### PR TITLE
Podcasting: save podcast show URL

### DIFF
--- a/client/my-sites/podcast/components/distribution.tsx
+++ b/client/my-sites/podcast/components/distribution.tsx
@@ -12,6 +12,8 @@ import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { useFeedUrl } from '../hooks/use-feed-url';
 import {
 	LogoAmazon,
@@ -29,6 +31,9 @@ type Directory = {
 	name: string;
 	submitUrl: string;
 	learnMoreUrl?: string;
+	// Hostnames a saved show URL is allowed to live on (lowercase, no `www.`).
+	// Mirrors SHOW_URL_HOSTS in wp-content/mu-plugins/podcasting/settings-rest-api.php.
+	showHosts: string[];
 	Logo: ComponentType;
 };
 
@@ -38,6 +43,7 @@ const DIRECTORIES: Directory[] = [
 		name: 'Pocket Casts',
 		submitUrl: 'https://pocketcasts.com/submit',
 		learnMoreUrl: 'https://support.pocketcasts.com/knowledge-base/submitting-podcasts/',
+		showHosts: [ 'pca.st', 'pocketcasts.com' ],
 		Logo: LogoPocketCasts,
 	},
 	{
@@ -45,6 +51,7 @@ const DIRECTORIES: Directory[] = [
 		name: 'Apple Podcasts',
 		submitUrl: 'https://podcastsconnect.apple.com/',
 		learnMoreUrl: 'https://podcasters.apple.com/support/897-submit-a-show',
+		showHosts: [ 'podcasts.apple.com' ],
 		Logo: LogoApple,
 	},
 	{
@@ -53,6 +60,7 @@ const DIRECTORIES: Directory[] = [
 		submitUrl: 'https://creators.spotify.com/',
 		learnMoreUrl:
 			'https://support.spotify.com/creators/article/claiming-your-podcast-on-spotify-for-creators/',
+		showHosts: [ 'open.spotify.com' ],
 		Logo: LogoSpotify,
 	},
 	{
@@ -60,24 +68,37 @@ const DIRECTORIES: Directory[] = [
 		name: 'YouTube',
 		submitUrl: 'https://studio.youtube.com',
 		learnMoreUrl: 'https://support.google.com/youtube/answer/13973017',
+		showHosts: [ 'youtube.com', 'm.youtube.com', 'youtu.be', 'music.youtube.com' ],
 		Logo: LogoYouTube,
 	},
 	{
 		id: 'amazon',
 		name: 'Amazon Music',
 		submitUrl: 'https://podcasters.amazon.com',
+		showHosts: [
+			'music.amazon.com',
+			'music.amazon.co.uk',
+			'music.amazon.de',
+			'music.amazon.co.jp',
+			'music.amazon.com.au',
+			'music.amazon.fr',
+			'music.amazon.ca',
+			'music.amazon.es',
+		],
 		Logo: LogoAmazon,
 	},
 	{
 		id: 'podcastindex',
 		name: 'Podcast Index',
 		submitUrl: 'https://podcastindex.org/add',
+		showHosts: [ 'podcastindex.org' ],
 		Logo: LogoPodcastIndex,
 	},
 ];
 
 function Distribution() {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const feedUrl = useFeedUrl();
 	const [ activeId, setActiveId ] = useState< string | null >( null );
 	const [ showConfetti, setShowConfetti ] = useState( false );
@@ -85,6 +106,15 @@ function Distribution() {
 	const prefersReducedMotion =
 		typeof window !== 'undefined' &&
 		window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
+
+	const openSubmitModal = ( directoryId: string ) => {
+		dispatch(
+			recordTracksEvent( 'calypso_podcast_submit_modal_opened', {
+				directory: directoryId,
+			} )
+		);
+		setActiveId( directoryId );
+	};
 
 	return (
 		<>
@@ -139,7 +169,11 @@ function Distribution() {
 											</span>
 											<Text weight={ 500 }>{ name }</Text>
 										</HStack>
-										<Button variant="primary" size="compact" onClick={ () => setActiveId( id ) }>
+										<Button
+											variant="primary"
+											size="compact"
+											onClick={ () => openSubmitModal( id ) }
+										>
 											{ translate( 'Submit' ) }
 										</Button>
 									</HStack>
@@ -158,6 +192,7 @@ function Distribution() {
 						name: activeDirectory.name,
 						submitUrl: activeDirectory.submitUrl,
 						learnMoreUrl: activeDirectory.learnMoreUrl,
+						showHosts: activeDirectory.showHosts,
 					} }
 					onClose={ () => setActiveId( null ) }
 					onFirstSave={ () => setShowConfetti( true ) }

--- a/client/my-sites/podcast/components/submit-modal.tsx
+++ b/client/my-sites/podcast/components/submit-modal.tsx
@@ -5,6 +5,7 @@ import {
 	Modal,
 	Notice,
 	TextControl,
+	VisuallyHidden,
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
@@ -139,7 +140,9 @@ const SubmitModal = ( { feedUrl, podcatcher, onClose, onFirstSave }: Props ) => 
 		}
 		// Capture before the dispatch — hadAnyStoredUrl flips to true once the
 		// save lands, so without snapshotting we'd never qualify as a first save.
-		const isFirstEverSave = ! hadAnyStoredUrl;
+		// `null` (settings not yet hydrated) is preserved as null so we can skip
+		// confetti rather than guess.
+		const isFirstEverSave = hadAnyStoredUrl === null ? null : ! hadAnyStoredUrl;
 		setIsSaving( true );
 		setSaveError( null );
 		try {
@@ -151,7 +154,10 @@ const SubmitModal = ( { feedUrl, podcatcher, onClose, onFirstSave }: Props ) => 
 					is_replace: !! storedUrl,
 				} )
 			);
-			if ( isFirstEverSave ) {
+			// Only celebrate when we definitively know there were no prior URLs.
+			// `null` means site settings hadn't hydrated yet — skip confetti so a
+			// returning user on a fresh tab doesn't get a spurious celebration.
+			if ( isFirstEverSave === true ) {
 				onFirstSave?.();
 			}
 			onClose();
@@ -270,6 +276,7 @@ const SubmitModal = ( { feedUrl, podcatcher, onClose, onFirstSave }: Props ) => 
 									className="podcast__submit-step-saved-icon"
 									aria-hidden="true"
 								/>
+								<VisuallyHidden>{ translate( 'Saved:' ) }</VisuallyHidden>
 								<Text className="podcast__submit-step-saved-url" title={ storedUrl }>
 									{ storedUrl }
 								</Text>
@@ -277,6 +284,7 @@ const SubmitModal = ( { feedUrl, podcatcher, onClose, onFirstSave }: Props ) => 
 							<Button
 								variant="secondary"
 								__next40pxDefaultSize
+								aria-label={ translate( 'Replace %(service)s URL', serviceArgs ) as string }
 								onClick={ () => {
 									hasInitializedDraft.current = true;
 									setDraftUrl( storedUrl );

--- a/client/my-sites/podcast/components/submit-modal.tsx
+++ b/client/my-sites/podcast/components/submit-modal.tsx
@@ -79,11 +79,17 @@ const SubmitModal = ( { feedUrl, podcatcher, onClose, onFirstSave }: Props ) => 
 	const [ isEditing, setIsEditing ] = useState( false );
 	const [ saveError, setSaveError ] = useState< string | null >( null );
 	const copyTimeoutRef = useRef< ReturnType< typeof setTimeout > | null >( null );
+	const inputContainerRef = useRef< HTMLDivElement >( null );
 	// `storedUrl` may be empty on mount if site settings haven't hydrated yet;
 	// once it lands, mirror it into the draft. We flip this ref whenever the
 	// draft is touched (sync, typing, or Replace) so late hydration can never
 	// clobber input the user has already started.
 	const hasInitializedDraft = useRef( !! storedUrl );
+	// Set when Replace is clicked so the post-render effect knows to move
+	// focus into the now-mounted input. We don't trigger on every isEditing
+	// flip — typing also flips it, and grabbing focus mid-keystroke would be
+	// disruptive.
+	const shouldFocusInputRef = useRef( false );
 
 	useEffect(
 		() => () => {
@@ -100,6 +106,17 @@ const SubmitModal = ( { feedUrl, podcatcher, onClose, onFirstSave }: Props ) => 
 			setDraftUrl( storedUrl );
 		}
 	}, [ storedUrl ] );
+
+	useEffect( () => {
+		if ( ! shouldFocusInputRef.current || ! isEditing ) {
+			return;
+		}
+		shouldFocusInputRef.current = false;
+		const input = inputContainerRef.current?.querySelector( 'input' );
+		input?.focus();
+		// Pre-select so the user can type over the existing URL immediately.
+		input?.select();
+	}, [ isEditing ] );
 
 	const handleCopy = async () => {
 		if ( ! feedUrl || ! navigator.clipboard?.writeText ) {
@@ -287,6 +304,7 @@ const SubmitModal = ( { feedUrl, podcatcher, onClose, onFirstSave }: Props ) => 
 								aria-label={ translate( 'Replace %(service)s URL', serviceArgs ) as string }
 								onClick={ () => {
 									hasInitializedDraft.current = true;
+									shouldFocusInputRef.current = true;
 									setDraftUrl( storedUrl );
 									setSaveError( null );
 									setIsEditing( true );
@@ -298,7 +316,7 @@ const SubmitModal = ( { feedUrl, podcatcher, onClose, onFirstSave }: Props ) => 
 					) : (
 						<form className="podcast__submit-step-form" onSubmit={ handleSave }>
 							<HStack spacing={ 2 } alignment="center" className="podcast__submit-step-row">
-								<div className="podcast__submit-step-field">
+								<div className="podcast__submit-step-field" ref={ inputContainerRef }>
 									<TextControl
 										label={ translate( '%(service)s URL', serviceArgs ) as string }
 										hideLabelFromVision

--- a/client/my-sites/podcast/components/submit-modal.tsx
+++ b/client/my-sites/podcast/components/submit-modal.tsx
@@ -1,28 +1,29 @@
 import {
 	Button,
 	ExternalLink,
+	Icon,
 	Modal,
+	Notice,
 	TextControl,
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { external, link } from '@wordpress/icons';
+import { check, external, link } from '@wordpress/icons';
+import { prependHTTPS } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useRef, useState, type FormEvent } from 'react';
-import { useSelector } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import {
-	hasCelebratedFirstSave,
-	markCelebratedFirstSave,
-	usePodcatcherUrl,
-} from '../hooks/use-podcatcher-url';
+import { useHasAnyStoredPodcatcherUrl, usePodcatcherUrl } from '../hooks/use-podcatcher-url';
 
 export type Podcatcher = {
 	id: string;
 	name: string;
 	submitUrl: string;
 	learnMoreUrl?: string;
+	showHosts: string[];
 };
 
 type Props = {
@@ -34,12 +35,48 @@ type Props = {
 
 const COPIED_FEEDBACK_MS = 2000;
 
+// Mirrors SHOW_URL_MAX_LENGTH in the wpcom backend.
+const SHOW_URL_MAX_LENGTH = 2048;
+
+// prependHTTPS adds the scheme for bare hosts but leaves an existing http://
+// alone, so upgrade it ourselves — the backend rejects non-https.
+const normalizeShowUrl = ( raw: string ): string =>
+	prependHTTPS( raw.trim() ).replace( /^http:\/\//i, 'https://' );
+
+// Mirrors the per-podcatcher allowlist + esc_url_raw + wp_http_validate_url
+// gauntlet the backend runs each save through. Empty input is rejected here so
+// the modal never silently deletes a stored entry by clearing the field.
+const isValidShowUrl = ( url: string, allowedHosts: string[] ): boolean => {
+	if ( url === '' ) {
+		return false;
+	}
+	if ( url.length > SHOW_URL_MAX_LENGTH ) {
+		return false;
+	}
+	let parsed: URL;
+	try {
+		parsed = new URL( url );
+	} catch {
+		return false;
+	}
+	if ( parsed.protocol !== 'https:' ) {
+		return false;
+	}
+	const host = parsed.hostname.toLowerCase().replace( /^www\./, '' );
+	return allowedHosts.includes( host );
+};
+
 const SubmitModal = ( { feedUrl, podcatcher, onClose, onFirstSave }: Props ) => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const siteId = useSelector( getSelectedSiteId );
 	const [ storedUrl, setStoredUrl ] = usePodcatcherUrl( siteId, podcatcher.id );
+	const hadAnyStoredUrl = useHasAnyStoredPodcatcherUrl( siteId );
 	const [ draftUrl, setDraftUrl ] = useState( storedUrl );
 	const [ hasCopied, setHasCopied ] = useState( false );
+	const [ isSaving, setIsSaving ] = useState( false );
+	const [ isEditing, setIsEditing ] = useState( false );
+	const [ saveError, setSaveError ] = useState< string | null >( null );
 	const copyTimeoutRef = useRef< ReturnType< typeof setTimeout > | null >( null );
 
 	useEffect(
@@ -51,41 +88,66 @@ const SubmitModal = ( { feedUrl, podcatcher, onClose, onFirstSave }: Props ) => 
 		[]
 	);
 
-	const handleCopy = () => {
+	const handleCopy = async () => {
 		if ( ! feedUrl || ! navigator.clipboard?.writeText ) {
 			return;
 		}
-		navigator.clipboard
-			.writeText( feedUrl )
-			.then( () => {
-				setHasCopied( true );
-				if ( copyTimeoutRef.current ) {
-					clearTimeout( copyTimeoutRef.current );
-				}
-				copyTimeoutRef.current = setTimeout( () => setHasCopied( false ), COPIED_FEEDBACK_MS );
-			} )
-			.catch( ( error ) => {
-				// eslint-disable-next-line no-console
-				console.warn( 'Podcast: failed to copy RSS feed URL to clipboard', error );
-			} );
-	};
-
-	const handleSave = ( event: FormEvent< HTMLFormElement > ) => {
-		event.preventDefault();
-		const trimmed = draftUrl.trim();
-		setStoredUrl( trimmed );
-		if ( trimmed && ! hasCelebratedFirstSave( siteId ) ) {
-			markCelebratedFirstSave( siteId );
-			onFirstSave?.();
+		try {
+			await navigator.clipboard.writeText( feedUrl );
+			setHasCopied( true );
+			if ( copyTimeoutRef.current ) {
+				clearTimeout( copyTimeoutRef.current );
+			}
+			copyTimeoutRef.current = setTimeout( () => setHasCopied( false ), COPIED_FEEDBACK_MS );
+		} catch ( error ) {
+			// eslint-disable-next-line no-console
+			console.warn( 'Podcast: failed to copy RSS feed URL to clipboard', error );
 		}
-		onClose();
 	};
-
-	const isUnchanged = draftUrl.trim() === storedUrl.trim();
 
 	const serviceArgs = {
 		args: { service: podcatcher.name },
 		comment: '%(service)s is a podcast directory name, e.g. "Spotify" or "Apple Podcasts".',
+	};
+
+	const invalidUrlError = translate( 'Enter a valid %(service)s URL.', serviceArgs ) as string;
+	const saveFailedError = translate(
+		'We couldn’t save your %(service)s URL. Please try again.',
+		serviceArgs
+	) as string;
+
+	const normalizedDraft = normalizeShowUrl( draftUrl );
+	const isUnchanged = normalizedDraft === storedUrl;
+
+	const handleSave = async ( event: FormEvent< HTMLFormElement > ) => {
+		event.preventDefault();
+		if ( ! isValidShowUrl( normalizedDraft, podcatcher.showHosts ) ) {
+			setSaveError( invalidUrlError );
+			return;
+		}
+		// Capture before the dispatch — hadAnyStoredUrl flips to true once the
+		// save lands, so without snapshotting we'd never qualify as a first save.
+		const isFirstEverSave = ! hadAnyStoredUrl;
+		setIsSaving( true );
+		setSaveError( null );
+		try {
+			await setStoredUrl( normalizedDraft );
+			dispatch(
+				recordTracksEvent( 'calypso_podcast_show_url_saved', {
+					directory: podcatcher.id,
+					is_first_save: isFirstEverSave,
+					is_replace: !! storedUrl,
+				} )
+			);
+			if ( isFirstEverSave ) {
+				onFirstSave?.();
+			}
+			onClose();
+		} catch {
+			setSaveError( saveFailedError );
+		} finally {
+			setIsSaving( false );
+		}
 	};
 
 	const step2Note =
@@ -182,31 +244,78 @@ const SubmitModal = ( { feedUrl, podcatcher, onClose, onFirstSave }: Props ) => 
 							serviceArgs
 						) }
 					</Text>
-					<form className="podcast__submit-step-form" onSubmit={ handleSave }>
+					{ storedUrl && ! isEditing ? (
 						<HStack spacing={ 2 } alignment="center" className="podcast__submit-step-row">
-							<div className="podcast__submit-step-field">
-								<TextControl
-									label={ translate( '%(service)s URL', serviceArgs ) as string }
-									hideLabelFromVision
-									value={ draftUrl }
-									onChange={ setDraftUrl }
-									placeholder="https://"
-									type="url"
-									__next40pxDefaultSize
-									__nextHasNoMarginBottom
-								/>
-							</div>
-							<Button
-								variant="primary"
-								__next40pxDefaultSize
-								type="submit"
-								disabled={ isUnchanged }
-								accessibleWhenDisabled
+							<HStack
+								spacing={ 2 }
+								alignment="center"
+								expanded={ false }
+								justify="flex-start"
+								className="podcast__submit-step-saved"
 							>
-								{ translate( 'Save' ) }
+								<Icon
+									icon={ check }
+									className="podcast__submit-step-saved-icon"
+									aria-hidden="true"
+								/>
+								<Text className="podcast__submit-step-saved-url" title={ storedUrl }>
+									{ storedUrl }
+								</Text>
+							</HStack>
+							<Button
+								variant="secondary"
+								__next40pxDefaultSize
+								onClick={ () => {
+									setDraftUrl( storedUrl );
+									setSaveError( null );
+									setIsEditing( true );
+								} }
+							>
+								{ translate( 'Replace' ) }
 							</Button>
 						</HStack>
-					</form>
+					) : (
+						<form className="podcast__submit-step-form" onSubmit={ handleSave }>
+							<HStack spacing={ 2 } alignment="center" className="podcast__submit-step-row">
+								<div className="podcast__submit-step-field">
+									<TextControl
+										label={ translate( '%(service)s URL', serviceArgs ) as string }
+										hideLabelFromVision
+										value={ draftUrl }
+										onChange={ ( value ) => {
+											setDraftUrl( value );
+											setSaveError( null );
+										} }
+										placeholder="https://"
+										type="text"
+										inputMode="url"
+										__next40pxDefaultSize
+										__nextHasNoMarginBottom
+									/>
+								</div>
+								<Button
+									variant="primary"
+									__next40pxDefaultSize
+									type="submit"
+									disabled={ ! normalizedDraft || isUnchanged || isSaving }
+									isBusy={ isSaving }
+									accessibleWhenDisabled
+								>
+									{ translate( 'Save' ) }
+								</Button>
+							</HStack>
+							{ saveError && (
+								<Notice
+									status="error"
+									isDismissible
+									onRemove={ () => setSaveError( null ) }
+									className="podcast__submit-step-notice"
+								>
+									{ saveError }
+								</Notice>
+							) }
+						</form>
+					) }
 				</VStack>
 			</VStack>
 		</Modal>

--- a/client/my-sites/podcast/components/submit-modal.tsx
+++ b/client/my-sites/podcast/components/submit-modal.tsx
@@ -297,6 +297,10 @@ const SubmitModal = ( { feedUrl, podcatcher, onClose, onFirstSave }: Props ) => 
 										value={ draftUrl }
 										onChange={ ( value ) => {
 											hasInitializedDraft.current = true;
+											// Pin the form open so a late `storedUrl` hydration
+											// can't swap us back to the saved/read-only view
+											// mid-keystroke.
+											setIsEditing( true );
 											setDraftUrl( value );
 											setSaveError( null );
 										} }

--- a/client/my-sites/podcast/components/submit-modal.tsx
+++ b/client/my-sites/podcast/components/submit-modal.tsx
@@ -78,6 +78,11 @@ const SubmitModal = ( { feedUrl, podcatcher, onClose, onFirstSave }: Props ) => 
 	const [ isEditing, setIsEditing ] = useState( false );
 	const [ saveError, setSaveError ] = useState< string | null >( null );
 	const copyTimeoutRef = useRef< ReturnType< typeof setTimeout > | null >( null );
+	// `storedUrl` may be empty on mount if site settings haven't hydrated yet;
+	// once it lands, mirror it into the draft. We flip this ref whenever the
+	// draft is touched (sync, typing, or Replace) so late hydration can never
+	// clobber input the user has already started.
+	const hasInitializedDraft = useRef( !! storedUrl );
 
 	useEffect(
 		() => () => {
@@ -87,6 +92,13 @@ const SubmitModal = ( { feedUrl, podcatcher, onClose, onFirstSave }: Props ) => 
 		},
 		[]
 	);
+
+	useEffect( () => {
+		if ( ! hasInitializedDraft.current && storedUrl ) {
+			hasInitializedDraft.current = true;
+			setDraftUrl( storedUrl );
+		}
+	}, [ storedUrl ] );
 
 	const handleCopy = async () => {
 		if ( ! feedUrl || ! navigator.clipboard?.writeText ) {
@@ -117,7 +129,7 @@ const SubmitModal = ( { feedUrl, podcatcher, onClose, onFirstSave }: Props ) => 
 	) as string;
 
 	const normalizedDraft = normalizeShowUrl( draftUrl );
-	const isUnchanged = normalizedDraft === storedUrl;
+	const isUnchanged = draftUrl === storedUrl;
 
 	const handleSave = async ( event: FormEvent< HTMLFormElement > ) => {
 		event.preventDefault();
@@ -266,6 +278,7 @@ const SubmitModal = ( { feedUrl, podcatcher, onClose, onFirstSave }: Props ) => 
 								variant="secondary"
 								__next40pxDefaultSize
 								onClick={ () => {
+									hasInitializedDraft.current = true;
 									setDraftUrl( storedUrl );
 									setSaveError( null );
 									setIsEditing( true );
@@ -283,6 +296,7 @@ const SubmitModal = ( { feedUrl, podcatcher, onClose, onFirstSave }: Props ) => 
 										hideLabelFromVision
 										value={ draftUrl }
 										onChange={ ( value ) => {
+											hasInitializedDraft.current = true;
 											setDraftUrl( value );
 											setSaveError( null );
 										} }

--- a/client/my-sites/podcast/hooks/use-podcatcher-url.ts
+++ b/client/my-sites/podcast/hooks/use-podcatcher-url.ts
@@ -1,72 +1,92 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback } from 'react';
+import { useDispatch, useSelector } from 'calypso/state';
+import getSiteSetting from 'calypso/state/selectors/get-site-setting';
+import { saveSiteSettings } from 'calypso/state/site-settings/actions';
 
-const storageKey = ( siteId: number, podcatcherId: string ) =>
-	`podcasting:${ siteId }:${ podcatcherId }:url`;
+const SAVE_FAILED = 'podcatcher_url_save_failed';
 
-const celebrationKey = ( siteId: number ) => `podcasting:${ siteId }:celebrated_first_save`;
-
-export const hasCelebratedFirstSave = ( siteId: number | null | undefined ): boolean => {
-	if ( typeof window === 'undefined' || ! siteId ) {
-		return false;
+// Reads the per-podcatcher value from a `podcasting_show_urls` payload.
+// The backend pads missing keys with empty strings and PHP encodes an empty
+// associative array as [], so the field can be an object, an empty array, or
+// missing entirely.
+const readShowUrl = ( showUrls: unknown, podcatcherId: string ): string | undefined => {
+	if ( ! showUrls || typeof showUrls !== 'object' || Array.isArray( showUrls ) ) {
+		return undefined;
 	}
-	try {
-		return window.localStorage.getItem( celebrationKey( siteId ) ) === '1';
-	} catch {
-		return false;
-	}
-};
-
-export const markCelebratedFirstSave = ( siteId: number | null | undefined ): void => {
-	if ( typeof window === 'undefined' || ! siteId ) {
-		return;
-	}
-	try {
-		window.localStorage.setItem( celebrationKey( siteId ), '1' );
-	} catch {
-		/* storage unavailable — fail silent */
-	}
-};
-
-const readUrl = ( siteId: number | null | undefined, podcatcherId: string ): string => {
-	if ( typeof window === 'undefined' || ! siteId ) {
-		return '';
-	}
-	try {
-		return window.localStorage.getItem( storageKey( siteId, podcatcherId ) ) ?? '';
-	} catch {
-		return '';
-	}
+	const value = ( showUrls as Record< string, unknown > )[ podcatcherId ];
+	return typeof value === 'string' ? value : undefined;
 };
 
 export const usePodcatcherUrl = (
 	siteId: number | null | undefined,
 	podcatcherId: string
-): [ string, ( next: string ) => void ] => {
-	const [ url, setUrl ] = useState( () => readUrl( siteId, podcatcherId ) );
+): [ string, ( next: string ) => Promise< void > ] => {
+	const dispatch = useDispatch();
+	const url = useSelector( ( state ) => {
+		if ( ! siteId ) {
+			return '';
+		}
+		return (
+			readShowUrl( getSiteSetting( state, siteId, 'podcasting_show_urls' ), podcatcherId ) ?? ''
+		);
+	} );
 
-	useEffect( () => {
-		setUrl( readUrl( siteId, podcatcherId ) );
-	}, [ siteId, podcatcherId ] );
-
+	// Each save patches a single key; the backend merges it into the stored
+	// option and treats an empty string as a delete (see wpcom PR 214724).
+	// The backend silently drops URLs that fail validation (wrong host,
+	// non-https, etc.), so we compare what came back to confirm the write
+	// actually landed and reject otherwise.
 	const save = useCallback(
-		( next: string ) => {
-			setUrl( next );
-			if ( typeof window === 'undefined' || ! siteId ) {
+		async ( next: string ): Promise< void > => {
+			if ( ! siteId ) {
+				throw new Error( SAVE_FAILED );
+			}
+			const trimmed = next.trim();
+			const result = ( await dispatch(
+				saveSiteSettings( siteId, {
+					podcasting_show_urls: { [ podcatcherId ]: trimmed },
+				} )
+			) ) as { updated?: { podcasting_show_urls?: unknown } } | null;
+
+			// A bare error response (network failure, auth, etc.) lacks `updated`.
+			if ( ! result?.updated || ! ( 'podcasting_show_urls' in result.updated ) ) {
+				throw new Error( SAVE_FAILED );
+			}
+
+			const persisted = readShowUrl( result.updated.podcasting_show_urls, podcatcherId );
+
+			if ( trimmed === '' ) {
+				// Delete intent — success means the key is absent or empty.
+				if ( persisted && persisted !== '' ) {
+					throw new Error( SAVE_FAILED );
+				}
 				return;
 			}
-			try {
-				const key = storageKey( siteId, podcatcherId );
-				if ( next ) {
-					window.localStorage.setItem( key, next );
-				} else {
-					window.localStorage.removeItem( key );
-				}
-			} catch {
-				/* storage unavailable — fail silent */
+
+			// Add/update intent — success means the response carries our exact value.
+			if ( persisted !== trimmed ) {
+				throw new Error( SAVE_FAILED );
 			}
 		},
-		[ siteId, podcatcherId ]
+		[ dispatch, siteId, podcatcherId ]
 	);
 
 	return [ url, save ];
 };
+
+// True if at least one podcatcher entry under `podcasting_show_urls` is a
+// non-empty string. Used to gate the first-save confetti so it only fires
+// on the user's true first save across all directories.
+export const useHasAnyStoredPodcatcherUrl = ( siteId: number | null | undefined ): boolean =>
+	useSelector( ( state ) => {
+		if ( ! siteId ) {
+			return false;
+		}
+		const showUrls = getSiteSetting( state, siteId, 'podcasting_show_urls' );
+		if ( ! showUrls || typeof showUrls !== 'object' || Array.isArray( showUrls ) ) {
+			return false;
+		}
+		return Object.values( showUrls as Record< string, unknown > ).some(
+			( value ) => typeof value === 'string' && value.trim() !== ''
+		);
+	} );

--- a/client/my-sites/podcast/hooks/use-podcatcher-url.ts
+++ b/client/my-sites/podcast/hooks/use-podcatcher-url.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'calypso/state';
 import getSiteSetting from 'calypso/state/selectors/get-site-setting';
 import { saveSiteSettings } from 'calypso/state/site-settings/actions';
+import { getSiteSettings } from 'calypso/state/site-settings/selectors';
 
 const SAVE_FAILED = 'podcatcher_url_save_failed';
 
@@ -42,14 +43,20 @@ export const usePodcatcherUrl = (
 				throw new Error( SAVE_FAILED );
 			}
 			const trimmed = next.trim();
+			// `saveSiteSettings` doesn't throw on failure — it `return error;`,
+			// so the awaited value can be the response body OR an Error.
 			const result = ( await dispatch(
 				saveSiteSettings( siteId, {
 					podcasting_show_urls: { [ podcatcherId ]: trimmed },
 				} )
-			) ) as { updated?: { podcasting_show_urls?: unknown } } | null;
+			) ) as { updated?: { podcasting_show_urls?: unknown } } | Error | null;
+
+			if ( ! result || result instanceof Error ) {
+				throw new Error( SAVE_FAILED );
+			}
 
 			// A bare error response (network failure, auth, etc.) lacks `updated`.
-			if ( ! result?.updated || ! ( 'podcasting_show_urls' in result.updated ) ) {
+			if ( ! result.updated || ! ( 'podcasting_show_urls' in result.updated ) ) {
 				throw new Error( SAVE_FAILED );
 			}
 
@@ -74,13 +81,21 @@ export const usePodcatcherUrl = (
 	return [ url, save ];
 };
 
-// True if at least one podcatcher entry under `podcasting_show_urls` is a
-// non-empty string. Used to gate the first-save confetti so it only fires
-// on the user's true first save across all directories.
-export const useHasAnyStoredPodcatcherUrl = ( siteId: number | null | undefined ): boolean =>
+// Returns true if at least one podcatcher entry under `podcasting_show_urls`
+// is a non-empty string, false if we know there are none, or null if site
+// settings haven't hydrated yet. Used to gate the first-save confetti so it
+// only fires when we're sure this is the user's first save across all
+// directories — never on a not-yet-loaded fallback.
+export const useHasAnyStoredPodcatcherUrl = ( siteId: number | null | undefined ): boolean | null =>
 	useSelector( ( state ) => {
 		if ( ! siteId ) {
-			return false;
+			return null;
+		}
+		// `getSiteSettings` returns null until the settings request resolves;
+		// distinguishing that from "loaded with no URLs" is what avoids spurious
+		// confetti on a fast click before hydration.
+		if ( ! getSiteSettings( state, siteId ) ) {
+			return null;
 		}
 		const showUrls = getSiteSetting( state, siteId, 'podcasting_show_urls' );
 		if ( ! showUrls || typeof showUrls !== 'object' || Array.isArray( showUrls ) ) {

--- a/client/my-sites/podcast/style.scss
+++ b/client/my-sites/podcast/style.scss
@@ -377,3 +377,35 @@ body.is-section-podcasting {
 	align-self: flex-start;
 	justify-content: flex-start;
 }
+
+.podcast__submit-step-notice {
+	margin-block: 8px 0;
+	margin-inline: 0;
+}
+
+.podcast__submit-step-saved {
+	flex: 1;
+	min-width: 0;
+	padding: 8px 12px;
+	background: var( --wpds-color-bg-surface, #fff );
+	border: 1px solid var( --wpds-color-border-neutral, #ddd );
+	border-radius: 4px;
+}
+
+.podcast__submit-step-saved-icon {
+	flex-shrink: 0;
+	color: var( --wpds-color-fg-content-success, #007a3d );
+
+	// Gutenberg's Icon paths use fill="currentColor"; force any stray fill="none"
+	// or hard-coded colors to inherit so the success token actually wins.
+	svg {
+		fill: currentColor;
+	}
+}
+
+.podcast__submit-step-saved-url {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	min-width: 0;
+}


### PR DESCRIPTION
Fixes PODS-92/add-wpcom-podcast-feed-submission-result-after-submit-modal-redesign

## Proposed Changes

* Persist per-directory show URLs to the `podcasting_show_urls` site setting (replaces the prior `localStorage` stash).
* Add client-side validation mirroring the wpcom host allowlist + 2048-char cap.
* Normalize URLs on submit (`prependHTTPS` + `http://` upgrade) so users can paste bare hosts.
* New "Saved" state in the submit modal with a Replace button; empty saves are now blocked at the UI level.
* Confetti now gated on no podcatcher having a stored URL anywhere on the site (server-state, not localStorage).
* Tracks events: `calypso_podcast_submit_modal_opened` and `calypso_podcast_show_url_saved`.

## Why are these changes being made?

Backend wiring (`214724-ghe-Automattic/wpcom`) has already merged to trunk and shipped, so the `podcasting_show_urls` site setting is live. This makes the Calypso Distribution UI use that server-side setting so saved show URLs survive across browsers and devices.

## Testing Instructions

* Settings → Podcast → Distribution. Click Submit on any directory.
* Paste a bare host (e.g. `podcasts.apple.com/...`); confirm it saves and the modal shows the Saved view on reopen.
* Paste a wrong-host URL (e.g. `blahblah.com` for Apple); confirm the inline error and that no save dispatches.
* Save a URL on a fresh site; confetti fires once. Save another for a different directory; no confetti.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?