### PR TITLE
Standardize ManageSubscription card states

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -709,16 +709,6 @@ function getFields( {
 							date: formatDate( new Date( purchase.renew_date ), locale, { dateStyle: 'long' } ),
 						} );
 					}
-					if ( isIncludedWithPlan( purchase ) && purchase.attached_to_purchase_id ) {
-						return (
-							<Link
-								to={ purchaseSettingsRoute.fullPath }
-								params={ { purchaseId: purchase.attached_to_purchase_id } }
-							>
-								{ __( 'Renews with plan' ) }
-							</Link>
-						);
-					}
 					if ( ! purchase.is_auto_renew_enabled && purchase.expiry_date ) {
 						const date = formatDate( new Date( purchase.expiry_date ), locale, {
 							dateStyle: 'long',

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -54,7 +54,11 @@ import Breadcrumbs from '../../../app/breadcrumbs';
 import { useLocale } from '../../../app/locale';
 import { domainRoute } from '../../../app/router/domains';
 import { emailsRoute } from '../../../app/router/emails';
-import { cancelPurchaseRoute, purchaseSettingsRoute } from '../../../app/router/me';
+import {
+	cancelPurchaseRoute,
+	changePaymentMethodRoute,
+	purchaseSettingsRoute,
+} from '../../../app/router/me';
 import { getCurrentDashboard } from '../../../app/routing';
 import { ActionList } from '../../../components/action-list';
 import { Card, CardBody } from '../../../components/card';
@@ -688,6 +692,7 @@ function getFields( {
 			label: __( 'Enable auto-renew' ),
 			Edit: ( { field, data: purchase, onChange } ) => {
 				const locale = useLocale();
+				const navigate = useNavigate();
 				const isSplitCancelRemoveEnabled = useIsSplitCancelRemoveEnabled();
 				const { getValue } = field;
 				const helpText = ( () => {
@@ -714,45 +719,47 @@ function getFields( {
 							</Link>
 						);
 					}
-					if ( purchase.is_auto_renew_enabled ) {
-						return __( 'Will not auto-renew because there is no payment method' );
+					if ( ! purchase.is_auto_renew_enabled && purchase.expiry_date ) {
+						const date = formatDate( new Date( purchase.expiry_date ), locale, {
+							dateStyle: 'long',
+						} );
+						if ( isExpired( purchase ) || isInExpirationGracePeriod( purchase ) ) {
+							return sprintf(
+								// translators: date is a formatted expiry date
+								__( 'Expired on %(date)s.' ),
+								{ date }
+							);
+						}
+						return sprintf(
+							// translators: date is a formatted expiry date
+							__( 'Expires on %(date)s.' ),
+							{ date }
+						);
 					}
 					return undefined;
 				} )();
-				if ( purchase.is_jetpack_plan_or_product ) {
-					if ( purchase.is_auto_renew_enabled ) {
-						return (
-							<ActionList.ActionItem
-								title={ __( 'Subscription renewal' ) }
-								description={ ( (): string => {
-									return typeof helpText === 'string' ? helpText : '';
-								} )() }
-								actions={ <></> }
-							/>
-						);
-					}
+				if ( purchase.is_auto_renew_enabled && ! purchase.is_rechargeable ) {
 					return (
-						<ActionList.ActionItem
-							title={ __( 'Your subscription is inactive' ) }
-							description={ sprintf(
-								// translators: date is a formatted expiry date
-								__( 'Expires on %(date)s.' ),
-								{
-									date: formatDate( new Date( purchase.expiry_date ), locale, {
-										dateStyle: 'long',
-									} ),
+						<div className="purchase-settings__action-item-standalone">
+							<ActionList.ActionItem
+								title={ __( 'Enable auto-renew' ) }
+								description={ __( 'Auto-renew needs a payment method.' ) }
+								actions={
+									<Button
+										variant="secondary"
+										size="compact"
+										onClick={ () =>
+											navigate( {
+												to: changePaymentMethodRoute.fullPath,
+												params: { purchaseId: purchase.ID },
+											} )
+										}
+									>
+										{ __( 'Add payment method' ) }
+									</Button>
 								}
-							) }
-							actions={
-								<Button
-									variant="secondary"
-									size="compact"
-									onClick={ () => onChange( { is_auto_renew_enabled: true } ) }
-								>
-									{ __( 'Re-activate subscription' ) }
-								</Button>
-							}
-						/>
+							/>
+						</div>
 					);
 				}
 				return (
@@ -760,7 +767,9 @@ function getFields( {
 						__nextHasNoMarginBottom
 						className="purchase-settings__toggle-control"
 						label={
-							shouldAllowExpiredAutoRenewToggle( purchase )
+							! purchase.is_auto_renew_enabled &&
+							isExpired( purchase ) &&
+							purchase.is_jetpack_plan_or_product
 								? __( 'Re-activate subscription' )
 								: field.label
 						}
@@ -777,7 +786,7 @@ function getFields( {
 		},
 		{
 			id: 'purchase_payment_method',
-			isVisible: ( item ) => item.is_auto_renew_enabled,
+			isVisible: ( item ) => item.is_auto_renew_enabled && item.is_rechargeable,
 			Edit: ( { data: purchase } ) => {
 				return <PurchasePaymentMethod purchase={ purchase } showUpdateButton />;
 			},
@@ -805,6 +814,11 @@ function ManageSubscriptionCard( { purchase }: { purchase: Purchase } ) {
 		isPending: isMutationPending,
 	} = useMutation( userPurchaseSetAutoRenewQuery() );
 	const { user } = useAuth();
+
+	if ( isIncludedWithPlan( purchase ) ) {
+		return null;
+	}
+
 	return (
 		<Card>
 			<CardBody>
@@ -1315,13 +1329,30 @@ export default function PurchaseSettings() {
 		...domainQuery( purchase.meta ?? '' ),
 		enabled: Boolean( purchase.meta ) && purchase.is_domain,
 	} );
+	const isIncluded = isIncludedWithPlan( purchase ) && Boolean( purchase.attached_to_purchase_id );
+	const { data: parentPurchase } = useQuery( {
+		...purchaseQuery( purchase.attached_to_purchase_id ?? 0 ),
+		enabled: isIncluded,
+	} );
 	const formattedExpiry = useFormattedTime( purchase.expiry_date ?? '' );
 	const formattedRenewal = useFormattedTime( purchase.renew_date ?? '' );
+	const formattedParentExpiry = useFormattedTime( parentPurchase?.expiry_date ?? '' );
+	const formattedParentRenewal = useFormattedTime( parentPurchase?.renew_date ?? '' );
 	const upgradeUrl = getSitePurchaseUpgradeUrl( purchase, getUpgradedPurchaseRedirectUrl() );
 	const willRenew = Boolean(
 		! isExpired( purchase ) && purchase.renew_date && ! isExpiring( purchase )
 	);
+	const parentWillRenew = parentPurchase
+		? Boolean(
+				parentPurchase.is_auto_renew_enabled &&
+					parentPurchase.renew_date &&
+					! isExpiring( parentPurchase )
+		  )
+		: undefined;
 	const expiryDateTitle = ( () => {
+		if ( isIncluded && parentPurchase ) {
+			return parentWillRenew ? __( 'Renews' ) : __( 'Expires' );
+		}
 		if ( isExpired( purchase ) ) {
 			return __( 'Expired' );
 		}
@@ -1440,6 +1471,9 @@ export default function PurchaseSettings() {
 								icon={ calendar }
 								title={ expiryDateTitle }
 								heading={ ( () => {
+									if ( isIncluded && parentPurchase ) {
+										return parentWillRenew ? formattedParentRenewal : formattedParentExpiry;
+									}
 									if ( isOneTimePurchase( purchase ) || isAkismetFreeProduct( purchase ) ) {
 										return __( 'Never expires' );
 									}
@@ -1464,13 +1498,15 @@ export default function PurchaseSettings() {
 									if ( purchase.is_auto_renew_enabled && isRenewing( purchase ) ) {
 										return __( 'Auto-renew is enabled' );
 									}
-									if ( isIncludedWithPlan( purchase ) && purchase.attached_to_purchase_id ) {
+									if ( isIncluded && purchase.attached_to_purchase_id ) {
 										return (
 											<Link
 												to={ purchaseSettingsRoute.fullPath }
 												params={ { purchaseId: purchase.attached_to_purchase_id } }
 											>
-												{ __( 'Renews with plan' ) }
+												{ parentPurchase && ! parentWillRenew
+													? __( 'Expires with plan' )
+													: __( 'Renews with plan' ) }
 											</Link>
 										);
 									}

--- a/client/dashboard/me/billing-purchases/purchase-settings/style.scss
+++ b/client/dashboard/me/billing-purchases/purchase-settings/style.scss
@@ -1,7 +1,7 @@
 @import "@wordpress/base-styles/variables";
 
 .purchase-settings__action-item-standalone {
-	margin: -$grid-unit-20 0;
+	margin-block: -$grid-unit-20;
 }
 
 .purchase-settings__toggle-control {

--- a/client/dashboard/me/billing-purchases/purchase-settings/style.scss
+++ b/client/dashboard/me/billing-purchases/purchase-settings/style.scss
@@ -1,3 +1,9 @@
+@import "@wordpress/base-styles/variables";
+
+.purchase-settings__action-item-standalone {
+	margin: -$grid-unit-20 0;
+}
+
 .purchase-settings__toggle-control {
 	.components-form-toggle {
 		order: 2;


### PR DESCRIPTION
Fixes: https://linear.app/a8c/issue/CHE-481
Relates to: https://github.com/Automattic/wp-calypso/pull/110213

## Summary

This PR fixes a number of weird states in the MSD purchase management screen. Primarily by consolidating our approaches across wordpress.com and Jetpack but also by handling the auto-renew status more thoughtfully.

| Before | After |
| -- | -- | 
| <img width="1840" height="1196" alt="Screenshot 2026-05-07 at 7 53 28 PM" src="https://github.com/user-attachments/assets/b8d4017c-0ba0-438e-b3c4-05bad214dd7e" /> | <img width="1840" height="1196" alt="Screenshot 2026-05-07 at 7 52 59 PM" src="https://github.com/user-attachments/assets/90e9cadd-92d9-4881-8eb5-998e10825a91" /> |
| <img width="1840" height="1196" alt="Screenshot 2026-05-07 at 7 54 10 PM" src="https://github.com/user-attachments/assets/70b7d949-eead-439d-889e-5bee585d9424" /> | <img width="1840" height="1196" alt="Screenshot 2026-05-07 at 7 54 03 PM" src="https://github.com/user-attachments/assets/ddef16ce-8aab-4e56-8eb3-aad5fd8f64f1" /> |
| <img width="1840" height="1196" alt="Screenshot 2026-05-07 at 7 55 42 PM" src="https://github.com/user-attachments/assets/ca0013aa-715b-49f4-bbab-ddd8b6ae96b7" /> |<img width="1840" height="1196" alt="Screenshot 2026-05-07 at 7 54 57 PM" src="https://github.com/user-attachments/assets/2996aa23-5a0e-441a-80f5-94e94e82ba4f" /> |
| <img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/74c9c879-5879-4a83-88ab-ec68ffef56ba" /> |  <img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/e9852d4e-0d64-48e1-bc1d-0c36a711bab2" /> |

- Collapse the divergent Jetpack branch in `getFields` into the standard `ToggleControl` path — both standard and Jetpack purchases now render identical UI for renewing, grace-period, and auto-renew-off states
- Replace the no-payment-method toggle (which showed a contradictory "on" state) with an `ActionList.ActionItem` that routes to Add Payment Method
- Hide `ManageSubscriptionCard` entirely for included-with-plan purchases, and make the Renews/Expires `OverviewCard` parent-aware so it mirrors the parent plan's auto-renew state
- Add "Expires on {date}." / "Expired on {date}." help text when auto-renew is off

## Test plan

- [ ] **B1 Standard — renewing**: toggle ON + next billing date + payment method row — unchanged
- [ ] **B2 Standard — grace period**: toggle ON + "Pending renewal" — unchanged
- [ ] **B3 Standard — included with plan**: ManageSubscriptionCard is hidden; OverviewCard shows "Renews with plan" / "Expires with plan" link based on parent plan's auto-renew state
- [ ] **B4 Standard — no payment method**: ActionItem with "Auto-renew needs a payment method." + "Add payment method" button; payment method row hidden
- [ ] **B5 Standard — auto-renew off**: toggle OFF + "Expires on {date}." help text
- [ ] **A1–A5 Jetpack states** now match their standard counterparts (no more ActionList rows with empty actions)
- [ ] Verify the parent-aware OverviewCard falls back gracefully while the parent purchase is loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)