### PR TITLE
Reader social: show spinner on ATmosphere & Mastodon loading screens

### DIFF
--- a/client/reader/atmosphere/atmosphere-account-view.tsx
+++ b/client/reader/atmosphere/atmosphere-account-view.tsx
@@ -1,6 +1,6 @@
 import { useConnectionsQuery } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
-import { __experimentalVStack as VStack } from '@wordpress/components';
+import { Spinner, __experimentalVStack as VStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -49,8 +49,9 @@ export function AtmosphereAccountView( { connectionId, tab }: Props ) {
 		return (
 			<ReaderMain className="atmosphere-view">
 				<DocumentHead title={ translate( 'ATmosphere ‹ Reader' ) } />
-				<div role="status" aria-live="polite">
-					{ translate( 'Loading…' ) }
+				<div className="wp-spinner-wrapper" role="status" aria-live="polite">
+					<Spinner />
+					<p>{ translate( 'Loading…' ) }</p>
 				</div>
 			</ReaderMain>
 		);

--- a/client/reader/atmosphere/atmosphere-landing-view.tsx
+++ b/client/reader/atmosphere/atmosphere-landing-view.tsx
@@ -1,6 +1,6 @@
 import { useConnectionsQuery } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
-import { Button } from '@wordpress/components';
+import { Button, Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -33,8 +33,9 @@ export function AtmosphereLandingView() {
 					</Button>
 				</div>
 			) : (
-				<div role="status" aria-live="polite">
-					{ translate( 'Loading…' ) }
+				<div className="wp-spinner-wrapper" role="status" aria-live="polite">
+					<Spinner />
+					<p>{ translate( 'Loading…' ) }</p>
 				</div>
 			) }
 		</ReaderMain>

--- a/client/reader/atmosphere/atmosphere-thread-view.tsx
+++ b/client/reader/atmosphere/atmosphere-thread-view.tsx
@@ -1,6 +1,6 @@
 import { useConnectionsQuery } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
-import { Button } from '@wordpress/components';
+import { Button, Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -49,8 +49,9 @@ export function AtmosphereThreadView( { connectionId, did, rkey }: Props ) {
 		return (
 			<ReaderMain className="atmosphere-view">
 				<DocumentHead title={ translate( 'Thread ‹ ATmosphere ‹ Reader' ) } />
-				<div role="status" aria-live="polite">
-					{ translate( 'Loading…' ) }
+				<div className="wp-spinner-wrapper" role="status" aria-live="polite">
+					<Spinner />
+					<p>{ translate( 'Loading…' ) }</p>
 				</div>
 			</ReaderMain>
 		);

--- a/client/reader/atmosphere/author-profile-view.tsx
+++ b/client/reader/atmosphere/author-profile-view.tsx
@@ -1,6 +1,6 @@
 import { useConnectionsQuery } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
-import { Button } from '@wordpress/components';
+import { Button, Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
@@ -64,8 +64,9 @@ export function AuthorProfileView( { connectionId, actor }: Props ) {
 		return (
 			<ReaderMain className="atmosphere-view">
 				<DocumentHead title={ translate( 'Profile ‹ ATmosphere ‹ Reader' ) } />
-				<div role="status" aria-live="polite">
-					{ translate( 'Loading…' ) }
+				<div className="wp-spinner-wrapper" role="status" aria-live="polite">
+					<Spinner />
+					<p>{ translate( 'Loading…' ) }</p>
 				</div>
 			</ReaderMain>
 		);

--- a/client/reader/atmosphere/tag-feed-view.tsx
+++ b/client/reader/atmosphere/tag-feed-view.tsx
@@ -1,6 +1,6 @@
 import { useConnectionsQuery } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
-import { Button } from '@wordpress/components';
+import { Button, Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -46,8 +46,9 @@ export function TagFeedView( { connectionId, hashtag }: Props ) {
 		return (
 			<ReaderMain className="atmosphere-view">
 				<DocumentHead title={ translate( 'Tag ‹ Bluesky ‹ Reader' ) } />
-				<div role="status" aria-live="polite">
-					{ translate( 'Loading…' ) }
+				<div className="wp-spinner-wrapper" role="status" aria-live="polite">
+					<Spinner />
+					<p>{ translate( 'Loading…' ) }</p>
 				</div>
 			</ReaderMain>
 		);

--- a/client/reader/mastodon/author-profile-view.tsx
+++ b/client/reader/mastodon/author-profile-view.tsx
@@ -3,7 +3,7 @@ import {
 	useMastodonConnectionsQuery,
 } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
-import { Button } from '@wordpress/components';
+import { Button, Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -58,8 +58,9 @@ export function MastodonAuthorProfileView( { connectionId, actor }: Props ) {
 		return (
 			<ReaderMain className="mastodon-view">
 				<DocumentHead title={ translate( 'Profile ‹ Mastodon ‹ Reader' ) } />
-				<div role="status" aria-live="polite">
-					{ translate( 'Loading…' ) }
+				<div className="wp-spinner-wrapper" role="status" aria-live="polite">
+					<Spinner />
+					<p>{ translate( 'Loading…' ) }</p>
 				</div>
 			</ReaderMain>
 		);

--- a/client/reader/mastodon/mastodon-account-view.tsx
+++ b/client/reader/mastodon/mastodon-account-view.tsx
@@ -1,6 +1,6 @@
 import { useMastodonConnectionQuery, useMastodonConnectionsQuery } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
-import { __experimentalVStack as VStack } from '@wordpress/components';
+import { Spinner, __experimentalVStack as VStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -63,8 +63,9 @@ export function MastodonAccountView( { connectionId, tab }: Props ) {
 		return (
 			<ReaderMain className="mastodon-view">
 				<DocumentHead title={ translate( 'Mastodon ‹ Reader' ) } />
-				<div role="status" aria-live="polite">
-					{ translate( 'Loading…' ) }
+				<div className="wp-spinner-wrapper" role="status" aria-live="polite">
+					<Spinner />
+					<p>{ translate( 'Loading…' ) }</p>
 				</div>
 			</ReaderMain>
 		);

--- a/client/reader/mastodon/mastodon-landing-view.tsx
+++ b/client/reader/mastodon/mastodon-landing-view.tsx
@@ -1,6 +1,6 @@
 import { useMastodonConnectionsQuery } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
-import { Button } from '@wordpress/components';
+import { Button, Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -33,8 +33,9 @@ export function MastodonLandingView() {
 					</Button>
 				</div>
 			) : (
-				<div role="status" aria-live="polite">
-					{ translate( 'Loading…' ) }
+				<div className="wp-spinner-wrapper" role="status" aria-live="polite">
+					<Spinner />
+					<p>{ translate( 'Loading…' ) }</p>
 				</div>
 			) }
 		</ReaderMain>

--- a/client/reader/mastodon/mastodon-thread-view.tsx
+++ b/client/reader/mastodon/mastodon-thread-view.tsx
@@ -1,6 +1,6 @@
 import { useMastodonConnectionsQuery } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
-import { Button } from '@wordpress/components';
+import { Button, Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -55,8 +55,9 @@ export function MastodonThreadView( { connectionId, statusId }: Props ) {
 		return (
 			<ReaderMain className="mastodon-view">
 				<DocumentHead title={ translate( 'Thread ‹ Mastodon ‹ Reader' ) } />
-				<div role="status" aria-live="polite">
-					{ translate( 'Loading…' ) }
+				<div className="wp-spinner-wrapper" role="status" aria-live="polite">
+					<Spinner />
+					<p>{ translate( 'Loading…' ) }</p>
 				</div>
 			</ReaderMain>
 		);

--- a/client/reader/mastodon/tag-feed-view.tsx
+++ b/client/reader/mastodon/tag-feed-view.tsx
@@ -1,6 +1,6 @@
 import { useMastodonConnectionsQuery } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
-import { Button } from '@wordpress/components';
+import { Button, Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -47,8 +47,9 @@ export function MastodonTagFeedView( { connectionId, hashtag }: Props ) {
 		return (
 			<ReaderMain className="mastodon-view">
 				<DocumentHead title={ translate( 'Tag ‹ Mastodon ‹ Reader' ) } />
-				<div role="status" aria-live="polite">
-					{ translate( 'Loading…' ) }
+				<div className="wp-spinner-wrapper" role="status" aria-live="polite">
+					<Spinner />
+					<p>{ translate( 'Loading…' ) }</p>
 				</div>
 			</ReaderMain>
 		);


### PR DESCRIPTION
Fixes CM-700

## Proposed Changes

* Replace the bare "Loading…" text in the ATmosphere and Mastodon Reader views with the shared `wp-spinner-wrapper` pattern (`<Spinner />` from `@wordpress/components` + a `<p>` label).
* Applies to the 10 view files under `client/reader/atmosphere/` and `client/reader/mastodon/` (landing, account, thread, author-profile, tag-feed for each protocol).
* The existing `role="status"` and `aria-live="polite"` attributes on the wrapper are preserved.

## Why are these changes being made?

A bare text "Loading…" gives users no visual loading affordance and feels inconsistent with the rest of the Reader, which already uses the centered-spinner pattern in `client/reader/list/` and `client/reader/user-profile/`. Aligning the social protocol views with that pattern is a small UX-polish improvement.

## Testing Instructions

1. Open `/reader/atmosphere`, `/reader/mastodon`, an ATmosphere or Mastodon thread view, an author profile view, a tag feed view, and a per-connection account view.
2. While the per-connection query resolves (or in a slow-network throttling preset), confirm the loading state shows a centered spinner with a "Loading…" label underneath instead of the bare text.
3. With a screen reader enabled, confirm the loading state is still announced (the `role="status"` + `aria-live="polite"` wrapper is preserved).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?