### PR TITLE
Reader Mastodon: quote-post composer (CM-664)

### DIFF
--- a/client/reader/AGENTS.md
+++ b/client/reader/AGENTS.md
@@ -178,8 +178,9 @@ The reply / quote / standalone composer follows the same pattern with
 provider once per view (account, thread, author-profile) alongside
 `<ComposerModal />` and `<ComposeFab />`; panels that should render the
 inline `<TimelineComposePill />` opt in via `useOptionalComposer()`. The
-config carries the per-protocol limit, supported mode kinds (Mastodon
-omits `'quote'`), wire-shape `buildParams`, error-message map (with a
+config carries the per-protocol limit, supported mode kinds (both
+protocols support `'reply'`, `'quote'`, and `'standalone'`),
+wire-shape `buildParams`, error-message map (with a
 mandatory `default:` arm using `err satisfies never;` — same lesson as
 the like / repost adapters), Tracks event names, success-notice copy,
 optional `logBadRequest` (lives in the per-protocol adapter so

--- a/client/reader/mastodon/author-profile-panel.tsx
+++ b/client/reader/mastodon/author-profile-panel.tsx
@@ -10,10 +10,12 @@ import {
 	SocialProfileCard,
 	mapMastodonAccountToSocialProfileCardProps,
 	mapMastodonFeedItemToSocialPost,
+	type SocialPost,
 	type SocialProfileStat,
 } from 'calypso/reader/social';
 import { LikeProvider } from 'calypso/reader/social/components/post-card/like-context';
 import { RepostProvider } from 'calypso/reader/social/components/post-card/repost-context';
+import { useOptionalComposer } from 'calypso/reader/social/composer';
 import { MastodonAuthorProfileTabs, useMastodonAuthorFeedFilter } from './author-profile-tabs';
 import { projectMastodonError } from './error-projection';
 import { errorMessage } from './profile-errors';
@@ -183,6 +185,36 @@ export function MastodonAuthorProfilePanel( {
 		[ connection.id ]
 	);
 
+	const composer = useOptionalComposer();
+	const openComposer = composer?.openComposer;
+
+	const onReplyClick = useMemo( () => {
+		if ( ! openComposer ) {
+			return undefined;
+		}
+		return ( post: SocialPost ) => {
+			openComposer( {
+				kind: 'reply',
+				root: { uri: post.uri },
+				parent: { uri: post.uri },
+				previewPost: post,
+			} );
+		};
+	}, [ openComposer ] );
+
+	const onQuoteClick = useMemo( () => {
+		if ( ! openComposer ) {
+			return undefined;
+		}
+		return ( post: SocialPost ) => {
+			openComposer( {
+				kind: 'quote',
+				quote: { uri: post.uri },
+				previewPost: post,
+			} );
+		};
+	}, [ openComposer ] );
+
 	return (
 		<LikeProvider value={ useLikeAction }>
 			<RepostProvider value={ useRepostAction }>
@@ -203,6 +235,8 @@ export function MastodonAuthorProfilePanel( {
 					buildProfileUrl={ buildProfileUrl }
 					buildThreadUrl={ buildThreadUrl }
 					buildTagUrl={ buildTagUrl }
+					onReplyClick={ onReplyClick }
+					onQuoteClick={ onQuoteClick }
 					emptyTitle={
 						isLockedEmpty
 							? String( translate( 'This account’s posts are private.' ) )

--- a/client/reader/mastodon/composer-config.tsx
+++ b/client/reader/mastodon/composer-config.tsx
@@ -27,7 +27,47 @@ export const mastodonComposerConfig: ComposerConfig<
 	// instances. The retry lives in `createMastodonPostWithQuoteFallback`
 	// — see packages/api-queries/src/reader-mastodon.ts.
 	supportedModes: [ 'reply', 'quote', 'standalone' ],
-	mutationFactory: createMastodonPostMutation,
+	mutationFactory: ( queryClient ) =>
+		createMastodonPostMutation( queryClient, {
+			// Observability hooks for the native → text-quoting downgrade.
+			// `packages/api-queries` can't import `calypso/lib/logstash`
+			// (lint-restricted), so the per-protocol adapter wires them in.
+			// `info` (not `debug`) because we want this counted in
+			// dashboards to size the backend follow-up for a
+			// quote-specific error code; `debug` is filtered by most
+			// pipelines. The user-typed `status` is intentionally NOT
+			// logged — we ship `connection_id` and the opaque
+			// `quoted_status_id` for spot-checking which instance is
+			// driving fallbacks.
+			onQuoteFallback: ( params ) => {
+				logToLogstash( {
+					feature: 'calypso_client',
+					message: 'Mastodon composer: quote fallback triggered',
+					severity: 'info',
+					extra: {
+						env: config( 'env_id' ),
+						type: 'reader_mastodon_quote_fallback',
+						connection_id: params.connectionId,
+						quoted_status_id: params.quoted_status_id,
+					},
+				} );
+			},
+			onQuoteFallbackFailed: ( params, originalError, retryError ) => {
+				logToLogstash( {
+					feature: 'calypso_client',
+					message: 'Mastodon composer: quote fallback retry failed',
+					severity: 'warning',
+					extra: {
+						env: config( 'env_id' ),
+						type: 'reader_mastodon_quote_fallback_failed',
+						connection_id: params.connectionId,
+						quoted_status_id: params.quoted_status_id,
+						original_error_kind: originalError.kind,
+						retry_error_kind: retryError.kind,
+					},
+				} );
+			},
+		} ),
 	buildParams: ( mode, text ) => buildParamsForMode( mode, text ),
 	errorMessage: ( error, translate ) => errorMessageFor( error, translate ),
 	successNotice: ( mode, result, translate ) => {

--- a/client/reader/mastodon/composer-config.tsx
+++ b/client/reader/mastodon/composer-config.tsx
@@ -3,7 +3,7 @@ import config from '@automattic/calypso-config';
 import { logToLogstash } from 'calypso/lib/logstash';
 import { getThreadUrl } from './route';
 import type {
-	MastodonCreatePostParams,
+	MastodonCreatePostMutationParams,
 	MastodonCreatePostResult,
 	MastodonError,
 } from '@automattic/api-core';
@@ -18,14 +18,15 @@ const LIMIT = 500;
 
 export const mastodonComposerConfig: ComposerConfig<
 	MastodonError,
-	MastodonCreatePostParams,
+	MastodonCreatePostMutationParams,
 	MastodonCreatePostResult
 > = {
 	limit: LIMIT,
-	// No quote concept on the wire; the menu item never appears on
-	// Mastodon-rendered RepostButtons, and the openComposer guard in the
-	// generic provider drops a `kind: 'quote'` call before it sets state.
-	supportedModes: [ 'reply', 'standalone' ],
+	// Quote mode uses Mastodon 4.5+'s native `quoted_status_id` with a
+	// text-based fallback (permalink appended to status) for older
+	// instances. The retry lives in `createMastodonPostWithQuoteFallback`
+	// — see packages/api-queries/src/reader-mastodon.ts.
+	supportedModes: [ 'reply', 'quote', 'standalone' ],
 	mutationFactory: createMastodonPostMutation,
 	buildParams: ( mode, text ) => buildParamsForMode( mode, text ),
 	errorMessage: ( error, translate ) => errorMessageFor( error, translate ),
@@ -36,6 +37,7 @@ export const mastodonComposerConfig: ComposerConfig<
 				threadUrl: getThreadUrl( mode.connectionId, mode.parent.uri ),
 			};
 		}
+		// Quote and standalone both link to the new post's own thread.
 		return {
 			text: translate( 'Your post was published.' ),
 			threadUrl: getThreadUrl( mode.connectionId, result.id ),
@@ -49,8 +51,6 @@ export const mastodonComposerConfig: ComposerConfig<
 					props: { connection_id: mode.connectionId, parent_uri: mode.parent.uri },
 				};
 			}
-			// Quote mode is unsupported and openComposer rejects it before this
-			// point, but the discriminated union still requires a branch.
 			if ( mode.kind === 'quote' ) {
 				return {
 					event: 'calypso_reader_mastodon_quote_composer_opened',
@@ -133,6 +133,9 @@ function titleForMode( mode: ActiveMode, t: Translate ): string {
 	if ( mode.kind === 'reply' ) {
 		return t( 'Reply' ) as string;
 	}
+	if ( mode.kind === 'quote' ) {
+		return t( 'Quote post' ) as string;
+	}
 	return t( 'New post' ) as string;
 }
 
@@ -144,15 +147,32 @@ function placeholderForMode( mode: ActiveMode, t: Translate, handle: string | un
 				'Placeholder text in the reply composer; %(handle)s is the Mastodon handle of the user being replied to.',
 		} ) as string;
 	}
+	if ( mode.kind === 'quote' ) {
+		return t( 'Add a comment…' ) as string;
+	}
 	return t( 'What’s on your mind?' ) as string;
 }
 
-function buildParamsForMode( mode: ActiveMode, text: string ): MastodonCreatePostParams {
+function buildParamsForMode( mode: ActiveMode, text: string ): MastodonCreatePostMutationParams {
 	if ( mode.kind === 'reply' ) {
 		return {
 			connectionId: mode.connectionId,
 			status: text,
 			in_reply_to_id: mode.parent.uri,
+		};
+	}
+	if ( mode.kind === 'quote' ) {
+		// Mastodon 4.5+ native quote post: send `quoted_status_id` and let the
+		// upstream embed the quoted post. The mutation falls back to text-based
+		// quoting (append the permalink to status) when the upstream returns
+		// `bad_request` (instance < 4.5, or quoting disabled). Surface the
+		// permalink to the mutation via `quotedFallbackPermalink` so it can
+		// retry without us re-walking the composer state.
+		return {
+			connectionId: mode.connectionId,
+			status: text,
+			quoted_status_id: mode.quote.uri,
+			quotedFallbackPermalink: mode.previewPost.permalink,
 		};
 	}
 	return {

--- a/client/reader/mastodon/test/composer-config.test.tsx
+++ b/client/reader/mastodon/test/composer-config.test.tsx
@@ -19,10 +19,26 @@ const replyMode: ActiveMode = {
 	parent: { uri: '108020' },
 	previewPost: {
 		uri: '108020',
+		permalink: 'https://mastodon.social/@alice/108020',
 		text: 'parent body',
 		html: '<p>parent body</p>',
 		author: { handle: 'alice', display_name: 'Alice' },
 	},
+};
+
+const quotePreview = {
+	uri: '109876543210',
+	permalink: 'https://mastodon.social/@alice/109876543210',
+	text: 'hello mastodon',
+	html: '<p>hello mastodon</p>',
+	author: { handle: 'alice@mastodon.social', display_name: 'Alice' },
+};
+
+const quoteMode: ActiveMode = {
+	kind: 'quote',
+	connectionId: 42,
+	quote: { uri: '109876543210' },
+	previewPost: quotePreview,
 };
 
 const standaloneMode: ActiveMode = {
@@ -33,8 +49,8 @@ const standaloneMode: ActiveMode = {
 
 describe( 'mastodonComposerConfig', () => {
 	describe( 'supportedModes', () => {
-		it( 'supports reply and standalone but not quote', () => {
-			expect( mastodonComposerConfig.supportedModes ).toEqual( [ 'reply', 'standalone' ] );
+		it( 'supports reply, quote, and standalone', () => {
+			expect( mastodonComposerConfig.supportedModes ).toEqual( [ 'reply', 'quote', 'standalone' ] );
 		} );
 	} );
 
@@ -61,6 +77,67 @@ describe( 'mastodonComposerConfig', () => {
 				status: 'a post',
 			} );
 			expect( params ).not.toHaveProperty( 'in_reply_to_id' );
+		} );
+
+		it( 'quote mode sets quoted_status_id and surfaces the permalink as a fallback hint', () => {
+			// Native Mastodon 4.5+ quote: send `quoted_status_id` on the wire
+			// and pass the permalink alongside as `quotedFallbackPermalink`.
+			// The mutation layer uses the fallback only on bad_request from
+			// older instances. Crucially, `status` is the user's text untouched
+			// — no permalink append at buildParams time.
+			expect( mastodonComposerConfig.buildParams( quoteMode, 'great point' ) ).toEqual( {
+				connectionId: 42,
+				status: 'great point',
+				quoted_status_id: '109876543210',
+				quotedFallbackPermalink: 'https://mastodon.social/@alice/109876543210',
+			} );
+		} );
+
+		it( 'quote mode submits an empty status when the user has not typed anything', () => {
+			// The user can publish a quote with no commentary; native quotes
+			// carry the embedded reference via `quoted_status_id` so an empty
+			// status is fine. The composer's own "empty body" UI gate is
+			// upstream of this.
+			expect( mastodonComposerConfig.buildParams( quoteMode, '' ) ).toEqual( {
+				connectionId: 42,
+				status: '',
+				quoted_status_id: '109876543210',
+				quotedFallbackPermalink: 'https://mastodon.social/@alice/109876543210',
+			} );
+		} );
+
+		it( 'quote mode passes through user text verbatim — no trim, no permalink append', () => {
+			// Trailing whitespace and the absence of the URL in `status` are
+			// intentional: the wire shape of a native quote does not include
+			// the permalink in the body. Trim happens only on the bad_request
+			// retry path (mutation layer).
+			expect( mastodonComposerConfig.buildParams( quoteMode, 'commentary   ' ) ).toEqual( {
+				connectionId: 42,
+				status: 'commentary   ',
+				quoted_status_id: '109876543210',
+				quotedFallbackPermalink: 'https://mastodon.social/@alice/109876543210',
+			} );
+		} );
+
+		it( 'quote mode emits an undefined fallback permalink when previewPost lacks one', () => {
+			// Belt-and-suspenders: panels always pass a SocialPost (which
+			// carries a permalink) but the structural PreviewPost type allows
+			// it to be missing. Surface that to the mutation as `undefined` so
+			// the fallback retry knows it has nothing to fall back to and
+			// re-throws the upstream bad_request rather than retrying with an
+			// empty trailer.
+			const mode: ActiveMode = {
+				kind: 'quote',
+				connectionId: 42,
+				quote: { uri: '109876543210' },
+				previewPost: { ...quotePreview, permalink: undefined },
+			};
+			expect( mastodonComposerConfig.buildParams( mode, 'commentary' ) ).toEqual( {
+				connectionId: 42,
+				status: 'commentary',
+				quoted_status_id: '109876543210',
+				quotedFallbackPermalink: undefined,
+			} );
 		} );
 	} );
 

--- a/client/reader/mastodon/test/quote-fallback.test.ts
+++ b/client/reader/mastodon/test/quote-fallback.test.ts
@@ -186,4 +186,268 @@ describe( 'createMastodonPostMutation — quote fallback', () => {
 			} )
 		).rejects.toMatchObject( { kind: 'auth_required' } );
 	} );
+
+	it( 'invokes onQuoteFallback exactly once when the fallback path fires', async () => {
+		nock( BASE )
+			.post( '/wpcom/v2/reader/mastodon/connections/7/statuses', {
+				status: 'commentary',
+				quoted_status_id: '116522382646486388',
+			} )
+			.reply( 400, { error: 'reader_mastodon_bad_request' } );
+		nock( BASE )
+			.post(
+				'/wpcom/v2/reader/mastodon/connections/7/statuses',
+				( body ) =>
+					body.status === 'commentary\n\nhttps://mastodon.social/@alice/116522382646486388'
+			)
+			.reply( 200, {
+				id: '999',
+				url: 'https://mastodon.social/@me/999',
+				in_reply_to_id: null,
+			} );
+
+		const onQuoteFallback = jest.fn();
+		const mutation = createMastodonPostMutation( makeQueryClient(), { onQuoteFallback } );
+		await mutation.mutationFn?.( {
+			connectionId: 7,
+			status: 'commentary',
+			quoted_status_id: '116522382646486388',
+			quotedFallbackPermalink: 'https://mastodon.social/@alice/116522382646486388',
+		} );
+
+		expect( onQuoteFallback ).toHaveBeenCalledTimes( 1 );
+		expect( onQuoteFallback ).toHaveBeenCalledWith(
+			expect.objectContaining( { connectionId: 7, quoted_status_id: '116522382646486388' } )
+		);
+	} );
+
+	it( 'does not invoke onQuoteFallback on a successful native attempt', async () => {
+		nock( BASE )
+			.post( '/wpcom/v2/reader/mastodon/connections/7/statuses', {
+				status: 'commentary',
+				quoted_status_id: '116522382646486388',
+			} )
+			.reply( 200, {
+				id: '999',
+				url: 'https://mastodon.social/@me/999',
+				in_reply_to_id: null,
+			} );
+
+		const onQuoteFallback = jest.fn();
+		const mutation = createMastodonPostMutation( makeQueryClient(), { onQuoteFallback } );
+		await mutation.mutationFn?.( {
+			connectionId: 7,
+			status: 'commentary',
+			quoted_status_id: '116522382646486388',
+			quotedFallbackPermalink: 'https://mastodon.social/@alice/116522382646486388',
+		} );
+
+		expect( onQuoteFallback ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not invoke onQuoteFallback when bad_request comes from a non-quote attempt', async () => {
+		nock( BASE )
+			.post( '/wpcom/v2/reader/mastodon/connections/7/statuses', { status: 'plain' } )
+			.reply( 400, { error: 'reader_mastodon_bad_request' } );
+
+		const onQuoteFallback = jest.fn();
+		const mutation = createMastodonPostMutation( makeQueryClient(), { onQuoteFallback } );
+		await expect(
+			mutation.mutationFn?.( { connectionId: 7, status: 'plain' } )
+		).rejects.toMatchObject( { kind: 'bad_request' } );
+
+		expect( onQuoteFallback ).not.toHaveBeenCalled();
+	} );
+
+	it( 'surfaces the second-attempt error when the text-fallback retry also fails', async () => {
+		// Native quote attempt 400s as bad_request → fallback fires.
+		nock( BASE )
+			.post( '/wpcom/v2/reader/mastodon/connections/7/statuses', {
+				status: 'commentary',
+				quoted_status_id: '116522382646486388',
+			} )
+			.reply( 400, { error: 'reader_mastodon_bad_request' } );
+		// Retry comes back with a *different* error (auth expired mid-flight).
+		// The wrapper must surface the retry's error, not the original
+		// bad_request — the user sees the current state.
+		nock( BASE )
+			.post(
+				'/wpcom/v2/reader/mastodon/connections/7/statuses',
+				( body ) =>
+					body.status === 'commentary\n\nhttps://mastodon.social/@alice/116522382646486388'
+			)
+			.reply( 401, { error: 'not_authenticated' } );
+
+		const mutation = createMastodonPostMutation( makeQueryClient() );
+		await expect(
+			mutation.mutationFn?.( {
+				connectionId: 7,
+				status: 'commentary',
+				quoted_status_id: '116522382646486388',
+				quotedFallbackPermalink: 'https://mastodon.social/@alice/116522382646486388',
+			} )
+		).rejects.toMatchObject( { kind: 'auth_required' } );
+	} );
+
+	it( 'invokes onQuoteFallbackFailed exactly once when the retry fails', async () => {
+		nock( BASE )
+			.post( '/wpcom/v2/reader/mastodon/connections/7/statuses', {
+				status: 'commentary',
+				quoted_status_id: '116522382646486388',
+			} )
+			.reply( 400, { error: 'reader_mastodon_bad_request' } );
+		nock( BASE )
+			.post(
+				'/wpcom/v2/reader/mastodon/connections/7/statuses',
+				( body ) =>
+					body.status === 'commentary\n\nhttps://mastodon.social/@alice/116522382646486388'
+			)
+			.reply( 400, { error: 'reader_mastodon_bad_request' } );
+
+		const onQuoteFallback = jest.fn();
+		const onQuoteFallbackFailed = jest.fn();
+		const mutation = createMastodonPostMutation( makeQueryClient(), {
+			onQuoteFallback,
+			onQuoteFallbackFailed,
+		} );
+		await expect(
+			mutation.mutationFn?.( {
+				connectionId: 7,
+				status: 'commentary',
+				quoted_status_id: '116522382646486388',
+				quotedFallbackPermalink: 'https://mastodon.social/@alice/116522382646486388',
+			} )
+		).rejects.toMatchObject( { kind: 'bad_request' } );
+
+		expect( onQuoteFallback ).toHaveBeenCalledTimes( 1 );
+		expect( onQuoteFallbackFailed ).toHaveBeenCalledTimes( 1 );
+		expect( onQuoteFallbackFailed ).toHaveBeenCalledWith(
+			expect.objectContaining( { connectionId: 7 } ),
+			expect.objectContaining( { kind: 'bad_request' } ),
+			expect.objectContaining( { kind: 'bad_request' } )
+		);
+	} );
+
+	it( 'does not invoke onQuoteFallbackFailed when the retry succeeds', async () => {
+		nock( BASE )
+			.post( '/wpcom/v2/reader/mastodon/connections/7/statuses', {
+				status: 'commentary',
+				quoted_status_id: '116522382646486388',
+			} )
+			.reply( 400, { error: 'reader_mastodon_bad_request' } );
+		nock( BASE )
+			.post(
+				'/wpcom/v2/reader/mastodon/connections/7/statuses',
+				( body ) =>
+					body.status === 'commentary\n\nhttps://mastodon.social/@alice/116522382646486388'
+			)
+			.reply( 200, {
+				id: '999',
+				url: 'https://mastodon.social/@me/999',
+				in_reply_to_id: null,
+			} );
+
+		const onQuoteFallbackFailed = jest.fn();
+		const mutation = createMastodonPostMutation( makeQueryClient(), { onQuoteFallbackFailed } );
+		await mutation.mutationFn?.( {
+			connectionId: 7,
+			status: 'commentary',
+			quoted_status_id: '116522382646486388',
+			quotedFallbackPermalink: 'https://mastodon.social/@alice/116522382646486388',
+		} );
+
+		expect( onQuoteFallbackFailed ).not.toHaveBeenCalled();
+	} );
+
+	it( 'falls back to bare permalink when status is whitespace-only', async () => {
+		// `body.trimEnd()` empties whitespace-only input, so the fallback
+		// emits the bare permalink (no leading blank line). Pin this in
+		// case anyone changes the truthy check to `body.length > 0`.
+		nock( BASE )
+			.post( '/wpcom/v2/reader/mastodon/connections/7/statuses', {
+				status: '   ',
+				quoted_status_id: '116522382646486388',
+			} )
+			.reply( 400, { error: 'reader_mastodon_bad_request' } );
+		const fallback = nock( BASE )
+			.post(
+				'/wpcom/v2/reader/mastodon/connections/7/statuses',
+				( body ) =>
+					body.status === 'https://mastodon.social/@alice/116522382646486388' &&
+					! ( 'quoted_status_id' in body )
+			)
+			.reply( 200, {
+				id: '999',
+				url: 'https://mastodon.social/@me/999',
+				in_reply_to_id: null,
+			} );
+
+		const mutation = createMastodonPostMutation( makeQueryClient() );
+		await mutation.mutationFn?.( {
+			connectionId: 7,
+			status: '   ',
+			quoted_status_id: '116522382646486388',
+			quotedFallbackPermalink: 'https://mastodon.social/@alice/116522382646486388',
+		} );
+
+		expect( fallback.isDone() ).toBe( true );
+	} );
+
+	it( 'does not retry when quotedFallbackPermalink is explicitly undefined', async () => {
+		// `buildParams` for the quote arm emits
+		// `quotedFallbackPermalink: undefined` when the preview lacks a
+		// permalink. The wrapper must treat that the same as "field
+		// absent" and propagate the original bad_request unchanged.
+		nock( BASE )
+			.post( '/wpcom/v2/reader/mastodon/connections/7/statuses', {
+				status: 'commentary',
+				quoted_status_id: '116522382646486388',
+			} )
+			.reply( 400, { error: 'reader_mastodon_bad_request' } );
+
+		const mutation = createMastodonPostMutation( makeQueryClient() );
+		await expect(
+			mutation.mutationFn?.( {
+				connectionId: 7,
+				status: 'commentary',
+				quoted_status_id: '116522382646486388',
+				quotedFallbackPermalink: undefined,
+			} )
+		).rejects.toMatchObject( { kind: 'bad_request' } );
+	} );
+
+	it( 'still completes the retry when onQuoteFallback throws', async () => {
+		nock( BASE )
+			.post( '/wpcom/v2/reader/mastodon/connections/7/statuses', {
+				status: 'commentary',
+				quoted_status_id: '116522382646486388',
+			} )
+			.reply( 400, { error: 'reader_mastodon_bad_request' } );
+		const fallback = nock( BASE )
+			.post(
+				'/wpcom/v2/reader/mastodon/connections/7/statuses',
+				( body ) =>
+					body.status === 'commentary\n\nhttps://mastodon.social/@alice/116522382646486388'
+			)
+			.reply( 200, {
+				id: '999',
+				url: 'https://mastodon.social/@me/999',
+				in_reply_to_id: null,
+			} );
+
+		const onQuoteFallback = jest.fn( () => {
+			throw new Error( 'observability blew up' );
+		} );
+		const mutation = createMastodonPostMutation( makeQueryClient(), { onQuoteFallback } );
+		const result = await mutation.mutationFn?.( {
+			connectionId: 7,
+			status: 'commentary',
+			quoted_status_id: '116522382646486388',
+			quotedFallbackPermalink: 'https://mastodon.social/@alice/116522382646486388',
+		} );
+
+		expect( onQuoteFallback ).toHaveBeenCalledTimes( 1 );
+		expect( fallback.isDone() ).toBe( true );
+		expect( result?.id ).toBe( '999' );
+	} );
 } );

--- a/client/reader/mastodon/test/quote-fallback.test.ts
+++ b/client/reader/mastodon/test/quote-fallback.test.ts
@@ -1,0 +1,189 @@
+import { createMastodonPostMutation } from '@automattic/api-queries';
+import { QueryClient } from '@tanstack/react-query';
+import nock from 'nock';
+
+const BASE = 'https://public-api.wordpress.com';
+
+function makeQueryClient() {
+	return new QueryClient( { defaultOptions: { mutations: { retry: false } } } );
+}
+
+describe( 'createMastodonPostMutation — quote fallback', () => {
+	afterEach( () => nock.cleanAll() );
+
+	it( 'submits quoted_status_id natively on the first attempt and resolves', async () => {
+		const scope = nock( BASE )
+			.post( '/wpcom/v2/reader/mastodon/connections/7/statuses', {
+				status: 'commentary',
+				quoted_status_id: '116522382646486388',
+			} )
+			.reply( 200, {
+				id: '999',
+				url: 'https://mastodon.social/@me/999',
+				in_reply_to_id: null,
+			} );
+
+		const mutation = createMastodonPostMutation( makeQueryClient() );
+		const result = await mutation.mutationFn?.( {
+			connectionId: 7,
+			status: 'commentary',
+			quoted_status_id: '116522382646486388',
+			quotedFallbackPermalink: 'https://mastodon.social/@alice/116522382646486388',
+		} );
+
+		expect( result?.id ).toBe( '999' );
+		expect( scope.isDone() ).toBe( true );
+	} );
+
+	it( 'falls back to text-based quoting when the native attempt returns bad_request', async () => {
+		const native = nock( BASE )
+			.post( '/wpcom/v2/reader/mastodon/connections/7/statuses', {
+				status: 'commentary',
+				quoted_status_id: '116522382646486388',
+			} )
+			.reply( 400, {
+				error: 'reader_mastodon_bad_request',
+				message: 'quoting unsupported',
+			} );
+		// Retry: quoted_status_id removed, permalink appended to status with
+		// a blank-line separator. The wire body must NOT carry the
+		// client-only quotedFallbackPermalink hint.
+		const fallback = nock( BASE )
+			.post( '/wpcom/v2/reader/mastodon/connections/7/statuses', ( body ) => {
+				return (
+					body.status === 'commentary\n\nhttps://mastodon.social/@alice/116522382646486388' &&
+					! ( 'quoted_status_id' in body ) &&
+					! ( 'quotedFallbackPermalink' in body )
+				);
+			} )
+			.reply( 200, {
+				id: '999',
+				url: 'https://mastodon.social/@me/999',
+				in_reply_to_id: null,
+			} );
+
+		const mutation = createMastodonPostMutation( makeQueryClient() );
+		const result = await mutation.mutationFn?.( {
+			connectionId: 7,
+			status: 'commentary',
+			quoted_status_id: '116522382646486388',
+			quotedFallbackPermalink: 'https://mastodon.social/@alice/116522382646486388',
+		} );
+
+		expect( result?.id ).toBe( '999' );
+		expect( native.isDone() ).toBe( true );
+		expect( fallback.isDone() ).toBe( true );
+	} );
+
+	it( 'falls back to bare permalink when the user submitted empty commentary', async () => {
+		nock( BASE )
+			.post( '/wpcom/v2/reader/mastodon/connections/7/statuses', {
+				status: '',
+				quoted_status_id: '116522382646486388',
+			} )
+			.reply( 400, { error: 'reader_mastodon_bad_request' } );
+		const fallback = nock( BASE )
+			.post(
+				'/wpcom/v2/reader/mastodon/connections/7/statuses',
+				( body ) => body.status === 'https://mastodon.social/@alice/116522382646486388'
+			)
+			.reply( 200, {
+				id: '999',
+				url: 'https://mastodon.social/@me/999',
+				in_reply_to_id: null,
+			} );
+
+		const mutation = createMastodonPostMutation( makeQueryClient() );
+		await mutation.mutationFn?.( {
+			connectionId: 7,
+			status: '',
+			quoted_status_id: '116522382646486388',
+			quotedFallbackPermalink: 'https://mastodon.social/@alice/116522382646486388',
+		} );
+
+		expect( fallback.isDone() ).toBe( true );
+	} );
+
+	it( 'does not retry when the bad_request comes from a non-quote attempt', async () => {
+		nock( BASE )
+			.post( '/wpcom/v2/reader/mastodon/connections/7/statuses', { status: 'plain' } )
+			.reply( 400, { error: 'reader_mastodon_bad_request' } );
+
+		const mutation = createMastodonPostMutation( makeQueryClient() );
+		await expect(
+			mutation.mutationFn?.( { connectionId: 7, status: 'plain' } )
+		).rejects.toMatchObject( { kind: 'bad_request' } );
+	} );
+
+	it( 'does not retry when the quote attempt has no quotedFallbackPermalink', async () => {
+		nock( BASE )
+			.post( '/wpcom/v2/reader/mastodon/connections/7/statuses', {
+				status: 'commentary',
+				quoted_status_id: '116522382646486388',
+			} )
+			.reply( 400, { error: 'reader_mastodon_bad_request' } );
+
+		const mutation = createMastodonPostMutation( makeQueryClient() );
+		await expect(
+			mutation.mutationFn?.( {
+				connectionId: 7,
+				status: 'commentary',
+				quoted_status_id: '116522382646486388',
+			} )
+		).rejects.toMatchObject( { kind: 'bad_request' } );
+	} );
+
+	it( 'preserves in_reply_to_id on the retry path when a quote-reply combo falls back', async () => {
+		// The composer config doesn't combine reply + quote today, but the
+		// type allows it and `...rest` must propagate `in_reply_to_id`. If
+		// this test ever fails, the wrapper has dropped a wire field on the
+		// fallback path.
+		nock( BASE )
+			.post( '/wpcom/v2/reader/mastodon/connections/7/statuses', {
+				status: 'commentary',
+				quoted_status_id: '116522382646486388',
+				in_reply_to_id: '108020',
+			} )
+			.reply( 400, { error: 'reader_mastodon_bad_request' } );
+		const fallback = nock( BASE )
+			.post( '/wpcom/v2/reader/mastodon/connections/7/statuses', ( body ) => {
+				return (
+					body.status === 'commentary\n\nhttps://mastodon.social/@alice/116522382646486388' &&
+					body.in_reply_to_id === '108020' &&
+					! ( 'quoted_status_id' in body )
+				);
+			} )
+			.reply( 200, {
+				id: '999',
+				url: 'https://mastodon.social/@me/999',
+				in_reply_to_id: '108020',
+			} );
+
+		const mutation = createMastodonPostMutation( makeQueryClient() );
+		await mutation.mutationFn?.( {
+			connectionId: 7,
+			status: 'commentary',
+			in_reply_to_id: '108020',
+			quoted_status_id: '116522382646486388',
+			quotedFallbackPermalink: 'https://mastodon.social/@alice/116522382646486388',
+		} );
+
+		expect( fallback.isDone() ).toBe( true );
+	} );
+
+	it( 'propagates non-bad_request errors without falling back', async () => {
+		nock( BASE )
+			.post( '/wpcom/v2/reader/mastodon/connections/7/statuses' )
+			.reply( 401, { error: 'not_authenticated' } );
+
+		const mutation = createMastodonPostMutation( makeQueryClient() );
+		await expect(
+			mutation.mutationFn?.( {
+				connectionId: 7,
+				status: 'commentary',
+				quoted_status_id: '116522382646486388',
+				quotedFallbackPermalink: 'https://mastodon.social/@alice/116522382646486388',
+			} )
+		).rejects.toMatchObject( { kind: 'auth_required' } );
+	} );
+} );

--- a/client/reader/mastodon/test/use-mastodon-repost-action.test.tsx
+++ b/client/reader/mastodon/test/use-mastodon-repost-action.test.tsx
@@ -219,4 +219,69 @@ describe( 'makeUseMastodonRepostAction', () => {
 		const button = screen.getByRole( 'button', { name: /boost, 5 boosts/i } );
 		expect( button ).toBeVisible();
 	} );
+
+	it( '"Quote post" menu item is disabled when no onQuoteClick is wired', async () => {
+		const user = userEvent.setup();
+		renderRepostButton();
+		await user.click( screen.getByRole( 'button', { name: /boost, 5 boosts/i } ) );
+		const item = await screen.findByRole( 'menuitem', { name: /quote post/i } );
+		expect( item ).toHaveAttribute( 'aria-disabled', 'true' );
+	} );
+
+	it( '"Quote post" menu item is enabled when onQuoteClick is provided', async () => {
+		const user = userEvent.setup();
+		const onQuoteClick = jest.fn();
+		const useMastodonRepostAction = makeUseMastodonRepostAction( CONNECTION_ID );
+		renderWithProvider(
+			<SocialAnalyticsProvider
+				value={ {
+					source: 'mastodon',
+					connectionId: CONNECTION_ID,
+					onClick: jest.fn(),
+					onQuoteClick,
+				} }
+			>
+				<RepostProvider value={ useMastodonRepostAction }>
+					<RepostButton post={ makePost() } />
+				</RepostProvider>
+			</SocialAnalyticsProvider>,
+			{ queryClient: makeQueryClient() }
+		);
+
+		await user.click( screen.getByRole( 'button', { name: /boost, 5 boosts/i } ) );
+		const item = await screen.findByRole( 'menuitem', { name: /quote post/i } );
+		expect( item ).not.toHaveAttribute( 'aria-disabled', 'true' );
+	} );
+
+	it( 'clicking "Quote post" calls onQuoteClick(post) and fires _quote_clicked Tracks', async () => {
+		const user = userEvent.setup();
+		const onQuoteClick = jest.fn();
+		const onClick = jest.fn();
+		const post = makePost();
+		const useMastodonRepostAction = makeUseMastodonRepostAction( CONNECTION_ID );
+		renderWithProvider(
+			<SocialAnalyticsProvider
+				value={ {
+					source: 'mastodon',
+					connectionId: CONNECTION_ID,
+					onClick,
+					onQuoteClick,
+				} }
+			>
+				<RepostProvider value={ useMastodonRepostAction }>
+					<RepostButton post={ post } />
+				</RepostProvider>
+			</SocialAnalyticsProvider>,
+			{ queryClient: makeQueryClient() }
+		);
+
+		await user.click( screen.getByRole( 'button', { name: /boost, 5 boosts/i } ) );
+		await user.click( await screen.findByRole( 'menuitem', { name: /quote post/i } ) );
+
+		expect( onQuoteClick ).toHaveBeenCalledWith( post );
+		expect( onClick ).toHaveBeenCalledWith(
+			'calypso_reader_mastodon_quote_clicked',
+			expect.objectContaining( { connection_id: CONNECTION_ID, post_uri: STATUS_ID } )
+		);
+	} );
 } );

--- a/client/reader/mastodon/thread-panel.tsx
+++ b/client/reader/mastodon/thread-panel.tsx
@@ -150,6 +150,19 @@ export function ThreadPanel( { connection, statusId }: ThreadPanelProps ) {
 		};
 	}, [ openComposer ] );
 
+	const onQuoteClick = useMemo( () => {
+		if ( ! openComposer ) {
+			return undefined;
+		}
+		return ( post: SocialPost ) => {
+			openComposer( {
+				kind: 'quote',
+				quote: { uri: post.uri },
+				previewPost: post,
+			} );
+		};
+	}, [ openComposer ] );
+
 	const analyticsValue = useMemo(
 		() => ( {
 			source: 'mastodon' as const,
@@ -159,8 +172,17 @@ export function ThreadPanel( { connection, statusId }: ThreadPanelProps ) {
 			getProfileUrl: buildProfileUrl,
 			getTagUrl: buildTagUrl,
 			onReplyClick,
+			onQuoteClick,
 		} ),
-		[ connection.id, onClickAnalytics, getThreadUrl, buildProfileUrl, buildTagUrl, onReplyClick ]
+		[
+			connection.id,
+			onClickAnalytics,
+			getThreadUrl,
+			buildProfileUrl,
+			buildTagUrl,
+			onReplyClick,
+			onQuoteClick,
+		]
 	);
 
 	const useLikeAction = useMemo(

--- a/client/reader/mastodon/timeline-panel.tsx
+++ b/client/reader/mastodon/timeline-panel.tsx
@@ -141,6 +141,19 @@ export function TimelinePanel( { connection }: TimelinePanelProps ) {
 		};
 	}, [ openComposer ] );
 
+	const onQuoteClick = useMemo( () => {
+		if ( ! openComposer ) {
+			return undefined;
+		}
+		return ( post: SocialPost ) => {
+			openComposer( {
+				kind: 'quote',
+				quote: { uri: post.uri },
+				previewPost: post,
+			} );
+		};
+	}, [ openComposer ] );
+
 	const useLikeAction = useMemo(
 		() => makeUseMastodonLikeAction( connection.id ),
 		[ connection.id ]
@@ -163,8 +176,17 @@ export function TimelinePanel( { connection }: TimelinePanelProps ) {
 			getProfileUrl: buildProfileUrl,
 			getTagUrl: buildTagUrl,
 			onReplyClick,
+			onQuoteClick,
 		} ),
-		[ connection.id, onClickAnalytics, getThreadUrl, buildProfileUrl, buildTagUrl, onReplyClick ]
+		[
+			connection.id,
+			onClickAnalytics,
+			getThreadUrl,
+			buildProfileUrl,
+			buildTagUrl,
+			onReplyClick,
+			onQuoteClick,
+		]
 	);
 
 	const useRepostAction = useMemo(

--- a/client/reader/mastodon/use-mastodon-repost-action.ts
+++ b/client/reader/mastodon/use-mastodon-repost-action.ts
@@ -61,9 +61,10 @@ function errorMessageForBoost(
  * useCreateMastodonRepostMutation etc.), so it must only be called
  * inside a React component.
  *
- * Note: Mastodon has no native quote-post feature. `canQuote` is always
- * false and `quote()` is a no-op. Slice-7d may revisit if quote support
- * ships upstream.
+ * Mastodon has no native quote-post API; `quote()` implements it as a
+ * text post that appends the original's permalink (see `buildParamsForMode`
+ * in composer-config.tsx). `canQuote` is true when the composer is mounted
+ * upstream (signalled by `analytics.onQuoteClick` being set).
  */
 export function makeUseMastodonRepostAction( connectionId: number ): UseRepostActionFn {
 	return function useMastodonRepostAction( post: SocialPost ): RepostAction {
@@ -117,8 +118,17 @@ export function makeUseMastodonRepostAction( connectionId: number ): UseRepostAc
 			remove.mutate( { statusId: post.uri }, { onError: ( err ) => trackError( err, 'unboost' ) } );
 		};
 
+		const onQuoteClick = analytics?.onQuoteClick;
+
 		const quote = () => {
-			// Mastodon has no native quote-post — slice-7d follow-up if it ever ships.
+			if ( ! onQuoteClick ) {
+				return;
+			}
+			analytics?.onClick( `calypso_reader_${ analytics.source }_quote_clicked`, {
+				connection_id: connectionId,
+				post_uri: post.uri,
+			} );
+			onQuoteClick( post );
 		};
 
 		const accessibleLabel = ( count: number, reposted: boolean ) => {
@@ -144,7 +154,7 @@ export function makeUseMastodonRepostAction( connectionId: number ): UseRepostAc
 				action: translate( 'Boost' ),
 				accessibleLabel,
 			},
-			canQuote: false,
+			canQuote: Boolean( onQuoteClick ),
 			repost,
 			unrepost,
 			quote,

--- a/client/reader/social/AGENTS.md
+++ b/client/reader/social/AGENTS.md
@@ -353,11 +353,20 @@ Two render branches by viewer state:
   toggle is the same shape of button (`aria-haspopup="menu"`). The menu
   has two `<MenuItem>`s: the action item (label provided by the adapter
   — "Repost" for ATmosphere, "Boost" for Mastodon) and "Quote post"
-  (disabled when `action.canQuote === false`). ATmosphere reports
-  `canQuote: true` when the panel has wired `onQuoteClick` on the
-  analytics context AND the post carries a `cid`; clicking the item
-  opens the same composer as the standalone `<QuoteButton>`. Mastodon
-  has no native quote concept and reports `canQuote: false` always.
+  (disabled when `action.canQuote === false`). ATmosphere sets
+  `canQuote: Boolean(analytics.onQuoteClick && post.cid)` — both
+  composer-presence and the AT-Proto strong-ref check are required;
+  clicking the item opens the same composer as the standalone
+  `<QuoteButton>`. Mastodon sets
+  `canQuote: Boolean(analytics.onQuoteClick)` — no `cid` requirement
+  since Mastodon's quote contract uses a numeric status id. Mastodon
+  4.5+ supports native quote posts via `quoted_status_id`;
+  `buildParams` for `kind: 'quote'` sets that field plus a
+  client-only `quotedFallbackPermalink` hint. The mutation wraps the
+  fetcher with a `bad_request` retry: when the upstream rejects the
+  quote (instance < 4.5 or quoting disabled, surfaced as 400) it omits
+  `quoted_status_id` and appends the permalink to `status` (separated
+  by a blank line) before retrying once.
 
 Each protocol shell wires its own adapter hook factory:
 
@@ -378,7 +387,10 @@ Each protocol shell wires its own adapter hook factory:
   uses `post.uri` (the status_id) for the delete call, and emits the
   UK-spelled labels "Boost" / "Boost, %d boost(s)" / "Undo boost, %d
   boost(s)". Tracks events: `_boost_clicked`, `_unboost_clicked`,
-  `_boost_error_shown`.
+  `_boost_error_shown`, `_quote_clicked`. `canQuote` is true when
+  `analytics.onQuoteClick` is set; the quote contract (native 4.5+
+  with `bad_request` text-fallback) is described in the `canQuote`
+  paragraph above and implemented in `createMastodonPostMutation`.
 
 Both mutation hooks optimistically patch every cached query under their
 protocol's `readerXxxKeys.all` (timeline / author-feed / tag-feed pages

--- a/client/reader/social/author-profile-panel.tsx
+++ b/client/reader/social/author-profile-panel.tsx
@@ -96,6 +96,13 @@ export interface SocialAuthorProfilePanelProps<
 	// back to the anchor's external href.
 	buildTagUrl?: ( tag: string ) => string | null;
 
+	// Composer action handlers forwarded to the analytics context so the
+	// reply / quote buttons on post-cards work from within the profile feed.
+	// Both are optional — surfaces without a mounted composer omit them and
+	// the buttons stay in their static (unsupported) state.
+	onReplyClick?: ( post: SocialPost ) => void;
+	onQuoteClick?: ( post: SocialPost ) => void;
+
 	// Empty / error vocabulary for the SocialFeedList. Wrappers compute
 	// these (e.g. Mastodon swaps in a locked-account variant when the
 	// profile is locked and the feed is empty).
@@ -140,6 +147,8 @@ export function SocialAuthorProfilePanel< TProfile, TError extends ProtocolError
 	buildProfileUrl,
 	buildThreadUrl,
 	buildTagUrl,
+	onReplyClick,
+	onQuoteClick,
 	emptyTitle,
 	emptyLine,
 	emptyActionLabel,
@@ -305,8 +314,19 @@ export function SocialAuthorProfilePanel< TProfile, TError extends ProtocolError
 			getThreadUrl: buildThreadUrl,
 			getProfileUrl: buildProfileUrl,
 			getTagUrl: buildTagUrl,
+			onReplyClick,
+			onQuoteClick,
 		} ),
