### PR TITLE
Dashboard Domains: add pending registration notice on domain overview

### DIFF
--- a/client/dashboard/domains/domain-connection-setup/test/domain-connection-verification.test.tsx
+++ b/client/dashboard/domains/domain-connection-setup/test/domain-connection-verification.test.tsx
@@ -105,6 +105,7 @@ const createMockDomain = ( overrides?: Partial< Domain > ): Domain => ( {
 	points_to_wpcom: false,
 	pending_registration: false,
 	pending_registration_at_registry: false,
+	pending_registration_at_registry_url: '',
 	pending_transfer: false,
 	renewable_until: '',
 	ssl_status: 'inactive',

--- a/client/dashboard/domains/domain-forwarding/test/notice.test.tsx
+++ b/client/dashboard/domains/domain-forwarding/test/notice.test.tsx
@@ -37,6 +37,7 @@ const getMockedDomainData = ( customProps: Partial< Domain > = {} ) => {
 		is_wpcom_staging_domain: false,
 		pending_registration: false,
 		pending_registration_at_registry: false,
+		pending_registration_at_registry_url: '',
 		pending_renewal: false,
 		pending_transfer: false,
 		points_to_wpcom: false,

--- a/client/dashboard/domains/domain-overview/index.tsx
+++ b/client/dashboard/domains/domain-overview/index.tsx
@@ -27,6 +27,7 @@ import { TLDMaintenanceNotice } from '../maintenance-notice';
 import Actions from './actions';
 import FeaturedCards from './featured-cards';
 import IcannSuspensionNotice from './icann-suspension-notice';
+import PendingRegistrationNotice from './pending-registration-notice';
 import DomainOverviewSettings from './settings';
 import TransferredDomainDetails from './transferred-domain-details';
 
@@ -126,6 +127,7 @@ export default function DomainOverview() {
 					isTldInMaintenance( domain ) && <TLDMaintenanceNotice showGoBackLink={ false } />
 				}
 			>
+				<PendingRegistrationNotice domain={ domain } />
 				{ domain.subtype.id === DomainSubtype.DOMAIN_TRANSFER && (
 					<TransferredDomainDetails domain={ domain } />
 				) }

--- a/client/dashboard/domains/domain-overview/pending-registration-notice.tsx
+++ b/client/dashboard/domains/domain-overview/pending-registration-notice.tsx
@@ -1,0 +1,47 @@
+import { Button, __experimentalText as Text } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import Notice from '../../components/notice';
+import type { Domain } from '@automattic/api-core';
+
+export default function PendingRegistrationNotice( { domain }: { domain: Domain } ) {
+	if ( domain.pending_registration_at_registry ) {
+		return (
+			<Notice
+				variant="warning"
+				title={ __( 'Domain registration in progress' ) }
+				actions={
+					domain.pending_registration_at_registry_url ? (
+						<Button
+							variant="link"
+							href={ domain.pending_registration_at_registry_url }
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							{ __( 'More info' ) }
+						</Button>
+					) : undefined
+				}
+			>
+				<Text>
+					{ __(
+						'We forwarded the domain registration request to Registro.br (.com.br registry). It may take up to 3 days for the request to be evaluated and accepted.'
+					) }
+				</Text>
+			</Notice>
+		);
+	}
+
+	if ( domain.pending_registration ) {
+		return (
+			<Notice variant="warning" title={ __( 'Domain registration in progress' ) }>
+				<Text>
+					{ __(
+						'Your domain is being registered - this usually takes just a few minutes. Please check back shortly.'
+					) }
+				</Text>
+			</Notice>
+		);
+	}
+
+	return null;
+}

--- a/client/dashboard/domains/domain-overview/test/actions.utils.test.ts
+++ b/client/dashboard/domains/domain-overview/test/actions.utils.test.ts
@@ -8,6 +8,7 @@ const createDomain = ( overrides: Partial< Domain > = {} ): Domain =>
 		is_redeemable: false,
 		pending_registration: false,
 		pending_registration_at_registry: false,
+		pending_registration_at_registry_url: '',
 		move_to_new_site_pending: false,
 		aftermarket_auction: false,
 		can_transfer_to_any_user: true,

--- a/client/dashboard/domains/domain-overview/test/settings.test.tsx
+++ b/client/dashboard/domains/domain-overview/test/settings.test.tsx
@@ -38,6 +38,7 @@ const getMockedDomainData = ( customProps: Partial< Domain > = {} ): Domain => {
 		is_wpcom_staging_domain: false,
 		pending_registration: false,
 		pending_registration_at_registry: false,
+		pending_registration_at_registry_url: '',
 		pending_renewal: false,
 		pending_transfer: false,
 		points_to_wpcom: false,

--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -443,7 +443,17 @@ export function resolveDomainStatus(
 				};
 			}
 
-			if ( isRecentlyRegistered( domain.registrationDate ) || domain.pendingRegistration ) {
+			if ( domain.pendingRegistration || domain.pendingRegistrationAtRegistry ) {
+				return {
+					statusText: translate( 'Registering' ),
+					statusClass: 'status-warning',
+					status: translate( 'Registering' ),
+					icon: 'cloud_upload',
+					listStatusWeight: 400,
+				};
+			}
+
+			if ( isRecentlyRegistered( domain.registrationDate ) ) {
 				let noticeText;
 				if ( domain.isPrimary ) {
 					noticeText = translate(

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -696,6 +696,19 @@ const Settings = ( {
 		);
 	};
 
+	const renderPendingRegistrationNotice = () => {
+		return (
+			<Notice
+				text={ translate(
+					'Your domain is being registered - this usually takes just a few minutes. Please check back shortly.'
+				) }
+				icon="info"
+				showDismiss={ false }
+				status="is-warning"
+			/>
+		);
+	};
+
 	const renderDomainGlueRecordsSection = () => {
 		// We can only create glue records for domains registered with us through KS_RAM
 		if (
@@ -740,6 +753,14 @@ const Settings = ( {
 			return (
 				<>
 					{ renderPendingRegistrationAtRegistryNotice() }
+					{ renderDetailsSection() }
+				</>
+			);
+		}
+		if ( domain.pendingRegistration ) {
+			return (
+				<>
+					{ renderPendingRegistrationNotice() }
 					{ renderDetailsSection() }
 				</>
 			);

--- a/packages/api-core/src/domain/types.ts
+++ b/packages/api-core/src/domain/types.ts
@@ -92,6 +92,7 @@ export interface Domain extends DomainSummary {
 	points_to_wpcom: boolean;
 	pending_registration: boolean;
 	pending_registration_at_registry: boolean;
+	pending_registration_at_registry_url: string;
 	pending_transfer: boolean;
 	whois_update_unmodifiable_fields: string[];
 	renewable_until: string;

--- a/packages/domains-table/src/utils/resolve-domain-status.tsx
+++ b/packages/domains-table/src/utils/resolve-domain-status.tsx
@@ -449,7 +449,17 @@ export function resolveDomainStatus(
 				};
 			}
 
-			if ( isRecentlyRegistered( domain.registrationDate ) || domain.pendingRegistration ) {
+			if ( domain.pendingRegistration || domain.pendingRegistrationAtRegistry ) {
+				return {
+					statusText: translate( 'Registering' ),
+					statusClass: 'status-warning',
+					status: translate( 'Registering' ),
+					icon: 'cloud_upload',
+					listStatusWeight: 400,
+				};
+			}
+
+			if ( isRecentlyRegistered( domain.registrationDate ) ) {
 				let noticeText;
 				if ( domain.isPrimary ) {
 					noticeText = translate(


### PR DESCRIPTION
We're working on doing the domain registrations asynchronously. There are couple of cases that we were not handling properly and this is one of them.

The notices we'll show look like this:

<img width="687" height="107" alt="Screenshot 2026-05-08 at 16 26 50" src="https://github.com/user-attachments/assets/aa7db06c-184a-4778-b472-7f0a7b266f87" />

<img width="699" height="166" alt="Screenshot 2026-05-08 at 16 26 41" src="https://github.com/user-attachments/assets/2778eeef-91e3-4c50-8ecc-6c905a8e2913" />


Part of #

## Proposed Changes

* Add a `PendingRegistrationNotice` component at the top of the dashboard's domain overview page that surfaces when a domain is in a pending-registration state.
* When `pending_registration_at_registry` is true, show the registry-specific copy reused verbatim from the classic Calypso `.com.br` notice, with an optional "More info" link to `pending_registration_at_registry_url`.
* When only `pending_registration` is true, show a generic "domain is being registered, ready in a few minutes" notice. The registry flag takes precedence.
* Extend the dashboard `Domain` type in `@automattic/api-core` with `pending_registration_at_registry_url: string` (already returned by the API and typed in the legacy data-stores / domains-table packages).

## Why are these changes being made?

* Domain management routes are already gated when registration is pending (see prior `Dashboard Domains: gate domain management routes while registration is pending`), but until now the overview page rendered with no explanation of *why* actions were unavailable.
* The notice mirrors the long-standing classic Calypso behavior in `client/my-sites/domains/domain-management/settings/index.tsx` so the user experience is consistent across the legacy and new dashboards.
* Reusing existing copy (the `.com.br` registry message and the route-gate's pending-registration message) keeps wording consistent and avoids new translation strings for ideas already present in the codebase.

## Testing Instructions

* `yarn start-dashboard`, navigate to `/domains/<domain>` and verify:
    * A domain with `pending_registration_at_registry: true` → shows the Registro.br warning notice at the top, with a "More info" link when `pending_registration_at_registry_url` is non-empty.
    * A domain with only `pending_registration: true` → shows the generic warning notice (no link).
    * A domain with both flags true → only the registry notice renders (precedence).
    * A normal domain → no notice rendered.
* `yarn lint` / `yarn typecheck-client` pass.
* `yarn test-client client/dashboard/domains/domain-overview client/dashboard/domains/domain-forwarding client/dashboard/domains/domain-connection-setup` pass.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?