### PR TITLE
Reader: fix pending-posts badge flicker after click

### DIFF
--- a/client/reader/stream/test/use-stream-pending-posts.test.tsx
+++ b/client/reader/stream/test/use-stream-pending-posts.test.tsx
@@ -184,22 +184,16 @@ describe( 'useStreamPendingPosts', () => {
 
 		await waitFor( () => expect( result.current.pendingCount ).toBe( 1 ) );
 
-		// `resetQueries` re-fetches active observers; mock the second call.
-		nock( BASE )
-			.get( LIKES_PATH )
-			.query( true )
-			.reply( 200, {
-				posts: [ apiPost( 2 ), apiPost( 3 ) ],
-				date_range: { after: null, before: null },
-			} );
-
+		// `reset` overwrites the cached head with an empty response — it must
+		// not trigger a follow-up fetch (the previous `resetQueries`
+		// implementation did, racing the consumer's infinite-query refetch
+		// and flashing the badge back to N).
 		act( () => {
 			result.current.reset();
 		} );
 
-		// pendingCount snaps to 0 immediately after reset (data is undefined),
-		// and stays 0 once the follow-up fetch lands matching the visible items.
 		await waitFor( () => expect( result.current.pendingCount ).toBe( 0 ) );
+		expect( nock.pendingMocks() ).toHaveLength( 0 );
 	} );
 
 	it( 'rotates queryKey on streamKey change so polled head does not bleed across streams', async () => {

--- a/client/reader/stream/use-stream-pending-posts.ts
+++ b/client/reader/stream/use-stream-pending-posts.ts
@@ -145,7 +145,16 @@ export function useStreamPendingPosts( {
 	}, [ pollHead.data, items, streamType ] );
 
 	const reset = useCallback( () => {
-		queryClient.resetQueries( { queryKey: pollQueryKey, exact: true } );
+		// Snapshot an empty response into the cache instead of `resetQueries`.
+		// `resetQueries` would re-trigger an immediate fetch from this active
+		// observer; the freshly fetched head could land before the consumer's
+		// infinite-query refetch settles, flashing `pendingCount` back to N
+		// before `items[]` has caught up — the badge would reappear right
+		// after the click. `setQueryData` clears the count without scheduling
+		// a new fetch; the next `refetchInterval` tick handles re-syncing.
+		queryClient.setQueryData< ReadStreamResponse >( pollQueryKey, () => ( {
+			posts: [],
+		} ) );
 	}, [ queryClient, pollQueryKey ] );
 
 	return { pendingCount, hasPendingPosts: pendingCount > 0, reset };


### PR DESCRIPTION
## Proposed Changes

* Switch `useStreamPendingPosts` `reset()` from `queryClient.resetQueries` to `setQueryData` with an empty stream response.
* Update the related test to assert no follow-up fetch fires after `reset()`.

## Why are these changes being made?

`resetQueries` clears the cached head **and** triggers an immediate refetch from the active poll observer. That fresh poll typically lands before the consumer's infinite-query refetch settles, so `pendingCount` is recomputed against stale `items[]` and the "X new posts" badge flashes back to N right after the user clicks it. `setQueryData` clears the count without scheduling a new fetch — the regular `refetchInterval` tick reconciles naturally once `items[]` has caught up.

## Testing Instructions

* Open a Reader stream (e.g. `/reader`) and wait until the "X new posts" pill appears.
* Click the pill — the badge should disappear and stay gone (no brief reappearance) while the stream refetches and scrolls to the top.
* `yarn test-client client/reader/stream/test/use-stream-pending-posts.test.tsx` — all 7 tests pass.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?