### PR TITLE
Reader social: add Notifications tab for ATmosphere

### DIFF
--- a/client/reader/atmosphere/atmosphere-account-view.tsx
+++ b/client/reader/atmosphere/atmosphere-account-view.tsx
@@ -11,12 +11,13 @@ import { ComposeFab, ComposerModal, ComposerProvider } from 'calypso/reader/soci
 import { normalizeHandle } from 'calypso/reader/social/utils/normalize-handle';
 import { AtmosphereNavigation } from './atmosphere-navigation';
 import { atmosphereComposerConfig } from './composer-config';
-import { PROFILE_TAB, TIMELINE_TAB } from './helper';
+import { NOTIFICATIONS_TAB, PROFILE_TAB, TIMELINE_TAB } from './helper';
+import { NotificationsPanel } from './notifications-panel';
 import { ProfilePanel } from './profile-panel';
 import { TimelinePanel } from './timeline-panel';
 import type { AtmosphereConnection } from '@automattic/api-core';
 
-const VALID_TABS = new Set( [ TIMELINE_TAB, PROFILE_TAB ] );
+const VALID_TABS = new Set( [ TIMELINE_TAB, NOTIFICATIONS_TAB, PROFILE_TAB ] );
 
 interface Props {
 	connectionId: number;
@@ -94,6 +95,8 @@ function renderTab( slug: string, connection: AtmosphereConnection ) {
 	switch ( slug ) {
 		case PROFILE_TAB:
 			return <ProfilePanel connection={ connection } />;
+		case NOTIFICATIONS_TAB:
+			return <NotificationsPanel connection={ connection } />;
 		case TIMELINE_TAB:
 		default:
 			return <TimelinePanel connection={ connection } />;

--- a/client/reader/atmosphere/atmosphere-navigation.tsx
+++ b/client/reader/atmosphere/atmosphere-navigation.tsx
@@ -4,7 +4,7 @@ import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import { useDispatch } from 'calypso/state';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
-import { TIMELINE_TAB, PROFILE_TAB } from './helper';
+import { NOTIFICATIONS_TAB, PROFILE_TAB, TIMELINE_TAB } from './helper';
 
 interface Tab {
 	slug: string;
@@ -35,6 +35,11 @@ export function AtmosphereNavigation( { connectionId, selectedTab }: Props ) {
 			slug: TIMELINE_TAB,
 			title: translate( 'Timeline' ),
 			path: `/reader/atmosphere/${ connectionId }/${ TIMELINE_TAB }`,
+		},
+		{
+			slug: NOTIFICATIONS_TAB,
+			title: translate( 'Notifications' ),
+			path: `/reader/atmosphere/${ connectionId }/${ NOTIFICATIONS_TAB }`,
 		},
 		{
 			slug: PROFILE_TAB,

--- a/client/reader/atmosphere/helper.ts
+++ b/client/reader/atmosphere/helper.ts
@@ -1,4 +1,5 @@
 export const ATMOSPHERE_PREFIX = 'reader/atmosphere';
 export const TIMELINE_TAB = 'timeline';
+export const NOTIFICATIONS_TAB = 'notifications';
 export const PROFILE_TAB = 'profile';
 export const DEFAULT_ATMOSPHERE_TAB = TIMELINE_TAB;

--- a/client/reader/atmosphere/notifications-panel.tsx
+++ b/client/reader/atmosphere/notifications-panel.tsx
@@ -1,0 +1,29 @@
+import { useAtmosphereNotificationsInfiniteQuery } from '@automattic/api-queries';
+import { useMemo } from 'react';
+import { SocialNotificationsList } from 'calypso/reader/social';
+import type { AtmosphereConnection } from '@automattic/api-core';
+
+interface Props {
+	connection: AtmosphereConnection;
+}
+
+export function NotificationsPanel( { connection }: Props ) {
+	const { data, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
+		useAtmosphereNotificationsInfiniteQuery( connection.id );
+
+	const items = useMemo( () => data?.pages.flatMap( ( p ) => p.items ) ?? [], [ data ] );
+	const seenAt = data?.pages[ 0 ]?.seen_at ?? null;
+
+	return (
+		<SocialNotificationsList
+			items={ items }
+			seenAt={ seenAt }
+			isLoading={ isLoading || isFetchingNextPage }
+			isError={ isError }
+			hasMore={ !! hasNextPage }
+			onLoadMore={ () => {
+				fetchNextPage();
+			} }
+		/>
+	);
+}

--- a/client/reader/atmosphere/notifications-panel.tsx
+++ b/client/reader/atmosphere/notifications-panel.tsx
@@ -12,13 +12,12 @@ export function NotificationsPanel( { connection }: Props ) {
 		useAtmosphereNotificationsInfiniteQuery( connection.id );
 
 	const items = useMemo( () => data?.pages.flatMap( ( p ) => p.items ) ?? [], [ data ] );
-	const seenAt = data?.pages[ 0 ]?.seen_at ?? null;
 
 	return (
 		<SocialNotificationsList
 			items={ items }
-			seenAt={ seenAt }
-			isLoading={ isLoading || isFetchingNextPage }
+			isLoading={ isLoading }
+			isLoadingMore={ isFetchingNextPage }
 			isError={ isError }
 			hasMore={ !! hasNextPage }
 			onLoadMore={ () => {

--- a/client/reader/atmosphere/notifications-panel.tsx
+++ b/client/reader/atmosphere/notifications-panel.tsx
@@ -8,7 +8,7 @@ interface Props {
 }
 
 export function NotificationsPanel( { connection }: Props ) {
-	const { data, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
+	const { data, isPending, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
 		useAtmosphereNotificationsInfiniteQuery( connection.id );
 
 	const items = useMemo( () => data?.pages.flatMap( ( p ) => p.items ) ?? [], [ data ] );
@@ -16,7 +16,7 @@ export function NotificationsPanel( { connection }: Props ) {
 	return (
 		<SocialNotificationsList
 			items={ items }
-			isLoading={ isLoading }
+			isLoading={ isPending }
 			isLoadingMore={ isFetchingNextPage }
 			isError={ isError }
 			hasMore={ !! hasNextPage }

--- a/client/reader/atmosphere/test/atmosphere-account-view.test.tsx
+++ b/client/reader/atmosphere/test/atmosphere-account-view.test.tsx
@@ -7,7 +7,7 @@ import { screen, waitFor } from '@testing-library/react';
 import nock from 'nock';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { AtmosphereAccountView } from '../atmosphere-account-view';
-import { PROFILE_TAB, TIMELINE_TAB } from '../helper';
+import { NOTIFICATIONS_TAB, PROFILE_TAB, TIMELINE_TAB } from '../helper';
 import type React from 'react';
 
 jest.mock(
@@ -129,6 +129,19 @@ describe( 'AtmosphereAccountView', () => {
 		const matches = await screen.findAllByText( /a\.bsky\.social/ );
 		expect( matches.length ).toBeGreaterThan( 0 );
 		matches.forEach( ( match ) => expect( match ).toBeVisible() );
+	} );
+
+	it( 'renders the notifications tab when asked', async () => {
+		mockConnections();
+		mockConnectionDetails( 7 );
+		nock( 'https://public-api.wordpress.com' )
+			.get( `${ listUrl }/7/notifications` )
+			.query( true )
+			.reply( 200, { items: [], next_cursor: null, seen_at: null } );
+		renderWithProvider( <AtmosphereAccountView connectionId={ 7 } tab={ NOTIFICATIONS_TAB } />, {
+			queryClient: makeClient(),
+		} );
+		expect( await screen.findByText( /no notifications yet/i ) ).toBeVisible();
 	} );
 
 	it( 'renders the section title and the handle-aware subtitle in the header', async () => {

--- a/client/reader/atmosphere/test/atmosphere-navigation.test.tsx
+++ b/client/reader/atmosphere/test/atmosphere-navigation.test.tsx
@@ -33,19 +33,21 @@ describe( 'AtmosphereNavigation', () => {
 		mockRecordReaderTracksEvent.mockClear();
 	} );
 
-	it( 'renders two tabs and marks the selected one active', () => {
+	it( 'renders three tabs and marks the selected one active', () => {
 		renderWithProvider( <AtmosphereNavigation connectionId={ 42 } selectedTab="profile" /> );
 
 		expect( screen.getByRole( 'menuitem', { name: /timeline/i } ) ).toBeVisible();
+		expect( screen.getByRole( 'menuitem', { name: /notifications/i } ) ).toBeVisible();
 		expect( screen.getByRole( 'menuitem', { name: /profile/i } ) ).toBeVisible();
+
+		const items = screen.getAllByRole( 'menuitem' );
+		expect( items[ 0 ] ).toHaveTextContent( /timeline/i );
+		expect( items[ 1 ] ).toHaveTextContent( /notifications/i );
+		expect( items[ 2 ] ).toHaveTextContent( /profile/i );
 
 		expect( screen.getByRole( 'menuitem', { name: /profile/i } ) ).toHaveAttribute(
 			'aria-current',
 			'true'
-		);
-		expect( screen.getByRole( 'menuitem', { name: /timeline/i } ) ).toHaveAttribute(
-			'aria-current',
-			'false'
 		);
 	} );
 
@@ -55,6 +57,10 @@ describe( 'AtmosphereNavigation', () => {
 		expect( screen.getByRole( 'menuitem', { name: /timeline/i } ) ).toHaveAttribute(
 			'href',
 			'/reader/atmosphere/42/timeline'
+		);
+		expect( screen.getByRole( 'menuitem', { name: /notifications/i } ) ).toHaveAttribute(
+			'href',
+			'/reader/atmosphere/42/notifications'
 		);
 		expect( screen.getByRole( 'menuitem', { name: /profile/i } ) ).toHaveAttribute(
 			'href',

--- a/client/reader/atmosphere/test/notifications-panel.test.tsx
+++ b/client/reader/atmosphere/test/notifications-panel.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { NotificationsPanel } from '../notifications-panel';
+import type { AtmosphereConnection } from '@automattic/api-core';
+
+const BASE = 'https://public-api.wordpress.com';
+
+const connection: AtmosphereConnection = {
+	id: 101,
+	did: 'did:plc:me',
+	handle: 'me.bsky.social',
+	display_name: 'Me',
+	avatar: null,
+};
+
+describe( 'NotificationsPanel', () => {
+	afterEach( () => nock.cleanAll() );
+
+	it( 'renders fetched notifications via the shared list', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/atmosphere/connections/101/notifications' )
+			.query( {} )
+			.reply( 200, {
+				items: [
+					{
+						id: 'a',
+						protocol_type: 'like',
+						canonical_type: 'like',
+						actor: {
+							handle: 'jane.bsky.social',
+							display_name: 'Jane',
+							avatar_url: null,
+							profile_uri: 'at://did:plc:jane',
+						},
+						target: { kind: 'post', uri: 'at://post', excerpt: 'hi' },
+						target_url: 'https://bsky.app/profile/me/post/3k',
+						created_at: '2026-05-11T12:34:56Z',
+						is_read: false,
+						raw: {},
+					},
+				],
+				next_cursor: null,
+				seen_at: null,
+			} );
+		renderWithProvider( <NotificationsPanel connection={ connection } /> );
+		await waitFor( () => expect( screen.getByText( /jane/i ) ).toBeVisible() );
+		expect( screen.getByText( /liked your post/i ) ).toBeVisible();
+	} );
+
+	it( 'renders an empty state when no notifications', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/atmosphere/connections/101/notifications' )
+			.query( {} )
+			.reply( 200, { items: [], next_cursor: null, seen_at: null } );
+		renderWithProvider( <NotificationsPanel connection={ connection } /> );
+		await waitFor( () => expect( screen.getByText( /no notifications yet/i ) ).toBeVisible() );
+	} );
+} );

--- a/client/reader/atmosphere/test/notifications-panel.test.tsx
+++ b/client/reader/atmosphere/test/notifications-panel.test.tsx
@@ -40,7 +40,6 @@ describe( 'NotificationsPanel', () => {
 						target_url: 'https://bsky.app/profile/me/post/3k',
 						created_at: '2026-05-11T12:34:56Z',
 						is_read: false,
-						raw: {},
 					},
 				],
 				next_cursor: null,

--- a/client/reader/social/components/notifications-list/index.tsx
+++ b/client/reader/social/components/notifications-list/index.tsx
@@ -1,0 +1,61 @@
+import './style.scss';
+
+import { Button, Spinner, __experimentalVStack as VStack } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { SocialNotificationItem } from './notification-item';
+import type { AtmosphereNotification } from '@automattic/api-core';
+
+interface Props {
+	items: AtmosphereNotification[];
+	seenAt: string | null;
+	isLoading: boolean;
+	isError: boolean;
+	hasMore: boolean;
+	onLoadMore: () => void;
+}
+
+export function SocialNotificationsList( {
+	items,
+	isLoading,
+	isError,
+	hasMore,
+	onLoadMore,
+}: Props ) {
+	const translate = useTranslate();
+
+	if ( isLoading && items.length === 0 ) {
+		return (
+			<div className="social-notifications-list__status" role="status" aria-live="polite">
+				<Spinner />
+			</div>
+		);
+	}
+	if ( isError && items.length === 0 ) {
+		return (
+			<div className="social-notifications-list__status">
+				<p>{ translate( 'We couldn’t load notifications. Try again later.' ) as string }</p>
+			</div>
+		);
+	}
+	if ( items.length === 0 ) {
+		return (
+			<div className="social-notifications-list__status">
+				<p>{ translate( 'No notifications yet.' ) as string }</p>
+			</div>
+		);
+	}
+	return (
+		<VStack spacing={ 0 } className="social-notifications-list">
+			{ items.map( ( item ) => (
+				<SocialNotificationItem key={ item.id } notification={ item } />
+			) ) }
+			{ hasMore && (
+				<div className="social-notifications-list__footer">
+					<Button variant="secondary" onClick={ onLoadMore }>
+						{ translate( 'Load more' ) as string }
+					</Button>
+				</div>
+			) }
+		</VStack>
+	);
+}

--- a/client/reader/social/components/notifications-list/index.tsx
+++ b/client/reader/social/components/notifications-list/index.tsx
@@ -7,8 +7,8 @@ import type { AtmosphereNotification } from '@automattic/api-core';
 
 interface Props {
 	items: AtmosphereNotification[];
-	seenAt: string | null;
 	isLoading: boolean;
+	isLoadingMore?: boolean;
 	isError: boolean;
 	hasMore: boolean;
 	onLoadMore: () => void;
@@ -17,6 +17,7 @@ interface Props {
 export function SocialNotificationsList( {
 	items,
 	isLoading,
+	isLoadingMore = false,
 	isError,
 	hasMore,
 	onLoadMore,
@@ -51,7 +52,12 @@ export function SocialNotificationsList( {
 			) ) }
 			{ hasMore && (
 				<div className="social-notifications-list__footer">
-					<Button variant="secondary" onClick={ onLoadMore }>
+					<Button
+						variant="secondary"
+						onClick={ onLoadMore }
+						disabled={ isLoadingMore }
+						isBusy={ isLoadingMore }
+					>
 						{ translate( 'Load more' ) as string }
 					</Button>
 				</div>

--- a/client/reader/social/components/notifications-list/index.tsx
+++ b/client/reader/social/components/notifications-list/index.tsx
@@ -28,6 +28,9 @@ export function SocialNotificationsList( {
 		return (
 			<div className="social-notifications-list__status" role="status" aria-live="polite">
 				<Spinner />
+				<span className="screen-reader-text">
+					{ translate( 'Loading notifications' ) as string }
+				</span>
 			</div>
 		);
 	}

--- a/client/reader/social/components/notifications-list/index.tsx
+++ b/client/reader/social/components/notifications-list/index.tsx
@@ -45,12 +45,26 @@ export function SocialNotificationsList( {
 			</div>
 		);
 	}
+	// `isError && items.length > 0` means an earlier page succeeded but the
+	// most recent fetchNextPage failed. Surface a retry affordance instead
+	// of silently degrading to the last successful page.
+	const showRetry = isError && hasMore && ! isLoadingMore;
 	return (
 		<VStack spacing={ 0 } className="social-notifications-list">
 			{ items.map( ( item ) => (
 				<SocialNotificationItem key={ item.id } notification={ item } />
 			) ) }
-			{ hasMore && (
+			{ showRetry && (
+				<div className="social-notifications-list__footer" role="alert">
+					<p className="social-notifications-list__error">
+						{ translate( 'We couldn’t load more notifications.' ) as string }
+					</p>
+					<Button variant="secondary" onClick={ onLoadMore }>
+						{ translate( 'Try again' ) as string }
+					</Button>
+				</div>
+			) }
+			{ hasMore && ! isError && (
 				<div className="social-notifications-list__footer">
 					<Button
 						variant="secondary"

--- a/client/reader/social/components/notifications-list/notification-item.tsx
+++ b/client/reader/social/components/notifications-list/notification-item.tsx
@@ -1,0 +1,89 @@
+import './style.scss';
+
+import { TimeSince } from '@automattic/components';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import type {
+	AtmosphereNotification,
+	AtmosphereNotificationCanonicalType,
+} from '@automattic/api-core';
+
+interface Props {
+	notification: AtmosphereNotification;
+}
+
+export function SocialNotificationItem( { notification }: Props ) {
+	const translate = useTranslate();
+	const { actor, target, target_url, canonical_type, protocol_type, is_read, created_at } =
+		notification;
+	const actorName = actor.display_name || actor.handle;
+	const phrase = actionPhrase( canonical_type, protocol_type, translate );
+	const ariaLabel = translate( '%(actor)s %(phrase)s', {
+		args: { actor: actorName, phrase: String( phrase ) },
+	} ) as string;
+
+	return (
+		<a
+			className={ clsx( 'social-notification-item', { 'is-unread': ! is_read } ) }
+			href={ target_url }
+			target="_blank"
+			rel="noopener noreferrer"
+			aria-label={ ariaLabel }
+		>
+			<HStack alignment="flex-start" spacing={ 3 }>
+				{ actor.avatar_url ? (
+					<img className="social-notification-item__avatar" src={ actor.avatar_url } alt="" />
+				) : (
+					<span className="social-notification-item__avatar is-placeholder" aria-hidden />
+				) }
+				<VStack spacing={ 1 } className="social-notification-item__body">
+					<span className="social-notification-item__line">
+						<span className="social-notification-item__actor">{ actorName }</span>{ ' ' }
+						<span className="social-notification-item__phrase">{ phrase }</span>
+					</span>
+					{ target?.excerpt ? (
+						<span className="social-notification-item__excerpt">{ target.excerpt }</span>
+					) : null }
+					{ created_at ? (
+						<TimeSince className="social-notification-item__time" date={ created_at } />
+					) : null }
+				</VStack>
+				{ ! is_read && (
+					<span
+						className="social-notification-item__unread-dot"
+						aria-label={ translate( 'Unread' ) as string }
+					/>
+				) }
+			</HStack>
+		</a>
+	);
+}
+
+function actionPhrase(
+	canonical: AtmosphereNotificationCanonicalType,
+	protocolType: string,
+	translate: ReturnType< typeof useTranslate >
+): string {
+	switch ( canonical ) {
+		case 'like':
+			return translate( 'liked your post' ) as string;
+		case 'repost':
+			return translate( 'reposted your post' ) as string;
+		case 'follow':
+			return translate( 'followed you' ) as string;
+		case 'mention':
+			return translate( 'mentioned you' ) as string;
+		case 'reply':
+			return translate( 'replied to your post' ) as string;
+		case 'quote':
+			return translate( 'quoted your post' ) as string;
+		case 'other':
+		default:
+			// e.g. 'starterpack-joined' -> 'starterpack joined'.
+			return protocolType.replace( /[-_]/g, ' ' );
+	}
+}

--- a/client/reader/social/components/notifications-list/notification-item.tsx
+++ b/client/reader/social/components/notifications-list/notification-item.tsx
@@ -30,7 +30,13 @@ export function SocialNotificationItem( { notification }: Props ) {
 	const { actor, target, target_url, canonical_type, is_read, created_at } = notification;
 	const actorName = actor.display_name || actor.handle;
 	const phrase = actionPhrase( canonical_type, translate );
-	const ariaLabel = actionAriaLabel( canonical_type, actorName, translate );
+	const actionLabel = actionAriaLabel( canonical_type, actorName, translate );
+	// An explicit `aria-label` on the anchor replaces the accessible name, so
+	// the inner SR-only "Unread" span would never be announced. Fold the unread
+	// state into the label instead.
+	const ariaLabel = is_read
+		? actionLabel
+		: ( translate( 'Unread. %(label)s', { args: { label: actionLabel } } ) as string );
 
 	const safe = isSafeUrl( target_url );
 	const className = clsx( 'social-notification-item', { 'is-unread': ! is_read } );
@@ -54,12 +60,7 @@ export function SocialNotificationItem( { notification }: Props ) {
 					<TimeSince className="social-notification-item__time" date={ created_at } />
 				) : null }
 			</VStack>
-			{ ! is_read && (
-				<>
-					<span className="screen-reader-text">{ translate( 'Unread' ) as string }</span>
-					<span className="social-notification-item__unread-dot" aria-hidden />
-				</>
-			) }
+			{ ! is_read && <span className="social-notification-item__unread-dot" aria-hidden /> }
 		</HStack>
 	);
 

--- a/client/reader/social/components/notifications-list/notification-item.tsx
+++ b/client/reader/social/components/notifications-list/notification-item.tsx
@@ -27,13 +27,10 @@ function isSafeUrl( url: string ): boolean {
 
 export function SocialNotificationItem( { notification }: Props ) {
 	const translate = useTranslate();
-	const { actor, target, target_url, canonical_type, protocol_type, is_read, created_at } =
-		notification;
+	const { actor, target, target_url, canonical_type, is_read, created_at } = notification;
 	const actorName = actor.display_name || actor.handle;
-	const phrase = actionPhrase( canonical_type, protocol_type, translate );
-	const ariaLabel = translate( '%(actor)s %(phrase)s', {
-		args: { actor: actorName, phrase: String( phrase ) },
-	} ) as string;
+	const phrase = actionPhrase( canonical_type, translate );
+	const ariaLabel = actionAriaLabel( canonical_type, actorName, translate );
 
 	const safe = isSafeUrl( target_url );
 	const className = clsx( 'social-notification-item', { 'is-unread': ! is_read } );
@@ -89,7 +86,6 @@ export function SocialNotificationItem( { notification }: Props ) {
 
 function actionPhrase(
 	canonical: AtmosphereNotificationCanonicalType,
-	protocolType: string,
 	translate: ReturnType< typeof useTranslate >
 ): string {
 	switch ( canonical ) {
@@ -107,7 +103,30 @@ function actionPhrase(
 			return translate( 'quoted your post' ) as string;
 		case 'other':
 		default:
-			// e.g. 'starterpack-joined' -> 'starterpack joined'.
-			return protocolType.replace( /[-_]/g, ' ' );
+			return translate( 'interacted with you' ) as string;
+	}
+}
+
+function actionAriaLabel(
+	canonical: AtmosphereNotificationCanonicalType,
+	actor: string,
+	translate: ReturnType< typeof useTranslate >
+): string {
+	switch ( canonical ) {
+		case 'like':
+			return translate( '%(actor)s liked your post', { args: { actor } } ) as string;
+		case 'repost':
+			return translate( '%(actor)s reposted your post', { args: { actor } } ) as string;
+		case 'follow':
+			return translate( '%(actor)s followed you', { args: { actor } } ) as string;
+		case 'mention':
+			return translate( '%(actor)s mentioned you', { args: { actor } } ) as string;
+		case 'reply':
+			return translate( '%(actor)s replied to your post', { args: { actor } } ) as string;
+		case 'quote':
+			return translate( '%(actor)s quoted your post', { args: { actor } } ) as string;
+		case 'other':
+		default:
+			return translate( '%(actor)s interacted with you', { args: { actor } } ) as string;
 	}
 }

--- a/client/reader/social/components/notifications-list/notification-item.tsx
+++ b/client/reader/social/components/notifications-list/notification-item.tsx
@@ -16,6 +16,15 @@ interface Props {
 	notification: AtmosphereNotification;
 }
 
+function isSafeUrl( url: string ): boolean {
+	try {
+		const parsed = new URL( url );
+		return parsed.protocol === 'https:' || parsed.protocol === 'http:';
+	} catch {
+		return false;
+	}
+}
+
 export function SocialNotificationItem( { notification }: Props ) {
 	const translate = useTranslate();
 	const { actor, target, target_url, canonical_type, protocol_type, is_read, created_at } =
@@ -26,40 +35,55 @@ export function SocialNotificationItem( { notification }: Props ) {
 		args: { actor: actorName, phrase: String( phrase ) },
 	} ) as string;
 
+	const safe = isSafeUrl( target_url );
+	const className = clsx( 'social-notification-item', { 'is-unread': ! is_read } );
+
+	const body = (
+		<HStack alignment="flex-start" spacing={ 3 }>
+			{ actor.avatar_url ? (
+				<img className="social-notification-item__avatar" src={ actor.avatar_url } alt="" />
+			) : (
+				<span className="social-notification-item__avatar is-placeholder" aria-hidden />
+			) }
+			<VStack spacing={ 1 } className="social-notification-item__body">
+				<span className="social-notification-item__line">
+					<span className="social-notification-item__actor">{ actorName }</span>{ ' ' }
+					<span className="social-notification-item__phrase">{ phrase }</span>
+				</span>
+				{ target?.excerpt ? (
+					<span className="social-notification-item__excerpt">{ target.excerpt }</span>
+				) : null }
+				{ created_at ? (
+					<TimeSince className="social-notification-item__time" date={ created_at } />
+				) : null }
+			</VStack>
+			{ ! is_read && (
+				<>
+					<span className="screen-reader-text">{ translate( 'Unread' ) as string }</span>
+					<span className="social-notification-item__unread-dot" aria-hidden />
+				</>
+			) }
+		</HStack>
+	);
+
+	if ( safe ) {
+		return (
+			<a
+				className={ className }
+				href={ target_url }
+				target="_blank"
+				rel="noopener noreferrer"
+				aria-label={ ariaLabel }
+			>
+				{ body }
+			</a>
+		);
+	}
+
 	return (
-		<a
-			className={ clsx( 'social-notification-item', { 'is-unread': ! is_read } ) }
-			href={ target_url }
-			target="_blank"
-			rel="noopener noreferrer"
-			aria-label={ ariaLabel }
-		>
-			<HStack alignment="flex-start" spacing={ 3 }>
-				{ actor.avatar_url ? (
-					<img className="social-notification-item__avatar" src={ actor.avatar_url } alt="" />
-				) : (
-					<span className="social-notification-item__avatar is-placeholder" aria-hidden />
-				) }
-				<VStack spacing={ 1 } className="social-notification-item__body">
-					<span className="social-notification-item__line">
-						<span className="social-notification-item__actor">{ actorName }</span>{ ' ' }
-						<span className="social-notification-item__phrase">{ phrase }</span>
-					</span>
-					{ target?.excerpt ? (
-						<span className="social-notification-item__excerpt">{ target.excerpt }</span>
-					) : null }
-					{ created_at ? (
-						<TimeSince className="social-notification-item__time" date={ created_at } />
-					) : null }
-				</VStack>
-				{ ! is_read && (
-					<span
-						className="social-notification-item__unread-dot"
-						aria-label={ translate( 'Unread' ) as string }
-					/>
-				) }
-			</HStack>
-		</a>
+		<div className={ className } aria-label={ ariaLabel }>
+			{ body }
+		</div>
 	);
 }
 

--- a/client/reader/social/components/notifications-list/notification-item.tsx
+++ b/client/reader/social/components/notifications-list/notification-item.tsx
@@ -44,6 +44,7 @@ export function SocialNotificationItem( { notification }: Props ) {
 	const body = (
 		<HStack alignment="flex-start" spacing={ 3 }>
 			{ actor.avatar_url ? (
+				// Decorative: the actor identity is announced via the row aria-label.
 				<img className="social-notification-item__avatar" src={ actor.avatar_url } alt="" />
 			) : (
 				<span className="social-notification-item__avatar is-placeholder" aria-hidden />

--- a/client/reader/social/components/notifications-list/style.scss
+++ b/client/reader/social/components/notifications-list/style.scss
@@ -6,7 +6,8 @@
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	padding: 2rem 1rem;
+	padding-block: 2rem;
+	padding-inline: 1rem;
 	color: var(--color-text-subtle);
 	text-align: center;
 }
@@ -17,7 +18,8 @@
 	align-items: center;
 	justify-content: center;
 	gap: 0.5rem;
-	padding: 1rem;
+	padding-block: 1rem;
+	padding-inline: 1rem;
 }
 
 .social-notifications-list__error {
@@ -27,7 +29,8 @@
 
 .social-notification-item {
 	display: block;
-	padding: 0.75rem 1rem;
+	padding-block: 0.75rem;
+	padding-inline: 1rem;
 	color: inherit;
 	text-decoration: none;
 	border-block-end: 1px solid var(--color-border-subtle);

--- a/client/reader/social/components/notifications-list/style.scss
+++ b/client/reader/social/components/notifications-list/style.scss
@@ -1,3 +1,22 @@
+.social-notifications-list {
+	inline-size: 100%;
+}
+
+.social-notifications-list__status {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	padding: 2rem 1rem;
+	color: var(--color-text-subtle);
+	text-align: center;
+}
+
+.social-notifications-list__footer {
+	display: flex;
+	justify-content: center;
+	padding: 1rem;
+}
+
 .social-notification-item {
 	display: block;
 	padding: 0.75rem 1rem;

--- a/client/reader/social/components/notifications-list/style.scss
+++ b/client/reader/social/components/notifications-list/style.scss
@@ -13,8 +13,16 @@
 
 .social-notifications-list__footer {
 	display: flex;
+	flex-direction: column;
+	align-items: center;
 	justify-content: center;
+	gap: 0.5rem;
 	padding: 1rem;
+}
+
+.social-notifications-list__error {
+	margin: 0;
+	color: var(--color-text-subtle);
 }
 
 .social-notification-item {

--- a/client/reader/social/components/notifications-list/style.scss
+++ b/client/reader/social/components/notifications-list/style.scss
@@ -1,0 +1,68 @@
+.social-notification-item {
+	display: block;
+	padding: 0.75rem 1rem;
+	color: inherit;
+	text-decoration: none;
+	border-block-end: 1px solid var(--color-border-subtle);
+
+	&:hover {
+		background: var(--color-surface-backdrop);
+	}
+
+	&.is-unread {
+		background: var(--color-surface-subtle);
+	}
+}
+
+.social-notification-item__avatar {
+	flex: 0 0 40px;
+	inline-size: 40px;
+	block-size: 40px;
+	border-radius: 50%;
+	overflow: hidden;
+	background: var(--color-neutral-5);
+	object-fit: cover;
+
+	&.is-placeholder {
+		display: inline-block;
+	}
+}
+
+.social-notification-item__body {
+	min-inline-size: 0;
+	flex: 1;
+}
+
+.social-notification-item__line {
+	color: var(--color-text);
+}
+
+.social-notification-item__actor {
+	font-weight: 600;
+}
+
+.social-notification-item__phrase {
+	color: var(--color-text-subtle);
+}
+
+.social-notification-item__excerpt {
+	color: var(--color-text-subtle);
+	overflow: hidden;
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+}
+
+.social-notification-item__time {
+	color: var(--color-text-subtle);
+	font-size: 0.85em;
+}
+
+.social-notification-item__unread-dot {
+	flex: 0 0 0.5rem;
+	inline-size: 0.5rem;
+	block-size: 0.5rem;
+	border-radius: 50%;
+	background: var(--color-accent);
+	margin-block-start: 0.5rem;
+}

--- a/client/reader/social/components/notifications-list/test/index.test.tsx
+++ b/client/reader/social/components/notifications-list/test/index.test.tsx
@@ -72,4 +72,17 @@ describe( 'SocialNotificationsList', () => {
 		renderWithProvider( <SocialNotificationsList { ...baseProps } hasMore isLoadingMore /> );
 		expect( screen.getByRole( 'button', { name: /load more/i } ) ).toBeDisabled();
 	} );
+
+	it( 'shows a retry footer when pagination errors with items present', async () => {
+		const onLoadMore = jest.fn();
+		const user = userEvent.setup();
+		renderWithProvider(
+			<SocialNotificationsList { ...baseProps } hasMore isError onLoadMore={ onLoadMore } />
+		);
+		expect( screen.getByText( /couldn’t load more notifications/i ) ).toBeVisible();
+		// The plain "Load more" button is replaced by the retry CTA.
+		expect( screen.queryByRole( 'button', { name: /load more/i } ) ).toBeNull();
+		await user.click( screen.getByRole( 'button', { name: /try again/i } ) );
+		expect( onLoadMore ).toHaveBeenCalledTimes( 1 );
+	} );
 } );

--- a/client/reader/social/components/notifications-list/test/index.test.tsx
+++ b/client/reader/social/components/notifications-list/test/index.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { SocialNotificationsList } from '../index';
+import type { AtmosphereNotification } from '@automattic/api-core';
+
+const baseItem: AtmosphereNotification = {
+	id: 'a',
+	protocol_type: 'like',
+	canonical_type: 'like',
+	actor: {
+		handle: 'jane.bsky.social',
+		display_name: 'Jane',
+		avatar_url: null,
+		profile_uri: 'at://did:plc:jane',
+	},
+	target: { kind: 'post', uri: 'at://post', excerpt: 'hello' },
+	target_url: 'https://bsky.app/profile/me/post/3k',
+	created_at: '2026-05-11T12:34:56Z',
+	is_read: false,
+	raw: {},
+};
+
+const baseProps = {
+	items: [ baseItem ],
+	seenAt: null,
+	isLoading: false,
+	isError: false,
+	hasMore: false,
+	onLoadMore: jest.fn(),
+};
+
+describe( 'SocialNotificationsList', () => {
+	it( 'renders an empty state when items is empty and not loading', () => {
+		renderWithProvider( <SocialNotificationsList { ...baseProps } items={ [] } /> );
+		expect( screen.getByText( /no notifications yet/i ) ).toBeVisible();
+	} );
+
+	it( 'renders a spinner when loading the first page', () => {
+		renderWithProvider( <SocialNotificationsList { ...baseProps } items={ [] } isLoading /> );
+		expect( screen.getByRole( 'status' ) ).toBeVisible();
+	} );
+
+	it( 'renders an error state when isError is true with no items', () => {
+		renderWithProvider( <SocialNotificationsList { ...baseProps } items={ [] } isError /> );
+		expect( screen.getByText( /couldn’t load notifications/i ) ).toBeVisible();
+	} );
+
+	it( 'renders items', () => {
+		renderWithProvider( <SocialNotificationsList { ...baseProps } /> );
+		expect( screen.getByText( /liked your post/i ) ).toBeVisible();
+	} );
+
+	it( 'shows Load more when hasMore is true and triggers onLoadMore', async () => {
+		const onLoadMore = jest.fn();
+		const user = userEvent.setup();
+		renderWithProvider(
+			<SocialNotificationsList { ...baseProps } hasMore onLoadMore={ onLoadMore } />
+		);
+		await user.click( screen.getByRole( 'button', { name: /load more/i } ) );
+		expect( onLoadMore ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'does not render Load more when hasMore is false', () => {
+		renderWithProvider( <SocialNotificationsList { ...baseProps } hasMore={ false } /> );
+		expect( screen.queryByRole( 'button', { name: /load more/i } ) ).toBeNull();
+	} );
+} );

--- a/client/reader/social/components/notifications-list/test/index.test.tsx
+++ b/client/reader/social/components/notifications-list/test/index.test.tsx
@@ -26,7 +26,6 @@ const baseItem: AtmosphereNotification = {
 
 const baseProps = {
 	items: [ baseItem ],
-	seenAt: null,
 	isLoading: false,
 	isError: false,
 	hasMore: false,
@@ -67,5 +66,10 @@ describe( 'SocialNotificationsList', () => {
 	it( 'does not render Load more when hasMore is false', () => {
 		renderWithProvider( <SocialNotificationsList { ...baseProps } hasMore={ false } /> );
 		expect( screen.queryByRole( 'button', { name: /load more/i } ) ).toBeNull();
+	} );
+
+	it( 'disables Load more while fetching the next page', () => {
+		renderWithProvider( <SocialNotificationsList { ...baseProps } hasMore isLoadingMore /> );
+		expect( screen.getByRole( 'button', { name: /load more/i } ) ).toBeDisabled();
 	} );
 } );

--- a/client/reader/social/components/notifications-list/test/index.test.tsx
+++ b/client/reader/social/components/notifications-list/test/index.test.tsx
@@ -21,7 +21,6 @@ const baseItem: AtmosphereNotification = {
 	target_url: 'https://bsky.app/profile/me/post/3k',
 	created_at: '2026-05-11T12:34:56Z',
 	is_read: false,
-	raw: {},
 };
 
 const baseProps = {

--- a/client/reader/social/components/notifications-list/test/notification-item.test.tsx
+++ b/client/reader/social/components/notifications-list/test/notification-item.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { SocialNotificationItem } from '../notification-item';
+import type { AtmosphereNotification } from '@automattic/api-core';
+
+function makeItem( overrides: Partial< AtmosphereNotification > = {} ): AtmosphereNotification {
+	return {
+		id: 'at://x',
+		protocol_type: 'like',
+		canonical_type: 'like',
+		actor: {
+			handle: 'jane.bsky.social',
+			display_name: 'Jane',
+			avatar_url: null,
+			profile_uri: 'at://did:plc:jane',
+		},
+		target: { kind: 'post', uri: 'at://post', excerpt: 'hello world' },
+		target_url: 'https://bsky.app/profile/me/post/3k',
+		created_at: '2026-05-11T12:34:56Z',
+		is_read: false,
+		raw: {},
+		...overrides,
+	};
+}
+
+describe( 'SocialNotificationItem', () => {
+	it( 'renders a like notification with actor + excerpt', () => {
+		renderWithProvider( <SocialNotificationItem notification={ makeItem() } /> );
+		expect( screen.getByText( /jane/i ) ).toBeVisible();
+		expect( screen.getByText( /liked your post/i ) ).toBeVisible();
+		expect( screen.getByText( /hello world/i ) ).toBeVisible();
+	} );
+
+	it( 'renders a follow notification with no target excerpt', () => {
+		renderWithProvider(
+			<SocialNotificationItem
+				notification={ makeItem( {
+					canonical_type: 'follow',
+					protocol_type: 'follow',
+					target: null,
+				} ) }
+			/>
+		);
+		expect( screen.getByText( /followed you/i ) ).toBeVisible();
+		expect( screen.queryByText( /hello world/i ) ).toBeNull();
+	} );
+
+	it.each( [
+		[ 'repost', /reposted your post/i ],
+		[ 'mention', /mentioned you/i ],
+		[ 'reply', /replied to your post/i ],
+		[ 'quote', /quoted your post/i ],
+	] as const )( 'renders a %s notification', ( type, copy ) => {
+		renderWithProvider(
+			<SocialNotificationItem
+				notification={ makeItem( { canonical_type: type, protocol_type: type } ) }
+			/>
+		);
+		expect( screen.getByText( copy ) ).toBeVisible();
+	} );
+
+	it( 'renders an unknown canonical_type via a generic template using protocol_type', () => {
+		renderWithProvider(
+			<SocialNotificationItem
+				notification={ makeItem( {
+					canonical_type: 'other',
+					protocol_type: 'starterpack-joined',
+					target: null,
+				} ) }
+			/>
+		);
+		expect( screen.getByText( /starterpack joined/i ) ).toBeVisible();
+	} );
+
+	it( 'links the row to target_url with target=_blank', () => {
+		renderWithProvider( <SocialNotificationItem notification={ makeItem() } /> );
+		const link = screen.getByRole( 'link' );
+		expect( link ).toHaveAttribute( 'href', 'https://bsky.app/profile/me/post/3k' );
+		expect( link ).toHaveAttribute( 'target', '_blank' );
+		expect( link.getAttribute( 'rel' ) ).toMatch( /noopener/ );
+	} );
+
+	it( 'applies an unread class when is_read is false', () => {
+		const { container } = renderWithProvider(
+			<SocialNotificationItem notification={ makeItem( { is_read: false } ) } />
+		);
+		expect( container.querySelector( '.is-unread' ) ).not.toBeNull();
+	} );
+
+	it( 'does not apply unread class when is_read is true', () => {
+		const { container } = renderWithProvider(
+			<SocialNotificationItem notification={ makeItem( { is_read: true } ) } />
+		);
+		expect( container.querySelector( '.is-unread' ) ).toBeNull();
+	} );
+} );

--- a/client/reader/social/components/notifications-list/test/notification-item.test.tsx
+++ b/client/reader/social/components/notifications-list/test/notification-item.test.tsx
@@ -21,7 +21,6 @@ function makeItem( overrides: Partial< AtmosphereNotification > = {} ): Atmosphe
 		target_url: 'https://bsky.app/profile/me/post/3k',
 		created_at: '2026-05-11T12:34:56Z',
 		is_read: false,
-		raw: {},
 		...overrides,
 	};
 }

--- a/client/reader/social/components/notifications-list/test/notification-item.test.tsx
+++ b/client/reader/social/components/notifications-list/test/notification-item.test.tsx
@@ -62,7 +62,7 @@ describe( 'SocialNotificationItem', () => {
 		expect( screen.getByText( copy ) ).toBeVisible();
 	} );
 
-	it( 'renders an unknown canonical_type via a generic template using protocol_type', () => {
+	it( 'renders an unknown canonical_type with a generic translated phrase', () => {
 		renderWithProvider(
 			<SocialNotificationItem
 				notification={ makeItem( {
@@ -72,7 +72,14 @@ describe( 'SocialNotificationItem', () => {
 				} ) }
 			/>
 		);
-		expect( screen.getByText( /starterpack joined/i ) ).toBeVisible();
+		expect( screen.getByText( /interacted with you/i ) ).toBeVisible();
+		// The raw protocol_type must not leak through to the UI.
+		expect( screen.queryByText( /starterpack/i ) ).toBeNull();
+	} );
+
+	it( 'announces a per-action aria label on the link', () => {
+		renderWithProvider( <SocialNotificationItem notification={ makeItem() } /> );
+		expect( screen.getByRole( 'link' ) ).toHaveAccessibleName( /jane liked your post/i );
 	} );
 
 	it( 'links the row to target_url with target=_blank', () => {

--- a/client/reader/social/components/notifications-list/test/notification-item.test.tsx
+++ b/client/reader/social/components/notifications-list/test/notification-item.test.tsx
@@ -96,4 +96,22 @@ describe( 'SocialNotificationItem', () => {
 		);
 		expect( container.querySelector( '.is-unread' ) ).toBeNull();
 	} );
+
+	it( 'renders as a non-navigating div when target_url is not http(s)', () => {
+		const { container } = renderWithProvider(
+			<SocialNotificationItem notification={ makeItem( { target_url: 'javascript:alert(1)' } ) } />
+		);
+		// Should NOT be a link.
+		expect( screen.queryByRole( 'link' ) ).toBeNull();
+		// Root is the .social-notification-item element, rendered as a <div>.
+		const root = container.querySelector( '.social-notification-item' );
+		expect( root?.tagName ).toBe( 'DIV' );
+	} );
+
+	it( 'announces unread state via screen-reader-only text', () => {
+		renderWithProvider(
+			<SocialNotificationItem notification={ makeItem( { is_read: false } ) } />
+		);
+		expect( screen.getByText( /^unread$/i ) ).toBeVisible();
+	} );
 } );

--- a/client/reader/social/components/notifications-list/test/notification-item.test.tsx
+++ b/client/reader/social/components/notifications-list/test/notification-item.test.tsx
@@ -115,10 +115,34 @@ describe( 'SocialNotificationItem', () => {
 		expect( root?.tagName ).toBe( 'DIV' );
 	} );
 
-	it( 'announces unread state via screen-reader-only text', () => {
+	it( 'folds the unread state into the link aria-label so screen readers hear it', () => {
 		renderWithProvider(
 			<SocialNotificationItem notification={ makeItem( { is_read: false } ) } />
 		);
-		expect( screen.getByText( /^unread$/i ) ).toBeVisible();
+		expect( screen.getByRole( 'link' ) ).toHaveAccessibleName( /^unread\. jane liked your post/i );
+	} );
+
+	it( 'omits the unread prefix from the aria-label when is_read is true', () => {
+		renderWithProvider( <SocialNotificationItem notification={ makeItem( { is_read: true } ) } /> );
+		expect( screen.getByRole( 'link' ) ).toHaveAccessibleName( /^jane liked your post/i );
+	} );
+
+	it( 'falls back to the actor handle when display_name is null', () => {
+		renderWithProvider(
+			<SocialNotificationItem
+				notification={ makeItem( {
+					actor: {
+						handle: 'jane.bsky.social',
+						display_name: null,
+						avatar_url: null,
+						profile_uri: 'at://did:plc:jane',
+					},
+				} ) }
+			/>
+		);
+		expect( screen.getByText( /jane\.bsky\.social/ ) ).toBeVisible();
+		expect( screen.getByRole( 'link' ) ).toHaveAccessibleName(
+			/jane\.bsky\.social liked your post/i
+		);
 	} );
 } );

--- a/client/reader/social/index.ts
+++ b/client/reader/social/index.ts
@@ -18,6 +18,7 @@ export type { SocialAccountListProps } from './account-list';
 export { SocialPostCard } from './components/post-card';
 export { SocialFeedList } from './components/feed-list';
 export { SocialNotificationItem } from './components/notifications-list/notification-item';
+export { SocialNotificationsList } from './components/notifications-list';
 export { SocialAnalyticsProvider } from './components/post-card/analytics-context';
 
 export type {

--- a/client/reader/social/index.ts
+++ b/client/reader/social/index.ts
@@ -17,6 +17,7 @@ export type { SocialAccountListProps } from './account-list';
 
 export { SocialPostCard } from './components/post-card';
 export { SocialFeedList } from './components/feed-list';
+export { SocialNotificationItem } from './components/notifications-list/notification-item';
 export { SocialAnalyticsProvider } from './components/post-card/analytics-context';
 
 export type {

--- a/packages/api-core/src/reader-atmosphere/__tests__/fetchers.test.ts
+++ b/packages/api-core/src/reader-atmosphere/__tests__/fetchers.test.ts
@@ -1349,7 +1349,6 @@ describe( 'atmosphere fetchers', () => {
 					target_url: 'https://bsky.app/profile/me/post/3k',
 					created_at: '2026-05-11T12:34:56Z',
 					is_read: false,
-					raw: {},
 				},
 			],
 			next_cursor: 'next',

--- a/packages/api-core/src/reader-atmosphere/__tests__/fetchers.test.ts
+++ b/packages/api-core/src/reader-atmosphere/__tests__/fetchers.test.ts
@@ -12,6 +12,7 @@ import {
 	deleteRepost,
 	getAtmosphereActorFollowers,
 	getAtmosphereActorFollows,
+	getAtmosphereNotifications,
 	getAtmosphereTagFeed,
 	getAuthorFeed,
 	getAuthorProfile,
@@ -28,6 +29,7 @@ import type {
 	AtmosphereAuthorFeedPage,
 	AtmosphereAuthorProfile,
 	AtmosphereFeedItem,
+	AtmosphereNotificationsPage,
 	AtmosphereScopedProfile,
 	AtmosphereThreadResponse,
 } from '../types';
@@ -1324,5 +1326,56 @@ describe( 'atmosphere fetchers', () => {
 			expect( res.cursor ).toBeNull();
 			expect( res.items ).toEqual( [] );
 		} );
+	} );
+
+	it( 'getAtmosphereNotifications hits the connection-scoped path with cursor + limit', async () => {
+		const page: AtmosphereNotificationsPage = {
+			items: [
+				{
+					id: 'at://did:plc:jane/app.bsky.feed.like/3l',
+					protocol_type: 'like',
+					canonical_type: 'like',
+					actor: {
+						handle: 'jane.bsky.social',
+						display_name: 'Jane',
+						avatar_url: null,
+						profile_uri: 'at://did:plc:jane',
+					},
+					target: {
+						kind: 'post',
+						uri: 'at://did:plc:me/app.bsky.feed.post/3k',
+						excerpt: 'hello',
+					},
+					target_url: 'https://bsky.app/profile/me/post/3k',
+					created_at: '2026-05-11T12:34:56Z',
+					is_read: false,
+					raw: {},
+				},
+			],
+			next_cursor: 'next',
+			seen_at: '2026-05-10T00:00:00Z',
+		};
+
+		nock( BASE )
+			.get( '/wpcom/v2/reader/atmosphere/connections/101/notifications' )
+			.query( { cursor: 'abc', limit: '30' } )
+			.reply( 200, page );
+
+		const res = await getAtmosphereNotifications( {
+			connectionId: 101,
+			cursor: 'abc',
+			limit: 30,
+		} );
+		expect( res ).toEqual( page );
+	} );
+
+	it( 'getAtmosphereNotifications omits cursor + limit when not provided', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/atmosphere/connections/101/notifications' )
+			.query( {} )
+			.reply( 200, { items: [], next_cursor: null, seen_at: null } );
+
+		const res = await getAtmosphereNotifications( { connectionId: 101 } );
+		expect( res.items ).toEqual( [] );
 	} );
 } );

--- a/packages/api-core/src/reader-atmosphere/__tests__/query-keys.test.ts
+++ b/packages/api-core/src/reader-atmosphere/__tests__/query-keys.test.ts
@@ -15,6 +15,15 @@ describe( 'readerAtmosphereKeys', () => {
 			42,
 		] );
 	} );
+
+	it( 'notifications(connectionId) returns a connection-scoped key', () => {
+		expect( readerAtmosphereKeys.notifications( 42 ) ).toEqual( [
+			'reader',
+			'atmosphere',
+			'notifications',
+			42,
+		] );
+	} );
 } );
 
 describe( 'readerAtmosphereKeys.profile', () => {

--- a/packages/api-core/src/reader-atmosphere/__tests__/types.test.ts
+++ b/packages/api-core/src/reader-atmosphere/__tests__/types.test.ts
@@ -81,4 +81,10 @@ describe( 'AtmosphereNotification types', () => {
 		};
 		expect( page.items[ 0 ].canonical_type ).toBe( 'like' );
 	} );
+
+	it( 'rejects unknown canonical_type values', () => {
+		// @ts-expect-error - 'bogus' is not in the canonical union.
+		const bad: AtmosphereNotificationCanonicalType = 'bogus';
+		expect( bad ).toBe( 'bogus' );
+	} );
 } );

--- a/packages/api-core/src/reader-atmosphere/__tests__/types.test.ts
+++ b/packages/api-core/src/reader-atmosphere/__tests__/types.test.ts
@@ -4,6 +4,11 @@ import type {
 	AtmosphereConnectionsResponse,
 	AtmosphereCreateConnectionResponse,
 	AtmosphereProfileCounts,
+	AtmosphereNotification,
+	AtmosphereNotificationActor,
+	AtmosphereNotificationTarget,
+	AtmosphereNotificationCanonicalType,
+	AtmosphereNotificationsPage,
 } from '../types';
 
 describe( 'reader-atmosphere types compile', () => {
@@ -41,5 +46,39 @@ describe( 'reader-atmosphere types compile', () => {
 		};
 		expect( [ list, created ] ).toHaveLength( 2 );
 		expect( details.counts.followers ).toBe( 0 );
+	} );
+} );
+
+describe( 'AtmosphereNotification types', () => {
+	it( 'compiles a notification envelope', () => {
+		const actor: AtmosphereNotificationActor = {
+			handle: 'jane.bsky.social',
+			display_name: 'Jane',
+			avatar_url: 'https://example/avatar.png',
+			profile_uri: 'at://did:plc:jane',
+		};
+		const target: AtmosphereNotificationTarget = {
+			kind: 'post',
+			uri: 'at://did:plc:me/app.bsky.feed.post/3k',
+			excerpt: 'hello',
+		};
+		const canonical: AtmosphereNotificationCanonicalType = 'like';
+		const item: AtmosphereNotification = {
+			id: 'at://did:plc:jane/app.bsky.feed.like/3l',
+			protocol_type: 'like',
+			canonical_type: canonical,
+			actor,
+			target,
+			target_url: 'https://bsky.app/profile/me/post/3k',
+			created_at: '2026-05-11T12:34:56Z',
+			is_read: false,
+			raw: {},
+		};
+		const page: AtmosphereNotificationsPage = {
+			items: [ item ],
+			next_cursor: null,
+			seen_at: '2026-05-10T00:00:00Z',
+		};
+		expect( page.items[ 0 ].canonical_type ).toBe( 'like' );
 	} );
 } );

--- a/packages/api-core/src/reader-atmosphere/__tests__/types.test.ts
+++ b/packages/api-core/src/reader-atmosphere/__tests__/types.test.ts
@@ -72,7 +72,6 @@ describe( 'AtmosphereNotification types', () => {
 			target_url: 'https://bsky.app/profile/me/post/3k',
 			created_at: '2026-05-11T12:34:56Z',
 			is_read: false,
-			raw: {},
 		};
 		const page: AtmosphereNotificationsPage = {
 			items: [ item ],

--- a/packages/api-core/src/reader-atmosphere/fetchers.ts
+++ b/packages/api-core/src/reader-atmosphere/fetchers.ts
@@ -112,7 +112,7 @@ export async function getAtmosphereNotifications(
 	if ( cursor ) {
 		query.cursor = cursor;
 	}
-	if ( limit ) {
+	if ( typeof limit === 'number' ) {
 		query.limit = String( limit );
 	}
 	try {

--- a/packages/api-core/src/reader-atmosphere/fetchers.ts
+++ b/packages/api-core/src/reader-atmosphere/fetchers.ts
@@ -8,6 +8,7 @@ import type {
 	AtmosphereConnectionsResponse,
 	AtmosphereCreateConnectionResponse,
 	AtmosphereCreateFollowResponse,
+	AtmosphereNotificationsPage,
 	AtmosphereScopedProfile,
 	AtmosphereScopedProfilesPage,
 	AtmosphereTagFeedPage,
@@ -92,6 +93,36 @@ export async function getTimeline( params: GetTimelineParams ): Promise< Atmosph
 			},
 			query
 		) ) as AtmosphereTimelinePage;
+	} catch ( raw ) {
+		throw classifyAtmosphereError( raw );
+	}
+}
+
+export interface GetAtmosphereNotificationsParams {
+	connectionId: number;
+	cursor?: string;
+	limit?: number;
+}
+
+export async function getAtmosphereNotifications(
+	params: GetAtmosphereNotificationsParams
+): Promise< AtmosphereNotificationsPage > {
+	const { connectionId, cursor, limit } = params;
+	const query: Record< string, string > = {};
+	if ( cursor ) {
+		query.cursor = cursor;
+	}
+	if ( limit ) {
+		query.limit = String( limit );
+	}
+	try {
+		return ( await wpcom.req.get(
+			{
+				path: `/reader/atmosphere/connections/${ connectionId }/notifications`,
+				apiNamespace: NAMESPACE,
+			},
+			query
+		) ) as AtmosphereNotificationsPage;
 	} catch ( raw ) {
 		throw classifyAtmosphereError( raw );
 	}

--- a/packages/api-core/src/reader-atmosphere/query-keys.ts
+++ b/packages/api-core/src/reader-atmosphere/query-keys.ts
@@ -6,6 +6,8 @@ export const readerAtmosphereKeys = {
 	connection: ( id: number | null ) => [ ...readerAtmosphereKeys.all, 'connection', id ] as const,
 	timeline: ( connectionId: number ) =>
 		[ ...readerAtmosphereKeys.all, 'timeline', connectionId ] as const,
+	notifications: ( connectionId: number ) =>
+		[ ...readerAtmosphereKeys.all, 'notifications', connectionId ] as const,
 	thread: ( uri: string ) => [ ...readerAtmosphereKeys.all, 'thread', uri ] as const,
 	scopedThread: ( connectionId: number, uri: string ) =>
 		[ ...readerAtmosphereKeys.all, 'scoped-thread', connectionId, uri ] as const,

--- a/packages/api-core/src/reader-atmosphere/types.ts
+++ b/packages/api-core/src/reader-atmosphere/types.ts
@@ -405,6 +405,12 @@ export interface DeletePostParams {
 	rkey: string;
 }
 
+/**
+ * Normalized cross-protocol notification kind. `'other'` is the forward-compat
+ * bucket for upstream types we don't yet render with bespoke templates (e.g.
+ * starterpack-joined, verified, subscribed-post). The frontend falls through to
+ * a generic renderer that uses `protocol_type` for the label.
+ */
 export type AtmosphereNotificationCanonicalType =
 	| 'like'
 	| 'repost'
@@ -427,8 +433,17 @@ export interface AtmosphereNotificationTarget {
 	excerpt: string;
 }
 
+/**
+ * Envelope shape returned by
+ * `/wpcom/v2/reader/atmosphere/connections/:id/notifications`.
+ * `protocol_type` is the raw upstream string (verbatim, lossless);
+ * `canonical_type` is the normalized enum. `raw` carries the original upstream
+ * object for forward-compat rendering. `is_read` is server-computed against the
+ * user's `seenAt` watermark.
+ */
 export interface AtmosphereNotification {
 	id: string;
+	/** Raw upstream type string, e.g. ATProto `reason`. */
 	protocol_type: string;
 	canonical_type: AtmosphereNotificationCanonicalType;
 	actor: AtmosphereNotificationActor;
@@ -439,6 +454,12 @@ export interface AtmosphereNotification {
 	raw: unknown;
 }
 
+/**
+ * Single page from the cursor-paginated notifications endpoint.
+ * `next_cursor: null` means end-of-list. `seen_at` is the server's watermark
+ * timestamp, exposed at the page level (not per-item) so subsequent "Load more"
+ * pages can classify items without re-fetching.
+ */
 export interface AtmosphereNotificationsPage {
 	items: AtmosphereNotification[];
 	next_cursor: string | null;

--- a/packages/api-core/src/reader-atmosphere/types.ts
+++ b/packages/api-core/src/reader-atmosphere/types.ts
@@ -437,9 +437,11 @@ export interface AtmosphereNotificationTarget {
  * Envelope shape returned by
  * `/wpcom/v2/reader/atmosphere/connections/:id/notifications`.
  * `protocol_type` is the raw upstream string (verbatim, lossless);
- * `canonical_type` is the normalized enum. `raw` carries the original upstream
- * object for forward-compat rendering. `is_read` is server-computed against the
- * user's `seenAt` watermark.
+ * `canonical_type` is the normalized enum. There is no `raw` passthrough —
+ * `protocol_type` is the long-tail escape hatch for upstream kinds we don't
+ * yet render with bespoke templates. `created_at` is nullable: the backend
+ * returns `null` when `indexedAt` is missing or unparseable. `is_read` is
+ * server-computed against the user's `seenAt` watermark.
  */
 export interface AtmosphereNotification {
 	id: string;
@@ -449,9 +451,8 @@ export interface AtmosphereNotification {
 	actor: AtmosphereNotificationActor;
 	target: AtmosphereNotificationTarget | null;
 	target_url: string;
-	created_at: string;
+	created_at: string | null;
 	is_read: boolean;
-	raw: unknown;
 }
 
 /**

--- a/packages/api-core/src/reader-atmosphere/types.ts
+++ b/packages/api-core/src/reader-atmosphere/types.ts
@@ -404,3 +404,43 @@ export interface DeletePostParams {
 	connectionId: number;
 	rkey: string;
 }
+
+export type AtmosphereNotificationCanonicalType =
+	| 'like'
+	| 'repost'
+	| 'follow'
+	| 'mention'
+	| 'reply'
+	| 'quote'
+	| 'other';
+
+export interface AtmosphereNotificationActor {
+	handle: string;
+	display_name: string | null;
+	avatar_url: string | null;
+	profile_uri: string;
+}
+
+export interface AtmosphereNotificationTarget {
+	kind: 'post' | 'profile';
+	uri: string;
+	excerpt: string;
+}
+
+export interface AtmosphereNotification {
+	id: string;
+	protocol_type: string;
+	canonical_type: AtmosphereNotificationCanonicalType;
+	actor: AtmosphereNotificationActor;
+	target: AtmosphereNotificationTarget | null;
+	target_url: string;
+	created_at: string;
+	is_read: boolean;
+	raw: unknown;
+}
+
+export interface AtmosphereNotificationsPage {
+	items: AtmosphereNotification[];
+	next_cursor: string | null;
+	seen_at: string | null;
+}

--- a/packages/api-queries/src/__tests__/reader-atmosphere.test.tsx
+++ b/packages/api-queries/src/__tests__/reader-atmosphere.test.tsx
@@ -36,6 +36,7 @@ import {
 	removePlaceholder,
 	swapPlaceholder,
 	unfollowAtmosphereActorMutation,
+	useAtmosphereNotificationsInfiniteQuery,
 	useAtmosphereScopedAuthorFeedInfiniteQuery,
 	useAtmosphereScopedThreadQuery,
 	useAuthorFeedInfiniteQuery,
@@ -220,6 +221,79 @@ describe( 'reader-atmosphere hooks', () => {
 				await result.current.refetch();
 			} );
 			expect( result.current.isSuccess ).toBe( true );
+		} );
+	} );
+
+	describe( 'useAtmosphereNotificationsInfiniteQuery', () => {
+		const PATH = '/wpcom/v2/reader/atmosphere/connections/42/notifications';
+
+		let wrapper: React.FC< { children: React.ReactNode } >;
+
+		// Same `notifyOnChangeProps: 'tracked'` workaround as the timeline test:
+		// touching properties inside the render callback so the observer
+		// notifies on later updates.
+		const renderNotificationsHook = ( connectionId: number ) =>
+			renderHook(
+				() => {
+					const q = useAtmosphereNotificationsInfiniteQuery( connectionId );
+					void q.data;
+					void q.hasNextPage;
+					void q.isFetchingNextPage;
+					void q.isError;
+					void q.error;
+					return q;
+				},
+				{ wrapper }
+			);
+
+		beforeEach( () => {
+			const client = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+			wrapper = ( { children } ) => (
+				<QueryClientProvider client={ client }>{ children }</QueryClientProvider>
+			);
+		} );
+
+		afterEach( () => {
+			nock.cleanAll();
+		} );
+
+		it( 'is disabled when connectionId is 0', () => {
+			const { result } = renderNotificationsHook( 0 );
+			expect( result.current.fetchStatus ).toBe( 'idle' );
+			expect( result.current.data ).toBeUndefined();
+		} );
+
+		it( 'fetches the first page on mount', async () => {
+			nock( BASE ).get( PATH ).query( {} ).reply( 200, {
+				items: [],
+				next_cursor: null,
+				seen_at: null,
+			} );
+			const { result } = renderNotificationsHook( 42 );
+			await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+			expect( result.current.data?.pages[ 0 ].items ).toEqual( [] );
+		} );
+
+		it( 'paginates via next_cursor returned by the previous page', async () => {
+			nock( BASE ).get( PATH ).query( {} ).reply( 200, {
+				items: [],
+				next_cursor: 'page-2',
+				seen_at: null,
+			} );
+			nock( BASE )
+				.get( PATH )
+				.query( { cursor: 'page-2' } )
+				.reply( 200, { items: [], next_cursor: null, seen_at: null } );
+
+			const { result } = renderNotificationsHook( 42 );
+			await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+			expect( result.current.hasNextPage ).toBe( true );
+
+			await act( async () => {
+				await result.current.fetchNextPage();
+			} );
+			expect( result.current.data?.pages.length ).toBe( 2 );
+			expect( result.current.hasNextPage ).toBe( false );
 		} );
 	} );
 

--- a/packages/api-queries/src/reader-atmosphere.ts
+++ b/packages/api-queries/src/reader-atmosphere.ts
@@ -176,7 +176,7 @@ export const notificationsInfiniteQuery = ( connectionId: number ) =>
 		queryKey: readerAtmosphereKeys.notifications( connectionId ),
 		queryFn: ( { pageParam } ) => getAtmosphereNotifications( { connectionId, cursor: pageParam } ),
 		initialPageParam: undefined,
-		getNextPageParam: ( lastPage ) => lastPage.next_cursor || undefined,
+		getNextPageParam: ( lastPage ) => lastPage.next_cursor ?? undefined,
 		enabled: connectionId > 0,
 		staleTime: 30_000,
 		gcTime: 5 * 60_000,

--- a/packages/api-queries/src/reader-atmosphere.ts
+++ b/packages/api-queries/src/reader-atmosphere.ts
@@ -10,6 +10,7 @@ import {
 	deleteRepost,
 	getAtmosphereActorFollowers,
 	getAtmosphereActorFollows,
+	getAtmosphereNotifications,
 	getAtmosphereTagFeed,
 	getAuthorFeed,
 	getAuthorProfile,
@@ -52,6 +53,7 @@ import type {
 	AtmosphereEmbed,
 	AtmosphereError,
 	AtmosphereFeedItem,
+	AtmosphereNotificationsPage,
 	AtmosphereScopedProfile,
 	AtmosphereScopedProfilesPage,
 	AtmosphereTagFeedPage,
@@ -161,6 +163,27 @@ export const timelineInfiniteQuery = ( connectionId: number ) =>
 
 export function useTimelineInfiniteQuery( connectionId: number ) {
 	return useInfiniteQuery( timelineInfiniteQuery( connectionId ) );
+}
+
+export const notificationsInfiniteQuery = ( connectionId: number ) =>
+	infiniteQueryOptions<
+		AtmosphereNotificationsPage,
+		AtmosphereError,
+		InfiniteData< AtmosphereNotificationsPage >,
+		QueryKey,
+		string | undefined
+	>( {
+		queryKey: readerAtmosphereKeys.notifications( connectionId ),
+		queryFn: ( { pageParam } ) => getAtmosphereNotifications( { connectionId, cursor: pageParam } ),
+		initialPageParam: undefined,
+		getNextPageParam: ( lastPage ) => lastPage.next_cursor || undefined,
+		enabled: connectionId > 0,
+		staleTime: 30_000,
+		gcTime: 5 * 60_000,
+	} );
+
+export function useAtmosphereNotificationsInfiniteQuery( connectionId: number ) {
+	return useInfiniteQuery( notificationsInfiniteQuery( connectionId ) );
 }
 
 export const threadQueryOptions = ( uri: string ) =>


### PR DESCRIPTION
Fixes CM-705

## Proposed Changes

* Add a new "Notifications" tab between Timeline and Profile in the Reader's ATmosphere section.
* Add `GET /wpcom/v2/reader/atmosphere/connections/:id/notifications` consumer: typed fetcher, `useAtmosphereNotificationsInfiniteQuery` hook, and cursor-paginated infinite-query factory in `@automattic/api-core` / `@automattic/api-queries`.
* Add a new protocol-agnostic shared component pair under `client/reader/social/components/notifications-list/` — `SocialNotificationsList` (list shell with empty / loading / error / Load more states) and `SocialNotificationItem` (per-item renderer with seven canonical-type templates plus a generic `other` fallback).
* Wire the atmosphere panel through a thin `NotificationsPanel` wrapper that hands envelope-shaped data straight to the shared component.
* Read-state UX is display-only in this cut — unread items get a visual treatment from the server-supplied `is_read` flag. "Mark all as read" is intentionally deferred.

## Why are these changes being made?

* Notifications are a missing piece for users who manage their Bluesky activity from inside the WordPress.com Reader — surfaces likes, reposts, follows, mentions, replies, quotes, and the long tail of upstream notification types.
* Builds the protocol-agnostic shared component so Mastodon can plug in next via a thin wrapper with zero further changes to the shared layer (the success test for the abstraction).

## Testing Instructions

* `yarn test-packages packages/api-core/src/reader-atmosphere` — 143 / 143 passing.
* `yarn test-packages packages/api-queries/src/__tests__/reader-atmosphere.test.tsx` — 108 / 108 passing.
* `yarn test-client client/reader/social/components/notifications-list` — 18 / 18 passing.
* `yarn test-client client/reader/atmosphere` — 267 / 267 passing.
* `yarn typecheck-client` clean (pre-existing `@automattic/omnibar` errors unrelated to this branch).
* Manual smoke test deferred — the backend endpoint ships in a separate parallel PR on the wpcom side; until that lands, the tab renders its error state (which is intentional and tested).
* Once the backend endpoint is in place: load `/reader/atmosphere/<id>/notifications`, confirm Timeline / Notifications / Profile order in the tab bar, click between tabs, scroll-to-load-more if more than one page is returned, click a notification row and confirm it opens upstream in a new tab.

### Dependencies

* Requires a companion wpcom PR on the macau repo that ships the new endpoint. The frontend ships safely before the backend — the error state is what users see until then. The envelope shape is locked between the two PRs; any change must be coordinated.

### Feature flag

* No new flag. The atmosphere routes are already gated behind the existing `reader/social` flag (disabled on production, enabled on `wpcalypso` / `development` / `test` / `stage` / `horizon`); the new tab inherits the gate for free.

### Out of scope (explicit follow-ups)

* Mastodon endpoint (separate wpcom PR) + Mastodon wrapper using the same shared component.
* "Mark all as read" write action (Bluesky `app.bsky.notification.updateSeen`, Mastodon `markers` PUT).
* Tab-bar unread badge.
* Background polling.
* Inline Reader navigation for clicked notifications — for now `target_url` opens upstream in a new tab; the envelope is shaped so inline navigation can be added later without a backend change.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
