### PR TITLE
CSS: wrap global reset in @layer to enable @wordpress/ui adoption

### DIFF
--- a/client/assets/stylesheets/shared/_reset.scss
+++ b/client/assets/stylesheets/shared/_reset.scss
@@ -1,150 +1,150 @@
 
 @layer reset {
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-font,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td {
-	border: 0;
-	font-family: inherit;
-	font-size: 100%;
-	font-style: inherit;
-	font-weight: inherit;
-	margin: 0;
-	outline: 0;
-	padding: 0;
-	vertical-align: baseline;
-}
-html {
-	-webkit-text-size-adjust: 100%; /* Prevents iOS text size adjust after orientation change, without disabling user zoom */
-	-ms-text-size-adjust: 100%; /* www.456bereastreet.com/archive/201012/controlling_text_size_in_safari_for_ios_without_disabling_user_zoom/ */
-}
-body {
-	background: #fff;
-}
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-main,
-nav,
-section {
-	display: block;
-}
-ol,
-ul {
-	list-style: none;
-}
-table {
-	/* tables still need 'cellspacing="0"' in the markup */
-	border-collapse: separate;
-	border-spacing: 0;
-}
-caption,
-th,
-td {
-	font-weight: normal;
-	text-align: left;
-}
-blockquote::before,
-blockquote::after,
-q::before,
-q::after {
-	content: "";
-}
-blockquote,
-q {
-	quotes: "" "";
-}
-a:focus {
-	outline: thin dotted;
-}
-a:hover,
-a:active {
-	/* Improves readability when focused and also mouse hovered in all browsers people.opera.com/patrickl/experiments/keyboard/test */
-	outline: 0;
-}
-a img {
-	border: 0;
-}
-button {
-	appearance: none;
-	background: transparent;
-	border: none;
-	font-size: inherit;
-	outline: 0;
-	padding: 0;
-	vertical-align: baseline;
-}
+	html,
+	body,
+	div,
+	span,
+	applet,
+	object,
+	iframe,
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
+	h6,
+	p,
+	blockquote,
+	pre,
+	a,
+	abbr,
+	acronym,
+	address,
+	big,
+	cite,
+	code,
+	del,
+	dfn,
+	em,
+	font,
+	ins,
+	kbd,
+	q,
+	s,
+	samp,
+	small,
+	strike,
+	strong,
+	sub,
+	sup,
+	tt,
+	var,
+	dl,
+	dt,
+	dd,
+	ol,
+	ul,
+	li,
+	legend,
+	table,
+	caption,
+	tbody,
+	tfoot,
+	thead,
+	tr,
+	th,
+	td {
+		border: 0;
+		font-family: inherit;
+		font-size: 100%;
+		font-style: inherit;
+		font-weight: inherit;
+		margin: 0;
+		outline: 0;
+		padding: 0;
+		vertical-align: baseline;
+	}
+	html {
+		-webkit-text-size-adjust: 100%; /* Prevents iOS text size adjust after orientation change, without disabling user zoom */
+		-ms-text-size-adjust: 100%; /* www.456bereastreet.com/archive/201012/controlling_text_size_in_safari_for_ios_without_disabling_user_zoom/ */
+	}
+	body {
+		background: #fff;
+	}
+	article,
+	aside,
+	details,
+	figcaption,
+	figure,
+	footer,
+	header,
+	hgroup,
+	main,
+	nav,
+	section {
+		display: block;
+	}
+	ol,
+	ul {
+		list-style: none;
+	}
+	table {
+		/* tables still need 'cellspacing="0"' in the markup */
+		border-collapse: separate;
+		border-spacing: 0;
+	}
+	caption,
+	th,
+	td {
+		font-weight: normal;
+		text-align: left;
+	}
+	blockquote::before,
+	blockquote::after,
+	q::before,
+	q::after {
+		content: "";
+	}
+	blockquote,
+	q {
+		quotes: "" "";
+	}
+	a:focus {
+		outline: thin dotted;
+	}
+	a:hover,
+	a:active {
+		/* Improves readability when focused and also mouse hovered in all browsers people.opera.com/patrickl/experiments/keyboard/test */
+		outline: 0;
+	}
+	a img {
+		border: 0;
+	}
+	button {
+		appearance: none;
+		background: transparent;
+		border: none;
+		font-size: inherit;
+		outline: 0;
+		padding: 0;
+		vertical-align: baseline;
+	}
 
-// Reset the default styling on form inputs in Webkit/iOS
-input,
-textarea {
-	border-radius: 0;
-	appearance: none;
-}
+	// Reset the default styling on form inputs in Webkit/iOS
+	input,
+	textarea {
+		border-radius: 0;
+		appearance: none;
+	}
 
-// Remove Firefox inner focus ring around button text (only FF on Windows shows that)
-button::-moz-focus-inner,
-input[type="reset"]::-moz-focus-inner,
-input[type="button"]::-moz-focus-inner,
-input[type="submit"]::-moz-focus-inner {
-	border: 0;
-	padding: 0;
-}
+	// Remove Firefox inner focus ring around button text (only FF on Windows shows that)
+	button::-moz-focus-inner,
+	input[type="reset"]::-moz-focus-inner,
+	input[type="button"]::-moz-focus-inner,
+	input[type="submit"]::-moz-focus-inner {
+		border: 0;
+		padding: 0;
+	}
 
 }

