### PR TITLE
E2E: Harden WooCommerce TOTP login redirect

### DIFF
--- a/test/e2e/specs/authentication/authentication__totp.spec.ts
+++ b/test/e2e/specs/authentication/authentication__totp.spec.ts
@@ -1,6 +1,8 @@
 import { DataHelper, TOTPClient } from '@automattic/calypso-e2e';
 import { expect, tags, test } from '../../lib/pw-base';
 
+const WOO_LOGIN_TIMEOUT = 30_000;
+
 test.describe(
 	'Authentication: Time-based One Time Passcode (TOTP)',
 	{ tag: [ tags.AUTHENTICATION ] },
@@ -80,13 +82,18 @@ test.describe(
 			} );
 
 			await test.step( 'And I choose to log in', async function () {
-				await page.getByRole( 'link', { name: 'Log in' } ).click();
+				const loginLink = page.getByRole( 'link', { name: 'Log in', exact: true } );
+				await expect( loginLink ).toBeVisible( { timeout: WOO_LOGIN_TIMEOUT } );
+				await loginLink.click();
+				await expect( page ).toHaveURL( /wordpress\.com\/log-in/, {
+					timeout: WOO_LOGIN_TIMEOUT,
+				} );
 			} );
 
 			await test.step( 'Then I see the WordPress.com log in page', async function () {
 				await expect(
 					page.getByRole( 'heading', { name: 'Log in to Woo with WordPress.com' } )
-				).toBeVisible();
+				).toBeVisible( { timeout: WOO_LOGIN_TIMEOUT } );
 			} );
 
 			await test.step( 'When I enter my username', async function () {


### PR DESCRIPTION
## Proposed Changes

* Add an explicit wait for the WooCommerce.com login link before clicking it.
* Assert that the WooCommerce.com SSO hop reaches the WordPress.com login page before entering credentials.
* Apply the same bounded wait to the WordPress.com login heading assertion.

## Why are these changes being made?

* A recent Authentication E2E run timed out during the WooCommerce.com SSO hop before credentials were entered.
* This keeps the test on the same critical user workflow while making the external redirect readiness explicit.

## Testing Instructions

* `CALYPSO_BASE_URL=https://wordpress.com WOO_BASE_URL=https://woocommerce.com yarn playwright test specs/authentication/authentication__totp.spec.ts --project=authentication --grep @authentication --reporter=list --workers=1`
  * 3 passed in 1.1m.
* `yarn prettier --check test/e2e/specs/authentication/authentication__totp.spec.ts`
* `yarn eslint test/e2e/specs/authentication/authentication__totp.spec.ts`
* `git diff --check`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?