### PR TITLE
Renewal pricing: consolidate the way the discounts are presented

### DIFF
--- a/packages/plans-grid-next/src/index.tsx
+++ b/packages/plans-grid-next/src/index.tsx
@@ -14,6 +14,13 @@ import usePlanFeaturesForGridPlans from './hooks/data-store/use-plan-features-fo
 import usePlansFromTypes from './hooks/data-store/use-plans-from-types';
 import useRestructuredPlanFeaturesForComparisonGrid from './hooks/data-store/use-restructured-plan-features-for-comparison-grid';
 import { useManageTooltipToggle } from './hooks/use-manage-tooltip-toggle';
+import {
+	getPlanPriceForDuration,
+	calculateDiscountPercentage,
+	fromPricingMetaForGridPlan,
+	fromVariantPriceData,
+} from './lib/plan-pricing-utils';
+import type { PlanPriceInfo, VariantPriceData } from './lib/plan-pricing-utils';
 
 /**
  * Types
@@ -46,3 +53,14 @@ export {
  * Constants
  */
 export { EFFECTIVE_TERMS_LIST };
+
+/**
+ * Plan pricing utilities
+ */
+export type { PlanPriceInfo, VariantPriceData };
+export {
+	getPlanPriceForDuration,
+	calculateDiscountPercentage,
+	fromPricingMetaForGridPlan,
+	fromVariantPriceData,
+};

