### PR TITLE
Add headers support to `wpcomRequest`

### DIFF
--- a/packages/wpcom-proxy-request/types/index.d.ts
+++ b/packages/wpcom-proxy-request/types/index.d.ts
@@ -21,7 +21,7 @@ export interface WpcomRequestParams {
 	signal?: AbortSignal;
 	apiNamespace?: string;
 	formData?: ( string | File )[][];
-	// Search for allowedRequestHeaders in OpenGrok to extend these.
+	// Search for allowedRequestHeaders to extend these.
 	headers?: {
 		'X-WPCOM-AI-Feature'?: string;
 		'X-Fingerprint'?: string;

--- a/packages/wpcom-proxy-request/types/index.d.ts
+++ b/packages/wpcom-proxy-request/types/index.d.ts
@@ -21,6 +21,12 @@ export interface WpcomRequestParams {
 	signal?: AbortSignal;
 	apiNamespace?: string;
 	formData?: ( string | File )[][];
+	// Search for allowedRequestHeaders in OpenGrok to extend these.
+	headers?: {
+		'X-WPCOM-AI-Feature'?: string;
+		'X-Fingerprint'?: string;
+		Accept?: string;
+	};
 }
 
 export function reloadProxy(): void;


### PR DESCRIPTION
This mirrors the rest proxy config of the allowed request headers.

Required for https://github.com/Automattic/wp-calypso/pull/110149