### PR TITLE
Fix stepper devtools require() for Vite

### DIFF
--- a/client/landing/stepper/utils/devtools.ts
+++ b/client/landing/stepper/utils/devtools.ts
@@ -1,3 +1,7 @@
+import config from '@automattic/calypso-config';
+import { Site } from '@automattic/data-stores';
+import * as wpData from '@wordpress/data';
+
 interface MagicWindow extends Window {
 	wp: undefined | Record< string, any >;
 }
@@ -12,16 +16,12 @@ export const setupWpDataDebug = () => {
 				window.wp = {};
 			}
 			if ( ! window.wp.data ) {
-				window.wp.data = require( '@wordpress/data' );
+				window.wp.data = wpData;
 
-				const config = require( '@automattic/calypso-config' ).default;
-				const clientCreds = {
+				Site.register( {
 					client_id: config( 'wpcom_signup_id' ),
 					client_secret: config( 'wpcom_signup_key' ),
-				};
-
-				const { Site } = require( '@automattic/data-stores' );
-				Site.register( clientCreds );
+				} );
 			}
 		}
 	}


### PR DESCRIPTION
## Proposed Changes

* Replace `require()` calls in `client/landing/stepper/utils/devtools.ts` with static ES imports.

## Why are these changes being made?

`require()` doesn't exist in Vite/ESM and threw at runtime on `/setup/onboarding`. Switch to static ES imports.

The original `require()`s sat inside a `NODE_ENV !== 'production'` branch, likely intended to keep the deps out of the prod bundle via dead-code elimination. But `@wordpress/data`, `@automattic/calypso-config`, and `@automattic/data-stores` are already statically imported at the top of the stepper entry (`client/landing/stepper/index.tsx`), so the gating saved nothing.

Cherry-picked from #110140 so it can be merged to trunk independently.

## Testing Instructions

`setupWpDataDebug()` runs once on stepper boot (`client/landing/stepper/index.tsx`) and exposes `window.wp.data` plus a registered `automattic/site` store, for poking at from the browser devtools console.

1. `yarn start` and visit any stepper URL in dev, e.g. `/setup/onboarding`.
2. Confirm the page loads — there should be no `Uncaught ReferenceError: require is not defined` in the console. (Without this fix, the stepper entry blows up before rendering.)
3. In the devtools console, run:
   * `window.wp.data` — should be the `@wordpress/data` module (has `select`, `dispatch`, `subscribe`, etc.).
   * `window.wp.data.select( 'automattic/site' )` — should return the Site store selectors (not `undefined`), confirming `Site.register()` ran with the wpcom signup creds.
4. Reload the page — `setupWpDataDebug` is idempotent (guarded by `! window.wp.data`), so the second load should not re-register or warn.
5. Sanity-check a non-stepper page (e.g. `/`) is unaffected.

Production behaviour is unchanged — the `process.env.NODE_ENV !== 'production'` guard still strips the body in prod builds.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?