### PR TITLE
Signup: clarify account creation error and add support link

### DIFF
--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -155,7 +155,18 @@ class PasswordlessSignupForm extends Component {
 				this.setState( {
 					errorMessages: [
 						this.props.translate(
-							'Sorry, something went wrong when trying to create your account. Please try again.'
+							'We couldn’t create your account with this email. Please try a different email, or {{a}}contact support{{/a}} if the problem persists.',
+							{
+								components: {
+									a: (
+										<a
+											href="https://wordpress.com/help/contact"
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
+									),
+								},
+							}
 						),
 					],
 				} );

--- a/client/blocks/signup-form/test/passwordless.jsx
+++ b/client/blocks/signup-form/test/passwordless.jsx
@@ -62,7 +62,7 @@ describe( 'createAccountError', () => {
 		await renderFormAndSubmit();
 
 		await waitFor( () => {
-			expect( screen.getByText( /something went wrong /i ) ).toBeInTheDocument();
+			expect( screen.getByText( /couldn.t create your account/i ) ).toBeInTheDocument();
 		} );
 	} );
 } );


### PR DESCRIPTION
Part of [DOTOBRD-411](https://linear.app/a8c/issue/DOTOBRD-411)

## Proposed Changes

* Replace the generic "Sorry, something went wrong when trying to create your account. Please try again." fallback in the passwordless signup flow (`client/blocks/signup-form/passwordless.jsx`) with a specific message that names the email as the likely cause and offers a "contact support" link as a recovery path.

## Why are these changes being made?

The original message left users with no recoverable path — they couldn't tell what went wrong or what to try next. The new copy points to a concrete next step.

### Reproduction notes

* Tested with a generic Gmail address using `+` notation: account creation worked fine.
* The error only reproduces with `@automattic.com` emails (server-side block on the internal domain).
* Even when the UI error appears, the account is still created and a confirmation email is sent. This is a server-side inconsistency in `users/new` and is being filed separately — out of scope for this PR.
* The original ticket screenshot showed two stacked errors; on current trunk only one renders for this scenario. If reviewers know a path that still produces two, please flag and I will follow up.

## Testing Instructions

* `yarn start` and visit `/setup/onboarding/user`.
* Submit `<your-username>+test@automattic.com` → new error copy appears with a working "contact support" link.
* Submit `not-an-email` → "Please provide a valid email address." still appears (client-side validator path, unchanged).
* Submit an email belonging to an existing wpcom account → still redirects to `/log-in?is_signup_existing_account=true` (unchanged).
* Repeat with `/setup/onboarding/user?ref=hosting-lp` (email-first variant) to confirm both layouts.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

## Translation context

String: `We couldn't create your account with this email. Please try a different email, or {{a}}contact support{{/a}} if the problem persists.`

Screenshot:
<img width="1412" height="920" alt="CleanShot 2026-05-12 at 20 29 53@2x" src="https://github.com/user-attachments/assets/1240ecf7-6501-4151-9f08-8bbd624da5e2" />

