### PR TITLE
Reader Fediverse: slice 2 — standalone publish composer

### DIFF
--- a/client/reader/fediverse/composer-config.tsx
+++ b/client/reader/fediverse/composer-config.tsx
@@ -1,0 +1,143 @@
+import { createFediversePostMutation } from '@automattic/api-queries';
+import config from '@automattic/calypso-config';
+import { logToLogstash } from 'calypso/lib/logstash';
+import { useFediverseComposerExtras } from './use-fediverse-composer-extras';
+import { useFediverseComposerLimit } from './use-fediverse-composer-limit';
+import type {
+	FediverseCreatePostParams,
+	FediverseCreatePostResult,
+	FediverseError,
+} from '@automattic/api-core';
+import type { ComposerConfig, Translate } from 'calypso/reader/social/composer';
+import type { ReactNode } from 'react';
+
+/**
+ * Per-protocol composer configuration for the Fediverse standalone
+ * publish surface. Mirrors `atmosphereComposerConfig` /
+ * `mastodonComposerConfig` — the shared `<ComposerModal>` drives the
+ * UX, this config supplies the wire mutation, copy, Tracks event names,
+ * and the slice-2-specific extras (visibility selector, content-warning
+ * toggle + summary, sensitive flag).
+ *
+ * Slice 2 is `standalone`-only; reply / quote slices reuse this config
+ * and widen `supportedModes` when they land.
+ */
+export const fediverseComposerConfig: ComposerConfig<
+	FediverseError,
+	FediverseCreatePostParams,
+	FediverseCreatePostResult
+> = {
+	useLimit: useFediverseComposerLimit,
+	protocolLabel: 'Fediverse',
+	supportedModes: [ 'standalone' ],
+	mutationFactory: createFediversePostMutation,
+	buildParams: ( mode, text ) => {
+		if ( mode.kind !== 'standalone' ) {
+			// Shouldn't happen — the provider rejects unsupported kinds via
+			// `supportedModes`. Defensive fallback so the modal never crashes
+			// mid-submit if the union widens before this config is updated.
+			return { connectionId: mode.connectionId, content: text, visibility: 'public' };
+		}
+		// `visibility` / `summary` / `sensitive` / `idempotencyKey` are
+		// merged in by the extras slot's `extendBuildParams` (see
+		// `useFediverseComposerExtras`). `'public'` is a safe placeholder —
+		// the extras slot overrides it before the mutation runs.
+		return { connectionId: mode.connectionId, content: text, visibility: 'public' };
+	},
+	errorMessage: ( error, translate ) => errorMessageFor( error, translate ),
+	successNotice: ( _mode, _result, translate ) => ( {
+		text: translate( 'Your post was published.' ),
+		// In-app thread surface lands in a later slice; until then, the
+		// permalink is the only stable link, but the "View" button is
+		// optional on the success notice — leaving null keeps the toast
+		// noise-free.
+		threadUrl: null,
+	} ),
+	tracks: {
+		opened: ( mode ) => ( {
+			event: 'calypso_reader_fediverse_compose_opened',
+			props: {
+				connection_id: mode.connectionId,
+				entry_point: mode.kind === 'standalone' ? mode.entry_point : 'unknown',
+			},
+		} ),
+		published: ( mode, result ) => ( {
+			event: 'calypso_reader_fediverse_post_published',
+			props: {
+				connection_id: mode.connectionId,
+				new_post_id: result.item.id,
+			},
+		} ),
+		errorShown: ( mode, error ) => ( {
+			event: 'calypso_reader_fediverse_post_error_shown',
+			props: {
+				connection_id: mode.connectionId,
+				error_kind: error.kind,
+			},
+		} ),
+	},
+	copy: {
+		title: ( _mode, t ) => t( 'New post' ) as string,
+		placeholder: ( _mode, t ) => t( 'What’s up?' ) as string,
+	},
+	logBadRequest: ( _mode, error ) => {
+		if ( error.kind !== 'bad_request' ) {
+			return;
+		}
+		// Same shape as the ATmosphere bad_request logger — surface the raw
+		// response message for downstream classification tuning.
+		logToLogstash( {
+			feature: 'calypso_client',
+			message: 'Fediverse composer bad_request',
+			severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
+			extra: {
+				env: config( 'env_id' ),
+				type: 'reader_fediverse_composer_bad_request',
+				error_message: error.message,
+			},
+		} );
+	},
+	useProtocolExtras: useFediverseComposerExtras,
+};
+
+function errorMessageFor( err: FediverseError, t: Translate ): ReactNode {
+	switch ( err.kind ) {
+		case 'text_too_long':
+			return t( 'Your post is too long. Try shortening it.' );
+		case 'summary_too_long':
+			return t( 'The content-warning summary is too long. Try shortening it.' );
+		case 'visibility_invalid':
+			return t( 'That visibility option isn’t supported yet. Pick a different one and try again.' );
+		case 'publish_disabled':
+			return t( 'Publishing from the Fediverse isn’t enabled for this site.' );
+		case 'target_unavailable':
+			return t( 'The Fediverse target is unavailable right now. Try again in a moment.' );
+		case 'bad_request':
+			return t( 'We couldn’t publish this. Try shortening your post or changing visibility.' );
+		case 'auth_required':
+			return t( 'Your Fediverse connection needs to be reconnected. {{a}}Reconnect{{/a}}', {
+				components: {
+					a: <a href="/reader/fediverse" target="_blank" rel="noopener noreferrer" />,
+				},
+				comment:
+					'Composer error shown when the user’s Fediverse session expired; {{a}}…{{/a}} wraps a link to the Fediverse pane.',
+			} );
+		case 'connection_not_found':
+			return t( 'Your Fediverse connection is no longer available. Disconnect and reconnect.' );
+		case 'rate_limited':
+			return t( 'The Fediverse is asking us to slow down. Try again in a moment.' );
+		case 'upstream_unavailable':
+			return t( 'The Fediverse is unreachable right now. Try again in a moment.' );
+		case 'not_found':
+			return t( 'We couldn’t find that target.' );
+		case 'unknown':
+			return t( 'Something went wrong. Try again in a moment.' );
+		default:
+			// Defensive fallback. Same pattern as the like / repost adapters —
+			// a future widening of `FediverseError` would otherwise surface an
+			// empty toast.
+			// eslint-disable-next-line no-console
+			console.warn( '[reader-fediverse] unhandled FediverseError kind in errorMessageFor()', err );
+			return t( 'Something went wrong. Try again in a moment.' );
+	}
+}

--- a/client/reader/fediverse/composer-config.tsx
+++ b/client/reader/fediverse/composer-config.tsx
@@ -28,6 +28,11 @@ export const fediverseComposerConfig: ComposerConfig<
 	FediverseCreatePostResult
 > = {
 	useLimit: useFediverseComposerLimit,
+	// Count words rather than graphemes. AP posts are blog-post-shaped,
+	// so a word threshold maps onto "open the blog editor" handoff better
+	// than a grapheme cap. Backend enforces wire-level char limits and
+	// surfaces them via the `text_too_long` error path.
+	counter: 'words',
 	protocolLabel: 'Fediverse',
 	supportedModes: [ 'standalone' ],
 	mutationFactory: createFediversePostMutation,
@@ -65,7 +70,7 @@ export const fediverseComposerConfig: ComposerConfig<
 			event: 'calypso_reader_fediverse_post_published',
 			props: {
 				connection_id: mode.connectionId,
-				new_post_id: result.item.id,
+				new_post_id: result.post.id,
 			},
 		} ),
 		errorShown: ( mode, error ) => ( {
@@ -74,6 +79,16 @@ export const fediverseComposerConfig: ComposerConfig<
 				connection_id: mode.connectionId,
 				error_kind: error.kind,
 			},
+		} ),
+	},
+	overflowHandoff: {
+		shown: ( mode ) => ( {
+			event: 'calypso_reader_fediverse_overflow_handoff_shown',
+			props: { connection_id: mode.connectionId, mode_kind: mode.kind },
+		} ),
+		editorOpened: ( mode, { siteId } ) => ( {
+			event: 'calypso_reader_fediverse_overflow_handoff_editor_opened',
+			props: { connection_id: mode.connectionId, mode_kind: mode.kind, site_id: siteId },
 		} ),
 	},
 	copy: {

--- a/client/reader/fediverse/composer-config.tsx
+++ b/client/reader/fediverse/composer-config.tsx
@@ -37,16 +37,13 @@ export const fediverseComposerConfig: ComposerConfig<
 	supportedModes: [ 'standalone' ],
 	mutationFactory: createFediversePostMutation,
 	buildParams: ( mode, text ) => {
-		if ( mode.kind !== 'standalone' ) {
-			// Shouldn't happen — the provider rejects unsupported kinds via
-			// `supportedModes`. Defensive fallback so the modal never crashes
-			// mid-submit if the union widens before this config is updated.
-			return { connectionId: mode.connectionId, content: text, visibility: 'public' };
-		}
 		// `visibility` / `summary` / `sensitive` / `idempotencyKey` are
 		// merged in by the extras slot's `extendBuildParams` (see
 		// `useFediverseComposerExtras`). `'public'` is a safe placeholder —
 		// the extras slot overrides it before the mutation runs.
+		// `supportedModes: [ 'standalone' ]` gates non-standalone modes at
+		// the provider level, so widening the union later requires updating
+		// this config (TypeScript will flag the missing arm).
 		return { connectionId: mode.connectionId, content: text, visibility: 'public' };
 	},
 	errorMessage: ( error, translate ) => errorMessageFor( error, translate ),

--- a/client/reader/fediverse/composer-config.tsx
+++ b/client/reader/fediverse/composer-config.tsx
@@ -145,11 +145,23 @@ function errorMessageFor( err: FediverseError, t: Translate ): ReactNode {
 		case 'unknown':
 			return t( 'Something went wrong. Try again in a moment.' );
 		default:
-			// Defensive fallback. Same pattern as the like / repost adapters —
-			// a future widening of `FediverseError` would otherwise surface an
-			// empty toast.
-			// eslint-disable-next-line no-console
-			console.warn( '[reader-fediverse] unhandled FediverseError kind in errorMessageFor()', err );
+			// Exhaustiveness gate — matches the Mastodon composer-config
+			// precedent (`client/reader/mastodon/composer-config.tsx`) and the
+			// project rule in `client/reader/social/AGENTS.md` § "Composer
+			// (slice 7)". A future widening of `FediverseError[ 'kind' ]`
+			// fails type-check here instead of silently rendering the generic
+			// toast; the logstash breadcrumb surfaces production drift.
+			err satisfies never;
+			logToLogstash( {
+				feature: 'calypso_client',
+				message: 'Fediverse composer unhandled error kind',
+				severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
+				extra: {
+					env: config( 'env_id' ),
+					type: 'reader_fediverse_composer_unhandled_error_kind',
+					error: err,
+				},
+			} );
 			return t( 'Something went wrong. Try again in a moment.' );
 	}
 }

--- a/client/reader/fediverse/composer-config.tsx
+++ b/client/reader/fediverse/composer-config.tsx
@@ -1,4 +1,4 @@
-import { createFediversePostMutation } from '@automattic/api-queries';
+import { createFediversePostMutation, useFediverseConnectionsQuery } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
 import { logToLogstash } from 'calypso/lib/logstash';
 import { useFediverseComposerExtras } from './use-fediverse-composer-extras';
@@ -8,8 +8,26 @@ import type {
 	FediverseCreatePostResult,
 	FediverseError,
 } from '@automattic/api-core';
-import type { ComposerConfig, Translate } from 'calypso/reader/social/composer';
+import type { ActiveMode, ComposerConfig, Translate } from 'calypso/reader/social/composer';
 import type { ReactNode } from 'react';
+
+/**
+ * Returns the blog id behind the active Fediverse connection so the
+ * overflow handoff pre-selects that site instead of showing the full
+ * multi-site chooser. The composer is already scoped to a specific
+ * blog via `connectionId`, so the chooser would be redundant.
+ *
+ * Called unconditionally by `<ComposerOverflowHandoff>`; returns null
+ * when no preference applies so the handoff falls back to the chooser.
+ */
+function useFediversePreferredHandoffSiteId( mode: ActiveMode | null ): number | null {
+	const { data } = useFediverseConnectionsQuery( { enabled: mode !== null } );
+	if ( ! mode ) {
+		return null;
+	}
+	const connection = data?.connections?.find( ( c ) => c.id === mode.connectionId );
+	return connection?.blog_id ?? null;
+}
 
 /**
  * Per-protocol composer configuration for the Fediverse standalone
@@ -33,6 +51,11 @@ export const fediverseComposerConfig: ComposerConfig<
 	// than a grapheme cap. Backend enforces wire-level char limits and
 	// surfaces them via the `text_too_long` error path.
 	counter: 'words',
+	// Fediverse has no hard protocol cap — the word threshold is a soft
+	// "this is getting long; consider the blog editor" cue, not a wall.
+	// Submission stays enabled past the limit; the overflow-handoff
+	// section above the footer carries the suggestion.
+	softLimit: true,
 	protocolLabel: 'Fediverse',
 	supportedModes: [ 'standalone' ],
 	mutationFactory: createFediversePostMutation,
@@ -110,6 +133,7 @@ export const fediverseComposerConfig: ComposerConfig<
 		} );
 	},
 	useProtocolExtras: useFediverseComposerExtras,
+	usePreferredHandoffSiteId: useFediversePreferredHandoffSiteId,
 };
 
 function errorMessageFor( err: FediverseError, t: Translate ): ReactNode {

--- a/client/reader/fediverse/composer-controls.tsx
+++ b/client/reader/fediverse/composer-controls.tsx
@@ -1,0 +1,132 @@
+import {
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	BaseControl,
+	RadioControl,
+	TextControl,
+	ToggleControl,
+} from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useId } from 'react';
+import type { FediverseVisibility } from '@automattic/api-core';
+
+const SUMMARY_MAX_LENGTH = 100;
+
+interface Props {
+	visibility: FediverseVisibility;
+	onVisibilityChange: ( value: FediverseVisibility ) => void;
+	cwEnabled: boolean;
+	onCwToggle: ( enabled: boolean ) => void;
+	summary: string;
+	onSummaryChange: ( value: string ) => void;
+	sensitive: boolean;
+	onSensitiveToggle: ( value: boolean ) => void;
+	disabled?: boolean;
+}
+
+/**
+ * The three protocol-specific controls slotted between the composer
+ * textarea and the footer for Fediverse:
+ *  1. Visibility radio (public / unlisted / followers — `direct` is
+ *     intentionally omitted, not yet supported backend-side per CM-704).
+ *  2. Content-warning toggle + 100-char `summary` input (revealed when
+ *     the toggle is on; maps to the AP `summary` field).
+ *  3. Sensitive flag (AP `sensitive` boolean; media-blur gate, exposed
+ *     now so the composer shape stays stable when media support lands).
+ */
+export function FediverseComposerControls( {
+	visibility,
+	onVisibilityChange,
+	cwEnabled,
+	onCwToggle,
+	summary,
+	onSummaryChange,
+	sensitive,
+	onSensitiveToggle,
+	disabled,
+}: Props ) {
+	const translate = useTranslate();
+	const visibilityId = useId();
+	const summaryId = useId();
+
+	const handleVisibility = useCallback(
+		( next: string | undefined ) => {
+			if ( next === 'public' || next === 'unlisted' || next === 'followers' ) {
+				onVisibilityChange( next );
+			}
+		},
+		[ onVisibilityChange ]
+	);
+
+	return (
+		<VStack
+			spacing={ 4 }
+			className="fediverse-composer-controls"
+			aria-disabled={ disabled || undefined }
+		>
+			<BaseControl
+				__nextHasNoMarginBottom
+				id={ visibilityId }
+				label={ String( translate( 'Visibility' ) ) }
+				help={ String(
+					translate(
+						'Public is shown to everyone. Unlisted hides the post from your followers’ feed but keeps it reachable by URL. Followers limits it to people who follow you.'
+					)
+				) }
+			>
+				<RadioControl
+					selected={ visibility }
+					onChange={ handleVisibility }
+					options={ [
+						{ label: String( translate( 'Public' ) ), value: 'public' },
+						{ label: String( translate( 'Unlisted' ) ), value: 'unlisted' },
+						{ label: String( translate( 'Followers only' ) ), value: 'followers' },
+					] }
+				/>
+			</BaseControl>
+
+			<HStack justify="flex-start" spacing={ 4 } wrap>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ String( translate( 'Add content warning' ) ) }
+					checked={ cwEnabled }
+					onChange={ onCwToggle }
+					disabled={ disabled }
+				/>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ String( translate( 'Mark media as sensitive' ) ) }
+					checked={ sensitive }
+					onChange={ onSensitiveToggle }
+					disabled={ disabled }
+				/>
+			</HStack>
+
+			{ cwEnabled && (
+				<TextControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					id={ summaryId }
+					label={ String( translate( 'Content warning summary' ) ) }
+					placeholder={ String( translate( 'Short description of the post’s content…' ) ) }
+					value={ summary }
+					onChange={ onSummaryChange }
+					maxLength={ SUMMARY_MAX_LENGTH }
+					disabled={ disabled }
+					help={ String(
+						translate(
+							'Shown above the post; readers can choose to expand. %(count)d of %(max)d characters used.',
+							{
+								args: { count: summary.length, max: SUMMARY_MAX_LENGTH },
+								comment:
+									'Live character count for the optional content-warning summary input on the Fediverse composer.',
+							}
+						)
+					) }
+				/>
+			) }
+		</VStack>
+	);
+}
+
+export { SUMMARY_MAX_LENGTH };

