### PR TITLE
Domain search: optimistic CTA flip on add-to-cart

### DIFF
--- a/client/components/domains/wpcom-domain-search/test/use-wpcom-domain-search-props.ts
+++ b/client/components/domains/wpcom-domain-search/test/use-wpcom-domain-search-props.ts
@@ -596,6 +596,71 @@ describe( 'useWPCOMDomainSearchProps', () => {
 		expect( result.current.cart.hasItem( 'external-map.com' ) ).toBe( false );
 	} );
 
+	it( 'reports a domain as in the cart as soon as onAddItem is called, before the server sync resolves', async () => {
+		// Hold the sync open so the server response never arrives during the test.
+		const replaceProductsInCart = jest.fn(
+			() =>
+				new Promise< never >( () => {} ) as ReturnType< UseShoppingCart[ 'replaceProductsInCart' ] >
+		);
+
+		mockUseShoppingCart.mockReturnValue(
+			buildShoppingCart( {
+				responseCart: { products: [] },
+				replaceProductsInCart,
+			} )
+		);
+
+		const { result, rerender } = renderHookWithProvider( () =>
+			useWPCOMDomainSearchProps( defaultProps )
+		);
+
+		expect( result.current.cart.hasItem( 'my-domain.com' ) ).toBe( false );
+
+		void result.current.cart.onAddItem( {
+			domain_name: 'my-domain.com',
+			product_slug: 'domain',
+			supports_privacy: false,
+		} );
+
+		// State updates from onAddItem need a re-render to be observable.
+		rerender();
+
+		expect( replaceProductsInCart ).toHaveBeenCalled();
+		expect( result.current.cart.hasItem( 'my-domain.com' ) ).toBe( true );
+	} );
+
+	it( 'rolls back the optimistic hasItem flag when the cart sync rejects', async () => {
+		const replaceProductsInCart = jest.fn(
+			() =>
+				Promise.reject( new Error( 'sync failed' ) ) as ReturnType<
+					UseShoppingCart[ 'replaceProductsInCart' ]
+				>
+		);
+
+		mockUseShoppingCart.mockReturnValue(
+			buildShoppingCart( {
+				responseCart: { products: [] },
+				replaceProductsInCart,
+			} )
+		);
+
+		const { result, rerender } = renderHookWithProvider( () =>
+			useWPCOMDomainSearchProps( defaultProps )
+		);
+
+		await expect(
+			result.current.cart.onAddItem( {
+				domain_name: 'my-domain.com',
+				product_slug: 'domain',
+				supports_privacy: false,
+			} )
+		).rejects.toThrow( 'sync failed' );
+
+		rerender();
+
+		expect( result.current.cart.hasItem( 'my-domain.com' ) ).toBe( false );
+	} );
+
 	it( 'returns no items from the cart if flowAllowsMultipleDomainsInCart is false', () => {
 		mockUseShoppingCart.mockReturnValue(
 			buildShoppingCart( {

--- a/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-cart.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-cart.ts
@@ -12,7 +12,7 @@ import {
 	type ResponseCartProduct,
 	useShoppingCart,
 } from '@automattic/shopping-cart';
-import { ComponentProps, useMemo } from 'react';
+import { ComponentProps, useCallback, useEffect, useMemo, useState } from 'react';
 
 const wpcomCartToDomainSearchCart = (
 	domain: ResponseCartProduct,
@@ -66,6 +66,47 @@ export const useWPCOMDomainSearchCart = ( {
 }: UseWPCOMDomainSearchCartOptions ) => {
 	const { responseCart, replaceProductsInCart, removeProductFromCart } = useShoppingCart( cartKey );
 
+	// Tracks domains that have been clicked on but whose cart sync hasn't yet
+	// completed. Treating these as "in cart" lets the CTA flip from "Add" to
+	// "Continue" before the server roundtrip resolves; the entry is removed once
+	// the real cart catches up or the sync errors out.
+	const [ pendingAddedDomains, setPendingAddedDomains ] = useState< Set< string > >(
+		() => new Set()
+	);
+
+	const removePendingDomain = useCallback( ( domain: string ) => {
+		setPendingAddedDomains( ( prev ) => {
+			if ( ! prev.has( domain ) ) {
+				return prev;
+			}
+			const next = new Set( prev );
+			next.delete( domain );
+			return next;
+		} );
+	}, [] );
+
+	// Once the server-confirmed cart contains a domain we were tracking
+	// optimistically, drop the optimistic entry so the real cart is the source
+	// of truth.
+	useEffect( () => {
+		if ( pendingAddedDomains.size === 0 ) {
+			return;
+		}
+		const realDomainNames = new Set( responseCart.products.map( ( product ) => product.meta ) );
+		setPendingAddedDomains( ( prev ) => {
+			let next: Set< string > | undefined;
+			prev.forEach( ( domain ) => {
+				if ( realDomainNames.has( domain ) ) {
+					if ( ! next ) {
+						next = new Set( prev );
+					}
+					next.delete( domain );
+				}
+			} );
+			return next ?? prev;
+		} );
+	}, [ responseCart.products, pendingAddedDomains ] );
+
 	return useMemo( () => {
 		const domainItems = flowAllowsMultipleDomainsInCart
 			? responseCart.products.filter(
@@ -116,28 +157,44 @@ export const useWPCOMDomainSearchCart = ( {
 				wpcomCartToDomainSearchCart( domainItem, freeDomainName === domainItem.meta )
 			),
 			total,
-			hasItem: ( domain ) => !! domainItems.find( ( item ) => item.meta === domain ),
+			hasItem: ( domain ) =>
+				pendingAddedDomains.has( domain ) ||
+				!! domainItems.find( ( item ) => item.meta === domain ),
 			onAddItem: async ( { domain_name, product_slug, supports_privacy } ) => {
-				const cartItems = await replaceProductsInCart( [
-					beforeAddDomainToCart( {
-						product_slug,
-						meta: domain_name,
-						extra: {
-							...( supports_privacy && {
-								privacy_available: supports_privacy,
-								privacy: supports_privacy,
-							} ),
-							...( flowName && { flow_name: flowName } ),
-						},
-					} ),
-					...responseCart.products,
-				] );
+				setPendingAddedDomains( ( prev ) => {
+					if ( prev.has( domain_name ) ) {
+						return prev;
+					}
+					const next = new Set( prev );
+					next.add( domain_name );
+					return next;
+				} );
 
-				if ( ! flowAllowsMultipleDomainsInCart ) {
-					return onContinue( cartItems.products.filter( ( item ) => item.meta === domain_name ) );
+				try {
+					const cartItems = await replaceProductsInCart( [
+						beforeAddDomainToCart( {
+							product_slug,
+							meta: domain_name,
+							extra: {
+								...( supports_privacy && {
+									privacy_available: supports_privacy,
+									privacy: supports_privacy,
+								} ),
+								...( flowName && { flow_name: flowName } ),
+							},
+						} ),
+						...responseCart.products,
+					] );
+
+					if ( ! flowAllowsMultipleDomainsInCart ) {
+						return onContinue( cartItems.products.filter( ( item ) => item.meta === domain_name ) );
+					}
+
+					return cartItems;
+				} catch ( error ) {
+					removePendingDomain( domain_name );
+					throw error;
 				}
-
-				return cartItems;
 			},
 			onRemoveItem: ( uuid ) => removeProductFromCart( uuid ),
 		};
@@ -158,5 +215,7 @@ export const useWPCOMDomainSearchCart = ( {
 		flowAllowsMultipleDomainsInCart,
 		onContinue,
 		beforeAddDomainToCart,
+		pendingAddedDomains,
+		removePendingDomain,
 	] );
 };


### PR DESCRIPTION
## Proposed Changes

* Track domains optimistically inside `useWPCOMDomainSearchCart` so the CTA on a domain suggestion flips from "Add to cart" to "Continue" the moment the user clicks it, without waiting for the `/me/shopping-cart` POST roundtrip.
* The optimistic entry is dropped when the next response cart includes the domain, or when the `replaceProductsInCart` promise rejects (so the existing inline error CTA still surfaces).
* Adds two unit tests in `use-wpcom-domain-search-props.ts` covering the optimistic-true case and the rollback-on-rejection case.

## Why are these changes being made?

On flows like onboarding ("Claim your space on the web"), every "Add to cart" click waits ~1–2 s for:

1. A `domainAvailability` pre-check (sometimes cached).
2. `replaceProductsInCart` → POST `/me/shopping-cart/{cartKey}` and full server-side cart recalc (taxes, currency, premium-domain checks, free-domain promo).
3. `RECEIVE_UPDATED_RESPONSE_CART` dispatched, `useMutation` resolves.

The CTA only flips after step 3 because the suggestion CTA at [packages/domain-search/src/components/suggestion-cta/index.tsx#L88-L92](https://github.com/Automattic/wp-calypso/blob/trunk/packages/domain-search/src/components/suggestion-cta/index.tsx#L88-L92) gates the "Continue" state on `cart.hasItem(domainName)`, which reads `lastValidResponseCart` (the shopping-cart package is intentionally pessimistic — see the comment in [packages/shopping-cart/src/shopping-cart-reducer.ts#L97-L105](https://github.com/Automattic/wp-calypso/blob/trunk/packages/shopping-cart/src/shopping-cart-reducer.ts#L97-L105)).

This change keeps the package-level pessimism intact and adds a thin optimistic layer at the consumer. Result: clicks feel instant; the Continue button stays disabled (via `useIsMutating`) during the in-flight sync, so no premature navigation.

Out of scope (potential follow-ups):
* Optimistic entries in the cart panel (`cart.items` / `cart.total`) — non-trivial because of free-for-first-year and currency math.
* Switching from `replaceProductsInCart` to `addProductsToCart` for a smaller delta payload.
* Pre-fetching `domainAvailability` for visible suggestions to remove the second sequential roundtrip.

## Testing Instructions

1. `yarn start` and open an onboarding flow that hits the domain step ("Claim your space on the web"), e.g. `/setup/onboarding/domains`.
2. Search for a domain and click **Add to cart** on a suggestion.
3. **Expected**: the CTA flips to "Continue" immediately (disabled while the cart syncs), then becomes enabled once the sync completes. Previously the CTA showed a busy spinner for the full sync duration.
4. To exercise the rollback path: in DevTools, block `POST /me/shopping-cart/*` and click Add. The CTA should briefly show "Continue" (disabled), then return to the error CTA when the request fails.
5. Confirm the existing single-domain flows (e.g. CIAB) still navigate to the next step on Add — `onContinue` is still gated on the awaited cart sync.

Run:

```bash
yarn test-client client/components/domains/wpcom-domain-search
```

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?