### PR TITLE
Remove CommonJS browser require usage

### DIFF
--- a/client/me/security/controller.jsx
+++ b/client/me/security/controller.jsx
@@ -29,8 +29,8 @@ export function password( context, next ) {
 	next();
 }
 
-export function twoStep( context, next ) {
-	const TwoStepComponent = require( 'calypso/me/two-step' ).default;
+export async function twoStep( context, next ) {
+	const { default: TwoStepComponent } = await import( 'calypso/me/two-step' );
 
 	context.primary = createElement( TwoStepComponent, {
 		path: context.path,

--- a/client/state/reader/posts/actions.js
+++ b/client/state/reader/posts/actions.js
@@ -1,8 +1,10 @@
 import { filter, forEach, partition, get } from 'lodash';
 import { bumpStat } from 'calypso/lib/analytics/mc';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import wpcom from 'calypso/lib/wp';
 import readerContentWidth from 'calypso/reader/lib/content-width';
 import { keyForPost } from 'calypso/reader/post-key';
+import { pageViewForPost } from 'calypso/reader/stats';
 import { receiveLikes } from 'calypso/state/posts/likes/actions';
 import { READER_POSTS_RECEIVE, READER_POST_SEEN } from 'calypso/state/reader/action-types';
 import { runFastRules, runSlowRules } from './normalization-rules';
@@ -10,17 +12,8 @@ import { hasPostBeenSeen } from './selectors';
 
 import 'calypso/state/reader/init';
 
-// TODO: make underlying lib/analytics/tracks and reader/stats capable of existing in test code without mocks
-// OR switch to analytics middleware
-let tracks = { recordEvent: () => {} };
-let pageViewForPost = () => {};
-if ( process.env.NODE_ENV !== 'test' ) {
-	pageViewForPost = require( 'calypso/reader/stats' ).pageViewForPost;
-	tracks = require( 'calypso/lib/analytics/tracks' );
-}
-
 function trackRailcarRender( post ) {
-	tracks.recordTracksEvent( 'calypso_traintracks_render', post.railcar );
+	recordTracksEvent( 'calypso_traintracks_render', post.railcar );
 }
 
 // helper that hides promise rejections so they return successfully with null instead of rejecting

--- a/client/state/reader/posts/test/actions.js
+++ b/client/state/reader/posts/test/actions.js
@@ -1,9 +1,9 @@
 import { bumpStat } from 'calypso/lib/analytics/mc';
 import * as tracks from 'calypso/lib/analytics/tracks';
 import wp from 'calypso/lib/wp';
+import { pageViewForPost } from 'calypso/reader/stats';
 import { READER_POSTS_RECEIVE, READER_POST_SEEN } from 'calypso/state/reader/action-types';
 import * as actions from '../actions';
-const { pageViewForPost } = require( 'calypso/reader/stats' );
 
 jest.mock( 'calypso/reader/stats', () => ( { pageViewForPost: jest.fn() } ) );
 
@@ -99,8 +99,8 @@ describe( 'actions', () => {
 				payload: { post, site },
 			} );
 
-			// expect( pageViewForPost.mock.calls.length ).toBe( 1 );
-			expect( bumpStat.mock.calls.length ).toBe( 1 );
+			expect( pageViewForPost ).toHaveBeenCalledTimes( 1 );
+			expect( bumpStat ).toHaveBeenCalledTimes( 1 );
 		} );
 	} );
 } );


### PR DESCRIPTION
Part of #110140

## Proposed Changes

* Convert the `/me/security` two-step route loader from `require()` to a dynamic `import()`.
* Replace the Reader posts actions test-sensitive `require()` block with static ESM imports.
* Update the Reader posts actions unit test to use Jest mocks for Reader stats, keeping the page-view assertion active.

## Why are these changes being made?

This extracts the narrow CommonJS/browser route cleanup from #110140 into a smaller PR

Basically we should move away CommonJS and towards ESM.

## Testing Instructions

* Smoke test `/me/security/two-step` while logged in. Confirm the Two-Step Authentication page loads and the rest of the `/me/security` navigation still works.
* Smoke test `/reader` while logged in. Confirm the following stream loads posts.
* From `/reader`, open any post and confirm the full-post route loads, for example `/reader/feeds/:feed_id/posts/:post_id` or `/reader/blogs/:blog_id/posts/:post_id`.
* In browser DevTools, confirm Reader Tracks requests are still emitted during the smoke test. Filter Network requests for `pixel.wp.com/t.gif` and look for events such as `calypso_reader_following_loaded` on `/reader` and `calypso_reader_article_opened` when opening a full post. If the stream includes railcar-backed posts, also confirm `calypso_traintracks_render`.
* Optional focused checks:
    * `yarn eslint --ext .js,.jsx client/me/security/controller.jsx client/state/reader/posts/actions.js client/state/reader/posts/test/actions.js`
    * `yarn test-client client/state/reader/posts/test/actions.js`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
