### PR TITLE
[Take 2] Onboarding: header refinements + Plans back-nav + domain copy

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -319,7 +319,17 @@ const onboarding: FlowV2< typeof initialize > = {
 					return;
 			}
 		};
-		return { submit };
+
+		const goBack = () => {
+			switch ( currentStepSlug ) {
+				case 'plans':
+					return navigate( 'domains' );
+				default:
+					return window.history.back();
+			}
+		};
+
+		return { submit, goBack };
 	},
 	useSideEffect( currentStepSlug ) {
 		const reduxDispatch = useReduxDispatch();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -441,7 +441,7 @@ const DomainSearchStep: StepType< {
 				<>
 					{ config.allowsUsingOwnDomain && (
 						<Step.LinkButton onClick={ () => events.onExternalDomainClick( query ) }>
-							{ __( 'Use a domain I already own' ) }
+							{ __( 'Use a domain I own' ) }
 						</Step.LinkButton>
 					) }
 				</>
@@ -500,7 +500,7 @@ const DomainSearchStep: StepType< {
 				onClick={ () => events.onExternalDomainClick( query ) }
 				variant="link"
 			>
-				<span>{ __( 'Use a domain I already own' ) }</span>
+				<span>{ __( 'Use a domain I own' ) }</span>
 			</Button>
 		);
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -36,7 +36,7 @@ import {
 	domainMapping,
 } from 'calypso/my-sites/domains/paths';
 import { siteHasPaidPlan } from 'calypso/signup/steps/site-picker/site-picker-submit';
-import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
+import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors';
 import { useQuery } from '../../../../hooks/use-query';
 import { useSite } from '../../../../hooks/use-site';
@@ -77,6 +77,7 @@ const DomainSearchStep: StepType< {
 	submits: UseMyDomain | StepSubmission;
 } > = function DomainSearchStep( { navigation, flow } ) {
 	const userSiteCount = useSelector( getCurrentUserSiteCount );
+	const isLoggedIn = useSelector( isUserLoggedIn );
 	const dashboardOptIn = useSelector( hasDashboardOptIn );
 	const site = useSite();
 	const siteSlug = useSiteSlugParam();
@@ -413,8 +414,11 @@ const DomainSearchStep: StepType< {
 					backDestination = navigation.goBack;
 					backLabelText = __( 'Back' );
 				} else {
+					if ( ! isLoggedIn || ! userSiteCount ) {
+						return;
+					}
 					backDestination = defaultBackUrl;
-					backLabelText = sitesBackLabelText;
+					backLabelText = __( 'Back' );
 				}
 			}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -644,10 +644,6 @@ function UnifiedPlansStep( {
 
 	if ( useStepContainerV2 && wrapperProps ) {
 		const goBack = wrapperProps.hideBack ? undefined : wrapperProps.goBack;
-		const handleOnboardingBack = () => {
-			window.location.href = getStepUrl( 'onboarding', 'domains' );
-		};
-		const backClick = isOnboardingFlow( flowName ) ? handleOnboardingBack : goBack;
 
 		return (
 			<>
@@ -657,8 +653,8 @@ function UnifiedPlansStep( {
 					topBar={
 						<Step.TopBar
 							leftElement={
-								backClick ? (
-									<Step.BackButton onClick={ backClick }>{ backLabelText }</Step.BackButton>
+								goBack ? (
+									<Step.BackButton onClick={ goBack }>{ backLabelText }</Step.BackButton>
 								) : undefined
 							}
 							rightElement={

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -645,7 +645,7 @@ function UnifiedPlansStep( {
 	if ( useStepContainerV2 && wrapperProps ) {
 		const goBack = wrapperProps.hideBack ? undefined : wrapperProps.goBack;
 		const handleOnboardingBack = () => {
-			window.location.href = '/setup/onboarding/domains';
+			window.location.href = getStepUrl( 'onboarding', 'domains' );
 		};
 		const backClick = isOnboardingFlow( flowName ) ? handleOnboardingBack : goBack;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -6,11 +6,12 @@ import {
 	PLAN_WOO_HOSTED_FREE_TRIAL_MONTHLY,
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
-import { Plans } from '@automattic/data-stores';
+import { HelpCenter, HelpCenterSelect, Plans } from '@automattic/data-stores';
 import { FREE_THEME } from '@automattic/design-picker';
 import {
 	DOMAIN_FLOW,
 	isNewHostedSiteCreationFlow,
+	isOnboardingFlow,
 	isTailoredSignupFlow,
 	ONBOARDING_FLOW,
 	Step,
@@ -202,6 +203,8 @@ export interface UnifiedPlansStepProps {
 	isStepperUpgradeFlow?: boolean;
 }
 
+const HELP_CENTER_STORE = HelpCenter.register();
+
 /**
  * This is a "unified" plans step component that is utilised by both Start (old framework) and Stepper (new framework).
  * It contains the latest logic/conditioning, properties, etc. that apply to the latest main iterations of the plans step.
@@ -257,6 +260,13 @@ function UnifiedPlansStep( {
 	const dispatch = reduxUseDispatch();
 	const translate = useTranslate();
 	const dashboardOptIn = useSelector( hasDashboardOptIn );
+
+	const { setShowHelpCenter } = useDispatch( HELP_CENTER_STORE );
+	const isHelpCenterShown = useSelect(
+		( select ) => ( select( HELP_CENTER_STORE ) as HelpCenterSelect ).isHelpCenterShown(),
+		[]
+	);
+	const toggleHelpCenter = () => setShowHelpCenter( ! isHelpCenterShown );
 	const initializedSitesBackUrl = useSelector( ( state ) => {
 		if ( getCurrentUserSiteCount( state ) ) {
 			return null;
@@ -634,6 +644,10 @@ function UnifiedPlansStep( {
 
 	if ( useStepContainerV2 && wrapperProps ) {
 		const goBack = wrapperProps.hideBack ? undefined : wrapperProps.goBack;
+		const handleOnboardingBack = () => {
+			window.location.href = '/setup/onboarding/domains';
+		};
+		const backClick = isOnboardingFlow( flowName ) ? handleOnboardingBack : goBack;
 
 		return (
 			<>
@@ -643,8 +657,15 @@ function UnifiedPlansStep( {
 					topBar={
 						<Step.TopBar
 							leftElement={
-								goBack ? (
-									<Step.BackButton onClick={ goBack }>{ backLabelText }</Step.BackButton>
+								backClick ? (
+									<Step.BackButton onClick={ backClick }>{ backLabelText }</Step.BackButton>
+								) : undefined
+							}
+							rightElement={
+								isOnboardingFlow( flowName ) ? (
+									<Step.LinkButton onClick={ toggleHelpCenter }>
+										{ translate( 'Need help?' ) }
+									</Step.LinkButton>
 								) : undefined
 							}
 						/>

--- a/packages/onboarding/src/step-container-v2/components/TopBar/TopBar.tsx
+++ b/packages/onboarding/src/step-container-v2/components/TopBar/TopBar.tsx
@@ -65,8 +65,6 @@ export const TopBar = ( {
 		<div className="step-container-v2__top-bar">
 			{ ! hideLogo && resolvedLogo }
 
-			{ ! hideLogo && leftElement && <div className="step-container-v2__top-bar-divider" /> }
-
 			{ leftElement && (
 				<div className="step-container-v2__top-bar-left-element">{ leftElement }</div>
 			) }

--- a/packages/onboarding/src/step-container-v2/components/TopBar/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/TopBar/style.scss
@@ -6,6 +6,7 @@
 	box-sizing: border-box;
 	display: flex;
 	align-items: center;
+	gap: 1rem;
 	padding: var( --step-container-v2-top-bar-padding );
 
 	@include break-small {
@@ -32,10 +33,6 @@
 .step-container-v2__top-bar-wordpress-logo {
 	color: var( --color-text );
 	margin: 0;
-
-	@include break-small {
-		margin-right: 0.5rem;
-	}
 }
 
 .step-container-v2__top-bar-wordpress-logo--wordmark {
@@ -61,20 +58,10 @@
 	}
 }
 
-.step-container-v2__top-bar-divider {
-	width: 1px;
-	height: 1rem;
-	background-color: var( --color-border-subtle );
-	margin-inline: 1rem 0;
-
-	@include break-small {
-		margin-inline: 1.5rem 0.75rem;
-	}
-}
-
 .step-container-v2__top-bar-right-element {
 	display: flex;
-	gap: 1.5rem;
+	align-items: center;
+	gap: 1rem;
 	margin-left: auto;
 	font-size: 0.875rem;
 	line-height: 1;

--- a/packages/onboarding/src/step-container-v2/components/buttons/BackButton/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/buttons/BackButton/style.scss
@@ -1,7 +1,16 @@
-.step-container-v2__back-button {
+.step-container-v2__back-button.components-button {
 	--wp-components-color-accent: var(--color-neutral-100);
 	--color-link: var(--color-neutral-100);
 	font-size: 0.875rem;
+	font-weight: 500;
 	line-height: 1;
-	text-decoration: none !important;
+	text-decoration: underline;
+	gap: 4px;
+	padding: 0 !important;
+	min-width: 0;
+	height: auto;
+
+	svg {
+		margin-inline-end: 0;
+	}
 }

--- a/packages/onboarding/src/step-container-v2/components/buttons/LinkButton/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/buttons/LinkButton/style.scss
@@ -1,5 +1,6 @@
-.step-container-v2__link-button {
+.step-container-v2__link-button.components-button {
 	font-size: inherit;
 	line-height: inherit;
 	font-weight: 500;
+	text-decoration: underline;
 }


### PR DESCRIPTION
#110314 was merged into `fix/domain-search-back-button-logged-out` instead of `trunk`. This is the same set of changes with `trunk` as a base.

Copied from #110314:

----

Part of https://linear.app/a8c/issue/DSGCOM-510

Extracted from #110133 to land the shared header refinements and bug-fix wiring independently of the mobile "X of 3" stepper, which stays on #110133 for separate review.

Context: p1777471813363859/1777392197.641519-slack-C097SQTJV9S

Stacked on #110130.

## Proposed Changes

### Shared `step-container-v2` TopBar refinements (~41 surfaces)

These are visual changes to the shared TopBar and apply to every step-container-v2 surface:

- Remove the vertical divider between the logo and left element.
- `gap: 1rem` on the main container and right-element (was `1.5rem` on right-element, plus divider + margins elsewhere).
- `BackButton` and `LinkButton` are now consistently underlined and `font-weight: 500`. `BackButton` has zero padding and a 4px gap between chevron and text.
- Remove stale `margin-right: 0.5rem` on the logo wrapper (redundant with the new container `gap`).

### Domains (`/setup/onboarding/domains`)

- Rename "Use a domain I already own" → "Use a domain I own", in both the v2 TopBar right element and the pre-v2 step-container variant.

### Plans (`/setup/onboarding/plans`)

- Add a "Need help?" link in the right element that toggles the HelpCenter (gated on `isOnboardingFlow(flowName)`).
- Back button now explicitly navigates to the Domains step via `getStepUrl( 'onboarding', 'domains' )`. Returning from Checkout → Plans → back now lands on Domains rather than on Checkout's browser-history entry.

All onboarding-specific behavior is gated on `isOnboardingFlow(flowName)` — non-onboarding flows are unaffected.

## Why are these changes being made?

Onboarding design refresh — six page headers are moving to the same minimal pattern (no vertical divider, consistent underlined link styling). This PR covers the shared TopBar refinements plus the Domains and Plans page-level wiring.

The Plans Back-button override also fixes a navigation bug: previously, pressing Back from Checkout, then Plans, looped users back to Checkout, not to Domains. The override now sends users explicitly to Domains.

#110133 covers the mobile-only "X of 3" stepper indicator on Domains/Plans/Checkout and stays open for review.

### Approach

The split was chosen because the shared TopBar refinements touch ~41 surfaces and shouldn't be blocked on the stepper review. The bug-fix wiring (Plans back-nav, domain copy rename) lives here because it's tightly coupled to the same pages and the same wiring touches.

The Plans back-button URL uses `getStepUrl( 'onboarding', 'domains' )` rather than a hardcoded path, per review feedback on the original PR.

## Testing Instructions

Run Calypso locally.

### Onboarding pages

| URL | Expected header |
|---|---|
| `/setup/onboarding/domains` | Logo + `< Back` (from #110130) + `Use a domain I own` |
| `/setup/onboarding/plans` | Logo + `< Back` + `Need help?` (click opens HelpCenter) |

### Behavior checks

- **Plans `< Back`** goes to `/setup/onboarding/domains` (not the browser's previous entry, so Domains → Plans → Checkout → Back → Back lands on Domains).

### Regression checks (shared TopBar — ~41 surfaces)

The shared refinements touch every step-container-v2 TopBar. Spot-check:

- `/setup/copy-site/domains`, `/setup/copy-site/plans` — existing layout, no divider.
- `/setup/site-migration-identify` — divider gone; existing elements space correctly.
- Login views (`wp-login/components/one-login-layout.tsx` consumers) — `compactLogo` path still shows the logo, layout intact.
- Onboarding checkout (`/setup/onboarding/checkout`) — Back button still opens the leave-checkout modal; help link layout unchanged.