### PR TITLE
Reader: render own posts feed under ATmosphere Profile tab

### DIFF
--- a/client/reader/atmosphere/author-profile-panel.tsx
+++ b/client/reader/atmosphere/author-profile-panel.tsx
@@ -495,7 +495,14 @@ export function AuthorProfilePanel( { connection, actor }: AuthorProfilePanelPro
 					onBackToTimeline={ handleBackToTimeline }
 				/>
 				{ renderHeader() }
-				<AuthorProfileTabs connectionId={ connection.id } actor={ actor } activeFilter={ filter } />
+				<AuthorProfileTabs
+					connectionId={ connection.id }
+					actor={ actor }
+					basePath={ `/reader/atmosphere/${ connection.id }/profile/${ encodeURIComponent(
+						actor
+					) }` }
+					activeFilter={ filter }
+				/>
 				<SocialFeedList< SocialPost >
 					items={ items }
 					isPending={ feed.isPending }

--- a/client/reader/atmosphere/author-profile-panel.tsx
+++ b/client/reader/atmosphere/author-profile-panel.tsx
@@ -11,7 +11,6 @@ import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import EmptyContent from 'calypso/components/empty-content';
 import {
-	AuthorProfileHeader,
 	FollowButton,
 	SocialAnalyticsProvider,
 	SocialFeedList,
@@ -28,7 +27,7 @@ import { AuthorProfileTabs, useAuthorProfileFilter } from './author-profile-tabs
 import { useOptionalComposer } from './composer';
 import { projectAtmosphereError } from './error-projection';
 import { errorMessage } from './profile-errors';
-import { getProfileUrl, getTagFeedUrl, getThreadUrl, getTimelineUrl } from './route';
+import { getProfileUrl, getTagFeedUrl, getThreadUrl } from './route';
 import type {
 	AtmosphereAuthorFeedFilter,
 	AtmosphereScopedProfile,
@@ -92,9 +91,14 @@ function buildEmptyTitle(
 interface AuthorProfilePanelProps {
 	connection: AtmosphereConnection;
 	actor: string;
+	subtabBasePath: string;
 }
 
-export function AuthorProfilePanel( { connection, actor }: AuthorProfilePanelProps ) {
+export function AuthorProfilePanel( {
+	connection,
+	actor,
+	subtabBasePath,
+}: AuthorProfilePanelProps ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch< ThunkDispatch< AppState, void, UnknownAction > >();
 	const filter = useAuthorProfileFilter();
@@ -224,15 +228,6 @@ export function AuthorProfilePanel( { connection, actor }: AuthorProfilePanelPro
 		);
 		feed.refetch();
 	}, [ connection.id, actor, feed, dispatch ] );
-
-	const handleBackToTimeline = useCallback( () => {
-		dispatch(
-			recordReaderTracksEvent( 'calypso_reader_atmosphere_profile_back_to_timeline_clicked', {
-				connection_id: connection.id,
-				actor,
-			} )
-		);
-	}, [ connection.id, actor, dispatch ] );
 
 	const onClickAnalytics = useCallback(
 		( event: string, props: Record< string, unknown > ) => {
@@ -490,17 +485,11 @@ export function AuthorProfilePanel( { connection, actor }: AuthorProfilePanelPro
 	return (
 		<SocialAnalyticsProvider value={ analyticsValue }>
 			<VStack spacing={ 4 } className="atmosphere-author-profile">
-				<AuthorProfileHeader
-					timelineUrl={ getTimelineUrl( connection.id ) }
-					onBackToTimeline={ handleBackToTimeline }
-				/>
 				{ renderHeader() }
 				<AuthorProfileTabs
 					connectionId={ connection.id }
 					actor={ actor }
-					basePath={ `/reader/atmosphere/${ connection.id }/profile/${ encodeURIComponent(
-						actor
-					) }` }
+					basePath={ subtabBasePath }
 					activeFilter={ filter }
 				/>
 				<SocialFeedList< SocialPost >

--- a/client/reader/atmosphere/author-profile-tabs.tsx
+++ b/client/reader/atmosphere/author-profile-tabs.tsx
@@ -36,23 +36,28 @@ export function useAuthorProfileFilter(): AtmosphereAuthorFeedFilter {
 interface AuthorProfileTabsProps {
 	connectionId: number;
 	actor: string;
+	basePath: string;
 	activeFilter: AtmosphereAuthorFeedFilter;
 }
 
-function buildPath( connectionId: number, actor: string, slug: string ): string {
-	const base = `/reader/atmosphere/${ connectionId }/profile/${ encodeURIComponent( actor ) }`;
+function buildPath( basePath: string, slug: string ): string {
 	if ( typeof window === 'undefined' ) {
-		return `${ base }?tab=${ slug }`;
+		return `${ basePath }?tab=${ slug }`;
 	}
 	// Preserve any other query params and the fragment (e.g. ?from=timeline,
 	// or #scroll-anchor) the user may have on the URL when switching tabs.
 	const params = new URLSearchParams( window.location.search );
 	params.set( 'tab', slug );
 	const hash = window.location.hash;
-	return `${ base }?${ params.toString() }${ hash }`;
+	return `${ basePath }?${ params.toString() }${ hash }`;
 }
 
-export function AuthorProfileTabs( { connectionId, actor, activeFilter }: AuthorProfileTabsProps ) {
+export function AuthorProfileTabs( {
+	connectionId,
+	actor,
+	basePath,
+	activeFilter,
+}: AuthorProfileTabsProps ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -61,20 +66,20 @@ export function AuthorProfileTabs( { connectionId, actor, activeFilter }: Author
 			{
 				slug: 'posts',
 				title: translate( 'Posts' ) as TranslateResult,
-				path: buildPath( connectionId, actor, 'posts' ),
+				path: buildPath( basePath, 'posts' ),
 			},
 			{
 				slug: 'replies',
 				title: translate( 'Replies' ) as TranslateResult,
-				path: buildPath( connectionId, actor, 'replies' ),
+				path: buildPath( basePath, 'replies' ),
 			},
 			{
 				slug: 'media',
 				title: translate( 'Media' ) as TranslateResult,
-				path: buildPath( connectionId, actor, 'media' ),
+				path: buildPath( basePath, 'media' ),
 			},
 		],
-		[ connectionId, actor, translate ]
+		[ basePath, translate ]
 	);
 
 	const activeSlug = FILTER_TO_SLUG[ activeFilter ] ?? DEFAULT_SLUG;

--- a/client/reader/atmosphere/author-profile-view.tsx
+++ b/client/reader/atmosphere/author-profile-view.tsx
@@ -2,11 +2,18 @@ import { useConnectionsQuery } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import ReaderMain from 'calypso/reader/components/reader-main';
+import { AuthorProfileHeader } from 'calypso/reader/social';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import { AuthorProfilePanel } from './author-profile-panel';
 import { ComposerModal, ComposerProvider } from './composer';
+import { getTimelineUrl } from './route';
+import type { AppState } from 'calypso/types';
+import type { UnknownAction } from 'redux';
+import type { ThunkDispatch } from 'redux-thunk';
 
 interface Props {
 	connectionId: number;
@@ -15,6 +22,15 @@ interface Props {
 
 export function AuthorProfileView( { connectionId, actor }: Props ) {
 	const translate = useTranslate();
+	const dispatch = useDispatch< ThunkDispatch< AppState, void, UnknownAction > >();
+	const handleBackToTimeline = useCallback( () => {
+		dispatch(
+			recordReaderTracksEvent( 'calypso_reader_atmosphere_profile_back_to_timeline_clicked', {
+				connection_id: connectionId,
+				actor,
+			} )
+		);
+	}, [ connectionId, actor, dispatch ] );
 	const { data, isPending, isError, refetch } = useConnectionsQuery();
 
 	const connections = data?.connections ?? [];
@@ -58,7 +74,17 @@ export function AuthorProfileView( { connectionId, actor }: Props ) {
 		<ComposerProvider connectionId={ connection.id }>
 			<ReaderMain className="atmosphere-view">
 				<DocumentHead title={ translate( '%s ‹ ATmosphere ‹ Reader', { args: actor } ) } />
-				<AuthorProfilePanel connection={ connection } actor={ actor } />
+				<AuthorProfileHeader
+					timelineUrl={ getTimelineUrl( connection.id ) }
+					onBackToTimeline={ handleBackToTimeline }
+				/>
+				<AuthorProfilePanel
+					connection={ connection }
+					actor={ actor }
+					subtabBasePath={ `/reader/atmosphere/${ connection.id }/profile/${ encodeURIComponent(
+						actor
+					) }` }
+				/>
 			</ReaderMain>
 			<ComposerModal />
 		</ComposerProvider>

--- a/client/reader/atmosphere/author-profile-view.tsx
+++ b/client/reader/atmosphere/author-profile-view.tsx
@@ -70,6 +70,10 @@ export function AuthorProfileView( { connectionId, actor }: Props ) {
 		);
 	}
 
+	const subtabBasePath = `/reader/atmosphere/${ connection.id }/profile/${ encodeURIComponent(
+		actor
+	) }`;
+
 	return (
 		<ComposerProvider connectionId={ connection.id }>
 			<ReaderMain className="atmosphere-view">
@@ -81,9 +85,7 @@ export function AuthorProfileView( { connectionId, actor }: Props ) {
 				<AuthorProfilePanel
 					connection={ connection }
 					actor={ actor }
-					subtabBasePath={ `/reader/atmosphere/${ connection.id }/profile/${ encodeURIComponent(
-						actor
-					) }` }
+					subtabBasePath={ subtabBasePath }
 				/>
 			</ReaderMain>
 			<ComposerModal />

--- a/client/reader/atmosphere/profile-panel.tsx
+++ b/client/reader/atmosphere/profile-panel.tsx
@@ -1,8 +1,4 @@
-import { useConnectionQuery } from '@automattic/api-queries';
-import { useTranslate } from 'i18n-calypso';
-import EmptyContent from 'calypso/components/empty-content';
-import { SocialProfileCard, type SocialProfileStat } from 'calypso/reader/social';
-import { errorMessage } from './profile-errors';
+import { AuthorProfilePanel } from './author-profile-panel';
 import type { AtmosphereConnection } from '@automattic/api-core';
 
 interface ProfilePanelProps {
@@ -10,59 +6,11 @@ interface ProfilePanelProps {
 }
 
 export function ProfilePanel( { connection }: ProfilePanelProps ) {
-	const translate = useTranslate();
-	const { data, error, isPending } = useConnectionQuery( connection.id );
-
-	if ( isPending && ! data ) {
-		return (
-			<div role="status" aria-live="polite">
-				{ translate( 'Loading profile…' ) }
-			</div>
-		);
-	}
-
-	if ( error ) {
-		return (
-			<EmptyContent
-				title={ translate( 'Couldn’t load your profile' ) }
-				line={ errorMessage( error, translate ) }
-			/>
-		);
-	}
-
-	if ( ! data ) {
-		return null;
-	}
-
-	const stats: SocialProfileStat[] = [
-		{
-			key: 'followers',
-			count: data.counts.followers,
-			label: translate( 'follower', 'followers', { count: data.counts.followers } ),
-		},
-		{
-			key: 'follows',
-			count: data.counts.follows,
-			label: translate( 'following', {
-				context: 'profile stats: count of accounts followed',
-			} ),
-		},
-		{
-			key: 'posts',
-			count: data.counts.posts,
-			label: translate( 'post', 'posts', { count: data.counts.posts } ),
-		},
-	];
-
 	return (
-		<SocialProfileCard
-			avatar={ data.avatar }
-			banner={ data.banner }
-			displayName={ data.display_name ?? undefined }
-			handle={ data.handle }
-			bio={ data.description }
-			stats={ stats }
-			statsLabel={ String( translate( 'Profile stats' ) ) }
+		<AuthorProfilePanel
+			connection={ connection }
+			actor={ connection.handle }
+			subtabBasePath={ `/reader/atmosphere/${ connection.id }/profile` }
 		/>
 	);
 }

--- a/client/reader/atmosphere/test/author-profile-panel.test.tsx
+++ b/client/reader/atmosphere/test/author-profile-panel.test.tsx
@@ -111,6 +111,28 @@ describe( 'AuthorProfilePanel', () => {
 		expect( screen.getByRole( 'button', { name: /like, 0 likes/i } ) ).toBeVisible();
 	} );
 
+	it( 'does not render the back-to-timeline button (it is owned by the parent view)', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social' )
+			.reply( 200, profilePayload );
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+			.query( true )
+			.reply( 200, { items: [], cursor: null } );
+
+		renderWithProvider(
+			<AuthorProfilePanel
+				connection={ connection }
+				actor="alice.bsky.social"
+				subtabBasePath="/reader/atmosphere/42/profile/alice.bsky.social"
+			/>,
+			{ queryClient: makeQueryClient() }
+		);
+
+		await screen.findByRole( 'heading', { level: 2, name: 'Alice' } );
+		expect( screen.queryByRole( 'button', { name: /back/i } ) ).toBeNull();
+	} );
+
 	it( 'fires profile_viewed on mount', async () => {
 		const spy = analytics.recordReaderTracksEvent as unknown as jest.Mock;
 		nock( 'https://public-api.wordpress.com' )

--- a/client/reader/atmosphere/test/author-profile-panel.test.tsx
+++ b/client/reader/atmosphere/test/author-profile-panel.test.tsx
@@ -93,7 +93,11 @@ describe( 'AuthorProfilePanel', () => {
 			.reply( 200, { items: [ feedItem ], cursor: null } );
 
 		renderWithProvider(
-			<AuthorProfilePanel connection={ connection } actor="alice.bsky.social" />,
+			<AuthorProfilePanel
+				connection={ connection }
+				actor="alice.bsky.social"
+				subtabBasePath="/reader/atmosphere/42/profile/alice.bsky.social"
+			/>,
 			{ queryClient: makeQueryClient() }
 		);
 
@@ -118,7 +122,11 @@ describe( 'AuthorProfilePanel', () => {
 			.reply( 200, { items: [], cursor: null } );
 
 		renderWithProvider(
-			<AuthorProfilePanel connection={ connection } actor="alice.bsky.social" />,
+			<AuthorProfilePanel
+				connection={ connection }
+				actor="alice.bsky.social"
+				subtabBasePath="/reader/atmosphere/42/profile/alice.bsky.social"
+			/>,
 			{ queryClient: makeQueryClient() }
 		);
 
@@ -142,9 +150,16 @@ describe( 'AuthorProfilePanel', () => {
 			.query( true )
 			.reply( 404, { error: 'atmosphere_not_found' } );
 
-		renderWithProvider( <AuthorProfilePanel connection={ connection } actor="missing" />, {
-			queryClient: makeQueryClient(),
-		} );
+		renderWithProvider(
+			<AuthorProfilePanel
+				connection={ connection }
+				actor="missing"
+				subtabBasePath="/reader/atmosphere/42/profile/missing"
+			/>,
+			{
+				queryClient: makeQueryClient(),
+			}
+		);
 
 		expect( await screen.findByText( /Profile not found/i ) ).toBeVisible();
 	} );
@@ -160,7 +175,11 @@ describe( 'AuthorProfilePanel', () => {
 			.reply( 502, { error: 'atmosphere_upstream_unavailable' } );
 
 		renderWithProvider(
-			<AuthorProfilePanel connection={ connection } actor="alice.bsky.social" />,
+			<AuthorProfilePanel
+				connection={ connection }
+				actor="alice.bsky.social"
+				subtabBasePath="/reader/atmosphere/42/profile/alice.bsky.social"
+			/>,
 			{ queryClient: makeQueryClient() }
 		);
 
@@ -182,34 +201,6 @@ describe( 'AuthorProfilePanel', () => {
 		await user.click( retries[ 0 ] );
 
 		expect( await screen.findByRole( 'heading', { level: 2, name: 'Alice' } ) ).toBeVisible();
-	} );
-
-	it( 'navigates to the connection timeline when the back button is clicked', async () => {
-		const user = userEvent.setup();
-		const spy = analytics.recordReaderTracksEvent as unknown as jest.Mock;
-		nock( 'https://public-api.wordpress.com' )
-			.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social' )
-			.reply( 200, profilePayload );
-		nock( 'https://public-api.wordpress.com' )
-			.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
-			.query( true )
-			.reply( 200, { items: [], cursor: null } );
-
-		renderWithProvider(
-			<AuthorProfilePanel connection={ connection } actor="alice.bsky.social" />,
-			{ queryClient: makeQueryClient() }
-		);
-
-		const back = await screen.findByRole( 'button', { name: /back/i } );
-		await user.click( back );
-		expect( page ).toHaveBeenCalledWith( '/reader/atmosphere/42/timeline' );
-		expect( spy ).toHaveBeenCalledWith(
-			'calypso_reader_atmosphere_profile_back_to_timeline_clicked',
-			expect.objectContaining( {
-				connection_id: 42,
-				actor: 'alice.bsky.social',
-			} )
-		);
 	} );
 
 	it( 'paginates when sentinel comes into view', async () => {
@@ -236,7 +227,11 @@ describe( 'AuthorProfilePanel', () => {
 			} );
 
 		renderWithProvider(
-			<AuthorProfilePanel connection={ connection } actor="alice.bsky.social" />,
+			<AuthorProfilePanel
+				connection={ connection }
+				actor="alice.bsky.social"
+				subtabBasePath="/reader/atmosphere/42/profile/alice.bsky.social"
+			/>,
 			{ queryClient: makeQueryClient() }
 		);
 
@@ -258,7 +253,11 @@ describe( 'AuthorProfilePanel', () => {
 				.reply( 200, { items: [ feedItem ], cursor: null } );
 
 			renderWithProvider(
-				<AuthorProfilePanel connection={ connection } actor="alice.bsky.social" />,
+				<AuthorProfilePanel
+					connection={ connection }
+					actor="alice.bsky.social"
+					subtabBasePath="/reader/atmosphere/42/profile/alice.bsky.social"
+				/>,
 				{ queryClient: makeQueryClient() }
 			);
 			await waitFor( () => expect( feedScope.isDone() ).toBe( true ) );
@@ -280,7 +279,11 @@ describe( 'AuthorProfilePanel', () => {
 				.reply( 200, { items: [], cursor: null } );
 
 			renderWithProvider(
-				<AuthorProfilePanel connection={ connection } actor="alice.bsky.social" />,
+				<AuthorProfilePanel
+					connection={ connection }
+					actor="alice.bsky.social"
+					subtabBasePath="/reader/atmosphere/42/profile/alice.bsky.social"
+				/>,
 				{ queryClient: makeQueryClient() }
 			);
 			await waitFor( () => expect( feedScope.isDone() ).toBe( true ) );
@@ -298,7 +301,11 @@ describe( 'AuthorProfilePanel', () => {
 				.reply( 200, { items: [], cursor: null } );
 
 			renderWithProvider(
-				<AuthorProfilePanel connection={ connection } actor="alice.bsky.social" />,
+				<AuthorProfilePanel
+					connection={ connection }
+					actor="alice.bsky.social"
+					subtabBasePath="/reader/atmosphere/42/profile/alice.bsky.social"
+				/>,
 				{ queryClient: makeQueryClient() }
 			);
 
@@ -325,7 +332,11 @@ describe( 'AuthorProfilePanel', () => {
 				.reply( 200, { items: [], cursor: null } );
 
 			renderWithProvider(
-				<AuthorProfilePanel connection={ connection } actor="alice.bsky.social" />,
+				<AuthorProfilePanel
+					connection={ connection }
+					actor="alice.bsky.social"
+					subtabBasePath="/reader/atmosphere/42/profile/alice.bsky.social"
+				/>,
 				{ queryClient: makeQueryClient() }
 			);
 
@@ -353,7 +364,11 @@ describe( 'AuthorProfilePanel', () => {
 				.reply( 429, { error: 'atmosphere_rate_limited' } );
 
 			renderWithProvider(
-				<AuthorProfilePanel connection={ connection } actor="alice.bsky.social" />,
+				<AuthorProfilePanel
+					connection={ connection }
+					actor="alice.bsky.social"
+					subtabBasePath="/reader/atmosphere/42/profile/alice.bsky.social"
+				/>,
 				{ queryClient: makeQueryClient() }
 			);
 
@@ -395,7 +410,11 @@ describe( 'AuthorProfilePanel', () => {
 				.reply( 200, { items: [], cursor: null } );
 
 			renderWithProvider(
-				<AuthorProfilePanel connection={ connection } actor="alice.bsky.social" />,
+				<AuthorProfilePanel
+					connection={ connection }
+					actor="alice.bsky.social"
+					subtabBasePath="/reader/atmosphere/42/profile/alice.bsky.social"
+				/>,
 				{ queryClient: makeQueryClient() }
 			);
 
@@ -420,7 +439,11 @@ describe( 'AuthorProfilePanel', () => {
 				.reply( 200, { items: [], cursor: null } );
 
 			renderWithProvider(
-				<AuthorProfilePanel connection={ connection } actor="alice.bsky.social" />,
+				<AuthorProfilePanel
+					connection={ connection }
+					actor="alice.bsky.social"
+					subtabBasePath="/reader/atmosphere/42/profile/alice.bsky.social"
+				/>,
 				{ queryClient: makeQueryClient() }
 			);
 
@@ -454,7 +477,11 @@ describe( 'AuthorProfilePanel', () => {
 				} );
 
 			renderWithProvider(
-				<AuthorProfilePanel connection={ connection } actor="alice.bsky.social" />,
+				<AuthorProfilePanel
+					connection={ connection }
+					actor="alice.bsky.social"
+					subtabBasePath="/reader/atmosphere/42/profile/alice.bsky.social"
+				/>,
 				{ queryClient: makeQueryClient() }
 			);
 
@@ -487,7 +514,11 @@ describe( 'AuthorProfilePanel', () => {
 				.reply( 200, { items: [], cursor: null } );
 
 			renderWithProvider(
-				<AuthorProfilePanel connection={ connection } actor="alice.bsky.social" />,
+				<AuthorProfilePanel
+					connection={ connection }
+					actor="alice.bsky.social"
+					subtabBasePath="/reader/atmosphere/42/profile/alice.bsky.social"
+				/>,
 				{ queryClient: makeQueryClient() }
 			);
 
@@ -511,7 +542,11 @@ describe( 'AuthorProfilePanel', () => {
 				.reply( 502, { error: 'atmosphere_upstream_unavailable' } );
 
 			renderWithProvider(
-				<AuthorProfilePanel connection={ connection } actor="alice.bsky.social" />,
+				<AuthorProfilePanel
+					connection={ connection }
+					actor="alice.bsky.social"
+					subtabBasePath="/reader/atmosphere/42/profile/alice.bsky.social"
+				/>,
 				{ queryClient: makeQueryClient() }
 			);
 
@@ -547,7 +582,11 @@ describe( 'AuthorProfilePanel', () => {
 				.reply( 200, { items: [], cursor: null } );
 
 			renderWithProvider(
-				<AuthorProfilePanel connection={ connection } actor="viewer.bsky.social" />,
+				<AuthorProfilePanel
+					connection={ connection }
+					actor="viewer.bsky.social"
+					subtabBasePath="/reader/atmosphere/42/profile/viewer.bsky.social"
+				/>,
 				{ queryClient: makeQueryClient() }
 			);
 
@@ -585,7 +624,11 @@ describe( 'AuthorProfilePanel', () => {
 			} );
 
 		renderWithProvider(
-			<AuthorProfilePanel connection={ connection } actor="alice.bsky.social" />,
+			<AuthorProfilePanel
+				connection={ connection }
+				actor="alice.bsky.social"
+				subtabBasePath="/reader/atmosphere/42/profile/alice.bsky.social"
+			/>,
 			{ queryClient: makeQueryClient() }
 		);
 

--- a/client/reader/atmosphere/test/author-profile-tabs.test.tsx
+++ b/client/reader/atmosphere/test/author-profile-tabs.test.tsx
@@ -118,6 +118,7 @@ describe( 'AuthorProfileTabs', () => {
 			<AuthorProfileTabs
 				connectionId={ 42 }
 				actor="alice.bsky.social"
+				basePath="/reader/atmosphere/42/profile/alice.bsky.social"
 				activeFilter="posts_no_replies"
 				{ ...props }
 			/>
@@ -193,6 +194,22 @@ describe( 'AuthorProfileTabs', () => {
 		expect( screen.getByRole( 'menuitem', { name: 'Media' } ) ).toBeVisible();
 		const postsTab = screen.getByRole( 'menuitem', { name: 'Posts' } );
 		expect( postsTab.closest( 'li' ) ).toHaveClass( 'is-selected' );
+	} );
+
+	it( 'builds tab hrefs from basePath alone (no actor segment)', () => {
+		renderTabs( { basePath: '/reader/atmosphere/42/profile' } );
+		expect( screen.getByRole( 'menuitem', { name: 'Posts' } ) ).toHaveAttribute(
+			'href',
+			'/reader/atmosphere/42/profile?tab=posts'
+		);
+		expect( screen.getByRole( 'menuitem', { name: 'Replies' } ) ).toHaveAttribute(
+			'href',
+			'/reader/atmosphere/42/profile?tab=replies'
+		);
+		expect( screen.getByRole( 'menuitem', { name: 'Media' } ) ).toHaveAttribute(
+			'href',
+			'/reader/atmosphere/42/profile?tab=media'
+		);
 	} );
 
 	it( 'modifier-click does not call preventDefault — native browser handling kicks in', async () => {

--- a/client/reader/atmosphere/test/author-profile-view.test.tsx
+++ b/client/reader/atmosphere/test/author-profile-view.test.tsx
@@ -5,6 +5,7 @@ import page from '@automattic/calypso-router';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
+import * as analytics from 'calypso/state/reader/analytics/actions';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { AuthorProfileView } from '../author-profile-view';
 import type React from 'react';
@@ -16,10 +17,6 @@ jest.mock(
 			return <div>{ children }</div>;
 		}
 );
-
-jest.mock( 'calypso/state/reader/analytics/actions', () => ( {
-	recordReaderTracksEvent: () => ( { type: '@@TEST/NOOP' } ),
-} ) );
 
 jest.mock( 'calypso/components/data/document-head', () => () => null );
 
@@ -42,6 +39,15 @@ beforeAll( () => {
 afterAll( () => {
 	// @ts-expect-error -- cleaning up the stub
 	delete global.IntersectionObserver;
+} );
+
+beforeEach( () => {
+	// recordReaderTracksEvent is a thunk that reads state.reader.follows.
+	// Replace it with a no-op action creator so dispatch() doesn't throw,
+	// while still letting spies observe call-site arguments.
+	jest
+		.spyOn( analytics, 'recordReaderTracksEvent' )
+		.mockImplementation( () => ( { type: '@@TEST/NOOP' } ) as never );
 } );
 
 afterEach( () => {
@@ -160,5 +166,9 @@ describe( 'AuthorProfileView', () => {
 		const backButton = screen.getByRole( 'button', { name: /back/i } );
 		await user.click( backButton );
 		expect( page as unknown as jest.Mock ).toHaveBeenCalledWith( '/reader/atmosphere/42/timeline' );
+		expect( analytics.recordReaderTracksEvent ).toHaveBeenCalledWith(
+			'calypso_reader_atmosphere_profile_back_to_timeline_clicked',
+			{ connection_id: 42, actor: 'alice.bsky.social' }
+		);
 	} );
 } );

--- a/client/reader/atmosphere/test/author-profile-view.test.tsx
+++ b/client/reader/atmosphere/test/author-profile-view.test.tsx
@@ -3,6 +3,7 @@
  */
 import page from '@automattic/calypso-router';
 import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { AuthorProfileView } from '../author-profile-view';
@@ -22,10 +23,11 @@ jest.mock( 'calypso/state/reader/analytics/actions', () => ( {
 
 jest.mock( 'calypso/components/data/document-head', () => () => null );
 
-jest.mock( '@automattic/calypso-router', () => ( {
-	__esModule: true,
-	default: { replace: jest.fn() },
-} ) );
+jest.mock( '@automattic/calypso-router', () => {
+	const mockPage = jest.fn();
+	mockPage.replace = jest.fn();
+	return { __esModule: true, default: mockPage };
+} );
 
 // NavTabs (used by AuthorProfileTabs inside AuthorProfilePanel) relies on
 // IntersectionObserver, which jsdom does not provide.
@@ -45,6 +47,7 @@ afterAll( () => {
 afterEach( () => {
 	nock.cleanAll();
 	jest.restoreAllMocks();
+	( page as unknown as jest.Mock ).mockClear();
 	( page.replace as jest.Mock ).mockClear();
 } );
 
@@ -111,5 +114,51 @@ describe( 'AuthorProfileView', () => {
 		renderWithProvider( <AuthorProfileView connectionId={ 42 } actor="alice.bsky.social" /> );
 
 		expect( await screen.findByRole( 'heading', { level: 2, name: 'Alice' } ) ).toBeVisible();
+	} );
+
+	it( 'renders the back-to-timeline button above the panel', async () => {
+		const user = userEvent.setup();
+		// jsdom starts with history.length === 1, so BackButton will call page() directly.
+		jest.spyOn( window.history, 'length', 'get' ).mockReturnValue( 1 );
+
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/wpcom/v2/reader/atmosphere/connections' )
+			.reply( 200, {
+				connections: [
+					{
+						id: 42,
+						did: 'did:plc:viewer',
+						handle: 'viewer.bsky.social',
+						display_name: 'Viewer',
+						avatar: null,
+					},
+				],
+			} );
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social' )
+			.reply( 200, {
+				did: 'did:plc:abc',
+				handle: 'alice.bsky.social',
+				display_name: 'Alice',
+				description: '',
+				description_html: '',
+				avatar: null,
+				banner: null,
+				bluesky_url: 'https://bsky.app/profile/alice.bsky.social',
+				counts: { followers: 0, follows: 0, posts: 0 },
+				viewer: { following: null, following_rkey: null, followed_by: false },
+			} );
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/wpcom/v2/reader/atmosphere/profile/alice.bsky.social/feed' )
+			.reply( 200, { items: [], cursor: null } );
+
+		renderWithProvider( <AuthorProfileView connectionId={ 42 } actor="alice.bsky.social" /> );
+
+		// Wait for the panel to render (connection resolved), then verify the
+		// back button is present in the view and navigates to the timeline.
+		await screen.findByRole( 'heading', { level: 2, name: 'Alice' } );
+		const backButton = screen.getByRole( 'button', { name: /back/i } );
+		await user.click( backButton );
+		expect( page as unknown as jest.Mock ).toHaveBeenCalledWith( '/reader/atmosphere/42/timeline' );
 	} );
 } );

--- a/client/reader/atmosphere/test/author-profile-view.test.tsx
+++ b/client/reader/atmosphere/test/author-profile-view.test.tsx
@@ -21,8 +21,9 @@ jest.mock(
 jest.mock( 'calypso/components/data/document-head', () => () => null );
 
 jest.mock( '@automattic/calypso-router', () => {
-	const mockPage = jest.fn();
-	mockPage.replace = jest.fn();
+	const mockPage: jest.Mock & { replace: jest.Mock } = Object.assign( jest.fn(), {
+		replace: jest.fn(),
+	} );
 	return { __esModule: true, default: mockPage };
 } );
 

--- a/client/reader/atmosphere/test/author-profile-view.test.tsx
+++ b/client/reader/atmosphere/test/author-profile-view.test.tsx
@@ -124,7 +124,7 @@ describe( 'AuthorProfileView', () => {
 
 	it( 'renders the back-to-timeline button above the panel', async () => {
 		const user = userEvent.setup();
-		// jsdom starts with history.length === 1, so BackButton will call page() directly.
+		// Force history.length === 1 so BackButton routes via page() instead of history.back().
 		jest.spyOn( window.history, 'length', 'get' ).mockReturnValue( 1 );
 
 		nock( 'https://public-api.wordpress.com' )
@@ -160,11 +160,10 @@ describe( 'AuthorProfileView', () => {
 
 		renderWithProvider( <AuthorProfileView connectionId={ 42 } actor="alice.bsky.social" /> );
 
-		// Wait for the panel to render (connection resolved), then verify the
-		// back button is present in the view and navigates to the timeline.
 		await screen.findByRole( 'heading', { level: 2, name: 'Alice' } );
-		const backButton = screen.getByRole( 'button', { name: /back/i } );
-		await user.click( backButton );
+		const backButtons = screen.getAllByRole( 'button', { name: /back/i } );
+		expect( backButtons ).toHaveLength( 1 );
+		await user.click( backButtons[ 0 ] );
 		expect( page as unknown as jest.Mock ).toHaveBeenCalledWith( '/reader/atmosphere/42/timeline' );
 		expect( analytics.recordReaderTracksEvent ).toHaveBeenCalledWith(
 			'calypso_reader_atmosphere_profile_back_to_timeline_clicked',

--- a/client/reader/atmosphere/test/profile-panel.test.tsx
+++ b/client/reader/atmosphere/test/profile-panel.test.tsx
@@ -110,7 +110,6 @@ describe( 'ProfilePanel (own profile)', () => {
 			queryClient: makeQueryClient(),
 		} );
 
-		// Wait for the panel to render before reading hrefs.
 		await screen.findByRole( 'heading', { level: 2, name: 'Viewer Name' } );
 
 		expect( screen.getByRole( 'menuitem', { name: 'Posts' } ) ).toHaveAttribute(
@@ -139,12 +138,39 @@ describe( 'ProfilePanel (own profile)', () => {
 		expect( screen.queryByRole( 'button', { name: /^Following$/i } ) ).toBeNull();
 	} );
 
+	it( 'does not render the back-to-timeline button on the own-profile route', async () => {
+		setupHappyPath();
+
+		renderWithProvider( <ProfilePanel connection={ connection } />, {
+			queryClient: makeQueryClient(),
+		} );
+
+		await screen.findByRole( 'heading', { level: 2, name: 'Viewer Name' } );
+		expect( screen.queryByRole( 'button', { name: /back/i } ) ).toBeNull();
+	} );
+
+	it( 'preserves unrelated query params when building subtab hrefs', async () => {
+		setupHappyPath();
+		window.history.replaceState( {}, '', '/reader/atmosphere/42/profile?from=tabs&foo=bar' );
+
+		renderWithProvider( <ProfilePanel connection={ connection } />, {
+			queryClient: makeQueryClient(),
+		} );
+
+		await screen.findByRole( 'heading', { level: 2, name: 'Viewer Name' } );
+		expect( screen.getByRole( 'menuitem', { name: 'Replies' } ) ).toHaveAttribute(
+			'href',
+			'/reader/atmosphere/42/profile?from=tabs&foo=bar&tab=replies'
+		);
+	} );
+
 	it( 'renders an error state when the profile endpoint fails', async () => {
-		// Use .times(3) to cover the initial attempt plus up to 2 retries that
-		// atmosphereScopedProfileQuery makes for non-terminal errors.
+		// atmosphereScopedProfileQuery retries non-terminal errors; persist the
+		// 502 reply so retry-policy tweaks don't make this test pass for the
+		// wrong reason.
 		nock( 'https://public-api.wordpress.com' )
+			.persist()
 			.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/viewer.bsky.social' )
-			.times( 3 )
 			.reply( 502, { error: 'atmosphere_upstream_unavailable' } );
 		nock( 'https://public-api.wordpress.com' )
 			.get( '/wpcom/v2/reader/atmosphere/profile/viewer.bsky.social/feed' )

--- a/client/reader/atmosphere/test/profile-panel.test.tsx
+++ b/client/reader/atmosphere/test/profile-panel.test.tsx
@@ -4,6 +4,7 @@
 import { QueryClient } from '@tanstack/react-query';
 import { screen } from '@testing-library/react';
 import nock from 'nock';
+import * as analytics from 'calypso/state/reader/analytics/actions';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { ProfilePanel } from '../profile-panel';
 import type { AtmosphereConnection } from '@automattic/api-core';
@@ -16,54 +17,139 @@ const connection: AtmosphereConnection = {
 	avatar: null,
 };
 
+const profilePayload = {
+	did: 'did:plc:viewer',
+	handle: 'viewer.bsky.social',
+	display_name: 'Viewer Name',
+	description: 'About me.',
+	description_html: '<p>About me.</p>',
+	avatar: 'https://cdn.example/a.jpg',
+	banner: 'https://cdn.example/b.jpg',
+	bluesky_url: 'https://bsky.app/profile/viewer.bsky.social',
+	counts: { followers: 12, follows: 7, posts: 4 },
+	viewer: { following: null, following_rkey: null, followed_by: false },
+};
+
+const feedItem = {
+	uri: 'at://did:plc:viewer/app.bsky.feed.post/aaaaaaaaaaaaa',
+	cid: 'cid',
+	author: {
+		did: 'did:plc:viewer',
+		handle: 'viewer.bsky.social',
+		display_name: 'Viewer Name',
+		avatar: null,
+	},
+	created_at: '2024-01-01T00:00:00.000Z',
+	indexed_at: '2024-01-01T00:00:00.000Z',
+	text: 'hello world',
+	html: '<p>hello world</p>',
+	lang: [ 'en' ],
+	reply_parent: null,
+	reply_root: null,
+	reason: null,
+	embed: null,
+	counts: { replies: 0, reposts: 0, likes: 0, quotes: 0 },
+	bluesky_url: 'https://bsky.app/profile/viewer.bsky.social/post/aaaaaaaaaaaaa',
+};
+
 function makeQueryClient() {
-	return new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+	return new QueryClient( { defaultOptions: { queries: { retry: false, retryDelay: 0 } } } );
 }
+
+beforeAll( () => {
+	global.IntersectionObserver = class IntersectionObserver {
+		observe() {}
+		unobserve() {}
+		disconnect() {}
+	} as unknown as typeof global.IntersectionObserver;
+} );
+
+afterAll( () => {
+	// @ts-expect-error -- cleaning up the stub
+	delete global.IntersectionObserver;
+} );
+
+beforeEach( () => {
+	jest
+		.spyOn( analytics, 'recordReaderTracksEvent' )
+		.mockImplementation( () => ( { type: '@@TEST/NOOP' } ) as never );
+	window.history.replaceState( {}, '', '/reader/atmosphere/42/profile' );
+} );
 
 afterEach( () => {
 	nock.cleanAll();
+	jest.restoreAllMocks();
 } );
 
 describe( 'ProfilePanel (own profile)', () => {
-	it( 'shows a loading status while the connection details are pending', () => {
+	function setupHappyPath() {
 		nock( 'https://public-api.wordpress.com' )
-			.get( '/wpcom/v2/reader/atmosphere/connections/42' )
-			.delay( 5000 )
-			.reply( 200, {} );
-
-		renderWithProvider( <ProfilePanel connection={ connection } />, {
-			queryClient: makeQueryClient(),
-		} );
-
-		expect( screen.getByRole( 'status' ) ).toHaveTextContent( /loading/i );
-	} );
-
-	it( 'renders the rich SocialProfileCard once the data resolves', async () => {
+			.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/viewer.bsky.social' )
+			.reply( 200, profilePayload );
 		nock( 'https://public-api.wordpress.com' )
-			.get( '/wpcom/v2/reader/atmosphere/connections/42' )
-			.reply( 200, {
-				did: 'did:plc:viewer',
-				handle: 'viewer.bsky.social',
-				display_name: 'Viewer Name',
-				description: 'About me.',
-				avatar: 'https://cdn.example/a.jpg',
-				banner: 'https://cdn.example/b.jpg',
-				counts: { followers: 12, follows: 7, posts: 4 },
-			} );
+			.get( '/wpcom/v2/reader/atmosphere/profile/viewer.bsky.social/feed' )
+			.query( true )
+			.reply( 200, { items: [ feedItem ], cursor: null } );
+	}
+
+	it( "renders the profile card and the user's post once both queries resolve", async () => {
+		setupHappyPath();
 
 		renderWithProvider( <ProfilePanel connection={ connection } />, {
 			queryClient: makeQueryClient(),
 		} );
 
 		expect( await screen.findByRole( 'heading', { level: 2, name: 'Viewer Name' } ) ).toBeVisible();
-		expect( screen.getByText( '@viewer.bsky.social' ) ).toBeVisible();
-		expect( screen.getByText( 'About me.' ) ).toBeVisible();
+		expect( await screen.findByText( 'hello world' ) ).toBeVisible();
 	} );
 
-	it( 'renders an error state when the connection endpoint fails', async () => {
+	it( 'subtab links use the no-actor profile base path', async () => {
+		setupHappyPath();
+
+		renderWithProvider( <ProfilePanel connection={ connection } />, {
+			queryClient: makeQueryClient(),
+		} );
+
+		// Wait for the panel to render before reading hrefs.
+		await screen.findByRole( 'heading', { level: 2, name: 'Viewer Name' } );
+
+		expect( screen.getByRole( 'menuitem', { name: 'Posts' } ) ).toHaveAttribute(
+			'href',
+			'/reader/atmosphere/42/profile?tab=posts'
+		);
+		expect( screen.getByRole( 'menuitem', { name: 'Replies' } ) ).toHaveAttribute(
+			'href',
+			'/reader/atmosphere/42/profile?tab=replies'
+		);
+		expect( screen.getByRole( 'menuitem', { name: 'Media' } ) ).toHaveAttribute(
+			'href',
+			'/reader/atmosphere/42/profile?tab=media'
+		);
+	} );
+
+	it( "does not render the Follow button on the connection owner's own profile", async () => {
+		setupHappyPath();
+
+		renderWithProvider( <ProfilePanel connection={ connection } />, {
+			queryClient: makeQueryClient(),
+		} );
+
+		await screen.findByRole( 'heading', { level: 2, name: 'Viewer Name' } );
+		expect( screen.queryByRole( 'button', { name: /^Follow$/i } ) ).toBeNull();
+		expect( screen.queryByRole( 'button', { name: /^Following$/i } ) ).toBeNull();
+	} );
+
+	it( 'renders an error state when the profile endpoint fails', async () => {
+		// Use .times(3) to cover the initial attempt plus up to 2 retries that
+		// atmosphereScopedProfileQuery makes for non-terminal errors.
 		nock( 'https://public-api.wordpress.com' )
-			.get( '/wpcom/v2/reader/atmosphere/connections/42' )
+			.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/viewer.bsky.social' )
+			.times( 3 )
 			.reply( 502, { error: 'atmosphere_upstream_unavailable' } );
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/wpcom/v2/reader/atmosphere/profile/viewer.bsky.social/feed' )
+			.query( true )
+			.reply( 200, { items: [], cursor: null } );
 
 		renderWithProvider( <ProfilePanel connection={ connection } />, {
 			queryClient: makeQueryClient(),


### PR DESCRIPTION
Fixes CM-665

## Proposed Changes

- The ATmosphere Profile tab now shows the connection owner's full author panel (profile card + Posts/Replies/Media subtabs + feed) instead of just the profile card.
- `AuthorProfilePanel` is now reused on both the actor URL (`/reader/atmosphere/:id/profile/:actor`, served by `AuthorProfileView`) and the Profile tab (`/reader/atmosphere/:id/profile`).
- `AuthorProfileTabs` is parameterized with a `basePath` prop so each surface keeps its own subtab URL shape; the Profile tab stays on `/reader/atmosphere/:id/profile?tab=…` (no actor segment).
- The back-to-timeline header was lifted out of `AuthorProfilePanel` into `AuthorProfileView`. The Profile tab doesn't need it because `<AtmosphereNavigation>` already provides Timeline as a sibling tab.

## Why are these changes being made?

Previously, viewing your own posts on ATmosphere required navigating to `/reader/atmosphere/<id>/profile/<your-handle>`, which renders `AuthorProfileView`. The Profile tab in `atmosphere-account-view.tsx` is the more discoverable surface for "this is me", but it only rendered a `<SocialProfileCard>` — no feed. Reusing `AuthorProfilePanel` brings parity to the tab while keeping the existing actor-URL surface byte-identical (Tracks payloads for `_filter_changed`, `_profile_viewed`, and `_back_to_timeline_clicked` are unchanged).

The mastodon parallel files (`client/reader/mastodon/*`) are intentionally **not** updated in this PR — mastodon uses a different abstraction (`SocialAuthorProfilePanel`) for chrome and a separate consolidation pass would fit it.

## Testing Instructions

1. Connect an ATmosphere (Bluesky) account from `/reader/atmosphere`.
2. Open `/reader/atmosphere/<id>/profile` — the Profile tab should show the profile card AND a feed of your own posts.
3. Click the Posts / Replies / Media subtabs — the URL should become `/reader/atmosphere/<id>/profile?tab=replies` (etc.) with NO actor segment, and the feed should reload accordingly.
4. The Profile tab should NOT show a "Back to timeline" button (the Timeline tab in `<AtmosphereNavigation>` covers that).
5. Visit `/reader/atmosphere/<id>/profile/<some-other-handle>` — the back-to-timeline button should still appear above the panel and still dispatch the existing `calypso_reader_atmosphere_profile_back_to_timeline_clicked` Tracks event.
6. Visit `/reader/atmosphere/<id>/profile/<your-own-handle>` directly — works as before, with no Follow button (own profile).

> Manual smoke testing in a real browser session is still pending at the time of opening this PR.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?