### PR TITLE
Dashboard: Clean up upcoming renewals dialog

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/style.scss
+++ b/client/dashboard/me/billing-purchases/purchase-settings/style.scss
@@ -2,7 +2,7 @@
 	.upcoming-renewals-dialog__site-label,
 	.upcoming-renewals-dialog__product-subtitle {
 		color: var( --dashboard__text-muted-color, #757575 );
-	}
+		color: var( --dashboard__text-muted-color );
 
 	.dataviews-view-table thead {
 		display: none;

--- a/client/dashboard/me/billing-purchases/purchase-settings/style.scss
+++ b/client/dashboard/me/billing-purchases/purchase-settings/style.scss
@@ -1,19 +1,3 @@
-.upcoming-renewals-dialog .components-modal__frame {
-	.upcoming-renewals-dialog__site-label,
-	.upcoming-renewals-dialog__product-subtitle {
-		color: var( --dashboard__text-muted-color, #757575 );
-		color: var( --dashboard__text-muted-color );
-
-	.dataviews-view-table thead {
-		display: none;
-	}
-
-	.dataviews-view-table__col-actions,
-	.dataviews-view-table__actions-column {
-		display: none;
-	}
-}
-
 .purchase-settings__toggle-control {
 	.components-form-toggle {
 		order: 2;

--- a/client/dashboard/me/billing-purchases/purchase-settings/style.scss
+++ b/client/dashboard/me/billing-purchases/purchase-settings/style.scss
@@ -1,8 +1,17 @@
-// ConfirmDialog sets the z-index so high that the Popover used by DataViews
-// actions does not show up so we have to set this lower.
-// @see https://github.com/wordpress/gutenberg/issues/71463
-div.components-modal__screen-overlay.upcoming-renewals-dialog {
-	z-index: 500;
+.upcoming-renewals-dialog .components-modal__frame {
+	.upcoming-renewals-dialog__site-label,
+	.upcoming-renewals-dialog__product-subtitle {
+		color: var( --dashboard__text-muted-color, #757575 );
+	}
+
+	.dataviews-view-table thead {
+		display: none;
+	}
+
+	.dataviews-view-table__col-actions,
+	.dataviews-view-table__actions-column {
+		display: none;
+	}
 }
 
 .purchase-settings__toggle-control {

--- a/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
@@ -1,3 +1,4 @@
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { formatCurrency } from '@automattic/number-formatters';
 import {
 	CheckboxControl,
@@ -27,26 +28,59 @@ interface Props {
 	submitButtonText?: string;
 }
 
-function getRenewalDescription( item: Purchase, locale: string ): string {
+function getRenewalDescription(
+	item: Purchase,
+	locale: string,
+	hasEnTranslation: ( phrase: string ) => boolean
+): string {
 	const subtitleText = getSubtitleForDisplay( item );
-	const prefix = subtitleText ? `${ subtitleText }: ` : '';
 	const price = formatCurrency( item.sale_amount ?? item.amount, item.currency_code, {
 		stripZeros: true,
 	} );
 
 	if ( isRenewing( item ) ) {
 		const date = formatDate( new Date( item.renew_date ), locale, { dateStyle: 'long' } );
+		if ( subtitleText && hasEnTranslation( '%1$s: Renews at %2$s on %3$s' ) ) {
+			return sprintf(
+				// translators: %1$s: purchase type subtitle (e.g. “Site plan”), %2$s: formatted price, %3$s: formatted date
+				__( '%1$s: Renews at %2$s on %3$s' ),
+				subtitleText,
+				price,
+				date
+			);
+		}
 		// translators: %1$s: formatted price, %2$s: formatted date
-		return prefix + sprintf( __( 'Renews at %1$s on %2$s' ), price, date );
+		const text = sprintf( __( 'Renews at %1$s on %2$s' ), price, date );
+		return subtitleText ? `${ subtitleText }: ${ text }` : text;
 	}
-	if ( isExpired( item ) || isInExpirationGracePeriod( item ) ) {
-		const date = formatDate( new Date( item.expiry_date ), locale, { dateStyle: 'long' } );
-		// translators: %s: formatted date
-		return prefix + sprintf( __( 'Expired on %s' ), date );
-	}
+
 	const date = formatDate( new Date( item.expiry_date ), locale, { dateStyle: 'long' } );
+
+	if ( isExpired( item ) || isInExpirationGracePeriod( item ) ) {
+		if ( subtitleText && hasEnTranslation( '%1$s: Expired on %2$s' ) ) {
+			return sprintf(
+				// translators: %1$s: purchase type subtitle (e.g. “Site plan”), %2$s: formatted date
+				__( '%1$s: Expired on %2$s' ),
+				subtitleText,
+				date
+			);
+		}
+		// translators: %s: formatted date
+		const text = sprintf( __( 'Expired on %s' ), date );
+		return subtitleText ? `${ subtitleText }: ${ text }` : text;
+	}
+
+	if ( subtitleText && hasEnTranslation( '%1$s: Expires on %2$s' ) ) {
+		return sprintf(
+			// translators: %1$s: purchase type subtitle (e.g. “Site plan”), %2$s: formatted date
+			__( '%1$s: Expires on %2$s' ),
+			subtitleText,
+			date
+		);
+	}
 	// translators: %s: formatted date
-	return prefix + sprintf( __( 'Expires on %s' ), date );
+	const text = sprintf( __( 'Expires on %s' ), date );
+	return subtitleText ? `${ subtitleText }: ${ text }` : text;
 }
 
 export function UpcomingRenewalsDialog( {
@@ -57,6 +91,7 @@ export function UpcomingRenewalsDialog( {
 	submitButtonText,
 }: Props ) {
 	const locale = useLocale();
+	const hasEnTranslation = useHasEnTranslation();
 
 	const purchasesSortByRecentExpiryDate = useMemo(
 		() =>
@@ -109,7 +144,7 @@ export function UpcomingRenewalsDialog( {
 								<CheckboxControl
 									__nextHasNoMarginBottom
 									label={ item.is_domain ? item.meta ?? '' : item.product_name }
-									help={ getRenewalDescription( item, locale ) }
+									help={ getRenewalDescription( item, locale, hasEnTranslation ) }
 									checked={ selection.includes( id ) }
 									onChange={ () => {
 										setSelection( ( prev ) =>

--- a/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
@@ -1,14 +1,16 @@
 import { formatCurrency } from '@automattic/number-formatters';
 import {
+	CheckboxControl,
 	__experimentalText as Text,
 	__experimentalConfirmDialog as ConfirmDialog,
 	__experimentalVStack as VStack,
 	__experimentalHeading as Heading,
 } from '@wordpress/components';
-import { DataViews } from '@wordpress/dataviews';
 import { __, sprintf } from '@wordpress/i18n';
-import { useState, useEffect, useMemo } from 'react';
-import { getRelativeTimeString } from '../../../utils/datetime';
+import { useState, useEffect, useMemo, Fragment } from 'react';
+import { useLocale } from '../../../app/locale';
+import { CardDivider } from '../../../components/card';
+import { formatDate } from '../../../utils/datetime';
 import {
 	getSubtitleForDisplay,
 	isExpired,
@@ -16,7 +18,6 @@ import {
 	isInExpirationGracePeriod,
 } from '../../../utils/purchase';
 import type { Purchase } from '@automattic/api-core';
-import type { Field, View, Action } from '@wordpress/dataviews';
 
 interface Props {
 	siteDomain: string;
@@ -26,65 +27,26 @@ interface Props {
 	submitButtonText?: string;
 }
 
-function ExpiresText( { purchase }: { purchase: Purchase } ) {
-	if ( isRenewing( purchase ) ) {
-		if ( isInExpirationGracePeriod( purchase ) ) {
-			return __( 'pending renewal' );
-		}
-		// translators: "renewDate" is relative to the present time and it is already localized, eg. "in a year", "in a month"
-		return sprintf( __( 'renews %(renewDate)s' ), {
-			renewDate: getRelativeTimeString( new Date( purchase.renew_date ) ),
-		} );
-	}
-	if ( isExpired( purchase ) || isInExpirationGracePeriod( purchase ) ) {
-		// translators: "expiry" is relative to the present time and it is already localized, eg. "in a year", "in a month", "a week ago"
-		return sprintf( __( 'expired %(expiry)s' ), {
-			expiry: getRelativeTimeString( new Date( purchase.expiry_date ) ),
-		} );
-	}
-	// translators: "expiry" is relative to the present time and it is already localized, eg. "in a year", "in a month", "a week ago"
-	return sprintf( __( 'expires %(expiry)s' ), {
-		expiry: getRelativeTimeString( new Date( purchase.expiry_date ) ),
+function getRenewalDescription( item: Purchase, locale: string ): string {
+	const subtitleText = getSubtitleForDisplay( item );
+	const prefix = subtitleText ? `${ subtitleText }: ` : '';
+	const price = formatCurrency( item.sale_amount ?? item.amount, item.currency_code, {
+		stripZeros: true,
 	} );
-}
 
-function getPurchaseFields(): Field< Purchase >[] {
-	const fields: Field< Purchase >[] = [
-		{
-			id: 'product_name',
-			type: 'text',
-			label: __( 'Product' ),
-			getValue: ( { item } ) => ( item.is_domain ? item.meta ?? '' : item.product_name ),
-			render: ( { item } ) => {
-				const purchaseTypeText = getSubtitleForDisplay( item );
-				return (
-					<VStack spacing={ 1 }>
-						<Text>{ item.is_domain ? item.meta ?? '' : item.product_name }</Text>
-						<Text variant="muted" className="upcoming-renewals-dialog__product-subtitle">
-							{ purchaseTypeText ? `${ purchaseTypeText }: ` : '' }
-							<span>{ purchaseTypeText && <ExpiresText purchase={ item } /> }</span>
-						</Text>
-					</VStack>
-				);
-			},
-		},
-		{
-			id: 'amount',
-			type: 'text',
-			label: __( 'Price' ),
-			getValue: ( { item } ) =>
-				formatCurrency( item.sale_amount ?? item.amount, item.currency_code, { stripZeros: true } ),
-			render: ( { item } ) => (
-				<Text>
-					{ formatCurrency( item.sale_amount ?? item.amount, item.currency_code, {
-						stripZeros: true,
-					} ) }
-				</Text>
-			),
-		},
-	];
-
-	return fields;
+	if ( isRenewing( item ) ) {
+		const date = formatDate( new Date( item.renew_date ), locale, { dateStyle: 'long' } );
+		// translators: %1$s: formatted price, %2$s: formatted date
+		return prefix + sprintf( __( 'Renews at %1$s on %2$s' ), price, date );
+	}
+	if ( isExpired( item ) || isInExpirationGracePeriod( item ) ) {
+		const date = formatDate( new Date( item.expiry_date ), locale, { dateStyle: 'long' } );
+		// translators: %s: formatted date
+		return prefix + sprintf( __( 'Expired on %s' ), date );
+	}
+	const date = formatDate( new Date( item.expiry_date ), locale, { dateStyle: 'long' } );
+	// translators: %s: formatted date
+	return prefix + sprintf( __( 'Expires on %s' ), date );
 }
 
 export function UpcomingRenewalsDialog( {
@@ -94,6 +56,8 @@ export function UpcomingRenewalsDialog( {
 	onConfirm,
 	submitButtonText,
 }: Props ) {
+	const locale = useLocale();
+
 	const purchasesSortByRecentExpiryDate = useMemo(
 		() =>
 			[ ...purchases ].sort( ( a, b ) => {
@@ -104,50 +68,17 @@ export function UpcomingRenewalsDialog( {
 		[ purchases ]
 	);
 
-	const [ view, setView ] = useState< View >( {
-		type: 'table',
-		perPage: 100,
-		page: 1,
-		fields: [ 'product_name', 'amount' ],
-		layout: {
-			styles: {
-				product_name: { width: '100%' },
-				amount: { width: '1%', align: 'end' },
-			},
-		},
-	} );
-
-	const fields = useMemo( () => getPurchaseFields(), [] );
-
 	const [ selection, setSelection ] = useState< string[] >(
-		purchases.map( ( purchase ) => purchase.ID.toString() )
+		purchases.map( ( p ) => String( p.ID ) )
 	);
 
 	useEffect( () => {
-		setSelection( purchases.map( ( purchase ) => purchase.ID.toString() ) );
+		setSelection( purchases.map( ( p ) => String( p.ID ) ) );
 	}, [ purchases ] );
 
-	const actions = useMemo(
-		(): Action< Purchase >[] => [
-			{
-				id: 'select-for-renewal',
-				label: __( 'Select for renewal' ),
-				supportsBulk: true,
-				icon: () => null,
-				callback: () => {
-					// This action exists just to enable bulk selection checkboxes.
-					// The actual renewal logic is handled by the dialog's confirm button.
-				},
-			},
-		],
-		[]
-	);
-
 	const handleConfirm = () => {
-		const selectedPurchaseIds = selection.map( Number );
-		const selectedPurchasesData = purchases.filter( ( purchase ) =>
-			selectedPurchaseIds.includes( purchase.ID )
-		);
+		const selectedIds = new Set( selection );
+		const selectedPurchasesData = purchases.filter( ( p ) => selectedIds.has( String( p.ID ) ) );
 		onConfirm( selectedPurchasesData );
 	};
 
@@ -169,25 +100,27 @@ export function UpcomingRenewalsDialog( {
 						}
 					</Text>
 				</VStack>
-				<DataViews
-					data={ purchasesSortByRecentExpiryDate }
-					fields={ fields }
-					view={ view }
-					onChangeView={ setView }
-					selection={ selection }
-					onChangeSelection={ setSelection }
-					actions={ actions }
-					getItemId={ ( item ) => item.ID.toString() }
-					isLoading={ false }
-					paginationInfo={ {
-						totalItems: purchasesSortByRecentExpiryDate.length,
-						totalPages: 1,
-					} }
-					defaultLayouts={ { table: {} } }
-					search={ false }
-				>
-					<DataViews.Layout />
-				</DataViews>
+				<VStack spacing={ 4 }>
+					{ purchasesSortByRecentExpiryDate.map( ( item ) => {
+						const id = String( item.ID );
+						return (
+							<Fragment key={ id }>
+								<CardDivider />
+								<CheckboxControl
+									__nextHasNoMarginBottom
+									label={ item.is_domain ? item.meta ?? '' : item.product_name }
+									help={ getRenewalDescription( item, locale ) }
+									checked={ selection.includes( id ) }
+									onChange={ () => {
+										setSelection( ( prev ) =>
+											prev.includes( id ) ? prev.filter( ( s ) => s !== id ) : [ ...prev, id ]
+										);
+									} }
+								/>
+							</Fragment>
+						);
+					} ) }
+				</VStack>
 			</VStack>
 		</ConfirmDialog>
 	);

--- a/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
@@ -1,16 +1,13 @@
 import { formatCurrency } from '@automattic/number-formatters';
-import { useNavigate } from '@tanstack/react-router';
 import {
 	__experimentalText as Text,
 	__experimentalConfirmDialog as ConfirmDialog,
-	__experimentalDivider as Divider,
 	__experimentalVStack as VStack,
 	__experimentalHeading as Heading,
 } from '@wordpress/components';
 import { DataViews } from '@wordpress/dataviews';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState, useEffect, useMemo } from 'react';
-import { purchaseSettingsRoute } from '../../../app/router/me';
 import { getRelativeTimeString } from '../../../utils/datetime';
 import {
 	getSubtitleForDisplay,
@@ -27,7 +24,6 @@ interface Props {
 	onClose: () => void;
 	onConfirm: ( purchases: Purchase[] ) => void;
 	submitButtonText?: string;
-	hideManagePurchaseLinks?: boolean;
 }
 
 function ExpiresText( { purchase }: { purchase: Purchase } ) {
@@ -64,7 +60,7 @@ function getPurchaseFields(): Field< Purchase >[] {
 				return (
 					<VStack spacing={ 1 }>
 						<Text>{ item.is_domain ? item.meta ?? '' : item.product_name }</Text>
-						<Text variant="muted">
+						<Text variant="muted" className="upcoming-renewals-dialog__product-subtitle">
 							{ purchaseTypeText ? `${ purchaseTypeText }: ` : '' }
 							<span>{ purchaseTypeText && <ExpiresText purchase={ item } /> }</span>
 						</Text>
@@ -97,9 +93,7 @@ export function UpcomingRenewalsDialog( {
 	onClose,
 	onConfirm,
 	submitButtonText,
-	hideManagePurchaseLinks,
 }: Props ) {
-	const navigate = useNavigate();
 	const purchasesSortByRecentExpiryDate = useMemo(
 		() =>
 			[ ...purchases ].sort( ( a, b ) => {
@@ -115,8 +109,15 @@ export function UpcomingRenewalsDialog( {
 		perPage: 100,
 		page: 1,
 		fields: [ 'product_name', 'amount' ],
-		layout: {},
+		layout: {
+			styles: {
+				product_name: { width: '100%' },
+				amount: { width: '1%', align: 'end' },
+			},
+		},
 	} );
+
+	const fields = useMemo( () => getPurchaseFields(), [] );
 
 	const [ selection, setSelection ] = useState< string[] >(
 		purchases.map( ( purchase ) => purchase.ID.toString() )
@@ -126,10 +127,8 @@ export function UpcomingRenewalsDialog( {
 		setSelection( purchases.map( ( purchase ) => purchase.ID.toString() ) );
 	}, [ purchases ] );
 
-	const fields = useMemo( () => getPurchaseFields(), [] );
-
-	const actions = useMemo( (): Action< Purchase >[] => {
-		const actionsList: Action< Purchase >[] = [
+	const actions = useMemo(
+		(): Action< Purchase >[] => [
 			{
 				id: 'select-for-renewal',
 				label: __( 'Select for renewal' ),
@@ -140,22 +139,9 @@ export function UpcomingRenewalsDialog( {
 					// The actual renewal logic is handled by the dialog's confirm button.
 				},
 			},
-		];
-
-		if ( ! hideManagePurchaseLinks ) {
-			actionsList.push( {
-				id: 'manage-purchase',
-				label: __( 'Manage purchase' ),
-				supportsBulk: false,
-				callback: ( [ item ] ) => {
-					onClose();
-					navigate( { to: purchaseSettingsRoute.fullPath, params: { purchaseId: item.ID } } );
-				},
-			} );
-		}
-
-		return actionsList;
-	}, [ hideManagePurchaseLinks, onClose, navigate ] );
+		],
+		[]
+	);
 
 	const handleConfirm = () => {
 		const selectedPurchaseIds = selection.map( Number );
@@ -168,37 +154,41 @@ export function UpcomingRenewalsDialog( {
 	return (
 		<ConfirmDialog
 			overlayClassName="upcoming-renewals-dialog"
-			size="large"
+			size="medium"
 			confirmButtonText={ submitButtonText ?? __( 'Renew now' ) }
 			onConfirm={ handleConfirm }
 			onCancel={ onClose }
 		>
-			<VStack>
-				<Heading>{ __( 'Upcoming renewals' ) }</Heading>
-				<Text variant="muted">
-					{
-						// translators: siteName is the URL of the site
-						sprintf( __( 'Site: %(siteName)s' ), { siteName: siteDomain } )
-					}
-				</Text>
+			<VStack spacing={ 4 }>
+				<VStack>
+					<Heading>{ __( 'Upcoming renewals' ) }</Heading>
+					<Text variant="muted" className="upcoming-renewals-dialog__site-label">
+						{
+							// translators: siteName is the URL of the site
+							sprintf( __( 'Site: %(siteName)s' ), { siteName: siteDomain } )
+						}
+					</Text>
+				</VStack>
+				<DataViews
+					data={ purchasesSortByRecentExpiryDate }
+					fields={ fields }
+					view={ view }
+					onChangeView={ setView }
+					selection={ selection }
+					onChangeSelection={ setSelection }
+					actions={ actions }
+					getItemId={ ( item ) => item.ID.toString() }
+					isLoading={ false }
+					paginationInfo={ {
+						totalItems: purchasesSortByRecentExpiryDate.length,
+						totalPages: 1,
+					} }
+					defaultLayouts={ { table: {} } }
+					search={ false }
+				>
+					<DataViews.Layout />
+				</DataViews>
 			</VStack>
-			<Divider margin={ 3 } />
-			<DataViews
-				data={ purchasesSortByRecentExpiryDate }
-				fields={ fields }
-				view={ view }
-				onChangeView={ setView }
-				selection={ selection }
-				onChangeSelection={ setSelection }
-				actions={ actions }
-				getItemId={ ( item ) => item.ID.toString() }
-				isLoading={ false }
-				paginationInfo={ {
-					totalItems: purchasesSortByRecentExpiryDate.length,
-					totalPages: 1,
-				} }
-				defaultLayouts={ { table: {} } }
-			/>
 		</ConfirmDialog>
 	);
 }


### PR DESCRIPTION
Fixes: https://linear.app/a8c/issue/CHE-483

## Proposed Changes

This PR cleans up the Upcoming renewals modal on the purchase management screen.

| Before | After |
| -- | -- |
| <img width="1840" height="1196" alt="Screenshot 2026-05-08 at 12 27 02 AM" src="https://github.com/user-attachments/assets/49c80870-e9aa-4fd5-99e8-eb9235d650e5" /> | <img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/a5ea23b9-97d2-47b3-bb82-4cc32c2a611e" /> |




## Why are these changes being made?

The dialog only ever shows a handful of upcoming renewals, so the full DataViews chrome (search, filters, view options, sortable headers, per-row actions, bulk-action footer) was overkill. Strip it back to a clean list with checkboxes for selection and remove the dead code that was only ever used by one removed action.

## Testing Instructions

* Navigate to a site's billing purchases page that has multiple upcoming renewals.
* Trigger the upcoming renewals dialog (e.g. the "Renew now" action when there are other renewals coming up soon).
* Verify:
  * Modal is medium-sized.
  * "Upcoming renewals" heading + "Site: …" subtitle render with the muted dashboard color in both light and dark mode.
  * Table shows just rows with checkboxes — no search bar, no column header row, no kebab menus, no actions column.
  * Product column fills available width; price column is right-aligned and sized to content.
  * Selecting / deselecting checkboxes still controls which purchases are renewed.
  * Cancel and Renew now buttons work as before.