### PR TITLE
Reader onboarding rsm - refactor steps to share the same modal.

### DIFF
--- a/client/reader/onboarding-rsm/index.tsx
+++ b/client/reader/onboarding-rsm/index.tsx
@@ -3,6 +3,8 @@ import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { CircularProgressBar } from '@automattic/components';
 import { Checklist, ChecklistItem, Task } from '@automattic/launchpad';
+import { Modal } from '@wordpress/components';
+import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 import React, { useState, useEffect } from 'react';
 import { useFollowedReaderTags } from 'calypso/data/reader/use-reader-tags';
@@ -15,15 +17,32 @@ import InterestsModal from 'calypso/reader/onboarding-rsm/interests-modal';
 import SubscribeModal from 'calypso/reader/onboarding-rsm/subscribe-modal';
 import WelcomeModal from 'calypso/reader/onboarding-rsm/welcome-modal';
 import { useDispatch, useSelector } from 'calypso/state';
-import { getCurrentUserDate } from 'calypso/state/current-user/selectors';
+import {
+	getCurrentUserDate,
+	isCurrentUserEmailVerified,
+} from 'calypso/state/current-user/selectors';
 import { requestGravatarDetails } from 'calypso/state/gravatar-status/actions';
 import { hasGravatar } from 'calypso/state/gravatar-status/selectors';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
+import { requestFollows } from 'calypso/state/reader/follows/actions';
 import { getReaderFollows } from 'calypso/state/reader/follows/selectors';
 import hasCompletedReaderProfile from 'calypso/state/reader/onboarding/selectors/has-completed-reader-profile';
+import { clearStream, requestPage } from 'calypso/state/reader/streams/actions';
 import { useSiteSubscriptions } from '../following/use-site-subscriptions';
 import './style.scss';
