### PR TITLE
Update/reader onboarding rsm subscriptions modal borders

### DIFF
--- a/client/reader/follow-button/index.tsx
+++ b/client/reader/follow-button/index.tsx
@@ -14,6 +14,8 @@ interface ReaderFollowButtonProps {
 	className?: string;
 	feedId?: number;
 	followSource?: string;
+	followIcon?: JSX.Element;
+	followingIcon?: JSX.Element;
 	hasButtonStyle?: boolean;
 	iconSize?: number;
 	isButtonOnly?: boolean;
@@ -46,8 +48,9 @@ export default function ReaderFollowButton( props: ReaderFollowButtonProps ): JS
 		}
 	}
 
-	const followingIcon = ReaderFollowingFeedIcon( { iconSize: iconSize || 20 } );
-	const followIcon = ReaderFollowFeedIcon( { iconSize: iconSize || 20 } );
+	const followingIcon =
+		props.followingIcon ?? ReaderFollowingFeedIcon( { iconSize: iconSize || 20 } );
+	const followIcon = props.followIcon ?? ReaderFollowFeedIcon( { iconSize: iconSize || 20 } );
 
 	return (
 		<FollowButtonContainer

--- a/client/reader/onboarding-rsm/interests-modal/style.scss
+++ b/client/reader/onboarding-rsm/interests-modal/style.scss
@@ -26,6 +26,18 @@ $actions-height: 64px;
 		padding-bottom: $actions-height;
 	}
 
+	.reader-onboarding-modal__footer {
+		// The global footer uses margin-based tricks that leave a scrollbar gap on
+		// the right and mis-align content when the modal padding is 24px (not 32px).
+		// Use explicit inset + matching padding so the footer spans the full width
+		// and its content aligns with the rest of the modal body.
+		inset-inline-start: 0;
+		inset-inline-end: 0;
+		width: auto;
+		margin-inline: 0;
+		padding-inline: 24px;
+	}
+
 	&__title {
 		font-family: Recoleta, sans-serif;
 		font-size: 2.75rem;

--- a/client/reader/onboarding-rsm/subscribe-modal/index.tsx
+++ b/client/reader/onboarding-rsm/subscribe-modal/index.tsx
@@ -19,11 +19,10 @@ import { READER_ONBOARDING_TRACKS_EVENT_PREFIX } from 'calypso/reader/onboarding
 import { curatedBlogs } from 'calypso/reader/onboarding-rsm/curated-blogs';
 import { StepIndicator } from 'calypso/reader/onboarding-rsm/step-indicator';
 import Stream from 'calypso/reader/stream';
-import { useDispatch, useStore } from 'calypso/state';
+import { useDispatch } from 'calypso/state';
 import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import { getFeed } from 'calypso/state/reader/feeds/selectors';
 import { requestFollows } from 'calypso/state/reader/follows/actions';
-import { getReaderFollows } from 'calypso/state/reader/follows/selectors';
 import {
 	requestPage,
 	clearStream,
@@ -86,7 +85,6 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 		( selectedFeed as { site_icon?: string; image?: string } | null )?.site_icon ??
 		( selectedFeed as { site_icon?: string; image?: string } | null )?.image;
 	const dispatch = useDispatch();
-	const store = useStore();
 	const currentLocale = getLocaleSlug();
 	const SITES_PER_PAGE = 6;
 	const queryClient = useQueryClient();
@@ -239,41 +237,6 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 		[ selectedSite ]
 	);
 
-	const handleFollowToggle = useCallback(
-		async ( site: CardData, following: boolean ) => {
-			// Read fresh follow state from the store on each call to avoid stale closure issues
-			// inside the retry loop where the captured `follows` array won't reflect updates
-			// dispatched mid-loop.
-			const isFollowingSite = () => {
-				const currentFollows = getReaderFollows( store.getState() );
-				return currentFollows.some(
-					( follow ) => follow.feed_ID === site.feed_ID || follow.blog_ID === site.site_ID
-				);
-			};
-
-			// Exit early if the follow state already matches what we want.
-			if ( following === isFollowingSite() ) {
-				return;
-			}
-
-			// Maximum number of retries
-			const MAX_RETRIES = 3;
-
-			for ( let attempt = 0; attempt < MAX_RETRIES; attempt++ ) {
-				// Update the subscriptions list behind the modal.
-				await dispatch( requestFollows() );
-
-				// Delay the next attempt.
-				await new Promise( ( resolve ) => setTimeout( resolve, 300 ) );
-
-				if ( following === isFollowingSite() ) {
-					return;
-				}
-			}
-		},
-		[ store, dispatch ]
-	);
-
 	const formatUrl = ( url: string ): string => {
 		return url
 			.replace( /^(https?:\/\/)?(www\.)?/, '' ) // Remove protocol and www
@@ -281,6 +244,7 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 	};
 
 	const handleClose = useCallback( () => {
+		dispatch( requestFollows() );
 		dispatch( clearStream( { streamKey: 'following' } ) );
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		dispatch( requestPage( { streamKey: 'following' } as any ) );
@@ -350,9 +314,6 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 												replaceStreamClickWithItemClick
 												onItemClick={ () => handleItemClick( site ) }
 												isSelected={ selectedSite?.feed_ID === site.feed_ID }
-												onFollowToggle={ ( following: boolean ) =>
-													handleFollowToggle( site, following )
-												}
 											/>
 										) ) }
 									</div>
@@ -390,9 +351,6 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 															icon={ check }
 															size={ 18 }
 														/>
-													}
-													onFollowToggle={ ( following: boolean ) =>
-														handleFollowToggle( selectedSite, following )
 													}
 												/>
 											</div>

