### PR TITLE
Remove ineffective masterbar cart dynamic import

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -61,6 +61,7 @@ import { getSectionGroup } from 'calypso/state/ui/selectors';
 import Item from './item';
 import Masterbar from './masterbar';
 import { AgentsManagerIcon } from './masterbar-agents-manager/agents-manager-icon';
+import MasterbarCartWrapper from './masterbar-cart/masterbar-cart-wrapper';
 import { HelpCenterIcon } from './masterbar-help-center/help-center-icon';
 import { MasterbarLaunchButton } from './masterbar-launch-button';
 import Notifications from './masterbar-notifications/notifications-button';
@@ -70,10 +71,6 @@ const loadCheckout = () =>
 const loadQuickLanguageSwitcher = () =>
 	import(
 		/* webpackChunkName: "async-load-calypso-layout-masterbar-quick-language-switcher" */ './quick-language-switcher'
-	);
-const loadMasterbarCartWrapper = () =>
-	import(
-		/* webpackChunkName: "async-load-calypso-layout-masterbar-masterbar-cart-masterbar-cart-wrapper" */ './masterbar-cart/masterbar-cart-wrapper'
 	);
 const loadMasterbarAgentsManager = () =>
 	import(
@@ -759,9 +756,7 @@ class MasterbarLoggedIn extends Component {
 			return null;
 		}
 		return (
-			<AsyncLoad
-				require={ loadMasterbarCartWrapper }
-				placeholder={ null }
+			<MasterbarCartWrapper
 				goToCheckout={ this.goToCheckout }
 				onRemoveProduct={ this.onRemoveCartProduct }
 				onRemoveCoupon={ this.onRemoveCartProduct }


### PR DESCRIPTION
Part of #

## Proposed Changes

* Render `MasterbarCartWrapper` directly from the logged-in masterbar instead of loading it through `AsyncLoad`.

## Why are these changes being made?

* Vite reports `client/layout/masterbar/masterbar-cart/masterbar-cart-wrapper.tsx` as an ineffective dynamic import because Jetpack Cloud statically imports the same wrapper, so the dynamic import cannot create a separate chunk.

## Testing Instructions

1. Start Calypso with `yarn start` and sign in.
2. Use a test site and add any product to that site cart, such as a plan, domain, or renewal. Stop before completing checkout.
3. Navigate to a site-specific Calypso route such as `/plugins/:site` or `/themes/:site`, replacing `:site` with the site slug that owns the cart.
4. Confirm the masterbar shows the shopping cart icon on the right side.
5. Click the cart icon and confirm the mini cart popover opens, refreshes the cart, and lists the product you added.
6. Click through to checkout or remove the product from the mini cart, then confirm the popover state updates correctly.
7. Navigate to a non-site route such as `/me/account` and confirm the masterbar cart is not shown there.
8. Check the browser console for TypeScript, React, and module loading errors.
9. In the Vite migration branch or build, confirm the ineffective dynamic import warning for `client/layout/masterbar/masterbar-cart/masterbar-cart-wrapper.tsx` no longer appears.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?