### PR TITLE
APM: Rework Backend Overview with side rail, area chart, and slow-requests bar list

### DIFF
--- a/client/dashboard/sites/performance/backend/backend-status.tsx
+++ b/client/dashboard/sites/performance/backend/backend-status.tsx
@@ -1,0 +1,81 @@
+import { __, sprintf } from '@wordpress/i18n';
+import { Notice } from '../../../components/notice';
+
+export type BackendStatus = 'good' | 'needsImprovement' | 'bad';
+
+export function getBackendStatus( avgResponseMs: number ): BackendStatus {
+	if ( avgResponseMs <= 500 ) {
+		return 'good';
+	}
+	if ( avgResponseMs <= 1500 ) {
+		return 'needsImprovement';
+	}
+	return 'bad';
+}
+
+function formatMs( ms: number ): string {
+	if ( ms >= 1000 ) {
+		return sprintf(
+			/* translators: %s is a number of seconds. */
+			__( '%s s' ),
+			( ms / 1000 ).toFixed( 2 )
+		);
+	}
+	return sprintf(
+		/* translators: %d is a number of milliseconds. */
+		__( '%d ms' ),
+		ms
+	);
+}
+
+export default function BackendStatusNotice( { avgResponseMs }: { avgResponseMs: number } ) {
+	const status = getBackendStatus( avgResponseMs );
+	const formatted = formatMs( avgResponseMs );
+
+	if ( status === 'bad' ) {
+		return (
+			<Notice
+				variant="error"
+				title={ sprintf(
+					/* translators: %s is the average response time. */
+					__( 'Backend is slow — avg %s' ),
+					formatted
+				) }
+			>
+				{ __(
+					'Most requests are taking longer than expected. Review the slowest requests below to find the cause.'
+				) }
+			</Notice>
+		);
+	}
+
+	if ( status === 'needsImprovement' ) {
+		return (
+			<Notice
+				variant="warning"
+				title={ sprintf(
+					/* translators: %s is the average response time. */
+					__( 'Backend needs improvement — avg %s' ),
+					formatted
+				) }
+			>
+				{ __(
+					'Some requests are running slow. Review the slowest requests below to make targeted improvements.'
+				) }
+			</Notice>
+		);
+	}
+
+	return (
+		<Notice
+			variant="success"
+			title={ sprintf(
+				/* translators: %s is the average response time. */
+				__( 'Healthy backend — avg %s' ),
+				formatted
+			) }
+		>
+			{ __( 'Most requests respond quickly. Review the slowest ones below to keep it that way.' ) }
+		</Notice>
+	);
+}

