### PR TITLE
APM: add Frontend/Backend tab fallback for legacy header-bar layout

### DIFF
--- a/client/dashboard/sites/performance/backend/index.tsx
+++ b/client/dashboard/sites/performance/backend/index.tsx
@@ -10,6 +10,7 @@ import PageLayout from '../../../components/page-layout';
 import UpsellCallout from '../../hosting-feature-gated-with-callout/upsell';
 import { hasBackendAccess } from '../backend-access';
 import { getBackendCalloutProps } from '../backend-callout';
+import PerformanceTabs from '../performance-tabs';
 import Database from './database';
 import EnableApmCallout from './enable-apm-callout';
 import ExternalRequests from './external-requests';
@@ -106,6 +107,9 @@ export default function SitePerformanceBackend( {
 	};
 
 	return (
-		<PageLayout header={ <PageHeader title={ __( 'Backend' ) } /> }>{ renderContent() }</PageLayout>
+		<PageLayout header={ <PageHeader title={ __( 'Backend' ) } /> }>
+			<PerformanceTabs siteSlug={ siteSlug } activeTab="backend" />
+			{ renderContent() }
+		</PageLayout>
 	);
 }

--- a/client/dashboard/sites/performance/frontend/index.tsx
+++ b/client/dashboard/sites/performance/frontend/index.tsx
@@ -10,6 +10,7 @@ import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
 import DeviceToggle from '../device-toggle';
 import PageSelector from '../page-selector';
+import PerformanceTabs from '../performance-tabs';
 import Report from '../report';
 import ReportErrorNotice from '../report-error-notice';
 import ReportLoading from '../report-loading';
@@ -148,6 +149,7 @@ export default function SitePerformanceFrontend( { siteSlug }: { siteSlug: strin
 				/>
 			}
 		>
+			<PerformanceTabs siteSlug={ siteSlug } activeTab="frontend" />
 			{ renderContent() }
 		</PageLayout>
 	);

--- a/client/dashboard/sites/performance/performance-tabs.tsx
+++ b/client/dashboard/sites/performance/performance-tabs.tsx
@@ -1,0 +1,47 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { useNavigate } from '@tanstack/react-router';
+import { TabPanel } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+export type PerformanceTab = 'frontend' | 'backend';
+
+const TABS = [
+	{ name: 'frontend' as const, title: __( 'Frontend' ) },
+	{ name: 'backend' as const, title: __( 'Backend' ) },
+];
+
+/**
+ * Frontend/Backend tabs for the legacy (non-omnibar) layout.
+ *
+ * The omnibar sidebar exposes Frontend/Backend as a submenu under Performance,
+ * so this fallback only renders when the sidebar is not available.
+ */
+export default function PerformanceTabs( {
+	siteSlug,
+	activeTab,
+}: {
+	siteSlug: string;
+	activeTab: PerformanceTab;
+} ) {
+	const navigate = useNavigate();
+
+	if ( isEnabled( 'dashboard/omnibar' ) || ! isEnabled( 'performance/apm' ) ) {
+		return null;
+	}
+
+	return (
+		<TabPanel
+			activeClass="is-active"
+			tabs={ TABS }
+			initialTabName={ activeTab }
+			onSelect={ ( name ) => {
+				if ( name === activeTab ) {
+					return;
+				}
+				navigate( { to: `/sites/${ siteSlug }/performance/${ name }` } );
+			} }
+		>
+			{ () => null }
+		</TabPanel>
+	);
+}


### PR DESCRIPTION
## Proposed Changes

* Add a small `<PerformanceTabs>` component that renders a Frontend/Backend `TabPanel` inside both the Frontend and Backend pages, gated on `! isEnabled( 'dashboard/omnibar' ) && isEnabled( 'performance/apm' )`.

## Why are these changes being made?

When `dashboard/omnibar` is disabled (the current production state), the responsive sidebar is not rendered. Site navigation comes from the legacy `<HeaderBar>` + flat `<SiteMenu>`, which has a single top-level **Performance** entry and no submenu. The Frontend/Backend submenu we scaffolded only exists in `site-sidebar` and is therefore invisible in legacy mode, leaving `/performance/backend` unreachable from the UI.

This mirrors the existing scan/logs fallback pattern (`! isEnabled( 'dashboard/omnibar' ) && <inline TabPanel />`), so once `performance/apm` is enabled in any environment that still runs without the omnibar, users have a way to switch between Frontend and Backend.

The fallback returns `null` whenever the omnibar is enabled or APM is off, so there is no behavior change in development or in production today.

## Testing Instructions

1. Ensure `performance/apm` is enabled and `dashboard/omnibar` is disabled (e.g. add overrides in `config/development.json`, or via the dev preferences helper).
2. Visit `/sites/<slug>/performance` — confirm Frontend page now shows a tab strip with **Frontend** / **Backend**.
3. Click **Backend** — URL changes to `/sites/<slug>/performance/backend` and the Backend page renders, with the same tab strip on top.
4. Re-enable `dashboard/omnibar` — confirm the inline tabs disappear and the sidebar submenu is the only switch (existing behavior).
5. Disable `performance/apm` — confirm no tabs render in either mode.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?