### PR TITLE
E2E: Fix LOHP theme signup selection

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/lohp-theme-signup-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/lohp-theme-signup-flow.ts
@@ -50,19 +50,6 @@ export class LOHPThemeSignupFlow {
 	}
 
 	/**
-	 * Navigates to the Calypso Get Started link for the selected theme.
-	 * @returns {Promise<string>} The theme slug of the selected theme.
-	 */
-	async visitCalypsoGetStartedLinkForTheme(): Promise< string > {
-		const pageThemeDetails = new ThemesDetailPage( this.page );
-		const calypsoGetStartedLink = await pageThemeDetails.calypsoGetStartedLink();
-		const themeSlug =
-			pageThemeDetails.getThemeSlugFromCalypsoGetStartedLink( calypsoGetStartedLink );
-		await this.page.goto( calypsoGetStartedLink );
-		return themeSlug;
-	}
-
-	/**
 	 * Cancels the plan purchase during the flow.
 	 * @returns {Promise<void>}
 	 */

--- a/packages/calypso-e2e/src/lib/pages/logged-out-home-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/logged-out-home-page.ts
@@ -38,7 +38,7 @@ export class LoggedOutHomePage {
 				timeout: 30 * 1000,
 				waitUntil: 'domcontentloaded',
 			} ),
