### PR TITLE
Fix cancel survey refresh redirecting to confirmation screen

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -1365,9 +1365,8 @@ function CancelPurchaseInner() {
 		// Purchase Settings instead of re-showing the confirmation screen.
 		// Bypass when surveyShown is true — the post-mutation survey should
 		// still render within the same session.
-			isSplitCancelRemoveEnabled &&
-			intent === 'cancel' &&
-			! purchase.is_auto_renew_enabled;
+		const isAlreadyCancelledForSplitFlag =
+			isSplitCancelRemoveEnabled && intent === 'cancel' && ! purchase.is_auto_renew_enabled;
 
 		if ( isAlreadyCancelledForSplitFlag && ! state.surveyShown ) {
 			return false;
@@ -1417,7 +1416,14 @@ function CancelPurchaseInner() {
 		}
 
 		return true;
-	}, [ createErrorNotice, intent, isDataLoading, purchase, state.surveyShown ] );
+	}, [
+		createErrorNotice,
+		intent,
+		isDataLoading,
+		isSplitCancelRemoveEnabled,
+		purchase,
+		state.surveyShown,
+	] );
 
 	const didRunEffect = useRef< boolean >( false );
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -1360,6 +1360,20 @@ function CancelPurchaseInner() {
 			return false;
 		}
 
+		// Under the split flag, if intent=cancel but auto-renew is already off
+		// (e.g. page refresh after cancel-autorenew mutation), redirect to
+		// Purchase Settings instead of re-showing the confirmation screen.
+		// Bypass when surveyShown is true — the post-mutation survey should
+		// still render within the same session.
+		const isAlreadyCancelledForSplitFlag =
+			config.isEnabled( 'purchases/split-cancel-remove' ) &&
+			intent === 'cancel' &&
+			! purchase.is_auto_renew_enabled;
+
+		if ( isAlreadyCancelledForSplitFlag && ! state.surveyShown ) {
+			return false;
+		}
+
 		if ( ! purchase.is_cancelable && state.surveyShown ) {
 			return true;
 		}
@@ -1404,7 +1418,7 @@ function CancelPurchaseInner() {
 		}
 
 		return true;
-	}, [ createErrorNotice, isDataLoading, purchase, state.surveyShown ] );
+	}, [ createErrorNotice, intent, isDataLoading, purchase, state.surveyShown ] );
 
 	const didRunEffect = useRef< boolean >( false );
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -1365,8 +1365,7 @@ function CancelPurchaseInner() {
 		// Purchase Settings instead of re-showing the confirmation screen.
 		// Bypass when surveyShown is true — the post-mutation survey should
 		// still render within the same session.
-		const isAlreadyCancelledForSplitFlag =
-			config.isEnabled( 'purchases/split-cancel-remove' ) &&
+			isSplitCancelRemoveEnabled &&
 			intent === 'cancel' &&
 			! purchase.is_auto_renew_enabled;
 

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -281,6 +281,20 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			return true;
 		}
 
+		// Under the split flag, if intent=cancel but auto-renew is already off
+		// (e.g. page refresh after cancel-autorenew mutation), redirect to
+		// Purchase Settings instead of re-showing the confirmation screen.
+		// Bypass when surveyShown is true — the post-mutation survey should
+		// still render within the same session.
+		if (
+			props.isSplitCancelRemoveEnabled &&
+			props.intent === 'cancel' &&
+			! purchase.isAutoRenewEnabled &&
+			! this.state.surveyShown
+		) {
+			return false;
+		}
+
 		// Under the split flag, any purchase reached via ?intent=remove renders
 		// the unified confirmation screen. Allow through regardless of
 		// canAutoRenewBeTurnedOff so the page doesn't redirect away.
@@ -299,10 +313,18 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		const { purchase, siteSlug } = this.props;
 		let redirectPath = this.props.purchaseListUrl ?? purchasesRoot;
 
+		const isAlreadyCancelledForSplitFlag =
+			this.props.isSplitCancelRemoveEnabled &&
+			this.props.intent === 'cancel' &&
+			purchase &&
+			! purchase.isAutoRenewEnabled;
+
 		if (
 			siteSlug &&
 			purchase &&
-			( ! canAutoRenewBeTurnedOff( purchase ) || isDomainTransfer( purchase ) )
+			( isAlreadyCancelledForSplitFlag ||
+				! canAutoRenewBeTurnedOff( purchase ) ||
+				isDomainTransfer( purchase ) )
 		) {
 			redirectPath = ( this.props.getManagePurchaseUrlFor ?? managePurchase )(
 				siteSlug,


### PR DESCRIPTION
## Summary

This PR fixes a bug where if you try return to the cancel confirmation screen after a subscription has been canceled, it redirects you back to the purchase management screen. This can happen if you cancel, visit the survey, then press back or refresh. 

Remove flow (`?intent=remove`) and the flag-off legacy path are untouched.

## Test plan

- [ ] Navigate to a plan's Purchase Settings, click Cancel subscription (flag on)
- [ ] Confirm cancellation fires, verify post-cancel survey renders
- [ ] Refresh the browser on the survey screen — should redirect to Purchase Settings, not re-show confirmation
- [ ] Navigate directly to `/cancel?intent=cancel` for an already-cancelled purchase — should redirect to Purchase Settings
- [ ] Repeat on both surfaces (`my.localhost:3000` dashboard + `calypso.localhost:3000` legacy)
- [ ] Verify remove flow (`?intent=remove`) is unaffected
- [ ] Verify flag-off behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)