### PR TITLE
Theme Showcase: SSR modern logged-out cards; stabilize e2e theme-signup tests

### DIFF
--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -1,14 +1,22 @@
+import { isEnabled } from '@automattic/calypso-config';
 import debugFactory from 'debug';
 import { logServerEvent } from 'calypso/lib/analytics/statsd-utils';
 import trackScrollPage from 'calypso/lib/track-scroll-page';
 import wpcom from 'calypso/lib/wp';
 import performanceMark from 'calypso/server/lib/performance-mark';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { THEME_FILTERS_ADD } from 'calypso/state/themes/action-types';
 import { requestThemes } from 'calypso/state/themes/actions';
 import { DEFAULT_THEME_QUERY } from 'calypso/state/themes/constants';
 import { getThemeFilters, getThemesForQuery } from 'calypso/state/themes/selectors';
 import { getAnalyticsData } from './helpers';
 import LoggedOutComponent from './logged-out';
+import {
+	FAVORITES_QUERY,
+	FRESH_QUERY,
+	PARTNER_QUERY,
+} from './sections-modern/recommended-sections';
+import { buildThemesSelectionQuery } from './themes-selection';
 
 const debug = debugFactory( 'calypso:themes' );
 
@@ -79,6 +87,57 @@ export function fetchThemeData( context, next ) {
 	context.store
 		.dispatch( requestThemes( siteId, query, context.lang ) )
 		.then( next )
+		.catch( next );
+}
+
+// SSR pre-fetch for the modern logged-out showcase. Without this, cards only appear
+// after the client-side fetch resolves; the legacy fetchThemeData uses a different
+// query shape than what the modern components read, so its result is unused here.
+export function fetchModernShowcaseData( context, next ) {
+	if ( context.cachedMarkup ) {
+		debug( 'Skipping modern showcase data fetch (cached markup)' );
+		return next();
+	}
+
+	if (
+		! context.isServerSide ||
+		! isEnabled( 'themes/showcase-modern' ) ||
+		isUserLoggedIn( context.store.getState() )
+	) {
+		return next();
+	}
+
+	performanceMark( context, 'fetchModernShowcaseData' );
+
+	const { category, tier, filter, vertical, view } = context.params;
+	const search = context.query.s;
+	const isShowcaseRoot = ! category && ! tier && ! filter && ! vertical && ! view && ! search;
+
+	const queries = isShowcaseRoot
+		? [ FAVORITES_QUERY, FRESH_QUERY, PARTNER_QUERY ]
+		: [
+				buildThemesSelectionQuery( {
+					search: search || '',
+					page: 1,
+					tier: tier || '',
+					filter: filter || '',
+					vertical: vertical || '',
+					tabFilter: category || 'recommended',
+				} ),
+		  ];
+
+	return Promise.all(
+		queries.map( ( query ) =>
+			context.store.dispatch( requestThemes( 'wpcom', query, context.lang ) )
+		)
+	)
+		.then( () => {
+			logServerEvent( 'themes', {
+				name: `ssr.modern_showcase_fetch.${ isShowcaseRoot ? 'root' : 'tier' }`,
+				type: 'counting',
+			} );
+			next();
+		} )
 		.catch( next );
 }
 

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -3,6 +3,7 @@ import { makeLayout, ssrSetupLocale } from 'calypso/controller';
 import { setHrefLangLinks, setLocalizedCanonicalUrl } from 'calypso/controller/localized-links';
 import { setupPreferences } from 'calypso/controller/preferences';
 import {
+	fetchModernShowcaseData,
 	fetchThemeData,
 	fetchThemeFilters,
 	redirectSearchAndType,
@@ -39,6 +40,7 @@ export default function ( router ) {
 		validateVertical,
 		validateFilters,
 		fetchThemeData,
+		fetchModernShowcaseData,
 		setHrefLangLinks,
 		setLocalizedCanonicalUrl,
 		renderThemes,
@@ -64,5 +66,12 @@ export default function ( router ) {
 			redirectToThemeDetails( res.redirect, site, theme, section, next )
 	);
 	// The following route definition is needed so direct hits on `/themes/<mysite>` don't result in a 404.
-	router( '/themes/*', setupPreferences, fetchThemeData, renderThemes, makeLayout );
+	router(
+		'/themes/*',
+		setupPreferences,
+		fetchThemeData,
+		fetchModernShowcaseData,
+		renderThemes,
+		makeLayout
+	);
 }

--- a/client/my-sites/themes/sections-modern/recommended-sections.tsx
+++ b/client/my-sites/themes/sections-modern/recommended-sections.tsx
@@ -6,7 +6,7 @@ import DIFMBanner from '../banners-modern/difm-banner';
 import PlanUpgradeBanner from '../banners-modern/plan-upgrade-banner';
 import ThemeSection from './theme-section';
 
-const FAVORITES_QUERY: ThemesQuery = {
+export const FAVORITES_QUERY: ThemesQuery = {
 	collection: 'recommended',
 	number: 6,
 	tier: '',
@@ -15,7 +15,7 @@ const FAVORITES_QUERY: ThemesQuery = {
 	page: 1,
 };
 
-const FRESH_QUERY: ThemesQuery = {
+export const FRESH_QUERY: ThemesQuery = {
 	number: 6,
 	tier: '',
 	filter: '',
@@ -24,7 +24,7 @@ const FRESH_QUERY: ThemesQuery = {
 	sort: 'date',
 };
 
-const PARTNER_QUERY: ThemesQuery = {
+export const PARTNER_QUERY: ThemesQuery = {
 	collection: 'recommended',
 	number: 6,
 	tier: 'marketplace',

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -315,6 +315,32 @@ function bindGetThemeTierForTheme( state ) {
 	return ( themeId ) => getThemeTierForTheme( state, themeId );
 }
 
+// Exported so SSR pre-fetch dispatches the exact query shape <ThemesSelection> reads,
+// avoiding cache-key drift between server fetch and client selector. number: 2000 for
+// non-paginating Jetpack endpoints.
+export function buildThemesSelectionQuery( {
+	search = '',
+	page = 1,
+	tier = '',
+	filter = '',
+	vertical = '',
+	hiddenFilters = [],
+	tabFilter,
+	sourceSiteId = 'wpcom',
+	premiumThemesEnabled = true,
+} = {} ) {
+	const number = ! [ 'wpcom', 'wporg' ].includes( sourceSiteId ) ? 2000 : 100;
+	return {
+		search,
+		page,
+		tier: premiumThemesEnabled ? tier : 'free',
+		filter: compact( [ filter, vertical ] ).concat( hiddenFilters ).join( ',' ),
+		number,
+		...( tabFilter === 'recommended' && { collection: 'recommended' } ),
+		...( tabFilter === 'all' && { sort: 'date' } ),
+	};
+}
+
 // Exporting this for use in customized themes lists (recommended-themes.jsx, etc.)
 // We do not want pagination triggered in that use of the component.
 export const ConnectedThemesSelection = connect(
@@ -333,20 +359,17 @@ export const ConnectedThemesSelection = connect(
 			sourceSiteId = siteId ? siteId : 'wpcom';
 		}
 
-		// number calculation is just a hack for Jetpack sites. Jetpack themes endpoint does not paginate the
-		// results and sends all of the themes at once. QueryManager is not expecting such behaviour
-		// and we ended up loosing all of the themes above number 20. Real solution will be pagination on
-		// Jetpack themes endpoint.
-		const number = ! [ 'wpcom', 'wporg' ].includes( sourceSiteId ) ? 2000 : 100;
-		const query = {
+		const query = buildThemesSelectionQuery( {
 			search,
 			page,
-			tier: premiumThemesEnabled ? tier : 'free',
-			filter: compact( [ filter, vertical ] ).concat( hiddenFilters ).join( ',' ),
-			number,
-			...( tabFilter === 'recommended' && { collection: 'recommended' } ),
-			...( tabFilter === 'all' && { sort: 'date' } ),
-		};
+			tier,
+			filter,
+			vertical,
+			hiddenFilters,
+			tabFilter,
+			sourceSiteId,
+			premiumThemesEnabled,
+		} );
 
 		const themes = getThemesForQueryIgnoringPage( state, sourceSiteId, query );
 

--- a/packages/calypso-e2e/src/lib/flows/lohp-theme-signup-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/lohp-theme-signup-flow.ts
@@ -50,19 +50,6 @@ export class LOHPThemeSignupFlow {
 	}
 
 	/**
-	 * Navigates to the Calypso Get Started link for the selected theme.
-	 * @returns {Promise<string>} The theme slug of the selected theme.
-	 */
-	async visitCalypsoGetStartedLinkForTheme(): Promise< string > {
-		const pageThemeDetails = new ThemesDetailPage( this.page );
-		const calypsoGetStartedLink = await pageThemeDetails.calypsoGetStartedLink();
-		const themeSlug =
-			pageThemeDetails.getThemeSlugFromCalypsoGetStartedLink( calypsoGetStartedLink );
-		await this.page.goto( calypsoGetStartedLink );
-		return themeSlug;
-	}
-
-	/**
 	 * Cancels the plan purchase during the flow.
 	 * @returns {Promise<void>}
 	 */

--- a/packages/calypso-e2e/src/lib/pages/logged-out-themes-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/logged-out-themes-page.ts
@@ -18,10 +18,14 @@ export class LoggedOutThemesPage {
 	/**
 	 * Filters the themes by the given filter.
 	 *
+	 * Selecting a tier triggers a client-side navigation that re-renders the showcase.
+	 * Wait for cards to settle after that transition so callers can click them safely.
+	 *
 	 * @param {string} filter - The filter to apply.
 	 */
 	async filterBy( filter: string ) {
 		await this.page.getByRole( 'combobox', { name: 'View' } ).click();
 		await this.page.getByRole( 'option', { name: filter } ).click();
+		await this.firstThemeCard.waitFor( { state: 'visible', timeout: 30_000 } );
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/logged-out-themes-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/logged-out-themes-page.ts
@@ -16,6 +16,36 @@ export class LoggedOutThemesPage {
 	}
 
 	/**
+	 * Clicks the "Get started" overlay button on the first theme card matching the
+	 * optional tier filter, navigating straight to the signup flow and skipping the
+	 * theme details page. Returns the theme slug parsed from the link's href.
+	 *
+	 * @param {Object} [options]
+	 * @param {string} [options.tier] - Theme tier slug (e.g. 'premium', 'free') to filter by.
+	 */
+	async selectThemeForSignup( { tier }: { tier?: string } = {} ): Promise< string > {
+		const card = (
+			tier
+				? this.page.locator( `[data-e2e-theme]:has(.theme-tier-badge--${ tier })` )
+				: this.page.locator( '[data-e2e-theme]' )
+		).first();
+		await card.waitFor( { state: 'visible', timeout: 30_000 } );
+
+		const getStartedLink = card.getByRole( 'link', { name: 'Get started' } );
+		const href = await getStartedLink.getAttribute( 'href' );
+		if ( ! href ) {
+			throw new Error( '"Get started" link is missing an href on the theme card' );
+		}
+		const themeSlug = new URL( href, this.page.url() ).searchParams.get( 'theme' );
+		if ( ! themeSlug ) {
+			throw new Error( `Theme slug not found in "Get started" href: ${ href }` );
+		}
+
+		await getStartedLink.click();
+		return themeSlug;
+	}
+
+	/**
 	 * Filters the themes by the given filter.
 	 *
 	 * Selecting a tier triggers a client-side navigation that re-renders the showcase.

--- a/test/e2e/specs/onboarding/signup__with-theme-LOHP.spec.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-LOHP.spec.ts
@@ -50,9 +50,7 @@ test.describe(
 				await flowLOHPThemeSignup.loggedOutHomePage.exploreThemesLink.click();
 
 				await flowLOHPThemeSignup.loggedOutThemesPage.filterBy( 'Free' );
-				await flowLOHPThemeSignup.loggedOutThemesPage.firstThemeCard.click();
-
-				themeSlug = await flowLOHPThemeSignup.visitCalypsoGetStartedLinkForTheme();
+				themeSlug = await flowLOHPThemeSignup.loggedOutThemesPage.selectThemeForSignup();
 			} );
 
 			await test.step( 'Then I see the "Create your account" page', async function () {

--- a/test/e2e/specs/onboarding/signup__with-theme-premium.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-premium.ts
@@ -16,8 +16,8 @@ import {
 	MeSidebarComponent,
 	NoticeComponent,
 	PurchasesPage,
-	ThemesDetailPage,
 	ThemesPage,
+	LoggedOutThemesPage,
 	cancelAtomicPurchaseFlow,
 	DomainSearchComponent,
 } from '@automattic/calypso-e2e';
@@ -60,24 +60,10 @@ describe( 'Lifecyle: Premium theme signup, onboard, launch and cancel subscripti
 			await themesPage.visitShowcase();
 		} );
 
-		it( 'Selects a Premium theme', async function () {
-			// Theme cards load asynchronously after hydration in the modern showcase, so wait
-			// generously for the first premium card to appear before clicking.
-			const premiumCard = page
-				.locator( 'div.theme-card:has(div.theme-tier-badge--premium)' )
-				.first();
-			await premiumCard.waitFor( { state: 'visible', timeout: 30_000 } );
-			await premiumCard.click();
-		} );
-
-		it( 'Navigate to Signup page', async function () {
-			const themeDetailsPage = new ThemesDetailPage( page );
-
-			const pageMatch = new URL( page.url() ).pathname.match( 'theme/(.*)/?' );
-
-			themeSlug = pageMatch?.[ 1 ] || null;
-
-			await themeDetailsPage.pickThisDesign();
+		it( 'Selects a Premium theme and starts signup', async function () {
+			themeSlug = await new LoggedOutThemesPage( page ).selectThemeForSignup( {
+				tier: 'premium',
+			} );
 		} );
 
 		it( 'Sign up as new user', async function () {

--- a/test/e2e/specs/onboarding/signup__with-theme-premium.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-premium.ts
@@ -61,7 +61,13 @@ describe( 'Lifecyle: Premium theme signup, onboard, launch and cancel subscripti
 		} );
 
 		it( 'Selects a Premium theme', async function () {
-			await page.locator( 'div.theme-card:has(div.theme-tier-badge--premium)' ).first().click();
+			// Theme cards load asynchronously after hydration in the modern showcase, so wait
+			// generously for the first premium card to appear before clicking.
+			const premiumCard = page
+				.locator( 'div.theme-card:has(div.theme-tier-badge--premium)' )
+				.first();
+			await premiumCard.waitFor( { state: 'visible', timeout: 30_000 } );
+			await premiumCard.click();
 		} );
 
 		it( 'Navigate to Signup page', async function () {


### PR DESCRIPTION
Fixes DOTCOM-17052

## Proposed Changes

* Add `fetchModernShowcaseData` SSR middleware that pre-fetches the queries the modern logged-out showcase reads on hydration. Showcase root fans out the three `RecommendedSections` queries (FAVORITES / FRESH / PARTNER); tier and category paths dispatch one `ThemesSelection`-shaped query.
* Extract `buildThemesSelectionQuery` from `themes-selection.jsx` so the SSR middleware and the `connect` mapper share a single query shape, avoiding cache-key drift.
* Wait for the first card in `LoggedOutThemesPage.filterBy` after the tier-select option click; the option click triggers a client-side navigation that re-renders the showcase, so callers need a settle point before clicking.
* Add `LoggedOutThemesPage.selectThemeForSignup({ tier? })` — reads the overlay "Get started" link's `href`, parses the theme slug, and clicks through to signup, skipping the theme details page. Both `signup__with-theme-LOHP` and `signup__with-theme-premium` use it; drops the now-unused `LOHPThemeSignupFlow.visitCalypsoGetStartedLinkForTheme`.

## Why are these changes being made?

The "Theme Showcase: Launch modern logged-out redesign" rollout (#109601 plus follow-ups) ships a layout where structural elements (hero, filter bar, section headings, banners, FAQ) render in SSR but theme cards arrive only after a client-side fetch. On `/themes` the modern `RecommendedSections` issues three queries that don't match anything `fetchThemeData` pre-fetches; on `/themes/<tier>` the query shape `ThemesSelection` reads (`number: 100`, conditional `collection` / `sort`) drifted from `fetchThemeData`'s shape (`number: 20`, no collection / sort), so its result is unused. Net effect: 0 theme cards in initial HTML on every logged-out showcase route, and the cards-load-after-hydration race made `[data-e2e-theme]`-based e2e tests flaky on CI.

The middleware fixes the SSR side for users (better LCP/CLS, SEO, perceived performance) and as a side effect makes the e2e tests stable on most paths. The wait fix keeps the e2e tests correct for paths that still defer rendering (the LOHP `?ref=…` entry bypasses SSR via `loggedOut`'s query-param gate, which I left alone — out of scope for this PR).

Independent of SSR, the modern card now renders a hover/focus overlay row with "Preview demo" and "Get started" buttons centered over the image. Those buttons sit on top of the underlying image link and capture clicks at the card's geometric center, so a plain `[data-e2e-theme]` click no longer hits the image-link target — Playwright's actionability check sees the overlay's button wrapper as topmost. `selectThemeForSignup` sidesteps the geometry by reading the "Get started" link's `href` directly and clicking the link, which is the same signup destination the prior two-step (card → theme details → Get Started) flow reached.

## Testing Instructions

Local SSR smoke test against `node build/server.js` with the change:

| Route | Cards in SSR before | Cards in SSR after |
|---|---|---|
| `/themes` | 0 | 18 (6 favorites + 6 fresh + 6 partner) |
| `/themes/free` | 0 | 87 |
| `/themes/recommended/premium` | 0 | 64 |

To reproduce:

1. `yarn build-server`
2. `PORT=3001 NODE_OPTIONS='--max-old-space-size=12288' BROWSERSLIST_ENV=evergreen node build/server.js`
3. `curl -s 'http://calypso.localhost:3001/themes' -H 'Host: calypso.localhost' | grep -oE 'data-e2e-theme="[^"]+"' | wc -l`
4. Repeat for `/themes/free`, `/themes/recommended/premium`.

E2E:

* Run `signup__with-theme-LOHP.spec.ts` and `signup__with-theme-premium.ts` — both should pass through theme selection into signup without flaking on the theme cards.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?