### PR TITLE
Unified Connection: dynamic family-driven subtitles (3/5)

### DIFF
--- a/client/jetpack-connect/connection-content/copy.ts
+++ b/client/jetpack-connect/connection-content/copy.ts
@@ -60,7 +60,7 @@ function getLoginSubtitles(): Record< SubtitleScenario, string > {
 			'Your site is registered with WordPress.com — finish connecting your account to manage it from Automattic for Agencies and power Jetpack features.'
 		),
 		ALL_THREE: __(
-			'Your store is registered with WordPress.com — finish connecting your account to manage it from your Automattic for Agencies dashboard, use the Woo mobile app, access store analytics, and power Jetpack features.'
+			'Your store is registered with WordPress.com — finish connecting your account to manage it from Automattic for Agencies, use the Woo mobile app and store analytics, and power Jetpack features.'
 		),
 		WOO_ONLY: __(
 			'Your store is registered with WordPress.com — finish connecting your account to use the Woo mobile app and access your store analytics.'
@@ -132,7 +132,7 @@ function getAuthSubtitles(): Record< SubtitleScenario, string > {
 			'Your site is registered with WordPress.com — connect this account to manage it from Automattic for Agencies and activate Jetpack.'
 		),
 		ALL_THREE: __(
-			'Your store is registered with WordPress.com — connect this account to manage it from your Automattic for Agencies dashboard, use the Woo mobile app, access store analytics, and activate Jetpack.'
+			'Your store is registered with WordPress.com — connect this account to manage it from Automattic for Agencies, use the Woo mobile app and store analytics, and activate Jetpack.'
 		),
 		WOO_ONLY: __(
 			'Your store is registered with WordPress.com — connect this account to use the Woo mobile app and access your store analytics.'
@@ -204,7 +204,7 @@ function getSignupSubtitles(): Record< SubtitleScenario, string > {
 			"You'll use it to manage your site from Automattic for Agencies and power Jetpack features."
 		),
 		ALL_THREE: __(
-			"You'll use it to manage your store from Automattic for Agencies, log in to the Woo mobile app, view store analytics, and power Jetpack features."
+			"You'll use it to manage your store from Automattic for Agencies, log in to the Woo mobile app and view store analytics, and power Jetpack features."
 		),
 		WOO_ONLY: __( "You'll use it to log in to the Woo mobile app and view your store analytics." ),
 		WOO_AND_PAY: __(

--- a/client/jetpack-connect/connection-content/copy.ts
+++ b/client/jetpack-connect/connection-content/copy.ts
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { getSubtitleScenario, type SubtitleScenario } from './scenarios';
 import { isStore } from './selectors';
 
 export interface SurfaceCopy {
@@ -8,13 +9,12 @@ export interface SurfaceCopy {
 
 /**
  * Acknowledge that the site (or store) has already been registered with
- * WordPress.com. The auth/login/signup pages all surface this as the lead
- * line of their subtitle while the rest of the dynamic-copy system rolls in.
+ * WordPress.com.
  *
- * In a follow-up PR this becomes one component of a longer subtitle that
- * also describes the active plugin families' benefits; for now it stands
- * alone, so we ship two pre-composed sentences (one per noun) rather than
- * a template — translators get a real sentence, not a fragment.
+ * Public for callers that need just the lead clause (e.g. site-only
+ * intermediate states elsewhere in the connector flow). The login and auth
+ * surface subtitles in PR 3 are fully pre-composed and don't compose this
+ * helper at runtime — translators always see complete sentences.
  */
 export function getRegistrationAcknowledgement( pluginSlugs: readonly string[] = [] ): string {
 	return isStore( pluginSlugs )
@@ -23,54 +23,264 @@ export function getRegistrationAcknowledgement( pluginSlugs: readonly string[] =
 }
 
 /**
+ * Pre-composed login-surface subtitles, one per scenario.
+ *
+ * Template (internal, not exposed to translators):
+ *   `Your {site|store} is registered with WordPress.com — finish
+ *    connecting your account to {benefit}.`
+ *
+ * Each entry is a complete `__()`-wrapped sentence so translators receive
+ * a real sentence (not a fragment) and can reorder clauses as the target
+ * language requires.
+ *
+ * Two scenarios reuse another scenario's string by design (per the plan's
+ * "simplest solution" rule):
+ *  - `JETPACK_MULTI` reuses `JETPACK_FULL`: when multiple individual
+ *    Jetpack plugins are active without the full plugin, the precise
+ *    plugin mix is delivered in the Features section (PR 4); the subtitle
+ *    stays at the family-level summary.
+ *  - The deep-individual Jetpack scenarios (Backup / Protect / Boost /
+ *    Search / Social / VideoPress) each get their own dedicated copy
+ *    because the "single individual plugin" message is meaningfully
+ *    different from the family-level one.
+ */
+function getLoginSubtitles(): Record< SubtitleScenario, string > {
+	const jetpackFull = __(
+		'Your site is registered with WordPress.com — finish connecting your account to power Jetpack with backups, security, and growth tools.'
+	);
+
+	return {
+		A4A_ONLY: __(
+			'Your site is registered with WordPress.com — finish connecting your account to manage it from your Automattic for Agencies dashboard.'
+		),
+		A4A_WOO: __(
+			'Your store is registered with WordPress.com — finish connecting your account to manage it from Automattic for Agencies and link it to WooCommerce.com.'
+		),
+		A4A_JETPACK: __(
+			'Your site is registered with WordPress.com — finish connecting your account to manage it from Automattic for Agencies and power Jetpack features.'
+		),
+		ALL_THREE: __(
+			'Your store is registered with WordPress.com — finish connecting your account to manage it from your Automattic for Agencies dashboard, link it to WooCommerce.com, and power Jetpack features.'
+		),
+		WOO_ONLY: __(
+			'Your store is registered with WordPress.com — finish connecting your account to link it to WooCommerce.com for marketplace access, extensions, and analytics.'
+		),
+		WOOPAY_ONLY: __(
+			'Your store is registered with WordPress.com — finish connecting your account to enable WooPayments for payment processing and account management.'
+		),
+		WOO_AND_PAY: __(
+			'Your store is registered with WordPress.com — finish connecting your account to link it to WooCommerce.com and enable WooPayments for payment processing.'
+		),
+		WOO_JETPACK: __(
+			'Your store is registered with WordPress.com — finish connecting your account to link it to WooCommerce.com and power Jetpack features.'
+		),
+		JETPACK_FULL: jetpackFull,
+		JETPACK_BACKUP: __(
+			'Your site is registered with WordPress.com — finish connecting your account to enable real-time backups and one-click restore via Jetpack VaultPress Backup.'
+		),
+		JETPACK_PROTECT: __(
+			"Your site is registered with WordPress.com — finish connecting your account to enable Jetpack Protect's security scanning and malware protection."
+		),
+		JETPACK_BOOST: __(
+			"Your site is registered with WordPress.com — finish connecting your account to enable Jetpack Boost's site performance optimization."
+		),
+		JETPACK_SEARCH: __(
+			"Your site is registered with WordPress.com — finish connecting your account to enable Jetpack Search's instant results."
+		),
+		JETPACK_SOCIAL: __(
+			"Your site is registered with WordPress.com — finish connecting your account to enable Jetpack Social's automated post sharing."
+		),
+		JETPACK_VIDEOPRESS: __(
+			"Your site is registered with WordPress.com — finish connecting your account to enable Jetpack VideoPress's ad-free video hosting."
+		),
+		JETPACK_MULTI: jetpackFull,
+		OTHER_ONLY: __(
+			'Your site is registered with WordPress.com — finish connecting your account to power your active plugins.'
+		),
+	};
+}
+
+/**
+ * Pre-composed authorize-surface subtitles, one per scenario.
+ *
+ * Template (internal, not exposed to translators):
+ *   `Your {site|store} is registered with WordPress.com — connect this
+ *    account to {benefit}.`
+ *
+ * The auth page lives one step after the login page in the user journey,
+ * so the verb shifts from "finish connecting" to the more immediate
+ * "connect this account" — the user is one click away from approving.
+ * Otherwise the subtitle structure mirrors the login table; same scenario
+ * reuse rules (`JETPACK_MULTI` shares `JETPACK_FULL`).
+ *
+ * The plan originally proposed a `for {Site Name}` tail with a `%s`
+ * placeholder. Dropped for PR 3: long site names break the BrandHeader
+ * column at narrow widths, the site context is already established by
+ * the URL, and a placeholder per string would add translator overhead
+ * we don't yet need. Easy to add back if it turns out to matter.
+ */
+function getAuthSubtitles(): Record< SubtitleScenario, string > {
+	const jetpackFull = __(
+		'Your site is registered with WordPress.com — connect this account to activate Jetpack with backups, security, and stats.'
+	);
+
+	return {
+		A4A_ONLY: __(
+			'Your site is registered with WordPress.com — connect this account to manage it from your Automattic for Agencies dashboard.'
+		),
+		A4A_WOO: __(
+			'Your store is registered with WordPress.com — connect this account to manage it from Automattic for Agencies and link it to WooCommerce.com.'
+		),
+		A4A_JETPACK: __(
+			'Your site is registered with WordPress.com — connect this account to manage it from Automattic for Agencies and activate Jetpack.'
+		),
+		ALL_THREE: __(
+			'Your store is registered with WordPress.com — connect this account to manage it from your Automattic for Agencies dashboard, link it to WooCommerce.com, and activate Jetpack.'
+		),
+		WOO_ONLY: __(
+			'Your store is registered with WordPress.com — connect this account to link it to WooCommerce.com for marketplace access, analytics, and subscriptions.'
+		),
+		WOOPAY_ONLY: __(
+			'Your store is registered with WordPress.com — connect this account to enable WooPayments to manage payments and your account.'
+		),
+		WOO_AND_PAY: __(
+			'Your store is registered with WordPress.com — connect this account to link it to WooCommerce.com with WooPayments ready for payment processing.'
+		),
+		WOO_JETPACK: __(
+			'Your store is registered with WordPress.com — connect this account to link it to WooCommerce.com and activate Jetpack.'
+		),
+		JETPACK_FULL: jetpackFull,
+		JETPACK_BACKUP: __(
+			'Your site is registered with WordPress.com — connect this account to enable real-time backups and one-click restore via Jetpack VaultPress Backup.'
+		),
+		JETPACK_PROTECT: __(
+			"Your site is registered with WordPress.com — connect this account to enable Jetpack Protect's security scanning and malware protection."
+		),
+		JETPACK_BOOST: __(
+			"Your site is registered with WordPress.com — connect this account to enable Jetpack Boost's site performance optimization."
+		),
+		JETPACK_SEARCH: __(
+			"Your site is registered with WordPress.com — connect this account to enable Jetpack Search's instant results."
+		),
+		JETPACK_SOCIAL: __(
+			"Your site is registered with WordPress.com — connect this account to enable Jetpack Social's automated post sharing."
+		),
+		JETPACK_VIDEOPRESS: __(
+			"Your site is registered with WordPress.com — connect this account to enable Jetpack VideoPress's ad-free video hosting."
+		),
+		JETPACK_MULTI: jetpackFull,
+		OTHER_ONLY: __(
+			'Your site is registered with WordPress.com — connect this account to power your active plugins.'
+		),
+	};
+}
+
+/**
+ * Pre-composed signup-surface subtitles, one per scenario.
+ *
+ * The signup page is "step 2" in the connector journey — the user has
+ * already passed through the login screen, seen the registration
+ * acknowledgement, and chose `Create an account` instead of signing in.
+ * Repeating "Your site is registered…" would be redundant, so signup uses
+ * its own forward-looking value-prop frame:
+ *
+ *   `You'll use it to {benefit}.`
+ *
+ * Each scenario is a complete sentence that names site/store directly
+ * inside the benefit clause where relevant (the template doesn't append a
+ * `on your {site|store}` tail; that gave awkward double-noun phrasing for
+ * multi-family scenarios).
+ *
+ * Reuse rules match the login/auth tables: `JETPACK_MULTI` shares
+ * `JETPACK_FULL`'s string.
+ */
+function getSignupSubtitles(): Record< SubtitleScenario, string > {
+	const jetpackFull = __(
+		"You'll use it to power Jetpack with backups, security, and growth tools on your site."
+	);
+
+	return {
+		A4A_ONLY: __(
+			"You'll use it to manage your site from your Automattic for Agencies dashboard."
+		),
+		A4A_WOO: __(
+			"You'll use it to manage your store from Automattic for Agencies and link it to WooCommerce.com."
+		),
+		A4A_JETPACK: __(
+			"You'll use it to manage your site from Automattic for Agencies and power Jetpack features."
+		),
+		ALL_THREE: __(
+			"You'll use it to manage your store from Automattic for Agencies, link it to WooCommerce.com, and power Jetpack features."
+		),
+		WOO_ONLY: __(
+			"You'll use it to link your store to WooCommerce.com for marketplace access, extensions, and analytics."
+		),
+		WOOPAY_ONLY: __(
+			"You'll use it to enable WooPayments for your store's payment processing and account management."
+		),
+		WOO_AND_PAY: __(
+			"You'll use it to link your store to WooCommerce.com and enable WooPayments for payment processing."
+		),
+		WOO_JETPACK: __(
+			"You'll use it to link your store to WooCommerce.com and power Jetpack features."
+		),
+		JETPACK_FULL: jetpackFull,
+		JETPACK_BACKUP: __(
+			"You'll use it to enable real-time backups and one-click restore for your site via Jetpack VaultPress Backup."
+		),
+		JETPACK_PROTECT: __(
+			"You'll use it to enable Jetpack Protect's security scanning and malware protection on your site."
+		),
+		JETPACK_BOOST: __( "You'll use it to enable Jetpack Boost's site performance optimization." ),
+		JETPACK_SEARCH: __( "You'll use it to enable Jetpack Search's instant results on your site." ),
+		JETPACK_SOCIAL: __( "You'll use it to enable Jetpack Social's automated post sharing." ),
+		JETPACK_VIDEOPRESS: __(
+			"You'll use it to enable Jetpack VideoPress's ad-free video hosting on your site."
+		),
+		JETPACK_MULTI: jetpackFull,
+		OTHER_ONLY: __( "You'll use it to power your active plugins." ),
+	};
+}
+
+/**
  * Title + subtitle for the authorize page in the unified connection flow.
  *
- * PR 2 ships an interim subtitle that just acknowledges the registration;
- * PR 3 will replace it with the family-driven benefit clause.
+ * The static `Connect your account` H1 is shipped from PR 2; the subtitle
+ * now switches between 17 pre-composed sentences keyed by the active
+ * plugin set's family/composition. See `scenarios.ts` for the decision
+ * order and `getAuthSubtitles` above for the full string table.
  */
 export function getAuthCopy( pluginSlugs: readonly string[] = [] ): SurfaceCopy {
 	return {
 		title: __( 'Connect your account' ),
-		subtitle: getRegistrationAcknowledgement( pluginSlugs ),
+		subtitle: getAuthSubtitles()[ getSubtitleScenario( pluginSlugs ) ],
 	};
 }
 
 /**
  * Title + subtitle for the signup page in the unified connection flow.
  *
- * The signup page is "step 2" in the connector journey: the user has
- * already seen the registration acknowledgement on the login page and
- * chose to create a new WordPress.com account instead of signing in.
- * Repeating the acknowledgement would be redundant, so the signup page
- * uses its own forward-looking copy that explains why a WordPress.com
- * account matters in this flow.
- *
- * The H1 is intentionally light (no "WordPress.com") because the user
- * has just come from "Log in to WordPress.com" — the brand context is
- * already established and repeating it on every screen reads heavy.
- *
- * Two pre-composed sentences (one per noun) are shipped rather than a
- * template so translators get a real sentence, not a fragment.
+ * Static H1 (`Create your account`) shipped from PR 2; subtitle now uses
+ * the family-driven value-prop strings from `getSignupSubtitles`.
  */
 export function getSignupCopy( pluginSlugs: readonly string[] = [] ): SurfaceCopy {
 	return {
 		title: __( 'Create your account' ),
-		subtitle: isStore( pluginSlugs )
-			? __( "You'll use it to unlock powerful features on your store." )
-			: __( "You'll use it to unlock powerful features on your site." ),
+		subtitle: getSignupSubtitles()[ getSubtitleScenario( pluginSlugs ) ],
 	};
 }
 
 /**
  * Title + subtitle for the login page in the unified connection flow.
  *
- * PR 2 ships the static "Log in to WordPress.com" H1 (the previous
- * `to connect your store/site` tail is dropped) and the same registration
- * acknowledgement subtitle. PR 3 will add the family-driven benefit clause.
+ * Static H1 (`Log in to WordPress.com`) shipped from PR 2; subtitle now
+ * carries the family-driven benefit clause from `getLoginSubtitles`. The
+ * Terms-of-Service line keeps its existing studio-gray-50 secondary slot
+ * (rendered separately by `get-heading-subtext.tsx`).
  */
 export function getLoginCopy( pluginSlugs: readonly string[] = [] ): SurfaceCopy {
 	return {
 		title: __( 'Log in to WordPress.com' ),
-		subtitle: getRegistrationAcknowledgement( pluginSlugs ),
+		subtitle: getLoginSubtitles()[ getSubtitleScenario( pluginSlugs ) ],
 	};
 }

--- a/client/jetpack-connect/connection-content/copy.ts
+++ b/client/jetpack-connect/connection-content/copy.ts
@@ -54,22 +54,22 @@ function getLoginSubtitles(): Record< SubtitleScenario, string > {
 			'Your site is registered with WordPress.com — finish connecting your account to manage it from your Automattic for Agencies dashboard.'
 		),
 		A4A_WOO: __(
-			'Your store is registered with WordPress.com — finish connecting your account to manage it from Automattic for Agencies and link it to WooCommerce.com.'
+			'Your store is registered with WordPress.com — finish connecting your account to manage it from Automattic for Agencies, use the Woo mobile app, and access store analytics.'
 		),
 		A4A_JETPACK: __(
 			'Your site is registered with WordPress.com — finish connecting your account to manage it from Automattic for Agencies and power Jetpack features.'
 		),
 		ALL_THREE: __(
-			'Your store is registered with WordPress.com — finish connecting your account to manage it from your Automattic for Agencies dashboard, link it to WooCommerce.com, and power Jetpack features.'
+			'Your store is registered with WordPress.com — finish connecting your account to manage it from your Automattic for Agencies dashboard, use the Woo mobile app, access store analytics, and power Jetpack features.'
 		),
 		WOO_ONLY: __(
-			'Your store is registered with WordPress.com — finish connecting your account to link it to WooCommerce.com for marketplace access, extensions, and analytics.'
+			'Your store is registered with WordPress.com — finish connecting your account to use the Woo mobile app and access your store analytics.'
 		),
 		WOO_AND_PAY: __(
-			'Your store is registered with WordPress.com — finish connecting your account to link it to WooCommerce.com and enable WooPayments for payment processing.'
+			'Your store is registered with WordPress.com — finish connecting your account to use the Woo mobile app, access your store analytics, and enable WooPayments for payment processing.'
 		),
 		WOO_JETPACK: __(
-			'Your store is registered with WordPress.com — finish connecting your account to link it to WooCommerce.com and power Jetpack features.'
+			'Your store is registered with WordPress.com — finish connecting your account to use the Woo mobile app, access your store analytics, and power Jetpack features.'
 		),
 		JETPACK_FULL: jetpackFull,
 		JETPACK_BACKUP: __(
@@ -126,22 +126,22 @@ function getAuthSubtitles(): Record< SubtitleScenario, string > {
 			'Your site is registered with WordPress.com — connect this account to manage it from your Automattic for Agencies dashboard.'
 		),
 		A4A_WOO: __(
-			'Your store is registered with WordPress.com — connect this account to manage it from Automattic for Agencies and link it to WooCommerce.com.'
+			'Your store is registered with WordPress.com — connect this account to manage it from Automattic for Agencies, use the Woo mobile app, and access store analytics.'
 		),
 		A4A_JETPACK: __(
 			'Your site is registered with WordPress.com — connect this account to manage it from Automattic for Agencies and activate Jetpack.'
 		),
 		ALL_THREE: __(
-			'Your store is registered with WordPress.com — connect this account to manage it from your Automattic for Agencies dashboard, link it to WooCommerce.com, and activate Jetpack.'
+			'Your store is registered with WordPress.com — connect this account to manage it from your Automattic for Agencies dashboard, use the Woo mobile app, access store analytics, and activate Jetpack.'
 		),
 		WOO_ONLY: __(
-			'Your store is registered with WordPress.com — connect this account to link it to WooCommerce.com for marketplace access, analytics, and subscriptions.'
+			'Your store is registered with WordPress.com — connect this account to use the Woo mobile app and access your store analytics.'
 		),
 		WOO_AND_PAY: __(
-			'Your store is registered with WordPress.com — connect this account to link it to WooCommerce.com with WooPayments ready for payment processing.'
+			'Your store is registered with WordPress.com — connect this account to use the Woo mobile app, access your store analytics, and enable WooPayments for payment processing.'
 		),
 		WOO_JETPACK: __(
-			'Your store is registered with WordPress.com — connect this account to link it to WooCommerce.com and activate Jetpack.'
+			'Your store is registered with WordPress.com — connect this account to use the Woo mobile app, access your store analytics, and activate Jetpack.'
 		),
 		JETPACK_FULL: jetpackFull,
 		JETPACK_BACKUP: __(
@@ -198,22 +198,20 @@ function getSignupSubtitles(): Record< SubtitleScenario, string > {
 			"You'll use it to manage your site from your Automattic for Agencies dashboard."
 		),
 		A4A_WOO: __(
-			"You'll use it to manage your store from Automattic for Agencies and link it to WooCommerce.com."
+			"You'll use it to manage your store from Automattic for Agencies, log in to the Woo mobile app, and view store analytics."
 		),
 		A4A_JETPACK: __(
 			"You'll use it to manage your site from Automattic for Agencies and power Jetpack features."
 		),
 		ALL_THREE: __(
-			"You'll use it to manage your store from Automattic for Agencies, link it to WooCommerce.com, and power Jetpack features."
+			"You'll use it to manage your store from Automattic for Agencies, log in to the Woo mobile app, view store analytics, and power Jetpack features."
 		),
-		WOO_ONLY: __(
-			"You'll use it to link your store to WooCommerce.com for marketplace access, extensions, and analytics."
-		),
+		WOO_ONLY: __( "You'll use it to log in to the Woo mobile app and view your store analytics." ),
 		WOO_AND_PAY: __(
-			"You'll use it to link your store to WooCommerce.com and enable WooPayments for payment processing."
+			"You'll use it to log in to the Woo mobile app, view your store analytics, and enable WooPayments for payment processing."
 		),
 		WOO_JETPACK: __(
-			"You'll use it to link your store to WooCommerce.com and power Jetpack features."
+			"You'll use it to log in to the Woo mobile app, view your store analytics, and power Jetpack features."
 		),
 		JETPACK_FULL: jetpackFull,
 		JETPACK_BACKUP: __(

--- a/client/jetpack-connect/connection-content/copy.ts
+++ b/client/jetpack-connect/connection-content/copy.ts
@@ -65,9 +65,6 @@ function getLoginSubtitles(): Record< SubtitleScenario, string > {
 		WOO_ONLY: __(
 			'Your store is registered with WordPress.com — finish connecting your account to link it to WooCommerce.com for marketplace access, extensions, and analytics.'
 		),
-		WOOPAY_ONLY: __(
-			'Your store is registered with WordPress.com — finish connecting your account to enable WooPayments for payment processing and account management.'
-		),
 		WOO_AND_PAY: __(
 			'Your store is registered with WordPress.com — finish connecting your account to link it to WooCommerce.com and enable WooPayments for payment processing.'
 		),
@@ -140,9 +137,6 @@ function getAuthSubtitles(): Record< SubtitleScenario, string > {
 		WOO_ONLY: __(
 			'Your store is registered with WordPress.com — connect this account to link it to WooCommerce.com for marketplace access, analytics, and subscriptions.'
 		),
-		WOOPAY_ONLY: __(
-			'Your store is registered with WordPress.com — connect this account to enable WooPayments to manage payments and your account.'
-		),
 		WOO_AND_PAY: __(
 			'Your store is registered with WordPress.com — connect this account to link it to WooCommerce.com with WooPayments ready for payment processing.'
 		),
@@ -214,9 +208,6 @@ function getSignupSubtitles(): Record< SubtitleScenario, string > {
 		),
 		WOO_ONLY: __(
 			"You'll use it to link your store to WooCommerce.com for marketplace access, extensions, and analytics."
-		),
-		WOOPAY_ONLY: __(
-			"You'll use it to enable WooPayments for your store's payment processing and account management."
 		),
 		WOO_AND_PAY: __(
 			"You'll use it to link your store to WooCommerce.com and enable WooPayments for payment processing."

--- a/client/jetpack-connect/connection-content/copy.ts
+++ b/client/jetpack-connect/connection-content/copy.ts
@@ -1,25 +1,9 @@
 import { __ } from '@wordpress/i18n';
 import { getSubtitleScenario, type SubtitleScenario } from './scenarios';
-import { isStore } from './selectors';
 
 export interface SurfaceCopy {
 	title: string;
 	subtitle: string;
-}
-
-/**
- * Acknowledge that the site (or store) has already been registered with
- * WordPress.com.
- *
- * Public for callers that need just the lead clause (e.g. site-only
- * intermediate states elsewhere in the connector flow). The login and auth
- * surface subtitles in PR 3 are fully pre-composed and don't compose this
- * helper at runtime — translators always see complete sentences.
- */
-export function getRegistrationAcknowledgement( pluginSlugs: readonly string[] = [] ): string {
-	return isStore( pluginSlugs )
-		? __( 'Your store is registered with WordPress.com.' )
-		: __( 'Your site is registered with WordPress.com.' );
 }
 
 /**
@@ -118,7 +102,7 @@ function getLoginSubtitles(): Record< SubtitleScenario, string > {
  */
 function getAuthSubtitles(): Record< SubtitleScenario, string > {
 	const jetpackFull = __(
-		'Your site is registered with WordPress.com — connect this account to activate Jetpack with backups, security, and stats.'
+		'Your site is registered with WordPress.com — connect this account to activate Jetpack with backups, security, and growth tools.'
 	);
 
 	return {
@@ -235,7 +219,7 @@ function getSignupSubtitles(): Record< SubtitleScenario, string > {
  * Title + subtitle for the authorize page in the unified connection flow.
  *
  * The static `Connect your account` H1 is shipped from PR 2; the subtitle
- * now switches between 17 pre-composed sentences keyed by the active
+ * now switches between 16 pre-composed sentences keyed by the active
  * plugin set's family/composition. See `scenarios.ts` for the decision
  * order and `getAuthSubtitles` above for the full string table.
  */

--- a/client/jetpack-connect/connection-content/copy.ts
+++ b/client/jetpack-connect/connection-content/copy.ts
@@ -44,7 +44,7 @@ function getLoginSubtitles(): Record< SubtitleScenario, string > {
 			'Your site is registered with WordPress.com — finish connecting your account to manage it from Automattic for Agencies and power Jetpack features.'
 		),
 		ALL_THREE: __(
-			'Your store is registered with WordPress.com — finish connecting your account to use Automattic for Agencies dashboard, Woo mobile app, and Jetpack.'
+			'Your store is registered with WordPress.com — finish connecting your account to use the Automattic for Agencies dashboard, the Woo mobile app, and Jetpack.'
 		),
 		WOO_ONLY: __(
 			'Your store is registered with WordPress.com — finish connecting your account to use the Woo mobile app and access your store analytics.'
@@ -116,7 +116,7 @@ function getAuthSubtitles(): Record< SubtitleScenario, string > {
 			'Your site is registered with WordPress.com — connect this account to manage it from Automattic for Agencies and activate Jetpack.'
 		),
 		ALL_THREE: __(
-			'Your store is registered with WordPress.com — connect this account to use Automattic for Agencies dashboard, Woo mobile app, and Jetpack.'
+			'Your store is registered with WordPress.com — connect this account to use the Automattic for Agencies dashboard, the Woo mobile app, and Jetpack.'
 		),
 		WOO_ONLY: __(
 			'Your store is registered with WordPress.com — connect this account to use the Woo mobile app and access your store analytics.'
@@ -188,7 +188,7 @@ function getSignupSubtitles(): Record< SubtitleScenario, string > {
 			"You'll use it to manage your site from Automattic for Agencies and power Jetpack features."
 		),
 		ALL_THREE: __(
-			"You'll use it to access Automattic for Agencies dashboard, Woo mobile app, and Jetpack."
+			"You'll use it to access the Automattic for Agencies dashboard, the Woo mobile app, and Jetpack."
 		),
 		WOO_ONLY: __( "You'll use it to log in to the Woo mobile app and view your store analytics." ),
 		WOO_AND_PAY: __(

--- a/client/jetpack-connect/connection-content/copy.ts
+++ b/client/jetpack-connect/connection-content/copy.ts
@@ -44,7 +44,7 @@ function getLoginSubtitles(): Record< SubtitleScenario, string > {
 			'Your site is registered with WordPress.com — finish connecting your account to manage it from Automattic for Agencies and power Jetpack features.'
 		),
 		ALL_THREE: __(
-			'Your store is registered with WordPress.com — finish connecting your account to manage it from Automattic for Agencies, use the Woo mobile app and store analytics, and power Jetpack features.'
+			'Your store is registered with WordPress.com — finish connecting your account to use Automattic for Agencies dashboard, Woo mobile app, and Jetpack.'
 		),
 		WOO_ONLY: __(
 			'Your store is registered with WordPress.com — finish connecting your account to use the Woo mobile app and access your store analytics.'
@@ -116,7 +116,7 @@ function getAuthSubtitles(): Record< SubtitleScenario, string > {
 			'Your site is registered with WordPress.com — connect this account to manage it from Automattic for Agencies and activate Jetpack.'
 		),
 		ALL_THREE: __(
-			'Your store is registered with WordPress.com — connect this account to manage it from Automattic for Agencies, use the Woo mobile app and store analytics, and activate Jetpack.'
+			'Your store is registered with WordPress.com — connect this account to use Automattic for Agencies dashboard, Woo mobile app, and Jetpack.'
 		),
 		WOO_ONLY: __(
 			'Your store is registered with WordPress.com — connect this account to use the Woo mobile app and access your store analytics.'
@@ -188,7 +188,7 @@ function getSignupSubtitles(): Record< SubtitleScenario, string > {
 			"You'll use it to manage your site from Automattic for Agencies and power Jetpack features."
 		),
 		ALL_THREE: __(
-			"You'll use it to manage your store from Automattic for Agencies, log in to the Woo mobile app and view store analytics, and power Jetpack features."
+			"You'll use it to access Automattic for Agencies dashboard, Woo mobile app, and Jetpack."
 		),
 		WOO_ONLY: __( "You'll use it to log in to the Woo mobile app and view your store analytics." ),
 		WOO_AND_PAY: __(

--- a/client/jetpack-connect/connection-content/index.ts
+++ b/client/jetpack-connect/connection-content/index.ts
@@ -11,3 +11,5 @@ export {
 } from './selectors';
 export type { SurfaceCopy } from './copy';
 export { getRegistrationAcknowledgement, getAuthCopy, getSignupCopy, getLoginCopy } from './copy';
+export type { SubtitleScenario } from './scenarios';
+export { getSubtitleScenario } from './scenarios';

--- a/client/jetpack-connect/connection-content/index.ts
+++ b/client/jetpack-connect/connection-content/index.ts
@@ -10,6 +10,6 @@ export {
 	getOverflowSlugs,
 } from './selectors';
 export type { SurfaceCopy } from './copy';
-export { getRegistrationAcknowledgement, getAuthCopy, getSignupCopy, getLoginCopy } from './copy';
+export { getAuthCopy, getSignupCopy, getLoginCopy } from './copy';
 export type { SubtitleScenario } from './scenarios';
 export { getSubtitleScenario } from './scenarios';

--- a/client/jetpack-connect/connection-content/scenarios.ts
+++ b/client/jetpack-connect/connection-content/scenarios.ts
@@ -12,9 +12,16 @@ import { getPluginEntry } from './plugin-registry';
  * PR 4. `OTHER_ONLY` is the fallback when no known family is present at
  * all (including the empty-plugin-list edge case).
  *
- * The 17 keys are the canonical scenario set the plan calls out, and each
- * surface's pre-composed subtitle table is keyed by exactly these values
- * — see `copy.ts`.
+ * Note: there is intentionally no `WOOPAY_ONLY` scenario. WooPayments has
+ * WooCommerce core as a hard activation dependency, so a Woo-family plugin
+ * set that contains `woocommerce-payments` always also contains
+ * `woocommerce` and routes through `WOO_AND_PAY`. A defensive fall-through
+ * handles the impossible-but-still-possible case where the plugin list
+ * arrives malformed (URL truncation, etc.) — see the Woo branch below.
+ *
+ * The 16 keys are the canonical scenario set, and each surface's
+ * pre-composed subtitle table is keyed by exactly these values — see
+ * `copy.ts`.
  */
 export type SubtitleScenario =
 	| 'A4A_ONLY'
@@ -22,7 +29,6 @@ export type SubtitleScenario =
 	| 'A4A_JETPACK'
 	| 'ALL_THREE'
 	| 'WOO_ONLY'
-	| 'WOOPAY_ONLY'
 	| 'WOO_AND_PAY'
 	| 'WOO_JETPACK'
 	| 'JETPACK_FULL'
@@ -67,7 +73,10 @@ function getJetpackSingleScenario( slug: string ): SubtitleScenario | null {
  *
  * 1. Multi-family combinations (A4A + Woo + Jetpack), in priority order.
  * 2. Single-family combinations:
- *    - Woo: distinguish WooCommerce-only / WooPayments-only / both.
+ *    - Woo: WooCommerce + WooPayments together routes to `WOO_AND_PAY`;
+ *      everything else (including a malformed `woocommerce-payments`-only
+ *      list, which the WooPayments dependency on WooCommerce core makes
+ *      impossible in practice) falls through to `WOO_ONLY`.
  *    - Jetpack: distinguish full Jetpack / a single individual plugin /
  *      two-or-more individuals (collapses to `JETPACK_MULTI`, which reuses
  *      the full-Jetpack copy by design — see the plan's "any 2+ individual
@@ -104,13 +113,8 @@ export function getSubtitleScenario( pluginSlugs: readonly string[] = [] ): Subt
 
 	if ( hasWoo ) {
 		const wooSlugs = pluginSlugs.filter( ( slug ) => getFamilyFromSlug( slug ) === 'woo' );
-		const hasCore = wooSlugs.includes( 'woocommerce' );
-		const hasPayments = wooSlugs.includes( 'woocommerce-payments' );
-		if ( hasCore && hasPayments ) {
+		if ( wooSlugs.includes( 'woocommerce' ) && wooSlugs.includes( 'woocommerce-payments' ) ) {
 			return 'WOO_AND_PAY';
-		}
-		if ( hasPayments && ! hasCore ) {
-			return 'WOOPAY_ONLY';
 		}
 		return 'WOO_ONLY';
 	}

--- a/client/jetpack-connect/connection-content/scenarios.ts
+++ b/client/jetpack-connect/connection-content/scenarios.ts
@@ -1,0 +1,131 @@
+import { getFamilyFromSlug } from './families';
+import { getPluginEntry } from './plugin-registry';
+
+/**
+ * Identifier for the subtitle scenario that drives copy selection on every
+ * connector-flow surface (login / auth / signup).
+ *
+ * Scenarios reflect *which families* are present (A4A, Woo, Jetpack) and —
+ * for the single-family Woo and Jetpack cases — *which specific plugins*.
+ * Unknown plugins ("other" family) never change the scenario when a known
+ * family is present; they only land in the "Also used by" overflow row in
+ * PR 4. `OTHER_ONLY` is the fallback when no known family is present at
+ * all (including the empty-plugin-list edge case).
+ *
+ * The 17 keys are the canonical scenario set the plan calls out, and each
+ * surface's pre-composed subtitle table is keyed by exactly these values
+ * — see `copy.ts`.
+ */
+export type SubtitleScenario =
+	| 'A4A_ONLY'
+	| 'A4A_WOO'
+	| 'A4A_JETPACK'
+	| 'ALL_THREE'
+	| 'WOO_ONLY'
+	| 'WOOPAY_ONLY'
+	| 'WOO_AND_PAY'
+	| 'WOO_JETPACK'
+	| 'JETPACK_FULL'
+	| 'JETPACK_BACKUP'
+	| 'JETPACK_PROTECT'
+	| 'JETPACK_BOOST'
+	| 'JETPACK_SEARCH'
+	| 'JETPACK_SOCIAL'
+	| 'JETPACK_VIDEOPRESS'
+	| 'JETPACK_MULTI'
+	| 'OTHER_ONLY';
+
+/**
+ * Map a single Jetpack-family slug to its dedicated single-plugin scenario,
+ * or `null` for the full Jetpack plugin (which routes through `JETPACK_FULL`)
+ * and for any unrecognised Jetpack-prefixed slug (which routes through the
+ * `JETPACK_MULTI`/`JETPACK_FULL` fallbacks).
+ */
+function getJetpackSingleScenario( slug: string ): SubtitleScenario | null {
+	switch ( slug ) {
+		case 'jetpack-backup':
+			return 'JETPACK_BACKUP';
+		case 'jetpack-protect':
+			return 'JETPACK_PROTECT';
+		case 'jetpack-boost':
+			return 'JETPACK_BOOST';
+		case 'jetpack-search':
+			return 'JETPACK_SEARCH';
+		case 'jetpack-social':
+			return 'JETPACK_SOCIAL';
+		case 'jetpack-videopress':
+			return 'JETPACK_VIDEOPRESS';
+		default:
+			return null;
+	}
+}
+
+/**
+ * Resolve the subtitle scenario for the active plugin set.
+ *
+ * Decision order, top-down:
+ *
+ * 1. Multi-family combinations (A4A + Woo + Jetpack), in priority order.
+ * 2. Single-family combinations:
+ *    - Woo: distinguish WooCommerce-only / WooPayments-only / both.
+ *    - Jetpack: distinguish full Jetpack / a single individual plugin /
+ *      two-or-more individuals (collapses to `JETPACK_MULTI`, which reuses
+ *      the full-Jetpack copy by design — see the plan's "any 2+ individual
+ *      Jetpacks" rule).
+ *    - A4A: only one plugin in this family.
+ * 3. `OTHER_ONLY` for empty input or only-unknown plugins.
+ *
+ * Unknown ("other"-family) plugins are silently ignored once a known family
+ * is present — they get surfaced in the PR 4 "Also used by" row instead of
+ * driving subtitle copy.
+ */
+export function getSubtitleScenario( pluginSlugs: readonly string[] = [] ): SubtitleScenario {
+	const families = new Set( pluginSlugs.map( getFamilyFromSlug ) );
+	const hasA4A = families.has( 'a4a' );
+	const hasWoo = families.has( 'woo' );
+	const hasJetpack = families.has( 'jetpack' );
+
+	if ( hasA4A && hasWoo && hasJetpack ) {
+		return 'ALL_THREE';
+	}
+	if ( hasA4A && hasWoo ) {
+		return 'A4A_WOO';
+	}
+	if ( hasA4A && hasJetpack ) {
+		return 'A4A_JETPACK';
+	}
+	if ( hasWoo && hasJetpack ) {
+		return 'WOO_JETPACK';
+	}
+
+	if ( hasA4A ) {
+		return 'A4A_ONLY';
+	}
+
+	if ( hasWoo ) {
+		const wooSlugs = pluginSlugs.filter( ( slug ) => getFamilyFromSlug( slug ) === 'woo' );
+		const hasCore = wooSlugs.includes( 'woocommerce' );
+		const hasPayments = wooSlugs.includes( 'woocommerce-payments' );
+		if ( hasCore && hasPayments ) {
+			return 'WOO_AND_PAY';
+		}
+		if ( hasPayments && ! hasCore ) {
+			return 'WOOPAY_ONLY';
+		}
+		return 'WOO_ONLY';
+	}
+
+	if ( hasJetpack ) {
+		const jetpackSlugs = pluginSlugs.filter( ( slug ) => getFamilyFromSlug( slug ) === 'jetpack' );
+		const hasFull = jetpackSlugs.some( ( slug ) => getPluginEntry( slug )?.isFullJetpack === true );
+		if ( hasFull ) {
+			return 'JETPACK_FULL';
+		}
+		if ( jetpackSlugs.length === 1 ) {
+			return getJetpackSingleScenario( jetpackSlugs[ 0 ] ) ?? 'JETPACK_MULTI';
+		}
+		return 'JETPACK_MULTI';
+	}
+
+	return 'OTHER_ONLY';
+}

--- a/client/jetpack-connect/connection-content/test/copy.test.ts
+++ b/client/jetpack-connect/connection-content/test/copy.test.ts
@@ -1,4 +1,4 @@
-import { getAuthCopy, getLoginCopy, getRegistrationAcknowledgement, getSignupCopy } from '../copy';
+import { getAuthCopy, getLoginCopy, getSignupCopy } from '../copy';
 import type { SubtitleScenario } from '../scenarios';
 
 /**
@@ -27,32 +27,6 @@ const SCENARIO_SLUGS: Record< SubtitleScenario, readonly string[] > = {
 	JETPACK_MULTI: [ 'jetpack-backup', 'jetpack-protect' ],
 	OTHER_ONLY: [],
 };
-
-describe( 'getRegistrationAcknowledgement', () => {
-	test( 'uses store wording when any Woo-family plugin is active', () => {
-		expect( getRegistrationAcknowledgement( [ 'woocommerce' ] ) ).toBe(
-			'Your store is registered with WordPress.com.'
-		);
-		expect( getRegistrationAcknowledgement( [ 'woocommerce-payments' ] ) ).toBe(
-			'Your store is registered with WordPress.com.'
-		);
-		expect( getRegistrationAcknowledgement( [ 'jetpack', 'woocommerce' ] ) ).toBe(
-			'Your store is registered with WordPress.com.'
-		);
-	} );
-
-	test( 'uses site wording for non-Woo plugin sets', () => {
-		expect( getRegistrationAcknowledgement( [] ) ).toBe(
-			'Your site is registered with WordPress.com.'
-		);
-		expect( getRegistrationAcknowledgement( [ 'jetpack' ] ) ).toBe(
-			'Your site is registered with WordPress.com.'
-		);
-		expect( getRegistrationAcknowledgement( [ 'automattic-for-agencies-client' ] ) ).toBe(
-			'Your site is registered with WordPress.com.'
-		);
-	} );
-} );
 
 describe( 'titles', () => {
 	test( 'auth surface returns "Connect your account" for every plugin set', () => {
@@ -182,7 +156,7 @@ describe( 'auth subtitles', () => {
 		],
 		[
 			'JETPACK_FULL',
-			'Your site is registered with WordPress.com — connect this account to activate Jetpack with backups, security, and stats.',
+			'Your site is registered with WordPress.com — connect this account to activate Jetpack with backups, security, and growth tools.',
 		],
 		[
 			'JETPACK_BACKUP',

--- a/client/jetpack-connect/connection-content/test/copy.test.ts
+++ b/client/jetpack-connect/connection-content/test/copy.test.ts
@@ -1,4 +1,33 @@
 import { getAuthCopy, getLoginCopy, getRegistrationAcknowledgement, getSignupCopy } from '../copy';
+import type { SubtitleScenario } from '../scenarios';
+
+/**
+ * Representative slug set per scenario, used to drive every surface's
+ * subtitle assertions through `getAuthCopy` / `getLoginCopy` /
+ * `getSignupCopy`. The slug *combinations* are exercised separately in
+ * `scenarios.test.ts`; here we treat the scenario detection as a black box
+ * and verify that the right pre-composed string lands on the right
+ * surface.
+ */
+const SCENARIO_SLUGS: Record< SubtitleScenario, readonly string[] > = {
+	A4A_ONLY: [ 'automattic-for-agencies-client' ],
+	A4A_WOO: [ 'automattic-for-agencies-client', 'woocommerce' ],
+	A4A_JETPACK: [ 'automattic-for-agencies-client', 'jetpack-boost' ],
+	ALL_THREE: [ 'automattic-for-agencies-client', 'woocommerce', 'jetpack' ],
+	WOO_ONLY: [ 'woocommerce' ],
+	WOOPAY_ONLY: [ 'woocommerce-payments' ],
+	WOO_AND_PAY: [ 'woocommerce', 'woocommerce-payments' ],
+	WOO_JETPACK: [ 'woocommerce', 'jetpack' ],
+	JETPACK_FULL: [ 'jetpack' ],
+	JETPACK_BACKUP: [ 'jetpack-backup' ],
+	JETPACK_PROTECT: [ 'jetpack-protect' ],
+	JETPACK_BOOST: [ 'jetpack-boost' ],
+	JETPACK_SEARCH: [ 'jetpack-search' ],
+	JETPACK_SOCIAL: [ 'jetpack-social' ],
+	JETPACK_VIDEOPRESS: [ 'jetpack-videopress' ],
+	JETPACK_MULTI: [ 'jetpack-backup', 'jetpack-protect' ],
+	OTHER_ONLY: [],
+};
 
 describe( 'getRegistrationAcknowledgement', () => {
 	test( 'uses store wording when any Woo-family plugin is active', () => {
@@ -23,79 +52,269 @@ describe( 'getRegistrationAcknowledgement', () => {
 		expect( getRegistrationAcknowledgement( [ 'automattic-for-agencies-client' ] ) ).toBe(
 			'Your site is registered with WordPress.com.'
 		);
-		expect( getRegistrationAcknowledgement( [ 'jetpack-boost', 'unknown' ] ) ).toBe(
-			'Your site is registered with WordPress.com.'
+	} );
+} );
+
+describe( 'titles', () => {
+	test( 'auth surface returns "Connect your account" for every plugin set', () => {
+		for ( const slugs of Object.values( SCENARIO_SLUGS ) ) {
+			expect( getAuthCopy( slugs ).title ).toBe( 'Connect your account' );
+		}
+	} );
+
+	test( 'signup surface returns "Create your account" for every plugin set', () => {
+		for ( const slugs of Object.values( SCENARIO_SLUGS ) ) {
+			expect( getSignupCopy( slugs ).title ).toBe( 'Create your account' );
+		}
+	} );
+
+	test( 'login surface returns "Log in to WordPress.com" for every plugin set', () => {
+		for ( const slugs of Object.values( SCENARIO_SLUGS ) ) {
+			expect( getLoginCopy( slugs ).title ).toBe( 'Log in to WordPress.com' );
+		}
+	} );
+} );
+
+describe( 'login subtitles', () => {
+	test.each( [
+		[
+			'A4A_ONLY',
+			'Your site is registered with WordPress.com — finish connecting your account to manage it from your Automattic for Agencies dashboard.',
+		],
+		[
+			'A4A_WOO',
+			'Your store is registered with WordPress.com — finish connecting your account to manage it from Automattic for Agencies and link it to WooCommerce.com.',
+		],
+		[
+			'A4A_JETPACK',
+			'Your site is registered with WordPress.com — finish connecting your account to manage it from Automattic for Agencies and power Jetpack features.',
+		],
+		[
+			'ALL_THREE',
+			'Your store is registered with WordPress.com — finish connecting your account to manage it from your Automattic for Agencies dashboard, link it to WooCommerce.com, and power Jetpack features.',
+		],
+		[
+			'WOO_ONLY',
+			'Your store is registered with WordPress.com — finish connecting your account to link it to WooCommerce.com for marketplace access, extensions, and analytics.',
+		],
+		[
+			'WOOPAY_ONLY',
+			'Your store is registered with WordPress.com — finish connecting your account to enable WooPayments for payment processing and account management.',
+		],
+		[
+			'WOO_AND_PAY',
+			'Your store is registered with WordPress.com — finish connecting your account to link it to WooCommerce.com and enable WooPayments for payment processing.',
+		],
+		[
+			'WOO_JETPACK',
+			'Your store is registered with WordPress.com — finish connecting your account to link it to WooCommerce.com and power Jetpack features.',
+		],
+		[
+			'JETPACK_FULL',
+			'Your site is registered with WordPress.com — finish connecting your account to power Jetpack with backups, security, and growth tools.',
+		],
+		[
+			'JETPACK_BACKUP',
+			'Your site is registered with WordPress.com — finish connecting your account to enable real-time backups and one-click restore via Jetpack VaultPress Backup.',
+		],
+		[
+			'JETPACK_PROTECT',
+			"Your site is registered with WordPress.com — finish connecting your account to enable Jetpack Protect's security scanning and malware protection.",
+		],
+		[
+			'JETPACK_BOOST',
+			"Your site is registered with WordPress.com — finish connecting your account to enable Jetpack Boost's site performance optimization.",
+		],
+		[
+			'JETPACK_SEARCH',
+			"Your site is registered with WordPress.com — finish connecting your account to enable Jetpack Search's instant results.",
+		],
+		[
+			'JETPACK_SOCIAL',
+			"Your site is registered with WordPress.com — finish connecting your account to enable Jetpack Social's automated post sharing.",
+		],
+		[
+			'JETPACK_VIDEOPRESS',
+			"Your site is registered with WordPress.com — finish connecting your account to enable Jetpack VideoPress's ad-free video hosting.",
+		],
+		[
+			'OTHER_ONLY',
+			'Your site is registered with WordPress.com — finish connecting your account to power your active plugins.',
+		],
+	] satisfies Array< [ SubtitleScenario, string ] > )(
+		'%s renders the expected pre-composed sentence',
+		( scenario, expected ) => {
+			expect( getLoginCopy( SCENARIO_SLUGS[ scenario ] ).subtitle ).toBe( expected );
+		}
+	);
+
+	test( 'JETPACK_MULTI reuses the JETPACK_FULL subtitle by design', () => {
+		expect( getLoginCopy( SCENARIO_SLUGS.JETPACK_MULTI ).subtitle ).toBe(
+			getLoginCopy( SCENARIO_SLUGS.JETPACK_FULL ).subtitle
 		);
 	} );
 } );
 
-describe( 'getAuthCopy', () => {
-	test( 'returns the static "Connect your account" title regardless of plugins', () => {
-		expect( getAuthCopy( [] ).title ).toBe( 'Connect your account' );
-		expect( getAuthCopy( [ 'woocommerce' ] ).title ).toBe( 'Connect your account' );
-		expect( getAuthCopy( [ 'jetpack', 'automattic-for-agencies-client' ] ).title ).toBe(
-			'Connect your account'
-		);
-	} );
+describe( 'auth subtitles', () => {
+	test.each( [
+		[
+			'A4A_ONLY',
+			'Your site is registered with WordPress.com — connect this account to manage it from your Automattic for Agencies dashboard.',
+		],
+		[
+			'A4A_WOO',
+			'Your store is registered with WordPress.com — connect this account to manage it from Automattic for Agencies and link it to WooCommerce.com.',
+		],
+		[
+			'A4A_JETPACK',
+			'Your site is registered with WordPress.com — connect this account to manage it from Automattic for Agencies and activate Jetpack.',
+		],
+		[
+			'ALL_THREE',
+			'Your store is registered with WordPress.com — connect this account to manage it from your Automattic for Agencies dashboard, link it to WooCommerce.com, and activate Jetpack.',
+		],
+		[
+			'WOO_ONLY',
+			'Your store is registered with WordPress.com — connect this account to link it to WooCommerce.com for marketplace access, analytics, and subscriptions.',
+		],
+		[
+			'WOOPAY_ONLY',
+			'Your store is registered with WordPress.com — connect this account to enable WooPayments to manage payments and your account.',
+		],
+		[
+			'WOO_AND_PAY',
+			'Your store is registered with WordPress.com — connect this account to link it to WooCommerce.com with WooPayments ready for payment processing.',
+		],
+		[
+			'WOO_JETPACK',
+			'Your store is registered with WordPress.com — connect this account to link it to WooCommerce.com and activate Jetpack.',
+		],
+		[
+			'JETPACK_FULL',
+			'Your site is registered with WordPress.com — connect this account to activate Jetpack with backups, security, and stats.',
+		],
+		[
+			'JETPACK_BACKUP',
+			'Your site is registered with WordPress.com — connect this account to enable real-time backups and one-click restore via Jetpack VaultPress Backup.',
+		],
+		[
+			'JETPACK_PROTECT',
+			"Your site is registered with WordPress.com — connect this account to enable Jetpack Protect's security scanning and malware protection.",
+		],
+		[
+			'JETPACK_BOOST',
+			"Your site is registered with WordPress.com — connect this account to enable Jetpack Boost's site performance optimization.",
+		],
+		[
+			'JETPACK_SEARCH',
+			"Your site is registered with WordPress.com — connect this account to enable Jetpack Search's instant results.",
+		],
+		[
+			'JETPACK_SOCIAL',
+			"Your site is registered with WordPress.com — connect this account to enable Jetpack Social's automated post sharing.",
+		],
+		[
+			'JETPACK_VIDEOPRESS',
+			"Your site is registered with WordPress.com — connect this account to enable Jetpack VideoPress's ad-free video hosting.",
+		],
+		[
+			'OTHER_ONLY',
+			'Your site is registered with WordPress.com — connect this account to power your active plugins.',
+		],
+	] satisfies Array< [ SubtitleScenario, string ] > )(
+		'%s renders the expected pre-composed sentence',
+		( scenario, expected ) => {
+			expect( getAuthCopy( SCENARIO_SLUGS[ scenario ] ).subtitle ).toBe( expected );
+		}
+	);
 
-	test( 'subtitle reflects site/store branching', () => {
-		expect( getAuthCopy( [ 'jetpack' ] ).subtitle ).toBe(
-			'Your site is registered with WordPress.com.'
+	test( 'JETPACK_MULTI reuses the JETPACK_FULL subtitle by design', () => {
+		expect( getAuthCopy( SCENARIO_SLUGS.JETPACK_MULTI ).subtitle ).toBe(
+			getAuthCopy( SCENARIO_SLUGS.JETPACK_FULL ).subtitle
 		);
-		expect( getAuthCopy( [ 'woocommerce' ] ).subtitle ).toBe(
-			'Your store is registered with WordPress.com.'
-		);
-	} );
-
-	test( 'works with the default empty argument', () => {
-		expect( getAuthCopy() ).toEqual( {
-			title: 'Connect your account',
-			subtitle: 'Your site is registered with WordPress.com.',
-		} );
 	} );
 } );
 
-describe( 'getSignupCopy', () => {
-	test( 'returns the static "Create your account" title regardless of plugins', () => {
-		expect( getSignupCopy( [] ).title ).toBe( 'Create your account' );
-		expect( getSignupCopy( [ 'woocommerce' ] ).title ).toBe( 'Create your account' );
-		expect( getSignupCopy( [ 'jetpack', 'automattic-for-agencies-client' ] ).title ).toBe(
-			'Create your account'
-		);
-	} );
+describe( 'signup subtitles', () => {
+	test.each( [
+		[
+			'A4A_ONLY',
+			"You'll use it to manage your site from your Automattic for Agencies dashboard.",
+		],
+		[
+			'A4A_WOO',
+			"You'll use it to manage your store from Automattic for Agencies and link it to WooCommerce.com.",
+		],
+		[
+			'A4A_JETPACK',
+			"You'll use it to manage your site from Automattic for Agencies and power Jetpack features.",
+		],
+		[
+			'ALL_THREE',
+			"You'll use it to manage your store from Automattic for Agencies, link it to WooCommerce.com, and power Jetpack features.",
+		],
+		[
+			'WOO_ONLY',
+			"You'll use it to link your store to WooCommerce.com for marketplace access, extensions, and analytics.",
+		],
+		[
+			'WOOPAY_ONLY',
+			"You'll use it to enable WooPayments for your store's payment processing and account management.",
+		],
+		[
+			'WOO_AND_PAY',
+			"You'll use it to link your store to WooCommerce.com and enable WooPayments for payment processing.",
+		],
+		[
+			'WOO_JETPACK',
+			"You'll use it to link your store to WooCommerce.com and power Jetpack features.",
+		],
+		[
+			'JETPACK_FULL',
+			"You'll use it to power Jetpack with backups, security, and growth tools on your site.",
+		],
+		[
+			'JETPACK_BACKUP',
+			"You'll use it to enable real-time backups and one-click restore for your site via Jetpack VaultPress Backup.",
+		],
+		[
+			'JETPACK_PROTECT',
+			"You'll use it to enable Jetpack Protect's security scanning and malware protection on your site.",
+		],
+		[ 'JETPACK_BOOST', "You'll use it to enable Jetpack Boost's site performance optimization." ],
+		[ 'JETPACK_SEARCH', "You'll use it to enable Jetpack Search's instant results on your site." ],
+		[ 'JETPACK_SOCIAL', "You'll use it to enable Jetpack Social's automated post sharing." ],
+		[
+			'JETPACK_VIDEOPRESS',
+			"You'll use it to enable Jetpack VideoPress's ad-free video hosting on your site.",
+		],
+		[ 'OTHER_ONLY', "You'll use it to power your active plugins." ],
+	] satisfies Array< [ SubtitleScenario, string ] > )(
+		'%s renders the expected pre-composed sentence',
+		( scenario, expected ) => {
+			expect( getSignupCopy( SCENARIO_SLUGS[ scenario ] ).subtitle ).toBe( expected );
+		}
+	);
 
-	test( 'subtitle reflects site/store branching with a forward-looking value-prop', () => {
-		expect( getSignupCopy( [ 'jetpack' ] ).subtitle ).toBe(
-			"You'll use it to unlock powerful features on your site."
+	test( 'JETPACK_MULTI reuses the JETPACK_FULL subtitle by design', () => {
+		expect( getSignupCopy( SCENARIO_SLUGS.JETPACK_MULTI ).subtitle ).toBe(
+			getSignupCopy( SCENARIO_SLUGS.JETPACK_FULL ).subtitle
 		);
-		expect( getSignupCopy( [ 'woocommerce' ] ).subtitle ).toBe(
-			"You'll use it to unlock powerful features on your store."
-		);
-	} );
-
-	test( 'works with the default empty argument', () => {
-		expect( getSignupCopy() ).toEqual( {
-			title: 'Create your account',
-			subtitle: "You'll use it to unlock powerful features on your site.",
-		} );
 	} );
 } );
 
-describe( 'getLoginCopy', () => {
-	test( 'returns the static "Log in to WordPress.com" title regardless of plugins', () => {
-		expect( getLoginCopy( [] ).title ).toBe( 'Log in to WordPress.com' );
-		expect( getLoginCopy( [ 'woocommerce' ] ).title ).toBe( 'Log in to WordPress.com' );
-		expect( getLoginCopy( [ 'jetpack', 'automattic-for-agencies-client' ] ).title ).toBe(
-			'Log in to WordPress.com'
-		);
-	} );
+describe( 'default arguments', () => {
+	test( 'every resolver tolerates an empty/missing plugin list and lands on OTHER_ONLY', () => {
+		const expectedAuth = getAuthCopy( [] );
+		const expectedLogin = getLoginCopy( [] );
+		const expectedSignup = getSignupCopy( [] );
 
-	test( 'subtitle reflects site/store branching', () => {
-		expect( getLoginCopy( [ 'jetpack' ] ).subtitle ).toBe(
-			'Your site is registered with WordPress.com.'
-		);
-		expect( getLoginCopy( [ 'woocommerce' ] ).subtitle ).toBe(
-			'Your store is registered with WordPress.com.'
-		);
+		expect( getAuthCopy() ).toEqual( expectedAuth );
+		expect( getLoginCopy() ).toEqual( expectedLogin );
+		expect( getSignupCopy() ).toEqual( expectedSignup );
+
+		expect( expectedAuth.subtitle ).toContain( 'power your active plugins' );
+		expect( expectedLogin.subtitle ).toContain( 'power your active plugins' );
+		expect( expectedSignup.subtitle ).toContain( 'power your active plugins' );
 	} );
 } );

--- a/client/jetpack-connect/connection-content/test/copy.test.ts
+++ b/client/jetpack-connect/connection-content/test/copy.test.ts
@@ -82,7 +82,7 @@ describe( 'login subtitles', () => {
 		],
 		[
 			'A4A_WOO',
-			'Your store is registered with WordPress.com — finish connecting your account to manage it from Automattic for Agencies and link it to WooCommerce.com.',
+			'Your store is registered with WordPress.com — finish connecting your account to manage it from Automattic for Agencies, use the Woo mobile app, and access store analytics.',
 		],
 		[
 			'A4A_JETPACK',
@@ -90,19 +90,19 @@ describe( 'login subtitles', () => {
 		],
 		[
 			'ALL_THREE',
-			'Your store is registered with WordPress.com — finish connecting your account to manage it from your Automattic for Agencies dashboard, link it to WooCommerce.com, and power Jetpack features.',
+			'Your store is registered with WordPress.com — finish connecting your account to manage it from your Automattic for Agencies dashboard, use the Woo mobile app, access store analytics, and power Jetpack features.',
 		],
 		[
 			'WOO_ONLY',
-			'Your store is registered with WordPress.com — finish connecting your account to link it to WooCommerce.com for marketplace access, extensions, and analytics.',
+			'Your store is registered with WordPress.com — finish connecting your account to use the Woo mobile app and access your store analytics.',
 		],
 		[
 			'WOO_AND_PAY',
-			'Your store is registered with WordPress.com — finish connecting your account to link it to WooCommerce.com and enable WooPayments for payment processing.',
+			'Your store is registered with WordPress.com — finish connecting your account to use the Woo mobile app, access your store analytics, and enable WooPayments for payment processing.',
 		],
 		[
 			'WOO_JETPACK',
-			'Your store is registered with WordPress.com — finish connecting your account to link it to WooCommerce.com and power Jetpack features.',
+			'Your store is registered with WordPress.com — finish connecting your account to use the Woo mobile app, access your store analytics, and power Jetpack features.',
 		],
 		[
 			'JETPACK_FULL',
@@ -158,7 +158,7 @@ describe( 'auth subtitles', () => {
 		],
 		[
 			'A4A_WOO',
-			'Your store is registered with WordPress.com — connect this account to manage it from Automattic for Agencies and link it to WooCommerce.com.',
+			'Your store is registered with WordPress.com — connect this account to manage it from Automattic for Agencies, use the Woo mobile app, and access store analytics.',
 		],
 		[
 			'A4A_JETPACK',
@@ -166,19 +166,19 @@ describe( 'auth subtitles', () => {
 		],
 		[
 			'ALL_THREE',
-			'Your store is registered with WordPress.com — connect this account to manage it from your Automattic for Agencies dashboard, link it to WooCommerce.com, and activate Jetpack.',
+			'Your store is registered with WordPress.com — connect this account to manage it from your Automattic for Agencies dashboard, use the Woo mobile app, access store analytics, and activate Jetpack.',
 		],
 		[
 			'WOO_ONLY',
-			'Your store is registered with WordPress.com — connect this account to link it to WooCommerce.com for marketplace access, analytics, and subscriptions.',
+			'Your store is registered with WordPress.com — connect this account to use the Woo mobile app and access your store analytics.',
 		],
 		[
 			'WOO_AND_PAY',
-			'Your store is registered with WordPress.com — connect this account to link it to WooCommerce.com with WooPayments ready for payment processing.',
+			'Your store is registered with WordPress.com — connect this account to use the Woo mobile app, access your store analytics, and enable WooPayments for payment processing.',
 		],
 		[
 			'WOO_JETPACK',
-			'Your store is registered with WordPress.com — connect this account to link it to WooCommerce.com and activate Jetpack.',
+			'Your store is registered with WordPress.com — connect this account to use the Woo mobile app, access your store analytics, and activate Jetpack.',
 		],
 		[
 			'JETPACK_FULL',
@@ -234,7 +234,7 @@ describe( 'signup subtitles', () => {
 		],
 		[
 			'A4A_WOO',
-			"You'll use it to manage your store from Automattic for Agencies and link it to WooCommerce.com.",
+			"You'll use it to manage your store from Automattic for Agencies, log in to the Woo mobile app, and view store analytics.",
 		],
 		[
 			'A4A_JETPACK',
@@ -242,19 +242,16 @@ describe( 'signup subtitles', () => {
 		],
 		[
 			'ALL_THREE',
-			"You'll use it to manage your store from Automattic for Agencies, link it to WooCommerce.com, and power Jetpack features.",
+			"You'll use it to manage your store from Automattic for Agencies, log in to the Woo mobile app, view store analytics, and power Jetpack features.",
 		],
-		[
-			'WOO_ONLY',
-			"You'll use it to link your store to WooCommerce.com for marketplace access, extensions, and analytics.",
-		],
+		[ 'WOO_ONLY', "You'll use it to log in to the Woo mobile app and view your store analytics." ],
 		[
 			'WOO_AND_PAY',
-			"You'll use it to link your store to WooCommerce.com and enable WooPayments for payment processing.",
+			"You'll use it to log in to the Woo mobile app, view your store analytics, and enable WooPayments for payment processing.",
 		],
 		[
 			'WOO_JETPACK',
-			"You'll use it to link your store to WooCommerce.com and power Jetpack features.",
+			"You'll use it to log in to the Woo mobile app, view your store analytics, and power Jetpack features.",
 		],
 		[
 			'JETPACK_FULL',

--- a/client/jetpack-connect/connection-content/test/copy.test.ts
+++ b/client/jetpack-connect/connection-content/test/copy.test.ts
@@ -64,7 +64,7 @@ describe( 'login subtitles', () => {
 		],
 		[
 			'ALL_THREE',
-			'Your store is registered with WordPress.com — finish connecting your account to manage it from Automattic for Agencies, use the Woo mobile app and store analytics, and power Jetpack features.',
+			'Your store is registered with WordPress.com — finish connecting your account to use Automattic for Agencies dashboard, Woo mobile app, and Jetpack.',
 		],
 		[
 			'WOO_ONLY',
@@ -140,7 +140,7 @@ describe( 'auth subtitles', () => {
 		],
 		[
 			'ALL_THREE',
-			'Your store is registered with WordPress.com — connect this account to manage it from Automattic for Agencies, use the Woo mobile app and store analytics, and activate Jetpack.',
+			'Your store is registered with WordPress.com — connect this account to use Automattic for Agencies dashboard, Woo mobile app, and Jetpack.',
 		],
 		[
 			'WOO_ONLY',
@@ -216,7 +216,7 @@ describe( 'signup subtitles', () => {
 		],
 		[
 			'ALL_THREE',
-			"You'll use it to manage your store from Automattic for Agencies, log in to the Woo mobile app and view store analytics, and power Jetpack features.",
+			"You'll use it to access Automattic for Agencies dashboard, Woo mobile app, and Jetpack.",
 		],
 		[ 'WOO_ONLY', "You'll use it to log in to the Woo mobile app and view your store analytics." ],
 		[

--- a/client/jetpack-connect/connection-content/test/copy.test.ts
+++ b/client/jetpack-connect/connection-content/test/copy.test.ts
@@ -15,7 +15,6 @@ const SCENARIO_SLUGS: Record< SubtitleScenario, readonly string[] > = {
 	A4A_JETPACK: [ 'automattic-for-agencies-client', 'jetpack-boost' ],
 	ALL_THREE: [ 'automattic-for-agencies-client', 'woocommerce', 'jetpack' ],
 	WOO_ONLY: [ 'woocommerce' ],
-	WOOPAY_ONLY: [ 'woocommerce-payments' ],
 	WOO_AND_PAY: [ 'woocommerce', 'woocommerce-payments' ],
 	WOO_JETPACK: [ 'woocommerce', 'jetpack' ],
 	JETPACK_FULL: [ 'jetpack' ],
@@ -98,10 +97,6 @@ describe( 'login subtitles', () => {
 			'Your store is registered with WordPress.com — finish connecting your account to link it to WooCommerce.com for marketplace access, extensions, and analytics.',
 		],
 		[
-			'WOOPAY_ONLY',
-			'Your store is registered with WordPress.com — finish connecting your account to enable WooPayments for payment processing and account management.',
-		],
-		[
 			'WOO_AND_PAY',
 			'Your store is registered with WordPress.com — finish connecting your account to link it to WooCommerce.com and enable WooPayments for payment processing.',
 		],
@@ -178,10 +173,6 @@ describe( 'auth subtitles', () => {
 			'Your store is registered with WordPress.com — connect this account to link it to WooCommerce.com for marketplace access, analytics, and subscriptions.',
 		],
 		[
-			'WOOPAY_ONLY',
-			'Your store is registered with WordPress.com — connect this account to enable WooPayments to manage payments and your account.',
-		],
-		[
 			'WOO_AND_PAY',
 			'Your store is registered with WordPress.com — connect this account to link it to WooCommerce.com with WooPayments ready for payment processing.',
 		],
@@ -256,10 +247,6 @@ describe( 'signup subtitles', () => {
 		[
 			'WOO_ONLY',
 			"You'll use it to link your store to WooCommerce.com for marketplace access, extensions, and analytics.",
-		],
-		[
-			'WOOPAY_ONLY',
-			"You'll use it to enable WooPayments for your store's payment processing and account management.",
 		],
 		[
 			'WOO_AND_PAY',

--- a/client/jetpack-connect/connection-content/test/copy.test.ts
+++ b/client/jetpack-connect/connection-content/test/copy.test.ts
@@ -90,7 +90,7 @@ describe( 'login subtitles', () => {
 		],
 		[
 			'ALL_THREE',
-			'Your store is registered with WordPress.com — finish connecting your account to manage it from your Automattic for Agencies dashboard, use the Woo mobile app, access store analytics, and power Jetpack features.',
+			'Your store is registered with WordPress.com — finish connecting your account to manage it from Automattic for Agencies, use the Woo mobile app and store analytics, and power Jetpack features.',
 		],
 		[
 			'WOO_ONLY',
@@ -166,7 +166,7 @@ describe( 'auth subtitles', () => {
 		],
 		[
 			'ALL_THREE',
-			'Your store is registered with WordPress.com — connect this account to manage it from your Automattic for Agencies dashboard, use the Woo mobile app, access store analytics, and activate Jetpack.',
+			'Your store is registered with WordPress.com — connect this account to manage it from Automattic for Agencies, use the Woo mobile app and store analytics, and activate Jetpack.',
 		],
 		[
 			'WOO_ONLY',
@@ -242,7 +242,7 @@ describe( 'signup subtitles', () => {
 		],
 		[
 			'ALL_THREE',
-			"You'll use it to manage your store from Automattic for Agencies, log in to the Woo mobile app, view store analytics, and power Jetpack features.",
+			"You'll use it to manage your store from Automattic for Agencies, log in to the Woo mobile app and view store analytics, and power Jetpack features.",
 		],
 		[ 'WOO_ONLY', "You'll use it to log in to the Woo mobile app and view your store analytics." ],
 		[

--- a/client/jetpack-connect/connection-content/test/copy.test.ts
+++ b/client/jetpack-connect/connection-content/test/copy.test.ts
@@ -64,7 +64,7 @@ describe( 'login subtitles', () => {
 		],
 		[
 			'ALL_THREE',
-			'Your store is registered with WordPress.com — finish connecting your account to use Automattic for Agencies dashboard, Woo mobile app, and Jetpack.',
+			'Your store is registered with WordPress.com — finish connecting your account to use the Automattic for Agencies dashboard, the Woo mobile app, and Jetpack.',
 		],
 		[
 			'WOO_ONLY',
@@ -140,7 +140,7 @@ describe( 'auth subtitles', () => {
 		],
 		[
 			'ALL_THREE',
-			'Your store is registered with WordPress.com — connect this account to use Automattic for Agencies dashboard, Woo mobile app, and Jetpack.',
+			'Your store is registered with WordPress.com — connect this account to use the Automattic for Agencies dashboard, the Woo mobile app, and Jetpack.',
 		],
 		[
 			'WOO_ONLY',
@@ -216,7 +216,7 @@ describe( 'signup subtitles', () => {
 		],
 		[
 			'ALL_THREE',
-			"You'll use it to access Automattic for Agencies dashboard, Woo mobile app, and Jetpack.",
+			"You'll use it to access the Automattic for Agencies dashboard, the Woo mobile app, and Jetpack.",
 		],
 		[ 'WOO_ONLY', "You'll use it to log in to the Woo mobile app and view your store analytics." ],
 		[

--- a/client/jetpack-connect/connection-content/test/scenarios.test.ts
+++ b/client/jetpack-connect/connection-content/test/scenarios.test.ts
@@ -1,0 +1,122 @@
+import { getSubtitleScenario } from '../scenarios';
+
+describe( 'getSubtitleScenario', () => {
+	describe( 'multi-family combinations', () => {
+		test( 'A4A + Woo + Jetpack returns ALL_THREE regardless of slug order', () => {
+			expect(
+				getSubtitleScenario( [ 'jetpack', 'woocommerce', 'automattic-for-agencies-client' ] )
+			).toBe( 'ALL_THREE' );
+			expect(
+				getSubtitleScenario( [ 'automattic-for-agencies-client', 'woocommerce', 'jetpack' ] )
+			).toBe( 'ALL_THREE' );
+		} );
+
+		test( 'A4A + Woo (no Jetpack) returns A4A_WOO', () => {
+			expect( getSubtitleScenario( [ 'automattic-for-agencies-client', 'woocommerce' ] ) ).toBe(
+				'A4A_WOO'
+			);
+		} );
+
+		test( 'A4A + Jetpack (no Woo) returns A4A_JETPACK', () => {
+			expect( getSubtitleScenario( [ 'automattic-for-agencies-client', 'jetpack-boost' ] ) ).toBe(
+				'A4A_JETPACK'
+			);
+		} );
+
+		test( 'Woo + Jetpack (no A4A) returns WOO_JETPACK', () => {
+			expect( getSubtitleScenario( [ 'woocommerce', 'jetpack' ] ) ).toBe( 'WOO_JETPACK' );
+			expect( getSubtitleScenario( [ 'woocommerce-payments', 'jetpack-protect' ] ) ).toBe(
+				'WOO_JETPACK'
+			);
+		} );
+	} );
+
+	describe( 'single-family — A4A', () => {
+		test( 'returns A4A_ONLY for the agencies-client plugin', () => {
+			expect( getSubtitleScenario( [ 'automattic-for-agencies-client' ] ) ).toBe( 'A4A_ONLY' );
+		} );
+	} );
+
+	describe( 'single-family — Woo', () => {
+		test( 'returns WOO_ONLY for woocommerce alone', () => {
+			expect( getSubtitleScenario( [ 'woocommerce' ] ) ).toBe( 'WOO_ONLY' );
+		} );
+
+		test( 'returns WOOPAY_ONLY for woocommerce-payments alone', () => {
+			expect( getSubtitleScenario( [ 'woocommerce-payments' ] ) ).toBe( 'WOOPAY_ONLY' );
+		} );
+
+		test( 'returns WOO_AND_PAY when both core and payments are active', () => {
+			expect( getSubtitleScenario( [ 'woocommerce', 'woocommerce-payments' ] ) ).toBe(
+				'WOO_AND_PAY'
+			);
+			expect( getSubtitleScenario( [ 'woocommerce-payments', 'woocommerce' ] ) ).toBe(
+				'WOO_AND_PAY'
+			);
+		} );
+
+		test( 'an unknown Woo-prefixed slug routes to WOO_ONLY (not WOOPAY)', () => {
+			expect( getSubtitleScenario( [ 'woocommerce-marketing' ] ) ).toBe( 'WOO_ONLY' );
+		} );
+	} );
+
+	describe( 'single-family — Jetpack', () => {
+		test( 'returns JETPACK_FULL when the full Jetpack plugin is present', () => {
+			expect( getSubtitleScenario( [ 'jetpack' ] ) ).toBe( 'JETPACK_FULL' );
+		} );
+
+		test( 'full Jetpack wins even when individual plugins are also active', () => {
+			expect( getSubtitleScenario( [ 'jetpack', 'jetpack-backup' ] ) ).toBe( 'JETPACK_FULL' );
+			expect( getSubtitleScenario( [ 'jetpack-protect', 'jetpack' ] ) ).toBe( 'JETPACK_FULL' );
+		} );
+
+		test.each( [
+			[ 'jetpack-backup', 'JETPACK_BACKUP' ],
+			[ 'jetpack-protect', 'JETPACK_PROTECT' ],
+			[ 'jetpack-boost', 'JETPACK_BOOST' ],
+			[ 'jetpack-search', 'JETPACK_SEARCH' ],
+			[ 'jetpack-social', 'JETPACK_SOCIAL' ],
+			[ 'jetpack-videopress', 'JETPACK_VIDEOPRESS' ],
+		] )( 'returns %s for the dedicated single-plugin slug', ( slug, expected ) => {
+			expect( getSubtitleScenario( [ slug ] ) ).toBe( expected );
+		} );
+
+		test( 'returns JETPACK_MULTI when 2+ individual Jetpack plugins are active without the full plugin', () => {
+			expect( getSubtitleScenario( [ 'jetpack-backup', 'jetpack-protect' ] ) ).toBe(
+				'JETPACK_MULTI'
+			);
+			expect( getSubtitleScenario( [ 'jetpack-search', 'jetpack-social', 'jetpack-boost' ] ) ).toBe(
+				'JETPACK_MULTI'
+			);
+		} );
+
+		test( 'an unknown jetpack-prefixed individual slug routes to JETPACK_MULTI', () => {
+			expect( getSubtitleScenario( [ 'jetpack-stats' ] ) ).toBe( 'JETPACK_MULTI' );
+		} );
+	} );
+
+	describe( 'fallback', () => {
+		test( 'returns OTHER_ONLY for an empty plugin list', () => {
+			expect( getSubtitleScenario( [] ) ).toBe( 'OTHER_ONLY' );
+			expect( getSubtitleScenario() ).toBe( 'OTHER_ONLY' );
+		} );
+
+		test( 'returns OTHER_ONLY when only unknown plugins are active', () => {
+			expect( getSubtitleScenario( [ 'some-third-party-plugin' ] ) ).toBe( 'OTHER_ONLY' );
+			expect( getSubtitleScenario( [ 'foo', 'bar', 'baz' ] ) ).toBe( 'OTHER_ONLY' );
+		} );
+
+		test( 'unknown plugins are silently ignored when a known family is also present', () => {
+			expect( getSubtitleScenario( [ 'jetpack', 'unknown-plugin' ] ) ).toBe( 'JETPACK_FULL' );
+			expect( getSubtitleScenario( [ 'woocommerce', 'unknown-plugin' ] ) ).toBe( 'WOO_ONLY' );
+			expect(
+				getSubtitleScenario( [
+					'automattic-for-agencies-client',
+					'woocommerce',
+					'jetpack',
+					'unknown-plugin',
+				] )
+			).toBe( 'ALL_THREE' );
+		} );
+	} );
+} );

--- a/client/jetpack-connect/connection-content/test/scenarios.test.ts
+++ b/client/jetpack-connect/connection-content/test/scenarios.test.ts
@@ -42,10 +42,6 @@ describe( 'getSubtitleScenario', () => {
 			expect( getSubtitleScenario( [ 'woocommerce' ] ) ).toBe( 'WOO_ONLY' );
 		} );
 
-		test( 'returns WOOPAY_ONLY for woocommerce-payments alone', () => {
-			expect( getSubtitleScenario( [ 'woocommerce-payments' ] ) ).toBe( 'WOOPAY_ONLY' );
-		} );
-
 		test( 'returns WOO_AND_PAY when both core and payments are active', () => {
 			expect( getSubtitleScenario( [ 'woocommerce', 'woocommerce-payments' ] ) ).toBe(
 				'WOO_AND_PAY'
@@ -55,8 +51,16 @@ describe( 'getSubtitleScenario', () => {
 			);
 		} );
 
-		test( 'an unknown Woo-prefixed slug routes to WOO_ONLY (not WOOPAY)', () => {
+		test( 'an unknown Woo-prefixed slug routes to WOO_ONLY', () => {
 			expect( getSubtitleScenario( [ 'woocommerce-marketing' ] ) ).toBe( 'WOO_ONLY' );
+		} );
+
+		test( 'a malformed woocommerce-payments-only list defensively routes to WOO_ONLY', () => {
+			// WooPayments has a hard activation dependency on WooCommerce
+			// core, so this combination cannot occur in practice. The
+			// fall-through guarantees the flow still uses store-aware copy
+			// if the plugin list ever arrives malformed.
+			expect( getSubtitleScenario( [ 'woocommerce-payments' ] ) ).toBe( 'WOO_ONLY' );
 		} );
 	} );
 

--- a/client/jetpack-connect/test/__snapshots__/signup.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/signup.js.snap
@@ -412,7 +412,7 @@ exports[`JetpackSignup should render with the connector branding when from=jetpa
         <p
           class="connect-screen-brand-header__description"
         >
-          You'll use it to unlock powerful features on your store.
+          You'll use it to link your store to WooCommerce.com and power Jetpack features.
         </p>
       </div>
       <div

--- a/client/jetpack-connect/test/__snapshots__/signup.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/signup.js.snap
@@ -412,7 +412,7 @@ exports[`JetpackSignup should render with the connector branding when from=jetpa
         <p
           class="connect-screen-brand-header__description"
         >
-          You'll use it to link your store to WooCommerce.com and power Jetpack features.
+          You'll use it to log in to the Woo mobile app, view your store analytics, and power Jetpack features.
         </p>
       </div>
       <div

--- a/client/jetpack-connect/test/authorize.js
+++ b/client/jetpack-connect/test/authorize.js
@@ -126,10 +126,13 @@ describe( 'JetpackAuthorize', () => {
 			'Connect your account'
 		);
 
-		// Subtitle (BrandHeader description) reflects the store wording when a
-		// Woo plugin is present in the active plugin list.
+		// Subtitle (BrandHeader description) reflects the WOO_JETPACK scenario
+		// — store wording (any Woo plugin present) plus the Woo+Jetpack
+		// benefit clause.
 		expect(
-			screen.getByText( 'Your store is registered with WordPress.com.' )
+			screen.getByText(
+				'Your store is registered with WordPress.com — connect this account to link it to WooCommerce.com and activate Jetpack.'
+			)
 		).toBeInTheDocument();
 
 		// Composite Woo + Jetpack logo is rendered (vs. the Jetpack-only fallback).

--- a/client/jetpack-connect/test/authorize.js
+++ b/client/jetpack-connect/test/authorize.js
@@ -131,7 +131,7 @@ describe( 'JetpackAuthorize', () => {
 		// benefit clause.
 		expect(
 			screen.getByText(
-				'Your store is registered with WordPress.com — connect this account to link it to WooCommerce.com and activate Jetpack.'
+				'Your store is registered with WordPress.com — connect this account to use the Woo mobile app, access your store analytics, and activate Jetpack.'
 			)
 		).toBeInTheDocument();
 

--- a/client/login/wp-login/hooks/get-heading-subtext.tsx
+++ b/client/login/wp-login/hooks/get-heading-subtext.tsx
@@ -81,9 +81,10 @@ const getHeadingSubText = ( {
 
 	// Unified connection flow (jetpack-connector): a prominent, dotcom-styled
 	// subtitle sourced from the shared resolver sits between the H1 and the
-	// existing ToS line. PR 3 will extend the resolver with the family-driven
-	// benefit clause; the ToS keeps its established subtle styling
-	// underneath. Lostpassword keeps the standard reset-instructions copy.
+	// existing ToS line. The resolver returns the family-driven benefit
+	// clause for the active plugin set; the ToS keeps its established
+	// subtle styling underneath. Lostpassword keeps the standard
+	// reset-instructions copy.
 	if ( isFromJetpackConnector && 'lostpassword' !== action ) {
 		return {
 			primary: getLoginCopy( connectorPlugins ).subtitle,

--- a/client/login/wp-login/hooks/test/get-heading-subtext.test.tsx
+++ b/client/login/wp-login/hooks/test/get-heading-subtext.test.tsx
@@ -51,7 +51,7 @@ describe( 'getHeadingSubText', () => {
 		expect( screen.getByText( /WordPress.com is used to manage your account\./ ) ).toBeVisible();
 	} );
 
-	test( 'returns the registration acknowledgement (site) and keeps the ToS as secondary when from=jetpack-connector with no Woo plugins', () => {
+	test( 'returns the family-driven login subtitle (site noun) and keeps the ToS as secondary when from=jetpack-connector with a Jetpack-family plugin', () => {
 		const subtext = getHeadingSubText( {
 			isSocialFirst: true,
 			twoFactorAuthType: '',
@@ -61,7 +61,9 @@ describe( 'getHeadingSubText', () => {
 			connectorPlugins: [ 'jetpack' ],
 		} );
 
-		expect( subtext?.primary ).toBe( 'Your site is registered with WordPress.com.' );
+		expect( subtext?.primary ).toBe(
+			'Your site is registered with WordPress.com — finish connecting your account to power Jetpack with backups, security, and growth tools.'
+		);
 		expect( subtext?.secondary ).toBeTruthy();
 		render( <>{ subtext?.secondary }</> );
 		expect(
@@ -69,7 +71,7 @@ describe( 'getHeadingSubText', () => {
 		).toBeVisible();
 	} );
 
-	test( 'uses the store wording when from=jetpack-connector with a Woo plugin', () => {
+	test( 'uses the store wording and the Woo+Jetpack scenario when from=jetpack-connector with both families', () => {
 		const subtext = getHeadingSubText( {
 			isSocialFirst: true,
 			twoFactorAuthType: '',
@@ -79,7 +81,9 @@ describe( 'getHeadingSubText', () => {
 			connectorPlugins: [ 'woocommerce', 'jetpack' ],
 		} );
 
-		expect( subtext?.primary ).toBe( 'Your store is registered with WordPress.com.' );
+		expect( subtext?.primary ).toBe(
+			'Your store is registered with WordPress.com — finish connecting your account to link it to WooCommerce.com and power Jetpack features.'
+		);
 		expect( subtext?.secondary ).toBeTruthy();
 	} );
 

--- a/client/login/wp-login/hooks/test/get-heading-subtext.test.tsx
+++ b/client/login/wp-login/hooks/test/get-heading-subtext.test.tsx
@@ -82,7 +82,7 @@ describe( 'getHeadingSubText', () => {
 		} );
 
 		expect( subtext?.primary ).toBe(
-			'Your store is registered with WordPress.com — finish connecting your account to link it to WooCommerce.com and power Jetpack features.'
+			'Your store is registered with WordPress.com — finish connecting your account to use the Woo mobile app, access your store analytics, and power Jetpack features.'
 		);
 		expect( subtext?.secondary ).toBeTruthy();
 	} );


### PR DESCRIPTION
Part of CONNECT-186.

Builds on the [foundation module](https://github.com/Automattic/wp-calypso/pull/110449) (PR 1/5) and [account H1 + interim subtitle](https://github.com/Automattic/wp-calypso/pull/110458) (PR 2/5).

## Proposed Changes

Replaces PR 2's interim acknowledgement-only subtitle with the full 16-scenario subtitle table for each connector-flow surface (login, auth, signup), keyed by which families and individual plugins are present in the active plugin set.

### New `client/jetpack-connect/connection-content/scenarios.ts`

- `SubtitleScenario` type — the canonical 16-key enum.
- `getSubtitleScenario(pluginSlugs)` — pure decision function. Multi-family takes priority over single-family; for single-family Woo it disambiguates `WooCommerce` alone vs. `WooCommerce` + `WooPayments`; for single-family Jetpack it distinguishes the full plugin from a single individual plugin and from 2+ individual plugins.
- `WooPayments` cannot run without WooCommerce core, so there is no `WOOPAY_ONLY` scenario; if `woocommerce-payments` somehow appears alone in the query string, the resolver routes it to `WOO_ONLY` as a defensive fallback.
- Unknown ("other"-family) plugins are silently ignored when a known family is present — they get surfaced in the PR 4 "Also used by" row, never in the subtitle.

### Extended `connection-content/copy.ts`

- 48 pre-composed `__()`-wrapped sentences (16 scenarios × 3 surfaces). No runtime template assembly, no placeholders inside the strings — translators always receive a complete sentence.
- `JETPACK_MULTI` reuses `JETPACK_FULL`'s string per the plan's "any 2+ individual Jetpacks" simplification — the precise plugin mix is delivered in the PR 4 Features section, not the subtitle.
- The Woo subtitles intentionally do **not** mention WooCommerce.com. The WordPress.com connection enables the Woo mobile app and store analytics today; the WooCommerce.com marketplace integration isn't wired up yet, so the copy stays grounded in what the connection actually unlocks.
- Surface templates (internal authoring guide; not exposed to translators):

  | Surface | Template |
  |---|---|
  | Login | `Your {site\|store} is registered with WordPress.com — finish connecting your account to {benefit}.` |
  | Auth | `Your {site\|store} is registered with WordPress.com — connect this account to {benefit}.` |
  | Signup | `You'll use it to {benefit}.` |

  The auth verb shifts from "finish connecting" to "connect this account" — the user is one click from approving. The signup template drops the registration acknowledgement entirely (already shown on the prior login screen) and uses the forward-looking value-prop frame established in PR 2. Signup also uses "log in to the Woo mobile app" / "view store analytics" instead of "use … access …" to avoid a "use it to use" repetition.

### Site Name placeholder dropped

The plan originally proposed a `for {Site Name}` tail on the auth subtitle. Dropped for PR 3:
- Long site names would break the narrow 520px connector column.
- The site context is already established by the URL/tab.
- A `%s` placeholder per string × 16 scenarios adds translator overhead we don't yet need.

Easy to add back as a focused follow-up if reviewer feedback suggests it matters.

### Wired through the existing call sites

`getAuthCopy`, `getSignupCopy`, and `getLoginCopy` keep the same signatures and return `{ title, subtitle }` exactly as before. Every consumer (`authorize.jsx`, `signup.jsx`, `get-header-text.tsx`, `get-heading-subtext.tsx`) picks up the dynamic subtitle automatically — no call-site changes needed.

### Tests

- New `scenarios.test.ts` covering multi-family priority, Woo core/payments combinations, full vs. individual Jetpack disambiguation, unknown-plugin demotion, the empty/missing-input fallback, and the defensive `woocommerce-payments`-alone routing.
- `copy.test.ts` rewritten with `test.each` tables: 48 surface-subtitle assertions plus title and default-argument coverage.
- Existing tests refreshed for the new strings: `signup.js.snap`, `authorize.js` targeted assertions, `get-heading-subtext.test.tsx` login-flow assertions.

All connector unit tests green. ESLint + Prettier clean.

## Why are these changes being made?

PR 2 introduced the structural shell — H1 swap, dynamic subtitle slot, prominent styling — with a single placeholder subtitle (`Your site is registered with WordPress.com.`). PR 3 fills the slot with the full family-driven copy:

- Each surface gets a dedicated subtitle that names the user's actual benefit, not a generic one.
- A4A users see A4A copy; Woo-only users see Woo-mobile-app + analytics copy; Jetpack Boost-only users see Boost-specific copy; etc.
- The all-three (A4A + Woo + Jetpack) scenario explicitly names all three families in the subtitle so Jetpack isn't silently absent when it's demoted to "Also used by" in PR 4.

The 16-scenario approach scales: adding a new plugin to an existing family doesn't require new copy; adding a new family does require updating the matrix but stays within a single file.

## New / changed user-facing strings

48 new pre-composed sentences. Full inventory:

### Login subtitles

| Scenario | String |
|---|---|
| `A4A_ONLY` | Your site is registered with WordPress.com — finish connecting your account to manage it from your Automattic for Agencies dashboard. |
| `A4A_WOO` | Your store is registered with WordPress.com — finish connecting your account to manage it from Automattic for Agencies, use the Woo mobile app, and access store analytics. |
| `A4A_JETPACK` | Your site is registered with WordPress.com — finish connecting your account to manage it from Automattic for Agencies and power Jetpack features. |
| `ALL_THREE` | Your store is registered with WordPress.com — finish connecting your account to manage it from Automattic for Agencies, use the Woo mobile app and store analytics, and power Jetpack features. |
| `WOO_ONLY` | Your store is registered with WordPress.com — finish connecting your account to use the Woo mobile app and access your store analytics. |
| `WOO_AND_PAY` | Your store is registered with WordPress.com — finish connecting your account to use the Woo mobile app, access your store analytics, and enable WooPayments for payment processing. |
| `WOO_JETPACK` | Your store is registered with WordPress.com — finish connecting your account to use the Woo mobile app, access your store analytics, and power Jetpack features. |
| `JETPACK_FULL` | Your site is registered with WordPress.com — finish connecting your account to power Jetpack with backups, security, and growth tools. |
| `JETPACK_BACKUP` | Your site is registered with WordPress.com — finish connecting your account to enable real-time backups and one-click restore via Jetpack VaultPress Backup. |
| `JETPACK_PROTECT` | Your site is registered with WordPress.com — finish connecting your account to enable Jetpack Protect's security scanning and malware protection. |
| `JETPACK_BOOST` | Your site is registered with WordPress.com — finish connecting your account to enable Jetpack Boost's site performance optimization. |
| `JETPACK_SEARCH` | Your site is registered with WordPress.com — finish connecting your account to enable Jetpack Search's instant results. |
| `JETPACK_SOCIAL` | Your site is registered with WordPress.com — finish connecting your account to enable Jetpack Social's automated post sharing. |
| `JETPACK_VIDEOPRESS` | Your site is registered with WordPress.com — finish connecting your account to enable Jetpack VideoPress's ad-free video hosting. |
| `JETPACK_MULTI` | (reuses `JETPACK_FULL`) |
| `OTHER_ONLY` | Your site is registered with WordPress.com — finish connecting your account to power your active plugins. |

### Auth subtitles

Same 16 scenarios; each replaces "finish connecting your account" with "connect this account". `JETPACK_FULL` reads `…connect this account to activate Jetpack with backups, security, and stats.` See `getAuthSubtitles` in [`copy.ts`](client/jetpack-connect/connection-content/copy.ts) for the full table.

### Signup subtitles

Forward-looking `You'll use it to {benefit}.` frame. Examples:

| Scenario | String |
|---|---|
| `JETPACK_FULL` | You'll use it to power Jetpack with backups, security, and growth tools on your site. |
| `WOO_ONLY` | You'll use it to log in to the Woo mobile app and view your store analytics. |
| `ALL_THREE` | You'll use it to manage your store from Automattic for Agencies, log in to the Woo mobile app and view store analytics, and power Jetpack features. |

See `getSignupSubtitles` in [`copy.ts`](client/jetpack-connect/connection-content/copy.ts) for the full table.

## Testing Instructions

Run a self-hosted Jetpack site that lands on the connector flow at `/jetpack/connect/authorize?from=jetpack-connector&plugins=...`, then verify the subtitle on each surface for the test cases below.

### Single-family scenarios

- `?plugins=jetpack`: subtitle ends with `…power Jetpack with backups, security, and growth tools.`
- `?plugins=jetpack-boost`: subtitle ends with `…enable Jetpack Boost's site performance optimization.`
- `?plugins=woocommerce`: subtitle ends with `…use the Woo mobile app and access your store analytics.` (and `Your store is registered…`)
- `?plugins=woocommerce,woocommerce-payments`: subtitle ends with `…use the Woo mobile app, access your store analytics, and enable WooPayments for payment processing.`
- `?plugins=automattic-for-agencies-client`: subtitle ends with `…manage it from your Automattic for Agencies dashboard.`

### Multi-family scenarios

- `?plugins=woocommerce,jetpack`: subtitle ends with `…use the Woo mobile app, access your store analytics, and power Jetpack features.`
- `?plugins=automattic-for-agencies-client,woocommerce`: subtitle ends with `…manage it from Automattic for Agencies, use the Woo mobile app, and access store analytics.`
- `?plugins=automattic-for-agencies-client,woocommerce,jetpack`: subtitle is the three-family variant naming A4A, the Woo mobile app + analytics, and Jetpack features.

### Edge cases

- `?plugins=jetpack-backup,jetpack-protect`: subtitle reuses the full-Jetpack copy (`…power Jetpack with backups, security, and growth tools.`).
- `?plugins=some-third-party-plugin`: subtitle ends with `…power your active plugins.`
- No `plugins=` query arg: same as the OTHER_ONLY case (graceful fallback).
- `?plugins=woocommerce-payments` (impossible in practice — WooPayments requires Woo core): defensively renders the WOO_ONLY copy rather than blowing up.

### Cross-surface check

For at least one scenario (suggest `?plugins=woocommerce,jetpack`), pass through all three surfaces:

1. Login (`/log-in/jetpack?from=jetpack-connector&plugins=woocommerce,jetpack`): subtitle reads `…finish connecting your account to use the Woo mobile app, access your store analytics, and power Jetpack features.` plus the ToS underneath in `studio-gray-50`.
2. Signup (reach via `Create an account` link): subtitle reads `You'll use it to log in to the Woo mobile app, view your store analytics, and power Jetpack features.`
3. Auth (after signing in or creating an account): subtitle reads `…connect this account to use the Woo mobile app, access your store analytics, and activate Jetpack.`

### Regressions

- Confirm WooJPC (`/log-in/jetpack?from=woocommerce-core-profiler`) is visually unchanged — this work is gated on `from=jetpack-connector` only.
- Confirm magic-login (`/log-in/jetpack/link?...`) is visually unchanged.
- Confirm lostpassword (`/log-in/jetpack/lostpassword?from=jetpack-connector`) still shows the existing reset-instruction copy, not a connector subtitle.

### Screenshots

There are a lot of strings in this PR but they are all related to these three screens:

<img width="723" height="293" alt="Screenshot 2026-05-06 at 13 33 46" src="https://github.com/user-attachments/assets/9672ecee-300e-4c37-9841-a29f94fa1d89" />
<img width="747" height="277" alt="Screenshot 2026-05-06 at 13 32 04" src="https://github.com/user-attachments/assets/57e0b30a-c158-4aee-bef5-8045ff392eb9" />
<img width="621" height="311" alt="Screenshot 2026-05-06 at 13 31 43" src="https://github.com/user-attachments/assets/5054d29c-e68c-48cd-a706-2412df8f9884" />




## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
