### PR TITLE
Checkout: gate rsm_better_checkout experiment on large viewport

### DIFF
--- a/client/my-sites/checkout/src/components/item-variation-picker/index.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/index.tsx
@@ -5,7 +5,7 @@ import { ItemVariationRadioButtons } from './item-variation-radio-buttons';
 import type { ItemVariationPickerProps } from './types';
 
 /**
- * A fascade component to allow using different types of variant pickers (eg:
+ * A facade component to allow using different types of variant pickers (eg:
  * radio buttons vs. dropdown).
  */
 export const ItemVariationPicker: FunctionComponent< ItemVariationPickerProps > = ( props ) => {

--- a/client/my-sites/checkout/src/components/item-variation-picker/index.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/index.tsx
@@ -1,8 +1,5 @@
 import { isWpComPlan } from '@automattic/calypso-products';
-import { useViewportMatch } from '@wordpress/compose';
 import { FunctionComponent } from 'react';
-import { useRsmBetterCheckoutExperiment } from '../../hooks/use-rsm-better-checkout-experiment';
-import { ItemVariationButtonRow } from './item-variation-button-row';
 import { ItemVariationDropDown } from './item-variation-dropdown';
 import { ItemVariationRadioButtons } from './item-variation-radio-buttons';
 import type { ItemVariationPickerProps } from './types';
@@ -13,13 +10,8 @@ import type { ItemVariationPickerProps } from './types';
  */
 export const ItemVariationPicker: FunctionComponent< ItemVariationPickerProps > = ( props ) => {
 	const { selectedItem } = props;
-	const isLargeViewport = useViewportMatch( 'large', '>=' );
-	const isRsmBetterCheckout = useRsmBetterCheckoutExperiment();
 
 	if ( isWpComPlan( selectedItem.product_slug ) ) {
-		if ( isRsmBetterCheckout && isLargeViewport ) {
-			return <ItemVariationButtonRow { ...props } />;
-		}
 		return <ItemVariationRadioButtons { ...props } />;
 	}
 

--- a/client/my-sites/checkout/src/hooks/test/use-rsm-better-checkout-experiment.ts
+++ b/client/my-sites/checkout/src/hooks/test/use-rsm-better-checkout-experiment.ts
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import { useViewportMatch } from '@wordpress/compose';
+import { useExperiment } from 'calypso/lib/explat';
+import { useRsmBetterCheckoutExperiment } from '../use-rsm-better-checkout-experiment';
+
+jest.mock( '@wordpress/compose', () => ( {
+	...jest.requireActual( '@wordpress/compose' ),
+	useViewportMatch: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/lib/explat', () => ( {
+	useExperiment: jest.fn(),
+} ) );
+
+const mockUseViewportMatch = useViewportMatch as jest.MockedFunction< typeof useViewportMatch >;
+const mockUseExperiment = useExperiment as jest.MockedFunction< typeof useExperiment >;
+
+describe( 'useRsmBetterCheckoutExperiment', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockUseExperiment.mockReturnValue( [ false, null ] );
+		window.history.replaceState( {}, '', '/' );
+	} );
+
+	it( 'only requests experiment assignment for large viewports', () => {
+		mockUseViewportMatch.mockReturnValue( true );
+
+		renderHook( () => useRsmBetterCheckoutExperiment() );
+
+		expect( mockUseExperiment ).toHaveBeenCalledWith( 'calypso_rsm_better_checkout_v2', {
+			isEligible: true,
+		} );
+	} );
+
+	it( 'opts out of experiment assignment on small viewports', () => {
+		mockUseViewportMatch.mockReturnValue( false );
+
+		renderHook( () => useRsmBetterCheckoutExperiment() );
+
+		expect( mockUseExperiment ).toHaveBeenCalledWith( 'calypso_rsm_better_checkout_v2', {
+			isEligible: false,
+		} );
+	} );
+
+	it( 'returns true when the user is in the treatment variation on a large viewport', () => {
+		mockUseViewportMatch.mockReturnValue( true );
+		mockUseExperiment.mockReturnValue( [
+			false,
+			{ experimentName: 'calypso_rsm_better_checkout_v2', variationName: 'treatment' },
+		] );
+
+		const { result } = renderHook( () => useRsmBetterCheckoutExperiment() );
+
+		expect( result.current ).toBe( true );
+	} );
+
+	it( 'returns false when the user is in the control variation', () => {
+		mockUseViewportMatch.mockReturnValue( true );
+		mockUseExperiment.mockReturnValue( [
+			false,
+			{ experimentName: 'calypso_rsm_better_checkout_v2', variationName: 'control' },
+		] );
+
+		const { result } = renderHook( () => useRsmBetterCheckoutExperiment() );
+
+		expect( result.current ).toBe( false );
+	} );
+
+	it( 'honors the QA query-param override even on small viewports', () => {
+		mockUseViewportMatch.mockReturnValue( false );
+		window.history.replaceState( {}, '', '/?rsm_better_checkout=1' );
+
+		const { result } = renderHook( () => useRsmBetterCheckoutExperiment() );
+
+		expect( result.current ).toBe( true );
+	} );
+} );