--- a/client/dashboard/sites/performance/backend/backend-tabs.tsx
+++ b/client/dashboard/sites/performance/backend/backend-tabs.tsx
@@ -1,0 +1,131 @@
+import { __experimentalVStack as VStack, privateApis } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
+import { __, sprintf } from '@wordpress/i18n';
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+import { Text } from '../../../components/text';
+import { VIEWPORT_BREAKPOINTS } from '../constants';
+import type { ApmTab } from '.';
+import type { ApmSummary } from '@automattic/api-core';
+
+const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+	'@wordpress/components'
+);
+
+const { Tabs } = unlock( privateApis );
+
+type Intent = 'success' | 'warning' | 'error';
+
+function formatMs( ms: number ): string {
+	if ( ms >= 1000 ) {
+		return sprintf(
+			/* translators: %s is a number of seconds. */
+			__( '%s s' ),
+			( ms / 1000 ).toFixed( 2 )
+		);
+	}
+	return sprintf(
+		/* translators: %d is a number of milliseconds. */
+		__( '%d ms' ),
+		ms
+	);
+}
+
+function formatCount( value: number ): string {
+	return new Intl.NumberFormat().format( value );
+}
+
+function bucketByMs( ms: number, good: number, warn: number ): Intent {
+	if ( ms <= good ) {
+		return 'success';
+	}
+	if ( ms <= warn ) {
+		return 'warning';
+	}
+	return 'error';
+}
+
+function Tab( {
+	tabId,
+	label,
+	value,
+	intent,
+}: {
+	tabId: ApmTab;
+	label: string;
+	value: string;
+	intent?: Intent;
+} ) {
+	const isDesktop = useViewportMatch( VIEWPORT_BREAKPOINTS.desktop );
+
+	return (
+		<Tabs.Tab tabId={ tabId } style={ { height: '100%' } }>
+			<VStack alignment={ isDesktop ? 'flex-start' : 'center' } spacing={ 0 }>
+				<Text size={ 11 } lineHeight="24px" upperCase variant="muted">
+					{ label }
+				</Text>
+				<Text size={ 16 } weight={ 500 } lineHeight="32px" intent={ intent }>
+					{ value }
+				</Text>
+			</VStack>
+		</Tabs.Tab>
+	);
+}
+
+export default function BackendTabs( {
+	summary,
+	compact,
+}: {
+	summary: ApmSummary;
+	compact?: boolean;
+} ) {
+	const items: Array< {
+		tabId: ApmTab;
+		label: string;
+		value: string;
+		intent?: Intent;
+	} > = [
+		{
+			tabId: 'overview',
+			label: compact ? __( 'Avg' ) : __( 'Avg response' ),
+			value: formatMs( summary.avg_response_ms ),
+			intent: bucketByMs( summary.avg_response_ms, 500, 1500 ),
+		},
+		{
+			tabId: 'requests',
+			label: compact ? __( 'Slow' ) : __( 'Slow requests' ),
+			value: formatCount( summary.slow_request_count ),
+		},
+		{
+			tabId: 'transactions',
+			label: __( 'Transactions' ),
+			value: formatCount( summary.transaction_count ),
+		},
+		{
+			tabId: 'database',
+			label: compact ? __( 'DB' ) : __( 'Database' ),
+			value: formatMs( summary.db_avg_ms ),
+			intent: bucketByMs( summary.db_avg_ms, 200, 600 ),
+		},
+		{
+			tabId: 'external-requests',
+			label: __( 'External' ),
+			value: formatMs( summary.external_avg_ms ),
+			intent: bucketByMs( summary.external_avg_ms, 200, 600 ),
+		},
+	];
+
+	return (
+		<Tabs.TabList style={ { maxWidth: '100%' } }>
+			{ items.map( ( item ) => (
+				<Tab
+					key={ item.tabId }
+					tabId={ item.tabId }
+					label={ item.label }
+					value={ item.value }
+					intent={ item.intent }
+				/>
+			) ) }
+		</Tabs.TabList>
+	);
+}

--- a/client/dashboard/sites/performance/backend/index.tsx
+++ b/client/dashboard/sites/performance/backend/index.tsx
@@ -2,18 +2,28 @@ import { type Site } from '@automattic/api-core';
 import { siteBySlugQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
-import { TabPanel } from '@wordpress/components';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	privateApis,
+} from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { Card, CardBody, CardHeader } from '../../../components/card';
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+import { Card } from '../../../components/card';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
 import UpsellCallout from '../../hosting-feature-gated-with-callout/upsell';
 import { hasBackendAccess } from '../backend-access';
 import { getBackendCalloutProps } from '../backend-callout';
+import { VIEWPORT_BREAKPOINTS } from '../constants';
 import PerformanceTabs from '../performance-tabs';
+import BackendStatusNotice from './backend-status';
+import BackendTabs from './backend-tabs';
 import Database from './database';
 import EnableApmCallout from './enable-apm-callout';
 import ExternalRequests from './external-requests';
+import { siteApmOverviewQuery } from './mock-data';
 import Overview from './overview';
 import Requests from './requests';
 import Transactions from './transactions';
@@ -28,17 +38,18 @@ const TAB_PATHS: Record< ApmTab, string > = {
 	'external-requests': 'external-requests',
 };
 
