### PR TITLE
Remove ineffective search dynamic import

### DIFF
--- a/client/blocks/author-selector/switcher-shell.jsx
+++ b/client/blocks/author-selector/switcher-shell.jsx
@@ -1,10 +1,10 @@
 import { Gridicon, Popover } from '@automattic/components';
+import Search from '@automattic/search';
 import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component, createRef } from 'react';
 import ReactDom from 'react-dom';
-import AsyncLoad from 'calypso/components/async-load';
 import InfiniteList from 'calypso/components/infinite-list';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import UserItem from 'calypso/components/user';
@@ -15,9 +15,6 @@ import 'calypso/components/popover-menu/style.scss';
  * Module variables
  */
 const debug = debugModule( 'calypso:author-selector' );
-
-const loadSearch = () =>
-	import( /* webpackChunkName: "async-load-automattic-search" */ '@automattic/search' );
 
 class AuthorSwitcherShell extends Component {
 	static propTypes = {
@@ -66,8 +63,7 @@ class AuthorSwitcherShell extends Component {
 					ignoreContext={ this.props.ignoreContext }
 				>
 					{ ( this.props.search || users.length > 10 ) && (
-						<AsyncLoad
-							require={ loadSearch }
+						<Search
 							compact
 							onSearch={ this.props.updateSearch }
 							placeholder={ this.props.translate( 'Find Author…', { context: 'search label' } ) }


### PR DESCRIPTION
Part of #

## Proposed Changes

* Render the author selector search input directly instead of loading `@automattic/search` through `AsyncLoad`.

## Why are these changes being made?

* Vite reports `packages/search/src/index.ts` as an ineffective dynamic import because the package index is statically imported by many other components, so this dynamic import cannot create a separate chunk.

## Testing Instructions

1. Start Calypso with `yarn start`.
2. Use a test site with enough users for the author selector search field to appear. More than 10 users is the most direct path because `AuthorSelector` shows search automatically above that count.
3. Open `/people/team/:site`, replacing `:site` with that site slug.
4. Open a team member profile for a user other than the current user, then open the remove/delete user flow.
5. Choose the option to attribute content to another user. This reveals the author selector.
6. Open the author selector, type into the search field, and confirm matching users are filtered without console errors.
7. Select a different user and confirm the selected user appears in the reassignment control. You do not need to submit the delete form.
8. As an alternate smoke path, use an importer flow that reaches author mapping and repeat the same search/select behavior there.
9. In the Vite migration branch or build, confirm the ineffective dynamic import warning for `packages/search/src/index.ts` no longer appears.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?