### PR TITLE
Reader Fediverse compose: link out to block editor for media (CM-726)

### DIFF
--- a/client/reader/fediverse/composer-config.tsx
+++ b/client/reader/fediverse/composer-config.tsx
@@ -3,6 +3,7 @@ import config from '@automattic/calypso-config';
 import { logToLogstash } from 'calypso/lib/logstash';
 import { useFediverseComposerExtras } from './use-fediverse-composer-extras';
 import { useFediverseComposerLimit } from './use-fediverse-composer-limit';
+import { useFediverseComposerMedia } from './use-fediverse-composer-media';
 import type {
 	FediverseCreatePostParams,
 	FediverseCreatePostResult,
@@ -134,6 +135,16 @@ export const fediverseComposerConfig: ComposerConfig<
 	},
 	useProtocolExtras: useFediverseComposerExtras,
 	usePreferredHandoffSiteId: useFediversePreferredHandoffSiteId,
+	// CM-726: blog-level ActivityPub C2S exposes inbox/outbox for posts
+	// but no media-upload endpoint yet. The footer-start media button
+	// matches atmosphere/mastodon's shape exactly (same icon, same
+	// `social-composer__media` class, same `aria-label`) — the only
+	// difference is the click: instead of opening a file picker, it
+	// hands off to the block editor on the connection's blog with the
+	// current draft text prefilled. Replace `useFediverseComposerMedia`
+	// with an in-pane upload hook (mirroring `useAtmosphereComposerMedia`
+	// / `useMastodonComposerMedia`) when a C2S media endpoint ships.
+	useMedia: useFediverseComposerMedia,
 };
 
 function errorMessageFor( err: FediverseError, t: Translate ): ReactNode {

--- a/client/reader/fediverse/test/use-fediverse-composer-media.test.tsx
+++ b/client/reader/fediverse/test/use-fediverse-composer-media.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * @jest-environment jsdom
+ */
+jest.mock( 'calypso/lib/logstash', () => ( {
+	logToLogstash: jest.fn(),
+} ) );
+
+import { QueryClient } from '@tanstack/react-query';
+import { act, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useEffect } from 'react';
+import { ComposerProvider, useComposer, type ComposerConfig } from 'calypso/reader/social/composer';
+import { testComposerConfig } from 'calypso/reader/social/composer/test-config';
+import * as analytics from 'calypso/state/reader/analytics/actions';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { useFediverseComposerMedia } from '../use-fediverse-composer-media';
+import type { ReactNode } from 'react';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const configWithFediverseMedia: ComposerConfig< any, any, any > = {
+	...testComposerConfig,
+	useMedia: useFediverseComposerMedia,
+};
+
+// `recordReaderTracksEvent` is a thunk that reads `state.reader.follows`.
+// The test store doesn't seed that branch, so dispatching the real thunk
+// throws on click. Stub at file scope so every test is isolated from
+// the analytics pipeline.
+beforeEach( () => {
+	jest
+		.spyOn( analytics, 'recordReaderTracksEvent' )
+		.mockImplementation( () => ( { type: '@@TEST/NOOP' } ) as never );
+} );
+
+afterEach( () => {
+	jest.restoreAllMocks();
+} );
+
+function renderTrigger() {
+	const queryClient = new QueryClient( {
+		defaultOptions: { queries: { retry: false } },
+	} );
+
+	let composer: ReturnType< typeof useComposer > | null = null;
+
+	function Probe( { children }: { children: ReactNode } ) {
+		composer = useComposer();
+		useEffect( () => {
+			if ( ! composer!.mode ) {
+				composer!.openComposer( { kind: 'standalone', entry_point: 'fab' } );
+			}
+			// Only run on mount; subsequent re-renders are not the trigger we want.
+			// eslint-disable-next-line react-hooks/exhaustive-deps
+		}, [] );
+		return <>{ children }</>;
+	}
+
+	function Trigger() {
+		const { mediaSlot } = useComposer();
+		return <>{ mediaSlot.renderFooterTrigger() }</>;
+	}
+
+	const result = renderWithProvider(
+		<ComposerProvider connectionId={ 1 } config={ configWithFediverseMedia }>
+			<Probe>
+				<Trigger />
+			</Probe>
+		</ComposerProvider>,
+		{ queryClient }
+	);
+
+	return { ...result, getComposer: () => composer! };
+}
+
+describe( 'useFediverseComposerMedia — trigger shape', () => {
+	it( 'renders a footer-start button matching atmosphere/Mastodon shape', () => {
+		renderTrigger();
+
+		const button = screen.getByRole( 'button', { name: /add media/i } );
+		expect( button ).toBeVisible();
+		// Same class as atmosphere/mastosondon `<button className="social-composer__media">`
+		// — the unified-experience requirement from CM-726.
+		expect( button ).toHaveClass( 'social-composer__media' );
+	} );
+} );
+
+describe( 'useFediverseComposerMedia — click behaviour', () => {
+	it( 'flips the provider’s hasRequestedMediaHandoff flag on click', async () => {
+		const user = userEvent.setup();
+		const { getComposer } = renderTrigger();
+
+		expect( getComposer().hasRequestedMediaHandoff ).toBe( false );
+
+		const button = screen.getByRole( 'button', { name: /add media/i } );
+		await user.click( button );
+
+		expect( getComposer().hasRequestedMediaHandoff ).toBe( true );
+	} );
+
+	it( 'dispatches the media_handoff_clicked Tracks event with connection + mode_kind props', async () => {
+		const user = userEvent.setup();
+		renderTrigger();
+
+		const button = screen.getByRole( 'button', { name: /add media/i } );
+		await user.click( button );
+
+		const recordSpy = analytics.recordReaderTracksEvent as unknown as jest.Mock;
+		const clickedCalls = recordSpy.mock.calls.filter(
+			( call ) => call[ 0 ] === 'calypso_reader_fediverse_media_handoff_clicked'
+		);
+		expect( clickedCalls ).toHaveLength( 1 );
+		expect( clickedCalls[ 0 ][ 1 ] ).toEqual( {
+			connection_id: 1,
+			mode_kind: 'standalone',
+		} );
+	} );
+} );
+
+describe( 'useFediverseComposerMedia — slot defaults', () => {
+	it( 'returns trivial values for the non-trigger slot fields (no in-pane media state)', () => {
+		const queryClient = new QueryClient( {
+			defaultOptions: { queries: { retry: false } },
+		} );
+
+		let composer: ReturnType< typeof useComposer > | null = null;
+		function Probe() {
+			composer = useComposer();
+			useEffect( () => {
+				if ( ! composer!.mode ) {
+					composer!.openComposer( { kind: 'standalone', entry_point: 'fab' } );
+				}
+				// eslint-disable-next-line react-hooks/exhaustive-deps
+			}, [] );
+			return null;
+		}
+
+		renderWithProvider(
+			<ComposerProvider connectionId={ 1 } config={ configWithFediverseMedia }>
+				<Probe />
+			</ComposerProvider>,
+			{ queryClient }
+		);
+
+		const slot = composer!.mediaSlot;
+		expect( slot.hasAny ).toBe( false );
+		expect( slot.hasUploaded ).toBe( false );
+		// `isAllUploaded` MUST be true (vacuously) so the modal's submit gate
+		// `isAllUploaded && ! isAnyPending` stays satisfied with no images.
+		expect( slot.isAllUploaded ).toBe( true );
+		expect( slot.isAnyPending ).toBe( false );
+		expect( slot.renderGrid() ).toBeNull();
+		expect( slot.extendBuildParams( { foo: 1 } ) ).toEqual( { foo: 1 } );
+		// `onPublishSuccess` / `clear` are side-effect-free no-ops.
+		expect( () => slot.onPublishSuccess( queryClient, { uri: 'x' } ) ).not.toThrow();
+		expect( () => slot.clear( { keepPreviewUrlsAlive: false } ) ).not.toThrow();
+	} );
+
+	it( 'resets hasRequestedMediaHandoff when the modal is closed and reopened', async () => {
+		const user = userEvent.setup();
+		const { getComposer } = renderTrigger();
+
+		const button = screen.getByRole( 'button', { name: /add media/i } );
+		await user.click( button );
+		expect( getComposer().hasRequestedMediaHandoff ).toBe( true );
+
+		act( () => getComposer().closeComposer() );
+		act( () => getComposer().openComposer( { kind: 'standalone', entry_point: 'fab' } ) );
+
+		expect( getComposer().hasRequestedMediaHandoff ).toBe( false );
+	} );
+} );

--- a/client/reader/fediverse/use-fediverse-composer-media.tsx
+++ b/client/reader/fediverse/use-fediverse-composer-media.tsx
@@ -1,0 +1,108 @@
+/**
+ * Fediverse implementation of the shared `ComposerMediaSlot`. The wire
+ * layer (blog-level ActivityPub C2S) exposes inbox/outbox for posts but
+ * no media-upload endpoint yet (CM-726), so the slot can't run an
+ * in-pane upload flow the way atmosphere / mastodon do. Instead it
+ * renders a footer-start media trigger whose visual shape is identical
+ * to atmosphere's "Add media" button — same icon, same
+ * `social-composer__media` class, same `aria-label` — but clicking it
+ * doesn't open a file picker. It flips the provider's
+ * `markMediaHandoffRequested` flag, which surfaces the existing
+ * `<ComposerOverflowHandoff>` section (with media-flavoured copy) so
+ * the user has a clear path to the block editor on the connection's
+ * blog. The published post still federates over AP from that blog, so
+ * the destination is unchanged; the editor is just where the
+ * media-aware flow lives until a C2S media endpoint ships.
+ *
+ * When that endpoint lands, swap this hook for an in-pane upload hook
+ * (mirroring `useAtmosphereComposerMedia` / `useMastodonComposerMedia`)
+ * — the slot contract is the same.
+ */
+
+import { Icon, image as imageIcon } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useMemo } from 'react';
+import { useDispatch } from 'react-redux';
+import { useComposer } from 'calypso/reader/social/composer';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import type { ActiveMode, ComposerMediaSlot } from 'calypso/reader/social/composer';
+import type { AppState } from 'calypso/types';
+import type { UnknownAction } from 'redux';
+import type { ThunkDispatch } from 'redux-thunk';
+
+interface Ctx {
+	mode: ActiveMode | null;
+	connectionId: number;
+}
+
+export function useFediverseComposerMedia( { mode, connectionId }: Ctx ): ComposerMediaSlot {
+	const renderFooterTrigger = useCallback(
+		() => <FediverseMediaTrigger connectionId={ connectionId } modeKind={ mode?.kind ?? null } />,
+		[ connectionId, mode?.kind ]
+	);
+
+	return useMemo(
+		() => ( {
+			// No in-pane media state today — every flag is the trivial answer
+			// so the modal's submit gate (`isAllUploaded && ! isAnyPending`)
+			// stays satisfied and image-only / pending-media branches never
+			// fire. `extendBuildParams` is the identity; the wire mutation
+			// receives params unchanged.
+			hasAny: false,
+			hasUploaded: false,
+			isAllUploaded: true,
+			isAnyPending: false,
+			renderGrid: () => null,
+			renderFooterTrigger,
+			extendBuildParams: ( params ) => params,
+			onPublishSuccess: () => undefined,
+			clear: () => undefined,
+		} ),
+		[ renderFooterTrigger ]
+	);
+}
+
+interface TriggerProps {
+	connectionId: number;
+	modeKind: ActiveMode[ 'kind' ] | null;
+}
+
+/**
+ * Footer-start trigger. Visually identical to atmosphere's trigger; the
+ * only difference is the `onClick` — instead of opening a file picker,
+ * it flips the provider's `markMediaHandoffRequested` flag so the
+ * existing `<ComposerOverflowHandoff>` section surfaces the
+ * media-flavoured "Move to editor" CTA. Lives as a sub-component so it
+ * can call `useComposer()` — the parent hook runs inside the provider
+ * before context is established and can't read it directly.
+ */
+function FediverseMediaTrigger( { connectionId, modeKind }: TriggerProps ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch< ThunkDispatch< AppState, void, UnknownAction > >();
+	const { markMediaHandoffRequested } = useComposer();
+
+	const handleClick = () => {
+		// Surface the section first, then fire telemetry. The order matters:
+		// `recordReaderTracksEvent` is a thunk that reads `state.reader.follows`
+		// and can throw on a malformed store (seen in tests + on cold caches);
+		// the primary user-facing effect must not depend on its success.
+		markMediaHandoffRequested();
+		dispatch(
+			recordReaderTracksEvent( 'calypso_reader_fediverse_media_handoff_clicked', {
+				connection_id: connectionId,
+				mode_kind: modeKind,
+			} )
+		);
+	};
+
+	return (
+		<button
+			type="button"
+			className="social-composer__media"
+			aria-label={ translate( 'Add media' ) as string }
+			onClick={ handleClick }
+		>
+			<Icon icon={ imageIcon } size={ 18 } />
+		</button>
+	);
+}

