### PR TITLE
Onboarding domain search: Refine the empty search input on mobile

### DIFF
--- a/packages/domain-search/src/components/search-bar/index.tsx
+++ b/packages/domain-search/src/components/search-bar/index.tsx
@@ -6,7 +6,7 @@ import './style.scss';
 
 export const SearchBar = () => {
 	return (
-		<HStack spacing={ 4 }>
+		<HStack spacing={ 2 }>
 			<Input />
 			<Filter />
 		</HStack>

--- a/packages/domain-search/src/components/search-bar/index.tsx
+++ b/packages/domain-search/src/components/search-bar/index.tsx
@@ -6,7 +6,7 @@ import './style.scss';
 
 export const SearchBar = () => {
 	return (
-		<HStack spacing={ 2 }>
+		<HStack className="domain-search__search-bar" spacing={ 4 }>
 			<Input />
 			<Filter />
 		</HStack>

--- a/packages/domain-search/src/components/search-form/index.tsx
+++ b/packages/domain-search/src/components/search-form/index.tsx
@@ -7,7 +7,6 @@ import {
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
-import { useContainerQuery } from '../../hooks/use-container-query';
 import { useTypedPlaceholder } from '../../hooks/use-typed-placeholder';
 import { useDomainSearch } from '../../page/context';
 import { DomainSearchControls } from '../../ui';
@@ -31,8 +30,6 @@ export const SearchForm = () => {
 	const { placeholder } = useTypedPlaceholder( PLACEHOLDER_PHRASES, false );
 	const [ showSearchHint, setShowSearchHint ] = useState( false );
 
-	const { activeQuery, ref } = useContainerQuery( { small: 0, large: 480 } );
-
 	const handleSubmit = ( event: React.FormEvent< HTMLFormElement > ) => {
 		event.preventDefault();
 		setQuery( localQuery );
@@ -45,7 +42,7 @@ export const SearchForm = () => {
 	return (
 		<form onSubmit={ handleSubmit }>
 			<VStack spacing={ 2 }>
-				<HStack alignment="flex-start" spacing={ 4 } ref={ ref }>
+				<HStack alignment="flex-start" spacing={ 4 }>
 					<DomainSearchControls.Input
 						value={ localQuery }
 						onChange={ ( value ) => setLocalQuery( value.trim() ) }
@@ -54,9 +51,7 @@ export const SearchForm = () => {
 						// eslint-disable-next-line jsx-a11y/no-autofocus
 						autoFocus
 					/>
-					{ activeQuery === 'large' && (
-						<DomainSearchControls.Submit onClick={ () => onSubmitButtonClick( localQuery ) } />
-					) }
+					<DomainSearchControls.Submit onClick={ () => onSubmitButtonClick( localQuery ) } />
 				</HStack>
 				{ showSearchHint && (
 					<Text variant="muted">

--- a/packages/domain-search/src/components/search-form/index.tsx
+++ b/packages/domain-search/src/components/search-form/index.tsx
@@ -7,7 +7,7 @@ import {
 import { useViewportMatch } from '@wordpress/compose';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTypedPlaceholder } from '../../hooks/use-typed-placeholder';
 import { useDomainSearch } from '../../page/context';
 import { DomainSearchControls } from '../../ui';
@@ -36,6 +36,25 @@ export const SearchForm = () => {
 	// HStack with the text "Search domains" button alongside.
 	const isMobileViewport = useViewportMatch( 'small', '<' );
 
+	// Explicitly focus the input on mount.
+	//
+	// We previously relied on the underlying <input>'s `autoFocus`
+	// attribute, but that fires too early during the stepper's
+	// AnimatePresence route transition — the element mounts while
+	// the page is still animating in, React calls .focus() before
+	// the browser treats the page as the active focus target, and
+	// the cursor never lands. useEffect runs after the commit phase
+	// and after the transition has settled, so .focus() lands.
+	//
+	// Note: on iOS Safari this places focus + visible caret but does
+	// NOT open the soft keyboard — that's an OS restriction (only a
+	// user gesture can open the keyboard). Desktop and most Android
+	// browsers behave as expected.
+	const inputRef = useRef< HTMLInputElement >( null );
+	useEffect( () => {
+		inputRef.current?.focus();
+	}, [ isMobileViewport ] );
+
 	const handleSubmit = ( event: React.FormEvent< HTMLFormElement > ) => {
 		event.preventDefault();
 		setQuery( localQuery );
@@ -46,12 +65,11 @@ export const SearchForm = () => {
 	};
 
 	const inputProps = {
+		ref: inputRef,
 		value: localQuery,
 		onChange: ( value: string ) => setLocalQuery( value.trim() ),
 		onReset: () => setLocalQuery( '' ),
 		placeholder,
-		// eslint-disable-next-line jsx-a11y/no-autofocus
-		autoFocus: true,
 	};
 
 	return (

--- a/packages/domain-search/src/components/search-form/index.tsx
+++ b/packages/domain-search/src/components/search-form/index.tsx
@@ -1,8 +1,10 @@
 import {
 	Button,
+	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
 } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
@@ -28,6 +30,11 @@ export const SearchForm = () => {
 	const [ localQuery, setLocalQuery ] = useState( '' );
 	const { placeholder } = useTypedPlaceholder( PLACEHOLDER_PHRASES, false );
 	const [ showSearchHint, setShowSearchHint ] = useState( false );
+	// Mobile-only layout swap. Below the 'small' viewport breakpoint
+	// (600px), the Submit lives *inside* the search input as a compact
+	// icon button. At and above 'small', we fall back to the original
+	// HStack with the text "Search domains" button alongside.
+	const isMobileViewport = useViewportMatch( 'small', '<' );
 
 	const handleSubmit = ( event: React.FormEvent< HTMLFormElement > ) => {
 		event.preventDefault();
@@ -38,27 +45,36 @@ export const SearchForm = () => {
 		}
 	};
 
+	const inputProps = {
+		value: localQuery,
+		onChange: ( value: string ) => setLocalQuery( value.trim() ),
+		onReset: () => setLocalQuery( '' ),
+		placeholder,
+		// eslint-disable-next-line jsx-a11y/no-autofocus
+		autoFocus: true,
+	};
+
 	return (
 		<form onSubmit={ handleSubmit }>
 			<VStack spacing={ 2 }>
-				{ /* The submit button is *inside* the input on this screen
-				     rather than alongside it — see style.scss. The wrapper
-				     div gives the absolutely-positioned button a frame to
-				     anchor against. */ }
-				<div className="domain-search__search-form-field">
-					<DomainSearchControls.Input
-						value={ localQuery }
-						onChange={ ( value ) => setLocalQuery( value.trim() ) }
-						onReset={ () => setLocalQuery( '' ) }
-						placeholder={ placeholder }
-						// eslint-disable-next-line jsx-a11y/no-autofocus
-						autoFocus
-					/>
-					<DomainSearchControls.Submit
-						iconOnly
-						onClick={ () => onSubmitButtonClick( localQuery ) }
-					/>
-				</div>
+				{ isMobileViewport ? (
+					/* Mobile: wrapper div gives the absolutely-positioned
+					   Submit a frame to anchor against. */
+					<div className="domain-search__search-form-field">
+						<DomainSearchControls.Input { ...inputProps } />
+						<DomainSearchControls.Submit
+							iconOnly
+							onClick={ () => onSubmitButtonClick( localQuery ) }
+						/>
+					</div>
+				) : (
+					/* Desktop: original HStack layout with the text Submit
+					   sitting alongside the input. Unchanged from trunk. */
+					<HStack alignment="flex-start" spacing={ 4 }>
+						<DomainSearchControls.Input { ...inputProps } />
+						<DomainSearchControls.Submit onClick={ () => onSubmitButtonClick( localQuery ) } />
+					</HStack>
+				) }
 				{ showSearchHint && (
 					<Text variant="muted">
 						{ createInterpolateElement(

--- a/packages/domain-search/src/components/search-form/index.tsx
+++ b/packages/domain-search/src/components/search-form/index.tsx
@@ -1,6 +1,5 @@
 import {
 	Button,
-	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
 } from '@wordpress/components';
@@ -42,7 +41,11 @@ export const SearchForm = () => {
 	return (
 		<form onSubmit={ handleSubmit }>
 			<VStack spacing={ 2 }>
-				<HStack alignment="flex-start" spacing={ 4 }>
+				{ /* The submit button is *inside* the input on this screen
+				     rather than alongside it — see style.scss. The wrapper
+				     div gives the absolutely-positioned button a frame to
+				     anchor against. */ }
+				<div className="domain-search__search-form-field">
 					<DomainSearchControls.Input
 						value={ localQuery }
 						onChange={ ( value ) => setLocalQuery( value.trim() ) }
@@ -51,8 +54,11 @@ export const SearchForm = () => {
 						// eslint-disable-next-line jsx-a11y/no-autofocus
 						autoFocus
 					/>
-					<DomainSearchControls.Submit onClick={ () => onSubmitButtonClick( localQuery ) } />
-				</HStack>
+					<DomainSearchControls.Submit
+						iconOnly
+						onClick={ () => onSubmitButtonClick( localQuery ) }
+					/>
+				</div>
 				{ showSearchHint && (
 					<Text variant="muted">
 						{ createInterpolateElement(

--- a/packages/domain-search/src/components/search-form/index.tsx
+++ b/packages/domain-search/src/components/search-form/index.tsx
@@ -30,30 +30,14 @@ export const SearchForm = () => {
 	const [ localQuery, setLocalQuery ] = useState( '' );
 	const { placeholder } = useTypedPlaceholder( PLACEHOLDER_PHRASES, false );
 	const [ showSearchHint, setShowSearchHint ] = useState( false );
-	// Mobile-only layout swap. Below the 'small' viewport breakpoint
-	// (600px), the Submit lives *inside* the search input as a compact
-	// icon button. At and above 'small', we fall back to the original
-	// HStack with the text "Search domains" button alongside.
 	const isMobileViewport = useViewportMatch( 'small', '<' );
 
-	// Explicitly focus the input on mount.
-	//
-	// We previously relied on the underlying <input>'s `autoFocus`
-	// attribute, but that fires too early during the stepper's
-	// AnimatePresence route transition — the element mounts while
-	// the page is still animating in, React calls .focus() before
-	// the browser treats the page as the active focus target, and
-	// the cursor never lands. useEffect runs after the commit phase
-	// and after the transition has settled, so .focus() lands.
-	//
-	// Note: on iOS Safari this places focus + visible caret but does
-	// NOT open the soft keyboard — that's an OS restriction (only a
-	// user gesture can open the keyboard). Desktop and most Android
-	// browsers behave as expected.
+	// autoFocus races the stepper's route-transition animation; focus
+	// in an effect lands reliably after the commit phase.
 	const inputRef = useRef< HTMLInputElement >( null );
 	useEffect( () => {
 		inputRef.current?.focus();
-	}, [ isMobileViewport ] );
+	}, [] );
 
 	const handleSubmit = ( event: React.FormEvent< HTMLFormElement > ) => {
 		event.preventDefault();
@@ -76,8 +60,6 @@ export const SearchForm = () => {
 		<form onSubmit={ handleSubmit }>
 			<VStack spacing={ 2 }>
 				{ isMobileViewport ? (
-					/* Mobile: wrapper div gives the absolutely-positioned
-					   Submit a frame to anchor against. */
 					<div className="domain-search__search-form-field">
 						<DomainSearchControls.Input { ...inputProps } />
 						<DomainSearchControls.Submit
@@ -86,8 +68,6 @@ export const SearchForm = () => {
 						/>
 					</div>
 				) : (
-					/* Desktop: original HStack layout with the text Submit
-					   sitting alongside the input. Unchanged from trunk. */
 					<HStack alignment="flex-start" spacing={ 4 }>
 						<DomainSearchControls.Input { ...inputProps } />
 						<DomainSearchControls.Submit onClick={ () => onSubmitButtonClick( localQuery ) } />

--- a/packages/domain-search/src/components/search-form/style.scss
+++ b/packages/domain-search/src/components/search-form/style.scss
@@ -67,3 +67,18 @@
 		}
 	}
 }
+
+// Tighten the heading-to-content gap when this empty state is the
+// active step. The wireframe's .step-container-v2__content-wrapper
+// (owned by @automattic/onboarding) defaults to gap: 3rem between
+// the heading slot and the children slot. On mobile that's too
+// generous for this screen — drop it to 1.5rem.
+//
+// Scoped with :has() to the wrapper that actually contains the
+// initial-state, so other stepper-v2 pages keep the original 3rem.
+// Desktop is the natural fall-through.
+.step-container-v2__content-wrapper:has( .domain-search--initial-state ) {
+	@media ( max-width: #{ $break-small - 1px } ) {
+		gap: 1.5rem;
+	}
+}

--- a/packages/domain-search/src/components/search-form/style.scss
+++ b/packages/domain-search/src/components/search-form/style.scss
@@ -7,32 +7,11 @@
 	}
 }
 
-// ── Empty-state mobile-only refinements ──────────────────────────
-//
-// SearchForm is rendered exclusively by InitialState, so scoping
-// these overrides to the .domain-search--initial-state wrapper
-// keeps the results-page search-bar (which also uses
-// DomainSearchControls.Input) unaffected.
-//
-// All rules below are wrapped in a single @media query for the
-// 'small' breakpoint (< 600px). Above this breakpoint the empty
-// state falls back to the original trunk layout — HStack with the
-// text "Search domains" button alongside the input, 56px input
-// height, 4px corner radius, 20px placeholder text, visible left
-// search-glyph prefix.
 .domain-search--initial-state {
 	@media ( max-width: #{ $break-small - 1px } ) {
-		// 48px input height, 2px corner radius — matches the spec
-		// for the empty-state search input on mobile.
 		--domain-search-input-size: 48px;
 		--domain-search-input-border-radius: 2px;
 
-		// Field wrapper: positions the icon-only Submit absolutely
-		// inside the input's right edge. The input itself gets
-		// extra right padding so the placeholder / typed value
-		// never collides with the button (button width 36 + 6px
-		// gap from right edge + 6px breathing room from text =
-		// 48px reserved).
 		.domain-search__search-form-field {
 			position: relative;
 
@@ -50,33 +29,18 @@
 			}
 		}
 
-		// Drop the input/placeholder text from 20px (1.25rem) to
-		// 16px (1rem) — the 48px mobile input is shorter and the
-		// smaller type is more proportional.
 		.domain-search-controls__input
 			.components-input-control__container
 			input.components-input-control__input {
 			font-size: 1rem;
 		}
 
-		// Hide the left search-glyph prefix — redundant once the
-		// primary Submit (with the same magnifying-glass icon)
-		// lives inside the input on the right.
 		.domain-search-controls__input .components-input-control__prefix {
 			display: none;
 		}
 	}
 }
 
-// Tighten the heading-to-content gap when this empty state is the
-// active step. The wireframe's .step-container-v2__content-wrapper
-// (owned by @automattic/onboarding) defaults to gap: 3rem between
-// the heading slot and the children slot. On mobile that's too
-// generous for this screen — drop it to 1.5rem.
-//
-// Scoped with :has() to the wrapper that actually contains the
-// initial-state, so other stepper-v2 pages keep the original 3rem.
-// Desktop is the natural fall-through.
 .step-container-v2__content-wrapper:has( .domain-search--initial-state ) {
 	@media ( max-width: #{ $break-small - 1px } ) {
 		gap: 1.5rem;

--- a/packages/domain-search/src/components/search-form/style.scss
+++ b/packages/domain-search/src/components/search-form/style.scss
@@ -1,3 +1,4 @@
+@import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/colors';
 
 .domain-search {
@@ -38,6 +39,32 @@
 			.components-input-control__container
 			input.components-input-control__input {
 			padding-right: 48px;
+		}
+	}
+
+	// Mobile-only refinements (below the 'small' breakpoint, < 600px):
+	//   1. Drop the input text/placeholder size from 20px (1.25rem)
+	//      to 16px (1rem) — the 48px input is shorter on this state
+	//      and the smaller type is more proportional to the height.
+	//   2. Hide the search-glyph prefix on the *left* of the input —
+	//      it's redundant once the primary Submit (with the same
+	//      magnifying-glass icon) lives *inside* the input on the
+	//      right. Desktop keeps the prefix so the input still reads
+	//      visually as "a search field" without relying solely on
+	//      the right-side button.
+	// Pattern: mobile styles by default inside the @media block;
+	// desktop is the natural fall-through (the original 1.25rem +
+	// visible prefix from input.scss remain in effect outside the
+	// query).
+	@media ( max-width: #{ $break-small - 1px } ) {
+		.domain-search-controls__input
+			.components-input-control__container
+			input.components-input-control__input {
+			font-size: 1rem;
+		}
+
+		.domain-search-controls__input .components-input-control__prefix {
+			display: none;
 		}
 	}
 }

--- a/packages/domain-search/src/components/search-form/style.scss
+++ b/packages/domain-search/src/components/search-form/style.scss
@@ -7,62 +7,61 @@
 	}
 }
 
-// ── Empty-state-only refinements ─────────────────────────────────
+// ── Empty-state mobile-only refinements ──────────────────────────
+//
 // SearchForm is rendered exclusively by InitialState, so scoping
 // these overrides to the .domain-search--initial-state wrapper
 // keeps the results-page search-bar (which also uses
-// DomainSearchControls.Input) on its existing dimensions.
+// DomainSearchControls.Input) unaffected.
+//
+// All rules below are wrapped in a single @media query for the
+// 'small' breakpoint (< 600px). Above this breakpoint the empty
+// state falls back to the original trunk layout — HStack with the
+// text "Search domains" button alongside the input, 56px input
+// height, 4px corner radius, 20px placeholder text, visible left
+// search-glyph prefix.
 .domain-search--initial-state {
-	// 48px input height, 2px corner radius — matches the spec for
-	// the empty-state search input. Other consumers of the Input
-	// primitive (e.g. the results-page search bar) keep the default
-	// 56px / 4px because they sit inside a denser layout.
-	--domain-search-input-size: 48px;
-	--domain-search-input-border-radius: 2px;
-
-	// Field wrapper: positions the icon-only Submit absolutely inside
-	// the input's right edge. The input itself gets extra right
-	// padding so the placeholder / typed value never collides with
-	// the button (button width 36 + 6px gap from right edge + 6px
-	// breathing room from text = 48px reserved).
-	.domain-search__search-form-field {
-		position: relative;
-
-		.domain-search-controls__submit.is-icon-only {
-			position: absolute;
-			top: 50%;
-			right: 6px;
-			transform: translateY( -50% );
-		}
-
-		.domain-search-controls__input
-			.components-input-control__container
-			input.components-input-control__input {
-			padding-right: 48px;
-		}
-	}
-
-	// Mobile-only refinements (below the 'small' breakpoint, < 600px):
-	//   1. Drop the input text/placeholder size from 20px (1.25rem)
-	//      to 16px (1rem) — the 48px input is shorter on this state
-	//      and the smaller type is more proportional to the height.
-	//   2. Hide the search-glyph prefix on the *left* of the input —
-	//      it's redundant once the primary Submit (with the same
-	//      magnifying-glass icon) lives *inside* the input on the
-	//      right. Desktop keeps the prefix so the input still reads
-	//      visually as "a search field" without relying solely on
-	//      the right-side button.
-	// Pattern: mobile styles by default inside the @media block;
-	// desktop is the natural fall-through (the original 1.25rem +
-	// visible prefix from input.scss remain in effect outside the
-	// query).
 	@media ( max-width: #{ $break-small - 1px } ) {
+		// 48px input height, 2px corner radius — matches the spec
+		// for the empty-state search input on mobile.
+		--domain-search-input-size: 48px;
+		--domain-search-input-border-radius: 2px;
+
+		// Field wrapper: positions the icon-only Submit absolutely
+		// inside the input's right edge. The input itself gets
+		// extra right padding so the placeholder / typed value
+		// never collides with the button (button width 36 + 6px
+		// gap from right edge + 6px breathing room from text =
+		// 48px reserved).
+		.domain-search__search-form-field {
+			position: relative;
+
+			.domain-search-controls__submit.is-icon-only {
+				position: absolute;
+				top: 50%;
+				right: 6px;
+				transform: translateY( -50% );
+			}
+
+			.domain-search-controls__input
+				.components-input-control__container
+				input.components-input-control__input {
+				padding-right: 48px;
+			}
+		}
+
+		// Drop the input/placeholder text from 20px (1.25rem) to
+		// 16px (1rem) — the 48px mobile input is shorter and the
+		// smaller type is more proportional.
 		.domain-search-controls__input
 			.components-input-control__container
 			input.components-input-control__input {
 			font-size: 1rem;
 		}
 
+		// Hide the left search-glyph prefix — redundant once the
+		// primary Submit (with the same magnifying-glass icon)
+		// lives inside the input on the right.
 		.domain-search-controls__input .components-input-control__prefix {
 			display: none;
 		}

--- a/packages/domain-search/src/components/search-form/style.scss
+++ b/packages/domain-search/src/components/search-form/style.scss
@@ -5,3 +5,39 @@
 		color: #{$gray-900};
 	}
 }
+
+// ── Empty-state-only refinements ─────────────────────────────────
+// SearchForm is rendered exclusively by InitialState, so scoping
+// these overrides to the .domain-search--initial-state wrapper
+// keeps the results-page search-bar (which also uses
+// DomainSearchControls.Input) on its existing dimensions.
+.domain-search--initial-state {
+	// 48px input height, 2px corner radius — matches the spec for
+	// the empty-state search input. Other consumers of the Input
+	// primitive (e.g. the results-page search bar) keep the default
+	// 56px / 4px because they sit inside a denser layout.
+	--domain-search-input-size: 48px;
+	--domain-search-input-border-radius: 2px;
+
+	// Field wrapper: positions the icon-only Submit absolutely inside
+	// the input's right edge. The input itself gets extra right
+	// padding so the placeholder / typed value never collides with
+	// the button (button width 36 + 6px gap from right edge + 6px
+	// breathing room from text = 48px reserved).
+	.domain-search__search-form-field {
+		position: relative;
+
+		.domain-search-controls__submit.is-icon-only {
+			position: absolute;
+			top: 50%;
+			right: 6px;
+			transform: translateY( -50% );
+		}
+
+		.domain-search-controls__input
+			.components-input-control__container
+			input.components-input-control__input {
+			padding-right: 48px;
+		}
+	}
+}

--- a/packages/domain-search/src/components/search-form/test/index.tsx
+++ b/packages/domain-search/src/components/search-form/test/index.tsx
@@ -1,16 +1,7 @@
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SearchForm } from '..';
-import * as useContainerQueryModule from '../../../hooks/use-container-query';
 import { TestDomainSearch } from '../../../test-helpers/renderer';
-
-jest.mock( '../../../hooks/use-container-query', () => ( {
-	useContainerQuery: jest.fn().mockReturnValue( {
-		activeQuery: 'large',
-		currentWidth: 480,
-		ref: jest.fn(),
-	} ),
-} ) );
 
 const expectPlaceholderPhrase = ( phrase: string ) => {
 	// Initial state
@@ -72,14 +63,8 @@ describe( 'SearchForm', () => {
 		expect( onQueryChange ).toHaveBeenCalledWith( 'studio' );
 	} );
 
-	it( 'hides the submit button on small screens', async () => {
+	it( 'submits via the Enter key', async () => {
 		const user = userEvent.setup();
-
-		jest.spyOn( useContainerQueryModule, 'useContainerQuery' ).mockReturnValue( {
-			activeQuery: 'small',
-			currentWidth: 479,
-			ref: jest.fn(),
-		} );
 
 		const onQueryChange = jest.fn();
 
@@ -89,7 +74,9 @@ describe( 'SearchForm', () => {
 			</TestDomainSearch>
 		);
 
-		expect( screen.queryByRole( 'button', { name: 'Search domains' } ) ).not.toBeInTheDocument();
+		// Submit button is rendered at every width now — keyboard
+		// submit (Enter) should still work as an alternate path.
+		expect( screen.getByRole( 'button', { name: 'Search domains' } ) ).toBeInTheDocument();
 
 		await user.type( screen.getByRole( 'searchbox' ), 'test' );
 		await user.type( screen.getByRole( 'searchbox' ), '{enter}' );

--- a/packages/domain-search/src/components/search-form/test/index.tsx
+++ b/packages/domain-search/src/components/search-form/test/index.tsx
@@ -1,7 +1,19 @@
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { useViewportMatch } from '@wordpress/compose';
 import { SearchForm } from '..';
 import { TestDomainSearch } from '../../../test-helpers/renderer';
+
+jest.mock( '@wordpress/compose', () => ( {
+	...jest.requireActual( '@wordpress/compose' ),
+	useViewportMatch: jest.fn(),
+} ) );
+
+const mockUseViewportMatch = useViewportMatch as jest.Mock;
+
+beforeEach( () => {
+	mockUseViewportMatch.mockReturnValue( false );
+} );
 
 const expectPlaceholderPhrase = ( phrase: string ) => {
 	// Initial state
@@ -74,12 +86,32 @@ describe( 'SearchForm', () => {
 			</TestDomainSearch>
 		);
 
-		// Submit button is rendered at every width now — keyboard
-		// submit (Enter) should still work as an alternate path.
 		expect( screen.getByRole( 'button', { name: 'Search domains' } ) ).toBeInTheDocument();
 
 		await user.type( screen.getByRole( 'searchbox' ), 'test' );
 		await user.type( screen.getByRole( 'searchbox' ), '{enter}' );
+
+		expect( onQueryChange ).toHaveBeenCalledWith( 'test' );
+	} );
+
+	it( 'renders the icon-only submit inside a field wrapper on mobile', async () => {
+		mockUseViewportMatch.mockReturnValue( true );
+		const user = userEvent.setup();
+		const onQueryChange = jest.fn();
+
+		const { container } = render(
+			<TestDomainSearch events={ { onQueryChange } }>
+				<SearchForm />
+			</TestDomainSearch>
+		);
+
+		expect( container.querySelector( '.domain-search__search-form-field' ) ).toBeInTheDocument();
+		expect(
+			container.querySelector( '.domain-search-controls__submit.is-icon-only' )
+		).toBeInTheDocument();
+
+		await user.type( screen.getByRole( 'searchbox' ), 'test' );
+		await user.click( screen.getByRole( 'button', { name: 'Search domains' } ) );
 
 		expect( onQueryChange ).toHaveBeenCalledWith( 'test' );
 	} );

--- a/packages/domain-search/src/components/search-form/test/index.tsx
+++ b/packages/domain-search/src/components/search-form/test/index.tsx
@@ -9,7 +9,7 @@ jest.mock( '@wordpress/compose', () => ( {
 	useViewportMatch: jest.fn(),
 } ) );
 
-const mockUseViewportMatch = useViewportMatch as jest.Mock;
+const mockUseViewportMatch = jest.mocked( useViewportMatch );
 
 beforeEach( () => {
 	mockUseViewportMatch.mockReturnValue( false );

--- a/packages/domain-search/src/page/style.scss
+++ b/packages/domain-search/src/page/style.scss
@@ -48,6 +48,10 @@
 		--domain-search-input-size: 48px;
 		--domain-search-input-border-radius: 2px;
 
+		.domain-search__search-bar {
+			gap: 0.5rem;
+		}
+
 		.domain-search-controls__input {
 			// Mirror the radius onto the container so its inset
 			// box-shadow (which draws the visible border line)

--- a/packages/domain-search/src/page/style.scss
+++ b/packages/domain-search/src/page/style.scss
@@ -1,3 +1,4 @@
+@import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/colors';
 
 .domain-search {
@@ -42,4 +43,14 @@
 .domain-search--results {
 	width: 100%;
 	max-width: var( --domain-search-content-max-width );
+
+	@media ( max-width: #{ $break-small - 1px } ) {
+		--domain-search-input-size: 48px;
+	}
+}
+
+.step-container-v2__content-wrapper:has( .domain-search--results ) {
+	@media ( max-width: #{ $break-small - 1px } ) {
+		gap: 1.5rem;
+	}
 }

--- a/packages/domain-search/src/page/style.scss
+++ b/packages/domain-search/src/page/style.scss
@@ -53,9 +53,8 @@
 		}
 
 		.domain-search-controls__input {
-			// Mirror the radius onto the container so its inset
-			// box-shadow (which draws the visible border line)
-			// follows the corner curve instead of rendering square.
+			// The container's inset box-shadow draws the visible
+			// border, so the radius needs to live here too.
 			.components-input-control__container {
 				border-radius: var( --domain-search-input-border-radius );
 			}

--- a/packages/domain-search/src/page/style.scss
+++ b/packages/domain-search/src/page/style.scss
@@ -46,6 +46,22 @@
 
 	@media ( max-width: #{ $break-small - 1px } ) {
 		--domain-search-input-size: 48px;
+
+		.domain-search-controls__input {
+			.components-input-control__prefix > div {
+				padding-inline-start: 12px;
+			}
+
+			.components-input-control__container input.components-input-control__input {
+				min-height: var( --domain-search-input-size );
+				font-size: 1rem;
+				padding-left: 8px;
+			}
+
+			.components-input-control__suffix > div {
+				padding-inline-end: 12px;
+			}
+		}
 	}
 }
 

--- a/packages/domain-search/src/page/style.scss
+++ b/packages/domain-search/src/page/style.scss
@@ -46,8 +46,16 @@
 
 	@media ( max-width: #{ $break-small - 1px } ) {
 		--domain-search-input-size: 48px;
+		--domain-search-input-border-radius: 2px;
 
 		.domain-search-controls__input {
+			// Mirror the radius onto the container so its inset
+			// box-shadow (which draws the visible border line)
+			// follows the corner curve instead of rendering square.
+			.components-input-control__container {
+				border-radius: var( --domain-search-input-border-radius );
+			}
+
 			.components-input-control__prefix > div {
 				padding-inline-start: 12px;
 			}

--- a/packages/domain-search/src/ui/domain-search-controls/input.tsx
+++ b/packages/domain-search/src/ui/domain-search-controls/input.tsx
@@ -18,10 +18,6 @@ interface DomainSearchControlsInputProps {
 	'aria-describedby'?: string;
 }
 
-// Forwarded ref attaches to the underlying <input>. @wordpress/components'
-// SearchControl is itself a forwardRef component and merges any ref it
-// receives into its internal searchRef via useMergeRefs, so callers
-// can drive focus / selection imperatively.
 export const DomainSearchControlsInput = forwardRef<
 	HTMLInputElement,
 	DomainSearchControlsInputProps

--- a/packages/domain-search/src/ui/domain-search-controls/input.tsx
+++ b/packages/domain-search/src/ui/domain-search-controls/input.tsx
@@ -1,21 +1,9 @@
 import { SearchControl } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
+import { forwardRef } from 'react';
 import './input.scss';
 
-export const DomainSearchControlsInput = ( {
-	value,
-	label,
-	placeholder,
-	onChange,
-	onReset,
-	autoFocus,
-	onBlur,
-	onKeyDown,
-	minLength,
-	maxLength,
-	dir,
-	'aria-describedby': ariaDescribedBy,
-}: {
+interface DomainSearchControlsInputProps {
 	value: string;
 	label?: string;
 	placeholder?: string;
@@ -28,11 +16,37 @@ export const DomainSearchControlsInput = ( {
 	maxLength?: number;
 	dir?: 'ltr' | 'rtl';
 	'aria-describedby'?: string;
-} ) => {
+}
+
+// Forwarded ref attaches to the underlying <input>. @wordpress/components'
+// SearchControl is itself a forwardRef component and merges any ref it
+// receives into its internal searchRef via useMergeRefs, so callers
+// can drive focus / selection imperatively.
+export const DomainSearchControlsInput = forwardRef<
+	HTMLInputElement,
+	DomainSearchControlsInputProps
+>( function DomainSearchControlsInput(
+	{
+		value,
+		label,
+		placeholder,
+		onChange,
+		onReset,
+		autoFocus,
+		onBlur,
+		onKeyDown,
+		minLength,
+		maxLength,
+		dir,
+		'aria-describedby': ariaDescribedBy,
+	},
+	ref
+) {
 	const { __ } = useI18n();
 
 	return (
 		<SearchControl
+			ref={ ref }
 			className="domain-search-controls__input"
 			__nextHasNoMarginBottom
 			hideLabelFromVision
@@ -51,4 +65,4 @@ export const DomainSearchControlsInput = ( {
 			aria-describedby={ ariaDescribedBy }
 		/>
 	);
-};
+} );

--- a/packages/domain-search/src/ui/domain-search-controls/submit.scss
+++ b/packages/domain-search/src/ui/domain-search-controls/submit.scss
@@ -5,9 +5,6 @@
 	font-size: 1rem;
 	flex-shrink: 0;
 
-	// Compact icon-only variant — used when the submit lives inside
-	// the search input rather than alongside it. Fixed 36×36 square
-	// with a 24×24 white search glyph and a tighter 2px corner radius.
 	&.is-icon-only {
 		width: 36px;
 		min-width: 36px;
@@ -16,9 +13,6 @@
 		border-radius: 2px;
 		flex-shrink: 0;
 
-		// Force the WP <Icon /> SVG to the spec'd 24×24 regardless of
-		// the parent button's text-driven sizing rules. White fill so
-		// the glyph reads against the primary-blue background.
 		svg {
 			width: 24px;
 			height: 24px;

--- a/packages/domain-search/src/ui/domain-search-controls/submit.scss
+++ b/packages/domain-search/src/ui/domain-search-controls/submit.scss
@@ -4,4 +4,26 @@
 	border-radius: 4px;
 	font-size: 1rem;
 	flex-shrink: 0;
+
+	// Compact icon-only variant — used when the submit lives inside
+	// the search input rather than alongside it. Fixed 36×36 square
+	// with a 24×24 white search glyph and a tighter 2px corner radius.
+	&.is-icon-only {
+		width: 36px;
+		min-width: 36px;
+		height: 36px;
+		padding: 0;
+		border-radius: 2px;
+		flex-shrink: 0;
+
+		// Force the WP <Icon /> SVG to the spec'd 24×24 regardless of
+		// the parent button's text-driven sizing rules. White fill so
+		// the glyph reads against the primary-blue background.
+		svg {
+			width: 24px;
+			height: 24px;
+			flex-shrink: 0;
+			fill: #fff;
+		}
+	}
 }

--- a/packages/domain-search/src/ui/domain-search-controls/submit.tsx
+++ b/packages/domain-search/src/ui/domain-search-controls/submit.tsx
@@ -10,12 +10,6 @@ export const DomainSearchControlsSubmit = ( {
 	iconOnly = false,
 }: {
 	onClick?: () => void;
-	/**
-	 * Render as a compact icon-only button (36×36 square with a
-	 * magnifying-glass glyph) instead of the default text button.
-	 * Used when the Submit lives *inside* the search input rather
-	 * than alongside it — see SearchForm's empty-state layout.
-	 */
 	iconOnly?: boolean;
 } ) => {
 	const { __ } = useI18n();

--- a/packages/domain-search/src/ui/domain-search-controls/submit.tsx
+++ b/packages/domain-search/src/ui/domain-search-controls/submit.tsx
@@ -1,18 +1,37 @@
 import { Button } from '@wordpress/components';
+import { Icon, search } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
+import clsx from 'clsx';
 
 import './submit.scss';
 
-export const DomainSearchControlsSubmit = ( { onClick }: { onClick?: () => void } ) => {
+export const DomainSearchControlsSubmit = ( {
+	onClick,
+	iconOnly = false,
+}: {
+	onClick?: () => void;
+	/**
+	 * Render as a compact icon-only button (36×36 square with a
+	 * magnifying-glass glyph) instead of the default text button.
+	 * Used when the Submit lives *inside* the search input rather
+	 * than alongside it — see SearchForm's empty-state layout.
+	 */
+	iconOnly?: boolean;
+} ) => {
 	const { __ } = useI18n();
+	const label = __( 'Search domains' );
+
 	return (
 		<Button
 			variant="primary"
 			type="submit"
-			className="domain-search-controls__submit"
+			className={ clsx( 'domain-search-controls__submit', {
+				'is-icon-only': iconOnly,
+			} ) }
 			onClick={ onClick }
+			aria-label={ iconOnly ? label : undefined }
 		>
-			{ __( 'Search domains' ) }
+			{ iconOnly ? <Icon icon={ search } size={ 24 } /> : label }
 		</Button>
 	);
 };


### PR DESCRIPTION
## Summary

This PR tightens up the empty state of the onboarding domain search step on mobile, where it's the most-used surface. **Desktop is unchanged**.

The search input is now the unmissable primary CTA — a clear "Search" button lives inside it, the input is sized proportionally to a phone screen, and the caret lands in the field on page load so the user can start typing immediately (no extra tap needed on Android or desktop; iOS still requires the one expected tap due to a browser-level keyboard-policy restriction). There's less vertical space wasted on chrome, more attention on the action that matters.

**Builds on:** #110624 (under review) — that PR hid the in-body "Already have a domain?" card on mobile and surfaced the same CTA in the step's top bar. This PR refines the input itself. The two are independent in git terms but complementary in UX.

## Before / After

|  | Before | After |
|---|---|---|
| **Mobile — empty state** *(< 600px)* | _<img width="784" height="1692" alt="CleanShot 2026-05-11 at 13 34 41@2x" src="https://github.com/user-attachments/assets/bafcde27-c641-416c-9f75-c2e611b0aac6" />_ | _<img width="780" height="1686" alt="CleanShot 2026-05-11 at 13 35 26@2x" src="https://github.com/user-attachments/assets/63199dd8-55bc-431f-b81d-f02cd0db5459" />_ |
| **Desktop — empty state** *(≥ 600px, should be unchanged)* | _<img width="2048" height="1538" alt="CleanShot 2026-05-11 at 13 34 55@2x" src="https://github.com/user-attachments/assets/ecb6b00e-9c9f-4394-bfac-2e629ab598da" />_ | _<img width="2050" height="1536" alt="CleanShot 2026-05-11 at 13 42 19@2x" src="https://github.com/user-attachments/assets/0c2afad9-aef0-4f53-a80b-4b64bf4cead1" />_ |

## What changes (mobile only, < 600px)

- **Submit button surfaced.** The "Search domains" submit was previously hidden on narrow containers via `useContainerQuery`; mobile users had to rely on the keyboard's Enter / Go key. Now it's always rendered.
- **Submit moved inside the input.** On mobile it's a compact 36×36 icon-only button (white magnifying-glass glyph, 2px corner radius, primary blue) anchored to the right edge of the input, 6px from the border. The text variant of the same component is preserved for every other consumer and for the desktop empty state.
- **Input sized for mobile.** Height 48px (was 56px), corner radius 2px (was 4px), placeholder/text size 16px (was 20px).
- **Redundant left search-glyph hidden.** The `<SearchControl>`'s built-in prefix icon is removed on mobile — the new right-side icon button carries the same magnifying-glass meaning, and two were noisy.
- **Heading-to-content gap tightened.** The wireframe wrapper's default `gap: 3rem` between the heading slot and the content slot drops to `1.5rem` on mobile so the input sits closer to the headline and above the fold on shorter phones.
- **Caret placed in the input on mount.** Switched from `<input autoFocus>` to an explicit `useEffect` + ref pattern, which beats the stepper's animated route-transition race so the caret reliably lands on cold loads. (iOS Safari still won't auto-open the soft keyboard — that's an OS policy on user gestures, not a code issue.)

## What is **not** affected

- **Desktop empty state** — unchanged. Same HStack layout, text "Search domains" button alongside the 56px input.
- **The results page** — unchanged. Different component (`search-bar/input.tsx`); the input dimension overrides are scoped to `.domain-search--initial-state`.
- **Other consumers of `@automattic/domain-search`** — dashboard, my-sites domain settings, checkout thank-you, etc. — unaffected. All visual scoping is to `.domain-search--initial-state` and the new `iconOnly` prop on Submit defaults to `false`.

## Test plan

- [ ] Boot the dev server, navigate to a flow that hits the v2 domain-search step (e.g. `/setup/onboarding`).
- [ ] **Desktop** (≥ 600px wide):
  - [ ] Input is 56px tall, 4px corner radius, 20px placeholder text — unchanged.
  - [ ] Left search-glyph prefix visible — unchanged.
  - [ ] "Search domains" text button sits to the right of the input (HStack) — unchanged.
- [ ] **Mobile** (< 600px wide):
  - [ ] Input is 48px tall, 2px corner radius, 16px placeholder text.
  - [ ] No left search-glyph prefix.
  - [ ] 36×36 icon-only Submit button sits **inside** the input on the right, 6px from the edge.
  - [ ] Caret is in the input on page load.
  - [ ] Heading and input sit ~1.5rem apart vertically.
  - [ ] Tapping the Submit triggers the same search as pressing Enter.
- [ ] Typing characters: text never collides with the inside-input Submit button at any input width.
- [ ] After a search, the results page renders with its original (56px) input — the empty-state overrides don't leak.

## Mechanical changes

- `packages/domain-search/src/ui/domain-search-controls/submit.tsx` — new optional `iconOnly` prop, renders a 36×36 button with the `@wordpress/icons` search glyph. Text variant unchanged.
- `packages/domain-search/src/ui/domain-search-controls/submit.scss` — `.is-icon-only` modifier styles.
- `packages/domain-search/src/ui/domain-search-controls/input.tsx` — `forwardRef`-wrapped so callers can drive focus imperatively. Backwards-compatible.
- `packages/domain-search/src/components/search-form/index.tsx` — `useViewportMatch('small', '<')` drives a layout swap (mobile: wrapper div + inside-input submit; desktop: original HStack). `useRef` + `useEffect` focuses the input on mount.
- `packages/domain-search/src/components/search-form/style.scss` — all empty-state overrides (input dims, submit position, right padding, 16px text, hidden prefix, tighter wrapper gap via `:has()`) wrapped in a single `@media (max-width: $break-small - 1px)`.
- `packages/domain-search/src/components/search-form/test/index.tsx` — replaced the obsolete "hides submit on small screens" case with one asserting Enter-key submission, since the gate logic moved.
