### PR TITLE
Image Studio: Confirmation dialog before sharing Reel to Instagram

### DIFF
--- a/packages/image-studio/src/components/generate-layout/share-reel-action/index.test.tsx
+++ b/packages/image-studio/src/components/generate-layout/share-reel-action/index.test.tsx
@@ -1,8 +1,9 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { ShareReelAction } from './index';
 
 const mockUseReelShare = jest.fn();
 const mockUseGenericShare = jest.fn();
+const mockDialogProps = jest.fn();
 
 jest.mock( '../../../hooks/use-reel-share', () => ( {
 	useReelShare: () => mockUseReelShare(),
@@ -35,31 +36,10 @@ jest.mock( '@wordpress/components', () => ( {
 	},
 } ) );
 
-jest.mock( '../../confirmation-dialog', () => ( {
-	ConfirmationDialog: ( {
-		isOpen,
-		title,
-		actions,
-		children,
-	}: {
-		isOpen: boolean;
-		title?: string;
-		actions: Array< { text: string; onClick: () => void } >;
-		children: React.ReactNode;
-	} ) => {
-		if ( ! isOpen ) {
-			return null;
-		}
-		return (
-			<div role="dialog" aria-label={ title }>
-				<p>{ children }</p>
-				{ actions.map( ( a ) => (
-					<button key={ a.text } onClick={ a.onClick }>
-						{ a.text }
-					</button>
-				) ) }
-			</div>
-		);
+jest.mock( '../../reel-share-confirmation-dialog', () => ( {
+	ReelShareConfirmationDialog: ( props: Record< string, unknown > ) => {
+		mockDialogProps( props );
+		return props.isOpen ? <div role="dialog" /> : null;
 	},
 } ) );
 
@@ -160,73 +140,40 @@ describe( '<ShareReelAction />', () => {
 		expect( handleShare ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	describe( 'confirmation dialog', () => {
-		it( 'is hidden when isConfirming is false', () => {
-			render( <ShareReelAction /> );
-			expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
-		} );
-
-		it( 'is shown when isConfirming is true', () => {
-			mockUseReelShare.mockReturnValue( {
-				...visibleReel,
-				isConfirming: true,
-				igDisplayName: 'myhandle',
-			} );
-			render( <ShareReelAction /> );
-			expect( screen.getByRole( 'dialog', { name: /Share to Instagram/i } ) ).toBeInTheDocument();
-		} );
-
-		it( 'shows the connected account handle in the body when present, wrapped in <strong>', () => {
-			mockUseReelShare.mockReturnValue( {
-				...visibleReel,
-				isConfirming: true,
-				igDisplayName: 'myhandle',
-			} );
-			render( <ShareReelAction /> );
-
-			const dialog = screen.getByRole( 'dialog' );
-			expect( dialog ).toHaveTextContent( /published to myhandle on Instagram/i );
-
-			const handle = screen.getByText( 'myhandle' );
-			expect( handle.tagName ).toBe( 'STRONG' );
-		} );
-
-		it( 'shows a generic fallback body when no handle is available', () => {
-			mockUseReelShare.mockReturnValue( {
-				...visibleReel,
-				isConfirming: true,
-				igDisplayName: null,
-			} );
-			render( <ShareReelAction /> );
-			expect(
-				screen.getByText( /published to your connected Instagram account/i )
-			).toBeInTheDocument();
-		} );
-
-		it( 'invokes confirmShare when Share is clicked', () => {
+	describe( 'confirmation dialog wiring', () => {
+		it( 'passes through reel state and handlers as props', () => {
 			const confirmShare = jest.fn();
-			mockUseReelShare.mockReturnValue( {
-				...visibleReel,
-				isConfirming: true,
-				igDisplayName: 'myhandle',
-				confirmShare,
-			} );
-			render( <ShareReelAction /> );
-			fireEvent.click( screen.getByRole( 'button', { name: 'Share' } ) );
-			expect( confirmShare ).toHaveBeenCalledTimes( 1 );
-		} );
-
-		it( 'invokes cancelShare when Cancel is clicked', () => {
 			const cancelShare = jest.fn();
 			mockUseReelShare.mockReturnValue( {
 				...visibleReel,
 				isConfirming: true,
 				igDisplayName: 'myhandle',
+				confirmShare,
 				cancelShare,
 			} );
+
 			render( <ShareReelAction /> );
-			fireEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
-			expect( cancelShare ).toHaveBeenCalledTimes( 1 );
+
+			expect( mockDialogProps ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					isOpen: true,
+					igDisplayName: 'myhandle',
+					onConfirm: confirmShare,
+					onCancel: cancelShare,
+				} )
+			);
+			expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+		} );
+
+		it( 'passes isOpen=false when reel.isConfirming is false', () => {
+			mockUseReelShare.mockReturnValue( { ...visibleReel, isConfirming: false } );
+
+			render( <ShareReelAction /> );
+
+			expect( mockDialogProps ).toHaveBeenCalledWith(
+				expect.objectContaining( { isOpen: false } )
+			);
+			expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
 		} );
 	} );
 } );

--- a/packages/image-studio/src/components/generate-layout/share-reel-action/index.test.tsx
+++ b/packages/image-studio/src/components/generate-layout/share-reel-action/index.test.tsx
@@ -35,6 +35,34 @@ jest.mock( '@wordpress/components', () => ( {
 	},
 } ) );
 
+jest.mock( '../../confirmation-dialog', () => ( {
+	ConfirmationDialog: ( {
+		isOpen,
+		title,
+		actions,
+		children,
+	}: {
+		isOpen: boolean;
+		title?: string;
+		actions: Array< { text: string; onClick: () => void } >;
+		children: React.ReactNode;
+	} ) => {
+		if ( ! isOpen ) {
+			return null;
+		}
+		return (
+			<div role="dialog" aria-label={ title }>
+				<p>{ children }</p>
+				{ actions.map( ( a ) => (
+					<button key={ a.text } onClick={ a.onClick }>
+						{ a.text }
+					</button>
+				) ) }
+			</div>
+		);
+	},
+} ) );
+
 jest.mock( 'social-logos', () => ( {
 	SocialLogo: ( { icon, size }: { icon: string; size: number } ) => (
 		<span data-testid="social-logo" data-icon={ icon } data-size={ size } />
@@ -42,11 +70,13 @@ jest.mock( 'social-logos', () => ( {
 } ) );
 
 const visibleReel = {
-	canShare: true,
-	reason: null,
 	isVisible: true,
 	isSharing: false,
-	handleShare: jest.fn(),
+	isConfirming: false,
+	igDisplayName: null as string | null,
+	requestShare: jest.fn(),
+	confirmShare: jest.fn(),
+	cancelShare: jest.fn(),
 };
 
 const visibleGeneric = {
@@ -58,8 +88,8 @@ const visibleGeneric = {
 describe( '<ShareReelAction />', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
-		mockUseReelShare.mockReturnValue( visibleReel );
-		mockUseGenericShare.mockReturnValue( visibleGeneric );
+		mockUseReelShare.mockReturnValue( { ...visibleReel } );
+		mockUseGenericShare.mockReturnValue( { ...visibleGeneric } );
 	} );
 
 	it( 'renders nothing when both share modes are hidden', () => {
@@ -110,13 +140,15 @@ describe( '<ShareReelAction />', () => {
 		expect( screen.getByRole( 'button', { name: /Sharing to other apps/i } ) ).toBeDisabled();
 	} );
 
-	it( 'invokes handleShare on IG click', () => {
-		const handleShare = jest.fn();
-		mockUseReelShare.mockReturnValue( { ...visibleReel, handleShare } );
+	it( 'invokes requestShare on IG click (does not dispatch yet)', () => {
+		const requestShare = jest.fn();
+		const confirmShare = jest.fn();
+		mockUseReelShare.mockReturnValue( { ...visibleReel, requestShare, confirmShare } );
 
 		render( <ShareReelAction /> );
 		fireEvent.click( screen.getByRole( 'button', { name: /Share on Instagram/i } ) );
-		expect( handleShare ).toHaveBeenCalledTimes( 1 );
+		expect( requestShare ).toHaveBeenCalledTimes( 1 );
+		expect( confirmShare ).not.toHaveBeenCalled();
 	} );
 
 	it( 'invokes generic handleShare on share-icon click', () => {
@@ -126,5 +158,75 @@ describe( '<ShareReelAction />', () => {
 		render( <ShareReelAction /> );
 		fireEvent.click( screen.getByRole( 'button', { name: /Share to other apps/i } ) );
 		expect( handleShare ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	describe( 'confirmation dialog', () => {
+		it( 'is hidden when isConfirming is false', () => {
+			render( <ShareReelAction /> );
+			expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'is shown when isConfirming is true', () => {
+			mockUseReelShare.mockReturnValue( {
+				...visibleReel,
+				isConfirming: true,
+				igDisplayName: 'myhandle',
+			} );
+			render( <ShareReelAction /> );
+			expect( screen.getByRole( 'dialog', { name: /Share to Instagram/i } ) ).toBeInTheDocument();
+		} );
+
+		it( 'shows the connected account handle in the body when present, wrapped in <strong>', () => {
+			mockUseReelShare.mockReturnValue( {
+				...visibleReel,
+				isConfirming: true,
+				igDisplayName: 'myhandle',
+			} );
+			render( <ShareReelAction /> );
+
+			const dialog = screen.getByRole( 'dialog' );
+			expect( dialog ).toHaveTextContent( /published to myhandle on Instagram/i );
+
+			const handle = screen.getByText( 'myhandle' );
+			expect( handle.tagName ).toBe( 'STRONG' );
+		} );
+
+		it( 'shows a generic fallback body when no handle is available', () => {
+			mockUseReelShare.mockReturnValue( {
+				...visibleReel,
+				isConfirming: true,
+				igDisplayName: null,
+			} );
+			render( <ShareReelAction /> );
+			expect(
+				screen.getByText( /published to your connected Instagram account/i )
+			).toBeInTheDocument();
+		} );
+
+		it( 'invokes confirmShare when Share is clicked', () => {
+			const confirmShare = jest.fn();
+			mockUseReelShare.mockReturnValue( {
+				...visibleReel,
+				isConfirming: true,
+				igDisplayName: 'myhandle',
+				confirmShare,
+			} );
+			render( <ShareReelAction /> );
+			fireEvent.click( screen.getByRole( 'button', { name: 'Share' } ) );
+			expect( confirmShare ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'invokes cancelShare when Cancel is clicked', () => {
+			const cancelShare = jest.fn();
+			mockUseReelShare.mockReturnValue( {
+				...visibleReel,
+				isConfirming: true,
+				igDisplayName: 'myhandle',
+				cancelShare,
+			} );
+			render( <ShareReelAction /> );
+			fireEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+			expect( cancelShare ).toHaveBeenCalledTimes( 1 );
+		} );
 	} );
 } );

--- a/packages/image-studio/src/components/generate-layout/share-reel-action/index.tsx
+++ b/packages/image-studio/src/components/generate-layout/share-reel-action/index.tsx
@@ -1,9 +1,11 @@
 import { Button } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { share } from '@wordpress/icons';
 import { SocialLogo } from 'social-logos';
 import { useGenericShare } from '../../../hooks/use-generic-share';
 import { useReelShare } from '../../../hooks/use-reel-share';
+import { ConfirmationDialog } from '../../confirmation-dialog';
 import './style.scss';
 
 export function ShareReelAction(): JSX.Element | null {
@@ -21,6 +23,16 @@ export function ShareReelAction(): JSX.Element | null {
 	const genericAriaLabel = generic.isSharing
 		? __( 'Sharing to other apps…', __i18n_text_domain__ )
 		: __( 'Share to other apps', __i18n_text_domain__ );
+
+	const confirmBody = reel.igDisplayName
+		? createInterpolateElement(
+				__( 'This Reel will be published to <account /> on Instagram.', __i18n_text_domain__ ),
+				{ account: <strong>{ reel.igDisplayName }</strong> }
+		  )
+		: __(
+				'This Reel will be published to your connected Instagram account.',
+				__i18n_text_domain__
+		  );
 
 	return (
 		<div
@@ -47,9 +59,28 @@ export function ShareReelAction(): JSX.Element | null {
 					showTooltip
 					disabled={ reel.isSharing }
 					isBusy={ reel.isSharing }
-					onClick={ reel.handleShare }
+					onClick={ reel.requestShare }
 				/>
 			) }
+			<ConfirmationDialog
+				isOpen={ reel.isConfirming }
+				title={ __( 'Share to Instagram?', __i18n_text_domain__ ) }
+				actions={ [
+					{
+						text: __( 'Cancel', __i18n_text_domain__ ),
+						onClick: reel.cancelShare,
+						variant: 'tertiary',
+					},
+					{
+						text: __( 'Share', __i18n_text_domain__ ),
+						onClick: reel.confirmShare,
+						variant: 'primary',
+					},
+				] }
+				onClose={ reel.cancelShare }
+			>
+				{ confirmBody }
+			</ConfirmationDialog>
 		</div>
 	);
 }

--- a/packages/image-studio/src/components/generate-layout/share-reel-action/index.tsx
+++ b/packages/image-studio/src/components/generate-layout/share-reel-action/index.tsx
@@ -1,11 +1,10 @@
 import { Button } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { share } from '@wordpress/icons';
 import { SocialLogo } from 'social-logos';
 import { useGenericShare } from '../../../hooks/use-generic-share';
 import { useReelShare } from '../../../hooks/use-reel-share';
-import { ConfirmationDialog } from '../../confirmation-dialog';
+import { ReelShareConfirmationDialog } from '../../reel-share-confirmation-dialog';
 import './style.scss';
 
 export function ShareReelAction(): JSX.Element | null {
@@ -23,16 +22,6 @@ export function ShareReelAction(): JSX.Element | null {
 	const genericAriaLabel = generic.isSharing
 		? __( 'Sharing to other apps…', __i18n_text_domain__ )
 		: __( 'Share to other apps', __i18n_text_domain__ );
-
-	const confirmBody = reel.igDisplayName
-		? createInterpolateElement(
-				__( 'This Reel will be published to <account /> on Instagram.', __i18n_text_domain__ ),
-				{ account: <strong>{ reel.igDisplayName }</strong> }
-		  )
-		: __(
-				'This Reel will be published to your connected Instagram account.',
-				__i18n_text_domain__
-		  );
 
 	return (
 		<div
@@ -62,25 +51,12 @@ export function ShareReelAction(): JSX.Element | null {
 					onClick={ reel.requestShare }
 				/>
 			) }
-			<ConfirmationDialog
+			<ReelShareConfirmationDialog
 				isOpen={ reel.isConfirming }
-				title={ __( 'Share to Instagram?', __i18n_text_domain__ ) }
-				actions={ [
-					{
-						text: __( 'Cancel', __i18n_text_domain__ ),
-						onClick: reel.cancelShare,
-						variant: 'tertiary',
-					},
-					{
-						text: __( 'Share', __i18n_text_domain__ ),
-						onClick: reel.confirmShare,
-						variant: 'primary',
-					},
-				] }
-				onClose={ reel.cancelShare }
-			>
-				{ confirmBody }
-			</ConfirmationDialog>
+				igDisplayName={ reel.igDisplayName }
+				onConfirm={ reel.confirmShare }
+				onCancel={ reel.cancelShare }
+			/>
 		</div>
 	);
 }

--- a/packages/image-studio/src/components/reel-share-confirmation-dialog/index.test.tsx
+++ b/packages/image-studio/src/components/reel-share-confirmation-dialog/index.test.tsx
@@ -1,0 +1,107 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ReelShareConfirmationDialog } from './index';
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( str: string ) => str,
+} ) );
+
+jest.mock( '../confirmation-dialog', () => ( {
+	ConfirmationDialog: ( {
+		isOpen,
+		title,
+		actions,
+		children,
+	}: {
+		isOpen: boolean;
+		title?: string;
+		actions: Array< { text: string; onClick: () => void } >;
+		children: React.ReactNode;
+	} ) => {
+		if ( ! isOpen ) {
+			return null;
+		}
+		return (
+			<div role="dialog" aria-label={ title }>
+				<p>{ children }</p>
+				{ actions.map( ( a ) => (
+					<button key={ a.text } onClick={ a.onClick }>
+						{ a.text }
+					</button>
+				) ) }
+			</div>
+		);
+	},
+} ) );
+
+describe( '<ReelShareConfirmationDialog />', () => {
+	const baseProps = {
+		isOpen: true,
+		igDisplayName: null as string | null,
+		onConfirm: jest.fn(),
+		onCancel: jest.fn(),
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'renders nothing when isOpen is false', () => {
+		render( <ReelShareConfirmationDialog { ...baseProps } isOpen={ false } /> );
+		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the dialog with the expected title when isOpen is true', () => {
+		render( <ReelShareConfirmationDialog { ...baseProps } /> );
+		expect( screen.getByRole( 'dialog', { name: /Share to Instagram/i } ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows the connected account handle wrapped in <strong>', () => {
+		render( <ReelShareConfirmationDialog { ...baseProps } igDisplayName="myhandle" /> );
+
+		const dialog = screen.getByRole( 'dialog' );
+		expect( dialog ).toHaveTextContent( /published to myhandle on Instagram/i );
+
+		const handle = screen.getByText( 'myhandle' );
+		expect( handle.tagName ).toBe( 'STRONG' );
+	} );
+
+	it( 'falls back to a generic body when no handle is provided', () => {
+		render( <ReelShareConfirmationDialog { ...baseProps } igDisplayName={ null } /> );
+		expect(
+			screen.getByText( /published to your connected Instagram account/i )
+		).toBeInTheDocument();
+	} );
+
+	it( 'falls back to a generic body for empty-string handles', () => {
+		render( <ReelShareConfirmationDialog { ...baseProps } igDisplayName="" /> );
+		expect(
+			screen.getByText( /published to your connected Instagram account/i )
+		).toBeInTheDocument();
+	} );
+
+	it( 'invokes onConfirm when Share is clicked', () => {
+		const onConfirm = jest.fn();
+		render(
+			<ReelShareConfirmationDialog
+				{ ...baseProps }
+				igDisplayName="myhandle"
+				onConfirm={ onConfirm }
+			/>
+		);
+		fireEvent.click( screen.getByRole( 'button', { name: 'Share' } ) );
+		expect( onConfirm ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'invokes onCancel when Cancel is clicked', () => {
+		const onCancel = jest.fn();
+		render(
+			<ReelShareConfirmationDialog
+				{ ...baseProps }
+				igDisplayName="myhandle"
+				onCancel={ onCancel }
+			/>
+		);
+		fireEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+		expect( onCancel ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/packages/image-studio/src/components/reel-share-confirmation-dialog/index.tsx
+++ b/packages/image-studio/src/components/reel-share-confirmation-dialog/index.tsx
@@ -17,7 +17,7 @@ export function ReelShareConfirmationDialog( {
 }: ReelShareConfirmationDialogProps ): JSX.Element {
 	const body = igDisplayName
 		? createInterpolateElement(
-				__( 'This Reel will be published to <account /> on Instagram.', __i18n_text_domain__ ),
+				__( 'This video will be published to <account /> on Instagram.', __i18n_text_domain__ ),
 				{ account: <strong>{ igDisplayName }</strong> }
 		  )
 		: __(

--- a/packages/image-studio/src/components/reel-share-confirmation-dialog/index.tsx
+++ b/packages/image-studio/src/components/reel-share-confirmation-dialog/index.tsx
@@ -1,0 +1,49 @@
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { ConfirmationDialog } from '../confirmation-dialog';
+
+interface ReelShareConfirmationDialogProps {
+	isOpen: boolean;
+	igDisplayName: string | null;
+	onConfirm: () => void;
+	onCancel: () => void;
+}
+
+export function ReelShareConfirmationDialog( {
+	isOpen,
+	igDisplayName,
+	onConfirm,
+	onCancel,
+}: ReelShareConfirmationDialogProps ): JSX.Element {
+	const body = igDisplayName
+		? createInterpolateElement(
+				__( 'This Reel will be published to <account /> on Instagram.', __i18n_text_domain__ ),
+				{ account: <strong>{ igDisplayName }</strong> }
+		  )
+		: __(
+				'This Reel will be published to your connected Instagram account.',
+				__i18n_text_domain__
+		  );
+
+	return (
+		<ConfirmationDialog
+			isOpen={ isOpen }
+			title={ __( 'Share to Instagram?', __i18n_text_domain__ ) }
+			actions={ [
+				{
+					text: __( 'Cancel', __i18n_text_domain__ ),
+					onClick: onCancel,
+					variant: 'tertiary',
+				},
+				{
+					text: __( 'Share', __i18n_text_domain__ ),
+					onClick: onConfirm,
+					variant: 'primary',
+				},
+			] }
+			onClose={ onCancel }
+		>
+			{ body }
+		</ConfirmationDialog>
+	);
+}

--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
@@ -25,7 +25,11 @@ let mockMedia: Record< string, unknown > | null = null;
 let mockHasResolvedMedia = true;
 let mockReelVisible = false;
 let mockGenericVisible = false;
-const mockReelHandleShare = jest.fn();
+let mockReelIsConfirming = false;
+let mockReelIgDisplayName: string | null = null;
+const mockReelRequestShare = jest.fn();
+const mockReelConfirmShare = jest.fn();
+const mockReelCancelShare = jest.fn();
 const mockGenericHandleShare = jest.fn();
 
 jest.mock( '@wordpress/components', () => ( {
@@ -117,8 +121,40 @@ jest.mock( '../hooks/use-reel-share', () => ( {
 	useReelShare: () => ( {
 		isVisible: mockReelVisible,
 		isSharing: false,
-		handleShare: mockReelHandleShare,
+		isConfirming: mockReelIsConfirming,
+		igDisplayName: mockReelIgDisplayName,
+		requestShare: mockReelRequestShare,
+		confirmShare: mockReelConfirmShare,
+		cancelShare: mockReelCancelShare,
 	} ),
+} ) );
+
+jest.mock( '../components/confirmation-dialog', () => ( {
+	ConfirmationDialog: ( {
+		isOpen,
+		title,
+		actions,
+		children,
+	}: {
+		isOpen: boolean;
+		title?: string;
+		actions: Array< { text: string; onClick: () => void } >;
+		children: React.ReactNode;
+	} ) => {
+		if ( ! isOpen ) {
+			return null;
+		}
+		return (
+			<div role="dialog" aria-label={ title }>
+				<p>{ children }</p>
+				{ actions.map( ( a ) => (
+					<button key={ a.text } onClick={ a.onClick }>
+						{ a.text }
+					</button>
+				) ) }
+			</div>
+		);
+	},
 } ) );
 
 jest.mock( '../hooks/use-generic-share', () => ( {
@@ -153,7 +189,9 @@ describe( 'feature-clip-sidebar-extension', () => {
 		mockSetCurrentVideoUrl.mockClear();
 		mockSetCurrentAttachmentId.mockClear();
 		mockSetCurrentDurationSeconds.mockClear();
-		mockReelHandleShare.mockClear();
+		mockReelRequestShare.mockClear();
+		mockReelConfirmShare.mockClear();
+		mockReelCancelShare.mockClear();
 		mockGenericHandleShare.mockClear();
 		mockInsertBlocks.mockClear();
 		mockCreateBlock.mockClear();
@@ -162,6 +200,8 @@ describe( 'feature-clip-sidebar-extension', () => {
 		mockHasResolvedMedia = true;
 		mockReelVisible = false;
 		mockGenericVisible = false;
+		mockReelIsConfirming = false;
+		mockReelIgDisplayName = null;
 		( window as Record< string, unknown > ).imageStudioData = { isDevMode: true };
 		jest.resetModules();
 	} );
@@ -292,7 +332,7 @@ describe( 'feature-clip-sidebar-extension', () => {
 			expect( screen.getByRole( 'button', { name: /^Share$/i } ) ).toBeInTheDocument();
 		} );
 
-		it( 'invokes handleShare on share button clicks', () => {
+		it( 'invokes requestShare on the IG button and handleShare on the generic button', () => {
 			setupClip();
 			mockReelVisible = true;
 			mockGenericVisible = true;
@@ -300,10 +340,63 @@ describe( 'feature-clip-sidebar-extension', () => {
 			render( <FeatureClipPanel /> );
 
 			fireEvent.click( screen.getByRole( 'button', { name: /Share on Instagram/i } ) );
-			expect( mockReelHandleShare ).toHaveBeenCalledTimes( 1 );
+			expect( mockReelRequestShare ).toHaveBeenCalledTimes( 1 );
+			expect( mockReelConfirmShare ).not.toHaveBeenCalled();
 
 			fireEvent.click( screen.getByRole( 'button', { name: /^Share$/i } ) );
 			expect( mockGenericHandleShare ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'hides the confirmation dialog when isConfirming is false', () => {
+			setupClip();
+			mockReelVisible = true;
+			mockReelIsConfirming = false;
+			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			render( <FeatureClipPanel /> );
+			expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'shows the confirmation dialog with the connected account (in <strong>) when isConfirming is true', () => {
+			setupClip();
+			mockReelVisible = true;
+			mockReelIsConfirming = true;
+			mockReelIgDisplayName = 'myhandle';
+			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			render( <FeatureClipPanel /> );
+
+			const dialog = screen.getByRole( 'dialog', { name: /Share to Instagram/i } );
+			expect( dialog ).toHaveTextContent( /published to myhandle on Instagram/i );
+
+			const handle = screen.getByText( 'myhandle' );
+			expect( handle.tagName ).toBe( 'STRONG' );
+		} );
+
+		it( 'falls back to a generic body when no handle is available', () => {
+			setupClip();
+			mockReelVisible = true;
+			mockReelIsConfirming = true;
+			mockReelIgDisplayName = null;
+			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			render( <FeatureClipPanel /> );
+
+			expect(
+				screen.getByText( /published to your connected Instagram account/i )
+			).toBeInTheDocument();
+		} );
+
+		it( 'invokes confirmShare on Share click and cancelShare on Cancel click', () => {
+			setupClip();
+			mockReelVisible = true;
+			mockReelIsConfirming = true;
+			mockReelIgDisplayName = 'myhandle';
+			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			render( <FeatureClipPanel /> );
+
+			fireEvent.click( screen.getByRole( 'button', { name: 'Share' } ) );
+			expect( mockReelConfirmShare ).toHaveBeenCalledTimes( 1 );
+
+			fireEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+			expect( mockReelCancelShare ).toHaveBeenCalledTimes( 1 );
 		} );
 
 		it( 'opens Image Studio on Regenerate click', async () => {

--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
@@ -129,31 +129,12 @@ jest.mock( '../hooks/use-reel-share', () => ( {
 	} ),
 } ) );
 
-jest.mock( '../components/confirmation-dialog', () => ( {
-	ConfirmationDialog: ( {
-		isOpen,
-		title,
-		actions,
-		children,
-	}: {
-		isOpen: boolean;
-		title?: string;
-		actions: Array< { text: string; onClick: () => void } >;
-		children: React.ReactNode;
-	} ) => {
-		if ( ! isOpen ) {
-			return null;
-		}
-		return (
-			<div role="dialog" aria-label={ title }>
-				<p>{ children }</p>
-				{ actions.map( ( a ) => (
-					<button key={ a.text } onClick={ a.onClick }>
-						{ a.text }
-					</button>
-				) ) }
-			</div>
-		);
+const mockDialogProps = jest.fn();
+
+jest.mock( '../components/reel-share-confirmation-dialog', () => ( {
+	ReelShareConfirmationDialog: ( props: Record< string, unknown > ) => {
+		mockDialogProps( props );
+		return props.isOpen ? <div role="dialog" /> : null;
 	},
 } ) );
 
@@ -193,6 +174,7 @@ describe( 'feature-clip-sidebar-extension', () => {
 		mockReelConfirmShare.mockClear();
 		mockReelCancelShare.mockClear();
 		mockGenericHandleShare.mockClear();
+		mockDialogProps.mockClear();
 		mockInsertBlocks.mockClear();
 		mockCreateBlock.mockClear();
 		mockMeta = {};
@@ -347,56 +329,36 @@ describe( 'feature-clip-sidebar-extension', () => {
 			expect( mockGenericHandleShare ).toHaveBeenCalledTimes( 1 );
 		} );
 
-		it( 'hides the confirmation dialog when isConfirming is false', () => {
+		it( 'passes reel state and handlers to the confirmation dialog', () => {
+			setupClip();
+			mockReelVisible = true;
+			mockReelIsConfirming = true;
+			mockReelIgDisplayName = 'myhandle';
+			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			render( <FeatureClipPanel /> );
+
+			expect( mockDialogProps ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					isOpen: true,
+					igDisplayName: 'myhandle',
+					onConfirm: mockReelConfirmShare,
+					onCancel: mockReelCancelShare,
+				} )
+			);
+			expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+		} );
+
+		it( 'passes isOpen=false to the confirmation dialog when reel.isConfirming is false', () => {
 			setupClip();
 			mockReelVisible = true;
 			mockReelIsConfirming = false;
 			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
 			render( <FeatureClipPanel /> );
+
+			expect( mockDialogProps ).toHaveBeenCalledWith(
+				expect.objectContaining( { isOpen: false } )
+			);
 			expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
-		} );
-
-		it( 'shows the confirmation dialog with the connected account (in <strong>) when isConfirming is true', () => {
-			setupClip();
-			mockReelVisible = true;
-			mockReelIsConfirming = true;
-			mockReelIgDisplayName = 'myhandle';
-			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
-			render( <FeatureClipPanel /> );
-
-			const dialog = screen.getByRole( 'dialog', { name: /Share to Instagram/i } );
-			expect( dialog ).toHaveTextContent( /published to myhandle on Instagram/i );
-
-			const handle = screen.getByText( 'myhandle' );
-			expect( handle.tagName ).toBe( 'STRONG' );
-		} );
-
-		it( 'falls back to a generic body when no handle is available', () => {
-			setupClip();
-			mockReelVisible = true;
-			mockReelIsConfirming = true;
-			mockReelIgDisplayName = null;
-			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
-			render( <FeatureClipPanel /> );
-
-			expect(
-				screen.getByText( /published to your connected Instagram account/i )
-			).toBeInTheDocument();
-		} );
-
-		it( 'invokes confirmShare on Share click and cancelShare on Cancel click', () => {
-			setupClip();
-			mockReelVisible = true;
-			mockReelIsConfirming = true;
-			mockReelIgDisplayName = 'myhandle';
-			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
-			render( <FeatureClipPanel /> );
-
-			fireEvent.click( screen.getByRole( 'button', { name: 'Share' } ) );
-			expect( mockReelConfirmShare ).toHaveBeenCalledTimes( 1 );
-
-			fireEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
-			expect( mockReelCancelShare ).toHaveBeenCalledTimes( 1 );
 		} );
 
 		it( 'opens Image Studio on Regenerate click', async () => {

--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
@@ -13,13 +13,12 @@ import { Button } from '@wordpress/components';
 import { useEntityProp } from '@wordpress/core-data';
 import { dispatch, useSelect } from '@wordpress/data';
 import { PluginDocumentSettingPanel } from '@wordpress/editor';
-import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { share } from '@wordpress/icons';
 import { registerPlugin } from '@wordpress/plugins';
 import { SocialLogo } from 'social-logos';
-import { ConfirmationDialog } from '../components/confirmation-dialog';
 import { ExperimentalBadge } from '../components/experimental-badge';
+import { ReelShareConfirmationDialog } from '../components/reel-share-confirmation-dialog';
 import { useGenericShare } from '../hooks/use-generic-share';
 import { useReelShare } from '../hooks/use-reel-share';
 import { ImageStudioEntryPoint, store as imageStudioStore } from '../store';
@@ -84,16 +83,6 @@ function FeatureClipPreview( {
 		? __( 'Sharing…', __i18n_text_domain__ )
 		: __( 'Share', __i18n_text_domain__ );
 
-	const confirmBody = reel.igDisplayName
-		? createInterpolateElement(
-				__( 'This Reel will be published to <account /> on Instagram.', __i18n_text_domain__ ),
-				{ account: <strong>{ reel.igDisplayName }</strong> }
-		  )
-		: __(
-				'This Reel will be published to your connected Instagram account.',
-				__i18n_text_domain__
-		  );
-
 	const handleAddToPost = () => {
 		const { insertBlocks } = dispatch( 'core/block-editor' ) as {
 			insertBlocks?: ( blocks: unknown ) => void;
@@ -141,25 +130,12 @@ function FeatureClipPreview( {
 					{ reelLabel }
 				</Button>
 			) }
-			<ConfirmationDialog
+			<ReelShareConfirmationDialog
 				isOpen={ reel.isConfirming }
-				title={ __( 'Share to Instagram?', __i18n_text_domain__ ) }
-				actions={ [
-					{
-						text: __( 'Cancel', __i18n_text_domain__ ),
-						onClick: reel.cancelShare,
-						variant: 'tertiary',
-					},
-					{
-						text: __( 'Share', __i18n_text_domain__ ),
-						onClick: reel.confirmShare,
-						variant: 'primary',
-					},
-				] }
-				onClose={ reel.cancelShare }
-			>
-				{ confirmBody }
-			</ConfirmationDialog>
+				igDisplayName={ reel.igDisplayName }
+				onConfirm={ reel.confirmShare }
+				onCancel={ reel.cancelShare }
+			/>
 			<div className="image-studio-feature-clip-panel__bottom-actions">
 				<Button
 					variant="secondary"

--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
@@ -13,10 +13,12 @@ import { Button } from '@wordpress/components';
 import { useEntityProp } from '@wordpress/core-data';
 import { dispatch, useSelect } from '@wordpress/data';
 import { PluginDocumentSettingPanel } from '@wordpress/editor';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { share } from '@wordpress/icons';
 import { registerPlugin } from '@wordpress/plugins';
 import { SocialLogo } from 'social-logos';
+import { ConfirmationDialog } from '../components/confirmation-dialog';
 import { ExperimentalBadge } from '../components/experimental-badge';
 import { useGenericShare } from '../hooks/use-generic-share';
 import { useReelShare } from '../hooks/use-reel-share';
@@ -82,6 +84,16 @@ function FeatureClipPreview( {
 		? __( 'Sharing…', __i18n_text_domain__ )
 		: __( 'Share', __i18n_text_domain__ );
 
+	const confirmBody = reel.igDisplayName
+		? createInterpolateElement(
+				__( 'This Reel will be published to <account /> on Instagram.', __i18n_text_domain__ ),
+				{ account: <strong>{ reel.igDisplayName }</strong> }
+		  )
+		: __(
+				'This Reel will be published to your connected Instagram account.',
+				__i18n_text_domain__
+		  );
+
 	const handleAddToPost = () => {
 		const { insertBlocks } = dispatch( 'core/block-editor' ) as {
 			insertBlocks?: ( blocks: unknown ) => void;
@@ -124,11 +136,30 @@ function FeatureClipPreview( {
 					__next40pxDefaultSize
 					disabled={ reel.isSharing }
 					isBusy={ reel.isSharing }
-					onClick={ reel.handleShare }
+					onClick={ reel.requestShare }
 				>
 					{ reelLabel }
 				</Button>
 			) }
+			<ConfirmationDialog
+				isOpen={ reel.isConfirming }
+				title={ __( 'Share to Instagram?', __i18n_text_domain__ ) }
+				actions={ [
+					{
+						text: __( 'Cancel', __i18n_text_domain__ ),
+						onClick: reel.cancelShare,
+						variant: 'tertiary',
+					},
+					{
+						text: __( 'Share', __i18n_text_domain__ ),
+						onClick: reel.confirmShare,
+						variant: 'primary',
+					},
+				] }
+				onClose={ reel.cancelShare }
+			>
+				{ confirmBody }
+			</ConfirmationDialog>
 			<div className="image-studio-feature-clip-panel__bottom-actions">
 				<Button
 					variant="secondary"

--- a/packages/image-studio/src/hooks/use-reel-share/index.test.ts
+++ b/packages/image-studio/src/hooks/use-reel-share/index.test.ts
@@ -1,5 +1,11 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { act, renderHook } from '@testing-library/react';
 import { useReelShare } from './index';
+
+( globalThis as Record< string, unknown > ).__i18n_text_domain__ = 'default';
 
 // Tracking spies
 const mockTrackClicked = jest.fn();
@@ -9,6 +15,7 @@ const mockTrackNotPublished = jest.fn();
 const mockTrackInvalidState = jest.fn();
 const mockTrackDispatched = jest.fn();
 const mockTrackFailed = jest.fn();
+const mockTrackCancelled = jest.fn();
 
 // Store action spies
 const mockEditPost = jest.fn();
@@ -16,7 +23,13 @@ const mockShareCurrentPost = jest.fn();
 const mockAddNotice = jest.fn();
 
 // Selector state — mutable per-test
-type Connection = { connection_id: string; service_name: string; enabled: boolean };
+type Connection = {
+	connection_id: string;
+	service_name: string;
+	enabled: boolean;
+	display_name?: string;
+	external_handle?: string;
+};
 
 let mockState: {
 	currentVideoUrl: string | null;
@@ -86,6 +99,7 @@ jest.mock( '@wordpress/element', () => {
 	return {
 		useCallback: ( fn: ( ...args: unknown[] ) => unknown ) => fn,
 		useRef: React.useRef,
+		useState: React.useState,
 	};
 } );
 
@@ -124,12 +138,14 @@ jest.mock( '../../utils/tracking', () => ( {
 	trackImageStudioReelShareInvalidState: () => mockTrackInvalidState(),
 	trackImageStudioReelShareDispatched: () => mockTrackDispatched(),
 	trackImageStudioReelShareFailed: ( ...args: unknown[] ) => mockTrackFailed( ...args ),
+	trackImageStudioReelShareCancelled: () => mockTrackCancelled(),
 } ) );
 
 const igConnection: Connection = {
 	connection_id: '1001',
 	service_name: 'instagram-business',
 	enabled: true,
+	display_name: 'myhandle',
 };
 const twitterConnection: Connection = {
 	connection_id: '1002',
@@ -194,61 +210,68 @@ describe( 'useReelShare', () => {
 		} );
 	} );
 
-	describe( 'handleShare — happy path', () => {
-		it( 'writes attached_media and media_source then dispatches shareCurrentPost with non-IG connections skipped', async () => {
+	describe( 'requestShare — gates the confirmation', () => {
+		it( 'opens the confirmation without dispatching when validation passes', async () => {
 			const { result } = renderHook( () => useReelShare() );
 
 			await act( async () => {
-				await result.current.handleShare();
+				await result.current.requestShare();
 			} );
 
 			expect( mockTrackClicked ).toHaveBeenCalledWith( {
 				attachmentId: 555,
 				durationSeconds: 12,
 			} );
+			expect( mockEditPost ).not.toHaveBeenCalled();
+			expect( mockShareCurrentPost ).not.toHaveBeenCalled();
+			expect( result.current.isConfirming ).toBe( true );
+			expect( result.current.igDisplayName ).toBe( 'myhandle' );
+		} );
 
-			expect( mockEditPost ).toHaveBeenCalledWith( {
-				meta: {
-					jetpack_social_options: {
-						version: 2,
-						attached_media: [ { id: 555, url: 'https://example.com/clip.mp4', type: 'video/mp4' } ],
-						media_source: 'upload-video',
-					},
+		it( 'resolves igDisplayName from external_handle when display_name is missing', async () => {
+			mockState.connections = [
+				{
+					connection_id: '1001',
+					service_name: 'instagram-business',
+					enabled: true,
+					external_handle: '@brand',
 				},
-			} );
-
-			expect( mockShareCurrentPost ).toHaveBeenCalledWith(
-				{ message: '', skipped_connections: [ '1002' ] },
-				{ savePost: true, apiPath: '/wpcom/v2/publicize/share-post/{postId}' }
-			);
-
-			expect( mockTrackDispatched ).toHaveBeenCalledTimes( 1 );
-			expect( mockTrackFailed ).not.toHaveBeenCalled();
-		} );
-
-		it( 'shows a success notice when shareCurrentPost resolves truthy', async () => {
+				twitterConnection,
+			];
 			const { result } = renderHook( () => useReelShare() );
-			await act( async () => {
-				await result.current.handleShare();
-			} );
-			expect( mockAddNotice ).toHaveBeenCalledWith(
-				expect.stringMatching( /Reel shared to Instagram/i ),
-				'success'
-			);
-		} );
-	} );
 
-	describe( 'handleShare — pre-check gates', () => {
+			await act( async () => {
+				await result.current.requestShare();
+			} );
+
+			expect( result.current.igDisplayName ).toBe( '@brand' );
+		} );
+
+		it( 'resolves igDisplayName to null when neither field is present on the connection', async () => {
+			mockState.connections = [
+				{ connection_id: '1001', service_name: 'instagram-business', enabled: true },
+				twitterConnection,
+			];
+			const { result } = renderHook( () => useReelShare() );
+
+			await act( async () => {
+				await result.current.requestShare();
+			} );
+
+			expect( result.current.igDisplayName ).toBeNull();
+		} );
+
 		it( 'shows a no-connection notice with action when IG is not connected', async () => {
 			mockState.connections = [ twitterConnection ];
 			const { result } = renderHook( () => useReelShare() );
 
 			await act( async () => {
-				await result.current.handleShare();
+				await result.current.requestShare();
 			} );
 
 			expect( mockEditPost ).not.toHaveBeenCalled();
 			expect( mockShareCurrentPost ).not.toHaveBeenCalled();
+			expect( result.current.isConfirming ).toBe( false );
 			expect( mockTrackNotConnected ).toHaveBeenCalledTimes( 1 );
 			expect( mockTrackConnectionDisabled ).not.toHaveBeenCalled();
 			expect( mockAddNotice ).toHaveBeenCalledWith(
@@ -269,11 +292,11 @@ describe( 'useReelShare', () => {
 			const { result } = renderHook( () => useReelShare() );
 
 			await act( async () => {
-				await result.current.handleShare();
+				await result.current.requestShare();
 			} );
 
 			expect( mockEditPost ).not.toHaveBeenCalled();
-			expect( mockShareCurrentPost ).not.toHaveBeenCalled();
+			expect( result.current.isConfirming ).toBe( false );
 			expect( mockTrackConnectionDisabled ).toHaveBeenCalledTimes( 1 );
 			expect( mockTrackNotConnected ).not.toHaveBeenCalled();
 			expect( mockAddNotice ).toHaveBeenCalledWith(
@@ -289,11 +312,11 @@ describe( 'useReelShare', () => {
 			const { result } = renderHook( () => useReelShare() );
 
 			await act( async () => {
-				await result.current.handleShare();
+				await result.current.requestShare();
 			} );
 
 			expect( mockEditPost ).not.toHaveBeenCalled();
-			expect( mockShareCurrentPost ).not.toHaveBeenCalled();
+			expect( result.current.isConfirming ).toBe( false );
 			expect( mockTrackNotPublished ).toHaveBeenCalledTimes( 1 );
 			expect( mockAddNotice ).toHaveBeenCalledWith(
 				expect.stringMatching( /Publish this post first/i ),
@@ -308,11 +331,11 @@ describe( 'useReelShare', () => {
 			const { result } = renderHook( () => useReelShare() );
 
 			await act( async () => {
-				await result.current.handleShare();
+				await result.current.requestShare();
 			} );
 
 			expect( mockEditPost ).not.toHaveBeenCalled();
-			expect( mockShareCurrentPost ).not.toHaveBeenCalled();
+			expect( result.current.isConfirming ).toBe( false );
 			expect( mockTrackInvalidState ).toHaveBeenCalledTimes( 1 );
 			expect( mockAddNotice ).toHaveBeenCalledWith(
 				expect.stringMatching( /Generate a video first/i ),
@@ -321,13 +344,73 @@ describe( 'useReelShare', () => {
 		} );
 	} );
 
-	describe( 'handleShare — failure', () => {
+	describe( 'confirmShare — happy path', () => {
+		it( 'writes attached_media and dispatches shareCurrentPost with non-IG connections skipped', async () => {
+			const { result } = renderHook( () => useReelShare() );
+
+			await act( async () => {
+				await result.current.requestShare();
+			} );
+			await act( async () => {
+				await result.current.confirmShare();
+			} );
+
+			expect( mockEditPost ).toHaveBeenCalledWith( {
+				meta: {
+					jetpack_social_options: {
+						version: 2,
+						attached_media: [ { id: 555, url: 'https://example.com/clip.mp4', type: 'video/mp4' } ],
+						media_source: 'upload-video',
+					},
+				},
+			} );
+
+			expect( mockShareCurrentPost ).toHaveBeenCalledWith(
+				{ message: '', skipped_connections: [ '1002' ] },
+				{ savePost: true, apiPath: '/wpcom/v2/publicize/share-post/{postId}' }
+			);
+
+			expect( mockTrackDispatched ).toHaveBeenCalledTimes( 1 );
+			expect( mockTrackFailed ).not.toHaveBeenCalled();
+			expect( result.current.isConfirming ).toBe( false );
+		} );
+
+		it( 'shows a success notice when shareCurrentPost resolves truthy', async () => {
+			const { result } = renderHook( () => useReelShare() );
+			await act( async () => {
+				await result.current.requestShare();
+			} );
+			await act( async () => {
+				await result.current.confirmShare();
+			} );
+			expect( mockAddNotice ).toHaveBeenCalledWith(
+				expect.stringMatching( /Reel shared to Instagram/i ),
+				'success'
+			);
+		} );
+
+		it( 'is a no-op when confirmShare is called without a pending request', async () => {
+			const { result } = renderHook( () => useReelShare() );
+
+			await act( async () => {
+				await result.current.confirmShare();
+			} );
+
+			expect( mockEditPost ).not.toHaveBeenCalled();
+			expect( mockShareCurrentPost ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'confirmShare — failure', () => {
 		it( 'tracks reel_share_failed when shareCurrentPost resolves falsy', async () => {
 			mockShareCurrentPost.mockResolvedValueOnce( false );
 			const { result } = renderHook( () => useReelShare() );
 
 			await act( async () => {
-				await result.current.handleShare();
+				await result.current.requestShare();
+			} );
+			await act( async () => {
+				await result.current.confirmShare();
 			} );
 
 			expect( mockTrackFailed ).toHaveBeenCalledTimes( 1 );
@@ -339,11 +422,43 @@ describe( 'useReelShare', () => {
 			const { result } = renderHook( () => useReelShare() );
 
 			await act( async () => {
-				await result.current.handleShare();
+				await result.current.requestShare();
+			} );
+			await act( async () => {
+				await result.current.confirmShare();
 			} );
 
 			expect( mockTrackFailed ).toHaveBeenCalledWith( 'boom' );
 			expect( mockTrackDispatched ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'cancelShare', () => {
+		it( 'clears isConfirming and fires the cancelled tracker', async () => {
+			const { result } = renderHook( () => useReelShare() );
+
+			await act( async () => {
+				await result.current.requestShare();
+			} );
+			expect( result.current.isConfirming ).toBe( true );
+
+			act( () => {
+				result.current.cancelShare();
+			} );
+
+			expect( result.current.isConfirming ).toBe( false );
+			expect( mockTrackCancelled ).toHaveBeenCalledTimes( 1 );
+			expect( mockShareCurrentPost ).not.toHaveBeenCalled();
+		} );
+
+		it( 'does not fire the cancelled tracker when there was no pending request', () => {
+			const { result } = renderHook( () => useReelShare() );
+
+			act( () => {
+				result.current.cancelShare();
+			} );
+
+			expect( mockTrackCancelled ).not.toHaveBeenCalled();
 		} );
 	} );
 
@@ -356,11 +471,14 @@ describe( 'useReelShare', () => {
 
 			// Now the social store hydrates with an IG connection. useSelect
 			// would normally not re-run if its initial subscription missed the
-			// store, but our handleShare reads via standalone select() at click.
+			// store, but our requestShare reads via standalone select() at click.
 			mockState.connections = [ igConnection ];
 
 			await act( async () => {
-				await result.current.handleShare();
+				await result.current.requestShare();
+			} );
+			await act( async () => {
+				await result.current.confirmShare();
 			} );
 
 			expect( mockTrackNotConnected ).not.toHaveBeenCalled();
@@ -379,16 +497,17 @@ describe( 'useReelShare', () => {
 			mockState.isCurrentPostPublished = false;
 
 			await act( async () => {
-				await result.current.handleShare();
+				await result.current.requestShare();
 			} );
 
 			expect( mockTrackNotPublished ).toHaveBeenCalledTimes( 1 );
+			expect( result.current.isConfirming ).toBe( false );
 			expect( mockShareCurrentPost ).not.toHaveBeenCalled();
 		} );
 	} );
 
 	describe( 'double-click guard', () => {
-		it( 'ignores a second click while the first share is still in flight', async () => {
+		it( 'ignores a second confirmShare while the first share is still in flight', async () => {
 			let resolveShare: ( value: boolean ) => void = () => {};
 			const inFlight = new Promise< boolean >( ( resolve ) => {
 				resolveShare = resolve;
@@ -398,15 +517,18 @@ describe( 'useReelShare', () => {
 			const { result } = renderHook( () => useReelShare() );
 
 			await act( async () => {
-				const firstClick = result.current.handleShare();
-				await result.current.handleShare();
+				await result.current.requestShare();
+			} );
+
+			await act( async () => {
+				const firstClick = result.current.confirmShare();
+				await result.current.confirmShare();
 				resolveShare( true );
 				await firstClick;
 			} );
 
 			expect( mockEditPost ).toHaveBeenCalledTimes( 1 );
 			expect( mockShareCurrentPost ).toHaveBeenCalledTimes( 1 );
-			expect( mockTrackClicked ).toHaveBeenCalledTimes( 1 );
 		} );
 	} );
 } );

--- a/packages/image-studio/src/hooks/use-reel-share/index.test.ts
+++ b/packages/image-studio/src/hooks/use-reel-share/index.test.ts
@@ -568,5 +568,31 @@ describe( 'useReelShare', () => {
 			expect( mockEditPost ).toHaveBeenCalledTimes( 1 );
 			expect( mockShareCurrentPost ).toHaveBeenCalledTimes( 1 );
 		} );
+
+		it( 'ignores a fresh requestShare while a share is still in flight', async () => {
+			let resolveShare: ( value: boolean ) => void = () => {};
+			const inFlight = new Promise< boolean >( ( resolve ) => {
+				resolveShare = resolve;
+			} );
+			mockShareCurrentPost.mockReturnValueOnce( inFlight );
+
+			const { result } = renderHook( () => useReelShare() );
+
+			await act( async () => {
+				await result.current.requestShare();
+			} );
+			await act( async () => {
+				// Kick off the dispatch but don't await yet — the share is
+				// in flight while we attempt a second requestShare.
+				const inFlightConfirm = result.current.confirmShare();
+				await result.current.requestShare();
+				resolveShare( true );
+				await inFlightConfirm;
+			} );
+
+			// First requestShare counted; the second was blocked.
+			expect( mockTrackClicked ).toHaveBeenCalledTimes( 1 );
+			expect( mockShareCurrentPost ).toHaveBeenCalledTimes( 1 );
+		} );
 	} );
 } );

--- a/packages/image-studio/src/hooks/use-reel-share/index.test.ts
+++ b/packages/image-studio/src/hooks/use-reel-share/index.test.ts
@@ -228,6 +228,20 @@ describe( 'useReelShare', () => {
 			expect( result.current.igDisplayName ).toBe( 'myhandle' );
 		} );
 
+		it( 'is a no-op (no re-track, no re-stamp) when the dialog is already open', async () => {
+			const { result } = renderHook( () => useReelShare() );
+
+			await act( async () => {
+				await result.current.requestShare();
+			} );
+			expect( mockTrackClicked ).toHaveBeenCalledTimes( 1 );
+
+			await act( async () => {
+				await result.current.requestShare();
+			} );
+			expect( mockTrackClicked ).toHaveBeenCalledTimes( 1 );
+		} );
+
 		it( 'resolves igDisplayName from external_handle when display_name is missing', async () => {
 			mockState.connections = [
 				{

--- a/packages/image-studio/src/hooks/use-reel-share/index.test.ts
+++ b/packages/image-studio/src/hooks/use-reel-share/index.test.ts
@@ -476,7 +476,31 @@ describe( 'useReelShare', () => {
 		} );
 	} );
 
-	describe( 'click-time freshness', () => {
+	describe( 'freshness', () => {
+		it( 'skips any non-IG connection that hydrates while the confirmation dialog is open', async () => {
+			// Initially only the IG connection exists.
+			mockState.connections = [ igConnection ];
+			const { result } = renderHook( () => useReelShare() );
+
+			await act( async () => {
+				await result.current.requestShare();
+			} );
+
+			// A new non-IG connection hydrates after the dialog opened. The
+			// skipped list must be recomputed at confirm time so the Reel does
+			// not also publish to this newly enabled network.
+			mockState.connections = [ igConnection, twitterConnection ];
+
+			await act( async () => {
+				await result.current.confirmShare();
+			} );
+
+			expect( mockShareCurrentPost ).toHaveBeenCalledWith(
+				expect.objectContaining( { skipped_connections: [ '1002' ] } ),
+				expect.any( Object )
+			);
+		} );
+
 		it( 'rechecks the IG connection at click time even if useSelect missed it', async () => {
 			// Render with no IG connection — simulates the wp-data subscription
 			// missing the social store at mount time.

--- a/packages/image-studio/src/hooks/use-reel-share/index.ts
+++ b/packages/image-studio/src/hooks/use-reel-share/index.ts
@@ -41,7 +41,6 @@ interface JetpackSocialOptions {
 }
 
 interface PendingShare {
-	skipped: string[];
 	igDisplayName: string | null;
 }
 
@@ -196,12 +195,8 @@ export function useReelShare( clip?: ShareClipIdentity ): UseReelShareReturn {
 			| { getConnections: () => Connection[] }
 			| undefined;
 		const freshConnections = freshSocial?.getConnections?.() ?? [];
-		const freshEnabledConnections = freshConnections.filter( ( c ) => c.enabled !== false );
 		const freshIgConnection = freshConnections.find( ( c ) => c.service_name === IG_SERVICE );
 		const freshIgIsEnabled = !! freshIgConnection && freshIgConnection.enabled !== false;
-		const freshSkipped = freshEnabledConnections
-			.filter( ( c ) => c.service_name !== IG_SERVICE )
-			.map( ( c ) => String( c.connection_id ) );
 
 		const freshEditor = freshSelect( EDITOR_STORE ) as
 			| { isCurrentPostPublished: () => boolean }
@@ -269,7 +264,7 @@ export function useReelShare( clip?: ShareClipIdentity ): UseReelShareReturn {
 		const resolvedHandle =
 			freshIgConnection.display_name || freshIgConnection.external_handle || null;
 
-		setPendingShare( { skipped: freshSkipped, igDisplayName: resolvedHandle } );
+		setPendingShare( { igDisplayName: resolvedHandle } );
 	}, [
 		currentAttachmentId,
 		currentDurationSeconds,
@@ -298,7 +293,18 @@ export function useReelShare( clip?: ShareClipIdentity ): UseReelShareReturn {
 			return;
 		}
 
-		const { skipped } = pendingShare;
+		// Recompute the non-IG enabled connection IDs at confirm time. Capturing
+		// the list at requestShare time would miss any connection that finishes
+		// hydrating while the dialog is open — those would NOT be in
+		// `skipped_connections` and the Reel would also publish to them.
+		const freshSocial = freshSelect( SOCIAL_STORE ) as
+			| { getConnections: () => Connection[] }
+			| undefined;
+		const freshConnections = freshSocial?.getConnections?.() ?? [];
+		const skipped = freshConnections
+			.filter( ( c ) => c.enabled !== false && c.service_name !== IG_SERVICE )
+			.map( ( c ) => String( c.connection_id ) );
+
 		setPendingShare( null );
 
 		const existingSocialOptions =

--- a/packages/image-studio/src/hooks/use-reel-share/index.ts
+++ b/packages/image-studio/src/hooks/use-reel-share/index.ts
@@ -175,6 +175,12 @@ export function useReelShare( clip?: ShareClipIdentity ): UseReelShareReturn {
 		! isAiProcessing;
 
 	const requestShare = useCallback( async () => {
+		// Already awaiting confirmation — don't re-fire `clicked` or overwrite
+		// the captured snapshot with a fresh re-read.
+		if ( pendingShare ) {
+			return;
+		}
+
 		trackImageStudioReelShareClicked( {
 			attachmentId: currentAttachmentId ?? 0,
 			durationSeconds: currentDurationSeconds,
@@ -264,7 +270,14 @@ export function useReelShare( clip?: ShareClipIdentity ): UseReelShareReturn {
 			freshIgConnection.display_name || freshIgConnection.external_handle || null;
 
 		setPendingShare( { skipped: freshSkipped, igDisplayName: resolvedHandle } );
-	}, [ currentAttachmentId, currentDurationSeconds, currentVideoUrl, sharePath, showNotice ] );
+	}, [
+		currentAttachmentId,
+		currentDurationSeconds,
+		currentVideoUrl,
+		pendingShare,
+		sharePath,
+		showNotice,
+	] );
 
 	const confirmShare = useCallback( async () => {
 		// Synchronous double-click guard. `isSharing` from useSelect lags by a

--- a/packages/image-studio/src/hooks/use-reel-share/index.ts
+++ b/packages/image-studio/src/hooks/use-reel-share/index.ts
@@ -1,5 +1,5 @@
 import { select as freshSelect, useDispatch, useSelect } from '@wordpress/data';
-import { useCallback, useRef } from '@wordpress/element';
+import { useCallback, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
 	ImageStudioEntryPoint,
@@ -9,6 +9,7 @@ import {
 import { store as videoStudioStore } from '../../stores/video-studio';
 import { getJetpackAdminUrl, getReelSharePostPath } from '../../utils/jetpack-script-data';
 import {
+	trackImageStudioReelShareCancelled,
 	trackImageStudioReelShareClicked,
 	trackImageStudioReelShareConnectionDisabled,
 	trackImageStudioReelShareDispatched,
@@ -27,6 +28,8 @@ interface Connection {
 	connection_id: string | number;
 	service_name: string;
 	enabled?: boolean;
+	display_name?: string;
+	external_handle?: string;
 }
 
 interface JetpackSocialOptions {
@@ -37,10 +40,19 @@ interface JetpackSocialOptions {
 	[ key: string ]: unknown;
 }
 
+interface PendingShare {
+	skipped: string[];
+	igDisplayName: string | null;
+}
+
 interface UseReelShareReturn {
 	isVisible: boolean;
 	isSharing: boolean;
-	handleShare: () => Promise< void >;
+	isConfirming: boolean;
+	igDisplayName: string | null;
+	requestShare: () => Promise< void >;
+	confirmShare: () => Promise< void >;
+	cancelShare: () => void;
 }
 
 export function useReelShare( clip?: ShareClipIdentity ): UseReelShareReturn {
@@ -149,6 +161,8 @@ export function useReelShare( clip?: ShareClipIdentity ): UseReelShareReturn {
 	// the first dispatch by a render, so we can't rely on `disabled` alone.
 	const isSharingRef = useRef( false );
 
+	const [ pendingShare, setPendingShare ] = useState< PendingShare | null >( null );
+
 	// When the caller supplies an explicit clip (e.g. the sidebar reading meta),
 	// it has already asserted the video context — the entryPoint guard is only
 	// meaningful for the in-modal call site that reads the live store.
@@ -160,13 +174,7 @@ export function useReelShare( clip?: ShareClipIdentity ): UseReelShareReturn {
 		!! sharePath &&
 		! isAiProcessing;
 
-	const handleShare = useCallback( async () => {
-		// Synchronous double-click guard. `isSharing` from useSelect lags by a
-		// render so it can't reliably block a fast second click on its own.
-		if ( isSharingRef.current ) {
-			return;
-		}
-
+	const requestShare = useCallback( async () => {
 		trackImageStudioReelShareClicked( {
 			attachmentId: currentAttachmentId ?? 0,
 			durationSeconds: currentDurationSeconds,
@@ -252,6 +260,34 @@ export function useReelShare( clip?: ShareClipIdentity ): UseReelShareReturn {
 			return;
 		}
 
+		const resolvedHandle =
+			freshIgConnection.display_name || freshIgConnection.external_handle || null;
+
+		setPendingShare( { skipped: freshSkipped, igDisplayName: resolvedHandle } );
+	}, [ currentAttachmentId, currentDurationSeconds, currentVideoUrl, sharePath, showNotice ] );
+
+	const confirmShare = useCallback( async () => {
+		// Synchronous double-click guard. `isSharing` from useSelect lags by a
+		// render so it can't reliably block a fast second click on its own.
+		if ( isSharingRef.current ) {
+			return;
+		}
+
+		if ( ! pendingShare ) {
+			return;
+		}
+
+		if ( ! currentVideoUrl || ! currentAttachmentId || ! sharePath ) {
+			// requestShare gated these already; if we somehow lost state between
+			// open and confirm, fall back to closing the dialog rather than
+			// dispatching a half-formed share.
+			setPendingShare( null );
+			return;
+		}
+
+		const { skipped } = pendingShare;
+		setPendingShare( null );
+
 		const existingSocialOptions =
 			( currentMeta.jetpack_social_options as JetpackSocialOptions | undefined ) ?? {};
 
@@ -280,7 +316,7 @@ export function useReelShare( clip?: ShareClipIdentity ): UseReelShareReturn {
 			// the share fires; we depend on that ordering rather than awaiting a
 			// separate save round-trip ourselves.
 			const success = await shareCurrentPost(
-				{ message: '', skipped_connections: freshSkipped },
+				{ message: '', skipped_connections: skipped },
 				{ savePost: true, apiPath: sharePath }
 			);
 
@@ -305,9 +341,9 @@ export function useReelShare( clip?: ShareClipIdentity ): UseReelShareReturn {
 			isSharingRef.current = false;
 		}
 	}, [
+		pendingShare,
 		showNotice,
 		currentAttachmentId,
-		currentDurationSeconds,
 		currentMeta,
 		currentVideoUrl,
 		editPost,
@@ -315,9 +351,20 @@ export function useReelShare( clip?: ShareClipIdentity ): UseReelShareReturn {
 		shareCurrentPost,
 	] );
 
+	const cancelShare = useCallback( () => {
+		if ( pendingShare ) {
+			trackImageStudioReelShareCancelled();
+		}
+		setPendingShare( null );
+	}, [ pendingShare ] );
+
 	return {
 		isVisible,
 		isSharing,
-		handleShare,
+		isConfirming: pendingShare !== null,
+		igDisplayName: pendingShare?.igDisplayName ?? null,
+		requestShare,
+		confirmShare,
+		cancelShare,
 	};
 }

--- a/packages/image-studio/src/hooks/use-reel-share/index.ts
+++ b/packages/image-studio/src/hooks/use-reel-share/index.ts
@@ -174,9 +174,10 @@ export function useReelShare( clip?: ShareClipIdentity ): UseReelShareReturn {
 		! isAiProcessing;
 
 	const requestShare = useCallback( async () => {
-		// Already awaiting confirmation — don't re-fire `clicked` or overwrite
-		// the captured snapshot with a fresh re-read.
-		if ( pendingShare ) {
+		// `isSharing` from useSelect lags by a render, so the IG button can
+		// stay briefly clickable mid-dispatch — guard here to avoid a
+		// double-publish via a reopened dialog.
+		if ( isSharingRef.current || pendingShare ) {
 			return;
 		}
 

--- a/packages/image-studio/src/utils/tracking.test.ts
+++ b/packages/image-studio/src/utils/tracking.test.ts
@@ -13,6 +13,7 @@ import {
 	trackImageStudioReelShareNotConnected,
 	trackImageStudioReelShareNotPublished,
 	trackImageStudioReelShareInvalidState,
+	trackImageStudioReelShareCancelled,
 	trackImageStudioReelShareDispatched,
 	trackImageStudioReelShareFailed,
 	trackImageStudioReelShareConnectionDisabled,
@@ -209,6 +210,14 @@ describe( 'reel share tracking helpers', () => {
 		trackImageStudioReelShareDispatched();
 		expect( recordTracksEventMock ).toHaveBeenCalledWith(
 			'jetpack_big_sky_image_studio_reel_share_dispatched',
+			expect.any( Object )
+		);
+	} );
+
+	it( 'fires reel_share_cancelled', () => {
+		trackImageStudioReelShareCancelled();
+		expect( recordTracksEventMock ).toHaveBeenCalledWith(
+			'jetpack_big_sky_image_studio_reel_share_cancelled',
 			expect.any( Object )
 		);
 	} );

--- a/packages/image-studio/src/utils/tracking.ts
+++ b/packages/image-studio/src/utils/tracking.ts
@@ -589,6 +589,13 @@ export function trackImageStudioReelShareInvalidState(): void {
 }
 
 /**
+ * Tracks when the user dismisses the Reel share confirmation dialog.
+ */
+export function trackImageStudioReelShareCancelled(): void {
+	recordImageStudioEvent( 'image_studio_reel_share_cancelled' );
+}
+
+/**
  * Tracks when shareCurrentPost successfully dispatched the IG submission.
  */
 export function trackImageStudioReelShareDispatched(): void {


### PR DESCRIPTION
## Why are these changes being made?

Posting a Reel to Instagram is irreversible — the previous flow dispatched the share on the first click of the IG icon, with no way to back out. A confirmation step protects against accidental publishes and gives users a chance to verify which account the Reel is heading to.

<img width="1000" height="906" alt="Screenshot 2026-05-11 at 3 54 13 PM" src="https://github.com/user-attachments/assets/8d0a08e4-8e38-4bab-839c-34a0973097df" />


## Proposed Changes

* Add a confirmation dialog when the user clicks the Instagram (Reel) share button — previously a single click published the Reel immediately.
* Split `useReelShare`'s `handleShare` into `requestShare` / `confirmShare` / `cancelShare`, with `isConfirming` and `igDisplayName` exposed on the return value. Validation still runs in `requestShare`, so users never see "Confirm?" followed by an error.
* Render the existing `ConfirmationDialog` (Cancel / Share) from both surfaces that use the hook: `ShareReelAction` (Image Studio modal) and `FeatureClipPreview` (post-editor sidebar). The dialog body names the connected IG account in `<strong>`, falling back to a generic copy if no `display_name` / `external_handle` is available on the connection.
* New `trackImageStudioReelShareCancelled` tracking event (`image_studio_reel_share_cancelled`) for dismissals.

## Testing Instructions

Two surfaces to verify. Both share the same hook, so behaviour should match.

**Image Studio modal (Generate layout)**
1. Open a published post.
2. Open Image Studio and generate a video clip.
3. In the Generate layout, click the Instagram share icon.
4. Expect the dialog "Share to Instagram?" with body "This Reel will be published to **<account>** on Instagram." (account bolded). Cancel and Share buttons present.
5. Click **Cancel** → dialog closes, no share dispatched, `image_studio_reel_share_cancelled` event fires.
6. Click **Share** → dialog closes, share is dispatched, success notice appears (existing flow), `image_studio_reel_share_dispatched` event fires.

**Post-editor sidebar (Feature Clip preview)**
1. On a published post that already has a generated Feature Clip, open the sidebar panel.
2. Click the **Share on Instagram** button → same dialog as above.
3. Verify Cancel / Share behaviour from the sidebar surface.

**Edge cases (existing validation still runs in `requestShare`, before the dialog opens)**
- No IG connection → existing "Connect Instagram" notice; no dialog.
- IG connected but disabled for the post → existing "enable in sidebar" notice; no dialog.
- Post still a draft → existing "publish first" notice; no dialog.

**Tracking**

Events to look for in Tracks:
- `image_studio_reel_share_clicked` (existing, on the initial click)
- `image_studio_reel_share_cancelled` (new, on Cancel)
- `image_studio_reel_share_dispatched` (existing, on successful Share)

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?