### PR TITLE
Remove ineffective ExPlat dynamic import

### DIFF
--- a/client/state/sites/hooks/use-site-global-styles-status.ts
+++ b/client/state/sites/hooks/use-site-global-styles-status.ts
@@ -1,10 +1,11 @@
-import { ExperimentAssignment } from '@automattic/explat-client';
 import { useQuery } from '@tanstack/react-query';
+import { loadExperimentAssignment as loadExperimentAssignmentFromExPlat } from 'calypso/lib/explat';
 import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import type { ExperimentAssignment } from '@automattic/explat-client';
 
 export type GlobalStylesStatus = {
 	shouldLimitGlobalStyles: boolean;
@@ -22,21 +23,22 @@ const DEFAULT_GLOBAL_STYLES_INFO: GlobalStylesStatus = {
 	variation: null,
 };
 
-/*
- * We cannot import `loadExperimentAssignment` directly from 'calypso/lib/explat'
- * because it runs a side effect that produces an error on SSR contexts.
- */
-let loadExperimentAssignment = ( experimentName: string ): Promise< ExperimentAssignment > =>
-	Promise.resolve( { experimentName, variationName: null, retrievedTimestamp: 0, ttl: 0 } );
+const getFallbackExperimentAssignment = ( experimentName: string ): ExperimentAssignment => ( {
+	experimentName,
+	variationName: null,
+	retrievedTimestamp: 0,
+	ttl: 0,
+} );
 
-if ( typeof window !== 'undefined' ) {
-	import( 'calypso/lib/explat' )
-		.then( ( module ) => {
-			loadExperimentAssignment = module.loadExperimentAssignment;
-		} )
-		// eslint-disable-next-line @typescript-eslint/no-empty-function
-		.catch( () => {} );
-}
+const loadGlobalStylesExperimentAssignment = (
+	experimentName: string
+): Promise< ExperimentAssignment > => {
+	if ( typeof window === 'undefined' ) {
+		return Promise.resolve( getFallbackExperimentAssignment( experimentName ) );
+	}
+
+	return loadExperimentAssignmentFromExPlat( experimentName );
+};
 
 function shouldRunGlobalStylesOnPersonalExperiment(
 	siteId: number | null,
@@ -78,14 +80,15 @@ const getGlobalStylesInfoForSite = (
 	}
 
 	if ( siteId === null ) {
-		return loadExperimentAssignment( 'calypso_plans_global_styles_personal_20251124_v5' ).then(
-			( experimentAssignment ) =>
-				Promise.resolve( {
-					shouldLimitGlobalStyles: true,
-					globalStylesInUse: false,
-					globalStylesInPersonalPlan: !! experimentAssignment?.variationName,
-					variation: experimentAssignment?.variationName,
-				} )
+		return loadGlobalStylesExperimentAssignment(
+			'calypso_plans_global_styles_personal_20251124_v5'
+		).then( ( experimentAssignment ) =>
+			Promise.resolve( {
+				shouldLimitGlobalStyles: true,
+				globalStylesInUse: false,
+				globalStylesInPersonalPlan: !! experimentAssignment?.variationName,
+				variation: experimentAssignment?.variationName,
+			} )
 		);
 	}
 


### PR DESCRIPTION
Part of #

## Proposed Changes

* Import ExPlat directly in `use-site-global-styles-status` and keep a browser guard before calling the experiment assignment loader.

## Why are these changes being made?

* Vite reports `client/lib/explat/index.ts` as an ineffective dynamic import because that module is also statically imported by several dashboard and Calypso components, so the dynamic import cannot create a separate chunk.

## Testing Instructions

1. Start Calypso with `yarn start`.
2. In a logged-out or incognito browser session, hard-load a theme details page such as `/theme/twentytwentyfour`.
3. Confirm the logged-out theme page renders and the terminal/browser console does not show ExPlat or SSR-related errors.
4. Sign in and open a site-specific theme sheet such as `/theme/twentytwentyfour/:site`, replacing `:site` with a site slug you can access.
5. Confirm the theme sheet renders, style variation UI loads if the theme has variations, and the page does not show transient global-styles gating errors while data loads.
6. In the Network tab, confirm the site-specific `/global-styles/status` request runs for the selected site and the UI remains stable whether it succeeds or falls back.
7. If you have a site or account that triggers the personal-plan global styles experiment, confirm any upgrade notice or modal still appears in the same cases as trunk.
8. In the Vite migration branch or build, confirm the ineffective dynamic import warning for `client/lib/explat/index.ts` no longer appears.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?