+const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+	'@wordpress/components'
+);
+
+const { Tabs } = unlock( privateApis );
+
 function ApmDashboard( { site, tab }: { site: Site; tab: ApmTab } ) {
 	const router = useRouter();
 	const siteSlug = site.slug;
-
-	const tabs = [
-		{ name: 'overview' as const, title: __( 'Overview' ) },
-		{ name: 'requests' as const, title: __( 'Requests' ) },
-		{ name: 'transactions' as const, title: __( 'Transactions' ) },
-		{ name: 'database' as const, title: __( 'Database' ) },
-		{ name: 'external-requests' as const, title: __( 'External requests' ) },
-	];
+	const isDesktop = useViewportMatch( VIEWPORT_BREAKPOINTS.desktop );
+	const { data } = useSuspenseQuery( siteApmOverviewQuery( site.ID ) );
 
 	const handleTabChange = ( name: string ) => {
 		const next = name as ApmTab;
@@ -69,19 +80,29 @@ function ApmDashboard( { site, tab }: { site: Site; tab: ApmTab } ) {
 	};
 
 	return (
-		<Card>
-			<CardHeader style={ { paddingBottom: 0 } }>
-				<TabPanel
-					activeClass="is-active"
-					tabs={ tabs }
-					initialTabName={ tab }
-					onSelect={ handleTabChange }
-				>
-					{ () => null }
-				</TabPanel>
-			</CardHeader>
-			<CardBody>{ renderTab() }</CardBody>
-		</Card>
+		<VStack spacing={ 6 }>
+			<BackendStatusNotice avgResponseMs={ data.summary.avg_response_ms } />
+			<Tabs
+				orientation={ isDesktop ? 'vertical' : 'horizontal' }
+				selectedTabId={ tab }
+				onSelect={ handleTabChange }
+			>
+				<HStack wrap={ ! isDesktop } alignment="flex-start" justify="flex-start" spacing={ 6 }>
+					<Card
+						style={ {
+							flex: '0 0 auto',
+							width: isDesktop ? 280 : '100%',
+							alignSelf: 'flex-start',
+						} }
+					>
+						<BackendTabs compact={ ! isDesktop } summary={ data.summary } />
+					</Card>
+					<div style={ { flex: '1 1 auto', minWidth: 0, width: '100%' } }>
+						<Tabs.TabPanel tabId={ tab }>{ renderTab() }</Tabs.TabPanel>
+					</div>
+				</HStack>
+			</Tabs>
+		</VStack>
 	);
 }
 

--- a/client/dashboard/sites/performance/backend/mock-data.ts
+++ b/client/dashboard/sites/performance/backend/mock-data.ts
@@ -3,7 +3,13 @@
 // move the fetchers to `@automattic/api-core` and the queries to
 // `@automattic/api-queries`, then delete this file.
 import { queryOptions } from '@tanstack/react-query';
-import type { ApmOverview, ApmRequestDetail, ApmSlowRequest } from '@automattic/api-core';
+import type {
+	ApmOverview,
+	ApmRequestDetail,
+	ApmSlowRequest,
+	ApmSummary,
+	ApmTimePoint,
+} from '@automattic/api-core';
 
 function rng( seed: number ) {
 	let state = seed | 0;
@@ -61,6 +67,7 @@ function generateSlowRequests( seed: number, count: number ): ApmSlowRequest[] {
 			[ 'PUT', 0.15 ],
 		] );
 		const duration_ms = Math.round( 1500 + random() * 8500 );
+		const avg_duration_ms = Math.round( duration_ms * ( 0.25 + random() * 0.4 ) );
 		const status = pickWeighted( random, [
 			[ 200, 0.8 ],
 			[ 302, 0.15 ],
@@ -70,12 +77,33 @@ function generateSlowRequests( seed: number, count: number ): ApmSlowRequest[] {
 			id: `req-${ seed.toString( 36 ) }-${ i }`,
 			url,
 			method,
+			avg_duration_ms,
 			duration_ms,
 			status,
 			timestamp: now - Math.round( random() * 24 * 60 * 60 * 1000 ),
 		} );
 	}
 	return requests.sort( ( a, b ) => b.duration_ms - a.duration_ms );
+}
+
+function generateSummary( timeseries: ApmTimePoint[], slowRequests: ApmSlowRequest[] ): ApmSummary {
+	const totals = timeseries.reduce(
+		( acc, point ) => {
+			acc.total += point.db + point.wp_core + point.plugins + point.external + point.cache;
+			acc.db += point.db;
+			acc.external += point.external;
+			return acc;
+		},
+		{ total: 0, db: 0, external: 0 }
+	);
+	const points = Math.max( timeseries.length, 1 );
+	return {
+		avg_response_ms: Math.round( totals.total / points ),
+		slow_request_count: slowRequests.length,
+		transaction_count: 1000 + slowRequests.length * 47,
+		db_avg_ms: Math.round( totals.db / points ),
+		external_avg_ms: Math.round( totals.external / points ),
+	};
 }
 
 function fetchApmOverview( siteId: number ): Promise< ApmOverview > {
@@ -87,11 +115,14 @@ function fetchApmOverview( siteId: number ): Promise< ApmOverview > {
 		wp_core: Math.round( 50 + random() * 120 ),
 		plugins: Math.round( 60 + random() * 260 ),
 		external: Math.round( 20 + random() * 180 ),
+		cache: Math.round( 10 + random() * 80 ),
 	} ) );
