### PR TITLE
Reader Achievements: centralize feature gating in useAchievementsVisibility

### DIFF
--- a/client/reader/components/achievements/test/use-achievements-visibility.test.ts
+++ b/client/reader/components/achievements/test/use-achievements-visibility.test.ts
@@ -4,19 +4,21 @@
 import { renderHook } from '@testing-library/react';
 import useAchievementsVisibility from '../use-achievements-visibility';
 
-const mockUseQuery = jest.fn();
-jest.mock( '@tanstack/react-query', () => ( {
-	useQuery: ( ...args: unknown[] ) => mockUseQuery( ...args ),
+const mockIsEnabled = jest.fn();
+jest.mock( '@automattic/calypso-config', () => ( {
+	isEnabled: ( ...args: unknown[] ) => mockIsEnabled( ...args ),
 } ) );
 
-jest.mock( '@automattic/calypso-config', () => ( {
-	isEnabled: () => true,
+const mockUseQuery = jest.fn();
+jest.mock( '@tanstack/react-query', () => ( {
+	useQuery: ( options: unknown ) => mockUseQuery( options ),
 } ) );
 
 jest.mock( '@automattic/api-queries', () => ( {
 	readAchievementsSettingsQuery: ( userIdOrLogin: string ) => ( {
 		queryKey: [ 'read', 'achievements', userIdOrLogin, 'settings' ],
 	} ),
+	readTeamsQuery: () => ( { queryKey: [ 'read', 'teams' ] } ),
 } ) );
 
 const mockGetCurrentUser = jest.fn();
@@ -27,15 +29,92 @@ jest.mock( 'calypso/state/current-user/selectors', () => ( {
 	getCurrentUser: ( state: unknown ) => mockGetCurrentUser( state ),
 } ) );
 
+type QueryOptions = { queryKey: unknown[]; enabled?: boolean };
+type QueryResult = { data?: unknown; isLoading?: boolean };
+type QueryResponses = { teams?: QueryResult; settings?: QueryResult };
+
+function setupUseQuery( responses: QueryResponses = {} ) {
+	mockUseQuery.mockImplementation( ( options: QueryOptions ) => {
+		if ( options.enabled === false ) {
+			return { data: undefined, isLoading: false };
+		}
+		const isTeams = options.queryKey[ 1 ] === 'teams';
+		const response = ( isTeams ? responses.teams : responses.settings ) ?? {};
+		return { data: response.data, isLoading: response.isLoading ?? false };
+	} );
+}
+
+function findCall( mock: jest.Mock, predicate: ( options: QueryOptions ) => boolean ) {
+	return mock.mock.calls.find( ( [ options ] ) => predicate( options as QueryOptions ) ) as
+		| [ QueryOptions ]
+		| undefined;
+}
+
 describe( 'useAchievementsVisibility', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
-		mockUseQuery.mockReturnValue( { data: undefined, isLoading: false } );
+		mockIsEnabled.mockReturnValue( true );
+		mockGetCurrentUser.mockReturnValue( { username: 'myself' } );
+		setupUseQuery( {
+			teams: { data: { teams: [ { slug: 'a8c' } ] } },
+		} );
 	} );
 
-	test( 'should return isOwnProfile and isVisible true for own profile', () => {
-		mockGetCurrentUser.mockReturnValue( { username: 'myself' } );
+	test( 'returns isVisible false when feature flag is disabled', () => {
+		mockIsEnabled.mockReturnValue( false );
 
+		const { result } = renderHook( () => useAchievementsVisibility( 'myself' ) );
+
+		expect( result.current.isVisible ).toBe( false );
+		expect( result.current.isLoading ).toBe( false );
+	} );
+
+	test( 'does not fetch teams or settings when flag is disabled', () => {
+		mockIsEnabled.mockReturnValue( false );
+
+		renderHook( () => useAchievementsVisibility( 'other_user' ) );
+
+		const teamsCall = findCall( mockUseQuery, ( o ) => o.queryKey[ 1 ] === 'teams' );
+		const settingsCall = findCall( mockUseQuery, ( o ) => o.queryKey[ 1 ] === 'achievements' );
+		expect( teamsCall?.[ 0 ].enabled ).toBe( false );
+		expect( settingsCall?.[ 0 ].enabled ).toBe( false );
+	} );
+
+	test( 'returns isLoading true while teams query loads', () => {
+		setupUseQuery( {
+			teams: { isLoading: true },
+		} );
+
+		const { result } = renderHook( () => useAchievementsVisibility( 'myself' ) );
+
+		expect( result.current.isLoading ).toBe( true );
+		expect( result.current.isVisible ).toBe( false );
+	} );
+
+	test( 'returns isVisible false when viewer is not an automattician', () => {
+		setupUseQuery( {
+			teams: { data: { teams: [] } },
+			settings: { data: { settings: { 'achievements-visibility': 'public' } } },
+		} );
+
+		const { result } = renderHook( () => useAchievementsVisibility( 'myself' ) );
+
+		expect( result.current.isVisible ).toBe( false );
+		expect( result.current.isLoading ).toBe( false );
+	} );
+
+	test( 'does not fetch settings when viewer is not an automattician', () => {
+		setupUseQuery( {
+			teams: { data: { teams: [] } },
+		} );
+
+		renderHook( () => useAchievementsVisibility( 'other_user' ) );
+
+		const settingsCall = findCall( mockUseQuery, ( o ) => o.queryKey[ 1 ] === 'achievements' );
+		expect( settingsCall?.[ 0 ].enabled ).toBe( false );
+	} );
+
+	test( 'returns isOwnProfile and isVisible true for own profile when viewer is A8C', () => {
 		const { result } = renderHook( () => useAchievementsVisibility( 'myself' ) );
 
 		expect( result.current.isOwnProfile ).toBe( true );
@@ -43,19 +122,17 @@ describe( 'useAchievementsVisibility', () => {
 		expect( result.current.isLoading ).toBe( false );
 	} );
 
-	test( 'should not fetch settings for own profile', () => {
-		mockGetCurrentUser.mockReturnValue( { username: 'myself' } );
-
+	test( 'does not fetch settings for own profile', () => {
 		renderHook( () => useAchievementsVisibility( 'myself' ) );
 
-		expect( mockUseQuery ).toHaveBeenCalledWith( expect.objectContaining( { enabled: false } ) );
+		const settingsCall = findCall( mockUseQuery, ( o ) => o.queryKey[ 1 ] === 'achievements' );
+		expect( settingsCall?.[ 0 ].enabled ).toBe( false );
 	} );
 
-	test( 'should return isVisible true when other user has public achievements', () => {
-		mockGetCurrentUser.mockReturnValue( { username: 'myself' } );
-		mockUseQuery.mockReturnValue( {
-			data: { settings: { 'achievements-visibility': 'public' } },
-			isLoading: false,
+	test( 'returns isVisible true when other user has public achievements and viewer is A8C', () => {
+		setupUseQuery( {
+			teams: { data: { teams: [ { slug: 'a8c' } ] } },
+			settings: { data: { settings: { 'achievements-visibility': 'public' } } },
 		} );
 
 		const { result } = renderHook( () => useAchievementsVisibility( 'other_user' ) );
@@ -65,11 +142,10 @@ describe( 'useAchievementsVisibility', () => {
 		expect( result.current.isLoading ).toBe( false );
 	} );
 
-	test( 'should return isVisible false when other user has private achievements', () => {
-		mockGetCurrentUser.mockReturnValue( { username: 'myself' } );
-		mockUseQuery.mockReturnValue( {
-			data: { settings: { 'achievements-visibility': 'private' } },
-			isLoading: false,
+	test( 'returns isVisible false when other user has private achievements', () => {
+		setupUseQuery( {
+			teams: { data: { teams: [ { slug: 'a8c' } ] } },
+			settings: { data: { settings: { 'achievements-visibility': 'private' } } },
 		} );
 
 		const { result } = renderHook( () => useAchievementsVisibility( 'other_user' ) );
@@ -78,9 +154,11 @@ describe( 'useAchievementsVisibility', () => {
 		expect( result.current.isVisible ).toBe( false );
 	} );
 
-	test( 'should return isLoading true while fetching other user settings', () => {
-		mockGetCurrentUser.mockReturnValue( { username: 'myself' } );
-		mockUseQuery.mockReturnValue( { data: undefined, isLoading: true } );
+	test( 'returns isLoading true while fetching other user settings', () => {
+		setupUseQuery( {
+			teams: { data: { teams: [ { slug: 'a8c' } ] } },
+			settings: { isLoading: true },
+		} );
 
 		const { result } = renderHook( () => useAchievementsVisibility( 'other_user' ) );
 

--- a/client/reader/components/achievements/use-achievements-visibility.ts
+++ b/client/reader/components/achievements/use-achievements-visibility.ts
@@ -1,23 +1,32 @@
-import { readAchievementsSettingsQuery } from '@automattic/api-queries';
+import { readAchievementsSettingsQuery, readTeamsQuery } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
 import { useQuery } from '@tanstack/react-query';
+import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
 import { useSelector } from 'calypso/state';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 
 export default function useAchievementsVisibility( profileUserLogin?: string ) {
+	const featureEnabled = isEnabled( 'reader/achievements' );
 	const currentUser = useSelector( getCurrentUser );
 	const isOwnProfile = currentUser?.username === profileUserLogin;
 
-	const { data, isLoading } = useQuery( {
-		...readAchievementsSettingsQuery( profileUserLogin ),
-		enabled: isEnabled( 'reader/achievements' ) && ! isOwnProfile && profileUserLogin != null,
+	const { data: teamsData, isLoading: teamsLoading } = useQuery( {
+		...readTeamsQuery(),
+		enabled: featureEnabled,
 	} );
+	const isAutomattician = isAutomatticTeamMember( teamsData?.teams ?? [] );
 
-	const isPublic = data?.settings[ 'achievements-visibility' ] === 'public';
+	const { data: settingsData, isLoading: settingsLoading } = useQuery( {
+		...readAchievementsSettingsQuery( profileUserLogin ),
+		enabled: featureEnabled && isAutomattician && ! isOwnProfile && profileUserLogin != null,
+	} );
+	const isPublic = settingsData?.settings[ 'achievements-visibility' ] === 'public';
 
 	return {
 		isOwnProfile,
-		isVisible: isOwnProfile || isPublic,
-		isLoading: ! isOwnProfile && isLoading,
+		isVisible: featureEnabled && isAutomattician && ( isOwnProfile || isPublic ),
+		isLoading:
+			featureEnabled &&
+			( teamsLoading || ( ! isOwnProfile && isAutomattician && settingsLoading ) ),
 	};
 }

--- a/client/reader/user-profile/components/user-profile-header/index.tsx
+++ b/client/reader/user-profile/components/user-profile-header/index.tsx
@@ -1,5 +1,4 @@
 import './style.scss';
-import { isEnabled } from '@automattic/calypso-config';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useLayoutEffect, useRef, useState } from 'react';
@@ -61,7 +60,7 @@ const UserProfileHeader = ( { user, view }: UserProfileHeaderProps ): JSX.Elemen
 			path: `${ userProfileUrl }/recommended-blogs`,
 			selected: view === 'recommended-blogs',
 		},
-		...( isEnabled( 'reader/achievements' ) && showAchievements
+		...( showAchievements
 			? [
 					{
 						label: translate( 'Achievements' ),

--- a/client/reader/user-profile/components/user-profile-header/test/index.test.tsx
+++ b/client/reader/user-profile/components/user-profile-header/test/index.test.tsx
@@ -3,7 +3,6 @@
  */
 
 import { ReaderUser, UserSitesResponse } from '@automattic/api-core';
-import { isEnabled } from '@automattic/calypso-config';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -32,16 +31,11 @@ jest.mock(
 		)
 );
 
-jest.mock( '@automattic/calypso-config', () => ( {
-	isEnabled: jest.fn(),
-} ) );
-
+const mockUseAchievementsVisibility = jest.fn();
 jest.mock( 'calypso/reader/components/achievements/use-achievements-visibility', () => ( {
 	__esModule: true,
-	default: () => ( { isOwnProfile: true, isVisible: true, isLoading: false } ),
+	default: () => mockUseAchievementsVisibility(),
 } ) );
-
-const mockIsEnabled = isEnabled as jest.MockedFunction< typeof isEnabled >;
 
 describe( 'UserProfileHeader', () => {
 	const defaultUser: ReaderUser = {
@@ -60,6 +54,11 @@ describe( 'UserProfileHeader', () => {
 
 	beforeEach( () => {
 		jest.clearAllMocks();
+		mockUseAchievementsVisibility.mockReturnValue( {
+			isOwnProfile: true,
+			isVisible: true,
+			isLoading: false,
+		} );
 		nock.disableNetConnect();
 		queryClient = new QueryClient( {
 			defaultOptions: {
@@ -144,7 +143,11 @@ describe( 'UserProfileHeader', () => {
 	} );
 
 	test( 'should render navigation tabs with Posts, Sites, Lists, and Recommended Blogs options', () => {
-		mockIsEnabled.mockReturnValue( false );
+		mockUseAchievementsVisibility.mockReturnValue( {
+			isOwnProfile: true,
+			isVisible: false,
+			isLoading: false,
+		} );
 		renderWithClient( <UserProfileHeader user={ defaultUser } view="posts" /> );
 
 		const navItems = screen.getAllByRole( 'menuitem' );
@@ -157,8 +160,7 @@ describe( 'UserProfileHeader', () => {
 		expect( screen.queryByRole( 'menuitem', { name: 'Achievements' } ) ).not.toBeInTheDocument();
 	} );
 
-	test( 'should render Achievements tab when reader/achievements flag is enabled', () => {
-		mockIsEnabled.mockImplementation( ( flag ) => flag === 'reader/achievements' );
+	test( 'should render Achievements tab when achievements visibility hook reports it is visible', () => {
 		renderWithClient( <UserProfileHeader user={ defaultUser } view="posts" /> );
 
 		const navItems = screen.getAllByRole( 'menuitem' );

--- a/client/reader/user-profile/views/achievements/index.tsx
+++ b/client/reader/user-profile/views/achievements/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useAchievementsQuery } from 'calypso/data/reader/use-achievements-query';
@@ -18,10 +17,6 @@ const UserAchievements = ( { user }: UserAchievementsProps ): JSX.Element | null
 	const translate = useTranslate();
 	const { isOwnProfile, isVisible, isLoading } = useAchievementsVisibility( user.user_login );
 	const { yearsOfService } = useAchievementsQuery( isVisible ? user.user_login : undefined );
-
-	if ( ! isEnabled( 'reader/achievements' ) ) {
-		return null;
-	}
 
 	if ( isLoading ) {
 		return (

--- a/client/reader/user-profile/views/achievements/test/index.test.tsx
+++ b/client/reader/user-profile/views/achievements/test/index.test.tsx
@@ -1,14 +1,9 @@
 /**
  * @jest-environment jsdom
  */
-import { isEnabled } from '@automattic/calypso-config';
 import { render, screen } from '@testing-library/react';
 import UserAchievements from '../index';
 import type { ReaderUser } from '@automattic/api-core';
-
-jest.mock( '@automattic/calypso-config', () => ( {
-	isEnabled: jest.fn(),
-} ) );
 
 jest.mock( 'calypso/reader/components/achievements/use-achievements-visibility' );
 
@@ -33,8 +28,6 @@ jest.mock( 'calypso/reader/components/achievements/years-of-service-badge', () =
 		<div data-testid="years-of-service-badge">{ yearsOfService }</div>
 	),
 } ) );
-
-const mockIsEnabled = isEnabled as jest.MockedFunction< typeof isEnabled >;
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const useAchievementsVisibility =
@@ -61,25 +54,11 @@ describe( 'UserAchievements', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		mockAchievementsGridProps.mockClear();
-		mockIsEnabled.mockReturnValue( true );
 		useAchievementsQuery.mockReturnValue( {
 			yearsOfService: undefined,
 			lockedAchievements: [],
 			isLoading: false,
 		} );
-	} );
-
-	test( 'should render nothing when feature flag is disabled', () => {
-		mockIsEnabled.mockReturnValue( false );
-		useAchievementsVisibility.mockReturnValue( {
-			isOwnProfile: true,
-			isVisible: true,
-			isLoading: false,
-		} );
-
-		const { container } = render( <UserAchievements user={ defaultUser } /> );
-
-		expect( container.innerHTML ).toBe( '' );
 	} );
 
 	test( 'should render nothing when achievements are not visible', () => {


### PR DESCRIPTION
Part of RSM-1530

## Proposed Changes

* Move all three Achievements gates (feature flag, A8C team membership, profile owner's `achievements-visibility` preference) into `useAchievementsVisibility`.
* Block `isLoading` on the teams fetch so the Achievements tab and view don't flash in for non-Automatticians on a cold cache.
* Skip the `achievements-visibility` settings fetch when the viewer isn't an Automattician (or when the flag is off).
* Drop redundant `isEnabled('reader/achievements')` checks at call sites: `UserProfileHeader` (tab item) and `UserAchievements` (view).

## Why are these changes being made?

Non-Automatticians could reach the Achievements feature on environments where the `reader/achievements` flag is enabled (e.g. wpcalypso) because the gates were duplicated and incomplete across call sites. Centralizing the logic in a single hook makes the rules unambiguous and ensures every surface (badges, profile-tab, view) enforces the same restrictions.

## Testing Instructions

* In an environment with the `reader/achievements` flag enabled (e.g. wpcalypso):
  * As a non-Automattician, visit any user profile (own and someone else's). The Achievements tab should not appear, and `/achievements` should render nothing. Author achievement badges should not appear next to display names.
  * As an Automattician, visit your own profile: the Achievements tab + view should be visible, settings button shown, badges shown.
  * As an Automattician, visit another A8C user's profile with `achievements-visibility: public`: tab + view + badges shown.
  * As an Automattician, visit another A8C user's profile with `achievements-visibility: private`: tab hidden, view returns null, badges hidden.
* In an environment with the `reader/achievements` flag disabled, the feature should remain hidden in all cases.
* Run `yarn test-client client/reader/components/achievements client/reader/user-profile/components/user-profile-header client/reader/user-profile/views/achievements` — all 72 tests pass.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?