### PR TITLE
APM: Add WordPress sub-tab; drop standalone Requests sub-tab

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -635,24 +635,6 @@ export const sitePerformanceBackendIndexRoute = createRoute( {
 	)
 );
 
-export const sitePerformanceBackendRequestsRoute = createRoute( {
-	head: () => ( {
-		meta: [
-			{
-				title: isEnabled( 'dashboard/omnibar' ) ? __( 'Requests' ) : undefined,
-			},
-		],
-	} ),
-	getParentRoute: () => sitePerformanceBackendRoute,
-	path: 'requests',
-} ).lazy( () =>
-	import( '../../sites/performance/backend' ).then( ( d ) =>
-		createLazyRoute( 'site-performance-backend-requests' )( {
-			component: () => <d.default siteSlug={ siteRoute.useParams().siteSlug } tab="requests" />,
-		} )
-	)
-);
-
 export const sitePerformanceBackendTransactionsRoute = createRoute( {
 	head: () => ( {
 		meta: [
@@ -705,6 +687,29 @@ export const sitePerformanceBackendExternalRequestsRoute = createRoute( {
 			component: () => (
 				<d.default siteSlug={ siteRoute.useParams().siteSlug } tab="external-requests" />
 			),
+		} )
+	)
+);
+
+export const sitePerformanceBackendWordPressRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: isEnabled( 'dashboard/omnibar' ) ? __( 'WordPress' ) : undefined,
+			},
+		],
+	} ),
+	getParentRoute: () => sitePerformanceBackendRoute,
+	path: 'wordpress',
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		const { siteApmWordPressQuery } = await import( '../../sites/performance/backend/mock-data' );
+		await queryClient.ensureQueryData( siteApmWordPressQuery( site.ID ) );
+	},
+} ).lazy( () =>
+	import( '../../sites/performance/backend' ).then( ( d ) =>
+		createLazyRoute( 'site-performance-backend-wordpress' )( {
+			component: () => <d.default siteSlug={ siteRoute.useParams().siteSlug } tab="wordpress" />,
 		} )
 	)
 );