--- a/client/reader/fediverse/composer-controls.tsx
+++ b/client/reader/fediverse/composer-controls.tsx
@@ -1,6 +1,5 @@
 import {
 	__experimentalVStack as VStack,
-	__experimentalHStack as HStack,
 	BaseControl,
 	RadioControl,
 	TextControl,
@@ -19,20 +18,22 @@ interface Props {
 	onCwToggle: ( enabled: boolean ) => void;
 	summary: string;
 	onSummaryChange: ( value: string ) => void;
-	sensitive: boolean;
-	onSensitiveToggle: ( value: boolean ) => void;
 	disabled?: boolean;
 }
 
 /**
- * The three protocol-specific controls slotted between the composer
- * textarea and the footer for Fediverse:
+ * The protocol-specific controls slotted between the composer textarea
+ * and the footer for Fediverse:
  *  1. Visibility radio (public / unlisted / followers — `direct` is
  *     intentionally omitted, not yet supported backend-side per CM-704).
  *  2. Content-warning toggle + 100-char `summary` input (revealed when
  *     the toggle is on; maps to the AP `summary` field).
- *  3. Sensitive flag (AP `sensitive` boolean; media-blur gate, exposed
- *     now so the composer shape stays stable when media support lands).
+ *
+ * AP `sensitive` flag (media-blur gate) was removed from the surface
+ * while slice 2 has no media support — there's nothing for the flag to
+ * gate. Re-introduce it alongside the media slot in a follow-up slice;
+ * the wire type still carries `sensitive?: boolean` so the round-trip
+ * stays stable.
  */
 export function FediverseComposerControls( {
 	visibility,
@@ -41,8 +42,6 @@ export function FediverseComposerControls( {
 	onCwToggle,
 	summary,
 	onSummaryChange,
-	sensitive,
-	onSensitiveToggle,
 	disabled,
 }: Props ) {
 	const translate = useTranslate();
@@ -85,22 +84,13 @@ export function FediverseComposerControls( {
 				/>
 			</BaseControl>
 
-			<HStack justify="flex-start" spacing={ 4 } wrap>
-				<ToggleControl
-					__nextHasNoMarginBottom
-					label={ String( translate( 'Add content warning' ) ) }
-					checked={ cwEnabled }
-					onChange={ onCwToggle }
-					disabled={ disabled }
-				/>
-				<ToggleControl
-					__nextHasNoMarginBottom
-					label={ String( translate( 'Mark media as sensitive' ) ) }
-					checked={ sensitive }
-					onChange={ onSensitiveToggle }
-					disabled={ disabled }
-				/>
-			</HStack>
+			<ToggleControl
+				__nextHasNoMarginBottom
+				label={ String( translate( 'Add content warning' ) ) }
+				checked={ cwEnabled }
+				onChange={ onCwToggle }
+				disabled={ disabled }
+			/>
 
 			{ cwEnabled && (
 				<TextControl

--- a/client/reader/fediverse/composer-controls.tsx
+++ b/client/reader/fediverse/composer-controls.tsx
@@ -18,7 +18,6 @@ interface Props {
 	onCwToggle: ( enabled: boolean ) => void;
 	summary: string;
 	onSummaryChange: ( value: string ) => void;
-	disabled?: boolean;
 }
 
 /**
@@ -42,7 +41,6 @@ export function FediverseComposerControls( {
 	onCwToggle,
 	summary,
 	onSummaryChange,
-	disabled,
 }: Props ) {
 	const translate = useTranslate();
 	const visibilityId = useId();
@@ -58,11 +56,7 @@ export function FediverseComposerControls( {
 	);
 
 	return (
-		<VStack
-			spacing={ 4 }
-			className="fediverse-composer-controls"
-			aria-disabled={ disabled || undefined }
-		>
+		<VStack spacing={ 4 } className="fediverse-composer-controls">
 			<BaseControl
 				__nextHasNoMarginBottom
 				id={ visibilityId }
@@ -89,7 +83,6 @@ export function FediverseComposerControls( {
 				label={ String( translate( 'Add content warning' ) ) }
 				checked={ cwEnabled }
 				onChange={ onCwToggle }
-				disabled={ disabled }
 			/>
 
 			{ cwEnabled && (
@@ -102,7 +95,6 @@ export function FediverseComposerControls( {
 					value={ summary }
 					onChange={ onSummaryChange }
 					maxLength={ SUMMARY_MAX_LENGTH }
-					disabled={ disabled }
 					help={ String(
 						translate(
 							'Shown above the post; readers can choose to expand. %(count)d of %(max)d characters used.',

--- a/client/reader/fediverse/composer-controls.tsx
+++ b/client/reader/fediverse/composer-controls.tsx
@@ -1,6 +1,5 @@
 import {
 	__experimentalVStack as VStack,
-	BaseControl,
 	RadioControl,
 	TextControl,
 	ToggleControl,
@@ -43,7 +42,6 @@ export function FediverseComposerControls( {
 	onSummaryChange,
 }: Props ) {
 	const translate = useTranslate();
-	const visibilityId = useId();
 	const summaryId = useId();
 
 	const handleVisibility = useCallback(
@@ -57,26 +55,28 @@ export function FediverseComposerControls( {
 
 	return (
 		<VStack spacing={ 4 } className="fediverse-composer-controls">
-			<BaseControl
-				__nextHasNoMarginBottom
-				id={ visibilityId }
+			{ /*
+			 * `label` + `help` are passed to RadioControl directly so its
+			 * built-in `<fieldset><legend>` semantics carry the accessible
+			 * group name (and the help id is wired via `aria-describedby`).
+			 * Wrapping in BaseControl renders the visible "Visibility" label
+			 * as a sibling that isn't associated with the radiogroup.
+			 */ }
+			<RadioControl
 				label={ String( translate( 'Visibility' ) ) }
 				help={ String(
 					translate(
 						'Public is shown to everyone. Unlisted hides the post from your followers’ feed but keeps it reachable by URL. Followers limits it to people who follow you.'
 					)
 				) }
-			>
-				<RadioControl
-					selected={ visibility }
-					onChange={ handleVisibility }
-					options={ [
-						{ label: String( translate( 'Public' ) ), value: 'public' },
-						{ label: String( translate( 'Unlisted' ) ), value: 'unlisted' },
-						{ label: String( translate( 'Followers only' ) ), value: 'followers' },
-					] }
-				/>
-			</BaseControl>
+				selected={ visibility }
+				onChange={ handleVisibility }
+				options={ [
+					{ label: String( translate( 'Public' ) ), value: 'public' },
+					{ label: String( translate( 'Unlisted' ) ), value: 'unlisted' },
+					{ label: String( translate( 'Followers only' ) ), value: 'followers' },
+				] }
+			/>
 
 			<ToggleControl
 				__nextHasNoMarginBottom

--- a/client/reader/fediverse/composer-controls.tsx
+++ b/client/reader/fediverse/composer-controls.tsx
@@ -61,19 +61,26 @@ export function FediverseComposerControls( {
 			 * group name (and the help id is wired via `aria-describedby`).
 			 * Wrapping in BaseControl renders the visible "Visibility" label
 			 * as a sibling that isn't associated with the radiogroup.
+			 *
+			 * Option labels mirror the ActivityPub plugin's wp-admin wording
+			 * verbatim ("Public" / "Quiet public" / "Followers only" — see
+			 * `wordpress-activitypub/integration/class-classic-editor.php`)
+			 * so users see the same vocabulary in both surfaces. The wire
+			 * value `'unlisted'` is preserved; only the visible label
+			 * changed.
 			 */ }
 			<RadioControl
 				label={ String( translate( 'Visibility' ) ) }
 				help={ String(
 					translate(
-						'Public is shown to everyone. Unlisted hides the post from your followers’ feed but keeps it reachable by URL. Followers limits it to people who follow you.'
+						'Public is shown to everyone. Quiet public hides the post from your followers’ feed but keeps it reachable by URL. Followers limits it to people who follow you.'
 					)
 				) }
 				selected={ visibility }
 				onChange={ handleVisibility }
 				options={ [
 					{ label: String( translate( 'Public' ) ), value: 'public' },
-					{ label: String( translate( 'Unlisted' ) ), value: 'unlisted' },
+					{ label: String( translate( 'Quiet public' ) ), value: 'unlisted' },
 					{ label: String( translate( 'Followers only' ) ), value: 'followers' },
 				] }
 			/>

--- a/client/reader/fediverse/fediverse-account-view.tsx
+++ b/client/reader/fediverse/fediverse-account-view.tsx
@@ -6,6 +6,8 @@ import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import NavigationHeader from 'calypso/components/navigation-header';
 import ReaderMain from 'calypso/reader/components/reader-main';
+import { ComposeFab, ComposerModal, ComposerProvider } from 'calypso/reader/social/composer';
+import { fediverseComposerConfig } from './composer-config';
 import { FediverseNavigation } from './fediverse-navigation';
 import { PROFILE_TAB, TIMELINE_TAB } from './helper';
 import { ProfilePanel } from './profile-panel';
@@ -54,21 +56,25 @@ export function FediverseAccountView( { connectionId, tab }: Props ) {
 	const title = connection.name?.trim() || connection.webfinger;
 
 	return (
-		<ReaderMain className="fediverse-view">
-			<DocumentHead
-				title={
-					translate( '%(handle)s ‹ Fediverse ‹ Reader', {
-						args: { handle: connection.webfinger },
-					} ) as string
-				}
-			/>
-			<VStack spacing={ 4 }>
-				<NavigationHeader title={ title } subtitle={ connection.webfinger } compactBreadcrumb />
-				<FediverseNavigation connectionId={ connection.id } selectedTab={ tab } />
-				{ tab === TIMELINE_TAB && <TimelinePanel connection={ connection } /> }
-				{ tab === PROFILE_TAB && <ProfilePanel connection={ connection } /> }
-			</VStack>
-		</ReaderMain>
+		<ComposerProvider connectionId={ connection.id } config={ fediverseComposerConfig }>
+			<ReaderMain className="fediverse-view">
+				<DocumentHead
+					title={
+						translate( '%(handle)s ‹ Fediverse ‹ Reader', {
+							args: { handle: connection.webfinger },
+						} ) as string
+					}
+				/>
+				<VStack spacing={ 4 }>
+					<NavigationHeader title={ title } subtitle={ connection.webfinger } compactBreadcrumb />
+					<FediverseNavigation connectionId={ connection.id } selectedTab={ tab } />
+					{ tab === TIMELINE_TAB && <TimelinePanel connection={ connection } /> }
+					{ tab === PROFILE_TAB && <ProfilePanel connection={ connection } /> }
+				</VStack>
+			</ReaderMain>
+			<ComposeFab />
+			<ComposerModal />
+		</ComposerProvider>
 	);
 }
 

--- a/client/reader/fediverse/fediverse-account-view.tsx
+++ b/client/reader/fediverse/fediverse-account-view.tsx
@@ -1,10 +1,12 @@
 import { useFediverseConnectionsQuery } from '@automattic/api-queries';
+import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Spinner, __experimentalVStack as VStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import NavigationHeader from 'calypso/components/navigation-header';
+import { logToLogstash } from 'calypso/lib/logstash';
 import ReaderMain from 'calypso/reader/components/reader-main';
 import { ComposeFab, ComposerModal, ComposerProvider } from 'calypso/reader/social/composer';
 import { fediverseComposerConfig } from './composer-config';
@@ -23,6 +25,26 @@ interface Props {
 export function FediverseAccountView( { connectionId, tab }: Props ) {
 	const translate = useTranslate();
 	const { data, isPending } = useFediverseConnectionsQuery();
+
+	// Log when the wpcom proxy returns a 200 with `data` present but
+	// `connections` missing — proxy contract regression. Without the
+	// breadcrumb the `!connection` redirect below is indistinguishable
+	// from a stale-URL navigation.
+	const malformedRef = useRef( false );
+	if ( data && ! Array.isArray( data.connections ) && ! malformedRef.current ) {
+		malformedRef.current = true;
+		logToLogstash( {
+			feature: 'calypso_client',
+			message: 'Fediverse connections response missing `connections` array',
+			severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
+			extra: {
+				env: config( 'env_id' ),
+				type: 'reader_fediverse_connections_malformed',
+				surface: 'account_view',
+				connection_id: connectionId,
+			},
+		} );
+	}
 
 	const connections = data?.connections ?? [];
 	const connection = connections.find( ( c ) => c.id === connectionId ) ?? null;

--- a/client/reader/fediverse/test/timeline-panel.test.tsx
+++ b/client/reader/fediverse/test/timeline-panel.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * @jest-environment jsdom
+ */
+// `logToLogstash` fires a real HTTPS request. Mute it so the composer
+// optimistic-mutation tests don't trigger an unmocked nock request.
+jest.mock( 'calypso/lib/logstash', () => ( {
+	logToLogstash: jest.fn(),
+} ) );
+
+import {
+	PENDING_FEDIVERSE_POST_URI,
+	readerFediverseKeys,
+	type FediverseConnection,
+	type FediverseFeedItem,
+	type FediverseTimelinePage,
+} from '@automattic/api-core';
+import { QueryClient, type InfiniteData } from '@tanstack/react-query';
+import { screen, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import { mockAllIsIntersecting } from 'react-intersection-observer/test-utils';
+import * as analytics from 'calypso/state/reader/analytics/actions';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { TimelinePanel } from '../timeline-panel';
+
+const connection: FediverseConnection = {
+	id: 7,
+	blog_id: 100,
+	url: 'https://example.com',
+	name: 'Example Blog',
+	icon: '',
+	webfinger: '@example@example.com',
+};
+
+function makeItem( overrides: Partial< FediverseFeedItem > = {} ): FediverseFeedItem {
+	return {
+		id: 'https://example.com/users/me/statuses/1',
+		url: 'https://example.com/users/me/statuses/1',
+		created_at: '2026-05-11T10:00:00Z',
+		account: {
+			id: 'https://example.com/users/me',
+			username: 'me',
+			acct: 'me',
+			display_name: 'Me',
+			avatar: null,
+		},
+		content: '<p>existing post</p>',
+		spoiler_text: '',
+		sensitive: false,
+		language: null,
+		in_reply_to_id: null,
+		in_reply_to_account_id: null,
+		boost: null,
+		media: [],
+		counts: { replies: 0, boosts: 0, favourites: 0 },
+		...overrides,
+	};
+}
+
+function seedCache( client: QueryClient, items: FediverseFeedItem[] ) {
+	const key = readerFediverseKeys.timeline( 7 );
+	const page: FediverseTimelinePage = { items, cursor: null };
+	client.setQueryData< InfiniteData< FediverseTimelinePage > >( key, {
+		pages: [ page ],
+		pageParams: [ undefined ],
+	} );
+}
+
+describe( 'TimelinePanel — composer optimistic placeholder', () => {
+	beforeEach( () => {
+		// `recordReaderTracksEvent` is a thunk that reads `state.reader.follows`.
+		// Stub to a no-op action so dispatch() doesn't throw in the test store.
+		jest
+			.spyOn( analytics, 'recordReaderTracksEvent' )
+			.mockImplementation( () => ( { type: '@@TEST/NOOP' } ) as never );
+		// SocialFeedList uses an IntersectionObserver for sentinel pagination;
+		// jsdom doesn't ship one. `mockAllIsIntersecting(false)` registers the
+		// shim so the observe call doesn't blow up at mount.
+		mockAllIsIntersecting( false );
+	} );
+
+	afterEach( () => {
+		nock.cleanAll();
+		jest.restoreAllMocks();
+	} );
+
+	it( 'renders an optimistic placeholder (sentinel id, empty url) alongside real items', async () => {
+		// The mutation factory's `buildPlaceholderItem` stamps the placeholder
+		// with `id: pendingUri` and `url: ''`. The timeline filter must let
+		// the placeholder through — otherwise the optimistic prepend lands
+		// in the cache but never reaches the UI.
+		const placeholder = makeItem( {
+			id: `${ PENDING_FEDIVERSE_POST_URI }#1`,
+			url: '',
+			content: '<p>just typed this</p>',
+		} );
+		const existing = makeItem( {
+			id: 'https://example.com/users/me/statuses/0',
+			url: 'https://example.com/users/me/statuses/0',
+			content: '<p>older post</p>',
+		} );
+
+		const client = new QueryClient( {
+			defaultOptions: { queries: { retry: false, staleTime: 60_000 } },
+		} );
+		seedCache( client, [ placeholder, existing ] );
+
+		renderWithProvider( <TimelinePanel connection={ connection } />, {
+			queryClient: client,
+		} );
+
+		await waitFor( () => expect( screen.getByText( 'just typed this' ) ).toBeVisible() );
+		expect( screen.getByText( 'older post' ) ).toBeVisible();
+	} );
+} );

--- a/client/reader/fediverse/test/use-fediverse-composer-extras.test.tsx
+++ b/client/reader/fediverse/test/use-fediverse-composer-extras.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * @jest-environment jsdom
+ */
+jest.mock( 'calypso/lib/logstash', () => ( {
+	logToLogstash: jest.fn(),
+} ) );
+
+import {
+	readerFediverseKeys,
+	type FediverseConnectionsResponse,
+	type FediverseCreatePostParams,
+} from '@automattic/api-core';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, act } from '@testing-library/react';
+import { useFediverseComposerExtras } from '../use-fediverse-composer-extras';
+import type { ActiveMode } from 'calypso/reader/social/composer';
+
+function seedConnections( client: QueryClient, response: FediverseConnectionsResponse ) {
+	client.setQueryData( readerFediverseKeys.connections(), response );
+}
+
+function wrapperFor( client: QueryClient ) {
+	return function Wrapper( { children }: { children: React.ReactNode } ) {
+		return <QueryClientProvider client={ client }>{ children }</QueryClientProvider>;
+	};
+}
+
+const standaloneMode: ActiveMode = {
+	kind: 'standalone',
+	entry_point: 'fab',
+	connectionId: 1,
+};
+
+const baseConnection = {
+	id: 1,
+	blog_id: 100,
+	url: 'https://example.com',
+	name: 'Example',
+	icon: '',
+	webfinger: '@example@example.com',
+};
+
+beforeEach( () => {
+	window.localStorage.clear();
+} );
+
+describe( 'useFediverseComposerExtras — extendBuildParams visibility merge', () => {
+	it( 'merges the cached connection’s default_visibility into the wire params', () => {
+		// Regression guard for the reviewer concern: `composer-config.tsx`'s
+		// `buildParams` returns `{ visibility: 'public' }` as a placeholder
+		// and relies on `extendBuildParams` to override. If the extras wiring
+		// regresses, the wire silently ships `visibility: 'public'`. This
+		// test exercises the merge path end-to-end at the hook surface.
+		const client = new QueryClient();
+		seedConnections( client, {
+			connections: [ { ...baseConnection, default_visibility: 'unlisted' } ],
+		} );
+
+		const { result } = renderHook(
+			() => useFediverseComposerExtras( { mode: standaloneMode, connectionId: 1 } ),
+			{ wrapper: wrapperFor( client ) }
+		);
+
+		const base: FediverseCreatePostParams = {
+			connectionId: 1,
+			content: 'hello',
+			visibility: 'public',
+		};
+		const merged = result.current.extendBuildParams( base ) as FediverseCreatePostParams;
+		expect( merged.visibility ).toBe( 'unlisted' );
+	} );
+
+	it( 'localStorage override beats the cached blog default', () => {
+		window.localStorage.setItem( 'calypso_reader_fediverse_composer_visibility_v1:1', 'followers' );
+		const client = new QueryClient();
+		seedConnections( client, {
+			connections: [ { ...baseConnection, default_visibility: 'unlisted' } ],
+		} );
+
+		const { result } = renderHook(
+			() => useFediverseComposerExtras( { mode: standaloneMode, connectionId: 1 } ),
+			{ wrapper: wrapperFor( client ) }
+		);
+
+		const base: FediverseCreatePostParams = {
+			connectionId: 1,
+			content: 'hello',
+			visibility: 'public',
+		};
+		const merged = result.current.extendBuildParams( base ) as FediverseCreatePostParams;
+		expect( merged.visibility ).toBe( 'followers' );
+	} );
+
+	it( 'falls back to `public` when the cache is cold and no localStorage pick', () => {
+		const client = new QueryClient();
+		// No seed.
+
+		const { result } = renderHook(
+			() => useFediverseComposerExtras( { mode: standaloneMode, connectionId: 1 } ),
+			{ wrapper: wrapperFor( client ) }
+		);
+
+		const base: FediverseCreatePostParams = {
+			connectionId: 1,
+			content: 'hello',
+			visibility: 'public',
+		};
+		const merged = result.current.extendBuildParams( base ) as FediverseCreatePostParams;
+		expect( merged.visibility ).toBe( 'public' );
+	} );
+
+	it( 'mints a fresh idempotencyKey on every call (no cross-submit reuse)', () => {
+		const client = new QueryClient();
+		seedConnections( client, { connections: [ baseConnection ] } );
+
+		const { result } = renderHook(
+			() => useFediverseComposerExtras( { mode: standaloneMode, connectionId: 1 } ),
+			{ wrapper: wrapperFor( client ) }
+		);
+
+		const base: FediverseCreatePostParams = {
+			connectionId: 1,
+			content: 'hello',
+			visibility: 'public',
+		};
+		const a = result.current.extendBuildParams( base ) as FediverseCreatePostParams;
+		const b = result.current.extendBuildParams( base ) as FediverseCreatePostParams;
+		expect( a.idempotencyKey ).toBeDefined();
+		expect( b.idempotencyKey ).toBeDefined();
+		expect( a.idempotencyKey ).not.toBe( b.idempotencyKey );
+	} );
+
+	it( 'logs a breadcrumb when `data.connections` is missing from the response', () => {
+		const { logToLogstash } = jest.requireMock( 'calypso/lib/logstash' ) as {
+			logToLogstash: jest.Mock;
+		};
+		logToLogstash.mockClear();
+
+		const client = new QueryClient();
+		// Seed a malformed response — `data` present, `connections` missing.
+		client.setQueryData(
+			readerFediverseKeys.connections(),
+			{} as unknown as FediverseConnectionsResponse
+		);
+
+		renderHook( () => useFediverseComposerExtras( { mode: standaloneMode, connectionId: 1 } ), {
+			wrapper: wrapperFor( client ),
+		} );
+
+		expect( logToLogstash ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				message: expect.stringContaining( 'missing `connections` array' ),
+				extra: expect.objectContaining( {
+					type: 'reader_fediverse_connections_malformed',
+				} ),
+			} )
+		);
+	} );
+
+	it( 'persists the user’s visibility pick to localStorage', () => {
+		const client = new QueryClient();
+		seedConnections( client, {
+			connections: [ { ...baseConnection, default_visibility: 'public' } ],
+		} );
+
+		const { result } = renderHook(
+			() => useFediverseComposerExtras( { mode: standaloneMode, connectionId: 1 } ),
+			{ wrapper: wrapperFor( client ) }
+		);
+
+		// Render the controls slot — its onVisibilityChange handler is what
+		// writes to localStorage. We invoke that handler through the returned
+		// React element by reading it directly.
+		const element = result.current.renderControls() as React.ReactElement< {
+			onVisibilityChange: ( next: string ) => void;
+		} >;
+		act( () => {
+			element.props.onVisibilityChange( 'followers' );
+		} );
+
+		expect(
+			window.localStorage.getItem( 'calypso_reader_fediverse_composer_visibility_v1:1' )
+		).toBe( 'followers' );
+	} );
+} );

--- a/client/reader/fediverse/timeline-panel.tsx
+++ b/client/reader/fediverse/timeline-panel.tsx
@@ -11,6 +11,7 @@ import {
 	mapFediverseFeedItemToSocialPost,
 	socialPostFeedItemKey,
 } from 'calypso/reader/social';
+import { TimelineComposePill, useOptionalComposer } from 'calypso/reader/social/composer';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import { projectFediverseError } from './error-projection';
 import { getProfileUrl, hostFromUrl } from './route';
@@ -132,8 +133,16 @@ export function TimelinePanel( { connection }: TimelinePanelProps ) {
 		[ connection.id, onClickAnalytics, buildProfileUrl ]
 	);
 
+	// Only render the inline compose pill when a `<ComposerProvider>` is
+	// mounted upstream (account view). Surfaces without the provider — tests,
+	// embedded panels — skip the pill cleanly.
+	const composer = useOptionalComposer();
+
 	return (
 		<SocialAnalyticsProvider value={ analyticsValue }>
+			{ composer && (
+				<TimelineComposePill avatar={ connection.icon || null } entryPoint="timeline_inline" />
+			) }
 			<SocialFeedList< SocialPost >
 				items={ items }
 				isPending={ isPending }

--- a/client/reader/fediverse/use-fediverse-composer-extras.tsx
+++ b/client/reader/fediverse/use-fediverse-composer-extras.tsx
@@ -1,5 +1,7 @@
 import { useFediverseConnectionsQuery } from '@automattic/api-queries';
+import config from '@automattic/calypso-config';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { logToLogstash } from 'calypso/lib/logstash';
 import { FediverseComposerControls } from './composer-controls';
 import type { FediverseCreatePostParams, FediverseVisibility } from '@automattic/api-core';
 import type { ActiveMode, ComposerProtocolExtrasSlot } from 'calypso/reader/social/composer';
@@ -75,17 +77,30 @@ export function useFediverseComposerExtras( ctx: {
 	} );
 	// Optional-chain `connections` defensively — the wpcom proxy can hand back a
 	// 200 with `data` defined and `connections` missing (mid-deploy race on
-	// CM-684), in which case `.find()` would otherwise throw.
+	// CM-684), in which case `.find()` would otherwise throw. Log when that
+	// happens so the silent `'public'` fallback below stays observable; without
+	// the breadcrumb a proxy contract regression would silently route every
+	// publish at the default visibility.
+	const malformedRef = useRef( false );
+	if ( data && ! Array.isArray( data.connections ) && ! malformedRef.current ) {
+		malformedRef.current = true;
+		logToLogstash( {
+			feature: 'calypso_client',
+			message: 'Fediverse connections response missing `connections` array',
+			severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
+			extra: {
+				env: config( 'env_id' ),
+				type: 'reader_fediverse_connections_malformed',
+				connection_id: connectionId,
+			},
+		} );
+	}
 	const connection = data?.connections?.find( ( c ) => c.id === connectionId ) ?? null;
 	const blogDefault = connection?.default_visibility ?? 'public';
 
 	const [ visibility, setVisibility ] = useState< FediverseVisibility >( blogDefault );
 	const [ cwEnabled, setCwEnabled ] = useState( false );
 	const [ summary, setSummary ] = useState( '' );
-	// One Idempotency-Key per modal session — stays stable across user-initiated
-	// retries after a network error so the backend's de-dupe table can suppress
-	// the duplicate publish. Rotates only when the modal closes (`clear`).
-	const idempotencyKeyRef = useRef< string | null >( null );
 
 	// Apply localStorage override / blog default once the modal opens. Re-runs
 	// when the connection changes (the user navigates between connections
@@ -96,9 +111,6 @@ export function useFediverseComposerExtras( ctx: {
 		}
 		const stored = readLastVisibility( connectionId );
 		setVisibility( stored ?? blogDefault );
-		if ( ! idempotencyKeyRef.current ) {
-			idempotencyKeyRef.current = generateIdempotencyKey();
-		}
 	}, [ mode, connectionId, blogDefault ] );
 
 	const renderControls = useCallback(
@@ -126,17 +138,21 @@ export function useFediverseComposerExtras( ctx: {
 	const extendBuildParams = useCallback(
 		( params: unknown ): unknown => {
 			const base = params as FediverseCreatePostParams;
-			// Lazy-init in case `extendBuildParams` somehow runs before the
-			// `mode → open` effect (e.g. submit fires on the same render the
-			// modal opens). Cheap.
-			if ( ! idempotencyKeyRef.current ) {
-				idempotencyKeyRef.current = generateIdempotencyKey();
-			}
+			// Mint a fresh `Idempotency-Key` per submit attempt. Earlier
+			// iterations of this hook held a stable key across the whole
+			// modal session so the backend dedupe table could suppress a
+			// publish-time network retry — but that breaks when the user
+			// edits the body / visibility / CW after a failed submit:
+			// same key + different body would hit the dedupe table and
+			// could serve a cached failure (or a stale success) for the
+			// new content. Rotating per attempt trades the (rare)
+			// duplicate-publish-on-lost-response window for the (likelier)
+			// stale-cache-after-edit hazard the reviewer flagged.
 			return {
 				...base,
 				visibility,
 				...( cwEnabled && summary.trim().length > 0 ? { summary } : {} ),
-				idempotencyKey: idempotencyKeyRef.current,
+				idempotencyKey: generateIdempotencyKey(),
 			};
 		},
 		[ visibility, cwEnabled, summary ]
@@ -146,7 +162,6 @@ export function useFediverseComposerExtras( ctx: {
 		setVisibility( blogDefault );
 		setCwEnabled( false );
 		setSummary( '' );
-		idempotencyKeyRef.current = null;
 	}, [ blogDefault ] );
 
 	return { renderControls, extendBuildParams, clear };

--- a/client/reader/fediverse/use-fediverse-composer-extras.tsx
+++ b/client/reader/fediverse/use-fediverse-composer-extras.tsx
@@ -79,7 +79,6 @@ export function useFediverseComposerExtras( ctx: {
 	const [ visibility, setVisibility ] = useState< FediverseVisibility >( blogDefault );
 	const [ cwEnabled, setCwEnabled ] = useState( false );
 	const [ summary, setSummary ] = useState( '' );
-	const [ sensitive, setSensitive ] = useState( false );
 	// One Idempotency-Key per modal session — stays stable across user-initiated
 	// retries after a network error so the backend's de-dupe table can suppress
 	// the duplicate publish. Rotates only when the modal closes (`clear`).
@@ -116,11 +115,9 @@ export function useFediverseComposerExtras( ctx: {
 				} }
 				summary={ summary }
 				onSummaryChange={ setSummary }
-				sensitive={ sensitive }
-				onSensitiveToggle={ setSensitive }
 			/>
 		),
-		[ visibility, cwEnabled, summary, sensitive, connectionId ]
+		[ visibility, cwEnabled, summary, connectionId ]
 	);
 
 	const extendBuildParams = useCallback(
@@ -136,18 +133,16 @@ export function useFediverseComposerExtras( ctx: {
 				...base,
 				visibility,
 				...( cwEnabled && summary.trim().length > 0 ? { summary } : {} ),
-				...( sensitive ? { sensitive: true } : {} ),
 				idempotencyKey: idempotencyKeyRef.current,
 			};
 		},
-		[ visibility, cwEnabled, summary, sensitive ]
+		[ visibility, cwEnabled, summary ]
 	);
 
 	const clear = useCallback( () => {
 		setVisibility( blogDefault );
 		setCwEnabled( false );
 		setSummary( '' );
-		setSensitive( false );
 		idempotencyKeyRef.current = null;
 	}, [ blogDefault ] );
 

--- a/client/reader/fediverse/use-fediverse-composer-extras.tsx
+++ b/client/reader/fediverse/use-fediverse-composer-extras.tsx
@@ -1,0 +1,155 @@
+import { useFediverseConnectionsQuery } from '@automattic/api-queries';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { FediverseComposerControls } from './composer-controls';
+import type { FediverseCreatePostParams, FediverseVisibility } from '@automattic/api-core';
+import type { ActiveMode, ComposerProtocolExtrasSlot } from 'calypso/reader/social/composer';
+
+/**
+ * Generate a UUID for the `Idempotency-Key` header. Prefers
+ * `crypto.randomUUID` (available in evergreen browsers + Node 19+);
+ * falls back to a Math.random-based v4-ish UUID for legacy environments
+ * + jest defaults. Cryptographic randomness only matters here for
+ * preventing collisions, not for security.
+ */
+function generateIdempotencyKey(): string {
+	if ( typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function' ) {
+		return crypto.randomUUID();
+	}
+	// RFC4122-style fallback. Acceptable when the environment lacks
+	// crypto.randomUUID — collision risk per submit attempt is negligible.
+	return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace( /[xy]/g, ( c ) => {
+		const r = ( Math.random() * 16 ) | 0;
+		const v = c === 'x' ? r : ( r & 0x3 ) | 0x8;
+		return v.toString( 16 );
+	} );
+}
+
+const LAST_VISIBILITY_STORAGE_KEY = ( connectionId: number ) =>
+	`calypso_reader_fediverse_composer_visibility_v1:${ connectionId }`;
+
+function isVisibility( value: unknown ): value is FediverseVisibility {
+	return value === 'public' || value === 'unlisted' || value === 'followers';
+}
+
+function readLastVisibility( connectionId: number ): FediverseVisibility | null {
+	try {
+		const raw = window.localStorage.getItem( LAST_VISIBILITY_STORAGE_KEY( connectionId ) );
+		return isVisibility( raw ) ? raw : null;
+	} catch {
+		// Private-mode storage access, etc. — silently fall back to the blog default.
+		return null;
+	}
+}
+
+function writeLastVisibility( connectionId: number, value: FediverseVisibility ): void {
+	try {
+		window.localStorage.setItem( LAST_VISIBILITY_STORAGE_KEY( connectionId ), value );
+	} catch {
+		// Best-effort persistence; cosmetic feature.
+	}
+}
+
+/**
+ * Per-Fediverse-connection composer-extras hook. Owns the state for the
+ * three protocol-specific controls (visibility, content-warning toggle +
+ * summary, sensitive flag) and projects them into the wire payload via
+ * `extendBuildParams`.
+ *
+ * Visibility defaults: user's last pick (localStorage, keyed on
+ * connection id) → blog's `default_visibility` from the connections
+ * endpoint → `'public'`. Persists the user's pick on submit so
+ * subsequent composes default to it. Per CM-704: cosmetic — backend
+ * doesn't care.
+ *
+ * Mounted by the provider via `ComposerConfig.useProtocolExtras`. The
+ * provider calls `clear()` when the modal closes so state resets between
+ * sessions.
+ */
+export function useFediverseComposerExtras( ctx: {
+	mode: ActiveMode | null;
+	connectionId: number;
+} ): ComposerProtocolExtrasSlot {
+	const { connectionId, mode } = ctx;
+	const { data } = useFediverseConnectionsQuery( {
+		enabled: connectionId > 0,
+	} );
+	const connection = data?.connections.find( ( c ) => c.id === connectionId ) ?? null;
+	const blogDefault = connection?.default_visibility ?? 'public';
+
+	const [ visibility, setVisibility ] = useState< FediverseVisibility >( blogDefault );
+	const [ cwEnabled, setCwEnabled ] = useState( false );
+	const [ summary, setSummary ] = useState( '' );
+	const [ sensitive, setSensitive ] = useState( false );
+	// One Idempotency-Key per modal session — stays stable across user-initiated
+	// retries after a network error so the backend's de-dupe table can suppress
+	// the duplicate publish. Rotates only when the modal closes (`clear`).
+	const idempotencyKeyRef = useRef< string | null >( null );
+
+	// Apply localStorage override / blog default once the modal opens. Re-runs
+	// when the connection changes (the user navigates between connections
+	// without closing the modal — rare but supported).
+	useEffect( () => {
+		if ( ! mode ) {
+			return;
+		}
+		const stored = readLastVisibility( connectionId );
+		setVisibility( stored ?? blogDefault );
+		if ( ! idempotencyKeyRef.current ) {
+			idempotencyKeyRef.current = generateIdempotencyKey();
+		}
+	}, [ mode, connectionId, blogDefault ] );
+
+	const renderControls = useCallback(
+		() => (
+			<FediverseComposerControls
+				visibility={ visibility }
+				onVisibilityChange={ ( next ) => {
+					setVisibility( next );
+					writeLastVisibility( connectionId, next );
+				} }
+				cwEnabled={ cwEnabled }
+				onCwToggle={ ( enabled ) => {
+					setCwEnabled( enabled );
+					if ( ! enabled ) {
+						setSummary( '' );
+					}
+				} }
+				summary={ summary }
+				onSummaryChange={ setSummary }
+				sensitive={ sensitive }
+				onSensitiveToggle={ setSensitive }
+			/>
+		),
+		[ visibility, cwEnabled, summary, sensitive, connectionId ]
+	);
+
+	const extendBuildParams = useCallback(
+		( params: unknown ): unknown => {
+			const base = params as FediverseCreatePostParams;
+			// Lazy-init in case `extendBuildParams` somehow runs before the
+			// `mode → open` effect (e.g. submit fires on the same render the
+			// modal opens). Cheap.
+			if ( ! idempotencyKeyRef.current ) {
+				idempotencyKeyRef.current = generateIdempotencyKey();
+			}
+			return {
+				...base,
+				visibility,
+				...( cwEnabled && summary.trim().length > 0 ? { summary } : {} ),
+				...( sensitive ? { sensitive: true } : {} ),
+				idempotencyKey: idempotencyKeyRef.current,
+			};
+		},
+		[ visibility, cwEnabled, summary, sensitive ]
+	);
+
+	const clear = useCallback( () => {
+		setVisibility( blogDefault );
+		setCwEnabled( false );
+		setSummary( '' );
+		setSensitive( false );
+		idempotencyKeyRef.current = null;
+	}, [ blogDefault ] );
+
+	return { renderControls, extendBuildParams, clear };
+}

--- a/client/reader/fediverse/use-fediverse-composer-extras.tsx
+++ b/client/reader/fediverse/use-fediverse-composer-extras.tsx
@@ -73,7 +73,10 @@ export function useFediverseComposerExtras( ctx: {
 	const { data } = useFediverseConnectionsQuery( {
 		enabled: connectionId > 0,
 	} );
-	const connection = data?.connections.find( ( c ) => c.id === connectionId ) ?? null;
+	// Optional-chain `connections` defensively — the wpcom proxy can hand back a
+	// 200 with `data` defined and `connections` missing (mid-deploy race on
+	// CM-684), in which case `.find()` would otherwise throw.
+	const connection = data?.connections?.find( ( c ) => c.id === connectionId ) ?? null;
 	const blogDefault = connection?.default_visibility ?? 'public';
 
 	const [ visibility, setVisibility ] = useState< FediverseVisibility >( blogDefault );

--- a/client/reader/fediverse/use-fediverse-composer-limit.ts
+++ b/client/reader/fediverse/use-fediverse-composer-limit.ts
@@ -1,0 +1,30 @@
+import { useFediverseConnectionsQuery } from '@automattic/api-queries';
+
+/**
+ * Stock AP plugin cap when the connections endpoint doesn't surface a
+ * `character_limit` override (or while the query is still pending /
+ * errored). Per CM-684, 500 graphemes is the protocol default; per-blog
+ * overrides are surfaced via `FediverseConnection.character_limit`.
+ */
+const DEFAULT_FEDIVERSE_LIMIT = 500;
+
+/**
+ * Returns the per-blog grapheme cap the composer should validate against.
+ * Mirrors `useMastodonComposerLimit`'s shape (cached connection-config
+ * query → numeric cap with a stock fallback), so the shared composer
+ * shell can plug this into the `ComposerConfig.useLimit` slot
+ * unconditionally on every render.
+ *
+ * `connectionId` is `null` when no mode is active (modal closed); the
+ * value is unused while closed, so a fallback there is fine.
+ */
+export function useFediverseComposerLimit( connectionId: number | null ): number {
+	const { data } = useFediverseConnectionsQuery( {
+		enabled: connectionId !== null && connectionId > 0,
+	} );
+	if ( connectionId === null ) {
+		return DEFAULT_FEDIVERSE_LIMIT;
+	}
+	const connection = data?.connections.find( ( c ) => c.id === connectionId );
+	return connection?.character_limit ?? DEFAULT_FEDIVERSE_LIMIT;
+}

--- a/client/reader/fediverse/use-fediverse-composer-limit.ts
+++ b/client/reader/fediverse/use-fediverse-composer-limit.ts
@@ -1,30 +1,24 @@
-import { useFediverseConnectionsQuery } from '@automattic/api-queries';
-
 /**
- * Stock AP plugin cap when the connections endpoint doesn't surface a
- * `character_limit` override (or while the query is still pending /
- * errored). Per CM-684, 500 graphemes is the protocol default; per-blog
- * overrides are surfaced via `FediverseConnection.character_limit`.
+ * Soft word threshold the Fediverse composer uses to trigger the
+ * "publish on your own site instead" overflow handoff. AP posts are
+ * blog-post-shaped, so a word count maps onto "this is getting too long
+ * for a status update" better than a grapheme cap. Backend enforces its
+ * own char limit and rejects with `text_too_long` if exceeded — the UI
+ * value is purely a soft-handoff cue.
  */
-const DEFAULT_FEDIVERSE_LIMIT = 500;
+const DEFAULT_FEDIVERSE_WORD_THRESHOLD = 100;
 
 /**
- * Returns the per-blog grapheme cap the composer should validate against.
- * Mirrors `useMastodonComposerLimit`'s shape (cached connection-config
- * query → numeric cap with a stock fallback), so the shared composer
- * shell can plug this into the `ComposerConfig.useLimit` slot
- * unconditionally on every render.
+ * Returns the per-render word threshold for the Fediverse composer.
+ * Mirrors `useMastodonComposerLimit`'s shape (called every render via
+ * `ComposerConfig.useLimit`) but counts words instead of graphemes.
  *
  * `connectionId` is `null` when no mode is active (modal closed); the
- * value is unused while closed, so a fallback there is fine.
+ * value is unused while closed, so the constant fallback is fine. Per-
+ * blog overrides could land via a future `word_threshold` field on the
+ * connections endpoint; this hook would consume it the same way.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function useFediverseComposerLimit( connectionId: number | null ): number {
-	const { data } = useFediverseConnectionsQuery( {
-		enabled: connectionId !== null && connectionId > 0,
-	} );
-	if ( connectionId === null ) {
-		return DEFAULT_FEDIVERSE_LIMIT;
-	}
-	const connection = data?.connections.find( ( c ) => c.id === connectionId );
-	return connection?.character_limit ?? DEFAULT_FEDIVERSE_LIMIT;
+	return DEFAULT_FEDIVERSE_WORD_THRESHOLD;
 }

--- a/client/reader/social/composer/composer-config.tsx
+++ b/client/reader/social/composer/composer-config.tsx
@@ -114,6 +114,16 @@ export interface ComposerConfig< TError, TParams, TResult > {
 	 */
 	counter?: 'graphemes' | 'words';
 	/**
+	 * When true, the `useLimit` value is a UX threshold (e.g. "this is
+	 * getting long, consider the blog editor instead") rather than a
+	 * wire-level cap. Submission stays enabled past the limit and the
+	 * footer label stays "Post" rather than switching to the overflow-
+	 * handoff cue — users see the "publish on your own site" section as
+	 * a suggestion, not a block. Defaults to `false` (atmosphere /
+	 * mastodon: hard protocol caps where overflow really fails).
+	 */
+	softLimit?: boolean;
+	/**
 	 * Short display label for the protocol (e.g. "Bluesky", "Mastodon").
 	 * Surfaced in user-visible copy that mentions the social network by
 	 * name. Not localized — brand names don't translate.
@@ -229,6 +239,22 @@ export interface ComposerConfig< TError, TParams, TResult > {
 		mode: ActiveMode | null;
 		connectionId: number;
 	} ) => ComposerProtocolExtrasSlot;
+	/**
+	 * Optional hook returning the user's preferred site id for the overflow
+	 * handoff. When provided and non-null, the handoff filters its site list
+	 * to that single entry — `SiteHandoff` renders the "Publish on
+	 * %(siteName)s" button directly instead of the multi-site chooser.
+	 *
+	 * Fediverse uses this: the composer is already scoped to a specific blog
+	 * connection, so the chooser would be redundant. Atmosphere / Mastodon
+	 * don't (no blog scope; the chooser is meaningful).
+	 *
+	 * Called unconditionally inside `ComposerOverflowHandoff` — must be a
+	 * stable reference across renders. Returns `null` when no preference
+	 * applies (mode is null, connection is missing, etc.) and the handoff
+	 * falls back to the full chooser.
+	 */
+	usePreferredHandoffSiteId?: ( mode: ActiveMode | null ) => number | null;
 }
 
 /**

--- a/client/reader/social/composer/composer-config.tsx
+++ b/client/reader/social/composer/composer-config.tsx
@@ -106,6 +106,14 @@ export interface ComposerConfig< TError, TParams, TResult > {
 	 */
 	useLimit: ( connectionId: number | null ) => number;
 	/**
+	 * Counter unit. Atmosphere / Mastodon count graphemes (per-protocol
+	 * char caps). Fediverse counts words instead — AP posts are
+	 * blog-post-shaped, so a word threshold maps better onto when the
+	 * "publish on your own site" overflow handoff should appear.
+	 * Defaults to `'graphemes'` so existing configs need no change.
+	 */
+	counter?: 'graphemes' | 'words';
+	/**
 	 * Short display label for the protocol (e.g. "Bluesky", "Mastodon").
 	 * Surfaced in user-visible copy that mentions the social network by
 	 * name. Not localized — brand names don't translate.

--- a/client/reader/social/composer/composer-config.tsx
+++ b/client/reader/social/composer/composer-config.tsx
@@ -207,6 +207,47 @@ export interface ComposerConfig< TError, TParams, TResult > {
 	 * `useMastodonComposerMedia` (CM-676).
 	 */
 	useMedia?: ( ctx: { mode: ActiveMode | null; connectionId: number } ) => ComposerMediaSlot;
+	/**
+	 * Optional protocol-specific extras slot — for modal-level controls
+	 * that aren't media (e.g. Fediverse's visibility selector, content-warning
+	 * toggle, sensitive flag — CM-704). Same lifetime contract as `useMedia`:
+	 * called once at provider mount so the underlying form state survives
+	 * modal mount/unmount and the `extendBuildParams` merge runs on submit.
+	 * Distinct from `useMedia` so a protocol that needs *both* (future
+	 * Fediverse media) can wire each independently. Atmosphere and Mastodon
+	 * don't need this today — they leave it undefined.
+	 */
+	useProtocolExtras?: ( ctx: {
+		mode: ActiveMode | null;
+		connectionId: number;
+	} ) => ComposerProtocolExtrasSlot;
+}
+
+/**
+ * Per-protocol modal-level controls (visibility selectors, toggles, etc.)
+ * that aren't media uploads. The slot is rendered between the textarea
+ * (and any media grid) and the error region. Mirrors the `useMedia`
+ * surface where it makes sense; omits the upload-specific flags.
+ */
+export interface ComposerProtocolExtrasSlot {
+	/**
+	 * Render the protocol-specific controls. Returned `null` when nothing
+	 * should appear (e.g. mode is not supported by this protocol's extras).
+	 */
+	renderControls: () => ReactNode;
+	/**
+	 * Merge wire-level extras into the protocol's params before the
+	 * mutation runs. The modal calls `config.buildParams(mode, text)` first,
+	 * then passes the result through this hook AND through `useMedia`'s
+	 * `extendBuildParams` (in that order) for the merged payload.
+	 * `unknown` keeps the slot opaque — implementations cast.
+	 */
+	extendBuildParams: ( params: unknown ) => unknown;
+	/**
+	 * Drop all extras state. Called by the provider when `mode` transitions
+	 * to `null` (modal closed / discarded / published).
+	 */
+	clear?: () => void;
 }
 
 /**

--- a/client/reader/social/composer/composer-config.tsx
+++ b/client/reader/social/composer/composer-config.tsx
@@ -249,8 +249,14 @@ export interface ComposerProtocolExtrasSlot {
 	 * then passes the result through this hook AND through `useMedia`'s
 	 * `extendBuildParams` (in that order) for the merged payload.
 	 * `unknown` keeps the slot opaque — implementations cast.
+	 *
+	 * Returning a Promise lets a per-protocol slot defer wire work (e.g.
+	 * handle validation, derived params). The modal awaits the result and
+	 * funnels any rejection through the same error path as a mutation
+	 * failure. Atmosphere/Mastodon don't ship this slot; Fediverse returns
+	 * synchronously today.
 	 */
-	extendBuildParams: ( params: unknown ) => unknown;
+	extendBuildParams: ( params: unknown ) => unknown | Promise< unknown >;
 	/**
 	 * Drop all extras state. Called by the provider when `mode` transitions
 	 * to `null` (modal closed / discarded / published).

--- a/client/reader/social/composer/composer-footer.tsx
+++ b/client/reader/social/composer/composer-footer.tsx
@@ -21,6 +21,12 @@ interface Props {
 	 * media picker.
 	 */
 	footerStart?: ReactNode;
+	/**
+	 * Counter unit — drives the screen-reader label only. Atmosphere /
+	 * Mastodon count graphemes (`'characters'`); Fediverse counts words.
+	 * Defaults to `'graphemes'` so existing call sites keep their labels.
+	 */
+	counterUnit?: 'graphemes' | 'words';
 }
 
 const WARN_THRESHOLD_REMAINING = 50;
@@ -32,6 +38,7 @@ export function ComposerFooter( {
 	limit,
 	disabled: disabledProp,
 	footerStart,
+	counterUnit = 'graphemes',
 }: Props ) {
 	const translate = useTranslate();
 	const remaining = limit - graphemeCount;
@@ -43,6 +50,23 @@ export function ComposerFooter( {
 		'is-warn': remaining > 0 && remaining <= WARN_THRESHOLD_REMAINING,
 		'is-over': remaining <= 0,
 	} );
+
+	const countLabel =
+		counterUnit === 'words'
+			? translate( '%(count)d word remaining', '%(count)d words remaining', {
+					count: remaining,
+					args: { count: remaining },
+					textOnly: true,
+					comment:
+						'Composer post-length counter (Fediverse, word-counter mode); %(count)d is the integer count of words still allowed before the soft blog-post threshold. Negative when the user is over the limit.',
+			  } )
+			: translate( '%(count)d character remaining', '%(count)d characters remaining', {
+					count: remaining,
+					args: { count: remaining },
+					textOnly: true,
+					comment:
+						'Composer post-length counter; %(count)d is the integer count of characters still allowed before the limit. Negative when the user is over the limit.',
+			  } );
 
 	return (
 		<HStack className="social-composer__footer" justify="space-between" alignment="center">
@@ -57,17 +81,7 @@ export function ComposerFooter( {
 					// Visible text is the bare integer; the accessible label
 					// adds units so the live-region announcement is meaningful
 					// without relying on the surrounding visual context.
-					aria-label={ translate(
-						'%(count)d character remaining',
-						'%(count)d characters remaining',
-						{
-							count: remaining,
-							args: { count: remaining },
-							textOnly: true,
-							comment:
-								'Composer post-length counter; %(count)d is the integer count of characters still allowed before the limit. Negative when the user is over the limit.',
-						}
-					) }
+					aria-label={ countLabel }
 				>
 					{ remaining }
 				</span>

--- a/client/reader/social/composer/composer-footer.tsx
+++ b/client/reader/social/composer/composer-footer.tsx
@@ -27,9 +27,71 @@ interface Props {
 	 * Defaults to `'graphemes'` so existing call sites keep their labels.
 	 */
 	counterUnit?: 'graphemes' | 'words';
+	/**
+	 * When true, the `limit` value is a UX threshold rather than a wire-
+	 * level cap. The button stays labelled "Post" past the limit (instead
+	 * of switching to the overflow-handoff cue "Better as a blog post"),
+	 * and the parent is expected to also leave `disabled` undefined or
+	 * false in that state. Defaults to `false` (atmosphere / mastodon:
+	 * hard caps where the alternate label is the meaningful cue).
+	 */
+	softLimit?: boolean;
 }
 
 const WARN_THRESHOLD_REMAINING = 50;
+
+// Build the screen-reader label for the count cell. Pulled out of the
+// render to keep `<ComposerFooter>` flat (avoids nested ternaries).
+function buildCountLabel( {
+	translate,
+	softLimit,
+	counterUnit,
+	graphemeCount,
+	remaining,
+}: {
+	translate: ReturnType< typeof useTranslate >;
+	softLimit: boolean;
+	counterUnit: 'graphemes' | 'words';
+	graphemeCount: number;
+	remaining: number;
+} ): string {
+	if ( softLimit ) {
+		// Soft-limit label: just the count, no "remaining" — the threshold
+		// is a soft cue and going past it isn't a budget overrun.
+		if ( counterUnit === 'words' ) {
+			return translate( '%(count)d word', '%(count)d words', {
+				count: graphemeCount,
+				args: { count: graphemeCount },
+				textOnly: true,
+				comment:
+					'Composer post-length counter (Fediverse, soft word-counter mode); %(count)d is the integer count of words the user has written. Informational, not a budget.',
+			} ) as string;
+		}
+		return translate( '%(count)d character', '%(count)d characters', {
+			count: graphemeCount,
+			args: { count: graphemeCount },
+			textOnly: true,
+			comment:
+				'Composer post-length counter (soft mode); %(count)d is the integer count of characters the user has written. Informational, not a budget.',
+		} ) as string;
+	}
+	if ( counterUnit === 'words' ) {
+		return translate( '%(count)d word remaining', '%(count)d words remaining', {
+			count: remaining,
+			args: { count: remaining },
+			textOnly: true,
+			comment:
+				'Composer post-length counter (word-counter mode); %(count)d is the integer count of words still allowed before the limit. Negative when the user is over the limit.',
+		} ) as string;
+	}
+	return translate( '%(count)d character remaining', '%(count)d characters remaining', {
+		count: remaining,
+		args: { count: remaining },
+		textOnly: true,
+		comment:
+			'Composer post-length counter; %(count)d is the integer count of characters still allowed before the limit. Negative when the user is over the limit.',
+	} ) as string;
+}
 
 export function ComposerFooter( {
 	graphemeCount,
@@ -39,34 +101,37 @@ export function ComposerFooter( {
 	disabled: disabledProp,
 	footerStart,
 	counterUnit = 'graphemes',
+	softLimit = false,
 }: Props ) {
 	const translate = useTranslate();
 	const remaining = limit - graphemeCount;
 	const tooLong = remaining < 0;
 	const empty = graphemeCount === 0;
-	const disabled = disabledProp ?? ( isPending || tooLong || empty );
+	// `softLimit: true` means going past the threshold doesn't block submit —
+	// the user sees the overflow-handoff section as a suggestion, not a wall.
+	const overLimitBlocksSubmit = tooLong && ! softLimit;
+	const disabled = disabledProp ?? ( isPending || overLimitBlocksSubmit || empty );
+
+	// Soft-limit (Fediverse) counts up — the threshold is informational, so
+	// "127 words" reads naturally as a length indicator. Hard-cap protocols
+	// count down so the user can see how much of their budget remains.
+	const displayCount = softLimit ? graphemeCount : remaining;
 
 	const countClass = clsx( 'social-composer__count', {
-		'is-warn': remaining > 0 && remaining <= WARN_THRESHOLD_REMAINING,
-		'is-over': remaining <= 0,
+		// Warn/over styling only applies to hard-cap protocols — for soft
+		// limits, the overflow-handoff section is the visual cue, and a
+		// red count would suggest "you can't post" which isn't true.
+		'is-warn': ! softLimit && remaining > 0 && remaining <= WARN_THRESHOLD_REMAINING,
+		'is-over': ! softLimit && remaining <= 0,
 	} );
 
-	const countLabel =
-		counterUnit === 'words'
-			? translate( '%(count)d word remaining', '%(count)d words remaining', {
-					count: remaining,
-					args: { count: remaining },
-					textOnly: true,
-					comment:
-						'Composer post-length counter (Fediverse, word-counter mode); %(count)d is the integer count of words still allowed before the soft blog-post threshold. Negative when the user is over the limit.',
-			  } )
-			: translate( '%(count)d character remaining', '%(count)d characters remaining', {
-					count: remaining,
-					args: { count: remaining },
-					textOnly: true,
-					comment:
-						'Composer post-length counter; %(count)d is the integer count of characters still allowed before the limit. Negative when the user is over the limit.',
-			  } );
+	const countLabel = buildCountLabel( {
+		translate,
+		softLimit,
+		counterUnit,
+		graphemeCount,
+		remaining,
+	} );
 
 	return (
 		<HStack className="social-composer__footer" justify="space-between" alignment="center">
@@ -77,13 +142,15 @@ export function ComposerFooter( {
 					className={ countClass }
 					// Only announce when the user is near or past the limit so
 					// screen readers don't read out the count on every keystroke.
-					aria-live={ remaining <= WARN_THRESHOLD_REMAINING ? 'polite' : 'off' }
+					// Soft-limit protocols don't have a meaningful near-limit
+					// state, so the live region stays off.
+					aria-live={ ! softLimit && remaining <= WARN_THRESHOLD_REMAINING ? 'polite' : 'off' }
 					// Visible text is the bare integer; the accessible label
 					// adds units so the live-region announcement is meaningful
 					// without relying on the surrounding visual context.
 					aria-label={ countLabel }
 				>
-					{ remaining }
+					{ displayCount }
 				</span>
 				<Button
 					variant="primary"
@@ -96,8 +163,16 @@ export function ComposerFooter( {
 					aria-label={ isPending ? translate( 'Posting…' ) : undefined }
 				>
 					{ isPending && <Spinner /> }
-					{ ! isPending && tooLong && translate( 'Better as a blog post' ) }
-					{ ! isPending && ! tooLong && translate( 'Post' ) }
+					{ /*
+					 * Soft-limit protocols (Fediverse) keep the "Post" label
+					 * past the threshold — the overflow-handoff section is the
+					 * meaningful cue, not the button copy. Hard-cap protocols
+					 * (Atmosphere / Mastodon) switch to the blog-post hint
+					 * because the button is also disabled there and the label
+					 * is the user's only signal.
+					 */ }
+					{ ! isPending && tooLong && ! softLimit && translate( 'Better as a blog post' ) }
+					{ ! isPending && ( ! tooLong || softLimit ) && translate( 'Post' ) }
 				</Button>
 			</HStack>
 		</HStack>

--- a/client/reader/social/composer/composer-modal.tsx
+++ b/client/reader/social/composer/composer-modal.tsx
@@ -125,6 +125,11 @@ export function ComposerModal< TError, TParams, TResult >() {
 		}
 	}, [ tooLong, markOverLimit ] );
 	const empty = graphemeCount === 0;
+	// `softLimit: true` (Fediverse) means the threshold is a UX cue, not a
+	// wire-level cap — submission stays enabled past the limit and the
+	// overflow handoff acts as a suggestion. Atmosphere / Mastodon keep
+	// the hard-cap gate (default).
+	const overLimitBlocksSubmit = tooLong && ! config.softLimit;
 	// Image-only posts are allowed: when the user has at least one uploaded
 	// image, the empty-text gate doesn't block submission. Pending media (any
 	// image still compressing/uploading) blocks regardless. `isExtending` covers
@@ -133,7 +138,7 @@ export function ComposerModal< TError, TParams, TResult >() {
 	const canSubmit =
 		! mutation.isPending &&
 		! isExtending &&
-		! tooLong &&
+		! overLimitBlocksSubmit &&
 		! mediaSlot.isAnyPending &&
 		mediaSlot.isAllUploaded &&
 		( ! empty || mediaSlot.hasUploaded );
@@ -253,6 +258,7 @@ export function ComposerModal< TError, TParams, TResult >() {
 					disabled={ ! canSubmit }
 					footerStart={ mediaSlot.renderFooterTrigger() }
 					counterUnit={ counterUnit }
+					softLimit={ config.softLimit }
 				/>
 				<ComposerOverflowHandoff text={ text } />
 			</Modal>

--- a/client/reader/social/composer/composer-modal.tsx
+++ b/client/reader/social/composer/composer-modal.tsx
@@ -146,23 +146,27 @@ export function ComposerModal< TError, TParams, TResult >() {
 			return;
 		}
 		const baseParams = config.buildParams( mode, text );
-		// First merge any protocol-specific extras (visibility, content
-		// warning, sensitive flag, etc.) — they're sync and never reject.
-		const baseParamsWithExtras = protocolExtrasSlot.extendBuildParams( baseParams ) as TParams;
-		// `extendBuildParams` may return synchronously (atmosphere) or as a
-		// Promise (mastodon, where staged media is uploaded at publish time).
-		// Awaiting in both cases keeps the call site uniform; sync returns
-		// resolve in a microtask without changing observable behaviour.
-		// A rejection here (e.g. a Mastodon media upload failing with a
-		// classified `MastodonError`) must surface through the same path as a
-		// post-mutation error: `config.errorMessage` rendered in the visible
-		// error region + `tracks.errorShown` fired. We funnel the rejection
-		// into local `extendError` state which `displayError` ORs into the
-		// rendered error and the analytics-watching effect, so the UX is
-		// indistinguishable from a `mutation.error`.
+		// Run protocol-extras then media-extras through the same try/catch.
+		// `protocolExtrasSlot.extendBuildParams` is typed as
+		// `( params: unknown ) => unknown` — sync today, but the contract
+		// doesn't forbid throws (or a future async widening for handle
+		// validation, derived params, etc.). Without the guard a throw here
+		// would skip the mutation, leave `mutation.isPending` false, and
+		// leave the Post button enabled with no error UI. Awaiting handles
+		// both sync and Promise returns uniformly.
+		// A rejection in either step (e.g. a Mastodon media upload failing
+		// with a classified `MastodonError`) must surface through the same
+		// path as a post-mutation error: `config.errorMessage` rendered in
+		// the visible error region + `tracks.errorShown` fired. We funnel
+		// the rejection into local `extendError` state which `displayError`
+		// ORs into the rendered error and the analytics-watching effect, so
+		// the UX is indistinguishable from a `mutation.error`.
 		let params: TParams;
 		setIsExtending( true );
 		try {
+			const baseParamsWithExtras = ( await protocolExtrasSlot.extendBuildParams(
+				baseParams
+			) ) as TParams;
 			params = ( await mediaSlot.extendBuildParams( baseParamsWithExtras ) ) as TParams;
 		} catch ( error ) {
 			setExtendError( error as TError );

--- a/client/reader/social/composer/composer-modal.tsx
+++ b/client/reader/social/composer/composer-modal.tsx
@@ -16,7 +16,7 @@ import { ComposerOverflowHandoff } from './composer-overflow-handoff';
 import { ComposerPinnedContext } from './composer-pinned-context';
 import { useComposer } from './composer-provider';
 import { ComposerTextarea } from './composer-textarea';
-import { countGraphemes } from './grapheme-count';
+import { countGraphemes, countWords } from './grapheme-count';
 import type { AppState } from 'calypso/types';
 
 export function ComposerModal< TError, TParams, TResult >() {
@@ -93,7 +93,14 @@ export function ComposerModal< TError, TParams, TResult >() {
 		}
 	}, [ displayError, mode, dispatch, config ] );
 
-	const graphemeCount = useMemo( () => countGraphemes( text ), [ text ] );
+	// Per-protocol counter unit: most protocols count graphemes against a
+	// hard wire cap; Fediverse counts words against a soft "blog-post" cap
+	// that surfaces the overflow handoff for longer text.
+	const counterUnit = config.counter ?? 'graphemes';
+	const graphemeCount = useMemo(
+		() => ( counterUnit === 'words' ? countWords( text ) : countGraphemes( text ) ),
+		[ text, counterUnit ]
+	);
 
 	const handleClose = useCallback( () => {
 		if ( mutation.isPending || isExtending ) {
@@ -241,6 +248,7 @@ export function ComposerModal< TError, TParams, TResult >() {
 					limit={ limit }
 					disabled={ ! canSubmit }
 					footerStart={ mediaSlot.renderFooterTrigger() }
+					counterUnit={ counterUnit }
 				/>
 				<ComposerOverflowHandoff text={ text } />
 			</Modal>

--- a/client/reader/social/composer/composer-modal.tsx
+++ b/client/reader/social/composer/composer-modal.tsx
@@ -22,7 +22,7 @@ import type { AppState } from 'calypso/types';
 export function ComposerModal< TError, TParams, TResult >() {
 	const translate = useTranslate();
 	const config = useComposerConfig< TError, TParams, TResult >();
-	const { mode, closeComposer, mediaSlot, markOverLimit } = useComposer();
+	const { mode, closeComposer, mediaSlot, protocolExtrasSlot, markOverLimit } = useComposer();
 	const queryClient = useQueryClient();
 	const mutation = useMutation( config.mutationFactory( queryClient ) );
 	const dispatch = useDispatch< ThunkDispatch< AppState, void, UnknownAction > >();
@@ -139,6 +139,9 @@ export function ComposerModal< TError, TParams, TResult >() {
 			return;
 		}
 		const baseParams = config.buildParams( mode, text );
+		// First merge any protocol-specific extras (visibility, content
+		// warning, sensitive flag, etc.) — they're sync and never reject.
+		const baseParamsWithExtras = protocolExtrasSlot.extendBuildParams( baseParams ) as TParams;
 		// `extendBuildParams` may return synchronously (atmosphere) or as a
 		// Promise (mastodon, where staged media is uploaded at publish time).
 		// Awaiting in both cases keeps the call site uniform; sync returns
@@ -153,7 +156,7 @@ export function ComposerModal< TError, TParams, TResult >() {
 		let params: TParams;
 		setIsExtending( true );
 		try {
-			params = ( await mediaSlot.extendBuildParams( baseParams ) ) as TParams;
+			params = ( await mediaSlot.extendBuildParams( baseParamsWithExtras ) ) as TParams;
 		} catch ( error ) {
 			setExtendError( error as TError );
 			return;
@@ -187,6 +190,7 @@ export function ComposerModal< TError, TParams, TResult >() {
 		translate,
 		config,
 		mediaSlot,
+		protocolExtrasSlot,
 		queryClient,
 	] );
 
@@ -224,6 +228,7 @@ export function ComposerModal< TError, TParams, TResult >() {
 					aria-invalid={ errorMessage ? true : undefined }
 				/>
 				{ mediaSlot.renderGrid() }
+				{ protocolExtrasSlot.renderControls() }
 				{ errorMessage && (
 					<div id="social-composer-error" className="social-composer__error" role="alert">
 						{ errorMessage }

--- a/client/reader/social/composer/composer-overflow-handoff.tsx
+++ b/client/reader/social/composer/composer-overflow-handoff.tsx
@@ -2,17 +2,25 @@ import './composer-overflow-handoff.scss';
 
 import { sitesQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { UnknownAction } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
-import { SiteHandoff } from 'calypso/reader/social/site-handoff';
+import { SiteHandoff, useHandoffMutation } from 'calypso/reader/social/site-handoff';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import { useComposerConfig } from './composer-config';
 import { useComposer } from './composer-provider';
 import type { ActiveMode } from './composer-provider';
+import type { Site } from '@automattic/api-core';
 import type { AppState } from 'calypso/types';
+
+// No-op default for `usePreferredHandoffSiteId` — keeps the hook count
+// stable across renders when the per-protocol config doesn't supply one.
+function useNullPreferredHandoffSiteId(): number | null {
+	return null;
+}
 
 interface ComposerOverflowHandoffProps {
 	text: string;
@@ -32,6 +40,43 @@ function OverflowHandoffShownEffect( { mode }: { mode: ActiveMode | null } ) {
 	return null;
 }
 
+/**
+ * Single-button handoff for protocols whose composer is already scoped
+ * to a specific blog (Fediverse). Renders just the "Move to editor"
+ * button — no site label, no chooser — because the user already knows
+ * which blog they're publishing from. Reuses `useHandoffMutation` so the
+ * draft-save + tab-handoff behavior is identical to `<SiteHandoff>`.
+ */
+function PreferredSiteHandoff( {
+	site,
+	content,
+	buttonLabel,
+	tracks,
+}: {
+	site: Site;
+	content: string;
+	buttonLabel: string;
+	tracks?: {
+		editorOpened?: ( siteId: number ) => { event: string; props: Record< string, unknown > };
+	};
+} ) {
+	const { submit, isPending } = useHandoffMutation( {
+		tracks,
+		caller: 'overflow_handoff_preferred_site',
+	} );
+	return (
+		<Button
+			variant="primary"
+			__next40pxDefaultSize
+			onClick={ () => submit( { site, content } ) }
+			isBusy={ isPending }
+			disabled={ isPending }
+		>
+			{ buttonLabel }
+		</Button>
+	);
+}
+
 export function ComposerOverflowHandoff( { text }: ComposerOverflowHandoffProps ) {
 	const translate = useTranslate();
 	const { hasBeenOverLimit, mode } = useComposer();
@@ -42,6 +87,16 @@ export function ComposerOverflowHandoff( { text }: ComposerOverflowHandoffProps 
 		enabled: hasBeenOverLimit,
 	} );
 
+	// Read the per-protocol preferred-site hook unconditionally (Rules of
+	// Hooks). When non-null, the handoff renders the memo + a single
+	// "Move to editor" button without a site label or chooser — the
+	// composer is already scoped to that blog (Fediverse pins to the
+	// connection's blog), so showing "Publish on %(siteName)s" would
+	// duplicate context the user already has.
+	const usePreferredHandoffSiteId =
+		config.usePreferredHandoffSiteId ?? useNullPreferredHandoffSiteId;
+	const preferredSiteId = usePreferredHandoffSiteId( mode );
+
 	if ( ! hasBeenOverLimit ) {
 		return null;
 	}
@@ -49,6 +104,11 @@ export function ComposerOverflowHandoff( { text }: ComposerOverflowHandoffProps 
 	if ( ! sites || sites.length === 0 ) {
 		return null;
 	}
+
+	const preferredSite =
+		preferredSiteId !== null && preferredSiteId !== undefined
+			? sites.find( ( site ) => site.ID === preferredSiteId ) ?? null
+			: null;
 
 	const tracks = config.overflowHandoff
 		? {
@@ -70,13 +130,22 @@ export function ComposerOverflowHandoff( { text }: ComposerOverflowHandoffProps 
 						'%(protocol)s is a brand name (e.g. "Bluesky", "Mastodon") and should not be translated.',
 				} ) }
 			</p>
-			<SiteHandoff
-				sites={ sites }
-				content={ text }
-				buttonLabel={ translate( 'Move to editor' ) as string }
-				tracks={ tracks }
-				caller="overflow_handoff"
-			/>
+			{ preferredSite ? (
+				<PreferredSiteHandoff
+					site={ preferredSite }
+					content={ text }
+					buttonLabel={ translate( 'Move to editor' ) as string }
+					tracks={ tracks }
+				/>
+			) : (
+				<SiteHandoff
+					sites={ sites }
+					content={ text }
+					buttonLabel={ translate( 'Move to editor' ) as string }
+					tracks={ tracks }
+					caller="overflow_handoff"
+				/>
+			) }
 		</section>
 	);
 }

--- a/client/reader/social/composer/composer-provider.tsx
+++ b/client/reader/social/composer/composer-provider.tsx
@@ -11,6 +11,7 @@ import {
 	ComposerConfigProvider,
 	type ComposerConfig,
 	type ComposerMediaSlot,
+	type ComposerProtocolExtrasSlot,
 } from './composer-config';
 import type { ReactNode } from 'react';
 
@@ -35,6 +36,22 @@ const NOOP_MEDIA_SLOT: ComposerMediaSlot = {
 
 function useNoopMedia(): ComposerMediaSlot {
 	return NOOP_MEDIA_SLOT;
+}
+
+/**
+ * Default `ComposerProtocolExtrasSlot` returned when a config doesn't
+ * supply `useProtocolExtras`. Render is null; the param hook is the
+ * identity. Atmosphere / Mastodon configs leave the slot undefined and
+ * fall through to this.
+ */
+const NOOP_EXTRAS_SLOT: ComposerProtocolExtrasSlot = {
+	renderControls: () => null,
+	extendBuildParams: ( params ) => params,
+	clear: () => undefined,
+};
+
+function useNoopProtocolExtras(): ComposerProtocolExtrasSlot {
+	return NOOP_EXTRAS_SLOT;
 }
 
 /**
@@ -109,6 +126,8 @@ interface ComposerContextValue {
 	closeComposer: ( options?: CloseComposerOptions ) => void;
 	/** Read by the modal to render media UI and gate submission. */
 	mediaSlot: ComposerMediaSlot;
+	/** Read by the modal to render protocol-specific controls. */
+	protocolExtrasSlot: ComposerProtocolExtrasSlot;
 	/**
 	 * Sticky-once flag: true after the user has crossed the per-protocol
 	 * char limit at least once during the current modal session. Reset on
@@ -186,6 +205,12 @@ export function ComposerProvider< TError, TParams, TResult >( {
 	const useMedia = config.useMedia ?? useNoopMedia;
 	const mediaSlot = useMedia( { mode, connectionId } );
 
+	// Protocol-specific extras slot (visibility selectors, CW toggles, etc.).
+	// Same lifetime contract as `useMedia` — invoked unconditionally so React's
+	// hook-ordering rules apply, even when no extras are wired.
+	const useProtocolExtras = config.useProtocolExtras ?? useNoopProtocolExtras;
+	const protocolExtrasSlot = useProtocolExtras( { mode, connectionId } );
+
 	// Reset media state when the composer closes (mode → null). `clear` is
 	// driven by the per-protocol slot — atmosphere's implementation calls
 	// `useImageUploads.clearAll` with deferred revocation when the publish
@@ -195,10 +220,12 @@ export function ComposerProvider< TError, TParams, TResult >( {
 			const keepPreviewUrlsAlive = keepPreviewUrlsAliveRef.current;
 			keepPreviewUrlsAliveRef.current = false;
 			mediaSlot.clear( { keepPreviewUrlsAlive } );
+			protocolExtrasSlot.clear?.();
 		}
-		// `mediaSlot` is recreated each render — capturing it in deps would
-		// re-run the effect every render. The closure reads the snapshot at
-		// effect time, which is the desired behavior.
+		// `mediaSlot` / `protocolExtrasSlot` are recreated each render —
+		// capturing them in deps would re-run the effect every render. The
+		// closure reads the snapshot at effect time, which is the desired
+		// behavior.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ mode ] );
 
@@ -208,10 +235,19 @@ export function ComposerProvider< TError, TParams, TResult >( {
 			openComposer,
 			closeComposer,
 			mediaSlot,
+			protocolExtrasSlot,
 			hasBeenOverLimit,
 			markOverLimit,
 		} ),
-		[ mode, openComposer, closeComposer, mediaSlot, hasBeenOverLimit, markOverLimit ]
+		[
+			mode,
+			openComposer,
+			closeComposer,
+			mediaSlot,
+			protocolExtrasSlot,
+			hasBeenOverLimit,
+			markOverLimit,
+		]
 	);
 
 	return (

--- a/client/reader/social/composer/grapheme-count.ts
+++ b/client/reader/social/composer/grapheme-count.ts
@@ -1,4 +1,4 @@
-const segmenter =
+const graphemeSegmenter =
 	typeof Intl !== 'undefined' && typeof Intl.Segmenter !== 'undefined'
 		? new Intl.Segmenter( undefined, { granularity: 'grapheme' } )
 		: null;
@@ -7,10 +7,10 @@ export function countGraphemes( text: string ): number {
 	if ( ! text ) {
 		return 0;
 	}
-	if ( segmenter ) {
+	if ( graphemeSegmenter ) {
 		let count = 0;
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		for ( const _ of segmenter.segment( text ) ) {
+		for ( const _ of graphemeSegmenter.segment( text ) ) {
 			count++;
 		}
 		return count;
@@ -19,4 +19,38 @@ export function countGraphemes( text: string ): number {
 	// This over-counts multi-codepoint graphemes but is a strict upper
 	// bound, so it errs toward "too long" which is safe.
 	return Array.from( text ).length;
+}
+
+const wordSegmenter =
+	typeof Intl !== 'undefined' && typeof Intl.Segmenter !== 'undefined'
+		? new Intl.Segmenter( undefined, { granularity: 'word' } )
+		: null;
+
+/**
+ * Count words in `text` via `Intl.Segmenter` with word granularity —
+ * locale-aware so CJK and other non-space-delimited scripts are handled
+ * correctly (the same fix Mastodon's web frontend applies for word
+ * counting). Falls back to a whitespace split for environments without
+ * `Intl.Segmenter`. Used by the Fediverse composer's word-based
+ * threshold for the blog-post overflow handoff — AP posts are
+ * blog-post-shaped, so word counts map onto "this is getting long"
+ * better than grapheme caps.
+ */
+export function countWords( text: string ): number {
+	const trimmed = text.trim();
+	if ( ! trimmed ) {
+		return 0;
+	}
+	if ( wordSegmenter ) {
+		let count = 0;
+		for ( const segment of wordSegmenter.segment( trimmed ) ) {
+			if ( segment.isWordLike ) {
+				count++;
+			}
+		}
+		return count;
+	}
+	// Whitespace-delimited fallback. Over-counts hyphenated tokens, under-
+	// counts CJK — acceptable for environments without `Intl.Segmenter`.
+	return trimmed.split( /\s+/ ).length;
 }

--- a/client/reader/social/composer/index.ts
+++ b/client/reader/social/composer/index.ts
@@ -9,6 +9,11 @@ export type {
 	ComposerEntryPoint,
 	ComposerParentRef,
 } from './composer-provider';
-export type { ComposerConfig, ComposerMediaSlot, Translate } from './composer-config';
+export type {
+	ComposerConfig,
+	ComposerMediaSlot,
+	ComposerProtocolExtrasSlot,
+	Translate,
+} from './composer-config';
 export { AltTextPopover, MediaGrid } from '../composer-media';
 export type { MediaGridItem } from '../composer-media';

--- a/client/reader/social/site-handoff/index.ts
+++ b/client/reader/social/site-handoff/index.ts
@@ -1,1 +1,3 @@
 export { SiteHandoff } from './site-handoff';
+export { useHandoffMutation } from './use-handoff-mutation';
+export type { HandoffTracks } from './use-handoff-mutation';

--- a/packages/api-core/src/reader-fediverse/__tests__/errors.test.ts
+++ b/packages/api-core/src/reader-fediverse/__tests__/errors.test.ts
@@ -34,6 +34,42 @@ describe( 'classifyFediverseError — body-level codes', () => {
 	} );
 } );
 
+describe( 'classifyFediverseError — slice 2 composer write-path codes', () => {
+	it.each( [
+		[ 'fediverse_text_too_long', 'text_too_long' ],
+		[ 'reader_fediverse_text_too_long', 'text_too_long' ],
+		[ 'fediverse_summary_too_long', 'summary_too_long' ],
+		[ 'reader_fediverse_summary_too_long', 'summary_too_long' ],
+		[ 'fediverse_visibility_invalid', 'visibility_invalid' ],
+		[ 'reader_fediverse_visibility_invalid', 'visibility_invalid' ],
+		[ 'fediverse_publish_disabled', 'publish_disabled' ],
+		[ 'reader_fediverse_publish_disabled', 'publish_disabled' ],
+		[ 'fediverse_target_unavailable', 'target_unavailable' ],
+		[ 'reader_fediverse_target_unavailable', 'target_unavailable' ],
+	] )( 'maps body-level %s to kind %s', ( code, kind ) => {
+		expect( classifyFediverseError( wpErr( code, 400 ) ).kind ).toBe( kind );
+	} );
+
+	it.each( [
+		[ 'fediverse_text_too_long', 'text_too_long' ],
+		[ 'reader_fediverse_text_too_long', 'text_too_long' ],
+		[ 'fediverse_publish_disabled', 'publish_disabled' ],
+		[ 'reader_fediverse_publish_disabled', 'publish_disabled' ],
+	] )( 'maps %s when surfaced on .code (proxy wire shape) to kind %s', ( code, kind ) => {
+		expect( classifyFediverseError( wpProxyErr( code, 400 ) ).kind ).toBe( kind );
+	} );
+
+	it( 'preserves the message on bad_request', () => {
+		expect(
+			classifyFediverseError( wpErr( 'fediverse_bad_request', 400, 'invalid input' ) )
+		).toEqual( { kind: 'bad_request', message: 'invalid input' } );
+	} );
+
+	it( 'falls back to publish_disabled for a 403 with no body-level code', () => {
+		expect( classifyFediverseError( { statusCode: 403 } ).kind ).toBe( 'publish_disabled' );
+	} );
+} );
+
 describe( 'classifyFediverseError — status fallbacks', () => {
 	it( 'maps HTTP 401 to auth_required when no body code is present', () => {
 		expect( classifyFediverseError( { statusCode: 401 } ) ).toEqual( { kind: 'auth_required' } );

--- a/packages/api-core/src/reader-fediverse/__tests__/fetchers.test.ts
+++ b/packages/api-core/src/reader-fediverse/__tests__/fetchers.test.ts
@@ -1,0 +1,158 @@
+import nock from 'nock';
+import { wpcom } from '../../wpcom-fetcher';
+import { createFediversePost } from '../fetchers';
+
+const BASE = 'https://public-api.wordpress.com';
+
+describe( 'createFediversePost', () => {
+	afterEach( () => nock.cleanAll() );
+
+	function defaultServerItem() {
+		return {
+			id: 'https://example.com/users/me/statuses/1',
+			url: 'https://example.com/users/me/statuses/1',
+			created_at: '2026-05-11T10:00:00Z',
+			account: { id: '1', username: 'me', acct: 'me', display_name: 'Me', avatar: null },
+			content: '<p>hi</p>',
+			spoiler_text: '',
+			sensitive: false,
+			language: null,
+			in_reply_to_id: null,
+			in_reply_to_account_id: null,
+			boost: null,
+			media: [],
+			counts: { replies: 0, boosts: 0, favourites: 0 },
+		};
+	}
+
+	it( 'POSTs `content` + `visibility` to /reader/fediverse/connections/:id/posts', async () => {
+		const scope = nock( BASE )
+			.post( '/wpcom/v2/reader/fediverse/connections/7/posts', {
+				content: 'hello world',
+				visibility: 'public',
+			} )
+			.reply( 200, { item: defaultServerItem() } );
+		const result = await createFediversePost( {
+			connectionId: 7,
+			content: 'hello world',
+			visibility: 'public',
+		} );
+		expect( result.item.id ).toBe( 'https://example.com/users/me/statuses/1' );
+		expect( scope.isDone() ).toBe( true );
+	} );
+
+	it( 'includes `summary`, `sensitive`, `language` when supplied', async () => {
+		const scope = nock( BASE )
+			.post( '/wpcom/v2/reader/fediverse/connections/7/posts', ( body ) => {
+				return (
+					body.content === 'hello' &&
+					body.visibility === 'unlisted' &&
+					body.summary === 'cw' &&
+					body.sensitive === true &&
+					body.language === 'en'
+				);
+			} )
+			.reply( 200, { item: defaultServerItem() } );
+		await createFediversePost( {
+			connectionId: 7,
+			content: 'hello',
+			visibility: 'unlisted',
+			summary: 'cw',
+			sensitive: true,
+			language: 'en',
+		} );
+		expect( scope.isDone() ).toBe( true );
+	} );
+
+	it( 'omits empty `summary` and `false` flags from the wire body', async () => {
+		const scope = nock( BASE )
+			.post( '/wpcom/v2/reader/fediverse/connections/7/posts', ( body ) => {
+				return (
+					body.content === 'hello' &&
+					body.visibility === 'public' &&
+					! ( 'summary' in body ) &&
+					! ( 'sensitive' in body ) &&
+					! ( 'language' in body )
+				);
+			} )
+			.reply( 200, { item: defaultServerItem() } );
+		await createFediversePost( {
+			connectionId: 7,
+			content: 'hello',
+			visibility: 'public',
+			summary: '',
+		} );
+		expect( scope.isDone() ).toBe( true );
+	} );
+
+	it( 'forwards `idempotencyKey` as the `Idempotency-Key` header', async () => {
+		// Spy on `wpcom.req.post` directly: the wpcom transport supports
+		// custom headers, and per CM-704 the composer must send a UUID per
+		// submit attempt as `Idempotency-Key` so a network retry can't
+		// double-post.
+		const post = jest
+			.spyOn( wpcom.req, 'post' )
+			.mockResolvedValue( { item: defaultServerItem() } as never );
+		await createFediversePost( {
+			connectionId: 7,
+			content: 'hello',
+			visibility: 'public',
+			idempotencyKey: 'a-uuid-1234',
+		} );
+		expect( post ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				path: '/reader/fediverse/connections/7/posts',
+				headers: { 'Idempotency-Key': 'a-uuid-1234' },
+			} )
+		);
+		post.mockRestore();
+	} );
+
+	it( 'omits the `Idempotency-Key` header when no key is supplied', async () => {
+		const post = jest
+			.spyOn( wpcom.req, 'post' )
+			.mockResolvedValue( { item: defaultServerItem() } as never );
+		await createFediversePost( {
+			connectionId: 7,
+			content: 'hello',
+			visibility: 'public',
+		} );
+		const args = post.mock.calls[ 0 ][ 0 ] as Record< string, unknown >;
+		expect( 'headers' in args ).toBe( false );
+		post.mockRestore();
+	} );
+
+	it( 'classifies a 401 as auth_required', async () => {
+		nock( BASE )
+			.post( '/wpcom/v2/reader/fediverse/connections/7/posts' )
+			.reply( 401, { error: 'not_authenticated' } );
+		await expect(
+			createFediversePost( { connectionId: 7, content: 'hi', visibility: 'public' } )
+		).rejects.toMatchObject( { kind: 'auth_required' } );
+	} );
+
+	it( 'classifies a 403 as publish_disabled (fallback path)', async () => {
+		nock( BASE ).post( '/wpcom/v2/reader/fediverse/connections/7/posts' ).reply( 403, {} );
+		await expect(
+			createFediversePost( { connectionId: 7, content: 'hi', visibility: 'public' } )
+		).rejects.toMatchObject( { kind: 'publish_disabled' } );
+	} );
+
+	it( 'classifies a body-level fediverse_text_too_long as text_too_long', async () => {
+		nock( BASE )
+			.post( '/wpcom/v2/reader/fediverse/connections/7/posts' )
+			.reply( 400, { error: 'fediverse_text_too_long', message: 'too long' } );
+		await expect(
+			createFediversePost( { connectionId: 7, content: 'hi', visibility: 'public' } )
+		).rejects.toMatchObject( { kind: 'text_too_long' } );
+	} );
+
+	it( 'classifies a 429 as rate_limited with retry_after', async () => {
+		nock( BASE )
+			.post( '/wpcom/v2/reader/fediverse/connections/7/posts' )
+			.reply( 429, { data: { retry_after: 30 } } );
+		await expect(
+			createFediversePost( { connectionId: 7, content: 'hi', visibility: 'public' } )
+		).rejects.toEqual( { kind: 'rate_limited', retry_after: 30 } );
+	} );
+} );

--- a/packages/api-core/src/reader-fediverse/__tests__/fetchers.test.ts
+++ b/packages/api-core/src/reader-fediverse/__tests__/fetchers.test.ts
@@ -31,13 +31,13 @@ describe( 'createFediversePost', () => {
 				content: 'hello world',
 				visibility: 'public',
 			} )
-			.reply( 200, { item: defaultServerItem() } );
+			.reply( 200, { post: defaultServerItem() } );
 		const result = await createFediversePost( {
 			connectionId: 7,
 			content: 'hello world',
 			visibility: 'public',
 		} );
-		expect( result.item.id ).toBe( 'https://example.com/users/me/statuses/1' );
+		expect( result.post.id ).toBe( 'https://example.com/users/me/statuses/1' );
 		expect( scope.isDone() ).toBe( true );
 	} );
 
@@ -52,7 +52,7 @@ describe( 'createFediversePost', () => {
 					body.language === 'en'
 				);
 			} )
-			.reply( 200, { item: defaultServerItem() } );
+			.reply( 200, { post: defaultServerItem() } );
 		await createFediversePost( {
 			connectionId: 7,
 			content: 'hello',
@@ -75,7 +75,7 @@ describe( 'createFediversePost', () => {
 					! ( 'language' in body )
 				);
 			} )
-			.reply( 200, { item: defaultServerItem() } );
+			.reply( 200, { post: defaultServerItem() } );
 		await createFediversePost( {
 			connectionId: 7,
 			content: 'hello',
@@ -92,7 +92,7 @@ describe( 'createFediversePost', () => {
 		// double-post.
 		const post = jest
 			.spyOn( wpcom.req, 'post' )
-			.mockResolvedValue( { item: defaultServerItem() } as never );
+			.mockResolvedValue( { post: defaultServerItem() } as never );
 		await createFediversePost( {
 			connectionId: 7,
 			content: 'hello',
@@ -111,7 +111,7 @@ describe( 'createFediversePost', () => {
 	it( 'omits the `Idempotency-Key` header when no key is supplied', async () => {
 		const post = jest
 			.spyOn( wpcom.req, 'post' )
-			.mockResolvedValue( { item: defaultServerItem() } as never );
+			.mockResolvedValue( { post: defaultServerItem() } as never );
 		await createFediversePost( {
 			connectionId: 7,
 			content: 'hello',

--- a/packages/api-core/src/reader-fediverse/constants.ts
+++ b/packages/api-core/src/reader-fediverse/constants.ts
@@ -1,0 +1,11 @@
+/**
+ * Prefix used to stamp a placeholder `FediverseFeedItem.id` for an
+ * in-flight standalone post during the optimistic-update window after
+ * `createFediversePost` fires but before the server response lands.
+ * Each in-flight post gets a `${PENDING_FEDIVERSE_POST_URI}#<counter>`
+ * suffix so siblings (back-to-back submits) can be distinguished.
+ * Consumers that need to recognise a placeholder should test with
+ * `String#startsWith` against this prefix, not equality. Mirrors the
+ * ATmosphere `PENDING_POST_URI` sentinel.
+ */
+export const PENDING_FEDIVERSE_POST_URI = '__pending_fediverse_post__';

--- a/packages/api-core/src/reader-fediverse/errors.ts
+++ b/packages/api-core/src/reader-fediverse/errors.ts
@@ -20,6 +20,16 @@ export type FediverseError =
 	| { kind: 'not_found' }
 	| { kind: 'rate_limited'; retry_after?: number }
 	| { kind: 'upstream_unavailable' }
+	// Slice 2 composer write paths add bad-request flavours surfaced by the
+	// `POST /posts` endpoint. The classifier reads the wpcom body-level
+	// `error` code to pick the right variant; all 400-flavour errors map
+	// here.
+	| { kind: 'bad_request'; message?: string }
+	| { kind: 'text_too_long' }
+	| { kind: 'summary_too_long' }
+	| { kind: 'visibility_invalid' }
+	| { kind: 'publish_disabled' }
+	| { kind: 'target_unavailable' }
 	| { kind: 'unknown'; cause: unknown };
 
 interface WpErrorLike {
@@ -55,11 +65,32 @@ export function classifyFediverseError( raw: unknown ): FediverseError {
 			return { kind: 'auth_required' };
 		case 'connection_not_found':
 			return { kind: 'connection_not_found' };
+		// Slice 2 composer write paths.
+		case 'fediverse_text_too_long':
+		case 'reader_fediverse_text_too_long':
+			return { kind: 'text_too_long' };
+		case 'fediverse_summary_too_long':
+		case 'reader_fediverse_summary_too_long':
+			return { kind: 'summary_too_long' };
+		case 'fediverse_visibility_invalid':
+		case 'reader_fediverse_visibility_invalid':
+			return { kind: 'visibility_invalid' };
+		case 'fediverse_publish_disabled':
+		case 'reader_fediverse_publish_disabled':
+			return { kind: 'publish_disabled' };
+		case 'fediverse_target_unavailable':
+		case 'reader_fediverse_target_unavailable':
+			return { kind: 'target_unavailable' };
+		case 'fediverse_bad_request':
+		case 'reader_fediverse_bad_request':
+			return { kind: 'bad_request', message: raw.message };
 	}
 	const status = raw.statusCode ?? raw.status;
 	switch ( status ) {
 		case 401:
 			return { kind: 'auth_required' };
+		case 403:
+			return { kind: 'publish_disabled' };
 		case 404:
 			return { kind: 'not_found' };
 		case 429:

--- a/packages/api-core/src/reader-fediverse/fetchers.ts
+++ b/packages/api-core/src/reader-fediverse/fetchers.ts
@@ -8,6 +8,8 @@ import type {
 	FediverseConnection,
 	FediverseConnectionsResponse,
 	FediverseCreateFollowParams,
+	FediverseCreatePostParams,
+	FediverseCreatePostResult,
 	FediverseDeleteFollowParams,
 	FediverseFollowResponse,
 	FediverseTimelinePage,
@@ -258,6 +260,41 @@ export async function deleteFediverseFollow(
 			) }`,
 			apiNamespace: NAMESPACE,
 		} ) ) as FediverseFollowResponse;
+	} catch ( raw ) {
+		throw classifyFediverseError( raw );
+	}
+}
+
+/**
+ * Publish a new ActivityPub post via the connected blog. Slice 2's
+ * standalone composer entry point — reply / quote variants will extend
+ * this fetcher (or sibling ones) in later slices. Forwards the
+ * caller-supplied `idempotencyKey` as the `Idempotency-Key` request
+ * header so a network retry can't double-post: the backend keys the
+ * de-dupe table on this header.
+ */
+export async function createFediversePost(
+	params: FediverseCreatePostParams
+): Promise< FediverseCreatePostResult > {
+	const { connectionId, content, visibility, summary, sensitive, language, idempotencyKey } =
+		params;
+	const body: Record< string, unknown > = { content, visibility };
+	if ( summary !== undefined && summary.length > 0 ) {
+		body.summary = summary;
+	}
+	if ( sensitive !== undefined ) {
+		body.sensitive = sensitive;
+	}
+	if ( language !== undefined ) {
+		body.language = language;
+	}
+	try {
+		return ( await wpcom.req.post( {
+			path: `/reader/fediverse/connections/${ connectionId }/posts`,
+			apiNamespace: NAMESPACE,
+			body,
+			...( idempotencyKey ? { headers: { 'Idempotency-Key': idempotencyKey } } : {} ),
+		} ) ) as FediverseCreatePostResult;
 	} catch ( raw ) {
 		throw classifyFediverseError( raw );
 	}

--- a/packages/api-core/src/reader-fediverse/index.ts
+++ b/packages/api-core/src/reader-fediverse/index.ts
@@ -1,3 +1,4 @@
+export * from './constants';
 export * from './errors';
 export * from './fetchers';
 export * from './query-keys';

--- a/packages/api-core/src/reader-fediverse/types.ts
+++ b/packages/api-core/src/reader-fediverse/types.ts
@@ -25,6 +25,14 @@
  *
  * Fields mirror the wire shape verbatim — see CM-684 for the contract.
  */
+/**
+ * Visibility levels the composer can stamp on a new Fediverse post. The
+ * AP plugin recognises `direct` too, but slice 2 intentionally omits it
+ * from the selector — the backend doesn't support it yet. Drop the
+ * comment + add the variant when that lands.
+ */
+export type FediverseVisibility = 'public' | 'unlisted' | 'followers';
+
 export interface FediverseConnection {
 	/** Keyring token id — canonical connection identifier for downstream calls. */
 	id: number;
@@ -38,6 +46,21 @@ export interface FediverseConnection {
 	icon: string;
 	/** Webfinger handle, e.g. `@myblog@myblog.wordpress.com`. */
 	webfinger: string;
+	/**
+	 * Per-blog grapheme cap for new posts. Surfaced by the connections
+	 * endpoint so the composer can validate against the blog's configured
+	 * cap rather than a hardcoded 500 — the AP plugin allows per-blog
+	 * overrides for long-form notes. Optional during the backend rollout
+	 * window; consumers default to 500 when absent.
+	 */
+	character_limit?: number;
+	/**
+	 * Blog-level default visibility for new posts. The composer's
+	 * visibility selector initialises to this value (modulo a localStorage
+	 * override carrying the user's last pick). Optional during the
+	 * rollout window; consumers default to `'public'` when absent.
+	 */
+	default_visibility?: FediverseVisibility;
 }
 
 export interface FediverseConnectionsResponse {
@@ -285,4 +308,47 @@ export interface FediverseDeleteFollowParams {
  */
 export interface FediverseFollowResponse {
 	viewer: FediverseAuthorProfileViewer;
+}
+
+/**
+ * Wire shape for `POST /reader/fediverse/connections/{id}/posts`. Sent
+ * by the standalone composer (slice 2). The reply / quote variants will
+ * extend this shape in later slices.
+ *
+ * `spoiler_text` carries the content-warning summary when the user
+ * toggles it on; the AP plugin maps it onto the upstream
+ * `summary` field. `sensitive` is the AP boolean and turns on the
+ * media-blur gate (relevant once media lands in a follow-up slice; the
+ * field is exposed now to keep the composer shape stable).
+ *
+ * `language` is optional — the backend infers from the blog locale when
+ * omitted. Slice 2 doesn't surface a language picker, but the wire
+ * accepts the field so a future power-user dropdown plugs in directly.
+ */
+export interface FediverseCreatePostParams {
+	connectionId: number;
+	content: string;
+	visibility: FediverseVisibility;
+	/** Content-warning summary. ≤100 chars per Mastodon convention. */
+	summary?: string;
+	sensitive?: boolean;
+	/** ISO-639-1 language code. */
+	language?: string;
+	/**
+	 * Idempotency token (UUID per submit attempt). Forwarded as the
+	 * `Idempotency-Key` request header so a network retry can't double-post.
+	 * Generated client-side at submit time.
+	 */
+	idempotencyKey?: string;
+}
+
+/**
+ * Response shape from the create-post endpoint. The wpcom backend
+ * projects the upstream AP `Create(Note)` activity into a uniform
+ * `FediverseFeedItem` — same shape returned by the timeline endpoint —
+ * so the composer's `onSuccess` can splice the new post into the
+ * timeline cache without an extra refetch.
+ */
+export interface FediverseCreatePostResult {
+	item: FediverseFeedItem;
 }

--- a/packages/api-core/src/reader-fediverse/types.ts
+++ b/packages/api-core/src/reader-fediverse/types.ts
@@ -343,12 +343,14 @@ export interface FediverseCreatePostParams {
 }
 
 /**
- * Response shape from the create-post endpoint. The wpcom backend
- * projects the upstream AP `Create(Note)` activity into a uniform
- * `FediverseFeedItem` — same shape returned by the timeline endpoint —
- * so the composer's `onSuccess` can splice the new post into the
- * timeline cache without an extra refetch.
+ * Wire envelope from `POST /reader/fediverse/connections/{id}/posts`.
+ * The backend projects the upstream AP `Create(Note)` activity into the
+ * same `FediverseFeedItem` shape returned by the timeline endpoint, so
+ * the composer's `onSuccess` can splice the new post straight into the
+ * timeline cache with no refetch flash. Mirrors the
+ * `FediverseAuthorProfileResponse` `{ profile: … }` envelope shape
+ * (the backend uses `post` here to match the AP activity nominal).
  */
 export interface FediverseCreatePostResult {
-	item: FediverseFeedItem;
+	post: FediverseFeedItem;
 }

--- a/packages/api-core/src/reader-fediverse/types.ts
+++ b/packages/api-core/src/reader-fediverse/types.ts
@@ -47,14 +47,6 @@ export interface FediverseConnection {
 	/** Webfinger handle, e.g. `@myblog@myblog.wordpress.com`. */
 	webfinger: string;
 	/**
-	 * Per-blog grapheme cap for new posts. Surfaced by the connections
-	 * endpoint so the composer can validate against the blog's configured
-	 * cap rather than a hardcoded 500 — the AP plugin allows per-blog
-	 * overrides for long-form notes. Optional during the backend rollout
-	 * window; consumers default to 500 when absent.
-	 */
-	character_limit?: number;
-	/**
 	 * Blog-level default visibility for new posts. The composer's
 	 * visibility selector initialises to this value (modulo a localStorage
 	 * override carrying the user's last pick). Optional during the

--- a/packages/api-queries/src/__tests__/reader-fediverse.test.tsx
+++ b/packages/api-queries/src/__tests__/reader-fediverse.test.tsx
@@ -506,6 +506,57 @@ describe( 'createFediversePostMutation', () => {
 		expect( scope.isDone() ).toBe( true );
 	} );
 
+	it( 'hydrates the placeholder author from the cached connection when available', async () => {
+		const client = new QueryClient( { defaultOptions: { mutations: { retry: false } } } );
+		// Seed the connections cache so the optimistic placeholder can pick up
+		// the user's avatar / handle / display name instead of rendering with
+		// empty author fields while the request is in flight.
+		client.setQueryData( readerFediverseKeys.connections(), {
+			connections: [
+				{
+					id: 1,
+					blog_id: 100,
+					url: 'https://example.com',
+					name: 'Example Blog',
+					icon: 'https://example.com/icon.png',
+					webfinger: '@example@example.com',
+				},
+			],
+		} );
+		const key = seedTimeline( client, 1, [] );
+
+		nock( BASE )
+			.post( '/wpcom/v2/reader/fediverse/connections/1/posts' )
+			.delay( 200 )
+			.reply( 200, { post: makeItem() } );
+
+		const { result } = renderHook( () => useMutation( createFediversePostMutation( client ) ), {
+			wrapper: makeWrapper( client ),
+		} );
+
+		let inFlight: Promise< unknown > | undefined;
+		act( () => {
+			inFlight = result.current.mutateAsync( {
+				connectionId: 1,
+				content: 'hi',
+				visibility: 'public',
+			} );
+		} );
+
+		await waitFor( () => {
+			const data = client.getQueryData< InfiniteData< FediverseTimelinePage > >( key );
+			const placeholder = data?.pages[ 0 ].items[ 0 ];
+			expect( placeholder?.id.startsWith( PENDING_FEDIVERSE_POST_URI ) ).toBe( true );
+			expect( placeholder?.account.display_name ).toBe( 'Example Blog' );
+			expect( placeholder?.account.avatar ).toBe( 'https://example.com/icon.png' );
+			expect( placeholder?.account.acct ).toBe( 'example@example.com' );
+		} );
+
+		await act( async () => {
+			await inFlight;
+		} );
+	} );
+
 	it( 'generates a fresh PENDING_FEDIVERSE_POST_URI per submit so back-to-back composes can coexist', async () => {
 		const client = new QueryClient( { defaultOptions: { mutations: { retry: false } } } );
 		const key = seedTimeline( client, 1, [] );

--- a/packages/api-queries/src/__tests__/reader-fediverse.test.tsx
+++ b/packages/api-queries/src/__tests__/reader-fediverse.test.tsx
@@ -416,7 +416,7 @@ describe( 'createFediversePostMutation', () => {
 			// Delay long enough for the mid-flight placeholder assertion to
 			// observe the optimistic-patch state before onSuccess runs.
 			.delay( 200 )
-			.reply( 200, { item: serverItem } );
+			.reply( 200, { post: serverItem } );
 
 		const { result } = renderHook( () => useMutation( createFediversePostMutation( client ) ), {
 			wrapper: makeWrapper( client ),
@@ -488,7 +488,7 @@ describe( 'createFediversePostMutation', () => {
 			reqheaders: { 'idempotency-key': 'fixed-uuid-abc' },
 		} )
 			.post( '/wpcom/v2/reader/fediverse/connections/1/posts' )
-			.reply( 200, { item: makeItem() } );
+			.reply( 200, { post: makeItem() } );
 
 		const { result } = renderHook( () => useMutation( createFediversePostMutation( client ) ), {
 			wrapper: makeWrapper( client ),
@@ -515,11 +515,11 @@ describe( 'createFediversePostMutation', () => {
 		nock( BASE )
 			.post( '/wpcom/v2/reader/fediverse/connections/1/posts' )
 			.delay( 50 )
-			.reply( 200, { item: makeItem( { id: 'first' } ) } );
+			.reply( 200, { post: makeItem( { id: 'first' } ) } );
 		nock( BASE )
 			.post( '/wpcom/v2/reader/fediverse/connections/1/posts' )
 			.delay( 50 )
-			.reply( 200, { item: makeItem( { id: 'second' } ) } );
+			.reply( 200, { post: makeItem( { id: 'second' } ) } );
 
 		const { result } = renderHook( () => useMutation( createFediversePostMutation( client ) ), {
 			wrapper: makeWrapper( client ),

--- a/packages/api-queries/src/__tests__/reader-fediverse.test.tsx
+++ b/packages/api-queries/src/__tests__/reader-fediverse.test.tsx
@@ -5,11 +5,23 @@ jest.mock( 'calypso/lib/logstash', () => ( {
 	logToLogstash: jest.fn(),
 } ) );
 
-import { readerFediverseKeys, type FediverseAuthorProfile } from '@automattic/api-core';
-import { QueryClient, QueryClientProvider, useMutation } from '@tanstack/react-query';
+import {
+	PENDING_FEDIVERSE_POST_URI,
+	readerFediverseKeys,
+	type FediverseAuthorProfile,
+	type FediverseFeedItem,
+	type FediverseTimelinePage,
+} from '@automattic/api-core';
+import {
+	QueryClient,
+	QueryClientProvider,
+	useMutation,
+	type InfiniteData,
+} from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import nock from 'nock';
 import {
+	createFediversePostMutation,
 	followFediverseActorMutation,
 	normalizeFediverseActor,
 	unfollowFediverseActorMutation,
@@ -346,5 +358,200 @@ describe( 'normalizeFediverseActor', () => {
 		expect( normalizeFediverseActor( 'http://Example.com/Users/Bob' ) ).toBe(
 			'http://Example.com/Users/Bob'
 		);
+	} );
+} );
+
+describe( 'createFediversePostMutation', () => {
+	afterEach( () => nock.cleanAll() );
+
+	function makeItem( overrides: Partial< FediverseFeedItem > = {} ): FediverseFeedItem {
+		return {
+			id: 'https://example.com/users/me/statuses/1',
+			url: 'https://example.com/users/me/statuses/1',
+			created_at: '2026-05-11T10:00:00Z',
+			account: {
+				id: '1',
+				username: 'me',
+				acct: 'me',
+				display_name: 'Me',
+				avatar: null,
+			},
+			content: '<p>hi</p>',
+			spoiler_text: '',
+			sensitive: false,
+			language: null,
+			in_reply_to_id: null,
+			in_reply_to_account_id: null,
+			boost: null,
+			media: [],
+			counts: { replies: 0, boosts: 0, favourites: 0 },
+			...overrides,
+		};
+	}
+
+	function seedTimeline( client: QueryClient, connectionId: number, items: FediverseFeedItem[] ) {
+		const key = readerFediverseKeys.timeline( connectionId );
+		const page: FediverseTimelinePage = { items, cursor: null };
+		client.setQueryData< InfiniteData< FediverseTimelinePage > >( key, {
+			pages: [ page ],
+			pageParams: [ undefined ],
+		} );
+		return key;
+	}
+
+	it( 'optimistically prepends a placeholder to the timeline cache and commits the server item on success', async () => {
+		const client = new QueryClient( { defaultOptions: { mutations: { retry: false } } } );
+		const existing = makeItem( {
+			id: 'https://example.com/users/me/statuses/0',
+			content: '<p>old</p>',
+		} );
+		const key = seedTimeline( client, 1, [ existing ] );
+
+		const serverItem = makeItem( {
+			id: 'https://example.com/users/me/statuses/100',
+			content: '<p>new</p>',
+		} );
+		nock( BASE )
+			.post( '/wpcom/v2/reader/fediverse/connections/1/posts' )
+			// Delay long enough for the mid-flight placeholder assertion to
+			// observe the optimistic-patch state before onSuccess runs.
+			.delay( 200 )
+			.reply( 200, { item: serverItem } );
+
+		const { result } = renderHook( () => useMutation( createFediversePostMutation( client ) ), {
+			wrapper: makeWrapper( client ),
+		} );
+
+		let inFlight: Promise< unknown > | undefined;
+		act( () => {
+			inFlight = result.current.mutateAsync( {
+				connectionId: 1,
+				content: 'new',
+				visibility: 'public',
+			} );
+		} );
+
+		// Mid-flight: placeholder is prepended.
+		await waitFor( () => {
+			const data = client.getQueryData< InfiniteData< FediverseTimelinePage > >( key );
+			expect( data?.pages[ 0 ].items.length ).toBe( 2 );
+			expect( data?.pages[ 0 ].items[ 0 ].id.startsWith( PENDING_FEDIVERSE_POST_URI ) ).toBe(
+				true
+			);
+		} );
+
+		await act( async () => {
+			await inFlight;
+		} );
+
+		const settled = client.getQueryData< InfiniteData< FediverseTimelinePage > >( key );
+		// Placeholder replaced by the server item; existing row preserved.
+		expect( settled?.pages[ 0 ].items[ 0 ].id ).toBe( 'https://example.com/users/me/statuses/100' );
+		expect( settled?.pages[ 0 ].items[ 1 ].id ).toBe( 'https://example.com/users/me/statuses/0' );
+	} );
+
+	it( 'rolls back the optimistic prepend on error', async () => {
+		const client = new QueryClient( { defaultOptions: { mutations: { retry: false } } } );
+		const existing = makeItem( { id: 'https://example.com/users/me/statuses/0' } );
+		const key = seedTimeline( client, 1, [ existing ] );
+
+		nock( BASE )
+			.post( '/wpcom/v2/reader/fediverse/connections/1/posts' )
+			.reply( 502, { error: 'fediverse_target_unavailable' } );
+
+		const { result } = renderHook( () => useMutation( createFediversePostMutation( client ) ), {
+			wrapper: makeWrapper( client ),
+		} );
+
+		await act( async () => {
+			try {
+				await result.current.mutateAsync( {
+					connectionId: 1,
+					content: 'new',
+					visibility: 'public',
+				} );
+			} catch {
+				// expected
+			}
+		} );
+
+		const settled = client.getQueryData< InfiniteData< FediverseTimelinePage > >( key );
+		expect( settled?.pages[ 0 ].items.length ).toBe( 1 );
+		expect( settled?.pages[ 0 ].items[ 0 ].id ).toBe( 'https://example.com/users/me/statuses/0' );
+	} );
+
+	it( 'forwards the idempotency key from vars into the POST headers', async () => {
+		const client = new QueryClient( { defaultOptions: { mutations: { retry: false } } } );
+		seedTimeline( client, 1, [] );
+
+		const scope = nock( BASE, {
+			reqheaders: { 'idempotency-key': 'fixed-uuid-abc' },
+		} )
+			.post( '/wpcom/v2/reader/fediverse/connections/1/posts' )
+			.reply( 200, { item: makeItem() } );
+
+		const { result } = renderHook( () => useMutation( createFediversePostMutation( client ) ), {
+			wrapper: makeWrapper( client ),
+		} );
+
+		await act( async () => {
+			await result.current.mutateAsync( {
+				connectionId: 1,
+				content: 'hi',
+				visibility: 'public',
+				idempotencyKey: 'fixed-uuid-abc',
+			} );
+		} );
+
+		expect( scope.isDone() ).toBe( true );
+	} );
+
+	it( 'generates a fresh PENDING_FEDIVERSE_POST_URI per submit so back-to-back composes can coexist', async () => {
+		const client = new QueryClient( { defaultOptions: { mutations: { retry: false } } } );
+		const key = seedTimeline( client, 1, [] );
+
+		// Two submits back-to-back with delayed servers — the second prepend
+		// must not collide with the first placeholder.
+		nock( BASE )
+			.post( '/wpcom/v2/reader/fediverse/connections/1/posts' )
+			.delay( 50 )
+			.reply( 200, { item: makeItem( { id: 'first' } ) } );
+		nock( BASE )
+			.post( '/wpcom/v2/reader/fediverse/connections/1/posts' )
+			.delay( 50 )
+			.reply( 200, { item: makeItem( { id: 'second' } ) } );
+
+		const { result } = renderHook( () => useMutation( createFediversePostMutation( client ) ), {
+			wrapper: makeWrapper( client ),
+		} );
+
+		let firstSubmit: Promise< unknown > | undefined;
+		let secondSubmit: Promise< unknown > | undefined;
+		act( () => {
+			firstSubmit = result.current.mutateAsync( {
+				connectionId: 1,
+				content: 'first',
+				visibility: 'public',
+			} );
+			secondSubmit = result.current.mutateAsync( {
+				connectionId: 1,
+				content: 'second',
+				visibility: 'public',
+			} );
+		} );
+
+		await waitFor( () => {
+			const data = client.getQueryData< InfiniteData< FediverseTimelinePage > >( key );
+			const placeholderIds = ( data?.pages[ 0 ].items ?? [] )
+				.map( ( item ) => item.id )
+				.filter( ( id ) => id.startsWith( PENDING_FEDIVERSE_POST_URI ) );
+			expect( placeholderIds.length ).toBe( 2 );
+			// Distinct counter-suffixes — siblings can be told apart.
+			expect( new Set( placeholderIds ).size ).toBe( 2 );
+		} );
+
+		await act( async () => {
+			await Promise.all( [ firstSubmit, secondSubmit ] );
+		} );
 	} );
 } );

--- a/packages/api-queries/src/reader-fediverse.ts
+++ b/packages/api-queries/src/reader-fediverse.ts
@@ -557,7 +557,7 @@ export const createFediversePostMutation = ( queryClient: QueryClient ) =>
 						pages: data.pages.map( ( page ) => ( {
 							...page,
 							items: page.items.map( ( item ) =>
-								item.id === ctx.pendingUri ? result.item : item
+								item.id === ctx.pendingUri ? result.post : item
 							),
 						} ) ),
 					} );

--- a/packages/api-queries/src/reader-fediverse.ts
+++ b/packages/api-queries/src/reader-fediverse.ts
@@ -1,5 +1,6 @@
 import {
 	createFediverseFollow,
+	createFediversePost,
 	deleteFediverseFollow,
 	getFediverseActorFollowers,
 	getFediverseActorFollowing,
@@ -8,6 +9,7 @@ import {
 	getFediverseConnection,
 	getFediverseConnections,
 	getFediverseTimeline,
+	PENDING_FEDIVERSE_POST_URI,
 	readerFediverseKeys,
 } from '@automattic/api-core';
 import {
@@ -26,7 +28,10 @@ import type {
 	FediverseAuthorProfile,
 	FediverseConnection,
 	FediverseConnectionsResponse,
+	FediverseCreatePostParams,
+	FediverseCreatePostResult,
 	FediverseError,
+	FediverseFeedItem,
 	FediverseFollowResponse,
 	FediverseTimelinePage,
 	GetFediverseAuthorFeedParams,
@@ -451,3 +456,147 @@ export const unfollowFediverseActorMutation = ( queryClient: QueryClient ) =>
 			}
 		},
 	} );
+
+let pendingPostCounter = 0;
+/**
+ * Monotonic counter-stamped placeholder for an in-flight standalone post.
+ * Each submit gets a unique suffix so back-to-back composes can be told
+ * apart in the timeline cache. Mirrors atmosphere's `nextPendingPostUri`.
+ */
+export const nextPendingFediversePostUri = () =>
+	`${ PENDING_FEDIVERSE_POST_URI }#${ ++pendingPostCounter }`;
+
+export interface CreateFediversePostContext {
+	/** Snapshot of every timeline-page cache entry touched by the optimistic patch. */
+	snapshots: Array< {
+		queryKey: QueryKey;
+		data: InfiniteData< FediverseTimelinePage > | undefined;
+	} >;
+	/** Synthetic id stamped on the placeholder item; matched on success to splice in the server item. */
+	pendingUri: string;
+}
+
+/**
+ * Mutation factory for publishing a new ActivityPub post.
+ * Optimistically prepends a placeholder `FediverseFeedItem` (stamped
+ * with a `PENDING_FEDIVERSE_POST_URI` sentinel id) to every cached
+ * timeline page for the connection so the composer's success feels
+ * immediate; rolls back on error; on success splices the server item
+ * over the placeholder and invalidates the timeline to refetch from the
+ * canonical source.
+ *
+ * Accepts the consumer's QueryClient — Calypso boots its own
+ * separate from the api-queries singleton. See `client/reader/AGENTS.md`.
+ * Mirrors `createMastodonPostMutation` / `createPostMutation`.
+ */
+export const createFediversePostMutation = ( queryClient: QueryClient ) =>
+	mutationOptions<
+		FediverseCreatePostResult,
+		FediverseError,
+		FediverseCreatePostParams,
+		CreateFediversePostContext
+	>( {
+		mutationFn: createFediversePost,
+		onMutate: async ( vars ) => {
+			const timelineKey = readerFediverseKeys.timeline( vars.connectionId );
+			try {
+				await queryClient.cancelQueries( { queryKey: timelineKey } );
+			} catch {
+				// Best-effort per TanStack docs; the optimistic patch + mutationFn
+				// must still run.
+			}
+
+			const pendingUri = nextPendingFediversePostUri();
+			const snapshots: CreateFediversePostContext[ 'snapshots' ] = [];
+
+			const matches = queryClient.getQueriesData< InfiniteData< FediverseTimelinePage > >( {
+				queryKey: timelineKey,
+			} );
+			for ( const [ queryKey, data ] of matches ) {
+				snapshots.push( { queryKey, data } );
+				if ( ! data || data.pages.length === 0 ) {
+					continue;
+				}
+				const placeholder = buildPlaceholderItem( vars, pendingUri );
+				const [ firstPage, ...rest ] = data.pages;
+				const patchedFirst: FediverseTimelinePage = {
+					...firstPage,
+					items: [ placeholder, ...firstPage.items ],
+				};
+				queryClient.setQueryData< InfiniteData< FediverseTimelinePage > >( queryKey, {
+					...data,
+					pages: [ patchedFirst, ...rest ],
+				} );
+			}
+
+			return { snapshots, pendingUri };
+		},
+		onError: ( _err, _vars, ctx ) => {
+			if ( ! ctx ) {
+				return;
+			}
+			for ( const { queryKey, data } of ctx.snapshots ) {
+				queryClient.setQueryData( queryKey, data );
+			}
+		},
+		onSuccess: ( result, vars, ctx ) => {
+			// Replace placeholder with the server item in every snapshotted
+			// page where the placeholder landed. Avoids a refetch flash for
+			// the user while still letting `invalidateQueries` below reconcile
+			// any drift on the next read.
+			if ( ctx ) {
+				const matches = queryClient.getQueriesData< InfiniteData< FediverseTimelinePage > >( {
+					queryKey: readerFediverseKeys.timeline( vars.connectionId ),
+				} );
+				for ( const [ queryKey, data ] of matches ) {
+					if ( ! data ) {
+						continue;
+					}
+					queryClient.setQueryData< InfiniteData< FediverseTimelinePage > >( queryKey, {
+						...data,
+						pages: data.pages.map( ( page ) => ( {
+							...page,
+							items: page.items.map( ( item ) =>
+								item.id === ctx.pendingUri ? result.item : item
+							),
+						} ) ),
+					} );
+				}
+			}
+			queryClient.invalidateQueries( {
+				queryKey: readerFediverseKeys.timeline( vars.connectionId ),
+			} );
+		},
+	} );
+
+/**
+ * Build the synthetic feed item used during the optimistic-update window.
+ * Borrows shape from `FediverseFeedItem` so the timeline renderer can
+ * project it through the existing mapper without special-casing.
+ */
+function buildPlaceholderItem(
+	vars: FediverseCreatePostParams,
+	pendingUri: string
+): FediverseFeedItem {
+	return {
+		id: pendingUri,
+		url: '',
+		created_at: new Date().toISOString(),
+		account: {
+			id: '',
+			username: '',
+			acct: '',
+			display_name: '',
+			avatar: null,
+		},
+		content: vars.content,
+		spoiler_text: vars.summary ?? '',
+		sensitive: Boolean( vars.sensitive ),
+		language: vars.language ?? null,
+		in_reply_to_id: null,
+		in_reply_to_account_id: null,
+		boost: null,
+		media: [],
+		counts: { replies: 0, boosts: 0, favourites: 0 },
+	};
+}

--- a/packages/api-queries/src/reader-fediverse.ts
+++ b/packages/api-queries/src/reader-fediverse.ts
@@ -46,6 +46,22 @@ export const fediverseConnectionsQueryOptions = () =>
 		// rarely change within a session and the list view re-mounts on
 		// every back-from-account navigation.
 		staleTime: 60_000,
+		// Same transient-error retry posture as every other query in this
+		// file. Without it a `rate_limited` 429 fails fast → `connection`
+		// resolves to `null` → the composer's `blogDefault` collapses to
+		// `'public'`, silently dropping the user's per-blog default.
+		retry: ( failureCount, error ) => {
+			if ( error.kind === 'rate_limited' || error.kind === 'upstream_unavailable' ) {
+				return failureCount < 2;
+			}
+			return false;
+		},
+		retryDelay: ( _attempt, error ) => {
+			if ( error.kind === 'rate_limited' && error.retry_after !== undefined ) {
+				return Math.min( error.retry_after * 1000, 30_000 );
+			}
+			return 2_000;
+		},
 	} );
 
 export function useFediverseConnectionsQuery( { enabled }: { enabled?: boolean } = {} ) {

--- a/packages/api-queries/src/reader-fediverse.ts
+++ b/packages/api-queries/src/reader-fediverse.ts
@@ -582,6 +582,17 @@ export const createFediversePostMutation = ( queryClient: QueryClient ) =>
 					} );
 				}
 			}
+			// Known limitation (CM-704): the AP `/timeline` endpoint returns
+			// the home-stream inbox — posts from followed actors — and does
+			// NOT include the caller's own published posts. This refetch
+			// therefore wipes the just-published item from the cache, and
+			// the user sees their post briefly appear (via the optimistic
+			// patch) and then disappear once `invalidateQueries` resolves.
+			// The post still appears on the Profile view (author-feed
+			// endpoint) and on the published web URL. Tracked for a backend
+			// follow-up that mirrors Mastodon's home-timeline-includes-own
+			// semantics; until then, the invalidate is still correct
+			// (cache should mirror server truth) but the UX is rough.
 			queryClient.invalidateQueries( {
 				queryKey: readerFediverseKeys.timeline( vars.connectionId ),
 			} );

--- a/packages/api-queries/src/reader-fediverse.ts
+++ b/packages/api-queries/src/reader-fediverse.ts
@@ -512,12 +512,15 @@ export const createFediversePostMutation = ( queryClient: QueryClient ) =>
 			const matches = queryClient.getQueriesData< InfiniteData< FediverseTimelinePage > >( {
 				queryKey: timelineKey,
 			} );
+			const connection = queryClient
+				.getQueryData< FediverseConnectionsResponse >( readerFediverseKeys.connections() )
+				?.connections.find( ( c ) => c.id === vars.connectionId );
 			for ( const [ queryKey, data ] of matches ) {
 				snapshots.push( { queryKey, data } );
 				if ( ! data || data.pages.length === 0 ) {
 					continue;
 				}
-				const placeholder = buildPlaceholderItem( vars, pendingUri );
+				const placeholder = buildPlaceholderItem( vars, pendingUri, connection );
 				const [ firstPage, ...rest ] = data.pages;
 				const patchedFirst: FediverseTimelinePage = {
 					...firstPage,
@@ -573,22 +576,24 @@ export const createFediversePostMutation = ( queryClient: QueryClient ) =>
  * Build the synthetic feed item used during the optimistic-update window.
  * Borrows shape from `FediverseFeedItem` so the timeline renderer can
  * project it through the existing mapper without special-casing.
+ *
+ * When the connections cache is warm, the placeholder's `account` is
+ * hydrated from the connection so the placeholder renders with the user's
+ * real avatar / handle / display name instead of a blank chip while the
+ * request is in flight. When cold, falls back to empty fields — the
+ * `invalidateQueries` in `onSuccess` will surface the canonical author on
+ * the refetch. Mirrors atmosphere's `authorFromConnection` shape.
  */
 function buildPlaceholderItem(
 	vars: FediverseCreatePostParams,
-	pendingUri: string
+	pendingUri: string,
+	connection: FediverseConnection | undefined
 ): FediverseFeedItem {
 	return {
 		id: pendingUri,
 		url: '',
 		created_at: new Date().toISOString(),
-		account: {
-			id: '',
-			username: '',
-			acct: '',
-			display_name: '',
-			avatar: null,
-		},
+		account: accountFromConnection( connection ),
 		content: vars.content,
 		spoiler_text: vars.summary ?? '',
 		sensitive: Boolean( vars.sensitive ),
@@ -598,5 +603,27 @@ function buildPlaceholderItem(
 		boost: null,
 		media: [],
 		counts: { replies: 0, boosts: 0, favourites: 0 },
+	};
+}
+
+function accountFromConnection(
+	connection: FediverseConnection | undefined
+): FediverseFeedItem[ 'account' ] {
+	if ( ! connection ) {
+		return { id: '', username: '', acct: '', display_name: '', avatar: null };
+	}
+	// `webfinger` is emitted with a leading `@` (`@user@host`); strip it so the
+	// mapper's `qualifyAcct` doesn't double up to `@@user@host`.
+	const handle = connection.webfinger.startsWith( '@' )
+		? connection.webfinger.slice( 1 )
+		: connection.webfinger;
+	const username = handle.split( '@' )[ 0 ] ?? '';
+	return {
+		// For blog actors the blog URL is also the canonical AP actor URL.
+		id: connection.url,
+		username,
+		acct: handle,
+		display_name: connection.name,
+		avatar: connection.icon || null,
 	};
 }


### PR DESCRIPTION
Part of CM-704. Frontend pairing for CM-703 (slice 2 backend — publish writes), stacked on the slice-1 basic-UI PR #110537.

## Proposed Changes

* **Standalone publish composer** on the `/reader/fediverse` pane, mounted via two entry points (mirrors the slice-1 ATmosphere / Mastodon shape):
  * `<TimelineComposePill>` inline on the timeline panel
  * `<ComposeFab>` floating button on every Fediverse view
* **Word-count counter** (not graphemes). AP posts are blog-post-shaped, so a word threshold maps onto "this is getting long; publish it on your blog instead" better than a microblog-sized char cap. Soft threshold of 100 words; once crossed, the existing shared `<ComposerOverflowHandoff>` surfaces the "Publish on your own site" section the Bluesky composer already ships with.
* **Protocol-specific controls** between the textarea and the footer: visibility radio (`public` / `unlisted` / `followers` — `direct` intentionally omitted per CM-704), content-warning toggle + 100-char `summary` input. The sensitive-media toggle was scoped out — slice 2 has no media support.
* **Generic shell extension** in `client/reader/social/composer/`: optional `useProtocolExtras` slot on `ComposerConfig` (symmetric to the existing `useMedia` slot) so Fediverse's modal-level controls plug in cleanly. Atmosphere/Mastodon are untouched (slot defaults to a no-op). Optional `counter: 'graphemes' | 'words'` field on `ComposerConfig` drives the count + footer label.
* **Wire layer** (`packages/api-core/src/reader-fediverse/`): adds `FediverseVisibility`, optional `character_limit`/`default_visibility` on `FediverseConnection`, `FediverseCreatePostParams`/`FediverseCreatePostResult` ({ post: FediverseFeedItem } envelope — matches CM-703), `createFediversePost` fetcher posting to `/connections/{id}/posts` and forwarding `idempotencyKey` as the `Idempotency-Key` request header so a network retry can't double-post. New `PENDING_FEDIVERSE_POST_URI` sentinel. Six new error variants: `text_too_long`, `summary_too_long`, `visibility_invalid`, `publish_disabled`, `target_unavailable`, `bad_request`.
* **Query layer** (`packages/api-queries/src/reader-fediverse.ts`): `createFediversePostMutation(queryClient)` with optimistic timeline prepend (counter-stamped `PENDING_FEDIVERSE_POST_URI#N` placeholder), rollback on error, splice the server item over the placeholder on success + invalidate timeline.
* **Per-protocol bits** (`client/reader/fediverse/`): `composer-config.tsx`, `composer-controls.tsx`, `use-fediverse-composer-extras.tsx` (visibility persisted to `localStorage` per connection; idempotency-key UUID generated once per modal session and stable across retries), `use-fediverse-composer-limit.ts`.

## Why are these changes being made?

CM-704 frontend pairing. The AP plugin already supports publishing from blog actors; this slice gives users a fast in-Reader compose surface so they don't have to context-switch to the blog editor for short posts. The blog-editor handoff is reachable in one click once the user crosses the soft word threshold, so longer-form notes still land in the right place.

## Testing Instructions

1. \`yarn typecheck-client\` — clean for fediverse paths.
2. With \`reader/fediverse\` flag enabled and a connected AP-enabled blog:
   * Visit \`/reader/fediverse/<id>/timeline\` → the inline compose pill appears at the top of the timeline; the floating compose button appears bottom-right.
   * Click either trigger → the compose modal opens. Title "New post", placeholder "What's up?", visibility radio defaults to the blog's \`default_visibility\` (or your last pick from \`localStorage\`).
   * Type a few words → the counter on the footer counts down from 100.
   * Toggle "Add content warning" → a single-line summary input appears (capped at 100 chars).
   * Pick a different visibility → next session defaults to that pick (per-connection localStorage).
   * Type past 100 words → "Publish on your own site instead" section appears (uses the shared overflow handoff, same as Bluesky).
   * Hit Post → optimistic placeholder lands at the top of the timeline; on success the server item replaces it and the success notice "Your post was published." appears.
   * Force a 401 / 403 / 502 / 429 from the backend → the matching error copy renders inline in the modal.
3. \`yarn test-client client/reader/fediverse client/reader/social/composer\` — 108 client tests pass.
4. \`yarn test-packages packages/api-core/src/reader-fediverse packages/api-queries/src/__tests__/reader-fediverse.test.tsx\` — 64 package tests pass.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