--- a/client/reader/onboarding-rsm/subscribe-modal/index.tsx
+++ b/client/reader/onboarding-rsm/subscribe-modal/index.tsx
@@ -3,17 +3,18 @@ import { LoadingPlaceholder } from '@automattic/components';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Modal, Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { Icon, check } from '@wordpress/icons';
 import clsx from 'clsx';
 import { getLocaleSlug } from 'i18n-calypso';
 import React, { useMemo, useState, ComponentType, useEffect, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { AnyAction } from 'redux';
+import FollowButtonContainer from 'calypso/blocks/follow-button';
 import ConnectedReaderSubscriptionListItem from 'calypso/blocks/reader-subscription-list-item/connected';
 import { SiteIcon } from 'calypso/blocks/site-icon';
 import { useFollowedReaderTags } from 'calypso/data/reader/use-reader-tags';
 import wpcom from 'calypso/lib/wp';
 import { trackScrollPage } from 'calypso/reader/controller-helper';
-import ReaderFollowButton from 'calypso/reader/follow-button';
 import { READER_ONBOARDING_TRACKS_EVENT_PREFIX } from 'calypso/reader/onboarding-rsm/constants';
 import { curatedBlogs } from 'calypso/reader/onboarding-rsm/curated-blogs';
 import { StepIndicator } from 'calypso/reader/onboarding-rsm/step-indicator';
@@ -372,15 +373,23 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 													<SiteIcon size={ 24 } iconUrl={ selectedFeedIconUrl } />
 													<h3>{ formatUrl( selectedSite.site_URL ) }</h3>
 												</div>
-												<ReaderFollowButton
+												<FollowButtonContainer
 													siteUrl={ selectedSite.site_URL }
 													feedId={ selectedSite.feed_ID }
 													siteId={ selectedSite.site_ID }
-													followSource="reader-onboarding-modal"
 													hasButtonStyle
 													onFollowToggle={ ( following: boolean ) => {
 														void handleFollowToggle( selectedSite, following );
 													} }
+													followIcon={ <></> }
+													followingIcon={
+														<Icon
+															key="following"
+															className="reader-following-feed"
+															icon={ check }
+															size={ 18 }
+														/>
+													}
 												/>
 											</div>
 											<div className="subscribe-modal__preview-stream-container">

--- a/client/reader/onboarding-rsm/subscribe-modal/index.tsx
+++ b/client/reader/onboarding-rsm/subscribe-modal/index.tsx
@@ -9,15 +9,18 @@ import React, { useMemo, useState, ComponentType, useEffect, useCallback } from 
 import { useSelector } from 'react-redux';
 import { AnyAction } from 'redux';
 import ConnectedReaderSubscriptionListItem from 'calypso/blocks/reader-subscription-list-item/connected';
+import { SiteIcon } from 'calypso/blocks/site-icon';
 import { useFollowedReaderTags } from 'calypso/data/reader/use-reader-tags';
 import wpcom from 'calypso/lib/wp';
 import { trackScrollPage } from 'calypso/reader/controller-helper';
+import ReaderFollowButton from 'calypso/reader/follow-button';
 import { READER_ONBOARDING_TRACKS_EVENT_PREFIX } from 'calypso/reader/onboarding-rsm/constants';
 import { curatedBlogs } from 'calypso/reader/onboarding-rsm/curated-blogs';
 import { StepIndicator } from 'calypso/reader/onboarding-rsm/step-indicator';
 import Stream from 'calypso/reader/stream';
 import { useDispatch, useStore } from 'calypso/state';
 import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
+import { getFeed } from 'calypso/state/reader/feeds/selectors';
 import { requestFollows } from 'calypso/state/reader/follows/actions';
 import { getReaderFollows } from 'calypso/state/reader/follows/selectors';
 import {
@@ -75,6 +78,12 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 
 	const [ currentPage, setCurrentPage ] = useState( 0 );
 	const [ selectedSite, setSelectedSite ] = useState< CardData | null >( null );
+	const selectedFeed = useSelector( ( state: object ) =>
+		selectedSite ? getFeed( state, selectedSite.feed_ID ) : null
+	);
+	const selectedFeedIconUrl =
+		( selectedFeed as { site_icon?: string; image?: string } | null )?.site_icon ??
+		( selectedFeed as { site_icon?: string; image?: string } | null )?.image;
 	const dispatch = useDispatch();
 	const store = useStore();
 	const currentLocale = getLocaleSlug();
@@ -300,7 +309,7 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 		isOpen && (
 			<Modal
 				onRequestClose={ handleClose }
-				size="fill"
+				size="medium"
 				className={ clsx( 'subscribe-modal', {
 					'is-disabled': promptVerification,
 				} ) }
@@ -308,7 +317,7 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 				<div className="subscribe-modal__container">
 					{ promptVerification && <SubscribeVerificationNudge /> }
 					<div className="subscribe-modal__content">
-						<div className="subscribe-modal__site-list-column">
+						<div className="subscribe-modal__intro">
 							<h2 className="subscribe-modal__title">
 								{ __( "Discover sites that you'll love" ) }
 							</h2>
@@ -317,62 +326,75 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 									'Preview sites by clicking below, then subscribe to any site that inspires you.'
 								) }
 							</p>
-							{ isLoading && <LoadingPlaceholder /> }
-							{ ! isLoading && combinedRecommendations.length === 0 && (
-								<p>{ __( 'No recommendations available at the moment.' ) }</p>
-							) }
-							{ ! isLoading && combinedRecommendations.length > 0 && (
-								<div className="subscribe-modal__recommended-sites">
-									{ displayedRecommendations.map( ( site: CardData ) => (
-										<ConnectedReaderSubscriptionListItem
-											key={ site.feed_ID }
-											feedId={ site.feed_ID }
-											siteId={ site.site_ID }
-											site={ site }
-											url={ site.site_URL }
-											showLastUpdatedDate={ false }
-											showNotificationSettings={ false }
-											showFollowedOnDate={ false }
-											followSource="reader-onboarding-modal"
-											disableSuggestedFollows
-											replaceStreamClickWithItemClick
-											onItemClick={ () => handleItemClick( site ) }
-											isSelected={ selectedSite?.feed_ID === site.feed_ID }
-											onFollowToggle={ ( following: boolean ) =>
-												handleFollowToggle( site, following )
-											}
-										/>
-									) ) }
-								</div>
-							) }
-							{ currentPage < maxPages && (
-								<Button
-									className="subscribe-modal__load-more-button"
-									onClick={ handleLoadMore }
-									variant="link"
-								>
-									{ __( 'Load more recommendations' ) }
-								</Button>
-							) }
 						</div>
-						<div className="subscribe-modal__preview-column">
-							<div className="subscribe-modal__preview-placeholder">
-								{ selectedSite && (
-									<>
-										<div className="subscribe-modal__preview-stream-header">
-											<h3>{ formatUrl( selectedSite.site_URL ) }</h3>
-										</div>
-										<div className="subscribe-modal__preview-stream-container">
-											<TypedStream
-												streamKey={ `feed:${ selectedSite.feed_ID }` }
-												className="is-site-stream subscribe-modal__preview-stream"
-												followSource="reader_subscribe_modal"
-												useCompactCards
-												trackScrollPage={ trackScrollPage.bind( null ) }
-											/>
-										</div>
-									</>
+						<div className="subscribe-modal__columns">
+							<div className="subscribe-modal__site-list-column">
+								{ isLoading && <LoadingPlaceholder /> }
+								{ ! isLoading && combinedRecommendations.length === 0 && (
+									<p>{ __( 'No recommendations available at the moment.' ) }</p>
 								) }
+								{ ! isLoading && combinedRecommendations.length > 0 && (
+									<div className="subscribe-modal__recommended-sites">
+										{ displayedRecommendations.map( ( site: CardData ) => (
+											<ConnectedReaderSubscriptionListItem
+												key={ site.feed_ID }
+												feedId={ site.feed_ID }
+												siteId={ site.site_ID }
+												site={ site }
+												url={ site.site_URL }
+												showLastUpdatedDate={ false }
+												showNotificationSettings={ false }
+												showFollowedOnDate={ false }
+												followSource="reader-onboarding-modal"
+												replaceStreamClickWithItemClick
+												onItemClick={ () => handleItemClick( site ) }
+												isSelected={ selectedSite?.feed_ID === site.feed_ID }
+											/>
+										) ) }
+									</div>
+								) }
+								{ currentPage < maxPages && (
+									<Button
+										className="subscribe-modal__load-more-button"
+										onClick={ handleLoadMore }
+										variant="link"
+									>
+										{ __( 'Load more recommendations' ) }
+									</Button>
+								) }
+							</div>
+							<div className="subscribe-modal__preview-column">
+								<div className="subscribe-modal__preview-placeholder">
+									{ selectedSite && (
+										<>
+											<div className="subscribe-modal__preview-stream-header">
+												<div className="subscribe-modal__preview-site">
+													<SiteIcon size={ 24 } iconUrl={ selectedFeedIconUrl } />
+													<h3>{ formatUrl( selectedSite.site_URL ) }</h3>
+												</div>
+												<ReaderFollowButton
+													siteUrl={ selectedSite.site_URL }
+													feedId={ selectedSite.feed_ID }
+													siteId={ selectedSite.site_ID }
+													followSource="reader-onboarding-modal"
+													hasButtonStyle
+													onFollowToggle={ ( following: boolean ) => {
+														void handleFollowToggle( selectedSite, following );
+													} }
+												/>
+											</div>
+											<div className="subscribe-modal__preview-stream-container">
+												<TypedStream
+													streamKey={ `feed:${ selectedSite.feed_ID }` }
+													className="is-site-stream subscribe-modal__preview-stream"
+													followSource="reader_subscribe_modal"
+													useCompactCards
+													trackScrollPage={ trackScrollPage.bind( null ) }
+												/>
+											</div>
+										</>
+									) }
+								</div>
 							</div>
 						</div>
 						<div className="reader-onboarding-modal__footer">
@@ -383,17 +405,14 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 									justify="right"
 									className="reader-onboarding-modal__footer-buttons"
 								>
-									<Button __next40pxDefaultSize variant="tertiary" onClick={ handleClose }>
-										{ __( 'Cancel' ) }
-									</Button>
 									<Button
 										__next40pxDefaultSize
 										onClick={ handleContinue }
-										variant="primary"
+										variant="secondary"
 										disabled={ promptVerification }
 										accessibleWhenDisabled
 									>
-										{ __( 'Continue' ) }
+										{ __( 'Finish' ) }
 									</Button>
 								</HStack>
 							</HStack>

--- a/client/reader/onboarding-rsm/subscribe-modal/index.tsx
+++ b/client/reader/onboarding-rsm/subscribe-modal/index.tsx
@@ -237,12 +237,6 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 		[ selectedSite ]
 	);
 
-	const formatUrl = ( url: string ): string => {
-		return url
-			.replace( /^(https?:\/\/)?(www\.)?/, '' ) // Remove protocol and www
-			.replace( /\/$/, '' ); // Remove trailing slash
-	};
-
 	const handleClose = useCallback( () => {
 		dispatch( requestFollows() );
 		dispatch( clearStream( { streamKey: 'following' } ) );
@@ -335,7 +329,6 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 											<div className="subscribe-modal__preview-stream-header">
 												<div className="subscribe-modal__preview-site">
 													<SiteIcon size={ 24 } iconUrl={ selectedFeedIconUrl } />
-													<h3>{ formatUrl( selectedSite.site_URL ) }</h3>
 												</div>
 												<ReaderFollowButton
 													siteUrl={ selectedSite.site_URL }

--- a/client/reader/onboarding-rsm/subscribe-modal/index.tsx
+++ b/client/reader/onboarding-rsm/subscribe-modal/index.tsx
@@ -386,7 +386,7 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 											<div className="subscribe-modal__preview-stream-container">
 												<TypedStream
 													streamKey={ `feed:${ selectedSite.feed_ID }` }
-													className="is-site-stream subscribe-modal__preview-stream"
+													className="is-site-stream subscribe-modal__preview-stream no-padding"
 													followSource="reader_subscribe_modal"
 													useCompactCards
 													trackScrollPage={ trackScrollPage.bind( null ) }

--- a/client/reader/onboarding-rsm/subscribe-modal/index.tsx
+++ b/client/reader/onboarding-rsm/subscribe-modal/index.tsx
@@ -328,7 +328,7 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 										<>
 											<div className="subscribe-modal__preview-stream-header">
 												<div className="subscribe-modal__preview-site">
-													<SiteIcon size={ 24 } iconUrl={ selectedFeedIconUrl } />
+													<SiteIcon size={ 36 } iconUrl={ selectedFeedIconUrl } />
 												</div>
 												<ReaderFollowButton
 													siteUrl={ selectedSite.site_URL }

--- a/client/reader/onboarding-rsm/subscribe-modal/index.tsx
+++ b/client/reader/onboarding-rsm/subscribe-modal/index.tsx
@@ -329,6 +329,9 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 											<div className="subscribe-modal__preview-stream-header">
 												<div className="subscribe-modal__preview-site">
 													<SiteIcon size={ 36 } iconUrl={ selectedFeedIconUrl } />
+													<span className="subscribe-modal__preview-site-title">
+														{ selectedSite.site_name }
+													</span>
 												</div>
 												<ReaderFollowButton
 													siteUrl={ selectedSite.site_URL }

--- a/client/reader/onboarding-rsm/subscribe-modal/index.tsx
+++ b/client/reader/onboarding-rsm/subscribe-modal/index.tsx
@@ -9,12 +9,12 @@ import { getLocaleSlug } from 'i18n-calypso';
 import React, { useMemo, useState, ComponentType, useEffect, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { AnyAction } from 'redux';
-import FollowButtonContainer from 'calypso/blocks/follow-button';
 import ConnectedReaderSubscriptionListItem from 'calypso/blocks/reader-subscription-list-item/connected';
 import { SiteIcon } from 'calypso/blocks/site-icon';
 import { useFollowedReaderTags } from 'calypso/data/reader/use-reader-tags';
 import wpcom from 'calypso/lib/wp';
 import { trackScrollPage } from 'calypso/reader/controller-helper';
+import ReaderFollowButton from 'calypso/reader/follow-button';
 import { READER_ONBOARDING_TRACKS_EVENT_PREFIX } from 'calypso/reader/onboarding-rsm/constants';
 import { curatedBlogs } from 'calypso/reader/onboarding-rsm/curated-blogs';
 import { StepIndicator } from 'calypso/reader/onboarding-rsm/step-indicator';
@@ -350,6 +350,9 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 												replaceStreamClickWithItemClick
 												onItemClick={ () => handleItemClick( site ) }
 												isSelected={ selectedSite?.feed_ID === site.feed_ID }
+												onFollowToggle={ ( following: boolean ) =>
+													handleFollowToggle( site, following )
+												}
 											/>
 										) ) }
 									</div>
@@ -373,14 +376,12 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 													<SiteIcon size={ 24 } iconUrl={ selectedFeedIconUrl } />
 													<h3>{ formatUrl( selectedSite.site_URL ) }</h3>
 												</div>
-												<FollowButtonContainer
+												<ReaderFollowButton
 													siteUrl={ selectedSite.site_URL }
 													feedId={ selectedSite.feed_ID }
 													siteId={ selectedSite.site_ID }
+													followSource="reader-onboarding-modal"
 													hasButtonStyle
-													onFollowToggle={ ( following: boolean ) => {
-														void handleFollowToggle( selectedSite, following );
-													} }
 													followIcon={ <></> }
 													followingIcon={
 														<Icon
@@ -389,6 +390,9 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 															icon={ check }
 															size={ 18 }
 														/>
+													}
+													onFollowToggle={ ( following: boolean ) =>
+														handleFollowToggle( selectedSite, following )
 													}
 												/>
 											</div>

--- a/client/reader/onboarding-rsm/subscribe-modal/style.scss
+++ b/client/reader/onboarding-rsm/subscribe-modal/style.scss
@@ -30,6 +30,11 @@ $actions-height: 64px;
 		}
 	}
 
