### PR TITLE
Reader social: play videos inline on click in non-target thread nodes

### DIFF
--- a/client/reader/social/AGENTS.md
+++ b/client/reader/social/AGENTS.md
@@ -239,8 +239,11 @@ the timeline). When `expanded={true}`, the component renders a native
 
 The thumbnail is used as the `<video poster>` so users see a frame before
 hitting play. `<SocialPostCard>` forwards `expandedVideo` only for the
-highlighted root node inside `<ThreadTree>` — replies and parents stay
-thumbnail-only.
+highlighted root node inside `<ThreadTree>` — replies and parents render
+as thumbnail buttons by default. Clicking a thumbnail flips the embed to
+the player inline (no navigation) and autoplays inside the click's
+user-gesture window, so video posts deeper in a thread don't require a
+detour through the post detail view to play.
 
 This mirrors what bsky.app's own web app and other modern Bluesky clients do.
 The static `embed.bsky.app` widget was an earlier attempt but doesn't include

--- a/client/reader/social/components/post-card/post-card-embed-video.tsx
+++ b/client/reader/social/components/post-card/post-card-embed-video.tsx
@@ -38,10 +38,11 @@ export function PostCardEmbedVideo( { embed, expanded }: PostCardEmbedVideoProps
 			if ( shouldAutoPlayRef.current ) {
 				shouldAutoPlayRef.current = false;
 				// Browsers permit play() inside the user-gesture window
-				// opened by the click that flipped userExpanded; if the
-				// promise is rejected (e.g. autoplay policy on a
-				// detached connection) the user can still hit the
-				// native controls.
+				// opened by the click that flipped userExpanded. If the
+				// promise rejects (autoplay policy revoked across an
+				// async boundary on stricter mobile engines, source not
+				// yet attached, etc.) the native controls remain
+				// available as the user-visible recovery path.
 				video.play().catch( () => {} );
 			}
 		};

