### PR TITLE
Reader image carousel: keep long alt-text captions fully readable

### DIFF
--- a/packages/components/src/image-carousel/style.scss
+++ b/packages/components/src/image-carousel/style.scss
@@ -4,6 +4,10 @@
 	z-index: 9999;
 	background-color: #000;
 	transition: opacity 200ms ease-out;
+	// Flex column so the image area takes whatever vertical space is left
+	// after the (variable-height) footer renders its caption.
+	display: flex;
+	flex-direction: column;
 
 	@starting-style {
 		opacity: 0;
@@ -20,11 +24,8 @@
 
 .reader-image-carousel-wrap {
 	width: 100%;
-	height: calc(100vh - 64px);
-	
-	@media (max-width: 768px) {
-		height: calc(100vh - 100px);
-	}
+	flex: 1;
+	min-height: 0;
 
 	.swipeable__container {
 		height: 100%;
@@ -103,33 +104,48 @@
 }
 
 .reader-image-carousel-footer {
-	position: absolute;
-	bottom: 0;
-	left: 0;
-	right: 0;
 	z-index: 10001;
-	display: flex;
+	display: grid;
+	grid-template-columns: 1fr 1fr 1fr;
 	align-items: center;
 	width: 100%;
-	height: 64px;
+	min-height: 64px;
+	// Cap the footer at a third of the viewport so the image is never
+	// squeezed out by a very long caption — the caption itself scrolls
+	// inside its grid cell once it overflows.
+	max-height: 33vh;
 	padding: 16px;
 	color: #999;
 	font-size: 14px;
 	font-weight: 500;
 	box-sizing: border-box;
+	flex-shrink: 0;
 
 	> * {
-		width: 33.333%;
 		padding: 8px 12px;
 		box-sizing: border-box;
+		min-width: 0;
+	}
+
+	.reader-image-carousel-pagination {
+		grid-column: 1;
 	}
 
 	.reader-image-carousel-caption {
+		grid-column: 2;
 		text-align: center;
-	}
+		// Long captions (e.g. Bluesky alt text that mirrors the post body)
+		// can run for hundreds of words. Let the caption wrap freely up to
+		// the footer's max-height, then scroll inside the cell so the whole
+		// alt is readable without obscuring the image.
+		max-height: calc(33vh - 32px);
+		overflow-y: auto;
 
-	@media (max-width: 768px) {
-		bottom: 8px;
-		left: 8px;
+		// When the caption is the only child (single-image post), span the
+		// full footer width so the text has room to breathe rather than
+		// being squeezed into a left-aligned third.
+		&:only-child {
+			grid-column: 1 / -1;
+		}
 	}
 }


### PR DESCRIPTION
Fixes CM-702

## Proposed Changes

* `packages/components/src/image-carousel/style.scss` — switch the modal overlay to a flex column so the image-wrap and footer split the viewport based on their content, turn the footer into a 3-column grid with `min-height: 64px; max-height: 33vh`, and let the caption wrap freely up to that cap (scrolling inside its grid cell beyond it).
* Caption spans the full footer width when it's the only child (single-image posts) via `&:only-child { grid-column: 1 / -1 }`, and stays in the middle column when pagination is present.

## Why are these changes being made?

When a Bluesky / ATmosphere image post carries a long `alt` description (often the whole post body — e.g. Dave Winer's post on ATmosphere has ~1,214 chars of alt), the carousel footer caption used to spill out of its 64px-tall, 33%-wide slot onto the image, and pinned itself to the left third of the viewport with empty space on the right. That's not what the original "surface alt as a caption" intent was meant to look like.

## Testing Instructions

* Open the image modal on a Bluesky post with a long `alt` (e.g. `/reader/atmosphere/<connection-id>/thread/did:plc:oety7qbfx7x6exn2ytrwikmr/3mlbjtuqdg222` and click the image).
* Verify the caption wraps freely across the bottom of the modal, fully readable, with the image filling the remaining space above. The footer never exceeds ~33vh; if alt text is even longer than that, the caption scrolls inside its cell.
* Open an image modal on a regular Reader post (classic WordPress image gallery via `embed-container`). Captions there come from `img.dataset.imageCaption` and are typically short — the modal should look unchanged.
* Open a multi-image Bluesky post. Pagination (`N / M`) sits in the left third; caption is centered in the middle third; right third stays empty for visual balance (preserves the original 3-column layout when pagination is present).

## Notes

* The change affects both consumers of `ImageCarousel`: the ATmosphere image-embed (`client/reader/social/components/post-card/post-card-embed-images.tsx`) and the classic Reader image-gallery (`packages/components/src/embed-container/index.jsx`). In the embed-container case captions are typically short, so behavior there is effectively unchanged.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?