### PR TITLE
Renewal pricing: use full term discount calculation

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
@@ -183,7 +183,7 @@ export function CheckoutSidebarPlanUpsell() {
 	);
 	const percentSavings =
 		calculateDiscountPercentage(
-			getPlanPriceForDuration( currentInfo, upsellInfo.termMonths ),
+			compareToPriceForVariantTerm,
 			getPlanPriceForDuration( upsellInfo, upsellInfo.termMonths )
 		) ?? 0;
 

--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
@@ -1,6 +1,11 @@
 import { isPlan, isJetpackPlan } from '@automattic/calypso-products';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import { formatCurrency } from '@automattic/number-formatters';
+import {
+	calculateDiscountPercentage,
+	fromVariantPriceData,
+	getPlanPriceForDuration,
+} from '@automattic/plans-grid-next';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { createElement, createInterpolateElement, useState } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
@@ -12,10 +17,6 @@ import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { useGetProductVariants } from '../../hooks/product-variants';
-import {
-	getItemVariantCompareToPrice,
-	getItemVariantDiscount,
-} from '../item-variation-picker/util';
 import { CheckoutSummaryFeaturedList } from '../wp-checkout-order-summary';
 import type { WPCOMProductVariant } from '../item-variation-picker';
 import './style.scss';
@@ -174,11 +175,18 @@ export function CheckoutSidebarPlanUpsell() {
 		}
 	};
 
