### PR TITLE
ExPlat: demo getFeatureValue() with copy changes to 'My Home'

### DIFF
--- a/client/lib/explat/index.ts
+++ b/client/lib/explat/index.ts
@@ -1,8 +1,12 @@
-import { createExPlatClient } from '@automattic/explat-client';
+import { createExPlatClient, ExPlatSdk } from '@automattic/explat-client';
 import createExPlatClientReactHelpers from '@automattic/explat-client-react-helpers';
+import { useEffect, useState } from 'react';
 import { getAnonId, initializeAnonId } from './internals/anon-id';
 import fetchExperimentAssignment from './internals/fetch-experiment-assignment';
+import fetchFlagPayload from './internals/fetch-flag-payload';
+import getAttributes from './internals/get-attributes';
 import { logError } from './internals/log-error';
+import logFeatureAssignment from './internals/log-feature-assignment';
 import { isDevelopmentMode } from './internals/misc';
 
 initializeAnonId().catch( ( e ) => logError( { message: e.message } ) );
@@ -12,8 +16,39 @@ const exPlatClient = createExPlatClient( {
 	getAnonId,
 	logError,
 	isDevelopmentMode,
+	fetchFlagPayload,
+	logFeatureAssignment,
+	getAttributes,
 } );
 
-export const { loadExperimentAssignment, dangerouslyGetExperimentAssignment } = exPlatClient;
+export const { loadExperimentAssignment, dangerouslyGetExperimentAssignment, getFeatureValue } =
+	exPlatClient;
 const exPlatClientReactHelpers = createExPlatClientReactHelpers( exPlatClient );
 export const { useExperiment, Experiment, ProvideExperimentData } = exPlatClientReactHelpers;
