### PR TITLE
Remove ineffective global notices dynamic imports

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -14,6 +14,7 @@ import QuerySiteAdminColor from 'calypso/components/data/query-site-admin-color'
 import QuerySiteAdminMenu from 'calypso/components/data/query-site-admin-menu';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import QuerySites from 'calypso/components/data/query-sites';
+import GlobalNotices from 'calypso/components/global-notices';
 import JetpackCloudMasterbar from 'calypso/components/jetpack/masterbar';
 import { withCurrentRoute } from 'calypso/components/route';
 import SympathyDevWarning from 'calypso/components/sympathy-dev-warning';
@@ -105,10 +106,6 @@ const loadA8cForAgenciesStyle = () =>
 	);
 const loadJitm = () =>
 	import( /* webpackChunkName: "async-load-calypso-blocks-jitm" */ 'calypso/blocks/jitm' );
-const loadGlobalNotices = () =>
-	import(
-		/* webpackChunkName: "async-load-calypso-components-global-notices" */ 'calypso/components/global-notices'
-	);
 const loadCommunityTranslator = () =>
 	import(
 		/* webpackChunkName: "async-load-calypso-layout-community-translator" */ 'calypso/layout/community-translator'
@@ -408,7 +405,7 @@ class Layout extends Component {
 							messagePath={ `calypso:${ this.props.sectionJitmPath }:admin_notices` }
 						/>
 					) }
-					<AsyncLoad require={ loadGlobalNotices } placeholder={ null } id="notices" />
+					<GlobalNotices id="notices" />
 					{ ! ( this.props.needsColorScheme && this.props.isFetchingColorScheme ) && (
 						<>
 							<div id="secondary" className="layout__secondary" role="navigation">

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -10,6 +10,7 @@ import { connect, useSelector } from 'react-redux';
 import { CookieBannerContainerSSR } from 'calypso/blocks/cookie-banner';
 import ReaderJoinConversationDialog from 'calypso/blocks/reader-join-conversation/dialog';
 import AsyncLoad from 'calypso/components/async-load';
+import GlobalNotices from 'calypso/components/global-notices';
 import { withCurrentRoute } from 'calypso/components/route';
 import SympathyDevWarning from 'calypso/components/sympathy-dev-warning';
 import { getDashboardFromHostname } from 'calypso/dashboard/app/routing';
@@ -69,10 +70,6 @@ const loadJetpackCloudStyle = () =>
 const loadA8cForAgenciesStyle = () =>
 	import(
 		/* webpackChunkName: "async-load-calypso-a8c-for-agencies-style" */ 'calypso/a8c-for-agencies/style'
-	);
-const loadGlobalNotices = () =>
-	import(
-		/* webpackChunkName: "async-load-calypso-components-global-notices" */ 'calypso/components/global-notices'
 	);
 const loadSupportArticleDialog = () =>
 	import(
@@ -315,7 +312,7 @@ const LayoutLoggedOut = ( {
 					<AsyncLoad require={ loadA8cForAgenciesStyle } placeholder={ null } />
 				) }
 				<div id="content" className="layout__content">
-					<AsyncLoad require={ loadGlobalNotices } placeholder={ null } id="notices" />
+					<GlobalNotices id="notices" />
 					<div id="primary" className="layout__primary">
 						{ primary }
 					</div>

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -46,6 +46,7 @@ import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import SyncActiveTheme from 'calypso/components/data/sync-active-theme';
+import GlobalNotices from 'calypso/components/global-notices';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
@@ -130,11 +131,6 @@ import './style.scss';
 
 const loadJitm = () =>
 	import( /* webpackChunkName: "async-load-calypso-blocks-jitm" */ 'calypso/blocks/jitm' );
-const loadGlobalNotices = () =>
-	import(
-		/* webpackChunkName: "async-load-calypso-components-global-notices" */ 'calypso/components/global-notices'
-	);
-
 const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
 	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
 	'@wordpress/components'
@@ -1253,7 +1249,7 @@ class ThemeSheet extends Component {
 					title={ analyticsPageTitle }
 					properties={ { is_logged_in: isLoggedIn } }
 				/>
-				<AsyncLoad require={ loadGlobalNotices } placeholder={ null } id="notices" />
+				<GlobalNotices id="notices" />
 				{
 					siteId && (
 						<QueryActiveTheme siteId={ siteId } />


### PR DESCRIPTION
Part of #

## Proposed Changes

* Render global notices directly from the logged-in layout, logged-out layout, and theme sheet instead of loading `calypso/components/global-notices` through `AsyncLoad`.

## Why are these changes being made?

* Vite reports `client/components/global-notices/index.jsx` as an ineffective dynamic import because the module is also statically imported by magic login routes, so the dynamic imports cannot create a separate chunk.

## Testing Instructions

1. Start Calypso with `yarn start`.
2. Open a logged-in route such as `/me/account?debug`. If `dispatch` is not available in the browser console, add `?debug` to the route and reload.
3. In the browser console, dispatch a notice:

```js
dispatch( {
	type: "NOTICE_CREATE",
	notice: {
		noticeId: "global-notice-smoke",
		status: "is-success",
		text: "Global notice smoke test",
		showDismiss: true,
	},
} );
```

4. Confirm the notice appears in the global notices area, can be dismissed, and does not trigger console errors.
5. Repeat the same console dispatch on a logged-out layout route such as `/log-in?debug`.
6. Repeat it on a theme sheet route such as `/theme/twentytwentyfour/:site?debug`, replacing `:site` with a site slug you can access.
7. On each route, confirm the page still renders normally before and after the notice is dismissed.
8. In the Vite migration branch or build, confirm the ineffective dynamic import warning for `client/components/global-notices/index.jsx` no longer appears.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?