### PR TITLE
Renewal pricing: add new NON-EN/USD experiment assignment

### DIFF
--- a/client/my-sites/plans-features-main/hooks/test/use-renewal-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-renewal-price-experiment.ts
@@ -78,20 +78,47 @@ describe( 'useRenewalPricingExperiment', () => {
 		expect( result.current ).toEqual( [ true, null ] );
 	} );
 
+	it( 'blocks when V2 non-USD is loading', () => {
+		( useExperiment as jest.Mock )
+			.mockReturnValueOnce( [ false, null ] ) // V2 USD loaded
+			.mockReturnValueOnce( [ true, null ] ); // V2 non-USD loading
+		const { result } = renderHook( () => useRenewalPricingExperiment() );
+		expect( result.current ).toEqual( [ true, null ] );
+	} );
+
 	it( 'falls back to V1 when V2 is loaded and assignment is null (control)', () => {
 		( useExperiment as jest.Mock ).mockReturnValue( [ false, null ] );
 		const { result } = renderHook( () => useRenewalPricingExperiment() );
 		expect( result.current ).toEqual( [ false, 'crossed_price' ] );
 	} );
 
-	it( 'uses V2 variationName when assigned', () => {
-		( useExperiment as jest.Mock ).mockReturnValue( [ false, { variationName: 'variant_a' } ] );
+	it( 'uses V2 USD variationName when assigned', () => {
+		( useExperiment as jest.Mock )
+			.mockReturnValueOnce( [ false, { variationName: 'usd_variant' } ] ) // V2 USD assigned
+			.mockReturnValueOnce( [ false, null ] ); // V2 non-USD not assigned
 		const { result } = renderHook( () => useRenewalPricingExperiment() );
-		expect( result.current ).toEqual( [ false, 'variant_a' ] );
+		expect( result.current ).toEqual( [ false, 'usd_variant' ] );
 	} );
 
-	it( 'uses V1 when V2 is ineligible', () => {
-		( isJetpackCheckout as jest.Mock ).mockReturnValue( true ); // makes V2 ineligible by isEligibleForExperiment
+	it( 'uses V2 non-USD variationName when assigned', () => {
+		mockPlansWithCurrency( 'EUR' );
+		( useExperiment as jest.Mock )
+			.mockReturnValueOnce( [ false, null ] ) // V2 USD not assigned
+			.mockReturnValueOnce( [ false, { variationName: 'non_usd_variant' } ] ); // V2 non-USD assigned
+		const { result } = renderHook( () => useRenewalPricingExperiment() );
+		expect( result.current ).toEqual( [ false, 'non_usd_variant' ] );
+	} );
+
+	it( 'uses V2 non-USD assignment over V2 USD assignment', () => {
+		( useExperiment as jest.Mock )
+			.mockReturnValueOnce( [ false, { variationName: 'usd_variant' } ] ) // V2 USD assigned
+			.mockReturnValueOnce( [ false, { variationName: 'non_usd_variant' } ] ); // V2 non-USD assigned
+		const { result } = renderHook( () => useRenewalPricingExperiment() );
+		expect( result.current ).toEqual( [ false, 'non_usd_variant' ] );
+	} );
+
+	it( 'uses V1 when both V2s are ineligible', () => {
+		( isJetpackCheckout as jest.Mock ).mockReturnValue( true ); // makes both V2s ineligible by isEligibleForExperiment
 		const { result } = renderHook( () => useRenewalPricingExperiment() );
 		expect( result.current ).toEqual( [ false, null ] ); // V1 also ineligible because Jetpack checkout is excluded
 	} );

--- a/client/my-sites/plans-features-main/hooks/test/use-renewal-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-renewal-price-experiment.ts
@@ -79,9 +79,10 @@ describe( 'useRenewalPricingExperiment', () => {
 	} );
 
 	it( 'blocks when V2 non-USD is loading', () => {
+		mockPlansWithCurrency( 'EUR' ); // non-USD → V2 non-USD is eligible and may be loading
 		( useExperiment as jest.Mock )
-			.mockReturnValueOnce( [ false, null ] ) // V2 USD loaded
-			.mockReturnValueOnce( [ true, null ] ); // V2 non-USD loading
+			.mockReturnValueOnce( [ false, null ] ) // V2 USD: ineligible for EUR, returns immediately
+			.mockReturnValueOnce( [ true, null ] ); // V2 non-USD: eligible, still loading
 		const { result } = renderHook( () => useRenewalPricingExperiment() );
 		expect( result.current ).toEqual( [ true, null ] );
 	} );
@@ -124,21 +125,64 @@ describe( 'useRenewalPricingExperiment', () => {
 	} );
 
 	describe( 'locale gating', () => {
-		it( 'disqualifies non-English locales', () => {
+		it( 'disqualifies non-English locales from V1 and V2 USD', () => {
 			( useLocale as jest.Mock ).mockReturnValue( 'fr' );
+			// V2 non-USD is eligible for non-EN locale; mock returns null (control/not assigned)
 			const { result } = renderHook( () => useRenewalPricingExperiment() );
 			expect( result.current ).toEqual( [ false, null ] );
 		} );
 
-		it( 'qualifies English locale', () => {
+		it( 'qualifies English locale for V1', () => {
 			( useLocale as jest.Mock ).mockReturnValue( 'en' );
 			const { result } = renderHook( () => useRenewalPricingExperiment() );
 			expect( result.current[ 1 ] ).toBe( 'crossed_price' );
 		} );
+
+		it( 'skips V2 USD API call for non-EN locale', () => {
+			( useLocale as jest.Mock ).mockReturnValue( 'fr' );
+			renderHook( () => useRenewalPricingExperiment() );
+			expect( useExperiment ).toHaveBeenNthCalledWith(
+				1,
+				'wpcom_renewal_pricing_increase_v2_usd_202604_v1',
+				expect.objectContaining( { isEligible: false } )
+			);
+		} );
+
+		it( 'makes V2 non-USD API call for non-EN locale regardless of currency', () => {
+			( useLocale as jest.Mock ).mockReturnValue( 'fr' );
+			// USD currency — normally ineligible for non-USD experiment, but non-EN locale overrides
+			mockPlansWithCurrency( 'USD' );
+			renderHook( () => useRenewalPricingExperiment() );
+			expect( useExperiment ).toHaveBeenNthCalledWith(
+				2,
+				'wpcom_renewal_pricing_increase_v2_non_usd_202604_v1',
+				expect.objectContaining( { isEligible: true } )
+			);
+		} );
+
+		it( 'non-EN locale with V2 non-USD assignment returns that assignment', () => {
+			( useLocale as jest.Mock ).mockReturnValue( 'fr' );
+			( useExperiment as jest.Mock )
+				.mockReturnValueOnce( [ false, null ] ) // V2 USD: ineligible
+				.mockReturnValueOnce( [ false, { variationName: 'non_usd_variant' } ] ); // V2 non-USD assigned
+			const { result } = renderHook( () => useRenewalPricingExperiment() );
+			expect( result.current ).toEqual( [ false, 'non_usd_variant' ] );
+		} );
+
+		it( 'non-EN locale does not wait for plans to load before calling V2 non-USD API', () => {
+			( useLocale as jest.Mock ).mockReturnValue( 'fr' );
+			mockPlansWithCurrency( undefined ); // plans not yet loaded
+			renderHook( () => useRenewalPricingExperiment() );
+			expect( useExperiment ).toHaveBeenNthCalledWith(
+				2,
+				'wpcom_renewal_pricing_increase_v2_non_usd_202604_v1',
+				expect.objectContaining( { isEligible: true } )
+			);
+		} );
 	} );
 
 	describe( 'currency gating', () => {
-		it( 'disqualifies non-USD currencies', () => {
+		it( 'disqualifies non-USD currencies from V1', () => {
 			mockPlansWithCurrency( 'EUR' );
 			const { result } = renderHook( () => useRenewalPricingExperiment() );
 			expect( result.current ).toEqual( [ false, null ] );
@@ -148,6 +192,42 @@ describe( 'useRenewalPricingExperiment', () => {
 			mockPlansWithCurrency( undefined );
 			const { result } = renderHook( () => useRenewalPricingExperiment() );
 			expect( result.current ).toEqual( [ false, null ] );
+		} );
+
+		it( 'skips V2 non-USD API call for EN + USD users', () => {
+			// EN locale + USD currency → both conditions for non-USD experiment fail
+			renderHook( () => useRenewalPricingExperiment() );
+			expect( useExperiment ).toHaveBeenNthCalledWith(
+				2,
+				'wpcom_renewal_pricing_increase_v2_non_usd_202604_v1',
+				expect.objectContaining( { isEligible: false } )
+			);
+		} );
+
+		it( 'skips V2 USD API call for non-USD users', () => {
+			mockPlansWithCurrency( 'EUR' );
+			renderHook( () => useRenewalPricingExperiment() );
+			expect( useExperiment ).toHaveBeenNthCalledWith(
+				1,
+				'wpcom_renewal_pricing_increase_v2_usd_202604_v1',
+				expect.objectContaining( { isEligible: false } )
+			);
+		} );
+
+		it( 'skips both V2 API calls for EN locale when plans are not loaded', () => {
+			// EN locale: V2 USD needs currency=USD (not loaded), V2 non-USD needs currency≠USD (unknown)
+			mockPlansWithCurrency( undefined );
+			renderHook( () => useRenewalPricingExperiment() );
+			expect( useExperiment ).toHaveBeenNthCalledWith(
+				1,
+				'wpcom_renewal_pricing_increase_v2_usd_202604_v1',
+				expect.objectContaining( { isEligible: false } )
+			);
+			expect( useExperiment ).toHaveBeenNthCalledWith(
+				2,
+				'wpcom_renewal_pricing_increase_v2_non_usd_202604_v1',
+				expect.objectContaining( { isEligible: false } )
+			);
 		} );
 	} );
 

--- a/client/my-sites/plans-features-main/hooks/test/use-renewal-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-renewal-price-experiment.ts
@@ -110,14 +110,6 @@ describe( 'useRenewalPricingExperiment', () => {
 		expect( result.current ).toEqual( [ false, 'non_usd_variant' ] );
 	} );
 
-	it( 'uses V2 non-USD assignment over V2 USD assignment', () => {
-		( useExperiment as jest.Mock )
-			.mockReturnValueOnce( [ false, { variationName: 'usd_variant' } ] ) // V2 USD assigned
-			.mockReturnValueOnce( [ false, { variationName: 'non_usd_variant' } ] ); // V2 non-USD assigned
-		const { result } = renderHook( () => useRenewalPricingExperiment() );
-		expect( result.current ).toEqual( [ false, 'non_usd_variant' ] );
-	} );
-
 	it( 'uses V1 when both V2s are ineligible', () => {
 		( isJetpackCheckout as jest.Mock ).mockReturnValue( true ); // makes both V2s ineligible by isEligibleForExperiment
 		const { result } = renderHook( () => useRenewalPricingExperiment() );

--- a/client/my-sites/plans-features-main/hooks/use-renewal-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-renewal-price-experiment.ts
@@ -11,14 +11,14 @@ import { getCurrentUserDate } from 'calypso/state/current-user/selectors';
 const RENEWAL_PRICING_EXPERIMENT_V2_EN_USD = 'wpcom_renewal_pricing_increase_v2_usd_202604_v1';
 const RENEWAL_PRICING_EXPERIMENT_V2_NON_USD = 'wpcom_renewal_pricing_increase_v2_non_usd_202604_v1';
 
+function useCurrencyFromPlans(): string | undefined {
+	const plans = Plans.usePlans( { coupon: undefined } );
+	const firstPlan = plans.data && Object.values( plans.data )[ 0 ];
+	return firstPlan?.pricing?.currencyCode;
+}
+
 function useIsEligibleForV1EnUSDExperiment( flowName?: string | null ): [ boolean, string | null ] {
 	const REGISTRATION_DATE_CUTOFF = new Date( '2026-03-31T11:00:00Z' );
-
-	function useCurrencyFromPlans(): string | undefined {
-		const plans = Plans.usePlans( { coupon: undefined } );
-		const firstPlan = plans.data && Object.values( plans.data )[ 0 ];
-		return firstPlan?.pricing?.currencyCode;
-	}
 
 	function isNewUserOrLoggedOut( registrationDate: string | null | undefined ): boolean {
 		if ( ! registrationDate ) {
@@ -76,17 +76,25 @@ function isEligibleForExperiment( flowName?: string | null ): boolean {
 export function useRenewalPricingExperiment(
 	flowName?: string | null
 ): [ boolean, string | null ] {
+	const locale = useLocale();
+	const currencyCode = useCurrencyFromPlans();
 	const [ isLoadingV1, v1Variation ] = useIsEligibleForV1EnUSDExperiment( flowName );
 	const [ isLoadingV2EnUsd, v2EnUsdAssignment ] = useExperiment(
 		RENEWAL_PRICING_EXPERIMENT_V2_EN_USD,
 		{
-			isEligible: isEligibleForExperiment( flowName ),
+			// EN locale and USD currency required; skip until plans are loaded.
+			isEligible: locale === 'en' && currencyCode === 'USD' && isEligibleForExperiment( flowName ),
 		}
 	);
 	const [ isLoadingV2NonUsd, v2NonUsdAssignment ] = useExperiment(
 		RENEWAL_PRICING_EXPERIMENT_V2_NON_USD,
 		{
-			isEligible: isEligibleForExperiment( flowName ),
+			// Eligible when the user is either non-EN or non-USD. A non-EN locale
+			// is sufficient on its own (no need to wait for plans to load); for EN
+			// users we additionally wait for the currency to confirm it's non-USD.
+			isEligible:
+				( locale !== 'en' || ( currencyCode !== undefined && currencyCode !== 'USD' ) ) &&
+				isEligibleForExperiment( flowName ),
 		}
 	);
 	const isLoadingExperiment = isLoadingV1 || isLoadingV2EnUsd || isLoadingV2NonUsd;

--- a/client/my-sites/plans-features-main/hooks/use-renewal-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-renewal-price-experiment.ts
@@ -9,6 +9,7 @@ import { useSelector } from 'calypso/state';
 import { getCurrentUserDate } from 'calypso/state/current-user/selectors';
 
 const RENEWAL_PRICING_EXPERIMENT_V2_EN_USD = 'wpcom_renewal_pricing_increase_v2_usd_202604_v1';
+const RENEWAL_PRICING_EXPERIMENT_V2_NON_USD = 'wpcom_renewal_pricing_increase_v2_non_usd_202604_v1';
 
 function useIsEligibleForV1EnUSDExperiment( flowName?: string | null ): [ boolean, string | null ] {
 	const REGISTRATION_DATE_CUTOFF = new Date( '2026-03-31T11:00:00Z' );
@@ -82,8 +83,15 @@ export function useRenewalPricingExperiment(
 			isEligible: isEligibleForExperiment( flowName ),
 		}
 	);
-	const isLoadingExperiment = isLoadingV1 || isLoadingV2EnUsd;
-	const variationName = v2EnUsdAssignment?.variationName ?? v1Variation;
+	const [ isLoadingV2NonUsd, v2NonUsdAssignment ] = useExperiment(
+		RENEWAL_PRICING_EXPERIMENT_V2_NON_USD,
+		{
+			isEligible: isEligibleForExperiment( flowName ),
+		}
+	);
+	const isLoadingExperiment = isLoadingV1 || isLoadingV2EnUsd || isLoadingV2NonUsd;
+	const variationName =
+		v2NonUsdAssignment?.variationName ?? v2EnUsdAssignment?.variationName ?? v1Variation;
 	return [ isLoadingExperiment, isLoadingExperiment ? null : variationName ];
 }
 

--- a/client/my-sites/plans-features-main/hooks/use-renewal-price-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-renewal-price-experiment.ts
@@ -17,7 +17,11 @@ function useCurrencyFromPlans(): string | undefined {
 	return firstPlan?.pricing?.currencyCode;
 }
 
-function useIsEligibleForV1EnUSDExperiment( flowName?: string | null ): [ boolean, string | null ] {
+function useIsEligibleForV1EnUSDExperiment(
+	flowName: string | null | undefined,
+	locale: string,
+	currencyCode: string | undefined
+): [ boolean, string | null ] {
 	const REGISTRATION_DATE_CUTOFF = new Date( '2026-03-31T11:00:00Z' );
 
 	function isNewUserOrLoggedOut( registrationDate: string | null | undefined ): boolean {
@@ -28,8 +32,6 @@ function useIsEligibleForV1EnUSDExperiment( flowName?: string | null ): [ boolea
 		return new Date( registrationDate ) >= REGISTRATION_DATE_CUTOFF;
 	}
 
-	const locale = useLocale();
-	const currencyCode = useCurrencyFromPlans();
 	const userRegistrationDate = useSelector( getCurrentUserDate );
 
 	const flowFromStorage = getSignupCompleteFlowName();
@@ -78,7 +80,11 @@ export function useRenewalPricingExperiment(
 ): [ boolean, string | null ] {
 	const locale = useLocale();
 	const currencyCode = useCurrencyFromPlans();
-	const [ isLoadingV1, v1Variation ] = useIsEligibleForV1EnUSDExperiment( flowName );
+	const [ isLoadingV1, v1Variation ] = useIsEligibleForV1EnUSDExperiment(
+		flowName,
+		locale,
+		currencyCode
+	);
 	const [ isLoadingV2EnUsd, v2EnUsdAssignment ] = useExperiment(
 		RENEWAL_PRICING_EXPERIMENT_V2_EN_USD,
 		{


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-16881

## Proposed Changes

* Load the new experiment assignment, falling back to the previous pricing adjustment if no assignment is returned.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of the pricing experiment project.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Testing on Calypso.live or calypso.localhost, change your locale to non-English one or currency to non-USD, assign yourself to control, then test the /setup/onboarding/plans and /plans/{your site} routes to confirm that they match the current experience.
* Test with the treatment variants and confirm that the prices get updated correctly.
* Go to one of your sites and add a plan and a domain to the cart. 
* On Calypso.live or calypso.localhost, navigate to the checkout page and test the line items appearance and the TOS.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [X] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
