### PR TITLE
Dashboard: sort plan filter options from biggest to smallest

### DIFF
--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -121,10 +121,31 @@ function getDefaultFields( {
 					{}
 				);
 
-				return Object.entries( elements ).map( ( [ label, value ] ) => ( {
+				const planOrder = [
+					'Commerce',
+					'Business',
+					'Premium',
+					'Personal',
+					'Free',
+					'Jetpack Free',
+					'Security (10GB)',
+					'No Plan',
+				];
+
+				const mapped = Object.entries( elements ).map( ( [ label, value ] ) => ( {
 					label,
 					value,
 				} ) );
+
+				return mapped.sort( ( a, b ) => {
+					const indexA = planOrder.indexOf( a.value );
+					const indexB = planOrder.indexOf( b.value );
+					// Unknown plans go to the end, before "No Plan"
+					return (
+						( indexA === -1 ? planOrder.length - 1 : indexA ) -
+						( indexB === -1 ? planOrder.length - 1 : indexB )
+					);
+				} );
 			},
 			filterBy: {
 				operators: [ 'isAny' ],

--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -138,8 +138,8 @@ function getDefaultFields( {
 				} ) );
 
 				return mapped.sort( ( a, b ) => {
-					const indexA = planOrder.indexOf( a.value );
-					const indexB = planOrder.indexOf( b.value );
+					const indexA = planOrder.indexOf( a.label );
+					const indexB = planOrder.indexOf( b.label );
 					// Unknown plans go to the end, before "No Plan"
 					return (
 						( indexA === -1 ? planOrder.length - 1 : indexA ) -

--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -159,15 +159,15 @@ function getDefaultFields( {
 
 				return mapped.sort( ( a, b ) => {
 					// "No Plan" always sorts last.
-					if ( a.label === 'No Plan' ) {
+					if ( a.value === 'No Plan' ) {
 						return 1;
 					}
-					if ( b.label === 'No Plan' ) {
+					if ( b.value === 'No Plan' ) {
 						return -1;
 					}
 
-					const indexA = planOrder.indexOf( a.label );
-					const indexB = planOrder.indexOf( b.label );
+					const indexA = planOrder.indexOf( a.value );
+					const indexB = planOrder.indexOf( b.value );
 					const rankA = indexA === -1 ? planOrder.length : indexA;
 					const rankB = indexB === -1 ? planOrder.length : indexB;
 

--- a/client/dashboard/sites/dataviews/fields.tsx
+++ b/client/dashboard/sites/dataviews/fields.tsx
@@ -122,14 +122,34 @@ function getDefaultFields( {
 				);
 
 				const planOrder = [
+					// WordPress.com plans, highest tier to lowest.
+					'Enterprise',
+					'100-Year',
 					'Commerce',
 					'Business',
+					'Pro',
 					'Premium',
 					'Personal',
+					'Starter',
+					'Blogger',
 					'Free',
-					'Jetpack Free',
+					// Jetpack plans, highest tier to lowest.
+					'Jetpack Complete',
+					'Security (1TB)',
 					'Security (10GB)',
-					'No Plan',
+					'Akismet',
+					'Backup',
+					'Boost',
+					'Search',
+					'Social',
+					'Stats',
+					'VideoPress',
+					'Growth',
+					'Jetpack Starter',
+					'Jetpack Personal',
+					'Jetpack Premium',
+					'Jetpack Professional',
+					'Jetpack Free',
 				];
 
 				const mapped = Object.entries( elements ).map( ( [ label, value ] ) => ( {
@@ -138,13 +158,25 @@ function getDefaultFields( {
 				} ) );
 
 				return mapped.sort( ( a, b ) => {
+					// "No Plan" always sorts last.
+					if ( a.label === 'No Plan' ) {
+						return 1;
+					}
+					if ( b.label === 'No Plan' ) {
+						return -1;
+					}
+
 					const indexA = planOrder.indexOf( a.label );
 					const indexB = planOrder.indexOf( b.label );
-					// Unknown plans go to the end, before "No Plan"
-					return (
-						( indexA === -1 ? planOrder.length - 1 : indexA ) -
-						( indexB === -1 ? planOrder.length - 1 : indexB )
-					);
+					const rankA = indexA === -1 ? planOrder.length : indexA;
+					const rankB = indexB === -1 ? planOrder.length : indexB;
+
+					if ( rankA !== rankB ) {
+						return rankA - rankB;
+					}
+
+					// Same rank (both unknown): alphabetical by label.
+					return a.label.localeCompare( b.label );
 				} );
 			},
 			filterBy: {


### PR DESCRIPTION
Fixes: https://linear.app/a8c/issue/CHE-479/fix-plan-order

## Summary

The current plan filter list is not ordered in any logical way. It always takes me a moment to find what I'm looking for. This PR reorders the list from the most expensive plan to the cheapest. 

| Before | After | 
| -- | -- |
| <img width="2672" height="1522" alt="image" src="https://github.com/user-attachments/assets/48414d8d-a4e8-4216-8a1b-7c556902e963" /> | <img width="2672" height="1522" alt="image" src="https://github.com/user-attachments/assets/379fd3b8-ea5c-47dc-9275-15c83ff9fa2d" /> |
| <img width="2672" height="1522" alt="image" src="https://github.com/user-attachments/assets/a08720be-ea5f-4c25-9d57-28beb47d864d" /> | <img width="2672" height="1522" alt="image" src="https://github.com/user-attachments/assets/1dc28206-c29f-4418-b500-1a0d5a35afe8" /> |


## Testing

Open `my.localhost:3000/sites` → Add filter → Plan. Confirm dropdown shows plans in the order above (only plans your account has sites on will appear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)