### PR TITLE
E2E: Do not wait for load event for site selector detection

### DIFF
--- a/packages/calypso-e2e/src/lib/components/site-select-component.ts
+++ b/packages/calypso-e2e/src/lib/components/site-select-component.ts
@@ -30,8 +30,15 @@ export class SiteSelectComponent {
 	 * @returns {Promise<boolean>} Whether the site selector is shown.
 	 */
 	async isSiteSelectorVisible(): Promise< boolean > {
-		await this.page.waitForLoadState( 'load' );
-		return await this.page.isVisible( ':has-text("Select a site")' );
+		try {
+			await this.page
+				.locator( ':has-text("Select a site")' )
+				.first()
+				.waitFor( { state: 'visible', timeout: 5000 } );
+			return true;
+		} catch {
+			return false;
+		}
 	}
 
 	/**


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

Lately there have been many timeouts on the `SiteSelectComponent` step. The test waited for the `load` event to fire, then checked to see if there's a site selection component on the page. If the `load` event doesn't fire in the 15s window, the test fails.

This PR changes the test to instead directly look for the site select component for 5s, bypassing the event wait altogether.

See also: p1777913210541189-slack-C034JEXD1RD

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The timeouts look like this:
```
======= Failed test run #1 ==========
  page.waitForLoadState: Timeout 15000ms exceeded.
  =========================== logs ===========================
    "commit" event fired
    "domcontentloaded" event fired
  ============================================================
  at SiteSelectComponent.waitForLoadState (/home/teamcity-5/buildAgent/work/c4a9d5b38c1dacde/packages/calypso-e2e/src/lib/components/site-select-component.ts:33:19)
      at EditorPage.isSiteSelectorVisible (/home/teamcity-5/buildAgent/work/c4a9d5b38c1dacde/packages/calypso-e2e/src/lib/pages/editor-page.ts:123:53)
      at Object.<anonymous> (/home/teamcity-5/buildAgent/work/c4a9d5b38c1dacde/test/e2e/specs/blocks/shared/block-smoke-testing.ts:51:4)
======= Failed test run #2 ==========
  page.waitForLoadState: Timeout 15000ms exceeded.
  =========================== logs ===========================
    "commit" event fired
    "domcontentloaded" event fired
  ============================================================
  at SiteSelectComponent.waitForLoadState (/home/teamcity-5/buildAgent/work/c4a9d5b38c1dacde/packages/calypso-e2e/src/lib/components/site-select-component.ts:33:19)
      at EditorPage.isSiteSelectorVisible (/home/teamcity-5/buildAgent/work/c4a9d5b38c1dacde/packages/calypso-e2e/src/lib/pages/editor-page.ts:123:53)
      at Object.<anonymous> (/home/teamcity-5/buildAgent/work/c4a9d5b38c1dacde/test/e2e/specs/blocks/shared/block-smoke-testing.ts:51:4)
```

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This affects many tests, but try the following:
```
yarn workspace wp-e2e-tests build &&
ATOMIC_VARIATION="ecomm-plan" TEST_ON_ATOMIC="true" VIEWPORT_NAME="desktop" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/blocks/blocks__jetpack-media.ts" &&
ATOMIC_VARIATION="ecomm-plan" TEST_ON_ATOMIC="true" VIEWPORT_NAME="mobile" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/blocks/blocks__jetpack-media.ts"
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?