### PR TITLE
calypso-build: trim sass includePaths to what each project actually needs

### DIFF
--- a/apps/blaze-dashboard/webpack.config.js
+++ b/apps/blaze-dashboard/webpack.config.js
@@ -82,7 +82,7 @@ module.exports = {
 				include: shouldTranspileDependency,
 			} ),
 			SassConfig.loader( {
-				includePaths: [ process.cwd(), __dirname ],
+				includePaths: [ __dirname ],
 				postCssOptions: {
 					// Do not use postcss.config.js. This ensure we have the final say on how PostCSS is used in calypso.
 					// This is required because Calypso imports `@automattic/notifications` and that package defines its

--- a/apps/blaze-dashboard/webpack.config.js
+++ b/apps/blaze-dashboard/webpack.config.js
@@ -82,7 +82,6 @@ module.exports = {
 				include: shouldTranspileDependency,
 			} ),
 			SassConfig.loader( {
-				includePaths: [ __dirname ],
 				postCssOptions: {
 					// Do not use postcss.config.js. This ensure we have the final say on how PostCSS is used in calypso.
 					// This is required because Calypso imports `@automattic/notifications` and that package defines its

--- a/apps/odyssey-stats/webpack.config.js
+++ b/apps/odyssey-stats/webpack.config.js
@@ -86,7 +86,7 @@ module.exports = {
 				include: shouldTranspileDependency,
 			} ),
 			SassConfig.loader( {
-				includePaths: [ process.cwd(), __dirname ],
+				includePaths: [ __dirname ],
 				postCssOptions: {
 					// Do not use postcss.config.js. This ensure we have the final say on how PostCSS is used in calypso.
 					// This is required because Calypso imports `@automattic/notifications` and that package defines its

--- a/apps/odyssey-stats/webpack.config.js
+++ b/apps/odyssey-stats/webpack.config.js
@@ -86,7 +86,6 @@ module.exports = {
 				include: shouldTranspileDependency,
 			} ),
 			SassConfig.loader( {
-				includePaths: [ __dirname ],
 				postCssOptions: {
 					// Do not use postcss.config.js. This ensure we have the final say on how PostCSS is used in calypso.
 					// This is required because Calypso imports `@automattic/notifications` and that package defines its

--- a/client/assets/stylesheets/reader-mobile.scss
+++ b/client/assets/stylesheets/reader-mobile.scss
@@ -3,7 +3,7 @@
 //
 @import "shared/utils";
 @import '@automattic/calypso-color-schemes';
-@import "client/blocks/reader-full-post/content";
+@import "calypso/blocks/reader-full-post/content";
 
 @media (prefers-color-scheme: dark) {
 	.reader-full-post__story-content .jetpack-blogging-prompt .jetpack-blogging-prompt__label::before {

--- a/client/blocks/reader-feed-item/style.scss
+++ b/client/blocks/reader-feed-item/style.scss
@@ -1,5 +1,5 @@
 @import "@automattic/color-studio/dist/color-variables";
-@import "client/landing/subscriptions/components/site-subscriptions-list/styles/placeholders";
+@import "calypso/landing/subscriptions/components/site-subscriptions-list/styles/placeholders";
 
 .reader-feed-item {
 	border-block-end: 1px solid $studio-gray-5;

--- a/client/blocks/reader-site-subscription/styles.scss
+++ b/client/blocks/reader-site-subscription/styles.scss
@@ -3,7 +3,7 @@
 @import "@automattic/color-studio/dist/color-variables";
 @import "@automattic/typography/styles/variables";
 @import "@wordpress/base-styles/breakpoints";
-@import "client/landing/subscriptions/components/settings/styles";
+@import "calypso/landing/subscriptions/components/settings/styles";
 
 .site-subscription-page {
 	.loading-container {

--- a/client/components/jetpack/licensing-prompt-dialog/style.scss
+++ b/client/components/jetpack/licensing-prompt-dialog/style.scss
@@ -1,7 +1,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/variables";
-@import "jetpack-connect/colors";
+@import "calypso/jetpack-connect/colors";
 
 .is-section-jetpack-connect .licensing-prompt-dialog {
 	@include jetpack-connect-colors();

--- a/client/components/survey-container/components/style.scss
+++ b/client/components/survey-container/components/style.scss
@@ -1,7 +1,7 @@
 @import "@automattic/color-studio/dist/color-variables";
 @import "@automattic/typography/styles/variables";
 @import "@wordpress/base-styles/breakpoints";
-@import "client/components/forms/form-radio/style";
+@import "calypso/components/forms/form-radio/style";
 
 $blueberry-color: #3858e9;
 $dark-blueberry-color: #2145e6;

--- a/client/landing/subscriptions/components/comment-list/styles.scss
+++ b/client/landing/subscriptions/components/comment-list/styles.scss
@@ -1,7 +1,7 @@
 @import "@automattic/color-studio/dist/color-variables";
 @import "@automattic/typography/styles/variables";
 @import "@wordpress/base-styles/breakpoints";
-@import "client/landing/subscriptions/styles/row-title-label";
+@import "calypso/landing/subscriptions/styles/row-title-label";
 
 %ellipsis {
 	white-space: nowrap;

--- a/client/landing/subscriptions/components/site-subscriptions-list/styles/site-subscriptions-list-actions-bar.scss
+++ b/client/landing/subscriptions/components/site-subscriptions-list/styles/site-subscriptions-list-actions-bar.scss
@@ -1,9 +1,9 @@
 @import "@automattic/color-studio/dist/color-variables";
 @import "@automattic/typography/styles/variables";
 @import "@wordpress/base-styles/breakpoints";
-@import "client/assets/stylesheets/p2-vars";
-@import "client/landing/subscriptions/styles/row-title-label";
-@import "client/landing/subscriptions/styles/list-actions-bar";
+@import "calypso/assets/stylesheets/p2-vars";
+@import "calypso/landing/subscriptions/styles/row-title-label";
+@import "calypso/landing/subscriptions/styles/list-actions-bar";
 
 .site-subscriptions-list-actions-bar {
 	@extend %list-actions-bar;

--- a/client/landing/subscriptions/components/site-subscriptions-list/styles/site-subscriptions-list.scss
+++ b/client/landing/subscriptions/components/site-subscriptions-list/styles/site-subscriptions-list.scss
@@ -1,8 +1,8 @@
 @import "@automattic/color-studio/dist/color-variables";
 @import "@automattic/typography/styles/variables";
 @import "@wordpress/base-styles/breakpoints";
-@import "client/assets/stylesheets/p2-vars";
-@import "client/landing/subscriptions/styles/row-title-label";
+@import "calypso/assets/stylesheets/p2-vars";
+@import "calypso/landing/subscriptions/styles/row-title-label";
 @import "./placeholders";
 
 

--- a/client/landing/subscriptions/components/tab-views/comments/styles.scss
+++ b/client/landing/subscriptions/components/tab-views/comments/styles.scss
@@ -1,4 +1,4 @@
-@import "client/landing/subscriptions/styles/list-actions-bar";
+@import "calypso/landing/subscriptions/styles/list-actions-bar";
 
 .comments-list-actions-bar {
 	@extend %list-actions-bar;

--- a/client/my-sites/store/app/store-stats/store-stats-chart/style.scss
+++ b/client/my-sites/store/app/store-stats/store-stats-chart/style.scss
@@ -1,1 +1,1 @@
-@import "client/my-sites/stats/modernized-chart-tabs-styles";
+@import "calypso/my-sites/stats/modernized-chart-tabs-styles";

--- a/client/my-sites/store/style.scss
+++ b/client/my-sites/store/style.scss
@@ -1,4 +1,4 @@
-@import "client/my-sites/stats/modernized-tooltip-styles";
+@import "calypso/my-sites/stats/modernized-tooltip-styles";
 @import "calypso/my-sites/stats/modernized-layout-styles";
 
 .woocommerce {

--- a/client/my-sites/woocommerce/style.scss
+++ b/client/my-sites/woocommerce/style.scss
@@ -1,5 +1,5 @@
 @import "@automattic/onboarding/styles/mixins";
-@import "jetpack-connect/colors";
+@import "calypso/jetpack-connect/colors";
 
 .is-group-woocommerce-installation.is-section-woocommerce-installation .layout__content {
 	padding-bottom: 0; //removes whitespace in the end

--- a/client/reader/site-subscriptions-manager/style.scss
+++ b/client/reader/site-subscriptions-manager/style.scss
@@ -3,7 +3,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@automattic/typography/styles/variables";
 @import "@automattic/color-studio/dist/color-variables";
-@import "client/landing/subscriptions/styles/search-component";
+@import "calypso/landing/subscriptions/styles/search-component";
 
 @mixin hover-color {
 	&:hover,

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -2,7 +2,7 @@
 
 @import '@wordpress/base-styles/mixins';
 @import '@wordpress/base-styles/breakpoints';
-@import 'client/assets/stylesheets/shared/mixins/long-content-fade';
+@import 'calypso/assets/stylesheets/shared/mixins/long-content-fade';
 
 .following {
 

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -1,7 +1,7 @@
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 @import '@wordpress/base-styles/variables';
-@import 'client/assets/stylesheets/shared/mixins/long-content-fade';
+@import 'calypso/assets/stylesheets/shared/mixins/long-content-fade';
 
 body.is-reader-page,
 .is-reader-page .layout,

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -182,7 +182,7 @@ body.is-section-signup .layout:not(.dops) {
 }
 
 .layout.is-wccom-oauth-flow {
-	@import "jetpack-connect/colors";
+	@import "calypso/jetpack-connect/colors";
 	@include woocommerce-colors();
 	background-color: var(--color-woocommerce-onboarding-background);
 	height: 100%;

--- a/client/sites/deployments/components/repositories/style.scss
+++ b/client/sites/deployments/components/repositories/style.scss
@@ -1,5 +1,5 @@
-@import 'node_modules/@wordpress/base-styles/breakpoints';
-@import 'node_modules/@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .github-deployments-repositories {
 	display: flex;

--- a/client/sites/deployments/deployment-creation/style.scss
+++ b/client/sites/deployments/deployment-creation/style.scss
@@ -1,5 +1,5 @@
-@import 'node_modules/@wordpress/base-styles/breakpoints';
-@import 'node_modules/@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .repository-selection-dialog {
 	height: 515px;

--- a/client/sites/settings/server/style.scss
+++ b/client/sites/settings/server/style.scss
@@ -1,5 +1,5 @@
-@import 'node_modules/@wordpress/base-styles/breakpoints';
-@import 'node_modules/@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .settings-server {
 	select {

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -283,7 +283,6 @@ const webpackConfig = {
 				include: shouldTranspileDependency,
 			} ),
 			SassConfig.loader( {
-				includePaths: [ __dirname ],
 				postCssOptions: {
 					// Do not use postcss.config.js. This ensure we have the final say on how PostCSS is used in calypso.
 					// This is required because Calypso imports `@automattic/notifications` and that package defines its

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -283,7 +283,7 @@ const webpackConfig = {
 				include: shouldTranspileDependency,
 			} ),
 			SassConfig.loader( {
-				includePaths: [ process.cwd(), __dirname ],
+				includePaths: [ path.resolve( __dirname, '..' ), __dirname ],
 				postCssOptions: {
 					// Do not use postcss.config.js. This ensure we have the final say on how PostCSS is used in calypso.
 					// This is required because Calypso imports `@automattic/notifications` and that package defines its
@@ -296,9 +296,9 @@ const webpackConfig = {
 				// Final result should be something like `@use 'client/assets/stylesheets/shared/_utils.scss' as *;`
 				prelude: `@use '${
 					path
-						// Path, relative to Node CWD
+						// Path, relative to the repo root
 						.relative(
-							process.cwd(),
+							path.resolve( __dirname, '..' ),
 							path.join( __dirname, 'assets/stylesheets/shared/_utils.scss' )
 						)
 						.split( path.sep ) // Break any path (posix/win32) by path separator

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -283,7 +283,7 @@ const webpackConfig = {
 				include: shouldTranspileDependency,
 			} ),
 			SassConfig.loader( {
-				includePaths: [ path.resolve( __dirname, '..' ), __dirname ],
+				includePaths: [ __dirname ],
 				postCssOptions: {
 					// Do not use postcss.config.js. This ensure we have the final say on how PostCSS is used in calypso.
 					// This is required because Calypso imports `@automattic/notifications` and that package defines its
@@ -291,19 +291,7 @@ const webpackConfig = {
 					config: false,
 					plugins: [ autoprefixerPlugin() ],
 				},
-				// Since `prelude` string will be appended to each Sass file
-				// We need to ensure that the import path (inside a sass file) is a posix path, regardless of the OS/platform
-				// Final result should be something like `@use 'client/assets/stylesheets/shared/_utils.scss' as *;`
-				prelude: `@use '${
-					path
-						// Path, relative to the repo root
-						.relative(
-							path.resolve( __dirname, '..' ),
-							path.join( __dirname, 'assets/stylesheets/shared/_utils.scss' )
-						)
-						.split( path.sep ) // Break any path (posix/win32) by path separator
-						.join( path.posix.sep ) // Convert the path explicitly to posix to ensure imports work fine
-				}' as *;`,
+				prelude: `@use 'calypso/assets/stylesheets/shared/_utils.scss' as *;`,
 			} ),
 			{
 				include: path.join( __dirname, 'sections.js' ),


### PR DESCRIPTION
Follow-up to #110326.

## Proposed Changes

* `apps/blaze-dashboard` and `apps/odyssey-stats`: drop all custom `includePaths`. Their SCSS never needed this and #110326 was too cautious in keeping this backwards compatibility.
* `client`: drop CWD from `includePaths` too and fix up include paths
* Simplify `client`'s sass prelude which can just depend on `@use 'calypso/...'` resolution.
* Fix some peculiar imports
	* Fixed imports from `client/` when our convention is to use `calypso/` to import from the root of the client app
	* Fixed imports from `node_modules/@wordpress/base-styles/...`

## Why are these changes being made?

See PR review feedback from #110326 (https://github.com/Automattic/wp-calypso/pull/110326#discussion_r3217040616)

Allowing imports relative to CWD is a touch confusing, because you could potentially get different results depending on which working-directory you run a build command from.

## Testing Instructions

Verified true byte-equivalence with `bin/check-css-byte-equivalence.js` (from #110326):

```
node bin/check-css-byte-equivalence.js --base origin/trunk --head HEAD
```

Result: `Generated CSS is byte equivalent across 1296 files. Total mismatches: 0` across the full default target list (standalone-css, calypso-client, notifications, o2-blocks, help-center, wpcom-block-editor, agents-manager, happy-blocks, blaze-dashboard, odyssey-stats).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?