### PR TITLE
Charts: upgrade @automattic/charts to 1.3.0

### DIFF
--- a/.yarn/patches/@base-ui-react-npm-1.4.1-fbb7347502.patch
+++ b/.yarn/patches/@base-ui-react-npm-1.4.1-fbb7347502.patch
@@ -1,0 +1,23 @@
+diff --git a/package.json b/package.json
+index 519d71c82bb6d32946c3d004033962c8038cc2f2..38a52dd236ede4adc97d92b5e8b24fba48e88c3e 100644
+--- a/package.json
++++ b/package.json
+@@ -61,14 +61,14 @@
+   "exports": {
+     "./package.json": "./package.json",
+     ".": {
+-      "require": {
+-        "types": "./index.d.ts",
+-        "default": "./index.js"
+-      },
+       "import": {
+         "types": "./esm/index.d.ts",
+         "default": "./esm/index.js"
+       },
++      "require": {
++        "types": "./index.d.ts",
++        "default": "./index.js"
++      },
+       "default": {
+         "types": "./esm/index.d.ts",
+         "default": "./esm/index.js"

--- a/client/components/inline-support-link/use-support-doc-data.ts
+++ b/client/components/inline-support-link/use-support-doc-data.ts
@@ -5,16 +5,18 @@ import type { ContextLinks, SupportDocData } from './types';
 import type { HelpCenterDispatch } from '@automattic/data-stores';
 
 const HELP_CENTER_STORE = 'automattic/help-center';
-declare global {
-	interface Window {
-		wp: undefined | Record< string, any >;
-	}
-}
+
+type WpWithData = {
+	data?: {
+		dispatch?: ( store: string ) => unknown;
+	};
+};
 
 const loadHelpCenterDispatch = async () => {
 	// Check if the help center store is already loaded in the window object.
-	if ( typeof window !== 'undefined' && window.wp?.data?.dispatch?.( HELP_CENTER_STORE ) ) {
-		return window.wp.data.dispatch( HELP_CENTER_STORE ) as HelpCenterDispatch[ 'dispatch' ];
+	const wp = typeof window !== 'undefined' ? ( window.wp as WpWithData | undefined ) : undefined;
+	if ( wp?.data?.dispatch?.( HELP_CENTER_STORE ) ) {
+		return wp.data.dispatch( HELP_CENTER_STORE ) as HelpCenterDispatch[ 'dispatch' ];
 	}
 
 	// Load `@automattic/data-stores` asynchronously to avoid including it in the main bundle and reduce initial load size.

--- a/client/dashboard/app/chart-theme.ts
+++ b/client/dashboard/app/chart-theme.ts
@@ -15,8 +15,10 @@ export const dashboardChartTheme: Partial< ChartTheme > = {
 	xTickLineStyles: {
 		stroke: 'var(--dashboard-surface__border-color)',
 	},
-	legendLabelStyles: {
-		color: 'var(--dashboard__text-muted-color)',
+	legend: {
+		labelStyles: {
+			color: 'var(--dashboard__text-muted-color)',
+		},
 	},
 	svgLabelSmall: {
 		fill: 'var(--dashboard__text-muted-color)',

--- a/client/dashboard/app/layout.tsx
+++ b/client/dashboard/app/layout.tsx
@@ -6,6 +6,7 @@ import {
 	recordTracksPageViewWithPageParams,
 } from '@automattic/calypso-analytics';
 import { GlobalChartsProvider } from '@automattic/charts';
+import '@automattic/charts/style.css';
 import { resolveDeviceTypeByViewPort } from '@automattic/viewport';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { RouterProvider, type AnyRouter } from '@tanstack/react-router';

--- a/client/dashboard/app/layout.tsx
+++ b/client/dashboard/app/layout.tsx
@@ -6,7 +6,6 @@ import {
 	recordTracksPageViewWithPageParams,
 } from '@automattic/calypso-analytics';
 import { GlobalChartsProvider } from '@automattic/charts';
-import '@automattic/charts/style.css';
 import { resolveDeviceTypeByViewPort } from '@automattic/viewport';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { RouterProvider, type AnyRouter } from '@tanstack/react-router';

--- a/client/dashboard/sites/monitoring-http-responses-card/index.tsx
+++ b/client/dashboard/sites/monitoring-http-responses-card/index.tsx
@@ -1,5 +1,6 @@
 import { siteMetricsQuery } from '@automattic/api-queries';
 import { type DataPointDate, LineChart, SeriesData } from '@automattic/charts';
+import '@automattic/charts/style.css';
 import { useQuery } from '@tanstack/react-query';
 import {
 	GlyphDiamond,

--- a/client/dashboard/sites/monitoring-http-responses-card/index.tsx
+++ b/client/dashboard/sites/monitoring-http-responses-card/index.tsx
@@ -264,7 +264,7 @@ export default function MonitoringHttpResponsesCard( {
 						x: xAxisOptions,
 					},
 				} }
-				legendPosition="top"
+				legend={ { position: 'top' } }
 			/>
 		</MonitoringCard>
 	);

--- a/client/dashboard/sites/monitoring-performance-card/index.tsx
+++ b/client/dashboard/sites/monitoring-performance-card/index.tsx
@@ -1,5 +1,6 @@
 import { siteMetricsQuery } from '@automattic/api-queries';
 import { type DataPointDate, LineChart, SeriesData } from '@automattic/charts';
+import '@automattic/charts/style.css';
 import { useQuery } from '@tanstack/react-query';
 import { GlyphDiamond, GlyphCircle } from '@visx/glyph';
 import { __experimentalVStack as VStack } from '@wordpress/components';

--- a/client/dashboard/sites/monitoring-performance-card/index.tsx
+++ b/client/dashboard/sites/monitoring-performance-card/index.tsx
@@ -209,7 +209,7 @@ export default function MonitoringPerformanceCard( {
 							x: xAxisOptions,
 						},
 					} }
-					legendPosition="top"
+					legend={ { position: 'top' } }
 				/>
 			) : (
 				<VStack alignment="center">

--- a/client/dashboard/sites/monitoring-request-methods-card/index.tsx
+++ b/client/dashboard/sites/monitoring-request-methods-card/index.tsx
@@ -53,7 +53,6 @@ function useSiteRequestMethodsData( siteId: number, timeRange: number ): SiteReq
 					return {
 						label: method.toUpperCase(),
 						value: value,
-						percentage: valuePercentage,
 						valueDisplay: ( Math.round( valuePercentage * 10 ) / 10 ).toString() + '%',
 						color: chartColors[ index % chartColors.length ],
 					};

--- a/client/dashboard/sites/monitoring-request-methods-card/index.tsx
+++ b/client/dashboard/sites/monitoring-request-methods-card/index.tsx
@@ -1,5 +1,6 @@
 import { siteMetricsQuery } from '@automattic/api-queries';
 import { DataPointPercentage, PieChart, Legend } from '@automattic/charts';
+import '@automattic/charts/style.css';
 import { useQuery } from '@tanstack/react-query';
 import { __experimentalHStack as HStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';

--- a/client/dashboard/sites/monitoring-response-types-card/index.tsx
+++ b/client/dashboard/sites/monitoring-response-types-card/index.tsx
@@ -58,7 +58,6 @@ function useResponseTypesData( siteId: number, timeRange: number ): ResponseType
 						label:
 							method === 'php' ? 'Dynamic' : method.slice( 0, 1 ).toUpperCase() + method.slice( 1 ),
 						value: value,
-						percentage: valuePercentage,
 						valueDisplay: ( Math.round( valuePercentage * 10 ) / 10 ).toString() + '%',
 						color: chartColors[ index % chartColors.length ],
 					};

--- a/client/dashboard/sites/monitoring-response-types-card/index.tsx
+++ b/client/dashboard/sites/monitoring-response-types-card/index.tsx
@@ -1,5 +1,6 @@
 import { siteMetricsQuery } from '@automattic/api-queries';
 import { DataPointPercentage, PieChart, Legend } from '@automattic/charts';
+import '@automattic/charts/style.css';
 import { useQuery } from '@tanstack/react-query';
 import {
 	__experimentalHStack as HStack,

--- a/client/dashboard/sites/performance/core-metrics-chart.tsx
+++ b/client/dashboard/sites/performance/core-metrics-chart.tsx
@@ -16,7 +16,6 @@ import {
 } from '../../utils/site-performance';
 import { VIEWPORT_BREAKPOINTS } from './constants';
 import type { SitePerformanceReport, SitePerformanceHistory, Metrics } from '@automattic/api-core';
-import '@automattic/charts/line-chart/style.css';
 
 const WEEK_TO_SHOW = 8;
 

--- a/client/dashboard/sites/performance/core-metrics-chart.tsx
+++ b/client/dashboard/sites/performance/core-metrics-chart.tsx
@@ -1,4 +1,5 @@
 import { LineChart } from '@automattic/charts';
+import '@automattic/charts/style.css';
 import { GlyphCircle, GlyphSquare, GlyphTriangle } from '@visx/glyph';
 import { __experimentalHStack as HStack } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';

--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -1,4 +1,5 @@
 import { LineChart, type EventHandlerParams, type DataPointDate } from '@automattic/charts';
+import '@automattic/charts/style.css';
 import { formatNumber } from '@automattic/number-formatters';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';

--- a/client/my-sites/stats/pages/realtime/chart.tsx
+++ b/client/my-sites/stats/pages/realtime/chart.tsx
@@ -1,4 +1,5 @@
 import { LineChart } from '@automattic/charts';
+import '@automattic/charts/style.css';
 import clsx from 'clsx';
 import moment from 'moment';
 import { useEffect, useState, useMemo } from 'react';

--- a/client/package.json
+++ b/client/package.json
@@ -33,7 +33,7 @@
 		"@automattic/calypso-stripe": "workspace:^",
 		"@automattic/calypso-support-session": "workspace:^",
 		"@automattic/calypso-url": "workspace:^",
-		"@automattic/charts": "^0.46.1",
+		"@automattic/charts": "^1.3.0",
 		"@automattic/color-studio": "^4.1.0",
 		"@automattic/components": "workspace:^",
 		"@automattic/composite-checkout": "workspace:^",

--- a/package.json
+++ b/package.json
@@ -431,7 +431,9 @@
 		"@wordpress/viewport": "^6.23.0",
 		"@wordpress/warning": "3.23.0",
 		"@wordpress/widgets": "4.23.0",
-		"@wordpress/wordcount": "4.23.0"
+		"@wordpress/wordcount": "4.23.0",
+		"@base-ui/react@npm:^1.2.0": "patch:@base-ui/react@npm%3A1.4.1#~/.yarn/patches/@base-ui-react-npm-1.4.1-fbb7347502.patch",
+		"@base-ui/react@npm:^1.4.0": "patch:@base-ui/react@npm%3A1.4.1#~/.yarn/patches/@base-ui-react-npm-1.4.1-fbb7347502.patch"
 	},
 	"packageManager": "yarn@4.0.2",
 	"dependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
 		"@automattic/calypso-products": "workspace:^",
 		"@automattic/calypso-razorpay": "workspace:^",
 		"@automattic/calypso-router": "workspace:^",
-		"@automattic/charts": "^0.50.0",
+		"@automattic/charts": "^1.3.0",
 		"@automattic/color-studio": "^4.1.0",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4217,7 +4217,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@base-ui/react@npm:^1.2.0, @base-ui/react@npm:^1.4.0":
+"@base-ui/react@npm:1.4.1":
   version: 1.4.1
   resolution: "@base-ui/react@npm:1.4.1"
   dependencies:
@@ -4240,6 +4240,32 @@ __metadata:
     date-fns:
       optional: true
   checksum: 913361cd1e09f256d95bbd905287a10c34b2dab23482bf4ad5e595e4d72f5ea22e0b0b23657df6b548a938b248be3129c0bf1242c90753b59618a615c9e90ad5
+  languageName: node
+  linkType: hard
+
+"@base-ui/react@patch:@base-ui/react@npm%3A1.4.1#~/.yarn/patches/@base-ui-react-npm-1.4.1-fbb7347502.patch":
+  version: 1.4.1
+  resolution: "@base-ui/react@patch:@base-ui/react@npm%3A1.4.1#~/.yarn/patches/@base-ui-react-npm-1.4.1-fbb7347502.patch::version=1.4.1&hash=2be872"
+  dependencies:
+    "@babel/runtime": "npm:^7.29.2"
+    "@base-ui/utils": "npm:0.2.8"
+    "@floating-ui/react-dom": "npm:^2.1.8"
+    "@floating-ui/utils": "npm:^0.2.11"
+    use-sync-external-store: "npm:^1.6.0"
+  peerDependencies:
+    "@date-fns/tz": ^1.2.0
+    "@types/react": ^17 || ^18 || ^19
+    date-fns: ^4.0.0
+    react: ^17 || ^18 || ^19
+    react-dom: ^17 || ^18 || ^19
+  peerDependenciesMeta:
+    "@date-fns/tz":
+      optional: true
+    "@types/react":
+      optional: true
+    date-fns:
+      optional: true
+  checksum: b58800383b8df1274eae667581c1403449693c274ebe1a947aa9126792946a15b11e16435cf15533a5e329fd139836e0c8632b275c306c2666d5bb8eb196345b
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1715,18 +1715,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/number-formatters@npm:^1.1.0, @automattic/number-formatters@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "@automattic/number-formatters@npm:1.1.2"
-  dependencies:
-    "@wordpress/date": "npm:^5.19.0"
-    debug: "npm:^4.4.0"
-    tslib: "npm:^2.5.0"
-  checksum: bd83f99d1d53a81ccc9879c7062f66b6c9e1b1b0103ae5943189fd546fcb20d1a27d20f2d55f20c80164b64cf0bee5dbc72e533123e9b3f873b4e3670a6d67da
-  languageName: node
-  linkType: hard
-
-"@automattic/number-formatters@npm:^1.1.7":
+"@automattic/number-formatters@npm:^1.1.0, @automattic/number-formatters@npm:^1.1.2, @automattic/number-formatters@npm:^1.1.7":
   version: 1.1.7
   resolution: "@automattic/number-formatters@npm:1.1.7"
   dependencies:
@@ -4185,7 +4174,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:7.29.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.27.1, @babel/runtime@npm:^7.28.6, @babel/runtime@npm:^7.29.2, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.3, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:7.29.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.27.1, @babel/runtime@npm:^7.29.2, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.3, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.9.2":
   version: 7.29.2
   resolution: "@babel/runtime@npm:7.29.2"
   checksum: 30b80a0140d16467792e1bbeb06f655b0dab70407da38dfac7fedae9c859f9ae9d846ef14ad77bd3814c064295fe9b1bc551f1541ea14646ae9f22b71a8bc17a
@@ -4228,28 +4217,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@base-ui/react@npm:^1.2.0":
-  version: 1.3.0
-  resolution: "@base-ui/react@npm:1.3.0"
-  dependencies:
-    "@babel/runtime": "npm:^7.28.6"
-    "@base-ui/utils": "npm:0.2.6"
-    "@floating-ui/react-dom": "npm:^2.1.8"
-    "@floating-ui/utils": "npm:^0.2.11"
-    tabbable: "npm:^6.4.0"
-    use-sync-external-store: "npm:^1.6.0"
-  peerDependencies:
-    "@types/react": ^17 || ^18 || ^19
-    react: ^17 || ^18 || ^19
-    react-dom: ^17 || ^18 || ^19
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 36c9d2d77a82b41cb3783be39340aa0713bbe102fb18213f8f3e2c4f1295beb8359dd97067248bea34925f4a40eab281ddc42f05009179db1d5a7a99e4bfecdc
-  languageName: node
-  linkType: hard
-
-"@base-ui/react@npm:^1.4.0":
+"@base-ui/react@npm:^1.2.0, @base-ui/react@npm:^1.4.0":
   version: 1.4.1
   resolution: "@base-ui/react@npm:1.4.1"
   dependencies:
@@ -4272,25 +4240,6 @@ __metadata:
     date-fns:
       optional: true
   checksum: 913361cd1e09f256d95bbd905287a10c34b2dab23482bf4ad5e595e4d72f5ea22e0b0b23657df6b548a938b248be3129c0bf1242c90753b59618a615c9e90ad5
-  languageName: node
-  linkType: hard
-
-"@base-ui/utils@npm:0.2.6":
-  version: 0.2.6
-  resolution: "@base-ui/utils@npm:0.2.6"
-  dependencies:
-    "@babel/runtime": "npm:^7.28.6"
-    "@floating-ui/utils": "npm:^0.2.11"
-    reselect: "npm:^5.1.1"
-    use-sync-external-store: "npm:^1.6.0"
-  peerDependencies:
-    "@types/react": ^17 || ^18 || ^19
-    react: ^17 || ^18 || ^19
-    react-dom: ^17 || ^18 || ^19
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 5611442ac37066774277cd3360d16ebc3f599dc7b8efdfdfbf5b66b6d2eb6e87a18c0f9922b061818850e781d9bbc70aa5fc4ffb1dfd7fb234eefc401e070090
   languageName: node
   linkType: hard
 
@@ -16334,19 +16283,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:^3.2.6, dompurify@npm:^3.3.1":
-  version: 3.3.1
-  resolution: "dompurify@npm:3.3.1"
-  dependencies:
-    "@types/trusted-types": "npm:^2.0.7"
-  dependenciesMeta:
-    "@types/trusted-types":
-      optional: true
-  checksum: fa0a8c55a436ba0d54389195e3d2337e311f56de709a2fc9efc98dbbc7746fa53bb4b74b6ac043b77a279a8f2ebd8685f0ebaa6e58c9e32e92051d529bc0baf8
-  languageName: node
-  linkType: hard
-
-"dompurify@npm:^3.3.3":
+"dompurify@npm:^3.2.6, dompurify@npm:^3.3.1, dompurify@npm:^3.3.3":
   version: 3.4.2
   resolution: "dompurify@npm:3.4.2"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -813,12 +813,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@automattic/charts@npm:^0.46.1":
-  version: 0.46.1
-  resolution: "@automattic/charts@npm:0.46.1"
+"@automattic/charts@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "@automattic/charts@npm:1.3.0"
   dependencies:
-    "@automattic/number-formatters": "npm:^1.0.14"
-    "@babel/runtime": "npm:7.28.4"
+    "@automattic/number-formatters": "npm:^1.1.7"
+    "@babel/runtime": "npm:7.29.2"
     "@react-spring/web": "npm:9.7.5"
     "@visx/annotation": "npm:^3.12.0"
     "@visx/axis": "npm:^3.12.0"
@@ -834,54 +834,23 @@ __metadata:
     "@visx/shape": "npm:^3.12.0"
     "@visx/text": "npm:^3.12.0"
     "@visx/tooltip": "npm:^3.12.0"
+    "@visx/vendor": "npm:^3.12.0"
     "@visx/xychart": "npm:^3.12.0"
     "@wordpress/i18n": "npm:^6.0.0"
+    "@wordpress/icons": "npm:^12.0.0"
+    "@wordpress/theme": "npm:0.11.0"
+    "@wordpress/ui": "npm:0.11.0"
     clsx: "npm:2.1.1"
     date-fns: "npm:^4.1.0"
     deepmerge: "npm:4.3.1"
+    dompurify: "npm:^3.3.3"
     fast-deep-equal: "npm:3.1.3"
-    gridicons: "npm:3.4.2"
+    react-google-charts: "npm:^5.2.1"
     tslib: "npm:2.8.1"
   peerDependencies:
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
-  checksum: 0c986843d1ce366fe6bd0556f097ed278b39f6bdd1bd5e70ac665aac4ef4c3b5a5823f4ba9ecab6c277fe0e4ba5a6e6179664e05d933eb517fa91d24000f66bd
-  languageName: node
-  linkType: hard
-
-"@automattic/charts@npm:^0.50.0":
-  version: 0.50.2
-  resolution: "@automattic/charts@npm:0.50.2"
-  dependencies:
-    "@automattic/number-formatters": "npm:^1.0.15"
-    "@babel/runtime": "npm:7.28.4"
-    "@react-spring/web": "npm:9.7.5"
-    "@visx/annotation": "npm:^3.12.0"
-    "@visx/axis": "npm:^3.12.0"
-    "@visx/curve": "npm:^3.12.0"
-    "@visx/event": "npm:^3.12.0"
-    "@visx/gradient": "npm:^3.12.0"
-    "@visx/grid": "npm:^3.12.0"
-    "@visx/group": "npm:^3.12.0"
-    "@visx/legend": "npm:^3.12.0"
-    "@visx/pattern": "npm:^3.12.0"
-    "@visx/responsive": "npm:^3.12.0"
-    "@visx/scale": "npm:^3.12.0"
-    "@visx/shape": "npm:^3.12.0"
-    "@visx/text": "npm:^3.12.0"
-    "@visx/tooltip": "npm:^3.12.0"
-    "@visx/xychart": "npm:^3.12.0"
-    "@wordpress/i18n": "npm:^6.0.0"
-    clsx: "npm:2.1.1"
-    date-fns: "npm:^4.1.0"
-    deepmerge: "npm:4.3.1"
-    fast-deep-equal: "npm:3.1.3"
-    gridicons: "npm:3.4.2"
-    tslib: "npm:2.8.1"
-  peerDependencies:
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
-  checksum: e0bdce896e10910973c422eb9626e86375731abd53223f06f77daa717da30fb04457d5ed71d54d51c323a037518c722d947d8b50b869cc65a3bcd4c0c690d76d
+  checksum: 3723844a0ae9ae0c395f05e05e645a342ed25e3da395ce6d2610fa9be4f8f9e5aa27c73529050e4cb5b5bb373ecbc7d8acde72361cfe9133f7ba9b66acda4cbb
   languageName: node
   linkType: hard
 
@@ -1746,7 +1715,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/number-formatters@npm:^1.0.14, @automattic/number-formatters@npm:^1.0.15, @automattic/number-formatters@npm:^1.1.0, @automattic/number-formatters@npm:^1.1.2":
+"@automattic/number-formatters@npm:^1.1.0, @automattic/number-formatters@npm:^1.1.2":
   version: 1.1.2
   resolution: "@automattic/number-formatters@npm:1.1.2"
   dependencies:
@@ -1754,6 +1723,17 @@ __metadata:
     debug: "npm:^4.4.0"
     tslib: "npm:^2.5.0"
   checksum: bd83f99d1d53a81ccc9879c7062f66b6c9e1b1b0103ae5943189fd546fcb20d1a27d20f2d55f20c80164b64cf0bee5dbc72e533123e9b3f873b4e3670a6d67da
+  languageName: node
+  linkType: hard
+
+"@automattic/number-formatters@npm:^1.1.7":
+  version: 1.1.7
+  resolution: "@automattic/number-formatters@npm:1.1.7"
+  dependencies:
+    "@wordpress/date": "npm:^5.19.0"
+    debug: "npm:^4.4.0"
+    tslib: "npm:^2.5.0"
+  checksum: b93ea434c8b1e10cb54c6f4229fc344168f83fefa7693ef595dd2a679b51792532411703f52e88a126fd12f2ac52350e3ae4d8351e60b732eabf1da46414335d
   languageName: node
   linkType: hard
 
@@ -4198,13 +4178,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:7.28.4":
-  version: 7.28.4
-  resolution: "@babel/runtime@npm:7.28.4"
-  checksum: 792ce7af9750fb9b93879cc9d1db175701c4689da890e6ced242ea0207c9da411ccf16dc04e689cc01158b28d7898c40d75598f4559109f761c12ce01e959bf7
-  languageName: node
-  linkType: hard
-
 "@babel/runtime@npm:7.28.6":
   version: 7.28.6
   resolution: "@babel/runtime@npm:7.28.6"
@@ -4212,7 +4185,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.27.1, @babel/runtime@npm:^7.28.6, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.3, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:7.29.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.27.1, @babel/runtime@npm:^7.28.6, @babel/runtime@npm:^7.29.2, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.3, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.9.2":
   version: 7.29.2
   resolution: "@babel/runtime@npm:7.29.2"
   checksum: 30b80a0140d16467792e1bbeb06f655b0dab70407da38dfac7fedae9c859f9ae9d846ef14ad77bd3814c064295fe9b1bc551f1541ea14646ae9f22b71a8bc17a
@@ -4276,6 +4249,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@base-ui/react@npm:^1.4.0":
+  version: 1.4.1
+  resolution: "@base-ui/react@npm:1.4.1"
+  dependencies:
+    "@babel/runtime": "npm:^7.29.2"
+    "@base-ui/utils": "npm:0.2.8"
+    "@floating-ui/react-dom": "npm:^2.1.8"
+    "@floating-ui/utils": "npm:^0.2.11"
+    use-sync-external-store: "npm:^1.6.0"
+  peerDependencies:
+    "@date-fns/tz": ^1.2.0
+    "@types/react": ^17 || ^18 || ^19
+    date-fns: ^4.0.0
+    react: ^17 || ^18 || ^19
+    react-dom: ^17 || ^18 || ^19
+  peerDependenciesMeta:
+    "@date-fns/tz":
+      optional: true
+    "@types/react":
+      optional: true
+    date-fns:
+      optional: true
+  checksum: 913361cd1e09f256d95bbd905287a10c34b2dab23482bf4ad5e595e4d72f5ea22e0b0b23657df6b548a938b248be3129c0bf1242c90753b59618a615c9e90ad5
+  languageName: node
+  linkType: hard
+
 "@base-ui/utils@npm:0.2.6":
   version: 0.2.6
   resolution: "@base-ui/utils@npm:0.2.6"
@@ -4292,6 +4291,25 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 5611442ac37066774277cd3360d16ebc3f599dc7b8efdfdfbf5b66b6d2eb6e87a18c0f9922b061818850e781d9bbc70aa5fc4ffb1dfd7fb234eefc401e070090
+  languageName: node
+  linkType: hard
+
+"@base-ui/utils@npm:0.2.8":
+  version: 0.2.8
+  resolution: "@base-ui/utils@npm:0.2.8"
+  dependencies:
+    "@babel/runtime": "npm:^7.29.2"
+    "@floating-ui/utils": "npm:^0.2.11"
+    reselect: "npm:^5.1.1"
+    use-sync-external-store: "npm:^1.6.0"
+  peerDependencies:
+    "@types/react": ^17 || ^18 || ^19
+    react: ^17 || ^18 || ^19
+    react-dom: ^17 || ^18 || ^19
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 762ff2251875c08b9e506824d7b45299baef895944d28f633a34c088cd5d6f121ee29267d2afb79527180044d232e56591c4109b2fcab7ac926d7e490c5b2b29
   languageName: node
   linkType: hard
 
@@ -11534,6 +11552,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wordpress/theme@npm:0.11.0, @wordpress/theme@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "@wordpress/theme@npm:0.11.0"
+  dependencies:
+    "@wordpress/element": "npm:^6.44.0"
+    "@wordpress/private-apis": "npm:^1.44.0"
+    colorjs.io: "npm:^0.6.0"
+    memize: "npm:^2.1.0"
+  peerDependencies:
+    react: ^18.0.0
+    react-dom: ^18.0.0
+    stylelint: ^16.8.2
+  peerDependenciesMeta:
+    stylelint:
+      optional: true
+  checksum: dc73ccb449b32d47ec78561fe939801c488a39a3b54b8a74c65d57022fbcab8a6182548bf45dbaff7b6aa6083479564e08a4b8e18941200ee60fb35802bda95a
+  languageName: node
+  linkType: hard
+
 "@wordpress/theme@npm:0.8.0, @wordpress/theme@npm:^0.8.0":
   version: 0.8.0
   resolution: "@wordpress/theme@npm:0.8.0"
@@ -11578,6 +11615,29 @@ __metadata:
   dependencies:
     "@babel/runtime": "npm:7.25.7"
   checksum: e2a8f53b871f9fa0774dab021c7fec1e35040d15d744bd49c61b67867d8863046c93200a3387355d519c0016ffb4d5d989c7c70688062302ae8857c09a6ea5ac
+  languageName: node
+  linkType: hard
+
+"@wordpress/ui@npm:0.11.0":
+  version: 0.11.0
+  resolution: "@wordpress/ui@npm:0.11.0"
+  dependencies:
+    "@base-ui/react": "npm:^1.4.0"
+    "@wordpress/a11y": "npm:^4.44.0"
+    "@wordpress/compose": "npm:^7.44.0"
+    "@wordpress/element": "npm:^6.44.0"
+    "@wordpress/i18n": "npm:^6.17.0"
+    "@wordpress/icons": "npm:^12.2.0"
+    "@wordpress/keycodes": "npm:^4.44.0"
+    "@wordpress/primitives": "npm:^4.44.0"
+    "@wordpress/private-apis": "npm:^1.44.0"
+    "@wordpress/theme": "npm:^0.11.0"
+    clsx: "npm:^2.1.1"
+    tabbable: "npm:^6.4.0"
+  peerDependencies:
+    react: ^18.0.0
+    react-dom: ^18.0.0
+  checksum: 2e4d5d11b1fd3658f1a5e9894b2c1d21339eed1cdb3348caf54a64b3a442fb6d6595e0622c263b244b913db3d00a5d6bb52c0d1a4c4d815413c2dd7c9ed33816
   languageName: node
   linkType: hard
 
@@ -13440,7 +13500,7 @@ __metadata:
     "@automattic/calypso-stripe": "workspace:^"
     "@automattic/calypso-support-session": "workspace:^"
     "@automattic/calypso-url": "workspace:^"
-    "@automattic/charts": "npm:^0.46.1"
+    "@automattic/charts": "npm:^1.3.0"
     "@automattic/color-studio": "npm:^4.1.0"
     "@automattic/components": "workspace:^"
     "@automattic/composite-checkout": "workspace:^"
@@ -16283,6 +16343,18 @@ __metadata:
     "@types/trusted-types":
       optional: true
   checksum: fa0a8c55a436ba0d54389195e3d2337e311f56de709a2fc9efc98dbbc7746fa53bb4b74b6ac043b77a279a8f2ebd8685f0ebaa6e58c9e32e92051d529bc0baf8
+  languageName: node
+  linkType: hard
+
+"dompurify@npm:^3.3.3":
+  version: 3.4.2
+  resolution: "dompurify@npm:3.4.2"
+  dependencies:
+    "@types/trusted-types": "npm:^2.0.7"
+  dependenciesMeta:
+    "@types/trusted-types":
+      optional: true
+  checksum: 23ab3ab079480a49e1426c4ee7279e393913fa7f2193c4142a5be54d4163dbdd969558675876c6b8bbcbf2ad5d1bc3e00bf902acf142fff12e50274a65ae95b3
   languageName: node
   linkType: hard
 
@@ -33293,7 +33365,7 @@ __metadata:
     "@automattic/calypso-razorpay": "workspace:^"
     "@automattic/calypso-router": "workspace:^"
     "@automattic/calypso-storybook": "workspace:^"
-    "@automattic/charts": "npm:^0.50.0"
+    "@automattic/charts": "npm:^1.3.0"
     "@automattic/color-studio": "npm:^4.1.0"
     "@automattic/components": "workspace:^"
     "@automattic/data-stores": "workspace:^"


### PR DESCRIPTION
## Proposed Changes

- Bump `@automattic/charts` from `^0.46.1` (in `client/`) and `^0.50.0` (root) to `^1.3.0` in both `package.json` files; `yarn install` collapses the previously installed `0.46.1` and `0.50.2` to a single `1.3.0`.
- Adapt to breaking changes introduced in 1.0.0:
    - `legendPosition="top"` → `legend={ { position: 'top' } }` (consolidated legend config).
    - `DataPointPercentage` no longer accepts `percentage`; values are auto-calculated from `value`.
    - `ChartTheme.legendLabelStyles` → nested `legend.labelStyles`.
    - Single bundled stylesheet: `@automattic/charts/line-chart/style.css` → `@automattic/charts/style.css`.
- Load `@automattic/charts/style.css` in `client/dashboard/app/layout.tsx` (covers the dashboard) and in the two classic Calypso entry points that use `LineChart` directly (`my-sites/stats/components/line-chart`, `my-sites/stats/pages/realtime/chart`). The package stylesheet contains `.chart-layout__content svg { display: block }`, the upstream fix for an SVG-descender feedback loop that otherwise grows the chart container indefinitely and triggers a React "Maximum update depth exceeded" warning.

## Why are these changes being made?

To pick up the latest charts package on the new Multi-site Dashboard. The 1.0+ releases consolidate the legend API, drop `DataPointPercentage.percentage`, and ship a single `style.css` entry point — code that imported the old per-chart CSS path or omitted the stylesheet entirely renders incorrectly (chart grows without bound) on 1.3.0.

### Where `@automattic/charts` is used

Dashboard (MSD):
- `client/dashboard/app/layout.tsx` — `GlobalChartsProvider`, stylesheet import.
- `client/dashboard/app/chart-theme.ts` — `ChartTheme` type / dashboard theme overrides.
- `client/dashboard/sites/monitoring-http-responses-card/index.tsx` — `LineChart`.
- `client/dashboard/sites/monitoring-performance-card/index.tsx` — `LineChart`.
- `client/dashboard/sites/monitoring-request-methods-card/index.tsx` — `PieChart` + `Legend`.
- `client/dashboard/sites/monitoring-response-types-card/index.tsx` — `PieChart` + `Legend`.
- `client/dashboard/sites/performance/core-metrics-chart.tsx` — `LineChart`.

Classic Calypso (Stats):
- `client/my-sites/stats/components/line-chart/index.tsx` — `StatsLineChart` wrapper used by the main Stats view (`stats-chart-tabs`) and the Subscribers chart section.
- `client/my-sites/stats/pages/realtime/chart.tsx` — `RealtimeChart`.

## Testing Instructions

For each URL below, confirm the chart renders at a stable size, the legend appears in the expected slot, tooltips work on hover, and the browser console has no React "Maximum update depth exceeded" warning. Replace `:SITE` with any site on your account.

Dashboard (MSD):
- http://my.localhost:3000/sites/:SITE/monitoring — four charts on one page (HTTP responses LineChart, Server performance LineChart, HTTP request methods PieChart, Response types PieChart). This is the page where the growth bug was reported.
- http://my.localhost:3000/sites/:SITE/performance — Core Web Vitals LineChart in the core metrics card.

Classic Calypso Stats:
- http://calypso.localhost:3000/stats/day/:SITE — main Stats view with `ChartTabs`. Also spot-check `week`, `month`, `year`.
- http://calypso.localhost:3000/stats/subscribers/:SITE — `SubscribersChartSection` line chart.
- http://calypso.localhost:3000/stats/realtime/:SITE — Realtime "Current views" line chart.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
