### PR TITLE
Plugin directory: canonicalize localized pages to English equivalent

### DIFF
--- a/client/controller/localized-links.js
+++ b/client/controller/localized-links.js
@@ -54,6 +54,30 @@ export const setLocalizedCanonicalUrl = ( context, next ) => {
 	next();
 };
 
+export const setEnglishCanonicalUrl = ( context, next ) => {
+	performanceMark( context, 'setEnglishCanonicalUrl' );
+
+	if ( ! context.isServerSide || isUserLoggedIn( context.store.getState() ) ) {
+		next();
+		return;
+	}
+
+	const canonicalUrl = getLocalizedCanonicalUrl(
+		context.originalUrl,
+		'en',
+		context.excludeSearchFromCanonicalUrl
+	);
+
+	context.store.dispatch(
+		setDocumentHeadLink( {
+			rel: 'canonical',
+			href: canonicalUrl,
+		} )
+	);
+
+	next();
+};
+
 export const setHrefLangLinks = ( context, next ) => {
 	if ( ! context.isServerSide || isUserLoggedIn( context.store.getState() ) ) {
 		next();

--- a/client/controller/localized-links.js
+++ b/client/controller/localized-links.js
@@ -11,11 +11,12 @@ const getLocalizedCanonicalUrl = ( path, locale, excludeSearch = false ) => {
 		baseUrl.search = '';
 	}
 
-	const baseUrlWithoutLang = baseUrl.href.replace(
-		new RegExp( `\\/(${ getLanguageSlugs().join( '|' ) })(\\/|\\?|$)` ),
-		'$2'
-	);
-	let localizedUrl = localizeUrl( baseUrlWithoutLang, locale, false );
+	// Anchor the strip to the start of the pathname so slugs that happen to
+	// match a language code (e.g. /plugins/de, /tag/es) survive.
+	const langPrefixRegex = new RegExp( `^/(${ getLanguageSlugs().join( '|' ) })(/|$)` );
+	baseUrl.pathname = baseUrl.pathname.replace( langPrefixRegex, '/' );
+
+	let localizedUrl = localizeUrl( baseUrl.href, locale, false );
 
 	// Remove the trailing slash if `path` doesn't have one either.
 	if ( ! path.endsWith( '/' ) && localizedUrl.endsWith( '/' ) ) {

--- a/client/my-sites/plugins/index.node.js
+++ b/client/my-sites/plugins/index.node.js
@@ -1,7 +1,7 @@
 import { getLanguageRouteParam } from '@automattic/i18n-utils';
 import { JSDOM } from 'jsdom';
 import { makeLayout, ssrSetupLocale } from 'calypso/controller';
-import { setHrefLangLinks, setLocalizedCanonicalUrl } from 'calypso/controller/localized-links';
+import { setEnglishCanonicalUrl } from 'calypso/controller/localized-links';
 import { setupPreferences } from 'calypso/controller/preferences';
 import { overrideSanitizeSectionRoot } from 'calypso/lib/plugins/sanitize-section-content';
 import { browsePlugins, browsePluginsOrPlugin } from './controller';
@@ -24,8 +24,7 @@ export default function ( router ) {
 		ssrSetupLocale,
 		setupPreferences,
 		fetchPlugins,
-		setHrefLangLinks,
-		setLocalizedCanonicalUrl,
+		setEnglishCanonicalUrl,
 		browsePlugins,
 		makeLayout
 	);
@@ -36,8 +35,7 @@ export default function ( router ) {
 		ssrSetupLocale,
 		setupPreferences,
 		fetchCategoryPlugins,
-		setHrefLangLinks,
-		setLocalizedCanonicalUrl,
+		setEnglishCanonicalUrl,
 		browsePlugins,
 		makeLayout
 	);
@@ -49,8 +47,7 @@ export default function ( router ) {
 		ssrSetupLocale,
 		setupPreferences,
 		fetchPlugin,
-		setHrefLangLinks,
-		setLocalizedCanonicalUrl,
+		setEnglishCanonicalUrl,
 		browsePluginsOrPlugin,
 		makeLayout
 	);


### PR DESCRIPTION
Part of #

## Proposed Changes

**Plugin directory canonicals (primary change):**
- Add a `setEnglishCanonicalUrl` SSR middleware in `client/controller/localized-links.js` that emits `<link rel="canonical">` pointing to the English (locale-prefix-stripped) URL.
- Use it on all three plugin directory routes (browse root, browse category, plugin detail) in `client/my-sites/plugins/index.node.js`.
- Stop emitting `setHrefLangLinks` on those routes — the hreflang block was advertising translations that don't actually exist.

**Drive-by bug fix in `getLocalizedCanonicalUrl` (raised by Copilot review):**
- Anchor the language-prefix strip to the start of the pathname. Previously the helper ran an unanchored regex on the full href and would strip *any* `/<lang>` segment found anywhere in the URL — not just the leading locale prefix.
- Concrete failure: `/plugins/de` (English) was canonicalized to `/plugins`, dropping the slug. Same failure mode applied to `/tag/es`, `/theme/fr`, etc.
- The fix benefits every caller of this helper (existing `setLocalizedCanonicalUrl` and `setHrefLangLinks` for theme, pattern, and Reader-tag routes), not just the new middleware.

## Why are these changes being made?

The plugin directory pages at `/plugins/*` and `/<locale>/plugins/*` previously emitted a self-referencing canonical for each locale variant, plus a full hreflang block. But the underlying plugin content (descriptions, screenshots, install instructions) is sourced from WordPress.org and is in English regardless of the page locale.

Google was rejecting our self-canonicals and choosing the English URL anyway, generating ~12,000+ "Duplicate, Google chose different canonical" entries in Search Console. Pointing the canonical at the English equivalent — and removing the hreflang block, which falsely advertised localized variants — aligns the markup with the actual content and resolves the duplicate-canonical signal.

The themes directory has a similar architecture but the SC sample only shows ~17/1000 theme rows affected (themes are largely translated), so it is intentionally out of scope for this change.

The bundled bug fix in `getLocalizedCanonicalUrl` was surfaced during PR review. It's a long-standing footgun that could silently break canonicals on any route whose slug collides with a language code; including the fix here keeps this PR's correctness story coherent (the entire point is "emit accurate canonical URLs").

## Testing Instructions

1. Run `yarn start` and wait for the SSR build.
2. In an incognito window or via `curl` (to ensure the logged-out SSR path runs), hit a non-English plugin URL and inspect the rendered head:

   ```bash
   curl -s http://calypso.localhost:3000/es/plugins/limit-login-attempts \
     | grep -oE '<link[^>]*(rel="canonical"|hreflang)[^>]*>'
   ```

   Expected: one `<link rel="canonical" href="https://wordpress.com/plugins/limit-login-attempts"/>` line and zero `hreflang` lines.

3. Repeat for the English route (`/plugins/limit-login-attempts`) — canonical should point to itself, no hreflang.
4. Repeat for a browse category (`/de/plugins/browse/security`) — canonical should drop the locale prefix, no hreflang.
5. Sanity check an unchanged route (e.g. `/es/patterns`) — should still emit a localized canonical and the full hreflang block, confirming the change is scoped to plugin routes.
6. Verify the regex fix by checking a route whose slug equals a language code (e.g. a Reader tag like `/tag/de` if available, or any plugin slug matching a locale). The canonical should preserve the slug, not collapse to the parent browse page.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?