### PR TITLE
APM: Add fetcher and query for GET /hosting/apm/traces

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -635,24 +635,6 @@ export const sitePerformanceBackendIndexRoute = createRoute( {
 	)
 );
 
-export const sitePerformanceBackendRequestsRoute = createRoute( {
-	head: () => ( {
-		meta: [
-			{
-				title: isEnabled( 'dashboard/omnibar' ) ? __( 'Requests' ) : undefined,
-			},
-		],
-	} ),
-	getParentRoute: () => sitePerformanceBackendRoute,
-	path: 'requests',
-} ).lazy( () =>
-	import( '../../sites/performance/backend' ).then( ( d ) =>
-		createLazyRoute( 'site-performance-backend-requests' )( {
-			component: () => <d.default siteSlug={ siteRoute.useParams().siteSlug } tab="requests" />,
-		} )
-	)
-);
-
 export const sitePerformanceBackendTransactionsRoute = createRoute( {
 	head: () => ( {
 		meta: [
@@ -705,6 +687,29 @@ export const sitePerformanceBackendExternalRequestsRoute = createRoute( {
 			component: () => (
 				<d.default siteSlug={ siteRoute.useParams().siteSlug } tab="external-requests" />
 			),
+		} )
+	)
+);
+
+export const sitePerformanceBackendWordPressRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: isEnabled( 'dashboard/omnibar' ) ? __( 'WordPress' ) : undefined,
+			},
+		],
+	} ),
+	getParentRoute: () => sitePerformanceBackendRoute,
+	path: 'wordpress',
+	loader: async ( { params: { siteSlug } } ) => {
+		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+		const { siteApmWordPressQuery } = await import( '../../sites/performance/backend/mock-data' );
+		await queryClient.ensureQueryData( siteApmWordPressQuery( site.ID ) );
+	},
+} ).lazy( () =>
+	import( '../../sites/performance/backend' ).then( ( d ) =>
+		createLazyRoute( 'site-performance-backend-wordpress' )( {
+			component: () => <d.default siteSlug={ siteRoute.useParams().siteSlug } tab="wordpress" />,
 		} )
 	)
 );
