### PR TITLE
Reader: Replace trendingUp WP Icon with trophy Gridicon without importing the whole set

### DIFF
--- a/apps/notifications/src/app/note-icon/trophy-gridicon.tsx
+++ b/apps/notifications/src/app/note-icon/trophy-gridicon.tsx
@@ -1,0 +1,15 @@
+import { SVG, G, Path } from '@wordpress/primitives';
+
+const trophyGridicon: JSX.Element = (
+	<SVG version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" viewBox="0 0 24 24">
+		<G id="trophy">
+			<Path
+				d="M18,5.062V3H6v2.062H2V8c0,2.525,1.889,4.598,4.324,4.932C7.024,14.99,8.809,16.542,11,16.91V18c0,1.105-0.895,2-2,2H8v2h1
+		h2h2h2h1v-2h-1c-1.105,0-2-0.895-2-2v-1.09c2.191-0.368,3.976-1.92,4.676-3.978C20.111,12.598,22,10.525,22,8V5.062H18z M4,8V7.062
+		h2v3.766C4.836,10.416,4,9.304,4,8z M20,8c0,1.304-0.836,2.416-2,2.829V7.062h2V8z"
+			/>
+		</G>
+	</SVG>
+);
+
+export default trophyGridicon;

--- a/apps/notifications/src/app/note-list/dataviews.tsx
+++ b/apps/notifications/src/app/note-list/dataviews.tsx
@@ -9,13 +9,13 @@ import {
 	lockOutline,
 	plus,
 	store,
-	trendingUp,
 	thumbsUp,
 	update,
 } from '@wordpress/icons';
 import clsx from 'clsx';
 import { html } from '../../panel/indices-to-html';
 import NoteIcon from '../note-icon';
+import trophyGridicon from '../note-icon/trophy-gridicon';
 import type { Note } from '../types';
 import type { Field } from '@wordpress/dataviews';
 import type { JSX } from 'react';
@@ -30,7 +30,7 @@ const iconMap: { [ key in string ]: JSX.Element } = {
 	'\uf806': chartBar, // stats
 	'\uf805': update, // reblog
 	'\uf408': thumbsUp, // star
-	'\uf804': trendingUp, // trophy
+	'\uf804': trophyGridicon, // trophy
 	'\uf467': comment, // reply
 	'\uf414': caution, // warning
 	'\uf418': check,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes RSM-1890

## Proposed Changes

* Add a lightweight `trophy` Gridicon to the Note v2 app, replacing the `trendingUp` WP Icon used for achievement notifications.


| Before | After |
|--------|--------|
| <img width="426" height="71" alt="Screenshot 2026-05-05 at 10 41 57" src="https://github.com/user-attachments/assets/d0cbd140-6d5f-45df-825c-e4b663cd35a1" /> | <img width="426" height="71" alt="Screenshot 2026-05-05 at 10 41 48" src="https://github.com/user-attachments/assets/7e4a785e-bf91-4fa4-bf8b-608d58b7275d" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Ideally, we would only use WP Icons, but the set is missing a trophy icon, which is required to keep achievement notifications consistent across the platform.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enter the MSD (http://my.localhost:3000/sites) and open the notifications panel.
* Trigger an achievement if needed (PCYsg-1d0C-p2#test-it)
* Confirm the little badge in the achievement notification is a trophy instead of a trending up arrow.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?