### PR TITLE
Reader social: link profile display name to source service

### DIFF
--- a/client/reader/atmosphere/author-profile-panel.tsx
+++ b/client/reader/atmosphere/author-profile-panel.tsx
@@ -505,6 +505,7 @@ export function AuthorProfilePanel( {
 				stats={ stats }
 				statsLabel={ String( translate( 'Profile stats' ) ) }
 				headerActions={ followButton }
+				displayNameLink={ profileData.bluesky_url }
 			/>
 		);
 	};

--- a/client/reader/social/mappers/mastodon.ts
+++ b/client/reader/social/mappers/mastodon.ts
@@ -112,6 +112,34 @@ function qualifyAcct( acct: string, instance: string ): string {
 	return acct.includes( '@' ) ? acct : `${ acct }@${ instance }`;
 }
 
+// Defence-in-depth on the federated `acct` value. Mastodon's API normalises
+// account shape on the home instance, but `acct` carries data federated from
+// arbitrary remote servers — a malformed value (`alice@`, `@alice`,
+// `alice@@two.example`, etc.) would silently produce a hostile-looking URL
+// (`https:///@alice`, `https://alice/@`, `https://@two.example/@alice`) that
+// still parses as `https:` and slips past the SocialProfileCard scheme guard.
+// Reject anything that isn't exactly `<username>` or `<username>@<host>` with
+// non-empty parts and a hostname-shaped second segment.
+const MASTODON_HOST_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i;
+function safeProfileUrl( acct: string, instance: string ): string | undefined {
+	const at = acct.indexOf( '@' );
+	if ( at === -1 ) {
+		if ( ! acct || ! MASTODON_HOST_RE.test( instance ) ) {
+			return undefined;
+		}
+		return `https://${ instance }/@${ acct }`;
+	}
+	const username = acct.slice( 0, at );
+	const remoteInstance = acct.slice( at + 1 );
+	if ( ! username || ! remoteInstance || remoteInstance.includes( '@' ) ) {
+		return undefined;
+	}
+	if ( ! MASTODON_HOST_RE.test( remoteInstance ) ) {
+		return undefined;
+	}
+	return `https://${ remoteInstance }/@${ username }`;
+}
+
 // Map a Mastodon Account-shaped profile onto the subset of SocialProfileCard
 // props we control (avatar / banner / displayName / handle / bioHtml). Stats
 // and statsLabel come from the panel since they're translation-bound.
@@ -129,7 +157,7 @@ export function mapMastodonAccountToSocialProfileCardProps(
 		displayName: profile.display_name ? profile.display_name : undefined,
 		handle: qualifyAcct( profile.acct, options.instance ),
 		bioHtml: profile.note,
-		displayNameLink: profileUrl( profile.acct, options.instance ),
+		displayNameLink: safeProfileUrl( profile.acct, options.instance ),
 	};
 }
 

--- a/client/reader/social/mappers/mastodon.ts
+++ b/client/reader/social/mappers/mastodon.ts
@@ -118,7 +118,10 @@ function qualifyAcct( acct: string, instance: string ): string {
 export function mapMastodonAccountToSocialProfileCardProps(
 	profile: MastodonAuthorProfile,
 	options: MapMastodonOptions
-): Pick< SocialProfileCardProps, 'avatar' | 'banner' | 'displayName' | 'handle' | 'bioHtml' > {
+): Pick<
+	SocialProfileCardProps,
+	'avatar' | 'banner' | 'displayName' | 'handle' | 'bioHtml' | 'displayNameLink'
+> {
 	return {
 		avatar: profile.avatar,
 		banner: profile.header,
@@ -126,6 +129,7 @@ export function mapMastodonAccountToSocialProfileCardProps(
 		displayName: profile.display_name ? profile.display_name : undefined,
 		handle: qualifyAcct( profile.acct, options.instance ),
 		bioHtml: profile.note,
+		displayNameLink: profileUrl( profile.acct, options.instance ),
 	};
 }
 

--- a/client/reader/social/mappers/test/mastodon.test.ts
+++ b/client/reader/social/mappers/test/mastodon.test.ts
@@ -318,4 +318,19 @@ describe( 'mapMastodonAccountToSocialProfileCardProps', () => {
 		);
 		expect( props.displayNameLink ).toBe( 'https://infosec.exchange/@carol' );
 	} );
+
+	it.each( [
+		[ 'empty acct', '' ],
+		[ 'trailing-@ acct', 'alice@' ],
+		[ 'leading-@ acct', '@alice' ],
+		[ 'double-@ acct (userinfo trick)', 'alice@@two.example' ],
+		[ 'single-label remote host', 'alice@localhost' ],
+		[ 'remote host with userinfo separator', 'alice@evil@host.example' ],
+	] )( 'returns undefined displayNameLink for malformed %s', ( _label, acct ) => {
+		const props = mapMastodonAccountToSocialProfileCardProps(
+			{ ...PROFILE, acct },
+			{ instance: 'mastodon.social' }
+		);
+		expect( props.displayNameLink ).toBeUndefined();
+	} );
 } );

