### PR TITLE
Reader Mastodon: handle hide_collections + partial-followers notice (CM-723)

### DIFF
--- a/client/reader/mastodon/followers-view.tsx
+++ b/client/reader/mastodon/followers-view.tsx
@@ -18,6 +18,7 @@ import ReaderMain from 'calypso/reader/components/reader-main';
 import {
 	AuthorProfileHeader,
 	SocialAccountList,
+	SocialAccountListHeader,
 	type SocialAccountListProps,
 	type SocialAccountRowProps,
 } from 'calypso/reader/social';
@@ -236,7 +237,16 @@ export function FollowersView( { connectionId, actor }: Props ) {
 			/>
 			<AuthorProfileHeader timelineUrl={ profileHref ?? `/reader/mastodon/${ connectionId }` } />
 			{ hideCollections ? (
-				<HiddenCollectionsMessage />
+				<>
+					<SocialAccountListHeader
+						displayName={ profileQuery.data?.display_name ?? null }
+						handle={ profileQuery.data?.acct ?? actor }
+						count={ profileQuery.data?.counts.followers ?? null }
+						mode="followers"
+						isPending={ profileQuery.isPending }
+					/>
+					<HiddenCollectionsMessage />
+				</>
 			) : (
 				<>
 					<SocialAccountList< MastodonAccountSummary >

--- a/client/reader/mastodon/followers-view.tsx
+++ b/client/reader/mastodon/followers-view.tsx
@@ -23,6 +23,7 @@ import {
 } from 'calypso/reader/social';
 import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
 import { projectMastodonError } from './error-projection';
+import { HiddenCollectionsMessage, PartialCollectionsNotice } from './profile-collections-notice';
 import { followErrorMessage } from './profile-errors';
 import { getProfileUrl } from './route';
 import type { MastodonAccountSummary, MastodonError } from '@automattic/api-core';
@@ -56,7 +57,20 @@ export function FollowersView( { connectionId, actor }: Props ) {
 	}, [ connectionsPending, connectionsError, connection ] );
 
 	const profileQuery = useMastodonAuthorProfileQuery( connectionId, actor );
-	const followersQuery = useMastodonActorFollowersInfiniteQuery( { connectionId, actor } );
+
+	// When the actor has hidden their social graph (`hide_collections: true`),
+	// the upstream API returns 200 with an empty page. Short-circuit the list
+	// query so we don't burn an upstream call just to render an empty state —
+	// we'll render a dedicated "hidden" message instead. Older backends that
+	// don't emit the field surface as `undefined`, which is treated as "not
+	// hidden" so the existing behaviour is preserved.
+	const hideCollections = profileQuery.data?.hide_collections === true;
+
+	const followersQuery = useMastodonActorFollowersInfiniteQuery( {
+		connectionId,
+		actor,
+		enabled: ! hideCollections,
+	} );
 	const {
 		data: followersData,
 		isPending: followersIsPending,
@@ -221,27 +235,37 @@ export function FollowersView( { connectionId, actor }: Props ) {
 				) }
 			/>
 			<AuthorProfileHeader timelineUrl={ profileHref ?? `/reader/mastodon/${ connectionId }` } />
-			<SocialAccountList< MastodonAccountSummary >
-				query={ query }
-				renderItem={ renderItem }
-				itemKey={ ( item ) => item.id }
-				emptyTitle={ String( translate( 'No followers yet' ) ) }
-				emptyLine={ String(
-					translate( 'When someone follows %(actor)s, they will appear here.', {
-						args: { actor },
-					} )
-				) }
-				protocolLabel="Mastodon"
-				protocolHomeURL="/reader/mastodon"
-				protocolHomeLabel={ String( translate( 'Back to Mastodon' ) ) }
-				header={ {
-					displayName: profileQuery.data?.display_name ?? null,
-					handle: profileQuery.data?.acct ?? actor,
-					count: profileQuery.data?.counts.followers ?? null,
-					mode: 'followers',
-					isPending: profileQuery.isPending,
-				} }
-			/>
+			{ hideCollections ? (
+				<HiddenCollectionsMessage />
+			) : (
+				<>
+					<SocialAccountList< MastodonAccountSummary >
+						query={ query }
+						renderItem={ renderItem }
+						itemKey={ ( item ) => item.id }
+						emptyTitle={ String( translate( 'No followers yet' ) ) }
+						emptyLine={ String(
+							translate( 'When someone follows %(actor)s, they will appear here.', {
+								args: { actor },
+							} )
+						) }
+						protocolLabel="Mastodon"
+						protocolHomeURL="/reader/mastodon"
+						protocolHomeLabel={ String( translate( 'Back to Mastodon' ) ) }
+						header={ {
+							displayName: profileQuery.data?.display_name ?? null,
+							handle: profileQuery.data?.acct ?? actor,
+							count: profileQuery.data?.counts.followers ?? null,
+							mode: 'followers',
+							isPending: profileQuery.isPending,
+						} }
+					/>
+					<PartialCollectionsNotice
+						profileUrl={ profileQuery.data?.url ?? null }
+						mode="followers"
+					/>
+				</>
+			) }
 		</ReaderMain>
 	);
 }

