### PR TITLE
Reader Mastodon: extend reauth gate to author, thread, and tag-feed views

### DIFF
--- a/client/reader/mastodon/author-profile-view.tsx
+++ b/client/reader/mastodon/author-profile-view.tsx
@@ -11,6 +11,7 @@ import ReaderMain from 'calypso/reader/components/reader-main';
 import { ComposeFab, ComposerModal, ComposerProvider } from 'calypso/reader/social/composer';
 import { MastodonAuthorProfilePanel } from './author-profile-panel';
 import { mastodonComposerConfig } from './composer-config';
+import { MastodonReauthGate, useMastodonReauthGateState } from './use-mastodon-reauth-gate';
 
 interface Props {
 	connectionId: number;
@@ -23,6 +24,12 @@ export function MastodonAuthorProfileView( { connectionId, actor }: Props ) {
 
 	const connections = data?.connections ?? [];
 	const connection = connections.find( ( c ) => c.id === connectionId ) ?? null;
+
+	// The compose FAB and modal sit outside <ConnectionReauthGate>, so without
+	// an explicit guard they'd float over the reauth prompt. Hide both while
+	// the connection needs reauth — any post submitted via that path would
+	// fail with auth_required anyway.
+	const { needsReauth } = useMastodonReauthGateState( connection?.id ?? null );
 
 	useEffect( () => {
 		if ( isPending || isError ) {
@@ -62,16 +69,22 @@ export function MastodonAuthorProfileView( { connectionId, actor }: Props ) {
 		<ComposerProvider connectionId={ connection.id } config={ mastodonComposerConfig }>
 			<ReaderMain className="mastodon-view">
 				<MastodonAuthorProfileTitle connectionId={ connection.id } actor={ actor } />
-				<MastodonAuthorProfilePanel
-					connection={ connection }
-					actor={ actor }
-					subtabBasePath={ `/reader/mastodon/${ connection.id }/profile/${ encodeURIComponent(
-						actor
-					) }` }
-				/>
+				<MastodonReauthGate connection={ connection }>
+					<MastodonAuthorProfilePanel
+						connection={ connection }
+						actor={ actor }
+						subtabBasePath={ `/reader/mastodon/${ connection.id }/profile/${ encodeURIComponent(
+							actor
+						) }` }
+					/>
+				</MastodonReauthGate>
 			</ReaderMain>
-			<ComposeFab />
-			<ComposerModal />
+			{ ! needsReauth && (
+				<>
+					<ComposeFab />
+					<ComposerModal />
+				</>
+			) }
 		</ComposerProvider>
 	);
 }

--- a/client/reader/mastodon/mastodon-account-view.tsx
+++ b/client/reader/mastodon/mastodon-account-view.tsx
@@ -1,30 +1,19 @@
-import {
-	useAuthorizeMastodonConnectionMutation,
-	useMastodonAuthStatusQuery,
-	useMastodonConnectionQuery,
-	useMastodonConnectionsQuery,
-} from '@automattic/api-queries';
+import { useMastodonConnectionQuery, useMastodonConnectionsQuery } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
 import { __experimentalVStack as VStack } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import NavigationHeader from 'calypso/components/navigation-header';
 import ReaderMain from 'calypso/reader/components/reader-main';
-import { ConnectionReauthGate } from 'calypso/reader/social';
 import { ComposeFab, ComposerModal, ComposerProvider } from 'calypso/reader/social/composer';
-import { useDispatch } from 'calypso/state';
-import { errorNotice } from 'calypso/state/notices/actions';
-import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import { mastodonComposerConfig } from './composer-config';
 import { PROFILE_TAB, SETTINGS_TAB, TIMELINE_TAB } from './helper';
 import { MastodonNavigation } from './mastodon-navigation';
-import { isSafeReturnPath, saveOauthState } from './oauth-state';
 import { ProfilePanel } from './profile-panel';
 import { SettingsPanel } from './settings-panel';
 import { TimelinePanel } from './timeline-panel';
-import { useMastodonAuthStatusInvalidator } from './use-mastodon-auth-status-invalidator';
+import { MastodonReauthGate, useMastodonReauthGateState } from './use-mastodon-reauth-gate';
 import type { MastodonConnection } from '@automattic/api-core';
 
 const VALID_TABS = new Set( [ TIMELINE_TAB, PROFILE_TAB, SETTINGS_TAB ] );
@@ -34,37 +23,8 @@ interface Props {
 	tab: string;
 }
 
-// Adapter that maps `useMastodonAuthStatusQuery`'s shape to the gate's
-// `useAuthStatus` contract. Must be named with a `use` prefix so the
-// rules-of-hooks linter recognises it when passed as a hook prop.
-function useMastodonAuthStatusForGate( connectionId: number ) {
-	const r = useMastodonAuthStatusQuery( connectionId );
-	return { needsReauth: r.data?.needs_reauth };
-}
-
-// Defence in depth — `authorize()` should only ever return an `https:`
-// authorize URL on the user's instance, but a hostile or buggy upstream
-// could theoretically return something else. Refuse to navigate anywhere
-// that isn't `https:` on the same host the user opted to reconnect to.
-function isSafeAuthorizeUrl( url: string, instance: string ): boolean {
-	try {
-		const parsed = new URL( url );
-		if ( parsed.protocol !== 'https:' ) {
-			return false;
-		}
-		// Pinning to the connection's instance means a hostile upstream can't
-		// redirect a reconnect attempt off to an attacker-controlled host. The
-		// connection's instance is the host the user explicitly chose to
-		// reauthorize against, so any other host is by definition wrong.
-		return parsed.host.toLowerCase() === instance.toLowerCase();
-	} catch {
-		return false;
-	}
-}
-
 export function MastodonAccountView( { connectionId, tab }: Props ) {
 	const translate = useTranslate();
-	const dispatch = useDispatch();
 	const { data, isPending } = useMastodonConnectionsQuery();
 
 	const connections = data?.connections ?? [];
@@ -78,49 +38,11 @@ export function MastodonAccountView( { connectionId, tab }: Props ) {
 	// sidebar row share this fetch — no extra request.
 	const details = useMastodonConnectionQuery( connection?.id ?? null );
 
-	// Subscribe to the mastodon query cache; any auth_required error
-	// invalidates auth-status so the gate refetches and re-renders.
-	useMastodonAuthStatusInvalidator( connection?.id ?? null );
-
-	// Top-level read of auth-status so this component can fire the
-	// gate-shown Tracks event. The gate's adapter calls
-	// `useMastodonAuthStatusQuery` against the same key, so React Query
-	// dedupes — one fetch.
-	const authStatus = useMastodonAuthStatusQuery( connection?.id ?? null );
-
-	const authorize = useAuthorizeMastodonConnectionMutation();
-
-	const gateShownConnectionId = useRef< number | null >( null );
-	useEffect( () => {
-		if ( ! connection ) {
-			return;
-		}
-		if (
-			authStatus.data?.needs_reauth === true &&
-			gateShownConnectionId.current !== connection.id
-		) {
-			dispatch(
-				recordReaderTracksEvent( 'calypso_reader_reauth_gate_shown', {
-					provider: 'mastodon',
-					connection_id: connection.id,
-					trigger: 'auth-status',
-				} )
-			);
-			gateShownConnectionId.current = connection.id;
-		} else if ( authStatus.data?.needs_reauth === false ) {
-			// Reset the dedupe guard once the connection is healthy again so
-			// a later token expiry in the same session re-fires the
-			// `gate_shown` event. Without this reset the second
-			// needs_reauth=true edge would be silently swallowed and Tracks
-			// would under-count repeat reauth prompts.
-			if ( gateShownConnectionId.current === connection.id ) {
-				gateShownConnectionId.current = null;
-			}
-		}
-		// connection.id is the load-bearing identity here; we don't want
-		// to refire on connection-object identity churn from React Query.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ connection?.id, authStatus.data?.needs_reauth, dispatch ] );
+	// The compose FAB and modal sit outside <ConnectionReauthGate> (the gate
+	// only wraps the tab body), so without an explicit guard they'd float
+	// over the reauth prompt. Hide both while the connection needs reauth —
+	// any post submitted via that path would fail with auth_required anyway.
+	const { needsReauth } = useMastodonReauthGateState( connection?.id ?? null );
 
 	useEffect( () => {
 		if ( isPending ) {
@@ -134,97 +56,6 @@ export function MastodonAccountView( { connectionId, tab }: Props ) {
 			page.replace( `/reader/mastodon/${ connection.id }/${ TIMELINE_TAB }` );
 		}
 	}, [ isPending, connection, tabValid ] );
-
-	// Tracks whether the component is still mounted so a slow authorize()
-	// resolution can't yank the user off a page they navigated to during
-	// the round trip. Also short-circuits double-clicks before
-	// authorize.isPending flips.
-	const mountedRef = useRef( true );
-	useEffect( () => {
-		mountedRef.current = true;
-		return () => {
-			mountedRef.current = false;
-		};
-	}, [] );
-
-	const handleReconnect = () => {
-		if ( ! connection || authorize.isPending ) {
-			return;
-		}
-		dispatch(
-			recordReaderTracksEvent( 'calypso_reader_reauth_button_clicked', {
-				provider: 'mastodon',
-				connection_id: connection.id,
-			} )
-		);
-		const rawReturnPath = window.location.pathname + window.location.search;
-		const returnPath = isSafeReturnPath( rawReturnPath ) ? rawReturnPath : undefined;
-		authorize.mutate(
-			{ instance: connection.instance },
-			{
-				onSuccess: ( { authorize_url, state } ) => {
-					if ( ! mountedRef.current ) {
-						// The user navigated away (or the connection list
-						// resolved to a different connection) while authorize
-						// was in flight. Don't yank them off whatever page they
-						// landed on.
-						return;
-					}
-					if ( ! isSafeAuthorizeUrl( authorize_url, connection.instance ) ) {
-						dispatch(
-							errorNotice(
-								translate( 'We couldn’t start the reconnect safely. Please try again.' ),
-								{ duration: 5000 }
-							)
-						);
-						dispatch(
-							recordReaderTracksEvent( 'calypso_reader_mastodon_authorize_error', {
-								reason: 'unsafe_url',
-							} )
-						);
-						return;
-					}
-					const saved = saveOauthState( {
-						state,
-						instance: connection.instance,
-						returnPath,
-						reconnectingConnectionId: connection.id,
-					} );
-					if ( ! saved ) {
-						// sessionStorage was unavailable. The callback view
-						// validates `state` against the stored value, so without
-						// it the round-trip would always fail — refuse to redirect.
-						dispatch(
-							errorNotice(
-								translate( 'We couldn’t start the reconnect safely. Please try again.' ),
-								{ duration: 5000 }
-							)
-						);
-						dispatch(
-							recordReaderTracksEvent( 'calypso_reader_mastodon_authorize_error', {
-								reason: 'state_persist_failed',
-							} )
-						);
-						return;
-					}
-					window.location.assign( authorize_url );
-				},
-				onError: ( error ) => {
-					dispatch(
-						errorNotice( translate( 'Could not start the reconnect. Please try again.' ), {
-							duration: 5000,
-						} )
-					);
-					dispatch(
-						recordReaderTracksEvent( 'calypso_reader_mastodon_authorize_error', {
-							reason: 'authorize_failed',
-							error_kind: error.kind,
-						} )
-					);
-				},
-			}
-		);
-	};
 
 	if ( ! connection || ! tabValid ) {
 		return (
@@ -240,12 +71,6 @@ export function MastodonAccountView( { connectionId, tab }: Props ) {
 	const title = details.data?.display_name || connection.display_name || connection.handle;
 	const subtitle = connection.handle;
 
-	// The compose FAB and modal sit outside <ConnectionReauthGate> (the gate
-	// only wraps the tab body), so without an explicit guard they'd float
-	// over the reauth prompt. Hide both while the connection needs reauth —
-	// any post submitted via that path would fail with auth_required anyway.
-	const hideComposer = authStatus.data?.needs_reauth === true;
-
 	return (
 		<ComposerProvider connectionId={ connection.id } config={ mastodonComposerConfig }>
 			<ReaderMain className="mastodon-view">
@@ -253,30 +78,12 @@ export function MastodonAccountView( { connectionId, tab }: Props ) {
 				<NavigationHeader title={ title } subtitle={ subtitle } />
 				<MastodonNavigation connectionId={ connection.id } selectedTab={ tab } />
 				<VStack spacing={ 4 } className="mastodon-view__body">
-					<ConnectionReauthGate
-						connectionId={ connection.id }
-						useAuthStatus={ useMastodonAuthStatusForGate }
-						onReconnect={ handleReconnect }
-						isReconnecting={ authorize.isPending }
-						headline={ translate( 'Reconnect to update permissions' ) as string }
-						body={ createInterpolateElement(
-							translate(
-								'Your <strong>%(handle)s</strong> connection needs to be refreshed to keep working with new Reader features.',
-								{ args: { handle: connection.handle } }
-							) as string,
-							{ strong: <strong /> }
-						) }
-						buttonLabel={
-							translate( 'Reconnect on %(instance)s', {
-								args: { instance: connection.instance },
-							} ) as string
-						}
-					>
+					<MastodonReauthGate connection={ connection }>
 						{ renderTab( tab, connection ) }
-					</ConnectionReauthGate>
+					</MastodonReauthGate>
 				</VStack>
 			</ReaderMain>
-			{ ! hideComposer && (
+			{ ! needsReauth && (
 				<>
 					<ComposeFab />
 					<ComposerModal />

--- a/client/reader/mastodon/mastodon-account-view.tsx
+++ b/client/reader/mastodon/mastodon-account-view.tsx
@@ -38,10 +38,10 @@ export function MastodonAccountView( { connectionId, tab }: Props ) {
 	// sidebar row share this fetch — no extra request.
 	const details = useMastodonConnectionQuery( connection?.id ?? null );
 
-	// The compose FAB and modal sit outside <ConnectionReauthGate> (the gate
-	// only wraps the tab body), so without an explicit guard they'd float
-	// over the reauth prompt. Hide both while the connection needs reauth —
-	// any post submitted via that path would fail with auth_required anyway.
+	// The compose FAB and modal sit outside <ConnectionReauthGate>, so without
+	// an explicit guard they'd float over the reauth prompt. Hide both while
+	// the connection needs reauth — any post submitted via that path would
+	// fail with auth_required anyway.
 	const { needsReauth } = useMastodonReauthGateState( connection?.id ?? null );
 
 	useEffect( () => {

--- a/client/reader/mastodon/mastodon-thread-view.tsx
+++ b/client/reader/mastodon/mastodon-thread-view.tsx
@@ -8,6 +8,7 @@ import ReaderMain from 'calypso/reader/components/reader-main';
 import { ComposeFab, ComposerModal, ComposerProvider } from 'calypso/reader/social/composer';
 import { mastodonComposerConfig } from './composer-config';
 import { ThreadPanel } from './thread-panel';
+import { MastodonReauthGate, useMastodonReauthGateState } from './use-mastodon-reauth-gate';
 
 interface Props {
 	connectionId: number;
@@ -20,6 +21,12 @@ export function MastodonThreadView( { connectionId, statusId }: Props ) {
 
 	const connections = data?.connections ?? [];
 	const connection = connections.find( ( c ) => c.id === connectionId ) ?? null;
+
+	// The compose FAB and modal sit outside <ConnectionReauthGate>, so without
+	// an explicit guard they'd float over the reauth prompt. Hide both while
+	// the connection needs reauth — any post submitted via that path would
+	// fail with auth_required anyway.
+	const { needsReauth } = useMastodonReauthGateState( connection?.id ?? null );
 
 	useEffect( () => {
 		if ( isPending || isError ) {
@@ -61,10 +68,16 @@ export function MastodonThreadView( { connectionId, statusId }: Props ) {
 				<DocumentHead
 					title={ translate( '%s ‹ Mastodon ‹ Reader', { args: connection.handle } ) }
 				/>
-				<ThreadPanel connection={ connection } statusId={ statusId } />
+				<MastodonReauthGate connection={ connection }>
+					<ThreadPanel connection={ connection } statusId={ statusId } />
+				</MastodonReauthGate>
 			</ReaderMain>
-			<ComposeFab />
-			<ComposerModal />
+			{ ! needsReauth && (
+				<>
+					<ComposeFab />
+					<ComposerModal />
+				</>
+			) }
 		</ComposerProvider>
 	);
 }

--- a/client/reader/mastodon/tag-feed-view.tsx
+++ b/client/reader/mastodon/tag-feed-view.tsx
@@ -6,6 +6,7 @@ import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import ReaderMain from 'calypso/reader/components/reader-main';
 import { MastodonTagFeedPanel } from './tag-feed-panel';
+import { MastodonReauthGate } from './use-mastodon-reauth-gate';
 
 interface Props {
 	connectionId: number;
@@ -56,7 +57,9 @@ export function MastodonTagFeedView( { connectionId, hashtag }: Props ) {
 	return (
 		<ReaderMain className="mastodon-view">
 			<DocumentHead title={ translate( '#%s ‹ Mastodon ‹ Reader', { args: hashtag } ) } />
-			<MastodonTagFeedPanel connection={ connection } hashtag={ hashtag } />
+			<MastodonReauthGate connection={ connection }>
+				<MastodonTagFeedPanel connection={ connection } hashtag={ hashtag } />
+			</MastodonReauthGate>
 		</ReaderMain>
 	);
 }

--- a/client/reader/mastodon/test/author-profile-view-reauth.test.tsx
+++ b/client/reader/mastodon/test/author-profile-view-reauth.test.tsx
@@ -1,0 +1,242 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient } from '@tanstack/react-query';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import * as noticeActions from 'calypso/state/notices/actions';
+import * as readerAnalytics from 'calypso/state/reader/analytics/actions';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { MastodonAuthorProfileView } from '../author-profile-view';
+import type React from 'react';
+
+jest.mock( 'calypso/lib/logstash', () => ( { logToLogstash: jest.fn() } ) );
+
+jest.mock(
+	'calypso/reader/components/reader-main',
+	() =>
+		function ReaderMain( { children }: { children: React.ReactNode } ) {
+			return <div>{ children }</div>;
+		}
+);
+
+jest.mock( 'calypso/components/data/document-head', () => () => null );
+
+jest.mock( '../author-profile-panel', () => ( {
+	MastodonAuthorProfilePanel: () => <div>Mastodon author profile placeholder</div>,
+} ) );
+
+jest.mock( '@automattic/calypso-router', () => {
+	const replace = jest.fn();
+	const fn = jest.fn() as jest.Mock & { replace: jest.Mock };
+	fn.replace = replace;
+	return { __esModule: true, default: fn };
+} );
+
+const BASE = 'https://public-api.wordpress.com';
+const listUrl = '/wpcom/v2/reader/mastodon/connections';
+const ACTOR = 'alice@mastodon.social';
+
+function makeClient() {
+	return new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+}
+
+function mockConnections() {
+	nock( BASE )
+		.get( listUrl )
+		.reply( 200, {
+			connections: [
+				{
+					id: 42,
+					handle: '@jeherve@a8c.social',
+					instance: 'a8c.social',
+					display_name: 'Jeremy',
+					avatar: null,
+				},
+			],
+		} );
+}
+
+describe( 'MastodonAuthorProfileView reauth gate', () => {
+	let assignMock: jest.Mock;
+	let originalLocation: Location;
+	let trackSpy: jest.SpyInstance;
+
+	beforeAll( () => {
+		global.IntersectionObserver = class IntersectionObserver {
+			observe() {}
+			unobserve() {}
+			disconnect() {}
+		} as unknown as typeof global.IntersectionObserver;
+	} );
+
+	afterAll( () => {
+		// @ts-expect-error -- cleaning up the stub
+		delete global.IntersectionObserver;
+	} );
+
+	beforeEach( () => {
+		trackSpy = jest
+			.spyOn( readerAnalytics, 'recordReaderTracksEvent' )
+			.mockImplementation( () => ( { type: '@@TEST/NOOP' } ) as never );
+
+		originalLocation = window.location;
+		assignMock = jest.fn();
+		Object.defineProperty( window, 'location', {
+			configurable: true,
+			writable: true,
+			value: {
+				...originalLocation,
+				pathname: `/reader/mastodon/42/profile/${ ACTOR }`,
+				search: '',
+				assign: assignMock,
+			},
+		} );
+		window.sessionStorage.clear();
+	} );
+
+	afterEach( () => {
+		nock.cleanAll();
+		jest.restoreAllMocks();
+		Object.defineProperty( window, 'location', {
+			configurable: true,
+			writable: true,
+			value: originalLocation,
+		} );
+	} );
+
+	it( 'renders the gate overlay when auth-status reports needs_reauth: true', async () => {
+		mockConnections();
+		nock( BASE ).get( `${ listUrl }/42/auth-status` ).reply( 200, { needs_reauth: true } );
+
+		renderWithProvider( <MastodonAuthorProfileView connectionId={ 42 } actor={ ACTOR } />, {
+			queryClient: makeClient(),
+		} );
+
+		const heading = await screen.findByRole( 'heading', {
+			name: /reconnect to update permissions/i,
+		} );
+		expect( heading ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: /reconnect on a8c\.social/i } ) ).toBeVisible();
+
+		// Gated content must not render the panel placeholder while the gate is up.
+		expect( screen.queryByText( 'Mastodon author profile placeholder' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the panel when auth-status reports needs_reauth: false', async () => {
+		mockConnections();
+		nock( BASE ).get( `${ listUrl }/42/auth-status` ).reply( 200, { needs_reauth: false } );
+
+		renderWithProvider( <MastodonAuthorProfileView connectionId={ 42 } actor={ ACTOR } />, {
+			queryClient: makeClient(),
+		} );
+
+		await waitFor( () =>
+			expect( screen.getByText( 'Mastodon author profile placeholder' ) ).toBeVisible()
+		);
+		expect(
+			screen.queryByRole( 'heading', { name: /reconnect to update permissions/i } )
+		).not.toBeInTheDocument();
+		// Composer FAB should remain visible on a healthy connection.
+		expect( screen.getByRole( 'button', { name: /^compose$/i } ) ).toBeVisible();
+	} );
+
+	it( 'hides the compose FAB while the reauth gate is showing', async () => {
+		mockConnections();
+		nock( BASE ).get( `${ listUrl }/42/auth-status` ).reply( 200, { needs_reauth: true } );
+
+		renderWithProvider( <MastodonAuthorProfileView connectionId={ 42 } actor={ ACTOR } />, {
+			queryClient: makeClient(),
+		} );
+
+		await screen.findByRole( 'heading', { name: /reconnect to update permissions/i } );
+		expect( screen.queryByRole( 'button', { name: /^compose$/i } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'fires calypso_reader_reauth_gate_shown when the gate appears', async () => {
+		mockConnections();
+		nock( BASE ).get( `${ listUrl }/42/auth-status` ).reply( 200, { needs_reauth: true } );
+
+		renderWithProvider( <MastodonAuthorProfileView connectionId={ 42 } actor={ ACTOR } />, {
+			queryClient: makeClient(),
+		} );
+
+		await screen.findByRole( 'heading', { name: /reconnect to update permissions/i } );
+
+		await waitFor( () => {
+			expect( trackSpy ).toHaveBeenCalledWith(
+				'calypso_reader_reauth_gate_shown',
+				expect.objectContaining( {
+					provider: 'mastodon',
+					connection_id: 42,
+					trigger: 'auth-status',
+				} )
+			);
+		} );
+	} );
+
+	it( 'kicks off the authorize mutation, stores oauth-state with the profile return path, and navigates on click', async () => {
+		const user = userEvent.setup();
+		mockConnections();
+		nock( BASE ).get( `${ listUrl }/42/auth-status` ).reply( 200, { needs_reauth: true } );
+		nock( BASE ).post( listUrl, { step: 'authorize', instance: 'a8c.social' } ).reply( 200, {
+			authorize_url: 'https://a8c.social/oauth/authorize?client_id=x&state=abc',
+			state: 'abc',
+		} );
+
+		renderWithProvider( <MastodonAuthorProfileView connectionId={ 42 } actor={ ACTOR } />, {
+			queryClient: makeClient(),
+		} );
+
+		const button = await screen.findByRole( 'button', { name: /reconnect on a8c\.social/i } );
+		await user.click( button );
+
+		await waitFor( () =>
+			expect( assignMock ).toHaveBeenCalledWith(
+				'https://a8c.social/oauth/authorize?client_id=x&state=abc'
+			)
+		);
+		expect( trackSpy ).toHaveBeenCalledWith(
+			'calypso_reader_reauth_button_clicked',
+			expect.objectContaining( { provider: 'mastodon', connection_id: 42 } )
+		);
+
+		const stored = JSON.parse(
+			window.sessionStorage.getItem( 'reader.mastodon.oauthState' ) ?? ''
+		);
+		expect( stored ).toEqual( {
+			state: 'abc',
+			instance: 'a8c.social',
+			returnPath: `/reader/mastodon/42/profile/${ ACTOR }`,
+			reconnectingConnectionId: 42,
+		} );
+	} );
+
+	it( 'surfaces an error notice when the authorize endpoint fails', async () => {
+		const user = userEvent.setup();
+		const errorSpy = jest.spyOn( noticeActions, 'errorNotice' );
+
+		mockConnections();
+		nock( BASE ).get( `${ listUrl }/42/auth-status` ).reply( 200, { needs_reauth: true } );
+		nock( BASE )
+			.post( listUrl, { step: 'authorize', instance: 'a8c.social' } )
+			.reply( 429, { error: 'rate_limited', message: 'slow down' } );
+
+		renderWithProvider( <MastodonAuthorProfileView connectionId={ 42 } actor={ ACTOR } />, {
+			queryClient: makeClient(),
+		} );
+
+		const button = await screen.findByRole( 'button', { name: /reconnect on a8c\.social/i } );
+		await user.click( button );
+
+		await waitFor( () => expect( errorSpy ).toHaveBeenCalled() );
+		expect( assignMock ).not.toHaveBeenCalled();
+		expect( trackSpy ).toHaveBeenCalledWith(
+			'calypso_reader_mastodon_authorize_error',
+			expect.objectContaining( { reason: 'authorize_failed' } )
+		);
+
+		errorSpy.mockRestore();
+	} );
+} );

--- a/client/reader/mastodon/test/mastodon-account-view-reauth.test.tsx
+++ b/client/reader/mastodon/test/mastodon-account-view-reauth.test.tsx
@@ -326,4 +326,37 @@ describe( 'MastodonAccountView reauth gate', () => {
 
 		errorSpy.mockRestore();
 	} );
+
+	it( 'surfaces an error notice and refuses to redirect when sessionStorage cannot persist the oauth state', async () => {
+		const user = userEvent.setup();
+		const errorSpy = jest.spyOn( noticeActions, 'errorNotice' );
+		const setItemSpy = jest.spyOn( Storage.prototype, 'setItem' ).mockImplementation( () => {
+			throw new DOMException( 'QuotaExceeded' );
+		} );
+
+		mockConnections();
+		mockConnectionDetails();
+		nock( BASE ).get( `${ listUrl }/42/auth-status` ).reply( 200, { needs_reauth: true } );
+		nock( BASE ).post( listUrl, { step: 'authorize', instance: 'a8c.social' } ).reply( 200, {
+			authorize_url: 'https://a8c.social/oauth/authorize?client_id=x&state=abc',
+			state: 'abc',
+		} );
+
+		renderWithProvider( <MastodonAccountView connectionId={ 42 } tab={ TIMELINE_TAB } />, {
+			queryClient: makeClient(),
+		} );
+
+		const button = await screen.findByRole( 'button', { name: /reconnect on a8c\.social/i } );
+		await user.click( button );
+
+		await waitFor( () => expect( errorSpy ).toHaveBeenCalled() );
+		expect( assignMock ).not.toHaveBeenCalled();
+		expect( trackSpy ).toHaveBeenCalledWith(
+			'calypso_reader_mastodon_authorize_error',
+			expect.objectContaining( { reason: 'state_persist_failed' } )
+		);
+
+		setItemSpy.mockRestore();
+		errorSpy.mockRestore();
+	} );
 } );

--- a/client/reader/mastodon/test/mastodon-thread-view-reauth.test.tsx
+++ b/client/reader/mastodon/test/mastodon-thread-view-reauth.test.tsx
@@ -1,0 +1,240 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient } from '@tanstack/react-query';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import * as noticeActions from 'calypso/state/notices/actions';
+import * as readerAnalytics from 'calypso/state/reader/analytics/actions';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { MastodonThreadView } from '../mastodon-thread-view';
+import type React from 'react';
+
+jest.mock( 'calypso/lib/logstash', () => ( { logToLogstash: jest.fn() } ) );
+
+jest.mock(
+	'calypso/reader/components/reader-main',
+	() =>
+		function ReaderMain( { children }: { children: React.ReactNode } ) {
+			return <div>{ children }</div>;
+		}
+);
+
+jest.mock( 'calypso/components/data/document-head', () => () => null );
+
+jest.mock( '../thread-panel', () => ( {
+	ThreadPanel: () => <div>Mastodon thread placeholder</div>,
+} ) );
+
+jest.mock( '@automattic/calypso-router', () => {
+	const replace = jest.fn();
+	const fn = jest.fn() as jest.Mock & { replace: jest.Mock };
+	fn.replace = replace;
+	return { __esModule: true, default: fn };
+} );
+
+const BASE = 'https://public-api.wordpress.com';
+const listUrl = '/wpcom/v2/reader/mastodon/connections';
+const STATUS_ID = '109876543210';
+
+function makeClient() {
+	return new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+}
+
+function mockConnections() {
+	nock( BASE )
+		.get( listUrl )
+		.reply( 200, {
+			connections: [
+				{
+					id: 42,
+					handle: '@jeherve@a8c.social',
+					instance: 'a8c.social',
+					display_name: 'Jeremy',
+					avatar: null,
+				},
+			],
+		} );
+}
+
+describe( 'MastodonThreadView reauth gate', () => {
+	let assignMock: jest.Mock;
+	let originalLocation: Location;
+	let trackSpy: jest.SpyInstance;
+
+	beforeAll( () => {
+		global.IntersectionObserver = class IntersectionObserver {
+			observe() {}
+			unobserve() {}
+			disconnect() {}
+		} as unknown as typeof global.IntersectionObserver;
+	} );
+
+	afterAll( () => {
+		// @ts-expect-error -- cleaning up the stub
+		delete global.IntersectionObserver;
+	} );
+
+	beforeEach( () => {
+		trackSpy = jest
+			.spyOn( readerAnalytics, 'recordReaderTracksEvent' )
+			.mockImplementation( () => ( { type: '@@TEST/NOOP' } ) as never );
+
+		originalLocation = window.location;
+		assignMock = jest.fn();
+		Object.defineProperty( window, 'location', {
+			configurable: true,
+			writable: true,
+			value: {
+				...originalLocation,
+				pathname: `/reader/mastodon/42/thread/${ STATUS_ID }`,
+				search: '',
+				assign: assignMock,
+			},
+		} );
+		window.sessionStorage.clear();
+	} );
+
+	afterEach( () => {
+		nock.cleanAll();
+		jest.restoreAllMocks();
+		Object.defineProperty( window, 'location', {
+			configurable: true,
+			writable: true,
+			value: originalLocation,
+		} );
+	} );
+
+	it( 'renders the gate overlay when auth-status reports needs_reauth: true', async () => {
+		mockConnections();
+		nock( BASE ).get( `${ listUrl }/42/auth-status` ).reply( 200, { needs_reauth: true } );
+
+		renderWithProvider( <MastodonThreadView connectionId={ 42 } statusId={ STATUS_ID } />, {
+			queryClient: makeClient(),
+		} );
+
+		const heading = await screen.findByRole( 'heading', {
+			name: /reconnect to update permissions/i,
+		} );
+		expect( heading ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: /reconnect on a8c\.social/i } ) ).toBeVisible();
+
+		expect( screen.queryByText( 'Mastodon thread placeholder' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the panel when auth-status reports needs_reauth: false', async () => {
+		mockConnections();
+		nock( BASE ).get( `${ listUrl }/42/auth-status` ).reply( 200, { needs_reauth: false } );
+
+		renderWithProvider( <MastodonThreadView connectionId={ 42 } statusId={ STATUS_ID } />, {
+			queryClient: makeClient(),
+		} );
+
+		await waitFor( () =>
+			expect( screen.getByText( 'Mastodon thread placeholder' ) ).toBeVisible()
+		);
+		expect(
+			screen.queryByRole( 'heading', { name: /reconnect to update permissions/i } )
+		).not.toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: /^compose$/i } ) ).toBeVisible();
+	} );
+
+	it( 'hides the compose FAB while the reauth gate is showing', async () => {
+		mockConnections();
+		nock( BASE ).get( `${ listUrl }/42/auth-status` ).reply( 200, { needs_reauth: true } );
+
+		renderWithProvider( <MastodonThreadView connectionId={ 42 } statusId={ STATUS_ID } />, {
+			queryClient: makeClient(),
+		} );
+
+		await screen.findByRole( 'heading', { name: /reconnect to update permissions/i } );
+		expect( screen.queryByRole( 'button', { name: /^compose$/i } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'fires calypso_reader_reauth_gate_shown when the gate appears', async () => {
+		mockConnections();
+		nock( BASE ).get( `${ listUrl }/42/auth-status` ).reply( 200, { needs_reauth: true } );
+
+		renderWithProvider( <MastodonThreadView connectionId={ 42 } statusId={ STATUS_ID } />, {
+			queryClient: makeClient(),
+		} );
+
+		await screen.findByRole( 'heading', { name: /reconnect to update permissions/i } );
+
+		await waitFor( () => {
+			expect( trackSpy ).toHaveBeenCalledWith(
+				'calypso_reader_reauth_gate_shown',
+				expect.objectContaining( {
+					provider: 'mastodon',
+					connection_id: 42,
+					trigger: 'auth-status',
+				} )
+			);
+		} );
+	} );
+
+	it( 'kicks off the authorize mutation, stores oauth-state with the thread return path, and navigates on click', async () => {
+		const user = userEvent.setup();
+		mockConnections();
+		nock( BASE ).get( `${ listUrl }/42/auth-status` ).reply( 200, { needs_reauth: true } );
+		nock( BASE ).post( listUrl, { step: 'authorize', instance: 'a8c.social' } ).reply( 200, {
+			authorize_url: 'https://a8c.social/oauth/authorize?client_id=x&state=abc',
+			state: 'abc',
+		} );
+
+		renderWithProvider( <MastodonThreadView connectionId={ 42 } statusId={ STATUS_ID } />, {
+			queryClient: makeClient(),
+		} );
+
+		const button = await screen.findByRole( 'button', { name: /reconnect on a8c\.social/i } );
+		await user.click( button );
+
+		await waitFor( () =>
+			expect( assignMock ).toHaveBeenCalledWith(
+				'https://a8c.social/oauth/authorize?client_id=x&state=abc'
+			)
+		);
+		expect( trackSpy ).toHaveBeenCalledWith(
+			'calypso_reader_reauth_button_clicked',
+			expect.objectContaining( { provider: 'mastodon', connection_id: 42 } )
+		);
+
+		const stored = JSON.parse(
+			window.sessionStorage.getItem( 'reader.mastodon.oauthState' ) ?? ''
+		);
+		expect( stored ).toEqual( {
+			state: 'abc',
+			instance: 'a8c.social',
+			returnPath: `/reader/mastodon/42/thread/${ STATUS_ID }`,
+			reconnectingConnectionId: 42,
+		} );
+	} );
+
+	it( 'surfaces an error notice when the authorize endpoint fails', async () => {
+		const user = userEvent.setup();
+		const errorSpy = jest.spyOn( noticeActions, 'errorNotice' );
+
+		mockConnections();
+		nock( BASE ).get( `${ listUrl }/42/auth-status` ).reply( 200, { needs_reauth: true } );
+		nock( BASE )
+			.post( listUrl, { step: 'authorize', instance: 'a8c.social' } )
+			.reply( 429, { error: 'rate_limited', message: 'slow down' } );
+
+		renderWithProvider( <MastodonThreadView connectionId={ 42 } statusId={ STATUS_ID } />, {
+			queryClient: makeClient(),
+		} );
+
+		const button = await screen.findByRole( 'button', { name: /reconnect on a8c\.social/i } );
+		await user.click( button );
+
+		await waitFor( () => expect( errorSpy ).toHaveBeenCalled() );
+		expect( assignMock ).not.toHaveBeenCalled();
+		expect( trackSpy ).toHaveBeenCalledWith(
+			'calypso_reader_mastodon_authorize_error',
+			expect.objectContaining( { reason: 'authorize_failed' } )
+		);
+
+		errorSpy.mockRestore();
+	} );
+} );

--- a/client/reader/mastodon/test/tag-feed-view-reauth.test.tsx
+++ b/client/reader/mastodon/test/tag-feed-view-reauth.test.tsx
@@ -1,0 +1,227 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient } from '@tanstack/react-query';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import * as noticeActions from 'calypso/state/notices/actions';
+import * as readerAnalytics from 'calypso/state/reader/analytics/actions';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { MastodonTagFeedView } from '../tag-feed-view';
+import type React from 'react';
+
+jest.mock( 'calypso/lib/logstash', () => ( { logToLogstash: jest.fn() } ) );
+
+jest.mock(
+	'calypso/reader/components/reader-main',
+	() =>
+		function ReaderMain( { children }: { children: React.ReactNode } ) {
+			return <div>{ children }</div>;
+		}
+);
+
+jest.mock( 'calypso/components/data/document-head', () => () => null );
+
+jest.mock( '../tag-feed-panel', () => ( {
+	MastodonTagFeedPanel: () => <div>Mastodon tag feed placeholder</div>,
+} ) );
+
+jest.mock( '@automattic/calypso-router', () => {
+	const replace = jest.fn();
+	const fn = jest.fn() as jest.Mock & { replace: jest.Mock };
+	fn.replace = replace;
+	return { __esModule: true, default: fn };
+} );
+
+const BASE = 'https://public-api.wordpress.com';
+const listUrl = '/wpcom/v2/reader/mastodon/connections';
+const HASHTAG = 'rust';
+
+function makeClient() {
+	return new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+}
+
+function mockConnections() {
+	nock( BASE )
+		.get( listUrl )
+		.reply( 200, {
+			connections: [
+				{
+					id: 42,
+					handle: '@jeherve@a8c.social',
+					instance: 'a8c.social',
+					display_name: 'Jeremy',
+					avatar: null,
+				},
+			],
+		} );
+}
+
+describe( 'MastodonTagFeedView reauth gate', () => {
+	let assignMock: jest.Mock;
+	let originalLocation: Location;
+	let trackSpy: jest.SpyInstance;
+
+	beforeAll( () => {
+		global.IntersectionObserver = class IntersectionObserver {
+			observe() {}
+			unobserve() {}
+			disconnect() {}
+		} as unknown as typeof global.IntersectionObserver;
+	} );
+
+	afterAll( () => {
+		// @ts-expect-error -- cleaning up the stub
+		delete global.IntersectionObserver;
+	} );
+
+	beforeEach( () => {
+		trackSpy = jest
+			.spyOn( readerAnalytics, 'recordReaderTracksEvent' )
+			.mockImplementation( () => ( { type: '@@TEST/NOOP' } ) as never );
+
+		originalLocation = window.location;
+		assignMock = jest.fn();
+		Object.defineProperty( window, 'location', {
+			configurable: true,
+			writable: true,
+			value: {
+				...originalLocation,
+				pathname: `/reader/mastodon/42/tag/${ HASHTAG }`,
+				search: '',
+				assign: assignMock,
+			},
+		} );
+		window.sessionStorage.clear();
+	} );
+
+	afterEach( () => {
+		nock.cleanAll();
+		jest.restoreAllMocks();
+		Object.defineProperty( window, 'location', {
+			configurable: true,
+			writable: true,
+			value: originalLocation,
+		} );
+	} );
+
+	it( 'renders the gate overlay when auth-status reports needs_reauth: true', async () => {
+		mockConnections();
+		nock( BASE ).get( `${ listUrl }/42/auth-status` ).reply( 200, { needs_reauth: true } );
+
+		renderWithProvider( <MastodonTagFeedView connectionId={ 42 } hashtag={ HASHTAG } />, {
+			queryClient: makeClient(),
+		} );
+
+		const heading = await screen.findByRole( 'heading', {
+			name: /reconnect to update permissions/i,
+		} );
+		expect( heading ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: /reconnect on a8c\.social/i } ) ).toBeVisible();
+
+		expect( screen.queryByText( 'Mastodon tag feed placeholder' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the panel when auth-status reports needs_reauth: false', async () => {
+		mockConnections();
+		nock( BASE ).get( `${ listUrl }/42/auth-status` ).reply( 200, { needs_reauth: false } );
+
+		renderWithProvider( <MastodonTagFeedView connectionId={ 42 } hashtag={ HASHTAG } />, {
+			queryClient: makeClient(),
+		} );
+
+		await waitFor( () =>
+			expect( screen.getByText( 'Mastodon tag feed placeholder' ) ).toBeVisible()
+		);
+		expect(
+			screen.queryByRole( 'heading', { name: /reconnect to update permissions/i } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'fires calypso_reader_reauth_gate_shown when the gate appears', async () => {
+		mockConnections();
+		nock( BASE ).get( `${ listUrl }/42/auth-status` ).reply( 200, { needs_reauth: true } );
+
+		renderWithProvider( <MastodonTagFeedView connectionId={ 42 } hashtag={ HASHTAG } />, {
+			queryClient: makeClient(),
+		} );
+
+		await screen.findByRole( 'heading', { name: /reconnect to update permissions/i } );
+
+		await waitFor( () => {
+			expect( trackSpy ).toHaveBeenCalledWith(
+				'calypso_reader_reauth_gate_shown',
+				expect.objectContaining( {
+					provider: 'mastodon',
+					connection_id: 42,
+					trigger: 'auth-status',
+				} )
+			);
+		} );
+	} );
+
+	it( 'kicks off the authorize mutation, stores oauth-state with the tag-feed return path, and navigates on click', async () => {
+		const user = userEvent.setup();
+		mockConnections();
+		nock( BASE ).get( `${ listUrl }/42/auth-status` ).reply( 200, { needs_reauth: true } );
+		nock( BASE ).post( listUrl, { step: 'authorize', instance: 'a8c.social' } ).reply( 200, {
+			authorize_url: 'https://a8c.social/oauth/authorize?client_id=x&state=abc',
+			state: 'abc',
+		} );
+
+		renderWithProvider( <MastodonTagFeedView connectionId={ 42 } hashtag={ HASHTAG } />, {
+			queryClient: makeClient(),
+		} );
+
+		const button = await screen.findByRole( 'button', { name: /reconnect on a8c\.social/i } );
+		await user.click( button );
+
+		await waitFor( () =>
+			expect( assignMock ).toHaveBeenCalledWith(
+				'https://a8c.social/oauth/authorize?client_id=x&state=abc'
+			)
+		);
+		expect( trackSpy ).toHaveBeenCalledWith(
+			'calypso_reader_reauth_button_clicked',
+			expect.objectContaining( { provider: 'mastodon', connection_id: 42 } )
+		);
+
+		const stored = JSON.parse(
+			window.sessionStorage.getItem( 'reader.mastodon.oauthState' ) ?? ''
+		);
+		expect( stored ).toEqual( {
+			state: 'abc',
+			instance: 'a8c.social',
+			returnPath: `/reader/mastodon/42/tag/${ HASHTAG }`,
+			reconnectingConnectionId: 42,
+		} );
+	} );
+
+	it( 'surfaces an error notice when the authorize endpoint fails', async () => {
+		const user = userEvent.setup();
+		const errorSpy = jest.spyOn( noticeActions, 'errorNotice' );
+
+		mockConnections();
+		nock( BASE ).get( `${ listUrl }/42/auth-status` ).reply( 200, { needs_reauth: true } );
+		nock( BASE )
+			.post( listUrl, { step: 'authorize', instance: 'a8c.social' } )
+			.reply( 429, { error: 'rate_limited', message: 'slow down' } );
+
+		renderWithProvider( <MastodonTagFeedView connectionId={ 42 } hashtag={ HASHTAG } />, {
+			queryClient: makeClient(),
+		} );
+
+		const button = await screen.findByRole( 'button', { name: /reconnect on a8c\.social/i } );
+		await user.click( button );
+
+		await waitFor( () => expect( errorSpy ).toHaveBeenCalled() );
+		expect( assignMock ).not.toHaveBeenCalled();
+		expect( trackSpy ).toHaveBeenCalledWith(
+			'calypso_reader_mastodon_authorize_error',
+			expect.objectContaining( { reason: 'authorize_failed' } )
+		);
+
+		errorSpy.mockRestore();
+	} );
+} );

--- a/client/reader/mastodon/use-mastodon-reauth-gate.tsx
+++ b/client/reader/mastodon/use-mastodon-reauth-gate.tsx
@@ -5,6 +5,7 @@ import {
 import { createInterpolateElement } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { ReactNode, useEffect, useRef } from 'react';
+import { logToLogstash } from 'calypso/lib/logstash';
 import { ConnectionReauthGate } from 'calypso/reader/social';
 import { useDispatch } from 'calypso/state';
 import { errorNotice } from 'calypso/state/notices/actions';
@@ -37,6 +38,20 @@ function isSafeAuthorizeUrl( url: string, instance: string ): boolean {
 		// reauthorize against, so any other host is by definition wrong.
 		return parsed.host.toLowerCase() === instance.toLowerCase();
 	} catch {
+		// `new URL()` only throws on un-parseable input — that points at a
+		// wpcom-side regression returning gibberish rather than the deliberate
+		// http/wrong-host rejections above. Log to logstash so we can find it
+		// in dashboards; the caller still surfaces the user-visible notice via
+		// the `unsafe_url` errorNotice.
+		logToLogstash( {
+			feature: 'calypso_client',
+			message: 'Reader Mastodon authorize_url failed to parse',
+			severity: 'error',
+			extra: {
+				type: 'reader_mastodon_authorize_url_parse_error',
+				instance,
+			},
+		} );
 		return false;
 	}
 }
@@ -58,7 +73,7 @@ interface MastodonReauthGateProps {
  * query invalidates auth-status and re-renders.
  *
  * Consumers that render the composer (FAB / modal) should also read
- * `useMastodonReauthGateState(connection)` to hide composer affordances
+ * `useMastodonReauthGateState(connection.id)` to hide composer affordances
  * while needs_reauth is true; the FAB sits outside the gate, so without
  * an explicit guard it would float over the reauth prompt.
  */
@@ -190,7 +205,16 @@ function useMastodonReauthHandler( connection: MastodonConnection ) {
 						// The user navigated away (or the connection list
 						// resolved to a different connection) while authorize
 						// was in flight. Don't yank them off whatever page they
-						// landed on.
+						// landed on. Emit a Tracks event so this branch is
+						// distinguishable from a hung mutation in dashboards
+						// when users report "I clicked reconnect, nothing
+						// happened".
+						dispatch(
+							recordReaderTracksEvent( 'calypso_reader_mastodon_authorize_aborted', {
+								reason: 'unmounted',
+								connection_id: connection.id,
+							} )
+						);
 						return;
 					}
 					if ( ! isSafeAuthorizeUrl( authorize_url, connection.instance ) ) {

--- a/client/reader/mastodon/use-mastodon-reauth-gate.tsx
+++ b/client/reader/mastodon/use-mastodon-reauth-gate.tsx
@@ -1,0 +1,253 @@
+import {
+	useAuthorizeMastodonConnectionMutation,
+	useMastodonAuthStatusQuery,
+} from '@automattic/api-queries';
+import { createInterpolateElement } from '@wordpress/element';
+import { useTranslate } from 'i18n-calypso';
+import { ReactNode, useEffect, useRef } from 'react';
+import { ConnectionReauthGate } from 'calypso/reader/social';
+import { useDispatch } from 'calypso/state';
+import { errorNotice } from 'calypso/state/notices/actions';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import { isSafeReturnPath, saveOauthState } from './oauth-state';
+import { useMastodonAuthStatusInvalidator } from './use-mastodon-auth-status-invalidator';
+import type { MastodonConnection } from '@automattic/api-core';
+
+// Adapter that maps `useMastodonAuthStatusQuery`'s shape to the gate's
+// `useAuthStatus` contract. Must be named with a `use` prefix so the
+// rules-of-hooks linter recognises it when passed as a hook prop.
+export function useMastodonAuthStatusForGate( connectionId: number ) {
+	const r = useMastodonAuthStatusQuery( connectionId );
+	return { needsReauth: r.data?.needs_reauth };
+}
+
+// Defence in depth — `authorize()` should only ever return an `https:`
+// authorize URL on the user's instance, but a hostile or buggy upstream
+// could theoretically return something else. Refuse to navigate anywhere
+// that isn't `https:` on the same host the user opted to reconnect to.
+function isSafeAuthorizeUrl( url: string, instance: string ): boolean {
+	try {
+		const parsed = new URL( url );
+		if ( parsed.protocol !== 'https:' ) {
+			return false;
+		}
+		// Pinning to the connection's instance means a hostile upstream can't
+		// redirect a reconnect attempt off to an attacker-controlled host. The
+		// connection's instance is the host the user explicitly chose to
+		// reauthorize against, so any other host is by definition wrong.
+		return parsed.host.toLowerCase() === instance.toLowerCase();
+	} catch {
+		return false;
+	}
+}
+
+interface MastodonReauthGateProps {
+	connection: MastodonConnection;
+	children: ReactNode;
+}
+
+/**
+ * Per-connection reauth gate for Mastodon Reader surfaces. Wrap the
+ * inner content of any per-connection view with this component — when
+ * `auth-status` reports `needs_reauth: true` the children are replaced
+ * by the reconnect prompt, the gate-shown Tracks event fires once per
+ * needs_reauth=true edge, and the reconnect button kicks off the OAuth
+ * handshake (saving the current path so the user lands back where they
+ * started after callback). Mounting this component also subscribes to
+ * the Mastodon query cache so an `auth_required` error from any inner
+ * query invalidates auth-status and re-renders.
+ *
+ * Consumers that render the composer (FAB / modal) should also read
+ * `useMastodonReauthGateState(connection)` to hide composer affordances
+ * while needs_reauth is true; the FAB sits outside the gate, so without
+ * an explicit guard it would float over the reauth prompt.
+ */
+export function MastodonReauthGate( { connection, children }: MastodonReauthGateProps ) {
+	const translate = useTranslate();
+	const { onReconnect, isReconnecting } = useMastodonReauthHandler( connection );
+
+	return (
+		<ConnectionReauthGate
+			connectionId={ connection.id }
+			useAuthStatus={ useMastodonAuthStatusForGate }
+			onReconnect={ onReconnect }
+			isReconnecting={ isReconnecting }
+			headline={ translate( 'Reconnect to update permissions' ) as string }
+			body={ createInterpolateElement(
+				translate(
+					'Your <strong>%(handle)s</strong> connection needs to be refreshed to keep working with new Reader features.',
+					{ args: { handle: connection.handle } }
+				) as string,
+				{ strong: <strong /> }
+			) }
+			buttonLabel={
+				translate( 'Reconnect on %(instance)s', {
+					args: { instance: connection.instance },
+				} ) as string
+			}
+		>
+			{ children }
+		</ConnectionReauthGate>
+	);
+}
+
+/**
+ * Read-only auth-status state for a Mastodon connection. Use this from
+ * components that render the composer alongside `<MastodonReauthGate>`
+ * so they can hide compose affordances while `needsReauth` is true —
+ * any post submitted via the FAB would fail with auth_required anyway,
+ * and the FAB sits outside the gate so it would otherwise float over
+ * the reauth prompt.
+ *
+ * Safe to call alongside `<MastodonReauthGate>` on the same view: React
+ * Query dedupes on key, so the gate's adapter and this hook share one
+ * fetch.
+ */
+export function useMastodonReauthGateState( connectionId: number | null ) {
+	const r = useMastodonAuthStatusQuery( connectionId );
+	return { needsReauth: r.data?.needs_reauth === true };
+}
+
+/**
+ * Internal hook hosting the reconnect handler, the gate-shown Tracks
+ * effect, the auth-status invalidator subscription, and the
+ * mounted-ref guard. Encapsulated so every per-connection view shares
+ * the same telemetry and the same return-path / safety checks without
+ * copy-pasting.
+ */
+function useMastodonReauthHandler( connection: MastodonConnection ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const authorize = useAuthorizeMastodonConnectionMutation();
+
+	// Subscribe to the mastodon query cache; any auth_required error
+	// invalidates auth-status so the gate refetches and re-renders.
+	useMastodonAuthStatusInvalidator( connection.id );
+
+	// Top-level read of auth-status so this hook can fire the gate-shown
+	// Tracks event. The gate's adapter calls `useMastodonAuthStatusQuery`
+	// against the same key, so React Query dedupes — one fetch.
+	const authStatus = useMastodonAuthStatusQuery( connection.id );
+
+	const gateShownConnectionId = useRef< number | null >( null );
+	useEffect( () => {
+		if (
+			authStatus.data?.needs_reauth === true &&
+			gateShownConnectionId.current !== connection.id
+		) {
+			dispatch(
+				recordReaderTracksEvent( 'calypso_reader_reauth_gate_shown', {
+					provider: 'mastodon',
+					connection_id: connection.id,
+					trigger: 'auth-status',
+				} )
+			);
+			gateShownConnectionId.current = connection.id;
+		} else if ( authStatus.data?.needs_reauth === false ) {
+			// Reset the dedupe guard once the connection is healthy again so
+			// a later token expiry in the same session re-fires the
+			// `gate_shown` event. Without this reset the second
+			// needs_reauth=true edge would be silently swallowed and Tracks
+			// would under-count repeat reauth prompts.
+			if ( gateShownConnectionId.current === connection.id ) {
+				gateShownConnectionId.current = null;
+			}
+		}
+		// connection.id is the load-bearing identity here; we don't want
+		// to refire on connection-object identity churn from React Query.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ connection.id, authStatus.data?.needs_reauth, dispatch ] );
+
+	// Tracks whether the component is still mounted so a slow authorize()
+	// resolution can't yank the user off a page they navigated to during
+	// the round trip. Also short-circuits double-clicks before
+	// authorize.isPending flips.
+	const mountedRef = useRef( true );
+	useEffect( () => {
+		mountedRef.current = true;
+		return () => {
+			mountedRef.current = false;
+		};
+	}, [] );
+
+	const onReconnect = () => {
+		if ( authorize.isPending ) {
+			return;
+		}
+		dispatch(
+			recordReaderTracksEvent( 'calypso_reader_reauth_button_clicked', {
+				provider: 'mastodon',
+				connection_id: connection.id,
+			} )
+		);
+		const rawReturnPath = window.location.pathname + window.location.search;
+		const returnPath = isSafeReturnPath( rawReturnPath ) ? rawReturnPath : undefined;
+		authorize.mutate(
+			{ instance: connection.instance },
+			{
+				onSuccess: ( { authorize_url, state } ) => {
+					if ( ! mountedRef.current ) {
+						// The user navigated away (or the connection list
+						// resolved to a different connection) while authorize
+						// was in flight. Don't yank them off whatever page they
+						// landed on.
+						return;
+					}
+					if ( ! isSafeAuthorizeUrl( authorize_url, connection.instance ) ) {
+						dispatch(
+							errorNotice(
+								translate( 'We couldn’t start the reconnect safely. Please try again.' ),
+								{ duration: 5000 }
+							)
+						);
+						dispatch(
+							recordReaderTracksEvent( 'calypso_reader_mastodon_authorize_error', {
+								reason: 'unsafe_url',
+							} )
+						);
+						return;
+					}
+					const saved = saveOauthState( {
+						state,
+						instance: connection.instance,
+						returnPath,
+						reconnectingConnectionId: connection.id,
+					} );
+					if ( ! saved ) {
+						// sessionStorage was unavailable. The callback view
+						// validates `state` against the stored value, so without
+						// it the round-trip would always fail — refuse to redirect.
+						dispatch(
+							errorNotice(
+								translate( 'We couldn’t start the reconnect safely. Please try again.' ),
+								{ duration: 5000 }
+							)
+						);
+						dispatch(
+							recordReaderTracksEvent( 'calypso_reader_mastodon_authorize_error', {
+								reason: 'state_persist_failed',
+							} )
+						);
+						return;
+					}
+					window.location.assign( authorize_url );
+				},
+				onError: ( error ) => {
+					dispatch(
+						errorNotice( translate( 'Could not start the reconnect. Please try again.' ), {
+							duration: 5000,
+						} )
+					);
+					dispatch(
+						recordReaderTracksEvent( 'calypso_reader_mastodon_authorize_error', {
+							reason: 'authorize_failed',
+							error_kind: error.kind,
+						} )
+					);
+				},
+			}
+		);
+	};
+
+	return { onReconnect, isReconnecting: authorize.isPending };
+}


### PR DESCRIPTION
## Proposed Changes

* Extract the per-connection Mastodon reauth wiring (auth-status adapter, gate-shown Tracks effect, auth-status cache invalidator, mounted-ref guard, reconnect handler with `isSafeReturnPath` / `isSafeAuthorizeUrl` defence-in-depth) into a shared `use-mastodon-reauth-gate.tsx` module.
* Wrap the inner content of `author-profile-view`, `mastodon-thread-view`, and `tag-feed-view` with `<MastodonReauthGate>` so users with stale OAuth scopes see the same reconnect prompt that already covers the account view.
* Hide the composer FAB / modal on author and thread views while `needs_reauth: true`, mirroring the account-view guard — the FAB sits outside the gate so it would otherwise float over the prompt.
* Refactor `mastodon-account-view` to consume the shared module, removing ~150 lines of inline wiring.
* Add reauth tests mirroring `mastodon-account-view-reauth.test.tsx` for each newly-gated view: gate renders when `needs_reauth: true`, gated content renders on `false`, the gate-shown Tracks event fires, the reconnect button persists a return path that matches the current surface URL, and authorize errors surface a notice.

## Why are these changes being made?

When a user's stored Mastodon OAuth token is missing scopes that newer Reader features require (e.g. `write:follows`), `GET /wpcom/v2/reader/mastodon/connections/{id}/auth-status` returns `{ needs_reauth: true }`. The "Reconnect to update permissions" banner was previously rendered only on the account view. The per-connection profile, thread, and tag-feed views all let users click action buttons (Follow, Like, Boost, Reply) that fail with a generic `reader_mastodon_upstream_unavailable` (502) toast and leave no path to recover from that screen.

Surfacing the gate on every per-connection surface gives the user a consistent recovery affordance regardless of which deep link they followed. React Query dedupes on key, so adding the auth-status read on each view does not introduce extra HTTP requests as the user navigates between them.

## Testing Instructions

1. With a Mastodon connection whose stored token lacks `write:follows` (or whose `auth-status` endpoint returns `needs_reauth: true`):
   * Visit `/reader/mastodon/{id}/profile/{actor}` — the reauth banner should appear in place of the profile + feed; the Follow button should not be reachable; the compose FAB should be hidden.
   * Visit `/reader/mastodon/{id}/thread/{status_id}` — same behaviour for the thread tree.
   * Visit `/reader/mastodon/{id}/tag/{hashtag}` — same behaviour for the tag feed.
   * Click "Reconnect on {instance}" — after the OAuth round-trip the user should land back on the same `/profile`, `/thread`, or `/tag` URL they started from, not the timeline.
2. With a healthy connection (`needs_reauth: false`):
   * All three views should render their content as before; the compose FAB should be present on author / thread views.
3. Run `yarn test-client client/reader/mastodon` — all 29 suites should pass.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?