### PR TITLE
Purchases: let users adjust gift banner setting when disabling plan auto-renewal

### DIFF
--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.tsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.tsx
@@ -3,18 +3,27 @@ import {
 	isGSuiteOrGoogleWorkspace,
 	isPlan,
 	isTitanMail,
+	WPCOM_FEATURES_SUBSCRIPTION_GIFTING,
 } from '@automattic/calypso-products';
-import { Button } from '@wordpress/components';
+import { Button, CheckboxControl } from '@wordpress/components';
 import { localize, type LocalizeProps } from 'i18n-calypso';
 import moment from 'moment';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import { ConfirmDialog, DialogContent, DialogFooter } from 'calypso/components/confirm-dialog';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import CancelAutoRenewalForm from 'calypso/components/marketing-survey/cancel-auto-renewal-form';
 import { isAkismetHoldingSitePurchase } from 'calypso/me/purchases/utils';
+import { createNotice } from 'calypso/state/notices/actions';
 import isSiteAtomic from 'calypso/state/selectors/is-site-automated-transfer';
+import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import { saveSiteSettings } from 'calypso/state/site-settings/actions';
+import { getSiteSettings } from 'calypso/state/site-settings/selectors';
 import type { Purchases } from '@automattic/data-stores';
+import type { NoticeStatus, NoticeText, NoticeOptions } from 'calypso/state/notices/types';
+import type { IAppState } from 'calypso/state/types';
 
 const DIALOG = {
 	GENERAL: 'general',
@@ -30,6 +39,11 @@ interface MomentProps {
 
 interface AutoRenewDisablingDialogConnectedProps {
 	isAtomicSite: boolean;
+	siteId: number;
+	canShowGiftingOptIn: boolean;
+	currentGiftingValue: boolean;
+	saveSiteSettings: ( siteId: number, settings: Record< string, unknown > ) => Promise< unknown >;
+	createNotice: ( status: NoticeStatus, text: NoticeText, options?: NoticeOptions ) => void;
 }
 
 interface AutoRenewDisablingDialogProps {
@@ -37,13 +51,17 @@ interface AutoRenewDisablingDialogProps {
 	planName: string;
 	siteDomain: string;
 	purchase: Purchases.Purchase;
-	onConfirm: () => void;
+	// `afterSuccess` is invoked by the parent's auto-renew thunk only when the
+	// disable call actually succeeds. Used to chain the gift-setting save.
+	onConfirm: ( afterSuccess?: () => void ) => void;
 	onClose: () => void;
 }
 
 interface AutoRenewDisablingDialogState {
 	dialogType: DialogType;
 	surveyHasShown: boolean;
+	giftingChecked: boolean;
+	userEditedGifting: boolean;
 }
 
 type AutoRenewDisablingDialogAllProps = AutoRenewDisablingDialogProps &
@@ -58,6 +76,56 @@ class AutoRenewDisablingDialog extends Component<
 	state: AutoRenewDisablingDialogState = {
 		dialogType: DIALOG.GENERAL,
 		surveyHasShown: false,
+		giftingChecked: this.props.currentGiftingValue,
+		userEditedGifting: false,
+	};
+
+	componentDidUpdate( prevProps: AutoRenewDisablingDialogAllProps ) {
+		// The visibility transition guard prevents infinite re-render loops.
+		if ( ! prevProps.isVisible && this.props.isVisible ) {
+			/* eslint-disable-next-line react/no-did-update-set-state */
+			this.setState( {
+				giftingChecked: this.props.currentGiftingValue,
+				userEditedGifting: false,
+			} );
+			return;
+		}
+		if (
+			this.props.isVisible &&
+			! this.state.userEditedGifting &&
+			prevProps.currentGiftingValue !== this.props.currentGiftingValue
+		) {
+			/* eslint-disable-next-line react/no-did-update-set-state */
+			this.setState( { giftingChecked: this.props.currentGiftingValue } );
+		}
+	}
+
+	commitGiftingChange = () => {
+		const { canShowGiftingOptIn, currentGiftingValue, siteId, translate } = this.props;
+		if ( ! canShowGiftingOptIn ) {
+			return;
+		}
+		if ( this.state.giftingChecked === currentGiftingValue ) {
+			return;
+		}
+		// The thunk catches its own rejection and returns the error, so detect
+		// failure by the absence of `updated` in the resolved body.
+		Promise.resolve(
+			this.props.saveSiteSettings( siteId, {
+				wpcom_gifting_subscription: this.state.giftingChecked,
+			} )
+		).then( ( result: unknown ) => {
+			const isSuccess =
+				!! result && typeof result === 'object' && 'updated' in ( result as object );
+			if ( ! isSuccess ) {
+				this.props.createNotice(
+					'is-error',
+					translate(
+						"We couldn't update your gift subscription preference. You can change it later in your site settings."
+					)
+				);
+			}
+		} );
 	};
 
 	getVariation() {
@@ -213,7 +281,7 @@ class AutoRenewDisablingDialog extends Component<
 	}
 
 	onClickAtomicFollowUpConfirm = () => {
-		this.props.onConfirm();
+		this.props.onConfirm( this.commitGiftingChange );
 		this.setState( {
 			dialogType: DIALOG.SURVEY,
 		} );
@@ -271,7 +339,7 @@ class AutoRenewDisablingDialog extends Component<
 			return;
 		}
 
-		this.props.onConfirm();
+		this.props.onConfirm( this.commitGiftingChange );
 
 		if ( this.state.surveyHasShown ) {
 			return this.closeAndCleanup();
@@ -281,6 +349,33 @@ class AutoRenewDisablingDialog extends Component<
 			dialogType: DIALOG.SURVEY,
 			surveyHasShown: true,
 		} );
+	};
+
+	renderGiftingOptIn = () => {
+		const { canShowGiftingOptIn, translate } = this.props;
+		const variation = this.getVariation();
+
+		// Surface the gift toggle on every disable so the user can confirm or
+		// change the gift-banner state in the same step.
+		if ( ! canShowGiftingOptIn || ( variation !== 'plan' && variation !== 'atomic' ) ) {
+			return null;
+		}
+
+		return (
+			<CheckboxControl
+				__nextHasNoMarginBottom
+				checked={ this.state.giftingChecked }
+				onChange={ ( checked: boolean ) =>
+					this.setState( { giftingChecked: checked, userEditedGifting: true } )
+				}
+				label={ translate( 'Allow site visitors to gift your plan and domain renewal costs' ) }
+				help={ translate( '{{a}}Learn more{{/a}}', {
+					components: {
+						a: <InlineSupportLink supportContext="gift-a-subscription" showIcon={ false } />,
+					},
+				} ) }
+			/>
+		);
 	};
 
 	renderGeneralDialog = () => {
@@ -298,6 +393,7 @@ class AutoRenewDisablingDialog extends Component<
 			>
 				<DialogContent>
 					<p>{ description }</p>
+					{ this.renderGiftingOptIn() }
 				</DialogContent>
 
 				<DialogFooter>
@@ -337,6 +433,18 @@ class AutoRenewDisablingDialog extends Component<
 	}
 }
 
