### PR TITLE
Reader social: link prominent timestamp to source instance

### DIFF
--- a/client/reader/social/components/post-card/post-card-timestamp.tsx
+++ b/client/reader/social/components/post-card/post-card-timestamp.tsx
@@ -1,12 +1,19 @@
 import { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
+import { useSocialAnalytics } from './analytics-context';
 
 interface PostCardTimestampProps {
-	post: { created_at: string; indexed_at: string | null };
+	post: {
+		created_at: string;
+		indexed_at: string | null;
+		permalink?: string | null;
+		uri?: string;
+	};
 }
 
 export function PostCardTimestamp( { post }: PostCardTimestampProps ) {
 	const translate = useTranslate();
+	const analytics = useSocialAnalytics();
 	const locale = getLocaleSlug() ?? undefined;
 	const timestampIso = post.created_at || post.indexed_at || '';
 
@@ -38,9 +45,39 @@ export function PostCardTimestamp( { post }: PostCardTimestampProps ) {
 		return null;
 	}
 
-	return (
+	const time = (
 		<time className="social-post-card-timestamp" dateTime={ timestampIso }>
 			{ formatted }
 		</time>
+	);
+
+	if ( ! post.permalink ) {
+		return time;
+	}
+
+	const handleClick = () => {
+		if ( ! analytics ) {
+			return;
+		}
+		// Subcomponents emit `_timeline_*`; per-protocol thread shells rewrite
+		// the prefix to `_thread_*`. The "external" segment marks this as the
+		// always-leaves-the-app variant, distinct from the inline timestamp's
+		// in-app-thread-or-fallback `_post_clicked` event.
+		analytics.onClick( `calypso_reader_${ analytics.source }_timeline_external_post_clicked`, {
+			connection_id: analytics.connectionId,
+			post_uri: post.uri ?? null,
+		} );
+	};
+
+	return (
+		<a
+			className="social-post-card-timestamp-link"
+			href={ post.permalink }
+			target="_blank"
+			rel="noopener noreferrer"
+			onClick={ handleClick }
+		>
+			{ time }
+		</a>
 	);
 }

--- a/client/reader/social/components/post-card/post-card-timestamp.tsx
+++ b/client/reader/social/components/post-card/post-card-timestamp.tsx
@@ -6,8 +6,8 @@ interface PostCardTimestampProps {
 	post: {
 		created_at: string;
 		indexed_at: string | null;
-		permalink?: string | null;
-		uri?: string;
+		permalink: string;
+		uri: string;
 	};
 }
 
@@ -65,7 +65,8 @@ export function PostCardTimestamp( { post }: PostCardTimestampProps ) {
 		// in-app-thread-or-fallback `_post_clicked` event.
 		analytics.onClick( `calypso_reader_${ analytics.source }_timeline_external_post_clicked`, {
 			connection_id: analytics.connectionId,
-			post_uri: post.uri ?? null,
+			post_uri: post.uri,
+			destination: 'external',
 		} );
 	};
 
@@ -75,6 +76,13 @@ export function PostCardTimestamp( { post }: PostCardTimestampProps ) {
 			href={ post.permalink }
 			target="_blank"
 			rel="noopener noreferrer"
+			aria-label={
+				translate( '%(timestamp)s — view original post (opens in a new tab)', {
+					args: { timestamp: formatted },
+					comment:
+						'Accessible name for the prominent timestamp link on a single social post; "%(timestamp)s" is e.g. "3:17 PM · Apr 28, 2026".',
+				} ) as string
+			}
 			onClick={ handleClick }
 		>
 			{ time }

--- a/client/reader/social/components/post-card/style.scss
+++ b/client/reader/social/components/post-card/style.scss
@@ -233,6 +233,11 @@ a.social-post-card-header__timestamp::after {
 	color: inherit;
 	text-decoration: none;
 
+	&:focus-visible {
+		outline: 2px solid var( --studio-blue-50 );
+		outline-offset: 2px;
+	}
+
 	.social-post-card-timestamp::after {
 		content: "↗";
 		display: inline-block;

--- a/client/reader/social/components/post-card/style.scss
+++ b/client/reader/social/components/post-card/style.scss
@@ -7,6 +7,7 @@
 	.social-post-card-header__reply-context-link,
 	.social-post-card-counts__link,
 	.social-post-card-counts__reply-button,
+	.social-post-card-timestamp-link,
 	.social-post-card-body a,
 	a.social-post-card-embed-external,
 	.social-post-card-embed-quote-link,
@@ -223,6 +224,34 @@ a.social-post-card-header__timestamp::after {
 		// Reuse the timestamp's bottom border as the counts row's top separator (no extra gap).
 		margin-block-start: 8px;
 	}
+}
+
+// Wrapper anchor when a permalink is available; matches the hover-reveal
+// arrow used by the Reader full-post header title link.
+.social-post-card-timestamp-link {
+	display: block;
+	color: inherit;
+	text-decoration: none;
+
+	.social-post-card-timestamp::after {
+		content: "↗";
+		display: inline-block;
+		color: var( --studio-gray-30 );
+		font-size: 0.85em;
+		margin-inline-start: 6px;
+		opacity: 0;
+		transition: opacity 0.2s ease;
+	}
+
+	&:hover .social-post-card-timestamp::after,
+	&:focus-visible .social-post-card-timestamp::after {
+		opacity: 1;
+	}
+}
+
+// Counts row sits under the link wrapper now too; preserve the no-extra-gap rule.
+.social-post-card-timestamp-link + .social-post-card-counts {
+	margin-block-start: 8px;
 }
 
 .social-post-card-counts {

--- a/client/reader/social/components/post-card/test/post-card-timestamp.test.tsx
+++ b/client/reader/social/components/post-card/test/post-card-timestamp.test.tsx
@@ -1,7 +1,9 @@
 /**
  * @jest-environment jsdom
  */
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SocialAnalyticsProvider } from '../analytics-context';
 import { PostCardTimestamp } from '../post-card-timestamp';
 
 describe( 'PostCardTimestamp', () => {
@@ -42,5 +44,77 @@ describe( 'PostCardTimestamp', () => {
 			<PostCardTimestamp post={ { created_at: 'not a date', indexed_at: '' } } />
 		);
 		expect( container.querySelector( 'time' ) ).toBeNull();
+	} );
+
+	it( 'renders a bare <time> (no anchor) when permalink is missing', () => {
+		const { container } = render(
+			<PostCardTimestamp post={ { created_at: '2026-04-28T15:17:50Z', indexed_at: '' } } />
+		);
+		expect( container.querySelector( 'a' ) ).toBeNull();
+	} );
+
+	it( 'wraps the <time> in an external anchor when permalink is provided', () => {
+		render(
+			<PostCardTimestamp
+				post={ {
+					created_at: '2026-04-28T15:17:50Z',
+					indexed_at: '',
+					permalink: 'https://bsky.app/profile/example/post/abc',
+				} }
+			/>
+		);
+		const link = screen.getByRole( 'link' );
+		expect( link ).toHaveAttribute( 'href', 'https://bsky.app/profile/example/post/abc' );
+		expect( link ).toHaveAttribute( 'target', '_blank' );
+		expect( link ).toHaveAttribute( 'rel', 'noopener noreferrer' );
+		expect( link.querySelector( 'time' ) ).not.toBeNull();
+	} );
+
+	it( 'fires the external-post-clicked Tracks event on click', async () => {
+		const user = userEvent.setup();
+		const onClick = jest.fn();
+		render(
+			<SocialAnalyticsProvider
+				value={ {
+					source: 'atmosphere',
+					connectionId: 42,
+					onClick,
+				} }
+			>
+				<PostCardTimestamp
+					post={ {
+						created_at: '2026-04-28T15:17:50Z',
+						indexed_at: '',
+						permalink: 'https://bsky.app/profile/example/post/abc',
+						uri: 'at://did:plc:example/app.bsky.feed.post/abc',
+					} }
+				/>
+			</SocialAnalyticsProvider>
+		);
+		// Prevent jsdom from following the href on click.
+		await user.click( screen.getByRole( 'link' ) );
+		expect( onClick ).toHaveBeenCalledWith(
+			'calypso_reader_atmosphere_timeline_external_post_clicked',
+			expect.objectContaining( {
+				connection_id: 42,
+				post_uri: 'at://did:plc:example/app.bsky.feed.post/abc',
+			} )
+		);
+	} );
+
+	it( 'still renders the link without analytics provider mounted', () => {
+		render(
+			<PostCardTimestamp
+				post={ {
+					created_at: '2026-04-28T15:17:50Z',
+					indexed_at: '',
+					permalink: 'https://example.social/@user/123',
+				} }
+			/>
+		);
+		expect( screen.getByRole( 'link' ) ).toHaveAttribute(
+			'href',
+			'https://example.social/@user/123'
+		);
 	} );
 } );

--- a/client/reader/social/components/post-card/test/post-card-timestamp.test.tsx
+++ b/client/reader/social/components/post-card/test/post-card-timestamp.test.tsx
@@ -6,10 +6,14 @@ import userEvent from '@testing-library/user-event';
 import { SocialAnalyticsProvider } from '../analytics-context';
 import { PostCardTimestamp } from '../post-card-timestamp';
 
+const basePost = { permalink: '', uri: '' };
+
 describe( 'PostCardTimestamp', () => {
 	it( 'renders an absolute time + date in a semantic <time> element', () => {
 		const { container } = render(
-			<PostCardTimestamp post={ { created_at: '2026-04-28T15:17:50Z', indexed_at: '' } } />
+			<PostCardTimestamp
+				post={ { ...basePost, created_at: '2026-04-28T15:17:50Z', indexed_at: '' } }
+			/>
 		);
 
 		const timeEl = container.querySelector( 'time' );
@@ -24,7 +28,9 @@ describe( 'PostCardTimestamp', () => {
 
 	it( 'falls back to indexed_at when created_at is empty', () => {
 		const { container } = render(
-			<PostCardTimestamp post={ { created_at: '', indexed_at: '2026-04-28T15:17:50Z' } } />
+			<PostCardTimestamp
+				post={ { ...basePost, created_at: '', indexed_at: '2026-04-28T15:17:50Z' } }
+			/>
 		);
 		expect( container.querySelector( 'time' ) ).toHaveAttribute(
 			'dateTime',
@@ -34,21 +40,23 @@ describe( 'PostCardTimestamp', () => {
 
 	it( 'renders nothing when both timestamps are empty', () => {
 		const { container } = render(
-			<PostCardTimestamp post={ { created_at: '', indexed_at: '' } } />
+			<PostCardTimestamp post={ { ...basePost, created_at: '', indexed_at: '' } } />
 		);
 		expect( container.querySelector( 'time' ) ).toBeNull();
 	} );
 
 	it( 'renders nothing when the timestamp is unparseable', () => {
 		const { container } = render(
-			<PostCardTimestamp post={ { created_at: 'not a date', indexed_at: '' } } />
+			<PostCardTimestamp post={ { ...basePost, created_at: 'not a date', indexed_at: '' } } />
 		);
 		expect( container.querySelector( 'time' ) ).toBeNull();
 	} );
 
-	it( 'renders a bare <time> (no anchor) when permalink is missing', () => {
+	it( 'renders a bare <time> (no anchor) when permalink is empty', () => {
 		const { container } = render(
-			<PostCardTimestamp post={ { created_at: '2026-04-28T15:17:50Z', indexed_at: '' } } />
+			<PostCardTimestamp
+				post={ { ...basePost, created_at: '2026-04-28T15:17:50Z', indexed_at: '' } }
+			/>
 		);
 		expect( container.querySelector( 'a' ) ).toBeNull();
 	} );
@@ -60,6 +68,7 @@ describe( 'PostCardTimestamp', () => {
 					created_at: '2026-04-28T15:17:50Z',
 					indexed_at: '',
 					permalink: 'https://bsky.app/profile/example/post/abc',
+					uri: 'at://did:plc:example/app.bsky.feed.post/abc',
 				} }
 			/>
 		);
@@ -67,6 +76,7 @@ describe( 'PostCardTimestamp', () => {
 		expect( link ).toHaveAttribute( 'href', 'https://bsky.app/profile/example/post/abc' );
 		expect( link ).toHaveAttribute( 'target', '_blank' );
 		expect( link ).toHaveAttribute( 'rel', 'noopener noreferrer' );
+		expect( link ).toHaveAttribute( 'aria-label', expect.stringContaining( 'opens in a new tab' ) );
 		expect( link.querySelector( 'time' ) ).not.toBeNull();
 	} );
 
@@ -91,13 +101,13 @@ describe( 'PostCardTimestamp', () => {
 				/>
 			</SocialAnalyticsProvider>
 		);
-		// Prevent jsdom from following the href on click.
 		await user.click( screen.getByRole( 'link' ) );
 		expect( onClick ).toHaveBeenCalledWith(
 			'calypso_reader_atmosphere_timeline_external_post_clicked',
 			expect.objectContaining( {
 				connection_id: 42,
 				post_uri: 'at://did:plc:example/app.bsky.feed.post/abc',
+				destination: 'external',
 			} )
 		);
 	} );
@@ -109,6 +119,7 @@ describe( 'PostCardTimestamp', () => {
 					created_at: '2026-04-28T15:17:50Z',
 					indexed_at: '',
 					permalink: 'https://example.social/@user/123',
+					uri: 'tag:example.social,2026:status/123',
 				} }
 			/>
 		);


### PR DESCRIPTION
Fixes CM-692

## Proposed Changes

* Wrap the prominent timestamp under the highlighted post in `<ThreadPanel>` (ATmosphere + Mastodon thread views) in an external anchor pointing at the source instance, when `post.permalink` is set.
* Match the hover-arrow affordance used by the Reader full-post header title link, with a `:focus-visible` outline using `--studio-blue-50` (consistent with `repost-button.scss`).
* Emit `calypso_reader_<source>_timeline_external_post_clicked`, rewritten to `_thread_external_post_clicked` by each protocol's thread shell. Carries `connection_id`, `post_uri`, and a new `destination: 'external'` Tracks property — distinct from the existing `'in_app_thread' | 'bsky_app' | 'composer' | 'in_app'` family, used here because this surface always leaves the app.
* Tighten `PostCardTimestampProps` to match the canonical `SocialPost` shape (`permalink: string`, `uri: string`) so the Tracks payload no longer papers over a missing `post.uri` with a silent null. The only consumer (`post-card/index.tsx`) already passes a `SocialPost`, so call sites are satisfied.
* Add an `aria-label` announcing the external new-tab navigation, and a `destination: 'external'` Tracks property for parity with `_timeline_post_clicked`.

## Why are these changes being made?

In the ATmosphere and Mastodon thread views, the prominent timestamp under the highlighted post (e.g. “6:42 PM · May 8, 2026”) was rendered as plain text — even though the permalink to the source instance is already on the mapped `SocialPost` (bsky.app for ATmosphere, the home-instance URL for Mastodon). Wrapping the `<time>` in an external anchor when present makes that destination discoverable, matches the affordance used by the Reader full-post header title link, and gives us a Tracks signal for outbound clicks from the thread surface.

## Testing Instructions

* Open the ATmosphere thread view (`/reader/atmosphere/:id/thread/:did/:rkey`) and the Mastodon thread view (`/reader/mastodon/:id/thread/:status_id`) on a connected account.
* Hover the prominent timestamp at the bottom of the highlighted post — the small hover-reveal arrow (↗) should appear; the cursor should be a pointer.
* Tab to the timestamp from the keyboard — a visible focus outline should appear.
* Click the timestamp — a new tab should open at the source instance (bsky.app post URL for ATmosphere; home-instance URL for Mastodon).
* Verify the screen reader announces “3:17 PM · Apr 28, 2026 — view original post (opens in a new tab)”.
* In the Tracks debugger, verify the rewritten event names fire (e.g. `calypso_reader_atmosphere_thread_external_post_clicked` / `calypso_reader_mastodon_thread_external_post_clicked`) with `destination: 'external'`.
* Falls back to bare `<time>` (no anchor) when `permalink` is empty — covered by `post-card-timestamp.test.tsx`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?