### PR TITLE
Dashboard: show empty state on monetize subscriptions page

### DIFF
--- a/client/dashboard/me/billing-monetize-subscriptions/index.tsx
+++ b/client/dashboard/me/billing-monetize-subscriptions/index.tsx
@@ -9,6 +9,7 @@ import { useMemo, useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { monetizeSubscriptionRoute } from '../../app/router/me';
 import { DataViewsCard } from '../../components/dataviews';
+import EmptyState from '../../components/empty-state';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { adjustDataViewFieldsForWidth } from '../../utils/dataviews-width';
@@ -97,25 +98,37 @@ function MonetizeSubscriptions() {
 				<PageHeader
 					prefix={ <Breadcrumbs length={ 2 } /> }
 					title={ getMonetizeSubscriptionsPageTitle() }
-					description={ __( 'Manage your Monetize subscriptions.' ) }
+					description={ __(
+						'Track subscriptions from readers who pay for access to your content.'
+					) }
 				/>
 			}
 		>
-			<div ref={ ref }>
-				<DataViewsCard>
-					<DataViews
-						data={ adjustedMonetizeSubscriptions }
-						isLoading={ isLoadingMonetize }
-						fields={ monetizeDataFields }
-						view={ currentView }
-						onChangeView={ setView }
-						defaultLayouts={ { table: {} } }
-						actions={ actions }
-						getItemId={ getItemId }
-						paginationInfo={ paginationInfo }
-					/>
-				</DataViewsCard>
-			</div>
+			{ ! isLoadingMonetize && ( ! monetizeSubscriptions || monetizeSubscriptions.length === 0 ) ? (
+				<EmptyState.Wrapper isCompact>
+					<EmptyState>
+						<EmptyState.Description>
+							{ __( "You don't have any subscriptions yet." ) }
+						</EmptyState.Description>
+					</EmptyState>
+				</EmptyState.Wrapper>
+			) : (
+				<div ref={ ref }>
+					<DataViewsCard>
+						<DataViews
+							data={ adjustedMonetizeSubscriptions }
+							isLoading={ isLoadingMonetize }
+							fields={ monetizeDataFields }
+							view={ currentView }
+							onChangeView={ setView }
+							defaultLayouts={ { table: {} } }
+							actions={ actions }
+							getItemId={ getItemId }
+							paginationInfo={ paginationInfo }
+						/>
+					</DataViewsCard>
+				</div>
+			) }
 		</PageLayout>
 	);
 }


### PR DESCRIPTION
Fixes: https://linear.app/a8c/issue/RSM-586

## Summary

This PR cleans up the monetize subscription page with some minor tweaks.

| Before | After |
| -- | -- |
| <img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/105424b8-3949-43cd-aab8-820518ece2aa" /> | <img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/a5a0e9cd-9814-4176-8ec9-1f52572045de" /> |

## Test plan

- [ ] Visit `my.localhost:3000/me/billing/monetize-subscriptions` with an account that has no monetize subscriptions — verify empty state card appears
- [ ] Visit the same page with an account that has subscriptions — verify the DataViews table renders as before
- [ ] With subscriptions present, use the search bar to filter to zero results — verify "No results" still shows (not the empty state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)