### PR TITLE
Reader ATmosphere: image attachments composer (CM-671)

### DIFF
--- a/client/reader/atmosphere/composer/composer-footer.tsx
+++ b/client/reader/atmosphere/composer/composer-footer.tsx
@@ -2,6 +2,9 @@ import { __experimentalHStack as HStack, Button, Spinner } from '@wordpress/comp
 import { Icon, image } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import { useRef } from 'react';
+import { useComposer } from './composer-provider';
+import { ACCEPTED_IMAGE_TYPES } from './media/constants';
 
 interface Props {
 	graphemeCount: number;
@@ -11,9 +14,13 @@ interface Props {
 }
 
 const WARN_THRESHOLD_REMAINING = 50;
+const MAX_IMAGES = 4;
 
 export function ComposerFooter( { graphemeCount, onSubmit, isPending, limit }: Props ) {
 	const translate = useTranslate();
+	const { images, addFiles } = useComposer();
+	const inputRef = useRef< HTMLInputElement >( null );
+	const atMax = images.length >= MAX_IMAGES;
 	const remaining = limit - graphemeCount;
 	const tooLong = remaining < 0;
 	const empty = graphemeCount === 0;
@@ -27,16 +34,38 @@ export function ComposerFooter( { graphemeCount, onSubmit, isPending, limit }: P
 	return (
 		<HStack className="atmosphere-composer__footer" justify="space-between" alignment="center">
 			<div className="atmosphere-composer__footer-left">
-				{ /* Slice 8 wires this up — image / video upload + alt-text + content warnings. */ }
 				<button
 					type="button"
 					className="atmosphere-composer__media"
-					aria-disabled="true"
-					tabIndex={ 0 }
-					aria-label={ translate( 'Add media' ) }
+					aria-disabled={ atMax || undefined }
+					aria-label={
+						atMax
+							? ( translate( 'Maximum 4 images' ) as string )
+							: ( translate( 'Add media' ) as string )
+					}
+					onClick={ () => {
+						if ( ! atMax ) {
+							inputRef.current?.click();
+						}
+					} }
 				>
 					<Icon icon={ image } size={ 18 } />
 				</button>
+				<input
+					ref={ inputRef }
+					type="file"
+					accept={ ACCEPTED_IMAGE_TYPES }
+					multiple
+					hidden
+					onChange={ ( e ) => {
+						const files = Array.from( e.target.files ?? [] );
+						if ( files.length > 0 ) {
+							addFiles( files );
+						}
+						// Reset so picking the same file again still triggers onChange.
+						e.target.value = '';
+					} }
+				/>
 			</div>
 			<HStack spacing={ 2 } className="atmosphere-composer__footer-right">
 				<span

--- a/client/reader/atmosphere/composer/composer-footer.tsx
+++ b/client/reader/atmosphere/composer/composer-footer.tsx
@@ -4,19 +4,30 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useRef } from 'react';
 import { useComposer } from './composer-provider';
-import { ACCEPTED_IMAGE_TYPES } from './media/constants';
+import { ACCEPTED_IMAGE_TYPES, MAX_IMAGES } from './media/constants';
 
 interface Props {
 	graphemeCount: number;
 	onSubmit: () => void;
 	isPending: boolean;
 	limit: number;
+	/**
+	 * Optional override for the Post button's disabled state. When provided,
+	 * fully replaces the footer's internal `isPending || tooLong || empty`
+	 * logic so the parent can extend it (e.g. gating on uploaded media).
+	 */
+	disabled?: boolean;
 }
 
 const WARN_THRESHOLD_REMAINING = 50;
-const MAX_IMAGES = 4;
 
-export function ComposerFooter( { graphemeCount, onSubmit, isPending, limit }: Props ) {
+export function ComposerFooter( {
+	graphemeCount,
+	onSubmit,
+	isPending,
+	limit,
+	disabled: disabledProp,
+}: Props ) {
 	const translate = useTranslate();
 	const { images, addFiles } = useComposer();
 	const inputRef = useRef< HTMLInputElement >( null );
@@ -24,7 +35,7 @@ export function ComposerFooter( { graphemeCount, onSubmit, isPending, limit }: P
 	const remaining = limit - graphemeCount;
 	const tooLong = remaining < 0;
 	const empty = graphemeCount === 0;
-	const disabled = isPending || tooLong || empty;
+	const disabled = disabledProp ?? ( isPending || tooLong || empty );
 
 	const countClass = clsx( 'atmosphere-composer__count', {
 		'is-warn': remaining > 0 && remaining <= WARN_THRESHOLD_REMAINING,

--- a/client/reader/atmosphere/composer/composer-footer.tsx
+++ b/client/reader/atmosphere/composer/composer-footer.tsx
@@ -51,7 +51,11 @@ export function ComposerFooter( {
 					aria-disabled={ atMax || undefined }
 					aria-label={
 						atMax
-							? ( translate( 'Maximum 4 images' ) as string )
+							? ( translate( 'Maximum %(count)d images', {
+									args: { count: MAX_IMAGES },
+									comment:
+										'Tooltip on the composer "Add media" button when the user has reached the per-post image cap; %(count)d is the maximum number of images allowed on a single post.',
+							  } ) as string )
 							: ( translate( 'Add media' ) as string )
 					}
 					onClick={ () => {

--- a/client/reader/atmosphere/composer/composer-modal.tsx
+++ b/client/reader/atmosphere/composer/composer-modal.tsx
@@ -396,6 +396,15 @@ function errorMessageFor( err: AtmosphereError, t: ReturnType< typeof useTransla
 			return t( 'This Bluesky connection no longer exists.' );
 		case 'target_unavailable':
 			return t( 'This post is no longer available.' );
+		case 'media_invalid':
+			return t( 'Something’s wrong with the attached images. Please remove and re-add them.' );
+		case 'blob_too_large':
+		case 'blob_unsupported_type':
+		case 'blob_decode_failed':
+			// Should only surface from /blobs (handled inline by ImageGrid). If we
+			// ever see them bubble up here from a /posts response, render generic
+			// copy rather than something misleading.
+			return t( 'Something went wrong. Please try again.' );
 		case 'invalid_handle':
 		case 'unknown':
 			return t( 'Something went wrong. Please try again.' );

--- a/client/reader/atmosphere/composer/composer-modal.tsx
+++ b/client/reader/atmosphere/composer/composer-modal.tsx
@@ -18,6 +18,9 @@ import { ComposerPinnedContext } from './composer-pinned-context';
 import { useComposer, type ActiveMode } from './composer-provider';
 import { ComposerTextarea } from './composer-textarea';
 import { countGraphemes } from './grapheme-count';
+import { MAX_IMAGES } from './media/constants';
+import { ImageGrid } from './media/image-grid';
+import type { ComposerImage } from './media/types';
 import type { AtmosphereError, CreatePostParams, CreatePostResult } from '@automattic/api-core';
 import type { AppState } from 'calypso/types';
 import type { ReactNode } from 'react';
@@ -26,7 +29,17 @@ const LIMIT = 300;
 
 export function ComposerModal() {
 	const translate = useTranslate();
-	const { mode, closeComposer } = useComposer();
+	const {
+		mode,
+		closeComposer,
+		images,
+		addFiles,
+		removeImage,
+		retryImage,
+		setAlt,
+		isAllUploaded,
+		isAnyPending,
+	} = useComposer();
 	const queryClient = useQueryClient();
 	const mutation = useMutation( createPostMutation( queryClient ) );
 	const dispatch = useDispatch< ThunkDispatch< AppState, void, UnknownAction > >();
@@ -143,24 +156,29 @@ export function ComposerModal() {
 		if ( mutation.isPending ) {
 			return;
 		}
-		if ( text.trim().length > 0 ) {
+		if ( text.trim().length > 0 || images.length > 0 ) {
 			setConfirmDiscard( true );
 			return;
 		}
 		closeComposer();
-	}, [ mutation.isPending, text, closeComposer ] );
+	}, [ mutation.isPending, text, images.length, closeComposer ] );
+
+	const empty = graphemeCount === 0;
+	const tooLong = graphemeCount > LIMIT;
+	const hasImage = images.some( ( i ) => i.kind === 'uploaded' );
+	const canSubmit =
+		! mutation.isPending && ! tooLong && ! isAnyPending && isAllUploaded && ( ! empty || hasImage );
 
 	const handleSubmit = useCallback( () => {
 		if ( ! mode || mutation.isPending ) {
 			return;
 		}
 		// Guard against the Cmd/Ctrl+Enter shortcut bypassing the
-		// disabled Post button when the textarea is empty or over the
-		// limit. Mirrors the disabled logic in <ComposerFooter>.
-		if ( graphemeCount === 0 || graphemeCount > LIMIT ) {
+		// disabled Post button. Mirrors `canSubmit` above.
+		if ( ! canSubmit ) {
 			return;
 		}
-		const params = buildParamsForMode( mode, text );
+		const params = buildParamsForMode( mode, text, images );
 		mutation.mutate( params, {
 			onSuccess: ( result ) => {
 				if ( mode.kind === 'reply' ) {
@@ -194,7 +212,7 @@ export function ComposerModal() {
 				closeComposer();
 			},
 		} );
-	}, [ mode, mutation, text, graphemeCount, closeComposer, dispatch, translate ] );
+	}, [ mode, mutation, text, images, canSubmit, closeComposer, dispatch, translate ] );
 
 	if ( ! mode ) {
 		return null;
@@ -239,6 +257,14 @@ export function ComposerModal() {
 					}
 					aria-invalid={ errorMessage ? true : undefined }
 				/>
+				<ImageGrid
+					images={ images }
+					max={ MAX_IMAGES }
+					onPickFiles={ addFiles }
+					onRemove={ removeImage }
+					onRetry={ retryImage }
+					onSetAlt={ setAlt }
+				/>
 				{ errorMessage && (
 					<div id="atmosphere-composer-error" className="atmosphere-composer__error" role="alert">
 						{ errorMessage }
@@ -249,6 +275,7 @@ export function ComposerModal() {
 					onSubmit={ handleSubmit }
 					isPending={ mutation.isPending }
 					limit={ LIMIT }
+					disabled={ ! canSubmit }
 				/>
 			</Modal>
 			{ confirmDiscard && (
@@ -292,12 +319,31 @@ function placeholderForMode(
 	return t( 'What’s up?' ) as string;
 }
 
-function buildParamsForMode( mode: ActiveMode, text: string ): CreatePostParams {
+function buildParamsForMode(
+	mode: ActiveMode,
+	text: string,
+	images: ComposerImage[]
+): CreatePostParams {
+	const uploaded = images.filter(
+		( i ): i is Extract< ComposerImage, { kind: 'uploaded' } > => i.kind === 'uploaded'
+	);
+	const media =
+		uploaded.length > 0
+			? {
+					images: uploaded.map( ( i ) => ( {
+						blob: i.blob,
+						alt: i.alt,
+						aspectRatio: i.aspectRatio,
+					} ) ),
+			  }
+			: undefined;
+
 	if ( mode.kind === 'reply' ) {
 		return {
 			connectionId: mode.connectionId,
 			text,
 			reply: { root: mode.root, parent: mode.parent },
+			...( media ? { media } : {} ),
 		};
 	}
 	if ( mode.kind === 'quote' ) {
@@ -306,9 +352,14 @@ function buildParamsForMode( mode: ActiveMode, text: string ): CreatePostParams 
 			text,
 			quote: mode.quote,
 			...( mode.replyTo ? { reply: mode.replyTo } : {} ),
+			...( media ? { media } : {} ),
 		};
 	}
-	return { connectionId: mode.connectionId, text };
+	return {
+		connectionId: mode.connectionId,
+		text,
+		...( media ? { media } : {} ),
+	};
 }
 
 function errorMessageFor( err: AtmosphereError, t: ReturnType< typeof useTranslate > ): ReactNode {

--- a/client/reader/atmosphere/composer/composer-modal.tsx
+++ b/client/reader/atmosphere/composer/composer-modal.tsx
@@ -1,5 +1,5 @@
 import './style.scss';
-import { createPostMutation } from '@automattic/api-queries';
+import { createPostMutation, setAtmospherePostEmbed } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -21,7 +21,12 @@ import { countGraphemes } from './grapheme-count';
 import { MAX_IMAGES } from './media/constants';
 import { ImageGrid } from './media/image-grid';
 import type { ComposerImage } from './media/types';
-import type { AtmosphereError, CreatePostParams, CreatePostResult } from '@automattic/api-core';
+import type {
+	AtmosphereEmbedImages,
+	AtmosphereError,
+	CreatePostParams,
+	CreatePostResult,
+} from '@automattic/api-core';
 import type { AppState } from 'calypso/types';
 import type { ReactNode } from 'react';
 
@@ -181,6 +186,20 @@ export function ComposerModal() {
 		const params = buildParamsForMode( mode, text, images );
 		mutation.mutate( params, {
 			onSuccess: ( result ) => {
+				// Patch the just-published feed item with a local-preview-URL
+				// embed so the timeline / author-feed / thread caches show the
+				// user's just-attached images during the brief window before
+				// the next refetch replaces them with real CDN URLs from the
+				// AppView. The factory's `onSuccess` has already swapped the
+				// placeholder for an embed-less realItem; we layer the embed
+				// on top here. The composer-provider defers preview URL
+				// revocation past the 30s timeline staleTime so the local
+				// blob: URLs remain valid until the cache refetches.
+				const localEmbed = buildLocalImagesEmbed( images );
+				if ( localEmbed ) {
+					setAtmospherePostEmbed( queryClient, result.uri, localEmbed );
+				}
+
 				if ( mode.kind === 'reply' ) {
 					dispatch(
 						recordReaderTracksEvent( 'calypso_reader_atmosphere_reply_published', {
@@ -209,10 +228,10 @@ export function ComposerModal() {
 					? { button: translate( 'View' ) as string, onClick: () => page( threadUrl ) }
 					: undefined;
 				dispatch( successNotice( noticeText, options ) );
-				closeComposer();
+				closeComposer( { keepPreviewUrlsAlive: localEmbed !== null } );
 			},
 		} );
-	}, [ mode, mutation, text, images, canSubmit, closeComposer, dispatch, translate ] );
+	}, [ mode, mutation, text, images, canSubmit, closeComposer, dispatch, translate, queryClient ] );
 
 	if ( ! mode ) {
 		return null;
@@ -317,6 +336,36 @@ function placeholderForMode(
 		return t( 'Add a comment…' ) as string;
 	}
 	return t( 'What’s up?' ) as string;
+}
+
+/**
+ * Build an `AtmosphereEmbedImages` from the composer's uploaded images,
+ * using each image's local `previewUrl` as both `thumb` and `fullsize`.
+ * Returns `null` when nothing is uploaded so the caller can skip the
+ * cache patch entirely (no-op rather than emit an empty `images: []`
+ * embed, which the AppView never produces).
+ *
+ * The local URLs are short-lived: revocation is deferred by
+ * `useImageUploads`'s `clearAll` so they outlast the timeline / author
+ * feed staleTime; once the next refetch lands, the AppView's real CDN
+ * URLs replace this embed and the local URLs become unreferenced.
+ */
+function buildLocalImagesEmbed( images: ComposerImage[] ): AtmosphereEmbedImages | null {
+	const uploaded = images.filter(
+		( i ): i is Extract< ComposerImage, { kind: 'uploaded' } > => i.kind === 'uploaded'
+	);
+	if ( uploaded.length === 0 ) {
+		return null;
+	}
+	return {
+		type: 'images',
+		images: uploaded.map( ( i ) => ( {
+			thumb: i.previewUrl,
+			fullsize: i.previewUrl,
+			alt: i.alt,
+			aspect_ratio: i.aspectRatio,
+		} ) ),
+	};
 }
 
 function buildParamsForMode(

--- a/client/reader/atmosphere/composer/composer-modal.tsx
+++ b/client/reader/atmosphere/composer/composer-modal.tsx
@@ -396,14 +396,10 @@ function errorMessageFor( err: AtmosphereError, t: ReturnType< typeof useTransla
 			return t( 'This Bluesky connection no longer exists.' );
 		case 'target_unavailable':
 			return t( 'This post is no longer available.' );
-		case 'media_invalid':
-			return t( 'Something’s wrong with the attached images. Please remove and re-add them.' );
-		case 'blob_too_large':
-		case 'blob_unsupported_type':
 		case 'blob_decode_failed':
-			// Should only surface from /blobs (handled inline by ImageGrid). If we
-			// ever see them bubble up here from a /posts response, render generic
-			// copy rather than something misleading.
+			// Set client-side when `compressImage` throws. Should only surface
+			// inline on a thumbnail (ImageGrid); if it ever bubbles to the
+			// modal-level error region, render generic copy.
 			return t( 'Something went wrong. Please try again.' );
 		case 'invalid_handle':
 		case 'unknown':

--- a/client/reader/atmosphere/composer/composer-provider.tsx
+++ b/client/reader/atmosphere/composer/composer-provider.tsx
@@ -7,8 +7,11 @@ import {
 	useRef,
 	useState,
 } from 'react';
+import { useImageUploads } from './media/use-image-uploads';
 import type { AtUriRef } from '@automattic/api-core';
 import type { ReactNode } from 'react';
+
+type ImageUploads = ReturnType< typeof useImageUploads >;
 
 /**
  * Structural shape consumed by `<ComposerPinnedContext>`. Both
@@ -49,7 +52,7 @@ export type ComposerMode =
 
 export type ActiveMode = ComposerMode & { connectionId: number };
 
-interface ComposerContextValue {
+interface ComposerContextValue extends ImageUploads {
 	mode: ActiveMode | null;
 	openComposer: ( mode: ComposerMode ) => void;
 	closeComposer: () => void;
@@ -91,9 +94,25 @@ export function ComposerProvider( { connectionId, children }: Props ) {
 		setMode( null );
 	}, [] );
 
+	const imageUploads = useImageUploads( {
+		connectionId: mode?.connectionId ?? 0,
+		max: 4,
+	} );
+
+	// Reset images when the composer closes (mode transitions to null).
+	useEffect( () => {
+		if ( ! mode ) {
+			imageUploads.images.forEach( ( i ) => imageUploads.removeImage( i.localId ) );
+		}
+		// `imageUploads` is recreated each render — capturing it in deps would
+		// re-run the effect every render. The closure reads the snapshot at
+		// effect time, which is the desired behavior.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ mode ] );
+
 	const value = useMemo(
-		() => ( { mode, openComposer, closeComposer } ),
-		[ mode, openComposer, closeComposer ]
+		() => ( { mode, openComposer, closeComposer, ...imageUploads } ),
+		[ mode, openComposer, closeComposer, imageUploads ]
 	);
 
 	return <ComposerContext.Provider value={ value }>{ children }</ComposerContext.Provider>;

--- a/client/reader/atmosphere/composer/composer-provider.tsx
+++ b/client/reader/atmosphere/composer/composer-provider.tsx
@@ -7,10 +7,15 @@ import {
 	useRef,
 	useState,
 } from 'react';
+import { useDispatch } from 'react-redux';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import { MAX_IMAGES } from './media/constants';
 import { useImageUploads } from './media/use-image-uploads';
 import type { AtUriRef } from '@automattic/api-core';
+import type { AppState } from 'calypso/types';
 import type { ReactNode } from 'react';
+import type { UnknownAction } from 'redux';
+import type { ThunkDispatch } from 'redux-thunk';
 
 type ImageUploads = ReturnType< typeof useImageUploads >;
 
@@ -95,9 +100,19 @@ export function ComposerProvider( { connectionId, children }: Props ) {
 		setMode( null );
 	}, [] );
 
+	const dispatch = useDispatch< ThunkDispatch< AppState, void, UnknownAction > >();
+	const onTrack = useCallback(
+		( event: string, props: Record< string, unknown > ) => {
+			dispatch( recordReaderTracksEvent( event, props ) );
+		},
+		[ dispatch ]
+	);
+
 	const imageUploads = useImageUploads( {
 		connectionId: mode?.connectionId ?? 0,
 		max: MAX_IMAGES,
+		mode: mode?.kind ?? 'standalone',
+		onTrack,
 	} );
 
 	// Reset images when the composer closes (mode transitions to null).

--- a/client/reader/atmosphere/composer/composer-provider.tsx
+++ b/client/reader/atmosphere/composer/composer-provider.tsx
@@ -58,10 +58,23 @@ export type ComposerMode =
 
 export type ActiveMode = ComposerMode & { connectionId: number };
 
+export interface CloseComposerOptions {
+	/**
+	 * When `true`, defers revocation of every attached image's local
+	 * preview blob URL so cache entries that reference them (e.g. the
+	 * standalone-post placeholder embed patched in by the modal's
+	 * `onSuccess`) remain renderable past the timeline's staleTime.
+	 * The publish path passes this when ≥1 image was uploaded; the
+	 * cancel / discard path leaves it `false` (or omits it) so URLs
+	 * are reclaimed immediately.
+	 */
+	keepPreviewUrlsAlive?: boolean;
+}
+
 interface ComposerContextValue extends ImageUploads {
 	mode: ActiveMode | null;
 	openComposer: ( mode: ComposerMode ) => void;
-	closeComposer: () => void;
+	closeComposer: ( options?: CloseComposerOptions ) => void;
 }
 
 const ComposerContext = createContext< ComposerContextValue | null >( null );
@@ -96,7 +109,14 @@ export function ComposerProvider( { connectionId, children }: Props ) {
 		[ connectionId ]
 	);
 
-	const closeComposer = useCallback( () => {
+	// Tracks whether the most recent close should keep preview URLs alive.
+	// Read inside the `mode → null` effect that calls `clearAll`. Stored on
+	// a ref because the effect can't take a parameter, and stuffing the flag
+	// into `mode` itself would couple it to the open-state model.
+	const keepPreviewUrlsAliveRef = useRef( false );
+
+	const closeComposer = useCallback( ( options?: CloseComposerOptions ) => {
+		keepPreviewUrlsAliveRef.current = options?.keepPreviewUrlsAlive ?? false;
 		setMode( null );
 	}, [] );
 
@@ -122,7 +142,12 @@ export function ComposerProvider( { connectionId, children }: Props ) {
 	// `connection_id` / `mode` labels would be garbage anyway.)
 	useEffect( () => {
 		if ( ! mode ) {
-			imageUploads.clearAll();
+			const deferRevocation = keepPreviewUrlsAliveRef.current;
+			// Reset before calling clearAll so a subsequent cancel/discard
+			// close (no flag) doesn't inherit a stale `true` from a prior
+			// successful publish.
+			keepPreviewUrlsAliveRef.current = false;
+			imageUploads.clearAll( { deferRevocation } );
 		}
 		// `imageUploads` is recreated each render — capturing it in deps would
 		// re-run the effect every render. The closure reads the snapshot at

--- a/client/reader/atmosphere/composer/composer-provider.tsx
+++ b/client/reader/atmosphere/composer/composer-provider.tsx
@@ -7,6 +7,7 @@ import {
 	useRef,
 	useState,
 } from 'react';
+import { MAX_IMAGES } from './media/constants';
 import { useImageUploads } from './media/use-image-uploads';
 import type { AtUriRef } from '@automattic/api-core';
 import type { ReactNode } from 'react';
@@ -96,7 +97,7 @@ export function ComposerProvider( { connectionId, children }: Props ) {
 
 	const imageUploads = useImageUploads( {
 		connectionId: mode?.connectionId ?? 0,
-		max: 4,
+		max: MAX_IMAGES,
 	} );
 
 	// Reset images when the composer closes (mode transitions to null).

--- a/client/reader/atmosphere/composer/composer-provider.tsx
+++ b/client/reader/atmosphere/composer/composer-provider.tsx
@@ -116,9 +116,13 @@ export function ComposerProvider( { connectionId, children }: Props ) {
 	} );
 
 	// Reset images when the composer closes (mode transitions to null).
+	// `clearAll` skips the `media_removed` Tracks event for each entry —
+	// close-cleanup is a system action, not a user click on ×. (And by
+	// the time this effect runs, `mode` is already null, so the
+	// `connection_id` / `mode` labels would be garbage anyway.)
 	useEffect( () => {
 		if ( ! mode ) {
-			imageUploads.images.forEach( ( i ) => imageUploads.removeImage( i.localId ) );
+			imageUploads.clearAll();
 		}
 		// `imageUploads` is recreated each render — capturing it in deps would
 		// re-run the effect every render. The closure reads the snapshot at

--- a/client/reader/atmosphere/composer/media/alt-text-popover.tsx
+++ b/client/reader/atmosphere/composer/media/alt-text-popover.tsx
@@ -1,0 +1,76 @@
+import {
+	Button,
+	Modal,
+	TextareaControl,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+
+interface Props {
+	currentAlt: string;
+	previewUrl: string;
+	onSave: ( alt: string ) => void;
+}
+
+export function AltTextPopover( { currentAlt, previewUrl, onSave }: Props ) {
+	const translate = useTranslate();
+	const [ isOpen, setIsOpen ] = useState( false );
+	const [ draft, setDraft ] = useState( currentAlt );
+
+	const buttonLabel =
+		currentAlt.length > 0
+			? ( translate( 'Edit alt text' ) as string )
+			: ( translate( 'Add alt text' ) as string );
+
+	return (
+		<>
+			<Button
+				size="small"
+				variant="secondary"
+				aria-label={ buttonLabel }
+				onClick={ () => {
+					setDraft( currentAlt );
+					setIsOpen( true );
+				} }
+			>
+				{ currentAlt.length > 0 ? translate( 'ALT' ) : translate( '+ ALT' ) }
+			</Button>
+			{ isOpen && (
+				<Modal
+					title={ translate( 'Alt text' ) as string }
+					onRequestClose={ () => setIsOpen( false ) }
+					size="medium"
+				>
+					<img
+						src={ previewUrl }
+						alt=""
+						style={ { maxWidth: '100%', maxHeight: 200, marginBottom: 12 } }
+					/>
+					<TextareaControl
+						__nextHasNoMarginBottom
+						label={ translate( 'Alt text' ) }
+						help={ translate( 'Describe the image for people who can’t see it.' ) }
+						value={ draft }
+						onChange={ setDraft }
+						rows={ 4 }
+					/>
+					<HStack justify="flex-end" spacing={ 2 }>
+						<Button variant="tertiary" onClick={ () => setIsOpen( false ) }>
+							{ translate( 'Cancel' ) }
+						</Button>
+						<Button
+							variant="primary"
+							onClick={ () => {
+								onSave( draft );
+								setIsOpen( false );
+							} }
+						>
+							{ translate( 'Save' ) }
+						</Button>
+					</HStack>
+				</Modal>
+			) }
+		</>
+	);
+}

--- a/client/reader/atmosphere/composer/media/compress-image.ts
+++ b/client/reader/atmosphere/composer/media/compress-image.ts
@@ -1,0 +1,95 @@
+/**
+ * Canvas-based JPEG compressor mirroring bluesky-social/social-app's
+ * `src/lib/media/manip.web.ts`: decode the source image, downscale to a max
+ * long-edge, then binary-search JPEG quality until the encoded blob fits
+ * under a max byte size. EXIF metadata is dropped naturally by the canvas
+ * redraw — no explicit stripping required.
+ */
+
+const DEFAULT_MAX_DIMENSION = 2000;
+const DEFAULT_MAX_BYTES = 1_000_000;
+
+export interface CompressedImage {
+	blob: Blob;
+	width: number;
+	height: number;
+	size: number;
+}
+
+export class CompressionFailedError extends Error {
+	constructor() {
+		super( 'CompressionFailed: image cannot fit under maxBytes at any quality.' );
+		this.name = 'CompressionFailedError';
+	}
+}
+
+export interface CompressImageOptions {
+	maxDimension?: number;
+	maxBytes?: number;
+}
+
+export async function compressImage(
+	file: File | Blob,
+	options?: CompressImageOptions
+): Promise< CompressedImage > {
+	const maxDimension = options?.maxDimension ?? DEFAULT_MAX_DIMENSION;
+	const maxBytes = options?.maxBytes ?? DEFAULT_MAX_BYTES;
+
+	const bitmap = await createImageBitmap( file );
+	const { width: srcW, height: srcH } = bitmap;
+	const scale = Math.min( 1, maxDimension / Math.max( srcW, srcH ) );
+	const dstW = Math.round( srcW * scale );
+	const dstH = Math.round( srcH * scale );
+
+	const useOffscreen = typeof OffscreenCanvas !== 'undefined';
+	const canvas: OffscreenCanvas | HTMLCanvasElement = useOffscreen
+		? new OffscreenCanvas( dstW, dstH )
+		: Object.assign( document.createElement( 'canvas' ), { width: dstW, height: dstH } );
+	const ctx = ( canvas as HTMLCanvasElement | OffscreenCanvas ).getContext( '2d' );
+	if ( ! ctx ) {
+		bitmap.close?.();
+		throw new CompressionFailedError();
+	}
+	( ctx as CanvasRenderingContext2D ).drawImage( bitmap, 0, 0, dstW, dstH );
+	bitmap.close?.();
+
+	const toBlob = ( quality: number ): Promise< Blob > => {
+		if ( useOffscreen ) {
+			return ( canvas as OffscreenCanvas ).convertToBlob( {
+				type: 'image/jpeg',
+				quality,
+			} );
+		}
+		return new Promise( ( resolve, reject ) => {
+			( canvas as HTMLCanvasElement ).toBlob(
+				( blob ) => ( blob ? resolve( blob ) : reject( new CompressionFailedError() ) ),
+				'image/jpeg',
+				quality
+			);
+		} );
+	};
+
+	let minQ = 0;
+	let maxQ = 101;
+	let best: Blob | null = null;
+	while ( maxQ - minQ > 1 ) {
+		const q = Math.round( ( minQ + maxQ ) / 2 );
+		const blob = await toBlob( q / 100 );
+		if ( blob.size <= maxBytes ) {
+			best = blob;
+			minQ = q;
+		} else {
+			maxQ = q;
+		}
+	}
+
+	if ( ! best ) {
+		const fallback = await toBlob( 0 );
+		if ( fallback.size > maxBytes ) {
+			throw new CompressionFailedError();
+		}
+		best = fallback;
+	}
+
+	return { blob: best, width: dstW, height: dstH, size: best.size };
+}

--- a/client/reader/atmosphere/composer/media/constants.ts
+++ b/client/reader/atmosphere/composer/media/constants.ts
@@ -3,3 +3,9 @@
  * Mirrors the backend's allowed-types list (see CM-670 spec).
  */
 export const ACCEPTED_IMAGE_TYPES = 'image/jpeg,image/png,image/webp';
+
+/**
+ * Maximum number of images attachable to a single ATmosphere post.
+ * Mirrors the Bluesky/AT Protocol limit on `app.bsky.embed.images#main`.
+ */
+export const MAX_IMAGES = 4;

--- a/client/reader/atmosphere/composer/media/constants.ts
+++ b/client/reader/atmosphere/composer/media/constants.ts
@@ -1,0 +1,5 @@
+/**
+ * MIME types accepted by the ATmosphere image upload flow.
+ * Mirrors the backend's allowed-types list (see CM-670 spec).
+ */
+export const ACCEPTED_IMAGE_TYPES = 'image/jpeg,image/png,image/webp';

--- a/client/reader/atmosphere/composer/media/error-copy.ts
+++ b/client/reader/atmosphere/composer/media/error-copy.ts
@@ -3,19 +3,19 @@ import type { useTranslate } from 'i18n-calypso';
 
 /**
  * Localized copy for media-related error kinds surfaced inline on a
- * thumbnail. The composer-modal-level error region (Task 15) will share
- * `media_invalid` and `unknown` cases via its own switch.
+ * thumbnail. The composer-modal-level error region renders its own copy
+ * via a separate switch.
  */
 export function getMediaErrorMessage(
 	err: AtmosphereError,
 	t: ReturnType< typeof useTranslate >
 ): string {
 	switch ( err.kind ) {
-		case 'blob_too_large':
-			return t( 'Image is too large.' ) as string;
-		case 'blob_unsupported_type':
-			return t( 'We can only post JPG, PNG, or WebP images.' ) as string;
 		case 'blob_decode_failed':
+			// Set client-side when `compressImage` throws (canvas decode /
+			// re-encode failure). The slice-8a backend collapses every
+			// /blobs rejection (oversize, MIME, undecodable) into the
+			// generic `bad_request` kind handled by `default` below.
 			return t( 'We couldn’t read this image. Try a different file.' ) as string;
 		case 'rate_limited':
 			return t( 'You’re posting too quickly. Try again in a moment.' ) as string;

--- a/client/reader/atmosphere/composer/media/error-copy.ts
+++ b/client/reader/atmosphere/composer/media/error-copy.ts
@@ -1,0 +1,27 @@
+import type { AtmosphereError } from '@automattic/api-core';
+import type { useTranslate } from 'i18n-calypso';
+
+/**
+ * Localized copy for media-related error kinds surfaced inline on a
+ * thumbnail. The composer-modal-level error region (Task 15) will share
+ * `media_invalid` and `unknown` cases via its own switch.
+ */
+export function getMediaErrorMessage(
+	err: AtmosphereError,
+	t: ReturnType< typeof useTranslate >
+): string {
+	switch ( err.kind ) {
+		case 'blob_too_large':
+			return t( 'Image is too large.' ) as string;
+		case 'blob_unsupported_type':
+			return t( 'We can only post JPG, PNG, or WebP images.' ) as string;
+		case 'blob_decode_failed':
+			return t( 'We couldn’t read this image. Try a different file.' ) as string;
+		case 'rate_limited':
+			return t( 'You’re posting too quickly. Try again in a moment.' ) as string;
+		case 'upstream_unavailable':
+			return t( 'Bluesky is taking longer than usual. Please try again.' ) as string;
+		default:
+			return t( 'Something went wrong. Please try again.' ) as string;
+	}
+}

--- a/client/reader/atmosphere/composer/media/image-grid.tsx
+++ b/client/reader/atmosphere/composer/media/image-grid.tsx
@@ -1,0 +1,146 @@
+import { Button, Spinner } from '@wordpress/components';
+import { Icon, closeSmall, image as imageIcon } from '@wordpress/icons';
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import { useRef } from 'react';
+import { AltTextPopover } from './alt-text-popover';
+import type { ComposerImage } from './types';
+import type { AtmosphereError } from '@automattic/api-core';
+
+interface Props {
+	images: ComposerImage[];
+	max: number;
+	onPickFiles: ( files: File[] ) => void;
+	onRemove: ( localId: string ) => void;
+	onRetry: ( localId: string ) => void;
+	onSetAlt: ( localId: string, alt: string ) => void;
+}
+
+export function ImageGrid( { images, max, onPickFiles, onRemove, onRetry, onSetAlt }: Props ) {
+	const translate = useTranslate();
+	const inputRef = useRef< HTMLInputElement >( null );
+
+	if ( images.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<div
+			className="atmosphere-composer__image-grid"
+			role="group"
+			aria-label={ translate( 'Attached images' ) as string }
+		>
+			{ images.map( ( image ) => (
+				<Thumbnail
+					key={ image.localId }
+					image={ image }
+					onRemove={ onRemove }
+					onRetry={ onRetry }
+					onSetAlt={ onSetAlt }
+				/>
+			) ) }
+			{ images.length < max && (
+				<>
+					<button
+						type="button"
+						className="atmosphere-composer__image-add"
+						aria-label={ translate( 'Add more images' ) as string }
+						onClick={ () => inputRef.current?.click() }
+					>
+						<Icon icon={ imageIcon } size={ 24 } />
+					</button>
+					<input
+						ref={ inputRef }
+						type="file"
+						accept="image/jpeg,image/png,image/webp"
+						multiple
+						hidden
+						onChange={ ( e ) => {
+							const files = Array.from( e.target.files ?? [] );
+							if ( files.length > 0 ) {
+								onPickFiles( files );
+							}
+							// Reset so picking the same file again still triggers onChange.
+							e.target.value = '';
+						} }
+					/>
+				</>
+			) }
+		</div>
+	);
+}
+
+function Thumbnail( {
+	image,
+	onRemove,
+	onRetry,
+	onSetAlt,
+}: {
+	image: ComposerImage;
+	onRemove: ( id: string ) => void;
+	onRetry: ( id: string ) => void;
+	onSetAlt: ( id: string, alt: string ) => void;
+} ) {
+	const translate = useTranslate();
+	const isFailed = image.kind === 'failed';
+	const isPending = image.kind === 'compressing' || image.kind === 'uploading';
+
+	const previewUrl = 'previewUrl' in image ? image.previewUrl : '';
+	const alt = 'alt' in image ? image.alt : '';
+
+	return (
+		<div className={ clsx( 'atmosphere-composer__image', { 'is-failed': isFailed } ) }>
+			{ previewUrl && (
+				// `alt` may be empty until the user fills it in via the popover.
+				// Force `role="img"` so screen readers and tests can still locate
+				// the attached image; when `alt` is non-empty the role is
+				// already implicit.
+				// eslint-disable-next-line jsx-a11y/no-redundant-roles
+				<img src={ previewUrl } alt={ alt } role="img" />
+			) }
+			{ isPending && <Spinner /> }
+			<button
+				type="button"
+				className="atmosphere-composer__image-remove"
+				aria-label={ translate( 'Remove image' ) as string }
+				onClick={ () => onRemove( image.localId ) }
+			>
+				<Icon icon={ closeSmall } size={ 16 } />
+			</button>
+			{ ( image.kind === 'uploading' || image.kind === 'uploaded' ) && (
+				<div className="atmosphere-composer__image-alt">
+					<AltTextPopover
+						currentAlt={ alt }
+						previewUrl={ previewUrl }
+						onSave={ ( next ) => onSetAlt( image.localId, next ) }
+					/>
+				</div>
+			) }
+			{ isFailed && (
+				<div className="atmosphere-composer__image-error">
+					<span>{ errorMessage( image.error, translate ) }</span>
+					<Button variant="link" onClick={ () => onRetry( image.localId ) }>
+						{ translate( 'Retry' ) }
+					</Button>
+				</div>
+			) }
+		</div>
+	);
+}
+
+function errorMessage( err: AtmosphereError, t: ReturnType< typeof useTranslate > ): string {
+	switch ( err.kind ) {
+		case 'blob_too_large':
+			return t( 'Image is too large.' ) as string;
+		case 'blob_unsupported_type':
+			return t( 'We can only post JPG, PNG, or WebP images.' ) as string;
+		case 'blob_decode_failed':
+			return t( 'We couldn’t read this image. Try a different file.' ) as string;
+		case 'rate_limited':
+			return t( 'You’re posting too quickly. Try again in a moment.' ) as string;
+		case 'upstream_unavailable':
+			return t( 'Bluesky is taking longer than usual. Please try again.' ) as string;
+		default:
+			return t( 'Something went wrong. Please try again.' ) as string;
+	}
+}

--- a/client/reader/atmosphere/composer/media/image-grid.tsx
+++ b/client/reader/atmosphere/composer/media/image-grid.tsx
@@ -4,8 +4,9 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useRef } from 'react';
 import { AltTextPopover } from './alt-text-popover';
+import { ACCEPTED_IMAGE_TYPES } from './constants';
+import { getMediaErrorMessage } from './error-copy';
 import type { ComposerImage } from './types';
-import type { AtmosphereError } from '@automattic/api-core';
 
 interface Props {
 	images: ComposerImage[];
@@ -52,7 +53,7 @@ export function ImageGrid( { images, max, onPickFiles, onRemove, onRetry, onSetA
 					<input
 						ref={ inputRef }
 						type="file"
-						accept="image/jpeg,image/png,image/webp"
+						accept={ ACCEPTED_IMAGE_TYPES }
 						multiple
 						hidden
 						onChange={ ( e ) => {
@@ -87,17 +88,11 @@ function Thumbnail( {
 
 	const previewUrl = 'previewUrl' in image ? image.previewUrl : '';
 	const alt = 'alt' in image ? image.alt : '';
+	const imgAlt = alt.length > 0 ? alt : ( translate( 'Attached image' ) as string );
 
 	return (
 		<div className={ clsx( 'atmosphere-composer__image', { 'is-failed': isFailed } ) }>
-			{ previewUrl && (
-				// `alt` may be empty until the user fills it in via the popover.
-				// Force `role="img"` so screen readers and tests can still locate
-				// the attached image; when `alt` is non-empty the role is
-				// already implicit.
-				// eslint-disable-next-line jsx-a11y/no-redundant-roles
-				<img src={ previewUrl } alt={ alt } role="img" />
-			) }
+			{ previewUrl && <img src={ previewUrl } alt={ imgAlt } /> }
 			{ isPending && <Spinner /> }
 			<button
 				type="button"
@@ -118,7 +113,7 @@ function Thumbnail( {
 			) }
 			{ isFailed && (
 				<div className="atmosphere-composer__image-error">
-					<span>{ errorMessage( image.error, translate ) }</span>
+					<span>{ getMediaErrorMessage( image.error, translate ) }</span>
 					<Button variant="link" onClick={ () => onRetry( image.localId ) }>
 						{ translate( 'Retry' ) }
 					</Button>
@@ -126,21 +121,4 @@ function Thumbnail( {
 			) }
 		</div>
 	);
-}
-
-function errorMessage( err: AtmosphereError, t: ReturnType< typeof useTranslate > ): string {
-	switch ( err.kind ) {
-		case 'blob_too_large':
-			return t( 'Image is too large.' ) as string;
-		case 'blob_unsupported_type':
-			return t( 'We can only post JPG, PNG, or WebP images.' ) as string;
-		case 'blob_decode_failed':
-			return t( 'We couldn’t read this image. Try a different file.' ) as string;
-		case 'rate_limited':
-			return t( 'You’re posting too quickly. Try again in a moment.' ) as string;
-		case 'upstream_unavailable':
-			return t( 'Bluesky is taking longer than usual. Please try again.' ) as string;
-		default:
-			return t( 'Something went wrong. Please try again.' ) as string;
-	}
 }

--- a/client/reader/atmosphere/composer/media/index.ts
+++ b/client/reader/atmosphere/composer/media/index.ts
@@ -1,0 +1,3 @@
+export type { ComposerImage } from './types';
+export { compressImage, CompressionFailedError } from './compress-image';
+export type { CompressedImage } from './compress-image';

--- a/client/reader/atmosphere/composer/media/test/alt-text-popover.test.tsx
+++ b/client/reader/atmosphere/composer/media/test/alt-text-popover.test.tsx
@@ -1,0 +1,31 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AltTextPopover } from '../alt-text-popover';
+
+describe( 'AltTextPopover', () => {
+	it( 'opens, edits, and saves alt text', async () => {
+		const onSave = jest.fn();
+		const user = userEvent.setup();
+		render( <AltTextPopover currentAlt="" onSave={ onSave } previewUrl="blob:fake" /> );
+
+		await user.click( screen.getByRole( 'button', { name: /add alt text/i } ) );
+
+		const textarea = screen.getByRole( 'textbox', { name: /alt text/i } );
+		await user.type( textarea, 'a cat on a windowsill' );
+		await user.click( screen.getByRole( 'button', { name: /save/i } ) );
+
+		expect( onSave ).toHaveBeenCalledWith( 'a cat on a windowsill' );
+	} );
+
+	it( 'shows existing alt text in the textarea on open', async () => {
+		const user = userEvent.setup();
+		render( <AltTextPopover currentAlt="prefilled" onSave={ jest.fn() } previewUrl="blob:fake" /> );
+
+		await user.click( screen.getByRole( 'button', { name: /edit alt text/i } ) );
+
+		expect( screen.getByRole( 'textbox', { name: /alt text/i } ) ).toHaveValue( 'prefilled' );
+	} );
+} );

--- a/client/reader/atmosphere/composer/media/test/compress-image.test.ts
+++ b/client/reader/atmosphere/composer/media/test/compress-image.test.ts
@@ -19,7 +19,15 @@ describe( 'compressImage', () => {
 			const match = name.match( /(\d+)x(\d+)/ );
 			const width = match ? parseInt( match[ 1 ], 10 ) : 1200;
 			const height = match ? parseInt( match[ 2 ], 10 ) : 800;
-			return new ImageBitmap( width, height );
+			// `new ImageBitmap()` isn't constructible — fabricate an instance whose
+			// prototype satisfies `instanceof ImageBitmap` (jest-canvas-mock's
+			// `drawImage` checks via `instanceof`).
+			const bitmap = Object.assign( Object.create( ImageBitmap.prototype ) as ImageBitmap, {
+				width,
+				height,
+				close: () => {},
+			} );
+			return bitmap;
 		} ) as typeof createImageBitmap;
 	} );
 

--- a/client/reader/atmosphere/composer/media/test/compress-image.test.ts
+++ b/client/reader/atmosphere/composer/media/test/compress-image.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment jsdom
+ */
+import { compressImage, CompressionFailedError } from '../compress-image';
+
+describe( 'compressImage', () => {
+	let toBlobSpy: jest.SpyInstance;
+
+	beforeEach( () => {
+		// Force <canvas> fallback (jest-canvas-mock polyfills HTMLCanvasElement,
+		// not OffscreenCanvas).
+		// @ts-expect-error - intentional cleanup of any prior polyfill.
+		delete global.OffscreenCanvas;
+
+		// Polyfill createImageBitmap to return a fake bitmap whose dimensions
+		// are encoded in the source File's name (e.g. "synth-4000x2000.png").
+		global.createImageBitmap = jest.fn( async ( source: ImageBitmapSource ) => {
+			const name = ( source as File ).name ?? '';
+			const match = name.match( /(\d+)x(\d+)/ );
+			const width = match ? parseInt( match[ 1 ], 10 ) : 1200;
+			const height = match ? parseInt( match[ 2 ], 10 ) : 800;
+			return new ImageBitmap( width, height );
+		} ) as typeof createImageBitmap;
+	} );
+
+	afterEach( () => {
+		toBlobSpy?.mockRestore();
+		// @ts-expect-error - cleanup global polyfill.
+		delete global.createImageBitmap;
+	} );
+
+	function mockToBlobBySize( sizeFromQuality: ( quality: number ) => number ) {
+		toBlobSpy = jest.spyOn( HTMLCanvasElement.prototype, 'toBlob' ).mockImplementation( function (
+			this: HTMLCanvasElement,
+			cb: BlobCallback,
+			_type?: string,
+			quality?: number
+		) {
+			const q = quality ?? 1;
+			const size = Math.max( 1, Math.round( sizeFromQuality( q ) ) );
+			const blob = new Blob( [ new Uint8Array( size ) ], { type: 'image/jpeg' } );
+			cb( blob );
+		} );
+	}
+
+	it( 'returns a JPEG blob with width/height under 2000 and size under 1MB', async () => {
+		// Quality-dependent payload that crosses 1MB inside the search range.
+		mockToBlobBySize( ( q ) => 200_000 + 1_500_000 * q );
+
+		const file = new File( [ new Uint8Array( 10 ) ], 'synth-1200x800.png', {
+			type: 'image/png',
+		} );
+
+		const result = await compressImage( file );
+
+		expect( result.blob ).toBeInstanceOf( Blob );
+		expect( result.blob.type ).toBe( 'image/jpeg' );
+		expect( result.width ).toBeLessThanOrEqual( 2000 );
+		expect( result.height ).toBeLessThanOrEqual( 2000 );
+		expect( result.size ).toBeLessThanOrEqual( 1_000_000 );
+		expect( result.size ).toBe( result.blob.size );
+	} );
+
+	it( 'preserves aspect ratio when downscaling 4000x2000 to 2000x1000', async () => {
+		mockToBlobBySize( () => 100_000 );
+
+		const file = new File( [ new Uint8Array( 10 ) ], 'synth-4000x2000.png', {
+			type: 'image/png',
+		} );
+
+		const result = await compressImage( file );
+
+		expect( result.width ).toBe( 2000 );
+		expect( result.height ).toBe( 1000 );
+	} );
+
+	it( 'rejects with CompressionFailedError when maxBytes is impossibly small', async () => {
+		// Always larger than maxBytes regardless of quality.
+		mockToBlobBySize( () => 50_000 );
+
+		const file = new File( [ new Uint8Array( 10 ) ], 'synth-1200x800.png', {
+			type: 'image/png',
+		} );
+
+		await expect( compressImage( file, { maxBytes: 1 } ) ).rejects.toBeInstanceOf(
+			CompressionFailedError
+		);
+	} );
+} );

--- a/client/reader/atmosphere/composer/media/test/image-grid.test.tsx
+++ b/client/reader/atmosphere/composer/media/test/image-grid.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ImageGrid } from '../image-grid';
+import type { ComposerImage } from '../types';
+
+const uploaded = ( id: string, alt = '' ): ComposerImage => ( {
+	kind: 'uploaded',
+	localId: id,
+	previewUrl: `blob:${ id }`,
+	alt,
+	aspectRatio: { width: 100, height: 100 },
+	blob: { $type: 'blob', ref: { $link: 'a'.repeat( 50 ) }, mimeType: 'image/jpeg', size: 100 },
+} );
+
+describe( 'ImageGrid', () => {
+	const noop = () => {};
+
+	it( 'renders one thumbnail per image and a + tile when below max', () => {
+		render(
+			<ImageGrid
+				images={ [ uploaded( 'a' ), uploaded( 'b' ) ] }
+				max={ 4 }
+				onPickFiles={ noop }
+				onRemove={ noop }
+				onRetry={ noop }
+				onSetAlt={ noop }
+			/>
+		);
+
+		expect( screen.getAllByRole( 'img', { hidden: true } ) ).toHaveLength( 2 );
+		expect( screen.getByRole( 'button', { name: /add more images/i } ) ).toBeVisible();
+	} );
+
+	it( 'hides the + tile at the max', () => {
+		render(
+			<ImageGrid
+				images={ [ uploaded( 'a' ), uploaded( 'b' ), uploaded( 'c' ), uploaded( 'd' ) ] }
+				max={ 4 }
+				onPickFiles={ noop }
+				onRemove={ noop }
+				onRetry={ noop }
+				onSetAlt={ noop }
+			/>
+		);
+
+		expect( screen.queryByRole( 'button', { name: /add more images/i } ) ).toBeNull();
+	} );
+
+	it( 'calls onRemove with the localId when × is clicked', async () => {
+		const user = userEvent.setup();
+		const onRemove = jest.fn();
+		render(
+			<ImageGrid
+				images={ [ uploaded( 'a' ) ] }
+				max={ 4 }
+				onPickFiles={ noop }
+				onRemove={ onRemove }
+				onRetry={ noop }
+				onSetAlt={ noop }
+			/>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: /remove image/i } ) );
+
+		expect( onRemove ).toHaveBeenCalledWith( 'a' );
+	} );
+
+	it( 'shows a Retry control for failed entries', async () => {
+		const user = userEvent.setup();
+		const onRetry = jest.fn();
+		const failed: ComposerImage = {
+			kind: 'failed',
+			localId: 'f',
+			previewUrl: 'blob:f',
+			alt: '',
+			aspectRatio: { width: 100, height: 100 },
+			sourceFile: new File( [ 'x' ], 'f.png', { type: 'image/png' } ),
+			error: { kind: 'blob_decode_failed' },
+		};
+		render(
+			<ImageGrid
+				images={ [ failed ] }
+				max={ 4 }
+				onPickFiles={ noop }
+				onRemove={ noop }
+				onRetry={ onRetry }
+				onSetAlt={ noop }
+			/>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: /retry/i } ) );
+
+		expect( onRetry ).toHaveBeenCalledWith( 'f' );
+	} );
+} );

--- a/client/reader/atmosphere/composer/media/test/image-grid.test.tsx
+++ b/client/reader/atmosphere/composer/media/test/image-grid.test.tsx
@@ -30,7 +30,7 @@ describe( 'ImageGrid', () => {
 			/>
 		);
 
-		expect( screen.getAllByRole( 'img', { hidden: true } ) ).toHaveLength( 2 );
+		expect( screen.getAllByRole( 'img' ) ).toHaveLength( 2 );
 		expect( screen.getByRole( 'button', { name: /add more images/i } ) ).toBeVisible();
 	} );
 

--- a/client/reader/atmosphere/composer/media/test/use-image-uploads.test.tsx
+++ b/client/reader/atmosphere/composer/media/test/use-image-uploads.test.tsx
@@ -76,4 +76,72 @@ describe( 'useImageUploads', () => {
 		expect( uploaded.aspectRatio ).toEqual( { width: 1000, height: 750 } );
 		expect( uploaded.blob.mimeType ).toBe( 'image/jpeg' );
 	} );
+
+	it( 'enforces the cap across concurrent addFiles calls', async () => {
+		// Two rapid `addFiles` calls (mobile share sheet, double-tap) must
+		// not both capture the same `images.length` and admit more files
+		// than `max`. Without a synchronous slot reservation, the second
+		// call would slice against a stale count and overflow the cap.
+		jest.spyOn( wpcom.req, 'post' ).mockResolvedValue( {
+			blob: {
+				$type: 'blob',
+				ref: { $link: 'bafkrei' + 'a'.repeat( 50 ) },
+				mimeType: 'image/jpeg',
+				size: 10,
+			},
+		} );
+
+		const qc = new QueryClient();
+		const { result } = renderHook( () => useImageUploads( { connectionId: 9, max: 4 } ), {
+			wrapper: wrap( qc ),
+		} );
+
+		const batchA = [
+			new File( [ 'a' ], 'a.png', { type: 'image/png' } ),
+			new File( [ 'b' ], 'b.png', { type: 'image/png' } ),
+			new File( [ 'c' ], 'c.png', { type: 'image/png' } ),
+			new File( [ 'd' ], 'd.png', { type: 'image/png' } ),
+		];
+		const batchB = [ new File( [ 'e' ], 'e.png', { type: 'image/png' } ) ];
+
+		await act( async () => {
+			await Promise.all( [ result.current.addFiles( batchA ), result.current.addFiles( batchB ) ] );
+		} );
+
+		await waitFor( () => {
+			expect( result.current.images.every( ( i ) => i.kind === 'uploaded' ) ).toBe( true );
+		} );
+		expect( result.current.images.length ).toBeLessThanOrEqual( 4 );
+		expect( result.current.images.length ).toBe( 4 );
+	} );
+
+	it( 'narrows non-AtmosphereError throws to { kind: "unknown" }', async () => {
+		// `uploadBlob` normally classifies its rejections through
+		// `classifyAtmosphereError`, but a transport-level failure (network
+		// drop, abort) can short-circuit before that runs. Casting `err as
+		// AtmosphereError` would let downstream `error.kind` reads return
+		// `undefined`; the type guard collapses anything unrecognized to
+		// `{ kind: 'unknown', cause: err }`.
+		jest.spyOn( wpcom.req, 'post' ).mockRejectedValue( new Error( 'network down' ) );
+
+		const qc = new QueryClient();
+		const { result } = renderHook( () => useImageUploads( { connectionId: 9, max: 4 } ), {
+			wrapper: wrap( qc ),
+		} );
+
+		const file = new File( [ 'src' ], 'a.png', { type: 'image/png' } );
+		await act( async () => {
+			await result.current.addFiles( [ file ] );
+		} );
+
+		await waitFor( () => {
+			expect( result.current.images[ 0 ]?.kind ).toBe( 'failed' );
+		} );
+
+		const failed = result.current.images[ 0 ];
+		if ( failed.kind !== 'failed' ) {
+			throw new Error( 'expected failed' );
+		}
+		expect( failed.error.kind ).toBe( 'unknown' );
+	} );
 } );

--- a/client/reader/atmosphere/composer/media/test/use-image-uploads.test.tsx
+++ b/client/reader/atmosphere/composer/media/test/use-image-uploads.test.tsx
@@ -23,6 +23,15 @@ function wrap( queryClient: QueryClient ) {
 	);
 }
 
+const okBlobResponse = {
+	blob: {
+		$type: 'blob',
+		ref: { $link: 'bafkrei' + 'a'.repeat( 50 ) },
+		mimeType: 'image/jpeg',
+		size: 10,
+	},
+};
+
 describe( 'useImageUploads', () => {
 	beforeAll( () => {
 		// jsdom does not implement URL.createObjectURL / revokeObjectURL.
@@ -45,14 +54,7 @@ describe( 'useImageUploads', () => {
 		// HTTP request goes out. Spying on `wpcom.req.post` keeps the hook's
 		// state-machine wiring under test without taking on the transport's
 		// stream plumbing.
-		jest.spyOn( wpcom.req, 'post' ).mockResolvedValue( {
-			blob: {
-				$type: 'blob',
-				ref: { $link: 'bafkrei' + 'a'.repeat( 50 ) },
-				mimeType: 'image/jpeg',
-				size: 10,
-			},
-		} );
+		jest.spyOn( wpcom.req, 'post' ).mockResolvedValue( okBlobResponse );
 
 		const qc = new QueryClient();
 		const { result } = renderHook( () => useImageUploads( { connectionId: 9, max: 4 } ), {
@@ -82,14 +84,7 @@ describe( 'useImageUploads', () => {
 		// not both capture the same `images.length` and admit more files
 		// than `max`. Without a synchronous slot reservation, the second
 		// call would slice against a stale count and overflow the cap.
-		jest.spyOn( wpcom.req, 'post' ).mockResolvedValue( {
-			blob: {
-				$type: 'blob',
-				ref: { $link: 'bafkrei' + 'a'.repeat( 50 ) },
-				mimeType: 'image/jpeg',
-				size: 10,
-			},
-		} );
+		jest.spyOn( wpcom.req, 'post' ).mockResolvedValue( okBlobResponse );
 
 		const qc = new QueryClient();
 		const { result } = renderHook( () => useImageUploads( { connectionId: 9, max: 4 } ), {
@@ -113,6 +108,188 @@ describe( 'useImageUploads', () => {
 		} );
 		expect( result.current.images.length ).toBeLessThanOrEqual( 4 );
 		expect( result.current.images.length ).toBe( 4 );
+	} );
+
+	it( 'addFiles clamps a single oversized batch to max', async () => {
+		// Sibling to the concurrent-cap test: covers the single-call slice
+		// path. Six files into a max-of-four hook must drop the last two
+		// rather than admit them and rely on a downstream guard.
+		jest.spyOn( wpcom.req, 'post' ).mockResolvedValue( okBlobResponse );
+
+		const qc = new QueryClient();
+		const { result } = renderHook( () => useImageUploads( { connectionId: 9, max: 4 } ), {
+			wrapper: wrap( qc ),
+		} );
+
+		const six = Array.from(
+			{ length: 6 },
+			( _, i ) => new File( [ String( i ) ], `${ i }.png`, { type: 'image/png' } )
+		);
+
+		await act( async () => {
+			await result.current.addFiles( six );
+		} );
+
+		await waitFor( () => {
+			expect( result.current.images ).toHaveLength( 4 );
+		} );
+	} );
+
+	it( 'removeImage drops the entry, aborts an in-flight upload, and frees a slot', async () => {
+		// `removeImage` must release the synchronous slot reservation so
+		// the user can re-add an image after deleting one. We verify both
+		// the removal and the re-add succeeding under `max: 1`. The first
+		// upload uses a never-resolving promise so we can intercept it
+		// while it is still in the `uploading` state.
+		let resolveUpload: ( ( v: typeof okBlobResponse ) => void ) | undefined;
+		const uploadSpy = jest
+			.spyOn( wpcom.req, 'post' )
+			.mockImplementationOnce(
+				() =>
+					new Promise( ( resolve ) => {
+						resolveUpload = resolve;
+					} )
+			)
+			.mockResolvedValue( okBlobResponse );
+
+		const qc = new QueryClient();
+		const { result } = renderHook( () => useImageUploads( { connectionId: 9, max: 1 } ), {
+			wrapper: wrap( qc ),
+		} );
+
+		const file = new File( [ 'src' ], 'a.png', { type: 'image/png' } );
+		// Do NOT await addFiles — the first upload promise never resolves,
+		// so awaiting it here would deadlock the test. Kick it off and let
+		// `waitFor` observe the `uploading` transition instead.
+		act( () => {
+			void result.current.addFiles( [ file ] );
+		} );
+
+		await waitFor( () => expect( result.current.images[ 0 ]?.kind ).toBe( 'uploading' ) );
+
+		const uploading = result.current.images[ 0 ];
+		if ( uploading.kind !== 'uploading' ) {
+			throw new Error( 'expected uploading' );
+		}
+		const abortSpy = jest.spyOn( uploading.abort, 'abort' );
+
+		act( () => result.current.removeImage( uploading.localId ) );
+
+		expect( result.current.images ).toHaveLength( 0 );
+		expect( abortSpy ).toHaveBeenCalled();
+
+		// Drain the original pending upload so its `update` call lands
+		// before the assertion below (and Jest doesn't warn about a
+		// leaked promise). The matching `localId` is gone, so `update`
+		// is a no-op on `images`.
+		await act( async () => {
+			resolveUpload?.( okBlobResponse );
+		} );
+
+		const replacement = new File( [ 'src2' ], 'b.png', { type: 'image/png' } );
+		await act( async () => {
+			await result.current.addFiles( [ replacement ] );
+		} );
+
+		await waitFor( () => {
+			expect( result.current.images ).toHaveLength( 1 );
+			expect( result.current.images[ 0 ].kind ).toBe( 'uploaded' );
+		} );
+
+		expect( uploadSpy ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'retryImage moves a failed entry back through uploading to uploaded', async () => {
+		// First attempt rejects (transport-level error) so the entry lands
+		// in `failed` carrying its `sourceFile`. `retryImage` re-enters
+		// `startOne` with that same file; the second mock resolves.
+		const uploadSpy = jest
+			.spyOn( wpcom.req, 'post' )
+			.mockRejectedValueOnce( { kind: 'unknown', cause: new Error( 'down' ) } )
+			.mockResolvedValueOnce( okBlobResponse );
+
+		const qc = new QueryClient();
+		const { result } = renderHook( () => useImageUploads( { connectionId: 9, max: 4 } ), {
+			wrapper: wrap( qc ),
+		} );
+
+		const file = new File( [ 'src' ], 'a.png', { type: 'image/png' } );
+		await act( async () => {
+			await result.current.addFiles( [ file ] );
+		} );
+
+		await waitFor( () => expect( result.current.images[ 0 ].kind ).toBe( 'failed' ) );
+
+		const failedId = result.current.images[ 0 ].localId;
+		await act( async () => {
+			await result.current.retryImage( failedId );
+		} );
+
+		await waitFor( () => {
+			expect( result.current.images ).toHaveLength( 1 );
+			expect( result.current.images[ 0 ].kind ).toBe( 'uploaded' );
+		} );
+
+		expect( uploadSpy ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'setAlt updates alt on uploading or uploaded entries; no-ops on compressing', async () => {
+		// Alt strings flow into the AppView record as the post is composed.
+		// The state-machine variants for `compressing` carry no alt field
+		// (no preview yet), so calling `setAlt` mid-compress must be a
+		// silent no-op rather than throw.
+		jest.spyOn( wpcom.req, 'post' ).mockResolvedValue( okBlobResponse );
+
+		const qc = new QueryClient();
+		const { result } = renderHook( () => useImageUploads( { connectionId: 9, max: 4 } ), {
+			wrapper: wrap( qc ),
+		} );
+
+		const file = new File( [ 'src' ], 'a.png', { type: 'image/png' } );
+		await act( async () => {
+			await result.current.addFiles( [ file ] );
+		} );
+
+		await waitFor( () => expect( result.current.images[ 0 ].kind ).toBe( 'uploaded' ) );
+
+		const id = result.current.images[ 0 ].localId;
+		act( () => result.current.setAlt( id, 'a sunny field' ) );
+
+		const uploaded = result.current.images[ 0 ];
+		if ( uploaded.kind !== 'uploaded' ) {
+			throw new Error( 'expected uploaded' );
+		}
+		expect( uploaded.alt ).toBe( 'a sunny field' );
+
+		// setAlt on a non-existent id is a silent no-op (smoke test for
+		// the compressing branch, which has no alt field to mutate).
+		act( () => result.current.setAlt( 'not-a-real-id', 'ignored' ) );
+		expect( result.current.images ).toHaveLength( 1 );
+	} );
+
+	it( 'isAllUploaded and isAnyPending reflect derived state', async () => {
+		jest.spyOn( wpcom.req, 'post' ).mockResolvedValue( okBlobResponse );
+
+		const qc = new QueryClient();
+		const { result } = renderHook( () => useImageUploads( { connectionId: 9, max: 4 } ), {
+			wrapper: wrap( qc ),
+		} );
+
+		// Empty: every() over [] is true; nothing is pending.
+		expect( result.current.isAllUploaded ).toBe( true );
+		expect( result.current.isAnyPending ).toBe( false );
+
+		const file = new File( [ 'src' ], 'a.png', { type: 'image/png' } );
+		await act( async () => {
+			await result.current.addFiles( [ file ] );
+		} );
+
+		await waitFor( () => {
+			expect( result.current.images[ 0 ].kind ).toBe( 'uploaded' );
+		} );
+
+		expect( result.current.isAllUploaded ).toBe( true );
+		expect( result.current.isAnyPending ).toBe( false );
 	} );
 } );
 

--- a/client/reader/atmosphere/composer/media/test/use-image-uploads.test.tsx
+++ b/client/reader/atmosphere/composer/media/test/use-image-uploads.test.tsx
@@ -267,6 +267,213 @@ describe( 'useImageUploads', () => {
 		expect( result.current.images ).toHaveLength( 1 );
 	} );
 
+	it( 'fires _compose_media_picked when files are added', async () => {
+		jest.spyOn( wpcom.req, 'post' ).mockResolvedValue( okBlobResponse );
+
+		const onTrack = jest.fn();
+		const qc = new QueryClient();
+		const { result } = renderHook(
+			() => useImageUploads( { connectionId: 9, max: 4, mode: 'standalone', onTrack } ),
+			{ wrapper: wrap( qc ) }
+		);
+
+		const files = [
+			new File( [ 'a' ], 'a.png', { type: 'image/png' } ),
+			new File( [ 'b' ], 'b.png', { type: 'image/png' } ),
+		];
+		await act( async () => {
+			await result.current.addFiles( files );
+		} );
+
+		expect( onTrack ).toHaveBeenCalledWith( 'calypso_reader_atmosphere_compose_media_picked', {
+			connection_id: 9,
+			count: 2,
+			mode: 'standalone',
+		} );
+	} );
+
+	it( 'fires _compose_media_uploaded with byte totals after all uploads finish', async () => {
+		jest.spyOn( wpcom.req, 'post' ).mockResolvedValue( okBlobResponse );
+
+		// Override the default compressImage mock for this test so we
+		// can assert specific byte sizes ended up in the event payload.
+		const { compressImage } = jest.requireMock( '../compress-image' );
+		( compressImage as jest.Mock ).mockResolvedValueOnce( {
+			blob: new Blob( [ 'x'.repeat( 25 ) ], { type: 'image/jpeg' } ),
+			width: 800,
+			height: 600,
+			size: 25,
+		} );
+
+		const onTrack = jest.fn();
+		const qc = new QueryClient();
+		const { result } = renderHook(
+			() => useImageUploads( { connectionId: 9, max: 4, mode: 'reply', onTrack } ),
+			{ wrapper: wrap( qc ) }
+		);
+
+		// Source file size: payload 'src-bytes-here' = 14 chars.
+		const file = new File( [ 'src-bytes-here' ], 'a.png', { type: 'image/png' } );
+		await act( async () => {
+			await result.current.addFiles( [ file ] );
+		} );
+
+		await waitFor( () => expect( result.current.images[ 0 ].kind ).toBe( 'uploaded' ) );
+
+		expect( onTrack ).toHaveBeenCalledWith( 'calypso_reader_atmosphere_compose_media_uploaded', {
+			connection_id: 9,
+			count: 1,
+			total_bytes_before_compress: 14,
+			total_bytes_after_compress: 25,
+			mode: 'reply',
+		} );
+	} );
+
+	it( 'fires _compose_media_upload_error_shown when an upload fails', async () => {
+		// Surface any classifier-mapped `error_kind` from the rejected
+		// response. The exact shape of the rejection that `uploadBlob`
+		// re-throws is exercised in the mutation factory's own tests; here
+		// we only need the hook to forward the resulting `error.kind` into
+		// the Tracks event once per failed upload.
+		jest
+			.spyOn( wpcom.req, 'post' )
+			.mockRejectedValue( { kind: 'rate_limited', message: 'slow down' } );
+
+		const onTrack = jest.fn();
+		const qc = new QueryClient();
+		const { result } = renderHook(
+			() => useImageUploads( { connectionId: 9, max: 4, mode: 'quote', onTrack } ),
+			{ wrapper: wrap( qc ) }
+		);
+
+		const file = new File( [ 'src' ], 'a.png', { type: 'image/png' } );
+		await act( async () => {
+			await result.current.addFiles( [ file ] );
+		} );
+
+		await waitFor( () => expect( result.current.images[ 0 ].kind ).toBe( 'failed' ) );
+
+		const failed = result.current.images[ 0 ];
+		if ( failed.kind !== 'failed' ) {
+			throw new Error( 'expected failed' );
+		}
+		const errorCalls = onTrack.mock.calls.filter(
+			( [ name ] ) => name === 'calypso_reader_atmosphere_compose_media_upload_error_shown'
+		);
+		expect( errorCalls ).toHaveLength( 1 );
+		expect( errorCalls[ 0 ][ 1 ] ).toEqual( {
+			connection_id: 9,
+			mode: 'quote',
+			error_kind: failed.error.kind,
+		} );
+	} );
+
+	it( 'fires _compose_media_removed with was_uploaded flag', async () => {
+		// Scenario 1: full upload then remove → was_uploaded: true.
+		jest.spyOn( wpcom.req, 'post' ).mockResolvedValue( okBlobResponse );
+
+		const onTrack = jest.fn();
+		const qc = new QueryClient();
+		const { result } = renderHook(
+			() => useImageUploads( { connectionId: 9, max: 4, mode: 'standalone', onTrack } ),
+			{ wrapper: wrap( qc ) }
+		);
+
+		const file = new File( [ 'src' ], 'a.png', { type: 'image/png' } );
+		await act( async () => {
+			await result.current.addFiles( [ file ] );
+		} );
+
+		await waitFor( () => expect( result.current.images[ 0 ].kind ).toBe( 'uploaded' ) );
+
+		const uploadedId = result.current.images[ 0 ].localId;
+		act( () => result.current.removeImage( uploadedId ) );
+
+		const removedCalls = onTrack.mock.calls.filter(
+			( [ name ] ) => name === 'calypso_reader_atmosphere_compose_media_removed'
+		);
+		expect( removedCalls ).toHaveLength( 1 );
+		expect( removedCalls[ 0 ][ 1 ] ).toEqual( {
+			connection_id: 9,
+			was_uploaded: true,
+			mode: 'standalone',
+		} );
+	} );
+
+	it( 'fires _compose_media_removed with was_uploaded: false when removed during compressing', async () => {
+		// `compressImage` returns a never-resolving promise, so the entry
+		// stays in `compressing` while we issue `removeImage`. This is
+		// the only state where `kind !== 'uploaded'` is reachable
+		// synchronously from the test.
+		const { compressImage } = jest.requireMock( '../compress-image' );
+		( compressImage as jest.Mock ).mockImplementationOnce( () => new Promise( () => {} ) );
+		jest.spyOn( wpcom.req, 'post' ).mockResolvedValue( okBlobResponse );
+
+		const onTrack = jest.fn();
+		const qc = new QueryClient();
+		const { result } = renderHook(
+			() => useImageUploads( { connectionId: 9, max: 4, mode: 'standalone', onTrack } ),
+			{ wrapper: wrap( qc ) }
+		);
+
+		const file = new File( [ 'src' ], 'a.png', { type: 'image/png' } );
+		// Don't await — the compressing promise never resolves.
+		act( () => {
+			void result.current.addFiles( [ file ] );
+		} );
+
+		await waitFor( () => expect( result.current.images[ 0 ]?.kind ).toBe( 'compressing' ) );
+
+		const compressingId = result.current.images[ 0 ].localId;
+		act( () => result.current.removeImage( compressingId ) );
+
+		const removedCalls = onTrack.mock.calls.filter(
+			( [ name ] ) => name === 'calypso_reader_atmosphere_compose_media_removed'
+		);
+		expect( removedCalls ).toHaveLength( 1 );
+		expect( removedCalls[ 0 ][ 1 ].was_uploaded ).toBe( false );
+	} );
+
+	it( 'fires _compose_alt_text_added with length only (never the text)', async () => {
+		jest.spyOn( wpcom.req, 'post' ).mockResolvedValue( okBlobResponse );
+
+		const onTrack = jest.fn();
+		const qc = new QueryClient();
+		const { result } = renderHook(
+			() => useImageUploads( { connectionId: 9, max: 4, mode: 'standalone', onTrack } ),
+			{ wrapper: wrap( qc ) }
+		);
+
+		const file = new File( [ 'src' ], 'a.png', { type: 'image/png' } );
+		await act( async () => {
+			await result.current.addFiles( [ file ] );
+		} );
+		await waitFor( () => expect( result.current.images[ 0 ].kind ).toBe( 'uploaded' ) );
+
+		const id = result.current.images[ 0 ].localId;
+		act( () => result.current.setAlt( id, 'hello world' ) );
+
+		const altCalls = onTrack.mock.calls.filter(
+			( [ name ] ) => name === 'calypso_reader_atmosphere_compose_alt_text_added'
+		);
+		expect( altCalls ).toHaveLength( 1 );
+		const props = altCalls[ 0 ][ 1 ];
+		expect( props ).toEqual( {
+			connection_id: 9,
+			mode: 'standalone',
+			length: 11,
+		} );
+		expect( props ).not.toHaveProperty( 'text' );
+
+		// Subsequent edits (still non-empty) must NOT fire again.
+		act( () => result.current.setAlt( id, 'hello world!' ) );
+		expect(
+			onTrack.mock.calls.filter(
+				( [ name ] ) => name === 'calypso_reader_atmosphere_compose_alt_text_added'
+			)
+		).toHaveLength( 1 );
+	} );
+
 	it( 'isAllUploaded and isAnyPending reflect derived state', async () => {
 		jest.spyOn( wpcom.req, 'post' ).mockResolvedValue( okBlobResponse );
 

--- a/client/reader/atmosphere/composer/media/test/use-image-uploads.test.tsx
+++ b/client/reader/atmosphere/composer/media/test/use-image-uploads.test.tsx
@@ -434,6 +434,86 @@ describe( 'useImageUploads', () => {
 		expect( removedCalls[ 0 ][ 1 ].was_uploaded ).toBe( false );
 	} );
 
+	it( 'clearAll removes every entry without firing _compose_media_removed', async () => {
+		// Composer close-cleanup uses `clearAll` so a user closing the modal
+		// doesn't fire one `media_removed` event per attached image — those
+		// would all carry stale labels (mode/connection_id snap to defaults
+		// once the composer's `mode` flips to null) and aren't meaningful as
+		// "user removed an image" events anyway.
+		jest.spyOn( wpcom.req, 'post' ).mockResolvedValue( okBlobResponse );
+
+		const onTrack = jest.fn();
+		const qc = new QueryClient();
+		const { result } = renderHook(
+			() => useImageUploads( { connectionId: 9, max: 4, mode: 'standalone', onTrack } ),
+			{ wrapper: wrap( qc ) }
+		);
+
+		const files = [
+			new File( [ 'a' ], 'a.png', { type: 'image/png' } ),
+			new File( [ 'b' ], 'b.png', { type: 'image/png' } ),
+		];
+		await act( async () => {
+			await result.current.addFiles( files );
+		} );
+
+		await waitFor( () => {
+			expect( result.current.images.every( ( i ) => i.kind === 'uploaded' ) ).toBe( true );
+		} );
+
+		onTrack.mockClear();
+		act( () => result.current.clearAll() );
+
+		expect( result.current.images ).toHaveLength( 0 );
+		expect(
+			onTrack.mock.calls.filter(
+				( [ name ] ) => name === 'calypso_reader_atmosphere_compose_media_removed'
+			)
+		).toHaveLength( 0 );
+	} );
+
+	it( 'retryImage does not fire _compose_media_removed', async () => {
+		// `retryImage` internally drops the failed entry and re-enters the
+		// upload pipeline with the same source file. The user clicked Retry,
+		// not ×, so `media_removed` would be wrong analytics — the entry
+		// hasn't been "removed" from the user's perspective, it's being
+		// retried.
+		jest
+			.spyOn( wpcom.req, 'post' )
+			.mockRejectedValueOnce( { kind: 'unknown', cause: new Error( 'down' ) } )
+			.mockResolvedValueOnce( okBlobResponse );
+
+		const onTrack = jest.fn();
+		const qc = new QueryClient();
+		const { result } = renderHook(
+			() => useImageUploads( { connectionId: 9, max: 4, mode: 'standalone', onTrack } ),
+			{ wrapper: wrap( qc ) }
+		);
+
+		const file = new File( [ 'src' ], 'a.png', { type: 'image/png' } );
+		await act( async () => {
+			await result.current.addFiles( [ file ] );
+		} );
+
+		await waitFor( () => expect( result.current.images[ 0 ].kind ).toBe( 'failed' ) );
+
+		const failedId = result.current.images[ 0 ].localId;
+		onTrack.mockClear();
+		await act( async () => {
+			await result.current.retryImage( failedId );
+		} );
+
+		await waitFor( () => {
+			expect( result.current.images[ 0 ].kind ).toBe( 'uploaded' );
+		} );
+
+		expect(
+			onTrack.mock.calls.filter(
+				( [ name ] ) => name === 'calypso_reader_atmosphere_compose_media_removed'
+			)
+		).toHaveLength( 0 );
+	} );
+
 	it( 'fires _compose_alt_text_added with length only (never the text)', async () => {
 		jest.spyOn( wpcom.req, 'post' ).mockResolvedValue( okBlobResponse );
 

--- a/client/reader/atmosphere/composer/media/test/use-image-uploads.test.tsx
+++ b/client/reader/atmosphere/composer/media/test/use-image-uploads.test.tsx
@@ -5,7 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import React from 'react';
 import wpcom from 'calypso/lib/wp';
-import { useImageUploads } from '../use-image-uploads';
+import { toAtmosphereError, useImageUploads } from '../use-image-uploads';
 
 jest.mock( '../compress-image', () => ( {
 	compressImage: jest.fn( async () => ( {
@@ -114,34 +114,32 @@ describe( 'useImageUploads', () => {
 		expect( result.current.images.length ).toBeLessThanOrEqual( 4 );
 		expect( result.current.images.length ).toBe( 4 );
 	} );
+} );
 
-	it( 'narrows non-AtmosphereError throws to { kind: "unknown" }', async () => {
-		// `uploadBlob` normally classifies its rejections through
-		// `classifyAtmosphereError`, but a transport-level failure (network
-		// drop, abort) can short-circuit before that runs. Casting `err as
-		// AtmosphereError` would let downstream `error.kind` reads return
-		// `undefined`; the type guard collapses anything unrecognized to
-		// `{ kind: 'unknown', cause: err }`.
-		jest.spyOn( wpcom.req, 'post' ).mockRejectedValue( new Error( 'network down' ) );
+describe( 'toAtmosphereError', () => {
+	// `uploadBlob` normally classifies its rejections through
+	// `classifyAtmosphereError`, but a transport-level failure (network
+	// drop, abort, JSON parse error) can short-circuit before that runs.
+	// Casting `err as AtmosphereError` would let downstream `error.kind`
+	// reads return `undefined`; the guard collapses anything unrecognized
+	// to `{ kind: 'unknown', cause: err }` so failed-state consumers stay
+	// sound.
+	it( 'passes through valid AtmosphereError shapes', () => {
+		const e = { kind: 'rate_limited', message: 'slow down' };
+		expect( toAtmosphereError( e ) ).toBe( e );
+	} );
 
-		const qc = new QueryClient();
-		const { result } = renderHook( () => useImageUploads( { connectionId: 9, max: 4 } ), {
-			wrapper: wrap( qc ),
-		} );
+	it( 'narrows Error instances to unknown', () => {
+		const e = new Error( 'boom' );
+		const narrowed = toAtmosphereError( e );
+		expect( narrowed.kind ).toBe( 'unknown' );
+		expect( ( narrowed as { cause?: unknown } ).cause ).toBe( e );
+	} );
 
-		const file = new File( [ 'src' ], 'a.png', { type: 'image/png' } );
-		await act( async () => {
-			await result.current.addFiles( [ file ] );
-		} );
-
-		await waitFor( () => {
-			expect( result.current.images[ 0 ]?.kind ).toBe( 'failed' );
-		} );
-
-		const failed = result.current.images[ 0 ];
-		if ( failed.kind !== 'failed' ) {
-			throw new Error( 'expected failed' );
-		}
-		expect( failed.error.kind ).toBe( 'unknown' );
+	it( 'narrows arbitrary thrown values to unknown', () => {
+		expect( toAtmosphereError( 'string oops' ).kind ).toBe( 'unknown' );
+		expect( toAtmosphereError( { foo: 'bar' } ).kind ).toBe( 'unknown' );
+		expect( toAtmosphereError( null ).kind ).toBe( 'unknown' );
+		expect( toAtmosphereError( undefined ).kind ).toBe( 'unknown' );
 	} );
 } );

--- a/client/reader/atmosphere/composer/media/test/use-image-uploads.test.tsx
+++ b/client/reader/atmosphere/composer/media/test/use-image-uploads.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import React from 'react';
+import wpcom from 'calypso/lib/wp';
+import { useImageUploads } from '../use-image-uploads';
+
+jest.mock( '../compress-image', () => ( {
+	compressImage: jest.fn( async () => ( {
+		blob: new Blob( [ 'compressed' ], { type: 'image/jpeg' } ),
+		width: 1000,
+		height: 750,
+		size: 'compressed'.length,
+	} ) ),
+	CompressionFailedError: class extends Error {},
+} ) );
+
+function wrap( queryClient: QueryClient ) {
+	return ( { children }: { children: React.ReactNode } ) => (
+		<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+	);
+}
+
+describe( 'useImageUploads', () => {
+	beforeAll( () => {
+		// jsdom does not implement URL.createObjectURL / revokeObjectURL.
+		Object.defineProperty( URL, 'createObjectURL', {
+			configurable: true,
+			value: jest.fn( () => 'blob:mock' ),
+		} );
+		Object.defineProperty( URL, 'revokeObjectURL', {
+			configurable: true,
+			value: jest.fn(),
+		} );
+	} );
+
+	afterEach( () => jest.restoreAllMocks() );
+
+	it( 'transitions a picked file through compressing → uploading → uploaded', async () => {
+		// Mirrors `uploadBlobMutation` factory tests: nock can't drive the
+		// upload path because superagent's Node adapter streams FormData via
+		// `form-data`, which rejects jsdom Blob/File instances before any
+		// HTTP request goes out. Spying on `wpcom.req.post` keeps the hook's
+		// state-machine wiring under test without taking on the transport's
+		// stream plumbing.
+		jest.spyOn( wpcom.req, 'post' ).mockResolvedValue( {
+			blob: {
+				$type: 'blob',
+				ref: { $link: 'bafkrei' + 'a'.repeat( 50 ) },
+				mimeType: 'image/jpeg',
+				size: 10,
+			},
+		} );
+
+		const qc = new QueryClient();
+		const { result } = renderHook( () => useImageUploads( { connectionId: 9, max: 4 } ), {
+			wrapper: wrap( qc ),
+		} );
+
+		const file = new File( [ 'src' ], 'a.png', { type: 'image/png' } );
+		await act( async () => {
+			await result.current.addFiles( [ file ] );
+		} );
+
+		await waitFor( () => {
+			expect( result.current.images ).toHaveLength( 1 );
+			expect( result.current.images[ 0 ].kind ).toBe( 'uploaded' );
+		} );
+
+		const uploaded = result.current.images[ 0 ];
+		if ( uploaded.kind !== 'uploaded' ) {
+			throw new Error( 'expected uploaded' );
+		}
+		expect( uploaded.aspectRatio ).toEqual( { width: 1000, height: 750 } );
+		expect( uploaded.blob.mimeType ).toBe( 'image/jpeg' );
+	} );
+} );

--- a/client/reader/atmosphere/composer/media/test/use-image-uploads.test.tsx
+++ b/client/reader/atmosphere/composer/media/test/use-image-uploads.test.tsx
@@ -472,6 +472,115 @@ describe( 'useImageUploads', () => {
 		).toHaveLength( 0 );
 	} );
 
+	it( 'clearAll({ deferRevocation: true }) defers preview URL revocation past staleTime', async () => {
+		// Post-publish path: the modal patches a local-preview embed onto the
+		// just-published feed item, then closes. URL revocation is deferred so
+		// the cached embed's `<img src=blob:...>` stays valid past the
+		// timeline's 30s staleTime, where the next refetch replaces it with a
+		// real CDN URL.
+		jest.useFakeTimers();
+		try {
+			jest.spyOn( wpcom.req, 'post' ).mockResolvedValue( okBlobResponse );
+
+			const qc = new QueryClient();
+			const { result } = renderHook( () => useImageUploads( { connectionId: 9, max: 4 } ), {
+				wrapper: wrap( qc ),
+			} );
+
+			const file = new File( [ 'a' ], 'a.png', { type: 'image/png' } );
+			await act( async () => {
+				await result.current.addFiles( [ file ] );
+			} );
+			await waitFor( () =>
+				expect( result.current.images.every( ( i ) => i.kind === 'uploaded' ) ).toBe( true )
+			);
+
+			( URL.revokeObjectURL as jest.Mock ).mockClear();
+			act( () => result.current.clearAll( { deferRevocation: true } ) );
+
+			// Immediate revocation MUST NOT happen — the placeholder embed in
+			// the timeline cache still references this URL.
+			expect( URL.revokeObjectURL ).not.toHaveBeenCalled();
+
+			// After the deferred timer fires (~60s later, longer than the 30s
+			// staleTime), the URL is finally revoked.
+			act( () => {
+				jest.advanceTimersByTime( 60_000 );
+			} );
+			expect( URL.revokeObjectURL ).toHaveBeenCalled();
+		} finally {
+			jest.useRealTimers();
+		}
+	} );
+
+	it( 'clearAll() (no defer) revokes preview URLs synchronously', async () => {
+		// Cancel / discard path keeps the legacy synchronous behavior so URLs
+		// are reclaimed the moment the user dismisses the composer without
+		// publishing.
+		jest.spyOn( wpcom.req, 'post' ).mockResolvedValue( okBlobResponse );
+
+		const qc = new QueryClient();
+		const { result } = renderHook( () => useImageUploads( { connectionId: 9, max: 4 } ), {
+			wrapper: wrap( qc ),
+		} );
+
+		const file = new File( [ 'a' ], 'a.png', { type: 'image/png' } );
+		await act( async () => {
+			await result.current.addFiles( [ file ] );
+		} );
+		await waitFor( () =>
+			expect( result.current.images.every( ( i ) => i.kind === 'uploaded' ) ).toBe( true )
+		);
+
+		( URL.revokeObjectURL as jest.Mock ).mockClear();
+		act( () => result.current.clearAll() );
+		expect( URL.revokeObjectURL ).toHaveBeenCalled();
+	} );
+
+	it( 'skips _compose_media_upload_error_shown when an upload fails after the entry was removed', async () => {
+		// User opens composer, picks an image, closes the composer (or hits ×)
+		// while the upload is in flight. The transport-level failure
+		// (abort / network drop) should NOT fire an analytics event because
+		// the `connection_id` / `mode` refs have snapped to their defaults
+		// once the composer closed, and the user-perceived action was a
+		// remove, not an upload-failure.
+		let rejectUpload: ( e: unknown ) => void = () => {};
+		jest.spyOn( wpcom.req, 'post' ).mockImplementation(
+			() =>
+				new Promise( ( _resolve, reject ) => {
+					rejectUpload = reject;
+				} )
+		);
+
+		const onTrack = jest.fn();
+		const qc = new QueryClient();
+		const { result } = renderHook(
+			() => useImageUploads( { connectionId: 9, max: 4, mode: 'standalone', onTrack } ),
+			{ wrapper: wrap( qc ) }
+		);
+
+		const file = new File( [ 'a' ], 'a.png', { type: 'image/png' } );
+		await act( async () => {
+			void result.current.addFiles( [ file ] );
+		} );
+		await waitFor( () => expect( result.current.images[ 0 ]?.kind ).toBe( 'uploading' ) );
+
+		const id = result.current.images[ 0 ].localId;
+		act( () => result.current.removeImage( id ) );
+
+		await act( async () => {
+			rejectUpload( { kind: 'unknown', cause: new Error( 'aborted' ) } );
+			// Flush microtasks so the catch arm runs.
+			await Promise.resolve();
+		} );
+
+		expect( result.current.images ).toHaveLength( 0 );
+		const errorCalls = onTrack.mock.calls.filter(
+			( [ name ] ) => name === 'calypso_reader_atmosphere_compose_media_upload_error_shown'
+		);
+		expect( errorCalls ).toHaveLength( 0 );
+	} );
+
 	it( 'retryImage does not fire _compose_media_removed', async () => {
 		// `retryImage` internally drops the failed entry and re-enters the
 		// upload pipeline with the same source file. The user clicked Retry,

--- a/client/reader/atmosphere/composer/media/types.ts
+++ b/client/reader/atmosphere/composer/media/types.ts
@@ -1,0 +1,41 @@
+/**
+ * Discriminated union for an image attachment as it moves through the
+ * composer state machine: `compressing → uploading → uploaded`, with
+ * `failed` as the off-ramp reachable from either step. Each variant
+ * carries only the fields that exist in that state — TypeScript narrows
+ * on `kind`, so consumers can't read a blob ref before it exists.
+ */
+
+import type { AtmosphereBlobRef, AtmosphereError } from '@automattic/api-core';
+
+export type ComposerImage =
+	| {
+			kind: 'compressing';
+			localId: string;
+			sourceFile: File;
+	  }
+	| {
+			kind: 'uploading';
+			localId: string;
+			previewUrl: string;
+			alt: string;
+			aspectRatio: { width: number; height: number };
+			abort: AbortController;
+	  }
+	| {
+			kind: 'uploaded';
+			localId: string;
+			previewUrl: string;
+			alt: string;
+			aspectRatio: { width: number; height: number };
+			blob: AtmosphereBlobRef;
+	  }
+	| {
+			kind: 'failed';
+			localId: string;
+			previewUrl: string;
+			alt: string;
+			aspectRatio: { width: number; height: number };
+			sourceFile: File;
+			error: AtmosphereError;
+	  };

--- a/client/reader/atmosphere/composer/media/use-image-uploads.ts
+++ b/client/reader/atmosphere/composer/media/use-image-uploads.ts
@@ -61,11 +61,40 @@ export interface UseImageUploadsOptions {
 	onTrack?: ( event: string, props: Record< string, unknown > ) => void;
 }
 
+export interface ClearAllOptions {
+	/**
+	 * Defer revocation of every attached preview URL by ~60s instead of
+	 * revoking synchronously. Lets the post-publish placeholder embed
+	 * (which references these URLs in cache) survive past the timeline /
+	 * author-feed staleTime. The cancel / discard path leaves this
+	 * `false` so URLs are reclaimed immediately.
+	 */
+	deferRevocation?: boolean;
+}
+
+interface DoRemoveOptions {
+	silent?: boolean;
+	deferRevocation?: boolean;
+}
+
+// How long preview blob URLs survive past `clearAll({ deferRevocation: true })`.
+// 60s comfortably outlasts the 30s timeline / author-feed staleTime, so any
+// cache entry that references a preview URL (e.g. the standalone post
+// placeholder's local embed) gets refetched and replaced with real CDN URLs
+// from the AppView before the local URL is revoked.
+const DEFERRED_REVOKE_MS = 60_000;
+
 export function useImageUploads( opts: UseImageUploadsOptions ) {
 	const queryClient = useQueryClient();
 	const { mutateAsync: uploadBlob } = useMutation( uploadBlobMutation( queryClient ) );
 	const [ images, setImages ] = useState< ComposerImage[] >( [] );
 	const previewsRef = useRef< Set< string > >( new Set() );
+	// Tracks pending deferred-revocation timers so the unmount effect can
+	// clear them. Without this, a hook unmounting before the 60s timer
+	// elapses leaves an orphan timer that holds the revoke closure (and
+	// the previewUrl string) until it fires; in tests this surfaces as a
+	// "worker has failed to exit gracefully" warning.
+	const pendingRevokeTimersRef = useRef< Set< ReturnType< typeof setTimeout > > >( new Set() );
 	// Stable refs for the analytics inputs so callbacks below don't
 	// re-create on every render. The provider re-creates `onTrack` only
 	// when its `dispatch` reference changes (effectively never), but
@@ -88,6 +117,21 @@ export function useImageUploads( opts: UseImageUploadsOptions ) {
 	// fresh attempt) nets to zero capacity change automatically.
 	const slotCountRef = useRef( 0 );
 
+	// `imagesRef` mirrors the latest `images` state so callbacks below can
+	// inspect the current image without forcing the callback's identity to
+	// change on every render. Updated inline during render — the closure
+	// reads the snapshot at event time, which is the desired behavior.
+	const imagesRef = useRef< ComposerImage[] >( [] );
+	imagesRef.current = images;
+
+	// Synchronous mirror of which `localId`s the hook is actively tracking.
+	// `setImages` is React-async, so a post-await read of `imagesRef.current`
+	// can still see the pre-add state inside the same microtask chain. This
+	// set is mutated synchronously alongside every `setImages` call, so the
+	// post-await "still tracked?" guards in `startOne` (and `doRemove`'s
+	// abort path) observe the correct membership immediately.
+	const activeIdsRef = useRef< Set< string > >( new Set() );
+
 	const update = useCallback( ( id: string, next: ComposerImage ) => {
 		setImages( ( cur ) => cur.map( ( i ) => ( i.localId === id ? next : i ) ) );
 	}, [] );
@@ -102,11 +146,20 @@ export function useImageUploads( opts: UseImageUploadsOptions ) {
 		async ( file: File, batch?: { bytesBefore: number; bytesAfter: number; uploaded: number } ) => {
 			const localId = newLocalId();
 			slotCountRef.current += 1;
+			activeIdsRef.current.add( localId );
 			setImages( ( cur ) => [ ...cur, { kind: 'compressing', localId, sourceFile: file } ] );
 			let compressed;
 			try {
 				compressed = await compressImage( file );
 			} catch ( err ) {
+				// Skip the failure write-back (and the tracks event) when the
+				// entry was removed mid-compress (composer closed, user clicked ×).
+				// `update` is a setImages-map no-op for missing ids, but the
+				// analytics event would still fire with `connection_id` / `mode`
+				// snapped from the now-defaulted refs.
+				if ( ! activeIdsRef.current.has( localId ) ) {
+					return;
+				}
 				update( localId, {
 					kind: 'failed',
 					localId,
@@ -121,6 +174,13 @@ export function useImageUploads( opts: UseImageUploadsOptions ) {
 					mode: modeRef.current,
 					error_kind: 'blob_decode_failed',
 				} );
+				return;
+			}
+
+			// Compress succeeded; if the entry was removed in the meantime
+			// (close, ×, slot freed for a retry), bail without creating a
+			// stranded preview URL or transitioning state.
+			if ( ! activeIdsRef.current.has( localId ) ) {
 				return;
 			}
 
@@ -155,6 +215,13 @@ export function useImageUploads( opts: UseImageUploadsOptions ) {
 					batch.uploaded += 1;
 				}
 			} catch ( err ) {
+				// Skip the failure write-back when the entry was removed
+				// mid-upload (× click aborts via `entry.abort.abort()`,
+				// `clearAll` drops the entry on close). Same reasoning as
+				// the compress-stage guard above.
+				if ( ! activeIdsRef.current.has( localId ) ) {
+					return;
+				}
 				const error = toAtmosphereError( err );
 				update( localId, {
 					kind: 'failed',
@@ -215,30 +282,39 @@ export function useImageUploads( opts: UseImageUploadsOptions ) {
 		[ opts.max, startOne ]
 	);
 
-	// `imagesRef` mirrors the latest `images` state so callbacks below can
-	// inspect the current image without forcing the callback's identity to
-	// change on every render. The ref is updated in a layout effect (see
-	// below) so it is in sync before any user-driven event handler runs.
-	const imagesRef = useRef< ComposerImage[] >( images );
-	imagesRef.current = images;
-
-	// Internal removal worker. `silent: true` skips the
-	// `media_removed` Tracks event — used by `clearAll` (close cleanup
-	// is a system action, not a user click) and by `retryImage` (the
-	// user clicked Retry, not ×). Public `removeImage` always reports.
-	const doRemove = useCallback( ( id: string, silent: boolean ) => {
+	// Internal removal worker.
+	// - `silent: true` skips the `media_removed` Tracks event — used by
+	//   `clearAll` (close cleanup is a system action) and `retryImage`
+	//   (user clicked Retry, not ×). Public `removeImage` always reports.
+	// - `deferRevocation: true` keeps the entry's preview URL alive on a
+	//   60s timer instead of revoking immediately, so cache entries that
+	//   reference it (placeholder embed) remain renderable past the
+	//   timeline staleTime.
+	const doRemove = useCallback( ( id: string, options: DoRemoveOptions = {} ) => {
+		const { silent = false, deferRevocation = false } = options;
 		const entry = imagesRef.current.find( ( i ) => i.localId === id );
 		if ( ! entry ) {
 			return;
 		}
 		if ( entry.kind !== 'compressing' ) {
-			URL.revokeObjectURL( entry.previewUrl );
-			previewsRef.current.delete( entry.previewUrl );
+			if ( deferRevocation ) {
+				const url = entry.previewUrl;
+				const timerId: ReturnType< typeof setTimeout > = setTimeout( () => {
+					URL.revokeObjectURL( url );
+					previewsRef.current.delete( url );
+					pendingRevokeTimersRef.current.delete( timerId );
+				}, DEFERRED_REVOKE_MS );
+				pendingRevokeTimersRef.current.add( timerId );
+			} else {
+				URL.revokeObjectURL( entry.previewUrl );
+				previewsRef.current.delete( entry.previewUrl );
+			}
 		}
 		if ( entry.kind === 'uploading' ) {
 			entry.abort.abort();
 		}
 		slotCountRef.current = Math.max( 0, slotCountRef.current - 1 );
+		activeIdsRef.current.delete( id );
 		setImages( ( cur ) => cur.filter( ( i ) => i.localId !== id ) );
 		if ( ! silent ) {
 			onTrackRef.current?.( 'calypso_reader_atmosphere_compose_media_removed', {
@@ -251,20 +327,24 @@ export function useImageUploads( opts: UseImageUploadsOptions ) {
 
 	const removeImage = useCallback(
 		( id: string ) => {
-			doRemove( id, false );
+			doRemove( id, { silent: false } );
 		},
 		[ doRemove ]
 	);
 
-	const clearAll = useCallback( () => {
-		// Snapshot the ids first — `doRemove` mutates the underlying state,
-		// and `imagesRef.current` reflects the latest commit, but iterating
-		// the live array while removing entries is a footgun. The ref array
-		// itself is stable inside this synchronous loop (state updates are
-		// batched), but a snapshot keeps the intent explicit.
-		const ids = imagesRef.current.map( ( i ) => i.localId );
-		ids.forEach( ( id ) => doRemove( id, true ) );
-	}, [ doRemove ] );
+	const clearAll = useCallback(
+		( options: ClearAllOptions = {} ) => {
+			// Snapshot the ids first — `doRemove` mutates the underlying state,
+			// and `imagesRef.current` reflects the latest commit, but iterating
+			// the live array while removing entries is a footgun. The ref array
+			// itself is stable inside this synchronous loop (state updates are
+			// batched), but a snapshot keeps the intent explicit.
+			const ids = imagesRef.current.map( ( i ) => i.localId );
+			const deferRevocation = options.deferRevocation ?? false;
+			ids.forEach( ( id ) => doRemove( id, { silent: true, deferRevocation } ) );
+		},
+		[ doRemove ]
+	);
 
 	const retryImage = useCallback(
 		async ( id: string ) => {
@@ -273,7 +353,7 @@ export function useImageUploads( opts: UseImageUploadsOptions ) {
 				return;
 			}
 			const sourceFile = target.sourceFile;
-			doRemove( id, true );
+			doRemove( id, { silent: true } );
 			await startOne( sourceFile );
 		},
 		[ doRemove, startOne ]
@@ -315,6 +395,8 @@ export function useImageUploads( opts: UseImageUploadsOptions ) {
 
 	useEffect(
 		() => () => {
+			pendingRevokeTimersRef.current.forEach( ( id ) => clearTimeout( id ) );
+			pendingRevokeTimersRef.current.clear();
 			previewsRef.current.forEach( ( url ) => URL.revokeObjectURL( url ) );
 			previewsRef.current.clear();
 		},

--- a/client/reader/atmosphere/composer/media/use-image-uploads.ts
+++ b/client/reader/atmosphere/composer/media/use-image-uploads.ts
@@ -222,7 +222,11 @@ export function useImageUploads( opts: UseImageUploadsOptions ) {
 	const imagesRef = useRef< ComposerImage[] >( images );
 	imagesRef.current = images;
 
-	const removeImage = useCallback( ( id: string ) => {
+	// Internal removal worker. `silent: true` skips the
+	// `media_removed` Tracks event — used by `clearAll` (close cleanup
+	// is a system action, not a user click) and by `retryImage` (the
+	// user clicked Retry, not ×). Public `removeImage` always reports.
+	const doRemove = useCallback( ( id: string, silent: boolean ) => {
 		const entry = imagesRef.current.find( ( i ) => i.localId === id );
 		if ( ! entry ) {
 			return;
@@ -236,24 +240,43 @@ export function useImageUploads( opts: UseImageUploadsOptions ) {
 		}
 		slotCountRef.current = Math.max( 0, slotCountRef.current - 1 );
 		setImages( ( cur ) => cur.filter( ( i ) => i.localId !== id ) );
-		onTrackRef.current?.( 'calypso_reader_atmosphere_compose_media_removed', {
-			connection_id: connectionIdRef.current,
-			was_uploaded: entry.kind === 'uploaded',
-			mode: modeRef.current,
-		} );
+		if ( ! silent ) {
+			onTrackRef.current?.( 'calypso_reader_atmosphere_compose_media_removed', {
+				connection_id: connectionIdRef.current,
+				was_uploaded: entry.kind === 'uploaded',
+				mode: modeRef.current,
+			} );
+		}
 	}, [] );
+
+	const removeImage = useCallback(
+		( id: string ) => {
+			doRemove( id, false );
+		},
+		[ doRemove ]
+	);
+
+	const clearAll = useCallback( () => {
+		// Snapshot the ids first — `doRemove` mutates the underlying state,
+		// and `imagesRef.current` reflects the latest commit, but iterating
+		// the live array while removing entries is a footgun. The ref array
+		// itself is stable inside this synchronous loop (state updates are
+		// batched), but a snapshot keeps the intent explicit.
+		const ids = imagesRef.current.map( ( i ) => i.localId );
+		ids.forEach( ( id ) => doRemove( id, true ) );
+	}, [ doRemove ] );
 
 	const retryImage = useCallback(
 		async ( id: string ) => {
-			const target = images.find( ( i ) => i.localId === id );
+			const target = imagesRef.current.find( ( i ) => i.localId === id );
 			if ( ! target || target.kind !== 'failed' ) {
 				return;
 			}
 			const sourceFile = target.sourceFile;
-			removeImage( id );
+			doRemove( id, true );
 			await startOne( sourceFile );
 		},
-		[ images, removeImage, startOne ]
+		[ doRemove, startOne ]
 	);
 
 	const setAlt = useCallback( ( id: string, alt: string ) => {
@@ -298,5 +321,14 @@ export function useImageUploads( opts: UseImageUploadsOptions ) {
 		[]
 	);
 
-	return { images, addFiles, removeImage, retryImage, setAlt, isAllUploaded, isAnyPending };
+	return {
+		images,
+		addFiles,
+		removeImage,
+		clearAll,
+		retryImage,
+		setAlt,
+		isAllUploaded,
+		isAnyPending,
+	};
 }

--- a/client/reader/atmosphere/composer/media/use-image-uploads.ts
+++ b/client/reader/atmosphere/composer/media/use-image-uploads.ts
@@ -23,6 +23,25 @@ function newLocalId(): string {
 	return `img-${ Date.now() }-${ counter }`;
 }
 
+// Narrow `unknown` thrown values to AtmosphereError. `uploadBlob` already
+// classifies its rejections through `classifyAtmosphereError`, but a
+// transport-level failure (network drop, abort, JSON parse error) can
+// short-circuit before that classifier runs. Treat anything that doesn't
+// look like a classified error as `{ kind: 'unknown' }` so downstream
+// `error.kind` reads stay sound.
+function isAtmosphereError( e: unknown ): e is AtmosphereError {
+	return (
+		typeof e === 'object' &&
+		e !== null &&
+		'kind' in e &&
+		typeof ( e as { kind: unknown } ).kind === 'string'
+	);
+}
+
+function toAtmosphereError( err: unknown ): AtmosphereError {
+	return isAtmosphereError( err ) ? err : { kind: 'unknown', cause: err };
+}
+
 export interface UseImageUploadsOptions {
 	connectionId: number;
 	max: number;
@@ -33,9 +52,23 @@ export function useImageUploads( opts: UseImageUploadsOptions ) {
 	const { mutateAsync: uploadBlob } = useMutation( uploadBlobMutation( queryClient ) );
 	const [ images, setImages ] = useState< ComposerImage[] >( [] );
 	const previewsRef = useRef< Set< string > >( new Set() );
+	// Synchronous slot count. `images.length` only reflects the count
+	// after the next render commits, so two concurrent `addFiles` calls
+	// would both capture the same `images.length` and admit more files
+	// than `max - images.length`. The ref is incremented under the cap
+	// check in `addFiles` (atomic reservation); decrement only happens if
+	// the user removes an image (Task 8), since failed entries still
+	// occupy a slot in the grid.
+	const slotCountRef = useRef( 0 );
 
 	const update = useCallback( ( id: string, next: ComposerImage ) => {
 		setImages( ( cur ) => cur.map( ( i ) => ( i.localId === id ? next : i ) ) );
+	}, [] );
+
+	const createPreview = useCallback( ( source: Blob ) => {
+		const url = URL.createObjectURL( source );
+		previewsRef.current.add( url );
+		return url;
 	}, [] );
 
 	const startOne = useCallback(
@@ -49,17 +82,16 @@ export function useImageUploads( opts: UseImageUploadsOptions ) {
 				update( localId, {
 					kind: 'failed',
 					localId,
-					previewUrl: URL.createObjectURL( file ),
+					previewUrl: createPreview( file ),
 					alt: '',
 					aspectRatio: { width: 0, height: 0 },
 					sourceFile: file,
-					error: { kind: 'blob_decode_failed', message: 'decode failed' },
+					error: { kind: 'blob_decode_failed' },
 				} );
 				return;
 			}
 
-			const previewUrl = URL.createObjectURL( compressed.blob );
-			previewsRef.current.add( previewUrl );
+			const previewUrl = createPreview( compressed.blob );
 			const abort = new AbortController();
 			const aspectRatio = { width: compressed.width, height: compressed.height };
 			update( localId, {
@@ -92,20 +124,25 @@ export function useImageUploads( opts: UseImageUploadsOptions ) {
 					alt: '',
 					aspectRatio,
 					sourceFile: file,
-					error: err as AtmosphereError,
+					error: toAtmosphereError( err ),
 				} );
 			}
 		},
-		[ opts.connectionId, uploadBlob, update ]
+		[ opts.connectionId, uploadBlob, update, createPreview ]
 	);
 
 	const addFiles = useCallback(
 		async ( files: File[] ) => {
-			const remainingSlots = opts.max - images.length;
+			// Reserve slots synchronously so back-to-back calls (mobile share
+			// sheet, double-tap) can't both observe the same count and admit
+			// more files than `max`. The ref is the source of truth between
+			// the cap check and React committing the new images.
+			const remainingSlots = opts.max - slotCountRef.current;
 			const accepted = files.slice( 0, Math.max( 0, remainingSlots ) );
+			slotCountRef.current += accepted.length;
 			await Promise.all( accepted.map( startOne ) );
 		},
-		[ images.length, opts.max, startOne ]
+		[ opts.max, startOne ]
 	);
 
 	useEffect(

--- a/client/reader/atmosphere/composer/media/use-image-uploads.ts
+++ b/client/reader/atmosphere/composer/media/use-image-uploads.ts
@@ -45,6 +45,20 @@ export function toAtmosphereError( err: unknown ): AtmosphereError {
 export interface UseImageUploadsOptions {
 	connectionId: number;
 	max: number;
+	/**
+	 * Composer mode at the time the hook is mounted. Forwarded as the
+	 * `mode` property on every Tracks event the hook fires. Optional so
+	 * existing tests don't have to thread it through; defaults to
+	 * `'standalone'`.
+	 */
+	mode?: 'standalone' | 'reply' | 'quote';
+	/**
+	 * Tracks dispatcher injected by the caller. Decouples the hook from
+	 * Redux for testability — the provider wires this to
+	 * `dispatch( recordReaderTracksEvent( ... ) )`. Optional so existing
+	 * tests that don't assert on events can omit it.
+	 */
+	onTrack?: ( event: string, props: Record< string, unknown > ) => void;
 }
 
 export function useImageUploads( opts: UseImageUploadsOptions ) {
@@ -52,6 +66,17 @@ export function useImageUploads( opts: UseImageUploadsOptions ) {
 	const { mutateAsync: uploadBlob } = useMutation( uploadBlobMutation( queryClient ) );
 	const [ images, setImages ] = useState< ComposerImage[] >( [] );
 	const previewsRef = useRef< Set< string > >( new Set() );
+	// Stable refs for the analytics inputs so callbacks below don't
+	// re-create on every render. The provider re-creates `onTrack` only
+	// when its `dispatch` reference changes (effectively never), but
+	// guarding through a ref is cheap and avoids cascade invalidation if
+	// the caller ever forgets `useCallback`.
+	const modeRef = useRef( opts.mode ?? 'standalone' );
+	modeRef.current = opts.mode ?? 'standalone';
+	const onTrackRef = useRef( opts.onTrack );
+	onTrackRef.current = opts.onTrack;
+	const connectionIdRef = useRef( opts.connectionId );
+	connectionIdRef.current = opts.connectionId;
 	// Synchronous slot count. `images.length` only reflects the count
 	// after the next render commits, so two concurrent `addFiles` calls
 	// would both capture the same `images.length` and admit more files
@@ -74,7 +99,7 @@ export function useImageUploads( opts: UseImageUploadsOptions ) {
 	}, [] );
 
 	const startOne = useCallback(
-		async ( file: File ) => {
+		async ( file: File, batch?: { bytesBefore: number; bytesAfter: number; uploaded: number } ) => {
 			const localId = newLocalId();
 			slotCountRef.current += 1;
 			setImages( ( cur ) => [ ...cur, { kind: 'compressing', localId, sourceFile: file } ] );
@@ -90,6 +115,11 @@ export function useImageUploads( opts: UseImageUploadsOptions ) {
 					aspectRatio: { width: 0, height: 0 },
 					sourceFile: file,
 					error: { kind: 'blob_decode_failed' },
+				} );
+				onTrackRef.current?.( 'calypso_reader_atmosphere_compose_media_upload_error_shown', {
+					connection_id: connectionIdRef.current,
+					mode: modeRef.current,
+					error_kind: 'blob_decode_failed',
 				} );
 				return;
 			}
@@ -119,7 +149,13 @@ export function useImageUploads( opts: UseImageUploadsOptions ) {
 					aspectRatio,
 					blob: result.blob,
 				} );
+				if ( batch ) {
+					batch.bytesBefore += file.size;
+					batch.bytesAfter += compressed.size;
+					batch.uploaded += 1;
+				}
 			} catch ( err ) {
+				const error = toAtmosphereError( err );
 				update( localId, {
 					kind: 'failed',
 					localId,
@@ -127,7 +163,12 @@ export function useImageUploads( opts: UseImageUploadsOptions ) {
 					alt: '',
 					aspectRatio,
 					sourceFile: file,
-					error: toAtmosphereError( err ),
+					error,
+				} );
+				onTrackRef.current?.( 'calypso_reader_atmosphere_compose_media_upload_error_shown', {
+					connection_id: connectionIdRef.current,
+					mode: modeRef.current,
+					error_kind: error.kind,
 				} );
 			}
 		},
@@ -143,26 +184,62 @@ export function useImageUploads( opts: UseImageUploadsOptions ) {
 			// second concurrent call sees the first call's reservations.
 			const remainingSlots = opts.max - slotCountRef.current;
 			const accepted = files.slice( 0, Math.max( 0, remainingSlots ) );
-			await Promise.all( accepted.map( startOne ) );
+			if ( accepted.length === 0 ) {
+				return;
+			}
+			onTrackRef.current?.( 'calypso_reader_atmosphere_compose_media_picked', {
+				connection_id: connectionIdRef.current,
+				count: accepted.length,
+				mode: modeRef.current,
+			} );
+
+			// `media_uploaded` fires once per `addFiles` call (per-batch),
+			// not once per global "all uploads done" moment. This is a
+			// deliberate simplification: tracking a global transition would
+			// have to reason about overlapping `addFiles` invocations and
+			// images removed mid-flight. Per-batch reporting keeps the
+			// signal simple — each picker session yields at most one
+			// `media_uploaded` event when ≥1 image succeeds.
+			const batch = { bytesBefore: 0, bytesAfter: 0, uploaded: 0 };
+			await Promise.all( accepted.map( ( f ) => startOne( f, batch ) ) );
+			if ( batch.uploaded > 0 ) {
+				onTrackRef.current?.( 'calypso_reader_atmosphere_compose_media_uploaded', {
+					connection_id: connectionIdRef.current,
+					count: batch.uploaded,
+					total_bytes_before_compress: batch.bytesBefore,
+					total_bytes_after_compress: batch.bytesAfter,
+					mode: modeRef.current,
+				} );
+			}
 		},
 		[ opts.max, startOne ]
 	);
 
+	// `imagesRef` mirrors the latest `images` state so callbacks below can
+	// inspect the current image without forcing the callback's identity to
+	// change on every render. The ref is updated in a layout effect (see
+	// below) so it is in sync before any user-driven event handler runs.
+	const imagesRef = useRef< ComposerImage[] >( images );
+	imagesRef.current = images;
+
 	const removeImage = useCallback( ( id: string ) => {
-		setImages( ( cur ) => {
-			const entry = cur.find( ( i ) => i.localId === id );
-			if ( ! entry ) {
-				return cur;
-			}
-			if ( entry.kind !== 'compressing' ) {
-				URL.revokeObjectURL( entry.previewUrl );
-				previewsRef.current.delete( entry.previewUrl );
-			}
-			if ( entry.kind === 'uploading' ) {
-				entry.abort.abort();
-			}
-			slotCountRef.current = Math.max( 0, slotCountRef.current - 1 );
-			return cur.filter( ( i ) => i.localId !== id );
+		const entry = imagesRef.current.find( ( i ) => i.localId === id );
+		if ( ! entry ) {
+			return;
+		}
+		if ( entry.kind !== 'compressing' ) {
+			URL.revokeObjectURL( entry.previewUrl );
+			previewsRef.current.delete( entry.previewUrl );
+		}
+		if ( entry.kind === 'uploading' ) {
+			entry.abort.abort();
+		}
+		slotCountRef.current = Math.max( 0, slotCountRef.current - 1 );
+		setImages( ( cur ) => cur.filter( ( i ) => i.localId !== id ) );
+		onTrackRef.current?.( 'calypso_reader_atmosphere_compose_media_removed', {
+			connection_id: connectionIdRef.current,
+			was_uploaded: entry.kind === 'uploaded',
+			mode: modeRef.current,
 		} );
 	}, [] );
 
@@ -180,6 +257,13 @@ export function useImageUploads( opts: UseImageUploadsOptions ) {
 	);
 
 	const setAlt = useCallback( ( id: string, alt: string ) => {
+		const target = imagesRef.current.find( ( i ) => i.localId === id );
+		const didTransition = Boolean(
+			target &&
+				( target.kind === 'uploading' || target.kind === 'uploaded' || target.kind === 'failed' ) &&
+				target.alt.length === 0 &&
+				alt.length > 0
+		);
 		setImages( ( cur ) =>
 			cur.map( ( i ) => {
 				if ( i.localId !== id ) {
@@ -191,6 +275,16 @@ export function useImageUploads( opts: UseImageUploadsOptions ) {
 				return i;
 			} )
 		);
+		if ( didTransition ) {
+			// Fire only on the empty → non-empty transition (not on every
+			// keystroke). Length is included for distribution analysis;
+			// the alt text itself is intentionally NEVER reported.
+			onTrackRef.current?.( 'calypso_reader_atmosphere_compose_alt_text_added', {
+				connection_id: connectionIdRef.current,
+				mode: modeRef.current,
+				length: alt.length,
+			} );
+		}
 	}, [] );
 
 	const isAllUploaded = images.every( ( i ) => i.kind === 'uploaded' );

--- a/client/reader/atmosphere/composer/media/use-image-uploads.ts
+++ b/client/reader/atmosphere/composer/media/use-image-uploads.ts
@@ -55,10 +55,12 @@ export function useImageUploads( opts: UseImageUploadsOptions ) {
 	// Synchronous slot count. `images.length` only reflects the count
 	// after the next render commits, so two concurrent `addFiles` calls
 	// would both capture the same `images.length` and admit more files
-	// than `max - images.length`. The ref is incremented under the cap
-	// check in `addFiles` (atomic reservation); decrement only happens if
-	// the user removes an image (Task 8), since failed entries still
-	// occupy a slot in the grid.
+	// than `max - images.length`. Each call to `startOne` reserves a slot
+	// (every image, including failed ones, occupies a grid cell), and
+	// `removeImage` releases it. Putting the increment inside `startOne`
+	// — instead of in `addFiles` — means `retryImage` (which calls
+	// `removeImage` to clear the failed entry, then `startOne` for the
+	// fresh attempt) nets to zero capacity change automatically.
 	const slotCountRef = useRef( 0 );
 
 	const update = useCallback( ( id: string, next: ComposerImage ) => {
@@ -74,6 +76,7 @@ export function useImageUploads( opts: UseImageUploadsOptions ) {
 	const startOne = useCallback(
 		async ( file: File ) => {
 			const localId = newLocalId();
+			slotCountRef.current += 1;
 			setImages( ( cur ) => [ ...cur, { kind: 'compressing', localId, sourceFile: file } ] );
 			let compressed;
 			try {
@@ -135,15 +138,63 @@ export function useImageUploads( opts: UseImageUploadsOptions ) {
 		async ( files: File[] ) => {
 			// Reserve slots synchronously so back-to-back calls (mobile share
 			// sheet, double-tap) can't both observe the same count and admit
-			// more files than `max`. The ref is the source of truth between
-			// the cap check and React committing the new images.
+			// more files than `max`. The actual increment happens inside
+			// `startOne` per file; we slice here against the live ref so the
+			// second concurrent call sees the first call's reservations.
 			const remainingSlots = opts.max - slotCountRef.current;
 			const accepted = files.slice( 0, Math.max( 0, remainingSlots ) );
-			slotCountRef.current += accepted.length;
 			await Promise.all( accepted.map( startOne ) );
 		},
 		[ opts.max, startOne ]
 	);
+
+	const removeImage = useCallback( ( id: string ) => {
+		setImages( ( cur ) => {
+			const entry = cur.find( ( i ) => i.localId === id );
+			if ( ! entry ) {
+				return cur;
+			}
+			if ( entry.kind !== 'compressing' ) {
+				URL.revokeObjectURL( entry.previewUrl );
+				previewsRef.current.delete( entry.previewUrl );
+			}
+			if ( entry.kind === 'uploading' ) {
+				entry.abort.abort();
+			}
+			slotCountRef.current = Math.max( 0, slotCountRef.current - 1 );
+			return cur.filter( ( i ) => i.localId !== id );
+		} );
+	}, [] );
+
+	const retryImage = useCallback(
+		async ( id: string ) => {
+			const target = images.find( ( i ) => i.localId === id );
+			if ( ! target || target.kind !== 'failed' ) {
+				return;
+			}
+			const sourceFile = target.sourceFile;
+			removeImage( id );
+			await startOne( sourceFile );
+		},
+		[ images, removeImage, startOne ]
+	);
+
+	const setAlt = useCallback( ( id: string, alt: string ) => {
+		setImages( ( cur ) =>
+			cur.map( ( i ) => {
+				if ( i.localId !== id ) {
+					return i;
+				}
+				if ( i.kind === 'uploading' || i.kind === 'uploaded' || i.kind === 'failed' ) {
+					return { ...i, alt };
+				}
+				return i;
+			} )
+		);
+	}, [] );
+
+	const isAllUploaded = images.every( ( i ) => i.kind === 'uploaded' );
+	const isAnyPending = images.some( ( i ) => i.kind === 'compressing' || i.kind === 'uploading' );
 
 	useEffect(
 		() => () => {
@@ -153,5 +204,5 @@ export function useImageUploads( opts: UseImageUploadsOptions ) {
 		[]
 	);
 
-	return { images, addFiles };
+	return { images, addFiles, removeImage, retryImage, setAlt, isAllUploaded, isAnyPending };
 }

--- a/client/reader/atmosphere/composer/media/use-image-uploads.ts
+++ b/client/reader/atmosphere/composer/media/use-image-uploads.ts
@@ -1,0 +1,120 @@
+/**
+ * Hook driving the composer image state machine: each file picked by the
+ * user moves through `compressing → uploading → uploaded`, with `failed`
+ * as the off-ramp from either step. The hook owns the array of
+ * `ComposerImage` records and the per-image `AbortController`, and tracks
+ * preview object URLs so they can be revoked on unmount.
+ *
+ * `addFiles` is the test-friendly equivalent of a `pickFiles` driver — the
+ * consuming component owns the hidden `<input type="file" />` and forwards
+ * its `FileList` here.
+ */
+
+import { uploadBlobMutation } from '@automattic/api-queries';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { compressImage } from './compress-image';
+import type { ComposerImage } from './types';
+import type { AtmosphereError } from '@automattic/api-core';
+
+let counter = 0;
+function newLocalId(): string {
+	counter += 1;
+	return `img-${ Date.now() }-${ counter }`;
+}
+
+export interface UseImageUploadsOptions {
+	connectionId: number;
+	max: number;
+}
+
+export function useImageUploads( opts: UseImageUploadsOptions ) {
+	const queryClient = useQueryClient();
+	const { mutateAsync: uploadBlob } = useMutation( uploadBlobMutation( queryClient ) );
+	const [ images, setImages ] = useState< ComposerImage[] >( [] );
+	const previewsRef = useRef< Set< string > >( new Set() );
+
+	const update = useCallback( ( id: string, next: ComposerImage ) => {
+		setImages( ( cur ) => cur.map( ( i ) => ( i.localId === id ? next : i ) ) );
+	}, [] );
+
+	const startOne = useCallback(
+		async ( file: File ) => {
+			const localId = newLocalId();
+			setImages( ( cur ) => [ ...cur, { kind: 'compressing', localId, sourceFile: file } ] );
+			let compressed;
+			try {
+				compressed = await compressImage( file );
+			} catch ( err ) {
+				update( localId, {
+					kind: 'failed',
+					localId,
+					previewUrl: URL.createObjectURL( file ),
+					alt: '',
+					aspectRatio: { width: 0, height: 0 },
+					sourceFile: file,
+					error: { kind: 'blob_decode_failed', message: 'decode failed' },
+				} );
+				return;
+			}
+
+			const previewUrl = URL.createObjectURL( compressed.blob );
+			previewsRef.current.add( previewUrl );
+			const abort = new AbortController();
+			const aspectRatio = { width: compressed.width, height: compressed.height };
+			update( localId, {
+				kind: 'uploading',
+				localId,
+				previewUrl,
+				alt: '',
+				aspectRatio,
+				abort,
+			} );
+
+			try {
+				const result = await uploadBlob( {
+					connectionId: opts.connectionId,
+					file: compressed.blob,
+				} );
+				update( localId, {
+					kind: 'uploaded',
+					localId,
+					previewUrl,
+					alt: '',
+					aspectRatio,
+					blob: result.blob,
+				} );
+			} catch ( err ) {
+				update( localId, {
+					kind: 'failed',
+					localId,
+					previewUrl,
+					alt: '',
+					aspectRatio,
+					sourceFile: file,
+					error: err as AtmosphereError,
+				} );
+			}
+		},
+		[ opts.connectionId, uploadBlob, update ]
+	);
+
+	const addFiles = useCallback(
+		async ( files: File[] ) => {
+			const remainingSlots = opts.max - images.length;
+			const accepted = files.slice( 0, Math.max( 0, remainingSlots ) );
+			await Promise.all( accepted.map( startOne ) );
+		},
+		[ images.length, opts.max, startOne ]
+	);
+
+	useEffect(
+		() => () => {
+			previewsRef.current.forEach( ( url ) => URL.revokeObjectURL( url ) );
+			previewsRef.current.clear();
+		},
+		[]
+	);
+
+	return { images, addFiles };
+}

--- a/client/reader/atmosphere/composer/media/use-image-uploads.ts
+++ b/client/reader/atmosphere/composer/media/use-image-uploads.ts
@@ -38,7 +38,7 @@ function isAtmosphereError( e: unknown ): e is AtmosphereError {
 	);
 }
 
-function toAtmosphereError( err: unknown ): AtmosphereError {
+export function toAtmosphereError( err: unknown ): AtmosphereError {
 	return isAtmosphereError( err ) ? err : { kind: 'unknown', cause: err };
 }
 

--- a/client/reader/atmosphere/composer/style.scss
+++ b/client/reader/atmosphere/composer/style.scss
@@ -150,25 +150,46 @@
 		border: none;
 		cursor: pointer;
 		padding: 4px;
+		// 4px matches the radius the focus-visible outline rounds to,
+		// so the hover background and focus ring share the same shape.
+		border-radius: 4px;
 		color: var(--studio-gray-50, #646970);
+		transition: color 120ms ease, background-color 120ms ease;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+
+		// `@wordpress/icons` SVGs do not all inherit `fill` from
+		// `currentColor` automatically (the `image` glyph used here is one
+		// of the holdouts). Mirror the FAB's pattern so the icon tracks
+		// the button's text color through hover / focus / disabled states.
+		svg {
+			fill: currentColor;
+		}
 
 		&:hover {
 			color: var(--studio-blue-50, #3858e9);
+			background-color: var(--studio-blue-0, #f0f6fc);
 		}
 
 		&:focus-visible {
 			outline: 2px solid var(--studio-blue-50, #3858e9);
 			outline-offset: 2px;
-			border-radius: 2px;
 		}
 
 		// Native `disabled` would block focus; the button uses
 		// `aria-disabled` instead so AT users can still discover the
 		// "Maximum N images" tooltip via keyboard. Mirror that with the
-		// not-allowed cursor + muted color.
+		// not-allowed cursor + muted color, and suppress the hover
+		// affordance so the button visually reads as inert.
 		&[aria-disabled='true'] {
 			cursor: not-allowed;
 			color: var(--studio-gray-20, #a7aaad);
+
+			&:hover {
+				color: var(--studio-gray-20, #a7aaad);
+				background-color: transparent;
+			}
 		}
 	}
 

--- a/client/reader/atmosphere/composer/style.scss
+++ b/client/reader/atmosphere/composer/style.scss
@@ -245,6 +245,25 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	color: var(--studio-gray-30, #8c8f94);
+	transition: color 120ms ease, border-color 120ms ease, background-color 120ms ease;
+
+	// `@wordpress/icons` SVGs don't all inherit `currentColor` for fill;
+	// match the FAB / media button pattern so the icon tracks button color.
+	svg {
+		fill: currentColor;
+	}
+
+	&:hover {
+		color: var(--studio-blue-50, #3858e9);
+		border-color: var(--studio-blue-50, #3858e9);
+		background-color: var(--studio-blue-0, #f0f6fc);
+	}
+
+	&:focus-visible {
+		outline: 2px solid var(--studio-blue-50, #3858e9);
+		outline-offset: 2px;
+	}
 }
 
 .atmosphere-composer__image-remove {

--- a/client/reader/atmosphere/composer/style.scss
+++ b/client/reader/atmosphere/composer/style.scss
@@ -167,3 +167,77 @@
 		}
 	}
 }
+
+.atmosphere-composer__image-grid {
+	display: flex;
+	gap: 8px;
+	margin-block-start: 12px;
+	flex-wrap: wrap;
+}
+
+.atmosphere-composer__image,
+.atmosphere-composer__image-add {
+	position: relative;
+	inline-size: 90px;
+	block-size: 90px;
+	// 6px matches the surrounding compose surfaces (`.atmosphere-compose-pill`,
+	// `.atmosphere-compose-fab`, `.quick-post`) instead of the design-system
+	// scale.
+	/* stylelint-disable-next-line scales/radii */
+	border-radius: 6px;
+	overflow: hidden;
+}
+
+.atmosphere-composer__image img {
+	inline-size: 100%;
+	block-size: 100%;
+	object-fit: cover;
+}
+
+.atmosphere-composer__image.is-failed {
+	outline: 2px solid var(--studio-red-50, #d63638);
+}
+
+.atmosphere-composer__image-add {
+	border: 2px dashed var(--studio-gray-10, #c3c4c7);
+	background: transparent;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.atmosphere-composer__image-remove {
+	position: absolute;
+	inset-block-start: 4px;
+	inset-inline-end: 4px;
+	background: rgba(0, 0, 0, 0.7);
+	color: #fff;
+	border: 0;
+	border-radius: 50%;
+	inline-size: 20px;
+	block-size: 20px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.atmosphere-composer__image-alt {
+	position: absolute;
+	inset-block-end: 4px;
+	inset-inline-start: 4px;
+}
+
+.atmosphere-composer__image-error {
+	position: absolute;
+	inset: 0;
+	background: rgba(0, 0, 0, 0.7);
+	color: #fff;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	padding: 6px;
+	text-align: center;
+	font-size: 11px;
+}

--- a/client/reader/atmosphere/composer/style.scss
+++ b/client/reader/atmosphere/composer/style.scss
@@ -266,6 +266,41 @@
 	position: absolute;
 	inset-block-end: 4px;
 	inset-inline-start: 4px;
+
+	// Override the `@wordpress/components` secondary Button so the ALT
+	// badge reads against any photo background — the default
+	// blue-on-white treatment all but disappears on light or
+	// high-contrast images. Mirror the remove button's opaque-dark
+	// chip pattern (rgba(0, 0, 0, 0.7) + #fff text) so both badges
+	// share a consistent visual language at the corners of a
+	// thumbnail.
+	.components-button.is-secondary {
+		background: rgba(0, 0, 0, 0.7);
+		color: #fff;
+		box-shadow: none;
+		border: 0;
+		font-weight: 600;
+		font-size: 11px;
+		min-height: 0;
+		height: auto;
+		padding: 2px 6px;
+		line-height: 1.4;
+		// Match the thumbnail's rounded chip aesthetic without picking
+		// up the design system's larger Button radius.
+		border-radius: 4px;
+
+		&:hover:not(:disabled),
+		&:focus:not(:disabled) {
+			background: rgba(0, 0, 0, 0.85);
+			color: #fff;
+			box-shadow: none;
+		}
+
+		&:focus-visible {
+			outline: 2px solid #fff;
+			outline-offset: 1px;
+		}
+	}
 }
 
 .atmosphere-composer__image-error {

--- a/client/reader/atmosphere/composer/style.scss
+++ b/client/reader/atmosphere/composer/style.scss
@@ -148,9 +148,28 @@
 	.atmosphere-composer__media {
 		background: transparent;
 		border: none;
-		cursor: default;
+		cursor: pointer;
 		padding: 4px;
 		color: var(--studio-gray-50, #646970);
+
+		&:hover {
+			color: var(--studio-blue-50, #3858e9);
+		}
+
+		&:focus-visible {
+			outline: 2px solid var(--studio-blue-50, #3858e9);
+			outline-offset: 2px;
+			border-radius: 2px;
+		}
+
+		// Native `disabled` would block focus; the button uses
+		// `aria-disabled` instead so AT users can still discover the
+		// "Maximum N images" tooltip via keyboard. Mirror that with the
+		// not-allowed cursor + muted color.
+		&[aria-disabled='true'] {
+			cursor: not-allowed;
+			color: var(--studio-gray-20, #a7aaad);
+		}
 	}
 
 	.atmosphere-composer__count {

--- a/client/reader/atmosphere/composer/style.scss
+++ b/client/reader/atmosphere/composer/style.scss
@@ -260,6 +260,24 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	cursor: pointer;
+
+	// `@wordpress/icons` SVGs don't always inherit `currentColor` for
+	// fill, so the `closeSmall` glyph rendered in its native dark stroke
+	// against the dark chip background. Force the inherit so the × tracks
+	// the button's white `color`.
+	svg {
+		fill: currentColor;
+	}
+
+	&:hover {
+		background: rgba(0, 0, 0, 0.85);
+	}
+
+	&:focus-visible {
+		outline: 2px solid #fff;
+		outline-offset: 1px;
+	}
 }
 
 .atmosphere-composer__image-alt {

--- a/client/reader/atmosphere/composer/test/composer-footer.test.tsx
+++ b/client/reader/atmosphere/composer/test/composer-footer.test.tsx
@@ -4,10 +4,53 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ComposerFooter } from '../composer-footer';
+import { useComposer } from '../composer-provider';
+import type { ComposerImage } from '../media/types';
+
+jest.mock( '../composer-provider', () => ( {
+	useComposer: jest.fn(),
+} ) );
+
+const mockUseComposer = useComposer as jest.MockedFunction< typeof useComposer >;
+
+function makeUploadedImage( id: string ): ComposerImage {
+	return {
+		kind: 'uploaded',
+		localId: id,
+		previewUrl: `blob:${ id }`,
+		alt: '',
+		aspectRatio: { width: 100, height: 100 },
+		blob: { ref: { $link: id }, mimeType: 'image/jpeg', size: 100 } as never,
+	};
+}
 
 const noop = () => {};
 
+function setComposerState( overrides: Partial< ReturnType< typeof useComposer > > = {} ) {
+	mockUseComposer.mockReturnValue( {
+		mode: null,
+		openComposer: jest.fn(),
+		closeComposer: jest.fn(),
+		images: [],
+		addFiles: jest.fn(),
+		removeImage: jest.fn(),
+		retryImage: jest.fn(),
+		setAlt: jest.fn(),
+		isAllUploaded: true,
+		isAnyPending: false,
+		...overrides,
+	} as ReturnType< typeof useComposer > );
+}
+
 describe( '<ComposerFooter>', () => {
+	beforeEach( () => {
+		setComposerState();
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
 	it( 'shows the remaining count', () => {
 		render(
 			<ComposerFooter graphemeCount={ 100 } onSubmit={ noop } isPending={ false } limit={ 300 } />
@@ -43,13 +86,32 @@ describe( '<ComposerFooter>', () => {
 		expect( screen.getByText( '-5' ) ).toHaveClass( 'is-over' );
 	} );
 
-	it( 'media button is aria-disabled and tab-reachable', () => {
+	it( 'media button is enabled and labeled "Add media" with no images', () => {
 		render(
 			<ComposerFooter graphemeCount={ 5 } onSubmit={ noop } isPending={ false } limit={ 300 } />
 		);
-		const media = screen.getByRole( 'button', { name: /add media/i } );
+		const media = screen.getByRole( 'button', { name: 'Add media' } );
+		expect( media ).not.toHaveAttribute( 'aria-disabled' );
+		expect( media ).not.toBeDisabled();
+	} );
+
+	it( 'media button is aria-disabled and reads "Maximum 4 images" at 4 images', () => {
+		setComposerState( {
+			images: [
+				makeUploadedImage( 'a' ),
+				makeUploadedImage( 'b' ),
+				makeUploadedImage( 'c' ),
+				makeUploadedImage( 'd' ),
+			],
+		} );
+		render(
+			<ComposerFooter graphemeCount={ 5 } onSubmit={ noop } isPending={ false } limit={ 300 } />
+		);
+		const media = screen.getByRole( 'button', { name: 'Maximum 4 images' } );
 		expect( media ).toHaveAttribute( 'aria-disabled', 'true' );
-		expect( media ).toHaveAttribute( 'tabindex', '0' );
+		// We use aria-disabled (not the native HTML `disabled` attribute) so
+		// screen-reader users can still focus the button and hear the label.
+		expect( media ).not.toBeDisabled();
 	} );
 
 	it( 'shows spinner state when pending', () => {

--- a/client/reader/atmosphere/composer/test/composer-footer.test.tsx
+++ b/client/reader/atmosphere/composer/test/composer-footer.test.tsx
@@ -34,6 +34,7 @@ function setComposerState( overrides: Partial< ReturnType< typeof useComposer > 
 		images: [],
 		addFiles: jest.fn(),
 		removeImage: jest.fn(),
+		clearAll: jest.fn(),
 		retryImage: jest.fn(),
 		setAlt: jest.fn(),
 		isAllUploaded: true,

--- a/client/reader/atmosphere/composer/test/composer-modal.test.tsx
+++ b/client/reader/atmosphere/composer/test/composer-modal.test.tsx
@@ -10,6 +10,8 @@ import * as analytics from 'calypso/state/reader/analytics/actions';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { ComposerModal } from '../composer-modal';
 import { ComposerProvider, useComposer } from '../composer-provider';
+import { useImageUploads } from '../media/use-image-uploads';
+import type { ComposerImage } from '../media/types';
 
 jest.mock( '@automattic/calypso-router', () => ( {
 	__esModule: true,
@@ -19,6 +21,38 @@ jest.mock( '@automattic/calypso-router', () => ( {
 jest.mock( 'calypso/lib/logstash', () => ( {
 	logToLogstash: jest.fn(),
 } ) );
+
+jest.mock( '../media/use-image-uploads', () => ( {
+	useImageUploads: jest.fn(),
+} ) );
+
+const mockUseImageUploads = useImageUploads as jest.MockedFunction< typeof useImageUploads >;
+
+function makeUploadedImage( id: string ): ComposerImage {
+	return {
+		kind: 'uploaded',
+		localId: id,
+		previewUrl: `blob:${ id }`,
+		alt: '',
+		aspectRatio: { width: 100, height: 100 },
+		blob: { ref: { $link: id }, mimeType: 'image/jpeg', size: 100 } as never,
+	};
+}
+
+function makeImageUploadsState(
+	overrides: Partial< ReturnType< typeof useImageUploads > > = {}
+): ReturnType< typeof useImageUploads > {
+	return {
+		images: [],
+		addFiles: jest.fn(),
+		removeImage: jest.fn(),
+		retryImage: jest.fn(),
+		setAlt: jest.fn(),
+		isAllUploaded: true,
+		isAnyPending: false,
+		...overrides,
+	};
+}
 
 function makePreview() {
 	return {
@@ -172,6 +206,7 @@ describe( '<ComposerModal>', () => {
 			.mockImplementation( () => ( { type: '@@TEST/NOOP' } ) as never );
 		jest.spyOn( noticeActions, 'successNotice' );
 		( page as unknown as jest.Mock ).mockReset();
+		mockUseImageUploads.mockReturnValue( makeImageUploadsState() );
 	} );
 
 	afterEach( () => {
@@ -355,16 +390,55 @@ describe( '<ComposerModal>', () => {
 		expect( count ).toBeVisible();
 	} );
 
-	it( 'media button is aria-disabled and tab-reachable inside the dialog', async () => {
+	it( 'media button opens the file picker when clicked', async () => {
+		const addFiles = jest.fn();
+		mockUseImageUploads.mockReturnValue( makeImageUploadsState( { addFiles } ) );
+
 		const user = userEvent.setup();
 		renderWithProvider( <Harness connectionId={ 42 } /> );
 		await user.click( screen.getByText( 'open' ) );
 
-		const media = screen.getByRole( 'button', { name: /add media/i } );
+		const media = screen.getByRole( 'button', { name: 'Add media' } );
+		// The hidden file input is a sibling of the button. Spy on its
+		// .click() — the integration we care about is button → input.click().
+		const dialog = screen.getByRole( 'dialog' );
+		const input = dialog.querySelector( 'input[type="file"]' ) as HTMLInputElement | null;
+		expect( input ).not.toBeNull();
+		const inputClickSpy = jest.spyOn( input as HTMLInputElement, 'click' );
+
+		await user.click( media );
+		expect( inputClickSpy ).toHaveBeenCalledTimes( 1 );
+
+		// And once the input fires onChange (via userEvent.upload), addFiles
+		// is invoked with the picked files. This proves the second half of
+		// the wiring without depending on the browser's actual picker.
+		const file = new File( [ 'x' ], 'a.jpg', { type: 'image/jpeg' } );
+		await user.upload( input as HTMLInputElement, [ file ] );
+		expect( addFiles ).toHaveBeenCalledTimes( 1 );
+		expect( addFiles.mock.calls[ 0 ][ 0 ] ).toHaveLength( 1 );
+		expect( addFiles.mock.calls[ 0 ][ 0 ][ 0 ].name ).toBe( 'a.jpg' );
+	} );
+
+	it( 'media button is disabled at 4 images and reads "Maximum 4 images"', async () => {
+		mockUseImageUploads.mockReturnValue(
+			makeImageUploadsState( {
+				images: [
+					makeUploadedImage( 'a' ),
+					makeUploadedImage( 'b' ),
+					makeUploadedImage( 'c' ),
+					makeUploadedImage( 'd' ),
+				],
+			} )
+		);
+
+		const user = userEvent.setup();
+		renderWithProvider( <Harness connectionId={ 42 } /> );
+		await user.click( screen.getByText( 'open' ) );
+
+		const media = screen.getByRole( 'button', { name: 'Maximum 4 images' } );
 		expect( media ).toHaveAttribute( 'aria-disabled', 'true' );
-		// The native HTML `disabled` attribute would remove the button
-		// from the tab order. We use aria-disabled so screen-reader
-		// users can reach the placeholder while it remains inert.
+		// We use aria-disabled (not the native HTML `disabled` attribute) so
+		// screen-reader users can still focus the button and hear the label.
 		expect( media ).not.toBeDisabled();
 	} );
 

--- a/client/reader/atmosphere/composer/test/composer-modal.test.tsx
+++ b/client/reader/atmosphere/composer/test/composer-modal.test.tsx
@@ -303,23 +303,26 @@ describe( '<ComposerModal>', () => {
 		expect( screen.getByRole( 'textbox' ) ).toHaveValue( 'hi' );
 	} );
 
-	it( 'shows a media_invalid error message after a /posts rejection', async () => {
+	it( 'shows the bad_request copy after a /posts media rejection', async () => {
+		// The slice-8a backend collapses every media-body validation
+		// failure into the generic `atmosphere_bad_request` wire code (see
+		// `reader-atmosphere/AGENTS.md` — "the wire stays stable"), so the
+		// composer renders its existing `bad_request` copy rather than a
+		// media-specific message.
 		mockUseImageUploads.mockReturnValue(
 			makeImageUploadsState( { images: [ makeUploadedImage( 'a' ) ] } )
 		);
 
 		nock( 'https://public-api.wordpress.com' )
 			.post( '/wpcom/v2/reader/atmosphere/connections/42/posts' )
-			.reply( 400, { error: 'atmosphere_media_invalid' } );
+			.reply( 400, { error: 'atmosphere_bad_request', message: 'Invalid media payload.' } );
 
 		const user = userEvent.setup();
 		renderWithProvider( <HarnessStandalone connectionId={ 42 } entryPoint="timeline_inline" /> );
 		await user.click( screen.getByText( 'open' ) );
 		await user.click( screen.getByRole( 'button', { name: 'Post' } ) );
 
-		expect(
-			await screen.findByText( /something’s wrong with the attached images/i )
-		).toBeVisible();
+		expect( await screen.findByText( /we couldn't post this/i ) ).toBeVisible();
 		expect( screen.getByRole( 'dialog' ) ).toBeVisible();
 	} );
 

--- a/client/reader/atmosphere/composer/test/composer-modal.test.tsx
+++ b/client/reader/atmosphere/composer/test/composer-modal.test.tsx
@@ -46,6 +46,7 @@ function makeImageUploadsState(
 		images: [],
 		addFiles: jest.fn(),
 		removeImage: jest.fn(),
+		clearAll: jest.fn(),
 		retryImage: jest.fn(),
 		setAlt: jest.fn(),
 		isAllUploaded: true,

--- a/client/reader/atmosphere/composer/test/composer-modal.test.tsx
+++ b/client/reader/atmosphere/composer/test/composer-modal.test.tsx
@@ -303,6 +303,26 @@ describe( '<ComposerModal>', () => {
 		expect( screen.getByRole( 'textbox' ) ).toHaveValue( 'hi' );
 	} );
 
+	it( 'shows a media_invalid error message after a /posts rejection', async () => {
+		mockUseImageUploads.mockReturnValue(
+			makeImageUploadsState( { images: [ makeUploadedImage( 'a' ) ] } )
+		);
+
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/wpcom/v2/reader/atmosphere/connections/42/posts' )
+			.reply( 400, { error: 'atmosphere_media_invalid' } );
+
+		const user = userEvent.setup();
+		renderWithProvider( <HarnessStandalone connectionId={ 42 } entryPoint="timeline_inline" /> );
+		await user.click( screen.getByText( 'open' ) );
+		await user.click( screen.getByRole( 'button', { name: 'Post' } ) );
+
+		expect(
+			await screen.findByText( /something’s wrong with the attached images/i )
+		).toBeVisible();
+		expect( screen.getByRole( 'dialog' ) ).toBeVisible();
+	} );
+
 	it( 'maps 401 to a Reconnect link with target=_blank', async () => {
 		nock( 'https://public-api.wordpress.com' )
 			.post( '/wpcom/v2/reader/atmosphere/connections/42/posts' )

--- a/client/reader/atmosphere/composer/test/composer-modal.test.tsx
+++ b/client/reader/atmosphere/composer/test/composer-modal.test.tsx
@@ -401,8 +401,12 @@ describe( '<ComposerModal>', () => {
 		const media = screen.getByRole( 'button', { name: 'Add media' } );
 		// The hidden file input is a sibling of the button. Spy on its
 		// .click() — the integration we care about is button → input.click().
+		// Scope to the footer-left wrapper since <ImageGrid> can also render
+		// a hidden file input once images are attached.
 		const dialog = screen.getByRole( 'dialog' );
-		const input = dialog.querySelector( 'input[type="file"]' ) as HTMLInputElement | null;
+		const input = dialog.querySelector(
+			'.atmosphere-composer__footer-left input[type="file"]'
+		) as HTMLInputElement | null;
 		expect( input ).not.toBeNull();
 		const inputClickSpy = jest.spyOn( input as HTMLInputElement, 'click' );
 
@@ -440,6 +444,112 @@ describe( '<ComposerModal>', () => {
 		// We use aria-disabled (not the native HTML `disabled` attribute) so
 		// screen-reader users can still focus the button and hear the label.
 		expect( media ).not.toBeDisabled();
+	} );
+
+	it( 'renders the ImageGrid below the textarea when images are attached', async () => {
+		mockUseImageUploads.mockReturnValue(
+			makeImageUploadsState( { images: [ makeUploadedImage( 'a' ) ] } )
+		);
+
+		const user = userEvent.setup();
+		renderWithProvider( <HarnessStandalone connectionId={ 42 } entryPoint="timeline_inline" /> );
+		await user.click( screen.getByText( 'open' ) );
+
+		// Grid renders an <img> for each uploaded thumbnail.
+		const dialog = screen.getByRole( 'dialog' );
+		const textbox = screen.getByRole( 'textbox' );
+		const thumb = dialog.querySelector( '.atmosphere-composer__image-grid img' );
+		expect( thumb ).not.toBeNull();
+		// DOM order: textarea precedes the grid.
+		expect(
+			textbox.compareDocumentPosition( thumb as HTMLElement ) & Node.DOCUMENT_POSITION_FOLLOWING
+		).toBeTruthy();
+	} );
+
+	it( 'enables Post when text is empty and one image is uploaded', async () => {
+		mockUseImageUploads.mockReturnValue(
+			makeImageUploadsState( { images: [ makeUploadedImage( 'a' ) ] } )
+		);
+
+		const user = userEvent.setup();
+		renderWithProvider( <HarnessStandalone connectionId={ 42 } entryPoint="timeline_inline" /> );
+		await user.click( screen.getByText( 'open' ) );
+
+		expect( screen.getByRole( 'button', { name: 'Post' } ) ).toBeEnabled();
+	} );
+
+	it( 'submits with media payload (standalone mode)', async () => {
+		mockUseImageUploads.mockReturnValue(
+			makeImageUploadsState( { images: [ makeUploadedImage( 'a' ) ] } )
+		);
+
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/wpcom/v2/reader/atmosphere/connections/42/posts', ( body: unknown ) => {
+				const b = body as {
+					text?: string;
+					media?: { images?: Array< { blob?: unknown; alt?: string } > };
+				};
+				return (
+					b.text === '' &&
+					Array.isArray( b.media?.images ) &&
+					b.media?.images?.length === 1 &&
+					b.media?.images?.[ 0 ]?.alt === '' &&
+					!! b.media?.images?.[ 0 ]?.blob
+				);
+			} )
+			.reply( 200, { post: { uri: 'at://new', cid: 'newcid', rkey: 'abc' } } );
+
+		const user = userEvent.setup();
+		renderWithProvider( <HarnessStandalone connectionId={ 42 } entryPoint="timeline_inline" /> );
+		await user.click( screen.getByText( 'open' ) );
+		await user.click( screen.getByRole( 'button', { name: 'Post' } ) );
+
+		await waitFor( () => expect( nock.isDone() ).toBe( true ) );
+	} );
+
+	it( 'submits with quote + media (recordWithMedia)', async () => {
+		mockUseImageUploads.mockReturnValue(
+			makeImageUploadsState( { images: [ makeUploadedImage( 'a' ) ] } )
+		);
+
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/wpcom/v2/reader/atmosphere/connections/42/posts', ( body: unknown ) => {
+				const b = body as {
+					text?: string;
+					quote?: { uri?: string; cid?: string };
+					media?: { images?: unknown[] };
+				};
+				return (
+					b.text === 'q' &&
+					b.quote?.uri ===
+						'at://did:plc:abcdefghijklmnopqrstuvwx/app.bsky.feed.post/bbbbbbbbbbbbb' &&
+					b.quote?.cid === 'pcid' &&
+					Array.isArray( b.media?.images ) &&
+					b.media?.images?.length === 1
+				);
+			} )
+			.reply( 200, { post: { uri: 'at://new-quote', cid: 'newcid', rkey: 'abc' } } );
+
+		const user = userEvent.setup();
+		renderWithProvider( <HarnessQuote connectionId={ 42 } /> );
+		await user.click( screen.getByText( 'open' ) );
+		await user.type( screen.getByRole( 'textbox' ), 'q' );
+		await user.click( screen.getByRole( 'button', { name: 'Post' } ) );
+
+		await waitFor( () => expect( nock.isDone() ).toBe( true ) );
+	} );
+
+	it( 'shows DiscardConfirm when closing the modal with attached images and no text', async () => {
+		mockUseImageUploads.mockReturnValue(
+			makeImageUploadsState( { images: [ makeUploadedImage( 'a' ) ] } )
+		);
+
+		const user = userEvent.setup();
+		renderWithProvider( <HarnessStandalone connectionId={ 42 } entryPoint="timeline_inline" /> );
+		await user.click( screen.getByText( 'open' ) );
+		await user.keyboard( '{Escape}' );
+
+		expect( await screen.findByRole( 'button', { name: /^discard$/i } ) ).toBeVisible();
 	} );
 
 	it( 'Cmd+Enter on empty text does not POST (matches the disabled Post button)', async () => {

--- a/client/reader/atmosphere/composer/test/composer-provider.test.tsx
+++ b/client/reader/atmosphere/composer/test/composer-provider.test.tsx
@@ -122,7 +122,7 @@ describe( 'useComposer', () => {
 					>
 						open
 					</button>
-					{ mode && <button onClick={ closeComposer }>close</button> }
+					{ mode && <button onClick={ () => closeComposer() }>close</button> }
 				</>
 			);
 		}

--- a/client/reader/atmosphere/composer/test/composer-provider.test.tsx
+++ b/client/reader/atmosphere/composer/test/composer-provider.test.tsx
@@ -5,18 +5,28 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, renderHook, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from 'react';
+import { Provider } from 'react-redux';
+import { applyMiddleware, createStore } from 'redux';
+import { thunk as thunkMiddleware } from 'redux-thunk';
 import { ComposerProvider, useComposer } from '../composer-provider';
 
 // `ComposerProvider` consumes `useImageUploads`, which requires a
-// `QueryClientProvider` in the tree. Each test gets its own client so
-// cached state never leaks between cases.
-function withQueryClient( ui: React.ReactNode ) {
-	return <QueryClientProvider client={ new QueryClient() }>{ ui }</QueryClientProvider>;
+// `QueryClientProvider` in the tree, and dispatches Tracks events via
+// `useDispatch`, which requires a Redux `<Provider>`. Each test gets its
+// own client + a permissive noop store so cached state and dispatched
+// actions never leak between cases.
+function withProviders( ui: React.ReactNode ) {
+	const store = createStore( ( s = {} ) => s, applyMiddleware( thunkMiddleware ) );
+	return (
+		<QueryClientProvider client={ new QueryClient() }>
+			<Provider store={ store }>{ ui }</Provider>
+		</QueryClientProvider>
+	);
 }
 
 const wrap = ( connectionId: number ) =>
 	function Wrapper( { children }: { children: React.ReactNode } ) {
-		return withQueryClient(
+		return withProviders(
 			<ComposerProvider connectionId={ connectionId }>{ children }</ComposerProvider>
 		);
 	};
@@ -85,7 +95,7 @@ describe( 'useComposer', () => {
 			);
 		}
 
-		render( withQueryClient( <Harness /> ) );
+		render( withProviders( <Harness /> ) );
 		expect( screen.getByTestId( 'probe' ) ).toHaveTextContent( 'closed' );
 		await user.click( screen.getByRole( 'button', { name: 'open' } ) );
 		expect( screen.getByTestId( 'probe' ) ).toHaveTextContent( '42' );
@@ -118,7 +128,7 @@ describe( 'useComposer', () => {
 		}
 
 		render(
-			withQueryClient(
+			withProviders(
 				<ComposerProvider connectionId={ 42 }>
 					<FocusHarness />
 				</ComposerProvider>
@@ -136,7 +146,7 @@ describe( 'useComposer', () => {
 	it( 'throws if useComposer is called outside ComposerProvider', () => {
 		expect( () =>
 			renderHook( () => useComposer(), {
-				wrapper: ( { children }: { children: React.ReactNode } ) => withQueryClient( children ),
+				wrapper: ( { children }: { children: React.ReactNode } ) => withProviders( children ),
 			} )
 		).toThrow();
 	} );
@@ -158,7 +168,7 @@ describe( 'useComposer', () => {
 		}
 
 		render(
-			withQueryClient(
+			withProviders(
 				<ComposerProvider connectionId={ 42 }>
 					<Probe />
 				</ComposerProvider>
@@ -184,7 +194,7 @@ describe( 'useComposer', () => {
 		}
 
 		render(
-			withQueryClient(
+			withProviders(
 				<ComposerProvider connectionId={ 1 }>
 					<TestConsumer />
 				</ComposerProvider>

--- a/client/reader/atmosphere/composer/test/composer-provider.test.tsx
+++ b/client/reader/atmosphere/composer/test/composer-provider.test.tsx
@@ -1,14 +1,24 @@
 /**
  * @jest-environment jsdom
  */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, renderHook, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from 'react';
 import { ComposerProvider, useComposer } from '../composer-provider';
 
+// `ComposerProvider` consumes `useImageUploads`, which requires a
+// `QueryClientProvider` in the tree. Each test gets its own client so
+// cached state never leaks between cases.
+function withQueryClient( ui: React.ReactNode ) {
+	return <QueryClientProvider client={ new QueryClient() }>{ ui }</QueryClientProvider>;
+}
+
 const wrap = ( connectionId: number ) =>
 	function Wrapper( { children }: { children: React.ReactNode } ) {
-		return <ComposerProvider connectionId={ connectionId }>{ children }</ComposerProvider>;
+		return withQueryClient(
+			<ComposerProvider connectionId={ connectionId }>{ children }</ComposerProvider>
+		);
 	};
 
 describe( 'useComposer', () => {
@@ -75,7 +85,7 @@ describe( 'useComposer', () => {
 			);
 		}
 
-		render( <Harness /> );
+		render( withQueryClient( <Harness /> ) );
 		expect( screen.getByTestId( 'probe' ) ).toHaveTextContent( 'closed' );
 		await user.click( screen.getByRole( 'button', { name: 'open' } ) );
 		expect( screen.getByTestId( 'probe' ) ).toHaveTextContent( '42' );
@@ -108,9 +118,11 @@ describe( 'useComposer', () => {
 		}
 
 		render(
-			<ComposerProvider connectionId={ 42 }>
-				<FocusHarness />
-			</ComposerProvider>
+			withQueryClient(
+				<ComposerProvider connectionId={ 42 }>
+					<FocusHarness />
+				</ComposerProvider>
+			)
 		);
 
 		const openBtn = screen.getByRole( 'button', { name: 'open' } );
@@ -122,7 +134,38 @@ describe( 'useComposer', () => {
 	} );
 
 	it( 'throws if useComposer is called outside ComposerProvider', () => {
-		expect( () => renderHook( () => useComposer() ) ).toThrow();
+		expect( () =>
+			renderHook( () => useComposer(), {
+				wrapper: ( { children }: { children: React.ReactNode } ) => withQueryClient( children ),
+			} )
+		).toThrow();
+	} );
+
+	it( 'exposes the image-upload state machine through the composer context', () => {
+		function Probe() {
+			const ctx = useComposer();
+			return (
+				<ul data-testid="probe">
+					{ 'images' in ctx && <li>images</li> }
+					{ 'addFiles' in ctx && <li>addFiles</li> }
+					{ 'removeImage' in ctx && <li>removeImage</li> }
+					{ 'retryImage' in ctx && <li>retryImage</li> }
+					{ 'setAlt' in ctx && <li>setAlt</li> }
+					{ 'isAllUploaded' in ctx && <li>isAllUploaded</li> }
+					{ 'isAnyPending' in ctx && <li>isAnyPending</li> }
+				</ul>
+			);
+		}
+
+		render(
+			withQueryClient(
+				<ComposerProvider connectionId={ 42 }>
+					<Probe />
+				</ComposerProvider>
+			)
+		);
+
+		expect( screen.getByTestId( 'probe' ).children ).toHaveLength( 7 );
 	} );
 
 	it( 'preserves entry_point on standalone mode', async () => {
@@ -141,9 +184,11 @@ describe( 'useComposer', () => {
 		}
 
 		render(
-			<ComposerProvider connectionId={ 1 }>
-				<TestConsumer />
-			</ComposerProvider>
+			withQueryClient(
+				<ComposerProvider connectionId={ 1 }>
+					<TestConsumer />
+				</ComposerProvider>
+			)
 		);
 
 		await user.click( screen.getByRole( 'button', { name: 'open' } ) );

--- a/client/reader/atmosphere/composer/triggers/test/compose-fab.test.tsx
+++ b/client/reader/atmosphere/composer/triggers/test/compose-fab.test.tsx
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
@@ -19,15 +20,23 @@ function Spy( { onMode }: { onMode: ( m: ActiveMode ) => void } ) {
 	return null;
 }
 
+// `ComposerProvider` consumes `useImageUploads`, which requires a
+// `QueryClientProvider` in the tree.
+function withQueryClient( ui: React.ReactNode ) {
+	return <QueryClientProvider client={ new QueryClient() }>{ ui }</QueryClientProvider>;
+}
+
 describe( '<ComposeFab>', () => {
 	it( 'opens the composer in standalone mode with entry_point=fab', async () => {
 		const user = userEvent.setup();
 		const onMode = jest.fn();
 		render(
-			<ComposerProvider connectionId={ 7 }>
-				<ComposeFab />
-				<Spy onMode={ onMode } />
-			</ComposerProvider>
+			withQueryClient(
+				<ComposerProvider connectionId={ 7 }>
+					<ComposeFab />
+					<Spy onMode={ onMode } />
+				</ComposerProvider>
+			)
 		);
 
 		await user.click( screen.getByRole( 'button', { name: 'Compose' } ) );
@@ -50,10 +59,12 @@ describe( '<ComposeFab>', () => {
 		}
 
 		render(
-			<ComposerProvider connectionId={ 7 }>
-				<ComposeFab />
-				<Trigger />
-			</ComposerProvider>
+			withQueryClient(
+				<ComposerProvider connectionId={ 7 }>
+					<ComposeFab />
+					<Trigger />
+				</ComposerProvider>
+			)
 		);
 
 		expect( screen.getByRole( 'button', { name: 'Compose' } ) ).toBeVisible();

--- a/client/reader/atmosphere/composer/triggers/test/compose-fab.test.tsx
+++ b/client/reader/atmosphere/composer/triggers/test/compose-fab.test.tsx
@@ -4,6 +4,9 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import { applyMiddleware, createStore } from 'redux';
+import { thunk as thunkMiddleware } from 'redux-thunk';
 import {
 	ComposerProvider,
 	useComposer,
@@ -21,9 +24,17 @@ function Spy( { onMode }: { onMode: ( m: ActiveMode ) => void } ) {
 }
 
 // `ComposerProvider` consumes `useImageUploads`, which requires a
-// `QueryClientProvider` in the tree.
-function withQueryClient( ui: React.ReactNode ) {
-	return <QueryClientProvider client={ new QueryClient() }>{ ui }</QueryClientProvider>;
+// `QueryClientProvider` in the tree, and dispatches Tracks events via
+// `useDispatch`, which requires a Redux `<Provider>`. Each test gets its
+// own client + a permissive noop store so cached state and dispatched
+// actions never leak between cases.
+function withProviders( ui: React.ReactNode ) {
+	const store = createStore( ( s = {} ) => s, applyMiddleware( thunkMiddleware ) );
+	return (
+		<QueryClientProvider client={ new QueryClient() }>
+			<Provider store={ store }>{ ui }</Provider>
+		</QueryClientProvider>
+	);
 }
 
 describe( '<ComposeFab>', () => {
@@ -31,7 +42,7 @@ describe( '<ComposeFab>', () => {
 		const user = userEvent.setup();
 		const onMode = jest.fn();
 		render(
-			withQueryClient(
+			withProviders(
 				<ComposerProvider connectionId={ 7 }>
 					<ComposeFab />
 					<Spy onMode={ onMode } />
@@ -59,7 +70,7 @@ describe( '<ComposeFab>', () => {
 		}
 
 		render(
-			withQueryClient(
+			withProviders(
 				<ComposerProvider connectionId={ 7 }>
 					<ComposeFab />
 					<Trigger />

--- a/client/reader/atmosphere/composer/triggers/test/timeline-compose-pill.test.tsx
+++ b/client/reader/atmosphere/composer/triggers/test/timeline-compose-pill.test.tsx
@@ -4,14 +4,25 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import { applyMiddleware, createStore } from 'redux';
+import { thunk as thunkMiddleware } from 'redux-thunk';
 import { ComposerProvider, useComposer, type ActiveMode } from '../../composer-provider';
 import { TimelineComposePill } from '../timeline-compose-pill';
 import type { AtmosphereConnection } from '@automattic/api-core';
 
 // `ComposerProvider` consumes `useImageUploads`, which requires a
-// `QueryClientProvider` in the tree.
-function withQueryClient( ui: React.ReactNode ) {
-	return <QueryClientProvider client={ new QueryClient() }>{ ui }</QueryClientProvider>;
+// `QueryClientProvider` in the tree, and dispatches Tracks events via
+// `useDispatch`, which requires a Redux `<Provider>`. Each test gets its
+// own client + a permissive noop store so cached state and dispatched
+// actions never leak between cases.
+function withProviders( ui: React.ReactNode ) {
+	const store = createStore( ( s = {} ) => s, applyMiddleware( thunkMiddleware ) );
+	return (
+		<QueryClientProvider client={ new QueryClient() }>
+			<Provider store={ store }>{ ui }</Provider>
+		</QueryClientProvider>
+	);
 }
 
 const fakeConnection: AtmosphereConnection = {
@@ -36,7 +47,7 @@ const PLACEHOLDER_RE = /what['’]s up/i;
 describe( '<TimelineComposePill>', () => {
 	it( 'renders the avatar, placeholder, and is a single button', () => {
 		render(
-			withQueryClient(
+			withProviders(
 				<ComposerProvider connectionId={ 42 }>
 					<TimelineComposePill connection={ fakeConnection } entryPoint="timeline_inline" />
 				</ComposerProvider>
@@ -54,7 +65,7 @@ describe( '<TimelineComposePill>', () => {
 		const user = userEvent.setup();
 		const onMode = jest.fn();
 		render(
-			withQueryClient(
+			withProviders(
 				<ComposerProvider connectionId={ 42 }>
 					<TimelineComposePill connection={ fakeConnection } entryPoint="timeline_inline" />
 					<Spy onMode={ onMode } />
@@ -77,7 +88,7 @@ describe( '<TimelineComposePill>', () => {
 		const user = userEvent.setup();
 		const onMode = jest.fn();
 		render(
-			withQueryClient(
+			withProviders(
 				<ComposerProvider connectionId={ 42 }>
 					<TimelineComposePill connection={ fakeConnection } entryPoint="profile_inline" />
 					<Spy onMode={ onMode } />

--- a/client/reader/atmosphere/composer/triggers/test/timeline-compose-pill.test.tsx
+++ b/client/reader/atmosphere/composer/triggers/test/timeline-compose-pill.test.tsx
@@ -1,11 +1,18 @@
 /**
  * @jest-environment jsdom
  */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ComposerProvider, useComposer, type ActiveMode } from '../../composer-provider';
 import { TimelineComposePill } from '../timeline-compose-pill';
 import type { AtmosphereConnection } from '@automattic/api-core';
+
+// `ComposerProvider` consumes `useImageUploads`, which requires a
+// `QueryClientProvider` in the tree.
+function withQueryClient( ui: React.ReactNode ) {
+	return <QueryClientProvider client={ new QueryClient() }>{ ui }</QueryClientProvider>;
+}
 
 const fakeConnection: AtmosphereConnection = {
 	id: 42,
@@ -29,9 +36,11 @@ const PLACEHOLDER_RE = /what['’]s up/i;
 describe( '<TimelineComposePill>', () => {
 	it( 'renders the avatar, placeholder, and is a single button', () => {
 		render(
-			<ComposerProvider connectionId={ 42 }>
-				<TimelineComposePill connection={ fakeConnection } entryPoint="timeline_inline" />
-			</ComposerProvider>
+			withQueryClient(
+				<ComposerProvider connectionId={ 42 }>
+					<TimelineComposePill connection={ fakeConnection } entryPoint="timeline_inline" />
+				</ComposerProvider>
+			)
 		);
 
 		expect( screen.getByRole( 'button', { name: PLACEHOLDER_RE } ) ).toBeVisible();
@@ -45,10 +54,12 @@ describe( '<TimelineComposePill>', () => {
 		const user = userEvent.setup();
 		const onMode = jest.fn();
 		render(
-			<ComposerProvider connectionId={ 42 }>
-				<TimelineComposePill connection={ fakeConnection } entryPoint="timeline_inline" />
-				<Spy onMode={ onMode } />
-			</ComposerProvider>
+			withQueryClient(
+				<ComposerProvider connectionId={ 42 }>
+					<TimelineComposePill connection={ fakeConnection } entryPoint="timeline_inline" />
+					<Spy onMode={ onMode } />
+				</ComposerProvider>
+			)
 		);
 
 		await user.click( screen.getByRole( 'button', { name: PLACEHOLDER_RE } ) );
@@ -66,10 +77,12 @@ describe( '<TimelineComposePill>', () => {
 		const user = userEvent.setup();
 		const onMode = jest.fn();
 		render(
-			<ComposerProvider connectionId={ 42 }>
-				<TimelineComposePill connection={ fakeConnection } entryPoint="profile_inline" />
-				<Spy onMode={ onMode } />
-			</ComposerProvider>
+			withQueryClient(
+				<ComposerProvider connectionId={ 42 }>
+					<TimelineComposePill connection={ fakeConnection } entryPoint="profile_inline" />
+					<Spy onMode={ onMode } />
+				</ComposerProvider>
+			)
 		);
 
 		await user.click( screen.getByRole( 'button', { name: PLACEHOLDER_RE } ) );

--- a/client/reader/atmosphere/connect-form.tsx
+++ b/client/reader/atmosphere/connect-form.tsx
@@ -88,17 +88,15 @@ function errorMessage(
 		// connect form (it doesn't post), but the AtmosphereError union
 		// covers the whole atmosphere surface, so list them explicitly to
 		// keep `assertNever` exhaustive without changing the user-visible
-		// copy on this screen. Slice-8a media kinds are listed here for
-		// the same reason — they won't surface from the connect form.
+		// copy on this screen. The slice-8a `blob_decode_failed` kind is
+		// set client-side from `compressImage` failures and listed here
+		// for the same reason — it won't surface from the connect form.
 		case 'text_too_long':
 		case 'reply_disabled':
 		case 'quote_disabled':
 		case 'target_unavailable':
 		case 'unknown':
-		case 'blob_too_large':
-		case 'blob_unsupported_type':
 		case 'blob_decode_failed':
-		case 'media_invalid':
 			return translate( 'Something went wrong.' );
 		default:
 			return assertNever( error );

--- a/client/reader/atmosphere/connect-form.tsx
+++ b/client/reader/atmosphere/connect-form.tsx
@@ -99,10 +99,12 @@ function errorMessage(
 		case 'blob_decode_failed':
 			return translate( 'Something went wrong.' );
 		default:
-			return assertNever( error );
+			// Defensive fallback if AtmosphereError widens before this
+			// switch is updated. TypeScript exhaustiveness keeps this
+			// branch unreachable today; without it, an empty-toast notice
+			// would render via `errorNotice( undefined )` for a kind we
+			// haven't classified yet. See `client/reader/AGENTS.md` —
+			// "Add a default: arm to error-message switches."
+			return translate( 'Something went wrong.' );
 	}
-}
-
-function assertNever( value: never ): never {
-	throw new Error( `Unhandled AtmosphereError kind: ${ JSON.stringify( value ) }` );
 }

--- a/client/reader/atmosphere/connect-form.tsx
+++ b/client/reader/atmosphere/connect-form.tsx
@@ -88,12 +88,17 @@ function errorMessage(
 		// connect form (it doesn't post), but the AtmosphereError union
 		// covers the whole atmosphere surface, so list them explicitly to
 		// keep `assertNever` exhaustive without changing the user-visible
-		// copy on this screen.
+		// copy on this screen. Slice-8a media kinds are listed here for
+		// the same reason — they won't surface from the connect form.
 		case 'text_too_long':
 		case 'reply_disabled':
 		case 'quote_disabled':
 		case 'target_unavailable':
 		case 'unknown':
+		case 'blob_too_large':
+		case 'blob_unsupported_type':
+		case 'blob_decode_failed':
+		case 'media_invalid':
 			return translate( 'Something went wrong.' );
 		default:
 			return assertNever( error );

--- a/client/reader/social/components/post-card/like-button.tsx
+++ b/client/reader/social/components/post-card/like-button.tsx
@@ -41,10 +41,7 @@ function errorMessageForLike(
 		case 'quote_disabled':
 		case 'target_unavailable':
 		case 'unknown':
-		case 'blob_too_large':
-		case 'blob_unsupported_type':
 		case 'blob_decode_failed':
-		case 'media_invalid':
 			return translate( 'Could not save your like. Please try again.' );
 	}
 }

--- a/client/reader/social/components/post-card/like-button.tsx
+++ b/client/reader/social/components/post-card/like-button.tsx
@@ -41,6 +41,10 @@ function errorMessageForLike(
 		case 'quote_disabled':
 		case 'target_unavailable':
 		case 'unknown':
+		case 'blob_too_large':
+		case 'blob_unsupported_type':
+		case 'blob_decode_failed':
+		case 'media_invalid':
 			return translate( 'Could not save your like. Please try again.' );
 	}
 }

--- a/client/reader/social/components/post-card/post-actions-menu.tsx
+++ b/client/reader/social/components/post-card/post-actions-menu.tsx
@@ -46,12 +46,14 @@ function errorMessageForDelete(
 		case 'blob_decode_failed':
 			return t( "Couldn't delete that post. Please try again." ) as string;
 		default:
-			return assertNever( err );
+			// Defensive fallback if AtmosphereError widens before this
+			// switch is updated. TypeScript exhaustiveness keeps this
+			// branch unreachable today; without it, an empty-toast notice
+			// would render via `errorNotice( undefined )` for a kind we
+			// haven't classified yet. See `client/reader/AGENTS.md` —
+			// "Add a default: arm to error-message switches."
+			return t( "Couldn't delete that post. Please try again." ) as string;
 	}
-}
-
-function assertNever( value: never ): never {
-	throw new Error( `Unhandled discriminated-union case: ${ JSON.stringify( value ) }` );
 }
 
 export function PostActionsMenu( { post, connectionId }: PostActionsMenuProps ) {

--- a/client/reader/social/components/post-card/post-actions-menu.tsx
+++ b/client/reader/social/components/post-card/post-actions-menu.tsx
@@ -43,6 +43,10 @@ function errorMessageForDelete(
 		case 'target_unavailable':
 		case 'not_found':
 		case 'unknown':
+		case 'blob_too_large':
+		case 'blob_unsupported_type':
+		case 'blob_decode_failed':
+		case 'media_invalid':
 			return t( "Couldn't delete that post. Please try again." ) as string;
 		default:
 			return assertNever( err );

--- a/client/reader/social/components/post-card/post-actions-menu.tsx
+++ b/client/reader/social/components/post-card/post-actions-menu.tsx
@@ -43,10 +43,7 @@ function errorMessageForDelete(
 		case 'target_unavailable':
 		case 'not_found':
 		case 'unknown':
-		case 'blob_too_large':
-		case 'blob_unsupported_type':
 		case 'blob_decode_failed':
-		case 'media_invalid':
 			return t( "Couldn't delete that post. Please try again." ) as string;
 		default:
 			return assertNever( err );

--- a/client/reader/social/components/post-card/post-card-embed-images.tsx
+++ b/client/reader/social/components/post-card/post-card-embed-images.tsx
@@ -20,6 +20,13 @@ export function PostCardEmbedImages( { embed, compact }: PostCardEmbedImagesProp
 			embed.images.map( ( image ) => ( {
 				src: image.fullsize,
 				alt: image.alt,
+				// Surface the user-authored alt text as the carousel
+				// footer caption so sighted viewers see the description
+				// the author wrote for screen readers. `ImageCarouselModal`
+				// renders an empty caption slot when this is empty, which
+				// is fine — pagination still occupies the footer for
+				// multi-image posts.
+				caption: image.alt,
 			} ) ),
 		[ embed.images ]
 	);

--- a/client/reader/social/components/post-card/repost-button.tsx
+++ b/client/reader/social/components/post-card/repost-button.tsx
@@ -50,10 +50,7 @@ function errorMessageForRepost(
 		case 'quote_disabled':
 		case 'target_unavailable':
 		case 'unknown':
-		case 'blob_too_large':
-		case 'blob_unsupported_type':
 		case 'blob_decode_failed':
-		case 'media_invalid':
 			return translate( 'Could not save your repost. Please try again.' );
 	}
 }

--- a/client/reader/social/components/post-card/repost-button.tsx
+++ b/client/reader/social/components/post-card/repost-button.tsx
@@ -50,6 +50,10 @@ function errorMessageForRepost(
 		case 'quote_disabled':
 		case 'target_unavailable':
 		case 'unknown':
+		case 'blob_too_large':
+		case 'blob_unsupported_type':
+		case 'blob_decode_failed':
+		case 'media_invalid':
 			return translate( 'Could not save your repost. Please try again.' );
 	}
 }

--- a/client/reader/social/components/post-card/test/post-card-embed-images.test.tsx
+++ b/client/reader/social/components/post-card/test/post-card-embed-images.test.tsx
@@ -77,4 +77,18 @@ describe( 'PostCardEmbedImages', () => {
 		expect( screen.getByRole( 'button', { name: /view image 1 of 2/i } ) ).toBeVisible();
 		expect( screen.getByRole( 'button', { name: /view image 2 of 2/i } ) ).toBeVisible();
 	} );
+
+	it( 'surfaces the per-image alt text as the carousel footer caption', async () => {
+		const user = userEvent.setup();
+		render( <PostCardEmbedImages embed={ embed } /> );
+
+		// Open the carousel at index 1 — the second image's alt text
+		// should appear as the footer caption.
+		await user.click( screen.getAllByRole( 'button' )[ 1 ] );
+		expect( screen.getByText( 'second' ) ).toBeVisible();
+
+		// Stepping back to the first image swaps the caption.
+		await user.click( screen.getByRole( 'button', { name: /previous image/i } ) );
+		expect( screen.getByText( 'first' ) ).toBeVisible();
+	} );
 } );

--- a/packages/api-core/src/reader-atmosphere/__tests__/errors.test.ts
+++ b/packages/api-core/src/reader-atmosphere/__tests__/errors.test.ts
@@ -92,15 +92,20 @@ describe( 'classifyAtmosphereError', () => {
 	} );
 } );
 
-describe( 'classifyAtmosphereError — slice 8a kinds', () => {
+describe( 'classifyAtmosphereError — slice 8a media surface', () => {
+	// The slice-8a backend deliberately collapses every blob/media-related
+	// rejection into the generic `atmosphere_bad_request` wire code (see
+	// `reader-atmosphere/AGENTS.md` — "the wire stays stable"). Pin that
+	// expectation so a future refactor doesn't silently expect specific
+	// blob/media subtypes that never arrive.
 	it.each( [
-		[ 'atmosphere_blob_too_large', 'blob_too_large' ],
-		[ 'atmosphere_blob_unsupported_type', 'blob_unsupported_type' ],
-		[ 'atmosphere_blob_decode_failed', 'blob_decode_failed' ],
-		[ 'atmosphere_media_invalid', 'media_invalid' ],
-	] )( 'maps %s to kind %s', ( serverCode, expectedKind ) => {
-		const raw = { code: serverCode, message: 'm', status: 400 };
+		'POST /blobs — image too large',
+		'POST /blobs — unsupported image type',
+		'POST /blobs — undecodable image',
+		'POST /posts — invalid media body',
+	] )( 'classifies %s as bad_request', () => {
+		const raw = { code: 'atmosphere_bad_request', message: 'rejected', status: 400 };
 		const err = classifyAtmosphereError( raw );
-		expect( err.kind ).toBe( expectedKind );
+		expect( err.kind ).toBe( 'bad_request' );
 	} );
 } );

--- a/packages/api-core/src/reader-atmosphere/__tests__/errors.test.ts
+++ b/packages/api-core/src/reader-atmosphere/__tests__/errors.test.ts
@@ -91,3 +91,16 @@ describe( 'classifyAtmosphereError', () => {
 		);
 	} );
 } );
+
+describe( 'classifyAtmosphereError — slice 8a kinds', () => {
+	it.each( [
+		[ 'atmosphere_blob_too_large', 'blob_too_large' ],
+		[ 'atmosphere_blob_unsupported_type', 'blob_unsupported_type' ],
+		[ 'atmosphere_blob_decode_failed', 'blob_decode_failed' ],
+		[ 'atmosphere_media_invalid', 'media_invalid' ],
+	] )( 'maps %s to kind %s', ( serverCode, expectedKind ) => {
+		const raw = { code: serverCode, message: 'm', status: 400 };
+		const err = classifyAtmosphereError( raw );
+		expect( err.kind ).toBe( expectedKind );
+	} );
+} );

--- a/packages/api-core/src/reader-atmosphere/__tests__/fetchers.test.ts
+++ b/packages/api-core/src/reader-atmosphere/__tests__/fetchers.test.ts
@@ -1150,16 +1150,21 @@ describe( 'atmosphere fetchers', () => {
 			expect( result.blob.size ).toBe( 3 );
 		} );
 
-		it( 'classifies a 400 atmosphere_blob_too_large into a typed error', async () => {
+		it( 'classifies a 400 atmosphere_bad_request into a bad_request kind', async () => {
+			// The slice-8a backend collapses every /blobs rejection
+			// (oversize, unsupported MIME, undecodable bytes, …) into
+			// `atmosphere_bad_request` rather than a specific subtype. The
+			// classifier mirrors that shape.
 			jest.spyOn( wpcom.req, 'post' ).mockRejectedValue( {
-				code: 'atmosphere_blob_too_large',
-				message: 'too large',
+				code: 'atmosphere_bad_request',
+				message: 'Image is too large.',
 				statusCode: 400,
 			} );
 
 			const file = new Blob( [ 'x' ], { type: 'image/jpeg' } );
 			await expect( uploadBlob( { connectionId: 42, file } ) ).rejects.toMatchObject( {
-				kind: 'blob_too_large',
+				kind: 'bad_request',
+				message: 'Image is too large.',
 			} );
 		} );
 	} );

--- a/packages/api-core/src/reader-atmosphere/__tests__/fetchers.test.ts
+++ b/packages/api-core/src/reader-atmosphere/__tests__/fetchers.test.ts
@@ -1,4 +1,5 @@
 import nock from 'nock';
+import { wpcom } from '../../wpcom-fetcher';
 import {
 	createConnection,
 	createFollow,
@@ -19,6 +20,7 @@ import {
 	getScopedThread,
 	getThread,
 	getTimeline,
+	uploadBlob,
 } from '../fetchers';
 import type {
 	AtmosphereAuthorFeedPage,
@@ -1111,6 +1113,94 @@ describe( 'atmosphere fetchers', () => {
 				.reply( status as number, { error } );
 
 			await expect( createPost( { connectionId, text: 'x' } ) ).rejects.toMatchObject( { kind } );
+		} );
+	} );
+
+	describe( 'uploadBlob', () => {
+		// Multipart uploads can't be exercised end-to-end through nock here:
+		// the wpcom transport hands its `formData` to superagent's Node
+		// adapter, which streams via `form-data` and rejects jsdom Blob/File
+		// instances with `source.on is not a function`. Spying on
+		// `wpcom.req.post` keeps the fetcher contract under test (path,
+		// namespace, formData shape, error classification) without taking on
+		// the transport's stream wiring.
+		afterEach( () => jest.restoreAllMocks() );
+
+		it( 'POSTs to /connections/{id}/blobs with a multipart file field', async () => {
+			const file = new Blob( [ new Uint8Array( [ 0xff, 0xd8, 0xff ] ) ], { type: 'image/jpeg' } );
+			const post = jest.spyOn( wpcom.req, 'post' ).mockResolvedValue( {
+				blob: {
+					$type: 'blob',
+					ref: { $link: 'bafkrei' + 'a'.repeat( 50 ) },
+					mimeType: 'image/jpeg',
+					size: 3,
+				},
+			} );
+
+			const result = await uploadBlob( { connectionId: 42, file } );
+
+			expect( post ).toHaveBeenCalledTimes( 1 );
+			const callArg = post.mock.calls[ 0 ][ 0 ];
+			expect( callArg.path ).toBe( '/reader/atmosphere/connections/42/blobs' );
+			expect( callArg.apiNamespace ).toBe( 'wpcom/v2' );
+			expect( callArg.formData ).toHaveLength( 1 );
+			expect( callArg.formData[ 0 ][ 0 ] ).toBe( 'file' );
+			expect( result.blob.$type ).toBe( 'blob' );
+			expect( result.blob.mimeType ).toBe( 'image/jpeg' );
+			expect( result.blob.size ).toBe( 3 );
+		} );
+
+		it( 'classifies a 400 atmosphere_blob_too_large into a typed error', async () => {
+			jest.spyOn( wpcom.req, 'post' ).mockRejectedValue( {
+				code: 'atmosphere_blob_too_large',
+				message: 'too large',
+				statusCode: 400,
+			} );
+
+			const file = new Blob( [ 'x' ], { type: 'image/jpeg' } );
+			await expect( uploadBlob( { connectionId: 42, file } ) ).rejects.toMatchObject( {
+				kind: 'blob_too_large',
+			} );
+		} );
+	} );
+
+	describe( 'createPost — media forwarding', () => {
+		it( 'forwards optional media body when provided', async () => {
+			let capturedBody: any = null;
+			nock( BASE )
+				.post( '/wpcom/v2/reader/atmosphere/connections/9/posts', ( body ) => {
+					capturedBody = body;
+					return true;
+				} )
+				.reply( 200, {
+					post: {
+						uri: 'at://did:plc:x/app.bsky.feed.post/abc',
+						cid: 'bafkreiabc',
+						rkey: 'abc',
+					},
+				} );
+
+			await createPost( {
+				connectionId: 9,
+				text: '',
+				media: {
+					images: [
+						{
+							blob: {
+								$type: 'blob',
+								ref: { $link: 'bafkrei' + 'b'.repeat( 50 ) },
+								mimeType: 'image/jpeg',
+								size: 100,
+							},
+							alt: 'a sunset',
+							aspectRatio: { width: 2000, height: 1500 },
+						},
+					],
+				},
+			} );
+
+			expect( capturedBody.text ).toBe( '' );
+			expect( capturedBody.media.images[ 0 ].alt ).toBe( 'a sunset' );
 		} );
 	} );
 

--- a/packages/api-core/src/reader-atmosphere/errors.ts
+++ b/packages/api-core/src/reader-atmosphere/errors.ts
@@ -13,10 +13,11 @@ export type AtmosphereError =
 	| { kind: 'reply_disabled' }
 	| { kind: 'quote_disabled' }
 	| { kind: 'target_unavailable' }
-	| { kind: 'blob_too_large' }
-	| { kind: 'blob_unsupported_type' }
+	// Set client-side from `compressImage` failures; the server never emits
+	// a matching wire code (the slice-8a backend collapses every blob/media
+	// rejection into `atmosphere_bad_request`, which lands as `bad_request`
+	// above).
 	| { kind: 'blob_decode_failed' }
-	| { kind: 'media_invalid' }
 	| { kind: 'unknown'; cause: unknown };
 
 interface WpErrorLike {
@@ -81,14 +82,6 @@ export function classifyAtmosphereError( raw: unknown ): AtmosphereError {
 			return { kind: 'quote_disabled' };
 		case 'atmosphere_target_unavailable':
 			return { kind: 'target_unavailable' };
-		case 'atmosphere_blob_too_large':
-			return { kind: 'blob_too_large' };
-		case 'atmosphere_blob_unsupported_type':
-			return { kind: 'blob_unsupported_type' };
-		case 'atmosphere_blob_decode_failed':
-			return { kind: 'blob_decode_failed' };
-		case 'atmosphere_media_invalid':
-			return { kind: 'media_invalid' };
 		default:
 			return { kind: 'unknown', cause: raw };
 	}

--- a/packages/api-core/src/reader-atmosphere/errors.ts
+++ b/packages/api-core/src/reader-atmosphere/errors.ts
@@ -13,6 +13,10 @@ export type AtmosphereError =
 	| { kind: 'reply_disabled' }
 	| { kind: 'quote_disabled' }
 	| { kind: 'target_unavailable' }
+	| { kind: 'blob_too_large' }
+	| { kind: 'blob_unsupported_type' }
+	| { kind: 'blob_decode_failed' }
+	| { kind: 'media_invalid' }
 	| { kind: 'unknown'; cause: unknown };
 
 interface WpErrorLike {
@@ -77,6 +81,14 @@ export function classifyAtmosphereError( raw: unknown ): AtmosphereError {
 			return { kind: 'quote_disabled' };
 		case 'atmosphere_target_unavailable':
 			return { kind: 'target_unavailable' };
+		case 'atmosphere_blob_too_large':
+			return { kind: 'blob_too_large' };
+		case 'atmosphere_blob_unsupported_type':
+			return { kind: 'blob_unsupported_type' };
+		case 'atmosphere_blob_decode_failed':
+			return { kind: 'blob_decode_failed' };
+		case 'atmosphere_media_invalid':
+			return { kind: 'media_invalid' };
 		default:
 			return { kind: 'unknown', cause: raw };
 	}

--- a/packages/api-core/src/reader-atmosphere/fetchers.ts
+++ b/packages/api-core/src/reader-atmosphere/fetchers.ts
@@ -21,6 +21,8 @@ import type {
 	DeleteLikeParams,
 	DeletePostParams,
 	DeleteRepostParams,
+	UploadBlobParams,
+	UploadBlobResult,
 } from './types';
 
 const NAMESPACE = 'wpcom/v2';
@@ -351,14 +353,41 @@ export async function createLike( params: CreateLikeParams ): Promise< CreateLik
 	}
 }
 
+export async function uploadBlob( params: UploadBlobParams ): Promise< UploadBlobResult > {
+	const { connectionId, file } = params;
+	// `wpcom-xhr-request` expects each formData value to be either a primitive
+	// or a `{ fileContents, fileName }` envelope (it inspects `fileContents
+	// instanceof Blob` to decide whether to call `req.attach` vs `req.field`).
+	// Match the established pattern used by `client/post-editor/media-modal`
+	// so the transport produces a real multipart `file` part instead of a
+	// stringified Blob field.
+	const fileName = ( file as File ).name ?? 'blob';
+	const formData: [ string, { fileContents: Blob; fileName: string } ][] = [
+		[ 'file', { fileContents: file, fileName } ],
+	];
+
+	try {
+		return ( await wpcom.req.post( {
+			path: `/reader/atmosphere/connections/${ connectionId }/blobs`,
+			apiNamespace: NAMESPACE,
+			formData,
+		} ) ) as UploadBlobResult;
+	} catch ( raw ) {
+		throw classifyAtmosphereError( raw );
+	}
+}
+
 export async function createPost( params: CreatePostParams ): Promise< CreatePostResult > {
-	const { connectionId, text, reply, quote } = params;
+	const { connectionId, text, reply, quote, media } = params;
 	const body: Record< string, unknown > = { text };
 	if ( reply ) {
 		body.reply = reply;
 	}
 	if ( quote ) {
 		body.quote = quote;
+	}
+	if ( media ) {
+		body.media = media;
 	}
 	try {
 		const response = ( await wpcom.req.post( {

--- a/packages/api-core/src/reader-atmosphere/fetchers.ts
+++ b/packages/api-core/src/reader-atmosphere/fetchers.ts
@@ -361,7 +361,7 @@ export async function uploadBlob( params: UploadBlobParams ): Promise< UploadBlo
 	// Match the established pattern used by `client/post-editor/media-modal`
 	// so the transport produces a real multipart `file` part instead of a
 	// stringified Blob field.
-	const fileName = ( file as File ).name ?? 'blob';
+	const fileName = file instanceof File && file.name ? file.name : 'blob';
 	const formData: [ string, { fileContents: Blob; fileName: string } ][] = [
 		[ 'file', { fileContents: file, fileName } ],
 	];

--- a/packages/api-core/src/reader-atmosphere/types.ts
+++ b/packages/api-core/src/reader-atmosphere/types.ts
@@ -341,11 +341,34 @@ export interface AtUriRef {
 	cid: string;
 }
 
+export interface AtmosphereBlobRef {
+	$type: 'blob';
+	ref: { $link: string };
+	mimeType: string;
+	size: number;
+}
+
+export interface AtmosphereImageEmbed {
+	blob: AtmosphereBlobRef;
+	alt: string;
+	aspectRatio?: { width: number; height: number };
+}
+
+export interface UploadBlobParams {
+	connectionId: number;
+	file: Blob;
+}
+
+export interface UploadBlobResult {
+	blob: AtmosphereBlobRef;
+}
+
 export interface CreatePostParams {
 	connectionId: number;
 	text: string;
 	reply?: { root: AtUriRef; parent: AtUriRef };
 	quote?: AtUriRef;
+	media?: { images: AtmosphereImageEmbed[] };
 }
 
 export interface CreatePostResult {

--- a/packages/api-queries/src/__tests__/reader-atmosphere.test.tsx
+++ b/packages/api-queries/src/__tests__/reader-atmosphere.test.tsx
@@ -22,6 +22,7 @@ import {
 } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import nock from 'nock';
+import { wpcom } from '../../../api-core/src/wpcom-fetcher';
 import {
 	atmosphereScopedProfileQuery,
 	buildPlaceholderStandalonePost,
@@ -43,6 +44,7 @@ import {
 	useDeleteLikeMutation,
 	useDeletePostMutation,
 	useDeleteRepostMutation,
+	uploadBlobMutation,
 	useThreadQuery,
 	useTimelineInfiniteQuery,
 } from '../reader-atmosphere';
@@ -3482,5 +3484,38 @@ describe( 'removePlaceholder', () => {
 		const next = removePlaceholder( data, pendingUri );
 
 		expect( next ).toBe( data );
+	} );
+} );
+
+describe( 'uploadBlobMutation', () => {
+	// Mirrors the api-core fetcher tests: nock can't be used here because
+	// superagent's Node adapter streams formData via `form-data`, which
+	// rejects jsdom Blob/File instances before any HTTP request goes out.
+	// Spying on `wpcom.req.post` keeps the factory contract under test
+	// (mutationFn wiring + result propagation) without taking on the
+	// transport's stream wiring.
+	afterEach( () => jest.restoreAllMocks() );
+
+	it( 'wires uploadBlob into mutationFn and returns the blob ref', async () => {
+		jest.spyOn( wpcom.req, 'post' ).mockResolvedValue( {
+			blob: {
+				$type: 'blob',
+				ref: { $link: 'bafkrei' + 'a'.repeat( 50 ) },
+				mimeType: 'image/jpeg',
+				size: 3,
+			},
+		} );
+
+		const file = new Blob( [ new Uint8Array( [ 0xff, 0xd8, 0xff ] ) ], { type: 'image/jpeg' } );
+		const client = new QueryClient( { defaultOptions: { mutations: { retry: false } } } );
+
+		const { result } = renderHook( () => useMutation( uploadBlobMutation( client ) ), {
+			wrapper: makeWrapper( client ),
+		} );
+
+		const value = await result.current.mutateAsync( { connectionId: 7, file } );
+
+		expect( value.blob.mimeType ).toBe( 'image/jpeg' );
+		expect( value.blob.$type ).toBe( 'blob' );
 	} );
 } );

--- a/packages/api-queries/src/__tests__/reader-atmosphere.test.tsx
+++ b/packages/api-queries/src/__tests__/reader-atmosphere.test.tsx
@@ -44,6 +44,7 @@ import {
 	useDeleteLikeMutation,
 	useDeletePostMutation,
 	useDeleteRepostMutation,
+	setAtmospherePostEmbed,
 	uploadBlobMutation,
 	useThreadQuery,
 	useTimelineInfiniteQuery,
@@ -3517,5 +3518,79 @@ describe( 'uploadBlobMutation', () => {
 
 		expect( value.blob.mimeType ).toBe( 'image/jpeg' );
 		expect( value.blob.$type ).toBe( 'blob' );
+	} );
+
+	describe( 'setAtmospherePostEmbed', () => {
+		const POST_URI = 'at://did:plc:author/app.bsky.feed.post/3kembed';
+		const CONNECTION_ID = 42;
+
+		function seedTimeline( client: QueryClient, items: AtmosphereFeedItem[] ) {
+			const data: InfiniteData< AtmosphereTimelinePage > = {
+				pages: [ { items, cursor: null } ],
+				pageParams: [ undefined ],
+			};
+			client.setQueryData( readerAtmosphereKeys.timeline( CONNECTION_ID ), data );
+		}
+
+		it( 'patches the embed onto every cached feed item whose uri matches', () => {
+			const client = new QueryClient();
+			const target = makeFeedItem( { uri: POST_URI, embed: null } );
+			const other = makeFeedItem( { uri: 'at://did:plc:other/app.bsky.feed.post/keep' } );
+			seedTimeline( client, [ target, other ] );
+
+			const localUrl = 'blob:test/abcdef';
+			setAtmospherePostEmbed( client, POST_URI, {
+				type: 'images',
+				images: [
+					{
+						thumb: localUrl,
+						fullsize: localUrl,
+						alt: 'a sunset',
+						aspect_ratio: { width: 16, height: 9 },
+					},
+				],
+			} );
+
+			const items =
+				client.getQueryData< InfiniteData< AtmosphereTimelinePage > >(
+					readerAtmosphereKeys.timeline( CONNECTION_ID )
+				)?.pages[ 0 ].items ?? [];
+
+			const patched = items.find( ( i ) => i.uri === POST_URI );
+			expect( patched?.embed ).toEqual( {
+				type: 'images',
+				images: [
+					{
+						thumb: localUrl,
+						fullsize: localUrl,
+						alt: 'a sunset',
+						aspect_ratio: { width: 16, height: 9 },
+					},
+				],
+			} );
+
+			// Sibling item is left untouched.
+			const untouched = items.find( ( i ) => i.uri !== POST_URI );
+			expect( untouched?.embed ).toBeNull();
+		} );
+
+		it( 'is a no-op when no cache entry matches postUri', () => {
+			const client = new QueryClient();
+			const other = makeFeedItem( { uri: 'at://did:plc:other/app.bsky.feed.post/keep' } );
+			seedTimeline( client, [ other ] );
+
+			expect( () =>
+				setAtmospherePostEmbed( client, POST_URI, {
+					type: 'images',
+					images: [],
+				} )
+			).not.toThrow();
+
+			const items =
+				client.getQueryData< InfiniteData< AtmosphereTimelinePage > >(
+					readerAtmosphereKeys.timeline( CONNECTION_ID )
+				)?.pages[ 0 ].items ?? [];
+			expect( items[ 0 ].embed ).toBeNull();
+		} );
 	} );
 } );

--- a/packages/api-queries/src/reader-atmosphere.ts
+++ b/packages/api-queries/src/reader-atmosphere.ts
@@ -47,6 +47,7 @@ import type {
 	AtmosphereConnectionsResponse,
 	AtmosphereCreateConnectionResponse,
 	AtmosphereCreateFollowResponse,
+	AtmosphereEmbed,
 	AtmosphereError,
 	AtmosphereFeedItem,
 	AtmosphereScopedProfile,
@@ -615,6 +616,27 @@ function patchAtmospherePostCaches(
 		snapshots.push( { key, items: result.items } );
 	}
 	return { snapshots };
+}
+
+/**
+ * Patch the `embed` field of every cached `AtmosphereFeedItem` whose
+ * `uri` matches `postUri`, across all atmosphere queries (timeline,
+ * author-feed, thread, tag-feed). Used by the composer to inject a
+ * local-preview-URL embed onto the just-published placeholder so the
+ * timeline shows the user's just-attached images during the brief
+ * window before the next refetch replaces them with real CDN URLs from
+ * the AppView.
+ *
+ * No rollback is captured: this runs AFTER the mutation succeeds and is
+ * superseded by the next refetch. If no cache entry matches `postUri`
+ * (placeholder evicted, cache cold), the call is a no-op.
+ */
+export function setAtmospherePostEmbed(
+	queryClient: QueryClient,
+	postUri: string,
+	embed: AtmosphereEmbed
+): void {
+	patchAtmospherePostCaches( queryClient, postUri, ( item ) => ( { ...item, embed } ) );
 }
 
 function restoreFeedItems(

--- a/packages/api-queries/src/reader-atmosphere.ts
+++ b/packages/api-queries/src/reader-atmosphere.ts
@@ -24,6 +24,7 @@ import {
 	PENDING_REPOST_URI,
 	isValidHashtag,
 	readerAtmosphereKeys,
+	uploadBlob,
 } from '@automattic/api-core';
 import {
 	infiniteQueryOptions,
@@ -58,6 +59,8 @@ import type {
 	CreatePostParams,
 	CreatePostResult,
 	CreateRepostResult,
+	UploadBlobParams,
+	UploadBlobResult,
 } from '@automattic/api-core';
 
 const TERMINAL_ERROR_KINDS: ReadonlySet< AtmosphereError[ 'kind' ] > = new Set( [
@@ -1390,6 +1393,18 @@ export function removePlaceholder< P extends { items: AtmosphereFeedItem[] } >(
 	} );
 	return removed ? { ...data, pages } : data;
 }
+
+/**
+ * Wraps the uploadBlob fetcher. No cache invalidation needed — blob
+ * uploads are a transient step toward createPost. The QueryClient
+ * parameter is kept for symmetry with sibling factories in this module
+ * so future cache touches don't refactor the call sites.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const uploadBlobMutation = ( _queryClient: QueryClient ) =>
+	mutationOptions< UploadBlobResult, AtmosphereError, UploadBlobParams >( {
+		mutationFn: uploadBlob,
+	} );
 
 /**
  * Mutation factory for creating an `app.bsky.feed.post` record.


### PR DESCRIPTION
Fixes CM-671

## Proposed Changes

* Wires the previously-disabled "Add media" icon button in the ATmosphere composer to a full image attachment flow.
* New `client/reader/atmosphere/composer/media/`: `compressImage`, `useImageUploads`, `ImageGrid`, `AltTextPopover`.
* Available in standalone, reply, and quote composer modes; quote+media uses the backend's `recordWithMedia` embed.
* Empty post text is now allowed when at least one image is attached.
* New `api-core` types + `uploadBlob` fetcher + `uploadBlobMutation` factory follow the slice-7 patterns.
* 5 Tracks events for the media flow: `media_picked`, `media_uploaded`, `media_upload_error_shown`, `media_removed`, `alt_text_added`. The alt text itself is intentionally never sent — only its length is reported, for distribution analysis.

Backend: CM-670 (in flight in a separate workspace). Integration smoke tests are pending backend availability.

## Why are these changes being made?

Slice 8a of the Reader ATmosphere project — adds image attachments to the composer, parity with Bluesky's native compose flow.

## Testing Instructions

* `yarn test-client client/reader/atmosphere` — passes locally (312 tests).
* `yarn typecheck-client` was skipped — known to OOM on this hardware.
* Manual (after backend lands): attach a 5 MB phone photo to a standalone post — uploads under a second after compression, post lands on Bluesky.
* Manual (after backend lands): attach 4 images, attempt a 5th — affordance disabled with "Maximum 4 images".
* Manual (after backend lands): attach an image, fail the upload (offline), retry — succeeds.
* Manual (after backend lands): quote-with-media — verifies `recordWithMedia` shape end-to-end.
* Manual (after backend lands): media-only post (no text) — publishes successfully.
* A11y: ALT badge focusable; alt-text popover keyboard-traversable; "Maximum 4 images" announced.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?