### PR TITLE
Cancel flow: client-side feature list override infrastructure

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import {
 	Icon,
 	__experimentalHStack as HStack,
@@ -15,12 +16,40 @@ import {
 	getSingleItemCancelCopy,
 	getSingleItemRemoveCopy,
 } from './get-confirmation-copy';
+import { getOverrideCancellationFeatures } from './get-override-features';
 import type { Purchase, CancellationFeature } from '@automattic/api-core';
 
 type FeatureObject = {
 	getSlug: () => string;
 	getTitle: ( params?: { domainName?: string } ) => string;
 };
+
+type LossItem = { key: string; title: string };
+
+function getLossItems(
+	overrideFeatures: CancellationFeature[] | null,
+	cancellationFeatures: CancellationFeature[],
+	purchase: Purchase
+): LossItem[] {
+	if ( overrideFeatures ) {
+		return overrideFeatures.map( ( feature ) => ( {
+			key: String( feature.feature_id ),
+			title: feature.title,
+		} ) );
+	}
+	if ( cancellationFeatures.length ) {
+		return cancellationFeatures
+			.filter( ( feature ): feature is CancellationFeature => Boolean( feature ) )
+			.map( ( feature ) => ( {
+				key: String( feature.feature_id ),
+				title: feature.title,
+			} ) );
+	}
+	return getFallbackLossItems( purchase ).map( ( title, idx ) => ( {
+		key: `fallback-${ idx }`,
+		title,
+	} ) );
+}
 
 const CancelPurchaseFeatureList = ( {
 	purchase,
@@ -33,17 +62,14 @@ const CancelPurchaseFeatureList = ( {
 	cancellationFeatures: CancellationFeature[];
 	cancellationChanges: FeatureObject[];
 } ) => {
-	// When the server returns no feature list, fall back to a per-product-type
-	// item so every confirmation screen shows at least one concrete thing the
-	// user is giving up.
-	const lossItems: Array< { key: string; title: string } > = cancellationFeatures.length
-		? cancellationFeatures
-				.filter( ( feature ): feature is CancellationFeature => Boolean( feature ) )
-				.map( ( feature ) => ( { key: String( feature.feature_id ), title: feature.title } ) )
-		: getFallbackLossItems( purchase ).map( ( title, idx ) => ( {
-				key: `fallback-${ idx }`,
-				title,
-		  } ) );
+	// When the split-cancel-remove flag is on, use client-side feature overrides
+	// instead of the server-provided list. Falls back to API features when the
+	// override returns null (no entries yet for this product category).
+	const overrideFeatures = config.isEnabled( 'purchases/split-cancel-remove' )
+		? getOverrideCancellationFeatures( purchase )
+		: null;
+
+	const lossItems = getLossItems( overrideFeatures, cancellationFeatures, purchase );
 
 	if ( ! lossItems.length && ! cancellationChanges.length ) {
 		return null;

--- a/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
@@ -65,7 +65,8 @@ const CancelPurchaseFeatureList = ( {
 	// When the split-cancel-remove flag is on, use client-side feature overrides
 	// instead of the server-provided list. Falls back to API features when the
 	// override returns null (no entries yet for this product category).
-	const overrideFeatures = config.isEnabled( 'purchases/split-cancel-remove' )
+	const isSplitEnabled = useIsSplitCancelRemoveEnabled();
+	const overrideFeatures = isSplitEnabled
 		? getOverrideCancellationFeatures( purchase )
 		: null;
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import {
 	Icon,
 	__experimentalHStack as HStack,
@@ -17,6 +16,7 @@ import {
 	getSingleItemRemoveCopy,
 } from './get-confirmation-copy';
 import { getOverrideCancellationFeatures } from './get-override-features';
+import { useIsSplitCancelRemoveEnabled } from './use-is-split-cancel-remove-enabled';
 import type { Purchase, CancellationFeature } from '@automattic/api-core';
 
 type FeatureObject = {
@@ -66,9 +66,7 @@ const CancelPurchaseFeatureList = ( {
 	// instead of the server-provided list. Falls back to API features when the
 	// override returns null (no entries yet for this product category).
 	const isSplitEnabled = useIsSplitCancelRemoveEnabled();
-	const overrideFeatures = isSplitEnabled
-		? getOverrideCancellationFeatures( purchase )
-		: null;
+	const overrideFeatures = isSplitEnabled ? getOverrideCancellationFeatures( purchase ) : null;
 
 	const lossItems = getLossItems( overrideFeatures, cancellationFeatures, purchase );
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/get-override-features.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/get-override-features.ts
@@ -1,0 +1,69 @@
+import { getProductCategory } from './get-confirmation-copy';
+import type { PurchaseForCopy } from './get-confirmation-copy';
+import type { CancellationFeature } from '@automattic/api-core';
+
+/**
+ * Client-side override for cancellation features. When the split-cancel-remove
+ * flag is on, this replaces the server-provided feature list with
+ * benefit-oriented copy keyed by product slug and category.
+ *
+ * Returns null when no override exists — caller falls back to API features.
+ */
+export function getOverrideCancellationFeatures(
+	purchase: PurchaseForCopy
+): CancellationFeature[] | null {
+	const slug = purchase.product_slug;
+	const category = getProductCategory( purchase );
+
+	switch ( category ) {
+		case 'plan':
+			return getWpcomPlanFeatures( slug );
+		case 'domain':
+			return getDomainFeatures( purchase );
+		case 'email':
+			return getEmailFeatures( slug );
+		case 'jetpack':
+			return getJetpackFeatures( slug );
+		case 'akismet':
+			return getAkismetFeatures();
+		case 'marketplace':
+			return getMarketplaceFeatures( purchase );
+		case 'one-time':
+		case 'other':
+			return getAddonFeatures( slug );
+	}
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getWpcomPlanFeatures( slug: string ): CancellationFeature[] | null {
+	return null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getDomainFeatures( purchase: PurchaseForCopy ): CancellationFeature[] | null {
+	return null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getEmailFeatures( slug: string ): CancellationFeature[] | null {
+	return null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getJetpackFeatures( slug: string ): CancellationFeature[] | null {
+	return null;
+}
+
+function getAkismetFeatures(): CancellationFeature[] | null {
+	return null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getMarketplaceFeatures( purchase: PurchaseForCopy ): CancellationFeature[] | null {
+	return null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getAddonFeatures( slug: string ): CancellationFeature[] | null {
+	return null;
+}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/test/get-override-features.test.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/test/get-override-features.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment jsdom
+ */
+jest.mock( '@automattic/api-core', () => ( {
+	GoogleWorkspaceSlugs: {
+		GSUITE_BASIC_SLUG: 'gsuite-basic',
+		GSUITE_BUSINESS_SLUG: 'gsuite-business',
+	},
+	AkismetPlans: {},
+	TitanMailSlugs: {
+		TITAN_MAIL_MONTHLY_SLUG: 'titan-mail-monthly',
+		TITAN_MAIL_YEARLY_SLUG: 'titan-mail-yearly',
+	},
+} ) );
+
+import { getOverrideCancellationFeatures } from '../get-override-features';
+import type { PurchaseForCopy } from '../get-confirmation-copy';
+
+function makePurchase( overrides: Partial< PurchaseForCopy > = {} ): PurchaseForCopy {
+	return {
+		is_plan: false,
+		is_domain_registration: false,
+		is_jetpack_plan_or_product: false,
+		product_slug: 'test-product',
+		product_name: 'Test Product',
+		product_type: 'other',
+		expiry_date: '2027-04-16',
+		expiry_status: 'manual-renew',
+		domain: 'example.com',
+		...overrides,
+	} as PurchaseForCopy;
+}
+
+describe( 'getOverrideCancellationFeatures', () => {
+	it( 'returns null for a plan purchase (no entries yet)', () => {
+		const purchase = makePurchase( {
+			is_plan: true,
+			product_slug: 'business-bundle',
+			product_name: 'WordPress.com Business',
+		} );
+		expect( getOverrideCancellationFeatures( purchase ) ).toBeNull();
+	} );
+
+	it( 'returns null for a domain purchase', () => {
+		const purchase = makePurchase( {
+			is_domain_registration: true,
+			product_slug: 'dotcom_domain',
+			product_name: 'example.com',
+		} );
+		expect( getOverrideCancellationFeatures( purchase ) ).toBeNull();
+	} );
+
+	it( 'returns null for a Jetpack purchase', () => {
+		const purchase = makePurchase( {
+			is_jetpack_plan_or_product: true,
+			product_slug: 'jetpack_security_daily',
+			product_name: 'Jetpack Security',
+		} );
+		expect( getOverrideCancellationFeatures( purchase ) ).toBeNull();
+	} );
+} );

--- a/client/me/purchases/cancel-purchase/feature-list.tsx
+++ b/client/me/purchases/cancel-purchase/feature-list.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import moment from 'moment';
 import {
@@ -7,10 +8,37 @@ import {
 	getSingleItemCancelCopy,
 	getSingleItemRemoveCopy,
 } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy';
+import { getOverrideCancellationFeatures } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/get-override-features';
 import { toPurchaseForCopy } from './to-purchase-for-copy';
 import type { CancellationFeature } from '@automattic/api-core';
 import type { Purchases } from '@automattic/data-stores';
+import type { PurchaseForCopy } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy';
 import type { DisplayVariant } from 'calypso/lib/purchases/utils';
+
+type LossItem = { key: string; title: string };
+
+function getLossItems(
+	overrideFeatures: CancellationFeature[] | null,
+	cancellationFeatures: CancellationFeature[],
+	adapted: PurchaseForCopy
+): LossItem[] {
+	if ( overrideFeatures ) {
+		return overrideFeatures.map( ( feature ) => ( {
+			key: String( feature.feature_id ),
+			title: feature.title,
+		} ) );
+	}
+	if ( cancellationFeatures.length ) {
+		return cancellationFeatures.map( ( feature ) => ( {
+			key: feature.feature_id,
+			title: feature.title,
+		} ) );
+	}
+	return getFallbackLossItems( adapted ).map( ( title, idx ) => ( {
+		key: `fallback-${ idx }`,
+		title,
+	} ) );
+}
 
 const CancelPurchaseFeatureList = ( {
 	purchase,
@@ -22,16 +50,15 @@ const CancelPurchaseFeatureList = ( {
 	cancellationFeatures: CancellationFeature[];
 } ) => {
 	const adapted = toPurchaseForCopy( purchase );
-	// When the server returns no features, fall back to a per-product-type item.
-	const items: Array< { key: string; title: string } > = cancellationFeatures.length
-		? cancellationFeatures.map( ( feature ) => ( {
-				key: feature.feature_id,
-				title: feature.title,
-		  } ) )
-		: getFallbackLossItems( adapted ).map( ( title, idx ) => ( {
-				key: `fallback-${ idx }`,
-				title,
-		  } ) );
+
+	// When the split-cancel-remove flag is on, use client-side feature overrides
+	// instead of the server-provided list. Falls back to API features when the
+	// override returns null (no entries yet for this product category).
+	const overrideFeatures = config.isEnabled( 'purchases/split-cancel-remove' )
+		? getOverrideCancellationFeatures( adapted )
+		: null;
+
+	const items = getLossItems( overrideFeatures, cancellationFeatures, adapted );
 
 	if ( ! items.length ) {
 		return null;

--- a/client/me/purchases/cancel-purchase/feature-list.tsx
+++ b/client/me/purchases/cancel-purchase/feature-list.tsx
@@ -53,9 +53,10 @@ const CancelPurchaseFeatureList = ( {
 
 	// When the split-cancel-remove flag is on, use client-side feature overrides
 	// instead of the server-provided list. Falls back to API features when the
-	// override returns null (no entries yet for this product category).
-	const overrideFeatures = config.isEnabled( 'purchases/split-cancel-remove' )
+	const isSplitEnabled = useIsSplitCancelRemoveEnabled();
+	const overrideFeatures = isSplitEnabled
 		? getOverrideCancellationFeatures( adapted )
+		: null;
 		: null;
 
 	const items = getLossItems( overrideFeatures, cancellationFeatures, adapted );

--- a/client/me/purchases/cancel-purchase/feature-list.tsx
+++ b/client/me/purchases/cancel-purchase/feature-list.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import moment from 'moment';
 import {
@@ -9,6 +8,7 @@ import {
 	getSingleItemRemoveCopy,
 } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy';
 import { getOverrideCancellationFeatures } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/get-override-features';
+import { useIsSplitCancelRemoveEnabled } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/use-is-split-cancel-remove-enabled';
 import { toPurchaseForCopy } from './to-purchase-for-copy';
 import type { CancellationFeature } from '@automattic/api-core';
 import type { Purchases } from '@automattic/data-stores';
@@ -54,10 +54,7 @@ const CancelPurchaseFeatureList = ( {
 	// When the split-cancel-remove flag is on, use client-side feature overrides
 	// instead of the server-provided list. Falls back to API features when the
 	const isSplitEnabled = useIsSplitCancelRemoveEnabled();
-	const overrideFeatures = isSplitEnabled
-		? getOverrideCancellationFeatures( adapted )
-		: null;
-		: null;
+	const overrideFeatures = isSplitEnabled ? getOverrideCancellationFeatures( adapted ) : null;
 
 	const items = getLossItems( overrideFeatures, cancellationFeatures, adapted );
 


### PR DESCRIPTION
Part of: https://linear.app/a8c/issue/RSM-478

## Proposed Changes

This PR sets the stage for some content updates we're going to make across a range of products. Once all the updates are in, we'll have a product feature list for our plans, domains, add-ons, all Jetpack plans, and emails.

More details about the updates in this PR:
- Add `getOverrideCancellationFeatures()` — a category-routing skeleton that returns `null` for all product types. When the `purchases/split-cancel-remove` flag is on, both surfaces call this before falling back to the server-provided feature list.
- Wire the override into `CancelPurchaseFeatureList` on both dashboard and legacy surfaces.
- Add 3 skeleton tests confirming all stubs return `null`.

## Why are these changes being made?

RSM-478 replaces server-provided cancellation feature lists with benefit-oriented copy for 22 product types. This PR builds only the plumbing — the function skeleton and wiring into both surfaces. Product-specific feature entries are added in 4 independent follow-up PRs (plans, domains/email, marketplace, Jetpack), each off trunk, each needing only this infra PR merged first.

No visible behavior change — all stubs return `null`, so the override path always falls through to existing API features. Pure plumbing behind `purchases/split-cancel-remove`.

## Testing Instructions

1. Enable `purchases/split-cancel-remove` in Calypso config
2. Navigate to any purchase's cancel confirmation screen on both surfaces
3. Verify the feature list renders identically to trunk — the override stubs all return `null`, so existing server-provided features should display unchanged
4. Disable the flag and confirm no change

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?