### PR TITLE
Remove ineffective add new site dynamic import

### DIFF
--- a/client/components/sites-add-new-site/async.tsx
+++ b/client/components/sites-add-new-site/async.tsx
@@ -1,12 +1,6 @@
-import { Spinner } from '@wordpress/components';
-import AsyncLoad from 'calypso/components/async-load';
+import AddNewSite from '../../dashboard/sites/add-new-site';
 import type { AddNewSiteProps } from '../../dashboard/sites/add-new-site/types';
 
-const loadAddNewSite = () =>
-	import(
-		/* webpackChunkName: "async-load-calypso-dashboard-sites-add-new-site" */ 'calypso/dashboard/sites/add-new-site'
-	);
-
 export const AsyncContent = ( props: AddNewSiteProps ) => {
-	return <AsyncLoad require={ loadAddNewSite } placeholder={ <Spinner /> } { ...props } />;
+	return <AddNewSite { ...props } />;
 };


### PR DESCRIPTION
Part of #

## Proposed Changes

* Render the Dashboard add-new-site component directly from the shared sites add-new-site wrapper instead of loading it through `AsyncLoad`.

## Why are these changes being made?

* Vite reports `client/dashboard/sites/add-new-site/index.tsx` as an ineffective dynamic import because Dashboard already imports the same module statically, so the dynamic import cannot create a separate chunk.

## Testing Instructions

1. Start Calypso with `yarn start` and sign in.
2. Open `/sites`.
3. Click the `Add new site` control in the sites dashboard header.
4. Confirm the add-new-site popover/modal opens and shows the expected groups: `Start a new site`, `Bring an existing site`, and the offer card.
5. Confirm the expected actions are present, including `Create it yourself`, `Create with AI`, `Migrate to WordPress.com`, and `Via the Jetpack plugin` when available for the account.
6. Click one action, such as `Create it yourself`, and confirm it navigates to the expected setup route with the sites-dashboard source/ref query. Use browser back to return.
7. If the sites preview pane is open and the header switches to compact mode, click the compact add-site control and confirm it opens the same content.
8. Check the browser console for TypeScript, React, and module loading errors.
9. In the Vite migration branch or build, confirm the ineffective dynamic import warning for `client/dashboard/sites/add-new-site/index.tsx` no longer appears.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?