--- a/client/my-sites/checkout/src/hooks/test/use-rsm-better-checkout-experiment.ts
+++ b/client/my-sites/checkout/src/hooks/test/use-rsm-better-checkout-experiment.ts
@@ -49,7 +49,12 @@ describe( 'useRsmBetterCheckoutExperiment', () => {
 		mockUseViewportMatch.mockReturnValue( true );
 		mockUseExperiment.mockReturnValue( [
 			false,
-			{ experimentName: 'calypso_rsm_better_checkout_v2', variationName: 'treatment' },
+			{
+				experimentName: 'calypso_rsm_better_checkout_v2',
+				variationName: 'treatment',
+				retrievedTimestamp: 0,
+				ttl: 0,
+			},
 		] );
 
 		const { result } = renderHook( () => useRsmBetterCheckoutExperiment() );
@@ -61,7 +66,12 @@ describe( 'useRsmBetterCheckoutExperiment', () => {
 		mockUseViewportMatch.mockReturnValue( true );
 		mockUseExperiment.mockReturnValue( [
 			false,
-			{ experimentName: 'calypso_rsm_better_checkout_v2', variationName: 'control' },
+			{
+				experimentName: 'calypso_rsm_better_checkout_v2',
+				variationName: 'control',
+				retrievedTimestamp: 0,
+				ttl: 0,
+			},
 		] );
 
 		const { result } = renderHook( () => useRsmBetterCheckoutExperiment() );

--- a/client/my-sites/checkout/src/hooks/use-rsm-better-checkout-experiment.ts
+++ b/client/my-sites/checkout/src/hooks/use-rsm-better-checkout-experiment.ts
@@ -1,10 +1,17 @@
+import { useViewportMatch } from '@wordpress/compose';
 import { useExperiment } from 'calypso/lib/explat';
 
-const EXPERIMENT_NAME = 'calypso_rsm_better_checkout';
+const EXPERIMENT_NAME = 'calypso_rsm_better_checkout_v2';
 const QUERY_PARAM = 'rsm_better_checkout';
 
 export function useRsmBetterCheckoutExperiment(): boolean {
-	const [ , assignment ] = useExperiment( EXPERIMENT_NAME );
+	// The treatment UI only renders on large viewports, so only enroll
+	// large-viewport users to avoid diluting the treatment arm with users who
+	// would see the control UI regardless of assignment.
+	const isLargeViewport = useViewportMatch( 'large', '>=' );
+	const [ , assignment ] = useExperiment( EXPERIMENT_NAME, {
+		isEligible: isLargeViewport,
+	} );
 	const searchParams = new URLSearchParams( window.location.search );
 	if ( searchParams.get( QUERY_PARAM ) === '1' ) {
 		return true;


### PR DESCRIPTION
Part of RSM-758

## Proposed Changes

* `useRsmBetterCheckoutExperiment` now calls `useExperiment` with `{ isEligible: isLargeViewport }`, so only users on a large viewport are enrolled in the experiment.
* Renames the experiment slug to `calypso_rsm_better_checkout_v2` so prior (contaminated) assignments don't carry over into the relaunch.
* Adds a unit test covering both eligibility paths, the variation lookup, and the QA query-param override.
* Squashes in [#110688](https://github.com/Automattic/wp-calypso/pull/110688) by @pmkin: removes the experiment-gated `ItemVariationButtonRow` branch from [item-variation-picker/index.tsx](client/my-sites/checkout/src/components/item-variation-picker/index.tsx) so WPCom plans go back to the default radio-button picker. Bundled here because Paolo's PR was based on this branch and needs the same relaunch.

## Why are these changes being made?

The treatment UI only renders when `useViewportMatch( 'large', '>=' )` is true (see all call sites in [checkout-main-content.tsx](client/my-sites/checkout/src/components/checkout-main-content.tsx) and [wp-checkout-order-summary.tsx](client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx), all of which gate on \`isRsmBetterCheckout && isLargeViewport\`), but the previous hook enrolled every checkout visitor unconditionally.

That meant:

1. 50% control / 50% treatment by assignment.
2. Every control user saw control.
3. Treatment users on a large viewport saw treatment.
4. Treatment users on a small viewport (~25% of checkout traffic per Tracks) saw control.

Net effect: ~12.5% of visitors were assigned to treatment but exposed to the control UI, which dilutes the treatment arm and skews the experiment. Pushing the viewport gate into the hook (via ExPlat's built-in `isEligible` option) eliminates the enrollment of users who can't actually see the treatment.

The slug bump to \`_v2\` is the standard relaunch hygiene step — without it, anyone already assigned would keep their (incorrectly-scoped) variation across the fix.

## Testing Instructions

1. \`yarn test-client client/my-sites/checkout/src/hooks/test/use-rsm-better-checkout-experiment.ts\` — should pass 5 tests.
2. Manual smoke on a large-viewport browser at /checkout/<site>: confirm the treatment UI still renders for users in the treatment variation (and via \`?rsm_better_checkout=1\`).
3. Manual smoke on a small viewport: confirm no \`exposureLogging\` request for \`calypso_rsm_better_checkout_v2\` fires (check the Network tab for ExPlat assignment calls). Treatment UI should not render.
4. **Before merging**: ensure the new experiment slug \`calypso_rsm_better_checkout_v2\` is created and started in ExPlat.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?

