### PR TITLE
Dashboard: fix expired-domain UI inconsistencies

### DIFF
--- a/client/dashboard/domains/domain-overview/featured-card-renew.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-renew.tsx
@@ -22,19 +22,14 @@ export default function FeaturedCardRenew( { domain }: Props ) {
 	}
 
 	let intent: 'error' | 'success' | 'warning' | 'upsell' = 'warning';
+	let title = __( 'Expires' );
 
 	if ( domain.expired ) {
 		intent = 'error';
+		title = __( 'Expired' );
 	} else if ( domain.auto_renewing ) {
 		intent = 'success';
-	}
-
-	let title = __( 'Expires' );
-
-	if ( domain.auto_renewing ) {
 		title = __( 'Renews' );
-	} else if ( domain.expired ) {
-		title = __( 'Expired' );
 	}
 
 	const formattedDate = formatDate( new Date( date ), locale, {

--- a/client/dashboard/domains/domain-overview/featured-card-renew.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-renew.tsx
@@ -29,6 +29,14 @@ export default function FeaturedCardRenew( { domain }: Props ) {
 		intent = 'success';
 	}
 
+	let title = __( 'Expires' );
+
+	if ( domain.auto_renewing ) {
+		title = __( 'Renews' );
+	} else if ( domain.expired ) {
+		title = __( 'Expired' );
+	}
+
 	const formattedDate = formatDate( new Date( date ), locale, {
 		day: 'numeric',
 		month: 'long',
@@ -37,7 +45,7 @@ export default function FeaturedCardRenew( { domain }: Props ) {
 
 	return (
 		<OverviewCard
-			title={ domain.auto_renewing ? __( 'Renews' ) : __( 'Expires' ) }
+			title={ title }
 			heading={ formattedDate }
 			icon={ <Icon icon={ calendar } /> }
 			link={

--- a/client/dashboard/domains/domain-security/ssl-certificate.tsx
+++ b/client/dashboard/domains/domain-security/ssl-certificate.tsx
@@ -195,7 +195,10 @@ export default function SslCertificate( { domainName, domain, sslDetails }: SslC
 		if ( sslDetails.certificate_provisioned || domain.wpcom_domain ) {
 			return <Badge intent="success">{ __( 'SSL active' ) }</Badge>;
 		}
-		return <Badge intent="warning">{ __( 'SSL pending' ) }</Badge>;
+		if ( domain.ssl_status === 'newly_registered' || domain.ssl_status === 'pending' ) {
+			return <Badge intent="warning">{ __( 'SSL Pending' ) }</Badge>;
+		}
+		return <Badge intent="error">{ __( 'SSL Disabled' ) }</Badge>;
 	};
 
 	return (

--- a/client/dashboard/utils/domain.ts
+++ b/client/dashboard/utils/domain.ts
@@ -391,6 +391,7 @@ export function isPendingPrimaryDomain( domain: DomainSummary ): boolean {
 	return (
 		domain.subtype.id === DomainSubtype.DOMAIN_REGISTRATION &&
 		domain.can_set_as_primary &&
-		! domain.primary_domain
+		! domain.primary_domain &&
+		! domain.expired
 	);
 }


### PR DESCRIPTION
When a domain is expired we do show some confusing messaging - we were showing that the SSL certificate is being provisioned, that the domain "Expires" and inside the Security screen we were showing the SSL Status as pending. Here's a fix for those

## Screenshots

| Before | After |
| -- | -- |
| <img width="711" height="772" alt="Screenshot 2026-05-05 at 17 50 34" src="https://github.com/user-attachments/assets/c0df3cd6-b65b-4711-8b22-74e5e4713680" /> | <img width="696" height="640" alt="Screenshot 2026-05-05 at 17 48 15" src="https://github.com/user-attachments/assets/e4e421ad-d67a-4057-aaa2-d5c72fe1f927" /> |

## Proposed Changes

* `client/dashboard/domains/domain-overview/featured-card-renew.tsx` — the renewal FeaturedCard now reads **"Expired"** (with the existing red intent) when `domain.expired` is true, instead of always showing **"Expires"**. Auto-renewing domains still show "Renews".
* `client/dashboard/utils/domain.ts` — `isPendingPrimaryDomain()` now also requires `! domain.expired`, so the **"Setting up your custom domain"** notice (and its 5-second polling) is suppressed for expired registrations that are no longer resolving to WordPress.com.
* `client/dashboard/domains/domain-security/ssl-certificate.tsx` — `renderBadge()` now mirrors the tri-state classification used by the Domain security summary row: "SSL active" / "SSL Pending" / "SSL Disabled". The labels match `domains/domain-security/summary.tsx` exactly so existing translations are reused.

## Why are these changes being made?

When a registered domain has expired, three places in the new Dashboard show stale or contradictory state:

1. The renewal FeaturedCard renders **"Expires"** even after the expiry date has passed. The card already flips to a red "error" intent for expired domains, but the title never matched.
2. The **"Setting up your custom domain"** info notice still appears on the overview, even though the domain is no longer resolving to WordPress.com — making the message misleading for users who actually need to renew.
3. The Domain security summary row badge correctly shows **"SSL Disabled"**, but clicking through to the Domain security page shows **"SSL pending"**. The two surfaces read different fields (`domain.ssl_status` vs `sslDetails.certificate_provisioned`) and never agreed for the inactive/expired case.

These are small bugs individually, but together they make an expired domain look like it is mid-setup. The fix uses the data the domain object already carries (`expired`, `ssl_status`) and aligns the SSL badge logic with the summary row so the menu and the page can't drift apart.

## Testing Instructions

1. Run the Dashboard locally:
   ```bash
   yarn start-dashboard
   ```
2. Navigate to `/domains/<expired-domain>/` for a domain that has already expired (`expired: true`, `auto_renewing: false`):
    - The renewal FeaturedCard title should read **"Expired"** with the red intent.
    - The **"Setting up your custom domain"** notice should **not** be rendered.
    - The Domain security row badge should read **"SSL Disabled"**.
    - Click into Domain security; the badge at the top of the SSL certificate card should also read **"SSL Disabled"**, and the body copy should say "Your domain has expired. Renew your domain to issue a new SSL certificate."
3. Regression checks:
    - A healthy auto-renewing domain still shows the **"Renews"** card with success intent and an **"SSL active"** badge on both surfaces.
    - A domain not auto-renewing but not yet expired still shows **"Expires"** with the warning intent.
    - A freshly registered domain still propagating still shows the **"Setting up your custom domain"** notice and the **"SSL Pending"** badge on both surfaces.

Pre-PR checks run locally:

```
yarn eslint client/dashboard/domains/domain-overview/featured-card-renew.tsx \
            client/dashboard/utils/domain.ts \
            client/dashboard/domains/domain-security/ssl-certificate.tsx
yarn typecheck-client
```

Lint is clean and the touched files type-check cleanly (the only `tsc` errors reported on `trunk` are pre-existing `@automattic/omnibar` module-resolution errors, unrelated to this branch).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?