+	const slowRequests = generateSlowRequests( siteId, 8 );
 
 	return Promise.resolve( {
+		summary: generateSummary( timeseries, slowRequests ),
 		timeseries,
-		slow_requests: generateSlowRequests( siteId, 8 ),
+		slow_requests: slowRequests,
 	} );
 }
 
@@ -102,12 +133,14 @@ function fetchApmSlowRequests( siteId: number ): Promise< ApmSlowRequest[] > {
 function fetchApmRequest( siteId: number, requestId: string ): Promise< ApmRequestDetail > {
 	const seed = siteId ^ hashString( requestId );
 	const random = rng( seed );
+	const duration_ms = Math.round( 1500 + random() * 8500 );
 
 	return Promise.resolve( {
 		id: requestId,
 		url: SAMPLE_PATHS[ Math.floor( random() * SAMPLE_PATHS.length ) ],
 		method: random() < 0.7 ? 'GET' : 'POST',
-		duration_ms: Math.round( 1500 + random() * 8500 ),
+		avg_duration_ms: Math.round( duration_ms * ( 0.25 + random() * 0.4 ) ),
+		duration_ms,
 		status: 200,
 		timestamp: Date.now() - Math.round( random() * 60 * 60 * 1000 ),
 	} );

--- a/client/dashboard/sites/performance/backend/overview/chart-slot.tsx
+++ b/client/dashboard/sites/performance/backend/overview/chart-slot.tsx
@@ -1,16 +1,23 @@
-import { AreaChart, type SeriesData } from '@automattic/charts';
-import { __experimentalText as Text } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { AreaChart, GlobalChartsProvider, type SeriesData } from '@automattic/charts';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
 import { Card, CardBody, CardHeader } from '../../../../components/card';
+import { Text } from '../../../../components/text';
 import type { ApmTimePoint } from '@automattic/api-core';
 
 import '@automattic/charts/style.css';
+
+const CHART_ID = 'apm-response-time-breakdown';
 
 const SERIES: Array< { key: keyof Omit< ApmTimePoint, 'timestamp' >; label: string } > = [
 	{ key: 'db', label: __( 'Database' ) },
 	{ key: 'wp_core', label: __( 'WordPress core' ) },
 	{ key: 'plugins', label: __( 'Plugins' ) },
 	{ key: 'external', label: __( 'External' ) },
+	{ key: 'cache', label: __( 'Cache' ) },
 ];
 
 function toSeriesData( timeseries: ApmTimePoint[] ): SeriesData[] {
@@ -23,23 +30,68 @@ function toSeriesData( timeseries: ApmTimePoint[] ): SeriesData[] {
 	} ) );
 }
 
