### PR TITLE
Remove ineffective Blaze Pro dynamic import

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -19,6 +19,7 @@ import { withCurrentRoute } from 'calypso/components/route';
 import SympathyDevWarning from 'calypso/components/sympathy-dev-warning';
 import { getDashboardFromHostname } from 'calypso/dashboard/app/routing';
 import { retrieveMobileRedirect } from 'calypso/jetpack-connect/persistence-utils';
+import BlazeProMasterbar from 'calypso/layout/masterbar/blaze-pro';
 import EmptyMasterbar from 'calypso/layout/masterbar/empty';
 import MasterbarLoggedIn from 'calypso/layout/masterbar/logged-in';
 import { isInStepContainerV2FlowContext } from 'calypso/layout/utils';
@@ -78,10 +79,6 @@ import './style.scss';
 const loadWooCoreProfiler = () =>
 	import(
 		/* webpackChunkName: "async-load-calypso-layout-masterbar-woo-core-profiler" */ 'calypso/layout/masterbar/woo-core-profiler'
-	);
-const loadBlazePro = () =>
-	import(
-		/* webpackChunkName: "async-load-calypso-layout-masterbar-blaze-pro" */ 'calypso/layout/masterbar/blaze-pro'
 	);
 const loadReaderHeader = () =>
 	import(
@@ -249,7 +246,7 @@ class Layout extends Component {
 			return <AsyncLoad require={ loadWooCoreProfiler } placeholder={ null } />;
 		}
 		if ( this.props.isBlazePro ) {
-			return <AsyncLoad require={ loadBlazePro } placeholder={ null } />;
+			return <BlazeProMasterbar />;
 		}
 
 		if ( this.props.needsColorScheme && this.props.isFetchingColorScheme ) {


### PR DESCRIPTION
Part of #

## Proposed Changes

* Render the Blaze Pro masterbar directly from `client/layout/index.jsx` instead of loading it through `AsyncLoad`.

## Why are these changes being made?

* Vite reports `client/layout/masterbar/blaze-pro.tsx` as an ineffective dynamic import because the module is also statically imported by the OAuth masterbar, so the dynamic import cannot create a separate chunk.

## Testing Instructions

1. Start Calypso with `yarn start`.
2. In a fresh or logged-out browser session, open a Blaze Pro OAuth login flow. Use an existing Blaze Pro OAuth URL, or construct a local `/log-in` URL with a Blaze Pro `client_id` such as `92099` and a `redirect_to` value that also contains the same `client_id`.
3. Confirm the login page uses the Blaze Pro masterbar: the Blaze Pro logo is visible and the Back button is present.
4. Click the Back button and confirm it navigates back using the referrer or browser history.
5. Sign in and repeat the Blaze Pro OAuth or signup flow while already authenticated. Confirm the logged-in layout also renders the Blaze Pro masterbar.
6. Open a normal route such as `/log-in` without a Blaze Pro client ID and confirm the standard masterbar still renders.
7. Check the browser console for TypeScript, React, and module loading errors.
8. In the Vite migration branch or build, confirm the ineffective dynamic import warning for `client/layout/masterbar/blaze-pro.tsx` no longer appears.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?