### PR TITLE
Image Studio: feature clip preview + share + Regenerate in the post sidebar

### DIFF
--- a/packages/image-studio/src/abilities/update-canvas-video.test.ts
+++ b/packages/image-studio/src/abilities/update-canvas-video.test.ts
@@ -14,16 +14,14 @@ const mockSetCurrentAttachmentId = jest.fn().mockResolvedValue( undefined );
 const mockSetCurrentDurationSeconds = jest.fn().mockResolvedValue( undefined );
 const mockAddNotice = jest.fn();
 const mockTrackImageStudioImageGenerated = jest.fn();
-const mockReceiveEntityRecords = jest.fn();
-const mockApiFetch = jest.fn();
+const mockSaveEntityRecord = jest.fn().mockResolvedValue( undefined );
 
 let mockCurrentPostId: number | null = null;
 let mockCurrentPostType = 'post';
-let mockRestBase: string | undefined = 'posts';
 
 const mockDispatch = jest.fn( ( store?: string ) => {
 	if ( store === 'core' ) {
-		return { receiveEntityRecords: mockReceiveEntityRecords };
+		return { saveEntityRecord: mockSaveEntityRecord };
 	}
 	return {
 		setCurrentVideoUrl: mockSetCurrentVideoUrl,
@@ -40,23 +38,8 @@ const mockSelect = jest.fn( ( store?: string ) => {
 			getCurrentPostType: () => mockCurrentPostType,
 		};
 	}
-	if ( store === 'core' ) {
-		return {
-			getEntityRecord: () =>
-				mockRestBase === undefined ? undefined : { rest_base: mockRestBase },
-		};
-	}
 	return null;
 } );
-
-jest.mock(
-	'@wordpress/api-fetch',
-	() => ( {
-		__esModule: true,
-		default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
-	} ),
-	{ virtual: true }
-);
 
 jest.mock( '../utils/tracking', () => ( {
 	trackImageStudioImageGenerated: ( ...args: unknown[] ) =>
@@ -99,13 +82,9 @@ describe( 'registerUpdateCanvasVideoAbility', () => {
 		jest.clearAllMocks();
 		mockRegisterAbilityCategory.mockResolvedValue( undefined );
 		mockRegisterAbility.mockResolvedValue( undefined );
-		mockApiFetch.mockResolvedValue( {
-			id: 1,
-			meta: { _jetpack_feature_clip_id: 42 },
-		} );
+		mockSaveEntityRecord.mockResolvedValue( undefined );
 		mockCurrentPostId = null;
 		mockCurrentPostType = 'post';
-		mockRestBase = 'posts';
 		// Reset module-level isRegistered guard between tests.
 		jest.resetModules();
 
@@ -343,18 +322,25 @@ describe( 'registerUpdateCanvasVideoAbility', () => {
 				attachmentId: 42,
 			} );
 
-			expect( mockApiFetch ).toHaveBeenCalledWith( {
-				path: '/wp/v2/posts/7',
-				method: 'POST',
-				data: { meta: { _jetpack_feature_clip_id: 42 } },
+			expect( mockSaveEntityRecord ).toHaveBeenCalledWith( 'postType', 'post', {
+				id: 7,
+				meta: { _jetpack_feature_clip_id: 42 },
 			} );
-			expect( mockReceiveEntityRecords ).toHaveBeenCalledWith(
-				'postType',
-				'post',
-				expect.arrayContaining( [
-					expect.objectContaining( { meta: { _jetpack_feature_clip_id: 42 } } ),
-				] )
-			);
+		} );
+
+		it( 'forwards the current post type so saveEntityRecord targets the right entity', async () => {
+			mockCurrentPostId = 9;
+			mockCurrentPostType = 'page';
+			const { registerUpdateCanvasVideoAbility } = await import( './update-canvas-video' );
+			await registerUpdateCanvasVideoAbility();
+
+			const callback = getRegisteredCallback();
+			await callback( { url: 'https://files.wordpress.com/clip.mp4', attachmentId: 42 } );
+
+			expect( mockSaveEntityRecord ).toHaveBeenCalledWith( 'postType', 'page', {
+				id: 9,
+				meta: { _jetpack_feature_clip_id: 42 },
+			} );
 		} );
 
 		it( 'skips the meta write when there is no current post', async () => {
@@ -368,13 +354,12 @@ describe( 'registerUpdateCanvasVideoAbility', () => {
 				attachmentId: 42,
 			} );
 
-			expect( mockApiFetch ).not.toHaveBeenCalled();
-			expect( mockReceiveEntityRecords ).not.toHaveBeenCalled();
+			expect( mockSaveEntityRecord ).not.toHaveBeenCalled();
 		} );
 
 		it( 'never throws when the meta write fails — the canvas still swaps', async () => {
 			mockCurrentPostId = 7;
-			mockApiFetch.mockRejectedValueOnce( new Error( 'network down' ) );
+			mockSaveEntityRecord.mockRejectedValueOnce( new Error( 'network down' ) );
 			const consoleWarnSpy = jest.spyOn( console, 'warn' ).mockImplementation( () => undefined );
 
 			const { registerUpdateCanvasVideoAbility } = await import( './update-canvas-video' );
@@ -388,41 +373,10 @@ describe( 'registerUpdateCanvasVideoAbility', () => {
 				} )
 			).resolves.toEqual( { ok: true } );
 
-			expect( mockReceiveEntityRecords ).not.toHaveBeenCalled();
 			expect( mockSetCurrentVideoUrl ).toHaveBeenCalledWith(
 				'https://files.wordpress.com/clip.mp4'
 			);
 			consoleWarnSpy.mockRestore();
-		} );
-
-		it( "uses the post type's rest_base for the REST path when it diverges from the slug", async () => {
-			mockCurrentPostId = 7;
-			mockCurrentPostType = 'news'; // CPT whose slug doesn't pluralize cleanly
-			mockRestBase = 'news'; // already-plural rest_base
-			const { registerUpdateCanvasVideoAbility } = await import( './update-canvas-video' );
-			await registerUpdateCanvasVideoAbility();
-
-			const callback = getRegisteredCallback();
-			await callback( { url: 'https://files.wordpress.com/clip.mp4', attachmentId: 42 } );
-
-			expect( mockApiFetch ).toHaveBeenCalledWith(
-				expect.objectContaining( { path: '/wp/v2/news/7' } )
-			);
-		} );
-
-		it( 'falls back to slug + "s" if rest_base lookup is unavailable', async () => {
-			mockCurrentPostId = 7;
-			mockCurrentPostType = 'post';
-			mockRestBase = undefined;
-			const { registerUpdateCanvasVideoAbility } = await import( './update-canvas-video' );
-			await registerUpdateCanvasVideoAbility();
-
-			const callback = getRegisteredCallback();
-			await callback( { url: 'https://files.wordpress.com/clip.mp4', attachmentId: 42 } );
-
-			expect( mockApiFetch ).toHaveBeenCalledWith(
-				expect.objectContaining( { path: '/wp/v2/posts/7' } )
-			);
 		} );
 	} );
 } );

--- a/packages/image-studio/src/abilities/update-canvas-video.test.ts
+++ b/packages/image-studio/src/abilities/update-canvas-video.test.ts
@@ -322,10 +322,12 @@ describe( 'registerUpdateCanvasVideoAbility', () => {
 				attachmentId: 42,
 			} );
 
-			expect( mockSaveEntityRecord ).toHaveBeenCalledWith( 'postType', 'post', {
-				id: 7,
-				meta: { _jetpack_feature_clip_id: 42 },
-			} );
+			expect( mockSaveEntityRecord ).toHaveBeenCalledWith(
+				'postType',
+				'post',
+				{ id: 7, meta: { _jetpack_feature_clip_id: 42 } },
+				{ throwOnError: true }
+			);
 		} );
 
 		it( 'forwards the current post type so saveEntityRecord targets the right entity', async () => {
@@ -337,10 +339,12 @@ describe( 'registerUpdateCanvasVideoAbility', () => {
 			const callback = getRegisteredCallback();
 			await callback( { url: 'https://files.wordpress.com/clip.mp4', attachmentId: 42 } );
 
-			expect( mockSaveEntityRecord ).toHaveBeenCalledWith( 'postType', 'page', {
-				id: 9,
-				meta: { _jetpack_feature_clip_id: 42 },
-			} );
+			expect( mockSaveEntityRecord ).toHaveBeenCalledWith(
+				'postType',
+				'page',
+				{ id: 9, meta: { _jetpack_feature_clip_id: 42 } },
+				{ throwOnError: true }
+			);
 		} );
 
 		it( 'skips the meta write when there is no current post', async () => {

--- a/packages/image-studio/src/abilities/update-canvas-video.test.ts
+++ b/packages/image-studio/src/abilities/update-canvas-video.test.ts
@@ -14,12 +14,42 @@ const mockSetCurrentAttachmentId = jest.fn().mockResolvedValue( undefined );
 const mockSetCurrentDurationSeconds = jest.fn().mockResolvedValue( undefined );
 const mockAddNotice = jest.fn();
 const mockTrackImageStudioImageGenerated = jest.fn();
-const mockDispatch = jest.fn( () => ( {
-	setCurrentVideoUrl: mockSetCurrentVideoUrl,
-	setCurrentAttachmentId: mockSetCurrentAttachmentId,
-	setCurrentDurationSeconds: mockSetCurrentDurationSeconds,
-	addNotice: mockAddNotice,
-} ) );
+const mockReceiveEntityRecords = jest.fn();
+const mockApiFetch = jest.fn();
+
+let mockCurrentPostId: number | null = null;
+let mockCurrentPostType = 'post';
+
+const mockDispatch = jest.fn( ( store?: string ) => {
+	if ( store === 'core' ) {
+		return { receiveEntityRecords: mockReceiveEntityRecords };
+	}
+	return {
+		setCurrentVideoUrl: mockSetCurrentVideoUrl,
+		setCurrentAttachmentId: mockSetCurrentAttachmentId,
+		setCurrentDurationSeconds: mockSetCurrentDurationSeconds,
+		addNotice: mockAddNotice,
+	};
+} );
+
+const mockSelect = jest.fn( ( store?: string ) => {
+	if ( store === 'core/editor' ) {
+		return {
+			getCurrentPostId: () => mockCurrentPostId,
+			getCurrentPostType: () => mockCurrentPostType,
+		};
+	}
+	return null;
+} );
+
+jest.mock(
+	'@wordpress/api-fetch',
+	() => ( {
+		__esModule: true,
+		default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+	} ),
+	{ virtual: true }
+);
 
 jest.mock( '../utils/tracking', () => ( {
 	trackImageStudioImageGenerated: ( ...args: unknown[] ) =>
@@ -42,7 +72,7 @@ jest.mock( '@wordpress/data', () => ( {
 		...config,
 	} ) ),
 	register: jest.fn(),
-	select: jest.fn( () => null ),
+	select: ( ...args: unknown[] ) => mockSelect( ...args ),
 } ) );
 
 type AbilityCallback = ( input: unknown ) => Promise< unknown >;
@@ -62,6 +92,12 @@ describe( 'registerUpdateCanvasVideoAbility', () => {
 		jest.clearAllMocks();
 		mockRegisterAbilityCategory.mockResolvedValue( undefined );
 		mockRegisterAbility.mockResolvedValue( undefined );
+		mockApiFetch.mockResolvedValue( {
+			id: 1,
+			meta: { _jetpack_feature_clip_id: 42 },
+		} );
+		mockCurrentPostId = null;
+		mockCurrentPostType = 'post';
 		// Reset module-level isRegistered guard between tests.
 		jest.resetModules();
 
@@ -284,5 +320,71 @@ describe( 'registerUpdateCanvasVideoAbility', () => {
 
 		expect( mockTrackImageStudioImageGenerated ).not.toHaveBeenCalled();
 		expect( mockAddNotice ).not.toHaveBeenCalled();
+	} );
+
+	describe( 'feature clip post-meta persistence', () => {
+		it( 'persists the attachment ID against the current post via core REST', async () => {
+			mockCurrentPostId = 7;
+			mockCurrentPostType = 'post';
+			const { registerUpdateCanvasVideoAbility } = await import( './update-canvas-video' );
+			await registerUpdateCanvasVideoAbility();
+
+			const callback = getRegisteredCallback();
+			await callback( {
+				url: 'https://files.wordpress.com/clip.mp4',
+				attachmentId: 42,
+			} );
+
+			expect( mockApiFetch ).toHaveBeenCalledWith( {
+				path: '/wp/v2/posts/7',
+				method: 'POST',
+				data: { meta: { _jetpack_feature_clip_id: 42 } },
+			} );
+			expect( mockReceiveEntityRecords ).toHaveBeenCalledWith(
+				'postType',
+				'post',
+				expect.arrayContaining( [
+					expect.objectContaining( { meta: { _jetpack_feature_clip_id: 42 } } ),
+				] )
+			);
+		} );
+
+		it( 'skips the meta write when there is no current post', async () => {
+			mockCurrentPostId = null;
+			const { registerUpdateCanvasVideoAbility } = await import( './update-canvas-video' );
+			await registerUpdateCanvasVideoAbility();
+
+			const callback = getRegisteredCallback();
+			await callback( {
+				url: 'https://files.wordpress.com/clip.mp4',
+				attachmentId: 42,
+			} );
+
+			expect( mockApiFetch ).not.toHaveBeenCalled();
+			expect( mockReceiveEntityRecords ).not.toHaveBeenCalled();
+		} );
+
+		it( 'never throws when the meta write fails — the canvas still swaps', async () => {
+			mockCurrentPostId = 7;
+			mockApiFetch.mockRejectedValueOnce( new Error( 'network down' ) );
+			const consoleWarnSpy = jest.spyOn( console, 'warn' ).mockImplementation( () => undefined );
+
+			const { registerUpdateCanvasVideoAbility } = await import( './update-canvas-video' );
+			await registerUpdateCanvasVideoAbility();
+
+			const callback = getRegisteredCallback();
+			await expect(
+				callback( {
+					url: 'https://files.wordpress.com/clip.mp4',
+					attachmentId: 42,
+				} )
+			).resolves.toEqual( { ok: true } );
+
+			expect( mockReceiveEntityRecords ).not.toHaveBeenCalled();
+			expect( mockSetCurrentVideoUrl ).toHaveBeenCalledWith(
+				'https://files.wordpress.com/clip.mp4'
+			);
+			consoleWarnSpy.mockRestore();
+		} );
 	} );
 } );

--- a/packages/image-studio/src/abilities/update-canvas-video.test.ts
+++ b/packages/image-studio/src/abilities/update-canvas-video.test.ts
@@ -19,6 +19,7 @@ const mockApiFetch = jest.fn();
 
 let mockCurrentPostId: number | null = null;
 let mockCurrentPostType = 'post';
+let mockRestBase: string | undefined = 'posts';
 
 const mockDispatch = jest.fn( ( store?: string ) => {
 	if ( store === 'core' ) {
@@ -37,6 +38,12 @@ const mockSelect = jest.fn( ( store?: string ) => {
 		return {
 			getCurrentPostId: () => mockCurrentPostId,
 			getCurrentPostType: () => mockCurrentPostType,
+		};
+	}
+	if ( store === 'core' ) {
+		return {
+			getEntityRecord: () =>
+				mockRestBase === undefined ? undefined : { rest_base: mockRestBase },
 		};
 	}
 	return null;
@@ -98,6 +105,7 @@ describe( 'registerUpdateCanvasVideoAbility', () => {
 		} );
 		mockCurrentPostId = null;
 		mockCurrentPostType = 'post';
+		mockRestBase = 'posts';
 		// Reset module-level isRegistered guard between tests.
 		jest.resetModules();
 
@@ -385,6 +393,36 @@ describe( 'registerUpdateCanvasVideoAbility', () => {
 				'https://files.wordpress.com/clip.mp4'
 			);
 			consoleWarnSpy.mockRestore();
+		} );
+
+		it( "uses the post type's rest_base for the REST path when it diverges from the slug", async () => {
+			mockCurrentPostId = 7;
+			mockCurrentPostType = 'news'; // CPT whose slug doesn't pluralize cleanly
+			mockRestBase = 'news'; // already-plural rest_base
+			const { registerUpdateCanvasVideoAbility } = await import( './update-canvas-video' );
+			await registerUpdateCanvasVideoAbility();
+
+			const callback = getRegisteredCallback();
+			await callback( { url: 'https://files.wordpress.com/clip.mp4', attachmentId: 42 } );
+
+			expect( mockApiFetch ).toHaveBeenCalledWith(
+				expect.objectContaining( { path: '/wp/v2/news/7' } )
+			);
+		} );
+
+		it( 'falls back to slug + "s" if rest_base lookup is unavailable', async () => {
+			mockCurrentPostId = 7;
+			mockCurrentPostType = 'post';
+			mockRestBase = undefined;
+			const { registerUpdateCanvasVideoAbility } = await import( './update-canvas-video' );
+			await registerUpdateCanvasVideoAbility();
+
+			const callback = getRegisteredCallback();
+			await callback( { url: 'https://files.wordpress.com/clip.mp4', attachmentId: 42 } );
+
+			expect( mockApiFetch ).toHaveBeenCalledWith(
+				expect.objectContaining( { path: '/wp/v2/posts/7' } )
+			);
 		} );
 	} );
 } );

--- a/packages/image-studio/src/abilities/update-canvas-video.ts
+++ b/packages/image-studio/src/abilities/update-canvas-video.ts
@@ -47,18 +47,27 @@ async function persistFeatureClipMeta( attachmentId: number ): Promise< void > {
 		saveEntityRecord?: (
 			kind: string,
 			name: string,
-			record: { id: number; meta: Record< string, unknown > }
+			record: { id: number; meta: Record< string, unknown > },
+			options?: { throwOnError?: boolean }
 		) => Promise< unknown >;
 	};
 
 	try {
-		await core.saveEntityRecord?.( 'postType', postType, {
-			id: postId,
-			meta: { [ FEATURE_CLIP_META_KEY ]: attachmentId },
-		} );
+		// `throwOnError: true` is required — by default core-data resolves
+		// `saveEntityRecord` with the error stored on the entity rather than
+		// rejecting, which would silently bypass this catch and we'd never log
+		// the failure.
+		await core.saveEntityRecord?.(
+			'postType',
+			postType,
+			{
+				id: postId,
+				meta: { [ FEATURE_CLIP_META_KEY ]: attachmentId },
+			},
+			{ throwOnError: true }
+		);
 	} catch ( error ) {
-		// eslint-disable-next-line no-console
-		console.warn( '[Image Studio] Failed to persist feature clip meta:', error );
+		window.console?.warn?.( '[Image Studio] Failed to persist feature clip meta:', error );
 	}
 }
 

--- a/packages/image-studio/src/abilities/update-canvas-video.ts
+++ b/packages/image-studio/src/abilities/update-canvas-video.ts
@@ -8,12 +8,50 @@
  */
 
 import { registerAbility } from '@wordpress/abilities';
-import { dispatch } from '@wordpress/data';
+import apiFetch from '@wordpress/api-fetch';
+import { dispatch, select } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as imageStudioStore, type ImageStudioActions } from '../store';
 import { store as videoStudioStore, type VideoStudioActions } from '../stores/video-studio';
 import { ImageStudioMode } from '../types';
 import { trackImageStudioImageGenerated } from '../utils/tracking';
+
+const FEATURE_CLIP_META_KEY = '_jetpack_feature_clip_id';
+
+/**
+ * Persist the generated video clip's attachment ID against the current post
+ * via the standard core REST `posts` endpoint. The meta is registered by the
+ * Jetpack Image Studio extension with `show_in_rest`. Failures are logged but
+ * never block the canvas swap — the in-memory video-studio store still
+ * reflects the freshly generated clip even if the meta write loses the race.
+ */
+async function persistFeatureClipMeta( attachmentId: number ): Promise< void > {
+	const editor = select( 'core/editor' ) as
+		| { getCurrentPostId: () => number | null; getCurrentPostType: () => string | null }
+		| undefined;
+
+	const postId = editor?.getCurrentPostId?.() ?? null;
+	const postType = editor?.getCurrentPostType?.() ?? 'post';
+
+	if ( ! postId ) {
+		return;
+	}
+
+	try {
+		const response = ( await apiFetch( {
+			path: `/wp/v2/${ postType }s/${ postId }`,
+			method: 'POST',
+			data: { meta: { [ FEATURE_CLIP_META_KEY ]: attachmentId } },
+		} ) ) as Record< string, unknown >;
+
+		(
+			dispatch( 'core' ) as { receiveEntityRecords: ( ...args: unknown[] ) => void }
+		 )?.receiveEntityRecords?.( 'postType', postType, [ response ] );
+	} catch ( error ) {
+		// eslint-disable-next-line no-console
+		console.warn( '[Image Studio] Failed to persist feature clip meta:', error );
+	}
+}
 
 const ABILITY_NAME = 'image-studio/update-canvas-video';
 
@@ -117,6 +155,10 @@ export async function registerUpdateCanvasVideoAbility(): Promise< void > {
 				await setCurrentVideoUrl( url );
 				await setCurrentAttachmentId( attachmentId );
 				await setCurrentDurationSeconds( durationSeconds );
+
+				// Persist the clip → post linkage. Best-effort; the in-memory
+				// store reflects the new clip regardless of REST outcome.
+				await persistFeatureClipMeta( attachmentId );
 
 				trackImageStudioImageGenerated( {
 					mode: ImageStudioMode.Generate,

--- a/packages/image-studio/src/abilities/update-canvas-video.ts
+++ b/packages/image-studio/src/abilities/update-canvas-video.ts
@@ -37,9 +37,26 @@ async function persistFeatureClipMeta( attachmentId: number ): Promise< void > {
 		return;
 	}
 
+	// Look up the post type's actual REST base. Naive `${postType}s` breaks
+	// for custom post types whose REST base isn't a simple "+s" (e.g. an
+	// already-plural slug like `news`, or an explicit `rest_base` override).
+	// `getEntityRecord( 'root', 'postType', name )` is populated by the editor
+	// the moment the post loads, so this is a synchronous read in practice.
+	const core = select( 'core' ) as
+		| {
+				getEntityRecord: (
+					kind: string,
+					name: string,
+					id: string
+				) => { rest_base?: string } | undefined;
+		  }
+		| undefined;
+	const restBase = core?.getEntityRecord?.( 'root', 'postType', postType )?.rest_base;
+	const path = restBase ? `/wp/v2/${ restBase }/${ postId }` : `/wp/v2/${ postType }s/${ postId }`;
+
 	try {
 		const response = ( await apiFetch( {
-			path: `/wp/v2/${ postType }s/${ postId }`,
+			path,
 			method: 'POST',
 			data: { meta: { [ FEATURE_CLIP_META_KEY ]: attachmentId } },
 		} ) ) as Record< string, unknown >;

--- a/packages/image-studio/src/abilities/update-canvas-video.ts
+++ b/packages/image-studio/src/abilities/update-canvas-video.ts
@@ -23,6 +23,15 @@ import { trackImageStudioImageGenerated } from '../utils/tracking';
  * Jetpack Image Studio extension with `show_in_rest`. Failures are logged but
  * never block the canvas swap — the in-memory video-studio store still
  * reflects the freshly generated clip even if the meta write loses the race.
+ *
+ * NOTE: deliberately uses raw `apiFetch` rather than the cleaner
+ * `dispatch( 'core' ).saveEntityRecord( 'postType', ... )`. saveEntityRecord
+ * routes through `core.isSavingEntityRecord( 'postType', post.type, post.id )`,
+ * which `core/editor.isSavingPost` selects on. Calling it after every video
+ * generation would briefly flip the toolbar "Saving…" pill and disable the
+ * Publish button, even though the user didn't initiate a save. The meta write
+ * is background bookkeeping and shouldn't disturb the editor's idle state, so
+ * we POST the field directly and call `receiveEntityRecords` ourselves.
  */
 async function persistFeatureClipMeta( attachmentId: number ): Promise< void > {
 	const editor = select( 'core/editor' ) as

--- a/packages/image-studio/src/abilities/update-canvas-video.ts
+++ b/packages/image-studio/src/abilities/update-canvas-video.ts
@@ -8,7 +8,6 @@
  */
 
 import { registerAbility } from '@wordpress/abilities';
-import apiFetch from '@wordpress/api-fetch';
 import { dispatch, select } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { FEATURE_CLIP_META_KEY } from '../extensions/feature-clip-meta';
@@ -19,19 +18,18 @@ import { trackImageStudioImageGenerated } from '../utils/tracking';
 
 /**
  * Persist the generated video clip's attachment ID against the current post
- * via the standard core REST `posts` endpoint. The meta is registered by the
+ * via the core entity store. The meta is registered server-side by the
  * Jetpack Image Studio extension with `show_in_rest`. Failures are logged but
  * never block the canvas swap — the in-memory video-studio store still
  * reflects the freshly generated clip even if the meta write loses the race.
  *
- * NOTE: deliberately uses raw `apiFetch` rather than the cleaner
- * `dispatch( 'core' ).saveEntityRecord( 'postType', ... )`. saveEntityRecord
- * routes through `core.isSavingEntityRecord( 'postType', post.type, post.id )`,
- * which `core/editor.isSavingPost` selects on. Calling it after every video
- * generation would briefly flip the toolbar "Saving…" pill and disable the
- * Publish button, even though the user didn't initiate a save. The meta write
- * is background bookkeeping and shouldn't disturb the editor's idle state, so
- * we POST the field directly and call `receiveEntityRecords` ourselves.
+ * `saveEntityRecord` flips `core.isSavingEntityRecord( 'postType', ... )`,
+ * which `core/editor.isSavingPost` is composed from — so the editor's
+ * "Saving…" pill briefly shows and Publish briefly disables for the duration
+ * of this request. That's deliberate: a meta write *is* a save, the user
+ * deserves honest signalling, and video generations are rare enough that the
+ * brief flicker is preferable to the maintenance burden of a hand-rolled
+ * REST call (with rest_base lookup + manual cache hydration).
  */
 async function persistFeatureClipMeta( attachmentId: number ): Promise< void > {
 	const editor = select( 'core/editor' ) as
@@ -45,33 +43,19 @@ async function persistFeatureClipMeta( attachmentId: number ): Promise< void > {
 		return;
 	}
 
-	// Look up the post type's actual REST base. Naive `${postType}s` breaks
-	// for custom post types whose REST base isn't a simple "+s" (e.g. an
-	// already-plural slug like `news`, or an explicit `rest_base` override).
-	// `getEntityRecord( 'root', 'postType', name )` is populated by the editor
-	// the moment the post loads, so this is a synchronous read in practice.
-	const core = select( 'core' ) as
-		| {
-				getEntityRecord: (
-					kind: string,
-					name: string,
-					id: string
-				) => { rest_base?: string } | undefined;
-		  }
-		| undefined;
-	const restBase = core?.getEntityRecord?.( 'root', 'postType', postType )?.rest_base;
-	const path = restBase ? `/wp/v2/${ restBase }/${ postId }` : `/wp/v2/${ postType }s/${ postId }`;
+	const core = dispatch( 'core' ) as {
+		saveEntityRecord?: (
+			kind: string,
+			name: string,
+			record: { id: number; meta: Record< string, unknown > }
+		) => Promise< unknown >;
+	};
 
 	try {
-		const response = ( await apiFetch( {
-			path,
-			method: 'POST',
-			data: { meta: { [ FEATURE_CLIP_META_KEY ]: attachmentId } },
-		} ) ) as Record< string, unknown >;
-
-		(
-			dispatch( 'core' ) as { receiveEntityRecords: ( ...args: unknown[] ) => void }
-		 )?.receiveEntityRecords?.( 'postType', postType, [ response ] );
+		await core.saveEntityRecord?.( 'postType', postType, {
+			id: postId,
+			meta: { [ FEATURE_CLIP_META_KEY ]: attachmentId },
+		} );
 	} catch ( error ) {
 		// eslint-disable-next-line no-console
 		console.warn( '[Image Studio] Failed to persist feature clip meta:', error );

--- a/packages/image-studio/src/abilities/update-canvas-video.ts
+++ b/packages/image-studio/src/abilities/update-canvas-video.ts
@@ -11,12 +11,11 @@ import { registerAbility } from '@wordpress/abilities';
 import apiFetch from '@wordpress/api-fetch';
 import { dispatch, select } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { FEATURE_CLIP_META_KEY } from '../extensions/feature-clip-meta';
 import { store as imageStudioStore, type ImageStudioActions } from '../store';
 import { store as videoStudioStore, type VideoStudioActions } from '../stores/video-studio';
 import { ImageStudioMode } from '../types';
 import { trackImageStudioImageGenerated } from '../utils/tracking';
-
-const FEATURE_CLIP_META_KEY = '_jetpack_feature_clip_id';
 
 /**
  * Persist the generated video clip's attachment ID against the current post

--- a/packages/image-studio/src/extensions/feature-clip-meta.ts
+++ b/packages/image-studio/src/extensions/feature-clip-meta.ts
@@ -1,0 +1,7 @@
+/**
+ * Single source of truth for the post meta key that links a generated video
+ * clip to its post. Registered server-side by the Jetpack Image Studio
+ * extension; consumed both from the agent ability that persists the value
+ * after generation and from the sidebar that reads it back.
+ */
+export const FEATURE_CLIP_META_KEY = '_jetpack_feature_clip_id';

--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
@@ -15,20 +15,35 @@ const mockSetCurrentVideoUrl = jest.fn().mockResolvedValue( undefined );
 const mockSetCurrentAttachmentId = jest.fn().mockResolvedValue( undefined );
 const mockSetCurrentDurationSeconds = jest.fn().mockResolvedValue( undefined );
 
+let mockMeta: Record< string, unknown > = {};
+let mockMedia: Record< string, unknown > | null = null;
+let mockReelVisible = false;
+let mockGenericVisible = false;
+const mockReelHandleShare = jest.fn();
+const mockGenericHandleShare = jest.fn();
+
 jest.mock( '@wordpress/components', () => ( {
 	Button: ( {
 		children,
 		onClick,
 		className,
+		label,
+		icon,
 	}: {
-		children: React.ReactNode;
+		children?: React.ReactNode;
 		onClick?: () => void;
 		className?: string;
+		label?: string;
+		icon?: React.ReactNode;
 	} ) => (
-		<button className={ className } onClick={ onClick }>
-			{ children }
+		<button className={ className } aria-label={ label } onClick={ onClick }>
+			{ children ?? icon }
 		</button>
 	),
+} ) );
+
+jest.mock( '@wordpress/core-data', () => ( {
+	useEntityProp: () => [ mockMeta, jest.fn() ],
 } ) );
 
 jest.mock( '@wordpress/data', () => ( {
@@ -42,6 +57,17 @@ jest.mock( '@wordpress/data', () => ( {
 		}
 		return { openImageStudio: mockOpenImageStudio };
 	} ),
+	useSelect: ( selector: ( s: ( name: string ) => unknown ) => unknown ) => {
+		return selector( ( name: string ) => {
+			if ( name === 'core/editor' ) {
+				return { getCurrentPostType: () => 'post' };
+			}
+			if ( name === 'core' ) {
+				return { getMedia: () => mockMedia };
+			}
+			return undefined;
+		} );
+	},
 } ) );
 
 jest.mock( '@wordpress/editor', () => ( {
@@ -58,8 +84,32 @@ jest.mock( '@wordpress/i18n', () => ( {
 	__: ( text: string ) => text,
 } ) );
 
+jest.mock( '@wordpress/icons', () => ( {
+	share: 'share-icon',
+} ) );
+
 jest.mock( '@wordpress/plugins', () => ( {
 	registerPlugin: ( name: string, settings: unknown ) => mockRegisterPlugin( name, settings ),
+} ) );
+
+jest.mock( 'social-logos', () => ( {
+	SocialLogo: ( { icon }: { icon: string } ) => <span data-testid={ `social-${ icon }` } />,
+} ) );
+
+jest.mock( '../hooks/use-reel-share', () => ( {
+	useReelShare: () => ( {
+		isVisible: mockReelVisible,
+		isSharing: false,
+		handleShare: mockReelHandleShare,
+	} ),
+} ) );
+
+jest.mock( '../hooks/use-generic-share', () => ( {
+	useGenericShare: () => ( {
+		isVisible: mockGenericVisible,
+		isSharing: false,
+		handleShare: mockGenericHandleShare,
+	} ),
 } ) );
 
 jest.mock( '../store', () => ( {
@@ -86,6 +136,12 @@ describe( 'feature-clip-sidebar-extension', () => {
 		mockSetCurrentVideoUrl.mockClear();
 		mockSetCurrentAttachmentId.mockClear();
 		mockSetCurrentDurationSeconds.mockClear();
+		mockReelHandleShare.mockClear();
+		mockGenericHandleShare.mockClear();
+		mockMeta = {};
+		mockMedia = null;
+		mockReelVisible = false;
+		mockGenericVisible = false;
 		( window as Record< string, unknown > ).imageStudioData = { isDevMode: true };
 		jest.resetModules();
 	} );
@@ -121,27 +177,115 @@ describe( 'feature-clip-sidebar-extension', () => {
 		expect( mockRegisterPlugin.mock.calls[ 0 ][ 0 ] ).toBe( 'image-studio-feature-clip' );
 	} );
 
-	it( 'opens Image Studio with the post-editor entry point on click', async () => {
-		const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
-		render( <FeatureClipPanel /> );
+	describe( 'empty state (no clip linked)', () => {
+		it( 'renders the Generate clip CTA when meta is empty', () => {
+			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			render( <FeatureClipPanel /> );
+			expect( screen.getByRole( 'button', { name: 'Generate clip' } ) ).toBeInTheDocument();
+			expect( screen.queryByRole( 'button', { name: 'Regenerate clip' } ) ).not.toBeInTheDocument();
+		} );
 
-		fireEvent.click( screen.getByRole( 'button', { name: 'Generate clip' } ) );
+		it( 'renders the empty state when meta has an id but the attachment is gone', () => {
+			mockMeta = { _jetpack_feature_clip_id: 42 };
+			mockMedia = null; // attachment deleted
+			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			render( <FeatureClipPanel /> );
+			expect( screen.getByRole( 'button', { name: 'Generate clip' } ) ).toBeInTheDocument();
+		} );
 
-		// handleClick awaits the video-studio reset before opening the modal,
-		// so flush microtasks before asserting on the post-await calls.
-		await Promise.resolve();
-		await Promise.resolve();
+		it( 'opens Image Studio with the post-editor entry point on click', async () => {
+			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			render( <FeatureClipPanel /> );
 
-		expect( mockSetCurrentVideoUrl ).toHaveBeenCalledWith( null );
-		expect( mockSetCurrentAttachmentId ).toHaveBeenCalledWith( null );
-		expect( mockSetCurrentDurationSeconds ).toHaveBeenCalledWith( null );
-		expect( mockTrackOpened ).toHaveBeenCalledWith(
-			expect.objectContaining( { entryPoint: 'post_editor_feature_clip' } )
-		);
-		expect( mockOpenImageStudio ).toHaveBeenCalledWith(
-			undefined,
-			undefined,
-			'post_editor_feature_clip'
-		);
+			fireEvent.click( screen.getByRole( 'button', { name: 'Generate clip' } ) );
+
+			await Promise.resolve();
+			await Promise.resolve();
+
+			expect( mockSetCurrentVideoUrl ).toHaveBeenCalledWith( null );
+			expect( mockSetCurrentAttachmentId ).toHaveBeenCalledWith( null );
+			expect( mockSetCurrentDurationSeconds ).toHaveBeenCalledWith( null );
+			expect( mockTrackOpened ).toHaveBeenCalledWith(
+				expect.objectContaining( { entryPoint: 'post_editor_feature_clip' } )
+			);
+			expect( mockOpenImageStudio ).toHaveBeenCalledWith(
+				undefined,
+				undefined,
+				'post_editor_feature_clip'
+			);
+		} );
+	} );
+
+	describe( 'preview state (clip linked)', () => {
+		const setupClip = () => {
+			mockMeta = { _jetpack_feature_clip_id: 42 };
+			mockMedia = {
+				id: 42,
+				source_url: 'https://files.wordpress.com/clip.mp4',
+				media_details: { length: 8 },
+			};
+		};
+
+		it( 'renders the video preview and Regenerate button', () => {
+			setupClip();
+			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			const { container } = render( <FeatureClipPanel /> );
+
+			const video = container.querySelector( 'video' );
+			expect( video ).not.toBeNull();
+			expect( video?.getAttribute( 'src' ) ).toBe( 'https://files.wordpress.com/clip.mp4' );
+			expect( screen.getByRole( 'button', { name: 'Regenerate clip' } ) ).toBeInTheDocument();
+			expect( screen.queryByRole( 'button', { name: 'Generate clip' } ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'shows share buttons only when their hooks report isVisible', () => {
+			setupClip();
+			mockReelVisible = false;
+			mockGenericVisible = false;
+			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			const { rerender } = render( <FeatureClipPanel /> );
+			expect(
+				screen.queryByRole( 'button', { name: /Share on Instagram/i } )
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByRole( 'button', { name: /Share to other apps/i } )
+			).not.toBeInTheDocument();
+
+			mockReelVisible = true;
+			mockGenericVisible = true;
+			rerender( <FeatureClipPanel /> );
+			expect( screen.getByRole( 'button', { name: /Share on Instagram/i } ) ).toBeInTheDocument();
+			expect( screen.getByRole( 'button', { name: /Share to other apps/i } ) ).toBeInTheDocument();
+		} );
+
+		it( 'invokes handleShare on share button clicks', () => {
+			setupClip();
+			mockReelVisible = true;
+			mockGenericVisible = true;
+			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			render( <FeatureClipPanel /> );
+
+			fireEvent.click( screen.getByRole( 'button', { name: /Share on Instagram/i } ) );
+			expect( mockReelHandleShare ).toHaveBeenCalledTimes( 1 );
+
+			fireEvent.click( screen.getByRole( 'button', { name: /Share to other apps/i } ) );
+			expect( mockGenericHandleShare ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'opens Image Studio on Regenerate click', async () => {
+			setupClip();
+			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			render( <FeatureClipPanel /> );
+
+			fireEvent.click( screen.getByRole( 'button', { name: 'Regenerate clip' } ) );
+			await Promise.resolve();
+			await Promise.resolve();
+
+			expect( mockOpenImageStudio ).toHaveBeenCalledWith(
+				undefined,
+				undefined,
+				'post_editor_feature_clip'
+			);
+		} );
 	} );
 } );

--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
@@ -22,6 +22,7 @@ const mockCreateBlock = jest.fn( ( name: string, attributes: Record< string, unk
 
 let mockMeta: Record< string, unknown > = {};
 let mockMedia: Record< string, unknown > | null = null;
+let mockHasResolvedMedia = true;
 let mockReelVisible = false;
 let mockGenericVisible = false;
 const mockReelHandleShare = jest.fn();
@@ -73,10 +74,13 @@ jest.mock( '@wordpress/data', () => ( {
 	useSelect: ( selector: ( s: ( name: string ) => unknown ) => unknown ) => {
 		return selector( ( name: string ) => {
 			if ( name === 'core/editor' ) {
-				return { getCurrentPostType: () => 'post' };
+				return { getCurrentPostType: () => 'post', getCurrentPostId: () => 7 };
 			}
 			if ( name === 'core' ) {
-				return { getMedia: () => mockMedia };
+				return {
+					getMedia: () => mockMedia,
+					hasFinishedResolution: () => mockHasResolvedMedia,
+				};
 			}
 			return undefined;
 		} );
@@ -155,6 +159,7 @@ describe( 'feature-clip-sidebar-extension', () => {
 		mockCreateBlock.mockClear();
 		mockMeta = {};
 		mockMedia = null;
+		mockHasResolvedMedia = true;
 		mockReelVisible = false;
 		mockGenericVisible = false;
 		( window as Record< string, unknown > ).imageStudioData = { isDevMode: true };
@@ -203,9 +208,20 @@ describe( 'feature-clip-sidebar-extension', () => {
 		it( 'renders the empty state when meta has an id but the attachment is gone', () => {
 			mockMeta = { _jetpack_feature_clip_id: 42 };
 			mockMedia = null; // attachment deleted
+			mockHasResolvedMedia = true; // resolution finished, attachment confirmed gone
 			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
 			render( <FeatureClipPanel /> );
 			expect( screen.getByRole( 'button', { name: 'Generate clip' } ) ).toBeInTheDocument();
+		} );
+
+		it( 'holds the panel body blank while the attachment is still resolving', () => {
+			mockMeta = { _jetpack_feature_clip_id: 42 };
+			mockMedia = null;
+			mockHasResolvedMedia = false; // first render — getMedia hasn't completed
+			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			render( <FeatureClipPanel /> );
+			expect( screen.queryByRole( 'button', { name: 'Generate clip' } ) ).not.toBeInTheDocument();
+			expect( screen.queryByRole( 'button', { name: 'Regenerate' } ) ).not.toBeInTheDocument();
 		} );
 
 		it( 'opens Image Studio with the post-editor entry point on click', async () => {

--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
@@ -14,6 +14,11 @@ const mockTrackOpened = jest.fn();
 const mockSetCurrentVideoUrl = jest.fn().mockResolvedValue( undefined );
 const mockSetCurrentAttachmentId = jest.fn().mockResolvedValue( undefined );
 const mockSetCurrentDurationSeconds = jest.fn().mockResolvedValue( undefined );
+const mockInsertBlocks = jest.fn();
+const mockCreateBlock = jest.fn( ( name: string, attributes: Record< string, unknown > ) => ( {
+	name,
+	attributes,
+} ) );
 
 let mockMeta: Record< string, unknown > = {};
 let mockMedia: Record< string, unknown > | null = null;
@@ -46,6 +51,11 @@ jest.mock( '@wordpress/core-data', () => ( {
 	useEntityProp: () => [ mockMeta, jest.fn() ],
 } ) );
 
+jest.mock( '@wordpress/blocks', () => ( {
+	createBlock: ( name: string, attributes: Record< string, unknown > ) =>
+		mockCreateBlock( name, attributes ),
+} ) );
+
 jest.mock( '@wordpress/data', () => ( {
 	dispatch: jest.fn( ( store: string ) => {
 		if ( store === 'video-studio' ) {
@@ -54,6 +64,9 @@ jest.mock( '@wordpress/data', () => ( {
 				setCurrentAttachmentId: mockSetCurrentAttachmentId,
 				setCurrentDurationSeconds: mockSetCurrentDurationSeconds,
 			};
+		}
+		if ( store === 'core/block-editor' ) {
+			return { insertBlocks: mockInsertBlocks };
 		}
 		return { openImageStudio: mockOpenImageStudio };
 	} ),
@@ -138,6 +151,8 @@ describe( 'feature-clip-sidebar-extension', () => {
 		mockSetCurrentDurationSeconds.mockClear();
 		mockReelHandleShare.mockClear();
 		mockGenericHandleShare.mockClear();
+		mockInsertBlocks.mockClear();
+		mockCreateBlock.mockClear();
 		mockMeta = {};
 		mockMedia = null;
 		mockReelVisible = false;
@@ -226,7 +241,7 @@ describe( 'feature-clip-sidebar-extension', () => {
 			};
 		};
 
-		it( 'renders the video preview and Regenerate button', () => {
+		it( 'renders the video preview and bottom action buttons', () => {
 			setupClip();
 			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
 			const { container } = render( <FeatureClipPanel /> );
@@ -234,28 +249,31 @@ describe( 'feature-clip-sidebar-extension', () => {
 			const video = container.querySelector( 'video' );
 			expect( video ).not.toBeNull();
 			expect( video?.getAttribute( 'src' ) ).toBe( 'https://files.wordpress.com/clip.mp4' );
-			expect( screen.getByRole( 'button', { name: 'Regenerate clip' } ) ).toBeInTheDocument();
+			expect( screen.getByRole( 'button', { name: 'Add to post' } ) ).toBeInTheDocument();
+			expect( screen.getByRole( 'button', { name: 'Regenerate' } ) ).toBeInTheDocument();
 			expect( screen.queryByRole( 'button', { name: 'Generate clip' } ) ).not.toBeInTheDocument();
 		} );
 
-		it( 'shows share buttons only when their hooks report isVisible', () => {
+		it( 'hides share buttons when neither hook reports isVisible', () => {
 			setupClip();
 			mockReelVisible = false;
 			mockGenericVisible = false;
 			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
-			const { rerender } = render( <FeatureClipPanel /> );
+			render( <FeatureClipPanel /> );
 			expect(
 				screen.queryByRole( 'button', { name: /Share on Instagram/i } )
 			).not.toBeInTheDocument();
-			expect(
-				screen.queryByRole( 'button', { name: /Share to other apps/i } )
-			).not.toBeInTheDocument();
+			expect( screen.queryByRole( 'button', { name: /^Share$/i } ) ).not.toBeInTheDocument();
+		} );
 
+		it( 'shows both share buttons when both hooks report isVisible', () => {
+			setupClip();
 			mockReelVisible = true;
 			mockGenericVisible = true;
-			rerender( <FeatureClipPanel /> );
+			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			render( <FeatureClipPanel /> );
 			expect( screen.getByRole( 'button', { name: /Share on Instagram/i } ) ).toBeInTheDocument();
-			expect( screen.getByRole( 'button', { name: /Share to other apps/i } ) ).toBeInTheDocument();
+			expect( screen.getByRole( 'button', { name: /^Share$/i } ) ).toBeInTheDocument();
 		} );
 
 		it( 'invokes handleShare on share button clicks', () => {
@@ -268,7 +286,7 @@ describe( 'feature-clip-sidebar-extension', () => {
 			fireEvent.click( screen.getByRole( 'button', { name: /Share on Instagram/i } ) );
 			expect( mockReelHandleShare ).toHaveBeenCalledTimes( 1 );
 
-			fireEvent.click( screen.getByRole( 'button', { name: /Share to other apps/i } ) );
+			fireEvent.click( screen.getByRole( 'button', { name: /^Share$/i } ) );
 			expect( mockGenericHandleShare ).toHaveBeenCalledTimes( 1 );
 		} );
 
@@ -277,7 +295,7 @@ describe( 'feature-clip-sidebar-extension', () => {
 			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
 			render( <FeatureClipPanel /> );
 
-			fireEvent.click( screen.getByRole( 'button', { name: 'Regenerate clip' } ) );
+			fireEvent.click( screen.getByRole( 'button', { name: 'Regenerate' } ) );
 			await Promise.resolve();
 			await Promise.resolve();
 
@@ -286,6 +304,20 @@ describe( 'feature-clip-sidebar-extension', () => {
 				undefined,
 				'post_editor_feature_clip'
 			);
+		} );
+
+		it( 'inserts a core/video block when Add to post is clicked', () => {
+			setupClip();
+			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			render( <FeatureClipPanel /> );
+
+			fireEvent.click( screen.getByRole( 'button', { name: 'Add to post' } ) );
+
+			expect( mockCreateBlock ).toHaveBeenCalledWith( 'core/video', {
+				id: 42,
+				src: 'https://files.wordpress.com/clip.mp4',
+			} );
+			expect( mockInsertBlocks ).toHaveBeenCalledTimes( 1 );
 		} );
 	} );
 } );

--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
@@ -101,22 +101,9 @@ function FeatureClipPreview( {
 					preload="metadata"
 				/>
 			</div>
-			{ reel.isVisible && (
-				<Button
-					variant="primary"
-					icon={ <SocialLogo icon="instagram" size={ 18 } /> }
-					className="image-studio-feature-clip-panel__share-cta"
-					__next40pxDefaultSize
-					disabled={ reel.isSharing }
-					isBusy={ reel.isSharing }
-					onClick={ reel.handleShare }
-				>
-					{ reelLabel }
-				</Button>
-			) }
 			{ generic.isVisible && (
 				<Button
-					variant={ reel.isVisible ? 'secondary' : 'primary' }
+					variant="primary"
 					icon={ share }
 					className="image-studio-feature-clip-panel__share-cta"
 					__next40pxDefaultSize
@@ -125,6 +112,19 @@ function FeatureClipPreview( {
 					onClick={ generic.handleShare }
 				>
 					{ genericLabel }
+				</Button>
+			) }
+			{ reel.isVisible && (
+				<Button
+					variant={ generic.isVisible ? 'secondary' : 'primary' }
+					icon={ <SocialLogo icon="instagram" size={ 18 } /> }
+					className="image-studio-feature-clip-panel__share-cta"
+					__next40pxDefaultSize
+					disabled={ reel.isSharing }
+					isBusy={ reel.isSharing }
+					onClick={ reel.handleShare }
+				>
+					{ reelLabel }
 				</Button>
 			) }
 			<div className="image-studio-feature-clip-panel__bottom-actions">

--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
@@ -8,6 +8,7 @@
  * extension), shows a small video preview, a share row mirroring the modal,
  * and a Regenerate button.
  */
+import { createBlock } from '@wordpress/blocks';
 import { Button } from '@wordpress/components';
 import { useEntityProp } from '@wordpress/core-data';
 import { dispatch, useSelect } from '@wordpress/data';
@@ -76,8 +77,15 @@ function FeatureClipPreview( {
 		: __( 'Share on Instagram', __i18n_text_domain__ );
 
 	const genericLabel = generic.isSharing
-		? __( 'Sharing to other apps…', __i18n_text_domain__ )
-		: __( 'Share to other apps', __i18n_text_domain__ );
+		? __( 'Sharing…', __i18n_text_domain__ )
+		: __( 'Share', __i18n_text_domain__ );
+
+	const handleAddToPost = () => {
+		const { insertBlocks } = dispatch( 'core/block-editor' ) as {
+			insertBlocks?: ( blocks: unknown ) => void;
+		};
+		insertBlocks?.( createBlock( 'core/video', { id: attachmentId, src: videoUrl } ) );
+	};
 
 	return (
 		<>
@@ -93,46 +101,50 @@ function FeatureClipPreview( {
 					preload="metadata"
 				/>
 			</div>
-			{ ( reel.isVisible || generic.isVisible ) && (
-				<div
-					className="image-studio-feature-clip-panel__share-row"
-					role="group"
-					aria-label={ __( 'Share feature clip', __i18n_text_domain__ ) }
+			{ reel.isVisible && (
+				<Button
+					variant="primary"
+					icon={ <SocialLogo icon="instagram" size={ 18 } /> }
+					className="image-studio-feature-clip-panel__share-cta"
+					__next40pxDefaultSize
+					disabled={ reel.isSharing }
+					isBusy={ reel.isSharing }
+					onClick={ reel.handleShare }
 				>
-					{ generic.isVisible && (
-						<Button
-							variant="secondary"
-							icon={ share }
-							className="image-studio-feature-clip-panel__share-button"
-							label={ genericLabel }
-							showTooltip
-							disabled={ generic.isSharing }
-							isBusy={ generic.isSharing }
-							onClick={ generic.handleShare }
-						/>
-					) }
-					{ reel.isVisible && (
-						<Button
-							variant="secondary"
-							icon={ <SocialLogo icon="instagram" size={ 18 } /> }
-							className="image-studio-feature-clip-panel__share-button"
-							label={ reelLabel }
-							showTooltip
-							disabled={ reel.isSharing }
-							isBusy={ reel.isSharing }
-							onClick={ reel.handleShare }
-						/>
-					) }
-				</div>
+					{ reelLabel }
+				</Button>
 			) }
-			<Button
-				variant="secondary"
-				className="image-studio-feature-clip-panel__cta"
-				__next40pxDefaultSize
-				onClick={ openImageStudioForFeatureClip }
-			>
-				{ __( 'Regenerate clip', __i18n_text_domain__ ) }
-			</Button>
+			{ generic.isVisible && (
+				<Button
+					variant={ reel.isVisible ? 'secondary' : 'primary' }
+					icon={ share }
+					className="image-studio-feature-clip-panel__share-cta"
+					__next40pxDefaultSize
+					disabled={ generic.isSharing }
+					isBusy={ generic.isSharing }
+					onClick={ generic.handleShare }
+				>
+					{ genericLabel }
+				</Button>
+			) }
+			<div className="image-studio-feature-clip-panel__bottom-actions">
+				<Button
+					variant="secondary"
+					className="image-studio-feature-clip-panel__bottom-action"
+					__next40pxDefaultSize
+					onClick={ handleAddToPost }
+				>
+					{ __( 'Add to post', __i18n_text_domain__ ) }
+				</Button>
+				<Button
+					variant="secondary"
+					className="image-studio-feature-clip-panel__bottom-action"
+					__next40pxDefaultSize
+					onClick={ openImageStudioForFeatureClip }
+				>
+					{ __( 'Regenerate', __i18n_text_domain__ ) }
+				</Button>
+			</div>
 		</>
 	);
 }

--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
@@ -171,15 +171,24 @@ function FeatureClipEmptyState(): JSX.Element {
 }
 
 function FeatureClipPanel(): JSX.Element {
-	const postType = useSelect(
-		( select ) =>
-			(
-				select( 'core/editor' ) as { getCurrentPostType: () => string | null } | undefined
-			 )?.getCurrentPostType?.() ?? 'post',
-		[]
-	);
+	const { postType, postId } = useSelect( ( select ) => {
+		const editor = select( 'core/editor' ) as
+			| {
+					getCurrentPostType: () => string | null;
+					getCurrentPostId: () => number | null;
+			  }
+			| undefined;
+		return {
+			postType: editor?.getCurrentPostType?.() ?? 'post',
+			postId: editor?.getCurrentPostId?.() ?? null,
+		};
+	}, [] );
 
-	const entityPropResult = useEntityProp( 'postType', postType, 'meta' );
+	// Pass the post ID explicitly. Without it `useEntityProp` falls back to
+	// EntityProvider context, which isn't set up for sidebar surfaces in every
+	// editor — meta would silently come back undefined and the panel would
+	// stay stuck in the empty state even after a successful generation.
+	const entityPropResult = useEntityProp( 'postType', postType, 'meta', postId ?? undefined );
 	const meta = ( entityPropResult as unknown as [ Record< string, unknown > | undefined ] )[ 0 ];
 
 	const featureClipId = ( () => {
@@ -188,15 +197,27 @@ function FeatureClipPanel(): JSX.Element {
 		return Number.isFinite( n ) && n > 0 ? n : null;
 	} )();
 
-	const attachment = useSelect(
+	const { attachment, hasResolvedAttachment } = useSelect(
 		( select ) => {
 			if ( ! featureClipId ) {
-				return null;
+				return { attachment: null, hasResolvedAttachment: true };
 			}
 			const core = select( 'core' ) as
-				| { getMedia: ( id: number ) => MediaRecord | undefined }
+				| {
+						getMedia: ( id: number ) => MediaRecord | undefined;
+						hasFinishedResolution: ( name: string, args: unknown[] ) => boolean;
+				  }
 				| undefined;
-			return core?.getMedia?.( featureClipId ) ?? null;
+			return {
+				attachment: core?.getMedia?.( featureClipId ) ?? null,
+				// `getMedia` resolves async on first read. Until resolution
+				// finishes the result is `undefined`, which would otherwise
+				// flicker the panel into the empty CTA on reload before the
+				// preview appears. Defer the empty-state fallback until we
+				// know the lookup is genuinely done.
+				hasResolvedAttachment:
+					core?.hasFinishedResolution?.( 'getMedia', [ featureClipId ] ) ?? false,
+			};
 		},
 		[ featureClipId ]
 	);
@@ -214,6 +235,9 @@ function FeatureClipPanel(): JSX.Element {
 	const durationSeconds =
 		typeof attachment?.media_details?.length === 'number' ? attachment.media_details.length : null;
 	const hasUsableClip = !! featureClipId && !! videoUrl;
+	// Hold the panel body blank while the clip's attachment is resolving, so
+	// reload doesn't briefly flash the empty CTA before the preview appears.
+	const isResolvingAttachment = !! featureClipId && ! hasResolvedAttachment;
 
 	return (
 		<PluginDocumentSettingPanel
@@ -223,15 +247,21 @@ function FeatureClipPanel(): JSX.Element {
 			title={ titleNode as unknown as string }
 			className="image-studio-feature-clip-panel"
 		>
-			{ hasUsableClip ? (
-				<FeatureClipPreview
-					videoUrl={ videoUrl }
-					attachmentId={ featureClipId }
-					durationSeconds={ durationSeconds }
-				/>
-			) : (
-				<FeatureClipEmptyState />
-			) }
+			{ ( () => {
+				if ( hasUsableClip ) {
+					return (
+						<FeatureClipPreview
+							videoUrl={ videoUrl }
+							attachmentId={ featureClipId }
+							durationSeconds={ durationSeconds }
+						/>
+					);
+				}
+				if ( isResolvingAttachment ) {
+					return null;
+				}
+				return <FeatureClipEmptyState />;
+			} )() }
 		</PluginDocumentSettingPanel>
 	);
 }

--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
@@ -37,14 +37,16 @@ interface MediaRecord {
 	media_details?: { length?: number };
 }
 
-function openImageStudioForFeatureClip(): void {
+async function openImageStudioForFeatureClip(): Promise< void > {
 	const { openImageStudio } = dispatch( imageStudioStore );
 	const { setCurrentVideoUrl, setCurrentAttachmentId, setCurrentDurationSeconds } = dispatch(
 		videoStudioStore
 	) as VideoStudioActions;
-	// Reset the modal-session store synchronously; the modal will repopulate it
-	// on a successful regeneration.
-	void Promise.all( [
+	// Reset the modal-session store BEFORE opening the modal — these actions
+	// are promisified by wp-data, so a fire-and-forget here would let the modal
+	// mount with the previous clip's URL/attachmentId still in the store and
+	// flash the old preview for one render.
+	await Promise.all( [
 		setCurrentVideoUrl( null ),
 		setCurrentAttachmentId( null ),
 		setCurrentDurationSeconds( null ),

--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
@@ -24,11 +24,11 @@ import { ImageStudioEntryPoint, store as imageStudioStore } from '../store';
 import { store as videoStudioStore, type VideoStudioActions } from '../stores/video-studio';
 import { ImageStudioMode } from '../types';
 import { trackImageStudioOpened } from '../utils/tracking';
+import { FEATURE_CLIP_META_KEY } from './feature-clip-meta';
 import './feature-clip-sidebar.scss';
 
 const PLUGIN_NAME = 'image-studio-feature-clip';
 const PANEL_NAME = 'image-studio-feature-clip-panel';
-const FEATURE_CLIP_META_KEY = '_jetpack_feature_clip_id';
 
 interface MediaRecord {
 	id: number;
@@ -188,8 +188,14 @@ function FeatureClipPanel(): JSX.Element {
 	// EntityProvider context, which isn't set up for sidebar surfaces in every
 	// editor — meta would silently come back undefined and the panel would
 	// stay stuck in the empty state even after a successful generation.
-	const entityPropResult = useEntityProp( 'postType', postType, 'meta', postId ?? undefined );
-	const meta = ( entityPropResult as unknown as [ Record< string, unknown > | undefined ] )[ 0 ];
+	// `useEntityProp`'s upstream signature is loosely typed as
+	// `[ any, Function, any ]`, so cast the destructured tuple shape we use
+	// rather than reaching through `unknown` and indexing.
+	const [ meta ] = useEntityProp( 'postType', postType, 'meta', postId ?? undefined ) as [
+		Record< string, unknown > | undefined,
+		( value: Record< string, unknown > ) => void,
+		unknown,
+	];
 
 	const featureClipId = ( () => {
 		const raw = meta?.[ FEATURE_CLIP_META_KEY ];
@@ -297,11 +303,4 @@ export function registerFeatureClipSidebar(): void {
 	pluginRegistered = true;
 }
 
-export {
-	FeatureClipPanel,
-	FeatureClipPreview,
-	FeatureClipEmptyState,
-	PLUGIN_NAME,
-	PANEL_NAME,
-	FEATURE_CLIP_META_KEY,
-};
+export { FeatureClipPanel, FeatureClipPreview, FeatureClipEmptyState, PLUGIN_NAME, PANEL_NAME };

--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
@@ -2,17 +2,23 @@
  * "Generate Feature Clip" post-editor sidebar panel.
  *
  * Registers a PluginDocumentSettingPanel (from `@wordpress/editor`) in the
- * Gutenberg post editor with a short description + Generate clip button. The
- * panel header carries an "Experimental" badge. Visual rhythm matches the
- * surrounding sidebar panels (Excerpt, Categories, Featured Image) rather
- * than introducing a saturated hero card.
+ * Gutenberg post editor. When no clip is linked to the post, shows a short
+ * description + Generate clip button. Once a clip exists (via the
+ * `_jetpack_feature_clip_id` post meta registered by Jetpack's Image Studio
+ * extension), shows a small video preview, a share row mirroring the modal,
+ * and a Regenerate button.
  */
 import { Button } from '@wordpress/components';
-import { dispatch } from '@wordpress/data';
+import { useEntityProp } from '@wordpress/core-data';
+import { dispatch, useSelect } from '@wordpress/data';
 import { PluginDocumentSettingPanel } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
+import { share } from '@wordpress/icons';
 import { registerPlugin } from '@wordpress/plugins';
+import { SocialLogo } from 'social-logos';
 import { ExperimentalBadge } from '../components/experimental-badge';
+import { useGenericShare } from '../hooks/use-generic-share';
+import { useReelShare } from '../hooks/use-reel-share';
 import { ImageStudioEntryPoint, store as imageStudioStore } from '../store';
 import { store as videoStudioStore, type VideoStudioActions } from '../stores/video-studio';
 import { ImageStudioMode } from '../types';
@@ -21,47 +27,119 @@ import './feature-clip-sidebar.scss';
 
 const PLUGIN_NAME = 'image-studio-feature-clip';
 const PANEL_NAME = 'image-studio-feature-clip-panel';
+const FEATURE_CLIP_META_KEY = '_jetpack_feature_clip_id';
 
-function FeatureClipPanel(): JSX.Element {
-	const handleClick = async () => {
-		const { openImageStudio } = dispatch( imageStudioStore );
-		const { setCurrentVideoUrl, setCurrentAttachmentId, setCurrentDurationSeconds } = dispatch(
-			videoStudioStore
-		) as VideoStudioActions;
-		await Promise.all( [
-			setCurrentVideoUrl( null ),
-			setCurrentAttachmentId( null ),
-			setCurrentDurationSeconds( null ),
-		] );
+interface MediaRecord {
+	id: number;
+	source_url?: string;
+	mime_type?: string;
+	media_details?: { length?: number };
+}
 
-		trackImageStudioOpened( {
-			mode: ImageStudioMode.Generate,
-			entryPoint: ImageStudioEntryPoint.PostEditorFeatureClip,
-		} );
+function openImageStudioForFeatureClip(): void {
+	const { openImageStudio } = dispatch( imageStudioStore );
+	const { setCurrentVideoUrl, setCurrentAttachmentId, setCurrentDurationSeconds } = dispatch(
+		videoStudioStore
+	) as VideoStudioActions;
+	// Reset the modal-session store synchronously; the modal will repopulate it
+	// on a successful regeneration.
+	void Promise.all( [
+		setCurrentVideoUrl( null ),
+		setCurrentAttachmentId( null ),
+		setCurrentDurationSeconds( null ),
+	] );
 
-		openImageStudio( undefined, undefined, ImageStudioEntryPoint.PostEditorFeatureClip );
-	};
+	trackImageStudioOpened( {
+		mode: ImageStudioMode.Generate,
+		entryPoint: ImageStudioEntryPoint.PostEditorFeatureClip,
+	} );
 
-	const titleNode = (
-		<span className="image-studio-feature-clip-panel__title">
-			<span className="image-studio-feature-clip-panel__title-line">
-				{ __( 'Generate', __i18n_text_domain__ ) }
-			</span>
-			<span className="image-studio-feature-clip-panel__title-line">
-				{ __( 'Feature Clip', __i18n_text_domain__ ) }
-				<ExperimentalBadge variant="light" />
-			</span>
-		</span>
-	);
+	openImageStudio( undefined, undefined, ImageStudioEntryPoint.PostEditorFeatureClip );
+}
+
+interface FeatureClipPreviewProps {
+	videoUrl: string;
+	attachmentId: number;
+	durationSeconds: number | null;
+}
+
+function FeatureClipPreview( {
+	videoUrl,
+	attachmentId,
+	durationSeconds,
+}: FeatureClipPreviewProps ): JSX.Element {
+	const reel = useReelShare( { url: videoUrl, attachmentId, durationSeconds } );
+	const generic = useGenericShare( { url: videoUrl, attachmentId } );
+
+	const reelLabel = reel.isSharing
+		? __( 'Sharing on Instagram…', __i18n_text_domain__ )
+		: __( 'Share on Instagram', __i18n_text_domain__ );
+
+	const genericLabel = generic.isSharing
+		? __( 'Sharing to other apps…', __i18n_text_domain__ )
+		: __( 'Share to other apps', __i18n_text_domain__ );
 
 	return (
-		<PluginDocumentSettingPanel
-			name={ PANEL_NAME }
-			// PluginDocumentSettingPanel.title is typed as string but renders any ReactNode at runtime;
-			// the badge must live in the title row so it stays visible when the panel is collapsed.
-			title={ titleNode as unknown as string }
-			className="image-studio-feature-clip-panel"
-		>
+		<>
+			<div className="image-studio-feature-clip-panel__preview-frame">
+				<video
+					className="image-studio-feature-clip-panel__preview-video"
+					src={ videoUrl }
+					aria-label={ __( 'Feature clip preview', __i18n_text_domain__ ) }
+					controls
+					loop
+					muted
+					playsInline
+					preload="metadata"
+				/>
+			</div>
+			{ ( reel.isVisible || generic.isVisible ) && (
+				<div
+					className="image-studio-feature-clip-panel__share-row"
+					role="group"
+					aria-label={ __( 'Share feature clip', __i18n_text_domain__ ) }
+				>
+					{ generic.isVisible && (
+						<Button
+							variant="secondary"
+							icon={ share }
+							className="image-studio-feature-clip-panel__share-button"
+							label={ genericLabel }
+							showTooltip
+							disabled={ generic.isSharing }
+							isBusy={ generic.isSharing }
+							onClick={ generic.handleShare }
+						/>
+					) }
+					{ reel.isVisible && (
+						<Button
+							variant="secondary"
+							icon={ <SocialLogo icon="instagram" size={ 18 } /> }
+							className="image-studio-feature-clip-panel__share-button"
+							label={ reelLabel }
+							showTooltip
+							disabled={ reel.isSharing }
+							isBusy={ reel.isSharing }
+							onClick={ reel.handleShare }
+						/>
+					) }
+				</div>
+			) }
+			<Button
+				variant="secondary"
+				className="image-studio-feature-clip-panel__cta"
+				__next40pxDefaultSize
+				onClick={ openImageStudioForFeatureClip }
+			>
+				{ __( 'Regenerate clip', __i18n_text_domain__ ) }
+			</Button>
+		</>
+	);
+}
+
+function FeatureClipEmptyState(): JSX.Element {
+	return (
+		<>
 			<p className="image-studio-feature-clip-panel__description">
 				{ __(
 					'Turn this post into a short vertical video. Powered by your site guidelines.',
@@ -72,10 +150,76 @@ function FeatureClipPanel(): JSX.Element {
 				variant="secondary"
 				className="image-studio-feature-clip-panel__cta"
 				__next40pxDefaultSize
-				onClick={ handleClick }
+				onClick={ openImageStudioForFeatureClip }
 			>
 				{ __( 'Generate clip', __i18n_text_domain__ ) }
 			</Button>
+		</>
+	);
+}
+
+function FeatureClipPanel(): JSX.Element {
+	const postType = useSelect(
+		( select ) =>
+			(
+				select( 'core/editor' ) as { getCurrentPostType: () => string | null } | undefined
+			 )?.getCurrentPostType?.() ?? 'post',
+		[]
+	);
+
+	const entityPropResult = useEntityProp( 'postType', postType, 'meta' );
+	const meta = ( entityPropResult as unknown as [ Record< string, unknown > | undefined ] )[ 0 ];
+
+	const featureClipId = ( () => {
+		const raw = meta?.[ FEATURE_CLIP_META_KEY ];
+		const n = typeof raw === 'number' ? raw : Number( raw ?? 0 );
+		return Number.isFinite( n ) && n > 0 ? n : null;
+	} )();
+
+	const attachment = useSelect(
+		( select ) => {
+			if ( ! featureClipId ) {
+				return null;
+			}
+			const core = select( 'core' ) as
+				| { getMedia: ( id: number ) => MediaRecord | undefined }
+				| undefined;
+			return core?.getMedia?.( featureClipId ) ?? null;
+		},
+		[ featureClipId ]
+	);
+
+	const titleNode = (
+		<span className="image-studio-feature-clip-panel__title">
+			<span className="image-studio-feature-clip-panel__title-line">
+				{ __( 'Feature Clip', __i18n_text_domain__ ) }
+				<ExperimentalBadge variant="light" />
+			</span>
+		</span>
+	);
+
+	const videoUrl = attachment?.source_url ?? null;
+	const durationSeconds =
+		typeof attachment?.media_details?.length === 'number' ? attachment.media_details.length : null;
+	const hasUsableClip = !! featureClipId && !! videoUrl;
+
+	return (
+		<PluginDocumentSettingPanel
+			name={ PANEL_NAME }
+			// PluginDocumentSettingPanel.title is typed as string but renders any ReactNode at runtime;
+			// the badge must live in the title row so it stays visible when the panel is collapsed.
+			title={ titleNode as unknown as string }
+			className="image-studio-feature-clip-panel"
+		>
+			{ hasUsableClip ? (
+				<FeatureClipPreview
+					videoUrl={ videoUrl }
+					attachmentId={ featureClipId }
+					durationSeconds={ durationSeconds }
+				/>
+			) : (
+				<FeatureClipEmptyState />
+			) }
 		</PluginDocumentSettingPanel>
 	);
 }
@@ -111,4 +255,11 @@ export function registerFeatureClipSidebar(): void {
 	pluginRegistered = true;
 }
 
-export { FeatureClipPanel, PLUGIN_NAME, PANEL_NAME };
+export {
+	FeatureClipPanel,
+	FeatureClipPreview,
+	FeatureClipEmptyState,
+	PLUGIN_NAME,
+	PANEL_NAME,
+	FEATURE_CLIP_META_KEY,
+};

--- a/packages/image-studio/src/extensions/feature-clip-sidebar.scss
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar.scss
@@ -28,10 +28,9 @@
 		display: block;
 		width: 100%;
 		aspect-ratio: 9 / 16;
-		max-height: 360px;
 		margin: 0 auto 8px;
 		background: #000;
-		border-radius: 4px;
+		border-radius: 8px;
 		overflow: hidden;
 	}
 
@@ -39,7 +38,8 @@
 		display: block;
 		width: 100%;
 		height: 100%;
-		object-fit: contain;
+		object-fit: cover;
+		border-radius: inherit;
 	}
 
 	&__share-row {

--- a/packages/image-studio/src/extensions/feature-clip-sidebar.scss
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar.scss
@@ -45,7 +45,7 @@
 	&__share-row {
 		display: flex;
 		align-items: center;
-		justify-content: flex-start;
+		justify-content: flex-end;
 		gap: 6px;
 		margin-bottom: 8px;
 	}

--- a/packages/image-studio/src/extensions/feature-clip-sidebar.scss
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar.scss
@@ -22,4 +22,31 @@
 		width: 100%;
 		justify-content: center;
 	}
+
+	&__preview-frame {
+		position: relative;
+		display: block;
+		width: 100%;
+		aspect-ratio: 9 / 16;
+		max-height: 360px;
+		margin: 0 auto 8px;
+		background: #000;
+		border-radius: 4px;
+		overflow: hidden;
+	}
+
+	&__preview-video {
+		display: block;
+		width: 100%;
+		height: 100%;
+		object-fit: contain;
+	}
+
+	&__share-row {
+		display: flex;
+		align-items: center;
+		justify-content: flex-start;
+		gap: 6px;
+		margin-bottom: 8px;
+	}
 }

--- a/packages/image-studio/src/extensions/feature-clip-sidebar.scss
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar.scss
@@ -42,11 +42,20 @@
 		border-radius: inherit;
 	}
 
-	&__share-row {
-		display: flex;
-		align-items: center;
-		justify-content: flex-end;
-		gap: 6px;
+	&__share-cta {
+		width: 100%;
+		justify-content: center;
 		margin-bottom: 8px;
+	}
+
+	&__bottom-actions {
+		display: flex;
+		align-items: stretch;
+		gap: 8px;
+	}
+
+	&__bottom-action {
+		flex: 1 1 0;
+		justify-content: center;
 	}
 }

--- a/packages/image-studio/src/extensions/feature-clip-sidebar.scss
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar.scss
@@ -44,7 +44,14 @@
 
 	&__share-cta {
 		width: 100%;
+		// WP's Button defaults to a left-justified inline-flex row even when
+		// width is forced to 100%. Specify center alignment + a small gap so
+		// the icon + label cluster sits visually centered in the full-width
+		// pill and tracks the bottom-action row beneath it.
+		display: flex;
 		justify-content: center;
+		align-items: center;
+		gap: 8px;
 		margin-bottom: 8px;
 	}
 

--- a/packages/image-studio/src/hooks/share-types.ts
+++ b/packages/image-studio/src/hooks/share-types.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared identity of the clip a share-hook should act on.
+ *
+ * Surfaces that read the clip from somewhere other than the in-memory
+ * video-studio store (e.g. the post-editor sidebar, which reads the
+ * meta-bound clip) pass this in explicitly. Modal call sites omit it and
+ * fall back to the store. `durationSeconds` is optional because not every
+ * caller has it (the sidebar can resolve it from the attachment, but it's
+ * not required for the generic Web Share path).
+ */
+export interface ShareClipIdentity {
+	url: string | null;
+	attachmentId: number | null;
+	durationSeconds?: number | null;
+}

--- a/packages/image-studio/src/hooks/use-generic-share/index.ts
+++ b/packages/image-studio/src/hooks/use-generic-share/index.ts
@@ -9,21 +9,12 @@ import {
 	trackImageStudioGenericShareCompleted,
 	trackImageStudioGenericShareFailed,
 } from '../../utils/tracking';
+import type { ShareClipIdentity } from '../share-types';
 
 interface UseGenericShareReturn {
 	isVisible: boolean;
 	isSharing: boolean;
 	handleShare: () => Promise< void >;
-}
-
-/**
- * See `useReelShare`'s `ShareClipIdentity` — same purpose. Caller can pass an
- * explicit clip identity to source from somewhere other than the in-memory
- * video-studio store; omitting falls back to the store.
- */
-export interface ShareClipIdentity {
-	url: string | null;
-	attachmentId: number | null;
 }
 
 interface NavigatorWithShare {

--- a/packages/image-studio/src/hooks/use-generic-share/index.ts
+++ b/packages/image-studio/src/hooks/use-generic-share/index.ts
@@ -71,7 +71,7 @@ export function useGenericShare( clip?: ShareClipIdentity ): UseGenericShareRetu
 		createNotice?: (
 			status: string,
 			message: string,
-			options?: { isDismissible?: boolean }
+			options?: { type?: 'default' | 'snackbar'; isDismissible?: boolean }
 		) => Promise< void >;
 	};
 
@@ -81,7 +81,10 @@ export function useGenericShare( clip?: ShareClipIdentity ): UseGenericShareRetu
 	 */
 	const showNotice = async ( message: string, type: 'success' | 'warning' | 'error' ) => {
 		if ( hasOverride ) {
-			await createCoreNotice?.( type, message, { isDismissible: true } );
+			await createCoreNotice?.( type, message, {
+				type: 'snackbar',
+				isDismissible: true,
+			} );
 			return;
 		}
 		await addModalNotice( message, type );

--- a/packages/image-studio/src/hooks/use-generic-share/index.ts
+++ b/packages/image-studio/src/hooks/use-generic-share/index.ts
@@ -66,7 +66,26 @@ export function useGenericShare( clip?: ShareClipIdentity ): UseGenericShareRetu
 	const currentVideoUrl = hasOverride ? clip.url : storeUrl;
 	const currentAttachmentId = hasOverride ? clip.attachmentId : storeAttachmentId;
 
-	const { addNotice } = useDispatch( imageStudioStore ) as ImageStudioActions;
+	const { addNotice: addModalNotice } = useDispatch( imageStudioStore ) as ImageStudioActions;
+	const { createNotice: createCoreNotice } = useDispatch( 'core/notices' ) as {
+		createNotice?: (
+			status: string,
+			message: string,
+			options?: { isDismissible?: boolean }
+		) => Promise< void >;
+	};
+
+	/**
+	 * See `useReelShare` — same rationale. Sidebar callers (override clip) get
+	 * notices on the editor snackbar; modal callers get them in-modal.
+	 */
+	const showNotice = async ( message: string, type: 'success' | 'warning' | 'error' ) => {
+		if ( hasOverride ) {
+			await createCoreNotice?.( type, message, { isDismissible: true } );
+			return;
+		}
+		await addModalNotice( message, type );
+	};
 
 	// Synchronous double-click guard — same rationale as in useReelShare.
 	// Kept alongside `isSharing` state because state updates lag a render and
@@ -154,7 +173,7 @@ export function useGenericShare( clip?: ShareClipIdentity ): UseGenericShareRetu
 				failureKind: 'open-blocked',
 				message: 'window.open returned null',
 			} );
-			await addNotice(
+			await showNotice(
 				__(
 					'Could not open the video for download. Allow popups for this site and try again.',
 					__i18n_text_domain__
@@ -165,7 +184,7 @@ export function useGenericShare( clip?: ShareClipIdentity ): UseGenericShareRetu
 			isSharingRef.current = false;
 			setIsSharing( false );
 		}
-	}, [ addNotice, currentAttachmentId, currentVideoUrl ] );
+	}, [ showNotice, currentAttachmentId, currentVideoUrl ] );
 
 	return {
 		isVisible,

--- a/packages/image-studio/src/hooks/use-generic-share/index.ts
+++ b/packages/image-studio/src/hooks/use-generic-share/index.ts
@@ -16,6 +16,16 @@ interface UseGenericShareReturn {
 	handleShare: () => Promise< void >;
 }
 
+/**
+ * See `useReelShare`'s `ShareClipIdentity` — same purpose. Caller can pass an
+ * explicit clip identity to source from somewhere other than the in-memory
+ * video-studio store; omitting falls back to the store.
+ */
+export interface ShareClipIdentity {
+	url: string | null;
+	attachmentId: number | null;
+}
+
 interface NavigatorWithShare {
 	share?: ( data: { files?: File[]; title?: string; text?: string } ) => Promise< void >;
 	canShare?: ( data: { files?: File[] } ) => boolean;
@@ -39,20 +49,22 @@ function canShareVideoFiles( nav: NavigatorWithShare, filename: string ): boolea
 	}
 }
 
-export function useGenericShare(): UseGenericShareReturn {
-	const { currentVideoUrl, currentAttachmentId, entryPoint, isAiProcessing } = useSelect(
-		( select ) => {
-			const videoStore = select( videoStudioStore );
-			const studio = select( imageStudioStore );
-			return {
-				currentVideoUrl: videoStore.getCurrentVideoUrl?.() ?? null,
-				currentAttachmentId: videoStore.getCurrentAttachmentId?.() ?? null,
-				entryPoint: studio.getEntryPoint?.() ?? null,
-				isAiProcessing: studio.getImageStudioAiProcessing?.() ?? false,
-			};
-		},
-		[]
-	);
+export function useGenericShare( clip?: ShareClipIdentity ): UseGenericShareReturn {
+	const hasOverride = clip !== undefined;
+
+	const { storeUrl, storeAttachmentId, entryPoint, isAiProcessing } = useSelect( ( select ) => {
+		const videoStore = select( videoStudioStore );
+		const studio = select( imageStudioStore );
+		return {
+			storeUrl: videoStore.getCurrentVideoUrl?.() ?? null,
+			storeAttachmentId: videoStore.getCurrentAttachmentId?.() ?? null,
+			entryPoint: studio.getEntryPoint?.() ?? null,
+			isAiProcessing: studio.getImageStudioAiProcessing?.() ?? false,
+		};
+	}, [] );
+
+	const currentVideoUrl = hasOverride ? clip.url : storeUrl;
+	const currentAttachmentId = hasOverride ? clip.attachmentId : storeAttachmentId;
 
 	const { addNotice } = useDispatch( imageStudioStore ) as ImageStudioActions;
 
@@ -62,11 +74,12 @@ export function useGenericShare(): UseGenericShareReturn {
 	const isSharingRef = useRef( false );
 	const [ isSharing, setIsSharing ] = useState( false );
 
+	// When the caller supplies an explicit clip, it has already asserted the
+	// video context — the entryPoint guard is only meaningful for the in-modal
+	// call site that reads the live store.
+	const isVideoContext = hasOverride || entryPoint === ImageStudioEntryPoint.PostEditorFeatureClip;
 	const isVisible =
-		entryPoint === ImageStudioEntryPoint.PostEditorFeatureClip &&
-		!! currentVideoUrl &&
-		!! currentAttachmentId &&
-		! isAiProcessing;
+		isVideoContext && !! currentVideoUrl && !! currentAttachmentId && ! isAiProcessing;
 
 	const handleShare = useCallback( async () => {
 		if ( isSharingRef.current ) {

--- a/packages/image-studio/src/hooks/use-reel-share/index.ts
+++ b/packages/image-studio/src/hooks/use-reel-share/index.ts
@@ -105,7 +105,11 @@ export function useReelShare( clip?: ShareClipIdentity ): UseReelShareReturn {
 		createNotice?: (
 			status: string,
 			message: string,
-			options?: { isDismissible?: boolean; actions?: Array< { label: string; url?: string } > }
+			options?: {
+				type?: 'default' | 'snackbar';
+				isDismissible?: boolean;
+				actions?: Array< { label: string; url?: string } >;
+			}
 		) => Promise< void >;
 	};
 
@@ -125,6 +129,7 @@ export function useReelShare( clip?: ShareClipIdentity ): UseReelShareReturn {
 	) => {
 		if ( hasOverride ) {
 			await createCoreNotice?.( type, message, {
+				type: 'snackbar',
 				isDismissible: !! isDismissible,
 				actions: actions?.map( ( a ) => ( { label: a.label, url: a.url } ) ),
 			} );

--- a/packages/image-studio/src/hooks/use-reel-share/index.ts
+++ b/packages/image-studio/src/hooks/use-reel-share/index.ts
@@ -17,6 +17,7 @@ import {
 	trackImageStudioReelShareNotConnected,
 	trackImageStudioReelShareNotPublished,
 } from '../../utils/tracking';
+import type { ShareClipIdentity } from '../share-types';
 
 const SOCIAL_STORE = 'jetpack-social-plugin';
 const EDITOR_STORE = 'core/editor';
@@ -40,19 +41,6 @@ interface UseReelShareReturn {
 	isVisible: boolean;
 	isSharing: boolean;
 	handleShare: () => Promise< void >;
-}
-
-/**
- * Identity of the clip that should be shared. Pass this from a surface that
- * sources the clip from somewhere other than the in-memory video-studio store
- * (e.g. the post-editor sidebar, which reads the meta-bound clip). When
- * omitted, the hook falls back to whatever the modal session most recently
- * set on the video-studio store.
- */
-export interface ShareClipIdentity {
-	url: string | null;
-	attachmentId: number | null;
-	durationSeconds: number | null;
 }
 
 export function useReelShare( clip?: ShareClipIdentity ): UseReelShareReturn {
@@ -89,7 +77,7 @@ export function useReelShare( clip?: ShareClipIdentity ): UseReelShareReturn {
 
 	const currentVideoUrl = hasOverride ? clip.url : storeUrl;
 	const currentAttachmentId = hasOverride ? clip.attachmentId : storeAttachmentId;
-	const currentDurationSeconds = hasOverride ? clip.durationSeconds : storeDuration;
+	const currentDurationSeconds = hasOverride ? clip.durationSeconds ?? null : storeDuration;
 
 	const { editPost } = useDispatch( EDITOR_STORE ) as {
 		editPost: ( edits: { meta: Record< string, unknown > } ) => void;
@@ -108,7 +96,7 @@ export function useReelShare( clip?: ShareClipIdentity ): UseReelShareReturn {
 			options?: {
 				type?: 'default' | 'snackbar';
 				isDismissible?: boolean;
-				actions?: Array< { label: string; url?: string } >;
+				actions?: Array< { label: string; url?: string; onClick?: () => void } >;
 			}
 		) => Promise< void >;
 	};
@@ -130,8 +118,19 @@ export function useReelShare( clip?: ShareClipIdentity ): UseReelShareReturn {
 		if ( hasOverride ) {
 			await createCoreNotice?.( type, message, {
 				type: 'snackbar',
-				isDismissible: !! isDismissible,
-				actions: actions?.map( ( a ) => ( { label: a.label, url: a.url } ) ),
+				// Match imageStudioStore.addNotice's default (dismissible) when
+				// the caller doesn't say otherwise — coercing undefined to false
+				// would silently lose the user's ability to dismiss.
+				isDismissible: isDismissible ?? true,
+				// Honour `openInNewTab` by routing through an onClick that opens
+				// in a new tab, instead of the default same-tab navigation a
+				// bare `url` action triggers. Same-tab navigation away from the
+				// editor would discard any unsaved post edits.
+				actions: actions?.map( ( a ) =>
+					a.openInNewTab
+						? { label: a.label, onClick: () => window.open( a.url, '_blank', 'noopener' ) }
+						: { label: a.label, url: a.url }
+				),
 			} );
 			return;
 		}

--- a/packages/image-studio/src/hooks/use-reel-share/index.ts
+++ b/packages/image-studio/src/hooks/use-reel-share/index.ts
@@ -42,13 +42,27 @@ interface UseReelShareReturn {
 	handleShare: () => Promise< void >;
 }
 
-export function useReelShare(): UseReelShareReturn {
+/**
+ * Identity of the clip that should be shared. Pass this from a surface that
+ * sources the clip from somewhere other than the in-memory video-studio store
+ * (e.g. the post-editor sidebar, which reads the meta-bound clip). When
+ * omitted, the hook falls back to whatever the modal session most recently
+ * set on the video-studio store.
+ */
+export interface ShareClipIdentity {
+	url: string | null;
+	attachmentId: number | null;
+	durationSeconds: number | null;
+}
+
+export function useReelShare( clip?: ShareClipIdentity ): UseReelShareReturn {
 	const sharePath = getReelSharePostPath();
+	const hasOverride = clip !== undefined;
 
 	const {
-		currentVideoUrl,
-		currentAttachmentId,
-		currentDurationSeconds,
+		storeUrl,
+		storeAttachmentId,
+		storeDuration,
 		entryPoint,
 		isAiProcessing,
 		currentMeta,
@@ -62,9 +76,9 @@ export function useReelShare(): UseReelShareReturn {
 		const social = select( SOCIAL_STORE ) as { isSharingCurrentPost: () => boolean } | undefined;
 
 		return {
-			currentVideoUrl: videoStore.getCurrentVideoUrl?.() ?? null,
-			currentAttachmentId: videoStore.getCurrentAttachmentId?.() ?? null,
-			currentDurationSeconds: videoStore.getCurrentDurationSeconds?.() ?? null,
+			storeUrl: videoStore.getCurrentVideoUrl?.() ?? null,
+			storeAttachmentId: videoStore.getCurrentAttachmentId?.() ?? null,
+			storeDuration: videoStore.getCurrentDurationSeconds?.() ?? null,
 			entryPoint: studio.getEntryPoint?.() ?? null,
 			isAiProcessing: studio.getImageStudioAiProcessing?.() ?? false,
 			currentMeta:
@@ -72,6 +86,10 @@ export function useReelShare(): UseReelShareReturn {
 			isSharing: social?.isSharingCurrentPost?.() ?? false,
 		};
 	}, [] );
+
+	const currentVideoUrl = hasOverride ? clip.url : storeUrl;
+	const currentAttachmentId = hasOverride ? clip.attachmentId : storeAttachmentId;
+	const currentDurationSeconds = hasOverride ? clip.durationSeconds : storeDuration;
 
 	const { editPost } = useDispatch( EDITOR_STORE ) as {
 		editPost: ( edits: { meta: Record< string, unknown > } ) => void;
@@ -88,8 +106,12 @@ export function useReelShare(): UseReelShareReturn {
 	// the first dispatch by a render, so we can't rely on `disabled` alone.
 	const isSharingRef = useRef( false );
 
+	// When the caller supplies an explicit clip (e.g. the sidebar reading meta),
+	// it has already asserted the video context — the entryPoint guard is only
+	// meaningful for the in-modal call site that reads the live store.
+	const isVideoContext = hasOverride || entryPoint === ImageStudioEntryPoint.PostEditorFeatureClip;
 	const isVisible =
-		entryPoint === ImageStudioEntryPoint.PostEditorFeatureClip &&
+		isVideoContext &&
 		!! currentVideoUrl &&
 		!! currentAttachmentId &&
 		!! sharePath &&

--- a/packages/image-studio/src/hooks/use-reel-share/index.ts
+++ b/packages/image-studio/src/hooks/use-reel-share/index.ts
@@ -100,7 +100,46 @@ export function useReelShare( clip?: ShareClipIdentity ): UseReelShareReturn {
 			config: { apiPath: string; savePost?: boolean }
 		) => Promise< boolean >;
 	};
-	const { addNotice } = useDispatch( imageStudioStore ) as ImageStudioActions;
+	const { addNotice: addModalNotice } = useDispatch( imageStudioStore ) as ImageStudioActions;
+	const { createNotice: createCoreNotice } = useDispatch( 'core/notices' ) as {
+		createNotice?: (
+			status: string,
+			message: string,
+			options?: { isDismissible?: boolean; actions?: Array< { label: string; url?: string } > }
+		) => Promise< void >;
+	};
+
+	/**
+	 * Route notices to the surface that's actually visible right now. The
+	 * imageStudioStore notice list only renders inside the open Image Studio
+	 * modal; from the sidebar the modal isn't on screen, so notices need to
+	 * land on the editor's `core/notices` snackbar instead. We use the
+	 * presence of the clip override as the heuristic — only the sidebar
+	 * supplies one today.
+	 */
+	const showNotice = async (
+		message: string,
+		type: 'success' | 'warning' | 'error',
+		actions?: Array< { label: string; url: string; openInNewTab?: boolean } >,
+		isDismissible?: boolean
+	) => {
+		if ( hasOverride ) {
+			await createCoreNotice?.( type, message, {
+				isDismissible: !! isDismissible,
+				actions: actions?.map( ( a ) => ( { label: a.label, url: a.url } ) ),
+			} );
+			return;
+		}
+		// Forward only the args that were supplied so call sites that don't
+		// pass actions/isDismissible aren't surprised by trailing undefineds.
+		if ( isDismissible !== undefined ) {
+			await addModalNotice( message, type, actions, isDismissible );
+		} else if ( actions !== undefined ) {
+			await addModalNotice( message, type, actions );
+		} else {
+			await addModalNotice( message, type );
+		}
+	};
 
 	// Synchronous guard against double-clicks — `isSharing` from useSelect lags
 	// the first dispatch by a render, so we can't rely on `disabled` alone.
@@ -153,7 +192,7 @@ export function useReelShare( clip?: ShareClipIdentity ): UseReelShareReturn {
 
 		if ( ! currentVideoUrl || ! currentAttachmentId ) {
 			trackImageStudioReelShareInvalidState();
-			await addNotice(
+			await showNotice(
 				__( 'Generate a video first to share it as a Reel.', __i18n_text_domain__ ),
 				'error'
 			);
@@ -166,7 +205,7 @@ export function useReelShare( clip?: ShareClipIdentity ): UseReelShareReturn {
 
 		if ( ! freshIgConnection ) {
 			trackImageStudioReelShareNotConnected();
-			await addNotice(
+			await showNotice(
 				__(
 					'Connect Instagram in your site marketing settings to share Reels.',
 					__i18n_text_domain__
@@ -186,7 +225,7 @@ export function useReelShare( clip?: ShareClipIdentity ): UseReelShareReturn {
 
 		if ( ! freshIgIsEnabled ) {
 			trackImageStudioReelShareConnectionDisabled();
-			await addNotice(
+			await showNotice(
 				__(
 					'Instagram sharing is not enabled for this post. Enable it in the Jetpack Social sidebar to share this Reel.',
 					__i18n_text_domain__
@@ -200,7 +239,7 @@ export function useReelShare( clip?: ShareClipIdentity ): UseReelShareReturn {
 
 		if ( ! freshIsPublished ) {
 			trackImageStudioReelShareNotPublished();
-			await addNotice(
+			await showNotice(
 				__( 'Publish this post first to share it as an Instagram Reel.', __i18n_text_domain__ ),
 				'warning',
 				undefined,
@@ -243,7 +282,7 @@ export function useReelShare( clip?: ShareClipIdentity ): UseReelShareReturn {
 
 			if ( success ) {
 				trackImageStudioReelShareDispatched();
-				await addNotice(
+				await showNotice(
 					__(
 						'Reel shared to Instagram. It may take a few minutes to appear on your account.',
 						__i18n_text_domain__
@@ -262,7 +301,7 @@ export function useReelShare( clip?: ShareClipIdentity ): UseReelShareReturn {
 			isSharingRef.current = false;
 		}
 	}, [
-		addNotice,
+		showNotice,
 		currentAttachmentId,
 		currentDurationSeconds,
 		currentMeta,


### PR DESCRIPTION
## Summary
After a user generates a feature clip from the post-editor sidebar, the panel now shows what they made — a small video preview, the same Instagram / generic share buttons that ship in the modal, an Add to post action, and a "Regenerate clip" button — instead of disappearing back to the empty CTA.

The clip → post linkage is persisted via a new `_jetpack_feature_clip_id` post meta (registered server-side in a sibling Jetpack PR). After a successful generation we route through `dispatch( 'core' ).saveEntityRecord( 'postType', postType, { id, meta: { _jetpack_feature_clip_id: id } }, { throwOnError: true } )` — the canonical core-data primitive — which auto-resolves the entity's REST base, hydrates the local cache, and surfaces failures through the catch.

> **Trade-off**: `saveEntityRecord` flips `core.isSavingEntityRecord( 'postType', ... )`, which `core/editor.isSavingPost` is composed from — so the editor toolbar will briefly show "Saving…" and disable Publish/Update for the duration of the request (typically 100-300ms). That's deliberate: the meta write *is* a save, the user deserves honest signalling, and video generations are rare enough that the brief flicker beats the maintenance burden of a hand-rolled REST call. The behaviour and the reasoning are documented inline in `persistFeatureClipMeta` so the next reader doesn't try to "optimise" it back to a silent path.


## Screenshot

<img width="562" height="1320" alt="image" src="https://github.com/user-attachments/assets/dfbfff48-73c0-47f3-b4e8-3f9ac723166b" />

### What landed
- `update-canvas-video.ts` calls `saveEntityRecord` with `{ throwOnError: true }` after a successful generation. Failures are logged via `window.console?.warn?.` (matching the rest of the package's logging convention) and never block the canvas swap.
- `feature-clip-sidebar-extension.tsx` reads the meta via `useEntityProp` (with the post ID passed explicitly so it works outside `EntityProvider` context), resolves the attachment via `core/coreData getMedia()`, and gates the empty-state fallback on `hasFinishedResolution( 'getMedia', ... )` to avoid a reload flash. Falls back to the empty CTA when the attachment was deleted out from under us.
- `useReelShare` and `useGenericShare` accept an optional `ShareClipIdentity` (centralised in `hooks/share-types.ts`) so the sidebar can pass its meta-bound clip in. Modal call sites keep reading from the in-memory `videoStudioStore` exactly as before. The `entryPoint === PostEditorFeatureClip` guard is bypassed when an explicit clip is supplied — the caller has already asserted the video context.
- Sidebar share buttons route notices through `core/notices` (snackbar variant) when invoked from the override-clip path, so failure feedback appears in the editor's standard toast surface rather than disappearing into the closed modal's notice list. `openInNewTab` notice actions are wrapped through `onClick → window.open(_blank)` so the "Connect Instagram" link doesn't take the user out of the editor and discard unsaved post edits.
- `FEATURE_CLIP_META_KEY` lives in `extensions/feature-clip-meta.ts` as a single source of truth; both the canvas-update ability and the sidebar extension import from there.
- Sidebar-tailored styles for the preview frame, share CTAs, and the Add-to-post / Regenerate row.
- Existing 957 image-studio tests still pass; +7 cases for meta persistence in `update-canvas-video.test.ts`, +6 cases for the sidebar's preview state in `feature-clip-sidebar-extension.test.tsx`. Lint + tsc clean.

### Cross-site portability
The meta is registered on Jetpack — running on every Image-Studio-enabled surface (Atomic, WordPress.com, self-hosted with Jetpack) — and exposed via `show_in_rest`. The Calypso side delegates to `@wordpress/core-data`'s entity layer, which uses standard core REST endpoints, so the same code path works on all three surfaces.

### Depends on
The Jetpack PR that registers the post meta. Without it, `saveEntityRecord` will succeed but the meta key won't round-trip from the server, so the sidebar will stay in the empty state on reload — no worse than before, just no preview either.

## Test plan
- [ ] On a Premium+ site (modal + sidebar both load), generate a feature clip from the sidebar — preview appears, share + Add to post + Regenerate are shown, "Generate clip" CTA is gone.
- [ ] Reload the post editor — preview survives the reload (proves the meta persisted).
- [ ] Click Regenerate — modal reopens cleanly with no flash of the previous preview, generate a different clip, sidebar swaps to the new one.
- [ ] Delete the attachment from the Media Library, reload the post — sidebar falls back to "Generate clip" (after `getMedia` resolves; no empty-state flash).
- [ ] Click Add to post — a `core/video` block referencing the attachment is inserted at the cursor.
- [ ] Confirm Instagram + generic share buttons appear in the sidebar with the same conditions as in the modal (Jetpack Social loaded, `navigator.share` available, etc.).
- [ ] Click Instagram share in the sidebar — fires the same flow as in the modal (publish gate, IG-not-connected gate, etc.). Failure / status notices appear in the editor snackbar at the bottom of the screen, not as static admin banners at the top.
- [ ] When generation completes, the toolbar briefly shows "Saving…" and Publish/Update is briefly disabled — that's expected (see Summary).
- [ ] Modal call sites (`ShareReelAction`) behave identically to before — no change in modal share flow.
- [ ] Test on a self-hosted Jetpack dev environment to confirm the entity-record routing works there too (not just WPCOM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)