### PR TITLE
[RSM-2132] Improve dashboard dark mode plugin borders

### DIFF
--- a/client/dashboard/app/_dark-theme.scss
+++ b/client/dashboard/app/_dark-theme.scss
@@ -19,7 +19,7 @@
 	.components-surface.components-card {
 		background-color: var( --dashboard-surface__background-color );
 		color: var( --dashboard__text-color );
-		box-shadow: inset 0 0 0 1px var( --dashboard-surface__border-color );
+		box-shadow: 0 0 0 1px var( --dashboard-surface__border-color );
 	}
 
 	.components-surface.components-card.dashboard-notice {
@@ -767,7 +767,7 @@
 			}
 		}
 
-		&.is-selected + & {
+		&.is-selected + .plugin-switcher-item {
 			border-top-color: var( --dashboard-item-selected__border-color );
 		}
 	}
@@ -825,7 +825,8 @@
 @mixin dashboard-dark-theme-site-logs-badges {
 	// Data table badges in the logs views don't declare a Badge intent, and
 	// override the colors locally, so we have to target them directly here.
-	:is( .site-logs-card, .site-logs-details-modal ) :is(
+	:is( .site-logs-card, .site-logs-details-modal )
+		:is(
 			.badge--POST,
 			.badge--deprecated,
 			.badge--GET,
@@ -840,11 +841,7 @@
 			var( --wp-components-color-background ) 90%,
 			var( --base-color )
 		);
-		color: color-mix(
-			in srgb,
-			var( --wp-components-color-foreground ) 50%,
-			var( --base-color )
-		);
+		color: color-mix( in srgb, var( --wp-components-color-foreground ) 50%, var( --base-color ) );
 
 		// `<Badge intent="default">` adds `.is-default`, which the Badge
 		// component pairs with an inset box-shadow in dark mode to stay
@@ -885,8 +882,7 @@
 			color: var( --dashboard__text-muted-color );
 		}
 
-		.dataforms-layouts-panel__field-trigger.is-disabled
-			.dataforms-layouts-panel__field-control {
+		.dataforms-layouts-panel__field-trigger.is-disabled .dataforms-layouts-panel__field-control {
 			color: var( --dashboard__text-muted-color );
 		}
 	}
@@ -902,6 +898,26 @@
 	@include dashboard-dark-theme-color-palette( 'studio-gray', $studio-gray );
 	@include dashboard-dark-theme-color-palette-alias( 'studio-neutral', 'studio-gray' );
 	@include dashboard-dark-theme-color-palette-alias( 'color-neutral', 'studio-gray' );
+}
+
+// useful to indicate to the browser that this stylesheet supports dark mode (for example Safari might style scrollbars differently)
+@mixin dashboard-color-scheme {
+	html {
+		color-scheme: dark;
+	}
+}
+
+@mixin dashboard-dark-theme-scrollbars {
+	&,
+	* {
+		scrollbar-color: var( --wp-components-color-gray-400 ) transparent;
+	}
+	.components-surface.components-card::-webkit-scrollbar-track:vertical,
+	.plugin-switcher-card-body::-webkit-scrollbar-track:vertical,
+	.plugin-sites-card-body::-webkit-scrollbar-track:vertical,
+	.dashboard-notifications .dataviews-layout__container::-webkit-scrollbar-track:vertical {
+		box-shadow: inset 1px 0 0 var( --dashboard-surface__border-color );
+	}
 }
 
 // :root variables overridden for dark theme
@@ -946,15 +962,10 @@
 	--dashboard-field__border-color: #949494;
 	--dashboard__text-muted-color: #bdbdbd;
 	--dashboard-subtle__color: #bdbdbd;
