### PR TITLE
Reader user-profile: widen Achievements view with a responsive grid

### DIFF
--- a/client/reader/user-profile/index.tsx
+++ b/client/reader/user-profile/index.tsx
@@ -71,11 +71,15 @@ export function UserProfile( props: UserProfileProps ): JSX.Element | null {
 		}
 	};
 
+	const isWideView = view === 'achievements';
+
 	return (
 		<div className="user-profile">
-			<ReaderMain>
-				<ReaderBackButton />
-				<UserProfileHeader user={ user } view={ view } />
+			<ReaderMain wideLayout={ isWideView }>
+				<div className={ isWideView ? 'user-profile__narrow' : undefined }>
+					<ReaderBackButton />
+					<UserProfileHeader user={ user } view={ view } />
+				</div>
 				{ renderSelectedTabContent() }
 			</ReaderMain>
 		</div>

--- a/client/reader/user-profile/index.tsx
+++ b/client/reader/user-profile/index.tsx
@@ -71,12 +71,14 @@ export function UserProfile( props: UserProfileProps ): JSX.Element | null {
 		}
 	};
 
-	const isWideView = view === 'achievements';
+	const isAchievementWideView = view === 'achievements';
 
 	return (
 		<div className="user-profile">
-			<ReaderMain wideLayout={ isWideView }>
-				<div className={ isWideView ? 'user-profile__narrow' : undefined }>
+			<ReaderMain
+				className={ isAchievementWideView ? 'user-profile__achievements-view' : undefined }
+			>
+				<div className={ isAchievementWideView ? 'user-profile__narrow' : undefined }>
 					<ReaderBackButton />
 					<UserProfileHeader user={ user } view={ view } />
 				</div>

--- a/client/reader/user-profile/style.scss
+++ b/client/reader/user-profile/style.scss
@@ -18,6 +18,10 @@
 		margin-top: 50px;
 	}
 
+	.main:not(.is-wide-layout).user-profile__achievements-view {
+		max-width: 1280px;
+	}
+
 	.user-profile__narrow {
 		max-width: 720px;
 		margin-inline: auto;

--- a/client/reader/user-profile/style.scss
+++ b/client/reader/user-profile/style.scss
@@ -17,4 +17,9 @@
 		justify-content: center;
 		margin-top: 50px;
 	}
+
+	.user-profile__narrow {
+		max-width: 720px;
+		margin-inline: auto;
+	}
 }

--- a/client/reader/user-profile/views/achievements/achievements-grid/style.scss
+++ b/client/reader/user-profile/views/achievements/achievements-grid/style.scss
@@ -8,8 +8,8 @@
 		grid-template-columns: 1fr;
 		gap: 16px;
 
-		@media (min-width: 440px) {
-			grid-template-columns: repeat(auto-fit, minmax(440px, 1fr));
+		@include break-small() {
+			grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
 		}
 	}
 
@@ -109,8 +109,9 @@
 	.achievements__locked-heading {
 		font-size: 1.25rem;
 		font-weight: 500;
-		margin: 32px auto 16px;
+		margin: 48px auto 16px;
 		max-width: 720px;
+		text-align: center;
 	}
 
 	.achievements-grid--locked {

--- a/client/reader/user-profile/views/achievements/achievements-grid/style.scss
+++ b/client/reader/user-profile/views/achievements/achievements-grid/style.scss
@@ -8,8 +8,8 @@
 		grid-template-columns: 1fr;
 		gap: 16px;
 
-		@include break-small() {
-			grid-template-columns: 1fr 1fr;
+		@media (min-width: 440px) {
+			grid-template-columns: repeat(auto-fit, minmax(440px, 1fr));
 		}
 	}
 
@@ -36,6 +36,7 @@
 		color: var( --studio-gray-40 );
 		display: flex;
 		flex-direction: column;
+		flex-grow: 1;
 		line-height: 20px;
 		min-width: 0;
 	}
@@ -108,7 +109,8 @@
 	.achievements__locked-heading {
 		font-size: 1.25rem;
 		font-weight: 500;
-		margin: 32px 0 16px;
+		margin: 32px auto 16px;
+		max-width: 720px;
 	}
 
 	.achievements-grid--locked {
@@ -117,7 +119,8 @@
 
 	.achievements-grid__celebratory {
 		color: var( --studio-gray-60 );
-		margin: 24px 0 0;
+		margin: 24px auto 0;
+		max-width: 720px;
 		text-align: center;
 	}
 }

--- a/client/reader/user-profile/views/achievements/achievements-grid/style.scss
+++ b/client/reader/user-profile/views/achievements/achievements-grid/style.scss
@@ -9,7 +9,7 @@
 		gap: 16px;
 
 		@include break-small() {
-			grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+			grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
 		}
 	}
 

--- a/client/reader/user-profile/views/achievements/style.scss
+++ b/client/reader/user-profile/views/achievements/style.scss
@@ -4,7 +4,8 @@
 		flex-wrap: wrap;
 		align-items: flex-start;
 		gap: 24px;
-		margin: 16px 0;
+		margin: 16px auto 48px;
+		max-width: 720px;
 	}
 
 	.achievements__header .activity-streak-pill {


### PR DESCRIPTION
Part of RSM-413

## Proposed Changes

* Switch `<ReaderMain>` to `wideLayout` only when the Achievements tab is active, so the grid is no longer capped at the standard 768px Reader content width.
* Wrap the back button and `<UserProfileHeader>` in a new `.user-profile__narrow` container (max-width 720px, centered) so the page chrome keeps its current width.
* Cap the achievements header, locked-section heading, and celebratory paragraph at 720px (centered) so narrow copy stays centered while the two `.achievements-grid` blocks expand into the wider layout.
* Make the grid responsive: single column below 440px, `repeat(auto-fit, minmax(440px, 1fr))` at ≥ 440px viewports.
* Add `flex-grow: 1` to `.achievement-card__details` so the text column fills the rest of the card row.

## Why are these changes being made?

The Achievements tab was constrained to a 768px column, which left a lot of unused horizontal room on wider viewports and forced the cards into a 2-column-max layout. Widening this single view (without changing the rest of user-profile or the global Reader convention) lets the grid scale naturally with the available space while keeping the back button, heading, and other narrow copy visually identical to before.

## Testing Instructions

* Visit a user profile in the Reader and open the **Achievements** tab.
* Verify the achievement cards now expand past the previous 768px ceiling and reflow as the viewport changes width.
* Verify the back button, profile header, locked-section heading, and "You've unlocked them all" paragraph are still centered at the original ~720px width.
* Verify all other user-profile tabs (**Posts**, **Sites**, **Lists**, **Recommended blogs**) are unchanged.
* Resize the window across 400 / 440 / 768 / 1024 / 1440 px viewports to verify the responsive grid breakpoints look right.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?