### PR TITLE
Generate Feature Clip: hide sidebar panel on sites without VideoPress

### DIFF
--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
@@ -74,6 +74,7 @@ describe( 'feature-clip-sidebar-extension', () => {
 		mockSetCurrentAttachmentId.mockClear();
 		mockSetCurrentDurationSeconds.mockClear();
 		( window as Record< string, unknown > ).imageStudioData = { isDevMode: true };
+		jest.resetModules();
 	} );
 
 	afterEach( () => {

--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
@@ -88,10 +88,10 @@ describe( 'feature-clip-sidebar-extension', () => {
 		expect( mockRegisterPlugin ).not.toHaveBeenCalled();
 	} );
 
-	it( 'does not register the plugin when canUploadVideos is false', () => {
+	it( 'does not register the plugin when canGenerateVideoClips is false', () => {
 		( window as Record< string, unknown > ).imageStudioData = {
 			isDevMode: true,
-			canUploadVideos: false,
+			canGenerateVideoClips: false,
 		};
 		const { registerFeatureClipSidebar } = require( './feature-clip-sidebar-extension' );
 		registerFeatureClipSidebar();

--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
@@ -87,6 +87,16 @@ describe( 'feature-clip-sidebar-extension', () => {
 		expect( mockRegisterPlugin ).not.toHaveBeenCalled();
 	} );
 
+	it( 'does not register the plugin when canUploadVideos is false', () => {
+		( window as Record< string, unknown > ).imageStudioData = {
+			isDevMode: true,
+			canUploadVideos: false,
+		};
+		const { registerFeatureClipSidebar } = require( './feature-clip-sidebar-extension' );
+		registerFeatureClipSidebar();
+		expect( mockRegisterPlugin ).not.toHaveBeenCalled();
+	} );
+
 	it( 'registers a sidebar plugin exactly once', () => {
 		const { registerFeatureClipSidebar } = require( './feature-clip-sidebar-extension' );
 		registerFeatureClipSidebar();

--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
@@ -116,7 +116,7 @@ let pluginRegistered = false;
  * editor package isn't loaded on the page (e.g. wp-admin Media Library).
  */
 export function registerFeatureClipSidebar(): void {
-	if ( window.imageStudioData?.canUploadVideos === false ) {
+	if ( window.imageStudioData?.canGenerateVideoClips === false ) {
 		return;
 	}
 

--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
@@ -116,12 +116,11 @@ let pluginRegistered = false;
  * editor package isn't loaded on the page (e.g. wp-admin Media Library).
  */
 export function registerFeatureClipSidebar(): void {
-	if ( ! window.imageStudioData?.isDevMode ) {
+	if ( window.imageStudioData?.canUploadVideos === false ) {
 		return;
 	}
 
-	// Explicit `=== false` so an undefined flag (older Jetpack) preserves today's behavior.
-	if ( window.imageStudioData?.canUploadVideos === false ) {
+	if ( ! window.imageStudioData?.isDevMode ) {
 		return;
 	}
 

--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
@@ -120,6 +120,11 @@ export function registerFeatureClipSidebar(): void {
 		return;
 	}
 
+	// Explicit `=== false` so an undefined flag (older Jetpack) preserves today's behavior.
+	if ( window.imageStudioData?.canUploadVideos === false ) {
+		return;
+	}
+
 	if ( pluginRegistered ) {
 		return;
 	}

--- a/packages/image-studio/src/index.tsx
+++ b/packages/image-studio/src/index.tsx
@@ -26,6 +26,7 @@ interface ImageStudioData {
 	enabled?: boolean | string;
 	environment?: 'wp-admin' | 'ciab-admin';
 	isDevMode?: boolean;
+	canUploadVideos?: boolean;
 }
 
 declare global {

--- a/packages/image-studio/src/index.tsx
+++ b/packages/image-studio/src/index.tsx
@@ -26,7 +26,7 @@ interface ImageStudioData {
 	enabled?: boolean | string;
 	environment?: 'wp-admin' | 'ciab-admin';
 	isDevMode?: boolean;
-	canUploadVideos?: boolean;
+	canGenerateVideoClips?: boolean;
 }
 
 declare global {


### PR DESCRIPTION
## Summary

- Hide the Generate Feature Clip sidebar panel on sites where VideoPress is not available, so users don't see an entry point that would just hit a server-side error mid-flow.
- Reads the new `canGenerateVideoClips` flag from `imageStudioData`. If the flag is `undefined` (older Jetpack version that hasn't shipped it yet), behavior is unchanged — the panel still registers.

## Companion PR

- Jetpack: Automattic/jetpack#48486 (exposes `canGenerateVideoClips` to the client, derived from a strict VideoPress capability check).

## Base branch

Stacked on `try/rsm-118-video-generated-tracks` (Automattic/wp-calypso#110412). Will rebase to `trunk` once the parent merges.

## Test plan

- [ ] On a site with VideoPress, the Generate Feature Clip panel renders normally.
- [ ] On a site without VideoPress (`canGenerateVideoClips === false`), the panel does not render.
- [ ] On a site with no `canGenerateVideoClips` field at all (older Jetpack), the panel still renders.