--- a/client/reader/social/components/post-card/post-card-embed-video.tsx
+++ b/client/reader/social/components/post-card/post-card-embed-video.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { SocialEmbedVideo } from '../../types';
 
 interface PostCardEmbedVideoProps {
@@ -12,22 +12,43 @@ const HLS_MIME = 'application/vnd.apple.mpegurl';
 export function PostCardEmbedVideo( { embed, expanded }: PostCardEmbedVideoProps ) {
 	const translate = useTranslate();
 	const videoRef = useRef< HTMLVideoElement >( null );
+	// Tracks user-initiated expansion: clicking the thumbnail in a
+	// non-target thread node should expand the player inline, not navigate
+	// via the card-link overlay. We also use this to autoplay only on
+	// click — prop-driven expansion (the thread root) keeps its existing
+	// "render player but wait for the user to hit play" behaviour.
+	const [ userExpanded, setUserExpanded ] = useState( false );
+	const shouldAutoPlayRef = useRef( false );
+	const isExpanded = expanded || userExpanded;
+
 	const aspectRatioCss = embed.aspect_ratio
 		? `${ embed.aspect_ratio.width } / ${ embed.aspect_ratio.height }`
 		: undefined;
 	const containerStyle = aspectRatioCss ? { aspectRatio: aspectRatioCss } : undefined;
 
 	useEffect( () => {
-		if ( ! expanded ) {
+		if ( ! isExpanded ) {
 			return;
 		}
 		const video = videoRef.current;
 		if ( ! video ) {
 			return;
 		}
+		const playIfRequested = () => {
+			if ( shouldAutoPlayRef.current ) {
+				shouldAutoPlayRef.current = false;
+				// Browsers permit play() inside the user-gesture window
+				// opened by the click that flipped userExpanded; if the
+				// promise is rejected (e.g. autoplay policy on a
+				// detached connection) the user can still hit the
+				// native controls.
+				video.play().catch( () => {} );
+			}
+		};
 		// Safari + iOS WebKit play HLS natively; setting src is enough.
 		if ( video.canPlayType( HLS_MIME ) ) {
 			video.src = embed.playlist;
+			playIfRequested();
 			return () => {
 				// Switching threads while audio plays would otherwise leave
 				// the previous track buffered for a frame.
@@ -53,17 +74,18 @@ export function PostCardEmbedVideo( { embed, expanded }: PostCardEmbedVideoProps
 			hls = instance;
 			instance.loadSource( embed.playlist );
 			instance.attachMedia( video );
+			playIfRequested();
 		} )();
 		return () => {
 			cancelled = true;
 			hls?.destroy();
 			video.pause();
 		};
-	}, [ expanded, embed.playlist ] );
+	}, [ isExpanded, embed.playlist ] );
 
 	const accessibleLabel = embed.alt || String( translate( 'Bluesky video' ) );
 
-	if ( expanded ) {
+	if ( isExpanded ) {
 		return (
 			<div className="social-post-card-embed-video" style={ containerStyle }>
 				{ /* eslint-disable-next-line jsx-a11y/media-has-caption -- Bluesky's video upload flow does not produce captions. */ }
@@ -80,8 +102,25 @@ export function PostCardEmbedVideo( { embed, expanded }: PostCardEmbedVideoProps
 		);
 	}
 
+	const playLabel = String(
+		translate( 'Play video: %(label)s', {
+			args: { label: accessibleLabel },
+			comment:
+				'Accessible label for the play button overlaid on a Bluesky/Mastodon video thumbnail; %(label)s is the video alt text or a generic fallback.',
+		} )
+	);
+
 	return (
-		<div className="social-post-card-embed-video" style={ containerStyle }>
+		<button
+			type="button"
+			className="social-post-card-embed-video social-post-card-embed-video--thumbnail"
+			style={ containerStyle }
+			aria-label={ playLabel }
+			onClick={ () => {
+				shouldAutoPlayRef.current = true;
+				setUserExpanded( true );
+			} }
+		>
 			<img
 				className="social-post-card-embed-video__thumbnail"
 				src={ embed.thumbnail }
@@ -95,6 +134,6 @@ export function PostCardEmbedVideo( { embed, expanded }: PostCardEmbedVideoProps
 			<span className="social-post-card-embed-video__play" aria-hidden="true">
 				▶
 			</span>
-		</div>
+		</button>
 	);
 }

--- a/client/reader/social/components/post-card/post-card-embed-video.tsx
+++ b/client/reader/social/components/post-card/post-card-embed-video.tsx
@@ -55,6 +55,10 @@ export function PostCardEmbedVideo( { embed, expanded }: PostCardEmbedVideoProps
 				video.pause();
 				video.removeAttribute( 'src' );
 				video.load();
+				// Drop any unconsumed autoplay intent so a later effect run
+				// (e.g. embed.playlist changing in-place) doesn't autoplay
+				// without a fresh user gesture.
+				shouldAutoPlayRef.current = false;
 			};
 		}
 		// Other browsers: lazy-load hls.js (kept out of the timeline chunk).
@@ -80,6 +84,7 @@ export function PostCardEmbedVideo( { embed, expanded }: PostCardEmbedVideoProps
 			cancelled = true;
 			hls?.destroy();
 			video.pause();
+			shouldAutoPlayRef.current = false;
 		};
 	}, [ isExpanded, embed.playlist ] );
 

--- a/client/reader/social/components/post-card/style.scss
+++ b/client/reader/social/components/post-card/style.scss
@@ -12,6 +12,7 @@
 	a.social-post-card-embed-external,
 	.social-post-card-embed-quote-link,
 	button.social-post-card-embed-images__item,
+	button.social-post-card-embed-video--thumbnail,
 	.social-post-card-embed-audio,
 	.social-post-card-embed-gifv,
 	.social-post-card-content-warning .components-button,
@@ -408,6 +409,27 @@ a.social-post-card-header__timestamp::after {
 	border-radius: 8px;
 	margin-top: 8px;
 	background: var( --studio-gray-90 );
+}
+
+// Reset native button chrome so the thumbnail-as-play-button matches the
+// flush card styling. The button still has the inner-anchor z-index lift
+// on `.social-post-card-link` so it intercepts clicks above the
+// timestamp ::after overlay.
+button.social-post-card-embed-video--thumbnail {
+	display: block;
+	padding: 0;
+	border: 0;
+	background: var( --studio-gray-90 );
+	cursor: pointer;
+	width: 100%;
+	color: inherit;
+	font: inherit;
+	text-align: inherit;
+
+	&:focus-visible {
+		outline: 2px solid var( --studio-blue-50 );
+		outline-offset: 2px;
+	}
 }
 
 .social-post-card-embed-video__thumbnail {

--- a/client/reader/social/components/post-card/test/post-card-embed-video.test.tsx
+++ b/client/reader/social/components/post-card/test/post-card-embed-video.test.tsx
@@ -1,10 +1,22 @@
 /**
  * @jest-environment jsdom
  */
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { PostCardEmbedVideo } from '../post-card-embed-video';
 import type { AtmosphereEmbedVideo } from '@automattic/api-core';
+
+const mockHls = {
+	loadSource: jest.fn(),
+	attachMedia: jest.fn(),
+	destroy: jest.fn(),
+};
+
+jest.mock( 'hls.js', () => {
+	const Hls = jest.fn().mockImplementation( () => mockHls );
+	( Hls as unknown as { isSupported: () => boolean } ).isSupported = () => true;
+	return { __esModule: true, default: Hls };
+} );
 
 const embed: AtmosphereEmbedVideo = {
 	type: 'video',
@@ -15,6 +27,20 @@ const embed: AtmosphereEmbedVideo = {
 };
 
 describe( 'PostCardEmbedVideo', () => {
+	// JSDOM's HTMLMediaElement.play returns undefined; the spec says it
+	// returns a Promise. Stub a resolved promise so production code's
+	// `video.play().catch(...)` doesn't crash in the default test path.
+	let originalPlay: typeof window.HTMLMediaElement.prototype.play;
+	let playMock: jest.Mock< Promise< void >, [] >;
+	beforeEach( () => {
+		originalPlay = window.HTMLMediaElement.prototype.play;
+		playMock = jest.fn< Promise< void >, [] >().mockResolvedValue( undefined );
+		window.HTMLMediaElement.prototype.play = playMock;
+	} );
+	afterEach( () => {
+		window.HTMLMediaElement.prototype.play = originalPlay;
+	} );
+
 	it( 'renders a thumbnail in the default (non-expanded) mode', () => {
 		render( <PostCardEmbedVideo embed={ embed } /> );
 		const img = screen.getByRole( 'img', { name: 'Cute cat' } );
@@ -85,5 +111,55 @@ describe( 'PostCardEmbedVideo', () => {
 
 		const video = screen.getByLabelText( 'Cute cat' );
 		expect( video.tagName ).toBe( 'VIDEO' );
+	} );
+
+	it( 'does not autoplay when expanded via the prop (thread root)', () => {
+		const originalCanPlayType = window.HTMLMediaElement.prototype.canPlayType;
+		window.HTMLMediaElement.prototype.canPlayType = function ( type: string ) {
+			return type === 'application/vnd.apple.mpegurl' ? 'maybe' : '';
+		};
+		try {
+			render( <PostCardEmbedVideo embed={ embed } expanded /> );
+			expect( playMock ).not.toHaveBeenCalled();
+		} finally {
+			window.HTMLMediaElement.prototype.canPlayType = originalCanPlayType;
+		}
+	} );
+
+	it( 'autoplays after attachMedia on the hls.js branch when the thumbnail is clicked', async () => {
+		mockHls.loadSource.mockClear();
+		mockHls.attachMedia.mockClear();
+		mockHls.destroy.mockClear();
+		const user = userEvent.setup();
+		const originalCanPlayType = window.HTMLMediaElement.prototype.canPlayType;
+		// Force the non-Safari branch so the dynamic hls.js import path runs.
+		window.HTMLMediaElement.prototype.canPlayType = () => '';
+		try {
+			render( <PostCardEmbedVideo embed={ embed } /> );
+			await user.click( screen.getByRole( 'button', { name: /play video/i } ) );
+			await waitFor( () => expect( mockHls.attachMedia ).toHaveBeenCalledTimes( 1 ) );
+			await waitFor( () => expect( playMock ).toHaveBeenCalledTimes( 1 ) );
+			expect( mockHls.loadSource ).toHaveBeenCalledWith( embed.playlist );
+		} finally {
+			window.HTMLMediaElement.prototype.canPlayType = originalCanPlayType;
+		}
+	} );
+
+	it( 'requests playback inside the user-gesture window when the thumbnail is clicked', async () => {
+		const user = userEvent.setup();
+		const originalCanPlayType = window.HTMLMediaElement.prototype.canPlayType;
+		// Take the native-HLS branch so play() is invoked synchronously
+		// inside the same effect tick that flips the embed open, mirroring
+		// the user-gesture window the production code relies on.
+		window.HTMLMediaElement.prototype.canPlayType = function ( type: string ) {
+			return type === 'application/vnd.apple.mpegurl' ? 'maybe' : '';
+		};
+		try {
+			render( <PostCardEmbedVideo embed={ embed } /> );
+			await user.click( screen.getByRole( 'button', { name: /play video/i } ) );
+			expect( playMock ).toHaveBeenCalledTimes( 1 );
+		} finally {
+			window.HTMLMediaElement.prototype.canPlayType = originalCanPlayType;
+		}
 	} );
 } );

--- a/client/reader/social/components/post-card/test/post-card-embed-video.test.tsx
+++ b/client/reader/social/components/post-card/test/post-card-embed-video.test.tsx
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { PostCardEmbedVideo } from '../post-card-embed-video';
 import type { AtmosphereEmbedVideo } from '@automattic/api-core';
 
@@ -66,5 +67,23 @@ describe( 'PostCardEmbedVideo', () => {
 		const { container } = render( <PostCardEmbedVideo embed={ embed } expanded /> );
 		const wrapper = container.querySelector< HTMLDivElement >( '.social-post-card-embed-video' );
 		expect( wrapper?.style.aspectRatio ).toBe( '16 / 9' );
+	} );
+
+	it( 'renders the thumbnail as a button so clicks expand the player inline', () => {
+		render( <PostCardEmbedVideo embed={ embed } /> );
+		const button = screen.getByRole( 'button', { name: /play video/i } );
+		expect( button ).toBeVisible();
+	} );
+
+	it( 'replaces the thumbnail with a video element when the user clicks play', async () => {
+		const user = userEvent.setup();
+		render( <PostCardEmbedVideo embed={ embed } /> );
+
+		expect( screen.queryByLabelText( 'Cute cat' ) ).not.toBeInTheDocument();
+
+		await user.click( screen.getByRole( 'button', { name: /play video/i } ) );
+
+		const video = screen.getByLabelText( 'Cute cat' );
+		expect( video.tagName ).toBe( 'VIDEO' );
 	} );
 } );

--- a/client/reader/social/components/post-card/test/post-card-embed-video.test.tsx
+++ b/client/reader/social/components/post-card/test/post-card-embed-video.test.tsx
@@ -3,6 +3,7 @@
  */
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import Hls from 'hls.js';
 import { PostCardEmbedVideo } from '../post-card-embed-video';
 import type { AtmosphereEmbedVideo } from '@automattic/api-core';
 
@@ -13,10 +14,12 @@ const mockHls = {
 };
 
 jest.mock( 'hls.js', () => {
-	const Hls = jest.fn().mockImplementation( () => mockHls );
-	( Hls as unknown as { isSupported: () => boolean } ).isSupported = () => true;
-	return { __esModule: true, default: Hls };
+	const HlsCtor = jest.fn().mockImplementation( () => mockHls );
+	( HlsCtor as unknown as { isSupported: () => boolean } ).isSupported = () => true;
+	return { __esModule: true, default: HlsCtor };
 } );
+
+const HlsMock = Hls as unknown as jest.Mock;
 
 const embed: AtmosphereEmbedVideo = {
 	type: 'video',
@@ -36,6 +39,10 @@ describe( 'PostCardEmbedVideo', () => {
 		originalPlay = window.HTMLMediaElement.prototype.play;
 		playMock = jest.fn< Promise< void >, [] >().mockResolvedValue( undefined );
 		window.HTMLMediaElement.prototype.play = playMock;
+		HlsMock.mockClear();
+		mockHls.loadSource.mockClear();
+		mockHls.attachMedia.mockClear();
+		mockHls.destroy.mockClear();
 	} );
 	afterEach( () => {
 		window.HTMLMediaElement.prototype.play = originalPlay;
@@ -127,9 +134,6 @@ describe( 'PostCardEmbedVideo', () => {
 	} );
 
 	it( 'autoplays after attachMedia on the hls.js branch when the thumbnail is clicked', async () => {
-		mockHls.loadSource.mockClear();
-		mockHls.attachMedia.mockClear();
-		mockHls.destroy.mockClear();
 		const user = userEvent.setup();
 		const originalCanPlayType = window.HTMLMediaElement.prototype.canPlayType;
 		// Force the non-Safari branch so the dynamic hls.js import path runs.


### PR DESCRIPTION
Fixes CM-696

## Proposed Changes

* Make the non-expanded video thumbnail in `<PostCardEmbedVideo>` a real `<button>` so clicks expand the player inline (and autoplay) instead of being intercepted by the card-link overlay and routing to the post detail view.
* Track a per-instance `userExpanded` flag so prop-driven expansion (the thread root) keeps its current "render the player but wait for the user to hit play" behaviour, while click-driven expansion plays inside the user-gesture window.
* Raise the thumbnail button to `z-index: 1` alongside the other inner clickables in `client/reader/social/components/post-card/style.scss` so it intercepts the click before the timestamp anchor's `::after` overlay does.

## Why are these changes being made?

In the ATmosphere / Mastodon thread view only the highlighted (target) post got `expanded={true}`. Replies and parents stayed thumbnail-only and the play overlay was visually clickable but not actually wired up — clicking the play icon on a reply video bubbled to the card-link overlay and navigated to that post's detail view. Users had to click into the post detail before they could play the video, which feels broken for a thumbnail with a giant play button on it.

This is shared `client/reader/social/` code, so the fix applies to both the ATmosphere and Mastodon thread views.

## Testing Instructions

1. Make sure `reader/atmosphere` is enabled.
2. Open a thread that contains a video reply or parent (not the target post). Example: `/reader/atmosphere/<connection_id>/thread/did:plc:yoqhimjo6xs3fmf7q7wgywy3/3mlezwexscs2b`.
3. Click the play icon (or anywhere on the video thumbnail) of a non-target video card.
4. Expected: the thumbnail flips to an inline `<video controls>` and starts playing without leaving the page.
5. Click anywhere else on the same card (avatar, body text, timestamp): the original card-link navigation still routes to that post's thread view.
6. The target post still autoloads its `<video>` element; the user still has to hit play (unchanged from before).
7. Repeat in a Mastodon thread with a video attachment: same behaviour.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label?