+	// Prevent WP modal's own content wrapper from producing an outer scrollbar.
+	.components-modal__content {
+		overflow: hidden;
+	}
+
 	&__title {
 		font-family: Recoleta, sans-serif;
 		font-size: 2.25rem;
@@ -52,17 +57,18 @@ $actions-height: 64px;
 	}
 
 	&__content {
-		// Since the actions container is positioned absolutely,
-		// this padding bottom ensures that the content wrapper will properly
-		// detect overflowing content and start showing scrollbars at the right
-		// moment. Without this padding, the content would render under the actions
-		// bar without causing the wrapper to show a scrollbar.
+		// padding-bottom reserves space for the absolutely-positioned footer so
+		// the scrollable columns never slip behind it.
 		padding-bottom: $actions-height;
 
 		display: flex;
 		flex-direction: column;
-		min-height: 520px;
-		max-height: min( 680px, calc( 100vh - 180px ) );
+		// max-height is derived from the WP modal frame's own max-height (70vh)
+		// minus the WP modal header (~72px) and the WP content vertical padding
+		// (~28px). This keeps our content within the frame so the WP content
+		// wrapper never needs to scroll and the outer scrollbar never appears.
+		max-height: calc( 70vh - 100px );
+		min-height: 0;
 		overflow: hidden;
 	}
 

