### PR TITLE
E2E: harden launch-site domain escape hatch

### DIFF
--- a/packages/calypso-e2e/src/lib/components/domain-search-component.ts
+++ b/packages/calypso-e2e/src/lib/components/domain-search-component.ts
@@ -140,7 +140,12 @@ export class DomainSearchComponent {
 	 * @returns {string} Domain that was selected.
 	 */
 	async selectFirstSuggestion( waitForContinueButton: boolean = true ): Promise< string > {
-		const targetRow = this.getContainer().getByRole( 'listitem' ).first();
+		const targetRow = this.getContainer()
+			.getByRole( 'listitem' )
+			.filter( {
+				has: this.page.getByRole( 'button', { name: 'Add to cart' } ),
+			} )
+			.first();
 		const suggestion = await this.selectSuggestion( targetRow, waitForContinueButton );
 
 		if ( ! suggestion ) {

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -1,7 +1,8 @@
-import { Page } from 'playwright';
+import { expect } from 'playwright/test';
 import { getCalypsoURL } from '../../data-helper';
 import { clickNavTab } from '../../element-helper';
 import envVariables from '../../env-variables';
+import type { Page } from 'playwright';
 
 // Types to restrict the string arguments passed in. These are fixed sets of strings, so we can be more restrictive.
 export type Plans =
@@ -128,8 +129,24 @@ export class PlansPage {
 	 * Opens the escape hatch modal by clicking the "start with a free plan" trigger link.
 	 */
 	async openEscapeHatch(): Promise< void > {
-		const locator = this.page.getByText( 'start with a free plan' );
-		await locator.first().click();
+		const trigger = this.page
+			.getByRole( 'button', {
+				name: 'start with a free plan',
+				exact: true,
+			} )
+			.first();
+		await expect( trigger ).toBeVisible( { timeout: 30_000 } );
+		await trigger.click();
+
+		const escapeHatchDialog = this.page
+			.getByRole( 'dialog' )
+			.filter( {
+				has: this.page.getByRole( 'button', {
+					name: /Continue with Free|Get Personal|Get Premium/,
+				} ),
+			} )
+			.first();
+		await expect( escapeHatchDialog ).toBeVisible();
 	}
 
 	/**


### PR DESCRIPTION
Part of TESTOPS-99

## Proposed Changes

* Select the first domain suggestion from rows that actually contain an `Add to cart` button.
* Wait for the escape-hatch trigger to be visible, click it with an explicit action timeout, and verify the modal is visible before continuing.

## Why are these changes being made?

* Pre-release artifacts showed the launch-site flow expecting one selected domain while the escape-hatch modal displayed another.
* The same flow also timed out while clicking `start with a free plan` on a loaded mobile runner.

## Testing Instructions

* `yarn workspace @automattic/calypso-e2e build`
* Let PR E2E cover `start-launch-site__flows.spec.ts` and related domain flows.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the \"[Status] String Freeze\" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the \"[Status] Needs Privacy Updates\" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?