### PR TITLE
Revert "Pass email variant through cancel API for refund email A/B test"

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -1064,9 +1064,6 @@ function CancelPurchaseInner() {
 					options: {
 						product_id: purchase.product_id,
 						cancel_bundled_domain: state.cancelBundledDomain ?? false,
-						email_variant: config.isEnabled( 'purchases/split-cancel-remove' )
-							? 'treatment'
-							: 'control',
 					},
 				},
 				{

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -440,9 +440,6 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			await cancelAndRefundPurchaseAsync( purchase.id, {
 				product_id: purchase.productId,
 				cancel_bundled_domain: cancelBundledDomain ? 1 : 0,
-				email_variant: config.isEnabled( 'purchases/split-cancel-remove' )
-					? 'treatment'
-					: 'control',
 			} );
 			return {
 				success: true,

--- a/packages/api-core/src/upgrades/types.ts
+++ b/packages/api-core/src/upgrades/types.ts
@@ -448,12 +448,6 @@ export interface PurchaseCancelOptions {
 	 * will also be cancelled.
 	 */
 	cancel_bundled_domain: boolean;
-
-	/**
-	 * The experiment variation name for the refund email A/B test.
-	 * When 'treatment', the backend sends the wpcom-2022 themed email.
-	 */
-	email_variant?: 'treatment' | 'control';
 }
 
 /**


### PR DESCRIPTION
Reverts Automattic/wp-calypso#110272