### PR TITLE
E2E: Skip extra click when possible and tighten siteLink selector

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/pages-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/pages-page.ts
@@ -30,7 +30,15 @@ export class PagesPage {
 		const response = await this.page.goto( getCalypsoURL( 'pages' ) );
 
 		if ( siteSlug ) {
-			const siteLink = this.page.locator( `a:has-text("${ siteSlug }")` ).first();
+			// On single-site accounts, the server-side redirect already lands on /pages/<siteSlug>, so we
+			// can skip the selector click.
+			if ( new URL( this.page.url() ).pathname === `/pages/${ siteSlug }` ) {
+				return response;
+			}
+
+			const siteLink = this.page
+				.locator( `.site-selector__sites a:has-text("${ siteSlug }")` )
+				.first();
 			const appeared = await siteLink
 				.waitFor( { state: 'visible', timeout: 5000 } )
 				.then( () => true )


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

In #110364, it seems support for the site selector was added, but the locator selector (`a:has-text("${ siteSlug }")`) was too broad, so it clicked "View site", which dumped the test on the frontend of the site, resulting in a timeout and failure.

This PR narrows that selector so it targets the text inside the site selector. It also returns early (skipping that part altogether and saving 5s) if the URL is already on the specific site.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

```
yarn workspace wp-e2e-tests build &&
VIEWPORT_NAME="mobile" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/editor/editor__page-basic-flow.ts" &&
VIEWPORT_NAME="desktop" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/editor/editor__page-basic-flow.ts"
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
