### PR TITLE
AI Editorial Review: Add tracks events

### DIFF
--- a/packages/jetpack-ai-sidebar/package.json
+++ b/packages/jetpack-ai-sidebar/package.json
@@ -45,6 +45,7 @@
 	},
 	"dependencies": {
 		"@automattic/agenttic-client": "^0.1.58",
+		"@automattic/calypso-analytics": "workspace:^",
 		"@wordpress/abilities": "^0.4.0",
 		"@wordpress/components": "^30.9.0",
 		"@wordpress/i18n": "^5.23.0"

--- a/packages/jetpack-ai-sidebar/src/components/review-mediation.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/review-mediation.test.tsx
@@ -5,9 +5,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import '@testing-library/jest-dom';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import React from 'react';
 import ReviewMediation from './review-mediation';
+
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	recordTracksEvent: jest.fn(),
+} ) );
 
 // Mock scrollIntoView for JSDOM compatibility.
 Element.prototype.scrollIntoView = jest.fn();
@@ -22,6 +27,9 @@ const mockApplyReviewEdit = jest.fn();
 const mockFindBlockElement = jest.fn();
 const mockFindBlockListLayout = jest.fn();
 const mockUndoBlockEdit = jest.fn();
+const mockedRecordTracksEvent = recordTracksEvent as jest.MockedFunction<
+	typeof recordTracksEvent
+>;
 
 jest.mock( '../utils/block-actions', () => ( {
 	applyReviewEdit: ( ...args: any[] ) => mockApplyReviewEdit( ...args ),
@@ -109,6 +117,7 @@ beforeEach( () => {
 	mockUndoBlockEdit.mockReset();
 	mockUndoBlockEdit.mockReturnValue( true );
 	mockSelectBlock.mockReset();
+	mockedRecordTracksEvent.mockClear();
 	mockBlocks = blocks;
 } );
 
@@ -181,6 +190,60 @@ describe( 'ReviewMediation — smoke render', () => {
 		expect( screen.getByText( 'Copy' ) ).toBeInTheDocument();
 		// Violating excerpt rendered in its own blockquote.
 		expect( screen.getByText( 'was voted upon' ) ).toBeInTheDocument();
+	} );
+
+	it( 'tracks the rendered result with aggregate counts', async () => {
+		render(
+			<ReviewMediation
+				{ ...basePayload( {
+					review_context: 'notes_and_guidelines',
+					conflicts: [
+						{
+							subject: 'Procedural framing',
+							positions: [],
+							guideline_anchor: null,
+							recommended_resolution: '',
+						},
+					],
+					implications: [
+						{ change: 'Tone shift', implies: 'Update related FAQ.', affected_blocks: [ 1 ] },
+					],
+					suggested_edits: [
+						{
+							block_index: 1,
+							current_text: 'voted last Tuesday',
+							suggested_text: 'voted on Tuesday',
+							rationale: 'Concise.',
+							supported_by_reviewers: [],
+						},
+					],
+					guideline_violations: [
+						{
+							category: 'copy',
+							block_name: null,
+							guideline_quote: 'Avoid passive voice.',
+							block_index: 1,
+							violating_text: 'was voted upon',
+							issue: 'Passive voice detected.',
+						},
+					],
+				} ) }
+			/>
+		);
+
+		await waitFor( () => {
+			expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
+				'jetpack_ai_editorial_review_result_rendered',
+				{
+					outcome: 'success',
+					conflict_count: 1,
+					implication_count: 1,
+					suggested_edit_count: 1,
+					guideline_violation_count: 1,
+					review_context: 'notes_and_guidelines',
+				}
+			);
+		} );
 	} );
 
 	it.each( [
@@ -320,6 +383,14 @@ describe( 'ReviewMediation — suggested-edit accept flow', () => {
 		await waitFor( () => {
 			expect( screen.getByText( 'Accepted' ) ).toBeInTheDocument();
 		} );
+		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_ai_editorial_review_item_action',
+			{
+				action: 'accept',
+				target: 'edit',
+				outcome: 'success',
+			}
+		);
 
 		// Collapsed: rationale gone, Undo present.
 		expect( screen.queryByText( 'Concise.' ) ).not.toBeInTheDocument();

--- a/packages/jetpack-ai-sidebar/src/components/review-mediation.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/review-mediation.tsx
@@ -24,6 +24,7 @@ import {
 import {
 	trackAiEditorialReviewItemAction,
 	trackAiEditorialReviewResultRendered,
+	type ReviewContext,
 } from '../utils/tracking';
 import BlockRef, { type BlockSnapshot } from './block-ref';
 import ReviewerChip, { type ReviewerMetadata } from './reviewer-chip';
@@ -86,6 +87,7 @@ interface ReviewMediationProps {
 	implications: Implication[];
 	suggested_edits: SuggestedEdit[];
 	guideline_violations: GuidelineViolation[];
+	review_context?: ReviewContext;
 	/**
 	 * Server-built map keyed by reviewer display name. Optional — older
 	 * mediations or the empty-state payload may omit it; consumers degrade

--- a/packages/jetpack-ai-sidebar/src/components/review-mediation.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/review-mediation.tsx
@@ -21,6 +21,10 @@ import {
 	isSupportedEditBlockType,
 	undoBlockEdit,
 } from '../utils/block-actions';
+import {
+	trackAiEditorialReviewItemAction,
+	trackAiEditorialReviewResultRendered,
+} from '../utils/tracking';
 import BlockRef, { type BlockSnapshot } from './block-ref';
 import ReviewerChip, { type ReviewerMetadata } from './reviewer-chip';
 
@@ -265,6 +269,23 @@ function isManualSuggestedEdit( edit: SuggestedEdit ): boolean {
 	return edit.requires_manual === true;
 }
 
+function deriveResultOutcome(
+	isCacheHit: boolean,
+	reviewContext: ReviewContext | undefined,
+	hasNoFindings: boolean
+): 'success' | 'cache_hit' | 'no_findings' | 'insufficient_input' {
+	if ( isCacheHit ) {
+		return 'cache_hit';
+	}
+	if ( reviewContext === 'insufficient_input' ) {
+		return 'insufficient_input';
+	}
+	if ( hasNoFindings ) {
+		return 'no_findings';
+	}
+	return 'success';
+}
+
 function getSuggestedEditApplyUnavailableReason(
 	isManual: boolean,
 	disabledReason?: string
@@ -302,6 +323,7 @@ export default function ReviewMediation( {
 	implications,
 	suggested_edits,
 	guideline_violations,
+	review_context,
 	reviewers_metadata,
 	cached_at,
 }: ReviewMediationProps ) {
@@ -417,6 +439,18 @@ export default function ReviewMediation( {
 		[ getClientId, selectBlock ]
 	);
 
+	const fireItemAction = useCallback(
+		( options: {
+			action: 'accept' | 'undo' | 'dismiss' | 'bulk_accept';
+			target: 'edit' | 'conflict' | 'mixed';
+			outcome: 'success' | 'failed' | 'partial_failed';
+			itemCount?: number;
+		} ) => {
+			trackAiEditorialReviewItemAction( options );
+		},
+		[]
+	);
+
 	// Clear focus-mode when the mediation session ends.
 	useEffect( () => {
 		return () => {
@@ -481,6 +515,11 @@ export default function ReviewMediation( {
 			}
 			if ( edit.block_index === null ) {
 				setEditStatus( editIndex, 'failed' );
+				fireItemAction( {
+					action: 'accept',
+					target: 'edit',
+					outcome: 'failed',
+				} );
 				return;
 			}
 			setEditStatus( editIndex, 'applying' );
@@ -501,26 +540,48 @@ export default function ReviewMediation( {
 					contentAfter: result.contentAfter,
 				};
 			}
+			fireItemAction( {
+				action: 'accept',
+				target: 'edit',
+				outcome: result.success ? 'success' : 'failed',
+			} );
 			setEditStatus( editIndex, result.success ? 'accepted' : 'failed' );
 		},
-		[ applyTextToBlock, setEditStatus ]
+		[ applyTextToBlock, fireItemAction, setEditStatus ]
 	);
 	const handleUndoEdit = useCallback(
 		( editIndex: number ) => {
 			const snap = editSnapshots.current[ editIndex ];
 			if ( snap ) {
 				if ( ! undoBlockEdit( snap.clientId, snap.contentBefore, snap.contentAfter ) ) {
+					fireItemAction( {
+						action: 'undo',
+						target: 'edit',
+						outcome: 'failed',
+					} );
 					return;
 				}
 				delete editSnapshots.current[ editIndex ];
 			}
+			fireItemAction( {
+				action: 'undo',
+				target: 'edit',
+				outcome: 'success',
+			} );
 			setEditStatus( editIndex, 'pending' );
 		},
-		[ setEditStatus ]
+		[ fireItemAction, setEditStatus ]
 	);
 	const handleDismissEdit = useCallback(
-		( editIndex: number ) => setEditStatus( editIndex, 'dismissed' ),
-		[ setEditStatus ]
+		( editIndex: number ) => {
+			fireItemAction( {
+				action: 'dismiss',
+				target: 'edit',
+				outcome: 'success',
+			} );
+			setEditStatus( editIndex, 'dismissed' );
+		},
+		[ fireItemAction, setEditStatus ]
 	);
 
 	// ---------- Conflict handlers ----------
@@ -528,6 +589,11 @@ export default function ReviewMediation( {
 		async ( conflictIndex: number, candidate: CandidateResolution ) => {
 			if ( getBlockEditDisabledReason( candidate.block_index, candidate.current_text ) ) {
 				setConflictStatus( conflictIndex, 'failed' );
+				fireItemAction( {
+					action: 'accept',
+					target: 'conflict',
+					outcome: 'failed',
+				} );
 				return;
 			}
 			setConflictStatus( conflictIndex, 'applying' );
@@ -548,26 +614,48 @@ export default function ReviewMediation( {
 					contentAfter: result.contentAfter,
 				};
 			}
+			fireItemAction( {
+				action: 'accept',
+				target: 'conflict',
+				outcome: result.success ? 'success' : 'failed',
+			} );
 			setConflictStatus( conflictIndex, result.success ? 'accepted' : 'failed' );
 		},
-		[ applyTextToBlock, getBlockEditDisabledReason, setConflictStatus ]
+		[ applyTextToBlock, fireItemAction, getBlockEditDisabledReason, setConflictStatus ]
 	);
 	const handleUndoConflict = useCallback(
 		( conflictIndex: number ) => {
 			const snap = conflictSnapshots.current[ conflictIndex ];
 			if ( snap ) {
 				if ( ! undoBlockEdit( snap.clientId, snap.contentBefore, snap.contentAfter ) ) {
+					fireItemAction( {
+						action: 'undo',
+						target: 'conflict',
+						outcome: 'failed',
+					} );
 					return;
 				}
 				delete conflictSnapshots.current[ conflictIndex ];
 			}
+			fireItemAction( {
+				action: 'undo',
+				target: 'conflict',
+				outcome: 'success',
+			} );
 			setConflictStatus( conflictIndex, 'pending' );
 		},
-		[ setConflictStatus ]
+		[ fireItemAction, setConflictStatus ]
 	);
 	const handleDismissConflict = useCallback(
-		( conflictIndex: number ) => setConflictStatus( conflictIndex, 'dismissed' ),
-		[ setConflictStatus ]
+		( conflictIndex: number ) => {
+			fireItemAction( {
+				action: 'dismiss',
+				target: 'conflict',
+				outcome: 'success',
+			} );
+			setConflictStatus( conflictIndex, 'dismissed' );
+		},
+		[ fireItemAction, setConflictStatus ]
 	);
 
 	// ---------- Bulk apply ----------
@@ -603,6 +691,20 @@ export default function ReviewMediation( {
 		if ( bulkRunning || totalPendingCount === 0 ) {
 			return;
 		}
+		let bulkTarget: 'edit' | 'conflict' | 'mixed' = 'edit';
+		if ( pendingAiConflictCount > 0 && pendingEditCount > 0 ) {
+			bulkTarget = 'mixed';
+		} else if ( pendingAiConflictCount > 0 ) {
+			bulkTarget = 'conflict';
+		}
+		let successCount = 0;
+		let failureCount = 0;
+		const getBulkOutcome = () => {
+			if ( failureCount === 0 ) {
+				return 'success';
+			}
+			return successCount === 0 ? 'failed' : 'partial_failed';
+		};
 		setBulkRunning( true );
 		// Sequential so users see the shimmer on each block as it applies;
 		// parallel would race the same dispatch and confuse the state store.
@@ -635,6 +737,11 @@ export default function ReviewMediation( {
 					contentBefore: result.contentBefore,
 					contentAfter: result.contentAfter,
 				};
+			}
+			if ( ! result.success ) {
+				failureCount++;
+			} else {
+				successCount++;
 			}
 			setConflictStatus( i, result.success ? 'accepted' : 'failed' );
 		}
@@ -669,17 +776,31 @@ export default function ReviewMediation( {
 					contentAfter: result.contentAfter,
 				};
 			}
+			if ( ! result.success ) {
+				failureCount++;
+			} else {
+				successCount++;
+			}
 			setEditStatus( i, result.success ? 'accepted' : 'failed' );
 		}
+		fireItemAction( {
+			action: 'bulk_accept',
+			target: bulkTarget,
+			outcome: getBulkOutcome(),
+			itemCount: successCount + failureCount,
+		} );
 		setBulkRunning( false );
 	}, [
 		bulkRunning,
 		totalPendingCount,
+		pendingAiConflictCount,
+		pendingEditCount,
 		conflicts,
 		conflictStatuses,
 		suggested_edits,
 		editStatuses,
 		applyTextToBlock,
+		fireItemAction,
 		getBlockEditDisabledReason,
 		setConflictStatus,
 		setEditStatus,
@@ -710,6 +831,36 @@ export default function ReviewMediation( {
 		( name: string ): ReviewerMetadata | null => reviewers_metadata?.[ name ] ?? null,
 		[ reviewers_metadata ]
 	);
+
+	// Latch on the first effect run so re-renders do not duplicate `_result_rendered`.
+	const hasTrackedResultRef = useRef( false );
+	useEffect( () => {
+		if ( hasTrackedResultRef.current ) {
+			return;
+		}
+		hasTrackedResultRef.current = true;
+		const isCacheHit = cached_at !== undefined;
+		const noReviewerSignal =
+			conflicts.length === 0 &&
+			implications.length === 0 &&
+			suggested_edits.length === 0 &&
+			renderedGuidelineViolations.length === 0;
+		trackAiEditorialReviewResultRendered( {
+			outcome: deriveResultOutcome( isCacheHit, review_context, noReviewerSignal ),
+			conflictCount: conflicts.length,
+			implicationCount: implications.length,
+			suggestedEditCount: suggested_edits.length,
+			guidelineViolationCount: renderedGuidelineViolations.length,
+			reviewContext: review_context,
+		} );
+	}, [
+		cached_at,
+		conflicts,
+		implications,
+		renderedGuidelineViolations,
+		review_context,
+		suggested_edits,
+	] );
 
 	return (
 		<div className="jetpack-ai-review-mediation">

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -7,6 +7,7 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { act, render } from '@testing-library/react';
 import React from 'react';
 import ReviewMediation from './components/review-mediation';
@@ -25,7 +26,14 @@ import {
 	useSuggestions,
 } from './index';
 
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	recordTracksEvent: jest.fn(),
+} ) );
+
 const mockSetIsSplitScreen = jest.fn();
+const mockedRecordTracksEvent = recordTracksEvent as jest.MockedFunction<
+	typeof recordTracksEvent
+>;
 let mockSelectedBlock: any = null;
 let mockCurrentPostType: string | undefined = 'post';
 
@@ -143,6 +151,10 @@ describe( 'getChatComponent', () => {
 } );
 
 describe( 'getEmptyViewSuggestions', () => {
+	beforeEach( () => {
+		mockedRecordTracksEvent.mockClear();
+	} );
+
 	afterEach( () => {
 		delete ( globalThis as any ).agentsManagerData;
 		delete ( window as any ).wp;
@@ -160,6 +172,10 @@ describe( 'getEmptyViewSuggestions', () => {
 		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
 		expect( labels ).toContain( 'Optimize Title' );
 		expect( labels ).toContain( 'AI Editorial Review' );
+		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_ai_editorial_review_suggestion_rendered',
+			{}
+		);
 	} );
 
 	it( 'hides AI Editorial Review on page editors', () => {
@@ -188,6 +204,7 @@ describe( 'useSuggestions', () => {
 		mockSelectedBlock = null;
 		mockCurrentPostType = 'post';
 		mockSetIsSplitScreen.mockReset();
+		mockedRecordTracksEvent.mockClear();
 		delete ( globalThis as any ).agentsManagerData;
 	} );
 
@@ -228,6 +245,10 @@ describe( 'useSuggestions', () => {
 		} );
 
 		expect( mockSetIsSplitScreen ).toHaveBeenCalledWith( true );
+		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_ai_editorial_review_suggestion_click',
+			{}
+		);
 	} );
 
 	it( 'does not open split-screen when AI Editorial Review is unavailable', () => {

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -36,6 +36,10 @@ import {
 	UPDATE_BLOCK_CONTENT_ABILITY,
 	isUpdateBlockContentTool,
 } from './utils/tool-provider';
+import {
+	trackAiEditorialReviewSuggestionClick,
+	trackAiEditorialReviewSuggestionRendered,
+} from './utils/tracking';
 import type { ComponentType } from 'react';
 
 // Re-export block-action helpers as part of the package's public surface.
@@ -44,6 +48,9 @@ export { applyReviewEdit, findBlockElement, findBlockListLayout };
 // ---------- Module state ----------
 
 let clearSuggestionsFn: ( () => void ) | null = null;
+
+/** Whether `_suggestion_rendered` has fired this page life (once-per-session). */
+let suggestionRenderedFiredOnce = false;
 
 /** Default suggestion shown when no block is selected. */
 const OPTIMIZE_TITLE_SUGGESTION = {
@@ -85,7 +92,14 @@ function isAiEditorialReviewAvailable(
 }
 
 function getAiEditorialReviewSuggestions( currentPostType?: string ) {
-	return isAiEditorialReviewAvailable( currentPostType ) ? [ AI_EDITORIAL_REVIEW_SUGGESTION ] : [];
+	if ( ! isAiEditorialReviewAvailable( currentPostType ) ) {
+		return [];
+	}
+	if ( ! suggestionRenderedFiredOnce ) {
+		suggestionRenderedFiredOnce = true;
+		trackAiEditorialReviewSuggestionRendered();
+	}
+	return [ AI_EDITORIAL_REVIEW_SUGGESTION ];
 }
 
 function getPostLevelSuggestions( currentPostType?: string ) {
@@ -552,6 +566,7 @@ export function useSuggestions(): {
 				typeof value === 'string' &&
 				value === AI_EDITORIAL_REVIEW_SUGGESTION.prompt
 			) {
+				trackAiEditorialReviewSuggestionClick();
 				try {
 					( dispatch as any )( 'automattic/agents-manager' ).setIsSplitScreen( true );
 				} catch {

--- a/packages/jetpack-ai-sidebar/src/utils/tracking.test.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/tracking.test.ts
@@ -1,0 +1,124 @@
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	recordTracksEvent: jest.fn(),
+} ) );
+
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import {
+	trackAiEditorialReviewItemAction,
+	trackAiEditorialReviewResultRendered,
+	trackAiEditorialReviewSuggestionClick,
+	trackAiEditorialReviewSuggestionRendered,
+} from './tracking';
+
+const mockedRecordTracksEvent = recordTracksEvent as jest.MockedFunction<
+	typeof recordTracksEvent
+>;
+
+const expectPrivacySafePayload = ( properties: Record< string, unknown > ) => {
+	expect( properties ).not.toHaveProperty( 'post_id' );
+	expect( properties ).not.toHaveProperty( 'post_type' );
+	expect( properties ).not.toHaveProperty( 'block_index' );
+	expect( properties ).not.toHaveProperty( 'run_id' );
+	expect( properties ).not.toHaveProperty( 'client_run_id' );
+	expect( properties ).not.toHaveProperty( 'trigger' );
+	expect( properties ).not.toHaveProperty( 'cache_hit' );
+	expect( properties ).not.toHaveProperty( 'auto_suggested_edit_count' );
+	expect( properties ).not.toHaveProperty( 'manual_suggested_edit_count' );
+	expect( properties ).not.toHaveProperty( 'success_count' );
+	expect( properties ).not.toHaveProperty( 'failure_count' );
+	expect( properties ).not.toHaveProperty( 'text' );
+	expect( properties ).not.toHaveProperty( 'reviewer' );
+};
+
+type WindowWithAgentsManagerActions = Window & {
+	__agentsManagerActions?: {
+		getSessionId?: () => string;
+	};
+};
+
+describe( 'AI Editorial Review tracking', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		( window as WindowWithAgentsManagerActions ).__agentsManagerActions = {
+			getSessionId: jest.fn( () => 'test-session-id' ),
+		};
+	} );
+
+	afterEach( () => {
+		delete ( window as WindowWithAgentsManagerActions ).__agentsManagerActions;
+	} );
+
+	it( 'tracks suggestion exposure with only session context', () => {
+		trackAiEditorialReviewSuggestionRendered();
+
+		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_ai_editorial_review_suggestion_rendered',
+			{
+				sessionid: 'test-session-id',
+			}
+		);
+		expectPrivacySafePayload( mockedRecordTracksEvent.mock.calls[ 0 ][ 1 ] );
+	} );
+
+	it( 'tracks suggestion click with only session context', () => {
+		trackAiEditorialReviewSuggestionClick();
+
+		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_ai_editorial_review_suggestion_click',
+			{
+				sessionid: 'test-session-id',
+			}
+		);
+		expectPrivacySafePayload( mockedRecordTracksEvent.mock.calls[ 0 ][ 1 ] );
+	} );
+
+	it( 'tracks rendered results as aggregate usefulness counts', () => {
+		trackAiEditorialReviewResultRendered( {
+			outcome: 'success',
+			conflictCount: 2,
+			implicationCount: 3,
+			suggestedEditCount: 8,
+			guidelineViolationCount: 0,
+			reviewContext: 'notes_and_guidelines',
+		} );
+
+		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_ai_editorial_review_result_rendered',
+			{
+				outcome: 'success',
+				conflict_count: 2,
+				implication_count: 3,
+				suggested_edit_count: 8,
+				guideline_violation_count: 0,
+				review_context: 'notes_and_guidelines',
+				sessionid: 'test-session-id',
+			}
+		);
+		expectPrivacySafePayload( mockedRecordTracksEvent.mock.calls[ 0 ][ 1 ] );
+	} );
+
+	it( 'tracks item actions after completion without row identifiers', () => {
+		trackAiEditorialReviewItemAction( {
+			action: 'bulk_accept',
+			target: 'mixed',
+			outcome: 'partial_failed',
+			itemCount: 4,
+		} );
+
+		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_ai_editorial_review_item_action',
+			{
+				action: 'bulk_accept',
+				target: 'mixed',
+				outcome: 'partial_failed',
+				item_count: 4,
+				sessionid: 'test-session-id',
+			}
+		);
+		expectPrivacySafePayload( mockedRecordTracksEvent.mock.calls[ 0 ][ 1 ] );
+	} );
+} );

--- a/packages/jetpack-ai-sidebar/src/utils/tracking.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/tracking.ts
@@ -32,7 +32,7 @@ function recordTracksEvent( eventName: string, properties: TrackProperties = {} 
 	} );
 }
 
