### PR TITLE
Cancel/remove: override feature lists for Jetpack + Akismet

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import {
 	Icon,
 	__experimentalHStack as HStack,
@@ -15,12 +16,40 @@ import {
 	getSingleItemCancelCopy,
 	getSingleItemRemoveCopy,
 } from './get-confirmation-copy';
+import { getOverrideCancellationFeatures } from './get-override-features';
 import type { Purchase, CancellationFeature } from '@automattic/api-core';
 
 type FeatureObject = {
 	getSlug: () => string;
 	getTitle: ( params?: { domainName?: string } ) => string;
 };
+
+type LossItem = { key: string; title: string };
+
+function getLossItems(
+	overrideFeatures: CancellationFeature[] | null,
+	cancellationFeatures: CancellationFeature[],
+	purchase: Purchase
+): LossItem[] {
+	if ( overrideFeatures ) {
+		return overrideFeatures.map( ( feature ) => ( {
+			key: String( feature.feature_id ),
+			title: feature.title,
+		} ) );
+	}
+	if ( cancellationFeatures.length ) {
+		return cancellationFeatures
+			.filter( ( feature ): feature is CancellationFeature => Boolean( feature ) )
+			.map( ( feature ) => ( {
+				key: String( feature.feature_id ),
+				title: feature.title,
+			} ) );
+	}
+	return getFallbackLossItems( purchase ).map( ( title, idx ) => ( {
+		key: `fallback-${ idx }`,
+		title,
+	} ) );
+}
 
 const CancelPurchaseFeatureList = ( {
 	purchase,
@@ -33,17 +62,14 @@ const CancelPurchaseFeatureList = ( {
 	cancellationFeatures: CancellationFeature[];
 	cancellationChanges: FeatureObject[];
 } ) => {
-	// When the server returns no feature list, fall back to a per-product-type
-	// item so every confirmation screen shows at least one concrete thing the
-	// user is giving up.
-	const lossItems: Array< { key: string; title: string } > = cancellationFeatures.length
-		? cancellationFeatures
-				.filter( ( feature ): feature is CancellationFeature => Boolean( feature ) )
-				.map( ( feature ) => ( { key: String( feature.feature_id ), title: feature.title } ) )
-		: getFallbackLossItems( purchase ).map( ( title, idx ) => ( {
-				key: `fallback-${ idx }`,
-				title,
-		  } ) );
+	// When the split-cancel-remove flag is on, use client-side feature overrides
+	// instead of the server-provided list. Falls back to API features when the
+	// override returns null (no entries yet for this product category).
+	const overrideFeatures = config.isEnabled( 'purchases/split-cancel-remove' )
+		? getOverrideCancellationFeatures( purchase )
+		: null;
+
+	const lossItems = getLossItems( overrideFeatures, cancellationFeatures, purchase );
 
 	if ( ! lossItems.length && ! cancellationChanges.length ) {
 		return null;

--- a/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
@@ -65,7 +65,8 @@ const CancelPurchaseFeatureList = ( {
 	// When the split-cancel-remove flag is on, use client-side feature overrides
 	// instead of the server-provided list. Falls back to API features when the
 	// override returns null (no entries yet for this product category).
-	const overrideFeatures = config.isEnabled( 'purchases/split-cancel-remove' )
+	const isSplitEnabled = useIsSplitCancelRemoveEnabled();
+	const overrideFeatures = isSplitEnabled
 		? getOverrideCancellationFeatures( purchase )
 		: null;
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import {
 	Icon,
 	__experimentalHStack as HStack,
@@ -17,6 +16,7 @@ import {
 	getSingleItemRemoveCopy,
 } from './get-confirmation-copy';
 import { getOverrideCancellationFeatures } from './get-override-features';
+import { useIsSplitCancelRemoveEnabled } from './use-is-split-cancel-remove-enabled';
 import type { Purchase, CancellationFeature } from '@automattic/api-core';
 
 type FeatureObject = {
@@ -66,9 +66,7 @@ const CancelPurchaseFeatureList = ( {
 	// instead of the server-provided list. Falls back to API features when the
 	// override returns null (no entries yet for this product category).
 	const isSplitEnabled = useIsSplitCancelRemoveEnabled();
-	const overrideFeatures = isSplitEnabled
-		? getOverrideCancellationFeatures( purchase )
-		: null;
+	const overrideFeatures = isSplitEnabled ? getOverrideCancellationFeatures( purchase ) : null;
 
 	const lossItems = getLossItems( overrideFeatures, cancellationFeatures, purchase );
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/get-override-features.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/get-override-features.ts
@@ -1,6 +1,15 @@
+import { __ } from '@wordpress/i18n';
 import { getProductCategory } from './get-confirmation-copy';
 import type { PurchaseForCopy } from './get-confirmation-copy';
 import type { CancellationFeature } from '@automattic/api-core';
+
+function features( ...titles: string[] ): CancellationFeature[] {
+	return titles.map( ( title, idx ) => ( {
+		feature_id: `override-${ idx }`,
+		title,
+		description: '',
+	} ) );
+}
 
 /**
  * Client-side override for cancellation features. When the split-cancel-remove
@@ -13,6 +22,13 @@ export function getOverrideCancellationFeatures(
 	purchase: PurchaseForCopy
 ): CancellationFeature[] | null {
 	const slug = purchase.product_slug;
+
+	// Jetpack check first: some Jetpack products have is_plan=true which
+	// causes getProductCategory to return 'plan' instead of 'jetpack'.
+	if ( purchase.is_jetpack_plan_or_product ) {
+		return getJetpackFeatures( slug );
+	}
+
 	const category = getProductCategory( purchase );
 
 	switch ( category ) {
@@ -22,8 +38,6 @@ export function getOverrideCancellationFeatures(
 			return getDomainFeatures( purchase );
 		case 'email':
 			return getEmailFeatures( slug );
-		case 'jetpack':
-			return getJetpackFeatures( slug );
 		case 'akismet':
 			return getAkismetFeatures();
 		case 'marketplace':
@@ -49,13 +63,139 @@ function getEmailFeatures( slug: string ): CancellationFeature[] | null {
 	return null;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getJetpackFeatures( slug: string ): CancellationFeature[] | null {
+	if ( slug.startsWith( 'jetpack_security' ) ) {
+		return features(
+			__( 'Priority support' ),
+			__( 'Real-time backups with one-click restores' ),
+			__( 'Malware scanning with one-click fixes' ),
+			__( 'Akismet spam protection' ),
+			__( '30-day activity log' ),
+			__( 'Brute force attack protection' ),
+			__( 'Downtime monitoring' )
+		);
+	}
+	if ( slug.startsWith( 'jetpack_growth' ) ) {
+		return features(
+			__( 'Priority support' ),
+			__( 'Advanced site stats and analytics' ),
+			__( 'Social media auto-sharing' ),
+			__( 'Newsletter and paid subscriptions' ),
+			__( 'Paid content gating and paywalls' ),
+			__( 'Display ads with WordAds' ),
+			__( '2% transaction fees on payments (vs higher on free)' )
+		);
+	}
+	if ( slug.startsWith( 'jetpack_complete' ) ) {
+		return features(
+			__( 'Access to the full Jetpack suite' ),
+			__( 'Priority support' ),
+			__( 'Real-time backups with 1-year history' ),
+			__( '1 TB of cloud storage' ),
+			__( 'Malware scanning and spam protection' ),
+			__( 'Instant site search' ),
+			__( '1 TB of ad-free video hosting' ),
+			__( 'Site speed and performance tools' )
+		);
+	}
+	if ( slug.startsWith( 'jetpack_ai' ) ) {
+		return features(
+			__( 'AI content generation in your editor' ),
+			__( 'Tone and style adjustments' ),
+			__( 'Spelling and grammar help' ),
+			__( 'Title and summary generation' ),
+			__( 'High request capacity' )
+		);
+	}
+	// Match jetpack_backup but NOT jetpack_backup_addon_storage
+	if ( slug.startsWith( 'jetpack_backup' ) && ! slug.includes( 'addon_storage' ) ) {
+		return features(
+			__( 'Real-time backups as you edit' ),
+			__( '10 GB of cloud storage for your backups' ),
+			__( 'Unlimited one-click restores from the last 30 days' ),
+			__( '30-day activity log' ),
+			__( 'Restore from desktop or mobile, even if your site is offline' ),
+			__( 'Priority support' )
+		);
+	}
+	if ( slug.startsWith( 'jetpack_boost' ) ) {
+		return features(
+			__( 'Automatic site speed optimization' ),
+			__( 'Image size reduction and quality controls' ),
+			__( 'Page caching for faster server response' ),
+			__( 'Site performance scores and tracking' ),
+			__( 'Historical performance chart' ),
+			__( 'Priority support' )
+		);
+	}
+	if ( slug.startsWith( 'jetpack_scan' ) ) {
+		return features(
+			__( 'Website firewall (WAF)' ),
+			__( 'Automated daily malware scanning' ),
+			__( 'One-click fixes for most issues' ),
+			__( 'Instant email threat notifications' ),
+			__( 'Priority support' )
+		);
+	}
+	if ( slug.startsWith( 'jetpack_social' ) ) {
+		return features(
+			__( 'Auto-share to Facebook, Instagram, LinkedIn, and more' ),
+			__( 'Posting to multiple channels at once' ),
+			__( 'Scheduled posts' ),
+			__( 'Custom images and videos with your posts' ),
+			__( 'Auto-generated social images' ),
+			__( 'Content recycling for old posts' )
+		);
+	}
+	// Exclude jetpack_search_free
+	if ( slug.startsWith( 'jetpack_search' ) && ! slug.includes( 'free' ) ) {
+		return features(
+			__( 'Instant search results for your visitors' ),
+			__( 'Filtering and indexing across your content' ),
+			__( 'Support for 38 languages' ),
+			__( 'Spelling correction for typos' ),
+			__( 'Customizable design to match your site' )
+		);
+	}
+	if ( slug.startsWith( 'jetpack_videopress' ) ) {
+		return features(
+			__( '1 TB of cloud video hosting' ),
+			__( 'Ad-free video playback' ),
+			__( '4K video at 60 FPS' ),
+			__( 'Customizable video player' ),
+			__( 'Video and story blocks for the editor' ),
+			__( 'Global CDN for fast delivery' )
+		);
+	}
+	// Exclude free tiers
+	if ( slug.startsWith( 'jetpack_stats' ) && ! slug.includes( 'free' ) ) {
+		return features(
+			__( 'Real-time visitor data' ),
+			__( 'Traffic trends for posts and pages' ),
+			__( 'Referrer and country insights' ),
+			__( 'UTM tracking' ),
+			__( 'Commercial use rights' )
+		);
+	}
+	if ( slug.startsWith( 'jetpack_anti_spam' ) ) {
+		return features(
+			__( 'Spam protection for comments and forms' ),
+			__( '10,000 API calls per month' ),
+			__( 'CAPTCHA-free spam blocking' ),
+			__( 'Priority support' )
+		);
+	}
+	// CRM: unclear if in purchases system (RSM-826) — fall through to null
 	return null;
 }
 
 function getAkismetFeatures(): CancellationFeature[] | null {
-	return null;
+	return features(
+		__( 'Spam protection for comments and forms' ),
+		__( '10,000 API calls per month' ),
+		__( 'CAPTCHA-free spam blocking' ),
+		__( 'Priority support' )
+	);
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/client/dashboard/me/billing-purchases/cancel-purchase/get-override-features.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/get-override-features.ts
@@ -185,7 +185,7 @@ function getJetpackFeatures( slug: string ): CancellationFeature[] | null {
 			__( 'Priority support' )
 		);
 	}
-	// CRM: unclear if in purchases system (RSM-826) — fall through to null
+	// CRM: no override — fall through to null.
 	return null;
 }
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/get-override-features.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/get-override-features.ts
@@ -45,6 +45,8 @@ export function getOverrideCancellationFeatures(
 		case 'one-time':
 		case 'other':
 			return getAddonFeatures( slug );
+		default:
+			return null;
 	}
 }
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/get-override-features.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/get-override-features.ts
@@ -1,0 +1,69 @@
+import { getProductCategory } from './get-confirmation-copy';
+import type { PurchaseForCopy } from './get-confirmation-copy';
+import type { CancellationFeature } from '@automattic/api-core';
+
+/**
+ * Client-side override for cancellation features. When the split-cancel-remove
+ * flag is on, this replaces the server-provided feature list with
+ * benefit-oriented copy keyed by product slug and category.
+ *
+ * Returns null when no override exists — caller falls back to API features.
+ */
+export function getOverrideCancellationFeatures(
+	purchase: PurchaseForCopy
+): CancellationFeature[] | null {
+	const slug = purchase.product_slug;
+	const category = getProductCategory( purchase );
+
+	switch ( category ) {
+		case 'plan':
+			return getWpcomPlanFeatures( slug );
+		case 'domain':
+			return getDomainFeatures( purchase );
+		case 'email':
+			return getEmailFeatures( slug );
+		case 'jetpack':
+			return getJetpackFeatures( slug );
+		case 'akismet':
+			return getAkismetFeatures();
+		case 'marketplace':
+			return getMarketplaceFeatures( purchase );
+		case 'one-time':
+		case 'other':
+			return getAddonFeatures( slug );
+	}
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getWpcomPlanFeatures( slug: string ): CancellationFeature[] | null {
+	return null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getDomainFeatures( purchase: PurchaseForCopy ): CancellationFeature[] | null {
+	return null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getEmailFeatures( slug: string ): CancellationFeature[] | null {
+	return null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getJetpackFeatures( slug: string ): CancellationFeature[] | null {
+	return null;
+}
+
+function getAkismetFeatures(): CancellationFeature[] | null {
+	return null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getMarketplaceFeatures( purchase: PurchaseForCopy ): CancellationFeature[] | null {
+	return null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getAddonFeatures( slug: string ): CancellationFeature[] | null {
+	return null;
+}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/test/get-override-features.test.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/test/get-override-features.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment jsdom
+ */
+jest.mock( '@automattic/api-core', () => ( {
+	GoogleWorkspaceSlugs: {
+		GSUITE_BASIC_SLUG: 'gsuite-basic',
+		GSUITE_BUSINESS_SLUG: 'gsuite-business',
+	},
+	AkismetPlans: {},
+	TitanMailSlugs: {
+		TITAN_MAIL_MONTHLY_SLUG: 'titan-mail-monthly',
+		TITAN_MAIL_YEARLY_SLUG: 'titan-mail-yearly',
+	},
+} ) );
+
+import { getOverrideCancellationFeatures } from '../get-override-features';
+import type { PurchaseForCopy } from '../get-confirmation-copy';
+
+function makePurchase( overrides: Partial< PurchaseForCopy > = {} ): PurchaseForCopy {
+	return {
+		is_plan: false,
+		is_domain_registration: false,
+		is_jetpack_plan_or_product: false,
+		product_slug: 'test-product',
+		product_name: 'Test Product',
+		product_type: 'other',
+		expiry_date: '2027-04-16',
+		expiry_status: 'manual-renew',
+		domain: 'example.com',
+		...overrides,
+	} as PurchaseForCopy;
+}
+
+describe( 'getOverrideCancellationFeatures', () => {
+	it( 'returns null for a plan purchase (no entries yet)', () => {
+		const purchase = makePurchase( {
+			is_plan: true,
+			product_slug: 'business-bundle',
+			product_name: 'WordPress.com Business',
+		} );
+		expect( getOverrideCancellationFeatures( purchase ) ).toBeNull();
+	} );
+
+	it( 'returns null for a domain purchase', () => {
+		const purchase = makePurchase( {
+			is_domain_registration: true,
+			product_slug: 'dotcom_domain',
+			product_name: 'example.com',
+		} );
+		expect( getOverrideCancellationFeatures( purchase ) ).toBeNull();
+	} );
+
+	it( 'returns null for a Jetpack purchase', () => {
+		const purchase = makePurchase( {
+			is_jetpack_plan_or_product: true,
+			product_slug: 'jetpack_security_daily',
+			product_name: 'Jetpack Security',
+		} );
+		expect( getOverrideCancellationFeatures( purchase ) ).toBeNull();
+	} );
+} );

--- a/client/dashboard/me/billing-purchases/cancel-purchase/test/get-override-features.test.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/test/get-override-features.test.ts
@@ -6,7 +6,9 @@ jest.mock( '@automattic/api-core', () => ( {
 		GSUITE_BASIC_SLUG: 'gsuite-basic',
 		GSUITE_BUSINESS_SLUG: 'gsuite-business',
 	},
-	AkismetPlans: {},
+	AkismetPlans: {
+		PRODUCT_AKISMET_PLUS_YEARLY: 'ak_plus_yearly_1',
+	},
 	TitanMailSlugs: {
 		TITAN_MAIL_MONTHLY_SLUG: 'titan-mail-monthly',
 		TITAN_MAIL_YEARLY_SLUG: 'titan-mail-yearly',
@@ -50,12 +52,211 @@ describe( 'getOverrideCancellationFeatures', () => {
 		expect( getOverrideCancellationFeatures( purchase ) ).toBeNull();
 	} );
 
-	it( 'returns null for a Jetpack purchase', () => {
-		const purchase = makePurchase( {
-			is_jetpack_plan_or_product: true,
-			product_slug: 'jetpack_security_daily',
-			product_name: 'Jetpack Security',
+	describe( 'Jetpack products', () => {
+		it( 'jetpack_security_t1_yearly → returns 7 features', () => {
+			const purchase = makePurchase( {
+				is_jetpack_plan_or_product: true,
+				product_slug: 'jetpack_security_t1_yearly',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 7 );
 		} );
-		expect( getOverrideCancellationFeatures( purchase ) ).toBeNull();
+
+		it( 'jetpack_security_t2_monthly → returns 7 features (different tier)', () => {
+			const purchase = makePurchase( {
+				is_jetpack_plan_or_product: true,
+				product_slug: 'jetpack_security_t2_monthly',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 7 );
+		} );
+
+		it( 'jetpack_growth_yearly → returns 7 features', () => {
+			const purchase = makePurchase( {
+				is_jetpack_plan_or_product: true,
+				product_slug: 'jetpack_growth_yearly',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 7 );
+		} );
+
+		it( 'jetpack_complete → returns 8 features', () => {
+			const purchase = makePurchase( {
+				is_jetpack_plan_or_product: true,
+				product_slug: 'jetpack_complete',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 8 );
+		} );
+
+		it( 'jetpack_complete_bi_yearly → returns 8 features (billing period variant)', () => {
+			const purchase = makePurchase( {
+				is_jetpack_plan_or_product: true,
+				product_slug: 'jetpack_complete_bi_yearly',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 8 );
+		} );
+
+		it( 'jetpack_ai_yearly → returns 5 features', () => {
+			const purchase = makePurchase( {
+				is_jetpack_plan_or_product: true,
+				product_slug: 'jetpack_ai_yearly',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 5 );
+		} );
+
+		it( 'jetpack_ai_monthly_100 → returns 5 features (quantity variant)', () => {
+			const purchase = makePurchase( {
+				is_jetpack_plan_or_product: true,
+				product_slug: 'jetpack_ai_monthly_100',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 5 );
+		} );
+
+		it( 'jetpack_backup_t1_yearly → returns 6 features', () => {
+			const purchase = makePurchase( {
+				is_jetpack_plan_or_product: true,
+				product_slug: 'jetpack_backup_t1_yearly',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 6 );
+		} );
+
+		it( 'jetpack_backup_addon_storage_10gb_yearly → returns null (excluded)', () => {
+			const purchase = makePurchase( {
+				is_jetpack_plan_or_product: true,
+				product_slug: 'jetpack_backup_addon_storage_10gb_yearly',
+			} );
+			expect( getOverrideCancellationFeatures( purchase ) ).toBeNull();
+		} );
+
+		it( 'jetpack_boost_yearly → returns 6 features', () => {
+			const purchase = makePurchase( {
+				is_jetpack_plan_or_product: true,
+				product_slug: 'jetpack_boost_yearly',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 6 );
+		} );
+
+		it( 'jetpack_scan → returns 5 features', () => {
+			const purchase = makePurchase( {
+				is_jetpack_plan_or_product: true,
+				product_slug: 'jetpack_scan',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 5 );
+		} );
+
+		it( 'jetpack_social_basic_yearly → returns 6 features', () => {
+			const purchase = makePurchase( {
+				is_jetpack_plan_or_product: true,
+				product_slug: 'jetpack_social_basic_yearly',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 6 );
+		} );
+
+		it( 'jetpack_social_advanced_monthly → returns 6 features', () => {
+			const purchase = makePurchase( {
+				is_jetpack_plan_or_product: true,
+				product_slug: 'jetpack_social_advanced_monthly',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 6 );
+		} );
+
+		it( 'jetpack_search → returns 5 features', () => {
+			const purchase = makePurchase( {
+				is_jetpack_plan_or_product: true,
+				product_slug: 'jetpack_search',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 5 );
+		} );
+
+		it( 'jetpack_search_free → returns null (free excluded)', () => {
+			const purchase = makePurchase( {
+				is_jetpack_plan_or_product: true,
+				product_slug: 'jetpack_search_free',
+			} );
+			expect( getOverrideCancellationFeatures( purchase ) ).toBeNull();
+		} );
+
+		it( 'jetpack_videopress → returns 6 features', () => {
+			const purchase = makePurchase( {
+				is_jetpack_plan_or_product: true,
+				product_slug: 'jetpack_videopress',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 6 );
+		} );
+
+		it( 'jetpack_stats_monthly → returns 5 features', () => {
+			const purchase = makePurchase( {
+				is_jetpack_plan_or_product: true,
+				product_slug: 'jetpack_stats_monthly',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 5 );
+		} );
+
+		it( 'jetpack_stats_free → returns null (free excluded)', () => {
+			const purchase = makePurchase( {
+				is_jetpack_plan_or_product: true,
+				product_slug: 'jetpack_stats_free',
+			} );
+			expect( getOverrideCancellationFeatures( purchase ) ).toBeNull();
+		} );
+
+		it( 'jetpack_anti_spam → returns 4 features', () => {
+			const purchase = makePurchase( {
+				is_jetpack_plan_or_product: true,
+				product_slug: 'jetpack_anti_spam',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 4 );
+		} );
+
+		it( 'jetpack_anti_spam_monthly_v2 → returns 4 features', () => {
+			const purchase = makePurchase( {
+				is_jetpack_plan_or_product: true,
+				product_slug: 'jetpack_anti_spam_monthly_v2',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 4 );
+		} );
+
+		it( 'jetpack_crm → returns null (no override, RSM-826)', () => {
+			const purchase = makePurchase( {
+				is_jetpack_plan_or_product: true,
+				product_slug: 'jetpack_crm',
+			} );
+			expect( getOverrideCancellationFeatures( purchase ) ).toBeNull();
+		} );
+
+		it( 'routes Jetpack products that also have is_plan=true correctly', () => {
+			const purchase = makePurchase( {
+				is_plan: true,
+				is_jetpack_plan_or_product: true,
+				product_slug: 'jetpack_security_t1_yearly',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 7 );
+		} );
+	} );
+
+	describe( 'Akismet', () => {
+		it( 'returns 4 features for an Akismet plan', () => {
+			const purchase = makePurchase( {
+				product_slug: 'ak_plus_yearly_1',
+				product_name: 'Akismet Plus',
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result ).toHaveLength( 4 );
+		} );
 	} );
 } );

--- a/client/me/purchases/cancel-purchase/feature-list.tsx
+++ b/client/me/purchases/cancel-purchase/feature-list.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import moment from 'moment';
 import {
@@ -7,10 +8,37 @@ import {
 	getSingleItemCancelCopy,
 	getSingleItemRemoveCopy,
 } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy';
+import { getOverrideCancellationFeatures } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/get-override-features';
 import { toPurchaseForCopy } from './to-purchase-for-copy';
 import type { CancellationFeature } from '@automattic/api-core';
 import type { Purchases } from '@automattic/data-stores';
+import type { PurchaseForCopy } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy';
 import type { DisplayVariant } from 'calypso/lib/purchases/utils';
+
+type LossItem = { key: string; title: string };
+
+function getLossItems(
+	overrideFeatures: CancellationFeature[] | null,
+	cancellationFeatures: CancellationFeature[],
+	adapted: PurchaseForCopy
+): LossItem[] {
+	if ( overrideFeatures ) {
+		return overrideFeatures.map( ( feature ) => ( {
+			key: String( feature.feature_id ),
+			title: feature.title,
+		} ) );
+	}
+	if ( cancellationFeatures.length ) {
+		return cancellationFeatures.map( ( feature ) => ( {
+			key: feature.feature_id,
+			title: feature.title,
+		} ) );
+	}
+	return getFallbackLossItems( adapted ).map( ( title, idx ) => ( {
+		key: `fallback-${ idx }`,
+		title,
+	} ) );
+}
 
 const CancelPurchaseFeatureList = ( {
 	purchase,
@@ -22,16 +50,15 @@ const CancelPurchaseFeatureList = ( {
 	cancellationFeatures: CancellationFeature[];
 } ) => {
 	const adapted = toPurchaseForCopy( purchase );
-	// When the server returns no features, fall back to a per-product-type item.
-	const items: Array< { key: string; title: string } > = cancellationFeatures.length
-		? cancellationFeatures.map( ( feature ) => ( {
-				key: feature.feature_id,
-				title: feature.title,
-		  } ) )
-		: getFallbackLossItems( adapted ).map( ( title, idx ) => ( {
-				key: `fallback-${ idx }`,
-				title,
-		  } ) );
+
+	// When the split-cancel-remove flag is on, use client-side feature overrides
+	// instead of the server-provided list. Falls back to API features when the
+	// override returns null (no entries yet for this product category).
+	const overrideFeatures = config.isEnabled( 'purchases/split-cancel-remove' )
+		? getOverrideCancellationFeatures( adapted )
+		: null;
+
+	const items = getLossItems( overrideFeatures, cancellationFeatures, adapted );
 
 	if ( ! items.length ) {
 		return null;

--- a/client/me/purchases/cancel-purchase/feature-list.tsx
+++ b/client/me/purchases/cancel-purchase/feature-list.tsx
@@ -53,9 +53,10 @@ const CancelPurchaseFeatureList = ( {
 
 	// When the split-cancel-remove flag is on, use client-side feature overrides
 	// instead of the server-provided list. Falls back to API features when the
-	// override returns null (no entries yet for this product category).
-	const overrideFeatures = config.isEnabled( 'purchases/split-cancel-remove' )
+	const isSplitEnabled = useIsSplitCancelRemoveEnabled();
+	const overrideFeatures = isSplitEnabled
 		? getOverrideCancellationFeatures( adapted )
+		: null;
 		: null;
 
 	const items = getLossItems( overrideFeatures, cancellationFeatures, adapted );

--- a/client/me/purchases/cancel-purchase/feature-list.tsx
+++ b/client/me/purchases/cancel-purchase/feature-list.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
 import moment from 'moment';
 import {
@@ -9,6 +8,7 @@ import {
 	getSingleItemRemoveCopy,
 } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy';
 import { getOverrideCancellationFeatures } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/get-override-features';
+import { useIsSplitCancelRemoveEnabled } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/use-is-split-cancel-remove-enabled';
 import { toPurchaseForCopy } from './to-purchase-for-copy';
 import type { CancellationFeature } from '@automattic/api-core';
 import type { Purchases } from '@automattic/data-stores';
@@ -54,10 +54,7 @@ const CancelPurchaseFeatureList = ( {
 	// When the split-cancel-remove flag is on, use client-side feature overrides
 	// instead of the server-provided list. Falls back to API features when the
 	const isSplitEnabled = useIsSplitCancelRemoveEnabled();
-	const overrideFeatures = isSplitEnabled
-		? getOverrideCancellationFeatures( adapted )
-		: null;
-		: null;
+	const overrideFeatures = isSplitEnabled ? getOverrideCancellationFeatures( adapted ) : null;
 
 	const items = getLossItems( overrideFeatures, cancellationFeatures, adapted );
 


### PR DESCRIPTION
Depends on: https://github.com/Automattic/wp-calypso/pull/110478
Related to: https://linear.app/a8c/issue/RSM-478

## Summary

This PR adds feature summaries for Jetpack products:

| Before | After |
| -- | -- |
| <img width="1760" height="1196" alt="image" src="https://github.com/user-attachments/assets/e5a3d5bb-5f3e-4cf6-b06b-fb05017f8f0e" /> | <img width="1760" height="1196" alt="image" src="https://github.com/user-attachments/assets/03f90a28-56f8-42f4-b71e-c5048e66d5ff" /> | 

## Test plan

- [ ] Navigate to a Jetpack product's cancel/remove screen on the dashboard with the `purchases/split-cancel-remove` flag enabled
- [ ] Verify a bulleted feature list appears for each supported Jetpack product family
- [ ] Verify `jetpack_anti_spam` products show Akismet-style features (4 items)
- [ ] Verify `jetpack_backup_addon_storage_*`, `jetpack_search_free`, `jetpack_stats_free*`, and `jetpack_crm` fall back to the generic copy (no override)
- [ ] Verify standalone Akismet plans (`ak_*` slugs) still show 4 Akismet features
- [ ] Verify WordPress.com plans still show no override (stub returns null, falls back to API features)

## Fixes
Fixes: https://linear.app/a8c/issue/RSM-812
Fixes: https://linear.app/a8c/issue/RSM-813
Fixes: https://linear.app/a8c/issue/RSM-815
Fixes: https://linear.app/a8c/issue/RSM-817
Fixes: https://linear.app/a8c/issue/RSM-818
Fixes: https://linear.app/a8c/issue/RSM-819
Fixes: https://linear.app/a8c/issue/RSM-820
Fixes: https://linear.app/a8c/issue/RSM-822
Fixes: https://linear.app/a8c/issue/RSM-823
Fixes: https://linear.app/a8c/issue/RSM-824
Fixes: https://linear.app/a8c/issue/RSM-825
Fixes: https://linear.app/a8c/issue/RSM-826

🤖 Generated with [Claude Code](https://claude.com/claude-code)