### PR TITLE
Cancellation feature list: domain and email products

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import {
 	Icon,
 	__experimentalHStack as HStack,
@@ -15,12 +16,40 @@ import {
 	getSingleItemCancelCopy,
 	getSingleItemRemoveCopy,
 } from './get-confirmation-copy';
+import { getOverrideCancellationFeatures } from './get-override-features';
 import type { Purchase, CancellationFeature } from '@automattic/api-core';
 
 type FeatureObject = {
 	getSlug: () => string;
 	getTitle: ( params?: { domainName?: string } ) => string;
 };
+
+type LossItem = { key: string; title: string };
+
+function getLossItems(
+	overrideFeatures: CancellationFeature[] | null,
+	cancellationFeatures: CancellationFeature[],
+	purchase: Purchase
+): LossItem[] {
+	if ( overrideFeatures ) {
+		return overrideFeatures.map( ( feature ) => ( {
+			key: String( feature.feature_id ),
+			title: feature.title,
+		} ) );
+	}
+	if ( cancellationFeatures.length ) {
+		return cancellationFeatures
+			.filter( ( feature ): feature is CancellationFeature => Boolean( feature ) )
+			.map( ( feature ) => ( {
+				key: String( feature.feature_id ),
+				title: feature.title,
+			} ) );
+	}
+	return getFallbackLossItems( purchase ).map( ( title, idx ) => ( {
+		key: `fallback-${ idx }`,
+		title,
+	} ) );
+}
 
 const CancelPurchaseFeatureList = ( {
 	purchase,
@@ -33,17 +62,14 @@ const CancelPurchaseFeatureList = ( {
 	cancellationFeatures: CancellationFeature[];
 	cancellationChanges: FeatureObject[];
 } ) => {
-	// When the server returns no feature list, fall back to a per-product-type
-	// item so every confirmation screen shows at least one concrete thing the
-	// user is giving up.
-	const lossItems: Array< { key: string; title: string } > = cancellationFeatures.length
-		? cancellationFeatures
-				.filter( ( feature ): feature is CancellationFeature => Boolean( feature ) )
-				.map( ( feature ) => ( { key: String( feature.feature_id ), title: feature.title } ) )
-		: getFallbackLossItems( purchase ).map( ( title, idx ) => ( {
-				key: `fallback-${ idx }`,
-				title,
-		  } ) );
+	// When the split-cancel-remove flag is on, use client-side feature overrides
+	// instead of the server-provided list. Falls back to API features when the
+	// override returns null (no entries yet for this product category).
+	const overrideFeatures = config.isEnabled( 'purchases/split-cancel-remove' )
+		? getOverrideCancellationFeatures( purchase )
+		: null;
+
+	const lossItems = getLossItems( overrideFeatures, cancellationFeatures, purchase );
 
 	if ( ! lossItems.length && ! cancellationChanges.length ) {
 		return null;

--- a/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
@@ -65,7 +65,8 @@ const CancelPurchaseFeatureList = ( {
 	// When the split-cancel-remove flag is on, use client-side feature overrides
 	// instead of the server-provided list. Falls back to API features when the
 	// override returns null (no entries yet for this product category).
-	const overrideFeatures = config.isEnabled( 'purchases/split-cancel-remove' )
+	const isSplitEnabled = useIsSplitCancelRemoveEnabled();
+	const overrideFeatures = isSplitEnabled
 		? getOverrideCancellationFeatures( purchase )
 		: null;
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import {
 	Icon,
 	__experimentalHStack as HStack,
@@ -17,6 +16,7 @@ import {
 	getSingleItemRemoveCopy,
 } from './get-confirmation-copy';
 import { getOverrideCancellationFeatures } from './get-override-features';
+import { useIsSplitCancelRemoveEnabled } from './use-is-split-cancel-remove-enabled';
 import type { Purchase, CancellationFeature } from '@automattic/api-core';
 
 type FeatureObject = {
@@ -66,9 +66,7 @@ const CancelPurchaseFeatureList = ( {
 	// instead of the server-provided list. Falls back to API features when the
 	// override returns null (no entries yet for this product category).
 	const isSplitEnabled = useIsSplitCancelRemoveEnabled();
-	const overrideFeatures = isSplitEnabled
-		? getOverrideCancellationFeatures( purchase )
-		: null;
+	const overrideFeatures = isSplitEnabled ? getOverrideCancellationFeatures( purchase ) : null;
 
 	const lossItems = getLossItems( overrideFeatures, cancellationFeatures, purchase );
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/get-override-features.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/get-override-features.ts
@@ -1,0 +1,69 @@
+import { getProductCategory } from './get-confirmation-copy';
+import type { PurchaseForCopy } from './get-confirmation-copy';
+import type { CancellationFeature } from '@automattic/api-core';
+
+/**
+ * Client-side override for cancellation features. When the split-cancel-remove
+ * flag is on, this replaces the server-provided feature list with
+ * benefit-oriented copy keyed by product slug and category.
+ *
+ * Returns null when no override exists — caller falls back to API features.
+ */
+export function getOverrideCancellationFeatures(
+	purchase: PurchaseForCopy
+): CancellationFeature[] | null {
+	const slug = purchase.product_slug;
+	const category = getProductCategory( purchase );
+
+	switch ( category ) {
+		case 'plan':
+			return getWpcomPlanFeatures( slug );
+		case 'domain':
+			return getDomainFeatures( purchase );
+		case 'email':
+			return getEmailFeatures( slug );
+		case 'jetpack':
+			return getJetpackFeatures( slug );
+		case 'akismet':
+			return getAkismetFeatures();
+		case 'marketplace':
+			return getMarketplaceFeatures( purchase );
+		case 'one-time':
+		case 'other':
+			return getAddonFeatures( slug );
+	}
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getWpcomPlanFeatures( slug: string ): CancellationFeature[] | null {
+	return null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getDomainFeatures( purchase: PurchaseForCopy ): CancellationFeature[] | null {
+	return null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getEmailFeatures( slug: string ): CancellationFeature[] | null {
+	return null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getJetpackFeatures( slug: string ): CancellationFeature[] | null {
+	return null;
+}
+
+function getAkismetFeatures(): CancellationFeature[] | null {
+	return null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getMarketplaceFeatures( purchase: PurchaseForCopy ): CancellationFeature[] | null {
+	return null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getAddonFeatures( slug: string ): CancellationFeature[] | null {
+	return null;
+}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/get-override-features.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/get-override-features.ts
@@ -1,6 +1,16 @@
+import { __ } from '@wordpress/i18n';
+import { isGSuiteOrGoogleWorkspaceProductSlug } from '../../../utils/purchase';
 import { getProductCategory } from './get-confirmation-copy';
 import type { PurchaseForCopy } from './get-confirmation-copy';
 import type { CancellationFeature } from '@automattic/api-core';
+
+function features( ...titles: string[] ): CancellationFeature[] {
+	return titles.map( ( title, idx ) => ( {
+		feature_id: `override-${ idx }`,
+		title,
+		description: '',
+	} ) );
+}
 
 /**
  * Client-side override for cancellation features. When the split-cancel-remove
@@ -40,13 +50,34 @@ function getWpcomPlanFeatures( slug: string ): CancellationFeature[] | null {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-function getDomainFeatures( purchase: PurchaseForCopy ): CancellationFeature[] | null {
-	return null;
+function getDomainFeatures( _purchase: PurchaseForCopy ): CancellationFeature[] | null {
+	return features(
+		__( 'Your claim to this domain (anyone can register it once it\u2019s released)' ),
+		__( 'Privacy protection on your contact info' ),
+		__( 'Free SSL certificate' ),
+		__( 'Email forwarding to your current inbox' ),
+		__( 'DNS management through your dashboard' )
+	);
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getEmailFeatures( slug: string ): CancellationFeature[] | null {
-	return null;
+	if ( isGSuiteOrGoogleWorkspaceProductSlug( slug ) ) {
+		return features(
+			__( 'Your custom email address' ),
+			__( 'Gmail, Calendar, and Contacts' ),
+			__( 'Docs, Sheets, and Slides' ),
+			__( '30 GB of cloud storage in Drive' ),
+			__( 'Google Meet video calls' ),
+			__( 'Real-time collaboration on shared files' )
+		);
+	}
+	return features(
+		__( 'Your custom email address' ),
+		__( '30 GB of mailbox storage' ),
+		__( 'Email, calendar, and contacts' ),
+		__( 'Access on web and mobile' ),
+		__( '24/7 email support' )
+	);
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/client/dashboard/me/billing-purchases/cancel-purchase/test/get-override-features.test.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/test/get-override-features.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment jsdom
+ */
+jest.mock( '@automattic/api-core', () => ( {
+	GoogleWorkspaceSlugs: {
+		GSUITE_BASIC_SLUG: 'gsuite-basic',
+		GSUITE_BUSINESS_SLUG: 'gsuite-business',
+	},
+	AkismetPlans: {},
+	TitanMailSlugs: {
+		TITAN_MAIL_MONTHLY_SLUG: 'titan-mail-monthly',
+		TITAN_MAIL_YEARLY_SLUG: 'titan-mail-yearly',
+	},
+} ) );
+
+import { getOverrideCancellationFeatures } from '../get-override-features';
+import type { PurchaseForCopy } from '../get-confirmation-copy';
+
+function makePurchase( overrides: Partial< PurchaseForCopy > = {} ): PurchaseForCopy {
+	return {
+		is_plan: false,
+		is_domain_registration: false,
+		is_jetpack_plan_or_product: false,
+		product_slug: 'test-product',
+		product_name: 'Test Product',
+		product_type: 'other',
+		expiry_date: '2027-04-16',
+		expiry_status: 'manual-renew',
+		domain: 'example.com',
+		...overrides,
+	} as PurchaseForCopy;
+}
+
+describe( 'getOverrideCancellationFeatures', () => {
+	it( 'returns null for a plan purchase (no entries yet)', () => {
+		const purchase = makePurchase( {
+			is_plan: true,
+			product_slug: 'business-bundle',
+			product_name: 'WordPress.com Business',
+		} );
+		expect( getOverrideCancellationFeatures( purchase ) ).toBeNull();
+	} );
+
+	it( 'returns null for a domain purchase', () => {
+		const purchase = makePurchase( {
+			is_domain_registration: true,
+			product_slug: 'dotcom_domain',
+			product_name: 'example.com',
+		} );
+		expect( getOverrideCancellationFeatures( purchase ) ).toBeNull();
+	} );
+
+	it( 'returns null for a Jetpack purchase', () => {
+		const purchase = makePurchase( {
+			is_jetpack_plan_or_product: true,
+			product_slug: 'jetpack_security_daily',
+			product_name: 'Jetpack Security',
+		} );
+		expect( getOverrideCancellationFeatures( purchase ) ).toBeNull();
+	} );
+} );

--- a/client/dashboard/me/billing-purchases/cancel-purchase/test/get-override-features.test.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/test/get-override-features.test.ts
@@ -3,13 +3,15 @@
  */
 jest.mock( '@automattic/api-core', () => ( {
 	GoogleWorkspaceSlugs: {
-		GSUITE_BASIC_SLUG: 'gsuite-basic',
-		GSUITE_BUSINESS_SLUG: 'gsuite-business',
+		GSUITE_BASIC_SLUG: 'gapps',
+		GSUITE_BUSINESS_SLUG: 'gapps_unlimited',
+		GOOGLE_WORKSPACE_BUSINESS_STARTER_MONTHLY: 'wp_google_workspace_business_starter_monthly',
+		GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY: 'wp_google_workspace_business_starter_yearly',
 	},
 	AkismetPlans: {},
 	TitanMailSlugs: {
-		TITAN_MAIL_MONTHLY_SLUG: 'titan-mail-monthly',
-		TITAN_MAIL_YEARLY_SLUG: 'titan-mail-yearly',
+		TITAN_MAIL_MONTHLY_SLUG: 'wp_titan_mail_monthly',
+		TITAN_MAIL_YEARLY_SLUG: 'wp_titan_mail_yearly',
 	},
 } ) );
 
@@ -41,13 +43,58 @@ describe( 'getOverrideCancellationFeatures', () => {
 		expect( getOverrideCancellationFeatures( purchase ) ).toBeNull();
 	} );
 
-	it( 'returns null for a domain purchase', () => {
-		const purchase = makePurchase( {
-			is_domain_registration: true,
-			product_slug: 'dotcom_domain',
-			product_name: 'example.com',
+	describe( 'domain and email products', () => {
+		it( 'returns 5 features for a domain registration', () => {
+			const purchase = makePurchase( {
+				is_domain_registration: true,
+				product_slug: 'dotcom_domain',
+				product_name: 'example.com',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 5 );
+			expect( result![ 0 ].title ).toContain( 'domain' );
 		} );
-		expect( getOverrideCancellationFeatures( purchase ) ).toBeNull();
+
+		it( 'returns 6 features for Google Workspace (yearly)', () => {
+			const purchase = makePurchase( {
+				product_slug: 'wp_google_workspace_business_starter_yearly',
+				product_name: 'Google Workspace',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 6 );
+			expect( result![ 0 ].title ).toBe( 'Your custom email address' );
+			expect( result![ 1 ].title ).toContain( 'Gmail' );
+		} );
+
+		it( 'returns 6 features for legacy G Suite (gapps)', () => {
+			const purchase = makePurchase( {
+				product_slug: 'gapps',
+				product_name: 'G Suite',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 6 );
+			expect( result![ 0 ].title ).toBe( 'Your custom email address' );
+		} );
+
+		it( 'returns 5 features for Professional Email (yearly)', () => {
+			const purchase = makePurchase( {
+				product_slug: 'wp_titan_mail_yearly',
+				product_name: 'Professional Email',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 5 );
+			expect( result![ 0 ].title ).toBe( 'Your custom email address' );
+			expect( result![ 1 ].title ).toContain( 'mailbox' );
+		} );
+
+		it( 'returns 5 features for Professional Email (monthly)', () => {
+			const purchase = makePurchase( {
+				product_slug: 'wp_titan_mail_monthly',
+				product_name: 'Professional Email',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 5 );
+		} );
 	} );
 
 	it( 'returns null for a Jetpack purchase', () => {

--- a/client/me/purchases/cancel-purchase/feature-list.tsx
+++ b/client/me/purchases/cancel-purchase/feature-list.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import moment from 'moment';
 import {
@@ -7,10 +8,37 @@ import {
 	getSingleItemCancelCopy,
 	getSingleItemRemoveCopy,
 } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy';
+import { getOverrideCancellationFeatures } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/get-override-features';
 import { toPurchaseForCopy } from './to-purchase-for-copy';
 import type { CancellationFeature } from '@automattic/api-core';
 import type { Purchases } from '@automattic/data-stores';
+import type { PurchaseForCopy } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy';
 import type { DisplayVariant } from 'calypso/lib/purchases/utils';
+
+type LossItem = { key: string; title: string };
+
+function getLossItems(
+	overrideFeatures: CancellationFeature[] | null,
+	cancellationFeatures: CancellationFeature[],
+	adapted: PurchaseForCopy
+): LossItem[] {
+	if ( overrideFeatures ) {
+		return overrideFeatures.map( ( feature ) => ( {
+			key: String( feature.feature_id ),
+			title: feature.title,
+		} ) );
+	}
+	if ( cancellationFeatures.length ) {
+		return cancellationFeatures.map( ( feature ) => ( {
+			key: feature.feature_id,
+			title: feature.title,
+		} ) );
+	}
+	return getFallbackLossItems( adapted ).map( ( title, idx ) => ( {
+		key: `fallback-${ idx }`,
+		title,
+	} ) );
+}
 
 const CancelPurchaseFeatureList = ( {
 	purchase,
@@ -22,16 +50,15 @@ const CancelPurchaseFeatureList = ( {
 	cancellationFeatures: CancellationFeature[];
 } ) => {
 	const adapted = toPurchaseForCopy( purchase );
-	// When the server returns no features, fall back to a per-product-type item.
-	const items: Array< { key: string; title: string } > = cancellationFeatures.length
-		? cancellationFeatures.map( ( feature ) => ( {
-				key: feature.feature_id,
-				title: feature.title,
-		  } ) )
-		: getFallbackLossItems( adapted ).map( ( title, idx ) => ( {
-				key: `fallback-${ idx }`,
-				title,
-		  } ) );
+
+	// When the split-cancel-remove flag is on, use client-side feature overrides
+	// instead of the server-provided list. Falls back to API features when the
+	// override returns null (no entries yet for this product category).
+	const overrideFeatures = config.isEnabled( 'purchases/split-cancel-remove' )
+		? getOverrideCancellationFeatures( adapted )
+		: null;
+
+	const items = getLossItems( overrideFeatures, cancellationFeatures, adapted );
 
 	if ( ! items.length ) {
 		return null;

--- a/client/me/purchases/cancel-purchase/feature-list.tsx
+++ b/client/me/purchases/cancel-purchase/feature-list.tsx
@@ -53,9 +53,10 @@ const CancelPurchaseFeatureList = ( {
 
 	// When the split-cancel-remove flag is on, use client-side feature overrides
 	// instead of the server-provided list. Falls back to API features when the
-	// override returns null (no entries yet for this product category).
-	const overrideFeatures = config.isEnabled( 'purchases/split-cancel-remove' )
+	const isSplitEnabled = useIsSplitCancelRemoveEnabled();
+	const overrideFeatures = isSplitEnabled
 		? getOverrideCancellationFeatures( adapted )
+		: null;
 		: null;
 
 	const items = getLossItems( overrideFeatures, cancellationFeatures, adapted );

--- a/client/me/purchases/cancel-purchase/feature-list.tsx
+++ b/client/me/purchases/cancel-purchase/feature-list.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import moment from 'moment';
 import {
@@ -9,6 +8,7 @@ import {
 	getSingleItemRemoveCopy,
 } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy';
 import { getOverrideCancellationFeatures } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/get-override-features';
+import { useIsSplitCancelRemoveEnabled } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/use-is-split-cancel-remove-enabled';
 import { toPurchaseForCopy } from './to-purchase-for-copy';
 import type { CancellationFeature } from '@automattic/api-core';
 import type { Purchases } from '@automattic/data-stores';
@@ -54,10 +54,7 @@ const CancelPurchaseFeatureList = ( {
 	// When the split-cancel-remove flag is on, use client-side feature overrides
 	// instead of the server-provided list. Falls back to API features when the
 	const isSplitEnabled = useIsSplitCancelRemoveEnabled();
-	const overrideFeatures = isSplitEnabled
-		? getOverrideCancellationFeatures( adapted )
-		: null;
-		: null;
+	const overrideFeatures = isSplitEnabled ? getOverrideCancellationFeatures( adapted ) : null;
 
 	const items = getLossItems( overrideFeatures, cancellationFeatures, adapted );
 


### PR DESCRIPTION
Part of #110478
Related to: https://linear.app/a8c/issue/RSM-478

Fixes: https://linear.app/a8c/issue/RSM-683
Fixes: https://linear.app/a8c/issue/RSM-690
Fixes: https://linear.app/a8c/issue/RSM-691

## Proposed Changes

This PR updates the feature lists for emails and domains.

| Before | After |
| -- | -- |
| <img width="1760" height="1196" alt="Screenshot 2026-05-06 at 12 03 17 PM" src="https://github.com/user-attachments/assets/c585120b-e935-47ea-ab8e-3a63a013dbbc" /> | <img width="1760" height="1196" alt="Screenshot 2026-05-06 at 12 03 15 PM" src="https://github.com/user-attachments/assets/947e8631-28a4-42fd-bc9c-de79d4a37743" /> |
| <img width="1760" height="1196" alt="image" src="https://github.com/user-attachments/assets/740ca246-31c1-4cff-ae46-44d0d7c08111" /> |  <img width="1760" height="1196" alt="image" src="https://github.com/user-attachments/assets/ca17233b-2ba4-42f6-8c7f-a5c8bb2df767" /> |
|  <img width="1760" height="1196" alt="image" src="https://github.com/user-attachments/assets/35e4d490-d6db-4553-8872-54015ff91f1d" /> |  <img width="1760" height="1196" alt="image" src="https://github.com/user-attachments/assets/4fb1df6c-86c5-49e8-81d2-18dafc2dfeba" /> |



Here's the technical details of what was updated:
- Fill `getDomainFeatures` with 5 static benefit-oriented bullets (domain claim, privacy protection, SSL, email forwarding, DNS management)
- Fill `getEmailFeatures` with product-specific bullets: 6 for Google Workspace (Gmail, Drive, Meet, etc.), 5 for Professional Email / Titan Mail (mailbox storage, calendar, mobile access, support)
- Add `features()` helper to reduce boilerplate when building `CancellationFeature[]` arrays from plain strings
- Fix test mock slugs to match real `@automattic/api-core` constants (`gapps`, `wp_titan_mail_yearly`, etc.)
- Add 5 tests covering domain registration, Google Workspace (yearly + legacy gapps), and Professional Email (yearly + monthly)

## Why are these changes being made?

RSM-683 (domains), RSM-690 (Google Workspace), RSM-691 (Professional Email) — the cancel/remove confirmation screen should show what the customer will lose when they remove a domain or email product. Currently it falls back to generic server-provided features that don't communicate the value clearly.

Stacked on #110478 (infra). Independent of plans, marketplace, and Jetpack PRs.

## Testing Instructions

1. Enable `purchases/split-cancel-remove` feature flag
2. Navigate to a domain purchase → Purchase Settings → Remove domain
3. Confirm the cancellation screen shows 5 domain-specific bullets
4. Navigate to a Google Workspace purchase → Remove
5. Confirm 6 Google Workspace-specific bullets (Gmail, Drive, Meet, etc.)
6. Navigate to a Professional Email purchase → Remove
7. Confirm 5 Professional Email-specific bullets (mailbox storage, calendar, etc.)
8. Verify both surfaces (dashboard `my.localhost:3000` and legacy `calypso.localhost:3000`)

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?

🤖 Generated with [Claude Code](https://claude.com/claude-code)