### PR TITLE
Reader social: anchor section headers on service identity

### DIFF
--- a/client/reader/atmosphere/atmosphere-account-view.tsx
+++ b/client/reader/atmosphere/atmosphere-account-view.tsx
@@ -5,6 +5,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import NavigationHeader from 'calypso/components/navigation-header';
+import { ReaderBlueskyIcon } from 'calypso/reader/components/icons/bluesky-icon';
 import ReaderMain from 'calypso/reader/components/reader-main';
 import { ComposeFab, ComposerModal, ComposerProvider } from 'calypso/reader/social/composer';
 import { AtmosphereNavigation } from './atmosphere-navigation';
@@ -54,13 +55,29 @@ export function AtmosphereAccountView( { connectionId, tab }: Props ) {
 		);
 	}
 
-	const title = connection.display_name || connection.handle;
+	const documentTitle = connection.display_name || connection.handle;
+	const handle = connection.handle;
+	const subtitle = handle
+		? translate(
+				'Catch up with the latest from the people you follow on Bluesky with @%(handle)s',
+				{ args: { handle } }
+		  )
+		: translate( 'Catch up with the latest from the people you follow on Bluesky.' );
+
+	const title = (
+		<span className="atmosphere-view__section-title">
+			<span data-testid="atmosphere-section-logo" aria-hidden="true">
+				<ReaderBlueskyIcon />
+			</span>
+			<span>ATmosphere</span>
+		</span>
+	);
 
 	return (
 		<ComposerProvider connectionId={ connection.id } config={ atmosphereComposerConfig }>
 			<ReaderMain className="atmosphere-view">
-				<DocumentHead title={ translate( '%s ‹ ATmosphere ‹ Reader', { args: title } ) } />
-				<NavigationHeader title={ title } subtitle={ `@${ connection.handle }` } />
+				<DocumentHead title={ translate( '%s ‹ ATmosphere ‹ Reader', { args: documentTitle } ) } />
+				<NavigationHeader title={ title } subtitle={ subtitle } />
 				<AtmosphereNavigation connectionId={ connection.id } selectedTab={ tab } />
 				<VStack spacing={ 4 } className="atmosphere-view__body">
 					{ renderTab( tab, connection ) }

--- a/client/reader/atmosphere/atmosphere-account-view.tsx
+++ b/client/reader/atmosphere/atmosphere-account-view.tsx
@@ -8,6 +8,7 @@ import NavigationHeader from 'calypso/components/navigation-header';
 import { ReaderBlueskyIcon } from 'calypso/reader/components/icons/bluesky-icon';
 import ReaderMain from 'calypso/reader/components/reader-main';
 import { ComposeFab, ComposerModal, ComposerProvider } from 'calypso/reader/social/composer';
+import { normalizeHandle } from 'calypso/reader/social/utils/normalize-handle';
 import { AtmosphereNavigation } from './atmosphere-navigation';
 import { atmosphereComposerConfig } from './composer-config';
 import { PROFILE_TAB, SETTINGS_TAB, TIMELINE_TAB } from './helper';
@@ -56,7 +57,7 @@ export function AtmosphereAccountView( { connectionId, tab }: Props ) {
 	}
 
 	const documentTitle = connection.display_name || connection.handle;
-	const handle = connection.handle.replace( /^@/, '' );
+	const handle = normalizeHandle( connection.handle );
 	const subtitle = handle
 		? translate(
 				'Catch up with the latest from the people you follow on Bluesky with @%(handle)s',

--- a/client/reader/atmosphere/atmosphere-account-view.tsx
+++ b/client/reader/atmosphere/atmosphere-account-view.tsx
@@ -56,7 +56,7 @@ export function AtmosphereAccountView( { connectionId, tab }: Props ) {
 	}
 
 	const documentTitle = connection.display_name || connection.handle;
-	const handle = connection.handle;
+	const handle = connection.handle.replace( /^@/, '' );
 	const subtitle = handle
 		? translate(
 				'Catch up with the latest from the people you follow on Bluesky with @%(handle)s',

--- a/client/reader/atmosphere/atmosphere-connect-view.tsx
+++ b/client/reader/atmosphere/atmosphere-connect-view.tsx
@@ -4,6 +4,7 @@ import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import NavigationHeader from 'calypso/components/navigation-header';
+import { ReaderBlueskyIcon } from 'calypso/reader/components/icons/bluesky-icon';
 import ReaderMain from 'calypso/reader/components/reader-main';
 import { ConnectForm } from './connect-form';
 
@@ -19,11 +20,20 @@ export function AtmosphereConnectView() {
 		} );
 	};
 
+	const title = (
+		<span className="atmosphere-view__section-title">
+			<span data-testid="atmosphere-section-logo" aria-hidden="true">
+				<ReaderBlueskyIcon />
+			</span>
+			<span>{ translate( 'Connect a Bluesky account' ) }</span>
+		</span>
+	);
+
 	return (
 		<ReaderMain className="atmosphere-view">
 			<DocumentHead title={ translate( 'Connect account ‹ ATmosphere ‹ Reader' ) } />
 			<NavigationHeader
-				title={ translate( 'Connect a Bluesky account' ) }
+				title={ title }
 				subtitle={ translate( 'Bring your Bluesky account into the Reader.' ) }
 			/>
 			<VStack spacing={ 4 } className="atmosphere-view__body">

--- a/client/reader/atmosphere/style.scss
+++ b/client/reader/atmosphere/style.scss
@@ -23,3 +23,13 @@
 		padding-top: 5px;
 	}
 }
