### PR TITLE
Unified Connection: foundation module for plugin family detection (1/5)

### DIFF
--- a/client/jetpack-connect/connection-content/families.ts
+++ b/client/jetpack-connect/connection-content/families.ts
@@ -1,0 +1,42 @@
+/**
+ * Family classification for plugins that use the unified Jetpack
+ * connection flow.
+ *
+ * Used to drive priority-based UI decisions across the flow — titles,
+ * subtitles, featured "Connection enables" cards, and the "Also used by"
+ * overflow row.
+ */
+export type Family = 'a4a' | 'woo' | 'jetpack' | 'other';
+
+/**
+ * Priority order for surfacing families in copy and feature cards.
+ * A4A wins, then Woo, then Jetpack, then anything else.
+ *
+ * Featured cards and subtitle slot picking iterate this array, so changing
+ * the order changes the entire flow's hierarchy.
+ */
+export const FAMILY_PRIORITY: readonly Family[] = [ 'a4a', 'woo', 'jetpack', 'other' ];
+
+/**
+ * Determine the family for a given plugin slug.
+ *
+ * Falls back to `'other'` for any slug that doesn't match a known family
+ * prefix — unknown plugins never block the connection flow, they just land
+ * in the generic overflow bucket.
+ * @param slug Plugin slug exactly as it arrives in the `plugins` query
+ *             parameter. Slugs are matched by family prefix so that future
+ *             plugin additions in a known family don't require a registry
+ *             update before they can be classified.
+ */
+export function getFamilyFromSlug( slug: string ): Family {
+	if ( slug.startsWith( 'automattic' ) ) {
+		return 'a4a';
+	}
+	if ( slug.startsWith( 'woocommerce' ) ) {
+		return 'woo';
+	}
+	if ( slug === 'jetpack' || slug.startsWith( 'jetpack-' ) ) {
+		return 'jetpack';
+	}
+	return 'other';
+}

--- a/client/jetpack-connect/connection-content/index.ts
+++ b/client/jetpack-connect/connection-content/index.ts
@@ -1,0 +1,11 @@
+export type { Family } from './families';
+export { FAMILY_PRIORITY, getFamilyFromSlug } from './families';
+export type { PluginEntry } from './plugin-registry';
+export { PLUGIN_REGISTRY, getPluginEntry, getLogoForFamilies } from './plugin-registry';
+export {
+	getPresentFamilies,
+	getTopFamilies,
+	isStore,
+	hasFullJetpack,
+	getOverflowSlugs,
+} from './selectors';

--- a/client/jetpack-connect/connection-content/plugin-registry.ts
+++ b/client/jetpack-connect/connection-content/plugin-registry.ts
@@ -1,0 +1,74 @@
+import jetpackConnectA8cLogo from '../images/jetpack-connect-a8c.svg';
+import jetpackConnectAllLogo from '../images/jetpack-connect-all.svg';
+import jetpackConnectWooLogo from '../images/jetpack-connect-woo.svg';
+import jetpackConnectLogo from '../images/jetpack-connect.svg';
+import type { Family } from './families';
+
+/**
+ * Registry entry for a known plugin participating in the unified connection flow.
+ *
+ * PR 1 keeps each entry minimal — just the family classification and a flag
+ * for the full Jetpack plugin. Future PRs extend this with display name,
+ * card title/description, and feature bullets, which is why the entry is
+ * its own typed shape rather than a bare value.
+ */
+export interface PluginEntry {
+	slug: string;
+	family: Family;
+	/** True only for the full Jetpack plugin (not the individual sub-plugins). */
+	isFullJetpack?: boolean;
+}
+
+/**
+ * Slug → entry map for plugins we explicitly recognise.
+ *
+ * The registry is additive: callers should always treat unknown slugs as a
+ * graceful fallback (resolve their family via `getFamilyFromSlug`) rather
+ * than relying on the entry being present here.
+ */
+export const PLUGIN_REGISTRY: Record< string, PluginEntry > = {
+	jetpack: { slug: 'jetpack', family: 'jetpack', isFullJetpack: true },
+	'jetpack-backup': { slug: 'jetpack-backup', family: 'jetpack' },
+	'jetpack-protect': { slug: 'jetpack-protect', family: 'jetpack' },
+	'jetpack-boost': { slug: 'jetpack-boost', family: 'jetpack' },
+	'jetpack-search': { slug: 'jetpack-search', family: 'jetpack' },
+	'jetpack-social': { slug: 'jetpack-social', family: 'jetpack' },
+	'jetpack-videopress': { slug: 'jetpack-videopress', family: 'jetpack' },
+	woocommerce: { slug: 'woocommerce', family: 'woo' },
+	'woocommerce-payments': { slug: 'woocommerce-payments', family: 'woo' },
+	'automattic-for-agencies-client': {
+		slug: 'automattic-for-agencies-client',
+		family: 'a4a',
+	},
+};
+
+/**
+ * Look up a plugin's registry entry by slug. Returns `undefined` for slugs
+ * that aren't explicitly registered — callers must handle the fallback.
+ */
+export function getPluginEntry( slug: string ): PluginEntry | undefined {
+	return PLUGIN_REGISTRY[ slug ];
+}
+
+/**
+ * Pick the composite connector logo SVG for a set of families present in
+ * the active plugins.
+ *
+ * Mirrors the PHP `get_connector_logo_url()` logic in
+ * `class-jetpack-connector.php` so Calypso and Jetpack stay aligned.
+ */
+export function getLogoForFamilies( families: readonly Family[] ): string {
+	const hasWoo = families.includes( 'woo' );
+	const hasA4a = families.includes( 'a4a' );
+
+	if ( hasWoo && hasA4a ) {
+		return jetpackConnectAllLogo;
+	}
+	if ( hasWoo ) {
+		return jetpackConnectWooLogo;
+	}
+	if ( hasA4a ) {
+		return jetpackConnectA8cLogo;
+	}
+	return jetpackConnectLogo;
+}

