### PR TITLE
Reader ATmosphere: wire Quote-post menu item (CM-664)

### DIFF
--- a/client/reader/atmosphere/use-atmosphere-repost-action.ts
+++ b/client/reader/atmosphere/use-atmosphere-repost-action.ts
@@ -179,8 +179,37 @@ export function makeUseAtmosphereRepostAction( connectionId: number ): UseRepost
 			);
 		};
 
+		const onQuoteClick = analytics?.onQuoteClick;
+
 		const quote = () => {
-			// Slice-7d work — disabled menu item for now. No-op.
+			// Atmosphere quote requires a strong-ref `cid`. Same observability
+			// shape as `repost` — log + Tracks event so a panel-wiring bug
+			// (cid missing) doesn't dead-button silently in production.
+			if ( ! post.cid ) {
+				logToLogstash( {
+					feature: 'calypso_client',
+					message: 'Atmosphere quote: post.cid missing on click',
+					severity: 'warning',
+					extra: {
+						type: 'reader_atmosphere_quote_missing_cid',
+						connection_id: connectionId,
+						post_uri: post.uri,
+					},
+				} );
+				analytics?.onClick( `calypso_reader_${ analytics.source }_quote_missing_cid`, {
+					connection_id: connectionId,
+					post_uri: post.uri,
+				} );
+				return;
+			}
+			if ( ! onQuoteClick ) {
+				return;
+			}
+			analytics?.onClick( `calypso_reader_${ analytics.source }_quote_clicked`, {
+				connection_id: connectionId,
+				post_uri: post.uri,
+			} );
+			onQuoteClick( post );
 		};
 
 		const accessibleLabel = ( count: number, reposted: boolean ) => {
@@ -206,7 +235,13 @@ export function makeUseAtmosphereRepostAction( connectionId: number ): UseRepost
 				action: translate( 'Repost' ),
 				accessibleLabel,
 			},
-			canQuote: false, // slice-7d
+			// Quote menu item is enabled only when (a) the per-protocol shell
+			// has wired `analytics.onQuoteClick` (the composer is mounted
+			// upstream), AND (b) the post carries a strong-ref `cid`.
+			// `quote()` itself re-checks both before firing for defence in
+			// depth — `canQuote` only drives the disabled state of the
+			// menu item.
+			canQuote: Boolean( onQuoteClick && post.cid ),
 			repost,
 			unrepost,
 			quote,

--- a/client/reader/social/AGENTS.md
+++ b/client/reader/social/AGENTS.md
@@ -336,9 +336,12 @@ Two render branches by viewer state:
   toggle is the same shape of button (`aria-haspopup="menu"`). The menu
   has two `<MenuItem>`s: the action item (label provided by the adapter
   — "Repost" for ATmosphere, "Boost" for Mastodon) and "Quote post"
-  (disabled when `action.canQuote === false` — true today for both
-  protocols; ATmosphere wires up in slice 7d, Mastodon has no native
-  quote concept).
+  (disabled when `action.canQuote === false`). ATmosphere enables the
+  item when both `analytics.onQuoteClick` is bound (the composer is
+  mounted upstream) and the post carries a strong-ref `cid`; clicking
+  it routes through `analytics.onQuoteClick(post)` which opens the
+  shared composer in `kind: 'quote'` mode. Mastodon has no native quote
+  concept and stays `canQuote: false`.
 
 Each protocol shell wires its own adapter hook factory:
 

--- a/client/reader/social/components/post-card/test/repost-button.test.tsx
+++ b/client/reader/social/components/post-card/test/repost-button.test.tsx
@@ -297,18 +297,76 @@ describe( '<RepostButton>', () => {
 	} );
 
 	// The dropdown's "Quote post" menu item is disabled when the adapter
