### PR TITLE
Plugins: announce uncompacted install count to screen readers (DOTCOM-12414)

### DIFF
--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -173,9 +173,7 @@ const PluginDetailsHeader = ( {
 							{ translate( 'Active installations' ) }
 						</div>
 						<div className="plugin-details-header__info-value">
-							<span aria-hidden="true">
-								{ formatNumberCompact( plugin.active_installs ) }
-							</span>
+							<span aria-hidden="true">{ formatNumberCompact( plugin.active_installs ) }</span>
 							<ScreenReaderText>
 								{ formatNumberCompact( plugin.active_installs, {
 									numberFormatOptions: { compactDisplay: 'long' },

--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -1,4 +1,4 @@
-import { Badge, Button } from '@automattic/components';
+import { Badge, Button, ScreenReaderText } from '@automattic/components';
 import { formatNumberCompact } from '@automattic/number-formatters';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
@@ -173,7 +173,14 @@ const PluginDetailsHeader = ( {
 							{ translate( 'Active installations' ) }
 						</div>
 						<div className="plugin-details-header__info-value">
-							{ formatNumberCompact( plugin.active_installs ) }
+							<span aria-hidden="true">
+								{ formatNumberCompact( plugin.active_installs ) }
+							</span>
+							<ScreenReaderText>
+								{ formatNumberCompact( plugin.active_installs, {
+									numberFormatOptions: { compactDisplay: 'long' },
+								} ) }
+							</ScreenReaderText>
 						</div>
 					</div>
 				) }


### PR DESCRIPTION
## Summary

- Closes [DOTCOM-12414](https://linear.app/a8c/issue/DOTCOM-12414).
- The plugin marketplace page renders active install counts using `formatNumberCompact` (e.g. `5M`). Visually that matches the W3C/Unicode compact-short convention and is consistent with the ~20 other places in Calypso that use the same formatter, so the visible label is unchanged. Screen readers, however, currently announce *"five M"*, which is unclear.
- This PR keeps the visible compact form, hides it from assistive tech with `aria-hidden`, and adds a `<ScreenReaderText>` sibling that renders the locale-aware long form (e.g. *"5 million"*, *"5 millones"*) so screen-reader users hear the actual quantity.

## Why this pattern instead of `aria-label`?

`aria-label` on a role-less `<div>` is unreliable across screen readers — VoiceOver honors it, NVDA in browse mode often reads the visible text content and ignores the label, JAWS varies by version. The hidden-span / `<ScreenReaderText>` pattern is the standard in this repo (used in ~30 places) and is deterministic across NVDA, JAWS, VoiceOver, and TalkBack because it puts the long-form text into the accessibility tree as actual content rather than as an attribute on a generic element.

## How it works

`@automattic/number-formatters`' `formatNumberCompact` already merges user options on top of its internal `notation: 'compact'`, so passing `numberFormatOptions: { compactDisplay: 'long' }` produces the long form (e.g. `1 million`, `1 thousand`) without disturbing the visible call site. Locale plumbing inside the package reads `window.wp.date.getSettings().l10n.locale` then `navigator.language`, so the long form is locale-aware and matches the visible compact form's locale.

## Test plan

- [ ] `/plugins/<popular-plugin>/<site>` (e.g. Yoast, Elementor) renders unchanged visually — install count still shows `5M` / `1.2K` / `47`.
- [ ] With NVDA running on Windows + Firefox/Edge, navigating to the install-count stat announces the long form (`five million active installations`-equivalent) rather than `five M`.
- [ ] With VoiceOver on macOS Safari, same expectation.
- [ ] Switch the WP user locale to `es` and confirm the SR-only text matches the visible locale (e.g. `5 millones` for the long form).
- [ ] Inspect the DOM and confirm the visible span has `aria-hidden="true"` so it isn't double-announced.
- [ ] Plugins with small install counts (`<1000`) still render correctly — long form == visible value, harmless redundancy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)