### PR TITLE
Reader Mastodon: add Notifications tab

### DIFF
--- a/client/reader/mastodon/helper.ts
+++ b/client/reader/mastodon/helper.ts
@@ -1,4 +1,5 @@
 export const MASTODON_PREFIX = 'reader/mastodon';
 export const TIMELINE_TAB = 'timeline';
+export const NOTIFICATIONS_TAB = 'notifications';
 export const PROFILE_TAB = 'profile';
 export const DEFAULT_MASTODON_TAB = TIMELINE_TAB;

--- a/client/reader/mastodon/mastodon-account-view.tsx
+++ b/client/reader/mastodon/mastodon-account-view.tsx
@@ -10,14 +10,15 @@ import ReaderMain from 'calypso/reader/components/reader-main';
 import { ComposeFab, ComposerModal, ComposerProvider } from 'calypso/reader/social/composer';
 import { normalizeHandle } from 'calypso/reader/social/utils/normalize-handle';
 import { mastodonComposerConfig } from './composer-config';
-import { PROFILE_TAB, TIMELINE_TAB } from './helper';
+import { NOTIFICATIONS_TAB, PROFILE_TAB, TIMELINE_TAB } from './helper';
 import { MastodonNavigation } from './mastodon-navigation';
+import { NotificationsPanel } from './notifications-panel';
 import { ProfilePanel } from './profile-panel';
 import { TimelinePanel } from './timeline-panel';
 import { MastodonReauthGate, useMastodonReauthGateState } from './use-mastodon-reauth-gate';
 import type { MastodonConnection } from '@automattic/api-core';
 
