### PR TITLE
RSM-2358: AI Editorial workflow - review mediation tracks events

### DIFF
--- a/packages/jetpack-ai-sidebar/package.json
+++ b/packages/jetpack-ai-sidebar/package.json
@@ -45,6 +45,7 @@
 	},
 	"dependencies": {
 		"@automattic/agenttic-client": "^0.1.58",
+		"@automattic/calypso-analytics": "workspace:^",
 		"@wordpress/abilities": "^0.4.0",
 		"@wordpress/components": "^30.9.0",
 		"@wordpress/i18n": "^5.23.0"

--- a/packages/jetpack-ai-sidebar/src/components/review-mediation.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/review-mediation.tsx
@@ -21,6 +21,12 @@ import {
 	isSupportedEditBlockType,
 	undoBlockEdit,
 } from '../utils/block-actions';
+import { consumePendingRunId } from '../utils/run-id';
+import {
+	trackReviewMediationError,
+	trackReviewMediationItemAction,
+	trackReviewMediationResultRendered,
+} from '../utils/tracking';
 import BlockRef, { type BlockSnapshot } from './block-ref';
 import ReviewerChip, { type ReviewerMetadata } from './reviewer-chip';
 
@@ -265,6 +271,19 @@ function isManualSuggestedEdit( edit: SuggestedEdit ): boolean {
 	return edit.requires_manual === true;
 }
 
+function deriveResultOutcome(
+	isCacheHit: boolean,
+	hasNoInput: boolean
+): 'success' | 'cache_hit' | 'empty_notes' {
+	if ( isCacheHit ) {
+		return 'cache_hit';
+	}
+	if ( hasNoInput ) {
+		return 'empty_notes';
+	}
+	return 'success';
+}
+
 function getSuggestedEditApplyUnavailableReason(
 	isManual: boolean,
 	disabledReason?: string
@@ -312,6 +331,10 @@ export default function ReviewMediation( {
 	type UndoSnapshot = { clientId: string; contentBefore: string; contentAfter: string };
 	const editSnapshots = useRef< Record< number, UndoSnapshot > >( {} );
 	const conflictSnapshots = useRef< Record< number, UndoSnapshot > >( {} );
+
+	// Run id is claimed in the post-commit effect (see below) so this card
+	// owns the join key for all downstream Tracks events.
+	const runIdRef = useRef< string | null >( null );
 
 	// Controlled open-state per PanelBody so the stats-strip click handler
 	// can programmatically expand a section before scrolling to it.
@@ -368,6 +391,12 @@ export default function ReviewMediation( {
 		return flattenBlocks( rootBlocks );
 	}, [] );
 
+	const postId = useSelect( ( select ) => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const pid = ( select as any )( 'core/editor' )?.getCurrentPostId?.();
+		return typeof pid === 'number' ? pid : undefined;
+	}, [] );
+
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const { selectBlock } = useDispatch( 'core/block-editor' ) as any;
 
@@ -415,6 +444,51 @@ export default function ReviewMediation( {
 			findBlockListLayout()?.classList.add( FOCUS_MODE_CLASS );
 		},
 		[ getClientId, selectBlock ]
+	);
+
+	const fireItemAction = useCallback(
+		(
+			action: 'accept' | 'undo' | 'dismiss' | 'bulk_accept' | 'focus',
+			target: 'edit' | 'conflict',
+			blockIndex: number | null = null
+		) => {
+			trackReviewMediationItemAction( {
+				action,
+				target,
+				postId,
+				runId: runIdRef.current ?? undefined,
+				blockIndex,
+			} );
+		},
+		[ postId ]
+	);
+
+	const fireError = useCallback(
+		( errorPhase: 'load' | 'render' | 'apply' | 'undo' | 'network', errorType: string ) => {
+			trackReviewMediationError( {
+				errorPhase,
+				errorType,
+				postId,
+				runId: runIdRef.current ?? undefined,
+			} );
+		},
+		[ postId ]
+	);
+
+	const focusBlockFromConflict = useCallback(
+		( blockIndex: number | null ) => {
+			fireItemAction( 'focus', 'conflict', blockIndex );
+			focusBlock( blockIndex );
+		},
+		[ fireItemAction, focusBlock ]
+	);
+
+	const focusBlockFromEdit = useCallback(
+		( blockIndex: number | null ) => {
+			fireItemAction( 'focus', 'edit', blockIndex );
+			focusBlock( blockIndex );
+		},
+		[ fireItemAction, focusBlock ]
 	);
 
 	// Clear focus-mode when the mediation session ends.
@@ -479,8 +553,10 @@ export default function ReviewMediation( {
 			if ( isManualSuggestedEdit( edit ) ) {
 				return;
 			}
+			fireItemAction( 'accept', 'edit', edit.block_index );
 			if ( edit.block_index === null ) {
 				setEditStatus( editIndex, 'failed' );
+				fireError( 'apply', 'no_block_target' );
 				return;
 			}
 			setEditStatus( editIndex, 'applying' );
@@ -501,33 +577,43 @@ export default function ReviewMediation( {
 					contentAfter: result.contentAfter,
 				};
 			}
+			if ( ! result.success ) {
+				fireError( 'apply', 'apply_failed' );
+			}
 			setEditStatus( editIndex, result.success ? 'accepted' : 'failed' );
 		},
-		[ applyTextToBlock, setEditStatus ]
+		[ applyTextToBlock, fireError, fireItemAction, setEditStatus ]
 	);
 	const handleUndoEdit = useCallback(
 		( editIndex: number ) => {
+			fireItemAction( 'undo', 'edit' );
 			const snap = editSnapshots.current[ editIndex ];
 			if ( snap ) {
 				if ( ! undoBlockEdit( snap.clientId, snap.contentBefore, snap.contentAfter ) ) {
+					fireError( 'undo', 'undo_failed' );
 					return;
 				}
 				delete editSnapshots.current[ editIndex ];
 			}
 			setEditStatus( editIndex, 'pending' );
 		},
-		[ setEditStatus ]
+		[ fireError, fireItemAction, setEditStatus ]
 	);
 	const handleDismissEdit = useCallback(
-		( editIndex: number ) => setEditStatus( editIndex, 'dismissed' ),
-		[ setEditStatus ]
+		( editIndex: number ) => {
+			fireItemAction( 'dismiss', 'edit' );
+			setEditStatus( editIndex, 'dismissed' );
+		},
+		[ fireItemAction, setEditStatus ]
 	);
 
 	// ---------- Conflict handlers ----------
 	const handleAcceptCandidate = useCallback(
 		async ( conflictIndex: number, candidate: CandidateResolution ) => {
+			fireItemAction( 'accept', 'conflict', candidate.block_index );
 			if ( getBlockEditDisabledReason( candidate.block_index, candidate.current_text ) ) {
 				setConflictStatus( conflictIndex, 'failed' );
+				fireError( 'apply', 'invalid_block_target' );
 				return;
 			}
 			setConflictStatus( conflictIndex, 'applying' );
@@ -548,26 +634,34 @@ export default function ReviewMediation( {
 					contentAfter: result.contentAfter,
 				};
 			}
+			if ( ! result.success ) {
+				fireError( 'apply', 'apply_failed' );
+			}
 			setConflictStatus( conflictIndex, result.success ? 'accepted' : 'failed' );
 		},
-		[ applyTextToBlock, getBlockEditDisabledReason, setConflictStatus ]
+		[ applyTextToBlock, fireError, fireItemAction, getBlockEditDisabledReason, setConflictStatus ]
 	);
 	const handleUndoConflict = useCallback(
 		( conflictIndex: number ) => {
+			fireItemAction( 'undo', 'conflict' );
 			const snap = conflictSnapshots.current[ conflictIndex ];
 			if ( snap ) {
 				if ( ! undoBlockEdit( snap.clientId, snap.contentBefore, snap.contentAfter ) ) {
+					fireError( 'undo', 'undo_failed' );
 					return;
 				}
 				delete conflictSnapshots.current[ conflictIndex ];
 			}
 			setConflictStatus( conflictIndex, 'pending' );
 		},
-		[ setConflictStatus ]
+		[ fireError, fireItemAction, setConflictStatus ]
 	);
 	const handleDismissConflict = useCallback(
-		( conflictIndex: number ) => setConflictStatus( conflictIndex, 'dismissed' ),
-		[ setConflictStatus ]
+		( conflictIndex: number ) => {
+			fireItemAction( 'dismiss', 'conflict' );
+			setConflictStatus( conflictIndex, 'dismissed' );
+		},
+		[ fireItemAction, setConflictStatus ]
 	);
 
 	// ---------- Bulk apply ----------
@@ -603,6 +697,10 @@ export default function ReviewMediation( {
 		if ( bulkRunning || totalPendingCount === 0 ) {
 			return;
 		}
+		// Mixed runs (both pending) report as 'conflict' since AI conflict
+		// resolutions are the dominant action driving this CTA.
+		const bulkTarget: 'edit' | 'conflict' = pendingAiConflictCount > 0 ? 'conflict' : 'edit';
+		fireItemAction( 'bulk_accept', bulkTarget );
 		setBulkRunning( true );
 		// Sequential so users see the shimmer on each block as it applies;
 		// parallel would race the same dispatch and confuse the state store.
@@ -635,6 +733,9 @@ export default function ReviewMediation( {
 					contentBefore: result.contentBefore,
 					contentAfter: result.contentAfter,
 				};
+			}
+			if ( ! result.success ) {
+				fireError( 'apply', 'apply_failed' );
 			}
 			setConflictStatus( i, result.success ? 'accepted' : 'failed' );
 		}
@@ -669,17 +770,23 @@ export default function ReviewMediation( {
 					contentAfter: result.contentAfter,
 				};
 			}
+			if ( ! result.success ) {
+				fireError( 'apply', 'apply_failed' );
+			}
 			setEditStatus( i, result.success ? 'accepted' : 'failed' );
 		}
 		setBulkRunning( false );
 	}, [
 		bulkRunning,
 		totalPendingCount,
+		pendingAiConflictCount,
 		conflicts,
 		conflictStatuses,
 		suggested_edits,
 		editStatuses,
 		applyTextToBlock,
+		fireError,
+		fireItemAction,
 		getBlockEditDisabledReason,
 		setConflictStatus,
 		setEditStatus,
@@ -710,6 +817,55 @@ export default function ReviewMediation( {
 		( name: string ): ReviewerMetadata | null => reviewers_metadata?.[ name ] ?? null,
 		[ reviewers_metadata ]
 	);
+
+	// Drain the pending run id once per mount and fire `_result_rendered`.
+	// Latch on the first effect run so a later dep change can't consume a
+	// future click's run id.
+	const hasTrackedResultRef = useRef( false );
+	useEffect( () => {
+		if ( hasTrackedResultRef.current ) {
+			return;
+		}
+		hasTrackedResultRef.current = true;
+		if ( runIdRef.current === null ) {
+			runIdRef.current = consumePendingRunId();
+		}
+		if ( runIdRef.current === null ) {
+			return;
+		}
+		const isCacheHit = cached_at !== undefined;
+		const noReviewerSignal =
+			conflicts.length === 0 &&
+			implications.length === 0 &&
+			suggested_edits.length === 0 &&
+			guideline_violations.length === 0;
+		// Mirror the UI's effective-manual classification: a row is "manual" if
+		// the payload flags it OR the block target is missing/unsupported/stale.
+		const manualEditCount = suggested_edits.filter(
+			( edit ) =>
+				isManualSuggestedEdit( edit ) ||
+				getBlockEditDisabledReason( edit.block_index, edit.current_text ) !== undefined
+		).length;
+		trackReviewMediationResultRendered( {
+			outcome: deriveResultOutcome( isCacheHit, noReviewerSignal ),
+			cacheHit: isCacheHit,
+			conflictCount: conflicts.length,
+			suggestedEditCount: suggested_edits.length,
+			autoSuggestedEditCount: suggested_edits.length - manualEditCount,
+			manualSuggestedEditCount: manualEditCount,
+			guidelineViolationCount: guideline_violations.length,
+			postId,
+			runId: runIdRef.current ?? undefined,
+		} );
+	}, [
+		cached_at,
+		conflicts,
+		getBlockEditDisabledReason,
+		guideline_violations,
+		implications,
+		postId,
+		suggested_edits,
+	] );
 
 	return (
 		<div className="jetpack-ai-review-mediation">
@@ -912,7 +1068,7 @@ export default function ReviewMediation( {
 															<BlockRef
 																index={ headerBlockIndex }
 																blocks={ blocks }
-																onFocus={ focusBlock }
+																onFocus={ focusBlockFromConflict }
 															/>
 															<span
 																className="jetpack-ai-review-mediation__collapsed-sep"
@@ -962,7 +1118,7 @@ export default function ReviewMediation( {
 														<BlockRef
 															index={ headerBlockIndex }
 															blocks={ blocks }
-															onFocus={ focusBlock }
+															onFocus={ focusBlockFromConflict }
 															className="jetpack-ai-review-mediation__conflict-block-ref"
 														/>
 													) }
@@ -1158,7 +1314,7 @@ export default function ReviewMediation( {
 													<BlockRef
 														index={ edit.block_index }
 														blocks={ blocks }
-														onFocus={ clickable ? focusBlock : undefined }
+														onFocus={ clickable ? focusBlockFromEdit : undefined }
 													/>
 													{ edit.suggested_text && (
 														<>
@@ -1202,7 +1358,7 @@ export default function ReviewMediation( {
 													<BlockRef
 														index={ edit.block_index }
 														blocks={ blocks }
-														onFocus={ clickable ? focusBlock : undefined }
+														onFocus={ clickable ? focusBlockFromEdit : undefined }
 													/>
 												</p>
 												{ edit.current_text && (

--- a/packages/jetpack-ai-sidebar/src/components/review-mediation.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/review-mediation.tsx
@@ -21,7 +21,7 @@ import {
 	isSupportedEditBlockType,
 	undoBlockEdit,
 } from '../utils/block-actions';
-import { consumePendingRunId } from '../utils/run-id';
+import { consumePendingClientRunId, generateClientRunId } from '../utils/run-id';
 import {
 	trackReviewMediationError,
 	trackReviewMediationItemAction,
@@ -332,9 +332,9 @@ export default function ReviewMediation( {
 	const editSnapshots = useRef< Record< number, UndoSnapshot > >( {} );
 	const conflictSnapshots = useRef< Record< number, UndoSnapshot > >( {} );
 
-	// Run id is claimed in the post-commit effect (see below) so this card
+	// Client run id is claimed in the post-commit effect (see below) so this card
 	// owns the join key for all downstream Tracks events.
-	const runIdRef = useRef< string | null >( null );
+	const clientRunIdRef = useRef< string | null >( null );
 
 	// Controlled open-state per PanelBody so the stats-strip click handler
 	// can programmatically expand a section before scrolling to it.
@@ -391,12 +391,6 @@ export default function ReviewMediation( {
 		return flattenBlocks( rootBlocks );
 	}, [] );
 
-	const postId = useSelect( ( select ) => {
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const pid = ( select as any )( 'core/editor' )?.getCurrentPostId?.();
-		return typeof pid === 'number' ? pid : undefined;
-	}, [] );
-
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const { selectBlock } = useDispatch( 'core/block-editor' ) as any;
 
@@ -447,20 +441,18 @@ export default function ReviewMediation( {
 	);
 
 	const fireItemAction = useCallback(
-		(
-			action: 'accept' | 'undo' | 'dismiss' | 'bulk_accept' | 'focus',
-			target: 'edit' | 'conflict',
-			blockIndex: number | null = null
-		) => {
+		( options: {
+			action: 'accept' | 'undo' | 'dismiss' | 'bulk_accept';
+			target: 'edit' | 'conflict' | 'mixed';
+			outcome: 'success' | 'failed' | 'partial_failed';
+			itemCount?: number;
+		} ) => {
 			trackReviewMediationItemAction( {
-				action,
-				target,
-				postId,
-				runId: runIdRef.current ?? undefined,
-				blockIndex,
+				...options,
+				clientRunId: clientRunIdRef.current ?? undefined,
 			} );
 		},
-		[ postId ]
+		[]
 	);
 
 	const fireError = useCallback(
@@ -468,27 +460,10 @@ export default function ReviewMediation( {
 			trackReviewMediationError( {
 				errorPhase,
 				errorType,
-				postId,
-				runId: runIdRef.current ?? undefined,
+				clientRunId: clientRunIdRef.current ?? undefined,
 			} );
 		},
-		[ postId ]
-	);
-
-	const focusBlockFromConflict = useCallback(
-		( blockIndex: number | null ) => {
-			fireItemAction( 'focus', 'conflict', blockIndex );
-			focusBlock( blockIndex );
-		},
-		[ fireItemAction, focusBlock ]
-	);
-
-	const focusBlockFromEdit = useCallback(
-		( blockIndex: number | null ) => {
-			fireItemAction( 'focus', 'edit', blockIndex );
-			focusBlock( blockIndex );
-		},
-		[ fireItemAction, focusBlock ]
+		[]
 	);
 
 	// Clear focus-mode when the mediation session ends.
@@ -553,10 +528,14 @@ export default function ReviewMediation( {
 			if ( isManualSuggestedEdit( edit ) ) {
 				return;
 			}
-			fireItemAction( 'accept', 'edit', edit.block_index );
 			if ( edit.block_index === null ) {
 				setEditStatus( editIndex, 'failed' );
 				fireError( 'apply', 'no_block_target' );
+				fireItemAction( {
+					action: 'accept',
+					target: 'edit',
+					outcome: 'failed',
+				} );
 				return;
 			}
 			setEditStatus( editIndex, 'applying' );
@@ -580,28 +559,46 @@ export default function ReviewMediation( {
 			if ( ! result.success ) {
 				fireError( 'apply', 'apply_failed' );
 			}
+			fireItemAction( {
+				action: 'accept',
+				target: 'edit',
+				outcome: result.success ? 'success' : 'failed',
+			} );
 			setEditStatus( editIndex, result.success ? 'accepted' : 'failed' );
 		},
 		[ applyTextToBlock, fireError, fireItemAction, setEditStatus ]
 	);
 	const handleUndoEdit = useCallback(
 		( editIndex: number ) => {
-			fireItemAction( 'undo', 'edit' );
 			const snap = editSnapshots.current[ editIndex ];
 			if ( snap ) {
 				if ( ! undoBlockEdit( snap.clientId, snap.contentBefore, snap.contentAfter ) ) {
 					fireError( 'undo', 'undo_failed' );
+					fireItemAction( {
+						action: 'undo',
+						target: 'edit',
+						outcome: 'failed',
+					} );
 					return;
 				}
 				delete editSnapshots.current[ editIndex ];
 			}
+			fireItemAction( {
+				action: 'undo',
+				target: 'edit',
+				outcome: 'success',
+			} );
 			setEditStatus( editIndex, 'pending' );
 		},
 		[ fireError, fireItemAction, setEditStatus ]
 	);
 	const handleDismissEdit = useCallback(
 		( editIndex: number ) => {
-			fireItemAction( 'dismiss', 'edit' );
+			fireItemAction( {
+				action: 'dismiss',
+				target: 'edit',
+				outcome: 'success',
+			} );
 			setEditStatus( editIndex, 'dismissed' );
 		},
 		[ fireItemAction, setEditStatus ]
@@ -610,10 +607,14 @@ export default function ReviewMediation( {
 	// ---------- Conflict handlers ----------
 	const handleAcceptCandidate = useCallback(
 		async ( conflictIndex: number, candidate: CandidateResolution ) => {
-			fireItemAction( 'accept', 'conflict', candidate.block_index );
 			if ( getBlockEditDisabledReason( candidate.block_index, candidate.current_text ) ) {
 				setConflictStatus( conflictIndex, 'failed' );
 				fireError( 'apply', 'invalid_block_target' );
+				fireItemAction( {
+					action: 'accept',
+					target: 'conflict',
+					outcome: 'failed',
+				} );
 				return;
 			}
 			setConflictStatus( conflictIndex, 'applying' );
@@ -637,28 +638,46 @@ export default function ReviewMediation( {
 			if ( ! result.success ) {
 				fireError( 'apply', 'apply_failed' );
 			}
+			fireItemAction( {
+				action: 'accept',
+				target: 'conflict',
+				outcome: result.success ? 'success' : 'failed',
+			} );
 			setConflictStatus( conflictIndex, result.success ? 'accepted' : 'failed' );
 		},
 		[ applyTextToBlock, fireError, fireItemAction, getBlockEditDisabledReason, setConflictStatus ]
 	);
 	const handleUndoConflict = useCallback(
 		( conflictIndex: number ) => {
-			fireItemAction( 'undo', 'conflict' );
 			const snap = conflictSnapshots.current[ conflictIndex ];
 			if ( snap ) {
 				if ( ! undoBlockEdit( snap.clientId, snap.contentBefore, snap.contentAfter ) ) {
 					fireError( 'undo', 'undo_failed' );
+					fireItemAction( {
+						action: 'undo',
+						target: 'conflict',
+						outcome: 'failed',
+					} );
 					return;
 				}
 				delete conflictSnapshots.current[ conflictIndex ];
 			}
+			fireItemAction( {
+				action: 'undo',
+				target: 'conflict',
+				outcome: 'success',
+			} );
 			setConflictStatus( conflictIndex, 'pending' );
 		},
 		[ fireError, fireItemAction, setConflictStatus ]
 	);
 	const handleDismissConflict = useCallback(
 		( conflictIndex: number ) => {
-			fireItemAction( 'dismiss', 'conflict' );
+			fireItemAction( {
+				action: 'dismiss',
+				target: 'conflict',
+				outcome: 'success',
+			} );
 			setConflictStatus( conflictIndex, 'dismissed' );
 		},
 		[ fireItemAction, setConflictStatus ]
@@ -697,10 +716,20 @@ export default function ReviewMediation( {
 		if ( bulkRunning || totalPendingCount === 0 ) {
 			return;
 		}
-		// Mixed runs (both pending) report as 'conflict' since AI conflict
-		// resolutions are the dominant action driving this CTA.
-		const bulkTarget: 'edit' | 'conflict' = pendingAiConflictCount > 0 ? 'conflict' : 'edit';
-		fireItemAction( 'bulk_accept', bulkTarget );
+		let bulkTarget: 'edit' | 'conflict' | 'mixed' = 'edit';
+		if ( pendingAiConflictCount > 0 && pendingEditCount > 0 ) {
+			bulkTarget = 'mixed';
+		} else if ( pendingAiConflictCount > 0 ) {
+			bulkTarget = 'conflict';
+		}
+		let successCount = 0;
+		let failureCount = 0;
+		const getBulkOutcome = () => {
+			if ( failureCount === 0 ) {
+				return 'success';
+			}
+			return successCount === 0 ? 'failed' : 'partial_failed';
+		};
 		setBulkRunning( true );
 		// Sequential so users see the shimmer on each block as it applies;
 		// parallel would race the same dispatch and confuse the state store.
@@ -736,6 +765,9 @@ export default function ReviewMediation( {
 			}
 			if ( ! result.success ) {
 				fireError( 'apply', 'apply_failed' );
+				failureCount++;
+			} else {
+				successCount++;
 			}
 			setConflictStatus( i, result.success ? 'accepted' : 'failed' );
 		}
@@ -772,14 +804,24 @@ export default function ReviewMediation( {
 			}
 			if ( ! result.success ) {
 				fireError( 'apply', 'apply_failed' );
+				failureCount++;
+			} else {
+				successCount++;
 			}
 			setEditStatus( i, result.success ? 'accepted' : 'failed' );
 		}
+		fireItemAction( {
+			action: 'bulk_accept',
+			target: bulkTarget,
+			outcome: getBulkOutcome(),
+			itemCount: successCount + failureCount,
+		} );
 		setBulkRunning( false );
 	}, [
 		bulkRunning,
 		totalPendingCount,
 		pendingAiConflictCount,
+		pendingEditCount,
 		conflicts,
 		conflictStatuses,
 		suggested_edits,
@@ -818,7 +860,7 @@ export default function ReviewMediation( {
 		[ reviewers_metadata ]
 	);
 
-	// Drain the pending run id once per mount and fire `_result_rendered`.
+	// Drain the pending client run id once per mount and fire `_result_rendered`.
 	// Latch on the first effect run so a later dep change can't consume a
 	// future click's run id.
 	const hasTrackedResultRef = useRef( false );
@@ -827,45 +869,25 @@ export default function ReviewMediation( {
 			return;
 		}
 		hasTrackedResultRef.current = true;
-		if ( runIdRef.current === null ) {
-			runIdRef.current = consumePendingRunId();
-		}
-		if ( runIdRef.current === null ) {
-			return;
+		if ( clientRunIdRef.current === null ) {
+			const pendingClientRunId = consumePendingClientRunId();
+			clientRunIdRef.current = pendingClientRunId ?? generateClientRunId();
 		}
 		const isCacheHit = cached_at !== undefined;
 		const noReviewerSignal =
 			conflicts.length === 0 &&
 			implications.length === 0 &&
 			suggested_edits.length === 0 &&
-			guideline_violations.length === 0;
-		// Mirror the UI's effective-manual classification: a row is "manual" if
-		// the payload flags it OR the block target is missing/unsupported/stale.
-		const manualEditCount = suggested_edits.filter(
-			( edit ) =>
-				isManualSuggestedEdit( edit ) ||
-				getBlockEditDisabledReason( edit.block_index, edit.current_text ) !== undefined
-		).length;
+			renderedGuidelineViolations.length === 0;
 		trackReviewMediationResultRendered( {
 			outcome: deriveResultOutcome( isCacheHit, noReviewerSignal ),
-			cacheHit: isCacheHit,
 			conflictCount: conflicts.length,
+			implicationCount: implications.length,
 			suggestedEditCount: suggested_edits.length,
-			autoSuggestedEditCount: suggested_edits.length - manualEditCount,
-			manualSuggestedEditCount: manualEditCount,
-			guidelineViolationCount: guideline_violations.length,
-			postId,
-			runId: runIdRef.current ?? undefined,
+			guidelineViolationCount: renderedGuidelineViolations.length,
+			clientRunId: clientRunIdRef.current,
 		} );
-	}, [
-		cached_at,
-		conflicts,
-		getBlockEditDisabledReason,
-		guideline_violations,
-		implications,
-		postId,
-		suggested_edits,
-	] );
+	}, [ cached_at, conflicts, implications, renderedGuidelineViolations, suggested_edits ] );
 
 	return (
 		<div className="jetpack-ai-review-mediation">
@@ -1068,7 +1090,7 @@ export default function ReviewMediation( {
 															<BlockRef
 																index={ headerBlockIndex }
 																blocks={ blocks }
-																onFocus={ focusBlockFromConflict }
+																onFocus={ focusBlock }
 															/>
 															<span
 																className="jetpack-ai-review-mediation__collapsed-sep"
@@ -1118,7 +1140,7 @@ export default function ReviewMediation( {
 														<BlockRef
 															index={ headerBlockIndex }
 															blocks={ blocks }
-															onFocus={ focusBlockFromConflict }
+															onFocus={ focusBlock }
 															className="jetpack-ai-review-mediation__conflict-block-ref"
 														/>
 													) }
@@ -1314,7 +1336,7 @@ export default function ReviewMediation( {
 													<BlockRef
 														index={ edit.block_index }
 														blocks={ blocks }
-														onFocus={ clickable ? focusBlockFromEdit : undefined }
+														onFocus={ clickable ? focusBlock : undefined }
 													/>
 													{ edit.suggested_text && (
 														<>
@@ -1358,7 +1380,7 @@ export default function ReviewMediation( {
 													<BlockRef
 														index={ edit.block_index }
 														blocks={ blocks }
-														onFocus={ clickable ? focusBlockFromEdit : undefined }
+														onFocus={ clickable ? focusBlock : undefined }
 													/>
 												</p>
 												{ edit.current_text && (

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -31,7 +31,7 @@ import {
 	getModuleCheckpointApi,
 	startBlockShimmer,
 } from './utils/block-actions';
-import { generateRunId, setPendingRunId } from './utils/run-id';
+import { generateClientRunId, setPendingClientRunId } from './utils/run-id';
 import {
 	UPDATE_BLOCK_CONTENT_TOOL_ID,
 	UPDATE_BLOCK_CONTENT_ABILITY,
@@ -52,11 +52,6 @@ let clearSuggestionsFn: ( () => void ) | null = null;
 
 /** Whether `_suggestion_rendered` has fired this page life (once-per-session). */
 let suggestionRenderedFiredOnce = false;
-
-function getCurrentPostId(): number | undefined {
-	const pid = ( window as any ).wp?.data?.select?.( 'core/editor' )?.getCurrentPostId?.();
-	return typeof pid === 'number' ? pid : undefined;
-}
 
 /** Default suggestion shown when no block is selected. */
 const OPTIMIZE_TITLE_SUGGESTION = {
@@ -98,10 +93,7 @@ function getReviewMediatorSuggestions( currentPostType?: string ) {
 	}
 	if ( ! suggestionRenderedFiredOnce ) {
 		suggestionRenderedFiredOnce = true;
-		trackReviewMediationSuggestionRendered( {
-			postId: getCurrentPostId(),
-			postType: currentPostType ?? getCurrentEditorPostType(),
-		} );
+		trackReviewMediationSuggestionRendered();
 	}
 	return [ MEDIATE_REVIEW_SUGGESTION ];
 }
@@ -570,13 +562,10 @@ export function useSuggestions(): {
 				typeof value === 'string' &&
 				value === MEDIATE_REVIEW_SUGGESTION.prompt
 			) {
-				const runId = generateRunId();
-				setPendingRunId( runId );
+				const clientRunId = generateClientRunId();
+				setPendingClientRunId( clientRunId );
 				trackReviewMediationSuggestionClick( {
-					runId,
-					trigger: 'suggestion',
-					postId: getCurrentPostId(),
-					postType: getCurrentEditorPostType(),
+					clientRunId,
 				} );
 				try {
 					( dispatch as any )( 'automattic/agents-manager' ).setIsSplitScreen( true );

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -31,11 +31,16 @@ import {
 	getModuleCheckpointApi,
 	startBlockShimmer,
 } from './utils/block-actions';
+import { generateRunId, setPendingRunId } from './utils/run-id';
 import {
 	UPDATE_BLOCK_CONTENT_TOOL_ID,
 	UPDATE_BLOCK_CONTENT_ABILITY,
 	isUpdateBlockContentTool,
 } from './utils/tool-provider';
+import {
+	trackReviewMediationSuggestionClick,
+	trackReviewMediationSuggestionRendered,
+} from './utils/tracking';
 import type { ComponentType } from 'react';
 
 // Re-export block-action helpers as part of the package's public surface.
@@ -44,6 +49,14 @@ export { applyReviewEdit, findBlockElement, findBlockListLayout };
 // ---------- Module state ----------
 
 let clearSuggestionsFn: ( () => void ) | null = null;
+
+/** Whether `_suggestion_rendered` has fired this page life (once-per-session). */
+let suggestionRenderedFiredOnce = false;
+
+function getCurrentPostId(): number | undefined {
+	const pid = ( window as any ).wp?.data?.select?.( 'core/editor' )?.getCurrentPostId?.();
+	return typeof pid === 'number' ? pid : undefined;
+}
 
 /** Default suggestion shown when no block is selected. */
 const OPTIMIZE_TITLE_SUGGESTION = {
@@ -80,7 +93,17 @@ function isReviewMediatorAvailable(
 }
 
 function getReviewMediatorSuggestions( currentPostType?: string ) {
-	return isReviewMediatorAvailable( currentPostType ) ? [ MEDIATE_REVIEW_SUGGESTION ] : [];
+	if ( ! isReviewMediatorAvailable( currentPostType ) ) {
+		return [];
+	}
+	if ( ! suggestionRenderedFiredOnce ) {
+		suggestionRenderedFiredOnce = true;
+		trackReviewMediationSuggestionRendered( {
+			postId: getCurrentPostId(),
+			postType: currentPostType ?? getCurrentEditorPostType(),
+		} );
+	}
+	return [ MEDIATE_REVIEW_SUGGESTION ];
 }
 
 function getPostLevelSuggestions( currentPostType?: string ) {
@@ -547,6 +570,14 @@ export function useSuggestions(): {
 				typeof value === 'string' &&
 				value === MEDIATE_REVIEW_SUGGESTION.prompt
 			) {
+				const runId = generateRunId();
+				setPendingRunId( runId );
+				trackReviewMediationSuggestionClick( {
+					runId,
+					trigger: 'suggestion',
+					postId: getCurrentPostId(),
+					postType: getCurrentEditorPostType(),
+				} );
 				try {
 					( dispatch as any )( 'automattic/agents-manager' ).setIsSplitScreen( true );
 				} catch {

--- a/packages/jetpack-ai-sidebar/src/utils/run-id.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/run-id.ts
@@ -1,0 +1,36 @@
+/**
+ * Run-id state for the Review Mediation flow. Generated at click time and
+ * consumed by the mediation card on mount so all events share a join key.
+ */
+
+const PENDING_RUN_ID_TTL_MS = 5 * 60 * 1000;
+
+let pendingRunId: string | null = null;
+let pendingRunIdSetAt = 0;
+
+export function generateRunId(): string {
+	if ( typeof globalThis.crypto?.randomUUID === 'function' ) {
+		return globalThis.crypto.randomUUID();
+	}
+	return `rm-${ Date.now().toString( 36 ) }-${ Math.random().toString( 36 ).slice( 2, 10 ) }`;
+}
+
+export function setPendingRunId( runId: string ): void {
+	pendingRunId = runId;
+	pendingRunIdSetAt = Date.now();
+}
+
+/**
+ * Reads and drains the pending run id. Drain prevents a stale id from
+ * leaking into a later programmatic card; TTL drops ids from clicks that
+ * never produced a card (orchestrator failure, navigation away, etc.).
+ */
+export function consumePendingRunId(): string | null {
+	if ( pendingRunId !== null && Date.now() - pendingRunIdSetAt > PENDING_RUN_ID_TTL_MS ) {
+		pendingRunId = null;
+	}
+	const id = pendingRunId;
+	pendingRunId = null;
+	pendingRunIdSetAt = 0;
+	return id;
+}

--- a/packages/jetpack-ai-sidebar/src/utils/run-id.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/run-id.ts
@@ -1,5 +1,5 @@
 /**
- * Run-id state for the Review Mediation flow. Generated at click time and
+ * Client run-id state for the Review Mediation flow. Generated at click time and
  * consumed by the mediation card on mount so all events share a join key.
  */
 
@@ -8,24 +8,24 @@ const PENDING_RUN_ID_TTL_MS = 5 * 60 * 1000;
 let pendingRunId: string | null = null;
 let pendingRunIdSetAt = 0;
 
-export function generateRunId(): string {
+export function generateClientRunId(): string {
 	if ( typeof globalThis.crypto?.randomUUID === 'function' ) {
 		return globalThis.crypto.randomUUID();
 	}
 	return `rm-${ Date.now().toString( 36 ) }-${ Math.random().toString( 36 ).slice( 2, 10 ) }`;
 }
 
-export function setPendingRunId( runId: string ): void {
-	pendingRunId = runId;
+export function setPendingClientRunId( clientRunId: string ): void {
+	pendingRunId = clientRunId;
 	pendingRunIdSetAt = Date.now();
 }
 
 /**
- * Reads and drains the pending run id. Drain prevents a stale id from
+ * Reads and drains the pending client run id. Drain prevents a stale id from
  * leaking into a later programmatic card; TTL drops ids from clicks that
  * never produced a card (orchestrator failure, navigation away, etc.).
  */
-export function consumePendingRunId(): string | null {
+export function consumePendingClientRunId(): string | null {
 	if ( pendingRunId !== null && Date.now() - pendingRunIdSetAt > PENDING_RUN_ID_TTL_MS ) {
 		pendingRunId = null;
 	}

--- a/packages/jetpack-ai-sidebar/src/utils/tracking.test.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/tracking.test.ts
@@ -1,0 +1,145 @@
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	recordTracksEvent: jest.fn(),
+} ) );
+
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import {
+	trackReviewMediationError,
+	trackReviewMediationItemAction,
+	trackReviewMediationResultRendered,
+	trackReviewMediationSuggestionClick,
+	trackReviewMediationSuggestionRendered,
+} from './tracking';
+
+const mockedRecordTracksEvent = recordTracksEvent as jest.MockedFunction<
+	typeof recordTracksEvent
+>;
+
+const expectPrivacySafePayload = ( properties: Record< string, unknown > ) => {
+	expect( properties ).not.toHaveProperty( 'post_id' );
+	expect( properties ).not.toHaveProperty( 'post_type' );
+	expect( properties ).not.toHaveProperty( 'block_index' );
+	expect( properties ).not.toHaveProperty( 'run_id' );
+	expect( properties ).not.toHaveProperty( 'trigger' );
+	expect( properties ).not.toHaveProperty( 'cache_hit' );
+	expect( properties ).not.toHaveProperty( 'auto_suggested_edit_count' );
+	expect( properties ).not.toHaveProperty( 'manual_suggested_edit_count' );
+	expect( properties ).not.toHaveProperty( 'success_count' );
+	expect( properties ).not.toHaveProperty( 'failure_count' );
+	expect( properties ).not.toHaveProperty( 'text' );
+	expect( properties ).not.toHaveProperty( 'reviewer' );
+};
+
+type WindowWithAgentsManagerActions = Window & {
+	__agentsManagerActions?: {
+		getSessionId?: () => string;
+	};
+};
+
+describe( 'Review Mediation tracking', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		( window as WindowWithAgentsManagerActions ).__agentsManagerActions = {
+			getSessionId: jest.fn( () => 'test-session-id' ),
+		};
+	} );
+
+	afterEach( () => {
+		delete ( window as WindowWithAgentsManagerActions ).__agentsManagerActions;
+	} );
+
+	it( 'tracks suggestion exposure with only session context', () => {
+		trackReviewMediationSuggestionRendered();
+
+		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_ai_review_mediation_suggestion_rendered',
+			{
+				sessionid: 'test-session-id',
+			}
+		);
+		expectPrivacySafePayload( mockedRecordTracksEvent.mock.calls[ 0 ][ 1 ] );
+	} );
+
+	it( 'tracks suggestion click with a client-only join id', () => {
+		trackReviewMediationSuggestionClick( {
+			clientRunId: 'client-run-1',
+		} );
+
+		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_ai_review_mediation_suggestion_click',
+			{
+				client_run_id: 'client-run-1',
+				sessionid: 'test-session-id',
+			}
+		);
+		expectPrivacySafePayload( mockedRecordTracksEvent.mock.calls[ 0 ][ 1 ] );
+	} );
+
+	it( 'tracks rendered results as aggregate usefulness counts', () => {
+		trackReviewMediationResultRendered( {
+			outcome: 'success',
+			conflictCount: 2,
+			implicationCount: 3,
+			suggestedEditCount: 8,
+			guidelineViolationCount: 0,
+			clientRunId: 'client-run-1',
+		} );
+
+		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_ai_review_mediation_result_rendered',
+			{
+				outcome: 'success',
+				conflict_count: 2,
+				implication_count: 3,
+				suggested_edit_count: 8,
+				guideline_violation_count: 0,
+				client_run_id: 'client-run-1',
+				sessionid: 'test-session-id',
+			}
+		);
+		expectPrivacySafePayload( mockedRecordTracksEvent.mock.calls[ 0 ][ 1 ] );
+	} );
+
+	it( 'tracks item actions after completion without row identifiers', () => {
+		trackReviewMediationItemAction( {
+			action: 'bulk_accept',
+			target: 'mixed',
+			outcome: 'partial_failed',
+			clientRunId: 'client-run-1',
+			itemCount: 4,
+		} );
+
+		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_ai_review_mediation_item_action',
+			{
+				action: 'bulk_accept',
+				target: 'mixed',
+				outcome: 'partial_failed',
+				client_run_id: 'client-run-1',
+				item_count: 4,
+				sessionid: 'test-session-id',
+			}
+		);
+		expectPrivacySafePayload( mockedRecordTracksEvent.mock.calls[ 0 ][ 1 ] );
+	} );
+
+	it( 'tracks errors with only the phase, type, and optional join id', () => {
+		trackReviewMediationError( {
+			errorPhase: 'apply',
+			errorType: 'apply_failed',
+			clientRunId: 'client-run-1',
+		} );
+
+		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith( 'jetpack_ai_review_mediation_error', {
+			error_phase: 'apply',
+			error_type: 'apply_failed',
+			client_run_id: 'client-run-1',
+			sessionid: 'test-session-id',
+		} );
+		expectPrivacySafePayload( mockedRecordTracksEvent.mock.calls[ 0 ][ 1 ] );
+	} );
+} );

--- a/packages/jetpack-ai-sidebar/src/utils/tracking.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/tracking.ts
@@ -1,0 +1,201 @@
+/**
+ * Tracking helpers for the Review Mediation Tracks events.
+ */
+
+import { recordTracksEvent as recordTracksEventBase } from '@automattic/calypso-analytics';
+
+const TRACKS_PREFIX = 'jetpack';
+
+function recordTracksEvent(
+	eventName: string,
+	properties: Record< string, string | number | boolean > = {}
+): void {
+	recordTracksEventBase( `${ TRACKS_PREFIX }_${ eventName }`, properties );
+}
+
+interface TrackReviewMediationSuggestionRenderedOptions {
+	postId?: number;
+	postType?: string;
+}
+
+interface TrackReviewMediationSuggestionClickOptions {
+	runId: string;
+	trigger: 'suggestion' | 'typed_prompt';
+	postId?: number;
+	postType?: string;
+}
+
+interface TrackReviewMediationResultRenderedOptions {
+	outcome: 'success' | 'cache_hit' | 'empty_notes';
+	cacheHit: boolean;
+	conflictCount: number;
+	suggestedEditCount: number;
+	autoSuggestedEditCount: number;
+	manualSuggestedEditCount: number;
+	guidelineViolationCount: number;
+	postId?: number;
+	runId?: string;
+}
+
+interface TrackReviewMediationItemActionOptions {
+	action: 'accept' | 'undo' | 'dismiss' | 'bulk_accept' | 'focus';
+	target: 'edit' | 'conflict';
+	postId?: number;
+	runId?: string;
+	blockIndex?: number | null;
+}
+
+interface TrackReviewMediationErrorOptions {
+	errorPhase: 'load' | 'render' | 'apply' | 'undo' | 'network';
+	errorType: string;
+	postId?: number;
+	runId?: string;
+}
+
+/**
+ * Tracks the empty-view "Mediate review notes" suggestion appearing.
+ * @param options          - Tracking options
+ * @param options.postId   - (optional) Post ID
+ * @param options.postType - (optional) Post type
+ */
+export function trackReviewMediationSuggestionRendered( {
+	postId,
+	postType,
+}: TrackReviewMediationSuggestionRenderedOptions ): void {
+	const properties: Record< string, string | number | boolean > = {};
+	if ( postId !== undefined ) {
+		properties.post_id = postId;
+	}
+	if ( postType !== undefined ) {
+		properties.post_type = postType;
+	}
+	recordTracksEvent( 'ai_review_mediation_suggestion_rendered', properties );
+}
+
+/**
+ * Tracks a user clicking the "Mediate review notes" suggestion.
+ * @param options          - Tracking options
+ * @param options.runId    - Run id generated at click time, threaded through downstream events
+ * @param options.trigger  - Whether the run was triggered via the suggestion chip or a typed prompt
+ * @param options.postId   - (optional) Post ID
+ * @param options.postType - (optional) Post type
+ */
+export function trackReviewMediationSuggestionClick( {
+	runId,
+	trigger,
+	postId,
+	postType,
+}: TrackReviewMediationSuggestionClickOptions ): void {
+	const properties: Record< string, string | number | boolean > = {
+		run_id: runId,
+		trigger,
+	};
+	if ( postId !== undefined ) {
+		properties.post_id = postId;
+	}
+	if ( postType !== undefined ) {
+		properties.post_type = postType;
+	}
+	recordTracksEvent( 'ai_review_mediation_suggestion_click', properties );
+}
+
+/**
+ * Tracks the mediation card mounting and becoming visible to the user.
+ * @param options                          - Tracking options
+ * @param options.outcome                  - High-level outcome: success, cache_hit, or empty_notes
+ * @param options.cacheHit                 - Whether the server short-circuited via the state-hash cache
+ * @param options.conflictCount            - Number of conflict items in the payload
+ * @param options.suggestedEditCount       - Total number of suggested edits
+ * @param options.autoSuggestedEditCount   - Suggested edits eligible for one-click apply
+ * @param options.manualSuggestedEditCount - Suggested edits requiring manual application
+ * @param options.guidelineViolationCount  - Number of guideline violations in the payload
+ * @param options.postId                   - (optional) Post ID
+ * @param options.runId                    - (optional) Run id threaded from the click event
+ */
+export function trackReviewMediationResultRendered( {
+	outcome,
+	cacheHit,
+	conflictCount,
+	suggestedEditCount,
+	autoSuggestedEditCount,
+	manualSuggestedEditCount,
+	guidelineViolationCount,
+	postId,
+	runId,
+}: TrackReviewMediationResultRenderedOptions ): void {
+	const properties: Record< string, string | number | boolean > = {
+		outcome,
+		cache_hit: cacheHit,
+		conflict_count: conflictCount,
+		suggested_edit_count: suggestedEditCount,
+		auto_suggested_edit_count: autoSuggestedEditCount,
+		manual_suggested_edit_count: manualSuggestedEditCount,
+		guideline_violation_count: guidelineViolationCount,
+	};
+	if ( postId !== undefined ) {
+		properties.post_id = postId;
+	}
+	if ( runId !== undefined ) {
+		properties.run_id = runId;
+	}
+	recordTracksEvent( 'ai_review_mediation_result_rendered', properties );
+}
+
+/**
+ * Tracks a user action on a mediation row (accept, undo, dismiss, bulk-accept, focus).
+ * @param options            - Tracking options
+ * @param options.action     - Action verb
+ * @param options.target     - Whether the row is a suggested edit or a conflict candidate
+ * @param options.postId     - (optional) Post ID
+ * @param options.runId      - (optional) Run id from the originating click
+ * @param options.blockIndex - (optional) Block index for the row's target block
+ */
+export function trackReviewMediationItemAction( {
+	action,
+	target,
+	postId,
+	runId,
+	blockIndex,
+}: TrackReviewMediationItemActionOptions ): void {
+	const properties: Record< string, string | number | boolean > = {
+		action,
+		target,
+	};
+	if ( postId !== undefined ) {
+		properties.post_id = postId;
+	}
+	if ( runId !== undefined ) {
+		properties.run_id = runId;
+	}
+	if ( blockIndex !== undefined && blockIndex !== null ) {
+		properties.block_index = blockIndex;
+	}
+	recordTracksEvent( 'ai_review_mediation_item_action', properties );
+}
+
+/**
+ * Tracks a Review Mediation failure (load, render, apply, undo, or network).
+ * @param options            - Tracking options
+ * @param options.errorPhase - Which step failed
+ * @param options.errorType  - A short error code or message tag
+ * @param options.postId     - (optional) Post ID
+ * @param options.runId      - (optional) Run id when the failure is tied to a specific invocation
+ */
+export function trackReviewMediationError( {
+	errorPhase,
+	errorType,
+	postId,
+	runId,
+}: TrackReviewMediationErrorOptions ): void {
+	const properties: Record< string, string | number | boolean > = {
+		error_phase: errorPhase,
+		error_type: errorType,
+	};
+	if ( postId !== undefined ) {
+		properties.post_id = postId;
+	}
+	if ( runId !== undefined ) {
+		properties.run_id = runId;
+	}
+	recordTracksEvent( 'ai_review_mediation_error', properties );
+}

--- a/packages/jetpack-ai-sidebar/src/utils/tracking.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/tracking.ts
@@ -6,96 +6,77 @@ import { recordTracksEvent as recordTracksEventBase } from '@automattic/calypso-
 
 const TRACKS_PREFIX = 'jetpack';
 
-function recordTracksEvent(
-	eventName: string,
-	properties: Record< string, string | number | boolean > = {}
-): void {
-	recordTracksEventBase( `${ TRACKS_PREFIX }_${ eventName }`, properties );
+type TrackProperties = Record< string, string | number | boolean >;
+
+type WindowWithAgentsManagerActions = Window & {
+	__agentsManagerActions?: {
+		getSessionId?: () => unknown;
+	};
+};
+
+function getSessionId(): string | undefined {
+	if ( typeof window === 'undefined' ) {
+		return undefined;
+	}
+
+	const agentsManagerActions = ( window as WindowWithAgentsManagerActions ).__agentsManagerActions;
+	const sessionId = agentsManagerActions?.getSessionId?.();
+	return typeof sessionId === 'string' && sessionId !== '' ? sessionId : undefined;
 }
 
-interface TrackReviewMediationSuggestionRenderedOptions {
-	postId?: number;
-	postType?: string;
+function recordTracksEvent( eventName: string, properties: TrackProperties = {} ): void {
+	const sessionId = getSessionId();
+	recordTracksEventBase( `${ TRACKS_PREFIX }_${ eventName }`, {
+		...properties,
+		...( sessionId ? { sessionid: sessionId } : {} ),
+	} );
 }
 
 interface TrackReviewMediationSuggestionClickOptions {
-	runId: string;
-	trigger: 'suggestion' | 'typed_prompt';
-	postId?: number;
-	postType?: string;
+	clientRunId: string;
 }
 
 interface TrackReviewMediationResultRenderedOptions {
 	outcome: 'success' | 'cache_hit' | 'empty_notes';
-	cacheHit: boolean;
 	conflictCount: number;
+	implicationCount: number;
 	suggestedEditCount: number;
-	autoSuggestedEditCount: number;
-	manualSuggestedEditCount: number;
 	guidelineViolationCount: number;
-	postId?: number;
-	runId?: string;
+	clientRunId: string;
 }
 
 interface TrackReviewMediationItemActionOptions {
-	action: 'accept' | 'undo' | 'dismiss' | 'bulk_accept' | 'focus';
-	target: 'edit' | 'conflict';
-	postId?: number;
-	runId?: string;
-	blockIndex?: number | null;
+	action: 'accept' | 'undo' | 'dismiss' | 'bulk_accept';
+	target: 'edit' | 'conflict' | 'mixed';
+	outcome: 'success' | 'failed' | 'partial_failed';
+	clientRunId?: string;
+	itemCount?: number;
 }
 
 interface TrackReviewMediationErrorOptions {
 	errorPhase: 'load' | 'render' | 'apply' | 'undo' | 'network';
 	errorType: string;
-	postId?: number;
-	runId?: string;
+	clientRunId?: string;
 }
 
 /**
  * Tracks the empty-view "Mediate review notes" suggestion appearing.
- * @param options          - Tracking options
- * @param options.postId   - (optional) Post ID
- * @param options.postType - (optional) Post type
  */
-export function trackReviewMediationSuggestionRendered( {
-	postId,
-	postType,
-}: TrackReviewMediationSuggestionRenderedOptions ): void {
-	const properties: Record< string, string | number | boolean > = {};
-	if ( postId !== undefined ) {
-		properties.post_id = postId;
-	}
-	if ( postType !== undefined ) {
-		properties.post_type = postType;
-	}
-	recordTracksEvent( 'ai_review_mediation_suggestion_rendered', properties );
+export function trackReviewMediationSuggestionRendered(): void {
+	recordTracksEvent( 'ai_review_mediation_suggestion_rendered' );
 }
 
 /**
  * Tracks a user clicking the "Mediate review notes" suggestion.
- * @param options          - Tracking options
- * @param options.runId    - Run id generated at click time, threaded through downstream events
- * @param options.trigger  - Whether the run was triggered via the suggestion chip or a typed prompt
- * @param options.postId   - (optional) Post ID
- * @param options.postType - (optional) Post type
+ * @param options             - Tracking options
+ * @param options.clientRunId - Client-side join id generated at click time
  */
 export function trackReviewMediationSuggestionClick( {
-	runId,
-	trigger,
-	postId,
-	postType,
+	clientRunId,
 }: TrackReviewMediationSuggestionClickOptions ): void {
-	const properties: Record< string, string | number | boolean > = {
-		run_id: runId,
-		trigger,
+	const properties: TrackProperties = {
+		client_run_id: clientRunId,
 	};
-	if ( postId !== undefined ) {
-		properties.post_id = postId;
-	}
-	if ( postType !== undefined ) {
-		properties.post_type = postType;
-	}
 	recordTracksEvent( 'ai_review_mediation_suggestion_click', properties );
 }
 
@@ -103,99 +84,79 @@ export function trackReviewMediationSuggestionClick( {
  * Tracks the mediation card mounting and becoming visible to the user.
  * @param options                          - Tracking options
  * @param options.outcome                  - High-level outcome: success, cache_hit, or empty_notes
- * @param options.cacheHit                 - Whether the server short-circuited via the state-hash cache
  * @param options.conflictCount            - Number of conflict items in the payload
+ * @param options.implicationCount         - Number of implication items in the payload
  * @param options.suggestedEditCount       - Total number of suggested edits
- * @param options.autoSuggestedEditCount   - Suggested edits eligible for one-click apply
- * @param options.manualSuggestedEditCount - Suggested edits requiring manual application
  * @param options.guidelineViolationCount  - Number of guideline violations in the payload
- * @param options.postId                   - (optional) Post ID
- * @param options.runId                    - (optional) Run id threaded from the click event
+ * @param options.clientRunId              - Client-side join id for this mediation card
  */
 export function trackReviewMediationResultRendered( {
 	outcome,
-	cacheHit,
 	conflictCount,
+	implicationCount,
 	suggestedEditCount,
-	autoSuggestedEditCount,
-	manualSuggestedEditCount,
 	guidelineViolationCount,
-	postId,
-	runId,
+	clientRunId,
 }: TrackReviewMediationResultRenderedOptions ): void {
-	const properties: Record< string, string | number | boolean > = {
+	const properties: TrackProperties = {
 		outcome,
-		cache_hit: cacheHit,
 		conflict_count: conflictCount,
+		implication_count: implicationCount,
 		suggested_edit_count: suggestedEditCount,
-		auto_suggested_edit_count: autoSuggestedEditCount,
-		manual_suggested_edit_count: manualSuggestedEditCount,
 		guideline_violation_count: guidelineViolationCount,
+		client_run_id: clientRunId,
 	};
-	if ( postId !== undefined ) {
-		properties.post_id = postId;
-	}
-	if ( runId !== undefined ) {
-		properties.run_id = runId;
-	}
 	recordTracksEvent( 'ai_review_mediation_result_rendered', properties );
 }
 
 /**
- * Tracks a user action on a mediation row (accept, undo, dismiss, bulk-accept, focus).
- * @param options            - Tracking options
- * @param options.action     - Action verb
- * @param options.target     - Whether the row is a suggested edit or a conflict candidate
- * @param options.postId     - (optional) Post ID
- * @param options.runId      - (optional) Run id from the originating click
- * @param options.blockIndex - (optional) Block index for the row's target block
+ * Tracks a user action on a mediation row.
+ * @param options                - Tracking options
+ * @param options.action         - Action verb
+ * @param options.target         - Suggested edit, conflict, or mixed bulk action
+ * @param options.outcome        - Whether the action completed successfully
+ * @param options.clientRunId    - (optional) Client-side join id
+ * @param options.itemCount      - (optional) Number of items attempted
  */
 export function trackReviewMediationItemAction( {
 	action,
 	target,
-	postId,
-	runId,
-	blockIndex,
+	outcome,
+	clientRunId,
+	itemCount,
 }: TrackReviewMediationItemActionOptions ): void {
-	const properties: Record< string, string | number | boolean > = {
+	const properties: TrackProperties = {
 		action,
 		target,
+		outcome,
 	};
-	if ( postId !== undefined ) {
-		properties.post_id = postId;
+	if ( clientRunId !== undefined ) {
+		properties.client_run_id = clientRunId;
 	}
-	if ( runId !== undefined ) {
-		properties.run_id = runId;
-	}
-	if ( blockIndex !== undefined && blockIndex !== null ) {
-		properties.block_index = blockIndex;
+	if ( itemCount !== undefined ) {
+		properties.item_count = itemCount;
 	}
 	recordTracksEvent( 'ai_review_mediation_item_action', properties );
 }
 
 /**
  * Tracks a Review Mediation failure (load, render, apply, undo, or network).
- * @param options            - Tracking options
- * @param options.errorPhase - Which step failed
- * @param options.errorType  - A short error code or message tag
- * @param options.postId     - (optional) Post ID
- * @param options.runId      - (optional) Run id when the failure is tied to a specific invocation
+ * @param options             - Tracking options
+ * @param options.errorPhase  - Which step failed
+ * @param options.errorType   - A short error code or message tag
+ * @param options.clientRunId - (optional) Client-side join id
  */
 export function trackReviewMediationError( {
 	errorPhase,
 	errorType,
-	postId,
-	runId,
+	clientRunId,
 }: TrackReviewMediationErrorOptions ): void {
-	const properties: Record< string, string | number | boolean > = {
+	const properties: TrackProperties = {
 		error_phase: errorPhase,
 		error_type: errorType,
 	};
-	if ( postId !== undefined ) {
-		properties.post_id = postId;
-	}
-	if ( runId !== undefined ) {
-		properties.run_id = runId;
+	if ( clientRunId !== undefined ) {
+		properties.client_run_id = clientRunId;
 	}
 	recordTracksEvent( 'ai_review_mediation_error', properties );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1516,6 +1516,7 @@ __metadata:
   resolution: "@automattic/jetpack-ai-sidebar@workspace:packages/jetpack-ai-sidebar"
   dependencies:
     "@automattic/agenttic-client": "npm:^0.1.58"
+    "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@types/react": "npm:^18.3.1"
     "@types/react-dom": "npm:^18.3.1"


### PR DESCRIPTION
## Proposed changes

  * Add privacy-safe Tracks events for the Review Mediation funnel in the Jetpack AI sidebar package.
  * Track the main usefulness signals for v1:
    * `jetpack_ai_review_mediation_suggestion_rendered`
    * `jetpack_ai_review_mediation_suggestion_click`
    * `jetpack_ai_review_mediation_result_rendered`
    * `jetpack_ai_review_mediation_item_action`
    * `jetpack_ai_review_mediation_error`
  * Add a client-generated `client_run_id` so suggestion clicks, rendered results, item actions, and
  errors can be joined without sending post or block identifiers.
  * Include the Agents Manager `sessionid` when available.
  * Keep event payloads intentionally small and privacy-safe:
    * No post ID.
    * No post type.
    * No block index.
    * No reviewer identity.
    * No reviewed text or suggested text.
  * Add unit coverage for event names, payload shape, session ID inclusion, and privacy-sensitive fields
  being excluded.
  * Add the package dependency on `@automattic/calypso-analytics`.

  ## Why are these changes being made?

  * Review Mediation now has the core end-to-end experience in place. The next step is measuring whether
  users actually discover it, run it, receive useful output, and act on the results.
  * These events provide a minimal v1 funnel:
    * Was the suggestion shown?
    * Did the user click it?
    * Did a result render?
    * How much actionable output did the result contain?
    * Did users accept, undo, dismiss, or bulk-accept items?
    * Where do user-facing failures occur?
  * The payload is intentionally constrained to aggregate counts, outcomes, action types, and a client-
  side join ID. This gives us usefulness signals without exposing editor content, reviewer details, post
  IDs, or block-level identifiers.

  ## Event payload summary

  ### `jetpack_ai_review_mediation_suggestion_rendered`

  Fired when the “Mediate review notes” suggestion appears.

  Properties:

  * `sessionid`, when available.

  ### `jetpack_ai_review_mediation_suggestion_click`

  Fired when the user clicks the “Mediate review notes” suggestion.

  Properties:

  * `client_run_id`
  * `sessionid`, when available.

  ### `jetpack_ai_review_mediation_result_rendered`

  Fired when the Review Mediation component renders.

  Properties:

  * `outcome`: `success`, `cache_hit`, or `empty_notes`
  * `conflict_count`
  * `implication_count`
  * `suggested_edit_count`
  * `guideline_violation_count`
  * `client_run_id`
  * `sessionid`, when available.

  ### `jetpack_ai_review_mediation_item_action`

  Fired when the user acts on mediation output.

  Properties:

  * `action`: `accept`, `undo`, `dismiss`, or `bulk_accept`
  * `target`: `edit`, `conflict`, or `mixed`
  * `outcome`: `success`, `failed`, or `partial_failed`
  * `item_count`, when relevant
  * `client_run_id`, when available
  * `sessionid`, when available.

  ### `jetpack_ai_review_mediation_error`

  Fired when Review Mediation hits a user-facing failure.

  Properties:

  * `error_phase`: `load`, `render`, `apply`, `undo`, or `network`
  * `error_type`
  * `client_run_id`, when available
  * `sessionid`, when available.

  ## Testing instructions

  * Run the focused tracking tests:

  - Manual smoke test:
      - Open a post where Review Mediation is available.
      - Confirm the “Mediate review notes” suggestion appears.
      - Click the suggestion and wait for the mediation result.
      - Accept, undo, dismiss, and bulk-accept where possible.
      - Confirm the UI behavior is unchanged from the base Review Mediation flow.