### PR TITLE
Reader: migrate Likes stream to React Query (READ-498)

### DIFF
--- a/client/state/data-layer/wpcom/read/streams/index.js
+++ b/client/state/data-layer/wpcom/read/streams/index.js
@@ -81,11 +81,6 @@ const defaultQueryFn = getQueryString;
 const seed = random( 0, 1000 );
 
 const streamApis = {
-	likes: {
-		path: () => '/read/liked',
-		dateProperty: 'date_liked',
-		pollQuery: () => getQueryStringForPoll( [ 'date_liked' ] ),
-	},
 	recommendations_posts: {
 		path: () => '/read/recommendations/posts',
 		dateProperty: 'date',

--- a/client/state/data-layer/wpcom/read/streams/test/index.js
+++ b/client/state/data-layer/wpcom/read/streams/test/index.js
@@ -2,7 +2,7 @@ import deepfreeze from 'deep-freeze';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { READER_STREAMS_PAGE_REQUEST } from 'calypso/state/reader/action-types';
 import { receivePage, receiveUpdates } from 'calypso/state/reader/streams/actions';
-import { requestPage, handlePage, INITIAL_FETCH, QUERY_META } from '../';
+import { requestPage, handlePage, INITIAL_FETCH, PER_FETCH, QUERY_META } from '../';
 
 jest.mock( 'calypso/lib/analytics/tracks', () => ( {
 	recordTracksEvent: jest.fn(),
@@ -34,10 +34,11 @@ function makeAction( { streamKey, ...overrides } ) {
 }
 
 describe( 'streams', () => {
-	// All `date`-based streams plus `following`/`discover`/`conversations` are
-	// migrated to React Query (see client/state/reader/streams/test/actions.js).
-	// Use a still-unmigrated stream type for the shared `handlePage` action.
-	const action = makeAction( { streamKey: 'likes' } );
+	// All `date`-based streams plus `following`/`discover`/`conversations`/
+	// `likes` are migrated to React Query (see
+	// client/state/reader/streams/test/actions.js). Use a still-unmigrated
+	// stream type for the shared `handlePage` action.
+	const action = makeAction( { streamKey: 'recommendations_posts' } );
 
 	describe( 'requestPage', () => {
 		const query = {
@@ -74,6 +75,7 @@ describe( 'streams', () => {
 			'user:42',
 			'conversations',
 			'conversations-a8c',
+			'likes',
 		] )( 'returns undefined for migrated streamKey %s', ( streamKey ) => {
 			expect( requestPage( makeAction( { streamKey } ) ) ).toBeUndefined();
 		} );
@@ -83,15 +85,6 @@ describe( 'streams', () => {
 			// each test is an assertion of the http call that should be made
 			// when the given stream id is handed to request page
 			[
-				{
-					stream: 'likes',
-					expected: {
-						method: 'GET',
-						path: '/read/liked',
-						apiVersion: '1.2',
-						query,
-					},
-				},
 				{
 					stream: 'recommendations_posts',
 					expected: {
@@ -155,6 +148,8 @@ describe( 'streams', () => {
 		it( 'should return a receivePage action', () => {
 			const { streamKey, query } = action.payload;
 			const result = handlePage( action, data );
+			// `recommendations_posts` matches the `streamType.includes('rec')`
+			// branch in `extractPageHandle`, which returns an offset cursor.
 			expect( result ).toEqual( [
 				expect.any( Function ), // receivePosts thunk
 				receivePage( {
@@ -162,7 +157,7 @@ describe( 'streams', () => {
 					query,
 					streamItems: data.posts,
 					gap: null,
-					pageHandle: { before: '2018' },
+					pageHandle: { offset: PER_FETCH },
 					totalItems: 1,
 					totalPages: 1,
 				} ),
@@ -179,7 +174,7 @@ describe( 'streams', () => {
 					query,
 					streamItems: data.posts,
 					gap: null,
-					pageHandle: { before: '2018' },
+					pageHandle: { offset: PER_FETCH },
 				} ),
 			] );
 		} );

--- a/client/state/reader/streams/actions.js
+++ b/client/state/reader/streams/actions.js
@@ -124,7 +124,7 @@ function buildStreamQueryParams( {
 		}
 		if ( streamType === 'likes' ) {
 			// Legacy `streamApis.likes.pollQuery`.
-			return getQueryStringForPoll( [ 'date_liked' ], commonQueryParams );
+			return getQueryStringForPoll( [ 'date_liked' ] );
 		}
 		return getQueryStringForPoll( [], commonQueryParams );
 	}

--- a/client/state/reader/streams/actions.js
+++ b/client/state/reader/streams/actions.js
@@ -38,12 +38,14 @@ import 'calypso/state/reader/init';
 /**
  * Per-stream date property used by `createStreamDataFromPosts` to populate
  * `streamItem.date`. Mirrors `streamApis[type].dateProperty` in the legacy
- * data-layer (`client/state/data-layer/wpcom/read/streams/index.js`). When
- * `likes` migrates next this will need a `'likes'` case (`date_liked`).
+ * data-layer (`client/state/data-layer/wpcom/read/streams/index.js`).
  */
 function getDatePropertyForStream( streamType ) {
 	if ( streamType === 'conversations' || streamType === 'conversations-a8c' ) {
 		return 'last_comment_date_gmt';
+	}
+	if ( streamType === 'likes' ) {
+		return 'date_liked';
 	}
 	return 'date';
 }
@@ -119,6 +121,10 @@ function buildStreamQueryParams( {
 				...commonQueryParams,
 				index: 'a8c',
 			} );
+		}
+		if ( streamType === 'likes' ) {
+			// Legacy `streamApis.likes.pollQuery`.
+			return getQueryStringForPoll( [ 'date_liked' ], commonQueryParams );
 		}
 		return getQueryStringForPoll( [], commonQueryParams );
 	}

--- a/client/state/reader/streams/migrated-stream-types.ts
+++ b/client/state/reader/streams/migrated-stream-types.ts
@@ -7,7 +7,7 @@
  * Each PR in the READ-485 migration extends this once the matching fetcher
  * exists in `@automattic/api-core` and is wired into `readStreamQuery` in
  * `@automattic/api-queries`. Streams still served by the legacy data-layer:
- * `likes`, `recommendations_posts`, `custom_recs_posts_with_images`,
+ * `recommendations_posts`, `custom_recs_posts_with_images`,
  * `custom_recs_sites_with_images`. Those land in a final cleanup PR that
  * deletes the data-layer file entirely.
  */
@@ -29,6 +29,7 @@ const MIGRATED_STREAM_TYPES: ReadonlySet< string > = new Set( [
 	'user',
 	'conversations',
 	'conversations-a8c',
+	'likes',
 ] );
 
 export function isMigratedStream( streamType: string ): boolean {

--- a/client/state/reader/streams/test/actions.js
+++ b/client/state/reader/streams/test/actions.js
@@ -65,13 +65,13 @@ afterEach( () => {
 describe( 'requestPage thunk', () => {
 	describe( 'unmigrated stream type', () => {
 		it( 'dispatches the legacy READER_STREAMS_PAGE_REQUEST', () => {
-			const { dispatch } = runThunk( { streamKey: 'likes' } );
+			const { dispatch } = runThunk( { streamKey: 'recommendations_posts' } );
 			expect( dispatch ).toHaveBeenCalledTimes( 1 );
 			const action = dispatch.mock.calls[ 0 ][ 0 ];
 			expect( action.type ).toBe( READER_STREAMS_PAGE_REQUEST );
 			expect( action.payload ).toMatchObject( {
-				streamKey: 'likes',
-				streamType: 'likes',
+				streamKey: 'recommendations_posts',
+				streamType: 'recommendations_posts',
 				isPoll: false,
 			} );
 		} );
@@ -533,6 +533,12 @@ describe( 'requestPage thunk', () => {
 			path: '/rest/v1/users/42/posts',
 			expectedQuery: { orderBy: 'date' },
 		},
+		{
+			name: 'likes',
+			streamKey: 'likes',
+			path: '/rest/v1.2/read/liked',
+			expectedQuery: { orderBy: 'date', meta: 'post,discover_original_post' },
+		},
 	] )( '$name hits $path with the right query', async ( c ) => {
 		let captured;
 		nock( BASE )
@@ -599,6 +605,69 @@ describe( 'requestPage thunk', () => {
 
 		expect( captured.number ).toBe( '20' );
 	} );
+
+	// `likes` has a non-default `dateProperty` (`date_liked`) and a custom
+	// poll query (`fields=…,date_liked`). Verify both survived the migration.
+	describe( 'likes stream specifics', () => {
+		// Two posts whose `date_liked` order intentionally diverges from `date`
+		// so we can confirm the thunk uses `date_liked` to build streamItems.
+		const likesResponse = {
+			posts: [
+				{
+					ID: 30,
+					site_ID: 300,
+					feed_ID: 990,
+					feed_item_ID: 70,
+					date: '2026-01-01',
+					date_liked: '2026-04-10',
+					URL: 'https://example.com/post-30',
+					site_name: 'Liked Example A',
+				},
+				{
+					ID: 31,
+					site_ID: 301,
+					feed_ID: 991,
+					feed_item_ID: 71,
+					date: '2026-04-15',
+					date_liked: '2026-02-20',
+					URL: 'https://example.com/post-31',
+					site_name: 'Liked Example B',
+				},
+			],
+			date_range: { after: '2026-02-20' },
+			found: 2,
+		};
+
+		it( 'builds streamItems using `date_liked` instead of `date`', async () => {
+			nock( BASE ).get( '/rest/v1.2/read/liked' ).query( true ).reply( 200, likesResponse );
+
+			const { dispatch, result } = runThunk( { streamKey: 'likes' } );
+			await result;
+
+			const receivePageAction = dispatch.mock.calls
+				.map( ( c ) => c[ 0 ] )
+				.find( ( a ) => a && a.type === READER_STREAMS_PAGE_RECEIVE );
+			const dates = receivePageAction.payload.streamItems.map( ( item ) => item.date );
+			expect( dates ).toEqual( [ '2026-04-10', '2026-02-20' ] );
+		} );
+
+		it( 'sends `date_liked` in the poll fields query param', async () => {
+			let captured;
+			nock( BASE )
+				.get( '/rest/v1.2/read/liked' )
+				.query( ( q ) => {
+					captured = q;
+					return true;
+				} )
+				.reply( 200, likesResponse );
+
+			const { result } = runThunk( { streamKey: 'likes', isPoll: true } );
+			await result;
+
+			expect( captured.fields ).toBeDefined();
+			expect( captured.fields.split( ',' ) ).toContain( 'date_liked' );
+		} );
+	} );
 } );
 
 describe( 'requestPaginatedStream thunk', () => {
@@ -647,7 +716,7 @@ describe( 'requestPaginatedStream thunk', () => {
 
 	it( 'returns the legacy action for unmigrated streamKey', () => {
 		const { dispatch, result } = runPaginatedThunk( {
-			streamKey: 'likes',
+			streamKey: 'recommendations_posts',
 			page: 1,
 			perPage: 10,
 		} );
@@ -655,7 +724,7 @@ describe( 'requestPaginatedStream thunk', () => {
 		// path. The first dispatch carried the same action.
 		expect( result ).toMatchObject( {
 			type: 'READER_STREAMS_PAGINATED_REQUEST',
-			payload: { streamKey: 'likes', page: 1, perPage: 10 },
+			payload: { streamKey: 'recommendations_posts', page: 1, perPage: 10 },
 		} );
 		expect( dispatch ).toHaveBeenCalledTimes( 1 );
 	} );

--- a/client/state/reader/streams/test/actions.js
+++ b/client/state/reader/streams/test/actions.js
@@ -667,6 +667,22 @@ describe( 'requestPage thunk', () => {
 			expect( captured.fields ).toBeDefined();
 			expect( captured.fields.split( ',' ) ).toContain( 'date_liked' );
 		} );
+
+		it( 'does not send the selected Recent feed id in the poll query', async () => {
+			let captured;
+			nock( BASE )
+				.get( '/rest/v1.2/read/liked' )
+				.query( ( q ) => {
+					captured = q;
+					return true;
+				} )
+				.reply( 200, likesResponse );
+
+			const { result } = runThunk( { streamKey: 'likes', isPoll: true, feedId: 1234 } );
+			await result;
+
+			expect( captured ).not.toHaveProperty( 'feed_id' );
+		} );
 	} );
 } );
 

--- a/client/state/reader/streams/test/migrated-stream-types.ts
+++ b/client/state/reader/streams/test/migrated-stream-types.ts
@@ -22,12 +22,12 @@ describe( 'isMigratedStream', () => {
 		'user',
 		'conversations',
 		'conversations-a8c',
+		'likes',
 	] )( 'returns true for `%s`', ( streamType ) => {
 		expect( isMigratedStream( streamType ) ).toBe( true );
 	} );
 
 	it.each( [
-		'likes',
 		'recommendations_posts',
 		'custom_recs_posts_with_images',
 		'custom_recs_sites_with_images',

--- a/packages/api-core/src/read-streams/fetchers.ts
+++ b/packages/api-core/src/read-streams/fetchers.ts
@@ -4,7 +4,7 @@ import type { ReadStreamQueryParams, ReadStreamResponse } from './types';
 
 // READ-485: streams migrated incrementally. Streams still served by the
 // legacy data-layer at `client/state/data-layer/wpcom/read/streams/index.js`:
-// `likes`, `recommendations_posts`, `custom_recs_posts_with_images`,
+// `recommendations_posts`, `custom_recs_posts_with_images`,
 // `custom_recs_sites_with_images`. See the legacy `streamApis` map for their
 // canonical per-shape `path`, `apiVersion`, `apiNamespace`, and `query`
 // definitions to mirror when porting each one.
@@ -244,6 +244,20 @@ export const fetchReadDiscoverFreshlyPressed = (
 ): Promise< ReadStreamResponse > =>
 	wpcom.req.get( {
 		path: addQueryArgs( '/freshly-pressed', params ),
+		apiVersion: '1.2',
+		method: 'GET',
+	} );
+
+/**
+ * Fetch the `likes` stream — posts the current user has liked. Hits
+ * `/read/liked` on REST `1.2`. The API orders results by `date_liked`
+ * (the `dateProperty` the thunk uses to build `streamItems`).
+ */
+export const fetchReadLiked = (
+	params: ReadStreamQueryParams = {}
+): Promise< ReadStreamResponse > =>
+	wpcom.req.get( {
+		path: addQueryArgs( '/read/liked', params ),
 		apiVersion: '1.2',
 		method: 'GET',
 	} );

--- a/packages/api-queries/src/__tests__/read-streams.test.tsx
+++ b/packages/api-queries/src/__tests__/read-streams.test.tsx
@@ -107,10 +107,49 @@ describe( 'readStreamQuery', () => {
 		expect( scope.isDone() ).toBe( true );
 	} );
 
+	it( 'fetches liked posts from /read/liked', async () => {
+		const scope = nock( BASE )
+			.get( '/rest/v1.2/read/liked' )
+			.query( true )
+			.reply( 200, {
+				posts: [
+					{
+						ID: 30,
+						site_ID: 300,
+						date: '2026-01-01',
+						date_liked: '2026-04-10',
+						URL: 'https://example.com/liked',
+					},
+				],
+				date_range: { after: '2026-04-10' },
+			} );
+
+		const client = newClient();
+		const { result } = renderHook(
+			() =>
+				useQuery(
+					readStreamQuery(
+						'likes',
+						{ orderBy: 'date', meta: 'post,discover_original_post', number: 4, content_width: 675 },
+						null
+					)
+				),
+			{ wrapper: makeWrapper( client ) }
+		);
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+		expect( scope.isDone() ).toBe( true );
+		expect( result.current.data?.posts ).toHaveLength( 1 );
+		expect( result.current.data?.posts?.[ 0 ].date_liked ).toBe( '2026-04-10' );
+	} );
+
 	it( 'throws when called for an unmigrated streamType', () => {
-		// `likes` is still served by the legacy data-layer (different
-		// dateProperty); update this case when it lands in `readStreamQuery`.
-		const opts = readStreamQuery( 'likes', { number: 4 }, null );
-		expect( () => opts.queryFn!( {} as never ) ).toThrow( /unsupported streamType "likes"/ );
+		// `recommendations_posts` is still served by the legacy data-layer
+		// (custom `seed` + `algorithm` query shape); update this case when it
+		// lands in `readStreamQuery`.
+		const opts = readStreamQuery( 'recommendations_posts', { number: 4 }, null );
+		expect( () => opts.queryFn!( {} as never ) ).toThrow(
+			/unsupported streamType "recommendations_posts"/
+		);
 	} );
 } );

--- a/packages/api-queries/src/read-streams.ts
+++ b/packages/api-queries/src/read-streams.ts
@@ -8,6 +8,7 @@ import {
 	fetchReadFeedPosts,
 	fetchReadFollowing,
 	fetchReadFollowingP2,
+	fetchReadLiked,
 	fetchReadListPosts,
 	fetchReadNotifications,
 	fetchReadOnThisDay,
@@ -57,9 +58,9 @@ const fetchDiscover = (
  *
  * Migrated: `following`, every `discover:*` sub-tab, plus `recent`, `search`,
  * `feed`, `site`, `notifications`, `featured`, `p2`, `a8c`, `tag`,
- * `tag_popular`, `list`, `on_this_day`, `user`, `conversations`, and
- * `conversations-a8c`. Streams still served by the legacy data-layer:
- * `likes`, `recommendations_posts`, `custom_recs_*`. Those will land in a
+ * `tag_popular`, `list`, `on_this_day`, `user`, `conversations`,
+ * `conversations-a8c`, and `likes`. Streams still served by the legacy
+ * data-layer: `recommendations_posts`, `custom_recs_*`. Those will land in a
  * final cleanup PR that also deletes the data-layer file.
  */
 export const readStreamQuery = (
@@ -108,6 +109,8 @@ export const readStreamQuery = (
 				case 'conversations':
 				case 'conversations-a8c':
 					return fetchReadConversations( queryParams );
+				case 'likes':
+					return fetchReadLiked( queryParams );
 				default:
 					throw new Error(
 						`readStreamQuery: unsupported streamType "${ streamType }". Add the fetcher in @automattic/api-core and a case here when migrating this stream.`


### PR DESCRIPTION
Closes READ-498.

## Proposed Changes

* Add `fetchReadLiked` in `@automattic/api-core` (`/read/liked`, REST 1.2) and a `'likes'` case in `readStreamQuery` so the migrated-thunk wrapper can resolve the stream.
* Teach the thunk in `client/state/reader/streams/actions.js` about the `likes` quirks: `getDatePropertyForStream` returns `date_liked`, and the poll branch sends `fields=…,date_liked` (matching the legacy `streamApis.likes.pollQuery`).
* Add `'likes'` to `MIGRATED_STREAM_TYPES`, remove the now-dead `streamApis.likes` entry from the legacy data-layer, and swap the `'likes'` sentinel used in unmigrated-stream tests over to `'recommendations_posts'`.
* Cover the new path with unit tests: parametric URL/query check, `date_liked` ordering of `streamItems`, poll fields contain `date_liked`, and a `useQuery` round-trip in the api-queries test.

## Why are these changes being made?

`likes` was the last non-recommendation stream still flowing through the legacy Redux data-layer. Moving it to React Query shrinks the gate set to the three `recommendations_*` streams and unblocks the eventual cleanup PR that deletes `client/state/data-layer/wpcom/read/streams/index.js` and the matching Redux slice (READ-486).

## Testing Instructions

* `yarn test-client client/state/reader/streams/test/actions.js client/state/reader/streams/test/migrated-stream-types.ts client/state/data-layer/wpcom/read/streams/test/index.js` — 93 tests pass.
* `yarn test-packages packages/api-queries/src/__tests__/read-streams.test.tsx` — 7 tests pass.
* Manual smoke: visit `/activities/likes` while logged in. Verify the liked posts list renders, scrolling triggers a paginated request to `/rest/v1.2/read/liked?…`, polling sends `fields` containing `date_liked`, and ordering remains newest-liked-first. Confirm empty and error states still render.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
