### PR TITLE
A4A MCP: render settings as categorized sections with Enable all

### DIFF
--- a/client/a8c-for-agencies/data/mcp-ai/types.ts
+++ b/client/a8c-for-agencies/data/mcp-ai/types.ts
@@ -2,11 +2,18 @@ export interface McpAvailableAbility {
 	name: string;
 	title: string;
 	description: string;
+	category: string;
 	enabled: boolean;
+}
+
+export interface McpAvailableCategory {
+	slug: string;
+	label: string;
 }
 
 export interface McpSettings {
 	enabled: boolean;
+	available_categories: McpAvailableCategory[];
 	available_abilities: McpAvailableAbility[];
 }
 

--- a/client/a8c-for-agencies/data/mcp-ai/use-save-mcp-settings.ts
+++ b/client/a8c-for-agencies/data/mcp-ai/use-save-mcp-settings.ts
@@ -1,0 +1,87 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { __ } from '@wordpress/i18n';
+import { useMemo } from 'react';
+import { useDispatch, useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { getMcpSettingsQueryKey } from './use-fetch-mcp-settings';
+import useUpdateMcpSettingsMutation from './use-update-mcp-settings-mutation';
+import type { McpSettings, McpSettingsUpdate, McpApiError } from './types';
+import type { UseMutationResult } from '@tanstack/react-query';
+
+/**
+ * Apply an in-flight `McpSettingsUpdate` to a cached `McpSettings` snapshot
+ * so the optimistic-update path produces the same shape the server would
+ * return. Pure so it stays testable in isolation from react-query / redux.
+ */
+function applyUpdate( previous: McpSettings, update: McpSettingsUpdate ): McpSettings {
+	return {
+		...previous,
+		enabled: update.enabled ?? previous.enabled,
+		available_abilities: previous.available_abilities.map( ( ability ) =>
+			update.abilities && Object.prototype.hasOwnProperty.call( update.abilities, ability.name )
+				? { ...ability, enabled: !! update.abilities[ ability.name ] }
+				: ability
+		),
+	};
+}
+
+interface OptimisticContext {
+	previous?: McpSettings;
+}
+
+/**
+ * Higher-level wrapper around `useUpdateMcpSettingsMutation` that adds the
+ * optimistic-update + user-notice wiring callers want from a settings UI:
+ *
+ *   - Flips the cached settings synchronously so toggles can update without
+ *     waiting for the server round-trip.
+ *   - Rolls back to the previous snapshot on failure so the toggle snaps
+ *     back to its real state.
+ *   - Shows a generic success/error notice (stable id + duration) on save.
+ *
+ * Returns the underlying mutation result, so callers can keep using
+ * `.mutate(update)` and read `.isPending` etc. as if they were calling the
+ * lower-level hook directly.
+ */
+export default function useSaveMcpSettings(): UseMutationResult<
+	McpSettings,
+	McpApiError,
+	McpSettingsUpdate,
+	OptimisticContext
+> {
+	const dispatch = useDispatch();
+	const queryClient = useQueryClient();
+	const agencyId = useSelector( getActiveAgencyId );
+	const queryKey = useMemo( () => getMcpSettingsQueryKey( agencyId ), [ agencyId ] );
+
+	return useUpdateMcpSettingsMutation< OptimisticContext >( {
+		onMutate: async ( update ) => {
+			await queryClient.cancelQueries( { queryKey } );
+			const previous = queryClient.getQueryData< McpSettings >( queryKey );
+			if ( previous ) {
+				queryClient.setQueryData( queryKey, applyUpdate( previous, update ) );
+			}
+			return { previous };
+		},
+		onError: ( _err, _vars, context ) => {
+			if ( context?.previous ) {
+				queryClient.setQueryData( queryKey, context.previous );
+			}
+			dispatch(
+				errorNotice( __( 'Failed to save MCP settings.' ), {
+					id: 'a4a-ai-mcp-settings-save-failed',
+					duration: 8000,
+				} )
+			);
+		},
+		onSuccess: () => {
+			dispatch(
+				successNotice( __( 'MCP settings saved.' ), {
+					id: 'a4a-ai-mcp-settings-saved',
+					duration: 5000,
+				} )
+			);
+		},
+	} );
+}

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/available-tools/available-tools-content.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/available-tools/available-tools-content.tsx
@@ -1,7 +1,6 @@
 import {
 	ToggleControl,
 	__experimentalHStack as HStack,
-	__experimentalSpacer as Spacer,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
@@ -136,14 +135,12 @@ export default function AiMcpAvailableToolsContent() {
 	);
 
 	return (
-		<div className="a4a-ai-mcp-overview">
-			<Spacer className="a4a-ai-mcp-overview__intro" marginBottom={ 12 }>
-				<Text size={ 15 }>
-					{ preventWidows(
-						__( 'Control which AI tools are available to your external AI assistant.' )
-					) }
-				</Text>
-			</Spacer>
+		<VStack className="a4a-ai-mcp-overview" spacing={ 6 }>
+			<Text className="a4a-ai-mcp-overview__intro" size={ 15 }>
+				{ preventWidows(
+					__( 'Control which AI tools are available to your external AI assistant.' )
+				) }
+			</Text>
 			{ ! abilities.length ? (
 				<VStack spacing={ 4 }>
 					<Card>
@@ -171,7 +168,6 @@ export default function AiMcpAvailableToolsContent() {
 											{ group.label }
 										</Text>
 										<ToggleControl
-											__nextHasNoMarginBottom
 											checked={ allEnabled }
 											label={ __( 'Enable all' ) }
 											onChange={ ( next: boolean ) => onToggleCategory( group, next ) }
@@ -184,7 +180,6 @@ export default function AiMcpAvailableToolsContent() {
 										{ group.abilities.map( ( ability ) => (
 											<ToggleControl
 												key={ ability.name }
-												__nextHasNoMarginBottom
 												checked={ ability.enabled }
 												label={ ability.title }
 												help={ ability.description }
@@ -198,6 +193,6 @@ export default function AiMcpAvailableToolsContent() {
 					} ) }
 				</VStack>
 			) }
-		</div>
+		</VStack>
 	);
 }

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/available-tools/available-tools-content.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/available-tools/available-tools-content.tsx
@@ -6,28 +6,84 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import useFetchMcpSettings from 'calypso/a8c-for-agencies/data/mcp-ai/use-fetch-mcp-settings';
-import useUpdateMcpSettingsMutation from 'calypso/a8c-for-agencies/data/mcp-ai/use-update-mcp-settings-mutation';
-import { Card, CardBody } from 'calypso/dashboard/components/card';
+import useSaveMcpSettings from 'calypso/a8c-for-agencies/data/mcp-ai/use-save-mcp-settings';
+import { Card, CardBody, CardDivider } from 'calypso/dashboard/components/card';
 import { preventWidows } from 'calypso/lib/formatting';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { errorNotice } from 'calypso/state/notices/actions';
+import type {
+	McpAvailableAbility,
+	McpAvailableCategory,
+} from 'calypso/a8c-for-agencies/data/mcp-ai/types';
 
 import '../style.scss';
+
+/**
+ * Slug used to bucket any ability the backend returned without a category
+ * (or with a category slug not present in `available_categories`). Renders
+ * under an "Other" heading at the end so nothing silently disappears from
+ * the UI if the backend and frontend drift.
+ */
+const UNCATEGORIZED_SLUG = '__uncategorized__';
+
+interface CategoryGroup {
+	slug: string;
+	label: string;
+	abilities: McpAvailableAbility[];
+}
+
+/**
+ * Build the render-time list of category sections. We walk
+ * `available_categories` in backend order so the UI section order stays
+ * controlled server-side, then append any ability whose category slug
+ * isn't in that list into an "Other" bucket so they remain visible.
+ */
+function groupAbilitiesByCategory(
+	abilities: McpAvailableAbility[],
+	categories: McpAvailableCategory[]
+): CategoryGroup[] {
+	const bySlug = new Map< string, McpAvailableAbility[] >();
+	for ( const ability of abilities ) {
+		const slug = ability.category || UNCATEGORIZED_SLUG;
+		const bucket = bySlug.get( slug ) ?? [];
+		bucket.push( ability );
+		bySlug.set( slug, bucket );
+	}
+
+	const groups: CategoryGroup[] = [];
+	for ( const category of categories ) {
+		const bucket = bySlug.get( category.slug );
+		if ( bucket && bucket.length > 0 ) {
+			groups.push( { slug: category.slug, label: category.label, abilities: bucket } );
+			bySlug.delete( category.slug );
+		}
+	}
+
+	// Anything left didn't match a declared category — surface it under
+	// "Other" rather than dropping it.
+	const leftovers: McpAvailableAbility[] = [];
+	for ( const bucket of bySlug.values() ) {
+		leftovers.push( ...bucket );
+	}
+	if ( leftovers.length > 0 ) {
+		groups.push( {
+			slug: UNCATEGORIZED_SLUG,
+			label: __( 'Other' ),
+			abilities: leftovers,
+		} );
+	}
+
+	return groups;
+}
 
 export default function AiMcpAvailableToolsContent() {
 	const dispatch = useDispatch();
 
 	const { data: settings } = useFetchMcpSettings();
-
-	const mutation = useUpdateMcpSettingsMutation( {
-		onError: () => {
-			dispatch( errorNotice( __( 'Could not save. Please try again.' ) ) );
-		},
-	} );
+	const saveSettings = useSaveMcpSettings();
 
 	const onToggleAbility = useCallback(
 		( abilityName: string, next: boolean ) => {
@@ -37,15 +93,50 @@ export default function AiMcpAvailableToolsContent() {
 					enabled: next,
 				} )
 			);
-			mutation.mutate( { abilities: { [ abilityName ]: next } } );
+			saveSettings.mutate( { abilities: { [ abilityName ]: next } } );
 		},
-		[ dispatch, mutation ]
+		[ dispatch, saveSettings ]
 	);
 
-	const abilities = settings?.available_abilities ?? [];
+	const onToggleCategory = useCallback(
+		( group: CategoryGroup, next: boolean ) => {
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_ai_mcp_category_toggled', {
+					category: group.slug,
+					enabled: next,
+					ability_count: group.abilities.length,
+				} )
+			);
+			// Send one payload per category — the backend merges by name, so
+			// we flip every ability in this group in a single request.
+			const payload: Record< string, boolean > = {};
+			for ( const ability of group.abilities ) {
+				payload[ ability.name ] = next;
+			}
+			saveSettings.mutate( { abilities: payload } );
+		},
+		[ dispatch, saveSettings ]
+	);
+
+	// `settings?.x ?? []` returns a fresh array on every render, which would
+	// rotate the useMemo deps below — wrap in useMemo so the array identity
+	// is stable between renders where the underlying data hasn't changed.
+	const abilities = useMemo(
+		() => settings?.available_abilities ?? [],
+		[ settings?.available_abilities ]
+	);
+	const categories = useMemo(
+		() => settings?.available_categories ?? [],
+		[ settings?.available_categories ]
+	);
+
+	const groups = useMemo(
+		() => groupAbilitiesByCategory( abilities, categories ),
+		[ abilities, categories ]
+	);
 
 	return (
-		<>
+		<div className="a4a-ai-mcp-overview">
 			<Spacer className="a4a-ai-mcp-overview__intro" marginBottom={ 12 }>
 				<Text size={ 15 }>
 					{ preventWidows(
@@ -53,8 +144,8 @@ export default function AiMcpAvailableToolsContent() {
 					) }
 				</Text>
 			</Spacer>
-			<VStack spacing={ 3 }>
-				{ ! abilities.length ? (
+			{ ! abilities.length ? (
+				<VStack spacing={ 4 }>
 					<Card>
 						<CardBody>
 							<HStack alignment="left" spacing={ 4 }>
@@ -66,29 +157,47 @@ export default function AiMcpAvailableToolsContent() {
 							</HStack>
 						</CardBody>
 					</Card>
-				) : (
-					abilities.map( ( ability ) => (
-						<Card key={ ability.name }>
-							<CardBody>
-								<HStack alignment="left" spacing={ 4 }>
-									<ToggleControl
-										label=""
-										checked={ ability.enabled }
-										onChange={ ( next: boolean ) => onToggleAbility( ability.name, next ) }
-										disabled={ mutation.isPending }
-									/>
-									<VStack spacing={ 1 }>
-										<Text weight={ 600 } size={ 15 }>
-											{ ability.title }
+				</VStack>
+			) : (
+				<VStack spacing={ 4 }>
+					{ groups.map( ( group ) => {
+						const allEnabled = group.abilities.every( ( ability ) => ability.enabled );
+
+						return (
+							<Card key={ group.slug }>
+								<CardBody>
+									<HStack justify="space-between" alignment="center">
+										<Text as="h3" weight={ 600 } size={ 14 }>
+											{ group.label }
 										</Text>
-										<Text variant="muted">{ ability.description }</Text>
+										<ToggleControl
+											__nextHasNoMarginBottom
+											checked={ allEnabled }
+											label={ __( 'Enable all' ) }
+											onChange={ ( next: boolean ) => onToggleCategory( group, next ) }
+										/>
+									</HStack>
+								</CardBody>
+								<CardDivider style={ { borderColor: 'var(--color-neutral-5)' } } />
+								<CardBody>
+									<VStack spacing={ 4 }>
+										{ group.abilities.map( ( ability ) => (
+											<ToggleControl
+												key={ ability.name }
+												__nextHasNoMarginBottom
+												checked={ ability.enabled }
+												label={ ability.title }
+												help={ ability.description }
+												onChange={ ( next: boolean ) => onToggleAbility( ability.name, next ) }
+											/>
+										) ) }
 									</VStack>
-								</HStack>
-							</CardBody>
-						</Card>
-					) )
-				) }
-			</VStack>
-		</>
+								</CardBody>
+							</Card>
+						);
+					} ) }
+				</VStack>
+			) }
+		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/style.scss
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/style.scss
@@ -31,10 +31,23 @@
 	flex: 0 1 auto;
 }
 
-.a4a-ai-mcp-connect-agent ol code {
-	padding: 2px 6px;
-	border-radius: 3px;
-	background: var( --color-neutral-0 );
-	font-family: monospace;
-	font-size: inherit;
+.a4a-ai-mcp-connect-agent {
+	ol {
+		padding-inline-start: 20px;
+		margin: 0;
+
+		li,
+		li > span {
+			color: var( --color-neutral-60 );
+			font-size: calc(13px);
+		}
+
+		code {
+			padding: 2px 6px;
+			border-radius: 3px;
+			background: var( --color-neutral-0 );
+			font-family: monospace;
+			font-size: inherit;
+		}
+	}
 }

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/style.scss
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/style.scss
@@ -25,6 +25,12 @@
 	}
 }
 
+// Constrain ToggleControl labels to their text width so the click target
+// only covers the visible label, not the whole row.
+.a4a-ai-mcp-overview .components-toggle-control__label {
+	flex: 0 1 auto;
+}
+
 .a4a-ai-mcp-connect-agent ol code {
 	padding: 2px 6px;
 	border-radius: 3px;

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/style.scss
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/style.scss
@@ -48,6 +48,7 @@
 			background: var( --color-neutral-0 );
 			font-family: monospace;
 			font-size: inherit;
+			overflow-wrap: anywhere;
 		}
 	}
 }

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -25,7 +25,7 @@
 		}
 	],
 	"features": {
-		"a4a-ai-mcp": false,
+		"a4a-ai-mcp": true,
 		"a4a-benchmarks": false,
 		"a4a-bd-checkout": false,
 		"a4a-bd-term-pricing": true,


### PR DESCRIPTION
## Summary

Related to A4A-2579
Resolves A4A-2587
Resolves A4A-2541

<img width="3840" height="4116" alt="screencapture-agencies-localhost-3000-resources-and-tools-ai-mcp-tools-2026-05-12-15_34_28" src="https://github.com/user-attachments/assets/a10be7aa-2620-498c-a5fe-75a4bfc40408" />


Restructures the A4A MCP settings page (`agencies.automattic.com/resources-and-tools/ai-mcp`) to mirror the wpcom Dashboard MCP layout (`my.wordpress.com/me/preferences/mcp/read`): one card per category, an "Enable all" toggle in each category header, and the abilities grouped underneath. Pairs with the wpcom-side categorization PR (216594-ghe-Automattic/wpcom — backend that emits `available_categories` + `category` per ability via the settings endpoint).

## Changes

### MCP settings UI

- **One Card per category**, with a header HStack: section label on the left, **"Enable all"** toggle on the right. CardDivider underneath uses `var(--color-neutral-5)`. Body is a VStack of `<ToggleControl>`s using the WP component's built-in `label`/`help` props.
- **Backend-driven category list and order.** The settings endpoint returns `available_categories` (ordered `{slug, label}` list) plus a `category` slug per ability — Calypso renders sections in the order the backend ships. Defensive "Other" bucket renders any ability whose category slug isn't in `available_categories` so nothing silently disappears if the lists drift.
- **`useSaveMcpSettings` hook.** Wraps `useUpdateMcpSettingsMutation` with optimistic cache updates, rollback on failure, and notice-with-id/duration for both success and error. The component is a thin render layer that just calls `saveSettings.mutate(update)`.
- **No more `disabled={isPending}`** on toggles — the optimistic flip is the per-action confirmation.
- **"Enable all" sends one mutation** containing every ability in the category (single round-trip per click).
- **Constrained click target.** `.components-toggle-control__label { flex: 0 1 auto }` so the per-ability toggle's clickable area only covers the label text, not the full row.

### Feature flag

- `config/a8c-for-agencies-horizon.json`: `a4a-ai-mcp` flipped from `false` → `true` so the new layout is testable on Horizon. Stage and Production unchanged.

## Testing instructions

On Horizon (or local dev with `a4a-ai-mcp: true`), visit `/resources-and-tools/ai-mcp/available-tools`:

- Patch 216594-ghe-Automattic/wpcom
- Five category cards render in order: Agency, Sites, Site Health & Operations, Migrations, Commissions. Each header carries the section label and an "Enable all" toggle.
- Per-ability toggles inside each card show `title` + muted `description`. Clicking the label outside the text does **not** toggle.
- Toggling an ability flips immediately (optimistic), shows "MCP settings saved." (or "Failed to save MCP settings." on failure), and the toggle stays operable while the request is in flight.
- Toggling "Enable all" flips every ability in that category in a single network request and shows one notice.
- Multiple rapid toggles produce a single visible "Saved" notice (id collapses them) rather than stacking.
- Section ordering and labels follow whatever the backend ships in `available_categories`.

Some minor UI enhancements:

<img width="1551" height="851" alt="Screenshot 2026-05-12 at 1 04 15 PM" src="https://github.com/user-attachments/assets/96e5295f-7427-4c89-bfd7-16672e23a20d" />



## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)