-const VALID_TABS = new Set( [ TIMELINE_TAB, PROFILE_TAB ] );
+const VALID_TABS = new Set( [ TIMELINE_TAB, NOTIFICATIONS_TAB, PROFILE_TAB ] );
 
 interface Props {
 	connectionId: number;
@@ -114,6 +115,8 @@ function renderTab( slug: string, connection: MastodonConnection ) {
 	switch ( slug ) {
 		case PROFILE_TAB:
 			return <ProfilePanel connection={ connection } />;
+		case NOTIFICATIONS_TAB:
+			return <NotificationsPanel connection={ connection } />;
 		case TIMELINE_TAB:
 		default:
 			return <TimelinePanel connection={ connection } />;

--- a/client/reader/mastodon/mastodon-navigation.tsx
+++ b/client/reader/mastodon/mastodon-navigation.tsx
@@ -4,7 +4,7 @@ import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import { useDispatch } from 'calypso/state';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
-import { TIMELINE_TAB, PROFILE_TAB } from './helper';
+import { NOTIFICATIONS_TAB, PROFILE_TAB, TIMELINE_TAB } from './helper';
 
 interface Tab {
 	slug: string;
@@ -35,6 +35,11 @@ export function MastodonNavigation( { connectionId, selectedTab }: Props ) {
 			slug: TIMELINE_TAB,
 			title: translate( 'Timeline' ),
 			path: `/reader/mastodon/${ connectionId }/${ TIMELINE_TAB }`,
+		},
+		{
+			slug: NOTIFICATIONS_TAB,
+			title: translate( 'Notifications' ),
+			path: `/reader/mastodon/${ connectionId }/${ NOTIFICATIONS_TAB }`,
 		},
 		{
 			slug: PROFILE_TAB,

--- a/client/reader/mastodon/notifications-panel.tsx
+++ b/client/reader/mastodon/notifications-panel.tsx
@@ -1,0 +1,28 @@
+import { useMastodonNotificationsInfiniteQuery } from '@automattic/api-queries';
+import { useMemo } from 'react';
+import { SocialNotificationsList } from 'calypso/reader/social';
+import type { MastodonConnection } from '@automattic/api-core';
+
+interface Props {
+	connection: MastodonConnection;
+}
+
+export function NotificationsPanel( { connection }: Props ) {
+	const { data, isPending, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
+		useMastodonNotificationsInfiniteQuery( connection.id );
+
+	const items = useMemo( () => data?.pages.flatMap( ( p ) => p.items ) ?? [], [ data ] );
+
+	return (
+		<SocialNotificationsList
+			items={ items }
+			isLoading={ isPending }
+			isLoadingMore={ isFetchingNextPage }
+			isError={ isError }
+			hasMore={ !! hasNextPage }
+			onLoadMore={ () => {
+				fetchNextPage();
+			} }
+		/>
+	);
+}

--- a/client/reader/mastodon/test/mastodon-account-view.test.tsx
+++ b/client/reader/mastodon/test/mastodon-account-view.test.tsx
@@ -7,7 +7,7 @@ import { screen, waitFor } from '@testing-library/react';
 import nock from 'nock';
 import * as readerAnalytics from 'calypso/state/reader/analytics/actions';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
-import { PROFILE_TAB, TIMELINE_TAB } from '../helper';
+import { NOTIFICATIONS_TAB, PROFILE_TAB, TIMELINE_TAB } from '../helper';
 import { MastodonAccountView } from '../mastodon-account-view';
 import type { MastodonAuthorProfile } from '@automattic/api-core';
 import type React from 'react';
@@ -205,6 +205,19 @@ describe( 'MastodonAccountView', () => {
 				'Alice the Brave ‹ Mastodon ‹ Reader'
 			)
 		);
+	} );
+
+	it( 'renders the notifications tab when asked', async () => {
+		mockConnections();
+		mockConnectionDetails( 7 );
+		nock( 'https://public-api.wordpress.com' )
+			.get( `${ listUrl }/7/notifications` )
+			.query( {} )
+			.reply( 200, { items: [], next_cursor: null, seen_at: null } );
+		renderWithProvider( <MastodonAccountView connectionId={ 7 } tab={ NOTIFICATIONS_TAB } />, {
+			queryClient: makeClient(),
+		} );
+		expect( await screen.findByText( /no notifications yet/i ) ).toBeVisible();
 	} );
 
 	it( 'renders the profile tab when asked', async () => {

--- a/client/reader/mastodon/test/mastodon-navigation.test.tsx
+++ b/client/reader/mastodon/test/mastodon-navigation.test.tsx
@@ -33,10 +33,11 @@ describe( 'MastodonNavigation', () => {
 		mockRecordReaderTracksEvent.mockClear();
 	} );
 
-	it( 'renders two tabs and marks the selected one active', () => {
+	it( 'renders three tabs and marks the selected one active', () => {
 		renderWithProvider( <MastodonNavigation connectionId={ 42 } selectedTab="profile" /> );
 
 		expect( screen.getByRole( 'menuitem', { name: /timeline/i } ) ).toBeVisible();
+		expect( screen.getByRole( 'menuitem', { name: /notifications/i } ) ).toBeVisible();
 		expect( screen.getByRole( 'menuitem', { name: /profile/i } ) ).toBeVisible();
 
 		expect( screen.getByRole( 'menuitem', { name: /profile/i } ) ).toHaveAttribute(
@@ -44,6 +45,10 @@ describe( 'MastodonNavigation', () => {
 			'true'
 		);
 		expect( screen.getByRole( 'menuitem', { name: /timeline/i } ) ).toHaveAttribute(
+			'aria-current',
+			'false'
+		);
+		expect( screen.getByRole( 'menuitem', { name: /notifications/i } ) ).toHaveAttribute(
 			'aria-current',
 			'false'
 		);
@@ -55,6 +60,10 @@ describe( 'MastodonNavigation', () => {
 		expect( screen.getByRole( 'menuitem', { name: /timeline/i } ) ).toHaveAttribute(
 			'href',
 			'/reader/mastodon/42/timeline'
+		);
+		expect( screen.getByRole( 'menuitem', { name: /notifications/i } ) ).toHaveAttribute(
+			'href',
+			'/reader/mastodon/42/notifications'
 		);
 		expect( screen.getByRole( 'menuitem', { name: /profile/i } ) ).toHaveAttribute(
 			'href',

--- a/client/reader/mastodon/test/notifications-panel.test.tsx
+++ b/client/reader/mastodon/test/notifications-panel.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { NotificationsPanel } from '../notifications-panel';
+import type { MastodonConnection } from '@automattic/api-core';
+
+const BASE = 'https://public-api.wordpress.com';
+
+const connection: MastodonConnection = {
+	id: 101,
+	handle: '@me@mastodon.social',
+	instance: 'mastodon.social',
+	display_name: 'Me',
+	avatar: null,
+};
+
+describe( 'Mastodon NotificationsPanel', () => {
+	afterEach( () => nock.cleanAll() );
+
+	it( 'renders fetched notifications via the shared list', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/mastodon/connections/101/notifications' )
+			.query( {} )
+			.reply( 200, {
+				items: [
+					{
+						id: '13371337',
+						// Upstream Mastodon spells it "favourite"; the canonical
+						// enum normalizes to "like" so the shared renderer can
+						// emit the same phrase across protocols.
+						protocol_type: 'favourite',
+						canonical_type: 'like',
+						actor: {
+							handle: 'jane@mastodon.social',
+							display_name: 'Jane',
+							avatar_url: null,
+							profile_uri: 'https://mastodon.social/@jane',
+						},
+						// `''` excerpt is the documented contract for likes
+						// (subject post text isn't fetched).
+						target: {
+							kind: 'post',
+							uri: 'https://mastodon.social/@me/110000000000000001',
+							excerpt: '',
+						},
+						target_url: 'https://mastodon.social/@me/110000000000000001',
+						created_at: '2026-05-11T12:34:56Z',
+						is_read: false,
+					},
+				],
+				next_cursor: null,
+				seen_at: null,
+			} );
+		renderWithProvider( <NotificationsPanel connection={ connection } /> );
+		await waitFor( () => expect( screen.getByText( /jane/i ) ).toBeVisible() );
+		expect( screen.getByText( /liked your post/i ) ).toBeVisible();
+	} );
+
+	it( 'renders Mastodon "reblog" notifications as repost via canonical_type', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/mastodon/connections/101/notifications' )
+			.query( {} )
+			.reply( 200, {
+				items: [
+					{
+						id: '13371338',
+						protocol_type: 'reblog',
+						canonical_type: 'repost',
+						actor: {
+							handle: 'jane@mastodon.social',
+							display_name: 'Jane',
+							avatar_url: null,
+							profile_uri: 'https://mastodon.social/@jane',
+						},
+						target: {
+							kind: 'post',
+							uri: 'https://mastodon.social/@me/110000000000000002',
+							excerpt: '',
+						},
+						target_url: 'https://mastodon.social/@me/110000000000000002',
+						created_at: '2026-05-11T13:00:00Z',
+						is_read: false,
+					},
+				],
+				next_cursor: null,
+				seen_at: null,
+			} );
+		renderWithProvider( <NotificationsPanel connection={ connection } /> );
+		await waitFor( () => expect( screen.getByText( /reposted your post/i ) ).toBeVisible() );
+	} );
+
+	it( 'falls back to the generic phrase for unknown canonical types (forward-compat)', async () => {
+		// The wpcom envelope deliberately omits a `raw` passthrough; the
+		// frontend renders unknown upstream kinds via canonical_type='other'
+		// and a generic phrase. This guards the long-tail rendering path the
+		// CM-660 / CM-662 envelope-shape tie-break depends on.
+		nock( BASE )
+			.get( '/wpcom/v2/reader/mastodon/connections/101/notifications' )
+			.query( {} )
+			.reply( 200, {
+				items: [
+					{
+						id: '13371339',
+						protocol_type: 'admin.sign_up',
+						canonical_type: 'other',
+						actor: {
+							handle: 'newbie@mastodon.social',
+							display_name: 'Newbie',
+							avatar_url: null,
+							profile_uri: 'https://mastodon.social/@newbie',
+						},
+						target: null,
+						target_url: '',
+						created_at: '2026-05-11T14:00:00Z',
+						is_read: false,
+					},
+				],
+				next_cursor: null,
+				seen_at: null,
+			} );
+		renderWithProvider( <NotificationsPanel connection={ connection } /> );
+		await waitFor( () => expect( screen.getByText( /interacted with you/i ) ).toBeVisible() );
+	} );
+
+	it( 'renders an empty state when no notifications', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/mastodon/connections/101/notifications' )
+			.query( {} )
+			.reply( 200, { items: [], next_cursor: null, seen_at: null } );
+		renderWithProvider( <NotificationsPanel connection={ connection } /> );
+		await waitFor( () => expect( screen.getByText( /no notifications yet/i ) ).toBeVisible() );
+	} );
+} );

--- a/client/reader/social/components/notifications-list/index.tsx
+++ b/client/reader/social/components/notifications-list/index.tsx
@@ -3,10 +3,17 @@ import './style.scss';
 import { Button, Spinner, __experimentalVStack as VStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { SocialNotificationItem } from './notification-item';
-import type { AtmosphereNotification } from '@automattic/api-core';
+import type { AtmosphereNotification, MastodonNotification } from '@automattic/api-core';
+
+// Cross-protocol envelope. The wpcom backend commits to a byte-compatible
+// shape across protocols (CM-660 / CM-662) so the shared renderer doesn't
+// have to branch on `source`. Listed as a discriminated-ish union here so a
+// future protocol whose envelope drifts surfaces as a type error at the
+// callers instead of a silent miss in the renderer.
+type SocialNotification = AtmosphereNotification | MastodonNotification;
 
 interface Props {
-	items: AtmosphereNotification[];
+	items: SocialNotification[];
 	isLoading: boolean;
 	isLoadingMore?: boolean;
 	isError: boolean;

--- a/client/reader/social/components/notifications-list/notification-item.tsx
+++ b/client/reader/social/components/notifications-list/notification-item.tsx
@@ -10,10 +10,22 @@ import { useTranslate } from 'i18n-calypso';
 import type {
 	AtmosphereNotification,
 	AtmosphereNotificationCanonicalType,
+	MastodonNotification,
+	MastodonNotificationCanonicalType,
 } from '@automattic/api-core';
 
+// The wpcom backend ships byte-compatible notification envelopes across
+// protocols; both per-protocol types share the same canonical_type union.
+// Aliased here so the renderer takes either without per-protocol branching.
+// Keep both arms in the union so a future per-protocol widening surfaces as
+// a switch-exhaustiveness error instead of being silently funneled to 'other'.
+type SocialNotification = AtmosphereNotification | MastodonNotification;
+type SocialNotificationCanonicalType =
+	| AtmosphereNotificationCanonicalType
+	| MastodonNotificationCanonicalType;
+
 interface Props {
-	notification: AtmosphereNotification;
+	notification: SocialNotification;
 }
 
 function isSafeUrl( url: string ): boolean {
@@ -87,7 +99,7 @@ export function SocialNotificationItem( { notification }: Props ) {
 }
 
 function actionPhrase(
-	canonical: AtmosphereNotificationCanonicalType,
+	canonical: SocialNotificationCanonicalType,
 	translate: ReturnType< typeof useTranslate >
 ): string {
 	switch ( canonical ) {
@@ -104,13 +116,19 @@ function actionPhrase(
 		case 'quote':
 			return translate( 'quoted your post' ) as string;
 		case 'other':
-		default:
 			return translate( 'interacted with you' ) as string;
+		default: {
+			// Future per-protocol union widening should fail to type-check here
+			// instead of silently funneling new kinds to the generic phrase.
+			const _exhaustive: never = canonical;
+			void _exhaustive;
+			return translate( 'interacted with you' ) as string;
+		}
 	}
 }
 
 function actionAriaLabel(
-	canonical: AtmosphereNotificationCanonicalType,
+	canonical: SocialNotificationCanonicalType,
 	actor: string,
 	translate: ReturnType< typeof useTranslate >
 ): string {
@@ -128,7 +146,11 @@ function actionAriaLabel(
 		case 'quote':
 			return translate( '%(actor)s quoted your post', { args: { actor } } ) as string;
 		case 'other':
-		default:
 			return translate( '%(actor)s interacted with you', { args: { actor } } ) as string;
+		default: {
+			const _exhaustive: never = canonical;
+			void _exhaustive;
+			return translate( '%(actor)s interacted with you', { args: { actor } } ) as string;
+		}
 	}
 }

--- a/packages/api-core/src/reader-mastodon/__tests__/fetchers.test.ts
+++ b/packages/api-core/src/reader-mastodon/__tests__/fetchers.test.ts
@@ -945,18 +945,6 @@ describe( 'getMastodonNotifications', () => {
 		expect( res.next_cursor ).toBeNull();
 	} );
 
-	it( 'sends explicit limit=0 (seen_at-only refresh)', async () => {
-		// Belt-and-suspenders: `typeof limit === 'number'` lets `limit: 0`
-		// through. A truthy guard would have dropped it and silently
-		// changed behaviour.
-		nock( BASE )
-			.get( '/wpcom/v2/reader/mastodon/connections/101/notifications' )
-			.query( { limit: '0' } )
-			.reply( 200, { items: [], next_cursor: null, seen_at: '2026-05-11T00:00:00Z' } );
-		const res = await getMastodonNotifications( { connectionId: 101, limit: 0 } );
-		expect( res.seen_at ).toBe( '2026-05-11T00:00:00Z' );
-	} );
-
 	it( 'classifies wpcom 401 as auth_required', async () => {
 		nock( BASE )
 			.get( '/wpcom/v2/reader/mastodon/connections/101/notifications' )

--- a/packages/api-core/src/reader-mastodon/__tests__/fetchers.test.ts
+++ b/packages/api-core/src/reader-mastodon/__tests__/fetchers.test.ts
@@ -16,10 +16,12 @@ import {
 	getMastodonConnection,
 	getMastodonConnections,
 	getMastodonInstanceConfig,
+	getMastodonNotifications,
 	getMastodonTagFeed,
 	getMastodonTimeline,
 	uploadMastodonMedia,
 } from '../fetchers';
+import type { MastodonNotificationsPage } from '../types';
 
 const BASE = 'https://public-api.wordpress.com';
 
@@ -887,5 +889,81 @@ describe( 'deleteMastodonFollow', () => {
 		await expect(
 			deleteMastodonFollow( { connectionId: 7, accountId: '200' } )
 		).rejects.toMatchObject( { kind: expectedKind } );
+	} );
+} );
+
+describe( 'getMastodonNotifications', () => {
+	afterEach( () => nock.cleanAll() );
+
+	it( 'hits the connection-scoped path with cursor + limit', async () => {
+		const page: MastodonNotificationsPage = {
+			items: [
+				{
+					id: '13371337',
+					protocol_type: 'favourite',
+					canonical_type: 'like',
+					actor: {
+						handle: 'jane@mastodon.social',
+						display_name: 'Jane',
+						avatar_url: null,
+						profile_uri: 'https://mastodon.social/@jane',
+					},
+					target: {
+						kind: 'post',
+						uri: 'https://mastodon.social/@me/110000000000000001',
+						excerpt: '',
+					},
+					target_url: 'https://mastodon.social/@me/110000000000000001',
+					created_at: '2026-05-11T12:34:56Z',
+					is_read: false,
+				},
+			],
+			next_cursor: 'next',
+			seen_at: '2026-05-10T00:00:00Z',
+		};
+		nock( BASE )
+			.get( '/wpcom/v2/reader/mastodon/connections/101/notifications' )
+			.query( { cursor: 'abc', limit: '30' } )
+			.reply( 200, page );
+
+		const res = await getMastodonNotifications( {
+			connectionId: 101,
+			cursor: 'abc',
+			limit: 30,
+		} );
+		expect( res ).toEqual( page );
+	} );
+
+	it( 'omits cursor + limit when not provided', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/mastodon/connections/101/notifications' )
+			.query( {} )
+			.reply( 200, { items: [], next_cursor: null, seen_at: null } );
+
+		const res = await getMastodonNotifications( { connectionId: 101 } );
+		expect( res.items ).toEqual( [] );
+		expect( res.next_cursor ).toBeNull();
+	} );
+
+	it( 'sends explicit limit=0 (seen_at-only refresh)', async () => {
+		// Belt-and-suspenders: `typeof limit === 'number'` lets `limit: 0`
+		// through. A truthy guard would have dropped it and silently
+		// changed behaviour.
+		nock( BASE )
+			.get( '/wpcom/v2/reader/mastodon/connections/101/notifications' )
+			.query( { limit: '0' } )
+			.reply( 200, { items: [], next_cursor: null, seen_at: '2026-05-11T00:00:00Z' } );
+		const res = await getMastodonNotifications( { connectionId: 101, limit: 0 } );
+		expect( res.seen_at ).toBe( '2026-05-11T00:00:00Z' );
+	} );
+
+	it( 'classifies wpcom 401 as auth_required', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/mastodon/connections/101/notifications' )
+			.query( {} )
+			.reply( 401, { code: 'reader_mastodon_auth_required' } );
+		await expect( getMastodonNotifications( { connectionId: 101 } ) ).rejects.toMatchObject( {
+			kind: 'auth_required',
+		} );
 	} );
 } );

--- a/packages/api-core/src/reader-mastodon/__tests__/query-keys.test.ts
+++ b/packages/api-core/src/reader-mastodon/__tests__/query-keys.test.ts
@@ -81,6 +81,17 @@ describe( 'readerMastodonKeys.tagFeed', () => {
 	} );
 } );
 
+describe( 'readerMastodonKeys.notifications', () => {
+	it( 'keys by connection id', () => {
+		expect( readerMastodonKeys.notifications( 42 ) ).toEqual( [
+			'reader',
+			'mastodon',
+			'notifications',
+			42,
+		] );
+	} );
+} );
+
 describe( 'readerMastodonKeys.authStatus', () => {
 	it( 'authStatus key includes the connection id', () => {
 		expect( readerMastodonKeys.authStatus( 42 ) ).toEqual( [

--- a/packages/api-core/src/reader-mastodon/__tests__/types.test.ts
+++ b/packages/api-core/src/reader-mastodon/__tests__/types.test.ts
@@ -10,6 +10,9 @@ import type {
 	MastodonDeleteFollowParams,
 	MastodonFeedItem,
 	MastodonFollowResponse,
+	MastodonNotification,
+	MastodonNotificationCanonicalType,
+	MastodonNotificationsPage,
 	MastodonProfileCounts,
 	MastodonTagFilter,
 	MastodonTagInfo,
@@ -155,5 +158,80 @@ describe( 'follow types', () => {
 			viewer: { following: true, followed_by: false, requested: false },
 		};
 		expect( r.viewer.following ).toBe( true );
+	} );
+} );
+
+describe( 'MastodonNotification types', () => {
+	it( 'canonical type accepts the documented enum values', () => {
+		const types: MastodonNotificationCanonicalType[] = [
+			'like',
+			'repost',
+			'follow',
+			'mention',
+			'reply',
+			'quote',
+			'other',
+		];
+		expect( types ).toHaveLength( 7 );
+	} );
+
+	it( 'MastodonNotification + page canonical shapes', () => {
+		const canonical: MastodonNotificationCanonicalType = 'mention';
+		const item: MastodonNotification = {
+			id: '13371337',
+			protocol_type: 'mention',
+			canonical_type: canonical,
+			actor: {
+				handle: 'alice@mastodon.social',
+				display_name: 'Alice',
+				avatar_url: 'https://example.invalid/a.png',
+				profile_uri: 'https://mastodon.social/@alice',
+			},
+			target: {
+				kind: 'post',
+				uri: 'https://mastodon.social/@me/110000000000000001',
+				excerpt: '@me hi there',
+			},
+			target_url: 'https://mastodon.social/@me/110000000000000001',
+			created_at: '2026-05-11T12:34:56Z',
+			is_read: false,
+		};
+		const page: MastodonNotificationsPage = {
+			items: [ item ],
+			next_cursor: null,
+			seen_at: '2026-05-11T00:00:00Z',
+		};
+		expect( page.items ).toHaveLength( 1 );
+		expect( page.items[ 0 ].canonical_type ).toBe( 'mention' );
+	} );
+
+	it( 'MastodonNotification permits null target + null created_at', () => {
+		// `null` target shape is the documented contract for forward-compat
+		// types where the wpcom backend has no subject post to project
+		// (e.g. follow, `other` items). `null` created_at covers
+		// unparseable upstream timestamps.
+		const item: MastodonNotification = {
+			id: '13371338',
+			protocol_type: 'admin.sign_up',
+			canonical_type: 'other',
+			actor: {
+				handle: 'newbie@mastodon.social',
+				display_name: null,
+				avatar_url: null,
+				profile_uri: 'https://mastodon.social/@newbie',
+			},
+			target: null,
+			target_url: '',
+			created_at: null,
+			is_read: true,
+		};
+		expect( item.target ).toBeNull();
+		expect( item.target_url ).toBe( '' );
+	} );
+
+	it( '@ts-expect-error rejects unknown canonical types', () => {
+		// @ts-expect-error — string-literal union rejects bogus values.
+		const bad: MastodonNotificationCanonicalType = 'bogus';
+		expect( bad ).toBe( 'bogus' );
 	} );
 } );

--- a/packages/api-core/src/reader-mastodon/fetchers.ts
+++ b/packages/api-core/src/reader-mastodon/fetchers.ts
@@ -22,6 +22,7 @@ import type {
 	MastodonFollowResponse,
 	MastodonMediaUploadParams,
 	MastodonMediaUploadResult,
+	MastodonNotificationsPage,
 	MastodonTagFilter,
 	MastodonTagFeedPage,
 	MastodonThreadResponse,
@@ -151,6 +152,38 @@ export async function getMastodonTimeline(
 			},
 			query
 		) ) as MastodonTimelinePage;
+	} catch ( raw ) {
+		throw classifyMastodonError( raw );
+	}
+}
+
+export interface GetMastodonNotificationsParams {
+	connectionId: number;
+	cursor?: string;
+	limit?: number;
+}
+
+export async function getMastodonNotifications(
+	params: GetMastodonNotificationsParams
+): Promise< MastodonNotificationsPage > {
+	const { connectionId, cursor, limit } = params;
+	const query: Record< string, string > = {};
+	if ( cursor ) {
+		query.cursor = cursor;
+	}
+	// typeof guard so an explicit `limit: 0` (used by callers that want
+	// only the seen_at watermark refreshed without items) reaches the wire.
+	if ( typeof limit === 'number' ) {
+		query.limit = String( limit );
+	}
+	try {
+		return ( await wpcom.req.get(
+			{
+				path: `/reader/mastodon/connections/${ connectionId }/notifications`,
+				apiNamespace: NAMESPACE,
+			},
+			query
+		) ) as MastodonNotificationsPage;
 	} catch ( raw ) {
 		throw classifyMastodonError( raw );
 	}

--- a/packages/api-core/src/reader-mastodon/fetchers.ts
+++ b/packages/api-core/src/reader-mastodon/fetchers.ts
@@ -171,9 +171,7 @@ export async function getMastodonNotifications(
 	if ( cursor ) {
 		query.cursor = cursor;
 	}
-	// typeof guard so an explicit `limit: 0` (used by callers that want
-	// only the seen_at watermark refreshed without items) reaches the wire.
-	if ( typeof limit === 'number' ) {
+	if ( limit ) {
 		query.limit = String( limit );
 	}
 	try {

--- a/packages/api-core/src/reader-mastodon/query-keys.ts
+++ b/packages/api-core/src/reader-mastodon/query-keys.ts
@@ -11,6 +11,8 @@ export const readerMastodonKeys = {
 		[ ...readerMastodonKeys.all, 'instance-config', id ] as const,
 	timeline: ( connectionId: number ) =>
 		[ ...readerMastodonKeys.all, 'timeline', connectionId ] as const,
+	notifications: ( connectionId: number ) =>
+		[ ...readerMastodonKeys.all, 'notifications', connectionId ] as const,
 	thread: ( connectionId: number, statusId: string ) =>
 		[ ...readerMastodonKeys.all, 'thread', connectionId, statusId ] as const,
 	authorProfile: ( connectionId: number, actor: string ) =>

--- a/packages/api-core/src/reader-mastodon/types.ts
+++ b/packages/api-core/src/reader-mastodon/types.ts
@@ -410,3 +410,78 @@ export interface MastodonAccountSummariesPage {
 	items: MastodonAccountSummary[];
 	cursor: string | null;
 }
+
+/**
+ * Normalized cross-protocol notification kind. Identical to
+ * `AtmosphereNotificationCanonicalType` by design — the wpcom backend
+ * commits to a byte-compatible envelope across protocols so the shared
+ * frontend renderer doesn't have to branch on `source`. `'other'` is the
+ * forward-compat bucket for upstream Mastodon types we don't yet render
+ * with bespoke templates (`status`, `admin.*`, `update`, etc.). The
+ * shared renderer falls through to a generic phrase that humanizes
+ * `protocol_type` for the label.
+ */
+export type MastodonNotificationCanonicalType =
+	| 'like'
+	| 'repost'
+	| 'follow'
+	| 'mention'
+	| 'reply'
+	| 'quote'
+	| 'other';
+
+export interface MastodonNotificationActor {
+	handle: string;
+	display_name: string | null;
+	avatar_url: string | null;
+	profile_uri: string;
+}
+
+export interface MastodonNotificationTarget {
+	kind: 'post' | 'profile';
+	uri: string;
+	excerpt: string;
+}
+
+/**
+ * Envelope shape returned by
+ * `/wpcom/v2/reader/mastodon/connections/:id/notifications`. Byte-compatible
+ * with `AtmosphereNotification` — the wpcom backend normalizes both protocols
+ * to the same shape so the shared frontend renderer takes either.
+ *
+ * `protocol_type` is the raw upstream Mastodon `type` value (verbatim,
+ * lossless: `favourite`, `reblog`, `follow`, `mention`, `status`, …);
+ * `canonical_type` is the normalized enum. There is no `raw` passthrough —
+ * `protocol_type` is the long-tail escape hatch for upstream kinds we don't
+ * yet render with bespoke templates. `target.excerpt` is `''` for
+ * `like`/`repost` (the subject post text isn't fetched for these — only
+ * mention/reply/quote shapes populate it). `target_url` is best-effort: the
+ * status URL when buildable, otherwise the actor profile URL, otherwise the
+ * empty string (the frontend skips linkification when empty). `created_at` is
+ * normalized to `YYYY-MM-DDTHH:MM:SSZ` (UTC, no fractional seconds) and is
+ * nullable when the upstream timestamp is missing or unparseable. `is_read`
+ * is server-computed against the user's `last_read_id` watermark.
+ */
+export interface MastodonNotification {
+	id: string;
+	/** Raw upstream type string, e.g. Mastodon `notification.type`. */
+	protocol_type: string;
+	canonical_type: MastodonNotificationCanonicalType;
+	actor: MastodonNotificationActor;
+	target: MastodonNotificationTarget | null;
+	target_url: string;
+	created_at: string | null;
+	is_read: boolean;
+}
+
+/**
+ * Single page from the cursor-paginated notifications endpoint.
+ * `next_cursor: null` means end-of-list. `seen_at` is the server's watermark
+ * timestamp, exposed at the page level (not per-item) so subsequent "Load
+ * more" pages can classify items without re-fetching.
+ */
+export interface MastodonNotificationsPage {
+	items: MastodonNotification[];
+	next_cursor: string | null;
+	seen_at: string | null;
+}

--- a/packages/api-queries/src/__tests__/reader-mastodon.test.tsx
+++ b/packages/api-queries/src/__tests__/reader-mastodon.test.tsx
@@ -37,6 +37,7 @@ import {
 	useMastodonAuthorProfileQuery,
 	useMastodonConnectionQuery,
 	useMastodonConnectionsQuery,
+	useMastodonNotificationsInfiniteQuery,
 	useMastodonTagFeedInfiniteQuery,
 	useMastodonTimelineInfiniteQuery,
 } from '../reader-mastodon';
@@ -239,6 +240,82 @@ describe( 'useMastodonTimelineInfiniteQuery', () => {
 		} );
 		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
 		expect( result.current.data?.pages[ 0 ].cursor ).toBe( 'next-cursor' );
+	} );
+} );
+
+describe( 'useMastodonNotificationsInfiniteQuery', () => {
+	const PATH = '/wpcom/v2/reader/mastodon/connections/42/notifications';
+
+	// Touch tracked properties inside the render callback so React Query's
+	// `notifyOnChangeProps: 'tracked'` observer fires on later updates.
+	// Without this, `fetchNextPage()` resolves but the rendered `data` /
+	// `hasNextPage` lag, producing flaky pagination assertions.
+	const renderNotificationsHook = (
+		connectionId: number,
+		wrapper: ReturnType< typeof createWrapper >
+	) =>
+		renderHook(
+			() => {
+				const q = useMastodonNotificationsInfiniteQuery( connectionId );
+				void q.data;
+				void q.hasNextPage;
+				void q.isFetchingNextPage;
+				void q.isError;
+				void q.error;
+				return q;
+			},
+			{ wrapper }
+		);
+
+	afterEach( () => nock.cleanAll() );
+
+	it( 'is disabled when connectionId is 0', () => {
+		const { result } = renderNotificationsHook( 0, createWrapper() );
+		expect( result.current.fetchStatus ).toBe( 'idle' );
+		expect( result.current.data ).toBeUndefined();
+	} );
+
+	it( 'fetches the first page on mount', async () => {
+		nock( BASE ).get( PATH ).query( {} ).reply( 200, {
+			items: [],
+			next_cursor: null,
+			seen_at: null,
+		} );
+		const { result } = renderNotificationsHook( 42, createWrapper() );
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+		expect( result.current.data?.pages[ 0 ].items ).toEqual( [] );
+	} );
+
+	it( 'paginates via next_cursor returned by the previous page', async () => {
+		nock( BASE ).get( PATH ).query( {} ).reply( 200, {
+			items: [],
+			next_cursor: 'page-2',
+			seen_at: null,
+		} );
+		nock( BASE )
+			.get( PATH )
+			.query( { cursor: 'page-2' } )
+			.reply( 200, { items: [], next_cursor: null, seen_at: null } );
+
+		const { result } = renderNotificationsHook( 42, createWrapper() );
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+		expect( result.current.hasNextPage ).toBe( true );
+
+		await act( async () => {
+			await result.current.fetchNextPage();
+		} );
+		expect( result.current.data?.pages.length ).toBe( 2 );
+		expect( result.current.hasNextPage ).toBe( false );
+	} );
+
+	it( 'does not retry terminal errors', async () => {
+		// Mirror the timeline test policy: auth_required is terminal — no
+		// extra requests beyond the first. nock would throw if a retry
+		// happened (only one interceptor registered).
+		nock( BASE ).get( PATH ).query( {} ).reply( 401, { code: 'reader_mastodon_auth_required' } );
+		const { result } = renderNotificationsHook( 42, createWrapper() );
+		await waitFor( () => expect( result.current.isError ).toBe( true ) );
+		expect( ( result.current.error as { kind: string } ).kind ).toBe( 'auth_required' );
 	} );
 } );
 

--- a/packages/api-queries/src/reader-mastodon.ts
+++ b/packages/api-queries/src/reader-mastodon.ts
@@ -16,6 +16,7 @@ import {
 	getMastodonConnection,
 	getMastodonConnections,
 	getMastodonInstanceConfig,
+	getMastodonNotifications,
 	getMastodonTagFeed,
 	getMastodonThread,
 	getMastodonTimeline,
@@ -57,6 +58,7 @@ import type {
 	MastodonInstanceConfig,
 	MastodonMediaUploadParams,
 	MastodonMediaUploadResult,
+	MastodonNotificationsPage,
 	MastodonTagFilter,
 	MastodonTagFeedPage,
 	MastodonThreadNode,
@@ -198,6 +200,43 @@ export const mastodonTimelineInfiniteQuery = ( connectionId: number ) =>
 
 export function useMastodonTimelineInfiniteQuery( connectionId: number ) {
 	return useInfiniteQuery( mastodonTimelineInfiniteQuery( connectionId ) );
+}
+
+export const mastodonNotificationsInfiniteQuery = ( connectionId: number ) =>
+	infiniteQueryOptions<
+		MastodonNotificationsPage,
+		MastodonError,
+		InfiniteData< MastodonNotificationsPage >,
+		QueryKey,
+		string | undefined
+	>( {
+		queryKey: readerMastodonKeys.notifications( connectionId ),
+		queryFn: ( { pageParam } ) => getMastodonNotifications( { connectionId, cursor: pageParam } ),
+		initialPageParam: undefined,
+		getNextPageParam: ( lastPage ) => lastPage.next_cursor ?? undefined,
+		enabled: connectionId > 0,
+		staleTime: 30_000,
+		gcTime: 5 * 60_000,
+		// Mirror the timeline policy: transient errors get one extra
+		// attempt with backoff keyed off `retry_after` where present;
+		// terminal errors (`auth_required`, `not_found`, `unknown`) fall
+		// through to the EmptyContent immediately.
+		retry: ( failureCount, error ) => {
+			if ( error.kind === 'rate_limited' || error.kind === 'upstream_unavailable' ) {
+				return failureCount < 2;
+			}
+			return false;
+		},
+		retryDelay: ( _attempt, error ) => {
+			if ( error.kind === 'rate_limited' && error.retry_after !== undefined ) {
+				return Math.min( error.retry_after * 1000, 30_000 );
+			}
+			return 2_000;
+		},
+	} );
+
+export function useMastodonNotificationsInfiniteQuery( connectionId: number ) {
+	return useInfiniteQuery( mastodonNotificationsInfiniteQuery( connectionId ) );
 }
 
 export const mastodonThreadQueryOptions = ( connectionId: number, statusId: string ) =>


### PR DESCRIPTION
Fixes CM-709

## Proposed Changes

- Add a Notifications tab to the Reader's Mastodon shell, mirroring the ATmosphere Notifications tab (#110635).
- New `fetchMastodonNotifications` fetcher and `MastodonNotification*` types in `@automattic/api-core`.
- New `mastodonNotificationsInfiniteQuery` in `@automattic/api-queries`, matching the timeline query's retry / staleTime policy.
- New `<NotificationsPanel>` in `client/reader/mastodon/`, wired into the account view and navigation.
- Widen the shared `SocialNotificationsList` to accept either `AtmosphereNotification | MastodonNotification`. The renderer's canonical-type switch carries a `_exhaustive: never` arm so future per-protocol union widening surfaces as a type error rather than silently funneling new kinds to the generic phrase.

## Why are these changes being made?

The wpcom backend commits to a byte-compatible notification envelope across protocols. The shared frontend renderer was built for ATmosphere first; this PR proves the cross-protocol contract by reusing the renderer for Mastodon with no per-protocol branching. Completes the notifications slice for the Mastodon milestone of Reader Everywhere.

## Testing Instructions

1. Connect a Mastodon account at `/reader/mastodon/connect`.
2. Visit `/reader/mastodon/:id/notifications`.
3. Confirm the panel renders likes / boosts / follows / mentions / replies / quotes with avatar + actor name + phrase + relative time, and that the unread dot appears on items where `is_read` is false.
4. Confirm the empty state renders when the account has no notifications.
5. Confirm "Load more" pagination concatenates additional pages.
6. Confirm an unknown upstream type (`canonical_type: 'other'`) falls through to the generic "interacted with you" phrase rather than throwing.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?