+
+.atmosphere-view__section-title {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.atmosphere-view__section-title svg {
+	flex-shrink: 0;
+}

--- a/client/reader/atmosphere/style.scss
+++ b/client/reader/atmosphere/style.scss
@@ -27,7 +27,7 @@
 .atmosphere-view__section-title {
 	display: inline-flex;
 	align-items: center;
-	gap: 8px;
+	gap: 4px;
 }
 
 .atmosphere-view__section-title svg {

--- a/client/reader/atmosphere/style.scss
+++ b/client/reader/atmosphere/style.scss
@@ -31,5 +31,6 @@
 }
 
 .atmosphere-view__section-title svg {
+	display: block;
 	flex-shrink: 0;
 }

--- a/client/reader/atmosphere/style.scss
+++ b/client/reader/atmosphere/style.scss
@@ -33,4 +33,8 @@
 .atmosphere-view__section-title svg {
 	display: block;
 	flex-shrink: 0;
+	// The icon component bakes in the `.sidebar__menu-icon` class so the
+	// sidebar can spec its own spacing. In the header we lay things out
+	// with `gap`, so reset the inherited margin to keep the gap honest.
+	margin: 0;
 }

--- a/client/reader/atmosphere/test/atmosphere-account-view.test.tsx
+++ b/client/reader/atmosphere/test/atmosphere-account-view.test.tsx
@@ -126,6 +126,23 @@ describe( 'AtmosphereAccountView', () => {
 		renderWithProvider( <AtmosphereAccountView connectionId={ 7 } tab={ PROFILE_TAB } />, {
 			queryClient: makeClient(),
 		} );
-		expect( await screen.findByText( /a\.bsky\.social/ ) ).toBeVisible();
+		const matches = await screen.findAllByText( /a\.bsky\.social/ );
+		expect( matches.length ).toBeGreaterThan( 0 );
+		matches.forEach( ( match ) => expect( match ).toBeVisible() );
+	} );
+
+	it( 'renders the section title and the handle-aware subtitle in the header', async () => {
+		mockConnections();
+		mockConnectionDetails( 7 );
+		renderWithProvider( <AtmosphereAccountView connectionId={ 7 } tab={ TIMELINE_TAB } />, {
+			queryClient: makeClient(),
+		} );
+		expect( await screen.findByRole( 'heading', { name: /ATmosphere/ } ) ).toBeVisible();
+		expect( screen.getByTestId( 'atmosphere-section-logo' ) ).toBeVisible();
+		expect(
+			screen.getByText(
+				/Catch up with the latest from the people you follow on Bluesky with @a\.bsky\.social/
+			)
+		).toBeVisible();
 	} );
 } );

--- a/client/reader/atmosphere/test/atmosphere-connect-view.test.tsx
+++ b/client/reader/atmosphere/test/atmosphere-connect-view.test.tsx
@@ -51,4 +51,11 @@ describe( 'AtmosphereConnectView', () => {
 
 		await waitFor( () => expect( page ).toHaveBeenCalledWith( '/reader/atmosphere/99/timeline' ) );
 	} );
+
+	it( 'renders the connect title with the Bluesky icon and the explanatory subtitle', () => {
+		renderWithProvider( <AtmosphereConnectView /> );
+		expect( screen.getByRole( 'heading', { name: /Connect a Bluesky account/i } ) ).toBeVisible();
+		expect( screen.getByTestId( 'atmosphere-section-logo' ) ).toBeVisible();
+		expect( screen.getByText( /Bring your Bluesky account into the Reader\./i ) ).toBeVisible();
+	} );
 } );

