### PR TITLE
APM: Add stacked area chart for response time breakdown on Overview tab

### DIFF
--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -48,6 +48,7 @@ module.exports = {
 							'!@automattic/calypso-sentry',
 							'!@automattic/calypso-support-session',
 							'!@automattic/charts',
+							'!@automattic/charts-next',
 							'!@automattic/components',
 							'@automattic/components/*',
 							'!@automattic/components/src',

--- a/client/dashboard/sites/performance/backend/overview/chart-slot.tsx
+++ b/client/dashboard/sites/performance/backend/overview/chart-slot.tsx
@@ -1,14 +1,45 @@
+import { AreaChart, type SeriesData } from '@automattic/charts-next';
 import { __experimentalText as Text } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Card, CardBody } from '../../../../components/card';
+import { Card, CardBody, CardHeader } from '../../../../components/card';
+import type { ApmTimePoint } from '@automattic/api-core';
 
-export default function ChartSlot() {
+import '@automattic/charts-next/style.css';
+
+const SERIES: Array< { key: keyof Omit< ApmTimePoint, 'timestamp' >; label: string } > = [
+	{ key: 'db', label: __( 'Database' ) },
+	{ key: 'wp_core', label: __( 'WordPress core' ) },
+	{ key: 'plugins', label: __( 'Plugins' ) },
+	{ key: 'external', label: __( 'External' ) },
+];
+
+function toSeriesData( timeseries: ApmTimePoint[] ): SeriesData[] {
+	return SERIES.map( ( { key, label } ) => ( {
+		label,
+		data: timeseries.map( ( point ) => ( {
+			date: new Date( point.timestamp ),
+			value: point[ key ],
+		} ) ),
+	} ) );
+}
+
+export default function ChartSlot( { timeseries }: { timeseries: ApmTimePoint[] } ) {
+	const data = toSeriesData( timeseries );
+
 	return (
 		<Card>
+			<CardHeader>
+				<Text weight={ 500 }>{ __( 'Response time breakdown' ) }</Text>
+			</CardHeader>
 			<CardBody>
-				<div style={ { minHeight: 320, display: 'grid', placeItems: 'center' } }>
-					<Text variant="muted">{ __( 'Response time chart coming soon.' ) }</Text>
-				</div>
+				<AreaChart
+					height={ 320 }
+					data={ data }
+					stacked
+					curveType="monotone"
+					showLegend
+					withTooltips
+				/>
 			</CardBody>
 		</Card>
 	);

--- a/client/dashboard/sites/performance/backend/overview/index.tsx
+++ b/client/dashboard/sites/performance/backend/overview/index.tsx
@@ -10,7 +10,7 @@ export default function Overview( { site }: { site: Site } ) {
 
 	return (
 		<VStack spacing={ 6 }>
-			<ChartSlot />
+			<ChartSlot timeseries={ data.timeseries } />
 			<SlowRequestsList site={ site } slowRequests={ data.slow_requests } />
 		</VStack>
 	);

--- a/client/dashboard/sites/performance/backend/test/index.test.tsx
+++ b/client/dashboard/sites/performance/backend/test/index.test.tsx
@@ -9,6 +9,10 @@ import { render } from '../../../../test-utils';
 import SitePerformanceBackend from '../index';
 import type { Site } from '@automattic/api-core';
 
+jest.mock( '@automattic/charts-next', () => ( {
+	AreaChart: () => null,
+} ) );
+
 const siteSlug = 'test-site.wordpress.com';
 const siteId = 1;
 

--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
 		"@automattic/calypso-razorpay": "workspace:^",
 		"@automattic/calypso-router": "workspace:^",
 		"@automattic/charts": "^0.50.0",
+		"@automattic/charts-next": "npm:@automattic/charts@1.3.0",
 		"@automattic/color-studio": "^4.1.0",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -773,6 +773,47 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@automattic/charts-next@npm:@automattic/charts@1.3.0":
+  version: 1.3.0
+  resolution: "@automattic/charts@npm:1.3.0"
+  dependencies:
+    "@automattic/number-formatters": "npm:^1.1.7"
+    "@babel/runtime": "npm:7.29.2"
+    "@react-spring/web": "npm:9.7.5"
+    "@visx/annotation": "npm:^3.12.0"
+    "@visx/axis": "npm:^3.12.0"
+    "@visx/curve": "npm:^3.12.0"
+    "@visx/event": "npm:^3.12.0"
+    "@visx/gradient": "npm:^3.12.0"
+    "@visx/grid": "npm:^3.12.0"
+    "@visx/group": "npm:^3.12.0"
+    "@visx/legend": "npm:^3.12.0"
+    "@visx/pattern": "npm:^3.12.0"
+    "@visx/responsive": "npm:^3.12.0"
+    "@visx/scale": "npm:^3.12.0"
+    "@visx/shape": "npm:^3.12.0"
+    "@visx/text": "npm:^3.12.0"
+    "@visx/tooltip": "npm:^3.12.0"
+    "@visx/vendor": "npm:^3.12.0"
+    "@visx/xychart": "npm:^3.12.0"
+    "@wordpress/i18n": "npm:^6.0.0"
+    "@wordpress/icons": "npm:^12.0.0"
+    "@wordpress/theme": "npm:0.11.0"
+    "@wordpress/ui": "npm:0.11.0"
+    clsx: "npm:2.1.1"
+    date-fns: "npm:^4.1.0"
+    deepmerge: "npm:4.3.1"
+    dompurify: "npm:^3.3.3"
+    fast-deep-equal: "npm:3.1.3"
+    react-google-charts: "npm:^5.2.1"
+    tslib: "npm:2.8.1"
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+  checksum: 3723844a0ae9ae0c395f05e05e645a342ed25e3da395ce6d2610fa9be4f8f9e5aa27c73529050e4cb5b5bb373ecbc7d8acde72361cfe9133f7ba9b66acda4cbb
+  languageName: node
+  linkType: hard
+
 "@automattic/charts@npm:>=0.58.0 <1.0.0":
   version: 0.58.0
   resolution: "@automattic/charts@npm:0.58.0"
@@ -1754,6 +1795,17 @@ __metadata:
     debug: "npm:^4.4.0"
     tslib: "npm:^2.5.0"
   checksum: bd83f99d1d53a81ccc9879c7062f66b6c9e1b1b0103ae5943189fd546fcb20d1a27d20f2d55f20c80164b64cf0bee5dbc72e533123e9b3f873b4e3670a6d67da
+  languageName: node
+  linkType: hard
+
+"@automattic/number-formatters@npm:^1.1.7":
+  version: 1.1.7
+  resolution: "@automattic/number-formatters@npm:1.1.7"
+  dependencies:
+    "@wordpress/date": "npm:^5.19.0"
+    debug: "npm:^4.4.0"
+    tslib: "npm:^2.5.0"
+  checksum: b93ea434c8b1e10cb54c6f4229fc344168f83fefa7693ef595dd2a679b51792532411703f52e88a126fd12f2ac52350e3ae4d8351e60b732eabf1da46414335d
   languageName: node
   linkType: hard
 
@@ -4212,7 +4264,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.27.1, @babel/runtime@npm:^7.28.6, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.3, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:7.29.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.27.1, @babel/runtime@npm:^7.28.6, @babel/runtime@npm:^7.29.2, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.3, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.9.2":
   version: 7.29.2
   resolution: "@babel/runtime@npm:7.29.2"
   checksum: 30b80a0140d16467792e1bbeb06f655b0dab70407da38dfac7fedae9c859f9ae9d846ef14ad77bd3814c064295fe9b1bc551f1541ea14646ae9f22b71a8bc17a
@@ -4276,6 +4328,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@base-ui/react@npm:^1.4.0":
+  version: 1.4.1
+  resolution: "@base-ui/react@npm:1.4.1"
+  dependencies:
+    "@babel/runtime": "npm:^7.29.2"
+    "@base-ui/utils": "npm:0.2.8"
+    "@floating-ui/react-dom": "npm:^2.1.8"
+    "@floating-ui/utils": "npm:^0.2.11"
+    use-sync-external-store: "npm:^1.6.0"
+  peerDependencies:
+    "@date-fns/tz": ^1.2.0
+    "@types/react": ^17 || ^18 || ^19
+    date-fns: ^4.0.0
+    react: ^17 || ^18 || ^19
+    react-dom: ^17 || ^18 || ^19
+  peerDependenciesMeta:
+    "@date-fns/tz":
+      optional: true
+    "@types/react":
+      optional: true
+    date-fns:
+      optional: true
+  checksum: 913361cd1e09f256d95bbd905287a10c34b2dab23482bf4ad5e595e4d72f5ea22e0b0b23657df6b548a938b248be3129c0bf1242c90753b59618a615c9e90ad5
+  languageName: node
+  linkType: hard
+
 "@base-ui/utils@npm:0.2.6":
   version: 0.2.6
   resolution: "@base-ui/utils@npm:0.2.6"
@@ -4292,6 +4370,25 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 5611442ac37066774277cd3360d16ebc3f599dc7b8efdfdfbf5b66b6d2eb6e87a18c0f9922b061818850e781d9bbc70aa5fc4ffb1dfd7fb234eefc401e070090
+  languageName: node
+  linkType: hard
+
+"@base-ui/utils@npm:0.2.8":
+  version: 0.2.8
+  resolution: "@base-ui/utils@npm:0.2.8"
+  dependencies:
+    "@babel/runtime": "npm:^7.29.2"
+    "@floating-ui/utils": "npm:^0.2.11"
+    reselect: "npm:^5.1.1"
+    use-sync-external-store: "npm:^1.6.0"
+  peerDependencies:
+    "@types/react": ^17 || ^18 || ^19
+    react: ^17 || ^18 || ^19
+    react-dom: ^17 || ^18 || ^19
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 762ff2251875c08b9e506824d7b45299baef895944d28f633a34c088cd5d6f121ee29267d2afb79527180044d232e56591c4109b2fcab7ac926d7e490c5b2b29
   languageName: node
   linkType: hard
 
@@ -11534,6 +11631,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wordpress/theme@npm:0.11.0, @wordpress/theme@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "@wordpress/theme@npm:0.11.0"
+  dependencies:
+    "@wordpress/element": "npm:^6.44.0"
+    "@wordpress/private-apis": "npm:^1.44.0"
+    colorjs.io: "npm:^0.6.0"
+    memize: "npm:^2.1.0"
+  peerDependencies:
+    react: ^18.0.0
+    react-dom: ^18.0.0
+    stylelint: ^16.8.2
+  peerDependenciesMeta:
+    stylelint:
+      optional: true
+  checksum: dc73ccb449b32d47ec78561fe939801c488a39a3b54b8a74c65d57022fbcab8a6182548bf45dbaff7b6aa6083479564e08a4b8e18941200ee60fb35802bda95a
+  languageName: node
+  linkType: hard
+
 "@wordpress/theme@npm:0.8.0, @wordpress/theme@npm:^0.8.0":
   version: 0.8.0
   resolution: "@wordpress/theme@npm:0.8.0"
@@ -11578,6 +11694,29 @@ __metadata:
   dependencies:
     "@babel/runtime": "npm:7.25.7"
   checksum: e2a8f53b871f9fa0774dab021c7fec1e35040d15d744bd49c61b67867d8863046c93200a3387355d519c0016ffb4d5d989c7c70688062302ae8857c09a6ea5ac
+  languageName: node
+  linkType: hard
+
+"@wordpress/ui@npm:0.11.0":
+  version: 0.11.0
+  resolution: "@wordpress/ui@npm:0.11.0"
+  dependencies:
+    "@base-ui/react": "npm:^1.4.0"
+    "@wordpress/a11y": "npm:^4.44.0"
+    "@wordpress/compose": "npm:^7.44.0"
+    "@wordpress/element": "npm:^6.44.0"
+    "@wordpress/i18n": "npm:^6.17.0"
+    "@wordpress/icons": "npm:^12.2.0"
+    "@wordpress/keycodes": "npm:^4.44.0"
+    "@wordpress/primitives": "npm:^4.44.0"
+    "@wordpress/private-apis": "npm:^1.44.0"
+    "@wordpress/theme": "npm:^0.11.0"
+    clsx: "npm:^2.1.1"
+    tabbable: "npm:^6.4.0"
+  peerDependencies:
+    react: ^18.0.0
+    react-dom: ^18.0.0
+  checksum: 2e4d5d11b1fd3658f1a5e9894b2c1d21339eed1cdb3348caf54a64b3a442fb6d6595e0622c263b244b913db3d00a5d6bb52c0d1a4c4d815413c2dd7c9ed33816
   languageName: node
   linkType: hard
 
@@ -16283,6 +16422,18 @@ __metadata:
     "@types/trusted-types":
       optional: true
   checksum: fa0a8c55a436ba0d54389195e3d2337e311f56de709a2fc9efc98dbbc7746fa53bb4b74b6ac043b77a279a8f2ebd8685f0ebaa6e58c9e32e92051d529bc0baf8
+  languageName: node
+  linkType: hard
+
+"dompurify@npm:^3.3.3":
+  version: 3.4.2
+  resolution: "dompurify@npm:3.4.2"
+  dependencies:
+    "@types/trusted-types": "npm:^2.0.7"
+  dependenciesMeta:
+    "@types/trusted-types":
+      optional: true
+  checksum: 23ab3ab079480a49e1426c4ee7279e393913fa7f2193c4142a5be54d4163dbdd969558675876c6b8bbcbf2ad5d1bc3e00bf902acf142fff12e50274a65ae95b3
   languageName: node
   linkType: hard
 
@@ -33294,6 +33445,7 @@ __metadata:
     "@automattic/calypso-router": "workspace:^"
     "@automattic/calypso-storybook": "workspace:^"
     "@automattic/charts": "npm:^0.50.0"
+    "@automattic/charts-next": "npm:@automattic/charts@1.3.0"
     "@automattic/color-studio": "npm:^4.1.0"
     "@automattic/components": "workspace:^"
     "@automattic/data-stores": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1787,18 +1787,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/number-formatters@npm:^1.0.14, @automattic/number-formatters@npm:^1.0.15, @automattic/number-formatters@npm:^1.1.0, @automattic/number-formatters@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "@automattic/number-formatters@npm:1.1.2"
-  dependencies:
-    "@wordpress/date": "npm:^5.19.0"
-    debug: "npm:^4.4.0"
-    tslib: "npm:^2.5.0"
-  checksum: bd83f99d1d53a81ccc9879c7062f66b6c9e1b1b0103ae5943189fd546fcb20d1a27d20f2d55f20c80164b64cf0bee5dbc72e533123e9b3f873b4e3670a6d67da
-  languageName: node
-  linkType: hard
-
-"@automattic/number-formatters@npm:^1.1.7":
+"@automattic/number-formatters@npm:^1.0.14, @automattic/number-formatters@npm:^1.0.15, @automattic/number-formatters@npm:^1.1.0, @automattic/number-formatters@npm:^1.1.2, @automattic/number-formatters@npm:^1.1.7":
   version: 1.1.7
   resolution: "@automattic/number-formatters@npm:1.1.7"
   dependencies:
@@ -4264,7 +4253,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:7.29.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.27.1, @babel/runtime@npm:^7.28.6, @babel/runtime@npm:^7.29.2, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.3, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:7.29.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.27.1, @babel/runtime@npm:^7.29.2, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.3, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.9.2":
   version: 7.29.2
   resolution: "@babel/runtime@npm:7.29.2"
   checksum: 30b80a0140d16467792e1bbeb06f655b0dab70407da38dfac7fedae9c859f9ae9d846ef14ad77bd3814c064295fe9b1bc551f1541ea14646ae9f22b71a8bc17a
@@ -4307,28 +4296,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@base-ui/react@npm:^1.2.0":
-  version: 1.3.0
-  resolution: "@base-ui/react@npm:1.3.0"
-  dependencies:
-    "@babel/runtime": "npm:^7.28.6"
-    "@base-ui/utils": "npm:0.2.6"
-    "@floating-ui/react-dom": "npm:^2.1.8"
-    "@floating-ui/utils": "npm:^0.2.11"
-    tabbable: "npm:^6.4.0"
-    use-sync-external-store: "npm:^1.6.0"
-  peerDependencies:
-    "@types/react": ^17 || ^18 || ^19
-    react: ^17 || ^18 || ^19
-    react-dom: ^17 || ^18 || ^19
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 36c9d2d77a82b41cb3783be39340aa0713bbe102fb18213f8f3e2c4f1295beb8359dd97067248bea34925f4a40eab281ddc42f05009179db1d5a7a99e4bfecdc
-  languageName: node
-  linkType: hard
-
-"@base-ui/react@npm:^1.4.0":
+"@base-ui/react@npm:^1.2.0, @base-ui/react@npm:^1.4.0":
   version: 1.4.1
   resolution: "@base-ui/react@npm:1.4.1"
   dependencies:
@@ -4351,25 +4319,6 @@ __metadata:
     date-fns:
       optional: true
   checksum: 913361cd1e09f256d95bbd905287a10c34b2dab23482bf4ad5e595e4d72f5ea22e0b0b23657df6b548a938b248be3129c0bf1242c90753b59618a615c9e90ad5
-  languageName: node
-  linkType: hard
-
-"@base-ui/utils@npm:0.2.6":
-  version: 0.2.6
-  resolution: "@base-ui/utils@npm:0.2.6"
-  dependencies:
-    "@babel/runtime": "npm:^7.28.6"
-    "@floating-ui/utils": "npm:^0.2.11"
-    reselect: "npm:^5.1.1"
-    use-sync-external-store: "npm:^1.6.0"
-  peerDependencies:
-    "@types/react": ^17 || ^18 || ^19
-    react: ^17 || ^18 || ^19
-    react-dom: ^17 || ^18 || ^19
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 5611442ac37066774277cd3360d16ebc3f599dc7b8efdfdfbf5b66b6d2eb6e87a18c0f9922b061818850e781d9bbc70aa5fc4ffb1dfd7fb234eefc401e070090
   languageName: node
   linkType: hard
 
@@ -16413,19 +16362,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:^3.2.6, dompurify@npm:^3.3.1":
-  version: 3.3.1
-  resolution: "dompurify@npm:3.3.1"
-  dependencies:
-    "@types/trusted-types": "npm:^2.0.7"
-  dependenciesMeta:
-    "@types/trusted-types":
-      optional: true
-  checksum: fa0a8c55a436ba0d54389195e3d2337e311f56de709a2fc9efc98dbbc7746fa53bb4b74b6ac043b77a279a8f2ebd8685f0ebaa6e58c9e32e92051d529bc0baf8
-  languageName: node
-  linkType: hard
-
-"dompurify@npm:^3.3.3":
+"dompurify@npm:^3.2.6, dompurify@npm:^3.3.1, dompurify@npm:^3.3.3":
   version: 3.4.2
   resolution: "dompurify@npm:3.4.2"
   dependencies:


### PR DESCRIPTION
## Proposed Changes

* Replace the placeholder `ChartSlot` in the APM **Overview** tab with a stacked `AreaChart` rendering the timeseries breakdown (Database, WordPress core, Plugins, External).
* Use `@automattic/charts-next` (npm-aliased to `@automattic/charts@1.3.0`) — the older `@automattic/charts@^0.50.x` already in the tree has no `AreaChart` export.
* Add `@automattic/charts-next` to the dashboard ESLint allowlist, alongside the already-allowed `@automattic/charts`.
* Mock `@automattic/charts-next` in the existing backend tests so Jest's transformIgnorePatterns don't trip on the package's ESM transitive deps.

## Why are these changes being made?

The APM Overview was shipping a "Response time chart coming soon" placeholder. This PR replaces it with a real stacked area chart over the mock timeseries data already returned by `siteApmOverviewQuery`, so the Overview tab tells a complete story alongside the slow-requests list.

## Testing Instructions

1. Build the dashboard: `yarn start-dashboard`.
2. Visit a site on Business or Ecommerce that has APM enabled: `/sites/<slug>/performance/backend`.
3. The Overview tab should now show a stacked area chart titled "Response time breakdown" with four series (Database, WordPress core, Plugins, External), legend, and hover tooltip.
4. Switch tabs and back — chart re-renders cleanly.
5. Hard-reload — chart renders on first paint without a console warning.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?