--- a/client/reader/mastodon/following-view.tsx
+++ b/client/reader/mastodon/following-view.tsx
@@ -18,6 +18,7 @@ import ReaderMain from 'calypso/reader/components/reader-main';
 import {
 	AuthorProfileHeader,
 	SocialAccountList,
+	SocialAccountListHeader,
 	type SocialAccountListProps,
 	type SocialAccountRowProps,
 } from 'calypso/reader/social';
@@ -221,7 +222,16 @@ export function FollowingView( { connectionId, actor }: Props ) {
 			/>
 			<AuthorProfileHeader timelineUrl={ profileHref ?? `/reader/mastodon/${ connectionId }` } />
 			{ hideCollections ? (
-				<HiddenCollectionsMessage />
+				<>
+					<SocialAccountListHeader
+						displayName={ profileQuery.data?.display_name ?? null }
+						handle={ profileQuery.data?.acct ?? actor }
+						count={ profileQuery.data?.counts.following ?? null }
+						mode="following"
+						isPending={ profileQuery.isPending }
+					/>
+					<HiddenCollectionsMessage />
+				</>
 			) : (
 				<>
 					<SocialAccountList< MastodonAccountSummary >

--- a/client/reader/mastodon/following-view.tsx
+++ b/client/reader/mastodon/following-view.tsx
@@ -23,6 +23,7 @@ import {
 } from 'calypso/reader/social';
 import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
 import { projectMastodonError } from './error-projection';
+import { HiddenCollectionsMessage, PartialCollectionsNotice } from './profile-collections-notice';
 import { followErrorMessage } from './profile-errors';
 import { getProfileUrl } from './route';
 import type { MastodonAccountSummary, MastodonError } from '@automattic/api-core';
@@ -56,7 +57,16 @@ export function FollowingView( { connectionId, actor }: Props ) {
 	}, [ connectionsPending, connectionsError, connection ] );
 
 	const profileQuery = useMastodonAuthorProfileQuery( connectionId, actor );
-	const followingQuery = useMastodonActorFollowingInfiniteQuery( { connectionId, actor } );
+
+	// See followers-view for the rationale; same short-circuit applies to
+	// the following collection when the actor has hidden their social graph.
+	const hideCollections = profileQuery.data?.hide_collections === true;
+
+	const followingQuery = useMastodonActorFollowingInfiniteQuery( {
+		connectionId,
+		actor,
+		enabled: ! hideCollections,
+	} );
 	const {
 		data: followingData,
 		isPending: followingIsPending,
@@ -210,27 +220,37 @@ export function FollowingView( { connectionId, actor }: Props ) {
 				) }
 			/>
 			<AuthorProfileHeader timelineUrl={ profileHref ?? `/reader/mastodon/${ connectionId }` } />
-			<SocialAccountList< MastodonAccountSummary >
-				query={ query }
-				renderItem={ renderItem }
-				itemKey={ ( item ) => item.id }
-				emptyTitle={ String( translate( 'Not following anyone yet' ) ) }
-				emptyLine={ String(
-					translate( 'When %(actor)s follows someone, they will appear here.', {
-						args: { actor },
-					} )
-				) }
-				protocolLabel="Mastodon"
-				protocolHomeURL="/reader/mastodon"
-				protocolHomeLabel={ String( translate( 'Back to Mastodon' ) ) }
-				header={ {
-					displayName: profileQuery.data?.display_name ?? null,
-					handle: profileQuery.data?.acct ?? actor,
-					count: profileQuery.data?.counts.following ?? null,
-					mode: 'following',
-					isPending: profileQuery.isPending,
-				} }
-			/>
+			{ hideCollections ? (
+				<HiddenCollectionsMessage />
+			) : (
+				<>
+					<SocialAccountList< MastodonAccountSummary >
+						query={ query }
+						renderItem={ renderItem }
+						itemKey={ ( item ) => item.id }
+						emptyTitle={ String( translate( 'Not following anyone yet' ) ) }
+						emptyLine={ String(
+							translate( 'When %(actor)s follows someone, they will appear here.', {
+								args: { actor },
+							} )
+						) }
+						protocolLabel="Mastodon"
+						protocolHomeURL="/reader/mastodon"
+						protocolHomeLabel={ String( translate( 'Back to Mastodon' ) ) }
+						header={ {
+							displayName: profileQuery.data?.display_name ?? null,
+							handle: profileQuery.data?.acct ?? actor,
+							count: profileQuery.data?.counts.following ?? null,
+							mode: 'following',
+							isPending: profileQuery.isPending,
+						} }
+					/>
+					<PartialCollectionsNotice
+						profileUrl={ profileQuery.data?.url ?? null }
+						mode="following"
+					/>
+				</>
+			) }
 		</ReaderMain>
 	);
 }

