### PR TITLE
Login: Fail open stalled Blackbox challenges

### DIFF
--- a/client/blocks/login/utils/test/use-blackbox.jsx
+++ b/client/blocks/login/utils/test/use-blackbox.jsx
@@ -104,6 +104,24 @@ describe( 'useBlackbox', () => {
 		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/inactive/empty' );
 	} );
 
+	test( 'fails open when a started challenge never completes', async () => {
+		let callbacks;
+		window.Blackbox.configure.mockImplementationOnce( ( config ) => {
+			callbacks = config;
+		} );
+
+		render( <TestComponent /> );
+
+		await act( async () => {} );
+		act( () => callbacks.onChallengeStart() );
+
+		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/active/empty' );
+
+		act( () => jest.advanceTimersByTime( 5000 ) );
+
+		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/inactive/empty' );
+	} );
+
 	test( 'tracks challenge container content as a blocking signal', async () => {
 		let callbacks;
 		window.Blackbox.configure.mockImplementationOnce( ( config ) => {
@@ -124,6 +142,25 @@ describe( 'useBlackbox', () => {
 		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/inactive/content' );
 
 		act( () => callbacks.onChallengeComplete() );
+
+		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/inactive/empty' );
+	} );
+
+	test( 'fails open when challenge content remains without completion', async () => {
+		window.Blackbox.configure.mockImplementationOnce( () => {} );
+
+		render( <TestComponent /> );
+
+		await act( async () => {} );
+		act( () => jest.advanceTimersByTime( 500 ) );
+
+		await act( async () => {
+			screen.getByTestId( 'blackbox-container' ).appendChild( document.createElement( 'iframe' ) );
+		} );
+
+		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/inactive/content' );
+
+		act( () => jest.advanceTimersByTime( 5000 ) );
 
 		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/inactive/empty' );
 	} );

--- a/client/blocks/login/utils/use-blackbox.js
+++ b/client/blocks/login/utils/use-blackbox.js
@@ -6,6 +6,8 @@ import { loadBlackboxSdk } from 'calypso/blocks/login/utils/blackbox-sdk';
 // after configure(), avoiding a brief enabled submit button while the widget initializes.
 const BLACKBOX_CONFIGURE_SETTLE_TIMEOUT_MS = 500;
 const BLACKBOX_FAIL_OPEN_TIMEOUT_MS = 5000;
+// Blackbox must not create a permanent login dead end if a challenge never settles.
+const BLACKBOX_SUBMIT_BLOCK_TIMEOUT_MS = 5000;
 
 // Tracks whether configure() has been called at least once across mounts.
 // On remount (e.g. back from 2FA), we call reset() to start a fresh session
@@ -24,6 +26,26 @@ export function useBlackbox( { containerRef } ) {
 	const [ isChallengeActive, setIsChallengeActive ] = useState( false );
 	const [ isLoading, setIsLoading ] = useState( isEnabled );
 	const [ hasChallengeContent, setHasChallengeContent ] = useState( false );
+	const [ hasFailedOpen, setHasFailedOpen ] = useState( false );
+
+	useEffect( () => {
+		if ( ! isEnabled || hasFailedOpen ) {
+			return;
+		}
+
+		if ( ! isLoading && ! isChallengeActive && ! hasChallengeContent ) {
+			return;
+		}
+
+		const failOpenTimeout = setTimeout( () => {
+			setHasFailedOpen( true );
+			setIsLoading( false );
+			setIsChallengeActive( false );
+			setHasChallengeContent( false );
+		}, BLACKBOX_SUBMIT_BLOCK_TIMEOUT_MS );
+
+		return () => clearTimeout( failOpenTimeout );
+	}, [ isEnabled, hasFailedOpen, isLoading, isChallengeActive, hasChallengeContent ] );
 
 	useEffect( () => {
 		const container = containerRef.current;
@@ -133,5 +155,9 @@ export function useBlackbox( { containerRef } ) {
 		};
 	}, [ containerRef, isEnabled ] );
 
-	return { isChallengeActive, isLoading, hasChallengeContent };
+	return {
+		isChallengeActive: ! hasFailedOpen && isChallengeActive,
+		isLoading: ! hasFailedOpen && isLoading,
+		hasChallengeContent: ! hasFailedOpen && hasChallengeContent,
+	};
 }

--- a/test/e2e/specs/authentication/authentication__login-localized-hydration.spec.ts
+++ b/test/e2e/specs/authentication/authentication__login-localized-hydration.spec.ts
@@ -18,6 +18,7 @@ test.describe(
 				name: /email address|username/i,
 			} );
 			await expect( usernameInput ).toBeEnabled( { timeout: 15_000 } );
+			await usernameInput.fill( 'e2e@example.com' );
 
 			const continueButton = page.getByRole( 'button', { name: /^continue$/i } );
 			await expect( continueButton ).toBeEnabled( { timeout: 15_000 } );
@@ -36,6 +37,7 @@ test.describe(
 				name: /e-mailadres|gebruikersnaam/i,
 			} );
 			await expect( usernameInput ).toBeEnabled( { timeout: 15_000 } );
+			await usernameInput.fill( 'e2e@example.com' );
 
 			const continueButton = page.getByRole( 'button', { name: /^doorgaan$/i } );
 			await expect( continueButton ).toBeEnabled( { timeout: 15_000 } );


### PR DESCRIPTION
## Proposed Changes

* Add a bounded fail-open path to the Blackbox login hook when submit would otherwise stay blocked by loading, an active challenge, or lingering challenge content.
* Add unit coverage for Blackbox challenges/content that never complete.
* Update the localized login hydration E2E check to fill a username before asserting the submit button is enabled.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The Authentication TeamCity build started failing after #110069 because the login form can remain stuck with `Continue` disabled when Blackbox starts but does not settle in the authentication E2E browser.
* @westi could you review this fail-open behavior and sanity-check it against the intended Blackbox integration? The goal is to keep Blackbox from creating a permanent login dead end while preserving normal challenge blocking during the bounded window.
* TeamCity failure: https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Authentication/17654945

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `yarn test-client client/blocks/login/utils/test --runInBand`
* Run `yarn test-client client/blocks/login/test/login-form.jsx --runInBand`
* Run `./node_modules/.bin/eslint --ext .js,.jsx,.ts,.tsx --cache client/blocks/login/utils/use-blackbox.js client/blocks/login/utils/test/use-blackbox.jsx test/e2e/specs/authentication/authentication__login-localized-hydration.spec.ts`
* Run `yarn workspace @automattic/calypso-e2e build`
* Run Authentication E2E in CI and confirm the login-localized-hydration and TOTP specs no longer fail on a disabled `Continue` button.

Note: `NODE_OPTIONS=--max-old-space-size=8192 yarn typecheck-client` currently fails on existing trunk errors outside this change: dashboard chart/omnibar, Reader Mastodon auth status, achievements progress/target, and inline support `window.wp`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
