### PR TITLE
Clean up host-managed purchase detail cards

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -854,17 +854,7 @@ function PurchasePriceCard( { purchase }: { purchase: Purchase } ) {
 		);
 	}
 	if ( purchase.partner_name && ! isA4ABillingDragonPurchase( purchase ) ) {
-		return (
-			<OverviewCard
-				icon={ currencyDollar }
-				title={
-					// translators: partnerName is the name of a business partner through which this product was sold
-					sprintf( __( 'Please contact %(partnerName)s for details' ), {
-						partnerName: purchase.partner_name,
-					} )
-				}
-			/>
-		);
+		return null;
 	}
 	if ( purchase.is_trial_plan ) {
 		return (
@@ -1297,6 +1287,18 @@ function PurchaseSubtitle( { purchase }: { purchase: Purchase } ) {
 		return null;
 	}
 
+	if ( purchase.partner_name && ! isA4ABillingDragonPurchase( purchase ) ) {
+		return (
+			<MetadataItem
+				title={ sprintf(
+					// translators: subtitle is the type of purchase (e.g. "Host Managed Plan"), partnerName is the name of the business partner
+					__( '%(subtitle)s. Please contact %(partnerName)s for details.' ),
+					{ subtitle, partnerName: purchase.partner_name }
+				) }
+			/>
+		);
+	}
+
 	return <MetadataItem title={ subtitle } />;
 }
 
@@ -1342,6 +1344,7 @@ export default function PurchaseSettings() {
 		enabled: isSplitEnabled,
 	} );
 	const features = isSplitEnabled ? cancelFeaturesResponse?.features ?? null : null;
+	const hasExpiryInfo = ! purchase.partner_name || isA4ABillingDragonPurchase( purchase );
 
 	const isSmallViewport = useViewportMatch( 'medium', '<' );
 	const columns = isSmallViewport ? 1 : 2;
@@ -1429,57 +1432,58 @@ export default function PurchaseSettings() {
 							String( user.ID ) === String( purchase.user_id ) ? user.email : undefined
 						}
 					/>