--- a/client/jetpack-connect/connection-content/selectors.ts
+++ b/client/jetpack-connect/connection-content/selectors.ts
@@ -1,0 +1,57 @@
+import { FAMILY_PRIORITY, getFamilyFromSlug } from './families';
+import { getPluginEntry } from './plugin-registry';
+import type { Family } from './families';
+
+/**
+ * Return families present in the active plugin list, ordered by priority
+ * (A4A → Woo → Jetpack → Other). Each family appears at most once.
+ */
+export function getPresentFamilies( pluginSlugs: readonly string[] ): Family[] {
+	const present = new Set< Family >();
+	for ( const slug of pluginSlugs ) {
+		present.add( getFamilyFromSlug( slug ) );
+	}
+	return FAMILY_PRIORITY.filter( ( family ) => present.has( family ) );
+}
+
+/**
+ * Return up to `max` highest-priority families present in the active plugin
+ * list. Defaults to two to match the "Connection enables" two-up layout.
+ */
+export function getTopFamilies( pluginSlugs: readonly string[], max = 2 ): Family[] {
+	return getPresentFamilies( pluginSlugs ).slice( 0, max );
+}
+
+/**
+ * Return true when any active plugin is part of the WooCommerce family.
+ *
+ * The single decision point for whether the flow refers to the property as
+ * "store" or "site" in user-facing copy.
+ */
+export function isStore( pluginSlugs: readonly string[] ): boolean {
+	return pluginSlugs.some( ( slug ) => getFamilyFromSlug( slug ) === 'woo' );
+}
+
+/**
+ * Return true when the full Jetpack plugin is among the active plugins.
+ *
+ * Used by later PRs to choose between the "full Jetpack" copy variants and
+ * the individual-plugin variants.
+ */
+export function hasFullJetpack( pluginSlugs: readonly string[] ): boolean {
+	return pluginSlugs.some( ( slug ) => getPluginEntry( slug )?.isFullJetpack === true );
+}
+
+/**
+ * Active plugin slugs that aren't represented by a featured family card.
+ *
+ * `featuredFamilies` is typically the result of `getTopFamilies(...)`. Any
+ * plugin whose family isn't featured falls into the "Also used by" overflow
+ * row that lands in PR 4.
+ */
+export function getOverflowSlugs(
+	pluginSlugs: readonly string[],
+	featuredFamilies: readonly Family[]
+): string[] {
+	return pluginSlugs.filter( ( slug ) => ! featuredFamilies.includes( getFamilyFromSlug( slug ) ) );
+}

