### PR TITLE
Reader ATmosphere: re-enable Quote post menu item in repost dropdown

### DIFF
--- a/client/reader/atmosphere/use-atmosphere-repost-action.ts
+++ b/client/reader/atmosphere/use-atmosphere-repost-action.ts
@@ -180,8 +180,22 @@ export function makeUseAtmosphereRepostAction( connectionId: number ): UseRepost
 			);
 		};
 
+		// Composer-driven quote handler is provided by the panel via the
+		// analytics context (`onQuoteClick`). The menu item is only active
+		// when the panel has wired the composer AND the post carries the
+		// `cid` strong-ref the composer needs to mint an AT-Proto quote.
+		const onQuoteClick = analytics?.onQuoteClick;
+		const canQuote = Boolean( post.cid && onQuoteClick );
+
 		const quote = () => {
-			// Slice-7d work — disabled menu item for now. No-op.
+			if ( ! canQuote || ! onQuoteClick ) {
+				return;
+			}
+			analytics?.onClick( `calypso_reader_${ analytics.source }_quote_clicked`, {
+				connection_id: connectionId,
+				post_uri: post.uri,
+			} );
+			onQuoteClick( post );
 		};
 
 		const accessibleLabel = ( count: number, reposted: boolean ) => {
@@ -207,7 +221,7 @@ export function makeUseAtmosphereRepostAction( connectionId: number ): UseRepost
 				action: translate( 'Repost' ),
 				accessibleLabel,
 			},
-			canQuote: false, // slice-7d
+			canQuote,
 			repost,
 			unrepost,
 			quote,

--- a/client/reader/social/AGENTS.md
+++ b/client/reader/social/AGENTS.md
@@ -336,9 +336,11 @@ Two render branches by viewer state:
   toggle is the same shape of button (`aria-haspopup="menu"`). The menu
   has two `<MenuItem>`s: the action item (label provided by the adapter
   — "Repost" for ATmosphere, "Boost" for Mastodon) and "Quote post"
-  (disabled when `action.canQuote === false` — true today for both
-  protocols; ATmosphere wires up in slice 7d, Mastodon has no native
-  quote concept).
+  (disabled when `action.canQuote === false`). ATmosphere reports
+  `canQuote: true` when the panel has wired `onQuoteClick` on the
+  analytics context AND the post carries a `cid`; clicking the item
+  opens the same composer as the standalone `<QuoteButton>`. Mastodon
+  has no native quote concept and reports `canQuote: false` always.
 
 Each protocol shell wires its own adapter hook factory:
 
@@ -350,7 +352,9 @@ Each protocol shell wires its own adapter hook factory:
   DELETE with a fake rkey), guards the create on missing `post.cid`, and
   emits the labels "Repost" / "Repost, %d repost(s)" / "Undo repost, %d
   repost(s)". Tracks events: `_repost_clicked`, `_unrepost_clicked`,
-  `_repost_error_shown`.
+  `_quote_clicked`, `_repost_error_shown`. The `quote()` action delegates
+  to the analytics context's `onQuoteClick`, sharing the composer wiring
+  with the standalone `<QuoteButton>`.
 - Mastodon: `client/reader/mastodon/use-mastodon-repost-action.ts`
   exports `makeUseMastodonRepostAction(connectionId)`. It calls
   `useCreateMastodonRepostMutation()` / `useDeleteMastodonRepostMutation()`,