--- a/client/reader/mastodon/profile-collections-notice.tsx
+++ b/client/reader/mastodon/profile-collections-notice.tsx
@@ -1,0 +1,92 @@
+import { ExternalLink } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import EmptyContent from 'calypso/components/empty-content';
+
+/**
+ * Validate `profileUrl` as an https web URL and split out the hostname for
+ * the link label. Returns `null` when the URL is missing, malformed, or
+ * uses a non-https scheme — in that case the calling component should
+ * render nothing (rather than a broken anchor with a `#` href).
+ */
+function safeProfileUrl(
+	profileUrl: string | null | undefined
+): { href: string; host: string } | null {
+	if ( ! profileUrl ) {
+		return null;
+	}
+	try {
+		const parsed = new URL( profileUrl );
+		if ( parsed.protocol !== 'https:' ) {
+			return null;
+		}
+		return { href: profileUrl, host: parsed.host };
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Rendered in place of the followers / following list when the upstream
+ * Mastodon profile reports `hide_collections: true`. Mirrors the message
+ * mas.to (and other Mastodon UIs) show in the same situation so users get
+ * a consistent explanation across surfaces.
+ */
+export function HiddenCollectionsMessage() {
+	const translate = useTranslate();
+	return (
+		<EmptyContent
+			title={ String(
+				translate( 'This user has chosen to not make this information available.' )
+			) }
+		/>
+	);
+}
+
+interface PartialCollectionsNoticeProps {
+	profileUrl: string | null | undefined;
+	mode: 'followers' | 'following';
+}
+
+/**
+ * Footer rendered below the followers / following list when collections
+ * are visible. The home-instance API only returns the locally-known
+ * subset of follow relationships for remote actors, so the totals on the
+ * actor's home instance can be much higher. The link sends the user to
+ * the source-of-truth list.
+ */
+export function PartialCollectionsNotice( { profileUrl, mode }: PartialCollectionsNoticeProps ) {
+	const translate = useTranslate();
+	const link = safeProfileUrl( profileUrl );
+	if ( ! link ) {
+		return null;
+	}
+
+	// Split into two translations so each lead-in has its own translator
+	// context — the home-instance label below is shared, so we render the
+	// `ExternalLink` once via `components` interpolation.
+	const lead =
+		mode === 'followers'
+			? translate( 'Followers for this profile may be missing.' )
+			: translate( 'Accounts followed by this profile may be missing.' );
+
+	return (
+		<p className="mastodon-profile-collections-notice">
+			{ lead }{ ' ' }
+			{ translate( 'See more on {{externalLink}}%(host)s{{/externalLink}}.', {
+				args: { host: link.host },
+				components: {
+					// `children` is provided by the i18n-calypso substitution;
+					// passing `null` here satisfies the typed required prop on
+					// `ExternalLink` without overriding the substituted text.
+					externalLink: (
+						<ExternalLink
+							className="mastodon-profile-collections-notice__link"
+							href={ link.href }
+							children={ null }
+						/>
+					),
+				},
+			} ) }
+		</p>
+	);
+}

--- a/client/reader/mastodon/profile-collections-notice.tsx
+++ b/client/reader/mastodon/profile-collections-notice.tsx
@@ -19,7 +19,7 @@ function safeProfileUrl(
 		if ( parsed.protocol !== 'https:' ) {
 			return null;
 		}
-		return { href: profileUrl, host: parsed.host };
+		return { href: parsed.href, host: parsed.host };
 	} catch {
 		return null;
 	}
@@ -61,32 +61,33 @@ export function PartialCollectionsNotice( { profileUrl, mode }: PartialCollectio
 		return null;
 	}
 
-	// Split into two translations so each lead-in has its own translator
-	// context — the home-instance label below is shared, so we render the
-	// `ExternalLink` once via `components` interpolation.
-	const lead =
+	// One full translatable sentence per mode so translators see (and can
+	// reorder) the assembled string. `children` is provided by the
+	// i18n-calypso substitution; passing `null` here satisfies the typed
+	// required prop on `ExternalLink` without overriding the substituted
+	// text.
+	const options = {
+		args: { host: link.host },
+		components: {
+			externalLink: (
+				<ExternalLink
+					className="mastodon-profile-collections-notice__link"
+					href={ link.href }
+					children={ null }
+				/>
+			),
+		},
+	};
+	const message =
 		mode === 'followers'
-			? translate( 'Followers for this profile may be missing.' )
-			: translate( 'Accounts followed by this profile may be missing.' );
+			? translate(
+					'Followers for this profile may be missing. See more on {{externalLink}}%(host)s{{/externalLink}}.',
+					options
+			  )
+			: translate(
+					'Accounts followed by this profile may be missing. See more on {{externalLink}}%(host)s{{/externalLink}}.',
+					options
+			  );
 
-	return (
-		<p className="mastodon-profile-collections-notice">
-			{ lead }{ ' ' }
-			{ translate( 'See more on {{externalLink}}%(host)s{{/externalLink}}.', {
-				args: { host: link.host },
-				components: {
-					// `children` is provided by the i18n-calypso substitution;
-					// passing `null` here satisfies the typed required prop on
-					// `ExternalLink` without overriding the substituted text.
-					externalLink: (
-						<ExternalLink
-							className="mastodon-profile-collections-notice__link"
-							href={ link.href }
-							children={ null }
-						/>
-					),
-				},
-			} ) }
-		</p>
-	);
+	return <p className="mastodon-profile-collections-notice">{ message }</p>;
 }

--- a/client/reader/mastodon/style.scss
+++ b/client/reader/mastodon/style.scss
@@ -78,3 +78,10 @@
 	// with `gap`, so reset the inherited margin to keep the gap honest.
 	margin: 0;
 }
