### PR TITLE
Themes: Add an activation modal with basic vs. full setup choice

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -344,7 +344,7 @@ class ThemeSheet extends Component {
 
 		// Intercept activation so the user can preview the new theme and choose
 		// between a basic and a full setup. Skip the modal on Jetpack/Atomic
-		// sites where the full-setup path (theme-setup) doesn't apply, leaving
+		// sites where the full-setup path (theme-headstart) doesn't apply, leaving
 		// only one effective choice.
 		const { isAtomic, isStandaloneJetpack } = this.props;
 		if ( this.props.defaultOption?.key === 'activate' && ! isAtomic && ! isStandaloneJetpack ) {

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -109,6 +109,7 @@ import {
 	getThemeDemoUrl,
 	getThemeDetailsUrl,
 	getThemeRequestErrors,
+	shouldShowActivationModal,
 	shouldShowTryAndCustomize,
 	isExternallyManagedTheme as getIsExternallyManagedTheme,
 	isSiteEligibleForManagedExternalThemes as getIsSiteEligibleForManagedExternalThemes,
@@ -343,11 +344,8 @@ class ThemeSheet extends Component {
 		this.onBeforeOptionAction();
 
 		// Intercept activation so the user can preview the new theme and choose
-		// between a basic and a full setup. Skip the modal on Jetpack/Atomic
-		// sites where the full-setup path (theme-headstart) doesn't apply, leaving
-		// only one effective choice.
-		const { isAtomic, isStandaloneJetpack } = this.props;
-		if ( this.props.defaultOption?.key === 'activate' && ! isAtomic && ! isStandaloneJetpack ) {
+		// between a basic and a full setup, when applicable.
+		if ( this.props.defaultOption?.key === 'activate' && this.props.shouldShowActivationModal ) {
 			event?.preventDefault();
 			this.setState( { isActivationModalVisible: true } );
 			return;
@@ -1524,6 +1522,7 @@ export default connect(
 		return {
 			...theme,
 			themeId,
+			shouldShowActivationModal: shouldShowActivationModal( state, siteId, themeId ),
 			error,
 			siteId,
 			siteSlug,

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -340,6 +340,8 @@ class ThemeSheet extends Component {
 			return;
 		}
 
+		this.onBeforeOptionAction();
+
 		// Intercept activation so the user can preview the new theme and choose
 		// between a basic and a full setup. Skip the modal on Jetpack/Atomic
 		// sites where the full-setup path (theme-setup) doesn't apply, leaving
@@ -351,7 +353,6 @@ class ThemeSheet extends Component {
 			return;
 		}
 
-		this.onBeforeOptionAction();
 		this.props.defaultOption.action?.( this.props.themeId );
 	};
 

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -60,6 +60,7 @@ import { ClassicColorSchemeProvider, withColorScheme } from 'calypso/lib/color-s
 import { decodeEntities } from 'calypso/lib/formatting';
 import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 import { ReviewsSummary } from 'calypso/my-sites/marketplace/components/reviews-summary';
+import ActivationModal from 'calypso/my-sites/themes/activation-modal';
 import {
 	localizeThemesPath,
 	shouldEnableThemesColorScheme,
@@ -218,6 +219,7 @@ class ThemeSheet extends Component {
 		isRedirectingToEditorWebPreview: false,
 		isReviewsModalVisible: false,
 		isSiteSelectorModalVisible: false,
+		isActivationModalVisible: false,
 		isWide: isWithinBreakpoint( '>960px' ),
 	};
 
@@ -338,8 +340,23 @@ class ThemeSheet extends Component {
 			return;
 		}
 
+		// Intercept activation so the user can preview the new theme and choose
+		// between a basic and a full setup. Skip the modal on Jetpack/Atomic
+		// sites where the full-setup path (theme-setup) doesn't apply, leaving
+		// only one effective choice.
+		const { isAtomic, isStandaloneJetpack } = this.props;
+		if ( this.props.defaultOption?.key === 'activate' && ! isAtomic && ! isStandaloneJetpack ) {
+			event?.preventDefault();
+			this.setState( { isActivationModalVisible: true } );
+			return;
+		}
+
 		this.onBeforeOptionAction();
 		this.props.defaultOption.action?.( this.props.themeId );
+	};
+
+	closeActivationModal = () => {
+		this.setState( { isActivationModalVisible: false } );
 	};
 
 	onUnlockStyleButtonClick = () => {
@@ -1327,6 +1344,15 @@ class ThemeSheet extends Component {
 					/>
 				) }
 				<EligibilityWarningModal />
+				{ this.state.isActivationModalVisible && (
+					<ActivationModal
+						themeId={ themeId }
+						siteId={ siteId }
+						source="details"
+						styleVariation={ this.getSelectedStyleVariation() }
+						onClose={ this.closeActivationModal }
+					/>
+				) }
 			</Main>
 		);
 	};

--- a/client/my-sites/themes/_dark-mode.scss
+++ b/client/my-sites/themes/_dark-mode.scss
@@ -21,7 +21,7 @@
 	// scale so 60+ are mixed with white — pick higher-index blues here.
 	.iframe-preview-card {
 		// Lower the default so the hover step matches light mode in magnitude.
-		border-color: var( --color-neutral-80 );
+		border-color: var( --color-neutral-50 );
 
 		&:hover {
 			border-color: var( --color-neutral-70 );
@@ -36,8 +36,17 @@
 		}
 
 		.form-radio {
+			border-color: var( --color-neutral-50 );
+
 			&:hover {
 				border-color: var( --color-neutral-70 );
+			}
+
+			// The default focus halo uses --color-primary-10, which lands in
+			// the surface-blended end of the regenerated studio-blue scale —
+			// invisible against the dark card. Swap in a lighter blue.
+			&:focus {
+				box-shadow: 0 0 0 2px var( --studio-blue-70 );
 			}
 
 			&:checked::before {
@@ -45,15 +54,16 @@
 			}
 		}
 
-		// Overlays an always-light iframe, so pin the background to a stable
-		// dark token instead of letting it follow the dark-mode neutrals.
+		// Overlays an always-light iframe, so use the dashboard page background
+		// (a stable dark color) instead of any neutral that the dark-mode mixin
+		// has remapped toward the foreground.
 		.iframe-preview-card__enter-preview {
-			background: var( --studio-black );
+			background: var( --dashboard__background-color );
 		}
 	}
 
 	.themes__activation-modal .components-button.is-tertiary {
-		color: var( --studio-blue-60 );
+		color: var( --studio-blue-70 );
 	}
 }
 

--- a/client/my-sites/themes/_dark-mode.scss
+++ b/client/my-sites/themes/_dark-mode.scss
@@ -16,6 +16,45 @@
 	--theme-submenu-background-color: var( --dashboard-surface__background-color );
 	--theme-icon-color: var( --dashboard__text-muted-color );
 	--theme-notification-color: var( --wp-admin-theme-color );
+
+	// Activation modal: the dashboard dark theme re-generates the studio-blue
+	// scale so 60+ are mixed with white — pick higher-index blues here.
+	.iframe-preview-card {
+		// Lower the default so the hover step matches light mode in magnitude.
+		border-color: var( --color-neutral-80 );
+
+		&:hover {
+			border-color: var( --color-neutral-70 );
+		}
+
+		&:focus-within {
+			border-color: var( --studio-blue-80 );
+		}
+
+		&.is-selected {
+			border-color: var( --studio-blue-60 );
+		}
+
+		.form-radio {
+			&:hover {
+				border-color: var( --color-neutral-70 );
+			}
+
+			&:checked::before {
+				background: var( --studio-blue-60 );
+			}
+		}
+
+		// Overlays an always-light iframe, so pin the background to a stable
+		// dark token instead of letting it follow the dark-mode neutrals.
+		.iframe-preview-card__enter-preview {
+			background: var( --studio-black );
+		}
+	}
+
+	.themes__activation-modal .components-button.is-tertiary {
+		color: var( --studio-blue-60 );
+	}
 }
 
 @mixin themes-dark-mode-root {

--- a/client/my-sites/themes/activation-modal.scss
+++ b/client/my-sites/themes/activation-modal.scss
@@ -51,6 +51,14 @@
 		}
 	}
 
+	.themes__activation-modal-loading {
+		flex: 1 1 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		min-height: 200px;
+	}
+
 	.themes__activation-modal-actions {
 		display: flex;
 		justify-content: flex-end;

--- a/client/my-sites/themes/activation-modal.scss
+++ b/client/my-sites/themes/activation-modal.scss
@@ -1,0 +1,59 @@
+@import '@wordpress/base-styles/breakpoints';
+
+.themes__activation-modal {
+	width: calc(100% - 32px);
+	max-width: 1280px;
+	// @wordpress/components Modal caps height at 70% of viewport on tall
+	// screens (≥960px) and `calc(100% - 128px)` on shorter ones. With wide
+	// 4:3 preview cards inside, that's tight enough to trigger a scrollbar.
+	// Allow the modal to use most of the viewport with just 32px breathing
+	// room top and bottom.
+	max-height: calc(100vh - 64px);
+	// Below 600px, @wordpress/components Modal switches its default margin from
+	// `auto` to `40px 0 0 0` (a top-anchored full-bleed style). Since we keep
+	// the modal narrower than the viewport, force horizontal auto so it stays
+	// centered at every breakpoint.
+	margin-inline: auto;
+
+	// Mobile: drop our desktop overrides and let @wordpress/components Modal's
+	// default treatment take over — top-anchored, full-width, natural content
+	// height. That's the most common Calypso pattern (used by ConfirmModal,
+	// the various theme/import dialogs, etc.).
+	@media (max-width: $break-small) {
+		width: 100%;
+		max-width: none;
+		max-height: none;
+		margin: 40px 0 0 0;
+	}
+
+	.themes__activation-modal-previews {
+		display: flex;
+		gap: 24px;
+		margin-block-end: 24px;
+
+		> * {
+			flex: 1 1 0;
+		}
+
+		// On narrow viewports stack the options vertically so each one gets
+		// the full modal width.
+		@media (max-width: $break-small) {
+			flex-direction: column;
+
+			// In column mode, `flex: 1 1 0` distributes height equally — which
+			// constrains each card's height below what its 4:3 wrapper wants
+			// (silently overriding the wrapper's aspect-ratio and clipping the
+			// iframe's bottom). Disable the grow/shrink here so cards size to
+			// their natural content height.
+			> * {
+				flex: 0 0 auto;
+			}
+		}
+	}
+
+	.themes__activation-modal-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: 8px;
+	}
+}

--- a/client/my-sites/themes/activation-modal.scss
+++ b/client/my-sites/themes/activation-modal.scss
@@ -59,6 +59,14 @@
 		min-height: 200px;
 	}
 
+	// While the theme is activating, dim the modal's close (X) button and
+	// block pointer events so it visually reads as disabled. We can't disable
+	// it via a Modal prop — the X is rendered internally by @wordpress/components.
+	&.is-activating .components-modal__header .components-button {
+		opacity: 0.5;
+		pointer-events: none;
+	}
+
 	.themes__activation-modal-actions {
 		display: flex;
 		justify-content: flex-end;

--- a/client/my-sites/themes/activation-modal.tsx
+++ b/client/my-sites/themes/activation-modal.tsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { Spinner } from '@automattic/components';
 import { useLocale } from '@automattic/i18n-utils';
 import { Button, Modal } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
@@ -8,7 +9,7 @@ import { connect } from 'react-redux';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { getSiteDomain, isJetpackSite } from 'calypso/state/sites/selectors';
 import { activate as activateTheme } from 'calypso/state/themes/actions';
-import { getCanonicalTheme } from 'calypso/state/themes/selectors';
+import { getCanonicalTheme, isRequestingTheme } from 'calypso/state/themes/selectors';
 import IframePreviewCard from './iframe-preview-card';
 import type { IAppState } from 'calypso/state/types';
 import type { Theme } from 'calypso/types';
@@ -36,6 +37,7 @@ interface ConnectedProps {
 	theme: Theme | null;
 	siteDomain?: string | null;
 	supportsFullSetup: boolean;
+	isLoadingTheme: boolean;
 }
 
 interface DispatchProps {
@@ -49,6 +51,7 @@ const ActivationModal = ( {
 	siteId,
 	siteDomain,
 	supportsFullSetup,
+	isLoadingTheme,
 	source = 'details',
 	styleVariation,
 	onClose,
@@ -114,6 +117,10 @@ const ActivationModal = ( {
 
 	const showFullSetupOption = supportsFullSetup && !! fullSetupIframeSrc;
 
+	// Wait for the canonical theme to finish loading; otherwise a late-arriving
+	// `demo_uri` would briefly leave the basic-setup card stretched alone.
+	const isWaitingForFullSetup = supportsFullSetup && ! fullSetupIframeSrc && isLoadingTheme;
+
 	const handleActivate = () => {
 		const setupChoice = showFullSetupOption && choice === 'full_setup' ? 'full' : 'basic';
 		recordTracksEvent( 'calypso_theme_activation_modal_activate_click', {
@@ -156,37 +163,45 @@ const ActivationModal = ( {
 				className="themes__activation-modal-previews"
 				role={ showFullSetupOption ? 'radiogroup' : undefined }
 			>
-				<IframePreviewCard
-					name={ RADIO_GROUP_NAME }
-					value="basic_setup"
-					isSelected={ ! showFullSetupOption || choice === 'basic_setup' }
-					onSelect={ ( value ) => setChoice( value as SetupChoice ) }
-					label={ basicSetupLabel }
-					optionName={ basicSetupOptionName }
-					iframeUrl={ basicSetupIframeSrc }
-					iframeTitle={
-						translate( "Preview of your site with %(themeName)s's basic setup applied", {
-							args: { themeName },
-						} ) as string
-					}
-					caption={ basicSetupLabel }
-				/>
-				{ showFullSetupOption && (
-					<IframePreviewCard
-						name={ RADIO_GROUP_NAME }
-						value="full_setup"
-						isSelected={ choice === 'full_setup' }
-						onSelect={ ( value ) => setChoice( value as SetupChoice ) }
-						label={ fullSetupLabel }
-						optionName={ fullSetupOptionName }
-						iframeUrl={ fullSetupIframeSrc as string }
-						iframeTitle={
-							translate( "Preview of your site with %(themeName)s's full setup applied", {
-								args: { themeName },
-							} ) as string
-						}
-						caption={ fullSetupLabel }
-					/>
+				{ isWaitingForFullSetup ? (
+					<div className="themes__activation-modal-loading">
+						<Spinner size={ 50 } />
+					</div>
+				) : (
+					<>
+						<IframePreviewCard
+							name={ RADIO_GROUP_NAME }
+							value="basic_setup"
+							isSelected={ ! showFullSetupOption || choice === 'basic_setup' }
+							onSelect={ ( value ) => setChoice( value as SetupChoice ) }
+							label={ basicSetupLabel }
+							optionName={ basicSetupOptionName }
+							iframeUrl={ basicSetupIframeSrc }
+							iframeTitle={
+								translate( "Preview of your site with %(themeName)s's basic setup applied", {
+									args: { themeName },
+								} ) as string
+							}
+							caption={ basicSetupLabel }
+						/>
+						{ showFullSetupOption && (
+							<IframePreviewCard
+								name={ RADIO_GROUP_NAME }
+								value="full_setup"
+								isSelected={ choice === 'full_setup' }
+								onSelect={ ( value ) => setChoice( value as SetupChoice ) }
+								label={ fullSetupLabel }
+								optionName={ fullSetupOptionName }
+								iframeUrl={ fullSetupIframeSrc as string }
+								iframeTitle={
+									translate( "Preview of your site with %(themeName)s's full setup applied", {
+										args: { themeName },
+									} ) as string
+								}
+								caption={ fullSetupLabel }
+							/>
+						) }
+					</>
 				) }
 			</div>
 			<div className="themes__activation-modal-actions">
@@ -212,6 +227,7 @@ export default connect(
 			// The "Full setup" path runs the theme-headstart endpoint, which doesn't
 			// apply on Jetpack/Atomic sites.
 			supportsFullSetup: ! isJetpackOrAtomic,
+			isLoadingTheme: isRequestingTheme( state, 'wpcom', themeId ),
 		};
 	},
 	{

--- a/client/my-sites/themes/activation-modal.tsx
+++ b/client/my-sites/themes/activation-modal.tsx
@@ -33,7 +33,7 @@ interface OwnProps {
 }
 
 interface ConnectedProps {
-	theme?: Theme;
+	theme: Theme | null;
 	siteDomain?: string | null;
 	supportsFullSetup: boolean;
 }

--- a/client/my-sites/themes/activation-modal.tsx
+++ b/client/my-sites/themes/activation-modal.tsx
@@ -7,8 +7,7 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useRef, useState } from 'react';
 import { connect } from 'react-redux';
-import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
-import { getSiteDomain, isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSiteDomain } from 'calypso/state/sites/selectors';
 import { activate as activateTheme } from 'calypso/state/themes/actions';
 import { getCanonicalTheme, isRequestingTheme } from 'calypso/state/themes/selectors';
 import IframePreviewCard from './iframe-preview-card';
@@ -37,7 +36,6 @@ interface OwnProps {
 interface ConnectedProps {
 	theme: Theme | null;
 	siteDomain?: string | null;
-	supportsFullSetup: boolean;
 	isLoadingTheme: boolean;
 }
 
@@ -51,7 +49,6 @@ const ActivationModal = ( {
 	theme,
 	siteId,
 	siteDomain,
-	supportsFullSetup,
 	isLoadingTheme,
 	source = 'details',
 	styleVariation,
@@ -117,14 +114,13 @@ const ActivationModal = ( {
 		  } )
 		: null;
 
-	const showFullSetupOption = supportsFullSetup && !! fullSetupIframeSrc;
-
-	// Wait for the canonical theme to finish loading; otherwise a late-arriving
-	// `demo_uri` would briefly leave the basic-setup card stretched alone.
-	const isWaitingForFullSetup = supportsFullSetup && ! fullSetupIframeSrc && isLoadingTheme;
+	// `demo_uri` can land a tick after the canonical theme is first cached, so
+	// show a spinner until it arrives. Without this, the basic-setup card would
+	// briefly stretch alone before the full-setup card pops in.
+	const isWaitingForFullSetup = ! fullSetupIframeSrc && isLoadingTheme;
 
 	const handleActivate = async () => {
-		const setupChoice = showFullSetupOption && choice === 'full_setup' ? 'full' : 'basic';
+		const setupChoice = choice === 'full_setup' ? 'full' : 'basic';
 		recordTracksEvent( 'calypso_theme_activation_modal_activate_click', {
 			theme: themeId,
 			source,
@@ -170,10 +166,7 @@ const ActivationModal = ( {
 			shouldCloseOnClickOutside={ ! isActivating }
 			shouldCloseOnEsc={ ! isActivating }
 		>
-			<div
-				className="themes__activation-modal-previews"
-				role={ showFullSetupOption ? 'radiogroup' : undefined }
-			>
+			<div className="themes__activation-modal-previews" role="radiogroup">
 				{ isWaitingForFullSetup ? (
 					<div className="themes__activation-modal-loading">
 						<Spinner size={ 50 } />
@@ -183,7 +176,7 @@ const ActivationModal = ( {
 						<IframePreviewCard
 							name={ RADIO_GROUP_NAME }
 							value="basic_setup"
-							isSelected={ ! showFullSetupOption || choice === 'basic_setup' }
+							isSelected={ choice === 'basic_setup' }
 							onSelect={ ( value ) => setChoice( value as SetupChoice ) }
 							label={ basicSetupLabel }
 							optionName={ basicSetupOptionName }
@@ -196,24 +189,22 @@ const ActivationModal = ( {
 							caption={ basicSetupLabel }
 							disabled={ isActivating }
 						/>
-						{ showFullSetupOption && (
-							<IframePreviewCard
-								name={ RADIO_GROUP_NAME }
-								value="full_setup"
-								isSelected={ choice === 'full_setup' }
-								onSelect={ ( value ) => setChoice( value as SetupChoice ) }
-								label={ fullSetupLabel }
-								optionName={ fullSetupOptionName }
-								iframeUrl={ fullSetupIframeSrc as string }
-								iframeTitle={
-									translate( "Preview of your site with %(themeName)s's full setup applied", {
-										args: { themeName },
-									} ) as string
-								}
-								caption={ fullSetupLabel }
-								disabled={ isActivating }
-							/>
-						) }
+						<IframePreviewCard
+							name={ RADIO_GROUP_NAME }
+							value="full_setup"
+							isSelected={ choice === 'full_setup' }
+							onSelect={ ( value ) => setChoice( value as SetupChoice ) }
+							label={ fullSetupLabel }
+							optionName={ fullSetupOptionName }
+							iframeUrl={ fullSetupIframeSrc as string }
+							iframeTitle={
+								translate( "Preview of your site with %(themeName)s's full setup applied", {
+									args: { themeName },
+								} ) as string
+							}
+							caption={ fullSetupLabel }
+							disabled={ isActivating }
+						/>
 					</>
 				) }
 			</div>
@@ -235,19 +226,11 @@ const ActivationModal = ( {
 };
 
 export default connect(
-	( state: IAppState, { themeId, siteId }: OwnProps ): ConnectedProps => {
-		const isJetpackOrAtomic =
-			!! isJetpackSite( state, siteId ) || !! isSiteWpcomAtomic( state, siteId );
-
-		return {
-			theme: getCanonicalTheme( state, siteId, themeId ),
-			siteDomain: getSiteDomain( state, siteId ),
-			// The "Full setup" path runs the theme-headstart endpoint, which doesn't
-			// apply on Jetpack/Atomic sites.
-			supportsFullSetup: ! isJetpackOrAtomic,
-			isLoadingTheme: isRequestingTheme( state, 'wpcom', themeId ),
-		};
-	},
+	( state: IAppState, { themeId, siteId }: OwnProps ): ConnectedProps => ( {
+		theme: getCanonicalTheme( state, siteId, themeId ),
+		siteDomain: getSiteDomain( state, siteId ),
+		isLoadingTheme: isRequestingTheme( state, 'wpcom', themeId ),
+	} ),
 	{
 		dispatchActivateTheme: activateTheme,
 	}

--- a/client/my-sites/themes/activation-modal.tsx
+++ b/client/my-sites/themes/activation-modal.tsx
@@ -3,6 +3,7 @@ import { Spinner } from '@automattic/components';
 import { useLocale } from '@automattic/i18n-utils';
 import { Button, Modal } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useRef, useState } from 'react';
 import { connect } from 'react-redux';
@@ -60,6 +61,7 @@ const ActivationModal = ( {
 	const translate = useTranslate();
 	const locale = useLocale();
 	const [ choice, setChoice ] = useState< SetupChoice >( 'full_setup' );
+	const [ isActivating, setIsActivating ] = useState( false );
 
 	// Fire the modal-view Tracks event once per modal mount, after the theme
 	// is loaded so we have the theme id to attach.
@@ -121,18 +123,25 @@ const ActivationModal = ( {
 	// `demo_uri` would briefly leave the basic-setup card stretched alone.
 	const isWaitingForFullSetup = supportsFullSetup && ! fullSetupIframeSrc && isLoadingTheme;
 
-	const handleActivate = () => {
+	const handleActivate = async () => {
 		const setupChoice = showFullSetupOption && choice === 'full_setup' ? 'full' : 'basic';
 		recordTracksEvent( 'calypso_theme_activation_modal_activate_click', {
 			theme: themeId,
 			source,
 			setup_choice: setupChoice,
 		} );
-		dispatchActivateTheme( themeId, siteId, { source, setupChoice } );
-		onClose();
+		setIsActivating( true );
+		try {
+			await dispatchActivateTheme( themeId, siteId, { source, setupChoice } );
+		} finally {
+			onClose();
+		}
 	};
 
 	const handleDismiss = () => {
+		if ( isActivating ) {
+			return;
+		}
 		recordTracksEvent( 'calypso_theme_activation_modal_dismiss', {
 			theme: themeId,
 			source,
@@ -151,13 +160,15 @@ const ActivationModal = ( {
 
 	return (
 		<Modal
-			className="themes__activation-modal"
+			className={ clsx( 'themes__activation-modal', { 'is-activating': isActivating } ) }
 			title={
 				translate( 'How would you like to use %(themeName)s?', {
 					args: { themeName },
 				} ) as string
 			}
 			onRequestClose={ handleDismiss }
+			shouldCloseOnClickOutside={ ! isActivating }
+			shouldCloseOnEsc={ ! isActivating }
 		>
 			<div
 				className="themes__activation-modal-previews"
@@ -183,6 +194,7 @@ const ActivationModal = ( {
 								} ) as string
 							}
 							caption={ basicSetupLabel }
+							disabled={ isActivating }
 						/>
 						{ showFullSetupOption && (
 							<IframePreviewCard
@@ -199,16 +211,22 @@ const ActivationModal = ( {
 									} ) as string
 								}
 								caption={ fullSetupLabel }
+								disabled={ isActivating }
 							/>
 						) }
 					</>
 				) }
 			</div>
 			<div className="themes__activation-modal-actions">
-				<Button variant="tertiary" onClick={ handleDismiss }>
+				<Button variant="tertiary" onClick={ handleDismiss } disabled={ isActivating }>
 					{ translate( 'Cancel' ) }
 				</Button>
-				<Button variant="primary" onClick={ handleActivate }>
+				<Button
+					variant="primary"
+					onClick={ handleActivate }
+					isBusy={ isActivating }
+					disabled={ isActivating }
+				>
 					{ translate( 'Activate %(themeName)s', { args: { themeName } } ) }
 				</Button>
 			</div>

--- a/client/my-sites/themes/activation-modal.tsx
+++ b/client/my-sites/themes/activation-modal.tsx
@@ -7,7 +7,8 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useRef, useState } from 'react';
 import { connect } from 'react-redux';
-import { getSiteDomain } from 'calypso/state/sites/selectors';
+import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
+import { getSiteDomain, getSiteOption } from 'calypso/state/sites/selectors';
 import { activate as activateTheme } from 'calypso/state/themes/actions';
 import { getCanonicalTheme, isRequestingTheme } from 'calypso/state/themes/selectors';
 import IframePreviewCard from './iframe-preview-card';
@@ -19,6 +20,7 @@ import './activation-modal.scss';
 type SetupChoice = 'basic_setup' | 'full_setup';
 
 const RADIO_GROUP_NAME = 'activation-modal-setup-choice';
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
 
 interface StyleVariation {
 	slug?: string;
@@ -37,6 +39,8 @@ interface ConnectedProps {
 	theme: Theme | null;
 	siteDomain?: string | null;
 	isLoadingTheme: boolean;
+	isSiteLaunched: boolean;
+	siteAgeInDays: number | null;
 }
 
 interface DispatchProps {
@@ -50,6 +54,8 @@ const ActivationModal = ( {
 	siteId,
 	siteDomain,
 	isLoadingTheme,
+	isSiteLaunched,
+	siteAgeInDays,
 	source = 'details',
 	styleVariation,
 	onClose,
@@ -71,6 +77,8 @@ const ActivationModal = ( {
 		recordTracksEvent( 'calypso_theme_activation_modal_view', {
 			theme: theme.id,
 			source,
+			is_site_launched: isSiteLaunched,
+			...( siteAgeInDays !== null && { site_age_in_days: siteAgeInDays } ),
 		} );
 	}, [ theme, source ] );
 
@@ -125,6 +133,8 @@ const ActivationModal = ( {
 			theme: themeId,
 			source,
 			setup_choice: setupChoice,
+			is_site_launched: isSiteLaunched,
+			...( siteAgeInDays !== null && { site_age_in_days: siteAgeInDays } ),
 		} );
 		setIsActivating( true );
 		try {
@@ -141,6 +151,8 @@ const ActivationModal = ( {
 		recordTracksEvent( 'calypso_theme_activation_modal_dismiss', {
 			theme: themeId,
 			source,
+			is_site_launched: isSiteLaunched,
+			...( siteAgeInDays !== null && { site_age_in_days: siteAgeInDays } ),
 		} );
 		onClose();
 	};
@@ -240,11 +252,19 @@ const ActivationModal = ( {
 };
 
 export default connect(
-	( state: IAppState, { themeId, siteId }: OwnProps ): ConnectedProps => ( {
-		theme: getCanonicalTheme( state, siteId, themeId ),
-		siteDomain: getSiteDomain( state, siteId ),
-		isLoadingTheme: isRequestingTheme( state, 'wpcom', themeId ),
-	} ),
+	( state: IAppState, { themeId, siteId }: OwnProps ): ConnectedProps => {
+		const createdAt = getSiteOption( state, siteId, 'created_at' ) as string | undefined;
+		const siteAgeInDays = createdAt
+			? Math.floor( ( Date.now() - new Date( createdAt ).getTime() ) / DAY_IN_MS )
+			: null;
+		return {
+			theme: getCanonicalTheme( state, siteId, themeId ),
+			siteDomain: getSiteDomain( state, siteId ),
+			isLoadingTheme: isRequestingTheme( state, 'wpcom', themeId ),
+			isSiteLaunched: ! isUnlaunchedSite( state, siteId ),
+			siteAgeInDays,
+		};
+	},
 	{
 		dispatchActivateTheme: activateTheme,
 	}

--- a/client/my-sites/themes/activation-modal.tsx
+++ b/client/my-sites/themes/activation-modal.tsx
@@ -1,0 +1,220 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { useLocale } from '@automattic/i18n-utils';
+import { Button, Modal } from '@wordpress/components';
+import { addQueryArgs } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useRef, useState } from 'react';
+import { connect } from 'react-redux';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
+import { getSiteDomain, isJetpackSite } from 'calypso/state/sites/selectors';
+import { activate as activateTheme } from 'calypso/state/themes/actions';
+import { getCanonicalTheme } from 'calypso/state/themes/selectors';
+import IframePreviewCard from './iframe-preview-card';
+import type { IAppState } from 'calypso/state/types';
+import type { Theme } from 'calypso/types';
+
+import './activation-modal.scss';
+
+type SetupChoice = 'basic_setup' | 'full_setup';
+
+const RADIO_GROUP_NAME = 'activation-modal-setup-choice';
+
+interface StyleVariation {
+	slug?: string;
+	title?: string;
+}
+
+interface OwnProps {
+	themeId: string;
+	siteId: number;
+	source?: 'details' | 'list' | 'upload';
+	styleVariation?: StyleVariation;
+	onClose: () => void;
+}
+
+interface ConnectedProps {
+	theme?: Theme;
+	siteDomain?: string | null;
+	supportsFullSetup: boolean;
+}
+
+interface DispatchProps {
+	dispatchActivateTheme: typeof activateTheme;
+}
+
+type Props = OwnProps & ConnectedProps & DispatchProps;
+
+const ActivationModal = ( {
+	theme,
+	siteId,
+	siteDomain,
+	supportsFullSetup,
+	source = 'details',
+	styleVariation,
+	onClose,
+	dispatchActivateTheme,
+}: Props ) => {
+	const translate = useTranslate();
+	const locale = useLocale();
+	const [ choice, setChoice ] = useState< SetupChoice >( 'full_setup' );
+
+	// Fire the modal-view Tracks event once per modal mount, after the theme
+	// is loaded so we have the theme id to attach.
+	const hasFiredViewEvent = useRef( false );
+	useEffect( () => {
+		if ( hasFiredViewEvent.current || ! theme ) {
+			return;
+		}
+		hasFiredViewEvent.current = true;
+		recordTracksEvent( 'calypso_theme_activation_modal_view', {
+			theme: theme.id,
+			source,
+		} );
+	}, [ theme, source ] );
+
+	if ( ! theme || ! siteDomain ) {
+		return null;
+	}
+
+	const { id: themeId, name: themeName, stylesheet, demo_uri: demoUri } = theme;
+
+	// Match the convention used by client/my-sites/themes/theme-preview.jsx:
+	// pass the variation's `title` (not slug) as the `style_variation` query
+	// arg, and skip it for the default variation.
+	const styleVariationParam =
+		styleVariation && styleVariation.slug && styleVariation.slug !== 'default'
+			? { style_variation: styleVariation.title }
+			: {};
+
+	// Match theme-preview.jsx: append `&language=<locale>` so the previewed
+	// site renders in the user's UI locale. Skip for `en` (the default) and
+	// for empty values.
+	const localeParam = locale && locale !== 'en' ? { language: locale } : {};
+
+	// "Basic setup": preview the user's existing site with the new theme's
+	// stylesheet applied — no theme-setup, no content additions.
+	const basicSetupIframeSrc = addQueryArgs( `//${ siteDomain }/`, {
+		theme: stylesheet,
+		hide_banners: 'true',
+		...styleVariationParam,
+		...localeParam,
+	} );
+
+	// "Full setup": preview the theme's official demo site, which is what the
+	// theme-setup endpoint will broadly replicate by adding pages to the site.
+	const fullSetupIframeSrc = demoUri
+		? addQueryArgs( demoUri, {
+				demo: 'true',
+				iframe: 'true',
+				theme_preview: 'true',
+				...styleVariationParam,
+				...localeParam,
+		  } )
+		: null;
+
+	const showFullSetupOption = supportsFullSetup && !! fullSetupIframeSrc;
+
+	const handleActivate = () => {
+		const setupChoice = showFullSetupOption && choice === 'full_setup' ? 'full' : 'basic';
+		recordTracksEvent( 'calypso_theme_activation_modal_activate_click', {
+			theme: themeId,
+			source,
+			setup_choice: setupChoice,
+		} );
+		dispatchActivateTheme( themeId, siteId, { source, setupChoice } );
+		onClose();
+	};
+
+	const handleDismiss = () => {
+		recordTracksEvent( 'calypso_theme_activation_modal_dismiss', {
+			theme: themeId,
+			source,
+		} );
+		onClose();
+	};
+
+	const basicSetupOptionName = translate( 'Basic setup' ) as string;
+	const fullSetupOptionName = translate( 'Full setup' ) as string;
+	const basicSetupLabel = translate(
+		"Basic setup: Use the theme's styling, but don't add extra pages to the site"
+	) as string;
+	const fullSetupLabel = translate(
+		'Full setup: Add extra content to more closely match the design'
+	) as string;
+
+	return (
+		<Modal
+			className="themes__activation-modal"
+			title={
+				translate( 'How would you like to use %(themeName)s?', {
+					args: { themeName },
+				} ) as string
+			}
+			onRequestClose={ handleDismiss }
+		>
+			<div
+				className="themes__activation-modal-previews"
+				role={ showFullSetupOption ? 'radiogroup' : undefined }
+			>
+				<IframePreviewCard
+					name={ RADIO_GROUP_NAME }
+					value="basic_setup"
+					isSelected={ ! showFullSetupOption || choice === 'basic_setup' }
+					onSelect={ ( value ) => setChoice( value as SetupChoice ) }
+					label={ basicSetupLabel }
+					optionName={ basicSetupOptionName }
+					iframeUrl={ basicSetupIframeSrc }
+					iframeTitle={
+						translate( "Preview of your site with %(themeName)s's basic setup applied", {
+							args: { themeName },
+						} ) as string
+					}
+					caption={ basicSetupLabel }
+				/>
+				{ showFullSetupOption && (
+					<IframePreviewCard
+						name={ RADIO_GROUP_NAME }
+						value="full_setup"
+						isSelected={ choice === 'full_setup' }
+						onSelect={ ( value ) => setChoice( value as SetupChoice ) }
+						label={ fullSetupLabel }
+						optionName={ fullSetupOptionName }
+						iframeUrl={ fullSetupIframeSrc as string }
+						iframeTitle={
+							translate( "Preview of your site with %(themeName)s's full setup applied", {
+								args: { themeName },
+							} ) as string
+						}
+						caption={ fullSetupLabel }
+					/>
+				) }
+			</div>
+			<div className="themes__activation-modal-actions">
+				<Button variant="tertiary" onClick={ handleDismiss }>
+					{ translate( 'Cancel' ) }
+				</Button>
+				<Button variant="primary" onClick={ handleActivate }>
+					{ translate( 'Activate %(themeName)s', { args: { themeName } } ) }
+				</Button>
+			</div>
+		</Modal>
+	);
+};
+
+export default connect(
+	( state: IAppState, { themeId, siteId }: OwnProps ): ConnectedProps => {
+		const isJetpackOrAtomic =
+			!! isJetpackSite( state, siteId ) || !! isSiteWpcomAtomic( state, siteId );
+
+		return {
+			theme: getCanonicalTheme( state, siteId, themeId ),
+			siteDomain: getSiteDomain( state, siteId ),
+			// The "Full setup" path runs the theme-setup endpoint, which doesn't
+			// apply on Jetpack/Atomic sites.
+			supportsFullSetup: ! isJetpackOrAtomic,
+		};
+	},
+	{
+		dispatchActivateTheme: activateTheme,
+	}
+)( ActivationModal );

--- a/client/my-sites/themes/activation-modal.tsx
+++ b/client/my-sites/themes/activation-modal.tsx
@@ -1,5 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { Spinner } from '@automattic/components';
+import { ScreenReaderText, Spinner } from '@automattic/components';
 import { useLocale } from '@automattic/i18n-utils';
 import { Button, Modal } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
@@ -166,10 +166,15 @@ const ActivationModal = ( {
 			shouldCloseOnClickOutside={ ! isActivating }
 			shouldCloseOnEsc={ ! isActivating }
 		>
-			<div className="themes__activation-modal-previews" role="radiogroup">
+			<div
+				className="themes__activation-modal-previews"
+				role="radiogroup"
+				aria-label={ translate( 'Setup option' ) as string }
+			>
 				{ isWaitingForFullSetup ? (
-					<div className="themes__activation-modal-loading">
+					<div className="themes__activation-modal-loading" role="status">
 						<Spinner size={ 50 } />
+						<ScreenReaderText>{ translate( 'Loading preview…' ) }</ScreenReaderText>
 					</div>
 				) : (
 					<>
@@ -207,6 +212,15 @@ const ActivationModal = ( {
 						/>
 					</>
 				) }
+			</div>
+			{ /*
+				Persistent live region so screen readers hear when activation
+				starts. Success and error outcomes are announced separately via
+				Calypso's notice system after the modal closes.
+			*/ }
+			<div className="screen-reader-text" role="status">
+				{ isActivating &&
+					( translate( 'Activating %(themeName)s…', { args: { themeName } } ) as string ) }
 			</div>
 			<div className="themes__activation-modal-actions">
 				<Button variant="tertiary" onClick={ handleDismiss } disabled={ isActivating }>

--- a/client/my-sites/themes/activation-modal.tsx
+++ b/client/my-sites/themes/activation-modal.tsx
@@ -92,7 +92,7 @@ const ActivationModal = ( {
 	const localeParam = locale && locale !== 'en' ? { language: locale } : {};
 
 	// "Basic setup": preview the user's existing site with the new theme's
-	// stylesheet applied — no theme-setup, no content additions.
+	// stylesheet applied — no theme-headstart, no content additions.
 	const basicSetupIframeSrc = addQueryArgs( `//${ siteDomain }/`, {
 		theme: stylesheet,
 		hide_banners: 'true',
@@ -101,7 +101,7 @@ const ActivationModal = ( {
 	} );
 
 	// "Full setup": preview the theme's official demo site, which is what the
-	// theme-setup endpoint will broadly replicate by adding pages to the site.
+	// theme-headstart endpoint will broadly replicate by adding pages to the site.
 	const fullSetupIframeSrc = demoUri
 		? addQueryArgs( demoUri, {
 				demo: 'true',
@@ -209,7 +209,7 @@ export default connect(
 		return {
 			theme: getCanonicalTheme( state, siteId, themeId ),
 			siteDomain: getSiteDomain( state, siteId ),
-			// The "Full setup" path runs the theme-setup endpoint, which doesn't
+			// The "Full setup" path runs the theme-headstart endpoint, which doesn't
 			// apply on Jetpack/Atomic sites.
 			supportsFullSetup: ! isJetpackOrAtomic,
 		};

--- a/client/my-sites/themes/iframe-preview-card.scss
+++ b/client/my-sites/themes/iframe-preview-card.scss
@@ -27,6 +27,11 @@
 		border-color: var(--studio-blue-50);
 	}
 
+	&.is-disabled {
+		cursor: default;
+		opacity: 0.5;
+	}
+
 	// Once a card is selected, its iframe becomes interactive (scrollable).
 	// Until then, pointer events fall through to the wrapping <label> so a click
 	// anywhere on the card — including the iframe — selects it.

--- a/client/my-sites/themes/iframe-preview-card.scss
+++ b/client/my-sites/themes/iframe-preview-card.scss
@@ -1,0 +1,154 @@
+@import '@automattic/typography/styles/variables';
+
+.iframe-preview-card {
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	// Generous gap between the iframe wrapper and the radio/caption row so
+	// the choice control reads as distinct from the preview above it.
+	gap: 16px;
+	padding: 8px;
+	min-width: 0;
+	border: 4px solid var(--color-neutral-10);
+	border-radius: 4px;
+	background: var(--color-surface);
+	cursor: pointer;
+	transition: border-color 0.15s;
+
+	&:hover {
+		border-color: var(--color-neutral-30);
+	}
+
+	&:focus-within {
+		border-color: var(--studio-blue-30);
+	}
+
+	&.is-selected {
+		border-color: var(--studio-blue-50);
+	}
+
+	// Once a card is selected, its iframe becomes interactive (scrollable).
+	// Until then, pointer events fall through to the wrapping <label> so a click
+	// anywhere on the card — including the iframe — selects it.
+	&.is-selected .iframe-preview-card__iframe {
+		pointer-events: auto;
+	}
+}
+
+.iframe-preview-card__caption-row {
+	display: flex;
+	align-items: flex-start;
+	justify-content: center;
+	gap: 8px;
+}
+
+.iframe-preview-card__radio {
+	// Override .form-radio's default margins; small top margin keeps the radio
+	// vertically aligned with the first line of caption text, even when the
+	// caption wraps to a second line.
+	flex-shrink: 0;
+	margin: 4px 0 0;
+}
+
+.iframe-preview-card__frame-wrapper {
+	// Element is a <span> (so the markup stays valid inside <label>, which only
+	// accepts phrasing content). Force block-level layout for the wrapper.
+	display: block;
+	position: relative;
+	width: 100%;
+	// 4:3 matches the iframe's intrinsic 1200x900 so the scaled iframe fills
+	// the wrapper exactly with no bottom crop.
+	aspect-ratio: 4 / 3;
+	// Block flex-shrink from compressing the wrapper's aspect-ratio-derived
+	// height. The card is a flex column container; without this, when the
+	// modal's max-height makes the parent flex chain attempt to shrink the
+	// card, the wrapper gets squeezed below its 4:3 height and the iframe's
+	// bottom is clipped.
+	flex-shrink: 0;
+	overflow: hidden;
+	border: 1px solid var(--color-neutral-10);
+	border-radius: 4px;
+	background: var(--color-neutral-0);
+	// Establishes a containment context so the iframe inside can size itself
+	// against the wrapper's width via container query units (cqw).
+	container-type: inline-size;
+}
+
+.iframe-preview-card__loading {
+	// Centered spinner overlay shown while the iframe is loading. Sits above
+	// the (transparent) iframe and is removed once `onLoad` fires.
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	// Click-through so a click on the still-loading area selects the card via
+	// the wrapping <label> instead of being absorbed by the spinner div.
+	pointer-events: none;
+}
+
+.iframe-preview-card__iframe {
+	// Smooth fade-in once the iframe has finished loading.
+	transition: opacity 0.2s;
+	// Render at a fixed 1200x900 desktop viewport so the previewed site loads
+	// its desktop styles, then scale to fit the wrapper using container query units.
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 1200px;
+	height: 900px;
+	// Calypso's global stylesheet (_main.scss) sets `iframe { max-width: 100% }`,
+	// which would clamp the intrinsic 1200px to the wrapper's actual width.
+	// Override it so the iframe truly renders at 1200px before being scaled down.
+	max-width: none;
+	border: 0;
+	// `tan(atan2(y, x))` mathematically equals `y / x` and is a widely-compatible
+	// way to convert length-over-length into a unitless number. The simpler
+	// `calc(100cqw / 1200px)` form would require CSS Values 4 support, which
+	// is below our browser floor. The expression is wrapped in `#{"..."}` so
+	// Sass passes it through verbatim instead of trying to evaluate at build time.
+	transform: #{"scale(tan(atan2(100cqw, 1200px)))"};
+	transform-origin: top left;
+	pointer-events: none;
+}
+
+.iframe-preview-card__enter-preview {
+	// Visually hidden until the button is keyboard-focused — same pattern
+	// as the masterbar's "Skip to main content" link
+	// (client/jetpack-cloud/sections/pricing/jpcom-masterbar/style.scss).
+	// Mouse users never see it; keyboard users land on it after the radio
+	// in tab order and can press Enter to push focus into the iframe content.
+	position: absolute;
+	top: 8px;
+	left: 8px;
+	width: 1px;
+	height: 1px;
+	padding: 8px 16px;
+	overflow: hidden;
+	color: var(--studio-white);
+	background: var(--color-neutral-100);
+	border: 0;
+	border-radius: 4px;
+	font-size: $font-body-small;
+	font-weight: 500;
+	cursor: pointer;
+	transform: translateX(-1000px);
+	transition: transform 0.1s ease-in-out;
+	z-index: 2;
+
+	&:focus {
+		width: auto;
+		height: auto;
+		transform: translateX(0);
+		outline: 2px solid var(--studio-blue-50);
+		outline-offset: 2px;
+	}
+}
+
+.iframe-preview-card__caption {
+	// Matches the ThemeCard title pattern (label-below-thumbnail).
+	font-size: $font-body;
+	font-weight: 500;
+	line-height: 24px;
+	color: var(--color-neutral-80);
+}

--- a/client/my-sites/themes/iframe-preview-card.tsx
+++ b/client/my-sites/themes/iframe-preview-card.tsx
@@ -20,6 +20,7 @@ interface IframePreviewCardProps {
 	iframeTitle: string;
 	caption: string;
 	className?: string;
+	disabled?: boolean;
 }
 
 const IframePreviewCard = ( {
@@ -33,6 +34,7 @@ const IframePreviewCard = ( {
 	iframeTitle,
 	caption,
 	className,
+	disabled = false,
 }: IframePreviewCardProps ) => {
 	const translate = useTranslate();
 	const radioId = useId();
@@ -50,7 +52,11 @@ const IframePreviewCard = ( {
 	return (
 		<label
 			htmlFor={ radioId }
-			className={ clsx( 'iframe-preview-card', { 'is-selected': isSelected }, className ) }
+			className={ clsx(
+				'iframe-preview-card',
+				{ 'is-selected': isSelected, 'is-disabled': disabled },
+				className
+			) }
 		>
 			<span className="iframe-preview-card__frame-wrapper">
 				{ ! isLoaded && (
@@ -78,6 +84,7 @@ const IframePreviewCard = ( {
 					type="button"
 					className="iframe-preview-card__enter-preview"
 					onClick={ handleEnterPreview }
+					disabled={ disabled }
 				>
 					{ translate( 'Enter preview for the "%(optionName)s" option', {
 						args: { optionName },
@@ -93,6 +100,7 @@ const IframePreviewCard = ( {
 					onChange={ () => onSelect( value ) }
 					aria-label={ label }
 					className="iframe-preview-card__radio"
+					disabled={ disabled }
 				/>
 				<span className="iframe-preview-card__caption">{ caption }</span>
 			</span>

--- a/client/my-sites/themes/iframe-preview-card.tsx
+++ b/client/my-sites/themes/iframe-preview-card.tsx
@@ -1,0 +1,103 @@
+import { Spinner } from '@automattic/components';
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import { useId, useRef, useState } from 'react';
+import FormRadio from 'calypso/components/forms/form-radio';
+
+import './iframe-preview-card.scss';
+
+interface IframePreviewCardProps {
+	name: string;
+	value: string;
+	isSelected: boolean;
+	onSelect: ( value: string ) => void;
+	label: string;
+	// Short, user-facing name for the option (e.g. "Basic setup"). Used in the
+	// "Enter preview" button label so keyboard users know which option's iframe
+	// they're entering.
+	optionName: string;
+	iframeUrl: string;
+	iframeTitle: string;
+	caption: string;
+	className?: string;
+}
+
+const IframePreviewCard = ( {
+	name,
+	value,
+	isSelected,
+	onSelect,
+	label,
+	optionName,
+	iframeUrl,
+	iframeTitle,
+	caption,
+	className,
+}: IframePreviewCardProps ) => {
+	const translate = useTranslate();
+	const radioId = useId();
+	const iframeRef = useRef< HTMLIFrameElement | null >( null );
+	const [ isLoaded, setIsLoaded ] = useState( false );
+
+	const handleEnterPreview = ( event: React.MouseEvent | React.KeyboardEvent ) => {
+		// Don't bubble to the wrapping <label> — pressing Enter / Space on the
+		// "Enter preview" button shouldn't also flip the radio.
+		event.preventDefault();
+		event.stopPropagation();
+		iframeRef.current?.contentWindow?.focus();
+	};
+
+	return (
+		<label
+			htmlFor={ radioId }
+			className={ clsx( 'iframe-preview-card', { 'is-selected': isSelected }, className ) }
+		>
+			<span className="iframe-preview-card__frame-wrapper">
+				{ ! isLoaded && (
+					<span className="iframe-preview-card__loading" aria-hidden="true">
+						<Spinner size={ 50 } />
+					</span>
+				) }
+				<iframe
+					ref={ iframeRef }
+					loading="lazy"
+					title={ iframeTitle }
+					src={ iframeUrl }
+					tabIndex={ -1 }
+					className="iframe-preview-card__iframe"
+					onLoad={ () => setIsLoaded( true ) }
+					style={ { opacity: isLoaded ? 1 : 0 } }
+				/>
+				{ /*
+					Visually-hidden-until-focused button that lets keyboard users
+					opt into the iframe's content tab order. Mirrors the
+					"Skip to main content" pattern used in
+					client/jetpack-cloud/sections/pricing/jpcom-masterbar/.
+				*/ }
+				<button
+					type="button"
+					className="iframe-preview-card__enter-preview"
+					onClick={ handleEnterPreview }
+				>
+					{ translate( 'Enter preview for the "%(optionName)s" option', {
+						args: { optionName },
+					} ) }
+				</button>
+			</span>
+			<span className="iframe-preview-card__caption-row">
+				<FormRadio
+					id={ radioId }
+					name={ name }
+					value={ value }
+					checked={ isSelected }
+					onChange={ () => onSelect( value ) }
+					aria-label={ label }
+					className="iframe-preview-card__radio"
+				/>
+				<span className="iframe-preview-card__caption">{ caption }</span>
+			</span>
+		</label>
+	);
+};
+
+export default IframePreviewCard;

--- a/client/state/themes/actions/activate-theme.jsx
+++ b/client/state/themes/actions/activate-theme.jsx
@@ -26,11 +26,17 @@ import { activateStyleVariation } from './activate-style-variation';
  * @param {string}  [options.source]     The source that is requesting theme activation, e.g. 'showcase'
  * @param {boolean} [options.purchased]  Whether the theme has been purchased prior to activation
  * @param {boolean} [options.showSuccessNotice]  Whether the theme has been purchased prior to activation
+ * @param {'basic'|'full'} [options.setupChoice] The user's setup choice from the activation modal: `'full'` runs `/theme-setup` after activation to add the theme's extra demo content; `'basic'` skips it. Omit on direct activate paths that don't surface the choice (e.g., when the modal isn't shown).
  * @returns {Function}        Action thunk
  */
 export function activateTheme( themeId, siteId, options = {} ) {
 	return ( dispatch, getState ) => {
-		const { source = 'unknown', purchased = false, showSuccessNotice = false } = options || {};
+		const {
+			source = 'unknown',
+			purchased = false,
+			showSuccessNotice = false,
+			setupChoice,
+		} = options || {};
 		const themeOptions = getThemePreviewThemeOptions( getState() );
 		const styleVariationSlug =
 			themeOptions && themeOptions.themeId === themeId
@@ -60,11 +66,37 @@ export function activateTheme( themeId, siteId, options = {} ) {
 
 				return theme;
 			} )
+			.then( async ( theme ) => {
+				if ( setupChoice === 'full' ) {
+					try {
+						await wpcom.req.post( {
+							path: `/sites/${ siteId }/theme-setup/?_locale=user`,
+							apiNamespace: 'wpcom/v2',
+						} );
+					} catch ( error ) {
+						dispatch(
+							errorNotice(
+								translate(
+									"Your theme was activated, but we couldn't complete the full setup. The theme's extra content wasn't added."
+								)
+							)
+						);
+					}
+				}
+				return theme;
+			} )
 			.then( ( theme ) => {
 				// Fall back to ID for Jetpack sites which don't return a stylesheet attr.
 				const themeStylesheet = theme.stylesheet || themeId;
 				dispatch(
-					themeActivated( themeStylesheet, siteId, source, purchased, styleVariationSlug )
+					themeActivated(
+						themeStylesheet,
+						siteId,
+						source,
+						purchased,
+						styleVariationSlug,
+						setupChoice
+					)
 				);
 
 				if ( showSuccessNotice ) {

--- a/client/state/themes/actions/activate-theme.jsx
+++ b/client/state/themes/actions/activate-theme.jsx
@@ -26,7 +26,7 @@ import { activateStyleVariation } from './activate-style-variation';
  * @param {string}  [options.source]     The source that is requesting theme activation, e.g. 'showcase'
  * @param {boolean} [options.purchased]  Whether the theme has been purchased prior to activation
  * @param {boolean} [options.showSuccessNotice]  Whether the theme has been purchased prior to activation
- * @param {'basic'|'full'} [options.setupChoice] The user's setup choice from the activation modal: `'full'` runs `/theme-setup` after activation to add the theme's extra demo content; `'basic'` skips it. Omit on direct activate paths that don't surface the choice (e.g., when the modal isn't shown).
+ * @param {'basic'|'full'} [options.setupChoice] The user's setup choice from the activation modal: `'full'` runs `/theme-headstart` after activation to add the theme's extra demo content; `'basic'` skips it. Omit on direct activate paths that don't surface the choice (e.g., when the modal isn't shown).
  * @returns {Function}        Action thunk
  */
 export function activateTheme( themeId, siteId, options = {} ) {
@@ -70,7 +70,7 @@ export function activateTheme( themeId, siteId, options = {} ) {
 				if ( setupChoice === 'full' ) {
 					try {
 						await wpcom.req.post( {
-							path: `/sites/${ siteId }/theme-setup/?_locale=user`,
+							path: `/sites/${ siteId }/theme-headstart/?_locale=user`,
 							apiNamespace: 'wpcom/v2',
 						} );
 					} catch ( error ) {

--- a/client/state/themes/actions/activate-theme.jsx
+++ b/client/state/themes/actions/activate-theme.jsx
@@ -49,6 +49,8 @@ export function activateTheme( themeId, siteId, options = {} ) {
 			siteId,
 		} );
 
+		let fullSetupFailed = false;
+
 		return wpcom.req
 			.post( `/sites/${ siteId }/themes/mine?_locale=user`, {
 				theme: themeId,
@@ -74,6 +76,7 @@ export function activateTheme( themeId, siteId, options = {} ) {
 							apiNamespace: 'wpcom/v2',
 						} );
 					} catch ( error ) {
+						fullSetupFailed = true;
 						dispatch(
 							errorNotice(
 								translate(
@@ -99,7 +102,10 @@ export function activateTheme( themeId, siteId, options = {} ) {
 					)
 				);
 
-				if ( showSuccessNotice ) {
+				// When the full-setup step failed, the partial-success error
+				// notice already conveys the outcome — skip the success notice
+				// so we don't show both at once.
+				if ( showSuccessNotice && ! fullSetupFailed ) {
 					dispatch(
 						successNotice(
 							translate( 'The %(themeName)s theme is activated successfully!', {

--- a/client/state/themes/actions/activate.js
+++ b/client/state/themes/actions/activate.js
@@ -23,6 +23,7 @@ import 'calypso/state/themes/init';
  * @param  {string}   [options.source]    The source that is requesting theme activation, e.g. 'showcase'
  * @param  {boolean}  [options.purchased] Whether the theme has been purchased prior to activation
  * @param  {boolean}  [options.isOnboardingFlow] Whether the activation happens in the onboarding flow
+ * @param  {'basic'|'full'} [options.setupChoice] The user's setup choice from the activation modal: `'full'` runs `/theme-setup` after activation to add the theme's extra demo content; `'basic'` skips it. Omit on direct activate paths that don't surface the choice (e.g., when the modal isn't shown).
  * @returns {Function}          Action thunk
  */
 export function activate( themeId, siteId, options ) {
@@ -33,6 +34,7 @@ export function activate( themeId, siteId, options ) {
 			isOnboardingFlow = typeof window !== 'undefined' &&
 				hasQueryArg( window.location.href, 'onboarding' ),
 			showSuccessNotice = true,
+			setupChoice,
 		} = options || {};
 		const isDotComTheme = !! getTheme( getState(), 'wpcom', themeId );
 		const isDotOrgTheme = !! getTheme( getState(), 'wporg', themeId );
@@ -76,6 +78,7 @@ export function activate( themeId, siteId, options ) {
 			source,
 			purchased,
 			showSuccessNotice,
+			setupChoice,
 		} )( dispatch, getState );
 	};
 }

--- a/client/state/themes/actions/activate.js
+++ b/client/state/themes/actions/activate.js
@@ -23,7 +23,7 @@ import 'calypso/state/themes/init';
  * @param  {string}   [options.source]    The source that is requesting theme activation, e.g. 'showcase'
  * @param  {boolean}  [options.purchased] Whether the theme has been purchased prior to activation
  * @param  {boolean}  [options.isOnboardingFlow] Whether the activation happens in the onboarding flow
- * @param  {'basic'|'full'} [options.setupChoice] The user's setup choice from the activation modal: `'full'` runs `/theme-setup` after activation to add the theme's extra demo content; `'basic'` skips it. Omit on direct activate paths that don't surface the choice (e.g., when the modal isn't shown).
+ * @param  {'basic'|'full'} [options.setupChoice] The user's setup choice from the activation modal: `'full'` runs `/theme-headstart` after activation to add the theme's extra demo content; `'basic'` skips it. Omit on direct activate paths that don't surface the choice (e.g., when the modal isn't shown).
  * @returns {Function}          Action thunk
  */
 export function activate( themeId, siteId, options ) {

--- a/client/state/themes/actions/theme-activated.js
+++ b/client/state/themes/actions/theme-activated.js
@@ -25,6 +25,7 @@ import 'calypso/state/themes/init';
  * @param  {string}   source             The source that is requesting theme activation, e.g. 'showcase'
  * @param  {boolean}  purchased          Whether the theme has been purchased prior to activation
  * @param  {string}   styleVariationSlug The theme style slug
+ * @param  {'basic'|'full'} [setupChoice] The user's setup choice from the activation modal. Surfaces on the Tracks event as `setup_choice`. Omit on direct activate paths that don't surface the choice (e.g., when the modal isn't shown).
  * @returns {Function}                   Action thunk
  */
 export function themeActivated(
@@ -32,7 +33,8 @@ export function themeActivated(
 	siteId,
 	source = 'unknown',
 	purchased = false,
-	styleVariationSlug
+	styleVariationSlug,
+	setupChoice
 ) {
 	const action = {
 		type: THEME_ACTIVATE_SUCCESS,
@@ -62,6 +64,11 @@ export function themeActivated(
 			style_variation_slug: styleVariationSlug || '',
 			theme_type: getThemeType( getState(), themeId ),
 			theme_tier: getThemeTierForTheme( getState(), themeId )?.slug,
+			// Only include the modal-driven `setup_choice` when the activation
+			// was initiated with an explicit choice. Direct activate paths
+			// (e.g., when the modal isn't shown) pass undefined and the prop
+			// is omitted from the payload.
+			...( setupChoice !== undefined && { setup_choice: setupChoice } ),
 		} );
 		dispatch( withAnalytics( trackThemeActivation, action ) );
 

--- a/client/state/themes/selectors/index.js
+++ b/client/state/themes/selectors/index.js
@@ -70,6 +70,7 @@ export { isValidThemeFilterTerm } from 'calypso/state/themes/selectors/is-valid-
 export { isWpcomTheme } from 'calypso/state/themes/selectors/is-wpcom-theme';
 export { isWporgTheme } from 'calypso/state/themes/selectors/is-wporg-theme';
 export { prependThemeFilterKeys } from 'calypso/state/themes/selectors/prepend-theme-filter-keys';
+export { shouldShowActivationModal } from 'calypso/state/themes/selectors/should-show-activation-modal';
 export { shouldShowAtomicTransferDialog } from 'calypso/state/themes/selectors/should-show-atomic-transfer-dialog';
 export { shouldShowTryAndCustomize } from 'calypso/state/themes/selectors/should-show-try-and-customize';
 export { themePreviewVisibility } from 'calypso/state/themes/selectors/theme-preview-visibility';

--- a/client/state/themes/selectors/should-show-activation-modal.ts
+++ b/client/state/themes/selectors/should-show-activation-modal.ts
@@ -1,3 +1,5 @@
+import { englishLocales } from '@automattic/i18n-utils';
+import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getCanonicalTheme } from 'calypso/state/themes/selectors/get-canonical-theme';
@@ -13,6 +15,9 @@ import type { AppState } from 'calypso/types';
  *   Simple sites, so the "full setup" choice wouldn't apply elsewhere.
  * - Theme has `supports_theme_switch_headstart`: server-side opt-in that the
  *   theme has headstart content to install on full activation.
+ * - User's locale is English: temporary gate while modal copy translations
+ *   land and while content produced by the full-setup path is still not
+ *   reliably translated. Remove once both are resolved.
  */
 export function shouldShowActivationModal(
 	state: AppState,
@@ -22,5 +27,7 @@ export function shouldShowActivationModal(
 	const theme = getCanonicalTheme( state, siteId, themeId );
 	const isAtomic = !! isSiteWpcomAtomic( state, siteId );
 	const isJetpack = !! isJetpackSite( state, siteId );
-	return ! isAtomic && ! isJetpack && !! theme?.supports_theme_switch_headstart;
+	const localeSlug = getCurrentLocaleSlug( state );
+	const isEnglish = ! localeSlug || englishLocales.includes( localeSlug );
+	return ! isAtomic && ! isJetpack && !! theme?.supports_theme_switch_headstart && isEnglish;
 }

--- a/client/state/themes/selectors/should-show-activation-modal.ts
+++ b/client/state/themes/selectors/should-show-activation-modal.ts
@@ -1,0 +1,26 @@
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getCanonicalTheme } from 'calypso/state/themes/selectors/get-canonical-theme';
+import 'calypso/state/themes/init';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Returns whether the activation modal makes sense for this theme on this
+ * site. Callers fall through to direct activation when this returns false.
+ *
+ * Conditions:
+ * - Site is not Atomic and not Jetpack: `/theme-headstart` only exists on
+ *   Simple sites, so the "full setup" choice wouldn't apply elsewhere.
+ * - Theme has `supports_theme_switch_headstart`: server-side opt-in that the
+ *   theme has headstart content to install on full activation.
+ */
+export function shouldShowActivationModal(
+	state: AppState,
+	siteId: number,
+	themeId: string
+): boolean {
+	const theme = getCanonicalTheme( state, siteId, themeId );
+	const isAtomic = !! isSiteWpcomAtomic( state, siteId );
+	const isJetpack = !! isJetpackSite( state, siteId );
+	return ! isAtomic && ! isJetpack && !! theme?.supports_theme_switch_headstart;
+}

--- a/client/types.ts
+++ b/client/types.ts
@@ -63,6 +63,7 @@ export interface Theme {
 	};
 	trending_rank: number;
 	version: string;
+	supports_theme_switch_headstart?: boolean;
 }
 
 interface MarketplaceThemeProductDetails {


### PR DESCRIPTION
This is part of fixing phcsdm-1qF-p2.

## Proposed Changes

This pull request reintroduces a theme activation modal that lets users preview and choose between activating a theme's styling only ("Basic setup") or also installing extra demo content ("Full setup"), for themes that choose to support this feature via a `supports_theme_switch_headstart` property in the theme API endpoints. The modal is skipped on Jetpack/Atomic sites, where the "Full setup" option is not supported. In addition, Tracks events for interacting with the modal have been added.  The modal is loosely based on the one that was originally added in https://github.com/Automattic/wp-calypso/pull/53796 and https://github.com/Automattic/wp-calypso/pull/53959 and then removed in https://github.com/Automattic/wp-calypso/pull/77881.

_**This pull request adds all the functionality for the modal, but note that it isn't turned on for anyone yet (that will happen via server-side code).**_

Visually, the new modal looks like this (using the Jaida theme as an example, since that shows an interesting difference between the two options):

<img width="1311" height="694" alt="jaida" src="https://github.com/user-attachments/assets/1317bb01-dae7-481e-b7f9-81dea30b1f18" />

## Why are these changes being made?

For some WordPress.com themes in particular, activating that theme looks nothing like the screenshot or demo that was shown to you before you activated it.  The goal here is to give users an option to get closer to the design that they originally thought they were starting out with.

## Testing Instructions

To test this requires 218019-ghe-Automattic/wpcom and 218926-ghe-Automattic/wpcom to be applied on the server (and then you will need to modify `wpcom_get_theme_switch_headstart_theme_list()` on the server to return the themes you want to test with -- note that `pub/twentytwentytwo` is a good one to use for testing since it already has the plumbing required to make the "Full setup" option work correctly).

Currently you will also need to have your user account set to English in order to test this.  That is a temporary measure until translations are finished, and until some server-side issues get fixed that prevent the "Full setup" option from working well on non-English sites.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?