### PR TITLE
Checkout: route WPCom plans back to the default radio-button picker

### DIFF
--- a/client/my-sites/checkout/src/components/item-variation-picker/index.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/index.tsx
@@ -1,8 +1,5 @@
 import { isWpComPlan } from '@automattic/calypso-products';
-import { useViewportMatch } from '@wordpress/compose';
 import { FunctionComponent } from 'react';
-import { useRsmBetterCheckoutExperiment } from '../../hooks/use-rsm-better-checkout-experiment';
-import { ItemVariationButtonRow } from './item-variation-button-row';
 import { ItemVariationDropDown } from './item-variation-dropdown';
 import { ItemVariationRadioButtons } from './item-variation-radio-buttons';
 import type { ItemVariationPickerProps } from './types';
@@ -13,13 +10,8 @@ import type { ItemVariationPickerProps } from './types';
  */
 export const ItemVariationPicker: FunctionComponent< ItemVariationPickerProps > = ( props ) => {
 	const { selectedItem } = props;
-	const isLargeViewport = useViewportMatch( 'large', '>=' );
-	const isRsmBetterCheckout = useRsmBetterCheckoutExperiment();
 
 	if ( isWpComPlan( selectedItem.product_slug ) ) {
-		if ( isRsmBetterCheckout && isLargeViewport ) {
-			return <ItemVariationButtonRow { ...props } />;
-		}
 		return <ItemVariationRadioButtons { ...props } />;
 	}
 


### PR DESCRIPTION
Part of RSM-758

## Proposed Changes

* In `client/my-sites/checkout/src/components/item-variation-picker/index.tsx`, drop the dispatcher branch that routed `isRsmBetterCheckout && isLargeViewport` to `ItemVariationButtonRow`. WPCom plans now flow into `ItemVariationRadioButtons` regardless of the experiment.
* Leave `item-variation-button-row.tsx` in place as orphaned code so we don't lose the work while the design is still in progress.

## Why are these changes being made?

The side-by-side button row added in #110394 isn't ready for the experiment audience. Sending WPCom-plan users back to the radio-button picker keeps the rest of the redesign experiment running without shipping a half-finished picker.

## Testing Instructions

* Open a checkout for a WPCom plan with multiple term variants (e.g., Premium: month / 1 year / 2 years / 3 years).
* Confirm the stacked radio-button picker renders at every viewport size, including ≥1024px.
* Confirm enrolment in the `rsm_better_checkout` experiment no longer changes the picker; it still renders radio buttons.
* Non-WPCom carts (e.g., a domain-only purchase) still render the dropdown picker.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?