### PR TITLE
agents-manager: extract useRegisterCustomActions hook

### DIFF
--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -15,6 +15,7 @@ import useConversation from '../../hooks/use-conversation';
 import useCopyAction from '../../hooks/use-copy-action';
 import useFeedbackAction from '../../hooks/use-feedback-action';
 import useSaveNewChatRoute from '../../hooks/use-save-new-chat-route';
+import useRegisterCustomActions from '../../hooks/use-setup-custom-actions/use-register-custom-actions';
 import useSourcesAction from '../../hooks/use-sources-action';
 import useZoomAction from '../../hooks/use-zoom-action';
 import { markSessionUsed } from '../../utils/agent-session';
@@ -275,20 +276,7 @@ export default function OrchestratorChat( {
 		[ inputValue, onSubmitWithImages ]
 	);
 
-	useEffect( () => {
-		window.__agentsManagerActions = window.__agentsManagerActions || ( {} as AgentsManagerActions );
-		window.__agentsManagerActions.setChatInput = setChatInput;
-		window.__agentsManagerActions.submitChatMessage = submitChatMessage;
-
-		return () => {
-			if ( window.__agentsManagerActions?.setChatInput === setChatInput ) {
-				delete window.__agentsManagerActions.setChatInput;
-			}
-			if ( window.__agentsManagerActions?.submitChatMessage === submitChatMessage ) {
-				delete window.__agentsManagerActions.submitChatMessage;
-			}
-		};
-	}, [ setChatInput, submitChatMessage ] );
+	useRegisterCustomActions( { setChatInput, submitChatMessage } );
 
 	const handleContextCardAction = useCallback(
 		( card: ExternalContextCard, action: ExternalContextCardAction ) => {

--- a/packages/agents-manager/src/hooks/__tests__/use-register-custom-actions.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-register-custom-actions.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import useRegisterCustomActions from '../use-setup-custom-actions/use-register-custom-actions';
+
+describe( 'useRegisterCustomActions', () => {
+	beforeEach( () => {
+		delete window.__agentsManagerActions;
+	} );
+
+	it( 'registers each action on window.__agentsManagerActions', () => {
+		const setChatInput = jest.fn();
+		const submitChatMessage = jest.fn();
+
+		renderHook( () => useRegisterCustomActions( { setChatInput, submitChatMessage } ) );
+
+		expect( window.__agentsManagerActions?.setChatInput ).toBe( setChatInput );
+		expect( window.__agentsManagerActions?.submitChatMessage ).toBe( submitChatMessage );
+	} );
+
+	it( 'cleans up only its own keys on unmount', () => {
+		const setChatInput = jest.fn();
+		// Pre-populate an unrelated action that the hook must not touch.
+		window.__agentsManagerActions = {
+			setContextEntry: jest.fn(),
+		} as unknown as AgentsManagerActions;
+		const externalSetContextEntry = window.__agentsManagerActions.setContextEntry;
+
+		const { unmount } = renderHook( () => useRegisterCustomActions( { setChatInput } ) );
+		unmount();
+
+		expect( window.__agentsManagerActions?.setChatInput ).toBeUndefined();
+		expect( window.__agentsManagerActions?.setContextEntry ).toBe( externalSetContextEntry );
+	} );
+
+	it( 'leaves a replacement value alone when the effect re-runs', () => {
+		const first = jest.fn();
+		const second = jest.fn();
+
+		const { rerender } = renderHook(
+			( { fn } ) => useRegisterCustomActions( { setChatInput: fn } ),
+			{
+				initialProps: { fn: first },
+			}
+		);
+		expect( window.__agentsManagerActions?.setChatInput ).toBe( first );
+
+		rerender( { fn: second } );
+		expect( window.__agentsManagerActions?.setChatInput ).toBe( second );
+	} );
+
+	it( 'does not delete a key that another consumer has overwritten', () => {
+		const ours = jest.fn();
+		const theirs = jest.fn();
+
+		const { unmount } = renderHook( () => useRegisterCustomActions( { setChatInput: ours } ) );
+		// Simulate another consumer replacing our value before we unmount.
+		( window.__agentsManagerActions as AgentsManagerActions ).setChatInput = theirs;
+
+		unmount();
+
+		expect( window.__agentsManagerActions?.setChatInput ).toBe( theirs );
+	} );
+} );

--- a/packages/agents-manager/src/hooks/use-setup-custom-actions/use-register-custom-actions.ts
+++ b/packages/agents-manager/src/hooks/use-setup-custom-actions/use-register-custom-actions.ts
@@ -1,0 +1,50 @@
+import { useEffect } from '@wordpress/element';
+
+/**
+ * Register a set of action callbacks on `window.__agentsManagerActions`,
+ * cleaning up only the keys this caller wrote.
+ *
+ * Multiple components can write to the same global object (for example
+ * `useSetupCustomActions` in `AgentDock` and component-local actions in
+ * `OrchestratorChat`). The cleanup compares each key's current value
+ * against the callback identity this hook registered, so a fresh
+ * registration that has already replaced our value is left intact and
+ * registrations from other consumers are never touched.
+ *
+ * Callers should wrap each callback in `useCallback` so identities only
+ * change when their inputs do — otherwise the registration effect re-runs
+ * every render.
+ * @param actions Map of action keys to callback functions.
+ */
+export default function useRegisterCustomActions( actions: Partial< AgentsManagerActions > ): void {
+	useEffect(
+		() => {
+			window.__agentsManagerActions =
+				window.__agentsManagerActions || ( {} as AgentsManagerActions );
+
+			const target = window.__agentsManagerActions;
+			const keys = Object.keys( actions ) as Array< keyof AgentsManagerActions >;
+
+			keys.forEach( ( key ) => {
+				( target as unknown as Record< string, unknown > )[ key ] = actions[ key ];
+			} );
+
+			return () => {
+				const current = window.__agentsManagerActions;
+				if ( ! current ) {
+					return;
+				}
+				keys.forEach( ( key ) => {
+					if ( current[ key ] === actions[ key ] ) {
+						delete ( current as unknown as Record< string, unknown > )[ key ];
+					}
+				} );
+			};
+		},
+		// Re-run whenever any callback identity changes. The `actions`
+		// object is recreated on every render, so we depend on its values
+		// (which are expected to be memoized) rather than the object itself.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		Object.values( actions )
+	);
+}


### PR DESCRIPTION
Part of #110400 (follow-up)

## Proposed Changes

* Add a new helper hook, `useRegisterCustomActions`, in `packages/agents-manager/src/hooks/use-setup-custom-actions/`. It registers a partial map of `AgentsManagerActions` callbacks on `window.__agentsManagerActions` and cleans up only the keys it wrote, by callback identity.
* Refactor `OrchestratorChat` to use the new hook instead of an inline `useEffect` that did the same registration + cleanup work.
* Add unit tests covering registration, scoped cleanup, replacement on re-run, and respecting another consumer's overwrite.

## Why are these changes being made?

* In the [external-context bridge PR](https://github.com/Automattic/wp-calypso/pull/110400), `setChatInput` and `submitChatMessage` were registered directly inside `OrchestratorChat`, which duplicated the registration pattern that `useSetupCustomActions` already implements in `AgentDock`. Two components writing to the same global from two different places makes it harder to reason about ownership and cleanup.
* Reviewer feedback explicitly asked for a follow-up that consolidates the registration into the `use-setup-custom-actions` folder so all global-action wiring lives in one canonical place.
* `setChatInput` / `submitChatMessage` need access to `OrchestratorChat`-local state (`inputValue`, `setInputValue`, and `onSubmitWithImages` which closes over `useAgentChat`'s `onSubmit`). Lifting that state up to `AgentDock` would be a bigger refactor that churns `useAgentChat` placement. Extracting a shared registration helper instead lets each component keep its callbacks close to the state they need while sharing one canonical registration mechanism.

## Testing Instructions

* `yarn jest -c test/packages/jest.config.js --testPathPattern=agents-manager` — 170/170 should pass (4 new tests for the helper).
* `yarn typecheck-packages` — should be clean.
* In Calypso (`yarn start`) or any sandboxed Simple / Atomic / CIAB site:
  1. Open the chat (Big Sky / Agents Manager).
  2. Confirm `window.__agentsManagerActions.setChatInput("hello")` populates the textarea and focuses it.
  3. Confirm `window.__agentsManagerActions.submitChatMessage("hello")` sends the message.
  4. Verify the existing actions registered by `useSetupCustomActions` (e.g. `setChatOpen`, `setChatDocked`, `setContextEntry`) still work.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?