### PR TITLE
Reader Fediverse: follow / unfollow button on the AP author profile (CM-718)

### DIFF
--- a/client/reader/fediverse/author-profile-panel.tsx
+++ b/client/reader/fediverse/author-profile-panel.tsx
@@ -1,11 +1,17 @@
 import {
+	followFediverseActorMutation,
+	unfollowFediverseActorMutation,
 	useFediverseAuthorFeedInfiniteQuery,
 	useFediverseAuthorProfileQuery,
 } from '@automattic/api-queries';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTranslate, type TranslateResult } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
+import { useDispatch } from 'react-redux';
 import EmptyContent from 'calypso/components/empty-content';
+import { logToLogstash } from 'calypso/lib/logstash';
 import {
+	FollowButton,
 	SocialAuthorProfilePanel,
 	SocialProfileCard,
 	mapFediverseAuthorProfileToSocialProfileCardProps,
@@ -13,7 +19,10 @@ import {
 	stripLeadingAt,
 	type SocialProfileStat,
 } from 'calypso/reader/social';
+import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import { projectFediverseError } from './error-projection';
+import { followErrorMessage } from './profile-errors';
 import {
 	getFollowersUrl,
 	getFollowingUrl,
@@ -27,6 +36,9 @@ import type {
 	FediverseError,
 	FediverseFeedItem,
 } from '@automattic/api-core';
+import type { AppState } from 'calypso/types';
+import type { UnknownAction } from 'redux';
+import type { ThunkDispatch } from 'redux-thunk';
 
 interface FediverseAuthorProfilePanelProps {
 	connection: FediverseConnection;
@@ -48,9 +60,95 @@ export function FediverseAuthorProfilePanel( {
 	actor,
 }: FediverseAuthorProfilePanelProps ) {
 	const translate = useTranslate();
+	const dispatch = useDispatch< ThunkDispatch< AppState, void, UnknownAction > >();
+	const queryClient = useQueryClient();
 
 	const profile = useFediverseAuthorProfileQuery( connection.id, actor );
 	const feed = useFediverseAuthorFeedInfiniteQuery( connection.id, actor );
+
+	const followMut = useMutation( followFediverseActorMutation( queryClient ) );
+	const unfollowMut = useMutation( unfollowFediverseActorMutation( queryClient ) );
+	// `.mutate` is the only stable handle on the useMutation result — depending
+	// on the result object would re-create handleFollow / handleUnfollow on
+	// every render (mirrors the Mastodon panel).
+	const followMutate = followMut.mutate;
+	const unfollowMutate = unfollowMut.mutate;
+
+	const showFollowError = useCallback(
+		( error: FediverseError, action: 'follow' | 'unfollow' ) => {
+			dispatch(
+				recordReaderTracksEvent( 'calypso_reader_fediverse_profile_follow_error', {
+					connection_id: connection.id,
+					action,
+					error_kind: error.kind,
+				} )
+			);
+			dispatch(
+				errorNotice( followErrorMessage( error, action, translate ), {
+					id: 'fediverse-follow-error',
+				} )
+			);
+			// Pipeline-level log so failures stay observable in dashboards even
+			// when no Tracks dashboard is consulted (matches the Mastodon panel).
+			logToLogstash( {
+				feature: 'calypso_client',
+				message: `Reader Fediverse ${ action } mutation failed`,
+				severity: 'error',
+				extra: {
+					type: `reader_fediverse_${ action }_mutation_error`,
+					connection_id: connection.id,
+					error_kind: error.kind,
+				},
+			} );
+		},
+		[ connection.id, dispatch, translate ]
+	);
+
+	const handleFollow = useCallback( () => {
+		if ( ! profile.data ) {
+			return;
+		}
+		// Capture at click time so analytics survive a profile refetch racing
+		// with the in-flight mutation.
+		const locked = profile.data.locked;
+		dispatch(
+			recordReaderTracksEvent( 'calypso_reader_fediverse_profile_follow_clicked', {
+				connection_id: connection.id,
+				was_followed_by: profile.data.viewer?.followed_by ?? false,
+				was_locked: locked,
+			} )
+		);
+		followMutate(
+			{ connectionId: connection.id, actor, locked },
+			{
+				onSuccess: () => {
+					dispatch( removeNotice( 'fediverse-follow-error' ) );
+				},
+				onError: ( error ) => showFollowError( error, 'follow' ),
+			}
+		);
+	}, [ profile.data, connection.id, actor, dispatch, followMutate, showFollowError ] );
+
+	const handleUnfollow = useCallback( () => {
+		if ( ! profile.data ) {
+			return;
+		}
+		dispatch(
+			recordReaderTracksEvent( 'calypso_reader_fediverse_profile_unfollow_clicked', {
+				connection_id: connection.id,
+				was_requested: profile.data.viewer?.requested ?? false,
+			} )
+		);
+		unfollowMutate(
+			{ connectionId: connection.id, actor },
+			{
+				onSuccess: () => {
+					dispatch( removeNotice( 'fediverse-follow-error' ) );
+				},
+				onError: ( error ) => showFollowError( error, 'unfollow' ),
+			}
+		);
+	}, [ profile.data, connection.id, actor, dispatch, unfollowMutate, showFollowError ] );
 
 	// Connection's home host — feeds the mapper's webfinger qualifier
 	// so local-account `acct` values render as `@user@host`. Falls back
@@ -97,15 +195,41 @@ export function FediverseAuthorProfilePanel( {
 			const cardProps = mapFediverseAuthorProfileToSocialProfileCardProps( profileData, {
 				host,
 			} );
+			// Forwards-compat gate: only render the button when the backend
+			// has projected the viewer block. Pre-deploy backends omit
+			// `viewer` entirely and we hide the button rather than guess at
+			// follow state. `is_self` hides the button on the viewer's own
+			// profile. Mirrors the Mastodon panel.
+			const followButton =
+				profileData.viewer && ! profileData.is_self ? (
+					<FollowButton
+						isFollowing={ profileData.viewer.following }
+						isFollowedBy={ profileData.viewer.followed_by }
+						isRequested={ profileData.viewer.requested }
+						isPending={ followMut.isPending || unfollowMut.isPending }
+						actorHandle={ stripLeadingAt( profileData.acct ) }
+						onFollow={ handleFollow }
+						onUnfollow={ handleUnfollow }
+					/>
+				) : null;
 			return (
 				<SocialProfileCard
 					{ ...cardProps }
 					stats={ stats }
 					statsLabel={ String( translate( 'Profile stats' ) ) }
+					headerActions={ followButton }
 				/>
 			);
 		},
-		[ host, stats, translate ]
+		[
+			host,
+			stats,
+			translate,
+			followMut.isPending,
+			unfollowMut.isPending,
+			handleFollow,
+			handleUnfollow,
+		]
 	);
 
 	const renderProfileError = useCallback(

--- a/client/reader/fediverse/author-profile-panel.tsx
+++ b/client/reader/fediverse/author-profile-panel.tsx
@@ -74,6 +74,12 @@ export function FediverseAuthorProfilePanel( {
 	const followMutate = followMut.mutate;
 	const unfollowMutate = unfollowMut.mutate;
 
+	// Scope the error-notice id to `(connectionId, actor)` so a successful
+	// follow on one surface doesn't silently dismiss an unresolved error
+	// toast posted by a different surface (the followers / following lists
+	// share the same notice space). Same pattern as the Mastodon panel.
+	const noticeId = `fediverse-follow-error-${ connection.id }-${ actor }`;
+
 	const showFollowError = useCallback(
 		( error: FediverseError, action: 'follow' | 'unfollow' ) => {
 			dispatch(
@@ -85,11 +91,14 @@ export function FediverseAuthorProfilePanel( {
 			);
 			dispatch(
 				errorNotice( followErrorMessage( error, action, translate ), {
-					id: 'fediverse-follow-error',
+					id: noticeId,
 				} )
 			);
 			// Pipeline-level log so failures stay observable in dashboards even
 			// when no Tracks dashboard is consulted (matches the Mastodon panel).
+			// Swallow rejections — the logstash POST going down must not bubble
+			// to the global handler, which is exactly the silent failure this
+			// breadcrumb exists to surface.
 			logToLogstash( {
 				feature: 'calypso_client',
 				message: `Reader Fediverse ${ action } mutation failed`,
@@ -99,9 +108,9 @@ export function FediverseAuthorProfilePanel( {
 					connection_id: connection.id,
 					error_kind: error.kind,
 				},
-			} );
+			} ).catch( () => undefined );
 		},
-		[ connection.id, dispatch, translate ]
+		[ connection.id, dispatch, translate, noticeId ]
 	);
 
 	const handleFollow = useCallback( () => {
@@ -122,12 +131,12 @@ export function FediverseAuthorProfilePanel( {
 			{ connectionId: connection.id, actor, locked },
 			{
 				onSuccess: () => {
-					dispatch( removeNotice( 'fediverse-follow-error' ) );
+					dispatch( removeNotice( noticeId ) );
 				},
 				onError: ( error ) => showFollowError( error, 'follow' ),
 			}
 		);
-	}, [ profile.data, connection.id, actor, dispatch, followMutate, showFollowError ] );
+	}, [ profile.data, connection.id, actor, dispatch, followMutate, showFollowError, noticeId ] );
 
 	const handleUnfollow = useCallback( () => {
 		if ( ! profile.data ) {
@@ -143,12 +152,12 @@ export function FediverseAuthorProfilePanel( {
 			{ connectionId: connection.id, actor },
 			{
 				onSuccess: () => {
-					dispatch( removeNotice( 'fediverse-follow-error' ) );
+					dispatch( removeNotice( noticeId ) );
 				},
 				onError: ( error ) => showFollowError( error, 'unfollow' ),
 			}
 		);
-	}, [ profile.data, connection.id, actor, dispatch, unfollowMutate, showFollowError ] );
+	}, [ profile.data, connection.id, actor, dispatch, unfollowMutate, showFollowError, noticeId ] );
 
 	// Connection's home host — feeds the mapper's webfinger qualifier
 	// so local-account `acct` values render as `@user@host`. Falls back

--- a/client/reader/fediverse/followers-view.tsx
+++ b/client/reader/fediverse/followers-view.tsx
@@ -102,17 +102,26 @@ export function FollowersView( { connectionId, actor }: Props ) {
 	const followMut = useMutation( followFediverseActorMutation( queryClient ) );
 	const unfollowMut = useMutation( unfollowFediverseActorMutation( queryClient ) );
 
-	// Surface follow / unfollow failures via a stable notice id so a stale
-	// toast from one click is dismissed when the user retries. Also emit a
-	// pipeline-level log so failures stay observable in dashboards even
-	// when no Tracks dashboard is consulted.
+	// Scope the error-notice id to `(connectionId, rowActor)` so:
+	//  - A successful click on one row only dismisses its own stale toast,
+	//    not another row's unresolved error.
+	//  - A retry within the same row dismisses the previous attempt's toast.
+	//  - Surfaces outside this view (author panel, sibling list) keep their
+	//    own toast space.
+	const noticeIdFor = useCallback(
+		( rowActor: string ) => `fediverse-follow-error-${ connectionId }-${ rowActor }`,
+		[ connectionId ]
+	);
 	const showFollowError = useCallback(
-		( error: FediverseError, action: 'follow' | 'unfollow' ) => {
+		( error: FediverseError, action: 'follow' | 'unfollow', rowActor: string ) => {
 			dispatch(
 				errorNotice( followErrorMessage( error, action, translate ), {
-					id: 'fediverse-follow-error',
+					id: noticeIdFor( rowActor ),
 				} )
 			);
+			// Pipeline-level log so failures stay observable in dashboards even
+			// when no Tracks dashboard is consulted. Swallow rejections — the
+			// logstash POST going down must not bubble to the global handler.
 			logToLogstash( {
 				feature: 'calypso_client',
 				message: `Reader Fediverse ${ action } mutation failed`,
@@ -122,13 +131,16 @@ export function FollowersView( { connectionId, actor }: Props ) {
 					connection_id: connectionId,
 					error_kind: error.kind,
 				},
-			} );
+			} ).catch( () => undefined );
 		},
-		[ dispatch, translate, connectionId ]
+		[ dispatch, translate, connectionId, noticeIdFor ]
 	);
-	const dismissFollowError = useCallback( () => {
-		dispatch( removeNotice( 'fediverse-follow-error' ) );
-	}, [ dispatch ] );
+	const dismissFollowError = useCallback(
+		( rowActor: string ) => {
+			dispatch( removeNotice( noticeIdFor( rowActor ) ) );
+		},
+		[ dispatch, noticeIdFor ]
+	);
 
 	// Refetch the actor list after a follow / unfollow so the row's `viewer`
 	// state mirrors server truth. Without this, the row keeps the pre-click
@@ -183,10 +195,10 @@ export function FollowersView( { connectionId, actor }: Props ) {
 									},
 									{
 										onSuccess: () => {
-											dismissFollowError();
+											dismissFollowError( item.handle );
 											invalidateActorList();
 										},
-										onError: ( error ) => showFollowError( error, 'follow' ),
+										onError: ( error ) => showFollowError( error, 'follow', item.handle ),
 									}
 								),
 							onUnfollow: () =>
@@ -197,10 +209,10 @@ export function FollowersView( { connectionId, actor }: Props ) {
 									},
 									{
 										onSuccess: () => {
-											dismissFollowError();
+											dismissFollowError( item.handle );
 											invalidateActorList();
 										},
-										onError: ( error ) => showFollowError( error, 'unfollow' ),
+										onError: ( error ) => showFollowError( error, 'unfollow', item.handle ),
 									}
 								),
 					  },

--- a/client/reader/fediverse/following-view.tsx
+++ b/client/reader/fediverse/following-view.tsx
@@ -100,17 +100,24 @@ export function FollowingView( { connectionId, actor }: Props ) {
 	const followMut = useMutation( followFediverseActorMutation( queryClient ) );
 	const unfollowMut = useMutation( unfollowFediverseActorMutation( queryClient ) );
 
-	// Surface follow / unfollow failures via a stable notice id so a stale
-	// toast from one click is dismissed when the user retries. Also emit a
-	// pipeline-level log so failures stay observable in dashboards even
-	// when no Tracks dashboard is consulted.
+	// Scope the error-notice id to `(connectionId, rowActor)` so a successful
+	// click on one row only dismisses its own stale toast, not another row's
+	// unresolved error. Sibling surfaces (author panel, followers list) keep
+	// their own toast space.
+	const noticeIdFor = useCallback(
+		( rowActor: string ) => `fediverse-follow-error-${ connectionId }-${ rowActor }`,
+		[ connectionId ]
+	);
 	const showFollowError = useCallback(
-		( error: FediverseError, action: 'follow' | 'unfollow' ) => {
+		( error: FediverseError, action: 'follow' | 'unfollow', rowActor: string ) => {
 			dispatch(
 				errorNotice( followErrorMessage( error, action, translate ), {
-					id: 'fediverse-follow-error',
+					id: noticeIdFor( rowActor ),
 				} )
 			);
+			// Pipeline-level log so failures stay observable in dashboards even
+			// when no Tracks dashboard is consulted. Swallow rejections — the
+			// logstash POST going down must not bubble to the global handler.
 			logToLogstash( {
 				feature: 'calypso_client',
 				message: `Reader Fediverse ${ action } mutation failed`,
@@ -120,13 +127,16 @@ export function FollowingView( { connectionId, actor }: Props ) {
 					connection_id: connectionId,
 					error_kind: error.kind,
 				},
-			} );
+			} ).catch( () => undefined );
 		},
-		[ dispatch, translate, connectionId ]
+		[ dispatch, translate, connectionId, noticeIdFor ]
 	);
-	const dismissFollowError = useCallback( () => {
-		dispatch( removeNotice( 'fediverse-follow-error' ) );
-	}, [ dispatch ] );
+	const dismissFollowError = useCallback(
+		( rowActor: string ) => {
+			dispatch( removeNotice( noticeIdFor( rowActor ) ) );
+		},
+		[ dispatch, noticeIdFor ]
+	);
 
 	const invalidateActorList = useCallback( () => {
 		queryClient.invalidateQueries( {
@@ -172,10 +182,10 @@ export function FollowingView( { connectionId, actor }: Props ) {
 									},
 									{
 										onSuccess: () => {
-											dismissFollowError();
+											dismissFollowError( item.handle );
 											invalidateActorList();
 										},
-										onError: ( error ) => showFollowError( error, 'follow' ),
+										onError: ( error ) => showFollowError( error, 'follow', item.handle ),
 									}
 								),
 							onUnfollow: () =>
@@ -186,10 +196,10 @@ export function FollowingView( { connectionId, actor }: Props ) {
 									},
 									{
 										onSuccess: () => {
-											dismissFollowError();
+											dismissFollowError( item.handle );
 											invalidateActorList();
 										},
-										onError: ( error ) => showFollowError( error, 'unfollow' ),
+										onError: ( error ) => showFollowError( error, 'unfollow', item.handle ),
 									}
 								),
 					  },

--- a/client/reader/fediverse/test/author-profile-panel.test.tsx
+++ b/client/reader/fediverse/test/author-profile-panel.test.tsx
@@ -1,0 +1,305 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient } from '@tanstack/react-query';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import * as logstash from 'calypso/lib/logstash';
+import * as notices from 'calypso/state/notices/actions';
+import * as analytics from 'calypso/state/reader/analytics/actions';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { FediverseAuthorProfilePanel } from '../author-profile-panel';
+import type { FediverseAuthorProfile, FediverseConnection } from '@automattic/api-core';
+
+jest.mock( '@automattic/calypso-router', () => jest.fn() );
+
+// `logToLogstash` fires a real HTTPS request; mute it so the follow-error
+// path doesn't trigger an unmocked-request alarm in nock.
+jest.mock( 'calypso/lib/logstash', () => ( {
+	logToLogstash: jest.fn().mockResolvedValue( undefined ),
+} ) );
+
+const BASE = 'https://public-api.wordpress.com';
+
+const connection: FediverseConnection = {
+	id: 7,
+	blog_id: 100,
+	url: 'https://example.com',
+	name: 'Example',
+	icon: '',
+	webfinger: '@example@example.com',
+};
+
+const ACTOR = 'alice@remote.example';
+
+function makeProfile( overrides: Partial< FediverseAuthorProfile > = {} ): FediverseAuthorProfile {
+	return {
+		id: 'https://remote.example/users/alice',
+		username: 'alice',
+		acct: '@alice@remote.example',
+		handle: '@alice@remote.example',
+		instance: 'remote.example',
+		display_name: 'Alice',
+		note: '',
+		avatar: null,
+		header: null,
+		url: 'https://remote.example/@alice',
+		locked: false,
+		counts: { followers: 12, following: 34, posts: 56 },
+		// `viewer` / `is_self` are optional on the wire; tests opt in per case.
+		...overrides,
+	};
+}
+
+function makeQueryClient() {
+	return new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+}
+
+function profileUrl() {
+	return `/wpcom/v2/reader/fediverse/connections/7/profile/${ encodeURIComponent( ACTOR ) }`;
+}
+
+function feedUrl() {
+	return `/wpcom/v2/reader/fediverse/connections/7/profile/${ encodeURIComponent(
+		ACTOR
+	) }/timeline`;
+}
+
+function stubProfile( overrides: Partial< FediverseAuthorProfile > = {} ) {
+	// Wire response wraps the profile in a `{ profile: ... }` envelope —
+	// the fetcher unwraps it before passing to `useFediverseAuthorProfileQuery`.
+	return nock( BASE )
+		.get( profileUrl() )
+		.reply( 200, { profile: makeProfile( overrides ) } );
+}
+
+function stubFeed() {
+	return nock( BASE ).get( feedUrl() ).reply( 200, { items: [], cursor: null } );
+}
+
+describe( 'FediverseAuthorProfilePanel — follow / unfollow button', () => {
+	// `SocialFeedList` uses IntersectionObserver via
+	// `react-intersection-observer`; jsdom doesn't provide it.
+	beforeAll( () => {
+		global.IntersectionObserver = class IntersectionObserver {
+			observe() {}
+			unobserve() {}
+			disconnect() {}
+		} as unknown as typeof global.IntersectionObserver;
+	} );
+
+	afterAll( () => {
+		// @ts-expect-error -- cleaning up the stub
+		delete global.IntersectionObserver;
+	} );
+
+	beforeEach( () => {
+		// recordReaderTracksEvent is a thunk that reads state.reader.follows.
+		// Replace it with a no-op action creator so dispatch() doesn't throw,
+		// while letting spies observe call-site arguments.
+		jest
+			.spyOn( analytics, 'recordReaderTracksEvent' )
+			.mockImplementation( () => ( { type: '@@TEST/NOOP' } ) as never );
+	} );
+
+	afterEach( () => {
+		nock.cleanAll();
+		jest.restoreAllMocks();
+	} );
+
+	// ---------------------------------------------------------------
+	// jeherve flag #1: button hidden when viewer missing OR is_self true
+	// ---------------------------------------------------------------
+
+	it( 'hides the button when viewer is undefined (forwards-compat for pre-deploy backends)', async () => {
+		stubProfile();
+		stubFeed();
+
+		renderWithProvider( <FediverseAuthorProfilePanel connection={ connection } actor={ ACTOR } />, {
+			queryClient: makeQueryClient(),
+		} );
+
+		await waitFor( () => expect( screen.getByRole( 'heading', { name: 'Alice' } ) ).toBeVisible() );
+		expect( screen.queryByRole( 'button', { name: /^Follow$/ } ) ).toBeNull();
+		expect( screen.queryByRole( 'button', { name: /Unfollow/ } ) ).toBeNull();
+	} );
+
+	it( 'hides the button when is_self is true', async () => {
+		stubProfile( {
+			viewer: { following: false, followed_by: false, requested: false },
+			is_self: true,
+		} );
+		stubFeed();
+
+		renderWithProvider( <FediverseAuthorProfilePanel connection={ connection } actor={ ACTOR } />, {
+			queryClient: makeQueryClient(),
+		} );
+
+		await waitFor( () => expect( screen.getByRole( 'heading', { name: 'Alice' } ) ).toBeVisible() );
+		expect( screen.queryByRole( 'button', { name: /^Follow$/ } ) ).toBeNull();
+		expect( screen.queryByRole( 'button', { name: /Unfollow/ } ) ).toBeNull();
+	} );
+
+	// ---------------------------------------------------------------
+	// jeherve flag #2: follow / unfollow click → Tracks payload
+	// (was_locked / was_requested captured at click time)
+	// ---------------------------------------------------------------
+
+	it( 'flows was_locked: true through to the follow_clicked Tracks payload for locked accounts', async () => {
+		const user = userEvent.setup();
+		const spy = analytics.recordReaderTracksEvent as unknown as jest.Mock;
+		stubProfile( {
+			locked: true,
+			viewer: { following: false, followed_by: false, requested: false },
+			is_self: false,
+		} );
+		stubFeed();
+		nock( BASE )
+			.post( '/wpcom/v2/reader/fediverse/connections/7/follows', { actor: ACTOR } )
+			.reply( 200, { viewer: { following: false, followed_by: false, requested: true } } );
+
+		renderWithProvider( <FediverseAuthorProfilePanel connection={ connection } actor={ ACTOR } />, {
+			queryClient: makeQueryClient(),
+		} );
+
+		await user.click( await screen.findByRole( 'button', { name: /^Follow$/ } ) );
+
+		await waitFor( () =>
+			expect( spy.mock.calls ).toContainEqual( [
+				'calypso_reader_fediverse_profile_follow_clicked',
+				{
+					connection_id: 7,
+					was_followed_by: false,
+					was_locked: true,
+				},
+			] )
+		);
+	} );
+
+	it( 'cancels a pending follow request and emits was_requested: true when clicking Cancel', async () => {
+		const user = userEvent.setup();
+		const spy = analytics.recordReaderTracksEvent as unknown as jest.Mock;
+		stubProfile( {
+			locked: true,
+			viewer: { following: false, followed_by: false, requested: true },
+			is_self: false,
+		} );
+		stubFeed();
+		nock( BASE )
+			.delete( `/wpcom/v2/reader/fediverse/connections/7/follows/${ encodeURIComponent( ACTOR ) }` )
+			.reply( 200, { viewer: { following: false, followed_by: false, requested: false } } );
+
+		renderWithProvider( <FediverseAuthorProfilePanel connection={ connection } actor={ ACTOR } />, {
+			queryClient: makeQueryClient(),
+		} );
+
+		await user.click(
+			await screen.findByRole( 'button', {
+				name: /Cancel follow request to @alice@remote\.example/,
+			} )
+		);
+
+		await waitFor( () =>
+			expect( spy.mock.calls ).toContainEqual( [
+				'calypso_reader_fediverse_profile_unfollow_clicked',
+				{
+					connection_id: 7,
+					was_requested: true,
+				},
+			] )
+		);
+	} );
+
+	// ---------------------------------------------------------------
+	// jeherve flag #3: error path → Tracks error event +
+	// errorNotice id + logstash type discriminator
+	// ---------------------------------------------------------------
+
+	it( 'fires _follow_error + scoped errorNotice + logstash on a 502 follow response', async () => {
+		const user = userEvent.setup();
+		const tracksSpy = analytics.recordReaderTracksEvent as unknown as jest.Mock;
+		const noticeSpy = jest.spyOn( notices, 'errorNotice' );
+		stubProfile( {
+			viewer: { following: false, followed_by: false, requested: false },
+			is_self: false,
+		} );
+		stubFeed();
+		nock( BASE )
+			.post( '/wpcom/v2/reader/fediverse/connections/7/follows', { actor: ACTOR } )
+			.reply( 502, { code: 'reader_fediverse_upstream_unavailable' } );
+
+		renderWithProvider( <FediverseAuthorProfilePanel connection={ connection } actor={ ACTOR } />, {
+			queryClient: makeQueryClient(),
+		} );
+
+		await user.click( await screen.findByRole( 'button', { name: /^Follow$/ } ) );
+
+		await waitFor( () =>
+			expect(
+				tracksSpy.mock.calls.some(
+					( [ event, props ] ) =>
+						event === 'calypso_reader_fediverse_profile_follow_error' &&
+						( props as Record< string, unknown > )?.action === 'follow' &&
+						( props as Record< string, unknown > )?.error_kind === 'upstream_unavailable'
+				)
+			).toBe( true )
+		);
+		// Notice id is scoped to (connection.id, actor) so a sibling surface
+		// (followers / following list) doesn't silently dismiss this toast.
+		expect( noticeSpy ).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining( { id: `fediverse-follow-error-7-${ ACTOR }` } )
+		);
+		// Logstash type discriminator carries the action — `follow_mutation_error`,
+		// not `unfollow_mutation_error` — so dashboards can split by direction.
+		expect( logstash.logToLogstash ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				feature: 'calypso_client',
+				severity: 'error',
+				extra: expect.objectContaining( {
+					type: 'reader_fediverse_follow_mutation_error',
+					connection_id: 7,
+					error_kind: 'upstream_unavailable',
+				} ),
+			} )
+		);
+	} );
+
+	// ---------------------------------------------------------------
+	// jeherve flag #4: removeNotice on a successful retry
+	// ---------------------------------------------------------------
+
+	it( 'clears the stale follow-error toast on a successful retry', async () => {
+		const user = userEvent.setup();
+		const removeSpy = jest.spyOn( notices, 'removeNotice' );
+		stubProfile( {
+			viewer: { following: false, followed_by: false, requested: false },
+			is_self: false,
+		} );
+		stubFeed();
+		// First click 502s; second click succeeds. The success path should
+		// `removeNotice` the same scoped id used by the error path so the
+		// stale toast doesn't outlive the retry.
+		nock( BASE )
+			.post( '/wpcom/v2/reader/fediverse/connections/7/follows', { actor: ACTOR } )
+			.reply( 502, { code: 'reader_fediverse_upstream_unavailable' } );
+		nock( BASE )
+			.post( '/wpcom/v2/reader/fediverse/connections/7/follows', { actor: ACTOR } )
+			.reply( 200, { viewer: { following: true, followed_by: false, requested: false } } );
+
+		renderWithProvider( <FediverseAuthorProfilePanel connection={ connection } actor={ ACTOR } />, {
+			queryClient: makeQueryClient(),
+		} );
+
+		await user.click( await screen.findByRole( 'button', { name: /^Follow$/ } ) );
+		// Wait for the panel to settle back to the Follow button after the
+		// optimistic patch rolls back, then click again.
+		await screen.findByRole( 'button', { name: /^Follow$/ } );
+		await user.click( screen.getByRole( 'button', { name: /^Follow$/ } ) );
+
+		await waitFor( () =>
+			expect( removeSpy ).toHaveBeenCalledWith( `fediverse-follow-error-7-${ ACTOR }` )
+		);
+	} );
+} );

--- a/client/reader/mastodon/author-profile-panel.tsx
+++ b/client/reader/mastodon/author-profile-panel.tsx
@@ -107,6 +107,12 @@ export function MastodonAuthorProfilePanel( {
 	const followMutate = followMut.mutate;
 	const unfollowMutate = unfollowMut.mutate;
 
+	// Scope the error-notice id to `(connectionId, actor)` so a successful
+	// follow on one surface doesn't silently dismiss an unresolved error
+	// toast posted by a different surface (the followers / following lists
+	// share the same notice space).
+	const noticeId = `mastodon-follow-error-${ connection.id }-${ actor }`;
+
 	const showFollowError = useCallback(
 		( error: MastodonError, action: 'follow' | 'unfollow', accountId: string ) => {
 			dispatch(
@@ -119,11 +125,14 @@ export function MastodonAuthorProfilePanel( {
 			);
 			dispatch(
 				errorNotice( followErrorMessage( error, action, translate ), {
-					id: 'mastodon-follow-error',
+					id: noticeId,
 				} )
 			);
 			// Pipeline-level log so failures stay observable in dashboards
-			// even when no Tracks dashboard is consulted.
+			// even when no Tracks dashboard is consulted. Swallow rejections —
+			// the logstash POST going down must not bubble to the global
+			// handler, which is exactly the silent failure this breadcrumb
+			// exists to surface.
 			logToLogstash( {
 				feature: 'calypso_client',
 				message: `Reader Mastodon ${ action } mutation failed`,
@@ -134,9 +143,9 @@ export function MastodonAuthorProfilePanel( {
 					account_id: accountId,
 					error_kind: error.kind,
 				},
-			} );
+			} ).catch( () => undefined );
 		},
-		[ connection.id, dispatch, translate ]
+		[ connection.id, dispatch, translate, noticeId ]
 	);
 
 	const handleFollow = useCallback( () => {
@@ -159,12 +168,12 @@ export function MastodonAuthorProfilePanel( {
 			{ connectionId: connection.id, actor, accountId, locked },
 			{
 				onSuccess: () => {
-					dispatch( removeNotice( 'mastodon-follow-error' ) );
+					dispatch( removeNotice( noticeId ) );
 				},
 				onError: ( error ) => showFollowError( error, 'follow', accountId ),
 			}
 		);
-	}, [ profile.data, connection.id, actor, dispatch, followMutate, showFollowError ] );
+	}, [ profile.data, connection.id, actor, dispatch, followMutate, showFollowError, noticeId ] );
 
 	const handleUnfollow = useCallback( () => {
 		if ( ! profile.data ) {
@@ -182,12 +191,12 @@ export function MastodonAuthorProfilePanel( {
 			{ connectionId: connection.id, actor, accountId },
 			{
 				onSuccess: () => {
-					dispatch( removeNotice( 'mastodon-follow-error' ) );
+					dispatch( removeNotice( noticeId ) );
 				},
 				onError: ( error ) => showFollowError( error, 'unfollow', accountId ),
 			}
 		);
-	}, [ profile.data, connection.id, actor, dispatch, unfollowMutate, showFollowError ] );
+	}, [ profile.data, connection.id, actor, dispatch, unfollowMutate, showFollowError, noticeId ] );
 
 	const renderProfileBody = useCallback(
 		( profileData: MastodonAuthorProfile ) => {

--- a/client/reader/mastodon/followers-view.tsx
+++ b/client/reader/mastodon/followers-view.tsx
@@ -115,21 +115,29 @@ export function FollowersView( { connectionId, actor }: Props ) {
 	const followMut = useMutation( followMastodonActorMutation( queryClient ) );
 	const unfollowMut = useMutation( unfollowMastodonActorMutation( queryClient ) );
 
-	// Surface follow / unfollow failures via a stable notice id so a stale
-	// toast from one click is dismissed when the user retries.
+	// Scope the error-notice id to `(connectionId, rowActor)` so a successful
+	// click on one row only dismisses its own stale toast, not another row's
+	// unresolved error (or one posted by a sibling surface).
+	const noticeIdFor = useCallback(
+		( rowActor: string ) => `mastodon-follow-error-${ connectionId }-${ rowActor }`,
+		[ connectionId ]
+	);
 	const showFollowError = useCallback(
-		( error: MastodonError, action: 'follow' | 'unfollow' ) => {
+		( error: MastodonError, action: 'follow' | 'unfollow', rowActor: string ) => {
 			dispatch(
 				errorNotice( followErrorMessage( error, action, translate ), {
-					id: 'mastodon-follow-error',
+					id: noticeIdFor( rowActor ),
 				} )
 			);
 		},
-		[ dispatch, translate ]
+		[ dispatch, translate, noticeIdFor ]
 	);
-	const dismissFollowError = useCallback( () => {
-		dispatch( removeNotice( 'mastodon-follow-error' ) );
-	}, [ dispatch ] );
+	const dismissFollowError = useCallback(
+		( rowActor: string ) => {
+			dispatch( removeNotice( noticeIdFor( rowActor ) ) );
+		},
+		[ dispatch, noticeIdFor ]
+	);
 
 	// Refetch the actor list after a follow / unfollow so the row's `viewer`
 	// state mirrors server truth. Without this, the row keeps the pre-click
@@ -184,10 +192,10 @@ export function FollowersView( { connectionId, actor }: Props ) {
 								},
 								{
 									onSuccess: () => {
-										dismissFollowError();
+										dismissFollowError( item.handle );
 										invalidateActorList();
 									},
-									onError: ( error ) => showFollowError( error, 'follow' ),
+									onError: ( error ) => showFollowError( error, 'follow', item.handle ),
 								}
 							),
 						onUnfollow: () =>
@@ -199,10 +207,10 @@ export function FollowersView( { connectionId, actor }: Props ) {
 								},
 								{
 									onSuccess: () => {
-										dismissFollowError();
+										dismissFollowError( item.handle );
 										invalidateActorList();
 									},
-									onError: ( error ) => showFollowError( error, 'unfollow' ),
+									onError: ( error ) => showFollowError( error, 'unfollow', item.handle ),
 								}
 							),
 				  },

--- a/client/reader/mastodon/following-view.tsx
+++ b/client/reader/mastodon/following-view.tsx
@@ -109,19 +109,29 @@ export function FollowingView( { connectionId, actor }: Props ) {
 	const followMut = useMutation( followMastodonActorMutation( queryClient ) );
 	const unfollowMut = useMutation( unfollowMastodonActorMutation( queryClient ) );
 
+	// Scope the error-notice id to `(connectionId, rowActor)` so a successful
+	// click on one row only dismisses its own stale toast, not another row's
+	// unresolved error (or one posted by a sibling surface).
+	const noticeIdFor = useCallback(
+		( rowActor: string ) => `mastodon-follow-error-${ connectionId }-${ rowActor }`,
+		[ connectionId ]
+	);
 	const showFollowError = useCallback(
-		( error: MastodonError, action: 'follow' | 'unfollow' ) => {
+		( error: MastodonError, action: 'follow' | 'unfollow', rowActor: string ) => {
 			dispatch(
 				errorNotice( followErrorMessage( error, action, translate ), {
-					id: 'mastodon-follow-error',
+					id: noticeIdFor( rowActor ),
 				} )
 			);
 		},
-		[ dispatch, translate ]
+		[ dispatch, translate, noticeIdFor ]
 	);
-	const dismissFollowError = useCallback( () => {
-		dispatch( removeNotice( 'mastodon-follow-error' ) );
-	}, [ dispatch ] );
+	const dismissFollowError = useCallback(
+		( rowActor: string ) => {
+			dispatch( removeNotice( noticeIdFor( rowActor ) ) );
+		},
+		[ dispatch, noticeIdFor ]
+	);
 
 	const invalidateActorList = useCallback( () => {
 		queryClient.invalidateQueries( {
@@ -169,10 +179,10 @@ export function FollowingView( { connectionId, actor }: Props ) {
 								},
 								{
 									onSuccess: () => {
-										dismissFollowError();
+										dismissFollowError( item.handle );
 										invalidateActorList();
 									},
-									onError: ( error ) => showFollowError( error, 'follow' ),
+									onError: ( error ) => showFollowError( error, 'follow', item.handle ),
 								}
 							),
 						onUnfollow: () =>
@@ -184,10 +194,10 @@ export function FollowingView( { connectionId, actor }: Props ) {
 								},
 								{
 									onSuccess: () => {
-										dismissFollowError();
+										dismissFollowError( item.handle );
 										invalidateActorList();
 									},
-									onError: ( error ) => showFollowError( error, 'unfollow' ),
+									onError: ( error ) => showFollowError( error, 'unfollow', item.handle ),
 								}
 							),
 				  },

--- a/client/reader/mastodon/test/author-profile-panel.test.tsx
+++ b/client/reader/mastodon/test/author-profile-panel.test.tsx
@@ -521,7 +521,7 @@ describe( 'MastodonAuthorProfilePanel', () => {
 				},
 			] );
 			expect( await screen.findByRole( 'button', { name: /^Follow$/ } ) ).toBeVisible();
-			expect( removeSpy ).toHaveBeenCalledWith( 'mastodon-follow-error' );
+			expect( removeSpy ).toHaveBeenCalledWith( 'mastodon-follow-error-7-108020' );
 		} );
 
 		it( 'cancels a pending follow request and emits was_requested: true when clicking Cancel', async () => {
@@ -615,7 +615,7 @@ describe( 'MastodonAuthorProfilePanel', () => {
 			// `type` discriminator carries the `unfollow` action.
 			expect( noticeSpy ).toHaveBeenCalledWith(
 				expect.anything(),
-				expect.objectContaining( { id: 'mastodon-follow-error' } )
+				expect.objectContaining( { id: 'mastodon-follow-error-7-108020' } )
 			);
 			expect( logstash.logToLogstash ).toHaveBeenCalledWith(
 				expect.objectContaining( {
@@ -659,7 +659,7 @@ describe( 'MastodonAuthorProfilePanel', () => {
 			await waitFor( () =>
 				expect( noticeSpy ).toHaveBeenCalledWith(
 					'Couldn’t unfollow this account.',
-					expect.objectContaining( { id: 'mastodon-follow-error' } )
+					expect.objectContaining( { id: 'mastodon-follow-error-7-108020' } )
 				)
 			);
 		} );
@@ -710,7 +710,7 @@ describe( 'MastodonAuthorProfilePanel', () => {
 			);
 			expect( noticeSpy ).toHaveBeenCalledWith(
 				expect.anything(),
-				expect.objectContaining( { id: 'mastodon-follow-error' } )
+				expect.objectContaining( { id: 'mastodon-follow-error-7-108020' } )
 			);
 			// Pipeline-level log so failures stay observable in dashboards
 			// even when no Tracks dashboard is consulted.
@@ -759,7 +759,7 @@ describe( 'MastodonAuthorProfilePanel', () => {
 			await waitFor( () =>
 				expect( noticeSpy ).toHaveBeenCalledWith(
 					'Couldn’t follow this account.',
-					expect.objectContaining( { id: 'mastodon-follow-error' } )
+					expect.objectContaining( { id: 'mastodon-follow-error-7-108020' } )
 				)
 			);
 		} );
@@ -778,7 +778,7 @@ describe( 'MastodonAuthorProfilePanel', () => {
 				);
 			stubFeed();
 			// First click 502s; second click succeeds — the success path
-			// should fire `removeNotice('mastodon-follow-error')` so the
+			// should fire `removeNotice('mastodon-follow-error-7-108020')` so the
 			// stale error toast doesn't outlive the retry.
 			nock( BASE )
 				.post( '/wpcom/v2/reader/mastodon/connections/7/follows', { account_id: '108020' } )
@@ -802,7 +802,9 @@ describe( 'MastodonAuthorProfilePanel', () => {
 			await screen.findByRole( 'button', { name: /^Follow$/ } );
 			await user.click( screen.getByRole( 'button', { name: /^Follow$/ } ) );
 
-			await waitFor( () => expect( removeSpy ).toHaveBeenCalledWith( 'mastodon-follow-error' ) );
+			await waitFor( () =>
+				expect( removeSpy ).toHaveBeenCalledWith( 'mastodon-follow-error-7-108020' )
+			);
 		} );
 	} );
 } );

--- a/packages/api-core/src/reader-fediverse/types.ts
+++ b/packages/api-core/src/reader-fediverse/types.ts
@@ -210,9 +210,21 @@ export interface FediverseAuthorProfile {
 	/** True for AP actors that gate their content behind a follow approval. */
 	locked: boolean;
 	counts: FediverseProfileCounts;
-	viewer: FediverseAuthorProfileViewer;
-	/** True when this actor is the connected caller's own self. */
-	is_self: boolean;
+	/**
+	 * Relationship state from the connected account's perspective. Optional
+	 * during the backend rollout window — consumers must treat undefined as
+	 * "no follow UI available" rather than synthesizing a default, which
+	 * would mislead users into clicking Follow on accounts they already
+	 * follow. Matches the `FediverseFeedItem.viewer` rollout shape and the
+	 * Mastodon sibling type.
+	 */
+	viewer?: FediverseAuthorProfileViewer;
+	/**
+	 * `true` when this actor matches the connected caller's own account.
+	 * Optional during the backend rollout window — the panel hides the
+	 * follow button on `is_self === true`. Matches the Mastodon sibling.
+	 */
+	is_self?: boolean;
 }
 
 /**


### PR DESCRIPTION
Part of CM-718. Mounts the shared `<FollowButton>` on the Fediverse author-profile panel, mirroring the Mastodon and ATmosphere wirings. The Fediverse follow / unfollow mutation factories shipped in slice 1 (used by the followers / following list views) — this PR is purely a UI hookup.

## Proposed Changes

* `client/reader/fediverse/author-profile-panel.tsx`:
  * Mount `followFediverseActorMutation` + `unfollowFediverseActorMutation` via the consumer's `QueryClient`.
  * Build `handleFollow` / `handleUnfollow` callbacks that capture `locked` at click time (so analytics survive a profile refetch racing with the in-flight mutation), dispatch the Tracks click event, fire the mutation, and route errors through the existing `followErrorMessage` copy + a logstash breadcrumb. Mirrors the Mastodon shape.
  * Tracks events:
    * `calypso_reader_fediverse_profile_follow_clicked` (props: `connection_id`, `was_followed_by`, `was_locked`)
    * `calypso_reader_fediverse_profile_unfollow_clicked` (props: `connection_id`, `was_requested`)
    * `calypso_reader_fediverse_profile_follow_error` (props: `connection_id`, `action`, `error_kind`)
  * Logstash type names: `reader_fediverse_follow_mutation_error` / `reader_fediverse_unfollow_mutation_error`.
  * Render `<FollowButton>` in `renderProfileBody`, gated on `viewer && ! is_self` — pre-deploy backends that don't yet project the `viewer` block (or the user's own profile) hide the button entirely rather than guess at follow state. The button passes through `following` / `followed_by` / `requested` from the profile, plus a pending flag derived from either mutation being in flight.
  * The button slots into `<SocialProfileCard headerActions>` so the layout matches Mastodon's exactly.

Error-notice id `fediverse-follow-error` stays shared with the followers / following list views — only one toast at a time across the whole Fediverse pane.

## Why are these changes being made?

CM-718. The author-profile view rendered the actor's bio + counts but had no follow affordance — users could only follow via the followers / following list-row buttons, which is an awkward path from the profile surface. This brings the Fediverse profile to parity with the Mastodon and ATmosphere panels.

## Testing Instructions

1. `yarn typecheck-client` — clean for `client/reader/fediverse/*`.
2. `yarn test-client client/reader/fediverse` — green (29 tests).
3. With `reader/fediverse` enabled and a connected AP-enabled blog:
   * Visit `/reader/fediverse/<id>/profile/<actor>` for a remote AP actor → the Follow button renders inside the profile header band.
   * Click Follow on an unlocked account → button flips to "Following" optimistically; success notice on commit.
   * Click "Following" → button flips back to "Follow"; the unfollow mutation invalidates the actor's row in the followers / following list caches.
   * Click Follow on a locked account → button shows "Requested" (Mastodon's pending state) until the upstream approves.
   * Force a 401 / 502 from the backend → the matching `followErrorMessage` copy renders in a toast, and Logstash sees `reader_fediverse_follow_mutation_error`.
   * Visit your own profile → no Follow button renders (the `is_self` gate).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