-			this.exploreThemesLink.click( { timeout: 30 * 1000 } ),
+			this.exploreThemesLink.click(),
 		] );
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/logged-out-home-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/logged-out-home-page.ts
@@ -29,6 +29,20 @@ export class LoggedOutHomePage {
 	}
 
 	/**
+	 * Navigates to the logged-out themes showcase page.
+	 * returns {Promise<void>}
+	 */
+	async exploreThemes(): Promise< void > {
+		await Promise.all( [
+			this.page.waitForURL( /\/themes(?:[/?#].*)?$/, {
+				timeout: 30 * 1000,
+				waitUntil: 'domcontentloaded',
+			} ),
+			this.exploreThemesLink.click( { timeout: 30 * 1000 } ),
+		] );
+	}
+
+	/**
 	 * Sets the store cookie for the specified currency.
 	 * @param currency
 	 */

--- a/packages/calypso-e2e/src/lib/pages/logged-out-home-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/logged-out-home-page.ts
@@ -33,13 +33,11 @@ export class LoggedOutHomePage {
 	 * returns {Promise<void>}
 	 */
 	async exploreThemes(): Promise< void > {
-		await Promise.all( [
-			this.page.waitForURL( /\/themes(?:[/?#].*)?$/, {
-				timeout: 30 * 1000,
-				waitUntil: 'domcontentloaded',
-			} ),
-			this.exploreThemesLink.click(),
-		] );
+		await this.exploreThemesLink.click();
+		await this.page.waitForURL( /\/themes(?:[/?#].*)?$/, {
+			timeout: 30 * 1000,
+			waitUntil: 'domcontentloaded',
+		} );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/logged-out-themes-page.test.ts
+++ b/packages/calypso-e2e/src/lib/pages/logged-out-themes-page.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from '@jest/globals';
+import { getCalypsoGetStartedUrlFromHref } from './logged-out-themes-page';
+
+describe( 'LoggedOutThemesPage', function () {
+	describe( 'getCalypsoGetStartedUrlFromHref', function () {
+		test.each< {
+			currentUrl: string;
+			getStartedRoute: string;
+			expectedThemeSlug: string;
+			expectedUrl: string;
+		} >`
+			currentUrl                               | getStartedRoute                                                                                | expectedThemeSlug | expectedUrl
+			${ 'https://wordpress.com/themes/free' } | ${ '/start/with-theme?ref=calypshowcase&theme=primarium&theme_type=free&intervalType=yearly' } | ${ 'primarium' }  | ${ 'http://calypso.localhost:3000/start/with-theme?ref=calypshowcase&theme=primarium&theme_type=free&intervalType=yearly' }
+			${ 'https://wordpress.com/themes/free' } | ${ 'https://wordpress.com/start/with-theme?theme=assembler&theme_type=free#step' }             | ${ 'assembler' }  | ${ 'http://calypso.localhost:3000/start/with-theme?theme=assembler&theme_type=free#step' }
+		`(
+			'returns a Calypso URL and theme slug for $getStartedRoute',
+			function ( { currentUrl, getStartedRoute, expectedThemeSlug, expectedUrl } ) {
+				expect( getCalypsoGetStartedUrlFromHref( getStartedRoute, currentUrl ) ).toEqual( {
+					themeSlug: expectedThemeSlug,
+					url: expectedUrl,
+				} );
+			}
+		);
+
+		test( 'throws when the href does not include a theme parameter', function () {
+			expect( () =>
+				getCalypsoGetStartedUrlFromHref(
+					'/start/with-theme?ref=calypshowcase',
+					'https://wordpress.com/themes/free'
+				)
+			).toThrow( 'Theme slug not found' );
+		} );
+	} );
+} );

--- a/packages/calypso-e2e/src/lib/pages/logged-out-themes-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/logged-out-themes-page.ts
@@ -1,5 +1,36 @@
+import { expect } from 'playwright/test';
 import { getCalypsoURL } from '../../data-helper';
 import type { Locator, Page } from 'playwright';
+
+const THEME_ACTION_TIMEOUT_MS = 10 * 1000;
+const THEME_NAVIGATION_TIMEOUT_MS = 30 * 1000;
+
+/**
+ * Caps a helper's total runtime, even when it contains multiple Playwright waits.
+ *
+ * @param {Promise} promise The helper work to run.
+ * @param {number} timeout Maximum time to wait.
+ * @param {string} errorMessage Message to throw when the timeout is reached.
+ * @returns {Promise} The wrapped promise result.
+ */
+async function withTimeout< T >(
+	promise: Promise< T >,
+	timeout: number,
+	errorMessage: string
+): Promise< T > {
+	let timeoutId: ReturnType< typeof setTimeout > | undefined;
+	const timeoutPromise = new Promise< never >( ( _, reject ) => {
+		timeoutId = setTimeout( () => reject( new Error( errorMessage ) ), timeout );
+	} );
+
+	try {
+		return await Promise.race( [ promise, timeoutPromise ] );
+	} finally {
+		if ( timeoutId ) {
+			clearTimeout( timeoutId );
+		}
+	}
+}
 
 /**
  * Resolves a logged-out theme "Get started" href against the current test target.
@@ -50,10 +81,10 @@ export class LoggedOutThemesPage {
 	 */
 	async waitUntilLoaded(): Promise< void > {
 		await this.page.waitForURL( /\/themes(?:\/[^/?#]+)?(?:[?#].*)?$/, {
-			timeout: 30 * 1000,
+			timeout: THEME_NAVIGATION_TIMEOUT_MS,
 			waitUntil: 'domcontentloaded',
 		} );
-		await this.viewFilter.waitFor( { state: 'visible', timeout: 30 * 1000 } );
+		await expect( this.viewFilter ).toBeVisible( { timeout: THEME_ACTION_TIMEOUT_MS } );
 	}
 
 	/**
@@ -62,6 +93,19 @@ export class LoggedOutThemesPage {
 	 * @param {string} filter - The filter to apply.
 	 */
 	async filterBy( filter: string ): Promise< void > {
+		await withTimeout(
+			this.filterByWithinTimeout( filter ),
+			THEME_NAVIGATION_TIMEOUT_MS,
+			`Timed out filtering logged-out themes by "${ filter }"`
+		);
+	}
+
+	/**
+	 * Applies a theme filter within the caller's total timeout budget.
+	 *
+	 * @param {string} filter - The filter to apply.
+	 */
+	private async filterByWithinTimeout( filter: string ): Promise< void > {
 		await this.waitUntilLoaded();
 		await this.viewFilter.scrollIntoViewIfNeeded();
 		await this.viewFilter.click();
@@ -71,18 +115,15 @@ export class LoggedOutThemesPage {
 				? /\/themes(?:[?#].*)?$/
 				: new RegExp( `/themes/${ filterSlug }(?:[?#].*)?$` );
 
-		await Promise.all( [
-			this.page.waitForURL( filterUrlPattern, {
-				timeout: 30 * 1000,
-				waitUntil: 'domcontentloaded',
-			} ),
-			this.page.getByRole( 'option', { name: filter, exact: true } ).click(),
-		] );
-		await this.viewFilter.filter( { hasText: filter } ).waitFor( {
-			state: 'visible',
-			timeout: 30 * 1000,
+		await this.page.getByRole( 'option', { name: filter, exact: true } ).click();
+		await this.page.waitForURL( filterUrlPattern, {
+			timeout: THEME_NAVIGATION_TIMEOUT_MS,
+			waitUntil: 'domcontentloaded',
 		} );
-		await this.firstThemeCard.waitFor( { state: 'visible', timeout: 30 * 1000 } );
+		await expect( this.viewFilter ).toContainText( filter, {
+			timeout: THEME_ACTION_TIMEOUT_MS,
+		} );
+		await expect( this.firstThemeCard ).toBeVisible( { timeout: THEME_ACTION_TIMEOUT_MS } );
 	}
 
 	/**
@@ -91,14 +132,17 @@ export class LoggedOutThemesPage {
 	 * @returns {Promise<string>} The slug of the selected theme.
 	 */
 	async startWithFirstTheme(): Promise< string > {
-		await this.firstThemeGetStartedLink.waitFor( { state: 'visible', timeout: 30 * 1000 } );
+		await expect( this.firstThemeGetStartedLink ).toBeVisible( {
+			timeout: THEME_ACTION_TIMEOUT_MS,
+		} );
+		await expect( this.firstThemeGetStartedLink ).toHaveAttribute( 'href', /theme=/, {
+			timeout: THEME_ACTION_TIMEOUT_MS,
+		} );
 
 		const getStartedRoute = await this.firstThemeGetStartedLink.getAttribute( 'href' );
 		if ( ! getStartedRoute ) {
 			throw new Error( 'First theme Get started URL not found' );
 		}
-
-		await this.firstThemeGetStartedLink.click( { trial: true } );
 
 		const { themeSlug, url: getStartedUrl } = getCalypsoGetStartedUrlFromHref(
 			getStartedRoute,
@@ -106,7 +150,7 @@ export class LoggedOutThemesPage {
 		);
 
 		await this.page.goto( getStartedUrl, {
-			timeout: 30 * 1000,
+			timeout: THEME_NAVIGATION_TIMEOUT_MS,
 			waitUntil: 'domcontentloaded',
 		} );
 

--- a/packages/calypso-e2e/src/lib/pages/logged-out-themes-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/logged-out-themes-page.ts
@@ -54,7 +54,6 @@ export class LoggedOutThemesPage {
 			waitUntil: 'domcontentloaded',
 		} );
 		await this.viewFilter.waitFor( { state: 'visible', timeout: 30 * 1000 } );
-		await this.firstThemeCard.waitFor( { state: 'visible', timeout: 30 * 1000 } );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/logged-out-themes-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/logged-out-themes-page.ts
@@ -6,33 +6,6 @@ const THEME_ACTION_TIMEOUT_MS = 10 * 1000;
 const THEME_NAVIGATION_TIMEOUT_MS = 30 * 1000;
 
 /**
- * Caps a helper's total runtime, even when it contains multiple Playwright waits.
- *
- * @param {Promise} promise The helper work to run.
- * @param {number} timeout Maximum time to wait.
- * @param {string} errorMessage Message to throw when the timeout is reached.
- * @returns {Promise} The wrapped promise result.
- */
-async function withTimeout< T >(
-	promise: Promise< T >,
-	timeout: number,
-	errorMessage: string
-): Promise< T > {
-	let timeoutId: ReturnType< typeof setTimeout > | undefined;
-	const timeoutPromise = new Promise< never >( ( _, reject ) => {
-		timeoutId = setTimeout( () => reject( new Error( errorMessage ) ), timeout );
-	} );
-
-	try {
-		return await Promise.race( [ promise, timeoutPromise ] );
-	} finally {
-		if ( timeoutId ) {
-			clearTimeout( timeoutId );
-		}
-	}
-}
-
-/**
  * Resolves a logged-out theme "Get started" href against the current test target.
  *
  * @param {string} getStartedRoute The route or URL from the theme CTA.
@@ -93,37 +66,26 @@ export class LoggedOutThemesPage {
 	 * @param {string} filter - The filter to apply.
 	 */
 	async filterBy( filter: string ): Promise< void > {
-		await withTimeout(
-			this.filterByWithinTimeout( filter ),
-			THEME_NAVIGATION_TIMEOUT_MS,
-			`Timed out filtering logged-out themes by "${ filter }"`
-		);
-	}
-
-	/**
-	 * Applies a theme filter within the caller's total timeout budget.
-	 *
-	 * @param {string} filter - The filter to apply.
-	 */
-	private async filterByWithinTimeout( filter: string ): Promise< void > {
-		await this.waitUntilLoaded();
-		await this.viewFilter.scrollIntoViewIfNeeded();
-		await this.viewFilter.click();
 		const filterSlug = filter.toLowerCase();
 		const filterUrlPattern =
 			filterSlug === 'all'
 				? /\/themes(?:[?#].*)?$/
 				: new RegExp( `/themes/${ filterSlug }(?:[?#].*)?$` );
 
-		await this.page.getByRole( 'option', { name: filter, exact: true } ).click();
-		await this.page.waitForURL( filterUrlPattern, {
+		await expect( async () => {
+			await this.waitUntilLoaded();
+			await this.viewFilter.scrollIntoViewIfNeeded();
+			await this.viewFilter.click();
+			await this.page.getByRole( 'option', { name: filter, exact: true } ).click();
+			await this.page.waitForURL( filterUrlPattern, {
+				waitUntil: 'domcontentloaded',
+			} );
+			await expect( this.viewFilter ).toContainText( filter );
+			await expect( this.firstThemeCard ).toBeVisible();
+		} ).toPass( {
 			timeout: THEME_NAVIGATION_TIMEOUT_MS,
-			waitUntil: 'domcontentloaded',
+			intervals: [ 1_000, 2_000, 5_000 ],
 		} );
-		await expect( this.viewFilter ).toContainText( filter, {
-			timeout: THEME_ACTION_TIMEOUT_MS,
-		} );
-		await expect( this.firstThemeCard ).toBeVisible( { timeout: THEME_ACTION_TIMEOUT_MS } );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/logged-out-themes-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/logged-out-themes-page.ts
@@ -1,5 +1,28 @@
-import { Locator, Page } from 'playwright';
 import { getCalypsoURL } from '../../data-helper';
+import type { Locator, Page } from 'playwright';
+
+/**
+ * Resolves a logged-out theme "Get started" href against the current test target.
+ *
+ * @param {string} getStartedRoute The route or URL from the theme CTA.
+ * @param {string} currentUrl The current page URL used to resolve relative hrefs.
+ * @returns {Object} The Calypso URL and selected theme slug.
+ */
+export function getCalypsoGetStartedUrlFromHref(
+	getStartedRoute: string,
+	currentUrl: string
+): { themeSlug: string; url: string } {
+	const getStartedRouteUrl = new URL( getStartedRoute, currentUrl );
+	const url = getCalypsoURL(
+		`${ getStartedRouteUrl.pathname }${ getStartedRouteUrl.search }${ getStartedRouteUrl.hash }`
+	);
+	const themeSlug = new URL( url ).searchParams.get( 'theme' );
+	if ( ! themeSlug ) {
+		throw new Error( 'Theme slug not found' );
+	}
+
+	return { themeSlug, url };
+}
 
 /**
  * Represents the logged-out themes showcase page.
@@ -41,8 +64,8 @@ export class LoggedOutThemesPage {
 	 */
 	async filterBy( filter: string ): Promise< void > {
 		await this.waitUntilLoaded();
-		await this.viewFilter.scrollIntoViewIfNeeded( { timeout: 30 * 1000 } );
-		await this.viewFilter.click( { timeout: 30 * 1000 } );
+		await this.viewFilter.scrollIntoViewIfNeeded();
+		await this.viewFilter.click();
 		const filterSlug = filter.toLowerCase();
 		const filterUrlPattern =
 			filterSlug === 'all'
@@ -54,9 +77,7 @@ export class LoggedOutThemesPage {
 				timeout: 30 * 1000,
 				waitUntil: 'domcontentloaded',
 			} ),
-			this.page.getByRole( 'option', { name: filter, exact: true } ).click( {
-				timeout: 30 * 1000,
-			} ),
+			this.page.getByRole( 'option', { name: filter, exact: true } ).click(),
 		] );
 		await this.viewFilter.filter( { hasText: filter } ).waitFor( {
 			state: 'visible',
@@ -78,14 +99,12 @@ export class LoggedOutThemesPage {
 			throw new Error( 'First theme Get started URL not found' );
 		}
 
-		const getStartedRouteUrl = new URL( getStartedRoute, this.page.url() );
-		const getStartedUrl = getCalypsoURL(
-			`${ getStartedRouteUrl.pathname }${ getStartedRouteUrl.search }${ getStartedRouteUrl.hash }`
+		await this.firstThemeGetStartedLink.click( { trial: true } );
+
+		const { themeSlug, url: getStartedUrl } = getCalypsoGetStartedUrlFromHref(
+			getStartedRoute,
+			this.page.url()
 		);
-		const themeSlug = new URL( getStartedUrl ).searchParams.get( 'theme' );
-		if ( ! themeSlug ) {
-			throw new Error( 'Theme slug not found' );
-		}
 
 		await this.page.goto( getStartedUrl, {
 			timeout: 30 * 1000,

--- a/packages/calypso-e2e/src/lib/pages/logged-out-themes-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/logged-out-themes-page.ts
@@ -1,4 +1,5 @@
 import { Locator, Page } from 'playwright';
+import { getCalypsoURL } from '../../data-helper';
 
 /**
  * Represents the logged-out themes showcase page.
@@ -6,6 +7,8 @@ import { Locator, Page } from 'playwright';
 export class LoggedOutThemesPage {
 	private page: Page;
 	readonly firstThemeCard: Locator;
+	private readonly firstThemeGetStartedLink: Locator;
+	private readonly viewFilter: Locator;
 
 	/**
 	 * Constructs an instance of the logged-out themes showcase page.
@@ -13,6 +16,22 @@ export class LoggedOutThemesPage {
 	constructor( page: Page ) {
 		this.page = page;
 		this.firstThemeCard = this.page.locator( '[data-e2e-theme]' ).first();
+		this.firstThemeGetStartedLink = this.firstThemeCard
+			.getByRole( 'link', { name: 'Get started' } )
+			.first();
+		this.viewFilter = this.page.getByRole( 'combobox', { name: 'View' } ).first();
+	}
+
+	/**
+	 * Waits for the logged-out themes showcase page to be ready for interaction.
+	 */
+	async waitUntilLoaded(): Promise< void > {
+		await this.page.waitForURL( /\/themes(?:\/[^/?#]+)?(?:[?#].*)?$/, {
+			timeout: 30 * 1000,
+			waitUntil: 'domcontentloaded',
+		} );
+		await this.viewFilter.waitFor( { state: 'visible', timeout: 30 * 1000 } );
+		await this.firstThemeCard.waitFor( { state: 'visible', timeout: 30 * 1000 } );
 	}
 
 	/**
@@ -20,8 +39,59 @@ export class LoggedOutThemesPage {
 	 *
 	 * @param {string} filter - The filter to apply.
 	 */
-	async filterBy( filter: string ) {
-		await this.page.getByRole( 'combobox', { name: 'View' } ).click();
-		await this.page.getByRole( 'option', { name: filter } ).click();
+	async filterBy( filter: string ): Promise< void > {
+		await this.waitUntilLoaded();
+		await this.viewFilter.scrollIntoViewIfNeeded( { timeout: 30 * 1000 } );
+		await this.viewFilter.click( { timeout: 30 * 1000 } );
+		const filterSlug = filter.toLowerCase();
+		const filterUrlPattern =
+			filterSlug === 'all'
+				? /\/themes(?:[?#].*)?$/
+				: new RegExp( `/themes/${ filterSlug }(?:[?#].*)?$` );
+
+		await Promise.all( [
+			this.page.waitForURL( filterUrlPattern, {
+				timeout: 30 * 1000,
+				waitUntil: 'domcontentloaded',
+			} ),
+			this.page.getByRole( 'option', { name: filter, exact: true } ).click( {
+				timeout: 30 * 1000,
+			} ),
+		] );
+		await this.viewFilter.filter( { hasText: filter } ).waitFor( {
+			state: 'visible',
+			timeout: 30 * 1000,
+		} );
+		await this.firstThemeCard.waitFor( { state: 'visible', timeout: 30 * 1000 } );
+	}
+
+	/**
+	 * Starts signup with the first theme on the page.
+	 *
+	 * @returns {Promise<string>} The slug of the selected theme.
+	 */
+	async startWithFirstTheme(): Promise< string > {
+		await this.firstThemeGetStartedLink.waitFor( { state: 'visible', timeout: 30 * 1000 } );
+
+		const getStartedRoute = await this.firstThemeGetStartedLink.getAttribute( 'href' );
+		if ( ! getStartedRoute ) {
+			throw new Error( 'First theme Get started URL not found' );
+		}
+
+		const getStartedRouteUrl = new URL( getStartedRoute, this.page.url() );
+		const getStartedUrl = getCalypsoURL(
+			`${ getStartedRouteUrl.pathname }${ getStartedRouteUrl.search }${ getStartedRouteUrl.hash }`
+		);
+		const themeSlug = new URL( getStartedUrl ).searchParams.get( 'theme' );
+		if ( ! themeSlug ) {
+			throw new Error( 'Theme slug not found' );
+		}
+
+		await this.page.goto( getStartedUrl, {
+			timeout: 30 * 1000,
+			waitUntil: 'domcontentloaded',
+		} );
+
+		return themeSlug;
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/themes-detail-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/themes-detail-page.ts
@@ -124,31 +124,4 @@ export class ThemesDetailPage {
 		] );
 		return popup;
 	}
-
-	/**
-	 * Gets the "Get started" link URL.
-	 *
-	 * @returns Promise<string> The full URL of the "Get started" link.
-	 */
-	async calypsoGetStartedLink(): Promise< string > {
-		const route = await this.page
-			.getByRole( 'link', { name: 'Get started' } )
-			.first()
-			.getAttribute( 'href' );
-		return getCalypsoURL( route ?? '' );
-	}
-
-	/**
-	 * Gets the theme slug from the "Get started" link.
-	 *
-	 * @param {string} calypsoGetStartedLink The full URL of the "Get started" link.
-	 * @returns {string} The theme slug extracted from the URL.
-	 */
-	getThemeSlugFromCalypsoGetStartedLink( calypsoGetStartedLink: string ): string {
-		const themeSlug = new URL( calypsoGetStartedLink ).searchParams.get( 'theme' );
-		if ( ! themeSlug ) {
-			throw new Error( 'Theme slug not found' );
-		}
-		return themeSlug;
-	}
 }

--- a/packages/calypso-e2e/src/test/lib/pages/logged-out-themes-page.test.ts
+++ b/packages/calypso-e2e/src/test/lib/pages/logged-out-themes-page.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from '@jest/globals';
-import { getCalypsoGetStartedUrlFromHref } from './logged-out-themes-page';
+import { getCalypsoGetStartedUrlFromHref } from '../../../lib/pages/logged-out-themes-page';
 
 describe( 'LoggedOutThemesPage', function () {
 	describe( 'getCalypsoGetStartedUrlFromHref', function () {

--- a/test/e2e/specs/onboarding/signup__with-theme-LOHP.spec.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-LOHP.spec.ts
@@ -47,12 +47,10 @@ test.describe(
 			} );
 
 			await test.step( 'When I select the first free theme and choose Get Started', async function () {
-				await flowLOHPThemeSignup.loggedOutHomePage.exploreThemesLink.click();
+				await flowLOHPThemeSignup.loggedOutHomePage.exploreThemes();
 
 				await flowLOHPThemeSignup.loggedOutThemesPage.filterBy( 'Free' );
-				await flowLOHPThemeSignup.loggedOutThemesPage.firstThemeCard.click();
-
-				themeSlug = await flowLOHPThemeSignup.visitCalypsoGetStartedLinkForTheme();
+				themeSlug = await flowLOHPThemeSignup.loggedOutThemesPage.startWithFirstTheme();
 			} );
 
 			await test.step( 'Then I see the "Create your account" page', async function () {


### PR DESCRIPTION
## Proposed Changes

* Add page-object waits for the logged-out home page to themes showcase navigation and the themes filter state.
* Start the LOHP theme signup flow from the first card's explicit Get started URL instead of clicking the theme card/image.
* Preserve the selected theme slug from the start URL so the existing post-purchase theme assertion still verifies the chosen theme.

## Why are these changes being made?

The modern logged-out themes card uses a hover overlay with Preview demo and Get started actions. Playwright's click path hovers the image link before clicking it, which can reveal the overlay and let the Preview demo button intercept pointer events. This restores the older CTA-href pattern for this flow and removes the flaky card/image click from the release E2E path.

## Testing Instructions

* `yarn workspace @automattic/calypso-e2e build`
* `./node_modules/.bin/eslint --ext .ts --cache packages/calypso-e2e/src/lib/pages/logged-out-home-page.ts packages/calypso-e2e/src/lib/pages/logged-out-themes-page.ts test/e2e/specs/onboarding/signup__with-theme-LOHP.spec.ts`
* `git diff --check`
* Ran the targeted Playwright desktop spec against the pre-release Calypso environment with `--reporter=list`.
* Confirmed locally: `2 passed`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
