### PR TITLE
Reader Fediverse: guard data.connections access in the landing view

### DIFF
--- a/client/reader/fediverse/fediverse-landing-view.tsx
+++ b/client/reader/fediverse/fediverse-landing-view.tsx
@@ -24,13 +24,17 @@ export function FediverseLandingView() {
 		if ( isPending || isError || ! data ) {
 			return;
 		}
-		const first = data.connections[ 0 ];
+		// Defensive: the wpcom proxy occasionally hands back a 200 with
+		// `data` defined but `connections` missing (mid-deploy / cold-mint
+		// races on the backend). Optional-chain so the redirect simply
+		// no-ops instead of throwing.
+		const first = data.connections?.[ 0 ];
 		if ( first ) {
 			page.replace( `/reader/fediverse/${ first.id }/${ TIMELINE_TAB }` );
 		}
 	}, [ isPending, data, isError ] );
 
-	const hasConnections = ! isPending && ! isError && ( data?.connections.length ?? 0 ) > 0;
+	const hasConnections = ! isPending && ! isError && ( data?.connections?.length ?? 0 ) > 0;
 
 	return (
 		<ReaderMain className="fediverse-view">


### PR DESCRIPTION
Defensive optional-chain fix for the Fediverse landing view. Spun out of the slice-1 PR #110537 review (the equivalent fix was committed there but didn't make it into the squash-merge to trunk).

## Proposed Changes

* In \`client/reader/fediverse/fediverse-landing-view.tsx\`, optional-chain on \`data.connections\` in both spots that read it:
  * The redirect effect (\`data.connections[ 0 ]\` → \`data.connections?.[ 0 ]\`).
  * The \`hasConnections\` gate (\`data?.connections.length\` → \`data?.connections?.length\` — the previous \`?.\` only short-circuited on \`data\`, not on \`connections\`).

## Why are these changes being made?

\`useFediverseConnectionsQuery\` is typed as returning \`{ connections: FediverseConnection[] }\`, but in practice the wpcom proxy occasionally hands back a 200 with \`data\` defined and \`connections\` missing — typically a mid-deploy / cold-mint race on the CM-684 endpoint. When that happens, the landing view crashes the route with \`TypeError: data.connections is undefined\` instead of falling through to the empty-state.

## Testing Instructions

1. \`yarn test-client client/reader/fediverse\` — green (22 tests).
2. With \`reader/fediverse\` enabled and the connections endpoint returning \`{}\` instead of \`{ connections: [] }\`, hit \`/reader/fediverse\` — the empty-state renders instead of an uncaught exception.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?