### PR TITLE
Remove ineffective Reader subscriptions dynamic import

### DIFF
--- a/client/reader/controller.jsx
+++ b/client/reader/controller.jsx
@@ -9,6 +9,7 @@ import wpcom from 'calypso/lib/wp';
 import FeedError from 'calypso/reader/feed-error';
 import StreamComponent from 'calypso/reader/following/main';
 import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
+import SiteSubscriptionsManager from 'calypso/reader/site-subscriptions-manager';
 import { recordTrack } from 'calypso/reader/stats';
 import { getCurrentTabFromURL } from 'calypso/reader/utils';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -48,10 +49,6 @@ const loadMain = () =>
 	import( /* webpackChunkName: "async-load-calypso-reader-a8c-main" */ 'calypso/reader/a8c/main' );
 const loadP2Main = () =>
 	import( /* webpackChunkName: "async-load-calypso-reader-p2-main" */ 'calypso/reader/p2/main' );
-const loadSiteSubscriptionsManager = () =>
-	import(
-		/* webpackChunkName: "async-load-calypso-reader-site-subscriptions-manager" */ 'calypso/reader/site-subscriptions-manager'
-	);
 const loadSiteSubscription = () =>
 	import(
 		/* webpackChunkName: "async-load-calypso-reader-site-subscription" */ 'calypso/reader/site-subscription'
@@ -368,7 +365,7 @@ export async function siteSubscriptionsManager( context, next ) {
 	const mcKey = 'subscription-sites';
 	trackPageLoad( basePath, fullAnalyticsPageTitle, mcKey );
 
-	context.primary = <AsyncLoad require={ loadSiteSubscriptionsManager } />;
+	context.primary = <SiteSubscriptionsManager />;
 	next();
 }
 


### PR DESCRIPTION
Part of #

## Proposed Changes

* Render the Reader site subscriptions manager directly from the Reader controller instead of loading it through `AsyncLoad`.

## Why are these changes being made?

* Vite reports `client/reader/site-subscriptions-manager/index.tsx` as an ineffective dynamic import because `client/sections.js` also references the same section module, so the dynamic import cannot create a separate chunk.

## Testing Instructions

1. Start Calypso with `yarn start` and sign in with an account that has Reader subscriptions.
2. Open `/reader/subscriptions`.
3. Confirm the site subscriptions manager renders with the `Manage subscriptions` page shell and the `Sites`, `Comments`, and, when applicable, `Pending` navigation tabs.
4. Search or filter the site subscriptions list and confirm the list updates correctly.
5. Open the import/export or more-options menu if it is available, then close it and confirm the page remains usable.
6. Navigate to `/reader/subscriptions/comments` and confirm the comments subscriptions manager still loads.
7. Navigate to `/reader/subscriptions/pending` and confirm the pending subscriptions manager still loads, or shows the expected empty state.
8. If you have a subscription ID handy, open `/reader/subscriptions/:subscription_id` and confirm the individual subscription route still loads.
9. Check the browser console for TypeScript, React, and module loading errors.
10. In the Vite migration branch or build, confirm the ineffective dynamic import warning for `client/reader/site-subscriptions-manager/index.tsx` no longer appears.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?