@@ -1792,8 +1797,8 @@ export const createSitesRoutes = ( config: AppConfig ) => {
 				? [
 						sitePerformanceBackendRoute.addChildren( [
 							sitePerformanceBackendIndexRoute,
-							sitePerformanceBackendRequestsRoute,
 							sitePerformanceBackendTransactionsRoute,
+							sitePerformanceBackendWordPressRoute,
 							sitePerformanceBackendDatabaseRoute,
 							sitePerformanceBackendExternalRequestsRoute,
 							sitePerformanceBackendRequestDetailRoute,

--- a/client/dashboard/sites/performance/backend/backend-status.tsx
+++ b/client/dashboard/sites/performance/backend/backend-status.tsx
@@ -1,0 +1,81 @@
+import { __, sprintf } from '@wordpress/i18n';
+import { Notice } from '../../../components/notice';
+
+export type BackendStatus = 'good' | 'needsImprovement' | 'bad';
+
+export function getBackendStatus( avgResponseMs: number ): BackendStatus {
+	if ( avgResponseMs <= 500 ) {
+		return 'good';
+	}
+	if ( avgResponseMs <= 1500 ) {
+		return 'needsImprovement';
+	}
+	return 'bad';
+}
+
+function formatMs( ms: number ): string {
+	if ( ms >= 1000 ) {
+		return sprintf(
+			/* translators: %s is a number of seconds. */
+			__( '%s s' ),
+			( ms / 1000 ).toFixed( 2 )
+		);
+	}
+	return sprintf(
+		/* translators: %d is a number of milliseconds. */
+		__( '%d ms' ),
+		ms
+	);
+}
+
+export default function BackendStatusNotice( { avgResponseMs }: { avgResponseMs: number } ) {
+	const status = getBackendStatus( avgResponseMs );
+	const formatted = formatMs( avgResponseMs );
+
+	if ( status === 'bad' ) {
+		return (
+			<Notice
+				variant="error"
+				title={ sprintf(
+					/* translators: %s is the average response time. */
+					__( 'Backend is slow — avg %s' ),
+					formatted
+				) }
+			>
+				{ __(
+					'Most requests are taking longer than expected. Review the slowest requests below to find the cause.'
+				) }
+			</Notice>
+		);
+	}
+
+	if ( status === 'needsImprovement' ) {
+		return (
+			<Notice
+				variant="warning"
+				title={ sprintf(
+					/* translators: %s is the average response time. */
+					__( 'Backend needs improvement — avg %s' ),
+					formatted
+				) }
+			>
+				{ __(
+					'Some requests are running slow. Review the slowest requests below to make targeted improvements.'
+				) }
+			</Notice>
+		);
+	}
+
+	return (
+		<Notice
+			variant="success"
+			title={ sprintf(
+				/* translators: %s is the average response time. */
+				__( 'Healthy backend — avg %s' ),
+				formatted
+			) }
+		>
+			{ __( 'Most requests respond quickly. Review the slowest ones below to keep it that way.' ) }
+		</Notice>
+	);
+}

--- a/client/dashboard/sites/performance/backend/backend-tabs.tsx
+++ b/client/dashboard/sites/performance/backend/backend-tabs.tsx
@@ -1,0 +1,131 @@
+import { __experimentalVStack as VStack, privateApis } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
+import { __, sprintf } from '@wordpress/i18n';
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+import { Text } from '../../../components/text';
+import { VIEWPORT_BREAKPOINTS } from '../constants';
+import type { ApmTab } from '.';
+import type { ApmSummary } from '@automattic/api-core';
+
+const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+	'@wordpress/components'
+);
+
+const { Tabs } = unlock( privateApis );
+
+type Intent = 'success' | 'warning' | 'error';
+
+function formatMs( ms: number ): string {
+	if ( ms >= 1000 ) {
+		return sprintf(
+			/* translators: %s is a number of seconds. */
+			__( '%s s' ),
+			( ms / 1000 ).toFixed( 2 )
+		);
+	}
+	return sprintf(
+		/* translators: %d is a number of milliseconds. */
+		__( '%d ms' ),
+		ms
+	);
+}
+
+function formatCount( value: number ): string {
+	return new Intl.NumberFormat().format( value );
+}
+
+function bucketByMs( ms: number, good: number, warn: number ): Intent {
+	if ( ms <= good ) {
+		return 'success';
+	}
+	if ( ms <= warn ) {
+		return 'warning';
+	}
+	return 'error';
+}
+
+function Tab( {
+	tabId,
+	label,
+	value,
+	intent,
+}: {
+	tabId: ApmTab;
+	label: string;
+	value: string;
+	intent?: Intent;
+} ) {
+	const isDesktop = useViewportMatch( VIEWPORT_BREAKPOINTS.desktop );
+
+	return (
+		<Tabs.Tab tabId={ tabId } style={ { height: '100%' } }>
+			<VStack alignment={ isDesktop ? 'flex-start' : 'center' } spacing={ 0 }>
+				<Text size={ 11 } lineHeight="24px" upperCase variant="muted">
+					{ label }
+				</Text>
+				<Text size={ 16 } weight={ 500 } lineHeight="32px" intent={ intent }>
+					{ value }
+				</Text>
+			</VStack>
+		</Tabs.Tab>
+	);
+}
+
+export default function BackendTabs( {
+	summary,
+	compact,
+}: {
+	summary: ApmSummary;
+	compact?: boolean;
+} ) {
+	const items: Array< {
+		tabId: ApmTab;
+		label: string;
+		value: string;
+		intent?: Intent;
+	} > = [
+		{
+			tabId: 'overview',
+			label: compact ? __( 'Avg' ) : __( 'Avg response' ),
+			value: formatMs( summary.avg_response_ms ),
+			intent: bucketByMs( summary.avg_response_ms, 500, 1500 ),
+		},
+		{
+			tabId: 'requests',
+			label: compact ? __( 'Slow' ) : __( 'Slow requests' ),
+			value: formatCount( summary.slow_request_count ),
+		},
+		{
+			tabId: 'transactions',
+			label: __( 'Transactions' ),
+			value: formatCount( summary.transaction_count ),
+		},
+		{
+			tabId: 'database',
+			label: compact ? __( 'DB' ) : __( 'Database' ),
+			value: formatMs( summary.db_avg_ms ),
+			intent: bucketByMs( summary.db_avg_ms, 200, 600 ),
+		},
+		{
+			tabId: 'external-requests',
+			label: __( 'External' ),
+			value: formatMs( summary.external_avg_ms ),
+			intent: bucketByMs( summary.external_avg_ms, 200, 600 ),
+		},
+	];
+
+	return (
+		<Tabs.TabList style={ { maxWidth: '100%' } }>
+			{ items.map( ( item ) => (
+				<Tab
+					key={ item.tabId }
+					tabId={ item.tabId }
+					label={ item.label }
+					value={ item.value }
+					intent={ item.intent }
+				/>
+			) ) }
+		</Tabs.TabList>
+	);
+}

--- a/client/dashboard/sites/performance/backend/backend-tabs.tsx
+++ b/client/dashboard/sites/performance/backend/backend-tabs.tsx
@@ -92,14 +92,15 @@ export default function BackendTabs( {
 			intent: bucketByMs( summary.avg_response_ms, 500, 1500 ),
 		},
 		{
-			tabId: 'requests',
-			label: compact ? __( 'Slow' ) : __( 'Slow requests' ),
-			value: formatCount( summary.slow_request_count ),
-		},
-		{
 			tabId: 'transactions',
 			label: __( 'Transactions' ),
 			value: formatCount( summary.transaction_count ),
+		},
+		{
+			tabId: 'wordpress',
+			label: compact ? __( 'WP' ) : __( 'WordPress' ),
+			value: formatMs( summary.plugins_avg_ms ),
+			intent: bucketByMs( summary.plugins_avg_ms, 100, 300 ),
 		},
 		{
 			tabId: 'database',

--- a/client/dashboard/sites/performance/backend/bar-list.tsx
+++ b/client/dashboard/sites/performance/backend/bar-list.tsx
@@ -1,0 +1,79 @@
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { Text } from '../../../components/text';
+
+export type BarListRow = { id: string; label: string; value: number };
+
+export default function BarList( {
+	rows,
+	valueFormatter,
+}: {
+	rows: BarListRow[];
+	valueFormatter: ( value: number ) => string;
+} ) {
+	const max = Math.max( 1, ...rows.map( ( r ) => r.value ) );
+
+	return (
+		<VStack spacing={ 3 }>
+			{ rows.map( ( row ) => {
+				const fillPercent = ( row.value / max ) * 100;
+				return (
+					<HStack key={ row.id } spacing={ 4 } alignment="center">
+						<div
+							style={ {
+								position: 'relative',
+								flex: 1,
+								minWidth: 0,
+								height: 32,
+								borderRadius: 4,
+								overflow: 'hidden',
+								background:
+									'color-mix(in srgb, var(--wp-admin-theme-color, #3858e9) 8%, transparent)',
+							} }
+						>
+							<div
+								style={ {
+									position: 'absolute',
+									insetInlineStart: 0,
+									insetBlockStart: 0,
+									insetBlockEnd: 0,
+									width: `${ fillPercent }%`,
+									background:
+										'color-mix(in srgb, var(--wp-admin-theme-color, #3858e9) 32%, transparent)',
+								} }
+							/>
+							<div
+								style={ {
+									position: 'absolute',
+									insetBlockStart: 0,
+									insetBlockEnd: 0,
+									insetInlineStart: 0,
+									insetInlineEnd: 0,
+									paddingInline: 12,
+									display: 'flex',
+									alignItems: 'center',
+								} }
+							>
+								<Text
+									style={ {
+										overflow: 'hidden',
+										textOverflow: 'ellipsis',
+										whiteSpace: 'nowrap',
+										width: '100%',
+									} }
+								>
+									{ row.label }
+								</Text>
+							</div>
+						</div>
+						<Text variant="muted" style={ { minWidth: 80, textAlign: 'end' } }>
+							{ valueFormatter( row.value ) }
+						</Text>
+					</HStack>
+				);
+			} ) }
+		</VStack>
+	);
+}

--- a/client/dashboard/sites/performance/backend/index.tsx
+++ b/client/dashboard/sites/performance/backend/index.tsx
@@ -2,18 +2,28 @@ import { type Site } from '@automattic/api-core';
 import { siteBySlugQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
-import { TabPanel } from '@wordpress/components';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	privateApis,
+} from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { Card, CardBody, CardHeader } from '../../../components/card';
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+import { Card } from '../../../components/card';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
 import UpsellCallout from '../../hosting-feature-gated-with-callout/upsell';
 import { hasBackendAccess } from '../backend-access';
 import { getBackendCalloutProps } from '../backend-callout';
+import { VIEWPORT_BREAKPOINTS } from '../constants';
 import PerformanceTabs from '../performance-tabs';
+import BackendStatusNotice from './backend-status';
+import BackendTabs from './backend-tabs';
 import Database from './database';
 import EnableApmCallout from './enable-apm-callout';
 import ExternalRequests from './external-requests';
+import { siteApmOverviewQuery } from './mock-data';
 import Overview from './overview';
 import Requests from './requests';
 import Transactions from './transactions';
@@ -28,17 +38,18 @@ const TAB_PATHS: Record< ApmTab, string > = {
 	'external-requests': 'external-requests',
 };
 
+const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+	'@wordpress/components'
+);
+
+const { Tabs } = unlock( privateApis );
+
 function ApmDashboard( { site, tab }: { site: Site; tab: ApmTab } ) {
 	const router = useRouter();
 	const siteSlug = site.slug;
-
-	const tabs = [
-		{ name: 'overview' as const, title: __( 'Overview' ) },
-		{ name: 'requests' as const, title: __( 'Requests' ) },
-		{ name: 'transactions' as const, title: __( 'Transactions' ) },
-		{ name: 'database' as const, title: __( 'Database' ) },
-		{ name: 'external-requests' as const, title: __( 'External requests' ) },
-	];
+	const isDesktop = useViewportMatch( VIEWPORT_BREAKPOINTS.desktop );
+	const { data } = useSuspenseQuery( siteApmOverviewQuery( site.ID ) );
 
 	const handleTabChange = ( name: string ) => {
 		const next = name as ApmTab;
@@ -69,19 +80,29 @@ function ApmDashboard( { site, tab }: { site: Site; tab: ApmTab } ) {
 	};
 
 	return (
-		<Card>
-			<CardHeader style={ { paddingBottom: 0 } }>
-				<TabPanel
-					activeClass="is-active"
-					tabs={ tabs }
-					initialTabName={ tab }
-					onSelect={ handleTabChange }
-				>
-					{ () => null }
-				</TabPanel>
-			</CardHeader>
-			<CardBody>{ renderTab() }</CardBody>
-		</Card>
+		<VStack spacing={ 6 }>
+			<BackendStatusNotice avgResponseMs={ data.summary.avg_response_ms } />
+			<Tabs
+				orientation={ isDesktop ? 'vertical' : 'horizontal' }
+				selectedTabId={ tab }
+				onSelect={ handleTabChange }
+			>
+				<HStack wrap={ ! isDesktop } alignment="flex-start" justify="flex-start" spacing={ 6 }>
+					<Card
+						style={ {
+							flex: '0 0 auto',
+							width: isDesktop ? 280 : '100%',
+							alignSelf: 'flex-start',
+						} }
+					>
+						<BackendTabs compact={ ! isDesktop } summary={ data.summary } />
+					</Card>
+					<div style={ { flex: '1 1 auto', minWidth: 0, width: '100%' } }>
+						<Tabs.TabPanel tabId={ tab }>{ renderTab() }</Tabs.TabPanel>
+					</div>
+				</HStack>
+			</Tabs>
+		</VStack>
 	);
 }
 

--- a/client/dashboard/sites/performance/backend/index.tsx
+++ b/client/dashboard/sites/performance/backend/index.tsx
@@ -25,15 +25,15 @@ import EnableApmCallout from './enable-apm-callout';
 import ExternalRequests from './external-requests';
 import { siteApmOverviewQuery } from './mock-data';
 import Overview from './overview';
-import Requests from './requests';
 import Transactions from './transactions';
+import WordPress from './wordpress';
 
-export type ApmTab = 'overview' | 'requests' | 'transactions' | 'database' | 'external-requests';
+export type ApmTab = 'overview' | 'transactions' | 'wordpress' | 'database' | 'external-requests';
 
 const TAB_PATHS: Record< ApmTab, string > = {
 	overview: '',
-	requests: 'requests',
 	transactions: 'transactions',
+	wordpress: 'wordpress',
 	database: 'database',
 	'external-requests': 'external-requests',
 };
@@ -68,10 +68,10 @@ function ApmDashboard( { site, tab }: { site: Site; tab: ApmTab } ) {
 		switch ( tab ) {
 			case 'overview':
 				return <Overview site={ site } />;
-			case 'requests':
-				return <Requests />;
 			case 'transactions':
 				return <Transactions />;
+			case 'wordpress':
+				return <WordPress site={ site } />;
 			case 'database':
 				return <Database />;
 			case 'external-requests':

--- a/client/dashboard/sites/performance/backend/mock-data.ts
+++ b/client/dashboard/sites/performance/backend/mock-data.ts
@@ -3,7 +3,13 @@
 // move the fetchers to `@automattic/api-core` and the queries to
 // `@automattic/api-queries`, then delete this file.
 import { queryOptions } from '@tanstack/react-query';
-import type { ApmOverview, ApmRequestDetail, ApmSlowRequest } from '@automattic/api-core';
+import type {
+	ApmOverview,
+	ApmRequestDetail,
+	ApmSlowRequest,
+	ApmSummary,
+	ApmTimePoint,
+} from '@automattic/api-core';
 
 function rng( seed: number ) {
 	let state = seed | 0;
@@ -61,6 +67,7 @@ function generateSlowRequests( seed: number, count: number ): ApmSlowRequest[] {
 			[ 'PUT', 0.15 ],
 		] );
 		const duration_ms = Math.round( 1500 + random() * 8500 );
+		const avg_duration_ms = Math.round( duration_ms * ( 0.25 + random() * 0.4 ) );
 		const status = pickWeighted( random, [
 			[ 200, 0.8 ],
 			[ 302, 0.15 ],
@@ -70,12 +77,33 @@ function generateSlowRequests( seed: number, count: number ): ApmSlowRequest[] {
 			id: `req-${ seed.toString( 36 ) }-${ i }`,
 			url,
 			method,
+			avg_duration_ms,
 			duration_ms,
 			status,
 			timestamp: now - Math.round( random() * 24 * 60 * 60 * 1000 ),
 		} );
 	}
 	return requests.sort( ( a, b ) => b.duration_ms - a.duration_ms );
+}
+
+function generateSummary( timeseries: ApmTimePoint[], slowRequests: ApmSlowRequest[] ): ApmSummary {
+	const totals = timeseries.reduce(
+		( acc, point ) => {
+			acc.total += point.db + point.wp_core + point.plugins + point.external + point.cache;
+			acc.db += point.db;
+			acc.external += point.external;
+			return acc;
+		},
+		{ total: 0, db: 0, external: 0 }
+	);
+	const points = Math.max( timeseries.length, 1 );
+	return {
+		avg_response_ms: Math.round( totals.total / points ),
+		slow_request_count: slowRequests.length,
+		transaction_count: 1000 + slowRequests.length * 47,
+		db_avg_ms: Math.round( totals.db / points ),
+		external_avg_ms: Math.round( totals.external / points ),
+	};
 }
 
 function fetchApmOverview( siteId: number ): Promise< ApmOverview > {
@@ -87,11 +115,14 @@ function fetchApmOverview( siteId: number ): Promise< ApmOverview > {
 		wp_core: Math.round( 50 + random() * 120 ),
 		plugins: Math.round( 60 + random() * 260 ),
 		external: Math.round( 20 + random() * 180 ),
+		cache: Math.round( 10 + random() * 80 ),
 	} ) );
+	const slowRequests = generateSlowRequests( siteId, 8 );
 
 	return Promise.resolve( {
+		summary: generateSummary( timeseries, slowRequests ),
 		timeseries,
-		slow_requests: generateSlowRequests( siteId, 8 ),
+		slow_requests: slowRequests,
 	} );
 }
 
@@ -102,12 +133,14 @@ function fetchApmSlowRequests( siteId: number ): Promise< ApmSlowRequest[] > {
 function fetchApmRequest( siteId: number, requestId: string ): Promise< ApmRequestDetail > {
 	const seed = siteId ^ hashString( requestId );
 	const random = rng( seed );
+	const duration_ms = Math.round( 1500 + random() * 8500 );
 
 	return Promise.resolve( {
 		id: requestId,
 		url: SAMPLE_PATHS[ Math.floor( random() * SAMPLE_PATHS.length ) ],
 		method: random() < 0.7 ? 'GET' : 'POST',
-		duration_ms: Math.round( 1500 + random() * 8500 ),
+		avg_duration_ms: Math.round( duration_ms * ( 0.25 + random() * 0.4 ) ),
+		duration_ms,
 		status: 200,
 		timestamp: Date.now() - Math.round( random() * 60 * 60 * 1000 ),
 	} );

--- a/client/dashboard/sites/performance/backend/mock-data.ts
+++ b/client/dashboard/sites/performance/backend/mock-data.ts
@@ -4,11 +4,15 @@
 // `@automattic/api-queries`, then delete this file.
 import { queryOptions } from '@tanstack/react-query';
 import type {
+	ApmHookUsage,
 	ApmOverview,
+	ApmPluginUsage,
 	ApmRequestDetail,
 	ApmSlowRequest,
 	ApmSummary,
+	ApmTemplateUsage,
 	ApmTimePoint,
+	ApmWordPress,
 } from '@automattic/api-core';
 
 function rng( seed: number ) {
@@ -92,18 +96,100 @@ function generateSummary( timeseries: ApmTimePoint[], slowRequests: ApmSlowReque
 			acc.total += point.db + point.wp_core + point.plugins + point.external + point.cache;
 			acc.db += point.db;
 			acc.external += point.external;
+			acc.plugins += point.plugins;
 			return acc;
 		},
-		{ total: 0, db: 0, external: 0 }
+		{ total: 0, db: 0, external: 0, plugins: 0 }
 	);
 	const points = Math.max( timeseries.length, 1 );
 	return {
 		avg_response_ms: Math.round( totals.total / points ),
-		slow_request_count: slowRequests.length,
 		transaction_count: 1000 + slowRequests.length * 47,
 		db_avg_ms: Math.round( totals.db / points ),
 		external_avg_ms: Math.round( totals.external / points ),
+		plugins_avg_ms: Math.round( totals.plugins / points ),
 	};
+}
+
+const SAMPLE_PLUGINS: Array< { slug: string; name: string } > = [
+	{ slug: 'jetpack', name: 'Jetpack' },
+	{ slug: 'woocommerce', name: 'WooCommerce' },
+	{ slug: 'akismet', name: 'Akismet Anti-spam' },
+	{ slug: 'yoast-seo', name: 'Yoast SEO' },
+	{ slug: 'wpforms-lite', name: 'WPForms Lite' },
+	{ slug: 'elementor', name: 'Elementor' },
+	{ slug: 'wordfence', name: 'Wordfence Security' },
+	{ slug: 'classic-editor', name: 'Classic Editor' },
+];
+
+const SAMPLE_HOOKS = [
+	'init',
+	'wp_loaded',
+	'template_redirect',
+	'wp_enqueue_scripts',
+	'plugins_loaded',
+	'admin_init',
+	'pre_get_posts',
+	'shutdown',
+	'rest_api_init',
+	'save_post',
+];
+
+const SAMPLE_TEMPLATES = [
+	'single.php',
+	'page.php',
+	'archive.php',
+	'index.php',
+	'header.php',
+	'footer.php',
+	'sidebar.php',
+	'searchform.php',
+	'404.php',
+	'category.php',
+];
+
+function generateWordPress( seed: number ): ApmWordPress {
+	const random = rng( seed ^ 0x57504d50 );
+
+	const plugins: ApmPluginUsage[] = SAMPLE_PLUGINS.map( ( plugin ) => {
+		const call_count = Math.round( 200 + random() * 4800 );
+		const avg_ms = Math.round( 5 + random() * 95 );
+		return {
+			slug: plugin.slug,
+			name: plugin.name,
+			call_count,
+			avg_ms,
+			total_ms: call_count * avg_ms,
+		};
+	} ).sort( ( a, b ) => b.total_ms - a.total_ms );
+
+	const hooks: ApmHookUsage[] = SAMPLE_HOOKS.map( ( name ) => {
+		const call_count = Math.round( 500 + random() * 9500 );
+		const avg_ms = Math.round( 1 + random() * 40 );
+		return {
+			name,
+			call_count,
+			avg_ms,
+			total_ms: call_count * avg_ms,
+		};
+	} ).sort( ( a, b ) => b.total_ms - a.total_ms );
+
+	const templates: ApmTemplateUsage[] = SAMPLE_TEMPLATES.map( ( template ) => {
+		const hit_count = Math.round( 50 + random() * 2950 );
+		const avg_ms = Math.round( 20 + random() * 380 );
+		return {
+			template,
+			hit_count,
+			avg_ms,
+			total_ms: hit_count * avg_ms,
+		};
+	} ).sort( ( a, b ) => b.total_ms - a.total_ms );
+
+	return { plugins, hooks, templates };
+}
+
+function fetchApmWordPress( siteId: number ): Promise< ApmWordPress > {
+	return Promise.resolve( generateWordPress( siteId ) );
 }
 
 function fetchApmOverview( siteId: number ): Promise< ApmOverview > {
@@ -162,4 +248,10 @@ export const siteApmRequestQuery = ( siteId: number, requestId: string ) =>
 	queryOptions( {
 		queryKey: [ 'site', siteId, 'apm', 'request', requestId ],
 		queryFn: () => fetchApmRequest( siteId, requestId ),
+	} );
+
+export const siteApmWordPressQuery = ( siteId: number ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'apm', 'wordpress' ],
+		queryFn: () => fetchApmWordPress( siteId ),
 	} );

--- a/client/dashboard/sites/performance/backend/overview/chart-slot.tsx
+++ b/client/dashboard/sites/performance/backend/overview/chart-slot.tsx
@@ -1,16 +1,23 @@
-import { AreaChart, type SeriesData } from '@automattic/charts';
-import { __experimentalText as Text } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { AreaChart, GlobalChartsProvider, type SeriesData } from '@automattic/charts';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
 import { Card, CardBody, CardHeader } from '../../../../components/card';
+import { Text } from '../../../../components/text';
 import type { ApmTimePoint } from '@automattic/api-core';
 
 import '@automattic/charts/style.css';
+
+const CHART_ID = 'apm-response-time-breakdown';
 
 const SERIES: Array< { key: keyof Omit< ApmTimePoint, 'timestamp' >; label: string } > = [
 	{ key: 'db', label: __( 'Database' ) },
 	{ key: 'wp_core', label: __( 'WordPress core' ) },
 	{ key: 'plugins', label: __( 'Plugins' ) },
 	{ key: 'external', label: __( 'External' ) },
+	{ key: 'cache', label: __( 'Cache' ) },
 ];
 
 function toSeriesData( timeseries: ApmTimePoint[] ): SeriesData[] {
@@ -23,23 +30,68 @@ function toSeriesData( timeseries: ApmTimePoint[] ): SeriesData[] {
 	} ) );
 }
 
+function formatMs( ms: number ): string {
+	if ( ms >= 1000 ) {
+		return sprintf(
+			/* translators: %s is a number of seconds. */
+			__( '%s s' ),
+			( ms / 1000 ).toFixed( 2 )
+		);
+	}
+	return sprintf(
+		/* translators: %d is a number of milliseconds. */
+		__( '%d ms' ),
+		ms
+	);
+}
+
+function getAverageTotal( timeseries: ApmTimePoint[] ): number {
+	if ( ! timeseries.length ) {
+		return 0;
+	}
+	const total = timeseries.reduce(
+		( sum, point ) => sum + point.db + point.wp_core + point.plugins + point.external + point.cache,
+		0
+	);
+	return Math.round( total / timeseries.length );
+}
+
 export default function ChartSlot( { timeseries }: { timeseries: ApmTimePoint[] } ) {
 	const data = toSeriesData( timeseries );
+	const averageTotal = getAverageTotal( timeseries );
 
 	return (
 		<Card>
 			<CardHeader>
-				<Text weight={ 500 }>{ __( 'Response time breakdown' ) }</Text>
+				<HStack wrap spacing={ 4 } justify="space-between" alignment="flex-start">
+					<VStack spacing={ 2 } alignment="flex-start">
+						<Text size="title" weight={ 500 } as="h2">
+							{ __( 'Response time breakdown' ) }
+						</Text>
+						<Text size={ 32 } weight={ 500 } lineHeight="40px">
+							{ formatMs( averageTotal ) }
+						</Text>
+						<Text variant="muted">
+							{ __(
+								'Average time spent across the database, WordPress core, plugins, external requests, and cache.'
+							) }
+						</Text>
+					</VStack>
+				</HStack>
 			</CardHeader>
 			<CardBody>
-				<AreaChart
-					height={ 320 }
-					data={ data }
-					stacked
-					curveType="monotone"
-					showLegend
-					withTooltips
-				/>
+				<GlobalChartsProvider>
+					<AreaChart
+						chartId={ CHART_ID }
+						height={ 320 }
+						data={ data }
+						stacked
+						curveType="monotone"
+						showLegend
+						legend={ { interactive: true } }
+						withTooltips
+					/>
+				</GlobalChartsProvider>
 			</CardBody>
 		</Card>
 	);

--- a/client/dashboard/sites/performance/backend/overview/chart-slot.tsx
+++ b/client/dashboard/sites/performance/backend/overview/chart-slot.tsx
@@ -1,14 +1,45 @@
+import { AreaChart, type SeriesData } from '@automattic/charts';
 import { __experimentalText as Text } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Card, CardBody } from '../../../../components/card';
+import { Card, CardBody, CardHeader } from '../../../../components/card';
+import type { ApmTimePoint } from '@automattic/api-core';
 
-export default function ChartSlot() {
+import '@automattic/charts/style.css';
+
+const SERIES: Array< { key: keyof Omit< ApmTimePoint, 'timestamp' >; label: string } > = [
+	{ key: 'db', label: __( 'Database' ) },
+	{ key: 'wp_core', label: __( 'WordPress core' ) },
+	{ key: 'plugins', label: __( 'Plugins' ) },
+	{ key: 'external', label: __( 'External' ) },
+];
+
+function toSeriesData( timeseries: ApmTimePoint[] ): SeriesData[] {
+	return SERIES.map( ( { key, label } ) => ( {
+		label,
+		data: timeseries.map( ( point ) => ( {
+			date: new Date( point.timestamp ),
+			value: point[ key ],
+		} ) ),
+	} ) );
+}
+
+export default function ChartSlot( { timeseries }: { timeseries: ApmTimePoint[] } ) {
+	const data = toSeriesData( timeseries );
+
 	return (
 		<Card>
+			<CardHeader>
+				<Text weight={ 500 }>{ __( 'Response time breakdown' ) }</Text>
+			</CardHeader>
 			<CardBody>
-				<div style={ { minHeight: 320, display: 'grid', placeItems: 'center' } }>
-					<Text variant="muted">{ __( 'Response time chart coming soon.' ) }</Text>
-				</div>
+				<AreaChart
+					height={ 320 }
+					data={ data }
+					stacked
+					curveType="monotone"
+					showLegend
+					withTooltips
+				/>
 			</CardBody>
 		</Card>
 	);

--- a/client/dashboard/sites/performance/backend/overview/index.tsx
+++ b/client/dashboard/sites/performance/backend/overview/index.tsx
@@ -10,7 +10,7 @@ export default function Overview( { site }: { site: Site } ) {
 
 	return (
 		<VStack spacing={ 6 }>
-			<ChartSlot />
+			<ChartSlot timeseries={ data.timeseries } />
 			<SlowRequestsList site={ site } slowRequests={ data.slow_requests } />
 		</VStack>
 	);

--- a/client/dashboard/sites/performance/backend/overview/index.tsx
+++ b/client/dashboard/sites/performance/backend/overview/index.tsx
@@ -11,7 +11,7 @@ export default function Overview( { site }: { site: Site } ) {
 	return (
 		<VStack spacing={ 6 }>
 			<ChartSlot timeseries={ data.timeseries } />
-			<SlowRequestsList site={ site } slowRequests={ data.slow_requests } />
+			<SlowRequestsList slowRequests={ data.slow_requests } />
 		</VStack>
 	);
 }

--- a/client/dashboard/sites/performance/backend/overview/slow-requests-list.tsx
+++ b/client/dashboard/sites/performance/backend/overview/slow-requests-list.tsx
@@ -1,12 +1,30 @@
+import { BarListChart, GlobalChartsProvider, type SeriesData } from '@automattic/charts';
 import { useRouter } from '@tanstack/react-router';
-import { __experimentalText as Text, Button } from '@wordpress/components';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	Button,
+} from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { Card, CardBody, CardHeader } from '../../../../components/card';
+import { useState } from 'react';
+import { Card, CardBody, CardHeader, CardFooter } from '../../../../components/card';
+import { Text } from '../../../../components/text';
 import type { ApmSlowRequest, Site } from '@automattic/api-core';
+
+import '@automattic/charts/style.css';
+
+type Metric = 'avg' | 'max';
+const CHART_ID = 'apm-slow-requests';
 
 function formatDuration( ms: number ): string {
 	if ( ms >= 1000 ) {
-		return `${ ( ms / 1000 ).toFixed( 2 ) } s`;
+		return sprintf(
+			/* translators: %s is a number of seconds. */
+			__( '%s s' ),
+			( ms / 1000 ).toFixed( 2 )
+		);
 	}
 	return sprintf(
 		/* translators: %d is a number of milliseconds. */
@@ -15,25 +33,27 @@ function formatDuration( ms: number ): string {
 	);
 }
 
-function formatRelativeTime( timestamp: number ): string {
-	const diffSec = Math.floor( ( Date.now() - timestamp ) / 1000 );
-	if ( diffSec < 60 ) {
-		return __( 'just now' );
+function toSeriesData( requests: ApmSlowRequest[], metric: Metric ): SeriesData[] {
+	return [
+		{
+			label: metric === 'avg' ? __( 'Average' ) : __( 'Max' ),
+			data: requests.map( ( request ) => ( {
+				label: `${ request.method } ${ request.url }`,
+				value: metric === 'avg' ? request.avg_duration_ms : request.duration_ms,
+			} ) ),
+		},
+	];
+}
+
+function pickHeadlineDuration( requests: ApmSlowRequest[], metric: Metric ): number {
+	if ( ! requests.length ) {
+		return 0;
 	}
-	const diffMin = Math.floor( diffSec / 60 );
-	if ( diffMin < 60 ) {
-		return sprintf(
-			/* translators: %d is a number of minutes. */
-			__( '%dm ago' ),
-			diffMin
-		);
+	if ( metric === 'avg' ) {
+		const total = requests.reduce( ( sum, r ) => sum + r.avg_duration_ms, 0 );
+		return Math.round( total / requests.length );
 	}
-	const diffHr = Math.floor( diffMin / 60 );
-	return sprintf(
-		/* translators: %d is a number of hours. */
-		__( '%dh ago' ),
-		diffHr
-	);
+	return requests.reduce( ( max, r ) => Math.max( max, r.duration_ms ), 0 );
 }
 
 export default function SlowRequestsList( {
@@ -44,50 +64,70 @@ export default function SlowRequestsList( {
 	slowRequests: ApmSlowRequest[];
 } ) {
 	const router = useRouter();
+	const [ metric, setMetric ] = useState< Metric >( 'max' );
 
-	const navigateToRequest = ( request: ApmSlowRequest ) => {
+	const data = toSeriesData( slowRequests, metric );
+	const headline = pickHeadlineDuration( slowRequests, metric );
+	const height = Math.max( 240, slowRequests.length * 36 );
+
+	const viewAllRequests = () => {
 		router.navigate( {
-			to: `/sites/${ site.slug }/performance/backend/requests/${ request.id }`,
+			to: `/sites/${ site.slug }/performance/backend/requests`,
 		} );
 	};
+
+	const description =
+		metric === 'avg'
+			? __( 'Average response time across the slowest endpoints in the selected period.' )
+			: __( 'Slowest single response observed across these endpoints in the selected period.' );
 
 	return (
 		<Card>
 			<CardHeader>
-				<Text weight={ 600 }>{ __( 'Slowest requests' ) }</Text>
+				<HStack wrap spacing={ 4 } justify="space-between" alignment="flex-start">
+					<VStack spacing={ 2 } alignment="flex-start">
+						<Text size="title" weight={ 500 } as="h2">
+							{ __( 'Slowest requests' ) }
+						</Text>
+						<Text size={ 32 } weight={ 500 } lineHeight="40px">
+							{ formatDuration( headline ) }
+						</Text>
+						<Text variant="muted">{ description }</Text>
+					</VStack>
+					<ToggleGroupControl
+						value={ metric }
+						isBlock
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+						onChange={ ( value ) => setMetric( ( value as Metric ) ?? 'max' ) }
+						label={ __( 'Duration metric' ) }
+						hideLabelFromVision
+					>
+						<ToggleGroupControlOption value="avg" label={ __( 'Avg' ) } />
+						<ToggleGroupControlOption value="max" label={ __( 'Max' ) } />
+					</ToggleGroupControl>
+				</HStack>
 			</CardHeader>
 			<CardBody>
-				<table style={ { width: '100%', borderCollapse: 'collapse' } }>
-					<thead>
-						<tr>
-							<th style={ { textAlign: 'start', padding: '8px 0' } }>{ __( 'URL' ) }</th>
-							<th style={ { textAlign: 'start', padding: '8px 0' } }>{ __( 'Method' ) }</th>
-							<th style={ { textAlign: 'start', padding: '8px 0' } }>{ __( 'Status' ) }</th>
-							<th style={ { textAlign: 'end', padding: '8px 0' } }>{ __( 'Duration' ) }</th>
-							<th style={ { textAlign: 'end', padding: '8px 0' } }>{ __( 'When' ) }</th>
-						</tr>
-					</thead>
-					<tbody>
-						{ slowRequests.map( ( request ) => (
-							<tr key={ request.id }>
-								<td style={ { padding: '8px 0' } }>
-									<Button variant="link" onClick={ () => navigateToRequest( request ) }>
-										{ request.url }
-									</Button>
-								</td>
-								<td style={ { padding: '8px 0' } }>{ request.method }</td>
-								<td style={ { padding: '8px 0' } }>{ request.status }</td>
-								<td style={ { padding: '8px 0', textAlign: 'end' } }>
-									{ formatDuration( request.duration_ms ) }
-								</td>
-								<td style={ { padding: '8px 0', textAlign: 'end' } }>
-									<Text variant="muted">{ formatRelativeTime( request.timestamp ) }</Text>
-								</td>
-							</tr>
-						) ) }
-					</tbody>
-				</table>
+				<GlobalChartsProvider>
+					<BarListChart
+						chartId={ CHART_ID }
+						data={ data }
+						height={ height }
+						withTooltips
+						options={ {
+							yScale: {},
+							xScale: {},
+							valueFormatter: formatDuration,
+						} }
+					/>
+				</GlobalChartsProvider>
 			</CardBody>
+			<CardFooter>
+				<Button variant="secondary" onClick={ viewAllRequests }>
+					{ __( 'View all requests' ) }
+				</Button>
+			</CardFooter>
 		</Card>
 	);
 }

--- a/client/dashboard/sites/performance/backend/overview/slow-requests-list.tsx
+++ b/client/dashboard/sites/performance/backend/overview/slow-requests-list.tsx
@@ -1,22 +1,17 @@
-import { BarListChart, GlobalChartsProvider, type SeriesData } from '@automattic/charts';
-import { useRouter } from '@tanstack/react-router';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
-	Button,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState } from 'react';
-import { Card, CardBody, CardHeader, CardFooter } from '../../../../components/card';
+import { Card, CardBody, CardHeader } from '../../../../components/card';
 import { Text } from '../../../../components/text';
-import type { ApmSlowRequest, Site } from '@automattic/api-core';
-
-import '@automattic/charts/style.css';
+import BarList, { type BarListRow } from '../bar-list';
+import type { ApmSlowRequest } from '@automattic/api-core';
 
 type Metric = 'avg' | 'max';
-const CHART_ID = 'apm-slow-requests';
 
 function formatDuration( ms: number ): string {
 	if ( ms >= 1000 ) {
@@ -33,16 +28,12 @@ function formatDuration( ms: number ): string {
 	);
 }
 
-function toSeriesData( requests: ApmSlowRequest[], metric: Metric ): SeriesData[] {
-	return [
-		{
-			label: metric === 'avg' ? __( 'Average' ) : __( 'Max' ),
-			data: requests.map( ( request ) => ( {
-				label: `${ request.method } ${ request.url }`,
-				value: metric === 'avg' ? request.avg_duration_ms : request.duration_ms,
-			} ) ),
-		},
-	];
+function toRows( requests: ApmSlowRequest[], metric: Metric ): BarListRow[] {
+	return requests.map( ( request ) => ( {
+		id: request.id,
+		label: `${ request.method } ${ request.url }`,
+		value: metric === 'avg' ? request.avg_duration_ms : request.duration_ms,
+	} ) );
 }
 
 function pickHeadlineDuration( requests: ApmSlowRequest[], metric: Metric ): number {
@@ -56,25 +47,11 @@ function pickHeadlineDuration( requests: ApmSlowRequest[], metric: Metric ): num
 	return requests.reduce( ( max, r ) => Math.max( max, r.duration_ms ), 0 );
 }
 
-export default function SlowRequestsList( {
-	site,
-	slowRequests,
-}: {
-	site: Site;
-	slowRequests: ApmSlowRequest[];
-} ) {
-	const router = useRouter();
+export default function SlowRequestsList( { slowRequests }: { slowRequests: ApmSlowRequest[] } ) {
 	const [ metric, setMetric ] = useState< Metric >( 'max' );
 
-	const data = toSeriesData( slowRequests, metric );
+	const rows = toRows( slowRequests, metric );
 	const headline = pickHeadlineDuration( slowRequests, metric );
-	const height = Math.max( 240, slowRequests.length * 36 );
-
-	const viewAllRequests = () => {
-		router.navigate( {
-			to: `/sites/${ site.slug }/performance/backend/requests`,
-		} );
-	};
 
 	const description =
 		metric === 'avg'
@@ -109,25 +86,8 @@ export default function SlowRequestsList( {
 				</HStack>
 			</CardHeader>
 			<CardBody>
-				<GlobalChartsProvider>
-					<BarListChart
-						chartId={ CHART_ID }
-						data={ data }
-						height={ height }
-						withTooltips
-						options={ {
-							yScale: {},
-							xScale: {},
-							valueFormatter: formatDuration,
-						} }
-					/>
-				</GlobalChartsProvider>
+				<BarList rows={ rows } valueFormatter={ formatDuration } />
 			</CardBody>
-			<CardFooter>
-				<Button variant="secondary" onClick={ viewAllRequests }>
-					{ __( 'View all requests' ) }
-				</Button>
-			</CardFooter>
 		</Card>
 	);
 }

--- a/client/dashboard/sites/performance/backend/requests/index.tsx
+++ b/client/dashboard/sites/performance/backend/requests/index.tsx
@@ -1,6 +1,0 @@
-import { __experimentalText as Text } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-
-export default function Requests() {
-	return <Text variant="muted">{ __( 'Coming soon.' ) }</Text>;
-}

--- a/client/dashboard/sites/performance/backend/test/index.test.tsx
+++ b/client/dashboard/sites/performance/backend/test/index.test.tsx
@@ -9,6 +9,10 @@ import { render } from '../../../../test-utils';
 import SitePerformanceBackend from '../index';
 import type { Site } from '@automattic/api-core';
 
+jest.mock( '@automattic/charts', () => ( {
+	AreaChart: () => null,
+} ) );
+
 const siteSlug = 'test-site.wordpress.com';
 const siteId = 1;
 

--- a/client/dashboard/sites/performance/backend/test/index.test.tsx
+++ b/client/dashboard/sites/performance/backend/test/index.test.tsx
@@ -80,6 +80,16 @@ describe( '<SitePerformanceBackend>', () => {
 		expect( screen.getByRole( 'heading', { name: 'Slowest requests' } ) ).toBeVisible();
 	} );
 
+	test( 'renders Plugins, Hooks and Templates on the WordPress tab', async () => {
+		mockSite( businessSite( true ) );
+
+		render( <SitePerformanceBackend siteSlug={ siteSlug } tab="wordpress" /> );
+
+		expect( await screen.findByRole( 'heading', { name: 'Plugins' } ) ).toBeVisible();
+		expect( screen.getByRole( 'heading', { name: 'Hooks' } ) ).toBeVisible();
+		expect( screen.getByRole( 'heading', { name: 'Templates' } ) ).toBeVisible();
+	} );
+
 	test( 'clicking Enable POSTs { active: true }', async () => {
 		mockSite( businessSite( false ) );
 		const scope = mockApmToggle( true );

--- a/client/dashboard/sites/performance/backend/test/index.test.tsx
+++ b/client/dashboard/sites/performance/backend/test/index.test.tsx
@@ -11,6 +11,8 @@ import type { Site } from '@automattic/api-core';
 
 jest.mock( '@automattic/charts', () => ( {
 	AreaChart: () => null,
+	BarListChart: () => null,
+	GlobalChartsProvider: ( { children }: { children: React.ReactNode } ) => children,
 } ) );
 
 const siteSlug = 'test-site.wordpress.com';
@@ -72,11 +74,10 @@ describe( '<SitePerformanceBackend>', () => {
 
 		render( <SitePerformanceBackend siteSlug={ siteSlug } /> );
 
-		expect( await screen.findByRole( 'tab', { name: 'Overview' } ) ).toBeVisible();
-		expect( screen.getByRole( 'tab', { name: 'Requests' } ) ).toBeVisible();
-		expect( screen.getByRole( 'tab', { name: 'Transactions' } ) ).toBeVisible();
-		expect( screen.getByRole( 'tab', { name: 'Database' } ) ).toBeVisible();
-		expect( screen.getByRole( 'tab', { name: 'External requests' } ) ).toBeVisible();
+		expect(
+			await screen.findByRole( 'heading', { name: 'Response time breakdown' } )
+		).toBeVisible();
+		expect( screen.getByRole( 'heading', { name: 'Slowest requests' } ) ).toBeVisible();
 	} );
 
 	test( 'clicking Enable POSTs { active: true }', async () => {

--- a/client/dashboard/sites/performance/backend/wordpress/index.tsx
+++ b/client/dashboard/sites/performance/backend/wordpress/index.tsx
@@ -1,0 +1,118 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { Card, CardBody, CardHeader } from '../../../../components/card';
+import { Text } from '../../../../components/text';
+import BarList, { type BarListRow } from '../bar-list';
+import { siteApmWordPressQuery } from '../mock-data';
+import type { ApmHookUsage, ApmPluginUsage, ApmTemplateUsage, Site } from '@automattic/api-core';
+
+function formatMs( ms: number ): string {
+	if ( ms >= 1000 ) {
+		return sprintf(
+			/* translators: %s is a number of seconds. */
+			__( '%s s' ),
+			( ms / 1000 ).toFixed( 2 )
+		);
+	}
+	return sprintf(
+		/* translators: %d is a number of milliseconds. */
+		__( '%d ms' ),
+		ms
+	);
+}
+
+function totalMs( items: Array< { total_ms: number } > ): number {
+	return items.reduce( ( sum, item ) => sum + item.total_ms, 0 );
+}
+
+function Section( {
+	title,
+	headline,
+	description,
+	rows,
+}: {
+	title: string;
+	headline: string;
+	description: string;
+	rows: BarListRow[];
+} ) {
+	return (
+		<Card>
+			<CardHeader>
+				<HStack wrap spacing={ 4 } justify="space-between" alignment="flex-start">
+					<VStack spacing={ 2 } alignment="flex-start">
+						<Text size="title" weight={ 500 } as="h2">
+							{ title }
+						</Text>
+						<Text size={ 32 } weight={ 500 } lineHeight="40px">
+							{ headline }
+						</Text>
+						<Text variant="muted">{ description }</Text>
+					</VStack>
+				</HStack>
+			</CardHeader>
+			<CardBody>
+				<BarList rows={ rows } valueFormatter={ formatMs } />
+			</CardBody>
+		</Card>
+	);
+}
+
+function pluginsToRows( plugins: ApmPluginUsage[] ): BarListRow[] {
+	return plugins.map( ( plugin ) => ( {
+		id: plugin.slug,
+		label: plugin.name,
+		value: plugin.total_ms,
+	} ) );
+}
+
+function hooksToRows( hooks: ApmHookUsage[] ): BarListRow[] {
+	return hooks.map( ( hook ) => ( {
+		id: hook.name,
+		label: hook.name,
+		value: hook.total_ms,
+	} ) );
+}
+
+function templatesToRows( templates: ApmTemplateUsage[] ): BarListRow[] {
+	return templates.map( ( template ) => ( {
+		id: template.template,
+		label: template.template,
+		value: template.total_ms,
+	} ) );
+}
+
+export default function WordPress( { site }: { site: Site } ) {
+	const { data } = useSuspenseQuery( siteApmWordPressQuery( site.ID ) );
+
+	return (
+		<VStack spacing={ 6 }>
+			<Section
+				title={ __( 'Plugins' ) }
+				headline={ formatMs( totalMs( data.plugins ) ) }
+				description={ __( 'Total time consumed by each active plugin in the selected period.' ) }
+				rows={ pluginsToRows( data.plugins ) }
+			/>
+			<Section
+				title={ __( 'Hooks' ) }
+				headline={ formatMs( totalMs( data.hooks ) ) }
+				description={ __(
+					'Total time spent in the slowest action and filter hooks fired during the selected period.'
+				) }
+				rows={ hooksToRows( data.hooks ) }
+			/>
+			<Section
+				title={ __( 'Templates' ) }
+				headline={ formatMs( totalMs( data.templates ) ) }
+				description={ __(
+					'Total time spent rendering each theme template in the selected period.'
+				) }
+				rows={ templatesToRows( data.templates ) }
+			/>
+		</VStack>
+	);
+}

--- a/packages/api-core/src/site-hosting-apm/fetchers.ts
+++ b/packages/api-core/src/site-hosting-apm/fetchers.ts
@@ -1,0 +1,15 @@
+import { wpcom } from '../wpcom-fetcher';
+import type { ApmTraces, ApmTracesParams } from './types';
+
+export async function fetchApmTraces(
+	siteId: number,
+	params: ApmTracesParams
+): Promise< ApmTraces > {
+	return wpcom.req.get(
+		{
+			path: `/sites/${ siteId }/hosting/apm/traces`,
+			apiNamespace: 'wpcom/v2',
+		},
+		params
+	);
+}

--- a/packages/api-core/src/site-hosting-apm/index.ts
+++ b/packages/api-core/src/site-hosting-apm/index.ts
@@ -1,2 +1,3 @@
+export * from './fetchers';
 export * from './mutators';
 export * from './types';

--- a/packages/api-core/src/site-hosting-apm/types.ts
+++ b/packages/api-core/src/site-hosting-apm/types.ts
@@ -4,12 +4,14 @@ export interface ApmTimePoint {
 	wp_core: number;
 	plugins: number;
 	external: number;
+	cache: number;
 }
 
 export interface ApmSlowRequest {
 	id: string;
 	url: string;
 	method: string;
+	avg_duration_ms: number;
 	duration_ms: number;
 	status: number;
 	timestamp: number;
@@ -17,7 +19,16 @@ export interface ApmSlowRequest {
 
 export type ApmRequestDetail = ApmSlowRequest;
 
+export interface ApmSummary {
+	avg_response_ms: number;
+	slow_request_count: number;
+	transaction_count: number;
+	db_avg_ms: number;
+	external_avg_ms: number;
+}
+
 export interface ApmOverview {
+	summary: ApmSummary;
 	timeseries: ApmTimePoint[];
 	slow_requests: ApmSlowRequest[];
 }

--- a/packages/api-core/src/site-hosting-apm/types.ts
+++ b/packages/api-core/src/site-hosting-apm/types.ts
@@ -33,6 +33,20 @@ export interface ApmOverview {
 	slow_requests: ApmSlowRequest[];
 }
 
+export interface ApmTracesParams {
+	/** Inclusive lower bound, epoch milliseconds. */
+	from: number;
+	/** Exclusive upper bound, epoch milliseconds. */
+	to: number;
+}
+
+export interface ApmTraces {
+	summary: ApmSummary;
+	timeseries: ApmTimePoint[];
+	slow_requests: ApmSlowRequest[];
+	wordpress: ApmWordPress;
+}
+
 export interface ApmPluginUsage {
 	slug: string;
 	name: string;

--- a/packages/api-core/src/site-hosting-apm/types.ts
+++ b/packages/api-core/src/site-hosting-apm/types.ts
@@ -21,14 +21,42 @@ export type ApmRequestDetail = ApmSlowRequest;
 
 export interface ApmSummary {
 	avg_response_ms: number;
-	slow_request_count: number;
 	transaction_count: number;
 	db_avg_ms: number;
 	external_avg_ms: number;
+	plugins_avg_ms: number;
 }
 
 export interface ApmOverview {
 	summary: ApmSummary;
 	timeseries: ApmTimePoint[];
 	slow_requests: ApmSlowRequest[];
+}
+
+export interface ApmPluginUsage {
+	slug: string;
+	name: string;
+	total_ms: number;
+	avg_ms: number;
+	call_count: number;
+}
+
+export interface ApmHookUsage {
+	name: string;
+	total_ms: number;
+	avg_ms: number;
+	call_count: number;
+}
+
+export interface ApmTemplateUsage {
+	template: string;
+	total_ms: number;
+	avg_ms: number;
+	hit_count: number;
+}
+
+export interface ApmWordPress {
+	plugins: ApmPluginUsage[];
+	hooks: ApmHookUsage[];
+	templates: ApmTemplateUsage[];
 }

--- a/packages/api-queries/src/site-apm.ts
+++ b/packages/api-queries/src/site-apm.ts
@@ -1,8 +1,14 @@
-import { updateApmEnabled } from '@automattic/api-core';
-import { mutationOptions } from '@tanstack/react-query';
+import { fetchApmTraces, updateApmEnabled } from '@automattic/api-core';
+import { mutationOptions, queryOptions } from '@tanstack/react-query';
 import { queryClient } from './query-client';
 import { siteQueryFilter } from './site';
-import type { Site } from '@automattic/api-core';
+import type { ApmTracesParams, Site } from '@automattic/api-core';
+
+export const siteApmTracesQuery = ( siteId: number, params: ApmTracesParams ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'apm', 'traces', params ],
+		queryFn: () => fetchApmTraces( siteId, params ),
+	} );
 
 export const siteApmEnabledMutation = ( siteId: number ) =>
 	mutationOptions( {


### PR DESCRIPTION
Stacked on top of #110676.

## Proposed Changes

Adds the API-layer plumbing for the in-memory APM aggregation endpoint that the backend is implementing.

- **`packages/api-core`** — adds `fetchApmTraces(siteId, { from, to })` calling `wpcom/v2/sites/{id}/hosting/apm/traces`, plus new types `ApmTracesParams` and `ApmTraces`.
- **`packages/api-queries`** — adds `siteApmTracesQuery(siteId, params)` with a stable query key that includes the params object so different time ranges cache independently.

Dashboard views still consume mock data from `client/dashboard/sites/performance/backend/mock-data.ts`. Flipping each view over to the real query is the next commit (a follow-up PR) and depends on the endpoint being live.

## Why are these changes being made?

This is the first concrete step of the frontend/backend integration for the APM tooling. Landing the fetcher + query options now means a follow-up PR can be a small, focused diff that just switches `useSuspenseQuery` call sites from the mock-data queries to `siteApmTracesQuery`.

## Response contract assumed by this PR

The fetcher is typed against the shape below — this is the contract the backend should match. It wraps the shapes the existing Backend dashboard views consume into one response so each view can read its slice from a single query:

```ts
interface ApmTracesParams {
  from: number; // epoch ms, inclusive
  to: number;   // epoch ms, exclusive
}

interface ApmTraces {
  summary: {
    avg_response_ms: number;
    transaction_count: number;
    db_avg_ms: number;
    external_avg_ms: number;
    plugins_avg_ms: number;
  };
  timeseries: Array<{
    timestamp: number;
    db: number;
    wp_core: number;
    plugins: number;
    external: number;
    cache: number;
  }>;
  slow_requests: Array<{
    id: string;
    url: string;
    method: string;
    avg_duration_ms: number;
    duration_ms: number;
    status: number;
    timestamp: number;
  }>;
  wordpress: {
    plugins: Array<{ slug: string; name: string; total_ms: number; avg_ms: number; call_count: number }>;
    hooks: Array<{ name: string; total_ms: number; avg_ms: number; call_count: number }>;
    templates: Array<{ template: string; total_ms: number; avg_ms: number; hit_count: number }>;
  };
}
```

Notes for the backend:
- `timeseries` resolution should adapt to the range (`from` → `to`). For ≤24h, 5-minute buckets work well; for ≤7d, 1-hour; for ≤30d, 1-day. Aim for ≤200 points either way so the chart isn't crushed.
- `plugins` / `hooks` / `templates` should be top-N (8–10 is plenty for the current UI).
- `slow_requests` is top-N by `duration_ms`. The dashboard also shows an Avg/Max toggle, which uses `avg_duration_ms` from the same rows.

## Testing Instructions

1. `yarn typecheck-packages` — passes locally.
2. `yarn eslint packages/api-core/src/site-hosting-apm/ packages/api-queries/src/site-apm.ts` — clean.
3. The dashboard at `/sites/<slug>/performance/backend` still works against the mock data (this PR doesn't touch dashboard code paths).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
