### PR TITLE
WooCommerce Onboarding: do not wait for full automated transfer before showing big sky prompt

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -314,9 +314,17 @@ const onboarding: FlowV2< typeof initialize > = {
 							refParameter === WOO_HOSTING_SOLUTIONS_REF &&
 							isEnabled( 'onboarding/woo-hosting-post-purchase-setup-choice' )
 						) {
-							return navigate( 'setup-your-site-ai' );
+							return navigate(
+								addQueryArgs( 'setup-your-site-ai', {
+									siteId: providedDependencies.siteId,
+								} ) as typeof currentStepSlug
+							);
 						} else if ( providedDependencies?.postCheckoutBigSkyVariation === 'big_sky' ) {
-							return navigate( 'setup-your-site-ai' );
+							return navigate(
+								addQueryArgs( 'setup-your-site-ai', {
+									siteId: providedDependencies.siteId,
+								} ) as typeof currentStepSlug
+							);
 						} else {
 							// replace the location to delete processing step from history.
 							window.location.replace( destination );

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -224,6 +224,11 @@ const onboarding: FlowV2< typeof initialize > = {
 
 					switch ( setupChoice ) {
 						case 'build-with-ai':
+							// The processing case stamped a wc-admin URL into the signup
+							// destination cookie as the woo-hosting-solutions fallback.
+							// Once the user commits to Build with AI, clear it so no
+							// downstream consumer (checkout, etc.) can send them there.
+							clearSignupDestinationCookie();
 							window.location.assign(
 								addQueryArgs( `/setup/${ SITE_SETUP_FLOW }/${ STEPS.LAUNCH_BIG_SKY.slug }`, {
 									siteSlug,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launch-big-sky/index.tsx
@@ -76,7 +76,13 @@ const LaunchBigSky: StepType = function ( props ) {
 	const { siteSlug, siteId, site } = useSiteData();
 	const urlQuery = useQuery();
 	const ref = urlQuery.get( 'ref' );
-	const { isEligible } = useIsBigSkyEligible( flow );
+	const fromPostCheckoutSetupSite = urlQuery.get( 'fromPostCheckoutSetupSite' ) === '1';
+	// On the post-checkout entry path the upstream flow has already decided the
+	// user gets Big Sky, and this step is the one that writes the feature into
+	// the plan. Skip the plan-features check so we don't bounce on a stale read.
+	const { isEligible } = useIsBigSkyEligible( flow, {
+		skipFeatureCheck: fromPostCheckoutSetupSite,
+	} );
 	const { setDesignOnSite, setStaticHomepageOnSite, setGoalsOnSite, setIntentOnSite } =
 		useDispatch( SITE_STORE );
 	const goals = useSelect(
@@ -103,10 +109,16 @@ const LaunchBigSky: StepType = function ( props ) {
 	};
 
 	useEffect( () => {
+		// Wait for the site object to load before deciding eligibility; otherwise
+		// useIsSiteOwner returns null on the first render and we bounce before
+		// the real check can run.
+		if ( ! site ) {
+			return;
+		}
 		if ( ! isEligible ) {
 			window.location.replace( `/sites/${ siteSlug }` );
 		}
-	}, [ isEligible, siteSlug ] );
+	}, [ site, isEligible, siteSlug ] );
 
 	const exitFlow = useCallback(
 		async ( selectedSiteId: string, selectedSiteSlug: string ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
@@ -17,7 +17,6 @@ import Loading from 'calypso/components/loading';
 import { WOO_HOSTING_SOLUTIONS_REF } from 'calypso/landing/stepper/constants';
 import { useQuery as useUrlParams } from 'calypso/landing/stepper/hooks/use-query';
 import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
-import { waitForPluginsActive } from 'calypso/landing/stepper/utils/wait-for-plugins-active';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useExperiment } from 'calypso/lib/explat';
 import { useMarketplaceThemeProducts } from '../../../../hooks/use-marketplace-theme-products';
@@ -211,15 +210,6 @@ const PostCheckoutOnboarding: StepType< {
 					await waitForInitiateTransfer( pluginToInstall );
 					await waitForAtomic();
 				}
-			}
-
-			// Poll for the Woo ref regardless of the atomic path above — the
-			// site may already be Atomic when this effect mounts while
-			// WooCommerce is still finishing installation. This covers both the
-			// Commerce plan (backend auto-install) and the Business plan (install
-			// via the transfer initiated above).
-			if ( isWooHostingSolutions ) {
-				await waitForPluginsActive( site.ID, [ 'woocommerce' ] );
 			}
 
 			return providedDependencies;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
@@ -200,6 +200,7 @@ const PostCheckoutOnboarding: StepType< {
 
 		setPendingAction( async () => {
 			const providedDependencies = {
+				siteId: site.ID,
 				siteSlug,
 				hasExternalTheme,
 				hasPluginByGoal,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
@@ -112,19 +112,24 @@ const PostCheckoutOnboarding: StepType< {
 
 	const { setIntentOnSite, setGoalsOnSite } = useDispatch( SITE_STORE );
 
-	const waitForAtomic = async () => {
-		await waitForTransfer();
-		await setIntentOnSite( siteSlug, intent );
-		await setGoalsOnSite( siteSlug, goals );
-		await waitForFeature();
-		await waitForLatestSiteData();
-	};
-
 	const goalPlugin = usePluginByGoal();
 	const hasPluginByGoal = !! goalPlugin;
 
 	const refParameter = useUrlParams().get( 'ref' );
 	const isWooHostingSolutions = refParameter === WOO_HOSTING_SOLUTIONS_REF;
+
+	const waitForAtomic = async () => {
+		await waitForTransfer();
+		await setIntentOnSite( siteSlug, intent );
+		await setGoalsOnSite( siteSlug, goals );
+		await waitForFeature();
+		// woo-hosting-solutions sends the user straight to a choice screen and
+		// then on to Atomic wp-admin; neither needs fresh WPCOM capabilities, so
+		// skip the ~20s wait for Jetpack sync to propagate manage_options.
+		if ( ! isWooHostingSolutions ) {
+			await waitForLatestSiteData();
+		}
+	};
 
 	// Prefer the cart item (what the user just bought — freshest signal during
 	// post-checkout) over site.plan (which can be stale before the site's plan

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
@@ -22,7 +22,7 @@ import { useExperiment } from 'calypso/lib/explat';
 import { useMarketplaceThemeProducts } from '../../../../hooks/use-marketplace-theme-products';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
 import { useSiteTransferStatusQuery } from '../../../../hooks/use-site-transfer/query';
-import { useWaitForAtomic } from '../../../../hooks/use-wait-for-atomic';
+import { transferStates, useWaitForAtomic } from '../../../../hooks/use-wait-for-atomic';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 import type { Step as StepType } from '../../types';
 import type { OnboardSelect } from '@automattic/data-stores';
@@ -118,7 +118,15 @@ const PostCheckoutOnboarding: StepType< {
 	const isWooHostingSolutions = refParameter === WOO_HOSTING_SOLUTIONS_REF;
 
 	const waitForAtomic = async () => {
-		await waitForTransfer();
+		// woo-hosting-solutions sends the user to a choice screen next, which
+		// only needs the Atomic install to be reachable. Unblock as soon as the
+		// transfer reaches "provisioned" rather than waiting for the post-
+		// transfer cleanup that "completed" implies.
+		await waitForTransfer(
+			isWooHostingSolutions
+				? { acceptedStatuses: [ transferStates.PROVISIONED, transferStates.COMPLETED ] }
+				: undefined
+		);
 		await setIntentOnSite( siteSlug, intent );
 		await setGoalsOnSite( siteSlug, goals );
 		await waitForFeature();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/setup-your-site-ai/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/setup-your-site-ai/index.tsx
@@ -11,9 +11,11 @@ import { arrowUp, layout } from '@wordpress/icons';
 import i18n, { useTranslate } from 'i18n-calypso';
 import { FormEvent, useState } from 'react';
 import { WOO_HOSTING_SOLUTIONS_REF } from 'calypso/landing/stepper/constants';
+import { waitForPluginsActive } from 'calypso/landing/stepper/utils/wait-for-plugins-active';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useQuery } from '../../../../hooks/use-query';
 import { useSiteData } from '../../../../hooks/use-site-data';
+import { useWaitForAtomic } from '../../../../hooks/use-wait-for-atomic';
 import type { Step as StepType } from '../../types';
 import './style.scss';
 
@@ -23,13 +25,38 @@ const SetupYourSiteAIStep: StepType = ( { navigation } ) => {
 	const ref = useQuery().get( 'ref' );
 	const showPromptInput = ref === WOO_HOSTING_SOLUTIONS_REF;
 	const [ prompt, setPrompt ] = useState( '' );
+	const [ isFinalizing, setIsFinalizing ] = useState( false );
 
-	const submitBuildWithAI = ( trimmedPrompt?: string ) => {
+	const { waitForTransfer, waitForLatestSiteData } = useWaitForAtomic( { siteId } );
+
+	// post-checkout-onboarding unblocks this screen as soon as the transfer
+	// reaches "provisioned", so the remaining WPCOM-side readiness gates run
+	// here in parallel before we hand the user off. By the time they pick a
+	// choice, most of these have usually already resolved.
+	const finalizeAtomicReadiness = async () => {
+		if ( ! siteId ) {
+			return;
+		}
+		try {
+			await Promise.all( [
+				waitForTransfer(),
+				waitForLatestSiteData(),
+				waitForPluginsActive( siteId, [ 'woocommerce' ] ),
+			] );
+		} catch ( error ) {
+			recordTracksEvent( 'calypso_onboarding_setup_your_site_ai_finalize_error', {
+				message: ( error as Error )?.message,
+			} );
+		}
+	};
+
+	const submitBuildWithAI = async ( trimmedPrompt?: string ) => {
 		recordTracksEvent( 'calypso_onboarding_setup_your_site_with_ai_selection', {
 			selection: 'build-with-ai',
 			has_prompt: Boolean( trimmedPrompt ),
 		} );
-
+		setIsFinalizing( true );
+		await finalizeAtomicReadiness();
 		navigation.submit( {
 			setupChoice: 'build-with-ai',
 			siteSlug,
@@ -47,16 +74,21 @@ const SetupYourSiteAIStep: StepType = ( { navigation } ) => {
 		submitBuildWithAI( prompt.trim() );
 	};
 
-	const handleBlankSite = () => {
+	const handleBlankSite = async () => {
 		recordTracksEvent( 'calypso_onboarding_setup_your_site_with_ai_selection', {
 			selection: 'blank-site',
 		} );
-
+		setIsFinalizing( true );
+		await finalizeAtomicReadiness();
 		navigation.submit( {
 			setupChoice: 'blank-site',
 			siteSlug,
 		} );
 	};
+
+	if ( isFinalizing ) {
+		return <Step.Loading />;
+	}
 
 	const buildWithAIPromptCard = (
 		<form className="setup-your-site-ai-step__build-with-ai" onSubmit={ handleBuildWithAISubmit }>

--- a/client/landing/stepper/hooks/use-is-site-big-sky-eligible.ts
+++ b/client/landing/stepper/hooks/use-is-site-big-sky-eligible.ts
@@ -28,7 +28,7 @@ const invalidGoals = [
 	SiteGoal.SellDigital,
 ];
 
-export function useIsBigSkyEligible( flowName?: string ) {
+export function useIsBigSkyEligible( flowName?: string, options?: { skipFeatureCheck?: boolean } ) {
 	const { isOwner } = useIsSiteOwner();
 	const site = useSite();
 	const product_slug = site?.plan?.product_slug || '';
@@ -55,7 +55,7 @@ export function useIsBigSkyEligible( flowName?: string ) {
 				featureFlagEnabled &&
 				featurePostCheckoutAiStepEnabled &&
 				!! isOwner &&
-				siteHasBigSkyFeature &&
+				( options?.skipFeatureCheck || siteHasBigSkyFeature ) &&
 				onSupportedDevice,
 		};
 	}

--- a/client/landing/stepper/hooks/use-wait-for-atomic.ts
+++ b/client/landing/stepper/hooks/use-wait-for-atomic.ts
@@ -32,6 +32,8 @@ export const transferStates = {
 	CLEANUP: 'cleanup',
 } as const;
 
+type TransferStatus = ( typeof transferStates )[ keyof typeof transferStates ];
+
 interface UseWaitForAtomicProps {
 	handleTransferFailure?: ( failureInfo: FailureInfo ) => void;
 	siteId?: number;
@@ -71,7 +73,9 @@ export const useWaitForAtomic = ( {
 		);
 	};
 
-	const waitForTransfer = async () => {
+	const waitForTransfer = async ( {
+		acceptedStatuses = [ transferStates.COMPLETED ],
+	}: { acceptedStatuses?: readonly TransferStatus[] } = {} ) => {
 		const startTime = new Date().getTime();
 		const totalTimeout = 1000 * 300;
 		const maxFinishTime = startTime + totalTimeout;
@@ -102,7 +106,7 @@ export const useWaitForAtomic = ( {
 				throw new Error( 'transfer timeout' );
 			}
 
-			if ( transferStatus === transferStates.COMPLETED ) {
+			if ( transferStatus && acceptedStatuses.includes( transferStatus as TransferStatus ) ) {
 				break;
 			}
 		}


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/RSM-2787/investigate-automated-transfer-speed-for-new-sites

## Proposed changes

This PR modifies the WooCommerce onboarding flow so that it does not wait for the full automated transfer process to complete after checkout before displaying the Big Sky prompt page. Then it finishes waiting after the user has made a choice on that page before sending them to wp-admin on their new WoW site.

## Why are these changes being made?

The automated transfer process takes a very long time (even longer if the site needs WooCommerce or Big Sky). For a WooCommerce onboarding flow, this process happens post-checkout before the user is sent to the wp-admin on their site. This is not great UX.

We can't easily speed up the transfer process itself, but we can improve the perceived time it takes. https://github.com/Automattic/wp-calypso/pull/110126 added a page inside calypso which asks the user if they want to use Big Sky or not for their site. We can display that page before the transfer completes and gain some time before the user needs to go to wp-admin.

## Testing instructions

> [!WARNING]
> You cannot test this flow with a store sandbox purchase. It must be using production tables, but if you like, public-api can be pointed to your sandbox server (as long as it's up to date and store sandbox is not enabled).

> [!NOTE]
> You should be logged-in to test this flow. In theory it should also work logged-out but there's something about how the initial onboarding steps work that doesn't make it easy to switch to localhost calypso. I haven't tried it but if you want to do logged-out maybe just use the production flow until you get to checkout and then switch to calypso.localhost or the calypso.live URL.

First, either start calypso with this branch locally, or get the latest calypso.live link (click the "direct link" link next to "Calypso Live" below, wait for the URL to turn into something like https://container-gracious-feynman.calypso.live/ – sometimes you have to reload it to get it to appear).

* Start at https://woocommerce.com/start/#hosts and click on WordPress.com.
* Once you end up on wordpress.com, manually edit the URL to change wordpress.com to calypso.localhost:3000 or the calypso.live URL depending on which you chose in the setup step.
* Complete a purchase flow with any paid plan. (You can use credits to make the purchase.) **Measure the time this takes; it should be faster than production.**
* After checkout and plugin installation, confirm you land on the "Set up your site" page with "Build with AI" and "Manual setup" options.
* Clicking "Build with AI" should navigate to the Big Sky spec builder (this also may take a while). **Measure the time this takes; it should be roughly similar to production.**