+
+// All onboarding steps share a single <Modal> frame so transitions between
+// them feel seamless (no close/open animation between steps). The active
+// step's body is rendered as the only child of the shared modal; the
+// per-step CSS class on the modal frame keeps existing styles working.
+type Step = 'welcome' | 'interests' | 'discover';
+
+const STEP_FRAME_CLASS: Record< Step, string > = {
+	welcome: 'reader-welcome-modal',
+	interests: 'interests-modal',
+	discover: 'subscribe-modal',
+};
 
 const ReaderOnboardingRsm = ( {
 	onRender,
@@ -33,10 +52,8 @@ const ReaderOnboardingRsm = ( {
 	isSuppressed?: boolean;
 } ) => {
 	const dispatch = useDispatch();
-	const [ isWelcomeModalOpen, setIsWelcomeModalOpen ] = useState( false );
+	const [ currentStep, setCurrentStep ] = useState< Step | null >( null );
 	const [ hasCompletedWelcomeStep, setHasCompletedWelcomeStep ] = useState( false );
-	const [ isInterestsModalOpen, setIsInterestsModalOpen ] = useState( false );
-	const [ isDiscoverModalOpen, setIsDiscoverModalOpen ] = useState( false );
 
 	const preferencesLoaded = useSelector( hasReceivedRemotePreferences );
 	const userRegistrationDate: string | null = useSelector( getCurrentUserDate );
@@ -46,6 +63,7 @@ const ReaderOnboardingRsm = ( {
 	const follows = useSelector( getReaderFollows );
 	const profileCompleted = useSelector( hasCompletedReaderProfile );
 	const hasUserGravatar = useSelector( hasGravatar );
+	const promptVerification = ! useSelector( isCurrentUserEmailVerified );
 
 	const hasCompletedOnboarding: boolean | null = useSelector( ( state ) =>
 		getPreference( state, READER_ONBOARDING_PREFERENCE_KEY )
@@ -76,51 +94,63 @@ const ReaderOnboardingRsm = ( {
 
 	const shouldRenderOnboarding = shouldShowOnboarding && ! isSuppressed;
 
-	// Modal state handlers with tracking.
-	const openWelcomeModal = () => {
-		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }welcome_modal_open` );
-		setIsWelcomeModalOpen( true );
-	};
-
-	const closeWelcomeModal = () => {
-		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }welcome_modal_close` );
-		setIsWelcomeModalOpen( false );
-		if ( ! hasSeenOnboarding ) {
-			dispatch( savePreference( READER_ONBOARDING_SEEN_PREFERENCE_KEY, true ) );
+	// Side-effects that run when a given step is closed (whether via the X /
+	// escape, or via the "continue" button transitioning to the next step).
+	// Centralised so the same effects fire on either path.
+	const performStepCloseSideEffects = ( step: Step ) => {
+		if ( step === 'welcome' ) {
+			recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }welcome_modal_close` );
+			if ( ! hasSeenOnboarding ) {
+				dispatch( savePreference( READER_ONBOARDING_SEEN_PREFERENCE_KEY, true ) );
+			}
+		} else if ( step === 'interests' ) {
+			recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }interests_modal_close` );
+		} else if ( step === 'discover' ) {
+			recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }discover_modal_close` );
+			// Refresh the Following stream after the user might have followed
+			// new sites in the discover step.
+			dispatch( requestFollows() );
+			dispatch( clearStream( { streamKey: 'following' } ) );
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			dispatch( requestPage( { streamKey: 'following' } as any ) );
 		}
 	};
 
-	const openInterestsModal = () => {
-		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }interests_modal_open` );
-		setIsInterestsModalOpen( true );
+	const recordStepOpen = ( step: Step ) => {
+		if ( step === 'welcome' ) {
+			recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }welcome_modal_open` );
+		} else if ( step === 'interests' ) {
+			recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }interests_modal_open` );
+		} else if ( step === 'discover' ) {
+			recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }discover_modal_open` );
+		}
 	};
 
-	const closeInterestsModal = () => {
-		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }interests_modal_close` );
-		setIsInterestsModalOpen( false );
+	const openStep = ( step: Step ) => {
+		recordStepOpen( step );
+		setCurrentStep( step );
 	};
 
-	const openDiscoverModal = () => {
-		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }discover_modal_open` );
-		setIsDiscoverModalOpen( true );
-	};
-
-	const closeDiscoverModal = () => {
-		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }discover_modal_close` );
-		setIsDiscoverModalOpen( false );
+	const handleStepClose = () => {
+		if ( currentStep ) {
+			performStepCloseSideEffects( currentStep );
+		}
+		setCurrentStep( null );
 	};
 
 	const handleWelcomeContinue = () => {
 		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }welcome_modal_continue` );
 		setHasCompletedWelcomeStep( true );
-		closeWelcomeModal();
-		openInterestsModal();
+		performStepCloseSideEffects( 'welcome' );
+		recordStepOpen( 'interests' );
+		setCurrentStep( 'interests' );
 	};
 
 	const handleInterestsContinue = () => {
 		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }interests_modal_continue` );
-		closeInterestsModal();
-		openDiscoverModal();
+		performStepCloseSideEffects( 'interests' );
+		recordStepOpen( 'discover' );
+		setCurrentStep( 'discover' );
 	};
 
 	const itemClickHandler = ( task: Task ) => {
@@ -142,11 +172,12 @@ const ReaderOnboardingRsm = ( {
 		}
 	}, [ shouldRenderOnboarding, dispatch ] );
 
-	// Auto-open the welcome modal if onboarding should render and it has never been opened before.
+	// Auto-open the welcome step if onboarding should render and it has never been opened before.
 	useEffect( () => {
 		if ( shouldRenderOnboarding && preferencesLoaded && ! hasSeenOnboarding ) {
-			openWelcomeModal();
+			openStep( 'welcome' );
 		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ shouldRenderOnboarding, preferencesLoaded, hasSeenOnboarding, dispatch ] );
 
 	// Reopen subscription onboarding page if prompted by query param.
@@ -155,12 +186,13 @@ const ReaderOnboardingRsm = ( {
 		const shouldReloadOnboarding = urlParams.has( 'reloadSubscriptionOnboarding' );
 
 		if ( shouldReloadOnboarding ) {
-			openDiscoverModal();
+			openStep( 'discover' );
 			urlParams.delete( 'reloadSubscriptionOnboarding' );
 			page.redirect(
 				`${ window.location.pathname }${ urlParams.toString() ? '?' + urlParams.toString() : '' }`
 			);
 		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
 	// Fetch gravatar info when component mounts
@@ -182,21 +214,21 @@ const ReaderOnboardingRsm = ( {
 		{
 			id: 'welcome',
 			title: translate( 'Welcome to Reader' ),
-			actionDispatch: openWelcomeModal,
+			actionDispatch: () => openStep( 'welcome' ),
 			completed: hasCompletedWelcomeStep,
 			disabled: false,
 		},
 		{
 			id: 'select-interests',
 			title: translate( 'Select some of your interests' ),
-			actionDispatch: openInterestsModal,
+			actionDispatch: () => openStep( 'interests' ),
 			completed: hasFollowedTags,
 			disabled: ! hasCompletedWelcomeStep,
 		},
 		{
 			id: 'discover-sites',
 			title: translate( "Discover and subscribe to sites you'll love" ),
-			actionDispatch: openDiscoverModal,
+			actionDispatch: () => openStep( 'discover' ),
 			completed: hasFollowedSites,
 			disabled: ! hasFollowedSites && ! hasFollowedTags,
 		},
@@ -237,17 +269,25 @@ const ReaderOnboardingRsm = ( {
 				</div>
 			</div>
 
-			<WelcomeModal
-				isOpen={ isWelcomeModalOpen }
-				onClose={ closeWelcomeModal }
-				onContinue={ handleWelcomeContinue }
-			/>
-			<InterestsModal
-				isOpen={ isInterestsModalOpen }
-				onClose={ closeInterestsModal }
-				onContinue={ handleInterestsContinue }
-			/>
-			<SubscribeModal isOpen={ isDiscoverModalOpen } onClose={ closeDiscoverModal } />
+			{ currentStep && (
+				<Modal
+					onRequestClose={ handleStepClose }
+					size="medium"
+					className={ clsx( 'reader-onboarding-rsm-modal', STEP_FRAME_CLASS[ currentStep ], {
+						'is-disabled': currentStep === 'discover' && promptVerification,
+					} ) }
+				>
+					{ currentStep === 'welcome' && (
+						<WelcomeModal onClose={ handleStepClose } onContinue={ handleWelcomeContinue } />
+					) }
+					{ currentStep === 'interests' && (
+						<InterestsModal onContinue={ handleInterestsContinue } />
+					) }
+					{ currentStep === 'discover' && (
+						<SubscribeModal onClose={ handleStepClose } promptVerification={ promptVerification } />
+					) }
+				</Modal>
+			) }
 		</>
 	);
 };

--- a/client/reader/onboarding-rsm/interests-modal/index.tsx
+++ b/client/reader/onboarding-rsm/interests-modal/index.tsx
@@ -2,7 +2,6 @@ import { followReadTagMutation, unfollowReadTagMutation } from '@automattic/api-
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import {
-	Modal,
 	Button,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
@@ -27,23 +26,22 @@ import type { CuratedBlog } from '../curated-blogs';
 import './style.scss';
 
 interface InterestsModalProps {
-	isOpen: boolean;
-	onClose: () => void;
 	onContinue: () => void;
 }
 
 type ResolvedPack = TopicGroup & { blogs: CuratedBlog[] };
 const MAX_INTEREST_TOPICS = 40;
 
-const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose, onContinue } ) => {
+// Renders the body of the "interests" step. The shared <Modal> wrapper is
+// provided by the parent (`ReaderOnboardingRsm`); this component is only
+// mounted while the step is active. X-out / escape are handled by the
+// wrapper's `onRequestClose`.
+const InterestsModal: React.FC< InterestsModalProps > = ( { onContinue } ) => {
 	const [ followedTags, setFollowedTags ] = useState< string[] >( [] );
 	const [ showAllTopics, setShowAllTopics ] = useState( false );
 	const hasSyncedFromServerRef = useRef( false );
 	const followedTagsRef = useRef< string[] >( [] );
-	const interestTopics = useReaderInterestTags( { enabled: isOpen } ).slice(
-		0,
-		MAX_INTEREST_TOPICS
-	);
+	const interestTopics = useReaderInterestTags( { enabled: true } ).slice( 0, MAX_INTEREST_TOPICS );
 	const { data: followedTagsFromState } = useFollowedReaderTags();
 	const reduxFollows = useSelector( getReaderFollows );
 	const dispatch = useDispatch();
@@ -55,8 +53,12 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose, onC
 	const { mutateAsync: followTag } = useMutation( followReadTagMutation( queryClient ) );
 	const { mutateAsync: unfollowTag } = useMutation( unfollowReadTagMutation( queryClient ) );
 
+	// Sync the user's already-followed tags from server once on mount. The
+	// component only mounts while the step is active, so the previous
+	// `isOpen`-gated reset effect is no longer needed — the ref is reset
+	// implicitly when the component unmounts after the user leaves the step.
 	useEffect( () => {
-		if ( ! isOpen || ! followedTagsFromState || hasSyncedFromServerRef.current ) {
+		if ( ! followedTagsFromState || hasSyncedFromServerRef.current ) {
 			return;
 		}
 		if ( inFlightTagOpsRef.current.size > 0 ) {
@@ -66,14 +68,7 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose, onC
 		followedTagsRef.current = syncedTags;
 		setFollowedTags( syncedTags );
 		hasSyncedFromServerRef.current = true;
-	}, [ isOpen, followedTagsFromState ] );
-
-	useEffect( () => {
-		if ( isOpen ) {
-			return;
-		}
-		hasSyncedFromServerRef.current = false;
-	}, [ isOpen ] );
+	}, [ followedTagsFromState ] );
 
 	useEffect( () => {
 		followedTagsRef.current = followedTags;
@@ -255,7 +250,6 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose, onC
 
 	const handleContinue = () => {
 		if ( ! isContinueDisabled ) {
-			onClose();
 			onContinue();
 		}
 	};
@@ -270,108 +264,98 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { isOpen, onClose, onC
 	};
 
 	return (
-		isOpen && (
-			<Modal onRequestClose={ onClose } size="large" className="interests-modal">
-				<VStack spacing={ 8 } className="interests-modal__content">
-					<VStack spacing={ 0 }>
-						<h2 className="interests-modal__title">{ __( 'What topics interest you?' ) }</h2>
-						<p className="interests-modal__subtitle">
-							{ __(
-								'​​Stay up-to-date with your favorite blogs and discover new voices—all from one place.'
-							) }
-						</p>
-						<p className="interests-modal__subtitle">
-							{ fixMe( {
-								text: 'Pick a pack that describes your interest, or switch to individual topics.',
-								newCopy: __(
-									'Pick a pack that describes your interest, or switch to individual topics.'
-								),
-								oldCopy: __( 'Follow at least 3 topics to personalize your Reader feed.' ),
-							} ) }
-						</p>
-					</VStack>
-
-					{ packs.length > 0 && (
-						<div className="interests-modal__packs" role="list">
-							{ packs.map( ( pack ) => (
-								<div className="interests-modal__pack-item" role="listitem" key={ pack.id }>
-									<TopicGroupCard
-										title={ pack.title }
-										imageUrl={ pack.imageUrl }
-										description={ pack.description }
-										tags={ pack.tags }
-										blogs={ pack.blogs }
-										isSubscribed={ isPackSubscribed( pack ) }
-										isBusy={ processingPacks.has( pack.id ) }
-										onSubscribe={ () => void handlePackSubscribe( pack ) }
-									/>
-								</div>
-							) ) }
-						</div>
-					) }
-
-					{ interestTopics.length > 0 && (
-						<div className="interests-modal__topics-toggle-row">
-							<Button
-								variant="link"
-								onClick={ handleToggleTopics }
-								className="interests-modal__topics-toggle"
-								aria-expanded={ showAllTopics }
-							>
-								{ showAllTopics ? __( 'See less topics' ) : __( 'See more topics' ) }
-							</Button>
-						</div>
-					) }
-
-					{ showAllTopics && (
-						<div
-							className="interests-modal__topics-pills"
-							role="group"
-							aria-label={ __( 'Topics' ) }
-						>
-							{ interestTopics.map( ( topic ) => {
-								const checked = followedTags.includes( topic.tag );
-								return (
-									<button
-										key={ topic.tag }
-										type="button"
-										className={ clsx( 'interests-modal__topic-pill', {
-											'is-selected': checked,
-										} ) }
-										aria-pressed={ checked }
-										disabled={ processingTags.has( topic.tag ) }
-										onClick={ () => void handleTopicChange( ! checked, topic.tag ) }
-									>
-										{ topic.name }
-									</button>
-								);
-							} ) }
-						</div>
-					) }
+		<>
+			<VStack spacing={ 8 } className="interests-modal__content">
+				<VStack spacing={ 0 }>
+					<h2 className="interests-modal__title">{ __( 'What topics interest you?' ) }</h2>
+					<p className="interests-modal__subtitle">
+						{ __(
+							'​​Stay up-to-date with your favorite blogs and discover new voices—all from one place.'
+						) }
+					</p>
+					<p className="interests-modal__subtitle">
+						{ fixMe( {
+							text: 'Pick a pack that describes your interest, or switch to individual topics.',
+							newCopy: __(
+								'Pick a pack that describes your interest, or switch to individual topics.'
+							),
+							oldCopy: __( 'Follow at least 3 topics to personalize your Reader feed.' ),
+						} ) }
+					</p>
 				</VStack>
 
-				<div className="reader-onboarding-modal__footer">
-					<HStack justify="space-between" className="reader-onboarding-modal__footer-actions">
-						<StepIndicator totalSteps={ 3 } currentStep={ 2 } />
-						<HStack
-							spacing={ 2 }
-							justify="right"
-							className="reader-onboarding-modal__footer-buttons"
+				{ packs.length > 0 && (
+					<div className="interests-modal__packs" role="list">
+						{ packs.map( ( pack ) => (
+							<div className="interests-modal__pack-item" role="listitem" key={ pack.id }>
+								<TopicGroupCard
+									title={ pack.title }
+									imageUrl={ pack.imageUrl }
+									description={ pack.description }
+									tags={ pack.tags }
+									blogs={ pack.blogs }
+									isSubscribed={ isPackSubscribed( pack ) }
+									isBusy={ processingPacks.has( pack.id ) }
+									onSubscribe={ () => void handlePackSubscribe( pack ) }
+								/>
+							</div>
+						) ) }
+					</div>
+				) }
+
+				{ interestTopics.length > 0 && (
+					<div className="interests-modal__topics-toggle-row">
+						<Button
+							variant="link"
+							onClick={ handleToggleTopics }
+							className="interests-modal__topics-toggle"
+							aria-expanded={ showAllTopics }
 						>
-							<Button
-								__next40pxDefaultSize
-								onClick={ handleContinue }
-								variant="secondary"
-								disabled={ isContinueDisabled }
-								accessibleWhenDisabled
-							>
-								{ __( 'Continue' ) }
-							</Button>
-						</HStack>
+							{ showAllTopics ? __( 'See less topics' ) : __( 'See more topics' ) }
+						</Button>
+					</div>
+				) }
+
+				{ showAllTopics && (
+					<div className="interests-modal__topics-pills" role="group" aria-label={ __( 'Topics' ) }>
+						{ interestTopics.map( ( topic ) => {
+							const checked = followedTags.includes( topic.tag );
+							return (
+								<button
+									key={ topic.tag }
+									type="button"
+									className={ clsx( 'interests-modal__topic-pill', {
+										'is-selected': checked,
+									} ) }
+									aria-pressed={ checked }
+									disabled={ processingTags.has( topic.tag ) }
+									onClick={ () => void handleTopicChange( ! checked, topic.tag ) }
+								>
+									{ topic.name }
+								</button>
+							);
+						} ) }
+					</div>
+				) }
+			</VStack>
+
+			<div className="reader-onboarding-modal__footer">
+				<HStack justify="space-between" className="reader-onboarding-modal__footer-actions">
+					<StepIndicator totalSteps={ 3 } currentStep={ 2 } />
+					<HStack spacing={ 2 } justify="right" className="reader-onboarding-modal__footer-buttons">
+						<Button
+							__next40pxDefaultSize
+							onClick={ handleContinue }
+							variant="secondary"
+							disabled={ isContinueDisabled }
+							accessibleWhenDisabled
+						>
+							{ __( 'Continue' ) }
+						</Button>
 					</HStack>
-				</div>
-			</Modal>
-		)
+				</HStack>
+			</div>
+		</>
 	);
 };
 

--- a/client/reader/onboarding-rsm/subscribe-modal/index.tsx
+++ b/client/reader/onboarding-rsm/subscribe-modal/index.tsx
@@ -1,10 +1,9 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { LoadingPlaceholder } from '@automattic/components';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { Modal, Button, __experimentalHStack as HStack } from '@wordpress/components';
+import { Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, check } from '@wordpress/icons';
-import clsx from 'clsx';
 import { getLocaleSlug } from 'i18n-calypso';
 import React, { useMemo, useState, ComponentType, useEffect, useCallback } from 'react';
 import { useSelector } from 'react-redux';
@@ -19,20 +18,14 @@ import { curatedBlogs } from 'calypso/reader/onboarding-rsm/curated-blogs';
 import { StepIndicator } from 'calypso/reader/onboarding-rsm/step-indicator';
 import Stream from 'calypso/reader/stream';
 import { useDispatch } from 'calypso/state';
-import { isCurrentUserEmailVerified } from 'calypso/state/current-user/selectors';
 import { getFeed } from 'calypso/state/reader/feeds/selectors';
-import { requestFollows } from 'calypso/state/reader/follows/actions';
-import {
-	requestPage,
-	clearStream,
-	requestPaginatedStream,
-} from 'calypso/state/reader/streams/actions';
+import { requestPage, requestPaginatedStream } from 'calypso/state/reader/streams/actions';
 import SubscribeVerificationNudge from './verificationNudge';
 
 import './style.scss';
 
 interface SubscribeModalProps {
-	isOpen: boolean;
+	promptVerification: boolean;
 	onClose: () => void;
 }
 
@@ -65,15 +58,18 @@ interface StreamProps {
 
 const TypedStream: ComponentType< StreamProps > = Stream as ComponentType< StreamProps >;
 
-const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) => {
+// Renders the body of the "discover" step. The shared <Modal> wrapper is
+// provided by the parent (`ReaderOnboardingRsm`); this component is only
+// mounted while the step is active. X-out / escape are handled by the
+// wrapper's `onRequestClose`, which also runs the same close-side-effects
+// (data refresh, analytics) that `handleClose` previously did inline.
+const SubscribeModal: React.FC< SubscribeModalProps > = ( { promptVerification, onClose } ) => {
 	const { data: followedTags } = useFollowedReaderTags();
 
 	const followedTagSlugs = useMemo(
 		() => followedTags?.map( ( tag ) => tag.slug ) ?? [],
 		[ followedTags ]
 	);
-
-	const promptVerification = ! useSelector( isCurrentUserEmailVerified );
 
 	const [ currentPage, setCurrentPage ] = useState( 0 );
 	const [ selectedSite, setSelectedSite ] = useState< CardData | null >( null );
@@ -197,15 +193,16 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 		}
 	}, [ combinedRecommendations, dispatch ] );
 
-	// Prefetch all feed streams when the modal is opened.
+	// Prefetch all feed streams when the step is shown. The component only
+	// mounts while the step is active, so we no longer need an `isOpen` gate.
 	useEffect( () => {
-		if ( isOpen && combinedRecommendations.length > 0 ) {
+		if ( combinedRecommendations.length > 0 ) {
 			combinedRecommendations.forEach( ( site ) => {
 				// eslint-disable-next-line @typescript-eslint/no-explicit-any
 				dispatch( requestPage( { streamKey: `feed:${ site.feed_ID }` } as any ) );
 			} );
 		}
-	}, [ isOpen, combinedRecommendations, dispatch ] );
+	}, [ combinedRecommendations, dispatch ] );
 
 	// Reset the page and selected site when the followed tags change.
 	useEffect( () => {
@@ -236,15 +233,6 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 		[ selectedSite ]
 	);
 
-	const handleClose = useCallback( () => {
-		dispatch( requestFollows() );
-		dispatch( clearStream( { streamKey: 'following' } ) );
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		dispatch( requestPage( { streamKey: 'following' } as any ) );
-
-		onClose();
-	}, [ dispatch, onClose ] );
-
 	const handleContinue = useCallback( () => {
 		// Invalidate the subscriptions count query to refresh the Recent stream.
 		queryClient.invalidateQueries( {
@@ -260,133 +248,121 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { isOpen, onClose } ) 
 			} )
 		);
 
-		handleClose();
-	}, [ dispatch, handleClose, queryClient ] );
+		// Following-stream refresh + analytics happen in the parent's close
+		// handler so that X-out / escape triggers the same side-effects.
+		onClose();
+	}, [ dispatch, onClose, queryClient ] );
 
 	return (
-		isOpen && (
-			<Modal
-				onRequestClose={ handleClose }
-				size="medium"
-				className={ clsx( 'subscribe-modal', {
-					'is-disabled': promptVerification,
-				} ) }
-			>
-				{ promptVerification && <SubscribeVerificationNudge /> }
-				<div className="subscribe-modal__container">
-					<div className="subscribe-modal__content">
-						<div className="subscribe-modal__intro">
-							<h2 className="subscribe-modal__title">
-								{ __( "Discover sites that you'll love" ) }
-							</h2>
-							<p className="subscribe-modal__description">
-								{ __(
-									'Preview sites by clicking below, then subscribe to any site that inspires you.'
-								) }
-							</p>
-						</div>
-						<div className="subscribe-modal__columns">
-							<div className="subscribe-modal__site-list-column">
-								{ isLoading && <LoadingPlaceholder /> }
-								{ ! isLoading && combinedRecommendations.length === 0 && (
-									<p>{ __( 'No recommendations available at the moment.' ) }</p>
-								) }
-								{ ! isLoading && combinedRecommendations.length > 0 && (
-									<div className="subscribe-modal__recommended-sites">
-										{ displayedRecommendations.map( ( site: CardData ) => (
-											<ConnectedReaderSubscriptionListItem
-												key={ site.feed_ID }
-												feedId={ site.feed_ID }
-												siteId={ site.site_ID }
-												site={ site }
-												url={ site.site_URL }
-												showLastUpdatedDate={ false }
-												showNotificationSettings={ false }
-												showFollowedOnDate={ false }
-												followSource="reader-onboarding-modal"
-												replaceStreamClickWithItemClick
-												onItemClick={ () => handleItemClick( site ) }
-												isSelected={ selectedSite?.feed_ID === site.feed_ID }
-											/>
-										) ) }
-									</div>
-								) }
-								{ currentPage < maxPages && (
-									<Button
-										className="subscribe-modal__load-more-button"
-										onClick={ handleLoadMore }
-										variant="link"
-									>
-										{ __( 'Load more recommendations' ) }
-									</Button>
-								) }
-							</div>
-							<div className="subscribe-modal__preview-column">
-								<div className="subscribe-modal__preview-placeholder">
-									{ selectedSite && (
-										<>
-											<div className="subscribe-modal__preview-stream-header">
-												<div className="subscribe-modal__preview-site">
-													<SiteIcon size={ 36 } iconUrl={ selectedFeedIconUrl } />
-													<span className="subscribe-modal__preview-site-title">
-														{ selectedSite.site_name }
-													</span>
-												</div>
-												<ReaderFollowButton
-													siteUrl={ selectedSite.site_URL }
-													feedId={ selectedSite.feed_ID }
-													siteId={ selectedSite.site_ID }
-													followSource="reader-onboarding-modal"
-													hasButtonStyle
-													followIcon={ <></> }
-													followingIcon={
-														<Icon
-															key="following"
-															className="reader-following-feed"
-															icon={ check }
-															size={ 18 }
-														/>
-													}
-												/>
-											</div>
-											<div className="subscribe-modal__preview-stream-container">
-												<TypedStream
-													streamKey={ `feed:${ selectedSite.feed_ID }` }
-													className="is-site-stream subscribe-modal__preview-stream no-padding"
-													followSource="reader_subscribe_modal"
-													useCompactCards
-													trackScrollPage={ trackScrollPage.bind( null ) }
-												/>
-											</div>
-										</>
-									) }
+		<>
+			{ promptVerification && <SubscribeVerificationNudge /> }
+			<div className="subscribe-modal__container">
+				<div className="subscribe-modal__content">
+					<div className="subscribe-modal__intro">
+						<h2 className="subscribe-modal__title">{ __( "Discover sites that you'll love" ) }</h2>
+						<p className="subscribe-modal__description">
+							{ __(
+								'Preview sites by clicking below, then subscribe to any site that inspires you.'
+							) }
+						</p>
+					</div>
+					<div className="subscribe-modal__columns">
+						<div className="subscribe-modal__site-list-column">
+							{ isLoading && <LoadingPlaceholder /> }
+							{ ! isLoading && combinedRecommendations.length === 0 && (
+								<p>{ __( 'No recommendations available at the moment.' ) }</p>
+							) }
+							{ ! isLoading && combinedRecommendations.length > 0 && (
+								<div className="subscribe-modal__recommended-sites">
+									{ displayedRecommendations.map( ( site: CardData ) => (
+										<ConnectedReaderSubscriptionListItem
+											key={ site.feed_ID }
+											feedId={ site.feed_ID }
+											siteId={ site.site_ID }
+											site={ site }
+											url={ site.site_URL }
+											showLastUpdatedDate={ false }
+											showNotificationSettings={ false }
+											showFollowedOnDate={ false }
+											followSource="reader-onboarding-modal"
+											replaceStreamClickWithItemClick
+											onItemClick={ () => handleItemClick( site ) }
+											isSelected={ selectedSite?.feed_ID === site.feed_ID }
+										/>
+									) ) }
 								</div>
+							) }
+							{ currentPage < maxPages && (
+								<Button
+									className="subscribe-modal__load-more-button"
+									onClick={ handleLoadMore }
+									variant="link"
+								>
+									{ __( 'Load more recommendations' ) }
+								</Button>
+							) }
+						</div>
+						<div className="subscribe-modal__preview-column">
+							<div className="subscribe-modal__preview-placeholder">
+								{ selectedSite && (
+									<>
+										<div className="subscribe-modal__preview-stream-header">
+											<div className="subscribe-modal__preview-site">
+												<SiteIcon size={ 36 } iconUrl={ selectedFeedIconUrl } />
+												<span className="subscribe-modal__preview-site-title">
+													{ selectedSite.site_name }
+												</span>
+											</div>
+											<ReaderFollowButton
+												siteUrl={ selectedSite.site_URL }
+												feedId={ selectedSite.feed_ID }
+												siteId={ selectedSite.site_ID }
+												followSource="reader-onboarding-modal"
+												hasButtonStyle
+												followIcon={ <></> }
+												followingIcon={
+													<Icon
+														key="following"
+														className="reader-following-feed"
+														icon={ check }
+														size={ 18 }
+													/>
+												}
+											/>
+										</div>
+										<div className="subscribe-modal__preview-stream-container">
+											<TypedStream
+												streamKey={ `feed:${ selectedSite.feed_ID }` }
+												className="is-site-stream subscribe-modal__preview-stream no-padding"
+												followSource="reader_subscribe_modal"
+												useCompactCards
+												trackScrollPage={ trackScrollPage.bind( null ) }
+											/>
+										</div>
+									</>
+								) }
 							</div>
 						</div>
 					</div>
 				</div>
-				<div className="reader-onboarding-modal__footer">
-					<HStack justify="space-between" className="reader-onboarding-modal__footer-actions">
-						<StepIndicator totalSteps={ 3 } currentStep={ 3 } />
-						<HStack
-							spacing={ 2 }
-							justify="right"
-							className="reader-onboarding-modal__footer-buttons"
+			</div>
+			<div className="reader-onboarding-modal__footer">
+				<HStack justify="space-between" className="reader-onboarding-modal__footer-actions">
+					<StepIndicator totalSteps={ 3 } currentStep={ 3 } />
+					<HStack spacing={ 2 } justify="right" className="reader-onboarding-modal__footer-buttons">
+						<Button
+							__next40pxDefaultSize
+							onClick={ handleContinue }
+							variant="secondary"
+							disabled={ promptVerification }
+							accessibleWhenDisabled
 						>
-							<Button
-								__next40pxDefaultSize
-								onClick={ handleContinue }
-								variant="secondary"
-								disabled={ promptVerification }
-								accessibleWhenDisabled
-							>
-								{ __( 'Finish' ) }
-							</Button>
-						</HStack>
+							{ __( 'Finish' ) }
+						</Button>
 					</HStack>
-				</div>
-			</Modal>
-		)
+				</HStack>
+			</div>
+		</>
 	);
 };
 

--- a/client/reader/onboarding-rsm/welcome-modal/index.tsx
+++ b/client/reader/onboarding-rsm/welcome-modal/index.tsx
@@ -1,5 +1,4 @@
 import {
-	Modal,
 	Button,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
@@ -11,7 +10,6 @@ import { StepIndicator } from 'calypso/reader/onboarding-rsm/step-indicator';
 import './style.scss';
 
 interface WelcomeModalProps {
-	isOpen: boolean;
 	onClose: () => void;
 	onContinue: () => void;
 }
@@ -113,66 +111,65 @@ const renderTileImage = ( item: WelcomeTileItem ) => {
 	);
 };
 
-const WelcomeModal: React.FC< WelcomeModalProps > = ( { isOpen, onClose, onContinue } ) => {
+// Renders the body of the "welcome" step. The shared <Modal> wrapper is
+// provided by the parent (`ReaderOnboardingRsm`) so transitions between
+// steps don't unmount/remount the modal frame.
+const WelcomeModal: React.FC< WelcomeModalProps > = ( { onClose, onContinue } ) => {
 	return (
-		isOpen && (
-			<Modal onRequestClose={ onClose } size="medium" className="reader-welcome-modal">
-				<VStack spacing={ 8 } className="reader-welcome-modal__content">
-					<VStack
-						spacing={ 1 }
-						className="reader-welcome-modal__intro reader-welcome-modal__animate-in reader-welcome-modal__animate-in--intro"
-					>
-						<h2 className="reader-welcome-modal__title">{ __( 'Your reading home base' ) }</h2>
-						<p className="reader-welcome-modal__subtitle">
-							<span>{ __( 'All your favorite blogs and newsletters in one focused feed.' ) }</span>
-							<br />
-							<span>
-								{ __(
-									"Discover writers you'll love, no pop-ups, no clutter, just great writing."
-								) }
-							</span>
-						</p>
-					</VStack>
-
-					<div className="reader-welcome-modal__people-grid reader-welcome-modal__animate-in reader-welcome-modal__animate-in--people">
-						<div className="reader-welcome-modal__tile-row">
-							{ publications.map( ( publication ) => (
-								<div key={ publication.name } className="reader-welcome-modal__tile">
-									{ renderTileImage( publication ) }
-									<span className="reader-welcome-modal__tile-label">{ publication.name }</span>
-								</div>
-							) ) }
-						</div>
-						<div className="reader-welcome-modal__tile-row">
-							{ bloggers.map( ( blogger ) => (
-								<div key={ blogger.name } className="reader-welcome-modal__tile">
-									{ renderTileImage( blogger ) }
-									<span className="reader-welcome-modal__tile-label">{ blogger.name }</span>
-								</div>
-							) ) }
-						</div>
-					</div>
+		<>
+			<VStack spacing={ 8 } className="reader-welcome-modal__content">
+				<VStack
+					spacing={ 1 }
+					className="reader-welcome-modal__intro reader-welcome-modal__animate-in reader-welcome-modal__animate-in--intro"
+				>
+					<h2 className="reader-welcome-modal__title">{ __( 'Your reading home base' ) }</h2>
+					<p className="reader-welcome-modal__subtitle">
+						<span>{ __( 'All your favorite blogs and newsletters in one focused feed.' ) }</span>
+						<br />
+						<span>
+							{ __( "Discover writers you'll love, no pop-ups, no clutter, just great writing." ) }
+						</span>
+					</p>
 				</VStack>
 
-				<div className="reader-onboarding-modal__footer">
-					<HStack justify="space-between" className="reader-onboarding-modal__footer-actions">
-						<StepIndicator totalSteps={ 3 } currentStep={ 1 } />
-						<HStack
-							spacing={ 2 }
-							justify="right"
-							className="reader-onboarding-modal__footer-buttons reader-welcome-modal__footer-buttons"
-						>
-							<Button __next40pxDefaultSize variant="tertiary" onClick={ onClose }>
-								{ __( 'Do it later' ) }
-							</Button>
-							<Button __next40pxDefaultSize variant="primary" onClick={ onContinue }>
-								{ __( 'Pick your topics' ) }
-							</Button>
-						</HStack>
-					</HStack>
+				<div className="reader-welcome-modal__people-grid reader-welcome-modal__animate-in reader-welcome-modal__animate-in--people">
+					<div className="reader-welcome-modal__tile-row">
+						{ publications.map( ( publication ) => (
+							<div key={ publication.name } className="reader-welcome-modal__tile">
+								{ renderTileImage( publication ) }
+								<span className="reader-welcome-modal__tile-label">{ publication.name }</span>
+							</div>
+						) ) }
+					</div>
+					<div className="reader-welcome-modal__tile-row">
+						{ bloggers.map( ( blogger ) => (
+							<div key={ blogger.name } className="reader-welcome-modal__tile">
+								{ renderTileImage( blogger ) }
+								<span className="reader-welcome-modal__tile-label">{ blogger.name }</span>
+							</div>
+						) ) }
+					</div>
 				</div>
-			</Modal>
-		)
+			</VStack>
+
+			<div className="reader-onboarding-modal__footer">
+				<HStack justify="space-between" className="reader-onboarding-modal__footer-actions">
+					<StepIndicator totalSteps={ 3 } currentStep={ 1 } />
+					<HStack
+						spacing={ 2 }
+						justify="right"
+						className="reader-onboarding-modal__footer-buttons reader-welcome-modal__footer-buttons"
+					>
+						<Button __next40pxDefaultSize variant="tertiary" onClick={ onClose }>
+							{ __( 'Do it later' ) }
+						</Button>
+						<Button __next40pxDefaultSize variant="primary" onClick={ onContinue }>
+							{ __( 'Pick your topics' ) }
+						</Button>
+					</HStack>
+				</HStack>
+			</div>
+		</>
 	);
 };
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # https://linear.app/a8c/issue/RSM-2427/unify-modal-sizeflow

## Proposed Changes

* Refactors the 3 individual modals to be steps that are included in the same overall modal.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Get rid of the jumpy experience between steps (modals closing/opening)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This can be tested at `*/reader?flags=reader/onboarding-rsm,reader/force-onboarding`.
* Smoke test the onboarding modals. Ensure they each open well stand-alon from the checklist. Ensure clicking to the next modal feels seemless (no flash away and come back), Smoke test features, and sizes/scroll containers on different viewport constraints.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