-					{ isExpired( purchase ) ? (
-						<OverviewCard icon={ info } title={ __( 'Status' ) } heading={ __( 'Removed' ) } />
-					) : (
-						<OverviewCard
-							icon={ calendar }
-							title={ expiryDateTitle }
-							heading={ ( () => {
-								if ( isOneTimePurchase( purchase ) || isAkismetFreeProduct( purchase ) ) {
-									return __( 'Never expires' );
-								}
-								if ( isInExpirationGracePeriod( purchase ) ) {
+					{ hasExpiryInfo &&
+						( isExpired( purchase ) ? (
+							<OverviewCard icon={ info } title={ __( 'Status' ) } heading={ __( 'Removed' ) } />
+						) : (
+							<OverviewCard
+								icon={ calendar }
+								title={ expiryDateTitle }
+								heading={ ( () => {
+									if ( isOneTimePurchase( purchase ) || isAkismetFreeProduct( purchase ) ) {
+										return __( 'Never expires' );
+									}
+									if ( isInExpirationGracePeriod( purchase ) ) {
+										return formattedExpiry;
+									}
+									if ( willRenew ) {
+										return formattedRenewal;
+									}
+									if ( purchase.subscription_status !== 'active' ) {
+										return __( 'Inactive' );
+									}
 									return formattedExpiry;
-								}
-								if ( willRenew ) {
-									return formattedRenewal;
-								}
-								if ( purchase.subscription_status !== 'active' ) {
-									return __( 'Inactive' );
-								}
-								return formattedExpiry;
-							} )() }
-							description={ ( () => {
-								if ( isCentennial ) {
-									return undefined;
-								}
-								if ( purchase.is_auto_renew_enabled && isInExpirationGracePeriod( purchase ) ) {
-									return __( 'Pending renewal' );
-								}
-								if ( purchase.is_auto_renew_enabled && isRenewing( purchase ) ) {
-									return __( 'Auto-renew is enabled' );
-								}
-								if ( isIncludedWithPlan( purchase ) && purchase.attached_to_purchase_id ) {
-									return (
-										<Link
-											to={ purchaseSettingsRoute.fullPath }
-											params={ { purchaseId: purchase.attached_to_purchase_id } }
-										>
-											{ __( 'Renews with plan' ) }
-										</Link>
-									);
-								}
-								if ( purchase.is_trial_plan || isAkismetFreeProduct( purchase ) ) {
-									return undefined;
-								}
-								if ( purchase.is_auto_renew_enabled ) {
-									return __( 'Will not auto-renew because there is no payment method' );
-								}
-								return __( 'Auto-renew is disabled' );
-							} )() }
-						/>
-					) }
+								} )() }
+								description={ ( () => {
+									if ( isCentennial ) {
+										return undefined;
+									}
+									if ( purchase.is_auto_renew_enabled && isInExpirationGracePeriod( purchase ) ) {
+										return __( 'Pending renewal' );
+									}
+									if ( purchase.is_auto_renew_enabled && isRenewing( purchase ) ) {
+										return __( 'Auto-renew is enabled' );
+									}
+									if ( isIncludedWithPlan( purchase ) && purchase.attached_to_purchase_id ) {
+										return (
+											<Link
+												to={ purchaseSettingsRoute.fullPath }
+												params={ { purchaseId: purchase.attached_to_purchase_id } }
+											>
+												{ __( 'Renews with plan' ) }
+											</Link>
+										);
+									}
+									if ( purchase.is_trial_plan || isAkismetFreeProduct( purchase ) ) {
+										return undefined;
+									}
+									if ( purchase.is_auto_renew_enabled ) {
+										return __( 'Will not auto-renew because there is no payment method' );
+									}
+									return __( 'Auto-renew is disabled' );
+								} )() }
+							/>
+						) ) }
 					<PurchasePriceCard purchase={ purchase } />
 					{ purchase.is_jetpack_plan_or_product && (
 						<JetpackLicenseKeyCard purchaseId={ purchase.ID } />


### PR DESCRIPTION
Fixes: https://linear.app/a8c/issue/CHE-482
Relates to: https://github.com/Automattic/wp-calypso/pull/110564, https://github.com/Automattic/wp-calypso/pull/110546

## Summary
This PR hides Renews/Expires and Pricing cards if there is no data to show in them.

| Before | After |
| -- | -- |
| <img width="1840" height="1196" alt="Screenshot 2026-05-07 at 11 21 43 PM" src="https://github.com/user-attachments/assets/00117dfb-cda3-4109-af70-6042c8c5204f" /> | <img width="1840" height="1196" alt="Screenshot 2026-05-07 at 11 21 40 PM" src="https://github.com/user-attachments/assets/d40539d4-e0e1-4203-ad14-310a09496164" /> |

Here are the specifics of what was changed:
- Remove the EXPIRES and PRICE cards from host-managed (Pressable) purchase detail pages — they showed misleading or redundant info since Pressable controls billing
- Move the partner contact message ("Please contact Pressable for details") into the page subtitle instead of wasting a full card on it
- A4A Billing Dragon purchases are unaffected — they continue showing price/expiry cards as before

## Test plan
- [ ] Visit a host-managed partner purchase detail page (e.g. Pressable Jetpack Security) — only SITE and OWNER cards should appear in the grid
- [ ] Subtitle should read "Host Managed Plan. Please contact Pressable for details." (not "Host Managed Plan for [site-slug]")
- [ ] Visit a regular (non-partner) purchase detail page — all four cards still appear, subtitle unchanged
- [ ] Visit an A4A Billing Dragon purchase — price and expiry cards still appear
- [ ] Visit an expired purchase — status card still shows "Removed" (for non-partner purchases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)