-	// reports `canQuote === false`. The atmosphere adapter sets `canQuote:
-	// false` until slice 7d wires composer-driven quoting, so this is the
-	// only case the cm-660 design covers today. The previously passing
-	// "enables Quote post via onQuote prop" test was replaced when the
-	// RepostButton signature lost its `onQuote` prop in favour of the
-	// adapter contract.
-	it( 'leaves "Quote post" disabled when the adapter reports canQuote=false', async () => {
+	// reports `canQuote === false`. The atmosphere adapter (slice 7d)
+	// sets `canQuote: Boolean( onQuoteClick && post.cid )`, so the menu
+	// item is disabled when no `onQuoteClick` is bound on the analytics
+	// context (e.g. when no `<ComposerProvider>` is mounted upstream).
+	it( 'leaves "Quote post" disabled when no onQuoteClick is bound', async () => {
 		const user = userEvent.setup();
 		renderRepostButton();
 		await user.click( screen.getByRole( 'button', { name: /repost, 4 reposts/i } ) );
 		const item = await screen.findByRole( 'menuitem', { name: /quote post/i } );
 		expect( item ).toHaveAttribute( 'aria-disabled', 'true' );
+	} );
+
+	it( 'enables "Quote post" when onQuoteClick is bound and post has cid; click invokes the handler', async () => {
+		const onQuoteClick = jest.fn();
+		const onClick = jest.fn();
+		const user = userEvent.setup();
+		const useRepostAction = makeUseAtmosphereRepostAction( 42 );
+		const socialPost = mapAtmosphereFeedItemToSocialPost( makePost() );
+		renderWithProvider(
+			<SocialAnalyticsProvider
+				value={ {
+					source: 'atmosphere',
+					connectionId: 42,
+					onClick,
+					onQuoteClick,
+				} }
+			>
+				<RepostProvider value={ useRepostAction }>
+					<RepostButton post={ socialPost } />
+				</RepostProvider>
+			</SocialAnalyticsProvider>,
+			{ queryClient: makeQueryClient() }
+		);
+
+		await user.click( screen.getByRole( 'button', { name: /repost, 4 reposts/i } ) );
+		const item = await screen.findByRole( 'menuitem', { name: /quote post/i } );
+		expect( item ).not.toHaveAttribute( 'aria-disabled', 'true' );
+		await user.click( item );
+		expect( onQuoteClick ).toHaveBeenCalledWith( socialPost );
+		expect( onClick ).toHaveBeenCalledWith(
+			'calypso_reader_atmosphere_quote_clicked',
+			expect.objectContaining( { connection_id: 42, post_uri: POST_URI } )
+		);
+	} );
+
+	it( 'leaves "Quote post" disabled when onQuoteClick is bound but post.cid is missing', async () => {
+		const onQuoteClick = jest.fn();
+		const user = userEvent.setup();
+		const useRepostAction = makeUseAtmosphereRepostAction( 42 );
+		const cidlessPost = mapAtmosphereFeedItemToSocialPost( makePost( { cid: '' } ) );
+		renderWithProvider(
+			<SocialAnalyticsProvider
+				value={ {
+					source: 'atmosphere',
+					connectionId: 42,
+					onClick: jest.fn(),
+					onQuoteClick,
+				} }
+			>
+				<RepostProvider value={ useRepostAction }>
+					<RepostButton post={ cidlessPost } />
+				</RepostProvider>
+			</SocialAnalyticsProvider>,
+			{ queryClient: makeQueryClient() }
+		);
+
+		await user.click( screen.getByRole( 'button', { name: /repost, 4 reposts/i } ) );
+		const item = await screen.findByRole( 'menuitem', { name: /quote post/i } );
+		expect( item ).toHaveAttribute( 'aria-disabled', 'true' );
+		expect( onQuoteClick ).not.toHaveBeenCalled();
 	} );
 
 	it( 'click does not bubble to a parent listener', async () => {


### PR DESCRIPTION
Part of CM-664

> **Base branch:** `cm-662-mastodon-slice-7c-frontend-reply-composer-calypso`. This slice builds on the composer infrastructure shipped in CM-662 (#110451). When CM-662 lands in trunk, this PR's base will rebase to trunk automatically.

## Proposed Changes

*   `makeUseAtmosphereRepostAction` enables the `<RepostButton>` dropdown's "Quote post" menu item for ATmosphere posts. The composer support for `kind: 'quote'` already shipped in CM-662 — this slice is purely the adapter wiring.
*   `canQuote = Boolean( analytics.onQuoteClick && post.cid )`. The panel-level `onQuoteClick` (already wired in `atmosphere/{timeline,thread,author-profile,tag-feed}-panel.tsx` to call `openComposer({ kind: 'quote', … })`) is the composer-presence signal; the `post.cid` check guards AT-Proto's strong-ref requirement.
*   `quote()` fires a `_quote_clicked` Tracks event and delegates to `analytics.onQuoteClick( post )`.
*   Cid-miss observability mirrors the existing `repost` action: warning logstash entry plus a `_quote_missing_cid` Tracks event. Defence-in-depth — `canQuote` already prevents the menu item from being clickable in this state, but the guard catches direct `action.quote()` calls.
*   Mastodon's adapter is unaffected — no native quote concept on the wire, Mastodon panels don't bind `onQuoteClick`.

## Why are these changes being made?

The "Quote post" menu item was rendered disabled in CM-660 (boost) with a `// slice-7d` placeholder, then the composer's `kind: 'quote'` mode shipped in CM-662 (Mastodon reply + standalone). This slice closes the loop on the ATmosphere side.

## Testing Instructions

1.  `yarn test-client client/reader/social/components/post-card/test/repost-button.test.tsx` — should pass (18 tests, 3 new for slice 7d).
2.  `yarn test-client client/reader/atmosphere` — should pass (no regressions; the existing onQuoteClick wiring in panel tests still applies).
3.  Bring up Calypso with an ATmosphere connection (`/reader/atmosphere/<id>`):
    *   Click any post's repost icon → the dropdown shows "Repost" (enabled) and "Quote post" (now enabled, was disabled).
    *   Click "Quote post" → composer opens in `kind: 'quote'` mode with the post pinned at the top, placeholder reads "Add a comment…", limit shows 300, posting succeeds.
    *   Confirm `_quote_clicked` Tracks event fires on the menu click and `_quote_composer_opened` fires on modal mount.
    *   Confirm a Mastodon connection's repost dropdown still shows "Quote post" disabled (Mastodon doesn't bind `onQuoteClick`).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?