+function formatMs( ms: number ): string {
+	if ( ms >= 1000 ) {
+		return sprintf(
+			/* translators: %s is a number of seconds. */
+			__( '%s s' ),
+			( ms / 1000 ).toFixed( 2 )
+		);
+	}
+	return sprintf(
+		/* translators: %d is a number of milliseconds. */
+		__( '%d ms' ),
+		ms
+	);
+}
+
+function getAverageTotal( timeseries: ApmTimePoint[] ): number {
+	if ( ! timeseries.length ) {
+		return 0;
+	}
+	const total = timeseries.reduce(
+		( sum, point ) => sum + point.db + point.wp_core + point.plugins + point.external + point.cache,
+		0
+	);
+	return Math.round( total / timeseries.length );
+}
+
 export default function ChartSlot( { timeseries }: { timeseries: ApmTimePoint[] } ) {
 	const data = toSeriesData( timeseries );
+	const averageTotal = getAverageTotal( timeseries );
 
 	return (
 		<Card>
 			<CardHeader>
-				<Text weight={ 500 }>{ __( 'Response time breakdown' ) }</Text>
+				<HStack wrap spacing={ 4 } justify="space-between" alignment="flex-start">
+					<VStack spacing={ 2 } alignment="flex-start">
+						<Text size="title" weight={ 500 } as="h2">
+							{ __( 'Response time breakdown' ) }
+						</Text>
+						<Text size={ 32 } weight={ 500 } lineHeight="40px">
+							{ formatMs( averageTotal ) }
+						</Text>
+						<Text variant="muted">
+							{ __(
+								'Average time spent across the database, WordPress core, plugins, external requests, and cache.'
+							) }
+						</Text>
+					</VStack>
+				</HStack>
 			</CardHeader>
 			<CardBody>
-				<AreaChart
-					height={ 320 }
-					data={ data }
-					stacked
-					curveType="monotone"
-					showLegend
-					withTooltips
-				/>
+				<GlobalChartsProvider>
+					<AreaChart
+						chartId={ CHART_ID }
+						height={ 320 }
+						data={ data }
+						stacked
+						curveType="monotone"
+						showLegend
+						legend={ { interactive: true } }
+						withTooltips
+					/>
+				</GlobalChartsProvider>
 			</CardBody>
 		</Card>
 	);

--- a/client/dashboard/sites/performance/backend/overview/chart-slot.tsx
+++ b/client/dashboard/sites/performance/backend/overview/chart-slot.tsx
@@ -1,14 +1,45 @@
+import { AreaChart, type SeriesData } from '@automattic/charts';
 import { __experimentalText as Text } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Card, CardBody } from '../../../../components/card';
+import { Card, CardBody, CardHeader } from '../../../../components/card';
+import type { ApmTimePoint } from '@automattic/api-core';
 
