### PR TITLE
Fix generate-password Node crypto access

### DIFF
--- a/packages/generate-password/src/index.ts
+++ b/packages/generate-password/src/index.ts
@@ -57,7 +57,7 @@ export function generatePassword( {
 	// @link https://dimitri.xyz/random-ints-from-random-bits/
 	for ( let i = 0; i < length; i++ ) {
 		do {
-			window.crypto.getRandomValues( randomNumber );
+			globalThis.crypto.getRandomValues( randomNumber );
 		} while ( randomNumber[ 0 ] >= characterPool.length );
 
 		password += characterPool[ randomNumber[ 0 ] ];

--- a/packages/generate-password/src/test/node.ts
+++ b/packages/generate-password/src/test/node.ts
@@ -1,0 +1,11 @@
+/**
+ * @jest-environment node
+ */
+import { generatePassword } from '../';
+
+describe( 'generatePassword in Node', () => {
+	test( 'does not require a browser window global', () => {
+		expect( typeof window ).toBe( 'undefined' );
+		expect( generatePassword() ).toHaveLength( 24 );
+	} );
+} );


### PR DESCRIPTION
## Proposed Changes

- Replace browser-only `window.crypto` usage in `@automattic/generate-password` with runtime-neutral `globalThis.crypto`.
- Add a Node-environment regression test proving `generatePassword()` works without a browser `window` global.

## Why

`@automattic/generate-password` is published as a reusable CJS/ESM package, but the current implementation fails in Node because it hardcodes `window.crypto.getRandomValues(...)`. Node exposes Web Crypto on `globalThis.crypto`, so the package can support browser and Node runtimes with a one-line runtime-neutral access change.

Fixes https://github.com/Automattic/wp-calypso/issues/110620

Downstream Studio impact: https://github.com/Automattic/studio/issues/3417

## Evidence

Package-level failing proof before this fix:
- Homeboy run: `5cb85066-4f35-4607-a9e0-e339d5e01a44`
- Artifact: `/Users/chubes/.local/share/homeboy/artifacts/5cb85066-4f35-4607-a9e0-e339d5e01a44/370a1f6a-cbf7-455b-8f16-0847694769dd-trace.json`
- Observed error: `ReferenceError: window is not defined` at `package/dist/cjs/index.js:33`

Studio downstream proof with this fix packed from Calypso and installed into a clean Studio trunk checkout:
- Durable rig PR: https://github.com/chubes4/homeboy-rigs/pull/110
- Homeboy run: `f38a2595-a359-4eeb-808d-43f42992cf35`
- Raw result artifact: `/Users/chubes/.local/share/homeboy/artifacts/f38a2595-a359-4eeb-808d-43f42992cf35/0535cb55-0578-4e48-9d24-8c3d7ae0078e-result-cli-password-node-cli-password-node-26696-1778362784838-0mjqzmixbbga.json`
- Result: `studio site create --no-start` completed with `Site created successfully`.

## Testing Instructions

```sh
yarn jest packages/generate-password/src/test/index.ts packages/generate-password/src/test/node.ts --config packages/generate-password/jest.config.js
yarn workspace @automattic/generate-password build
```

Both passed locally.

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Reproducing the package failure with Homeboy, drafting the minimal fix and regression test, and running the downstream Studio proof rig. Chris reviewed the upstream-first direction and requested the durable Homeboy proof.
