### PR TITLE
Reader ATmosphere: route thread + author-feed through authed PDS

### DIFF
--- a/client/reader/atmosphere/author-profile-panel.tsx
+++ b/client/reader/atmosphere/author-profile-panel.tsx
@@ -1,8 +1,8 @@
 import {
 	followAtmosphereActorMutation,
 	unfollowAtmosphereActorMutation,
+	useAtmosphereScopedAuthorFeedInfiniteQuery,
 	useAtmosphereScopedProfileQuery,
-	useAuthorFeedInfiniteQuery,
 } from '@automattic/api-queries';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { __experimentalVStack as VStack } from '@wordpress/components';
@@ -107,7 +107,11 @@ export function AuthorProfilePanel( { connection, actor }: AuthorProfilePanelPro
 	const profile = useAtmosphereScopedProfileQuery( { connectionId: connection.id, actor } );
 	const followMut = useMutation( followAtmosphereActorMutation( queryClient ) );
 	const unfollowMut = useMutation( unfollowAtmosphereActorMutation( queryClient ) );
-	const feed = useAuthorFeedInfiniteQuery( { actor, filter } );
+	const feed = useAtmosphereScopedAuthorFeedInfiniteQuery( {
+		connectionId: connection.id,
+		actor,
+		filter,
+	} );
 
 	// Reset the error_shown dedup ref when navigating between profiles so the
 	// next author's first error fires its analytics even when the kind matches.

--- a/client/reader/atmosphere/test/atmosphere-thread-view.test.tsx
+++ b/client/reader/atmosphere/test/atmosphere-thread-view.test.tsx
@@ -31,7 +31,7 @@ jest.mock( '@automattic/calypso-router', () => {
 } );
 
 const listUrl = '/wpcom/v2/reader/atmosphere/connections';
-const threadUrl = '/wpcom/v2/reader/atmosphere/thread';
+const threadUrl = '/wpcom/v2/reader/atmosphere/connections/7/thread';
 
 const DID = 'did:plc:abc234567defghi234567jkl';
 const RKEY = '3kabcdefghijk';

--- a/client/reader/atmosphere/test/author-profile-panel.test.tsx
+++ b/client/reader/atmosphere/test/author-profile-panel.test.tsx
@@ -61,7 +61,9 @@ const feedItem = {
 };
 
 function makeQueryClient() {
-	return new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+	return new QueryClient( {
+		defaultOptions: { queries: { retry: false, retryDelay: 0 } },
+	} );
 }
 
 describe( 'AuthorProfilePanel', () => {
@@ -151,12 +153,15 @@ describe( 'AuthorProfilePanel', () => {
 
 	it( 'allows retry on a 502 error', async () => {
 		const user = userEvent.setup();
+		// Both the profile and the scoped author feed retry transient
+		// upstream_unavailable up to 2 more times (3 total) before surrendering.
 		nock( 'https://public-api.wordpress.com' )
 			.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social' )
 			.reply( 502, { error: 'atmosphere_upstream_unavailable' } );
 		nock( 'https://public-api.wordpress.com' )
 			.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social/feed' )
 			.query( true )
+			.times( 3 )
 			.reply( 502, { error: 'atmosphere_upstream_unavailable' } );
 
 		renderWithProvider(

--- a/client/reader/atmosphere/test/author-profile-panel.test.tsx
+++ b/client/reader/atmosphere/test/author-profile-panel.test.tsx
@@ -88,7 +88,7 @@ describe( 'AuthorProfilePanel', () => {
 			.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social' )
 			.reply( 200, profilePayload );
 		nock( 'https://public-api.wordpress.com' )
-			.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+			.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social/feed' )
 			.query( true )
 			.reply( 200, { items: [ feedItem ], cursor: null } );
 
@@ -113,7 +113,7 @@ describe( 'AuthorProfilePanel', () => {
 			.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social' )
 			.reply( 200, profilePayload );
 		nock( 'https://public-api.wordpress.com' )
-			.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+			.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social/feed' )
 			.query( true )
 			.reply( 200, { items: [], cursor: null } );
 
@@ -138,7 +138,7 @@ describe( 'AuthorProfilePanel', () => {
 			.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/missing' )
 			.reply( 404, { error: 'atmosphere_not_found' } );
 		nock( 'https://public-api.wordpress.com' )
-			.get( '/wpcom/v2/reader/atmosphere/profile/missing/feed' )
+			.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/missing/feed' )
 			.query( true )
 			.reply( 404, { error: 'atmosphere_not_found' } );
 
@@ -155,7 +155,7 @@ describe( 'AuthorProfilePanel', () => {
 			.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social' )
 			.reply( 502, { error: 'atmosphere_upstream_unavailable' } );
 		nock( 'https://public-api.wordpress.com' )
-			.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+			.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social/feed' )
 			.query( true )
 			.reply( 502, { error: 'atmosphere_upstream_unavailable' } );
 
@@ -175,7 +175,7 @@ describe( 'AuthorProfilePanel', () => {
 			.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social' )
 			.reply( 200, profilePayload );
 		nock( 'https://public-api.wordpress.com' )
-			.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+			.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social/feed' )
 			.query( true )
 			.reply( 200, { items: [ feedItem ], cursor: null } );
 
@@ -191,7 +191,7 @@ describe( 'AuthorProfilePanel', () => {
 			.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social' )
 			.reply( 200, profilePayload );
 		nock( 'https://public-api.wordpress.com' )
-			.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+			.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social/feed' )
 			.query( true )
 			.reply( 200, { items: [], cursor: null } );
 
@@ -217,11 +217,11 @@ describe( 'AuthorProfilePanel', () => {
 			.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social' )
 			.reply( 200, profilePayload );
 		nock( 'https://public-api.wordpress.com' )
-			.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+			.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social/feed' )
 			.query( ( q ) => ! q.cursor )
 			.reply( 200, { items: [ feedItem ], cursor: 'page-2' } );
 		nock( 'https://public-api.wordpress.com' )
-			.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+			.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social/feed' )
 			.query( ( q ) => q.cursor === 'page-2' )
 			.reply( 200, {
 				items: [
@@ -253,7 +253,7 @@ describe( 'AuthorProfilePanel', () => {
 				.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social' )
 				.reply( 200, profilePayload );
 			const feedScope = nock( 'https://public-api.wordpress.com' )
-				.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+				.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social/feed' )
 				.query( ( q ) => ! ( 'filter' in q ) )
 				.reply( 200, { items: [ feedItem ], cursor: null } );
 
@@ -275,7 +275,7 @@ describe( 'AuthorProfilePanel', () => {
 				.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social' )
 				.reply( 200, profilePayload );
 			const feedScope = nock( 'https://public-api.wordpress.com' )
-				.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+				.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social/feed' )
 				.query( { filter: 'posts_with_replies' } )
 				.reply( 200, { items: [], cursor: null } );
 
@@ -293,7 +293,7 @@ describe( 'AuthorProfilePanel', () => {
 				.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social' )
 				.reply( 200, profilePayload );
 			nock( 'https://public-api.wordpress.com' )
-				.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+				.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social/feed' )
 				.query( true )
 				.reply( 200, { items: [], cursor: null } );
 
@@ -320,7 +320,7 @@ describe( 'AuthorProfilePanel', () => {
 				.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social' )
 				.reply( 200, profilePayload );
 			nock( 'https://public-api.wordpress.com' )
-				.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+				.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social/feed' )
 				.query( true )
 				.reply( 200, { items: [], cursor: null } );
 
@@ -348,7 +348,7 @@ describe( 'AuthorProfilePanel', () => {
 				.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social' )
 				.reply( 429, { error: 'atmosphere_rate_limited' } );
 			nock( 'https://public-api.wordpress.com' )
-				.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+				.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social/feed' )
 				.query( true )
 				.reply( 429, { error: 'atmosphere_rate_limited' } );
 
@@ -390,7 +390,7 @@ describe( 'AuthorProfilePanel', () => {
 				.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social' )
 				.reply( 200, profilePayload );
 			nock( 'https://public-api.wordpress.com' )
-				.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+				.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social/feed' )
 				.query( true )
 				.reply( 200, { items: [], cursor: null } );
 
@@ -415,7 +415,7 @@ describe( 'AuthorProfilePanel', () => {
 				.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social' )
 				.reply( 200, profilePayload );
 			nock( 'https://public-api.wordpress.com' )
-				.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+				.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social/feed' )
 				.query( true )
 				.reply( 200, { items: [], cursor: null } );
 
@@ -438,7 +438,7 @@ describe( 'AuthorProfilePanel', () => {
 				.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social' )
 				.reply( 200, profilePayload );
 			nock( 'https://public-api.wordpress.com' )
-				.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+				.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social/feed' )
 				.query( true )
 				.reply( 200, { items: [], cursor: null } );
 			const followScope = nock( 'https://public-api.wordpress.com' )
@@ -482,7 +482,7 @@ describe( 'AuthorProfilePanel', () => {
 					viewer: { following: null, following_rkey: null, followed_by: true },
 				} );
 			nock( 'https://public-api.wordpress.com' )
-				.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+				.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social/feed' )
 				.query( true )
 				.reply( 200, { items: [], cursor: null } );
 
@@ -503,7 +503,7 @@ describe( 'AuthorProfilePanel', () => {
 				.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social' )
 				.reply( 200, profilePayload );
 			nock( 'https://public-api.wordpress.com' )
-				.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+				.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social/feed' )
 				.query( true )
 				.reply( 200, { items: [], cursor: null } );
 			nock( 'https://public-api.wordpress.com' )
@@ -542,7 +542,7 @@ describe( 'AuthorProfilePanel', () => {
 					display_name: 'Viewer',
 				} );
 			nock( 'https://public-api.wordpress.com' )
-				.get( '/wpcom/v2/reader/atmosphere/profile/viewer.bsky.social/feed' )
+				.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/viewer.bsky.social/feed' )
 				.query( true )
 				.reply( 200, { items: [], cursor: null } );
 
@@ -563,11 +563,11 @@ describe( 'AuthorProfilePanel', () => {
 			.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social' )
 			.reply( 200, profilePayload );
 		nock( 'https://public-api.wordpress.com' )
-			.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+			.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social/feed' )
 			.query( ( q ) => ! q.cursor )
 			.reply( 200, { items: [ feedItem ], cursor: 'page-2' } );
 		nock( 'https://public-api.wordpress.com' )
-			.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+			.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social/feed' )
 			.query( ( q ) => q.cursor === 'page-2' )
 			.reply( 200, {
 				items: [

--- a/client/reader/atmosphere/test/author-profile-view.test.tsx
+++ b/client/reader/atmosphere/test/author-profile-view.test.tsx
@@ -68,7 +68,7 @@ describe( 'AuthorProfileView', () => {
 			.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social' )
 			.reply( 200, {} );
 		nock( 'https://public-api.wordpress.com' )
-			.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+			.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social/feed' )
 			.reply( 200, { items: [], cursor: null } );
 
 		renderWithProvider( <AuthorProfileView connectionId={ 42 } actor="alice.bsky.social" /> );
@@ -105,7 +105,7 @@ describe( 'AuthorProfileView', () => {
 				viewer: { following: null, following_rkey: null, followed_by: false },
 			} );
 		nock( 'https://public-api.wordpress.com' )
-			.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+			.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social/feed' )
 			.reply( 200, { items: [], cursor: null } );
 
 		renderWithProvider( <AuthorProfileView connectionId={ 42 } actor="alice.bsky.social" /> );

--- a/client/reader/atmosphere/test/thread-panel.test.tsx
+++ b/client/reader/atmosphere/test/thread-panel.test.tsx
@@ -27,7 +27,7 @@ const connection: AtmosphereConnection = {
 };
 
 const BASE = 'https://public-api.wordpress.com';
-const PATH = '/wpcom/v2/reader/atmosphere/thread';
+const PATH = `/wpcom/v2/reader/atmosphere/connections/${ connection.id }/thread`;
 
 const DID = 'did:plc:abc234567defghi234567jkl';
 const RKEY = '3kabcdefghijk';

--- a/client/reader/atmosphere/thread-panel.tsx
+++ b/client/reader/atmosphere/thread-panel.tsx
@@ -1,4 +1,4 @@
-import { useThreadQuery } from '@automattic/api-queries';
+import { useAtmosphereScopedThreadQuery } from '@automattic/api-queries';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
@@ -40,7 +40,8 @@ export function ThreadPanel( { connection, did, rkey }: ThreadPanelProps ) {
 
 	const targetUri = useMemo( () => `at://${ did }/app.bsky.feed.post/${ rkey }`, [ did, rkey ] );
 
-	const { data, isPending, isFetching, isError, error, refetch } = useThreadQuery( {
+	const { data, isPending, isFetching, isError, error, refetch } = useAtmosphereScopedThreadQuery( {
+		connectionId: connection.id,
 		uri: targetUri,
 	} );
 

--- a/packages/api-core/src/reader-atmosphere/__tests__/fetchers.test.ts
+++ b/packages/api-core/src/reader-atmosphere/__tests__/fetchers.test.ts
@@ -13,7 +13,9 @@ import {
 	getAuthorProfile,
 	getConnection,
 	getConnections,
+	getScopedAuthorFeed,
 	getScopedProfile,
+	getScopedThread,
 	getThread,
 	getTimeline,
 } from '../fetchers';
@@ -340,6 +342,77 @@ describe( 'atmosphere fetchers', () => {
 		} );
 	} );
 
+	describe( 'getScopedThread', () => {
+		const URI = 'at://did:plc:abc/app.bsky.feed.post/3kabc';
+		const payload: AtmosphereThreadResponse = {
+			thread: {
+				type: 'post',
+				post: makeFeedItem( {
+					uri: URI,
+					viewer: {
+						like: 'at://did:plc:viewer/app.bsky.feed.like/3klike',
+						repost: 'at://did:plc:viewer/app.bsky.feed.repost/3krepost',
+					},
+				} ),
+				parent: null,
+				replies: [],
+			},
+		};
+
+		it( 'GETs /reader/atmosphere/connections/:id/thread with uri and returns the typed response', async () => {
+			nock( BASE )
+				.get( '/wpcom/v2/reader/atmosphere/connections/42/thread' )
+				.query( { uri: URI } )
+				.reply( 200, payload );
+
+			const got = await getScopedThread( { connectionId: 42, uri: URI } );
+			expect( got ).toEqual( payload );
+		} );
+
+		it( 'forwards depth and parentHeight as query params when supplied', async () => {
+			const scope = nock( BASE )
+				.get( '/wpcom/v2/reader/atmosphere/connections/42/thread' )
+				.query( { uri: URI, depth: '6', parentHeight: '80' } )
+				.reply( 200, payload );
+
+			await getScopedThread( { connectionId: 42, uri: URI, depth: 6, parentHeight: 80 } );
+			expect( scope.isDone() ).toBe( true );
+		} );
+
+		it( 'classifies a 401 atmosphere_auth_required response', async () => {
+			nock( BASE )
+				.get( '/wpcom/v2/reader/atmosphere/connections/42/thread' )
+				.query( true )
+				.reply( 401, { error: 'atmosphere_auth_required' } );
+
+			await expect( getScopedThread( { connectionId: 42, uri: URI } ) ).rejects.toMatchObject( {
+				kind: 'auth_required',
+			} );
+		} );
+
+		it( 'classifies a 404 atmosphere_not_found response', async () => {
+			nock( BASE )
+				.get( '/wpcom/v2/reader/atmosphere/connections/42/thread' )
+				.query( true )
+				.reply( 404, { error: 'atmosphere_not_found' } );
+
+			await expect( getScopedThread( { connectionId: 42, uri: URI } ) ).rejects.toMatchObject( {
+				kind: 'not_found',
+			} );
+		} );
+
+		it( 'classifies a network error as unknown', async () => {
+			nock( BASE )
+				.get( '/wpcom/v2/reader/atmosphere/connections/42/thread' )
+				.query( true )
+				.replyWithError( 'boom' );
+
+			await expect( getScopedThread( { connectionId: 42, uri: URI } ) ).rejects.toMatchObject( {
+				kind: 'unknown',
+			} );
+		} );
+	} );
+
 	describe( 'getAuthorProfile', () => {
 		it( 'fetches the profile for a handle and decodes the response', async () => {
 			const payload: AtmosphereAuthorProfile = {
@@ -549,6 +622,82 @@ describe( 'atmosphere fetchers', () => {
 			await expect(
 				getScopedProfile( { connectionId: 42, actor: 'alice.bsky.social' } )
 			).rejects.toMatchObject( { kind: 'auth_required' } );
+		} );
+	} );
+
+	describe( 'getScopedAuthorFeed', () => {
+		const PATH = '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social/feed';
+		const payload: AtmosphereAuthorFeedPage = { items: [], cursor: 'next' };
+
+		it( 'GETs /reader/atmosphere/connections/:id/profile/:actor/feed and returns the page', async () => {
+			nock( BASE ).get( PATH ).reply( 200, payload );
+
+			const result = await getScopedAuthorFeed( { connectionId: 42, actor: 'alice.bsky.social' } );
+			expect( result ).toEqual( payload );
+		} );
+
+		it( 'forwards cursor and limit as query params', async () => {
+			const scope = nock( BASE )
+				.get( PATH )
+				.query( { cursor: 'abc', limit: '50' } )
+				.reply( 200, { items: [], cursor: null } );
+
+			await getScopedAuthorFeed( {
+				connectionId: 42,
+				actor: 'alice.bsky.social',
+				cursor: 'abc',
+				limit: 50,
+			} );
+			expect( scope.isDone() ).toBe( true );
+		} );
+
+		it( 'forwards filter as a query param when set', async () => {
+			const scope = nock( BASE )
+				.get( PATH )
+				.query( { filter: 'posts_with_replies' } )
+				.reply( 200, { items: [], cursor: null } );
+
+			await getScopedAuthorFeed( {
+				connectionId: 42,
+				actor: 'alice.bsky.social',
+				filter: 'posts_with_replies',
+			} );
+			expect( scope.isDone() ).toBe( true );
+		} );
+
+		it( 'omits filter from the query string when undefined', async () => {
+			const scope = nock( BASE )
+				.get( PATH )
+				.query( ( q ) => ! ( 'filter' in q ) )
+				.reply( 200, { items: [], cursor: null } );
+
+			await getScopedAuthorFeed( { connectionId: 42, actor: 'alice.bsky.social' } );
+			expect( scope.isDone() ).toBe( true );
+		} );
+
+		it( 'percent-encodes the actor in the path', async () => {
+			const scope = nock( BASE )
+				.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/did%3Aplc%3Aabc123/feed' )
+				.reply( 200, { items: [], cursor: null } );
+
+			await getScopedAuthorFeed( { connectionId: 42, actor: 'did:plc:abc123' } );
+			expect( scope.isDone() ).toBe( true );
+		} );
+
+		it( 'classifies a 401 atmosphere_auth_required response', async () => {
+			nock( BASE ).get( PATH ).reply( 401, { error: 'atmosphere_auth_required' } );
+
+			await expect(
+				getScopedAuthorFeed( { connectionId: 42, actor: 'alice.bsky.social' } )
+			).rejects.toMatchObject( { kind: 'auth_required' } );
+		} );
+
+		it( 'classifies a network error as unknown', async () => {
+			nock( BASE ).get( PATH ).replyWithError( 'boom' );
+
+			await expect(
+				getScopedAuthorFeed( { connectionId: 42, actor: 'alice.bsky.social' } )
+			).rejects.toMatchObject( { kind: 'unknown' } );
 		} );
 	} );
 

--- a/packages/api-core/src/reader-atmosphere/__tests__/query-keys.test.ts
+++ b/packages/api-core/src/reader-atmosphere/__tests__/query-keys.test.ts
@@ -77,3 +77,74 @@ describe( 'readerAtmosphereKeys.authorFeed', () => {
 		).not.toEqual( readerAtmosphereKeys.authorFeed( 'alice.bsky.social', 'posts_with_replies' ) );
 	} );
 } );
+
+describe( 'readerAtmosphereKeys.scopedThread', () => {
+	const URI = 'at://did:plc:abc/app.bsky.feed.post/3kabc';
+
+	it( 'returns a stable key shape keyed on connectionId and uri', () => {
+		expect( readerAtmosphereKeys.scopedThread( 42, URI ) ).toEqual( [
+			'reader',
+			'atmosphere',
+			'scoped-thread',
+			42,
+			URI,
+		] );
+	} );
+
+	it( 'differs from the public thread key for the same uri', () => {
+		expect( readerAtmosphereKeys.scopedThread( 42, URI ) ).not.toEqual(
+			readerAtmosphereKeys.thread( URI )
+		);
+	} );
+
+	it( 'differs across connections for the same uri', () => {
+		expect( readerAtmosphereKeys.scopedThread( 1, URI ) ).not.toEqual(
+			readerAtmosphereKeys.scopedThread( 2, URI )
+		);
+	} );
+} );
+
+describe( 'readerAtmosphereKeys.scopedAuthorFeed', () => {
+	it( 'returns a stable 5-element key shape when filter is undefined', () => {
+		expect( readerAtmosphereKeys.scopedAuthorFeed( 42, 'alice.bsky.social' ) ).toEqual( [
+			'reader',
+			'atmosphere',
+			'scoped-author-feed',
+			42,
+			'alice.bsky.social',
+		] );
+	} );
+
+	it( 'appends the filter as a sixth element when set', () => {
+		expect(
+			readerAtmosphereKeys.scopedAuthorFeed( 42, 'alice.bsky.social', 'posts_with_replies' )
+		).toEqual( [
+			'reader',
+			'atmosphere',
+			'scoped-author-feed',
+			42,
+			'alice.bsky.social',
+			'posts_with_replies',
+		] );
+	} );
+
+	it( 'differs from the public author-feed key for the same actor + filter', () => {
+		expect(
+			readerAtmosphereKeys.scopedAuthorFeed( 42, 'alice.bsky.social', 'posts_with_media' )
+		).not.toEqual( readerAtmosphereKeys.authorFeed( 'alice.bsky.social', 'posts_with_media' ) );
+	} );
+
+	it( 'differs across connections for the same actor', () => {
+		expect( readerAtmosphereKeys.scopedAuthorFeed( 1, 'alice.bsky.social' ) ).not.toEqual(
+			readerAtmosphereKeys.scopedAuthorFeed( 2, 'alice.bsky.social' )
+		);
+	} );
+
+	it( 'differs across filter values for the same connection + actor', () => {
+		expect(
+			readerAtmosphereKeys.scopedAuthorFeed( 42, 'alice.bsky.social', 'posts_no_replies' )
+		).not.toEqual(
+			readerAtmosphereKeys.scopedAuthorFeed( 42, 'alice.bsky.social', 'posts_with_replies' )
+		);
+	} );
+} );

--- a/packages/api-core/src/reader-atmosphere/fetchers.ts
+++ b/packages/api-core/src/reader-atmosphere/fetchers.ts
@@ -122,6 +122,45 @@ export async function getThread( params: GetThreadParams ): Promise< AtmosphereT
 	}
 }
 
+export interface GetScopedThreadParams {
+	connectionId: number;
+	uri: string;
+	depth?: number;
+	parentHeight?: number;
+}
+
+/**
+ * Authed companion to `getThread`. Routes through the connection's PDS
+ * session so the Bluesky AppView can populate per-viewer fields
+ * (`viewer.like`, `viewer.repost`) on every post in the returned tree.
+ * The unauthenticated `getThread` is retained for SSR / embed callers
+ * that have no connection identity.
+ */
+export async function getScopedThread(
+	params: GetScopedThreadParams
+): Promise< AtmosphereThreadResponse > {
+	const { connectionId, uri, depth, parentHeight } = params;
+	const query: Record< string, string > = { uri };
+	// typeof guard preserves depth=0 (root only) and parentHeight=0 — valid backend values.
+	if ( typeof depth === 'number' ) {
+		query.depth = String( depth );
+	}
+	if ( typeof parentHeight === 'number' ) {
+		query.parentHeight = String( parentHeight );
+	}
+	try {
+		return ( await wpcom.req.get(
+			{
+				path: `/reader/atmosphere/connections/${ connectionId }/thread`,
+				apiNamespace: NAMESPACE,
+			},
+			query
+		) ) as AtmosphereThreadResponse;
+	} catch ( raw ) {
+		throw classifyAtmosphereError( raw );
+	}
+}
+
 export interface GetAuthorProfileParams {
 	actor: string;
 }
@@ -165,6 +204,50 @@ export async function getAuthorFeed(
 		return ( await wpcom.req.get(
 			{
 				path: `/reader/atmosphere/profile/${ encodeURIComponent( actor ) }/feed`,
+				apiNamespace: NAMESPACE,
+			},
+			query
+		) ) as AtmosphereAuthorFeedPage;
+	} catch ( raw ) {
+		throw classifyAtmosphereError( raw );
+	}
+}
+
+export interface GetScopedAuthorFeedParams {
+	connectionId: number;
+	actor: string;
+	cursor?: string;
+	limit?: number;
+	filter?: AtmosphereAuthorFeedFilter;
+}
+
+/**
+ * Authed companion to `getAuthorFeed`. Routes through the connection's
+ * PDS session so the Bluesky AppView can populate per-viewer fields
+ * (`viewer.like`, `viewer.repost`) on every post in the returned page.
+ * The unauthenticated `getAuthorFeed` is retained for SSR / embed
+ * callers that have no connection identity.
+ */
+export async function getScopedAuthorFeed(
+	params: GetScopedAuthorFeedParams
+): Promise< AtmosphereAuthorFeedPage > {
+	const { connectionId, actor, cursor, limit, filter } = params;
+	const query: Record< string, string > = {};
+	if ( cursor ) {
+		query.cursor = cursor;
+	}
+	if ( limit ) {
+		query.limit = String( limit );
+	}
+	if ( filter ) {
+		query.filter = filter;
+	}
+	try {
+		return ( await wpcom.req.get(
+			{
+				path: `/reader/atmosphere/connections/${ connectionId }/profile/${ encodeURIComponent(
+					actor
+				) }/feed`,
 				apiNamespace: NAMESPACE,
 			},
 			query

--- a/packages/api-core/src/reader-atmosphere/query-keys.ts
+++ b/packages/api-core/src/reader-atmosphere/query-keys.ts
@@ -7,6 +7,8 @@ export const readerAtmosphereKeys = {
 	timeline: ( connectionId: number ) =>
 		[ ...readerAtmosphereKeys.all, 'timeline', connectionId ] as const,
 	thread: ( uri: string ) => [ ...readerAtmosphereKeys.all, 'thread', uri ] as const,
+	scopedThread: ( connectionId: number, uri: string ) =>
+		[ ...readerAtmosphereKeys.all, 'scoped-thread', connectionId, uri ] as const,
 	profile: ( actor: string ) => [ ...readerAtmosphereKeys.all, 'profile', actor ] as const,
 	scopedProfile: ( connectionId: number, actor: string ) =>
 		[ ...readerAtmosphereKeys.all, 'scoped-profile', connectionId, actor ] as const,
@@ -14,6 +16,16 @@ export const readerAtmosphereKeys = {
 		filter
 			? ( [ ...readerAtmosphereKeys.all, 'author-feed', actor, filter ] as const )
 			: ( [ ...readerAtmosphereKeys.all, 'author-feed', actor ] as const ),
+	scopedAuthorFeed: ( connectionId: number, actor: string, filter?: AtmosphereAuthorFeedFilter ) =>
+		filter
+			? ( [
+					...readerAtmosphereKeys.all,
+					'scoped-author-feed',
+					connectionId,
+					actor,
+					filter,
+			  ] as const )
+			: ( [ ...readerAtmosphereKeys.all, 'scoped-author-feed', connectionId, actor ] as const ),
 	tagFeed: ( connectionId: number, hashtag: string ) =>
 		[ ...readerAtmosphereKeys.all, 'tag-feed', connectionId, hashtag ] as const,
 };

--- a/packages/api-queries/src/__tests__/reader-atmosphere.test.tsx
+++ b/packages/api-queries/src/__tests__/reader-atmosphere.test.tsx
@@ -24,6 +24,8 @@ import {
 	createPostMutation,
 	followAtmosphereActorMutation,
 	unfollowAtmosphereActorMutation,
+	useAtmosphereScopedAuthorFeedInfiniteQuery,
+	useAtmosphereScopedThreadQuery,
 	useAuthorFeedInfiniteQuery,
 	useAuthorProfileQuery,
 	useConnectionQuery,
@@ -595,6 +597,42 @@ describe( 'reader-atmosphere hooks', () => {
 				queryKey: readerAtmosphereKeys.authorFeed( 'alice.bsky.social' ),
 			} );
 			expect( matched ).toHaveLength( 2 );
+		} );
+	} );
+
+	describe( 'useAtmosphereScopedThreadQuery', () => {
+		it( 'is disabled when connectionId is 0', () => {
+			const queryClient = new QueryClient();
+			const wrapper = makeWrapper( queryClient );
+
+			renderHook(
+				() =>
+					useAtmosphereScopedThreadQuery( {
+						connectionId: 0,
+						uri: 'at://did:plc:abc/app.bsky.feed.post/3kabc',
+					} ),
+				{ wrapper }
+			);
+
+			expect( queryClient.isFetching() ).toBe( 0 );
+		} );
+	} );
+
+	describe( 'useAtmosphereScopedAuthorFeedInfiniteQuery', () => {
+		it( 'is disabled when connectionId is 0', () => {
+			const queryClient = new QueryClient();
+			const wrapper = makeWrapper( queryClient );
+
+			renderHook(
+				() =>
+					useAtmosphereScopedAuthorFeedInfiniteQuery( {
+						connectionId: 0,
+						actor: 'alice.bsky.social',
+					} ),
+				{ wrapper }
+			);
+
+			expect( queryClient.isFetching() ).toBe( 0 );
 		} );
 	} );
 

--- a/packages/api-queries/src/reader-atmosphere.ts
+++ b/packages/api-queries/src/reader-atmosphere.ts
@@ -12,7 +12,9 @@ import {
 	getAuthorProfile,
 	getConnection,
 	getConnections,
+	getScopedAuthorFeed,
 	getScopedProfile,
+	getScopedThread,
 	getThread,
 	getTimeline,
 	PENDING_LIKE_URI,
@@ -175,6 +177,33 @@ export function useThreadQuery( { uri }: UseThreadQueryParams ) {
 	return useQuery( threadQueryOptions( uri ) );
 }
 
+export interface AtmosphereScopedThreadQueryParams {
+	connectionId: number;
+	uri: string;
+}
+
+export const atmosphereScopedThreadQuery = ( params: AtmosphereScopedThreadQueryParams ) =>
+	queryOptions< AtmosphereThreadResponse, AtmosphereError >( {
+		queryKey: readerAtmosphereKeys.scopedThread( params.connectionId, params.uri ),
+		queryFn: () => getScopedThread( params ),
+		enabled: params.uri.length > 0 && params.connectionId > 0,
+		staleTime: 30_000,
+		gcTime: 5 * 60_000,
+		// Match threadQueryOptions' policy: bail immediately on terminal errors
+		// (auth, 404, rate-limit, …) so the EmptyContent surfaces fast, but
+		// retry transient failures twice before showing the error UI.
+		retry: ( failureCount, error ) => {
+			if ( isTerminalError( error ) ) {
+				return false;
+			}
+			return failureCount < 2;
+		},
+	} );
+
+export function useAtmosphereScopedThreadQuery( params: AtmosphereScopedThreadQueryParams ) {
+	return useQuery( atmosphereScopedThreadQuery( params ) );
+}
+
 export const profileQueryOptions = ( actor: string ) =>
 	queryOptions< AtmosphereAuthorProfile, AtmosphereError >( {
 		queryKey: readerAtmosphereKeys.profile( actor ),
@@ -251,6 +280,51 @@ export interface UseAuthorFeedInfiniteQueryParams {
 
 export function useAuthorFeedInfiniteQuery( { actor, filter }: UseAuthorFeedInfiniteQueryParams ) {
 	return useInfiniteQuery( authorFeedInfiniteQuery( actor, filter ) );
+}
+
+export interface AtmosphereScopedAuthorFeedInfiniteQueryParams {
+	connectionId: number;
+	actor: string;
+	filter?: AtmosphereAuthorFeedFilter;
+}
+
+export const atmosphereScopedAuthorFeedInfiniteQuery = (
+	params: AtmosphereScopedAuthorFeedInfiniteQueryParams
+) => {
+	// Mirror authorFeedInfiniteQuery: collapse the default filter to undefined
+	// so the cache key and request URL stay clean for the default tab.
+	const normalizedFilter = params.filter === 'posts_no_replies' ? undefined : params.filter;
+	return infiniteQueryOptions<
+		AtmosphereAuthorFeedPage,
+		AtmosphereError,
+		InfiniteData< AtmosphereAuthorFeedPage >,
+		QueryKey,
+		string | undefined
+	>( {
+		queryKey: readerAtmosphereKeys.scopedAuthorFeed(
+			params.connectionId,
+			params.actor,
+			normalizedFilter
+		),
+		queryFn: ( { pageParam } ) =>
+			getScopedAuthorFeed( {
+				connectionId: params.connectionId,
+				actor: params.actor,
+				cursor: pageParam,
+				filter: normalizedFilter,
+			} ),
+		initialPageParam: undefined,
+		getNextPageParam: ( lastPage ) => lastPage.cursor || undefined,
+		enabled: params.actor.length > 0 && params.connectionId > 0,
+		staleTime: 30_000,
+		gcTime: 5 * 60_000,
+	} );
+};
+
+export function useAtmosphereScopedAuthorFeedInfiniteQuery(
+	params: AtmosphereScopedAuthorFeedInfiniteQueryParams
+) {
+	return useInfiniteQuery( atmosphereScopedAuthorFeedInfiniteQuery( params ) );
 }
 
 export interface FollowAtmosphereActorVars {

--- a/packages/api-queries/src/reader-atmosphere.ts
+++ b/packages/api-queries/src/reader-atmosphere.ts
@@ -318,6 +318,15 @@ export const atmosphereScopedAuthorFeedInfiniteQuery = (
 		enabled: params.actor.length > 0 && params.connectionId > 0,
 		staleTime: 30_000,
 		gcTime: 5 * 60_000,
+		// Match threadQueryOptions' policy: bail immediately on terminal errors
+		// (auth, 404, rate-limit, …) so the EmptyContent surfaces fast, but
+		// retry transient failures twice before showing the error UI.
+		retry: ( failureCount, error ) => {
+			if ( isTerminalError( error ) ) {
+				return false;
+			}
+			return failureCount < 2;
+		},
 	} );
 };
 


### PR DESCRIPTION
Fixes CM-666

## Proposed Changes

* Add new authed fetchers `getScopedThread` and `getScopedAuthorFeed` (with matching `useAtmosphereScopedThreadQuery` / `useAtmosphereScopedAuthorFeedInfiniteQuery` hooks and query keys) that target `/reader/atmosphere/connections/{id}/thread` and `/connections/{id}/profile/{actor}/feed`.
* Migrate `ThreadPanel` and `AuthorProfilePanel` to the scoped hooks; the public `useThreadQuery` / `useAuthorFeedInfiniteQuery` are kept around for SSR / embed callers, mirroring the slice 7d `getScopedProfile` precedent.
* Update fetcher / query-key tests and the affected component tests for the new URL shape.

## Why are these changes being made?

The thread and author-feed surfaces went through the unauthenticated public AppView, which only ever returns `viewer.like = null` / `viewer.repost = null`. Posts you'd already liked or reposted on Bluesky rendered as not-liked / not-reposted on every reload — clicking the buttons updated optimistically, but the next fetch overwrote the cache with nulls. Routing through the connection's PDS session lets the AppView populate per-viewer state correctly. The companion wpcom backend PR adds the matching authed routes (must land + deploy first, otherwise these calls 404).

## Testing Instructions

* Open a Bluesky thread in the in-app ATmosphere reader where you've previously liked or reposted a post: the heart / repost arrow should render in the toggled-on color on first load (not just after clicking).
* Same on a profile's author feed (`/reader/atmosphere/{id}/profile/{actor}`).
* Like / repost a post, reload, and confirm the toggled state persists.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?