### PR TITLE
Cancellation feature list: marketplace and add-on products

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import {
 	Icon,
 	__experimentalHStack as HStack,
@@ -15,12 +16,40 @@ import {
 	getSingleItemCancelCopy,
 	getSingleItemRemoveCopy,
 } from './get-confirmation-copy';
+import { getOverrideCancellationFeatures } from './get-override-features';
 import type { Purchase, CancellationFeature } from '@automattic/api-core';
 
 type FeatureObject = {
 	getSlug: () => string;
 	getTitle: ( params?: { domainName?: string } ) => string;
 };
+
+type LossItem = { key: string; title: string };
+
+function getLossItems(
+	overrideFeatures: CancellationFeature[] | null,
+	cancellationFeatures: CancellationFeature[],
+	purchase: Purchase
+): LossItem[] {
+	if ( overrideFeatures ) {
+		return overrideFeatures.map( ( feature ) => ( {
+			key: String( feature.feature_id ),
+			title: feature.title,
+		} ) );
+	}
+	if ( cancellationFeatures.length ) {
+		return cancellationFeatures
+			.filter( ( feature ): feature is CancellationFeature => Boolean( feature ) )
+			.map( ( feature ) => ( {
+				key: String( feature.feature_id ),
+				title: feature.title,
+			} ) );
+	}
+	return getFallbackLossItems( purchase ).map( ( title, idx ) => ( {
+		key: `fallback-${ idx }`,
+		title,
+	} ) );
+}
 
 const CancelPurchaseFeatureList = ( {
 	purchase,
@@ -33,17 +62,14 @@ const CancelPurchaseFeatureList = ( {
 	cancellationFeatures: CancellationFeature[];
 	cancellationChanges: FeatureObject[];
 } ) => {
-	// When the server returns no feature list, fall back to a per-product-type
-	// item so every confirmation screen shows at least one concrete thing the
-	// user is giving up.
-	const lossItems: Array< { key: string; title: string } > = cancellationFeatures.length
-		? cancellationFeatures
-				.filter( ( feature ): feature is CancellationFeature => Boolean( feature ) )
-				.map( ( feature ) => ( { key: String( feature.feature_id ), title: feature.title } ) )
-		: getFallbackLossItems( purchase ).map( ( title, idx ) => ( {
-				key: `fallback-${ idx }`,
-				title,
-		  } ) );
+	// When the split-cancel-remove flag is on, use client-side feature overrides
+	// instead of the server-provided list. Falls back to API features when the
+	// override returns null (no entries yet for this product category).
+	const overrideFeatures = config.isEnabled( 'purchases/split-cancel-remove' )
+		? getOverrideCancellationFeatures( purchase )
+		: null;
+
+	const lossItems = getLossItems( overrideFeatures, cancellationFeatures, purchase );
 
 	if ( ! lossItems.length && ! cancellationChanges.length ) {
 		return null;

--- a/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
@@ -65,7 +65,8 @@ const CancelPurchaseFeatureList = ( {
 	// When the split-cancel-remove flag is on, use client-side feature overrides
 	// instead of the server-provided list. Falls back to API features when the
 	// override returns null (no entries yet for this product category).
-	const overrideFeatures = config.isEnabled( 'purchases/split-cancel-remove' )
+	const isSplitEnabled = useIsSplitCancelRemoveEnabled();
+	const overrideFeatures = isSplitEnabled
 		? getOverrideCancellationFeatures( purchase )
 		: null;
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import {
 	Icon,
 	__experimentalHStack as HStack,
@@ -17,6 +16,7 @@ import {
 	getSingleItemRemoveCopy,
 } from './get-confirmation-copy';
 import { getOverrideCancellationFeatures } from './get-override-features';
+import { useIsSplitCancelRemoveEnabled } from './use-is-split-cancel-remove-enabled';
 import type { Purchase, CancellationFeature } from '@automattic/api-core';
 
 type FeatureObject = {
@@ -66,9 +66,7 @@ const CancelPurchaseFeatureList = ( {
 	// instead of the server-provided list. Falls back to API features when the
 	// override returns null (no entries yet for this product category).
 	const isSplitEnabled = useIsSplitCancelRemoveEnabled();
-	const overrideFeatures = isSplitEnabled
-		? getOverrideCancellationFeatures( purchase )
-		: null;
+	const overrideFeatures = isSplitEnabled ? getOverrideCancellationFeatures( purchase ) : null;
 
 	const lossItems = getLossItems( overrideFeatures, cancellationFeatures, purchase );
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/get-override-features.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/get-override-features.ts
@@ -1,6 +1,15 @@
+import { __ } from '@wordpress/i18n';
 import { getProductCategory } from './get-confirmation-copy';
 import type { PurchaseForCopy } from './get-confirmation-copy';
 import type { CancellationFeature } from '@automattic/api-core';
+
+function features( ...titles: string[] ): CancellationFeature[] {
+	return titles.map( ( title, idx ) => ( {
+		feature_id: `override-${ idx }`,
+		title,
+		description: '',
+	} ) );
+}
 
 /**
  * Client-side override for cancellation features. When the split-cancel-remove
@@ -58,12 +67,49 @@ function getAkismetFeatures(): CancellationFeature[] | null {
 	return null;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getMarketplaceFeatures( purchase: PurchaseForCopy ): CancellationFeature[] | null {
-	return null;
+	if ( purchase.product_type === 'marketplace_theme' ) {
+		return features(
+			__( 'Access to this theme' ),
+			__( 'Customizations you\u2019ve made to the theme' ),
+			__( 'Theme-specific features and layouts' ),
+			__( 'Automatic updates and security patches' )
+		);
+	}
+	return features(
+		__( 'Access to this plugin' ),
+		__( 'Data and settings you\u2019ve created with the plugin' ),
+		__( 'Features and functionality the plugin adds to your site' ),
+		__( 'Automatic updates and security patches' )
+	);
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function isStorageAddon( slug: string ): boolean {
+	return slug.endsWith( 'gb_space_upgrade' ) || slug === 'wordpress_com_1gb_space_addon_yearly';
+}
+
 function getAddonFeatures( slug: string ): CancellationFeature[] | null {
+	if ( slug === 'unlimited_themes' ) {
+		return features(
+			__( 'Any premium theme currently active on your site' ),
+			__( 'Access to the full premium theme collection' ),
+			__( 'Professionally designed themes from expert creators' ),
+			__( 'Automatic theme updates' )
+		);
+	}
+	if ( isStorageAddon( slug ) ) {
+		return features(
+			__( 'Extra storage space' ),
+			__( 'Space to keep uploading high-resolution photos and videos' ),
+			__( 'Breathing room for your themes, plugins, backups, and posts' )
+		);
+	}
+	if ( slug === 'custom-design' ) {
+		return features(
+			__( 'Custom CSS code you\u2019ve written for your site' ),
+			__( 'Design changes beyond what the theme customizer allows' ),
+			__( 'Fine-tuned control over your site\u2019s look and feel' )
+		);
+	}
 	return null;
 }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/get-override-features.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/get-override-features.ts
@@ -1,0 +1,69 @@
+import { getProductCategory } from './get-confirmation-copy';
+import type { PurchaseForCopy } from './get-confirmation-copy';
+import type { CancellationFeature } from '@automattic/api-core';
+
+/**
+ * Client-side override for cancellation features. When the split-cancel-remove
+ * flag is on, this replaces the server-provided feature list with
+ * benefit-oriented copy keyed by product slug and category.
+ *
+ * Returns null when no override exists — caller falls back to API features.
+ */
+export function getOverrideCancellationFeatures(
+	purchase: PurchaseForCopy
+): CancellationFeature[] | null {
+	const slug = purchase.product_slug;
+	const category = getProductCategory( purchase );
+
+	switch ( category ) {
+		case 'plan':
+			return getWpcomPlanFeatures( slug );
+		case 'domain':
+			return getDomainFeatures( purchase );
+		case 'email':
+			return getEmailFeatures( slug );
+		case 'jetpack':
+			return getJetpackFeatures( slug );
+		case 'akismet':
+			return getAkismetFeatures();
+		case 'marketplace':
+			return getMarketplaceFeatures( purchase );
+		case 'one-time':
+		case 'other':
+			return getAddonFeatures( slug );
+	}
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getWpcomPlanFeatures( slug: string ): CancellationFeature[] | null {
+	return null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getDomainFeatures( purchase: PurchaseForCopy ): CancellationFeature[] | null {
+	return null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getEmailFeatures( slug: string ): CancellationFeature[] | null {
+	return null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getJetpackFeatures( slug: string ): CancellationFeature[] | null {
+	return null;
+}
+
+function getAkismetFeatures(): CancellationFeature[] | null {
+	return null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getMarketplaceFeatures( purchase: PurchaseForCopy ): CancellationFeature[] | null {
+	return null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getAddonFeatures( slug: string ): CancellationFeature[] | null {
+	return null;
+}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/test/get-override-features.test.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/test/get-override-features.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment jsdom
+ */
+jest.mock( '@automattic/api-core', () => ( {
+	GoogleWorkspaceSlugs: {
+		GSUITE_BASIC_SLUG: 'gsuite-basic',
+		GSUITE_BUSINESS_SLUG: 'gsuite-business',
+	},
+	AkismetPlans: {},
+	TitanMailSlugs: {
+		TITAN_MAIL_MONTHLY_SLUG: 'titan-mail-monthly',
+		TITAN_MAIL_YEARLY_SLUG: 'titan-mail-yearly',
+	},
+} ) );
+
+import { getOverrideCancellationFeatures } from '../get-override-features';
+import type { PurchaseForCopy } from '../get-confirmation-copy';
+
+function makePurchase( overrides: Partial< PurchaseForCopy > = {} ): PurchaseForCopy {
+	return {
+		is_plan: false,
+		is_domain_registration: false,
+		is_jetpack_plan_or_product: false,
+		product_slug: 'test-product',
+		product_name: 'Test Product',
+		product_type: 'other',
+		expiry_date: '2027-04-16',
+		expiry_status: 'manual-renew',
+		domain: 'example.com',
+		...overrides,
+	} as PurchaseForCopy;
+}
+
+describe( 'getOverrideCancellationFeatures', () => {
+	it( 'returns null for a plan purchase (no entries yet)', () => {
+		const purchase = makePurchase( {
+			is_plan: true,
+			product_slug: 'business-bundle',
+			product_name: 'WordPress.com Business',
+		} );
+		expect( getOverrideCancellationFeatures( purchase ) ).toBeNull();
+	} );
+
+	it( 'returns null for a domain purchase', () => {
+		const purchase = makePurchase( {
+			is_domain_registration: true,
+			product_slug: 'dotcom_domain',
+			product_name: 'example.com',
+		} );
+		expect( getOverrideCancellationFeatures( purchase ) ).toBeNull();
+	} );
+
+	it( 'returns null for a Jetpack purchase', () => {
+		const purchase = makePurchase( {
+			is_jetpack_plan_or_product: true,
+			product_slug: 'jetpack_security_daily',
+			product_name: 'Jetpack Security',
+		} );
+		expect( getOverrideCancellationFeatures( purchase ) ).toBeNull();
+	} );
+} );

--- a/client/dashboard/me/billing-purchases/cancel-purchase/test/get-override-features.test.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/test/get-override-features.test.ts
@@ -58,4 +58,97 @@ describe( 'getOverrideCancellationFeatures', () => {
 		} );
 		expect( getOverrideCancellationFeatures( purchase ) ).toBeNull();
 	} );
+
+	describe( 'marketplace and add-on products', () => {
+		it( 'returns 4 features for a marketplace plugin', () => {
+			const purchase = makePurchase( {
+				product_type: 'marketplace_plugin',
+				product_slug: 'some-marketplace-plugin',
+				product_name: 'SEO Plugin',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 4 );
+			expect( result![ 0 ].title ).toContain( 'plugin' );
+		} );
+
+		it( 'returns 4 features for a SaaS plugin', () => {
+			const purchase = makePurchase( {
+				product_type: 'saas_plugin',
+				product_slug: 'some-saas-plugin',
+				product_name: 'SaaS Plugin',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 4 );
+			expect( result![ 0 ].title ).toContain( 'plugin' );
+		} );
+
+		it( 'returns 4 features for a marketplace theme', () => {
+			const purchase = makePurchase( {
+				product_type: 'marketplace_theme',
+				product_slug: 'some-marketplace-theme',
+				product_name: 'Premium Theme',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 4 );
+			expect( result![ 0 ].title ).toContain( 'theme' );
+		} );
+
+		it( 'returns 4 features for the premium theme add-on (unlimited_themes)', () => {
+			const purchase = makePurchase( {
+				product_slug: 'unlimited_themes',
+				product_name: 'Premium Themes',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 4 );
+			expect( result![ 0 ].title ).toContain( 'premium theme' );
+		} );
+
+		it( 'returns 3 features for a storage add-on (50gb)', () => {
+			const purchase = makePurchase( {
+				product_slug: '50gb_space_upgrade',
+				product_name: '50 GB Storage',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 3 );
+			expect( result![ 0 ].title ).toContain( 'storage' );
+		} );
+
+		it( 'returns 3 features for a storage add-on (other tier)', () => {
+			const purchase = makePurchase( {
+				product_slug: '1gb_space_upgrade',
+				product_name: '1 GB Storage',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 3 );
+			expect( result![ 0 ].title ).toContain( 'storage' );
+		} );
+
+		it( 'returns 3 features for the tiered-volume storage add-on', () => {
+			const purchase = makePurchase( {
+				product_slug: 'wordpress_com_1gb_space_addon_yearly',
+				product_name: 'Storage Add-On Space Upgrade 50 GB',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 3 );
+			expect( result![ 0 ].title ).toContain( 'storage' );
+		} );
+
+		it( 'returns 3 features for the CSS add-on (custom-design)', () => {
+			const purchase = makePurchase( {
+				product_slug: 'custom-design',
+				product_name: 'Custom Design',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 3 );
+			expect( result![ 0 ].title ).toContain( 'CSS' );
+		} );
+
+		it( 'returns null for an unknown other product', () => {
+			const purchase = makePurchase( {
+				product_slug: 'unknown-addon',
+				product_name: 'Unknown Add-on',
+			} );
+			expect( getOverrideCancellationFeatures( purchase ) ).toBeNull();
+		} );
+	} );
 } );

--- a/client/me/purchases/cancel-purchase/feature-list.tsx
+++ b/client/me/purchases/cancel-purchase/feature-list.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import moment from 'moment';
 import {
@@ -7,10 +8,37 @@ import {
 	getSingleItemCancelCopy,
 	getSingleItemRemoveCopy,
 } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy';
+import { getOverrideCancellationFeatures } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/get-override-features';
 import { toPurchaseForCopy } from './to-purchase-for-copy';
 import type { CancellationFeature } from '@automattic/api-core';
 import type { Purchases } from '@automattic/data-stores';
+import type { PurchaseForCopy } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy';
 import type { DisplayVariant } from 'calypso/lib/purchases/utils';
+
+type LossItem = { key: string; title: string };
+
+function getLossItems(
+	overrideFeatures: CancellationFeature[] | null,
+	cancellationFeatures: CancellationFeature[],
+	adapted: PurchaseForCopy
+): LossItem[] {
+	if ( overrideFeatures ) {
+		return overrideFeatures.map( ( feature ) => ( {
+			key: String( feature.feature_id ),
+			title: feature.title,
+		} ) );
+	}
+	if ( cancellationFeatures.length ) {
+		return cancellationFeatures.map( ( feature ) => ( {
+			key: feature.feature_id,
+			title: feature.title,
+		} ) );
+	}
+	return getFallbackLossItems( adapted ).map( ( title, idx ) => ( {
+		key: `fallback-${ idx }`,
+		title,
+	} ) );
+}
 
 const CancelPurchaseFeatureList = ( {
 	purchase,
@@ -22,16 +50,15 @@ const CancelPurchaseFeatureList = ( {
 	cancellationFeatures: CancellationFeature[];
 } ) => {
 	const adapted = toPurchaseForCopy( purchase );
-	// When the server returns no features, fall back to a per-product-type item.
-	const items: Array< { key: string; title: string } > = cancellationFeatures.length
-		? cancellationFeatures.map( ( feature ) => ( {
-				key: feature.feature_id,
-				title: feature.title,
-		  } ) )
-		: getFallbackLossItems( adapted ).map( ( title, idx ) => ( {
-				key: `fallback-${ idx }`,
-				title,
-		  } ) );
+
+	// When the split-cancel-remove flag is on, use client-side feature overrides
+	// instead of the server-provided list. Falls back to API features when the
+	// override returns null (no entries yet for this product category).
+	const overrideFeatures = config.isEnabled( 'purchases/split-cancel-remove' )
+		? getOverrideCancellationFeatures( adapted )
+		: null;
+
+	const items = getLossItems( overrideFeatures, cancellationFeatures, adapted );
 
 	if ( ! items.length ) {
 		return null;

--- a/client/me/purchases/cancel-purchase/feature-list.tsx
+++ b/client/me/purchases/cancel-purchase/feature-list.tsx
@@ -53,9 +53,10 @@ const CancelPurchaseFeatureList = ( {
 
 	// When the split-cancel-remove flag is on, use client-side feature overrides
 	// instead of the server-provided list. Falls back to API features when the
-	// override returns null (no entries yet for this product category).
-	const overrideFeatures = config.isEnabled( 'purchases/split-cancel-remove' )
+	const isSplitEnabled = useIsSplitCancelRemoveEnabled();
+	const overrideFeatures = isSplitEnabled
 		? getOverrideCancellationFeatures( adapted )
+		: null;
 		: null;
 
 	const items = getLossItems( overrideFeatures, cancellationFeatures, adapted );

--- a/client/me/purchases/cancel-purchase/feature-list.tsx
+++ b/client/me/purchases/cancel-purchase/feature-list.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import moment from 'moment';
 import {
@@ -9,6 +8,7 @@ import {
 	getSingleItemRemoveCopy,
 } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy';
 import { getOverrideCancellationFeatures } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/get-override-features';
+import { useIsSplitCancelRemoveEnabled } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/use-is-split-cancel-remove-enabled';
 import { toPurchaseForCopy } from './to-purchase-for-copy';
 import type { CancellationFeature } from '@automattic/api-core';
 import type { Purchases } from '@automattic/data-stores';
@@ -54,10 +54,7 @@ const CancelPurchaseFeatureList = ( {
 	// When the split-cancel-remove flag is on, use client-side feature overrides
 	// instead of the server-provided list. Falls back to API features when the
 	const isSplitEnabled = useIsSplitCancelRemoveEnabled();
-	const overrideFeatures = isSplitEnabled
-		? getOverrideCancellationFeatures( adapted )
-		: null;
-		: null;
+	const overrideFeatures = isSplitEnabled ? getOverrideCancellationFeatures( adapted ) : null;
 
 	const items = getLossItems( overrideFeatures, cancellationFeatures, adapted );
 


### PR DESCRIPTION
Depends on: https://github.com/Automattic/wp-calypso/pull/110478
Related to: https://linear.app/a8c/issue/RSM-478

Fixes: https://linear.app/a8c/issue/RSM-687, 
Fixes: https://linear.app/a8c/issue/RSM-688, 
Fixes: https://linear.app/a8c/issue/RSM-697, 
Fixes: https://linear.app/a8c/issue/RSM-710, 
Fixes: https://linear.app/a8c/issue/RSM-711

## Proposed Changes
This PR adds new feature strings for our marketplace products and more. Here are some samples:

| Before | After |
| -- | -- |
| <img width="1760" height="1196" alt="image" src="https://github.com/user-attachments/assets/61783e5d-8905-4165-9eb2-3b3c9cfcc31c" /> | <img width="1760" height="1196" alt="image" src="https://github.com/user-attachments/assets/1e588ec0-fdc5-4822-a01a-c2946756adce" /> |
| <img width="1760" height="1196" alt="image" src="https://github.com/user-attachments/assets/9db37433-c49f-4fcf-b967-68ce9d5e88bd" /> | <img width="1760" height="1196" alt="image" src="https://github.com/user-attachments/assets/2a1a7526-62ad-494b-b26c-498e07746755" /> |
| <img width="1760" height="1196" alt="image" src="https://github.com/user-attachments/assets/6e293522-7f7c-4e93-b56e-ba93bb155b69" /> | <img width="1760" height="1196" alt="image" src="https://github.com/user-attachments/assets/181a08e7-d27c-4d3e-8226-5038f0f0ee41" /> |


Here are some technical details for what was done:
- Fill in `getMarketplaceFeatures`: marketplace plugins get plugin-oriented copy, marketplace themes get theme-oriented copy (distinguished via `purchase.product_type`)
- Fill in `getAddonFeatures`: premium theme add-on (`unlimited_themes`), storage add-ons (both legacy `Xgb_space_upgrade` and tiered-volume `wordpress_com_1gb_space_addon_yearly`), CSS add-on (`custom-design`)
- Add `features()` helper for concise feature list construction
- 9 new tests covering all product types plus unknown-product null fallback

## Why are these changes being made?

The cancel/remove confirmation screen currently shows no feature list for marketplace products and add-ons — users see an empty confirmation with no indication of what they'll lose. This fills in the product-specific copy behind the `purchases/split-cancel-remove` flag so users understand the impact before confirming.

Generic copy is used in v1 ("this plugin" / "this theme") rather than personalized product names — personalization is a v2 follow-up.

## Testing Instructions

1. Enable `purchases/split-cancel-remove` feature flag
2. Navigate to a marketplace plugin purchase → Cancel/Remove → confirm the 4-bullet feature list appears (plugin-oriented copy)
3. Navigate to a marketplace theme purchase → Cancel/Remove → confirm the 4-bullet feature list appears (theme-oriented copy)
4. Navigate to a storage add-on (e.g., 50 GB Storage) → Cancel/Remove → confirm the 3-bullet feature list appears
5. Navigate to a premium themes add-on → Cancel/Remove → confirm the 4-bullet feature list appears
6. Navigate to Custom CSS add-on → Cancel/Remove → confirm the 3-bullet feature list appears

**Stacked on #110478** (infra PR).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?