### PR TITLE
Reader social sidebar: truncate long handles with ellipsis

### DIFF
--- a/client/reader/sidebar/social/social-account-menu-item.tsx
+++ b/client/reader/sidebar/social/social-account-menu-item.tsx
@@ -38,8 +38,12 @@ export function SocialAccountMenuItem( {
 					<SiteIcon iconUrl={ null } size={ 22 } />
 				) }
 				<div className="sidebar-social__account-text">
-					<div className="sidebar__menu-item-title">{ displayName }</div>
-					<div className="sidebar-social__account-handle">{ handle }</div>
+					<div className="sidebar__menu-item-title" title={ displayName }>
+						{ displayName }
+					</div>
+					<div className="sidebar-social__account-handle" title={ handle }>
+						{ handle }
+					</div>
 				</div>
 			</MenuItemLink>
 		</MenuItem>

--- a/client/reader/sidebar/social/style.scss
+++ b/client/reader/sidebar/social/style.scss
@@ -16,6 +16,24 @@
 	background-color: var( --color-sidebar-menu-selected-background );
 }
 
+// The link is `display: flex` with `overflow: hidden`. Without `min-width: 0`,
+// the text column refuses to shrink below its content width and long handles
+// (especially Mastodon-style `@user@instance` where username and instance are
+// the same domain) escape the sidebar. Truncate both the display name and the
+// handle with a single-line ellipsis; the native `title` attribute on each
+// element exposes the full value on hover.
+.sidebar-social__account-text {
+	flex: 1;
+	min-width: 0;
+}
+
+.sidebar-social__account-item .sidebar__menu-item-title,
+.sidebar-social__account-handle {
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+}
+
 .sidebar-social__account-handle {
 	display: block;
 	font-size: 0.67rem; /* stylelint-disable-line scales/font-sizes */


### PR DESCRIPTION
Fixes CM-715

## Proposed Changes

* Constrain `.sidebar-social__account-text` with `flex: 1; min-width: 0;` so it can shrink inside the flex link.
* Add a single-line ellipsis to both the display name (scoped to social rows) and the handle.
* Add `title={ displayName }` / `title={ handle }` so the full values remain available on hover and to assistive tech.

## Why are these changes being made?

Mastodon-style handles where the username and instance share a long domain (e.g. `@jehervevideo.wordpress.com@jehervevideo.wordpress.com`) overflowed the sidebar because the social account row's text column had no `min-width: 0` and the handle had no truncation rules — so the second half of the handle clipped out of the menu entirely.

The same `SocialAccountMenuItem` component renders Mastodon, ATmosphere, and Fediverse rows, so one change fixes all three protocols.

## Testing Instructions

1. Connect a Fediverse / Mastodon / ATmosphere account whose handle is long enough to overflow the sidebar (the duplicated-domain case above is the canonical worst case).
2. Open `/reader/fediverse/<id>/timeline` (or the equivalent Mastodon / ATmosphere route).
3. Confirm the account row in the sidebar stays inside the sidebar bounds, with the handle truncated by an ellipsis.
4. Hover over the handle and confirm a tooltip shows the full value. Repeat for the display name if it's long enough to truncate.

Smoke-tested locally at `http://calypso.localhost:3000/reader/fediverse/<id>/timeline`. \`yarn test-client client/reader/sidebar/social\`, \`yarn eslint\`, and \`yarn stylelint\` all pass on the changed files.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?