@@ -1792,8 +1797,8 @@ export const createSitesRoutes = ( config: AppConfig ) => {
 				? [
 						sitePerformanceBackendRoute.addChildren( [
 							sitePerformanceBackendIndexRoute,
-							sitePerformanceBackendRequestsRoute,
 							sitePerformanceBackendTransactionsRoute,
+							sitePerformanceBackendWordPressRoute,
 							sitePerformanceBackendDatabaseRoute,
 							sitePerformanceBackendExternalRequestsRoute,
 							sitePerformanceBackendRequestDetailRoute,

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -645,6 +645,13 @@ export const sitePerformanceBackendTransactionsRoute = createRoute( {
 	} ),
 	getParentRoute: () => sitePerformanceBackendRoute,
 	path: 'transactions',
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		const { siteApmTransactionsQuery } = await import(
+			'../../sites/performance/backend/mock-data'
+		);
+		await queryClient.ensureQueryData( siteApmTransactionsQuery( site.ID ) );
+	},
 } ).lazy( () =>
 	import( '../../sites/performance/backend' ).then( ( d ) =>
 		createLazyRoute( 'site-performance-backend-transactions' )( {
@@ -663,6 +670,11 @@ export const sitePerformanceBackendDatabaseRoute = createRoute( {
 	} ),
 	getParentRoute: () => sitePerformanceBackendRoute,
 	path: 'database',
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		const { siteApmSlowQueriesQuery } = await import( '../../sites/performance/backend/mock-data' );
+		await queryClient.ensureQueryData( siteApmSlowQueriesQuery( site.ID ) );
+	},
 } ).lazy( () =>
 	import( '../../sites/performance/backend' ).then( ( d ) =>
 		createLazyRoute( 'site-performance-backend-database' )( {
@@ -681,6 +693,13 @@ export const sitePerformanceBackendExternalRequestsRoute = createRoute( {
 	} ),
 	getParentRoute: () => sitePerformanceBackendRoute,
 	path: 'external-requests',
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		const { siteApmExternalRequestsQuery } = await import(
+			'../../sites/performance/backend/mock-data'
+		);
+		await queryClient.ensureQueryData( siteApmExternalRequestsQuery( site.ID ) );
+	},
 } ).lazy( () =>
 	import( '../../sites/performance/backend' ).then( ( d ) =>
 		createLazyRoute( 'site-performance-backend-external-requests' )( {

--- a/client/dashboard/sites/performance/backend/backend-status.tsx
+++ b/client/dashboard/sites/performance/backend/backend-status.tsx
@@ -1,38 +1,12 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { Notice } from '../../../components/notice';
-
-export type BackendStatus = 'good' | 'needsImprovement' | 'bad';
-
-export function getBackendStatus( avgResponseMs: number ): BackendStatus {
-	if ( avgResponseMs <= 500 ) {
-		return 'good';
-	}
-	if ( avgResponseMs <= 1500 ) {
-		return 'needsImprovement';
-	}
-	return 'bad';
-}
-
-function formatMs( ms: number ): string {
-	if ( ms >= 1000 ) {
-		return sprintf(
-			/* translators: %s is a number of seconds. */
-			__( '%s s' ),
-			( ms / 1000 ).toFixed( 2 )
-		);
-	}
-	return sprintf(
-		/* translators: %d is a number of milliseconds. */
-		__( '%d ms' ),
-		ms
-	);
-}
+import { BACKEND_THRESHOLDS_MS, bucketByMs, formatMs } from './utils';
 
 export default function BackendStatusNotice( { avgResponseMs }: { avgResponseMs: number } ) {
-	const status = getBackendStatus( avgResponseMs );
+	const intent = bucketByMs( avgResponseMs, BACKEND_THRESHOLDS_MS.response );
 	const formatted = formatMs( avgResponseMs );
 
-	if ( status === 'bad' ) {
+	if ( intent === 'error' ) {
 		return (
 			<Notice
 				variant="error"
@@ -49,7 +23,7 @@ export default function BackendStatusNotice( { avgResponseMs }: { avgResponseMs:
 		);
 	}
 
-	if ( status === 'needsImprovement' ) {
+	if ( intent === 'warning' ) {
 		return (
 			<Notice
 				variant="warning"

--- a/client/dashboard/sites/performance/backend/backend-tabs.tsx
+++ b/client/dashboard/sites/performance/backend/backend-tabs.tsx
@@ -1,9 +1,10 @@
 import { __experimentalVStack as VStack, privateApis } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 import { Text } from '../../../components/text';
 import { VIEWPORT_BREAKPOINTS } from '../constants';
+import { BACKEND_THRESHOLDS_MS, bucketByMs, formatMs, type Intent } from './utils';
 import type { ApmTab } from '.';
 import type { ApmSummary } from '@automattic/api-core';
 
@@ -14,35 +15,8 @@ const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
 
 const { Tabs } = unlock( privateApis );
 
-type Intent = 'success' | 'warning' | 'error';
-
-function formatMs( ms: number ): string {
-	if ( ms >= 1000 ) {
-		return sprintf(
-			/* translators: %s is a number of seconds. */
-			__( '%s s' ),
-			( ms / 1000 ).toFixed( 2 )
-		);
-	}
-	return sprintf(
-		/* translators: %d is a number of milliseconds. */
-		__( '%d ms' ),
-		ms
-	);
-}
-
 function formatCount( value: number ): string {
 	return new Intl.NumberFormat().format( value );
-}
-
-function bucketByMs( ms: number, good: number, warn: number ): Intent {
-	if ( ms <= good ) {
-		return 'success';
-	}
-	if ( ms <= warn ) {
-		return 'warning';
-	}
-	return 'error';
 }
 
 function Tab( {
@@ -89,7 +63,7 @@ export default function BackendTabs( {
 			tabId: 'overview',
 			label: compact ? __( 'Avg' ) : __( 'Avg response' ),
 			value: formatMs( summary.avg_response_ms ),
-			intent: bucketByMs( summary.avg_response_ms, 500, 1500 ),
+			intent: bucketByMs( summary.avg_response_ms, BACKEND_THRESHOLDS_MS.response ),
 		},
 		{
 			tabId: 'transactions',
@@ -100,19 +74,19 @@ export default function BackendTabs( {
 			tabId: 'wordpress',
 			label: compact ? __( 'WP' ) : __( 'WordPress' ),
 			value: formatMs( summary.plugins_avg_ms ),
-			intent: bucketByMs( summary.plugins_avg_ms, 100, 300 ),
+			intent: bucketByMs( summary.plugins_avg_ms, BACKEND_THRESHOLDS_MS.plugins ),
 		},
 		{
 			tabId: 'database',
 			label: compact ? __( 'DB' ) : __( 'Database' ),
 			value: formatMs( summary.db_avg_ms ),
-			intent: bucketByMs( summary.db_avg_ms, 200, 600 ),
+			intent: bucketByMs( summary.db_avg_ms, BACKEND_THRESHOLDS_MS.db ),
 		},
 		{
 			tabId: 'external-requests',
 			label: __( 'External' ),
 			value: formatMs( summary.external_avg_ms ),
-			intent: bucketByMs( summary.external_avg_ms, 200, 600 ),
+			intent: bucketByMs( summary.external_avg_ms, BACKEND_THRESHOLDS_MS.external ),
 		},
 	];
 

--- a/client/dashboard/sites/performance/backend/backend-tabs.tsx
+++ b/client/dashboard/sites/performance/backend/backend-tabs.tsx
@@ -92,14 +92,15 @@ export default function BackendTabs( {
 			intent: bucketByMs( summary.avg_response_ms, 500, 1500 ),
 		},
 		{
-			tabId: 'requests',
-			label: compact ? __( 'Slow' ) : __( 'Slow requests' ),
-			value: formatCount( summary.slow_request_count ),
-		},
-		{
 			tabId: 'transactions',
 			label: __( 'Transactions' ),
 			value: formatCount( summary.transaction_count ),
+		},
+		{
+			tabId: 'wordpress',
+			label: compact ? __( 'WP' ) : __( 'WordPress' ),
+			value: formatMs( summary.plugins_avg_ms ),
+			intent: bucketByMs( summary.plugins_avg_ms, 100, 300 ),
 		},
 		{
 			tabId: 'database',

--- a/client/dashboard/sites/performance/backend/bar-list.tsx
+++ b/client/dashboard/sites/performance/backend/bar-list.tsx
@@ -1,0 +1,79 @@
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { Text } from '../../../components/text';
+
+export type BarListRow = { id: string; label: string; value: number };
+
+export default function BarList( {
+	rows,
+	valueFormatter,
+}: {
+	rows: BarListRow[];
+	valueFormatter: ( value: number ) => string;
+} ) {
+	const max = Math.max( 1, ...rows.map( ( r ) => r.value ) );
+
+	return (
+		<VStack spacing={ 3 }>
+			{ rows.map( ( row ) => {
+				const fillPercent = ( row.value / max ) * 100;
+				return (
+					<HStack key={ row.id } spacing={ 4 } alignment="center">
+						<div
+							style={ {
+								position: 'relative',
+								flex: 1,
+								minWidth: 0,
+								height: 32,
+								borderRadius: 4,
+								overflow: 'hidden',
+								background:
+									'color-mix(in srgb, var(--wp-admin-theme-color, #3858e9) 8%, transparent)',
+							} }
+						>
+							<div
+								style={ {
+									position: 'absolute',
+									insetInlineStart: 0,
+									insetBlockStart: 0,
+									insetBlockEnd: 0,
+									width: `${ fillPercent }%`,
+									background:
+										'color-mix(in srgb, var(--wp-admin-theme-color, #3858e9) 32%, transparent)',
+								} }
+							/>
+							<div
+								style={ {
+									position: 'absolute',
+									insetBlockStart: 0,
+									insetBlockEnd: 0,
+									insetInlineStart: 0,
+									insetInlineEnd: 0,
+									paddingInline: 12,
+									display: 'flex',
+									alignItems: 'center',
+								} }
+							>
+								<Text
+									style={ {
+										overflow: 'hidden',
+										textOverflow: 'ellipsis',
+										whiteSpace: 'nowrap',
+										width: '100%',
+									} }
+								>
+									{ row.label }
+								</Text>
+							</div>
+						</div>
+						<Text variant="muted" style={ { minWidth: 80, textAlign: 'end' } }>
+							{ valueFormatter( row.value ) }
+						</Text>
+					</HStack>
+				);
+			} ) }
+		</VStack>
+	);
+}

--- a/client/dashboard/sites/performance/backend/database/index.tsx
+++ b/client/dashboard/sites/performance/backend/database/index.tsx
@@ -1,6 +1,31 @@
-import { __experimentalText as Text } from '@wordpress/components';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
+import { siteApmSlowQueriesQuery } from '../mock-data';
+import SlowList, { type SlowListItem } from '../slow-list';
+import type { ApmSlowQuery, Site } from '@automattic/api-core';
 
-export default function Database() {
-	return <Text variant="muted">{ __( 'Coming soon.' ) }</Text>;
+function toItems( queries: ApmSlowQuery[] ): SlowListItem[] {
+	return queries.map( ( query ) => ( {
+		id: query.id,
+		label: query.query,
+		avg_ms: query.avg_ms,
+		max_ms: query.max_ms,
+	} ) );
+}
+
+export default function Database( { site }: { site: Site } ) {
+	const { data } = useSuspenseQuery( siteApmSlowQueriesQuery( site.ID ) );
+
+	return (
+		<SlowList
+			title={ __( 'Slowest queries' ) }
+			avgDescription={ __(
+				'Average execution time per query across all calls in the selected period.'
+			) }
+			maxDescription={ __(
+				'Slowest single execution observed for each query in the selected period.'
+			) }
+			items={ toItems( data ) }
+		/>
+	);
 }

--- a/client/dashboard/sites/performance/backend/external-requests/index.tsx
+++ b/client/dashboard/sites/performance/backend/external-requests/index.tsx
@@ -1,6 +1,31 @@
-import { __experimentalText as Text } from '@wordpress/components';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
+import { siteApmExternalRequestsQuery } from '../mock-data';
+import SlowList, { type SlowListItem } from '../slow-list';
+import type { ApmExternalRequest, Site } from '@automattic/api-core';
 
-export default function ExternalRequests() {
-	return <Text variant="muted">{ __( 'Coming soon.' ) }</Text>;
+function toItems( requests: ApmExternalRequest[] ): SlowListItem[] {
+	return requests.map( ( request ) => ( {
+		id: `${ request.method } ${ request.host }${ request.endpoint }`,
+		label: `${ request.method } ${ request.host }${ request.endpoint }`,
+		avg_ms: request.avg_ms,
+		max_ms: request.max_ms,
+	} ) );
+}
+
+export default function ExternalRequests( { site }: { site: Site } ) {
+	const { data } = useSuspenseQuery( siteApmExternalRequestsQuery( site.ID ) );
+
+	return (
+		<SlowList
+			title={ __( 'Slowest external requests' ) }
+			avgDescription={ __(
+				'Average response time for outbound calls to each third-party host in the selected period.'
+			) }
+			maxDescription={ __(
+				'Slowest single outbound call observed to each third-party host in the selected period.'
+			) }
+			items={ toItems( data ) }
+		/>
+	);
 }

--- a/client/dashboard/sites/performance/backend/index.tsx
+++ b/client/dashboard/sites/performance/backend/index.tsx
@@ -25,15 +25,15 @@ import EnableApmCallout from './enable-apm-callout';
 import ExternalRequests from './external-requests';
 import { siteApmOverviewQuery } from './mock-data';
 import Overview from './overview';
-import Requests from './requests';
 import Transactions from './transactions';
+import WordPress from './wordpress';
 
-export type ApmTab = 'overview' | 'requests' | 'transactions' | 'database' | 'external-requests';
+export type ApmTab = 'overview' | 'transactions' | 'wordpress' | 'database' | 'external-requests';
 
 const TAB_PATHS: Record< ApmTab, string > = {
 	overview: '',
-	requests: 'requests',
 	transactions: 'transactions',
+	wordpress: 'wordpress',
 	database: 'database',
 	'external-requests': 'external-requests',
 };
@@ -68,10 +68,10 @@ function ApmDashboard( { site, tab }: { site: Site; tab: ApmTab } ) {
 		switch ( tab ) {
 			case 'overview':
 				return <Overview site={ site } />;
-			case 'requests':
-				return <Requests />;
 			case 'transactions':
 				return <Transactions />;
+			case 'wordpress':
+				return <WordPress site={ site } />;
 			case 'database':
 				return <Database />;
 			case 'external-requests':

--- a/client/dashboard/sites/performance/backend/index.tsx
+++ b/client/dashboard/sites/performance/backend/index.tsx
@@ -69,13 +69,13 @@ function ApmDashboard( { site, tab }: { site: Site; tab: ApmTab } ) {
 			case 'overview':
 				return <Overview site={ site } />;
 			case 'transactions':
-				return <Transactions />;
+				return <Transactions site={ site } />;
 			case 'wordpress':
 				return <WordPress site={ site } />;
 			case 'database':
-				return <Database />;
+				return <Database site={ site } />;
 			case 'external-requests':
-				return <ExternalRequests />;
+				return <ExternalRequests site={ site } />;
 		}
 	};
 

--- a/client/dashboard/sites/performance/backend/mock-data.ts
+++ b/client/dashboard/sites/performance/backend/mock-data.ts
@@ -4,14 +4,17 @@
 // `@automattic/api-queries`, then delete this file.
 import { queryOptions } from '@tanstack/react-query';
 import type {
+	ApmExternalRequest,
 	ApmHookUsage,
 	ApmOverview,
 	ApmPluginUsage,
 	ApmRequestDetail,
+	ApmSlowQuery,
 	ApmSlowRequest,
 	ApmSummary,
 	ApmTemplateUsage,
 	ApmTimePoint,
+	ApmTransaction,
 	ApmWordPress,
 } from '@automattic/api-core';
 
@@ -192,6 +195,107 @@ function fetchApmWordPress( siteId: number ): Promise< ApmWordPress > {
 	return Promise.resolve( generateWordPress( siteId ) );
 }
 
+const TRANSACTION_ROUTES: Array< { method: string; url: string } > = [
+	{ method: 'GET', url: '/wp-json/wp/v2/posts' },
+	{ method: 'POST', url: '/wp-admin/admin-ajax.php' },
+	{ method: 'GET', url: '/wp-json/woocommerce/v3/orders' },
+	{ method: 'GET', url: '/?p=1234' },
+	{ method: 'POST', url: '/wp-login.php' },
+	{ method: 'GET', url: '/feed/' },
+	{ method: 'GET', url: '/shop/cart/' },
+	{ method: 'POST', url: '/checkout/' },
+	{ method: 'GET', url: '/wp-cron.php' },
+	{ method: 'GET', url: '/wp-json/jetpack/v4/sync' },
+];
+
+function generateTransactions( seed: number ): ApmTransaction[] {
+	const random = rng( seed ^ 0x54584e53 );
+	return TRANSACTION_ROUTES.map( ( { method, url } ) => {
+		const call_count = Math.round( 50 + random() * 4950 );
+		const avg_ms = Math.round( 80 + random() * 920 );
+		const max_ms = Math.round( avg_ms * ( 1.5 + random() * 6 ) );
+		return {
+			method,
+			url,
+			call_count,
+			avg_ms,
+			max_ms,
+			total_ms: call_count * avg_ms,
+		};
+	} ).sort( ( a, b ) => b.max_ms - a.max_ms );
+}
+
+const SAMPLE_QUERIES = [
+	"SELECT * FROM wp_posts WHERE post_type = 'product' AND post_status = 'publish' ORDER BY post_date DESC LIMIT 12",
+	'SELECT option_value FROM wp_options WHERE option_name = ? LIMIT 1',
+	'SELECT meta_key, meta_value FROM wp_postmeta WHERE post_id IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+	'SELECT * FROM wp_woocommerce_order_items WHERE order_id = ?',
+	"SELECT user_id, meta_value FROM wp_usermeta WHERE meta_key = 'session_tokens'",
+	'SELECT COUNT(*) FROM wp_comments WHERE comment_approved = ?',
+	'SELECT * FROM wp_terms INNER JOIN wp_term_taxonomy ON wp_terms.term_id = wp_term_taxonomy.term_id',
+	"SELECT * FROM wp_actionscheduler_actions WHERE status = 'pending' AND scheduled_date_gmt <= NOW()",
+	'UPDATE wp_options SET option_value = ? WHERE option_name = ?',
+	'SELECT * FROM wp_posts WHERE ID = ?',
+];
+
+function generateSlowQueries( seed: number ): ApmSlowQuery[] {
+	const random = rng( seed ^ 0x44424153 );
+	return SAMPLE_QUERIES.map( ( query, i ) => {
+		const call_count = Math.round( 20 + random() * 4980 );
+		const avg_ms = Math.round( 20 + random() * 480 );
+		const max_ms = Math.round( avg_ms * ( 1.4 + random() * 5 ) );
+		return {
+			id: `q-${ seed.toString( 36 ) }-${ i }`,
+			query,
+			call_count,
+			avg_ms,
+			max_ms,
+			total_ms: call_count * avg_ms,
+		};
+	} ).sort( ( a, b ) => b.max_ms - a.max_ms );
+}
+
+const SAMPLE_EXTERNAL_REQUESTS: Array< { host: string; endpoint: string; method: string } > = [
+	{ host: 'api.stripe.com', endpoint: '/v1/charges', method: 'POST' },
+	{ host: 'connect.akismet.com', endpoint: '/1.1/comment-check', method: 'POST' },
+	{ host: 'public-api.wordpress.com', endpoint: '/rest/v1.1/sites', method: 'GET' },
+	{ host: 'jetpack.wordpress.com', endpoint: '/jetpack-api/v1/sync', method: 'POST' },
+	{ host: 'api.mailchimp.com', endpoint: '/3.0/lists/{id}/members', method: 'POST' },
+	{ host: 'graph.facebook.com', endpoint: '/v18.0/me/feed', method: 'POST' },
+	{ host: 'api.cloudflare.com', endpoint: '/client/v4/zones/{id}/purge_cache', method: 'POST' },
+	{ host: 'fonts.googleapis.com', endpoint: '/css2', method: 'GET' },
+];
+
+function generateExternalRequests( seed: number ): ApmExternalRequest[] {
+	const random = rng( seed ^ 0x45585452 );
+	return SAMPLE_EXTERNAL_REQUESTS.map( ( { host, endpoint, method } ) => {
+		const call_count = Math.round( 10 + random() * 1990 );
+		const avg_ms = Math.round( 100 + random() * 1400 );
+		const max_ms = Math.round( avg_ms * ( 1.5 + random() * 5 ) );
+		return {
+			host,
+			endpoint,
+			method,
+			call_count,
+			avg_ms,
+			max_ms,
+			total_ms: call_count * avg_ms,
+		};
+	} ).sort( ( a, b ) => b.max_ms - a.max_ms );
+}
+
+function fetchApmTransactions( siteId: number ): Promise< ApmTransaction[] > {
+	return Promise.resolve( generateTransactions( siteId ) );
+}
+
+function fetchApmSlowQueries( siteId: number ): Promise< ApmSlowQuery[] > {
+	return Promise.resolve( generateSlowQueries( siteId ) );
+}
+
+function fetchApmExternalRequests( siteId: number ): Promise< ApmExternalRequest[] > {
+	return Promise.resolve( generateExternalRequests( siteId ) );
+}
+
 function fetchApmOverview( siteId: number ): Promise< ApmOverview > {
 	const random = rng( siteId );
 	const now = Date.now();
@@ -254,4 +358,22 @@ export const siteApmWordPressQuery = ( siteId: number ) =>
 	queryOptions( {
 		queryKey: [ 'site', siteId, 'apm', 'wordpress' ],
 		queryFn: () => fetchApmWordPress( siteId ),
+	} );
+
+export const siteApmTransactionsQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'apm', 'transactions' ],
+		queryFn: () => fetchApmTransactions( siteId ),
+	} );
+
+export const siteApmSlowQueriesQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'apm', 'slow-queries' ],
+		queryFn: () => fetchApmSlowQueries( siteId ),
+	} );
+
+export const siteApmExternalRequestsQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'apm', 'external-requests' ],
+		queryFn: () => fetchApmExternalRequests( siteId ),
 	} );

--- a/client/dashboard/sites/performance/backend/mock-data.ts
+++ b/client/dashboard/sites/performance/backend/mock-data.ts
@@ -4,11 +4,15 @@
 // `@automattic/api-queries`, then delete this file.
 import { queryOptions } from '@tanstack/react-query';
 import type {
+	ApmHookUsage,
 	ApmOverview,
+	ApmPluginUsage,
 	ApmRequestDetail,
 	ApmSlowRequest,
 	ApmSummary,
+	ApmTemplateUsage,
 	ApmTimePoint,
+	ApmWordPress,
 } from '@automattic/api-core';
 
 function rng( seed: number ) {
@@ -92,18 +96,100 @@ function generateSummary( timeseries: ApmTimePoint[], slowRequests: ApmSlowReque
 			acc.total += point.db + point.wp_core + point.plugins + point.external + point.cache;
 			acc.db += point.db;
 			acc.external += point.external;
+			acc.plugins += point.plugins;
 			return acc;
 		},
-		{ total: 0, db: 0, external: 0 }
+		{ total: 0, db: 0, external: 0, plugins: 0 }
 	);
 	const points = Math.max( timeseries.length, 1 );
 	return {
 		avg_response_ms: Math.round( totals.total / points ),
-		slow_request_count: slowRequests.length,
 		transaction_count: 1000 + slowRequests.length * 47,
 		db_avg_ms: Math.round( totals.db / points ),
 		external_avg_ms: Math.round( totals.external / points ),
+		plugins_avg_ms: Math.round( totals.plugins / points ),
 	};
+}
+
+const SAMPLE_PLUGINS: Array< { slug: string; name: string } > = [
+	{ slug: 'jetpack', name: 'Jetpack' },
+	{ slug: 'woocommerce', name: 'WooCommerce' },
+	{ slug: 'akismet', name: 'Akismet Anti-spam' },
+	{ slug: 'yoast-seo', name: 'Yoast SEO' },
+	{ slug: 'wpforms-lite', name: 'WPForms Lite' },
+	{ slug: 'elementor', name: 'Elementor' },
+	{ slug: 'wordfence', name: 'Wordfence Security' },
+	{ slug: 'classic-editor', name: 'Classic Editor' },
+];
+
+const SAMPLE_HOOKS = [
+	'init',
+	'wp_loaded',
+	'template_redirect',
+	'wp_enqueue_scripts',
+	'plugins_loaded',
+	'admin_init',
+	'pre_get_posts',
+	'shutdown',
+	'rest_api_init',
+	'save_post',
+];
+
+const SAMPLE_TEMPLATES = [
+	'single.php',
+	'page.php',
+	'archive.php',
+	'index.php',
+	'header.php',
+	'footer.php',
+	'sidebar.php',
+	'searchform.php',
+	'404.php',
+	'category.php',
+];
+
+function generateWordPress( seed: number ): ApmWordPress {
+	const random = rng( seed ^ 0x57504d50 );
+
+	const plugins: ApmPluginUsage[] = SAMPLE_PLUGINS.map( ( plugin ) => {
+		const call_count = Math.round( 200 + random() * 4800 );
+		const avg_ms = Math.round( 5 + random() * 95 );
+		return {
+			slug: plugin.slug,
+			name: plugin.name,
+			call_count,
+			avg_ms,
+			total_ms: call_count * avg_ms,
+		};
+	} ).sort( ( a, b ) => b.total_ms - a.total_ms );
+
+	const hooks: ApmHookUsage[] = SAMPLE_HOOKS.map( ( name ) => {
+		const call_count = Math.round( 500 + random() * 9500 );
+		const avg_ms = Math.round( 1 + random() * 40 );
+		return {
+			name,
+			call_count,
+			avg_ms,
+			total_ms: call_count * avg_ms,
+		};
+	} ).sort( ( a, b ) => b.total_ms - a.total_ms );
+
+	const templates: ApmTemplateUsage[] = SAMPLE_TEMPLATES.map( ( template ) => {
+		const hit_count = Math.round( 50 + random() * 2950 );
+		const avg_ms = Math.round( 20 + random() * 380 );
+		return {
+			template,
+			hit_count,
+			avg_ms,
+			total_ms: hit_count * avg_ms,
+		};
+	} ).sort( ( a, b ) => b.total_ms - a.total_ms );
+
+	return { plugins, hooks, templates };
+}
+
+function fetchApmWordPress( siteId: number ): Promise< ApmWordPress > {
+	return Promise.resolve( generateWordPress( siteId ) );
 }
 
 function fetchApmOverview( siteId: number ): Promise< ApmOverview > {
@@ -162,4 +248,10 @@ export const siteApmRequestQuery = ( siteId: number, requestId: string ) =>
 	queryOptions( {
 		queryKey: [ 'site', siteId, 'apm', 'request', requestId ],
 		queryFn: () => fetchApmRequest( siteId, requestId ),
+	} );
+
+export const siteApmWordPressQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'apm', 'wordpress' ],
+		queryFn: () => fetchApmWordPress( siteId ),
 	} );

--- a/client/dashboard/sites/performance/backend/overview/chart-slot.tsx
+++ b/client/dashboard/sites/performance/backend/overview/chart-slot.tsx
@@ -3,9 +3,10 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { Card, CardBody, CardHeader } from '../../../../components/card';
 import { Text } from '../../../../components/text';
+import { formatMs } from '../utils';
 import type { ApmTimePoint } from '@automattic/api-core';
 
 import '@automattic/charts/style.css';
@@ -28,21 +29,6 @@ function toSeriesData( timeseries: ApmTimePoint[] ): SeriesData[] {
 			value: point[ key ],
 		} ) ),
 	} ) );
-}
-
-function formatMs( ms: number ): string {
-	if ( ms >= 1000 ) {
-		return sprintf(
-			/* translators: %s is a number of seconds. */
-			__( '%s s' ),
-			( ms / 1000 ).toFixed( 2 )
-		);
-	}
-	return sprintf(
-		/* translators: %d is a number of milliseconds. */
-		__( '%d ms' ),
-		ms
-	);
 }
 
 function getAverageTotal( timeseries: ApmTimePoint[] ): number {

--- a/client/dashboard/sites/performance/backend/overview/index.tsx
+++ b/client/dashboard/sites/performance/backend/overview/index.tsx
@@ -11,7 +11,7 @@ export default function Overview( { site }: { site: Site } ) {
 	return (
 		<VStack spacing={ 6 }>
 			<ChartSlot timeseries={ data.timeseries } />
-			<SlowRequestsList site={ site } slowRequests={ data.slow_requests } />
+			<SlowRequestsList slowRequests={ data.slow_requests } />
 		</VStack>
 	);
 }

--- a/client/dashboard/sites/performance/backend/overview/slow-requests-list.tsx
+++ b/client/dashboard/sites/performance/backend/overview/slow-requests-list.tsx
@@ -1,22 +1,17 @@
-import { BarListChart, GlobalChartsProvider, type SeriesData } from '@automattic/charts';
-import { useRouter } from '@tanstack/react-router';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
-	Button,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState } from 'react';
-import { Card, CardBody, CardHeader, CardFooter } from '../../../../components/card';
+import { Card, CardBody, CardHeader } from '../../../../components/card';
 import { Text } from '../../../../components/text';
-import type { ApmSlowRequest, Site } from '@automattic/api-core';
-
-import '@automattic/charts/style.css';
+import BarList, { type BarListRow } from '../bar-list';
+import type { ApmSlowRequest } from '@automattic/api-core';
 
 type Metric = 'avg' | 'max';
-const CHART_ID = 'apm-slow-requests';
 
 function formatDuration( ms: number ): string {
 	if ( ms >= 1000 ) {
@@ -33,16 +28,12 @@ function formatDuration( ms: number ): string {
 	);
 }
 
-function toSeriesData( requests: ApmSlowRequest[], metric: Metric ): SeriesData[] {
-	return [
-		{
-			label: metric === 'avg' ? __( 'Average' ) : __( 'Max' ),
-			data: requests.map( ( request ) => ( {
-				label: `${ request.method } ${ request.url }`,
-				value: metric === 'avg' ? request.avg_duration_ms : request.duration_ms,
-			} ) ),
-		},
-	];
+function toRows( requests: ApmSlowRequest[], metric: Metric ): BarListRow[] {
+	return requests.map( ( request ) => ( {
+		id: request.id,
+		label: `${ request.method } ${ request.url }`,
+		value: metric === 'avg' ? request.avg_duration_ms : request.duration_ms,
+	} ) );
 }
 
 function pickHeadlineDuration( requests: ApmSlowRequest[], metric: Metric ): number {
@@ -56,25 +47,11 @@ function pickHeadlineDuration( requests: ApmSlowRequest[], metric: Metric ): num
 	return requests.reduce( ( max, r ) => Math.max( max, r.duration_ms ), 0 );
 }
 
-export default function SlowRequestsList( {
-	site,
-	slowRequests,
-}: {
-	site: Site;
-	slowRequests: ApmSlowRequest[];
-} ) {
-	const router = useRouter();
+export default function SlowRequestsList( { slowRequests }: { slowRequests: ApmSlowRequest[] } ) {
 	const [ metric, setMetric ] = useState< Metric >( 'max' );
 
-	const data = toSeriesData( slowRequests, metric );
+	const rows = toRows( slowRequests, metric );
 	const headline = pickHeadlineDuration( slowRequests, metric );
-	const height = Math.max( 240, slowRequests.length * 36 );
-
-	const viewAllRequests = () => {
-		router.navigate( {
-			to: `/sites/${ site.slug }/performance/backend/requests`,
-		} );
-	};
 
 	const description =
 		metric === 'avg'
@@ -109,25 +86,8 @@ export default function SlowRequestsList( {
 				</HStack>
 			</CardHeader>
 			<CardBody>
-				<GlobalChartsProvider>
-					<BarListChart
-						chartId={ CHART_ID }
-						data={ data }
-						height={ height }
-						withTooltips
-						options={ {
-							yScale: {},
-							xScale: {},
-							valueFormatter: formatDuration,
-						} }
-					/>
-				</GlobalChartsProvider>
+				<BarList rows={ rows } valueFormatter={ formatDuration } />
 			</CardBody>
-			<CardFooter>
-				<Button variant="secondary" onClick={ viewAllRequests }>
-					{ __( 'View all requests' ) }
-				</Button>
-			</CardFooter>
 		</Card>
 	);
 }

--- a/client/dashboard/sites/performance/backend/overview/slow-requests-list.tsx
+++ b/client/dashboard/sites/performance/backend/overview/slow-requests-list.tsx
@@ -4,29 +4,15 @@ import {
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
 import { Card, CardBody, CardHeader } from '../../../../components/card';
 import { Text } from '../../../../components/text';
 import BarList, { type BarListRow } from '../bar-list';
+import { formatMs } from '../utils';
 import type { ApmSlowRequest } from '@automattic/api-core';
 
 type Metric = 'avg' | 'max';
-
-function formatDuration( ms: number ): string {
-	if ( ms >= 1000 ) {
-		return sprintf(
-			/* translators: %s is a number of seconds. */
-			__( '%s s' ),
-			( ms / 1000 ).toFixed( 2 )
-		);
-	}
-	return sprintf(
-		/* translators: %d is a number of milliseconds. */
-		__( '%d ms' ),
-		ms
-	);
-}
 
 function toRows( requests: ApmSlowRequest[], metric: Metric ): BarListRow[] {
 	return requests.map( ( request ) => ( {
@@ -67,7 +53,7 @@ export default function SlowRequestsList( { slowRequests }: { slowRequests: ApmS
 							{ __( 'Slowest requests' ) }
 						</Text>
 						<Text size={ 32 } weight={ 500 } lineHeight="40px">
-							{ formatDuration( headline ) }
+							{ formatMs( headline ) }
 						</Text>
 						<Text variant="muted">{ description }</Text>
 					</VStack>
@@ -86,7 +72,7 @@ export default function SlowRequestsList( { slowRequests }: { slowRequests: ApmS
 				</HStack>
 			</CardHeader>
 			<CardBody>
-				<BarList rows={ rows } valueFormatter={ formatDuration } />
+				<BarList rows={ rows } valueFormatter={ formatMs } />
 			</CardBody>
 		</Card>
 	);

--- a/client/dashboard/sites/performance/backend/request-detail/index.tsx
+++ b/client/dashboard/sites/performance/backend/request-detail/index.tsx
@@ -5,23 +5,13 @@ import {
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import Breadcrumbs from '../../../../app/breadcrumbs';
 import { Card, CardHeader } from '../../../../components/card';
 import { PageHeader } from '../../../../components/page-header';
 import PageLayout from '../../../../components/page-layout';
 import { siteApmRequestQuery } from '../mock-data';
-
-function formatMs( ms: number ): string {
-	if ( ms >= 1000 ) {
-		return `${ ( ms / 1000 ).toFixed( 2 ) } s`;
-	}
-	return sprintf(
-		/* translators: %d is a number of milliseconds. */
-		__( '%d ms' ),
-		ms
-	);
-}
+import { formatMs } from '../utils';
 
 export default function RequestDetail( {
 	siteSlug,

--- a/client/dashboard/sites/performance/backend/requests/index.tsx
+++ b/client/dashboard/sites/performance/backend/requests/index.tsx
@@ -1,6 +1,0 @@
-import { __experimentalText as Text } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-
-export default function Requests() {
-	return <Text variant="muted">{ __( 'Coming soon.' ) }</Text>;
-}

--- a/client/dashboard/sites/performance/backend/slow-list.tsx
+++ b/client/dashboard/sites/performance/backend/slow-list.tsx
@@ -1,0 +1,92 @@
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useState } from 'react';
+import { Card, CardBody, CardHeader } from '../../../components/card';
+import { Text } from '../../../components/text';
+import BarList from './bar-list';
+import { formatMs } from './utils';
+
+export interface SlowListItem {
+	id: string;
+	label: string;
+	avg_ms: number;
+	max_ms: number;
+}
+
+export type SlowListMetric = 'avg' | 'max';
+
+function headlineFor( items: SlowListItem[], metric: SlowListMetric ): number {
+	if ( ! items.length ) {
+		return 0;
+	}
+	if ( metric === 'avg' ) {
+		const total = items.reduce( ( sum, item ) => sum + item.avg_ms, 0 );
+		return Math.round( total / items.length );
+	}
+	return items.reduce( ( max, item ) => Math.max( max, item.max_ms ), 0 );
+}
+
+export default function SlowList( {
+	title,
+	avgDescription,
+	maxDescription,
+	items,
+	defaultMetric = 'max',
+}: {
+	title: string;
+	avgDescription: string;
+	maxDescription: string;
+	items: SlowListItem[];
+	defaultMetric?: SlowListMetric;
+} ) {
+	const [ metric, setMetric ] = useState< SlowListMetric >( defaultMetric );
+
+	const sorted = [ ...items ].sort( ( a, b ) =>
+		metric === 'avg' ? b.avg_ms - a.avg_ms : b.max_ms - a.max_ms
+	);
+	const rows = sorted.map( ( item ) => ( {
+		id: item.id,
+		label: item.label,
+		value: metric === 'avg' ? item.avg_ms : item.max_ms,
+	} ) );
+	const headline = headlineFor( items, metric );
+	const description = metric === 'avg' ? avgDescription : maxDescription;
+
+	return (
+		<Card>
+			<CardHeader>
+				<HStack wrap spacing={ 4 } justify="space-between" alignment="flex-start">
+					<VStack spacing={ 2 } alignment="flex-start">
+						<Text size="title" weight={ 500 } as="h2">
+							{ title }
+						</Text>
+						<Text size={ 32 } weight={ 500 } lineHeight="40px">
+							{ formatMs( headline ) }
+						</Text>
+						<Text variant="muted">{ description }</Text>
+					</VStack>
+					<ToggleGroupControl
+						value={ metric }
+						isBlock
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+						onChange={ ( value ) => setMetric( ( value as SlowListMetric ) ?? defaultMetric ) }
+						label={ __( 'Duration metric' ) }
+						hideLabelFromVision
+					>
+						<ToggleGroupControlOption value="avg" label={ __( 'Avg' ) } />
+						<ToggleGroupControlOption value="max" label={ __( 'Max' ) } />
+					</ToggleGroupControl>
+				</HStack>
+			</CardHeader>
+			<CardBody>
+				<BarList rows={ rows } valueFormatter={ formatMs } />
+			</CardBody>
+		</Card>
+	);
+}

--- a/client/dashboard/sites/performance/backend/test/index.test.tsx
+++ b/client/dashboard/sites/performance/backend/test/index.test.tsx
@@ -90,6 +90,38 @@ describe( '<SitePerformanceBackend>', () => {
 		expect( screen.getByRole( 'heading', { name: 'Templates' } ) ).toBeVisible();
 	} );
 
+	test( 'shows a status notice with the average response time', async () => {
+		mockSite( businessSite( true ) );
+
+		render( <SitePerformanceBackend siteSlug={ siteSlug } /> );
+
+		// The notice variant depends on seeded mock data, but one of these three
+		// titles must always appear and must include the formatted avg duration.
+		expect(
+			await screen.findByText(
+				/(Healthy backend|Backend needs improvement|Backend is slow) — avg /
+			)
+		).toBeVisible();
+	} );
+
+	test( 'toggling Avg/Max on Slowest requests updates the description', async () => {
+		mockSite( businessSite( true ) );
+
+		render( <SitePerformanceBackend siteSlug={ siteSlug } /> );
+
+		// Wait for the Slowest requests card to mount.
+		await screen.findByRole( 'heading', { name: 'Slowest requests' } );
+
+		expect( screen.getByText( /Slowest single response observed/ ) ).toBeVisible();
+
+		await userEvent.click( screen.getByRole( 'radio', { name: 'Avg' } ) );
+
+		expect(
+			screen.getByText( /Average response time across the slowest endpoints/ )
+		).toBeVisible();
+		expect( screen.queryByText( /Slowest single response observed/ ) ).not.toBeInTheDocument();
+	} );
+
 	test( 'clicking Enable POSTs { active: true }', async () => {
 		mockSite( businessSite( false ) );
 		const scope = mockApmToggle( true );

--- a/client/dashboard/sites/performance/backend/test/index.test.tsx
+++ b/client/dashboard/sites/performance/backend/test/index.test.tsx
@@ -90,6 +90,36 @@ describe( '<SitePerformanceBackend>', () => {
 		expect( screen.getByRole( 'heading', { name: 'Templates' } ) ).toBeVisible();
 	} );
 
+	test( 'renders Slowest transactions on the Transactions tab', async () => {
+		mockSite( businessSite( true ) );
+
+		render( <SitePerformanceBackend siteSlug={ siteSlug } tab="transactions" /> );
+
+		expect( await screen.findByRole( 'heading', { name: 'Slowest transactions' } ) ).toBeVisible();
+		expect( screen.getByText( /GET \/wp-json\/wp\/v2\/posts/ ) ).toBeVisible();
+		expect( screen.getByRole( 'radio', { name: 'Max' } ) ).toBeChecked();
+	} );
+
+	test( 'renders Slowest queries on the Database tab', async () => {
+		mockSite( businessSite( true ) );
+
+		render( <SitePerformanceBackend siteSlug={ siteSlug } tab="database" /> );
+
+		expect( await screen.findByRole( 'heading', { name: 'Slowest queries' } ) ).toBeVisible();
+		expect( screen.getByText( /SELECT \* FROM wp_woocommerce_order_items/ ) ).toBeVisible();
+	} );
+
+	test( 'renders Slowest external requests on the External tab', async () => {
+		mockSite( businessSite( true ) );
+
+		render( <SitePerformanceBackend siteSlug={ siteSlug } tab="external-requests" /> );
+
+		expect(
+			await screen.findByRole( 'heading', { name: 'Slowest external requests' } )
+		).toBeVisible();
+		expect( screen.getByText( /api\.stripe\.com/ ) ).toBeVisible();
+	} );
+
 	test( 'shows a status notice with the average response time', async () => {
 		mockSite( businessSite( true ) );
 

--- a/client/dashboard/sites/performance/backend/test/index.test.tsx
+++ b/client/dashboard/sites/performance/backend/test/index.test.tsx
@@ -80,6 +80,16 @@ describe( '<SitePerformanceBackend>', () => {
 		expect( screen.getByRole( 'heading', { name: 'Slowest requests' } ) ).toBeVisible();
 	} );
 
+	test( 'renders Plugins, Hooks and Templates on the WordPress tab', async () => {
+		mockSite( businessSite( true ) );
+
+		render( <SitePerformanceBackend siteSlug={ siteSlug } tab="wordpress" /> );
+
+		expect( await screen.findByRole( 'heading', { name: 'Plugins' } ) ).toBeVisible();
+		expect( screen.getByRole( 'heading', { name: 'Hooks' } ) ).toBeVisible();
+		expect( screen.getByRole( 'heading', { name: 'Templates' } ) ).toBeVisible();
+	} );
+
 	test( 'clicking Enable POSTs { active: true }', async () => {
 		mockSite( businessSite( false ) );
 		const scope = mockApmToggle( true );

--- a/client/dashboard/sites/performance/backend/transactions/index.tsx
+++ b/client/dashboard/sites/performance/backend/transactions/index.tsx
@@ -1,6 +1,31 @@
-import { __experimentalText as Text } from '@wordpress/components';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
+import { siteApmTransactionsQuery } from '../mock-data';
+import SlowList, { type SlowListItem } from '../slow-list';
+import type { ApmTransaction, Site } from '@automattic/api-core';
 
-export default function Transactions() {
-	return <Text variant="muted">{ __( 'Coming soon.' ) }</Text>;
+function toItems( transactions: ApmTransaction[] ): SlowListItem[] {
+	return transactions.map( ( transaction ) => ( {
+		id: `${ transaction.method } ${ transaction.url }`,
+		label: `${ transaction.method } ${ transaction.url }`,
+		avg_ms: transaction.avg_ms,
+		max_ms: transaction.max_ms,
+	} ) );
+}
+
+export default function Transactions( { site }: { site: Site } ) {
+	const { data } = useSuspenseQuery( siteApmTransactionsQuery( site.ID ) );
+
+	return (
+		<SlowList
+			title={ __( 'Slowest transactions' ) }
+			avgDescription={ __(
+				'Average response time per route across all transactions in the selected period.'
+			) }
+			maxDescription={ __(
+				'Slowest single transaction observed on each route in the selected period.'
+			) }
+			items={ toItems( data ) }
+		/>
+	);
 }

--- a/client/dashboard/sites/performance/backend/utils.ts
+++ b/client/dashboard/sites/performance/backend/utils.ts
@@ -1,0 +1,43 @@
+import { __, sprintf } from '@wordpress/i18n';
+
+export type Intent = 'success' | 'warning' | 'error';
+
+export interface ThresholdMs {
+	good: number;
+	warn: number;
+}
+
+export const BACKEND_THRESHOLDS_MS: Record<
+	'response' | 'db' | 'external' | 'plugins',
+	ThresholdMs
+> = {
+	response: { good: 500, warn: 1500 },
+	db: { good: 200, warn: 600 },
+	external: { good: 200, warn: 600 },
+	plugins: { good: 100, warn: 300 },
+};
+
+export function bucketByMs( ms: number, { good, warn }: ThresholdMs ): Intent {
+	if ( ms <= good ) {
+		return 'success';
+	}
+	if ( ms <= warn ) {
+		return 'warning';
+	}
+	return 'error';
+}
+
+export function formatMs( ms: number ): string {
+	if ( ms >= 1000 ) {
+		return sprintf(
+			/* translators: %s is a number of seconds. */
+			__( '%s s' ),
+			( ms / 1000 ).toFixed( 2 )
+		);
+	}
+	return sprintf(
+		/* translators: %d is a number of milliseconds. */
+		__( '%d ms' ),
+		ms
+	);
+}

--- a/client/dashboard/sites/performance/backend/wordpress/index.tsx
+++ b/client/dashboard/sites/performance/backend/wordpress/index.tsx
@@ -1,0 +1,118 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { Card, CardBody, CardHeader } from '../../../../components/card';
+import { Text } from '../../../../components/text';
+import BarList, { type BarListRow } from '../bar-list';
+import { siteApmWordPressQuery } from '../mock-data';
+import type { ApmHookUsage, ApmPluginUsage, ApmTemplateUsage, Site } from '@automattic/api-core';
+
+function formatMs( ms: number ): string {
+	if ( ms >= 1000 ) {
+		return sprintf(
+			/* translators: %s is a number of seconds. */
+			__( '%s s' ),
+			( ms / 1000 ).toFixed( 2 )
+		);
+	}
+	return sprintf(
+		/* translators: %d is a number of milliseconds. */
+		__( '%d ms' ),
+		ms
+	);
+}
+
+function totalMs( items: Array< { total_ms: number } > ): number {
+	return items.reduce( ( sum, item ) => sum + item.total_ms, 0 );
+}
+
+function Section( {
+	title,
+	headline,
+	description,
+	rows,
+}: {
+	title: string;
+	headline: string;
+	description: string;
+	rows: BarListRow[];
+} ) {
+	return (
+		<Card>
+			<CardHeader>
+				<HStack wrap spacing={ 4 } justify="space-between" alignment="flex-start">
+					<VStack spacing={ 2 } alignment="flex-start">
+						<Text size="title" weight={ 500 } as="h2">
+							{ title }
+						</Text>
+						<Text size={ 32 } weight={ 500 } lineHeight="40px">
+							{ headline }
+						</Text>
+						<Text variant="muted">{ description }</Text>
+					</VStack>
+				</HStack>
+			</CardHeader>
+			<CardBody>
+				<BarList rows={ rows } valueFormatter={ formatMs } />
+			</CardBody>
+		</Card>
+	);
+}
+
+function pluginsToRows( plugins: ApmPluginUsage[] ): BarListRow[] {
+	return plugins.map( ( plugin ) => ( {
+		id: plugin.slug,
+		label: plugin.name,
+		value: plugin.total_ms,
+	} ) );
+}
+
+function hooksToRows( hooks: ApmHookUsage[] ): BarListRow[] {
+	return hooks.map( ( hook ) => ( {
+		id: hook.name,
+		label: hook.name,
+		value: hook.total_ms,
+	} ) );
+}
+
+function templatesToRows( templates: ApmTemplateUsage[] ): BarListRow[] {
+	return templates.map( ( template ) => ( {
+		id: template.template,
+		label: template.template,
+		value: template.total_ms,
+	} ) );
+}
+
+export default function WordPress( { site }: { site: Site } ) {
+	const { data } = useSuspenseQuery( siteApmWordPressQuery( site.ID ) );
+
+	return (
+		<VStack spacing={ 6 }>
+			<Section
+				title={ __( 'Plugins' ) }
+				headline={ formatMs( totalMs( data.plugins ) ) }
+				description={ __( 'Total time consumed by each active plugin in the selected period.' ) }
+				rows={ pluginsToRows( data.plugins ) }
+			/>
+			<Section
+				title={ __( 'Hooks' ) }
+				headline={ formatMs( totalMs( data.hooks ) ) }
+				description={ __(
+					'Total time spent in the slowest action and filter hooks fired during the selected period.'
+				) }
+				rows={ hooksToRows( data.hooks ) }
+			/>
+			<Section
+				title={ __( 'Templates' ) }
+				headline={ formatMs( totalMs( data.templates ) ) }
+				description={ __(
+					'Total time spent rendering each theme template in the selected period.'
+				) }
+				rows={ templatesToRows( data.templates ) }
+			/>
+		</VStack>
+	);
+}

--- a/client/dashboard/sites/performance/backend/wordpress/index.tsx
+++ b/client/dashboard/sites/performance/backend/wordpress/index.tsx
@@ -3,27 +3,13 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { Card, CardBody, CardHeader } from '../../../../components/card';
 import { Text } from '../../../../components/text';
 import BarList, { type BarListRow } from '../bar-list';
 import { siteApmWordPressQuery } from '../mock-data';
+import { formatMs } from '../utils';
 import type { ApmHookUsage, ApmPluginUsage, ApmTemplateUsage, Site } from '@automattic/api-core';
-
-function formatMs( ms: number ): string {
-	if ( ms >= 1000 ) {
-		return sprintf(
-			/* translators: %s is a number of seconds. */
-			__( '%s s' ),
-			( ms / 1000 ).toFixed( 2 )
-		);
-	}
-	return sprintf(
-		/* translators: %d is a number of milliseconds. */
-		__( '%d ms' ),
-		ms
-	);
-}
 
 function totalMs( items: Array< { total_ms: number } > ): number {
 	return items.reduce( ( sum, item ) => sum + item.total_ms, 0 );

--- a/packages/api-core/src/site-hosting-apm/types.ts
+++ b/packages/api-core/src/site-hosting-apm/types.ts
@@ -21,14 +21,42 @@ export type ApmRequestDetail = ApmSlowRequest;
 
 export interface ApmSummary {
 	avg_response_ms: number;
-	slow_request_count: number;
 	transaction_count: number;
 	db_avg_ms: number;
 	external_avg_ms: number;
+	plugins_avg_ms: number;
 }
 
 export interface ApmOverview {
 	summary: ApmSummary;
 	timeseries: ApmTimePoint[];
 	slow_requests: ApmSlowRequest[];
+}
+
+export interface ApmPluginUsage {
+	slug: string;
+	name: string;
+	total_ms: number;
+	avg_ms: number;
+	call_count: number;
+}
+
+export interface ApmHookUsage {
+	name: string;
+	total_ms: number;
+	avg_ms: number;
+	call_count: number;
+}
+
+export interface ApmTemplateUsage {
+	template: string;
+	total_ms: number;
+	avg_ms: number;
+	hit_count: number;
+}
+
+export interface ApmWordPress {
+	plugins: ApmPluginUsage[];
+	hooks: ApmHookUsage[];
+	templates: ApmTemplateUsage[];
 }

--- a/packages/api-core/src/site-hosting-apm/types.ts
+++ b/packages/api-core/src/site-hosting-apm/types.ts
@@ -60,3 +60,31 @@ export interface ApmWordPress {
 	hooks: ApmHookUsage[];
 	templates: ApmTemplateUsage[];
 }
+
+export interface ApmTransaction {
+	method: string;
+	url: string;
+	avg_ms: number;
+	max_ms: number;
+	call_count: number;
+	total_ms: number;
+}
+
+export interface ApmSlowQuery {
+	id: string;
+	query: string;
+	avg_ms: number;
+	max_ms: number;
+	call_count: number;
+	total_ms: number;
+}
+
+export interface ApmExternalRequest {
+	host: string;
+	endpoint: string;
+	method: string;
+	avg_ms: number;
+	max_ms: number;
+	call_count: number;
+	total_ms: number;
+}


### PR DESCRIPTION
Stacked on top of #110558.

## Proposed Changes

- **Side-rail tabs** reordered to Avg response / Transactions / **WordPress** / Database / External. The Slow tile is removed; the standalone Requests sub-tab (which only rendered "Coming soon") is removed too. Slow-request samples remain reachable from the Overview card and from the per-trace drill-down.
- **New WordPress sub-tab** with three sections — Plugins, Hooks, Templates. Each is a `Card` with a headline metric and a bar list of the top items, modelled after what Kinsta APM and New Relic surface for WordPress hosts.
- **New shared `BarList` component** (`client/dashboard/sites/performance/backend/bar-list.tsx`) renders a full-width tracked bar with the label overlaid. Long labels overflow onto the track instead of white space, and every label is always rendered.
- **Slowest requests card on Overview** switches from `BarListChart` to the shared `BarList` for the same overflow handling and consistent visual language.
- **API types** (`@automattic/api-core`): adds `ApmPluginUsage`, `ApmHookUsage`, `ApmTemplateUsage`, `ApmWordPress`. Adds `plugins_avg_ms` to `ApmSummary`; drops the now-unused `slow_request_count`.
- **Shared `utils.ts`** (`client/dashboard/sites/performance/backend/utils.ts`) consolidates the `formatMs` helper (previously copy-pasted across six files, with one copy missing i18n on the seconds branch) and the per-metric thresholds (`response` / `db` / `external` / `plugins`) into one place, so the status notice and the side-rail tabs can't bucket the same value differently.

## Why are these changes being made?

The previous side rail surfaced "Slow requests" but no plugin/hook attribution — the highest-leverage WordPress-specific view, judging from how reference APM tools structure their dashboards (New Relic's WordPress integration and Kinsta APM both lead with this). Adding the WordPress sub-tab lays down the UI surface the new backend querying system will feed into.

The shared `BarList` replaces `BarListChart` from `@automattic/charts` because that component hides labels on alternating rows and lets long labels overflow into white space when the value is small — visible on the existing Overview slow-requests card.

This PR is the starting point of the frontend work for the in-memory APM query system; further filters (time range, request kind, route grouping) will stack on top.

## Testing Instructions

1. `yarn start-dashboard`
2. Visit `/sites/<slug>/performance/backend` on a Business+ Atomic site with `apm_enabled`.
3. **Side rail**: confirm the five tiles are Avg response / Transactions / WordPress / Database / External; the Slow tile is gone.
4. **WordPress tab**: clicking it changes the URL and shows three cards — Plugins, Hooks, Templates — each with a headline total and a bar list. Long names (e.g., Yoast SEO) render with their label always visible and overflow gracefully onto the track.
5. **Overview tab**: the Slowest requests card uses the new bar list; the Avg / Max toggle still works and updates bar widths + the headline.
6. **Status notice** above the rail reflects the avg response time (success / warning / error variants).
7. The old `/sites/<slug>/performance/backend/requests` URL no longer resolves; `/.../performance/backend/requests/<id>` (per-trace drill-down) still does.
8. `yarn test-client client/dashboard/sites/performance/backend/test/index.test.tsx` (7/7 passes locally; covers the Enable / upsell paths, the WordPress sub-tab content, the status notice copy, and the Avg / Max toggle on the Slowest requests card).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
