### PR TITLE
Podcast: move route from /podcasting to /settings/podcast

### DIFF
--- a/client/my-sites/podcast/components/welcome.tsx
+++ b/client/my-sites/podcast/components/welcome.tsx
@@ -190,11 +190,13 @@ function Welcome() {
 	// Forward into the Settings tab with the form pre-revealed; picking a
 	// category there writes podcasting_category_id and flips podcasting on.
 	const goToSettings = () => {
-		const path = siteSlug ? `/podcasting/settings/${ siteSlug }` : '/podcasting/settings';
+		const path = siteSlug
+			? `/settings/podcast/settings/${ siteSlug }`
+			: '/settings/podcast/settings';
 		page.show( path );
 	};
 
-	// Redirect through Calypso checkout, then back to /podcasting so the user can
+	// Redirect through Calypso checkout, then back to /settings/podcast so the user can
 	// click Enable on their now-eligible plan.
 	const goToCheckout = ( targetPlan: PlanSlug ) => {
 		dispatch(
@@ -203,7 +205,7 @@ function Welcome() {
 				current_tier: planTier,
 			} )
 		);
-		const returnTo = siteSlug ? `/podcasting/${ siteSlug }` : '/podcasting';
+		const returnTo = siteSlug ? `/settings/podcast/${ siteSlug }` : '/settings/podcast';
 		const path = siteSlug
 			? `/checkout/${ siteSlug }/${ targetPlan }?redirect_to=${ encodeURIComponent( returnTo ) }`
 			: `/checkout/${ targetPlan }`;

--- a/client/my-sites/podcast/hooks/use-access-gate.tsx
+++ b/client/my-sites/podcast/hooks/use-access-gate.tsx
@@ -28,7 +28,7 @@ const useAccessGate = ( className: string = DEFAULT_CLASSNAME ) => {
 		return null;
 	}
 
-	// Mirror the legacy /settings/podcasting gating so /podcasting does not
+	// Mirror the legacy /settings/podcasting gating so /settings/podcast does not
 	// expose flows that are unsupported elsewhere in product.
 	if ( isPrivate ) {
 		return (

--- a/client/my-sites/podcast/index.ts
+++ b/client/my-sites/podcast/index.ts
@@ -5,13 +5,13 @@ import { siteSettings } from 'calypso/my-sites/site-settings/settings-controller
 import { createPodcast } from './controller';
 
 export default function () {
-	page( '/podcasting', siteSelection, sites, makeLayout, clientRender );
-	page( '/podcasting/episodes', siteSelection, sites, makeLayout, clientRender );
-	page( '/podcasting/distribution', siteSelection, sites, makeLayout, clientRender );
-	page( '/podcasting/settings', siteSelection, sites, makeLayout, clientRender );
+	page( '/settings/podcast', siteSelection, sites, makeLayout, clientRender );
+	page( '/settings/podcast/episodes', siteSelection, sites, makeLayout, clientRender );
+	page( '/settings/podcast/distribution', siteSelection, sites, makeLayout, clientRender );
+	page( '/settings/podcast/settings', siteSelection, sites, makeLayout, clientRender );
 
 	page(
-		'/podcasting/:site_id',
+		'/settings/podcast/:site_id',
 		siteSelection,
 		navigation,
 		siteSettings,
@@ -21,7 +21,7 @@ export default function () {
 	);
 
 	page(
-		'/podcasting/:section(episodes|distribution|settings)/:site_id',
+		'/settings/podcast/:section(episodes|distribution|settings)/:site_id',
 		siteSelection,
 		navigation,
 		siteSettings,

--- a/client/my-sites/podcast/main.tsx
+++ b/client/my-sites/podcast/main.tsx
@@ -57,7 +57,7 @@ const PodcastMain = ( { section }: PodcastMainProps ) => {
 	// True once we have a definitive answer for `isSetUp` — either the
 	// setting has loaded (any value, including 0), or the terms list has
 	// loaded. Used to suppress a welcome → tabs flash on the bare
-	// /podcasting/[site] URL while data is still in flight.
+	// /settings/podcast/[site] URL while data is still in flight.
 	const isSetupResolved = useSelector( ( state ) => {
 		if ( ! siteId ) {
 			return true;
@@ -70,7 +70,7 @@ const PodcastMain = ( { section }: PodcastMainProps ) => {
 	const pathSuffix = siteSlug ? '/' + siteSlug : '';
 
 	// Tabs only show when podcasting is actually set up. A deep link to
-	// /podcasting/episodes/[site] on a non-set-up site bounces back to the
+	// /settings/podcast/episodes/[site] on a non-set-up site bounces back to the
 	// welcome via the URL-sync effect below.
 	const showTabs = isSetUp;
 
@@ -88,20 +88,22 @@ const PodcastMain = ( { section }: PodcastMainProps ) => {
 	}, [ section ] );
 
 	// Keep the URL in sync with the current view: tabs live at
-	// /podcasting/<section>/[site], welcome at the bare /podcasting/[site]. A
+	// /settings/podcast/<section>/[site], welcome at the bare /settings/podcast/[site]. A
 	// disabled podcast on episodes/distribution gets bounced back to welcome,
-	// but /podcasting/settings stays accessible so the user can flip podcasting on.
+	// but /settings/podcast/settings stays accessible so the user can flip podcasting on.
 	useEffect( () => {
 		if ( ! isSetupResolved ) {
 			return;
 		}
 		const path = window.location.pathname;
-		const isSectionUrl = /^\/podcasting\/(episodes|distribution|settings)(\/|$)/.test( path );
-		const isContentSectionUrl = /^\/podcasting\/(episodes|distribution)(\/|$)/.test( path );
+		const isSectionUrl = /^\/settings\/podcast\/(episodes|distribution|settings)(\/|$)/.test(
+			path
+		);
+		const isContentSectionUrl = /^\/settings\/podcast\/(episodes|distribution)(\/|$)/.test( path );
 		if ( showTabs && ! isSectionUrl ) {
-			window.history.replaceState( null, '', '/podcasting/episodes' + pathSuffix );
+			window.history.replaceState( null, '', '/settings/podcast/episodes' + pathSuffix );
 		} else if ( ! showTabs && isContentSectionUrl ) {
-			window.history.replaceState( null, '', '/podcasting' + pathSuffix );
+			window.history.replaceState( null, '', '/settings/podcast' + pathSuffix );
 		}
 	}, [ showTabs, isSetupResolved, pathSuffix ] );
 
@@ -111,7 +113,7 @@ const PodcastMain = ( { section }: PodcastMainProps ) => {
 	const prevIsSetUp = useRef( isSetUp );
 	useEffect( () => {
 		if ( isSetupResolved && prevIsSetUp.current && ! isSetUp ) {
-			page.show( '/podcasting' + pathSuffix );
+			page.show( '/settings/podcast' + pathSuffix );
 		}
 		prevIsSetUp.current = isSetUp;
 	}, [ isSetUp, isSetupResolved, pathSuffix ] );
@@ -120,17 +122,17 @@ const PodcastMain = ( { section }: PodcastMainProps ) => {
 		{
 			name: 'episodes' as const,
 			title: translate( 'Episodes' ) as string,
-			path: '/podcasting/episodes' + pathSuffix,
+			path: '/settings/podcast/episodes' + pathSuffix,
 		},
 		{
 			name: 'distribution' as const,
 			title: translate( 'Distribution' ) as string,
-			path: '/podcasting/distribution' + pathSuffix,
+			path: '/settings/podcast/distribution' + pathSuffix,
 		},
 		{
 			name: 'settings' as const,
 			title: translate( 'Settings' ) as string,
-			path: '/podcasting/settings' + pathSuffix,
+			path: '/settings/podcast/settings' + pathSuffix,
 		},
 	];
 

--- a/client/sections.js
+++ b/client/sections.js
@@ -207,7 +207,7 @@ const sections = [
 	},
 	{
 		name: 'podcasting',
-		paths: [ '/podcasting' ],
+		paths: [ '/settings/podcast' ],
 		module: 'calypso/my-sites/podcast',
 		group: 'sites',
 	},


### PR DESCRIPTION
## Proposed Changes

* Move the new podcasting UI from `/podcasting/*` to `/settings/podcast/*` across route registrations, internal navigation, URL-sync regexes, and checkout return URLs.
* Update tab path strings and the `page.show` redirect that fires when a user disables podcasting.
* The legacy `/settings/podcasting` settings page is untouched — using singular `podcast` keeps the new tabbed UI and the legacy settings panel coexisting cleanly.

## Why are these changes being made?

* The bare `/podcasting` path is intercepted by wpcom before Calypso ever sees it, so even though the route was registered it 404'd in production. Nesting under `/settings/*` keeps the route firmly inside Calypso-controlled territory.

## Testing Instructions

* Visit `/settings/podcast/<your-site>` — should land on the Welcome screen for an un-set-up site, or Episodes for a set-up site.
* Click each tab (Episodes, Distribution, Settings) — URL should swap to `/settings/podcast/<section>/<site>` without a full page reload, browser back/forward should still work.
* From Welcome on a free site, click "Upgrade to Premium" — checkout should `redirect_to` back to `/settings/podcast/<site>`.
* From Welcome's "Enable podcasting" CTA, confirm landing on `/settings/podcast/settings/<site>`.
* Disable podcasting from the Settings tab — should bounce to `/settings/podcast/<site>` (Welcome).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?