### PR TITLE
Reader: migrate Conversations stream to React Query (READ-496)

### DIFF
--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -81,19 +81,6 @@ const defaultQueryFn = getQueryString;
 const seed = random( 0, 1000 );
 
 const streamApis = {
-	conversations: {
-		path: () => '/read/conversations',
-		dateProperty: 'last_comment_date_gmt',
-		query: ( extras ) => getQueryString( { ...extras, comments_per_post: 20 } ),
-		pollQuery: () => getQueryStringForPoll( [ 'last_comment_date_gmt', 'comments' ] ),
-	},
-	'conversations-a8c': {
-		path: () => '/read/conversations',
-		dateProperty: 'last_comment_date_gmt',
-		query: ( extras ) => getQueryString( { ...extras, index: 'a8c', comments_per_post: 20 } ),
-		pollQuery: () =>
-			getQueryStringForPoll( [ 'last_comment_date_gmt', 'comments' ], { index: 'a8c' } ),
-	},
 	likes: {
 		path: () => '/read/liked',
 		dateProperty: 'date_liked',

--- a/client/state/data-layer/wpcom/read/streams/test/index.js
+++ b/client/state/data-layer/wpcom/read/streams/test/index.js
@@ -34,10 +34,10 @@ function makeAction( { streamKey, ...overrides } ) {
 }
 
 describe( 'streams', () => {
-	// All `date`-based streams plus `following`/`discover` are migrated to
-	// React Query (see client/state/reader/streams/test/actions.js). Use a
-	// still-unmigrated stream type for the shared `handlePage` action below.
-	const action = makeAction( { streamKey: 'conversations' } );
+	// All `date`-based streams plus `following`/`discover`/`conversations` are
+	// migrated to React Query (see client/state/reader/streams/test/actions.js).
+	// Use a still-unmigrated stream type for the shared `handlePage` action.
+	const action = makeAction( { streamKey: 'likes' } );
 
 	describe( 'requestPage', () => {
 		const query = {
@@ -72,6 +72,8 @@ describe( 'streams', () => {
 			'on_this_day',
 			'on_this_day:3:15',
 			'user:42',
+			'conversations',
+			'conversations-a8c',
 		] )( 'returns undefined for migrated streamKey %s', ( streamKey ) => {
 			expect( requestPage( makeAction( { streamKey } ) ) ).toBeUndefined();
 		} );
@@ -81,24 +83,6 @@ describe( 'streams', () => {
 			// each test is an assertion of the http call that should be made
 			// when the given stream id is handed to request page
 			[
-				{
-					stream: 'conversations',
-					expected: {
-						method: 'GET',
-						path: '/read/conversations',
-						apiVersion: '1.2',
-						query: { ...query, comments_per_post: 20 },
-					},
-				},
-				{
-					stream: 'conversations-a8c',
-					expected: {
-						method: 'GET',
-						path: '/read/conversations',
-						apiVersion: '1.2',
-						query: { ...query, comments_per_post: 20, index: 'a8c' },
-					},
-				},
 				{
 					stream: 'likes',
 					expected: {

--- a/client/state/reader/streams/actions.js
+++ b/client/state/reader/streams/actions.js
@@ -35,6 +35,19 @@ import {
 import 'calypso/state/data-layer/wpcom/read/streams';
 import 'calypso/state/reader/init';
 
+/**
+ * Per-stream date property used by `createStreamDataFromPosts` to populate
+ * `streamItem.date`. Mirrors `streamApis[type].dateProperty` in the legacy
+ * data-layer (`client/state/data-layer/wpcom/read/streams/index.js`). When
+ * `likes` migrates next this will need a `'likes'` case (`date_liked`).
+ */
+function getDatePropertyForStream( streamType ) {
+	if ( streamType === 'conversations' || streamType === 'conversations-a8c' ) {
+		return 'last_comment_date_gmt';
+	}
+	return 'date';
+}
+
 function buildPageRequestAction( {
 	streamKey,
 	feedId,
@@ -96,6 +109,17 @@ function buildStreamQueryParams( {
 			// Legacy `streamApis.user.pollQuery` polled with `number: 20`.
 			return getQueryStringForPoll( [], { ...commonQueryParams, number: 20 } );
 		}
+		if ( streamType === 'conversations' ) {
+			// Legacy `streamApis.conversations.pollQuery`.
+			return getQueryStringForPoll( [ 'last_comment_date_gmt', 'comments' ], commonQueryParams );
+		}
+		if ( streamType === 'conversations-a8c' ) {
+			// Legacy `streamApis['conversations-a8c'].pollQuery`.
+			return getQueryStringForPoll( [ 'last_comment_date_gmt', 'comments' ], {
+				...commonQueryParams,
+				index: 'a8c',
+			} );
+		}
 		return getQueryStringForPoll( [], commonQueryParams );
 	}
 	const extras = {
@@ -118,6 +142,10 @@ function buildStreamQueryParams( {
 			return buildListQueryParams( extras );
 		case 'on_this_day':
 			return buildOnThisDayQueryParams( extras, streamKey );
+		case 'conversations':
+			return getQueryString( { ...extras, comments_per_post: 20 } );
+		case 'conversations-a8c':
+			return getQueryString( { ...extras, comments_per_post: 20, index: 'a8c' } );
 		default:
 			return getQueryString( extras );
 	}
@@ -285,10 +313,7 @@ async function dispatchMigratedStreamRequest( dispatch, params ) {
 		return;
 	}
 
-	// Every migrated streamType uses `date`. This will need to become
-	// per-streamType once `conversations` (`last_comment_date_gmt`) and
-	// `likes` (`date_liked`) migrate.
-	const dateProperty = 'date';
+	const dateProperty = getDatePropertyForStream( streamType );
 	let streamItems = [];
 	let streamPosts = [];
 	let streamSites = [];

--- a/client/state/reader/streams/migrated-stream-types.ts
+++ b/client/state/reader/streams/migrated-stream-types.ts
@@ -7,9 +7,9 @@
  * Each PR in the READ-485 migration extends this once the matching fetcher
  * exists in `@automattic/api-core` and is wired into `readStreamQuery` in
  * `@automattic/api-queries`. Streams still served by the legacy data-layer:
- * `conversations`, `conversations-a8c`, `likes`, `recommendations_posts`,
- * `custom_recs_posts_with_images`, `custom_recs_sites_with_images`. Those
- * land in a final cleanup PR that deletes the data-layer file entirely.
+ * `likes`, `recommendations_posts`, `custom_recs_posts_with_images`,
+ * `custom_recs_sites_with_images`. Those land in a final cleanup PR that
+ * deletes the data-layer file entirely.
  */
 const MIGRATED_STREAM_TYPES: ReadonlySet< string > = new Set( [
 	'following',
@@ -27,6 +27,8 @@ const MIGRATED_STREAM_TYPES: ReadonlySet< string > = new Set( [
 	'list',
 	'on_this_day',
 	'user',
+	'conversations',
+	'conversations-a8c',
 ] );
 
 export function isMigratedStream( streamType: string ): boolean {

--- a/client/state/reader/streams/test/actions.js
+++ b/client/state/reader/streams/test/actions.js
@@ -65,13 +65,13 @@ afterEach( () => {
 describe( 'requestPage thunk', () => {
 	describe( 'unmigrated stream type', () => {
 		it( 'dispatches the legacy READER_STREAMS_PAGE_REQUEST', () => {
-			const { dispatch } = runThunk( { streamKey: 'conversations' } );
+			const { dispatch } = runThunk( { streamKey: 'likes' } );
 			expect( dispatch ).toHaveBeenCalledTimes( 1 );
 			const action = dispatch.mock.calls[ 0 ][ 0 ];
 			expect( action.type ).toBe( READER_STREAMS_PAGE_REQUEST );
 			expect( action.payload ).toMatchObject( {
-				streamKey: 'conversations',
-				streamType: 'conversations',
+				streamKey: 'likes',
+				streamType: 'likes',
 				isPoll: false,
 			} );
 		} );
@@ -647,7 +647,7 @@ describe( 'requestPaginatedStream thunk', () => {
 
 	it( 'returns the legacy action for unmigrated streamKey', () => {
 		const { dispatch, result } = runPaginatedThunk( {
-			streamKey: 'conversations',
+			streamKey: 'likes',
 			page: 1,
 			perPage: 10,
 		} );
@@ -655,7 +655,7 @@ describe( 'requestPaginatedStream thunk', () => {
 		// path. The first dispatch carried the same action.
 		expect( result ).toMatchObject( {
 			type: 'READER_STREAMS_PAGINATED_REQUEST',
-			payload: { streamKey: 'conversations', page: 1, perPage: 10 },
+			payload: { streamKey: 'likes', page: 1, perPage: 10 },
 		} );
 		expect( dispatch ).toHaveBeenCalledTimes( 1 );
 	} );

--- a/client/state/reader/streams/test/migrated-stream-types.ts
+++ b/client/state/reader/streams/test/migrated-stream-types.ts
@@ -20,13 +20,13 @@ describe( 'isMigratedStream', () => {
 		'list',
 		'on_this_day',
 		'user',
+		'conversations',
+		'conversations-a8c',
 	] )( 'returns true for `%s`', ( streamType ) => {
 		expect( isMigratedStream( streamType ) ).toBe( true );
 	} );
 
 	it.each( [
-		'conversations',
-		'conversations-a8c',
 		'likes',
 		'recommendations_posts',
 		'custom_recs_posts_with_images',

--- a/packages/api-core/src/read-streams/fetchers.ts
+++ b/packages/api-core/src/read-streams/fetchers.ts
@@ -3,12 +3,11 @@ import { wpcom } from '../wpcom-fetcher';
 import type { ReadStreamQueryParams, ReadStreamResponse } from './types';
 
 // READ-485: streams migrated incrementally. Streams still served by the
-// legacy data-layer at `client/state/data-layer/wpcom/read/streams/index.js`
-// (with non-`date` dateProperty or non-stream endpoints): `conversations`,
-// `conversations-a8c`, `likes`, `recommendations_posts`,
-// `custom_recs_posts_with_images`, `custom_recs_sites_with_images`. See the
-// legacy `streamApis` map for their canonical per-shape `path`, `apiVersion`,
-// `apiNamespace`, and `query` definitions to mirror when porting each one.
+// legacy data-layer at `client/state/data-layer/wpcom/read/streams/index.js`:
+// `likes`, `recommendations_posts`, `custom_recs_posts_with_images`,
+// `custom_recs_sites_with_images`. See the legacy `streamApis` map for their
+// canonical per-shape `path`, `apiVersion`, `apiNamespace`, and `query`
+// definitions to mirror when porting each one.
 export const fetchReadFollowing = (
 	params: ReadStreamQueryParams = {}
 ): Promise< ReadStreamResponse > =>
@@ -245,6 +244,22 @@ export const fetchReadDiscoverFreshlyPressed = (
 ): Promise< ReadStreamResponse > =>
 	wpcom.req.get( {
 		path: addQueryArgs( '/freshly-pressed', params ),
+		apiVersion: '1.2',
+		method: 'GET',
+	} );
+
+/**
+ * Fetch the `conversations` stream — `/read/conversations`. The thunk in
+ * `client/state/reader/streams/actions.js` always passes `comments_per_post: 20`
+ * and (for the a8c variant) `index: 'a8c'` in `params`, mirroring the legacy
+ * `streamApis.conversations` definition. Pagination is date-based via
+ * `last_comment_date_gmt` on the response.
+ */
+export const fetchReadConversations = (
+	params: ReadStreamQueryParams = {}
+): Promise< ReadStreamResponse > =>
+	wpcom.req.get( {
+		path: addQueryArgs( '/read/conversations', params ),
 		apiVersion: '1.2',
 		method: 'GET',
 	} );

--- a/packages/api-queries/src/__tests__/read-streams.test.tsx
+++ b/packages/api-queries/src/__tests__/read-streams.test.tsx
@@ -56,12 +56,61 @@ describe( 'readStreamQuery', () => {
 		expect( result.current.data?.date_range?.after ).toBe( '2026-01-01' );
 	} );
 
-	it( 'throws when called for an unmigrated streamType', () => {
-		// `conversations` is still served by the legacy data-layer (different
-		// dateProperty); update this case when it lands in `readStreamQuery`.
-		const opts = readStreamQuery( 'conversations', { number: 4 }, null );
-		expect( () => opts.queryFn!( {} as never ) ).toThrow(
-			/unsupported streamType "conversations"/
+	it( 'fetches conversations posts from /read/conversations', async () => {
+		const scope = nock( BASE )
+			.get( '/rest/v1.2/read/conversations' )
+			.query( ( query ) => query.comments_per_post === '20' )
+			.reply( 200, {
+				posts: [
+					{
+						ID: 1,
+						site_ID: 100,
+						last_comment_date_gmt: '2026-04-30',
+						URL: 'https://example.com/a',
+					},
+				],
+				date_range: { after: '2026-04-30' },
+			} );
+
+		const client = newClient();
+		const { result } = renderHook(
+			() =>
+				useQuery( readStreamQuery( 'conversations', { number: 4, comments_per_post: 20 }, null ) ),
+			{ wrapper: makeWrapper( client ) }
 		);
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+		expect( scope.isDone() ).toBe( true );
+		expect( result.current.data?.posts ).toHaveLength( 1 );
+	} );
+
+	it( 'fetches conversations-a8c posts with the a8c index filter', async () => {
+		const scope = nock( BASE )
+			.get( '/rest/v1.2/read/conversations' )
+			.query( ( query ) => query.index === 'a8c' && query.comments_per_post === '20' )
+			.reply( 200, { posts: [], date_range: { after: null } } );
+
+		const client = newClient();
+		const { result } = renderHook(
+			() =>
+				useQuery(
+					readStreamQuery(
+						'conversations-a8c',
+						{ number: 4, comments_per_post: 20, index: 'a8c' },
+						null
+					)
+				),
+			{ wrapper: makeWrapper( client ) }
+		);
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+		expect( scope.isDone() ).toBe( true );
+	} );
+
+	it( 'throws when called for an unmigrated streamType', () => {
+		// `likes` is still served by the legacy data-layer (different
+		// dateProperty); update this case when it lands in `readStreamQuery`.
+		const opts = readStreamQuery( 'likes', { number: 4 }, null );
+		expect( () => opts.queryFn!( {} as never ) ).toThrow( /unsupported streamType "likes"/ );
 	} );
 } );

--- a/packages/api-queries/src/read-streams.ts
+++ b/packages/api-queries/src/read-streams.ts
@@ -1,5 +1,6 @@
 import {
 	fetchReadA8c,
+	fetchReadConversations,
 	fetchReadDiscoverFreshlyPressed,
 	fetchReadDiscoverLatest,
 	fetchReadDiscoverRecommended,
@@ -56,11 +57,10 @@ const fetchDiscover = (
  *
  * Migrated: `following`, every `discover:*` sub-tab, plus `recent`, `search`,
  * `feed`, `site`, `notifications`, `featured`, `p2`, `a8c`, `tag`,
- * `tag_popular`, `list`, `on_this_day`, and `user`. Streams still served by
- * the legacy data-layer (non-`date` dateProperty or non-stream endpoints):
- * `conversations`, `conversations-a8c`, `likes`, `recommendations_posts`,
- * `custom_recs_*`. Those will land in a final cleanup PR that also deletes
- * the data-layer file.
+ * `tag_popular`, `list`, `on_this_day`, `user`, `conversations`, and
+ * `conversations-a8c`. Streams still served by the legacy data-layer:
+ * `likes`, `recommendations_posts`, `custom_recs_*`. Those will land in a
+ * final cleanup PR that also deletes the data-layer file.
  */
 export const readStreamQuery = (
 	streamKey: string,
@@ -105,6 +105,9 @@ export const readStreamQuery = (
 					return fetchReadUserPosts( suffix, queryParams );
 				case 'on_this_day':
 					return fetchReadOnThisDay( queryParams );
+				case 'conversations':
+				case 'conversations-a8c':
+					return fetchReadConversations( queryParams );
 				default:
 					throw new Error(
 						`readStreamQuery: unsupported streamType "${ streamType }". Add the fetcher in @automattic/api-core and a case here when migrating this stream.`


### PR DESCRIPTION
Part of READ-485 — Linear: READ-496

## Proposed Changes

* Add `fetchReadConversations` in `@automattic/api-core` (one fetcher covers both `conversations` and `conversations-a8c` — same endpoint, the a8c variant just adds `index: 'a8c'` to params).
* Wire `case 'conversations'` and `case 'conversations-a8c'` into `readStreamQuery` in `@automattic/api-queries`.
* Resolve the `dateProperty` TODO in `dispatchMigratedStreamRequest` with a per-stream helper (`last_comment_date_gmt` for both conversations keys, `date` for everything else).
* Add conversations cases to `buildStreamQueryParams` for both the request payload (`comments_per_post: 20`, plus `index: 'a8c'`) and the poll override (`['last_comment_date_gmt', 'comments']` extra fields), mirroring the legacy `streamApis.conversations[*].pollQuery` exactly.
* Flip the migration gate (`MIGRATED_STREAM_TYPES`) and delete the conversations entries from the legacy data-layer's `streamApis` map. Only `likes` and the `recommendations_posts` / `custom_recs_*` trio remain in the legacy data-layer after this PR.

## Why are these changes being made?

* Sub-task of the broader Reader migration off the Redux data-layer onto `@automattic/api-core` + `@automattic/api-queries`. Conversations is the first migration that introduces a non-`date` `dateProperty` and per-stream poll-query extras into the new path, so it also unblocks `likes` (`date_liked`) next. The `receivePosts(...)` bridge is preserved so `getPostByKey` consumers and the `state.reader.conversations` reducer's `READER_POSTS_RECEIVE` listener (for `is_following_conversation`) keep working until the slice is removed under READ-486.

## Testing Instructions

* Visit `/read/conversations` and `/read/conversations/a8c`. Confirm posts render with comment threads, infinite-scroll loads page 2, and the follow-conversation toggle still works. In the network panel: `comments_per_post=20` should be on both requests and `index=a8c` on the a8c variant — both against `/rest/v1.2/read/conversations` (no longer through the legacy `dispatchRequest` path).
* Leave the Conversations tab idle for ~60s and confirm the poll request includes `last_comment_date_gmt` and `comments` in the `fields_response` set (legacy parity).
* Run unit tests:
  * `yarn test-packages packages/api-queries/src/__tests__/read-streams.test.tsx` (6 tests).
  * `yarn test-client client/state/reader/streams/test/ client/state/reader/conversations/test/ client/state/data-layer/wpcom/read/streams/` (164 tests).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?