### PR TITLE
Reader Social composer: offer to publish on your own site when over char limit

### DIFF
--- a/client/reader/atmosphere/composer-config.tsx
+++ b/client/reader/atmosphere/composer-config.tsx
@@ -121,6 +121,16 @@ export const atmosphereComposerConfig: ComposerConfig<
 			};
 		},
 	},
+	overflowHandoff: {
+		shown: ( mode ) => ( {
+			event: 'calypso_reader_atmosphere_overflow_handoff_shown',
+			props: { connection_id: mode.connectionId, mode_kind: mode.kind },
+		} ),
+		editorOpened: ( mode, { siteId } ) => ( {
+			event: 'calypso_reader_atmosphere_overflow_handoff_editor_opened',
+			props: { connection_id: mode.connectionId, mode_kind: mode.kind, site_id: siteId },
+		} ),
+	},
 	copy: {
 		title: ( mode, translate ) => titleForMode( mode, translate ),
 		placeholder: ( mode, translate, handle ) => placeholderForMode( mode, translate, handle ),

--- a/client/reader/atmosphere/composer-config.tsx
+++ b/client/reader/atmosphere/composer-config.tsx
@@ -21,6 +21,7 @@ export const atmosphereComposerConfig: ComposerConfig<
 	CreatePostResult
 > = {
 	useLimit: useAtmosphereComposerLimit,
+	protocolLabel: 'Bluesky',
 	supportedModes: [ 'reply', 'quote', 'standalone' ],
 	mutationFactory: createPostMutation,
 	buildParams: ( mode, text ) => buildParamsForMode( mode, text ),

--- a/client/reader/mastodon/composer-config.tsx
+++ b/client/reader/mastodon/composer-config.tsx
@@ -21,6 +21,7 @@ export const mastodonComposerConfig: ComposerConfig<
 	// configuration via `useMastodonInstanceConfigQuery` and falls back to
 	// 500 (stock Mastodon default) when the query is pending or errors.
 	useLimit: useMastodonComposerLimit,
+	protocolLabel: 'Mastodon',
 	// Quote mode uses Mastodon 4.5+'s native `quoted_status_id` with a
 	// text-based fallback (permalink appended to status) for older
 	// instances. The retry lives in `createMastodonPostWithQuoteFallback`

--- a/client/reader/mastodon/composer-config.tsx
+++ b/client/reader/mastodon/composer-config.tsx
@@ -147,6 +147,16 @@ export const mastodonComposerConfig: ComposerConfig<
 			};
 		},
 	},
