### PR TITLE
Dashboard: Sync sidebar scroll with body for tall sidebars

### DIFF
--- a/client/dashboard/app/omnibar/style.scss
+++ b/client/dashboard/app/omnibar/style.scss
@@ -1,5 +1,3 @@
-$omnibar-height: 32px;
-
 #wpcom-omnibar {
 	position: fixed;
 	top: 0;
@@ -8,7 +6,7 @@ $omnibar-height: 32px;
 }
 
 body:has( #wpcom-omnibar ) #wpcom {
-	padding-block-start: $omnibar-height;
+	padding-block-start: var(--omnibar-height);
 	height: auto;
-	min-height: calc( 100vh - #{$omnibar-height} );
+	min-height: calc( 100vh - var(--omnibar-height) );
 }

--- a/client/dashboard/app/responsive-sidebar/index.tsx
+++ b/client/dashboard/app/responsive-sidebar/index.tsx
@@ -18,7 +18,7 @@ export default function ResponsiveSidebar( {
 	const router = useRouter();
 	const isDesktop = useViewportMatch( 'medium' );
 
-	useSidebarScrollSync();
+	useSidebarScrollSync( isDesktop );
 
 	const handleOverlayClick = () => {
 		onClose();

--- a/client/dashboard/app/responsive-sidebar/index.tsx
+++ b/client/dashboard/app/responsive-sidebar/index.tsx
@@ -4,6 +4,7 @@ import clsx from 'clsx';
 import { useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import Sidebar from './sidebar';
+import { useSidebarScrollSync } from './use-sidebar-scroll-sync';
 
 import './style.scss';
 
@@ -16,6 +17,8 @@ export default function ResponsiveSidebar( {
 } ) {
 	const router = useRouter();
 	const isDesktop = useViewportMatch( 'medium' );
+
+	useSidebarScrollSync();
 
 	const handleOverlayClick = () => {
 		onClose();

--- a/client/dashboard/app/responsive-sidebar/index.tsx
+++ b/client/dashboard/app/responsive-sidebar/index.tsx
@@ -4,7 +4,6 @@ import clsx from 'clsx';
 import { useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import Sidebar from './sidebar';
-import { useSidebarScrollSync } from './use-sidebar-scroll-sync';
 
 import './style.scss';
 
@@ -17,8 +16,6 @@ export default function ResponsiveSidebar( {
 } ) {
 	const router = useRouter();
 	const isDesktop = useViewportMatch( 'medium' );
-
-	useSidebarScrollSync( isDesktop );
 
 	const handleOverlayClick = () => {
 		onClose();
@@ -46,7 +43,7 @@ export default function ResponsiveSidebar( {
 	}, [ isDesktop, router, onClose ] );
 
 	if ( isDesktop ) {
-		return <Sidebar />;
+		return <Sidebar scrollSyncEnabled />;
 	}
 
 	return (

--- a/client/dashboard/app/responsive-sidebar/sidebar.scss
+++ b/client/dashboard/app/responsive-sidebar/sidebar.scss
@@ -8,16 +8,17 @@
 	flex-direction: column;
 	flex-shrink: 0;
 	gap: $grid-unit-30;
-	position: sticky;
+	position: fixed;
 	top: var(--masterbar-height, 0);
+	inset-inline-start: 0;
+	bottom: 0;
 	width: $sidebar-width;
-	min-height: calc( 100vh - var( --masterbar-height, 0 ) );
 	padding: 0;
 	border-inline-end: $border-width solid var( --dashboard-header__border-color );
 	box-sizing: border-box;
 	color: var( --dashboard-menu-item__color );
 	background-color: var( --dashboard-header__background-color );
-	overflow-y: auto;
+	overflow: hidden;
 }
 
 .dashboard-responsive-sidebar__sidebar:not( :has( > .dashboard-responsive-sidebar__logo ) ) {

--- a/client/dashboard/app/responsive-sidebar/sidebar.scss
+++ b/client/dashboard/app/responsive-sidebar/sidebar.scss
@@ -8,10 +8,6 @@
 	flex-direction: column;
 	flex-shrink: 0;
 	gap: $grid-unit-30;
-	position: fixed;
-	top: var(--masterbar-height, 0);
-	inset-inline-start: 0;
-	bottom: 0;
 	width: $sidebar-width;
 	padding: 0;
 	border-inline-end: $border-width solid var( --dashboard-header__border-color );
@@ -19,6 +15,15 @@
 	color: var( --dashboard-menu-item__color );
 	background-color: var( --dashboard-header__background-color );
 	overflow: hidden;
+}
+
+// Desktop: pin to viewport. On mobile, the parent .dashboard-responsive-sidebar
+// is the fixed-positioned wrapper, so the inner sidebar stays in flow.
+.dashboard-root__body > .dashboard-responsive-sidebar__sidebar {
+	position: fixed;
+	top: var(--masterbar-height, 0);
+	inset-inline-start: 0;
+	bottom: 0;
 }
 
 .dashboard-responsive-sidebar__sidebar:not( :has( > .dashboard-responsive-sidebar__logo ) ) {

--- a/client/dashboard/app/responsive-sidebar/sidebar.tsx
+++ b/client/dashboard/app/responsive-sidebar/sidebar.tsx
@@ -1,6 +1,7 @@
 import { __experimentalHStack as HStack } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { brush, envelope, globe, layout, plugins } from '@wordpress/icons';
+import { useRef } from 'react';
 import RouterLinkButton from '../../components/router-link-button';
 import { SidebarExpandableMenuItem, SidebarMenu, SidebarMenuItem } from '../../components/sidebar';
 import SidebarNavigator from '../../components/sidebar-navigator';
@@ -10,15 +11,20 @@ import SiteSidebar from '../../sites/site-sidebar';
 import { wpcomLink } from '../../utils/link';
 import { useAnalytics } from '../analytics';
 import { useAppContext } from '../context';
+import { useSidebarScrollSync } from './use-sidebar-scroll-sync';
 
 import './sidebar.scss';
 
-export default function Sidebar() {
+export default function Sidebar( { scrollSyncEnabled = false }: { scrollSyncEnabled?: boolean } ) {
 	const { Logo, name } = useAppContext();
 	const { recordTracksEvent } = useAnalytics();
+	const sidebarRef = useRef< HTMLDivElement >( null );
+	const navigatorRef = useRef< HTMLDivElement >( null );
+
+	useSidebarScrollSync( { enabled: scrollSyncEnabled, sidebarRef, navigatorRef } );
 
 	return (
-		<div className="dashboard-responsive-sidebar__sidebar">
+		<div ref={ sidebarRef } className="dashboard-responsive-sidebar__sidebar">
 			{ Logo && (
 				<div className="dashboard-responsive-sidebar__logo">
 					<RouterLinkButton
@@ -32,7 +38,7 @@ export default function Sidebar() {
 					/>
 				</div>
 			) }
-			<SidebarNavigator>
+			<SidebarNavigator ref={ navigatorRef }>
 				<SidebarNavigator.Screen path="/">
 					<PrimaryMenuSidebar />
 				</SidebarNavigator.Screen>

--- a/client/dashboard/app/responsive-sidebar/use-sidebar-scroll-sync.ts
+++ b/client/dashboard/app/responsive-sidebar/use-sidebar-scroll-sync.ts
@@ -77,25 +77,43 @@ export function useSidebarScrollSync( enabled: boolean = true ) {
 			window.requestAnimationFrame( apply );
 		};
 
-		const onScroll = schedule;
-		const onResize = () => {
+		// One observer for everything that could invalidate our cached
+		// measurements:
+		// - the inner navigator: SidebarNavigator swaps screens between
+		//   routes and each screen has a different content height. We
+		//   observe the navigator rather than the sidebar itself because
+		//   when the sidebar overflows, this hook pins `style.height` on
+		//   the sidebar, so its box-size stops reflecting content changes.
+		// - the masterbar: its height changes at the responsive breakpoint.
+		// - documentElement: stands in for window resize.
+		const resizeObserver = new ResizeObserver( () => {
 			measure();
 			schedule();
-		};
+		} );
+		resizeObserver.observe( document.documentElement );
 
 		// Initial measurement may need to wait for masterbar to mount.
 		const initId = window.requestAnimationFrame( () => {
 			measure();
 			schedule();
+			const { masterbar } = getEls();
+			const navigator = document.querySelector< HTMLElement >(
+				'.dashboard-responsive-sidebar__sidebar .dashboard-sidebar-navigator'
+			);
+			if ( navigator ) {
+				resizeObserver.observe( navigator );
+			}
+			if ( masterbar ) {
+				resizeObserver.observe( masterbar );
+			}
 		} );
 
-		window.addEventListener( 'scroll', onScroll, { passive: true } );
-		window.addEventListener( 'resize', onResize );
+		window.addEventListener( 'scroll', schedule, { passive: true } );
 
 		return () => {
 			window.cancelAnimationFrame( initId );
-			window.removeEventListener( 'scroll', onScroll );
-			window.removeEventListener( 'resize', onResize );
+			window.removeEventListener( 'scroll', schedule );
+			resizeObserver.disconnect();
 			const { sidebar, content } = getEls();
 			sidebar?.removeAttribute( 'style' );
 			if ( content ) {

--- a/client/dashboard/app/responsive-sidebar/use-sidebar-scroll-sync.ts
+++ b/client/dashboard/app/responsive-sidebar/use-sidebar-scroll-sync.ts
@@ -10,8 +10,11 @@ import { useEffect } from 'react';
  * which clamps the sidebar's bottom to the viewport bottom and removes the
  * jumps you'd get from toggling between fixed and absolute positioning.
  */
-export function useSidebarScrollSync() {
+export function useSidebarScrollSync( enabled: boolean = true ) {
 	useEffect( () => {
+		if ( ! enabled ) {
+			return;
+		}
 		let cachedSidebarHeight = 0;
 		let cachedMasterbarHeight = 0;
 		let scheduled = false;
@@ -93,6 +96,11 @@ export function useSidebarScrollSync() {
 			window.cancelAnimationFrame( initId );
 			window.removeEventListener( 'scroll', onScroll );
 			window.removeEventListener( 'resize', onResize );
+			const { sidebar, content } = getEls();
+			sidebar?.removeAttribute( 'style' );
+			if ( content ) {
+				content.style.minHeight = '';
+			}
 		};
-	}, [] );
+	}, [ enabled ] );
 }

--- a/client/dashboard/app/responsive-sidebar/use-sidebar-scroll-sync.ts
+++ b/client/dashboard/app/responsive-sidebar/use-sidebar-scroll-sync.ts
@@ -1,0 +1,98 @@
+import { useEffect } from 'react';
+
+/**
+ * Mirrors v1's SidebarScrollSynchronizer (client/layout/utils.ts) — a tall
+ * sidebar should appear to scroll along with the page until its bottom reaches
+ * the viewport bottom, then pin there.
+ *
+ * The sidebar is always `position: fixed`; this hook only adjusts `top`. As the
+ * page scrolls, top is `max(viewport - sidebarHeight, masterbar - scrollY)`,
+ * which clamps the sidebar's bottom to the viewport bottom and removes the
+ * jumps you'd get from toggling between fixed and absolute positioning.
+ */
+export function useSidebarScrollSync() {
+	useEffect( () => {
+		let cachedSidebarHeight = 0;
+		let cachedMasterbarHeight = 0;
+		let scheduled = false;
+
+		const getEls = () => ( {
+			sidebar: document.querySelector< HTMLElement >( '.dashboard-responsive-sidebar__sidebar' ),
+			content: document.querySelector< HTMLElement >( '.dashboard-root__content' ),
+			masterbar: document.querySelector< HTMLElement >( '#wpcom-omnibar' ),
+		} );
+
+		const measure = () => {
+			const { sidebar, masterbar } = getEls();
+			if ( ! sidebar || ! masterbar ) {
+				return;
+			}
+			// Read scrollHeight without our inline `height` interfering.
+			const prevHeight = sidebar.style.height;
+			sidebar.style.height = '';
+			cachedSidebarHeight = sidebar.scrollHeight;
+			cachedMasterbarHeight = masterbar.getBoundingClientRect().height;
+			sidebar.style.height = prevHeight;
+		};
+
+		const apply = () => {
+			scheduled = false;
+			const { sidebar, content } = getEls();
+			if ( ! sidebar || ! content ) {
+				return;
+			}
+
+			const sH = cachedSidebarHeight;
+			const mH = cachedMasterbarHeight;
+			const wH = window.innerHeight;
+
+			if ( sH + mH <= wH ) {
+				// Sidebar fits in the viewport — let the CSS defaults apply.
+				sidebar.removeAttribute( 'style' );
+				content.style.minHeight = '';
+				return;
+			}
+
+			// Ensure the page can scroll far enough to reveal the entire sidebar.
+			const minBodyHeight = sH + mH;
+			if ( content.scrollHeight < minBodyHeight ) {
+				content.style.minHeight = `${ minBodyHeight }px`;
+			}
+
+			const scrollY = -document.body.getBoundingClientRect().top;
+			const top = Math.max( wH - sH, mH - scrollY );
+			sidebar.style.top = `${ top }px`;
+			sidebar.style.bottom = 'auto';
+			sidebar.style.height = `${ sH }px`;
+		};
+
+		const schedule = () => {
+			if ( scheduled ) {
+				return;
+			}
+			scheduled = true;
+			window.requestAnimationFrame( apply );
+		};
+
+		const onScroll = schedule;
+		const onResize = () => {
+			measure();
+			schedule();
+		};
+
+		// Initial measurement may need to wait for masterbar to mount.
+		const initId = window.requestAnimationFrame( () => {
+			measure();
+			schedule();
+		} );
+
+		window.addEventListener( 'scroll', onScroll, { passive: true } );
+		window.addEventListener( 'resize', onResize );
+
+		return () => {
+			window.cancelAnimationFrame( initId );
+			window.removeEventListener( 'scroll', onScroll );
+			window.removeEventListener( 'resize', onResize );
+		};
+	}, [] );
+}

--- a/client/dashboard/app/responsive-sidebar/use-sidebar-scroll-sync.ts
+++ b/client/dashboard/app/responsive-sidebar/use-sidebar-scroll-sync.ts
@@ -1,4 +1,11 @@
 import { useEffect } from 'react';
+import type { RefObject } from 'react';
+
+interface Options {
+	enabled: boolean;
+	sidebarRef: RefObject< HTMLElement | null >;
+	navigatorRef: RefObject< HTMLElement | null >;
+}
 
 /**
  * Mirrors v1's SidebarScrollSynchronizer (client/layout/utils.ts) — a tall
@@ -6,64 +13,62 @@ import { useEffect } from 'react';
  * the viewport bottom, then pin there.
  *
  * The sidebar is always `position: fixed`; this hook only adjusts `top`. As the
- * page scrolls, top is `max(viewport - sidebarHeight, masterbar - scrollY)`,
+ * page scrolls, top is `max(viewport - sidebarHeight, omnibar - scrollY)`,
  * which clamps the sidebar's bottom to the viewport bottom and removes the
  * jumps you'd get from toggling between fixed and absolute positioning.
  */
-export function useSidebarScrollSync( enabled: boolean = true ) {
+export function useSidebarScrollSync( { enabled, sidebarRef, navigatorRef }: Options ) {
 	useEffect( () => {
 		if ( ! enabled ) {
 			return;
 		}
 		let cachedSidebarHeight = 0;
-		let cachedMasterbarHeight = 0;
+		let cachedOmnibarHeight = 0;
 		let scheduled = false;
 
-		const getEls = () => ( {
-			sidebar: document.querySelector< HTMLElement >( '.dashboard-responsive-sidebar__sidebar' ),
-			content: document.querySelector< HTMLElement >( '.dashboard-root__content' ),
-			masterbar: document.querySelector< HTMLElement >( '#wpcom-omnibar' ),
-		} );
+		const getOmnibar = () => document.getElementById( 'wpcom-omnibar' );
 
 		const measure = () => {
-			const { sidebar, masterbar } = getEls();
-			if ( ! sidebar || ! masterbar ) {
+			const sidebar = sidebarRef.current;
+			const omnibar = getOmnibar();
+			if ( ! sidebar || ! omnibar ) {
 				return;
 			}
 			// Read scrollHeight without our inline `height` interfering.
 			const prevHeight = sidebar.style.height;
 			sidebar.style.height = '';
 			cachedSidebarHeight = sidebar.scrollHeight;
-			cachedMasterbarHeight = masterbar.getBoundingClientRect().height;
+			cachedOmnibarHeight = omnibar.getBoundingClientRect().height;
 			sidebar.style.height = prevHeight;
 		};
 
 		const apply = () => {
 			scheduled = false;
-			const { sidebar, content } = getEls();
-			if ( ! sidebar || ! content ) {
+			const sidebar = sidebarRef.current;
+			if ( ! sidebar ) {
 				return;
 			}
 
 			const sH = cachedSidebarHeight;
-			const mH = cachedMasterbarHeight;
+			const oH = cachedOmnibarHeight;
 			const wH = window.innerHeight;
+			const body = document.body;
 
-			if ( sH + mH <= wH ) {
+			if ( sH + oH <= wH ) {
 				// Sidebar fits in the viewport — let the CSS defaults apply.
 				sidebar.removeAttribute( 'style' );
-				content.style.minHeight = '';
+				body.style.minHeight = '';
 				return;
 			}
 
 			// Ensure the page can scroll far enough to reveal the entire sidebar.
-			const minBodyHeight = sH + mH;
-			if ( content.scrollHeight < minBodyHeight ) {
-				content.style.minHeight = `${ minBodyHeight }px`;
+			const minBodyHeight = sH + oH;
+			if ( body.scrollHeight < minBodyHeight ) {
+				body.style.minHeight = `${ minBodyHeight }px`;
 			}
 
-			const scrollY = -document.body.getBoundingClientRect().top;
-			const top = Math.max( wH - sH, mH - scrollY );
+			const scrollY = -body.getBoundingClientRect().top;
+			const top = Math.max( wH - sH, oH - scrollY );
 			sidebar.style.top = `${ top }px`;
 			sidebar.style.bottom = 'auto';
 			sidebar.style.height = `${ sH }px`;
@@ -84,7 +89,7 @@ export function useSidebarScrollSync( enabled: boolean = true ) {
 		//   observe the navigator rather than the sidebar itself because
 		//   when the sidebar overflows, this hook pins `style.height` on
 		//   the sidebar, so its box-size stops reflecting content changes.
-		// - the masterbar: its height changes at the responsive breakpoint.
+		// - the omnibar: its height changes at the responsive breakpoint.
 		// - documentElement: stands in for window resize.
 		const resizeObserver = new ResizeObserver( () => {
 			measure();
@@ -92,19 +97,16 @@ export function useSidebarScrollSync( enabled: boolean = true ) {
 		} );
 		resizeObserver.observe( document.documentElement );
 
-		// Initial measurement may need to wait for masterbar to mount.
+		// Initial measurement may need to wait for the omnibar to mount.
 		const initId = window.requestAnimationFrame( () => {
 			measure();
 			schedule();
-			const { masterbar } = getEls();
-			const navigator = document.querySelector< HTMLElement >(
-				'.dashboard-responsive-sidebar__sidebar .dashboard-sidebar-navigator'
-			);
-			if ( navigator ) {
-				resizeObserver.observe( navigator );
+			if ( navigatorRef.current ) {
+				resizeObserver.observe( navigatorRef.current );
 			}
-			if ( masterbar ) {
-				resizeObserver.observe( masterbar );
+			const omnibar = getOmnibar();
+			if ( omnibar ) {
+				resizeObserver.observe( omnibar );
 			}
 		} );
 
@@ -114,11 +116,8 @@ export function useSidebarScrollSync( enabled: boolean = true ) {
 			window.cancelAnimationFrame( initId );
 			window.removeEventListener( 'scroll', schedule );
 			resizeObserver.disconnect();
-			const { sidebar, content } = getEls();
-			sidebar?.removeAttribute( 'style' );
-			if ( content ) {
-				content.style.minHeight = '';
-			}
+			sidebarRef.current?.removeAttribute( 'style' );
+			document.body.style.minHeight = '';
 		};
-	}, [ enabled ] );
+	}, [ enabled, sidebarRef, navigatorRef ] );
 }

--- a/client/dashboard/app/root/style.scss
+++ b/client/dashboard/app/root/style.scss
@@ -9,9 +9,18 @@
 	z-index: 3; // DataViews header seems to have z-index: 1; CalloutOverlay has z-index: 2
 }
 
+.dashboard-root__layout {
+	display: flex;
+	flex-direction: column;
+}
+
 .dashboard-root__body {
 	display: flex;
 	min-height: calc(100vh - var(--masterbar-height) );
+
+	&:has(.dashboard-responsive-sidebar__sidebar) {
+		padding-inline-start: $sidebar-width;
+	}
 
 	&:has(.dashboard-responsive-sidebar) {
 		overflow-x: hidden;

--- a/client/dashboard/app/root/style.scss
+++ b/client/dashboard/app/root/style.scss
@@ -18,7 +18,7 @@
 	display: flex;
 	min-height: calc(100vh - var(--masterbar-height) );
 
-	&:has(.dashboard-responsive-sidebar__sidebar) {
+	&:has(> .dashboard-responsive-sidebar__sidebar) {
 		padding-inline-start: $sidebar-width;
 	}
 

--- a/client/dashboard/components/sidebar-navigator/index.tsx
+++ b/client/dashboard/components/sidebar-navigator/index.tsx
@@ -4,7 +4,11 @@ import { Children, forwardRef, isValidElement, useMemo } from 'react';
 import { SidebarNavigatorContext } from './context';
 import SidebarNavigatorScreen from './sidebar-navigator-screen';
 import type { ScreenProps } from './sidebar-navigator-screen';
-import type { ReactElement } from 'react';
+import type { ForwardedRef, ReactElement } from 'react';
+
+interface SidebarNavigatorProps {
+	children: React.ReactNode;
+}
 
 import './style.scss';
 
@@ -46,43 +50,44 @@ function findParentPath( routeId: string, screenPaths: string[] ): string | unde
  * </SidebarNavigator>
  * ```
  */
-const SidebarNavigator = forwardRef< HTMLDivElement, { children: React.ReactNode } >(
-	function SidebarNavigator( { children }, ref ) {
-		const matches = useRouterState( { select: ( s ) => s.matches } );
+function UnforwardedSidebarNavigator(
+	{ children }: SidebarNavigatorProps,
+	ref: ForwardedRef< HTMLDivElement >
+) {
+	const matches = useRouterState( { select: ( s ) => s.matches } );
 
-		const screens = Children.toArray( children ).filter(
-			( child ): child is ReactElement< ScreenProps > =>
-				isValidElement( child ) && child.type === SidebarNavigatorScreen
-		);
+	const screens = Children.toArray( children ).filter(
+		( child ): child is ReactElement< ScreenProps > =>
+			isValidElement( child ) && child.type === SidebarNavigatorScreen
+	);
 
-		const screenPaths = screens.map( ( s ) => s.props.path );
+	const screenPaths = screens.map( ( s ) => s.props.path );
 
-		// Find the active path: first try exact match, then walk up to find parent.
-		const routeId = matches[ matches.length - 1 ]?.routeId;
-		const activePath =
-			screenPaths.find( ( sp ) => matches.some( ( m ) => m.routeId === sp ) ) ??
-			findParentPath( routeId, screenPaths );
+	// Find the active path: first try exact match, then walk up to find parent.
+	const routeId = matches[ matches.length - 1 ]?.routeId;
+	const activePath =
+		screenPaths.find( ( sp ) => matches.some( ( m ) => m.routeId === sp ) ) ??
+		findParentPath( routeId, screenPaths );
 
-		const previousPath = usePrevious( activePath );
-		const isBack =
-			previousPath !== undefined &&
-			activePath !== previousPath &&
-			activePath === findParentPath( previousPath, screenPaths );
+	const previousPath = usePrevious( activePath );
+	const isBack =
+		previousPath !== undefined &&
+		activePath !== previousPath &&
+		activePath === findParentPath( previousPath, screenPaths );
 
-		const contextValue = useMemo( () => ( { activePath, isBack } ), [ activePath, isBack ] );
+	const contextValue = useMemo( () => ( { activePath, isBack } ), [ activePath, isBack ] );
 
-		return (
-			<SidebarNavigatorContext.Provider value={ contextValue }>
-				<div ref={ ref } className="dashboard-sidebar-navigator">
-					{ children }
-				</div>
-			</SidebarNavigatorContext.Provider>
-		);
-	}
-) as React.ForwardRefExoticComponent<
-	{ children: React.ReactNode } & React.RefAttributes< HTMLDivElement >
-> & { Screen: typeof SidebarNavigatorScreen };
+	return (
+		<SidebarNavigatorContext.Provider value={ contextValue }>
+			<div ref={ ref } className="dashboard-sidebar-navigator">
+				{ children }
+			</div>
+		</SidebarNavigatorContext.Provider>
+	);
+}
 
-SidebarNavigator.Screen = SidebarNavigatorScreen;
+const SidebarNavigator = Object.assign( forwardRef( UnforwardedSidebarNavigator ), {
+	Screen: SidebarNavigatorScreen,
+} );
 
 export default SidebarNavigator;

--- a/client/dashboard/components/sidebar-navigator/index.tsx
+++ b/client/dashboard/components/sidebar-navigator/index.tsx
@@ -1,6 +1,6 @@
 import { useRouterState } from '@tanstack/react-router';
 import { usePrevious } from '@wordpress/compose';
-import { Children, isValidElement, useMemo } from 'react';
+import { Children, forwardRef, isValidElement, useMemo } from 'react';
 import { SidebarNavigatorContext } from './context';
 import SidebarNavigatorScreen from './sidebar-navigator-screen';
 import type { ScreenProps } from './sidebar-navigator-screen';
@@ -46,36 +46,42 @@ function findParentPath( routeId: string, screenPaths: string[] ): string | unde
  * </SidebarNavigator>
  * ```
  */
-function SidebarNavigator( { children }: { children: React.ReactNode } ) {
-	const matches = useRouterState( { select: ( s ) => s.matches } );
+const SidebarNavigator = forwardRef< HTMLDivElement, { children: React.ReactNode } >(
+	function SidebarNavigator( { children }, ref ) {
+		const matches = useRouterState( { select: ( s ) => s.matches } );
 
-	const screens = Children.toArray( children ).filter(
-		( child ): child is ReactElement< ScreenProps > =>
-			isValidElement( child ) && child.type === SidebarNavigatorScreen
-	);
+		const screens = Children.toArray( children ).filter(
+			( child ): child is ReactElement< ScreenProps > =>
+				isValidElement( child ) && child.type === SidebarNavigatorScreen
+		);
 
-	const screenPaths = screens.map( ( s ) => s.props.path );
+		const screenPaths = screens.map( ( s ) => s.props.path );
 
-	// Find the active path: first try exact match, then walk up to find parent.
-	const routeId = matches[ matches.length - 1 ]?.routeId;
-	const activePath =
-		screenPaths.find( ( sp ) => matches.some( ( m ) => m.routeId === sp ) ) ??
-		findParentPath( routeId, screenPaths );
+		// Find the active path: first try exact match, then walk up to find parent.
+		const routeId = matches[ matches.length - 1 ]?.routeId;
+		const activePath =
+			screenPaths.find( ( sp ) => matches.some( ( m ) => m.routeId === sp ) ) ??
+			findParentPath( routeId, screenPaths );
 
-	const previousPath = usePrevious( activePath );
-	const isBack =
-		previousPath !== undefined &&
-		activePath !== previousPath &&
-		activePath === findParentPath( previousPath, screenPaths );
+		const previousPath = usePrevious( activePath );
+		const isBack =
+			previousPath !== undefined &&
+			activePath !== previousPath &&
+			activePath === findParentPath( previousPath, screenPaths );
 
-	const contextValue = useMemo( () => ( { activePath, isBack } ), [ activePath, isBack ] );
+		const contextValue = useMemo( () => ( { activePath, isBack } ), [ activePath, isBack ] );
 
-	return (
-		<SidebarNavigatorContext.Provider value={ contextValue }>
-			<div className="dashboard-sidebar-navigator">{ children }</div>
-		</SidebarNavigatorContext.Provider>
-	);
-}
+		return (
+			<SidebarNavigatorContext.Provider value={ contextValue }>
+				<div ref={ ref } className="dashboard-sidebar-navigator">
+					{ children }
+				</div>
+			</SidebarNavigatorContext.Provider>
+		);
+	}
+) as React.ForwardRefExoticComponent<
+	{ children: React.ReactNode } & React.RefAttributes< HTMLDivElement >
+> & { Screen: typeof SidebarNavigatorScreen };
 
 SidebarNavigator.Screen = SidebarNavigatorScreen;
 

--- a/client/dashboard/components/sidebar-navigator/style.scss
+++ b/client/dashboard/components/sidebar-navigator/style.scss
@@ -3,6 +3,7 @@
 .dashboard-sidebar-navigator {
 	position: relative;
 	overflow: hidden;
+	flex-shrink: 0;
 }
 
 .dashboard-sidebar-navigator__screen {

--- a/packages/omnibar/src/components/omnibar.scss
+++ b/packages/omnibar/src/components/omnibar.scss
@@ -9,13 +9,16 @@ $omnibar-text-color: #fff;
 $omnibar-submenu-text-color: #bcbcbc;
 $omnibar-highlight-color: #7b90ff;
 
-.omnibar {
+body:has( .omnibar ) {
 	--omnibar-height: #{$omnibar-height-mobile};
+	--masterbar-height: var( --omnibar-height );
 
 	@media ( min-width: 782px ) {
 		--omnibar-height: #{$omnibar-height};
 	}
+}
 
+.omnibar {
 	background-color: $omnibar-base-color;
 	min-height: var( --omnibar-height );
 	height: var( --omnibar-height );


### PR DESCRIPTION
## Proposed Changes

* Port v1's `SidebarScrollSynchronizer` pattern (`client/layout/utils.ts`) to the dashboard, in a new `useSidebarScrollSync` hook.
* Sidebar is `position: fixed` by default. When its content is taller than the viewport, the hook adjusts `top` on every scroll so the sidebar travels with the body until its bottom reaches the viewport bottom, then pins there.
* `.dashboard-root__body` now reserves space for the fixed sidebar via `padding-inline-start: $sidebar-width` (previously the sidebar lived in the body's flex flow).
* `.dashboard-root__layout` becomes a flex column to drop a phantom 20px line-box created by inline-block dropdown siblings of `.dashboard-root__body`.
* `.dashboard-sidebar-navigator` gets `flex-shrink: 0` so its full content height contributes to `sidebar.scrollHeight`, which the hook reads to compute scroll offsets.

## Why are these changes being made?

A short sidebar should stay pinned under the masterbar; a tall sidebar (e.g. the site overview's nav with Performance, Logs, Backups, Domains, Settings) currently has its overflow content clipped on shorter viewports with no way to reach it. v1's hosting sidebar already handled this — every scroll update sets `top = max(viewport - sidebarHeight, masterbar - scrollY)`, which keeps every transition continuous.

## Testing Instructions

* Open `/sites/<a-site-slug>` (the site overview page).
* Resize the browser to ~400px tall and confirm:
  * At scroll 0, the sidebar is pinned under the masterbar (Back to Sites, site switcher, Overview at top).
  * Scrolling down, the sidebar slides up smoothly with the body.
  * Once the sidebar's bottom (Settings) reaches the viewport bottom, the sidebar pins there.
  * Scrolling back up reverses the same path; no jumps in either direction.
* Resize taller than the sidebar — the inline styles should be cleared and the CSS default (fixed top:masterbar; bottom:0) takes over.
* Open `/sites` and confirm body scroll behavior still works for content overflow.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?