### PR TITLE
Cancel flow: Wire speak-with-support intervention to direct Zendesk chat

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solution-cards-config.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solution-cards-config.ts
@@ -27,13 +27,13 @@ export type CardActionContext = {
 		initialMessage: string;
 		section?: string;
 		siteUrl?: string;
-		siteId?: number;
+		siteId?: string;
 	} ) => void;
 	setOpenOdieWithContext: ( config: {
 		initialMessage: string;
 		section?: string;
 		siteUrl?: string;
-		siteId?: number;
+		siteId?: string;
 	} ) => void;
 };
 
@@ -81,22 +81,22 @@ export const SOLUTION_CARD_CONFIG: SolutionCardConfigEntry[] = [
 	{
 		id: 'speak-with-support',
 		title: 'Speak with our support team',
-		subtitle: 'We’re here to answer any of your questions.',
+		subtitle: "We're here to answer any of your questions.",
 		onClick: ( ctx ) => {
 			const initialMessage =
-				'User is contacting us from pre-cancellation form. Cancellation reason they’ve given: ' +
+				"User is contacting us from pre-cancellation form. Cancellation reason they've given: " +
 				ctx.cancellationReason;
 			if ( ctx.canConnectToZendeskMessaging ) {
 				ctx.setNewMessagingChat( {
 					initialMessage,
 					siteUrl: ctx.site.URL,
-					siteId: ctx.site.ID,
+					siteId: String( ctx.site.ID ),
 				} );
 			} else {
 				ctx.setOpenOdieWithContext( {
 					initialMessage,
 					siteUrl: ctx.site.URL,
-					siteId: ctx.site.ID,
+					siteId: String( ctx.site.ID ),
 				} );
 			}
 		},
@@ -121,7 +121,7 @@ export const SOLUTION_CARD_CONFIG: SolutionCardConfigEntry[] = [
 					ctx.cancellationReason,
 				section: 'pre-cancellation-upsell',
 				siteUrl: ctx.site.URL,
-				siteId: ctx.site.ID,
+				siteId: String( ctx.site.ID ),
 			} );
 			ctx.closeDialog();
 		},

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solution-cards-config.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solution-cards-config.ts
@@ -81,10 +81,10 @@ export const SOLUTION_CARD_CONFIG: SolutionCardConfigEntry[] = [
 	{
 		id: 'speak-with-support',
 		title: 'Speak with our support team',
-		subtitle: 'We\u2019re here to answer any of your questions.',
+		subtitle: 'We’re here to answer any of your questions.',
 		onClick: ( ctx ) => {
 			const initialMessage =
-				'User is contacting us from pre-cancellation form. Cancellation reason they\u2019ve given: ' +
+				'User is contacting us from pre-cancellation form. Cancellation reason they’ve given: ' +
 				ctx.cancellationReason;
 			if ( ctx.canConnectToZendeskMessaging ) {
 				ctx.setNewMessagingChat( {
@@ -93,8 +93,11 @@ export const SOLUTION_CARD_CONFIG: SolutionCardConfigEntry[] = [
 					siteId: ctx.site.ID,
 				} );
 			} else {
-				ctx.setNavigateToRoute( '/odie' );
-				ctx.setShowHelpCenter( true );
+				ctx.setOpenOdieWithContext( {
+					initialMessage,
+					siteUrl: ctx.site.URL,
+					siteId: ctx.site.ID,
+				} );
 			}
 		},
 	},

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solution-cards-config.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solution-cards-config.ts
@@ -11,10 +11,6 @@ const SITE_SPEED_URL = localizeUrl( 'https://wordpress.com/support/site-speed/' 
 const SITE_MIGRATION_URL = localizeUrl( 'https://wordpress.com/support/site-migration/' );
 const DOMAINS_SUPPORT_URL = localizeUrl( 'https://wordpress.com/support/domains/' );
 
-function getLiveChatUrlForPlans( site: SiteDetails, purchase: Purchase ): string {
-	return `/purchases/subscriptions/${ site.slug }/${ purchase.id }`;
-}
-
 export type CardActionContext = {
 	site: SiteDetails;
 	purchase: Purchase;
@@ -24,17 +20,20 @@ export type CardActionContext = {
 	cancellationReason: string;
 	onClickDowngrade?: ( upsell: string ) => void;
 	onSelectSwitchToMonthly?: () => void;
+	canConnectToZendeskMessaging: boolean;
+	setNavigateToRoute: ( route?: string ) => void;
+	setShowHelpCenter: ( show: boolean ) => void;
 	setNewMessagingChat: ( config: {
 		initialMessage: string;
-		section: string;
-		siteUrl: string;
-		siteId: number;
+		section?: string;
+		siteUrl?: string;
+		siteId?: number;
 	} ) => void;
 	setOpenOdieWithContext: ( config: {
 		initialMessage: string;
-		section: string;
-		siteUrl: string;
-		siteId: number;
+		section?: string;
+		siteUrl?: string;
+		siteId?: number;
 	} ) => void;
 };
 
@@ -82,18 +81,21 @@ export const SOLUTION_CARD_CONFIG: SolutionCardConfigEntry[] = [
 	{
 		id: 'speak-with-support',
 		title: 'Speak with our support team',
-		subtitle: "We're here to answer any of your questions.",
+		subtitle: 'We\u2019re here to answer any of your questions.',
 		onClick: ( ctx ) => {
-			page( getLiveChatUrlForPlans( ctx.site, ctx.purchase ) );
-			ctx.setNewMessagingChat( {
-				initialMessage:
-					"User is contacting us from pre-cancellation form. Cancellation reason they've given: " +
-					ctx.cancellationReason,
-				section: 'pre-cancellation-upsell',
-				siteUrl: ctx.site.URL,
-				siteId: ctx.site.ID,
-			} );
-			ctx.closeDialog();
+			const initialMessage =
+				'User is contacting us from pre-cancellation form. Cancellation reason they\u2019ve given: ' +
+				ctx.cancellationReason;
+			if ( ctx.canConnectToZendeskMessaging ) {
+				ctx.setNewMessagingChat( {
+					initialMessage,
+					siteUrl: ctx.site.URL,
+					siteId: ctx.site.ID,
+				} );
+			} else {
+				ctx.setNavigateToRoute( '/odie' );
+				ctx.setShowHelpCenter( true );
+			}
 		},
 	},
 	{
@@ -189,4 +191,4 @@ export const SOLUTION_CARD_CONFIG: SolutionCardConfigEntry[] = [
 	},
 ];
 
-export { BUILT_BY_URL, RENEW_COUPON, getLiveChatUrlForPlans };
+export { BUILT_BY_URL, RENEW_COUPON };

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -6,6 +6,7 @@ import {
 } from '@automattic/calypso-products';
 import { SummaryButton } from '@automattic/components';
 import { HelpCenter } from '@automattic/data-stores';
+import { useCanConnectToZendeskMessaging } from '@automattic/zendesk-client';
 import { Button } from '@wordpress/components';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import {
@@ -183,7 +184,9 @@ export default function SolutionsCardsUpsellStep( {
 	const [ busyButton, setBusyButton ] = useState( '' );
 	const [ showDowngradeStep, setShowDowngradeStep ] = useState( false );
 	const solutions = getSolutionsForReason( cancellationReason );
-	const { setNewMessagingChat, setOpenOdieWithContext } = useDataStoreDispatch( HELP_CENTER_STORE );
+	const { setNewMessagingChat, setNavigateToRoute, setShowHelpCenter, setOpenOdieWithContext } =
+		useDataStoreDispatch( HELP_CENTER_STORE );
+	const { data: canConnectToZendeskMessaging } = useCanConnectToZendeskMessaging();
 
 	const showSwitchToMonthly = isAnnualOrLongerPlan( purchase.productSlug );
 
@@ -229,6 +232,9 @@ export default function SolutionsCardsUpsellStep( {
 				setShowDowngradeStep( true );
 			}
 		},
+		canConnectToZendeskMessaging: !! canConnectToZendeskMessaging,
+		setNavigateToRoute,
+		setShowHelpCenter,
 		setNewMessagingChat,
 		setOpenOdieWithContext,
 	};

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/test/solutions-cards-upsell-step.test.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/test/solutions-cards-upsell-step.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SolutionsCardsUpsellStep from '../solutions-cards-upsell-step';
+import type { SiteDetails } from '@automattic/data-stores';
+import type { Purchase } from 'calypso/lib/purchases/types';
+
+const mockSetNewMessagingChat = jest.fn();
+const mockSetNavigateToRoute = jest.fn();
+const mockSetShowHelpCenter = jest.fn();
+const mockSetOpenOdieWithContext = jest.fn();
+
+jest.mock( '@wordpress/data', () => {
+	const noop = () => ( {} );
+	const identity = ( fn: unknown ) => fn;
+	return {
+		useDispatch: () => ( {
+			setNewMessagingChat: mockSetNewMessagingChat,
+			setNavigateToRoute: mockSetNavigateToRoute,
+			setShowHelpCenter: mockSetShowHelpCenter,
+			setOpenOdieWithContext: mockSetOpenOdieWithContext,
+		} ),
+		useSelect: ( selector: ( s: unknown ) => unknown ) => selector( () => undefined ),
+		combineReducers: ( reducers: Record< string, unknown > ) => reducers,
+		createSelector: identity,
+		createReduxStore: noop,
+		createRegistrySelector: identity,
+		register: noop,
+		registerStore: noop,
+		use: noop,
+		plugins: { persistence: noop },
+		dispatch: () => ( {} ),
+		select: () => ( {} ),
+		subscribe: () => () => {},
+	};
+} );
+
+let mockCanConnectToZendesk = true;
+
+jest.mock( '@automattic/zendesk-client', () => ( {
+	useCanConnectToZendeskMessaging: () => ( { data: mockCanConnectToZendesk } ),
+} ) );
+
+jest.mock( 'i18n-calypso', () => {
+	const passthrough = ( s: string ) => s;
+	return {
+		useTranslate: () => passthrough,
+		translate: passthrough,
+		localize: ( Component: React.ComponentType ) => Component,
+	};
+} );
+
+jest.mock( 'calypso/components/formatted-header', () => {
+	return function MockFormattedHeader( { headerText }: { headerText: string } ) {
+		return <h2>{ headerText }</h2>;
+	};
+} );
+
+const purchase = {
+	id: 123,
+	productSlug: 'business-bundle',
+	currencyCode: 'USD',
+} as Purchase;
+
+const site = {
+	ID: 456,
+	slug: 'example.wordpress.com',
+	URL: 'https://example.wordpress.com',
+} as SiteDetails;
+
+describe( '<SolutionsCardsUpsellStep /> (legacy)', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockCanConnectToZendesk = true;
+	} );
+
+	test( 'speak-with-support calls setNewMessagingChat when Zendesk eligible', async () => {
+		const user = userEvent.setup();
+		const closeDialog = jest.fn();
+
+		render(
+			<SolutionsCardsUpsellStep
+				cancellationReason="noLongerNeedSite"
+				purchase={ purchase }
+				site={ site }
+				closeDialog={ closeDialog }
+				onDeclineUpsell={ jest.fn() }
+			/>
+		);
+
+		const supportCard = screen.getByRole( 'button', {
+			name: /Speak with our support team/,
+		} );
+		await user.click( supportCard );
+
+		expect( mockSetNewMessagingChat ).toHaveBeenCalledTimes( 1 );
+		expect( mockSetNewMessagingChat ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				siteUrl: 'https://example.wordpress.com',
+				siteId: 456,
+			} )
+		);
+		expect( mockSetNavigateToRoute ).not.toHaveBeenCalledWith( '/odie' );
+		expect( closeDialog ).not.toHaveBeenCalled();
+	} );
+
+	test( 'speak-with-support opens Odie fallback when not Zendesk eligible', async () => {
+		mockCanConnectToZendesk = false;
+		const user = userEvent.setup();
+		const closeDialog = jest.fn();
+
+		render(
+			<SolutionsCardsUpsellStep
+				cancellationReason="noLongerNeedSite"
+				purchase={ purchase }
+				site={ site }
+				closeDialog={ closeDialog }
+				onDeclineUpsell={ jest.fn() }
+			/>
+		);
+
+		const supportCard = screen.getByRole( 'button', {
+			name: /Speak with our support team/,
+		} );
+		await user.click( supportCard );
+
+		expect( mockSetNavigateToRoute ).toHaveBeenCalledWith( '/odie' );
+		expect( mockSetShowHelpCenter ).toHaveBeenCalledWith( true );
+		expect( mockSetNewMessagingChat ).not.toHaveBeenCalled();
+		expect( closeDialog ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/test/solutions-cards-upsell-step.test.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/test/solutions-cards-upsell-step.test.tsx
@@ -99,7 +99,7 @@ describe( '<SolutionsCardsUpsellStep /> (legacy)', () => {
 		expect( mockSetNewMessagingChat ).toHaveBeenCalledWith(
 			expect.objectContaining( {
 				siteUrl: 'https://example.wordpress.com',
-				siteId: 456,
+				siteId: '456',
 			} )
 		);
 		expect( mockSetNavigateToRoute ).not.toHaveBeenCalledWith( '/odie' );
@@ -131,7 +131,7 @@ describe( '<SolutionsCardsUpsellStep /> (legacy)', () => {
 			expect.objectContaining( {
 				initialMessage: expect.stringContaining( 'Cancellation reason' ),
 				siteUrl: 'https://example.wordpress.com',
-				siteId: 456,
+				siteId: '456',
 			} )
 		);
 		expect( mockSetNewMessagingChat ).not.toHaveBeenCalled();

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/test/solutions-cards-upsell-step.test.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/test/solutions-cards-upsell-step.test.tsx
@@ -126,8 +126,14 @@ describe( '<SolutionsCardsUpsellStep /> (legacy)', () => {
 		} );
 		await user.click( supportCard );
 
-		expect( mockSetNavigateToRoute ).toHaveBeenCalledWith( '/odie' );
-		expect( mockSetShowHelpCenter ).toHaveBeenCalledWith( true );
+		expect( mockSetOpenOdieWithContext ).toHaveBeenCalledTimes( 1 );
+		expect( mockSetOpenOdieWithContext ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				initialMessage: expect.stringContaining( 'Cancellation reason' ),
+				siteUrl: 'https://example.wordpress.com',
+				siteId: 456,
+			} )
+		);
 		expect( mockSetNewMessagingChat ).not.toHaveBeenCalled();
 		expect( closeDialog ).not.toHaveBeenCalled();
 	} );

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -240,8 +240,7 @@ export default function SolutionsCardsUpsellStep( {
 }: SolutionsCardsUpsellStepProps ) {
 	const [ showDowngradeStep, setShowDowngradeStep ] = React.useState( false );
 	const solutions = getSolutionsForReason( cancellationReason );
-	const { setNewMessagingChat, setNavigateToRoute, setShowHelpCenter, setOpenOdieWithContext } =
-		useHelpCenter();
+	const { setNewMessagingChat, setOpenOdieWithContext } = useHelpCenter();
 	const { data: canConnectToZendeskMessaging } = useCanConnectToZendeskMessaging();
 
 	const showSwitchToMonthly = isAnnualOrLongerPlan( purchase );
@@ -314,7 +313,7 @@ export default function SolutionsCardsUpsellStep( {
 				break;
 			case 'speak-with-support': {
 				const initialMessage =
-					'User is contacting us from pre-cancellation form. Cancellation reason they\u2019ve given: ' +
+					'User is contacting us from pre-cancellation form. Cancellation reason they’ve given: ' +
 					cancellationReason;
 				if ( canConnectToZendeskMessaging ) {
 					setNewMessagingChat( {
@@ -323,8 +322,11 @@ export default function SolutionsCardsUpsellStep( {
 						siteId: String( purchase.blog_id ),
 					} );
 				} else {
-					setNavigateToRoute( '/odie' );
-					setShowHelpCenter( true );
+					setOpenOdieWithContext( {
+						initialMessage,
+						siteUrl: purchase.site_slug,
+						siteId: String( purchase.blog_id ),
+					} );
 				}
 				break;
 			}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -313,7 +313,7 @@ export default function SolutionsCardsUpsellStep( {
 				break;
 			case 'speak-with-support': {
 				const initialMessage =
-					'User is contacting us from pre-cancellation form. Cancellation reason they’ve given: ' +
+					"User is contacting us from pre-cancellation form. Cancellation reason they've given: " +
 					cancellationReason;
 				if ( canConnectToZendeskMessaging ) {
 					setNewMessagingChat( {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -1,5 +1,7 @@
 import { PersonalPlans, SubscriptionBillPeriod } from '@automattic/api-core';
 import { localizeUrl } from '@automattic/i18n-utils';
+// eslint-disable-next-line no-restricted-imports -- Zendesk eligibility gate for speak-with-support intervention
+import { useCanConnectToZendeskMessaging } from '@automattic/zendesk-client';
 import {
 	Button,
 	Icon,
@@ -238,7 +240,9 @@ export default function SolutionsCardsUpsellStep( {
 }: SolutionsCardsUpsellStepProps ) {
 	const [ showDowngradeStep, setShowDowngradeStep ] = React.useState( false );
 	const solutions = getSolutionsForReason( cancellationReason );
-	const { setNewMessagingChat, setOpenOdieWithContext } = useHelpCenter();
+	const { setNewMessagingChat, setNavigateToRoute, setShowHelpCenter, setOpenOdieWithContext } =
+		useHelpCenter();
+	const { data: canConnectToZendeskMessaging } = useCanConnectToZendeskMessaging();
 
 	const showSwitchToMonthly = isAnnualOrLongerPlan( purchase );
 
@@ -310,13 +314,18 @@ export default function SolutionsCardsUpsellStep( {
 				break;
 			case 'speak-with-support': {
 				const initialMessage =
-					"User is contacting us from pre-cancellation form. Cancellation reason they've given: " +
+					'User is contacting us from pre-cancellation form. Cancellation reason they\u2019ve given: ' +
 					cancellationReason;
-				setNewMessagingChat( {
-					initialMessage,
-					section: 'pre-cancellation-upsell',
-				} );
-				closeDialog?.();
+				if ( canConnectToZendeskMessaging ) {
+					setNewMessagingChat( {
+						initialMessage,
+						siteUrl: purchase.site_slug,
+						siteId: String( purchase.blog_id ),
+					} );
+				} else {
+					setNavigateToRoute( '/odie' );
+					setShowHelpCenter( true );
+				}
 				break;
 			}
 			case 'built-by':

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/test/solutions-cards-upsell-step.test.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/test/solutions-cards-upsell-step.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../../../../../test-utils';
+import SolutionsCardsUpsellStep from '../solutions-cards-upsell-step';
+import type { Purchase } from '@automattic/api-core';
+
+const mockSetNewMessagingChat = jest.fn();
+const mockSetNavigateToRoute = jest.fn();
+const mockSetShowHelpCenter = jest.fn();
+
+jest.mock( '../../../../../../app/help-center', () => ( {
+	useHelpCenter: () => ( {
+		setNewMessagingChat: mockSetNewMessagingChat,
+		setNavigateToRoute: mockSetNavigateToRoute,
+		setShowHelpCenter: mockSetShowHelpCenter,
+		setOpenOdieWithContext: jest.fn(),
+	} ),
+} ) );
+
+let mockCanConnectToZendesk = true;
+
+jest.mock( '@automattic/zendesk-client', () => ( {
+	useCanConnectToZendeskMessaging: () => ( { data: mockCanConnectToZendesk } ),
+} ) );
+
+const purchase = {
+	ID: 123,
+	blog_id: 456,
+	site_slug: 'example.wordpress.com',
+	product_slug: 'business-bundle',
+	currency_code: 'USD',
+	bill_period_days: 365,
+} as Purchase;
+
+describe( '<SolutionsCardsUpsellStep />', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockCanConnectToZendesk = true;
+	} );
+
+	test( 'speak-with-support calls setNewMessagingChat when Zendesk eligible', async () => {
+		const user = userEvent.setup();
+		const closeDialog = jest.fn();
+
+		render(
+			<SolutionsCardsUpsellStep
+				cancellationReason="noLongerNeedSite"
+				purchase={ purchase }
+				closeDialog={ closeDialog }
+				onDeclineUpsell={ jest.fn() }
+			/>
+		);
+
+		const supportCard = await screen.findByRole( 'button', {
+			name: /Speak with our support team/,
+		} );
+		await user.click( supportCard );
+
+		expect( mockSetNewMessagingChat ).toHaveBeenCalledTimes( 1 );
+		expect( mockSetNewMessagingChat ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				siteUrl: 'example.wordpress.com',
+				siteId: '456',
+			} )
+		);
+		expect( mockSetNavigateToRoute ).not.toHaveBeenCalledWith( '/odie' );
+		expect( closeDialog ).not.toHaveBeenCalled();
+	} );
+
+	test( 'speak-with-support opens Odie fallback when not Zendesk eligible', async () => {
+		mockCanConnectToZendesk = false;
+		const user = userEvent.setup();
+		const closeDialog = jest.fn();
+
+		render(
+			<SolutionsCardsUpsellStep
+				cancellationReason="noLongerNeedSite"
+				purchase={ purchase }
+				closeDialog={ closeDialog }
+				onDeclineUpsell={ jest.fn() }
+			/>
+		);
+
+		const supportCard = await screen.findByRole( 'button', {
+			name: /Speak with our support team/,
+		} );
+		await user.click( supportCard );
+
+		expect( mockSetNavigateToRoute ).toHaveBeenCalledWith( '/odie' );
+		expect( mockSetShowHelpCenter ).toHaveBeenCalledWith( true );
+		expect( mockSetNewMessagingChat ).not.toHaveBeenCalled();
+		expect( closeDialog ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/test/solutions-cards-upsell-step.test.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/test/solutions-cards-upsell-step.test.tsx
@@ -10,13 +10,14 @@ import type { Purchase } from '@automattic/api-core';
 const mockSetNewMessagingChat = jest.fn();
 const mockSetNavigateToRoute = jest.fn();
 const mockSetShowHelpCenter = jest.fn();
+const mockSetOpenOdieWithContext = jest.fn();
 
 jest.mock( '../../../../../../app/help-center', () => ( {
 	useHelpCenter: () => ( {
 		setNewMessagingChat: mockSetNewMessagingChat,
 		setNavigateToRoute: mockSetNavigateToRoute,
 		setShowHelpCenter: mockSetShowHelpCenter,
-		setOpenOdieWithContext: jest.fn(),
+		setOpenOdieWithContext: mockSetOpenOdieWithContext,
 	} ),
 } ) );
 
@@ -89,8 +90,14 @@ describe( '<SolutionsCardsUpsellStep />', () => {
 		} );
 		await user.click( supportCard );
 
-		expect( mockSetNavigateToRoute ).toHaveBeenCalledWith( '/odie' );
-		expect( mockSetShowHelpCenter ).toHaveBeenCalledWith( true );
+		expect( mockSetOpenOdieWithContext ).toHaveBeenCalledTimes( 1 );
+		expect( mockSetOpenOdieWithContext ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				initialMessage: expect.stringContaining( 'Cancellation reason' ),
+				siteUrl: 'example.wordpress.com',
+				siteId: '456',
+			} )
+		);
 		expect( mockSetNewMessagingChat ).not.toHaveBeenCalled();
 		expect( closeDialog ).not.toHaveBeenCalled();
 	} );


### PR DESCRIPTION
Depends on https://github.com/Automattic/wp-calypso/pull/110442
Part of https://linear.app/a8c/issue/RSM-487

## Summary
This PR fixes the contact support intervention so go directly to human chat (vs opening our AI chat only).


## Test plan
- [ ] On the cancel survey interventions step, click "Speak with our support team"
- [ ] Verify the help center opens with a Zendesk chat (or Odie if not eligible)
- [ ] Verify the user stays on the survey step (not navigated away)
- [ ] Verify the cancellation reason is included in the chat initial message
- [ ] Test on both dashboard (`my.localhost:3000`) and legacy (`calypso.localhost:3000`)


🤖 Generated with [Claude Code](https://claude.com/claude-code)