### PR TITLE
Dashboard: Show dark mode controls in new dashboard

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -910,7 +910,11 @@ export const appearanceRoute = createRoute( {
 	getParentRoute: () => preferencesRoute,
 	path: 'appearance',
 	beforeLoad: ( { context } ) => {
-		if ( ! context.config.supports.darkMode || isDashboardBackport() ) {
+		if (
+			! context.config.supports.darkMode ||
+			! context.config.supports.colorScheme ||
+			isDashboardBackport()
+		) {
 			throw dashboardRedirect( { to: '/me/preferences', replace: true } );
 		}
 	},
@@ -1141,7 +1145,7 @@ export const createMeRoutes = ( config: AppConfig ) => {
 	if ( config.optIn ) {
 		preferencesChildren.push( hostingDashboardRoute );
 	}
-	if ( config.supports.darkMode ) {
+	if ( config.supports.darkMode && config.supports.colorScheme ) {
 		preferencesChildren.push( appearanceRoute );
 	}
 	if ( isEnabled( 'mcp-settings' ) ) {

--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -36,6 +36,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { createRoute, createLazyRoute } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import { getMonetizeSubscriptionsPageTitle } from '../../me/billing-monetize-subscriptions/title';
+import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { reauthRequiredLink } from '../../utils/link';
 import {
 	getTitleForDisplay,
@@ -908,15 +909,8 @@ export const appearanceRoute = createRoute( {
 	} ),
 	getParentRoute: () => preferencesRoute,
 	path: 'appearance',
-	beforeLoad: async ( { context } ) => {
-		const preferences = await queryClient.ensureQueryData( rawUserPreferencesQuery() );
-		const optIn = preferences[ 'hosting-dashboard-opt-in' ];
-		const isDashboardEnrolled =
-			context.config.optIn &&
-			( optIn?.value === 'opt-in' ||
-				optIn?.value === 'forced-opt-in' ||
-				isEnabled( 'dashboard/forced-opt-in' ) );
-		if ( ! context.config.supports.colorScheme || ! isDashboardEnrolled ) {
+	beforeLoad: ( { context } ) => {
+		if ( ! context.config.supports.darkMode || isDashboardBackport() ) {
 			throw dashboardRedirect( { to: '/me/preferences', replace: true } );
 		}
 	},
@@ -1147,7 +1141,7 @@ export const createMeRoutes = ( config: AppConfig ) => {
 	if ( config.optIn ) {
 		preferencesChildren.push( hostingDashboardRoute );
 	}
-	if ( config.supports.colorScheme && config.optIn ) {
+	if ( config.supports.darkMode ) {
 		preferencesChildren.push( appearanceRoute );
 	}
 	if ( isEnabled( 'mcp-settings' ) ) {

--- a/client/dashboard/app/router/test/me.test.tsx
+++ b/client/dashboard/app/router/test/me.test.tsx
@@ -28,18 +28,37 @@ const dashboardConfig: AppConfig = {
 
 type RouteLike = {
 	path?: string;
-	options?: {
-		path?: string;
-	};
-	children?: RouteLike[];
+	options?: unknown;
+	children?: unknown[];
 };
 
-function hasRoutePath( routes: RouteLike[], path: string ): boolean {
+function getRouteOptionsPath( route: RouteLike ): string | undefined {
+	if (
+		route.options &&
+		typeof route.options === 'object' &&
+		'path' in route.options &&
+		typeof route.options.path === 'string'
+	) {
+		return route.options.path;
+	}
+}
+
+function getRouteChildren( route: unknown ): unknown[] {
+	if ( ! route || typeof route !== 'object' || ! ( 'children' in route ) ) {
+		return [];
+	}
+
+	return Array.isArray( route.children ) ? route.children : [];
+}
+
+function hasRoutePath( routes: unknown[], path: string ): boolean {
 	return routes.some(
 		( route ) =>
-			route.options?.path === path ||
-			route.path === path ||
-			hasRoutePath( route.children ?? [], path )
+			typeof route === 'object' &&
+			route !== null &&
+			( getRouteOptionsPath( route ) === path ||
+				( 'path' in route && route.path === path ) ||
+				( 'children' in route && hasRoutePath( getRouteChildren( route ), path ) ) )
 	);
 }
 

--- a/client/dashboard/app/router/test/me.test.tsx
+++ b/client/dashboard/app/router/test/me.test.tsx
@@ -67,3 +67,19 @@ test( 'does not register the appearance route when dark mode is not supported', 
 		)
 	).toBe( false );
 } );
+
+test( 'does not register the appearance route when color scheme is not supported', () => {
+	expect(
+		hasRoutePath(
+			createMeRoutes( {
+				...dashboardConfig,
+				supports: {
+					...dashboardConfig.supports,
+					colorScheme: false,
+					darkMode: true,
+				},
+			} ),
+			'appearance'
+		)
+	).toBe( false );
+} );

--- a/client/dashboard/app/router/test/me.test.tsx
+++ b/client/dashboard/app/router/test/me.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { isDashboardBackport } from '../../../utils/is-dashboard-backport';
+import { APP_CONTEXT_DEFAULT_CONFIG, type AppConfig } from '../../context';
+import { createMeRoutes } from '../me';
+
+jest.mock( '../../../utils/is-dashboard-backport', () => ( {
+	isDashboardBackport: jest.fn( () => false ),
+} ) );
+
+const mockIsDashboardBackport = jest.mocked( isDashboardBackport );
+
+const dashboardConfig: AppConfig = {
+	...APP_CONTEXT_DEFAULT_CONFIG,
+	supports: {
+		...APP_CONTEXT_DEFAULT_CONFIG.supports,
+		me: {
+			billing: false,
+			security: false,
+			apps: false,
+		},
+		colorScheme: true,
+		darkMode: true,
+	},
+};
+
+type RouteLike = {
+	path?: string;
+	options?: {
+		path?: string;
+	};
+	children?: RouteLike[];
+};
+
+function hasRoutePath( routes: RouteLike[], path: string ): boolean {
+	return routes.some(
+		( route ) =>
+			route.options?.path === path ||
+			route.path === path ||
+			hasRoutePath( route.children ?? [], path )
+	);
+}
+
+beforeEach( () => {
+	mockIsDashboardBackport.mockReturnValue( false );
+} );
+
+test( 'registers the appearance route in the Dashboard backport so deep links can redirect', () => {
+	mockIsDashboardBackport.mockReturnValue( true );
+
+	expect( hasRoutePath( createMeRoutes( dashboardConfig ), 'appearance' ) ).toBe( true );
+} );
+
+test( 'does not register the appearance route when dark mode is not supported', () => {
+	expect(
+		hasRoutePath(
+			createMeRoutes( {
+				...dashboardConfig,
+				supports: {
+					...dashboardConfig.supports,
+					darkMode: false,
+				},
+			} ),
+			'appearance'
+		)
+	).toBe( false );
+} );

--- a/client/dashboard/components/dark-mode-announcement/index.tsx
+++ b/client/dashboard/components/dark-mode-announcement/index.tsx
@@ -20,7 +20,12 @@ export function useShouldShowDarkModeAnnouncement() {
 		userPreferenceQuery( DISMISSED_PREFERENCE )
 	);
 
-	return config.supports.darkMode && ! isDashboardBackport() && ! isDismissedPersisted;
+	return (
+		config.supports.darkMode &&
+		config.supports.colorScheme &&
+		! isDashboardBackport() &&
+		! isDismissedPersisted
+	);
 }
 
 function DarkModeAnnouncementContent( { tracksContext }: { tracksContext: string } ) {

--- a/client/dashboard/components/dark-mode-announcement/index.tsx
+++ b/client/dashboard/components/dark-mode-announcement/index.tsx
@@ -1,5 +1,4 @@
 import { userPreferenceMutation, userPreferenceQuery } from '@automattic/api-queries';
-import { isEnabled } from '@automattic/calypso-config';
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { Button } from '@wordpress/components';
@@ -8,6 +7,7 @@ import { __ } from '@wordpress/i18n';
 import { useAnalytics } from '../../app/analytics';
 import { useColorScheme } from '../../app/color-scheme';
 import { useAppContext } from '../../app/context';
+import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { ButtonStack } from '../button-stack';
 import ComponentViewTracker from '../component-view-tracker';
 import Notice from '../notice';
@@ -16,18 +16,11 @@ const DISMISSED_PREFERENCE = 'hosting-dashboard-dark-mode-announcement-dismissed
 
 export function useShouldShowDarkModeAnnouncement() {
 	const config = useAppContext();
-	const { data: dashboardOptIn } = useSuspenseQuery(
-		userPreferenceQuery( 'hosting-dashboard-opt-in' )
-	);
 	const { data: isDismissedPersisted } = useSuspenseQuery(
 		userPreferenceQuery( DISMISSED_PREFERENCE )
 	);
-	const isDashboardEnrolled =
-		dashboardOptIn?.value === 'opt-in' ||
-		dashboardOptIn?.value === 'forced-opt-in' ||
-		isEnabled( 'dashboard/forced-opt-in' );
 
-	return config.optIn && config.supports.darkMode && isDashboardEnrolled && ! isDismissedPersisted;
+	return config.supports.darkMode && ! isDashboardBackport() && ! isDismissedPersisted;
 }
 
 function DarkModeAnnouncementContent( { tracksContext }: { tracksContext: string } ) {

--- a/client/dashboard/components/dark-mode-announcement/test/index.test.tsx
+++ b/client/dashboard/components/dark-mode-announcement/test/index.test.tsx
@@ -260,6 +260,28 @@ test( 'does not render when dark mode is not supported by the Dashboard config',
 	} );
 } );
 
+test( 'does not render when color scheme is not supported by the Dashboard config', async () => {
+	renderAnnouncement(
+		{
+			'hosting-dashboard-opt-in': optInPreference,
+		},
+		{
+			...dashboardConfig,
+			supports: {
+				...dashboardConfig.supports,
+				colorScheme: false,
+				darkMode: true,
+			},
+		}
+	);
+
+	await waitFor( () => {
+		expect(
+			screen.queryByText( /Dark mode support is now available in the dashboard/i )
+		).not.toBeInTheDocument();
+	} );
+} );
+
 test( 'dismisses without saving a color-scheme preference', async () => {
 	const user = userEvent.setup();
 	nock( API_BASE )

--- a/client/dashboard/components/dark-mode-announcement/test/index.test.tsx
+++ b/client/dashboard/components/dark-mode-announcement/test/index.test.tsx
@@ -3,7 +3,6 @@
  */
 
 import { queryClient, rawUserPreferencesQuery } from '@automattic/api-queries';
-import { isEnabled } from '@automattic/calypso-config';
 import '@testing-library/jest-dom';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -12,15 +11,11 @@ import { DarkModeAnnouncement } from '..';
 import { ColorSchemeProvider } from '../../../app/color-scheme';
 import { AppProvider, APP_CONTEXT_DEFAULT_CONFIG } from '../../../app/context';
 import { render } from '../../../test-utils';
+import { isDashboardBackport } from '../../../utils/is-dashboard-backport';
 
-jest.mock( '@automattic/calypso-config', () => {
-	const config = jest.fn( () => 'development' );
-	return Object.assign( config, {
-		__esModule: true,
-		default: config,
-		isEnabled: jest.fn( () => false ),
-	} );
-} );
+jest.mock( '../../../utils/is-dashboard-backport', () => ( {
+	isDashboardBackport: jest.fn( () => false ),
+} ) );
 
 const API_BASE = 'https://public-api.wordpress.com';
 const PREFERENCES_PATH = '/rest/v1.1/me/preferences';
@@ -31,22 +26,23 @@ const optInPreference = {
 	value: 'opt-in',
 	updated_at: '2026-05-08T00:00:00.000Z',
 };
-const mockIsEnabled = jest.mocked( isEnabled );
+const mockIsDashboardBackport = jest.mocked( isDashboardBackport );
 const mockUpdatePreference = jest.fn();
 const dashboardConfig = {
 	...APP_CONTEXT_DEFAULT_CONFIG,
 	optIn: true,
 	supports: {
 		...APP_CONTEXT_DEFAULT_CONFIG.supports,
+		colorScheme: true,
 		darkMode: true,
 	},
 };
 
-const renderAnnouncement = ( preferences: Record< string, unknown > ) => {
+const renderAnnouncement = ( preferences: Record< string, unknown >, config = dashboardConfig ) => {
 	queryClient.setQueryData( rawUserPreferencesQuery().queryKey, preferences );
 
 	return render(
-		<AppProvider config={ dashboardConfig }>
+		<AppProvider config={ config }>
 			<ColorSchemeProvider>
 				<DarkModeAnnouncement tracksContext="sites" />
 			</ColorSchemeProvider>
@@ -82,7 +78,7 @@ beforeEach( () => {
 } );
 
 afterEach( () => {
-	mockIsEnabled.mockReturnValue( false );
+	mockIsDashboardBackport.mockReturnValue( false );
 	document.documentElement.removeAttribute( 'data-theme' );
 } );
 
@@ -194,10 +190,10 @@ test( 'renders when the saved color scheme is invalid', async () => {
 	expect( document.documentElement.dataset.theme ).toBe( 'light' );
 } );
 
-test( 'renders for a forced opted-in user without a saved color scheme', async () => {
+test( 'renders when the user has opted out of the Hosting Dashboard', async () => {
 	renderAnnouncement( {
 		'hosting-dashboard-opt-in': {
-			value: 'forced-opt-in',
+			value: 'opt-out',
 			updated_at: '2026-05-08T00:00:00.000Z',
 		},
 	} );
@@ -207,15 +203,8 @@ test( 'renders for a forced opted-in user without a saved color scheme', async (
 	).toBeVisible();
 } );
 
-test( 'renders when the forced opt-in flag enrolls the user', async () => {
-	mockIsEnabled.mockReturnValue( true );
-
-	renderAnnouncement( {
-		'hosting-dashboard-opt-in': {
-			value: 'unset',
-			updated_at: '',
-		},
-	} );
+test( 'renders when the opt-in preference is missing', async () => {
+	renderAnnouncement( {} );
 
 	expect(
 		await screen.findByText( /Dark mode support is now available in the dashboard/i )
@@ -235,13 +224,34 @@ test( 'does not render when the announcement was already dismissed', async () =>
 	} );
 } );
 
-test( 'does not render when the user is not enrolled in the Hosting Dashboard', async () => {
+test( 'does not render in the Dashboard backport', async () => {
+	mockIsDashboardBackport.mockReturnValue( true );
+
 	renderAnnouncement( {
-		'hosting-dashboard-opt-in': {
-			value: 'opt-out',
-			updated_at: '2026-05-08T00:00:00.000Z',
-		},
+		'hosting-dashboard-opt-in': optInPreference,
 	} );
+
+	await waitFor( () => {
+		expect(
+			screen.queryByText( /Dark mode support is now available in the dashboard/i )
+		).not.toBeInTheDocument();
+	} );
+} );
+
+test( 'does not render when dark mode is not supported by the Dashboard config', async () => {
+	renderAnnouncement(
+		{
+			'hosting-dashboard-opt-in': optInPreference,
+		},
+		{
+			...dashboardConfig,
+			supports: {
+				...dashboardConfig.supports,
+				colorScheme: true,
+				darkMode: false,
+			},
+		}
+	);
 
 	await waitFor( () => {
 		expect(

--- a/client/dashboard/me/preferences-appearance/index.tsx
+++ b/client/dashboard/me/preferences-appearance/index.tsx
@@ -1,13 +1,10 @@
-import { userPreferenceQuery } from '@automattic/api-queries';
-import { isEnabled } from '@automattic/calypso-config';
-import { useQuery } from '@tanstack/react-query';
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { styles } from '@wordpress/icons';
 import { useColorScheme, type ColorScheme } from '../../app/color-scheme';
 import { useAppContext } from '../../app/context';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
-import type { AppConfig } from '../../app/context';
+import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import type { Density } from '@automattic/components/src/summary-button/types';
 
 function getColorSchemeLabel( colorScheme: ColorScheme ) {
@@ -21,33 +18,8 @@ function getColorSchemeLabel( colorScheme: ColorScheme ) {
 	}
 }
 
-function PreferencesAppearanceSummary( {
-	density,
-	config,
-}: {
-	density?: Density;
-	config: AppConfig;
-} ) {
-	const {
-		data: optIn,
-		isLoading,
-		isError,
-	} = useQuery( userPreferenceQuery( 'hosting-dashboard-opt-in' ) );
+function PreferencesAppearanceSummary( { density }: { density?: Density } ) {
 	const { colorScheme } = useColorScheme();
-
-	if ( isLoading || isError ) {
-		return null;
-	}
-
-	const isDashboardEnrolled =
-		config.optIn &&
-		( optIn?.value === 'opt-in' ||
-			optIn?.value === 'forced-opt-in' ||
-			isEnabled( 'dashboard/forced-opt-in' ) );
-
-	if ( ! isDashboardEnrolled ) {
-		return null;
-	}
 
 	return (
 		<RouterLinkSummaryButton
@@ -64,9 +36,9 @@ function PreferencesAppearanceSummary( {
 export default function PreferencesAppearance( { density }: { density?: Density } ) {
 	const config = useAppContext();
 
-	if ( ! config.supports.colorScheme ) {
+	if ( ! config.supports.darkMode || isDashboardBackport() ) {
 		return null;
 	}
 
-	return <PreferencesAppearanceSummary density={ density } config={ config } />;
+	return <PreferencesAppearanceSummary density={ density } />;
 }

--- a/client/dashboard/me/preferences-appearance/index.tsx
+++ b/client/dashboard/me/preferences-appearance/index.tsx
@@ -36,7 +36,7 @@ function PreferencesAppearanceSummary( { density }: { density?: Density } ) {
 export default function PreferencesAppearance( { density }: { density?: Density } ) {
 	const config = useAppContext();
 
-	if ( ! config.supports.darkMode || isDashboardBackport() ) {
+	if ( ! config.supports.darkMode || ! config.supports.colorScheme || isDashboardBackport() ) {
 		return null;
 	}
 

--- a/client/dashboard/me/preferences-appearance/test/index.test.tsx
+++ b/client/dashboard/me/preferences-appearance/test/index.test.tsx
@@ -93,3 +93,20 @@ test( 'does not render when dark mode is not supported', async () => {
 		).not.toBeInTheDocument();
 	} );
 } );
+
+test( 'does not render when color scheme is not supported', async () => {
+	renderPreferencesAppearance( {
+		...dashboardConfig,
+		supports: {
+			...dashboardConfig.supports,
+			colorScheme: false,
+			darkMode: true,
+		},
+	} );
+
+	await waitFor( () => {
+		expect(
+			screen.queryByRole( 'link', { name: /Appearance \(Experimental\)/i } )
+		).not.toBeInTheDocument();
+	} );
+} );

--- a/client/dashboard/me/preferences-appearance/test/index.test.tsx
+++ b/client/dashboard/me/preferences-appearance/test/index.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { queryClient, rawUserPreferencesQuery } from '@automattic/api-queries';
+import '@testing-library/jest-dom';
+import { screen, waitFor } from '@testing-library/react';
+import PreferencesAppearance from '..';
+import { ColorSchemeProvider } from '../../../app/color-scheme';
+import { AppProvider, APP_CONTEXT_DEFAULT_CONFIG } from '../../../app/context';
+import { render } from '../../../test-utils';
+import { isDashboardBackport } from '../../../utils/is-dashboard-backport';
+
+jest.mock( '../../../utils/is-dashboard-backport', () => ( {
+	isDashboardBackport: jest.fn( () => false ),
+} ) );
+
+const mockIsDashboardBackport = jest.mocked( isDashboardBackport );
+
+const dashboardConfig = {
+	...APP_CONTEXT_DEFAULT_CONFIG,
+	supports: {
+		...APP_CONTEXT_DEFAULT_CONFIG.supports,
+		colorScheme: true,
+		darkMode: true,
+	},
+};
+
+function renderPreferencesAppearance( config = dashboardConfig ) {
+	queryClient.setQueryData( rawUserPreferencesQuery().queryKey, {
+		'hosting-dashboard-opt-in': {
+			value: 'opt-out',
+			updated_at: '2026-05-11T00:00:00.000Z',
+		},
+		'hosting-dashboard-color-scheme': 'dark',
+	} );
+
+	return render(
+		<AppProvider config={ config }>
+			<ColorSchemeProvider>
+				<PreferencesAppearance />
+			</ColorSchemeProvider>
+		</AppProvider>,
+		{ queryClient }
+	);
+}
+
+beforeEach( () => {
+	queryClient.clear();
+	queryClient.setDefaultOptions( {
+		queries: { retry: false },
+	} );
+	mockIsDashboardBackport.mockReturnValue( false );
+} );
+
+afterEach( () => {
+	document.documentElement.removeAttribute( 'data-theme' );
+} );
+
+test( 'renders when dark mode is supported regardless of opt-in preference', async () => {
+	renderPreferencesAppearance();
+
+	expect(
+		await screen.findByRole( 'link', { name: /Appearance \(Experimental\)/i } )
+	).toHaveAttribute( 'href', '/me/preferences/appearance' );
+	expect( screen.getByText( 'Dark' ) ).toBeVisible();
+} );
+
+test( 'does not render in the Dashboard backport', async () => {
+	mockIsDashboardBackport.mockReturnValue( true );
+
+	renderPreferencesAppearance();
+
+	await waitFor( () => {
+		expect(
+			screen.queryByRole( 'link', { name: /Appearance \(Experimental\)/i } )
+		).not.toBeInTheDocument();
+	} );
+} );
+
+test( 'does not render when dark mode is not supported', async () => {
+	renderPreferencesAppearance( {
+		...dashboardConfig,
+		supports: {
+			...dashboardConfig.supports,
+			darkMode: false,
+		},
+	} );
+
+	await waitFor( () => {
+		expect(
+			screen.queryByRole( 'link', { name: /Appearance \(Experimental\)/i } )
+		).not.toBeInTheDocument();
+	} );
+} );

--- a/client/dashboard/me/preferences/index.tsx
+++ b/client/dashboard/me/preferences/index.tsx
@@ -27,7 +27,7 @@ export default function Preferences() {
 		>
 			<SummaryButtonList>
 				{ optIn ? <PreferencesNewHostingDashboard /> : null }
-				{ isEnabled( 'dark-mode' ) ? <PreferencesAppearance /> : null }
+				<PreferencesAppearance />
 				{ isEnabled( 'mcp-settings' ) ? <PreferencesAiMcp /> : null }
 				<PreferencesLanguage />
 				<PreferencesDefaults />


### PR DESCRIPTION
## Proposed Changes

* Show the dark mode announcement and Appearance setting in the new Hosting Dashboard whenever dark mode is supported.
* Keep both hidden in old Calypso dashboard/backport screens.
* Add tests for opt-out visibility, backport hiding, and dark-mode support gating.

## Why are these changes being made?

These controls belong to the new Hosting Dashboard experience, but they were still gated by the hosting-dashboard opt-in preference. This makes their visibility follow Dashboard dark-mode support instead, allowing people to try it out even if they didn't opt-in.

## Testing Instructions

* In the new Hosting Dashboard, verify the announcement and Appearance setting are visible when dark mode is supported even if the user hasn't opted in.
* In old Calypso/backport dashboard screens, verify both remain hidden.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