--- a/packages/plans-grid-next/src/lib/plan-pricing-utils.ts
+++ b/packages/plans-grid-next/src/lib/plan-pricing-utils.ts
@@ -114,7 +114,12 @@ export function fromPricingMetaForGridPlan(
 	return {
 		termMonths,
 		regularPricePerMonth: meta.originalPrice.monthly,
-		discountedPricePerMonth: meta.discountedPrice.monthly ?? undefined,
+		// The API sometimes sets discountedPrice.monthly to the intro offer price rather than
+		// a genuine site-level discount (e.g. currency conversion, proration credit). When an
+		// intro offer is active the intro structure already captures the discounted period, so
+		// using discountedPrice here would contaminate the post-intro "regular" rate used by
+		// getPlanPriceForDuration — producing incorrect totals for the non-intro months.
+		discountedPricePerMonth: isIntroActive ? undefined : meta.discountedPrice.monthly ?? undefined,
 		introOffer: meta.introOffer
 			? {
 					pricePerMonth: meta.introOffer.rawPrice.monthly,

--- a/packages/plans-grid-next/src/lib/plan-pricing-utils.ts
+++ b/packages/plans-grid-next/src/lib/plan-pricing-utils.ts
@@ -141,14 +141,14 @@ export function fromPricingMetaForGridPlan(
  *     derived by subtracting the non-intro months at the regular rate.
  */
 export interface VariantPriceData {
-	termIntervalInMonths: number;
-	/** Actual price charged for the full term (may embed an intro offer) */
-	priceInteger: number;
-	/** Full-term price at the regular (non-intro) rate */
-	priceBeforeDiscounts: number;
 	introductoryInterval: number;
 	/** 'month' | 'year' */
 	introductoryTerm: string;
+	/** Full-term price at the regular (non-intro) rate */
+	priceBeforeDiscounts: number;
+	/** Actual price charged for the full term (may embed an intro offer) */
+	priceInteger: number;
+	termIntervalInMonths: number;
 }
 
 /**

--- a/packages/plans-grid-next/src/lib/plan-pricing-utils.ts
+++ b/packages/plans-grid-next/src/lib/plan-pricing-utils.ts
@@ -1,0 +1,191 @@
+import { Plans } from '@automattic/data-stores';
+
+/**
+ * Intermediate structure that normalizes plan pricing from different sources
+ * (PricingMetaForGridPlan, WPCOMProductVariant) into a common shape suitable
+ * for discount calculations.
+ *
+ * All prices are in the smallest currency unit (e.g. cents).
+ */
+export interface PlanPriceInfo {
+	/** Billing period length in months (1, 12, 24, 36) */
+	termMonths: number;
+	/** Regular price per month — no intro offer, no site-level discount */
+	regularPricePerMonth: number;
+	/** Site-level discounted price per month (currency conversion / proration credit), if any */
+	discountedPricePerMonth?: number;
+	introOffer?: {
+		/** Monthly-equivalent price during the intro period */
+		pricePerMonth: number;
+		/** How many months the intro offer lasts */
+		durationMonths: number;
+		/** False once the offer has already been used by this user */
+		isActive: boolean;
+	};
+}
+
+// billingPeriod values are in days (from PERIOD_LIST in calypso-products)
+const BILLING_PERIOD_DAYS_TO_MONTHS: Record< number, number > = {
+	31: 1,
+	365: 12,
+	730: 24,
+	1095: 36,
+};
+
+function billingPeriodDaysToMonths( billingPeriod: number | undefined ): number | null {
+	if ( billingPeriod === undefined || billingPeriod === null ) {
+		return null;
+	}
+	return BILLING_PERIOD_DAYS_TO_MONTHS[ billingPeriod ] ?? null;
+}
+
+/**
+ * Calculates the total cost of a plan over `durationMonths` months.
+ *
+ * Handles partial billing periods via pro-ration (e.g. a yearly plan priced at
+ * $200/year costs $100 for 6 months).
+ *
+ * When `useIntroOffer` is true (default) and an active intro offer exists, the
+ * intro price is applied for the first `introOffer.durationMonths` months, and
+ * the regular (or discounted) price for the remainder.
+ *
+ * @example
+ * // Monthly plan: $10 intro for 1 month, then $20/month; cost for 6 months:
+ * // 1×$10 + 5×$20 = $110 (in cents: 1100 + 10000 = 11000)
+ * getPlanPriceForDuration( info, 6, { useIntroOffer: true } ) // 11000
+ *
+ * @example
+ * // Yearly plan: $100/yr intro, $200/yr regular; cost for 6 months:
+ * // useIntroOffer=true  → 6×($100/12) = $50   (5000 cents)
+ * // useIntroOffer=false → 6×($200/12) = $100  (10000 cents)
+ */
+export function getPlanPriceForDuration(
+	info: PlanPriceInfo,
+	durationMonths: number,
+	{ useIntroOffer = true }: { useIntroOffer?: boolean } = {}
+): number {
+	const basePricePerMonth = info.discountedPricePerMonth ?? info.regularPricePerMonth;
+
+	if ( useIntroOffer && info.introOffer?.isActive ) {
+		const introMonths = Math.min( durationMonths, info.introOffer.durationMonths );
+		const regularMonths = Math.max( 0, durationMonths - info.introOffer.durationMonths );
+		return introMonths * info.introOffer.pricePerMonth + regularMonths * basePricePerMonth;
+	}
+
+	return durationMonths * basePricePerMonth;
+}
+
+/**
+ * Calculates the percentage discount between a reference price and a cheaper price.
+ *
+ * Always uses Math.floor — conservative, never overstates savings.
+ *
+ * Returns `undefined` (not 0) when there is no saving, allowing callers to
+ * distinguish "no discount" from a computed "0% discount".
+ */
+export function calculateDiscountPercentage(
+	referencePrice: number,
+	cheaperPrice: number
+): number | undefined {
+	if ( cheaperPrice >= referencePrice || referencePrice <= 0 ) {
+		return undefined;
+	}
+	return Math.floor( ( 100 * ( referencePrice - cheaperPrice ) ) / referencePrice );
+}
+
+/**
+ * Converts a `PricingMetaForGridPlan` (from @automattic/data-stores Plans hooks)
+ * into a `PlanPriceInfo` suitable for use with `getPlanPriceForDuration` and
+ * `calculateDiscountPercentage`.
+ *
+ * Returns null when required pricing data is absent (e.g. free/enterprise plans
+ * that have no monthly price, or plans whose billing period is unknown).
+ */
+export function fromPricingMetaForGridPlan(
+	meta: Plans.PricingMetaForGridPlan
+): PlanPriceInfo | null {
+	const termMonths = billingPeriodDaysToMonths( meta.billingPeriod );
+	if ( termMonths === null || meta.originalPrice.monthly === null ) {
+		return null;
+	}
+
+	const isIntroActive = !! meta.introOffer && ! meta.introOffer.isOfferComplete;
+
+	return {
+		termMonths,
+		regularPricePerMonth: meta.originalPrice.monthly,
+		discountedPricePerMonth: meta.discountedPrice.monthly ?? undefined,
+		introOffer: meta.introOffer
+			? {
+					pricePerMonth: meta.introOffer.rawPrice.monthly,
+					durationMonths:
+						meta.introOffer.intervalCount * ( meta.introOffer.intervalUnit === 'year' ? 12 : 1 ),
+					isActive: isIntroActive,
+			  }
+			: undefined,
+	};
+}
+
+/**
+ * Minimal structural type describing the pricing fields needed from a product
+ * variant. `WPCOMProductVariant` (defined in checkout) satisfies this interface
+ * structurally, so it can be passed directly without importing the checkout type
+ * into this package.
+ *
+ * Key invariants:
+ *   - `priceBeforeDiscounts` is always the full-term cost at the regular rate.
+ *   - `priceInteger` is the actual amount charged, which embeds both intro and
+ *     non-intro portions when an intro offer spans only part of the term
+ *     (e.g. a 1-year intro on a 2-year plan).
+ *   - When `priceInteger < priceBeforeDiscounts`, the intro price portion is
+ *     derived by subtracting the non-intro months at the regular rate.
+ */
+export interface VariantPriceData {
+	termIntervalInMonths: number;
+	/** Actual price charged for the full term (may embed an intro offer) */
+	priceInteger: number;
+	/** Full-term price at the regular (non-intro) rate */
+	priceBeforeDiscounts: number;
+	introductoryInterval: number;
+	/** 'month' | 'year' */
+	introductoryTerm: string;
+}
+
+/**
+ * Converts a variant price data object (structurally compatible with
+ * `WPCOMProductVariant`) into a `PlanPriceInfo`.
+ *
+ * `discountedPricePerMonth` is intentionally not set: `WPCOMProductVariant`
+ * does not separate site-level discounts from the intro price. Coupon discounts
+ * in checkout are tracked separately via `product.coupon_savings_integer`.
+ */
+export function fromVariantPriceData( variant: VariantPriceData ): PlanPriceInfo {
+	const {
+		termIntervalInMonths: termMonths,
+		priceBeforeDiscounts,
+		priceInteger,
+		introductoryInterval,
+		introductoryTerm,
+	} = variant;
+
+	const regularPricePerMonth = priceBeforeDiscounts / termMonths;
+
+	const introDurationMonths =
+		introductoryInterval > 0 ? introductoryInterval * ( introductoryTerm === 'year' ? 12 : 1 ) : 0;
+
+	let introOffer: PlanPriceInfo[ 'introOffer' ] | undefined;
+
+	if ( introDurationMonths > 0 && priceInteger < priceBeforeDiscounts ) {
+		// Derive the intro-period price by subtracting the non-intro months
+		// (billed at the regular rate) from the total priceInteger.
+		const nonIntroMonths = termMonths - introDurationMonths;
+		const introPriceTotal = priceInteger - nonIntroMonths * regularPricePerMonth;
+		introOffer = {
+			pricePerMonth: introPriceTotal / introDurationMonths,
+			durationMonths: introDurationMonths,
+			isActive: true,
+		};
+	}
+
+	return { termMonths, regularPricePerMonth, introOffer };
+}

--- a/packages/plans-grid-next/src/lib/plan-pricing-utils.ts
+++ b/packages/plans-grid-next/src/lib/plan-pricing-utils.ts
@@ -163,6 +163,12 @@ export interface VariantPriceData {
  * `discountedPricePerMonth` is intentionally not set: `WPCOMProductVariant`
  * does not separate site-level discounts from the intro price. Coupon discounts
  * in checkout are tracked separately via `product.coupon_savings_integer`.
+ *
+ * Per-month values are derived by dividing full-term prices (integers in the
+ * smallest currency unit) by the number of months. The result is rounded to the
+ * nearest integer (Math.round) so that all fields in the returned `PlanPriceInfo`
+ * remain whole-cent values safe for use with currency formatters. The rounding
+ * error is at most 0.5¢ per month and is negligible for percentage comparisons.
  */
 export function fromVariantPriceData( variant: VariantPriceData ): PlanPriceInfo {
 	const {
@@ -173,7 +179,7 @@ export function fromVariantPriceData( variant: VariantPriceData ): PlanPriceInfo
 		introductoryTerm,
 	} = variant;
 
-	const regularPricePerMonth = priceBeforeDiscounts / termMonths;
+	const regularPricePerMonth = Math.round( priceBeforeDiscounts / termMonths );
 
 	const introDurationMonths =
 		introductoryInterval > 0 ? introductoryInterval * ( introductoryTerm === 'year' ? 12 : 1 ) : 0;
@@ -186,7 +192,7 @@ export function fromVariantPriceData( variant: VariantPriceData ): PlanPriceInfo
 		const nonIntroMonths = termMonths - introDurationMonths;
 		const introPriceTotal = priceInteger - nonIntroMonths * regularPricePerMonth;
 		introOffer = {
-			pricePerMonth: introPriceTotal / introDurationMonths,
+			pricePerMonth: Math.round( introPriceTotal / introDurationMonths ),
 			durationMonths: introDurationMonths,
 			isActive: true,
 		};

--- a/packages/plans-grid-next/src/lib/plan-pricing-utils.ts
+++ b/packages/plans-grid-next/src/lib/plan-pricing-utils.ts
@@ -187,15 +187,24 @@ export function fromVariantPriceData( variant: VariantPriceData ): PlanPriceInfo
 	let introOffer: PlanPriceInfo[ 'introOffer' ] | undefined;
 
 	if ( introDurationMonths > 0 && priceInteger < priceBeforeDiscounts ) {
-		// Derive the intro-period price by subtracting the non-intro months
-		// (billed at the regular rate) from the total priceInteger.
-		const nonIntroMonths = termMonths - introDurationMonths;
+		// When the intro spans the full term (introDurationMonths >= termMonths), all of
+		// priceInteger is at the intro rate and there are zero non-intro months.
+		// When the intro is shorter than the term (introDurationMonths < termMonths), we
+		// subtract the non-intro portion (billed at the regular rate) to isolate the intro cost.
+		const nonIntroMonths = Math.max( 0, termMonths - introDurationMonths );
 		const introPriceTotal = priceInteger - nonIntroMonths * regularPricePerMonth;
-		introOffer = {
-			pricePerMonth: Math.round( introPriceTotal / introDurationMonths ),
-			durationMonths: introDurationMonths,
-			isActive: true,
-		};
+
+		// A non-positive introPriceTotal means inconsistent data (e.g. a sub-term intro
+		// with a priceInteger that is less than the non-intro months at the regular rate).
+		if ( introPriceTotal > 0 ) {
+			// When introDurationMonths > termMonths the whole billing term is within the
+			// intro period, so we spread introPriceTotal over termMonths (not introDurationMonths).
+			introOffer = {
+				pricePerMonth: Math.round( introPriceTotal / Math.min( introDurationMonths, termMonths ) ),
+				durationMonths: introDurationMonths,
+				isActive: true,
+			};
+		}
 	}
 
 	return { termMonths, regularPricePerMonth, introOffer };

--- a/packages/plans-grid-next/src/lib/test/plan-pricing-utils.ts
+++ b/packages/plans-grid-next/src/lib/test/plan-pricing-utils.ts
@@ -361,7 +361,7 @@ describe( 'fromVariantPriceData', () => {
 		// introDuration = 1 × 12 = 12 months = full term
 		// nonIntroMonths = 12 - 12 = 0
 		// introPriceTotal = 10000 - 0 × 2000 = 10000
-		// introPricePerMonth = 10000 / 12
+		// introPricePerMonth = Math.round(10000 / 12) = Math.round(833.33) = 833
 		const variant = makeVariant( {
 			termIntervalInMonths: 12,
 			priceInteger: 10000,
@@ -373,7 +373,7 @@ describe( 'fromVariantPriceData', () => {
 		expect( result.termMonths ).toBe( 12 );
 		expect( result.regularPricePerMonth ).toBe( 2000 );
 		expect( result.introOffer ).toEqual( {
-			pricePerMonth: 10000 / 12,
+			pricePerMonth: 833,
 			durationMonths: 12,
 			isActive: true,
 		} );
@@ -386,7 +386,7 @@ describe( 'fromVariantPriceData', () => {
 		// introDuration = 1 × 12 = 12 months
 		// nonIntroMonths = 24 - 12 = 12
 		// introPriceTotal = 34000 - 12 × 2000 = 34000 - 24000 = 10000
-		// introPricePerMonth = 10000 / 12
+		// introPricePerMonth = Math.round(10000 / 12) = Math.round(833.33) = 833
 		const variant = makeVariant( {
 			termIntervalInMonths: 24,
 			priceInteger: 34000,
@@ -398,10 +398,40 @@ describe( 'fromVariantPriceData', () => {
 		expect( result.termMonths ).toBe( 24 );
 		expect( result.regularPricePerMonth ).toBe( 2000 );
 		expect( result.introOffer ).toEqual( {
-			pricePerMonth: 10000 / 12,
+			pricePerMonth: 833,
 			durationMonths: 12,
 			isActive: true,
 		} );
+	} );
+
+	it( 'rounds regularPricePerMonth to the nearest integer for non-evenly-divisible prices', () => {
+		// 10000 / 12 = 833.333... → rounds to 833 (not 834, and not a fraction)
+		const variant = makeVariant( {
+			termIntervalInMonths: 12,
+			priceBeforeDiscounts: 10000,
+			priceInteger: 10000,
+			introductoryInterval: 0,
+		} );
+		const result = fromVariantPriceData( variant );
+		expect( result.regularPricePerMonth ).toBe( 833 );
+		expect( Number.isInteger( result.regularPricePerMonth ) ).toBe( true );
+	} );
+
+	it( 'rounds introOffer.pricePerMonth to the nearest integer for non-evenly-divisible prices', () => {
+		// Annual plan, full term is the intro period
+		// priceBeforeDiscounts = 24000 → regularPricePerMonth = 2000 (exact)
+		// priceInteger = 5000 → introPriceTotal = 5000 - 0*2000 = 5000
+		// 5000 / 12 = 416.666... → rounds to 417
+		const variant = makeVariant( {
+			termIntervalInMonths: 12,
+			priceBeforeDiscounts: 24000,
+			priceInteger: 5000,
+			introductoryInterval: 1,
+			introductoryTerm: 'year',
+		} );
+		const result = fromVariantPriceData( variant );
+		expect( result.introOffer?.pricePerMonth ).toBe( 417 );
+		expect( Number.isInteger( result.introOffer?.pricePerMonth ) ).toBe( true );
 	} );
 
 	it( 'handles a monthly intro offer (introductoryTerm: month)', () => {

--- a/packages/plans-grid-next/src/lib/test/plan-pricing-utils.ts
+++ b/packages/plans-grid-next/src/lib/test/plan-pricing-utils.ts
@@ -476,6 +476,58 @@ describe( 'fromVariantPriceData', () => {
 		expect( fromVariantPriceData( variant ).introOffer ).toBeUndefined();
 	} );
 
+	it( 'handles a multi-month intro on a monthly plan (introDurationMonths > termMonths)', () => {
+		// Monthly plan ($20/month), 3-month intro at $5/month.
+		// termMonths=1, introDurationMonths=3 → whole term is within the intro period.
+		// nonIntroMonths = max(0, 1 - 3) = 0
+		// introPriceTotal = 500 - 0 = 500
+		// introPricePerMonth = round(500 / min(3, 1)) = round(500 / 1) = 500
+		const variant = makeVariant( {
+			termIntervalInMonths: 1,
+			priceBeforeDiscounts: 2000,
+			priceInteger: 500,
+			introductoryInterval: 3,
+			introductoryTerm: 'month',
+		} );
+		const result = fromVariantPriceData( variant );
+		expect( result.introOffer?.pricePerMonth ).toBe( 500 );
+		expect( result.introOffer?.durationMonths ).toBe( 3 );
+	} );
+
+	it( 'handles a multi-year intro on an annual plan (introDurationMonths > termMonths)', () => {
+		// Annual plan ($200/year), 3-year intro at $100/year.
+		// termMonths=12, introDurationMonths=36 → whole term is within the intro period.
+		// regularPricePerMonth = round(20000 / 12) = 1667
+		// nonIntroMonths = max(0, 12 - 36) = 0
+		// introPriceTotal = 10000 - 0 = 10000
+		// introPricePerMonth = round(10000 / min(36, 12)) = round(10000 / 12) = 833
+		const variant = makeVariant( {
+			termIntervalInMonths: 12,
+			priceBeforeDiscounts: 20000,
+			priceInteger: 10000,
+			introductoryInterval: 3,
+			introductoryTerm: 'year',
+		} );
+		const result = fromVariantPriceData( variant );
+		expect( result.introOffer?.pricePerMonth ).toBe( 833 );
+		expect( result.introOffer?.durationMonths ).toBe( 36 );
+	} );
+
+	it( 'produces no introOffer when introPriceTotal is non-positive (inconsistent data)', () => {
+		// Annual plan with a 3-month intro, but priceInteger is too low to be consistent:
+		// regularPricePerMonth = round(24000 / 12) = 2000
+		// nonIntroMonths = 12 - 3 = 9
+		// introPriceTotal = 1000 - 9 × 2000 = 1000 - 18000 = -17000 → bail out
+		const variant = makeVariant( {
+			termIntervalInMonths: 12,
+			priceBeforeDiscounts: 24000,
+			priceInteger: 1000,
+			introductoryInterval: 3,
+			introductoryTerm: 'month',
+		} );
+		expect( fromVariantPriceData( variant ).introOffer ).toBeUndefined();
+	} );
+
 	it( 'does not set discountedPricePerMonth', () => {
 		const variant = makeVariant();
 		const result = fromVariantPriceData( variant );

--- a/packages/plans-grid-next/src/lib/test/plan-pricing-utils.ts
+++ b/packages/plans-grid-next/src/lib/test/plan-pricing-utils.ts
@@ -1,0 +1,512 @@
+import {
+	getPlanPriceForDuration,
+	calculateDiscountPercentage,
+	fromPricingMetaForGridPlan,
+	fromVariantPriceData,
+} from '../plan-pricing-utils';
+import type { PlanPriceInfo, VariantPriceData } from '../plan-pricing-utils';
+import type { Plans } from '@automattic/data-stores';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makePlanPriceInfo( overrides: Partial< PlanPriceInfo > = {} ): PlanPriceInfo {
+	return {
+		termMonths: 12,
+		regularPricePerMonth: 2000,
+		...overrides,
+	};
+}
+
+function makePricingMeta(
+	overrides: Partial< Plans.PricingMetaForGridPlan > = {}
+): Plans.PricingMetaForGridPlan {
+	return {
+		originalPrice: { monthly: 2000, full: 24000 },
+		discountedPrice: { monthly: null, full: null },
+		...overrides,
+	};
+}
+
+function makeVariant( overrides: Partial< VariantPriceData > = {} ): VariantPriceData {
+	return {
+		termIntervalInMonths: 12,
+		priceInteger: 24000,
+		priceBeforeDiscounts: 24000,
+		introductoryInterval: 0,
+		introductoryTerm: 'year',
+		...overrides,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// getPlanPriceForDuration
+// ---------------------------------------------------------------------------
+
+describe( 'getPlanPriceForDuration', () => {
+	describe( 'no intro offer', () => {
+		it( 'returns regularPricePerMonth × durationMonths for a monthly plan', () => {
+			const info = makePlanPriceInfo( { termMonths: 1, regularPricePerMonth: 2000 } );
+			expect( getPlanPriceForDuration( info, 6 ) ).toBe( 12000 );
+		} );
+
+		it( 'returns pro-rated price for a yearly plan over 6 months', () => {
+			const info = makePlanPriceInfo( { termMonths: 12, regularPricePerMonth: 1500 } );
+			expect( getPlanPriceForDuration( info, 6 ) ).toBe( 9000 );
+		} );
+
+		it( 'uses discountedPricePerMonth instead of regularPricePerMonth when provided', () => {
+			const info = makePlanPriceInfo( {
+				termMonths: 12,
+				regularPricePerMonth: 2000,
+				discountedPricePerMonth: 1800,
+			} );
+			expect( getPlanPriceForDuration( info, 6 ) ).toBe( 10800 );
+		} );
+
+		it( 'uses discountedPricePerMonth for post-intro months when both are present', () => {
+			const info = makePlanPriceInfo( {
+				termMonths: 12,
+				regularPricePerMonth: 2000,
+				discountedPricePerMonth: 1800,
+				introOffer: { pricePerMonth: 1000, durationMonths: 6, isActive: true },
+			} );
+			// 6 intro months × 1000 + 6 regular months × 1800
+			expect( getPlanPriceForDuration( info, 12 ) ).toBe( 6000 + 10800 );
+		} );
+	} );
+
+	describe( 'with active intro offer', () => {
+		const monthlyWithIntro = makePlanPriceInfo( {
+			termMonths: 1,
+			regularPricePerMonth: 2000,
+			introOffer: { pricePerMonth: 1000, durationMonths: 1, isActive: true },
+		} );
+
+		const yearlyWithIntro = makePlanPriceInfo( {
+			termMonths: 12,
+			regularPricePerMonth: 2000,
+			introOffer: { pricePerMonth: 1000, durationMonths: 12, isActive: true },
+		} );
+
+		it( 'applies intro price for the first N months and regular price thereafter (monthly plan, 6 months)', () => {
+			// 1 intro month × 1000 + 5 regular months × 2000
+			expect( getPlanPriceForDuration( monthlyWithIntro, 6 ) ).toBe( 11000 );
+		} );
+
+		it( 'ignores intro price when useIntroOffer is false (monthly plan)', () => {
+			expect( getPlanPriceForDuration( monthlyWithIntro, 6, { useIntroOffer: false } ) ).toBe(
+				12000
+			);
+		} );
+
+		it( 'applies intro price for a yearly plan over 6 months (duration shorter than intro)', () => {
+			// intro covers 12 months; for 6 months only intro applies
+			// 6 × 1000 = 6000
+			expect( getPlanPriceForDuration( yearlyWithIntro, 6 ) ).toBe( 6000 );
+		} );
+
+		it( 'ignores intro price when useIntroOffer is false (yearly plan)', () => {
+			expect( getPlanPriceForDuration( yearlyWithIntro, 6, { useIntroOffer: false } ) ).toBe(
+				12000
+			);
+		} );
+
+		it( 'handles duration longer than the intro period (3-month duration, 1-month intro)', () => {
+			// 1 intro month × 1000 + 2 regular months × 2000
+			expect( getPlanPriceForDuration( monthlyWithIntro, 3 ) ).toBe( 5000 );
+		} );
+
+		it( 'handles duration exactly equal to the intro period', () => {
+			expect( getPlanPriceForDuration( monthlyWithIntro, 1 ) ).toBe( 1000 );
+		} );
+	} );
+
+	describe( 'with inactive intro offer', () => {
+		it( 'falls through to regular price when isActive is false, even if useIntroOffer is true', () => {
+			const info = makePlanPriceInfo( {
+				termMonths: 12,
+				regularPricePerMonth: 2000,
+				introOffer: { pricePerMonth: 1000, durationMonths: 12, isActive: false },
+			} );
+			expect( getPlanPriceForDuration( info, 6 ) ).toBe( 12000 );
+		} );
+	} );
+
+	describe( 'edge cases', () => {
+		it( 'returns 0 for 0 duration months', () => {
+			const info = makePlanPriceInfo( { termMonths: 12, regularPricePerMonth: 2000 } );
+			expect( getPlanPriceForDuration( info, 0 ) ).toBe( 0 );
+		} );
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// calculateDiscountPercentage
+// ---------------------------------------------------------------------------
+
+describe( 'calculateDiscountPercentage', () => {
+	it( 'returns the floored percentage discount for a standard case', () => {
+		// (2000 - 1400) / 2000 × 100 = 30
+		expect( calculateDiscountPercentage( 2000, 1400 ) ).toBe( 30 );
+	} );
+
+	it( 'floors fractional percentages (does not round up)', () => {
+		// (3000 - 2050) / 3000 × 100 = 31.666... → floor = 31
+		expect( calculateDiscountPercentage( 3000, 2050 ) ).toBe( 31 );
+	} );
+
+	it( 'returns undefined when cheaperPrice equals referencePrice (no saving)', () => {
+		expect( calculateDiscountPercentage( 2000, 2000 ) ).toBeUndefined();
+	} );
+
+	it( 'returns undefined when cheaperPrice is higher than referencePrice', () => {
+		expect( calculateDiscountPercentage( 2000, 2500 ) ).toBeUndefined();
+	} );
+
+	it( 'returns undefined when referencePrice is zero', () => {
+		expect( calculateDiscountPercentage( 0, 0 ) ).toBeUndefined();
+	} );
+
+	it( 'returns undefined when referencePrice is negative', () => {
+		expect( calculateDiscountPercentage( -100, -200 ) ).toBeUndefined();
+	} );
+
+	it( 'returns 99 for a near-complete discount (not 100)', () => {
+		// (1000 - 1) / 1000 × 100 = 99.9 → floor = 99
+		expect( calculateDiscountPercentage( 1000, 1 ) ).toBe( 99 );
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// fromPricingMetaForGridPlan
+// ---------------------------------------------------------------------------
+
+describe( 'fromPricingMetaForGridPlan', () => {
+	it( 'converts a monthly plan with no intro offer', () => {
+		const meta = makePricingMeta( { billingPeriod: 31 } );
+		const result = fromPricingMetaForGridPlan( meta );
+		expect( result ).toEqual( {
+			termMonths: 1,
+			regularPricePerMonth: 2000,
+			discountedPricePerMonth: undefined,
+			introOffer: undefined,
+		} );
+	} );
+
+	it( 'converts a yearly plan with no intro offer', () => {
+		const meta = makePricingMeta( { billingPeriod: 365 } );
+		const result = fromPricingMetaForGridPlan( meta );
+		expect( result ).toEqual( {
+			termMonths: 12,
+			regularPricePerMonth: 2000,
+			discountedPricePerMonth: undefined,
+			introOffer: undefined,
+		} );
+	} );
+
+	it( 'converts a biennial plan (730 days → 24 months)', () => {
+		const meta = makePricingMeta( {
+			billingPeriod: 730,
+			originalPrice: { monthly: 1500, full: 36000 },
+		} );
+		const result = fromPricingMetaForGridPlan( meta );
+		expect( result?.termMonths ).toBe( 24 );
+		expect( result?.regularPricePerMonth ).toBe( 1500 );
+	} );
+
+	it( 'converts a triennial plan (1095 days → 36 months)', () => {
+		const meta = makePricingMeta( {
+			billingPeriod: 1095,
+			originalPrice: { monthly: 1200, full: 43200 },
+		} );
+		const result = fromPricingMetaForGridPlan( meta );
+		expect( result?.termMonths ).toBe( 36 );
+	} );
+
+	it( 'sets discountedPricePerMonth when discountedPrice.monthly is provided', () => {
+		const meta = makePricingMeta( {
+			billingPeriod: 365,
+			discountedPrice: { monthly: 1800, full: 21600 },
+		} );
+		const result = fromPricingMetaForGridPlan( meta );
+		expect( result?.discountedPricePerMonth ).toBe( 1800 );
+	} );
+
+	it( 'leaves discountedPricePerMonth undefined when discountedPrice.monthly is null', () => {
+		const meta = makePricingMeta( { billingPeriod: 365 } );
+		const result = fromPricingMetaForGridPlan( meta );
+		expect( result?.discountedPricePerMonth ).toBeUndefined();
+	} );
+
+	it( 'maps an active yearly intro offer (intervalUnit: year, intervalCount: 1)', () => {
+		const meta = makePricingMeta( {
+			billingPeriod: 365,
+			introOffer: {
+				rawPrice: { monthly: 1000, full: 12000 },
+				intervalUnit: 'year',
+				intervalCount: 1,
+				isOfferComplete: false,
+				formattedPrice: '$120',
+			},
+		} );
+		const result = fromPricingMetaForGridPlan( meta );
+		expect( result?.introOffer ).toEqual( {
+			pricePerMonth: 1000,
+			durationMonths: 12,
+			isActive: true,
+		} );
+	} );
+
+	it( 'maps a completed intro offer with isActive: false', () => {
+		const meta = makePricingMeta( {
+			billingPeriod: 365,
+			introOffer: {
+				rawPrice: { monthly: 1000, full: 12000 },
+				intervalUnit: 'year',
+				intervalCount: 1,
+				isOfferComplete: true,
+				formattedPrice: '$120',
+			},
+		} );
+		const result = fromPricingMetaForGridPlan( meta );
+		expect( result?.introOffer?.isActive ).toBe( false );
+	} );
+
+	it( 'maps an intro offer spanning 2 years (intervalUnit: year, intervalCount: 2 → 24 months)', () => {
+		const meta = makePricingMeta( {
+			billingPeriod: 730,
+			originalPrice: { monthly: 1500, full: 36000 },
+			introOffer: {
+				rawPrice: { monthly: 900, full: 21600 },
+				intervalUnit: 'year',
+				intervalCount: 2,
+				isOfferComplete: false,
+				formattedPrice: '$216',
+			},
+		} );
+		const result = fromPricingMetaForGridPlan( meta );
+		expect( result?.introOffer?.durationMonths ).toBe( 24 );
+	} );
+
+	it( 'maps an intro offer in months (intervalUnit: month, intervalCount: 3 → 3 months)', () => {
+		const meta = makePricingMeta( {
+			billingPeriod: 365,
+			introOffer: {
+				rawPrice: { monthly: 500, full: 1500 },
+				intervalUnit: 'month',
+				intervalCount: 3,
+				isOfferComplete: false,
+				formattedPrice: '$15',
+			},
+		} );
+		const result = fromPricingMetaForGridPlan( meta );
+		expect( result?.introOffer?.durationMonths ).toBe( 3 );
+	} );
+
+	it( 'returns null when originalPrice.monthly is null', () => {
+		const meta = makePricingMeta( {
+			billingPeriod: 365,
+			originalPrice: { monthly: null, full: null },
+		} );
+		expect( fromPricingMetaForGridPlan( meta ) ).toBeNull();
+	} );
+
+	it( 'returns null when billingPeriod is undefined', () => {
+		const meta = makePricingMeta( { billingPeriod: undefined } );
+		expect( fromPricingMetaForGridPlan( meta ) ).toBeNull();
+	} );
+
+	it( 'returns null for billingPeriod -1 (lifetime/unknown)', () => {
+		const meta = makePricingMeta( { billingPeriod: -1 } );
+		expect( fromPricingMetaForGridPlan( meta ) ).toBeNull();
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// fromVariantPriceData
+// ---------------------------------------------------------------------------
+
+describe( 'fromVariantPriceData', () => {
+	it( 'converts a monthly plan with no intro offer', () => {
+		const variant = makeVariant( {
+			termIntervalInMonths: 1,
+			priceInteger: 2000,
+			priceBeforeDiscounts: 2000,
+			introductoryInterval: 0,
+		} );
+		expect( fromVariantPriceData( variant ) ).toEqual( {
+			termMonths: 1,
+			regularPricePerMonth: 2000,
+			introOffer: undefined,
+		} );
+	} );
+
+	it( 'converts an annual plan with no intro offer', () => {
+		const variant = makeVariant( {
+			termIntervalInMonths: 12,
+			priceInteger: 24000,
+			priceBeforeDiscounts: 24000,
+			introductoryInterval: 0,
+		} );
+		const result = fromVariantPriceData( variant );
+		expect( result.termMonths ).toBe( 12 );
+		expect( result.regularPricePerMonth ).toBe( 2000 );
+		expect( result.introOffer ).toBeUndefined();
+	} );
+
+	it( 'converts an annual plan where the entire term is the intro (1-year intro on annual plan)', () => {
+		// priceInteger = 10000 (intro year), priceBeforeDiscounts = 24000 (regular year)
+		// introDuration = 1 × 12 = 12 months = full term
+		// nonIntroMonths = 12 - 12 = 0
+		// introPriceTotal = 10000 - 0 × 2000 = 10000
+		// introPricePerMonth = 10000 / 12
+		const variant = makeVariant( {
+			termIntervalInMonths: 12,
+			priceInteger: 10000,
+			priceBeforeDiscounts: 24000,
+			introductoryInterval: 1,
+			introductoryTerm: 'year',
+		} );
+		const result = fromVariantPriceData( variant );
+		expect( result.termMonths ).toBe( 12 );
+		expect( result.regularPricePerMonth ).toBe( 2000 );
+		expect( result.introOffer ).toEqual( {
+			pricePerMonth: 10000 / 12,
+			durationMonths: 12,
+			isActive: true,
+		} );
+	} );
+
+	it( 'derives intro price for a biennial plan with a 1-year intro', () => {
+		// priceBeforeDiscounts = 48000 (2 × 24000 regular year)
+		// priceInteger = 34000 (intro year 10000 + regular year 24000)
+		// regularPricePerMonth = 48000 / 24 = 2000
+		// introDuration = 1 × 12 = 12 months
+		// nonIntroMonths = 24 - 12 = 12
+		// introPriceTotal = 34000 - 12 × 2000 = 34000 - 24000 = 10000
+		// introPricePerMonth = 10000 / 12
+		const variant = makeVariant( {
+			termIntervalInMonths: 24,
+			priceInteger: 34000,
+			priceBeforeDiscounts: 48000,
+			introductoryInterval: 1,
+			introductoryTerm: 'year',
+		} );
+		const result = fromVariantPriceData( variant );
+		expect( result.termMonths ).toBe( 24 );
+		expect( result.regularPricePerMonth ).toBe( 2000 );
+		expect( result.introOffer ).toEqual( {
+			pricePerMonth: 10000 / 12,
+			durationMonths: 12,
+			isActive: true,
+		} );
+	} );
+
+	it( 'handles a monthly intro offer (introductoryTerm: month)', () => {
+		// Monthly plan with a 1-month intro: the whole term is intro
+		// termIntervalInMonths: 12, introDuration: 1 month
+		// priceBeforeDiscounts: 24000, priceInteger: 22000
+		// regularPricePerMonth = 24000 / 12 = 2000
+		// nonIntroMonths = 12 - 1 = 11
+		// introPriceTotal = 22000 - 11 × 2000 = 22000 - 22000 = 0 — not useful
+		// Use a simpler case: termIntervalInMonths: 1, 1-month intro
+		const variant = makeVariant( {
+			termIntervalInMonths: 1,
+			priceInteger: 1000,
+			priceBeforeDiscounts: 2000,
+			introductoryInterval: 1,
+			introductoryTerm: 'month',
+		} );
+		const result = fromVariantPriceData( variant );
+		expect( result.introOffer?.durationMonths ).toBe( 1 );
+		// nonIntroMonths = 1 - 1 = 0; introPriceTotal = 1000 - 0 = 1000
+		expect( result.introOffer?.pricePerMonth ).toBe( 1000 );
+	} );
+
+	it( 'produces no introOffer when introductoryInterval is 0', () => {
+		const variant = makeVariant( {
+			priceInteger: 24000,
+			priceBeforeDiscounts: 24000,
+			introductoryInterval: 0,
+		} );
+		expect( fromVariantPriceData( variant ).introOffer ).toBeUndefined();
+	} );
+
+	it( 'produces no introOffer when priceInteger equals priceBeforeDiscounts (no actual discount)', () => {
+		// introductoryInterval is set but prices are equal — indicates intro not applied
+		const variant = makeVariant( {
+			termIntervalInMonths: 12,
+			priceInteger: 24000,
+			priceBeforeDiscounts: 24000,
+			introductoryInterval: 1,
+			introductoryTerm: 'year',
+		} );
+		expect( fromVariantPriceData( variant ).introOffer ).toBeUndefined();
+	} );
+
+	it( 'does not set discountedPricePerMonth', () => {
+		const variant = makeVariant();
+		const result = fromVariantPriceData( variant );
+		expect( result.discountedPricePerMonth ).toBeUndefined();
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// Integration: adapters + getPlanPriceForDuration + calculateDiscountPercentage
+// ---------------------------------------------------------------------------
+
+describe( 'integration — fromPricingMetaForGridPlan → getPlanPriceForDuration → calculateDiscountPercentage', () => {
+	it( 'calculates the annual vs monthly discount (no intro offers)', () => {
+		const monthlyMeta = makePricingMeta( {
+			billingPeriod: 31,
+			originalPrice: { monthly: 2000, full: 2000 },
+		} );
+		const yearlyMeta = makePricingMeta( {
+			billingPeriod: 365,
+			originalPrice: { monthly: 1500, full: 18000 },
+		} );
+
+		const monthlyInfo = fromPricingMetaForGridPlan( monthlyMeta )!;
+		const yearlyInfo = fromPricingMetaForGridPlan( yearlyMeta )!;
+
+		// Compare monthly-equivalent prices for 12 months
+		const monthlyEquivPerMonth =
+			getPlanPriceForDuration( monthlyInfo, 12, { useIntroOffer: false } ) / 12;
+		const yearlyEquivPerMonth =
+			getPlanPriceForDuration( yearlyInfo, 12, { useIntroOffer: false } ) / 12;
+
+		// (2000 - 1500) / 2000 × 100 = 25
+		expect( calculateDiscountPercentage( monthlyEquivPerMonth, yearlyEquivPerMonth ) ).toBe( 25 );
+	} );
+} );
+
+describe( 'integration — fromVariantPriceData → getPlanPriceForDuration → calculateDiscountPercentage', () => {
+	it( 'calculates the upsell discount from annual to biennial (no intros)', () => {
+		const annualVariant = makeVariant( {
+			termIntervalInMonths: 12,
+			priceInteger: 24000,
+			priceBeforeDiscounts: 24000,
+			introductoryInterval: 0,
+		} );
+		const biennialVariant = makeVariant( {
+			termIntervalInMonths: 24,
+			priceInteger: 40000,
+			priceBeforeDiscounts: 40000,
+			introductoryInterval: 0,
+		} );
+
+		const annualInfo = fromVariantPriceData( annualVariant );
+		const biennialInfo = fromVariantPriceData( biennialVariant );
+
+		// Normalise both to per-month cost over the biennial period (24 months)
+		const refPerMonth = getPlanPriceForDuration( annualInfo, 24 ) / 24;
+		const cheaperPerMonth = getPlanPriceForDuration( biennialInfo, 24 ) / 24;
+
+		// annualInfo per month: 24000/12 = 2000; over 24 months: 48000 → 2000/mo
+		// biennialInfo per month: 40000/24 ≈ 1666.67/mo
+		// discount = floor((2000 - 1666.67) / 2000 × 100) = floor(16.67) = 16
+		expect( calculateDiscountPercentage( refPerMonth, cheaperPerMonth ) ).toBe( 16 );
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-17172

## Proposed Changes

* Adds a shared `plan-pricing-utils` library to `plans-grid-next` to implement a new way of calculating the discounts between monthly and yearly/2-yearly/3-yearly plans where the plan prices would be compared using **full-term equivalent comparison** by calculating how much a monthly plan would cost at a given term.
* Adds a PlanPriceInfo interface with two adapters (fromPricingMetaForGridPlan for the plans grid, fromVariantPriceData for checkout variants) and two pure utility functions (getPlanPriceForDuration for total cost over an arbitrary period, calculateDiscountPercentage for floored savings).

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We have discovered that the discounts are not calculated accurately across different places in the plans grid and the checkout.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review, run the tests with `yarn test-packages packages/plans-grid-next/src/lib/test/plan-pricing-utils.ts`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
