### PR TITLE
Reader onboarding rsm - use email verification banner on interests step

### DIFF
--- a/client/me/email-verification-banner/style.scss
+++ b/client/me/email-verification-banner/style.scss
@@ -6,6 +6,10 @@
 
 	.banner__action {
 		display: flex;
+
+		.button {
+			white-space: nowrap;
+		}
 	}
 
 	@media (max-width: $break-xlarge) {

--- a/client/reader/onboarding-rsm/get-reload-step.ts
+++ b/client/reader/onboarding-rsm/get-reload-step.ts
@@ -1,0 +1,25 @@
+type Step = 'welcome' | 'interests' | 'discover';
+
+/** Maps each reload query-param name to the onboarding step it should reopen. */
+const RELOAD_PARAM_TO_STEP: Record< string, Step > = {
+	reloadSubscriptionOnboarding: 'discover',
+	reloadInterestsOnboarding: 'interests',
+};
+
+/**
+ * Inspects a URL search string for a known reload param and returns the step
+ * to open along with the cleaned search string (param removed).
+ * Returns null when no recognised param is present.
+ */
+export function getReloadStep( search: string ): { step: Step; cleanedSearch: string } | null {
+	const urlParams = new URLSearchParams( search );
+
+	for ( const [ param, step ] of Object.entries( RELOAD_PARAM_TO_STEP ) ) {
+		if ( urlParams.has( param ) ) {
+			urlParams.delete( param );
+			return { step, cleanedSearch: urlParams.toString() };
+		}
+	}
+
+	return null;
+}

--- a/client/reader/onboarding-rsm/get-reload-step.ts
+++ b/client/reader/onboarding-rsm/get-reload-step.ts
@@ -1,10 +1,17 @@
 type Step = 'welcome' | 'interests' | 'discover';
 
-/** Maps each reload query-param name to the onboarding step it should reopen. */
-const RELOAD_PARAM_TO_STEP: Record< string, Step > = {
+/**
+ * Maps each reload query-param name to the onboarding step it should reopen.
+ * `as const satisfies` preserves the literal key types so `ReloadParam` below
+ * is a precise union rather than `string`, keeping callers and this map in sync.
+ */
+const RELOAD_PARAM_TO_STEP = {
 	reloadSubscriptionOnboarding: 'discover',
 	reloadInterestsOnboarding: 'interests',
-};
+} as const satisfies Record< string, Step >;
+
+/** Union of the recognised reload query-param names. */
+export type ReloadParam = keyof typeof RELOAD_PARAM_TO_STEP;
 
 /**
  * Inspects a URL search string for a known reload param and returns the step
@@ -14,7 +21,9 @@ const RELOAD_PARAM_TO_STEP: Record< string, Step > = {
 export function getReloadStep( search: string ): { step: Step; cleanedSearch: string } | null {
 	const urlParams = new URLSearchParams( search );
 
-	for ( const [ param, step ] of Object.entries( RELOAD_PARAM_TO_STEP ) ) {
+	for ( const [ param, step ] of Object.entries( RELOAD_PARAM_TO_STEP ) as Array<
+		[ ReloadParam, Step ]
+	> ) {
 		if ( urlParams.has( param ) ) {
 			urlParams.delete( param );
 			return { step, cleanedSearch: urlParams.toString() };

--- a/client/reader/onboarding-rsm/index.tsx
+++ b/client/reader/onboarding-rsm/index.tsx
@@ -180,14 +180,22 @@ const ReaderOnboardingRsm = ( {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ shouldRenderOnboarding, preferencesLoaded, hasSeenOnboarding, dispatch ] );
 
-	// Reopen subscription onboarding page if prompted by query param.
+	// Reopen a specific onboarding step if signalled by a query param after email verification.
+	// Only one reload param will be present at a time.
 	useEffect( () => {
 		const urlParams = new URLSearchParams( window.location.search );
-		const shouldReloadOnboarding = urlParams.has( 'reloadSubscriptionOnboarding' );
 
-		if ( shouldReloadOnboarding ) {
-			openStep( 'discover' );
+		let stepToOpen: Step | null = null;
+		if ( urlParams.has( 'reloadSubscriptionOnboarding' ) ) {
+			stepToOpen = 'discover';
 			urlParams.delete( 'reloadSubscriptionOnboarding' );
+		} else if ( urlParams.has( 'reloadInterestsOnboarding' ) ) {
+			stepToOpen = 'interests';
+			urlParams.delete( 'reloadInterestsOnboarding' );
+		}
+
+		if ( stepToOpen ) {
+			openStep( stepToOpen );
 			page.redirect(
 				`${ window.location.pathname }${ urlParams.toString() ? '?' + urlParams.toString() : '' }`
 			);
@@ -274,14 +282,18 @@ const ReaderOnboardingRsm = ( {
 					onRequestClose={ handleStepClose }
 					size="medium"
 					className={ clsx( 'reader-onboarding-rsm-modal', STEP_FRAME_CLASS[ currentStep ], {
-						'is-disabled': currentStep === 'discover' && promptVerification,
+						'is-disabled':
+							( currentStep === 'discover' || currentStep === 'interests' ) && promptVerification,
 					} ) }
 				>
 					{ currentStep === 'welcome' && (
 						<WelcomeModal onClose={ handleStepClose } onContinue={ handleWelcomeContinue } />
 					) }
 					{ currentStep === 'interests' && (
-						<InterestsModal onContinue={ handleInterestsContinue } />
+						<InterestsModal
+							onContinue={ handleInterestsContinue }
+							promptVerification={ promptVerification }
+						/>
 					) }
 					{ currentStep === 'discover' && (
 						<SubscribeModal onClose={ handleStepClose } promptVerification={ promptVerification } />

--- a/client/reader/onboarding-rsm/index.tsx
+++ b/client/reader/onboarding-rsm/index.tsx
@@ -30,6 +30,7 @@ import { getReaderFollows } from 'calypso/state/reader/follows/selectors';
 import hasCompletedReaderProfile from 'calypso/state/reader/onboarding/selectors/has-completed-reader-profile';
 import { clearStream, requestPage } from 'calypso/state/reader/streams/actions';
 import { useSiteSubscriptions } from '../following/use-site-subscriptions';
+import { getReloadStep } from './get-reload-step';
 import './style.scss';
 
 // All onboarding steps share a single <Modal> frame so transitions between
@@ -181,23 +182,12 @@ const ReaderOnboardingRsm = ( {
 	}, [ shouldRenderOnboarding, preferencesLoaded, hasSeenOnboarding, dispatch ] );
 
 	// Reopen a specific onboarding step if signalled by a query param after email verification.
-	// Only one reload param will be present at a time.
 	useEffect( () => {
-		const urlParams = new URLSearchParams( window.location.search );
-
-		let stepToOpen: Step | null = null;
-		if ( urlParams.has( 'reloadSubscriptionOnboarding' ) ) {
-			stepToOpen = 'discover';
-			urlParams.delete( 'reloadSubscriptionOnboarding' );
-		} else if ( urlParams.has( 'reloadInterestsOnboarding' ) ) {
-			stepToOpen = 'interests';
-			urlParams.delete( 'reloadInterestsOnboarding' );
-		}
-
-		if ( stepToOpen ) {
-			openStep( stepToOpen );
+		const result = getReloadStep( window.location.search );
+		if ( result ) {
+			openStep( result.step );
 			page.redirect(
-				`${ window.location.pathname }${ urlParams.toString() ? '?' + urlParams.toString() : '' }`
+				`${ window.location.pathname }${ result.cleanedSearch ? '?' + result.cleanedSearch : '' }`
 			);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client/reader/onboarding-rsm/interests-modal/index.tsx
+++ b/client/reader/onboarding-rsm/interests-modal/index.tsx
@@ -21,12 +21,14 @@ import { getReaderFollows } from 'calypso/state/reader/follows/selectors';
 import { getPackBlogs } from './get-pack-blogs';
 import TopicGroupCard from './topic-group-card';
 import { getTopicGroups, type TopicGroup } from './topic-groups';
+import InterestsVerificationNudge from './verificationNudge';
 import type { CuratedBlog } from '../curated-blogs';
 
 import './style.scss';
 
 interface InterestsModalProps {
 	onContinue: () => void;
+	promptVerification: boolean;
 }
 
 type ResolvedPack = TopicGroup & { blogs: CuratedBlog[] };
@@ -36,7 +38,7 @@ const MAX_INTEREST_TOPICS = 40;
 // provided by the parent (`ReaderOnboardingRsm`); this component is only
 // mounted while the step is active. X-out / escape are handled by the
 // wrapper's `onRequestClose`.
-const InterestsModal: React.FC< InterestsModalProps > = ( { onContinue } ) => {
+const InterestsModal: React.FC< InterestsModalProps > = ( { onContinue, promptVerification } ) => {
 	const [ followedTags, setFollowedTags ] = useState< string[] >( [] );
 	const [ showAllTopics, setShowAllTopics ] = useState( false );
 	const hasSyncedFromServerRef = useRef( false );
@@ -265,6 +267,7 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { onContinue } ) => {
 
 	return (
 		<>
+			{ promptVerification && <InterestsVerificationNudge /> }
 			<VStack spacing={ 5 } className="interests-modal__content">
 				<VStack spacing={ 0 }>
 					<h2 className="interests-modal__title">{ __( 'What topics interest you?' ) }</h2>
@@ -347,7 +350,7 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { onContinue } ) => {
 							__next40pxDefaultSize
 							onClick={ handleContinue }
 							variant="secondary"
-							disabled={ isContinueDisabled }
+							disabled={ isContinueDisabled || promptVerification }
 							accessibleWhenDisabled
 						>
 							{ __( 'Continue' ) }

--- a/client/reader/onboarding-rsm/interests-modal/style.scss
+++ b/client/reader/onboarding-rsm/interests-modal/style.scss
@@ -6,6 +6,17 @@
 	// the footer are shared with the other onboarding-rsm modals; see
 	// `client/reader/onboarding-rsm/style.scss`.
 
+	.email-verification-banner {
+		margin: 12px 16px 0;
+	}
+
+	&.is-disabled {
+		.interests-modal__content {
+			opacity: 0.5;
+			pointer-events: none;
+		}
+	}
+
 	&__content {
 		padding: 4px 32px 12px;
 	}

--- a/client/reader/onboarding-rsm/interests-modal/test/index.test.tsx
+++ b/client/reader/onboarding-rsm/interests-modal/test/index.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import InterestsModal from '../index';
+
+// ── External data hooks ──────────────────────────────────────────────────────
+
+jest.mock( 'calypso/data/reader/use-reader-interest-tags', () => ( {
+	useReaderInterestTags: () => [],
+} ) );
+
+jest.mock( 'calypso/data/reader/use-reader-tags', () => ( {
+	useFollowedReaderTags: () => ( { data: [] } ),
+} ) );
+
+// ── Internal helpers / child components ─────────────────────────────────────
+
+jest.mock( '../get-pack-blogs', () => ( {
+	getPackBlogs: () => [],
+} ) );
+
+jest.mock( '../topic-groups', () => ( {
+	getTopicGroups: () => [],
+} ) );
+
+jest.mock( '../topic-group-card', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+
+// Give the nudge a stable test-id so tests can assert on its presence.
+jest.mock( '../verificationNudge', () => ( {
+	__esModule: true,
+	default: () => <div data-testid="interests-verification-nudge" />,
+} ) );
+
+// ── Redux / state ────────────────────────────────────────────────────────────
+
+jest.mock( 'calypso/state/reader/follows/selectors', () => ( {
+	getReaderFollows: jest.fn().mockReturnValue( [] ),
+} ) );
+
+jest.mock( 'calypso/state/reader/follows/actions', () => ( {
+	follow: jest.fn( () => ( { type: 'READER_FOLLOW' } ) ),
+} ) );
+
+jest.mock( 'calypso/state/notices/actions', () => ( {
+	errorNotice: jest.fn( () => ( { type: 'NOTICES_ERROR' } ) ),
+} ) );
+
+// ── Analytics / i18n ────────────────────────────────────────────────────────
+
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	recordTracksEvent: jest.fn(),
+} ) );
+
+jest.mock( 'i18n-calypso', () => ( {
+	...jest.requireActual( 'i18n-calypso' ),
+	fixMe: ( { newCopy }: { newCopy: string } ) => newCopy,
+} ) );
+
+// ── TanStack / mutations ─────────────────────────────────────────────────────
+
+jest.mock( '@tanstack/react-query', () => ( {
+	...jest.requireActual( '@tanstack/react-query' ),
+	useMutation: () => ( { mutateAsync: jest.fn() } ),
+} ) );
+
+jest.mock( '@automattic/api-queries', () => ( {
+	followReadTagMutation: jest.fn(),
+	unfollowReadTagMutation: jest.fn(),
+} ) );
+
+// ── Shared step indicator (not under test here) ──────────────────────────────
+
+jest.mock( 'calypso/reader/onboarding-rsm/step-indicator', () => ( {
+	StepIndicator: () => null,
+} ) );
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe( 'InterestsModal – verification nudge', () => {
+	it( 'does not render the verification nudge when promptVerification is false', () => {
+		renderWithProvider( <InterestsModal onContinue={ jest.fn() } promptVerification={ false } /> );
+
+		expect( screen.queryByTestId( 'interests-verification-nudge' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the verification nudge when promptVerification is true', () => {
+		renderWithProvider( <InterestsModal onContinue={ jest.fn() } promptVerification /> );
+
+		expect( screen.getByTestId( 'interests-verification-nudge' ) ).toBeVisible();
+	} );
+
+	it( 'disables the Continue button when promptVerification is true', () => {
+		renderWithProvider( <InterestsModal onContinue={ jest.fn() } promptVerification /> );
+
+		// accessibleWhenDisabled renders aria-disabled instead of the native disabled attribute.
+		expect( screen.getByRole( 'button', { name: 'Continue' } ) ).toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
+	} );
+
+	it( 'does not invoke onContinue when Continue is clicked while verification is required', async () => {
+		const user = userEvent.setup();
+		const onContinue = jest.fn();
+
+		renderWithProvider( <InterestsModal onContinue={ onContinue } promptVerification /> );
+
+		// The button is aria-disabled; userEvent still fires a click event but the
+		// component's onClick guard should prevent calling onContinue.
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
+
+		expect( onContinue ).not.toHaveBeenCalled();
+	} );
+
+	it( 'disables the Continue button from tag count when promptVerification is false and no tags are followed', () => {
+		renderWithProvider( <InterestsModal onContinue={ jest.fn() } promptVerification={ false } /> );
+
+		// Still disabled (< 3 tags), but the nudge is absent.
+		expect( screen.getByRole( 'button', { name: 'Continue' } ) ).toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
+		expect( screen.queryByTestId( 'interests-verification-nudge' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/reader/onboarding-rsm/interests-modal/verificationNudge.tsx
+++ b/client/reader/onboarding-rsm/interests-modal/verificationNudge.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import VerificationNudge from 'calypso/reader/onboarding-rsm/verificationNudge';
+
+const InterestsVerificationNudge: React.FC = () => (
+	<VerificationNudge reloadParam="reloadInterestsOnboarding" />
+);
+
+export default InterestsVerificationNudge;

--- a/client/reader/onboarding-rsm/subscribe-modal/style.scss
+++ b/client/reader/onboarding-rsm/subscribe-modal/style.scss
@@ -19,6 +19,10 @@ body.is-reader-page .subscribe-modal__preview-column .reader__card.card.is-place
 	// the footer are shared with the other onboarding-rsm modals; see
 	// `client/reader/onboarding-rsm/style.scss`.
 
+	.email-verification-banner {
+		margin: 12px 16px 0;
+	}
+
 	&__container {
 		display: flex;
 		flex-direction: column;

--- a/client/reader/onboarding-rsm/subscribe-modal/test/index.test.tsx
+++ b/client/reader/onboarding-rsm/subscribe-modal/test/index.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import SubscribeModal from '../index';
+
+// ── Recommendations hook ─────────────────────────────────────────────────────
+
+jest.mock( '../use-subscribe-recommendations', () => ( {
+	useSubscribeRecommendations: () => ( {
+		combinedRecommendations: [],
+		recommendations: [],
+		isLoading: false,
+		isValidating: false,
+		hasNoRecommendations: false,
+		followedTagSlugs: [],
+		markSessionFollow: jest.fn(),
+	} ),
+} ) );
+
+// ── Heavy UI dependencies ────────────────────────────────────────────────────
+
+jest.mock( 'calypso/reader/stream', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+
+jest.mock( 'calypso/blocks/reader-subscription-list-item/connected', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+
+jest.mock( 'calypso/blocks/site-icon', () => ( {
+	SiteIcon: () => null,
+} ) );
+
+jest.mock( 'calypso/components/data/query-reader-site', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+
+jest.mock( 'calypso/reader/follow-button', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+
+jest.mock( 'calypso/reader/controller-helper', () => ( {
+	trackScrollPage: jest.fn(),
+} ) );
+
+jest.mock( '@automattic/components', () => ( {
+	LoadingPlaceholder: () => null,
+} ) );
+
+// ── Give the nudge a stable test-id so tests can assert on its presence ──────
+
+jest.mock( '../verificationNudge', () => ( {
+	__esModule: true,
+	default: () => <div data-testid="subscribe-verification-nudge" />,
+} ) );
+
+// ── Redux / state ────────────────────────────────────────────────────────────
+
+jest.mock( 'calypso/state/reader/feeds/selectors', () => ( {
+	getFeed: jest.fn().mockReturnValue( null ),
+} ) );
+
+jest.mock( 'calypso/state/reader/streams/actions', () => ( {
+	requestPage: jest.fn( () => ( { type: 'READER_REQUEST_PAGE' } ) ),
+	requestPaginatedStream: jest.fn( () => ( { type: 'READER_REQUEST_PAGINATED_STREAM' } ) ),
+} ) );
+
+// ── Analytics ────────────────────────────────────────────────────────────────
+
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	recordTracksEvent: jest.fn(),
+} ) );
+
+// ── Shared step indicator (not under test here) ──────────────────────────────
+
+jest.mock( 'calypso/reader/onboarding-rsm/step-indicator', () => ( {
+	StepIndicator: () => null,
+} ) );
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe( 'SubscribeModal – verification nudge', () => {
+	it( 'does not render the verification nudge when promptVerification is false', () => {
+		renderWithProvider( <SubscribeModal onClose={ jest.fn() } promptVerification={ false } /> );
+
+		expect( screen.queryByTestId( 'subscribe-verification-nudge' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the verification nudge when promptVerification is true', () => {
+		renderWithProvider( <SubscribeModal onClose={ jest.fn() } promptVerification /> );
+
+		expect( screen.getByTestId( 'subscribe-verification-nudge' ) ).toBeVisible();
+	} );
+
+	it( 'disables the Finish button when promptVerification is true', () => {
+		renderWithProvider( <SubscribeModal onClose={ jest.fn() } promptVerification /> );
+
+		// accessibleWhenDisabled renders aria-disabled instead of the native disabled attribute.
+		expect( screen.getByRole( 'button', { name: 'Finish' } ) ).toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
+	} );
+
+	it( 'does not invoke onClose when Finish is clicked while verification is required', async () => {
+		const user = userEvent.setup();
+		const onClose = jest.fn();
+
+		renderWithProvider( <SubscribeModal onClose={ onClose } promptVerification /> );
+
+		await user.click( screen.getByRole( 'button', { name: 'Finish' } ) );
+
+		expect( onClose ).not.toHaveBeenCalled();
+	} );
+
+	it( 'enables the Finish button when promptVerification is false', () => {
+		renderWithProvider( <SubscribeModal onClose={ jest.fn() } promptVerification={ false } /> );
+
+		const button = screen.getByRole( 'button', { name: 'Finish' } );
+		expect( button ).not.toHaveAttribute( 'aria-disabled', 'true' );
+		expect( button ).not.toBeDisabled();
+	} );
+} );

--- a/client/reader/onboarding-rsm/subscribe-modal/verificationNudge.tsx
+++ b/client/reader/onboarding-rsm/subscribe-modal/verificationNudge.tsx
@@ -1,34 +1,8 @@
-import { addQueryArgs } from '@wordpress/url';
-import { useTranslate } from 'i18n-calypso';
-import EmailVerificationBanner from 'calypso/me/email-verification-banner';
+import React from 'react';
+import VerificationNudge from 'calypso/reader/onboarding-rsm/verificationNudge';
 
-const SubscribeVerificationNudge: React.FC = () => {
-	const translate = useTranslate();
-
-	const reloadLink = addQueryArgs( '/reader', { reloadSubscriptionOnboarding: 'true' } );
-
-	return (
-		<EmailVerificationBanner
-			dialogCloseLabel={ translate( 'I just verified my email' ) }
-			dialogCloseAction={ () => window.location.replace( reloadLink ) }
-			customDescription={ translate(
-				'Verifying your email helps you secure your WordPress.com account and enables key features such as subscribing to sites. If necessary, please {{link}}click here{{/link}} to reload when complete.',
-				{
-					components: {
-						link: (
-							<a
-								href={ reloadLink }
-								onClick={ ( e ) => {
-									e.preventDefault();
-									window.location.replace( reloadLink );
-								} }
-							/>
-						),
-					},
-				}
-			) }
-		/>
-	);
-};
+const SubscribeVerificationNudge: React.FC = () => (
+	<VerificationNudge reloadParam="reloadSubscriptionOnboarding" />
+);
 
 export default SubscribeVerificationNudge;

--- a/client/reader/onboarding-rsm/test/get-reload-step.test.ts
+++ b/client/reader/onboarding-rsm/test/get-reload-step.test.ts
@@ -1,0 +1,47 @@
+import { getReloadStep } from '../get-reload-step';
+
+describe( 'getReloadStep', () => {
+	it( 'returns null when the search string is empty', () => {
+		expect( getReloadStep( '' ) ).toBeNull();
+	} );
+
+	it( 'returns null when no recognised reload param is present', () => {
+		expect( getReloadStep( '?flags=reader%2Fonboarding-rsm' ) ).toBeNull();
+	} );
+
+	it( 'maps reloadSubscriptionOnboarding to the "discover" step', () => {
+		const result = getReloadStep( '?reloadSubscriptionOnboarding=true' );
+		expect( result?.step ).toBe( 'discover' );
+	} );
+
+	it( 'maps reloadInterestsOnboarding to the "interests" step', () => {
+		const result = getReloadStep( '?reloadInterestsOnboarding=true' );
+		expect( result?.step ).toBe( 'interests' );
+	} );
+
+	it( 'removes the reload param from the cleaned search string', () => {
+		const result = getReloadStep( '?reloadSubscriptionOnboarding=true' );
+		expect( result?.cleanedSearch ).toBe( '' );
+	} );
+
+	it( 'preserves other query params in the cleaned search string', () => {
+		const result = getReloadStep(
+			'?flags=reader%2Fonboarding-rsm&reloadSubscriptionOnboarding=true'
+		);
+		expect( result?.cleanedSearch ).toContain( 'flags=' );
+		expect( result?.cleanedSearch ).not.toContain( 'reloadSubscriptionOnboarding' );
+	} );
+
+	it( 'preserves other query params when removing the interests reload param', () => {
+		const result = getReloadStep(
+			'?flags=reader%2Fforce-onboarding&reloadInterestsOnboarding=true'
+		);
+		expect( result?.step ).toBe( 'interests' );
+		expect( result?.cleanedSearch ).toContain( 'flags=' );
+		expect( result?.cleanedSearch ).not.toContain( 'reloadInterestsOnboarding' );
+	} );
+
+	it( 'returns null for an unrelated param that happens to have "reload" in its name', () => {
+		expect( getReloadStep( '?reloadSomethingElse=true' ) ).toBeNull();
+	} );
+} );

--- a/client/reader/onboarding-rsm/test/verificationNudge.test.tsx
+++ b/client/reader/onboarding-rsm/test/verificationNudge.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import VerificationNudge from '../verificationNudge';
+
+// Expose the props in a way that lets us inspect and interact with them.
+jest.mock( 'calypso/me/email-verification-banner', () => ( {
+	__esModule: true,
+	default: ( {
+		customDescription,
+		dialogCloseLabel,
+		dialogCloseAction,
+	}: {
+		customDescription?: React.ReactNode;
+		dialogCloseLabel?: React.ReactNode;
+		dialogCloseAction?: () => void;
+	} ) => (
+		<div>
+			<div data-testid="banner-description">{ customDescription }</div>
+			<button data-testid="banner-close" onClick={ dialogCloseAction }>
+				{ dialogCloseLabel }
+			</button>
+		</div>
+	),
+} ) );
+
+// i18n-calypso's useTranslate is called inside VerificationNudge.
+jest.mock( 'i18n-calypso', () => ( {
+	...jest.requireActual( 'i18n-calypso' ),
+	useTranslate:
+		() => ( text: string, opts?: { components?: Record< string, React.ReactNode > } ) => {
+			if ( ! opts?.components ) {
+				return text;
+			}
+			// Return the link component so it ends up in the DOM.
+			return opts.components.link;
+		},
+} ) );
+
+describe( 'VerificationNudge', () => {
+	const replaceMock = jest.fn();
+
+	beforeEach( () => {
+		replaceMock.mockClear();
+		Object.defineProperty( window, 'location', {
+			configurable: true,
+			value: {
+				pathname: '/reader',
+				search: '',
+				replace: replaceMock,
+			},
+		} );
+	} );
+
+	it( 'includes reloadSubscriptionOnboarding in the "click here" link href', () => {
+		render( <VerificationNudge reloadParam="reloadSubscriptionOnboarding" /> );
+
+		const link = screen.getByRole( 'link' );
+		expect( link ).toHaveAttribute(
+			'href',
+			expect.stringContaining( 'reloadSubscriptionOnboarding=true' )
+		);
+	} );
+
+	it( 'includes reloadInterestsOnboarding in the "click here" link href', () => {
+		render( <VerificationNudge reloadParam="reloadInterestsOnboarding" /> );
+
+		const link = screen.getByRole( 'link' );
+		expect( link ).toHaveAttribute(
+			'href',
+			expect.stringContaining( 'reloadInterestsOnboarding=true' )
+		);
+	} );
+
+	it( 'preserves existing query params in the reload link', () => {
+		Object.defineProperty( window, 'location', {
+			configurable: true,
+			value: {
+				pathname: '/reader',
+				search: '?flags=reader%2Fonboarding-rsm%2Creader%2Fforce-onboarding',
+				replace: replaceMock,
+			},
+		} );
+
+		render( <VerificationNudge reloadParam="reloadSubscriptionOnboarding" /> );
+
+		const href = screen.getByRole( 'link' ).getAttribute( 'href' ) ?? '';
+		expect( href ).toContain( 'reloadSubscriptionOnboarding=true' );
+		expect( href ).toContain( 'flags=' );
+	} );
+
+	it( 'calls window.location.replace with the reload URL when the "click here" link is clicked', async () => {
+		const user = userEvent.setup();
+		render( <VerificationNudge reloadParam="reloadSubscriptionOnboarding" /> );
+
+		await user.click( screen.getByRole( 'link' ) );
+
+		expect( replaceMock ).toHaveBeenCalledTimes( 1 );
+		expect( replaceMock ).toHaveBeenCalledWith(
+			expect.stringContaining( 'reloadSubscriptionOnboarding=true' )
+		);
+	} );
+
+	it( 'calls window.location.replace with the reload URL when the dialog close action fires', async () => {
+		const user = userEvent.setup();
+		render( <VerificationNudge reloadParam="reloadInterestsOnboarding" /> );
+
+		await user.click( screen.getByTestId( 'banner-close' ) );
+
+		expect( replaceMock ).toHaveBeenCalledTimes( 1 );
+		expect( replaceMock ).toHaveBeenCalledWith(
+			expect.stringContaining( 'reloadInterestsOnboarding=true' )
+		);
+	} );
+} );

--- a/client/reader/onboarding-rsm/verificationNudge.tsx
+++ b/client/reader/onboarding-rsm/verificationNudge.tsx
@@ -1,0 +1,41 @@
+import { addQueryArgs } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+import EmailVerificationBanner from 'calypso/me/email-verification-banner';
+
+interface VerificationNudgeProps {
+	reloadParam: string;
+}
+
+const VerificationNudge: React.FC< VerificationNudgeProps > = ( { reloadParam } ) => {
+	const translate = useTranslate();
+
+	const reloadLink = addQueryArgs( window.location.pathname + window.location.search, {
+		[ reloadParam ]: 'true',
+	} );
+
+	return (
+		<EmailVerificationBanner
+			dialogCloseLabel={ translate( 'I just verified my email' ) }
+			dialogCloseAction={ () => window.location.replace( reloadLink ) }
+			customDescription={ translate(
+				'Verifying your email helps you secure your WordPress.com account and enables key features such as subscribing to sites. If necessary, please {{link}}click here{{/link}} to reload when complete.',
+				{
+					components: {
+						link: (
+							<a
+								href={ reloadLink }
+								onClick={ ( e ) => {
+									e.preventDefault();
+									window.location.replace( reloadLink );
+								} }
+							/>
+						),
+					},
+				}
+			) }
+		/>
+	);
+};
+
+export default VerificationNudge;

--- a/client/reader/onboarding-rsm/verificationNudge.tsx
+++ b/client/reader/onboarding-rsm/verificationNudge.tsx
@@ -2,9 +2,10 @@ import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import EmailVerificationBanner from 'calypso/me/email-verification-banner';
+import { type ReloadParam } from './get-reload-step';
 
 interface VerificationNudgeProps {
-	reloadParam: string;
+	reloadParam: ReloadParam;
 }
 
 const VerificationNudge: React.FC< VerificationNudgeProps > = ( { reloadParam } ) => {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # https://linear.app/a8c/issue/RSM-2791/test-email-verification-gate-for-interests-and-subscribe-steps

## Proposed Changes

Uses the email verification banner on the interests step.
* Refactors to share between subscribe and interest step.
* Adds similar reloading and opening modal behavior for interests step.
* Preserves other url params (such as our testing flags) when reloading.
* Updates styles slightly to apply margin to the banner and no line wrapping of the cta button.
* Adds unit tests to verify the functionality.

AFTER
<img width="1024" height="772" alt="Screenshot 2026-05-11 at 2 17 32 PM" src="https://github.com/user-attachments/assets/15204d5d-3862-44b7-9e2c-4ca841cbd6f1" />
<img width="1033" height="784" alt="Screenshot 2026-05-11 at 2 17 37 PM" src="https://github.com/user-attachments/assets/10892261-7421-4e4d-9643-f0f03e3ce224" />

BEFORE
<img width="1006" height="767" alt="Screenshot 2026-05-11 at 2 27 40 PM" src="https://github.com/user-attachments/assets/d25c45f9-1128-4b7b-b2c5-0b9dd3368356" />
(and not implemented on interest modal before)


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Subscribing to a blog requires verified email. Since we have blog subscriptions in the interest packs, we need to require and surface the email verification nudge flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this calypso build
* go to the reader with query params for onboarding-rsm `*/reader?flags=reader/onboarding-rsm,reader/force-onboarding`
* Either be on an account with unverified email, or update the redux selector to `() => false;` [here](https://github.com/Automattic/wp-calypso/blob/c971e2c4d295febbad7faba402344b8abba24329/client/state/current-user/selectors.js#L141).
* Click "welcome to reader" and go next into the interests modal. It should be disabled with the banner. Clicking "click here" in the banner or "I just verified my email" in the modal its cta opens should reload the page and reopen the interests modal.
* Close the interests modal, click the launchpad task for "Discover and subscribe to sites you'll love". Verify this verification banner is also here, disabling the modal, and noted links to reload reopens this modal.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