--- a/client/reader/mastodon/connect-form.tsx
+++ b/client/reader/mastodon/connect-form.tsx
@@ -26,6 +26,9 @@ export function ConnectForm( { onSubmit, isSubmitting, error }: ConnectFormProps
 		<Card>
 			<CardBody>
 				<form onSubmit={ handleSubmit }>
+					<p className="mastodon-connect-form__instruction">
+						{ translate( 'Enter your server’s address — we’ll hand you off to sign in there.' ) }
+					</p>
 					<TextControl
 						label={ translate( 'Instance' ) }
 						value={ instance }

--- a/client/reader/mastodon/mastodon-account-view.tsx
+++ b/client/reader/mastodon/mastodon-account-view.tsx
@@ -1,10 +1,11 @@
-import { useMastodonConnectionQuery, useMastodonConnectionsQuery } from '@automattic/api-queries';
+import { useMastodonConnectionsQuery } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import NavigationHeader from 'calypso/components/navigation-header';
+import { ReaderMastodonIcon } from 'calypso/reader/components/icons/mastodon-icon';
 import ReaderMain from 'calypso/reader/components/reader-main';
 import { ComposeFab, ComposerModal, ComposerProvider } from 'calypso/reader/social/composer';
 import { mastodonComposerConfig } from './composer-config';
@@ -30,13 +31,6 @@ export function MastodonAccountView( { connectionId, tab }: Props ) {
 	const connections = data?.connections ?? [];
 	const connection = connections.find( ( c ) => c.id === connectionId ) ?? null;
 	const tabValid = VALID_TABS.has( tab );
-
-	// The list endpoint omits display_name for Mastodon connections (it comes
-	// back null), so the header would otherwise fall back to the raw handle
-	// for the title and duplicate it as the subtitle. The details endpoint has
-	// the display name; React Query dedupes by key, so ProfilePanel and the
-	// sidebar row share this fetch — no extra request.
-	const details = useMastodonConnectionQuery( connection?.id ?? null );
 
 	// The compose FAB and modal sit outside <ConnectionReauthGate>, so without
 	// an explicit guard they'd float over the reauth prompt. Hide both while
@@ -68,13 +62,28 @@ export function MastodonAccountView( { connectionId, tab }: Props ) {
 		);
 	}
 
-	const title = details.data?.display_name || connection.display_name || connection.handle;
-	const subtitle = connection.handle;
+	const documentTitle = connection.display_name || connection.handle;
+	const handle = connection.handle;
+	const subtitle = handle
+		? translate(
+				'Catch up with the latest from the people you follow on Mastodon with @%(handle)s',
+				{ args: { handle } }
+		  )
+		: translate( 'Catch up with the latest from the people you follow on Mastodon.' );
+
+	const title = (
+		<span className="mastodon-view__section-title">
+			<span data-testid="mastodon-section-logo" aria-hidden="true">
+				<ReaderMastodonIcon />
+			</span>
+			<span>Mastodon</span>
+		</span>
+	);
 
 	return (
 		<ComposerProvider connectionId={ connection.id } config={ mastodonComposerConfig }>
 			<ReaderMain className="mastodon-view">
-				<DocumentHead title={ translate( '%s ‹ Mastodon ‹ Reader', { args: title } ) } />
+				<DocumentHead title={ translate( '%s ‹ Mastodon ‹ Reader', { args: documentTitle } ) } />
 				<NavigationHeader title={ title } subtitle={ subtitle } />
 				<MastodonNavigation connectionId={ connection.id } selectedTab={ tab } />
 				<VStack spacing={ 4 } className="mastodon-view__body">

--- a/client/reader/mastodon/mastodon-account-view.tsx
+++ b/client/reader/mastodon/mastodon-account-view.tsx
@@ -1,4 +1,4 @@
-import { useMastodonConnectionsQuery } from '@automattic/api-queries';
+import { useMastodonConnectionQuery, useMastodonConnectionsQuery } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
@@ -8,6 +8,7 @@ import NavigationHeader from 'calypso/components/navigation-header';
 import { ReaderMastodonIcon } from 'calypso/reader/components/icons/mastodon-icon';
 import ReaderMain from 'calypso/reader/components/reader-main';
 import { ComposeFab, ComposerModal, ComposerProvider } from 'calypso/reader/social/composer';
+import { normalizeHandle } from 'calypso/reader/social/utils/normalize-handle';
 import { mastodonComposerConfig } from './composer-config';
 import { PROFILE_TAB, SETTINGS_TAB, TIMELINE_TAB } from './helper';
 import { MastodonNavigation } from './mastodon-navigation';
@@ -31,6 +32,13 @@ export function MastodonAccountView( { connectionId, tab }: Props ) {
 	const connections = data?.connections ?? [];
 	const connection = connections.find( ( c ) => c.id === connectionId ) ?? null;
 	const tabValid = VALID_TABS.has( tab );
+
+	// The list endpoint omits display_name for Mastodon connections (it
+	// comes back null), so the browser tab title would otherwise fall
+	// back to the raw handle. The details endpoint has the display name;
+	// React Query dedupes by key, so ProfilePanel and the sidebar row
+	// share this fetch — no extra request.
+	const details = useMastodonConnectionQuery( connection?.id ?? null );
 
 	// The compose FAB and modal sit outside <ConnectionReauthGate>, so without
 	// an explicit guard they'd float over the reauth prompt. Hide both while
@@ -62,8 +70,8 @@ export function MastodonAccountView( { connectionId, tab }: Props ) {
 		);
 	}
 
-	const documentTitle = connection.display_name || connection.handle;
-	const handle = connection.handle.replace( /^@/, '' );
+	const documentTitle = details.data?.display_name || connection.display_name || connection.handle;
+	const handle = normalizeHandle( connection.handle );
 	const subtitle = handle
 		? translate(
 				'Catch up with the latest from the people you follow on Mastodon with @%(handle)s',

--- a/client/reader/mastodon/mastodon-account-view.tsx
+++ b/client/reader/mastodon/mastodon-account-view.tsx
@@ -63,7 +63,7 @@ export function MastodonAccountView( { connectionId, tab }: Props ) {
 	}
 
 	const documentTitle = connection.display_name || connection.handle;
-	const handle = connection.handle;
+	const handle = connection.handle.replace( /^@/, '' );
 	const subtitle = handle
 		? translate(
 				'Catch up with the latest from the people you follow on Mastodon with @%(handle)s',

--- a/client/reader/mastodon/mastodon-connect-view.tsx
+++ b/client/reader/mastodon/mastodon-connect-view.tsx
@@ -4,6 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import NavigationHeader from 'calypso/components/navigation-header';
+import { ReaderMastodonIcon } from 'calypso/reader/components/icons/mastodon-icon';
 import ReaderMain from 'calypso/reader/components/reader-main';
 import { useDispatch } from 'calypso/state';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
@@ -77,10 +78,15 @@ export function MastodonConnectView() {
 		<ReaderMain className="mastodon-view">
 			<DocumentHead title={ translate( 'Connect account ‹ Mastodon ‹ Reader' ) } />
 			<NavigationHeader
-				title={ translate( 'Connect a Mastodon account' ) }
-				subtitle={ translate(
-					'Enter your server’s address — we’ll hand you off to sign in there.'
-				) }
+				title={
+					<span className="mastodon-view__section-title">
+						<span data-testid="mastodon-section-logo" aria-hidden="true">
+							<ReaderMastodonIcon />
+						</span>
+						<span>{ translate( 'Connect a Mastodon account' ) }</span>
+					</span>
+				}
+				subtitle={ translate( 'Bring your Mastodon account into the Reader.' ) }
 			/>
 			<VStack spacing={ 4 } className="mastodon-view__body">
 				<ConnectForm

--- a/client/reader/mastodon/style.scss
+++ b/client/reader/mastodon/style.scss
@@ -73,4 +73,8 @@
 .mastodon-view__section-title svg {
 	display: block;
 	flex-shrink: 0;
+	// The icon component bakes in the `.sidebar__menu-icon` class so the
+	// sidebar can spec its own spacing. In the header we lay things out
+	// with `gap`, so reset the inherited margin to keep the gap honest.
+	margin: 0;
 }

--- a/client/reader/mastodon/style.scss
+++ b/client/reader/mastodon/style.scss
@@ -67,7 +67,7 @@
 .mastodon-view__section-title {
 	display: inline-flex;
 	align-items: center;
-	gap: 8px;
+	gap: 4px;
 }
 
 .mastodon-view__section-title svg {

--- a/client/reader/mastodon/style.scss
+++ b/client/reader/mastodon/style.scss
@@ -63,3 +63,13 @@
 .social-composer .reader-mastodon-composer__sensitive-toggle {
 	margin-block-start: 12px;
 }
+
+.mastodon-view__section-title {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.mastodon-view__section-title svg {
+	flex-shrink: 0;
+}

--- a/client/reader/mastodon/style.scss
+++ b/client/reader/mastodon/style.scss
@@ -71,5 +71,6 @@
 }
 
 .mastodon-view__section-title svg {
+	display: block;
 	flex-shrink: 0;
 }

--- a/client/reader/mastodon/test/mastodon-account-view.test.tsx
+++ b/client/reader/mastodon/test/mastodon-account-view.test.tsx
@@ -171,6 +171,23 @@ describe( 'MastodonAccountView', () => {
 		).toBeVisible();
 	} );
 
+	it( 'still renders the section title when display_name is null on the list endpoint', async () => {
+		// The list endpoint can omit display_name for Mastodon connections.
+		// The section header is anchored on section identity, so the title
+		// should remain "Mastodon" and the subtitle should keep showing the
+		// handle without relying on the details endpoint.
+		mockConnections( null );
+		renderWithProvider( <MastodonAccountView connectionId={ 7 } tab={ TIMELINE_TAB } />, {
+			queryClient: makeClient(),
+		} );
+		expect( await screen.findByRole( 'heading', { name: /Mastodon/ } ) ).toBeVisible();
+		expect(
+			screen.getByText(
+				/Catch up with the latest from the people you follow on Mastodon with @alice@mastodon\.social/
+			)
+		).toBeVisible();
+	} );
+
 	it( 'renders the profile tab when asked', async () => {
 		mockConnections();
 		mockConnectionDetails( 7 );

--- a/client/reader/mastodon/test/mastodon-account-view.test.tsx
+++ b/client/reader/mastodon/test/mastodon-account-view.test.tsx
@@ -5,11 +5,9 @@ import page from '@automattic/calypso-router';
 import { QueryClient } from '@tanstack/react-query';
 import { screen, waitFor } from '@testing-library/react';
 import nock from 'nock';
-import * as readerAnalytics from 'calypso/state/reader/analytics/actions';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
-import { PROFILE_TAB, TIMELINE_TAB } from '../helper';
+import { TIMELINE_TAB } from '../helper';
 import { MastodonAccountView } from '../mastodon-account-view';
-import type { MastodonAuthorProfile } from '@automattic/api-core';
 import type React from 'react';
 
 jest.mock(
@@ -20,11 +18,11 @@ jest.mock(
 		}
 );
 
-jest.mock( 'calypso/components/data/document-head', () => () => null );
-
-jest.mock( '../timeline-panel', () => ( {
-	TimelinePanel: () => <div>Mastodon timeline placeholder</div>,
+jest.mock( 'calypso/state/reader/analytics/actions', () => ( {
+	recordReaderTracksEvent: () => ( { type: '@@TEST/NOOP' } ),
 } ) );
+
+jest.mock( 'calypso/components/data/document-head', () => () => null );
 
 jest.mock( '@automattic/calypso-router', () => {
 	const replace = jest.fn();
@@ -39,66 +37,24 @@ function makeClient() {
 	return new QueryClient( { defaultOptions: { queries: { retry: false } } } );
 }
 
-function mockConnections( displayName: string | null = 'Alice' ) {
-	return nock( 'https://public-api.wordpress.com' )
+function mockConnections() {
+	nock( 'https://public-api.wordpress.com' )
 		.get( listUrl )
 		.reply( 200, {
 			connections: [
 				{
 					id: 7,
-					handle: '@alice@mastodon.social',
 					instance: 'mastodon.social',
-					display_name: displayName,
+					handle: 'alice@mastodon.social',
+					display_name: null,
 					avatar: null,
+					needs_reauth: false,
 				},
 			],
 		} );
 }
 
-function mockConnectionDetails( id: number, displayName: string = 'Alice' ) {
-	nock( 'https://public-api.wordpress.com' )
-		.get( `${ listUrl }/${ id }` )
-		.reply( 200, {
-			handle: '@alice@mastodon.social',
-			instance: 'mastodon.social',
-			display_name: displayName,
-			description: '',
-			avatar: null,
-			header: null,
-			counts: { followers: 0, following: 0, posts: 0 },
-			raw: {},
-		} );
-}
-
-// `connection.handle` is `@alice@mastodon.social`; the query options
-// normalize that to `alice@mastodon.social` (strip leading @, lowercase),
-// then the fetcher URL-encodes it.
-const ENCODED_ACTOR = 'alice%40mastodon.social';
-
-function mockAuthorEndpoints( id: number, profile: Partial< MastodonAuthorProfile > = {} ): void {
-	nock( 'https://public-api.wordpress.com' )
-		.get( `${ listUrl }/${ id }/profile/${ ENCODED_ACTOR }` )
-		.reply( 200, {
-			id: String( id ),
-			acct: 'alice@mastodon.social',
-			display_name: 'Alice',
-			avatar: null,
-			header: null,
-			note: '',
-			counts: { followers: 0, following: 0, posts: 0 },
-			locked: false,
-			raw: {},
-			...profile,
-		} );
-	nock( 'https://public-api.wordpress.com' )
-		.get( `${ listUrl }/${ id }/profile/${ ENCODED_ACTOR }/feed` )
-		.query( true )
-		.reply( 200, { items: [], cursor: null } );
-}
-
-describe( 'MastodonAccountView', () => {
-	// NavTabs (used by MastodonNavigation) relies on IntersectionObserver,
-	// which jsdom does not provide.
+describe( 'MastodonAccountView header', () => {
 	beforeAll( () => {
 		global.IntersectionObserver = class IntersectionObserver {
 			observe() {}
@@ -115,26 +71,21 @@ describe( 'MastodonAccountView', () => {
 	beforeEach( () => {
 		( page as unknown as jest.Mock ).mockClear();
 		( page.replace as jest.Mock ).mockClear();
-		// recordReaderTracksEvent is a thunk that reads state.reader.follows;
-		// the test store doesn't seed that slice. Replace with a no-op so
-		// dispatch() doesn't throw when MastodonAuthorProfilePanel fires
-		// `_profile_viewed` after the profile query resolves.
-		jest
-			.spyOn( readerAnalytics, 'recordReaderTracksEvent' )
-			.mockImplementation( () => ( { type: '@@TEST/NOOP' } ) as never );
 	} );
-	afterEach( () => {
-		nock.cleanAll();
-		jest.restoreAllMocks();
-	} );
+	afterEach( () => nock.cleanAll() );
 
-	it( 'renders the timeline tab for a valid connection', async () => {
+	it( 'renders the section title and the handle-aware subtitle in the header', async () => {
 		mockConnections();
-		mockConnectionDetails( 7 );
 		renderWithProvider( <MastodonAccountView connectionId={ 7 } tab={ TIMELINE_TAB } />, {
 			queryClient: makeClient(),
 		} );
-		expect( await screen.findByRole( 'menuitem', { name: /Timeline/ } ) ).toBeVisible();
+		expect( await screen.findByRole( 'heading', { name: /Mastodon/ } ) ).toBeVisible();
+		expect( screen.getByTestId( 'mastodon-section-logo' ) ).toBeVisible();
+		expect(
+			screen.getByText(
+				/Catch up with the latest from the people you follow on Mastodon with @alice@mastodon\.social/
+			)
+		).toBeVisible();
 	} );
 
 	it( 'redirects when connection id is not in the list', async () => {
@@ -143,55 +94,5 @@ describe( 'MastodonAccountView', () => {
 			queryClient: makeClient(),
 		} );
 		await waitFor( () => expect( page.replace ).toHaveBeenCalledWith( '/reader/mastodon' ) );
-	} );
-
-	it( 'redirects invalid tab to /:id/timeline', async () => {
-		mockConnections();
-		mockConnectionDetails( 7 );
-		renderWithProvider( <MastodonAccountView connectionId={ 7 } tab="nope" />, {
-			queryClient: makeClient(),
-		} );
-		await waitFor( () =>
-			expect( page.replace ).toHaveBeenCalledWith( '/reader/mastodon/7/timeline' )
-		);
-	} );
-
-	it( 'uses the display name from the details endpoint when the list omits it', async () => {
-		// Regression: the list endpoint returns display_name as null for
-		// Mastodon, so reading it directly made the header show the raw
-		// webfinger handle as the title AND subtitle. The details endpoint is
-		// authoritative for display name; the sidebar already lazy-fetches it,
-		// the header has to as well.
-		mockConnections( null );
-		mockConnectionDetails( 7, 'Rocinante the Bold' );
-		renderWithProvider( <MastodonAccountView connectionId={ 7 } tab={ TIMELINE_TAB } />, {
-			queryClient: makeClient(),
-		} );
-		// The heading flashes to the handle before the details query resolves;
-		// assert on the final state rather than the first findByRole match.
-		await waitFor( () =>
-			expect( screen.getByRole( 'heading', { level: 1 } ) ).toHaveTextContent(
-				'Rocinante the Bold'
-			)
-		);
-		expect( screen.getByRole( 'heading', { level: 1 } ) ).not.toHaveTextContent(
-			'@alice@mastodon.social'
-		);
-	} );
-
-	it( 'renders the profile tab when asked', async () => {
-		mockConnections();
-		mockConnectionDetails( 7 );
-		// ProfilePanel now renders MastodonAuthorProfilePanel for the
-		// connected user, which fetches the author profile + feed.
-		mockAuthorEndpoints( 7 );
-		renderWithProvider( <MastodonAccountView connectionId={ 7 } tab={ PROFILE_TAB } />, {
-			queryClient: makeClient(),
-		} );
-		// Exact handle, not substring. A permissive `/@alice@mastodon\.social/`
-		// would also match `@alice@mastodon.social@mastodon.social`, so an
-		// accidental instance-doubling regression would go undetected.
-		expect( await screen.findByText( '@alice@mastodon.social' ) ).toBeVisible();
-		expect( screen.queryByText( /@mastodon\.social@mastodon\.social/ ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/reader/mastodon/test/mastodon-account-view.test.tsx
+++ b/client/reader/mastodon/test/mastodon-account-view.test.tsx
@@ -20,7 +20,9 @@ jest.mock(
 		}
 );
 
-jest.mock( 'calypso/components/data/document-head', () => () => null );
+jest.mock( 'calypso/components/data/document-head', () => ( { title }: { title: string } ) => (
+	<div data-testid="document-head-title">{ title }</div>
+) );
 
 jest.mock( '../timeline-panel', () => ( {
 	TimelinePanel: () => <div>Mastodon timeline placeholder</div>,
@@ -177,6 +179,7 @@ describe( 'MastodonAccountView', () => {
 		// should remain "Mastodon" and the subtitle should keep showing the
 		// handle without relying on the details endpoint.
 		mockConnections( null );
+		mockConnectionDetails( 7 );
 		renderWithProvider( <MastodonAccountView connectionId={ 7 } tab={ TIMELINE_TAB } />, {
 			queryClient: makeClient(),
 		} );
@@ -186,6 +189,22 @@ describe( 'MastodonAccountView', () => {
 				/Catch up with the latest from the people you follow on Mastodon with @alice@mastodon\.social/
 			)
 		).toBeVisible();
+	} );
+
+	it( 'pulls the document title from the details endpoint when the list omits display_name', async () => {
+		// Mastodon's list endpoint returns display_name: null. Without the
+		// details fallback, the browser tab and bookmarks would silently
+		// downgrade to the raw webfinger handle.
+		mockConnections( null );
+		mockConnectionDetails( 7, 'Alice the Brave' );
+		renderWithProvider( <MastodonAccountView connectionId={ 7 } tab={ TIMELINE_TAB } />, {
+			queryClient: makeClient(),
+		} );
+		await waitFor( () =>
+			expect( screen.getByTestId( 'document-head-title' ) ).toHaveTextContent(
+				'Alice the Brave ‹ Mastodon ‹ Reader'
+			)
+		);
 	} );
 
 	it( 'renders the profile tab when asked', async () => {

--- a/client/reader/mastodon/test/mastodon-account-view.test.tsx
+++ b/client/reader/mastodon/test/mastodon-account-view.test.tsx
@@ -5,9 +5,11 @@ import page from '@automattic/calypso-router';
 import { QueryClient } from '@tanstack/react-query';
 import { screen, waitFor } from '@testing-library/react';
 import nock from 'nock';
+import * as readerAnalytics from 'calypso/state/reader/analytics/actions';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
-import { TIMELINE_TAB } from '../helper';
+import { PROFILE_TAB, TIMELINE_TAB } from '../helper';
 import { MastodonAccountView } from '../mastodon-account-view';
+import type { MastodonAuthorProfile } from '@automattic/api-core';
 import type React from 'react';
 
 jest.mock(
@@ -18,11 +20,11 @@ jest.mock(
 		}
 );
 
-jest.mock( 'calypso/state/reader/analytics/actions', () => ( {
-	recordReaderTracksEvent: () => ( { type: '@@TEST/NOOP' } ),
-} ) );
-
 jest.mock( 'calypso/components/data/document-head', () => () => null );
+
+jest.mock( '../timeline-panel', () => ( {
+	TimelinePanel: () => <div>Mastodon timeline placeholder</div>,
+} ) );
 
 jest.mock( '@automattic/calypso-router', () => {
 	const replace = jest.fn();
@@ -37,24 +39,66 @@ function makeClient() {
 	return new QueryClient( { defaultOptions: { queries: { retry: false } } } );
 }
 
-function mockConnections() {
-	nock( 'https://public-api.wordpress.com' )
+function mockConnections( displayName: string | null = 'Alice' ) {
+	return nock( 'https://public-api.wordpress.com' )
 		.get( listUrl )
 		.reply( 200, {
 			connections: [
 				{
 					id: 7,
+					handle: '@alice@mastodon.social',
 					instance: 'mastodon.social',
-					handle: 'alice@mastodon.social',
-					display_name: null,
+					display_name: displayName,
 					avatar: null,
-					needs_reauth: false,
 				},
 			],
 		} );
 }
 
-describe( 'MastodonAccountView header', () => {
+function mockConnectionDetails( id: number, displayName: string = 'Alice' ) {
+	nock( 'https://public-api.wordpress.com' )
+		.get( `${ listUrl }/${ id }` )
+		.reply( 200, {
+			handle: '@alice@mastodon.social',
+			instance: 'mastodon.social',
+			display_name: displayName,
+			description: '',
+			avatar: null,
+			header: null,
+			counts: { followers: 0, following: 0, posts: 0 },
+			raw: {},
+		} );
+}
+
+// `connection.handle` is `@alice@mastodon.social`; the query options
+// normalize that to `alice@mastodon.social` (strip leading @, lowercase),
+// then the fetcher URL-encodes it.
+const ENCODED_ACTOR = 'alice%40mastodon.social';
+
+function mockAuthorEndpoints( id: number, profile: Partial< MastodonAuthorProfile > = {} ): void {
+	nock( 'https://public-api.wordpress.com' )
+		.get( `${ listUrl }/${ id }/profile/${ ENCODED_ACTOR }` )
+		.reply( 200, {
+			id: String( id ),
+			acct: 'alice@mastodon.social',
+			display_name: 'Alice',
+			avatar: null,
+			header: null,
+			note: '',
+			counts: { followers: 0, following: 0, posts: 0 },
+			locked: false,
+			raw: {},
+			...profile,
+		} );
+	nock( 'https://public-api.wordpress.com' )
+		.get( `${ listUrl }/${ id }/profile/${ ENCODED_ACTOR }/feed` )
+		.query( true )
+		.reply( 200, { items: [], cursor: null } );
+}
+
+describe( 'MastodonAccountView', () => {
+	// NavTabs (used by MastodonNavigation) relies on IntersectionObserver,
+	// which jsdom does not provide.
 	beforeAll( () => {
 		global.IntersectionObserver = class IntersectionObserver {
 			observe() {}
@@ -71,11 +115,50 @@ describe( 'MastodonAccountView header', () => {
 	beforeEach( () => {
 		( page as unknown as jest.Mock ).mockClear();
 		( page.replace as jest.Mock ).mockClear();
+		// recordReaderTracksEvent is a thunk that reads state.reader.follows;
+		// the test store doesn't seed that slice. Replace with a no-op so
+		// dispatch() doesn't throw when MastodonAuthorProfilePanel fires
+		// `_profile_viewed` after the profile query resolves.
+		jest
+			.spyOn( readerAnalytics, 'recordReaderTracksEvent' )
+			.mockImplementation( () => ( { type: '@@TEST/NOOP' } ) as never );
 	} );
-	afterEach( () => nock.cleanAll() );
+	afterEach( () => {
+		nock.cleanAll();
+		jest.restoreAllMocks();
+	} );
+
+	it( 'renders the timeline tab for a valid connection', async () => {
+		mockConnections();
+		mockConnectionDetails( 7 );
+		renderWithProvider( <MastodonAccountView connectionId={ 7 } tab={ TIMELINE_TAB } />, {
+			queryClient: makeClient(),
+		} );
+		expect( await screen.findByRole( 'menuitem', { name: /Timeline/ } ) ).toBeVisible();
+	} );
+
+	it( 'redirects when connection id is not in the list', async () => {
+		mockConnections();
+		renderWithProvider( <MastodonAccountView connectionId={ 999 } tab={ TIMELINE_TAB } />, {
+			queryClient: makeClient(),
+		} );
+		await waitFor( () => expect( page.replace ).toHaveBeenCalledWith( '/reader/mastodon' ) );
+	} );
+
+	it( 'redirects invalid tab to /:id/timeline', async () => {
+		mockConnections();
+		mockConnectionDetails( 7 );
+		renderWithProvider( <MastodonAccountView connectionId={ 7 } tab="nope" />, {
+			queryClient: makeClient(),
+		} );
+		await waitFor( () =>
+			expect( page.replace ).toHaveBeenCalledWith( '/reader/mastodon/7/timeline' )
+		);
+	} );
 
 	it( 'renders the section title and the handle-aware subtitle in the header', async () => {
 		mockConnections();
+		mockConnectionDetails( 7 );
 		renderWithProvider( <MastodonAccountView connectionId={ 7 } tab={ TIMELINE_TAB } />, {
 			queryClient: makeClient(),
 		} );
@@ -88,11 +171,19 @@ describe( 'MastodonAccountView header', () => {
 		).toBeVisible();
 	} );
 
-	it( 'redirects when connection id is not in the list', async () => {
+	it( 'renders the profile tab when asked', async () => {
 		mockConnections();
-		renderWithProvider( <MastodonAccountView connectionId={ 999 } tab={ TIMELINE_TAB } />, {
+		mockConnectionDetails( 7 );
+		// ProfilePanel now renders MastodonAuthorProfilePanel for the
+		// connected user, which fetches the author profile + feed.
+		mockAuthorEndpoints( 7 );
+		renderWithProvider( <MastodonAccountView connectionId={ 7 } tab={ PROFILE_TAB } />, {
 			queryClient: makeClient(),
 		} );
-		await waitFor( () => expect( page.replace ).toHaveBeenCalledWith( '/reader/mastodon' ) );
+		// Exact handle, not substring. A permissive `/@alice@mastodon\.social/`
+		// would also match `@alice@mastodon.social@mastodon.social`, so an
+		// accidental instance-doubling regression would go undetected.
+		expect( await screen.findByText( '@alice@mastodon.social' ) ).toBeVisible();
+		expect( screen.queryByText( /@mastodon\.social@mastodon\.social/ ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/reader/mastodon/test/mastodon-connect-view.test.tsx
+++ b/client/reader/mastodon/test/mastodon-connect-view.test.tsx
@@ -103,6 +103,21 @@ describe( 'MastodonConnectView', () => {
 		expect( window.sessionStorage.getItem( 'reader.mastodon.oauthState' ) ).toBeNull();
 	} );
 
+	it( 'renders the connect title with the Mastodon icon, the unified subtitle, and the instance instructions above the input', () => {
+		renderWithProvider( <MastodonConnectView /> );
+		expect( screen.getByRole( 'heading', { name: /Connect a Mastodon account/i } ) ).toBeVisible();
+		expect( screen.getByTestId( 'mastodon-section-logo' ) ).toBeVisible();
+		expect( screen.getByText( /Bring your Mastodon account into the Reader\./i ) ).toBeVisible();
+		const instruction = screen.getByText(
+			/Enter your server.{1,3}s address.*we.{1,3}ll hand you off to sign in there\./i
+		);
+		expect( instruction ).toBeVisible();
+		const input = screen.getByLabelText( /Instance/ );
+		expect(
+			instruction.compareDocumentPosition( input ) & Node.DOCUMENT_POSITION_FOLLOWING
+		).toBeTruthy();
+	} );
+
 	it( 'does not redirect when the authorize mutation errors', async () => {
 		const user = userEvent.setup();
 		nock( 'https://public-api.wordpress.com' )

--- a/client/reader/mastodon/test/mastodon-connect-view.test.tsx
+++ b/client/reader/mastodon/test/mastodon-connect-view.test.tsx
@@ -113,6 +113,11 @@ describe( 'MastodonConnectView', () => {
 		);
 		expect( instruction ).toBeVisible();
 		const input = screen.getByLabelText( /Instance/ );
+		const form = instruction.closest( 'form' );
+		expect( form ).not.toBeNull();
+		// Both elements must live inside the same <form>, with the
+		// instruction preceding the input in document order.
+		expect( input.closest( 'form' ) ).toBe( form );
 		expect(
 			instruction.compareDocumentPosition( input ) & Node.DOCUMENT_POSITION_FOLLOWING
 		).toBeTruthy();

--- a/client/reader/social/utils/normalize-handle.ts
+++ b/client/reader/social/utils/normalize-handle.ts
@@ -1,0 +1,13 @@
+/**
+ * Strip leading `@`s from a social handle for display.
+ *
+ * Mastodon handles arrive shaped as `@user@instance` (one leading `@`);
+ * ATproto handles have no leading `@`. Both views render the handle
+ * inside an `@%(handle)s` template, so any leading `@` on the input
+ * would double up in the rendered string. Strip all leading `@`s rather
+ * than a single one so a malformed upstream value (`@@user@instance`)
+ * still renders as `@user@instance` instead of `@@user@instance`.
+ */
+export function normalizeHandle( handle: string ): string {
+	return handle.replace( /^@+/, '' );
+}

--- a/client/reader/social/utils/test/normalize-handle.test.ts
+++ b/client/reader/social/utils/test/normalize-handle.test.ts
@@ -1,0 +1,31 @@
+import { normalizeHandle } from '../normalize-handle';
+
+describe( 'normalizeHandle', () => {
+	it( 'strips a leading @ from a Mastodon-style handle', () => {
+		expect( normalizeHandle( '@alice@mastodon.social' ) ).toBe( 'alice@mastodon.social' );
+	} );
+
+	it( 'leaves an ATproto-style handle untouched', () => {
+		expect( normalizeHandle( 'alice.bsky.social' ) ).toBe( 'alice.bsky.social' );
+	} );
+
+	it( 'strips every leading @ so a malformed @@-prefixed handle does not double up after templating', () => {
+		expect( normalizeHandle( '@@double' ) ).toBe( 'double' );
+	} );
+
+	it( 'collapses a bare @ to an empty string', () => {
+		expect( normalizeHandle( '@' ) ).toBe( '' );
+	} );
+
+	it( 'leaves interior @s alone', () => {
+		expect( normalizeHandle( 'a@b@c' ) ).toBe( 'a@b@c' );
+	} );
+
+	it( 'does not strip leading whitespace before an @', () => {
+		expect( normalizeHandle( ' @user@instance' ) ).toBe( ' @user@instance' );
+	} );
+
+	it( 'returns an empty string for empty input', () => {
+		expect( normalizeHandle( '' ) ).toBe( '' );
+	} );
+} );


### PR DESCRIPTION
Fixes CM-687

## Proposed Changes

- ATmosphere (Bluesky) and Mastodon connect views now render the section logo next to the title.
- Mastodon's previous instructional connect-view subtitle ("Enter your server's address — we'll hand you off to sign in there.") moves into the body of the connect form, immediately above the instance input.
- Account views (`/reader/atmosphere/<id>/...` and `/reader/mastodon/<id>/...`) now show the section name + logo as the title (`ATmosphere` / `Mastodon`) instead of the connected user's display name, and a descriptive subtitle that names the network and weaves in the connected handle: "Catch up with the latest from the people you follow on Bluesky/Mastodon with @<handle>".
- The handle is normalized in code (`connection.handle.replace( /^@/, '' )`) so the format string's leading `@` always renders a single prefix regardless of whether the protocol stores its handle with a leading `@` (Mastodon) or without (Bluesky).
- Tests cover the new header content for all four routes; pre-existing structural coverage for the account views is preserved.

## Why are these changes being made?

The rest of the Reader (Search, Discover, Following, Saved, On This Day, etc.) uses a consistent NavigationHeader pattern: a static section title plus a short, action-oriented subtitle that tells the reader what the page is for. The two newer social sections diverged — the connect views were close to on-pattern but lacked branding, and the account views filled the title with the user's display name and the subtitle with the bare handle, which doesn't identify the section and doesn't match anything else in the Reader.

This pass aligns the social headers with that pattern and adds the protocol logo so the section is visually anchored — useful when navigating between ATmosphere and Mastosdon, or when arriving on these pages from elsewhere.

The instructional copy on the Mastodon connect view ("Enter your server's address …") is more useful as form-level guidance immediately above the input than as a header subtitle — it now lives there, with the descriptive subtitle taking its place above.

## Testing Instructions

1. Visit `/reader/atmosphere/connect`. The header should show the Bluesky butterfly logo + "Connect a Bluesky account" with the subtitle "Bring your Bluesky account into the Reader.".
2. Visit `/reader/atmosphere/<connection-id>/timeline` for any connected Bluesky account. Header should show the Bluesky logo + "ATmosphere"; subtitle should read "Catch up with the latest from the people you follow on Bluesky with @<handle>" (single `@`, regardless of stored format).
3. Visit `/reader/mastodon/connect`. Header should show the Mastodon logo + "Connect a Mastodon account"; subtitle should read "Bring your Mastodon account into the Reader."; instructional copy "Enter your server's address — we'll hand you off to sign in there." should render above the Instance input.
4. Visit `/reader/mastodon/<connection-id>/timeline` for any connected Mastodon account. Header should show the Mastodon logo + "Mastodon"; subtitle should read "Catch up with the latest from the people you follow on Mastodon with @<user>@<instance>" (note: this is the only place the `@@` would have appeared if the normalization were missing).
5. The shared `NavigationHeader` is unchanged, but verify it still renders correctly elsewhere — e.g., `/reader/search`, `/discover`, `/reader` (Recent).
6. `yarn test-client client/reader/atmosphere client/reader/mastodon` should pass (currently 543/543).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?