### PR TITLE
Image Studio: thumbs up/down feedback parity for generated video clips

### DIFF
--- a/packages/image-studio/src/components/generate-layout/index.tsx
+++ b/packages/image-studio/src/components/generate-layout/index.tsx
@@ -1,16 +1,21 @@
 import { BigSkyIcon, cn } from '@automattic/agenttic-ui';
 import { __ } from '@wordpress/i18n';
 import { ShareReelAction } from './share-reel-action';
+import { VideoFeedbackButtons } from './video-feedback-buttons';
 import './style.scss';
 
 export const GenerateLayout = ( {
 	isAiProcessing,
 	isPromptSent,
 	videoUrl,
+	onFeedback,
+	onSubmitFeedbackText,
 }: {
 	isPromptSent: boolean;
 	isAiProcessing: boolean;
 	videoUrl?: string | null;
+	onFeedback?: ( feedback: 'up' | 'down' ) => void;
+	onSubmitFeedbackText?: ( feedbackText: string ) => Promise< void >;
 } ) => {
 	if ( videoUrl ) {
 		return (
@@ -32,7 +37,14 @@ export const GenerateLayout = ( {
 						preload="metadata"
 					/>
 				</div>
-				<ShareReelAction />
+				<div className="image-studio-modal__video-actions-bar">
+					<VideoFeedbackButtons
+						videoUrl={ videoUrl }
+						onFeedback={ onFeedback }
+						onSubmitFeedbackText={ onSubmitFeedbackText }
+					/>
+					<ShareReelAction />
+				</div>
 			</div>
 		);
 	}

--- a/packages/image-studio/src/components/generate-layout/share-reel-action/style.scss
+++ b/packages/image-studio/src/components/generate-layout/share-reel-action/style.scss
@@ -1,18 +1,11 @@
 .image-studio-share-reel-action {
-	// Sits just above the chat box (footer). Width-matched and centered to
-	// the same 600px column the .image-studio-footer uses, so the button's
-	// right edge aligns with the chat input's right edge — not the modal's
-	// far edge.
+	// Right-side cluster of the .image-studio-modal__video-actions-bar row.
+	// The parent owns width/centering/padding; we own the button gap.
 	display: flex;
 	align-items: center;
 	justify-content: flex-end;
 	gap: 6px;
 	flex: 0 0 auto;
-	width: 100%;
-	max-width: 600px;
-	align-self: center;
-	padding: 0 16px;
-	margin-top: 4px;
 
 	&__button svg {
 		transition:

--- a/packages/image-studio/src/components/generate-layout/style.scss
+++ b/packages/image-studio/src/components/generate-layout/style.scss
@@ -46,6 +46,22 @@
 		border-radius: 8px;
 	}
 
+	&__video-actions-bar {
+		// One row beneath the video frame, width-matched and centered to the
+		// same 600px column the .image-studio-footer uses. Feedback sits on
+		// the left, share controls on the right.
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		flex: 0 0 auto;
+		width: 100%;
+		max-width: 600px;
+		align-self: center;
+		padding: 0 16px;
+		margin-top: 4px;
+		gap: 12px;
+	}
+
 	&__generate-layout {
 		color: #666;
 		text-align: center;

--- a/packages/image-studio/src/components/generate-layout/video-feedback-buttons/index.test.tsx
+++ b/packages/image-studio/src/components/generate-layout/video-feedback-buttons/index.test.tsx
@@ -1,0 +1,146 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { VideoFeedbackButtons } from './index';
+
+const mockTrack = jest.fn();
+
+jest.mock( '../../../utils/tracking', () => ( {
+	trackImageStudioImageFeedback: ( ...args: unknown[] ) => mockTrack( ...args ),
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( str: string ) => str,
+} ) );
+
+interface MessageActionAction {
+	id: string;
+	label: string;
+	onClick: () => void;
+	disabled?: boolean;
+	pressed?: boolean;
+}
+
+jest.mock( '@automattic/agenttic-ui', () => ( {
+	MessageActions: ( { message }: { message: { actions: MessageActionAction[] } } ) => (
+		<div data-testid="message-actions">
+			{ message.actions.map( ( action ) => (
+				<button
+					key={ action.id }
+					aria-label={ action.label }
+					aria-pressed={ action.pressed ? 'true' : 'false' }
+					disabled={ action.disabled }
+					onClick={ action.onClick }
+				>
+					{ action.id }
+				</button>
+			) ) }
+		</div>
+	),
+	ThumbsUpIcon: () => <span>up-icon</span>,
+	ThumbsDownIcon: () => <span>down-icon</span>,
+} ) );
+
+jest.mock(
+	'@automattic/agents-manager',
+	() => ( {
+		FeedbackInput: ( {
+			onSubmit,
+			onCancel,
+		}: {
+			onSubmit: ( text: string ) => Promise< void >;
+			onCancel: () => void;
+		} ) => (
+			<div data-testid="feedback-input">
+				<button onClick={ () => onSubmit( 'bad clip' ) }>submit</button>
+				<button onClick={ onCancel }>cancel</button>
+			</div>
+		),
+	} ),
+	{ virtual: true }
+);
+
+jest.mock( '@wordpress/components', () => ( {
+	Popover: ( { children }: { children: React.ReactNode } ) => (
+		<div data-testid="popover">{ children }</div>
+	),
+} ) );
+
+describe( '<VideoFeedbackButtons />', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'renders thumbs up + down', () => {
+		render( <VideoFeedbackButtons videoUrl="https://example.com/v.mp4" /> );
+		expect( screen.getByRole( 'button', { name: /Good response/i } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: /Bad response/i } ) ).toBeInTheDocument();
+	} );
+
+	it( 'invokes onFeedback("up") and tracks on thumbs up', () => {
+		const onFeedback = jest.fn();
+		render(
+			<VideoFeedbackButtons videoUrl="https://example.com/v.mp4" onFeedback={ onFeedback } />
+		);
+		fireEvent.click( screen.getByRole( 'button', { name: /Good response/i } ) );
+		expect( onFeedback ).toHaveBeenCalledWith( 'up' );
+		expect( mockTrack ).toHaveBeenCalledWith(
+			expect.objectContaining( { feedback: 'up', attachmentId: null } )
+		);
+	} );
+
+	it( 'opens feedback popover on thumbs down when onSubmitFeedbackText is provided', () => {
+		render(
+			<VideoFeedbackButtons
+				videoUrl="https://example.com/v.mp4"
+				onSubmitFeedbackText={ jest.fn().mockResolvedValue( undefined ) }
+			/>
+		);
+		expect( screen.queryByTestId( 'feedback-input' ) ).not.toBeInTheDocument();
+		fireEvent.click( screen.getByRole( 'button', { name: /Bad response/i } ) );
+		expect( screen.getByTestId( 'feedback-input' ) ).toBeInTheDocument();
+	} );
+
+	it( 'does not open popover on thumbs down without onSubmitFeedbackText', () => {
+		render( <VideoFeedbackButtons videoUrl="https://example.com/v.mp4" /> );
+		fireEvent.click( screen.getByRole( 'button', { name: /Bad response/i } ) );
+		expect( screen.queryByTestId( 'feedback-input' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'locks feedback after first click — opposite button is disabled', () => {
+		render( <VideoFeedbackButtons videoUrl="https://example.com/v.mp4" /> );
+		fireEvent.click( screen.getByRole( 'button', { name: /Good response/i } ) );
+		expect( screen.getByRole( 'button', { name: /Good response/i } ) ).toHaveAttribute(
+			'aria-pressed',
+			'true'
+		);
+		expect( screen.getByRole( 'button', { name: /Bad response/i } ) ).toBeDisabled();
+	} );
+
+	it( 'resets feedback state when videoUrl changes', () => {
+		const { rerender } = render( <VideoFeedbackButtons videoUrl="https://example.com/a.mp4" /> );
+		fireEvent.click( screen.getByRole( 'button', { name: /Good response/i } ) );
+		expect( screen.getByRole( 'button', { name: /Good response/i } ) ).toHaveAttribute(
+			'aria-pressed',
+			'true'
+		);
+
+		rerender( <VideoFeedbackButtons videoUrl="https://example.com/b.mp4" /> );
+		expect( screen.getByRole( 'button', { name: /Good response/i } ) ).toHaveAttribute(
+			'aria-pressed',
+			'false'
+		);
+		expect( screen.getByRole( 'button', { name: /Bad response/i } ) ).not.toBeDisabled();
+	} );
+
+	it( 'submits free-text feedback through onSubmitFeedbackText', async () => {
+		const onSubmitFeedbackText = jest.fn().mockResolvedValue( undefined );
+		render(
+			<VideoFeedbackButtons
+				videoUrl="https://example.com/v.mp4"
+				onSubmitFeedbackText={ onSubmitFeedbackText }
+			/>
+		);
+		fireEvent.click( screen.getByRole( 'button', { name: /Bad response/i } ) );
+		fireEvent.click( screen.getByRole( 'button', { name: /^submit$/i } ) );
+		expect( onSubmitFeedbackText ).toHaveBeenCalledWith( 'bad clip' );
+	} );
+} );

--- a/packages/image-studio/src/components/generate-layout/video-feedback-buttons/index.tsx
+++ b/packages/image-studio/src/components/generate-layout/video-feedback-buttons/index.tsx
@@ -1,0 +1,101 @@
+import { FeedbackInput } from '@automattic/agents-manager';
+import { MessageActions, ThumbsDownIcon, ThumbsUpIcon } from '@automattic/agenttic-ui';
+import { Popover } from '@wordpress/components';
+import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { ImageStudioMode } from '../../../types';
+import { trackImageStudioImageFeedback } from '../../../utils/tracking';
+import './style.scss';
+
+interface VideoFeedbackButtonsProps {
+	videoUrl: string;
+	onFeedback?: ( feedback: 'up' | 'down' ) => void;
+	onSubmitFeedbackText?: ( feedbackText: string ) => Promise< void >;
+}
+
+export const VideoFeedbackButtons = ( {
+	videoUrl,
+	onFeedback,
+	onSubmitFeedbackText,
+}: VideoFeedbackButtonsProps ): JSX.Element => {
+	const [ selectedFeedback, setSelectedFeedback ] = useState< 'up' | 'down' | null >( null );
+	const [ showFeedbackPopover, setShowFeedbackPopover ] = useState( false );
+	const anchorRef = useRef< HTMLDivElement | null >( null );
+
+	useEffect( () => {
+		setSelectedFeedback( null );
+		setShowFeedbackPopover( false );
+	}, [ videoUrl ] );
+
+	const handleFeedback = useCallback(
+		( feedback: 'up' | 'down' ) => {
+			if ( selectedFeedback !== null ) {
+				return;
+			}
+			setSelectedFeedback( feedback );
+			trackImageStudioImageFeedback( {
+				feedback,
+				attachmentId: null,
+				mode: ImageStudioMode.Generate,
+			} );
+			onFeedback?.( feedback );
+			if ( feedback === 'down' && onSubmitFeedbackText ) {
+				setShowFeedbackPopover( true );
+			}
+		},
+		[ selectedFeedback, onFeedback, onSubmitFeedbackText ]
+	);
+
+	const handleClosePopover = useCallback( () => setShowFeedbackPopover( false ), [] );
+
+	const actionMessage = useMemo(
+		() => ( {
+			id: `video_${ videoUrl }`,
+			role: 'agent' as const,
+			content: [],
+			timestamp: Date.now(),
+			archived: false,
+			showIcon: false,
+			actions: [
+				{
+					id: 'feedback-up',
+					label: __( 'Good response', __i18n_text_domain__ ),
+					icon: <ThumbsUpIcon />,
+					onClick: () => handleFeedback( 'up' ),
+					tooltip: __( 'Good response', __i18n_text_domain__ ),
+					disabled: selectedFeedback === 'down',
+					pressed: selectedFeedback === 'up',
+				},
+				{
+					id: 'feedback-down',
+					label: __( 'Bad response', __i18n_text_domain__ ),
+					icon: <ThumbsDownIcon />,
+					onClick: () => handleFeedback( 'down' ),
+					tooltip: __( 'Bad response', __i18n_text_domain__ ),
+					disabled: selectedFeedback === 'up',
+					pressed: selectedFeedback === 'down',
+				},
+			],
+		} ),
+		[ videoUrl, handleFeedback, selectedFeedback ]
+	);
+
+	return (
+		<div className="image-studio-video-feedback-buttons" ref={ anchorRef }>
+			<MessageActions message={ actionMessage } />
+			{ showFeedbackPopover && onSubmitFeedbackText && (
+				<Popover
+					className="image-studio-video-feedback-buttons__popover"
+					placement="top-start"
+					anchor={ anchorRef.current }
+					onClose={ handleClosePopover }
+					variant="unstyled"
+					offset={ 12 }
+					shift
+				>
+					<FeedbackInput onSubmit={ onSubmitFeedbackText } onCancel={ handleClosePopover } />
+				</Popover>
+			) }
+		</div>
+	);
+};

--- a/packages/image-studio/src/components/generate-layout/video-feedback-buttons/style.scss
+++ b/packages/image-studio/src/components/generate-layout/video-feedback-buttons/style.scss
@@ -1,0 +1,50 @@
+@import "../../styles/variables";
+@import "../../styles/mixins";
+
+.image-studio-video-feedback-buttons {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	flex: 0 0 auto;
+
+	button[aria-pressed="true"] {
+		cursor: default;
+	}
+
+	&__popover {
+		// FeedbackInput inherits theme variables from Agenttic. The popover
+		// renders outside that context, so set them explicitly here.
+		@include image-studio-theme-variables();
+		background-color: $color-background;
+		border: 1px solid $color-border;
+		border-radius: 4px;
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+		padding: 12px;
+
+		.agents-manager-feedback-input {
+			width: 300px;
+
+			.components-base-control__label {
+				color: var( --color-muted-foreground );
+			}
+
+			.components-button.is-tertiary {
+				color: var( --color-muted-foreground );
+
+				&:hover,
+				&:focus {
+					color: var( --color-foreground );
+				}
+			}
+
+			&,
+			&__inner {
+				margin: 0;
+				padding: 0;
+				border: none;
+				background-color: transparent;
+				border-radius: 0;
+			}
+		}
+	}
+}

--- a/packages/image-studio/src/components/index.tsx
+++ b/packages/image-studio/src/components/index.tsx
@@ -348,7 +348,7 @@ const ImageStudioContent = withInstanceId(
 		const { handleFeedback, handleSubmitFeedbackText } = useImageStudioFeedback( {
 			authProvider: agentConfigState?.authProvider,
 			sessionId: agentConfigState?.sessionId,
-			displayImageUrl,
+			displayImageUrl: isVideoMode ? currentVideoUrl : displayImageUrl,
 			mode: config?.attachmentId ? ImageStudioMode.Edit : ImageStudioMode.Generate,
 		} );
 
@@ -587,6 +587,8 @@ const ImageStudioContent = withInstanceId(
 								isAiProcessing={ isAiProcessing }
 								isPromptSent={ isPromptSent }
 								videoUrl={ isVideoMode ? currentVideoUrl : null }
+								onFeedback={ handleFeedback }
+								onSubmitFeedbackText={ handleSubmitFeedbackText }
 							/>
 						) }
 


### PR DESCRIPTION
## Summary
- Brings the thumbs up/down + free-text feedback popover that already ships for generated images to the generated video clip flow.
- The feedback row is rendered in the same actions-bar strip as the share buttons (left = feedback, right = share), so clicks land in normal flow rather than fighting the native `<video controls>` chrome.
- Local feedback state is keyed by the video URL — no `attachmentId` gating, no store dependency — and resets cleanly on each new clip. Submissions go through the existing `useImageStudioFeedback` hook (`rateMessage` + `submitFeedback`) and reuse `trackImageStudioImageFeedback` for analytics.

### Files
- New component: `packages/image-studio/src/components/generate-layout/video-feedback-buttons/`
- `GenerateLayout` wraps the new buttons + `ShareReelAction` in a flex `__video-actions-bar` row; ShareReelAction's wrapper styles drop the row-level centering since the parent now owns it.
- `components/index.tsx` passes `currentVideoUrl` to `useImageStudioFeedback` in video mode and threads `handleFeedback` / `handleSubmitFeedbackText` down.

## Test plan
- [ ] Generate a feature clip; thumbs-up button responds and the opposite button locks.
- [ ] Thumbs-down opens the feedback popover; submitting free text resolves and closes it; cancel closes it.
- [ ] Generating a fresh clip resets the feedback state for the new URL.
- [ ] Layout stays width-aligned with the chat input column at the modal's standard breakpoints.
- [ ] `image_studio_image_thumbs_up` / `image_studio_image_thumbs_down` events fire with `mode = generate`.
- [ ] Component test suite passes (`yarn workspace @automattic/image-studio test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)