-export default connect( ( state, { purchase }: AutoRenewDisablingDialogProps ) => ( {
-	isAtomicSite: isSiteAtomic( state, purchase.siteId ),
-} ) )( localize( withLocalizedMoment( AutoRenewDisablingDialog ) ) );
+export default connect(
+	( state: IAppState, { purchase }: AutoRenewDisablingDialogProps ) => {
+		const siteId = purchase.siteId;
+		const settings = getSiteSettings( state, siteId );
+		const hasGiftingFeature = siteHasFeature( state, siteId, WPCOM_FEATURES_SUBSCRIPTION_GIFTING );
+		const isStaging = isSiteWpcomStaging( state, siteId );
+		return {
+			isAtomicSite: isSiteAtomic( state, siteId ) ?? false,
+			siteId,
+			canShowGiftingOptIn: Boolean( siteId ) && hasGiftingFeature && ! isStaging,
+			currentGiftingValue: Boolean( settings?.wpcom_gifting_subscription ),
+		};
+	},
+	{ saveSiteSettings, createNotice }
+)( localize( withLocalizedMoment( AutoRenewDisablingDialog ) ) );

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/index.tsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/index.tsx
@@ -1,8 +1,11 @@
+import { isPlan } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, ToggleControl } from '@wordpress/components';
 import { localize, LocalizeProps } from 'i18n-calypso';
 import { Component, type ReactNode } from 'react';
 import { connect } from 'react-redux';
+import QuerySiteFeatures from 'calypso/components/data/query-site-features';
+import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 import { disableAutoRenew, enableAutoRenew } from 'calypso/lib/purchases/actions';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
@@ -54,6 +57,7 @@ interface AutoRenewToggleState {
 	showAutoRenewDisablingDialog: boolean;
 	showPaymentMethodDialog: boolean;
 	isRequesting: boolean;
+	prefetchGiftingData: boolean;
 }
 
 class AutoRenewToggle extends Component<
