### PR TITLE
Remove ineffective Jetpack Cloud sidebar dynamic import

### DIFF
--- a/client/my-sites/navigation/index.jsx
+++ b/client/my-sites/navigation/index.jsx
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import { withCurrentRoute } from 'calypso/components/route';
+import ManageSelectedSiteSidebar from 'calypso/jetpack-cloud/sections/sidebar-navigation/manage-selected-site';
 import GlobalSidebar, { GLOBAL_SIDEBAR_EVENTS } from 'calypso/layout/global-sidebar';
 import HostingDashboardOptInBanner from 'calypso/my-sites/hosting-dashboard-opt-in-banner';
 import MySitesSidebarUnifiedBody from 'calypso/my-sites/sidebar/body';
@@ -12,10 +13,6 @@ import { getSidebarType, SidebarType } from 'calypso/state/global-sidebar/select
 import { getSiteDomain } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
-const loadManageSelectedSite = () =>
-	import(
-		/* webpackChunkName: "async-load-calypso-jetpack-cloud-sections-sidebar-navigation-manage-selected-site" */ 'calypso/jetpack-cloud/sections/sidebar-navigation/manage-selected-site'
-	);
 const loadSidebar = () =>
 	import(
 		/* webpackChunkName: "async-load-calypso-my-sites-sidebar" */ 'calypso/my-sites/sidebar'
@@ -42,7 +39,7 @@ class MySitesNavigation extends Component {
 		let asyncSidebar = null;
 
 		if ( config.isEnabled( 'jetpack-cloud' ) ) {
-			asyncSidebar = <AsyncLoad require={ loadManageSelectedSite } { ...asyncProps } />;
+			asyncSidebar = <ManageSelectedSiteSidebar path={ this.props.path } />;
 		} else if ( this.props.isGlobalSidebarVisible ) {
 			return this.renderGlobalSidebar();
 		} else {


### PR DESCRIPTION
Part of #

## Proposed Changes

* Render the Jetpack Cloud selected-site sidebar directly from My Sites navigation instead of loading it through `AsyncLoad`.

## Why are these changes being made?

* Vite reports `client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx` as an ineffective dynamic import because the Jetpack Cloud landing controller statically imports the same module, so the dynamic import cannot create a separate chunk.

## Testing Instructions

1. Start Calypso in a Jetpack Cloud configuration where the `jetpack-cloud` feature flag is enabled, then sign in.
2. Open a selected-site Jetpack Cloud route such as `/backup/:site` or `/scan/:site`, replacing `:site` with a Jetpack-connected site slug.
3. Confirm the selected-site sidebar renders with the site header and the expected items for that site, such as Activity Log, Backup, Scan, Search, Settings, or Purchases depending on site features and permissions.
4. Click a sidebar item, such as Search or Settings, and confirm navigation works and the active item state updates.
5. If testing with an agency account, confirm the `Back to Sites` control appears and returns to `/dashboard`.
6. Open `/landing/:site` with cache disabled or before site features have loaded, and confirm the landing interstitial can render the same selected-site sidebar before redirecting to the eligible product route.
7. Check the browser console for TypeScript, React, and module loading errors.
8. In the Vite migration branch or build, confirm the ineffective dynamic import warning for `client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx` no longer appears.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?