--- a/client/reader/social/mappers/test/mastodon.test.ts
+++ b/client/reader/social/mappers/test/mastodon.test.ts
@@ -1,5 +1,8 @@
-import { mapMastodonFeedItemToSocialPost } from '../mastodon';
-import type { MastodonFeedItem } from '@automattic/api-core';
+import {
+	mapMastodonAccountToSocialProfileCardProps,
+	mapMastodonFeedItemToSocialPost,
+} from '../mastodon';
+import type { MastodonAuthorProfile, MastodonFeedItem } from '@automattic/api-core';
 
 const FIXTURE: MastodonFeedItem = {
 	id: '111111111111111111',
@@ -285,5 +288,34 @@ describe( 'mapMastodonFeedItemToSocialPost', () => {
 			const post = mapMastodonFeedItemToSocialPost( FIXTURE, OPTS );
 			expect( post.viewer ).toBeUndefined();
 		} );
+	} );
+} );
+
+describe( 'mapMastodonAccountToSocialProfileCardProps', () => {
+	const PROFILE: MastodonAuthorProfile = {
+		id: '7',
+		acct: 'alice',
+		display_name: 'Alice',
+		avatar: 'https://cdn/a.jpg',
+		header: 'https://cdn/h.jpg',
+		note: '<p>Hi</p>',
+		counts: { followers: 1, following: 2, posts: 3 },
+		locked: false,
+		raw: {},
+	};
+
+	it( 'derives the local-account display-name link from the connection instance', () => {
+		const props = mapMastodonAccountToSocialProfileCardProps( PROFILE, {
+			instance: 'mastodon.social',
+		} );
+		expect( props.displayNameLink ).toBe( 'https://mastodon.social/@alice' );
+	} );
+
+	it( 'derives the remote-account display-name link from the qualified acct', () => {
+		const props = mapMastodonAccountToSocialProfileCardProps(
+			{ ...PROFILE, acct: 'carol@infosec.exchange' },
+			{ instance: 'mastodon.social' }
+		);
+		expect( props.displayNameLink ).toBe( 'https://infosec.exchange/@carol' );
 	} );
 } );

--- a/client/reader/social/profile-card.tsx
+++ b/client/reader/social/profile-card.tsx
@@ -35,6 +35,13 @@ export interface SocialProfileCardProps {
 	statsLabel: string;
 	/** Slot for buttons / links in the header band (rich layout only). */
 	headerActions?: ReactNode;
+	/**
+	 * External URL pointing to the profile on the third-party service
+	 * (e.g. bsky.app for ATmosphere, the home-instance URL for Mastodon).
+	 * When set, the display name renders inside an external anchor with a
+	 * hover-reveal arrow affordance, mirroring the post timestamp link.
+	 */
+	displayNameLink?: string;
 }
 
 // Mastodon bios include paragraphs, line breaks, and anchors (including rel="me"
