### PR TITLE
Dashboard: Wire cancel/remove/auto-renew through site-level interstitial

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -294,18 +294,22 @@ export const purchaseSettingsRoute = createRoute( {
 		cancelled?: true;
 		downgraded?: true;
 		intent?: 'auto-renew';
+		cancelledCount?: number;
 	} => {
 		const isRefunded = search.refunded === true || search.refunded === 'true';
 		const isUpgraded = search.upgraded === true || search.upgraded === 'true';
 		const isCancelled = search.cancelled === true || search.cancelled === 'true';
 		const isDowngraded = search.downgraded === true || search.downgraded === 'true';
 		const intent = search.intent === 'auto-renew' ? ( 'auto-renew' as const ) : undefined;
+		const rawCount = Number( search.cancelledCount );
+		const cancelledCount = Number.isFinite( rawCount ) && rawCount > 1 ? rawCount : undefined;
 		return {
 			...( isRefunded ? { refunded: true } : {} ),
 			...( isUpgraded ? { upgraded: true } : {} ),
 			...( isCancelled ? { cancelled: true } : {} ),
 			...( isDowngraded ? { downgraded: true } : {} ),
 			...( intent ? { intent } : {} ),
+			...( cancelledCount ? { cancelledCount } : {} ),
 		};
 	},
 } );