+
+.mastodon-view .mastodon-profile-collections-notice {
+	margin: 16px 0 0;
+	color: var(--color-text-subtle);
+	font-size: 13px;
+	text-align: center;
+}

--- a/client/reader/mastodon/test/profile-collections-notice.test.tsx
+++ b/client/reader/mastodon/test/profile-collections-notice.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { HiddenCollectionsMessage, PartialCollectionsNotice } from '../profile-collections-notice';
+
+describe( 'HiddenCollectionsMessage', () => {
+	it( 'renders the same wording the Mastodon UI uses for hide_collections', () => {
+		render( <HiddenCollectionsMessage /> );
+		expect(
+			screen.getByText( 'This user has chosen to not make this information available.' )
+		).toBeInTheDocument();
+	} );
+} );
+
+describe( 'PartialCollectionsNotice', () => {
+	it( 'renders the followers lead-in and an external link to the actor home host', () => {
+		render(
+			<PartialCollectionsNotice
+				profileUrl="https://social.growyourown.services/@FediTips"
+				mode="followers"
+			/>
+		);
+		expect( screen.getByText( /Followers for this profile may be missing\./ ) ).toBeInTheDocument();
+		const link = screen.getByRole( 'link', { name: /social\.growyourown\.services/ } );
+		expect( link ).toHaveAttribute( 'href', 'https://social.growyourown.services/@FediTips' );
+	} );
+
+	it( 'renders the following-mode lead-in when mode="following"', () => {
+		render( <PartialCollectionsNotice profileUrl="https://mas.to/@alice" mode="following" /> );
+		expect(
+			screen.getByText( /Accounts followed by this profile may be missing\./ )
+		).toBeInTheDocument();
+		expect( screen.getByRole( 'link', { name: /mas\.to/ } ) ).toBeInTheDocument();
+	} );
+
+	it.each( [
+		[ 'null', null ],
+		[ 'undefined', undefined ],
+		[ 'empty string', '' ],
+		[ 'http (non-https)', 'http://example.com/@a' ],
+		[ 'javascript: scheme', 'javascript:alert(1)' ],
+		[ 'malformed url', 'not-a-url' ],
+	] )( 'renders nothing when profileUrl is %s', ( _label, url ) => {
+		const { container } = render(
+			<PartialCollectionsNotice profileUrl={ url } mode="followers" />
+		);
+		expect( container ).toBeEmptyDOMElement();
+	} );
+} );

