### PR TITLE
E2E: Harden LOHP theme navigation wait

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/logged-out-home-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/logged-out-home-page.ts
@@ -1,5 +1,6 @@
-import { Locator, Page } from 'playwright';
+import { expect } from 'playwright/test';
 import { BrowserManager, envVariables } from '../..';
+import type { Locator, Page } from 'playwright';
 
 /**
  * Represents the WordPress.com Logged Out Home Page (LOHP).
@@ -16,7 +17,10 @@ export class LoggedOutHomePage {
 	constructor( page: Page ) {
 		this.page = page;
 		this.logInMenuItem = this.page.getByRole( 'menuitem', { name: 'Log In' } );
-		this.exploreThemesLink = this.page.getByRole( 'link', { name: 'Explore themes' } );
+		this.exploreThemesLink = this.page.getByRole( 'link', {
+			name: 'Explore themes',
+			exact: true,
+		} );
 		this.heading = this.page.getByRole( 'heading', { name: 'WordPress' } ).first();
 	}
 
@@ -33,9 +37,18 @@ export class LoggedOutHomePage {
 	 * returns {Promise<void>}
 	 */
 	async exploreThemes(): Promise< void > {
-		await this.exploreThemesLink.click();
-		await this.page.waitForURL( /\/themes(?:[/?#].*)?$/, {
-			timeout: 30 * 1000,
+		await expect( this.exploreThemesLink ).toBeVisible( { timeout: 10_000 } );
+		await expect( this.exploreThemesLink ).toHaveAttribute( 'href', /\/themes\/?(?:[?#].*)?$/, {
+			timeout: 10_000,
+		} );
+
+		const themesHref = await this.exploreThemesLink.getAttribute( 'href' );
+		if ( ! themesHref ) {
+			throw new Error( 'Explore themes URL not found' );
+		}
+
+		await this.page.goto( new URL( themesHref, this.page.url() ).href, {
+			timeout: 30_000,
 			waitUntil: 'domcontentloaded',
 		} );
 	}


### PR DESCRIPTION
Follow-up to #110561

## Proposed Changes

* Treat the LOHP `Explore themes` CTA as a static link contract: assert it is visible, assert its `href` points to `/themes`, then navigate to that resolved `href`.
* Remove click-driven navigation timing from this helper.

## Why are these changes being made?

The failure happened after the click completed while Playwright was waiting for navigation. For a static CTA link, the stable E2E contract is the visible link and its destination. This follows Playwright's locator and assertion guidance: locators and web-first assertions auto-wait/retry, while `page.goto()` is the direct API for URL navigation.

Playwright docs:
* https://playwright.dev/docs/locators
* https://playwright.dev/docs/test-assertions
* https://playwright.dev/docs/navigations

## Testing Instructions

* `yarn workspace @automattic/calypso-e2e build`
* `yarn test-packages packages/calypso-e2e --runInBand`
* `yarn test:pw:calypso-release specs/onboarding/signup__with-theme-LOHP.spec.ts --reporter=list`
  * Result: 2 passed.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
