### PR TITLE
Reader Social: dedupe React keys when the same post is reposted multiple times

### DIFF
--- a/client/reader/atmosphere/author-profile-panel.tsx
+++ b/client/reader/atmosphere/author-profile-panel.tsx
@@ -18,6 +18,7 @@ import {
 	SocialProfileCard,
 	SocialProfileHeaderSkeleton,
 	mapAtmosphereFeedItemToSocialPost,
+	socialPostFeedItemKey,
 	type SocialPost,
 	type SocialProfileStat,
 } from 'calypso/reader/social';
@@ -276,7 +277,7 @@ export function AuthorProfilePanel( {
 		),
 		[ connection.id ]
 	);
-	const itemKey = useCallback( ( post: SocialPost ) => post.uri, [] );
+	const itemKey = useCallback( ( post: SocialPost ) => socialPostFeedItemKey( post ), [] );
 
 	const stats: SocialProfileStat[] = profile.data
 		? [

--- a/client/reader/atmosphere/tag-feed-panel.tsx
+++ b/client/reader/atmosphere/tag-feed-panel.tsx
@@ -9,6 +9,7 @@ import {
 	SocialFeedList,
 	SocialPostCard,
 	mapAtmosphereFeedItemToSocialPost,
+	socialPostFeedItemKey,
 	type SocialPost,
 } from 'calypso/reader/social';
 import { LikeProvider } from 'calypso/reader/social/components/post-card/like-context';
@@ -145,7 +146,7 @@ export function TagFeedPanel( { connection, hashtag }: Props ) {
 		),
 		[ connection.id ]
 	);