@@ -65,6 +69,15 @@ class AutoRenewToggle extends Component<
 		showAutoRenewDisablingDialog: false,
 		showPaymentMethodDialog: false,
 		isRequesting: false,
+		prefetchGiftingData: false,
+	};
+
+	// Prefetch site settings/features on hover/focus so the gift checkbox in
+	// the disable dialog renders without a visible delay.
+	prefetchGiftingData = () => {
+		if ( ! this.state.prefetchGiftingData && isPlan( this.props.purchase ) ) {
+			this.setState( { prefetchGiftingData: true } );
+		}
 	};
 
 	componentDidUpdate() {
@@ -124,7 +137,7 @@ class AutoRenewToggle extends Component<
 		} );
 	};
 
-	toggleAutoRenew = () => {
+	toggleAutoRenew = ( afterSuccess?: () => void ) => {
 		const {
 			purchase: { id: purchaseId, productSlug },
 			currentUserId,
@@ -174,6 +187,10 @@ class AutoRenewToggle extends Component<
 						],
 					} );
 				}
+
+				// Run any post-success follow-up the caller passed in. Skipped on failure so we
+				// don't change the gift state when auto-renew didn't actually move.
+				afterSuccess?.();
 
 				return;
 			}
@@ -244,6 +261,8 @@ class AutoRenewToggle extends Component<
 					variant="link"
 					className="is-link"
 					onClick={ this.onToggleAutoRenew }
+					onMouseEnter={ this.prefetchGiftingData }
+					onFocus={ this.prefetchGiftingData }
 					disabled={ shouldDisable || ! this.shouldRender( purchase ) }
 				>
 					{ children }
@@ -251,17 +270,25 @@ class AutoRenewToggle extends Component<
 			);
 		} else {
 			toggle = (
-				<ToggleControl
-					checked={ this.getToggleUiStatus() }
-					disabled={ this.isUpdatingAutoRenew() || shouldDisable }
-					onChange={ this.onToggleAutoRenew }
-					label={ this.props.label ?? ( withTextStatus ? this.renderTextStatus() : undefined ) }
-				/>
+				<span onMouseEnter={ this.prefetchGiftingData } onFocus={ this.prefetchGiftingData }>
+					<ToggleControl
+						checked={ this.getToggleUiStatus() }
+						disabled={ this.isUpdatingAutoRenew() || shouldDisable }
+						onChange={ this.onToggleAutoRenew }
+						label={ this.props.label ?? ( withTextStatus ? this.renderTextStatus() : undefined ) }
+					/>
+				</span>
 			);
 		}
 
 		return (
 			<>
+				{ this.state.prefetchGiftingData && purchase.siteId ? (
+					<>
+						<QuerySiteFeatures siteIds={ [ purchase.siteId ] } />
+						<QuerySiteSettings siteId={ purchase.siteId } />
+					</>
+				) : null }
 				{ toggle }
 				<AutoRenewDisablingDialog
 					isVisible={ this.state.showAutoRenewDisablingDialog }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes
Closes #101977

* When turning off auto-renew on a plan, the disable dialog now shows an **"Allow site visitors to gift your plan and domain renewal costs"** checkbox, pre-filled with the site's current "Accept a gift subscription" setting.
* The gift banner setting save runs only after the auto-renew disable succeeds, with an error notice on failure.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Today, wherever it is enabled, we automatically show the Gift Subscription banner on plans that are not set to auto-renew, but business owners may find the banner embarrassing and not realize it's there till they view their site as someone else. Surfacing the choice when they turn off auto-renew, lets them opt in or out of the gift banner display consciously.  

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Visit `https://wordpress.com/purchases/subscriptions/<site>/<purchase_id>` and `https://wordpress.com/me/purchases/<site>/<purchase_id>`
2. Toggle auto-renew off. The dialog should include the new checkbox (pre-filled with the site's current "Accept a gift subscription" setting)                                                                            
3. Checking/unchecking the checkbox and then turning off auto-renewal should work as expected. The updated setting should also reflect here: https://wordpress.com/sites/<site>/settings/subscription-gifting

| Before | After |
| ------- | ------- |
|<img width="576" height="258" alt="Screenshot 2026-05-06 at 1 33 23 AM" src="https://github.com/user-attachments/assets/cba97b72-4e2b-413c-b021-13c51ae11b3b" /> | <img width="576" height="315" alt="Screenshot 2026-05-06 at 1 37 17 AM" src="https://github.com/user-attachments/assets/9cb4be35-a3a1-43d4-ac06-c288387c8b78" /> |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
