### PR TITLE
BLIK: improve cancel copy and post-expiry UX

### DIFF
--- a/client/my-sites/checkout/src/lib/blik-confirmation.tsx
+++ b/client/my-sites/checkout/src/lib/blik-confirmation.tsx
@@ -18,17 +18,18 @@ export function BlikConfirmation( {
 	cancel,
 }: {
 	formattedTotal: string;
-	cancel: () => void;
+	cancel: ( wasExpired: boolean ) => void;
 } ) {
 	const translate = useTranslate();
 	const secondsRemaining = useCountdown( BLIK_AUTHORIZATION_TIMEOUT_SECONDS );
 	const isExpired = secondsRemaining <= 0;
+	const handleDismiss = () => cancel( isExpired );
 
 	return (
 		<Modal
 			title={ translate( 'Confirm your BLIK payment' ) as string }
 			className="blik-confirmation"
-			onRequestClose={ cancel }
+			onRequestClose={ handleDismiss }
 			shouldCloseOnClickOutside={ false }
 			isDismissible
 		>
@@ -71,8 +72,8 @@ export function BlikConfirmation( {
 			</BlikModalBody>
 
 			<BlikModalFooter>
-				<Button borderless onClick={ cancel }>
-					{ translate( 'Cancel payment' ) }
+				<Button borderless onClick={ handleDismiss }>
+					{ isExpired ? translate( 'Close' ) : translate( 'Cancel payment' ) }
 				</Button>
 			</BlikModalFooter>
 		</Modal>

--- a/client/my-sites/checkout/src/lib/blik-processor.ts
+++ b/client/my-sites/checkout/src/lib/blik-processor.ts
@@ -116,7 +116,9 @@ export default async function blikProcessor(
 				cancel: () => {
 					safeDismissModal();
 					isModalActive = false;
-					explicitClosureMessage = translate( 'Payment cancelled.' );
+					explicitClosureMessage = translate(
+						'Payment cancelled. If you have already approved the payment in your banking app, the payment may still go through. Please check your account before trying again.'
+					);
 				},
 			} );
 

--- a/client/my-sites/checkout/src/lib/blik-processor.ts
+++ b/client/my-sites/checkout/src/lib/blik-processor.ts
@@ -113,12 +113,14 @@ export default async function blikProcessor(
 			displayModal( {
 				root,
 				formattedTotal,
-				cancel: () => {
+				cancel: ( wasExpired ) => {
 					safeDismissModal();
 					isModalActive = false;
-					explicitClosureMessage = translate(
-						'Payment cancelled. If you have already approved the payment in your banking app, the payment may still go through. Please check your account before trying again.'
-					);
+					explicitClosureMessage = wasExpired
+						? translate( 'BLIK code expired. Please try again.' )
+						: translate(
+								'Payment cancelled. If you have already approved the payment in your banking app, the payment may still go through. Please check your account before trying again.'
+						  );
 				},
 			} );
 
@@ -183,7 +185,7 @@ function displayModal( {
 }: {
 	root: Root;
 	formattedTotal: string;
-	cancel: () => void;
+	cancel: ( wasExpired: boolean ) => void;
 } ) {
 	root.render(
 		createElement( BlikConfirmation, {


### PR DESCRIPTION
Fixes [SHILL-1950](https://linear.app/a8c/issue/SHILL-1950/blik-cancel-button-doesnt-cancel-the-stripe-paymentintent).

## Proposed Changes

* When a customer clicks "Cancel payment" on the BLIK confirmation modal, surface a message warning that an already-approved payment may still complete, instead of the bare "Payment cancelled."
* After the 60-second authorization window expires, relabel the modal button from "Cancel payment" to "Close" — there is nothing left to cancel at that point.
* When the user dismisses the modal post-expiry, surface "BLIK code expired. Please try again." instead of the cancel-time copy.

## Why are these changes being made?

The BLIK cancel handler closes the modal client-side but does not call `paymentIntent.cancel()` on Stripe. If the customer approves in their banking app within the 60-second window after clicking Cancel, the order completes server-side and they are charged — while checkout has told them "Payment cancelled." A proper server-side cancel is tracked as part of the broader Stripe-redirect refactor (SHILL-1912); this PR is the lightweight copy-only mitigation so customers are not blindsided by a silent charge.

The post-expiry relabel is a smaller adjacent fix: the modal stays open after expiry on purpose (so the customer sees what happened), but the button still read "Cancel payment" and the closure message warned about an in-flight approval — both nonsensical once the PaymentIntent has timed out.

## Testing Instructions

* Start a BLIK payment, enter a 6-digit code, submit. The waiting modal opens with the 60s countdown.
* Click "Cancel payment" before the timer hits zero. Verify checkout shows the new closure message warning that the payment may still complete.
* Testing a failed payment in sandbox is difficult because there isn't a code to fail on. 

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?