### PR TITLE
Onboarding domain search: surface "Use a domain I own" in top bar on mobile

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -12,6 +12,7 @@ import {
 	StepContainer,
 } from '@automattic/onboarding';
 import { Button } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { useMemo } from 'react';
@@ -79,6 +80,12 @@ const DomainSearchStep: StepType< {
 	const userSiteCount = useSelector( getCurrentUserSiteCount );
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const dashboardOptIn = useSelector( hasDashboardOptIn );
+	// On mobile, the empty-state "Already have a domain?" body card is
+	// hidden via CSS (see style.scss) and its CTA is surfaced in the
+	// top bar's right slot instead — keeps the affordance reachable
+	// without the in-body card taking up scarce vertical space on
+	// small screens.
+	const isMobileViewport = useViewportMatch( 'small', '<' );
 	const site = useSite();
 	const siteSlug = useSiteSlugParam();
 	const siteId = useSiteIdParam();
@@ -434,7 +441,13 @@ const DomainSearchStep: StepType< {
 		};
 
 		const getTopBarRightElement = () => {
-			if ( ! query ) {
+			// Surface the "Use a domain I own" CTA whenever:
+			//   - the user has searched (query is non-empty), OR
+			//   - we're on a mobile viewport (where the in-body
+			//     empty-state card is hidden — see style.scss).
+			// On desktop empty state, the link stays hidden and the
+			// in-body card carries the same CTA.
+			if ( ! query && ! isMobileViewport ) {
 				return;
 			}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -80,11 +80,6 @@ const DomainSearchStep: StepType< {
 	const userSiteCount = useSelector( getCurrentUserSiteCount );
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const dashboardOptIn = useSelector( hasDashboardOptIn );
-	// On mobile, the empty-state "Already have a domain?" body card is
-	// hidden via CSS (see style.scss) and its CTA is surfaced in the
-	// top bar's right slot instead — keeps the affordance reachable
-	// without the in-body card taking up scarce vertical space on
-	// small screens.
 	const isMobileViewport = useViewportMatch( 'small', '<' );
 	const site = useSite();
 	const siteSlug = useSiteSlugParam();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/style.scss
@@ -39,4 +39,18 @@
 	flex: 1;
 	display: flex;
 	flex-direction: column;
+
+	// Empty-state "Already have a domain?" CTA.
+	// On mobile, vertical space is scarce and the same CTA is
+	// surfaced in the top bar (see getTopBarRightElement in
+	// index.tsx) — so the in-body card is hidden below the small
+	// breakpoint. Desktop keeps the card where there's plenty of
+	// room and the top bar stays focused on Back.
+	.domain-search--initial-state__already-own-domain-cta {
+		display: none;
+
+		@include break-small {
+			display: revert;
+		}
+	}
 }


### PR DESCRIPTION
## Summary

On mobile, the empty-state "Already have a domain?" body card eats a chunk of vertical space at the moment users most need to focus on the search input. This PR moves that affordance to the top bar on mobile only — desktop is unchanged.

| | Desktop (≥ 600px) | Mobile (< 600px) |
|---|---|---|
| Empty state | Body card only *(unchanged)* | Top-bar link only *(new)* |
| Searched state | Top-bar link *(unchanged)* | Top-bar link *(unchanged)* |

## Before / After

**Note:** For the After images, I'm logged in, hence the '< Back' link in the header.

|  | Before | After |
|---|---|---|
| **Mobile — empty state** *(< 600px)* | <img width="300" alt="Mobile before" src="https://github.com/user-attachments/assets/67dd5c6b-ef42-4a99-ae7d-cc340041bb1a" /> | <img width="300" alt="Mobile after" src="https://github.com/user-attachments/assets/2546f777-f58c-4cfe-9898-ccfadb1e9010" /> |
| **Desktop — empty state** *(≥ 600px, should be unchanged)* | <img width="500" alt="Desktop before" src="https://github.com/user-attachments/assets/20081511-3fcb-4d74-96d9-e514ff1248bc" /> | <img width="500" alt="Desktop after" src="https://github.com/user-attachments/assets/0a0813a7-b76c-41b6-acaf-9d3975a643fe" /> |

## Changes

Two coordinated changes, both scoped to the v2 stepper's domain-search step:

1. **`client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx`**
   Added `const isMobileViewport = useViewportMatch( 'small', '<' );` and relaxed `getTopBarRightElement`'s gate from `if ( ! query ) return;` to `if ( ! query && ! isMobileViewport ) return;`. The link now surfaces on mobile even when the search is empty.

2. **`client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/style.scss`**
   Hides `.domain-search--initial-state__already-own-domain-cta` below `break-small`, scoped to `.step-container-v2--domain-search` so other consumers of the shared package aren't affected.

The 600px threshold matches Calypso's existing `useViewportMatch( 'small', '<' )` + `@include break-small` conventions.

## Test plan

- [ ] Boot the dev server and navigate to a flow that hits the v2 domain-search step (e.g. `/setup/onboarding`).
- [ ] **Desktop** (≥ 600px wide):
  - [ ] Empty state shows the "Already have a domain?" body card.
  - [ ] Empty state's top-bar right slot is empty.
  - [ ] Typing into the search box surfaces "Use a domain I own" in the top bar (unchanged).
- [ ] **Mobile** (< 600px wide):
  - [ ] Empty state shows "Use a domain I own" in the top bar.
  - [ ] Empty state has *no* body card.
  - [ ] Typing into the search box keeps the top-bar link visible (unchanged).
- [ ] Both the body card and the top-bar link invoke the same `onExternalDomainClick` handler.
- [ ] Other consumers of `@automattic/domain-search`'s `InitialState` (e.g. dashboard, my-sites domain settings) are unaffected — the hide rule is scoped to `.step-container-v2--domain-search`.
