### PR TITLE
Reader: highlight active ATmosphere/Mastodon connection row in sidebar

### DIFF
--- a/client/reader/sidebar/social/style.scss
+++ b/client/reader/sidebar/social/style.scss
@@ -1,19 +1,19 @@
 @import '@automattic/typography/styles/variables';
 
-// Reader's togglable sidebar applies `font-weight: 600` and the
-// selected-text color to `.selected .sidebar__menu-link` (see
-// client/reader/sidebar/style.scss), which makes social account rows
-// look louder than the neighbouring Recent rows. Keep the selected
-// background, but reset the weight and color so the rows read like the
-// rest of the sidebar. Selector specificity has to match the reader
-// override (7 classes) to win the cascade.
-.theme-default .global-sidebar .sidebar .sidebar__menu.is-togglable .sidebar-social__account-item.selected .sidebar__menu-link {
-	font-weight: normal;
-
-	&,
-	&:visited {
-		color: var( --color-sidebar-text );
-	}
+// Inside .is-togglable, the base sidebar rule
+// (.selected .sidebar__menu-link { background-color: ... } in
+// client/layout/sidebar/style.scss) doesn't reach the link — the
+// togglable cascade leaves selected social rows without a background.
+// Match the togglable selector specificity (7 classes) and apply the
+// standard selected background so the active connection row reads as
+// "you are here" alongside its bold weight + selected text color.
+.theme-default
+	.global-sidebar
+	.sidebar
+	.sidebar__menu.is-togglable
+	.sidebar-social__account-item.selected
+	.sidebar__menu-link {
+	background-color: var( --color-sidebar-menu-selected-background );
 }
 
 .sidebar-social__account-handle {


### PR DESCRIPTION
Fixes CM-669

## Proposed Changes

* In the Reader sidebar, give the connection row corresponding to the current ATmosphere or Mastodon route a clear "you are here" treatment — bold weight + selected text color + selected background — across timeline, thread, profile, tag-feed, and settings sub-routes.
* Single-file CSS-only change in `client/reader/sidebar/social/style.scss`.

## Why are these changes being made?

The state plumbing already passes `isSelected={ connection.id === activeId }` to `SocialAccountMenuItem`, which adds the `selected` class on the underlying `<li>`. Two things were getting in the way of that being visible:

1. An override in `social/style.scss` reset `font-weight` and `color` on selected social rows back to plain text, deliberately muting the "you are here" cue.
2. The base sidebar's selected-row background (`var(--color-sidebar-menu-selected-background)`, applied at `client/layout/sidebar/style.scss` for `.selected .sidebar__menu-link`) doesn't reach the link inside the togglable cascade — top-level items like Discover get a background when selected, but rows inside an expandable don't.

This PR replaces the muting override with a rule that explicitly applies the standard selected background on the active social row, scoped to the togglable selector with matching specificity. The bold weight and selected text color now flow through naturally from the Reader's togglable selected styling.

No JS/TS changes — the active connection regex (`getActiveConnectionId`) already matches every ATmosphere and Mastodon sub-route.

## Testing Instructions

1. Connect at least one ATmosphere (Bluesky) account, and ideally a Mastodon account too.
2. Visit each of the following URLs in turn and confirm the matching connection row in the sidebar is bold, has the selected text color, and has the light-blue selected background:
   * `/reader/atmosphere/<id>` (redirects to timeline)
   * `/reader/atmosphere/<id>/timeline`
   * `/reader/atmosphere/<id>/profile`
   * `/reader/atmosphere/<id>/settings`
   * `/reader/atmosphere/<id>/thread/:did/:rkey` (open any post's thread)
   * `/reader/atmosphere/<id>/profile/:actor` (click an author in a post)
   * `/reader/atmosphere/<id>/tag/<hashtag>` (click a hashtag in a post)
3. On `/reader/atmosphere` (landing) and `/reader/atmosphere/connect`, confirm **no** connection row is highlighted.
4. Repeat for `/reader/mastodon/<id>/...` if you have a Mastodon connection.
5. With ≥ 2 connected accounts, switch between them on any sub-route — the highlight should move with the URL; never two highlighted at once.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?