### PR TITLE
Purchases: add site-level action interstitial for legacy surface

### DIFF
--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -34,6 +34,7 @@ import { Downgrade } from './downgrade';
 import ManagePurchase from './manage-purchase';
 import { ManagePurchaseByOwnership } from './manage-purchase/manage-purchase-by-ownership';
 import PurchasesListDataView from './purchases-list-in-dataviews';
+import SiteActionInterstitial from './site-level-actions';
 import titles from './titles';
 import VatInfoPage from './vat-info';
 import useVatDetails from './vat-info/use-vat-details';
@@ -131,6 +132,36 @@ export function cancelPurchase( context, next ) {
 	} );
 
 	context.primary = <CancelPurchaseWrapper />;
+	next();
+}
+
+export function siteActionInterstitial( context, next ) {
+	const actionType = context.query?.action ?? 'renew';
+
+	let pageTitle;
+	if ( actionType === 'cancel' ) {
+		pageTitle = i18n.translate( 'Cancel subscriptions' );
+	} else if ( actionType === 'remove' ) {
+		pageTitle = i18n.translate( 'Remove upgrades' );
+	} else {
+		pageTitle = i18n.translate( 'Renew subscriptions' );
+	}
+
+	const SiteActionInterstitialWrapper = () => {
+		return (
+			<PurchasesWrapper title={ pageTitle }>
+				<Main wideLayout className="purchases__site-actions">
+					<SiteActionInterstitial
+						purchaseId={ parseInt( context.params.purchaseId, 10 ) }
+						siteSlug={ context.params.site }
+						actionType={ actionType }
+					/>
+				</Main>
+			</PurchasesWrapper>
+		);
+	};
+
+	context.primary = <SiteActionInterstitialWrapper />;
 	next();
 }
 

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -176,6 +176,18 @@ export default ( router ) => {
 	);
 
 	router(
+		paths.siteActionInterstitial( ':site', ':purchaseId' ),
+		setupPreferences,
+		maybeRedirectToMultiSiteDashboard(
+			( params ) => `/me/billing/purchases/${ params.purchaseId }/site-level-actions`
+		),
+		sidebar,
+		controller.siteActionInterstitial,
+		makeLayout,
+		clientRender
+	);
+
+	router(
 		paths.downgradePurchase( ':site', ':purchaseId' ),
 		sidebar,
 		controller.downgradePurchase,

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -324,16 +324,16 @@ class ManagePurchase extends Component<
 
 	handleRenew = () => {
 		const { purchase, siteSlug, redirectTo } = this.props;
-		const options = redirectTo ? { redirectTo } : undefined;
-		const isSitelessRenewal =
-			purchase &&
-			( isAkismetHoldingSitePurchase( purchase ) ||
-				isMarketplaceHoldingSitePurchase( purchase ) ||
-				isA4AHoldingSitePurchase( purchase ) );
 
 		if ( ! purchase ) {
 			return;
 		}
+
+		const options = redirectTo ? { redirectTo } : undefined;
+		const isSitelessRenewal =
+			isAkismetHoldingSitePurchase( purchase ) ||
+			isMarketplaceHoldingSitePurchase( purchase ) ||
+			isA4AHoldingSitePurchase( purchase );
 
 		// If this renewal is for a siteless purchase, we'll drop the site slug
 		this.props.handleRenewNowClick( purchase, ! isSitelessRenewal ? siteSlug : '', options );

--- a/client/me/purchases/paths.js
+++ b/client/me/purchases/paths.js
@@ -47,6 +47,15 @@ export function cancelPurchase( siteName, purchaseId ) {
 	return managePurchase( siteName, purchaseId ) + '/cancel';
 }
 
+export function siteActionInterstitial( siteName, purchaseId ) {
+	if ( process.env.NODE_ENV !== 'production' ) {
+		if ( 'undefined' === typeof siteName || 'undefined' === typeof purchaseId ) {
+			throw new Error( 'siteName and purchaseId must be provided' );
+		}
+	}
+	return managePurchase( siteName, purchaseId ) + '/site-level-actions';
+}
+
 export function downgradePurchase( siteName, purchaseId ) {
 	if ( process.env.NODE_ENV !== 'production' ) {
 		if ( 'undefined' === typeof siteName || 'undefined' === typeof purchaseId ) {

--- a/client/me/purchases/site-level-actions/index.tsx
+++ b/client/me/purchases/site-level-actions/index.tsx
@@ -1,0 +1,263 @@
+import page from '@automattic/calypso-router';
+import { Button, Card, FormLabel } from '@automattic/components';
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect, useState } from 'react';
+import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
+import FormattedHeader from 'calypso/components/formatted-header';
+import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
+import HeaderCakeBack from 'calypso/components/header-cake/back';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { useIsSplitCancelRemoveEnabled } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/use-is-split-cancel-remove-enabled';
+import { getName, handleRenewMultiplePurchasesClick } from 'calypso/lib/purchases';
+import { cancelPurchase, managePurchase } from 'calypso/me/purchases/paths';
+import PurchaseSiteHeader from 'calypso/me/purchases/purchases-site/header';
+import { useDispatch as useReduxDispatch, useSelector } from 'calypso/state';
+import {
+	getByPurchaseId,
+	getSitePurchases,
+	hasLoadedUserPurchasesFromServer,
+} from 'calypso/state/purchases/selectors';
+import type { Purchase } from 'calypso/lib/purchases/types';
+
+import './style.scss';
+
+interface SiteActionInterstitialProps {
+	purchaseId: number;
+	siteSlug: string;
+	actionType: 'cancel' | 'remove' | 'renew';
+}
+
+export default function SiteActionInterstitial( {
+	purchaseId,
+	siteSlug,
+	actionType,
+}: SiteActionInterstitialProps ) {
+	const translate = useTranslate();
+	const dispatch = useReduxDispatch();
+	const moment = useLocalizedMoment();
+	const isSplitEnabled = useIsSplitCancelRemoveEnabled();
+
+	const purchase = useSelector( ( state ) => getByPurchaseId( state, purchaseId ) );
+	const purchases = useSelector( ( state ) =>
+		purchase ? getSitePurchases( state, purchase.siteId ) : null
+	);
+	const hasLoaded = useSelector( hasLoadedUserPurchasesFromServer );
+
+	const [ selectedIds, setSelectedIds ] = useState< Set< number > >(
+		() => new Set( [ purchaseId ] )
+	);
+
+	const shouldBypass = hasLoaded && ( ! isSplitEnabled || ! purchases || purchases.length <= 1 );
+
+	// Redirect to normal renew flow when flag is off or site has only one purchase
+	useEffect( () => {
+		if ( ! shouldBypass ) {
+			return;
+		}
+		if ( purchase ) {
+			dispatch( handleRenewMultiplePurchasesClick( [ purchase ], siteSlug ) );
+		} else {
+			page( managePurchase( siteSlug, String( purchaseId ) ) );
+		}
+	}, [ shouldBypass, purchase, dispatch, siteSlug, purchaseId ] );
+
+	if ( shouldBypass ) {
+		return null;
+	}
+
+	// Heading and section label only depend on actionType (from URL), safe before data loads
+	let heading: string;
+	let sectionLabel: string;
+
+	if ( actionType === 'renew' ) {
+		heading = translate( 'Renew subscriptions' ) as string;
+		sectionLabel = translate( 'Subscriptions' ) as string;
+	} else if ( actionType === 'cancel' ) {
+		heading = translate( 'Cancel subscriptions' ) as string;
+		sectionLabel = translate( 'Subscriptions' ) as string;
+	} else {
+		heading = translate( 'Remove upgrades' ) as string;
+		sectionLabel = translate( 'Upgrades' ) as string;
+	}
+
+	// Skeleton loading state while purchases load
+	if ( ! hasLoaded || ! purchase || ! purchases ) {
+		return (
+			<>
+				<QueryUserPurchases />
+				<div className="site-level-actions__back">
+					<HeaderCakeBack
+						icon="chevron-left"
+						href={ managePurchase( siteSlug, String( purchaseId ) ) }
+					/>
+				</div>
+				<FormattedHeader
+					className="site-level-actions__formatted-header"
+					headerText={ heading }
+					align="left"
+					brandFont
+				/>
+				<p className="site-level-actions__description">
+					<span className="site-level-actions__placeholder site-level-actions__placeholder--text" />
+				</p>
+				<div className="site-level-actions__inner-wrapper">
+					<div className="site-level-actions__left">
+						<Card className="site-level-actions__wrapper-card">
+							<h3 className="site-level-actions__section-title">{ sectionLabel }</h3>
+							<div className="site-level-actions__row">
+								<span className="site-level-actions__placeholder site-level-actions__placeholder--medium" />
+								<span className="site-level-actions__placeholder site-level-actions__placeholder--long" />
+							</div>
+							<div className="site-level-actions__row">
+								<span className="site-level-actions__placeholder site-level-actions__placeholder--medium" />
+								<span className="site-level-actions__placeholder site-level-actions__placeholder--long" />
+							</div>
+						</Card>
+					</div>
+					<div className="site-level-actions__right">
+						<PurchaseSiteHeader isPlaceholder />
+					</div>
+				</div>
+			</>
+		);
+	}
+
+	const handleToggle = ( id: number ) => {
+		if ( id === purchaseId ) {
+			return;
+		}
+		setSelectedIds( ( prev ) => {
+			const next = new Set( prev );
+			if ( next.has( id ) ) {
+				next.delete( id );
+			} else {
+				next.add( id );
+			}
+			return next;
+		} );
+	};
+
+	const handleContinue = () => {
+		const selectedPurchases = purchases.filter( ( p ) => selectedIds.has( p.id ) );
+		if ( actionType === 'renew' ) {
+			dispatch( handleRenewMultiplePurchasesClick( selectedPurchases, siteSlug ) );
+			return;
+		}
+		const intent = actionType;
+		const additionalIds = [ ...selectedIds ].filter( ( id ) => id !== purchaseId );
+		const baseUrl = cancelPurchase( siteSlug, String( purchaseId ) );
+		const params = new URLSearchParams( { intent } );
+		if ( additionalIds.length > 0 ) {
+			params.set( 'additionalPurchaseIds', additionalIds.join( ',' ) );
+		}
+		page( `${ baseUrl }?${ params.toString() }` );
+	};
+
+	// Copy variables by action type
+	const isRemove = actionType === 'remove';
+	const siteName = purchase.domain ?? siteSlug;
+	const productName = getName( purchase );
+
+	let buttonLabel: string;
+	let isDestructive = false;
+
+	if ( actionType === 'renew' ) {
+		buttonLabel = translate( 'Continue to checkout' ) as string;
+	} else if ( actionType === 'cancel' ) {
+		buttonLabel = translate( 'Continue to cancel' ) as string;
+		isDestructive = true;
+	} else {
+		buttonLabel = translate( 'Continue to remove' ) as string;
+		isDestructive = true;
+	}
+
+	let description: string;
+	if ( actionType === 'renew' ) {
+		description = translate(
+			'Your site %(siteName)s has other subscriptions. Select any you\u2019d like to renew along with %(productName)s.',
+			{ args: { siteName, productName } }
+		) as string;
+	} else if ( actionType === 'cancel' ) {
+		description = translate(
+			'Your site %(siteName)s has other subscriptions. Select any you\u2019d like to cancel along with %(productName)s.',
+			{ args: { siteName, productName } }
+		) as string;
+	} else {
+		description = translate(
+			'Your site %(siteName)s has other upgrades. Select any you\u2019d like to remove along with %(productName)s.',
+			{ args: { siteName, productName } }
+		) as string;
+	}
+
+	const getRenewalText = ( p: Purchase ) => {
+		if ( isRemove ) {
+			return translate( 'Expires on %(date)s', {
+				args: { date: moment( p.expiryDate ).format( 'LL' ) },
+			} );
+		}
+		return translate( 'Renews at %(price)s on %(date)s', {
+			args: {
+				price: p.priceText,
+				date: moment( p.renewDate || p.expiryDate ).format( 'LL' ),
+			},
+		} );
+	};
+
+	return (
+		<>
+			<QueryUserPurchases />
+			<div className="site-level-actions__back">
+				<HeaderCakeBack
+					icon="chevron-left"
+					href={ managePurchase( siteSlug, String( purchaseId ) ) }
+				/>
+			</div>
+			<FormattedHeader
+				className="site-level-actions__formatted-header"
+				headerText={ heading }
+				align="left"
+				brandFont
+			/>
+			<p className="site-level-actions__description">{ description }</p>
+			<div className="site-level-actions__inner-wrapper">
+				<div className="site-level-actions__left">
+					<Card className="site-level-actions__wrapper-card">
+						<h3 className="site-level-actions__section-title">{ sectionLabel }</h3>
+						{ purchases.map( ( p ) => (
+							<div
+								key={ p.id }
+								className={ clsx( 'site-level-actions__row', {
+									'is-selected': selectedIds.has( p.id ),
+								} ) }
+							>
+								<FormLabel className="site-level-actions__label">
+									<FormInputCheckbox
+										className="site-level-actions__checkbox"
+										checked={ selectedIds.has( p.id ) }
+										onChange={ () => handleToggle( p.id ) }
+										disabled={ p.id === purchaseId }
+									/>
+									<span className="site-level-actions__name">{ getName( p ) }</span>
+								</FormLabel>
+								<span className="site-level-actions__renewal-info">{ getRenewalText( p ) }</span>
+							</div>
+						) ) }
+						<div className="site-level-actions__button-row">
+							<Button primary scary={ isDestructive } onClick={ handleContinue }>
+								{ buttonLabel }
+							</Button>
+						</div>
+					</Card>
+				</div>
+				<div className="site-level-actions__right">
+					<PurchaseSiteHeader
+						siteId={ purchase.siteId }
+						name={ purchase.siteName }
+						purchase={ purchase }
+					/>
+				</div>
+			</div>
+		</>
+	);
+}

--- a/client/me/purchases/site-level-actions/style.scss
+++ b/client/me/purchases/site-level-actions/style.scss
@@ -1,0 +1,166 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+// Back link — match cancel-purchase spacing
+.site-level-actions__back .header-cake__back {
+	padding-block: 24px;
+	padding-inline: 0;
+	text-align: start;
+}
+
+// Title — match cancel-purchase spacing
+.site-level-actions__formatted-header.formatted-header {
+	margin-block: 16px 8px;
+	margin-inline: 0;
+}
+
+.site-level-actions__description {
+	margin-block-end: 24px;
+	font-size: $font-body-small;
+}
+
+// Two-column layout — match cancel-purchase grid (7fr content / 3fr site card)
+.site-level-actions__inner-wrapper {
+	display: flex;
+	flex-direction: column-reverse;
+	margin-block-end: 24px;
+
+	@include break-large {
+		display: grid;
+		grid-template-columns: 7fr 3fr;
+		gap: 32px;
+	}
+}
+
+// Hide site card on mobile — not needed at small widths
+.site-level-actions__right {
+	display: none;
+
+	@include break-large {
+		display: block;
+	}
+}
+
+.site-level-actions__right .purchases-site__header.card {
+	background: var(--studio-gray-0);
+	border-radius: 2px;
+}
+
+.site-level-actions__wrapper-card {
+	padding: 0;
+}
+
+// Section title — simple bold label inside the card
+.site-level-actions__section-title {
+	font-size: $font-body-small;
+	font-weight: 600;
+	color: var(--color-text);
+	margin: 0;
+	padding-block: 0 16px;
+	padding-inline: 0;
+	border-block-end: 1px solid var(--color-border-subtle);
+}
+
+// Purchase row — checkbox + name on the left, renewal info on the right
+// On mobile: wraps so renewal info drops below, indented past the checkbox
+.site-level-actions__row {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	padding: 16px;
+	border-block-end: 1px solid var(--color-border-subtle);
+
+	&.is-selected {
+		background-color: var(--studio-blue-5);
+	}
+
+	&:last-of-type {
+		border-block-end: none;
+	}
+}
+
+.site-level-actions__label.form-label {
+	display: flex;
+	align-items: center;
+	flex: 1 1 100%;
+	gap: 8px;
+	margin-block-end: 0;
+	font-weight: normal;
+	cursor: pointer;
+
+	@include break-large {
+		flex: 1;
+	}
+
+	.site-level-actions__checkbox {
+		margin: 0;
+	}
+
+	.site-level-actions__name {
+		font-size: $font-body;
+		margin-inline-start: 0;
+		font-weight: 500;
+	}
+}
+
+.site-level-actions__renewal-info {
+	font-size: $font-body-small;
+	color: var(--color-text-subtle);
+	margin-inline-start: 24px;
+	margin-block-start: 4px;
+
+	@include break-large {
+		white-space: nowrap;
+		margin-inline-start: 16px;
+		margin-block-start: 0;
+	}
+}
+
+.site-level-actions__button-row {
+	padding-block-start: 24px;
+}
+
+// Skeleton loading placeholders
+.site-level-actions__placeholder {
+	display: block;
+	height: 14px;
+	background-color: var(--color-neutral-10);
+	border-radius: 2px;
+	animation: loading-pulse 1.6s ease-in-out infinite;
+}
+
+.site-level-actions__placeholder--text {
+	width: 70%;
+}
+
+.site-level-actions__placeholder--medium {
+	width: 100%;
+
+	@include break-large {
+		width: 160px;
+	}
+}
+
+.site-level-actions__placeholder--long {
+	width: 200px;
+	margin-block-start: 4px;
+
+	@include break-large {
+		margin-inline-start: auto;
+		margin-block-start: 0;
+	}
+}
+
+@keyframes loading-pulse {
+	0% {
+		opacity: 1;
+	}
+
+	50% {
+		opacity: 0.5;
+	}
+
+	100% {
+		opacity: 1;
+	}
+}


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/RSM-490

## Proposed Changes
This PR adds the basic plumbing to offer group renewals, cancelations, and removals. It sets up the interstitial screen and routing in Calypso.  Here's how the interstitial looks in Calypso:

<img width="1838" height="1196" alt="Screenshot 2026-05-07 at 9 00 12 AM" src="https://github.com/user-attachments/assets/b1d12444-3555-48cf-b85c-6f31c1616cb5" />

Here are the specifics of what's been done:
- Add a site-level action interstitial page at `/me/purchases/:site/:purchaseId/site-level-actions`
- When a user initiates cancel, remove, or renew on a purchase, and the site has other purchases, this interstitial lets them batch-select additional products to include in the action
- Skeleton loading state while purchases load, bypass logic when the feature flag is off or site has a single purchase
- Two-column layout matching the existing cancel-purchase page grid

Up next:

1. Wire cancel/remove buttons through the interstitial + cancel flow multi-product support (additionalPurchaseIds query param, multi-product confirmation copy, sequential mutations). Stacked on this branch.                                                              
2. Add the dashboard interstitial + routing (new surface, TanStack Query).        
3. Wire the new dashboard's cancel/remove buttons through the interstitial.

## Why are these changes being made?

Users often cancel a plan but forget about associated domains or other subscriptions. They get charged later and file support tickets. This interstitial surfaces all site purchases at the decision point, letting users batch actions and avoid surprise renewals.

Behind the `purchases/split-cancel-remove` feature flag.

## Testing Instructions

1. Enable the `purchases/split-cancel-remove` flag
2. Navigate to a purchase on a site that has multiple purchases
4. Visit `/me/purchases/{site}/{purchaseId}/site-level-actions?action=renew` — should show the interstitial with all site purchases, originating product pre-checked and disabled
5. Visit with `?action=cancel` and `?action=remove` — should show cancel/remove copy variants with scary button styling
6. On a site with only one purchase, the interstitial should bypass and redirect to the normal flow
7. With the flag off, the interstitial should bypass and redirect to the normal flow
8. Test mobile responsiveness — site card hides on small screens, purchase rows wrap properly

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?