### PR TITLE
e2e tests: Attempt to fix flaky likes__post test

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
@@ -50,23 +50,8 @@ export class PublishedPostPage {
 		await waitForWPWidgetsIfNecessary( this.page );
 
 		const iframe = this.page.frameLocator( 'iframe[title="Like or Reblog"]' );
-
-		// Check if the post is already liked (e.g. from a previous retry attempt).
-		const likedLocator = iframe.getByRole( 'link', { name: 'Liked', exact: true } );
 		const likeLocator = iframe.getByRole( 'link', { name: 'Like', exact: true } );
-
-		// Wait for either "Like" or "Liked" button to be visible.
-		await likedLocator.or( likeLocator ).waitFor();
-
-		// If already liked, unlike it first to ensure we test the like action.
-		if ( await likedLocator.isVisible() ) {
-			await iframeLocator.scrollIntoViewIfNeeded();
-			await likedLocator.evaluate( ( element ) => element.scrollIntoView() );
-			await likedLocator.click();
-
-			// Wait for the button to change to "Like".
-			await likeLocator.waitFor();
-		}
+		await likeLocator.waitFor();
 
 		// On AT sites Playwright is not able to scroll directly to the iframe
 		// containing the Like/Unlike button (similar to Post Comments).
@@ -77,7 +62,7 @@ export class PublishedPostPage {
 		await likeLocator.click();
 
 		// The button should now read "Liked".
-		await likedLocator.waitFor();
+		await iframe.getByRole( 'link', { name: 'Liked', exact: true } ).waitFor();
 	}
 
 	/**

--- a/test/e2e/specs/published-content/likes__post.ts
+++ b/test/e2e/specs/published-content/likes__post.ts
@@ -71,7 +71,11 @@ describe( 'Likes: Post', function () {
 		} );
 
 		it( 'Like post', async function () {
+			const siteID = postingUser.credentials.testSites?.primary.id as number;
 			await ElementHelper.reloadAndRetry( page, async () => {
+				// Reset like state via REST API before each attempt.
+				await restAPIClient.postLikeAction( 'unlike', siteID, newPost.ID );
+				await page.reload();
 				publishedPostPage = new PublishedPostPage( page );
 				await publishedPostPage.likePost();
 			} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Follow-up to #107034, #107067, #107429

## Proposed Changes

* Resets like state before running likes__post test

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Prevent this test from being so flaky in the TC env

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* All e2e tests should pass first time

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
