### PR TITLE
E2E: restore release test readiness

### DIFF
--- a/packages/calypso-e2e/src/lib/components/domain-search-component.ts
+++ b/packages/calypso-e2e/src/lib/components/domain-search-component.ts
@@ -140,12 +140,7 @@ export class DomainSearchComponent {
 	 * @returns {string} Domain that was selected.
 	 */
 	async selectFirstSuggestion( waitForContinueButton: boolean = true ): Promise< string > {
-		const targetRow = this.getContainer()
-			.getByRole( 'listitem' )
-			.filter( {
-				has: this.page.getByRole( 'button', { name: 'Add to cart' } ),
-			} )
-			.first();
+		const targetRow = this.getContainer().getByRole( 'listitem' ).first();
 		const suggestion = await this.selectSuggestion( targetRow, waitForContinueButton );
 
 		if ( ! suggestion ) {

--- a/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
@@ -315,11 +315,12 @@ export class CartCheckoutPage {
 	async enterPaymentDetails( paymentDetails: PaymentDetails ): Promise< void > {
 		// Select the Credit or debit card payment method to expand the fields.
 		// On mobile the sticky Pay CTA and the auto-selected Google Pay tile sit
-		// over the card label, so a real click can't reach it. Dispatch the
-		// click on the underlying radio input, then wait for the form fields
-		// that prove the payment method is ready.
+		// over the card label, so a real click can't reach it. Wait for the
+		// underlying radio input to become enabled, then dispatch the click and
+		// wait for the form fields that prove the payment method is ready.
 		const cardPaymentRadio = this.page.locator( selectors.cardPaymentRadio );
 		await cardPaymentRadio.waitFor( { state: 'attached', timeout: 15 * 1000 } );
+		await expect( cardPaymentRadio ).toBeEnabled( { timeout: 30 * 1000 } );
 		await cardPaymentRadio.dispatchEvent( 'click' );
 		await expect( cardPaymentRadio ).toHaveJSProperty( 'checked', true );
 		await this.validatePaymentForm();


### PR DESCRIPTION
Follow-up fix to #110654 and #110655

## Proposed Changes

* Restore first domain suggestion selection to the first result row, instead of filtering by an `Add to cart` button first.
* Keep #110654's checkout card-radio path and form-field oracle, but wait for the radio to become enabled before dispatching the click.

## Why are these changes being made?

* A post-deploy pre-release run failed broadly after #110654 and #110655 merged.
* The filtered domain suggestion locator kept targeting a row whose `Add to cart` button stayed visible after click, blocking domain/search release flows.
* Mobile checkout also showed the card radio can be attached while still disabled, so the helper needs an explicit enabled-state wait before selecting it.
* PR-side E2E checks were not enough here because the PR matrix did not execute real release tests. This follow-up should be verified with a personal pre-release TeamCity run before merge.

## Testing Instructions

* `yarn workspace @automattic/calypso-e2e build`
* Let PR CI run.
* Before merge, trigger a personal pre-release run for this branch and verify the desktop/mobile leaf builds show real test counts.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
