### PR TITLE
E2E: Disable QUIC for Playwright Chromium

### DIFF
--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -38,6 +38,8 @@ if ( process.env.CI ) {
 
 // All end-to-end tests use a custom user agent containing this string.
 const E2E_USER_AGENT_SUFFIX = 'wp-e2e-tests';
+// Keep Chromium on HTTP/2 for WPCOM rest-proxy stability; the legacy Jest suite used the same flag.
+const CHROMIUM_LAUNCH_ARGS = [ '--disable-quic' ];
 
 const appendE2EUserAgent = ( userAgent: string ) => `${ userAgent } ${ E2E_USER_AGENT_SUFFIX }`;
 
@@ -94,6 +96,9 @@ export default defineConfig( {
 			dependencies: [ 'mailosaur-usage-check' ],
 			use: withCustomOptions( {
 				...devices[ 'Desktop Chrome HiDPI' ],
+				launchOptions: {
+					args: CHROMIUM_LAUNCH_ARGS,
+				},
 				userAgent: appendE2EUserAgent( devices[ 'Desktop Chrome HiDPI' ].userAgent ),
 				viewportName: 'desktop',
 			} ),
@@ -121,6 +126,9 @@ export default defineConfig( {
 			dependencies: [ 'mailosaur-usage-check' ],
 			use: withCustomOptions( {
 				...devices[ 'Pixel 7' ],
+				launchOptions: {
+					args: CHROMIUM_LAUNCH_ARGS,
+				},
 				userAgent: appendE2EUserAgent( devices[ 'Pixel 7' ].userAgent ),
 				viewportName: 'mobile',
 			} ),
@@ -131,6 +139,9 @@ export default defineConfig( {
 			dependencies: [ 'mailosaur-usage-check' ],
 			use: withCustomOptions( {
 				...devices[ 'Galaxy S24' ],
+				launchOptions: {
+					args: CHROMIUM_LAUNCH_ARGS,
+				},
 				userAgent: appendE2EUserAgent( devices[ 'Galaxy S24' ].userAgent ),
 				viewportName: 'mobile',
 			} ),
@@ -156,6 +167,7 @@ export default defineConfig( {
 				bypassCSP: true,
 				launchOptions: {
 					args: [
+						...CHROMIUM_LAUNCH_ARGS,
 						'--disable-blink-features=AutomationControlled',
 						'--disable-features=IsolateOrigins,site-per-process',
 					],


### PR DESCRIPTION
Follow-up to #110639

## Proposed Changes

* Disable QUIC for Chromium-backed Playwright projects.
* Apply the flag to desktop Chrome, Pixel, Galaxy, and the Authentication Chromium project.
* Leave Firefox, WebKit, and iPhone projects unchanged.

## Why are these changes being made?

A LOHP theme signup trace failed while loading the WPCOM rest-proxy iframe with `net::ERR_QUIC_PROTOCOL_ERROR`. The themes page depends on that iframe for client-side WPCOM API requests. When it fails, `/themes/free` can remain on skeleton cards and `[data-e2e-theme]` never appears.

The legacy Calypso E2E Playwright config already used `--disable-quic`. This carries that stability behavior into the current Playwright config.

## Testing Instructions

* `yarn prettier --check test/e2e/playwright.config.ts`
* `git diff --check`
* `yarn workspace wp-e2e-tests playwright test --list --project=chrome specs/onboarding/signup__with-theme-LOHP.spec.ts`
* `yarn workspace wp-e2e-tests test:pw:calypso-release specs/onboarding/signup__with-theme-LOHP.spec.ts --reporter=list`
  * Reached theme selection and the `Get started` handoff.
  * Failed afterward because no local Calypso dev server was running at `calypso.localhost:3000`.

Chaos probe:

* Aborting `public-api.wordpress.com/wp-admin/rest-proxy/?v=2.0` reproduced the skeleton-only themes page.
* Blocking theme screenshot images did not block theme card rendering.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
