### PR TITLE
Add top margin to add-ons grid

### DIFF
--- a/client/my-sites/add-ons/components/add-ons-grid.tsx
+++ b/client/my-sites/add-ons/components/add-ons-grid.tsx
@@ -17,6 +17,7 @@ const Container = styled.div`
 	display: grid;
 	grid-template-columns: repeat( 1, 1fr );
 	gap: 1em;
+	margin-block-start: 24px;
 
 	@media screen and ( min-width: 1080px ) {
 		grid-template-columns: repeat( 2, 1fr );


### PR DESCRIPTION
## Summary

Adds a 24px top margin to the add-ons grid container to improve vertical spacing between the page header and the grid of add-on cards.

## Changes

- Add `margin-block-start: 24px` to the grid `Container` in `client/my-sites/add-ons/components/add-ons-grid.tsx`





## How to test

1. Navigate to the add-ons page at `/add-ons/:site` on a site with add-ons available.
2. Verify the add-ons grid has a visible 24px gap between the page header area and the first row of add-on cards.
3. Resize the viewport across the responsive breakpoints (single column, 2-column at ≥1080px, 3-column at ≥1280px) and confirm the top margin is preserved at every breakpoint.
4. Confirm no regression in spacing on other pages that render `AddOnsGrid` (e.g. add-ons sub-views).

## Checklist

- [ ] Visual changes match the expected design
- [ ] No console errors introduced
- [ ] Tested with different user roles (if applicable)

---
_Created as a **draft** by Build on WP.com. The author will mark this ready for review when they choose to._