@@ -76,6 +83,7 @@ export function SocialProfileCard( {
 	stats,
 	statsLabel,
 	headerActions,
+	displayNameLink,
 }: SocialProfileCardProps ) {
 	const analytics = useSocialAnalytics();
 
@@ -191,7 +199,37 @@ export function SocialProfileCard( {
 				) : null }
 			</div>
 			{ headingText ? (
-				<h2 className="social-profile-card__display-name">{ headingText }</h2>
+				<h2 className="social-profile-card__display-name">
+					{ displayNameLink ? (
+						<a
+							className="social-profile-card__display-name-link"
+							href={ displayNameLink }
+							target="_blank"
+							rel="noopener noreferrer"
+							onClick={ () => {
+								if ( ! analytics ) {
+									return;
+								}
+								// Sibling to the prominent timestamp's
+								// `_external_post_clicked` (see post-card-timestamp.tsx).
+								// Emitted directly under `_profile_` so the panel-level
+								// `_timeline_*` → `_profile_*` rewrite leaves it alone.
+								analytics.onClick(
+									`calypso_reader_${ analytics.source }_profile_external_clicked`,
+									{
+										connection_id: analytics.connectionId,
+										destination: 'external',
+										actor_handle: handle ?? null,
+									}
+								);
+							} }
+						>
+							{ headingText }
+						</a>
+					) : (
+						headingText
+					) }
+				</h2>
 			) : null }
 			{ handle ? <p className="social-profile-card__handle">@{ handle }</p> : null }
 			{ bioNode }

--- a/client/reader/social/profile-card.tsx
+++ b/client/reader/social/profile-card.tsx
@@ -171,6 +171,27 @@ export function SocialProfileCard( {
 
 	const headingText = displayName || handle;
 
+	// Defence-in-depth: `displayNameLink` is typed `string` but originates from
+	// a remote service (wpcom for Bluesky; the home Mastodon instance, which
+	// federates `acct` from arbitrary remote servers). Only render the anchor
+	// when the value parses as an http(s) URL — otherwise fall back to plain
+	// heading text so a malformed payload can't produce a same-origin or
+	// `data:`/`javascript:` navigation.
+	const safeDisplayNameLink = useMemo( () => {
+		if ( ! displayNameLink ) {
+			return undefined;
+		}
+		try {
+			const parsed = new URL( displayNameLink );
+			if ( parsed.protocol !== 'https:' && parsed.protocol !== 'http:' ) {
+				return undefined;
+			}
+			return parsed.toString();
+		} catch {
+			return undefined;
+		}
+	}, [ displayNameLink ] );
+
 	return (
 		<div className="social-profile-card">
 			{ banner ? (
@@ -200,10 +221,10 @@ export function SocialProfileCard( {
 			</div>
 			{ headingText ? (
 				<h2 className="social-profile-card__display-name">
-					{ displayNameLink ? (
+					{ safeDisplayNameLink ? (
 						<a
 							className="social-profile-card__display-name-link"
-							href={ displayNameLink }
+							href={ safeDisplayNameLink }
 							target="_blank"
 							rel="noopener noreferrer"
 							onClick={ () => {

--- a/client/reader/social/style.scss
+++ b/client/reader/social/style.scss
@@ -60,6 +60,33 @@
 	line-height: 1.2;
 }
 
+// Wrapper anchor when a third-party profile URL is available; matches the
+// hover-reveal arrow used by the prominent post timestamp link.
+.social-profile-card__display-name-link {
+	color: inherit;
+	text-decoration: none;
+
+	&:focus-visible {
+		outline: 2px solid var( --studio-blue-50 );
+		outline-offset: 2px;
+	}
+
+	&::after {
+		content: "↗";
+		display: inline-block;
+		color: var( --studio-gray-30 );
+		font-size: 0.85em;
+		margin-inline-start: 6px;
+		opacity: 0;
+		transition: opacity 0.2s ease;
+	}
+
+	&:hover::after,
+	&:focus-visible::after {
+		opacity: 1;
+	}
+}
+
 .social-profile-card__handle {
 	margin: 0;
 	color: var( --studio-gray-50, #646970 );

--- a/client/reader/social/test/profile-card.test.tsx
+++ b/client/reader/social/test/profile-card.test.tsx
@@ -575,6 +575,26 @@ describe( 'SocialProfileCard — rich variant', () => {
 		);
 	} );
 
+	it.each( [
+		[ 'javascript: URL', 'javascript:alert(1)' ],
+		[ 'data: URL', 'data:text/html,<script>alert(1)</script>' ],
+		[ 'protocol-relative URL', '//evil.example/profile' ],
+		[ 'whitespace-only string', '   ' ],
+		[ 'malformed URL', 'not a url' ],
+	] )( 'renders plain heading text when displayNameLink is a %s', ( _label, value ) => {
+		render(
+			<SocialProfileCard
+				displayName="Alice"
+				handle="alice.bsky.social"
+				displayNameLink={ value }
+				stats={ [] }
+				statsLabel="Profile stats"
+			/>
+		);
+		expect( screen.queryByRole( 'link', { name: 'Alice' } ) ).not.toBeInTheDocument();
+		expect( screen.getByRole( 'heading', { level: 2, name: 'Alice' } ) ).toBeVisible();
+	} );
+
 	it( 'hides the banner image on load failure', () => {
 		const { container } = render(
 			<SocialProfileCard

--- a/client/reader/social/test/profile-card.test.tsx
+++ b/client/reader/social/test/profile-card.test.tsx
@@ -505,6 +505,76 @@ describe( 'SocialProfileCard — rich variant', () => {
 		expect( screen.getByText( 'Plain bio.' ) ).toBeVisible();
 	} );
 
+	it( 'wraps the display name in an external link when displayNameLink is set', () => {
+		render(
+			<SocialProfileCard
+				displayName="Alice"
+				handle="alice.bsky.social"
+				displayNameLink="https://bsky.app/profile/alice.bsky.social"
+				stats={ [] }
+				statsLabel="Profile stats"
+			/>
+		);
+		const link = screen.getByRole( 'link', { name: 'Alice' } );
+		expect( link ).toHaveAttribute( 'href', 'https://bsky.app/profile/alice.bsky.social' );
+		expect( link ).toHaveAttribute( 'target', '_blank' );
+		expect( link ).toHaveAttribute( 'rel', 'noopener noreferrer' );
+		// The heading's accessible name remains the bare display name so
+		// existing heading-by-name lookups continue to work.
+		expect( screen.getByRole( 'heading', { level: 2, name: 'Alice' } ) ).toBeVisible();
+	} );
+
+	it( 'falls back to the handle inside the link when displayName is missing', () => {
+		render(
+			<SocialProfileCard
+				handle="alice.bsky.social"
+				displayNameLink="https://bsky.app/profile/alice.bsky.social"
+				stats={ [] }
+				statsLabel="Profile stats"
+			/>
+		);
+		const link = screen.getByRole( 'link', { name: 'alice.bsky.social' } );
+		expect( link ).toBeVisible();
+	} );
+
+	it( 'renders the display name as plain text when no displayNameLink is provided', () => {
+		render(
+			<SocialProfileCard
+				displayName="Alice"
+				handle="alice.bsky.social"
+				stats={ [] }
+				statsLabel="Profile stats"
+			/>
+		);
+		expect( screen.queryByRole( 'link', { name: 'Alice' } ) ).not.toBeInTheDocument();
+		expect( screen.getByRole( 'heading', { level: 2, name: 'Alice' } ) ).toBeVisible();
+	} );
+
+	it( 'fires the profile_external_clicked Tracks event when the link is clicked', async () => {
+		const user = userEvent.setup();
+		const onClick = jest.fn();
+		render(
+			<SocialAnalyticsProvider value={ { source: 'atmosphere', connectionId: 7, onClick } }>
+				<SocialProfileCard
+					displayName="Alice"
+					handle="alice.bsky.social"
+					displayNameLink="https://bsky.app/profile/alice.bsky.social"
+					stats={ [] }
+					statsLabel="Profile stats"
+				/>
+			</SocialAnalyticsProvider>
+		);
+		await user.click( screen.getByRole( 'link', { name: 'Alice' } ) );
+		expect( onClick ).toHaveBeenCalledWith(
+			'calypso_reader_atmosphere_profile_external_clicked',
+			expect.objectContaining( {
+				connection_id: 7,
+				destination: 'external',
+				actor_handle: 'alice.bsky.social',
+			} )
+		);
+	} );
+
 	it( 'hides the banner image on load failure', () => {
 		const { container } = render(
 			<SocialProfileCard


### PR DESCRIPTION
Fixes CM-697

## Proposed Changes

* Wrap the profile card's display name in an external anchor pointing at the source instance — `bsky.app` for ATmosphere (from `AtmosphereAuthorProfile.bluesky_url`) and the home-instance URL for Mastodon (derived from `acct` + `instance` via the existing `profileUrl` helper in the social mapper).
* Match the hover-reveal `↗` arrow affordance used by the prominent post timestamp link (#110599), with a `:focus-visible` outline using `--studio-blue-50` (consistent with `repost-button.scss`).
* Emit `calypso_reader_<source>_profile_external_clicked` directly under the `_profile_` prefix so the panel-level `_timeline_*` → `_profile_*` rewrite leaves it alone. Carries `connection_id`, `destination: 'external'`, and `actor_handle`.
* Extend `mapMastodonAccountToSocialProfileCardProps` to surface the constructed third-party URL via the new `displayNameLink` prop, mirroring how `mapAccount` already builds `profile_url` for post-card authors.
* Keep the link's accessible name as the bare display name so the heading parent's accessible name stays unchanged — preserves the existing `findByRole( 'heading', { name: '…' } )` lookups across the profile-panel test suites.

## Why are these changes being made?

The post-card timestamp already exposes a link to the original on the source service (#110599). The profile card display name didn't, so users had no obvious way to jump out to `bsky.app` / their Mastodon home instance from the in-app profile view. This closes that gap with the same affordance, on every surface that mounts `<SocialProfileCard>` (your-own-connection profile + any-author profile, both protocols).

## Testing Instructions

* Open an ATmosphere profile (e.g. `/reader/atmosphere/:id/profile/atrupar.com`) and a Mastodon profile (`/reader/mastodon/:id/profile/:actor`).
* Hover the display name — the small `↗` arrow should appear; the cursor should be a pointer.
* Tab to the display name from the keyboard — a visible focus outline should appear.
* Click — a new tab should open at the source instance (`bsky.app/profile/<handle>` for ATmosphere; `https://<instance>/@<acct>` for Mastodon).
* Verify the same affordance on your own connected-user profile (`/reader/atmosphere/:id/profile` and `/reader/mastodon/:id/profile`).
* In the Tracks debugger, verify `calypso_reader_atmosphere_profile_external_clicked` / `calypso_reader_mastodon_profile_external_clicked` fires with `connection_id`, `destination: 'external'`, and `actor_handle`.
* Confirm no link is rendered when `displayNameLink` is omitted (slim verify-card layout) — covered by `profile-card.test.tsx`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?