--- a/client/reader/mastodon/test/profile-collections-notice.test.tsx
+++ b/client/reader/mastodon/test/profile-collections-notice.test.tsx
@@ -9,7 +9,7 @@ describe( 'HiddenCollectionsMessage', () => {
 		render( <HiddenCollectionsMessage /> );
 		expect(
 			screen.getByText( 'This user has chosen to not make this information available.' )
-		).toBeInTheDocument();
+		).toBeVisible();
 	} );
 } );
 
@@ -21,8 +21,9 @@ describe( 'PartialCollectionsNotice', () => {
 				mode="followers"
 			/>
 		);
-		expect( screen.getByText( /Followers for this profile may be missing\./ ) ).toBeInTheDocument();
+		expect( screen.getByText( /Followers for this profile may be missing\./ ) ).toBeVisible();
 		const link = screen.getByRole( 'link', { name: /social\.growyourown\.services/ } );
+		expect( link ).toBeVisible();
 		expect( link ).toHaveAttribute( 'href', 'https://social.growyourown.services/@FediTips' );
 	} );
 
@@ -30,8 +31,8 @@ describe( 'PartialCollectionsNotice', () => {
 		render( <PartialCollectionsNotice profileUrl="https://mas.to/@alice" mode="following" /> );
 		expect(
 			screen.getByText( /Accounts followed by this profile may be missing\./ )
-		).toBeInTheDocument();
-		expect( screen.getByRole( 'link', { name: /mas\.to/ } ) ).toBeInTheDocument();
+		).toBeVisible();
+		expect( screen.getByRole( 'link', { name: /mas\.to/ } ) ).toBeVisible();
 	} );
 
 	it.each( [

--- a/client/reader/social/account-list.tsx
+++ b/client/reader/social/account-list.tsx
@@ -49,7 +49,7 @@ export interface SocialAccountListProps< T > {
 	header?: SocialAccountListHeader;
 }
 
-function AccountListHeader( {
+export function SocialAccountListHeader( {
 	displayName,
 	handle,
 	count,
@@ -108,7 +108,7 @@ export function SocialAccountList< T >( props: SocialAccountListProps< T > ) {
 
 	return (
 		<>
-			{ props.header && <AccountListHeader { ...props.header } /> }
+			{ props.header && <SocialAccountListHeader { ...props.header } /> }
 			<SocialFeedList< T >
 				items={ items }
 				isPending={ props.query.isPending }

--- a/client/reader/social/index.ts
+++ b/client/reader/social/index.ts
@@ -12,7 +12,7 @@ export type { FollowButtonProps } from './follow-button';
 export { SocialAccountRow } from './account-row';
 export type { SocialAccountRowProps, SocialAccountRowFollowState } from './account-row';
 
-export { SocialAccountList } from './account-list';
+export { SocialAccountList, SocialAccountListHeader } from './account-list';
 export type { SocialAccountListProps } from './account-list';
 
 export { SocialPostCard } from './components/post-card';

--- a/packages/api-core/src/reader-mastodon/__tests__/types.test.ts
+++ b/packages/api-core/src/reader-mastodon/__tests__/types.test.ts
@@ -146,6 +146,37 @@ describe( 'follow types', () => {
 		expect( p.is_self ).toBe( false );
 	} );
 
+	it( 'MastodonAuthorProfile exposes hide_collections as an optional boolean', () => {
+		const hidden: MastodonAuthorProfile = {
+			id: '200',
+			acct: 'alice@mastodon.social',
+			display_name: 'Alice',
+			avatar: null,
+			header: null,
+			note: '',
+			counts: { followers: 0, following: 0, posts: 0 },
+			locked: false,
+			hide_collections: true,
+			raw: {},
+		};
+		expect( hidden.hide_collections ).toBe( true );
+
+		// Older backend response — field absent. Consumers must treat
+		// `undefined` as `false` (visible), not as "hidden".
+		const visible: MastodonAuthorProfile = {
+			id: '200',
+			acct: 'alice@mastodon.social',
+			display_name: 'Alice',
+			avatar: null,
+			header: null,
+			note: '',
+			counts: { followers: 0, following: 0, posts: 0 },
+			locked: false,
+			raw: {},
+		};
+		expect( visible.hide_collections ).toBeUndefined();
+	} );
+
 	it( 'MastodonCreateFollowParams + DeleteFollowParams shape', () => {
 		const c: MastodonCreateFollowParams = { connectionId: 1, accountId: '200' };
 		const d: MastodonDeleteFollowParams = { connectionId: 1, accountId: '200' };

--- a/packages/api-core/src/reader-mastodon/types.ts
+++ b/packages/api-core/src/reader-mastodon/types.ts
@@ -162,6 +162,22 @@ export interface MastodonAuthorProfile {
 	note: string;
 	counts: MastodonProfileCounts;
 	locked: boolean;
+	/**
+	 * Web URL of the actor's profile on their home instance, e.g.
+	 * `https://social.growyourown.services/@FediTips`. Used by the
+	 * followers / following surfaces to link out to the source-of-truth
+	 * list (the home-instance API only returns the locally-known subset).
+	 * Optional: older backend revisions don't emit it.
+	 */
+	url?: string | null;
+	/**
+	 * `true` when the actor has opted to hide their followers / following
+	 * collections. Absent on backends that haven't deployed the flag yet —
+	 * consumers must treat `undefined` as `false` (visible) rather than as
+	 * "hidden", so a missing field on an older backend doesn't black out
+	 * the tabs.
+	 */
+	hide_collections?: boolean;
 	raw: Record< string, unknown >;
 	/**
 	 * Relationship state from the connected account's perspective. Absent

--- a/packages/api-queries/src/__tests__/reader-mastodon.test.tsx
+++ b/packages/api-queries/src/__tests__/reader-mastodon.test.tsx
@@ -23,6 +23,8 @@ import nock from 'nock';
 import {
 	createMastodonPostMutation,
 	followMastodonActorMutation,
+	mastodonActorFollowersInfiniteQuery,
+	mastodonActorFollowingInfiniteQuery,
 	mastodonAuthStatusQueryOptions,
 	unfollowMastodonActorMutation,
 	uploadMastodonMediaMutation,
@@ -1954,5 +1956,32 @@ describe( 'useMastodonAuthStatusQuery', () => {
 
 	it( 'mastodonAuthStatusQueryOptions(null) is disabled', () => {
 		expect( mastodonAuthStatusQueryOptions( null ).enabled ).toBe( false );
+	} );
+} );
+
+describe.each( [
+	[ 'mastodonActorFollowersInfiniteQuery', mastodonActorFollowersInfiniteQuery ],
+	[ 'mastodonActorFollowingInfiniteQuery', mastodonActorFollowingInfiniteQuery ],
+] )( '%s enabled gating', ( _name, factory ) => {
+	const validParams = { connectionId: 1, actor: 'alice@mastodon.social' };
+
+	it( 'is enabled by default when connectionId and actor are valid', () => {
+		expect( factory( validParams ).enabled ).toBe( true );
+	} );
+
+	it( 'is enabled when `enabled: true` is passed explicitly', () => {
+		expect( factory( { ...validParams, enabled: true } ).enabled ).toBe( true );
+	} );
+
+	it( 'is disabled when `enabled: false` overrides otherwise-valid params', () => {
+		expect( factory( { ...validParams, enabled: false } ).enabled ).toBe( false );
+	} );
+
+	it( 'stays disabled when connectionId is invalid even with `enabled: true`', () => {
+		expect( factory( { ...validParams, connectionId: 0, enabled: true } ).enabled ).toBe( false );
+	} );
+
+	it( 'stays disabled when actor is empty even with `enabled: true`', () => {
+		expect( factory( { ...validParams, actor: '', enabled: true } ).enabled ).toBe( false );
 	} );
 } );

--- a/packages/api-queries/src/reader-mastodon.ts
+++ b/packages/api-queries/src/reader-mastodon.ts
@@ -367,6 +367,14 @@ export function useMastodonAuthorFeedInfiniteQuery(
 export interface MastodonActorPageQueryParams {
 	connectionId: number;
 	actor: string;
+	/**
+	 * Lets the caller suppress the request even when connectionId and actor
+	 * are valid — used by the followers / following views to short-circuit
+	 * when the upstream profile reports `hide_collections: true` so we don't
+	 * burn an upstream call only to render the empty-state placeholder.
+	 * Defaults to enabled.
+	 */
+	enabled?: boolean;
 }
 
 export const mastodonActorFollowersInfiniteQuery = ( params: MastodonActorPageQueryParams ) => {
@@ -389,7 +397,7 @@ export const mastodonActorFollowersInfiniteQuery = ( params: MastodonActorPageQu
 		// `|| undefined` (not `??`): an empty-string cursor terminates pagination,
 		// matching the slice-6 author-feed hardening.
 		getNextPageParam: ( lastPage ) => lastPage.cursor || undefined,
-		enabled: params.connectionId > 0 && normalizedActor.length > 0,
+		enabled: params.connectionId > 0 && normalizedActor.length > 0 && params.enabled !== false,
 		staleTime: 30_000,
 		gcTime: 5 * 60_000,
 		retry: ( failureCount, error ) => {
@@ -429,7 +437,7 @@ export const mastodonActorFollowingInfiniteQuery = ( params: MastodonActorPageQu
 			} ),
 		initialPageParam: undefined,
 		getNextPageParam: ( lastPage ) => lastPage.cursor || undefined,
-		enabled: params.connectionId > 0 && normalizedActor.length > 0,
+		enabled: params.connectionId > 0 && normalizedActor.length > 0 && params.enabled !== false,
 		staleTime: 30_000,
 		gcTime: 5 * 60_000,
 		retry: ( failureCount, error ) => {


### PR DESCRIPTION
Fixes CM-723

## Proposed Changes

* `followers-view.tsx` / `following-view.tsx`: when the upstream profile reports `hide_collections: true`, short-circuit the list query (`enabled: false`) and render a dedicated `HiddenCollectionsMessage` matching the canonical Mastodon copy — "This user has chosen to not make this information available."
* For the non-hidden case, add a `PartialCollectionsNotice` footer that explains the list may be partial (the home-instance API only knows the locally-cached subset for remote actors) and links out to the actor's home-instance profile. `safeProfileUrl` validates https + parse-ability; bad / missing URLs render nothing.
* `MastodonAuthorProfile` gains optional `url?: string | null` and `hide_collections?: boolean`. `undefined` is treated as "visible / not hidden" so older backends without CM-722 deployed don't black out the tabs.
* `MastodonActorPageQueryParams` gains optional `enabled?: boolean`, defaulting to `true` to preserve every existing call site.
* New tests cover the hidden-collections copy, both follower / following lead-ins, host extraction, URL hardening (`null` / `undefined` / empty / `http:` / `javascript:` / malformed), the `hide_collections` tri-state contract on `MastodonAuthorProfile`, and a truth-table for the new `enabled` param on both infinite-query factories.

## Why are these changes being made?

The Reader's Mastodon followers / following tabs treated two very different upstream states identically:

* An actor whose home instance only enumerates a subset of follow relationships (Mastodon's API only returns locally-known rows for remote actors) — the list is real but incomplete.
* An actor who has opted to hide their collections (`hide_collections: true`) — the upstream API returns empty for everyone.

Both rendered the generic "No followers yet" empty state, which is misleading. With CM-722 surfacing `hide_collections` on the profile response, the client can now distinguish the two and show the canonical Mastodon copy for hidden actors, plus a "may be partial — see the home instance" footer for the rest.

Depends on CM-722 (wpcom) being deployed for the hidden-collections branch to ever trigger. The notice and the visible-case behaviour are unchanged when the field is absent.

## Screenshots

**Before**

<img width="871" height="334" alt="Screenshot 2026-05-12 at 16 33 00" src="https://github.com/user-attachments/assets/a16eee43-12ba-4751-b256-ae16e0545fa8" />

**After**

<img width="889" height="488" alt="Screenshot 2026-05-12 at 17 22 53" src="https://github.com/user-attachments/assets/0dcddb55-8de0-4f48-af8d-454a06840e08" />

<img width="598" height="67" alt="Screenshot 2026-05-12 at 17 23 26" src="https://github.com/user-attachments/assets/97e469d9-5102-4e75-a00d-4718edb8abbc" />


## Testing Instructions

1. Connect a Mastodon account in the Reader (`/reader/mastodon`).
2. Visit the profile of an actor whose home instance has `hide_collections: true` (e.g. `@FediTips@social.growyourown.services`). With CM-722 deployed, the followers and following tabs should render the "This user has chosen to not make this information available." message instead of the empty list.
3. Visit the profile of an actor with public collections (e.g. `@alice@mas.to`). The followers / following tabs should render the list plus a small footer underneath: "Followers for this profile may be missing. See more on mas.to." with `mas.to` linking to the actor's home-instance profile in a new tab.
4. Repeat step 3 with an actor whose profile API response omits `url` (older backend); the footer should not render at all (no broken link).

Automated tests:

```
yarn test-client client/reader/mastodon/test/profile-collections-notice.test.tsx
yarn test-packages packages/api-queries/src/__tests__/reader-mastodon.test.tsx
yarn test-packages packages/api-core/src/reader-mastodon/__tests__/types.test.ts
```

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?