### PR TITLE
Arcade Mode: i18n, masterbar gating, SCSS-imported font

### DIFF
--- a/client/layout/arcade-mode/activate.ts
+++ b/client/layout/arcade-mode/activate.ts
@@ -1,15 +1,16 @@
+import { __ } from '@wordpress/i18n';
 import './style.scss';
 
 const BODY_CLASS = 'is-arcade-mode';
-const FLASH_CLASS = 'is-arcade-mode--just-activated';
+const FLASH_CLASS = 'arcade-mode-flash';
 const FLASH_DURATION_MS = 1500;
-const FONT_LINK_ID = 'arcade-mode-font';
-const FONT_HREF = 'https://fonts.googleapis.com/css2?family=VT323&display=swap';
 const LIVES_ID = 'arcade-mode-lives';
+const MASTERBAR_RIGHT_SELECTOR = '.masterbar__section--right';
 
 let active = false;
 let escapeListener: ( ( event: KeyboardEvent ) => void ) | null = null;
 let flashTimeout: number | null = null;
+let flashElement: HTMLElement | null = null;
 
 function isEditableTarget( target: EventTarget | null ): boolean {
 	if ( ! ( target instanceof HTMLElement ) ) {
@@ -19,34 +20,32 @@ function isEditableTarget( target: EventTarget | null ): boolean {
 	return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || target.isContentEditable;
 }
 
-function loadFont(): void {
-	if ( document.getElementById( FONT_LINK_ID ) ) {
-		return;
-	}
-	const link = document.createElement( 'link' );
-	link.id = FONT_LINK_ID;
-	link.rel = 'stylesheet';
-	link.href = FONT_HREF;
-	document.head.appendChild( link );
-}
-
-function mountLivesCounter(): void {
+function mountLivesCounter( section: Element ): void {
 	if ( document.getElementById( LIVES_ID ) ) {
 		return;
 	}
 	const wrapper = document.createElement( 'div' );
 	wrapper.id = LIVES_ID;
 	wrapper.className = 'masterbar__item-wrapper';
-	wrapper.innerHTML =
-		'<div class="masterbar__item arcade-lives" aria-label="30 lives" role="status">' +
-		'<span class="arcade-lives__icon" aria-hidden="true">🕹</span>' +
-		'<span class="masterbar__item-content">30 LIVES</span>' +
-		'</div>';
 
-	const section = document.querySelector( '.masterbar__section--right' );
-	if ( ! section ) {
-		return;
-	}
+	const item = document.createElement( 'div' );
+	item.className = 'masterbar__item arcade-lives';
+	item.setAttribute( 'role', 'status' );
+	item.setAttribute( 'aria-label', __( '30 lives' ) );
+
+	const icon = document.createElement( 'span' );
+	icon.className = 'arcade-lives__icon';
+	icon.setAttribute( 'aria-hidden', 'true' );
+	icon.textContent = '🕹';
+
+	const label = document.createElement( 'span' );
+	label.className = 'masterbar__item-content';
+	label.textContent = __( '30 LIVES' );
+
+	item.appendChild( icon );
+	item.appendChild( label );
+	wrapper.appendChild( item );
+
 	const profile = section.querySelector( '.masterbar__item-howdy' );
 	const profileWrapper =
 		( profile?.closest( '.masterbar__item-wrapper' ) as Element | null ) ?? profile;
@@ -57,13 +56,23 @@ function mountLivesCounter(): void {
 	}
 }
 
+function mountFlashBanner(): void {
+	flashElement = document.createElement( 'div' );
+	flashElement.className = FLASH_CLASS;
+	flashElement.setAttribute( 'role', 'status' );
+	flashElement.textContent = __( 'ARCADE MODE ACTIVATED' );
+	document.body.appendChild( flashElement );
+}
+
 function deactivate(): void {
 	if ( ! active ) {
 		return;
 	}
 	active = false;
-	document.body.classList.remove( BODY_CLASS, FLASH_CLASS );
+	document.body.classList.remove( BODY_CLASS );
 	document.getElementById( LIVES_ID )?.remove();
+	flashElement?.remove();
+	flashElement = null;
 	if ( escapeListener ) {
 		document.removeEventListener( 'keydown', escapeListener );
 		escapeListener = null;
@@ -78,14 +87,23 @@ export function activateArcadeMode(): void {
 	if ( active ) {
 		return;
 	}
+	// Arcade mode renders chrome inside the masterbar. Surfaces without a
+	// masterbar (logged-out flows, EmptyMasterbar, MSD Reader, checkout-failed)
+	// would only get a partial activation, so bail before any side effects.
+	const section = document.querySelector( MASTERBAR_RIGHT_SELECTOR );
+	if ( ! section ) {
+		return;
+	}
+
 	active = true;
 
-	document.body.classList.add( BODY_CLASS, FLASH_CLASS );
-	loadFont();
-	mountLivesCounter();
+	document.body.classList.add( BODY_CLASS );
+	mountLivesCounter( section );
+	mountFlashBanner();
 
 	flashTimeout = window.setTimeout( () => {
-		document.body.classList.remove( FLASH_CLASS );
+		flashElement?.remove();
+		flashElement = null;
 		flashTimeout = null;
 	}, FLASH_DURATION_MS );
 

--- a/client/layout/arcade-mode/style.scss
+++ b/client/layout/arcade-mode/style.scss
@@ -1,3 +1,5 @@
+@import "https://fonts.googleapis.com/css?family=VT323&display=swap";
+
 // Konami code easter egg — Arcade Mode visuals.
 // All selectors are gated behind body.is-arcade-mode so they have no effect when off.
 
@@ -82,8 +84,7 @@ body.is-arcade-mode {
 }
 
 // One-shot activation banner (auto-removed after 1.5s).
-body.is-arcade-mode--just-activated::after {
-	content: 'ARCADE MODE ACTIVATED';
+.arcade-mode-flash {
 	position: fixed;
 	inset: 0;
 	display: flex;

--- a/client/layout/arcade-mode/test/index.test.tsx
+++ b/client/layout/arcade-mode/test/index.test.tsx
@@ -36,6 +36,19 @@ async function flushImport() {
 	await Promise.resolve();
 }
 
+function mountFakeMasterbar() {
+	const section = document.createElement( 'div' );
+	section.className = 'masterbar__section--right';
+	const profileWrapper = document.createElement( 'div' );
+	profileWrapper.className = 'masterbar__item-wrapper';
+	const profile = document.createElement( 'div' );
+	profile.className = 'masterbar__item-howdy';
+	profileWrapper.appendChild( profile );
+	section.appendChild( profileWrapper );
+	document.body.appendChild( section );
+	return section;
+}
+
 describe( 'installKonamiListener', () => {
 	let uninstall: () => void;
 
@@ -90,17 +103,48 @@ describe( 'installKonamiListener', () => {
 } );
 
 describe( 'activateArcadeMode', () => {
+	let masterbar: HTMLElement | null = null;
+
+	beforeEach( () => {
+		masterbar = mountFakeMasterbar();
+	} );
+
 	afterEach( () => {
 		// Send Escape to deactivate, then sweep any leftovers from a failed test.
 		dispatchKey( 'Escape' );
-		document.body.classList.remove( 'is-arcade-mode', 'is-arcade-mode--just-activated' );
-		document.getElementById( 'arcade-mode-font' )?.remove();
+		document.body.classList.remove( 'is-arcade-mode' );
 		document.getElementById( 'arcade-mode-lives' )?.remove();
+		document.querySelectorAll( '.arcade-mode-flash' ).forEach( ( node ) => node.remove() );
+		masterbar?.remove();
+		masterbar = null;
 	} );
 
 	it( 'adds the arcade body class', () => {
 		realActivate.activateArcadeMode();
 		expect( document.body.classList.contains( 'is-arcade-mode' ) ).toBe( true );
+	} );
+
+	it( 'mounts the lives counter inside the masterbar', () => {
+		realActivate.activateArcadeMode();
+		const counter = document.getElementById( 'arcade-mode-lives' );
+		expect( counter ).not.toBeNull();
+		expect( counter?.parentElement ).toBe( masterbar );
+	} );
+
+	it( 'mounts a translatable flash banner', () => {
+		realActivate.activateArcadeMode();
+		const banner = document.querySelector( '.arcade-mode-flash' );
+		expect( banner ).not.toBeNull();
+		expect( banner?.textContent ).toBeTruthy();
+	} );
+
+	it( 'does not activate when the masterbar is absent', () => {
+		masterbar?.remove();
+		masterbar = null;
+		realActivate.activateArcadeMode();
+		expect( document.body.classList.contains( 'is-arcade-mode' ) ).toBe( false );
+		expect( document.getElementById( 'arcade-mode-lives' ) ).toBeNull();
+		expect( document.querySelector( '.arcade-mode-flash' ) ).toBeNull();
 	} );
 
 	it( 'removes the arcade body class when Escape is pressed', () => {
@@ -118,10 +162,10 @@ describe( 'activateArcadeMode', () => {
 		input.remove();
 	} );
 
-	it( 'is idempotent — calling again while active does not re-add side effects', () => {
+	it( 'is idempotent — calling again while active does not duplicate the lives counter', () => {
 		realActivate.activateArcadeMode();
 		realActivate.activateArcadeMode();
-		expect( document.querySelectorAll( '#arcade-mode-font' ) ).toHaveLength( 1 );
+		expect( document.querySelectorAll( '#arcade-mode-lives' ) ).toHaveLength( 1 );
 	} );
 
 	it( 'allows re-activation after Escape', () => {


### PR DESCRIPTION
> [!NOTE]
> Companion to the Arcade Mode easter egg PR at #110422.

## Proposed Changes

- **i18n**: route user-facing strings through \`@wordpress/i18n\`'s \`__()\` (matches \`client/layout/masterbar/logged-in.jsx\` and friends): the \`aria-label\`, the \"30 LIVES\" counter text, and the \"ARCADE MODE ACTIVATED\" banner. The flash banner moves from a CSS \`::after\` pseudo-element to a real DOM node so its text can be localized. I know things were left intentionally untranslated in the original branch, but we can have fun with arcade in non-english speaking countries too :)
- **Gate to surfaces with a masterbar**: \`activateArcadeMode()\` now bails before any side effect when \`.masterbar__section--right\` is absent. Previously the body class, scan-line overlay, font, and Escape listener applied even on logged-out flows / \`EmptyMasterbar\` / MSD Reader / failed-checkout, where the lives counter would silently fail to mount — a half-on state. Now: no masterbar, no activation.
- **Load VT323 via SCSS \`@import\`**: matches the rest of the codebase (Reader, site-profiler, bloganuary, Jetpack Cloud pricing, etc.). Removes the runtime \`loadFont()\` helper, the \`<link>\` injected into \`<head>\`, and the dedup logic. The font still ships in the same async chunk as the rest of \`activate\`, so the lazy-load behavior is preserved.

## Why are these changes being made?

Pre-merge polish on the easter egg:

- All user-facing copy in Calypso should be translatable, even for an easter egg — at minimum, the \`aria-label\` is announced by screen readers regardless of locale.
- A half-activated state (CRT body styling, no lives counter) is more confusing than no activation at all on surfaces that don't render a masterbar.
- Following the established \`@import\` pattern keeps the font load consistent with how every other Google-Font-using stylesheet in the repo handles it, and removes a small chunk of imperative DOM code.

The lives-counter-vanishing-from-React-reconciliation concern from the review is intentionally not addressed here — it's low-stakes for an easter egg and a \`MutationObserver\` / portal would be overkill.

## Testing Instructions

1. \`yarn start\` and visit any Calypso surface that renders the masterbar while logged in.
2. Type the Konami code (↑ ↑ ↓ ↓ ← → ← → B A). Expect: the CRT/neon body styling, the green \"ARCADE MODE ACTIVATED\" banner (now a real DOM element, not a pseudo-element), and the \"30 LIVES\" counter inserted into the right side of the masterbar before the profile menu.
3. Press Escape — everything reverts.
4. Log out (or visit a checkout surface, MSD Reader, or any \`masterbarIsHidden\` flow) and try the Konami code: nothing should happen — no body class, no flash, no Escape listener.
5. Confirm the VT323 font is loaded (Network tab → \`fonts.googleapis.com/css?family=VT323…\`) only after activation.
6. \`yarn test-client client/layout/arcade-mode\` — 12 tests pass, including the new \"does not activate when the masterbar is absent\" case.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the \"[Status] String Freeze\" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the \"[Status] Needs Privacy Updates\" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?