### PR TITLE
Substack Importer: Fix content step being stuck while importing content

### DIFF
--- a/client/state/imports/reducer.js
+++ b/client/state/imports/reducer.js
@@ -82,6 +82,7 @@ function importerStatus( state = {}, action ) {
 
 			// convert the response with `fromApi` only after we know it's not empty
 			const newImporterStatus = fromApi( action.importerStatus );
+			const newSiteId = newImporterStatus.site?.ID;
 
 			return omitBy(
 				{
@@ -90,10 +91,21 @@ function importerStatus( state = {}, action ) {
 					// ...and the importer being received.
 					[ newImporterStatus.importerId ]: newImporterStatus,
 				},
-				( importer ) =>
-					[ appStates.CANCEL_PENDING, appStates.DEFUNCT, appStates.EXPIRED ].includes(
-						importer.importerState
-					)
+				( importer ) => {
+					// Drop terminal-state importers.
+					if (
+						[ appStates.CANCEL_PENDING, appStates.DEFUNCT, appStates.EXPIRED ].includes(
+							importer.importerState
+						)
+					) {
+						return true;
+					}
+					// The server only tracks one importer per site (a single restapi_import_manager_data blog option).
+					// Without this, an old importerId could linger in Redux, and the UI would keep POSTing to /imports/{stale-id} and getting 404s.
+					return (
+						importer.importerId !== newImporterStatus.importerId && importer.site?.ID === newSiteId
+					);
+				}
 			);
 		}
 

--- a/client/state/imports/selectors.js
+++ b/client/state/imports/selectors.js
@@ -17,7 +17,7 @@ export function getImporterStatus( state, importerId ) {
 export const getImporterStatusForSiteId = createSelector(
 	( state, siteId ) => {
 		return Object.values( state.imports.importerStatus ).filter(
-			( importer ) => importer.site.ID === siteId
+			( importer ) => importer.site?.ID === siteId
 		);
 	},
 	( state ) => [ state.imports.importerStatus ]


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes: https://linear.app/a8c/issue/NL-611/substack-content-importer-is-unavailable-on-jetpack-sites

## Proposed Changes

- Make sure to always use the new import ID coming from the API.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- In Jetpack sites case the importer is using the old importer ID even when the new ID is received via the API.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to your test Jetpack site.
- Try importing content using Substack importer.
- Verify that the content is imported successfully.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
