### PR TITLE
Checkout: gate redesign behind calypso_rsm_better_checkout experiment

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -63,6 +63,7 @@ import { areVatDetailsSame } from 'calypso/me/purchases/vat-info/are-vat-details
 import useVatDetails from 'calypso/me/purchases/vat-info/use-vat-details';
 import { CheckoutOrderBanner } from 'calypso/my-sites/checkout/src/components/checkout-order-banner';
 import { useCheckoutUiRedesignExperiment } from 'calypso/my-sites/checkout/src/hooks/use-checkout-ui-redesign-experiment';
+import { useRsmBetterCheckoutExperiment } from 'calypso/my-sites/checkout/src/hooks/use-rsm-better-checkout-experiment';
 import useValidCheckoutBackUrl from 'calypso/my-sites/checkout/src/hooks/use-valid-checkout-back-url';
 import { leaveCheckout } from 'calypso/my-sites/checkout/src/lib/leave-checkout';
 import {
@@ -548,6 +549,7 @@ export default function CheckoutMainContent( {
 	const isLargeViewport = useViewportMatch( 'large', '>=' );
 
 	const [ , isCheckoutUiRedesignV1 ] = useCheckoutUiRedesignExperiment();
+	const isRsmBetterCheckout = useRsmBetterCheckoutExperiment();
 	const originalPriceForHeader = responseCart.products.reduce(
 		( sum, product ) => sum + product.item_original_subtotal_integer,
 		0
@@ -599,9 +601,11 @@ export default function CheckoutMainContent( {
 	) {
 		debug( 'rendering empty cart page' );
 		return (
-			<WPCheckoutWrapper>
-				<WPCheckoutSidebarContent></WPCheckoutSidebarContent>
-				<WPCheckoutMainContent>
+			<WPCheckoutWrapper isRsmBetterCheckout={ isRsmBetterCheckout }>
+				<WPCheckoutSidebarContent
+					isRsmBetterCheckout={ isRsmBetterCheckout }
+				></WPCheckoutSidebarContent>
+				<WPCheckoutMainContent isRsmBetterCheckout={ isRsmBetterCheckout }>
 					<PerformanceTrackerStop />
 					<WPCheckoutTitle className="checkout__main-title">
 						{ translate( 'Checkout' ) }
@@ -634,7 +638,10 @@ export default function CheckoutMainContent( {
 	};
 
 	const checkoutSummary = (
-		<WPCheckoutSidebarContent className="checkout-sidebar-content">
+		<WPCheckoutSidebarContent
+			className="checkout-sidebar-content"
+			isRsmBetterCheckout={ isRsmBetterCheckout }
+		>
 			{ isLoading && <LoadingSidebarContent /> }
 			{ ! isLoading && (
 				<>
@@ -716,11 +723,28 @@ export default function CheckoutMainContent( {
 							</CheckoutSummaryBody>
 						</CheckoutErrorBoundary>
 						{
-							// Rendered inside CheckoutSummaryArea so it sits within the sticky
-							// container and stays 24px below the order card as the page scrolls.
-							// At desktop width the upsell is always visible; at mobile it's only
-							// shown when the checkout summary is toggled open.
-							isCheckoutUiRedesignV1 && ( isSummaryVisible || isLargeViewport ) && (
+							// In treatment, render the upsell inside CheckoutSummaryArea so it
+							// sits within the sticky container and stays 24px below the order
+							// card as the page scrolls. In control it renders outside the area
+							// (legacy position).
+							isRsmBetterCheckout &&
+								isCheckoutUiRedesignV1 &&
+								( isSummaryVisible || isLargeViewport ) && (
+									<CheckoutSummaryNudgeArea>
+										<CheckoutSidebarNudge
+											addItemToCart={ addItemToCart }
+											areThereDomainProductsInCart={ areThereDomainProductsInCart }
+										/>
+									</CheckoutSummaryNudgeArea>
+								)
+						}
+					</CheckoutSummaryArea>
+					{
+						// Legacy position for the upsell, used when not in the rsm
+						// better-checkout treatment.
+						! isRsmBetterCheckout &&
+							isCheckoutUiRedesignV1 &&
+							( isSummaryVisible || isLargeViewport ) && (
 								<CheckoutSummaryNudgeArea>
 									<CheckoutSidebarNudge
 										addItemToCart={ addItemToCart }
@@ -728,8 +752,7 @@ export default function CheckoutMainContent( {
 									/>
 								</CheckoutSummaryNudgeArea>
 							)
-						}
-					</CheckoutSummaryArea>
+					}
 				</>
 			) }
 		</WPCheckoutSidebarContent>
@@ -737,7 +760,10 @@ export default function CheckoutMainContent( {
 
 	const checkoutMainContent = (
 		<RestorableProductsProvider>
-			<WPCheckoutMainContent className="checkout-main-content">
+			<WPCheckoutMainContent
+				className="checkout-main-content"
+				isRsmBetterCheckout={ isRsmBetterCheckout }
+			>
 				<CheckoutOrderBanner />
 				{ isStepContainerV2 ? (
 					<Step.Heading
@@ -753,7 +779,7 @@ export default function CheckoutMainContent( {
 				<CheckoutStepGroup
 					loadingHeader={ loadingHeader }
 					onStepChanged={ onStepChanged }
-					scrollToStepOnForwardNavigation={ ! isLargeViewport }
+					scrollToStepOnForwardNavigation={ ! ( isRsmBetterCheckout && isLargeViewport ) }
 				>
 					<PerformanceTrackerStop />
 					{ infoMessage }
@@ -941,9 +967,9 @@ export default function CheckoutMainContent( {
 						is100YearPlanTermsAccepted={ is100YearPlanTermsAccepted }
 						setIs100YearPlanTermsAccepted={ setIs100YearPlanTermsAccepted }
 						isSubmitted={ isSubmitted }
-						isLargeViewport={ isLargeViewport }
+						isLargeViewport={ isRsmBetterCheckout && isLargeViewport }
 					/>
-					{ isLargeViewport ? (
+					{ isRsmBetterCheckout && isLargeViewport ? (
 						<PortaledCheckoutFormSubmit validateForm={ validateForm } />
 					) : (
 						<CheckoutFormSubmit
@@ -970,6 +996,7 @@ export default function CheckoutMainContent( {
 					className="checkout-wrapper"
 					isLargeViewport={ isLargeViewport }
 					isCheckoutUiRedesignV1={ isCheckoutUiRedesignV1 }
+					isRsmBetterCheckout={ isRsmBetterCheckout }
 				>
 					{ isCheckoutUiRedesignV1 && ! isLargeViewport && (
 						<WPCheckoutTitle className="checkout__main-title checkout__redesign-header">
@@ -978,7 +1005,7 @@ export default function CheckoutMainContent( {
 					) }
 					{ checkoutSummary }
 					{ checkoutMainContent }
-					{ isLargeViewport && (
+					{ isRsmBetterCheckout && isLargeViewport && (
 						<>
 							<CheckoutProcessorNotice />
 							<CheckoutTrustCards cart={ responseCart } />
@@ -994,6 +1021,7 @@ export default function CheckoutMainContent( {
 			<StepContainerV2CheckoutFixer
 				isLargeViewport={ isLargeViewport }
 				isCheckoutUiRedesignV1={ isCheckoutUiRedesignV1 }
+				isRsmBetterCheckout={ isRsmBetterCheckout }
 			>
 				<Step.TwoColumnLayout
 					firstColumnWidth={ 8 }
@@ -1032,11 +1060,15 @@ export default function CheckoutMainContent( {
 						if ( isLargeViewport ) {
 							return (
 								<>
-									<div className="checkout-main-column">
-										{ checkoutMainContent }
-										<CheckoutProcessorNotice />
-										<CheckoutTrustCards cart={ responseCart } />
-									</div>
+									{ isRsmBetterCheckout ? (
+										<div className="checkout-main-column">
+											{ checkoutMainContent }
+											<CheckoutProcessorNotice />
+											<CheckoutTrustCards cart={ responseCart } />
+										</div>
+									) : (
+										checkoutMainContent
+									) }
 									{ checkoutSummary }
 								</>
 							);
@@ -1054,6 +1086,7 @@ export default function CheckoutMainContent( {
 const StepContainerV2CheckoutFixer = styled.div< {
 	isLargeViewport: boolean;
 	isCheckoutUiRedesignV1?: boolean;
+	isRsmBetterCheckout?: boolean;
 } >`
 	background: ${ colorStudio.colors[ 'White' ] };
 
@@ -1156,6 +1189,20 @@ const StepContainerV2CheckoutFixer = styled.div< {
 				background: none;
 				position: relative;
 				height: 100%;
+
+				${ ! props.isRsmBetterCheckout &&
+				css`
+					&:before {
+						content: '';
+						display: block;
+						background: var( --color-neutral-0 );
+						position: fixed;
+						top: calc( var( --step-container-v2-top-bar-height ) * -1 );
+						transform: translateX( calc( var( --left-padding ) * -1 ) );
+						width: 100vw;
+						bottom: 0;
+					}
+				` }
 			}
 
 			.checkout__summary-area,
@@ -1178,6 +1225,20 @@ const StepContainerV2CheckoutFixer = styled.div< {
 		` }
 	${ ( props ) =>
 		props.isLargeViewport &&
+		! props.isRsmBetterCheckout &&
+		css`
+			div:has( .checkout-sidebar-content ) {
+				position: sticky;
+				top: 32px;
+			}
+			.checkout__summary-area,
+			.checkout-loading-sidebar {
+				min-width: 384px;
+			}
+		` }
+	${ ( props ) =>
+		props.isLargeViewport &&
+		props.isRsmBetterCheckout &&
 		css`
 			/*
 			 * Stick the inner summary area, not the sidebar wrapper.
@@ -1250,6 +1311,14 @@ const StepContainerV2CheckoutFixer = styled.div< {
 			}
 			.checkout__summary-card > .wp-checkout-order-summary__section-title,
 			.checkout__summary-card > .wp-checkout-order-summary__amount-wrapper {
+				flex-shrink: 0;
+			}
+			/*
+			 * Lock intrinsic child sizing so the 24px gap between the sticky order
+			 * card and the two-year upsell isn't collapsed when the sticky area
+			 * reaches the bottom of its grid cell.
+			 */
+			.checkout__summary-area > * {
 				flex-shrink: 0;
 			}
 		` }
@@ -1547,15 +1616,6 @@ const CheckoutSummary = styled.div`
 	width: 100%;
 	display: flex;
 	flex-direction: column;
-
-	/*
-	 * Lock intrinsic child sizing so the 24px gap between the sticky order card
-	 * and the two-year upsell isn't collapsed when the sticky area reaches the
-	 * bottom of its grid cell and some browsers compress flex children to fit.
-	 */
-	& > * {
-		flex-shrink: 0;
-	}
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 		padding-left: 24px;
@@ -1922,32 +1982,56 @@ const SubmitButtonHeaderWrapper = styled.div`
 const WPCheckoutWrapper = styled.div< {
 	isLargeViewport?: boolean;
 	isCheckoutUiRedesignV1?: boolean;
+	isRsmBetterCheckout?: boolean;
 } >`
 	background: ${ colorStudio.colors[ 'White' ] };
 	display: grid;
 	grid-template-columns: 1fr;
-	grid-template-areas:
-		'sidebar-content'
-		'main-content'
-		'processor-notice'
-		'trust-cards';
-	align-content: start;
+	${ ( props ) =>
+		props.isRsmBetterCheckout
+			? css`
+					grid-template-areas:
+						'sidebar-content'
+						'main-content'
+						'processor-notice'
+						'trust-cards';
+					align-content: start;
+			  `
+			: css`
+					grid-template-rows: auto;
+					grid-template-areas: 'sidebar-content' 'main-content';
+			  ` }
 	justify-content: center;
 	justify-items: center;
 	min-height: 100vh;
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 		grid-template-columns: 1fr minmax( 500px, 688px ) 475px 1fr;
-		grid-template-areas:
-			'main-content main-content sidebar-content sidebar-content'
-			'. processor-notice sidebar-content sidebar-content'
-			'. trust-cards sidebar-content sidebar-content';
+		${ ( props ) =>
+			props.isRsmBetterCheckout
+				? css`
+						grid-template-areas:
+							'main-content main-content sidebar-content sidebar-content'
+							'. processor-notice sidebar-content sidebar-content'
+							'. trust-cards sidebar-content sidebar-content';
+				  `
+				: css`
+						grid-template-areas: 'main-content main-content sidebar-content sidebar-content';
+				  ` }
 		justify-items: end;
 	}
 
 	& > * {
 		box-sizing: border-box;
 		width: 100%;
+
+		${ ( props ) =>
+			! props.isRsmBetterCheckout &&
+			css`
+				@media ( ${ props.theme.breakpoints.desktopUp } ) {
+					min-height: 100vh;
+				}
+			` }
 	}
 
 	& > .checkout-trust-cards {
@@ -1976,41 +2060,58 @@ const WPCheckoutWrapper = styled.div< {
 			.checkout-sidebar-plan-upsell {
 				min-width: 384px;
 			}
-			/*
-			 * Keep the totals + Pay CTA + terms always visible regardless of
-			 * cart length. Cap the summary card itself (not the whole area)
-			 * at viewport height, scroll the line items list inside, and
-			 * lock the bottom block (subtotal/total/CTA/terms) at full size.
-			 *
-			 * The Save 19% upsell below the card sits at its natural size;
-			 * if it doesn't fit alongside the card in a short viewport,
-			 * it scrolls past the bottom — the Pay CTA is the priority.
-			 */
-			.checkout__summary-card {
-				max-height: calc( 100vh - 64px );
-				display: flex;
-				flex-direction: column;
-			}
-			.checkout__summary-card > .wp-checkout-order-summary__products-list {
-				flex: 1 1 auto;
-				min-height: 0;
-				overflow-y: auto;
-			}
-			.checkout__summary-card > .wp-checkout-order-summary__section-title,
-			.checkout__summary-card > .wp-checkout-order-summary__amount-wrapper {
-				flex-shrink: 0;
-			}
+			${ props.isRsmBetterCheckout &&
+			css`
+				/*
+				 * Keep the totals + Pay CTA + terms always visible regardless of
+				 * cart length. Cap the summary card itself (not the whole area)
+				 * at viewport height, scroll the line items list inside, and
+				 * lock the bottom block (subtotal/total/CTA/terms) at full size.
+				 *
+				 * The Save 19% upsell below the card sits at its natural size;
+				 * if it doesn't fit alongside the card in a short viewport,
+				 * it scrolls past the bottom — the Pay CTA is the priority.
+				 */
+				.checkout__summary-card {
+					max-height: calc( 100vh - 64px );
+					display: flex;
+					flex-direction: column;
+				}
+				.checkout__summary-card > .wp-checkout-order-summary__products-list {
+					flex: 1 1 auto;
+					min-height: 0;
+					overflow-y: auto;
+				}
+				.checkout__summary-card > .wp-checkout-order-summary__section-title,
+				.checkout__summary-card > .wp-checkout-order-summary__amount-wrapper {
+					flex-shrink: 0;
+				}
+				/*
+				 * Lock intrinsic child sizing so the 24px gap between the sticky
+				 * order card and the two-year upsell isn't collapsed when the
+				 * sticky area reaches the bottom of its grid cell.
+				 */
+				.checkout__summary-area > * {
+					flex-shrink: 0;
+				}
+			` }
 		` }
 	${ ( props ) =>
 		props.isCheckoutUiRedesignV1 &&
 		! props.isLargeViewport &&
 		css`
-			grid-template-areas:
-				'checkout-title-area'
-				'sidebar-content'
-				'main-content'
-				'processor-notice'
-				'trust-cards';
+			${ props.isRsmBetterCheckout
+				? css`
+						grid-template-areas:
+							'checkout-title-area'
+							'sidebar-content'
+							'main-content'
+							'processor-notice'
+							'trust-cards';
+				  `
+				: css`
+						grid-template-areas: 'checkout-title-area' 'sidebar-content' 'main-content';
+				  ` }
 			.checkout-sidebar-content {
 				background: ${ colorStudio.colors[ 'White' ] };
 			}
@@ -2358,9 +2459,14 @@ const WPCheckoutCompletedWrapper = styled.div`
 	}
 `;
 
-const WPCheckoutMainContent = styled.div`
+const WPCheckoutMainContent = styled.div< { isRsmBetterCheckout?: boolean } >`
 	grid-area: main-content;
 	margin-top: 50px;
+	${ ( props ) =>
+		! props.isRsmBetterCheckout &&
+		css`
+			min-height: 100vh;
+		` }
 
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
 		padding: 0 24px;
@@ -2370,19 +2476,34 @@ const WPCheckoutMainContent = styled.div`
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 		margin-top: calc( var( --masterbar-checkout-height ) + 24px );
 		max-width: 688px;
-		padding-block: 0;
-		padding-inline-start: 24px;
-		padding-inline-end: 64px;
+		${ ( props ) =>
+			props.isRsmBetterCheckout
+				? css`
+						padding-block: 0;
+						padding-inline-start: 24px;
+						padding-inline-end: 64px;
+				  `
+				: css`
+						padding: 0 64px 0 24px;
+
+						.rtl & {
+							padding: 0 24px 0 64px;
+						}
+				  ` }
 	}
 
-	/* On narrower desktops the 64px between form and sidebar is too tight
-	   when stacked with the sidebar's own 64px left padding. Drop the form's
-	   right padding so its content reaches col-2's right edge, matching the
-	   trust cards row beneath. Restored above 1024px where the layout has
-	   room to breathe. */
-	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) and ( max-width: 1024px ) {
-		padding-inline-end: 0;
-	}
+	${ ( props ) =>
+		props.isRsmBetterCheckout &&
+		css`
+			/* On narrower desktops the 64px between form and sidebar is too tight
+			   when stacked with the sidebar's own 64px left padding. Drop the form's
+			   right padding so its content reaches col-2's right edge, matching the
+			   trust cards row beneath. Restored above 1024px where the layout has
+			   room to breathe. */
+			@media ( ${ props.theme.breakpoints.desktopUp } ) and ( max-width: 1024px ) {
+				padding-inline-end: 0;
+			}
+		` }
 	${ ( props ) => css`
 		.checkout-line-item .checkout-line-item__remove-product {
 			font-size: 14px;
@@ -2415,7 +2536,7 @@ const WPCheckoutCompletedMainContent = styled.div`
 	}
 `;
 
-const WPCheckoutSidebarContent = styled.div`
+const WPCheckoutSidebarContent = styled.div< { isRsmBetterCheckout?: boolean } >`
 	background: ${ ( props ) => props.theme.colors.background };
 	grid-area: sidebar-content;
 	margin-top: var( --masterbar-checkout-height );
@@ -2425,13 +2546,24 @@ const WPCheckoutSidebarContent = styled.div`
 	}
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
-		background: ${ colorStudio.colors[ 'White' ] };
 		margin-top: 0;
-		padding: 144px 24px 24px 64px;
+		${ ( props ) =>
+			props.isRsmBetterCheckout
+				? css`
+						background: ${ colorStudio.colors[ 'White' ] };
+						padding: 144px 24px 24px 64px;
 
-		.rtl & {
-			padding: 144px 64px 24px 24px;
-		}
+						.rtl & {
+							padding: 144px 64px 24px 24px;
+						}
+				  `
+				: css`
+						padding: 144px 24px 144px 64px;
+
+						.rtl & {
+							padding: 144px 64px 0 24px;
+						}
+				  ` }
 	}
 `;
 const SitePreviewWrapper = styled.div`

--- a/client/my-sites/checkout/src/components/item-variation-picker/index.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/index.tsx
@@ -1,6 +1,7 @@
 import { isWpComPlan } from '@automattic/calypso-products';
 import { useViewportMatch } from '@wordpress/compose';
 import { FunctionComponent } from 'react';
+import { useRsmBetterCheckoutExperiment } from '../../hooks/use-rsm-better-checkout-experiment';
 import { ItemVariationButtonRow } from './item-variation-button-row';
 import { ItemVariationDropDown } from './item-variation-dropdown';
 import { ItemVariationRadioButtons } from './item-variation-radio-buttons';
@@ -13,9 +14,10 @@ import type { ItemVariationPickerProps } from './types';
 export const ItemVariationPicker: FunctionComponent< ItemVariationPickerProps > = ( props ) => {
 	const { selectedItem } = props;
 	const isLargeViewport = useViewportMatch( 'large', '>=' );
+	const isRsmBetterCheckout = useRsmBetterCheckoutExperiment();
 
 	if ( isWpComPlan( selectedItem.product_slug ) ) {
-		if ( isLargeViewport ) {
+		if ( isRsmBetterCheckout && isLargeViewport ) {
 			return <ItemVariationButtonRow { ...props } />;
 		}
 		return <ItemVariationRadioButtons { ...props } />;

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -47,6 +47,7 @@ import useEquivalentMonthlyTotals, {
 import { useSelector } from 'calypso/state';
 import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { useCheckoutUiRedesignExperiment } from '../hooks/use-checkout-ui-redesign-experiment';
+import { useRsmBetterCheckoutExperiment } from '../hooks/use-rsm-better-checkout-experiment';
 import getAkismetProductFeatures from '../lib/get-akismet-product-features';
 import getJetpackProductFeatures from '../lib/get-jetpack-product-features';
 import getPlanFeatures from '../lib/get-plan-features';
@@ -159,6 +160,7 @@ function CheckoutSummaryPriceList() {
 	const translate = useTranslate();
 	const monthlyPrices = useEquivalentMonthlyTotals( responseCart.products );
 	const [ , isCheckoutUiRedesignV1 ] = useCheckoutUiRedesignExperiment();
+	const isRsmBetterCheckout = useRsmBetterCheckoutExperiment();
 	const { setSlotEl } = useSubmitButtonSlot();
 	const isLargeViewport = useViewportMatch( 'large', '>=' );
 
@@ -172,7 +174,7 @@ function CheckoutSummaryPriceList() {
 	return (
 		<>
 			<CheckoutSummaryTitle className="wp-checkout-order-summary__section-title">
-				<span>{ translate( 'Summary' ) }</span>
+				<span>{ isRsmBetterCheckout ? translate( 'Summary' ) : translate( 'Your order' ) }</span>
 			</CheckoutSummaryTitle>
 			<ProductsAndCostOverridesList responseCart={ responseCart } />
 			<CheckoutSummaryAmountWrapper className="wp-checkout-order-summary__amount-wrapper">
@@ -244,7 +246,7 @@ function CheckoutSummaryPriceList() {
 						{ totalLineItem.formattedAmount }
 					</span>
 				</CheckoutSummaryTotal>
-				{ isLargeViewport && (
+				{ isRsmBetterCheckout && isLargeViewport && (
 					<>
 						<CheckoutSummaryPayButtonSlot
 							ref={ setSlotEl }

--- a/client/my-sites/checkout/src/hooks/use-rsm-better-checkout-experiment.ts
+++ b/client/my-sites/checkout/src/hooks/use-rsm-better-checkout-experiment.ts
@@ -1,0 +1,13 @@
+import { useExperiment } from 'calypso/lib/explat';
+
+const EXPERIMENT_NAME = 'calypso_rsm_better_checkout';
+const QUERY_PARAM = 'rsm_better_checkout';
+
+export function useRsmBetterCheckoutExperiment(): boolean {
+	const [ , assignment ] = useExperiment( EXPERIMENT_NAME );
+	const searchParams = new URLSearchParams( window.location.search );
+	if ( searchParams.get( QUERY_PARAM ) === '1' ) {
+		return true;
+	}
+	return assignment?.variationName === 'treatment';
+}


### PR DESCRIPTION
Part of #

## Proposed Changes

* Add `useRsmBetterCheckoutExperiment` hook in `client/my-sites/checkout/src/hooks/`. Wraps `useExperiment( 'calypso_rsm_better_checkout' )` from `calypso/lib/explat`, returns a single boolean (no `isLoadingExperimentAssignment`), and accepts `?rsm_better_checkout=1` as a manual treatment override for QA. Mirrors the existing `useCheckoutUiRedesignExperiment` pattern.
* Gate every behavioral and CSS change on this branch behind the new boolean. Control falls back to the prior behavior in every spot the branch had touched against trunk.

### Where the gating lives

* `checkout-main-content.tsx` — the boolean is read once and used to gate: the upsell-position move (inside vs outside `CheckoutSummaryArea`), `scrollToStepOnForwardNavigation`, the `<PortaledCheckoutFormSubmit>` ↔ `<CheckoutFormSubmit>` switch, the `<CheckoutTermsAndCheckboxes isLargeViewport>` prop, the trust-cards / processor-notice rendering on both layout paths, and the `.checkout-main-column` wrapper. It is also threaded as a styled-component prop into `WPCheckoutWrapper`, `StepContainerV2CheckoutFixer`, `WPCheckoutMainContent`, and `WPCheckoutSidebarContent` — restoring the removed `&:before` pseudo, the old `div:has(.checkout-sidebar-content)` sticky selector, the old grid-template-areas, the old paddings, and the `min-height: 100vh` rule when control.
* `wp-checkout-order-summary.tsx` — gates the `'Summary'` ↔ `'Your order'` title swap and the new sidebar Pay-button slot block.
* `item-variation-picker/index.tsx` — gates the desktop `<ItemVariationButtonRow>` render; control falls back to the radio buttons.

The new files this branch added (`checkout-trust-cards`, `checkout-processor-notice`, `checkout-pay-button-footer`, `checkout-summary-refund-windows`, `checkout-terms-modal`, `submit-button-slot`, `item-variation-button-row`) need no internal gating because they only render from gated call sites. Refactor-only changes (`refund-policies` helper extraction, `cost-overrides-list` className addition, `CheckoutMoneyBackGuarantee` import-path swap, `checkout-terms` opt-in `expandReadMore` prop with default `false`) preserve control behavior automatically.

## Why are these changes being made?

To run the redesign as an A/B test rather than a hard rollout. Without gating, every change layered onto checkout this branch would ship to 100% of traffic; the experiment lets us measure impact on conversion before committing.

The pre-existing `isCheckoutUiRedesignV1` flag continues to gate prior redesign work independently — the new experiment gates only this branch's diff against the merge-base. `calypso_rsm_better_checkout` only renders coherently when the prior redesign is also on; that is an experiment-targeting concern, not a code concern.

## Testing Instructions

* Append `?rsm_better_checkout=1` to a checkout URL to force into the treatment branch without an ExPlat assignment. Verify the new layout renders end-to-end (sticky summary, sidebar Pay CTA portal, trust cards row, processor notice, button-row variation picker on desktop).
* Without the query param (and without an experiment assignment) verify checkout looks and behaves identically to trunk: original sticky selector, original grid template, the original `<CheckoutFormSubmit>` rendering with money-back footer, original "Your order" title, radio-button variation picker on desktop.
* Manual smoke test on at least one cart on each path (legacy `WPCheckoutWrapper` and `StepContainerV2`) at desktop and mobile widths.
* No tests added — this PR introduces no new behavior, only gating around existing branch work.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)