### PR TITLE
Remove ineffective Stepper stores dynamic import

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -33,6 +33,7 @@ import Loading from 'calypso/components/loading';
 import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
 import { dashboardLink } from 'calypso/dashboard/utils/link';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { debug, TRACKING_IDS } from 'calypso/lib/analytics/ad-tracking/constants';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { mayWeTrackByTracker } from 'calypso/lib/analytics/tracker-buckets';
@@ -232,10 +233,7 @@ export class CheckoutThankYou extends Component<
 
 		if ( isOnlyDomainTransfers( getPurchases( this.props ) ) ) {
 			// We need to reset the store upon checkout completion, on the bulk domain transfer flow
-			// We do it dinamically to avoid loading unnecessary javascript if not necessary.
-			import( 'calypso/landing/stepper/stores' ).then( ( imports ) =>
-				( dispatch( imports.ONBOARD_STORE ) as OnboardActions ).resetOnboardStore()
-			);
+			( dispatch( ONBOARD_STORE ) as OnboardActions ).resetOnboardStore();
 
 			if ( mayWeTrackByTracker( 'googleAds' ) ) {
 				const params: [ 'event', 'conversion', { send_to: string } ] = [


### PR DESCRIPTION
Part of #

## Proposed Changes

* Import `ONBOARD_STORE` directly in checkout thank-you and use it for the bulk domain transfer reset.

## Why are these changes being made?

* Vite reports `client/landing/stepper/stores.ts` as an ineffective dynamic import because the store module is statically imported by other Stepper and checkout code, so the dynamic import cannot create a separate chunk.

## Testing Instructions

1. Start Calypso with `yarn start` and sign in with an account that can use a checkout sandbox.
2. Complete a test checkout that contains only domain transfer products, or reuse a known test receipt where every purchase is a domain transfer.
3. Open the resulting thank-you URL. It should be one of `/checkout/thank-you/:site/:receiptId` or `/checkout/thank-you/no-site/:receiptId` depending on the checkout.
4. Confirm the redesigned bulk domain transfer thank-you page renders with the `Your domain transfer has started` or `Your domain transfers have started` heading.
5. Confirm the purchased domain transfer products are listed and the `Transfer more domains` and `Manage your domain(s)` actions render.
6. Click `Transfer more domains` and confirm the domain transfer setup flow starts cleanly, with no stale domains or onboarding state carried over from the completed checkout.
7. Return to the thank-you page and check the browser console for TypeScript, React, and module loading errors.
8. In the Vite migration branch or build, confirm the ineffective dynamic import warning for `client/landing/stepper/stores.ts` no longer appears.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?