### PR TITLE
Revert "Theme Showcase: SSR modern logged-out cards; stabilize e2e theme-signup tests"

### DIFF
--- a/client/my-sites/themes/controller.jsx
+++ b/client/my-sites/themes/controller.jsx
@@ -1,22 +1,14 @@
-import { isEnabled } from '@automattic/calypso-config';
 import debugFactory from 'debug';
 import { logServerEvent } from 'calypso/lib/analytics/statsd-utils';
 import trackScrollPage from 'calypso/lib/track-scroll-page';
 import wpcom from 'calypso/lib/wp';
 import performanceMark from 'calypso/server/lib/performance-mark';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { THEME_FILTERS_ADD } from 'calypso/state/themes/action-types';
 import { requestThemes } from 'calypso/state/themes/actions';
 import { DEFAULT_THEME_QUERY } from 'calypso/state/themes/constants';
 import { getThemeFilters, getThemesForQuery } from 'calypso/state/themes/selectors';
 import { getAnalyticsData } from './helpers';
 import LoggedOutComponent from './logged-out';
-import {
-	FAVORITES_QUERY,
-	FRESH_QUERY,
-	PARTNER_QUERY,
-} from './sections-modern/recommended-sections';
-import { buildThemesSelectionQuery } from './themes-selection';
 
 const debug = debugFactory( 'calypso:themes' );
 
@@ -87,57 +79,6 @@ export function fetchThemeData( context, next ) {
 	context.store
 		.dispatch( requestThemes( siteId, query, context.lang ) )
 		.then( next )
-		.catch( next );
-}
-
-// SSR pre-fetch for the modern logged-out showcase. Without this, cards only appear
-// after the client-side fetch resolves; the legacy fetchThemeData uses a different
-// query shape than what the modern components read, so its result is unused here.
-export function fetchModernShowcaseData( context, next ) {
-	if ( context.cachedMarkup ) {
-		debug( 'Skipping modern showcase data fetch (cached markup)' );
-		return next();
-	}
-
-	if (
-		! context.isServerSide ||
-		! isEnabled( 'themes/showcase-modern' ) ||
-		isUserLoggedIn( context.store.getState() )
-	) {
-		return next();
-	}
-
-	performanceMark( context, 'fetchModernShowcaseData' );
-
-	const { category, tier, filter, vertical, view } = context.params;
-	const search = context.query.s;
-	const isShowcaseRoot = ! category && ! tier && ! filter && ! vertical && ! view && ! search;
-
-	const queries = isShowcaseRoot
-		? [ FAVORITES_QUERY, FRESH_QUERY, PARTNER_QUERY ]
-		: [
-				buildThemesSelectionQuery( {
-					search: search || '',
-					page: 1,
-					tier: tier || '',
-					filter: filter || '',
-					vertical: vertical || '',
-					tabFilter: category || 'recommended',
-				} ),
-		  ];
-
-	return Promise.all(
-		queries.map( ( query ) =>
-			context.store.dispatch( requestThemes( 'wpcom', query, context.lang ) )
-		)
-	)
-		.then( () => {
-			logServerEvent( 'themes', {
-				name: `ssr.modern_showcase_fetch.${ isShowcaseRoot ? 'root' : 'tier' }`,
-				type: 'counting',
-			} );
-			next();
-		} )
 		.catch( next );
 }
 

