### PR TITLE
Update Blaze v3 ad preview options

### DIFF
--- a/client/my-sites/promote-post-i2/components/ad-preview/index.tsx
+++ b/client/my-sites/promote-post-i2/components/ad-preview/index.tsx
@@ -13,9 +13,11 @@ interface Props {
 export default function AdPreview( { htmlCode, isLoading, templateFormat, width }: Props ) {
 	const adWidth = width ? `${ width }` : '300px';
 
-	// Both the classic html5_v2 template and the AI-generated html5_v3 template
-	// emit the same `wa-inline-frame` postMessage protocol to size the iframe.
-	const isResponsiveHtmlFormat = templateFormat === 'html5_v2' || templateFormat === 'html5_v3';
+	// Responsive WPCOM templates emit the same `wa-inline-frame` postMessage
+	// protocol to size the iframe.
+	const isResponsiveHtmlFormat = [ 'html5_v2', 'html5_v3', 'html5_v4' ].includes(
+		templateFormat
+	);
 
 	useEffect( () => {
 		if ( ! isLoading && isResponsiveHtmlFormat ) {
@@ -54,6 +56,7 @@ export default function AdPreview( { htmlCode, isLoading, templateFormat, width 
 	const classes = clsx( 'campaign-item-details__preview-content', {
 		v02: templateFormat === 'html5_v2',
 		v03: templateFormat === 'html5_v3',
+		v04: templateFormat === 'html5_v4',
 	} );
 
 	return (

--- a/client/my-sites/promote-post-i2/components/ad-preview/index.tsx
+++ b/client/my-sites/promote-post-i2/components/ad-preview/index.tsx
@@ -15,9 +15,7 @@ export default function AdPreview( { htmlCode, isLoading, templateFormat, width 
 
 	// Responsive WPCOM templates emit the same `wa-inline-frame` postMessage
 	// protocol to size the iframe.
-	const isResponsiveHtmlFormat = [ 'html5_v2', 'html5_v3', 'html5_v4' ].includes(
-		templateFormat
-	);
+	const isResponsiveHtmlFormat = [ 'html5_v2', 'html5_v3', 'html5_v4' ].includes( templateFormat );
 
 	useEffect( () => {
 		if ( ! isLoading && isResponsiveHtmlFormat ) {

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/AdPreviewModal.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/AdPreviewModal.tsx
@@ -19,9 +19,9 @@ const AdPreviewModal: React.FC< Props > = ( { templateFormat, htmlCode, isLoadin
 	const closeModal = () => setOpen( false );
 
 	const [ previewSelected, setPreviewSelected ] = useState< Device >( 'mobile' );
-	const isV3Template = templateFormat === 'html5_v3';
+	const hasNoDesktopPreview = [ 'html5_v3', 'html5_v4' ].includes( templateFormat || '' );
 	const effectivePreviewSelected =
-		isV3Template && previewSelected === 'desktop' ? 'tablet' : previewSelected;
+		hasNoDesktopPreview && previewSelected === 'desktop' ? 'tablet' : previewSelected;
 
 	const MobileIcon = () => {
 		return (
@@ -143,10 +143,10 @@ const AdPreviewModal: React.FC< Props > = ( { templateFormat, htmlCode, isLoadin
 							) }
 						>
 							<TabletIcon />
-							<span>{ isV3Template ? __( 'Tablet/Desktop' ) : __( 'Tablet' ) }</span>
+							<span>{ hasNoDesktopPreview ? __( 'Tablet/Desktop' ) : __( 'Tablet' ) }</span>
 						</button>
 
-						{ ! isV3Template && (
+						{ ! hasNoDesktopPreview && (
 							<button
 								onClick={ showDesktopPreview }
 								color="inherit"

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/AdPreviewModal.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/AdPreviewModal.tsx
@@ -19,6 +19,9 @@ const AdPreviewModal: React.FC< Props > = ( { templateFormat, htmlCode, isLoadin
 	const closeModal = () => setOpen( false );
 
 	const [ previewSelected, setPreviewSelected ] = useState< Device >( 'mobile' );
+	const isV3Template = templateFormat === 'html5_v3';
+	const effectivePreviewSelected =
+		isV3Template && previewSelected === 'desktop' ? 'tablet' : previewSelected;
 
 	const MobileIcon = () => {
 		return (
@@ -113,7 +116,7 @@ const AdPreviewModal: React.FC< Props > = ( { templateFormat, htmlCode, isLoadin
 							isLoading={ isLoading }
 							htmlCode={ htmlCode || '' }
 							templateFormat={ templateFormat || '' }
-							width={ getPreviewWidth( previewSelected ) }
+							width={ getPreviewWidth( effectivePreviewSelected ) }
 						/>
 					</div>
 					<div className="ad-preview-modal__links">
@@ -121,7 +124,10 @@ const AdPreviewModal: React.FC< Props > = ( { templateFormat, htmlCode, isLoadin
 							onClick={ showMobilePreview }
 							color="inherit"
 							rel="noreferrer"
-							className={ clsx( 'link-preview', previewSelected === 'mobile' ? 'active' : '' ) }
+							className={ clsx(
+								'link-preview',
+								effectivePreviewSelected === 'mobile' ? 'active' : ''
+							) }
 						>
 							<MobileIcon />
 							<span>{ __( 'Mobile' ) }</span>
@@ -131,21 +137,29 @@ const AdPreviewModal: React.FC< Props > = ( { templateFormat, htmlCode, isLoadin
 							onClick={ showTabletPreview }
 							color="inherit"
 							rel="noreferrer"
-							className={ clsx( 'link-preview', previewSelected === 'tablet' ? 'active' : '' ) }
+							className={ clsx(
+								'link-preview',
+								effectivePreviewSelected === 'tablet' ? 'active' : ''
+							) }
 						>
 							<TabletIcon />
-							<span>{ __( 'Tablet' ) }</span>
+							<span>{ isV3Template ? __( 'Tablet/Desktop' ) : __( 'Tablet' ) }</span>
 						</button>
 
-						<button
-							onClick={ showDesktopPreview }
-							color="inherit"
-							rel="noreferrer"
-							className={ clsx( 'link-preview', previewSelected === 'desktop' ? 'active' : '' ) }
-						>
-							<DesktopIcon />
-							<span>{ __( 'Desktop' ) }</span>
-						</button>
+						{ ! isV3Template && (
+							<button
+								onClick={ showDesktopPreview }
+								color="inherit"
+								rel="noreferrer"
+								className={ clsx(
+									'link-preview',
+									effectivePreviewSelected === 'desktop' ? 'active' : ''
+								) }
+							>
+								<DesktopIcon />
+								<span>{ __( 'Desktop' ) }</span>
+							</button>
+						) }
 					</div>
 				</Modal>
 			) }

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -493,10 +493,9 @@ export default function CampaignItemDetails( props: Props ) {
 		? `$${ formatCents( total_budget_used || 0, 2 ) }`
 		: '- ';
 
-	// Both the classic (html5_v2) and AI-generated (html5_v3) responsive WP
-	// placements ship a renderable HTML doc — anything else has no preview,
-	// just dimensions.
-	const isWpcomHtmlFormat = format === 'html5_v2' || format === 'html5_v3';
+	// Responsive WPCOM placements ship a renderable HTML doc — anything else
+	// has no preview, just dimensions.
+	const isWpcomHtmlFormat = [ 'html5_v2', 'html5_v3', 'html5_v4' ].includes( format || '' );
 
 	const adPreviewLabel = isWpcomHtmlFormat ? (
 		<div className="campaign-item-details__preview-header-preview-button">

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -732,14 +732,16 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 	}
 
 	.campaign-item-details__preview-content.v02,
-	.campaign-item-details__preview-content.v03 {
+	.campaign-item-details__preview-content.v03,
+	.campaign-item-details__preview-content.v04 {
 		margin: 0 auto;
 		min-width: 300px;
 		width: 100%;
 	}
 
 	.campaign-item-details__preview-content.v02 iframe,
-	.campaign-item-details__preview-content.v03 iframe{
+	.campaign-item-details__preview-content.v03 iframe,
+	.campaign-item-details__preview-content.v04 iframe {
 		height: 200px;
 		width: 100%;
 	}


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/ADS-1030/remove-desktop-template-from-blaze-ad-views

## Proposed Changes

Part of https://github.tumblr.net/Tumblr/a8c-dsp/pull/3860

This PR has to be merged first


🤖 
* Updates the Blaze ad preview modal to check the template format before deciding which preview device options to show.
* Keeps the existing Mobile, Tablet, and Desktop preview options for existing `html5_v2` ads.
* Shows only Mobile and Tablet/Desktop for `html5_v3` ads, using the tablet preview width for the combined option.

## Why are these changes being made?

The new DSP `html5_v3` Blaze template removes the desktop layout, so Calypso should not offer a separate desktop preview for those ads. Existing `html5_v2` ads still support desktop and should keep the current three-option preview.

## Testing Instructions

* Open a Blaze campaign using an `html5_v2` ad and open the ad preview modal.
* Confirm the modal shows Mobile, Tablet, and Desktop options.
* Open a Blaze campaign using an `html5_v3` ad and open the ad preview modal.
* Confirm the modal shows Mobile and Tablet/Desktop only.
* Confirm selecting Tablet/Desktop renders the 500px tablet-sized preview.

Local note: `yarn eslint client/my-sites/promote-post-i2/components/campaign-item-details/AdPreviewModal.tsx` could not run in the fresh worktree because Yarn reported the missing `node_modules` state file. `git diff --check` passes.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