-export default function ChartSlot() {
+import '@automattic/charts/style.css';
+
+const SERIES: Array< { key: keyof Omit< ApmTimePoint, 'timestamp' >; label: string } > = [
+	{ key: 'db', label: __( 'Database' ) },
+	{ key: 'wp_core', label: __( 'WordPress core' ) },
+	{ key: 'plugins', label: __( 'Plugins' ) },
+	{ key: 'external', label: __( 'External' ) },
+];
+
+function toSeriesData( timeseries: ApmTimePoint[] ): SeriesData[] {
+	return SERIES.map( ( { key, label } ) => ( {
+		label,
+		data: timeseries.map( ( point ) => ( {
+			date: new Date( point.timestamp ),
+			value: point[ key ],
+		} ) ),
+	} ) );
+}
+
+export default function ChartSlot( { timeseries }: { timeseries: ApmTimePoint[] } ) {
+	const data = toSeriesData( timeseries );
+
 	return (
 		<Card>
+			<CardHeader>
+				<Text weight={ 500 }>{ __( 'Response time breakdown' ) }</Text>
+			</CardHeader>
 			<CardBody>
-				<div style={ { minHeight: 320, display: 'grid', placeItems: 'center' } }>
-					<Text variant="muted">{ __( 'Response time chart coming soon.' ) }</Text>
-				</div>
+				<AreaChart
+					height={ 320 }
+					data={ data }
+					stacked
+					curveType="monotone"
+					showLegend
+					withTooltips
+				/>
 			</CardBody>
 		</Card>
 	);

--- a/client/dashboard/sites/performance/backend/overview/index.tsx
+++ b/client/dashboard/sites/performance/backend/overview/index.tsx
@@ -10,7 +10,7 @@ export default function Overview( { site }: { site: Site } ) {
 
 	return (
 		<VStack spacing={ 6 }>
-			<ChartSlot />
+			<ChartSlot timeseries={ data.timeseries } />
 			<SlowRequestsList site={ site } slowRequests={ data.slow_requests } />
 		</VStack>
 	);

--- a/client/dashboard/sites/performance/backend/overview/slow-requests-list.tsx
+++ b/client/dashboard/sites/performance/backend/overview/slow-requests-list.tsx
@@ -1,12 +1,30 @@
+import { BarListChart, GlobalChartsProvider, type SeriesData } from '@automattic/charts';
 import { useRouter } from '@tanstack/react-router';
-import { __experimentalText as Text, Button } from '@wordpress/components';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	Button,
+} from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { Card, CardBody, CardHeader } from '../../../../components/card';
+import { useState } from 'react';
+import { Card, CardBody, CardHeader, CardFooter } from '../../../../components/card';
+import { Text } from '../../../../components/text';
 import type { ApmSlowRequest, Site } from '@automattic/api-core';
+
+import '@automattic/charts/style.css';
+
+type Metric = 'avg' | 'max';
+const CHART_ID = 'apm-slow-requests';
 
 function formatDuration( ms: number ): string {
 	if ( ms >= 1000 ) {
-		return `${ ( ms / 1000 ).toFixed( 2 ) } s`;
+		return sprintf(
+			/* translators: %s is a number of seconds. */
+			__( '%s s' ),
+			( ms / 1000 ).toFixed( 2 )
+		);
 	}
 	return sprintf(
 		/* translators: %d is a number of milliseconds. */
@@ -15,25 +33,27 @@ function formatDuration( ms: number ): string {
 	);
 }
 
-function formatRelativeTime( timestamp: number ): string {
-	const diffSec = Math.floor( ( Date.now() - timestamp ) / 1000 );
-	if ( diffSec < 60 ) {
-		return __( 'just now' );
+function toSeriesData( requests: ApmSlowRequest[], metric: Metric ): SeriesData[] {
+	return [
+		{
+			label: metric === 'avg' ? __( 'Average' ) : __( 'Max' ),
+			data: requests.map( ( request ) => ( {
+				label: `${ request.method } ${ request.url }`,
+				value: metric === 'avg' ? request.avg_duration_ms : request.duration_ms,
+			} ) ),
+		},
+	];
+}
+
+function pickHeadlineDuration( requests: ApmSlowRequest[], metric: Metric ): number {
+	if ( ! requests.length ) {
+		return 0;
 	}
-	const diffMin = Math.floor( diffSec / 60 );
-	if ( diffMin < 60 ) {
-		return sprintf(
-			/* translators: %d is a number of minutes. */
-			__( '%dm ago' ),
-			diffMin
-		);
+	if ( metric === 'avg' ) {
+		const total = requests.reduce( ( sum, r ) => sum + r.avg_duration_ms, 0 );
+		return Math.round( total / requests.length );
 	}
-	const diffHr = Math.floor( diffMin / 60 );
-	return sprintf(
-		/* translators: %d is a number of hours. */
-		__( '%dh ago' ),
-		diffHr
-	);
+	return requests.reduce( ( max, r ) => Math.max( max, r.duration_ms ), 0 );
 }
 
 export default function SlowRequestsList( {
@@ -44,50 +64,70 @@ export default function SlowRequestsList( {
 	slowRequests: ApmSlowRequest[];
 } ) {
 	const router = useRouter();
+	const [ metric, setMetric ] = useState< Metric >( 'max' );
 
-	const navigateToRequest = ( request: ApmSlowRequest ) => {
+	const data = toSeriesData( slowRequests, metric );
+	const headline = pickHeadlineDuration( slowRequests, metric );
+	const height = Math.max( 240, slowRequests.length * 36 );
+
+	const viewAllRequests = () => {
 		router.navigate( {
-			to: `/sites/${ site.slug }/performance/backend/requests/${ request.id }`,
+			to: `/sites/${ site.slug }/performance/backend/requests`,
 		} );
 	};
+
+	const description =
+		metric === 'avg'
+			? __( 'Average response time across the slowest endpoints in the selected period.' )
+			: __( 'Slowest single response observed across these endpoints in the selected period.' );
 
 	return (
 		<Card>
 			<CardHeader>
-				<Text weight={ 600 }>{ __( 'Slowest requests' ) }</Text>
+				<HStack wrap spacing={ 4 } justify="space-between" alignment="flex-start">
+					<VStack spacing={ 2 } alignment="flex-start">
+						<Text size="title" weight={ 500 } as="h2">
+							{ __( 'Slowest requests' ) }
+						</Text>
+						<Text size={ 32 } weight={ 500 } lineHeight="40px">
+							{ formatDuration( headline ) }
+						</Text>
+						<Text variant="muted">{ description }</Text>
+					</VStack>
+					<ToggleGroupControl
+						value={ metric }
+						isBlock
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+						onChange={ ( value ) => setMetric( ( value as Metric ) ?? 'max' ) }
+						label={ __( 'Duration metric' ) }
+						hideLabelFromVision
+					>
+						<ToggleGroupControlOption value="avg" label={ __( 'Avg' ) } />
+						<ToggleGroupControlOption value="max" label={ __( 'Max' ) } />
+					</ToggleGroupControl>
+				</HStack>
 			</CardHeader>
 			<CardBody>
-				<table style={ { width: '100%', borderCollapse: 'collapse' } }>
-					<thead>
-						<tr>
-							<th style={ { textAlign: 'start', padding: '8px 0' } }>{ __( 'URL' ) }</th>
-							<th style={ { textAlign: 'start', padding: '8px 0' } }>{ __( 'Method' ) }</th>
-							<th style={ { textAlign: 'start', padding: '8px 0' } }>{ __( 'Status' ) }</th>
-							<th style={ { textAlign: 'end', padding: '8px 0' } }>{ __( 'Duration' ) }</th>
-							<th style={ { textAlign: 'end', padding: '8px 0' } }>{ __( 'When' ) }</th>
-						</tr>
-					</thead>
-					<tbody>
-						{ slowRequests.map( ( request ) => (
-							<tr key={ request.id }>
-								<td style={ { padding: '8px 0' } }>
-									<Button variant="link" onClick={ () => navigateToRequest( request ) }>
-										{ request.url }
-									</Button>
-								</td>
-								<td style={ { padding: '8px 0' } }>{ request.method }</td>
-								<td style={ { padding: '8px 0' } }>{ request.status }</td>
-								<td style={ { padding: '8px 0', textAlign: 'end' } }>
-									{ formatDuration( request.duration_ms ) }
-								</td>
-								<td style={ { padding: '8px 0', textAlign: 'end' } }>
-									<Text variant="muted">{ formatRelativeTime( request.timestamp ) }</Text>
-								</td>
-							</tr>
-						) ) }
-					</tbody>
-				</table>
+				<GlobalChartsProvider>
+					<BarListChart
+						chartId={ CHART_ID }
+						data={ data }
+						height={ height }
+						withTooltips
+						options={ {
+							yScale: {},
+							xScale: {},
+							valueFormatter: formatDuration,
+						} }
+					/>
+				</GlobalChartsProvider>
 			</CardBody>
+			<CardFooter>
+				<Button variant="secondary" onClick={ viewAllRequests }>
+					{ __( 'View all requests' ) }
+				</Button>
+			</CardFooter>
 		</Card>
 	);
 }

--- a/client/dashboard/sites/performance/backend/test/index.test.tsx
+++ b/client/dashboard/sites/performance/backend/test/index.test.tsx
@@ -9,6 +9,10 @@ import { render } from '../../../../test-utils';
 import SitePerformanceBackend from '../index';
 import type { Site } from '@automattic/api-core';
 
+jest.mock( '@automattic/charts', () => ( {
+	AreaChart: () => null,
+} ) );
+
 const siteSlug = 'test-site.wordpress.com';
 const siteId = 1;
 

--- a/client/dashboard/sites/performance/backend/test/index.test.tsx
+++ b/client/dashboard/sites/performance/backend/test/index.test.tsx
@@ -11,6 +11,8 @@ import type { Site } from '@automattic/api-core';
 
 jest.mock( '@automattic/charts', () => ( {
 	AreaChart: () => null,
+	BarListChart: () => null,
+	GlobalChartsProvider: ( { children }: { children: React.ReactNode } ) => children,
 } ) );
 
 const siteSlug = 'test-site.wordpress.com';
@@ -72,11 +74,10 @@ describe( '<SitePerformanceBackend>', () => {
 
 		render( <SitePerformanceBackend siteSlug={ siteSlug } /> );
 
-		expect( await screen.findByRole( 'tab', { name: 'Overview' } ) ).toBeVisible();
-		expect( screen.getByRole( 'tab', { name: 'Requests' } ) ).toBeVisible();
-		expect( screen.getByRole( 'tab', { name: 'Transactions' } ) ).toBeVisible();
-		expect( screen.getByRole( 'tab', { name: 'Database' } ) ).toBeVisible();
-		expect( screen.getByRole( 'tab', { name: 'External requests' } ) ).toBeVisible();
+		expect(
+			await screen.findByRole( 'heading', { name: 'Response time breakdown' } )
+		).toBeVisible();
+		expect( screen.getByRole( 'heading', { name: 'Slowest requests' } ) ).toBeVisible();
 	} );
 
 	test( 'clicking Enable POSTs { active: true }', async () => {

--- a/packages/api-core/src/site-hosting-apm/types.ts
+++ b/packages/api-core/src/site-hosting-apm/types.ts
@@ -4,12 +4,14 @@ export interface ApmTimePoint {
 	wp_core: number;
 	plugins: number;
 	external: number;
+	cache: number;
 }
 
 export interface ApmSlowRequest {
 	id: string;
 	url: string;
 	method: string;
+	avg_duration_ms: number;
 	duration_ms: number;
 	status: number;
 	timestamp: number;
@@ -17,7 +19,16 @@ export interface ApmSlowRequest {
 
 export type ApmRequestDetail = ApmSlowRequest;
 
+export interface ApmSummary {
+	avg_response_ms: number;
+	slow_request_count: number;
+	transaction_count: number;
+	db_avg_ms: number;
+	external_avg_ms: number;
+}
+
 export interface ApmOverview {
+	summary: ApmSummary;
 	timeseries: ApmTimePoint[];
 	slow_requests: ApmSlowRequest[];
 }


### PR DESCRIPTION
Part of [APM-TBD]

## Proposed Changes

Restructures the Backend Overview to match the Frontend page pattern: a status `Notice` at the top, a left-rail `Card` with five metric tabs (Avg response, Slow, Transactions, DB, External), and a content panel for the active tab.

Overview tab:

- Response time breakdown card has an interactive legend (toggle series on/off) and adds a `cache` series.
- Slowest requests card uses `BarListChart` from `@automattic/charts` with an Avg / Max toggle in the header; `View all requests` moves to a `CardFooter`.

Extends `@automattic/api-core` APM types with `ApmSummary`, `ApmTimePoint.cache`, and `ApmSlowRequest.avg_duration_ms`; mock data updated to match.

## Why?

The previous Backend Overview was a placeholder (stub chart + plain table). Aligning it with the Frontend page makes the two surfaces feel like one product, and the bar list + Avg / Max toggle matches what users expect from APM tools.

## Testing Instructions

1. `yarn start-dashboard-only`, then visit `/sites/<slug>/performance/backend` on a Business+ Atomic site with `apm_enabled`.
2. Status `Notice` reflects the average response time; left rail switches the content panel.
3. On Overview: toggle legend series; toggle Avg / Max on the slow-requests card; `View all requests` jumps to the Requests tab.
4. `yarn test-client client/dashboard/sites/performance/backend/test/index.test.tsx`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
