### PR TITLE
Remove ineffective agents manager dynamic import

### DIFF
--- a/client/layout/agents-manager-loader.tsx
+++ b/client/layout/agents-manager-loader.tsx
@@ -1,4 +1,4 @@
-import { useShouldUseUnifiedAgent } from '@automattic/agents-manager';
+import { useShouldUseUnifiedAgent } from '@automattic/agents-manager/src/hooks/use-should-use-unified-agent';
 import { useSelector } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
@@ -7,9 +7,7 @@ import { getSiteBySlug } from 'calypso/state/sites/selectors';
 import { getSelectedSite, isSiteSection } from 'calypso/state/ui/selectors';
 
 const importAgentsManager = () =>
-	import(
-		/* webpackChunkName: "async-load-automattic-agents-manager" */ '@automattic/agents-manager'
-	);
+	import( /* webpackChunkName: "async-load-calypso-layout-agents-manager" */ './agents-manager' );
 
 export default function AgentsManagerLoader( {
 	sectionName,

--- a/client/layout/agents-manager.tsx
+++ b/client/layout/agents-manager.tsx
@@ -1,0 +1,1 @@
+export { default } from '@automattic/agents-manager';


### PR DESCRIPTION
Part of #

## Proposed Changes

* Keep `AgentsManagerLoader` lazy by dynamically importing a local wrapper module for `@automattic/agents-manager`.
* Import `useShouldUseUnifiedAgent` from the hook submodule so the package index is not evaluated by the loader before the feature flag path needs it.

## Why are these changes being made?

* Vite reports `packages/agents-manager/src/index.ts` as an ineffective dynamic import because the loader and other consumers statically import the same package index, so directly dynamic-importing the package index cannot create a separate chunk.
* Keeping the loader lazy preserves the existing behavior where the full Agents Manager UI is not loaded when the unified agent experience is disabled.

## Testing Instructions

1. Start Calypso with `yarn start` and sign in with an account that is eligible for the unified agent experience.
2. Open `/home/:site` or `/help`, replacing `:site` with a site slug you can access.
3. In the Network tab, confirm `/agents-manager/state?key=unified_ai_chat` is requested and returns `unified_ai_chat: true` for the positive smoke path.
4. Confirm the Agents Manager UI appears, either as the docked chat control or sidebar control depending on viewport and route.
5. Open the Agents Manager UI, switch between its available views if present, then close it. Confirm the page layout recovers correctly.
6. If chat is available in the test account, send a short prompt and confirm the loading and response states render without console errors.
7. Repeat with an account or state where `/agents-manager/state?key=unified_ai_chat` returns false. Confirm no Agents Manager UI appears and no console errors are logged.
8. In the Vite migration branch or build, confirm the ineffective dynamic import warning for `packages/agents-manager/src/index.ts` no longer appears.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?