### PR TITLE
Dashboard: announce dark mode support

### DIFF
--- a/client/dashboard/app-ciab/index.tsx
+++ b/client/dashboard/app-ciab/index.tsx
@@ -49,6 +49,7 @@ boot( {
 			preview: true,
 		},
 		colorScheme: false,
+		darkMode: false,
 	},
 	optIn: false,
 	components: {

--- a/client/dashboard/app-dotcom/index.tsx
+++ b/client/dashboard/app-dotcom/index.tsx
@@ -45,6 +45,7 @@ boot( {
 			preview: ! isEnabled( 'dashboard/omnibar' ),
 		},
 		colorScheme: isEnabled( 'dark-mode' ),
+		darkMode: isEnabled( 'dark-mode' ),
 	},
 	optIn: true,
 	components: {

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -53,6 +53,7 @@ export type AppConfig = {
 		startStoreRoute?: boolean;
 		siteOverview: SiteOverviewSupports;
 		colorScheme: boolean;
+		darkMode: boolean;
 	};
 	posthog?: {
 		apiKey: string;
@@ -99,6 +100,7 @@ export const APP_CONTEXT_DEFAULT_CONFIG: AppConfig = {
 			preview: false,
 		},
 		colorScheme: false,
+		darkMode: false,
 	},
 	optIn: false,
 	components: {

--- a/client/dashboard/components/dark-mode-announcement/index.tsx
+++ b/client/dashboard/components/dark-mode-announcement/index.tsx
@@ -27,9 +27,7 @@ export function useShouldShowDarkModeAnnouncement() {
 		dashboardOptIn?.value === 'forced-opt-in' ||
 		isEnabled( 'dashboard/forced-opt-in' );
 
-	return (
-		config.optIn && config.supports.colorScheme && isDashboardEnrolled && ! isDismissedPersisted
-	);
+	return config.optIn && config.supports.darkMode && isDashboardEnrolled && ! isDismissedPersisted;
 }
 
 function DarkModeAnnouncementContent( { tracksContext }: { tracksContext: string } ) {

--- a/client/dashboard/components/dark-mode-announcement/index.tsx
+++ b/client/dashboard/components/dark-mode-announcement/index.tsx
@@ -2,10 +2,13 @@ import { userPreferenceMutation, userPreferenceQuery } from '@automattic/api-que
 import { isEnabled } from '@automattic/calypso-config';
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
+import { Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useAnalytics } from '../../app/analytics';
+import { useColorScheme } from '../../app/color-scheme';
 import { useAppContext } from '../../app/context';
+import { ButtonStack } from '../button-stack';
 import ComponentViewTracker from '../component-view-tracker';
 import Notice from '../notice';
 
@@ -33,11 +36,33 @@ function DarkModeAnnouncementContent( { tracksContext }: { tracksContext: string
 	const { mutate: dismiss, isPending: isDismissing } = useMutation(
 		userPreferenceMutation( DISMISSED_PREFERENCE )
 	);
+	const { colorScheme, setColorScheme } = useColorScheme();
 	const { recordTracksEvent } = useAnalytics();
+	const isDarkModeActive = colorScheme === 'dark';
 	const handleClose = () => {
 		dismiss( new Date().toISOString() );
 		recordTracksEvent( 'calypso_dashboard_dark_mode_announcement_dismiss_click', {
 			context: tracksContext,
+		} );
+	};
+	const handleToggleDarkMode = () => {
+		if ( isDarkModeActive ) {
+			setColorScheme( 'light', {
+				onSuccess: () => {
+					recordTracksEvent( 'calypso_dashboard_dark_mode_announcement_revert_click', {
+						context: tracksContext,
+					} );
+				},
+			} );
+			return;
+		}
+
+		setColorScheme( 'dark', {
+			onSuccess: () => {
+				recordTracksEvent( 'calypso_dashboard_dark_mode_announcement_try_dark_click', {
+					context: tracksContext,
+				} );
+			},
 		} );
 	};
 
@@ -46,14 +71,32 @@ function DarkModeAnnouncementContent( { tracksContext }: { tracksContext: string
 	}
 
 	return (
-		<Notice onClose={ handleClose } variant="info">
+		<Notice
+			onClose={ handleClose }
+			variant="info"
+			actions={
+				<ButtonStack justify="flex-start">
+					<Button variant="primary" size="compact" onClick={ handleToggleDarkMode }>
+						{ isDarkModeActive ? __( 'Go back to light mode' ) : __( 'Try dark mode' ) }
+					</Button>
+					<Button
+						variant="secondary"
+						size="compact"
+						aria-label={ __( 'Dismiss dark mode announcement' ) }
+						onClick={ handleClose }
+					>
+						{ __( 'Dismiss' ) }
+					</Button>
+				</ButtonStack>
+			}
+		>
 			<ComponentViewTracker
 				eventName="calypso_dashboard_dark_mode_announcement_impression"
 				properties={ { context: tracksContext } }
 			/>
 			{ createInterpolateElement(
 				__(
-					'Dark mode support is now available in the dashboard. You can change the current appearance style from the <appearanceLink>Appearance settings</appearanceLink>.'
+					'Dark mode support is now available in the dashboard. You can change your choice (or set it to match your system) in the <appearanceLink>Appearance settings</appearanceLink>.'
 				),
 				{
 					appearanceLink: (

--- a/client/dashboard/components/dark-mode-announcement/index.tsx
+++ b/client/dashboard/components/dark-mode-announcement/index.tsx
@@ -1,0 +1,83 @@
+import { userPreferenceMutation, userPreferenceQuery } from '@automattic/api-queries';
+import { isEnabled } from '@automattic/calypso-config';
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import { Link } from '@tanstack/react-router';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useAnalytics } from '../../app/analytics';
+import { useAppContext } from '../../app/context';
+import ComponentViewTracker from '../component-view-tracker';
+import Notice from '../notice';
+
+const DISMISSED_PREFERENCE = 'hosting-dashboard-dark-mode-announcement-dismissed';
+
+export function useShouldShowDarkModeAnnouncement() {
+	const config = useAppContext();
+	const { data: dashboardOptIn } = useSuspenseQuery(
+		userPreferenceQuery( 'hosting-dashboard-opt-in' )
+	);
+	const { data: isDismissedPersisted } = useSuspenseQuery(
+		userPreferenceQuery( DISMISSED_PREFERENCE )
+	);
+	const isDashboardEnrolled =
+		dashboardOptIn?.value === 'opt-in' ||
+		dashboardOptIn?.value === 'forced-opt-in' ||
+		isEnabled( 'dashboard/forced-opt-in' );
+
+	return (
+		config.optIn && config.supports.colorScheme && isDashboardEnrolled && ! isDismissedPersisted
+	);
+}
+
+function DarkModeAnnouncementContent( { tracksContext }: { tracksContext: string } ) {
+	const { mutate: dismiss, isPending: isDismissing } = useMutation(
+		userPreferenceMutation( DISMISSED_PREFERENCE )
+	);
+	const { recordTracksEvent } = useAnalytics();
+	const handleClose = () => {
+		dismiss( new Date().toISOString() );
+		recordTracksEvent( 'calypso_dashboard_dark_mode_announcement_dismiss_click', {
+			context: tracksContext,
+		} );
+	};
+
+	if ( isDismissing ) {
+		return null;
+	}
+
+	return (
+		<Notice onClose={ handleClose } variant="info">
+			<ComponentViewTracker
+				eventName="calypso_dashboard_dark_mode_announcement_impression"
+				properties={ { context: tracksContext } }
+			/>
+			{ createInterpolateElement(
+				__(
+					'Dark mode is now available in the Hosting Dashboard. Test it from <appearanceLink>Appearance settings</appearanceLink>.'
+				),
+				{
+					appearanceLink: (
+						<Link
+							to="/me/preferences/appearance"
+							onClick={ () => {
+								recordTracksEvent( 'calypso_dashboard_dark_mode_announcement_appearance_click', {
+									context: tracksContext,
+								} );
+							} }
+						/>
+					),
+				}
+			) }
+		</Notice>
+	);
+}
+
+export function DarkModeAnnouncement( { tracksContext }: { tracksContext: string } ) {
+	const shouldShow = useShouldShowDarkModeAnnouncement();
+
+	if ( ! shouldShow ) {
+		return null;
+	}
+
+	return <DarkModeAnnouncementContent tracksContext={ tracksContext } />;
+}

--- a/client/dashboard/components/dark-mode-announcement/index.tsx
+++ b/client/dashboard/components/dark-mode-announcement/index.tsx
@@ -53,7 +53,7 @@ function DarkModeAnnouncementContent( { tracksContext }: { tracksContext: string
 			/>
 			{ createInterpolateElement(
 				__(
-					'Dark mode is now available in the Hosting Dashboard. Test it from <appearanceLink>Appearance settings</appearanceLink>.'
+					'Dark mode support is now available in the dashboard. You can change the current appearance style from the <appearanceLink>Appearance settings</appearanceLink>.'
 				),
 				{
 					appearanceLink: (

--- a/client/dashboard/components/dark-mode-announcement/test/index.test.tsx
+++ b/client/dashboard/components/dark-mode-announcement/test/index.test.tsx
@@ -82,7 +82,6 @@ beforeEach( () => {
 } );
 
 afterEach( () => {
-	nock.cleanAll();
 	mockIsEnabled.mockReturnValue( false );
 	document.documentElement.removeAttribute( 'data-theme' );
 } );
@@ -94,7 +93,7 @@ test( 'renders for an enrolled user without a saved color scheme', async () => {
 
 	expect(
 		await screen.findByText( /Dark mode support is now available in the dashboard/i )
-	).toBeInTheDocument();
+	).toBeVisible();
 	expect(
 		screen.getByText( /change your choice \(or set it to match your system\)/i )
 	).toBeVisible();
@@ -115,7 +114,7 @@ test( 'renders after the user has selected light mode', async () => {
 
 	expect(
 		await screen.findByText( /Dark mode support is now available in the dashboard/i )
-	).toBeInTheDocument();
+	).toBeVisible();
 } );
 
 test( 'switches to dark mode from the notice and can revert back', async () => {
@@ -152,7 +151,8 @@ test( 'renders after the user has selected system mode', async () => {
 
 	expect(
 		await screen.findByText( /Dark mode support is now available in the dashboard/i )
-	).toBeInTheDocument();
+	).toBeVisible();
+	expect( screen.getByRole( 'button', { name: 'Try dark mode' } ) ).toBeVisible();
 } );
 
 test( 'renders a revert action when dark mode is already active', async () => {
@@ -190,7 +190,7 @@ test( 'renders when the saved color scheme is invalid', async () => {
 
 	expect(
 		await screen.findByText( /Dark mode support is now available in the dashboard/i )
-	).toBeInTheDocument();
+	).toBeVisible();
 	expect( document.documentElement.dataset.theme ).toBe( 'light' );
 } );
 
@@ -204,7 +204,7 @@ test( 'renders for a forced opted-in user without a saved color scheme', async (
 
 	expect(
 		await screen.findByText( /Dark mode support is now available in the dashboard/i )
-	).toBeInTheDocument();
+	).toBeVisible();
 } );
 
 test( 'renders when the forced opt-in flag enrolls the user', async () => {
@@ -219,7 +219,7 @@ test( 'renders when the forced opt-in flag enrolls the user', async () => {
 
 	expect(
 		await screen.findByText( /Dark mode support is now available in the dashboard/i )
-	).toBeInTheDocument();
+	).toBeVisible();
 } );
 
 test( 'does not render when the announcement was already dismissed', async () => {

--- a/client/dashboard/components/dark-mode-announcement/test/index.test.tsx
+++ b/client/dashboard/components/dark-mode-announcement/test/index.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { queryClient, rawUserPreferencesQuery } from '@automattic/api-queries';
+import { isEnabled } from '@automattic/calypso-config';
+import '@testing-library/jest-dom';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import { DarkModeAnnouncement } from '..';
+import { ColorSchemeProvider } from '../../../app/color-scheme';
+import { AppProvider, APP_CONTEXT_DEFAULT_CONFIG } from '../../../app/context';
+import { render } from '../../../test-utils';
+
+jest.mock( '@automattic/calypso-config', () => {
+	const config = jest.fn( () => 'development' );
+	return Object.assign( config, {
+		__esModule: true,
+		default: config,
+		isEnabled: jest.fn( () => false ),
+	} );
+} );
+
+const API_BASE = 'https://public-api.wordpress.com';
+const PREFERENCES_PATH = '/rest/v1.1/me/preferences';
+const COLOR_SCHEME_PREFERENCE = 'hosting-dashboard-color-scheme';
+const DISMISSED_PREFERENCE = 'hosting-dashboard-dark-mode-announcement-dismissed';
+
+const optInPreference = {
+	value: 'opt-in',
+	updated_at: '2026-05-08T00:00:00.000Z',
+};
+const mockIsEnabled = jest.mocked( isEnabled );
+const dashboardConfig = {
+	...APP_CONTEXT_DEFAULT_CONFIG,
+	optIn: true,
+	supports: {
+		...APP_CONTEXT_DEFAULT_CONFIG.supports,
+		colorScheme: true,
+	},
+};
+
+const renderAnnouncement = ( preferences: Record< string, unknown > ) => {
+	queryClient.setQueryData( rawUserPreferencesQuery().queryKey, preferences );
+
+	return render(
+		<AppProvider config={ dashboardConfig }>
+			<ColorSchemeProvider>
+				<DarkModeAnnouncement tracksContext="sites" />
+			</ColorSchemeProvider>
+		</AppProvider>,
+		{
+			queryClient,
+		}
+	);
+};
+
+beforeEach( () => {
+	queryClient.clear();
+	queryClient.setDefaultOptions( {
+		queries: { retry: false },
+	} );
+} );
+
+afterEach( () => {
+	nock.cleanAll();
+	mockIsEnabled.mockReturnValue( false );
+	document.documentElement.removeAttribute( 'data-theme' );
+} );
+
+test( 'renders for an enrolled user without a saved color scheme', async () => {
+	renderAnnouncement( {
+		'hosting-dashboard-opt-in': optInPreference,
+	} );
+
+	expect(
+		await screen.findByText( /Dark mode is now available in the Hosting Dashboard/i )
+	).toBeInTheDocument();
+	expect( screen.getByRole( 'link', { name: 'Appearance settings' } ) ).toHaveAttribute(
+		'href',
+		'/me/preferences/appearance'
+	);
+	expect( document.documentElement.dataset.theme ).toBe( 'light' );
+} );
+
+test( 'renders after the user has selected light mode', async () => {
+	renderAnnouncement( {
+		'hosting-dashboard-opt-in': optInPreference,
+		[ COLOR_SCHEME_PREFERENCE ]: 'light',
+	} );
+
+	expect(
+		await screen.findByText( /Dark mode is now available in the Hosting Dashboard/i )
+	).toBeInTheDocument();
+} );
+
+test( 'renders after the user has selected system mode', async () => {
+	renderAnnouncement( {
+		'hosting-dashboard-opt-in': optInPreference,
+		[ COLOR_SCHEME_PREFERENCE ]: 'system',
+	} );
+
+	expect(
+		await screen.findByText( /Dark mode is now available in the Hosting Dashboard/i )
+	).toBeInTheDocument();
+} );
+
+test( 'renders when the saved color scheme is invalid', async () => {
+	renderAnnouncement( {
+		'hosting-dashboard-opt-in': optInPreference,
+		[ COLOR_SCHEME_PREFERENCE ]: 'blue',
+	} );
+
+	expect(
+		await screen.findByText( /Dark mode is now available in the Hosting Dashboard/i )
+	).toBeInTheDocument();
+	expect( document.documentElement.dataset.theme ).toBe( 'light' );
+} );
+
+test( 'renders for a forced opted-in user without a saved color scheme', async () => {
+	renderAnnouncement( {
+		'hosting-dashboard-opt-in': {
+			value: 'forced-opt-in',
+			updated_at: '2026-05-08T00:00:00.000Z',
+		},
+	} );
+
+	expect(
+		await screen.findByText( /Dark mode is now available in the Hosting Dashboard/i )
+	).toBeInTheDocument();
+} );
+
+test( 'renders when the forced opt-in flag enrolls the user', async () => {
+	mockIsEnabled.mockReturnValue( true );
+
+	renderAnnouncement( {
+		'hosting-dashboard-opt-in': {
+			value: 'unset',
+			updated_at: '',
+		},
+	} );
+
+	expect(
+		await screen.findByText( /Dark mode is now available in the Hosting Dashboard/i )
+	).toBeInTheDocument();
+} );
+
+test( 'does not render when the announcement was already dismissed', async () => {
+	renderAnnouncement( {
+		'hosting-dashboard-opt-in': optInPreference,
+		[ DISMISSED_PREFERENCE ]: '2026-05-08T00:00:00.000Z',
+	} );
+
+	await waitFor( () => {
+		expect(
+			screen.queryByText( /Dark mode is now available in the Hosting Dashboard/i )
+		).not.toBeInTheDocument();
+	} );
+} );
+
+test( 'does not render when the user is not enrolled in the Hosting Dashboard', async () => {
+	renderAnnouncement( {
+		'hosting-dashboard-opt-in': {
+			value: 'opt-out',
+			updated_at: '2026-05-08T00:00:00.000Z',
+		},
+	} );
+
+	await waitFor( () => {
+		expect(
+			screen.queryByText( /Dark mode is now available in the Hosting Dashboard/i )
+		).not.toBeInTheDocument();
+	} );
+} );
+
+test( 'dismisses without saving a color-scheme preference', async () => {
+	const user = userEvent.setup();
+	const mockUpdatePreference = jest.fn();
+	nock( API_BASE )
+		.post( PREFERENCES_PATH, ( body ) => {
+			mockUpdatePreference( body );
+			expect( body.calypso_preferences ).toHaveProperty( DISMISSED_PREFERENCE );
+			expect( body.calypso_preferences ).not.toHaveProperty( COLOR_SCHEME_PREFERENCE );
+			return true;
+		} )
+		.reply( 200, {
+			calypso_preferences: {
+				[ DISMISSED_PREFERENCE ]: '2026-05-08T00:00:00.000Z',
+			},
+		} );
+
+	renderAnnouncement( {
+		'hosting-dashboard-opt-in': optInPreference,
+	} );
+
+	await user.click( await screen.findByRole( 'button', { name: 'Dismiss' } ) );
+
+	await waitFor( () => {
+		expect( mockUpdatePreference ).toHaveBeenCalledTimes( 1 );
+		expect( nock.isDone() ).toBe( true );
+		expect(
+			queryClient.getQueryData< Record< string, unknown > >( rawUserPreferencesQuery().queryKey )
+		).toHaveProperty( DISMISSED_PREFERENCE );
+		expect(
+			screen.queryByText( /Dark mode is now available in the Hosting Dashboard/i )
+		).not.toBeInTheDocument();
+	} );
+} );

--- a/client/dashboard/components/dark-mode-announcement/test/index.test.tsx
+++ b/client/dashboard/components/dark-mode-announcement/test/index.test.tsx
@@ -75,7 +75,7 @@ test( 'renders for an enrolled user without a saved color scheme', async () => {
 	} );
 
 	expect(
-		await screen.findByText( /Dark mode is now available in the Hosting Dashboard/i )
+		await screen.findByText( /Dark mode support is now available in the dashboard/i )
 	).toBeInTheDocument();
 	expect( screen.getByRole( 'link', { name: 'Appearance settings' } ) ).toHaveAttribute(
 		'href',
@@ -91,7 +91,7 @@ test( 'renders after the user has selected light mode', async () => {
 	} );
 
 	expect(
-		await screen.findByText( /Dark mode is now available in the Hosting Dashboard/i )
+		await screen.findByText( /Dark mode support is now available in the dashboard/i )
 	).toBeInTheDocument();
 } );
 
@@ -102,7 +102,7 @@ test( 'renders after the user has selected system mode', async () => {
 	} );
 
 	expect(
-		await screen.findByText( /Dark mode is now available in the Hosting Dashboard/i )
+		await screen.findByText( /Dark mode support is now available in the dashboard/i )
 	).toBeInTheDocument();
 } );
 
@@ -113,7 +113,7 @@ test( 'renders when the saved color scheme is invalid', async () => {
 	} );
 
 	expect(
-		await screen.findByText( /Dark mode is now available in the Hosting Dashboard/i )
+		await screen.findByText( /Dark mode support is now available in the dashboard/i )
 	).toBeInTheDocument();
 	expect( document.documentElement.dataset.theme ).toBe( 'light' );
 } );
@@ -127,7 +127,7 @@ test( 'renders for a forced opted-in user without a saved color scheme', async (
 	} );
 
 	expect(
-		await screen.findByText( /Dark mode is now available in the Hosting Dashboard/i )
+		await screen.findByText( /Dark mode support is now available in the dashboard/i )
 	).toBeInTheDocument();
 } );
 
@@ -142,7 +142,7 @@ test( 'renders when the forced opt-in flag enrolls the user', async () => {
 	} );
 
 	expect(
-		await screen.findByText( /Dark mode is now available in the Hosting Dashboard/i )
+		await screen.findByText( /Dark mode support is now available in the dashboard/i )
 	).toBeInTheDocument();
 } );
 
@@ -154,7 +154,7 @@ test( 'does not render when the announcement was already dismissed', async () =>
 
 	await waitFor( () => {
 		expect(
-			screen.queryByText( /Dark mode is now available in the Hosting Dashboard/i )
+			screen.queryByText( /Dark mode support is now available in the dashboard/i )
 		).not.toBeInTheDocument();
 	} );
 } );
@@ -169,7 +169,7 @@ test( 'does not render when the user is not enrolled in the Hosting Dashboard', 
 
 	await waitFor( () => {
 		expect(
-			screen.queryByText( /Dark mode is now available in the Hosting Dashboard/i )
+			screen.queryByText( /Dark mode support is now available in the dashboard/i )
 		).not.toBeInTheDocument();
 	} );
 } );
@@ -203,7 +203,7 @@ test( 'dismisses without saving a color-scheme preference', async () => {
 			queryClient.getQueryData< Record< string, unknown > >( rawUserPreferencesQuery().queryKey )
 		).toHaveProperty( DISMISSED_PREFERENCE );
 		expect(
-			screen.queryByText( /Dark mode is now available in the Hosting Dashboard/i )
+			screen.queryByText( /Dark mode support is now available in the dashboard/i )
 		).not.toBeInTheDocument();
 	} );
 } );

--- a/client/dashboard/components/dark-mode-announcement/test/index.test.tsx
+++ b/client/dashboard/components/dark-mode-announcement/test/index.test.tsx
@@ -32,6 +32,7 @@ const optInPreference = {
 	updated_at: '2026-05-08T00:00:00.000Z',
 };
 const mockIsEnabled = jest.mocked( isEnabled );
+const mockUpdatePreference = jest.fn();
 const dashboardConfig = {
 	...APP_CONTEXT_DEFAULT_CONFIG,
 	optIn: true,
@@ -56,11 +57,28 @@ const renderAnnouncement = ( preferences: Record< string, unknown > ) => {
 	);
 };
 
+function mockUpdateColorScheme( colorScheme: 'light' | 'dark' | 'system' ) {
+	return nock( API_BASE )
+		.post( PREFERENCES_PATH, ( body ) => {
+			mockUpdatePreference( body );
+			expect( body.calypso_preferences ).toMatchObject( {
+				[ COLOR_SCHEME_PREFERENCE ]: colorScheme,
+			} );
+			return true;
+		} )
+		.reply( 200, {
+			calypso_preferences: {
+				[ COLOR_SCHEME_PREFERENCE ]: colorScheme,
+			},
+		} );
+}
+
 beforeEach( () => {
 	queryClient.clear();
 	queryClient.setDefaultOptions( {
 		queries: { retry: false },
 	} );
+	mockUpdatePreference.mockClear();
 } );
 
 afterEach( () => {
@@ -77,6 +95,11 @@ test( 'renders for an enrolled user without a saved color scheme', async () => {
 	expect(
 		await screen.findByText( /Dark mode support is now available in the dashboard/i )
 	).toBeInTheDocument();
+	expect(
+		screen.getByText( /change your choice \(or set it to match your system\)/i )
+	).toBeVisible();
+	expect( screen.getByRole( 'button', { name: 'Try dark mode' } ) ).toBeVisible();
+	expect( screen.getByRole( 'button', { name: 'Dismiss dark mode announcement' } ) ).toBeVisible();
 	expect( screen.getByRole( 'link', { name: 'Appearance settings' } ) ).toHaveAttribute(
 		'href',
 		'/me/preferences/appearance'
@@ -95,6 +118,32 @@ test( 'renders after the user has selected light mode', async () => {
 	).toBeInTheDocument();
 } );
 
+test( 'switches to dark mode from the notice and can revert back', async () => {
+	const user = userEvent.setup();
+	mockUpdateColorScheme( 'dark' );
+	mockUpdateColorScheme( 'light' );
+
+	renderAnnouncement( {
+		'hosting-dashboard-opt-in': optInPreference,
+		[ COLOR_SCHEME_PREFERENCE ]: 'light',
+	} );
+
+	await user.click( await screen.findByRole( 'button', { name: 'Try dark mode' } ) );
+
+	await waitFor( () => {
+		expect( document.documentElement.dataset.theme ).toBe( 'dark' );
+		expect( screen.getByRole( 'button', { name: 'Go back to light mode' } ) ).toBeVisible();
+	} );
+
+	await user.click( screen.getByRole( 'button', { name: 'Go back to light mode' } ) );
+
+	await waitFor( () => {
+		expect( document.documentElement.dataset.theme ).toBe( 'light' );
+		expect( screen.getByRole( 'button', { name: 'Try dark mode' } ) ).toBeVisible();
+		expect( mockUpdatePreference ).toHaveBeenCalledTimes( 2 );
+	} );
+} );
+
 test( 'renders after the user has selected system mode', async () => {
 	renderAnnouncement( {
 		'hosting-dashboard-opt-in': optInPreference,
@@ -104,6 +153,33 @@ test( 'renders after the user has selected system mode', async () => {
 	expect(
 		await screen.findByText( /Dark mode support is now available in the dashboard/i )
 	).toBeInTheDocument();
+} );
+
+test( 'renders a revert action when dark mode is already active', async () => {
+	renderAnnouncement( {
+		'hosting-dashboard-opt-in': optInPreference,
+		[ COLOR_SCHEME_PREFERENCE ]: 'dark',
+	} );
+
+	expect( await screen.findByRole( 'button', { name: 'Go back to light mode' } ) ).toBeVisible();
+} );
+
+test( 'goes back to light mode from a previously active dark mode', async () => {
+	const user = userEvent.setup();
+	mockUpdateColorScheme( 'light' );
+
+	renderAnnouncement( {
+		'hosting-dashboard-opt-in': optInPreference,
+		[ COLOR_SCHEME_PREFERENCE ]: 'dark',
+	} );
+
+	await user.click( await screen.findByRole( 'button', { name: 'Go back to light mode' } ) );
+
+	await waitFor( () => {
+		expect( document.documentElement.dataset.theme ).toBe( 'light' );
+		expect( screen.getByRole( 'button', { name: 'Try dark mode' } ) ).toBeVisible();
+		expect( mockUpdatePreference ).toHaveBeenCalledTimes( 1 );
+	} );
 } );
 
 test( 'renders when the saved color scheme is invalid', async () => {
@@ -176,7 +252,6 @@ test( 'does not render when the user is not enrolled in the Hosting Dashboard', 
 
 test( 'dismisses without saving a color-scheme preference', async () => {
 	const user = userEvent.setup();
-	const mockUpdatePreference = jest.fn();
 	nock( API_BASE )
 		.post( PREFERENCES_PATH, ( body ) => {
 			mockUpdatePreference( body );
@@ -194,7 +269,9 @@ test( 'dismisses without saving a color-scheme preference', async () => {
 		'hosting-dashboard-opt-in': optInPreference,
 	} );
 
-	await user.click( await screen.findByRole( 'button', { name: 'Dismiss' } ) );
+	await user.click(
+		await screen.findByRole( 'button', { name: 'Dismiss dark mode announcement' } )
+	);
 
 	await waitFor( () => {
 		expect( mockUpdatePreference ).toHaveBeenCalledTimes( 1 );

--- a/client/dashboard/components/dark-mode-announcement/test/index.test.tsx
+++ b/client/dashboard/components/dark-mode-announcement/test/index.test.tsx
@@ -38,7 +38,7 @@ const dashboardConfig = {
 	optIn: true,
 	supports: {
 		...APP_CONTEXT_DEFAULT_CONFIG.supports,
-		colorScheme: true,
+		darkMode: true,
 	},
 };
 

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -16,8 +16,9 @@ import { useAuth } from '../app/auth';
 import { useAppContext } from '../app/context';
 import { usePersistentView } from '../app/hooks/use-persistent-view';
 import { sitesRoute } from '../app/router/sites';
+import { DarkModeAnnouncement } from '../components/dark-mode-announcement';
 import { DataViewsEmptyStateLayout } from '../components/dataviews';
-import OptInSurvey from '../components/opt-in-survey';
+import OptInSurvey, { useShouldShowOptInSurvey } from '../components/opt-in-survey';
 import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
 import { isDashboardBackport } from '../utils/is-dashboard-backport';
@@ -190,6 +191,7 @@ export default function Sites() {
 	};
 
 	const userHasSites = user.site_count > 0;
+	const shouldShowOptInSurvey = useShouldShowOptInSurvey();
 
 	const { data: filteredData, paginationInfo } = filterSortAndPaginateSites(
 		sites ?? [],
@@ -226,7 +228,12 @@ export default function Sites() {
 				notices={
 					<>
 						<SitesNotices />
-						{ ! isDashboardBackport() && <OptInSurvey /> }
+						{ ! isDashboardBackport() &&
+							( shouldShowOptInSurvey ? (
+								<OptInSurvey />
+							) : (
+								<DarkModeAnnouncement tracksContext="sites" />
+							) ) }
 					</>
 				}
 			>

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -14,6 +14,7 @@ import clsx from 'clsx';
 import { useRef } from 'react';
 import { useAppContext } from '../../app/context';
 import { PerformanceTrackerStop } from '../../app/performance-tracking';
+import { DarkModeAnnouncement } from '../../components/dark-mode-announcement';
 import { GuidedTourContextProvider, GuidedTourStep } from '../../components/guided-tour';
 import OptInSurvey, { useShouldShowOptInSurvey } from '../../components/opt-in-survey';
 import { PageHeader } from '../../components/page-header';
@@ -208,6 +209,10 @@ function SiteOverview( {
 
 		if ( ! isDashboardBackport() && shouldShowOptInSurvey ) {
 			return <OptInSurvey />;
+		}
+
+		if ( ! isDashboardBackport() ) {
+			return <DarkModeAnnouncement tracksContext="site-overview" />;
 		}
 
 		return null;

--- a/packages/api-core/src/me-preferences/types.ts
+++ b/packages/api-core/src/me-preferences/types.ts
@@ -21,6 +21,7 @@ export interface UserPreferences {
 	recentSites?: number[];
 	'hosting-dashboard-color-scheme'?: 'light' | 'dark' | 'system';
 	'hosting-dashboard-opt-in'?: HostingDashboardOptIn;
+	'hosting-dashboard-dark-mode-announcement-dismissed'?: string; // Timestamp when the user dismissed the notice
 	'hosting-dashboard-opt-in-welcome-modal-dismissed'?: string; // Timestamp when the user dismissed the modal
 	[ key: `hosting-dashboard-dataviews-view-${ string }` ]: View | undefined;
 	[ key: `hosting-dashboard-overview-storage-notice-dismissed-${ number }` ]: string | undefined; // Timestamp when the user dismissed the notice

--- a/packages/api-queries/src/me-preferences.ts
+++ b/packages/api-queries/src/me-preferences.ts
@@ -6,6 +6,7 @@ import type { UserPreferences } from '@automattic/api-core';
 const defaultValues: Required< UserPreferences > = {
 	recentSites: [],
 	'hosting-dashboard-color-scheme': 'light',
+	'hosting-dashboard-dark-mode-announcement-dismissed': '',
 	'hosting-dashboard-opt-in': { value: 'unset', updated_at: '' },
 	'hosting-dashboard-opt-in-welcome-modal-dismissed': '',
 	'hosting-dashboard-welcome-notice-dismissed': '',


### PR DESCRIPTION
## Proposed Changes
<img width="2770" height="276" alt="CleanShot 2026-05-08 at 16 04 59@2x" src="https://github.com/user-attachments/assets/41a5e230-6a39-4532-a60a-a50c9332db10" />

* Show a Hosting Dashboard notice announcing that dark mode support is available to enrolled users when the opt-in survey is not being shown.
* Let users try dark mode directly from the notice, return to light mode when already dark, or dismiss the announcement without changing their appearance preference.
* Keep the Appearance settings link in the notice so users can later choose light, dark, or system matching.

## Why are these changes being made?

Dark mode is now testable in the Hosting Dashboard, and enrolled users need a lightweight way to discover it from the dashboard itself. The notice gives users a direct path to try the new appearance mode while preserving a clear dismiss path and keeping the opt-in survey as the higher-priority notice.

## Testing Instructions

* Visit `http://my.localhost:3000/sites` with the Hosting Dashboard enabled.
* Confirm the dark mode announcement appears when the opt-in survey is not displayed.
* Use the `Try dark mode` button and confirm the dashboard switches to dark mode.
* Confirm the primary action changes to `Go back to light mode`, then use it to return to light mode.
* Repeat the same checks on a site overview page.
* Use the explicit `Dismiss` button and confirm the notice is dismissed.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

---