--- a/client/reader/social/components/post-card/test/repost-button.test.tsx
+++ b/client/reader/social/components/post-card/test/repost-button.test.tsx
@@ -309,12 +309,16 @@ describe( '<RepostButton>', () => {
 	it( 'leaves "Quote post" disabled when the post is missing a cid', async () => {
 		const onQuoteClick = jest.fn();
 		const user = userEvent.setup();
-		renderRepostButton( makePost( { cid: '' } ), { onQuoteClick } );
+		const { onClick } = renderRepostButton( makePost( { cid: '' } ), { onQuoteClick } );
 		await user.click( screen.getByRole( 'button', { name: /repost, 4 reposts/i } ) );
 		const item = await screen.findByRole( 'menuitem', { name: /quote post/i } );
 		expect( item ).toHaveAttribute( 'aria-disabled', 'true' );
 		await user.click( item );
 		expect( onQuoteClick ).not.toHaveBeenCalled();
+		expect( onClick ).not.toHaveBeenCalledWith(
+			'calypso_reader_atmosphere_quote_clicked',
+			expect.anything()
+		);
 	} );
 
 	it( 'enables "Quote post" and invokes onQuoteClick when the analytics context wires it', async () => {

--- a/client/reader/social/components/post-card/test/repost-button.test.tsx
+++ b/client/reader/social/components/post-card/test/repost-button.test.tsx
@@ -59,18 +59,20 @@ function makeQueryClient() {
 
 function renderRepostButton(
 	post = makePost(),
-	{ onClick = jest.fn() }: { onClick?: jest.Mock } = {}
+	{ onClick = jest.fn(), onQuoteClick }: { onClick?: jest.Mock; onQuoteClick?: jest.Mock } = {}
 ) {
 	const useRepostAction = makeUseAtmosphereRepostAction( 42 );
 	const socialPost = mapAtmosphereFeedItemToSocialPost( post );
 	return {
 		onClick,
+		onQuoteClick,
 		...renderWithProvider(
 			<SocialAnalyticsProvider
 				value={ {
 					source: 'atmosphere',
 					connectionId: 42,
 					onClick,
+					onQuoteClick,
 				} }
 			>
 				<RepostProvider value={ useRepostAction }>
@@ -296,19 +298,42 @@ describe( '<RepostButton>', () => {
 		expect( errorNoticeSpy ).toHaveBeenCalledWith( 'Reconnect your Bluesky account to repost.' );
 	} );
 
-	// The dropdown's "Quote post" menu item is disabled when the adapter
-	// reports `canQuote === false`. The atmosphere adapter sets `canQuote:
-	// false` until slice 7d wires composer-driven quoting, so this is the
-	// only case the cm-660 design covers today. The previously passing
-	// "enables Quote post via onQuote prop" test was replaced when the
-	// RepostButton signature lost its `onQuote` prop in favour of the
-	// adapter contract.
-	it( 'leaves "Quote post" disabled when the adapter reports canQuote=false', async () => {
+	it( 'leaves "Quote post" disabled when no onQuoteClick is wired in the analytics context', async () => {
 		const user = userEvent.setup();
 		renderRepostButton();
 		await user.click( screen.getByRole( 'button', { name: /repost, 4 reposts/i } ) );
 		const item = await screen.findByRole( 'menuitem', { name: /quote post/i } );
 		expect( item ).toHaveAttribute( 'aria-disabled', 'true' );
+	} );
+
+	it( 'leaves "Quote post" disabled when the post is missing a cid', async () => {
+		const onQuoteClick = jest.fn();
+		const user = userEvent.setup();
+		renderRepostButton( makePost( { cid: '' } ), { onQuoteClick } );
+		await user.click( screen.getByRole( 'button', { name: /repost, 4 reposts/i } ) );
+		const item = await screen.findByRole( 'menuitem', { name: /quote post/i } );
+		expect( item ).toHaveAttribute( 'aria-disabled', 'true' );
+		await user.click( item );
+		expect( onQuoteClick ).not.toHaveBeenCalled();
+	} );
+
+	it( 'enables "Quote post" and invokes onQuoteClick when the analytics context wires it', async () => {
+		const onQuoteClick = jest.fn();
+		const user = userEvent.setup();
+		const { onClick } = renderRepostButton( makePost(), { onQuoteClick } );
+		await user.click( screen.getByRole( 'button', { name: /repost, 4 reposts/i } ) );
+		const item = await screen.findByRole( 'menuitem', { name: 'Quote post' } );
+		expect( item ).not.toHaveAttribute( 'aria-disabled', 'true' );
+
+		await user.click( item );
+		expect( onQuoteClick ).toHaveBeenCalledTimes( 1 );
+		expect( onQuoteClick.mock.calls[ 0 ][ 0 ] ).toEqual(
+			expect.objectContaining( { uri: POST_URI, cid: POST_CID } )
+		);
+		expect( onClick ).toHaveBeenCalledWith(
+			'calypso_reader_atmosphere_quote_clicked',
+			expect.objectContaining( { connection_id: 42, post_uri: POST_URI } )
+		);
 	} );
 
 	it( 'click does not bubble to a parent listener', async () => {


### PR DESCRIPTION
Fixes CM-674.
Related to CM-655 (the original quote-composer slice, PR #110423).

## Proposed Changes

* `client/reader/atmosphere/use-atmosphere-repost-action.ts` — `canQuote` now derives from `Boolean( post.cid && analytics?.onQuoteClick )`. `quote()` calls `analytics.onQuoteClick( post )` and emits `calypso_reader_atmosphere_quote_clicked` so the menu-item path is observable alongside the existing `_repost_clicked` / `_unrepost_clicked` events. The stale `// slice-7d` comments are dropped.
* `client/reader/social/components/post-card/test/repost-button.test.tsx` — the apologetic "leaves Quote post disabled" test is replaced by three: disabled with no `onQuoteClick`, disabled with no `cid`, and enabled + invokes `onQuoteClick(post)` + fires the new Tracks event when both are present.
* `client/reader/social/AGENTS.md` — updates the `<RepostButton>` description to reflect the now-active path and adds `_quote_clicked` to the Tracks event list.

## Why are these changes being made?

PR #110423 (slice 7d, CM-655) shipped the Quote-post composer and wired an `onQuote` prop into `<RepostButton>`. PR #110404 (CM-660, Mastodon boost frontend) merged a few hours later and refactored `<RepostButton>` to read from a per-protocol adapter via `RepostContext`. In that refactor the new ATmosphere adapter was created with `canQuote: false` and a `// slice-7d` comment, as if slice 7d were still pending — it wasn't. The dropdown's "Quote post" menu item has been permanently disabled on trunk since.

The standalone `<QuoteButton>` (the quote count) was unaffected because it reads `onQuoteClick` from the analytics context directly. This PR routes the dropdown menu item through the same handler so both surfaces open the same composer.

The Mastodon adapter is intentionally untouched (`canQuote: false` stays — Mastodon has no native quote concept).

## Testing Instructions

Automated:

```
yarn test-client client/reader/social/components/post-card/test/repost-button.test.tsx
yarn test-client client/reader/atmosphere
```

Manual (requires a Bluesky-connected ATmosphere account):

1. Run `yarn start` and visit `/reader/atmosphere/<id>/thread/<did>/<rkey>`.
2. On any post, open the repost dropdown (the chevron button next to the repost count when not yet reposted).
3. Click "Quote post".
4. Confirm the composer opens in quote mode with the post preview attached, identical to clicking the quote-count button on the same card.
5. Confirm the Tracks event `calypso_reader_atmosphere_quote_clicked` fires with `connection_id` and `post_uri` props.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?