-	--dashboard-item-selected__background-color: color-mix(
-		in srgb,
-		var( --dashboard-surface__background-color ) 88%,
-		var( --wp-admin-theme-color )
-	);
-	--dashboard-item-selected-hover__background-color: color-mix(
-		in srgb,
-		var( --dashboard-surface__background-color ) 76%,
-		var( --wp-admin-theme-color )
+	--dashboard-item-selected__background-color: rgba( var( --wp-admin-theme-color--rgb ), 0.12 );
+	--dashboard-item-selected-hover__background-color: rgba(
+		var( --wp-admin-theme-color--rgb ),
+		0.24
 	);
 	--dashboard-item-selected__border-color: var( --wp-admin-theme-color );
 	--dashboard-warning__background-color: rgba( 212, 118, 8, 0.18 );
@@ -1005,6 +1016,7 @@
 	--jp-gray-off: #2a2a2a;
 
 	@include dashboard-calypso-theme-properties;
+	@include dashboard-color-scheme;
 	@include dashboard-dark-theme-action-list;
 	@include dashboard-dark-theme-agenttic;
 	@include dashboard-dark-theme-breadcrumbs;
@@ -1025,5 +1037,6 @@
 	@include dashboard-dark-theme-section-header;
 	@include dashboard-dark-theme-site-icon;
 	@include dashboard-dark-theme-site-logs-badges;
+	@include dashboard-dark-theme-scrollbars;
 	@include dashboard-dark-theme-summary-button;
 }

--- a/client/dashboard/app/_dark-theme.scss
+++ b/client/dashboard/app/_dark-theme.scss
@@ -1022,6 +1022,5 @@
 	@include dashboard-dark-theme-section-header;
 	@include dashboard-dark-theme-site-icon;
 	@include dashboard-dark-theme-site-logs-badges;
-	@include dashboard-dark-theme-scrollbars;
 	@include dashboard-dark-theme-summary-button;
 }

--- a/client/dashboard/app/_dark-theme.scss
+++ b/client/dashboard/app/_dark-theme.scss
@@ -738,16 +738,6 @@
 		border-top-color: var( --dashboard-surface__border-color );
 	}
 
