### PR TITLE
fix(magic-login): match centralized TOS link color (DOTCOM-13796)

### DIFF
--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -326,6 +326,23 @@
 			white-space: pre;
 		}
 	}
+
+	// Match the centralized Login TOS treatment (--studio-gray-50, the same
+	// color .wp-login__one-login-layout-tos provides to the Login screen).
+	// The .connect-screen-consent-text class also rides on this element via
+	// <ConsentText>, and its `a { color: var(--studio-gray-70) }` rule beats
+	// `color: inherit` at equal specificity. Chaining both classes here
+	// raises specificity (0,3,1 > 0,2,1) so we win cleanly without touching
+	// connect-screen styles used by Jetpack Connect / invite flows.
+	&.connect-screen-consent-text a {
+		color: var( --studio-gray-50, #646970 );
+
+		&:hover,
+		&:focus,
+		&:focus-visible {
+			color: var( --studio-gray-50, #646970 );
+		}
+	}
 }
 
 .magic-login__a4a-logo {

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -334,6 +334,12 @@
 	// `color: inherit` at equal specificity. Chaining both classes here
 	// raises specificity (0,2,1 > 0,1,1) so we win cleanly without touching
 	// connect-screen styles used by Jetpack Connect / invite flows.
+	//
+	// Co-residency contract: this rule depends on both classes being applied
+	// to the same element. The current callsite is request-login-email-form's
+	// `<ConsentText className="magic-login__tos wp-login__one-login-layout-tos">`.
+	// If a future refactor drops one of those classes, this rule silently
+	// no-ops and the color regresses to the consent-text default (gray-70).
 	&.connect-screen-consent-text a {
 		color: var( --studio-gray-50, #646970 );
 

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -332,7 +332,7 @@
 	// The .connect-screen-consent-text class also rides on this element via
 	// <ConsentText>, and its `a { color: var(--studio-gray-70) }` rule beats
 	// `color: inherit` at equal specificity. Chaining both classes here
-	// raises specificity (0,3,1 > 0,2,1) so we win cleanly without touching
+	// raises specificity (0,2,1 > 0,1,1) so we win cleanly without touching
 	// connect-screen styles used by Jetpack Connect / invite flows.
 	&.connect-screen-consent-text a {
 		color: var( --studio-gray-50, #646970 );


### PR DESCRIPTION
## What

Fixes [DOTCOM-13796](https://linear.app/a8c/issue/DOTCOM-13796/login-magic-login-update-footer-and-subheader-text-and-links-to-match) — Magic Login TOS link was rendering in `--studio-gray-80` (and `--studio-gray-70` on hover / focus) instead of the `--studio-gray-50` used by the Login screen's centralized TOS treatment.

## Why

The wrapper element on Magic Login carries three classes — `connect-screen-consent-text` (added by `<ConsentText>`), `magic-login__tos`, and `wp-login__one-login-layout-tos`.

The centralized `.wp-login__one-login-layout-tos a { color: inherit }` rule loses to `.connect-screen-consent-text a { color: var(--studio-gray-70) }` at equal specificity, because an explicit color value beats `inherit`. So the centralized class is present but loses the cascade.

## How

Chain `.magic-login__tos.connect-screen-consent-text a` to raise the override's specificity to `(0,3,1)` versus the connect-screen rule's `(0,2,1)`. The magic-login override wins cleanly without modifying `connect-screen-consent-text` styles, which are also used by Jetpack Connect and the invite flows.

Same color applied for `:hover`, `:focus`, and `:focus-visible` so the centralized treatment is consistent across all interaction states.

## Testing

Verified on production via Playwright before any code change, then again with the patched CSS injected into the live Magic Login page:

| State | Login (`/log-in`) | Magic Login (`/log-in/link`) before | Magic Login after fix |
| --- | --- | --- | --- |
| Default color | `rgb(100,105,112)` (gray-50) | `rgb(60,67,74)` (gray-80) | `rgb(100,105,112)` (gray-50) ✓ |
| Hover / focus | inherits gray-50 | `rgb(80,87,94)` (gray-70) | `rgb(100,105,112)` (gray-50) ✓ |

The issue also lists a footer-link checkbox ("Enter a password instead"). Verified separately on production: that link already renders `rgb(29,35,39)` (gray-90) with underline on both Login and Magic Login — already matching, no code change needed. Likely addressed by an earlier audit PR. Calling it out here so the issue's first checkbox can be ticked on review.

No build performed locally (no yarn / pnpm in this environment); CSS-only change with no syntactic surprises, CI stylelint will catch any issues.

Note: The Linear issue is in **In Progress** because this PR is opened by a Bug Blitz contributor (Happiness Engineer), not an engineer actively driving the work. Ready for review by the Audit Login, Signup & Auth team — please re-triage if scope or owner is wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)