### PR TITLE
E2E: match renamed "Use a domain I own" button

### DIFF
--- a/packages/calypso-e2e/src/lib/components/domain-search-component.ts
+++ b/packages/calypso-e2e/src/lib/components/domain-search-component.ts
@@ -82,7 +82,7 @@ export class DomainSearchComponent {
 	 * Clicks on the button to use a domain I already own
 	 */
 	async clickUseADomainIAlreadyOwn(): Promise< void > {
-		await this.page.getByRole( 'button', { name: 'Use a domain I already own' } ).click();
+		await this.page.getByRole( 'button', { name: 'Use a domain I own' } ).click();
 	}
 
 	/**


### PR DESCRIPTION
## Proposed Changes

* Update `DomainSearchComponent.clickUseADomainIAlreadyOwn` to look for the renamed button label "Use a domain I own" (was "Use a domain I already own").

## Why are these changes being made?

* #110464 renamed the button in the stepper domain-search step. `setup-onboarding__flows.spec.ts` started failing on `clickUseADomainIAlreadyOwn` because the locator no longer matches.

## Testing Instructions

* `cd test/e2e && yarn test:pw specs/flows/setup-onboarding__flows.spec.ts` — all 7 tests pass on chrome + pixel projects.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE).
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?