### PR TITLE
E2E: harden checkout card payment readiness

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
@@ -1,7 +1,8 @@
-import { Frame, Page } from 'playwright';
+import { expect } from 'playwright/test';
 import { getCalypsoURL } from '../../data-helper';
 import envVariables from '../../env-variables';
 import type { PaymentDetails, RegistrarDetails } from '../../types/data-helper.types';
+import type { Frame, Page } from 'playwright';
 
 const selectors = {
 	// Modal
@@ -49,6 +50,7 @@ const selectors = {
 
 	// Payment field
 	cardholderName: 'input[id="cardholder-name"]',
+	cardPaymentRadio: 'input#card[type="radio"]',
 	cardNumberFrame: 'iframe[title="Secure card number input frame"]',
 	cardNumberInput: 'input[data-elements-stable-field-name="cardNumber"]',
 	cardExpiryFrame: 'iframe[title="Secure expiration date input frame"]',
@@ -313,13 +315,14 @@ export class CartCheckoutPage {
 	async enterPaymentDetails( paymentDetails: PaymentDetails ): Promise< void > {
 		// Select the Credit or debit card payment method to expand the fields.
 		// On mobile the sticky Pay CTA and the auto-selected Google Pay tile sit
-		// over the card label, so a real click can't reach it. Wait for the
-		// labelled, enabled card option to appear, then dispatch the click on
-		// its underlying radio input.
-		await this.page
-			.locator( 'label[for="card"]:has-text("credit or debit card"):not([disabled])' )
-			.waitFor( { state: 'attached', timeout: 10 * 1000 } );
-		await this.page.locator( 'input#card[type="radio"]' ).dispatchEvent( 'click' );
+		// over the card label, so a real click can't reach it. Dispatch the
+		// click on the underlying radio input, then wait for the form fields
+		// that prove the payment method is ready.
+		const cardPaymentRadio = this.page.locator( selectors.cardPaymentRadio );
+		await cardPaymentRadio.waitFor( { state: 'attached', timeout: 15 * 1000 } );
+		await cardPaymentRadio.dispatchEvent( 'click' );
+		await expect( cardPaymentRadio ).toHaveJSProperty( 'checked', true );
+		await this.validatePaymentForm();
 
 		// Begin filling in the card details from
 		// top to bottom.


### PR DESCRIPTION
Part of TESTOPS-99

## Proposed Changes

* Wait for the checkout card radio input and visible cardholder field before filling payment details.
* Remove the brittle card-label text wait that can miss already-rendered checkout state.

## Why are these changes being made?

* Pre-release failures showed checkout card fields rendered while the helper timed out waiting for the old label selector.

## Testing Instructions

* `yarn workspace @automattic/calypso-e2e build`
* Let PR E2E cover the affected checkout flows.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the \"[Status] String Freeze\" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the \"[Status] Needs Privacy Updates\" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?