### PR TITLE
Reader: show shimmer placeholder for tag stats while loading

### DIFF
--- a/client/reader/stream/reader-tag-sidebar/index.jsx
+++ b/client/reader/stream/reader-tag-sidebar/index.jsx
@@ -80,20 +80,23 @@ const ReaderTagSidebar = ( {
 	) );
 	const tagsPageUrl = addLocaleToPathLocaleInFront( '/tags' );
 
+	const renderStatCount = ( value ) =>
+		value != null ? (
+			<span className="reader-tag-sidebar-stats__count">{ formatNumberCompact( value ) }</span>
+		) : (
+			<span className="reader-tag-sidebar-stats__count is-placeholder" aria-hidden="true" />
+		);
+
 	return (
 		<>
 			{ tagStats && (
 				<div className="reader-tag-sidebar-stats">
 					<div className="reader-tag-sidebar-stats__item">
-						<span className="reader-tag-sidebar-stats__count">
-							{ formatNumberCompact( tagStats?.data?.total_posts ) }
-						</span>
+						{ renderStatCount( tagStats?.data?.total_posts ) }
 						<span className="reader-tag-sidebar-stats__title">{ translate( 'Posts' ) }</span>
 					</div>
 					<div className="reader-tag-sidebar-stats__item">
-						<span className="reader-tag-sidebar-stats__count">
-							{ formatNumberCompact( tagStats?.data?.total_sites ) }
-						</span>
+						{ renderStatCount( tagStats?.data?.total_sites ) }
 						<span className="reader-tag-sidebar-stats__title">{ translate( 'Sites' ) }</span>
 					</div>
 				</div>

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -834,6 +834,15 @@ body.is-section-reader div.layout.is-global-sidebar-visible .is-site-stream .bac
 			font-size: $font-title-small;
 			font-weight: bold;
 			width: 90px;
+
+			&.is-placeholder {
+				@include placeholder();
+				display: inline-block;
+				width: 48px;
+				height: 1em;
+				border-radius: 2px;
+				vertical-align: middle;
+			}
 		}
 
 		.reader-tag-sidebar-stats__title {


### PR DESCRIPTION
Avoids rendering NaN in the tag sidebar Posts/Sites counts before useTagStats resolves; uses the existing placeholder shimmer mixin instead.

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of READ-502

## Proposed Changes

* 
<img width="348" height="182" alt="Screenshot 2026-05-06 at 16 41 30" src="https://github.com/user-attachments/assets/9c3c8e3e-bbd9-47c2-8b83-40dfdb15eef5" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

* visit a new tag, let's say /tag/sofia
* observe placeholder, instead of NaN

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
