### PR TITLE
Dashboard Domains: gate domain management routes while registration is pending

### DIFF
--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -169,9 +169,10 @@ export const domainRoute = createRoute( {
 
 		if ( isContactVerificationSubRoute ) {
 			checkDomainContactVerificationPermissions( domain );
+		}
+
 		if ( isForwardingSubRoute || isSecuritySubRoute || isGlueRecordsSubRoute ) {
 			checkDomainNotPendingRegistration( domain );
-		}
 		}
 
 		return domain;

--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -169,18 +169,9 @@ export const domainRoute = createRoute( {
 
 		if ( isContactVerificationSubRoute ) {
 			checkDomainContactVerificationPermissions( domain );
-		}
-
-		if ( isForwardingSubRoute ) {
+		if ( isForwardingSubRoute || isSecuritySubRoute || isGlueRecordsSubRoute ) {
 			checkDomainNotPendingRegistration( domain );
 		}
-
-		if ( isSecuritySubRoute ) {
-			checkDomainNotPendingRegistration( domain );
-		}
-
-		if ( isGlueRecordsSubRoute ) {
-			checkDomainNotPendingRegistration( domain );
 		}
 
 		return domain;

--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -36,6 +36,7 @@ import {
 	checkDomainContactInfoPermissions,
 	checkDomainDnsRecordsPermissions,
 	checkDomainContactVerificationPermissions,
+	checkDomainNotPendingRegistration,
 } from '../../utils/domain-permissions';
 import { queryParamToArray } from '../../utils/url';
 import { dashboardRedirect } from './redirect';
@@ -133,6 +134,9 @@ export const domainRoute = createRoute( {
 		const isContactInfoSubRoute = location.pathname.includes( '/contact-info' );
 		const isDnsSubRoute = location.pathname.includes( '/dns' );
 		const isContactVerificationSubRoute = location.pathname.includes( '/contact-verification' );
+		const isForwardingSubRoute = location.pathname.includes( '/forwarding' );
+		const isSecuritySubRoute = location.pathname.includes( '/security' );
+		const isGlueRecordsSubRoute = location.pathname.includes( '/glue-records' );
 
 		// For generic sub-routes permissions checks,
 		// throw error and handle it with the global error boundary
@@ -165,6 +169,18 @@ export const domainRoute = createRoute( {
 
 		if ( isContactVerificationSubRoute ) {
 			checkDomainContactVerificationPermissions( domain );
+		}
+
+		if ( isForwardingSubRoute ) {
+			checkDomainNotPendingRegistration( domain );
+		}
+
+		if ( isSecuritySubRoute ) {
+			checkDomainNotPendingRegistration( domain );
+		}
+
+		if ( isGlueRecordsSubRoute ) {
+			checkDomainNotPendingRegistration( domain );
 		}
 
 		return domain;

--- a/client/dashboard/domains/domain-connection-setup/test/domain-connection-verification.test.tsx
+++ b/client/dashboard/domains/domain-connection-setup/test/domain-connection-verification.test.tsx
@@ -98,8 +98,6 @@ const createMockDomain = ( overrides?: Partial< Domain > ): Domain => ( {
 	nominet_pending_contact_verification_request: false,
 	nominet_domain_suspended: false,
 	owner: 'user',
-	is_pending_registration: false,
-	is_pending_registration_at_registry: false,
 	private_domain: false,
 	privacy_available: false,
 	points_to_wpcom: false,

--- a/client/dashboard/utils/domain-permissions.ts
+++ b/client/dashboard/utils/domain-permissions.ts
@@ -28,7 +28,12 @@ const checkNotHundredYearDomain: DomainCheckFunction = ( domain: Domain ) =>
 	! domain.is_hundred_year_domain;
 
 const checkNotPendingRegistration: DomainCheckFunction = ( domain: Domain ) =>
-	! domain.is_pending_registration && ! domain.is_pending_registration_at_registry;
+	! domain.pending_registration && ! domain.pending_registration_at_registry;
+
+const getPendingRegistrationErrorMessage = () =>
+	__(
+		'Your domain is being registered - this usually takes just a few minutes. Please check back shortly.'
+	);
 
 const checkNotAftermarketAuction: DomainCheckFunction = ( domain: Domain ) =>
 	! domain.aftermarket_auction;
@@ -119,10 +124,7 @@ const DOMAIN_PERMISSION_CHECKS = {
 		},
 		{
 			check: checkNotPendingRegistration,
-			getErrorMessage: () =>
-				__(
-					'We are still setting up your domain. You will not be able to transfer it until the registration setup is done.'
-				),
+			getErrorMessage: getPendingRegistrationErrorMessage,
 		},
 		{
 			check: checkNotAftermarketAuction,
@@ -142,6 +144,10 @@ const DOMAIN_PERMISSION_CHECKS = {
 	],
 	[ PermissionCheck.NAME_SERVERS ]: [
 		{
+			check: checkNotPendingRegistration,
+			getErrorMessage: getPendingRegistrationErrorMessage,
+		},
+		{
 			check: checkCanManageNameServers,
 			getErrorMessage: ( domain: Domain ) =>
 				domain.cannot_manage_name_servers_reason ||
@@ -150,6 +156,10 @@ const DOMAIN_PERMISSION_CHECKS = {
 	],
 	[ PermissionCheck.DNS_RECORDS ]: [
 		{
+			check: checkNotPendingRegistration,
+			getErrorMessage: getPendingRegistrationErrorMessage,
+		},
+		{
 			check: checkCanManageDnsRecords,
 			getErrorMessage: ( domain: Domain ) =>
 				domain.cannot_manage_dns_records_reason ||
@@ -157,6 +167,10 @@ const DOMAIN_PERMISSION_CHECKS = {
 		},
 	],
 	[ PermissionCheck.CONTACT_INFO ]: [
+		{
+			check: checkNotPendingRegistration,
+			getErrorMessage: getPendingRegistrationErrorMessage,
+		},
 		{
 			check: checkNotInSupportSession,
 			getErrorMessage: () =>
@@ -185,6 +199,10 @@ const DOMAIN_PERMISSION_CHECKS = {
 		},
 	],
 	[ PermissionCheck.CONTACT_VERIFICATION ]: [
+		{
+			check: checkNotPendingRegistration,
+			getErrorMessage: getPendingRegistrationErrorMessage,
+		},
 		{
 			check: checkCurrentUserIsOwner,
 			getErrorMessage: ( domain: Domain ) =>
@@ -238,4 +256,10 @@ export function checkDomainDnsRecordsPermissions( domain: Domain ): void {
 
 export function checkDomainContactVerificationPermissions( domain: Domain ): void {
 	checkDomainPermissions( domain, PermissionCheck.CONTACT_VERIFICATION );
+}
+
+export function checkDomainNotPendingRegistration( domain: Domain ): void {
+	if ( ! checkNotPendingRegistration( domain ) ) {
+		throw new DomainPermissionError( getPendingRegistrationErrorMessage() );
+	}
 }

--- a/packages/api-core/src/domain/types.ts
+++ b/packages/api-core/src/domain/types.ts
@@ -85,8 +85,6 @@ export interface Domain extends DomainSummary {
 	nominet_pending_contact_verification_request: boolean;
 	nominet_domain_suspended: boolean;
 	owner: string;
-	is_pending_registration: boolean;
-	is_pending_registration_at_registry: boolean;
 	private_domain: boolean;
 	privacy_available: boolean;
 	points_to_wpcom: boolean;


### PR DESCRIPTION
Part of #

## Proposed Changes

* Block access to domain Forwarding, Security, and Glue Records sub-routes while a domain is still pending registration, by adding a new `checkDomainNotPendingRegistration` permission check wired up in the domain router.
* Add the existing pending-registration check to the Name Servers, DNS Records, Contact Info, and Contact Verification permission groups so those screens are also gated.
* Replace the previous error copy with a friendlier message: "Your domain is being registered - this usually takes just a few minutes. Please check back shortly."
* Rename `is_pending_registration` / `is_pending_registration_at_registry` usages to `pending_registration` / `pending_registration_at_registry` to match the canonical fields already defined on the `Domain` type, and drop the duplicate type members.

## Why are these changes being made?

* While a domain is still being registered (or being created at the registry), most management surfaces in the new Dashboard cannot do anything useful — name servers, DNS records, forwarding, security, glue records, and contact info/verification all depend on a fully registered domain. Letting users land on those screens results in confusing failures or no-ops.
* The previous error copy implied the user was specifically blocked from transferring the domain, which doesn't fit the broader set of management screens we now gate. The new message reads as a transient "come back in a moment" status.
* The `Domain` type had two pairs of fields representing the same state (`is_pending_registration` vs. `pending_registration`); consolidating on the canonical names removes the duplication and the risk of the two drifting.

## Testing Instructions

* Open the new Dashboard for an account that owns a domain currently in pending registration (e.g. a freshly purchased domain whose registration hasn't completed at the registry yet).
* Navigate directly via URL to each of the following sub-routes and confirm the global error boundary is shown with the new message ("Your domain is being registered - this usually takes just a few minutes. Please check back shortly."):
  * `/forwarding`
  * `/security`
  * `/glue-records`
  * `/name-servers`
  * `/dns`
  * `/contact-info`
  * `/contact-verification`
* For a domain that is fully registered, confirm all of the above sub-routes load normally with no permission error.
* Run `yarn typecheck-client` and `yarn test-client client/dashboard/domains/domain-connection-setup` to confirm the type rename and updated mock domain factory still pass.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)