-	const compareToPriceForVariantTerm = getItemVariantCompareToPrice(
-		upsellVariant,
-		currentVariant
+	const currentInfo = fromVariantPriceData( currentVariant );
+	const upsellInfo = fromVariantPriceData( upsellVariant );
+	const compareToPriceForVariantTerm = getPlanPriceForDuration(
+		currentInfo,
+		upsellInfo.termMonths
 	);
-	const percentSavings = getItemVariantDiscount( upsellVariant, currentVariant );
+	const percentSavings =
+		calculateDiscountPercentage(
+			getPlanPriceForDuration( currentInfo, upsellInfo.termMonths ),
+			getPlanPriceForDuration( upsellInfo, upsellInfo.termMonths )
+		) ?? 0;
+
 	if ( percentSavings <= 0 ) {
 		debug( 'percent savings is too low', percentSavings );
 		return null;

--- a/client/my-sites/checkout/src/components/item-variation-picker/item-variation-button-row.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/item-variation-button-row.tsx
@@ -1,5 +1,10 @@
 import colorStudio from '@automattic/color-studio';
 import { formatCurrency } from '@automattic/number-formatters';
+import {
+	calculateDiscountPercentage,
+	fromVariantPriceData,
+	getPlanPriceForDuration,
+} from '@automattic/plans-grid-next';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import {
@@ -12,7 +17,6 @@ import {
 	type FunctionComponent,
 	type KeyboardEvent,
 } from 'react';
-import { getItemVariantDiscount } from './util';
 import type { ItemVariationPickerProps, WPCOMProductVariant, OnChangeItemVariant } from './types';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
@@ -127,7 +131,14 @@ const ButtonTile = forwardRef(
 		} );
 
 		const label = termIntervalInMonths === 1 ? translate( 'Month' ) : variantLabel.noun;
-		const discountPercentage = getItemVariantDiscount( productVariant, compareTo );
+		const compareToInfo = compareTo ? fromVariantPriceData( compareTo ) : null;
+		const variantInfo = fromVariantPriceData( productVariant );
+		const discountPercentage = compareToInfo
+			? calculateDiscountPercentage(
+					getPlanPriceForDuration( compareToInfo, variantInfo.termMonths ),
+					getPlanPriceForDuration( variantInfo, variantInfo.termMonths )
+			  ) ?? 0
+			: 0;
 
 		return (
 			<Tile

--- a/client/my-sites/checkout/src/components/item-variation-picker/variant-dropdown-price.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/variant-dropdown-price.tsx
@@ -3,6 +3,11 @@ import {
 	isMultiYearDomainProduct,
 } from '@automattic/calypso-products';
 import { formatCurrency } from '@automattic/number-formatters';
+import {
+	calculateDiscountPercentage,
+	fromVariantPriceData,
+	getPlanPriceForDuration,
+} from '@automattic/plans-grid-next';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
@@ -17,7 +22,6 @@ import {
 	PriceTextContainer,
 	Variant,
 } from './styles';
-import { getItemVariantDiscount, getItemVariantCompareToPrice } from './util';
 import type { WPCOMProductVariant } from './types';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
@@ -40,8 +44,18 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 	product: ResponseCartProduct;
 } > = ( { variant, compareTo, product } ) => {
 	const isMobile = useMobileBreakpoint();
-	const compareToPriceForVariantTerm = getItemVariantCompareToPrice( variant, compareTo );
-	const discountPercentage = getItemVariantDiscount( variant, compareTo );
+	const compareToInfo = compareTo ? fromVariantPriceData( compareTo ) : null;
+	const variantInfo = fromVariantPriceData( variant );
+	const compareToPriceForVariantTerm = compareToInfo
+		? getPlanPriceForDuration( compareToInfo, variantInfo.termMonths )
+		: undefined;
+	const discountPercentage =
+		( compareToPriceForVariantTerm &&
+			calculateDiscountPercentage(
+				compareToPriceForVariantTerm,
+				getPlanPriceForDuration( variantInfo, variantInfo.termMonths )
+			) ) ??
+		0;
 
 	const formattedCurrentPrice = formatCurrency( variant.priceInteger, variant.currency, {
 		stripZeros: true,

--- a/client/my-sites/checkout/src/components/item-variation-picker/variant-radio-price.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/variant-radio-price.tsx
@@ -1,10 +1,14 @@
 import colorStudio from '@automattic/color-studio';
 import { formatCurrency } from '@automattic/number-formatters';
+import {
+	calculateDiscountPercentage,
+	fromVariantPriceData,
+	getPlanPriceForDuration,
+} from '@automattic/plans-grid-next';
 import { styled } from '@automattic/wpcom-checkout';
 import i18n, { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import { useCheckoutUiRedesignExperiment } from 'calypso/my-sites/checkout/src/hooks/use-checkout-ui-redesign-experiment';
-import { getItemVariantDiscount } from './util';
 import type { WPCOMProductVariant } from './types';
 
 const Discount = styled.span`
@@ -81,7 +85,14 @@ export const ItemVariantRadioPrice: FunctionComponent< {
 } > = ( { variant, compareTo } ) => {
 	const translate = useTranslate();
 	const [ , isCheckoutUiRedesignV1 ] = useCheckoutUiRedesignExperiment();
-	const discountPercentage = getItemVariantDiscount( variant, compareTo );
+	const compareToInfo = compareTo ? fromVariantPriceData( compareTo ) : null;
+	const variantInfo = fromVariantPriceData( variant );
+	const discountPercentage = compareToInfo
+		? calculateDiscountPercentage(
+				getPlanPriceForDuration( compareToInfo, variantInfo.termMonths ),
+				getPlanPriceForDuration( variantInfo, variantInfo.termMonths )
+		  ) ?? 0
+		: 0;
 
 	// Calculate months per bill period with introductory offers.
 	let priceTermIntervalInMonths = variant.termIntervalInMonths;

--- a/packages/plans-grid-next/src/components/plan-type-selector/hooks/use-max-discount.ts
+++ b/packages/plans-grid-next/src/components/plan-type-selector/hooks/use-max-discount.ts
@@ -1,12 +1,7 @@
-import {
-	type PlanSlug,
-	TERM_ANNUALLY,
-	getPlanSlugForTermVariant,
-	isMonthly,
-	isWpComPlan,
-} from '@automattic/calypso-products';
+import { type PlanSlug } from '@automattic/calypso-products';
 import { Plans } from '@automattic/data-stores';
 import { useState } from '@wordpress/element';
+import useMaxDiscountsForPlanTerms from './use-max-discounts-for-plan-terms';
 
 export default function useMaxDiscount(
 	plans: PlanSlug[],
@@ -14,49 +9,13 @@ export default function useMaxDiscount(
 	siteId?: number | null
 ): number {
 	const [ maxDiscount, setMaxDiscount ] = useState( 0 );
-	const wpcomMonthlyPlans = ( plans || [] ).filter( isWpComPlan ).filter( isMonthly );
-	const yearlyVariantPlanSlugs = wpcomMonthlyPlans
-		.map( ( planSlug ) => getPlanSlugForTermVariant( planSlug, TERM_ANNUALLY ) )
-		.filter( Boolean ) as PlanSlug[];
-	const monthlyPlansPricing = Plans.usePricingMetaForGridPlans( {
-		planSlugs: wpcomMonthlyPlans,
-		siteId,
-		coupon: undefined,
+	const discounts = useMaxDiscountsForPlanTerms(
+		plans,
+		[ 'monthly', 'yearly' ],
 		useCheckPlanAvailabilityForPurchase,
-	} );
-	const yearlyPlansPricing = Plans.usePricingMetaForGridPlans( {
-		planSlugs: yearlyVariantPlanSlugs,
-		siteId,
-		coupon: undefined,
-		useCheckPlanAvailabilityForPurchase,
-	} );
-
-	const discounts = wpcomMonthlyPlans.map( ( planSlug ) => {
-		const yearlyVariantPlanSlug = getPlanSlugForTermVariant( planSlug, TERM_ANNUALLY );
-
-		if ( ! yearlyVariantPlanSlug ) {
-			return 0;
-		}
-
-		const monthlyPlanAnnualCost =
-			( monthlyPlansPricing?.[ planSlug ]?.originalPrice.full ?? 0 ) * 12;
-
-		if ( ! monthlyPlanAnnualCost ) {
-			return 0;
-		}
-
-		const yearlyVariantPricing = yearlyPlansPricing?.[ yearlyVariantPlanSlug ];
-		const isOnIntroOffer =
-			yearlyVariantPricing?.introOffer && ! yearlyVariantPricing.introOffer.isOfferComplete;
-		const yearlyPlanAnnualCost = isOnIntroOffer
-			? yearlyVariantPricing?.originalPrice.full || 0
-			: yearlyVariantPricing?.discountedPrice.full || yearlyVariantPricing?.originalPrice.full || 0;
-
-		return Math.floor(
-			( ( monthlyPlanAnnualCost - yearlyPlanAnnualCost ) / ( monthlyPlanAnnualCost || 1 ) ) * 100
-		);
-	} );
-	const currentMaxDiscount = discounts.length ? Math.max( ...discounts ) : 0;
+		siteId
+	);
+	const currentMaxDiscount = discounts[ 'yearly' ] ?? 0;
 
 	if ( currentMaxDiscount > 0 && currentMaxDiscount !== maxDiscount ) {
 		setMaxDiscount( currentMaxDiscount );

--- a/packages/plans-grid-next/src/components/plan-type-selector/hooks/use-max-discounts-for-plan-terms.ts
+++ b/packages/plans-grid-next/src/components/plan-type-selector/hooks/use-max-discounts-for-plan-terms.ts
@@ -10,6 +10,11 @@ import {
 	isWpcomEnterpriseGridPlan,
 } from '@automattic/calypso-products';
 import { Plans } from '@automattic/data-stores';
+import {
+	calculateDiscountPercentage,
+	fromPricingMetaForGridPlan,
+	getPlanPriceForDuration,
+} from '../../../lib/plan-pricing-utils';
 
 /**
  * Calculate the maximum discount for each term for a given set of plans
@@ -41,7 +46,6 @@ export default function useMaxDiscountsForPlanTerms(
 			? currentLowestTerm
 			: term;
 	}, terms[ 0 ] );
-	const lowestTermInMonths = getBillingMonthsForTerm( lowestTerm );
 
 	const lowestTermPlanSlugs = allRelatedPlanSlugs.filter(
 		( planSlug ) => getPlan( planSlug )?.term === lowestTerm
@@ -60,37 +64,32 @@ export default function useMaxDiscountsForPlanTerms(
 	>;
 	termDefinitionsMapping.forEach( ( termMapping ) => {
 		if ( termMapping.term === lowestTerm ) {
-			return 0;
+			return;
 		}
 		const termDiscounts = lowestTermPlanSlugs.map( ( lowestTermPlanSlug ) => {
 			const lowestTermPlanPricing = plansPricing?.[ lowestTermPlanSlug ];
-			const lowestTermPlanCost = lowestTermPlanPricing?.originalPrice.full;
-			if ( ! lowestTermPlanCost ) {
+			const lowestTermInfo = lowestTermPlanPricing
+				? fromPricingMetaForGridPlan( lowestTermPlanPricing )
+				: null;
+			if ( ! lowestTermInfo ) {
 				return 0;
 			}
-			const lowestTermMonthlyCost = lowestTermPlanCost / lowestTermInMonths;
 
-			/**
-			 * Calculate the monthly cost of the term price
-			 */
 			const variantPlanSlug =
 				getPlanSlugForTermVariant( lowestTermPlanSlug, termMapping.term ) ?? '';
 			const variantPlanPricing = plansPricing?.[ variantPlanSlug ];
-			const isOnIntroOffer =
-				variantPlanPricing?.introOffer && ! variantPlanPricing.introOffer.isOfferComplete;
-			const variantTermPrice = isOnIntroOffer
-				? variantPlanPricing?.originalPrice?.full || 0
-				: variantPlanPricing?.discountedPrice?.full || variantPlanPricing?.originalPrice?.full || 0;
-			if ( ! variantTermPrice ) {
+			const variantInfo = variantPlanPricing
+				? fromPricingMetaForGridPlan( variantPlanPricing )
+				: null;
+			if ( ! variantInfo ) {
 				return 0;
 			}
-			const variantTermInMonths = getBillingMonthsForTerm(
-				URL_FRIENDLY_TERMS_MAPPING[ termMapping.urlFriendlyTerm ]
-			);
-			const variantTermMonthlyCost = variantTermPrice / variantTermInMonths;
 
-			return Math.floor(
-				( ( lowestTermMonthlyCost - variantTermMonthlyCost ) * 100 ) / lowestTermMonthlyCost
+			return (
+				calculateDiscountPercentage(
+					getPlanPriceForDuration( lowestTermInfo, variantInfo.termMonths ),
+					getPlanPriceForDuration( variantInfo, variantInfo.termMonths )
+				) ?? 0
 			);
 		} );
 		termWiseMaxDiscount[ termMapping.urlFriendlyTerm ] = termDiscounts.length

--- a/packages/plans-grid-next/src/components/shared/header-price/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price/index.tsx
@@ -138,6 +138,10 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 			typeof discountedPrice.monthly === 'number'
 				? discountedPrice.monthly
 				: introOffer.rawPrice.monthly;
+		// Recalculate the savings for Monthly plans with introductory offers
+		// since we are comparing the introductory price with the same plan
+		// renewal price, instead of comparing yearly to monthly costs for
+		// the same period.
 		if (
 			showBillingDescriptionForIncreasedRenewalPrice &&
 			compareToMonthlyPrice > monthlyPrice &&

--- a/packages/plans-grid-next/src/components/shared/header-price/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price/index.tsx
@@ -13,6 +13,11 @@ import { useTranslate } from 'i18n-calypso';
 import { usePlansGridContext } from '../../../grid-context';
 import useIsLargeCurrency from '../../../hooks/use-is-large-currency';
 import { usePlanPricingInfoFromGridPlans } from '../../../hooks/use-plan-pricing-info-from-grid-plans';
+import {
+	calculateDiscountPercentage,
+	fromPricingMetaForGridPlan,
+	getPlanPriceForDuration,
+} from '../../../lib/plan-pricing-utils';
 import { useHeaderPriceContext } from './header-price-context';
 import type { GridPlan } from '../../../types';
 import './style.scss';
@@ -62,6 +67,7 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 	const {
 		current,
 		pricing: { currencyCode, originalPrice, discountedPrice, introOffer, billingPeriod },
+		isMonthlyPlan,
 	} = gridPlansIndex[ planSlug ];
 	const isPricedPlan = null !== originalPrice.monthly;
 
@@ -90,12 +96,16 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 		useCheckPlanAvailabilityForPurchase: helpers?.useCheckPlanAvailabilityForPurchase,
 	} )?.[ termVariantPlanSlug ?? '' ];
 
-	const termVariantPrice =
-		termVariantPricing?.discountedPrice.monthly ?? termVariantPricing?.originalPrice.monthly ?? 0;
-	const planPrice = discountedPrice.monthly ?? originalPrice.monthly ?? 0;
+	const termVariantInfo = termVariantPricing
+		? fromPricingMetaForGridPlan( termVariantPricing )
+		: null;
+	const currentPlanInfo = fromPricingMetaForGridPlan( gridPlansIndex[ planSlug ].pricing );
 	let savings =
-		termVariantPrice > planPrice
-			? Math.floor( ( ( termVariantPrice - planPrice ) / termVariantPrice ) * 100 )
+		termVariantInfo && currentPlanInfo
+			? calculateDiscountPercentage(
+					getPlanPriceForDuration( termVariantInfo, currentPlanInfo.termMonths ),
+					getPlanPriceForDuration( currentPlanInfo, currentPlanInfo.termMonths )
+			  ) ?? 0
 			: 0;
 
 	useEffect( () => {
@@ -128,10 +138,12 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 			typeof discountedPrice.monthly === 'number'
 				? discountedPrice.monthly
 				: introOffer.rawPrice.monthly;
-		if ( showBillingDescriptionForIncreasedRenewalPrice && compareToMonthlyPrice > monthlyPrice ) {
-			savings = Math.floor(
-				( ( compareToMonthlyPrice - monthlyPrice ) / compareToMonthlyPrice ) * 100
-			);
+		if (
+			showBillingDescriptionForIncreasedRenewalPrice &&
+			compareToMonthlyPrice > monthlyPrice &&
+			isMonthlyPlan
+		) {
+			savings = calculateDiscountPercentage( compareToMonthlyPrice, monthlyPrice ) ?? 0;
 		}
 		return (
 			<div className="plans-grid-next-header-price">

--- a/packages/plans-grid-next/src/components/test/header-price.tsx
+++ b/packages/plans-grid-next/src/components/test/header-price.tsx
@@ -209,6 +209,7 @@ describe( 'HeaderPrice', () => {
 			[ PLAN_PERSONAL_MONTHLY ]: {
 				originalPrice: { monthly: 20, full: 240 },
 				discountedPrice: { monthly: null, full: null },
+				billingPeriod: 31,
 			},
 		} );
 

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
@@ -13,6 +13,7 @@ import { Plans } from '@automattic/data-stores';
 import { formatCurrency } from '@automattic/number-formatters';
 import { useTranslate } from 'i18n-calypso';
 import { usePlansGridContext } from '../../grid-context';
+import { calculateDiscountPercentage } from '../../lib/plan-pricing-utils';
 import { getRenewalPricingText } from './get-renewal-pricing-text';
 import type { GridPlan } from '../../types';
 
@@ -90,17 +91,13 @@ export default function usePlanBillingDescription( {
 				: yearlyVariantPricing.introOffer?.rawPrice?.monthly ?? null;
 		}
 
-		if (
-			yearlyVariantMaybeDiscountedPrice &&
-			yearlyVariantMaybeDiscountedPrice < originalPrice.monthly
-		) {
+		const discountRate = calculateDiscountPercentage(
+			originalPrice.monthly,
+			yearlyVariantMaybeDiscountedPrice ?? 0
+		);
+		if ( discountRate !== undefined ) {
 			return translate( 'Save %(discountRate)s%% by paying annually', {
-				args: {
-					discountRate: Math.floor(
-						( 100 * ( originalPrice.monthly - yearlyVariantMaybeDiscountedPrice ) ) /
-							originalPrice.monthly
-					),
-				},
+				args: { discountRate },
 			} );
 		}
 

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
@@ -91,10 +91,10 @@ export default function usePlanBillingDescription( {
 				: yearlyVariantPricing.introOffer?.rawPrice?.monthly ?? null;
 		}
 
-		const discountRate = calculateDiscountPercentage(
-			originalPrice.monthly,
-			yearlyVariantMaybeDiscountedPrice ?? 0
-		);
+		const discountRate =
+			yearlyVariantMaybeDiscountedPrice != null
+				? calculateDiscountPercentage( originalPrice.monthly, yearlyVariantMaybeDiscountedPrice )
+				: undefined;
 		if ( discountRate !== undefined ) {
 			return translate( 'Save %(discountRate)s%% by paying annually', {
 				args: { discountRate },


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-17172

Follow-up to [110684](https://github.com/Automattic/wp-calypso/pull/110684)

## Proposed Changes

* Migrate useMaxDiscountsForPlanTerms, useMaxDiscount, HeaderPrice, usePlanBillingDescription, and CheckoutSidebarPlanUpsell and the checkout variant buttons to use the new shared utilities for calculating monthly vs yearly discounts.

**Control:**

|**Before**|**After**|
|---|---|
|<img width="1243" height="668" alt="before-control-grid" src="https://github.com/user-attachments/assets/560ef407-aadd-4be1-b8f2-41a02f6df309" />|<img width="1243" height="710" alt="after-control-grid" src="https://github.com/user-attachments/assets/27dba726-6b68-48e4-ad7a-ef41239877cb" />|
|<img width="1243" height="703" alt="before-control-checkout" src="https://github.com/user-attachments/assets/eb43a30d-c7de-4dec-8d2f-6ee9bbf380fb" />|<img width="1243" height="710" alt="after-control-checkout" src="https://github.com/user-attachments/assets/b0228792-a10c-43db-8925-cabc699475d7" />|

**Large Increase**

|**Before**|**After**|
|---|---|
|<img width="1269" height="774" alt="before-large_increase-grid" src="https://github.com/user-attachments/assets/53610f36-1467-4010-92c2-0cc42c2386a3" />|<img width="1243" height="752" alt="after-large_increase-grid" src="https://github.com/user-attachments/assets/1a238795-4e70-464a-8ea6-daf4b412e2a4" />|
|<img width="1243" height="703" alt="before-large_increase-checkout" src="https://github.com/user-attachments/assets/7007fae0-ef7f-4b27-ab26-4c820c8f08d4" />|<img width="1189" height="722" alt="after-large_increase-checkout" src="https://github.com/user-attachments/assets/e802103e-4fe1-4bc7-965b-559435f4dcce" />|


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Multiple places across the plans grid and checkout each computed plan savings independently, with inconsistent rounding (Math.floor vs Math.round), different reference-price baselines, and varying treatment of intro offers. The new shared utilities provide a single authoritative implementation — always Math.floor, always comparing against originalPrice.monthly, and correctly accounting for intro offers in the reference price.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox public-api and edit lines 1702-1703 in wpcom-billing.php on WPCOM to be:
```
public function get_test_variation_for_current_user(): ?string {
	return 'large_increase';
	$experiment_name = $this->get_test_series_slug();
```
* Switch your account to EUR, the locale can stay in English or be a non-English one.
* Navigate to /plans on a site and confirm the billing-period toggle shows correct "Save X%" badges on the monthly, annual, biennial and triennial options.
* Add a plan to cart, go to checkout and confirm the sidebar upsell shows the correct savings percentage and struck-through comparison price.
* Confirm that the discount percentages in the checkout match the ones shown on the plans grid.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
