### PR TITLE
Plans: Restore modal-backed free plan CTA

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -460,6 +460,9 @@ function UnifiedPlansStep( {
 			( paidDomainName != null || isPaidTheme ) ) ||
 		deemphasizeFreePlanFromProps;
 
+	const shouldUseModalBackedFreePlanCTA =
+		useStepContainerV2 && deemphasizeFreePlan && ( paidDomainName != null || isPaidTheme );
+
 	const getSubheaderText = () => {
 		const freePlanButton = (
 			<Button
@@ -495,6 +498,12 @@ function UnifiedPlansStep( {
 
 		if ( intent === 'plans-website-builder' ) {
 			if ( deemphasizeFreePlan ) {
+				if ( shouldUseModalBackedFreePlanCTA ) {
+					return translate(
+						'Everything you need to go from idea to one-of-a-kind site, blog, or newsletter.'
+					);
+				}
+
 				return translate(
 					'Everything you need to go from idea to one-of-a-kind site, blog, or newsletter. Or {{link}}start with our free plan{{/link}}.',
 					{ components: { link: freePlanButton } }
@@ -543,10 +552,9 @@ function UnifiedPlansStep( {
 			);
 		}
 
-		// In stepper-v2, <PlansPageSubheader>'s deemphasize branch is suppressed,
-		// so surface its "Unlock a powerful bundle…" copy here as Step.Heading subText
-		// to keep the free-plan CTA visible.
-		if ( useStepContainerV2 && deemphasizeFreePlan ) {
+		// Keep the non-modal CTA in Step.Heading. Paid-domain/theme flows use
+		// <PlansPageSubheader> so the CTA can open PlanUpsellModal first.
+		if ( useStepContainerV2 && deemphasizeFreePlan && ! shouldUseModalBackedFreePlanCTA ) {
 			return translate(
 				'Unlock a powerful bundle of features. Or {{link}}start with a free plan{{/link}}.',
 				{ components: { link: freePlanButton } }
@@ -639,6 +647,7 @@ function UnifiedPlansStep( {
 				onUpgradeClick={ handleUpgradeClick }
 				customerType={ customerType }
 				deemphasizeFreePlan={ deemphasizeFreePlan }
+				renderFreePlanCtaInStepContainerV2={ shouldUseModalBackedFreePlanCTA }
 				plansWithScroll={ isDesktop }
 				intent={ intent }
 				flowName={ flowName }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -682,6 +682,7 @@ function UnifiedPlansStep( {
 			<>
 				<MarketingMessage path="signup/plans" />
 				<Step.WideLayout
+					headingColumnWidth={ 6 }
 					className="step-container-v2--plans"
 					topBar={
 						<Step.TopBar

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -311,7 +311,7 @@ function UnifiedPlansStep( {
 
 	const siteUrl = onboardingStoreSiteUrl ?? signupDependencies.siteUrl;
 
-	const isPaidTheme = selectedThemeType && selectedThemeType !== FREE_THEME;
+	const isPaidTheme = Boolean( selectedThemeType && selectedThemeType !== FREE_THEME );
 
 	const effectiveSubmitSignupStep = useMemo(
 		() =>
@@ -682,7 +682,6 @@ function UnifiedPlansStep( {
 			<>
 				<MarketingMessage path="signup/plans" />
 				<Step.WideLayout
-					headingColumnWidth={ 6 }
 					className="step-container-v2--plans"
 					topBar={
 						<Step.TopBar

--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -237,6 +237,7 @@ const PlansPageSubheader = ( {
 	siteSlug,
 	isDisplayingPlansNeededForFeature,
 	deemphasizeFreePlan,
+	renderFreePlanCtaInStepContainerV2,
 	showPlanBenefits,
 	offeringFreePlan,
 	flowName,
@@ -248,6 +249,7 @@ const PlansPageSubheader = ( {
 	siteSlug?: string | null;
 	isDisplayingPlansNeededForFeature: boolean;
 	deemphasizeFreePlan?: boolean;
+	renderFreePlanCtaInStepContainerV2?: boolean;
 	offeringFreePlan?: boolean;
 	showPlanBenefits?: boolean;
 	flowName?: string | null;
@@ -316,7 +318,11 @@ const PlansPageSubheader = ( {
 			return null;
 		}
 
-		if ( ! isUsingStepContainerV2 && deemphasizeFreePlan && offeringFreePlan ) {
+		if (
+			( ! isUsingStepContainerV2 || renderFreePlanCtaInStepContainerV2 ) &&
+			deemphasizeFreePlan &&
+			offeringFreePlan
+		) {
 			return (
 				<Subheader { ...subheaderCommonProps }>
 					{ translate(

--- a/client/my-sites/plans-features-main/components/test/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/test/plans-page-subheader.tsx
@@ -1,0 +1,48 @@
+/** @jest-environment jsdom */
+
+import { fireEvent, screen } from '@testing-library/react';
+import React from 'react';
+import { shouldUseStepContainerV2 } from 'calypso/landing/stepper/declarative-flow/helpers/should-use-step-container-v2';
+import PlansPageSubheader from 'calypso/my-sites/plans-features-main/components/plans-page-subheader';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+
+jest.mock(
+	'calypso/landing/stepper/declarative-flow/helpers/should-use-step-container-v2',
+	() => ( {
+		shouldUseStepContainerV2: jest.fn(),
+	} )
+);
+
+const defaultProps = {
+	isDisplayingPlansNeededForFeature: false,
+	deemphasizeFreePlan: true,
+	offeringFreePlan: true,
+	flowName: 'domain',
+	onFreePlanCTAClick: jest.fn(),
+	selectedFeature: null,
+};
+
+describe( 'PlansPageSubheader', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		jest.mocked( shouldUseStepContainerV2 ).mockReturnValue( true );
+	} );
+
+	test( 'does not render the free-plan CTA in stepper-v2 by default', () => {
+		renderWithProvider( <PlansPageSubheader { ...defaultProps } /> );
+
+		expect(
+			screen.queryByRole( 'button', { name: 'start with a free plan' } )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'renders a modal-backed free-plan CTA in stepper-v2 when requested', () => {
+		renderWithProvider(
+			<PlansPageSubheader { ...defaultProps } renderFreePlanCtaInStepContainerV2 />
+		);
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'start with a free plan' } ) );
+
+		expect( defaultProps.onFreePlanCTAClick ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -188,6 +188,7 @@ export interface PlansFeaturesMainProps {
 	 * It's outside of the intent system since it is about the way the Free plan is presented, not the plan mix available to choose.
 	 */
 	deemphasizeFreePlan?: boolean;
+	renderFreePlanCtaInStepContainerV2?: boolean;
 
 	selectedThemeType?: string;
 }
@@ -233,6 +234,7 @@ const PlansFeaturesMain = ( {
 	isLaunchPage = false,
 	showLegacyStorageFeature = false,
 	deemphasizeFreePlan,
+	renderFreePlanCtaInStepContainerV2 = false,
 	isSpotlightOnCurrentPlan,
 	renderSiblingWhenLoaded,
 	showPlanTypeSelectorDropdown = false,
@@ -911,6 +913,7 @@ const PlansFeaturesMain = ( {
 					offeringFreePlan={ offeringFreePlan }
 					flowName={ flowName }
 					deemphasizeFreePlan={ deemphasizeFreePlan }
+					renderFreePlanCtaInStepContainerV2={ renderFreePlanCtaInStepContainerV2 }
 					onFreePlanCTAClick={ onFreePlanCTAClick }
 					intent={ intent }
 					showDifferentiatorHeader={ showDifferentiatorHeader }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Follow-up to #110305 — fixes a regression it introduced.

## Proposed Changes

* Add a discriminator `shouldUseModalBackedFreePlanCTA = useStepContainerV2 && deemphasizeFreePlan && (paidDomainName != null || isPaidTheme)`.
* When true: suppress the inline `start with a free plan` CTA in `Step.Heading subText` and route through `<PlansPageSubheader>` so `PlanUpsellModal` opens before checkout.
* When false (stepper-v2 + deemphasized free plan, no paid domain/theme): keep the inline-in-`Step.Heading` CTA from #110305.
* Non-stepper-v2 paths and rich subheader variants (`DifferentiatorHeader`, `PlanBenefitHeader`, `SecondaryFormattedHeader`) are untouched.
* Add a Jest unit test for the `renderFreePlanCtaInStepContainerV2` opt-in on `PlansPageSubheader`.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

#110305 collapsed the Plans step heading into a single `Step.Heading` with `subText` to match the Domains step. The change suppressed the `<Subheader>` paragraph in stepper-v2 — which, in paid-domain flows, was the host for the modal-backed `start with a free plan` CTA.

Before #110305, clicking that CTA with a paid domain in cart opened `PlanUpsellModal` to confirm the user wanted to skip the upgrade. After #110305, the inline CTA in `Step.Heading subText` selected the free plan directly and routed to checkout — bypassing the confirmation modal.

The setup-domain release E2E test (`test/e2e/specs/flows/setup-domain__flows.spec.ts`, "WITHOUT a plan upgrade") caught this by expecting the `Continue with Free` / `Continue with Free plan` modal action before checkout. The test was asserting real product behavior, not stale expectations — the modal step is an intentional safeguard.

This PR keeps the layout/copy work from #110305 while restoring the modal-backed escape hatch for the narrow case that needs it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `yarn eslint-branch`
* `yarn test-client client/my-sites/plans-features-main/components/test/plans-page-subheader.tsx`
* `yarn typecheck-packages`
* `NODE_OPTIONS=--max-old-space-size=8192 yarn typecheck-client` — verified no errors in the touched files; remaining suite errors were pre-existing/unrelated.
* `CALYPSO_BASE_URL=http://calypso.localhost:3000 yarn workspace wp-e2e-tests test:pw:desktop ./specs/flows/setup-domain__flows.spec.ts --grep "WITHOUT a plan upgrade" --reporter=list`
* `CALYPSO_BASE_URL=http://calypso.localhost:3000 yarn workspace wp-e2e-tests test:pw:mobile ./specs/flows/setup-domain__flows.spec.ts --grep "WITHOUT a plan upgrade" --reporter=list`
* Manual: at `/setup/domain/plans` with a paid TLD selected, click "start with our free plan" — `Continue with Free` / `Continue with Free plan` modal should appear before checkout. Repeat with a free TLD; the inline `Step.Heading` CTA from #110305 should still apply.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