--- a/client/my-sites/themes/index.node.js
+++ b/client/my-sites/themes/index.node.js
@@ -3,7 +3,6 @@ import { makeLayout, ssrSetupLocale } from 'calypso/controller';
 import { setHrefLangLinks, setLocalizedCanonicalUrl } from 'calypso/controller/localized-links';
 import { setupPreferences } from 'calypso/controller/preferences';
 import {
-	fetchModernShowcaseData,
 	fetchThemeData,
 	fetchThemeFilters,
 	redirectSearchAndType,
@@ -40,7 +39,6 @@ export default function ( router ) {
 		validateVertical,
 		validateFilters,
 		fetchThemeData,
-		fetchModernShowcaseData,
 		setHrefLangLinks,
 		setLocalizedCanonicalUrl,
 		renderThemes,
@@ -66,12 +64,5 @@ export default function ( router ) {
 			redirectToThemeDetails( res.redirect, site, theme, section, next )
 	);
 	// The following route definition is needed so direct hits on `/themes/<mysite>` don't result in a 404.
-	router(
-		'/themes/*',
-		setupPreferences,
-		fetchThemeData,
-		fetchModernShowcaseData,
-		renderThemes,
-		makeLayout
-	);
+	router( '/themes/*', setupPreferences, fetchThemeData, renderThemes, makeLayout );
 }

--- a/client/my-sites/themes/sections-modern/recommended-sections.tsx
+++ b/client/my-sites/themes/sections-modern/recommended-sections.tsx
@@ -6,7 +6,7 @@ import DIFMBanner from '../banners-modern/difm-banner';
 import PlanUpgradeBanner from '../banners-modern/plan-upgrade-banner';
 import ThemeSection from './theme-section';
 
-export const FAVORITES_QUERY: ThemesQuery = {
+const FAVORITES_QUERY: ThemesQuery = {
 	collection: 'recommended',
 	number: 6,
 	tier: '',
@@ -15,7 +15,7 @@ export const FAVORITES_QUERY: ThemesQuery = {
 	page: 1,
 };
 
-export const FRESH_QUERY: ThemesQuery = {
+const FRESH_QUERY: ThemesQuery = {
 	number: 6,
 	tier: '',
 	filter: '',
@@ -24,7 +24,7 @@ export const FRESH_QUERY: ThemesQuery = {
 	sort: 'date',
 };
 
-export const PARTNER_QUERY: ThemesQuery = {
+const PARTNER_QUERY: ThemesQuery = {
 	collection: 'recommended',
 	number: 6,
 	tier: 'marketplace',

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -315,32 +315,6 @@ function bindGetThemeTierForTheme( state ) {
 	return ( themeId ) => getThemeTierForTheme( state, themeId );
 }
 
-// Exported so SSR pre-fetch dispatches the exact query shape <ThemesSelection> reads,
-// avoiding cache-key drift between server fetch and client selector. number: 2000 for
-// non-paginating Jetpack endpoints.
-export function buildThemesSelectionQuery( {
-	search = '',
-	page = 1,
-	tier = '',
-	filter = '',
-	vertical = '',
-	hiddenFilters = [],
-	tabFilter,
-	sourceSiteId = 'wpcom',
-	premiumThemesEnabled = true,
-} = {} ) {
-	const number = ! [ 'wpcom', 'wporg' ].includes( sourceSiteId ) ? 2000 : 100;
-	return {
-		search,
-		page,
-		tier: premiumThemesEnabled ? tier : 'free',
-		filter: compact( [ filter, vertical ] ).concat( hiddenFilters ).join( ',' ),
-		number,
-		...( tabFilter === 'recommended' && { collection: 'recommended' } ),
-		...( tabFilter === 'all' && { sort: 'date' } ),
-	};
-}
-
 // Exporting this for use in customized themes lists (recommended-themes.jsx, etc.)
 // We do not want pagination triggered in that use of the component.
 export const ConnectedThemesSelection = connect(
@@ -359,17 +333,20 @@ export const ConnectedThemesSelection = connect(
 			sourceSiteId = siteId ? siteId : 'wpcom';
 		}
 
-		const query = buildThemesSelectionQuery( {
+		// number calculation is just a hack for Jetpack sites. Jetpack themes endpoint does not paginate the
+		// results and sends all of the themes at once. QueryManager is not expecting such behaviour
+		// and we ended up loosing all of the themes above number 20. Real solution will be pagination on
+		// Jetpack themes endpoint.
+		const number = ! [ 'wpcom', 'wporg' ].includes( sourceSiteId ) ? 2000 : 100;
+		const query = {
 			search,
 			page,
-			tier,
-			filter,
-			vertical,
-			hiddenFilters,
-			tabFilter,
-			sourceSiteId,
-			premiumThemesEnabled,
-		} );
+			tier: premiumThemesEnabled ? tier : 'free',
+			filter: compact( [ filter, vertical ] ).concat( hiddenFilters ).join( ',' ),
+			number,
+			...( tabFilter === 'recommended' && { collection: 'recommended' } ),
+			...( tabFilter === 'all' && { sort: 'date' } ),
+		};
 
 		const themes = getThemesForQueryIgnoringPage( state, sourceSiteId, query );
 

--- a/packages/calypso-e2e/src/lib/flows/lohp-theme-signup-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/lohp-theme-signup-flow.ts
@@ -50,6 +50,19 @@ export class LOHPThemeSignupFlow {
 	}
 
 	/**
+	 * Navigates to the Calypso Get Started link for the selected theme.
+	 * @returns {Promise<string>} The theme slug of the selected theme.
+	 */
+	async visitCalypsoGetStartedLinkForTheme(): Promise< string > {
+		const pageThemeDetails = new ThemesDetailPage( this.page );
+		const calypsoGetStartedLink = await pageThemeDetails.calypsoGetStartedLink();
+		const themeSlug =
+			pageThemeDetails.getThemeSlugFromCalypsoGetStartedLink( calypsoGetStartedLink );
+		await this.page.goto( calypsoGetStartedLink );
+		return themeSlug;
+	}
+
+	/**
 	 * Cancels the plan purchase during the flow.
 	 * @returns {Promise<void>}
 	 */

--- a/packages/calypso-e2e/src/lib/pages/logged-out-themes-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/logged-out-themes-page.ts
@@ -16,46 +16,12 @@ export class LoggedOutThemesPage {
 	}
 
 	/**
-	 * Clicks the "Get started" overlay button on the first theme card matching the
-	 * optional tier filter, navigating straight to the signup flow and skipping the
-	 * theme details page. Returns the theme slug parsed from the link's href.
-	 *
-	 * @param {Object} [options]
-	 * @param {string} [options.tier] - Theme tier slug (e.g. 'premium', 'free') to filter by.
-	 */
-	async selectThemeForSignup( { tier }: { tier?: string } = {} ): Promise< string > {
-		const card = (
-			tier
-				? this.page.locator( `[data-e2e-theme]:has(.theme-tier-badge--${ tier })` )
-				: this.page.locator( '[data-e2e-theme]' )
-		).first();
-		await card.waitFor( { state: 'visible', timeout: 30_000 } );
-
-		const getStartedLink = card.getByRole( 'link', { name: 'Get started' } );
-		const href = await getStartedLink.getAttribute( 'href' );
-		if ( ! href ) {
-			throw new Error( '"Get started" link is missing an href on the theme card' );
-		}
-		const themeSlug = new URL( href, this.page.url() ).searchParams.get( 'theme' );
-		if ( ! themeSlug ) {
-			throw new Error( `Theme slug not found in "Get started" href: ${ href }` );
-		}
-
-		await getStartedLink.click();
-		return themeSlug;
-	}
-
-	/**
 	 * Filters the themes by the given filter.
-	 *
-	 * Selecting a tier triggers a client-side navigation that re-renders the showcase.
-	 * Wait for cards to settle after that transition so callers can click them safely.
 	 *
 	 * @param {string} filter - The filter to apply.
 	 */
 	async filterBy( filter: string ) {
 		await this.page.getByRole( 'combobox', { name: 'View' } ).click();
 		await this.page.getByRole( 'option', { name: filter } ).click();
-		await this.firstThemeCard.waitFor( { state: 'visible', timeout: 30_000 } );
 	}
 }

--- a/test/e2e/specs/onboarding/signup__with-theme-LOHP.spec.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-LOHP.spec.ts
@@ -50,7 +50,9 @@ test.describe(
 				await flowLOHPThemeSignup.loggedOutHomePage.exploreThemesLink.click();
 
 				await flowLOHPThemeSignup.loggedOutThemesPage.filterBy( 'Free' );
-				themeSlug = await flowLOHPThemeSignup.loggedOutThemesPage.selectThemeForSignup();
+				await flowLOHPThemeSignup.loggedOutThemesPage.firstThemeCard.click();
+
+				themeSlug = await flowLOHPThemeSignup.visitCalypsoGetStartedLinkForTheme();
 			} );
 
 			await test.step( 'Then I see the "Create your account" page', async function () {

--- a/test/e2e/specs/onboarding/signup__with-theme-premium.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-premium.ts
@@ -16,8 +16,8 @@ import {
 	MeSidebarComponent,
 	NoticeComponent,
 	PurchasesPage,
+	ThemesDetailPage,
 	ThemesPage,
-	LoggedOutThemesPage,
 	cancelAtomicPurchaseFlow,
 	DomainSearchComponent,
 } from '@automattic/calypso-e2e';
@@ -60,10 +60,18 @@ describe( 'Lifecyle: Premium theme signup, onboard, launch and cancel subscripti
 			await themesPage.visitShowcase();
 		} );
 
-		it( 'Selects a Premium theme and starts signup', async function () {
-			themeSlug = await new LoggedOutThemesPage( page ).selectThemeForSignup( {
-				tier: 'premium',
-			} );
+		it( 'Selects a Premium theme', async function () {
+			await page.locator( 'div.theme-card:has(div.theme-tier-badge--premium)' ).first().click();
+		} );
+
+		it( 'Navigate to Signup page', async function () {
+			const themeDetailsPage = new ThemesDetailPage( page );
+
+			const pageMatch = new URL( page.url() ).pathname.match( 'theme/(.*)/?' );
+
+			themeSlug = pageMatch?.[ 1 ] || null;
+
+			await themeDetailsPage.pickThisDesign();
 		} );
 
 		it( 'Sign up as new user', async function () {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#110544