### PR TITLE
Reader onboard rsm - add back button, update styles, and a11y focus

### DIFF
--- a/client/reader/onboarding-rsm/index.tsx
+++ b/client/reader/onboarding-rsm/index.tsx
@@ -3,7 +3,9 @@ import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { CircularProgressBar } from '@automattic/components';
 import { Checklist, ChecklistItem, Task } from '@automattic/launchpad';
-import { Modal } from '@wordpress/components';
+import { Button, Modal } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { chevronLeft } from '@wordpress/icons';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
 import React, { useState, useEffect } from 'react';
@@ -154,6 +156,16 @@ const ReaderOnboardingRsm = ( {
 		setCurrentStep( 'discover' );
 	};
 
+	const handleInterestsBack = () => {
+		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }interests_modal_back` );
+		openStep( 'welcome' );
+	};
+
+	const handleDiscoverBack = () => {
+		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }discover_modal_back` );
+		openStep( 'interests' );
+	};
+
 	const itemClickHandler = ( task: Task ) => {
 		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }task_click`, {
 			task: task.id,
@@ -241,6 +253,29 @@ const ReaderOnboardingRsm = ( {
 		},
 	];
 
+	let modalBackButton = null;
+	if ( currentStep === 'interests' ) {
+		modalBackButton = (
+			<Button
+				size="compact"
+				className="reader-onboarding-modal__back-button"
+				onClick={ handleInterestsBack }
+				icon={ chevronLeft }
+				label={ __( 'Back' ) }
+			/>
+		);
+	} else if ( currentStep === 'discover' ) {
+		modalBackButton = (
+			<Button
+				size="compact"
+				className="reader-onboarding-modal__back-button"
+				onClick={ handleDiscoverBack }
+				icon={ chevronLeft }
+				label={ __( 'Back' ) }
+			/>
+		);
+	}
+
 	return (
 		<>
 			<div className="reader-onboarding">
@@ -275,6 +310,7 @@ const ReaderOnboardingRsm = ( {
 						'is-disabled':
 							( currentStep === 'discover' || currentStep === 'interests' ) && promptVerification,
 					} ) }
+					headerActions={ modalBackButton }
 				>
 					{ currentStep === 'welcome' && (
 						<WelcomeModal onClose={ handleStepClose } onContinue={ handleWelcomeContinue } />

--- a/client/reader/onboarding-rsm/interests-modal/index.tsx
+++ b/client/reader/onboarding-rsm/interests-modal/index.tsx
@@ -268,7 +268,7 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { onContinue, promptVe
 	return (
 		<>
 			{ promptVerification && <InterestsVerificationNudge /> }
-			<VStack spacing={ 5 } className="interests-modal__content">
+			<VStack spacing={ 4 } className="interests-modal__content">
 				<VStack spacing={ 0 }>
 					<h2 className="interests-modal__title">{ __( 'What topics interest you?' ) }</h2>
 					<p className="interests-modal__subtitle">

--- a/client/reader/onboarding-rsm/interests-modal/index.tsx
+++ b/client/reader/onboarding-rsm/interests-modal/index.tsx
@@ -8,7 +8,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
-import { fixMe, translate } from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import React, { useState, useEffect, useRef } from 'react';
 import { useReaderInterestTags } from 'calypso/data/reader/use-reader-interest-tags';
 import { useFollowedReaderTags } from 'calypso/data/reader/use-reader-tags';
@@ -272,18 +272,15 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { onContinue, promptVe
 				<VStack spacing={ 0 }>
 					<h2 className="interests-modal__title">{ __( 'What topics interest you?' ) }</h2>
 					<p className="interests-modal__subtitle">
-						{ __(
-							'​​Stay up-to-date with your favorite blogs and discover new voices—all from one place.'
-						) }
-					</p>
-					<p className="interests-modal__subtitle">
-						{ fixMe( {
-							text: 'Pick a pack that describes your interest, or switch to individual topics.',
-							newCopy: __(
-								'Pick a pack that describes your interest, or switch to individual topics.'
-							),
-							oldCopy: __( 'Follow at least 3 topics to personalize your Reader feed.' ),
-						} ) }
+						<span>
+							{ __(
+								'​​Stay up-to-date with your favorite blogs and discover new voices—all from one place.'
+							) }
+						</span>
+						<br className="interests-modal__subtitle-break" />{ ' ' }
+						<span>
+							{ __( 'Pick a pack that describes your interest, or switch to individual topics.' ) }
+						</span>
 					</p>
 				</VStack>
 

--- a/client/reader/onboarding-rsm/interests-modal/style.scss
+++ b/client/reader/onboarding-rsm/interests-modal/style.scss
@@ -41,8 +41,8 @@
 		display: flex;
 		gap: 16px;
 		overflow-x: auto;
-		padding: 4px 4px 12px;
-		// Allow card shadows to show without being clipped while we scroll.
+		padding: 12px 4px 12px;
+		// Allow card shadows and stacked-card pseudo-elements to show without being clipped.
 		margin: 0 -4px;
 		scroll-snap-type: x mandatory;
 		scroll-padding-left: 4px;
@@ -63,6 +63,35 @@
 	&__pack-item {
 		display: flex;
 		flex: 0 0 auto;
+		position: relative;
+
+		// Create two "stacked cards" behind the main card using pseudo-elements.
+		// Only the bottom strips of the stacked cards are visible below the main card.
+		// Front card border: --color-border-subtle (#E0E0E0). Back cards: #F0F0F0 (designer spec).
+		&::before,
+		&::after {
+			content: '';
+			position: absolute;
+			background: var( --color-surface );
+			border-radius: 8px;
+			border: 1px solid var( --studio-gray-5, #f0f0f0 );
+		}
+
+		// Middle stacked card: 4px inset on each side, peeks 4px above.
+		&::before {
+			inset-inline: 4px;
+			top: -4px;
+			bottom: 4px;
+			z-index: 0;
+		}
+
+		// Back stacked card: 8px inset on each side, peeks 8px above.
+		&::after {
+			inset-inline: 8px;
+			top: -8px;
+			bottom: 8px;
+			z-index: -1;
+		}
 	}
 
 	&__topics-toggle-row {

--- a/client/reader/onboarding-rsm/interests-modal/style.scss
+++ b/client/reader/onboarding-rsm/interests-modal/style.scss
@@ -107,9 +107,10 @@
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: center;
-		gap: 8px;
+		gap: 12px;
 		padding-inline: 60px;
 		margin-block-start: 4px;
+		padding-block-end: 32px;
 
 		@media ( max-width: $break-medium ) {
 			padding-inline: 12px;

--- a/client/reader/onboarding-rsm/interests-modal/style.scss
+++ b/client/reader/onboarding-rsm/interests-modal/style.scss
@@ -41,7 +41,7 @@
 		display: flex;
 		gap: 16px;
 		overflow-x: auto;
-		padding: 12px 4px 12px;
+		padding: 16px 4px 12px;
 		// Allow card shadows and stacked-card pseudo-elements to show without being clipped.
 		margin: 0 -4px;
 		scroll-snap-type: x mandatory;
@@ -77,19 +77,19 @@
 			border: 1px solid var( --studio-gray-5, #f0f0f0 );
 		}
 
-		// Middle stacked card: 4px inset on each side, peeks 4px above.
+		// Middle stacked card: 10px inset on each side, peeks 6px above.
 		&::before {
-			inset-inline: 4px;
-			top: -4px;
-			bottom: 4px;
+			inset-inline: 10px;
+			top: -6px;
+			bottom: 6px;
 			z-index: 0;
 		}
 
-		// Back stacked card: 8px inset on each side, peeks 8px above.
+		// Back stacked card: 20px inset on each side, peeks 12px above.
 		&::after {
-			inset-inline: 8px;
-			top: -8px;
-			bottom: 8px;
+			inset-inline: 20px;
+			top: -12px;
+			bottom: 12px;
 			z-index: -1;
 		}
 	}

--- a/client/reader/onboarding-rsm/interests-modal/style.scss
+++ b/client/reader/onboarding-rsm/interests-modal/style.scss
@@ -38,7 +38,7 @@
 	}
 
 	&__subtitle-break {
-		// Keep subtitle sentances on separate lines when there is reasonable room for them.
+		// Keep subtitle sentences on separate lines when there is reasonable room for them.
 		// On smaller viewports, they should be one text block for wrapping.
 		@media ( max-width: $break-medium ) {
 			display: none;

--- a/client/reader/onboarding-rsm/interests-modal/style.scss
+++ b/client/reader/onboarding-rsm/interests-modal/style.scss
@@ -37,6 +37,14 @@
 		margin: 0;
 	}
 
+	&__subtitle-break {
+		// Keep subtitle sentances on separate lines when there is reasonable room for them.
+		// On smaller viewports, they should be one text block for wrapping.
+		@media ( max-width: $break-medium ) {
+			display: none;
+		}
+	}
+
 	&__packs {
 		display: flex;
 		gap: 16px;

--- a/client/reader/onboarding-rsm/interests-modal/topic-group-card/style.scss
+++ b/client/reader/onboarding-rsm/interests-modal/topic-group-card/style.scss
@@ -77,8 +77,6 @@
 		overflow: hidden;
 		margin-left: -6px;
 		background-color: var( --studio-white, #fff );
-		box-shadow: 0 0 0 2px var( --color-surface, #fff );
-
 		// Reverse stacking so left avatars overlap right ones.
 		&:nth-child(1) { z-index: 4; }
 		&:nth-child(2) { z-index: 3; }
@@ -91,7 +89,6 @@
 		font-weight: 500;
 		color: var( --color-neutral-40, #8c8f94 );
 		background-color: var( --color-neutral-0, #efefef );
-		box-shadow: 0 0 0 2px var( --color-surface, #fff );
 	}
 
 	&__subscribe {

--- a/client/reader/onboarding-rsm/interests-modal/topic-group-card/style.scss
+++ b/client/reader/onboarding-rsm/interests-modal/topic-group-card/style.scss
@@ -69,6 +69,7 @@
 	}
 
 	&__avatar {
+		position: relative;
 		display: inline-flex;
 		align-items: center;
 		justify-content: center;
@@ -77,6 +78,12 @@
 		margin-left: -6px;
 		background-color: var( --studio-white, #fff );
 		box-shadow: 0 0 0 2px var( --color-surface, #fff );
+
+		// Reverse stacking so left avatars overlap right ones.
+		&:nth-child(1) { z-index: 4; }
+		&:nth-child(2) { z-index: 3; }
+		&:nth-child(3) { z-index: 2; }
+		&:nth-child(4) { z-index: 1; }
 	}
 
 	&__avatar-more {

--- a/client/reader/onboarding-rsm/interests-modal/topic-group-card/style.scss
+++ b/client/reader/onboarding-rsm/interests-modal/topic-group-card/style.scss
@@ -1,4 +1,6 @@
 .topic-group-card {
+	position: relative;
+	z-index: 1;
 	display: flex;
 	flex-direction: column;
 	width: 264px;

--- a/client/reader/onboarding-rsm/style.scss
+++ b/client/reader/onboarding-rsm/style.scss
@@ -18,6 +18,13 @@
 
 $actions-height: 64px;
 
+// Back button appears in the WP Modal header via the `headerActions` prop.
+// `order: -1` moves it before the (empty) title container, placing it on the
+// left side while the close button stays on the right.
+.reader-onboarding-rsm-modal .reader-onboarding-modal__back-button {
+	order: -1;
+}
+
 // Shared layout for all reader-onboarding-rsm modals (welcome, interests,
 // subscribe). All three share the same overall size, the same flex-column
 // scroll/footer architecture, and the same footer styling. Per-modal

--- a/client/reader/onboarding-rsm/style.scss
+++ b/client/reader/onboarding-rsm/style.scss
@@ -25,6 +25,29 @@ $actions-height: 64px;
 	order: -1;
 }
 
+// Match Calypso keyboard-mode focus (`accessible-focus` on `<html>` from
+// `@automattic/accessible-focus`): hide focus rings on pointer use, show a
+// consistent outline when the user is navigating by keyboard.
+html:not( .accessible-focus ) .reader-onboarding-rsm-modal {
+	button:focus,
+	a:focus,
+	[tabindex]:focus {
+		box-shadow: none;
+		outline: none;
+	}
+}
+
+.accessible-focus .reader-onboarding-rsm-modal {
+	button:focus,
+	a:focus,
+	[tabindex]:focus-visible {
+		outline: 2px solid var( --color-accent, #3858e9 );
+		outline-offset: 2px;
+		border-radius: 4px;
+		box-shadow: none;
+	}
+}
+
 // Shared layout for all reader-onboarding-rsm modals (welcome, interests,
 // subscribe). All three share the same overall size, the same flex-column
 // scroll/footer architecture, and the same footer styling. Per-modal

--- a/client/reader/onboarding-rsm/style.scss
+++ b/client/reader/onboarding-rsm/style.scss
@@ -62,9 +62,8 @@ $actions-height: 64px;
 	.reader-onboarding-modal__footer {
 		height: $actions-height;
 		flex: 0 0 auto;
-		background-color: #fff;
+		background-color: var( --color-surface );
 		padding-inline: 32px;
-		border-top: 1px solid #ddd; //$gray-300;
 
 		.reader-onboarding-modal__footer-actions {
 			height: 100%;
@@ -79,11 +78,6 @@ $actions-height: 64px;
 			justify-content: flex-end;
 		}
 	}
-}
-
-// Welcome doesn't show a divider above its footer.
-.reader-welcome-modal .reader-onboarding-modal__footer {
-	border-top: 0;
 }
 
 // VStack-based modals (welcome, interests) make the inner content the scroll

--- a/client/reader/onboarding-rsm/subscribe-modal/index.tsx
+++ b/client/reader/onboarding-rsm/subscribe-modal/index.tsx
@@ -278,8 +278,9 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { promptVerification, 
 										</div>
 										<div
 											className="subscribe-modal__preview-stream-container"
-											// @ts-expect-error `inert` removes preview stream from tab order + a11y tree (preview is non-interactive).
-											inert=""
+											// @ts-expect-error For some reason there's no inert type.
+											// `inert` removes preview stream from tab order + a11y tree (preview is non-interactive).
+											inert
 										>
 											<TypedStream
 												streamKey={ `feed:${ selectedSite.feed_ID }` }

--- a/client/reader/onboarding-rsm/subscribe-modal/index.tsx
+++ b/client/reader/onboarding-rsm/subscribe-modal/index.tsx
@@ -276,7 +276,11 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { promptVerification, 
 												}
 											/>
 										</div>
-										<div className="subscribe-modal__preview-stream-container">
+										<div
+											className="subscribe-modal__preview-stream-container"
+											// @ts-expect-error `inert` removes preview stream from tab order + a11y tree (preview is non-interactive).
+											inert=""
+										>
 											<TypedStream
 												streamKey={ `feed:${ selectedSite.feed_ID }` }
 												className="is-site-stream subscribe-modal__preview-stream no-padding"

--- a/client/reader/onboarding-rsm/subscribe-modal/style.scss
+++ b/client/reader/onboarding-rsm/subscribe-modal/style.scss
@@ -245,8 +245,9 @@ body.is-reader-page .subscribe-modal__preview-column .reader__card.card.is-place
 			transition: none;
 		}
 
+		// Omit `:focus` here — `box-shadow: none` removed the keyboard focus ring;
+		// global onboarding focus styles in `onboarding-rsm/style.scss` supply it.
 		.follow-button.has-button-style:hover,
-		.follow-button.has-button-style:focus,
 		.follow-button.has-button-style:active {
 			padding: 8px 14px;
 			border-width: 1px;

--- a/client/reader/onboarding-rsm/subscribe-modal/style.scss
+++ b/client/reader/onboarding-rsm/subscribe-modal/style.scss
@@ -73,7 +73,7 @@ body.is-reader-page .subscribe-modal__preview-column .reader__card.card.is-place
 		display: flex;
 		flex-direction: column;
 		align-items: center;
-		gap: 12px;
+		gap: 4px;
 		padding: 20px 24px 10px;
 	}
 

--- a/client/reader/onboarding-rsm/subscribe-modal/style.scss
+++ b/client/reader/onboarding-rsm/subscribe-modal/style.scss
@@ -2,7 +2,7 @@
 @import '@wordpress/base-styles/mixins';
 
 body.is-reader-page .subscribe-modal__preview-column .reader__card.card.is-placeholder {
-	padding: 12px 0;
+	padding: 14px 16px;
 
 	.reader__post-title {
 		margin-top: 0;

--- a/client/reader/onboarding-rsm/subscribe-modal/style.scss
+++ b/client/reader/onboarding-rsm/subscribe-modal/style.scss
@@ -82,7 +82,7 @@ body.is-reader-page .subscribe-modal__preview-column .reader__card.card.is-place
 		flex: 1;
 		min-height: 0;
 		padding: 20px 24px 0;
-		gap: 16px;
+		gap: 8px;
 
 		// Below ~700px viewport the modal itself starts clamping to 100vw
 		// and both columns no longer have usable room; collapse to list-only.
@@ -96,7 +96,7 @@ body.is-reader-page .subscribe-modal__preview-column .reader__card.card.is-place
 		padding-top: 2px;
 		overflow-y: auto;
 		max-width: 300px;
-		padding-inline-end: 32px;
+		padding-inline-end: 16px;
 
 		@media ( max-width: 699px ) {
 			flex: 1;

--- a/client/reader/onboarding-rsm/test/index.test.tsx
+++ b/client/reader/onboarding-rsm/test/index.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import ReaderOnboardingRsm from '../index';
+
+// ── Router ────────────────────────────────────────────────────────────────────
+
+jest.mock( '@automattic/calypso-router', () => ( {
+	__esModule: true,
+	default: Object.assign( jest.fn(), { redirect: jest.fn() } ),
+} ) );
+
+// ── Heavy UI ──────────────────────────────────────────────────────────────────
+
+jest.mock( '@automattic/components', () => ( {
+	CircularProgressBar: () => null,
+} ) );
+
+jest.mock( '@automattic/launchpad', () => ( {
+	Checklist: ( { children }: { children: React.ReactNode } ) => <>{ children }</>,
+	ChecklistItem: () => null,
+} ) );
+
+// Render the WP Modal without a portal so headerActions and children
+// are reachable via standard screen queries.
+jest.mock( '@wordpress/components', () => {
+	const { Button } =
+		jest.requireActual< typeof import('@wordpress/components') >( '@wordpress/components' );
+	return {
+		Button,
+		Modal: ( {
+			children,
+			headerActions,
+		}: {
+			children: React.ReactNode;
+			headerActions?: React.ReactNode;
+		} ) => (
+			<div role="dialog">
+				{ headerActions }
+				{ children }
+			</div>
+		),
+	};
+} );
+
+// ── Child modals (not under test here) ───────────────────────────────────────
+
+jest.mock( 'calypso/reader/onboarding-rsm/welcome-modal', () => ( {
+	__esModule: true,
+	default: ( { onContinue }: { onContinue: () => void } ) => (
+		<div data-testid="welcome-modal-content">
+			<button onClick={ onContinue }>Pick your topics</button>
+		</div>
+	),
+} ) );
+
+jest.mock( 'calypso/reader/onboarding-rsm/interests-modal', () => ( {
+	__esModule: true,
+	default: ( { onContinue }: { onContinue: () => void } ) => (
+		<div data-testid="interests-modal-content">
+			<button onClick={ onContinue }>Continue</button>
+		</div>
+	),
+} ) );
+
+jest.mock( 'calypso/reader/onboarding-rsm/subscribe-modal', () => ( {
+	__esModule: true,
+	default: () => <div data-testid="subscribe-modal-content" />,
+} ) );
+
+// ── Redux / selectors ─────────────────────────────────────────────────────────
+
+jest.mock( 'calypso/state/preferences/selectors', () => ( {
+	// null = onboarding neither completed nor seen; triggers auto-open of welcome step.
+	getPreference: jest.fn().mockReturnValue( null ),
+	hasReceivedRemotePreferences: jest.fn().mockReturnValue( true ),
+} ) );
+
+jest.mock( 'calypso/state/preferences/actions', () => ( {
+	savePreference: jest.fn( () => ( { type: 'PREFERENCES_SAVE' } ) ),
+} ) );
+
+jest.mock( 'calypso/state/current-user/selectors', () => ( {
+	getCurrentUserDate: jest.fn().mockReturnValue( '2025-06-01' ),
+	isCurrentUserEmailVerified: jest.fn().mockReturnValue( true ),
+} ) );
+
+jest.mock( 'calypso/state/gravatar-status/selectors', () => ( {
+	hasGravatar: jest.fn().mockReturnValue( false ),
+} ) );
+
+jest.mock( 'calypso/state/gravatar-status/actions', () => ( {
+	requestGravatarDetails: jest.fn( () => ( { type: 'GRAVATAR_DETAILS_REQUEST' } ) ),
+} ) );
+
+jest.mock( 'calypso/state/reader/follows/selectors', () => ( {
+	getReaderFollows: jest.fn().mockReturnValue( [] ),
+} ) );
+
+jest.mock( 'calypso/state/reader/follows/actions', () => ( {
+	requestFollows: jest.fn( () => ( { type: 'READER_FOLLOWS_REQUEST' } ) ),
+} ) );
+
+jest.mock( 'calypso/state/reader/onboarding/selectors/has-completed-reader-profile', () => ( {
+	__esModule: true,
+	default: jest.fn().mockReturnValue( false ),
+} ) );
+
+jest.mock( 'calypso/state/reader/streams/actions', () => ( {
+	clearStream: jest.fn( () => ( { type: 'READER_CLEAR_STREAM' } ) ),
+	requestPage: jest.fn( () => ( { type: 'READER_REQUEST_PAGE' } ) ),
+} ) );
+
+// ── Data hooks ────────────────────────────────────────────────────────────────
+
+jest.mock( 'calypso/data/reader/use-reader-tags', () => ( {
+	useFollowedReaderTags: () => ( { data: [] } ),
+} ) );
+
+jest.mock( '../../following/use-site-subscriptions', () => ( {
+	useSiteSubscriptions: () => ( { isLoading: false, hasNonSelfSubscriptions: false } ),
+} ) );
+
+// ── Utilities ─────────────────────────────────────────────────────────────────
+
+jest.mock( '../get-reload-step', () => ( {
+	getReloadStep: () => null,
+} ) );
+
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	recordTracksEvent: jest.fn(),
+} ) );
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe( 'ReaderOnboardingRsm – back button navigation', () => {
+	// The welcome step auto-opens because hasSeenOnboarding is null (mocked via getPreference).
+
+	it( 'does not show a back button on the welcome step', async () => {
+		renderWithProvider( <ReaderOnboardingRsm /> );
+
+		expect( await screen.findByTestId( 'welcome-modal-content' ) ).toBeVisible();
+		expect( screen.queryByRole( 'button', { name: 'Back' } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows a back button on the interests step that navigates back to the welcome step', async () => {
+		const user = userEvent.setup();
+		renderWithProvider( <ReaderOnboardingRsm /> );
+
+		await screen.findByTestId( 'welcome-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Pick your topics' } ) );
+
+		expect( await screen.findByTestId( 'interests-modal-content' ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'Back' } ) ).toBeVisible();
+
+		await user.click( screen.getByRole( 'button', { name: 'Back' } ) );
+
+		expect( await screen.findByTestId( 'welcome-modal-content' ) ).toBeVisible();
+		expect( screen.queryByRole( 'button', { name: 'Back' } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows a back button on the subscribe step that navigates back to the interests step', async () => {
+		const user = userEvent.setup();
+		renderWithProvider( <ReaderOnboardingRsm /> );
+
+		await screen.findByTestId( 'welcome-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Pick your topics' } ) );
+		await screen.findByTestId( 'interests-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
+
+		expect( await screen.findByTestId( 'subscribe-modal-content' ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'Back' } ) ).toBeVisible();
+
+		await user.click( screen.getByRole( 'button', { name: 'Back' } ) );
+
+		expect( await screen.findByTestId( 'interests-modal-content' ) ).toBeVisible();
+	} );
+} );

--- a/client/reader/onboarding-rsm/welcome-modal/index.tsx
+++ b/client/reader/onboarding-rsm/welcome-modal/index.tsx
@@ -125,7 +125,7 @@ const WelcomeModal: React.FC< WelcomeModalProps > = ( { onClose, onContinue } ) 
 					<h2 className="reader-welcome-modal__title">{ __( 'Your reading home base' ) }</h2>
 					<p className="reader-welcome-modal__subtitle">
 						<span>{ __( 'All your favorite blogs and newsletters in one focused feed.' ) }</span>
-						<br />
+						<br className="reader-welcome-modal__subtitle-break" />{ ' ' }
 						<span>
 							{ __( "Discover writers you'll love, no pop-ups, no clutter, just great writing." ) }
 						</span>

--- a/client/reader/onboarding-rsm/welcome-modal/style.scss
+++ b/client/reader/onboarding-rsm/welcome-modal/style.scss
@@ -74,6 +74,14 @@ $entry-offset: 10px;
 		color: var( --color-text-subtle );
 	}
 
+	// Keep subtitle sentances on separate lines when there is reasonable room for them.
+	// On smaller viewports, they should be one text block for wrapping.
+	&__subtitle-break {
+		@media ( max-width: $break-medium ) {
+			display: none;
+		}
+	}
+
 	&__people-grid {
 		display: flex;
 		flex-direction: column;

--- a/client/reader/onboarding-rsm/welcome-modal/style.scss
+++ b/client/reader/onboarding-rsm/welcome-modal/style.scss
@@ -77,6 +77,7 @@ $entry-offset: 10px;
 	&__people-grid {
 		display: flex;
 		flex-direction: column;
+		align-items: center;
 		gap: 28px;
 		margin-top: 28px;
 	}
@@ -87,8 +88,21 @@ $entry-offset: 10px;
 		gap: 28px;
 		flex-wrap: nowrap;
 
+		// At tablet widths, constrain the row to exactly 3 tiles wide and allow
+		// wrapping. The fixed max-width forces the break at 3 per row, while
+		// justify-content: center (from the base rule) centers any partial last
+		// row — so publications wrap 3+3 and bloggers wrap 3+2 (centered).
 		@media ( max-width: $break-medium ) {
 			flex-wrap: wrap;
+			max-width: 356px; // 3 × 100px + 2 × 28px gap
+			width: 100%;
+		}
+
+		// At mobile widths, shrink to 2 tiles wide with a tighter gap.
+		// 2 × 100px + 1 × 20px gap = 220px.
+		@media ( max-width: $break-mobile ) {
+			max-width: 220px;
+			gap: 20px;
 		}
 	}
 

--- a/client/reader/onboarding-rsm/welcome-modal/style.scss
+++ b/client/reader/onboarding-rsm/welcome-modal/style.scss
@@ -74,7 +74,7 @@ $entry-offset: 10px;
 		color: var( --color-text-subtle );
 	}
 
-	// Keep subtitle sentances on separate lines when there is reasonable room for them.
+	// Keep subtitle sentences on separate lines when there is reasonable room for them.
 	// On smaller viewports, they should be one text block for wrapping.
 	&__subtitle-break {
 		@media ( max-width: $break-medium ) {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # https://linear.app/a8c/issue/RSM-2867/style-polishing-on-modals / https://linear.app/a8c/issue/RSM-2868/previous-step-link-in-top-left / https://linear.app/a8c/issue/RSM-1988/fix-a11y-focus-issue

## Proposed Changes

Updates the onboarding-rsm modals:
* Some visual style changes per design. Adding stacked card graphic, reverse icon stacking in packs, padding changes, mobile/tablet fixes, etc.
* Adds back button to subscribe and interests step.
* Fixes a11y focus outlines to ensure they are visible in a11y flows and not click flows.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* onboarding rsm stuff. also a11y is important. and yeah.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* changes can be seen on `*/reader?flags=reader/onboarding-rsm,reader/force-onboarding`
* Smoke test modals and various viewports for styles.
* Test back buttons on interests and subscribe step.
* Test tab navigation and outline.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
