### PR TITLE
E2E: curate pre-release suite; require CALYPSO_PR on release specs

### DIFF
--- a/test/e2e/specs/authentication/authentication__login-localized-hydration.spec.ts
+++ b/test/e2e/specs/authentication/authentication__login-localized-hydration.spec.ts
@@ -3,7 +3,7 @@ import { tags, test, expect } from '../../lib/pw-base';
 
 test.describe(
 	'Authentication: Login SSR + hydration (localized)',
-	{ tag: [ tags.AUTHENTICATION, tags.CALYPSO_RELEASE ] },
+	{ tag: [ tags.AUTHENTICATION, tags.CALYPSO_PR, tags.CALYPSO_RELEASE ] },
 	() => {
 		test( 'Default locale: headings SSR and controls interactive', async ( { page } ) => {
 			await page.goto( DataHelper.getCalypsoURL( 'log-in' ), {

--- a/test/e2e/specs/dashboard/dashboard__basic-and-routing.spec.ts
+++ b/test/e2e/specs/dashboard/dashboard__basic-and-routing.spec.ts
@@ -2,7 +2,7 @@ import { expect, tags, test } from '../../lib/pw-base';
 
 test.describe(
 	'Dashboard: Basic & Routing',
-	{ tag: [ tags.DASHBOARD_PR, tags.CALYPSO_RELEASE ] },
+	{ tag: [ tags.CALYPSO_PR, tags.CALYPSO_RELEASE, tags.DASHBOARD_PR ] },
 	() => {
 		test( 'As a WordPress.com user, I can see the new Multi-site Dashboard page as a list of my sites', async ( {
 			accountGivenByEnvironment,

--- a/test/e2e/specs/domain-upsell/domain-upsell__my-home.spec.ts
+++ b/test/e2e/specs/domain-upsell/domain-upsell__my-home.spec.ts
@@ -3,7 +3,7 @@ import { expect, skipIfMailosaurLimitReached, tags, test } from '../../lib/pw-ba
 test.describe(
 	'Domain: Upsell (Home)',
 	{
-		tag: [ tags.CALYPSO_RELEASE ],
+		tag: [ tags.CALYPSO_PR, tags.CALYPSO_RELEASE ],
 	},
 	() => {
 		skipIfMailosaurLimitReached();

--- a/test/e2e/specs/domain-upsell/domain-upsell__sidebar.spec.ts
+++ b/test/e2e/specs/domain-upsell/domain-upsell__sidebar.spec.ts
@@ -1,6 +1,6 @@
 import { expect, skipIfMailosaurLimitReached, tags, test } from '../../lib/pw-base';
 
-test.describe( 'Domain: Upsell (Sidebar)', { tag: [ tags.CALYPSO_RELEASE ] }, () => {
+test.describe( 'Domain: Upsell (Sidebar)', { tag: [ tags.CALYPSO_PR ] }, () => {
 	skipIfMailosaurLimitReached();
 
 	const planName = 'Premium';

--- a/test/e2e/specs/domains/domains__add.spec.ts
+++ b/test/e2e/specs/domains/domains__add.spec.ts
@@ -4,7 +4,7 @@ import { expect, skipIfMailosaurLimitReached, tags, test } from '../../lib/pw-ba
 test.describe(
 	'Domains: Add to current site',
 	{
-		tag: [ tags.CALYPSO_RELEASE ],
+		tag: [ tags.CALYPSO_PR, tags.CALYPSO_RELEASE ],
 	},
 	() => {
 		skipIfMailosaurLimitReached();

--- a/test/e2e/specs/flows/setup-domain-and-plan__skip-plan.spec.ts
+++ b/test/e2e/specs/flows/setup-domain-and-plan__skip-plan.spec.ts
@@ -1,6 +1,6 @@
 import { tags, test } from '../../lib/pw-base';
 
-test.describe( 'Domain: Upsell (Skip Plan)', { tag: [ tags.CALYPSO_RELEASE ] }, () => {
+test.describe( 'Domain: Upsell (Skip Plan)', { tag: [ tags.CALYPSO_PR ] }, () => {
 	test( 'As a user with a qualifying yearly plan, I skip plan selection and go directly to checkout', async ( {
 		accountAtomic,
 		componentDomainSearch,

--- a/test/e2e/specs/flows/setup-domain__flows.spec.ts
+++ b/test/e2e/specs/flows/setup-domain__flows.spec.ts
@@ -12,7 +12,7 @@ import { apiCloseAccount, apiDeleteSite } from '../shared';
 test.describe(
 	'Setup Domain Flows',
 	{
-		tag: [ tags.CALYPSO_RELEASE ],
+		tag: [ tags.CALYPSO_PR ],
 	},
 	() => {
 		const accountsToCleanup: {

--- a/test/e2e/specs/flows/setup-hundred-year-domain.spec.ts
+++ b/test/e2e/specs/flows/setup-hundred-year-domain.spec.ts
@@ -10,7 +10,7 @@ import { apiCloseAccount } from '../shared';
 test.describe(
 	'Setup Hundred Year Domain Flow',
 	{
-		tag: [ tags.CALYPSO_RELEASE ],
+		tag: [ tags.CALYPSO_PR ],
 	},
 	() => {
 		const accountsToCleanup: {

--- a/test/e2e/specs/flows/setup-onboarding__flows.spec.ts
+++ b/test/e2e/specs/flows/setup-onboarding__flows.spec.ts
@@ -11,7 +11,7 @@ import { apiCloseAccount, apiDeleteSite } from '../shared';
 test.describe(
 	'Setup Onboarding Flows',
 	{
-		tag: [ tags.CALYPSO_RELEASE ],
+		tag: [ tags.CALYPSO_PR ],
 	},
 	() => {
 		const accountsToCleanup: {
@@ -69,46 +69,50 @@ test.describe(
 			} );
 		} );
 
-		test( 'As a new user, I can complete the onboarding flow and purchase a plan without a custom domain', async ( {
-			page,
-			componentDomainSearch,
-			helperData,
-			pageCartCheckout,
-			pageSignupPickPlan,
-			pageUserSignUp,
-		} ) => {
-			const testUser = helperData.getNewTestUser();
-			const planName = 'Personal';
-			let newUserDetails: NewUserResponse;
-			let newSiteDetails: NewSiteResponse;
+		test(
+			'As a new user, I can complete the onboarding flow and purchase a plan without a custom domain',
+			{ tag: [ tags.CALYPSO_RELEASE ] },
+			async ( {
+				page,
+				componentDomainSearch,
+				helperData,
+				pageCartCheckout,
+				pageSignupPickPlan,
+				pageUserSignUp,
+			} ) => {
+				const testUser = helperData.getNewTestUser();
+				const planName = 'Personal';
+				let newUserDetails: NewUserResponse;
+				let newSiteDetails: NewSiteResponse;
 
-			await test.step( 'When I enter the onboarding flow', async function () {
-				BrowserManager.setStoreCookie( page, { currency: 'USD' } );
-				await page.goto( helperData.getCalypsoURL( '/setup/onboarding' ) );
-			} );
+				await test.step( 'When I enter the onboarding flow', async function () {
+					BrowserManager.setStoreCookie( page, { currency: 'USD' } );
+					await page.goto( helperData.getCalypsoURL( '/setup/onboarding' ) );
+				} );
 
-			await test.step( 'And I sign up as a new user', async function () {
-				newUserDetails = await pageUserSignUp.signupSocialFirstWithEmail( testUser.email );
-			} );
+				await test.step( 'And I sign up as a new user', async function () {
+					newUserDetails = await pageUserSignUp.signupSocialFirstWithEmail( testUser.email );
+				} );
 
-			await test.step( 'And I skip domain purchase', async function () {
-				await componentDomainSearch.search( helperData.getBlogName() );
-				await componentDomainSearch.skipPurchase();
-			} );
+				await test.step( 'And I skip domain purchase', async function () {
+					await componentDomainSearch.search( helperData.getBlogName() );
+					await componentDomainSearch.skipPurchase();
+				} );
 
-			await test.step( `And I select the ${ planName } plan`, async function () {
-				newSiteDetails = await pageSignupPickPlan.selectPlan( planName );
-				accountsToCleanup.push( { testUser, newUserDetails, newSiteDetails } );
-			} );
+				await test.step( `And I select the ${ planName } plan`, async function () {
+					newSiteDetails = await pageSignupPickPlan.selectPlan( planName );
+					accountsToCleanup.push( { testUser, newUserDetails, newSiteDetails } );
+				} );
 
-			await test.step( 'Then I see the plan at checkout', async function () {
-				await pageCartCheckout.validateCartItem( `WordPress.com ${ planName }` );
-			} );
+				await test.step( 'Then I see the plan at checkout', async function () {
+					await pageCartCheckout.validateCartItem( `WordPress.com ${ planName }` );
+				} );
 
-			await test.step( 'And I see only one item in the cart', async function () {
-				await pageCartCheckout.validateCartItemsCount( 1 );
-			} );
-		} );
+				await test.step( 'And I see only one item in the cart', async function () {
+					await pageCartCheckout.validateCartItemsCount( 1 );
+				} );
+			}
+		);
 
 		test( 'As a new user, I can complete the onboarding flow with domain transfer and plan purchase', async ( {
 			page,

--- a/test/e2e/specs/flows/start-domain__purchase-flows.spec.ts
+++ b/test/e2e/specs/flows/start-domain__purchase-flows.spec.ts
@@ -11,7 +11,7 @@ import { apiCloseAccount, apiDeleteSite } from '../shared';
 test.describe(
 	'Start Domain Only Flows',
 	{
-		tag: [ tags.CALYPSO_RELEASE ],
+		tag: [ tags.CALYPSO_PR ],
 	},
 	() => {
 		const accountsToCleanup: {

--- a/test/e2e/specs/flows/start-launch-site__flows.spec.ts
+++ b/test/e2e/specs/flows/start-launch-site__flows.spec.ts
@@ -11,7 +11,7 @@ import { apiCloseAccount, apiDeleteSite } from '../shared';
 test.describe(
 	'Launch Site Flows',
 	{
-		tag: [ tags.CALYPSO_RELEASE ],
+		tag: [ tags.CALYPSO_PR ],
 	},
 	() => {
 		const accountsToCleanup: {

--- a/test/e2e/specs/importer/importer__site-setup.spec.ts
+++ b/test/e2e/specs/importer/importer__site-setup.spec.ts
@@ -3,7 +3,7 @@ import { tags, test } from '../../lib/pw-base';
 test.describe(
 	'Importer: Site Setup',
 	{
-		tag: [ tags.CALYPSO_PR, tags.CALYPSO_RELEASE ],
+		tag: [ tags.CALYPSO_PR ],
 	},
 	() => {
 		let siteSlug: string;

--- a/test/e2e/specs/onboarding/launch-site__wp-admin.spec.ts
+++ b/test/e2e/specs/onboarding/launch-site__wp-admin.spec.ts
@@ -9,7 +9,14 @@ import { apiCloseAccount, apiDeleteSite, swapBaseUrl } from '../shared';
 
 test.describe(
 	'Onboarding: Launch site from WP Admin',
-	{ tag: [ tags.CALYPSO_RELEASE, tags.JETPACK_WPCOM_INTEGRATION, tags.DESKTOP_ONLY ] },
+	{
+		tag: [
+			tags.CALYPSO_PR,
+			tags.CALYPSO_RELEASE,
+			tags.JETPACK_WPCOM_INTEGRATION,
+			tags.DESKTOP_ONLY,
+		],
+	},
 	() => {
 		const accountsToCleanup: {
 			testUser: NewTestUserDetails;

--- a/test/e2e/specs/onboarding/signup__start-writing-tailored.spec.ts
+++ b/test/e2e/specs/onboarding/signup__start-writing-tailored.spec.ts
@@ -5,7 +5,7 @@ import { apiCloseAccount } from '../shared';
 test.describe(
 	'Signup: Tailored Start Writing Flow',
 	{
-		tag: [ tags.CALYPSO_RELEASE ],
+		tag: [ tags.CALYPSO_PR ],
 		annotation: {
 			type: 'flowchart',
 			description:

--- a/test/e2e/specs/onboarding/signup__with-theme-LOHP.spec.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-LOHP.spec.ts
@@ -10,7 +10,7 @@ import { apiCloseAccount } from '../shared';
 test.describe(
 	'Signup: Lifecycle: Logged Out Home Page, signup, onboard, launch and cancel subscription',
 	{
-		tag: [ tags.CALYPSO_RELEASE, tags.CALYPSO_PR ],
+		tag: [ tags.CALYPSO_PR ],
 		annotation: {
 			type: 'flowchart',
 			description:

--- a/test/e2e/specs/plans/plans__signup-business.spec.ts
+++ b/test/e2e/specs/plans/plans__signup-business.spec.ts
@@ -6,7 +6,7 @@ import type { NewSiteResponse, TestAccount } from '@automattic/calypso-e2e';
 test.describe(
 	'Plans: Create a WordPress.com/Business site as existing user',
 	{
-		tag: [ tags.CALYPSO_RELEASE ],
+		tag: [ tags.CALYPSO_PR ],
 	},
 	() => {
 		const planName = 'Business';

--- a/test/e2e/specs/tools/import__sites-medium.spec.ts
+++ b/test/e2e/specs/tools/import__sites-medium.spec.ts
@@ -10,7 +10,7 @@ const TEST_MEDIUM_EXPORT_FILE_PATH = path.join(
 test.describe(
 	'Site Import: Calypso: Medium',
 	{
-		tag: [ tags.CALYPSO_RELEASE, tags.IMPORTS, tags.DESKTOP_ONLY ],
+		tag: [ tags.CALYPSO_PR, tags.IMPORTS, tags.DESKTOP_ONLY ],
 		annotation: {
 			type: 'flowchart',
 			description:

--- a/test/e2e/specs/tools/import__sites-squarespace.spec.ts
+++ b/test/e2e/specs/tools/import__sites-squarespace.spec.ts
@@ -10,7 +10,7 @@ const TEST_SQUARESPACE_EXPORT_FILE_PATH = path.join(
 test.describe(
 	'Site Import: Calypso: Squarespace',
 	{
-		tag: [ tags.CALYPSO_RELEASE, tags.IMPORTS, tags.DESKTOP_ONLY ],
+		tag: [ tags.CALYPSO_PR, tags.IMPORTS, tags.DESKTOP_ONLY ],
 		annotation: {
 			type: 'flowchart',
 			description:

--- a/test/e2e/specs/tools/import__sites-substack.spec.ts
+++ b/test/e2e/specs/tools/import__sites-substack.spec.ts
@@ -6,7 +6,7 @@ const TEST_SUBSTACK_EXPORT_FILE_PATH = path.join( __dirname, 'import-files', 'su
 test.describe(
 	'Site Import: Calypso: Substack',
 	{
-		tag: [ tags.CALYPSO_RELEASE, tags.IMPORTS, tags.DESKTOP_ONLY ],
+		tag: [ tags.CALYPSO_PR, tags.IMPORTS, tags.DESKTOP_ONLY ],
 		annotation: {
 			type: 'flowchart',
 			description:

--- a/test/e2e/specs/tools/import__sites-wordpress.spec.ts
+++ b/test/e2e/specs/tools/import__sites-wordpress.spec.ts
@@ -10,7 +10,7 @@ const TEST_WORDPRESS_EXPORT_FILE_PATH = path.join(
 test.describe(
 	'Site Import: Calypso: WordPress',
 	{
-		tag: [ tags.CALYPSO_RELEASE, tags.IMPORTS, tags.DESKTOP_ONLY ],
+		tag: [ tags.CALYPSO_PR, tags.IMPORTS, tags.DESKTOP_ONLY ],
 		annotation: {
 			type: 'flowchart',
 			description:

--- a/test/e2e/specs/users/invite__revoke.spec.ts
+++ b/test/e2e/specs/users/invite__revoke.spec.ts
@@ -1,86 +1,80 @@
 import { DataHelper, SecretsManager } from '@automattic/calypso-e2e';
 import { expect, skipIfMailosaurLimitReached, tags, test } from '../../lib/pw-base';
 
-test.describe(
-	'Invite: Revoke',
-	{ tag: [ tags.CALYPSO_PR, tags.CALYPSO_RELEASE, tags.DESKTOP_ONLY ] },
-	() => {
-		skipIfMailosaurLimitReached();
-		const testUser = DataHelper.getNewTestUser( {
-			useMailosaur: true,
-			usernamePrefix: 'e2eflowtestinginvite',
-		} );
-		const inboxId = testUser.inboxId;
-		const testEmailAddress = testUser.email;
-		const role = 'Editor';
-		const inviteMessage = `Test invite for role of ${ role }`;
-		const credentials = SecretsManager.secrets.testAccounts.defaultUser;
+test.describe( 'Invite: Revoke', { tag: [ tags.CALYPSO_PR, tags.DESKTOP_ONLY ] }, () => {
+	skipIfMailosaurLimitReached();
+	const testUser = DataHelper.getNewTestUser( {
+		useMailosaur: true,
+		usernamePrefix: 'e2eflowtestinginvite',
+	} );
+	const inboxId = testUser.inboxId;
+	const testEmailAddress = testUser.email;
+	const role = 'Editor';
+	const inviteMessage = `Test invite for role of ${ role }`;
+	const credentials = SecretsManager.secrets.testAccounts.defaultUser;
 
-		let acceptInviteLink: string;
-		let userManagementRevampFeature = false;
+	let acceptInviteLink: string;
+	let userManagementRevampFeature = false;
 
-		test( 'As a site owner, I can revoke a pending invite so that the invitation link becomes invalid', async ( {
-			page,
-			componentSidebar,
-			clientEmail,
-			pageIncognito,
-			pagePeople,
-			accountDefaultUser,
-		} ) => {
-			await test.step( 'Given I create an invite via REST API', async function () {
-				const { RestAPIClient } = await import( '@automattic/calypso-e2e' );
-				const restAPIClient = new RestAPIClient( credentials );
+	test( 'As a site owner, I can revoke a pending invite so that the invitation link becomes invalid', async ( {
+		page,
+		componentSidebar,
+		clientEmail,
+		pageIncognito,
+		pagePeople,
+		accountDefaultUser,
+	} ) => {
+		await test.step( 'Given I create an invite via REST API', async function () {
+			const { RestAPIClient } = await import( '@automattic/calypso-e2e' );
+			const restAPIClient = new RestAPIClient( credentials );
 
-				await restAPIClient.createInvite( credentials.testSites?.primary?.id as number, {
-					email: [ testEmailAddress ],
-					role: role,
-					message: inviteMessage,
-				} );
-			} );
-
-			await test.step( 'When the invite email is received', async function () {
-				const message = await clientEmail.getLastMatchingMessage( {
-					inboxId: inboxId,
-					sentTo: testEmailAddress,
-				} );
-				const links = await clientEmail.getLinksFromMessage( message );
-				acceptInviteLink = links.find( ( link: string ) =>
-					link.includes( 'accept-invite' )
-				) as string;
-				expect( acceptInviteLink ).toBeDefined();
-			} );
-
-			await test.step( 'And I log in as the site owner', async function () {
-				await accountDefaultUser.authenticate( page );
-
-				userManagementRevampFeature = await page.evaluate(
-					"configData.features['user-management-revamp']"
-				);
-			} );
-
-			await test.step( 'When I navigate to Users > All Users', async function () {
-				await componentSidebar.navigate( 'Users', 'All Users' );
-				! userManagementRevampFeature && ( await pagePeople.clickTab( 'Invites' ) );
-			} );
-
-			await test.step( 'Then I can see the invite is pending', async function () {
-				await pagePeople.waitForInvitation( testEmailAddress );
-			} );
-
-			await test.step( 'When I select the invited user', async function () {
-				await pagePeople.selectInvitation( testEmailAddress );
-			} );
-
-			await test.step( 'And I revoke the invite', async function () {
-				await pagePeople.revokeInvite();
-			} );
-
-			await test.step( 'Then the invite link is no longer valid', async function () {
-				await pageIncognito.goto( acceptInviteLink );
-				await expect(
-					pageIncognito.getPage().getByText( 'That invite is not valid' )
-				).toBeVisible();
+			await restAPIClient.createInvite( credentials.testSites?.primary?.id as number, {
+				email: [ testEmailAddress ],
+				role: role,
+				message: inviteMessage,
 			} );
 		} );
-	}
-);
+
+		await test.step( 'When the invite email is received', async function () {
+			const message = await clientEmail.getLastMatchingMessage( {
+				inboxId: inboxId,
+				sentTo: testEmailAddress,
+			} );
+			const links = await clientEmail.getLinksFromMessage( message );
+			acceptInviteLink = links.find( ( link: string ) =>
+				link.includes( 'accept-invite' )
+			) as string;
+			expect( acceptInviteLink ).toBeDefined();
+		} );
+
+		await test.step( 'And I log in as the site owner', async function () {
+			await accountDefaultUser.authenticate( page );
+
+			userManagementRevampFeature = await page.evaluate(
+				"configData.features['user-management-revamp']"
+			);
+		} );
+
+		await test.step( 'When I navigate to Users > All Users', async function () {
+			await componentSidebar.navigate( 'Users', 'All Users' );
+			! userManagementRevampFeature && ( await pagePeople.clickTab( 'Invites' ) );
+		} );
+
+		await test.step( 'Then I can see the invite is pending', async function () {
+			await pagePeople.waitForInvitation( testEmailAddress );
+		} );
+
+		await test.step( 'When I select the invited user', async function () {
+			await pagePeople.selectInvitation( testEmailAddress );
+		} );
+
+		await test.step( 'And I revoke the invite', async function () {
+			await pagePeople.revokeInvite();
+		} );
+
+		await test.step( 'Then the invite link is no longer valid', async function () {
+			await pageIncognito.goto( acceptInviteLink );
+			await expect( pageIncognito.getPage().getByText( 'That invite is not valid' ) ).toBeVisible();
+		} );
+	} );
+} );


### PR DESCRIPTION
Read more at p4TIVU-b6O-p2

## Proposed Changes

* `CALYPSO_RELEASE` specs now also carry `CALYPSO_PR` — failures surface on PR, not just in the merge queue.
* Demote heavy flow / signup / checkout / importer specs out of `CALYPSO_RELEASE`.
* `setup-onboarding__flows`: PR tag on the describe; per-test `CALYPSO_RELEASE` on test #2 only (skip-domain variant) — keeps canonical `/setup/onboarding` smoke without dragging the other two onboarding tests into canary.

Pre-release smoke set after this PR:
- `authentication__login-localized-hydration`
- `dashboard__basic-and-routing`
- `domain-upsell__my-home`
- `domains__add`
- `launch-site__wp-admin`
- `me__smoke`
- `setup-onboarding__flows` test #2 only

## Why are these changes being made?

Pre-release ("canary") suite had grown to 22 specs while only 8 carried `CALYPSO_PR`. Heavy specs gated deploys but gave no PR signal — green PRs blew up post-merge. Curating the canary back to a focused smoke set, while routing every release-blocking spec through PR, gives PR-time feedback and shrinks canary runtime.

## Testing Instructions

* `grep -rl 'CALYPSO_RELEASE' test/e2e/specs` → 7 files; per-test occurrence in `setup-onboarding__flows.spec.ts` is on test #2.
* `grep -rl 'CALYPSO_PR' test/e2e/specs` → 26 files.
* Dry-run tag filters:
  * \`cd test/e2e && yarn playwright test --grep '@calypso-release' --list\`
  * \`cd test/e2e && yarn playwright test --grep '@calypso-pr' --list\`
* \`yarn lint:js test/e2e/specs\` clean.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?