-	const itemKey = useCallback( ( post: SocialPost ) => post.uri, [] );
+	const itemKey = useCallback( ( post: SocialPost ) => socialPostFeedItemKey( post ), [] );
 
 	const analyticsValue = useMemo(
 		() => ( {

--- a/client/reader/atmosphere/timeline-panel.tsx
+++ b/client/reader/atmosphere/timeline-panel.tsx
@@ -9,6 +9,7 @@ import {
 	SocialFeedList,
 	SocialPostCard,
 	mapAtmosphereFeedItemToSocialPost,
+	socialPostFeedItemKey,
 } from 'calypso/reader/social';
 import { LikeProvider } from 'calypso/reader/social/components/post-card/like-context';
 import { RepostProvider } from 'calypso/reader/social/components/post-card/repost-context';
@@ -170,7 +171,7 @@ export function TimelinePanel( { connection }: TimelinePanelProps ) {
 		),
 		[ connection.id ]
 	);
-	const itemKey = useCallback( ( post: SocialPost ) => post.uri, [] );
+	const itemKey = useCallback( ( post: SocialPost ) => socialPostFeedItemKey( post ), [] );
 
 	const analyticsValue = useMemo(
 		() => ( {

--- a/client/reader/mastodon/tag-feed-panel.tsx
+++ b/client/reader/mastodon/tag-feed-panel.tsx
@@ -9,6 +9,7 @@ import {
 	SocialFeedList,
 	SocialPostCard,
 	mapMastodonFeedItemToSocialPost,
+	socialPostFeedItemKey,
 	type SocialPost,
 } from 'calypso/reader/social';
 import { LikeProvider } from 'calypso/reader/social/components/post-card/like-context';
@@ -165,7 +166,7 @@ export function MastodonTagFeedPanel( { connection, hashtag }: Props ) {
 		),
 		[ connection.id ]
 	);
-	const itemKey = useCallback( ( post: SocialPost ) => post.uri, [] );
+	const itemKey = useCallback( ( post: SocialPost ) => socialPostFeedItemKey( post ), [] );
 
 	const analyticsValue = useMemo(
 		() => ( {

--- a/client/reader/mastodon/timeline-panel.tsx
+++ b/client/reader/mastodon/timeline-panel.tsx
@@ -12,6 +12,7 @@ import {
 	SocialFeedList,
 	SocialPostCard,
 	mapMastodonFeedItemToSocialPost,
+	socialPostFeedItemKey,
 } from 'calypso/reader/social';
 import { LikeProvider } from 'calypso/reader/social/components/post-card/like-context';
 import { RepostProvider } from 'calypso/reader/social/components/post-card/repost-context';
@@ -165,7 +166,7 @@ export function TimelinePanel( { connection }: TimelinePanelProps ) {
 		),
 		[ connection.id ]
 	);
-	const itemKey = useCallback( ( post: SocialPost ) => post.uri, [] );
+	const itemKey = useCallback( ( post: SocialPost ) => socialPostFeedItemKey( post ), [] );
 
 	const analyticsValue = useMemo(
 		() => ( {

--- a/client/reader/social/author-profile-panel.tsx
+++ b/client/reader/social/author-profile-panel.tsx
@@ -7,6 +7,7 @@ import { SocialFeedList } from './components/feed-list';
 import { SocialPostCard } from './components/post-card';
 import { SocialAnalyticsProvider } from './components/post-card/analytics-context';
 import { SocialProfileHeaderSkeleton } from './profile-header-skeleton';
+import { socialPostFeedItemKey } from './utils/social-post-feed-item-key';
 import type { SocialError, SocialPost } from './types';
 import type { AppState } from 'calypso/types';
 import type { TranslateResult } from 'i18n-calypso';
@@ -304,7 +305,7 @@ export function SocialAuthorProfilePanel< TProfile, TError extends ProtocolError
 		( post: SocialPost ) => <SocialPostCard post={ post } variant="default" />,
 		[]
 	);
-	const itemKey = useCallback( ( post: SocialPost ) => post.uri, [] );
+	const itemKey = useCallback( ( post: SocialPost ) => socialPostFeedItemKey( post ), [] );
 
 	const analyticsValue = useMemo(
 		() => ( {

--- a/client/reader/social/index.ts
+++ b/client/reader/social/index.ts
@@ -44,3 +44,4 @@ export {
 	mapMastodonFeedItemToSocialPost,
 	mapMastodonThreadResponseToSocialThreadNode,
 } from './mappers/mastodon';
+export { socialPostFeedItemKey } from './utils/social-post-feed-item-key';

--- a/client/reader/social/utils/social-post-feed-item-key.ts
+++ b/client/reader/social/utils/social-post-feed-item-key.ts
@@ -1,0 +1,17 @@
+import type { SocialPost } from '../types';
+
+/**
+ * Build a stable, unique React key for a post in a social feed list.
+ *
+ * The same post can appear multiple times in a single timeline when several
+ * accounts have reposted/boosted it. Keying solely on `post.uri` would
+ * collide and trigger React's "Encountered two children with the same key"
+ * warning, so we compose the reposter identity into the key when present.
+ */
+export function socialPostFeedItemKey( post: SocialPost ): string {
+	if ( post.reason?.type === 'repost' ) {
+		const reposter = post.reason.by.id ?? post.reason.by.handle;
+		return `repost:${ reposter }:${ post.uri }`;
+	}
+	return post.uri;
+}

--- a/client/reader/social/utils/test/social-post-feed-item-key.test.ts
+++ b/client/reader/social/utils/test/social-post-feed-item-key.test.ts
@@ -1,0 +1,67 @@
+import { socialPostFeedItemKey } from '../social-post-feed-item-key';
+import type { SocialPost } from '../../types';
+
+const basePost = ( overrides: Partial< SocialPost > = {} ): SocialPost =>
+	( {
+		uri: 'at://did:plc:original/app.bsky.feed.post/abc',
+		permalink: 'https://bsky.app/profile/foo/post/abc',
+		text: '',
+		html: '',
+		created_at: '2026-01-01T00:00:00Z',
+		indexed_at: null,
+		lang: [],
+		author: {
+			id: 'did:plc:original',
+			handle: 'foo.bsky.social',
+			display_name: 'Foo',
+			avatar: null,
+			profile_url: 'https://bsky.app/profile/foo.bsky.social',
+		},
+		reply_parent: null,
+		reply_root: null,
+		reason: null,
+		embed: null,
+		...overrides,
+	} ) as SocialPost;
+
+describe( 'socialPostFeedItemKey', () => {
+	it( 'returns the post uri when reason is null', () => {
+		const post = basePost();
+		expect( socialPostFeedItemKey( post ) ).toBe( post.uri );
+	} );
+
+	it( 'composes a distinct key per reposter so the same post via different reposters does not collide', () => {
+		const post = basePost();
+		const reposterA = basePost( {
+			reason: {
+				type: 'repost',
+				by: { id: 'did:plc:alice', handle: 'alice.bsky.social', display_name: 'Alice' },
+			},
+		} );
+		const reposterB = basePost( {
+			reason: {
+				type: 'repost',
+				by: { id: 'did:plc:bob', handle: 'bob.bsky.social', display_name: 'Bob' },
+			},
+		} );
+
+		const keys = [
+			socialPostFeedItemKey( post ),
+			socialPostFeedItemKey( reposterA ),
+			socialPostFeedItemKey( reposterB ),
+		];
+		expect( new Set( keys ).size ).toBe( 3 );
+	} );
+
+	it( 'falls back to the reposter handle when the reposter id is missing', () => {
+		const post = basePost( {
+			reason: {
+				type: 'repost',
+				by: { handle: 'alice.example', display_name: 'Alice' },
+			},
+		} );
+		expect( socialPostFeedItemKey( post ) ).toBe(
+			'repost:alice.example:at://did:plc:original/app.bsky.feed.post/abc'
+		);
+	} );
+} );


### PR DESCRIPTION
Fixes CM-678

## Proposed Changes

* Add `socialPostFeedItemKey()` helper in `client/reader/social/utils/` that composes the reposter identity into the React key when `post.reason` is set, so duplicate `post.uri` rows don't collide.
* Wire the helper into the six panels that render `<SocialFeedList>`: ATmosphere timeline / tag-feed / author-profile, Mastodon timeline / tag-feed, and the shared `SocialAuthorProfilePanel`.
* Unit-test the three branches (no reason, distinct reposters, handle fallback).

## Why are these changes being made?

When the same Bluesky post (or Mastodon status) appears in a timeline via several different reposters — e.g. Chris Hayes' Tennessee redistricting post showing 3× in the feed, once per reposter — every row carried `post.uri` as its React key. They collided and the console fired "Encountered two children with the same key" warnings. Composite keys for repost rows fix the warning while leaving non-reposted rows untouched.

## Testing Instructions

1. Connect a Bluesky account at `/reader/atmosphere`.
2. Make sure your Bluesky home feed includes a post that several of the people you follow have reposted (Chris Hayes' redistricting post is the canonical repro; any post repost-by-multiple-followees works).
3. Open the ATmosphere timeline with the browser console open.
4. **Before:** "Encountered two children with the same key, `at://…`" warning fires for every duplicated row.
5. **After:** no warning; the same post still renders once per reposter with the right "Reposted by …" preface.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?