-		[ source, connectionId, onClickAnalytics, buildThreadUrl, buildProfileUrl, buildTagUrl ]
+		[
+			source,
+			connectionId,
+			onClickAnalytics,
+			buildThreadUrl,
+			buildProfileUrl,
+			buildTagUrl,
+			onReplyClick,
+			onQuoteClick,
+		]
 	);
 
 	const renderHeader = () => {

--- a/client/reader/social/composer/composer-provider.tsx
+++ b/client/reader/social/composer/composer-provider.tsx
@@ -60,6 +60,7 @@ export interface ComposerParentRef {
 export interface PreviewPost {
 	uri: string;
 	cid?: string;
+	permalink?: string;
 	text: string;
 	html: string;
 	author: {

--- a/packages/api-core/src/reader-mastodon/__tests__/fetchers.test.ts
+++ b/packages/api-core/src/reader-mastodon/__tests__/fetchers.test.ts
@@ -482,6 +482,47 @@ describe( 'createMastodonPost', () => {
 		expect( scope.isDone() ).toBe( true );
 	} );
 
+	it( 'POSTs status + quoted_status_id when quoting', async () => {
+		const scope = nock( BASE )
+			.post( '/wpcom/v2/reader/mastodon/connections/7/statuses', {
+				status: 'commentary',
+				quoted_status_id: '116522382646486388',
+			} )
+			.reply( 200, {
+				id: '999',
+				url: 'https://mastodon.social/@me/999',
+				in_reply_to_id: null,
+			} );
+		const result = await createMastodonPost( {
+			connectionId: 7,
+			status: 'commentary',
+			quoted_status_id: '116522382646486388',
+		} );
+		expect( result.id ).toBe( '999' );
+		expect( scope.isDone() ).toBe( true );
+	} );
+
+	it( 'strips the client-only quotedFallbackPermalink before sending', async () => {
+		// The body matcher below would fail if the fetcher leaked
+		// `quotedFallbackPermalink` into the wire payload.
+		const scope = nock( BASE )
+			.post( '/wpcom/v2/reader/mastodon/connections/7/statuses', ( body ) => {
+				return (
+					body.status === 'commentary' &&
+					body.quoted_status_id === '116522382646486388' &&
+					! ( 'quotedFallbackPermalink' in body )
+				);
+			} )
+			.reply( 200, { id: '999', url: 'https://mastodon.social/@me/999', in_reply_to_id: null } );
+		await createMastodonPost( {
+			connectionId: 7,
+			status: 'commentary',
+			quoted_status_id: '116522382646486388',
+			quotedFallbackPermalink: 'https://mastodon.social/@alice/116522382646486388',
+		} );
+		expect( scope.isDone() ).toBe( true );
+	} );
+
 	it( 'classifies a 401 as auth_required', async () => {
 		nock( BASE )
 			.post( '/wpcom/v2/reader/mastodon/connections/7/statuses', { status: 'hello' } )

--- a/packages/api-core/src/reader-mastodon/fetchers.ts
+++ b/packages/api-core/src/reader-mastodon/fetchers.ts
@@ -302,10 +302,13 @@ export async function deleteMastodonRepost( params: MastodonDeleteRepostParams )
 export async function createMastodonPost(
 	params: MastodonCreatePostParams
 ): Promise< MastodonCreatePostResult > {
-	const { connectionId, status, in_reply_to_id } = params;
+	const { connectionId, status, in_reply_to_id, quoted_status_id } = params;
 	const body: Record< string, unknown > = { status };
 	if ( in_reply_to_id ) {
 		body.in_reply_to_id = in_reply_to_id;
+	}
+	if ( quoted_status_id ) {
+		body.quoted_status_id = quoted_status_id;
 	}
 	try {
 		return ( await wpcom.req.post( {

--- a/packages/api-core/src/reader-mastodon/types.ts
+++ b/packages/api-core/src/reader-mastodon/types.ts
@@ -246,10 +246,13 @@ export interface MastodonCreatePostParams {
 
 /**
  * Variables accepted by `createMastodonPostMutation`. Extends the wire
- * shape with one client-only hint that the mutation strips before the
- * wire call. The split exists so the wire type cannot accidentally leak
- * the hint into the request body via a future spread refactor — the
- * fetcher's signature literally cannot accept it.
+ * shape with one client-only hint. Because this type is structurally
+ * assignable to `MastodonCreatePostParams`, the type system won't stop a
+ * future caller from forwarding the whole object into `createMastodonPost`
+ * and leaking the hint into the request body — the actual guard is the
+ * explicit destructure in `createMastodonPostWithQuoteFallback`
+ * (`const { quotedFallbackPermalink, ...wireParams } = params;`). Keep
+ * the split so the destructure point stays singular and obvious.
  */
 export interface MastodonCreatePostMutationParams extends MastodonCreatePostParams {
 	/**

--- a/packages/api-core/src/reader-mastodon/types.ts
+++ b/packages/api-core/src/reader-mastodon/types.ts
@@ -221,10 +221,45 @@ export interface MastodonDeleteRepostParams {
 	statusId: string;
 }
 
+/**
+ * Wire-pure shape passed to `createMastodonPost`. Every field here lands
+ * in the request body (or the path, in `connectionId`'s case). Do not
+ * widen this type with client-only metadata — see
+ * `MastodonCreatePostMutationParams` for fields the mutation layer needs
+ * but the wire does not.
+ */
 export interface MastodonCreatePostParams {
 	connectionId: number;
 	status: string;
 	in_reply_to_id?: string;
+	/**
+	 * Native Mastodon quote post (Mastodon 4.5+). Numeric status id of the
+	 * post being quoted. Older instances reject the call with HTTP 400
+	 * `reader_mastodon_bad_request` (mapped from upstream 422); the
+	 * `createMastodonPostMutation` falls back to text-based quoting in
+	 * that case (see `MastodonCreatePostMutationParams`). Do **not** also
+	 * append the URL to `status` — that would double-quote on instances
+	 * that support native quotes.
+	 */
+	quoted_status_id?: string;
+}
+
+/**
+ * Variables accepted by `createMastodonPostMutation`. Extends the wire
+ * shape with one client-only hint that the mutation strips before the
+ * wire call. The split exists so the wire type cannot accidentally leak
+ * the hint into the request body via a future spread refactor — the
+ * fetcher's signature literally cannot accept it.
+ */
+export interface MastodonCreatePostMutationParams extends MastodonCreatePostParams {
+	/**
+	 * Client-only fallback hint. When a quote attempt fails with
+	 * `bad_request`, the mutation retries once with `quoted_status_id`
+	 * removed and this permalink appended to `status` (separated by a
+	 * blank line). Never sent to the server — destructured off in
+	 * `createMastodonPostWithQuoteFallback` before any wire call.
+	 */
+	quotedFallbackPermalink?: string;
 }
 
 export interface MastodonCreatePostResult {

--- a/packages/api-queries/src/reader-mastodon.ts
+++ b/packages/api-queries/src/reader-mastodon.ts
@@ -726,6 +726,35 @@ function isBadRequestError( err: unknown ): boolean {
 }
 
 /**
+ * Optional hooks the caller can supply for cross-cutting concerns the
+ * api-queries package can't reach itself (logstash imports are
+ * lint-restricted from this package; observability lives in the
+ * per-protocol adapter under `client/reader/mastodon/`).
+ */
+export interface CreateMastodonPostHooks {
+	/**
+	 * Fires once per mutation, immediately before the text-quoting retry
+	 * is issued. Use it to log the downgrade so we can tell whether users
+	 * are landing on Mastodon < 4.5 / quote-disabled instances. Receives
+	 * the (unstripped) mutation params; the implementation is responsible
+	 * for redacting any user-typed `status` content before logging.
+	 */
+	onQuoteFallback?: ( params: MastodonCreatePostMutationParams ) => void;
+	/**
+	 * Fires once per mutation when the text-quoting retry itself fails.
+	 * Receives the original `bad_request` and the retry's error so the
+	 * caller can dashboard "fallback fired but didn't help" — the signal
+	 * the bare `onQuoteFallback` counter can't surface. Same redaction
+	 * rules as `onQuoteFallback`.
+	 */
+	onQuoteFallbackFailed?: (
+		params: MastodonCreatePostMutationParams,
+		originalError: MastodonError,
+		retryError: MastodonError
+	) => void;
+}
+
+/**
  * Calls `createMastodonPost` with the wire-shape params destructured off
  * the mutation-params input. If a native quote attempt (`quoted_status_id`
  * set) returns `bad_request`, retries once with `quoted_status_id` removed
@@ -746,9 +775,12 @@ function isBadRequestError( err: unknown ): boolean {
  * UX (the user sees the current state). The narrower fix is for the
  * backend to emit a quote-specific error code (e.g.
  * `reader_mastodon_quote_unsupported`); switch to that when it ships.
+ * The `onQuoteFallback` hook lets the caller observe how often this path
+ * fires so we can size that follow-up.
  */
 async function createMastodonPostWithQuoteFallback(
-	params: MastodonCreatePostMutationParams
+	params: MastodonCreatePostMutationParams,
+	hooks?: CreateMastodonPostHooks
 ): Promise< MastodonCreatePostResult > {
 	const { quotedFallbackPermalink, ...wireParams } = params;
 	try {
@@ -762,6 +794,16 @@ async function createMastodonPostWithQuoteFallback(
 			throw err;
 		}
 		// Narrowed: `quotedFallbackPermalink` is `string` from here on.
+		try {
+			hooks?.onQuoteFallback?.( params );
+		} catch ( hookErr ) {
+			// Observability must never break the retry path, but a hook
+			// that throws every call would silently kill all our fallback
+			// metrics. Surface it to the dev console so a broken logger is
+			// visible during local work.
+			// eslint-disable-next-line no-console
+			console.error( 'onQuoteFallback hook threw', hookErr );
+		}
 		const body = wireParams.status.trimEnd();
 		const fallbackStatus = body
 			? `${ body }\n\n${ quotedFallbackPermalink }`
@@ -769,7 +811,21 @@ async function createMastodonPostWithQuoteFallback(
 		// Strip `quoted_status_id` for the text-fallback retry; the rest of
 		// the wire shape (status, in_reply_to_id, connectionId) carries over.
 		const { quoted_status_id: _omit, ...rest } = wireParams;
-		return await createMastodonPost( { ...rest, status: fallbackStatus } );
+		try {
+			return await createMastodonPost( { ...rest, status: fallbackStatus } );
+		} catch ( retryErr ) {
+			// The retry failed too. Surface the second-attempt error to the
+			// caller (the user sees the current state — that's the right
+			// UX), but emit the failure for telemetry first so we can size
+			// "fallback fired but didn't help" separately from the trigger.
+			try {
+				hooks?.onQuoteFallbackFailed?.( params, err as MastodonError, retryErr as MastodonError );
+			} catch ( hookErr ) {
+				// eslint-disable-next-line no-console
+				console.error( 'onQuoteFallbackFailed hook threw', hookErr );
+			}
+			throw retryErr;
+		}
 	}
 }
 
@@ -789,14 +845,17 @@ async function createMastodonPostWithQuoteFallback(
  * from the singleton in `@automattic/api-queries`. See
  * `client/reader/AGENTS.md` for the rationale.
  */
-export const createMastodonPostMutation = ( queryClient: QueryClient ) =>
+export const createMastodonPostMutation = (
+	queryClient: QueryClient,
+	hooks?: CreateMastodonPostHooks
+) =>
 	mutationOptions<
 		MastodonCreatePostResult,
 		MastodonError,
 		MastodonCreatePostMutationParams,
 		CreatePostContext
 	>( {
-		mutationFn: createMastodonPostWithQuoteFallback,
+		mutationFn: ( vars ) => createMastodonPostWithQuoteFallback( vars, hooks ),
 		onMutate: async ( vars ) => {
 			// cancelQueries is best-effort — TanStack docs flag it as such.
 			// If it rejects (rare; route-change teardown races) we want to

--- a/packages/api-queries/src/reader-mastodon.ts
+++ b/packages/api-queries/src/reader-mastodon.ts
@@ -40,7 +40,7 @@ import type {
 	MastodonConnectionDetails,
 	MastodonConnectionsResponse,
 	MastodonCreateConnectionResponse,
-	MastodonCreatePostParams,
+	MastodonCreatePostMutationParams,
 	MastodonCreatePostResult,
 	MastodonError,
 	MastodonFeedItem,
@@ -721,6 +721,58 @@ interface CreatePostContext {
 	parentCountsContext?: OptimisticContext;
 }
 
+function isBadRequestError( err: unknown ): boolean {
+	return typeof err === 'object' && err !== null && 'kind' in err && err.kind === 'bad_request';
+}
+
+/**
+ * Calls `createMastodonPost` with the wire-shape params destructured off
+ * the mutation-params input. If a native quote attempt (`quoted_status_id`
+ * set) returns `bad_request`, retries once with `quoted_status_id` removed
+ * and `quotedFallbackPermalink` appended to `status` separated by a blank
+ * line. The fallback covers Mastodon < 4.5 (no native quote support,
+ * upstream returns 422 → `bad_request`) and instances that have quoting
+ * disabled.
+ *
+ * The retry is opt-in via `quotedFallbackPermalink` — when the panel didn't
+ * supply one (or there's no permalink to fall back to) the original
+ * `bad_request` is propagated unchanged.
+ *
+ * Trade-off: `bad_request` is the only signal we have today, but the
+ * backend returns it for *any* upstream 422 (malformed status, attachment
+ * errors, character-limit overflow, etc.). When a user's content is
+ * genuinely invalid, the retry sends the same body plus a permalink and
+ * usually fails again — surfacing the second-attempt error is the right
+ * UX (the user sees the current state). The narrower fix is for the
+ * backend to emit a quote-specific error code (e.g.
+ * `reader_mastodon_quote_unsupported`); switch to that when it ships.
+ */
+async function createMastodonPostWithQuoteFallback(
+	params: MastodonCreatePostMutationParams
+): Promise< MastodonCreatePostResult > {
+	const { quotedFallbackPermalink, ...wireParams } = params;
+	try {
+		return await createMastodonPost( wireParams );
+	} catch ( err ) {
+		if (
+			! isBadRequestError( err ) ||
+			! wireParams.quoted_status_id ||
+			! quotedFallbackPermalink
+		) {
+			throw err;
+		}
+		// Narrowed: `quotedFallbackPermalink` is `string` from here on.
+		const body = wireParams.status.trimEnd();
+		const fallbackStatus = body
+			? `${ body }\n\n${ quotedFallbackPermalink }`
+			: quotedFallbackPermalink;
+		// Strip `quoted_status_id` for the text-fallback retry; the rest of
+		// the wire shape (status, in_reply_to_id, connectionId) carries over.
+		const { quoted_status_id: _omit, ...rest } = wireParams;
+		return await createMastodonPost( { ...rest, status: fallbackStatus } );
+	}
+}
+
 /**
  * Wire-layer factory for creating a Mastodon status (reply or standalone post).
  *
@@ -741,10 +793,10 @@ export const createMastodonPostMutation = ( queryClient: QueryClient ) =>
 	mutationOptions<
 		MastodonCreatePostResult,
 		MastodonError,
-		MastodonCreatePostParams,
+		MastodonCreatePostMutationParams,
 		CreatePostContext
 	>( {
-		mutationFn: createMastodonPost,
+		mutationFn: createMastodonPostWithQuoteFallback,
 		onMutate: async ( vars ) => {
 			// cancelQueries is best-effort — TanStack docs flag it as such.
 			// If it rejects (rare; route-change teardown races) we want to


### PR DESCRIPTION
Part of CM-664

> **Base branch:** `cm-662-mastodon-slice-7c-frontend-reply-composer-calypso`. This slice builds on the composer infrastructure shipped in CM-662 (#110451). When CM-662 lands in trunk, this PR's base will rebase to trunk automatically.

## Proposed Changes

* Enables the "Quote post" menu item inside `<RepostButton>` for Mastodon posts. The menu item was always rendered but disabled (`canQuote: false`) since Mastodon has no native quote-post API.
* Quote is implemented as a plain Mastodon status: `buildParamsForMode` appends `\n\n<permalink>` to the composed text so the quoted post is reachable via the link. The composer shows the quoted post preview (same pinned-context UI as ATmosphere replies).
* `makeUseMastodonRepostAction`: `canQuote` is now `Boolean(analytics.onQuoteClick)`. No strong-ref `cid` required (Mastodon has no AT-Proto record). `quote()` fires a `_quote_clicked` Tracks event and delegates to `analytics.onQuoteClick(post)`.
* Timeline, thread, and author-profile panels each gain an `onQuoteClick` memo wired to `openComposer({ kind: 'quote', … })` — identical shape to the existing `onReplyClick`.
* `SocialAuthorProfilePanel` (shared): optional `onReplyClick` / `onQuoteClick` props forwarded to the analytics context so the profile feed's post cards can open the composer.
* `PreviewPost` in the shared composer provider gains `permalink?: string` so `buildParamsForMode` can access the quoted post's URL without casting.

## Why are these changes being made?

Slice 7d. The `kind: 'quote'` path through `ComposerProvider` / `ComposerModal` already shipped in CM-662 (the composer's `supportedModes` gate just blocked Mastodon from using it). This slice closes the loop on the Mastodon side.

## Testing Instructions

1. `yarn test-client client/reader/mastodon/test/use-mastodon-repost-action.test.tsx` — 11 tests, 3 new for slice 7d.
2. `yarn test-client client/reader/social` — 297 tests, all passing.
3. Bring up Calypso with a Mastodon connection (`/reader/mastodon/<id>`):
   * Click any post's Boost icon → dropdown shows "Boost" (enabled) and "Quote post" (now enabled, was disabled).
   * Click "Quote post" → composer opens in `kind: 'quote'` mode with the post pinned at top, title reads "Quote post", placeholder "What's on your mind?", limit 500.
   * Write text and publish → new Mastodon status is created with the quoted post's permalink appended.
   * Confirm `_quote_clicked` Tracks event fires on menu click and `_quote_composer_opened` fires on modal mount.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?