### PR TITLE
Reader: add activity streak display on achievements page (RSM-396)

### DIFF
--- a/client/data/reader/use-achievements-query.ts
+++ b/client/data/reader/use-achievements-query.ts
@@ -29,6 +29,7 @@ export function useAchievementsQuery(
 		achievements: query.data?.pages.flatMap( ( p ) => p.achievements ?? [] ) ?? [],
 		lockedAchievements: query.data?.pages[ 0 ]?.locked_achievements ?? [],
 		yearsOfService: query.data?.pages[ 0 ]?.years_of_service,
+		engagementStreak: query.data?.pages[ 0 ]?.engagement_streak,
 		found: query.data?.pages[ 0 ]?.found ?? 0,
 		isLoading: query.isLoading,
 		isError: query.isError,

--- a/client/reader/user-profile/views/achievements/activity-streak-pill/index.tsx
+++ b/client/reader/user-profile/views/achievements/activity-streak-pill/index.tsx
@@ -1,0 +1,135 @@
+import { Tooltip } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import type { EngagementStreak } from '@automattic/api-core';
+
+import './style.scss';
+
+interface ActivityStreakPillProps {
+	streak: EngagementStreak | undefined;
+	isOwnProfile: boolean;
+}
+
+const SEPARATOR = ' · ';
+
+export function ActivityStreakPill( { streak, isOwnProfile }: ActivityStreakPillProps ) {
+	const translate = useTranslate();
+	const moment = useLocalizedMoment();
+
+	if ( ! streak ) {
+		return null;
+	}
+
+	if ( streak.current_streak === 0 && ! isOwnProfile ) {
+		return null;
+	}
+
+	if ( streak.current_streak === 0 ) {
+		return (
+			<div
+				className="activity-streak-pill activity-streak-pill--coaching"
+				role="group"
+				aria-label={ translate( 'Activity streak' ) }
+			>
+				<div className="activity-streak-pill__headline">
+					<span className="activity-streak-pill__emoji" aria-hidden="true">
+						🔥
+					</span>
+					<span>{ translate( 'Start your activity streak today' ) }</span>
+				</div>
+				<div className="activity-streak-pill__sub-line">
+					{ translate( 'Like, comment, follow, or post — anything counts.' ) }
+				</div>
+			</div>
+		);
+	}
+
+	let freezeChip: string;
+	if ( streak.freezes_available > 0 ) {
+		freezeChip = translate( '%(count)d freeze available', '%(count)d freezes available', {
+			count: streak.freezes_available,
+			args: { count: streak.freezes_available },
+			comment:
+				'Sub-line chip on the activity streak pill. Shown when the user has banked streak freezes. Example: "1 freeze available" or "2 freezes available".',
+		} ) as string;
+	} else if ( streak.freeze_used_date && streak.next_freeze_in_days >= 1 ) {
+		freezeChip = translate( 'freeze used %(relative)s', {
+			args: { relative: moment( streak.freeze_used_date ).fromNow() },
+			comment:
+				'Sub-line chip on the activity streak pill. Shown when the user recently used a streak freeze to cover a missed day. %(relative)s is a relative time like "yesterday" or "2 days ago".',
+		} ) as string;
+	} else {
+		freezeChip = translate( 'next freeze in %(count)d day', 'next freeze in %(count)d days', {
+			count: streak.next_freeze_in_days,
+			args: { count: streak.next_freeze_in_days },
+			comment:
+				'Sub-line chip on the activity streak pill. Shown when the user has no freeze banked and is climbing toward earning the next one.',
+		} ) as string;
+	}
+
+	const subLineChips: string[] = [];
+	if ( streak.longest_streak !== streak.current_streak ) {
+		subLineChips.push(
+			translate( 'Longest %(count)d', {
+				args: { count: streak.longest_streak },
+				comment:
+					'Abbreviated label for the longest activity streak count shown in the streak pill. Example: "Longest 28" means the user\'s longest streak was 28 days.',
+			} ) as string
+		);
+	}
+	subLineChips.push( freezeChip );
+
+	const streakExplainer = translate(
+		'Like, comment, follow, or post — anything counts.'
+	) as string;
+	const freezeExplainer = translate(
+		'A streak freeze automatically protects your streak when you miss a day.'
+	) as string;
+	const freezeEarnAppend =
+		streak.next_freeze_in_days > 0
+			? ( translate(
+					'You will earn one in %(count)d more active day.',
+					'You will earn one in %(count)d more active days.',
+					{
+						count: streak.next_freeze_in_days,
+						args: { count: streak.next_freeze_in_days },
+						comment:
+							'Trailing sentence appended to the activity-streak pill tooltip when the user has no freeze banked. Tells them how many more active days until they earn one.',
+					}
+			  ) as string )
+			: '';
+	const freezeLine = [ freezeExplainer, freezeEarnAppend ].filter( Boolean ).join( ' ' );
+	const tooltipContent = (
+		<span className="activity-streak-pill__tooltip">
+			<span className="activity-streak-pill__tooltip-line">{ streakExplainer }</span>
+			<span className="activity-streak-pill__tooltip-line">{ freezeLine }</span>
+		</span>
+	);
+
+	return (
+		// @wordpress/components types Tooltip's `text` as `string`, but the runtime
+		// accepts a ReactNode. Pass the JSX wrapper so we can control width and stack
+		// the two sentences. Cast keeps the build green without changing behavior.
+		<Tooltip text={ tooltipContent as unknown as string }>
+			<div
+				className="activity-streak-pill"
+				role="group"
+				aria-label={ translate( 'Activity streak' ) }
+				tabIndex={ 0 } // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
+			>
+				<div className="activity-streak-pill__headline">
+					<span className="activity-streak-pill__emoji" aria-hidden="true">
+						🔥
+					</span>
+					<span>
+						{ translate( '{{strong}}%(count)d{{/strong}}-day activity streak', {
+							args: { count: streak.current_streak },
+							components: { strong: <strong /> },
+						} ) }
+					</span>
+				</div>
+				<div className="activity-streak-pill__sub-line">{ subLineChips.join( SEPARATOR ) }</div>
+			</div>
+		</Tooltip>
+	);
+}

--- a/client/reader/user-profile/views/achievements/activity-streak-pill/style.scss
+++ b/client/reader/user-profile/views/achievements/activity-streak-pill/style.scss
@@ -1,0 +1,61 @@
+.activity-streak-pill {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	padding-block: 24px;
+	padding-inline: 24px;
+	border: 1px solid var(--color-border-subtle);
+	border-radius: 8px;
+	color: var(--color-text);
+	min-width: 0;
+	min-height: 148px;
+	box-sizing: border-box;
+}
+
+.activity-streak-pill__headline {
+	display: flex;
+	align-items: baseline;
+	gap: 8px;
+	font-size: 24px;
+	font-weight: 500;
+	line-height: 1.2;
+
+	strong {
+		font-weight: 700;
+	}
+}
+
+.activity-streak-pill__emoji {
+	font-size: 24px;
+	line-height: 1;
+}
+
+.activity-streak-pill__sub-line {
+	margin-block-start: 8px;
+	font-size: 14px;
+	color: var(--color-text-subtle);
+	line-height: 1.3;
+}
+
+.activity-streak-pill[tabindex] {
+	cursor: help;
+
+	&:focus-visible {
+		outline: 2px solid var(--color-accent);
+		outline-offset: 2px;
+	}
+}
+
+.activity-streak-pill__tooltip {
+	display: block;
+	max-width: 220px;
+	white-space: normal;
+}
+
+.activity-streak-pill__tooltip-line {
+	display: block;
+
+	& + & {
+		margin-block-start: 6px;
+	}
+}

--- a/client/reader/user-profile/views/achievements/activity-streak-pill/test/index.test.tsx
+++ b/client/reader/user-profile/views/achievements/activity-streak-pill/test/index.test.tsx
@@ -1,0 +1,221 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ActivityStreakPill } from '../index';
+import type { EngagementStreak } from '@automattic/api-core';
+
+const baseStreak: EngagementStreak = {
+	current_streak: 12,
+	longest_streak: 28,
+	freezes_available: 1,
+	freeze_used_date: null,
+	next_freeze_in_days: 5,
+};
+
+describe( 'ActivityStreakPill', () => {
+	test( 'renders nothing when streak is undefined', () => {
+		const { container } = render( <ActivityStreakPill streak={ undefined } isOwnProfile /> );
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	test( 'renders nothing when current_streak is 0 and not own profile', () => {
+		const { container } = render(
+			<ActivityStreakPill
+				streak={ { ...baseStreak, current_streak: 0, longest_streak: 4 } }
+				isOwnProfile={ false }
+			/>
+		);
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	test( 'renders the active two-line pill with headline and sub-line when current_streak > 0', () => {
+		render( <ActivityStreakPill streak={ baseStreak } isOwnProfile /> );
+
+		const group = screen.getByRole( 'group', { name: 'Activity streak' } );
+		expect( group ).toBeVisible();
+		expect( group ).toHaveTextContent( '12-day activity streak' );
+		expect( group ).toHaveTextContent( 'Longest 28' );
+	} );
+
+	describe( 'freeze chip', () => {
+		test( 'shows "1 freeze available" when freezes_available is 1', () => {
+			render(
+				<ActivityStreakPill streak={ { ...baseStreak, freezes_available: 1 } } isOwnProfile />
+			);
+			expect( screen.getByText( /1 freeze available/ ) ).toBeVisible();
+		} );
+
+		test( 'pluralizes "freezes available" for freezes_available > 1', () => {
+			render(
+				<ActivityStreakPill streak={ { ...baseStreak, freezes_available: 2 } } isOwnProfile />
+			);
+			expect( screen.getByText( /2 freezes available/ ) ).toBeVisible();
+		} );
+
+		test( 'shows "freeze used <relative>" when freeze_used_date is set and in cooldown', () => {
+			jest.useFakeTimers().setSystemTime( new Date( '2026-05-11T12:00:00Z' ) );
+			render(
+				<ActivityStreakPill
+					streak={ {
+						...baseStreak,
+						freezes_available: 0,
+						freeze_used_date: '2026-05-10T08:00:00Z',
+						next_freeze_in_days: 6,
+					} }
+					isOwnProfile
+				/>
+			);
+			expect( screen.getByText( /freeze used .+ago|freeze used yesterday/i ) ).toBeVisible();
+			jest.useRealTimers();
+		} );
+
+		test( 'shows "next freeze in N days" when no freeze banked and none recently used', () => {
+			render(
+				<ActivityStreakPill
+					streak={ {
+						...baseStreak,
+						freezes_available: 0,
+						freeze_used_date: null,
+						next_freeze_in_days: 4,
+					} }
+					isOwnProfile
+				/>
+			);
+			expect( screen.getByText( /next freeze in 4 days/i ) ).toBeVisible();
+		} );
+
+		test( 'pluralizes "next freeze in 1 day" (singular)', () => {
+			render(
+				<ActivityStreakPill
+					streak={ {
+						...baseStreak,
+						freezes_available: 0,
+						freeze_used_date: null,
+						next_freeze_in_days: 1,
+					} }
+					isOwnProfile
+				/>
+			);
+			expect( screen.getByText( /next freeze in 1 day(?!s)/i ) ).toBeVisible();
+		} );
+	} );
+
+	test( 'renders the coaching CTA when current_streak is 0 and own profile', () => {
+		render(
+			<ActivityStreakPill
+				streak={ { ...baseStreak, current_streak: 0, longest_streak: 0 } }
+				isOwnProfile
+			/>
+		);
+		const group = screen.getByRole( 'group', { name: 'Activity streak' } );
+		expect( group ).toBeVisible();
+		expect( group ).toHaveTextContent( 'Start your activity streak today' );
+		expect( group ).toHaveTextContent( 'Like, comment, follow, or post — anything counts.' );
+	} );
+
+	test( 'omits the "Longest" segment when longest_streak equals current_streak', () => {
+		render(
+			<ActivityStreakPill
+				streak={ { ...baseStreak, current_streak: 5, longest_streak: 5 } }
+				isOwnProfile
+			/>
+		);
+		const group = screen.getByRole( 'group', { name: 'Activity streak' } );
+		expect( group ).toBeVisible();
+		expect( group ).toHaveTextContent( '5-day activity streak' );
+		expect( screen.queryByText( /Longest 5/ ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'includes the "Longest" segment when longest_streak differs from current_streak', () => {
+		render(
+			<ActivityStreakPill
+				streak={ { ...baseStreak, current_streak: 5, longest_streak: 28 } }
+				isOwnProfile
+			/>
+		);
+		expect( screen.getByText( /Longest 28/ ) ).toBeVisible();
+	} );
+
+	test( 'emoji glyphs in the active pill are hidden from assistive tech', () => {
+		render( <ActivityStreakPill streak={ baseStreak } isOwnProfile /> );
+		const emoji = screen.getByText( '🔥' );
+		expect( emoji ).toHaveAttribute( 'aria-hidden', 'true' );
+	} );
+
+	describe( 'tooltip', () => {
+		test( 'active pill is focusable so the tooltip is keyboard-accessible', () => {
+			render( <ActivityStreakPill streak={ baseStreak } isOwnProfile /> );
+			expect( screen.getByRole( 'group', { name: 'Activity streak' } ) ).toHaveAttribute(
+				'tabindex',
+				'0'
+			);
+		} );
+
+		test( 'coaching CTA is not focusable (no tooltip)', () => {
+			render(
+				<ActivityStreakPill
+					streak={ { ...baseStreak, current_streak: 0, longest_streak: 0 } }
+					isOwnProfile
+				/>
+			);
+			expect( screen.getByRole( 'group', { name: 'Activity streak' } ) ).not.toHaveAttribute(
+				'tabindex'
+			);
+		} );
+
+		test( 'hovering the active pill reveals streak-day and freeze explainers', async () => {
+			const user = userEvent.setup();
+			render( <ActivityStreakPill streak={ baseStreak } isOwnProfile /> );
+			await user.hover( screen.getByRole( 'group', { name: 'Activity streak' } ) );
+			expect(
+				await screen.findByText( /Like, comment, follow, or post — anything counts\./i )
+			).toBeVisible();
+			expect(
+				screen.getByText(
+					/A streak freeze automatically protects your streak when you miss a day\./i
+				)
+			).toBeVisible();
+		} );
+
+		test( 'tooltip appends "earn one in N more active days" when next_freeze_in_days > 0', async () => {
+			const user = userEvent.setup();
+			render(
+				<ActivityStreakPill
+					streak={ {
+						...baseStreak,
+						freezes_available: 0,
+						freeze_used_date: null,
+						next_freeze_in_days: 4,
+					} }
+					isOwnProfile
+				/>
+			);
+			await user.hover( screen.getByRole( 'group', { name: 'Activity streak' } ) );
+			expect(
+				await screen.findByText( /You will earn one in 4 more active days\./i )
+			).toBeVisible();
+		} );
+
+		test( 'tooltip omits the earn-one append when next_freeze_in_days is 0', async () => {
+			const user = userEvent.setup();
+			render(
+				<ActivityStreakPill
+					streak={ {
+						...baseStreak,
+						freezes_available: 1,
+						freeze_used_date: null,
+						next_freeze_in_days: 0,
+					} }
+					isOwnProfile
+				/>
+			);
+			await user.hover( screen.getByRole( 'group', { name: 'Activity streak' } ) );
+			await screen.findByText(
+				/A streak freeze automatically protects your streak when you miss a day\./i
+			);
+			expect( screen.queryByText( /You will earn one in/i ) ).not.toBeInTheDocument();
+		} );
+	} );
+} );

--- a/client/reader/user-profile/views/achievements/index.tsx
+++ b/client/reader/user-profile/views/achievements/index.tsx
@@ -5,6 +5,7 @@ import useAchievementsVisibility from 'calypso/reader/components/achievements/us
 import { YearsOfServiceBadge } from 'calypso/reader/components/achievements/years-of-service-badge';
 import AchievementsGrid from './achievements-grid';
 import AchievementsSettings from './achievements-settings';
+import { ActivityStreakPill } from './activity-streak-pill';
 import type { ReaderUser } from '@automattic/api-core';
 
 import './style.scss';
@@ -16,9 +17,12 @@ interface UserAchievementsProps {
 const UserAchievements = ( { user }: UserAchievementsProps ): JSX.Element | null => {
 	const translate = useTranslate();
 	const { isOwnProfile, isVisible, isLoading } = useAchievementsVisibility( user.user_login );
-	const { yearsOfService } = useAchievementsQuery( isVisible ? user.user_login : undefined, {
-		refetchOnMount: 'always',
-	} );
+	const { yearsOfService, engagementStreak } = useAchievementsQuery(
+		isVisible ? user.user_login : undefined,
+		{
+			refetchOnMount: 'always',
+		}
+	);
 
 	if ( isLoading ) {
 		return (
@@ -38,6 +42,7 @@ const UserAchievements = ( { user }: UserAchievementsProps ): JSX.Element | null
 				{ !! yearsOfService && (
 					<YearsOfServiceBadge size="large" yearsOfService={ yearsOfService } />
 				) }
+				<ActivityStreakPill streak={ engagementStreak } isOwnProfile={ isOwnProfile } />
 				{ isOwnProfile && <AchievementsSettings /> }
 			</div>
 			<AchievementsGrid userLogin={ user.user_login } isOwnProfile={ isOwnProfile } />

--- a/client/reader/user-profile/views/achievements/style.scss
+++ b/client/reader/user-profile/views/achievements/style.scss
@@ -2,14 +2,13 @@
 	.achievements__header {
 		display: flex;
 		flex-wrap: wrap;
-		align-items: center;
-		justify-content: flex-end;
-		gap: 12px;
+		align-items: flex-start;
+		gap: 24px;
 		margin: 16px 0;
+	}
 
-		.years-of-service-badge {
-			margin-bottom: 16px;
-			margin-inline-end: auto;
-		}
+	.achievements__header .activity-streak-pill {
+		flex: 1 1 240px;
+		min-width: 240px;
 	}
 }

--- a/client/reader/user-profile/views/achievements/style.scss
+++ b/client/reader/user-profile/views/achievements/style.scss
@@ -1,8 +1,10 @@
 .is-reader-page {
 	.achievements__header {
 		display: flex;
-		align-items: flex-start;
+		flex-wrap: wrap;
+		align-items: center;
 		justify-content: flex-end;
+		gap: 12px;
 		margin: 16px 0;
 
 		.years-of-service-badge {

--- a/client/reader/user-profile/views/achievements/test/index.test.tsx
+++ b/client/reader/user-profile/views/achievements/test/index.test.tsx
@@ -29,6 +29,15 @@ jest.mock( 'calypso/reader/components/achievements/years-of-service-badge', () =
 	),
 } ) );
 
+const mockStreakPillProps = jest.fn();
+jest.mock( '../activity-streak-pill', () => ( {
+	__esModule: true,
+	ActivityStreakPill: ( props: { streak?: { current_streak: number }; isOwnProfile: boolean } ) => {
+		mockStreakPillProps( props );
+		return <div data-testid="activity-streak-pill" />;
+	},
+} ) );
+
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const useAchievementsVisibility =
 	require( 'calypso/reader/components/achievements/use-achievements-visibility' )
@@ -54,6 +63,7 @@ describe( 'UserAchievements', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		mockAchievementsGridProps.mockClear();
+		mockStreakPillProps.mockClear();
 		useAchievementsQuery.mockReturnValue( {
 			yearsOfService: undefined,
 			lockedAchievements: [],
@@ -192,6 +202,57 @@ describe( 'UserAchievements', () => {
 
 		expect( mockAchievementsGridProps ).toHaveBeenCalledWith(
 			expect.objectContaining( { userLogin: 'test_user', isOwnProfile: false } )
+		);
+	} );
+
+	test( 'renders ActivityStreakPill with the engagement streak slice', () => {
+		useAchievementsVisibility.mockReturnValue( {
+			isOwnProfile: true,
+			isVisible: true,
+			isLoading: false,
+		} );
+		useAchievementsQuery.mockReturnValue( {
+			yearsOfService: undefined,
+			lockedAchievements: [],
+			engagementStreak: {
+				current_streak: 7,
+				longest_streak: 12,
+				freezes_available: 1,
+				freeze_used_date: null,
+				next_freeze_in_days: 0,
+			},
+			isLoading: false,
+		} );
+
+		render( <UserAchievements user={ defaultUser } /> );
+
+		expect( screen.getByTestId( 'activity-streak-pill' ) ).toBeVisible();
+		expect( mockStreakPillProps ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				streak: expect.objectContaining( { current_streak: 7 } ),
+				isOwnProfile: true,
+			} )
+		);
+	} );
+
+	test( 'still renders ActivityStreakPill when engagement streak is undefined (pill self-handles)', () => {
+		useAchievementsVisibility.mockReturnValue( {
+			isOwnProfile: false,
+			isVisible: true,
+			isLoading: false,
+		} );
+		useAchievementsQuery.mockReturnValue( {
+			yearsOfService: undefined,
+			lockedAchievements: [],
+			engagementStreak: undefined,
+			isLoading: false,
+		} );
+
+		render( <UserAchievements user={ defaultUser } /> );
+
+		// Pill is mounted; the pill itself returns null internally when streak is undefined.
+		expect( mockStreakPillProps ).toHaveBeenCalledWith(
+			expect.objectContaining( { streak: undefined, isOwnProfile: false } )
 		);
 	} );
 } );

--- a/packages/api-core/src/read-achievements/types.ts
+++ b/packages/api-core/src/read-achievements/types.ts
@@ -60,10 +60,24 @@ export interface LockedSecretAchievement {
 export type EarnedAchievementEntry = Achievement | MaskedSecretAchievement;
 export type LockedAchievementEntry = LockedAchievement | LockedSecretAchievement;
 
+/**
+ * Engagement (activity) streak slice on the achievements endpoint response.
+ * See: https://fieldguide.automattic.com/activity-streak/
+ */
+export interface EngagementStreak {
+	current_streak: number;
+	longest_streak: number;
+	freezes_available: number;
+	freeze_used_date: string | null;
+	next_freeze_in_days: number;
+}
+
 export interface AchievementsResponse {
 	found: number;
 	achievements: EarnedAchievementEntry[];
 	/** Self-reads only. Endpoint returns the full set on page 1; not paginated. */
 	locked_achievements?: LockedAchievementEntry[];
 	years_of_service?: number;
+	/** Activity streak data. */
+	engagement_streak?: EngagementStreak;
 }


### PR DESCRIPTION
Part of RSM-396

## Proposed Changes

* Adds an `EngagementStreak` interface to `@automattic/api-core/read-achievements` and surfaces the slice through `useAchievementsQuery`. The slice is already returned by `/read/achievements/{user}` on page 1, alongside `years_of_service`.
* Adds a presentational `ActivityStreakPill` component under `client/reader/user-profile/views/achievements/activity-streak-pill/`. Three branches:
    * Active two-line pill — headline `🔥 {N}-day activity streak` with the streak count bolded, sub-line `Longest M · <freeze chip>`. The freeze chip is one of `1 freeze available`, `freeze used <relative>` (during the post-use cooldown), or `next freeze in N days`. The `Longest M` chip is dropped when `longest_streak === current_streak` to avoid visual repetition.
    * Coaching CTA on own profile when `current_streak === 0` — `🔥 Start your activity streak today` with sub-line `Like, comment, follow, or post — anything counts.`
    * `null` when the slice is absent (user outside the rollout) or when viewing someone else with `current_streak === 0`.
* On the active pill, a `<Tooltip>` covers the whole element with a multi-line explainer (streak-day activities + freeze concept). When `next_freeze_in_days > 0`, the explainer appends `You will earn one in N more active days.` The pill is focusable so keyboard users can also surface the tooltip.
* Wires the pill into the user-profile achievements page (`/reader/users/:user/achievements`) inside `.achievements__header`. Switches the header to a 3-column grid so the years-of-service badge and streak pill sit together centered in the row while the settings cog stays in the top-right (and remains in document flow so its popover anchors correctly).

## Why are these changes being made?

* RSM-396 (project: RSM: Achievements on WordPress.com, Foundation milestone). The activity-streak engine (`engagement_streak`) is currently rolled out to Automatticians, and the achievements page is the canonical surface where users see their streak status, longest streak, and freeze state. Without UI on the page, the engine's signal is invisible to the user it serves.

## Testing Instructions

### Setup

Visit `/reader/users/me/achievements` on a logged-in account that has `engagement_streak` data (rollout-gated; Automattician accounts have it). The pill should appear between the years-of-service badge and the settings cog, vertically aligned with the badge and centered as a pair.

### Driving each state

The pill is fully derived from the `engagement_streak` slice on the achievements endpoint response, so each state below is a deterministic function of that payload. Two ways to drive them:

* **Naturally** — find an account whose live data matches the desired state.
* **Stubbed** — open Chrome DevTools → Network → right-click the `/wpcom/v2/read/achievements/<login>` request → "Override content", and edit the `engagement_streak` block of the saved JSON to one of the shapes below. Also set "found" to a smaller number like "10". Reload the page to pick up the override.

### Active-pill state matrix

For each row, set `engagement_streak` to the listed values, reload, and confirm the pill matches the expected output.

| # | `current_streak` | `longest_streak` | `freezes_available` | `freeze_used_date` | `next_freeze_in_days` | Expected sub-line |
|---|---|---|---|---|---|---|
| 1 | 12 | 28 | 1 | `null` | 0 | `Longest 28 · 1 freeze available` |
| 2 | 11 | 28 | 0 | `"<ISO timestamp ~2 days ago>"` | 5 | `Longest 28 · freeze used 2 days ago` |
| 3 | 3 | 28 | 0 | `null` | 4 | `Longest 28 · next freeze in 4 days` |
| 4 | 5 | 5 | 1 | `null` | 0 | `1 freeze available` (the `Longest M` chip is dropped) |
| 5 | 2 | 2 | 0 | `null` | 5 | `next freeze in 5 days` (chip dropped) |

For rows 1–3 the headline reads `🔥 {current_streak}-day activity streak`. For rows 4–5 the same headline format applies with the smaller current value.

### Coaching CTA — own profile, `current_streak === 0`

Set `engagement_streak` to `{ current_streak: 0, longest_streak: 0, freezes_available: 0, freeze_used_date: null, next_freeze_in_days: 0 }` on your own profile. Expected:

* Headline: `🔥 Start your activity streak today`
* Sub-line: `Like, comment, follow, or post — anything counts.`

(The coaching CTA renders the same whether `longest_streak` is `0` or `> 0` — the rule fires purely on `current_streak === 0`.)

### Hidden states — pill should not render

* On a third-party profile (`/reader/users/<other>/achievements`) with `current_streak: 0` in the response — pill is absent, rest of page unchanged.
* Any response where the `engagement_streak` field is absent entirely — pill is absent. Use the same DevTools override to delete the field from the JSON and reload.

### Tooltip

Hover the active pill or tab to it; a tooltip ~220 px wide should appear with two lines:

* Line 1: `Like, comment, follow, or post — anything counts.`
* Line 2: `A streak freeze automatically protects your streak when you miss a day.` — appended with `You will earn one in N more active days.` whenever `next_freeze_in_days > 0`.

The coaching CTA does not render a tooltip.

### Layout

* Open the settings dropdown (cog at top-right). Its popover should anchor correctly to the cog's visible position.

#### Coaching CTA
(note the visual style has changed since this screenshot, but the content remains the same)
<img width="1199" height="747" alt="Screenshot 2026-05-12 at 10 39 15" src="https://github.com/user-attachments/assets/b1ab1dc6-b07c-4e72-b24c-f55c0c054e7d" />

#### Active streak with freeze, current streak isn't the longest streak
(note the visual style has changed since this screenshot, but the content remains the same)
<img width="1199" height="747" alt="Screenshot 2026-05-12 at 10 38 17" src="https://github.com/user-attachments/assets/2867ec1f-69ac-4b59-9c81-0f6d09a18c49" />

#### Active streak with recently used freeze
(note the visual style has changed since this screenshot, but the content remains the same)
<img width="1199" height="747" alt="Screenshot 2026-05-12 at 10 46 26" src="https://github.com/user-attachments/assets/8e425032-a2cc-44db-8835-c21200124ef3" />


#### Active streak with freeze, currently longest streak
(has the updated visual style)

<img width="1413" height="747" alt="Screenshot 2026-05-12 at 11 19 42" src="https://github.com/user-attachments/assets/756a4f42-8344-4360-b45e-a0545dc5e8ac" />

(also displayed the tooltip)

### CI gates

* `yarn test-client client/reader/user-profile/views/achievements/` — 60 tests.
* `yarn typecheck-client` — only pre-existing `client/dashboard/` errors should remain.
* `yarn lint` and `yarn stylelint client/reader/user-profile/views/achievements/**/*.scss`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?