### PR TITLE
Reader: Add a Reader Profile link to the sidebar

### DIFF
--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -4,7 +4,7 @@ import { readSubscribedListsQuery } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { useQuery } from '@tanstack/react-query';
-import { Icon, plus } from '@wordpress/icons';
+import { Icon, commentAuthorAvatar, plus } from '@wordpress/icons';
 import clsx from 'clsx';
 import closest from 'component-closest';
 import i18n, { localize } from 'i18n-calypso';
@@ -292,6 +292,22 @@ export class ReaderSidebar extends Component {
 						customIcon={ <ReaderManageSubscriptionsIcon size={ 24 } viewBox="0 0 24 24" /> }
 						link="/reader/subscriptions"
 					/>
+
+					<SidebarSeparator />
+
+					<SidebarItem
+						label={ translate( 'Profile' ) }
+						onNavigate={ () => recordReaderTracksEvent( 'calypso_reader_sidebar_profile_clicked' ) }
+						customIcon={
+							<Icon
+								className="sidebar__menu-icon"
+								icon={ commentAuthorAvatar }
+								viewBox="2 0 24 24"
+							/>
+						}
+						link="/reader/users/me"
+					/>
+
 					{ /*
 					Keep a separator at the end to avoid having the last item covered by browser breadcrumbs,
 					url links when hovering other items, etc. Otherwise when a user scrolls to the end of the

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -293,10 +293,8 @@ export class ReaderSidebar extends Component {
 						link="/reader/subscriptions"
 					/>
 
-					<SidebarSeparator />
-
 					<SidebarItem
-						label={ translate( 'Profile' ) }
+						label={ translate( 'Reader Profile' ) }
 						onNavigate={ () => recordReaderTracksEvent( 'calypso_reader_sidebar_profile_clicked' ) }
 						customIcon={
 							<Icon


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes RSM-412

## Proposed Changes

* Add a Reader Profile link at the end of the Reader sidebar, opening `/reader/users/me`.

| Before | After |
|--------|--------|
| <img width="280" height="187" alt="Screenshot 2026-05-11 at 16 51 45" src="https://github.com/user-attachments/assets/0e4c0857-522f-4141-a875-c9fc68af653e" /> | <img width="280" height="187" alt="Screenshot 2026-05-11 at 18 28 41" src="https://github.com/user-attachments/assets/462cab6c-be75-44e0-8a99-fd704c2be2b7" /> | 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Users don't have a direct way to open their own profiles otherwise.
* We are not calling it simply "Profile" as it would risk conflicting with the "Profile" link in the top-right `/me` menu.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to the Reader `/reader`.
* Locate the Profile link at the bottom of the sidebar.
* Click on the Profile link, and ensure it opens your own profile.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
