### PR TITLE
Checkout: wire up Stripe EPS slug mappings and refresh EPS label

### DIFF
--- a/packages/wpcom-checkout/src/payment-methods/eps.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/eps.tsx
@@ -58,7 +58,7 @@ export function createEpsMethod( {
 		activeContent: <EpsFields state={ state } />,
 		submitButton: <EpsPayButton state={ state } submitButtonContent={ submitButtonContent } />,
 		inactiveContent: <EpsSummary state={ state } />,
-		getAriaLabel: ( __ ) => __( 'EPS e-Pay' ),
+		getAriaLabel: ( __ ) => __( 'EPS' ),
 	};
 }
 
@@ -186,7 +186,7 @@ function isFormValid( state: EpsPaymentMethodState ): boolean {
 }
 
 function EpsLogoImg( { className }: { className?: string } ) {
-	return <img src="/calypso/images/upgrades/eps.svg" alt="EPS e-Pay" className={ className } />;
+	return <img src="/calypso/images/upgrades/eps.svg" alt="EPS" className={ className } />;
 }
 
 const EpsLogo = styled( EpsLogoImg )`
@@ -197,7 +197,7 @@ function EpsLabel() {
 	const { __ } = useI18n();
 	return (
 		<Fragment>
-			<span>{ __( 'EPS e-Pay' ) }</span>
+			<span>{ __( 'EPS' ) }</span>
 			<PaymentMethodLogos className="eps__logo payment-logos">
 				<EpsLogo />
 			</PaymentMethodLogos>

--- a/packages/wpcom-checkout/src/translate-payment-method-names.ts
+++ b/packages/wpcom-checkout/src/translate-payment-method-names.ts
@@ -33,6 +33,8 @@ export function translateWpcomPaymentMethodToCheckoutPaymentMethod(
 			return 'alipay';
 		case 'WPCOM_Billing_Stripe_Bancontact':
 			return 'bancontact';
+		case 'WPCOM_Billing_Stripe_Eps':
+			return 'eps';
 		case 'WPCOM_Billing_Stripe_Ideal':
 			return 'ideal';
 		case 'WPCOM_Billing_Stripe_P24':
@@ -92,6 +94,8 @@ export function translateCheckoutPaymentMethodToWpcomPaymentMethod(
 			return 'WPCOM_Billing_Stripe_Alipay';
 		case 'bancontact':
 			return 'WPCOM_Billing_Stripe_Bancontact';
+		case 'eps':
+			return 'WPCOM_Billing_Stripe_Eps';
 		case 'ideal':
 			return 'WPCOM_Billing_Stripe_Ideal';
 		case 'p24':
@@ -127,6 +131,7 @@ export function readWPCOMPaymentMethodClass( slug: string ): WPCOMPaymentMethod 
 		case 'WPCOM_Billing_Stripe_Payment_Method':
 		case 'WPCOM_Billing_Stripe_Alipay':
 		case 'WPCOM_Billing_Stripe_Bancontact':
+		case 'WPCOM_Billing_Stripe_Eps':
 		case 'WPCOM_Billing_Stripe_Ideal':
 		case 'WPCOM_Billing_Stripe_P24':
 		case 'WPCOM_Billing_Stripe_Wechat_Pay':
@@ -163,6 +168,7 @@ export function readCheckoutPaymentMethodSlug( slug: string ): CheckoutPaymentMe
 		case 'existingPayPalPPCP':
 		case 'alipay':
 		case 'bancontact':
+		case 'eps':
 		case 'ideal':
 		case 'p24':
 		case 'wechat':
@@ -205,6 +211,7 @@ export function isRedirectPaymentMethod( slug: CheckoutPaymentMethodSlug ): bool
 	const redirectPaymentMethods = [
 		'alipay',
 		'bancontact',
+		'eps',
 		'ideal',
 		'netbanking',
 		'paypal-express',

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -371,6 +371,7 @@ export type WPCOMPaymentMethod =
 	| 'WPCOM_Billing_Stripe_Payment_Method'
 	| 'WPCOM_Billing_Stripe_Alipay'
 	| 'WPCOM_Billing_Stripe_Bancontact'
+	| 'WPCOM_Billing_Stripe_Eps'
 	| 'WPCOM_Billing_Stripe_Ideal'
 	| 'WPCOM_Billing_Stripe_P24'
 	| 'WPCOM_Billing_Stripe_Wechat_Pay'

--- a/packages/wpcom-checkout/test/translate-payment-method-names.ts
+++ b/packages/wpcom-checkout/test/translate-payment-method-names.ts
@@ -1,0 +1,37 @@
+import {
+	translateWpcomPaymentMethodToCheckoutPaymentMethod,
+	translateCheckoutPaymentMethodToWpcomPaymentMethod,
+	readWPCOMPaymentMethodClass,
+	readCheckoutPaymentMethodSlug,
+	isRedirectPaymentMethod,
+} from '../src';
+
+describe( 'translate-payment-method-names', () => {
+	describe( 'EPS', () => {
+		test( 'maps WPCOM_Billing_Stripe_Eps to the eps slug', () => {
+			expect(
+				translateWpcomPaymentMethodToCheckoutPaymentMethod( 'WPCOM_Billing_Stripe_Eps' )
+			).toStrictEqual( 'eps' );
+		} );
+
+		test( 'maps the eps slug to WPCOM_Billing_Stripe_Eps', () => {
+			expect( translateCheckoutPaymentMethodToWpcomPaymentMethod( 'eps' ) ).toStrictEqual(
+				'WPCOM_Billing_Stripe_Eps'
+			);
+		} );
+
+		test( 'recognises WPCOM_Billing_Stripe_Eps as a valid WPCOM payment method class', () => {
+			expect( readWPCOMPaymentMethodClass( 'WPCOM_Billing_Stripe_Eps' ) ).toStrictEqual(
+				'WPCOM_Billing_Stripe_Eps'
+			);
+		} );
+
+		test( 'recognises eps as a valid checkout payment method slug', () => {
+			expect( readCheckoutPaymentMethodSlug( 'eps' ) ).toStrictEqual( 'eps' );
+		} );
+
+		test( 'classifies eps as a redirect payment method', () => {
+			expect( isRedirectPaymentMethod( 'eps' ) ).toBe( true );
+		} );
+	} );
+} );


### PR DESCRIPTION
Part of SHILL-1995

## Proposed Changes

* Add `'WPCOM_Billing_Stripe_Eps'` to the `WPCOMPaymentMethod` union in `packages/wpcom-checkout/src/types.ts`.
* Wire up the EPS slug mappings in `packages/wpcom-checkout/src/translate-payment-method-names.ts`:
  * `translateWpcomPaymentMethodToCheckoutPaymentMethod`: `WPCOM_Billing_Stripe_Eps` → `'eps'`
  * `translateCheckoutPaymentMethodToWpcomPaymentMethod`: `'eps'` → `WPCOM_Billing_Stripe_Eps`
  * `readWPCOMPaymentMethodClass`: accept `WPCOM_Billing_Stripe_Eps`
  * `readCheckoutPaymentMethodSlug`: accept `'eps'`
  * `isRedirectPaymentMethod`: classify `'eps'` as a redirect method
* Refresh the EPS label/aria-label/alt text from the legacy *"EPS e-Pay"* to just *"EPS"* in `packages/wpcom-checkout/src/payment-methods/eps.tsx`.
* Add a small unit test covering all five EPS slug-mapping touchpoints (`packages/wpcom-checkout/test/translate-payment-method-names.ts`).

## Why are these changes being made?

The EPS frontend scaffolding has existed in `wp-calypso` for some time (`eps.tsx`, the `useCreateEps` hook, the `genericRedirectProcessor('eps', ...)` registration, the logo, the cart-values entry, an `'eps'` slug in `CheckoutPaymentMethodSlug`), but EPS could never be surfaced to the UI because:

* The `WPCOMPaymentMethod` union did not include `WPCOM_Billing_Stripe_Eps`.
* `translate-payment-method-names.ts` had no slug ↔ class mappings for EPS, so `filterAppropriatePaymentMethods()` would reject it regardless of what the server returned from `get_active_payment_methods`.
* There was no `'eps'` entry in `isRedirectPaymentMethod`, so it would not have been treated as a redirect method by callers that check this.

The matching backend gateway (`WPCOM_Billing_Stripe_Eps`) has now landed in wpcom, so the only remaining gap is the slug-mapping wiring. The component itself is structurally identical to `ideal.tsx` and uses the same `genericRedirectProcessor` flow, so no other frontend changes are needed beyond the label refresh.

The new unit test covers the exact class of bug that left EPS unreachable for so long — missing slug-mapping cases — so any future redirect-only Stripe LPM can use it as a smoke-test pattern.

## Testing Instructions

* Run `yarn test-packages packages/wpcom-checkout/test/translate-payment-method-names.ts` — all 5 tests should pass.
* Run `yarn typecheck-packages` — should pass with no errors.
* With the linked backend PR: a checkout session for an Austrian (`AT`) customer paying in EUR, confirm the EPS option appears in the payment method picker, that the label reads *"EPS"* with the existing logo, and that selecting it kicks off the redirect flow through `genericRedirectProcessor`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?