--- a/client/assets/stylesheets/shared/_reset.scss
+++ b/client/assets/stylesheets/shared/_reset.scss
@@ -1,4 +1,6 @@
 
+@layer reset {
+
 html,
 body,
 div,
@@ -143,4 +145,6 @@ input[type="button"]::-moz-focus-inner,
 input[type="submit"]::-moz-focus-inner {
 	border: 0;
 	padding: 0;
+}
+
 }

--- a/client/assets/stylesheets/style.scss
+++ b/client/assets/stylesheets/style.scss
@@ -1,3 +1,10 @@
+// Layer order — weakest to strongest.
+// Unlayered styles (the bulk of Calypso) still beat both layers below.
+// Pinning `reset` before `wp-ui-components` lets `@wordpress/ui` defaults
+// override our reset (otherwise an unlayered reset would win over the
+// package's `@layer wp-ui-components` styles).
+@layer reset, wp-ui-components;
+
 // External Dependencies
 @import "vendor";
 


### PR DESCRIPTION
Part of DOTCOM-17023
Issue https://github.com/Automattic/wp-calypso/issues/110488
Related to https://github.com/Automattic/wp-calypso/pull/110466

## Proposed Changes

* Wrap `client/assets/stylesheets/shared/_reset.scss` in `@layer reset { ... }`.
* Declare `@layer reset, wp-ui-components;` at the top of `client/assets/stylesheets/style.scss` to pin reset as the weakest layer.

## Why are these changes being made?

`@wordpress/ui` (already a dependency at `client/package.json`) ships its component styles inside `@layer wp-ui-components`. Per the CSS cascade, **any unlayered rule beats any layered rule**, so Calypso's unlayered global reset overrides `@wordpress/ui` defaults — for example, the reset's `button { padding: 0 }` strips the package's Tabs trigger padding.

This is already biting us: `client/my-sites/podcast/style.scss` carries an explicit workaround re-applying the package's 16px Tabs padding, with an inline comment naming this exact problem. Without layering the reset, every future `@wordpress/ui` adoption point would need a similar patch.

After this change:

- The reset is in `@layer reset` → `@wordpress/ui` rules in `@layer wp-ui-components` win, so package defaults render correctly.
- The bulk of Calypso's CSS is unlayered → it still beats the reset (unlayered > any layer), so existing styles are unaffected.

The same logic applies to `@automattic/agenttic-ui`, the only other dependency in the build that uses `@layer`.

The podcast workaround is intentionally **not** removed in this PR so the architectural change stays isolated; it can be cleaned up in a follow-up.

## Testing Instructions

1. Pull the branch and run `yarn start`.
2. Click through Calypso (my-sites home, reader, me, checkout, podcast page) — there should be no visual regressions vs. trunk.
3. Spot-check surfaces that already use `@wordpress/ui` or `@automattic/agenttic-ui`: omnibar (search at top), Help Center button + chat panel, Jetpack components, Odie chat. These now render with package defaults; verify they look correct.
4. To verify the layering works as intended, temporarily comment out lines 16-18 of `client/my-sites/podcast/style.scss` (`.podcast__tabs [role='tab'] { padding-inline: ... }`) and load the podcast page. Tabs should keep their 16px horizontal padding (now sourced from `@layer wp-ui-components` instead of the workaround). Revert before merging.
5. In browser DevTools Styles pane, confirm reset rules now appear under `@layer reset`, and that `@wordpress/ui` rules under `@layer wp-ui-components` win where both target the same element.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?