### PR TITLE
Login: Align logo with Signup

### DIFF
--- a/client/login/wp-login/components/one-login-layout.tsx
+++ b/client/login/wp-login/components/one-login-layout.tsx
@@ -152,7 +152,7 @@ const OneLoginLayout = ( {
 			</nav>
 		);
 
-		return <Step.TopBar rightElement={ rightElement } compactLogo="always" logo={ topBarLogo } />;
+		return <Step.TopBar rightElement={ rightElement } logo={ topBarLogo } />;
 	};
 
 	const effectiveColumnWidth: 4 | 5 | 6 | 8 | 10 = ( columnWidth ?? 6 ) as 4 | 5 | 6 | 8 | 10;


### PR DESCRIPTION
Fixes [DSGCOM-518](https://linear.app/a8c/issue/DSGCOM-518/login-sign-up-fix-inconsistent-logo-between-login-and-create-account).

## What changed

One prop. Removed `compactLogo="always"` from the `Step.TopBar` in `client/login/wp-login/components/one-login-layout.tsx`. `logo={ topBarLogo }` is preserved so partner branding (CIAB / Woo) still applies.

## Why

Login and Signup live in the same area; users toggle between them freely, so a single brand mark should carry across both. Today they don't: `/log-in` shows the compact W icon at every breakpoint while `/start` shows the responsive WordPress.com wordmark.

The `compactLogo="always"` was added in #104439 (Connect Refresh, June 2025) and never propagated to `/start`. Removing it aligns Login to the `Step.TopBar` default — and to `/start`.

## Scope

This only affects **default WordPress.com `/log-in`**. Partner-branded routes (Woo, CIAB) pass a custom `topBarLogo` via `usePartnerBranding()`, which short-circuits the default-logo branch — so `compactLogo` was already a no-op for them. The TopBar source comment at [TopBar.tsx#L21-L22](https://github.com/Automattic/wp-calypso/blob/trunk/packages/onboarding/src/step-container-v2/components/TopBar/TopBar.tsx#L21-L22) explicitly asks to "Confirm with Design before changing functionality around this" — confirmed via DSGCOM-518.

## Before / After

|  | Before | After |
|---|---|---|
| **Login** (`/log-in`) | <img width="1024" alt="before-login" src="https://github.com/user-attachments/assets/cbc2c9f2-7319-4562-b6d1-8d5f6a679937" /> | <img width="1024" alt="Screenshot 2026-05-13 at 15 18 54" src="https://github.com/user-attachments/assets/8c7b6fa6-b3fc-4319-b7bb-8bb28a80224c" />  |
| **Signup** (`/start`) | <img width="1024" alt="before-signup" src="https://github.com/user-attachments/assets/aa2f92b5-b58c-4ffc-ae8b-37902e66bc71" /> | <img width="1024" alt="Screenshot 2026-05-13 at 15 19 04" src="https://github.com/user-attachments/assets/31cd1b8a-6c6f-46dd-83e0-af8b071c9894" /> |




## How to test

1. Run Calypso locally (`NODE_OPTIONS='--max-old-space-size=8192' yarn start`).
2. Open `http://calypso.localhost:3000/log-in` and `http://calypso.localhost:3000/start` side by side.
3. Confirm both show the **full WordPress.com wordmark** in the top bar at desktop widths.
4. Resize the window below 600px (the small breakpoint) — both should switch to the **compact WordPress icon**.
5. Partner-branding sanity check: visit a CIAB / Woo login route (e.g. `/log-in/woocommerce-core` or pass a partner `client_id`) and confirm the partner logo still appears.

## Related

- Original Connect Refresh PR that introduced \`compactLogo=\"always\"\`: #104439
- Partner branding system on Login: #108293
- Recent onboarding header work: #110133, #110314

🤖 Generated with [Claude Code](https://claude.com/claude-code)