### PR TITLE
Help Center: open inline chat images in a new tab

### DIFF
--- a/packages/odie-client/src/components/message/custom-a-link.tsx
+++ b/packages/odie-client/src/components/message/custom-a-link.tsx
@@ -1,6 +1,6 @@
 import { isThisASupportArticleLink } from '@automattic/urls';
 import clsx from 'clsx';
-import { useMemo } from 'react';
+import { Children, isValidElement, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useOdieAssistantContext } from '../../context';
 import { uriTransformer } from './uri-transformer';
@@ -27,6 +27,11 @@ const CustomALink = ( {
 
 	const transformedHref = useMemo( () => uriTransformer( href ?? '' ), [ href ] );
 
+	const wrapsImage = Children.toArray( children ).some(
+		( child ) => isValidElement( child ) && child.type === 'img'
+	);
+	const effectiveTarget = wrapsImage ? '_blank' : target;
+
 	const classNames = clsx( 'odie-sources', {
 		'odie-sources-inline': inline,
 	} );
@@ -36,7 +41,7 @@ const CustomALink = ( {
 			<a
 				className="odie-sources-link"
 				href={ transformedHref }
-				target={ target }
+				target={ effectiveTarget }
 				rel="noopener noreferrer"
 				onClick={ ( e ) => {
 					// Open support article links in the Help Center.


### PR DESCRIPTION
Fixes [DOTSUP-457](https://linear.app/a8c/issue/DOTSUP-457/help-center-chat-clicking-inline-images-opens-in-same-tab-losing-chat)

## Proposed Changes

* In `CustomALink`, detect when the rendered `<a>` wraps an `<img>` child (the markdown idiom `[![Image](url)](url)` used by `zendesk-message-converter` for inline image attachments) and force `target="_blank"` on the anchor.

## Why are these changes being made?

When a Happiness Engineer sends a screenshot in a Help Center live chat, the image is rendered inline as a markdown link wrapping an image. Clicking the image previously navigated the customer away from the chat in the same tab — losing the active chat session and their site context. DOTSUP-289 already applied `target="_blank"` to plain text links in chat, but the image-wrapping anchor was not covered; this PR extends the same behavior to inline images.

## Testing Instructions

1. Open a Help Center live chat with a Happiness Engineer (or simulate by triggering an inline image message from Zendesk).
2. Verify a screenshot appears inline in the chat.
3. Click the screenshot.
4. Expect: the image opens in a new browser tab; the chat session in the current tab remains intact.
5. Click a plain text link in the same chat and confirm it still opens in a new tab (no regression of DOTSUP-289).