+
+/**
+ * React hook wrapper around `getFeatureValue`. Returns the caller default
+ * synchronously, then re-renders with the resolved value once the flag payload
+ * loads. Subsequent calls share the package's cache, so this is cheap.
+ */
+export function useFeatureValue< T extends ExPlatSdk.FeatureValue >(
+	flagKey: string,
+	defaultValue: T
+): ExPlatSdk.WidenPrimitives< T > {
+	const [ value, setValue ] = useState< ExPlatSdk.WidenPrimitives< T > >(
+		defaultValue as unknown as ExPlatSdk.WidenPrimitives< T >
+	);
+	useEffect( () => {
+		let cancelled = false;
+		exPlatClient.getFeatureValue( flagKey, defaultValue ).then( ( resolved ) => {
+			if ( ! cancelled ) {
+				setValue( resolved );
+			}
+		} );
+		return () => {
+			cancelled = true;
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ flagKey ] );
+	return value;
+}

--- a/client/lib/explat/index.ts
+++ b/client/lib/explat/index.ts
@@ -26,7 +26,56 @@ export const { loadExperimentAssignment, dangerouslyGetExperimentAssignment, get
 const exPlatClientReactHelpers = createExPlatClientReactHelpers( exPlatClient );
 export const { useExperiment, Experiment, ProvideExperimentData } = exPlatClientReactHelpers;
 
-async function logFeatureValueDiagnostics( flagKey: string, resolved: unknown ): Promise< void > {
+/**
+ * Look up a dev-only forced value for `flagKey` from URL or localStorage.
+ *
+ *  - Query param: `?explat_force_<flagKey>=<value>`
+ *  - localStorage: `localStorage.setItem('explat_force_<flagKey>', '<value>')`
+ *
+ * Returns `null` if no override is set. Values are returned as strings; if the
+ * caller's `defaultValue` is a boolean or number the override is coerced to
+ * match.
+ */
+function readForceOverride< T extends ExPlatSdk.FeatureValue >(
+	flagKey: string,
+	defaultValue: T
+): ExPlatSdk.WidenPrimitives< T > | null {
+	if ( typeof window === 'undefined' ) {
+		return null;
+	}
+	const key = `explat_force_${ flagKey }`;
+	let raw: string | null = null;
+	try {
+		const params = new URLSearchParams( window.location.search );
+		raw = params.get( key );
+	} catch {
+		// Ignore.
+	}
+	if ( raw === null ) {
+		try {
+			raw = window.localStorage.getItem( key );
+		} catch {
+			// Ignore.
+		}
+	}
+	if ( raw === null ) {
+		return null;
+	}
+	if ( typeof defaultValue === 'boolean' ) {
+		return ( raw === 'true' ) as ExPlatSdk.WidenPrimitives< T >;
+	}
+	if ( typeof defaultValue === 'number' ) {
+		const n = Number( raw );
+		return ( Number.isFinite( n ) ? n : defaultValue ) as ExPlatSdk.WidenPrimitives< T >;
+	}
+	return raw as ExPlatSdk.WidenPrimitives< T >;
+}
+
+async function logFeatureValueDiagnostics(
+	flagKey: string,
+	resolved: unknown,
+	forced: boolean
+): Promise< void > {
 	if ( typeof window === 'undefined' ) {
 		return;
 	}
@@ -56,7 +105,17 @@ async function logFeatureValueDiagnostics( flagKey: string, resolved: unknown ):
 		: null;
 
 	/* eslint-disable no-console */
-	console.groupCollapsed( `[ExPlat] ${ flagKey } → ${ JSON.stringify( resolved ) }` );
+	console.groupCollapsed(
+		`[ExPlat] ${ flagKey } → ${ JSON.stringify( resolved ) }${ forced ? ' (FORCED)' : '' }`
+	);
+	if ( forced ) {
+		console.log(
+			'%cforced via explat_force_' +
+				flagKey +
+				' (URL or localStorage) — eval below is what would have run',
+			'color: orange; font-weight: bold'
+		);
+	}
 	console.log( 'attributes', attributes );
 	console.log( 'localStorage overrides', overrides );
 	console.log( 'window.__EXPLAT_RUNTIME__', runtime );
@@ -89,12 +148,20 @@ export function useFeatureValue< T extends ExPlatSdk.FeatureValue >(
 	);
 	useEffect( () => {
 		let cancelled = false;
+		const forced = readForceOverride( flagKey, defaultValue );
+		if ( forced !== null ) {
+			setValue( forced );
+			void logFeatureValueDiagnostics( flagKey, forced, true );
+			return () => {
+				cancelled = true;
+			};
+		}
 		exPlatClient.getFeatureValue( flagKey, defaultValue ).then( ( resolved ) => {
 			if ( cancelled ) {
 				return;
 			}
 			setValue( resolved );
-			void logFeatureValueDiagnostics( flagKey, resolved );
+			void logFeatureValueDiagnostics( flagKey, resolved, false );
 		} );
 		return () => {
 			cancelled = true;

--- a/client/lib/explat/index.ts
+++ b/client/lib/explat/index.ts
@@ -26,10 +26,59 @@ export const { loadExperimentAssignment, dangerouslyGetExperimentAssignment, get
 const exPlatClientReactHelpers = createExPlatClientReactHelpers( exPlatClient );
 export const { useExperiment, Experiment, ProvideExperimentData } = exPlatClientReactHelpers;
 
+async function logFeatureValueDiagnostics( flagKey: string, resolved: unknown ): Promise< void > {
+	if ( typeof window === 'undefined' ) {
+		return;
+	}
+	const runtime = ( window as unknown as { __EXPLAT_RUNTIME__?: unknown } ).__EXPLAT_RUNTIME__;
+	const overrides = ( () => {
+		try {
+			const raw = window.localStorage.getItem( 'explat_attribute_overrides' );
+			return raw ? JSON.parse( raw ) : null;
+		} catch {
+			return null;
+		}
+	} )();
+	const attributes = await getAttributes();
+	let payload: unknown = null;
+	let payloadError: string | null = null;
+	try {
+		payload = await fetchFlagPayload();
+	} catch ( e ) {
+		payloadError = ( e as Error ).message;
+	}
+	const flag =
+		payload && typeof payload === 'object' && 'flags' in payload
+			? ( payload as { flags: Record< string, ExPlatSdk.Feature > } ).flags[ flagKey ]
+			: undefined;
+	const evalResult = flag
+		? ExPlatSdk.evalFeature( flag, attributes as ExPlatSdk.Attributes )
+		: null;
+
+	/* eslint-disable no-console */
+	console.groupCollapsed( `[ExPlat] ${ flagKey } → ${ JSON.stringify( resolved ) }` );
+	console.log( 'attributes', attributes );
+	console.log( 'localStorage overrides', overrides );
+	console.log( 'window.__EXPLAT_RUNTIME__', runtime );
+	console.log( 'compiled flag config', flag );
+	console.log( 'full /flags/calypso payload', payload );
+	if ( payloadError ) {
+		console.warn( '/flags/calypso fetch error:', payloadError );
+	}
+	console.log( 'eval result', evalResult );
+	console.groupEnd();
+	/* eslint-enable no-console */
+}
+
 /**
  * React hook wrapper around `getFeatureValue`. Returns the caller default
  * synchronously, then re-renders with the resolved value once the flag payload
  * loads. Subsequent calls share the package's cache, so this is cheap.
+ *
+ * Logs diagnostics to the console after each resolution: attributes used,
+ * localStorage overrides, runtime bootstrap, the compiled flag config, the
+ * raw payload, and the SDK's `evalFeature` result (force/experiment match,
+ * variation, hash value).
  */
 export function useFeatureValue< T extends ExPlatSdk.FeatureValue >(
 	flagKey: string,
@@ -41,9 +90,11 @@ export function useFeatureValue< T extends ExPlatSdk.FeatureValue >(
 	useEffect( () => {
 		let cancelled = false;
 		exPlatClient.getFeatureValue( flagKey, defaultValue ).then( ( resolved ) => {
-			if ( ! cancelled ) {
-				setValue( resolved );
+			if ( cancelled ) {
+				return;
 			}
+			setValue( resolved );
+			void logFeatureValueDiagnostics( flagKey, resolved );
 		} );
 		return () => {
 			cancelled = true;

--- a/client/lib/explat/internals/fetch-flag-payload.ts
+++ b/client/lib/explat/internals/fetch-flag-payload.ts
@@ -1,0 +1,12 @@
+import wpcom from 'calypso/lib/wp';
+
+// SSR safety: Fail TypeScript compilation if `window` is used without an explicit undefined check
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+declare const window: undefined | ( Window & typeof globalThis );
+
+export default function fetchFlagPayload(): Promise< unknown > {
+	return wpcom.req.get( {
+		path: '/experiments/0.1.0/flags',
+		apiNamespace: 'wpcom/v2',
+	} );
+}

--- a/client/lib/explat/internals/fetch-flag-payload.ts
+++ b/client/lib/explat/internals/fetch-flag-payload.ts
@@ -6,7 +6,7 @@ declare const window: undefined | ( Window & typeof globalThis );
 
 export default function fetchFlagPayload(): Promise< unknown > {
 	return wpcom.req.get( {
-		path: '/experiments/0.1.0/flags',
+		path: '/experiments/0.1.0/flags/calypso',
 		apiNamespace: 'wpcom/v2',
 	} );
 }

--- a/client/lib/explat/internals/get-attributes.ts
+++ b/client/lib/explat/internals/get-attributes.ts
@@ -1,0 +1,29 @@
+import { getCurrentUser } from '@automattic/calypso-analytics';
+import { getAnonId } from './anon-id';
+
+/**
+ * Locally-derived attributes for client-side flag evaluation.
+ *
+ * For full coverage (country code, `is_test_user`, etc.) the server emits a
+ * private `window.__EXPLAT_RUNTIME__.attributes` map that the package overlays
+ * on top of these. This helper provides the boot-time minimum so the eval
+ * still works before the runtime bootstrap is in place.
+ */
+export default async function getAttributes(): Promise< Record< string, string > > {
+	const attributes: Record< string, string > = {};
+
+	const user = getCurrentUser();
+	if ( user ) {
+		attributes.wpcom_user_id = String( user.ID );
+		if ( user.localeSlug ) {
+			attributes.language = user.localeSlug;
+		}
+	}
+
+	const anonId = await getAnonId();
+	if ( anonId ) {
+		attributes.anon_id = anonId;
+	}
+
+	return attributes;
+}

--- a/client/lib/explat/internals/get-attributes.ts
+++ b/client/lib/explat/internals/get-attributes.ts
@@ -1,6 +1,8 @@
 import { getCurrentUser } from '@automattic/calypso-analytics';
 import { getAnonId } from './anon-id';
 
+const OVERRIDES_KEY = 'explat_attribute_overrides';
+
 /**
  * Locally-derived attributes for client-side flag evaluation.
  *
@@ -8,6 +10,10 @@ import { getAnonId } from './anon-id';
  * private `window.__EXPLAT_RUNTIME__.attributes` map that the package overlays
  * on top of these. This helper provides the boot-time minimum so the eval
  * still works before the runtime bootstrap is in place.
+ *
+ * Dev-only override: set `localStorage.explat_attribute_overrides` to a JSON
+ * object to force attribute values for testing — e.g.
+ * `localStorage.setItem('explat_attribute_overrides', JSON.stringify({country:'US',language:'en',is_test_user:'true'}))`.
  */
 export default async function getAttributes(): Promise< Record< string, string > > {
 	const attributes: Record< string, string > = {};
@@ -23,6 +29,17 @@ export default async function getAttributes(): Promise< Record< string, string >
 	const anonId = await getAnonId();
 	if ( anonId ) {
 		attributes.anon_id = anonId;
+	}
+
+	if ( typeof window !== 'undefined' ) {
+		try {
+			const raw = window.localStorage.getItem( OVERRIDES_KEY );
+			if ( raw ) {
+				Object.assign( attributes, JSON.parse( raw ) );
+			}
+		} catch ( e ) {
+			// Ignore parse errors — overrides are dev-only.
+		}
 	}
 
 	return attributes;

--- a/client/lib/explat/internals/log-feature-assignment.ts
+++ b/client/lib/explat/internals/log-feature-assignment.ts
@@ -1,0 +1,16 @@
+import wpcom from 'calypso/lib/wp';
+import type { FeatureAssignmentBeacon } from '@automattic/explat-client';
+
+// SSR safety: Fail TypeScript compilation if `window` is used without an explicit undefined check
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+declare const window: undefined | ( Window & typeof globalThis );
+
+export default function logFeatureAssignment( body: FeatureAssignmentBeacon ): Promise< void > {
+	return wpcom.req.post(
+		{
+			path: '/experiments/0.1.0/assignments/log',
+			apiNamespace: 'wpcom/v2',
+		},
+		body
+	);
+}

--- a/client/my-sites/customer-home/components/home-content/index.jsx
+++ b/client/my-sites/customer-home/components/home-content/index.jsx
@@ -19,6 +19,7 @@ import useHomeLayoutQuery, { getCacheKey } from 'calypso/data/home/use-home-layo
 import { usePurchasePlanNotification } from 'calypso/landing/stepper/declarative-flow/internals/hooks/use-purchase-plan-notification';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { setDomainNotice } from 'calypso/lib/domains/set-domain-notice';
+import { useFeatureValue } from 'calypso/lib/explat';
 import { preventWidows } from 'calypso/lib/formatting';
 import { getQueryArgs } from 'calypso/lib/query-args';
 import Primary from 'calypso/my-sites/customer-home/locations/primary';
@@ -83,6 +84,9 @@ const HomeContent = ( {
 	const [ launchedSiteId, setLaunchedSiteId ] = useState( null );
 	const queryClient = useQueryClient();
 	const translate = useTranslate();
+	const homeVariant = useFeatureValue( 'wpcom_explat_v2_demo_v1', 'control' );
+	const homeTitle =
+		homeVariant === 'treatment' ? translate( 'My Dashboard' ) : translate( 'My Home' );
 	const isP2 = site?.options?.is_wpforteams_site;
 
 	const { data: layout, isLoading, error: homeLayoutError } = useHomeLayoutQuery( siteId );
@@ -185,7 +189,7 @@ const HomeContent = ( {
 				compactBreadcrumb={ false }
 				navigationItems={ [] }
 				mobileItem={ null }
-				title={ translate( 'My Home' ) }
+				title={ homeTitle }
 				subtitle={ translate( 'Your hub for next steps, support center, and quick links.' ) }
 			>
 				{ headerActions }

--- a/client/my-sites/customer-home/main.tsx
+++ b/client/my-sites/customer-home/main.tsx
@@ -2,16 +2,20 @@ import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { useFeatureValue } from 'calypso/lib/explat';
 import HomeContent from './components/home-content';
 import type { SiteDetails } from '@automattic/data-stores';
 
 export default function CustomerHome( { site }: { site: SiteDetails } ) {
 	const translate = useTranslate();
+	const homeVariant = useFeatureValue( 'wpcom_explat_v2_demo_v1', 'control' );
+	const homeTitle =
+		homeVariant === 'treatment' ? translate( 'My Dashboard' ) : translate( 'My Home' );
 
 	return (
 		<Main wideLayout>
-			<PageViewTracker path="/home/:site" title={ translate( 'My Home' ) } />
-			<DocumentHead title={ translate( 'My Home' ) } />
+			<PageViewTracker path="/home/:site" title={ homeTitle } />
+			<DocumentHead title={ homeTitle } />
 			{ site.options && <HomeContent /> }
 		</Main>
 	);

--- a/client/my-sites/sidebar/use-site-menu-items.js
+++ b/client/my-sites/sidebar/use-site-menu-items.js
@@ -83,39 +83,6 @@ const useSiteMenuItems = () => {
 		);
 	};
 
-	if ( shouldShowGlobalSidebar ) {
-		return globalSidebarMenu( {
-			showP2s: showP2s,
-			hasOptIn: dashboardOptIn,
-		} );
-	}
-
-	/**
-	 * When no site domain is provided, lets show only menu items that support all sites screens.
-	 */
-	if ( ! siteDomain || isAllDomainsView ) {
-		return allSitesMenu( { showManagePlugins: hasSiteWithPlugins } );
-	}
-
-	/**
-	 * When we have a jetpack connected site & we cannot retrieve the dynamic menu from that site.
-	 */
-	if ( isJetpack && ! isAtomic && ! menuItems ) {
-		return jetpackMenu( { siteDomain, hasUnifiedImporter } );
-	}
-
-	/**
-	 * When we have a domain-only site & we cannot retrieve the dynamic menu from that site.
-	 */
-	if ( isDomainOnly && ! menuItems ) {
-		return domainOnlyFallbackMenu( { siteDomain } );
-	}
-
-	/**
-	 * Overrides for the static fallback data which will be displayed if/when there are
-	 * no menu items in the API response or the API response has yet to be cached in
-	 * browser storage APIs.
-	 */
 	const fallbackDataOverrides = {
 		siteDomain,
 		isAtomic,
@@ -127,7 +94,23 @@ const useSiteMenuItems = () => {
 		showSiteMonitoring: isAtomic,
 	};
 
-	return applyHomeMenuVariant( menuItems ?? buildFallbackResponse( fallbackDataOverrides ) );
+	const resolvedMenuItems = ( () => {
+		if ( shouldShowGlobalSidebar ) {
+			return globalSidebarMenu( { showP2s: showP2s, hasOptIn: dashboardOptIn } );
+		}
+		if ( ! siteDomain || isAllDomainsView ) {
+			return allSitesMenu( { showManagePlugins: hasSiteWithPlugins } );
+		}
+		if ( isJetpack && ! isAtomic && ! menuItems ) {
+			return jetpackMenu( { siteDomain, hasUnifiedImporter } );
+		}
+		if ( isDomainOnly && ! menuItems ) {
+			return domainOnlyFallbackMenu( { siteDomain } );
+		}
+		return menuItems ?? buildFallbackResponse( fallbackDataOverrides );
+	} )();
+
+	return applyHomeMenuVariant( resolvedMenuItems );
 };
 
 export default useSiteMenuItems;

--- a/client/my-sites/sidebar/use-site-menu-items.js
+++ b/client/my-sites/sidebar/use-site-menu-items.js
@@ -1,6 +1,8 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { translate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { useCurrentRoute } from 'calypso/components/route';
+import { useFeatureValue } from 'calypso/lib/explat';
 import domainOnlyFallbackMenu from 'calypso/my-sites/sidebar/static-data/domain-only-fallback-menu';
 import { getAdminMenu } from 'calypso/state/admin-menu/selectors';
 import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors';
@@ -71,6 +73,16 @@ const useSiteMenuItems = () => {
 
 	const dashboardOptIn = useSelector( ( state ) => hasDashboardOptIn( state ) );
 
+	const homeMenuVariant = useFeatureValue( 'wpcom_explat_v2_demo_v1', 'control' );
+	const applyHomeMenuVariant = ( items ) => {
+		if ( homeMenuVariant !== 'treatment' || ! Array.isArray( items ) ) {
+			return items;
+		}
+		return items.map( ( item ) =>
+			item?.slug === 'home' ? { ...item, title: translate( 'My Dashboard' ) } : item
+		);
+	};
+
 	if ( shouldShowGlobalSidebar ) {
 		return globalSidebarMenu( {
 			showP2s: showP2s,
@@ -115,7 +127,7 @@ const useSiteMenuItems = () => {
 		showSiteMonitoring: isAtomic,
 	};
 
-	return menuItems ?? buildFallbackResponse( fallbackDataOverrides );
+	return applyHomeMenuVariant( menuItems ?? buildFallbackResponse( fallbackDataOverrides ) );
 };
 
 export default useSiteMenuItems;


### PR DESCRIPTION
First end-to-end use of `getFeatureValue()` from #110516, gated on the `wpcom_explat_v2_demo_v1` flag.

## Proposed Changes

- New `fetchFlagPayload`, `logFeatureAssignment`, `getAttributes` host helpers in `client/lib/explat/internals/`, calling `/wpcom/v2/experiments/0.1.0/{flags,assignments/log}` via `wpcom.req`.
- `client/lib/explat/index.ts` passes the new helpers to `createExPlatClient`, re-exports `getFeatureValue`, and adds a `useFeatureValue` React hook (returns the default synchronously, re-renders with the resolved value).
- `client/my-sites/sidebar/use-site-menu-items.js` calls `useFeatureValue('wpcom_explat_v2_demo_v1', 'control')` and rewrites the `slug: 'home'` item's title to `'My Dashboard'` when the value is `'treatment'`.

## Why are these changes being made?

- Stacks on #110516 to prove out the `getFeatureValue()` wiring with a real, low-risk UI change.
- `getAttributes` returns what's available client-side at boot (`wpcom_user_id`, `language`, `anon_id`); the rest (country, `is_test_user`) comes from `window.__EXPLAT_RUNTIME__.attributes` once wpcom PR 4 is deployed.

## Testing Instructions

- Until wpcom PR 4 ships, the `/flags` endpoint 404s and the package fail-closes — the label stays \"My Home\". This is the expected pre-deployment behavior.
- Once `/flags` and `__EXPLAT_RUNTIME__` are available, log in as `wpcom_user_id=1` (matches the sample payload's second force rule) and confirm the sidebar label reads \"My Dashboard\".
- `yarn jest` inside `packages/explat-client/` — 198 passing.
- `yarn test-client --findRelatedTests client/lib/explat/index.ts client/my-sites/sidebar/use-site-menu-items.js` — 1097 passing.
- `yarn typecheck-client` clean for the touched files.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?