### PR TITLE
Charts: patch tooltip portal relocator to a no-op

### DIFF
--- a/.yarn/patches/@automattic-charts-npm-1.3.0-e188dc5003.patch
+++ b/.yarn/patches/@automattic-charts-npm-1.3.0-e188dc5003.patch
@@ -1,0 +1,132 @@
+diff --git a/dist/index.cjs b/dist/index.cjs
+index abe87c2e4f20462d930d6e4969a037ac4480d05c..b6be2ce0861b6ce49e84716ba32ea61b10ca9c9c 100644
+--- a/dist/index.cjs
++++ b/dist/index.cjs
+@@ -536,60 +536,7 @@ function uninstallRemoveChildPatch() {
+   origRemoveChild = null;
+   patchedRemoveChild = null;
+ }
+-function useTooltipPortalRelocator(containerRef) {
+-  _react.useEffect.call(void 0, () => {
+-    const container = _optionalChain([containerRef, 'optionalAccess', _5 => _5.current]);
+-    if (!container) {
+-      return;
+-    }
+-    const instanceNodes = /* @__PURE__ */ new Set();
+-    const relocateNode = (node2) => {
+-      if (!isVisxPortalNode(node2)) {
+-        return;
+-      }
+-      node2.style.opacity = "0";
+-      node2.classList.add(use_tooltip_portal_relocator_module_default.relocatedPortal);
+-      const { activeElement } = node2.ownerDocument;
+-      const focusedElement = activeElement instanceof HTMLElement && node2.contains(activeElement) ? activeElement : null;
+-      container.insertBefore(node2, container.firstChild);
+-      relocatedNodes.add(node2);
+-      instanceNodes.add(node2);
+-      if (focusedElement) {
+-        focusedElement.focus();
+-      }
+-      requestAnimationFrame(() => {
+-        requestAnimationFrame(() => {
+-          node2.style.opacity = "";
+-        });
+-      });
+-    };
+-    installRemoveChildPatch();
+-    for (const child of Array.from(document.body.children)) {
+-      relocateNode(child);
+-    }
+-    const observer = new MutationObserver((mutations) => {
+-      for (const mutation of mutations) {
+-        for (const node2 of mutation.addedNodes) {
+-          relocateNode(node2);
+-        }
+-      }
+-    });
+-    observer.observe(document.body, { childList: true });
+-    return () => {
+-      observer.disconnect();
+-      for (const node2 of instanceNodes) {
+-        if (node2 instanceof HTMLElement) {
+-          node2.classList.remove(use_tooltip_portal_relocator_module_default.relocatedPortal);
+-        }
+-        if (node2.parentNode === container) {
+-          document.body.appendChild(node2);
+-        }
+-        relocatedNodes.delete(node2);
+-      }
+-      instanceNodes.clear();
+-      uninstallRemoveChildPatch();
+-    };
+-  }, [containerRef]);
++function useTooltipPortalRelocator(_containerRef) {
+ }
+ 
+ // src/utils/create-composition.ts
+diff --git a/dist/index.js b/dist/index.js
+index 1dc337a2a73ea19ee81b5821ced7ec6155942756..3bb358ce93d50ea6c3cf113fb0f71f33841a21a0 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -536,60 +536,7 @@ function uninstallRemoveChildPatch() {
+   origRemoveChild = null;
+   patchedRemoveChild = null;
+ }
+-function useTooltipPortalRelocator(containerRef) {
+-  useEffect(() => {
+-    const container = containerRef?.current;
+-    if (!container) {
+-      return;
+-    }
+-    const instanceNodes = /* @__PURE__ */ new Set();
+-    const relocateNode = (node2) => {
+-      if (!isVisxPortalNode(node2)) {
+-        return;
+-      }
+-      node2.style.opacity = "0";
+-      node2.classList.add(use_tooltip_portal_relocator_module_default.relocatedPortal);
+-      const { activeElement } = node2.ownerDocument;
+-      const focusedElement = activeElement instanceof HTMLElement && node2.contains(activeElement) ? activeElement : null;
+-      container.insertBefore(node2, container.firstChild);
+-      relocatedNodes.add(node2);
+-      instanceNodes.add(node2);
+-      if (focusedElement) {
+-        focusedElement.focus();
+-      }
+-      requestAnimationFrame(() => {
+-        requestAnimationFrame(() => {
+-          node2.style.opacity = "";
+-        });
+-      });
+-    };
+-    installRemoveChildPatch();
+-    for (const child of Array.from(document.body.children)) {
+-      relocateNode(child);
+-    }
+-    const observer = new MutationObserver((mutations) => {
+-      for (const mutation of mutations) {
+-        for (const node2 of mutation.addedNodes) {
+-          relocateNode(node2);
+-        }
+-      }
+-    });
+-    observer.observe(document.body, { childList: true });
+-    return () => {
+-      observer.disconnect();
+-      for (const node2 of instanceNodes) {
+-        if (node2 instanceof HTMLElement) {
+-          node2.classList.remove(use_tooltip_portal_relocator_module_default.relocatedPortal);
+-        }
+-        if (node2.parentNode === container) {
+-          document.body.appendChild(node2);
+-        }
+-        relocatedNodes.delete(node2);
+-      }
+-      instanceNodes.clear();
+-      uninstallRemoveChildPatch();
+-    };
+-  }, [containerRef]);
++function useTooltipPortalRelocator(_containerRef) {
+ }
+ 
+ // src/utils/create-composition.ts

--- a/package.json
+++ b/package.json
@@ -433,7 +433,8 @@
 		"@wordpress/widgets": "4.23.0",
 		"@wordpress/wordcount": "4.23.0",
 		"@base-ui/react@npm:^1.2.0": "patch:@base-ui/react@npm%3A1.4.1#~/.yarn/patches/@base-ui-react-npm-1.4.1-fbb7347502.patch",
-		"@base-ui/react@npm:^1.4.0": "patch:@base-ui/react@npm%3A1.4.1#~/.yarn/patches/@base-ui-react-npm-1.4.1-fbb7347502.patch"
+		"@base-ui/react@npm:^1.4.0": "patch:@base-ui/react@npm%3A1.4.1#~/.yarn/patches/@base-ui-react-npm-1.4.1-fbb7347502.patch",
+		"@automattic/charts@npm:^1.3.0": "patch:@automattic/charts@npm%3A1.3.0#~/.yarn/patches/@automattic-charts-npm-1.3.0-e188dc5003.patch"
 	},
 	"packageManager": "yarn@4.0.2",
 	"dependenciesMeta": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -773,6 +773,47 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@automattic/charts@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@automattic/charts@npm:1.3.0"
+  dependencies:
+    "@automattic/number-formatters": "npm:^1.1.7"
+    "@babel/runtime": "npm:7.29.2"
+    "@react-spring/web": "npm:9.7.5"
+    "@visx/annotation": "npm:^3.12.0"
+    "@visx/axis": "npm:^3.12.0"
+    "@visx/curve": "npm:^3.12.0"
+    "@visx/event": "npm:^3.12.0"
+    "@visx/gradient": "npm:^3.12.0"
+    "@visx/grid": "npm:^3.12.0"
+    "@visx/group": "npm:^3.12.0"
+    "@visx/legend": "npm:^3.12.0"
+    "@visx/pattern": "npm:^3.12.0"
+    "@visx/responsive": "npm:^3.12.0"
+    "@visx/scale": "npm:^3.12.0"
+    "@visx/shape": "npm:^3.12.0"
+    "@visx/text": "npm:^3.12.0"
+    "@visx/tooltip": "npm:^3.12.0"
+    "@visx/vendor": "npm:^3.12.0"
+    "@visx/xychart": "npm:^3.12.0"
+    "@wordpress/i18n": "npm:^6.0.0"
+    "@wordpress/icons": "npm:^12.0.0"
+    "@wordpress/theme": "npm:0.11.0"
+    "@wordpress/ui": "npm:0.11.0"
+    clsx: "npm:2.1.1"
+    date-fns: "npm:^4.1.0"
+    deepmerge: "npm:4.3.1"
+    dompurify: "npm:^3.3.3"
+    fast-deep-equal: "npm:3.1.3"
+    react-google-charts: "npm:^5.2.1"
+    tslib: "npm:2.8.1"
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+  checksum: 3723844a0ae9ae0c395f05e05e645a342ed25e3da395ce6d2610fa9be4f8f9e5aa27c73529050e4cb5b5bb373ecbc7d8acde72361cfe9133f7ba9b66acda4cbb
+  languageName: node
+  linkType: hard
+
 "@automattic/charts@npm:>=0.58.0 <1.0.0":
   version: 0.58.0
   resolution: "@automattic/charts@npm:0.58.0"
@@ -813,9 +854,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@automattic/charts@npm:^1.3.0":
+"@automattic/charts@patch:@automattic/charts@npm%3A1.3.0#~/.yarn/patches/@automattic-charts-npm-1.3.0-e188dc5003.patch":
   version: 1.3.0
-  resolution: "@automattic/charts@npm:1.3.0"
+  resolution: "@automattic/charts@patch:@automattic/charts@npm%3A1.3.0#~/.yarn/patches/@automattic-charts-npm-1.3.0-e188dc5003.patch::version=1.3.0&hash=7d22bf"
   dependencies:
     "@automattic/number-formatters": "npm:^1.1.7"
     "@babel/runtime": "npm:7.29.2"
@@ -850,7 +891,7 @@ __metadata:
   peerDependencies:
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
-  checksum: 3723844a0ae9ae0c395f05e05e645a342ed25e3da395ce6d2610fa9be4f8f9e5aa27c73529050e4cb5b5bb373ecbc7d8acde72361cfe9133f7ba9b66acda4cbb
+  checksum: ff4b67383058fbf9e35c7c9cb0e2d8fe1770b068db96bf521728f9223d58fd65d60c61ffe55d3304410349325a6c44bb784156f4839ed3cdb55ece87a1c4dabd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Part of #

## Proposed Changes

* `yarn patch` for `@automattic/charts@1.3.0` that turns `useTooltipPortalRelocator` into a no-op (empty function body).
* Resolution wired in the root `package.json`, same pattern as the `@base-ui/react` patch from #110426.

## Why are these changes being made?

After upgrading to `@automattic/charts@1.3.0` in #110426, hovering a chart on the dashboard monitoring page works fine at the top of the page but drifts off the line as you scroll down. The amount of drift equals the scroll offset.

The package's `useTooltipPortalRelocator` hook moves visx's tooltip portals into the chart wrapper and pins them with `position: fixed` (intended to fix z-index conflicts with sticky headers). visx still positions glyphs and tooltips using **document coordinates** (`window.scrollX/scrollY` added to the chart's bounding rect). Once the parent is `position: fixed` (viewport-anchored), those document-coord children paint at the wrong viewport position — off by exactly the scroll offset.

Disabling the relocator restores baseline visx behavior: tooltip portals stay at `document.body` where the position math works correctly. The dashboard already styles `.visx-tooltip` globally in `client/dashboard/app/style.scss`, so the relocator's z-index purpose is already covered by other means for our consumer.

Upstream fix needed in `@automattic/charts` (the relocator should become opt-in, default off); this patch can be removed once that ships.

## Testing Instructions

1. `yarn install` and `yarn start-dashboard`.
2. Open `/sites/<slug>/monitoring` and `/sites/<slug>/performance/backend`.
3. Scroll each page so the chart is partially out of view.
4. Hover the chart. The colored circles and tooltip should stay locked to the line at any scroll offset.
5. Switch monitoring time ranges (mounts/unmounts the chart) and confirm no console errors.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?