### PR TITLE
Reader Achievements: show progress bar on locked incremental achievements (RSM-2598)

### DIFF
--- a/client/reader/user-profile/views/achievements/achievements-grid/achievement-card.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/achievement-card.tsx
@@ -1,3 +1,4 @@
+import { ProgressBar } from '@automattic/components';
 import { Icon } from '@wordpress/components';
 import { lock } from '@wordpress/icons';
 import clsx from 'clsx';
@@ -11,6 +12,8 @@ interface AchievementCardProps {
 	image?: string;
 	locked?: boolean;
 	secret?: boolean;
+	progressCurrent?: number;
+	progressTarget?: number;
 }
 
 export default function AchievementCard( {
@@ -21,6 +24,8 @@ export default function AchievementCard( {
 	caption,
 	locked,
 	secret,
+	progressCurrent,
+	progressTarget,
 }: AchievementCardProps ) {
 	const showLockIcon = locked || secret;
 	const rootClass = clsx( 'achievement-card', {
@@ -44,6 +49,18 @@ export default function AchievementCard( {
 				</h3>
 				{ description && <p className="achievement-card__description">{ description }</p> }
 				{ caption && <p className="achievement-card__caption">{ caption }</p> }
+				{ progressTarget !== undefined && (
+					<div className="achievement-card__progress">
+						<ProgressBar
+							className="achievement-card__progress-bar"
+							value={ progressCurrent ?? 0 }
+							total={ progressTarget }
+						/>
+						<span className="achievement-card__progress-label">
+							{ `${ progressCurrent ?? 0 }/${ progressTarget }` }
+						</span>
+					</div>
+				) }
 			</div>
 		</div>
 	);

--- a/client/reader/user-profile/views/achievements/achievements-grid/locked-achievement-card.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/locked-achievement-card.tsx
@@ -7,5 +7,13 @@ export default function LockedAchievementCard( { entry }: { entry: LockedAchieve
 		return <SecretAchievementCard locked />;
 	}
 
-	return <AchievementCard locked title={ entry.name } description={ entry.description } />;
+	return (
+		<AchievementCard
+			locked
+			title={ entry.name }
+			description={ entry.description }
+			progressCurrent={ entry.progress }
+			progressTarget={ entry.target }
+		/>
+	);
 }

--- a/client/reader/user-profile/views/achievements/achievements-grid/style.scss
+++ b/client/reader/user-profile/views/achievements/achievements-grid/style.scss
@@ -68,6 +68,22 @@
 		}
 	}
 
+	.achievement-card__progress {
+		align-items: center;
+		display: flex;
+		gap: 8px;
+		margin-top: 8px;
+	}
+
+	.achievement-card__progress-bar {
+		flex: 1;
+	}
+
+	.achievement-card__progress-label {
+		color: var( --studio-gray-40 );
+		font-size: $font-body-extra-small;
+	}
+
 	.achievement-card__empty {
 		margin-top: 26px;
 		text-align: center;

--- a/client/reader/user-profile/views/achievements/achievements-grid/test/achievement-card.test.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/test/achievement-card.test.tsx
@@ -45,4 +45,44 @@ describe( 'AchievementCard', () => {
 		expect( root ).not.toBeNull();
 		expect( container.querySelector( '.achievement-card__icon--lock svg' ) ).not.toBeNull();
 	} );
+
+	test( 'renders a progress bar and progress/target label when progressTarget is set', () => {
+		const { container } = render(
+			<AchievementCard
+				locked
+				title="Daily streak"
+				description="Publish for 30 days."
+				progressCurrent={ 100 }
+				progressTarget={ 300 }
+			/>
+		);
+
+		expect( container.querySelector( '.achievement-card__progress' ) ).not.toBeNull();
+		const bar = screen.getByRole( 'progressbar' );
+		expect( bar ).toHaveAttribute( 'aria-valuenow', '100' );
+		expect( bar ).toHaveAttribute( 'aria-valuemax', '300' );
+		expect( screen.getByText( '100/300' ) ).toBeVisible();
+	} );
+
+	test( 'treats missing progressCurrent as 0', () => {
+		render(
+			<AchievementCard
+				locked
+				title="Daily streak"
+				description="Publish for 30 days."
+				progressTarget={ 300 }
+			/>
+		);
+
+		const bar = screen.getByRole( 'progressbar' );
+		expect( bar ).toHaveAttribute( 'aria-valuenow', '0' );
+		expect( screen.getByText( '0/300' ) ).toBeVisible();
+	} );
+
+	test( 'omits the progress bar when progressTarget is not set', () => {
+		const { container } = render( <AchievementCard locked title="Locked" description="Hidden." /> );
+
+		expect( container.querySelector( '.achievement-card__progress' ) ).toBeNull();
+		expect( screen.queryByRole( 'progressbar' ) ).toBeNull();
+	} );
 } );

--- a/packages/api-core/src/read-achievements/types.ts
+++ b/packages/api-core/src/read-achievements/types.ts
@@ -42,6 +42,10 @@ export interface LockedAchievement {
 	badge_prefix: string;
 	is_secret: false;
 	date_created: string;
+	/** Current progress toward `target`. Present alongside `target` for incremental achievements. */
+	progress?: number;
+	/** Goal value for incremental achievements. Presence triggers progress UI. */
+	target?: number;
 }
 
 /**


### PR DESCRIPTION
Part of RSM-2598

## Proposed Changes

* Extend `LockedAchievement` (`packages/api-core/src/read-achievements/types.ts`) with optional `progress` and `target` numeric fields.
* Add optional `progressCurrent` / `progressTarget` props to the shared `AchievementCard`. When `progressTarget` is set, the card renders `<ProgressBar>` (from `@automattic/components`) alongside a `current/target` label.
* `LockedAchievementCard` forwards `entry.progress` and `entry.target` to `AchievementCard`. Secret entries continue to short-circuit to `SecretAchievementCard` and never expose progress.
* New SCSS for the `.achievement-card__progress` row (flex, gap, extra-small label using `--studio-gray-40`).
* New unit tests covering: rendering with both values, defaulting `progressCurrent` to 0 when missing, and omitting the bar when `progressTarget` is absent.

## Why are these changes being made?

The `read/achievements` endpoint now returns `progress` / `target` on incremental locked achievements (e.g. _publish a post every day for 30 days_). Surfacing that progress in the UI gives the user immediate feedback on how close they are to unlocking an achievement, which is the whole point of the new endpoint data. Secret achievements remain fully hidden, as before.

## Testing Instructions

* Visit your own Reader user profile achievements view and locate a locked, non-secret achievement that the API returns with a `target` (e.g. an incremental one). Confirm a progress bar plus the `progress/target` label render inside the card.
* Confirm locked achievements without a `target` still render the same way as before (no bar).
* Confirm locked _secret_ achievements still render the masked card with no progress UI.
* Run the unit tests:
  ```
  yarn test-client client/reader/user-profile/views/achievements
  ```

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?