@@ -315,6 +319,10 @@ export const purchaseSettingsIndexRoute = createRoute( {
 	path: '/',
 	loader: async ( { params: { purchaseId } } ) => {
 		const purchase = await queryClient.ensureQueryData( purchaseQuery( parseInt( purchaseId ) ) );
+
+		// Preload user purchases so CancelOrRemoveActionButton and
+		// ManageSubscriptionCard have data on first render (deep links).
+		await queryClient.ensureQueryData( userPurchasesQuery() );
 
 		// Preload site and storage data for wpcom plans
 		if ( purchase.site_slug && purchase.blog_id && ! purchase.is_attached_to_holding_site ) {
@@ -440,7 +448,13 @@ export const cancelPurchaseRoute = createRoute( {
 	},
 	getParentRoute: () => purchaseSettingsRoute,
 	path: 'cancel',
-	validateSearch: ( search ): { intent?: CancelIntent; additionalPurchaseIds?: string } => {
+	validateSearch: (
+		search
+	): {
+		intent?: CancelIntent;
+		additionalPurchaseIds?: string;
+		source?: 'auto-renew-toggle';
+	} => {
 		return {
 			...( search.intent === 'cancel' ||
 			search.intent === 'remove' ||
@@ -450,15 +464,24 @@ export const cancelPurchaseRoute = createRoute( {
 			...( typeof search.additionalPurchaseIds === 'string'
 				? { additionalPurchaseIds: search.additionalPurchaseIds }
 				: {} ),
+			...( search.source === 'auto-renew-toggle' ? { source: 'auto-renew-toggle' as const } : {} ),
 		};
 	},
-	loaderDeps: ( { search } ) => ( { intent: search.intent } ),
-	loader: async ( { parentMatchPromise, deps: { intent } } ) => {
+	loaderDeps: ( { search } ) => ( {
+		intent: search.intent,
+		additionalPurchaseIds: search.additionalPurchaseIds,
+	} ),
+	loader: async ( { parentMatchPromise, deps: { intent, additionalPurchaseIds } } ) => {
 		const parentMatch = await parentMatchPromise;
 		const purchase = parentMatch.loaderData?.purchase;
 		if ( ! purchase ) {
 			return { purchase: undefined, intent };
 		}
+		const additionalIds =
+			additionalPurchaseIds
+				?.split( ',' )
+				.map( Number )
+				.filter( ( id ) => id > 0 ) ?? [];
 		await Promise.all( [
 			queryClient.ensureQueryData( sitePurchasesQuery( purchase.blog_id ) ),
 			queryClient.ensureQueryData( productsQuery() ),
@@ -467,6 +490,9 @@ export const cancelPurchaseRoute = createRoute( {
 			// Prefetch the default (control) variant; the component refetches
 			// under the 'treatment' key when the split-cancel-remove flag is on.
 			queryClient.ensureQueryData( purchaseCancelFeaturesQuery( purchase.ID ) ),
+			...additionalIds.map( ( id ) =>
+				queryClient.ensureQueryData( purchaseCancelFeaturesQuery( id ) )
+			),
 		] );
 		return { purchase, intent };
 	},

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-button.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-button.tsx
@@ -4,6 +4,7 @@ import { DisplayVariant } from '../../../utils/purchase';
 import { ATOMIC_REVERT_STEP } from './cancel-purchase-form/steps';
 import { getButtonLabels } from './get-confirmation-copy';
 import { useIsSplitCancelRemoveEnabled } from './use-is-split-cancel-remove-enabled';
+import type { PurchaseForCopy } from './get-confirmation-copy';
 import type { CancelPurchaseState } from './types';
 import type { Purchase, AtomicTransfer } from '@automattic/api-core';
 
@@ -16,6 +17,7 @@ interface CancelButtonProps {
 	disabled?: boolean;
 	isBusy?: boolean;
 	onClick?: () => void;
+	additionalPurchases?: PurchaseForCopy[];
 }
 
 export default function CancelButton( {
@@ -27,6 +29,7 @@ export default function CancelButton( {
 	disabled,
 	isBusy,
 	onClick,
+	additionalPurchases,
 }: CancelButtonProps ) {
 	const isDomainRegistrationPurchase = purchase && purchase.is_domain_registration;
 	const isSplitEnabled = useIsSplitCancelRemoveEnabled();
@@ -49,6 +52,7 @@ export default function CancelButton( {
 		: getButtonLabels( {
 				purchase,
 				intent: displayVariant,
+				additionalPurchases,
 		  } ).primary;
 
 	return (

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-header-title.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-header-title.tsx
@@ -2,6 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { DisplayVariant } from '../../../utils/purchase';
 import { CANCELLATION_OFFER_STEP } from './cancel-purchase-form/steps';
 import { getCancellationHeading } from './get-confirmation-copy';
+import type { PurchaseForCopy } from './get-confirmation-copy';
 import type { Purchase } from '@automattic/api-core';
 
 interface CancelHeaderTitleProps {
@@ -9,6 +10,7 @@ interface CancelHeaderTitleProps {
 	purchase: Purchase;
 	surveyStep?: string;
 	surveyShown?: boolean;
+	additionalPurchases?: PurchaseForCopy[];
 }
 
 export default function CancelHeaderTitle( {
@@ -16,6 +18,7 @@ export default function CancelHeaderTitle( {
 	purchase,
 	surveyStep,
 	surveyShown,
+	additionalPurchases,
 }: CancelHeaderTitleProps ) {
 	if ( surveyStep === CANCELLATION_OFFER_STEP ) {
 		return __( 'Thanks for your feedback' );
@@ -31,5 +34,6 @@ export default function CancelHeaderTitle( {
 	return getCancellationHeading( {
 		purchase,
 		intent: displayVariant,
+		additionalPurchases,
 	} );
 }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
@@ -11,12 +11,14 @@ import CancelPurchaseFeatureList from './feature-list';
 import GSuiteAccessMessage from './gsuite-access-message';
 import PlanProductRevertContent from './plan-product-revert-content';
 import { useIsSplitCancelRemoveEnabled } from './use-is-split-cancel-remove-enabled';
+import type { PurchaseForCopy } from './get-confirmation-copy';
 import type { CancelPurchaseState } from './types';
 import type {
 	Purchase,
 	Domain,
 	AtomicTransfer,
 	Site,
+	CancellationFeature,
 	UpgradesCancelFeaturesResponse,
 } from '@automattic/api-core';
 
@@ -32,6 +34,8 @@ interface CancellationMainContentProps {
 	state: CancelPurchaseState;
 	purchaseCancelFeatures?: UpgradesCancelFeaturesResponse;
 	isBusy?: boolean;
+	additionalPurchases?: PurchaseForCopy[];
+	cancellationFeatures?: CancellationFeature[];
 	onCancelConfirmationStateChange: ( newState: Partial< CancelPurchaseState > ) => void;
 	onDomainConfirmationChange: ( checked: boolean ) => void;
 	onCustomerConfirmedUnderstandingChange: ( checked: boolean ) => void;
@@ -65,6 +69,8 @@ export default function CancellationMainContent( {
 	state,
 	purchaseCancelFeatures,
 	isBusy,
+	additionalPurchases,
+	cancellationFeatures: cancellationFeaturesProp,
 	onCancelConfirmationStateChange,
 	onDomainConfirmationChange,
 	onCustomerConfirmedUnderstandingChange,
@@ -202,8 +208,9 @@ export default function CancellationMainContent( {
 		}
 	}
 
-	// Get features from the API endpoint for this product
-	const cancellationFeatures = purchaseCancelFeatures?.features ?? [];
+	// When the parent provides pre-deduped combined features (multi-purchase),
+	// use those. Otherwise fall back to the single-purchase API response.
+	const cancellationFeatures = cancellationFeaturesProp ?? purchaseCancelFeatures?.features ?? [];
 
 	let showDefaultChanges = false;
 	if ( ! isJetpack && ! isAkismet && ! isGSuite && ! isDomainRegistrationPurchase ) {
@@ -250,6 +257,7 @@ export default function CancellationMainContent( {
 				displayVariant={ displayVariant }
 				cancellationFeatures={ cancellationFeatures }
 				cancellationChanges={ cancellationChanges }
+				additionalPurchases={ additionalPurchases }
 			/>
 
 			<PlanProductRevertContent
@@ -259,6 +267,7 @@ export default function CancellationMainContent( {
 				atomicTransfer={ atomicTransfer }
 				state={ state }
 				isBusy={ isBusy }
+				additionalPurchases={ additionalPurchases }
 				onDomainConfirmationChange={ onDomainConfirmationChange }
 				onCustomerConfirmedUnderstandingChange={ onCustomerConfirmedUnderstandingChange }
 				onCustomerConfirmedUnderstandingAtomicPlanRevert={

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-pre-survey-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-pre-survey-content.tsx
@@ -1,12 +1,14 @@
 import { DisplayVariant } from '../../../utils/purchase';
 import CancellationMainContent from './cancellation-main-content';
 import DomainOptionsContent from './domain-options-content';
+import type { PurchaseForCopy } from './get-confirmation-copy';
 import type { CancelPurchaseState } from './types';
 import type {
 	Purchase,
 	Domain,
 	AtomicTransfer,
 	Site,
+	CancellationFeature,
 	UpgradesCancelFeaturesResponse,
 } from '@automattic/api-core';
 
@@ -22,6 +24,8 @@ interface CancellationPreSurveyContentProps {
 	state: CancelPurchaseState;
 	purchaseCancelFeatures?: UpgradesCancelFeaturesResponse;
 	isBusy?: boolean;
+	additionalPurchases?: PurchaseForCopy[];
+	cancellationFeatures?: CancellationFeature[];
 	onCancelConfirmationStateChange: ( newState: Partial< CancelPurchaseState > ) => void;
 	onDomainConfirmationChange: ( checked: boolean ) => void;
 	onCustomerConfirmedUnderstandingChange: ( checked: boolean ) => void;
@@ -45,6 +49,8 @@ export default function CancellationPreSurveyContent( {
 	state,
 	purchaseCancelFeatures,
 	isBusy,
+	additionalPurchases,
+	cancellationFeatures,
 	onCancelConfirmationStateChange,
 	onDomainConfirmationChange,
 	onCustomerConfirmedUnderstandingChange,
@@ -79,6 +85,8 @@ export default function CancellationPreSurveyContent( {
 			state={ state }
 			purchaseCancelFeatures={ purchaseCancelFeatures }
 			isBusy={ isBusy }
+			additionalPurchases={ additionalPurchases }
+			cancellationFeatures={ cancellationFeatures }
 			onCancelConfirmationStateChange={ onCancelConfirmationStateChange }
 			onDomainConfirmationChange={ onDomainConfirmationChange }
 			onCustomerConfirmedUnderstandingChange={ onCustomerConfirmedUnderstandingChange }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/feature-list.tsx
@@ -10,11 +10,13 @@ import { Text } from '../../../components/text';
 import { DisplayVariant } from '../../../utils/purchase';
 import {
 	getCancelLossIntro,
+	getEarliestExpiryDate,
 	getFallbackLossItems,
 	getRemoveLossIntro,
 	getSingleItemCancelCopy,
 	getSingleItemRemoveCopy,
 } from './get-confirmation-copy';
+import type { PurchaseForCopy } from './get-confirmation-copy';
 import type { Purchase, CancellationFeature } from '@automattic/api-core';
 
 type FeatureObject = {
@@ -27,11 +29,13 @@ const CancelPurchaseFeatureList = ( {
 	displayVariant,
 	cancellationFeatures,
 	cancellationChanges,
+	additionalPurchases,
 }: {
 	purchase: Purchase;
 	displayVariant: DisplayVariant;
 	cancellationFeatures: CancellationFeature[];
 	cancellationChanges: FeatureObject[];
+	additionalPurchases?: PurchaseForCopy[];
 } ) => {
 	// When the server returns no feature list, fall back to a per-product-type
 	// item so every confirmation screen shows at least one concrete thing the
@@ -54,20 +58,23 @@ const CancelPurchaseFeatureList = ( {
 	// Remove happens immediately, no future date to surface.
 	// Use non-breaking spaces in the formatted date so it never wraps mid-date
 	// (e.g. "April\n16, 2027").
-	const fullExpiryDate = purchase.expiry_date
-		? intlFormat( purchase.expiry_date, { dateStyle: 'long' }, { locale: 'en-US' } ).replace(
+	const expirySource = additionalPurchases?.length
+		? getEarliestExpiryDate( [ purchase, ...additionalPurchases ] )
+		: purchase.expiry_date;
+	const fullExpiryDate = expirySource
+		? intlFormat( expirySource, { dateStyle: 'long' }, { locale: 'en-US' } ).replace(
 				/ /g,
 				'\u00a0'
 		  )
 		: '';
 	const introCopy =
 		displayVariant === 'remove'
-			? getRemoveLossIntro( purchase )
-			: getCancelLossIntro( purchase, fullExpiryDate );
+			? getRemoveLossIntro( purchase, additionalPurchases )
+			: getCancelLossIntro( purchase, fullExpiryDate, additionalPurchases );
 
 	return (
 		<VStack spacing={ 6 }>
-			{ lossItems.length === 1 ? (
+			{ lossItems.length === 1 && ! additionalPurchases?.length ? (
 				<Text as="p">
 					{ displayVariant === 'remove'
 						? getSingleItemRemoveCopy( purchase )

--- a/client/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy.ts
@@ -141,14 +141,14 @@ export function formatTimeRemaining( expiryDate: string | Date, from: Date = new
 	}
 	if ( parts.length === 2 ) {
 		return sprintf(
-			/* translators: joins two duration parts, e.g. "1 month and 11 days" */
+			/* translators: %1$s is a duration part like "1 month"; %2$s is a duration part like "11 days" */
 			__( '%1$s and %2$s' ),
 			parts[ 0 ],
 			parts[ 1 ]
 		);
 	}
 	return sprintf(
-		/* translators: joins three duration parts, e.g. "2 years, 3 months, and 14 days" */
+		/* translators: %1$s is a duration part like "2 years"; %2$s is a duration part like "3 months"; %3$s is a duration part like "14 days" */
 		__( '%1$s, %2$s, and %3$s' ),
 		parts[ 0 ],
 		parts[ 1 ],
@@ -159,7 +159,72 @@ export function formatTimeRemaining( expiryDate: string | Date, from: Date = new
 type ConfirmationCopyArgs = {
 	purchase: PurchaseForCopy;
 	intent: DisplayVariant;
+	additionalPurchases?: PurchaseForCopy[];
 };
+
+function getCategoryDisplayNoun( category: ProductCategory ): string {
+	switch ( category ) {
+		case 'plan':
+			return __( 'plan' );
+		case 'domain':
+			return __( 'domain' );
+		case 'email':
+			return __( 'email' );
+		default:
+			return __( 'subscription' );
+	}
+}
+
+export function buildCategoriesNounPhrase( purchases: PurchaseForCopy[] ): string {
+	const categories = [ ...new Set( purchases.map( getProductCategory ) ) ];
+	const nouns = [ ...new Set( categories.map( getCategoryDisplayNoun ) ) ];
+	if ( nouns.length === 0 ) {
+		return '';
+	}
+	if ( nouns.length === 1 ) {
+		return nouns[ 0 ];
+	}
+	if ( nouns.length === 2 ) {
+		return sprintf(
+			/* translators: %1$s is a product category like "plan"; %2$s is a product category like "domain" */
+			__( '%1$s and %2$s' ),
+			nouns[ 0 ],
+			nouns[ 1 ]
+		);
+	}
+	if ( nouns.length === 3 ) {
+		return sprintf(
+			/* translators: %1$s is a product category like "plan"; %2$s is a product category like "domain"; %3$s is a product category like "email" */
+			__( '%1$s, %2$s, and %3$s' ),
+			nouns[ 0 ],
+			nouns[ 1 ],
+			nouns[ 2 ]
+		);
+	}
+	return sprintf(
+		/* translators: %1$s is a product category like "plan"; %2$s is a product category like "domain"; %3$s is a product category like "email"; %4$s is a product category like "subscription" */
+		__( '%1$s, %2$s, %3$s, and %4$s' ),
+		nouns[ 0 ],
+		nouns[ 1 ],
+		nouns[ 2 ],
+		nouns[ 3 ]
+	);
+}
+
+export function getEarliestExpiryDate( purchases: PurchaseForCopy[] ): string {
+	let earliest = '';
+	let earliestTime = Infinity;
+	for ( const p of purchases ) {
+		if ( p.expiry_date ) {
+			const time = new Date( p.expiry_date ).getTime();
+			if ( ! isNaN( time ) && time < earliestTime ) {
+				earliestTime = time;
+				earliest = p.expiry_date;
+			}
+		}
+	}
+	return earliest;
+}
 
 /**
  * Screen heading.
@@ -167,9 +232,19 @@ type ConfirmationCopyArgs = {
  * - Remove intent → product-type-aware ("Remove plan", "Remove domain",
  *   "Remove {productName}" for individual products).
  */
-export function getCancellationHeading( { purchase, intent }: ConfirmationCopyArgs ): string {
+export function getCancellationHeading( {
+	purchase,
+	intent,
+	additionalPurchases,
+}: ConfirmationCopyArgs ): string {
 	if ( intent === 'auto-renew' ) {
 		return __( 'Turn off auto-renew' );
+	}
+	if ( additionalPurchases?.length ) {
+		if ( intent === 'cancel' ) {
+			return __( 'Cancel subscriptions' );
+		}
+		return __( 'Remove upgrades' );
 	}
 	if ( intent === 'cancel' ) {
 		return __( 'Cancel subscription' );
@@ -205,10 +280,33 @@ export function getCancellationHeading( { purchase, intent }: ConfirmationCopyAr
  * one-time purchases, and when we can't compute a duration (e.g. partner-
  * managed or already-expired purchases).
  */
-export function getTopNoticeCopy( { purchase, intent }: ConfirmationCopyArgs ): string | null {
+export function getTopNoticeCopy( {
+	purchase,
+	intent,
+	additionalPurchases,
+}: ConfirmationCopyArgs ): string | null {
 	if ( intent !== 'cancel' && intent !== 'auto-renew' ) {
 		return null;
 	}
+
+	if ( additionalPurchases?.length ) {
+		const allPurchases = [ purchase, ...additionalPurchases ];
+		const earliestExpiry = getEarliestExpiryDate( allPurchases );
+		if ( ! earliestExpiry ) {
+			return null;
+		}
+		const duration = formatTimeRemaining( earliestExpiry );
+		if ( ! duration ) {
+			return null;
+		}
+		const categories = buildCategoriesNounPhrase( allPurchases );
+		return sprintf(
+			/* translators: %(categories)s is a list like "plan and domain"; %(duration)s is time remaining */
+			__( 'Your %(categories)s features will be available for another %(duration)s.' ),
+			{ categories, duration }
+		);
+	}
+
 	if ( ! purchase.expiry_date ) {
 		return null;
 	}
@@ -253,7 +351,27 @@ export function getTopNoticeCopy( { purchase, intent }: ConfirmationCopyArgs ): 
  * Form: "Your {category} will expire on {date} and you’ll lose access to:"
  * Falls back to a date-less form when no expiry is available.
  */
-export function getCancelLossIntro( purchase: PurchaseForCopy, fullExpiryDate: string ): string {
+export function getCancelLossIntro(
+	purchase: PurchaseForCopy,
+	fullExpiryDate: string,
+	additionalPurchases?: PurchaseForCopy[]
+): string {
+	if ( additionalPurchases?.length ) {
+		const allPurchases = [ purchase, ...additionalPurchases ];
+		const categories = buildCategoriesNounPhrase( allPurchases );
+		if ( ! fullExpiryDate ) {
+			return sprintf(
+				/* translators: %(categories)s is a list like "plan and domain" */
+				__( 'Your %(categories)s will expire. Here’s what you’ll lose:' ),
+				{ categories }
+			);
+		}
+		return sprintf(
+			/* translators: %(date)s is the expiry date; %(categories)s is a list like "plan and domain" */
+			__( 'On %(date)s, your %(categories)s will expire. Here’s what you’ll lose:' ),
+			{ date: fullExpiryDate, categories }
+		);
+	}
 	const category = getProductCategory( purchase );
 	if ( ! fullExpiryDate ) {
 		return __( 'You’ll lose access to:' );
@@ -293,7 +411,19 @@ export function getCancelLossIntro( purchase: PurchaseForCopy, fullExpiryDate: s
  * of things being removed right now (vs. the Cancel variant, which frames it
  * as a future loss).
  */
-export function getRemoveLossIntro( purchase: PurchaseForCopy ): string {
+export function getRemoveLossIntro(
+	purchase: PurchaseForCopy,
+	additionalPurchases?: PurchaseForCopy[]
+): string {
+	if ( additionalPurchases?.length ) {
+		const allPurchases = [ purchase, ...additionalPurchases ];
+		const categories = buildCategoriesNounPhrase( allPurchases );
+		return sprintf(
+			/* translators: %(categories)s is a list like "plan and domain" */
+			__( 'Your %(categories)s will be removed immediately. Here’s what you’ll lose:' ),
+			{ categories }
+		);
+	}
 	const category = getProductCategory( purchase );
 	const productName = purchase.product_name;
 	switch ( category ) {
@@ -479,10 +609,32 @@ export function getCheckboxLabel(): string {
  * the terminal action. Secondary stays per-category so "Keep plan" / "Keep
  * domain" still match the surrounding copy.
  */
-export function getButtonLabels( { purchase, intent }: ConfirmationCopyArgs ): {
+export function getButtonLabels( {
+	purchase,
+	intent,
+	additionalPurchases,
+}: ConfirmationCopyArgs ): {
 	primary: string;
 	secondary: string;
 } {
+	if ( additionalPurchases?.length ) {
+		if ( intent === 'cancel' ) {
+			return {
+				primary: __( 'Cancel subscriptions' ),
+				secondary: __( 'Keep subscriptions' ),
+			};
+		}
+		if ( intent === 'auto-renew' ) {
+			return {
+				primary: __( 'Turn off auto-renew' ),
+				secondary: __( 'Keep auto-renew on' ),
+			};
+		}
+		return {
+			primary: __( 'Continue removal' ),
+			secondary: __( 'Keep upgrades' ),
+		};
+	}
 	const category = getProductCategory( purchase );
 	if ( intent === 'remove' ) {
 		const primary = __( 'Continue removal' );

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -30,6 +30,7 @@ import { invokeSurvicateEvent } from '@automattic/survicate';
 import {
 	useSuspenseQuery,
 	useQuery,
+	useQueries,
 	useMutation,
 	useQueryClient,
 	type QueryCacheNotifyEvent,
@@ -99,6 +100,7 @@ import RefundEligibilityNotice from './refund-eligibility-notice';
 import TimeRemainingNotice from './time-remaining-notice';
 import { useCancelMutationOnConfirm } from './use-cancel-mutation-on-confirm';
 import { useIsSplitCancelRemoveEnabled } from './use-is-split-cancel-remove-enabled';
+import type { PurchaseForCopy } from './get-confirmation-copy';
 import type { CancelPurchaseState } from './types';
 import type {
 	Purchase,
@@ -117,6 +119,7 @@ type TopNoticeArgs = {
 	purchase: Purchase;
 	intent: CancelIntent | null;
 	isSplitCancelRemoveEnabled: boolean;
+	additionalPurchases?: PurchaseForCopy[];
 };
 
 /**
@@ -133,6 +136,7 @@ function renderTopNotice( args: TopNoticeArgs ) {
 		purchase,
 		intent,
 		isSplitCancelRemoveEnabled,
+		additionalPurchases,
 	} = args;
 
 	if ( surveyShown || showDomainOptionsStep ) {
@@ -161,6 +165,7 @@ function renderTopNotice( args: TopNoticeArgs ) {
 			purchase={ purchase }
 			displayVariant={ displayVariant }
 			intent={ intent }
+			additionalPurchases={ additionalPurchases }
 		/>
 	);
 }
@@ -545,11 +550,55 @@ function CancelPurchaseInner() {
 	const cancelSearch = useSearch( { from: cancelPurchaseRoute.fullPath } );
 	const intent = getCancelIntentFromSearch( cancelSearch );
 	const displayVariant = getDisplayVariant( intent, flowType );
-	const getCancelledSearch = () => ( {
+	const getCancelledSearch = ( cancelledCount?: number ) => ( {
 		cancelled: true as const,
 		...( intent === 'auto-renew' ? { intent: 'auto-renew' as const } : {} ),
+		...( cancelledCount && cancelledCount > 1 ? { cancelledCount } : {} ),
 	} );
 	const mutationFlowType = getMutationFlowType( intent, purchase );
+
+	// Parse additional purchase IDs from the site-level interstitial
+	const rawAdditionalIds = cancelSearch.additionalPurchaseIds;
+	const additionalPurchaseIds: number[] = rawAdditionalIds
+		? rawAdditionalIds
+				.split( ',' )
+				.map( Number )
+				.filter( ( id: number ) => id > 0 && Number.isFinite( id ) )
+		: [];
+	const additionalPurchases = sitePurchases.filter( ( p ) =>
+		additionalPurchaseIds.includes( p.ID )
+	);
+
+	// Fetch cancellation features for additional purchases (loader prefetched these)
+	const additionalFeaturesQueries = useQueries( {
+		queries: additionalPurchaseIds.map( ( id ) => purchaseCancelFeaturesQuery( id ) ),
+	} );
+	const allCancellationFeatures = [
+		...( purchaseCancelFeatures?.features ?? [] ),
+		...additionalFeaturesQueries.flatMap( ( q ) => q.data?.features ?? [] ),
+	];
+	const seen = new Set< string >();
+	const dedupedCancellationFeatures = allCancellationFeatures.filter( ( f ) => {
+		if ( seen.has( f.feature_id ) ) {
+			return false;
+		}
+		seen.add( f.feature_id );
+		return true;
+	} );
+
+	// Narrow to PurchaseForCopy for the copy helpers
+	const additionalPurchasesForCopy: PurchaseForCopy[] = additionalPurchases.map( ( p ) => ( {
+		is_plan: p.is_plan,
+		is_domain_registration: p.is_domain_registration,
+		is_jetpack_plan_or_product: p.is_jetpack_plan_or_product,
+		product_slug: p.product_slug,
+		product_name: p.product_name,
+		product_type: p.product_type,
+		expiry_date: p.expiry_date,
+		expiry_status: p.expiry_status,
+		meta: p.meta,
+		domain: p.domain,
+	} ) );
 
 	const cancellationOffer = cancellationOffers?.length ? cancellationOffers[ 0 ] : undefined;
 
@@ -960,6 +1009,42 @@ function CancelPurchaseInner() {
 		return mutationFlowType;
 	};
 
+	// Process additional purchases selected on the site-level interstitial.
+	// Runs after the primary purchase mutation succeeds. Sequential processing,
+	// individual failures are non-fatal — the primary already succeeded.
+	const processAdditionalPurchases = async (): Promise< number > => {
+		if ( ! additionalPurchases.length ) {
+			return 0;
+		}
+		let count = 0;
+		for ( const p of additionalPurchases ) {
+			try {
+				if ( intent === 'remove' ) {
+					if ( hasAmountAvailableToRefund( p ) ) {
+						await cancelAndRefundMutation.mutateAsync( {
+							purchaseId: p.ID,
+							options: { product_id: p.product_id, cancel_bundled_domain: false },
+						} );
+					} else {
+						await setPurchaseAutoRenewMutation.mutateAsync( {
+							purchaseId: p.ID,
+							autoRenew: false,
+						} );
+					}
+				} else {
+					await setPurchaseAutoRenewMutation.mutateAsync( {
+						purchaseId: p.ID,
+						autoRenew: false,
+					} );
+				}
+				count++;
+			} catch {
+				// Individual failures are non-fatal — primary already succeeded
+			}
+		}
+		return count;
+	};
+
 	// Fire the cancel mutation at confirm-time and only advance to the survey
 	// once it resolves. The snackbar is deferred to onSurveyComplete so it
 	// shows on the destination (purchase management) screen, not mid-survey.
@@ -1209,15 +1294,19 @@ function CancelPurchaseInner() {
 					},
 				},
 				{
-					onSuccess: () => {
+					onSuccess: async () => {
 						if ( purchase.is_plan ) {
 							cancelAllMarketplaceSubscriptions();
 						}
+						const additionalCount = await processAdditionalPurchases();
 						invokeSurvicateEvent( 'purchaseRefunded' );
 						navigate( {
 							to: purchaseSettingsRoute.fullPath,
 							params: { purchaseId: purchase.ID },
-							search: { refunded: true },
+							search: {
+								refunded: true,
+								...( 1 + additionalCount > 1 ? { cancelledCount: 1 + additionalCount } : {} ),
+							},
 						} );
 					},
 					onError: ( error: Error ) => {
@@ -1231,11 +1320,12 @@ function CancelPurchaseInner() {
 		setPurchaseAutoRenewMutation.mutate(
 			{ purchaseId: purchase.ID, autoRenew: false },
 			{
-				onSuccess: () => {
+				onSuccess: async () => {
+					const additionalCount = await processAdditionalPurchases();
 					navigate( {
 						to: purchaseSettingsRoute.fullPath,
 						params: { purchaseId: purchase.ID },
-						search: getCancelledSearch(),
+						search: getCancelledSearch( 1 + additionalCount ),
 					} );
 				},
 				onError: () => {
@@ -1333,20 +1423,25 @@ function CancelPurchaseInner() {
 			//    and self-dismisses its notice. The cache guard's re-strip happens
 			//    synchronously inside the QueryCache notify callback, so the list's
 			//    useEffect never observes transient successes-path reappearances.
-			removePurchaseMutator.mutateAsync( purchase.ID ).catch( () => {
-				cleanupGuard();
-				queryClient.setQueryData(
-					userPurchasesQuery().queryKey,
-					( old: Purchase[] | undefined ) => {
-						const list = old ?? [];
-						return list.some( ( p ) => p.ID === purchase.ID ) ? list : [ ...list, purchase ];
-					}
-				);
-				createErrorNotice( __( 'Failed to remove your purchase. Please try again.' ), {
-					type: 'snackbar',
+			removePurchaseMutator
+				.mutateAsync( purchase.ID )
+				.then( () => {
+					void processAdditionalPurchases();
+				} )
+				.catch( () => {
+					cleanupGuard();
+					queryClient.setQueryData(
+						userPurchasesQuery().queryKey,
+						( old: Purchase[] | undefined ) => {
+							const list = old ?? [];
+							return list.some( ( p ) => p.ID === purchase.ID ) ? list : [ ...list, purchase ];
+						}
+					);
+					createErrorNotice( __( 'Failed to remove your purchase. Please try again.' ), {
+						type: 'snackbar',
+					} );
+					queryClient.invalidateQueries( { queryKey: userPurchasesQuery().queryKey } );
 				} );
-				queryClient.invalidateQueries( { queryKey: userPurchasesQuery().queryKey } );
-			} );
 		}, 1500 );
 	};
 
@@ -1354,12 +1449,13 @@ function CancelPurchaseInner() {
 		setPurchaseAutoRenewMutation.mutate(
 			{ purchaseId: purchase.ID, autoRenew: false },
 			{
-				onSuccess: () => {
+				onSuccess: async () => {
+					const additionalCount = await processAdditionalPurchases();
 					invokeSurvicateEvent( 'purchaseCancelled' );
 					navigate( {
 						to: purchaseSettingsRoute.fullPath,
 						params: { purchaseId: purchase.ID },
-						search: getCancelledSearch(),
+						search: getCancelledSearch( 1 + additionalCount ),
 					} );
 				},
 				onError: () => {
@@ -1380,7 +1476,7 @@ function CancelPurchaseInner() {
 		);
 	};
 
-	const onSurveyComplete = () => {
+	const onSurveyComplete = async () => {
 		// Set loading state to show busy button
 		setState( ( state ) => ( { ...state, isLoading: true } ) );
 
@@ -1388,15 +1484,18 @@ function CancelPurchaseInner() {
 
 		if ( shouldFireMutationOnConfirm() ) {
 			// Cancel intent: the mutation already fired at confirm-click via
-			// fireMutationFromConfirm. Navigate with the appropriate search param
-			// so the inline notice renders on the destination screen.
+			// fireMutationFromConfirm. Process additional purchases from the
+			// site-level interstitial, then navigate with the appropriate
+			// search param so the inline notice renders on the destination screen.
+			const additionalCount = await processAdditionalPurchases();
+			const cancelledCount = 1 + additionalCount;
 			navigate( {
 				to: purchaseSettingsRoute.fullPath,
 				params: { purchaseId: purchase.ID },
 				search:
 					effectiveFlowType === CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND
-						? { refunded: true }
-						: getCancelledSearch(),
+						? { refunded: true, ...( cancelledCount > 1 ? { cancelledCount } : {} ) }
+						: getCancelledSearch( cancelledCount ),
 			} );
 			return;
 		}
@@ -1749,6 +1848,7 @@ function CancelPurchaseInner() {
 							purchase={ purchase }
 							surveyStep={ state.surveyStep }
 							surveyShown={ state.surveyShown }
+							additionalPurchases={ additionalPurchasesForCopy }
 						/>
 					}
 					prefix={ <Breadcrumbs length={ 4 } /> }
@@ -1762,6 +1862,7 @@ function CancelPurchaseInner() {
 				purchase,
 				intent,
 				isSplitCancelRemoveEnabled,
+				additionalPurchases: additionalPurchasesForCopy,
 			} ) }
 		>
 			{ isSolutionsStep ? (
@@ -1783,7 +1884,9 @@ function CancelPurchaseInner() {
 									activeMarketplaceSubscriptions={ activeSubscriptions }
 									state={ state }
 									purchaseCancelFeatures={ purchaseCancelFeatures }
-									isBusy={ isMutationPending }
+									isBusy={ isMutationPending || state.isLoading }
+									additionalPurchases={ additionalPurchasesForCopy }
+									cancellationFeatures={ dedupedCancellationFeatures }
 									onCancelConfirmationStateChange={ onCancelConfirmationStateChange }
 									onDomainConfirmationChange={ onDomainConfirmationChange }
 									onCustomerConfirmedUnderstandingChange={ onCustomerConfirmedUnderstandingChange }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/keep-subscription-button.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/keep-subscription-button.tsx
@@ -3,22 +3,25 @@ import { Button } from '@wordpress/components';
 import { purchaseSettingsRoute } from '../../../app/router/me';
 import { DisplayVariant } from '../../../utils/purchase';
 import { getButtonLabels } from './get-confirmation-copy';
+import type { PurchaseForCopy } from './get-confirmation-copy';
 import type { Purchase } from '@automattic/api-core';
 
 interface KeepSubscriptionButtonProps {
 	purchase: Purchase;
 	intent: DisplayVariant;
 	onKeepSubscriptionClick: () => void;
+	additionalPurchases?: PurchaseForCopy[];
 }
 
 export default function KeepSubscriptionButton( {
 	purchase,
 	intent,
 	onKeepSubscriptionClick,
+	additionalPurchases,
 }: KeepSubscriptionButtonProps ) {
 	const navigate = useNavigate();
 
-	const label = getButtonLabels( { purchase, intent } ).secondary;
+	const label = getButtonLabels( { purchase, intent, additionalPurchases } ).secondary;
 
 	return (
 		<Button

--- a/client/dashboard/me/billing-purchases/cancel-purchase/plan-product-revert-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/plan-product-revert-content.tsx
@@ -4,6 +4,7 @@ import { DisplayVariant } from '../../../utils/purchase';
 import CancelButton from './cancel-button';
 import ConfirmCheckbox from './confirm-checkbox';
 import KeepSubscriptionButton from './keep-subscription-button';
+import type { PurchaseForCopy } from './get-confirmation-copy';
 import type { CancelPurchaseState } from './types';
 import type { Purchase, AtomicTransfer } from '@automattic/api-core';
 
@@ -14,6 +15,7 @@ interface PlanProductRevertContentProps {
 	atomicTransfer?: AtomicTransfer;
 	state: CancelPurchaseState;
 	isBusy?: boolean;
+	additionalPurchases?: PurchaseForCopy[];
 	onDomainConfirmationChange: ( checked: boolean ) => void;
 	onCustomerConfirmedUnderstandingChange: ( checked: boolean ) => void;
 	onCustomerConfirmedUnderstandingAtomicPlanRevert: ( checked: boolean ) => void;
@@ -28,6 +30,7 @@ export default function PlanProductRevertContent( {
 	atomicTransfer,
 	state,
 	isBusy,
+	additionalPurchases,
 	onDomainConfirmationChange,
 	onCustomerConfirmedUnderstandingChange,
 	onCustomerConfirmedUnderstandingAtomicPlanRevert,
@@ -59,11 +62,13 @@ export default function PlanProductRevertContent( {
 					state={ state }
 					isBusy={ isBusy }
 					onClick={ onCancelClick }
+					additionalPurchases={ additionalPurchases }
 				/>
 				<KeepSubscriptionButton
 					purchase={ purchase }
 					intent={ displayVariant }
 					onKeepSubscriptionClick={ onKeepSubscriptionClick }
+					additionalPurchases={ additionalPurchases }
 				/>
 			</ButtonStack>
 		</VStack>

--- a/client/dashboard/me/billing-purchases/cancel-purchase/test/get-confirmation-copy.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/test/get-confirmation-copy.ts
@@ -3,9 +3,12 @@
  */
 
 import {
+	buildCategoriesNounPhrase,
 	formatTimeRemaining,
+	getEarliestExpiryDate,
 	getProductCategory,
 	getCancellationHeading,
+	getCancelLossIntro,
 	getTopNoticeCopy,
 	getCheckboxLabel,
 	getButtonLabels,
@@ -308,6 +311,81 @@ describe( 'getFallbackLossItems', () => {
 				makePurchaseForCategory( 'one-time', { product_name: 'Do it for me: Website Design' } )
 			)
 		).toEqual( [ 'Do it for me: Website Design' ] );
+	} );
+} );
+
+describe( 'buildCategoriesNounPhrase', () => {
+	test( 'single category returns the noun alone', () => {
+		expect( buildCategoriesNounPhrase( [ makePurchaseForCategory( 'plan' ) ] ) ).toBe( 'plan' );
+	} );
+	test( 'two distinct categories joined with "and"', () => {
+		expect(
+			buildCategoriesNounPhrase( [
+				makePurchaseForCategory( 'plan' ),
+				makePurchaseForCategory( 'domain' ),
+			] )
+		).toBe( 'plan and domain' );
+	} );
+	test( 'three distinct categories use explicit sprintf template', () => {
+		const phrase = buildCategoriesNounPhrase( [
+			makePurchaseForCategory( 'plan' ),
+			makePurchaseForCategory( 'domain' ),
+			makePurchaseForCategory( 'email' ),
+		] );
+		expect( phrase ).toBe( 'plan, domain, and email' );
+	} );
+	test( 'four distinct categories use explicit sprintf template', () => {
+		const phrase = buildCategoriesNounPhrase( [
+			makePurchaseForCategory( 'plan' ),
+			makePurchaseForCategory( 'domain' ),
+			makePurchaseForCategory( 'email' ),
+			makePurchaseForCategory( 'other' ),
+		] );
+		expect( phrase ).toBe( 'plan, domain, email, and subscription' );
+	} );
+	test( 'duplicate categories are deduplicated', () => {
+		expect(
+			buildCategoriesNounPhrase( [
+				makePurchaseForCategory( 'plan' ),
+				makePurchaseForCategory( 'plan' ),
+			] )
+		).toBe( 'plan' );
+	} );
+} );
+
+describe( 'getEarliestExpiryDate', () => {
+	test( 'returns the earliest date among multiple purchases', () => {
+		const purchases = [
+			makePurchase( { expiry_date: '2027-06-01T00:00:00Z' } ),
+			makePurchase( { expiry_date: '2027-04-01T00:00:00Z' } ),
+			makePurchase( { expiry_date: '2027-09-01T00:00:00Z' } ),
+		];
+		expect( getEarliestExpiryDate( purchases ) ).toBe( '2027-04-01T00:00:00Z' );
+	} );
+	test( 'skips purchases with no expiry_date', () => {
+		const purchases = [
+			makePurchase( { expiry_date: '' } ),
+			makePurchase( { expiry_date: '2027-08-15T00:00:00Z' } ),
+		];
+		expect( getEarliestExpiryDate( purchases ) ).toBe( '2027-08-15T00:00:00Z' );
+	} );
+	test( 'returns empty string when no purchase has an expiry', () => {
+		expect(
+			getEarliestExpiryDate( [
+				makePurchase( { expiry_date: '' } ),
+				makePurchase( { expiry_date: '' } ),
+			] )
+		).toBe( '' );
+	} );
+} );
+
+describe( 'getCancelLossIntro (multi-purchase wiring)', () => {
+	test( 'includes the formatted date and noun phrase when additional purchases present', () => {
+		const primary = makePurchaseForCategory( 'plan' );
+		const additional = [ makePurchaseForCategory( 'domain' ) ];
+		const intro = getCancelLossIntro( primary, 'April 16, 2027', additional );
+		expect( intro ).toMatch( /April/ );
+		expect( intro ).toMatch( /plan and domain/ );
 	} );
 } );
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/time-remaining-notice.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/time-remaining-notice.tsx
@@ -2,18 +2,21 @@ import { isToday, isBefore } from 'date-fns';
 import Notice from '../../../components/notice';
 import { isPartnerPurchase, DisplayVariant, CancelIntent } from '../../../utils/purchase';
 import { getTopNoticeCopy } from './get-confirmation-copy';
+import type { PurchaseForCopy } from './get-confirmation-copy';
 import type { Purchase } from '@automattic/api-core';
 
 interface TimeRemainingNoticeProps {
 	purchase: Purchase;
 	displayVariant: DisplayVariant;
 	intent: CancelIntent | null;
+	additionalPurchases?: PurchaseForCopy[];
 }
 
 export default function TimeRemainingNotice( {
 	purchase,
 	displayVariant,
 	intent,
+	additionalPurchases,
 }: TimeRemainingNoticeProps ) {
 	// Remove screen: the product is going away immediately — no "active until"
 	// statement applies. A separate RefundEligibilityNotice handles the refund case.
@@ -21,20 +24,24 @@ export default function TimeRemainingNotice( {
 		return null;
 	}
 
-	// Partner-managed purchases don't really expire from the user's perspective.
-	// No notice to render.
-	if ( isPartnerPurchase( purchase ) || ! purchase.expiry_date ) {
-		return null;
+	// For multi-purchase, skip the partner/expiry early-returns — additional
+	// purchases may have their own valid expiry dates.
+	if ( ! additionalPurchases?.length ) {
+		// Partner-managed purchases don't really expire from the user's perspective.
+		// No notice to render.
+		if ( isPartnerPurchase( purchase ) || ! purchase.expiry_date ) {
+			return null;
+		}
+
+		// Don't show for a purchase that's already expired or expires today.
+		const purchaseExpiryDate = new Date( purchase.expiry_date );
+		const now = new Date();
+		if ( isToday( purchaseExpiryDate ) || isBefore( purchaseExpiryDate, now ) ) {
+			return null;
+		}
 	}
 
-	// Don't show for a purchase that's already expired or expires today.
-	const purchaseExpiryDate = new Date( purchase.expiry_date );
-	const now = new Date();
-	if ( isToday( purchaseExpiryDate ) || isBefore( purchaseExpiryDate, now ) ) {
-		return null;
-	}
-
-	const copy = getTopNoticeCopy( { purchase, intent: intent ?? 'cancel' } );
+	const copy = getTopNoticeCopy( { purchase, intent: intent ?? 'cancel', additionalPurchases } );
 	if ( ! copy ) {
 		return null;
 	}

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -9,6 +9,7 @@ import {
 	domainQuery,
 	purchaseCancelFeaturesQuery,
 	purchaseQuery,
+	userPurchasesQuery,
 	userPurchaseSetAutoRenewQuery,
 	siteDifmWebsiteContentQuery,
 	siteJetpackKeysQuery,
@@ -58,6 +59,7 @@ import {
 	cancelPurchaseRoute,
 	changePaymentMethodRoute,
 	purchaseSettingsRoute,
+	siteActionsRoute,
 } from '../../../app/router/me';
 import { getCurrentDashboard } from '../../../app/routing';
 import { ActionList } from '../../../components/action-list';
@@ -281,17 +283,36 @@ function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase } ) {
 	const navigate = useNavigate();
 	const locale = useLocale();
 	const isSplitEnabled = useIsSplitCancelRemoveEnabled();
+	const { data: allPurchases } = useQuery( userPurchasesQuery() );
 
 	// WordAds and non-primary domain warnings are shown inline on the confirmation screen
 	// under purchases/split-cancel-remove (see cancellation-main-content.tsx).
 	// FIXME: render "Domain transfers can take anywhere from five to seven days to complete." next to cancel button (see domainTransferDuration)
 
-	const goToCancel = ( intent?: 'cancel' | 'remove' ) =>
+	const goToCancel = ( intent?: 'cancel' | 'remove' ) => {
+		if ( isSplitEnabled && intent ) {
+			const sitePurchases = ( allPurchases ?? [] ).filter(
+				( p ) => p.blog_id === purchase.blog_id
+			);
+			const eligible =
+				intent === 'cancel'
+					? sitePurchases.filter( ( p ) => p.is_auto_renew_enabled || p.ID === purchase.ID )
+					: sitePurchases;
+
+			if ( eligible.length > 1 ) {
+				navigate( {
+					to: siteActionsRoute.fullPath,
+					params: { purchaseId: purchase.ID, action: intent },
+				} );
+				return;
+			}
+		}
 		navigate( {
 			to: cancelPurchaseRoute.fullPath,
 			params: { purchaseId: purchase.ID },
 			...( intent ? { search: { intent } } : {} ),
 		} );
+	};
 
 	if ( isSplitEnabled ) {
 		const hasRefund = hasAmountAvailableToRefund( purchase );
@@ -708,7 +729,7 @@ function getFields( {
 						if ( isInExpirationGracePeriod( purchase ) ) {
 							return __( 'Pending renewal' );
 						}
-						// translators: %(date)s is a formatted date string
+						// translators: %(date)s is a formatted billing date like "January 1, 2027"
 						return sprintf( __( 'You will be billed on %(date)s' ), {
 							date: formatDate( new Date( purchase.renew_date ), locale, { dateStyle: 'long' } ),
 						} );
@@ -719,13 +740,13 @@ function getFields( {
 						} );
 						if ( isExpired( purchase ) || isInExpirationGracePeriod( purchase ) ) {
 							return sprintf(
-								// translators: %(date)s is a formatted expiry date
+								// translators: %(date)s is a formatted expiry date like "January 1, 2027"
 								__( 'Expired on %(date)s.' ),
 								{ date }
 							);
 						}
 						return sprintf(
-							// translators: %(date)s is a formatted expiry date
+							// translators: %(date)s is a formatted expiry date like "January 1, 2027"
 							__( 'Expires on %(date)s.' ),
 							{ date }
 						);
@@ -810,6 +831,7 @@ function ManageSubscriptionCard( { purchase }: { purchase: Purchase } ) {
 	const { user } = useAuth();
 	const navigate = useNavigate();
 	const isSplitCancelRemoveEnabled = useIsSplitCancelRemoveEnabled();
+	const { data: allPurchases } = useQuery( userPurchasesQuery() );
 
 	if ( isIncludedWithPlan( purchase ) ) {
 		return null;
@@ -825,6 +847,19 @@ function ManageSubscriptionCard( { purchase }: { purchase: Purchase } ) {
 					onChange={ ( newData ) => {
 						if ( newData.is_auto_renew_enabled !== purchase.is_auto_renew_enabled ) {
 							if ( ! newData.is_auto_renew_enabled && isSplitCancelRemoveEnabled ) {
+								const sitePurchases = ( allPurchases ?? [] ).filter(
+									( p ) => p.blog_id === purchase.blog_id
+								);
+								const eligible = sitePurchases.filter(
+									( p ) => p.is_auto_renew_enabled || p.ID === purchase.ID
+								);
+								if ( eligible.length > 1 ) {
+									navigate( {
+										to: siteActionsRoute.fullPath,
+										params: { purchaseId: purchase.ID, action: 'auto-renew' as const },
+									} );
+									return;
+								}
 								navigate( {
 									to: cancelPurchaseRoute.fullPath,
 									params: { purchaseId: purchase.ID },
@@ -1272,7 +1307,7 @@ function PurchaseSecondSubtitle( {
 				<Text variant="muted">
 					{ description }{ ' ' }
 					{ sprintf(
-						// translators: %(numberOfMailboxes)d is a number of mailboxes and %(domain)s is a domain name
+						// translators: %(numberOfMailboxes)d is the number of mailboxes; %(domain)s is a domain name like "example.com"
 						_n(
 							'This purchase is for %(numberOfMailboxes)d mailbox for the domain %(domain)s.',
 							'This purchase is for %(numberOfMailboxes)d mailboxes for the domain %(domain)s.',
@@ -1309,7 +1344,7 @@ function PurchaseSubtitle( { purchase }: { purchase: Purchase } ) {
 		return (
 			<MetadataItem
 				title={ sprintf(
-					// translators: %(subtitle)s is the type of purchase (e.g. "Host Managed Plan"), %(partnerName)s is the name of the business partner
+					// translators: %(subtitle)s is the type of purchase (e.g. "Host Managed Plan"); %(partnerName)s is the name of the business partner
 					__( '%(subtitle)s. Please contact %(partnerName)s for details.' ),
 					{ subtitle, partnerName: purchase.partner_name }
 				) }

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-cancelled-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-cancelled-notice.tsx
@@ -13,10 +13,12 @@ import type { Purchase } from '@automattic/api-core';
 export function PurchaseCancelledNotice( {
 	purchase,
 	intent,
+	cancelledCount,
 	onClose,
 }: {
 	purchase: Purchase;
 	intent?: 'auto-renew';
+	cancelledCount?: number;
 	onClose: () => void;
 } ) {
 	// One-time purchases and edge cases without an expiry can't render a
@@ -68,16 +70,25 @@ export function PurchaseCancelledNotice( {
 		);
 	}
 
+	const isMultiple = cancelledCount && cancelledCount > 1;
 	const productNoun = getProductNounForCategory( classifyPurchaseForCopy( purchase ) );
 	return (
 		<Notice variant="success" onClose={ onClose }>
-			{ sprintf(
-				/* translators: %(productNoun)s is plan/domain/email/theme/plugin/subscription, %(expiryDate)s is a date like "April 21, 2027" */
-				__(
-					'Your subscription is cancelled and you won’t be billed again. You’ll continue to have access to the %(productNoun)s until %(expiryDate)s.'
-				),
-				{ productNoun, expiryDate }
-			) }
+			{ isMultiple
+				? sprintf(
+						/* translators: %(productNoun)s is plan/domain/email, %(expiryDate)s is a date like "April 21, 2027" */
+						__(
+							'Your subscriptions were cancelled and you won\u2019t be billed again. You\u2019ll continue to have access to the %(productNoun)s until %(expiryDate)s.'
+						),
+						{ productNoun, expiryDate }
+				  )
+				: sprintf(
+						/* translators: %(productNoun)s is plan/domain/email/theme/plugin/subscription, %(expiryDate)s is a date like "April 21, 2027" */
+						__(
+							'Your subscription is cancelled and you won\u2019t be billed again. You\u2019ll continue to have access to the %(productNoun)s until %(expiryDate)s.'
+						),
+						{ productNoun, expiryDate }
+				  ) }
 		</Notice>
 	);
 }

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -48,7 +48,8 @@ import type { Purchase } from '@automattic/api-core';
 export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 	const { user } = useAuth();
 	const isSplitCancelRemoveEnabled = useIsSplitCancelRemoveEnabled();
-	const { refunded, upgraded, cancelled, downgraded, intent } = purchaseSettingsRoute.useSearch();
+	const { refunded, upgraded, cancelled, downgraded, intent, cancelledCount } =
+		purchaseSettingsRoute.useSearch();
 	const navigate = purchaseSettingsRoute.useNavigate();
 	// Show the transient cancelled success notice once after a cancel redirects
 	// here. The URL search param is cleared immediately so that a refresh / back
@@ -59,7 +60,12 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 		if ( cancelled ) {
 			navigate( {
 				search: ( prev: Record< string, unknown > ) => {
-					const { cancelled: _cancelled, intent: _intent, ...rest } = prev;
+					const {
+						cancelled: _cancelled,
+						intent: _intent,
+						cancelledCount: _cancelledCount,
+						...rest
+					} = prev;
 					return rest;
 				},
 				replace: true,
@@ -129,6 +135,7 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 			<PurchaseCancelledNotice
 				purchase={ purchase }
 				intent={ cancelledIntent }
+				cancelledCount={ cancelledCount }
 				onClose={ () => setShowCancelledNotice( false ) }
 			/>
 		);

--- a/client/dashboard/me/billing-purchases/site-level-actions/index.tsx
+++ b/client/dashboard/me/billing-purchases/site-level-actions/index.tsx
@@ -191,7 +191,10 @@ export default function SiteLevelActions() {
 			navigate( {
 				to: cancelPurchaseRoute.fullPath,
 				params: { purchaseId: String( purchase.ID ) },
-				search: { intent: getCancelIntent( action ) },
+				search: {
+					intent: getCancelIntent( action ),
+					...( action === 'auto-renew' ? { source: 'auto-renew-toggle' as const } : {} ),
+				},
 				replace: true,
 			} );
 		}
@@ -228,13 +231,23 @@ export default function SiteLevelActions() {
 			return;
 		}
 
-		const additionalIds = selectedIds.filter( ( id ) => id !== String( purchase.ID ) );
+		// Pick the most important selected purchase as the primary for the
+		// cancel route — plan > non-plan — so the survey matches the highest-
+		// value product. The rest become additionalPurchaseIds.
+		const selectedPurchases = eligiblePurchases.filter( ( p ) =>
+			selectedIds.includes( String( p.ID ) )
+		);
+		const primaryPurchase = selectedPurchases.find( ( p ) => p.is_plan ) ?? selectedPurchases[ 0 ];
+		const additionalIds = selectedPurchases
+			.filter( ( p ) => p.ID !== primaryPurchase.ID )
+			.map( ( p ) => String( p.ID ) );
 		navigate( {
 			to: cancelPurchaseRoute.fullPath,
-			params: { purchaseId: purchase.ID },
+			params: { purchaseId: primaryPurchase.ID },
 			search: {
 				intent: getCancelIntent( action ),
 				...( additionalIds.length > 0 ? { additionalPurchaseIds: additionalIds.join( ',' ) } : {} ),
+				...( action === 'auto-renew' ? { source: 'auto-renew-toggle' as const } : {} ),
 			},
 		} );
 	};
@@ -253,13 +266,13 @@ export default function SiteLevelActions() {
 			case 'cancel':
 				return (
 					<Button variant="primary" isDestructive onClick={ handleContinue }>
-						{ __( 'Continue to cancel' ) }
+						{ __( 'Continue cancellation' ) }
 					</Button>
 				);
 			case 'remove':
 				return (
 					<Button variant="primary" isDestructive onClick={ handleContinue }>
-						{ __( 'Continue to remove' ) }
+						{ __( 'Continue removal' ) }
 					</Button>
 				);
 			case 'auto-renew':


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/RSM-490

Depends on: #110572

## Proposed Changes

This PR wires up the cancelation, removal, and auto-renew flows to the new multi-product interstitial.

<img width="1840" height="1196" alt="Screenshot 2026-05-08 at 1 50 46 PM" src="https://github.com/user-attachments/assets/e77e1601-66c8-4789-a3e5-31036fa14645" />
<img width="1839" height="1162" alt="image" src="https://github.com/user-attachments/assets/7c829ab4-0940-4f4d-8dcc-baa37640555f" />
<img width="1840" height="1196" alt="Screenshot 2026-05-08 at 1 50 29 PM" src="https://github.com/user-attachments/assets/d301dbc5-d308-488b-a721-75d0dcda14b8" />

More details about the changes:
* Purchase Settings cancel/remove buttons and auto-renew toggle-off now route through the site-level interstitial on multi-purchase sites (inline eligibility check, no flash).
* Cancel flow parses `additionalPurchaseIds` from the interstitial, fetches and deduplicates cancellation features across all selected purchases, and threads plural copy through headings, notices, feature lists, and button labels.
* Sequential batch mutations for additional purchases after the primary succeeds (individual failures non-fatal).
* Site-level interstitial promotes the plan to primary purchase when navigating to the cancel route.
* Pluralised success notice on Purchase Settings when multiple subscriptions are cancelled.
* Button labels updated: "Continue cancellation", "Continue removal", "Continue turning off auto-renew".

## Why are these changes being made?

Multi-purchase sites currently require users to cancel each subscription individually. This wires the site-level interstitial (shipped in #110572) into the cancel, remove, and auto-renew-off flows so users can act on multiple subscriptions at once — reducing friction and support volume.

## Testing Instructions

* Enable `purchases/split-cancel-remove` feature flag.
* Navigate to a site with multiple active subscriptions (plan + domain + email, for example).
* On Purchase Settings, click "Cancel subscription" — should redirect to the site-level interstitial showing eligible purchases with checkboxes.
* Select multiple purchases and continue — cancel flow should show plural headings ("Cancel subscriptions"), combined feature lists, and plural button labels.
* Complete the cancel flow — success notice should read "Your subscriptions were cancelled…" with the count.
* Repeat for "Remove" button and auto-renew toggle-off — each should route through the interstitial.
* On a single-subscription site, all three actions should bypass the interstitial and go directly to the cancel flow.