### PR TITLE
AGENTS.md: document type_check_client pre-PR check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,11 +67,23 @@ yarn test-client --testNamePattern="<TestName>" # Run a specific client unit tes
 # E2E tests - refer to: test/e2e/AGENTS.md
 
 # Code Quality
-yarn lint           # Lint everything
-yarn lint:css       # Lint CSS
-yarn lint:js        # Lint JavaScript
-yarn reformat-files # Fix formatting with Prettier
+yarn lint             # Lint everything
+yarn lint:css         # Lint CSS
+yarn lint:js          # Lint JavaScript
+yarn reformat-files   # Fix formatting with Prettier
+yarn typecheck-client # Type-check client/ (matches CI's type_check_client)
 ```
+
+## Pre-PR checks
+
+Before pushing a branch or running `gh pr create`, run the type-check that CI will run. PRs touching `client/` may fail the `type_check_client` CI check after opening, so verify locally first:
+
+```bash
+yarn               # Install dependencies first if you haven't already
+yarn typecheck-client
+```
+
+If it fails, fix the type errors at the source — do not silence them with `// @ts-expect-error`, `// @ts-ignore`, or `as any` unless you can justify it in the PR description. Other CI type-checks worth running when relevant: `yarn typecheck-packages`, `yarn typecheck-apps`.
 
 ## Creating Pull Requests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ yarn lint             # Lint everything
 yarn lint:css         # Lint CSS
 yarn lint:js          # Lint JavaScript
 yarn reformat-files   # Fix formatting with Prettier
-yarn typecheck-client # Type-check client/ (matches CI's type_check_client)
+yarn typecheck-client # Type-check client
 ```
 
 ## Pre-PR checks


### PR DESCRIPTION
Part of #

## Proposed Changes

* Add a "Pre-PR checks" section to the root `AGENTS.md` instructing contributors (humans and agents) to run `yarn typecheck-client` before pushing or opening a PR.
* Add `yarn typecheck-client` to the Code Quality block, alongside the existing lint and formatting commands.
* Note that `yarn` must be run first if dependencies aren't installed.

## Why are these changes being made?

PRs touching `client/` may pass local tests and lint but fail the `type_check_client` CI check after the PR is opened. The check runs `tsc --noEmit --project client/tsconfig.json` against the whole `client/` tree, so the failure mode is the same regardless of which client area was edited (Calypso, Reader, Jetpack Cloud, A8C for Agencies, shared infra). Surfacing the matching local command in `AGENTS.md` lets contributors catch these issues before pushing instead of after CI runs.

## Testing Instructions

* Read the updated `AGENTS.md`.
* Optionally run `yarn typecheck-client` from a clean checkout to confirm the script exists and matches the CI command (`tsc --noEmit --project client/tsconfig.json`, defined in `bin/unit-test-suite.mjs`).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?