### PR TITLE
A4A: drop dead legacy commission compute from getEstimatedCommission

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/consolidated-view/index.tsx
@@ -45,7 +45,7 @@ export default function ConsolidatedViews( {
 	const translate = useTranslate();
 	const { data: productsData, isFetching } = useProductsQuery( false, true );
 	const { previousQuarterExpectedCommission, pendingOrders, currentQuarterExpectedCommission } =
-		useGetConsolidatedPayoutData( referrals, productsData );
+		useGetConsolidatedPayoutData( referrals );
 	const { showSupportGuide } = useHelpCenter();
 	const { downloadCommissionsCsv } = useDownloadCommissionsCsv( isSingleClient );
 

--- a/client/a8c-for-agencies/sections/referrals/hooks/test/use-get-consolidated-payout-data.ts
+++ b/client/a8c-for-agencies/sections/referrals/hooks/test/use-get-consolidated-payout-data.ts
@@ -4,26 +4,14 @@
 
 import { renderHook } from '@testing-library/react';
 import * as getEstimatedCommission from '../../lib/get-estimated-commission';
-import * as getNextPayoutDate from '../../lib/get-next-payout-date';
 import useGetConsolidatedPayoutData from '../use-get-consolidated-payout-data';
 import type { Referral } from '../../types';
-import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
-// Mock the dependencies
 jest.mock( '../../lib/get-estimated-commission' );
-jest.mock( '../../lib/get-next-payout-date' );
 
 const mockGetEstimatedCommission =
 	getEstimatedCommission.getEstimatedCommission as jest.MockedFunction<
 		typeof getEstimatedCommission.getEstimatedCommission
-	>;
-const mockGetNextPayoutDateActivityWindow =
-	getNextPayoutDate.getNextPayoutDateActivityWindow as jest.MockedFunction<
-		typeof getNextPayoutDate.getNextPayoutDateActivityWindow
-	>;
-const mockGetCurrentCycleActivityWindow =
-	getNextPayoutDate.getCurrentCycleActivityWindow as jest.MockedFunction<
-		typeof getNextPayoutDate.getCurrentCycleActivityWindow
 	>;
 
 describe( 'useGetConsolidatedPayoutData', () => {
@@ -36,110 +24,49 @@ describe( 'useGetConsolidatedPayoutData', () => {
 					product_id: 1,
 					status: 'active',
 					quantity: 1,
-					license: {
-						issued_at: '2024-01-01T00:00:00Z',
-						revoked_at: null,
-					},
 				},
 				{
 					product_id: 2,
 					status: 'active',
 					quantity: 1,
-					license: {
-						issued_at: '2024-01-15T00:00:00Z',
-						revoked_at: null,
-					},
 				},
 			],
 		},
 	] as never;
 
-	const mockProducts: APIProductFamilyProduct[] = [
-		{
-			product_id: 1,
-			family_slug: 'jetpack-backup',
-			price_per_unit: 100,
-			supported_bundles: [],
-			name: 'Mock Product',
-			slug: 'mock-product',
-			currency: 'USD',
-			amount: '100',
-			price_interval: 'month',
-		},
-		{
-			product_id: 2,
-			family_slug: 'jetpack-security',
-			price_per_unit: 150,
-			supported_bundles: [],
-			name: 'Mock Product 2',
-			slug: 'mock-product-2',
-			currency: 'USD',
-			amount: '150',
-			price_interval: 'month',
-		},
-	];
-
-	const mockActivityWindow = {
-		start: new Date( '2024-01-01' ),
-		finish: new Date( '2024-03-31' ),
-	};
-
 	beforeEach( () => {
 		jest.clearAllMocks();
-		mockGetNextPayoutDateActivityWindow.mockReturnValue( mockActivityWindow );
-		mockGetCurrentCycleActivityWindow.mockReturnValue( mockActivityWindow );
+		// Default mock — `getEstimatedCommission` is dispatched on
+		// `usePreviousQuarter` so individual tests can override per-flag.
 		mockGetEstimatedCommission.mockReturnValue( 50 );
 	} );
 
-	it( 'should calculate previous quarter expected commission', () => {
-		const { result } = renderHook( () =>
-			useGetConsolidatedPayoutData( mockReferrals, mockProducts )
-		);
+	it( 'calls getEstimatedCommission once for each quarter flag', () => {
+		renderHook( () => useGetConsolidatedPayoutData( mockReferrals ) );
 
-		expect( mockGetEstimatedCommission ).toHaveBeenCalledWith(
-			mockReferrals,
-			mockProducts,
-			mockActivityWindow,
-			false // use current quarter
-		);
-		expect( mockGetEstimatedCommission ).toHaveBeenCalledWith(
-			mockReferrals,
-			mockProducts,
-			mockActivityWindow,
-			true // use previous quarter
-		);
-		expect( result.current.previousQuarterExpectedCommission ).toBe( 50 );
+		expect( mockGetEstimatedCommission ).toHaveBeenCalledTimes( 2 );
+		expect( mockGetEstimatedCommission ).toHaveBeenCalledWith( mockReferrals, true );
+		expect( mockGetEstimatedCommission ).toHaveBeenCalledWith( mockReferrals, false );
 	} );
 
-	it( 'should calculate current quarter expected commission', () => {
-		const { result } = renderHook( () =>
-			useGetConsolidatedPayoutData( mockReferrals, mockProducts )
+	it( 'returns the previous-quarter and current-quarter commissions from getEstimatedCommission', () => {
+		mockGetEstimatedCommission.mockImplementation( ( _referrals, usePreviousQuarter ) =>
+			usePreviousQuarter ? 75 : 50
 		);
 
-		expect( mockGetEstimatedCommission ).toHaveBeenCalledWith(
-			mockReferrals,
-			mockProducts,
-			mockActivityWindow,
-			false // use current quarter
-		);
-		expect( mockGetEstimatedCommission ).toHaveBeenCalledWith(
-			mockReferrals,
-			mockProducts,
-			mockActivityWindow,
-			true // use previous quarter
-		);
+		const { result } = renderHook( () => useGetConsolidatedPayoutData( mockReferrals ) );
+
+		expect( result.current.previousQuarterExpectedCommission ).toBe( 75 );
 		expect( result.current.currentQuarterExpectedCommission ).toBe( 50 );
 	} );
 
-	it( 'should calculate pending orders count', () => {
-		const { result } = renderHook( () =>
-			useGetConsolidatedPayoutData( mockReferrals, mockProducts )
-		);
+	it( 'counts pending referral statuses as pendingOrders', () => {
+		const { result } = renderHook( () => useGetConsolidatedPayoutData( mockReferrals ) );
 
 		expect( result.current.pendingOrders ).toBe( 1 );
 	} );
 
-	it( 'should handle multiple referrals with mixed statuses', () => {
+	it( 'sums pendingOrders across multiple referrals', () => {
 		const multipleReferrals: Referral[] = [
 			{
 				referralStatuses: [ 'active', 'pending' ],
@@ -158,83 +85,9 @@ describe( 'useGetConsolidatedPayoutData', () => {
 			},
 		] as never;
 
-		const { result } = renderHook( () =>
-			useGetConsolidatedPayoutData( multipleReferrals, mockProducts )
-		);
+		const { result } = renderHook( () => useGetConsolidatedPayoutData( multipleReferrals ) );
 
-		// Should count 3 pending orders (1 from first referral, 2 from second referral)
+		// 1 from the first referral + 2 from the second = 3.
 		expect( result.current.pendingOrders ).toBe( 3 );
-	} );
-
-	it( 'should handle scenario where one purchase was revoked in previous quarter', () => {
-		const referralsWithRevokedPurchase: Referral[] = [
-			{
-				referralStatuses: [ 'active', 'pending' ],
-				purchaseStatuses: [ 'active', 'revoked' ],
-				purchases: [
-					{
-						product_id: 1,
-						status: 'active',
-						quantity: 1,
-						license: {
-							issued_at: '2024-01-01T00:00:00Z',
-							revoked_at: null,
-						},
-					},
-					{
-						product_id: 2,
-						status: 'revoked',
-						quantity: 1,
-						license: {
-							issued_at: '2024-01-15T00:00:00Z',
-							revoked_at: '2024-02-15T00:00:00Z', // Revoked in previous quarter
-						},
-					},
-				],
-			},
-		] as never;
-
-		// Mock different activity windows for previous and current quarter
-		const previousQuarterWindow = {
-			start: new Date( '2024-01-01' ),
-			finish: new Date( '2024-03-31' ),
-		};
-		const currentQuarterWindow = {
-			start: new Date( '2024-04-01' ),
-			finish: new Date( '2024-06-30' ),
-		};
-
-		mockGetNextPayoutDateActivityWindow.mockReturnValue( previousQuarterWindow );
-		mockGetCurrentCycleActivityWindow.mockReturnValue( currentQuarterWindow );
-
-		// Mock commission calculation - previous quarter should have 2 products, current should have 1
-		mockGetEstimatedCommission.mockImplementation( ( referrals, products, activityWindow ) => {
-			if ( activityWindow === previousQuarterWindow ) {
-				return 75; // Commission for 2 products (before revocation)
-			} else if ( activityWindow === currentQuarterWindow ) {
-				return 50; // Commission for 1 product (after revocation)
-			}
-			return 0;
-		} );
-
-		const { result } = renderHook( () =>
-			useGetConsolidatedPayoutData( referralsWithRevokedPurchase, mockProducts )
-		);
-
-		expect( mockGetEstimatedCommission ).toHaveBeenCalledWith(
-			referralsWithRevokedPurchase,
-			mockProducts,
-			currentQuarterWindow,
-			false // use current quarter
-		);
-		expect( mockGetEstimatedCommission ).toHaveBeenCalledWith(
-			referralsWithRevokedPurchase,
-			mockProducts,
-			previousQuarterWindow,
-			true // use previous quarter
-		);
-		expect( result.current.previousQuarterExpectedCommission ).toBe( 75 );
-		expect( result.current.currentQuarterExpectedCommission ).toBe( 50 );
-		expect( result.current.pendingOrders ).toBe( 1 ); // Only 1 pending order (active status)
 	} );
 } );

--- a/client/a8c-for-agencies/sections/referrals/hooks/use-get-consolidated-payout-data.ts
+++ b/client/a8c-for-agencies/sections/referrals/hooks/use-get-consolidated-payout-data.ts
@@ -1,35 +1,14 @@
 import { useMemo } from 'react';
 import { getEstimatedCommission } from '../lib/get-estimated-commission';
-import {
-	getCurrentCycleActivityWindow,
-	getNextPayoutDateActivityWindow,
-} from '../lib/get-next-payout-date';
 import { Referral } from '../types';
-import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
-export default function useGetConsolidatedPayoutData(
-	referrals: Referral[],
-	products?: APIProductFamilyProduct[]
-) {
+export default function useGetConsolidatedPayoutData( referrals: Referral[] ) {
 	const { previousQuarterExpectedCommission, currentQuarterExpectedCommission } = useMemo( () => {
-		const currentDate = new Date();
-		const productsArray = products || [];
-
 		return {
-			previousQuarterExpectedCommission: getEstimatedCommission(
-				referrals,
-				productsArray,
-				getNextPayoutDateActivityWindow( currentDate ),
-				true // use previous quarter
-			),
-			currentQuarterExpectedCommission: getEstimatedCommission(
-				referrals,
-				productsArray,
-				getCurrentCycleActivityWindow( currentDate ),
-				false // use current quarter
-			),
+			previousQuarterExpectedCommission: getEstimatedCommission( referrals, true ),
+			currentQuarterExpectedCommission: getEstimatedCommission( referrals, false ),
 		};
-	}, [ referrals, products ] );
+	}, [ referrals ] );
 
 	const pendingOrders = useMemo(
 		() =>

--- a/client/a8c-for-agencies/sections/referrals/lib/get-estimated-commission.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/get-estimated-commission.ts
@@ -1,6 +1,5 @@
 import { APIProductFamilyProduct } from '../../../../state/partner-portal/types';
 import { Referral } from '../types';
-import { getProductCommissionPercentage } from './commissions';
 
 export const getDailyPrice = ( product: APIProductFamilyProduct, quantity: number ) => {
 	// If quantity is not 1 than we search corresponding bundle
@@ -20,7 +19,7 @@ export const getEstimatedCommission = (
 	activityWindow: { start: Date; finish: Date },
 	usePreviousQuarter: boolean = false
 ) => {
-	const { bdCommissions, legacyCommissionsInCents } = referrals.reduce(
+	const { commissions } = referrals.reduce(
 		( acc, referral ) => {
 			if ( ! referral?.purchases?.length ) {
 				return acc;
@@ -37,65 +36,17 @@ export const getEstimatedCommission = (
 					const commissionAmount = usePreviousQuarter
 						? purchase.commissions.estimated_commission_previous_quarter ?? 0
 						: purchase.commissions.estimated_commission_current_quarter ?? 0;
-					acc.bdCommissions += commissionAmount;
-				} else {
-					// Legacy approach, but we need to keep it to continue working with old data
-					// Calculate commission using the license data
-
-					// For legacy calculations, we need to find the corresponding product
-					const product = products.find(
-						( product ) => purchase.product_id === product.product_id
-					);
-					if ( ! product ) {
-						continue;
-					}
-
-					// Day the license was issued
-					const issuedDate = new Date( purchase.license.issued_at );
-					// Set hours to 0 to compare from start of the day
-					issuedDate.setHours( 0, 0, 0, 0 );
-
-					// Day the license was revoked if present
-					const revokedAt = purchase.license.revoked_at
-						? new Date( purchase.license.revoked_at )
-						: null;
-
-					// Start date is the latest of the license issued date and activity window start
-					const start = Math.max( issuedDate.getTime(), activityWindow.start.getTime() );
-					// Finish date is the earliest of the license revoked date and activity window finish
-					const finish = Math.min(
-						revokedAt ? revokedAt.getTime() : Infinity,
-						activityWindow.finish.getTime()
-					);
-
-					// Total days is the difference between finish and start dates in days
-					// We add 1 to include end-to-end days
-					const totalDays = Math.floor( ( finish - start ) / ( 1000 * 60 * 60 * 24 ) ) + 1;
-
-					if ( totalDays < 1 ) {
-						continue;
-					}
-
-					const dailyPrice = getDailyPrice( product, purchase.quantity );
-
-					// Get commission percentage for the product (common for both subscription and license)
-					const commissionPercentage = getProductCommissionPercentage(
-						product.slug,
-						product.family_slug
-					);
-
-					// Add commission to the total commission (in cents)
-					acc.legacyCommissionsInCents += dailyPrice * totalDays * commissionPercentage;
+					acc.commissions += commissionAmount;
 				}
 			}
 			return acc;
 		},
-		{ bdCommissions: 0, legacyCommissionsInCents: 0 }
+		{ commissions: 0 }
 	);
 
 	// Convert commission from cents to dollars,
 	// add subscriptions commission and round to 2 decimal places
-	const totalCommission = Number( ( bdCommissions + legacyCommissionsInCents / 100 ).toFixed( 2 ) );
+	const totalCommission = Number( commissions.toFixed( 2 ) );
 
 	return totalCommission;
 };

--- a/client/a8c-for-agencies/sections/referrals/lib/get-estimated-commission.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/get-estimated-commission.ts
@@ -1,52 +1,40 @@
-import { APIProductFamilyProduct } from '../../../../state/partner-portal/types';
 import { Referral } from '../types';
 
-export const getDailyPrice = ( product: APIProductFamilyProduct, quantity: number ) => {
-	// If quantity is not 1 than we search corresponding bundle
-	if ( quantity !== 1 ) {
-		return (
-			product.supported_bundles.find( ( bundleProduct ) => quantity === bundleProduct.quantity )
-				?.price_per_unit ?? 0
-		);
-	}
-	// If quantity is 1 than we return price per unit
-	return product.price_per_unit ?? 0;
-};
-
+/**
+ * Sum the estimated commissions wpcom returns per referral purchase, for
+ * either the current or previous payout quarter.
+ *
+ * Every purchase carries server-computed `estimated_commission_*_quarter`
+ * numbers as of Aug 2025 — the JS-only legacy fallback (license dates ×
+ * daily price × commission percentage) was removed when wpcom started
+ * computing those numbers for legacy purchases too. Purchases without a
+ * `commissions` block contribute 0 (rather than triggering the old
+ * fallback compute, which was double-counting alongside the BD path in
+ * mixed cases).
+ */
 export const getEstimatedCommission = (
 	referrals: Referral[],
-	products: APIProductFamilyProduct[],
-	activityWindow: { start: Date; finish: Date },
 	usePreviousQuarter: boolean = false
 ) => {
-	const { commissions } = referrals.reduce(
-		( acc, referral ) => {
-			if ( ! referral?.purchases?.length ) {
-				return acc;
-			}
-			for ( const purchase of referral.purchases ) {
-				// We go over 'active' and 'cancelled' subscriptions
-				if ( ! purchase || purchase.status === 'pending' || purchase.status === 'error' ) {
-					continue;
-				}
-				if ( purchase.commissions ) {
-					// As of Aug 2025, new client purchases will use BD for purchases
-					// In this case the estimated commission has already been calculated on the backend
-					// and we just need to add it to the total commission
-					const commissionAmount = usePreviousQuarter
-						? purchase.commissions.estimated_commission_previous_quarter ?? 0
-						: purchase.commissions.estimated_commission_current_quarter ?? 0;
-					acc.commissions += commissionAmount;
-				}
-			}
+	const total = referrals.reduce( ( acc, referral ) => {
+		if ( ! referral?.purchases?.length ) {
 			return acc;
-		},
-		{ commissions: 0 }
-	);
+		}
+		for ( const purchase of referral.purchases ) {
+			// Walk only 'active' / 'cancelled' subscriptions; pending and
+			// error purchases haven't produced commissionable activity.
+			if ( ! purchase || purchase.status === 'pending' || purchase.status === 'error' ) {
+				continue;
+			}
+			if ( ! purchase.commissions ) {
+				continue;
+			}
+			acc += usePreviousQuarter
+				? purchase.commissions.estimated_commission_previous_quarter ?? 0
+				: purchase.commissions.estimated_commission_current_quarter ?? 0;
+		}
+		return acc;
+	}, 0 );
 
-	// Convert commission from cents to dollars,
-	// add subscriptions commission and round to 2 decimal places
-	const totalCommission = Number( commissions.toFixed( 2 ) );
-
-	return totalCommission;
+	return Number( total.toFixed( 2 ) );
 };

--- a/client/a8c-for-agencies/sections/referrals/lib/get-estimated-commission.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/get-estimated-commission.ts
@@ -4,13 +4,6 @@ import { Referral } from '../types';
  * Sum the estimated commissions wpcom returns per referral purchase, for
  * either the current or previous payout quarter.
  *
- * Every purchase carries server-computed `estimated_commission_*_quarter`
- * numbers as of Aug 2025 — the JS-only legacy fallback (license dates ×
- * daily price × commission percentage) was removed when wpcom started
- * computing those numbers for legacy purchases too. Purchases without a
- * `commissions` block contribute 0 (rather than triggering the old
- * fallback compute, which was double-counting alongside the BD path in
- * mixed cases).
  */
 export const getEstimatedCommission = (
 	referrals: Referral[],

--- a/client/a8c-for-agencies/sections/referrals/lib/test/get-estimated-commission.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/test/get-estimated-commission.ts
@@ -1,391 +1,229 @@
-import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
-import { getEstimatedCommission, getDailyPrice } from '../get-estimated-commission';
+import { getEstimatedCommission } from '../get-estimated-commission';
 import type { Referral } from '../../types';
 
-describe( 'get-estimated-commission', () => {
-	describe( 'getDailyPrice', () => {
-		const mockProduct: APIProductFamilyProduct = {
-			product_id: 1,
-			price_per_unit: 100,
-			supported_bundles: [
-				{ quantity: 5, price_per_unit: 90, amount: '90' },
-				{ quantity: 10, price_per_unit: 80, amount: '80' },
-			],
-			name: 'Mock Product',
-			slug: 'mock-product',
-			currency: 'USD',
-			amount: '100',
-			price_interval: 'month',
-			family_slug: 'mock-family',
-		};
-
-		it( 'returns price_per_unit for quantity of 1', () => {
-			expect( getDailyPrice( mockProduct, 1 ) ).toBe( 100 );
-		} );
-
-		it( 'returns bundle price for matching quantity', () => {
-			expect( getDailyPrice( mockProduct, 5 ) ).toBe( 90 );
-			expect( getDailyPrice( mockProduct, 10 ) ).toBe( 80 );
-		} );
-
-		it( 'returns 0 for non-matching quantity', () => {
-			expect( getDailyPrice( mockProduct, 3 ) ).toBe( 0 );
-		} );
-
-		it( 'handles empty supported_bundles', () => {
-			const productWithoutBundles: APIProductFamilyProduct = {
-				...mockProduct,
-				supported_bundles: [],
-			};
-
-			expect( getDailyPrice( productWithoutBundles, 1 ) ).toBe( 100 );
-		} );
+describe( 'getEstimatedCommission', () => {
+	it( 'returns 0 for empty referrals', () => {
+		expect( getEstimatedCommission( [] ) ).toBe( 0 );
 	} );
 
-	describe( 'getEstimatedCommission', () => {
-		// Activity window for Q1 2024 (Jan 1 - Mar 31)
-		const mockActivityWindow = {
-			start: new Date( '2024-01-01' ),
-			finish: new Date( '2024-03-31' ),
-		};
-		const mockProduct: APIProductFamilyProduct = {
-			product_id: 1,
-			family_slug: 'jetpack-scan',
-			price_per_unit: 100,
-			supported_bundles: [],
-			name: 'Jetpack Scan',
-			slug: 'jetpack-scan',
-			currency: 'USD',
-			amount: '100',
-			price_interval: 'month',
-		};
-
-		it( 'returns 0 for empty referrals', () => {
-			expect( getEstimatedCommission( [], [ mockProduct ], mockActivityWindow ) ).toBe( 0 );
-		} );
-
-		it( 'calculates commission for active purchase within window', () => {
-			const referrals: Referral[] = [
-				{
-					purchaseStatuses: [ 'active' ],
-					referralStatuses: [ 'active' ],
-					purchases: [
-						{
-							product_id: 1,
-							status: 'active',
-							quantity: 1,
-							license: {
-								issued_at: '2024-03-01T00:00:00Z',
-								revoked_at: null,
-							},
+	it( 'sums current-quarter commissions across purchases', () => {
+		const referrals: Referral[] = [
+			{
+				purchaseStatuses: [ 'active' ],
+				referralStatuses: [ 'active' ],
+				purchases: [
+					{
+						product_id: 1,
+						status: 'active',
+						quantity: 1,
+						commissions: {
+							estimated_commission_current_quarter: 150,
+							estimated_commission_previous_quarter: 75,
 						},
-					],
-				} as never,
-			];
-
-			// Payout window is Jan 1 - Mar 31 for the activity window
-			// License issued on Mar 1, so 31 days (including Mar 1) * $100 daily price * 50% commission = 1550 cents
-			// Convert to dollars by dividing by 100
-			expect( getEstimatedCommission( referrals, [ mockProduct ], mockActivityWindow ) ).toBe(
-				15.5
-			);
-		} );
-
-		it( 'handles cancelled purchases', () => {
-			const referrals: Referral[] = [
-				{
-					purchaseStatuses: [ 'cancelled' ],
-					referralStatuses: [ 'cancelled' ],
-					purchases: [
-						{
-							product_id: 1,
-							status: 'cancelled',
-							quantity: 1,
-							license: {
-								issued_at: '2024-03-01T00:00:00Z',
-								revoked_at: '2024-03-10T00:00:00Z',
-							},
+					},
+					{
+						product_id: 2,
+						status: 'active',
+						quantity: 1,
+						commissions: {
+							estimated_commission_current_quarter: 200,
+							estimated_commission_previous_quarter: 100,
 						},
-					],
-				},
-			] as never;
+					},
+				],
+			} as never,
+		];
 
-			// 10 days * $100 daily price * 50% commission = 500 cents
-			// Convert to dollars by dividing by 100
-			expect( getEstimatedCommission( referrals, [ mockProduct ], mockActivityWindow ) ).toBe( 5 );
-		} );
+		expect( getEstimatedCommission( referrals ) ).toBe( 350 );
+	} );
 
-		it( 'skips pending purchases', () => {
-			const referrals: Referral[] = [
-				{
-					purchaseStatuses: [ 'pending' ],
-					referralStatuses: [ 'pending' ],
-					purchases: [
-						{
-							product_id: 1,
-							status: 'pending',
-							quantity: 1,
-							license: {
-								issued_at: '2024-03-01T00:00:00Z',
-								revoked_at: null,
-							},
+	it( 'sums previous-quarter commissions when usePreviousQuarter is true', () => {
+		const referrals: Referral[] = [
+			{
+				purchaseStatuses: [ 'active' ],
+				referralStatuses: [ 'active' ],
+				purchases: [
+					{
+						product_id: 1,
+						status: 'active',
+						quantity: 1,
+						commissions: {
+							estimated_commission_current_quarter: 150,
+							estimated_commission_previous_quarter: 75,
 						},
-					],
-				},
-			] as never;
-
-			// Pending purchases should not contribute to commission
-			expect( getEstimatedCommission( referrals, [ mockProduct ], mockActivityWindow ) ).toBe( 0 );
-		} );
-
-		it( 'calculates commission for multiple purchases in single referral', () => {
-			const referrals: Referral[] = [
-				{
-					purchaseStatuses: [ 'active', 'active' ],
-					referralStatuses: [ 'active' ],
-					purchases: [
-						{
-							product_id: 1,
-							status: 'active',
-							quantity: 1,
-							license: {
-								issued_at: '2024-03-01T00:00:00Z',
-								revoked_at: null,
-							},
+					},
+					{
+						product_id: 2,
+						status: 'active',
+						quantity: 1,
+						commissions: {
+							estimated_commission_current_quarter: 200,
+							estimated_commission_previous_quarter: 100,
 						},
-						{
-							product_id: 1,
-							status: 'active',
-							quantity: 1,
-							license: {
-								issued_at: '2024-03-01T00:00:00Z',
-								revoked_at: null,
-							},
+					},
+				],
+			} as never,
+		];
+
+		expect( getEstimatedCommission( referrals, true ) ).toBe( 175 );
+	} );
+
+	it( 'sums commissions across multiple referrals', () => {
+		const referrals: Referral[] = [
+			{
+				purchaseStatuses: [ 'active' ],
+				referralStatuses: [ 'active' ],
+				purchases: [
+					{
+						product_id: 1,
+						status: 'active',
+						quantity: 1,
+						commissions: {
+							estimated_commission_current_quarter: 150,
+							estimated_commission_previous_quarter: 75,
 						},
-					],
-				},
-			] as never;
-
-			// 31 days * $100 daily price * 50% commission * 2 purchases = 3100 cents
-			// Convert to dollars by dividing by 100
-			expect( getEstimatedCommission( referrals, [ mockProduct ], mockActivityWindow ) ).toBe( 31 );
-		} );
-
-		it( 'calculates commission for multiple referrals', () => {
-			const referrals: Referral[] = [
-				{
-					purchaseStatuses: [ 'active' ],
-					referralStatuses: [ 'active' ],
-					purchases: [
-						{
-							product_id: 1,
-							status: 'active',
-							quantity: 1,
-							license: {
-								issued_at: '2024-03-01T00:00:00Z',
-								revoked_at: null,
-							},
+					},
+				],
+			} as never,
+			{
+				purchaseStatuses: [ 'active' ],
+				referralStatuses: [ 'active' ],
+				purchases: [
+					{
+						product_id: 1,
+						status: 'active',
+						quantity: 1,
+						commissions: {
+							estimated_commission_current_quarter: 200,
+							estimated_commission_previous_quarter: 100,
 						},
-					],
-				},
-				{
-					purchaseStatuses: [ 'active' ],
-					referralStatuses: [ 'active' ],
-					purchases: [
-						{
-							product_id: 1,
-							status: 'active',
-							quantity: 1,
-							license: {
-								issued_at: '2024-03-01T00:00:00Z',
-								revoked_at: null,
-							},
+					},
+				],
+			} as never,
+		];
+
+		expect( getEstimatedCommission( referrals ) ).toBe( 350 );
+	} );
+
+	it( 'includes cancelled purchases', () => {
+		// Cancelled purchases still contribute commissions for the days they
+		// were active (the server-side compute already accounts for the
+		// revoked window).
+		const referrals: Referral[] = [
+			{
+				purchaseStatuses: [ 'cancelled' ],
+				referralStatuses: [ 'cancelled' ],
+				purchases: [
+					{
+						product_id: 1,
+						status: 'cancelled',
+						quantity: 1,
+						commissions: {
+							estimated_commission_current_quarter: 50,
+							estimated_commission_previous_quarter: 25,
 						},
-					],
-				},
-			] as never;
+					},
+				],
+			} as never,
+		];
 
-			// 31 days * $100 daily price * 50% commission * 2 referrals = 3100 cents
-			// Convert to dollars by dividing by 100
-			expect( getEstimatedCommission( referrals, [ mockProduct ], mockActivityWindow ) ).toBe( 31 );
-		} );
+		expect( getEstimatedCommission( referrals ) ).toBe( 50 );
+	} );
 
-		it( 'calculates commission with bundle pricing', () => {
-			const productWithBundle: APIProductFamilyProduct = {
-				...mockProduct,
-				supported_bundles: [ { quantity: 5, price_per_unit: 90, amount: '90' } ],
-			};
-
-			const referrals: Referral[] = [
-				{
-					purchaseStatuses: [ 'active' ],
-					referralStatuses: [ 'active' ],
-					purchases: [
-						{
-							product_id: 1,
-							status: 'active',
-							quantity: 5,
-							license: {
-								issued_at: '2024-03-01T00:00:00Z',
-								revoked_at: null,
-							},
+	it( 'skips pending purchases', () => {
+		const referrals: Referral[] = [
+			{
+				purchaseStatuses: [ 'pending' ],
+				referralStatuses: [ 'pending' ],
+				purchases: [
+					{
+						product_id: 1,
+						status: 'pending',
+						quantity: 1,
+						commissions: {
+							estimated_commission_current_quarter: 999,
+							estimated_commission_previous_quarter: 999,
 						},
-					],
-				},
-			] as never;
+					},
+				],
+			} as never,
+		];
 
-			// 31 days * $90 daily price * 50% commission = 1395 cents
-			// Convert to dollars by dividing by 100
-			expect( getEstimatedCommission( referrals, [ productWithBundle ], mockActivityWindow ) ).toBe(
-				13.95
-			);
-		} );
+		expect( getEstimatedCommission( referrals ) ).toBe( 0 );
+	} );
 
-		it( 'uses API commissions data when available', () => {
-			const referrals: Referral[] = [
-				{
-					client: { id: 1, email: 'test@example.com' },
-					purchaseStatuses: [ 'active' ],
-					referralStatuses: [ 'active' ],
-					purchases: [
-						{
-							product_id: 1,
-							status: 'active',
-							quantity: 1,
-							license: {
-								issued_at: '2024-03-01T00:00:00Z',
-								revoked_at: null,
-							},
-							commissions: {
-								estimated_commission_current_quarter: 150,
-								estimated_commission_previous_quarter: 75,
-							},
+	it( 'skips error purchases', () => {
+		const referrals: Referral[] = [
+			{
+				purchaseStatuses: [ 'error' ],
+				referralStatuses: [ 'active' ],
+				purchases: [
+					{
+						product_id: 1,
+						status: 'error',
+						quantity: 1,
+						commissions: {
+							estimated_commission_current_quarter: 999,
+							estimated_commission_previous_quarter: 999,
 						},
-					],
-				} as never,
-				{
-					client: { id: 2, email: 'test2@example.com' },
-					purchaseStatuses: [ 'active' ],
-					referralStatuses: [ 'active' ],
-					purchases: [
-						{
-							product_id: 1,
-							status: 'active',
-							quantity: 1,
-							license: {
-								issued_at: '2024-03-01T00:00:00Z',
-								revoked_at: null,
-							},
-							commissions: {
-								estimated_commission_current_quarter: 200,
-								estimated_commission_previous_quarter: 100,
-							},
+					},
+				],
+			} as never,
+		];
+
+		expect( getEstimatedCommission( referrals ) ).toBe( 0 );
+	} );
+
+	it( 'contributes 0 for purchases without a commissions block', () => {
+		// In production every purchase carries server-supplied commissions.
+		// Defensive coverage for the rare case where the field is missing —
+		// must contribute 0 rather than fall back to the (now-removed) JS
+		// compute that double-counted alongside the BD branch.
+		const referrals: Referral[] = [
+			{
+				purchaseStatuses: [ 'active' ],
+				referralStatuses: [ 'active' ],
+				purchases: [
+					{
+						product_id: 1,
+						status: 'active',
+						quantity: 1,
+					},
+				],
+			} as never,
+		];
+
+		expect( getEstimatedCommission( referrals ) ).toBe( 0 );
+	} );
+
+	it( 'rounds the total to 2 decimal places', () => {
+		const referrals: Referral[] = [
+			{
+				purchaseStatuses: [ 'active' ],
+				referralStatuses: [ 'active' ],
+				purchases: [
+					{
+						product_id: 1,
+						status: 'active',
+						quantity: 1,
+						commissions: {
+							estimated_commission_current_quarter: 10.111,
+							estimated_commission_previous_quarter: 5,
 						},
-					],
-				} as never,
-			];
-
-			// Should use the sum of current quarter commissions from API
-			expect(
-				getEstimatedCommission( referrals, [ mockProduct ], mockActivityWindow, false )
-			).toBe( 350 );
-
-			// Should use the sum of previous quarter commissions from API
-			expect( getEstimatedCommission( referrals, [ mockProduct ], mockActivityWindow, true ) ).toBe(
-				175
-			);
-		} );
-
-		it( 'combines API commissions with calculated commissions', () => {
-			const referrals: Referral[] = [
-				{
-					client: { id: 1, email: 'test@example.com' },
-					purchaseStatuses: [ 'active' ],
-					referralStatuses: [ 'active' ],
-					purchases: [
-						{
-							product_id: 1,
-							status: 'active',
-							quantity: 1,
-							license: {
-								issued_at: '2024-03-01T00:00:00Z',
-								revoked_at: null,
-							},
-							commissions: {
-								estimated_commission_current_quarter: 150,
-								estimated_commission_previous_quarter: 75,
-							},
+					},
+					{
+						product_id: 2,
+						status: 'active',
+						quantity: 1,
+						commissions: {
+							estimated_commission_current_quarter: 20.222,
+							estimated_commission_previous_quarter: 5,
 						},
-					],
-				} as never,
-				{
-					client: { id: 2, email: 'test2@example.com' },
-					purchaseStatuses: [ 'active' ],
-					referralStatuses: [ 'active' ],
-					purchases: [
-						{
-							product_id: 1,
-							status: 'active',
-							quantity: 1,
-							license: {
-								issued_at: '2024-03-01T00:00:00Z',
-								revoked_at: null,
-							},
-							// Missing commissions data - will be calculated
-						},
-					],
-				} as never,
-			];
+					},
+				],
+			} as never,
+		];
 
-			// Should combine API commissions (150) + calculated commissions (15.5) = 165.5
-			expect(
-				getEstimatedCommission( referrals, [ mockProduct ], mockActivityWindow, false )
-			).toBe( 165.5 );
-
-			// Should combine API commissions (75) + calculated commissions (15.5) = 90.5
-			expect( getEstimatedCommission( referrals, [ mockProduct ], mockActivityWindow, true ) ).toBe(
-				90.5
-			);
-		} );
-
-		it( 'falls back to calculation when no referrals have commissions data', () => {
-			const referrals: Referral[] = [
-				{
-					purchaseStatuses: [ 'active' ],
-					referralStatuses: [ 'active' ],
-					purchases: [
-						{
-							product_id: 1,
-							status: 'active',
-							quantity: 1,
-							license: {
-								issued_at: '2024-03-01T00:00:00Z',
-								revoked_at: null,
-							},
-						},
-					],
-				} as never,
-				{
-					purchaseStatuses: [ 'active' ],
-					referralStatuses: [ 'active' ],
-					purchases: [
-						{
-							product_id: 1,
-							status: 'active',
-							quantity: 1,
-							license: {
-								issued_at: '2024-03-01T00:00:00Z',
-								revoked_at: null,
-							},
-						},
-					],
-				} as never,
-			];
-
-			// Should fall back to calculation method
-			// 31 days * $100 daily price * 50% commission * 2 referrals = 3100 cents
-			// Convert to dollars by dividing by 100
-			expect( getEstimatedCommission( referrals, [ mockProduct ], mockActivityWindow ) ).toBe( 31 );
-		} );
+		expect( getEstimatedCommission( referrals ) ).toBe( 30.33 );
 	} );
 } );

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/commissions-column.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/commissions-column.tsx
@@ -2,30 +2,23 @@ import { Tooltip } from '@automattic/components';
 import { formatCurrency } from '@automattic/number-formatters';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useState } from 'react';
-import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
-import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
 import useGetConsolidatedPayoutData from '../hooks/use-get-consolidated-payout-data';
 import useGetPayoutData from '../hooks/use-get-payout-data';
 import type { Referral } from '../types';
 
 export default function CommissionsColumn( { referral }: { referral: Referral } ) {
 	const translate = useTranslate();
-	const { data, isFetching } = useProductsQuery( false, true );
 	const tooltipRef = useRef< HTMLSpanElement >( null );
 	const [ showTooltip, setShowTooltip ] = useState( false );
 
 	const { previousQuarterExpectedCommission, currentQuarterExpectedCommission } =
-		useGetConsolidatedPayoutData( [ referral ], data );
+		useGetConsolidatedPayoutData( [ referral ] );
 
 	const { areNextAndCurrentPayoutDatesEqual } = useGetPayoutData();
 
 	const totalPendingCommission = areNextAndCurrentPayoutDatesEqual
 		? formatCurrency( currentQuarterExpectedCommission, 'USD' )
 		: formatCurrency( previousQuarterExpectedCommission + currentQuarterExpectedCommission, 'USD' );
-
-	if ( isFetching ) {
-		return <TextPlaceholder />;
-	}
 
 	return (
 		<>


### PR DESCRIPTION
## Summary

Removes the JS-only legacy commission compute in `getEstimatedCommission` (and the surface that fed it) now that wpcom returns server-computed commissions for legacy non-BD purchases too. Every purchase now carries `estimated_commission_*_quarter`; the JS fallback (license dates × daily price × commission percentage) was both unreachable in production.

## Changes

- **`getEstimatedCommission`** (`lib/get-estimated-commission.ts`):
  - Drop the legacy `else` branch that computed commissions from license dates + daily price.
  - Drop the `products` and `activityWindow` parameters — no longer read.
  - Drop the `getDailyPrice` export and `APIProductFamilyProduct` import — only the legacy branch used them.
- **`useGetConsolidatedPayoutData`** (hook): drop the `products` parameter and the `getCurrentCycleActivityWindow`/`getNextPayoutDateActivityWindow` imports it no longer needs.
- **`CommissionsColumn`**: drop `useProductsQuery` — the loading state was only there to gate commission compute on product pricing.
- **Tests**:
  - `lib/test/get-estimated-commission.ts`: rewritten to cover the new surface — sums per-purchase commissions for the requested quarter, skips pending/error purchases, contributes 0 for purchases without a `commissions` block.
  - `hooks/test/use-get-consolidated-payout-data.ts`: simplified to mock only `getEstimatedCommission` and assert on the new `(referrals, usePreviousQuarter)` call shape.

## Why are these changes being made?

The legacy compute branch was unreachable: as of, `Referral_Product::get_commissions()` falls through to a server-side `compute_legacy_commissions()` for every non-BD purchase, so every `purchase.commissions` block is populated. Dropping the dead path also removes the `products` parameter chain that was being threaded through the hook and column for no remaining reason.

## Testing instructions

- Open the A4A live link > Go to Referrals
- Verify the Referrals page still shows the same per-row commission values it did before (numbers come from the same server-supplied `estimated_commission_*_quarter` fields).
- Verify the Referrals row no longer shows a brief loading skeleton waiting on the products query.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)