--- a/client/jetpack-connect/connection-content/test/families.test.ts
+++ b/client/jetpack-connect/connection-content/test/families.test.ts
@@ -1,0 +1,52 @@
+import { FAMILY_PRIORITY, getFamilyFromSlug } from '../families';
+import type { Family } from '../families';
+
+describe( 'FAMILY_PRIORITY', () => {
+	test( 'orders A4A → Woo → Jetpack → Other', () => {
+		expect( FAMILY_PRIORITY ).toEqual( [ 'a4a', 'woo', 'jetpack', 'other' ] );
+	} );
+} );
+
+describe( 'getFamilyFromSlug', () => {
+	test.each< [ string, Family ] >( [
+		[ 'jetpack', 'jetpack' ],
+		[ 'jetpack-backup', 'jetpack' ],
+		[ 'jetpack-protect', 'jetpack' ],
+		[ 'jetpack-boost', 'jetpack' ],
+		[ 'jetpack-search', 'jetpack' ],
+		[ 'jetpack-social', 'jetpack' ],
+		[ 'jetpack-videopress', 'jetpack' ],
+	] )( 'classifies %s as jetpack', ( slug, expected ) => {
+		expect( getFamilyFromSlug( slug ) ).toBe( expected );
+	} );
+
+	test.each< [ string, Family ] >( [
+		[ 'woocommerce', 'woo' ],
+		[ 'woocommerce-payments', 'woo' ],
+		[ 'woocommerce-experimental', 'woo' ],
+	] )( 'classifies %s as woo', ( slug, expected ) => {
+		expect( getFamilyFromSlug( slug ) ).toBe( expected );
+	} );
+
+	test.each< [ string, Family ] >( [
+		[ 'automattic-for-agencies-client', 'a4a' ],
+		[ 'automattic-for-agencies', 'a4a' ],
+		[ 'automattic-client', 'a4a' ],
+	] )( 'classifies %s as a4a', ( slug, expected ) => {
+		expect( getFamilyFromSlug( slug ) ).toBe( expected );
+	} );
+
+	test.each< [ string ] >( [
+		[ 'unknown-plugin' ],
+		[ 'my-custom-plugin' ],
+		[ 'jetpacky' ],
+		[ 'wpcom-something' ],
+		[ '' ],
+	] )( 'classifies %s as other', ( slug ) => {
+		expect( getFamilyFromSlug( slug ) ).toBe( 'other' );
+	} );
+
+	test( 'jetpacky is not jetpack family (requires exact slug or jetpack- prefix)', () => {
+		expect( getFamilyFromSlug( 'jetpacky' ) ).toBe( 'other' );
+	} );
+} );