--- a/client/reader/onboarding-rsm/subscribe-modal/style.scss
+++ b/client/reader/onboarding-rsm/subscribe-modal/style.scss
@@ -52,7 +52,13 @@ $actions-height: 64px;
 	}
 
 	&__content {
+		// Since the actions container is positioned absolutely,
+		// this padding bottom ensures that the content wrapper will properly
+		// detect overflowing content and start showing scrollbars at the right
+		// moment. Without this padding, the content would render under the actions
+		// bar without causing the wrapper to show a scrollbar.
 		padding-bottom: $actions-height;
+
 		display: flex;
 		flex-direction: column;
 		min-height: 520px;

--- a/client/reader/onboarding-rsm/subscribe-modal/style.scss
+++ b/client/reader/onboarding-rsm/subscribe-modal/style.scss
@@ -2,7 +2,7 @@
 @import '@wordpress/base-styles/mixins';
 
 body.is-reader-page .subscribe-modal__preview-column .reader__card.card.is-placeholder {
-	padding: 16px 24px 12px 24px;
+	padding: 12px 0;
 
 	.reader__post-title {
 		margin-top: 0;
@@ -17,77 +17,113 @@ body.is-reader-page .subscribe-modal__preview-column .reader__card.card.is-place
 $actions-height: 64px;
 
 .subscribe-modal {
+	&.components-modal__frame,
+	.components-modal__frame {
+		width: min( 1024px, calc( 100vw - 64px ) );
+		max-width: min( 1024px, calc( 100vw - 64px ) );
+
+		@media ( max-width: $break-medium ) {
+			width: 100vw;
+			max-width: 100vw;
+			margin-left: 0;
+			margin-right: 0;
+		}
+	}
+
 	&__title {
 		font-family: Recoleta, sans-serif;
 		font-size: 2.25rem;
 		font-weight: 400;
 		line-height: 1.2;
-		margin-bottom: 16px;
+		margin: 0;
 		text-wrap: balance;
+		text-align: center;
 
 		@media ( max-width: $break-medium ) {
 			font-size: 1.5rem;
 		}
 	}
 
-	&__content {
-		// Since the actions container is positioned absolutely,
-		// this padding bottom ensures that the content wrapper will properly
-		// detect overflowing content and start showing scrollbars at the right
-		// moment. Without this padding, the content would render under the actions
-		// bar without causing the wrapper to show a scrollbar.
-		padding-bottom: $actions-height;
+	&__description {
+		margin: 0;
+		text-align: center;
+		color: var( --color-text-subtle );
+		text-wrap: balance;
+	}
 
+	&__content {
+		padding-bottom: $actions-height;
 		display: flex;
 		flex-direction: column;
-		height: calc( 100vh - 200px );
-		align-items: center;
+		min-height: 520px;
+		max-height: min( 680px, calc( 100vh - 180px ) );
+		overflow: hidden;
+	}
 
-		@media ( min-width: 1200px ) {
-			flex-direction: row;
-			overflow: hidden;
-			align-items: initial;
+	&__intro {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 12px;
+		padding: 20px 24px 10px;
+	}
+
+	&__columns {
+		display: flex;
+		flex: 1;
+		min-height: 0;
+		padding: 20px 24px 0;
+		gap: 16px;
+
+		@media ( max-width: 1199px ) {
+			padding-inline: 0;
 		}
 	}
 
 	&__site-list-column {
-		flex: 1;
-		padding: 20px 20px 0;
+		flex: 0 0 34%;
+		padding-top: 2px;
 		overflow-y: auto;
-		max-width: 600px;
+		max-width: 320px;
+		padding-inline-end: 12px;
+		overflow-x: visible;
 
-		@media ( min-width: 1200px ) {
-			max-width: 450px;
-		}
-
-		@media ( max-width: $break-medium ) {
-			padding: 0;
+		@media ( max-width: 1199px ) {
+			flex: 1;
 			max-width: 700px;
-		}
-
-		p {
-			text-wrap: balance;
-		}
-
-		.subscribe-modal__description {
-			@media ( max-width: 1199px ) {
-				display: none;
-			}
+			padding-inline: 20px;
 		}
 
 		.reader-subscription-list-item {
+			position: relative;
 			padding: 12px;
-			border: 1px solid var( --color-neutral-5 );
+			border: 1px solid var( --color-neutral-10 );
 			border-radius: 6px; /* stylelint-disable-line scales/radii */
 			margin-bottom: 12px;
+			cursor: pointer;
 
-			@media ( min-width: 1200px ) {
-				cursor: pointer;
-				&.is-selected {
-					background-color: #e6f3fa;
-					border: 1px solid #0087be;
-					border-radius: 6px; /* stylelint-disable-line scales/radii */
+			&.is-selected {
+				background-color: #e6f3fa;
+				border-color: color-mix( in srgb, #0087be 55%, #fff );
+
+				&::after {
+					content: '';
+					position: absolute;
+					inset-inline-end: -12px;
+					top: 50%;
+					width: 12px;
+					height: 26px;
+					background: #e6f3fa;
+					border-top: 1px solid color-mix( in srgb, #0087be 55%, #fff );
+					border-right: 1px solid color-mix( in srgb, #0087be 55%, #fff );
+					border-bottom: 1px solid color-mix( in srgb, #0087be 55%, #fff );
+					clip-path: polygon( 0 0, 100% 50%, 0 100% );
+					transform: translateY( -50% );
 				}
+			}
+
+			.reader-subscription-list-item__options {
+				display: none;
 			}
 
 			.reader-subscription-list-item__site-url-timestamp {
@@ -103,13 +139,10 @@ $actions-height: 64px;
 	}
 
 	&__preview-column {
-		flex: 1;
-		padding: 24px;
+		flex: 1 1 auto;
 		display: none;
 		flex-direction: column;
 		overflow: hidden;
-
-		clip-path: inset( 0 0 0 0 );
 
 		@media ( min-width: 1200px ) {
 			display: flex;
@@ -124,47 +157,105 @@ $actions-height: 64px;
 	}
 
 	&__preview-placeholder {
-		justify-content: center;
-		border: 1px solid #f2f2f2;
+		display: flex;
+		flex-direction: column;
+		flex: 1;
+		min-height: 0;
+		border: 1px solid var( --color-neutral-5 );
 		border-radius: 6px; /* stylelint-disable-line scales/radii */
-		background-color: #f2f2f2;
-		height: calc( 100vh - 224px );
-		width: calc( 100vw - 620px );
+		background-color: #fff;
 		overflow: hidden;
-		position: fixed;
+		position: relative;
 	}
 
 	&__preview-stream-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 10px 14px;
 		background-color: #fff;
-		text-align: center;
-		line-height: rem( 36px );
-		font-size: rem( 14px );
+		border-bottom: 1px solid var( --color-neutral-5 );
+
+		h3 {
+			margin: 0;
+			font-size: rem( 14px );
+			font-weight: 500;
+		}
+
+		.follow-button.has-button-style {
+			box-sizing: border-box;
+			min-width: 106px;
+			min-height: 36px;
+			padding: 8px 14px;
+			border-radius: 4px;
+			border: 1px solid var( --color-accent );
+			line-height: 18px;
+			transition: none;
+		}
+
+		.follow-button.has-button-style:hover,
+		.follow-button.has-button-style:focus,
+		.follow-button.has-button-style:active {
+			padding: 8px 14px;
+			border-width: 1px;
+			border-radius: 4px;
+			box-shadow: none;
+		}
+	}
+
+	&__preview-site {
+		display: flex;
+		align-items: center;
+		gap: 8px;
 	}
 
 	&__preview-stream-container {
-		height: 100%;
+		flex: 1;
+		min-height: 0;
 		overflow-y: auto;
-		padding-top: 40px;
-	}
+		padding: 0;
+		background: #fff;
 
-	.components-modal__header {
-		.components-button {
-			&.is-link {
-				margin-right: auto;
-			}
+		.reader,
+		.reader__content,
+		.reader__content .stream__list,
+		.reader-stream__content {
+			max-width: none;
+			padding-inline: 0;
+			padding-top: 0;
+			margin: 0;
+		}
 
-			&.is-primary {
-				margin-left: 16px;
-			}
+		.reader__card.card,
+		.reader-post-card.card.is-compact {
+			margin-bottom: 0;
+			border-radius: 0;
+			border-inline: 0;
+			border-top: 0;
+			border-bottom: 1px solid var( --color-neutral-5 );
+			padding: 14px 16px 12px;
+		}
+
+		.reader__card.card.is-compact .reader-post-card__post-content:not(.reader-post-card__no-excerpt)
+			.reader-featured-image {
+			width: 212px !important;
+			height: auto !important;
+			aspect-ratio: 16 / 9;
+			overflow: hidden;
+		}
+
+		.reader__card.card.is-compact .reader-featured-image img {
+			width: 100%;
+			height: 100%;
+			object-fit: cover;
 		}
 	}
 
 	&.is-disabled {
 		.subscribe-modal__container {
-			height: calc( 100vh - 188px ); // Modal margin + modal padding + modal heading
-			overflow: hidden;
-			padding: 1px;
+			height: 100%;
 		}
+
 		.subscribe-modal__content {
 			opacity: 0.5;
 			pointer-events: none;

--- a/client/reader/onboarding-rsm/subscribe-modal/style.scss
+++ b/client/reader/onboarding-rsm/subscribe-modal/style.scss
@@ -121,7 +121,7 @@ $actions-height: 64px;
 		.reader-subscription-list-item {
 			position: relative;
 			padding: 12px;
-			border: 1px solid var( --color-neutral-10 );
+			border: 1px solid var( --color-neutral-5 );
 			border-radius: 6px; /* stylelint-disable-line scales/radii */
 			margin-bottom: 12px;
 			cursor: pointer;
@@ -197,7 +197,8 @@ $actions-height: 64px;
 		flex: 1;
 		min-height: 0;
 		border: 1px solid var( --color-neutral-5 );
-		border-radius: 6px; /* stylelint-disable-line scales/radii */
+		border-block-end: none;
+		border-radius: 6px 6px 0 0; /* stylelint-disable-line scales/radii */
 		background-color: #fff;
 		overflow: hidden;
 		position: relative;

--- a/client/reader/onboarding-rsm/subscribe-modal/style.scss
+++ b/client/reader/onboarding-rsm/subscribe-modal/style.scss
@@ -252,6 +252,7 @@ $actions-height: 64px;
 
 		.follow-button.has-button-style {
 			box-sizing: border-box;
+			flex-shrink: 0;
 			min-width: 106px;
 			min-height: 36px;
 			padding: 8px 14px;
@@ -293,11 +294,25 @@ $actions-height: 64px;
 		display: flex;
 		align-items: center;
 		gap: 8px;
+		// Must be able to shrink so a long title doesn't push the follow button off screen.
+		min-width: 0;
+		overflow: hidden;
 
 		.site-icon.site-icon {
+			flex-shrink: 0;
 			border-radius: 50%;
 			overflow: hidden;
 		}
+	}
+
+	&__preview-site-title {
+		min-width: 0; // flex-item must opt in to shrinking for ellipsis to fire
+		font-size: rem( 14px );
+		font-weight: 600;
+		color: var( --color-neutral-80 );
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
 	}
 
 	&__preview-stream-container {

--- a/client/reader/onboarding-rsm/subscribe-modal/style.scss
+++ b/client/reader/onboarding-rsm/subscribe-modal/style.scss
@@ -30,9 +30,18 @@ $actions-height: 64px;
 		}
 	}
 
-	// Prevent WP modal's own content wrapper from producing an outer scrollbar.
+	// Remove WP modal's block/inline padding so the footer spans the full modal
+	// width and no gap appears below it at the frame bottom.
 	.components-modal__content {
-		overflow: hidden;
+		padding-inline: 0;
+		padding-block-end: 0;
+	}
+
+	// The preview stream has z-index: 20 which would otherwise render above the
+	// absolute footer at small viewports. Raise the footer's z-index above it.
+	.reader-onboarding-modal__footer {
+		margin-inline: 0;
+		z-index: 25;
 	}
 
 	&__title {
@@ -63,12 +72,15 @@ $actions-height: 64px;
 
 		display: flex;
 		flex-direction: column;
-		// max-height is derived from the WP modal frame's own max-height (70vh)
-		// minus the WP modal header (~72px) and the WP content vertical padding
-		// (~28px). This keeps our content within the frame so the WP content
-		// wrapper never needs to scroll and the outer scrollbar never appears.
-		max-height: calc( 70vh - 100px );
-		min-height: 0;
+		// max-height keeps content within the WP modal frame (max-height: 70vh)
+		// minus the WP modal header (~72px) and the WP content top padding (~4px).
+		// WP content's bottom padding is zeroed out above, so the formula is
+		// 70vh - 76px rather than the original 70vh - 100px.
+		// min-height ensures columns stay usable (~2 post-card heights); below
+		// ~709px the WP content wrapper scrolls and the absolute footer remains
+		// pinned at the frame bottom via its z-index: 25 over the stream.
+		max-height: calc( 70vh - 76px );
+		min-height: 420px;
 		overflow: hidden;
 	}
 

--- a/client/reader/onboarding-rsm/subscribe-modal/style.scss
+++ b/client/reader/onboarding-rsm/subscribe-modal/style.scss
@@ -226,28 +226,10 @@ $actions-height: 64px;
 			margin: 0;
 		}
 
-		.reader__card.card,
 		.reader-post-card.card.is-compact {
 			margin-bottom: 0;
 			border-radius: 0;
-			border-inline: 0;
-			border-top: 0;
-			border-bottom: 1px solid var( --color-neutral-5 );
 			padding: 14px 16px 12px;
-		}
-
-		.reader__card.card.is-compact .reader-post-card__post-content:not(.reader-post-card__no-excerpt)
-			.reader-featured-image {
-			width: 212px !important;
-			height: auto !important;
-			aspect-ratio: 16 / 9;
-			overflow: hidden;
-		}
-
-		.reader__card.card.is-compact .reader-featured-image img {
-			width: 100%;
-			height: 100%;
-			object-fit: cover;
 		}
 	}
 

--- a/client/reader/onboarding-rsm/subscribe-modal/style.scss
+++ b/client/reader/onboarding-rsm/subscribe-modal/style.scss
@@ -198,10 +198,6 @@ $actions-height: 64px;
 
 	&__recommended-sites {
 		margin-bottom: 24px;
-
-		.reader-subscription-list-item__byline {
-			// margin-right: 0;
-		}
 	}
 
 	&__preview-column {

--- a/client/reader/onboarding-rsm/subscribe-modal/style.scss
+++ b/client/reader/onboarding-rsm/subscribe-modal/style.scss
@@ -90,8 +90,8 @@ $actions-height: 64px;
 		flex: 0 0 34%;
 		padding-top: 2px;
 		overflow-y: auto;
-		max-width: 320px;
-		padding-inline-end: 12px;
+		max-width: 300px;
+		padding-inline-end: 32px;
 		overflow-x: visible;
 
 		@media ( max-width: 1199px ) {
@@ -109,22 +109,23 @@ $actions-height: 64px;
 			cursor: pointer;
 
 			&.is-selected {
-				background-color: #e6f3fa;
-				border-color: color-mix( in srgb, #0087be 55%, #fff );
+				background-color: color-mix( in srgb, var( --color-accent ) 8%, #fff );
+				border-color: color-mix( in srgb, var( --color-accent ) 25%, #fff );
 
-				&::after {
-					content: '';
-					position: absolute;
-					inset-inline-end: -12px;
-					top: 50%;
-					width: 12px;
-					height: 26px;
-					background: #e6f3fa;
-					border-top: 1px solid color-mix( in srgb, #0087be 55%, #fff );
-					border-right: 1px solid color-mix( in srgb, #0087be 55%, #fff );
-					border-bottom: 1px solid color-mix( in srgb, #0087be 55%, #fff );
-					clip-path: polygon( 0 0, 100% 50%, 0 100% );
-					transform: translateY( -50% );
+				@media ( min-width: 1200px ) {
+					&::after {
+						content: '';
+						position: absolute;
+						top: 50%;
+						inset-inline-end: -1px;
+						width: 20px;
+						height: 20px;
+						background-color: color-mix( in srgb, var( --color-accent ) 8%, #fff );
+						border-top: 1px solid color-mix( in srgb, var( --color-accent ) 25%, #fff );
+						border-right: 1px solid color-mix( in srgb, var( --color-accent ) 25%, #fff );
+						border-radius: 2px;
+						transform: translate( 50%, -50% ) rotate( 45deg );
+					}
 				}
 			}
 
@@ -142,6 +143,10 @@ $actions-height: 64px;
 
 	&__recommended-sites {
 		margin-bottom: 24px;
+
+		.reader-subscription-list-item__byline {
+			// margin-right: 0;
+		}
 	}
 
 	&__preview-column {

--- a/client/reader/onboarding-rsm/subscribe-modal/style.scss
+++ b/client/reader/onboarding-rsm/subscribe-modal/style.scss
@@ -126,6 +126,12 @@ $actions-height: 64px;
 			margin-bottom: 12px;
 			cursor: pointer;
 
+			// Without min-width: 0 the byline flex-item expands to its content
+			// width, pushing __options off the right edge of the card.
+			.reader-subscription-list-item__byline {
+				min-width: 0;
+			}
+
 			&.is-selected {
 				background-color: color-mix( in srgb, var( --color-accent ) 8%, #fff );
 				border-color: color-mix( in srgb, var( --color-accent ) 25%, #fff );
@@ -160,6 +166,31 @@ $actions-height: 64px;
 			.reader-subscription-list-item__site-url-timestamp {
 				&:not( .is-placeholder )::after {
 					background: none;
+				}
+
+				// ul and li must not block the width constraint from reaching the anchor.
+				ul,
+				li {
+					overflow: hidden;
+				}
+
+				// Force the URL to one line with ellipsis while keeping the
+				// external-link icon always visible at the end.
+				.reader-subscription-list-item__site-url.has-icon {
+					display: block;
+					position: relative;
+					overflow: hidden;
+					white-space: nowrap;
+					text-overflow: ellipsis;
+					// Reserve room for the 14px icon + a small gap.
+					padding-inline-end: 18px;
+
+					svg {
+						position: absolute;
+						inset-inline-end: 0;
+						top: 50%;
+						transform: translateY( -50% );
+					}
 				}
 			}
 		}

--- a/client/reader/onboarding-rsm/subscribe-modal/style.scss
+++ b/client/reader/onboarding-rsm/subscribe-modal/style.scss
@@ -132,6 +132,11 @@ $actions-height: 64px;
 				min-width: 0;
 			}
 
+			.site-icon.site-icon {
+				border-radius: 50%;
+				overflow: hidden;
+			}
+
 			&.is-selected {
 				background-color: color-mix( in srgb, var( --color-accent ) 8%, #fff );
 				border-color: color-mix( in srgb, var( --color-accent ) 25%, #fff );
@@ -288,6 +293,11 @@ $actions-height: 64px;
 		display: flex;
 		align-items: center;
 		gap: 8px;
+
+		.site-icon.site-icon {
+			border-radius: 50%;
+			overflow: hidden;
+		}
 	}
 
 	&__preview-stream-container {

--- a/client/reader/onboarding-rsm/subscribe-modal/style.scss
+++ b/client/reader/onboarding-rsm/subscribe-modal/style.scss
@@ -242,7 +242,7 @@ $actions-height: 64px;
 		justify-content: space-between;
 		padding: 10px 14px;
 		background-color: #fff;
-		border-bottom: 1px solid var( --color-neutral-5 );
+		border-bottom: none;
 
 		h3 {
 			margin: 0;
@@ -336,6 +336,7 @@ $actions-height: 64px;
 			margin-bottom: 0;
 			border-radius: 0;
 			padding: 14px 16px 12px;
+			box-shadow: none;
 		}
 	}
 

--- a/client/reader/onboarding-rsm/subscribe-modal/style.scss
+++ b/client/reader/onboarding-rsm/subscribe-modal/style.scss
@@ -130,7 +130,13 @@ $actions-height: 64px;
 			}
 
 			.reader-subscription-list-item__options {
-				display: none;
+				display: flex;
+				align-items: flex-start;
+				flex-shrink: 0;
+
+				.follow-button__label {
+					display: none;
+				}
 			}
 
 			.reader-subscription-list-item__site-url-timestamp {
@@ -211,6 +217,24 @@ $actions-height: 64px;
 			border-width: 1px;
 			border-radius: 4px;
 			box-shadow: none;
+		}
+
+		.button.follow-button.has-button-style.is-following,
+		.button.follow-button.has-button-style.is-following:hover {
+			background-color: var( --studio-gray-90, #1e1e1e );
+			border-color: var( --studio-gray-90, #1e1e1e );
+
+			svg.reader-following-feed {
+				fill: var( --studio-white, #fff );
+
+				* {
+					fill: var( --studio-white, #fff );
+				}
+			}
+
+			.follow-button__label {
+				color: var( --studio-white, #fff );
+			}
 		}
 	}
 

--- a/client/reader/onboarding-rsm/subscribe-modal/style.scss
+++ b/client/reader/onboarding-rsm/subscribe-modal/style.scss
@@ -239,6 +239,10 @@ $actions-height: 64px;
 		}
 	}
 
+	&__preview-stream {
+		pointer-events: none;
+	}
+
 	&.is-disabled {
 		.subscribe-modal__container {
 			height: 100%;

--- a/client/reader/onboarding-rsm/welcome-modal/style.scss
+++ b/client/reader/onboarding-rsm/welcome-modal/style.scss
@@ -193,6 +193,13 @@ $entry-offset: 10px;
 
 	.reader-onboarding-modal__footer {
 		border-top: 0;
+		// Same fix as interests-modal: use explicit inset + matching padding so the
+		// footer covers the full width and its content aligns with the modal body.
+		inset-inline-start: 0;
+		inset-inline-end: 0;
+		width: auto;
+		margin-inline: 0;
+		padding-inline: 24px;
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

Test to remove the border separations in the preview column interior of the reader onboarding-rsm subscriptions modal.


BEFORE
<img width="1097" height="768" alt="Screenshot 2026-05-05 at 3 52 49 PM" src="https://github.com/user-attachments/assets/25ea1cfd-619a-45ec-997f-de7590ae3e85" />



AFTER
<img width="1125" height="825" alt="Screenshot 2026-05-05 at 5 01 09 PM" src="https://github.com/user-attachments/assets/8f2eb493-cfe5-4785-9f21-1acc05560f2f" />




*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* these changes can be seen by clicking the launchpad steps seen on `*/reader?flags=reader/onboarding-rsm,reader/force-onboarding`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
