### PR TITLE
Purchases: fix Back button navigating to stale cancel page after cancellation

### DIFF
--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -587,6 +587,21 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		}
 	};
 
+	handleSurveyClose = () => {
+		if ( this.shouldFireMutationOnConfirm() ) {
+			this.props.refreshSitePlans( this.props.purchase.siteId );
+			this.props.clearPurchases();
+			const managePurchaseUrl = ( this.props.getManagePurchaseUrlFor ?? managePurchase )(
+				this.props.siteSlug,
+				this.props.purchaseId
+			);
+			const backupRedirect = this.props.purchaseListUrl ?? purchasesRoot;
+			page.redirect( managePurchaseUrl ?? backupRedirect );
+			return;
+		}
+		this.setState( { surveyShown: false } );
+	};
+
 	onDialogClose = () => {
 		this.setState( {
 			showDialog: false,
@@ -1108,7 +1123,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 						disableButtons={ this.state.isLoading }
 						purchase={ purchase }
 						isVisible={ this.state.surveyShown }
-						onClose={ () => this.setState( { surveyShown: false } ) }
+						onClose={ this.handleSurveyClose }
 						onSurveyComplete={ this.onSurveyComplete }
 						flowType={ this.getCancelFlowType( purchase ) }
 						cancelBundledDomain={ this.state.cancelBundledDomain }


### PR DESCRIPTION
## Proposed Changes
This PR fixes a bug in Calypso where you confirm a cancellation and then move onto the survey. When you press back, it now takes you back to the purchase management screen with auto-renew off (instead of back to the cancel confirmation screen which could cause problems).

This applies to cancel only. For remove, it goes to the confirmation screen.

## Testing Instructions

1. Navigate to a cancelable subscription's manage-purchase page (e.g., a plan with the `purchases/split-cancel-remove` flag enabled).
2. Click "Cancel plan" to enter the cancel flow.
3. Confirm the cancellation — this fires the mutation and shows the survey.
4. Press the "Back" button (the `←` in the BlankCanvas header).
5. **Before**: You see the stale cancel confirmation form. **After**: You're redirected to the manage-purchase page.
6. Verify the remove flow still works: for a removable (expired) subscription, pressing Back from the survey should still return to the confirmation form.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)