--- a/client/jetpack-connect/connection-content/test/plugin-registry.test.ts
+++ b/client/jetpack-connect/connection-content/test/plugin-registry.test.ts
@@ -1,0 +1,80 @@
+import { PLUGIN_REGISTRY, getLogoForFamilies, getPluginEntry } from '../plugin-registry';
+
+describe( 'PLUGIN_REGISTRY', () => {
+	test( 'every entry agrees with its key on slug', () => {
+		for ( const [ slug, entry ] of Object.entries( PLUGIN_REGISTRY ) ) {
+			expect( entry.slug ).toBe( slug );
+		}
+	} );
+
+	test( 'isFullJetpack is set only on the full Jetpack entry', () => {
+		expect( PLUGIN_REGISTRY.jetpack.isFullJetpack ).toBe( true );
+		for ( const [ slug, entry ] of Object.entries( PLUGIN_REGISTRY ) ) {
+			if ( slug === 'jetpack' ) {
+				continue;
+			}
+			expect( entry.isFullJetpack ).toBeFalsy();
+		}
+	} );
+
+	test( 'covers the ten plugins enumerated in the unified-connection spec', () => {
+		const expected = [
+			'jetpack',
+			'jetpack-backup',
+			'jetpack-protect',
+			'jetpack-boost',
+			'jetpack-search',
+			'jetpack-social',
+			'jetpack-videopress',
+			'woocommerce',
+			'woocommerce-payments',
+			'automattic-for-agencies-client',
+		];
+		for ( const slug of expected ) {
+			expect( PLUGIN_REGISTRY[ slug ] ).toBeDefined();
+		}
+	} );
+} );
+
+describe( 'getPluginEntry', () => {
+	test( 'returns the entry for known slugs', () => {
+		expect( getPluginEntry( 'jetpack' )?.family ).toBe( 'jetpack' );
+		expect( getPluginEntry( 'woocommerce' )?.family ).toBe( 'woo' );
+		expect( getPluginEntry( 'automattic-for-agencies-client' )?.family ).toBe( 'a4a' );
+	} );
+
+	test( 'returns undefined for unknown slugs', () => {
+		expect( getPluginEntry( 'unknown-plugin' ) ).toBeUndefined();
+		expect( getPluginEntry( 'jetpack-search-extra' ) ).toBeUndefined();
+		expect( getPluginEntry( '' ) ).toBeUndefined();
+	} );
+} );
+
+describe( 'getLogoForFamilies', () => {
+	test( 'returns the default Jetpack logo when no families are present', () => {
+		expect( getLogoForFamilies( [] ) ).toMatch( /jetpack-connect\.svg$/ );
+	} );
+
+	test( 'returns the default Jetpack logo for jetpack-only and other-only sets', () => {
+		expect( getLogoForFamilies( [ 'jetpack' ] ) ).toMatch( /jetpack-connect\.svg$/ );
+		expect( getLogoForFamilies( [ 'jetpack', 'other' ] ) ).toMatch( /jetpack-connect\.svg$/ );
+		expect( getLogoForFamilies( [ 'other' ] ) ).toMatch( /jetpack-connect\.svg$/ );
+	} );
+
+	test( 'returns the Woo composite when only Woo is present', () => {
+		expect( getLogoForFamilies( [ 'woo' ] ) ).toMatch( /jetpack-connect-woo\.svg$/ );
+		expect( getLogoForFamilies( [ 'woo', 'jetpack' ] ) ).toMatch( /jetpack-connect-woo\.svg$/ );
+	} );
+
+	test( 'returns the A8C composite when only A4A is present', () => {
+		expect( getLogoForFamilies( [ 'a4a' ] ) ).toMatch( /jetpack-connect-a8c\.svg$/ );
+		expect( getLogoForFamilies( [ 'a4a', 'jetpack' ] ) ).toMatch( /jetpack-connect-a8c\.svg$/ );
+	} );
+
+	test( 'returns the all-families composite when both Woo and A4A are present', () => {
+		expect( getLogoForFamilies( [ 'woo', 'a4a' ] ) ).toMatch( /jetpack-connect-all\.svg$/ );
+		expect( getLogoForFamilies( [ 'a4a', 'woo', 'jetpack' ] ) ).toMatch(
+			/jetpack-connect-all\.svg$/
+		);
+	} );
+} );

