### PR TITLE
Reader Fediverse (C2S) — frontend (v0.1.0)

### DIFF
--- a/client/reader/components/icons/fediverse-icon.tsx
+++ b/client/reader/components/icons/fediverse-icon.tsx
@@ -1,0 +1,31 @@
+/**
+ * Renders the asterism glyph (U+2042) inside a 24×24 SVG so it slots into
+ * sidebar slots that expect a `sidebar__menu-icon`-classed inline SVG, the
+ * same shape used by the bluesky and mastodon sidebar icons.
+ */
+export function ReaderFediverseIcon() {
+	return (
+		<svg
+			className="sidebar__menu-icon sidebar_svg-fediverse"
+			height="24"
+			width="24"
+			viewBox="0 0 24 24"
+			xmlns="http://www.w3.org/2000/svg"
+			aria-hidden="true"
+			focusable="false"
+		>
+			<text
+				x="12"
+				y="12"
+				dy="0.05em"
+				textAnchor="middle"
+				dominantBaseline="central"
+				fontSize="22"
+				fontWeight="600"
+				fill="currentColor"
+			>
+				⁂
+			</text>
+		</svg>
+	);
+}

--- a/client/reader/components/icons/fediverse-icon.tsx
+++ b/client/reader/components/icons/fediverse-icon.tsx
@@ -17,11 +17,10 @@ export function ReaderFediverseIcon() {
 			<text
 				x="12"
 				y="12"
-				dy="0.05em"
 				textAnchor="middle"
 				dominantBaseline="central"
-				fontSize="22"
-				fontWeight="600"
+				fontSize="16"
+				fontWeight="700"
 				fill="currentColor"
 			>
 				⁂

--- a/client/reader/fediverse/analytics.ts
+++ b/client/reader/fediverse/analytics.ts
@@ -1,0 +1,22 @@
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+
+export const FEDIVERSE_EVENTS = {
+	CONNECT_STARTED: 'reader_fediverse_connect_started',
+	CAPABILITY_CHECK: 'reader_fediverse_capability_check',
+	FEATURE_ENABLED: 'reader_fediverse_feature_enabled',
+	C2S_ENABLED: 'reader_fediverse_c2s_enabled',
+	USER_ACTORS_ENABLED: 'reader_fediverse_user_actors_enabled',
+	AUTHORIZE_STARTED: 'reader_fediverse_authorize_started',
+	CONNECT_COMPLETED: 'reader_fediverse_connect_completed',
+	CONNECT_FAILED: 'reader_fediverse_connect_failed',
+	NOTE_POSTED: 'reader_fediverse_note_posted',
+	NOTE_FAILED: 'reader_fediverse_note_failed',
+	DISCONNECTED: 'reader_fediverse_disconnected',
+} as const;
+
+export function trackFediverseEvent(
+	event: keyof typeof FEDIVERSE_EVENTS,
+	props: Record< string, unknown > = {}
+) {
+	return recordReaderTracksEvent( FEDIVERSE_EVENTS[ event ], props );
+}

--- a/client/reader/fediverse/analytics.ts
+++ b/client/reader/fediverse/analytics.ts
@@ -1,17 +1,17 @@
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 
 export const FEDIVERSE_EVENTS = {
-	CONNECT_STARTED: 'reader_fediverse_connect_started',
-	CAPABILITY_CHECK: 'reader_fediverse_capability_check',
-	FEATURE_ENABLED: 'reader_fediverse_feature_enabled',
-	C2S_ENABLED: 'reader_fediverse_c2s_enabled',
-	USER_ACTORS_ENABLED: 'reader_fediverse_user_actors_enabled',
-	AUTHORIZE_STARTED: 'reader_fediverse_authorize_started',
-	CONNECT_COMPLETED: 'reader_fediverse_connect_completed',
-	CONNECT_FAILED: 'reader_fediverse_connect_failed',
-	NOTE_POSTED: 'reader_fediverse_note_posted',
-	NOTE_FAILED: 'reader_fediverse_note_failed',
-	DISCONNECTED: 'reader_fediverse_disconnected',
+	CONNECT_STARTED: 'calypso_reader_fediverse_connect_started',
+	CAPABILITY_CHECK: 'calypso_reader_fediverse_capability_check',
+	FEATURE_ENABLED: 'calypso_reader_fediverse_feature_enabled',
+	C2S_ENABLED: 'calypso_reader_fediverse_c2s_enabled',
+	USER_ACTORS_ENABLED: 'calypso_reader_fediverse_user_actors_enabled',
+	AUTHORIZE_STARTED: 'calypso_reader_fediverse_authorize_started',
+	CONNECT_COMPLETED: 'calypso_reader_fediverse_connect_completed',
+	CONNECT_FAILED: 'calypso_reader_fediverse_connect_failed',
+	NOTE_POSTED: 'calypso_reader_fediverse_note_posted',
+	NOTE_FAILED: 'calypso_reader_fediverse_note_failed',
+	DISCONNECTED: 'calypso_reader_fediverse_disconnected',
 } as const;
 
 export function trackFediverseEvent(

--- a/client/reader/fediverse/composer/compose-fab.tsx
+++ b/client/reader/fediverse/composer/compose-fab.tsx
@@ -1,0 +1,36 @@
+import { Button } from '@wordpress/components';
+import { edit } from '@wordpress/icons';
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import { useComposer } from './composer-provider';
+
+/**
+ * Floating Action Button that opens the composer.
+ *
+ * Stays mounted at all times — when a composer mode is active we hide it
+ * with `aria-hidden` + `tabIndex={ -1 }` and an `is-hidden` class for
+ * CSS-driven visibility. Unmounting would detach the trigger DOM node
+ * referenced by `<ComposerProvider>`'s `triggerRef`, which silently breaks
+ * focus restoration after the modal closes.
+ */
+export function ComposeFab() {
+	const translate = useTranslate();
+	const { mode, openComposer } = useComposer();
+	const isHidden = mode != null;
+
+	return (
+		<Button
+			className={ clsx( 'fediverse-compose-fab', { 'is-hidden': isHidden } ) }
+			icon={ edit }
+			text={ translate( 'Compose' ) as string }
+			aria-hidden={ isHidden || undefined }
+			tabIndex={ isHidden ? -1 : undefined }
+			onClick={ () =>
+				openComposer( {
+					connectionId: 0, // overridden by ComposerProvider with its own connectionId
+					entry_point: 'fab',
+				} )
+			}
+		/>
+	);
+}

--- a/client/reader/fediverse/composer/compose-fab.tsx
+++ b/client/reader/fediverse/composer/compose-fab.tsx
@@ -25,12 +25,7 @@ export function ComposeFab() {
 			text={ translate( 'Compose' ) as string }
 			aria-hidden={ isHidden || undefined }
 			tabIndex={ isHidden ? -1 : undefined }
-			onClick={ () =>
-				openComposer( {
-					connectionId: 0, // overridden by ComposerProvider with its own connectionId
-					entry_point: 'fab',
-				} )
-			}
+			onClick={ () => openComposer( { entry_point: 'fab' } ) }
 		/>
 	);
 }

--- a/client/reader/fediverse/composer/composer-footer.tsx
+++ b/client/reader/fediverse/composer/composer-footer.tsx
@@ -35,20 +35,30 @@ export function ComposerFooter( { graphemeCount, onSubmit, isPending, softLimit 
 					// Only announce when the user is near or past the soft limit so
 					// screen readers don't read out the count on every keystroke.
 					aria-live={ remaining <= WARN_THRESHOLD_REMAINING ? 'polite' : 'off' }
-					// Visible text is the bare integer; the accessible label
-					// adds units so the live-region announcement is meaningful
-					// without relying on the surrounding visual context.
-					aria-label={ translate(
-						'%(count)d character remaining',
-						'%(count)d characters remaining',
-						{
-							count: remaining,
-							args: { count: remaining },
-							textOnly: true,
-							comment:
-								'Composer post-length counter; %(count)d is the integer count of characters still allowed before the soft limit. Negative when the user is over the soft limit.',
-						}
-					) }
+					// Plural rules in many locales don't define a form for
+					// negative counts, so we branch on sign and feed _n / sprintf
+					// a non-negative integer in either case.
+					aria-label={
+						remaining >= 0
+							? translate( '%(count)d character remaining', '%(count)d characters remaining', {
+									count: remaining,
+									args: { count: remaining },
+									textOnly: true,
+									comment:
+										'Composer post-length counter; %(count)d is characters remaining before the soft limit.',
+							  } )
+							: translate(
+									'%(count)d character over the recommended length',
+									'%(count)d characters over the recommended length',
+									{
+										count: -remaining,
+										args: { count: -remaining },
+										textOnly: true,
+										comment:
+											'Composer post-length counter when the user has typed past the soft limit; %(count)d is how many characters over.',
+									}
+							  )
+					}
 				>
 					{ remaining }
 				</span>

--- a/client/reader/fediverse/composer/composer-footer.tsx
+++ b/client/reader/fediverse/composer/composer-footer.tsx
@@ -1,0 +1,70 @@
+import { __experimentalHStack as HStack, Button, Spinner } from '@wordpress/components';
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+
+interface Props {
+	graphemeCount: number;
+	onSubmit: () => void;
+	isPending: boolean;
+	softLimit: number;
+}
+
+const WARN_THRESHOLD_REMAINING = 50;
+
+export function ComposerFooter( { graphemeCount, onSubmit, isPending, softLimit }: Props ) {
+	const translate = useTranslate();
+	const remaining = softLimit - graphemeCount;
+	const empty = graphemeCount === 0;
+	// For Fediverse Notes there is no hard character limit for v0.1.0.
+	// The button is only disabled when the field is empty or while posting.
+	const disabled = isPending || empty;
+
+	const countClass = clsx( 'fediverse-composer__count', {
+		'is-warn': remaining > 0 && remaining <= WARN_THRESHOLD_REMAINING,
+		// Show amber styling when over the soft limit, but never disable the button.
+		'is-over': remaining <= 0,
+	} );
+
+	return (
+		<HStack className="fediverse-composer__footer" justify="space-between" alignment="center">
+			<div className="fediverse-composer__footer-left" />
+			<HStack spacing={ 2 } className="fediverse-composer__footer-right">
+				<span
+					id="fediverse-composer-count"
+					className={ countClass }
+					// Only announce when the user is near or past the soft limit so
+					// screen readers don't read out the count on every keystroke.
+					aria-live={ remaining <= WARN_THRESHOLD_REMAINING ? 'polite' : 'off' }
+					// Visible text is the bare integer; the accessible label
+					// adds units so the live-region announcement is meaningful
+					// without relying on the surrounding visual context.
+					aria-label={ translate(
+						'%(count)d character remaining',
+						'%(count)d characters remaining',
+						{
+							count: remaining,
+							args: { count: remaining },
+							textOnly: true,
+							comment:
+								'Composer post-length counter; %(count)d is the integer count of characters still allowed before the soft limit. Negative when the user is over the soft limit.',
+						}
+					) }
+				>
+					{ remaining }
+				</span>
+				<Button
+					variant="primary"
+					disabled={ disabled }
+					onClick={ onSubmit }
+					// Visible "Post" label is the accessible name in the idle
+					// state; while pending the visible text is replaced by a
+					// presentation-only spinner, so the button needs an
+					// explicit accessible name.
+					aria-label={ isPending ? translate( 'Posting…' ) : undefined }
+				>
+					{ isPending ? <Spinner /> : translate( 'Post' ) }
+				</Button>
+			</HStack>
+		</HStack>
+	);
+}

--- a/client/reader/fediverse/composer/composer-modal.tsx
+++ b/client/reader/fediverse/composer/composer-modal.tsx
@@ -61,6 +61,12 @@ export function ComposerModal() {
 						err && typeof err === 'object' && 'kind' in err
 							? String( ( err as { kind: string } ).kind )
 							: 'unknown';
+					// Surface the underlying cause so an unclassified backend
+					// error doesn't disappear into a generic 'unknown' bucket.
+					if ( errorCode === 'unknown' ) {
+						// eslint-disable-next-line no-console
+						console.error( 'Fediverse note post failed (unclassified):', err );
+					}
 					dispatch(
 						trackFediverseEvent( 'NOTE_FAILED', {
 							connection_id: mode.connectionId,

--- a/client/reader/fediverse/composer/composer-modal.tsx
+++ b/client/reader/fediverse/composer/composer-modal.tsx
@@ -1,0 +1,165 @@
+import './style.scss';
+import { useCreateFediverseNoteMutation } from '@automattic/api-queries';
+import { Modal, Button, __experimentalHStack as HStack } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useDispatch } from 'calypso/state';
+import { successNotice } from 'calypso/state/notices/actions';
+import { trackFediverseEvent } from '../analytics';
+import { ComposerFooter } from './composer-footer';
+import { useComposer } from './composer-provider';
+import { ComposerTextarea } from './composer-textarea';
+import { countGraphemes } from './grapheme-count';
+
+const SOFT_LIMIT = 280;
+
+export function ComposerModal() {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const { mode, closeComposer } = useComposer();
+	const mutation = useCreateFediverseNoteMutation( mode?.connectionId ?? 0 );
+
+	const [ text, setText ] = useState( '' );
+	const [ confirmDiscard, setConfirmDiscard ] = useState( false );
+
+	useEffect( () => {
+		if ( ! mode ) {
+			setText( '' );
+			setConfirmDiscard( false );
+			mutation.reset();
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ mode ] );
+
+	const graphemeCount = useMemo( () => countGraphemes( text ), [ text ] );
+
+	const handleClose = useCallback( () => {
+		if ( mutation.isPending ) {
+			return;
+		}
+		if ( text.trim().length > 0 ) {
+			setConfirmDiscard( true );
+			return;
+		}
+		closeComposer();
+	}, [ mutation.isPending, text, closeComposer ] );
+
+	const handleSubmit = useCallback( () => {
+		if ( ! mode || mutation.isPending || graphemeCount === 0 ) {
+			return;
+		}
+		mutation.mutate(
+			{ connectionId: mode.connectionId, text },
+			{
+				onSuccess: () => {
+					dispatch( trackFediverseEvent( 'NOTE_POSTED', { connection_id: mode.connectionId } ) );
+					dispatch( successNotice( translate( 'Posted to the Fediverse' ) ) );
+					closeComposer();
+				},
+				onError: ( err: unknown ) => {
+					const errorCode =
+						err && typeof err === 'object' && 'kind' in err
+							? String( ( err as { kind: string } ).kind )
+							: 'unknown';
+					dispatch(
+						trackFediverseEvent( 'NOTE_FAILED', {
+							connection_id: mode.connectionId,
+							error: errorCode,
+						} )
+					);
+				},
+			}
+		);
+	}, [ mode, mutation, text, graphemeCount, closeComposer, dispatch, translate ] );
+
+	if ( ! mode ) {
+		return null;
+	}
+
+	const errorMessage = mutation.isError ? errorMessageFor( mutation.error, translate ) : null;
+
+	return (
+		<>
+			<Modal
+				title={ translate( 'New Note' ) as string }
+				onRequestClose={ handleClose }
+				className="fediverse-composer"
+				focusOnMount
+				size="medium"
+			>
+				<ComposerTextarea
+					value={ text }
+					onChange={ setText }
+					onSubmit={ handleSubmit }
+					placeholder={ translate( "What's happening?" ) as string }
+					disabled={ mutation.isPending }
+					aria-label={ translate( 'New Note' ) as string }
+					aria-describedby={
+						errorMessage
+							? 'fediverse-composer-error fediverse-composer-count'
+							: 'fediverse-composer-count'
+					}
+					aria-invalid={ errorMessage ? true : undefined }
+				/>
+				{ errorMessage && (
+					<div id="fediverse-composer-error" className="fediverse-composer__error" role="alert">
+						{ errorMessage }
+					</div>
+				) }
+				<ComposerFooter
+					graphemeCount={ graphemeCount }
+					onSubmit={ handleSubmit }
+					isPending={ mutation.isPending }
+					softLimit={ SOFT_LIMIT }
+				/>
+			</Modal>
+			{ confirmDiscard && (
+				<Modal
+					title={ translate( 'Discard draft?' ) as string }
+					onRequestClose={ () => setConfirmDiscard( false ) }
+					size="small"
+					className="fediverse-composer-discard"
+				>
+					<p>{ translate( 'Your draft will be lost.' ) }</p>
+					<HStack justify="flex-end" spacing={ 2 }>
+						<Button variant="tertiary" onClick={ () => setConfirmDiscard( false ) }>
+							{ translate( 'Keep editing' ) }
+						</Button>
+						<Button
+							variant="primary"
+							isDestructive
+							onClick={ () => {
+								setConfirmDiscard( false );
+								closeComposer();
+							} }
+						>
+							{ translate( 'Discard' ) }
+						</Button>
+					</HStack>
+				</Modal>
+			) }
+		</>
+	);
+}
+
+function errorMessageFor( err: unknown, t: ReturnType< typeof useTranslate > ): string {
+	if ( ! err || typeof err !== 'object' || ! ( 'kind' in err ) ) {
+		return t( 'Something went wrong. Please try again.' ) as string;
+	}
+	const kind = ( err as { kind: string } ).kind;
+	switch ( kind ) {
+		case 'note_empty':
+			return t( "We couldn't post an empty Note." ) as string;
+		case 'auth_required':
+		case 'auth_failed':
+			return t( 'Your Fediverse connection needs to be reconnected.' ) as string;
+		case 'rate_limited':
+			return t( "You're posting too quickly. Try again in a moment." ) as string;
+		case 'upstream_unavailable':
+			return t( 'The Fediverse site is taking longer than usual. Please try again.' ) as string;
+		case 'forbidden':
+			return t( "You don't have permission to post on this site." ) as string;
+		default:
+			return t( 'Something went wrong. Please try again.' ) as string;
+	}
+}

--- a/client/reader/fediverse/composer/composer-provider.tsx
+++ b/client/reader/fediverse/composer/composer-provider.tsx
@@ -1,0 +1,84 @@
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from 'react';
+import type { ReactNode } from 'react';
+
+export type ComposerEntryPoint = 'fab' | 'timeline_inline';
+
+export interface ComposerActiveMode {
+	connectionId: number;
+	entry_point: ComposerEntryPoint;
+}
+
+interface ComposerContextValue {
+	mode: ComposerActiveMode | null;
+	openComposer: ( mode: ComposerActiveMode ) => void;
+	closeComposer: () => void;
+}
+
+const ComposerContext = createContext< ComposerContextValue | null >( null );
+
+interface Props {
+	connectionId: number;
+	children: ReactNode;
+}
+
+export function ComposerProvider( { connectionId, children }: Props ) {
+	const [ mode, setMode ] = useState< ComposerActiveMode | null >( null );
+	const triggerRef = useRef< HTMLElement | null >( null );
+	const wasOpenRef = useRef( false );
+
+	useEffect( () => {
+		if ( mode ) {
+			wasOpenRef.current = true;
+			return;
+		}
+		if ( wasOpenRef.current ) {
+			wasOpenRef.current = false;
+			triggerRef.current?.focus();
+		}
+	}, [ mode ] );
+
+	const openComposer = useCallback(
+		( next: ComposerActiveMode ) => {
+			triggerRef.current = document.activeElement as HTMLElement | null;
+			// Always re-key with the connectionId from props so callers
+			// don't have to pass it through every openComposer call.
+			setMode( { ...next, connectionId } );
+		},
+		[ connectionId ]
+	);
+
+	const closeComposer = useCallback( () => setMode( null ), [] );
+
+	const value = useMemo(
+		() => ( { mode, openComposer, closeComposer } ),
+		[ mode, openComposer, closeComposer ]
+	);
+
+	return <ComposerContext.Provider value={ value }>{ children }</ComposerContext.Provider>;
+}
+
+export function useComposer(): ComposerContextValue {
+	const ctx = useContext( ComposerContext );
+	if ( ! ctx ) {
+		throw new Error( 'useComposer must be called inside <ComposerProvider>' );
+	}
+	return ctx;
+}
+
+/**
+ * Soft variant: returns `null` outside a `<ComposerProvider>` instead of
+ * throwing. Use this in components that opt into the composer when one
+ * is mounted but should still render fine in tests or shells that don't
+ * provide a composer.
+ */
+export function useOptionalComposer(): ComposerContextValue | null {
+	return useContext( ComposerContext );
+}

--- a/client/reader/fediverse/composer/composer-provider.tsx
+++ b/client/reader/fediverse/composer/composer-provider.tsx
@@ -18,7 +18,7 @@ export interface ComposerActiveMode {
 
 interface ComposerContextValue {
 	mode: ComposerActiveMode | null;
-	openComposer: ( mode: ComposerActiveMode ) => void;
+	openComposer: ( mode: Omit< ComposerActiveMode, 'connectionId' > ) => void;
 	closeComposer: () => void;
 }
 
@@ -46,10 +46,8 @@ export function ComposerProvider( { connectionId, children }: Props ) {
 	}, [ mode ] );
 
 	const openComposer = useCallback(
-		( next: ComposerActiveMode ) => {
+		( next: Omit< ComposerActiveMode, 'connectionId' > ) => {
 			triggerRef.current = document.activeElement as HTMLElement | null;
-			// Always re-key with the connectionId from props so callers
-			// don't have to pass it through every openComposer call.
 			setMode( { ...next, connectionId } );
 		},
 		[ connectionId ]

--- a/client/reader/fediverse/composer/composer-textarea.tsx
+++ b/client/reader/fediverse/composer/composer-textarea.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useRef } from 'react';
+
+// Keep in sync with `min-height` on `.fediverse-composer__textarea` in
+// `style.scss`. Inline `style.height` set by the autogrow effect would
+// otherwise win over the stylesheet for empty / single-line content.
+const MIN_HEIGHT_PX = 80;
+
+interface Props {
+	value: string;
+	onChange: ( value: string ) => void;
+	onSubmit: () => void;
+	placeholder: string;
+	disabled?: boolean;
+	'aria-label'?: string;
+	'aria-describedby'?: string;
+	'aria-invalid'?: boolean;
+}
+
+export function ComposerTextarea( {
+	value,
+	onChange,
+	onSubmit,
+	placeholder,
+	disabled,
+	'aria-label': ariaLabel,
+	'aria-describedby': ariaDescribedBy,
+	'aria-invalid': ariaInvalid,
+}: Props ) {
+	const ref = useRef< HTMLTextAreaElement | null >( null );
+
+	useEffect( () => {
+		ref.current?.focus();
+	}, [] );
+
+	useEffect( () => {
+		const el = ref.current;
+		if ( ! el ) {
+			return;
+		}
+		el.style.height = 'auto';
+		el.style.height = `${ Math.max( el.scrollHeight, MIN_HEIGHT_PX ) }px`;
+	}, [ value ] );
+
+	return (
+		<textarea
+			ref={ ref }
+			className="fediverse-composer__textarea"
+			value={ value }
+			placeholder={ placeholder }
+			disabled={ disabled }
+			aria-label={ ariaLabel }
+			aria-describedby={ ariaDescribedBy }
+			aria-invalid={ ariaInvalid }
+			onChange={ ( e ) => onChange( e.target.value ) }
+			onKeyDown={ ( e ) => {
+				if ( e.key === 'Enter' && ( e.metaKey || e.ctrlKey ) ) {
+					e.preventDefault();
+					onSubmit();
+				}
+			} }
+		/>
+	);
+}

--- a/client/reader/fediverse/composer/grapheme-count.ts
+++ b/client/reader/fediverse/composer/grapheme-count.ts
@@ -1,0 +1,22 @@
+const segmenter =
+	typeof Intl !== 'undefined' && typeof Intl.Segmenter !== 'undefined'
+		? new Intl.Segmenter( undefined, { granularity: 'grapheme' } )
+		: null;
+
+export function countGraphemes( text: string ): number {
+	if ( ! text ) {
+		return 0;
+	}
+	if ( segmenter ) {
+		let count = 0;
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		for ( const _ of segmenter.segment( text ) ) {
+			count++;
+		}
+		return count;
+	}
+	// Fallback for environments without Intl.Segmenter — count code points.
+	// This over-counts multi-codepoint graphemes but is a strict upper
+	// bound, so it errs toward "too long" which is safe.
+	return Array.from( text ).length;
+}

--- a/client/reader/fediverse/composer/index.ts
+++ b/client/reader/fediverse/composer/index.ts
@@ -1,0 +1,4 @@
+export { ComposerProvider, useComposer, useOptionalComposer } from './composer-provider';
+export { ComposerModal } from './composer-modal';
+export { ComposeFab } from './compose-fab';
+export type { ComposerActiveMode, ComposerEntryPoint } from './composer-provider';

--- a/client/reader/fediverse/composer/style.scss
+++ b/client/reader/fediverse/composer/style.scss
@@ -1,0 +1,85 @@
+.fediverse-compose-fab {
+	position: fixed;
+	inset-block-end: 40px;
+	// Align the FAB's trailing edge with the right edge of the centered
+	// `<Main>` content (max-width 720px, sitting in the content area to
+	// the right of the global sidebar) so the FAB tracks the column
+	// instead of hugging the far viewport edge on wide screens. On
+	// narrower viewports the calc goes negative and the `max()` floor
+	// clamps to a 24px gutter.
+	inset-inline-end: max(
+		24px,
+		calc((100vw - var(--sidebar-width-max, 0px) - 720px) / 2)
+	);
+	height: auto;
+	min-height: 40px;
+	padding: 8px 16px;
+	gap: 6px;
+	/* stylelint-disable-next-line scales/radii */
+	border-radius: 6px;
+	background: var(--studio-blue-50, #3858e9);
+	color: var(--studio-white, #fff);
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
+	// `.main` sits at z-index 20 in Calypso's global stacking scheme
+	// (see `_z-index.scss`), and the FAB is rendered as its sibling.
+	// Anything below 20 lets post images and embeds inside the feed
+	// paint over the FAB. 25 keeps it above feed content while staying
+	// under the modal/popover layer (>=30).
+	z-index: 25;
+	transition: background-color 150ms ease, box-shadow 150ms ease;
+
+	&:hover {
+		background: var(--studio-blue-60, #1d35b4);
+		color: var(--studio-white, #fff);
+	}
+
+	&:focus-visible {
+		outline: 2px solid var(--studio-blue-30, #7b90ff);
+		outline-offset: 2px;
+	}
+
+	&.is-hidden {
+		display: none;
+	}
+
+	svg {
+		fill: currentColor;
+	}
+}
+
+.fediverse-composer {
+	.fediverse-composer__textarea {
+		width: 100%;
+		min-height: 80px;
+		resize: none;
+		border: none;
+		outline: none;
+		font: inherit;
+		padding: 8px 0;
+		background: transparent;
+	}
+
+	.fediverse-composer__error {
+		color: #b32d2e;
+		padding: 0 12px;
+		margin-block: 8px;
+	}
+
+	.fediverse-composer__footer {
+		margin-block-start: 8px;
+	}
+
+	.fediverse-composer__count {
+		color: var(--studio-gray-50, #646970);
+		font-variant-numeric: tabular-nums;
+
+		&.is-warn {
+			color: #b26200;
+		}
+
+		&.is-over {
+			color: #b26200;
+			font-weight: 600;
+		}
+	}
+}

--- a/client/reader/fediverse/composer/test/compose-fab.test.tsx
+++ b/client/reader/fediverse/composer/test/compose-fab.test.tsx
@@ -71,11 +71,7 @@ function HarnessWithOpener( { connectionId = 42 }: { connectionId?: number } ) {
 
 function OpenerButton() {
 	const { openComposer } = useComposer();
-	return (
-		<button onClick={ () => openComposer( { connectionId: 0, entry_point: 'timeline_inline' } ) }>
-			open
-		</button>
-	);
+	return <button onClick={ () => openComposer( { entry_point: 'timeline_inline' } ) }>open</button>;
 }
 
 // ---------------------------------------------------------------------------

--- a/client/reader/fediverse/composer/test/compose-fab.test.tsx
+++ b/client/reader/fediverse/composer/test/compose-fab.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ComposeFab } from '../compose-fab';
+import { ComposerProvider, useComposer } from '../composer-provider';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+jest.mock( 'i18n-calypso', () => ( {
+	useTranslate: () => ( str: string ) => str,
+} ) );
+
+jest.mock( '@wordpress/components', () => {
+	const React = require( 'react' );
+	return {
+		Button: ( {
+			children,
+			onClick,
+			className,
+			text,
+			'aria-hidden': ariaHidden,
+			tabIndex,
+		}: {
+			children?: React.ReactNode;
+			onClick?: () => void;
+			className?: string;
+			text?: string;
+			icon?: unknown;
+			'aria-hidden'?: boolean;
+			tabIndex?: number;
+		} ) =>
+			React.createElement(
+				'button',
+				{ onClick, className, 'aria-hidden': ariaHidden, tabIndex },
+				text ?? children
+			),
+	};
+} );
+
+jest.mock( '@wordpress/icons', () => ( { edit: null } ) );
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function Harness( { connectionId = 42 }: { connectionId?: number } ) {
+	return (
+		<ComposerProvider connectionId={ connectionId }>
+			<ComposeFab />
+		</ComposerProvider>
+	);
+}
+
+/**
+ * Helper: also mounts a trigger consumer so we can open the composer via a
+ * separate button (simulating external openComposer calls), letting the FAB
+ * reach its hidden state.
+ */
+function HarnessWithOpener( { connectionId = 42 }: { connectionId?: number } ) {
+	return (
+		<ComposerProvider connectionId={ connectionId }>
+			<OpenerButton />
+			<ComposeFab />
+		</ComposerProvider>
+	);
+}
+
+function OpenerButton() {
+	const { openComposer } = useComposer();
+	return (
+		<button onClick={ () => openComposer( { connectionId: 0, entry_point: 'timeline_inline' } ) }>
+			open
+		</button>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe( '<ComposeFab>', () => {
+	it( 'renders a "Compose" button', () => {
+		render( <Harness /> );
+		expect( screen.getByRole( 'button', { name: 'Compose' } ) ).toBeVisible();
+	} );
+
+	it( 'clicking the FAB opens the composer with entry_point "fab"', async () => {
+		const user = userEvent.setup();
+
+		function Probe() {
+			const { mode } = useComposer();
+			return (
+				<span data-testid="mode">
+					{ mode ? `${ mode.entry_point }:${ mode.connectionId }` : 'none' }
+				</span>
+			);
+		}
+
+		render(
+			<ComposerProvider connectionId={ 7 }>
+				<Probe />
+				<ComposeFab />
+			</ComposerProvider>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Compose' } ) );
+		expect( screen.getByTestId( 'mode' ) ).toHaveTextContent( 'fab:7' );
+	} );
+
+	it( 'is visible when mode is null', () => {
+		render( <Harness /> );
+		const btn = screen.getByRole( 'button', { name: 'Compose' } );
+		expect( btn ).not.toHaveClass( 'is-hidden' );
+		expect( btn ).not.toHaveAttribute( 'aria-hidden' );
+	} );
+
+	it( 'becomes hidden (is-hidden class, aria-hidden, tabIndex=-1) when mode is non-null', async () => {
+		const user = userEvent.setup();
+		render( <HarnessWithOpener connectionId={ 42 } /> );
+
+		// Open the composer via the external opener.
+		await user.click( screen.getByRole( 'button', { name: 'open' } ) );
+
+		// The FAB is still in the DOM but visually and semantically hidden.
+		// Use querySelector because aria-hidden removes the element from the
+		// accessibility tree, making getByRole unreliable across RTL versions.
+		const fab = document.querySelector( '.fediverse-compose-fab' ) as HTMLElement;
+		expect( fab ).not.toBeNull();
+		expect( fab ).toHaveClass( 'is-hidden' );
+		expect( fab ).toHaveAttribute( 'aria-hidden' );
+		expect( fab ).toHaveAttribute( 'tabIndex', '-1' );
+	} );
+} );

--- a/client/reader/fediverse/composer/test/composer-modal.test.tsx
+++ b/client/reader/fediverse/composer/test/composer-modal.test.tsx
@@ -86,9 +86,7 @@ function TriggerAndModal() {
 	const { openComposer } = useComposer();
 	return (
 		<>
-			<button onClick={ () => openComposer( { connectionId: 0, entry_point: 'fab' } ) }>
-				open
-			</button>
+			<button onClick={ () => openComposer( { entry_point: 'fab' } ) }>open</button>
 			<ComposerModal />
 		</>
 	);

--- a/client/reader/fediverse/composer/test/composer-modal.test.tsx
+++ b/client/reader/fediverse/composer/test/composer-modal.test.tsx
@@ -1,0 +1,284 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { ComposerModal } from '../composer-modal';
+import { ComposerProvider, useComposer } from '../composer-provider';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// Mock analytics — recordReaderTracksEvent must return a plain Redux action.
+const mockRecordReaderTracksEvent = jest.fn( () => ( { type: 'TEST_TRACKS_EVENT' } ) );
+jest.mock( 'calypso/state/reader/analytics/actions', () => ( {
+	recordReaderTracksEvent: ( ...args: unknown[] ) => mockRecordReaderTracksEvent( ...args ),
+} ) );
+
+// Mock useDispatch from calypso/state so Redux store is not required.
+const mockDispatch = jest.fn( ( action ) => action );
+jest.mock( 'calypso/state', () => ( {
+	useDispatch: () => mockDispatch,
+} ) );
+
+// Mock i18n-calypso to avoid the interpolate-components dependency chain.
+jest.mock( 'i18n-calypso', () => ( {
+	useTranslate: () => ( str: string ) => str,
+} ) );
+
+// Mock @automattic/api-queries — expose mockMutate so tests can control it.
+const mockMutate = jest.fn();
+const mockReset = jest.fn();
+jest.mock( '@automattic/api-queries', () => ( {
+	useCreateFediverseNoteMutation: () => ( {
+		mutate: mockMutate,
+		isPending: false,
+		isError: false,
+		error: null,
+		reset: mockReset,
+	} ),
+} ) );
+
+// Mock @wordpress/components — keep only what the composer uses.
+jest.mock( '@wordpress/components', () => {
+	const React = require( 'react' );
+	return {
+		Modal: ( {
+			title,
+			children,
+			onRequestClose,
+		}: {
+			title: string;
+			children: React.ReactNode;
+			onRequestClose: () => void;
+		} ) =>
+			React.createElement(
+				'div',
+				{ role: 'dialog', 'aria-label': title },
+				React.createElement( 'button', { onClick: onRequestClose, 'aria-label': 'Close' } ),
+				children
+			),
+		Button: ( {
+			children,
+			onClick,
+			disabled,
+		}: {
+			children: React.ReactNode;
+			onClick?: () => void;
+			disabled?: boolean;
+		} ) => React.createElement( 'button', { onClick, disabled }, children ),
+		Spinner: () => React.createElement( 'span', null, '...' ),
+		__experimentalHStack: ( { children }: { children: React.ReactNode } ) =>
+			React.createElement( 'div', null, children ),
+	};
+} );
+
+// Mock @wordpress/icons to avoid svg imports.
+jest.mock( '@wordpress/icons', () => ( { edit: null } ) );
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function TriggerAndModal() {
+	const { openComposer } = useComposer();
+	return (
+		<>
+			<button onClick={ () => openComposer( { connectionId: 0, entry_point: 'fab' } ) }>
+				open
+			</button>
+			<ComposerModal />
+		</>
+	);
+}
+
+function Harness( { connectionId = 42 }: { connectionId?: number } ) {
+	return (
+		<ComposerProvider connectionId={ connectionId }>
+			<TriggerAndModal />
+		</ComposerProvider>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+describe( '<ComposerModal>', () => {
+	beforeEach( () => {
+		mockDispatch.mockClear();
+		mockRecordReaderTracksEvent.mockClear();
+		mockMutate.mockReset();
+		mockReset.mockReset();
+	} );
+
+	// -------------------------------------------------------------------------
+	// 1. Renders nothing until opened
+	// -------------------------------------------------------------------------
+
+	it( 'renders nothing when mode is null', () => {
+		renderWithProvider( <Harness /> );
+		expect( screen.queryByRole( 'dialog' ) ).toBeNull();
+	} );
+
+	// -------------------------------------------------------------------------
+	// 2. Happy path: type text, click Post → mutation called, notice dispatched,
+	//    modal closed.
+	// -------------------------------------------------------------------------
+
+	it( 'opens a dialog when triggered', async () => {
+		const user = userEvent.setup();
+		renderWithProvider( <Harness /> );
+		await user.click( screen.getByText( 'open' ) );
+		expect( screen.getByRole( 'dialog', { name: 'New Note' } ) ).toBeVisible();
+	} );
+
+	it( 'calls mutate with connectionId and text on Post click', async () => {
+		const user = userEvent.setup();
+		renderWithProvider( <Harness connectionId={ 42 } /> );
+		await user.click( screen.getByText( 'open' ) );
+		await user.type( screen.getByRole( 'textbox' ), 'Hello Fediverse' );
+		await user.click( screen.getByRole( 'button', { name: 'Post' } ) );
+
+		expect( mockMutate ).toHaveBeenCalledWith(
+			{ connectionId: 42, text: 'Hello Fediverse' },
+			expect.objectContaining( {
+				onSuccess: expect.any( Function ),
+				onError: expect.any( Function ),
+			} )
+		);
+	} );
+
+	it( 'dispatches successNotice and NOTE_POSTED tracking on success', async () => {
+		const user = userEvent.setup();
+
+		mockMutate.mockImplementation(
+			( _params: unknown, { onSuccess }: { onSuccess: () => void } ) => {
+				onSuccess();
+			}
+		);
+
+		renderWithProvider( <Harness connectionId={ 42 } /> );
+		await user.click( screen.getByText( 'open' ) );
+		await user.type( screen.getByRole( 'textbox' ), 'hi' );
+		await user.click( screen.getByRole( 'button', { name: 'Post' } ) );
+
+		await waitFor( () => expect( mockDispatch ).toHaveBeenCalledTimes( 2 ) );
+		expect( mockRecordReaderTracksEvent ).toHaveBeenCalledWith(
+			'calypso_reader_fediverse_note_posted',
+			expect.objectContaining( { connection_id: 42 } )
+		);
+		// Second dispatch should be the successNotice.
+		expect( mockDispatch.mock.calls[ 1 ][ 0 ] ).toEqual(
+			expect.objectContaining( { type: expect.any( String ) } )
+		);
+	} );
+
+	it( 'closes the modal after a successful post', async () => {
+		const user = userEvent.setup();
+
+		mockMutate.mockImplementation(
+			( _params: unknown, { onSuccess }: { onSuccess: () => void } ) => {
+				onSuccess();
+			}
+		);
+
+		renderWithProvider( <Harness /> );
+		await user.click( screen.getByText( 'open' ) );
+		await user.type( screen.getByRole( 'textbox' ), 'hi' );
+		await user.click( screen.getByRole( 'button', { name: 'Post' } ) );
+
+		await waitFor( () => expect( screen.queryByRole( 'dialog' ) ).toBeNull() );
+	} );
+
+	// -------------------------------------------------------------------------
+	// 3. Error path: error from mutation → error copy shown, modal stays open
+	// -------------------------------------------------------------------------
+
+	it( 'dispatches NOTE_FAILED tracking on error', async () => {
+		const user = userEvent.setup();
+
+		mockMutate.mockImplementation(
+			( _params: unknown, { onError }: { onError: ( err: unknown ) => void } ) => {
+				onError( { kind: 'rate_limited' } );
+			}
+		);
+
+		renderWithProvider( <Harness connectionId={ 42 } /> );
+		await user.click( screen.getByText( 'open' ) );
+		await user.type( screen.getByRole( 'textbox' ), 'hi' );
+		await user.click( screen.getByRole( 'button', { name: 'Post' } ) );
+
+		await waitFor( () =>
+			expect( mockRecordReaderTracksEvent ).toHaveBeenCalledWith(
+				'calypso_reader_fediverse_note_failed',
+				expect.objectContaining( { connection_id: 42, error: 'rate_limited' } )
+			)
+		);
+	} );
+
+	it( 'does not call mutate when text is empty', async () => {
+		const user = userEvent.setup();
+		renderWithProvider( <Harness /> );
+		await user.click( screen.getByText( 'open' ) );
+		// Post button should be disabled (no text typed) — try clicking anyway
+		// to confirm the guard.
+		const postBtn = screen.getByRole( 'button', { name: 'Post' } );
+		expect( postBtn ).toBeDisabled();
+		expect( mockMutate ).not.toHaveBeenCalled();
+	} );
+
+	// -------------------------------------------------------------------------
+	// 4. Discard confirm: non-empty text + close → discard dialog appears
+	// -------------------------------------------------------------------------
+
+	it( 'shows discard-confirm when closing with unsaved text', async () => {
+		const user = userEvent.setup();
+		renderWithProvider( <Harness /> );
+		await user.click( screen.getByText( 'open' ) );
+		await user.type( screen.getByRole( 'textbox' ), 'hi' );
+		// Click the modal's own close button.
+		await user.click( screen.getByRole( 'button', { name: 'Close' } ) );
+		expect( await screen.findByRole( 'dialog', { name: 'Discard draft?' } ) ).toBeVisible();
+	} );
+
+	it( '"Keep editing" returns to the draft with text preserved', async () => {
+		const user = userEvent.setup();
+		renderWithProvider( <Harness /> );
+		await user.click( screen.getByText( 'open' ) );
+		await user.type( screen.getByRole( 'textbox' ), 'hello' );
+		await user.click( screen.getByRole( 'button', { name: 'Close' } ) );
+
+		await user.click( await screen.findByRole( 'button', { name: /keep editing/i } ) );
+		// The original composer modal is still visible with the draft.
+		expect( screen.getByRole( 'dialog', { name: 'New Note' } ) ).toBeVisible();
+		expect( screen.getByRole( 'textbox' ) ).toHaveValue( 'hello' );
+		// The discard dialog is gone.
+		expect( screen.queryByRole( 'dialog', { name: 'Discard draft?' } ) ).toBeNull();
+	} );
+
+	it( '"Discard" closes both modals and clears the draft', async () => {
+		const user = userEvent.setup();
+		renderWithProvider( <Harness /> );
+		await user.click( screen.getByText( 'open' ) );
+		await user.type( screen.getByRole( 'textbox' ), 'hello' );
+		await user.click( screen.getByRole( 'button', { name: 'Close' } ) );
+
+		await user.click( await screen.findByRole( 'button', { name: /^discard$/i } ) );
+		await waitFor( () => expect( screen.queryByRole( 'dialog' ) ).toBeNull() );
+
+		// Reopening should start with a fresh draft.
+		await user.click( screen.getByText( 'open' ) );
+		expect( screen.getByRole( 'textbox' ) ).toHaveValue( '' );
+	} );
+
+	it( 'closes immediately when close button is pressed with empty text', async () => {
+		const user = userEvent.setup();
+		renderWithProvider( <Harness /> );
+		await user.click( screen.getByText( 'open' ) );
+		await user.click( screen.getByRole( 'button', { name: 'Close' } ) );
+		await waitFor( () => expect( screen.queryByRole( 'dialog' ) ).toBeNull() );
+	} );
+} );

--- a/client/reader/fediverse/composer/test/composer-provider.test.tsx
+++ b/client/reader/fediverse/composer/test/composer-provider.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, renderHook, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { ComposerProvider, useComposer, useOptionalComposer } from '../composer-provider';
+
+const wrap = ( connectionId: number ) =>
+	function Wrapper( { children }: { children: React.ReactNode } ) {
+		return <ComposerProvider connectionId={ connectionId }>{ children }</ComposerProvider>;
+	};
+
+describe( 'useComposer', () => {
+	it( 'starts with mode = null', () => {
+		const { result } = renderHook( () => useComposer(), { wrapper: wrap( 42 ) } );
+		expect( result.current.mode ).toBeNull();
+	} );
+
+	it( 'openComposer sets mode + connectionId; closeComposer clears it', () => {
+		const { result } = renderHook( () => useComposer(), { wrapper: wrap( 42 ) } );
+		act( () => {
+			result.current.openComposer( { connectionId: 0, entry_point: 'fab' } );
+		} );
+		expect( result.current.mode ).toMatchObject( {
+			connectionId: 42,
+			entry_point: 'fab',
+		} );
+		act( () => result.current.closeComposer() );
+		expect( result.current.mode ).toBeNull();
+	} );
+
+	it( 'stamps the provider connectionId onto the mode, ignoring the caller-supplied one', () => {
+		const { result } = renderHook( () => useComposer(), { wrapper: wrap( 99 ) } );
+		act( () => {
+			// caller passes connectionId: 0 (the sentinel from ComposeFab)
+			result.current.openComposer( { connectionId: 0, entry_point: 'fab' } );
+		} );
+		expect( result.current.mode?.connectionId ).toBe( 99 );
+	} );
+
+	it( 'entry_point is preserved on the mode', async () => {
+		const user = userEvent.setup();
+
+		function TestConsumer() {
+			const { mode, openComposer } = useComposer();
+			return (
+				<>
+					<button
+						onClick={ () => openComposer( { connectionId: 0, entry_point: 'timeline_inline' } ) }
+					>
+						open
+					</button>
+					<span data-testid="entry">{ mode?.entry_point ?? '' }</span>
+				</>
+			);
+		}
+
+		render(
+			<ComposerProvider connectionId={ 1 }>
+				<TestConsumer />
+			</ComposerProvider>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'open' } ) );
+		expect( screen.getByTestId( 'entry' ) ).toHaveTextContent( 'timeline_inline' );
+	} );
+
+	it( 'restores focus to the trigger after the composer closes', async () => {
+		const user = userEvent.setup();
+
+		function FocusHarness() {
+			const { openComposer, closeComposer, mode } = useComposer();
+			return (
+				<>
+					<button onClick={ () => openComposer( { connectionId: 0, entry_point: 'fab' } ) }>
+						open
+					</button>
+					{ mode && <button onClick={ closeComposer }>close</button> }
+				</>
+			);
+		}
+
+		render(
+			<ComposerProvider connectionId={ 42 }>
+				<FocusHarness />
+			</ComposerProvider>
+		);
+
+		const openBtn = screen.getByRole( 'button', { name: 'open' } );
+		openBtn.focus();
+		await user.click( openBtn );
+		const closeBtn = await screen.findByRole( 'button', { name: 'close' } );
+		await user.click( closeBtn );
+		expect( document.activeElement ).toBe( openBtn );
+	} );
+
+	it( 'throws if useComposer is called outside ComposerProvider', () => {
+		// Suppress the React error boundary console output for this assertion.
+		const spy = jest.spyOn( console, 'error' ).mockImplementation( () => undefined );
+		expect( () => renderHook( () => useComposer() ) ).toThrow();
+		spy.mockRestore();
+	} );
+
+	it( 'snapshots connectionId at open time and ignores later prop changes', async () => {
+		const user = userEvent.setup();
+
+		function Probe() {
+			const { mode } = useComposer();
+			return <div data-testid="probe">{ mode?.connectionId ?? 'closed' }</div>;
+		}
+
+		function Opener() {
+			const { openComposer } = useComposer();
+			return (
+				<button onClick={ () => openComposer( { connectionId: 0, entry_point: 'fab' } ) }>
+					open
+				</button>
+			);
+		}
+
+		function Harness() {
+			const [ connectionId, setConnectionId ] = useState( 42 );
+			return (
+				<>
+					<button onClick={ () => setConnectionId( 99 ) }>bump</button>
+					<ComposerProvider connectionId={ connectionId }>
+						<Probe />
+						<Opener />
+					</ComposerProvider>
+				</>
+			);
+		}
+
+		render( <Harness /> );
+		expect( screen.getByTestId( 'probe' ) ).toHaveTextContent( 'closed' );
+		await user.click( screen.getByRole( 'button', { name: 'open' } ) );
+		expect( screen.getByTestId( 'probe' ) ).toHaveTextContent( '42' );
+		await user.click( screen.getByRole( 'button', { name: 'bump' } ) );
+		// connectionId stays 42 (the snapshot at open time)
+		expect( screen.getByTestId( 'probe' ) ).toHaveTextContent( '42' );
+	} );
+} );
+
+describe( 'useOptionalComposer', () => {
+	it( 'returns null outside a ComposerProvider', () => {
+		const { result } = renderHook( () => useOptionalComposer() );
+		expect( result.current ).toBeNull();
+	} );
+
+	it( 'returns the context value inside a ComposerProvider', () => {
+		const { result } = renderHook( () => useOptionalComposer(), { wrapper: wrap( 7 ) } );
+		expect( result.current ).not.toBeNull();
+		expect( result.current?.mode ).toBeNull();
+	} );
+} );

--- a/client/reader/fediverse/composer/test/composer-provider.test.tsx
+++ b/client/reader/fediverse/composer/test/composer-provider.test.tsx
@@ -20,7 +20,7 @@ describe( 'useComposer', () => {
 	it( 'openComposer sets mode + connectionId; closeComposer clears it', () => {
 		const { result } = renderHook( () => useComposer(), { wrapper: wrap( 42 ) } );
 		act( () => {
-			result.current.openComposer( { connectionId: 0, entry_point: 'fab' } );
+			result.current.openComposer( { entry_point: 'fab' } );
 		} );
 		expect( result.current.mode ).toMatchObject( {
 			connectionId: 42,
@@ -30,11 +30,10 @@ describe( 'useComposer', () => {
 		expect( result.current.mode ).toBeNull();
 	} );
 
-	it( 'stamps the provider connectionId onto the mode, ignoring the caller-supplied one', () => {
+	it( 'stamps the provider connectionId onto the mode', () => {
 		const { result } = renderHook( () => useComposer(), { wrapper: wrap( 99 ) } );
 		act( () => {
-			// caller passes connectionId: 0 (the sentinel from ComposeFab)
-			result.current.openComposer( { connectionId: 0, entry_point: 'fab' } );
+			result.current.openComposer( { entry_point: 'fab' } );
 		} );
 		expect( result.current.mode?.connectionId ).toBe( 99 );
 	} );
@@ -46,11 +45,7 @@ describe( 'useComposer', () => {
 			const { mode, openComposer } = useComposer();
 			return (
 				<>
-					<button
-						onClick={ () => openComposer( { connectionId: 0, entry_point: 'timeline_inline' } ) }
-					>
-						open
-					</button>
+					<button onClick={ () => openComposer( { entry_point: 'timeline_inline' } ) }>open</button>
 					<span data-testid="entry">{ mode?.entry_point ?? '' }</span>
 				</>
 			);
@@ -73,9 +68,7 @@ describe( 'useComposer', () => {
 			const { openComposer, closeComposer, mode } = useComposer();
 			return (
 				<>
-					<button onClick={ () => openComposer( { connectionId: 0, entry_point: 'fab' } ) }>
-						open
-					</button>
+					<button onClick={ () => openComposer( { entry_point: 'fab' } ) }>open</button>
 					{ mode && <button onClick={ closeComposer }>close</button> }
 				</>
 			);
@@ -112,11 +105,7 @@ describe( 'useComposer', () => {
 
 		function Opener() {
 			const { openComposer } = useComposer();
-			return (
-				<button onClick={ () => openComposer( { connectionId: 0, entry_point: 'fab' } ) }>
-					open
-				</button>
-			);
+			return <button onClick={ () => openComposer( { entry_point: 'fab' } ) }>open</button>;
 		}
 
 		function Harness() {

--- a/client/reader/fediverse/connect/capability-checklist.tsx
+++ b/client/reader/fediverse/connect/capability-checklist.tsx
@@ -14,7 +14,6 @@ const IN_FLIGHT_STATES: WizardStateName[] = [
 	'ENABLING_USER_ACTORS',
 	'AUTHORIZING',
 	'REDIRECTING',
-	'COMPLETING',
 ];
 
 function ChecklistIcon( { checked, spinning }: { checked: boolean; spinning: boolean } ) {

--- a/client/reader/fediverse/connect/capability-checklist.tsx
+++ b/client/reader/fediverse/connect/capability-checklist.tsx
@@ -1,0 +1,137 @@
+import { Button, Spinner, __experimentalVStack as VStack } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import type { WizardState, WizardStateName } from './wizard-types';
+
+interface Props {
+	state: WizardState;
+	onConnect: () => void;
+}
+
+const IN_FLIGHT_STATES: WizardStateName[] = [
+	'CHECKING_CAPABILITIES',
+	'ENABLING_FEATURE',
+	'ENABLING_C2S',
+	'ENABLING_USER_ACTORS',
+	'AUTHORIZING',
+	'REDIRECTING',
+	'COMPLETING',
+];
+
+function ChecklistIcon( { checked, spinning }: { checked: boolean; spinning: boolean } ) {
+	if ( spinning ) {
+		return <Spinner />;
+	}
+	if ( checked ) {
+		return <span aria-hidden="true">✓</span>;
+	}
+	return <span aria-hidden="true">☐</span>;
+}
+
+interface RowProps {
+	label: string;
+	checked: boolean;
+	spinning: boolean;
+}
+
+function ChecklistRow( { label, checked, spinning }: RowProps ) {
+	return (
+		<div className="fediverse-capability-checklist__row">
+			<ChecklistIcon checked={ checked } spinning={ spinning } />
+			<span>{ label }</span>
+		</div>
+	);
+}
+
+export function CapabilityChecklist( { state, onConnect }: Props ) {
+	const translate = useTranslate();
+
+	// While capabilities are still loading, show a spinner.
+	if ( state.name === 'CHECKING_CAPABILITIES' && state.capabilities === null ) {
+		return <Spinner />;
+	}
+
+	const caps = state.capabilities;
+	const currentName = state.name;
+
+	// Row 1: ActivityPub feature
+	const featureLabel =
+		caps?.site_kind === 'jetpack'
+			? translate( 'Install ActivityPub plugin' )
+			: translate( 'Enable ActivityPub feature' );
+	const featureChecked = caps?.activitypub_active ?? false;
+	const featureSpinning = currentName === 'ENABLING_FEATURE';
+
+	// Row 2: C2S API
+	const c2sLabel = translate( 'Enable Client-to-Server posting API' );
+	const c2sChecked = caps?.c2s_enabled ?? false;
+	const c2sSpinning = currentName === 'ENABLING_C2S';
+
+	// Row 3: Per-user actors
+	const actorsLabel = translate( 'Enable per-user accounts' );
+	const actorsChecked = caps?.actors.user.enabled ?? false;
+	const actorsSpinning = currentName === 'ENABLING_USER_ACTORS';
+
+	// Row 4: Authorize
+	const siteHost = caps?.site_host ?? '';
+	const authorizeLabel = translate( 'Authorize WordPress.com to post as @you@%(siteHost)s', {
+		args: { siteHost },
+	} );
+	const authorizeChecked = false;
+	const authorizeSpinning = currentName === 'AUTHORIZING' || currentName === 'REDIRECTING';
+
+	// Button state
+	const isInFlight = IN_FLIGHT_STATES.includes( currentName );
+
+	let buttonDisabled = isInFlight;
+	let disabledMessage: string | null = null;
+
+	if ( caps?.current_user_can_publish === false ) {
+		buttonDisabled = true;
+		disabledMessage = translate(
+			'You need permission to publish on this site to connect.'
+		) as string;
+	} else if ( caps?.actors.user.enabled === false && caps?.actors.user.can_enable === false ) {
+		buttonDisabled = true;
+		disabledMessage = translate(
+			'You need administrator permissions on this site to enable Fediverse posting.'
+		) as string;
+	}
+
+	return (
+		<VStack spacing={ 4 }>
+			<div className="fediverse-capability-checklist">
+				<ChecklistRow
+					label={ featureLabel as string }
+					checked={ featureChecked }
+					spinning={ featureSpinning }
+				/>
+				<ChecklistRow
+					label={ c2sLabel as string }
+					checked={ c2sChecked }
+					spinning={ c2sSpinning }
+				/>
+				<ChecklistRow
+					label={ actorsLabel as string }
+					checked={ actorsChecked }
+					spinning={ actorsSpinning }
+				/>
+				<ChecklistRow
+					label={ authorizeLabel as string }
+					checked={ authorizeChecked }
+					spinning={ authorizeSpinning }
+				/>
+			</div>
+			{ disabledMessage && (
+				<p className="fediverse-capability-checklist__disabled-message">{ disabledMessage }</p>
+			) }
+			<Button
+				variant="primary"
+				disabled={ buttonDisabled }
+				isBusy={ isInFlight }
+				onClick={ onConnect }
+			>
+				{ translate( 'Enable & Connect' ) }
+			</Button>
+		</VStack>
+	);
+}

--- a/client/reader/fediverse/connect/site-picker-step.tsx
+++ b/client/reader/fediverse/connect/site-picker-step.tsx
@@ -1,0 +1,32 @@
+/**
+ * @jest-environment jsdom
+ */
+import { __experimentalVStack as VStack } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import SiteSelector from 'calypso/components/site-selector';
+
+interface Props {
+	onPick: ( blogId: number ) => void;
+}
+
+export function SitePickerStep( { onPick }: Props ) {
+	const translate = useTranslate();
+
+	const handleSiteSelect = ( siteId: number ) => {
+		onPick( siteId );
+		// Return true so SiteSelector does not navigate away.
+		return true;
+	};
+
+	return (
+		<VStack spacing={ 4 }>
+			<h2>{ translate( 'Connect a Fediverse site' ) }</h2>
+			<p>
+				{ translate(
+					'Choose a WordPress.com site or a Jetpack-connected site to broadcast Notes from.'
+				) }
+			</p>
+			<SiteSelector onSiteSelect={ handleSiteSelect } />
+		</VStack>
+	);
+}

--- a/client/reader/fediverse/connect/site-picker-step.tsx
+++ b/client/reader/fediverse/connect/site-picker-step.tsx
@@ -1,6 +1,3 @@
-/**
- * @jest-environment jsdom
- */
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import SiteSelector from 'calypso/components/site-selector';

--- a/client/reader/fediverse/connect/test/capability-checklist.test.tsx
+++ b/client/reader/fediverse/connect/test/capability-checklist.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CapabilityChecklist } from '../capability-checklist';
+import { INITIAL_STATE } from '../wizard-state-machine';
+import type { WizardState } from '../wizard-types';
+import type { FediverseSiteCapabilities } from '@automattic/api-core';
+
+function makeCaps(
+	overrides: Partial< FediverseSiteCapabilities > = {}
+): FediverseSiteCapabilities {
+	return {
+		activitypub_active: true,
+		c2s_enabled: true,
+		actors: {
+			user: { enabled: true, can_enable: true },
+			blog: { enabled: false, can_enable: true },
+		},
+		oauth_metadata: null,
+		site_host: 'example.com',
+		site_kind: 'wpcom',
+		current_user_can_publish: true,
+		...overrides,
+	};
+}
+
+function makeState( overrides: Partial< WizardState > = {} ): WizardState {
+	return { ...INITIAL_STATE, ...overrides };
+}
+
+describe( 'CapabilityChecklist', () => {
+	describe( 'loading state', () => {
+		it( 'renders a spinner while capabilities are loading', () => {
+			const state = makeState( { name: 'CHECKING_CAPABILITIES', capabilities: null } );
+			render( <CapabilityChecklist state={ state } onConnect={ jest.fn() } /> );
+			expect( screen.getByRole( 'presentation' ) ).toBeVisible();
+			expect( screen.queryByRole( 'button', { name: /enable & connect/i } ) ).toBeNull();
+		} );
+	} );
+
+	describe( 'checklist rows', () => {
+		it( 'shows "Enable ActivityPub feature" for wpcom sites', () => {
+			const state = makeState( {
+				name: 'CHECKLIST_READY',
+				capabilities: makeCaps( { site_kind: 'wpcom' } ),
+			} );
+			render( <CapabilityChecklist state={ state } onConnect={ jest.fn() } /> );
+			expect( screen.getByText( /enable activitypub feature/i ) ).toBeVisible();
+		} );
+
+		it( 'shows "Install ActivityPub plugin" for jetpack sites', () => {
+			const state = makeState( {
+				name: 'CHECKLIST_READY',
+				capabilities: makeCaps( { site_kind: 'jetpack' } ),
+			} );
+			render( <CapabilityChecklist state={ state } onConnect={ jest.fn() } /> );
+			expect( screen.getByText( /install activitypub plugin/i ) ).toBeVisible();
+		} );
+
+		it( 'shows the C2S row label', () => {
+			const state = makeState( {
+				name: 'CHECKLIST_READY',
+				capabilities: makeCaps(),
+			} );
+			render( <CapabilityChecklist state={ state } onConnect={ jest.fn() } /> );
+			expect( screen.getByText( /enable client-to-server posting api/i ) ).toBeVisible();
+		} );
+
+		it( 'shows the per-user accounts row label', () => {
+			const state = makeState( {
+				name: 'CHECKLIST_READY',
+				capabilities: makeCaps(),
+			} );
+			render( <CapabilityChecklist state={ state } onConnect={ jest.fn() } /> );
+			expect( screen.getByText( /enable per-user accounts/i ) ).toBeVisible();
+		} );
+
+		it( 'shows the authorize row with site host placeholder', () => {
+			const state = makeState( {
+				name: 'CHECKLIST_READY',
+				capabilities: makeCaps( { site_host: 'my.site.com' } ),
+			} );
+			render( <CapabilityChecklist state={ state } onConnect={ jest.fn() } /> );
+			expect( screen.getByText( /@you@my\.site\.com/i ) ).toBeVisible();
+		} );
+	} );
+
+	describe( 'button state', () => {
+		it( 'enables the button when all capabilities are green', () => {
+			const state = makeState( {
+				name: 'CHECKLIST_READY',
+				capabilities: makeCaps(),
+			} );
+			render( <CapabilityChecklist state={ state } onConnect={ jest.fn() } /> );
+			expect( screen.getByRole( 'button', { name: /enable & connect/i } ) ).not.toBeDisabled();
+		} );
+
+		it( 'disables the button during CHECKING_CAPABILITIES when caps are present', () => {
+			// Simulate re-check with prior capabilities still in state
+			const state = makeState( {
+				name: 'CHECKING_CAPABILITIES',
+				capabilities: makeCaps(),
+			} );
+			render( <CapabilityChecklist state={ state } onConnect={ jest.fn() } /> );
+			expect( screen.getByRole( 'button', { name: /enable & connect/i } ) ).toBeDisabled();
+		} );
+
+		it( 'disables the button while ENABLING_FEATURE', () => {
+			const state = makeState( {
+				name: 'ENABLING_FEATURE',
+				capabilities: makeCaps( { activitypub_active: false } ),
+			} );
+			render( <CapabilityChecklist state={ state } onConnect={ jest.fn() } /> );
+			expect( screen.getByRole( 'button', { name: /enable & connect/i } ) ).toBeDisabled();
+		} );
+
+		it( 'disables the button while ENABLING_C2S', () => {
+			const state = makeState( {
+				name: 'ENABLING_C2S',
+				capabilities: makeCaps( { c2s_enabled: false } ),
+			} );
+			render( <CapabilityChecklist state={ state } onConnect={ jest.fn() } /> );
+			expect( screen.getByRole( 'button', { name: /enable & connect/i } ) ).toBeDisabled();
+		} );
+
+		it( 'disables the button while ENABLING_USER_ACTORS', () => {
+			const state = makeState( {
+				name: 'ENABLING_USER_ACTORS',
+				capabilities: makeCaps( {
+					actors: {
+						user: { enabled: false, can_enable: true },
+						blog: { enabled: false, can_enable: true },
+					},
+				} ),
+			} );
+			render( <CapabilityChecklist state={ state } onConnect={ jest.fn() } /> );
+			expect( screen.getByRole( 'button', { name: /enable & connect/i } ) ).toBeDisabled();
+		} );
+
+		it( 'disables the button with publish-permission message when current_user_can_publish is false', () => {
+			const state = makeState( {
+				name: 'CHECKLIST_READY',
+				capabilities: makeCaps( { current_user_can_publish: false } ),
+			} );
+			render( <CapabilityChecklist state={ state } onConnect={ jest.fn() } /> );
+			expect( screen.getByRole( 'button', { name: /enable & connect/i } ) ).toBeDisabled();
+			expect( screen.getByText( /you need permission to publish/i ) ).toBeVisible();
+		} );
+
+		it( 'disables the button with admin-permission message when actors.user.can_enable is false', () => {
+			const state = makeState( {
+				name: 'CHECKLIST_READY',
+				capabilities: makeCaps( {
+					current_user_can_publish: true,
+					actors: {
+						user: { enabled: false, can_enable: false },
+						blog: { enabled: false, can_enable: true },
+					},
+				} ),
+			} );
+			render( <CapabilityChecklist state={ state } onConnect={ jest.fn() } /> );
+			expect( screen.getByRole( 'button', { name: /enable & connect/i } ) ).toBeDisabled();
+			expect( screen.getByText( /administrator permissions/i ) ).toBeVisible();
+		} );
+	} );
+
+	describe( 'button interaction', () => {
+		it( 'calls onConnect when the button is clicked', async () => {
+			const user = userEvent.setup();
+			const onConnect = jest.fn();
+			const state = makeState( {
+				name: 'CHECKLIST_READY',
+				capabilities: makeCaps(),
+			} );
+			render( <CapabilityChecklist state={ state } onConnect={ onConnect } /> );
+			await user.click( screen.getByRole( 'button', { name: /enable & connect/i } ) );
+			expect( onConnect ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+} );

--- a/client/reader/fediverse/connect/test/site-picker-step.test.tsx
+++ b/client/reader/fediverse/connect/test/site-picker-step.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SitePickerStep } from '../site-picker-step';
+
+// SiteSelector requires heavy Redux wiring; mock it to a simple list of
+// clickable site items so we can test the onPick callback.
+jest.mock( 'calypso/components/site-selector', () => ( {
+	__esModule: true,
+	default: ( { onSiteSelect }: { onSiteSelect: ( siteId: number ) => boolean } ) => (
+		<ul>
+			<li>
+				<button onClick={ () => onSiteSelect( 1 ) }>Site One</button>
+			</li>
+			<li>
+				<button onClick={ () => onSiteSelect( 2 ) }>Site Two</button>
+			</li>
+		</ul>
+	),
+} ) );
+
+describe( 'SitePickerStep', () => {
+	it( 'renders heading and description', () => {
+		render( <SitePickerStep onPick={ jest.fn() } /> );
+		expect( screen.getByRole( 'heading', { name: /connect a fediverse site/i } ) ).toBeVisible();
+		expect( screen.getByText( /choose a wordpress\.com site/i ) ).toBeVisible();
+	} );
+
+	it( 'calls onPick with the blog id when a site is selected', async () => {
+		const user = userEvent.setup();
+		const onPick = jest.fn();
+		render( <SitePickerStep onPick={ onPick } /> );
+		await user.click( screen.getByRole( 'button', { name: /site one/i } ) );
+		expect( onPick ).toHaveBeenCalledWith( 1 );
+	} );
+
+	it( 'calls onPick with the correct id for a second site', async () => {
+		const user = userEvent.setup();
+		const onPick = jest.fn();
+		render( <SitePickerStep onPick={ onPick } /> );
+		await user.click( screen.getByRole( 'button', { name: /site two/i } ) );
+		expect( onPick ).toHaveBeenCalledWith( 2 );
+	} );
+} );

--- a/client/reader/fediverse/connect/test/wizard-error-states.test.tsx
+++ b/client/reader/fediverse/connect/test/wizard-error-states.test.tsx
@@ -43,12 +43,6 @@ describe( 'WizardErrorStates', () => {
 			expect( screen.getByText( /connection failed during authorization/i ) ).toBeVisible();
 		} );
 
-		it( 'shows the complete copy', () => {
-			const state = makeErrorState( { errorStep: 'complete' } );
-			render( <WizardErrorStates state={ state } onRetry={ jest.fn() } onReset={ jest.fn() } /> );
-			expect( screen.getByText( /session may have expired/i ) ).toBeVisible();
-		} );
-
 		it( 'shows the permission_denied copy', () => {
 			const state = makeErrorState( { errorStep: 'permission_denied' } );
 			render( <WizardErrorStates state={ state } onRetry={ jest.fn() } onReset={ jest.fn() } /> );
@@ -83,7 +77,6 @@ describe( 'WizardErrorStates', () => {
 			'enable_c2s',
 			'enable_user_actors',
 			'authorize',
-			'complete',
 		] as const;
 
 		it.each( retrySteps )( 'shows a retry button for errorStep %s', ( errorStep ) => {

--- a/client/reader/fediverse/connect/test/wizard-error-states.test.tsx
+++ b/client/reader/fediverse/connect/test/wizard-error-states.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { WizardErrorStates } from '../wizard-error-states';
+import { INITIAL_STATE } from '../wizard-state-machine';
+import type { WizardState } from '../wizard-types';
+
+function makeErrorState( overrides: Partial< WizardState > = {} ): WizardState {
+	return { ...INITIAL_STATE, name: 'ERROR', ...overrides };
+}
+
+describe( 'WizardErrorStates', () => {
+	describe( 'error copy by errorStep', () => {
+		it( 'shows the capability_check copy', () => {
+			const state = makeErrorState( { errorStep: 'capability_check' } );
+			render( <WizardErrorStates state={ state } onRetry={ jest.fn() } onReset={ jest.fn() } /> );
+			expect( screen.getByText( /reach this site/i ) ).toBeVisible();
+		} );
+
+		it( 'shows the enable_feature copy', () => {
+			const state = makeErrorState( { errorStep: 'enable_feature' } );
+			render( <WizardErrorStates state={ state } onRetry={ jest.fn() } onReset={ jest.fn() } /> );
+			expect( screen.getByText( /enable ActivityPub on this site/i ) ).toBeVisible();
+		} );
+
+		it( 'shows the enable_c2s copy', () => {
+			const state = makeErrorState( { errorStep: 'enable_c2s' } );
+			render( <WizardErrorStates state={ state } onRetry={ jest.fn() } onReset={ jest.fn() } /> );
+			expect( screen.getByText( /enable the C2S posting API/i ) ).toBeVisible();
+		} );
+
+		it( 'shows the enable_user_actors copy', () => {
+			const state = makeErrorState( { errorStep: 'enable_user_actors' } );
+			render( <WizardErrorStates state={ state } onRetry={ jest.fn() } onReset={ jest.fn() } /> );
+			expect( screen.getByText( /enable per-user accounts/i ) ).toBeVisible();
+		} );
+
+		it( 'shows the authorize copy', () => {
+			const state = makeErrorState( { errorStep: 'authorize' } );
+			render( <WizardErrorStates state={ state } onRetry={ jest.fn() } onReset={ jest.fn() } /> );
+			expect( screen.getByText( /connection failed during authorization/i ) ).toBeVisible();
+		} );
+
+		it( 'shows the complete copy', () => {
+			const state = makeErrorState( { errorStep: 'complete' } );
+			render( <WizardErrorStates state={ state } onRetry={ jest.fn() } onReset={ jest.fn() } /> );
+			expect( screen.getByText( /session may have expired/i ) ).toBeVisible();
+		} );
+
+		it( 'shows the permission_denied copy', () => {
+			const state = makeErrorState( { errorStep: 'permission_denied' } );
+			render( <WizardErrorStates state={ state } onRetry={ jest.fn() } onReset={ jest.fn() } /> );
+			expect(
+				screen.getByText( /ask a site administrator to enable Fediverse posting/i )
+			).toBeVisible();
+		} );
+	} );
+
+	describe( 'errorMessage display', () => {
+		it( 'shows errorMessage when non-empty', () => {
+			const state = makeErrorState( {
+				errorStep: 'capability_check',
+				errorMessage: 'network timeout',
+			} );
+			render( <WizardErrorStates state={ state } onRetry={ jest.fn() } onReset={ jest.fn() } /> );
+			expect( screen.getByText( 'network timeout' ) ).toBeVisible();
+		} );
+
+		it( 'does not show an error message paragraph when errorMessage is null', () => {
+			const state = makeErrorState( { errorStep: 'capability_check', errorMessage: null } );
+			render( <WizardErrorStates state={ state } onRetry={ jest.fn() } onReset={ jest.fn() } /> );
+			// Only the title paragraph should be visible; the message paragraph should be absent.
+			expect( screen.queryByText( /network timeout/i ) ).toBeNull();
+		} );
+	} );
+
+	describe( 'retry button', () => {
+		const retrySteps = [
+			'capability_check',
+			'enable_feature',
+			'enable_c2s',
+			'enable_user_actors',
+			'authorize',
+			'complete',
+		] as const;
+
+		it.each( retrySteps )( 'shows a retry button for errorStep %s', ( errorStep ) => {
+			const state = makeErrorState( { errorStep } );
+			render( <WizardErrorStates state={ state } onRetry={ jest.fn() } onReset={ jest.fn() } /> );
+			expect( screen.getByRole( 'button', { name: /try again/i } ) ).toBeVisible();
+		} );
+
+		it( 'calls onRetry when retry button is clicked', async () => {
+			const user = userEvent.setup();
+			const onRetry = jest.fn();
+			const state = makeErrorState( { errorStep: 'capability_check' } );
+			render( <WizardErrorStates state={ state } onRetry={ onRetry } onReset={ jest.fn() } /> );
+			await user.click( screen.getByRole( 'button', { name: /try again/i } ) );
+			expect( onRetry ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
+	describe( 'reset button', () => {
+		it( 'shows a "Pick a different site" button for permission_denied', () => {
+			const state = makeErrorState( { errorStep: 'permission_denied' } );
+			render( <WizardErrorStates state={ state } onRetry={ jest.fn() } onReset={ jest.fn() } /> );
+			expect( screen.getByRole( 'button', { name: /pick a different site/i } ) ).toBeVisible();
+			expect( screen.queryByRole( 'button', { name: /try again/i } ) ).toBeNull();
+		} );
+
+		it( 'calls onReset when "Pick a different site" is clicked', async () => {
+			const user = userEvent.setup();
+			const onReset = jest.fn();
+			const state = makeErrorState( { errorStep: 'permission_denied' } );
+			render( <WizardErrorStates state={ state } onRetry={ jest.fn() } onReset={ onReset } /> );
+			await user.click( screen.getByRole( 'button', { name: /pick a different site/i } ) );
+			expect( onReset ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+} );

--- a/client/reader/fediverse/connect/test/wizard-state-machine.test.ts
+++ b/client/reader/fediverse/connect/test/wizard-state-machine.test.ts
@@ -1,0 +1,335 @@
+import { INITIAL_STATE, wizardReducer } from '../wizard-state-machine';
+import type { WizardState } from '../wizard-types';
+import type { FediverseSiteCapabilities } from '@automattic/api-core';
+
+function makeCaps(
+	overrides: Partial< FediverseSiteCapabilities > = {}
+): FediverseSiteCapabilities {
+	return {
+		activitypub_active: true,
+		c2s_enabled: true,
+		actors: {
+			user: { enabled: true, can_enable: true },
+			blog: { enabled: false, can_enable: true },
+		},
+		oauth_metadata: null,
+		site_host: 'example.com',
+		site_kind: 'wpcom',
+		current_user_can_publish: true,
+		...overrides,
+	};
+}
+
+describe( 'wizardReducer', () => {
+	describe( 'INITIAL_STATE', () => {
+		it( 'has the expected shape', () => {
+			expect( INITIAL_STATE ).toEqual( {
+				name: 'PICKING_SITE',
+				blogId: null,
+				capabilities: null,
+				authorizeUrl: null,
+				errorStep: null,
+				errorMessage: null,
+			} );
+		} );
+	} );
+
+	describe( 'PICK_SITE', () => {
+		it( 'moves to CHECKING_CAPABILITIES and sets blogId', () => {
+			const next = wizardReducer( INITIAL_STATE, { type: 'PICK_SITE', blogId: 42 } );
+			expect( next.name ).toBe( 'CHECKING_CAPABILITIES' );
+			expect( next.blogId ).toBe( 42 );
+		} );
+
+		it( 'clears prior capabilities and errors', () => {
+			const prior: WizardState = {
+				...INITIAL_STATE,
+				name: 'ERROR',
+				blogId: 10,
+				capabilities: makeCaps(),
+				errorStep: 'capability_check',
+				errorMessage: 'old error',
+				authorizeUrl: 'https://example.com/oauth',
+			};
+			const next = wizardReducer( prior, { type: 'PICK_SITE', blogId: 99 } );
+			expect( next.capabilities ).toBeNull();
+			expect( next.errorStep ).toBeNull();
+			expect( next.errorMessage ).toBeNull();
+			expect( next.authorizeUrl ).toBeNull();
+			expect( next.blogId ).toBe( 99 );
+		} );
+	} );
+
+	describe( 'CAPABILITIES_LOADED', () => {
+		it( 'stores capabilities and moves to CHECKLIST_READY', () => {
+			const state: WizardState = { ...INITIAL_STATE, name: 'CHECKING_CAPABILITIES', blogId: 5 };
+			const caps = makeCaps();
+			const next = wizardReducer( state, { type: 'CAPABILITIES_LOADED', capabilities: caps } );
+			expect( next.name ).toBe( 'CHECKLIST_READY' );
+			expect( next.capabilities ).toBe( caps );
+		} );
+	} );
+
+	describe( 'CAPABILITIES_FAILED', () => {
+		it( 'moves to ERROR with errorStep capability_check', () => {
+			const state: WizardState = { ...INITIAL_STATE, name: 'CHECKING_CAPABILITIES', blogId: 5 };
+			const next = wizardReducer( state, {
+				type: 'CAPABILITIES_FAILED',
+				message: 'network error',
+			} );
+			expect( next.name ).toBe( 'ERROR' );
+			expect( next.errorStep ).toBe( 'capability_check' );
+			expect( next.errorMessage ).toBe( 'network error' );
+		} );
+	} );
+
+	describe( 'CONNECT_CLICKED', () => {
+		it( 'moves to AUTHORIZING when all flags are green', () => {
+			const state: WizardState = {
+				...INITIAL_STATE,
+				name: 'CHECKLIST_READY',
+				capabilities: makeCaps(),
+			};
+			const next = wizardReducer( state, { type: 'CONNECT_CLICKED' } );
+			expect( next.name ).toBe( 'AUTHORIZING' );
+		} );
+
+		it( 'moves to ENABLING_FEATURE when activitypub_active is false', () => {
+			const state: WizardState = {
+				...INITIAL_STATE,
+				name: 'CHECKLIST_READY',
+				capabilities: makeCaps( { activitypub_active: false } ),
+			};
+			const next = wizardReducer( state, { type: 'CONNECT_CLICKED' } );
+			expect( next.name ).toBe( 'ENABLING_FEATURE' );
+		} );
+
+		it( 'moves to ENABLING_C2S when feature is on but c2s_enabled is false', () => {
+			const state: WizardState = {
+				...INITIAL_STATE,
+				name: 'CHECKLIST_READY',
+				capabilities: makeCaps( { activitypub_active: true, c2s_enabled: false } ),
+			};
+			const next = wizardReducer( state, { type: 'CONNECT_CLICKED' } );
+			expect( next.name ).toBe( 'ENABLING_C2S' );
+		} );
+
+		it( 'moves to ENABLING_USER_ACTORS when c2s is on but user actors are disabled', () => {
+			const state: WizardState = {
+				...INITIAL_STATE,
+				name: 'CHECKLIST_READY',
+				capabilities: makeCaps( {
+					activitypub_active: true,
+					c2s_enabled: true,
+					actors: {
+						user: { enabled: false, can_enable: true },
+						blog: { enabled: false, can_enable: true },
+					},
+				} ),
+			};
+			const next = wizardReducer( state, { type: 'CONNECT_CLICKED' } );
+			expect( next.name ).toBe( 'ENABLING_USER_ACTORS' );
+		} );
+
+		it( 'returns unchanged state when capabilities are null', () => {
+			const state: WizardState = { ...INITIAL_STATE, name: 'CHECKLIST_READY', capabilities: null };
+			const next = wizardReducer( state, { type: 'CONNECT_CLICKED' } );
+			expect( next ).toBe( state );
+		} );
+	} );
+
+	describe( 'ENABLE_STEP_DONE', () => {
+		it( 'moves to ENABLING_C2S when feature step done but c2s still off', () => {
+			const state: WizardState = { ...INITIAL_STATE, name: 'ENABLING_FEATURE', blogId: 1 };
+			const caps = makeCaps( { activitypub_active: true, c2s_enabled: false } );
+			const next = wizardReducer( state, {
+				type: 'ENABLE_STEP_DONE',
+				step: 'feature',
+				capabilities: caps,
+			} );
+			expect( next.name ).toBe( 'ENABLING_C2S' );
+			expect( next.capabilities ).toBe( caps );
+		} );
+
+		it( 'moves to ENABLING_USER_ACTORS when c2s step done but user_actors still off', () => {
+			const state: WizardState = { ...INITIAL_STATE, name: 'ENABLING_C2S', blogId: 1 };
+			const caps = makeCaps( {
+				activitypub_active: true,
+				c2s_enabled: true,
+				actors: {
+					user: { enabled: false, can_enable: true },
+					blog: { enabled: false, can_enable: true },
+				},
+			} );
+			const next = wizardReducer( state, {
+				type: 'ENABLE_STEP_DONE',
+				step: 'c2s',
+				capabilities: caps,
+			} );
+			expect( next.name ).toBe( 'ENABLING_USER_ACTORS' );
+			expect( next.capabilities ).toBe( caps );
+		} );
+
+		it( 'moves to AUTHORIZING when user_actors step done and all green', () => {
+			const state: WizardState = { ...INITIAL_STATE, name: 'ENABLING_USER_ACTORS', blogId: 1 };
+			const caps = makeCaps();
+			const next = wizardReducer( state, {
+				type: 'ENABLE_STEP_DONE',
+				step: 'user_actors',
+				capabilities: caps,
+			} );
+			expect( next.name ).toBe( 'AUTHORIZING' );
+		} );
+	} );
+
+	describe( 'ENABLE_STEP_FAILED', () => {
+		it( 'moves to ERROR with errorStep permission_denied when permissionDenied is true', () => {
+			const state: WizardState = { ...INITIAL_STATE, name: 'ENABLING_FEATURE', blogId: 1 };
+			const next = wizardReducer( state, {
+				type: 'ENABLE_STEP_FAILED',
+				step: 'feature',
+				message: 'denied',
+				permissionDenied: true,
+			} );
+			expect( next.name ).toBe( 'ERROR' );
+			expect( next.errorStep ).toBe( 'permission_denied' );
+		} );
+
+		it( 'moves to ERROR with errorStep enable_feature when permissionDenied is false', () => {
+			const state: WizardState = { ...INITIAL_STATE, name: 'ENABLING_FEATURE', blogId: 1 };
+			const next = wizardReducer( state, {
+				type: 'ENABLE_STEP_FAILED',
+				step: 'feature',
+				message: 'failed',
+				permissionDenied: false,
+			} );
+			expect( next.name ).toBe( 'ERROR' );
+			expect( next.errorStep ).toBe( 'enable_feature' );
+			expect( next.errorMessage ).toBe( 'failed' );
+		} );
+
+		it( 'moves to ERROR with errorStep enable_c2s when step is c2s', () => {
+			const state: WizardState = { ...INITIAL_STATE, name: 'ENABLING_C2S', blogId: 1 };
+			const next = wizardReducer( state, {
+				type: 'ENABLE_STEP_FAILED',
+				step: 'c2s',
+				message: 'c2s failed',
+				permissionDenied: false,
+			} );
+			expect( next.name ).toBe( 'ERROR' );
+			expect( next.errorStep ).toBe( 'enable_c2s' );
+		} );
+
+		it( 'moves to ERROR with errorStep enable_user_actors when step is user_actors', () => {
+			const state: WizardState = { ...INITIAL_STATE, name: 'ENABLING_USER_ACTORS', blogId: 1 };
+			const next = wizardReducer( state, {
+				type: 'ENABLE_STEP_FAILED',
+				step: 'user_actors',
+				message: 'actors failed',
+				permissionDenied: false,
+			} );
+			expect( next.name ).toBe( 'ERROR' );
+			expect( next.errorStep ).toBe( 'enable_user_actors' );
+		} );
+	} );
+
+	describe( 'AUTHORIZE_DONE', () => {
+		it( 'stores authorizeUrl and moves to REDIRECTING', () => {
+			const state: WizardState = { ...INITIAL_STATE, name: 'AUTHORIZING', blogId: 1 };
+			const next = wizardReducer( state, {
+				type: 'AUTHORIZE_DONE',
+				authorizeUrl: 'https://example.com/oauth/authorize',
+			} );
+			expect( next.name ).toBe( 'REDIRECTING' );
+			expect( next.authorizeUrl ).toBe( 'https://example.com/oauth/authorize' );
+		} );
+	} );
+
+	describe( 'AUTHORIZE_FAILED', () => {
+		it( 'moves to ERROR with errorStep authorize', () => {
+			const state: WizardState = { ...INITIAL_STATE, name: 'AUTHORIZING', blogId: 1 };
+			const next = wizardReducer( state, {
+				type: 'AUTHORIZE_FAILED',
+				message: 'auth failed',
+			} );
+			expect( next.name ).toBe( 'ERROR' );
+			expect( next.errorStep ).toBe( 'authorize' );
+			expect( next.errorMessage ).toBe( 'auth failed' );
+		} );
+	} );
+
+	describe( 'COMPLETE_DONE', () => {
+		it( 'moves to DONE', () => {
+			const state: WizardState = { ...INITIAL_STATE, name: 'COMPLETING', blogId: 1 };
+			const next = wizardReducer( state, { type: 'COMPLETE_DONE' } );
+			expect( next.name ).toBe( 'DONE' );
+		} );
+	} );
+
+	describe( 'COMPLETE_FAILED', () => {
+		it( 'moves to ERROR with errorStep complete', () => {
+			const state: WizardState = { ...INITIAL_STATE, name: 'COMPLETING', blogId: 1 };
+			const next = wizardReducer( state, {
+				type: 'COMPLETE_FAILED',
+				message: 'completion failed',
+			} );
+			expect( next.name ).toBe( 'ERROR' );
+			expect( next.errorStep ).toBe( 'complete' );
+			expect( next.errorMessage ).toBe( 'completion failed' );
+		} );
+	} );
+
+	describe( 'RETRY_FROM_ERROR', () => {
+		it( 'returns unchanged state when blogId is null', () => {
+			const state: WizardState = {
+				...INITIAL_STATE,
+				name: 'ERROR',
+				blogId: null,
+				errorStep: 'capability_check',
+				errorMessage: 'failed',
+			};
+			const next = wizardReducer( state, { type: 'RETRY_FROM_ERROR' } );
+			expect( next ).toBe( state );
+		} );
+
+		it( 'moves to CHECKING_CAPABILITIES and clears errors when blogId is set', () => {
+			const state: WizardState = {
+				...INITIAL_STATE,
+				name: 'ERROR',
+				blogId: 7,
+				capabilities: makeCaps(),
+				errorStep: 'capability_check',
+				errorMessage: 'network error',
+			};
+			const next = wizardReducer( state, { type: 'RETRY_FROM_ERROR' } );
+			expect( next.name ).toBe( 'CHECKING_CAPABILITIES' );
+			expect( next.errorStep ).toBeNull();
+			expect( next.errorMessage ).toBeNull();
+			expect( next.capabilities ).toBeNull();
+			expect( next.blogId ).toBe( 7 );
+		} );
+	} );
+
+	describe( 'RESET', () => {
+		it( 'returns INITIAL_STATE', () => {
+			const state: WizardState = {
+				name: 'DONE',
+				blogId: 123,
+				capabilities: makeCaps(),
+				authorizeUrl: 'https://example.com',
+				errorStep: null,
+				errorMessage: null,
+			};
+			const next = wizardReducer( state, { type: 'RESET' } );
+			expect( next ).toEqual( INITIAL_STATE );
+		} );
+	} );
+
+	describe( 'unknown actions', () => {
+		it( 'returns state unchanged for unknown action types', () => {
+			// @ts-expect-error testing runtime behavior with invalid action
+			const next = wizardReducer( INITIAL_STATE, { type: 'UNKNOWN_ACTION' } );
+			expect( next ).toBe( INITIAL_STATE );
+		} );
+	} );
+} );

--- a/client/reader/fediverse/connect/test/wizard-state-machine.test.ts
+++ b/client/reader/fediverse/connect/test/wizard-state-machine.test.ts
@@ -76,10 +76,22 @@ describe( 'wizardReducer', () => {
 			const next = wizardReducer( state, {
 				type: 'CAPABILITIES_FAILED',
 				message: 'network error',
+				permissionDenied: false,
 			} );
 			expect( next.name ).toBe( 'ERROR' );
 			expect( next.errorStep ).toBe( 'capability_check' );
 			expect( next.errorMessage ).toBe( 'network error' );
+		} );
+
+		it( 'moves to ERROR with errorStep permission_denied when permissionDenied is true', () => {
+			const state: WizardState = { ...INITIAL_STATE, name: 'CHECKING_CAPABILITIES', blogId: 5 };
+			const next = wizardReducer( state, {
+				type: 'CAPABILITIES_FAILED',
+				message: '',
+				permissionDenied: true,
+			} );
+			expect( next.name ).toBe( 'ERROR' );
+			expect( next.errorStep ).toBe( 'permission_denied' );
 		} );
 	} );
 
@@ -255,27 +267,6 @@ describe( 'wizardReducer', () => {
 			expect( next.name ).toBe( 'ERROR' );
 			expect( next.errorStep ).toBe( 'authorize' );
 			expect( next.errorMessage ).toBe( 'auth failed' );
-		} );
-	} );
-
-	describe( 'COMPLETE_DONE', () => {
-		it( 'moves to DONE', () => {
-			const state: WizardState = { ...INITIAL_STATE, name: 'COMPLETING', blogId: 1 };
-			const next = wizardReducer( state, { type: 'COMPLETE_DONE' } );
-			expect( next.name ).toBe( 'DONE' );
-		} );
-	} );
-
-	describe( 'COMPLETE_FAILED', () => {
-		it( 'moves to ERROR with errorStep complete', () => {
-			const state: WizardState = { ...INITIAL_STATE, name: 'COMPLETING', blogId: 1 };
-			const next = wizardReducer( state, {
-				type: 'COMPLETE_FAILED',
-				message: 'completion failed',
-			} );
-			expect( next.name ).toBe( 'ERROR' );
-			expect( next.errorStep ).toBe( 'complete' );
-			expect( next.errorMessage ).toBe( 'completion failed' );
 		} );
 	} );
 

--- a/client/reader/fediverse/connect/wizard-error-states.tsx
+++ b/client/reader/fediverse/connect/wizard-error-states.tsx
@@ -1,0 +1,69 @@
+import { Button, Card, CardBody, __experimentalVStack as VStack } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import type { WizardState } from './wizard-types';
+
+interface Props {
+	state: WizardState;
+	onRetry: () => void;
+	onReset: () => void;
+}
+
+export function WizardErrorStates( { state, onRetry, onReset }: Props ) {
+	const translate = useTranslate();
+
+	let title: string;
+	let showRetry = true;
+
+	switch ( state.errorStep ) {
+		case 'capability_check':
+			title = translate( 'Couldn’t reach this site.' ) as string;
+			break;
+		case 'enable_feature':
+			title = translate( 'Couldn’t enable ActivityPub on this site.' ) as string;
+			break;
+		case 'enable_c2s':
+			title = translate( 'Couldn’t enable the C2S posting API.' ) as string;
+			break;
+		case 'enable_user_actors':
+			title = translate( 'Couldn’t enable per-user accounts.' ) as string;
+			break;
+		case 'authorize':
+			title = translate( 'Connection failed during authorization.' ) as string;
+			break;
+		case 'complete':
+			title = translate(
+				'Your connection couldn’t be completed. The session may have expired.'
+			) as string;
+			break;
+		case 'permission_denied':
+			title = translate(
+				'You don’t have permission to enable this on this site. Ask a site administrator to enable Fediverse posting.'
+			) as string;
+			showRetry = false;
+			break;
+		default:
+			title = translate( 'Something went wrong.' ) as string;
+	}
+
+	return (
+		<Card>
+			<CardBody>
+				<VStack spacing={ 3 }>
+					<p className="fediverse-wizard-error__title">{ title }</p>
+					{ state.errorMessage ? (
+						<p className="fediverse-wizard-error__message">{ state.errorMessage }</p>
+					) : null }
+					{ showRetry ? (
+						<Button variant="primary" onClick={ onRetry }>
+							{ translate( 'Try again' ) }
+						</Button>
+					) : (
+						<Button variant="secondary" onClick={ onReset }>
+							{ translate( 'Pick a different site' ) }
+						</Button>
+					) }
+				</VStack>
+			</CardBody>
+		</Card>
+	);
+}

--- a/client/reader/fediverse/connect/wizard-error-states.tsx
+++ b/client/reader/fediverse/connect/wizard-error-states.tsx
@@ -30,11 +30,6 @@ export function WizardErrorStates( { state, onRetry, onReset }: Props ) {
 		case 'authorize':
 			title = translate( 'Connection failed during authorization.' ) as string;
 			break;
-		case 'complete':
-			title = translate(
-				'Your connection couldn’t be completed. The session may have expired.'
-			) as string;
-			break;
 		case 'permission_denied':
 			title = translate(
 				'You don’t have permission to enable this on this site. Ask a site administrator to enable Fediverse posting.'

--- a/client/reader/fediverse/connect/wizard-state-machine.ts
+++ b/client/reader/fediverse/connect/wizard-state-machine.ts
@@ -1,0 +1,129 @@
+import {
+	INITIAL_STATE,
+	type WizardAction,
+	type WizardState,
+	type WizardStateName,
+} from './wizard-types';
+import type { FediverseSiteCapabilities } from '@automattic/api-core';
+
+export { INITIAL_STATE } from './wizard-types';
+
+function nextEnableStepFor( caps: FediverseSiteCapabilities ): WizardStateName {
+	if ( ! caps.activitypub_active ) {
+		return 'ENABLING_FEATURE';
+	}
+	if ( ! caps.c2s_enabled ) {
+		return 'ENABLING_C2S';
+	}
+	if ( ! caps.actors.user.enabled ) {
+		return 'ENABLING_USER_ACTORS';
+	}
+	return 'AUTHORIZING';
+}
+
+export function wizardReducer( state: WizardState, action: WizardAction ): WizardState {
+	switch ( action.type ) {
+		case 'PICK_SITE':
+			return {
+				...state,
+				name: 'CHECKING_CAPABILITIES',
+				blogId: action.blogId,
+				capabilities: null,
+				authorizeUrl: null,
+				errorStep: null,
+				errorMessage: null,
+			};
+
+		case 'CAPABILITIES_LOADED':
+			return {
+				...state,
+				name: 'CHECKLIST_READY',
+				capabilities: action.capabilities,
+			};
+
+		case 'CAPABILITIES_FAILED':
+			return {
+				...state,
+				name: 'ERROR',
+				errorStep: 'capability_check',
+				errorMessage: action.message,
+			};
+
+		case 'CONNECT_CLICKED': {
+			if ( ! state.capabilities ) {
+				return state;
+			}
+			return {
+				...state,
+				name: nextEnableStepFor( state.capabilities ),
+			};
+		}
+
+		case 'ENABLE_STEP_DONE':
+			return {
+				...state,
+				capabilities: action.capabilities,
+				name: nextEnableStepFor( action.capabilities ),
+			};
+
+		case 'ENABLE_STEP_FAILED': {
+			const errorStep = action.permissionDenied
+				? 'permission_denied'
+				: ( `enable_${ action.step }` as 'enable_feature' | 'enable_c2s' | 'enable_user_actors' );
+			return {
+				...state,
+				name: 'ERROR',
+				errorStep,
+				errorMessage: action.message,
+			};
+		}
+
+		case 'AUTHORIZE_DONE':
+			return {
+				...state,
+				name: 'REDIRECTING',
+				authorizeUrl: action.authorizeUrl,
+			};
+
+		case 'AUTHORIZE_FAILED':
+			return {
+				...state,
+				name: 'ERROR',
+				errorStep: 'authorize',
+				errorMessage: action.message,
+			};
+
+		case 'COMPLETE_DONE':
+			return {
+				...state,
+				name: 'DONE',
+			};
+
+		case 'COMPLETE_FAILED':
+			return {
+				...state,
+				name: 'ERROR',
+				errorStep: 'complete',
+				errorMessage: action.message,
+			};
+
+		case 'RETRY_FROM_ERROR': {
+			if ( state.blogId === null ) {
+				return state;
+			}
+			return {
+				...state,
+				name: 'CHECKING_CAPABILITIES',
+				capabilities: null,
+				errorStep: null,
+				errorMessage: null,
+			};
+		}
+
+		case 'RESET':
+			return INITIAL_STATE;
+
+		default:
+			return state;
+	}
+}

--- a/client/reader/fediverse/connect/wizard-state-machine.ts
+++ b/client/reader/fediverse/connect/wizard-state-machine.ts
@@ -8,6 +8,12 @@ import type { FediverseSiteCapabilities } from '@automattic/api-core';
 
 export { INITIAL_STATE } from './wizard-types';
 
+const ENABLE_STEP_TO_ERROR_STEP = {
+	feature: 'enable_feature',
+	c2s: 'enable_c2s',
+	user_actors: 'enable_user_actors',
+} as const;
+
 function nextEnableStepFor( caps: FediverseSiteCapabilities ): WizardStateName {
 	if ( ! caps.activitypub_active ) {
 		return 'ENABLING_FEATURE';
@@ -45,7 +51,7 @@ export function wizardReducer( state: WizardState, action: WizardAction ): Wizar
 			return {
 				...state,
 				name: 'ERROR',
-				errorStep: 'capability_check',
+				errorStep: action.permissionDenied ? 'permission_denied' : 'capability_check',
 				errorMessage: action.message,
 			};
 
@@ -69,7 +75,7 @@ export function wizardReducer( state: WizardState, action: WizardAction ): Wizar
 		case 'ENABLE_STEP_FAILED': {
 			const errorStep = action.permissionDenied
 				? 'permission_denied'
-				: ( `enable_${ action.step }` as 'enable_feature' | 'enable_c2s' | 'enable_user_actors' );
+				: ENABLE_STEP_TO_ERROR_STEP[ action.step ];
 			return {
 				...state,
 				name: 'ERROR',
@@ -90,20 +96,6 @@ export function wizardReducer( state: WizardState, action: WizardAction ): Wizar
 				...state,
 				name: 'ERROR',
 				errorStep: 'authorize',
-				errorMessage: action.message,
-			};
-
-		case 'COMPLETE_DONE':
-			return {
-				...state,
-				name: 'DONE',
-			};
-
-		case 'COMPLETE_FAILED':
-			return {
-				...state,
-				name: 'ERROR',
-				errorStep: 'complete',
 				errorMessage: action.message,
 			};
 

--- a/client/reader/fediverse/connect/wizard-types.ts
+++ b/client/reader/fediverse/connect/wizard-types.ts
@@ -1,0 +1,64 @@
+import type { FediverseSiteCapabilities } from '@automattic/api-core';
+
+export type WizardStateName =
+	| 'PICKING_SITE'
+	| 'CHECKING_CAPABILITIES'
+	| 'CHECKLIST_READY'
+	| 'ENABLING_FEATURE'
+	| 'ENABLING_C2S'
+	| 'ENABLING_USER_ACTORS'
+	| 'AUTHORIZING'
+	| 'REDIRECTING'
+	| 'COMPLETING'
+	| 'DONE'
+	| 'ERROR';
+
+export type WizardErrorStep =
+	| 'capability_check'
+	| 'enable_feature'
+	| 'enable_c2s'
+	| 'enable_user_actors'
+	| 'authorize'
+	| 'complete'
+	| 'permission_denied';
+
+export interface WizardState {
+	name: WizardStateName;
+	blogId: number | null;
+	capabilities: FediverseSiteCapabilities | null;
+	authorizeUrl: string | null;
+	errorStep: WizardErrorStep | null;
+	errorMessage: string | null;
+}
+
+export type WizardAction =
+	| { type: 'PICK_SITE'; blogId: number }
+	| { type: 'CAPABILITIES_LOADED'; capabilities: FediverseSiteCapabilities }
+	| { type: 'CAPABILITIES_FAILED'; message: string }
+	| { type: 'CONNECT_CLICKED' }
+	| {
+			type: 'ENABLE_STEP_DONE';
+			step: 'feature' | 'c2s' | 'user_actors';
+			capabilities: FediverseSiteCapabilities;
+	  }
+	| {
+			type: 'ENABLE_STEP_FAILED';
+			step: 'feature' | 'c2s' | 'user_actors';
+			message: string;
+			permissionDenied: boolean;
+	  }
+	| { type: 'AUTHORIZE_DONE'; authorizeUrl: string }
+	| { type: 'AUTHORIZE_FAILED'; message: string }
+	| { type: 'COMPLETE_DONE' }
+	| { type: 'COMPLETE_FAILED'; message: string }
+	| { type: 'RETRY_FROM_ERROR' }
+	| { type: 'RESET' };
+
+export const INITIAL_STATE: WizardState = {
+	name: 'PICKING_SITE',
+	blogId: null,
+	capabilities: null,
+	authorizeUrl: null,
+	errorStep: null,
+	errorMessage: null,
+};

--- a/client/reader/fediverse/connect/wizard-types.ts
+++ b/client/reader/fediverse/connect/wizard-types.ts
@@ -9,7 +9,6 @@ export type WizardStateName =
 	| 'ENABLING_USER_ACTORS'
 	| 'AUTHORIZING'
 	| 'REDIRECTING'
-	| 'COMPLETING'
 	| 'DONE'
 	| 'ERROR';
 
@@ -19,7 +18,6 @@ export type WizardErrorStep =
 	| 'enable_c2s'
 	| 'enable_user_actors'
 	| 'authorize'
-	| 'complete'
 	| 'permission_denied';
 
 export interface WizardState {
@@ -34,7 +32,7 @@ export interface WizardState {
 export type WizardAction =
 	| { type: 'PICK_SITE'; blogId: number }
 	| { type: 'CAPABILITIES_LOADED'; capabilities: FediverseSiteCapabilities }
-	| { type: 'CAPABILITIES_FAILED'; message: string }
+	| { type: 'CAPABILITIES_FAILED'; message: string; permissionDenied: boolean }
 	| { type: 'CONNECT_CLICKED' }
 	| {
 			type: 'ENABLE_STEP_DONE';
@@ -49,8 +47,6 @@ export type WizardAction =
 	  }
 	| { type: 'AUTHORIZE_DONE'; authorizeUrl: string }
 	| { type: 'AUTHORIZE_FAILED'; message: string }
-	| { type: 'COMPLETE_DONE' }
-	| { type: 'COMPLETE_FAILED'; message: string }
 	| { type: 'RETRY_FROM_ERROR' }
 	| { type: 'RESET' };
 

--- a/client/reader/fediverse/controller.tsx
+++ b/client/reader/fediverse/controller.tsx
@@ -1,0 +1,85 @@
+import { isEnabled } from '@automattic/calypso-config';
+import page, { type Context } from '@automattic/calypso-router';
+import AsyncLoad from 'calypso/components/async-load';
+import { TIMELINE_TAB } from './helper';
+
+const loadFediverseLandingView = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-reader-fediverse-landing-view" */ 'calypso/reader/fediverse/fediverse-landing-view'
+	);
+const loadFediverseConnectView = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-reader-fediverse-connect-view" */ 'calypso/reader/fediverse/fediverse-connect-view'
+	);
+const loadFediverseOauthCallbackView = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-reader-fediverse-oauth-callback-view" */ 'calypso/reader/fediverse/fediverse-oauth-callback-view'
+	);
+const loadFediverseAccountView = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-reader-fediverse-account-view" */ 'calypso/reader/fediverse/fediverse-account-view'
+	);
+
+function ensureFediverseEnabled(): boolean {
+	if ( ! isEnabled( 'reader/social' ) ) {
+		page.redirect( '/reader' );
+		return false;
+	}
+	return true;
+}
+
+export const fediverseLanding = ( context: Context, next: () => void ) => {
+	if ( ! ensureFediverseEnabled() ) {
+		return;
+	}
+	context.primary = <AsyncLoad require={ loadFediverseLandingView } placeholder={ null } />;
+	next();
+};
+
+export const fediverseConnect = ( context: Context, next: () => void ) => {
+	if ( ! ensureFediverseEnabled() ) {
+		return;
+	}
+	context.primary = <AsyncLoad require={ loadFediverseConnectView } placeholder={ null } />;
+	next();
+};
+
+export const fediverseOauthCallback = ( context: Context, next: () => void ) => {
+	if ( ! ensureFediverseEnabled() ) {
+		return;
+	}
+	const query = context.query as { state?: string; code?: string; error?: string };
+	context.primary = (
+		<AsyncLoad require={ loadFediverseOauthCallbackView } placeholder={ null } query={ query } />
+	);
+	next();
+};
+
+export const fediverseIdRedirect = ( context: Context ) => {
+	if ( ! ensureFediverseEnabled() ) {
+		return;
+	}
+	const id = Number( context.params.id );
+	if ( Number.isFinite( id ) && id > 0 ) {
+		page.redirect( `/reader/fediverse/${ id }/${ TIMELINE_TAB }` );
+		return;
+	}
+	page.redirect( '/reader/fediverse' );
+};
+
+export const fediverseAccount = ( context: Context, next: () => void ) => {
+	if ( ! ensureFediverseEnabled() ) {
+		return;
+	}
+	const id = Number( context.params.id );
+	const tab = String( context.params.tab ?? '' );
+	context.primary = (
+		<AsyncLoad
+			require={ loadFediverseAccountView }
+			placeholder={ null }
+			connectionId={ id }
+			tab={ tab }
+		/>
+	);
+	next();
+};

--- a/client/reader/fediverse/controller.tsx
+++ b/client/reader/fediverse/controller.tsx
@@ -40,7 +40,10 @@ export const fediverseConnect = ( context: Context, next: () => void ) => {
 	if ( ! ensureFediverseEnabled() ) {
 		return;
 	}
-	context.primary = <AsyncLoad require={ loadFediverseConnectView } placeholder={ null } />;
+	const query = context.query as { error?: string };
+	context.primary = (
+		<AsyncLoad require={ loadFediverseConnectView } placeholder={ null } query={ query } />
+	);
 	next();
 };
 

--- a/client/reader/fediverse/fediverse-account-view.tsx
+++ b/client/reader/fediverse/fediverse-account-view.tsx
@@ -1,6 +1,6 @@
 import { useFediverseConnectionsQuery } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
-import { __experimentalVStack as VStack } from '@wordpress/components';
+import { Button, __experimentalVStack as VStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -24,14 +24,14 @@ interface Props {
 
 export function FediverseAccountView( { connectionId, tab }: Props ) {
 	const translate = useTranslate();
-	const { data, isPending } = useFediverseConnectionsQuery();
+	const { data, isPending, isError, refetch } = useFediverseConnectionsQuery();
 
 	const connections = data?.connections ?? [];
 	const connection = connections.find( ( c ) => c.id === connectionId ) ?? null;
 	const tabValid = VALID_TABS.has( tab );
 
 	useEffect( () => {
-		if ( isPending ) {
+		if ( isPending || isError ) {
 			return;
 		}
 		if ( ! connection ) {
@@ -41,7 +41,21 @@ export function FediverseAccountView( { connectionId, tab }: Props ) {
 		if ( ! tabValid ) {
 			page.replace( getAccountUrl( connection.id, TIMELINE_TAB ) );
 		}
-	}, [ isPending, connection, tabValid ] );
+	}, [ isPending, isError, connection, tabValid ] );
+
+	if ( isError ) {
+		return (
+			<ReaderMain className="fediverse-view">
+				<DocumentHead title={ translate( 'Fediverse ‹ Reader' ) } />
+				<div role="alert" className="fediverse-account-error">
+					<p>{ translate( "We couldn't load your Fediverse connections." ) }</p>
+					<Button variant="secondary" onClick={ () => refetch() }>
+						{ translate( 'Try again' ) }
+					</Button>
+				</div>
+			</ReaderMain>
+		);
+	}
 
 	if ( ! connection || ! tabValid ) {
 		return (

--- a/client/reader/fediverse/fediverse-account-view.tsx
+++ b/client/reader/fediverse/fediverse-account-view.tsx
@@ -1,0 +1,90 @@
+import { useFediverseConnectionsQuery } from '@automattic/api-queries';
+import page from '@automattic/calypso-router';
+import { __experimentalVStack as VStack } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import DocumentHead from 'calypso/components/data/document-head';
+import NavigationHeader from 'calypso/components/navigation-header';
+import ReaderMain from 'calypso/reader/components/reader-main';
+import { ComposerModal, ComposerProvider, ComposeFab } from './composer';
+import { FediverseNavigation } from './fediverse-navigation';
+import { PROFILE_TAB, SETTINGS_TAB, TIMELINE_TAB } from './helper';
+import { ProfilePanel } from './profile-panel';
+import { getLandingUrl, getAccountUrl } from './route';
+import { SettingsPanel } from './settings-panel';
+import { TimelinePanel } from './timeline-panel';
+import type { FediverseConnection } from '@automattic/api-core';
+
+const VALID_TABS = new Set< string >( [ TIMELINE_TAB, PROFILE_TAB, SETTINGS_TAB ] );
+
+interface Props {
+	connectionId: number;
+	tab: string;
+}
+
+export function FediverseAccountView( { connectionId, tab }: Props ) {
+	const translate = useTranslate();
+	const { data, isPending } = useFediverseConnectionsQuery();
+
+	const connections = data?.connections ?? [];
+	const connection = connections.find( ( c ) => c.id === connectionId ) ?? null;
+	const tabValid = VALID_TABS.has( tab );
+
+	useEffect( () => {
+		if ( isPending ) {
+			return;
+		}
+		if ( ! connection ) {
+			page.replace( getLandingUrl() );
+			return;
+		}
+		if ( ! tabValid ) {
+			page.replace( getAccountUrl( connection.id, TIMELINE_TAB ) );
+		}
+	}, [ isPending, connection, tabValid ] );
+
+	if ( ! connection || ! tabValid ) {
+		return (
+			<ReaderMain className="fediverse-view">
+				<DocumentHead title={ translate( 'Fediverse ‹ Reader' ) } />
+				<div role="status" aria-live="polite">
+					{ translate( 'Loading…' ) }
+				</div>
+			</ReaderMain>
+		);
+	}
+
+	const title = connection.handle;
+
+	return (
+		<ReaderMain className="fediverse-view">
+			<DocumentHead title={ translate( '%s ‹ Fediverse ‹ Reader', { args: title } ) } />
+			<NavigationHeader title={ translate( 'Fediverse' ) } subtitle={ title } />
+			<FediverseNavigation connectionId={ connection.id } selectedTab={ tab } />
+			<ComposerProvider connectionId={ connection.id }>
+				<VStack spacing={ 4 } className="fediverse-view__body">
+					{ renderTab( tab, connection ) }
+				</VStack>
+				<ComposerModal />
+				<ComposeFab />
+			</ComposerProvider>
+		</ReaderMain>
+	);
+}
+
+function renderTab( slug: string, connection: FediverseConnection ) {
+	switch ( slug ) {
+		case PROFILE_TAB:
+			return (
+				<ProfilePanel
+					handle={ connection.handle }
+					actorUrl={ connection.actor_url }
+					siteHost={ connection.site_host }
+				/>
+			);
+		case SETTINGS_TAB:
+			return <SettingsPanel connectionId={ connection.id } />;
+		default:
+			return <TimelinePanel connectionId={ connection.id } handle={ connection.handle } />;
+	}
+}

--- a/client/reader/fediverse/fediverse-account-view.tsx
+++ b/client/reader/fediverse/fediverse-account-view.tsx
@@ -102,3 +102,5 @@ function renderTab( slug: string, connection: FediverseConnection ) {
 			return <TimelinePanel connectionId={ connection.id } handle={ connection.handle } />;
 	}
 }
+
+export default FediverseAccountView;

--- a/client/reader/fediverse/fediverse-connect-view.tsx
+++ b/client/reader/fediverse/fediverse-connect-view.tsx
@@ -286,3 +286,5 @@ function callbackErrorMessage( kind: string, t: ReturnType< typeof useTranslate 
 			return t( 'Something went wrong. Please try again.' ) as string;
 	}
 }
+
+export default FediverseConnectView;

--- a/client/reader/fediverse/fediverse-connect-view.tsx
+++ b/client/reader/fediverse/fediverse-connect-view.tsx
@@ -5,6 +5,7 @@ import {
 	useEnableFediverseUserActorsMutation,
 	useFediverseSiteCapabilitiesQuery,
 } from '@automattic/api-queries';
+import { useTranslate } from 'i18n-calypso';
 import { useEffect, useReducer } from 'react';
 import { useDispatch } from 'calypso/state';
 import { trackFediverseEvent } from './analytics';
@@ -38,9 +39,16 @@ function isPermissionDenied( err: unknown ): boolean {
 	return false;
 }
 
-export function FediverseConnectView() {
+interface Props {
+	query?: { error?: string };
+}
+
+export function FediverseConnectView( { query }: Props = {} ) {
 	const reduxDispatch = useDispatch();
+	const translate = useTranslate();
 	const [ state, dispatch ] = useReducer( wizardReducer, INITIAL_STATE );
+
+	const callbackError = query?.error;
 
 	// Fire capabilities query whenever blogId is set; the query disables itself when blogId is 0.
 	const capabilitiesQuery = useFediverseSiteCapabilitiesQuery( state.blogId ?? 0 );
@@ -59,8 +67,11 @@ export function FediverseConnectView() {
 			reduxDispatch( trackFediverseEvent( 'CAPABILITY_CHECK', { blog_id: state.blogId } ) );
 			dispatch( { type: 'CAPABILITIES_LOADED', capabilities: capabilitiesQuery.data } );
 		} else if ( capabilitiesQuery.isError ) {
-			const message = errorMessage( capabilitiesQuery.error );
-			dispatch( { type: 'CAPABILITIES_FAILED', message } );
+			dispatch( {
+				type: 'CAPABILITIES_FAILED',
+				message: errorMessage( capabilitiesQuery.error ),
+				permissionDenied: isPermissionDenied( capabilitiesQuery.error ),
+			} );
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ state.name, capabilitiesQuery.isSuccess, capabilitiesQuery.isError ] );
@@ -85,7 +96,7 @@ export function FediverseConnectView() {
 						type: 'ENABLE_STEP_FAILED',
 						step: 'feature',
 						message: errorMessage( refetched.error ),
-						permissionDenied: false,
+						permissionDenied: isPermissionDenied( refetched.error ),
 					} );
 				}
 			},
@@ -121,7 +132,7 @@ export function FediverseConnectView() {
 						type: 'ENABLE_STEP_FAILED',
 						step: 'c2s',
 						message: errorMessage( refetched.error ),
-						permissionDenied: false,
+						permissionDenied: isPermissionDenied( refetched.error ),
 					} );
 				}
 			},
@@ -157,7 +168,7 @@ export function FediverseConnectView() {
 						type: 'ENABLE_STEP_FAILED',
 						step: 'user_actors',
 						message: errorMessage( refetched.error ),
-						permissionDenied: false,
+						permissionDenied: isPermissionDenied( refetched.error ),
 					} );
 				}
 			},
@@ -202,15 +213,28 @@ export function FediverseConnectView() {
 		window.location.assign( state.authorizeUrl );
 	}, [ state.name, state.authorizeUrl ] );
 
+	// Surface an error banner when the OAuth callback redirected back here
+	// with `?error=` (provider-denied, state mismatch, expired link, etc.).
+	// Hide it as soon as the user starts a new attempt to avoid stale copy.
+	const showCallbackError = callbackError && state.name === 'PICKING_SITE';
+	const callbackErrorBanner = showCallbackError ? (
+		<p role="alert" className="fediverse-connect__callback-error">
+			{ callbackErrorMessage( callbackError, translate ) }
+		</p>
+	) : null;
+
 	switch ( state.name ) {
 		case 'PICKING_SITE':
 			return (
-				<SitePickerStep
-					onPick={ ( blogId ) => {
-						reduxDispatch( trackFediverseEvent( 'CONNECT_STARTED', { blog_id: blogId } ) );
-						dispatch( { type: 'PICK_SITE', blogId } );
-					} }
-				/>
+				<>
+					{ callbackErrorBanner }
+					<SitePickerStep
+						onPick={ ( blogId ) => {
+							reduxDispatch( trackFediverseEvent( 'CONNECT_STARTED', { blog_id: blogId } ) );
+							dispatch( { type: 'PICK_SITE', blogId } );
+						} }
+					/>
+				</>
 			);
 		case 'CHECKING_CAPABILITIES':
 		case 'CHECKLIST_READY':
@@ -219,7 +243,6 @@ export function FediverseConnectView() {
 		case 'ENABLING_USER_ACTORS':
 		case 'AUTHORIZING':
 		case 'REDIRECTING':
-		case 'COMPLETING':
 			return (
 				<CapabilityChecklist
 					state={ state }
@@ -237,5 +260,29 @@ export function FediverseConnectView() {
 		case 'DONE':
 		default:
 			return null;
+	}
+}
+
+function callbackErrorMessage( kind: string, t: ReturnType< typeof useTranslate > ): string {
+	switch ( kind ) {
+		case 'access_denied':
+			return t( 'You declined the authorization on the site.' ) as string;
+		case 'state_mismatch':
+		case 'state_expired':
+		case 'missing_params':
+			return t(
+				'This authorization link has expired or doesn’t match. Please try connecting again.'
+			) as string;
+		case 'auth_failed':
+		case 'auth_required':
+		case 'forbidden':
+		case 'not_found':
+			return t( 'Connection couldn’t be completed. Please try again.' ) as string;
+		case 'rate_limited':
+			return t( 'Too many attempts. Please wait a moment and try again.' ) as string;
+		case 'upstream_unavailable':
+			return t( 'The Fediverse site is temporarily unavailable. Please try again.' ) as string;
+		default:
+			return t( 'Something went wrong. Please try again.' ) as string;
 	}
 }

--- a/client/reader/fediverse/fediverse-connect-view.tsx
+++ b/client/reader/fediverse/fediverse-connect-view.tsx
@@ -1,0 +1,237 @@
+import {
+	useAuthorizeFediverseConnectionMutation,
+	useEnableFediverseC2sMutation,
+	useEnableFediverseFeatureMutation,
+	useEnableFediverseUserActorsMutation,
+	useFediverseSiteCapabilitiesQuery,
+} from '@automattic/api-queries';
+import { useEffect, useReducer } from 'react';
+import { useDispatch } from 'calypso/state';
+import { trackFediverseEvent } from './analytics';
+import { CapabilityChecklist } from './connect/capability-checklist';
+import { SitePickerStep } from './connect/site-picker-step';
+import { WizardErrorStates } from './connect/wizard-error-states';
+import { INITIAL_STATE, wizardReducer } from './connect/wizard-state-machine';
+import { saveOauthState } from './oauth-state';
+import type { FediverseError } from '@automattic/api-core';
+
+function errorMessage( err: unknown ): string {
+	if ( err && typeof err === 'object' && 'kind' in err ) {
+		const e = err as FediverseError;
+		if ( e.kind === 'bad_request' ) {
+			return e.message ?? e.kind;
+		}
+		return e.kind;
+	}
+	return String( err );
+}
+
+function isPermissionDenied( err: unknown ): boolean {
+	if ( err && typeof err === 'object' && 'kind' in err ) {
+		const e = err as FediverseError;
+		return e.kind === 'forbidden' || e.kind === 'auth_required';
+	}
+	return false;
+}
+
+export function FediverseConnectView() {
+	const reduxDispatch = useDispatch();
+	const [ state, dispatch ] = useReducer( wizardReducer, INITIAL_STATE );
+
+	// Fire capabilities query whenever blogId is set; the query disables itself when blogId is 0.
+	const capabilitiesQuery = useFediverseSiteCapabilitiesQuery( state.blogId ?? 0 );
+
+	const enableFeature = useEnableFediverseFeatureMutation( state.blogId ?? 0 );
+	const enableC2s = useEnableFediverseC2sMutation( state.blogId ?? 0 );
+	const enableUserActors = useEnableFediverseUserActorsMutation( state.blogId ?? 0 );
+	const authorize = useAuthorizeFediverseConnectionMutation();
+
+	// CHECKING_CAPABILITIES → on settle, dispatch.
+	useEffect( () => {
+		if ( state.name !== 'CHECKING_CAPABILITIES' ) {
+			return;
+		}
+		if ( capabilitiesQuery.isSuccess && capabilitiesQuery.data ) {
+			reduxDispatch( trackFediverseEvent( 'CAPABILITY_CHECK', { blog_id: state.blogId } ) );
+			dispatch( { type: 'CAPABILITIES_LOADED', capabilities: capabilitiesQuery.data } );
+		} else if ( capabilitiesQuery.isError ) {
+			const message = errorMessage( capabilitiesQuery.error );
+			dispatch( { type: 'CAPABILITIES_FAILED', message } );
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ state.name, capabilitiesQuery.isSuccess, capabilitiesQuery.isError ] );
+
+	// ENABLING_FEATURE → fire mutation → on settle, refetch caps then dispatch ENABLE_STEP_DONE / FAILED.
+	useEffect( () => {
+		if ( state.name !== 'ENABLING_FEATURE' || ! state.blogId ) {
+			return;
+		}
+		enableFeature.mutate( undefined, {
+			onSuccess: async () => {
+				reduxDispatch( trackFediverseEvent( 'FEATURE_ENABLED', { blog_id: state.blogId } ) );
+				const refetched = await capabilitiesQuery.refetch();
+				if ( refetched.data ) {
+					dispatch( {
+						type: 'ENABLE_STEP_DONE',
+						step: 'feature',
+						capabilities: refetched.data,
+					} );
+				} else {
+					dispatch( {
+						type: 'ENABLE_STEP_FAILED',
+						step: 'feature',
+						message: errorMessage( refetched.error ),
+						permissionDenied: false,
+					} );
+				}
+			},
+			onError: ( err ) => {
+				dispatch( {
+					type: 'ENABLE_STEP_FAILED',
+					step: 'feature',
+					message: errorMessage( err ),
+					permissionDenied: isPermissionDenied( err ),
+				} );
+			},
+		} );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ state.name ] );
+
+	// ENABLING_C2S → fire mutation → on settle, refetch caps then dispatch ENABLE_STEP_DONE / FAILED.
+	useEffect( () => {
+		if ( state.name !== 'ENABLING_C2S' || ! state.blogId ) {
+			return;
+		}
+		enableC2s.mutate( undefined, {
+			onSuccess: async () => {
+				reduxDispatch( trackFediverseEvent( 'C2S_ENABLED', { blog_id: state.blogId } ) );
+				const refetched = await capabilitiesQuery.refetch();
+				if ( refetched.data ) {
+					dispatch( {
+						type: 'ENABLE_STEP_DONE',
+						step: 'c2s',
+						capabilities: refetched.data,
+					} );
+				} else {
+					dispatch( {
+						type: 'ENABLE_STEP_FAILED',
+						step: 'c2s',
+						message: errorMessage( refetched.error ),
+						permissionDenied: false,
+					} );
+				}
+			},
+			onError: ( err ) => {
+				dispatch( {
+					type: 'ENABLE_STEP_FAILED',
+					step: 'c2s',
+					message: errorMessage( err ),
+					permissionDenied: isPermissionDenied( err ),
+				} );
+			},
+		} );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ state.name ] );
+
+	// ENABLING_USER_ACTORS → fire mutation → on settle, refetch caps then dispatch ENABLE_STEP_DONE / FAILED.
+	useEffect( () => {
+		if ( state.name !== 'ENABLING_USER_ACTORS' || ! state.blogId ) {
+			return;
+		}
+		enableUserActors.mutate( undefined, {
+			onSuccess: async () => {
+				reduxDispatch( trackFediverseEvent( 'USER_ACTORS_ENABLED', { blog_id: state.blogId } ) );
+				const refetched = await capabilitiesQuery.refetch();
+				if ( refetched.data ) {
+					dispatch( {
+						type: 'ENABLE_STEP_DONE',
+						step: 'user_actors',
+						capabilities: refetched.data,
+					} );
+				} else {
+					dispatch( {
+						type: 'ENABLE_STEP_FAILED',
+						step: 'user_actors',
+						message: errorMessage( refetched.error ),
+						permissionDenied: false,
+					} );
+				}
+			},
+			onError: ( err ) => {
+				dispatch( {
+					type: 'ENABLE_STEP_FAILED',
+					step: 'user_actors',
+					message: errorMessage( err ),
+					permissionDenied: isPermissionDenied( err ),
+				} );
+			},
+		} );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ state.name ] );
+
+	// AUTHORIZING → fire authorize mutation → AUTHORIZE_DONE / FAILED.
+	useEffect( () => {
+		if ( state.name !== 'AUTHORIZING' || ! state.blogId ) {
+			return;
+		}
+		authorize.mutate(
+			{ blog_id: state.blogId, actor: 'user' },
+			{
+				onSuccess: ( data ) => {
+					saveOauthState( { state: data.state, blog_id: state.blogId! } );
+					reduxDispatch( trackFediverseEvent( 'AUTHORIZE_STARTED', { blog_id: state.blogId } ) );
+					dispatch( { type: 'AUTHORIZE_DONE', authorizeUrl: data.authorize_url } );
+				},
+				onError: ( err ) => {
+					dispatch( { type: 'AUTHORIZE_FAILED', message: errorMessage( err ) } );
+				},
+			}
+		);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ state.name ] );
+
+	// REDIRECTING → navigate to the authorize URL.
+	useEffect( () => {
+		if ( state.name !== 'REDIRECTING' || ! state.authorizeUrl ) {
+			return;
+		}
+		window.location.assign( state.authorizeUrl );
+	}, [ state.name, state.authorizeUrl ] );
+
+	switch ( state.name ) {
+		case 'PICKING_SITE':
+			return (
+				<SitePickerStep
+					onPick={ ( blogId ) => {
+						reduxDispatch( trackFediverseEvent( 'CONNECT_STARTED', { blog_id: blogId } ) );
+						dispatch( { type: 'PICK_SITE', blogId } );
+					} }
+				/>
+			);
+		case 'CHECKING_CAPABILITIES':
+		case 'CHECKLIST_READY':
+		case 'ENABLING_FEATURE':
+		case 'ENABLING_C2S':
+		case 'ENABLING_USER_ACTORS':
+		case 'AUTHORIZING':
+		case 'REDIRECTING':
+		case 'COMPLETING':
+			return (
+				<CapabilityChecklist
+					state={ state }
+					onConnect={ () => dispatch( { type: 'CONNECT_CLICKED' } ) }
+				/>
+			);
+		case 'ERROR':
+			return (
+				<WizardErrorStates
+					state={ state }
+					onRetry={ () => dispatch( { type: 'RETRY_FROM_ERROR' } ) }
+					onReset={ () => dispatch( { type: 'RESET' } ) }
+				/>
+			);
+		case 'DONE':
+		default:
+			return null;
+	}
+}

--- a/client/reader/fediverse/fediverse-connect-view.tsx
+++ b/client/reader/fediverse/fediverse-connect-view.tsx
@@ -15,15 +15,19 @@ import { INITIAL_STATE, wizardReducer } from './connect/wizard-state-machine';
 import { saveOauthState } from './oauth-state';
 import type { FediverseError } from '@automattic/api-core';
 
+// Returns a server-provided human-readable message when one is available
+// (only `bad_request` carries one). For closed-set kinds we return an empty
+// string so the wizard's error card shows only the translated step title and
+// doesn't leak machine codes like `forbidden` / `not_found` to users. The
+// `kind` is still carried separately for telemetry via `isPermissionDenied`.
 function errorMessage( err: unknown ): string {
 	if ( err && typeof err === 'object' && 'kind' in err ) {
 		const e = err as FediverseError;
-		if ( e.kind === 'bad_request' ) {
-			return e.message ?? e.kind;
+		if ( e.kind === 'bad_request' && e.message ) {
+			return e.message;
 		}
-		return e.kind;
 	}
-	return String( err );
+	return '';
 }
 
 function isPermissionDenied( err: unknown ): boolean {

--- a/client/reader/fediverse/fediverse-landing-view.tsx
+++ b/client/reader/fediverse/fediverse-landing-view.tsx
@@ -1,0 +1,29 @@
+import { useFediverseConnectionsQuery } from '@automattic/api-queries';
+import page from '@automattic/calypso-router';
+import { Spinner } from '@wordpress/components';
+import { useEffect } from 'react';
+import { getAccountUrl, getConnectUrl } from './route';
+
+export function FediverseLandingView() {
+	const { data, isPending, isError } = useFediverseConnectionsQuery();
+
+	useEffect( () => {
+		if ( isPending ) {
+			return;
+		}
+		if ( isError ) {
+			page.replace( getConnectUrl() );
+			return;
+		}
+		const connections = data?.connections ?? [];
+		if ( connections.length > 0 ) {
+			page.replace( getAccountUrl( connections[ 0 ].id, 'timeline' ) );
+		} else {
+			page.replace( getConnectUrl() );
+		}
+	}, [ data, isPending, isError ] );
+
+	return <Spinner />;
+}
+
+export default FediverseLandingView;

--- a/client/reader/fediverse/fediverse-landing-view.tsx
+++ b/client/reader/fediverse/fediverse-landing-view.tsx
@@ -1,18 +1,16 @@
 import { useFediverseConnectionsQuery } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
-import { Spinner } from '@wordpress/components';
+import { Button, Spinner } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { getAccountUrl, getConnectUrl } from './route';
 
 export function FediverseLandingView() {
-	const { data, isPending, isError } = useFediverseConnectionsQuery();
+	const translate = useTranslate();
+	const { data, isPending, isError, refetch } = useFediverseConnectionsQuery();
 
 	useEffect( () => {
-		if ( isPending ) {
-			return;
-		}
-		if ( isError ) {
-			page.replace( getConnectUrl() );
+		if ( isPending || isError ) {
 			return;
 		}
 		const connections = data?.connections ?? [];
@@ -22,6 +20,17 @@ export function FediverseLandingView() {
 			page.replace( getConnectUrl() );
 		}
 	}, [ data, isPending, isError ] );
+
+	if ( isError ) {
+		return (
+			<div role="alert" className="fediverse-landing-error">
+				<p>{ translate( "We couldn't load your Fediverse connections." ) }</p>
+				<Button variant="secondary" onClick={ () => refetch() }>
+					{ translate( 'Try again' ) }
+				</Button>
+			</div>
+		);
+	}
 
 	return <Spinner />;
 }

--- a/client/reader/fediverse/fediverse-navigation.tsx
+++ b/client/reader/fediverse/fediverse-navigation.tsx
@@ -1,0 +1,75 @@
+import { useTranslate, type TranslateResult } from 'i18n-calypso';
+import SectionNav from 'calypso/components/section-nav';
+import NavItem from 'calypso/components/section-nav/item';
+import NavTabs from 'calypso/components/section-nav/tabs';
+import { useDispatch } from 'calypso/state';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import { TIMELINE_TAB, PROFILE_TAB, SETTINGS_TAB } from './helper';
+import { getAccountUrl } from './route';
+
+interface Tab {
+	slug: string;
+	title: TranslateResult;
+	path: string;
+}
+
+interface Props {
+	connectionId: number;
+	selectedTab: string;
+}
+
+export function FediverseNavigation( { connectionId, selectedTab }: Props ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const recordTabClick = ( tab: string ) => {
+		dispatch(
+			recordReaderTracksEvent( 'calypso_reader_fediverse_tab_clicked', {
+				connection_id: connectionId,
+				tab,
+			} )
+		);
+	};
+
+	const tabs: Tab[] = [
+		{
+			slug: TIMELINE_TAB,
+			title: translate( 'Timeline' ),
+			path: getAccountUrl( connectionId, TIMELINE_TAB ),
+		},
+		{
+			slug: PROFILE_TAB,
+			title: translate( 'Profile' ),
+			path: getAccountUrl( connectionId, PROFILE_TAB ),
+		},
+		{
+			slug: SETTINGS_TAB,
+			title: translate( 'Settings' ),
+			path: getAccountUrl( connectionId, SETTINGS_TAB ),
+		},
+	];
+
+	const selected = tabs.find( ( tab ) => tab.slug === selectedTab );
+
+	return (
+		<SectionNav
+			className="fediverse-navigation"
+			selectedText={ selected?.title }
+			variation="minimal"
+			enforceTabsView
+		>
+			<NavTabs hasHorizontalScroll>
+				{ tabs.map( ( tab ) => (
+					<NavItem
+						key={ tab.slug }
+						selected={ selectedTab === tab.slug }
+						path={ tab.path }
+						onClick={ () => recordTabClick( tab.slug ) }
+					>
+						{ tab.title }
+					</NavItem>
+				) ) }
+			</NavTabs>
+		</SectionNav>
+	);
+}

--- a/client/reader/fediverse/fediverse-oauth-callback-view.tsx
+++ b/client/reader/fediverse/fediverse-oauth-callback-view.tsx
@@ -1,0 +1,99 @@
+import { useCompleteFediverseConnectionMutation } from '@automattic/api-queries';
+import page from '@automattic/calypso-router';
+import { Spinner } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useMemo, useRef } from 'react';
+import { useDispatch } from 'calypso/state';
+import { trackFediverseEvent } from './analytics';
+import { clearOauthState, loadOauthState } from './oauth-state';
+import { getAccountUrl, getConnectUrl } from './route';
+import type { FediverseError } from '@automattic/api-core';
+
+interface Props {
+	query: { code?: string; state?: string; error?: string };
+}
+
+export function FediverseOauthCallbackView( { query }: Props ) {
+	const reduxDispatch = useDispatch();
+	const translate = useTranslate();
+	const complete = useCompleteFediverseConnectionMutation();
+	// Run exactly once per mount. StrictMode double-invoke in dev would
+	// otherwise fire two complete requests and the server would reject the
+	// second one (the authorization code is single-use).
+	const startedRef = useRef( false );
+
+	const providerError = query.error;
+	const code = query.code;
+	const state = query.state;
+
+	// Read storage once per mount. Re-reading on every render would flip
+	// `stateMismatch` to true after clearOauthState() in onSuccess, flashing
+	// an error before page.replace navigation tears down.
+	const stored = useMemo( loadOauthState, [] );
+
+	useEffect( () => {
+		if ( startedRef.current ) {
+			return;
+		}
+		if ( providerError || ! code || ! state ) {
+			return;
+		}
+		if ( ! stored || stored.state !== state ) {
+			return;
+		}
+		startedRef.current = true;
+		complete.mutate(
+			{ code, state },
+			{
+				onSuccess: ( { connection } ) => {
+					clearOauthState();
+					reduxDispatch(
+						trackFediverseEvent( 'CONNECT_COMPLETED', { connection_id: connection.id } )
+					);
+					page.replace( getAccountUrl( connection.id, 'timeline' ) );
+				},
+				onError: ( error: FediverseError ) => {
+					clearOauthState();
+					reduxDispatch(
+						trackFediverseEvent( 'CONNECT_FAILED', { step: 'complete', error: error.kind } )
+					);
+					page.replace( `${ getConnectUrl() }?error=${ encodeURIComponent( error.kind ) }` );
+				},
+			}
+		);
+	}, [ providerError, code, state, stored, complete, reduxDispatch ] );
+
+	// Terminal error branches: clear stale oauth state so it doesn't linger
+	// across retries.
+	const missingParams = ! providerError && ( ! code || ! state );
+	const stateMismatch =
+		! providerError && !! code && !! state && ( ! stored || stored.state !== state );
+
+	useEffect( () => {
+		if ( providerError ) {
+			clearOauthState();
+			reduxDispatch(
+				trackFediverseEvent( 'CONNECT_FAILED', {
+					step: 'authorize',
+					error: providerError,
+				} )
+			);
+			page.replace( `${ getConnectUrl() }?error=${ encodeURIComponent( providerError ) }` );
+		} else if ( missingParams ) {
+			clearOauthState();
+			page.replace( `${ getConnectUrl() }?error=missing_params` );
+		} else if ( stateMismatch ) {
+			clearOauthState();
+			page.replace( `${ getConnectUrl() }?error=state_mismatch` );
+		}
+	}, [ providerError, missingParams, stateMismatch, reduxDispatch ] );
+
+	return (
+		<div role="status" aria-live="polite">
+			<Spinner />
+			<p>{ translate( 'Finishing connection…' ) }</p>
+		</div>
+	);
+}
+
+export default FediverseOauthCallbackView;

--- a/client/reader/fediverse/fediverse-oauth-callback-view.tsx
+++ b/client/reader/fediverse/fediverse-oauth-callback-view.tsx
@@ -45,7 +45,7 @@ export function FediverseOauthCallbackView( { query }: Props ) {
 		complete.mutate(
 			{ code, state },
 			{
-				onSuccess: ( { connection } ) => {
+				onSuccess: ( connection ) => {
 					clearOauthState();
 					reduxDispatch(
 						trackFediverseEvent( 'CONNECT_COMPLETED', { connection_id: connection.id } )

--- a/client/reader/fediverse/helper.ts
+++ b/client/reader/fediverse/helper.ts
@@ -1,0 +1,5 @@
+export const TIMELINE_TAB = 'timeline' as const;
+export const PROFILE_TAB = 'profile' as const;
+export const SETTINGS_TAB = 'settings' as const;
+
+export type FediverseTab = typeof TIMELINE_TAB | typeof PROFILE_TAB | typeof SETTINGS_TAB;

--- a/client/reader/fediverse/helper.ts
+++ b/client/reader/fediverse/helper.ts
@@ -1,5 +1,3 @@
 export const TIMELINE_TAB = 'timeline' as const;
 export const PROFILE_TAB = 'profile' as const;
 export const SETTINGS_TAB = 'settings' as const;
-
-export type FediverseTab = typeof TIMELINE_TAB | typeof PROFILE_TAB | typeof SETTINGS_TAB;

--- a/client/reader/fediverse/index.tsx
+++ b/client/reader/fediverse/index.tsx
@@ -1,0 +1,48 @@
+import './style.scss';
+
+import page from '@automattic/calypso-router';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { sidebar, setBeforePrimary } from 'calypso/reader/controller';
+import {
+	fediverseAccount,
+	fediverseConnect,
+	fediverseIdRedirect,
+	fediverseLanding,
+	fediverseOauthCallback,
+} from './controller';
+
+export default function () {
+	page(
+		'/reader/fediverse',
+		sidebar,
+		setBeforePrimary,
+		fediverseLanding,
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/reader/fediverse/connect',
+		sidebar,
+		setBeforePrimary,
+		fediverseConnect,
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/reader/fediverse/oauth-callback',
+		sidebar,
+		setBeforePrimary,
+		fediverseOauthCallback,
+		makeLayout,
+		clientRender
+	);
+	page( '/reader/fediverse/:id(\\d+)', fediverseIdRedirect );
+	page(
+		'/reader/fediverse/:id(\\d+)/:tab',
+		sidebar,
+		setBeforePrimary,
+		fediverseAccount,
+		makeLayout,
+		clientRender
+	);
+}

--- a/client/reader/fediverse/oauth-state.ts
+++ b/client/reader/fediverse/oauth-state.ts
@@ -23,11 +23,14 @@ export function saveOauthState( value: FediverseOauthState ): void {
 	}
 	try {
 		storage.setItem( STORAGE_KEY, JSON.stringify( value ) );
-	} catch {
+	} catch ( err ) {
 		// sessionStorage can throw in private-mode or when the quota is
-		// exceeded. Save is best-effort; if it fails, the callback view
-		// will detect the missing stored state and surface a retry
-		// prompt rather than silently continuing.
+		// exceeded. Save is best-effort; the callback view will detect
+		// the missing stored state and surface a retry prompt. Log so
+		// the failure mode is visible in the browser console rather
+		// than disappearing silently.
+		// eslint-disable-next-line no-console
+		console.error( 'Fediverse OAuth state save failed:', err );
 	}
 }
 
@@ -51,7 +54,9 @@ export function loadOauthState(): FediverseOauthState | null {
 			return parsed as FediverseOauthState;
 		}
 		return null;
-	} catch {
+	} catch ( err ) {
+		// eslint-disable-next-line no-console
+		console.error( 'Fediverse OAuth state load failed:', err );
 		return null;
 	}
 }

--- a/client/reader/fediverse/oauth-state.ts
+++ b/client/reader/fediverse/oauth-state.ts
@@ -1,0 +1,70 @@
+const STORAGE_KEY = 'reader-fediverse-oauth-state';
+
+export interface FediverseOauthState {
+	state: string;
+	blog_id: number;
+}
+
+function getStorage(): Storage | null {
+	if ( typeof window === 'undefined' ) {
+		return null;
+	}
+	try {
+		return window.sessionStorage;
+	} catch {
+		return null;
+	}
+}
+
+export function saveOauthState( value: FediverseOauthState ): void {
+	const storage = getStorage();
+	if ( ! storage ) {
+		return;
+	}
+	try {
+		storage.setItem( STORAGE_KEY, JSON.stringify( value ) );
+	} catch {
+		// sessionStorage can throw in private-mode or when the quota is
+		// exceeded. Save is best-effort; if it fails, the callback view
+		// will detect the missing stored state and surface a retry
+		// prompt rather than silently continuing.
+	}
+}
+
+export function loadOauthState(): FediverseOauthState | null {
+	const storage = getStorage();
+	if ( ! storage ) {
+		return null;
+	}
+	try {
+		const raw = storage.getItem( STORAGE_KEY );
+		if ( ! raw ) {
+			return null;
+		}
+		const parsed = JSON.parse( raw ) as unknown;
+		if (
+			typeof parsed === 'object' &&
+			parsed !== null &&
+			typeof ( parsed as FediverseOauthState ).state === 'string' &&
+			typeof ( parsed as FediverseOauthState ).blog_id === 'number'
+		) {
+			return parsed as FediverseOauthState;
+		}
+		return null;
+	} catch {
+		return null;
+	}
+}
+
+export function clearOauthState(): void {
+	const storage = getStorage();
+	if ( ! storage ) {
+		return;
+	}
+	try {
+		storage.removeItem( STORAGE_KEY );
+	} catch {
+		// Best-effort cleanup; if storage is unavailable, there is nothing
+		// to clear anyway.
+	}
+}

--- a/client/reader/fediverse/profile-panel.tsx
+++ b/client/reader/fediverse/profile-panel.tsx
@@ -1,0 +1,23 @@
+import { useTranslate } from 'i18n-calypso';
+import EmptyContent from 'calypso/components/empty-content';
+
+interface Props {
+	handle: string;
+	actorUrl: string;
+	siteHost: string;
+}
+
+export function ProfilePanel( { handle, actorUrl, siteHost }: Props ) {
+	const translate = useTranslate();
+	return (
+		<EmptyContent
+			title={ translate( 'You are connected as %(handle)s', { args: { handle } } ) }
+			line={ translate( 'Posts you publish will appear on %(siteHost)s and across the Fediverse.', {
+				args: { siteHost },
+			} ) }
+			action={ translate( 'View your profile on %(siteHost)s', { args: { siteHost } } ) }
+			actionURL={ actorUrl }
+			actionTarget="_blank"
+		/>
+	);
+}

--- a/client/reader/fediverse/route.ts
+++ b/client/reader/fediverse/route.ts
@@ -1,0 +1,15 @@
+export function getLandingUrl(): string {
+	return '/reader/fediverse';
+}
+export function getConnectUrl(): string {
+	return '/reader/fediverse/connect';
+}
+export function getOauthCallbackUrl(): string {
+	return '/reader/fediverse/oauth-callback';
+}
+export function getAccountUrl(
+	connectionId: number,
+	tab: 'timeline' | 'profile' | 'settings' = 'timeline'
+): string {
+	return `/reader/fediverse/${ connectionId }/${ tab }`;
+}

--- a/client/reader/fediverse/route.ts
+++ b/client/reader/fediverse/route.ts
@@ -4,9 +4,6 @@ export function getLandingUrl(): string {
 export function getConnectUrl(): string {
 	return '/reader/fediverse/connect';
 }
-export function getOauthCallbackUrl(): string {
-	return '/reader/fediverse/oauth-callback';
-}
 export function getAccountUrl(
 	connectionId: number,
 	tab: 'timeline' | 'profile' | 'settings' = 'timeline'

--- a/client/reader/fediverse/settings-panel.tsx
+++ b/client/reader/fediverse/settings-panel.tsx
@@ -1,9 +1,88 @@
-// Task 10 will replace this implementation.
+import {
+	useFediverseConnectionQuery,
+	useDisconnectFediverseMutation,
+} from '@automattic/api-queries';
+import page from '@automattic/calypso-router';
+import {
+	Button,
+	Card,
+	CardBody,
+	Spinner,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import { useDispatch } from 'calypso/state';
+import { trackFediverseEvent } from './analytics';
+import { getLandingUrl } from './route';
+
 interface Props {
 	connectionId: number;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function SettingsPanel( { connectionId: _connectionId }: Props ) {
-	return null; // implemented by Task 10
+export function SettingsPanel( { connectionId }: Props ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const { data: connection, isPending } = useFediverseConnectionQuery( connectionId );
+	const disconnect = useDisconnectFediverseMutation( connectionId );
+	const [ confirming, setConfirming ] = useState( false );
+
+	if ( isPending || ! connection ) {
+		return (
+			<Card>
+				<CardBody>
+					<Spinner />
+				</CardBody>
+			</Card>
+		);
+	}
+
+	const handleClick = () => {
+		if ( ! confirming ) {
+			setConfirming( true );
+			return;
+		}
+		disconnect.mutate( undefined, {
+			onSuccess: () => {
+				dispatch( trackFediverseEvent( 'DISCONNECTED', { connection_id: connectionId } ) );
+				page( getLandingUrl() );
+			},
+		} );
+	};
+
+	return (
+		<Card>
+			<CardBody>
+				<VStack spacing={ 4 }>
+					<h2>{ translate( 'Connection' ) }</h2>
+					<p>
+						<strong>{ connection.handle }</strong>
+						<br />
+						{ connection.site_host }
+					</p>
+					<p>
+						{ translate(
+							'Disconnecting will remove your Fediverse connection from WordPress.com. Your posts on %(siteHost)s will not be deleted.',
+							{ args: { siteHost: connection.site_host } }
+						) }
+					</p>
+					{ disconnect.isError && (
+						<p role="alert">{ translate( "We couldn't disconnect. Please try again." ) }</p>
+					) }
+					<div>
+						<Button
+							variant="secondary"
+							isDestructive
+							disabled={ disconnect.isPending }
+							onClick={ handleClick }
+						>
+							{ confirming
+								? translate( 'Are you sure? Click again to disconnect' )
+								: translate( 'Disconnect' ) }
+						</Button>
+					</div>
+				</VStack>
+			</CardBody>
+		</Card>
+	);
 }

--- a/client/reader/fediverse/settings-panel.tsx
+++ b/client/reader/fediverse/settings-panel.tsx
@@ -1,0 +1,9 @@
+// Task 10 will replace this implementation.
+interface Props {
+	connectionId: number;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function SettingsPanel( { connectionId: _connectionId }: Props ) {
+	return null; // implemented by Task 10
+}

--- a/client/reader/fediverse/style.scss
+++ b/client/reader/fediverse/style.scss
@@ -1,0 +1,2 @@
+// Placeholder for future fediverse-section-level styles. Composer styles
+// live in client/reader/fediverse/composer/style.scss.

--- a/client/reader/fediverse/style.scss
+++ b/client/reader/fediverse/style.scss
@@ -1,2 +1,6 @@
-// Placeholder for future fediverse-section-level styles. Composer styles
-// live in client/reader/fediverse/composer/style.scss.
+// Composer styles live in client/reader/fediverse/composer/style.scss.
+
+.fediverse-connect__callback-error {
+	color: var( --color-error, #b91c1c );
+	margin-block-end: 1rem;
+}

--- a/client/reader/fediverse/test/fediverse-account-view.test.tsx
+++ b/client/reader/fediverse/test/fediverse-account-view.test.tsx
@@ -1,0 +1,224 @@
+/**
+ * @jest-environment jsdom
+ */
+import page from '@automattic/calypso-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { FediverseAccountView } from '../fediverse-account-view';
+import { PROFILE_TAB, SETTINGS_TAB, TIMELINE_TAB } from '../helper';
+import { getAccountUrl, getLandingUrl } from '../route';
+import type React from 'react';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+jest.mock( '@automattic/calypso-router', () => {
+	const replace = jest.fn();
+	const fn = jest.fn() as jest.Mock & { replace: jest.Mock };
+	fn.replace = replace;
+	return { __esModule: true, default: fn };
+} );
+
+jest.mock( 'calypso/reader/components/reader-main', () => ( {
+	__esModule: true,
+	default: function ReaderMain( { children }: { children: React.ReactNode } ) {
+		return <div>{ children }</div>;
+	},
+} ) );
+
+jest.mock( 'calypso/components/data/document-head', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+
+jest.mock( 'calypso/components/navigation-header', () => ( {
+	__esModule: true,
+	default: ( { title, subtitle }: { title: string; subtitle?: string } ) => (
+		<div>
+			<h1>{ title }</h1>
+			{ subtitle && <p>{ subtitle }</p> }
+		</div>
+	),
+} ) );
+
+// Mock the navigation component.
+jest.mock( '../fediverse-navigation', () => ( {
+	FediverseNavigation: ( { selectedTab }: { selectedTab: string } ) => (
+		<nav data-testid="fediverse-navigation" data-tab={ selectedTab } />
+	),
+} ) );
+
+// Mock panel components.
+jest.mock( '../timeline-panel', () => ( {
+	TimelinePanel: ( { handle }: { handle: string } ) => (
+		<div data-testid="timeline-panel">Timeline: { handle }</div>
+	),
+} ) );
+
+jest.mock( '../profile-panel', () => ( {
+	ProfilePanel: () => <div data-testid="profile-panel">Profile</div>,
+} ) );
+
+jest.mock( '../settings-panel', () => ( {
+	SettingsPanel: () => <div data-testid="settings-panel">Settings</div>,
+} ) );
+
+// Mock composer.
+jest.mock( '../composer', () => ( {
+	ComposerProvider: ( { children }: { children: React.ReactNode } ) => <>{ children }</>,
+	ComposerModal: () => null,
+	ComposeFab: () => null,
+} ) );
+
+// Mock @wordpress/components to avoid the full package import.
+jest.mock( '@wordpress/components', () => ( {
+	__experimentalVStack: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+} ) );
+
+// Mock i18n-calypso.
+jest.mock( 'i18n-calypso', () => ( {
+	useTranslate: () => ( str: string, options?: { args?: Record< string, string > } ) => {
+		if ( options?.args ) {
+			return Object.entries( options.args ).reduce(
+				( result, [ key, value ] ) => result.replace( `%(${ key })s`, value ),
+				str
+			);
+		}
+		return str;
+	},
+} ) );
+
+// Mock @automattic/api-queries entirely.
+const mockUseFediverseConnectionsQuery = jest.fn();
+jest.mock( '@automattic/api-queries', () => ( {
+	useFediverseConnectionsQuery: ( ...args: unknown[] ) =>
+		mockUseFediverseConnectionsQuery( ...args ),
+} ) );
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const CONNECTION = {
+	id: 7,
+	handle: '@alice@example.com',
+	site_host: 'example.com',
+	actor_url: 'https://example.com/users/alice',
+	avatar: '',
+	blog_id: 123,
+	actor_type: 'user' as const,
+};
+
+function makeClient() {
+	return new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+}
+
+function renderView( connectionId: number, tab: string ) {
+	const client = makeClient();
+	const Wrapper = ( { children }: { children: React.ReactNode } ) => (
+		<QueryClientProvider client={ client }>{ children }</QueryClientProvider>
+	);
+	return render( <FediverseAccountView connectionId={ connectionId } tab={ tab } />, {
+		wrapper: Wrapper,
+	} );
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+describe( 'FediverseAccountView', () => {
+	beforeEach( () => {
+		( page as unknown as jest.Mock ).mockClear();
+		( page.replace as jest.Mock ).mockClear();
+		mockUseFediverseConnectionsQuery.mockClear();
+	} );
+
+	// -------------------------------------------------------------------------
+	// 1. Pending state
+	// -------------------------------------------------------------------------
+
+	it( 'shows Loading… while connections are pending', () => {
+		mockUseFediverseConnectionsQuery.mockReturnValue( {
+			data: undefined,
+			isPending: true,
+		} );
+
+		renderView( 7, TIMELINE_TAB );
+
+		expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Loading…' );
+		expect( page.replace ).not.toHaveBeenCalled();
+	} );
+
+	// -------------------------------------------------------------------------
+	// 2. No matching connection → redirect to landing
+	// -------------------------------------------------------------------------
+
+	it( 'redirects to landing URL when connection is not found', async () => {
+		mockUseFediverseConnectionsQuery.mockReturnValue( {
+			data: { connections: [ CONNECTION ] },
+			isPending: false,
+		} );
+
+		renderView( 999, TIMELINE_TAB );
+
+		await waitFor( () => expect( page.replace ).toHaveBeenCalledWith( getLandingUrl() ) );
+	} );
+
+	// -------------------------------------------------------------------------
+	// 3. Invalid tab → redirect to timeline
+	// -------------------------------------------------------------------------
+
+	it( 'redirects to timeline when tab is invalid', async () => {
+		mockUseFediverseConnectionsQuery.mockReturnValue( {
+			data: { connections: [ CONNECTION ] },
+			isPending: false,
+		} );
+
+		renderView( 7, 'nope' );
+
+		await waitFor( () =>
+			expect( page.replace ).toHaveBeenCalledWith( getAccountUrl( 7, TIMELINE_TAB ) )
+		);
+	} );
+
+	// -------------------------------------------------------------------------
+	// 4. Valid connection + valid tab → render panel + nav
+	// -------------------------------------------------------------------------
+
+	it( 'renders the timeline panel and navigation for a valid connection', async () => {
+		mockUseFediverseConnectionsQuery.mockReturnValue( {
+			data: { connections: [ CONNECTION ] },
+			isPending: false,
+		} );
+
+		renderView( 7, TIMELINE_TAB );
+
+		expect( await screen.findByTestId( 'timeline-panel' ) ).toBeVisible();
+		expect( screen.getByTestId( 'fediverse-navigation' ) ).toBeVisible();
+		expect( page.replace ).not.toHaveBeenCalled();
+	} );
+
+	it( 'renders the profile panel when tab is profile', async () => {
+		mockUseFediverseConnectionsQuery.mockReturnValue( {
+			data: { connections: [ CONNECTION ] },
+			isPending: false,
+		} );
+
+		renderView( 7, PROFILE_TAB );
+
+		expect( await screen.findByTestId( 'profile-panel' ) ).toBeVisible();
+	} );
+
+	it( 'renders the settings panel when tab is settings', async () => {
+		mockUseFediverseConnectionsQuery.mockReturnValue( {
+			data: { connections: [ CONNECTION ] },
+			isPending: false,
+		} );
+
+		renderView( 7, SETTINGS_TAB );
+
+		expect( await screen.findByTestId( 'settings-panel' ) ).toBeVisible();
+	} );
+} );

--- a/client/reader/fediverse/test/fediverse-account-view.test.tsx
+++ b/client/reader/fediverse/test/fediverse-account-view.test.tsx
@@ -74,6 +74,7 @@ jest.mock( '../composer', () => ( {
 // Mock @wordpress/components to avoid the full package import.
 jest.mock( '@wordpress/components', () => ( {
 	__experimentalVStack: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+	Button: ( props: React.ButtonHTMLAttributes< HTMLButtonElement > ) => <button { ...props } />,
 } ) );
 
 // Mock i18n-calypso.

--- a/client/reader/fediverse/test/fediverse-connect-view.test.tsx
+++ b/client/reader/fediverse/test/fediverse-connect-view.test.tsx
@@ -1,0 +1,278 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { FediverseConnectView } from '../fediverse-connect-view';
+import type { FediverseSiteCapabilities } from '@automattic/api-core';
+import type React from 'react';
+
+// ---------------------------------------------------------------------------
+// Shared mock state for api-queries hooks. Tests configure these objects to
+// control hook return values before rendering.
+// ---------------------------------------------------------------------------
+
+let mockCapabilitiesQuery = {
+	isSuccess: false,
+	isError: false,
+	data: undefined as FediverseSiteCapabilities | undefined,
+	error: undefined as unknown,
+	refetch: jest.fn(),
+};
+
+const mockEnableFeatureMutate = jest.fn();
+const mockEnableC2sMutate = jest.fn();
+const mockEnableUserActorsMutate = jest.fn();
+const mockAuthorizeMutate = jest.fn();
+
+jest.mock( '@automattic/api-queries', () => ( {
+	useFediverseSiteCapabilitiesQuery: () => mockCapabilitiesQuery,
+	useEnableFediverseFeatureMutation: () => ( { mutate: mockEnableFeatureMutate } ),
+	useEnableFediverseC2sMutation: () => ( { mutate: mockEnableC2sMutate } ),
+	useEnableFediverseUserActorsMutation: () => ( { mutate: mockEnableUserActorsMutate } ),
+	useAuthorizeFediverseConnectionMutation: () => ( { mutate: mockAuthorizeMutate } ),
+} ) );
+
+// Mock SiteSelector so we can test the PICK_SITE transition without Redux wiring.
+jest.mock( 'calypso/components/site-selector', () => ( {
+	__esModule: true,
+	default: ( { onSiteSelect }: { onSiteSelect: ( id: number ) => void } ) => (
+		<button onClick={ () => onSiteSelect( 123 ) }>Pick site</button>
+	),
+} ) );
+
+// Mock analytics — recordReaderTracksEvent must return a plain Redux action
+// so that useDispatch can dispatch it without erroring.
+const mockRecordReaderTracksEvent = jest.fn( () => ( { type: 'TEST_TRACKS_EVENT' } ) );
+jest.mock( 'calypso/state/reader/analytics/actions', () => ( {
+	recordReaderTracksEvent: ( ...args: unknown[] ) => mockRecordReaderTracksEvent( ...args ),
+} ) );
+
+// ---------------------------------------------------------------------------
+// Helper factories
+// ---------------------------------------------------------------------------
+
+function makeCaps(
+	overrides: Partial< FediverseSiteCapabilities > = {}
+): FediverseSiteCapabilities {
+	return {
+		activitypub_active: true,
+		c2s_enabled: true,
+		actors: {
+			user: { enabled: true, can_enable: true },
+			blog: { enabled: false, can_enable: true },
+		},
+		oauth_metadata: null,
+		site_host: 'example.wordpress.com',
+		site_kind: 'wpcom',
+		current_user_can_publish: true,
+		...overrides,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+describe( 'FediverseConnectView', () => {
+	let assignMock: jest.Mock;
+	let originalLocation: Location;
+
+	beforeEach( () => {
+		// Reset all mock state before each test.
+		mockCapabilitiesQuery = {
+			isSuccess: false,
+			isError: false,
+			data: undefined,
+			error: undefined,
+			refetch: jest.fn(),
+		};
+
+		mockEnableFeatureMutate.mockReset();
+		mockEnableC2sMutate.mockReset();
+		mockEnableUserActorsMutate.mockReset();
+		mockAuthorizeMutate.mockReset();
+		mockRecordReaderTracksEvent.mockClear();
+
+		window.sessionStorage.clear();
+
+		originalLocation = window.location;
+		assignMock = jest.fn();
+		Object.defineProperty( window, 'location', {
+			configurable: true,
+			writable: true,
+			value: { ...originalLocation, assign: assignMock },
+		} );
+	} );
+
+	afterEach( () => {
+		Object.defineProperty( window, 'location', {
+			configurable: true,
+			writable: true,
+			value: originalLocation,
+		} );
+	} );
+
+	// -------------------------------------------------------------------------
+	// 1. Initial render
+	// -------------------------------------------------------------------------
+
+	it( 'renders SitePickerStep initially', () => {
+		renderWithProvider( <FediverseConnectView /> );
+		expect( screen.getByRole( 'heading', { name: /connect a fediverse site/i } ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: /pick site/i } ) ).toBeVisible();
+	} );
+
+	// -------------------------------------------------------------------------
+	// 2. Picking a site transitions to CHECKING_CAPABILITIES
+	// -------------------------------------------------------------------------
+
+	it( 'transitions to CHECKING_CAPABILITIES (shows spinner) after picking a site', async () => {
+		const user = userEvent.setup();
+
+		// Capabilities not yet resolved — stays in CHECKING_CAPABILITIES.
+		mockCapabilitiesQuery.isSuccess = false;
+		mockCapabilitiesQuery.isError = false;
+
+		renderWithProvider( <FediverseConnectView /> );
+
+		await user.click( screen.getByRole( 'button', { name: /pick site/i } ) );
+
+		// In CHECKING_CAPABILITIES with no caps, CapabilityChecklist renders a spinner.
+		await waitFor( () => expect( screen.getByRole( 'presentation' ) ).toBeVisible() );
+	} );
+
+	// -------------------------------------------------------------------------
+	// 3. Capabilities resolve (all flags true) → CHECKLIST_READY → authorize
+	// -------------------------------------------------------------------------
+
+	it( 'shows checklist and triggers authorize flow when all capabilities are green', async () => {
+		const user = userEvent.setup();
+		const caps = makeCaps();
+
+		// Pre-configure: capabilities succeed immediately on first render.
+		mockCapabilitiesQuery.isSuccess = true;
+		mockCapabilitiesQuery.data = caps;
+
+		// authorize.mutate resolves synchronously with a URL.
+		mockAuthorizeMutate.mockImplementation(
+			(
+				_params: unknown,
+				{ onSuccess }: { onSuccess: ( data: { authorize_url: string; state: string } ) => void }
+			) => {
+				onSuccess( {
+					authorize_url: 'https://example.wordpress.com/oauth/authorize?state=xyz',
+					state: 'xyz',
+				} );
+			}
+		);
+
+		renderWithProvider( <FediverseConnectView /> );
+
+		// Pick a site — enters CHECKING_CAPABILITIES then immediately CHECKLIST_READY
+		// because capabilities are already resolved.
+		await user.click( screen.getByRole( 'button', { name: /pick site/i } ) );
+
+		// Wait for the checklist to appear (CHECKLIST_READY).
+		await waitFor( () =>
+			expect( screen.getByRole( 'button', { name: /enable & connect/i } ) ).toBeVisible()
+		);
+
+		// Click "Enable & Connect" — all caps are true so goes to AUTHORIZING.
+		await user.click( screen.getByRole( 'button', { name: /enable & connect/i } ) );
+
+		// authorize.mutate fires, onSuccess saves state + sets REDIRECTING which assigns URL.
+		await waitFor( () =>
+			expect( assignMock ).toHaveBeenCalledWith(
+				'https://example.wordpress.com/oauth/authorize?state=xyz'
+			)
+		);
+
+		// OAuth state should be persisted to sessionStorage.
+		const stored = JSON.parse(
+			window.sessionStorage.getItem( 'reader-fediverse-oauth-state' ) ?? 'null'
+		);
+		expect( stored ).toMatchObject( { state: 'xyz', blog_id: 123 } );
+	} );
+
+	// -------------------------------------------------------------------------
+	// 4. activitypub_active: false → clicking "Enable & Connect" calls enableFeature
+	// -------------------------------------------------------------------------
+
+	it( 'calls enableFeature.mutate when activitypub_active is false', async () => {
+		const user = userEvent.setup();
+		const caps = makeCaps( { activitypub_active: false } );
+
+		// Pre-configure: capabilities resolve immediately.
+		mockCapabilitiesQuery.isSuccess = true;
+		mockCapabilitiesQuery.data = caps;
+
+		// enableFeature does nothing (leaves wizard in ENABLING_FEATURE).
+		mockEnableFeatureMutate.mockImplementation( () => undefined );
+
+		renderWithProvider( <FediverseConnectView /> );
+
+		await user.click( screen.getByRole( 'button', { name: /pick site/i } ) );
+
+		// Wait for checklist (activitypub_active=false means the row is unchecked but checklist renders).
+		await waitFor( () =>
+			expect( screen.getByRole( 'button', { name: /enable & connect/i } ) ).toBeVisible()
+		);
+
+		await user.click( screen.getByRole( 'button', { name: /enable & connect/i } ) );
+
+		await waitFor( () => expect( mockEnableFeatureMutate ).toHaveBeenCalledTimes( 1 ) );
+	} );
+
+	// -------------------------------------------------------------------------
+	// 5. enableFeature fails with forbidden → permission_denied error state
+	// -------------------------------------------------------------------------
+
+	it( 'shows permission-denied error when enableFeature fails with forbidden', async () => {
+		const user = userEvent.setup();
+		const caps = makeCaps( { activitypub_active: false } );
+
+		mockCapabilitiesQuery.isSuccess = true;
+		mockCapabilitiesQuery.data = caps;
+
+		mockEnableFeatureMutate.mockImplementation(
+			( _params: unknown, { onError }: { onError: ( err: unknown ) => void } ) => {
+				onError( { kind: 'forbidden', message: 'Permission denied.' } );
+			}
+		);
+
+		renderWithProvider( <FediverseConnectView /> );
+
+		await user.click( screen.getByRole( 'button', { name: /pick site/i } ) );
+
+		await waitFor( () =>
+			expect( screen.getByRole( 'button', { name: /enable & connect/i } ) ).toBeVisible()
+		);
+
+		await user.click( screen.getByRole( 'button', { name: /enable & connect/i } ) );
+
+		// The error title uses a curly apostrophe (') from wizard-error-states.tsx.
+		await waitFor( () => expect( screen.getByText( /permission to enable this/i ) ).toBeVisible() );
+	} );
+
+	// -------------------------------------------------------------------------
+	// 6. Capabilities query fails → ERROR with errorStep capability_check
+	// -------------------------------------------------------------------------
+
+	it( 'shows capability_check error when capabilities query fails', async () => {
+		const user = userEvent.setup();
+
+		// Pre-configure: capabilities fail immediately.
+		mockCapabilitiesQuery.isSuccess = false;
+		mockCapabilitiesQuery.isError = true;
+		mockCapabilitiesQuery.error = { kind: 'upstream_unavailable' };
+
+		renderWithProvider( <FediverseConnectView /> );
+
+		await user.click( screen.getByRole( 'button', { name: /pick site/i } ) );
+
+		// The error title uses a curly apostrophe (') from wizard-error-states.tsx.
+		await waitFor( () => expect( screen.getByText( /reach this site/i ) ).toBeVisible() );
+	} );
+} );

--- a/client/reader/fediverse/test/fediverse-landing-view.test.tsx
+++ b/client/reader/fediverse/test/fediverse-landing-view.test.tsx
@@ -3,7 +3,8 @@
  */
 import page from '@automattic/calypso-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { FediverseLandingView } from '../fediverse-landing-view';
 import { getAccountUrl, getConnectUrl } from '../route';
 import type React from 'react';
@@ -22,6 +23,7 @@ jest.mock( '@automattic/calypso-router', () => {
 // Mock @wordpress/components to avoid the full package import.
 jest.mock( '@wordpress/components', () => ( {
 	Spinner: () => null,
+	Button: ( props: React.ButtonHTMLAttributes< HTMLButtonElement > ) => <button { ...props } />,
 } ) );
 
 // Mock @automattic/api-queries entirely.
@@ -150,19 +152,27 @@ describe( 'FediverseLandingView', () => {
 	} );
 
 	// -------------------------------------------------------------------------
-	// 4. Error: redirect to connect page
+	// 4. Error: shows retry UI instead of silently redirecting
 	// -------------------------------------------------------------------------
 
-	it( 'redirects to connect page when query fails', async () => {
+	it( 'shows an error with a retry button when the query fails', async () => {
+		const refetch = jest.fn();
 		mockUseFediverseConnectionsQuery.mockReturnValue( {
 			data: undefined,
 			isPending: false,
 			isError: true,
+			refetch,
 		} );
 
 		renderView();
 
-		await waitFor( () => expect( page.replace ).toHaveBeenCalledWith( getConnectUrl() ) );
+		expect( screen.getByRole( 'alert' ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: /try again/i } ) ).toBeVisible();
+		expect( page.replace ).not.toHaveBeenCalled();
+
+		const user = userEvent.setup();
+		await user.click( screen.getByRole( 'button', { name: /try again/i } ) );
+		expect( refetch ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'redirects to connect page even when data is null', async () => {

--- a/client/reader/fediverse/test/fediverse-landing-view.test.tsx
+++ b/client/reader/fediverse/test/fediverse-landing-view.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * @jest-environment jsdom
+ */
+import page from '@automattic/calypso-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, waitFor } from '@testing-library/react';
+import { FediverseLandingView } from '../fediverse-landing-view';
+import { getAccountUrl, getConnectUrl } from '../route';
+import type React from 'react';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+jest.mock( '@automattic/calypso-router', () => {
+	const replace = jest.fn();
+	const fn = jest.fn() as jest.Mock & { replace: jest.Mock };
+	fn.replace = replace;
+	return { __esModule: true, default: fn };
+} );
+
+// Mock @wordpress/components to avoid the full package import.
+jest.mock( '@wordpress/components', () => ( {
+	Spinner: () => null,
+} ) );
+
+// Mock @automattic/api-queries entirely.
+const mockUseFediverseConnectionsQuery = jest.fn();
+jest.mock( '@automattic/api-queries', () => ( {
+	useFediverseConnectionsQuery: ( ...args: unknown[] ) =>
+		mockUseFediverseConnectionsQuery( ...args ),
+} ) );
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeClient() {
+	return new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+}
+
+function renderView() {
+	const client = makeClient();
+	const Wrapper = ( { children }: { children: React.ReactNode } ) => (
+		<QueryClientProvider client={ client }>{ children }</QueryClientProvider>
+	);
+	return render( <FediverseLandingView />, { wrapper: Wrapper } );
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+describe( 'FediverseLandingView', () => {
+	beforeEach( () => {
+		( page as unknown as jest.Mock ).mockClear();
+		( page.replace as jest.Mock ).mockClear();
+		mockUseFediverseConnectionsQuery.mockClear();
+	} );
+
+	// -------------------------------------------------------------------------
+	// 1. Pending: Spinner shown, no redirect
+	// -------------------------------------------------------------------------
+
+	it( 'shows spinner while connections are loading', () => {
+		mockUseFediverseConnectionsQuery.mockReturnValue( {
+			data: undefined,
+			isPending: true,
+			isError: false,
+		} );
+
+		const { container } = renderView();
+
+		// Spinner should be rendered (mock returns null, so container is just the wrapper)
+		expect( container ).toBeTruthy();
+		expect( page.replace ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not redirect while pending', async () => {
+		mockUseFediverseConnectionsQuery.mockReturnValue( {
+			data: undefined,
+			isPending: true,
+			isError: false,
+		} );
+
+		renderView();
+
+		// Wait a bit and ensure no redirect happened
+		await waitFor(
+			() => {
+				expect( page.replace ).not.toHaveBeenCalled();
+			},
+			{ timeout: 100 }
+		);
+	} );
+
+	// -------------------------------------------------------------------------
+	// 2. Empty connections: redirect to connect page
+	// -------------------------------------------------------------------------
+
+	it( 'redirects to connect page when no connections exist', async () => {
+		mockUseFediverseConnectionsQuery.mockReturnValue( {
+			data: { connections: [] },
+			isPending: false,
+			isError: false,
+		} );
+
+		renderView();
+
+		await waitFor( () => expect( page.replace ).toHaveBeenCalledWith( getConnectUrl() ) );
+	} );
+
+	// -------------------------------------------------------------------------
+	// 3. One connection: redirect to timeline
+	// -------------------------------------------------------------------------
+
+	it( 'redirects to timeline of first connection when at least one exists', async () => {
+		mockUseFediverseConnectionsQuery.mockReturnValue( {
+			data: {
+				connections: [ { id: 42, handle: 'user@mastodon.social', actor: 'http://example.com' } ],
+			},
+			isPending: false,
+			isError: false,
+		} );
+
+		renderView();
+
+		await waitFor( () =>
+			expect( page.replace ).toHaveBeenCalledWith( getAccountUrl( 42, 'timeline' ) )
+		);
+	} );
+
+	it( 'redirects to first connection when multiple exist', async () => {
+		mockUseFediverseConnectionsQuery.mockReturnValue( {
+			data: {
+				connections: [
+					{ id: 42, handle: 'user1@mastodon.social', actor: 'http://example1.com' },
+					{ id: 43, handle: 'user2@pixelfed.social', actor: 'http://example2.com' },
+				],
+			},
+			isPending: false,
+			isError: false,
+		} );
+
+		renderView();
+
+		await waitFor( () =>
+			expect( page.replace ).toHaveBeenCalledWith( getAccountUrl( 42, 'timeline' ) )
+		);
+	} );
+
+	// -------------------------------------------------------------------------
+	// 4. Error: redirect to connect page
+	// -------------------------------------------------------------------------
+
+	it( 'redirects to connect page when query fails', async () => {
+		mockUseFediverseConnectionsQuery.mockReturnValue( {
+			data: undefined,
+			isPending: false,
+			isError: true,
+		} );
+
+		renderView();
+
+		await waitFor( () => expect( page.replace ).toHaveBeenCalledWith( getConnectUrl() ) );
+	} );
+
+	it( 'redirects to connect page even when data is null', async () => {
+		mockUseFediverseConnectionsQuery.mockReturnValue( {
+			data: null,
+			isPending: false,
+			isError: false,
+		} );
+
+		renderView();
+
+		await waitFor( () => expect( page.replace ).toHaveBeenCalledWith( getConnectUrl() ) );
+	} );
+} );

--- a/client/reader/fediverse/test/fediverse-navigation.test.tsx
+++ b/client/reader/fediverse/test/fediverse-navigation.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FediverseNavigation } from '../fediverse-navigation';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// Mock analytics — recordReaderTracksEvent must return a plain Redux action.
+const mockRecordReaderTracksEvent: jest.Mock = jest.fn( () => ( {
+	type: 'TEST_TRACKS_EVENT',
+} ) );
+
+jest.mock( 'calypso/state/reader/analytics/actions', () => ( {
+	recordReaderTracksEvent: ( ...args: unknown[] ) => mockRecordReaderTracksEvent( ...args ),
+} ) );
+
+// Mock useDispatch from calypso/state so Redux store is not required.
+const mockDispatch = jest.fn( ( action ) => action );
+jest.mock( 'calypso/state', () => ( {
+	useDispatch: () => mockDispatch,
+} ) );
+
+// Mock i18n-calypso.
+jest.mock( 'i18n-calypso', () => ( {
+	useTranslate: () => ( str: string ) => str,
+} ) );
+
+// Mock SectionNav, NavTabs, NavItem to avoid pulling in @automattic/components.
+jest.mock( 'calypso/components/section-nav', () => ( {
+	__esModule: true,
+	default: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+} ) );
+
+jest.mock( 'calypso/components/section-nav/tabs', () => ( {
+	__esModule: true,
+	default: ( { children }: { children: React.ReactNode } ) => <ul role="menubar">{ children }</ul>,
+} ) );
+
+jest.mock( 'calypso/components/section-nav/item', () => ( {
+	__esModule: true,
+	default: ( {
+		children,
+		path,
+		selected,
+		onClick,
+	}: {
+		children: React.ReactNode;
+		path?: string;
+		selected?: boolean;
+		onClick?: () => void;
+	} ) => (
+		<li role="menuitem" aria-current={ String( selected ) }>
+			<a href={ path } onClick={ onClick }>
+				{ children }
+			</a>
+		</li>
+	),
+} ) );
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe( 'FediverseNavigation', () => {
+	beforeEach( () => {
+		mockRecordReaderTracksEvent.mockClear();
+		mockDispatch.mockClear();
+	} );
+
+	it( 'renders three tabs and marks the selected one active', () => {
+		render( <FediverseNavigation connectionId={ 42 } selectedTab="profile" /> );
+
+		expect( screen.getByRole( 'menuitem', { name: /timeline/i } ) ).toBeVisible();
+		expect( screen.getByRole( 'menuitem', { name: /profile/i } ) ).toBeVisible();
+		expect( screen.getByRole( 'menuitem', { name: /settings/i } ) ).toBeVisible();
+
+		expect( screen.getByRole( 'menuitem', { name: /profile/i } ) ).toHaveAttribute(
+			'aria-current',
+			'true'
+		);
+		expect( screen.getByRole( 'menuitem', { name: /timeline/i } ) ).toHaveAttribute(
+			'aria-current',
+			'false'
+		);
+	} );
+
+	it( 'links each tab to its route', () => {
+		render( <FediverseNavigation connectionId={ 42 } selectedTab="timeline" /> );
+
+		expect(
+			screen.getByRole( 'menuitem', { name: /timeline/i } ).querySelector( 'a' )
+		).toHaveAttribute( 'href', '/reader/fediverse/42/timeline' );
+		expect(
+			screen.getByRole( 'menuitem', { name: /profile/i } ).querySelector( 'a' )
+		).toHaveAttribute( 'href', '/reader/fediverse/42/profile' );
+		expect(
+			screen.getByRole( 'menuitem', { name: /settings/i } ).querySelector( 'a' )
+		).toHaveAttribute( 'href', '/reader/fediverse/42/settings' );
+	} );
+
+	it( 'dispatches a tracks event when a tab is clicked', async () => {
+		const user = userEvent.setup();
+		render( <FediverseNavigation connectionId={ 42 } selectedTab="timeline" /> );
+
+		await user.click( screen.getByRole( 'menuitem', { name: /profile/i } ).querySelector( 'a' )! );
+
+		expect( mockRecordReaderTracksEvent ).toHaveBeenCalledWith(
+			'calypso_reader_fediverse_tab_clicked',
+			{ connection_id: 42, tab: 'profile' }
+		);
+	} );
+} );

--- a/client/reader/fediverse/test/fediverse-oauth-callback-view.test.tsx
+++ b/client/reader/fediverse/test/fediverse-oauth-callback-view.test.tsx
@@ -86,11 +86,8 @@ describe( 'FediverseOauthCallbackView', () => {
 		saveOauthState( { state: 'abc', blog_id: 123 } );
 
 		mockMutate.mockImplementation(
-			(
-				_params: unknown,
-				{ onSuccess }: { onSuccess: ( data: { connection: { id: number } } ) => void }
-			) => {
-				onSuccess( { connection: { id: 99 } } );
+			( _params: unknown, { onSuccess }: { onSuccess: ( data: { id: number } ) => void } ) => {
+				onSuccess( { id: 99 } );
 			}
 		);
 
@@ -106,11 +103,8 @@ describe( 'FediverseOauthCallbackView', () => {
 		saveOauthState( { state: 'abc', blog_id: 123 } );
 
 		mockMutate.mockImplementation(
-			(
-				_params: unknown,
-				{ onSuccess }: { onSuccess: ( data: { connection: { id: number } } ) => void }
-			) => {
-				onSuccess( { connection: { id: 99 } } );
+			( _params: unknown, { onSuccess }: { onSuccess: ( data: { id: number } ) => void } ) => {
+				onSuccess( { id: 99 } );
 			}
 		);
 
@@ -129,12 +123,9 @@ describe( 'FediverseOauthCallbackView', () => {
 		let callCount = 0;
 
 		mockMutate.mockImplementation(
-			(
-				_params: unknown,
-				{ onSuccess }: { onSuccess: ( data: { connection: { id: number } } ) => void }
-			) => {
+			( _params: unknown, { onSuccess }: { onSuccess: ( data: { id: number } ) => void } ) => {
 				callCount++;
-				onSuccess( { connection: { id: 99 } } );
+				onSuccess( { id: 99 } );
 			}
 		);
 

--- a/client/reader/fediverse/test/fediverse-oauth-callback-view.test.tsx
+++ b/client/reader/fediverse/test/fediverse-oauth-callback-view.test.tsx
@@ -1,0 +1,251 @@
+/**
+ * @jest-environment jsdom
+ */
+import page from '@automattic/calypso-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, waitFor } from '@testing-library/react';
+import { FediverseOauthCallbackView } from '../fediverse-oauth-callback-view';
+import { saveOauthState } from '../oauth-state';
+import { getAccountUrl, getConnectUrl } from '../route';
+import type React from 'react';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+jest.mock( '@automattic/calypso-router', () => {
+	const replace = jest.fn();
+	const fn = jest.fn() as jest.Mock & { replace: jest.Mock };
+	fn.replace = replace;
+	return { __esModule: true, default: fn };
+} );
+
+// Mock analytics — recordReaderTracksEvent must return a plain Redux action.
+const mockRecordReaderTracksEvent = jest.fn( () => ( { type: 'TEST_TRACKS_EVENT' } ) );
+jest.mock( 'calypso/state/reader/analytics/actions', () => ( {
+	recordReaderTracksEvent: ( ...args: unknown[] ) => mockRecordReaderTracksEvent( ...args ),
+} ) );
+
+// Mock useDispatch from calypso/state so Redux store is not required.
+const mockDispatch = jest.fn( ( action ) => action );
+jest.mock( 'calypso/state', () => ( {
+	useDispatch: () => mockDispatch,
+} ) );
+
+// Mock i18n-calypso to avoid the interpolate-components dependency chain.
+jest.mock( 'i18n-calypso', () => ( {
+	useTranslate: () => ( str: string ) => str,
+} ) );
+
+// Mock @automattic/api-queries entirely.
+const mockMutate = jest.fn();
+jest.mock( '@automattic/api-queries', () => ( {
+	useCompleteFediverseConnectionMutation: () => ( { mutate: mockMutate } ),
+} ) );
+
+// Mock @wordpress/components to avoid the full package import.
+jest.mock( '@wordpress/components', () => ( {
+	Spinner: () => null,
+} ) );
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeClient() {
+	return new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+}
+
+function renderView( query: { code?: string; state?: string; error?: string } ) {
+	const client = makeClient();
+	const Wrapper = ( { children }: { children: React.ReactNode } ) => (
+		<QueryClientProvider client={ client }>{ children }</QueryClientProvider>
+	);
+	return render( <FediverseOauthCallbackView query={ query } />, { wrapper: Wrapper } );
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+describe( 'FediverseOauthCallbackView', () => {
+	beforeEach( () => {
+		( page as unknown as jest.Mock ).mockClear();
+		( page.replace as jest.Mock ).mockClear();
+		mockRecordReaderTracksEvent.mockClear();
+		mockDispatch.mockClear();
+		mockMutate.mockReset();
+		window.sessionStorage.clear();
+	} );
+
+	// -------------------------------------------------------------------------
+	// 1. Happy path: code+state match → mutation succeeds → redirect to timeline
+	// -------------------------------------------------------------------------
+
+	it( 'calls complete mutation and redirects to the new connection timeline on success', async () => {
+		saveOauthState( { state: 'abc', blog_id: 123 } );
+
+		mockMutate.mockImplementation(
+			(
+				_params: unknown,
+				{ onSuccess }: { onSuccess: ( data: { connection: { id: number } } ) => void }
+			) => {
+				onSuccess( { connection: { id: 99 } } );
+			}
+		);
+
+		renderView( { state: 'abc', code: 'xyz' } );
+
+		await waitFor( () =>
+			expect( page.replace ).toHaveBeenCalledWith( getAccountUrl( 99, 'timeline' ) )
+		);
+		expect( window.sessionStorage.getItem( 'reader-fediverse-oauth-state' ) ).toBeNull();
+	} );
+
+	it( 'dispatches CONNECT_COMPLETED analytics on success', async () => {
+		saveOauthState( { state: 'abc', blog_id: 123 } );
+
+		mockMutate.mockImplementation(
+			(
+				_params: unknown,
+				{ onSuccess }: { onSuccess: ( data: { connection: { id: number } } ) => void }
+			) => {
+				onSuccess( { connection: { id: 99 } } );
+			}
+		);
+
+		renderView( { state: 'abc', code: 'xyz' } );
+
+		await waitFor( () => expect( page.replace ).toHaveBeenCalled() );
+		expect( mockDispatch ).toHaveBeenCalledWith( { type: 'TEST_TRACKS_EVENT' } );
+		expect( mockRecordReaderTracksEvent ).toHaveBeenCalledWith(
+			'calypso_reader_fediverse_connect_completed',
+			expect.objectContaining( { connection_id: 99 } )
+		);
+	} );
+
+	it( 'fires the mutation only once (ref guard prevents double-invoke)', async () => {
+		saveOauthState( { state: 'abc', blog_id: 123 } );
+		let callCount = 0;
+
+		mockMutate.mockImplementation(
+			(
+				_params: unknown,
+				{ onSuccess }: { onSuccess: ( data: { connection: { id: number } } ) => void }
+			) => {
+				callCount++;
+				onSuccess( { connection: { id: 99 } } );
+			}
+		);
+
+		renderView( { state: 'abc', code: 'xyz' } );
+
+		await waitFor( () => expect( page.replace ).toHaveBeenCalled() );
+		expect( callCount ).toBe( 1 );
+	} );
+
+	// -------------------------------------------------------------------------
+	// 2. Provider error (?error=access_denied) → redirect to connect page
+	// -------------------------------------------------------------------------
+
+	it( 'redirects to connect page with error when provider returns ?error', async () => {
+		renderView( { error: 'access_denied' } );
+
+		await waitFor( () =>
+			expect( page.replace ).toHaveBeenCalledWith( `${ getConnectUrl() }?error=access_denied` )
+		);
+		expect( mockMutate ).not.toHaveBeenCalled();
+	} );
+
+	it( 'dispatches CONNECT_FAILED analytics for provider error', async () => {
+		renderView( { error: 'access_denied' } );
+
+		await waitFor( () => expect( page.replace ).toHaveBeenCalled() );
+		expect( mockRecordReaderTracksEvent ).toHaveBeenCalledWith(
+			'calypso_reader_fediverse_connect_failed',
+			expect.objectContaining( { step: 'authorize', error: 'access_denied' } )
+		);
+	} );
+
+	// -------------------------------------------------------------------------
+	// 3. Missing code parameter → redirect with missing_params
+	// -------------------------------------------------------------------------
+
+	it( 'redirects with missing_params error when code is absent', async () => {
+		renderView( { state: 'abc' } );
+
+		await waitFor( () =>
+			expect( page.replace ).toHaveBeenCalledWith( `${ getConnectUrl() }?error=missing_params` )
+		);
+	} );
+
+	it( 'redirects with missing_params error when state is absent', async () => {
+		renderView( { code: 'xyz' } );
+
+		await waitFor( () =>
+			expect( page.replace ).toHaveBeenCalledWith( `${ getConnectUrl() }?error=missing_params` )
+		);
+	} );
+
+	// -------------------------------------------------------------------------
+	// 4. State mismatch → redirect with state_mismatch, sessionStorage cleared
+	// -------------------------------------------------------------------------
+
+	it( 'redirects with state_mismatch error when stored state differs', async () => {
+		saveOauthState( { state: 'abc', blog_id: 123 } );
+
+		renderView( { state: 'different', code: 'xyz' } );
+
+		await waitFor( () =>
+			expect( page.replace ).toHaveBeenCalledWith( `${ getConnectUrl() }?error=state_mismatch` )
+		);
+		expect( window.sessionStorage.getItem( 'reader-fediverse-oauth-state' ) ).toBeNull();
+	} );
+
+	it( 'redirects with state_mismatch when no state is stored at all', async () => {
+		renderView( { state: 'abc', code: 'xyz' } );
+
+		await waitFor( () =>
+			expect( page.replace ).toHaveBeenCalledWith( `${ getConnectUrl() }?error=state_mismatch` )
+		);
+	} );
+
+	// -------------------------------------------------------------------------
+	// 5. Mutation failure → redirect with error kind, sessionStorage cleared
+	// -------------------------------------------------------------------------
+
+	it( 'redirects with error kind and clears storage when complete mutation fails', async () => {
+		saveOauthState( { state: 'abc', blog_id: 123 } );
+
+		mockMutate.mockImplementation(
+			( _params: unknown, { onError }: { onError: ( err: { kind: string } ) => void } ) => {
+				onError( { kind: 'auth_failed' } );
+			}
+		);
+
+		renderView( { state: 'abc', code: 'xyz' } );
+
+		await waitFor( () =>
+			expect( page.replace ).toHaveBeenCalledWith( `${ getConnectUrl() }?error=auth_failed` )
+		);
+		expect( window.sessionStorage.getItem( 'reader-fediverse-oauth-state' ) ).toBeNull();
+	} );
+
+	it( 'dispatches CONNECT_FAILED analytics for mutation error', async () => {
+		saveOauthState( { state: 'abc', blog_id: 123 } );
+
+		mockMutate.mockImplementation(
+			( _params: unknown, { onError }: { onError: ( err: { kind: string } ) => void } ) => {
+				onError( { kind: 'auth_failed' } );
+			}
+		);
+
+		renderView( { state: 'abc', code: 'xyz' } );
+
+		await waitFor( () => expect( page.replace ).toHaveBeenCalled() );
+		expect( mockRecordReaderTracksEvent ).toHaveBeenCalledWith(
+			'calypso_reader_fediverse_connect_failed',
+			expect.objectContaining( { step: 'complete', error: 'auth_failed' } )
+		);
+	} );
+} );

--- a/client/reader/fediverse/test/oauth-state.test.ts
+++ b/client/reader/fediverse/test/oauth-state.test.ts
@@ -1,0 +1,115 @@
+/**
+ * @jest-environment jsdom
+ */
+import { clearOauthState, loadOauthState, saveOauthState } from '../oauth-state';
+
+const STORAGE_KEY = 'reader-fediverse-oauth-state';
+
+describe( 'oauth-state', () => {
+	beforeEach( () => {
+		window.sessionStorage.clear();
+	} );
+
+	describe( 'saveOauthState + loadOauthState round-trip', () => {
+		it( 'saves and loads back the state and blog_id', () => {
+			saveOauthState( { state: 'abc', blog_id: 42 } );
+			expect( loadOauthState() ).toEqual( { state: 'abc', blog_id: 42 } );
+		} );
+	} );
+
+	describe( 'storage key verification', () => {
+		it( 'uses the correct storage key', () => {
+			saveOauthState( { state: 'test-state', blog_id: 123 } );
+			expect( window.sessionStorage.getItem( STORAGE_KEY ) ).toBe(
+				JSON.stringify( { state: 'test-state', blog_id: 123 } )
+			);
+		} );
+	} );
+
+	describe( 'loadOauthState with malformed storage', () => {
+		it( 'returns null when the key is missing', () => {
+			expect( loadOauthState() ).toBeNull();
+		} );
+
+		it( 'returns null for non-JSON content', () => {
+			window.sessionStorage.setItem( STORAGE_KEY, 'not-json' );
+			expect( loadOauthState() ).toBeNull();
+		} );
+
+		it( 'returns null for JSON that is not an object', () => {
+			window.sessionStorage.setItem( STORAGE_KEY, '"just-a-string"' );
+			expect( loadOauthState() ).toBeNull();
+		} );
+
+		it( 'returns null for a JSON array', () => {
+			window.sessionStorage.setItem( STORAGE_KEY, '[]' );
+			expect( loadOauthState() ).toBeNull();
+		} );
+
+		it( 'returns null when state is missing', () => {
+			window.sessionStorage.setItem( STORAGE_KEY, JSON.stringify( { blog_id: 42 } ) );
+			expect( loadOauthState() ).toBeNull();
+		} );
+
+		it( 'returns null when blog_id is missing', () => {
+			window.sessionStorage.setItem( STORAGE_KEY, JSON.stringify( { state: 'abc' } ) );
+			expect( loadOauthState() ).toBeNull();
+		} );
+
+		it( 'returns null when state is not a string', () => {
+			window.sessionStorage.setItem( STORAGE_KEY, JSON.stringify( { state: 123, blog_id: 42 } ) );
+			expect( loadOauthState() ).toBeNull();
+		} );
+
+		it( 'returns null when blog_id is not a number', () => {
+			window.sessionStorage.setItem(
+				STORAGE_KEY,
+				JSON.stringify( { state: 'abc', blog_id: 'not-a-number' } )
+			);
+			expect( loadOauthState() ).toBeNull();
+		} );
+
+		it( 'returns null when getItem throws', () => {
+			const spy = jest.spyOn( Storage.prototype, 'getItem' ).mockImplementation( () => {
+				throw new Error( 'storage unavailable' );
+			} );
+			try {
+				expect( loadOauthState() ).toBeNull();
+			} finally {
+				spy.mockRestore();
+			}
+		} );
+	} );
+
+	describe( 'saveOauthState failure modes', () => {
+		it( 'swallows QuotaExceededError from setItem', () => {
+			const spy = jest.spyOn( Storage.prototype, 'setItem' ).mockImplementation( () => {
+				throw new Error( 'QuotaExceededError' );
+			} );
+			try {
+				expect( () => saveOauthState( { state: 'abc', blog_id: 42 } ) ).not.toThrow();
+			} finally {
+				spy.mockRestore();
+			}
+		} );
+	} );
+
+	describe( 'clearOauthState', () => {
+		it( 'removes a previously stored state', () => {
+			saveOauthState( { state: 'abc', blog_id: 42 } );
+			clearOauthState();
+			expect( loadOauthState() ).toBeNull();
+		} );
+
+		it( 'swallows removeItem failures', () => {
+			const spy = jest.spyOn( Storage.prototype, 'removeItem' ).mockImplementation( () => {
+				throw new Error( 'storage unavailable' );
+			} );
+			try {
+				expect( () => clearOauthState() ).not.toThrow();
+			} finally {
+				spy.mockRestore();
+			}
+		} );
+	} );
+} );

--- a/client/reader/fediverse/test/profile-panel.test.tsx
+++ b/client/reader/fediverse/test/profile-panel.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { ProfilePanel } from '../profile-panel';
+
+// Mock i18n-calypso to avoid the interpolate-components dependency chain.
+jest.mock( 'i18n-calypso', () => ( {
+	useTranslate: () => ( str: string, options?: { args?: Record< string, string > } ) => {
+		if ( options?.args ) {
+			return Object.entries( options.args ).reduce(
+				( result, [ key, value ] ) => result.replace( `%(${ key })s`, value ),
+				str
+			);
+		}
+		return str;
+	},
+} ) );
+
+// Mock EmptyContent to keep the test focused while still rendering action links.
+jest.mock( 'calypso/components/empty-content', () => ( {
+	__esModule: true,
+	default: ( {
+		title,
+		line,
+		action,
+		actionURL,
+		actionTarget,
+	}: {
+		title?: string;
+		line?: string;
+		action?: string;
+		actionURL?: string;
+		actionTarget?: string;
+	} ) => (
+		<div>
+			{ title && <h2>{ title }</h2> }
+			{ line && <p>{ line }</p> }
+			{ action && actionURL && (
+				<a href={ actionURL } target={ actionTarget }>
+					{ action }
+				</a>
+			) }
+		</div>
+	),
+} ) );
+
+describe( 'ProfilePanel', () => {
+	it( 'renders the handle in the title', () => {
+		render(
+			<ProfilePanel
+				handle="@alice@example.com"
+				actorUrl="https://example.com/users/alice"
+				siteHost="example.com"
+			/>
+		);
+
+		expect( screen.getByText( /connected as @alice@example\.com/i ) ).toBeVisible();
+	} );
+
+	it( 'renders the site host in the subtitle', () => {
+		render(
+			<ProfilePanel
+				handle="@alice@example.com"
+				actorUrl="https://example.com/users/alice"
+				siteHost="example.com"
+			/>
+		);
+
+		expect( screen.getByText( /will appear on example\.com/i ) ).toBeVisible();
+	} );
+
+	it( 'renders an external link pointing at actorUrl', () => {
+		render(
+			<ProfilePanel
+				handle="@alice@example.com"
+				actorUrl="https://example.com/users/alice"
+				siteHost="example.com"
+			/>
+		);
+
+		const link = screen.getByRole( 'link', { name: /view your profile on example\.com/i } );
+		expect( link ).toBeVisible();
+		expect( link ).toHaveAttribute( 'href', 'https://example.com/users/alice' );
+		expect( link ).toHaveAttribute( 'target', '_blank' );
+	} );
+} );

--- a/client/reader/fediverse/test/settings-panel.test.tsx
+++ b/client/reader/fediverse/test/settings-panel.test.tsx
@@ -1,0 +1,224 @@
+/**
+ * @jest-environment jsdom
+ */
+import page from '@automattic/calypso-router';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { getLandingUrl } from '../route';
+import { SettingsPanel } from '../settings-panel';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+jest.mock( '@automattic/calypso-router', () => {
+	const fn = jest.fn() as jest.Mock;
+	return { __esModule: true, default: fn };
+} );
+
+jest.mock( 'i18n-calypso', () => ( {
+	useTranslate: () => ( str: string, options?: { args?: Record< string, string > } ) => {
+		if ( options?.args ) {
+			return Object.entries( options.args ).reduce(
+				( result, [ key, value ] ) => result.replace( `%(${ key })s`, value ),
+				str
+			);
+		}
+		return str;
+	},
+} ) );
+
+// Mock calypso/state to capture dispatch calls.
+const mockDispatch = jest.fn();
+jest.mock( 'calypso/state', () => ( {
+	useDispatch: () => mockDispatch,
+} ) );
+
+// Mock analytics so we can assert on events without Redux.
+jest.mock( '../analytics', () => ( {
+	trackFediverseEvent: jest.fn( ( event, props ) => ( { type: 'TRACK', event, props } ) ),
+} ) );
+
+// Mock @wordpress/components with minimal implementations.
+jest.mock( '@wordpress/components', () => ( {
+	Button: ( {
+		children,
+		onClick,
+		disabled,
+	}: {
+		children: React.ReactNode;
+		onClick?: () => void;
+		disabled?: boolean;
+	} ) => (
+		<button onClick={ onClick } disabled={ disabled }>
+			{ children }
+		</button>
+	),
+	Card: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+	CardBody: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+	Spinner: () => <span role="status">Loading</span>,
+	__experimentalVStack: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+} ) );
+
+// ---------------------------------------------------------------------------
+// Mocked hook factories — replaced per test.
+// ---------------------------------------------------------------------------
+
+const mockUseFediverseConnectionQuery = jest.fn();
+const mockUseDisconnectFediverseMutation = jest.fn();
+
+jest.mock( '@automattic/api-queries', () => ( {
+	useFediverseConnectionQuery: ( ...args: unknown[] ) => mockUseFediverseConnectionQuery( ...args ),
+	useDisconnectFediverseMutation: ( ...args: unknown[] ) =>
+		mockUseDisconnectFediverseMutation( ...args ),
+} ) );
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+const CONNECTION = {
+	id: 42,
+	handle: '@alice@example.social',
+	site_host: 'example.social',
+	actor_url: 'https://example.social/users/alice',
+	avatar: '',
+	blog_id: 123,
+	actor_type: 'user' as const,
+};
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+describe( 'SettingsPanel', () => {
+	beforeEach( () => {
+		( page as unknown as jest.Mock ).mockClear();
+		mockDispatch.mockClear();
+		mockUseFediverseConnectionQuery.mockClear();
+		mockUseDisconnectFediverseMutation.mockClear();
+
+		// Default: idle mutation with no error.
+		mockUseDisconnectFediverseMutation.mockReturnValue( {
+			mutate: jest.fn(),
+			isPending: false,
+			isError: false,
+		} );
+	} );
+
+	// -------------------------------------------------------------------------
+	// 1. Pending state shows spinner
+	// -------------------------------------------------------------------------
+
+	it( 'shows a spinner while the connection is pending', () => {
+		mockUseFediverseConnectionQuery.mockReturnValue( {
+			data: undefined,
+			isPending: true,
+		} );
+
+		render( <SettingsPanel connectionId={ 42 } /> );
+
+		expect( screen.getByRole( 'status' ) ).toBeVisible();
+		expect( screen.queryByRole( 'button' ) ).toBeNull();
+	} );
+
+	// -------------------------------------------------------------------------
+	// 2. Connection loaded — shows handle and site_host
+	// -------------------------------------------------------------------------
+
+	it( 'renders the handle and site_host once the connection is loaded', () => {
+		mockUseFediverseConnectionQuery.mockReturnValue( {
+			data: CONNECTION,
+			isPending: false,
+		} );
+
+		render( <SettingsPanel connectionId={ 42 } /> );
+
+		expect( screen.getByText( '@alice@example.social' ) ).toBeVisible();
+		expect( screen.getByText( 'example.social' ) ).toBeVisible();
+	} );
+
+	// -------------------------------------------------------------------------
+	// 3. First click → button text changes to confirm copy
+	// -------------------------------------------------------------------------
+
+	it( 'changes button label to confirm copy on first click', async () => {
+		const user = userEvent.setup();
+
+		mockUseFediverseConnectionQuery.mockReturnValue( {
+			data: CONNECTION,
+			isPending: false,
+		} );
+
+		render( <SettingsPanel connectionId={ 42 } /> );
+
+		const button = screen.getByRole( 'button', { name: 'Disconnect' } );
+		await user.click( button );
+
+		expect(
+			screen.getByRole( 'button', { name: 'Are you sure? Click again to disconnect' } )
+		).toBeVisible();
+	} );
+
+	// -------------------------------------------------------------------------
+	// 4. Second click → mutation fires; on success, tracks + navigates
+	// -------------------------------------------------------------------------
+
+	it( 'fires the mutation on the second click, then tracks and navigates', async () => {
+		const user = userEvent.setup();
+
+		mockUseFediverseConnectionQuery.mockReturnValue( {
+			data: CONNECTION,
+			isPending: false,
+		} );
+
+		const mockMutate = jest.fn( ( _vars, { onSuccess } ) => onSuccess() );
+		mockUseDisconnectFediverseMutation.mockReturnValue( {
+			mutate: mockMutate,
+			isPending: false,
+			isError: false,
+		} );
+
+		render( <SettingsPanel connectionId={ 42 } /> );
+
+		// First click: enter confirm state.
+		await user.click( screen.getByRole( 'button', { name: 'Disconnect' } ) );
+		// Second click: confirm.
+		await user.click(
+			screen.getByRole( 'button', { name: 'Are you sure? Click again to disconnect' } )
+		);
+
+		expect( mockMutate ).toHaveBeenCalledWith(
+			undefined,
+			expect.objectContaining( { onSuccess: expect.any( Function ) } )
+		);
+		expect( mockDispatch ).toHaveBeenCalledWith(
+			expect.objectContaining( { type: 'TRACK', event: 'DISCONNECTED' } )
+		);
+		expect( page as unknown as jest.Mock ).toHaveBeenCalledWith( getLandingUrl() );
+	} );
+
+	// -------------------------------------------------------------------------
+	// 5. Mutation error path shows the error message
+	// -------------------------------------------------------------------------
+
+	it( 'shows an error alert when the mutation has errored', () => {
+		mockUseFediverseConnectionQuery.mockReturnValue( {
+			data: CONNECTION,
+			isPending: false,
+		} );
+
+		mockUseDisconnectFediverseMutation.mockReturnValue( {
+			mutate: jest.fn(),
+			isPending: false,
+			isError: true,
+		} );
+
+		render( <SettingsPanel connectionId={ 42 } /> );
+
+		expect( screen.getByRole( 'alert' ) ).toBeVisible();
+		expect( screen.getByRole( 'alert' ) ).toHaveTextContent(
+			"We couldn't disconnect. Please try again."
+		);
+	} );
+} );

--- a/client/reader/fediverse/test/timeline-panel.test.tsx
+++ b/client/reader/fediverse/test/timeline-panel.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { TimelinePanel } from '../timeline-panel';
+
+// Mock i18n-calypso to avoid the interpolate-components dependency chain.
+jest.mock( 'i18n-calypso', () => ( {
+	useTranslate: () => ( str: string, options?: { args?: Record< string, string > } ) => {
+		if ( options?.args ) {
+			return Object.entries( options.args ).reduce(
+				( result, [ key, value ] ) => result.replace( `%(${ key })s`, value ),
+				str
+			);
+		}
+		return str;
+	},
+} ) );
+
+// Mock EmptyContent to keep the test focused.
+jest.mock( 'calypso/components/empty-content', () => ( {
+	__esModule: true,
+	default: ( { title, line }: { title?: string; line?: string } ) => (
+		<div>
+			{ title && <h2>{ title }</h2> }
+			{ line && <p>{ line }</p> }
+		</div>
+	),
+} ) );
+
+describe( 'TimelinePanel', () => {
+	it( 'renders the empty state title', () => {
+		render( <TimelinePanel connectionId={ 1 } handle="@alice@example.com" /> );
+
+		expect( screen.getByText( 'Your Fediverse activity will appear here' ) ).toBeVisible();
+	} );
+
+	it( 'renders the handle in the subtitle', () => {
+		render( <TimelinePanel connectionId={ 1 } handle="@alice@example.com" /> );
+
+		expect( screen.getByText( /connected as @alice@example\.com/i ) ).toBeVisible();
+	} );
+} );

--- a/client/reader/fediverse/timeline-panel.tsx
+++ b/client/reader/fediverse/timeline-panel.tsx
@@ -1,0 +1,22 @@
+import { useTranslate } from 'i18n-calypso';
+import EmptyContent from 'calypso/components/empty-content';
+
+interface Props {
+	connectionId: number;
+	handle: string;
+}
+
+// connectionId is currently unused but kept on the interface for forward-compat (wiring up the inbox).
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function TimelinePanel( { connectionId: _connectionId, handle }: Props ) {
+	const translate = useTranslate();
+	return (
+		<EmptyContent
+			title={ translate( 'Your Fediverse activity will appear here' ) }
+			line={ translate(
+				"You're connected as %(handle)s. Compose a Note to broadcast to the Fediverse.",
+				{ args: { handle } }
+			) }
+		/>
+	);
+}

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -46,6 +46,7 @@ import getCurrentIntlCollator from 'calypso/state/selectors/get-current-intl-col
 import { setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import ReaderSidebarHelper from './helper';
 import ReaderSidebarAtmosphere from './reader-sidebar-atmosphere';
+import ReaderSidebarFediverse from './reader-sidebar-fediverse';
 import ReaderSidebarLists from './reader-sidebar-lists';
 import ReaderSidebarMastodon from './reader-sidebar-mastodon';
 import ReaderSidebarNudges from './reader-sidebar-nudges';
@@ -195,6 +196,7 @@ export class ReaderSidebar extends Component {
 					{ isEnabled( 'reader/social' ) && (
 						<>
 							<ReaderSidebarAtmosphere path={ path } />
+							<ReaderSidebarFediverse path={ path } />
 							<ReaderSidebarMastodon path={ path } />
 						</>
 					) }

--- a/client/reader/sidebar/reader-sidebar-fediverse/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-fediverse/index.tsx
@@ -1,0 +1,159 @@
+import { useFediverseConnectionsQuery } from '@automattic/api-queries';
+import page from '@automattic/calypso-router';
+import { Icon, globe } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useState } from 'react';
+import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
+import SidebarItem from 'calypso/layout/sidebar/item';
+import { TIMELINE_TAB } from 'calypso/reader/fediverse/helper';
+import { SocialAccountMenuItem, SocialAddAccountMenuItem } from 'calypso/reader/sidebar/social';
+import { useDispatch } from 'calypso/state';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import ReaderSidebarHelper from '../helper';
+import type { FediverseConnection } from '@automattic/api-core';
+
+interface Props {
+	path: string;
+}
+
+const BASE_PATH = '/reader/fediverse';
+const CONNECT_PATH = `${ BASE_PATH }/connect`;
+
+/**
+ * Extract the numeric connection id from a path shaped like
+ * `/reader/fediverse/:id(/:tab)?`. The id segment must be all digits —
+ * fuzzy prefixes like `/reader/fediverse/1bogus` do not match. Returns null
+ * for any path that does not match (e.g. `/reader/fediverse/connect`).
+ */
+function getActiveConnectionId( path: string ): number | null {
+	const match = path.match( /^\/reader\/fediverse\/(\d+)(?:\/|$)/ );
+	return match ? Number( match[ 1 ] ) : null;
+}
+
+/**
+ * Renders a single connection row. The Fediverse connections list endpoint
+ * returns full details (handle + avatar), so no per-connection detail fetch
+ * is needed.
+ */
+function FediverseSidebarRow( {
+	connection,
+	isSelected,
+	onClick,
+}: {
+	connection: FediverseConnection;
+	isSelected: boolean;
+	onClick: () => void;
+} ) {
+	const href = `${ BASE_PATH }/${ connection.id }/${ TIMELINE_TAB }`;
+	return (
+		<SocialAccountMenuItem
+			avatarUrl={ connection.avatar || null }
+			displayName={ connection.handle }
+			handle={ connection.handle }
+			href={ href }
+			isSelected={ isSelected }
+			onClick={ onClick }
+		/>
+	);
+}
+
+function ReaderSidebarFediverse( { path }: Props ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const isOnFediverse = path.startsWith( BASE_PATH );
+	const [ isOpen, setIsOpen ] = useState( () => isOnFediverse );
+
+	// Only fetch connections on fediverse routes. On other Reader pages we
+	// render a flat link (no sub-items), so there's no need to hit the endpoint.
+	const { data } = useFediverseConnectionsQuery( { enabled: isOnFediverse } );
+	const connections = data?.connections ?? [];
+	const activeId = getActiveConnectionId( path );
+
+	// Auto-open when navigating into a fediverse sub-route. We only ever open
+	// here — collapsing on navigate-away would fight the user's explicit toggle.
+	useEffect( () => {
+		if ( isOnFediverse ) {
+			setIsOpen( true );
+		}
+	}, [ isOnFediverse ] );
+
+	const recordClick = () => {
+		dispatch( recordReaderTracksEvent( 'calypso_reader_sidebar_fediverse_clicked' ) );
+	};
+
+	const handleAddAccountClick = () => {
+		dispatch( recordReaderTracksEvent( 'calypso_reader_sidebar_fediverse_add_account_clicked' ) );
+	};
+
+	const handleConnectionClick = ( id: number ) => {
+		dispatch(
+			recordReaderTracksEvent( 'calypso_reader_sidebar_fediverse_connection_clicked', {
+				connection_id: id,
+			} )
+		);
+	};
+
+	// Off-fediverse paths: flat link, no expansion.
+	if ( ! isOnFediverse ) {
+		return (
+			<SidebarItem
+				label={ translate( 'Fediverse' ) }
+				link={ BASE_PATH }
+				onNavigate={ recordClick }
+				customIcon={ <Icon icon={ globe } size={ 24 } /> }
+				className={ ReaderSidebarHelper.itemLinkClass( BASE_PATH, path, {
+					'sidebar-streams__fediverse': true,
+				} ) }
+			/>
+		);
+	}
+
+	const handleMainClick = () => {
+		recordClick();
+		if ( ! isOpen ) {
+			setIsOpen( true );
+		}
+		// From a specific connection page, stay put — otherwise the landing
+		// controller would redirect us to the *first* connection's timeline,
+		// which may not be the one the user is currently viewing.
+		if ( activeId === null && path !== BASE_PATH ) {
+			page( BASE_PATH );
+		}
+	};
+
+	return (
+		<li>
+			<ExpandableSidebarMenu
+				expanded={ isOpen }
+				title={ translate( 'Fediverse' ) }
+				customIcon={ <Icon icon={ globe } size={ 24 } /> }
+				onClick={ handleMainClick }
+				expandableIconClick={ () => setIsOpen( ! isOpen ) }
+				disableFlyout
+				className={ ! isOpen ? 'sidebar__menu--selected' : undefined }
+				count={ undefined }
+				icon={ null }
+				materialIcon={ null }
+				materialIconStyle={ null }
+			>
+				{ connections.map( ( connection ) => (
+					<FediverseSidebarRow
+						key={ connection.id }
+						connection={ connection }
+						isSelected={ connection.id === activeId }
+						onClick={ () => handleConnectionClick( connection.id ) }
+					/>
+				) ) }
+				<SocialAddAccountMenuItem
+					label={ translate( 'Add account' ) }
+					href={ CONNECT_PATH }
+					onClick={ handleAddAccountClick }
+				/>
+			</ExpandableSidebarMenu>
+		</li>
+	);
+}
+
+export { ReaderSidebarFediverse };
+export default ReaderSidebarFediverse;

--- a/client/reader/sidebar/reader-sidebar-fediverse/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-fediverse/index.tsx
@@ -1,10 +1,10 @@
 import { useFediverseConnectionsQuery } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
-import { Icon, globe } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
 import SidebarItem from 'calypso/layout/sidebar/item';
+import { ReaderFediverseIcon } from 'calypso/reader/components/icons/fediverse-icon';
 import { TIMELINE_TAB } from 'calypso/reader/fediverse/helper';
 import { SocialAccountMenuItem, SocialAddAccountMenuItem } from 'calypso/reader/sidebar/social';
 import { useDispatch } from 'calypso/state';
@@ -101,7 +101,7 @@ function ReaderSidebarFediverse( { path }: Props ) {
 				label={ translate( 'Fediverse' ) }
 				link={ BASE_PATH }
 				onNavigate={ recordClick }
-				customIcon={ <Icon icon={ globe } size={ 24 } /> }
+				customIcon={ <ReaderFediverseIcon /> }
 				className={ ReaderSidebarHelper.itemLinkClass( BASE_PATH, path, {
 					'sidebar-streams__fediverse': true,
 				} ) }
@@ -127,7 +127,7 @@ function ReaderSidebarFediverse( { path }: Props ) {
 			<ExpandableSidebarMenu
 				expanded={ isOpen }
 				title={ translate( 'Fediverse' ) }
-				customIcon={ <Icon icon={ globe } size={ 24 } /> }
+				customIcon={ <ReaderFediverseIcon /> }
 				onClick={ handleMainClick }
 				expandableIconClick={ () => setIsOpen( ! isOpen ) }
 				disableFlyout

--- a/client/reader/sidebar/reader-sidebar-fediverse/test/index.test.tsx
+++ b/client/reader/sidebar/reader-sidebar-fediverse/test/index.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient } from '@tanstack/react-query';
+import { screen } from '@testing-library/react';
+import nock from 'nock';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { ReaderSidebarFediverse } from '../index';
+
+jest.mock( '@automattic/calypso-router', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+const BASE = 'https://public-api.wordpress.com';
+
+function makeClient() {
+	return new QueryClient( {
+		defaultOptions: { queries: { retry: false, staleTime: 0 } },
+	} );
+}
+
+interface MockConnection {
+	id: number;
+	handle: string;
+	site_host: string;
+	avatar?: string | null;
+}
+
+function mockConnections( connections: MockConnection[] ) {
+	nock( BASE )
+		.get( '/wpcom/v2/reader/activitypub/connections' )
+		.reply( 200, {
+			connections: connections.map( ( c ) => ( {
+				id: c.id,
+				handle: c.handle,
+				site_host: c.site_host,
+				avatar: c.avatar ?? null,
+				actor_url: `https://${ c.site_host }/activitypub/actor`,
+				blog_id: c.id * 100,
+				actor_type: 'user',
+			} ) ),
+		} );
+}
+
+describe( 'ReaderSidebarFediverse', () => {
+	afterEach( () => nock.cleanAll() );
+
+	it( 'does not fetch connections on non-fediverse paths and renders a flat link', async () => {
+		// No nock mock — if the query fired, nock would throw on the unmatched request.
+		renderWithProvider( <ReaderSidebarFediverse path="/reader" />, {
+			queryClient: makeClient(),
+		} );
+
+		const link = await screen.findByRole( 'link', { name: /fediverse/i } );
+		expect( link ).toHaveAttribute( 'href', '/reader/fediverse' );
+
+		// No expanded list of per-connection items or Add account link.
+		expect( screen.queryByRole( 'link', { name: /Add account/ } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'on /reader/fediverse with zero connections, renders only Add account', async () => {
+		mockConnections( [] );
+
+		renderWithProvider( <ReaderSidebarFediverse path="/reader/fediverse" />, {
+			queryClient: makeClient(),
+		} );
+
+		const addLink = await screen.findByRole( 'link', { name: /Add account/ } );
+		expect( addLink ).toBeVisible();
+	} );
+
+	it( 'renders a row per connection plus Add account when on /reader/fediverse/:id/:tab', async () => {
+		mockConnections( [
+			{
+				id: 1,
+				handle: '@alice@mastodon.social',
+				site_host: 'mastodon.social',
+				avatar: 'https://cdn/1.png',
+			},
+			{
+				id: 2,
+				handle: '@bob@fosstodon.org',
+				site_host: 'fosstodon.org',
+				avatar: 'https://cdn/2.png',
+			},
+		] );
+
+		renderWithProvider( <ReaderSidebarFediverse path="/reader/fediverse/1/timeline" />, {
+			queryClient: makeClient(),
+		} );
+
+		// Both connection handles appear as link labels (displayName = handle).
+		const row1 = await screen.findByRole( 'link', { name: /@alice@mastodon\.social/i } );
+		const row2 = await screen.findByRole( 'link', { name: /@bob@fosstodon\.org/i } );
+		expect( row1 ).toHaveAttribute( 'href', '/reader/fediverse/1/timeline' );
+		expect( row2 ).toHaveAttribute( 'href', '/reader/fediverse/2/timeline' );
+
+		// Add account link present.
+		expect( screen.getByRole( 'link', { name: /Add account/ } ) ).toBeVisible();
+	} );
+
+	it( 'marks the active row (matching :id in the path) as selected', async () => {
+		mockConnections( [
+			{ id: 1, handle: '@alice@mastodon.social', site_host: 'mastodon.social' },
+			{ id: 2, handle: '@bob@fosstodon.org', site_host: 'fosstodon.org' },
+		] );
+
+		const { container } = renderWithProvider(
+			<ReaderSidebarFediverse path="/reader/fediverse/2/timeline" />,
+			{ queryClient: makeClient() }
+		);
+
+		// Wait until the connection rows have rendered.
+		await screen.findByRole( 'link', { name: /@bob@fosstodon\.org/i } );
+
+		// Exactly one selected row, matching the :id in the path.
+		const selected = container.querySelectorAll( 'li.selected' );
+		expect( selected ).toHaveLength( 1 );
+		expect( selected[ 0 ].textContent ).toContain( '@bob@fosstodon.org' );
+	} );
+} );

--- a/client/sections.js
+++ b/client/sections.js
@@ -532,6 +532,19 @@ const sections = [
 	{
 		name: 'reader',
 		paths: [
+			'/reader/fediverse',
+			'/reader/fediverse/connect',
+			'/reader/fediverse/oauth-callback',
+			'/reader/fediverse/:id',
+			'/reader/fediverse/:id/:tab',
+		],
+		module: 'calypso/reader/fediverse',
+		group: 'reader',
+		enableLoggedOut: false,
+	},
+	{
+		name: 'reader',
+		paths: [
 			'/reader/mastodon',
 			'/reader/mastodon/connect',
 			'/reader/mastodon/oauth-callback',

--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -87,6 +87,7 @@ export * from './read-streams';
 export * from './read-tags';
 export * from './read-teams';
 export * from './read-thumbnails';
+export * from './reader-activitypub';
 export * from './reader-atmosphere';
 export * from './reader-mastodon';
 export * from './site';

--- a/packages/api-core/src/reader-activitypub/__tests__/fetchers.test.ts
+++ b/packages/api-core/src/reader-activitypub/__tests__/fetchers.test.ts
@@ -97,7 +97,7 @@ describe( 'fediverse activitypub fetchers', () => {
 		expect( res.authorize_url ).toContain( 'authorize' );
 	} );
 
-	it( 'completeFediverseConnection posts step=complete and returns the connection wrapper', async () => {
+	it( 'completeFediverseConnection posts step=complete and returns the connection', async () => {
 		nock( BASE )
 			.post( '/wpcom/v2/reader/activitypub/connections', {
 				step: 'complete',
@@ -105,18 +105,16 @@ describe( 'fediverse activitypub fetchers', () => {
 				state: 'abc',
 			} )
 			.reply( 200, {
-				connection: {
-					id: 99,
-					site_host: 'example.wordpress.com',
-					handle: '@alice@example.wordpress.com',
-					avatar: 'https://cdn/avatar.png',
-					actor_url: 'https://example.wordpress.com/wp-json/activitypub/1.0/users/1',
-					blog_id: 123,
-					actor_type: 'user',
-				},
+				id: 99,
+				site_host: 'example.wordpress.com',
+				handle: '@alice@example.wordpress.com',
+				avatar: 'https://cdn/avatar.png',
+				actor_url: 'https://example.wordpress.com/wp-json/activitypub/1.0/users/1',
+				blog_id: 123,
+				actor_type: 'user',
 			} );
 		const res = await completeFediverseConnection( { code: 'xyz', state: 'abc' } );
-		expect( res.connection.id ).toBe( 99 );
+		expect( res.id ).toBe( 99 );
 	} );
 
 	it( 'completeFediverseConnection classifies ERR_AUTH_REQUIRED as auth_required', async () => {

--- a/packages/api-core/src/reader-activitypub/__tests__/fetchers.test.ts
+++ b/packages/api-core/src/reader-activitypub/__tests__/fetchers.test.ts
@@ -1,0 +1,265 @@
+import nock from 'nock';
+import {
+	authorizeFediverseConnection,
+	completeFediverseConnection,
+	createFediverseNote,
+	deleteFediverseConnection,
+	enableFediverseC2s,
+	enableFediverseFeature,
+	enableFediverseUserActors,
+	getFediverseConnection,
+	getFediverseConnections,
+	getFediverseSiteCapabilities,
+} from '../fetchers';
+
+const BASE = 'https://public-api.wordpress.com';
+
+describe( 'fediverse activitypub fetchers', () => {
+	afterEach( () => nock.cleanAll() );
+
+	it( 'getFediverseConnections returns the list', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/activitypub/connections' )
+			.reply( 200, {
+				connections: [
+					{
+						id: 1,
+						site_host: 'example.wordpress.com',
+						handle: '@alice@example.wordpress.com',
+						avatar: 'https://cdn/avatar.png',
+						actor_url: 'https://example.wordpress.com/wp-json/activitypub/1.0/users/1',
+						blog_id: 123,
+						actor_type: 'user',
+					},
+				],
+			} );
+		const res = await getFediverseConnections();
+		expect( res.connections ).toHaveLength( 1 );
+		expect( res.connections[ 0 ].handle ).toBe( '@alice@example.wordpress.com' );
+		expect( res.connections[ 0 ].actor_type ).toBe( 'user' );
+	} );
+
+	it( 'getFediverseConnections classifies 401 as auth_required', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/activitypub/connections' )
+			.reply( 401, {
+				code: 'not_authenticated',
+				message: 'Authentication required.',
+				data: { status: 401 },
+			} );
+		await expect( getFediverseConnections() ).rejects.toMatchObject( { kind: 'auth_required' } );
+	} );
+
+	it( 'getFediverseConnections classifies 403 as forbidden', async () => {
+		nock( BASE ).get( '/wpcom/v2/reader/activitypub/connections' ).reply( 403, {
+			statusCode: 403,
+			message: 'Forbidden.',
+		} );
+		await expect( getFediverseConnections() ).rejects.toMatchObject( { kind: 'forbidden' } );
+	} );
+
+	it( 'getFediverseConnection GETs /connections/:id', async () => {
+		nock( BASE ).get( '/wpcom/v2/reader/activitypub/connections/42' ).reply( 200, {
+			id: 42,
+			site_host: 'example.wordpress.com',
+			handle: '@alice@example.wordpress.com',
+			avatar: 'https://cdn/avatar.png',
+			actor_url: 'https://example.wordpress.com/wp-json/activitypub/1.0/users/1',
+			blog_id: 123,
+			actor_type: 'user',
+		} );
+		const res = await getFediverseConnection( 42 );
+		expect( res.id ).toBe( 42 );
+		expect( res.actor_type ).toBe( 'user' );
+	} );
+
+	it( 'deleteFediverseConnection sends DELETE to /connections/:id', async () => {
+		const scope = nock( BASE )
+			.delete( '/wpcom/v2/reader/activitypub/connections/7' )
+			.reply( 200, {} );
+		await deleteFediverseConnection( 7 );
+		expect( scope.isDone() ).toBe( true );
+	} );
+
+	it( 'authorizeFediverseConnection posts step=authorize and returns authorize_url + state', async () => {
+		nock( BASE )
+			.post( '/wpcom/v2/reader/activitypub/connections', {
+				step: 'authorize',
+				blog_id: 123,
+				actor: 'user',
+			} )
+			.reply( 200, {
+				authorize_url: 'https://example.wordpress.com/oauth/authorize?state=abc',
+				state: 'abc',
+			} );
+		const res = await authorizeFediverseConnection( { blog_id: 123, actor: 'user' } );
+		expect( res.state ).toBe( 'abc' );
+		expect( res.authorize_url ).toContain( 'authorize' );
+	} );
+
+	it( 'completeFediverseConnection posts step=complete and returns the connection wrapper', async () => {
+		nock( BASE )
+			.post( '/wpcom/v2/reader/activitypub/connections', {
+				step: 'complete',
+				code: 'xyz',
+				state: 'abc',
+			} )
+			.reply( 200, {
+				connection: {
+					id: 99,
+					site_host: 'example.wordpress.com',
+					handle: '@alice@example.wordpress.com',
+					avatar: 'https://cdn/avatar.png',
+					actor_url: 'https://example.wordpress.com/wp-json/activitypub/1.0/users/1',
+					blog_id: 123,
+					actor_type: 'user',
+				},
+			} );
+		const res = await completeFediverseConnection( { code: 'xyz', state: 'abc' } );
+		expect( res.connection.id ).toBe( 99 );
+	} );
+
+	it( 'completeFediverseConnection classifies ERR_AUTH_REQUIRED as auth_required', async () => {
+		nock( BASE )
+			.post( '/wpcom/v2/reader/activitypub/connections' )
+			.reply( 401, {
+				code: 'ERR_AUTH_REQUIRED',
+				message: 'Auth required.',
+				data: { status: 401 },
+			} );
+		await expect(
+			completeFediverseConnection( { code: 'xyz', state: 'abc' } )
+		).rejects.toMatchObject( { kind: 'auth_required' } );
+	} );
+
+	it( 'completeFediverseConnection classifies state_expired (HTTP 400)', async () => {
+		nock( BASE )
+			.post( '/wpcom/v2/reader/activitypub/connections' )
+			.reply( 400, {
+				code: 'state_expired',
+				message: 'OAuth state has expired.',
+				data: { status: 400 },
+			} );
+		await expect(
+			completeFediverseConnection( { code: 'xyz', state: 'abc' } )
+		).rejects.toMatchObject( { kind: 'state_expired' } );
+	} );
+
+	it( 'getFediverseSiteCapabilities GETs /sites/:blog_id/capabilities', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/activitypub/sites/123/capabilities' )
+			.reply( 200, {
+				activitypub_active: true,
+				c2s_enabled: true,
+				actors: {
+					user: { enabled: true, can_enable: true },
+					blog: { enabled: false, can_enable: true },
+				},
+				oauth_metadata: null,
+				site_host: 'example.wordpress.com',
+				site_kind: 'wpcom',
+				current_user_can_publish: true,
+			} );
+		const res = await getFediverseSiteCapabilities( 123 );
+		expect( res.activitypub_active ).toBe( true );
+		expect( res.site_kind ).toBe( 'wpcom' );
+	} );
+
+	it( 'enableFediverseFeature POSTs to /sites/:blog_id/enable-feature', async () => {
+		const scope = nock( BASE )
+			.post( '/wpcom/v2/reader/activitypub/sites/123/enable-feature' )
+			.reply( 200, { success: true } );
+		const res = await enableFediverseFeature( 123 );
+		expect( res.success ).toBe( true );
+		expect( scope.isDone() ).toBe( true );
+	} );
+
+	it( 'enableFediverseC2s POSTs to /sites/:blog_id/enable-c2s', async () => {
+		const scope = nock( BASE )
+			.post( '/wpcom/v2/reader/activitypub/sites/123/enable-c2s' )
+			.reply( 200, { success: true } );
+		const res = await enableFediverseC2s( 123 );
+		expect( res.success ).toBe( true );
+		expect( scope.isDone() ).toBe( true );
+	} );
+
+	it( 'enableFediverseUserActors POSTs to /sites/:blog_id/enable-user-actors', async () => {
+		const scope = nock( BASE )
+			.post( '/wpcom/v2/reader/activitypub/sites/123/enable-user-actors' )
+			.reply( 200, { success: true } );
+		const res = await enableFediverseUserActors( 123 );
+		expect( res.success ).toBe( true );
+		expect( scope.isDone() ).toBe( true );
+	} );
+
+	it( 'createFediverseNote POSTs to /connections/:id/notes with body { text }', async () => {
+		nock( BASE )
+			.post( '/wpcom/v2/reader/activitypub/connections/7/notes', { text: 'Hello world' } )
+			.reply( 200, {
+				id: 'https://example.wordpress.com/activitypub/notes/1',
+				url: 'https://example.wordpress.com/?p=1',
+				posted_at: '2024-01-01T00:00:00Z',
+			} );
+		const res = await createFediverseNote( { connectionId: 7, text: 'Hello world' } );
+		expect( res.id ).toBe( 'https://example.wordpress.com/activitypub/notes/1' );
+	} );
+
+	it( 'createFediverseNote classifies reader_activitypub_note_empty as note_empty', async () => {
+		nock( BASE )
+			.post( '/wpcom/v2/reader/activitypub/connections/7/notes' )
+			.reply( 400, {
+				code: 'reader_activitypub_note_empty',
+				message: 'Note text cannot be empty.',
+				data: { status: 400 },
+			} );
+		await expect( createFediverseNote( { connectionId: 7, text: '' } ) ).rejects.toMatchObject( {
+			kind: 'note_empty',
+		} );
+	} );
+
+	it( 'classifies ERR_RATE_LIMITED with retry_after', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/activitypub/connections' )
+			.reply( 429, {
+				code: 'ERR_RATE_LIMITED',
+				message: 'Too many requests.',
+				data: { status: 429, retry_after: 30 },
+			} );
+		await expect( getFediverseConnections() ).rejects.toEqual( {
+			kind: 'rate_limited',
+			retry_after: 30,
+		} );
+	} );
+
+	it( 'classifies ERR_UPSTREAM_UNAVAILABLE as upstream_unavailable', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/activitypub/connections' )
+			.reply( 503, {
+				code: 'ERR_UPSTREAM_UNAVAILABLE',
+				message: 'Service unavailable.',
+				data: { status: 503 },
+			} );
+		await expect( getFediverseConnections() ).rejects.toMatchObject( {
+			kind: 'upstream_unavailable',
+		} );
+	} );
+
+	it( 'classifies ERR_AUTH_FAILED as auth_failed', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/activitypub/connections' )
+			.reply( 401, {
+				code: 'ERR_AUTH_FAILED',
+				message: 'Auth failed.',
+				data: { status: 401 },
+			} );
+		await expect( getFediverseConnections() ).rejects.toMatchObject( { kind: 'auth_failed' } );
+	} );
+
+	it( 'classifies 404 HTTP status as not_found', async () => {
+		nock( BASE ).get( '/wpcom/v2/reader/activitypub/connections/999' ).reply( 404, {
+			statusCode: 404,
+			message: 'Not found.',
+		} );
+		await expect( getFediverseConnection( 999 ) ).rejects.toMatchObject( { kind: 'not_found' } );
+	} );
+} );

--- a/packages/api-core/src/reader-activitypub/errors.ts
+++ b/packages/api-core/src/reader-activitypub/errors.ts
@@ -1,0 +1,84 @@
+export type FediverseError =
+	| { kind: 'auth_failed' }
+	| { kind: 'auth_required' }
+	| { kind: 'forbidden' }
+	| { kind: 'not_found' }
+	| { kind: 'state_expired' }
+	| { kind: 'note_empty' }
+	| { kind: 'rate_limited'; retry_after?: number }
+	| { kind: 'upstream_unavailable' }
+	| { kind: 'bad_request'; message: string }
+	| { kind: 'unknown'; cause: unknown };
+
+interface WpErrorLike {
+	// The wpcom-proxy / wpcom-xhr-request transports surface the WP REST
+	// envelope's error code as `code` on the thrown error. Some legacy
+	// callsites (and the existing test fixtures) populate `error` instead.
+	// Accept both so live errors classify correctly regardless of which
+	// transport raised them.
+	error?: string;
+	code?: string;
+	statusCode?: number;
+	status?: number;
+	message?: string;
+	data?: { retry_after?: number } & Record< string, unknown >;
+}
+
+function isWpErrorLike( e: unknown ): e is WpErrorLike {
+	if ( typeof e !== 'object' || e === null ) {
+		return false;
+	}
+	const obj = e as object;
+	return 'error' in obj || 'code' in obj || 'statusCode' in obj || 'status' in obj;
+}
+
+export function classifyFediverseError( raw: unknown ): FediverseError {
+	if ( ! isWpErrorLike( raw ) ) {
+		return { kind: 'unknown', cause: raw };
+	}
+	const rateLimited = ( source: WpErrorLike ): FediverseError => {
+		const retryAfter = source.data?.retry_after;
+		return typeof retryAfter === 'number'
+			? { kind: 'rate_limited', retry_after: retryAfter }
+			: { kind: 'rate_limited' };
+	};
+	const errorCode = raw.error ?? raw.code;
+	switch ( errorCode ) {
+		case 'state_expired':
+			return { kind: 'state_expired' };
+		case 'reader_activitypub_note_empty':
+			return { kind: 'note_empty' };
+		case 'ERR_AUTH_FAILED':
+		case 'auth_failed':
+			return { kind: 'auth_failed' };
+		case 'ERR_AUTH_REQUIRED':
+		case 'not_authenticated':
+			return { kind: 'auth_required' };
+		case 'ERR_RATE_LIMITED':
+		case 'rate_limited':
+			return rateLimited( raw );
+		case 'ERR_UPSTREAM_UNAVAILABLE':
+		case 'upstream_unavailable':
+			return { kind: 'upstream_unavailable' };
+	}
+	const statusCode = raw.statusCode ?? raw.status;
+	if ( statusCode === 400 && errorCode === 'state_expired' ) {
+		return { kind: 'state_expired' };
+	}
+	if ( statusCode === 401 ) {
+		return { kind: 'auth_required' };
+	}
+	if ( statusCode === 403 ) {
+		return { kind: 'forbidden' };
+	}
+	if ( statusCode === 404 ) {
+		return { kind: 'not_found' };
+	}
+	if ( statusCode === 429 ) {
+		return rateLimited( raw );
+	}
+	if ( statusCode === 503 ) {
+		return { kind: 'upstream_unavailable' };
+	}
+	return { kind: 'unknown', cause: raw };
+}

--- a/packages/api-core/src/reader-activitypub/errors.ts
+++ b/packages/api-core/src/reader-activitypub/errors.ts
@@ -62,9 +62,6 @@ export function classifyFediverseError( raw: unknown ): FediverseError {
 			return { kind: 'upstream_unavailable' };
 	}
 	const statusCode = raw.statusCode ?? raw.status;
-	if ( statusCode === 400 && errorCode === 'state_expired' ) {
-		return { kind: 'state_expired' };
-	}
 	if ( statusCode === 401 ) {
 		return { kind: 'auth_required' };
 	}

--- a/packages/api-core/src/reader-activitypub/fetchers.ts
+++ b/packages/api-core/src/reader-activitypub/fetchers.ts
@@ -1,0 +1,156 @@
+import { wpcom } from '../wpcom-fetcher';
+import { classifyFediverseError } from './errors';
+import type {
+	FediverseActorType,
+	FediverseAuthorizeResponse,
+	FediverseConnection,
+	FediverseConnectionsResponse,
+	FediverseEnableResponse,
+	FediverseNote,
+	FediverseSiteCapabilities,
+} from './types';
+
+const NAMESPACE = 'wpcom/v2';
+
+export async function getFediverseConnections(): Promise< FediverseConnectionsResponse > {
+	try {
+		return ( await wpcom.req.get( {
+			path: '/reader/activitypub/connections',
+			apiNamespace: NAMESPACE,
+		} ) ) as FediverseConnectionsResponse;
+	} catch ( raw ) {
+		throw classifyFediverseError( raw );
+	}
+}
+
+export async function getFediverseConnection( id: number ): Promise< FediverseConnection > {
+	try {
+		return ( await wpcom.req.get( {
+			path: `/reader/activitypub/connections/${ id }`,
+			apiNamespace: NAMESPACE,
+		} ) ) as FediverseConnection;
+	} catch ( raw ) {
+		throw classifyFediverseError( raw );
+	}
+}
+
+export async function deleteFediverseConnection( id: number ): Promise< void > {
+	try {
+		await wpcom.req.post( {
+			path: `/reader/activitypub/connections/${ id }`,
+			apiNamespace: NAMESPACE,
+			method: 'DELETE',
+		} );
+	} catch ( raw ) {
+		throw classifyFediverseError( raw );
+	}
+}
+
+export interface AuthorizeFediverseConnectionParams {
+	blog_id: number;
+	actor?: FediverseActorType;
+}
+
+export async function authorizeFediverseConnection(
+	params: AuthorizeFediverseConnectionParams
+): Promise< FediverseAuthorizeResponse > {
+	try {
+		return ( await wpcom.req.post( {
+			path: '/reader/activitypub/connections',
+			apiNamespace: NAMESPACE,
+			body: { step: 'authorize', ...params },
+		} ) ) as FediverseAuthorizeResponse;
+	} catch ( raw ) {
+		throw classifyFediverseError( raw );
+	}
+}
+
+export interface CompleteFediverseConnectionParams {
+	code: string;
+	state: string;
+}
+
+export async function completeFediverseConnection(
+	params: CompleteFediverseConnectionParams
+): Promise< { connection: FediverseConnection } > {
+	try {
+		// The upstream returns `{ connection: FediverseConnection }` matching the
+		// mastodon complete-connection shape. We cast directly to that wrapper
+		// rather than rebundling at the fetcher level.
+		return ( await wpcom.req.post( {
+			path: '/reader/activitypub/connections',
+			apiNamespace: NAMESPACE,
+			body: { step: 'complete', ...params },
+		} ) ) as { connection: FediverseConnection };
+	} catch ( raw ) {
+		throw classifyFediverseError( raw );
+	}
+}
+
+export async function getFediverseSiteCapabilities(
+	blogId: number
+): Promise< FediverseSiteCapabilities > {
+	try {
+		return ( await wpcom.req.get( {
+			path: `/reader/activitypub/sites/${ blogId }/capabilities`,
+			apiNamespace: NAMESPACE,
+		} ) ) as FediverseSiteCapabilities;
+	} catch ( raw ) {
+		throw classifyFediverseError( raw );
+	}
+}
+
+export async function enableFediverseFeature( blogId: number ): Promise< FediverseEnableResponse > {
+	try {
+		return ( await wpcom.req.post( {
+			path: `/reader/activitypub/sites/${ blogId }/enable-feature`,
+			apiNamespace: NAMESPACE,
+		} ) ) as FediverseEnableResponse;
+	} catch ( raw ) {
+		throw classifyFediverseError( raw );
+	}
+}
+
+export async function enableFediverseC2s( blogId: number ): Promise< FediverseEnableResponse > {
+	try {
+		return ( await wpcom.req.post( {
+			path: `/reader/activitypub/sites/${ blogId }/enable-c2s`,
+			apiNamespace: NAMESPACE,
+		} ) ) as FediverseEnableResponse;
+	} catch ( raw ) {
+		throw classifyFediverseError( raw );
+	}
+}
+
+export async function enableFediverseUserActors(
+	blogId: number
+): Promise< FediverseEnableResponse > {
+	try {
+		return ( await wpcom.req.post( {
+			path: `/reader/activitypub/sites/${ blogId }/enable-user-actors`,
+			apiNamespace: NAMESPACE,
+		} ) ) as FediverseEnableResponse;
+	} catch ( raw ) {
+		throw classifyFediverseError( raw );
+	}
+}
+
+export interface CreateFediverseNoteParams {
+	connectionId: number;
+	text: string;
+}
+
+export async function createFediverseNote(
+	params: CreateFediverseNoteParams
+): Promise< FediverseNote > {
+	const { connectionId, text } = params;
+	try {
+		return ( await wpcom.req.post( {
+			path: `/reader/activitypub/connections/${ connectionId }/notes`,
+			apiNamespace: NAMESPACE,
+			body: { text },
+		} ) ) as FediverseNote;
+	} catch ( raw ) {
+		throw classifyFediverseError( raw );
+	}
+}

--- a/packages/api-core/src/reader-activitypub/fetchers.ts
+++ b/packages/api-core/src/reader-activitypub/fetchers.ts
@@ -72,16 +72,13 @@ export interface CompleteFediverseConnectionParams {
 
 export async function completeFediverseConnection(
 	params: CompleteFediverseConnectionParams
-): Promise< { connection: FediverseConnection } > {
+): Promise< FediverseConnection > {
 	try {
-		// The upstream returns `{ connection: FediverseConnection }` matching the
-		// mastodon complete-connection shape. We cast directly to that wrapper
-		// rather than rebundling at the fetcher level.
 		return ( await wpcom.req.post( {
 			path: '/reader/activitypub/connections',
 			apiNamespace: NAMESPACE,
 			body: { step: 'complete', ...params },
-		} ) ) as { connection: FediverseConnection };
+		} ) ) as FediverseConnection;
 	} catch ( raw ) {
 		throw classifyFediverseError( raw );
 	}

--- a/packages/api-core/src/reader-activitypub/index.ts
+++ b/packages/api-core/src/reader-activitypub/index.ts
@@ -1,0 +1,4 @@
+export * from './errors';
+export * from './fetchers';
+export * from './query-keys';
+export * from './types';

--- a/packages/api-core/src/reader-activitypub/query-keys.ts
+++ b/packages/api-core/src/reader-activitypub/query-keys.ts
@@ -1,0 +1,7 @@
+export const readerActivityPubKeys = {
+	all: [ 'reader', 'activitypub' ] as const,
+	connections: () => [ ...readerActivityPubKeys.all, 'connections' ] as const,
+	connection: ( id: number | null ) => [ ...readerActivityPubKeys.all, 'connection', id ] as const,
+	capabilities: ( blogId: number | null ) =>
+		[ ...readerActivityPubKeys.all, 'capabilities', blogId ] as const,
+};

--- a/packages/api-core/src/reader-activitypub/types.ts
+++ b/packages/api-core/src/reader-activitypub/types.ts
@@ -1,0 +1,48 @@
+export type FediverseActorType = 'user' | 'blog';
+
+export interface FediverseConnection {
+	id: number;
+	site_host: string;
+	handle: string;
+	avatar: string;
+	actor_url: string;
+	blog_id: number;
+	actor_type: FediverseActorType;
+}
+
+export interface FediverseConnectionsResponse {
+	connections: FediverseConnection[];
+}
+
+export interface FediverseAuthorizeResponse {
+	authorize_url: string;
+	state: string;
+}
+
+export interface FediverseSiteCapabilities {
+	activitypub_active: boolean;
+	c2s_enabled: boolean;
+	actors: {
+		user: { enabled: boolean; can_enable: boolean };
+		blog: { enabled: boolean; can_enable: boolean };
+	};
+	oauth_metadata: {
+		authorize_url: string;
+		token_url: string;
+		registration_url: string;
+		revoke_url: string;
+	} | null;
+	site_host: string;
+	site_kind: 'wpcom' | 'jetpack';
+	current_user_can_publish: boolean;
+}
+
+export interface FediverseEnableResponse {
+	success: boolean;
+}
+
+export interface FediverseNote {
+	id: string;
+	url: string;
+	posted_at: string;
+}

--- a/packages/api-queries/src/__tests__/reader-activitypub.test.tsx
+++ b/packages/api-queries/src/__tests__/reader-activitypub.test.tsx
@@ -1,0 +1,272 @@
+import { readerActivityPubKeys } from '@automattic/api-core';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import {
+	useAuthorizeFediverseConnectionMutation,
+	useCompleteFediverseConnectionMutation,
+	useCreateFediverseNoteMutation,
+	useDisconnectFediverseMutation,
+	useEnableFediverseC2sMutation,
+	useEnableFediverseFeatureMutation,
+	useEnableFediverseUserActorsMutation,
+	useFediverseConnectionQuery,
+	useFediverseConnectionsQuery,
+	useFediverseSiteCapabilitiesQuery,
+} from '../reader-activitypub';
+
+const BASE = 'https://public-api.wordpress.com';
+
+function makeWrapper( c: QueryClient ) {
+	function Wrapper( { children }: { children: React.ReactNode } ) {
+		return <QueryClientProvider client={ c }>{ children }</QueryClientProvider>;
+	}
+	return Wrapper;
+}
+
+function createWrapper() {
+	const client = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+	return makeWrapper( client );
+}
+
+const STUB_CONNECTION = {
+	id: 1,
+	site_host: 'example.wordpress.com',
+	handle: '@alice@example.wordpress.com',
+	avatar: 'https://cdn/avatar.png',
+	actor_url: 'https://example.wordpress.com/wp-json/activitypub/1.0/users/1',
+	blog_id: 123,
+	actor_type: 'user',
+};
+
+describe( 'reader-activitypub hooks', () => {
+	afterEach( () => nock.cleanAll() );
+
+	it( 'useFediverseConnectionsQuery returns the list', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/activitypub/connections' )
+			.reply( 200, { connections: [] } );
+		const client = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+		const { result } = renderHook( () => useFediverseConnectionsQuery(), {
+			wrapper: makeWrapper( client ),
+		} );
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+	} );
+
+	it( 'useFediverseConnectionQuery is disabled when id is null', () => {
+		const client = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+		const { result } = renderHook( () => useFediverseConnectionQuery( null ), {
+			wrapper: makeWrapper( client ),
+		} );
+		expect( result.current.fetchStatus ).toBe( 'idle' );
+	} );
+
+	it( 'useFediverseConnectionQuery fetches /connections/:id', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/activitypub/connections/42' )
+			.reply( 200, { ...STUB_CONNECTION, id: 42 } );
+		const client = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+		const { result } = renderHook( () => useFediverseConnectionQuery( 42 ), {
+			wrapper: makeWrapper( client ),
+		} );
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+		expect( result.current.data?.id ).toBe( 42 );
+	} );
+
+	it( 'useFediverseSiteCapabilitiesQuery fetches /sites/:blog_id/capabilities', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/activitypub/sites/123/capabilities' )
+			.reply( 200, {
+				activitypub_active: true,
+				c2s_enabled: true,
+				actors: {
+					user: { enabled: true, can_enable: true },
+					blog: { enabled: false, can_enable: true },
+				},
+				oauth_metadata: null,
+				site_host: 'example.wordpress.com',
+				site_kind: 'wpcom',
+				current_user_can_publish: true,
+			} );
+		const { result } = renderHook( () => useFediverseSiteCapabilitiesQuery( 123 ), {
+			wrapper: createWrapper(),
+		} );
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+		expect( result.current.data?.c2s_enabled ).toBe( true );
+	} );
+
+	it( 'useAuthorizeFediverseConnectionMutation returns authorize_url + state without cache invalidation', async () => {
+		nock( BASE )
+			.post( '/wpcom/v2/reader/activitypub/connections', {
+				step: 'authorize',
+				blog_id: 123,
+			} )
+			.reply( 200, {
+				authorize_url: 'https://example.wordpress.com/oauth/authorize?state=abc',
+				state: 'abc',
+			} );
+		const client = new QueryClient();
+		const spy = jest.spyOn( client, 'invalidateQueries' );
+		const { result } = renderHook( () => useAuthorizeFediverseConnectionMutation(), {
+			wrapper: makeWrapper( client ),
+		} );
+		const response = await result.current.mutateAsync( { blog_id: 123 } );
+		expect( response.state ).toBe( 'abc' );
+		// authorize is a pure redirect-fetcher — there's nothing to invalidate yet.
+		expect( spy ).not.toHaveBeenCalled();
+	} );
+
+	it( 'useCompleteFediverseConnectionMutation seeds the connections list cache synchronously', async () => {
+		nock( BASE )
+			.post( '/wpcom/v2/reader/activitypub/connections', {
+				step: 'complete',
+				code: 'xyz',
+				state: 'abc',
+			} )
+			.reply( 200, { connection: { ...STUB_CONNECTION, id: 202 } } );
+		const client = new QueryClient();
+		client.setQueryData( readerActivityPubKeys.connections(), {
+			connections: [ { ...STUB_CONNECTION, id: 1 } ],
+		} );
+		const { result } = renderHook( () => useCompleteFediverseConnectionMutation(), {
+			wrapper: makeWrapper( client ),
+		} );
+		await result.current.mutateAsync( { code: 'xyz', state: 'abc' } );
+
+		const cached = client.getQueryData< { connections: Array< { id: number } > } >(
+			readerActivityPubKeys.connections()
+		);
+		expect( cached?.connections.map( ( c ) => c.id ) ).toEqual( [ 1, 202 ] );
+	} );
+
+	it( 'useCompleteFediverseConnectionMutation does not duplicate an already-cached connection', async () => {
+		nock( BASE )
+			.post( '/wpcom/v2/reader/activitypub/connections', {
+				step: 'complete',
+				code: 'xyz',
+				state: 'abc',
+			} )
+			.reply( 200, { connection: { ...STUB_CONNECTION, id: 303 } } );
+		const client = new QueryClient();
+		client.setQueryData( readerActivityPubKeys.connections(), {
+			connections: [ { ...STUB_CONNECTION, id: 303 } ],
+		} );
+		const { result } = renderHook( () => useCompleteFediverseConnectionMutation(), {
+			wrapper: makeWrapper( client ),
+		} );
+		await result.current.mutateAsync( { code: 'xyz', state: 'abc' } );
+
+		const cached = client.getQueryData< { connections: Array< { id: number } > } >(
+			readerActivityPubKeys.connections()
+		);
+		expect( cached?.connections.map( ( c ) => c.id ) ).toEqual( [ 303 ] );
+	} );
+
+	it( 'useCompleteFediverseConnectionMutation invalidates the connections query', async () => {
+		nock( BASE )
+			.post( '/wpcom/v2/reader/activitypub/connections', {
+				step: 'complete',
+				code: 'xyz',
+				state: 'abc',
+			} )
+			.reply( 200, { connection: { ...STUB_CONNECTION, id: 101 } } );
+		const client = new QueryClient();
+		client.setQueryData( readerActivityPubKeys.connections(), 'old' );
+		const spy = jest.spyOn( client, 'invalidateQueries' );
+		const { result } = renderHook( () => useCompleteFediverseConnectionMutation(), {
+			wrapper: makeWrapper( client ),
+		} );
+		await result.current.mutateAsync( { code: 'xyz', state: 'abc' } );
+		await waitFor( () =>
+			expect( spy ).toHaveBeenCalledWith( {
+				queryKey: readerActivityPubKeys.connections(),
+			} )
+		);
+	} );
+
+	it( 'useEnableFediverseFeatureMutation invalidates capabilities on success', async () => {
+		nock( BASE )
+			.post( '/wpcom/v2/reader/activitypub/sites/123/enable-feature' )
+			.reply( 200, { success: true } );
+		const client = new QueryClient();
+		const spy = jest.spyOn( client, 'invalidateQueries' );
+		const { result } = renderHook( () => useEnableFediverseFeatureMutation( 123 ), {
+			wrapper: makeWrapper( client ),
+		} );
+		await result.current.mutateAsync();
+		await waitFor( () =>
+			expect( spy ).toHaveBeenCalledWith( {
+				queryKey: readerActivityPubKeys.capabilities( 123 ),
+			} )
+		);
+	} );
+
+	it( 'useEnableFediverseC2sMutation invalidates capabilities on success', async () => {
+		nock( BASE )
+			.post( '/wpcom/v2/reader/activitypub/sites/123/enable-c2s' )
+			.reply( 200, { success: true } );
+		const client = new QueryClient();
+		const spy = jest.spyOn( client, 'invalidateQueries' );
+		const { result } = renderHook( () => useEnableFediverseC2sMutation( 123 ), {
+			wrapper: makeWrapper( client ),
+		} );
+		await result.current.mutateAsync();
+		await waitFor( () =>
+			expect( spy ).toHaveBeenCalledWith( {
+				queryKey: readerActivityPubKeys.capabilities( 123 ),
+			} )
+		);
+	} );
+
+	it( 'useEnableFediverseUserActorsMutation invalidates capabilities on success', async () => {
+		nock( BASE )
+			.post( '/wpcom/v2/reader/activitypub/sites/123/enable-user-actors' )
+			.reply( 200, { success: true } );
+		const client = new QueryClient();
+		const spy = jest.spyOn( client, 'invalidateQueries' );
+		const { result } = renderHook( () => useEnableFediverseUserActorsMutation( 123 ), {
+			wrapper: makeWrapper( client ),
+		} );
+		await result.current.mutateAsync();
+		await waitFor( () =>
+			expect( spy ).toHaveBeenCalledWith( {
+				queryKey: readerActivityPubKeys.capabilities( 123 ),
+			} )
+		);
+	} );
+
+	it( 'useCreateFediverseNoteMutation POSTs the note and returns it', async () => {
+		nock( BASE )
+			.post( '/wpcom/v2/reader/activitypub/connections/7/notes', { text: 'Hello world' } )
+			.reply( 200, {
+				id: 'https://example.wordpress.com/activitypub/notes/1',
+				url: 'https://example.wordpress.com/?p=1',
+				posted_at: '2024-01-01T00:00:00Z',
+			} );
+		const { result } = renderHook( () => useCreateFediverseNoteMutation( 7 ), {
+			wrapper: createWrapper(),
+		} );
+		const res = await result.current.mutateAsync( { connectionId: 7, text: 'Hello world' } );
+		expect( res.id ).toBe( 'https://example.wordpress.com/activitypub/notes/1' );
+	} );
+
+	it( 'useDisconnectFediverseMutation invalidates connections and removes the per-connection query', async () => {
+		nock( BASE ).delete( '/wpcom/v2/reader/activitypub/connections/7' ).reply( 200, {} );
+		const client = new QueryClient();
+		client.setQueryData( readerActivityPubKeys.connection( 7 ), STUB_CONNECTION );
+		const invalidateSpy = jest.spyOn( client, 'invalidateQueries' );
+		const removeSpy = jest.spyOn( client, 'removeQueries' );
+		const { result } = renderHook( () => useDisconnectFediverseMutation( 7 ), {
+			wrapper: makeWrapper( client ),
+		} );
+		await result.current.mutateAsync();
+		await waitFor( () =>
+			expect( invalidateSpy ).toHaveBeenCalledWith( {
+				queryKey: readerActivityPubKeys.connections(),
+			} )
+		);
+		expect( removeSpy ).toHaveBeenCalledWith( {
+			queryKey: readerActivityPubKeys.connection( 7 ),
+		} );
+	} );
+} );

--- a/packages/api-queries/src/index.ts
+++ b/packages/api-queries/src/index.ts
@@ -78,6 +78,7 @@ export * from './read-streams';
 export * from './read-tags';
 export * from './read-teams';
 export * from './read-thumbnails';
+export * from './reader-activitypub';
 export * from './reader-atmosphere';
 export * from './reader-mastodon';
 export * from './site-activity-log';

--- a/packages/api-queries/src/reader-activitypub.ts
+++ b/packages/api-queries/src/reader-activitypub.ts
@@ -1,0 +1,146 @@
+import {
+	authorizeFediverseConnection,
+	completeFediverseConnection,
+	createFediverseNote,
+	deleteFediverseConnection,
+	enableFediverseC2s,
+	enableFediverseFeature,
+	enableFediverseUserActors,
+	getFediverseConnection,
+	getFediverseConnections,
+	getFediverseSiteCapabilities,
+	readerActivityPubKeys,
+} from '@automattic/api-core';
+import { queryOptions, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type {
+	AuthorizeFediverseConnectionParams,
+	CompleteFediverseConnectionParams,
+	CreateFediverseNoteParams,
+	FediverseAuthorizeResponse,
+	FediverseConnection,
+	FediverseConnectionsResponse,
+	FediverseEnableResponse,
+	FediverseError,
+	FediverseNote,
+	FediverseSiteCapabilities,
+} from '@automattic/api-core';
+
+export const fediverseConnectionsQueryOptions = () =>
+	queryOptions< FediverseConnectionsResponse, FediverseError >( {
+		queryKey: readerActivityPubKeys.connections(),
+		queryFn: getFediverseConnections,
+		staleTime: 60_000,
+	} );
+
+export function useFediverseConnectionsQuery( { enabled }: { enabled?: boolean } = {} ) {
+	return useQuery( { ...fediverseConnectionsQueryOptions(), enabled } );
+}
+
+export const fediverseConnectionQueryOptions = ( id: number | null ) =>
+	queryOptions< FediverseConnection, FediverseError >( {
+		queryKey: readerActivityPubKeys.connection( id ),
+		queryFn: () => getFediverseConnection( id as number ),
+		enabled: id !== null && id > 0,
+		staleTime: 60_000,
+	} );
+
+export function useFediverseConnectionQuery( id: number | null ) {
+	return useQuery( fediverseConnectionQueryOptions( id ) );
+}
+
+export const fediverseSiteCapabilitiesQueryOptions = ( blogId: number ) =>
+	queryOptions< FediverseSiteCapabilities, FediverseError >( {
+		queryKey: readerActivityPubKeys.capabilities( blogId ),
+		queryFn: () => getFediverseSiteCapabilities( blogId ),
+		enabled: blogId > 0,
+		staleTime: 0,
+	} );
+
+export function useFediverseSiteCapabilitiesQuery( blogId: number ) {
+	return useQuery( fediverseSiteCapabilitiesQueryOptions( blogId ) );
+}
+
+export function useAuthorizeFediverseConnectionMutation() {
+	return useMutation<
+		FediverseAuthorizeResponse,
+		FediverseError,
+		AuthorizeFediverseConnectionParams
+	>( {
+		mutationFn: authorizeFediverseConnection,
+	} );
+}
+
+export function useCompleteFediverseConnectionMutation() {
+	const client = useQueryClient();
+	return useMutation<
+		{ connection: FediverseConnection },
+		FediverseError,
+		CompleteFediverseConnectionParams
+	>( {
+		mutationFn: completeFediverseConnection,
+		onSuccess: ( { connection } ) => {
+			// Seed the list cache synchronously so the route we `page.replace`
+			// to next can resolve the new connection without waiting for a
+			// refetch. Without this, the account view reads the stale cached
+			// list, can't find the new id, and redirects to the landing view.
+			client.setQueryData< FediverseConnectionsResponse >(
+				readerActivityPubKeys.connections(),
+				( prev ) => {
+					const existing = prev?.connections ?? [];
+					if ( existing.some( ( c ) => c.id === connection.id ) ) {
+						return prev;
+					}
+					return { connections: [ ...existing, connection ] };
+				}
+			);
+			client.invalidateQueries( { queryKey: readerActivityPubKeys.connections() } );
+		},
+	} );
+}
+
+export function useEnableFediverseFeatureMutation( blogId: number ) {
+	const client = useQueryClient();
+	return useMutation< FediverseEnableResponse, FediverseError, void >( {
+		mutationFn: () => enableFediverseFeature( blogId ),
+		onSuccess: () => {
+			client.invalidateQueries( { queryKey: readerActivityPubKeys.capabilities( blogId ) } );
+		},
+	} );
+}
+
+export function useEnableFediverseC2sMutation( blogId: number ) {
+	const client = useQueryClient();
+	return useMutation< FediverseEnableResponse, FediverseError, void >( {
+		mutationFn: () => enableFediverseC2s( blogId ),
+		onSuccess: () => {
+			client.invalidateQueries( { queryKey: readerActivityPubKeys.capabilities( blogId ) } );
+		},
+	} );
+}
+
+export function useEnableFediverseUserActorsMutation( blogId: number ) {
+	const client = useQueryClient();
+	return useMutation< FediverseEnableResponse, FediverseError, void >( {
+		mutationFn: () => enableFediverseUserActors( blogId ),
+		onSuccess: () => {
+			client.invalidateQueries( { queryKey: readerActivityPubKeys.capabilities( blogId ) } );
+		},
+	} );
+}
+
+export function useCreateFediverseNoteMutation( connectionId: number ) {
+	return useMutation< FediverseNote, FediverseError, CreateFediverseNoteParams >( {
+		mutationFn: ( params ) => createFediverseNote( { ...params, connectionId } ),
+	} );
+}
+
+export function useDisconnectFediverseMutation( connectionId: number ) {
+	const client = useQueryClient();
+	return useMutation< void, FediverseError, void >( {
+		mutationFn: () => deleteFediverseConnection( connectionId ),
+		onSuccess: () => {
+			client.invalidateQueries( { queryKey: readerActivityPubKeys.connections() } );
+			client.removeQueries( { queryKey: readerActivityPubKeys.connection( connectionId ) } );
+		},
+	} );
+}

--- a/packages/api-queries/src/reader-activitypub.ts
+++ b/packages/api-queries/src/reader-activitypub.ts
@@ -72,13 +72,9 @@ export function useAuthorizeFediverseConnectionMutation() {
 
 export function useCompleteFediverseConnectionMutation() {
 	const client = useQueryClient();
-	return useMutation<
-		{ connection: FediverseConnection },
-		FediverseError,
-		CompleteFediverseConnectionParams
-	>( {
+	return useMutation< FediverseConnection, FediverseError, CompleteFediverseConnectionParams >( {
 		mutationFn: completeFediverseConnection,
-		onSuccess: ( { connection } ) => {
+		onSuccess: ( connection ) => {
 			// Seed the list cache synchronously so the route we `page.replace`
 			// to next can resolve the new connection without waiting for a
 			// refetch. Without this, the account view reads the stale cached


### PR DESCRIPTION
Part of #

## Proposed Changes

* Adds a new Reader section at \`/reader/fediverse\` that lets a WordPress.com user connect a Fediverse-enabled WordPress site they own (WP.com-hosted or Jetpack-connected self-hosted) and post short-form text **Notes** via the ActivityPub Client-to-Server (C2S) API.
* New connect wizard with progressive enablement: site picker → capability checklist (ActivityPub feature, C2S API, per-user actor mode) → OAuth authorize → callback → done.
* Per-user actor only for v0.1.0; blog actor support is deferred to v0.2.0.
* Composer with text-only Notes, soft 280-grapheme indicator (no hard cap), success notice, error copy per error kind.
* Settings panel with confirm-then-disconnect.
* Sidebar entry alongside ATmosphere and Mastodon, gated by the \`reader/social\` feature flag.

### File map

* \`client/reader/fediverse/\` — views, controller, route registration, OAuth state, wizard reducer, connect sub-components, composer, panels, tests.
* \`client/reader/sidebar/reader-sidebar-fediverse/\` — sidebar entry.
* \`packages/api-core/src/reader-activitypub/\` — types, fetchers wrapping \`wpcom.req\`, error classifier, query keys.
* \`packages/api-queries/src/reader-activitypub.ts\` — React Query hook wrappers (queries + mutations).
* \`client/reader/sidebar/index.jsx\`, \`client/sections.js\`, \`packages/api-core/src/index.ts\`, \`packages/api-queries/src/index.ts\` — small registration changes.

### Naming

* UI labels say **Fediverse**.
* Backend route segments use **activitypub** (the protocol). The REST endpoints live at \`/wpcom/v2/reader/activitypub/*\`.

## Why are these changes being made?

* Pairs with the wpcom backend that exposes the C2S endpoints. v0.1.0 is an internal release behind the \`reader/social\` flag.
* Timeline and Profile panels render empty placeholders by design — Reader inbox/follow ingestion for Fediverse is out of scope for v0.1.0.

### Scope explicitly excluded from v0.1.0

* Timeline / inbox / notifications reading.
* Long-form Articles, media (images/video/audio), replies, mentions, hashtags, edit/delete, scheduled posts, drafts.
* Blog-actor support (deferred to v0.2.0 pending an upstream plugin patch).
* Connecting to sites the user does not own.

### Architecture notes

* The composer is a small, self-contained \`client/reader/fediverse/composer/\` for standalone Notes only. The original plan called for lifting ATmosphere's composer into a shared \`client/reader/social/composer/\` with an adapter pattern; that lift was deferred since ATmosphere's composer is heavily AT-protocol-coupled (AtUriRef, reply/quote modes, AtmosphereError, getThreadUrl) and a clean adapter-based extraction is a multi-hour refactor that would risk ATmosphere regressions. The shared lift remains a future-work item once a second non-ATmosphere consumer demands it.
* \`useCompleteFediverseConnectionMutation\` reads \`useQueryClient()\` from React context, so the mutation invalidates Calypso's QueryClient (not the api-queries singleton) when invoked from the Reader, per the convention documented in \`client/reader/AGENTS.md\`.
* Tracks events use the \`calypso_reader_fediverse_*\` prefix to match Reader convention.

## Testing Instructions

The backend that exposes \`/wpcom/v2/reader/activitypub/*\` is being built in parallel. Until it lands on a sandbox, you can exercise the wiring at the unit test level:

\`\`\`
yarn test-client client/reader/fediverse client/reader/sidebar/reader-sidebar-fediverse
yarn test-packages packages/api-core/src/reader-activitypub packages/api-queries/src/__tests__/reader-activitypub
\`\`\`

177 unit tests pass.

Once the backend lands on a sandbox, the manual smoke flow is:

1. Enable the \`reader/social\` flag.
2. Navigate to \`/reader/fediverse\` → expect a redirect to \`/reader/fediverse/connect\` if no connections exist.
3. Pick a wpcom site already configured for ActivityPub C2S → checklist all green → **Enable & Connect** → consent screen → callback → arrive at \`/reader/fediverse/{id}/timeline\`.
4. Pick a wpcom site with ActivityPub off → wizard runs three enable steps (feature, C2S, user actors) with spinners → arrives at the authorize step.
5. Pick a Jetpack-connected self-hosted site with no plugin → same flow against the third-party ActivityPub plugin's C2S endpoints.
6. Compose a Note via the FAB on the Timeline tab → success toast.
7. Disconnect via Settings → returns to landing.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?