### PR TITLE
Convert component-file-picker to ESM module

### DIFF
--- a/client/components/file-picker/component-file-picker.js
+++ b/client/components/file-picker/component-file-picker.js
@@ -2,13 +2,7 @@
  * Module Dependencies
  */
 
-const event = require( 'component-event' );
-
-/**
- * Expose `FilePicker`
- */
-
-module.exports = FilePicker;
+import * as event from 'component-event';
 
 /**
  * Input template
@@ -29,11 +23,10 @@ let bound = false;
 
 /**
  * Opens a file picker dialog.
- * @param {Object} options (optional)
+ * @param {Object} opts (optional)
  * @param {Function} fn callback function
  */
-
-function FilePicker( opts, fn ) {
+export default function FilePicker( opts, fn ) {
 	if ( 'function' === typeof opts ) {
 		fn = opts;
 		opts = {};


### PR DESCRIPTION
Extracted from #110140.

## Proposed Changes

* Convert `client/components/file-picker/component-file-picker.js` from CommonJS (`require`/`module.exports`) to ESM (`import`/`export default`).

## Why are these changes being made?

This makes the component compatible with Vite, not just Webpack.

## Testing Instructions

`FilePicker` is consumed across Calypso. Open the file picker dialog in each of the following places and confirm the OS file chooser opens and a selected file is processed without console errors:

You can test by exporting your reader subscriptions and then importing again.

* `/reader/subscriptions`
* Click kebab menu
* Export OPML
* After down, use Import OMPL
* Select file
* 👍 

Also:
* `yarn typecheck-client` passes.
* No new console errors/warnings when opening any of the above.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you checked for TypeScript, React or other console errors?