### PR TITLE
Image Studio: richer suggestion chips, and Share button uses navigator.share only

### DIFF
--- a/packages/image-studio/src/hooks/use-generic-share/index.test.ts
+++ b/packages/image-studio/src/hooks/use-generic-share/index.test.ts
@@ -5,6 +5,7 @@ const mockTrackClicked = jest.fn();
 const mockTrackCompleted = jest.fn();
 const mockTrackFailed = jest.fn();
 const mockAddNotice = jest.fn();
+const mockCreateCoreNotice = jest.fn();
 
 let mockState: {
 	currentVideoUrl: string | null;
@@ -34,6 +35,9 @@ jest.mock( '@wordpress/data', () => ( {
 	useDispatch: jest.fn( ( storeName: string ) => {
 		if ( storeName === 'image-studio' ) {
 			return { addNotice: mockAddNotice };
+		}
+		if ( storeName === 'core/notices' ) {
+			return { createNotice: mockCreateCoreNotice };
 		}
 		return {};
 	} ),
@@ -89,6 +93,16 @@ function setNavigatorShare( opts: {
 	} );
 }
 
+function fetchReturning( blob: Blob ): typeof fetch {
+	return jest.fn().mockResolvedValue( {
+		ok: true,
+		status: 200,
+		blob: () => Promise.resolve( blob ),
+	} ) as unknown as typeof fetch;
+}
+
+const NOTICE_RE = /could not share the video/i;
+
 afterEach( () => {
 	Object.defineProperty( global, 'navigator', {
 		value: originalNavigator,
@@ -109,6 +123,9 @@ describe( 'useGenericShare', () => {
 			isAiProcessing: false,
 		};
 		mockAddNotice.mockResolvedValue( undefined );
+		// The share button must never open a tab or download anything itself —
+		// spy so any such attempt fails the test.
+		window.open = jest.fn() as unknown as typeof window.open;
 	} );
 
 	describe( 'isVisible', () => {
@@ -142,18 +159,11 @@ describe( 'useGenericShare', () => {
 		} );
 	} );
 
-	describe( 'handleShare — Web Share path', () => {
-		it( 'fetches the file and invokes navigator.share', async () => {
+	describe( 'handleShare — Web Share (files) path', () => {
+		it( 'fetches the file and invokes navigator.share, opening nothing else', async () => {
 			const mockShare = jest.fn().mockResolvedValue( undefined );
-			const mockCanShare = jest.fn().mockReturnValue( true );
-			setNavigatorShare( { share: mockShare, canShare: mockCanShare } );
-
-			const blob = new Blob( [ 'video' ], { type: 'video/mp4' } );
-			global.fetch = jest.fn().mockResolvedValue( {
-				ok: true,
-				status: 200,
-				blob: () => Promise.resolve( blob ),
-			} ) as unknown as typeof fetch;
+			setNavigatorShare( { share: mockShare, canShare: jest.fn().mockReturnValue( true ) } );
+			global.fetch = fetchReturning( new Blob( [ 'video' ], { type: 'video/mp4' } ) );
 
 			const { result } = renderHook( () => useGenericShare() );
 			await act( async () => {
@@ -164,64 +174,72 @@ describe( 'useGenericShare', () => {
 			expect( mockShare ).toHaveBeenCalledWith(
 				expect.objectContaining( { files: expect.arrayContaining( [ expect.any( File ) ] ) } )
 			);
+			expect( window.open ).not.toHaveBeenCalled();
+			expect( mockAddNotice ).not.toHaveBeenCalled();
 			expect( mockTrackClicked ).toHaveBeenCalledWith( { method: 'web-share' } );
 			expect( mockTrackCompleted ).toHaveBeenCalledWith( { method: 'web-share' } );
 		} );
 
-		it( 'silently exits when the user cancels the share sheet', async () => {
-			const abortError = new DOMException( 'cancel', 'AbortError' );
-			const mockShare = jest.fn().mockRejectedValue( abortError );
-			const mockCanShare = jest.fn().mockReturnValue( true );
-			setNavigatorShare( { share: mockShare, canShare: mockCanShare } );
-
-			const blob = new Blob( [ 'v' ], { type: 'video/mp4' } );
-			global.fetch = jest.fn().mockResolvedValue( {
-				ok: true,
-				status: 200,
-				blob: () => Promise.resolve( blob ),
-			} ) as unknown as typeof fetch;
-
-			window.open = jest.fn() as unknown as typeof window.open;
+		it( 'silently exits when the user dismisses the share sheet', async () => {
+			const mockShare = jest.fn().mockRejectedValue( new DOMException( 'cancel', 'AbortError' ) );
+			setNavigatorShare( { share: mockShare, canShare: jest.fn().mockReturnValue( true ) } );
+			global.fetch = fetchReturning( new Blob( [ 'v' ], { type: 'video/mp4' } ) );
 
 			const { result } = renderHook( () => useGenericShare() );
 			await act( async () => {
 				await result.current.handleShare();
 			} );
 
+			expect( window.open ).not.toHaveBeenCalled();
+			expect( mockAddNotice ).not.toHaveBeenCalled();
+			// clicked fires before the work starts, so the funnel still records the attempt
+			// even though the silent-dismiss path emits no failed/completed.
+			expect( mockTrackClicked ).toHaveBeenCalledWith( { method: 'web-share' } );
 			expect( mockTrackFailed ).not.toHaveBeenCalled();
 			expect( mockTrackCompleted ).not.toHaveBeenCalled();
+		} );
+
+		it( 'shows an error notice — never downloads or opens a tab — when navigator.share throws', async () => {
+			const mockShare = jest.fn().mockRejectedValue( new Error( 'NotAllowedError' ) );
+			setNavigatorShare( { share: mockShare, canShare: jest.fn().mockReturnValue( true ) } );
+			global.fetch = fetchReturning( new Blob( [ 'v' ], { type: 'video/mp4' } ) );
+
+			const { result } = renderHook( () => useGenericShare() );
+			await act( async () => {
+				await result.current.handleShare();
+			} );
+
 			expect( window.open ).not.toHaveBeenCalled();
+			expect( mockAddNotice ).toHaveBeenCalledWith( expect.stringMatching( NOTICE_RE ), 'error' );
+			expect( mockTrackFailed ).toHaveBeenCalledWith(
+				expect.objectContaining( { method: 'web-share', message: 'NotAllowedError' } )
+			);
+			expect( mockTrackCompleted ).not.toHaveBeenCalled();
+		} );
+
+		it( 'tags an HTTP fetch failure as failureKind=http and shows the error notice', async () => {
+			setNavigatorShare( { share: jest.fn(), canShare: jest.fn().mockReturnValue( true ) } );
+			global.fetch = jest
+				.fn()
+				.mockResolvedValue( { ok: false, status: 404 } ) as unknown as typeof fetch;
+
+			const { result } = renderHook( () => useGenericShare() );
+			await act( async () => {
+				await result.current.handleShare();
+			} );
+
+			expect( window.open ).not.toHaveBeenCalled();
+			expect( mockTrackFailed ).toHaveBeenCalledWith(
+				expect.objectContaining( { method: 'web-share', failureKind: 'http' } )
+			);
+			expect( mockAddNotice ).toHaveBeenCalledWith( expect.stringMatching( NOTICE_RE ), 'error' );
 		} );
 	} );
 
-	describe( 'handleShare — download fallback', () => {
-		it( 'opens the URL in a new tab when Web Share API is unavailable', async () => {
-			setNavigatorShare( { share: undefined, canShare: undefined } );
-			const mockOpen = jest.fn().mockReturnValue( {} );
-			window.open = mockOpen as unknown as typeof window.open;
-
-			const { result } = renderHook( () => useGenericShare() );
-			await act( async () => {
-				await result.current.handleShare();
-			} );
-
-			expect( mockOpen ).toHaveBeenCalledWith(
-				'https://example.com/clip.mp4',
-				'_blank',
-				'noopener'
-			);
-			expect( mockTrackClicked ).toHaveBeenCalledWith( { method: 'download' } );
-			expect( mockTrackCompleted ).toHaveBeenCalledWith( { method: 'download' } );
-		} );
-
-		it( 'falls through to download and tracks web-share-unsupported when canShare rejects files', async () => {
-			const mockShare = jest.fn();
-			const mockCanShare = jest.fn().mockReturnValue( false );
-			setNavigatorShare( { share: mockShare, canShare: mockCanShare } );
-
+	describe( 'handleShare — file sharing unavailable', () => {
+		it( 'shows an error notice and never fetches or opens a tab when canShare rejects files', async () => {
+			setNavigatorShare( { share: jest.fn(), canShare: jest.fn().mockReturnValue( false ) } );
 			global.fetch = jest.fn() as unknown as typeof fetch;
-			const mockOpen = jest.fn().mockReturnValue( {} );
-			window.open = mockOpen as unknown as typeof window.open;
 
 			const { result } = renderHook( () => useGenericShare() );
 			await act( async () => {
@@ -229,51 +247,52 @@ describe( 'useGenericShare', () => {
 			} );
 
 			expect( global.fetch ).not.toHaveBeenCalled();
-			expect( mockShare ).not.toHaveBeenCalled();
+			expect( window.open ).not.toHaveBeenCalled();
+			expect( mockTrackClicked ).toHaveBeenCalledWith( { method: 'web-share-unsupported' } );
 			expect( mockTrackFailed ).toHaveBeenCalledWith( { method: 'web-share-unsupported' } );
-			expect( mockOpen ).toHaveBeenCalled();
-			expect( mockTrackCompleted ).toHaveBeenCalledWith( { method: 'download' } );
+			expect( mockAddNotice ).toHaveBeenCalledWith( expect.stringMatching( NOTICE_RE ), 'error' );
 		} );
 
-		it( 'tags fetch errors with our explicit Fetch-failed status as kind=http', async () => {
-			const mockShare = jest.fn();
-			const mockCanShare = jest.fn().mockReturnValue( true );
-			setNavigatorShare( { share: mockShare, canShare: mockCanShare } );
-
-			global.fetch = jest.fn().mockResolvedValue( {
-				ok: false,
-				status: 404,
-			} ) as unknown as typeof fetch;
-			window.open = jest.fn().mockReturnValue( {} ) as unknown as typeof window.open;
-
-			const { result } = renderHook( () => useGenericShare() );
-			await act( async () => {
-				await result.current.handleShare();
-			} );
-
-			expect( mockTrackFailed ).toHaveBeenCalledWith(
-				expect.objectContaining( { method: 'web-share', failureKind: 'http' } )
-			);
-		} );
-
-		it( 'shows an error notice when window.open is blocked', async () => {
+		it( 'shows an error notice when the Web Share API is missing entirely', async () => {
 			setNavigatorShare( { share: undefined, canShare: undefined } );
-			const mockOpen = jest.fn().mockReturnValue( null );
-			window.open = mockOpen as unknown as typeof window.open;
 
 			const { result } = renderHook( () => useGenericShare() );
 			await act( async () => {
 				await result.current.handleShare();
 			} );
 
-			expect( mockTrackFailed ).toHaveBeenCalledWith( {
-				method: 'download',
-				failureKind: 'open-blocked',
-				message: 'window.open returned null',
+			expect( window.open ).not.toHaveBeenCalled();
+			expect( mockTrackClicked ).toHaveBeenCalledWith( { method: 'web-share-unsupported' } );
+			expect( mockTrackFailed ).toHaveBeenCalledWith( { method: 'web-share-unsupported' } );
+			expect( mockAddNotice ).toHaveBeenCalledWith( expect.stringMatching( NOTICE_RE ), 'error' );
+		} );
+
+		it( 'surfaces the error via the snackbar (core/notices) when invoked from the sidebar with a clip override', async () => {
+			mockCreateCoreNotice.mockResolvedValue( undefined );
+			const mockShare = jest.fn().mockRejectedValue( new Error( 'NotAllowedError' ) );
+			setNavigatorShare( { share: mockShare, canShare: jest.fn().mockReturnValue( true ) } );
+			global.fetch = fetchReturning( new Blob( [ 'v' ], { type: 'video/mp4' } ) );
+
+			const { result } = renderHook( () =>
+				useGenericShare( {
+					url: 'https://example.com/sidebar-clip.mp4',
+					attachmentId: 999,
+				} )
+			);
+			await act( async () => {
+				await result.current.handleShare();
 			} );
-			expect( mockAddNotice ).toHaveBeenCalledWith(
-				expect.stringMatching( /Could not open the video/i ),
-				'error'
+
+			// Sidebar callers route notices through core/notices as a dismissible snackbar.
+			expect( mockCreateCoreNotice ).toHaveBeenCalledWith(
+				'error',
+				expect.stringMatching( NOTICE_RE ),
+				expect.objectContaining( { type: 'snackbar', isDismissible: true } )
+			);
+			// And NOT through the in-modal addNotice path.
+			expect( mockAddNotice ).not.toHaveBeenCalled();
+			expect( mockTrackFailed ).toHaveBeenCalledWith(
+				expect.objectContaining( { method: 'web-share' } )
 			);
 		} );
 	} );
@@ -285,14 +304,8 @@ describe( 'useGenericShare', () => {
 				resolveShare = resolve;
 			} );
 			const mockShare = jest.fn().mockReturnValue( sharePromise );
-			const mockCanShare = jest.fn().mockReturnValue( true );
-			setNavigatorShare( { share: mockShare, canShare: mockCanShare } );
-
-			global.fetch = jest.fn().mockResolvedValue( {
-				ok: true,
-				status: 200,
-				blob: () => Promise.resolve( new Blob( [ 'v' ], { type: 'video/mp4' } ) ),
-			} ) as unknown as typeof fetch;
+			setNavigatorShare( { share: mockShare, canShare: jest.fn().mockReturnValue( true ) } );
+			global.fetch = fetchReturning( new Blob( [ 'v' ], { type: 'video/mp4' } ) );
 
 			const { result } = renderHook( () => useGenericShare() );
 
@@ -320,21 +333,15 @@ describe( 'useGenericShare', () => {
 				resolveShare = resolve;
 			} );
 			const mockShare = jest.fn().mockReturnValue( sharePromise );
-			const mockCanShare = jest.fn().mockReturnValue( true );
-			setNavigatorShare( { share: mockShare, canShare: mockCanShare } );
-
-			global.fetch = jest.fn().mockResolvedValue( {
-				ok: true,
-				status: 200,
-				blob: () => Promise.resolve( new Blob( [ 'v' ], { type: 'video/mp4' } ) ),
-			} ) as unknown as typeof fetch;
+			setNavigatorShare( { share: mockShare, canShare: jest.fn().mockReturnValue( true ) } );
+			global.fetch = fetchReturning( new Blob( [ 'v' ], { type: 'video/mp4' } ) );
 
 			const { result } = renderHook( () => useGenericShare() );
 
 			let firstClick: Promise< void > = Promise.resolve();
 			await act( async () => {
 				firstClick = result.current.handleShare();
-				// Let the fetch + blob microtasks flush so we observe the in-flight state
+				// Flush the fetch + blob microtasks so we observe the in-flight state
 				// before navigator.share resolves.
 				await Promise.resolve();
 				await Promise.resolve();
@@ -348,17 +355,10 @@ describe( 'useGenericShare', () => {
 			expect( result.current.isSharing ).toBe( false );
 		} );
 
-		it( 'resets to false after the user cancels the share sheet (AbortError)', async () => {
-			const abortError = new DOMException( 'cancel', 'AbortError' );
-			const mockShare = jest.fn().mockRejectedValue( abortError );
-			const mockCanShare = jest.fn().mockReturnValue( true );
-			setNavigatorShare( { share: mockShare, canShare: mockCanShare } );
-
-			global.fetch = jest.fn().mockResolvedValue( {
-				ok: true,
-				status: 200,
-				blob: () => Promise.resolve( new Blob( [ 'v' ], { type: 'video/mp4' } ) ),
-			} ) as unknown as typeof fetch;
+		it( 'resets to false after the user dismisses the share sheet (AbortError)', async () => {
+			const mockShare = jest.fn().mockRejectedValue( new DOMException( 'cancel', 'AbortError' ) );
+			setNavigatorShare( { share: mockShare, canShare: jest.fn().mockReturnValue( true ) } );
+			global.fetch = fetchReturning( new Blob( [ 'v' ], { type: 'video/mp4' } ) );
 
 			const { result } = renderHook( () => useGenericShare() );
 			await act( async () => {
@@ -368,16 +368,10 @@ describe( 'useGenericShare', () => {
 			expect( result.current.isSharing ).toBe( false );
 		} );
 
-		it( 'resets to false after a fetch failure falls through to the download fallback', async () => {
-			const mockShare = jest.fn();
-			const mockCanShare = jest.fn().mockReturnValue( true );
-			setNavigatorShare( { share: mockShare, canShare: mockCanShare } );
-
-			global.fetch = jest.fn().mockResolvedValue( {
-				ok: false,
-				status: 500,
-			} ) as unknown as typeof fetch;
-			window.open = jest.fn().mockReturnValue( {} ) as unknown as typeof window.open;
+		it( 'resets to false after navigator.share throws', async () => {
+			const mockShare = jest.fn().mockRejectedValue( new Error( 'boom' ) );
+			setNavigatorShare( { share: mockShare, canShare: jest.fn().mockReturnValue( true ) } );
+			global.fetch = fetchReturning( new Blob( [ 'v' ], { type: 'video/mp4' } ) );
 
 			const { result } = renderHook( () => useGenericShare() );
 			await act( async () => {
@@ -387,24 +381,8 @@ describe( 'useGenericShare', () => {
 			expect( result.current.isSharing ).toBe( false );
 		} );
 
-		it( 'resets to false after the web-share-unsupported fallback runs', async () => {
-			const mockShare = jest.fn();
-			const mockCanShare = jest.fn().mockReturnValue( false );
-			setNavigatorShare( { share: mockShare, canShare: mockCanShare } );
-
-			window.open = jest.fn().mockReturnValue( {} ) as unknown as typeof window.open;
-
-			const { result } = renderHook( () => useGenericShare() );
-			await act( async () => {
-				await result.current.handleShare();
-			} );
-
-			expect( result.current.isSharing ).toBe( false );
-		} );
-
-		it( 'resets to false after window.open is blocked', async () => {
-			setNavigatorShare( { share: undefined, canShare: undefined } );
-			window.open = jest.fn().mockReturnValue( null ) as unknown as typeof window.open;
+		it( 'resets to false when file sharing is unavailable', async () => {
+			setNavigatorShare( { share: jest.fn(), canShare: jest.fn().mockReturnValue( false ) } );
 
 			const { result } = renderHook( () => useGenericShare() );
 			await act( async () => {

--- a/packages/image-studio/src/hooks/use-generic-share/index.ts
+++ b/packages/image-studio/src/hooks/use-generic-share/index.ts
@@ -109,71 +109,52 @@ export function useGenericShare( clip?: ShareClipIdentity ): UseGenericShareRetu
 		isSharingRef.current = true;
 		setIsSharing( true );
 		try {
-			// Fire the clicked event at the start of every method we attempt
-			// (web-share, web-share-unsupported, download), not after the work
-			// succeeds. Otherwise a fetch failure or canShare-rejects-files
-			// emits a `failed` event with no matching `clicked` and the funnel
-			// doesn't add up.
-			//
-			// Probe before fetching — saves a full MP4 download on browsers
-			// that expose navigator.share but reject files (most desktops).
-			if ( nav && canShareVideoFiles( nav, filename ) ) {
-				trackImageStudioGenericShareClicked( { method: 'web-share' } );
-				try {
-					const response = await fetch( currentVideoUrl );
-					if ( ! response.ok ) {
-						throw new Error( `Fetch failed: ${ response.status }` );
-					}
-					const blob = await response.blob();
-					const file = new File( [ blob ], filename, { type: 'video/mp4' } );
+			const showShareFailedNotice = async () =>
+				showNotice(
+					__( 'Could not share the video. Please try again.', __i18n_text_domain__ ),
+					'error'
+				);
 
-					await nav.share?.( {
-						files: [ file ],
-						title: __( 'Generated video clip', __i18n_text_domain__ ),
-					} );
-					trackImageStudioGenericShareCompleted( { method: 'web-share' } );
-					return;
-				} catch ( err ) {
-					if ( err instanceof DOMException && err.name === 'AbortError' ) {
-						// User cancelled the share sheet — silent, no notice, no fallback.
-						return;
-					}
-					const message = err instanceof Error ? err.message : '';
-					const failureKind =
-						err instanceof Error && err.message.startsWith( 'Fetch failed:' ) ? 'http' : undefined;
-					trackImageStudioGenericShareFailed( {
-						method: 'web-share',
-						...( failureKind ? { failureKind } : {} ),
-						message,
-					} );
-					// Fall through to download.
-				}
-			} else if ( nav && typeof nav.share === 'function' ) {
-				// Web Share API exists but doesn't accept video files — record this
-				// case so we can see how often it happens vs. a clean download path.
+			// Sharing a video *file* is essentially a mobile / Safari capability —
+			// desktop Chrome & Firefox expose navigator.share but throw when handed
+			// a File. Probe before fetching so we don't pull a multi-MB MP4 just to
+			// fail. When there's no file-share support, surface an error rather than
+			// falling back to a download — the toolbar already has a download action.
+			if ( ! nav || ! canShareVideoFiles( nav, filename ) ) {
 				trackImageStudioGenericShareClicked( { method: 'web-share-unsupported' } );
 				trackImageStudioGenericShareFailed( { method: 'web-share-unsupported' } );
-			}
-
-			// Fallback: open the MP4 URL in a new tab so the browser can save it.
-			trackImageStudioGenericShareClicked( { method: 'download' } );
-			const opened = window.open( currentVideoUrl, '_blank', 'noopener' );
-			if ( opened ) {
-				trackImageStudioGenericShareCompleted( { method: 'download' } );
+				await showShareFailedNotice();
 				return;
 			}
-			trackImageStudioGenericShareFailed( {
-				method: 'download',
-				failureKind: 'open-blocked',
-				message: 'window.open returned null',
-			} );
-			await showNotice(
-				__(
-					'Could not open the video for download. Allow popups for this site and try again.',
-					__i18n_text_domain__
-				),
-				'error'
-			);
+
+			trackImageStudioGenericShareClicked( { method: 'web-share' } );
+			try {
+				const response = await fetch( currentVideoUrl );
+				if ( ! response.ok ) {
+					throw new Error( `Fetch failed: ${ response.status }` );
+				}
+				const blob = await response.blob();
+				const file = new File( [ blob ], filename, { type: 'video/mp4' } );
+				await nav.share?.( {
+					files: [ file ],
+					title: __( 'Generated video clip', __i18n_text_domain__ ),
+				} );
+				trackImageStudioGenericShareCompleted( { method: 'web-share' } );
+			} catch ( err ) {
+				if ( err instanceof DOMException && err.name === 'AbortError' ) {
+					// User dismissed the share sheet — silent, no notice.
+					return;
+				}
+				const message = err instanceof Error ? err.message : '';
+				const failureKind =
+					err instanceof Error && err.message.startsWith( 'Fetch failed:' ) ? 'http' : undefined;
+				trackImageStudioGenericShareFailed( {
+					method: 'web-share',
+					...( failureKind ? { failureKind } : {} ),
+					message,
+				} );
+				await showShareFailedNotice();
+			}
 		} finally {
 			isSharingRef.current = false;
 			setIsSharing( false );

--- a/packages/image-studio/src/hooks/use-video-clip-suggestions.test.ts
+++ b/packages/image-studio/src/hooks/use-video-clip-suggestions.test.ts
@@ -237,7 +237,7 @@ describe( 'useVideoClipSuggestions', () => {
 		expect( built ).toContain( 'inner prompt body' );
 	} );
 
-	it( 'asks the loader for 3 dense two-axis suggestions (20-40 words, people allowed)', () => {
+	it( 'asks the loader for 3 dense three-axis suggestions (35-60 words, audio axis included)', () => {
 		renderHook( () =>
 			useVideoClipSuggestions( {
 				registerSuggestions: jest.fn(),
@@ -248,17 +248,18 @@ describe( 'useVideoClipSuggestions', () => {
 
 		const callArgs = mockUseAsyncSuggestionsLoader.mock.calls[ 0 ][ 0 ];
 		expect( callArgs.prompt ).toMatch( /3\s+dense/i );
-		expect( callArgs.prompt ).toContain( '20-40 words' );
-		expect( callArgs.prompt ).not.toContain( '15-28 words' );
-		expect( callArgs.prompt ).toMatch( /COMBINES TWO/i );
+		expect( callArgs.prompt ).toContain( '35-60 words' );
+		expect( callArgs.prompt ).not.toContain( '20-40 words' );
+		expect( callArgs.prompt ).toMatch( /COMBINES THREE/i );
+		expect( callArgs.prompt ).toMatch( /Audio \/ atmosphere/i );
 		expect( callArgs.prompt ).toMatch( /only adults/i );
 		expect( callArgs.prompt ).toMatch( /no children or minors/i );
 		expect( callArgs.prompt ).toContain( 'signage' );
 
 		const built = callArgs.buildSystemPrompt( 'inner prompt body', 'en' );
 		expect( built ).toMatch( /exactly\s+3\s+items/i );
-		expect( built ).toContain( '20-40 word' );
-		expect( built ).not.toContain( '15-28 word' );
+		expect( built ).toContain( '35-60 word' );
+		expect( built ).not.toContain( '20-40 word' );
 		expect( built ).toContain( '2-4 word' );
 	} );
 

--- a/packages/image-studio/src/hooks/use-video-clip-suggestions.ts
+++ b/packages/image-studio/src/hooks/use-video-clip-suggestions.ts
@@ -40,7 +40,7 @@ Each prompt MUST be:
   - Lighting (quality + direction + temperature + contrast: low warm raking key, soft cool ambient fill, neutral diffuse overcast, single warm practical against cool ambient, hard rim against soft fill). Describes HOW the light behaves; pair with the Time-of-day axis if you also need to say WHEN.
   - Texture / material detail (worn copper, weathered linen, polished oak, condensation on glass, matte ceramic, salt-crusted rope, moss-damp stone).
   - Time-of-day (dawn, blue hour, late afternoon, deep dusk, twilight).
-  - Audio / atmosphere (a 2-5 word *instrumental* music cue or concrete ambient cue: "warm acoustic folk, fingerpicked guitar"; "minimal ambient electronic, ~95 bpm"; "instrumental jazz, brushed drums"; "distant gull cries"; "low café murmur, ceramic clink"; "wind through pines"). Instrumental genre or environmental cue only — NEVER vocals, lyrics, dialog, song titles, or artists.
+  - Audio / atmosphere (a 2-5 word *instrumental* music cue or concrete non-voice ambient cue: "warm acoustic folk, fingerpicked guitar"; "minimal ambient electronic, ~95 bpm"; "instrumental jazz, brushed drums"; "distant gull cries"; "espresso machine hiss, ceramic clink"; "wind through pines"). Instrumental genre or environmental cue only — NEVER vocals, lyrics, dialogue, crowd murmur, song titles, or artists.
 - Written as woven prose — NOT a bulleted list, NOT axis labels (do not output "Camera: ... Subject: ...").
 - 35-60 words, no trailing punctuation.
 - People may appear — only adults, no children or minors. Describe them generically (e.g. "a barista", "a hiker") with no named individuals, public figures, or recognizable likenesses.

--- a/packages/image-studio/src/hooks/use-video-clip-suggestions.ts
+++ b/packages/image-studio/src/hooks/use-video-clip-suggestions.ts
@@ -21,10 +21,12 @@ const EMPTY_SUGGESTIONS: Suggestion[] = [];
  * and an active video tool, and it ends up calling the tool instead of
  * returning chips.
  *
- * Each prompt deliberately combines TWO descriptive axes (e.g. camera
- * move + lighting, or texture + time-of-day). Single-axis prompts read
- * thin to Veo and tend to produce generic outputs; pairing two axes
- * gives the model concrete intent in both motion and look.
+ * Each prompt deliberately combines THREE descriptive axes drawn from a
+ * pool of six (camera, subject, lighting, texture, time-of-day, audio).
+ * Two-axis prompts read thin to Veo; three concrete axes — woven into
+ * prose, each contributing a distinct word or phrase — give the model
+ * enough hooks to commit to a specific shot rather than averaging toward
+ * generic "scenic" output.
  */
 export function buildVideoClipSuggestionsPrompt( postBody: string ): string {
 	const trimmed = postBody.slice( 0, MAX_POST_BODY_CHARS );
@@ -32,13 +34,15 @@ export function buildVideoClipSuggestionsPrompt( postBody: string ): string {
 
 Each prompt MUST be:
 - Grounded in the post's subject matter (a place, object, environment, mood, or texture mentioned in the post — not the post's literal headline).
-- Phrased as a single piece of visual direction that COMBINES TWO of the following axes (never just one):
-  - Camera move (slow drift, gentle pan, dolly-in, crane, push-in, held wide, parallax tracking).
-  - Subject specificity (a concrete object/place from the post — not a generic noun).
-  - Lighting / mood (golden hour, overcast, naturalistic key, contemplative, motion-rich, energetic, twilight ambient).
-  - Texture / material detail (worn copper, weathered linen, polished oak, condensation on glass, matte ceramic).
-  - Time-of-day (dawn, blue hour, late afternoon, deep dusk).
-- 20-40 words, no trailing punctuation.
+- Phrased as a single piece of visual + audio direction that COMBINES THREE of the six axes below (never fewer than three). The three chosen axes must each contribute a distinct word or phrase you could point at — generic mood adjectives ("beautiful", "stunning", "atmospheric") do NOT count as an axis.
+  - Camera (movement + lens cue: slow dolly-in 24mm wide, macro push-in, gentle parallax pan, low crane lift, held wide deep-focus, hand-held 35mm follow).
+  - Subject specificity (a concrete object, place, or material from the post — never a generic noun like "scene" or "view").
+  - Lighting (quality + direction + temperature + contrast: low warm raking key, soft cool ambient fill, neutral diffuse overcast, single warm practical against cool ambient, hard rim against soft fill). Describes HOW the light behaves; pair with the Time-of-day axis if you also need to say WHEN.
+  - Texture / material detail (worn copper, weathered linen, polished oak, condensation on glass, matte ceramic, salt-crusted rope, moss-damp stone).
+  - Time-of-day (dawn, blue hour, late afternoon, deep dusk, twilight).
+  - Audio / atmosphere (a 2-5 word *instrumental* music cue or concrete ambient cue: "warm acoustic folk, fingerpicked guitar"; "minimal ambient electronic, ~95 bpm"; "instrumental jazz, brushed drums"; "distant gull cries"; "low café murmur, ceramic clink"; "wind through pines"). Instrumental genre or environmental cue only — NEVER vocals, lyrics, dialog, song titles, or artists.
+- Written as woven prose — NOT a bulleted list, NOT axis labels (do not output "Camera: ... Subject: ...").
+- 35-60 words, no trailing punctuation.
 - People may appear — only adults, no children or minors. Describe them generically (e.g. "a barista", "a hiker") with no named individuals, public figures, or recognizable likenesses.
 - Free of crowds, on-screen text, signage, dialogue, or copyrighted properties — these are non-negotiable for the safety pipeline.
 
@@ -52,9 +56,9 @@ function buildVideoClipSystemPrompt( suggestionPrompt: string, locale: string ):
 ${ suggestionPrompt }
 
 Output ONLY valid JSON matching this exact structure (no markdown, no explanation, no tool calls). The "suggestions" array MUST contain exactly 3 items:
-{"suggestions":[{"label":"2-4 word chip A","prompt":"20-40 word directional sentence combining two axes"},{"label":"2-4 word chip B","prompt":"20-40 word directional sentence combining two axes"},{"label":"2-4 word chip C","prompt":"20-40 word directional sentence combining two axes"}]}
+{"suggestions":[{"label":"2-4 word chip A","prompt":"35-60 word directional sentence combining three axes"},{"label":"2-4 word chip B","prompt":"35-60 word directional sentence combining three axes"},{"label":"2-4 word chip C","prompt":"35-60 word directional sentence combining three axes"}]}
 
-The chip "label" stays 2-4 words (it's tight UI real estate). The "prompt" is the dense one — 20-40 words, two axes combined.
+The chip "label" stays 2-4 words (it's tight UI real estate). The "prompt" is the dense one — 35-60 words, three axes woven into prose.
 
 Generate all text in the language corresponding to locale code "${ locale }" (e.g. en = English, fr = French, es = Spanish).
 

--- a/packages/image-studio/src/utils/tracking.test.ts
+++ b/packages/image-studio/src/utils/tracking.test.ts
@@ -278,14 +278,6 @@ describe( 'generic share tracking helpers', () => {
 		);
 	} );
 
-	it( 'fires generic_share_clicked with method=download', () => {
-		trackImageStudioGenericShareClicked( { method: 'download' } );
-		expect( recordTracksEventMock ).toHaveBeenCalledWith(
-			'jetpack_big_sky_image_studio_generic_share_clicked',
-			expect.objectContaining( { method: 'download' } )
-		);
-	} );
-
 	it( 'fires generic_share_completed with the chosen method', () => {
 		trackImageStudioGenericShareCompleted( { method: 'web-share' } );
 		expect( recordTracksEventMock ).toHaveBeenCalledWith(
@@ -302,18 +294,18 @@ describe( 'generic share tracking helpers', () => {
 		);
 	} );
 
-	it( 'fires generic_share_failed with method, message, and failureKind', () => {
+	it( 'fires generic_share_failed with method, message, and failureKind=http on a fetch failure', () => {
 		trackImageStudioGenericShareFailed( {
-			method: 'download',
-			message: 'window.open returned null',
-			failureKind: 'open-blocked',
+			method: 'web-share',
+			message: 'Fetch failed: 404',
+			failureKind: 'http',
 		} );
 		expect( recordTracksEventMock ).toHaveBeenCalledWith(
 			'jetpack_big_sky_image_studio_generic_share_failed',
 			expect.objectContaining( {
-				method: 'download',
-				error_message: 'window.open returned null',
-				failure_kind: 'open-blocked',
+				method: 'web-share',
+				error_message: 'Fetch failed: 404',
+				failure_kind: 'http',
 			} )
 		);
 	} );

--- a/packages/image-studio/src/utils/tracking.ts
+++ b/packages/image-studio/src/utils/tracking.ts
@@ -616,17 +616,15 @@ export function trackImageStudioReelShareFailed( errorMessage?: string ): void {
 
 /**
  * Tracks when the generic share initiates a particular method. Fires once per
- * attempted method, before the work runs — so a click that probes web-share,
- * finds files unsupported, and falls back to download produces three events
- * (one per method tried).
+ * attempted method, before the work runs.
  * @param options        - Tracking options
- * @param options.method - 'web-share' (Web Share API attempt), 'web-share-unsupported'
- *                         (canShare rejected files), or 'download' (fallback / direct).
+ * @param options.method - 'web-share' (Web Share API attempt) or 'web-share-unsupported'
+ *                         (canShare rejected files / Web Share unavailable).
  */
 export function trackImageStudioGenericShareClicked( {
 	method,
 }: {
-	method: 'web-share' | 'web-share-unsupported' | 'download';
+	method: 'web-share' | 'web-share-unsupported';
 } ): void {
 	recordImageStudioEvent( 'image_studio_generic_share_clicked', { method } );
 }
@@ -634,32 +632,28 @@ export function trackImageStudioGenericShareClicked( {
 /**
  * Tracks when the generic share completed successfully.
  * @param options        - Tracking options
- * @param options.method - 'web-share' or 'download' (the only methods that can complete;
- *                         'web-share-unsupported' is a precondition failure, never a success).
+ * @param options.method - 'web-share' (the only method that can complete;
+ *                         'web-share-unsupported' is a precondition failure).
  */
-export function trackImageStudioGenericShareCompleted( {
-	method,
-}: {
-	method: 'web-share' | 'download';
-} ): void {
+export function trackImageStudioGenericShareCompleted( { method }: { method: 'web-share' } ): void {
 	recordImageStudioEvent( 'image_studio_generic_share_completed', { method } );
 }
 
 /**
  * Tracks when the generic share failed.
  * @param options             - Tracking options
- * @param options.method      - 'web-share', 'web-share-unsupported', or 'download'
+ * @param options.method      - 'web-share' or 'web-share-unsupported'
  * @param options.message     - Optional error message
- * @param options.failureKind - Optional categorical reason: 'http' | 'open-blocked'
+ * @param options.failureKind - Optional categorical reason: 'http' (fetch returned !ok).
  */
 export function trackImageStudioGenericShareFailed( {
 	method,
 	message,
 	failureKind,
 }: {
-	method: 'web-share' | 'web-share-unsupported' | 'download';
+	method: 'web-share' | 'web-share-unsupported';
 	message?: string;
-	failureKind?: 'http' | 'open-blocked';
+	failureKind?: 'http';
 } ): void {
 	const properties: Record< string, string | number > = { method };
 	if ( message ) {


### PR DESCRIPTION
Two related polish changes to the video composer, on one branch:

## 1. Suggestion chips combine THREE axes (was: TWO)

Chip prompts that prefill the video composer's input now combine THREE of six axes (was: two of five). The new sixth axis is **Audio / atmosphere** — a 2-5 word *instrumental* music cue or concrete ambient cue, with an inline `no vocals / lyrics / dialog / song titles / artists` guard kept right beside the axis so the safety pipeline never has to catch it.

- Word budget bumped 20-40 → 35-60 so the downstream agent has denser, more concrete material to compose from instead of thin two-axis prompts that read as generic.
- Lighting and Time-of-day are now orthogonal — Lighting describes HOW the light behaves; Time-of-day describes WHEN — so picking both as the chosen three isn't degenerate.
- Output stays woven prose (no `Camera: ... Subject: ...` labels) with no trailing punctuation, so chips drop cleanly into the input as a starter the user can extend.

## 2. Share button: use `navigator.share` or fail with a notice — no silent download or new-tab fallback

Previously, when `navigator.share({files})` threw (anything but the user dismissing the sheet via AbortError) or when `canShare({files})` was false, `handleShare` fell through to a blob `<a download>`, and then to `window.open(videoUrl, '_blank')`, surfacing an "Allow popups for this site and try again" notice only if `window.open` was blocked. The toolbar already has a separate Download button, so silently downloading the clip when the share sheet can't open isn't what the user asked for — they pressed Share.

New behaviour:

- Web Share unavailable / `canShare({files})` false → tracked as `web-share-unsupported`, error notice.
- `navigator.share` AbortError → silent (user dismissed the sheet).
- `navigator.share` throws anything else, or `fetch` returns `!ok` → tracked as `web-share` failure (with `failureKind:'http'` on the fetch case), error notice.

The most common runtime failure — the first share of a freshly generated clip, where the cold MP4 fetch outruns the ~5s user-gesture window — is transient: a second click usually succeeds because the file is now HTTP-cached. The notice ("Could not share the video. Please try again.") matches that behaviour.

`tracking.ts` is tightened in the same commit: the unreachable `'download'` method and `'open-blocked'` `failureKind` are dropped from the tracking-function type unions and from the corresponding tracking-test cases. Test coverage on the hook is expanded — including the previously-uncovered sidebar/snackbar path (clip override routes the notice through `core/notices` instead of the in-modal `addNotice`).

## Test plan

Suggestion chips:
- [ ] In the post editor with a body ≥ 50 words, open the video composer; three suggestion chips render.
- [ ] Click a chip → inserted prompt is woven prose (no `Camera:` / `Subject:` labels), 35-60 words, three distinct concrete axes pointable.
- [ ] When the Audio axis is used, it's an instrumental genre or ambient cue — never vocals / lyrics / dialog / artists / song titles.
- [ ] Type into the input → chips hide; clear the input → chips re-appear (regression on the existing hide-while-typing behaviour).

Share button:
- [ ] Mobile / Safari (where `canShare({files})` is true): click Share on a freshly generated clip → native share sheet appears. Pick a target → completes; dismiss → silent.
- [ ] Desktop Chrome where `canShare({files})` is false: click Share → "Could not share the video. Please try again." notice; no new tab, no download.
- [ ] First-share cold-fetch case: if the cold MP4 fetch outruns the user gesture and the share API throws, the same error notice appears (no popup, no download); a second click succeeds.
- [ ] Sidebar Share button (post-editor sidebar): same behaviour, error surfaces as a dismissible snackbar via `core/notices` rather than an in-modal notice.

Tests:
- [ ] `npx jest --testPathPattern='use-video-clip-suggestions'` → 11/11.
- [ ] `npx jest --testPathPattern='use-generic-share'` → 18/18.
- [ ] `npx jest --testPathPattern='utils/tracking'` → all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