--- a/client/jetpack-connect/connection-content/test/selectors.test.ts
+++ b/client/jetpack-connect/connection-content/test/selectors.test.ts
@@ -1,0 +1,114 @@
+import {
+	getOverflowSlugs,
+	getPresentFamilies,
+	getTopFamilies,
+	hasFullJetpack,
+	isStore,
+} from '../selectors';
+
+describe( 'getPresentFamilies', () => {
+	test( 'returns an empty array when no plugins are active', () => {
+		expect( getPresentFamilies( [] ) ).toEqual( [] );
+	} );
+
+	test( 'orders by priority regardless of input order', () => {
+		expect(
+			getPresentFamilies( [ 'jetpack', 'woocommerce', 'automattic-for-agencies-client' ] )
+		).toEqual( [ 'a4a', 'woo', 'jetpack' ] );
+		expect( getPresentFamilies( [ 'unknown', 'jetpack' ] ) ).toEqual( [ 'jetpack', 'other' ] );
+	} );
+
+	test( 'deduplicates families when multiple plugins share one', () => {
+		expect( getPresentFamilies( [ 'jetpack', 'jetpack-backup', 'jetpack-boost' ] ) ).toEqual( [
+			'jetpack',
+		] );
+		expect( getPresentFamilies( [ 'woocommerce', 'woocommerce-payments' ] ) ).toEqual( [ 'woo' ] );
+	} );
+} );
+
+describe( 'getTopFamilies', () => {
+	test( 'returns at most two families by default', () => {
+		expect(
+			getTopFamilies( [ 'automattic-for-agencies-client', 'woocommerce', 'jetpack' ] )
+		).toEqual( [ 'a4a', 'woo' ] );
+	} );
+
+	test( 'respects the max argument when provided', () => {
+		expect(
+			getTopFamilies(
+				[ 'automattic-for-agencies-client', 'woocommerce', 'jetpack', 'unknown-plugin' ],
+				3
+			)
+		).toEqual( [ 'a4a', 'woo', 'jetpack' ] );
+		expect( getTopFamilies( [ 'automattic-for-agencies-client', 'woocommerce' ], 1 ) ).toEqual( [
+			'a4a',
+		] );
+	} );
+
+	test( 'returns whatever is present even if fewer than max', () => {
+		expect( getTopFamilies( [ 'jetpack' ] ) ).toEqual( [ 'jetpack' ] );
+		expect( getTopFamilies( [] ) ).toEqual( [] );
+	} );
+} );
+
+describe( 'isStore', () => {
+	test( 'is true when any Woo-family plugin is active', () => {
+		expect( isStore( [ 'woocommerce' ] ) ).toBe( true );
+		expect( isStore( [ 'woocommerce-payments' ] ) ).toBe( true );
+		expect( isStore( [ 'jetpack', 'woocommerce' ] ) ).toBe( true );
+		expect( isStore( [ 'automattic-for-agencies-client', 'woocommerce', 'jetpack' ] ) ).toBe(
+			true
+		);
+	} );
+
+	test( 'is false otherwise', () => {
+		expect( isStore( [] ) ).toBe( false );
+		expect( isStore( [ 'jetpack' ] ) ).toBe( false );
+		expect( isStore( [ 'jetpack-boost', 'unknown' ] ) ).toBe( false );
+		expect( isStore( [ 'automattic-for-agencies-client' ] ) ).toBe( false );
+	} );
+} );
+
+describe( 'hasFullJetpack', () => {
+	test( 'is true only when the full Jetpack plugin is present', () => {
+		expect( hasFullJetpack( [ 'jetpack' ] ) ).toBe( true );
+		expect( hasFullJetpack( [ 'jetpack-backup', 'jetpack' ] ) ).toBe( true );
+	} );
+
+	test( 'is false for individual Jetpack plugins only', () => {
+		expect( hasFullJetpack( [ 'jetpack-backup' ] ) ).toBe( false );
+		expect( hasFullJetpack( [ 'jetpack-protect', 'jetpack-boost' ] ) ).toBe( false );
+	} );
+
+	test( 'is false for empty and unknown sets', () => {
+		expect( hasFullJetpack( [] ) ).toBe( false );
+		expect( hasFullJetpack( [ 'unknown', 'woocommerce' ] ) ).toBe( false );
+	} );
+} );
+
+describe( 'getOverflowSlugs', () => {
+	test( 'returns slugs whose family is not in the featured list', () => {
+		expect(
+			getOverflowSlugs(
+				[ 'automattic-for-agencies-client', 'woocommerce', 'jetpack', 'unknown-plugin' ],
+				[ 'a4a', 'woo' ]
+			)
+		).toEqual( [ 'jetpack', 'unknown-plugin' ] );
+	} );
+
+	test( 'returns all slugs when featured list is empty', () => {
+		expect( getOverflowSlugs( [ 'jetpack', 'woocommerce' ], [] ) ).toEqual( [
+			'jetpack',
+			'woocommerce',
+		] );
+	} );
+
+	test( 'returns no slugs when every family is featured', () => {
+		expect(
+			getOverflowSlugs(
+				[ 'automattic-for-agencies-client', 'woocommerce', 'jetpack' ],
+				[ 'a4a', 'woo', 'jetpack' ]
+			)
+		).toEqual( [] );
+	} );
+} );

