### PR TITLE
Enable dashboard/wp-beta-program feature flag

### DIFF
--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -28,7 +28,7 @@
 		"bilmur-script": true,
 		"rum-tracking/logstash": true,
 		"dashboard/omnibar": false,
-		"dashboard/wp-beta-program": false,
+		"dashboard/wp-beta-program": true,
 		"dashboard/v2": false,
 		"domain-transfer-redesign": true,
 		"marketplace-redesign": true,

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -27,7 +27,7 @@
 		"cookie-banner": false,
 		"rum-tracking/logstash": true,
 		"dashboard/omnibar": false,
-		"dashboard/wp-beta-program": false,
+		"dashboard/wp-beta-program": true,
 		"dashboard/v2": false,
 		"dev/store-sandbox-helper": true,
 		"domain-transfer-redesign": true,


### PR DESCRIPTION
## Proposed Changes

* Enable the `dashboard/wp-beta-program` feature flag in `dashboard-production` and `dashboard-stage` environments.

## Why are these changes being made?

* The WordPress beta program feature in the Dashboard client is ready to ship to production. This PR flips the feature flag from `false` to `true` in production and stage configs, making the WP version switching UI available to all users.

## Testing Instructions

* Verify that the WordPress beta program / version switching option appears in the Dashboard site settings on production and stage environments.
* Confirm the feature is not affected in development or horizon environments (already enabled).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?