### PR TITLE
Cancellation feature list: WordPress.com plans

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import {
 	Icon,
 	__experimentalHStack as HStack,
@@ -15,12 +16,40 @@ import {
 	getSingleItemCancelCopy,
 	getSingleItemRemoveCopy,
 } from './get-confirmation-copy';
+import { getOverrideCancellationFeatures } from './get-override-features';
 import type { Purchase, CancellationFeature } from '@automattic/api-core';
 
 type FeatureObject = {
 	getSlug: () => string;
 	getTitle: ( params?: { domainName?: string } ) => string;
 };
+
+type LossItem = { key: string; title: string };
+
+function getLossItems(
+	overrideFeatures: CancellationFeature[] | null,
+	cancellationFeatures: CancellationFeature[],
+	purchase: Purchase
+): LossItem[] {
+	if ( overrideFeatures ) {
+		return overrideFeatures.map( ( feature ) => ( {
+			key: String( feature.feature_id ),
+			title: feature.title,
+		} ) );
+	}
+	if ( cancellationFeatures.length ) {
+		return cancellationFeatures
+			.filter( ( feature ): feature is CancellationFeature => Boolean( feature ) )
+			.map( ( feature ) => ( {
+				key: String( feature.feature_id ),
+				title: feature.title,
+			} ) );
+	}
+	return getFallbackLossItems( purchase ).map( ( title, idx ) => ( {
+		key: `fallback-${ idx }`,
+		title,
+	} ) );
+}
 
 const CancelPurchaseFeatureList = ( {
 	purchase,
@@ -33,17 +62,14 @@ const CancelPurchaseFeatureList = ( {
 	cancellationFeatures: CancellationFeature[];
 	cancellationChanges: FeatureObject[];
 } ) => {
-	// When the server returns no feature list, fall back to a per-product-type
-	// item so every confirmation screen shows at least one concrete thing the
-	// user is giving up.
-	const lossItems: Array< { key: string; title: string } > = cancellationFeatures.length
-		? cancellationFeatures
-				.filter( ( feature ): feature is CancellationFeature => Boolean( feature ) )
-				.map( ( feature ) => ( { key: String( feature.feature_id ), title: feature.title } ) )
-		: getFallbackLossItems( purchase ).map( ( title, idx ) => ( {
-				key: `fallback-${ idx }`,
-				title,
-		  } ) );
+	// When the split-cancel-remove flag is on, use client-side feature overrides
+	// instead of the server-provided list. Falls back to API features when the
+	// override returns null (no entries yet for this product category).
+	const overrideFeatures = config.isEnabled( 'purchases/split-cancel-remove' )
+		? getOverrideCancellationFeatures( purchase )
+		: null;
+
+	const lossItems = getLossItems( overrideFeatures, cancellationFeatures, purchase );
 
 	if ( ! lossItems.length && ! cancellationChanges.length ) {
 		return null;

--- a/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
@@ -65,7 +65,8 @@ const CancelPurchaseFeatureList = ( {
 	// When the split-cancel-remove flag is on, use client-side feature overrides
 	// instead of the server-provided list. Falls back to API features when the
 	// override returns null (no entries yet for this product category).
-	const overrideFeatures = config.isEnabled( 'purchases/split-cancel-remove' )
+	const isSplitEnabled = useIsSplitCancelRemoveEnabled();
+	const overrideFeatures = isSplitEnabled
 		? getOverrideCancellationFeatures( purchase )
 		: null;
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import {
 	Icon,
 	__experimentalHStack as HStack,
@@ -17,6 +16,7 @@ import {
 	getSingleItemRemoveCopy,
 } from './get-confirmation-copy';
 import { getOverrideCancellationFeatures } from './get-override-features';
+import { useIsSplitCancelRemoveEnabled } from './use-is-split-cancel-remove-enabled';
 import type { Purchase, CancellationFeature } from '@automattic/api-core';
 
 type FeatureObject = {
@@ -66,9 +66,7 @@ const CancelPurchaseFeatureList = ( {
 	// instead of the server-provided list. Falls back to API features when the
 	// override returns null (no entries yet for this product category).
 	const isSplitEnabled = useIsSplitCancelRemoveEnabled();
-	const overrideFeatures = isSplitEnabled
-		? getOverrideCancellationFeatures( purchase )
-		: null;
+	const overrideFeatures = isSplitEnabled ? getOverrideCancellationFeatures( purchase ) : null;
 
 	const lossItems = getLossItems( overrideFeatures, cancellationFeatures, purchase );
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy.ts
@@ -24,6 +24,7 @@ export type PurchaseForCopy = {
 	expiry_status: string;
 	meta?: string;
 	domain: string;
+	site_slug: string;
 };
 
 /**

--- a/client/dashboard/me/billing-purchases/cancel-purchase/get-override-features.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/get-override-features.ts
@@ -1,6 +1,15 @@
+import { __ } from '@wordpress/i18n';
 import { getProductCategory } from './get-confirmation-copy';
 import type { PurchaseForCopy } from './get-confirmation-copy';
 import type { CancellationFeature } from '@automattic/api-core';
+
+function features( ...titles: string[] ): CancellationFeature[] {
+	return titles.map( ( title, idx ) => ( {
+		feature_id: `override-${ idx }`,
+		title,
+		description: '',
+	} ) );
+}
 
 /**
  * Client-side override for cancellation features. When the split-cancel-remove
@@ -34,8 +43,54 @@ export function getOverrideCancellationFeatures(
 	}
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getWpcomPlanFeatures( slug: string ): CancellationFeature[] | null {
+	if ( slug.startsWith( 'personal-bundle' ) ) {
+		return features(
+			__( 'Custom domain for your site' ),
+			__( '6 GB of storage' ),
+			__( 'An ad-free experience for your visitors' ),
+			__( 'Plugins and themes to extend your site' ),
+			__( 'Customize fonts and colors' ),
+			__( 'Audio uploads' ),
+			__( 'Support from our team' )
+		);
+	}
+	if ( slug.startsWith( 'value_bundle' ) ) {
+		return features(
+			__( 'Custom domain for your site' ),
+			__( '13 GB of storage' ),
+			__( 'An ad-free experience for your visitors' ),
+			__( 'Plugins and themes to extend your site' ),
+			__( 'Advanced design tools and custom CSS' ),
+			__( 'Priority support' ),
+			__( 'Earn money from ads on your site' ),
+			__( 'Detailed visitor stats and insights' )
+		);
+	}
+	if ( slug.startsWith( 'business-bundle' ) ) {
+		return features(
+			__( 'Custom domain for your site' ),
+			__( '50 GB of storage' ),
+			__( 'An ad-free experience for your visitors' ),
+			__( 'Plugins and themes to extend your site' ),
+			__( 'Priority 24/7 support' ),
+			__( 'Developer tools like SFTP, SSH, Git, and GitHub Deployments' ),
+			__( 'Staging sites to test changes safely' ),
+			__( 'Daily backups with one-click restore' )
+		);
+	}
+	if ( slug.startsWith( 'ecommerce-bundle' ) || slug.startsWith( 'ecommerce-trial' ) ) {
+		return features(
+			__( 'Custom domain for your site' ),
+			__( 'Plugins and themes to extend your site' ),
+			__( '50 GB of storage' ),
+			__( 'Payments in 60+ countries' ),
+			__( 'Sell and ship products worldwide' ),
+			__( 'Integrations with shipping carriers' ),
+			__( 'Marketing tools for your store' ),
+			__( 'Priority 24/7 support' )
+		);
+	}
 	return null;
 }
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/get-override-features.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/get-override-features.ts
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { getProductCategory } from './get-confirmation-copy';
 import type { PurchaseForCopy } from './get-confirmation-copy';
 import type { CancellationFeature } from '@automattic/api-core';
@@ -26,7 +26,7 @@ export function getOverrideCancellationFeatures(
 
 	switch ( category ) {
 		case 'plan':
-			return getWpcomPlanFeatures( slug );
+			return getWpcomPlanFeatures( purchase );
 		case 'domain':
 			return getDomainFeatures( purchase );
 		case 'email':
@@ -43,52 +43,81 @@ export function getOverrideCancellationFeatures(
 	}
 }
 
-function getWpcomPlanFeatures( slug: string ): CancellationFeature[] | null {
+function hasCustomDomain( domain: string ): boolean {
+	return (
+		!! domain && ! domain.endsWith( '.wordpress.com' ) && ! domain.endsWith( '.wpcomstaging.com' )
+	);
+}
+
+function getDomainFeature( domain: string ): string {
+	if ( hasCustomDomain( domain ) ) {
+		return sprintf(
+			/* translators: %(domain)s is the site's primary domain, e.g. "filippodt.com" */
+			__( '%(domain)s as your primary domain' ),
+			{ domain }
+		);
+	}
+	return __( 'Custom domain for your site' );
+}
+
+function getWpcomPlanFeatures( purchase: PurchaseForCopy ): CancellationFeature[] | null {
+	const slug = purchase.product_slug;
+	const isMonthly = slug.includes( '-monthly' );
+	const domainFeature = getDomainFeature( purchase.site_slug );
+
 	if ( slug.startsWith( 'personal-bundle' ) ) {
 		return features(
-			__( 'Custom domain for your site' ),
-			__( '6 GB of storage' ),
-			__( 'An ad-free experience for your visitors' ),
-			__( 'Plugins and themes to extend your site' ),
-			__( 'Customize fonts and colors' ),
-			__( 'Audio uploads' ),
-			__( 'Support from our team' )
+			...( [
+				domainFeature,
+				__( '6 GB of storage' ),
+				__( 'An ad-free experience for your visitors' ),
+				__( 'Plugins and themes to extend your site' ),
+				__( 'Customize fonts and colors' ),
+				__( 'Audio uploads' ),
+				! isMonthly && __( 'Support from our team' ),
+			].filter( Boolean ) as string[] )
 		);
 	}
 	if ( slug.startsWith( 'value_bundle' ) ) {
 		return features(
-			__( 'Custom domain for your site' ),
-			__( '13 GB of storage' ),
-			__( 'An ad-free experience for your visitors' ),
-			__( 'Plugins and themes to extend your site' ),
-			__( 'Advanced design tools and custom CSS' ),
-			__( 'Priority support' ),
-			__( 'Earn money from ads on your site' ),
-			__( 'Detailed visitor stats and insights' )
+			...( [
+				domainFeature,
+				__( '13 GB of storage' ),
+				__( 'An ad-free experience for your visitors' ),
+				__( 'Plugins and themes to extend your site' ),
+				__( 'Advanced design tools and custom CSS' ),
+				! isMonthly && __( 'Priority support' ),
+				__( 'Earn money from ads on your site' ),
+				__( 'Detailed visitor stats and insights' ),
+			].filter( Boolean ) as string[] )
 		);
 	}
 	if ( slug.startsWith( 'business-bundle' ) ) {
 		return features(
-			__( 'Custom domain for your site' ),
-			__( '50 GB of storage' ),
-			__( 'An ad-free experience for your visitors' ),
-			__( 'Plugins and themes to extend your site' ),
-			__( 'Priority 24/7 support' ),
-			__( 'Developer tools like SFTP, SSH, Git, and GitHub Deployments' ),
-			__( 'Staging sites to test changes safely' ),
-			__( 'Daily backups with one-click restore' )
+			...( [
+				domainFeature,
+				__( '50 GB of storage' ),
+				__( 'An ad-free experience for your visitors' ),
+				__( 'Plugins and themes to extend your site' ),
+				! isMonthly && __( 'Priority 24/7 support' ),
+				__( 'Developer tools like SFTP, SSH, Git, and GitHub Deployments' ),
+				__( 'Staging sites to test changes safely' ),
+				__( 'Daily backups with one-click restore' ),
+			].filter( Boolean ) as string[] )
 		);
 	}
 	if ( slug.startsWith( 'ecommerce-bundle' ) || slug.startsWith( 'ecommerce-trial' ) ) {
 		return features(
-			__( 'Custom domain for your site' ),
-			__( 'Plugins and themes to extend your site' ),
-			__( '50 GB of storage' ),
-			__( 'Payments in 60+ countries' ),
-			__( 'Sell and ship products worldwide' ),
-			__( 'Integrations with shipping carriers' ),
-			__( 'Marketing tools for your store' ),
-			__( 'Priority 24/7 support' )
+			...( [
+				domainFeature,
+				__( 'Plugins and themes to extend your site' ),
+				__( '50 GB of storage' ),
+				__( 'Payments in 60+ countries' ),
+				__( 'Sell and ship products worldwide' ),
+				__( 'Integrations with shipping carriers' ),
+				__( 'Marketing tools for your store' ),
+				! isMonthly && __( 'Priority 24/7 support' ),
+			].filter( Boolean ) as string[] )
 		);
 	}
 	return null;

--- a/client/dashboard/me/billing-purchases/cancel-purchase/get-override-features.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/get-override-features.ts
@@ -1,0 +1,69 @@
+import { getProductCategory } from './get-confirmation-copy';
+import type { PurchaseForCopy } from './get-confirmation-copy';
+import type { CancellationFeature } from '@automattic/api-core';
+
+/**
+ * Client-side override for cancellation features. When the split-cancel-remove
+ * flag is on, this replaces the server-provided feature list with
+ * benefit-oriented copy keyed by product slug and category.
+ *
+ * Returns null when no override exists — caller falls back to API features.
+ */
+export function getOverrideCancellationFeatures(
+	purchase: PurchaseForCopy
+): CancellationFeature[] | null {
+	const slug = purchase.product_slug;
+	const category = getProductCategory( purchase );
+
+	switch ( category ) {
+		case 'plan':
+			return getWpcomPlanFeatures( slug );
+		case 'domain':
+			return getDomainFeatures( purchase );
+		case 'email':
+			return getEmailFeatures( slug );
+		case 'jetpack':
+			return getJetpackFeatures( slug );
+		case 'akismet':
+			return getAkismetFeatures();
+		case 'marketplace':
+			return getMarketplaceFeatures( purchase );
+		case 'one-time':
+		case 'other':
+			return getAddonFeatures( slug );
+	}
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getWpcomPlanFeatures( slug: string ): CancellationFeature[] | null {
+	return null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getDomainFeatures( purchase: PurchaseForCopy ): CancellationFeature[] | null {
+	return null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getEmailFeatures( slug: string ): CancellationFeature[] | null {
+	return null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getJetpackFeatures( slug: string ): CancellationFeature[] | null {
+	return null;
+}
+
+function getAkismetFeatures(): CancellationFeature[] | null {
+	return null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getMarketplaceFeatures( purchase: PurchaseForCopy ): CancellationFeature[] | null {
+	return null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getAddonFeatures( slug: string ): CancellationFeature[] | null {
+	return null;
+}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/test/get-override-features.test.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/test/get-override-features.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment jsdom
+ */
+jest.mock( '@automattic/api-core', () => ( {
+	GoogleWorkspaceSlugs: {
+		GSUITE_BASIC_SLUG: 'gsuite-basic',
+		GSUITE_BUSINESS_SLUG: 'gsuite-business',
+	},
+	AkismetPlans: {},
+	TitanMailSlugs: {
+		TITAN_MAIL_MONTHLY_SLUG: 'titan-mail-monthly',
+		TITAN_MAIL_YEARLY_SLUG: 'titan-mail-yearly',
+	},
+} ) );
+
+import { getOverrideCancellationFeatures } from '../get-override-features';
+import type { PurchaseForCopy } from '../get-confirmation-copy';
+
+function makePurchase( overrides: Partial< PurchaseForCopy > = {} ): PurchaseForCopy {
+	return {
+		is_plan: false,
+		is_domain_registration: false,
+		is_jetpack_plan_or_product: false,
+		product_slug: 'test-product',
+		product_name: 'Test Product',
+		product_type: 'other',
+		expiry_date: '2027-04-16',
+		expiry_status: 'manual-renew',
+		domain: 'example.com',
+		...overrides,
+	} as PurchaseForCopy;
+}
+
+describe( 'getOverrideCancellationFeatures', () => {
+	it( 'returns null for a plan purchase (no entries yet)', () => {
+		const purchase = makePurchase( {
+			is_plan: true,
+			product_slug: 'business-bundle',
+			product_name: 'WordPress.com Business',
+		} );
+		expect( getOverrideCancellationFeatures( purchase ) ).toBeNull();
+	} );
+
+	it( 'returns null for a domain purchase', () => {
+		const purchase = makePurchase( {
+			is_domain_registration: true,
+			product_slug: 'dotcom_domain',
+			product_name: 'example.com',
+		} );
+		expect( getOverrideCancellationFeatures( purchase ) ).toBeNull();
+	} );
+
+	it( 'returns null for a Jetpack purchase', () => {
+		const purchase = makePurchase( {
+			is_jetpack_plan_or_product: true,
+			product_slug: 'jetpack_security_daily',
+			product_name: 'Jetpack Security',
+		} );
+		expect( getOverrideCancellationFeatures( purchase ) ).toBeNull();
+	} );
+} );

--- a/client/dashboard/me/billing-purchases/cancel-purchase/test/get-override-features.test.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/test/get-override-features.test.ts
@@ -27,6 +27,7 @@ function makePurchase( overrides: Partial< PurchaseForCopy > = {} ): PurchaseFor
 		expiry_date: '2027-04-16',
 		expiry_status: 'manual-renew',
 		domain: 'example.com',
+		site_slug: 'example.com',
 		...overrides,
 	} as PurchaseForCopy;
 }
@@ -41,16 +42,18 @@ describe( 'getOverrideCancellationFeatures', () => {
 			} );
 			const result = getOverrideCancellationFeatures( purchase );
 			expect( result ).toHaveLength( 7 );
-			expect( result![ 0 ].title ).toBe( 'Custom domain for your site' );
+			expect( result![ 0 ].title ).toBe( 'example.com as your primary domain' );
 		} );
 
-		it( 'returns 7 features for personal-bundle-monthly', () => {
+		it( 'returns 6 features for personal-bundle-monthly (omits support)', () => {
 			const purchase = makePurchase( {
 				is_plan: true,
 				product_slug: 'personal-bundle-monthly',
 				product_name: 'WordPress.com Personal',
 			} );
-			expect( getOverrideCancellationFeatures( purchase ) ).toHaveLength( 7 );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 6 );
+			expect( result!.every( ( f ) => ! f.title.includes( 'Support' ) ) ).toBe( true );
 		} );
 
 		it( 'returns 8 features for value_bundle', () => {
@@ -61,7 +64,7 @@ describe( 'getOverrideCancellationFeatures', () => {
 			} );
 			const result = getOverrideCancellationFeatures( purchase );
 			expect( result ).toHaveLength( 8 );
-			expect( result![ 0 ].title ).toBe( 'Custom domain for your site' );
+			expect( result![ 0 ].title ).toBe( 'example.com as your primary domain' );
 		} );
 
 		it( 'returns 8 features for business-bundle', () => {
@@ -72,7 +75,7 @@ describe( 'getOverrideCancellationFeatures', () => {
 			} );
 			const result = getOverrideCancellationFeatures( purchase );
 			expect( result ).toHaveLength( 8 );
-			expect( result![ 0 ].title ).toBe( 'Custom domain for your site' );
+			expect( result![ 0 ].title ).toBe( 'example.com as your primary domain' );
 		} );
 
 		it( 'returns 8 features for ecommerce-bundle', () => {
@@ -83,16 +86,51 @@ describe( 'getOverrideCancellationFeatures', () => {
 			} );
 			const result = getOverrideCancellationFeatures( purchase );
 			expect( result ).toHaveLength( 8 );
-			expect( result![ 0 ].title ).toBe( 'Custom domain for your site' );
+			expect( result![ 0 ].title ).toBe( 'example.com as your primary domain' );
 		} );
 
-		it( 'returns 8 features for ecommerce-trial-bundle-monthly', () => {
+		it( 'returns 7 features for ecommerce-trial-bundle-monthly (omits support)', () => {
 			const purchase = makePurchase( {
 				is_plan: true,
 				product_slug: 'ecommerce-trial-bundle-monthly',
 				product_name: 'WordPress.com eCommerce',
 			} );
-			expect( getOverrideCancellationFeatures( purchase ) ).toHaveLength( 8 );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 7 );
+			expect( result!.every( ( f ) => ! f.title.includes( 'support' ) ) ).toBe( true );
+		} );
+
+		it( 'shows custom domain name when site has a custom domain', () => {
+			const purchase = makePurchase( {
+				is_plan: true,
+				product_slug: 'business-bundle',
+				product_name: 'WordPress.com Business',
+				site_slug: 'filippodt.com',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result![ 0 ].title ).toBe( 'filippodt.com as your primary domain' );
+		} );
+
+		it( 'falls back to generic domain copy for wordpress.com subdomain', () => {
+			const purchase = makePurchase( {
+				is_plan: true,
+				product_slug: 'business-bundle',
+				product_name: 'WordPress.com Business',
+				site_slug: 'mysite.wordpress.com',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result![ 0 ].title ).toBe( 'Custom domain for your site' );
+		} );
+
+		it( 'falls back to generic domain copy for wpcomstaging.com subdomain', () => {
+			const purchase = makePurchase( {
+				is_plan: true,
+				product_slug: 'business-bundle',
+				product_name: 'WordPress.com Business',
+				site_slug: 'mysite.wpcomstaging.com',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result![ 0 ].title ).toBe( 'Custom domain for your site' );
 		} );
 
 		it( 'returns null for an unknown plan slug', () => {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/test/get-override-features.test.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/test/get-override-features.test.ts
@@ -32,13 +32,77 @@ function makePurchase( overrides: Partial< PurchaseForCopy > = {} ): PurchaseFor
 }
 
 describe( 'getOverrideCancellationFeatures', () => {
-	it( 'returns null for a plan purchase (no entries yet)', () => {
-		const purchase = makePurchase( {
-			is_plan: true,
-			product_slug: 'business-bundle',
-			product_name: 'WordPress.com Business',
+	describe( 'WordPress.com plans', () => {
+		it( 'returns 7 features for personal-bundle', () => {
+			const purchase = makePurchase( {
+				is_plan: true,
+				product_slug: 'personal-bundle',
+				product_name: 'WordPress.com Personal',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 7 );
+			expect( result![ 0 ].title ).toBe( 'Custom domain for your site' );
 		} );
-		expect( getOverrideCancellationFeatures( purchase ) ).toBeNull();
+
+		it( 'returns 7 features for personal-bundle-monthly', () => {
+			const purchase = makePurchase( {
+				is_plan: true,
+				product_slug: 'personal-bundle-monthly',
+				product_name: 'WordPress.com Personal',
+			} );
+			expect( getOverrideCancellationFeatures( purchase ) ).toHaveLength( 7 );
+		} );
+
+		it( 'returns 8 features for value_bundle', () => {
+			const purchase = makePurchase( {
+				is_plan: true,
+				product_slug: 'value_bundle',
+				product_name: 'WordPress.com Premium',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 8 );
+			expect( result![ 0 ].title ).toBe( 'Custom domain for your site' );
+		} );
+
+		it( 'returns 8 features for business-bundle', () => {
+			const purchase = makePurchase( {
+				is_plan: true,
+				product_slug: 'business-bundle',
+				product_name: 'WordPress.com Business',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 8 );
+			expect( result![ 0 ].title ).toBe( 'Custom domain for your site' );
+		} );
+
+		it( 'returns 8 features for ecommerce-bundle', () => {
+			const purchase = makePurchase( {
+				is_plan: true,
+				product_slug: 'ecommerce-bundle',
+				product_name: 'WordPress.com eCommerce',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 8 );
+			expect( result![ 0 ].title ).toBe( 'Custom domain for your site' );
+		} );
+
+		it( 'returns 8 features for ecommerce-trial-bundle-monthly', () => {
+			const purchase = makePurchase( {
+				is_plan: true,
+				product_slug: 'ecommerce-trial-bundle-monthly',
+				product_name: 'WordPress.com eCommerce',
+			} );
+			expect( getOverrideCancellationFeatures( purchase ) ).toHaveLength( 8 );
+		} );
+
+		it( 'returns null for an unknown plan slug', () => {
+			const purchase = makePurchase( {
+				is_plan: true,
+				product_slug: 'unknown-plan-slug',
+				product_name: 'Unknown Plan',
+			} );
+			expect( getOverrideCancellationFeatures( purchase ) ).toBeNull();
+		} );
 	} );
 
 	it( 'returns null for a domain purchase', () => {

--- a/client/me/purchases/cancel-purchase/feature-list.tsx
+++ b/client/me/purchases/cancel-purchase/feature-list.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import moment from 'moment';
 import {
@@ -7,10 +8,37 @@ import {
 	getSingleItemCancelCopy,
 	getSingleItemRemoveCopy,
 } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy';
+import { getOverrideCancellationFeatures } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/get-override-features';
 import { toPurchaseForCopy } from './to-purchase-for-copy';
 import type { CancellationFeature } from '@automattic/api-core';
 import type { Purchases } from '@automattic/data-stores';
+import type { PurchaseForCopy } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy';
 import type { DisplayVariant } from 'calypso/lib/purchases/utils';
+
+type LossItem = { key: string; title: string };
+
+function getLossItems(
+	overrideFeatures: CancellationFeature[] | null,
+	cancellationFeatures: CancellationFeature[],
+	adapted: PurchaseForCopy
+): LossItem[] {
+	if ( overrideFeatures ) {
+		return overrideFeatures.map( ( feature ) => ( {
+			key: String( feature.feature_id ),
+			title: feature.title,
+		} ) );
+	}
+	if ( cancellationFeatures.length ) {
+		return cancellationFeatures.map( ( feature ) => ( {
+			key: feature.feature_id,
+			title: feature.title,
+		} ) );
+	}
+	return getFallbackLossItems( adapted ).map( ( title, idx ) => ( {
+		key: `fallback-${ idx }`,
+		title,
+	} ) );
+}
 
 const CancelPurchaseFeatureList = ( {
 	purchase,
@@ -22,16 +50,15 @@ const CancelPurchaseFeatureList = ( {
 	cancellationFeatures: CancellationFeature[];
 } ) => {
 	const adapted = toPurchaseForCopy( purchase );
-	// When the server returns no features, fall back to a per-product-type item.
-	const items: Array< { key: string; title: string } > = cancellationFeatures.length
-		? cancellationFeatures.map( ( feature ) => ( {
-				key: feature.feature_id,
-				title: feature.title,
-		  } ) )
-		: getFallbackLossItems( adapted ).map( ( title, idx ) => ( {
-				key: `fallback-${ idx }`,
-				title,
-		  } ) );
+
+	// When the split-cancel-remove flag is on, use client-side feature overrides
+	// instead of the server-provided list. Falls back to API features when the
+	// override returns null (no entries yet for this product category).
+	const overrideFeatures = config.isEnabled( 'purchases/split-cancel-remove' )
+		? getOverrideCancellationFeatures( adapted )
+		: null;
+
+	const items = getLossItems( overrideFeatures, cancellationFeatures, adapted );
 
 	if ( ! items.length ) {
 		return null;

--- a/client/me/purchases/cancel-purchase/feature-list.tsx
+++ b/client/me/purchases/cancel-purchase/feature-list.tsx
@@ -53,9 +53,10 @@ const CancelPurchaseFeatureList = ( {
 
 	// When the split-cancel-remove flag is on, use client-side feature overrides
 	// instead of the server-provided list. Falls back to API features when the
-	// override returns null (no entries yet for this product category).
-	const overrideFeatures = config.isEnabled( 'purchases/split-cancel-remove' )
+	const isSplitEnabled = useIsSplitCancelRemoveEnabled();
+	const overrideFeatures = isSplitEnabled
 		? getOverrideCancellationFeatures( adapted )
+		: null;
 		: null;
 
 	const items = getLossItems( overrideFeatures, cancellationFeatures, adapted );

--- a/client/me/purchases/cancel-purchase/feature-list.tsx
+++ b/client/me/purchases/cancel-purchase/feature-list.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import moment from 'moment';
 import {
@@ -9,6 +8,7 @@ import {
 	getSingleItemRemoveCopy,
 } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy';
 import { getOverrideCancellationFeatures } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/get-override-features';
+import { useIsSplitCancelRemoveEnabled } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/use-is-split-cancel-remove-enabled';
 import { toPurchaseForCopy } from './to-purchase-for-copy';
 import type { CancellationFeature } from '@automattic/api-core';
 import type { Purchases } from '@automattic/data-stores';
@@ -54,10 +54,7 @@ const CancelPurchaseFeatureList = ( {
 	// When the split-cancel-remove flag is on, use client-side feature overrides
 	// instead of the server-provided list. Falls back to API features when the
 	const isSplitEnabled = useIsSplitCancelRemoveEnabled();
-	const overrideFeatures = isSplitEnabled
-		? getOverrideCancellationFeatures( adapted )
-		: null;
-		: null;
+	const overrideFeatures = isSplitEnabled ? getOverrideCancellationFeatures( adapted ) : null;
 
 	const items = getLossItems( overrideFeatures, cancellationFeatures, adapted );
 

--- a/client/me/purchases/cancel-purchase/to-purchase-for-copy.ts
+++ b/client/me/purchases/cancel-purchase/to-purchase-for-copy.ts
@@ -24,5 +24,6 @@ export function toPurchaseForCopy( purchase: Purchases.Purchase ): PurchaseForCo
 		expiry_status: isOneTimePurchase( purchase ) ? 'one-time-purchase' : purchase.expiryStatus,
 		meta: purchase.meta,
 		domain: purchase.domain ?? '',
+		site_slug: purchase.siteSlug ?? '',
 	};
 }


### PR DESCRIPTION
Stacked on #110478 (override infrastructure).
Related to: https://linear.app/a8c/issue/RSM-478

Fixes: https://linear.app/a8c/issue/RSM-662
Fixes: https://linear.app/a8c/issue/RSM-679
Fixes: https://linear.app/a8c/issue/RSM-681
Fixes: https://linear.app/a8c/issue/RSM-682

## Summary
This PR updates the feature list for plans when you remove/cancel with a new up-to-date list and easier-to-read language.

| Before | After |
| -- | -- |
| <img width="1760" height="1196" alt="image" src="https://github.com/user-attachments/assets/4c6ef2c0-9fd1-4dc8-a4c3-3dfe11a5471b" /> | <img width="1760" height="1196" alt="image" src="https://github.com/user-attachments/assets/c303ccf9-5eec-4430-9f28-e3ad910cf9a9" /> |



Some additional technical notes:
- Fills in `getWpcomPlanFeatures` with static benefit-oriented copy for Personal (7 features), Premium (8), Business (8), and Commerce (8) plans
- Covers all billing periods (monthly, yearly, 2y, 3y) and trial variants via slug prefix matching
- Adds 9 unit tests covering all 4 tiers, billing period variants, trial variant, and unknown slug fallback
- Part of the update-feature-lists workstream (RSM-478). Three more independent PRs will fill in domains/email, marketplace, and Jetpack product features.

## Test plan

- [ ] Toggle `purchases/split-cancel-remove` flag on
- [ ] Navigate to cancel/remove flow for a Personal plan — verify 7 benefit-oriented bullets appear
- [ ] Repeat for Premium (8), Business (8), Commerce (8)
- [ ] Verify flag-off shows the original server-provided features unchanged
- [ ] `npx jest client/dashboard/me/billing-purchases/cancel-purchase/test/get-override-features --no-coverage` — 12 tests pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)