--- a/client/jetpack-connect/connector-branding-config.js
+++ b/client/jetpack-connect/connector-branding-config.js
@@ -1,9 +1,6 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, chartBar, next, share } from '@wordpress/icons';
-import jetpackConnectA8cLogo from './images/jetpack-connect-a8c.svg';
-import jetpackConnectAllLogo from './images/jetpack-connect-all.svg';
-import jetpackConnectWooLogo from './images/jetpack-connect-woo.svg';
-import jetpackConnectLogo from './images/jetpack-connect.svg';
+import { getLogoForFamilies, getPresentFamilies, isStore } from './connection-content';
 
 const DEFAULT_PERMISSIONS = [
 	{
@@ -37,28 +34,7 @@ const DEFAULT_PERMISSIONS_TITLE = ( { siteURL } = {} ) =>
  * @returns {string} Imported SVG URL for the matching connector logo.
  */
 export function getConnectorLogoUrl( pluginSlugs = [] ) {
-	let hasWoo = false;
-	let hasA4a = false;
-
-	for ( const slug of pluginSlugs ) {
-		if ( slug.startsWith( 'woocommerce' ) ) {
-			hasWoo = true;
-		}
-		if ( slug.startsWith( 'automattic' ) ) {
-			hasA4a = true;
-		}
-	}
-
-	if ( hasWoo && hasA4a ) {
-		return jetpackConnectAllLogo;
-	}
-	if ( hasWoo ) {
-		return jetpackConnectWooLogo;
-	}
-	if ( hasA4a ) {
-		return jetpackConnectA8cLogo;
-	}
-	return jetpackConnectLogo;
+	return getLogoForFamilies( getPresentFamilies( pluginSlugs ) );
 }
 
 /**
@@ -71,10 +47,11 @@ export function getConnectorLogoUrl( pluginSlugs = [] ) {
  * @returns {{ logo: string, title: string, subtitle: string, permissionsTitle: ( ( ctx?: { siteURL?: string } ) => string ), permissions: Array }} Branding object.
  */
 export function getConnectorBranding( pluginSlugs = [] ) {
-	const logo = getConnectorLogoUrl( pluginSlugs );
-	const hasWoo = pluginSlugs.some( ( slug ) => slug.startsWith( 'woocommerce' ) );
-	const title = hasWoo ? __( 'Connect your store' ) : __( 'Connect your site' );
-	const subtitle = hasWoo
+	const families = getPresentFamilies( pluginSlugs );
+	const hasStore = isStore( pluginSlugs );
+	const logo = getLogoForFamilies( families );
+	const title = hasStore ? __( 'Connect your store' ) : __( 'Connect your site' );
+	const subtitle = hasStore
 		? __( 'Connect your store to unlock powerful features.' )
 		: __( 'Connect your site to unlock powerful features.' );
 


### PR DESCRIPTION
Part of CONNECT-186

## Proposed Changes

- New `client/jetpack-connect/connection-content/` module — single source of truth for plugin family classification, priority, and shared selectors used across the unified connection flow:
  - `families.ts` — `Family` type, `FAMILY_PRIORITY` (`a4a` → `woo` → `jetpack` → `other`), `getFamilyFromSlug`
  - `plugin-registry.ts` — `PLUGIN_REGISTRY` for the 10 known connector plugins (full Jetpack + 6 individual Jetpack plugins, WooCommerce + WooPayments, Automattic for Agencies), `getPluginEntry`, `getLogoForFamilies` (replaces the inline logo branching that lived in `connector-branding-config.js`)
  - `selectors.ts` — `getPresentFamilies`, `getTopFamilies`, `isStore`, `hasFullJetpack`, `getOverflowSlugs`
  - `index.ts` — barrel
- `client/jetpack-connect/connector-branding-config.js` refactored to delegate internals to the new module while keeping its public API (`getConnectorBranding`, `getConnectorLogoUrl`) and string output identical.
- Three colocated test files under `connection-content/test/` covering priority ordering, slug → family classification, logo resolution, and overflow handling.

## Why are these changes being made?

This is the foundation PR for a multi-step rework of the unified Jetpack connection flow's copy system (titles, subtitles, "Connection enables" features section). Later PRs in the stack will:

1. (PR 2) Swap the H1 to "Connect your account" and add a `site` vs `store` helper plus an interim subtitle slot.
2. (PR 3) Wire 17 family-combination subtitles across login + auth + signup.
3. (PR 4) Replace `<PermissionsList>` with a new family-priority-driven `<FeaturesSection>`.
4. (PR 5) Final polish: signup parity, `jetpack-onboarding` strict-equality cleanup, dead-prop removal, plugins as a top-level login query arg, E2E coverage.

This PR lands as a no-op refactor — same strings ship, same logic — but gives every later PR a single, well-tested place to ask "which families are present here?", "is this a store?", "what's the right composite logo?".

## Testing Instructions

This PR has no user-visible changes. To verify the refactor:

- Run `yarn test-client client/jetpack-connect/` — all 11 suites / 140 tests pass, including the existing `connector-branding-config` snapshot tests.
- Sanity-check the connector flow on a self-hosted Jetpack site with `from=jetpack-connector` and various `plugins=` combinations (`jetpack`, `woocommerce`, `automattic-for-agencies-client`, combinations) — every flow should look identical to trunk: same logo, same H1, same subtitle, same permissions list.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed?
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation? *(no new strings)*
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?

Made with [Cursor](https://cursor.com)