### PR TITLE
Reader onboarding rsm - subscriptions preview - vertically center preview text content.

### DIFF
--- a/client/reader/onboarding-rsm/subscribe-modal/style.scss
+++ b/client/reader/onboarding-rsm/subscribe-modal/style.scss
@@ -325,6 +325,13 @@ body.is-reader-page .subscribe-modal__preview-column .reader__card.card.is-place
 				}
 			}
 
+			// Compact cards default to `min-height: 100px` on details so stream layouts
+			// align with thumbnails; here it adds empty space below short titles/excerpts
+			// so the block no longer matches vertical centering against the image.
+			.reader-post-card__post-details {
+				min-height: 0;
+			}
+
 			// 8px gap between the title/meta heading row and the excerpt
 			// body. Resetting the excerpt margin overrides the global
 			// `margin-bottom: 10px` it ships with.

--- a/client/reader/onboarding-rsm/subscribe-modal/style.scss
+++ b/client/reader/onboarding-rsm/subscribe-modal/style.scss
@@ -329,7 +329,7 @@ body.is-reader-page .subscribe-modal__preview-column .reader__card.card.is-place
 			// align with thumbnails; here it adds empty space below short titles/excerpts
 			// causing the block to no longer be vertically centered.
 			.reader-post-card__post-details {
-				min-height: 0;
+				min-height: auto;
 			}
 
 			// 8px gap between the title/meta heading row and the excerpt

--- a/client/reader/onboarding-rsm/subscribe-modal/style.scss
+++ b/client/reader/onboarding-rsm/subscribe-modal/style.scss
@@ -327,7 +327,7 @@ body.is-reader-page .subscribe-modal__preview-column .reader__card.card.is-place
 
 			// Compact cards default to `min-height: 100px` on details so stream layouts
 			// align with thumbnails; here it adds empty space below short titles/excerpts
-			// so the block no longer matches vertical centering against the image.
+			// causing the block to no longer be vertically centered.
 			.reader-post-card__post-details {
 				min-height: 0;
 			}


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Minor follow up on https://github.com/Automattic/wp-calypso/pull/110510 after noticing edge case with short content.

## Proposed Changes

* resets min-height from the text content in the previews here in the subscriptions modal


After
<img width="616" height="182" alt="Screenshot 2026-05-06 at 3 42 39 PM" src="https://github.com/user-attachments/assets/3fe4fa5a-9d94-41f6-a348-3d6c3287126d" />


Before (uncentered, slightly higher)
<img width="613" height="183" alt="Screenshot 2026-05-06 at 3 42 29 PM" src="https://github.com/user-attachments/assets/2b2b6390-5715-4682-8345-cc5e557464b4" />




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* styles

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* see https://github.com/Automattic/wp-calypso/pull/110510 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
