### PR TITLE
Checkout: migrate leave-checkout modal to @wordpress/ui Dialog

### DIFF
--- a/client/my-sites/checkout/src/components/leave-checkout-modal.tsx
+++ b/client/my-sites/checkout/src/components/leave-checkout-modal.tsx
@@ -1,5 +1,5 @@
-import { CheckoutModal } from '@automattic/composite-checkout';
 import { useShoppingCart } from '@automattic/shopping-cart';
+import { Dialog } from '@wordpress/ui';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useSelector } from 'react-redux';
@@ -74,23 +74,28 @@ export const LeaveCheckoutModal = ( {
 }: ReturnType< typeof useCheckoutLeaveModal > ) => {
 	const translate = useTranslate();
 
-	const modalTitleText = translate( 'You are about to leave checkout with items in your cart' );
-	const modalBodyText = translate( 'You can leave the items in the cart or empty the cart.' );
+	const modalTitleText = translate( 'Save your cart for later?' );
 	/* translators: The label to a button that will exit checkout without removing items from the shopping cart. */
-	const modalPrimaryText = translate( 'Leave items' );
+	const modalPrimaryText = translate( 'Save cart' );
 	/* translators: The label to a button that will remove all items from the shopping cart. */
 	const modalSecondaryText = translate( 'Empty cart' );
 
 	return (
-		<CheckoutModal
-			title={ modalTitleText }
-			copy={ modalBodyText }
-			closeModal={ () => setIsModalVisible( false ) }
-			isVisible={ isModalVisible }
-			primaryButtonCTA={ modalPrimaryText }
-			primaryAction={ closeAndLeave }
-			secondaryButtonCTA={ modalSecondaryText }
-			secondaryAction={ clearCartAndLeave }
-		/>
+		<Dialog.Root open={ isModalVisible } onOpenChange={ setIsModalVisible }>
+			<Dialog.Popup size="small">
+				<Dialog.Header>
+					<Dialog.Title>{ modalTitleText }</Dialog.Title>
+					<Dialog.CloseIcon />
+				</Dialog.Header>
+				<Dialog.Footer>
+					<Dialog.Action variant="outline" tone="neutral" onClick={ () => clearCartAndLeave() }>
+						{ modalSecondaryText }
+					</Dialog.Action>
+					<Dialog.Action variant="solid" onClick={ () => closeAndLeave() }>
+						{ modalPrimaryText }
+					</Dialog.Action>
+				</Dialog.Footer>
+			</Dialog.Popup>
+		</Dialog.Root>
 	);
 };


### PR DESCRIPTION
  > [!CAUTION]
  > **Do not merge.** This PR exists for side-by-side comparison with #110406 only. Buttons render unstyled in Calypso due to a cascade-layer collision between `@wordpress/ui` (layered) and Calypso's un-layered `button` reset. See screenshots and the discussion below.


Alternative to PR #110406 (which uses Modal from @wordpress/components), opened so reviewers can compare the two approaches side by side.

Replace the legacy emotion-styled CheckoutModal from @automattic/composite-checkout with Dialog from @wordpress/ui, and tighten the copy.

- Title: "You are about to leave checkout with items in your cart" → "Save your cart for later?"
- Body removed (just restated the buttons).
- Primary CTA: "Leave items" (ambiguous) → "Save cart".
- "Empty cart" unchanged.

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

  ## Known issue with this approach

Buttons in the dialog render unstyled. `@wordpress/ui` ships its CSS inside `@layer wp-ui-components`; Calypso's global button reset in `client/assets/stylesheets/shared/_reset.scss:122` is un-layered, so per cascade-layer rules the un-layered reset wins and strips background/border/padding from `@wordpress/ui` Buttons. Not fixable inside this file (class names are content-hashed). Proper fix is to wrap Calypso's global resets in a low-priority `@layer` — repo-wide change with its own review surface.

## Screenshots

Caveat: This is how the modal component looks like in Core.

| Before | After |
| --- | --- |
| <img width="2880" height="1800" alt="wordpress com_checkout_somethingsomethinggg9 wordpress com_redirect_to=%2Fsetup%2Fonboarding%2Fpost-checkout-onboarding%3FsiteSlug%3Dsomethingsomethinggg9 wordpress com%26ref%3Dnew-site-popover signup=1 checkoutBackUrl=https%3A%2F%2Fwor (1)" src="https://github.com/user-attachments/assets/bff3708f-6cf7-48bd-a35e-c08edab7e32d" /> | <img width="2880" height="1800" alt="calypso localhost_3000_checkout_phoenixowl77-wsbpe wordpress com_redirect_to=%2Fsetup%2Fonboarding%2Fpost-checkout-onboarding%3FsiteSlug%3Dphoenixowl77-wsbpe wordpress com%26ref%3Dnew-site-popover signup=1 checkoutBackUrl=http%3A%2F%2Fc (1)" src="https://github.com/user-attachments/assets/666b442f-a57f-4c28-88d3-e9f3f9306441" /> |
| <img width="750" height="1334" alt="wordpress com_checkout_somethingsomethinggg9 wordpress com_redirect_to=%2Fsetup%2Fonboarding%2Fpost-checkout-onboarding%3FsiteSlug%3Dsomethingsomethinggg9 wordpress com%26ref%3Dnew-site-popover signup=1 checkoutBackUrl=https%3A%2F%2Fwordpre" src="https://github.com/user-attachments/assets/e9b340aa-f92c-474c-9f10-4f3af6b927de" /> | <img width="750" height="1334" alt="calypso localhost_3000_checkout_phoenixowl77-wsbpe wordpress com_redirect_to=%2Fsetup%2Fonboarding%2Fpost-checkout-onboarding%3FsiteSlug%3Dphoenixowl77-wsbpe wordpress com%26ref%3Dnew-site-popover signup=1 checkoutBackUrl=http%3A%2F%2Fcalyp" src="https://github.com/user-attachments/assets/363941bc-0ed3-4ede-92b0-1c554f7b67ab" /> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
