### PR TITLE
Checkout: parity cleanup for UPI, PIX, and PIX Automatico processors

### DIFF
--- a/client/my-sites/checkout/src/lib/pix-automatico-processor.ts
+++ b/client/my-sites/checkout/src/lib/pix-automatico-processor.ts
@@ -106,6 +106,13 @@ export async function pixAutomaticoProcessor(
 	);
 
 	const root = getRenderRoot( genericErrorMessage );
+	let rootUnmounted = false;
+	const safeDismissModal = () => {
+		if ( ! rootUnmounted ) {
+			rootUnmounted = true;
+			hideModal( root );
+		}
+	};
 
 	return submitWpcomTransaction( formattedTransactionData, options )
 		.then( async ( response?: WPCOMTransactionEndpointResponse ) => {
@@ -135,12 +142,12 @@ export async function pixAutomaticoProcessor(
 				priceInteger: responseCart.total_cost_integer,
 				priceCurrency: responseCart.currency,
 				cancel: () => {
-					hideModal( root );
+					safeDismissModal();
 					isModalActive = false;
 					explicitClosureMessage = translate( 'Payment cancelled.' );
 				},
 				error: () => {
-					hideModal( root );
+					safeDismissModal();
 					isModalActive = false;
 					explicitClosureMessage = genericErrorMessage;
 				},
@@ -157,6 +164,8 @@ export async function pixAutomaticoProcessor(
 				throw new Error( explicitClosureMessage ?? genericFailureMessage );
 			}
 
+			safeDismissModal();
+
 			const responseData: Partial< WPCOMTransactionEndpointResponseSuccess > = {
 				success: true,
 				order_id: response.order_id,
@@ -164,7 +173,7 @@ export async function pixAutomaticoProcessor(
 			return makeSuccessResponse( responseData );
 		} )
 		.catch( ( error ) => {
-			hideModal( root );
+			safeDismissModal();
 			return makeErrorResponse( error.message );
 		} );
 }
@@ -257,9 +266,19 @@ function displayModal( {
 function isValidEbanxCardTransactionData(
 	submitData: unknown
 ): submitData is EbanxCardTransactionRequest {
-	const data = submitData as EbanxCardTransactionRequest;
-	if ( ! data ) {
-		throw new Error( 'Transaction requires data and none was provided' );
+	if ( ! submitData || typeof submitData !== 'object' ) {
+		return false;
 	}
-	return true;
+	const data = submitData as EbanxCardTransactionRequest;
+	return (
+		typeof data.name === 'string' &&
+		typeof data.countryCode === 'string' &&
+		typeof data.state === 'string' &&
+		typeof data.city === 'string' &&
+		typeof data.postalCode === 'string' &&
+		typeof data.address === 'string' &&
+		typeof data.streetNumber === 'string' &&
+		typeof data.phoneNumber === 'string' &&
+		typeof data.document === 'string'
+	);
 }

--- a/client/my-sites/checkout/src/lib/pix-processor.ts
+++ b/client/my-sites/checkout/src/lib/pix-processor.ts
@@ -106,6 +106,13 @@ export async function pixProcessor(
 	);
 
 	const root = getRenderRoot( genericErrorMessage );
+	let rootUnmounted = false;
+	const safeDismissModal = () => {
+		if ( ! rootUnmounted ) {
+			rootUnmounted = true;
+			hideModal( root );
+		}
+	};
 
 	return submitWpcomTransaction( formattedTransactionData, options )
 		.then( async ( response?: WPCOMTransactionEndpointResponse ) => {
@@ -135,12 +142,12 @@ export async function pixProcessor(
 				priceInteger: responseCart.total_cost_integer,
 				priceCurrency: responseCart.currency,
 				cancel: () => {
-					hideModal( root );
+					safeDismissModal();
 					isModalActive = false;
 					explicitClosureMessage = translate( 'Payment cancelled.' );
 				},
 				error: () => {
-					hideModal( root );
+					safeDismissModal();
 					isModalActive = false;
 					explicitClosureMessage = genericErrorMessage;
 				},
@@ -157,6 +164,8 @@ export async function pixProcessor(
 				throw new Error( explicitClosureMessage ?? genericFailureMessage );
 			}
 
+			safeDismissModal();
+
 			const responseData: Partial< WPCOMTransactionEndpointResponseSuccess > = {
 				success: true,
 				order_id: response.order_id,
@@ -164,7 +173,7 @@ export async function pixProcessor(
 			return makeSuccessResponse( responseData );
 		} )
 		.catch( ( error ) => {
-			hideModal( root );
+			safeDismissModal();
 			return makeErrorResponse( error.message );
 		} );
 }
@@ -257,9 +266,19 @@ function displayModal( {
 function isValidEbanxCardTransactionData(
 	submitData: unknown
 ): submitData is EbanxCardTransactionRequest {
-	const data = submitData as EbanxCardTransactionRequest;
-	if ( ! data ) {
-		throw new Error( 'Transaction requires data and none was provided' );
+	if ( ! submitData || typeof submitData !== 'object' ) {
+		return false;
 	}
-	return true;
+	const data = submitData as EbanxCardTransactionRequest;
+	return (
+		typeof data.name === 'string' &&
+		typeof data.countryCode === 'string' &&
+		typeof data.state === 'string' &&
+		typeof data.city === 'string' &&
+		typeof data.postalCode === 'string' &&
+		typeof data.address === 'string' &&
+		typeof data.streetNumber === 'string' &&
+		typeof data.phoneNumber === 'string' &&
+		typeof data.document === 'string'
+	);
 }

--- a/client/my-sites/checkout/src/lib/upi-processor.ts
+++ b/client/my-sites/checkout/src/lib/upi-processor.ts
@@ -166,6 +166,9 @@ export default async function upiProcessor(
 			while ( isModalActive && [ 'processing', 'async-pending' ].includes( orderStatus ) ) {
 				orderStatus = await pollForOrderStatus( response.order_id, 2000, genericErrorMessage );
 			}
+			// `payment-confirmed` is treated as success: Stripe has accepted the payment
+			// but order finalization can still take a while. Hand off to the framework's
+			// pending page rather than keeping the user waiting in the modal.
 			if ( orderStatus !== 'success' && orderStatus !== 'payment-confirmed' ) {
 				throw new Error( explicitClosureMessage ?? genericFailureMessage );
 			}

--- a/client/my-sites/checkout/src/lib/upi-processor.ts
+++ b/client/my-sites/checkout/src/lib/upi-processor.ts
@@ -1,8 +1,4 @@
-import {
-	makeErrorResponse,
-	makeRedirectResponse,
-	makeSuccessResponse,
-} from '@automattic/composite-checkout';
+import { makeErrorResponse, makeSuccessResponse } from '@automattic/composite-checkout';
 import { createElement } from 'react';
 import { Root, createRoot } from 'react-dom/client';
 import { PurchaseOrderStatus, fetchPurchaseOrder } from '../hooks/use-purchase-order';
@@ -149,14 +145,6 @@ export default async function upiProcessor(
 				genericErrorMessage
 			);
 
-			const pendingPageUrl = addUrlToPendingPageRedirect( thankYouUrl, {
-				siteSlug,
-				fromSiteSlug,
-				fromExternalCheckout,
-				orderId: response.order_id,
-				urlType: 'absolute',
-			} );
-
 			let isModalActive = true;
 			let explicitClosureMessage: string | undefined;
 			displayModal( {
@@ -178,11 +166,7 @@ export default async function upiProcessor(
 			while ( isModalActive && [ 'processing', 'async-pending' ].includes( orderStatus ) ) {
 				orderStatus = await pollForOrderStatus( response.order_id, 2000, genericErrorMessage );
 			}
-			if ( orderStatus === 'payment-confirmed' ) {
-				safeDismissModal();
-				return makeRedirectResponse( pendingPageUrl );
-			}
-			if ( orderStatus !== 'success' ) {
+			if ( orderStatus !== 'success' && orderStatus !== 'payment-confirmed' ) {
 				throw new Error( explicitClosureMessage ?? genericFailureMessage );
 			}
 

--- a/client/my-sites/checkout/src/lib/upi-processor.ts
+++ b/client/my-sites/checkout/src/lib/upi-processor.ts
@@ -103,7 +103,6 @@ export default async function upiProcessor(
 		paymentMethodId,
 		{
 			...submitData,
-			name: submitData.name ?? '',
 			successUrl,
 			cancelUrl,
 			couponId: responseCart.coupon,
@@ -221,7 +220,7 @@ async function getRedirectUrl(
 	if ( message && typeof message === 'object' && 'setup_intent_client_secret' in message ) {
 		return confirmUpiSetupIntent(
 			String( ( message as { setup_intent_client_secret: string } ).setup_intent_client_secret ),
-			submitData.name ?? '',
+			submitData.name,
 			options,
 			genericErrorMessage
 		);
@@ -345,9 +344,17 @@ function displayModal( {
 }
 
 function isValidTransactionData( submitData: unknown ): submitData is StripeUpiTransactionRequest {
-	const data = submitData as StripeUpiTransactionRequest;
-	if ( ! data ) {
-		throw new Error( 'Transaction requires data and none was provided' );
+	if ( ! submitData || typeof submitData !== 'object' ) {
+		return false;
 	}
-	return true;
+	const data = submitData as StripeUpiTransactionRequest;
+	return (
+		typeof data.name === 'string' &&
+		typeof data.address === 'string' &&
+		typeof data.streetNumber === 'string' &&
+		typeof data.city === 'string' &&
+		typeof data.state === 'string' &&
+		typeof data.postalCode === 'string' &&
+		typeof data.country === 'string'
+	);
 }

--- a/client/my-sites/checkout/src/test/upi-processor.ts
+++ b/client/my-sites/checkout/src/test/upi-processor.ts
@@ -338,7 +338,7 @@ describe( 'upiProcessor', () => {
 		} );
 	} );
 
-	it( 'redirects to the pending page when payment is confirmed', async () => {
+	it( 'returns a success response when the order is payment-confirmed', async () => {
 		render( createElement( 'div', { className: 'upi-modal-target' } ) );
 
 		const orderId = 54321;
@@ -351,11 +351,9 @@ describe( 'upiProcessor', () => {
 		mockOrderEndpoint( orderId, () => [ 200, mockOrderStatus ] );
 		mockTransactionsEndpoint( () => mockTransactionsRedirectResponse( orderId ) );
 
-		const expectedPendingUrl =
-			'https://example.com/checkout/thank-you/no-site/pending/54321?redirect_to=%2Fthank-you&receiptId=%3AreceiptId';
 		const expected = {
-			payload: expectedPendingUrl,
-			type: 'REDIRECT',
+			payload: { success: true, order_id: orderId },
+			type: 'SUCCESS',
 		};
 
 		await act( async () => {


### PR DESCRIPTION
Part of SHILL-1957

## Proposed Changes

* UPI processor: real type guard for `isValidTransactionData`, dropped dead `name ?? ''` defenses, and collapsed the three-path success structure into two paths. The `payment-confirmed` branch no longer calls `makeRedirectResponse(pendingPageUrl)` — `makeSuccessResponse({ order_id })` already routes through the pending page via the framework's success handler, and the prior `makeRedirectResponse` path was triggering a misleading "Redirecting to payment partner…" notice for an internal redirect.
* PIX processor: real validator, idempotent `safeDismissModal` guard, and a new `safeDismissModal()` on the success path matching UPI/BLIK.
* PIX Automatico processor: same parity cleanup as PIX.

## Why are these changes being made?

* Follow-up to the BLIK PR (#110270). UPI was the template BLIK was forked from, so cleaning UPI restores parity now that BLIK has diverged. PIX/PIX Automatico share the same template and were carrying the same fake-validator and unguarded modal-dismissal patterns.
* The UPI three-path collapse fixes a real correctness issue surfaced in review of #110270: `makeRedirectResponse` is meant for sending users to a payment partner's website, not to an internal pending page. The framework's `makeSuccessResponse` path already constructs the same pending URL via `useCreatePaymentSubmittedAndProcessingCallback`, so the manual `addUrlToPendingPageRedirect` + `makeRedirectResponse` was duplicate work that also bypassed analytics, cart reload, and the `clearPurchases` side effects.

## Testing Instructions

* Run `yarn test-client client/my-sites/checkout/src/test/upi-processor.ts` — UPI tests should pass (7/7). The `payment-confirmed` test case has been updated to expect `{ type: 'SUCCESS', payload: { success: true, order_id } }` instead of `{ type: 'REDIRECT', payload: pendingUrl }`.
* PIX and PIX Automatico have no automated test coverage. Manual sandbox verification of the happy path is recommended if practical. The changes are mechanical (validator shape check + idempotency guard + one new `safeDismissModal()` on the success path).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?