### PR TITLE
Reader achievements: refresh on visit + UI polish

### DIFF
--- a/client/data/reader/use-achievements-query.ts
+++ b/client/data/reader/use-achievements-query.ts
@@ -2,6 +2,10 @@ import { readAchievementsQuery } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
 import { useInfiniteQuery } from '@tanstack/react-query';
 
+interface UseAchievementsQueryOptions {
+	refetchOnMount?: boolean | 'always';
+}
+
 /**
  * Reads the achievements list and years of service from a single shared query.
  *
@@ -10,11 +14,15 @@ import { useInfiniteQuery } from '@tanstack/react-query';
  * `fetchNextPage` while `hasNextPage` is true. Consumers that only need page-1
  * data (e.g. badge contexts reading `yearsOfService`) can ignore pagination.
  */
-export function useAchievementsQuery( userIdOrLogin?: number | string ) {
+export function useAchievementsQuery(
+	userIdOrLogin?: number | string,
+	options: UseAchievementsQueryOptions = {}
+) {
 	const enabled = isEnabled( 'reader/achievements' ) && userIdOrLogin != null;
 	const query = useInfiniteQuery( {
 		...readAchievementsQuery( userIdOrLogin ),
 		enabled,
+		...options,
 	} );
 
 	return {

--- a/client/reader/user-profile/views/achievements/achievements-grid/achievement-card.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/achievement-card.tsx
@@ -1,4 +1,5 @@
 import { ProgressBar } from '@automattic/components';
+import { formatNumber } from '@automattic/number-formatters';
 import { Icon } from '@wordpress/components';
 import { lock } from '@wordpress/icons';
 import clsx from 'clsx';
@@ -57,7 +58,7 @@ export default function AchievementCard( {
 							total={ progressTarget }
 						/>
 						<span className="achievement-card__progress-label">
-							{ `${ progressCurrent ?? 0 }/${ progressTarget }` }
+							{ `${ formatNumber( progressCurrent ?? 0 ) }/${ formatNumber( progressTarget ) }` }
 						</span>
 					</div>
 				) }

--- a/client/reader/user-profile/views/achievements/achievements-grid/secret-achievement-card.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/secret-achievement-card.tsx
@@ -1,5 +1,6 @@
 import { TimeSince } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
 import AchievementCard from './achievement-card';
 
 interface SecretAchievementCardProps {
@@ -15,7 +16,20 @@ export default function SecretAchievementCard( {
 }: SecretAchievementCardProps ) {
 	const translate = useTranslate();
 	const title = translate( 'Secret achievement' );
-	const description = translate( 'This one’s a mystery. Earn it to reveal the details.' );
+	const descriptions = [
+		translate( 'This one’s a mystery. Earn it to reveal the details.' ),
+		translate( 'A secret achievement. Unlock it to see what’s inside.' ),
+		translate( 'Top secret. Earn it to read the briefing.' ),
+		translate( 'Shhh… this one’s a surprise. Unlock it to take a peek.' ),
+		translate( 'Classified for now. Earn it to see the file.' ),
+		translate( 'Some achievements prefer to stay hidden. Coax this one out.' ),
+		translate( 'No spoilers — earn it to find out what this one’s about.' ),
+		translate( 'A puzzle wrapped in a mystery. Earn it to uncover the answer.' ),
+		translate( 'Mystery achievement. Keep going — it’ll reveal itself.' ),
+		translate( 'Hidden in plain sight. Keep at it to unlock the details.' ),
+	];
+	const [ descriptionIndex ] = useState( () => Math.floor( Math.random() * descriptions.length ) );
+	const description = descriptions[ descriptionIndex ];
 	const caption = unlockedDate
 		? translate( 'Unlocked: {{timeSince/}}', {
 				components: { timeSince: <TimeSince date={ unlockedDate } /> },

--- a/client/reader/user-profile/views/achievements/achievements-grid/style.scss
+++ b/client/reader/user-profile/views/achievements/achievements-grid/style.scss
@@ -77,6 +77,7 @@
 
 	.achievement-card__progress-bar {
 		flex: 1;
+		overflow: hidden;
 	}
 
 	.achievement-card__progress-label {

--- a/client/reader/user-profile/views/achievements/achievements-grid/test/index.test.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/test/index.test.tsx
@@ -153,7 +153,7 @@ describe( 'AchievementsGrid', () => {
 		expect( screen.queryByText( /You.*unlocked them all/ ) ).not.toBeInTheDocument();
 	} );
 
-	test( 'renders locked secret with the secret title and mystery description', () => {
+	test( 'renders locked secret with the secret title', () => {
 		useAchievementsQuery.mockReturnValue( {
 			...baseQueryReturn,
 			achievements: [ earned() ],
@@ -163,9 +163,6 @@ describe( 'AchievementsGrid', () => {
 		renderGrid( { userLogin: 'me', isOwnProfile: true } );
 
 		expect( screen.getByText( 'Secret achievement' ) ).toBeVisible();
-		expect(
-			screen.getByText( /This one.*s a mystery\. Earn it to reveal the details\./ )
-		).toBeVisible();
 	} );
 
 	test( 'renders masked secret in earned list with caption Unlocked: <time>', () => {

--- a/client/reader/user-profile/views/achievements/index.tsx
+++ b/client/reader/user-profile/views/achievements/index.tsx
@@ -16,7 +16,9 @@ interface UserAchievementsProps {
 const UserAchievements = ( { user }: UserAchievementsProps ): JSX.Element | null => {
 	const translate = useTranslate();
 	const { isOwnProfile, isVisible, isLoading } = useAchievementsVisibility( user.user_login );
-	const { yearsOfService } = useAchievementsQuery( isVisible ? user.user_login : undefined );
+	const { yearsOfService } = useAchievementsQuery( isVisible ? user.user_login : undefined, {
+		refetchOnMount: 'always',
+	} );
 
 	if ( isLoading ) {
 		return (


### PR DESCRIPTION
Part of RSM-394

## Proposed Changes

* **Caching:** When the user navigates to the user-profile achievements view, the achievements list now refetches in the background once per visit (`refetchOnMount: 'always'`), while inline badge consumers (`author-achievement-badges`) keep the default behavior and respect the existing `staleTime`. Implemented via an `options` override on the shared `useAchievementsQuery` wrapper, applied only at the `UserAchievements` call site.
* **Progress bars:** Numbers in the progress label now go through `formatNumber` from `@automattic/number-formatters` so digit grouping is locale-aware, matching the convention used by the rest of the Reader. Small CSS tweak (`overflow: hidden` on the progress bar container) to clip the inner fill cleanly.
* **Secret cards:** The single hardcoded description on `SecretAchievementCard` becomes one of ten random variations. The variation is picked once per card on mount via a `useState` initializer, so it stays stable for the rest of the session.

## Why are these changes being made?

Achievement data was sticky — the only way to force a refresh inside `staleTime` was to wipe the app's IndexedDB. `refetchOnMount: 'always'` scoped to the user-profile view gives a friendlier "fresh on arrival" feel without trashing the cache for the inline badges that just need `yearsOfService`.

The progress label and secret description tweaks were small UX nits surfaced while reviewing the same surface — the unformatted progress numbers looked off for large values, and the single secret-achievement copy got repetitive once there are several masked secrets on screen.

## Testing Instructions

1. Visit any Reader user profile that has achievements (e.g. your own).
2. Confirm achievements render from cache (if any) and a background refetch fires — visible in DevTools Network as a `read/achievements` request on every entry to the page.
3. Stay on the page: no further refetches until `staleTime` (10 min) expires.
4. Navigate away and come back: a single refetch fires.
5. Visit a feed item from an author that uses `author-achievement-badges`: the inline badge should NOT trigger a new request if recent data is cached.
6. On the achievements grid, a card with a progress bar should show locale-formatted numbers (e.g. `1,234/5,000` in `en`).
7. Reload the page a few times and confirm masked-secret cards show varying descriptions across the grid; each card's description stays stable while the page is open.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?