### PR TITLE
Reader Mastodon: stop flag-gating the OAuth callback

### DIFF
--- a/client/reader/mastodon/controller.tsx
+++ b/client/reader/mastodon/controller.tsx
@@ -52,10 +52,15 @@ export const mastodonConnect = ( context: Context, next: () => void ) => {
 	next();
 };
 
+// Intentionally not flag-gated. The Mastodon backend hardcodes the OAuth
+// redirect_uri to https://wordpress.com/reader/mastodon/oauth-callback, so the
+// instance always sends the user to production after they authorize — even if
+// they started the flow elsewhere. Production has reader/social=false, so
+// running ensureMastodonEnabled() here would bounce every callback to /reader
+// and the connection would never persist. This view is only reached by users
+// who actively started the connect flow, so it is safe to run even when the
+// rest of the Mastodon surface is hidden behind the flag.
 export const mastodonOauthCallback = ( context: Context, next: () => void ) => {
-	if ( ! ensureMastodonEnabled() ) {
-		return;
-	}
 	const query = context.query as { state?: string; code?: string; error?: string };
 	context.primary = (
 		<AsyncLoad require={ loadMastodonOauthCallbackView } placeholder={ null } query={ query } />

--- a/client/reader/mastodon/test/controller.test.tsx
+++ b/client/reader/mastodon/test/controller.test.tsx
@@ -13,16 +13,25 @@ jest.mock( '@automattic/calypso-config', () => ( {
 	isEnabled: jest.fn().mockReturnValue( true ),
 } ) );
 
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
-import { mastodonProfile, mastodonTagFeed, mastodonThread } from '../controller';
+import {
+	mastodonConnect,
+	mastodonLanding,
+	mastodonOauthCallback,
+	mastodonProfile,
+	mastodonTagFeed,
+	mastodonThread,
+} from '../controller';
 
-function makeContext( params: Record< string, string > ) {
-	return { params, primary: null } as unknown as Parameters< typeof mastodonProfile >[ 0 ];
+function makeContext( params: Record< string, string >, query: Record< string, string > = {} ) {
+	return { params, query, primary: null } as unknown as Parameters< typeof mastodonProfile >[ 0 ];
 }
 
 beforeEach( () => {
 	mockNext.mockReset();
 	jest.mocked( page.redirect ).mockReset();
+	jest.mocked( isEnabled ).mockReturnValue( true );
 } );
 
 describe( 'mastodonProfile controller', () => {
@@ -120,5 +129,40 @@ describe( 'mastodonTagFeed controller', () => {
 		expect( ( ctx.primary as unknown as { props: { hashtag: string } } ).props.hashtag ).toBe(
 			'rust'
 		);
+	} );
+} );
+
+describe( 'reader/social flag gating', () => {
+	beforeEach( () => {
+		jest.mocked( isEnabled ).mockReturnValue( false );
+	} );
+
+	it( 'mastodonLanding redirects to /reader when flag is off', () => {
+		const ctx = makeContext( {} );
+		mastodonLanding( ctx, mockNext );
+		expect( page.redirect ).toHaveBeenCalledWith( '/reader' );
+		expect( mockNext ).not.toHaveBeenCalled();
+	} );
+
+	it( 'mastodonConnect redirects to /reader when flag is off', () => {
+		const ctx = makeContext( {} );
+		mastodonConnect( ctx, mockNext );
+		expect( page.redirect ).toHaveBeenCalledWith( '/reader' );
+		expect( mockNext ).not.toHaveBeenCalled();
+	} );
+
+	// The OAuth callback URL is hardcoded to production wordpress.com on the
+	// backend, so the user always lands on production after authorizing on the
+	// instance — regardless of where they started the flow. Production has
+	// reader/social=false, so flag-gating this route would bounce every callback
+	// to /reader and the connection would never persist. The callback is only
+	// reached by users who actively started the connect flow, so it is safe to
+	// run even when the rest of the surface is hidden.
+	it( 'mastodonOauthCallback still mounts the view when flag is off', () => {
+		const ctx = makeContext( {}, { state: 's', code: 'c' } );
+		mastodonOauthCallback( ctx, mockNext );
+		expect( page.redirect ).not.toHaveBeenCalled();
+		expect( ctx.primary ).not.toBeNull();
+		expect( mockNext ).toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
Part of CM-679

## Proposed Changes

* Drop the `ensureMastodonEnabled()` flag check from `mastodonOauthCallback` in `client/reader/mastodon/controller.tsx`. All other Mastodon routes (`mastodonLanding`, `mastodonConnect`, `mastodonAccount`, `mastodonThread`, `mastodonProfile`, `mastodonTagFeed`, `mastodonIdRedirect`) remain flag-gated as today.
* Add an inline comment on `mastodonOauthCallback` documenting why this one route can't be flag-gated.
* Add a `reader/social flag gating` describe block to `client/reader/mastodon/test/controller.test.tsx` covering the regression case (callback mounts when flag is off) plus invariant checks (landing/connect still bounce).

## Why are these changes being made?

The Mastodon backend hardcodes `redirect_uri` to `https://wordpress.com/reader/mastodon/oauth-callback` (`session-creator.php`, `REDIRECT_URI` constant). After the user authorizes on their instance, Mastodon always sends them to **production** wordpress.com — regardless of where the connect flow started.

Production has `"reader/social": false` in `config/production.json`, so before this fix the controller's `ensureMastodonEnabled()` ran on every callback and `page.redirect( '/reader' )` fired before the OAuth callback view could call `complete.mutate({ state, code })`. Net result: connections never persisted.

The OAuth callback page is only reached by users who actively started the connect flow, so it's safe to mount even when the rest of the surface is hidden behind the flag. The view's own validation (state/code presence + `stored.state !== state` against sessionStorage + the server-side state-transient pinned to `user_id`) is what makes the flag gate redundant on this route — removing the gate doesn't widen the attack surface.

ATmosphere uses a different (non-OAuth) flow with no callback route, so no parallel fix is needed there.

## Testing Instructions

Unit tests:

```
yarn test-client client/reader/mastodon/test/controller.test.tsx
```

Manual smoke test (uses the `?flags=-reader/social` query-param override to simulate the production flag state locally):

1. Visit `http://calypso.localhost:3000/reader/mastodon/oauth-callback?flags=-reader/social&state=fakestate&code=fakecode`. Expected: the callback view mounts and shows `"This authorization link has expired or doesn't match your current sign-in attempt."` (the state-mismatch branch). The sidebar correctly hides the Mastodon and ATmosphere entries, confirming the flag override is active.
2. Visit `http://calypso.localhost:3000/reader/mastodon/connect?flags=-reader/social`. Expected: redirected to `/reader` (other Mastodon routes still gated).
3. Visit `http://calypso.localhost:3000/reader/mastodon/connect` (no flag override). Expected: connect form renders normally.

End-to-end the production fix unblocks: after a user authorizes on the instance, Mastodon redirects to `https://wordpress.com/reader/mastodon/oauth-callback?code=...&state=...`, the callback view now mounts (instead of bouncing), `complete.mutate` runs, and the user lands on `/reader/mastodon/<id>/timeline`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?