### PR TITLE
BLIK: treat payment-confirmed as in-progress while polling

### DIFF
--- a/client/my-sites/checkout/src/lib/blik-processor.ts
+++ b/client/my-sites/checkout/src/lib/blik-processor.ts
@@ -128,7 +128,10 @@ export default async function blikProcessor(
 			while ( isModalActive && [ 'processing', 'async-pending' ].includes( orderStatus ) ) {
 				orderStatus = await pollForOrderStatus( response.order_id, 2000, genericErrorMessage );
 			}
-			if ( orderStatus !== 'success' ) {
+			// `payment-confirmed` is treated as success: Stripe has accepted the payment
+			// but order finalization can still take a while. Hand off to the framework's
+			// pending page rather than keeping the user waiting in the modal.
+			if ( orderStatus !== 'success' && orderStatus !== 'payment-confirmed' ) {
 				throw new Error( explicitClosureMessage ?? genericFailureMessage );
 			}
 
@@ -157,7 +160,10 @@ async function pollForOrderStatus(
 		console.error( 'Order was not found.' );
 		throw new Error( genericErrorMessage );
 	}
-	if ( orderData.processing_status === 'success' ) {
+	if (
+		orderData.processing_status === 'success' ||
+		orderData.processing_status === 'payment-confirmed'
+	) {
 		return orderData.processing_status;
 	}
 	await new Promise( ( resolve ) => setTimeout( resolve, pollInterval ) );

--- a/client/my-sites/checkout/src/test/blik-processor.ts
+++ b/client/my-sites/checkout/src/test/blik-processor.ts
@@ -1,0 +1,110 @@
+/**
+ * @jest-environment jsdom
+ */
+// @ts-nocheck - TODO: Fix TypeScript issues
+
+import { getEmptyResponseCart, getEmptyResponseCartProduct } from '@automattic/shopping-cart';
+import { act, render } from '@testing-library/react';
+import { translate } from 'i18n-calypso';
+import { createElement } from 'react';
+import blikProcessor from '../lib/blik-processor';
+import {
+	mockTransactionsEndpoint,
+	mockTransactionsRedirectResponse,
+	processorOptions,
+	countryCode,
+	postalCode,
+	mockOrderEndpoint,
+} from './util';
+
+describe( 'blikProcessor', () => {
+	const product = getEmptyResponseCartProduct();
+	const cart = { ...getEmptyResponseCart(), products: [ product ] };
+	const options = {
+		...processorOptions,
+		responseCart: cart,
+		contactDetails: {
+			countryCode,
+			postalCode,
+		},
+	};
+
+	const submitData = { code: '123456' };
+
+	it( 'returns a success response when the order is payment-confirmed', async () => {
+		// The processor renders the dialog into a div so that div must be
+		// present to avoid errors.
+		render( createElement( 'div', { className: 'blik-modal-target' } ) );
+
+		const orderId = 54321;
+		const mockOrderStatus = {
+			order_id: orderId,
+			user_id: 1234,
+			receipt_id: undefined,
+			processing_status: 'payment-confirmed',
+		};
+		mockOrderEndpoint( orderId, () => [ 200, mockOrderStatus ] );
+		mockTransactionsEndpoint( () => mockTransactionsRedirectResponse( orderId ) );
+
+		const expected = {
+			payload: { success: true, order_id: orderId },
+			type: 'SUCCESS',
+		};
+
+		await act( async () => {
+			await expect( blikProcessor( submitData, options, translate ) ).resolves.toStrictEqual(
+				expected
+			);
+		} );
+	} );
+
+	it( 'returns a success response when the order succeeds', async () => {
+		render( createElement( 'div', { className: 'blik-modal-target' } ) );
+
+		const orderId = 54321;
+		const mockOrderStatus = {
+			order_id: orderId,
+			user_id: 1234,
+			receipt_id: undefined,
+			processing_status: 'success',
+		};
+		mockOrderEndpoint( orderId, () => [ 200, mockOrderStatus ] );
+		mockTransactionsEndpoint( () => mockTransactionsRedirectResponse( orderId ) );
+
+		const expected = {
+			payload: { success: true, order_id: orderId },
+			type: 'SUCCESS',
+		};
+
+		await act( async () => {
+			await expect( blikProcessor( submitData, options, translate ) ).resolves.toStrictEqual(
+				expected
+			);
+		} );
+	} );
+
+	it( 'returns an error response when the order fails', async () => {
+		render( createElement( 'div', { className: 'blik-modal-target' } ) );
+
+		const orderId = 54321;
+		const mockOrderStatus = {
+			order_id: orderId,
+			user_id: 1234,
+			receipt_id: undefined,
+			processing_status: 'payment-failure',
+		};
+		mockOrderEndpoint( orderId, () => [ 200, mockOrderStatus ] );
+		mockTransactionsEndpoint( () => mockTransactionsRedirectResponse( orderId ) );
+
+		const expected = {
+			payload: 'Payment failed. Please check your account and try again.',
+			type: 'ERROR',
+		};
+
+		await act( async () => {
+			await expect( blikProcessor( submitData, options, translate ) ).resolves.toStrictEqual(
+				expected
+			);
+		} );
+	} );
+} );


### PR DESCRIPTION
Fixes SHILL-2004

## Proposed Changes

* Treat the `payment-confirmed` order status as non-terminal in the BLIK polling loop so the user is handed off to the pending page instead of seeing a spurious "Payment failed" message.
* Add a `blik-processor` test covering the `payment-confirmed`, `success`, and `payment-failure` paths.

## Why are these changes being made?

When a BLIK payment succeeds, the wpcom side records the Stripe `payment_intent.succeeded` webhook by setting `payment_data['payment_confirmed'] = true` on the order. While `process_order()` is still finalizing provisioning, `GET /me/transactions/order/{orderId}` returns `processing_status: 'payment-confirmed'` — a transient state meaning "paid, not yet provisioned."

The BLIK processor's polling loop only continued while the status was `processing` or `async-pending`, and after exit only treated `success` as non-failure. So any poll that landed during the `payment-confirmed` window broke out of the loop and threw the generic "Payment failed. Please check your account and try again." message — even though the payment had succeeded and the backend was still wrapping up.

The bug only surfaced for orders whose provisioning ran longer than one 2-second poll interval (e.g., domain registration, slower provisioning paths), which is why it appeared intermittent.

The fix mirrors the pattern already in `upi-processor.ts` (added in #109562) — `pollForOrderStatus` returns immediately on `payment-confirmed`, and the post-loop check accepts both `success` and `payment-confirmed`. Treating it as success here lets the framework's pending page take over and resolve the final state.

PIX and PIX Automatico use Ebanx rather than Stripe and likely have a different set of statuses; they are deliberately not changed here.

## Testing Instructions

* `yarn test-client client/my-sites/checkout/src/test/blik-processor.ts` — all three cases pass.
* Manual: make a BLIK payment for a product whose provisioning takes longer than ~2s (e.g., a plan with a domain registration). The flow should land on the pending page and complete normally rather than showing the "Payment failed" error.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?