-	.plugin-switcher-card-body,
-	.plugin-sites-card-body {
-		&::-webkit-scrollbar,
-		&::-webkit-scrollbar-track,
-		&::-webkit-scrollbar-track-piece,
-		&::-webkit-scrollbar-corner {
-			background: transparent;
-		}
-	}
-
 	.plugin-switcher-item {
 		border-top-color: var( --dashboard-surface__border-color );
 

--- a/client/dashboard/app/_dark-theme.scss
+++ b/client/dashboard/app/_dark-theme.scss
@@ -495,14 +495,6 @@
 @mixin dashboard-dark-theme-dataviews {
 	--wp-dataviews-color-background: var( --dashboard-surface__background-color );
 
-	// Inset the wrapper by 1px on the sides/bottom so the card's 1px inset
-	// box-shadow border stays visible all around. Gutenberg's default sets
-	// `padding: 10px 0 0` on this element, which lets the wrapper paint over
-	// the card border on the left, right, and bottom.
-	.components-card__body:has( > .dataviews-wrapper ) {
-		padding: $grid-unit-10 1px 1px;
-	}
-
 	// Table
 	.dataviews-view-table {
 		// Match the upstream light-mode table default, where non-primary fields
@@ -742,6 +734,10 @@
 
 /* Plugins */
 @mixin dashboard-dark-theme-plugins {
+	.plugin-tabs-panel {
+		border-top-color: var( --dashboard-surface__border-color );
+	}
+
 	.plugin-switcher-item {
 		border-top-color: var( --dashboard-surface__border-color );
 

--- a/client/dashboard/app/_dark-theme.scss
+++ b/client/dashboard/app/_dark-theme.scss
@@ -902,22 +902,7 @@
 
 // useful to indicate to the browser that this stylesheet supports dark mode (for example Safari might style scrollbars differently)
 @mixin dashboard-color-scheme {
-	html {
-		color-scheme: dark;
-	}
-}
-
-@mixin dashboard-dark-theme-scrollbars {
-	&,
-	* {
-		scrollbar-color: var( --wp-components-color-gray-400 ) transparent;
-	}
-	.components-surface.components-card::-webkit-scrollbar-track:vertical,
-	.plugin-switcher-card-body::-webkit-scrollbar-track:vertical,
-	.plugin-sites-card-body::-webkit-scrollbar-track:vertical,
-	.dashboard-notifications .dataviews-layout__container::-webkit-scrollbar-track:vertical {
-		box-shadow: inset 1px 0 0 var( --dashboard-surface__border-color );
-	}
+	color-scheme: dark;
 }
 
 // :root variables overridden for dark theme

--- a/client/dashboard/app/_dark-theme.scss
+++ b/client/dashboard/app/_dark-theme.scss
@@ -738,6 +738,16 @@
 		border-top-color: var( --dashboard-surface__border-color );
 	}
 
+	.plugin-switcher-card-body,
+	.plugin-sites-card-body {
+		&::-webkit-scrollbar,
+		&::-webkit-scrollbar-track,
+		&::-webkit-scrollbar-track-piece,
+		&::-webkit-scrollbar-corner {
+			background: transparent;
+		}
+	}
+
 	.plugin-switcher-item {
 		border-top-color: var( --dashboard-surface__border-color );
 

--- a/client/dashboard/plugins/manage/components/plugin-sites.scss
+++ b/client/dashboard/plugins/manage/components/plugin-sites.scss
@@ -14,6 +14,10 @@ img.plugin-icon {
 	height: 48px;
 }
 
+.plugin-sites-card {
+	overflow-y: hidden;
+}
+
 .plugin-sites-card-body {
 	max-height: $card-height;
 	padding-inline-start: 0;
@@ -30,4 +34,3 @@ img.plugin-icon {
 		height: 48px;
 	}
 }
-

--- a/client/dashboard/plugins/manage/components/plugin-sites.tsx
+++ b/client/dashboard/plugins/manage/components/plugin-sites.tsx
@@ -73,7 +73,7 @@ export const PluginSites = ( { selectedPluginSlug }: { selectedPluginSlug: strin
 	};
 
 	return (
-		<Card>
+		<Card className="plugin-sites-card">
 			<CardBody className="plugin-sites-card-body">
 				<SectionHeader
 					className="plugin-sites-card-header"

--- a/client/dashboard/plugins/manage/components/plugin-switcher.scss
+++ b/client/dashboard/plugins/manage/components/plugin-switcher.scss
@@ -1,5 +1,9 @@
 @import './variables.scss';
 
+.plugin-switcher-card {
+	overflow-y: hidden;
+}
+
 .plugin-switcher-card-body {
 	max-height: $card-height;
 	padding: 8px 0 0;

--- a/client/dashboard/plugins/manage/components/plugin-switcher.scss
+++ b/client/dashboard/plugins/manage/components/plugin-switcher.scss
@@ -14,6 +14,7 @@
 
 .plugin-switcher-item {
 	border-top: 1px solid #f0f0f0;
+	border-radius: 0;
 	padding: calc(4px * 4) calc(4px * 6);
 
 	&.is-selected {

--- a/client/dashboard/plugins/manage/components/plugin-switcher.tsx
+++ b/client/dashboard/plugins/manage/components/plugin-switcher.tsx
@@ -135,7 +135,7 @@ export const PluginSwitcher = ( {
 	);
 
 	return (
-		<Card>
+		<Card className="plugin-switcher-card">
 			<CardBody className="plugin-switcher-card-body" ref={ scrollRef }>
 				<SwitcherContent
 					itemClassName={ itemClassName }


### PR DESCRIPTION
Addresses RSM-2132 and RSM-2103

## Proposed Changes

* Advertise dark color scheme support from the Dashboard dark theme so browser-native controls render as dark-aware UI.
* Remove the previous DataViews padding workaround and keep Dashboard cards using the regular dark surface border treatment.
* Use the shared dark surface border token for plugin tab dividers and keep selected plugin list separators consistent.
* Addresses the scrollbar not being rounded in the plugins page.

## Why are these changes being made?

The manage plugins page had dark-mode scrollbar and card-border details that did not sit cleanly on Dashboard card surfaces. Some nested content could make card edges and tab dividers hard to read, while selected plugin rows exposed rounded item corners that interrupted the straight list edge.

<img width="2636" height="1272" alt="CleanShot 2026-05-04 at 18 14 40@2x" src="https://github.com/user-attachments/assets/3d958000-0805-401c-97a4-98fa6417da29" />

## Testing Instructions

* Open Dashboard manage plugins in dark mode and verify the plugin list scrollbar and card edge sit cleanly on the dark card surface.
* Verify the plugin tabs divider and plugin list item separators remain visible in dark mode.
* Focused Sass lint passed for the dark theme stylesheet.
* Diff whitespace check passed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
