### PR TITLE
Remove ineffective Help Center dynamic import

### DIFF
--- a/client/layout/help-center-loader.tsx
+++ b/client/layout/help-center-loader.tsx
@@ -1,4 +1,4 @@
-import { HelpCenter } from '@automattic/data-stores';
+import { HelpCenter as HelpCenterDataStore } from '@automattic/data-stores';
 import { useLocale } from '@automattic/i18n-utils';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { useDispatch } from '@wordpress/data';
@@ -16,9 +16,9 @@ import { getSiteBySlug } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 const importHelpCenter = () =>
-	import( /* webpackChunkName: "async-load-automattic-help-center" */ '@automattic/help-center' );
+	import( /* webpackChunkName: "async-load-calypso-layout-help-center" */ './help-center' );
 
-const HELP_CENTER_STORE = HelpCenter.register();
+const HELP_CENTER_STORE = HelpCenterDataStore.register();
 
 type Props = {
 	sectionName: string;

--- a/client/layout/help-center.tsx
+++ b/client/layout/help-center.tsx
@@ -1,0 +1,1 @@
+export { default } from '@automattic/help-center';


### PR DESCRIPTION
Part of #

## Proposed Changes

* Keep `HelpCenterLoader` lazy by dynamically importing a local wrapper module for `@automattic/help-center`.
* Avoid directly dynamic-importing the Help Center package index from the loader, which is what Vite reports as ineffective.

## Why are these changes being made?

* Vite reports `packages/help-center/src/index.ts` as an ineffective dynamic import because other Help Center entry points statically import the same package index, so directly dynamic-importing the package index cannot create a separate chunk.
* Keeping the loader lazy preserves the existing behavior where browser-only Help Center code is not evaluated on server-side layout paths or when the Help Center is not loaded.

## Testing Instructions

1. Start Calypso with `yarn start` and sign in with an account where the traditional Help Center is expected to be available.
2. Open `/home/:site`, replacing `:site` with a site slug you can access.
3. Click the Help icon in the masterbar and confirm the Help Center opens.
4. Search for a support topic, open one result, use the back control if available, then close the Help Center.
5. Open `/help` and repeat the open/search/close flow.
6. Open a route where the loader should not run, such as `/me/account`, and confirm the Help Center panel is not unexpectedly mounted or opened.
7. If the account is using the unified agent experience instead, confirm the traditional Help Center stays hidden and the page has no console errors.
8. Check the browser console for TypeScript, React, and module loading errors during the open and close transitions.
9. In the Vite migration branch or build, confirm the ineffective dynamic import warning for `packages/help-center/src/index.ts` no longer appears.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?