+	overflowHandoff: {
+		shown: ( mode ) => ( {
+			event: 'calypso_reader_mastodon_overflow_handoff_shown',
+			props: { connection_id: mode.connectionId, mode_kind: mode.kind },
+		} ),
+		editorOpened: ( mode, { siteId } ) => ( {
+			event: 'calypso_reader_mastodon_overflow_handoff_editor_opened',
+			props: { connection_id: mode.connectionId, mode_kind: mode.kind, site_id: siteId },
+		} ),
+	},
 	copy: {
 		title: ( mode, translate ) => titleForMode( mode, translate ),
 		placeholder: ( mode, translate, handle ) => placeholderForMode( mode, translate, handle ),

--- a/client/reader/social/AGENTS.md
+++ b/client/reader/social/AGENTS.md
@@ -461,6 +461,17 @@ Per-protocol `ComposerConfig` supplies:
   name + props. Names live in the config so a code search for
   `calypso_reader_<protocol>_<mode>_*` finds them; do not lift this
   into a shared helper.
+- `overflowHandoff.{shown, editorOpened}` — optional Tracks events
+  for the in-modal "Publish on your own site" escape hatch. `shown`
+  fires once per modal session when the handoff section first renders
+  (i.e. after the user crosses the limit AND the sites query resolves
+  with ≥1 site). `editorOpened` fires on Move-to-editor click with
+  `{ siteId }` — analogous to Reader's Quick Post
+  `calypso_reader_quick_post_full_editor_opened`. Configs that omit
+  this field don't emit overflow-handoff Tracks events. Atmosphere
+  and Mastodon both wire it as `calypso_reader_<protocol>_overflow_handoff_{shown,editor_opened}`
+  with `connection_id` + `mode_kind` props (plus `site_id` on the
+  click event).
 - `copy.{title, placeholder}` — per-mode strings.
 - `logBadRequest?` — fire-and-forget hook for the `bad_request` body
   log. Lives in the per-protocol adapter so `calypso/lib/logstash`

--- a/client/reader/social/composer/composer-config.tsx
+++ b/client/reader/social/composer/composer-config.tsx
@@ -108,9 +108,7 @@ export interface ComposerConfig< TError, TParams, TResult > {
 	/**
 	 * Short display label for the protocol (e.g. "Bluesky", "Mastodon").
 	 * Surfaced in user-visible copy that mentions the social network by
-	 * name — currently only the overflow-handoff section in
-	 * `<ComposerOverflowHandoff />`. Not localized: these are brand
-	 * names that don't translate.
+	 * name. Not localized — brand names don't translate.
 	 */
 	protocolLabel: string;
 	/**

--- a/client/reader/social/composer/composer-config.tsx
+++ b/client/reader/social/composer/composer-config.tsx
@@ -106,6 +106,14 @@ export interface ComposerConfig< TError, TParams, TResult > {
 	 */
 	useLimit: ( connectionId: number | null ) => number;
 	/**
+	 * Short display label for the protocol (e.g. "Bluesky", "Mastodon").
+	 * Surfaced in user-visible copy that mentions the social network by
+	 * name — currently only the overflow-handoff section in
+	 * `<ComposerOverflowHandoff />`. Not localized: these are brand
+	 * names that don't translate.
+	 */
+	protocolLabel: string;
+	/**
 	 * Mode kinds this protocol supports. Atmosphere supports all three;
 	 * Mastodon supports `'reply' | 'standalone'` (no native quote concept).
 	 * The modal renders nothing when an unsupported mode is opened.

--- a/client/reader/social/composer/composer-config.tsx
+++ b/client/reader/social/composer/composer-config.tsx
@@ -167,6 +167,22 @@ export interface ComposerConfig< TError, TParams, TResult > {
 			error: TError
 		) => { event: string; props: Record< string, unknown > };
 	};
+	/**
+	 * Optional Tracks events for the overflow-handoff section (the in-modal
+	 * "Publish on your own site" escape hatch). `shown` fires once per modal
+	 * session when the handoff section first renders (i.e. after the user
+	 * crosses the limit AND the sites query resolves with ≥1 site).
+	 * `editorOpened` fires when the user clicks "Move to editor" — analogous
+	 * to Reader's Quick Post `calypso_reader_quick_post_full_editor_opened`.
+	 * Configs that omit this field don't emit overflow-handoff Tracks events.
+	 */
+	overflowHandoff?: {
+		shown: ( mode: ActiveMode ) => { event: string; props: Record< string, unknown > };
+		editorOpened: (
+			mode: ActiveMode,
+			meta: { siteId: number }
+		) => { event: string; props: Record< string, unknown > };
+	};
 	/** Per-mode title and placeholder copy. */
 	copy: {
 		title: ( mode: ActiveMode, translate: Translate ) => string;

--- a/client/reader/social/composer/composer-footer.tsx
+++ b/client/reader/social/composer/composer-footer.tsx
@@ -75,13 +75,15 @@ export function ComposerFooter( {
 					variant="primary"
 					disabled={ disabled }
 					onClick={ onSubmit }
-					// Visible "Post" label is the accessible name in the idle
-					// state; while pending the visible text is replaced by a
-					// presentation-only spinner, so the button needs an
-					// explicit accessible name.
+					// Visible label is the accessible name in the idle and
+					// over-limit states; while pending the visible text is
+					// replaced by a presentation-only spinner, so the button
+					// needs an explicit accessible name.
 					aria-label={ isPending ? translate( 'Posting…' ) : undefined }
 				>
-					{ isPending ? <Spinner /> : translate( 'Post' ) }
+					{ isPending && <Spinner /> }
+					{ ! isPending && tooLong && translate( 'Better as a blog post' ) }
+					{ ! isPending && ! tooLong && translate( 'Post' ) }
 				</Button>
 			</HStack>
 		</HStack>

--- a/client/reader/social/composer/composer-modal.tsx
+++ b/client/reader/social/composer/composer-modal.tsx
@@ -229,7 +229,6 @@ export function ComposerModal< TError, TParams, TResult >() {
 						{ errorMessage }
 					</div>
 				) }
-				<ComposerOverflowHandoff text={ text } />
 				<ComposerFooter
 					graphemeCount={ graphemeCount }
 					onSubmit={ handleSubmit }
@@ -238,6 +237,7 @@ export function ComposerModal< TError, TParams, TResult >() {
 					disabled={ ! canSubmit }
 					footerStart={ mediaSlot.renderFooterTrigger() }
 				/>
+				<ComposerOverflowHandoff text={ text } />
 			</Modal>
 			{ confirmDiscard && (
 				<DiscardConfirm

--- a/client/reader/social/composer/composer-modal.tsx
+++ b/client/reader/social/composer/composer-modal.tsx
@@ -12,6 +12,7 @@ import { successNotice } from 'calypso/state/notices/actions';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import { useComposerConfig } from './composer-config';
 import { ComposerFooter } from './composer-footer';
+import { ComposerOverflowHandoff } from './composer-overflow-handoff';
 import { ComposerPinnedContext } from './composer-pinned-context';
 import { useComposer } from './composer-provider';
 import { ComposerTextarea } from './composer-textarea';
@@ -228,6 +229,7 @@ export function ComposerModal< TError, TParams, TResult >() {
 						{ errorMessage }
 					</div>
 				) }
+				<ComposerOverflowHandoff text={ text } />
 				<ComposerFooter
 					graphemeCount={ graphemeCount }
 					onSubmit={ handleSubmit }

--- a/client/reader/social/composer/composer-modal.tsx
+++ b/client/reader/social/composer/composer-modal.tsx
@@ -21,7 +21,7 @@ import type { AppState } from 'calypso/types';
 export function ComposerModal< TError, TParams, TResult >() {
 	const translate = useTranslate();
 	const config = useComposerConfig< TError, TParams, TResult >();
-	const { mode, closeComposer, mediaSlot } = useComposer();
+	const { mode, closeComposer, mediaSlot, markOverLimit } = useComposer();
 	const queryClient = useQueryClient();
 	const mutation = useMutation( config.mutationFactory( queryClient ) );
 	const dispatch = useDispatch< ThunkDispatch< AppState, void, UnknownAction > >();
@@ -111,6 +111,11 @@ export function ComposerModal< TError, TParams, TResult >() {
 	// rendering interactive content anyway, so the value is unused.
 	const limit = config.useLimit( mode?.connectionId ?? null );
 	const tooLong = graphemeCount > limit;
+	useEffect( () => {
+		if ( tooLong ) {
+			markOverLimit();
+		}
+	}, [ tooLong, markOverLimit ] );
 	const empty = graphemeCount === 0;
 	// Image-only posts are allowed: when the user has at least one uploaded
 	// image, the empty-text gate doesn't block submission. Pending media (any

--- a/client/reader/social/composer/composer-overflow-handoff.scss
+++ b/client/reader/social/composer/composer-overflow-handoff.scss
@@ -3,6 +3,12 @@
 	padding-block: 16px;
 	border-block-start: 1px solid var(--color-border-subtle);
 	animation: social-composer-overflow-handoff-fade-in 150ms ease-in;
+
+	fieldset {
+		border: 0;
+		padding: 0;
+		margin: 0;
+	}
 }
 
 @keyframes social-composer-overflow-handoff-fade-in {

--- a/client/reader/social/composer/composer-overflow-handoff.scss
+++ b/client/reader/social/composer/composer-overflow-handoff.scss
@@ -30,6 +30,13 @@
 		max-height: 180px;
 	}
 
+	// The combobox keeps focus after a selection, so the text caret keeps
+	// blinking in the value display. Hide the caret while the dropdown is
+	// closed — typing to filter reopens the dropdown and brings it back.
+	.components-combobox-control__input[aria-expanded='false'] {
+		caret-color: transparent;
+	}
+
 	// Invert the check icon when the row is highlighted so it stays
 	// readable against the theme primary background.
 	.is-selected .social-composer__overflow-handoff-check path {

--- a/client/reader/social/composer/composer-overflow-handoff.scss
+++ b/client/reader/social/composer/composer-overflow-handoff.scss
@@ -1,6 +1,13 @@
 .social-composer__overflow-handoff {
+	// Negative inline margins + matching inline padding bleed the top
+	// border across the full modal width. `.components-modal__content`
+	// adds 24px of horizontal padding around the composer; the separator
+	// reaches the modal edges while the section text stays aligned with
+	// the rest of the modal body.
 	margin-block-start: 16px;
+	margin-inline: -24px;
 	padding-block: 16px;
+	padding-inline: 24px;
 	border-block-start: 1px solid var(--color-border-subtle);
 	animation: social-composer-overflow-handoff-fade-in 150ms ease-in;
 

--- a/client/reader/social/composer/composer-overflow-handoff.scss
+++ b/client/reader/social/composer/composer-overflow-handoff.scss
@@ -1,0 +1,16 @@
+.social-composer__overflow-handoff {
+	margin-block-start: 16px;
+	padding-block: 16px;
+	border-block-start: 1px solid var(--color-border-subtle);
+	animation: social-composer-overflow-handoff-fade-in 150ms ease-in;
+}
+
+@keyframes social-composer-overflow-handoff-fade-in {
+	from {
+		opacity: 0;
+	}
+
+	to {
+		opacity: 1;
+	}
+}

--- a/client/reader/social/composer/composer-overflow-handoff.scss
+++ b/client/reader/social/composer/composer-overflow-handoff.scss
@@ -9,9 +9,13 @@
 	padding-block: 16px;
 	padding-inline: 24px;
 	border-block-start: 1px solid var(--color-border-subtle);
-	animation: social-composer-overflow-handoff-fade-in 150ms ease-in;
+	animation: social-composer-overflow-handoff-fade-in 280ms ease-out;
 
-	fieldset {
+	@media (prefers-reduced-motion: reduce) {
+		animation: none;
+	}
+
+	> fieldset {
 		border: 0;
 		padding: 0;
 		margin: 0;
@@ -21,9 +25,11 @@
 @keyframes social-composer-overflow-handoff-fade-in {
 	from {
 		opacity: 0;
+		transform: translateY(-4px);
 	}
 
 	to {
 		opacity: 1;
+		transform: translateY(0);
 	}
 }

--- a/client/reader/social/composer/composer-overflow-handoff.scss
+++ b/client/reader/social/composer/composer-overflow-handoff.scss
@@ -19,7 +19,54 @@
 		border: 0;
 		padding: 0;
 		margin: 0;
+		margin-block-end: 16px;
 	}
+}
+
+.social-composer__overflow-handoff-combobox {
+	// Cap the suggestions popover so it doesn't dominate the composer
+	// modal — ~3 rich rows visible, the rest scroll.
+	.components-form-token-field__suggestions-list {
+		max-height: 180px;
+	}
+
+	// Invert the check icon when the row is highlighted so it stays
+	// readable against the theme primary background.
+	.is-selected .social-composer__overflow-handoff-check path {
+		fill: var(--color-text-inverted);
+	}
+}
+
+.social-composer__overflow-handoff-option {
+	min-block-size: 32px;
+}
+
+.social-composer__overflow-handoff-site-icon,
+.social-composer__overflow-handoff-site-letter {
+	border-radius: 4px;
+	flex-shrink: 0;
+	inline-size: 32px;
+	block-size: 32px;
+}
+
+.social-composer__overflow-handoff-site-icon {
+	display: block;
+	outline: 1px solid var(--color-border-subtle);
+	outline-offset: -1px;
+	background: var(--color-surface);
+	object-fit: cover;
+}
+
+.social-composer__overflow-handoff-site-letter {
+	align-items: center;
+	background: var(--wp-admin-theme-color, var(--color-primary));
+	color: var(--color-text-inverted);
+	display: flex;
+	font-size: 16px;
+	justify-content: center;
+	overflow: hidden;
+	box-sizing: border-box;
+	text-transform: uppercase;
 }
 
 @keyframes social-composer-overflow-handoff-fade-in {

--- a/client/reader/social/composer/composer-overflow-handoff.tsx
+++ b/client/reader/social/composer/composer-overflow-handoff.tsx
@@ -23,8 +23,17 @@ interface OverflowFormData {
 	selectedSiteId: number;
 }
 
+type SaveDraftMutate = ReturnType<
+	typeof useMutation<
+		{ ID: number; site_ID: number; URL: string },
+		Error,
+		{ siteId: number; content: string }
+	>
+>[ 'mutate' ];
+
 function SingleSiteHandoff( { site, text }: { site: Site; text: string } ) {
 	const translate = useTranslate();
+	const { mutate, isPending } = useMutation( saveDraftMutation() );
 	return (
 		<>
 			<p>
@@ -32,42 +41,23 @@ function SingleSiteHandoff( { site, text }: { site: Site; text: string } ) {
 					args: { siteName: site.name },
 				} ) }
 			</p>
-			<MoveToEditorButton site={ site } text={ text } />
+			<MoveToEditorButton site={ site } text={ text } mutate={ mutate } isPending={ isPending } />
 		</>
 	);
 }
 
-function MultiSiteHandoff( { sites, text }: { sites: Site[]; text: string } ) {
-	const { data: userSettings, isPending } = useQuery( userSettingsQuery() );
+function MultiSiteHandoffForm( { sites, text }: { sites: Site[]; text: string } ) {
+	const { data: userSettings } = useQuery( userSettingsQuery() );
 
-	if ( isPending ) {
-		return null;
-	}
+	const [ userSelection, setUserSelection ] = useState< number | null >( null );
 
-	return (
-		<MultiSiteHandoffForm
-			sites={ sites }
-			text={ text }
-			primarySiteId={ userSettings?.primary_site_ID }
-		/>
-	);
-}
+	const displayedSiteId =
+		userSelection ??
+		( userSettings?.primary_site_ID && sites.some( ( s ) => s.ID === userSettings.primary_site_ID )
+			? userSettings.primary_site_ID
+			: sites[ 0 ].ID );
 
-function MultiSiteHandoffForm( {
-	sites,
-	text,
-	primarySiteId,
-}: {
-	sites: Site[];
-	text: string;
-	primarySiteId?: number;
-} ) {
-	const defaultSiteId =
-		primarySiteId && sites.some( ( s ) => s.ID === primarySiteId ) ? primarySiteId : sites[ 0 ].ID;
-
-	const [ formData, setFormData ] = useState< OverflowFormData >( {
-		selectedSiteId: defaultSiteId,
-	} );
+	const selectedSite = sites.find( ( s ) => s.ID === displayedSiteId ) ?? sites[ 0 ];
 
 	const { mutate, isPending } = useMutation( saveDraftMutation() );
 
@@ -103,19 +93,23 @@ function MultiSiteHandoffForm( {
 		fields: [ 'selectedSiteId' ],
 	};
 
-	const selectedSite = sites.find( ( s ) => s.ID === formData.selectedSiteId ) ?? sites[ 0 ];
+	const formData: OverflowFormData = { selectedSiteId: displayedSiteId };
 
 	return (
 		<>
-			<fieldset disabled={ isPending } style={ { border: 0, padding: 0, margin: 0 } }>
+			<fieldset disabled={ isPending }>
 				<DataForm< OverflowFormData >
 					data={ formData }
 					fields={ fields }
 					form={ form }
-					onChange={ ( edits ) => setFormData( ( d ) => ( { ...d, ...edits } ) ) }
+					onChange={ ( edits ) => {
+						if ( edits.selectedSiteId !== undefined ) {
+							setUserSelection( edits.selectedSiteId );
+						}
+					} }
 				/>
 			</fieldset>
-			<MoveToEditorButtonExternalState
+			<MoveToEditorButton
 				site={ selectedSite }
 				text={ text }
 				mutate={ mutate }
@@ -125,7 +119,7 @@ function MultiSiteHandoffForm( {
 	);
 }
 
-function MoveToEditorButtonExternalState( {
+function MoveToEditorButton( {
 	site,
 	text,
 	mutate,
@@ -133,65 +127,11 @@ function MoveToEditorButtonExternalState( {
 }: {
 	site: Site;
 	text: string;
-	mutate: ReturnType<
-		typeof useMutation<
-			{ ID: number; site_ID: number; URL: string },
-			Error,
-			{ siteId: number; content: string }
-		>
-	>[ 'mutate' ];
+	mutate: SaveDraftMutate;
 	isPending: boolean;
 } ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-
-	const handleClick = () => {
-		mutate(
-			{ siteId: site.ID, content: text },
-			{
-				onSuccess: ( data ) => {
-					const adminUrl = site.options?.admin_url;
-					if ( ! adminUrl ) {
-						dispatch(
-							errorNotice( translate( "Couldn't open the editor. Try a different site." ) )
-						);
-						return;
-					}
-					window.location.assign(
-						addQueryArgs( `${ adminUrl }post.php`, {
-							post: data.ID,
-							action: 'edit',
-						} )
-					);
-				},
-				onError: () => {
-					dispatch(
-						errorNotice(
-							translate( "Couldn't save your draft. Try again or pick a different site." )
-						)
-					);
-				},
-			}
-		);
-	};
-
-	return (
-		<Button
-			variant="primary"
-			__next40pxDefaultSize
-			onClick={ handleClick }
-			isBusy={ isPending }
-			disabled={ isPending }
-		>
-			{ translate( 'Move to editor' ) }
-		</Button>
-	);
-}
-
-function MoveToEditorButton( { site, text }: { site: Site; text: string } ) {
-	const translate = useTranslate();
-	const dispatch = useDispatch();
-	const { mutate, isPending } = useMutation( saveDraftMutation() );
 
 	const handleClick = () => {
 		mutate(
@@ -267,7 +207,7 @@ export function ComposerOverflowHandoff( { text }: ComposerOverflowHandoffProps 
 			{ sites.length === 1 ? (
 				<SingleSiteHandoff site={ sites[ 0 ] } text={ text } />
 			) : (
-				<MultiSiteHandoff sites={ sites } text={ text } />
+				<MultiSiteHandoffForm sites={ sites } text={ text } />
 			) }
 		</section>
 	);

--- a/client/reader/social/composer/composer-overflow-handoff.tsx
+++ b/client/reader/social/composer/composer-overflow-handoff.tsx
@@ -1,34 +1,31 @@
 import './composer-overflow-handoff.scss';
 
 import { sitesQuery, userSettingsQuery } from '@automattic/api-queries';
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { Button } from '@wordpress/components';
-import { DataForm, type Field } from '@wordpress/dataviews';
+import { useMutation, useQuery, type UseMutationResult } from '@tanstack/react-query';
+import { Button, ComboboxControl } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import PreferencesLoginSiteDropdown from 'calypso/dashboard/me/preferences-primary-site/site-dropdown';
+import { logToLogstash } from 'calypso/lib/logstash';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { useComposerConfig } from './composer-config';
 import { useComposer } from './composer-provider';
-import { saveDraftMutation } from './use-save-draft-mutation';
+import {
+	saveDraftMutation,
+	type SaveDraftMutationResult,
+	type SaveDraftMutationVariables,
+} from './use-save-draft-mutation';
 import type { Site } from '@automattic/api-core';
 
 interface ComposerOverflowHandoffProps {
 	text: string;
 }
 
-interface OverflowFormData {
-	selectedSiteId: number;
-}
-
-type SaveDraftMutate = ReturnType<
-	typeof useMutation<
-		{ ID: number; site_ID: number; URL: string },
-		Error,
-		{ siteId: number; content: string }
-	>
+type SaveDraftMutate = UseMutationResult<
+	SaveDraftMutationResult,
+	Error,
+	SaveDraftMutationVariables
 >[ 'mutate' ];
 
 function SingleSiteHandoff( { site, text }: { site: Site; text: string } ) {
@@ -47,66 +44,54 @@ function SingleSiteHandoff( { site, text }: { site: Site; text: string } ) {
 }
 
 function MultiSiteHandoffForm( { sites, text }: { sites: Site[]; text: string } ) {
-	const { data: userSettings } = useQuery( userSettingsQuery() );
+	const translate = useTranslate();
+	// Gate the picker render on `userSettings` having settled so the
+	// pre-selected value doesn't flip from sites[0] to the primary site
+	// once the query resolves (visible flicker if the user types past the
+	// limit before the settings query is in cache).
+	const { data: userSettings, isPending: settingsPending } = useQuery( userSettingsQuery() );
 
 	const [ userSelection, setUserSelection ] = useState< number | null >( null );
 
-	const displayedSiteId =
-		userSelection ??
-		( userSettings?.primary_site_ID && sites.some( ( s ) => s.ID === userSettings.primary_site_ID )
+	const initialSiteId =
+		userSettings?.primary_site_ID && sites.some( ( s ) => s.ID === userSettings.primary_site_ID )
 			? userSettings.primary_site_ID
-			: sites[ 0 ].ID );
+			: sites[ 0 ].ID;
+
+	const displayedSiteId = userSelection ?? initialSiteId;
 
 	const selectedSite = sites.find( ( s ) => s.ID === displayedSiteId ) ?? sites[ 0 ];
 
 	const { mutate, isPending } = useMutation( saveDraftMutation() );
 
-	const fields = useMemo< Field< OverflowFormData >[] >(
-		() => [
-			{
-				id: 'selectedSiteId',
-				label: '',
-				Edit: ( { field, onChange, data, hideLabelFromVision } ) => {
-					const { id, getValue } = field;
-					const value = getValue( { item: data } )?.toString( 10 ) ?? '';
-					return (
-						<PreferencesLoginSiteDropdown
-							sites={ sites }
-							value={ value }
-							onChange={ ( newValue ) => {
-								if ( newValue ) {
-									onChange( { [ id ]: parseInt( newValue, 10 ) } );
-								}
-							} }
-							label=""
-							hideLabelFromVision={ hideLabelFromVision }
-						/>
-					);
-				},
-			},
-		],
+	const options = useMemo(
+		() =>
+			sites.map( ( s ) => ( {
+				value: String( s.ID ),
+				label: s.name || s.URL,
+			} ) ),
 		[ sites ]
 	);
 
-	const form = {
-		layout: { type: 'regular' as const },
-		fields: [ 'selectedSiteId' ],
-	};
-
-	const formData: OverflowFormData = { selectedSiteId: displayedSiteId };
+	if ( settingsPending ) {
+		return null;
+	}
 
 	return (
 		<>
 			<fieldset disabled={ isPending }>
-				<DataForm< OverflowFormData >
-					data={ formData }
-					fields={ fields }
-					form={ form }
-					onChange={ ( edits ) => {
-						if ( edits.selectedSiteId !== undefined ) {
-							setUserSelection( edits.selectedSiteId );
+				<ComboboxControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ translate( 'Choose a site' ) as string }
+					value={ String( displayedSiteId ) }
+					onChange={ ( newValue ) => {
+						if ( newValue ) {
+							setUserSelection( parseInt( newValue, 10 ) );
 						}
 					} }
+					options={ options }
+					allowReset={ false }
 				/>
 			</fieldset>
 			<MoveToEditorButton
@@ -138,13 +123,11 @@ function MoveToEditorButton( {
 			{ siteId: site.ID, content: text },
 			{
 				onSuccess: ( data ) => {
-					const adminUrl = site.options?.admin_url;
-					if ( ! adminUrl ) {
-						dispatch(
-							errorNotice( translate( "Couldn't open the editor. Try a different site." ) )
-						);
-						return;
-					}
+					// `admin_url` is documented to be set on every WP.com site
+					// returned by /me/sites; falling back to a derived path
+					// avoids leaving an orphan draft if the field is missing.
+					const adminUrl =
+						site.options?.admin_url ?? `${ site.URL.replace( /\/$/, '' ) }/wp-admin/`;
 					window.location.assign(
 						addQueryArgs( `${ adminUrl }post.php`, {
 							post: data.ID,
@@ -152,12 +135,22 @@ function MoveToEditorButton( {
 						} )
 					);
 				},
-				onError: () => {
+				onError: ( error ) => {
 					dispatch(
 						errorNotice(
 							translate( "Couldn't save your draft. Try again or pick a different site." )
 						)
 					);
+					logToLogstash( {
+						feature: 'calypso_client',
+						message: 'Reader social composer overflow handoff: save draft failed',
+						severity: 'error',
+						extra: {
+							type: 'reader_social_composer_overflow_handoff_save_draft_error',
+							site_id: site.ID,
+							error_message: error?.message,
+						},
+					} );
 				},
 			}
 		);

--- a/client/reader/social/composer/composer-overflow-handoff.tsx
+++ b/client/reader/social/composer/composer-overflow-handoff.tsx
@@ -6,7 +6,7 @@ import { Button } from '@wordpress/components';
 import { DataForm, type Field } from '@wordpress/dataviews';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import PreferencesLoginSiteDropdown from 'calypso/dashboard/me/preferences-primary-site/site-dropdown';
 import { errorNotice } from 'calypso/state/notices/actions';
@@ -69,29 +69,34 @@ function MultiSiteHandoffForm( {
 		selectedSiteId: defaultSiteId,
 	} );
 
-	const fields: Field< OverflowFormData >[] = [
-		{
-			id: 'selectedSiteId',
-			label: '',
-			Edit: ( { field, onChange, data, hideLabelFromVision } ) => {
-				const { id, getValue } = field;
-				const value = getValue( { item: data } )?.toString( 10 ) ?? '';
-				return (
-					<PreferencesLoginSiteDropdown
-						sites={ sites }
-						value={ value }
-						onChange={ ( newValue ) => {
-							if ( newValue ) {
-								onChange( { [ id ]: parseInt( newValue, 10 ) } );
-							}
-						} }
-						label=""
-						hideLabelFromVision={ hideLabelFromVision }
-					/>
-				);
+	const { mutate, isPending } = useMutation( saveDraftMutation() );
+
+	const fields = useMemo< Field< OverflowFormData >[] >(
+		() => [
+			{
+				id: 'selectedSiteId',
+				label: '',
+				Edit: ( { field, onChange, data, hideLabelFromVision } ) => {
+					const { id, getValue } = field;
+					const value = getValue( { item: data } )?.toString( 10 ) ?? '';
+					return (
+						<PreferencesLoginSiteDropdown
+							sites={ sites }
+							value={ value }
+							onChange={ ( newValue ) => {
+								if ( newValue ) {
+									onChange( { [ id ]: parseInt( newValue, 10 ) } );
+								}
+							} }
+							label=""
+							hideLabelFromVision={ hideLabelFromVision }
+						/>
+					);
+				},
 			},
-		},
-	];
+		],
+		[ sites ]
+	);
 
 	const form = {
 		layout: { type: 'regular' as const },
@@ -102,14 +107,84 @@ function MultiSiteHandoffForm( {
 
 	return (
 		<>
-			<DataForm< OverflowFormData >
-				data={ formData }
-				fields={ fields }
-				form={ form }
-				onChange={ ( edits ) => setFormData( ( d ) => ( { ...d, ...edits } ) ) }
+			<fieldset disabled={ isPending } style={ { border: 0, padding: 0, margin: 0 } }>
+				<DataForm< OverflowFormData >
+					data={ formData }
+					fields={ fields }
+					form={ form }
+					onChange={ ( edits ) => setFormData( ( d ) => ( { ...d, ...edits } ) ) }
+				/>
+			</fieldset>
+			<MoveToEditorButtonExternalState
+				site={ selectedSite }
+				text={ text }
+				mutate={ mutate }
+				isPending={ isPending }
 			/>
-			<MoveToEditorButton site={ selectedSite } text={ text } />
 		</>
+	);
+}
+
+function MoveToEditorButtonExternalState( {
+	site,
+	text,
+	mutate,
+	isPending,
+}: {
+	site: Site;
+	text: string;
+	mutate: ReturnType<
+		typeof useMutation<
+			{ ID: number; site_ID: number; URL: string },
+			Error,
+			{ siteId: number; content: string }
+		>
+	>[ 'mutate' ];
+	isPending: boolean;
+} ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const handleClick = () => {
+		mutate(
+			{ siteId: site.ID, content: text },
+			{
+				onSuccess: ( data ) => {
+					const adminUrl = site.options?.admin_url;
+					if ( ! adminUrl ) {
+						dispatch(
+							errorNotice( translate( "Couldn't open the editor. Try a different site." ) )
+						);
+						return;
+					}
+					window.location.assign(
+						addQueryArgs( `${ adminUrl }post.php`, {
+							post: data.ID,
+							action: 'edit',
+						} )
+					);
+				},
+				onError: () => {
+					dispatch(
+						errorNotice(
+							translate( "Couldn't save your draft. Try again or pick a different site." )
+						)
+					);
+				},
+			}
+		);
+	};
+
+	return (
+		<Button
+			variant="primary"
+			__next40pxDefaultSize
+			onClick={ handleClick }
+			isBusy={ isPending }
+			disabled={ isPending }
+		>
+			{ translate( 'Move to editor' ) }
+		</Button>
 	);
 }
 

--- a/client/reader/social/composer/composer-overflow-handoff.tsx
+++ b/client/reader/social/composer/composer-overflow-handoff.tsx
@@ -1,0 +1,45 @@
+import './composer-overflow-handoff.scss';
+
+import { sitesQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import { useTranslate } from 'i18n-calypso';
+import { useComposerConfig } from './composer-config';
+import { useComposer } from './composer-provider';
+
+interface ComposerOverflowHandoffProps {
+	text: string;
+}
+
+export function ComposerOverflowHandoff( { text }: ComposerOverflowHandoffProps ) {
+	const translate = useTranslate();
+	const { hasBeenOverLimit } = useComposer();
+	const config = useComposerConfig();
+
+	const { data: sites } = useQuery( {
+		...sitesQuery( 'all' ),
+		enabled: hasBeenOverLimit,
+	} );
+
+	if ( ! hasBeenOverLimit ) {
+		return null;
+	}
+
+	if ( ! sites || sites.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<section
+			className="social-composer__overflow-handoff"
+			aria-label={ translate( 'Publish on your own site' ) as string }
+		>
+			{ /* Filled in by later tasks. */ }
+			<p>
+				{ translate( 'Too long for %(protocol)s? Publish it on your own site instead.', {
+					args: { protocol: config.protocolLabel },
+				} ) }
+			</p>
+			<p data-testid="overflow-handoff-debug-text">{ text }</p>
+		</section>
+	);
+}

--- a/client/reader/social/composer/composer-overflow-handoff.tsx
+++ b/client/reader/social/composer/composer-overflow-handoff.tsx
@@ -2,7 +2,15 @@ import './composer-overflow-handoff.scss';
 
 import { sitesQuery, userSettingsQuery } from '@automattic/api-queries';
 import { useMutation, useQuery, type UseMutationResult } from '@tanstack/react-query';
-import { Button, ComboboxControl } from '@wordpress/components';
+import {
+	Button,
+	ComboboxControl,
+	Icon,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+} from '@wordpress/components';
+import { check } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useState } from 'react';
@@ -43,6 +51,47 @@ function SingleSiteHandoff( { site, text }: { site: Site; text: string } ) {
 	);
 }
 
+function SiteIconThumb( { site }: { site: Site } ) {
+	const ico = site.icon?.img || site.icon?.ico;
+	const src = useMemo( () => {
+		if ( ! ico ) {
+			return undefined;
+		}
+		try {
+			const url = new URL( ico );
+			url.searchParams.set( 'w', '64' );
+			url.searchParams.set( 's', '64' );
+			return url.toString();
+		} catch {
+			return ico;
+		}
+	}, [ ico ] );
+
+	if ( src ) {
+		return (
+			<img
+				className="social-composer__overflow-handoff-site-icon"
+				src={ src }
+				alt=""
+				width={ 32 }
+				height={ 32 }
+				loading="lazy"
+			/>
+		);
+	}
+
+	const fallbackInitial = ( site.name || site.URL || '?' ).charAt( 0 );
+	return (
+		<div className="social-composer__overflow-handoff-site-letter" aria-hidden="true">
+			<span>{ fallbackInitial }</span>
+		</div>
+	);
+}
+
+function getSiteDisplayUrl( site: Site ) {
+	return ( site.URL || '' ).replace( /^https?:\/\//, '' );
+}
+
 function MultiSiteHandoffForm( { sites, text }: { sites: Site[]; text: string } ) {
 	const translate = useTranslate();
 	// Gate the picker render on `userSettings` having settled so the
@@ -69,9 +118,41 @@ function MultiSiteHandoffForm( { sites, text }: { sites: Site[]; text: string } 
 			sites.map( ( s ) => ( {
 				value: String( s.ID ),
 				label: s.name || s.URL,
+				site: s,
 			} ) ),
 		[ sites ]
 	);
+
+	const renderItem = ( { item }: { item: { value: string; label: string; site?: Site } } ) => {
+		const site = item.site ?? sites.find( ( s ) => String( s.ID ) === item.value );
+		if ( ! site ) {
+			return null;
+		}
+		const isSelected = item.value === String( displayedSiteId );
+		return (
+			<HStack
+				className="social-composer__overflow-handoff-option"
+				spacing={ 3 }
+				alignment="left"
+				justify="space-between"
+			>
+				<HStack spacing={ 3 } alignment="left" justify="left">
+					<SiteIconThumb site={ site } />
+					<VStack spacing={ 0 }>
+						<Text as="div" weight={ 500 } size={ 14 } lineHeight={ 1.5 } color="inherit">
+							{ item.label }
+						</Text>
+						<Text as="div" size={ 12 } weight={ 300 } lineHeight={ 1.2 } color="inherit">
+							{ getSiteDisplayUrl( site ) }
+						</Text>
+					</VStack>
+				</HStack>
+				{ isSelected && (
+					<Icon icon={ check } size={ 24 } className="social-composer__overflow-handoff-check" />
+				) }
+			</HStack>
+		);
+	};
 
 	if ( settingsPending ) {
 		return null;
@@ -83,6 +164,7 @@ function MultiSiteHandoffForm( { sites, text }: { sites: Site[]; text: string } 
 				<ComboboxControl
 					__next40pxDefaultSize
 					__nextHasNoMarginBottom
+					className="social-composer__overflow-handoff-combobox"
 					label={ translate( 'Choose a site' ) as string }
 					value={ String( displayedSiteId ) }
 					onChange={ ( newValue ) => {
@@ -92,6 +174,7 @@ function MultiSiteHandoffForm( { sites, text }: { sites: Site[]; text: string } 
 					} }
 					options={ options }
 					allowReset={ false }
+					__experimentalRenderItem={ renderItem }
 				/>
 			</fieldset>
 			<MoveToEditorButton

--- a/client/reader/social/composer/composer-overflow-handoff.tsx
+++ b/client/reader/social/composer/composer-overflow-handoff.tsx
@@ -128,12 +128,11 @@ function MoveToEditorButton( {
 					// avoids leaving an orphan draft if the field is missing.
 					const adminUrl =
 						site.options?.admin_url ?? `${ site.URL.replace( /\/$/, '' ) }/wp-admin/`;
-					window.location.assign(
-						addQueryArgs( `${ adminUrl }post.php`, {
-							post: data.ID,
-							action: 'edit',
-						} )
-					);
+					const editorUrl = addQueryArgs( `${ adminUrl }post.php`, {
+						post: data.ID,
+						action: 'edit',
+					} );
+					window.open( editorUrl, '_blank', 'noopener,noreferrer' );
 				},
 				onError: ( error ) => {
 					dispatch(

--- a/client/reader/social/composer/composer-overflow-handoff.tsx
+++ b/client/reader/social/composer/composer-overflow-handoff.tsx
@@ -1,15 +1,22 @@
 import './composer-overflow-handoff.scss';
 
-import { sitesQuery } from '@automattic/api-queries';
+import { sitesQuery, userSettingsQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
+import { DataForm, type Field } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import PreferencesLoginSiteDropdown from 'calypso/dashboard/me/preferences-primary-site/site-dropdown';
 import { useComposerConfig } from './composer-config';
 import { useComposer } from './composer-provider';
 import type { Site } from '@automattic/api-core';
 
 interface ComposerOverflowHandoffProps {
 	text: string;
+}
+
+interface OverflowFormData {
+	selectedSiteId: number;
 }
 
 function SingleSiteHandoff( { site, text }: { site: Site; text: string } ) {
@@ -27,12 +34,77 @@ function SingleSiteHandoff( { site, text }: { site: Site; text: string } ) {
 }
 
 function MultiSiteHandoff( { sites, text }: { sites: Site[]; text: string } ) {
-	// Implemented in task 8.
-	const translate = useTranslate();
+	const { data: userSettings, isPending } = useQuery( userSettingsQuery() );
+
+	if ( isPending ) {
+		return null;
+	}
+
+	return (
+		<MultiSiteHandoffForm
+			sites={ sites }
+			text={ text }
+			primarySiteId={ userSettings?.primary_site_ID }
+		/>
+	);
+}
+
+function MultiSiteHandoffForm( {
+	sites,
+	text,
+	primarySiteId,
+}: {
+	sites: Site[];
+	text: string;
+	primarySiteId?: number;
+} ) {
+	const defaultSiteId =
+		primarySiteId && sites.some( ( s ) => s.ID === primarySiteId ) ? primarySiteId : sites[ 0 ].ID;
+
+	const [ formData, setFormData ] = useState< OverflowFormData >( {
+		selectedSiteId: defaultSiteId,
+	} );
+
+	const fields: Field< OverflowFormData >[] = [
+		{
+			id: 'selectedSiteId',
+			label: '',
+			Edit: ( { field, onChange, data, hideLabelFromVision } ) => {
+				const { id, getValue } = field;
+				const value = getValue( { item: data } )?.toString( 10 ) ?? '';
+				return (
+					<PreferencesLoginSiteDropdown
+						sites={ sites }
+						value={ value }
+						onChange={ ( newValue ) => {
+							if ( newValue ) {
+								onChange( { [ id ]: parseInt( newValue, 10 ) } );
+							}
+						} }
+						label=""
+						hideLabelFromVision={ hideLabelFromVision }
+					/>
+				);
+			},
+		},
+	];
+
+	const form = {
+		layout: { type: 'regular' as const },
+		fields: [ 'selectedSiteId' ],
+	};
+
+	const selectedSite = sites.find( ( s ) => s.ID === formData.selectedSiteId ) ?? sites[ 0 ];
+
 	return (
 		<>
-			<p>{ translate( 'Pick a site:' ) }</p>
-			<MoveToEditorButton site={ sites[ 0 ] } text={ text } />
+			<DataForm< OverflowFormData >
+				data={ formData }
+				fields={ fields }
+				form={ form }
+				onChange={ ( edits ) => setFormData( ( d ) => ( { ...d, ...edits } ) ) }
+			/>
+			<MoveToEditorButton site={ selectedSite } text={ text } />
 		</>
 	);
 }

--- a/client/reader/social/composer/composer-overflow-handoff.tsx
+++ b/client/reader/social/composer/composer-overflow-handoff.tsx
@@ -13,10 +13,13 @@ import {
 import { check } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { UnknownAction } from 'redux';
+import { ThunkDispatch } from 'redux-thunk';
 import { logToLogstash } from 'calypso/lib/logstash';
 import { errorNotice } from 'calypso/state/notices/actions';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import { useComposerConfig } from './composer-config';
 import { useComposer } from './composer-provider';
 import {
@@ -24,7 +27,9 @@ import {
 	type SaveDraftMutationResult,
 	type SaveDraftMutationVariables,
 } from './use-save-draft-mutation';
+import type { ActiveMode } from './composer-provider';
 import type { Site } from '@automattic/api-core';
+import type { AppState } from 'calypso/types';
 
 interface ComposerOverflowHandoffProps {
 	text: string;
@@ -199,9 +204,18 @@ function MoveToEditorButton( {
 	isPending: boolean;
 } ) {
 	const translate = useTranslate();
-	const dispatch = useDispatch();
+	const dispatch = useDispatch< ThunkDispatch< AppState, void, UnknownAction > >();
+	const { mode } = useComposer();
+	const config = useComposerConfig();
 
 	const handleClick = () => {
+		// Fire on click intent (mirrors Quick Post's
+		// `calypso_reader_quick_post_full_editor_opened`) so the event
+		// captures the user's choice even when the draft save fails.
+		if ( mode && config.overflowHandoff ) {
+			const { event, props } = config.overflowHandoff.editorOpened( mode, { siteId: site.ID } );
+			dispatch( recordReaderTracksEvent( event, props ) );
+		}
 		mutate(
 			{ siteId: site.ID, content: text },
 			{
@@ -251,9 +265,32 @@ function MoveToEditorButton( {
 	);
 }
 
+/**
+ * Fires the `overflowHandoff.shown` Tracks event once when this component
+ * mounts. Lives as a sibling of the rendered handoff so it only mounts when
+ * the section actually appears (i.e. past the `hasBeenOverLimit` and
+ * non-empty-sites guards). Sticky-once across trim-back-under-limit because
+ * `hasBeenOverLimit` itself stays true; resets when the modal closes since
+ * the parent re-mounts the handoff on the next open.
+ */
+function OverflowHandoffShownEffect( { mode }: { mode: ActiveMode | null } ) {
+	const dispatch = useDispatch< ThunkDispatch< AppState, void, UnknownAction > >();
+	const config = useComposerConfig();
+	useEffect( () => {
+		if ( ! mode || ! config.overflowHandoff ) {
+			return;
+		}
+		const { event, props } = config.overflowHandoff.shown( mode );
+		dispatch( recordReaderTracksEvent( event, props ) );
+		// Fire once on mount; subsequent re-renders aren't a new "shown".
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+	return null;
+}
+
 export function ComposerOverflowHandoff( { text }: ComposerOverflowHandoffProps ) {
 	const translate = useTranslate();
-	const { hasBeenOverLimit } = useComposer();
+	const { hasBeenOverLimit, mode } = useComposer();
 	const config = useComposerConfig();
 
 	const { data: sites } = useQuery( {
@@ -274,6 +311,7 @@ export function ComposerOverflowHandoff( { text }: ComposerOverflowHandoffProps 
 			className="social-composer__overflow-handoff"
 			aria-label={ translate( 'Publish on your own site' ) as string }
 		>
+			<OverflowHandoffShownEffect mode={ mode } />
 			<p>
 				{ translate( 'Too long for %(protocol)s? Publish it on your own site instead.', {
 					args: { protocol: config.protocolLabel },

--- a/client/reader/social/composer/composer-overflow-handoff.tsx
+++ b/client/reader/social/composer/composer-overflow-handoff.tsx
@@ -2,12 +2,51 @@ import './composer-overflow-handoff.scss';
 
 import { sitesQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useComposerConfig } from './composer-config';
 import { useComposer } from './composer-provider';
+import type { Site } from '@automattic/api-core';
 
 interface ComposerOverflowHandoffProps {
 	text: string;
+}
+
+function SingleSiteHandoff( { site, text }: { site: Site; text: string } ) {
+	const translate = useTranslate();
+	return (
+		<>
+			<p>
+				{ translate( 'Publish on %(siteName)s', {
+					args: { siteName: site.name },
+				} ) }
+			</p>
+			<MoveToEditorButton site={ site } text={ text } />
+		</>
+	);
+}
+
+function MultiSiteHandoff( { sites, text }: { sites: Site[]; text: string } ) {
+	// Implemented in task 8.
+	const translate = useTranslate();
+	return (
+		<>
+			<p>{ translate( 'Pick a site:' ) }</p>
+			<MoveToEditorButton site={ sites[ 0 ] } text={ text } />
+		</>
+	);
+}
+
+function MoveToEditorButton( { site, text }: { site: Site; text: string } ) {
+	const translate = useTranslate();
+	// Wired up to the mutation + redirect in task 9.
+	void site;
+	void text;
+	return (
+		<Button variant="primary" __next40pxDefaultSize>
+			{ translate( 'Move to editor' ) }
+		</Button>
+	);
 }
 
 export function ComposerOverflowHandoff( { text }: ComposerOverflowHandoffProps ) {
@@ -33,13 +72,16 @@ export function ComposerOverflowHandoff( { text }: ComposerOverflowHandoffProps 
 			className="social-composer__overflow-handoff"
 			aria-label={ translate( 'Publish on your own site' ) as string }
 		>
-			{ /* Filled in by later tasks. */ }
 			<p>
 				{ translate( 'Too long for %(protocol)s? Publish it on your own site instead.', {
 					args: { protocol: config.protocolLabel },
 				} ) }
 			</p>
-			<p data-testid="overflow-handoff-debug-text">{ text }</p>
+			{ sites.length === 1 ? (
+				<SingleSiteHandoff site={ sites[ 0 ] } text={ text } />
+			) : (
+				<MultiSiteHandoff sites={ sites } text={ text } />
+			) }
 		</section>
 	);
 }

--- a/client/reader/social/composer/composer-overflow-handoff.tsx
+++ b/client/reader/social/composer/composer-overflow-handoff.tsx
@@ -18,7 +18,7 @@ import { useDispatch } from 'react-redux';
 import { UnknownAction } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { logToLogstash } from 'calypso/lib/logstash';
-import { errorNotice } from 'calypso/state/notices/actions';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import { useComposerConfig } from './composer-config';
 import { useComposer } from './composer-provider';
@@ -94,7 +94,7 @@ function SiteIconThumb( { site }: { site: Site } ) {
 }
 
 function getSiteDisplayUrl( site: Site ) {
-	return ( site.URL || '' ).replace( /^https?:\/\//, '' );
+	return ( site.URL || '' ).replace( /^https?:\/\//, '' ).replace( /\/$/, '' );
 }
 
 function MultiSiteHandoffForm( { sites, text }: { sites: Site[]; text: string } ) {
@@ -107,15 +107,6 @@ function MultiSiteHandoffForm( { sites, text }: { sites: Site[]; text: string } 
 
 	const [ userSelection, setUserSelection ] = useState< number | null >( null );
 
-	const initialSiteId =
-		userSettings?.primary_site_ID && sites.some( ( s ) => s.ID === userSettings.primary_site_ID )
-			? userSettings.primary_site_ID
-			: sites[ 0 ].ID;
-
-	const displayedSiteId = userSelection ?? initialSiteId;
-
-	const selectedSite = sites.find( ( s ) => s.ID === displayedSiteId ) ?? sites[ 0 ];
-
 	const { mutate, isPending } = useMutation( saveDraftMutation() );
 
 	const options = useMemo(
@@ -127,6 +118,22 @@ function MultiSiteHandoffForm( { sites, text }: { sites: Site[]; text: string } 
 			} ) ),
 		[ sites ]
 	);
+
+	// Caller gates on a non-empty sites array, but TypeScript can't see
+	// through that. Hooks above run unconditionally; this guard sits
+	// below them and above the first `sites[0]` access.
+	if ( sites.length === 0 ) {
+		return null;
+	}
+
+	const initialSiteId =
+		userSettings?.primary_site_ID && sites.some( ( s ) => s.ID === userSettings.primary_site_ID )
+			? userSettings.primary_site_ID
+			: sites[ 0 ].ID;
+
+	const displayedSiteId = userSelection ?? initialSiteId;
+
+	const selectedSite = sites.find( ( s ) => s.ID === displayedSiteId ) ?? sites[ 0 ];
 
 	const renderItem = ( { item }: { item: { value: string; label: string; site?: Site } } ) => {
 		const site = item.site ?? sites.find( ( s ) => String( s.ID ) === item.value );
@@ -220,16 +227,30 @@ function MoveToEditorButton( {
 			{ siteId: site.ID, content: text },
 			{
 				onSuccess: ( data ) => {
-					// `admin_url` is documented to be set on every WP.com site
-					// returned by /me/sites; falling back to a derived path
-					// avoids leaving an orphan draft if the field is missing.
+					// Fall back to a derived `/wp-admin/` path so a missing
+					// `admin_url` doesn't orphan the just-saved draft.
 					const adminUrl =
 						site.options?.admin_url ?? `${ site.URL.replace( /\/$/, '' ) }/wp-admin/`;
 					const editorUrl = addQueryArgs( `${ adminUrl }post.php`, {
 						post: data.ID,
 						action: 'edit',
 					} );
-					window.open( editorUrl, '_blank', 'noopener,noreferrer' );
+					// `window.open` from a post-mutation callback can be
+					// suppressed by popup blockers (transient user activation
+					// expires while the request is in flight). When that
+					// happens, surface the editor link in a success notice so
+					// the user can complete the handoff via a fresh click.
+					const newWindow = window.open( editorUrl, '_blank', 'noopener,noreferrer' );
+					if ( ! newWindow ) {
+						dispatch(
+							successNotice( translate( 'Draft saved.' ), {
+								button: translate( 'Open in editor' ),
+								onClick: () => {
+									window.open( editorUrl, '_blank', 'noopener,noreferrer' );
+								},
+							} )
+						);
+					}
 				},
 				onError: ( error ) => {
 					dispatch(
@@ -244,7 +265,7 @@ function MoveToEditorButton( {
 						extra: {
 							type: 'reader_social_composer_overflow_handoff_save_draft_error',
 							site_id: site.ID,
-							error_message: error?.message,
+							error_message: error.message,
 						},
 					} );
 				},
@@ -265,14 +286,9 @@ function MoveToEditorButton( {
 	);
 }
 
-/**
- * Fires the `overflowHandoff.shown` Tracks event once when this component
- * mounts. Lives as a sibling of the rendered handoff so it only mounts when
- * the section actually appears (i.e. past the `hasBeenOverLimit` and
- * non-empty-sites guards). Sticky-once across trim-back-under-limit because
- * `hasBeenOverLimit` itself stays true; resets when the modal closes since
- * the parent re-mounts the handoff on the next open.
- */
+// Sibling component rather than a parent-component effect: mounting is the
+// gate, so we get one fire per modal session without re-implementing the
+// `hasBeenOverLimit` + non-empty-sites preconditions in a dependency array.
 function OverflowHandoffShownEffect( { mode }: { mode: ActiveMode | null } ) {
 	const dispatch = useDispatch< ThunkDispatch< AppState, void, UnknownAction > >();
 	const config = useComposerConfig();
@@ -315,6 +331,8 @@ export function ComposerOverflowHandoff( { text }: ComposerOverflowHandoffProps 
 			<p>
 				{ translate( 'Too long for %(protocol)s? Publish it on your own site instead.', {
 					args: { protocol: config.protocolLabel },
+					comment:
+						'%(protocol)s is a brand name (e.g. "Bluesky", "Mastodon") and should not be translated.',
 				} ) }
 			</p>
 			{ sites.length === 1 ? (

--- a/client/reader/social/composer/composer-overflow-handoff.tsx
+++ b/client/reader/social/composer/composer-overflow-handoff.tsx
@@ -1,14 +1,18 @@
 import './composer-overflow-handoff.scss';
 
 import { sitesQuery, userSettingsQuery } from '@automattic/api-queries';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
 import { DataForm, type Field } from '@wordpress/dataviews';
+import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
+import { useDispatch } from 'react-redux';
 import PreferencesLoginSiteDropdown from 'calypso/dashboard/me/preferences-primary-site/site-dropdown';
+import { errorNotice } from 'calypso/state/notices/actions';
 import { useComposerConfig } from './composer-config';
 import { useComposer } from './composer-provider';
+import { saveDraftMutation } from './use-save-draft-mutation';
 import type { Site } from '@automattic/api-core';
 
 interface ComposerOverflowHandoffProps {
@@ -111,11 +115,47 @@ function MultiSiteHandoffForm( {
 
 function MoveToEditorButton( { site, text }: { site: Site; text: string } ) {
 	const translate = useTranslate();
-	// Wired up to the mutation + redirect in task 9.
-	void site;
-	void text;
+	const dispatch = useDispatch();
+	const { mutate, isPending } = useMutation( saveDraftMutation() );
+
+	const handleClick = () => {
+		mutate(
+			{ siteId: site.ID, content: text },
+			{
+				onSuccess: ( data ) => {
+					const adminUrl = site.options?.admin_url;
+					if ( ! adminUrl ) {
+						dispatch(
+							errorNotice( translate( "Couldn't open the editor. Try a different site." ) )
+						);
+						return;
+					}
+					window.location.assign(
+						addQueryArgs( `${ adminUrl }post.php`, {
+							post: data.ID,
+							action: 'edit',
+						} )
+					);
+				},
+				onError: () => {
+					dispatch(
+						errorNotice(
+							translate( "Couldn't save your draft. Try again or pick a different site." )
+						)
+					);
+				},
+			}
+		);
+	};
+
 	return (
-		<Button variant="primary" __next40pxDefaultSize>
+		<Button
+			variant="primary"
+			__next40pxDefaultSize
+			onClick={ handleClick }
+			isBusy={ isPending }
+			disabled={ isPending }
+		>
 			{ translate( 'Move to editor' ) }
 		</Button>
 	);

--- a/client/reader/social/composer/composer-provider.tsx
+++ b/client/reader/social/composer/composer-provider.tsx
@@ -109,9 +109,14 @@ interface ComposerContextValue {
 	closeComposer: ( options?: CloseComposerOptions ) => void;
 	/** Read by the modal to render media UI and gate submission. */
 	mediaSlot: ComposerMediaSlot;
-	/** Sticky-once flag: true after the user has crossed the per-protocol char limit at least once during the current modal session. Reset on each modal open. */
+	/**
+	 * Sticky-once flag: true after the user has crossed the per-protocol
+	 * char limit at least once during the current modal session. Reset on
+	 * each modal open. Stays true once tripped so the overflow-handoff UI
+	 * doesn't disappear when the user trims back under the limit, which
+	 * would otherwise hide the escape hatch they're working toward.
+	 */
 	hasBeenOverLimit: boolean;
-	/** Set `hasBeenOverLimit` to true. Idempotent. */
 	markOverLimit: () => void;
 }
 
@@ -150,6 +155,7 @@ export function ComposerProvider< TError, TParams, TResult >( {
 				return;
 			}
 			triggerRef.current = document.activeElement as HTMLElement | null;
+			setHasBeenOverLimit( false );
 			setMode( { ...next, connectionId } );
 		},
 		[ connectionId, config.supportedModes ]
@@ -169,12 +175,6 @@ export function ComposerProvider< TError, TParams, TResult >( {
 	const markOverLimit = useCallback( () => {
 		setHasBeenOverLimit( true );
 	}, [] );
-
-	useEffect( () => {
-		if ( mode ) {
-			setHasBeenOverLimit( false );
-		}
-	}, [ mode ] );
 
 	// `config.useMedia` is captured once at the start of the provider's life
 	// and called every render. Per the contract on `ComposerConfig.useMedia`,

--- a/client/reader/social/composer/composer-provider.tsx
+++ b/client/reader/social/composer/composer-provider.tsx
@@ -109,6 +109,10 @@ interface ComposerContextValue {
 	closeComposer: ( options?: CloseComposerOptions ) => void;
 	/** Read by the modal to render media UI and gate submission. */
 	mediaSlot: ComposerMediaSlot;
+	/** Sticky-once flag: true after the user has crossed the per-protocol char limit at least once during the current modal session. Reset on each modal open. */
+	hasBeenOverLimit: boolean;
+	/** Set `hasBeenOverLimit` to true. Idempotent. */
+	markOverLimit: () => void;
 }
 
 const ComposerContext = createContext< ComposerContextValue | null >( null );
@@ -125,6 +129,7 @@ export function ComposerProvider< TError, TParams, TResult >( {
 	children,
 }: Props< TError, TParams, TResult > ) {
 	const [ mode, setMode ] = useState< ActiveMode | null >( null );
+	const [ hasBeenOverLimit, setHasBeenOverLimit ] = useState( false );
 	const triggerRef = useRef< HTMLElement | null >( null );
 	const wasOpenRef = useRef( false );
 
@@ -161,6 +166,16 @@ export function ComposerProvider< TError, TParams, TResult >( {
 		setMode( null );
 	}, [] );
 
+	const markOverLimit = useCallback( () => {
+		setHasBeenOverLimit( true );
+	}, [] );
+
+	useEffect( () => {
+		if ( mode ) {
+			setHasBeenOverLimit( false );
+		}
+	}, [ mode ] );
+
 	// `config.useMedia` is captured once at the start of the provider's life
 	// and called every render. Per the contract on `ComposerConfig.useMedia`,
 	// it must be a stable reference — atmosphere exports a module-level hook
@@ -188,8 +203,15 @@ export function ComposerProvider< TError, TParams, TResult >( {
 	}, [ mode ] );
 
 	const value = useMemo(
-		() => ( { mode, openComposer, closeComposer, mediaSlot } ),
-		[ mode, openComposer, closeComposer, mediaSlot ]
+		() => ( {
+			mode,
+			openComposer,
+			closeComposer,
+			mediaSlot,
+			hasBeenOverLimit,
+			markOverLimit,
+		} ),
+		[ mode, openComposer, closeComposer, mediaSlot, hasBeenOverLimit, markOverLimit ]
 	);
 
 	return (

--- a/client/reader/social/composer/test-config.ts
+++ b/client/reader/social/composer/test-config.ts
@@ -23,6 +23,7 @@ interface TestResult {
  */
 export const testComposerConfig: ComposerConfig< TestError, TestParams, TestResult > = {
 	useLimit: () => 300,
+	protocolLabel: 'TestProtocol',
 	supportedModes: [ 'reply', 'quote', 'standalone' ],
 	mutationFactory: () =>
 		mutationOptions< TestResult, TestError, TestParams >( {

--- a/client/reader/social/composer/test/composer-footer.test.tsx
+++ b/client/reader/social/composer/test/composer-footer.test.tsx
@@ -29,6 +29,14 @@ describe( '<ComposerFooter>', () => {
 		expect( screen.getByRole( 'button', { name: /post/i } ) ).toBeDisabled();
 	} );
 
+	it( 'swaps the Post label to nudge toward the editor when over the limit', () => {
+		render(
+			<ComposerFooter graphemeCount={ 301 } onSubmit={ noop } isPending={ false } limit={ 300 } />
+		);
+		expect( screen.getByRole( 'button', { name: /better as a blog post/i } ) ).toBeDisabled();
+		expect( screen.queryByRole( 'button', { name: /^post$/i } ) ).toBeNull();
+	} );
+
 	it( 'shows amber count under 50 remaining', () => {
 		render(
 			<ComposerFooter graphemeCount={ 260 } onSubmit={ noop } isPending={ false } limit={ 300 } />

--- a/client/reader/social/composer/test/composer-modal.test.tsx
+++ b/client/reader/social/composer/test/composer-modal.test.tsx
@@ -409,3 +409,50 @@ describe( '<ComposerModal>', () => {
 		);
 	} );
 } );
+
+describe( '<ComposerModal> — markOverLimit', () => {
+	beforeEach( () => {
+		openFn = null;
+		closeFn = null;
+
+		jest
+			.spyOn( analytics, 'recordReaderTracksEvent' )
+			.mockImplementation( () => ( { type: '@@TEST/NOOP' } ) as never );
+		jest.spyOn( noticeActions, 'successNotice' );
+	} );
+
+	afterEach( () => {
+		jest.restoreAllMocks();
+	} );
+
+	it( 'sets hasBeenOverLimit on the context once the user types past the limit', async () => {
+		const user = userEvent.setup();
+		const tinyLimitConfig: ComposerConfig< TestError, TestParams, TestResult > = {
+			...testComposerConfig,
+			useLimit: () => 5,
+		};
+
+		const probe: { current: ReturnType< typeof useComposer > | null } = { current: null };
+		function Probe() {
+			probe.current = useComposer();
+			return null;
+		}
+
+		const queryClient = makeQueryClient();
+		renderWithProvider(
+			<ComposerProvider connectionId={ 7 } config={ tinyLimitConfig }>
+				<Probe />
+				<Capture />
+				<ComposerModal />
+			</ComposerProvider>,
+			{ queryClient }
+		);
+
+		act( () => openFn?.( standaloneMode ) );
+		expect( probe.current?.hasBeenOverLimit ).toBe( false );
+
+		await user.type( screen.getByRole( 'textbox' ), 'this is over the limit' );
+
+		expect( probe.current?.hasBeenOverLimit ).toBe( true );
+	} );
+} );

--- a/client/reader/social/composer/test/composer-modal.test.tsx
+++ b/client/reader/social/composer/test/composer-modal.test.tsx
@@ -4,6 +4,7 @@
 import { QueryClient, mutationOptions } from '@tanstack/react-query';
 import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import nock from 'nock';
 import * as noticeActions from 'calypso/state/notices/actions';
 import * as analytics from 'calypso/state/reader/analytics/actions';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
@@ -16,6 +17,7 @@ import {
 } from '../composer-provider';
 import { testComposerConfig } from '../test-config';
 import type { ComposerConfig } from '../composer-config';
+import type { Site } from '@automattic/api-core';
 
 interface TestError {
 	kind: string;
@@ -454,5 +456,101 @@ describe( '<ComposerModal> — markOverLimit', () => {
 		await user.type( screen.getByRole( 'textbox' ), 'this is over the limit' );
 
 		expect( probe.current?.hasBeenOverLimit ).toBe( true );
+	} );
+} );
+
+const ORIGIN = 'https://public-api.wordpress.com';
+
+afterEach( () => nock.cleanAll() );
+
+describe( '<ComposerModal> — overflow handoff visibility', () => {
+	beforeEach( () => {
+		// Re-establish spies for the new describe block (Jest doesn't share `beforeEach` across siblings).
+		jest
+			.spyOn( analytics, 'recordReaderTracksEvent' )
+			.mockImplementation( () => ( { type: '@@TEST/NOOP' } ) as never );
+		jest.spyOn( noticeActions, 'successNotice' );
+		openFn = null;
+		closeFn = null;
+	} );
+
+	afterEach( () => {
+		jest.restoreAllMocks();
+	} );
+
+	it( 'shows the overflow section after typing past the limit and keeps it visible after trimming back under', async () => {
+		const user = userEvent.setup();
+		nock( ORIGIN )
+			.get( /\/rest\/v1\.\d+\/me\/sites/ )
+			.reply( 200, {
+				sites: [
+					{
+						ID: 100,
+						name: 'My Blog',
+						slug: 'myblog.wordpress.com',
+						URL: 'https://myblog.wordpress.com',
+						site_migration: { in_progress: false, is_complete: false },
+						options: { admin_url: 'https://myblog.wordpress.com/wp-admin/' },
+					} as Partial< Site >,
+				],
+			} );
+
+		const tinyLimitConfig: ComposerConfig< TestError, TestParams, TestResult > = {
+			...testComposerConfig,
+			useLimit: () => 5,
+		};
+		renderModal( tinyLimitConfig );
+
+		act( () => openFn?.( standaloneMode ) );
+
+		const textarea = screen.getByRole( 'textbox' );
+		await user.type( textarea, 'this is way past the test fixture five-character limit' );
+
+		expect(
+			await screen.findByRole( 'region', { name: /Publish on your own site/i } )
+		).toBeVisible();
+
+		await user.clear( textarea );
+		await user.type( textarea, 'ok' );
+
+		expect( screen.getByRole( 'region', { name: /Publish on your own site/i } ) ).toBeVisible();
+	} );
+
+	it( 'hides the overflow section after the modal closes and reopens (flag resets)', async () => {
+		const user = userEvent.setup();
+		nock( ORIGIN )
+			.get( /\/rest\/v1\.\d+\/me\/sites/ )
+			.reply( 200, { sites: [] } );
+
+		const tinyLimitConfig: ComposerConfig< TestError, TestParams, TestResult > = {
+			...testComposerConfig,
+			useLimit: () => 5,
+		};
+
+		const probe: { current: ReturnType< typeof useComposer > | null } = { current: null };
+		function Probe() {
+			probe.current = useComposer();
+			return null;
+		}
+
+		const queryClient = makeQueryClient();
+		renderWithProvider(
+			<ComposerProvider connectionId={ 7 } config={ tinyLimitConfig }>
+				<Probe />
+				<Capture />
+				<ComposerModal />
+			</ComposerProvider>,
+			{ queryClient }
+		);
+
+		act( () => openFn?.( standaloneMode ) );
+		const textarea = screen.getByRole( 'textbox' );
+		await user.type( textarea, 'overflow xyz xyz' );
+		expect( probe.current!.hasBeenOverLimit ).toBe( true );
+
+		act( () => closeFn?.() );
+		act( () => openFn?.( standaloneMode ) );
+
+		expect( probe.current!.hasBeenOverLimit ).toBe( false );
 	} );
 } );

--- a/client/reader/social/composer/test/composer-overflow-handoff.test.tsx
+++ b/client/reader/social/composer/test/composer-overflow-handoff.test.tsx
@@ -6,6 +6,7 @@ import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { useEffect } from 'react';
+import * as notices from 'calypso/state/notices/actions';
 import * as analytics from 'calypso/state/reader/analytics/actions';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { ComposerOverflowHandoff } from '../composer-overflow-handoff';
@@ -207,6 +208,54 @@ describe( 'ComposerOverflowHandoff — multi-site picker', () => {
 		// `Blog B` is the primary site, so it should be the default value.
 		await waitFor( () => expect( ( combobox as HTMLInputElement ).value ).toContain( 'Blog B' ) );
 	} );
+
+	it( 'falls back to sites[0] when primary_site_ID is set but missing from the sites list', async () => {
+		mockSitesQuery( [
+			{
+				ID: 100,
+				name: 'Blog A',
+				slug: 'a.wordpress.com',
+				URL: 'https://a.wordpress.com',
+				options: { admin_url: 'https://a.wordpress.com/wp-admin/' },
+				site_migration: { in_progress: false, is_complete: false },
+			} as Partial< Site >,
+			{
+				ID: 200,
+				name: 'Blog B',
+				slug: 'b.wordpress.com',
+				URL: 'https://b.wordpress.com',
+				options: { admin_url: 'https://b.wordpress.com/wp-admin/' },
+				site_migration: { in_progress: false, is_complete: false },
+			} as Partial< Site >,
+		] );
+
+		// `primary_site_ID` is set to a site that's NOT in the visible
+		// list (e.g. user's primary site is excluded by the `sitesQuery`
+		// filter). The picker must fall back to `sites[0]` rather than
+		// pre-selecting a non-existent site.
+		nock( ORIGIN )
+			.get( /\/rest\/v1\.\d+\/me\/settings/ )
+			.reply( 200, { primary_site_ID: 999 } );
+
+		let composer: ReturnType< typeof useComposer > | null = null;
+		function Probe() {
+			composer = useComposer();
+			return null;
+		}
+
+		renderWithComposer(
+			<>
+				<Probe />
+				<ComposerOverflowHandoff text="hi" />
+			</>,
+			{ withMode: true }
+		);
+
+		act( () => composer!.markOverLimit() );
+
+		const combobox = await screen.findByRole( 'combobox' );
+		await waitFor( () => expect( ( combobox as HTMLInputElement ).value ).toContain( 'Blog A' ) );
+	} );
 } );
 
 describe( 'ComposerOverflowHandoff — Move to editor click', () => {
@@ -256,6 +305,113 @@ describe( 'ComposerOverflowHandoff — Move to editor click', () => {
 		const button = await screen.findByRole( 'button', { name: /Move to editor/i } );
 		await user.click( button );
 
+		await waitFor( () =>
+			expect( openSpy ).toHaveBeenCalledWith(
+				'https://myblog.wordpress.com/wp-admin/post.php?post=555&action=edit',
+				'_blank',
+				'noopener,noreferrer'
+			)
+		);
+	} );
+
+	it( 'dispatches a fallback success notice with an Open-in-editor button when window.open is blocked', async () => {
+		const user = userEvent.setup();
+		const successNoticeSpy = jest.spyOn( notices, 'successNotice' );
+		mockSitesQuery( [
+			{
+				ID: 100,
+				name: 'My Blog',
+				slug: 'myblog.wordpress.com',
+				URL: 'https://myblog.wordpress.com',
+				site_migration: { in_progress: false, is_complete: false },
+				options: { admin_url: 'https://myblog.wordpress.com/wp-admin/' },
+			} as Partial< Site >,
+		] );
+		nock( ORIGIN )
+			.post( /\/rest\/v1\.\d+\/sites\/100\/posts\/new/ )
+			.reply( 200, { ID: 555, site_ID: 100, URL: 'https://myblog.wordpress.com/?p=555' } );
+
+		let composer: ReturnType< typeof useComposer > | null = null;
+		function Probe() {
+			composer = useComposer();
+			return null;
+		}
+
+		renderWithComposer(
+			<>
+				<Probe />
+				<ComposerOverflowHandoff text="my long draft" />
+			</>,
+			{ withMode: true }
+		);
+
+		act( () => composer!.markOverLimit() );
+
+		const button = await screen.findByRole( 'button', { name: /Move to editor/i } );
+		await user.click( button );
+
+		// `openSpy` is mocked to return null (popup-blocker case). The
+		// fallback path dispatches a success notice with an "Open in editor"
+		// button whose onClick retries window.open from a fresh gesture.
+		await waitFor( () =>
+			expect( successNoticeSpy ).toHaveBeenCalledWith(
+				expect.stringMatching( /draft saved/i ),
+				expect.objectContaining( {
+					button: expect.stringMatching( /open in editor/i ),
+					onClick: expect.any( Function ),
+				} )
+			)
+		);
+		const noticeOptions = successNoticeSpy.mock.calls[ 0 ][ 1 ] as {
+			onClick: () => void;
+		};
+		noticeOptions.onClick();
+		expect( openSpy ).toHaveBeenLastCalledWith(
+			'https://myblog.wordpress.com/wp-admin/post.php?post=555&action=edit',
+			'_blank',
+			'noopener,noreferrer'
+		);
+		successNoticeSpy.mockRestore();
+	} );
+
+	it( 'derives the editor URL from site.URL when admin_url is missing', async () => {
+		const user = userEvent.setup();
+		mockSitesQuery( [
+			{
+				ID: 100,
+				name: 'My Blog',
+				slug: 'myblog.wordpress.com',
+				URL: 'https://myblog.wordpress.com/',
+				site_migration: { in_progress: false, is_complete: false },
+				options: undefined,
+			} as Partial< Site >,
+		] );
+		nock( ORIGIN )
+			.post( /\/rest\/v1\.\d+\/sites\/100\/posts\/new/ )
+			.reply( 200, { ID: 555 } );
+
+		let composer: ReturnType< typeof useComposer > | null = null;
+		function Probe() {
+			composer = useComposer();
+			return null;
+		}
+
+		renderWithComposer(
+			<>
+				<Probe />
+				<ComposerOverflowHandoff text="my long draft" />
+			</>,
+			{ withMode: true }
+		);
+
+		act( () => composer!.markOverLimit() );
+
+		const button = await screen.findByRole( 'button', { name: /Move to editor/i } );
+		await user.click( button );
+
+		// `site.URL` carries a trailing slash; the fallback strips it
+		// before appending `/wp-admin/post.php` so we don't end up with
+		// `//wp-admin/`.
 		await waitFor( () =>
 			expect( openSpy ).toHaveBeenCalledWith(
 				'https://myblog.wordpress.com/wp-admin/post.php?post=555&action=edit',
@@ -416,6 +572,57 @@ describe( 'ComposerOverflowHandoff — Tracks events', () => {
 				mode_kind: 'standalone',
 				site_id: 100,
 			} );
+		} finally {
+			openSpy.mockRestore();
+		}
+	} );
+
+	it( 'does not fire overflowHandoff Tracks events when the config omits the section', async () => {
+		const user = userEvent.setup();
+		const openSpy = jest.spyOn( window, 'open' ).mockImplementation( () => null );
+
+		try {
+			mockSitesQuery( [
+				{
+					ID: 100,
+					name: 'My Blog',
+					slug: 'myblog.wordpress.com',
+					URL: 'https://myblog.wordpress.com',
+					site_migration: { in_progress: false, is_complete: false },
+					options: { admin_url: 'https://myblog.wordpress.com/wp-admin/' },
+				} as Partial< Site >,
+			] );
+			nock( ORIGIN )
+				.post( /\/rest\/v1\.\d+\/sites\/100\/posts\/new/ )
+				.reply( 200, { ID: 555 } );
+
+			let composer: ReturnType< typeof useComposer > | null = null;
+			const Probe = () => {
+				composer = useComposer();
+				return null;
+			};
+
+			// `testComposerConfig` (the default) has no `overflowHandoff`
+			// field — protocols opt in by setting it. Confirm the
+			// section + click path stay silent in that case.
+			renderWithComposer(
+				<>
+					<Probe />
+					<ComposerOverflowHandoff text="my long draft" />
+				</>,
+				{ withMode: true }
+			);
+
+			act( () => composer!.markOverLimit() );
+
+			const button = await screen.findByRole( 'button', { name: /Move to editor/i } );
+			await user.click( button );
+			await waitFor( () => expect( openSpy ).toHaveBeenCalled() );
+
+			const handoffCalls = recordSpy.mock.calls.filter( ( call ) =>
+				String( call[ 0 ] ).includes( 'overflow_handoff' )
+			);
+			expect( handoffCalls ).toHaveLength( 0 );
 		} finally {
 			openSpy.mockRestore();
 		}

--- a/client/reader/social/composer/test/composer-overflow-handoff.test.tsx
+++ b/client/reader/social/composer/test/composer-overflow-handoff.test.tsx
@@ -6,10 +6,12 @@ import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { useEffect } from 'react';
+import * as analytics from 'calypso/state/reader/analytics/actions';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { ComposerOverflowHandoff } from '../composer-overflow-handoff';
 import { ComposerProvider, useComposer } from '../composer-provider';
 import { testComposerConfig } from '../test-config';
+import type { ComposerConfig } from '../composer-config';
 import type { Site } from '@automattic/api-core';
 import type { ReactNode } from 'react';
 
@@ -17,7 +19,17 @@ jest.mock( 'calypso/lib/logstash', () => ( { logToLogstash: jest.fn() } ) );
 
 const ORIGIN = 'https://public-api.wordpress.com';
 
-function renderWithComposer( ui: ReactNode, { withMode = false } = {} ) {
+function renderWithComposer(
+	ui: ReactNode,
+	{
+		withMode = false,
+		config = testComposerConfig,
+	}: {
+		withMode?: boolean;
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		config?: ComposerConfig< any, any, any >;
+	} = {}
+) {
 	const queryClient = new QueryClient( {
 		defaultOptions: { queries: { retry: false } },
 	} );
@@ -35,7 +47,7 @@ function renderWithComposer( ui: ReactNode, { withMode = false } = {} ) {
 	}
 
 	return renderWithProvider(
-		<ComposerProvider connectionId={ 1 } config={ testComposerConfig }>
+		<ComposerProvider connectionId={ 1 } config={ config }>
 			<Inner />
 		</ComposerProvider>,
 		{ queryClient }
@@ -290,6 +302,123 @@ describe( 'ComposerOverflowHandoff — Move to editor click', () => {
 
 		await waitFor( () => expect( nock.isDone() ).toBe( true ) );
 		expect( openSpy ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'ComposerOverflowHandoff — Tracks events', () => {
+	const trackingConfig: typeof testComposerConfig = {
+		...testComposerConfig,
+		overflowHandoff: {
+			shown: ( mode ) => ( {
+				event: 'test_composer_overflow_handoff_shown',
+				props: { connection_id: mode.connectionId, mode_kind: mode.kind },
+			} ),
+			editorOpened: ( mode, { siteId } ) => ( {
+				event: 'test_composer_overflow_handoff_editor_opened',
+				props: { connection_id: mode.connectionId, mode_kind: mode.kind, site_id: siteId },
+			} ),
+		},
+	};
+
+	let recordSpy: jest.SpyInstance;
+
+	beforeEach( () => {
+		recordSpy = jest
+			.spyOn( analytics, 'recordReaderTracksEvent' )
+			.mockImplementation( () => ( { type: '@@TEST/NOOP' } ) as never );
+	} );
+
+	afterEach( () => {
+		recordSpy.mockRestore();
+	} );
+
+	it( 'fires overflowHandoff.shown once when the section first renders', async () => {
+		mockSitesQuery( [
+			{
+				ID: 100,
+				name: 'My Blog',
+				slug: 'myblog.wordpress.com',
+				URL: 'https://myblog.wordpress.com',
+				options: { admin_url: 'https://myblog.wordpress.com/wp-admin/' },
+			} as Partial< Site >,
+		] );
+
+		let composer: ReturnType< typeof useComposer > | null = null;
+		function Probe() {
+			composer = useComposer();
+			return null;
+		}
+
+		renderWithComposer(
+			<>
+				<Probe />
+				<ComposerOverflowHandoff text="hi" />
+			</>,
+			{ withMode: true, config: trackingConfig }
+		);
+
+		act( () => composer!.markOverLimit() );
+
+		await screen.findByRole( 'button', { name: /Move to editor/i } );
+
+		const shownCalls = recordSpy.mock.calls.filter(
+			( call ) => call[ 0 ] === 'test_composer_overflow_handoff_shown'
+		);
+		expect( shownCalls ).toHaveLength( 1 );
+		expect( shownCalls[ 0 ][ 1 ] ).toEqual( { connection_id: 1, mode_kind: 'standalone' } );
+	} );
+
+	it( 'fires overflowHandoff.editorOpened with the chosen site_id on Move to editor click', async () => {
+		const user = userEvent.setup();
+		const openSpy = jest.spyOn( window, 'open' ).mockImplementation( () => null );
+
+		try {
+			mockSitesQuery( [
+				{
+					ID: 100,
+					name: 'My Blog',
+					slug: 'myblog.wordpress.com',
+					URL: 'https://myblog.wordpress.com',
+					site_migration: { in_progress: false, is_complete: false },
+					options: { admin_url: 'https://myblog.wordpress.com/wp-admin/' },
+				} as Partial< Site >,
+			] );
+
+			nock( ORIGIN )
+				.post( /\/rest\/v1\.\d+\/sites\/100\/posts\/new/ )
+				.reply( 200, { ID: 555, site_ID: 100, URL: 'https://myblog.wordpress.com/?p=555' } );
+
+			let composer: ReturnType< typeof useComposer > | null = null;
+			const Probe = () => {
+				composer = useComposer();
+				return null;
+			};
+
+			renderWithComposer(
+				<>
+					<Probe />
+					<ComposerOverflowHandoff text="my long draft" />
+				</>,
+				{ withMode: true, config: trackingConfig }
+			);
+
+			act( () => composer!.markOverLimit() );
+
+			const button = await screen.findByRole( 'button', { name: /Move to editor/i } );
+			await user.click( button );
+
+			const openedCalls = recordSpy.mock.calls.filter(
+				( call ) => call[ 0 ] === 'test_composer_overflow_handoff_editor_opened'
+			);
+			expect( openedCalls ).toHaveLength( 1 );
+			expect( openedCalls[ 0 ][ 1 ] ).toEqual( {
+				connection_id: 1,
+				mode_kind: 'standalone',
+				site_id: 100,
+			} );
+		} finally {
+			openSpy.mockRestore();
+		}
 	} );
 } );
 

--- a/client/reader/social/composer/test/composer-overflow-handoff.test.tsx
+++ b/client/reader/social/composer/test/composer-overflow-handoff.test.tsx
@@ -113,3 +113,51 @@ describe( 'ComposerOverflowHandoff — single site', () => {
 		expect( screen.queryByRole( 'combobox' ) ).toBeNull();
 	} );
 } );
+
+describe( 'ComposerOverflowHandoff — multi-site picker', () => {
+	it( "renders a combobox with the user's sites and pre-selects the primary site", async () => {
+		mockSitesQuery( [
+			{
+				ID: 100,
+				name: 'Blog A',
+				slug: 'a.wordpress.com',
+				URL: 'https://a.wordpress.com',
+				options: { admin_url: 'https://a.wordpress.com/wp-admin/' },
+				site_migration: { in_progress: false, is_complete: false },
+			} as Partial< Site >,
+			{
+				ID: 200,
+				name: 'Blog B',
+				slug: 'b.wordpress.com',
+				URL: 'https://b.wordpress.com',
+				options: { admin_url: 'https://b.wordpress.com/wp-admin/' },
+				site_migration: { in_progress: false, is_complete: false },
+			} as Partial< Site >,
+		] );
+
+		nock( ORIGIN )
+			.get( /\/rest\/v1\.\d+\/me\/settings/ )
+			.reply( 200, { primary_site_ID: 200 } );
+
+		let composer: ReturnType< typeof useComposer > | null = null;
+		function Probe() {
+			composer = useComposer();
+			return null;
+		}
+
+		renderWithComposer(
+			<>
+				<Probe />
+				<ComposerOverflowHandoff text="hi" />
+			</>,
+			{ withMode: true }
+		);
+
+		act( () => composer!.markOverLimit() );
+
+		const combobox = await screen.findByRole( 'combobox' );
+		expect( combobox ).toBeVisible();
+		// `Blog B` is the primary site, so it should be the default value.
+		expect( ( combobox as HTMLInputElement ).value ).toContain( 'Blog B' );
+	} );
+} );

--- a/client/reader/social/composer/test/composer-overflow-handoff.test.tsx
+++ b/client/reader/social/composer/test/composer-overflow-handoff.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import nock from 'nock';
 import { ComposerOverflowHandoff } from '../composer-overflow-handoff';
 import { ComposerProvider, useComposer } from '../composer-provider';
@@ -34,8 +34,6 @@ function renderWithComposer( ui: ReactNode, { withMode = false } = {} ) {
 	);
 }
 
-// Used by tests added in later tasks of the overflow-handoff series.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function mockSitesQuery( sites: Partial< Site >[] ) {
 	nock( ORIGIN )
 		.get( /\/rest\/v1\.\d+\/me\/sites/ )
@@ -47,6 +45,32 @@ afterEach( () => nock.cleanAll() );
 describe( 'ComposerOverflowHandoff — gate', () => {
 	it( 'renders nothing when hasBeenOverLimit is false', () => {
 		renderWithComposer( <ComposerOverflowHandoff text="hello" /> );
+		expect( screen.queryByRole( 'region', { name: /publish on your own site/i } ) ).toBeNull();
+	} );
+} );
+
+describe( 'ComposerOverflowHandoff — null branches', () => {
+	it( 'renders nothing when sites query resolves to []', async () => {
+		mockSitesQuery( [] );
+
+		let composer: ReturnType< typeof useComposer > | null = null;
+		function Probe() {
+			composer = useComposer();
+			return null;
+		}
+
+		renderWithComposer(
+			<>
+				<Probe />
+				<ComposerOverflowHandoff text="hi" />
+			</>,
+			{ withMode: true }
+		);
+
+		act( () => composer!.markOverLimit() );
+
+		// Wait a tick for the query to resolve, then assert nothing rendered.
+		await new Promise( ( r ) => setTimeout( r, 0 ) );
 		expect( screen.queryByRole( 'region', { name: /publish on your own site/i } ) ).toBeNull();
 	} );
 } );

--- a/client/reader/social/composer/test/composer-overflow-handoff.test.tsx
+++ b/client/reader/social/composer/test/composer-overflow-handoff.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import nock from 'nock';
+import { ComposerOverflowHandoff } from '../composer-overflow-handoff';
+import { ComposerProvider, useComposer } from '../composer-provider';
+import { testComposerConfig } from '../test-config';
+import type { Site } from '@automattic/api-core';
+import type { ReactNode } from 'react';
+
+const ORIGIN = 'https://public-api.wordpress.com';
+
+function renderWithComposer( ui: ReactNode, { withMode = false } = {} ) {
+	const queryClient = new QueryClient( {
+		defaultOptions: { queries: { retry: false } },
+	} );
+
+	function Inner() {
+		const composer = useComposer();
+		if ( withMode && ! composer.mode ) {
+			composer.openComposer( { kind: 'standalone', entry_point: 'fab' } );
+		}
+		return <>{ ui }</>;
+	}
+
+	return render(
+		<QueryClientProvider client={ queryClient }>
+			<ComposerProvider connectionId={ 1 } config={ testComposerConfig }>
+				<Inner />
+			</ComposerProvider>
+		</QueryClientProvider>
+	);
+}
+
+// Used by tests added in later tasks of the overflow-handoff series.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function mockSitesQuery( sites: Partial< Site >[] ) {
+	nock( ORIGIN )
+		.get( /\/rest\/v1\.\d+\/me\/sites/ )
+		.reply( 200, { sites } );
+}
+
+afterEach( () => nock.cleanAll() );
+
+describe( 'ComposerOverflowHandoff — gate', () => {
+	it( 'renders nothing when hasBeenOverLimit is false', () => {
+		renderWithComposer( <ComposerOverflowHandoff text="hello" /> );
+		expect( screen.queryByRole( 'region', { name: /publish on your own site/i } ) ).toBeNull();
+	} );
+} );

--- a/client/reader/social/composer/test/composer-overflow-handoff.test.tsx
+++ b/client/reader/social/composer/test/composer-overflow-handoff.test.tsx
@@ -159,7 +159,7 @@ describe( 'ComposerOverflowHandoff — multi-site picker', () => {
 		const combobox = await screen.findByRole( 'combobox' );
 		expect( combobox ).toBeVisible();
 		// `Blog B` is the primary site, so it should be the default value.
-		expect( ( combobox as HTMLInputElement ).value ).toContain( 'Blog B' );
+		await waitFor( () => expect( ( combobox as HTMLInputElement ).value ).toContain( 'Blog B' ) );
 	} );
 } );
 
@@ -263,8 +263,7 @@ describe( 'ComposerOverflowHandoff — Move to editor click', () => {
 		const button = await screen.findByRole( 'button', { name: /Move to editor/i } );
 		await user.click( button );
 
-		// Wait for the request to settle.
-		await new Promise( ( r ) => setTimeout( r, 100 ) );
+		await waitFor( () => expect( nock.isDone() ).toBe( true ) );
 		expect( assignSpy ).not.toHaveBeenCalled();
 	} );
 } );

--- a/client/reader/social/composer/test/composer-overflow-handoff.test.tsx
+++ b/client/reader/social/composer/test/composer-overflow-handoff.test.tsx
@@ -4,6 +4,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, render, screen } from '@testing-library/react';
 import nock from 'nock';
+import { useEffect } from 'react';
 import { ComposerOverflowHandoff } from '../composer-overflow-handoff';
 import { ComposerProvider, useComposer } from '../composer-provider';
 import { testComposerConfig } from '../test-config';
@@ -19,9 +20,13 @@ function renderWithComposer( ui: ReactNode, { withMode = false } = {} ) {
 
 	function Inner() {
 		const composer = useComposer();
-		if ( withMode && ! composer.mode ) {
-			composer.openComposer( { kind: 'standalone', entry_point: 'fab' } );
-		}
+		useEffect( () => {
+			if ( withMode && ! composer.mode ) {
+				composer.openComposer( { kind: 'standalone', entry_point: 'fab' } );
+			}
+			// Only run on mount; subsequent re-renders are not the trigger we want.
+			// eslint-disable-next-line react-hooks/exhaustive-deps
+		}, [] );
 		return <>{ ui }</>;
 	}
 
@@ -72,5 +77,39 @@ describe( 'ComposerOverflowHandoff — null branches', () => {
 		// Wait a tick for the query to resolve, then assert nothing rendered.
 		await new Promise( ( r ) => setTimeout( r, 0 ) );
 		expect( screen.queryByRole( 'region', { name: /publish on your own site/i } ) ).toBeNull();
+	} );
+} );
+
+describe( 'ComposerOverflowHandoff — single site', () => {
+	it( 'shows a static label and primary button when the user has exactly one site', async () => {
+		mockSitesQuery( [
+			{
+				ID: 100,
+				name: 'My Blog',
+				slug: 'myblog.wordpress.com',
+				URL: 'https://myblog.wordpress.com',
+				options: { admin_url: 'https://myblog.wordpress.com/wp-admin/' },
+			} as Partial< Site >,
+		] );
+
+		let composer: ReturnType< typeof useComposer > | null = null;
+		function Probe() {
+			composer = useComposer();
+			return null;
+		}
+
+		renderWithComposer(
+			<>
+				<Probe />
+				<ComposerOverflowHandoff text="hi" />
+			</>,
+			{ withMode: true }
+		);
+
+		act( () => composer!.markOverLimit() );
+
+		expect( await screen.findByText( /Publish on My Blog/i ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: /Move to editor/i } ) ).toBeVisible();
+		expect( screen.queryByRole( 'combobox' ) ).toBeNull();
 	} );
 } );

--- a/client/reader/social/composer/test/composer-overflow-handoff.test.tsx
+++ b/client/reader/social/composer/test/composer-overflow-handoff.test.tsx
@@ -268,3 +268,69 @@ describe( 'ComposerOverflowHandoff — Move to editor click', () => {
 		expect( assignSpy ).not.toHaveBeenCalled();
 	} );
 } );
+
+describe( 'ComposerOverflowHandoff — picker disabled during mutation', () => {
+	it( 'disables the combobox while the draft is saving', async () => {
+		const user = userEvent.setup();
+		mockSitesQuery( [
+			{
+				ID: 100,
+				name: 'A',
+				slug: 'a.wordpress.com',
+				URL: 'https://a.wordpress.com',
+				site_migration: { in_progress: false, is_complete: false },
+				options: { admin_url: 'https://a.wordpress.com/wp-admin/' },
+			} as Partial< Site >,
+			{
+				ID: 200,
+				name: 'B',
+				slug: 'b.wordpress.com',
+				URL: 'https://b.wordpress.com',
+				site_migration: { in_progress: false, is_complete: false },
+				options: { admin_url: 'https://b.wordpress.com/wp-admin/' },
+			} as Partial< Site >,
+		] );
+		nock( ORIGIN )
+			.get( /\/rest\/v1\.\d+\/me\/settings/ )
+			.reply( 200, { primary_site_ID: 100 } );
+		nock( ORIGIN )
+			.post( /\/rest\/v1\.\d+\/sites\/100\/posts\/new/ )
+			.delay( 200 )
+			.reply( 200, { ID: 9, site_ID: 100, URL: 'https://a.wordpress.com/?p=9' } );
+
+		let composer: ReturnType< typeof useComposer > | null = null;
+		function Probe() {
+			composer = useComposer();
+			return null;
+		}
+
+		const originalLocation = window.location;
+		Object.defineProperty( window, 'location', {
+			value: { ...originalLocation, assign: jest.fn() },
+			writable: true,
+		} );
+
+		try {
+			renderWithComposer(
+				<>
+					<Probe />
+					<ComposerOverflowHandoff text="hi" />
+				</>,
+				{ withMode: true }
+			);
+
+			act( () => composer!.markOverLimit() );
+
+			const combobox = await screen.findByRole( 'combobox' );
+			const button = await screen.findByRole( 'button', { name: /Move to editor/i } );
+			await user.click( button );
+
+			expect( combobox ).toBeDisabled();
+		} finally {
+			Object.defineProperty( window, 'location', {
+				value: originalLocation,
+				writable: true,
+			} );
+		}
+	} );
+} );

--- a/client/reader/social/composer/test/composer-overflow-handoff.test.tsx
+++ b/client/reader/social/composer/test/composer-overflow-handoff.test.tsx
@@ -1,10 +1,12 @@
 /**
  * @jest-environment jsdom
  */
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { act, render, screen } from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import { act, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { useEffect } from 'react';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { ComposerOverflowHandoff } from '../composer-overflow-handoff';
 import { ComposerProvider, useComposer } from '../composer-provider';
 import { testComposerConfig } from '../test-config';
@@ -30,12 +32,11 @@ function renderWithComposer( ui: ReactNode, { withMode = false } = {} ) {
 		return <>{ ui }</>;
 	}
 
-	return render(
-		<QueryClientProvider client={ queryClient }>
-			<ComposerProvider connectionId={ 1 } config={ testComposerConfig }>
-				<Inner />
-			</ComposerProvider>
-		</QueryClientProvider>
+	return renderWithProvider(
+		<ComposerProvider connectionId={ 1 } config={ testComposerConfig }>
+			<Inner />
+		</ComposerProvider>,
+		{ queryClient }
 	);
 }
 
@@ -159,5 +160,111 @@ describe( 'ComposerOverflowHandoff — multi-site picker', () => {
 		expect( combobox ).toBeVisible();
 		// `Blog B` is the primary site, so it should be the default value.
 		expect( ( combobox as HTMLInputElement ).value ).toContain( 'Blog B' );
+	} );
+} );
+
+describe( 'ComposerOverflowHandoff — Move to editor click', () => {
+	let originalLocation: Location;
+	let assignSpy: jest.Mock;
+
+	beforeEach( () => {
+		originalLocation = window.location;
+		assignSpy = jest.fn();
+		Object.defineProperty( window, 'location', {
+			configurable: true,
+			value: { assign: assignSpy },
+			writable: true,
+		} );
+	} );
+
+	afterEach( () => {
+		Object.defineProperty( window, 'location', {
+			configurable: true,
+			value: originalLocation,
+			writable: true,
+		} );
+	} );
+
+	it( 'creates a draft post and navigates to wp-admin on success', async () => {
+		const user = userEvent.setup();
+		mockSitesQuery( [
+			{
+				ID: 100,
+				name: 'My Blog',
+				slug: 'myblog.wordpress.com',
+				URL: 'https://myblog.wordpress.com',
+				site_migration: { in_progress: false, is_complete: false },
+				options: { admin_url: 'https://myblog.wordpress.com/wp-admin/' },
+			} as Partial< Site >,
+		] );
+
+		nock( ORIGIN )
+			.post( /\/rest\/v1\.\d+\/sites\/100\/posts\/new/ )
+			.reply( 200, { ID: 555, site_ID: 100, URL: 'https://myblog.wordpress.com/?p=555' } );
+
+		let composer: ReturnType< typeof useComposer > | null = null;
+		function Probe() {
+			composer = useComposer();
+			return null;
+		}
+
+		renderWithComposer(
+			<>
+				<Probe />
+				<ComposerOverflowHandoff text="my long draft" />
+			</>,
+			{ withMode: true }
+		);
+
+		act( () => composer!.markOverLimit() );
+
+		const button = await screen.findByRole( 'button', { name: /Move to editor/i } );
+		await user.click( button );
+
+		await waitFor( () =>
+			expect( assignSpy ).toHaveBeenCalledWith(
+				'https://myblog.wordpress.com/wp-admin/post.php?post=555&action=edit'
+			)
+		);
+	} );
+
+	it( 'fires an error notice and does not redirect on mutation failure', async () => {
+		const user = userEvent.setup();
+		mockSitesQuery( [
+			{
+				ID: 100,
+				name: 'My Blog',
+				slug: 'myblog.wordpress.com',
+				URL: 'https://myblog.wordpress.com',
+				site_migration: { in_progress: false, is_complete: false },
+				options: { admin_url: 'https://myblog.wordpress.com/wp-admin/' },
+			} as Partial< Site >,
+		] );
+		nock( ORIGIN )
+			.post( /\/rest\/v1\.\d+\/sites\/100\/posts\/new/ )
+			.reply( 500, { error: 'oops' } );
+
+		let composer: ReturnType< typeof useComposer > | null = null;
+		function Probe() {
+			composer = useComposer();
+			return null;
+		}
+
+		renderWithComposer(
+			<>
+				<Probe />
+				<ComposerOverflowHandoff text="my long draft" />
+			</>,
+			{ withMode: true }
+		);
+
+		act( () => composer!.markOverLimit() );
+
+		const button = await screen.findByRole( 'button', { name: /Move to editor/i } );
+		await user.click( button );
+
+		// Wait for the request to settle.
+		await new Promise( ( r ) => setTimeout( r, 100 ) );
+		expect( assignSpy ).not.toHaveBeenCalled();
 	} );
 } );

--- a/client/reader/social/composer/test/composer-overflow-handoff.test.tsx
+++ b/client/reader/social/composer/test/composer-overflow-handoff.test.tsx
@@ -13,6 +13,8 @@ import { testComposerConfig } from '../test-config';
 import type { Site } from '@automattic/api-core';
 import type { ReactNode } from 'react';
 
+jest.mock( 'calypso/lib/logstash', () => ( { logToLogstash: jest.fn() } ) );
+
 const ORIGIN = 'https://public-api.wordpress.com';
 
 function renderWithComposer( ui: ReactNode, { withMode = false } = {} ) {
@@ -78,6 +80,38 @@ describe( 'ComposerOverflowHandoff — null branches', () => {
 		// Wait a tick for the query to resolve, then assert nothing rendered.
 		await new Promise( ( r ) => setTimeout( r, 0 ) );
 		expect( screen.queryByRole( 'region', { name: /publish on your own site/i } ) ).toBeNull();
+	} );
+} );
+
+describe( 'ComposerOverflowHandoff — protocol label in copy', () => {
+	it( 'interpolates config.protocolLabel into the section description', async () => {
+		mockSitesQuery( [
+			{
+				ID: 100,
+				name: 'My Blog',
+				slug: 'myblog.wordpress.com',
+				URL: 'https://myblog.wordpress.com',
+				options: { admin_url: 'https://myblog.wordpress.com/wp-admin/' },
+			} as Partial< Site >,
+		] );
+
+		let composer: ReturnType< typeof useComposer > | null = null;
+		function Probe() {
+			composer = useComposer();
+			return null;
+		}
+
+		renderWithComposer(
+			<>
+				<Probe />
+				<ComposerOverflowHandoff text="hi" />
+			</>,
+			{ withMode: true }
+		);
+
+		act( () => composer!.markOverLimit() );
+
+		expect( await screen.findByText( /Too long for TestProtocol\?/i ) ).toBeVisible();
 	} );
 } );
 

--- a/client/reader/social/composer/test/composer-overflow-handoff.test.tsx
+++ b/client/reader/social/composer/test/composer-overflow-handoff.test.tsx
@@ -198,28 +198,17 @@ describe( 'ComposerOverflowHandoff — multi-site picker', () => {
 } );
 
 describe( 'ComposerOverflowHandoff — Move to editor click', () => {
-	let originalLocation: Location;
-	let assignSpy: jest.Mock;
+	let openSpy: jest.SpyInstance;
 
 	beforeEach( () => {
-		originalLocation = window.location;
-		assignSpy = jest.fn();
-		Object.defineProperty( window, 'location', {
-			configurable: true,
-			value: { assign: assignSpy },
-			writable: true,
-		} );
+		openSpy = jest.spyOn( window, 'open' ).mockImplementation( () => null );
 	} );
 
 	afterEach( () => {
-		Object.defineProperty( window, 'location', {
-			configurable: true,
-			value: originalLocation,
-			writable: true,
-		} );
+		openSpy.mockRestore();
 	} );
 
-	it( 'creates a draft post and navigates to wp-admin on success', async () => {
+	it( 'creates a draft post and opens wp-admin in a new tab on success', async () => {
 		const user = userEvent.setup();
 		mockSitesQuery( [
 			{
@@ -256,8 +245,10 @@ describe( 'ComposerOverflowHandoff — Move to editor click', () => {
 		await user.click( button );
 
 		await waitFor( () =>
-			expect( assignSpy ).toHaveBeenCalledWith(
-				'https://myblog.wordpress.com/wp-admin/post.php?post=555&action=edit'
+			expect( openSpy ).toHaveBeenCalledWith(
+				'https://myblog.wordpress.com/wp-admin/post.php?post=555&action=edit',
+				'_blank',
+				'noopener,noreferrer'
 			)
 		);
 	} );
@@ -298,7 +289,7 @@ describe( 'ComposerOverflowHandoff — Move to editor click', () => {
 		await user.click( button );
 
 		await waitFor( () => expect( nock.isDone() ).toBe( true ) );
-		expect( assignSpy ).not.toHaveBeenCalled();
+		expect( openSpy ).not.toHaveBeenCalled();
 	} );
 } );
 
@@ -337,11 +328,7 @@ describe( 'ComposerOverflowHandoff — picker disabled during mutation', () => {
 			return null;
 		}
 
-		const originalLocation = window.location;
-		Object.defineProperty( window, 'location', {
-			value: { ...originalLocation, assign: jest.fn() },
-			writable: true,
-		} );
+		const openSpy = jest.spyOn( window, 'open' ).mockImplementation( () => null );
 
 		try {
 			renderWithComposer(
@@ -360,10 +347,7 @@ describe( 'ComposerOverflowHandoff — picker disabled during mutation', () => {
 
 			expect( combobox ).toBeDisabled();
 		} finally {
-			Object.defineProperty( window, 'location', {
-				value: originalLocation,
-				writable: true,
-			} );
+			openSpy.mockRestore();
 		}
 	} );
 } );

--- a/client/reader/social/composer/test/composer-provider.test.tsx
+++ b/client/reader/social/composer/test/composer-provider.test.tsx
@@ -164,3 +164,37 @@ describe( '<ComposerProvider>', () => {
 		expect( trigger ).toHaveFocus();
 	} );
 } );
+
+function wrapperHasBeenOverLimit( { children }: { children: ReactNode } ) {
+	return (
+		<ComposerProvider connectionId={ 1 } config={ testComposerConfig }>
+			{ children }
+		</ComposerProvider>
+	);
+}
+
+describe( 'ComposerProvider — hasBeenOverLimit', () => {
+	it( 'defaults to false', () => {
+		const { result } = renderHook( () => useComposer(), { wrapper: wrapperHasBeenOverLimit } );
+		expect( result.current.hasBeenOverLimit ).toBe( false );
+	} );
+
+	it( 'flips to true when markOverLimit() runs and is idempotent', () => {
+		const { result } = renderHook( () => useComposer(), { wrapper: wrapperHasBeenOverLimit } );
+		act( () => result.current.markOverLimit() );
+		expect( result.current.hasBeenOverLimit ).toBe( true );
+		act( () => result.current.markOverLimit() );
+		expect( result.current.hasBeenOverLimit ).toBe( true );
+	} );
+
+	it( 'resets to false each time the modal opens (mode flips from null to a value)', () => {
+		const { result } = renderHook( () => useComposer(), { wrapper: wrapperHasBeenOverLimit } );
+		act( () => result.current.openComposer( { kind: 'standalone', entry_point: 'fab' } ) );
+		act( () => result.current.markOverLimit() );
+		expect( result.current.hasBeenOverLimit ).toBe( true );
+		act( () => result.current.closeComposer() );
+		// Closing leaves the flag alone; the reset fires on next open.
+		act( () => result.current.openComposer( { kind: 'standalone', entry_point: 'fab' } ) );
+		expect( result.current.hasBeenOverLimit ).toBe( false );
+	} );
+} );

--- a/client/reader/social/composer/use-save-draft-mutation.ts
+++ b/client/reader/social/composer/use-save-draft-mutation.ts
@@ -1,0 +1,21 @@
+import { mutationOptions } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+
+interface SaveDraftMutationVariables {
+	siteId: number;
+	content: string;
+}
+
+interface SaveDraftMutationResult {
+	ID: number;
+	site_ID: number;
+	URL: string;
+}
+
+export function saveDraftMutation() {
+	return mutationOptions< SaveDraftMutationResult, Error, SaveDraftMutationVariables >( {
+		mutationKey: [ 'reader-social-composer-overflow', 'save-draft' ],
+		mutationFn: ( { siteId, content } ) =>
+			wpcom.site( siteId ).post().add( { content, status: 'draft' } ),
+	} );
+}

--- a/client/reader/social/composer/use-save-draft-mutation.ts
+++ b/client/reader/social/composer/use-save-draft-mutation.ts
@@ -1,12 +1,12 @@
 import { mutationOptions } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 
-interface SaveDraftMutationVariables {
+export interface SaveDraftMutationVariables {
 	siteId: number;
 	content: string;
 }
 
-interface SaveDraftMutationResult {
+export interface SaveDraftMutationResult {
 	ID: number;
 	site_ID: number;
 	URL: string;

--- a/client/reader/social/composer/use-save-draft-mutation.ts
+++ b/client/reader/social/composer/use-save-draft-mutation.ts
@@ -8,8 +8,6 @@ export interface SaveDraftMutationVariables {
 
 export interface SaveDraftMutationResult {
 	ID: number;
-	site_ID: number;
-	URL: string;
 }
 
 export function saveDraftMutation() {


### PR DESCRIPTION
Fixes CM-688

## Proposed Changes

* New `<ComposerOverflowHandoff />` section that appears at the bottom of the Reader Social composer modal (Mastodon and ATmosphere/Bluesky) once the user types past the per-protocol character limit. The section is sticky for the modal session and lets the user pick one of their WordPress.com sites and hand off the current draft to that site's `wp-admin` post editor.
* Single-site users see a static "Publish on `<site>`" label + primary button; multi-site users get a `DataForm` + Dashboard's `PreferencesLoginSiteDropdown` defaulted to their primary site.
* Click the primary button → creates a real WP draft via `wpcom.site().post().add({ status: 'draft' })` → redirects to `${admin_url}post.php?post=<ID>&action=edit` (same draft-then-redirect pattern Quick Post uses).
* Picker is disabled while the mutation is in flight; mutation failures dispatch an `errorNotice` and keep the modal mounted with the text intact.
* `ComposerContext` gains `hasBeenOverLimit` / `markOverLimit` (sticky-once flag, reset per modal open). `ComposerConfig` gains `protocolLabel: string` for the user-facing "Too long for X?" copy.

## Why are these changes being made?

* When a user has more to say than 300 (Bluesky) or 500 (Mastodon) characters allow, the current modal just disables the Post button. This nudges them toward an alternative they already have — drafting a longer post on their own site — instead of forcing them to either trim the text or abandon the draft.
* Reuses existing infrastructure: TanStack Query for the sites lookup, the Dashboard's existing site dropdown component, and the same `wp-admin` handoff pattern Quick Post already uses for "Edit in full editor".

## Testing Instructions

* In the Reader, open a Mastodon or ATmosphere composer (timeline pill / FAB / reply / quote).
* Type past the character limit. The "Publish on your own site" section fades in below the text/error region.
* Trim the text back under the limit — the section stays visible (sticky for the session).
* If you have one site: confirm the static "Publish on `<site>`" label appears with a "Move to editor" button.
* If you have multiple sites: confirm the picker defaults to your primary site; pick a different site and click "Move to editor"; confirm you land on `${admin_url}post.php?post=<ID>&action=edit` with the draft prefilled in the post body.
* Force a mutation failure (e.g., disconnect the network) → confirm the modal stays open, the error notice fires, and the picker becomes interactive again.
* Close and reopen the composer without crossing the limit — the section should not appear.

Automated tests:

```
yarn test-client client/reader/social/composer
```

11 suites, 77 tests, all passing.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?