### PR TITLE
E2E: Fix WooCommerce TOTP dashboard assertion

### DIFF
--- a/test/e2e/specs/authentication/authentication__totp.spec.ts
+++ b/test/e2e/specs/authentication/authentication__totp.spec.ts
@@ -108,13 +108,14 @@ test.describe(
 				await pageLogin.submitVerificationCode( code );
 			} );
 
-			await test.step( 'Then I am see the my dashboard page on WooCommerce.com', async function () {
-				await expect
-					.poll( async () => page.url() )
-					.toBe( `${ environment.WOO_BASE_URL }/my-dashboard/` );
+			await test.step( 'Then I see the WooCommerce.com dashboard page', async function () {
+				await expect( page ).toHaveURL( `${ environment.WOO_BASE_URL }/my-dashboard/` );
 
-				// The Log Out link is only visible to authenticated users.
-				await expect( page.getByRole( 'link', { name: /log ?out/i } ) ).toBeVisible();
+				// These dashboard headings are only visible after a successful WooCommerce.com login.
+				await expect( page.getByRole( 'heading', { name: 'My account' } ) ).toBeVisible();
+				await expect(
+					page.getByRole( 'heading', { name: 'Welcome to the world of WooCommerce!' } )
+				).toBeVisible();
 			} );
 		} );
 	}


### PR DESCRIPTION
Follow-up fix to #110012

## Proposed Changes

* Update the WooCommerce.com TOTP E2E final assertion to verify authenticated dashboard headings instead of a visible Log Out link.
* Use Playwright `toHaveURL()` for the dashboard redirect assertion.

## Root Cause Analysis

* Classification: test-only change needed.
* `git bisect` identifies `65f5021a1d3` / #110012 as the first commit that introduced the failing assertion.
* That change correctly tried to avoid a URL-only false positive, but it used a visible `Log Out` link as the authenticated-state signal. Current WooCommerce.com dashboard artifacts show authenticated account content without an accessible `Log Out` link on the captured page.
* TeamCity first recorded this failure in Authentication build #4777 on April 23, 2026. The latest checked failure still has the same locator failure.
* A fresh logged-out visit to `/my-dashboard/` redirects to WordPress.com login and does not show the replacement dashboard headings, so this keeps the test meaningful without depending on hidden account-menu UI.

## Why are these changes being made?

* Authentication E2E has been failing since build #4777. The test reaches `/my-dashboard/` and shows the WooCommerce.com account dashboard, but no accessible Log Out link is visible in the captured page.
* This PR preserves the stronger post-login check by asserting authenticated-only dashboard content instead.

## Testing Instructions

* `yarn prettier --ignore-path .eslintignore --write test/e2e/specs/authentication/authentication__totp.spec.ts`
* `yarn eslint --ext .ts --cache test/e2e/specs/authentication/authentication__totp.spec.ts`
* `git diff --check`
* From `test/e2e`: `CALYPSO_BASE_URL=https://wordpress.com HEADLESS=true yarn playwright test specs/authentication/authentication__totp.spec.ts --project=authentication --grep "WooCommerce.com" --reporter=list`
* From `test/e2e`: `CALYPSO_BASE_URL=https://wordpress.com HEADLESS=true yarn playwright test --project=authentication --grep @authentication --reporter=list`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
