### PR TITLE
date-picker: migrate from react-day-picker v7 to v9

### DIFF
--- a/client/components/date-picker/README.md
+++ b/client/components/date-picker/README.md
@@ -10,7 +10,7 @@ React component used to display a Date Picker.
 import { Component } from 'react';
 import DatePicker from 'calypso/components/date-picker';
 
-export default class extends Component {
+export default class DatePickerExample extends Component {
 	// ...
 
 	onSelectDay( date ) {

--- a/client/components/date-picker/README.md
+++ b/client/components/date-picker/README.md
@@ -34,7 +34,7 @@ export default class extends Component {
 
 		return (
 			<DatePicker
-				initialMonth={ new Date( '2015-07-01' ) }
+				calendarInitialDate={ new Date( '2015-07-01' ) }
 				events={ events }
 				onSelectDay={ this.onSelectDay }
 				selectedDay={ this.state.date }
@@ -50,23 +50,26 @@ export default class extends Component {
 
 ### Props
 
-`initialMonth` - **optional** Date object that defines the month of the calendar. Default is `now`.
+`calendarInitialDate` - **optional** Date object that defines the month of the calendar at first render. Default is `now`.
 
-`selectedDay` - **optional** Moment instance to select the current day.
+`calendarViewDate` - **optional** Controlled month being displayed. Use with `onMonthChange`.
 
-`timeReference` - **optional** Moment instance used to adjust the time when a day
-is selected.
+`selectedDay` - **optional** Date object to select the current day.
 
-`events` - **optional** Array of events.
+`timeReference` - **optional** Moment instance used to adjust the time when a day is selected.
 
-`className` - **optional** Add a custom class property.
+`events` - **optional** Array of events. Each event needs a `date` property; optional `title`, `id`, `icon`, `socialIcon`, `socialIconColor` are used by the events tooltip.
 
 `onSelectDay` - **optional** Called when day is selected by user.
 
 `onMonthChange` - **optional** Called when month is changed by user.
 
-`locale` - **optional** String representing the current locale slug (eg: `en`). Note that the default component `export`ed is already wrapped in the `localize` HOC which automatically sets this prop for you. Previously this prop was an object of utility overides. This has been moved to a dedicated `localUtils` prop (see below).
+`disabledDays` - **optional** Array of [react-day-picker v9 matchers](https://daypicker.dev/api/type-aliases/Matcher).
 
-`localeUtils` - **optional** Object of [locale utility _overides_](http://react-day-picker.js.org/api/LocaleUtils) which are merged with the default utilities passed into the `react-day-picker` library. Previously this prop was named `locale`, but was moved to its own dedicated prop for API consistency with the React Day Picker library.
+`modifiers` - **optional** Custom day modifiers, mapped through `modifiersClassNames` to `DayPicker-Day--<name>` classes.
+
+`useArrowNavigation` - **optional** Render WordPress chevron arrows in the nav bar instead of month-name labels.
+
+`formatMonthTitle` - **optional** Override the calendar caption format. Receives a `Date`, returns a string. Pass `() => ''` to hide the caption (used by `post-schedule`, which renders its own header).
 
 ---

--- a/client/components/date-picker/day.jsx
+++ b/client/components/date-picker/day.jsx
@@ -1,27 +1,19 @@
-const noop = () => {};
+import { useEffect, useRef } from 'react';
 
-const handleDayMouseEnter =
-	( date, modifiers, onMouseEnter = noop ) =>
-	( event ) => {
-		onMouseEnter( date, modifiers, event );
-	};
+const DatePickerDayButton = ( { day, modifiers, ...buttonProps } ) => {
+	const ref = useRef( null );
 
-const handleDayMouseLeave =
-	( date, modifiers, onMouseLeave = noop ) =>
-	( event ) => {
-		onMouseLeave( date, modifiers, event );
-	};
+	useEffect( () => {
+		if ( modifiers.focused ) {
+			ref.current?.focus();
+		}
+	}, [ modifiers.focused ] );
 
-const DatePickerDay = ( { date, modifiers, onMouseEnter, onMouseLeave } ) => {
 	return (
-		<div
-			className="date-picker__day"
-			onMouseEnter={ handleDayMouseEnter( date, modifiers, onMouseEnter ) }
-			onMouseLeave={ handleDayMouseLeave( date, modifiers, onMouseLeave ) }
-		>
-			{ date.getDate() }
-		</div>
+		<button ref={ ref } { ...buttonProps }>
+			<div className="date-picker__day">{ day.date.getDate() }</div>
+		</button>
 	);
 };
 
-export default DatePickerDay;
+export default DatePickerDayButton;

--- a/client/components/date-picker/index.jsx
+++ b/client/components/date-picker/index.jsx
@@ -1,16 +1,95 @@
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
-import { merge, map, filter, get, debounce } from 'lodash';
+import { map, filter } from 'lodash';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
-import DayPicker from 'react-day-picker';
+import { DayPicker } from 'react-day-picker';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import DayItem from './day';
-import DatePickerNavBar from './nav-bar';
+import DatePickerDay from './day';
+import { DatePickerNavBar, DatePickerChevron } from './nav-bar';
 
 import './style.scss';
 
 const noop = () => {};
+
+// react-day-picker v9 emits `rdp-*` classes by default. We override every entry
+// back to the v7-era `DayPicker-*` names this wrapper's SCSS (and consumer
+// SCSS) still targets, so the visual styling is preserved without rewriting
+// every selector.
+const CLASS_NAMES = {
+	root: 'DayPicker',
+	months: 'DayPicker-Months',
+	month: 'DayPicker-Month-Wrapper',
+	month_grid: 'DayPicker-Month',
+	month_caption: 'DayPicker-Caption',
+	caption_label: 'DayPicker-CaptionLabel',
+	weekdays: 'DayPicker-Weekdays',
+	weekday: 'DayPicker-Weekday',
+	weeks: 'DayPicker-Body',
+	week: 'DayPicker-Week',
+	day: 'DayPicker-Day',
+	day_button: 'DayPicker-DayButton',
+	nav: 'DayPicker-NavBar',
+	button_previous: 'DayPicker-NavButton DayPicker-NavButton--prev',
+	button_next: 'DayPicker-NavButton DayPicker-NavButton--next',
+	chevron: 'DayPicker-Chevron',
+	today: 'DayPicker-Day--today',
+	outside: 'DayPicker-Day--outside',
+	disabled: 'DayPicker-Day--disabled',
+	hidden: 'DayPicker-Day--hidden',
+	selected: 'DayPicker-Day--selected',
+};
+
+// Same remap for matched modifiers: v9's default is `rdp-day_<name>`; we map
+// every modifier this wrapper adds (and the ones consumers pass through) back
+// to the v7-era `DayPicker-Day--<name>` names the SCSS expects.
+const MODIFIERS_CLASS_NAMES = {
+	'past-days': 'DayPicker-Day--past-days',
+	sunday: 'DayPicker-Day--sunday',
+	'is-selected': 'DayPicker-Day--is-selected',
+	events: 'DayPicker-Day--events',
+	start: 'DayPicker-Day--start',
+	end: 'DayPicker-Day--end',
+	range: 'DayPicker-Day--range',
+	'range-start': 'DayPicker-Day--range-start',
+	'range-end': 'DayPicker-Day--range-end',
+};
+
+function determineSelectionModeFromProps( selectedDay, selectedDays ) {
+	const isPlainDateRange = ( value ) =>
+		!! value &&
+		typeof value === 'object' &&
+		! ( value instanceof Date ) &&
+		( 'from' in value || 'to' in value );
+
+	if ( selectedDays instanceof Date ) {
+		return { mode: 'single', selected: selectedDays };
+	}
+	if ( isPlainDateRange( selectedDays ) ) {
+		return { mode: 'range', selected: selectedDays };
+	}
+	if ( Array.isArray( selectedDays ) ) {
+		const range = selectedDays.find( isPlainDateRange );
+		if ( range ) {
+			return { mode: 'range', selected: range };
+		}
+		return { mode: 'multiple', selected: selectedDays.filter( ( d ) => d instanceof Date ) };
+	}
+	if ( selectedDay instanceof Date ) {
+		return { mode: 'single', selected: selectedDay };
+	}
+	return { mode: 'single', selected: undefined };
+}
+
+// Safe because react-day-picker always hands us `nextMonth` as first-of-month
+// (it normalises via `dateLib.startOfMonth` before pagination — see
+// `helpers/getNextMonth.js`). Day-1 exists in every month, so `setMonth(n + 1)`
+// can't overflow into the following month the way it would for, say, Jan 31.
+function addMonths( date, n ) {
+	const result = new Date( date );
+	result.setMonth( result.getMonth() + n );
+	return result;
+}
 
 class DatePicker extends PureComponent {
 	static propTypes = {
@@ -26,19 +105,8 @@ class DatePicker extends PureComponent {
 				to: PropTypes.instanceOf( Date ),
 			} ),
 			PropTypes.array,
-			PropTypes.func,
 		] ),
 		disabledDays: PropTypes.array,
-		locale: PropTypes.string,
-		localeUtils: PropTypes.shape( {
-			// http://react-day-picker.js.org/api/LocaleUtils
-			formatDay: PropTypes.func,
-			formatMonthTitle: PropTypes.func,
-			formatWeekdayLong: PropTypes.func,
-			formatWeekdayShort: PropTypes.func,
-			getFirstDayOfWeek: PropTypes.func,
-			getMonths: PropTypes.func,
-		} ),
 		modifiers: PropTypes.object,
 		moment: PropTypes.func.isRequired,
 		selectedDay: PropTypes.object,
@@ -49,28 +117,18 @@ class DatePicker extends PureComponent {
 		onDayMouseLeave: PropTypes.func,
 		toMonth: PropTypes.object,
 		fromMonth: PropTypes.object,
-		onDayTouchStart: PropTypes.func,
-		onDayTouchEnd: PropTypes.func,
-		onDayTouchMove: PropTypes.func,
 		rootClassNames: PropTypes.object,
 		useArrowNavigation: PropTypes.bool,
+		formatMonthTitle: PropTypes.func,
 	};
 
 	static defaultProps = {
 		showOutsideDays: true,
-		calendarViewDate: new Date(),
-		calendarInitialDate: new Date(),
 		modifiers: {},
-		fromMonth: null,
-		locale: 'en',
-		selectedDay: null,
 		onMonthChange: noop,
 		onSelectDay: noop,
 		onDayMouseEnter: noop,
 		onDayMouseLeave: noop,
-		onDayTouchStart: noop,
-		onDayTouchEnd: noop,
-		onDayTouchMove: noop,
 		rootClassNames: {},
 		useArrowNavigation: false,
 	};
@@ -106,152 +164,149 @@ class DatePicker extends PureComponent {
 		return eventsInDay;
 	}
 
-	getLocaleUtils() {
-		const { moment, localeUtils } = this.props;
-		const localeData = moment().localeData();
-		const firstDayOfWeek = localeData.firstDayOfWeek();
-		const weekdaysMin = moment.weekdaysMin();
-		const weekdays = moment.weekdays();
-		const utils = {
-			formatDay: function ( date ) {
-				return moment( date ).format( 'llll' );
-			},
-
-			formatMonthTitle: function ( date ) {
-				return moment( date ).format( 'MMMM YYYY' );
-			},
-
-			formatWeekdayShort: function ( day ) {
-				return get( weekdaysMin, day, ' ' )[ 0 ];
-			},
-
-			formatWeekdayLong: function ( day ) {
-				return weekdays[ day ];
-			},
-
-			getFirstDayOfWeek: function () {
-				return firstDayOfWeek;
-			},
-
-			formatMonthShort: function ( month ) {
-				return moment( month.toISOString() ).format( 'MMM' );
-			},
-		};
-
-		return merge( {}, utils, localeUtils );
-	}
-
-	/**
-	 * Handler for the click/touch events on the calendar
-	 * Debounced to avoid multiple calls to this method
-	 * being fired for due to touch/click both being
-	 * called on touch devices.
-	 *
-	 * See https://github.com/Automattic/wp-calypso/pull/29938/
-	 */
-	setCalendarDay = debounce(
-		( day, modifiers ) => {
-			const momentDay = this.props.moment( day );
-
-			if ( modifiers.disabled ) {
-				return null;
-			}
-
-			const dateMods = {
-				year: momentDay.year(),
-				month: momentDay.month(),
-				date: momentDay.date(),
-			};
-
-			const date = ( this.props.timeReference || momentDay ).set( dateMods );
-
-			this.props.onSelectDay( date, dateMods, modifiers );
-		},
-		500,
-		{
-			leading: true, // invoke call immediately
-			trailing: false, // debounce any subsequent calls
-		}
-	);
-
 	getDateInstance( v ) {
 		return this.props.moment( v ).toDate();
 	}
 
-	renderDay = ( date, modifiers ) => (
-		<DayItem
-			date={ date }
-			modifiers={ modifiers }
-			onMouseEnter={ this.handleDayMouseEnter }
-			onMouseLeave={ this.handleDayMouseLeave }
-		/>
-	);
-
-	handleDayMouseEnter = ( date, modifiers, event ) => {
-		const eventsByDay = this.filterEventsByDay( date );
-		this.props.onDayMouseEnter( date, modifiers, event, eventsByDay );
+	handleDayClick = ( day, dayModifiers ) => {
+		if ( dayModifiers.disabled ) {
+			return;
+		}
+		const { moment, timeReference, onSelectDay } = this.props;
+		const dateMods = {
+			year: day.getFullYear(),
+			month: day.getMonth(),
+			date: day.getDate(),
+		};
+		const momentDay = moment( day );
+		const result = ( timeReference || momentDay ).set( dateMods );
+		onSelectDay( result, dateMods, dayModifiers );
 	};
 
-	handleDayMouseLeave = ( date, modifiers, event ) => {
-		const eventsByDay = this.filterEventsByDay( date );
-		this.props.onDayMouseLeave( date, modifiers, event, eventsByDay );
+	handleDayMouseEnter = ( day, dayModifiers, event ) => {
+		this.props.onDayMouseEnter( day, dayModifiers, event, this.filterEventsByDay( day ) );
 	};
 
-	handleDayTouchMove = ( date, modifiers, event ) => {
-		const eventsByDay = this.filterEventsByDay( date );
-		this.props.onDayTouchMove( date, modifiers, event, eventsByDay );
+	handleDayMouseLeave = ( day, dayModifiers, event ) => {
+		this.props.onDayMouseLeave( day, dayModifiers, event, this.filterEventsByDay( day ) );
+	};
+
+	formatCaption = ( date ) => {
+		if ( typeof this.props.formatMonthTitle === 'function' ) {
+			const result = this.props.formatMonthTitle( date );
+			return result == null ? '' : result;
+		}
+		return this.props.moment( date ).format( 'MMMM YYYY' );
+	};
+
+	// v9 dates land at midnight; v7's internal grid used noon (avoids DST
+	// surprises in the moment `llll` format). Pin to noon so the rendered
+	// aria-label matches v7's output exactly: e.g. "Thu, Oct 4, 2018 12:00 PM".
+	formatLabelDayButton = ( date ) => {
+		const noon = new Date( date );
+		noon.setHours( 12, 0, 0, 0 );
+		return this.props.moment( noon ).format( 'llll' );
+	};
+
+	renderNav = ( navProps ) => {
+		// v7 advertised the *last* visible month as `nextMonth` (so multi-month
+		// pickers said "Next month (December 2018)" when showing Oct+Nov). v9
+		// always reports the immediate next month. Re-shift it so existing aria
+		// labels are preserved.
+		const numberOfMonths = this.props.numberOfMonths || 1;
+		const nextMonth =
+			navProps.nextMonth && numberOfMonths > 1
+				? addMonths( navProps.nextMonth, numberOfMonths - 1 )
+				: navProps.nextMonth;
+
+		return (
+			<DatePickerNavBar
+				{ ...navProps }
+				nextMonth={ nextMonth }
+				formatMonthTitle={ this.formatCaption }
+			/>
+		);
 	};
 
 	render() {
-		const modifiers = {
-			...this.props.modifiers,
-			'past-days': { before: new Date() },
-			sunday: { daysOfWeek: [ 0 ] },
-		};
+		const {
+			calendarViewDate,
+			calendarInitialDate,
+			showOutsideDays,
+			numberOfMonths,
+			events,
+			selectedDays,
+			disabledDays,
+			modifiers: extraModifiers,
+			selectedDay,
+			onMonthChange,
+			toMonth,
+			fromMonth,
+			rootClassNames,
+			useArrowNavigation,
+		} = this.props;
 
-		if ( this.props.selectedDay ) {
-			modifiers[ 'is-selected' ] = this.getDateInstance( this.props.selectedDay );
+		const { mode, selected } = determineSelectionModeFromProps( selectedDay, selectedDays );
+
+		const modifiers = {
+			...extraModifiers,
+			'past-days': { before: new Date() },
+			sunday: { dayOfWeek: [ 0 ] },
+		};
+		if ( selectedDay ) {
+			modifiers[ 'is-selected' ] = this.getDateInstance( selectedDay );
 		}
 
-		if ( this.props.events && this.props.events.length ) {
+		if ( events && events.length ) {
 			modifiers.events = map(
-				filter( this.props.events, ( event ) => event.date ),
+				filter( events, ( event ) => event.date ),
 				( event ) => this.getDateInstance( event.date )
 			);
 		}
 
-		const numMonths = this.props.numberOfMonths || 1;
+		const numMonths = numberOfMonths || 1;
 		const rangeSelected = modifiers.start && modifiers.end;
-
-		const rootClassNames = clsx( {
+		const className = clsx( {
 			'date-picker': true,
 			'date-picker--no-range-selected': ! rangeSelected,
 			'date-picker--range-selected': rangeSelected,
 			[ `date-picker--${ numMonths }up` ]: true,
-			...this.props.rootClassNames,
+			...rootClassNames,
 		} );
+
+		const components = {
+			DayButton: DatePickerDay,
+		};
+		if ( useArrowNavigation ) {
+			components.Chevron = DatePickerChevron;
+		} else {
+			components.Nav = this.renderNav;
+		}
 
 		return (
 			<DayPicker
 				modifiers={ modifiers }
-				className={ rootClassNames }
-				disabledDays={ this.props.disabledDays }
-				initialMonth={ this.props.calendarInitialDate }
-				month={ this.props.calendarViewDate }
-				fromMonth={ this.props.fromMonth }
-				toMonth={ this.props.toMonth }
-				onDayClick={ this.setCalendarDay }
-				onDayTouchStart={ this.setCalendarDay }
-				onDayTouchEnd={ this.setCalendarDay }
-				onDayTouchMove={ this.handleDayTouchMove }
-				renderDay={ this.renderDay }
-				locale={ this.props.locale }
-				localeUtils={ this.getLocaleUtils() }
-				onMonthChange={ this.props.onMonthChange }
-				showOutsideDays={ this.props.showOutsideDays }
-				navbarElement={ <DatePickerNavBar useArrowNavigation={ this.props.useArrowNavigation } /> }
-				selectedDays={ this.props.selectedDays }
-				numberOfMonths={ this.props.numberOfMonths }
+				modifiersClassNames={ MODIFIERS_CLASS_NAMES }
+				className={ className }
+				classNames={ CLASS_NAMES }
+				disabled={ disabledDays }
+				defaultMonth={ calendarInitialDate || undefined }
+				month={ calendarViewDate || undefined }
+				startMonth={ fromMonth || undefined }
+				endMonth={ toMonth || undefined }
+				onDayClick={ this.handleDayClick }
+				components={ components }
+				formatters={ { formatCaption: this.formatCaption } }
+				labels={ { labelDayButton: this.formatLabelDayButton } }
+				onMonthChange={ onMonthChange }
+				showOutsideDays={ showOutsideDays }
+				mode={ mode }
+				required={ false }
+				selected={ selected }
+				onSelect={ noop }
+				numberOfMonths={ numberOfMonths }
+				onDayMouseEnter={ this.handleDayMouseEnter }
+				onDayMouseLeave={ this.handleDayMouseLeave }
 			/>
 		);
 	}

--- a/client/components/date-picker/index.jsx
+++ b/client/components/date-picker/index.jsx
@@ -6,7 +6,7 @@ import { PureComponent } from 'react';
 import { DayPicker } from 'react-day-picker';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import DatePickerDay from './day';
-import { DatePickerNavBar, DatePickerChevron } from './nav-bar';
+import { DatePickerPreviousMonthButton, DatePickerNextMonthButton } from './nav-bar';
 
 import './style.scss';
 
@@ -133,6 +133,59 @@ class DatePicker extends PureComponent {
 		useArrowNavigation: false,
 	};
 
+	// `month` on react-day-picker is strictly controlled: the calendar won't
+	// change its displayed month unless the consumer re-passes a new value.
+	// Consumers in this repo (DateRange, DateControl) pass a static
+	// `focusedMonth` and don't listen to `onMonthChange`, so prev/next clicks
+	// would otherwise be no-ops. The wrapper holds its own "displayed month",
+	// re-seeded from the consumer prop whenever it changes (tracked via
+	// `lastSyncedConsumerInputs`) and updated by v9 navigation events.
+	state = {
+		displayedMonth: DatePicker.computeDisplayedMonth( this.props ),
+		lastSyncedConsumerInputs: DatePicker.consumerInputsKey( this.props ),
+	};
+
+	static consumerInputsKey( props ) {
+		return [ props.calendarViewDate, props.toMonth, props.numberOfMonths ];
+	}
+
+	static computeDisplayedMonth( props ) {
+		// v9's getDisplayMonths truncates the display when `firstDisplayedMonth +
+		// (numberOfMonths - 1) > endMonth`. If a consumer pins `calendarViewDate`
+		// to a date inside `toMonth`'s month while requesting multiple months,
+		// shift the first displayed month back so the cap stays visible as the
+		// LAST month (the v7-era behaviour).
+		let monthProp = props.calendarViewDate || undefined;
+		const numberOfMonths = props.numberOfMonths || 1;
+		if ( monthProp && props.toMonth && numberOfMonths > 1 ) {
+			const endMonthFirstDay = new Date( props.toMonth.getFullYear(), props.toMonth.getMonth(), 1 );
+			const lastDisplayed = addMonths( monthProp, numberOfMonths - 1 );
+			if ( lastDisplayed > endMonthFirstDay ) {
+				monthProp = addMonths( endMonthFirstDay, -( numberOfMonths - 1 ) );
+			}
+		}
+		return monthProp;
+	}
+
+	static getDerivedStateFromProps( props, state ) {
+		const nextKey = DatePicker.consumerInputsKey( props );
+		const sameAsLast = nextKey.every(
+			( value, i ) => value === state.lastSyncedConsumerInputs[ i ]
+		);
+		if ( sameAsLast ) {
+			return null;
+		}
+		return {
+			displayedMonth: DatePicker.computeDisplayedMonth( props ),
+			lastSyncedConsumerInputs: nextKey,
+		};
+	}
+
+	handleMonthChange = ( newMonth ) => {
+		this.setState( { displayedMonth: newMonth } );
+		this.props.onMonthChange( newMonth );
+	};
+
 	isSameDay( d0, d1 ) {
 		d0 = this.props.moment( d0 );
 		d1 = this.props.moment( d1 );
@@ -199,6 +252,11 @@ class DatePicker extends PureComponent {
 		return this.props.moment( date ).format( 'MMMM YYYY' );
 	};
 
+	// Single-letter weekday headers, matching the v7 wrapper. Works for Latin
+	// ("Mo" → "M"), CJK (already one char), Cyrillic/Greek/Arabic. Doesn't
+	// handle UTF-16 surrogate pairs but no moment locale ships such weekdays.
+	formatWeekdayName = ( date ) => this.props.moment( date ).format( 'dd' )[ 0 ];
+
 	// v9 dates land at midnight; v7's internal grid used noon (avoids DST
 	// surprises in the moment `llll` format). Pin to noon so the rendered
 	// aria-label matches v7's output exactly: e.g. "Thu, Oct 4, 2018 12:00 PM".
@@ -208,29 +266,56 @@ class DatePicker extends PureComponent {
 		return this.props.moment( noon ).format( 'llll' );
 	};
 
-	renderNav = ( navProps ) => {
-		// v7 advertised the *last* visible month as `nextMonth` (so multi-month
-		// pickers said "Next month (December 2018)" when showing Oct+Nov). v9
-		// always reports the immediate next month. Re-shift it so existing aria
-		// labels are preserved.
-		const numberOfMonths = this.props.numberOfMonths || 1;
-		const nextMonth =
-			navProps.nextMonth && numberOfMonths > 1
-				? addMonths( navProps.nextMonth, numberOfMonths - 1 )
-				: navProps.nextMonth;
-
-		return (
-			<DatePickerNavBar
-				{ ...navProps }
-				nextMonth={ nextMonth }
-				formatMonthTitle={ this.formatCaption }
-			/>
-		);
+	// v9 invokes the label callbacks immediately before rendering the matching
+	// PreviousMonthButton / NextMonthButton, so storing the date on `this`
+	// lets the button overrides read it without us having to recompute v9's
+	// navigation math.
+	formatLabelPrevious = ( date ) => {
+		this.prevNavMonth = date;
+		if ( ! date ) {
+			return this.props.translate( 'Previous month' );
+		}
+		return this.props.translate( 'Previous month (%s)', {
+			comment: 'Aria label for date picker controls',
+			args: this.formatCaption( date ),
+		} );
 	};
+
+	// v9's `nextMonth` is the IMMEDIATE next month; v7 advertised the *last*
+	// visible month for multi-month displays ("Next month (December 2018)"
+	// when showing Oct+Nov). Re-shift here so existing aria labels are
+	// preserved.
+	formatLabelNext = ( date ) => {
+		const numberOfMonths = this.props.numberOfMonths || 1;
+		const adjusted = date && numberOfMonths > 1 ? addMonths( date, numberOfMonths - 1 ) : date;
+		this.nextNavMonth = adjusted;
+		if ( ! adjusted ) {
+			return this.props.translate( 'Next month' );
+		}
+		return this.props.translate( 'Next month (%s)', {
+			comment: 'Aria label for date picker controls',
+			args: this.formatCaption( adjusted ),
+		} );
+	};
+
+	renderPreviousMonthButton = ( buttonProps ) => (
+		<DatePickerPreviousMonthButton
+			{ ...buttonProps }
+			useArrowNavigation={ this.props.useArrowNavigation }
+			monthDate={ this.prevNavMonth }
+		/>
+	);
+
+	renderNextMonthButton = ( buttonProps ) => (
+		<DatePickerNextMonthButton
+			{ ...buttonProps }
+			useArrowNavigation={ this.props.useArrowNavigation }
+			monthDate={ this.nextNavMonth }
+		/>
+	);
 
 	render() {
 		const {
-			calendarViewDate,
 			calendarInitialDate,
 			showOutsideDays,
 			numberOfMonths,
@@ -239,11 +324,9 @@ class DatePicker extends PureComponent {
 			disabledDays,
 			modifiers: extraModifiers,
 			selectedDay,
-			onMonthChange,
 			toMonth,
 			fromMonth,
 			rootClassNames,
-			useArrowNavigation,
 		} = this.props;
 
 		const { mode, selected } = determineSelectionModeFromProps( selectedDay, selectedDays );
@@ -276,12 +359,9 @@ class DatePicker extends PureComponent {
 
 		const components = {
 			DayButton: DatePickerDay,
+			PreviousMonthButton: this.renderPreviousMonthButton,
+			NextMonthButton: this.renderNextMonthButton,
 		};
-		if ( useArrowNavigation ) {
-			components.Chevron = DatePickerChevron;
-		} else {
-			components.Nav = this.renderNav;
-		}
 
 		return (
 			<DayPicker
@@ -291,14 +371,23 @@ class DatePicker extends PureComponent {
 				classNames={ CLASS_NAMES }
 				disabled={ disabledDays }
 				defaultMonth={ calendarInitialDate || undefined }
-				month={ calendarViewDate || undefined }
+				month={ this.state.displayedMonth }
 				startMonth={ fromMonth || undefined }
 				endMonth={ toMonth || undefined }
+				weekStartsOn={ this.props.moment().localeData().firstDayOfWeek() }
+				navLayout="around"
 				onDayClick={ this.handleDayClick }
 				components={ components }
-				formatters={ { formatCaption: this.formatCaption } }
-				labels={ { labelDayButton: this.formatLabelDayButton } }
-				onMonthChange={ onMonthChange }
+				formatters={ {
+					formatCaption: this.formatCaption,
+					formatWeekdayName: this.formatWeekdayName,
+				} }
+				labels={ {
+					labelDayButton: this.formatLabelDayButton,
+					labelPrevious: this.formatLabelPrevious,
+					labelNext: this.formatLabelNext,
+				} }
+				onMonthChange={ this.handleMonthChange }
 				showOutsideDays={ showOutsideDays }
 				mode={ mode }
 				required={ false }

--- a/client/components/date-picker/nav-bar.jsx
+++ b/client/components/date-picker/nav-bar.jsx
@@ -1,80 +1,45 @@
 import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
-import clsx from 'clsx';
-import { translate } from 'i18n-calypso';
-
-const noop = () => {};
-
-const handleMonthClick =
-	( onClick = noop ) =>
-	( event ) => {
-		event.preventDefault();
-		onClick();
-	};
 
 function defaultFormatMonthShort( date ) {
 	return new Intl.DateTimeFormat( undefined, { month: 'short' } ).format( date );
 }
 
-function defaultFormatMonthTitle( date ) {
-	return new Intl.DateTimeFormat( undefined, { month: 'long', year: 'numeric' } ).format( date );
-}
-
-export const DatePickerNavBar = ( {
-	nextMonth,
-	previousMonth,
-	onPreviousClick,
-	onNextClick,
-	className,
-	formatMonthTitle = defaultFormatMonthTitle,
+// Shared shape for the prev/next slot overrides plugged into v9's
+// `components.PreviousMonthButton` / `components.NextMonthButton`. v9 calls
+// these with `{ type, className, tabIndex, aria-disabled, aria-label, onClick,
+// children }`; the wrapper layer also passes `useArrowNavigation` and
+// `monthDate` so the button can render an icon or the month abbreviation.
+function MonthButton( {
+	useArrowNavigation,
+	monthDate,
 	formatMonthShort = defaultFormatMonthShort,
-} ) => {
-	const classes = clsx( 'date-picker__nav-bar', {
-		[ className ]: !! className,
-	} );
+	sideClassName,
+	icon,
+	children,
+	...buttonProps
+} ) {
+	// v7 hid the button entirely when navigation in that direction wasn't
+	// possible. v9 keeps it in the DOM with `aria-disabled="true"`; match the
+	// v7 behaviour so existing tests (and visual layout) line up.
+	if ( buttonProps[ 'aria-disabled' ] ) {
+		return null;
+	}
 
-	const buttonClass = 'date-picker__month-button button';
+	const buttonClass = useArrowNavigation
+		? 'date-picker__arrow-button'
+		: 'date-picker__month-button button';
 
 	return (
-		<nav className={ classes }>
-			{ previousMonth && (
-				<button
-					className={ `date-picker__previous-month ${ buttonClass }` }
-					type="button"
-					aria-label={ translate( 'Previous month (%s)', {
-						comment: 'Aria label for date picker controls',
-						args: formatMonthTitle( previousMonth ),
-					} ) }
-					onClick={ handleMonthClick( onPreviousClick ) }
-				>
-					{ formatMonthShort( previousMonth ) }
-				</button>
-			) }
-
-			{ nextMonth && (
-				<button
-					className={ `date-picker__next-month ${ buttonClass }` }
-					type="button"
-					aria-label={ translate( 'Next month (%s)', {
-						comment: 'Aria label for date picker controls',
-						args: formatMonthTitle( nextMonth ),
-					} ) }
-					onClick={ handleMonthClick( onNextClick ) }
-				>
-					{ formatMonthShort( nextMonth ) }
-				</button>
-			) }
-		</nav>
+		<button { ...buttonProps } type="button" className={ `${ sideClassName } ${ buttonClass }` }>
+			{ useArrowNavigation ? <Icon icon={ icon } /> : monthDate && formatMonthShort( monthDate ) }
+		</button>
 	);
-};
-
-export function DatePickerChevron( { orientation } ) {
-	if ( orientation === 'left' ) {
-		return <Icon icon={ chevronLeft } />;
-	}
-	if ( orientation === 'right' ) {
-		return <Icon icon={ chevronRight } />;
-	}
-	return null;
 }
 
-export default DatePickerNavBar;
+export const DatePickerPreviousMonthButton = ( props ) => (
+	<MonthButton { ...props } sideClassName="date-picker__previous-month" icon={ chevronLeft } />
+);
+
+export const DatePickerNextMonthButton = ( props ) => (
+	<MonthButton { ...props } sideClassName="date-picker__next-month" icon={ chevronRight } />
+);

--- a/client/components/date-picker/nav-bar.jsx
+++ b/client/components/date-picker/nav-bar.jsx
@@ -11,64 +11,70 @@ const handleMonthClick =
 		onClick();
 	};
 
+function defaultFormatMonthShort( date ) {
+	return new Intl.DateTimeFormat( undefined, { month: 'short' } ).format( date );
+}
+
+function defaultFormatMonthTitle( date ) {
+	return new Intl.DateTimeFormat( undefined, { month: 'long', year: 'numeric' } ).format( date );
+}
+
 export const DatePickerNavBar = ( {
 	nextMonth,
 	previousMonth,
 	onPreviousClick,
 	onNextClick,
 	className,
-	localeUtils,
-	showPreviousButton = true,
-	showNextButton = true,
-	useArrowNavigation = false,
+	formatMonthTitle = defaultFormatMonthTitle,
+	formatMonthShort = defaultFormatMonthShort,
 } ) => {
 	const classes = clsx( 'date-picker__nav-bar', {
 		[ className ]: !! className,
 	} );
 
-	const buttonClass = useArrowNavigation
-		? 'date-picker__arrow-button'
-		: 'date-picker__month-button button';
+	const buttonClass = 'date-picker__month-button button';
 
 	return (
-		<div className={ classes }>
-			{ showPreviousButton && (
+		<nav className={ classes }>
+			{ previousMonth && (
 				<button
 					className={ `date-picker__previous-month ${ buttonClass }` }
 					type="button"
 					aria-label={ translate( 'Previous month (%s)', {
 						comment: 'Aria label for date picker controls',
-						args: localeUtils.formatMonthTitle( previousMonth ),
+						args: formatMonthTitle( previousMonth ),
 					} ) }
 					onClick={ handleMonthClick( onPreviousClick ) }
 				>
-					{ useArrowNavigation ? (
-						<Icon icon={ chevronLeft } />
-					) : (
-						localeUtils.formatMonthShort( previousMonth )
-					) }
+					{ formatMonthShort( previousMonth ) }
 				</button>
 			) }
 
-			{ showNextButton && (
+			{ nextMonth && (
 				<button
 					className={ `date-picker__next-month ${ buttonClass }` }
 					type="button"
 					aria-label={ translate( 'Next month (%s)', {
 						comment: 'Aria label for date picker controls',
-						args: localeUtils.formatMonthTitle( nextMonth ),
+						args: formatMonthTitle( nextMonth ),
 					} ) }
 					onClick={ handleMonthClick( onNextClick ) }
 				>
-					{ useArrowNavigation ? (
-						<Icon icon={ chevronRight } />
-					) : (
-						localeUtils.formatMonthShort( nextMonth )
-					) }
+					{ formatMonthShort( nextMonth ) }
 				</button>
 			) }
-		</div>
+		</nav>
 	);
 };
+
+export function DatePickerChevron( { orientation } ) {
+	if ( orientation === 'left' ) {
+		return <Icon icon={ chevronLeft } />;
+	}
+	if ( orientation === 'right' ) {
+		return <Icon icon={ chevronRight } />;
+	}
+	return null;
+}
 
 export default DatePickerNavBar;

--- a/client/components/date-picker/style.scss
+++ b/client/components/date-picker/style.scss
@@ -65,7 +65,13 @@ $date-picker_nav_button_size: 20px;
 
 .date-picker__previous-month,
 .date-picker__next-month {
-	float: right;
+	position: absolute;
+	top: 0;
+	// Match the caption row's height so flex centering puts the chevron / month
+	// text on the same baseline as the caption text.
+	height: $date-picker_caption_height;
+	display: inline-flex;
+	align-items: center;
 	padding: 1px 8px;
 	font-size: $font-body-extra-small;
 	text-transform: capitalize;
@@ -83,11 +89,11 @@ $date-picker_nav_button_size: 20px;
 }
 
 .date-picker__previous-month {
-	float: left;
+	left: 0;
 }
 
 .date-picker__next-month {
-	float: right;
+	right: 0;
 }
 
 .DayPicker-Month {
@@ -99,39 +105,20 @@ $date-picker_nav_button_size: 20px;
 	margin: 0;
 }
 
-.DayPicker-NavBar {
-	position: absolute;
-	left: 0;
-	right: 0;
-	height: $date-picker_caption_height;
-}
-
-.DayPicker-NavButton {
-	position: absolute;
-	width: $date-picker_nav_button_size;
-	height: $date-picker_nav_button_size;
-	line-height: $date-picker_nav_button_size;
-	top: ( $date-picker_caption_height - $date-picker_nav_button_size ) * 0.5;
-	background-repeat: no-repeat;
-	background-position: center;
-	background-size: contain;
-	cursor: pointer;
-	font-size: $font-title-small;
-
-	&::before {
-		height: $date-picker_nav_button_size;
-	}
+// react-day-picker v9 with `navLayout="around"` renders the prev/next buttons
+// as siblings of the caption inside each month wrapper. Make the wrapper a
+// positioning context so the buttons can sit at its top-left/right corners.
+.DayPicker-Month-Wrapper {
+	position: relative;
 }
 
 .DayPicker-Caption {
-	display: table-caption;
+	// Side gutters leave room for the absolutely-positioned prev/next buttons.
+	margin: 0 $date-picker_nav_button_size * 1.5;
 	text-align: center;
 	height: $date-picker_caption_height;
 	line-height: $date-picker_caption_height;
 	font-size: $font-body;
-	margin: 0 $date-picker_nav_button_size * 1.5;
-	position: relative;
-	cursor: pointer;
 
 	&::first-letter {
 		text-transform: uppercase;

--- a/client/components/date-picker/style.scss
+++ b/client/components/date-picker/style.scss
@@ -141,11 +141,6 @@ $date-picker_nav_button_size: 20px;
 .DayPicker-Weekdays {
 	margin-top: 10px;
 	border-top: 1px solid var(--color-neutral-5);
-	display: table-header-group;
-}
-
-.DayPicker-WeekdaysRow {
-	display: table-row;
 }
 
 .DayPicker-Weekday {
@@ -196,6 +191,24 @@ $date-picker_nav_button_size: 20px;
 
 .DayPicker--interactionDisabled .DayPicker-Day {
 	cursor: default;
+}
+
+// react-day-picker v9 wraps the day cell content in a <button>. Strip its
+// browser-default chrome so the inner .date-picker__day circle renders clean.
+.DayPicker-DayButton {
+	display: block;
+	width: 100%;
+	margin: 0;
+	padding: 0;
+	background: transparent;
+	border: 0;
+	color: inherit;
+	font: inherit;
+	cursor: pointer;
+
+	&:disabled {
+		cursor: default;
+	}
 }
 
 // base styles of the cell child element

--- a/client/components/date-range/test/index.js
+++ b/client/components/date-range/test/index.js
@@ -283,13 +283,13 @@ describe( 'DateRange', () => {
 			// Dates before `10-03-2018`
 			someDisabledDatesStrings.forEach( ( dateString ) => {
 				const el = screen.getByLabelText( dateString );
-				expect( el ).toHaveAttribute( 'aria-disabled', 'true' );
+				expect( el ).toBeDisabled();
 			} );
 
 			// Dates on/after `10-03-2018`
 			someEnabledDatesStrings.forEach( ( dateString ) => {
 				const el = screen.getByLabelText( dateString );
-				expect( el ).toHaveAttribute( 'aria-disabled', 'false' );
+				expect( el ).not.toBeDisabled();
 			} );
 		} );
 
@@ -315,13 +315,13 @@ describe( 'DateRange', () => {
 			// Dates on/before `10-03-2018`
 			someEnabledDatesStrings.forEach( ( dateString ) => {
 				const el = screen.getByLabelText( dateString );
-				expect( el ).toHaveAttribute( 'aria-disabled', 'false' );
+				expect( el ).not.toBeDisabled();
 			} );
 
 			// Dates after `10-03-2018`
 			someDisabledDatesStrings.forEach( ( dateString ) => {
 				const el = screen.getByLabelText( dateString );
-				expect( el ).toHaveAttribute( 'aria-disabled', 'true' );
+				expect( el ).toBeDisabled();
 			} );
 		} );
 
@@ -403,7 +403,10 @@ describe( 'DateRange', () => {
 
 			const startDateEl = screen.getByLabelText( 'Sat, Jun 30, 2018 12:00 PM' );
 
-			expect( startDateEl ).toHaveAttribute( 'aria-selected', 'true' );
+			expect( startDateEl.closest( '[role="gridcell"]' ) ).toHaveAttribute(
+				'aria-selected',
+				'true'
+			);
 		} );
 
 		test( 'should update end date selection on end date input blur', async () => {
@@ -417,7 +420,7 @@ describe( 'DateRange', () => {
 
 			const endDateEl = screen.getByLabelText( 'Sat, Jun 30, 2018 12:00 PM' );
 
-			expect( endDateEl ).toHaveAttribute( 'aria-selected', 'true' );
+			expect( endDateEl.closest( '[role="gridcell"]' ) ).toHaveAttribute( 'aria-selected', 'true' );
 		} );
 
 		test( 'should not update date selection on input change', async () => {
@@ -429,7 +432,7 @@ describe( 'DateRange', () => {
 
 			const el = screen.getByLabelText( 'Sat, Jun 30, 2018 12:00 PM' );
 
-			expect( el ).toHaveAttribute( 'aria-selected', 'false' );
+			expect( el.closest( '[role="gridcell"]' ) ).not.toHaveAttribute( 'aria-selected' );
 		} );
 
 		test( 'should not update start/end dates if input date is invalid', async () => {
@@ -462,8 +465,11 @@ describe( 'DateRange', () => {
 			const startDateEl = screen.getByLabelText( 'Wed, May 30, 2018 12:00 PM' );
 			const endDateEl = screen.getByLabelText( 'Sat, Jun 30, 2018 12:00 PM' );
 
-			expect( startDateEl ).toHaveAttribute( 'aria-selected', 'true' );
-			expect( endDateEl ).toHaveAttribute( 'aria-selected', 'true' );
+			expect( startDateEl.closest( '[role="gridcell"]' ) ).toHaveAttribute(
+				'aria-selected',
+				'true'
+			);
+			expect( endDateEl.closest( '[role="gridcell"]' ) ).toHaveAttribute( 'aria-selected', 'true' );
 		} );
 
 		test( 'should not update start date if input date is outside firstSelectableDate', async () => {
@@ -487,7 +493,9 @@ describe( 'DateRange', () => {
 
 			const supposedStartDateEl = screen.getByLabelText( badDateLabelString );
 
-			expect( supposedStartDateEl ).toHaveAttribute( 'aria-selected', 'false' );
+			expect( supposedStartDateEl.closest( '[role="gridcell"]' ) ).not.toHaveAttribute(
+				'aria-selected'
+			);
 		} );
 
 		test( 'should not update end date if input date is outside firstSelectableDate', async () => {
@@ -511,7 +519,9 @@ describe( 'DateRange', () => {
 
 			const supposedStartDateEl = screen.getByLabelText( badDateLabelString );
 
-			expect( supposedStartDateEl ).toHaveAttribute( 'aria-selected', 'false' );
+			expect( supposedStartDateEl.closest( '[role="gridcell"]' ) ).not.toHaveAttribute(
+				'aria-selected'
+			);
 		} );
 
 		test( 'should not update start date if input date is outside lastSelectableDate', async () => {
@@ -535,7 +545,9 @@ describe( 'DateRange', () => {
 
 			const supposedStartDateEl = screen.getByLabelText( badDateLabelString );
 
-			expect( supposedStartDateEl ).toHaveAttribute( 'aria-selected', 'false' );
+			expect( supposedStartDateEl.closest( '[role="gridcell"]' ) ).not.toHaveAttribute(
+				'aria-selected'
+			);
 		} );
 	} );
 
@@ -560,7 +572,9 @@ describe( 'DateRange', () => {
 
 		const supposedStartDateEl = screen.getByLabelText( badDateLabelString );
 
-		expect( supposedStartDateEl ).toHaveAttribute( 'aria-selected', 'false' );
+		expect( supposedStartDateEl.closest( '[role="gridcell"]' ) ).not.toHaveAttribute(
+			'aria-selected'
+		);
 	} );
 
 	describe( 'Actions and Information UI', () => {
@@ -607,7 +621,10 @@ describe( 'DateRange', () => {
 
 			await userEvent.click( screen.getByLabelText( 'Select date range' ) );
 
-			expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Please select the first day' );
+			const info = screen
+				.getAllByRole( 'status' )
+				.find( ( el ) => el.textContent.includes( 'Please select' ) );
+			expect( info ).toHaveTextContent( 'Please select the first day' );
 		} );
 
 		test( 'Should display prompt to select last date when no end date selected', async () => {
@@ -619,7 +636,10 @@ describe( 'DateRange', () => {
 
 			await userEvent.click( screen.getByLabelText( 'Select date range' ) );
 
-			expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Please select the last day' );
+			const info = screen
+				.getAllByRole( 'status' )
+				.find( ( el ) => el.textContent.includes( 'Please select' ) );
+			expect( info ).toHaveTextContent( 'Please select the last day' );
 		} );
 
 		test( 'Should display reset button when both dates are selected', async () => {
@@ -669,28 +689,24 @@ describe( 'DateRange', () => {
 			// Blurs out of `toInputEl`
 			await userEvent.tab();
 
-			expect( screen.getByLabelText( 'Fri, Apr 13, 2018 12:00 PM' ) ).toHaveAttribute(
-				'aria-selected',
-				'true'
-			);
-			expect( screen.getByLabelText( 'Sun, May 13, 2018 12:00 PM' ) ).toHaveAttribute(
-				'aria-selected',
-				'true'
-			);
+			expect(
+				screen.getByLabelText( 'Fri, Apr 13, 2018 12:00 PM' ).closest( '[role="gridcell"]' )
+			).toHaveAttribute( 'aria-selected', 'true' );
+			expect(
+				screen.getByLabelText( 'Sun, May 13, 2018 12:00 PM' ).closest( '[role="gridcell"]' )
+			).toHaveAttribute( 'aria-selected', 'true' );
 
 			const resetBtn = screen.getByLabelText( 'Reset selected dates' );
 			await userEvent.click( resetBtn );
 
 			expect( fromInputEl ).toHaveValue( '04/28/2018' );
 			expect( toInputEl ).toHaveValue( '05/28/2018' );
-			expect( screen.getByLabelText( 'Sat, Apr 28, 2018 12:00 PM' ) ).toHaveAttribute(
-				'aria-selected',
-				'true'
-			);
-			expect( screen.getByLabelText( 'Mon, May 28, 2018 12:00 PM' ) ).toHaveAttribute(
-				'aria-selected',
-				'true'
-			);
+			expect(
+				screen.getByLabelText( 'Sat, Apr 28, 2018 12:00 PM' ).closest( '[role="gridcell"]' )
+			).toHaveAttribute( 'aria-selected', 'true' );
+			expect(
+				screen.getByLabelText( 'Mon, May 28, 2018 12:00 PM' ).closest( '[role="gridcell"]' )
+			).toHaveAttribute( 'aria-selected', 'true' );
 		} );
 	} );
 

--- a/client/components/post-schedule/index.jsx
+++ b/client/components/post-schedule/index.jsx
@@ -62,14 +62,6 @@ export default class PostSchedule extends Component {
 		};
 	}
 
-	getLocaleUtils() {
-		return {
-			formatMonthTitle: function () {
-				return;
-			},
-		};
-	}
-
 	events() {
 		return this.props.events.concat( this.getEventsFromPosts( this.props.posts ) );
 	}
@@ -218,7 +210,7 @@ export default class PostSchedule extends Component {
 
 				<DatePicker
 					events={ this.events() }
-					localeUtils={ this.getLocaleUtils() }
+					formatMonthTitle={ () => undefined }
 					disabledDays={ this.props.disabledDays }
 					showOutsideDays={ this.props.showOutsideDays }
 					modifiers={ this.props.modifiers }

--- a/client/package.json
+++ b/client/package.json
@@ -200,7 +200,7 @@
 		"qrcode.react": "^3.1.0",
 		"qs": "^6.9.1",
 		"react": "^18.3.1",
-		"react-day-picker": "^7.4.10",
+		"react-day-picker": "^9.7.0",
 		"react-dom": "^18.3.1",
 		"react-intersection-observer": "^9.4.3",
 		"react-markdown": "^8.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13852,7 +13852,7 @@ __metadata:
     qrcode.react: "npm:^3.1.0"
     qs: "npm:^6.9.1"
     react: "npm:^18.3.1"
-    react-day-picker: "npm:^7.4.10"
+    react-day-picker: "npm:^9.7.0"
     react-dom: "npm:^18.3.1"
     react-intersection-observer: "npm:^9.4.3"
     react-markdown: "npm:^8.0.7"
@@ -27195,17 +27195,6 @@ __metadata:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
   checksum: 48eb73cf71e10841c2a61b6b06ab81da9fffa9876134c239bfdebcf348ce2a47e56b146338e35dfb03512c85966bfc9a53844fc56bc50154e71f8daee59ff6f0
-  languageName: node
-  linkType: hard
-
-"react-day-picker@npm:^7.4.10":
-  version: 7.4.10
-  resolution: "react-day-picker@npm:7.4.10"
-  dependencies:
-    prop-types: "npm:^15.6.2"
-  peerDependencies:
-    react: ~0.13.x || ~0.14.x || ^15.0.0 || ^16.0.0 || ^17.0.0
-  checksum: 547cb211fb63121837bc5bf989d5ff51938d87328a495ca7a2b089454ac09e2193ff48f25858a2d75d080c1cd597165ff5506d2505a4acec31bc11dd8250e879
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Depends on #110719

## Proposed Changes

Updates `client/components/date-picker` on top of react-day-picker v9 and removes the v7 install from `client/package.json`. The wrapper's public prop API _should_ be unchanged. The four call sites should keep working unchanged:
- `backup/date-button.tsx`
- `date-range/date-range-picker.tsx`
- `post-schedule/index.jsx` (one small change there: `localeUtils` → `formatMonthTitle`)
- `date-picker/docs/example.jsx`

`date-picker/README.md` was also updated to reflect the actual public prop names (`calendarInitialDate`, etc.) — because it looks like it had gotten out of date.

## Why are these changes being made?

We currently have two versions of `react-day-picker`, `7.4.10` and `9.7.0` (via `@automattic/ui`), coexisting via Webpack's per-importer `node_modules` resolution. Consolidating onto a single version reduces bundle size and avoids breaking [the Vite bundler I'm working on](https://github.com/Automattic/wp-calypso/pull/110140), which doesn't replicate webpack's per-importer behaviour.

I've tried to keep the diff as small as possible, but I suppose it's nature of breaking DOM changes that it's not as simple as just updating the package version. @kangzj @annacmc git said ya'll have worked on this component somewhat. Would you mind taking a look? @mirka I've pinged you too because it looks like you've spent some time with rdp v9 and maybe you have insights into the approach I've taken?

## Implementation notes

### API changes

Only two breaking changes versus the v7 wrapper:

- **`localeUtils` removed.** v8 of react-day-picker dropped `localeUtils` wholesale (replaced by `formatters`, `labels`, `locale`, `weekStartsOn`). Only `post-schedule` used it, and only to suppress the calendar caption (`formatMonthTitle: () => undefined`). The wrapper now exposes a single `formatMonthTitle?: (Date) => string | null | undefined` prop wired to v9's `formatters.formatCaption`.
- **`onDayTouchStart` / `onDayTouchEnd` / `onDayTouchMove` removed.** v8 dropped them; v9's native `<button>` only fires `click` once on mobile, so the v7 wrapper's 500 ms touch+click de-dup debounce is no longer needed. No call site passed these.

### Locale and right-to-left

I tested languages and locales to make sure we're rendering dates and days the same way that we used to. That means even when v9 has made a change, I've tried to match our existing behaviour.

RTL is a bit broken, but this was existing behaviour.

<img width="1466" height="1002" alt="CleanShot 2026-05-11 at 21 23 58@2x" src="https://github.com/user-attachments/assets/2db0363a-857d-4b55-afa8-76303b655f19" />


### Under the hood changes

- v9's default class names (`rdp-*`) are remapped to the legacy `DayPicker-*` names via the `classNames` / `modifiersClassNames` props so the existing SCSS keeps matching with minimal CSS churn.
- v9's day cell is now a real `<button>` (was a `<div>` in v7). A small `.DayPicker-DayButton` reset strips its browser-default chrome.
- v9 reports `nextMonth` as the *immediate* next month; v7 reported the *last visible* month. The wrapper re-shifts `nextMonth` by `numberOfMonths - 1` so existing aria-labels (`"Next month (December 2018)"`) are preserved.
- v9 marks the inner `<button>` `disabled` (HTML attribute) and puts `aria-selected` on the parent `<td role="gridcell">` — both correct ARIA. Test assertions that previously checked `aria-disabled`/`aria-selected` on the labelled element now use `toBeDisabled()` / `closest('[role="gridcell"]')` accordingly.


The v7 wrapper accepted `showPreviousButton` / `showNextButton` props on `nav-bar.jsx`. No consumer ever set them — they were injected only by `react-day-picker` v7 itself when it cloned `navbarElement`, as its "no further history available" signal. v9 expresses the same thing by passing `previousMonth: undefined` / `nextMonth: undefined`, so dropping them is non-breaking.


## Testing Instructions

Run \`yarn start\` and load each surface in a browser. On each:
- Day cells render as circles (\`.date-picker__day\` styling intact).
- Selected day animates in on click (the \`is-selected\` modifier).
- Disabled days are visually muted and don't fire \`onSelectDay\`.
- Prev/Next month buttons show text labels (\`"Sep"\`/\`"Oct"\`); aria-labels read \`"Previous month (October 2018)"\` / \`"Next month (December 2018)"\` on multi-month pickers.
- Range start/end/middle styling renders correctly on range pickers.
- No browser-console errors mentioning \`does not provide an export named 'default'\`.

| Surface | Wrapper used | URL |
|---|---|---|
| **Backup date picker** | \`<DateButton>\` → \`<DatePicker>\` (single day, disabled days) | \`/backup/:site\` — click "Select Date" |
| **Activity log filterbar** | \`<DateRange>\` → \`<DatePicker>\` (range, multi-month) | \`/activity-log/:site\` — open the range trigger |
| **Site logs (PHP and Web)** | \`<DateControl>\` → \`<DateRange>\` → \`<DatePicker>\` | \`/site-logs/:site/php\` and \`/site-logs/:site/web\` |
| **Stats date control** | \`<StatsDateControl>\` → \`<DateRange>\` → \`<DatePicker>\` | \`/stats/day/:site\`, \`/stats/week/:site\`, \`/stats/month/:site\`, \`/stats/year/:site\`; also \`/wordads/stats/day/:site\` if available |
| **Post-schedule + events tooltip** | \`<DatePicker>\` with events | Only reachable via DevDocs in this codebase — open \`/devdocs/blocks/calendar-button\` and click the calendar button. Days with events should have the event-dot styling and a hover tooltip listing scheduled posts. |

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes? — existing unit tests updated where v9's DOM/labels forced it; 81/81 passing across \`date-picker\`, \`date-range\`, \`post-schedule\`, \`backup-date-picker\`.
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors? — \`yarn typecheck-client\` clean (only pre-existing \`@automattic/omnibar\` errors remain, unrelated).
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2). — \`aria-selected\` now lives on the gridcell (per ARIA grid pattern) and the button uses the native \`disabled\` attribute, both more correct than the v7 wrapper.
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? — no new strings; \`translate('Previous month (%s)')\` / \`translate('Next month (%s)')\` already existed.
