### PR TITLE
Reader: more welcoming Bluesky and Mastodon connect screens

### DIFF
--- a/client/reader/atmosphere/connect-form.tsx
+++ b/client/reader/atmosphere/connect-form.tsx
@@ -22,15 +22,13 @@ export function ConnectForm( { onSubmit, isSubmitting, error }: ConnectFormProps
 	const [ appPassword, setAppPassword ] = useState( '' );
 	const canSubmit = handle.trim().length > 0 && appPassword.length > 0 && ! isSubmitting;
 
-	const appPasswordHelp = (
-		<>
-			{ translate(
-				'Use a Bluesky app password rather than your main password, so you can revoke access anytime.'
-			) }{ ' ' }
-			<ExternalLink href="https://bsky.app/settings/app-passwords">
-				{ translate( 'How do I get an app password?' ) }
-			</ExternalLink>
-		</>
+	const appPasswordHelp = translate(
+		'Use a Bluesky app password rather than your main password, so you can revoke access anytime. {{a}}How do I get an app password?{{/a}}',
+		{
+			components: {
+				a: <ExternalLink children={ null } href="https://bsky.app/settings/app-passwords" />,
+			},
+		}
 	);
 
 	const handleSubmit = ( event: FormEvent< HTMLFormElement > ) => {

--- a/client/reader/atmosphere/connect-form.tsx
+++ b/client/reader/atmosphere/connect-form.tsx
@@ -78,6 +78,7 @@ export function ConnectForm( { onSubmit, isSubmitting, error }: ConnectFormProps
 								{ errorMessage( error, translate ) }
 							</p>
 						) : null }
+						{ /* Wrap so the button stays intrinsic-sized inside VStack (which stretches children by default). */ }
 						<div>
 							<Button
 								variant="primary"
@@ -113,6 +114,13 @@ function errorMessage(
 		case 'connection_not_found':
 		case 'not_found':
 		case 'bad_request':
+		// The slice 7c POST /posts wire codes shouldn't surface from the
+		// connect form (it doesn't post), but the AtmosphereError union
+		// covers the whole atmosphere surface, so list them explicitly to
+		// keep the switch exhaustive without changing the user-visible
+		// copy on this screen. The slice-8a `blob_decode_failed` kind is
+		// set client-side from `compressImage` failures and listed here
+		// for the same reason — it won't surface from the connect form.
 		case 'text_too_long':
 		case 'reply_disabled':
 		case 'quote_disabled':
@@ -121,6 +129,12 @@ function errorMessage(
 		case 'blob_decode_failed':
 			return translate( 'Something went wrong.' );
 		default:
+			// Defensive fallback if AtmosphereError widens before this
+			// switch is updated. TypeScript exhaustiveness keeps this
+			// branch unreachable today; without it, an empty-toast notice
+			// would render via `errorNotice( undefined )` for a kind we
+			// haven't classified yet. See `client/reader/AGENTS.md` —
+			// "Add a default: arm to error-message switches."
 			return translate( 'Something went wrong.' );
 	}
 }

--- a/client/reader/atmosphere/connect-form.tsx
+++ b/client/reader/atmosphere/connect-form.tsx
@@ -1,4 +1,11 @@
-import { Button, Card, CardBody, ExternalLink, TextControl } from '@wordpress/components';
+import {
+	__experimentalVStack as VStack,
+	Button,
+	Card,
+	CardBody,
+	ExternalLink,
+	TextControl,
+} from '@wordpress/components';
 import { useTranslate, type TranslateResult } from 'i18n-calypso';
 import { useState, type FormEvent } from 'react';
 import type { AtmosphereError } from '@automattic/api-core';
@@ -15,10 +22,15 @@ export function ConnectForm( { onSubmit, isSubmitting, error }: ConnectFormProps
 	const [ appPassword, setAppPassword ] = useState( '' );
 	const canSubmit = handle.trim().length > 0 && appPassword.length > 0 && ! isSubmitting;
 
-	const helpLink = (
-		<ExternalLink href="https://bsky.app/settings/app-passwords">
-			{ translate( 'How do I get an app password?' ) }
-		</ExternalLink>
+	const appPasswordHelp = (
+		<>
+			{ translate(
+				'Use a Bluesky app password rather than your main password, so you can revoke access anytime.'
+			) }{ ' ' }
+			<ExternalLink href="https://bsky.app/settings/app-passwords">
+				{ translate( 'How do I get an app password?' ) }
+			</ExternalLink>
+		</>
 	);
 
 	const handleSubmit = ( event: FormEvent< HTMLFormElement > ) => {
@@ -33,33 +45,50 @@ export function ConnectForm( { onSubmit, isSubmitting, error }: ConnectFormProps
 		<Card>
 			<CardBody>
 				<form onSubmit={ handleSubmit }>
-					<TextControl
-						label={ translate( 'Handle' ) }
-						value={ handle }
-						onChange={ setHandle }
-						placeholder="alice.bsky.social"
-						disabled={ isSubmitting }
-						__nextHasNoMarginBottom
-					/>
-					<TextControl
-						label={ translate( 'App password' ) }
-						type="password"
-						autoComplete="new-password"
-						value={ appPassword }
-						onChange={ setAppPassword }
-						placeholder="xxxx-xxxx-xxxx-xxxx"
-						help={ helpLink }
-						disabled={ isSubmitting }
-						__nextHasNoMarginBottom
-					/>
-					{ error ? (
-						<p className="atmosphere-error" role="alert">
-							{ errorMessage( error, translate ) }
+					<VStack spacing={ 4 }>
+						<p>
+							{ translate(
+								'Once connected, your Bluesky timeline appears alongside your blog feeds. You can like, repost, reply, and post directly from the Reader, with no app switching needed.'
+							) }
 						</p>
-					) : null }
-					<Button variant="primary" type="submit" disabled={ ! canSubmit } isBusy={ isSubmitting }>
-						{ translate( 'Connect' ) }
-					</Button>
+						<TextControl
+							label={ translate( 'Bluesky username' ) }
+							value={ handle }
+							onChange={ setHandle }
+							placeholder="alice.bsky.social"
+							help={ translate(
+								'Your full handle, including the domain (for example, alice.bsky.social).'
+							) }
+							disabled={ isSubmitting }
+							__nextHasNoMarginBottom
+						/>
+						<TextControl
+							label={ translate( 'App password' ) }
+							type="password"
+							autoComplete="new-password"
+							value={ appPassword }
+							onChange={ setAppPassword }
+							placeholder="xxxx-xxxx-xxxx-xxxx"
+							help={ appPasswordHelp }
+							disabled={ isSubmitting }
+							__nextHasNoMarginBottom
+						/>
+						{ error ? (
+							<p className="atmosphere-error" role="alert">
+								{ errorMessage( error, translate ) }
+							</p>
+						) : null }
+						<div>
+							<Button
+								variant="primary"
+								type="submit"
+								disabled={ ! canSubmit }
+								isBusy={ isSubmitting }
+							>
+								{ translate( 'Connect' ) }
+							</Button>
+						</div>
+					</VStack>
 				</form>
 			</CardBody>
 		</Card>
@@ -84,13 +113,6 @@ function errorMessage(
 		case 'connection_not_found':
 		case 'not_found':
 		case 'bad_request':
-		// The slice 7c POST /posts wire codes shouldn't surface from the
-		// connect form (it doesn't post), but the AtmosphereError union
-		// covers the whole atmosphere surface, so list them explicitly to
-		// keep `assertNever` exhaustive without changing the user-visible
-		// copy on this screen. The slice-8a `blob_decode_failed` kind is
-		// set client-side from `compressImage` failures and listed here
-		// for the same reason — it won't surface from the connect form.
 		case 'text_too_long':
 		case 'reply_disabled':
 		case 'quote_disabled':
@@ -99,12 +121,6 @@ function errorMessage(
 		case 'blob_decode_failed':
 			return translate( 'Something went wrong.' );
 		default:
-			// Defensive fallback if AtmosphereError widens before this
-			// switch is updated. TypeScript exhaustiveness keeps this
-			// branch unreachable today; without it, an empty-toast notice
-			// would render via `errorNotice( undefined )` for a kind we
-			// haven't classified yet. See `client/reader/AGENTS.md` —
-			// "Add a default: arm to error-message switches."
 			return translate( 'Something went wrong.' );
 	}
 }

--- a/client/reader/atmosphere/test/atmosphere-connect-view.test.tsx
+++ b/client/reader/atmosphere/test/atmosphere-connect-view.test.tsx
@@ -52,10 +52,21 @@ describe( 'AtmosphereConnectView', () => {
 		await waitFor( () => expect( page ).toHaveBeenCalledWith( '/reader/atmosphere/99/timeline' ) );
 	} );
 
-	it( 'renders the connect title with the Bluesky icon and the explanatory subtitle', () => {
+	it( 'renders the connect title with the Bluesky icon, the unified subtitle, and the prose intro above the username input', () => {
 		renderWithProvider( <AtmosphereConnectView /> );
 		expect( screen.getByRole( 'heading', { name: /Connect a Bluesky account/i } ) ).toBeVisible();
 		expect( screen.getByTestId( 'atmosphere-section-logo' ) ).toBeVisible();
 		expect( screen.getByText( /Bring your Bluesky account into the Reader\./i ) ).toBeVisible();
+		const intro = screen.getByText( /your Bluesky timeline appears alongside your blog feeds/i );
+		expect( intro ).toBeVisible();
+		const input = screen.getByLabelText( /Bluesky username/ );
+		const form = intro.closest( 'form' );
+		expect( form ).not.toBeNull();
+		// Both elements must live inside the same <form>, with the
+		// intro preceding the input in document order.
+		expect( input.closest( 'form' ) ).toBe( form );
+		expect(
+			intro.compareDocumentPosition( input ) & Node.DOCUMENT_POSITION_FOLLOWING
+		).toBeTruthy();
 	} );
 } );

--- a/client/reader/atmosphere/test/atmosphere-connect-view.test.tsx
+++ b/client/reader/atmosphere/test/atmosphere-connect-view.test.tsx
@@ -45,7 +45,7 @@ describe( 'AtmosphereConnectView', () => {
 			} );
 
 		renderWithProvider( <AtmosphereConnectView /> );
-		await user.type( screen.getByLabelText( /Handle/ ), 'alice.bsky.social' );
+		await user.type( screen.getByLabelText( /Bluesky username/ ), 'alice.bsky.social' );
 		await user.type( screen.getByLabelText( /App password/ ), 'pass-word-xxx-xxx' );
 		await user.click( screen.getByRole( 'button', { name: /Connect/ } ) );
 

--- a/client/reader/atmosphere/test/connect-form.test.tsx
+++ b/client/reader/atmosphere/test/connect-form.test.tsx
@@ -32,6 +32,11 @@ describe( 'ConnectForm', () => {
 		expect( screen.getByRole( 'button', { name: /connect/i } ) ).toBeDisabled();
 	} );
 
+	it( 'disables submit while submitting even when both fields are filled', () => {
+		render( <ConnectForm onSubmit={ jest.fn() } isSubmitting error={ null } /> );
+		expect( screen.getByRole( 'button', { name: /connect/i } ) ).toBeDisabled();
+	} );
+
 	it( 'calls onSubmit with entered values', async () => {
 		const user = userEvent.setup();
 		const onSubmit = jest.fn();

--- a/client/reader/atmosphere/test/connect-form.test.tsx
+++ b/client/reader/atmosphere/test/connect-form.test.tsx
@@ -6,7 +6,28 @@ import userEvent from '@testing-library/user-event';
 import { ConnectForm } from '../connect-form';
 
 describe( 'ConnectForm', () => {
-	it( 'disables submit while handle or app_password empty', () => {
+	it( 'renders the prose intro describing what the user gets', () => {
+		render( <ConnectForm onSubmit={ jest.fn() } isSubmitting={ false } error={ null } /> );
+		expect(
+			screen.getByText( /your Bluesky timeline appears alongside your blog feeds/i )
+		).toBeVisible();
+	} );
+
+	it( 'labels the username field as "Bluesky username" with helper text', () => {
+		render( <ConnectForm onSubmit={ jest.fn() } isSubmitting={ false } error={ null } /> );
+		expect( screen.getByLabelText( /bluesky username/i ) ).toBeVisible();
+		expect( screen.getByText( /your full handle, including the domain/i ) ).toBeVisible();
+	} );
+
+	it( 'renders the app-password helper text and external link', () => {
+		render( <ConnectForm onSubmit={ jest.fn() } isSubmitting={ false } error={ null } /> );
+		expect(
+			screen.getByText( /use a Bluesky app password rather than your main password/i )
+		).toBeVisible();
+		expect( screen.getByRole( 'link', { name: /how do I get an app password/i } ) ).toBeVisible();
+	} );
+
+	it( 'disables submit while username or app password empty', () => {
 		render( <ConnectForm onSubmit={ jest.fn() } isSubmitting={ false } error={ null } /> );
 		expect( screen.getByRole( 'button', { name: /connect/i } ) ).toBeDisabled();
 	} );
@@ -15,7 +36,7 @@ describe( 'ConnectForm', () => {
 		const user = userEvent.setup();
 		const onSubmit = jest.fn();
 		render( <ConnectForm onSubmit={ onSubmit } isSubmitting={ false } error={ null } /> );
-		await user.type( screen.getByLabelText( /handle/i ), 'alice.bsky.social' );
+		await user.type( screen.getByLabelText( /bluesky username/i ), 'alice.bsky.social' );
 		await user.type( screen.getByLabelText( /app password/i ), 'xxxx-xxxx-xxxx-xxxx' );
 		await user.click( screen.getByRole( 'button', { name: /connect/i } ) );
 		expect( onSubmit ).toHaveBeenCalledWith( {

--- a/client/reader/mastodon/connect-form.tsx
+++ b/client/reader/mastodon/connect-form.tsx
@@ -1,4 +1,10 @@
-import { Button, Card, CardBody, TextControl } from '@wordpress/components';
+import {
+	__experimentalVStack as VStack,
+	Button,
+	Card,
+	CardBody,
+	TextControl,
+} from '@wordpress/components';
 import { useTranslate, type TranslateResult } from 'i18n-calypso';
 import { useState, type FormEvent } from 'react';
 import type { MastodonError } from '@automattic/api-core';
@@ -26,28 +32,40 @@ export function ConnectForm( { onSubmit, isSubmitting, error }: ConnectFormProps
 		<Card>
 			<CardBody>
 				<form onSubmit={ handleSubmit }>
-					<p className="mastodon-connect-form__instruction">
-						{ translate( 'Enter your server’s address — we’ll hand you off to sign in there.' ) }
-					</p>
-					<TextControl
-						label={ translate( 'Instance' ) }
-						value={ instance }
-						onChange={ setInstance }
-						placeholder="mastodon.social"
-						help={ translate(
-							'The domain of the Mastodon (or compatible) server where your account lives.'
-						) }
-						disabled={ isSubmitting }
-						__nextHasNoMarginBottom
-					/>
-					{ error ? (
-						<p className="mastodon-error" role="alert">
-							{ errorMessage( error, translate ) }
+					<VStack spacing={ 4 }>
+						<p>
+							{ translate(
+								'Once connected, your Mastodon timeline appears alongside your blog feeds. You can like, boost, reply, and post directly from the Reader, with no app switching needed.'
+							) }
 						</p>
-					) : null }
-					<Button variant="primary" type="submit" disabled={ ! canSubmit } isBusy={ isSubmitting }>
-						{ translate( 'Continue' ) }
-					</Button>
+						<TextControl
+							label={ translate( 'Instance' ) }
+							value={ instance }
+							onChange={ setInstance }
+							placeholder="mastodon.social"
+							help={ translate(
+								'The domain where your account lives. We’ll hand you off to sign in there, so we never see your password.'
+							) }
+							disabled={ isSubmitting }
+							__nextHasNoMarginBottom
+						/>
+						{ error ? (
+							<p className="mastodon-error" role="alert">
+								{ errorMessage( error, translate ) }
+							</p>
+						) : null }
+						{ /* Wrap so the button stays intrinsic-sized inside VStack (which stretches children by default). */ }
+						<div>
+							<Button
+								variant="primary"
+								type="submit"
+								disabled={ ! canSubmit }
+								isBusy={ isSubmitting }
+							>
+								{ translate( 'Continue' ) }
+							</Button>
+						</div>
+					</VStack>
 				</form>
 			</CardBody>
 		</Card>

--- a/client/reader/mastodon/test/connect-form.test.tsx
+++ b/client/reader/mastodon/test/connect-form.test.tsx
@@ -15,11 +15,8 @@ describe( 'ConnectForm', () => {
 
 	it( 'renders the instance helper text describing the OAuth handoff', () => {
 		render( <ConnectForm onSubmit={ jest.fn() } isSubmitting={ false } error={ null } /> );
-		expect(
-			screen.getByText(
-				/the domain where your account lives. we’ll hand you off to sign in there, so we never see your password\./i
-			)
-		).toBeVisible();
+		expect( screen.getByText( /hand you off to sign in there/i ) ).toBeVisible();
+		expect( screen.getByText( /never see your password/i ) ).toBeVisible();
 	} );
 
 	it( 'disables submit while instance is empty', () => {

--- a/client/reader/mastodon/test/connect-form.test.tsx
+++ b/client/reader/mastodon/test/connect-form.test.tsx
@@ -13,7 +13,7 @@ describe( 'ConnectForm', () => {
 		).toBeVisible();
 	} );
 
-	it( 'renders the rewritten instance helper text', () => {
+	it( 'renders the instance helper text describing the OAuth handoff', () => {
 		render( <ConnectForm onSubmit={ jest.fn() } isSubmitting={ false } error={ null } /> );
 		expect(
 			screen.getByText(

--- a/client/reader/mastodon/test/connect-form.test.tsx
+++ b/client/reader/mastodon/test/connect-form.test.tsx
@@ -6,6 +6,22 @@ import userEvent from '@testing-library/user-event';
 import { ConnectForm } from '../connect-form';
 
 describe( 'ConnectForm', () => {
+	it( 'renders the prose intro describing what the user gets', () => {
+		render( <ConnectForm onSubmit={ jest.fn() } isSubmitting={ false } error={ null } /> );
+		expect(
+			screen.getByText( /your Mastodon timeline appears alongside your blog feeds/i )
+		).toBeVisible();
+	} );
+
+	it( 'renders the rewritten instance helper text', () => {
+		render( <ConnectForm onSubmit={ jest.fn() } isSubmitting={ false } error={ null } /> );
+		expect(
+			screen.getByText(
+				/the domain where your account lives. we’ll hand you off to sign in there, so we never see your password\./i
+			)
+		).toBeVisible();
+	} );
+
 	it( 'disables submit while instance is empty', () => {
 		render( <ConnectForm onSubmit={ jest.fn() } isSubmitting={ false } error={ null } /> );
 		expect( screen.getByRole( 'button', { name: /continue/i } ) ).toBeDisabled();

--- a/client/reader/mastodon/test/mastodon-connect-view.test.tsx
+++ b/client/reader/mastodon/test/mastodon-connect-view.test.tsx
@@ -103,20 +103,20 @@ describe( 'MastodonConnectView', () => {
 		expect( window.sessionStorage.getItem( 'reader.mastodon.oauthState' ) ).toBeNull();
 	} );
 
-	it( 'renders the connect title with the Mastodon icon, the unified subtitle, and the instance instructions above the input', () => {
+	it( 'renders the connect title with the Mastodon icon, the unified subtitle, and the prose intro above the input', () => {
 		renderWithProvider( <MastodonConnectView /> );
 		expect( screen.getByRole( 'heading', { name: /Connect a Mastodon account/i } ) ).toBeVisible();
 		expect( screen.getByTestId( 'mastodon-section-logo' ) ).toBeVisible();
 		expect( screen.getByText( /Bring your Mastodon account into the Reader\./i ) ).toBeVisible();
 		const instruction = screen.getByText(
-			/Enter your server.{1,3}s address.*we.{1,3}ll hand you off to sign in there\./i
+			/your Mastodon timeline appears alongside your blog feeds/i
 		);
 		expect( instruction ).toBeVisible();
 		const input = screen.getByLabelText( /Instance/ );
 		const form = instruction.closest( 'form' );
 		expect( form ).not.toBeNull();
 		// Both elements must live inside the same <form>, with the
-		// instruction preceding the input in document order.
+		// intro preceding the input in document order.
 		expect( input.closest( 'form' ) ).toBe( form );
 		expect(
 			instruction.compareDocumentPosition( input ) & Node.DOCUMENT_POSITION_FOLLOWING


### PR DESCRIPTION
Fixes CM-689

## Proposed Changes

* Add a prose value-prop intro inside the Bluesky and Mastodon connect form cards explaining what the user gets after connecting (timeline alongside blog feeds, like / repost or boost / reply / post without leaving the Reader).
* Rename the first Bluesky field from "Handle" to "Bluesky username" and add helper text under each field.
* Rewrite the Mastodon instance helper text to mention the OAuth handoff explicitly.
* Wrap each form's contents in a `VStack spacing={ 4 }` so the rhythm between intro, fields, error region, and submit button is consistent. Each `TextControl` keeps `__nextHasNoMarginBottom` and the VStack provides the gap.
* Remove the now-unused `mastodon-connect-form__instruction` className (no SCSS rule existed for it).

## Why are these changes being made?

The current Bluesky connect screen is sparse: it doesn't explain why connecting is useful, the "Handle" label is jargon for non-Bluesky users, the username field has no helper text, and the spacing between fields feels off because each `TextControl` opts into the new no-bottom-margin model without a replacement rhythm container. The Mastodon connect screen has the same shape and benefits from the same treatment, so both protocols are updated in parallel to keep the two flows visually and editorially consistent.

## Testing Instructions

* Visit ` /reader/atmosphere/connect`. Confirm the card opens with the prose intro, shows the "Bluesky username" label with helper text below, shows the app-password helper text with a "How do I get an app password?" external link (opens in a new tab with an external icon), and that the spacing between intro, fields, error region, and button is consistent.
* Submit a wrong username/password and verify the error renders below the password field.
* Visit ` /reader/mastodon/connect`. Confirm the card opens with the prose intro, the "Instance" field shows the rewritten helper text mentioning the OAuth handoff, and the OAuth flow still completes end-to-end.
* `yarn test-client client/reader/atmosphere client/reader/mastodon` (550 tests pass locally).
* `yarn eslint client/reader/atmosphere client/reader/mastodon` (clean).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?