-type ReviewContext =
+export type ReviewContext =
 	| 'notes_and_guidelines'
 	| 'notes_only'
 	| 'guidelines_only'

--- a/packages/jetpack-ai-sidebar/src/utils/tracking.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/tracking.ts
@@ -1,0 +1,126 @@
+/**
+ * Tracking helpers for AI Editorial Review Tracks events.
+ */
+
+import { recordTracksEvent as recordTracksEventBase } from '@automattic/calypso-analytics';
+
+const TRACKS_PREFIX = 'jetpack';
+
+type TrackProperties = Record< string, string | number | boolean >;
+
+type WindowWithAgentsManagerActions = Window & {
+	__agentsManagerActions?: {
+		getSessionId?: () => unknown;
+	};
+};
+
+function getSessionId(): string | undefined {
+	if ( typeof window === 'undefined' ) {
+		return undefined;
+	}
+
+	const agentsManagerActions = ( window as WindowWithAgentsManagerActions ).__agentsManagerActions;
+	const sessionId = agentsManagerActions?.getSessionId?.();
+	return typeof sessionId === 'string' && sessionId !== '' ? sessionId : undefined;
+}
+
+function recordTracksEvent( eventName: string, properties: TrackProperties = {} ): void {
+	const sessionId = getSessionId();
+	recordTracksEventBase( `${ TRACKS_PREFIX }_${ eventName }`, {
+		...properties,
+		...( sessionId ? { sessionid: sessionId } : {} ),
+	} );
+}
+
+type ReviewContext =
+	| 'notes_and_guidelines'
+	| 'notes_only'
+	| 'guidelines_only'
+	| 'content_only'
+	| 'insufficient_input';
+
+interface TrackAiEditorialReviewResultRenderedOptions {
+	outcome: 'success' | 'cache_hit' | 'no_findings' | 'insufficient_input';
+	conflictCount: number;
+	implicationCount: number;
+	suggestedEditCount: number;
+	guidelineViolationCount: number;
+	reviewContext?: ReviewContext;
+}
+
+interface TrackAiEditorialReviewItemActionOptions {
+	action: 'accept' | 'undo' | 'dismiss' | 'bulk_accept';
+	target: 'edit' | 'conflict' | 'mixed';
+	outcome: 'success' | 'failed' | 'partial_failed';
+	itemCount?: number;
+}
+
+/**
+ * Tracks the empty-view "AI Editorial Review" suggestion appearing.
+ */
+export function trackAiEditorialReviewSuggestionRendered(): void {
+	recordTracksEvent( 'ai_editorial_review_suggestion_rendered' );
+}
+
+/**
+ * Tracks a user clicking the "AI Editorial Review" suggestion.
+ */
+export function trackAiEditorialReviewSuggestionClick(): void {
+	recordTracksEvent( 'ai_editorial_review_suggestion_click' );
+}
+
+/**
+ * Tracks the review card mounting and becoming visible to the user.
+ * @param options                          - Tracking options
+ * @param options.outcome                  - High-level outcome: success, cache_hit, no_findings, or insufficient_input
+ * @param options.conflictCount            - Number of conflict items in the payload
+ * @param options.implicationCount         - Number of implication items in the payload
+ * @param options.suggestedEditCount       - Total number of suggested edits
+ * @param options.guidelineViolationCount  - Number of guideline violations in the payload
+ * @param options.reviewContext            - Server-selected context used for this review
+ */
+export function trackAiEditorialReviewResultRendered( {
+	outcome,
+	conflictCount,
+	implicationCount,
+	suggestedEditCount,
+	guidelineViolationCount,
+	reviewContext,
+}: TrackAiEditorialReviewResultRenderedOptions ): void {
+	const properties: TrackProperties = {
+		outcome,
+		conflict_count: conflictCount,
+		implication_count: implicationCount,
+		suggested_edit_count: suggestedEditCount,
+		guideline_violation_count: guidelineViolationCount,
+	};
+	if ( reviewContext !== undefined ) {
+		properties.review_context = reviewContext;
+	}
+	recordTracksEvent( 'ai_editorial_review_result_rendered', properties );
+}
+
+/**
+ * Tracks a user action on an AI Editorial Review row.
+ * @param options                - Tracking options
+ * @param options.action         - Action verb
+ * @param options.target         - Suggested edit, conflict, or mixed bulk action
+ * @param options.outcome        - Whether the action completed successfully
+ * @param options.itemCount      - (optional) Number of items attempted
+ */
+export function trackAiEditorialReviewItemAction( {
+	action,
+	target,
+	outcome,
+	itemCount,
+}: TrackAiEditorialReviewItemActionOptions ): void {
+	const properties: TrackProperties = {
+		action,
+		target,
+		outcome,
+	};
+	if ( itemCount !== undefined ) {
+		properties.item_count = itemCount;
+	}
+	recordTracksEvent( 'ai_editorial_review_item_action', properties );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1557,6 +1557,7 @@ __metadata:
   resolution: "@automattic/jetpack-ai-sidebar@workspace:packages/jetpack-ai-sidebar"
   dependencies:
     "@automattic/agenttic-client": "npm:^0.1.58"
+    "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@types/react": "npm:^18.3.1"
     "@types/react-dom": "npm:^18.3.1"


### PR DESCRIPTION
 ## Proposed changes

  - Add Tracks events for the AI Editorial Review flow.
  - Track suggestion exposure, suggestion clicks, rendered review results, and item actions.
  - Keep event payloads aggregate-only; no post IDs, block IDs, reviewer names, or review text are tracked.



  ## Why

  Measure AI Editorial Review discovery and usage without logging editorial content or reviewer-specific data.

   ## Testability note

The feature is gated behind A8C Proxy at this stage. Testing the PR is "no-op" because without proxy the feature is not exposed and with feature ( behind A8C proxy ), the calypso analytics do not get queued. 

For testing, we can ensure that the unit/integration/e2e tests are passing and there is no regression
