### PR TITLE
Reader onboarding RSM - update styles of subscriptions step article previews.

### DIFF
--- a/client/blocks/reader-post-card/byline.jsx
+++ b/client/blocks/reader-post-card/byline.jsx
@@ -22,10 +22,12 @@ class PostByline extends Component {
 		showFollow: PropTypes.bool,
 		compact: PropTypes.bool,
 		openSuggestedFollows: PropTypes.func,
+		showBylineSecondarySiteLink: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		showAvatar: true,
+		showBylineSecondarySiteLink: true,
 	};
 
 	constructor( props ) {
@@ -97,8 +99,17 @@ class PostByline extends Component {
 	};
 
 	render() {
-		const { post, site, feed, showSiteName, showAvatar, teams, compact, openSuggestedFollows } =
-			this.props;
+		const {
+			post,
+			site,
+			feed,
+			showSiteName,
+			showAvatar,
+			teams,
+			compact,
+			openSuggestedFollows,
+			showBylineSecondarySiteLink,
+		} = this.props;
 		const feedId = feed ? feed.feed_ID : get( post, 'feed_ID' );
 		const feedIcon = feed ? feed.site_icon ?? get( feed, 'image' ) : null;
 		const siteId = get( site, 'ID' );
@@ -113,6 +124,7 @@ class PostByline extends Component {
 		// Use the siteName if not showing it elsewhere, otherwise use the slug.
 		const bylineSiteName = ! showSiteName ? siteName : siteSlug;
 		const showDate = post.date && post.URL;
+		const showSecondarySiteLink = showBylineSecondarySiteLink && bylineSiteName;
 
 		/* eslint-disable wpcalypso/jsx-gridicon-size */
 		return (
@@ -134,7 +146,7 @@ class PostByline extends Component {
 						</div>
 					) }
 					<div className="reader-post-card__author-and-timestamp">
-						{ ( shouldDisplayAuthor || bylineSiteName || showDate ) && (
+						{ ( shouldDisplayAuthor || showSecondarySiteLink || showDate ) && (
 							<span className="reader-post-card__byline-secondary" ref={ this.secondaryBylineRef }>
 								{ shouldDisplayAuthor && (
 									<>
@@ -146,14 +158,14 @@ class PostByline extends Component {
 										>
 											{ post.author.name }
 										</ReaderAuthorLink>
-										{ ( bylineSiteName || showDate ) && (
+										{ ( showSecondarySiteLink || showDate ) && (
 											<span className="reader-post-card__byline-secondary-bullet-wrapper">
 												<span className="reader-post-card__byline-secondary-bullet">·</span>
 											</span>
 										) }
 									</>
 								) }
-								{ bylineSiteName && (
+								{ showSecondarySiteLink && (
 									<>
 										<a
 											className="reader-post-card__byline-secondary-item"

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -49,6 +49,7 @@ class ReaderPostCard extends Component {
 		fixedHeaderHeight: PropTypes.number,
 		streamKey: PropTypes.string,
 		commentsApiDisabled: PropTypes.bool,
+		showBylineSecondarySiteLink: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -57,6 +58,7 @@ class ReaderPostCard extends Component {
 		handleClick: noop,
 		isSelected: false,
 		showSiteName: true,
+		showBylineSecondarySiteLink: true,
 	};
 
 	state = {
@@ -206,6 +208,7 @@ class ReaderPostCard extends Component {
 				showFollow
 				openSuggestedFollows={ this.openSuggestedFollowsModal }
 				compact={ compact }
+				showBylineSecondarySiteLink={ this.props.showBylineSecondarySiteLink }
 			/>
 		);
 

--- a/client/reader/onboarding-rsm/subscribe-modal/index.tsx
+++ b/client/reader/onboarding-rsm/subscribe-modal/index.tsx
@@ -47,6 +47,7 @@ interface StreamProps {
 	followSource?: string;
 	useCompactCards?: boolean;
 	wideLayout?: boolean;
+	showBylineSecondarySiteLink?: boolean;
 	trackScrollPage?: (
 		path: string,
 		title: string,
@@ -336,6 +337,7 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { promptVerification, 
 												className="is-site-stream subscribe-modal__preview-stream no-padding"
 												followSource="reader_subscribe_modal"
 												useCompactCards
+												showBylineSecondarySiteLink={ false }
 												trackScrollPage={ trackScrollPage.bind( null ) }
 											/>
 										</div>

--- a/client/reader/onboarding-rsm/subscribe-modal/style.scss
+++ b/client/reader/onboarding-rsm/subscribe-modal/style.scss
@@ -201,6 +201,15 @@ body.is-reader-page .subscribe-modal__preview-column .reader__card.card.is-place
 		.reader-update-notice {
 			display: none;
 		}
+
+		// Compact cards stack `.reader-post-card__post-options` above the featured
+		// image in `.reader-post-card__post-media`. We hide the ellipsis (and we are
+		// not on /discover so there is no follow button there), leaving an empty row
+		// — but the row still had the global compact rule `margin-bottom: 16px`,
+		// which pushed thumbnails down relative to the vertically-centered text.
+		.reader-post-card.card.is-compact .reader-post-card__post-options {
+			margin-bottom: 0;
+		}
 	}
 
 	&__preview-placeholder {
@@ -309,7 +318,29 @@ body.is-reader-page .subscribe-modal__preview-column .reader__card.card.is-place
 		.reader-post-card.card.is-compact {
 			margin-bottom: 0;
 			border-radius: 0;
-			padding: 14px 16px 12px;
+			padding: 14px 16px;
+
+			// Vertically center the title/meta/excerpt block against the
+			// featured image on the right.
+			.reader-post-card__post-content {
+				align-items: center;
+				margin-bottom: 0;
+			}
+
+			// 8px gap between the title/meta heading row and the excerpt
+			// body. Resetting the excerpt margin overrides the global
+			// `margin-bottom: 10px` it ships with.
+			.reader-post-card__post-heading {
+				margin-bottom: 8px;
+			}
+
+			.reader-excerpt,
+			.reader-excerpt__content {
+				margin: 0;
+				max-height: none;
+				font-size: 13px;
+				line-height: 20px;
+			}
 		}
 	}
 

--- a/client/reader/onboarding-rsm/subscribe-modal/style.scss
+++ b/client/reader/onboarding-rsm/subscribe-modal/style.scss
@@ -311,11 +311,18 @@ body.is-reader-page .subscribe-modal__preview-column .reader__card.card.is-place
 			border-radius: 0;
 			padding: 14px 16px;
 
-			// Vertically center the title/meta/excerpt block against the
-			// featured image on the right.
+			// Vertically center the text column against the thumbnail when the
+			// compact layout is a row (`flex-direction: row`). Do not apply
+			// `align-items: center` on `.reader-post-card__no-excerpt`: that variant
+			// uses a column stack and centering prevents horizontal stretch, which
+			// collapses featured-media width and hides full-width images that only
+			// have a fixed height + `object-fit: contain`.
 			.reader-post-card__post-content {
-				align-items: center;
 				margin-bottom: 0;
+
+				&:not(.reader-post-card__no-excerpt) {
+					align-items: center;
+				}
 			}
 
 			// 8px gap between the title/meta heading row and the excerpt
@@ -339,7 +346,7 @@ body.is-reader-page .subscribe-modal__preview-column .reader__card.card.is-place
 		pointer-events: none;
 	}
 
-		// Per-card follow + ellipsis live in `.reader-post-card__post-options`. On `/discover`,
+	// Per-card follow + ellipsis live in `.reader-post-card__post-options`. On `/discover`,
 	// compact cards use `display: flex` there with competing specificity; chaining the modal
 	// frame (both classes exist on the WP modal frame) keeps this scoped and wins in cascade.
 	&.components-modal__frame &__preview-column .reader-post-card.card .reader-post-card__post-options {

--- a/client/reader/onboarding-rsm/subscribe-modal/style.scss
+++ b/client/reader/onboarding-rsm/subscribe-modal/style.scss
@@ -201,15 +201,6 @@ body.is-reader-page .subscribe-modal__preview-column .reader__card.card.is-place
 		.reader-update-notice {
 			display: none;
 		}
-
-		// Compact cards stack `.reader-post-card__post-options` above the featured
-		// image in `.reader-post-card__post-media`. We hide the ellipsis (and we are
-		// not on /discover so there is no follow button there), leaving an empty row
-		// — but the row still had the global compact rule `margin-bottom: 16px`,
-		// which pushed thumbnails down relative to the vertically-centered text.
-		.reader-post-card.card.is-compact .reader-post-card__post-options {
-			margin-bottom: 0;
-		}
 	}
 
 	&__preview-placeholder {
@@ -346,6 +337,13 @@ body.is-reader-page .subscribe-modal__preview-column .reader__card.card.is-place
 
 	&__preview-stream {
 		pointer-events: none;
+	}
+
+		// Per-card follow + ellipsis live in `.reader-post-card__post-options`. On `/discover`,
+	// compact cards use `display: flex` there with competing specificity; chaining the modal
+	// frame (both classes exist on the WP modal frame) keeps this scoped and wins in cascade.
+	&.components-modal__frame &__preview-column .reader-post-card.card .reader-post-card__post-options {
+		display: none;
 	}
 
 	&.is-disabled {

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -93,6 +93,7 @@ class ReaderStream extends Component {
 		selectedStreamName: PropTypes.string,
 		isLoggedIn: PropTypes.bool,
 		wideLayout: PropTypes.bool,
+		showBylineSecondarySiteLink: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -109,6 +110,7 @@ class ReaderStream extends Component {
 		useCompactCards: false,
 		isLoggedIn: false,
 		wideLayout: false,
+		showBylineSecondarySiteLink: true,
 	};
 
 	state = {
@@ -597,6 +599,7 @@ class ReaderStream extends Component {
 					blockedSites={ this.props.blockedSites }
 					streamKey={ streamKey }
 					recsStreamKey={ this.props.recsStreamKey }
+					showBylineSecondarySiteLink={ this.props.showBylineSecondarySiteLink }
 					index={ index }
 					compact={ this.props.useCompactCards }
 					siteId={ primarySiteId }

--- a/client/reader/stream/post.jsx
+++ b/client/reader/stream/post.jsx
@@ -56,6 +56,7 @@ class ReaderPostCardAdapter extends Component {
 				fixedHeaderHeight={ this.props.fixedHeaderHeight }
 				streamKey={ this.props.streamKey }
 				commentsApiDisabled={ this.props.commentsApiDisabled }
+				showBylineSecondarySiteLink={ this.props.showBylineSecondarySiteLink }
 			>
 				<div ref={ this.props.postRef }>
 					{ feedId && <QueryReaderFeed feedId={ feedId } /> }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # https://linear.app/a8c/issue/RSM-1189/update-site-subscription-step-design

## Proposed Changes

* Creates a new prop in the reader-post-card for `showBylineSecondarySiteLink` that defaults to true, and passes this prop down from the preview component used in the onboarding step as `false`. This hides the extra URL shown in the byline in the card to match the designs, while leaving the default state as is.
* Updates some text sizes and layout on the reader onboarding-rsm subscriptions step.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* match the design

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* smoke test reader, changes can be seen at `*/reader?flags=reader%2Fonboarding-rsm%2Creader%2Fforce-onboarding`.
* smoke test reader cards across the reader and compare vs. production. the bylines should remain unchanged.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