--- a/client/reader/social/composer/composer-overflow-handoff.tsx
+++ b/client/reader/social/composer/composer-overflow-handoff.tsx
@@ -79,12 +79,14 @@ function PreferredSiteHandoff( {
 
 export function ComposerOverflowHandoff( { text }: ComposerOverflowHandoffProps ) {
 	const translate = useTranslate();
-	const { hasBeenOverLimit, mode } = useComposer();
+	const { hasBeenOverLimit, hasRequestedMediaHandoff, mode } = useComposer();
 	const config = useComposerConfig();
+
+	const isVisible = hasBeenOverLimit || hasRequestedMediaHandoff;
 
 	const { data: sites } = useQuery( {
 		...sitesQuery( 'all' ),
-		enabled: hasBeenOverLimit,
+		enabled: isVisible,
 	} );
 
 	// Read the per-protocol preferred-site hook unconditionally (Rules of
@@ -97,7 +99,7 @@ export function ComposerOverflowHandoff( { text }: ComposerOverflowHandoffProps 
 		config.usePreferredHandoffSiteId ?? useNullPreferredHandoffSiteId;
 	const preferredSiteId = usePreferredHandoffSiteId( mode );
 
-	if ( ! hasBeenOverLimit ) {
+	if ( ! isVisible ) {
 		return null;
 	}
 
@@ -124,11 +126,15 @@ export function ComposerOverflowHandoff( { text }: ComposerOverflowHandoffProps 
 		>
 			<OverflowHandoffShownEffect mode={ mode } />
 			<p>
-				{ translate( 'Too long for %(protocol)s? Publish it on your own site instead.', {
-					args: { protocol: config.protocolLabel },
-					comment:
-						'%(protocol)s is a brand name (e.g. "Bluesky", "Mastodon") and should not be translated.',
-				} ) }
+				{ hasRequestedMediaHandoff
+					? translate(
+							'Want to add media? Adding images isn’t supported here yet — publish it on your own site instead.'
+					  )
+					: translate( 'Too long for %(protocol)s? Publish it on your own site instead.', {
+							args: { protocol: config.protocolLabel },
+							comment:
+								'%(protocol)s is a brand name (e.g. "Bluesky", "Mastodon") and should not be translated.',
+					  } ) }
 			</p>
 			{ preferredSite ? (
 				<PreferredSiteHandoff

--- a/client/reader/social/composer/composer-provider.tsx
+++ b/client/reader/social/composer/composer-provider.tsx
@@ -137,6 +137,19 @@ interface ComposerContextValue {
 	 */
 	hasBeenOverLimit: boolean;
 	markOverLimit: () => void;
+	/**
+	 * Sticky-once flag: true after the user has explicitly asked to hand
+	 * off to the block editor for a feature the in-pane composer can't
+	 * cover (today: Fediverse media, CM-726 — blog-level ActivityPub C2S
+	 * has no media-upload endpoint). The fediverse `useMedia` slot's
+	 * footer-start button flips this flag on click; the overflow-handoff
+	 * section reuses its existing UI to render the "Move to editor" CTA
+	 * with media-flavoured copy. Stays true once tripped so the section
+	 * stays visible across re-renders (same lifecycle as `hasBeenOverLimit`).
+	 * Reset on each modal open.
+	 */
+	hasRequestedMediaHandoff: boolean;
+	markMediaHandoffRequested: () => void;
 }
 
 const ComposerContext = createContext< ComposerContextValue | null >( null );
@@ -154,6 +167,7 @@ export function ComposerProvider< TError, TParams, TResult >( {
 }: Props< TError, TParams, TResult > ) {
 	const [ mode, setMode ] = useState< ActiveMode | null >( null );
 	const [ hasBeenOverLimit, setHasBeenOverLimit ] = useState( false );
+	const [ hasRequestedMediaHandoff, setHasRequestedMediaHandoff ] = useState( false );
 	const triggerRef = useRef< HTMLElement | null >( null );
 	const wasOpenRef = useRef( false );
 
@@ -175,6 +189,7 @@ export function ComposerProvider< TError, TParams, TResult >( {
 			}
 			triggerRef.current = document.activeElement as HTMLElement | null;
 			setHasBeenOverLimit( false );
+			setHasRequestedMediaHandoff( false );
 			setMode( { ...next, connectionId } );
 		},
 		[ connectionId, config.supportedModes ]
@@ -193,6 +208,10 @@ export function ComposerProvider< TError, TParams, TResult >( {
 
 	const markOverLimit = useCallback( () => {
 		setHasBeenOverLimit( true );
+	}, [] );
+
+	const markMediaHandoffRequested = useCallback( () => {
+		setHasRequestedMediaHandoff( true );
 	}, [] );
 
 	// `config.useMedia` is captured once at the start of the provider's life
@@ -238,6 +257,8 @@ export function ComposerProvider< TError, TParams, TResult >( {
 			protocolExtrasSlot,
 			hasBeenOverLimit,
 			markOverLimit,
+			hasRequestedMediaHandoff,
+			markMediaHandoffRequested,
 		} ),
 		[
 			mode,
@@ -247,6 +268,8 @@ export function ComposerProvider< TError, TParams, TResult >( {
 			protocolExtrasSlot,
 			hasBeenOverLimit,
 			markOverLimit,
+			hasRequestedMediaHandoff,
+			markMediaHandoffRequested,
 		]
 	);
 

--- a/client/reader/social/composer/test/composer-overflow-handoff.test.tsx
+++ b/client/reader/social/composer/test/composer-overflow-handoff.test.tsx
@@ -70,6 +70,96 @@ describe( 'ComposerOverflowHandoff — gate', () => {
 	} );
 } );
 
+describe( 'ComposerOverflowHandoff — media-handoff trigger', () => {
+	it( 'surfaces the section with media-flavoured copy when hasRequestedMediaHandoff is set', async () => {
+		mockSitesQuery( [
+			{
+				ID: 100,
+				name: 'My Blog',
+				slug: 'myblog.wordpress.com',
+				URL: 'https://myblog.wordpress.com',
+				options: { admin_url: 'https://myblog.wordpress.com/wp-admin/' },
+			} as Partial< Site >,
+		] );
+
+		let composer: ReturnType< typeof useComposer > | null = null;
+		function Probe() {
+			composer = useComposer();
+			return null;
+		}
+
+		renderWithComposer(
+			<>
+				<Probe />
+				<ComposerOverflowHandoff text="" />
+			</>,
+			{ withMode: true }
+		);
+
+		act( () => composer!.markMediaHandoffRequested() );
+
+		// Media copy ("Want to add media?…") rather than the limit-overflow
+		// copy ("Too long for…").
+		expect( await screen.findByText( /Want to add media\?/i ) ).toBeVisible();
+		expect( screen.queryByText( /Too long for/i ) ).toBeNull();
+	} );
+
+	it( 'saves a non-empty draft body when the composer is empty (CM-726 empty-text guard)', async () => {
+		const user = userEvent.setup();
+		const openSpy = jest.spyOn( window, 'open' ).mockImplementation( () => null );
+
+		try {
+			mockSitesQuery( [
+				{
+					ID: 100,
+					name: 'My Blog',
+					slug: 'myblog.wordpress.com',
+					URL: 'https://myblog.wordpress.com',
+					site_migration: { in_progress: false, is_complete: false },
+					options: { admin_url: 'https://myblog.wordpress.com/wp-admin/' },
+				} as Partial< Site >,
+			] );
+
+			// Body-matcher: the placeholder must be present in the POST body
+			// so wpcom doesn't reject `content: ''`.
+			nock( ORIGIN )
+				.post(
+					/\/rest\/v1\.\d+\/sites\/100\/posts\/new/,
+					( body: { content?: string; status?: string } ) =>
+						body.content !== '' &&
+						typeof body.content === 'string' &&
+						body.content.trim().length > 0
+				)
+				.reply( 200, { ID: 777 } );
+
+			let composer: ReturnType< typeof useComposer > | null = null;
+			const Probe = () => {
+				composer = useComposer();
+				return null;
+			};
+
+			renderWithComposer(
+				<>
+					<Probe />
+					<ComposerOverflowHandoff text="" />
+				</>,
+				{ withMode: true }
+			);
+
+			act( () => composer!.markMediaHandoffRequested() );
+
+			const button = await screen.findByRole( 'button', { name: /Move to editor/i } );
+			await user.click( button );
+
+			// If the placeholder guard regressed (`content: ''` sent), the
+			// nock matcher above would fail and `isDone()` returns false.
+			await waitFor( () => expect( nock.isDone() ).toBe( true ) );
+		} finally {
+			openSpy.mockRestore();
+		}
+	} );
+} );
+
 describe( 'ComposerOverflowHandoff — null branches', () => {
 	it( 'renders nothing when sites query resolves to []', async () => {
 		mockSitesQuery( [] );

--- a/client/reader/social/composer/use-save-draft-mutation.ts
+++ b/client/reader/social/composer/use-save-draft-mutation.ts
@@ -10,10 +10,23 @@ export interface SaveDraftMutationResult {
 	ID: number;
 }
 
+// wpcom `/sites/:id/posts/new` rejects empty `content` (the limit-overflow
+// path can't reach it empty, but the Fediverse media-handoff trigger
+// from CM-726 does — the user clicks "Add media" with nothing typed).
+// Substitute a Gutenberg empty-paragraph block so the draft is created
+// and the editor opens on a clean empty post.
+const EMPTY_DRAFT_PLACEHOLDER = '<!-- wp:paragraph --><p></p><!-- /wp:paragraph -->';
+
 export function saveDraftMutation() {
 	return mutationOptions< SaveDraftMutationResult, Error, SaveDraftMutationVariables >( {
 		mutationKey: [ 'reader-social-composer-overflow', 'save-draft' ],
 		mutationFn: ( { siteId, content } ) =>
-			wpcom.site( siteId ).post().add( { content, status: 'draft' } ),
+			wpcom
+				.site( siteId )
+				.post()
+				.add( {
+					content: content.trim() === '' ? EMPTY_DRAFT_PLACEHOLDER : content,
+					status: 'draft',
+				} ),
 	} );
 }


### PR DESCRIPTION
Part of CM-726. Blog-level ActivityPub C2S exposes inbox/outbox for posts but no media-upload endpoint yet — atmosphere / Mastodon ship native media via their slice-8a `useMedia` slots, Fediverse can't. As an interim, the composer renders an always-on "Move to editor" handoff so users with media to attach have a one-click path to the block editor on the connection's blog. The published post still federates from that blog the same way.

## Proposed Changes

### Shared shell — `client/reader/social/composer/`

* New `<ComposerMediaHandoff>`. Mirrors `<ComposerOverflowHandoff>`'s shape (same plumbing — `usePreferredHandoffSiteId` + `useHandoffMutation`), different trigger condition: always-on when the per-protocol config opts in, vs the overflow's word-count gate. Renders nothing when the config doesn't opt in, when no preferred site resolves, or when the sites query hasn't surfaced a matching `Site` entry.
* New optional `mediaHandoff` field on `ComposerConfig`:
  * `guidance: ( mode, translate ) => ReactNode` — inline guidance copy explaining the API gap. Function-of-translate so per-protocol shells localise at render time (matches the existing `copy` block convention).
  * `triggerLabel: ( mode, translate ) => string` — button label.
  * `tracks?: { shown, editorOpened }` — optional Tracks events with the same shape as `overflowHandoff`. Omit the field to opt out of telemetry.
* Mounted in `<ComposerModal>` directly above `<ComposerOverflowHandoff>` so the media affordance appears before the length-overflow affordance in the visual flow.

### Fediverse opt-in — `client/reader/fediverse/composer-config.tsx`

* Inline guidance: *"Want to add an image? Publishing media isn't supported here yet — open the block editor to publish a post with media. It'll federate from your blog the same way."*
* Trigger label: *"Open the editor"*.
* Tracks events:
  * `calypso_reader_fediverse_media_handoff_shown` — once per modal session, on first render where the section resolves.
  * `calypso_reader_fediverse_media_handoff_editor_opened` — on click, after the draft save succeeds and the editor tab navigates. Carries `connection_id`, `mode_kind`, `site_id`.

Atmosphere and Mastodon leave `mediaHandoff` undefined; they already ship native in-pane media via their slice-8a `useMedia` slots. The shared composer's existing 592-test suite across those protocols stays green.

## Why are these changes being made?

CM-726. The Fediverse standalone composer (CM-704) shipped without a media slot because the blog-level ActivityPub C2S endpoint exposes `/inbox` + `/outbox` for posts but no media-upload counterpart yet. Users authoring with media had no in-pane path. This PR replaces the absent "Add media" affordance with a discoverable link to the block editor, with telemetry on click-through so we can size how often the fallback is hit. Revisit and remove when a C2S media endpoint lands and `useMedia` can wire an in-pane upload flow (mirroring atmosphere / mastodon slice 8a).

## Testing Instructions

1. `yarn typecheck-client` — clean for `client/reader/fediverse` / `client/reader/social/composer`.
2. `yarn test-client client/reader/fediverse client/reader/social/composer` — 121 tests pass (7 new in `composer-media-handoff.test.tsx`).
3. `yarn test-client client/reader/atmosphere client/reader/mastodon` — 592 tests across 58 suites pass (sibling protocols untouched).
4. With `reader/fediverse` enabled and a connected AP-enabled blog:
   * Open the Fediverse composer (FAB or the inline pill on a timeline). The "Open the editor" section appears below the visibility / CW controls, above the footer.
   * Click "Open the editor". A new tab opens with the block editor on the connection's blog; the post body is prefilled with whatever was in the composer.
   * Force `window.open` to be blocked (browser popup blocker). The success notice's "Open in editor" button shows instead. Click it; the editor opens.
   * Block the `/posts/new` save-draft endpoint with a 500. The composer error notice fires; no tab opens.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
