### PR TITLE
Add feature list to purchase settings on legacy Calypso

### DIFF
--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-import { SubscriptionBillPeriod } from '@automattic/api-core';
+import { SubscriptionBillPeriod, type CancellationFeature } from '@automattic/api-core';
+import { purchaseCancelFeaturesQuery } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
 import {
 	isPersonal,
@@ -55,6 +56,7 @@ import {
 import { Plans, type SiteDetails } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { DOMAIN_CANCEL, SUPPORT_ROOT } from '@automattic/urls';
+import { useQuery } from '@tanstack/react-query';
 import { hasTranslation } from '@wordpress/i18n';
 import {
 	check,
@@ -85,7 +87,6 @@ import CancelPurchaseForm from 'calypso/components/marketing-survey/cancel-purch
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
-import { getOverrideCancellationFeatures } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/get-override-features';
 import { useIsSplitCancelRemoveEnabled } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/use-is-split-cancel-remove-enabled';
 import {
 	getCancelButtonCopy,
@@ -122,7 +123,6 @@ import {
 import { getPurchaseCancellationFlowType } from 'calypso/lib/purchases/utils';
 import { hasCustomDomain } from 'calypso/lib/site/utils';
 import { addQueryArgs } from 'calypso/lib/url';
-import { toPurchaseForCopy } from 'calypso/me/purchases/cancel-purchase/to-purchase-for-copy';
 import NonPrimaryDomainDialog from 'calypso/me/purchases/non-primary-domain-dialog';
 import ProductLink from 'calypso/me/purchases/product-link';
 import titles from 'calypso/me/purchases/titles';
@@ -226,6 +226,7 @@ export interface ManagePurchaseProps {
 
 export interface ManagePurchaseConnectedProps {
 	isSplitCancelRemoveEnabled: boolean;
+	cancellationFeatures: CancellationFeature[] | null;
 	hasCustomPrimaryDomain?: boolean | null;
 	hasLoadedDomains?: boolean;
 	hasLoadedPurchasesFromServer: boolean;
@@ -1295,7 +1296,8 @@ class ManagePurchase extends Component<
 	}
 
 	renderPurchaseDescription() {
-		const { purchase, site, translate, isSplitCancelRemoveEnabled } = this.props;
+		const { purchase, site, translate, isSplitCancelRemoveEnabled, cancellationFeatures } =
+			this.props;
 
 		if ( ! purchase ) {
 			return null;
@@ -1305,24 +1307,21 @@ class ManagePurchase extends Component<
 			return null;
 		}
 
-		// When the split flag is on, show the feature list instead of the description
-		if ( isSplitCancelRemoveEnabled ) {
-			const adapted = toPurchaseForCopy( purchase );
-			const features = getOverrideCancellationFeatures( adapted );
-			if ( features && features.length > 0 ) {
-				return (
-					<div className="manage-purchase__content">
-						<ul className="manage-purchase__feature-list-items">
-							{ features.map( ( feature ) => (
-								<li key={ feature.feature_id } className="manage-purchase__feature-list-item">
-									<Icon icon={ check } size={ 24 } className="manage-purchase__feature-icon" />
-									<span>{ feature.title }</span>
-								</li>
-							) ) }
-						</ul>
-					</div>
-				);
-			}
+		// When the split flag is on and the API has returned features for this
+		// purchase, show the feature list instead of the description.
+		if ( isSplitCancelRemoveEnabled && cancellationFeatures && cancellationFeatures.length > 0 ) {
+			return (
+				<div className="manage-purchase__content">
+					<ul className="manage-purchase__feature-list-items">
+						{ cancellationFeatures.map( ( feature ) => (
+							<li key={ feature.feature_id } className="manage-purchase__feature-list-item">
+								<Icon icon={ check } size={ 24 } className="manage-purchase__feature-icon" />
+								<span>{ feature.title }</span>
+							</li>
+						) ) }
+					</ul>
+				</div>
+			);
 		}
 
 		const registrationAgreementUrl = getDomainRegistrationAgreementUrl( purchase );
@@ -1979,10 +1978,18 @@ function mapDispatchToProps( dispatch: CalypsoDispatch ) {
 
 function ManagePurchaseWithExperiment( props: ManagePurchaseProps ) {
 	const isSplitCancelRemoveEnabled = useIsSplitCancelRemoveEnabled();
+	const { data: cancelFeaturesResponse } = useQuery( {
+		...purchaseCancelFeaturesQuery( props.purchaseId, 'treatment' ),
+		enabled: isSplitCancelRemoveEnabled,
+	} );
+	const cancellationFeatures = isSplitCancelRemoveEnabled
+		? cancelFeaturesResponse?.features ?? null
+		: null;
 	return (
 		<ConnectedManagePurchase
 			{ ...props }
 			isSplitCancelRemoveEnabled={ isSplitCancelRemoveEnabled }
+			cancellationFeatures={ cancellationFeatures }
 		/>
 	);
 }

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -57,6 +57,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { DOMAIN_CANCEL, SUPPORT_ROOT } from '@automattic/urls';
 import { hasTranslation } from '@wordpress/i18n';
 import {
+	check,
 	column,
 	download,
 	Icon,
@@ -84,6 +85,7 @@ import CancelPurchaseForm from 'calypso/components/marketing-survey/cancel-purch
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
+import { getOverrideCancellationFeatures } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/get-override-features';
 import { useIsSplitCancelRemoveEnabled } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/use-is-split-cancel-remove-enabled';
 import {
 	getCancelButtonCopy,
@@ -120,6 +122,7 @@ import {
 import { getPurchaseCancellationFlowType } from 'calypso/lib/purchases/utils';
 import { hasCustomDomain } from 'calypso/lib/site/utils';
 import { addQueryArgs } from 'calypso/lib/url';
+import { toPurchaseForCopy } from 'calypso/me/purchases/cancel-purchase/to-purchase-for-copy';
 import NonPrimaryDomainDialog from 'calypso/me/purchases/non-primary-domain-dialog';
 import ProductLink from 'calypso/me/purchases/product-link';
 import titles from 'calypso/me/purchases/titles';
@@ -201,6 +204,28 @@ const loadProductPlanOverlapNotices = () =>
 	import(
 		/* webpackChunkName: "async-load-calypso-blocks-product-plan-overlap-notices" */ 'calypso/blocks/product-plan-overlap-notices'
 	);
+
+function PurchaseFeatureList( { purchase }: { purchase: Purchase } ) {
+	const adapted = toPurchaseForCopy( purchase );
+	const features = getOverrideCancellationFeatures( adapted );
+
+	if ( ! features || features.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<div className="manage-purchase__feature-list">
+			<ul className="manage-purchase__feature-list-items">
+				{ features.map( ( feature ) => (
+					<li key={ feature.feature_id }>
+						<Icon icon={ check } size={ 24 } className="manage-purchase__feature-icon" />
+						<span>{ feature.title }</span>
+					</li>
+				) ) }
+			</ul>
+		</div>
+	);
+}
 
 export interface ManagePurchaseProps {
 	cardTitle?: string;
@@ -1292,7 +1317,7 @@ class ManagePurchase extends Component<
 	}
 
 	renderPurchaseDescription() {
-		const { purchase, site, translate } = this.props;
+		const { purchase, site, translate, isSplitCancelRemoveEnabled } = this.props;
 
 		if ( ! purchase ) {
 			return null;
@@ -1300,6 +1325,19 @@ class ManagePurchase extends Component<
 
 		if ( isMarketplaceHoldingSitePurchase( purchase ) || isA4AHoldingSitePurchase( purchase ) ) {
 			return null;
+		}
+
+		// When the split flag is on, show the feature list instead of the description
+		if ( isSplitCancelRemoveEnabled ) {
+			const adapted = toPurchaseForCopy( purchase );
+			const features = getOverrideCancellationFeatures( adapted );
+			if ( features && features.length > 0 ) {
+				return (
+					<div className="manage-purchase__content">
+						<PurchaseFeatureList purchase={ purchase } />
+					</div>
+				);
+			}
 		}
 
 		const registrationAgreementUrl = getDomainRegistrationAgreementUrl( purchase );

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -205,28 +205,6 @@ const loadProductPlanOverlapNotices = () =>
 		/* webpackChunkName: "async-load-calypso-blocks-product-plan-overlap-notices" */ 'calypso/blocks/product-plan-overlap-notices'
 	);
 
-function PurchaseFeatureList( { purchase }: { purchase: Purchase } ) {
-	const adapted = toPurchaseForCopy( purchase );
-	const features = getOverrideCancellationFeatures( adapted );
-
-	if ( ! features || features.length === 0 ) {
-		return null;
-	}
-
-	return (
-		<div className="manage-purchase__feature-list">
-			<ul className="manage-purchase__feature-list-items">
-				{ features.map( ( feature ) => (
-					<li key={ feature.feature_id }>
-						<Icon icon={ check } size={ 24 } className="manage-purchase__feature-icon" />
-						<span>{ feature.title }</span>
-					</li>
-				) ) }
-			</ul>
-		</div>
-	);
-}
-
 export interface ManagePurchaseProps {
 	cardTitle?: string;
 	getAddNewPaymentMethodUrlFor?: typeof getAddNewPaymentMethodUrlFor;
@@ -1334,7 +1312,14 @@ class ManagePurchase extends Component<
 			if ( features && features.length > 0 ) {
 				return (
 					<div className="manage-purchase__content">
-						<PurchaseFeatureList purchase={ purchase } />
+						<ul className="manage-purchase__feature-list-items">
+							{ features.map( ( feature ) => (
+								<li key={ feature.feature_id } className="manage-purchase__feature-list-item">
+									<Icon icon={ check } size={ 24 } className="manage-purchase__feature-icon" />
+									<span>{ feature.title }</span>
+								</li>
+							) ) }
+						</ul>
 					</div>
 				);
 			}

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -233,13 +233,13 @@
 	margin: 0;
 	padding: 0;
 	transform: translateX( -4px );
+}
 
-	li {
-		display: flex;
-		align-items: flex-start;
-		gap: 12px;
-		padding-block: 2px;
-	}
+.manage-purchase__feature-list-item {
+	display: flex;
+	align-items: flex-start;
+	gap: 12px;
+	padding-block: 2px;
 }
 
 .manage-purchase__feature-icon {

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -228,6 +228,25 @@
 	}
 }
 
+.manage-purchase__feature-list-items {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	transform: translateX( -4px );
+
+	li {
+		display: flex;
+		align-items: flex-start;
+		gap: 12px;
+		padding-block: 2px;
+	}
+}
+
+.manage-purchase__feature-icon {
+	fill: var( --color-success );
+	flex-shrink: 0;
+}
+
 .manage-purchase__refund-text {
 	display: block;
 	font-size: $font-body-extra-small;


### PR DESCRIPTION
Fixes: https://linear.app/a8c/issue/RSM-492/

## Proposed changes

Pairs with #110527 to add a "What you get" feature list to the legacy Calypso purchase management screen. The features come from the same variant-aware `/upgrades/{id}/cancel-features` endpoint introduced in #110717, and only render when `purchases/split-cancel-remove` is enabled (or the `calypso_new_cancel_refund_flow_20260408` experiment is in treatment). Products without backend feature copy fall through to the existing description unchanged.

| Before | After |
| -- | -- |
| <img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/c636a10a-e232-41c3-9242-275d98c95d45" /> | <img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/0038a3bc-1698-4627-a7c1-e9533ae4ecac" /> |

* `ManagePurchaseWithExperiment` fetches `purchaseCancelFeaturesQuery(purchaseId, 'treatment')` (gated `enabled: isSplitCancelRemoveEnabled`) and threads the resulting features array into the class component as a new `cancellationFeatures` prop
* In `renderPurchaseDescription`, when the flag is on AND the API returned features, render an inline checkmark list in place of the generic description / "Plan Features" link; otherwise fall through to today's copy
* SCSS for the feature list lives under `.manage-purchase__feature-list-items` / `.manage-purchase__feature-list-item` (no bare element selectors)

## Why are these changes being made?

When a user views their purchase details, we want to show them the specific benefits they get from their plan — the same benefit-oriented copy that appears in the cancellation flow. Reinforcing the value of the subscription on the management screen helps reduce support volume around "what does my plan include?" questions and, ultimately, impulse cancellations.

Earlier iterations of this branch routed the benefit-oriented copy through a client-side `getOverrideCancellationFeatures()` module keyed by product category. That layer has been replaced by #110717 — the backend endpoint now accepts `variant=control|treatment` and returns the right copy directly, with access to dynamic per-subscription data (e.g. primary domain via `meta` / atomic-transfer redirect) that the client doesn't have without extra queries. This PR consumes that endpoint instead, so the dashboard purchase settings (#110527), the cancel/remove flows (already on trunk), and this legacy management screen all share a single source of truth.

## Testing instructions

TC:
```
yarn typecheck-client
yarn test-client --findRelatedTests client/me/purchases/manage-purchase/index.tsx
```

Manual testing:
1. Enable `purchases/split-cancel-remove` (or get assigned to the `calypso_new_cancel_refund_flow_20260408` treatment).
2. Navigate to `/me/purchases` and click into a WordPress.com plan (Personal, Premium, Business, eCommerce).
3. Verify the purchase description area shows a checkmark list of benefits instead of the generic description + "Plan Features" link.
4. Verify non-plan purchases (domains, email, Jetpack, marketplace) still render their existing description — these don't have backend feature copy yet.
5. Disable the flag and verify the original description renders, and that no `/cancel-features` request is made (Network tab).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
