### PR TITLE
Auth: add WPDS-based content-block foundation

### DIFF
--- a/client/blocks/authentication/current-user/current-user.stories.tsx
+++ b/client/blocks/authentication/current-user/current-user.stories.tsx
@@ -1,0 +1,29 @@
+import CurrentUser from './index';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta< typeof CurrentUser > = {
+	title: 'client/blocks/authentication/CurrentUser',
+	component: CurrentUser,
+	tags: [ 'autodocs' ],
+};
+
+export default meta;
+
+type Story = StoryObj< typeof CurrentUser >;
+
+const defaultArgs = {
+	avatarUrl: 'https://gravatar.com/avatar/0?d=mp&s=96',
+	name: 'Jane Doe',
+	email: 'jane@example.com',
+};
+
+export const Default: Story = {
+	args: defaultArgs,
+};
+
+export const LongName: Story = {
+	args: {
+		...defaultArgs,
+		name: 'Maximilian Alexander von Hohenzollern-Sigmaringen',
+	},
+};

--- a/client/blocks/authentication/current-user/index.tsx
+++ b/client/blocks/authentication/current-user/index.tsx
@@ -1,0 +1,24 @@
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+
+import './style.scss';
+
+type CurrentUserProps = {
+	avatarUrl: string;
+	name: string;
+	email: string;
+};
+
+const CurrentUser = ( { avatarUrl, name, email }: CurrentUserProps ) => (
+	<HStack className="auth-current-user" spacing={ 4 } justify="flex-start" alignment="center">
+		<img className="auth-current-user__avatar" src={ avatarUrl } alt="" />
+		<VStack spacing={ 0 }>
+			<span className="auth-current-user__name">{ name }</span>
+			<span className="auth-current-user__email">{ email }</span>
+		</VStack>
+	</HStack>
+);
+
+export default CurrentUser;

--- a/client/blocks/authentication/current-user/style.scss
+++ b/client/blocks/authentication/current-user/style.scss
@@ -8,8 +8,8 @@
 	// equally-100% primary button below it.
 	box-sizing: border-box;
 	inline-size: 100%;
-	background: $white;
-	border: $border-width solid $gray-200;
+	background: var(--color-surface);
+	border: $border-width solid var(--color-border-subtle);
 	border-radius: $radius-medium;
 	padding-inline-end: $grid-unit-15;
 	overflow: hidden;

--- a/client/blocks/authentication/current-user/style.scss
+++ b/client/blocks/authentication/current-user/style.scss
@@ -1,0 +1,39 @@
+@import '@wordpress/base-styles/colors';
+@import '@wordpress/base-styles/variables';
+
+.auth-current-user {
+	// Figma's 1-col template renders the card at `w-full` inside the 400px
+	// content-row. `box-sizing: border-box` keeps border + right padding
+	// inside the 100% — without it, the card renders ~14px wider than the
+	// equally-100% primary button below it.
+	box-sizing: border-box;
+	inline-size: 100%;
+	background: $white;
+	border: $border-width solid $gray-200;
+	border-radius: $radius-medium;
+	padding-inline-end: $grid-unit-15;
+	overflow: hidden;
+}
+
+.auth-current-user__avatar {
+	inline-size: $grid-unit-80;
+	block-size: $grid-unit-80;
+	flex-shrink: 0;
+	object-fit: cover;
+}
+
+// Type scale: WPDS has no 16px size token (jumps 15 → 20), so the name inherits
+// body's 16px ($font-body in packages/typography/styles/variables.scss). Weight
+// and line-height come from WPDS scale.
+.auth-current-user__name {
+	line-height: $font-line-height-medium;
+	font-weight: $font-weight-medium;
+	color: var(--color-text);
+}
+
+.auth-current-user__email {
+	font-size: $font-size-small;
+	line-height: $font-line-height-small;
+	font-weight: $font-weight-regular;
+	color: var(--color-text-subtle);
+}

--- a/client/blocks/authentication/current-user/test/index.test.tsx
+++ b/client/blocks/authentication/current-user/test/index.test.tsx
@@ -1,0 +1,33 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import CurrentUser from '../index';
+
+const defaultProps = {
+	avatarUrl: 'https://gravatar.com/avatar/0?d=mp&s=96',
+	name: 'Jane Doe',
+	email: 'jane@example.com',
+};
+
+describe( 'CurrentUser', () => {
+	test( 'renders the user name', () => {
+		render( <CurrentUser { ...defaultProps } /> );
+
+		expect( screen.getByText( 'Jane Doe' ) ).toBeVisible();
+	} );
+
+	test( 'renders the user email', () => {
+		render( <CurrentUser { ...defaultProps } /> );
+
+		expect( screen.getByText( 'jane@example.com' ) ).toBeVisible();
+	} );
+
+	test( 'renders the avatar with empty alt for decorative use', () => {
+		const { container } = render( <CurrentUser { ...defaultProps } /> );
+
+		const avatar = container.querySelector( '.auth-current-user__avatar' );
+		expect( avatar ).toHaveAttribute( 'src', defaultProps.avatarUrl );
+		expect( avatar ).toHaveAttribute( 'alt', '' );
+	} );
+} );

--- a/client/blocks/authentication/index.tsx
+++ b/client/blocks/authentication/index.tsx
@@ -1,1 +1,8 @@
+export { default as CurrentUser } from './current-user';
 export { default as FormDivider } from './form-divider';
+export { default as Screen } from './screen';
+export { default as SocialButton } from './social-button';
+export { default as SocialConnectWidget } from './social-connect-widget';
+
+export type { SocialProvider } from './social-button';
+export type { SocialConnectService } from './social-connect-widget';

--- a/client/blocks/authentication/screen/index.tsx
+++ b/client/blocks/authentication/screen/index.tsx
@@ -1,0 +1,72 @@
+import { WordPressLogo, WordPressWordmark } from '@automattic/components';
+import clsx from 'clsx';
+import type { ReactNode } from 'react';
+
+import './style.scss';
+
+type ScreenProps = {
+	/**
+	 * Optional element rendered on the trailing edge of the top bar — typically
+	 * a context-specific link like "Create an account" or "Log in".
+	 */
+	topBarAction?: ReactNode;
+	/**
+	 * The h1 text for the screen. Rendered in the Recoleta brand font when
+	 * the surrounding `lang` is supported by `@automattic/typography`.
+	 */
+	heading: ReactNode;
+	/**
+	 * Optional secondary copy rendered under the heading. Use for short
+	 * subtitles or the standard "By continuing…" Terms & Conditions blurb.
+	 */
+	subheading?: ReactNode;
+	/**
+	 * Optional inline notice rendered in the heading area, between the
+	 * heading and subheading. Pass a `Notice` element from
+	 * `calypso/dashboard/components/notice`.
+	 */
+	notice?: ReactNode;
+	/**
+	 * When true, the content area widens to 768px on `@break-medium` so a
+	 * consumer can lay out two columns side-by-side (input-CTA + social
+	 * options, with a vertical OR between them). When false (default),
+	 * content caps at 400px — the 1-col width used by lost-password,
+	 * magic-link, 2FA, social-connect, continue-as-user, etc.
+	 */
+	wide?: boolean;
+	/**
+	 * The screen's body — typically a `VStack` of WPDS primitives
+	 * (`TextControl`, `Button`, `Notice`) composed with the foundation
+	 * blocks (`SocialButton`, `CurrentUser`, `SocialConnectWidget`).
+	 */
+	children: ReactNode;
+};
+
+const Screen = ( {
+	topBarAction,
+	heading,
+	subheading,
+	notice,
+	wide = false,
+	children,
+}: ScreenProps ) => (
+	<div className={ clsx( 'auth-screen', { 'is-wide': wide } ) }>
+		<header className="auth-screen__top-bar">
+			<div className="auth-screen__top-bar-logo">
+				<WordPressLogo size={ 21 } className="auth-screen__top-bar-logo-compact" />
+				<WordPressWordmark color="currentColor" className="auth-screen__top-bar-logo-wordmark" />
+			</div>
+			{ topBarAction && <div className="auth-screen__top-bar-action">{ topBarAction }</div> }
+		</header>
+		<main className="auth-screen__content">
+			<header className="auth-screen__heading">
+				<h1 className="wp-brand-font">{ heading }</h1>
+				{ notice && <div className="auth-screen__notice">{ notice }</div> }
+				{ subheading && <p className="auth-screen__subheading">{ subheading }</p> }
+			</header>
+			<div className="auth-screen__body">{ children }</div>
+		</main>
+	</div>
+);
+
+export default Screen;

--- a/client/blocks/authentication/screen/index.tsx
+++ b/client/blocks/authentication/screen/index.tsx
@@ -6,6 +6,14 @@ import './style.scss';
 
 type ScreenProps = {
 	/**
+	 * Optional element rendered on the leading edge of the top bar, next to
+	 * the logo — typically a "Back" link that returns to the previous step
+	 * (e.g. lost-password → log-in). Consumers render the button themselves
+	 * so they can wire up the right destination and any client-side
+	 * navigation.
+	 */
+	backAction?: ReactNode;
+	/**
 	 * Optional element rendered on the trailing edge of the top bar — typically
 	 * a context-specific link like "Create an account" or "Log in".
 	 */
@@ -43,6 +51,7 @@ type ScreenProps = {
 };
 
 const Screen = ( {
+	backAction,
 	topBarAction,
 	heading,
 	subheading,
@@ -56,6 +65,7 @@ const Screen = ( {
 				<WordPressLogo size={ 21 } className="auth-screen__top-bar-logo-compact" />
 				<WordPressWordmark color="currentColor" className="auth-screen__top-bar-logo-wordmark" />
 			</div>
+			{ backAction && <div className="auth-screen__top-bar-back">{ backAction }</div> }
 			{ topBarAction && <div className="auth-screen__top-bar-action">{ topBarAction }</div> }
 		</header>
 		<main className="auth-screen__content">

--- a/client/blocks/authentication/screen/index.tsx
+++ b/client/blocks/authentication/screen/index.tsx
@@ -69,11 +69,11 @@ const Screen = ( {
 			{ topBarAction && <div className="auth-screen__top-bar-action">{ topBarAction }</div> }
 		</header>
 		<main className="auth-screen__content">
-			<header className="auth-screen__heading">
+			<div className="auth-screen__heading">
 				<h1 className="wp-brand-font">{ heading }</h1>
 				{ notice && <div className="auth-screen__notice">{ notice }</div> }
 				{ subheading && <p className="auth-screen__subheading">{ subheading }</p> }
-			</header>
+			</div>
 			<div className="auth-screen__body">{ children }</div>
 		</main>
 	</div>

--- a/client/blocks/authentication/screen/screen.stories.tsx
+++ b/client/blocks/authentication/screen/screen.stories.tsx
@@ -1,0 +1,154 @@
+import { Button, TextControl, __experimentalVStack as VStack } from '@wordpress/components';
+import Notice from 'calypso/dashboard/components/notice';
+import SocialButton from '../social-button';
+import Screen from './index';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import '../stories/recipes.scss';
+
+const meta: Meta< typeof Screen > = {
+	title: 'client/blocks/authentication/Screen',
+	component: Screen,
+	tags: [ 'autodocs' ],
+	parameters: {
+		layout: 'fullscreen',
+	},
+	// The `.wp-brand-font` selector only applies Recoleta when the parent has
+	// `lang` set to a supported language. Production HTML always has
+	// `<html lang="…">`; Storybook's iframe does not, so headings fall back
+	// to the default serif. Wrap stories with `lang="en"` to match prod.
+	decorators: [
+		( Story ) => (
+			<div lang="en">
+				<Story />
+			</div>
+		),
+	],
+};
+
+export default meta;
+
+type Story = StoryObj< typeof Screen >;
+
+const fullWidth = { width: '100%' };
+
+const PlaceholderContent = () => (
+	<VStack spacing={ 4 }>
+		<TextControl
+			__nextHasNoMarginBottom
+			__next40pxDefaultSize
+			label="Email address or username"
+			value=""
+			onChange={ () => {} }
+			type="text"
+			autoComplete="username"
+		/>
+		<Button variant="primary" __next40pxDefaultSize type="submit" style={ fullWidth }>
+			Continue
+		</Button>
+		<Button variant="link" href="/log-in/lostpassword">
+			Lost your password?
+		</Button>
+	</VStack>
+);
+
+export const Default: Story = {
+	args: {
+		topBarAction: (
+			<Button variant="link" href="/start">
+				Create an account
+			</Button>
+		),
+		heading: 'Log in to WordPress.com',
+		subheading: 'By continuing, you agree to our Terms of Service and Privacy Policy.',
+		children: <PlaceholderContent />,
+	},
+};
+
+export const WithNotice: Story = {
+	args: {
+		topBarAction: (
+			<Button variant="link" href="/start">
+				Create an account
+			</Button>
+		),
+		heading: 'Log in to WordPress.com',
+		notice: (
+			<Notice variant="error">
+				We found a WordPress.com account with the email address &quot;jane@example.com&quot;. Log in
+				to this account to connect it to your Google profile, or choose a different Google profile.
+			</Notice>
+		),
+		subheading: 'By continuing, you agree to our Terms of Service and Privacy Policy.',
+		children: <PlaceholderContent />,
+	},
+};
+
+export const HeadingOnly: Story = {
+	args: {
+		heading: 'Two-step authentication',
+		children: <PlaceholderContent />,
+	},
+};
+
+export const SignupAction: Story = {
+	args: {
+		topBarAction: (
+			<Button variant="link" href="/log-in">
+				Log in
+			</Button>
+		),
+		heading: 'Create your account',
+		subheading:
+			'By continuing with any of the options listed, you agree to our Terms of Service and Privacy Policy.',
+		children: <PlaceholderContent />,
+	},
+};
+
+// Demonstrates the `wide` prop with the canonical 2-column content
+// arrangement from `auth-desktop-template-2col`. The content row caps at
+// 768px so input-CTA + vertical OR + social options fit side-by-side on
+// desktop; on mobile the same composition stacks single-column via the
+// shared `recipes.scss` grid styles. For a fully composed real-world
+// example, see `Recipes / Login`.
+const TwoColumnContent = () => (
+	<div className="auth-recipe-login">
+		<VStack spacing={ 4 } className="auth-recipe-login__input">
+			<TextControl
+				__nextHasNoMarginBottom
+				__next40pxDefaultSize
+				label="Email address or username"
+				value=""
+				onChange={ () => {} }
+				type="text"
+				autoComplete="username"
+			/>
+			<Button variant="primary" __next40pxDefaultSize type="submit" style={ fullWidth }>
+				Continue
+			</Button>
+		</VStack>
+		<div className="auth-recipe-login__or">
+			<span>or</span>
+		</div>
+		<VStack spacing={ 2 } role="group">
+			<SocialButton provider="google">Continue with Google</SocialButton>
+			<SocialButton provider="apple">Continue with Apple</SocialButton>
+			<SocialButton provider="github">Continue with GitHub</SocialButton>
+			<SocialButton provider="email">Continue with email</SocialButton>
+		</VStack>
+	</div>
+);
+
+export const Wide: Story = {
+	args: {
+		topBarAction: (
+			<Button variant="link" href="/start">
+				Create an account
+			</Button>
+		),
+		heading: 'Log in to WordPress.com',
+		subheading: 'By continuing, you agree to our Terms of Service and Privacy Policy.',
+		wide: true,
+		children: <TwoColumnContent />,
+	},
+};

--- a/client/blocks/authentication/screen/screen.stories.tsx
+++ b/client/blocks/authentication/screen/screen.stories.tsx
@@ -130,7 +130,7 @@ const TwoColumnContent = () => (
 		<div className="auth-recipe-login__or">
 			<span>or</span>
 		</div>
-		<VStack spacing={ 2 } role="group">
+		<VStack spacing={ 2 } role="group" aria-label="Social login options">
 			<SocialButton provider="google">Continue with Google</SocialButton>
 			<SocialButton provider="apple">Continue with Apple</SocialButton>
 			<SocialButton provider="github">Continue with GitHub</SocialButton>

--- a/client/blocks/authentication/screen/style.scss
+++ b/client/blocks/authentication/screen/style.scss
@@ -74,6 +74,17 @@
 	}
 }
 
+.auth-screen__top-bar-back {
+	display: flex;
+	align-items: center;
+
+	// Same neutral-link treatment the trailing action gets — keeps a
+	// "Back" link from picking up Calypso's themed blue accent.
+	.components-button.is-link:not(.is-destructive) {
+		--wp-components-color-accent: #{$gray-900};
+	}
+}
+
 .auth-screen__top-bar-action {
 	margin-inline-start: auto;
 	display: flex;
@@ -90,6 +101,9 @@
 }
 
 // Content area — vertically centers heading + body in the remaining viewport.
+// Symmetric block padding so `justify-content: center` lands the content on
+// the true mid-line of the post-topbar area; an asymmetric pad would shift
+// the centroid toward the smaller edge.
 .auth-screen__content {
 	inline-size: 100%;
 	box-sizing: border-box;
@@ -99,8 +113,7 @@
 	align-items: center;
 	justify-content: center;
 	gap: $grid-unit-40;
-	padding-inline: $grid-unit-20;
-	padding-block-end: $grid-unit-40;
+	padding: $grid-unit-40 $grid-unit-20;
 
 	@include break-small {
 		padding-inline: $grid-unit-30;

--- a/client/blocks/authentication/screen/style.scss
+++ b/client/blocks/authentication/screen/style.scss
@@ -1,0 +1,175 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/colors';
+@import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/variables';
+
+.auth-screen {
+	// Figma surface — a touch lighter than calypso's default
+	// `--color-surface-backdrop` (gray-0 / #F6F7F7). Matches the dashboard's
+	// `--dashboard__background-color` from `client/dashboard/app-dotcom/`,
+	// but that scope isn't defined outside the dashboard app, so set the
+	// background here.
+	background: var(--dashboard__background-color, #fcfcfc);
+	// Fall back to 100vh for browsers without dynamic-viewport support; modern
+	// mobile browsers use 100dvh so the surface stays stable as the URL bar
+	// expands/collapses on scroll.
+	min-block-size: 100vh;
+	min-block-size: 100dvh;
+
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+
+	// `Notice` from `client/dashboard/components/notice/` uses dashboard
+	// CSS variables for variant background tints (`color-mix(in srgb,
+	// var(--dashboard__background-color-error) 4%, transparent)` and
+	// friends). Those variables are only defined inside the dashboard
+	// app's `:root` scope, so provide fallbacks here that mirror what the
+	// dashboard sets: WPDS `$alert-red` for error, plus the same
+	// hand-picked tints the dashboard uses for warning/success. The info
+	// variant reads `--wp-admin-theme-color` directly and doesn't need a
+	// fallback.
+	--dashboard__background-color-error: #{$alert-red};
+	--dashboard__background-color-warning: #d47608;
+	--dashboard__background-color-success: #3ca758;
+}
+
+// Top bar — full-bleed, with the logo on the leading edge and an optional
+// action on the trailing edge.
+.auth-screen__top-bar {
+	inline-size: 100%;
+	box-sizing: border-box;
+	display: flex;
+	align-items: center;
+	gap: $grid-unit-20;
+	padding: $grid-unit-20;
+
+	@include break-small {
+		padding-inline: $grid-unit-30;
+	}
+}
+
+.auth-screen__top-bar-logo {
+	color: var(--color-text);
+	display: flex;
+	align-items: center;
+}
+
+// Show the compact W mark on mobile and the full wordmark from `@break-small`,
+// matching the Figma DesktopBar (134×18 wordmark on desktop, compact logo on
+// mobile).
+.auth-screen__top-bar-logo-compact {
+	display: block;
+
+	@include break-small {
+		display: none;
+	}
+}
+
+.auth-screen__top-bar-logo-wordmark {
+	display: none;
+
+	@include break-small {
+		display: block;
+	}
+}
+
+.auth-screen__top-bar-action {
+	margin-inline-start: auto;
+	display: flex;
+	align-items: center;
+
+	// WPDS `Button variant="link"` colors itself with
+	// `--wp-components-color-accent`, which Calypso themes to its blue via
+	// `_wp-components-overrides.scss`. The Figma top-bar action reads as a
+	// neutral text link, so rebind the accent to WPDS `$gray-900` for any
+	// non-destructive link button inside the top-bar action slot.
+	.components-button.is-link:not(.is-destructive) {
+		--wp-components-color-accent: #{$gray-900};
+	}
+}
+
+// Content area — vertically centers heading + body in the remaining viewport.
+.auth-screen__content {
+	inline-size: 100%;
+	box-sizing: border-box;
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: $grid-unit-40;
+	padding-inline: $grid-unit-20;
+	padding-block-end: $grid-unit-40;
+
+	@include break-small {
+		padding-inline: $grid-unit-30;
+	}
+}
+
+// Cap the heading and body at 400px (1-col) — the canonical Figma width.
+// `is-wide` widens to 768px at `@break-medium` for the 2-col Login template,
+// and the heading + subheading re-center at the same breakpoint.
+.auth-screen__heading,
+.auth-screen__body {
+	inline-size: 100%;
+	max-inline-size: 400px;
+}
+
+.auth-screen.is-wide {
+	@include break-medium {
+		.auth-screen__heading,
+		.auth-screen__body {
+			max-inline-size: 768px;
+		}
+
+		.auth-screen__heading,
+		.auth-screen__heading h1,
+		.auth-screen__subheading {
+			text-align: center;
+		}
+
+		// Cap the subheading at 347px so long ToS / disclaimer copy doesn't
+		// stretch the full 768 wrapper — small body text becomes hard to
+		// scan past ~85 characters per line.
+		.auth-screen__subheading {
+			max-inline-size: 347px;
+			align-self: center;
+		}
+	}
+}
+
+// Heading block stacks h1 / notice / subheading vertically with an 8px gap,
+// matching the Figma's heading container (gap-[var(--8px,8px)]).
+// Left-aligned by default for 1-col.
+.auth-screen__heading {
+	display: flex;
+	flex-direction: column;
+	gap: $grid-unit-10;
+}
+
+.auth-screen__heading h1 {
+	margin: 0;
+	font-size: $font-size-2x-large;
+	line-height: $font-line-height-2x-large;
+	color: var(--color-neutral-100);
+	text-wrap: balance;
+}
+
+.auth-screen__subheading {
+	margin: 0;
+	font-size: $font-size-large;
+	color: var(--color-text-subtle);
+
+	// Inline links (e.g. Terms of Service / Privacy Policy) inherit the
+	// paragraph's gray instead of picking up Calypso's themed blue accent.
+	// The underline keeps them recognizable as links.
+	a {
+		color: inherit;
+		text-decoration: underline;
+	}
+}
+
+.auth-screen__notice {
+	margin: 0;
+}

--- a/client/blocks/authentication/screen/style.scss
+++ b/client/blocks/authentication/screen/style.scss
@@ -74,30 +74,33 @@
 	}
 }
 
-.auth-screen__top-bar-back {
+// Both leading (`backAction`) and trailing (`topBarAction`) slots: the
+// Figma top bar reads as neutral text, so override Calypso's themed blue
+// accent for any link inside. The prop contract is `ReactNode`, so we
+// cover both WPDS `Button variant="link"` (overrides via the WPDS accent
+// variable) and a plain anchor a consumer might pass directly.
+.auth-screen__top-bar-back,
+.auth-screen__top-bar-action {
 	display: flex;
 	align-items: center;
 
-	// Same neutral-link treatment the trailing action gets — keeps a
-	// "Back" link from picking up Calypso's themed blue accent.
 	.components-button.is-link:not(.is-destructive) {
 		--wp-components-color-accent: #{$gray-900};
+	}
+
+	a:not(.components-button) {
+		color: $gray-900;
+
+		&:hover,
+		&:focus,
+		&:visited {
+			color: $gray-900;
+		}
 	}
 }
 
 .auth-screen__top-bar-action {
 	margin-inline-start: auto;
-	display: flex;
-	align-items: center;
-
-	// WPDS `Button variant="link"` colors itself with
-	// `--wp-components-color-accent`, which Calypso themes to its blue via
-	// `_wp-components-overrides.scss`. The Figma top-bar action reads as a
-	// neutral text link, so rebind the accent to WPDS `$gray-900` for any
-	// non-destructive link button inside the top-bar action slot.
-	.components-button.is-link:not(.is-destructive) {
-		--wp-components-color-accent: #{$gray-900};
-	}
 }
 
 // Content area — vertically centers heading + body in the remaining viewport.

--- a/client/blocks/authentication/screen/test/index.test.tsx
+++ b/client/blocks/authentication/screen/test/index.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import Screen from '../index';
+
+describe( 'Screen', () => {
+	test( 'renders the heading as an h1', () => {
+		render(
+			<Screen heading="Log in to WordPress.com">
+				<div>content</div>
+			</Screen>
+		);
+
+		expect( screen.getByRole( 'heading', { level: 1 } ) ).toHaveTextContent(
+			'Log in to WordPress.com'
+		);
+	} );
+
+	test( 'renders the subheading when provided', () => {
+		render(
+			<Screen heading="Log in" subheading="By continuing…">
+				<div>content</div>
+			</Screen>
+		);
+
+		expect( screen.getByText( 'By continuing…' ) ).toBeVisible();
+	} );
+
+	test( 'omits the subheading when not provided', () => {
+		const { container } = render(
+			<Screen heading="Log in">
+				<div>content</div>
+			</Screen>
+		);
+
+		expect( container.querySelector( '.auth-screen__subheading' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'renders an optional notice between heading and subheading', () => {
+		render(
+			<Screen
+				heading="Log in"
+				subheading="By continuing…"
+				notice={ <div role="alert">Something went wrong</div> }
+			>
+				<div>content</div>
+			</Screen>
+		);
+
+		expect( screen.getByRole( 'alert' ) ).toHaveTextContent( 'Something went wrong' );
+	} );
+
+	test( 'renders an optional top-bar action', () => {
+		render(
+			<Screen heading="Log in" topBarAction={ <a href="/start">Create an account</a> }>
+				<div>content</div>
+			</Screen>
+		);
+
+		expect( screen.getByRole( 'link', { name: 'Create an account' } ) ).toBeVisible();
+	} );
+
+	test( 'renders the content children', () => {
+		render(
+			<Screen heading="Log in">
+				<button type="button">Continue</button>
+			</Screen>
+		);
+
+		expect( screen.getByRole( 'button', { name: 'Continue' } ) ).toBeVisible();
+	} );
+} );

--- a/client/blocks/authentication/social-button/index.tsx
+++ b/client/blocks/authentication/social-button/index.tsx
@@ -1,0 +1,54 @@
+import { Button } from '@wordpress/components';
+import clsx from 'clsx';
+import AppleIcon from 'calypso/components/social-icons/apple';
+import GitHubIcon from 'calypso/components/social-icons/github';
+import GoogleIcon from 'calypso/components/social-icons/google';
+import MailIcon from 'calypso/components/social-icons/mail';
+import PayPalIcon from 'calypso/components/social-icons/paypal';
+import type { MouseEventHandler, ReactNode } from 'react';
+
+import './style.scss';
+
+export type SocialProvider = 'google' | 'apple' | 'github' | 'paypal' | 'email';
+
+type SocialButtonProps = {
+	provider: SocialProvider;
+	children: ReactNode;
+	onClick?: MouseEventHandler< HTMLElement >;
+	disabled?: boolean;
+	className?: string;
+	'aria-label'?: string;
+};
+
+const providerIcon: Record< SocialProvider, JSX.Element > = {
+	google: <GoogleIcon />,
+	apple: <AppleIcon />,
+	github: <GitHubIcon />,
+	paypal: <PayPalIcon />,
+	email: <MailIcon />,
+};
+
+const SocialButton = ( {
+	provider,
+	children,
+	onClick,
+	disabled,
+	className,
+	'aria-label': ariaLabel,
+}: SocialButtonProps ) => (
+	<Button
+		variant="secondary"
+		__next40pxDefaultSize
+		className={ clsx( 'auth-social-button', className ) }
+		disabled={ disabled }
+		aria-label={ ariaLabel }
+		onClick={ onClick }
+	>
+		<span className="auth-social-button__icon" aria-hidden="true">
+			{ providerIcon[ provider ] }
+		</span>
+		<span className="auth-social-button__label">{ children }</span>
+	</Button>
+);
+
+export default SocialButton;

--- a/client/blocks/authentication/social-button/social-button.stories.tsx
+++ b/client/blocks/authentication/social-button/social-button.stories.tsx
@@ -1,0 +1,58 @@
+import SocialButton from './index';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta< typeof SocialButton > = {
+	title: 'client/blocks/authentication/SocialButton',
+	component: SocialButton,
+	tags: [ 'autodocs' ],
+	parameters: {
+		actions: { argTypesRegex: '^on.*' },
+	},
+};
+
+export default meta;
+
+type Story = StoryObj< typeof SocialButton >;
+
+export const Google: Story = {
+	args: {
+		provider: 'google',
+		children: 'Continue with Google',
+	},
+};
+
+export const Apple: Story = {
+	args: {
+		provider: 'apple',
+		children: 'Continue with Apple',
+	},
+};
+
+export const GitHub: Story = {
+	args: {
+		provider: 'github',
+		children: 'Continue with GitHub',
+	},
+};
+
+export const PayPal: Story = {
+	args: {
+		provider: 'paypal',
+		children: 'Continue with PayPal',
+	},
+};
+
+export const Email: Story = {
+	args: {
+		provider: 'email',
+		children: 'Continue with email',
+	},
+};
+
+export const Disabled: Story = {
+	args: {
+		provider: 'google',
+		children: 'Continue with Google',
+		disabled: true,
+	},
+};

--- a/client/blocks/authentication/social-button/style.scss
+++ b/client/blocks/authentication/social-button/style.scss
@@ -1,0 +1,63 @@
+// Auth social button — Figma spec calls for a neutral surface:
+// - white background
+// - subtle WPDS gray border ($gray-200)
+// - dark text
+// - hover/focus/active borders darken to $gray-900
+// - NO calypso-blue accent anywhere
+//
+// Calypso's _wp-components-overrides.scss sets
+// `--wp-components-color-accent: var(--color-accent)` (blue), and WPDS
+// `is-secondary` uses that variable for the border (via inset box-shadow),
+// the text color, hover, focus ring, and active states. Matching WPDS's
+// exact selector patterns (including the `:not(...)` arms) so we tie on
+// specificity and win on cascade order — no `!important` needed.
+
+@import '@wordpress/base-styles/colors';
+@import '@wordpress/base-styles/variables';
+
+.components-button.auth-social-button {
+	inline-size: 100%;
+	display: grid;
+	grid-template-columns: 20px 1fr 20px;
+	align-items: center;
+	column-gap: $grid-unit-15;
+	padding-inline: $grid-unit-15;
+	background: var(--color-surface);
+	color: var(--color-text);
+	box-shadow: inset 0 0 0 $border-width $gray-200;
+}
+
+.components-button.auth-social-button:hover:not(:disabled, [aria-disabled='true'], .is-pressed) {
+	background: var(--color-surface);
+	color: var(--color-text);
+	box-shadow: inset 0 0 0 $border-width $gray-900;
+}
+
+.components-button.auth-social-button:focus:not(:active) {
+	box-shadow:
+		inset 0 0 0 $border-width $gray-900,
+		0 0 0 var(--wp-admin-border-width-focus, 1.5px) $gray-900;
+}
+
+.components-button.auth-social-button:active:not(:disabled) {
+	box-shadow: inset 0 0 0 $border-width $gray-900;
+}
+
+.auth-social-button__icon {
+	grid-column: 1;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	inline-size: 20px;
+	block-size: 20px;
+}
+
+.auth-social-button__label {
+	grid-column: 2;
+	text-align: center;
+}
+
+.auth-social-button .social-icons {
+	inline-size: 20px;
+	block-size: 20px;
+}

--- a/client/blocks/authentication/social-button/test/index.test.tsx
+++ b/client/blocks/authentication/social-button/test/index.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SocialButton from '../index';
+
+describe( 'SocialButton', () => {
+	test( 'renders its label', () => {
+		render( <SocialButton provider="google">Continue with Google</SocialButton> );
+
+		expect( screen.getByRole( 'button', { name: /Continue with Google/i } ) ).toBeVisible();
+	} );
+
+	test( 'renders the provider icon', () => {
+		const { container } = render(
+			<SocialButton provider="google">Continue with Google</SocialButton>
+		);
+
+		expect( container.querySelector( '.social-icons__google' ) ).toBeInTheDocument();
+	} );
+
+	test( 'fires onClick when pressed', async () => {
+		const onClick = jest.fn();
+		render(
+			<SocialButton provider="apple" onClick={ onClick }>
+				Continue with Apple
+			</SocialButton>
+		);
+
+		await userEvent.click( screen.getByRole( 'button', { name: /Continue with Apple/i } ) );
+
+		expect( onClick ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'respects the disabled prop', async () => {
+		const onClick = jest.fn();
+		render(
+			<SocialButton provider="github" onClick={ onClick } disabled>
+				Continue with GitHub
+			</SocialButton>
+		);
+
+		const button = screen.getByRole( 'button', { name: /Continue with GitHub/i } );
+		expect( button ).toBeDisabled();
+		await userEvent.click( button );
+		expect( onClick ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/blocks/authentication/social-connect-widget/index.tsx
+++ b/client/blocks/authentication/social-connect-widget/index.tsx
@@ -1,0 +1,46 @@
+import AppleIcon from 'calypso/components/social-icons/apple';
+import GitHubIcon from 'calypso/components/social-icons/github';
+import GoogleIcon from 'calypso/components/social-icons/google';
+import PayPalIcon from 'calypso/components/social-icons/paypal';
+import SocialLogo from 'calypso/components/social-logo';
+import type { ReactNode } from 'react';
+
+import './style.scss';
+
+export type SocialConnectService = 'google' | 'apple' | 'github' | 'paypal';
+
+type SocialConnectWidgetProps = {
+	service: SocialConnectService;
+};
+
+const serviceIcon: Record< SocialConnectService, ReactNode > = {
+	google: <GoogleIcon width={ 32 } height={ 32 } />,
+	apple: <AppleIcon width={ 32 } height={ 32 } />,
+	github: <GitHubIcon width={ 32 } height={ 32 } />,
+	paypal: <PayPalIcon width={ 32 } height={ 32 } />,
+};
+
+const SocialConnectWidget = ( { service }: SocialConnectWidgetProps ) => (
+	<div className="auth-social-connect-widget">
+		<div className="auth-social-connect-widget__service-logo">{ serviceIcon[ service ] }</div>
+		<svg
+			className="auth-social-connect-widget__dots"
+			width="48"
+			height="4"
+			viewBox="0 0 48 4"
+			xmlns="http://www.w3.org/2000/svg"
+			aria-hidden="true"
+		>
+			<g stroke="none" fill="none" fillRule="evenodd">
+				<circle className="auth-social-connect-widget__dot" cx="2" cy="2" r="2" />
+				<circle className="auth-social-connect-widget__dot" cx="13" cy="2" r="2" />
+				<circle className="auth-social-connect-widget__dot" cx="24" cy="2" r="2" />
+				<circle className="auth-social-connect-widget__dot is-accent" cx="35" cy="2" r="2" />
+				<circle className="auth-social-connect-widget__dot" cx="46" cy="2" r="2" />
+			</g>
+		</svg>
+		<SocialLogo className="auth-social-connect-widget__wp-logo" icon="wordpress" size={ 40 } />
+	</div>
+);
+
+export default SocialConnectWidget;

--- a/client/blocks/authentication/social-connect-widget/index.tsx
+++ b/client/blocks/authentication/social-connect-widget/index.tsx
@@ -21,7 +21,11 @@ const serviceIcon: Record< SocialConnectService, ReactNode > = {
 };
 
 const SocialConnectWidget = ( { service }: SocialConnectWidgetProps ) => (
-	<div className="auth-social-connect-widget">
+	// The widget is a decorative summary of "[service] ↔ WordPress" — the
+	// connection's meaning is conveyed in the surrounding copy. Hide it
+	// from assistive tech so screen readers don't announce three separate
+	// graphics with no context.
+	<div className="auth-social-connect-widget" aria-hidden="true">
 		<div className="auth-social-connect-widget__service-logo">{ serviceIcon[ service ] }</div>
 		<svg
 			className="auth-social-connect-widget__dots"
@@ -29,7 +33,6 @@ const SocialConnectWidget = ( { service }: SocialConnectWidgetProps ) => (
 			height="4"
 			viewBox="0 0 48 4"
 			xmlns="http://www.w3.org/2000/svg"
-			aria-hidden="true"
 		>
 			<g stroke="none" fill="none" fillRule="evenodd">
 				<circle className="auth-social-connect-widget__dot" cx="2" cy="2" r="2" />

--- a/client/blocks/authentication/social-connect-widget/social-connect-widget.stories.tsx
+++ b/client/blocks/authentication/social-connect-widget/social-connect-widget.stories.tsx
@@ -1,0 +1,36 @@
+import SocialConnectWidget from './index';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta< typeof SocialConnectWidget > = {
+	title: 'client/blocks/authentication/SocialConnectWidget',
+	component: SocialConnectWidget,
+	tags: [ 'autodocs' ],
+};
+
+export default meta;
+
+type Story = StoryObj< typeof SocialConnectWidget >;
+
+export const Google: Story = {
+	args: {
+		service: 'google',
+	},
+};
+
+export const Apple: Story = {
+	args: {
+		service: 'apple',
+	},
+};
+
+export const GitHub: Story = {
+	args: {
+		service: 'github',
+	},
+};
+
+export const PayPal: Story = {
+	args: {
+		service: 'paypal',
+	},
+};

--- a/client/blocks/authentication/social-connect-widget/style.scss
+++ b/client/blocks/authentication/social-connect-widget/style.scss
@@ -1,3 +1,4 @@
+@import '@automattic/color-studio/dist/color-variables';
 @import '@wordpress/base-styles/colors';
 @import '@wordpress/base-styles/variables';
 
@@ -40,5 +41,8 @@
 }
 
 .auth-social-connect-widget__dot.is-accent {
-	fill: var(--wp-admin-theme-color);
+	// Fallback for contexts that don't define `--wp-admin-theme-color`
+	// (Storybook iframe, isolated tests): without it, the SVG `<g>` parent's
+	// `fill="none"` wins and the accent dot renders invisible.
+	fill: var(--wp-admin-theme-color, #{$studio-wordpress-blue});
 }

--- a/client/blocks/authentication/social-connect-widget/style.scss
+++ b/client/blocks/authentication/social-connect-widget/style.scss
@@ -1,0 +1,44 @@
+@import '@wordpress/base-styles/colors';
+@import '@wordpress/base-styles/variables';
+
+.auth-social-connect-widget {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: $grid-unit-10;
+}
+
+.auth-social-connect-widget__service-logo,
+.auth-social-connect-widget__wp-logo {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	inline-size: $grid-unit-50;
+	block-size: $grid-unit-50;
+	flex-shrink: 0;
+}
+
+// `client/components/social-icons/style.scss` applies a global
+// `margin-top: -2px` to `.social-icons` for inline-with-text alignment.
+// In our flex-centered 40×40 slot it pulls the provider icons 2px above
+// the row's center, breaking alignment with the WordPress `SocialLogo`
+// (which uses `.social-logo` and isn't affected). Neutralize it here.
+.auth-social-connect-widget__service-logo .social-icons {
+	margin-block-start: 0;
+}
+
+.auth-social-connect-widget__dots {
+	flex-shrink: 0;
+}
+
+// The dotted-line connector's fills come from WPDS tokens so the widget
+// inherits the theme palette: a neutral gray for the trail and the
+// themable admin accent for the one dot closest to the WP logo, reading
+// as a connection toward WordPress.com.
+.auth-social-connect-widget__dot {
+	fill: $gray-200;
+}
+
+.auth-social-connect-widget__dot.is-accent {
+	fill: var(--wp-admin-theme-color);
+}

--- a/client/blocks/authentication/social-connect-widget/test/index.test.tsx
+++ b/client/blocks/authentication/social-connect-widget/test/index.test.tsx
@@ -1,0 +1,25 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '@testing-library/react';
+import SocialConnectWidget from '../index';
+
+describe( 'SocialConnectWidget', () => {
+	test( 'renders the Google service icon', () => {
+		const { container } = render( <SocialConnectWidget service="google" /> );
+
+		expect( container.querySelector( '.social-icons__google' ) ).toBeInTheDocument();
+	} );
+
+	test( 'renders the dotted connector', () => {
+		const { container } = render( <SocialConnectWidget service="apple" /> );
+
+		expect( container.querySelector( '.auth-social-connect-widget__dots' ) ).toBeInTheDocument();
+	} );
+
+	test( 'renders the WordPress logo', () => {
+		const { container } = render( <SocialConnectWidget service="google" /> );
+
+		expect( container.querySelector( '.auth-social-connect-widget__wp-logo' ) ).toBeInTheDocument();
+	} );
+} );

--- a/client/blocks/authentication/stories/recipes.scss
+++ b/client/blocks/authentication/stories/recipes.scss
@@ -1,0 +1,75 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/colors';
+@import '@wordpress/base-styles/mixins';
+@import '@wordpress/base-styles/variables';
+
+// Recipe-specific layout for the Login screen. On narrow viewports the
+// content stacks (1-col); from `$break-medium` (782px) up it lays out
+// the input-CTA and the social options side-by-side with a vertical OR
+// rule between them, matching the Figma's `auth-desktop-template-2col`
+// frame (Wrapper 768px wide, columns 327px each, 34px OR gutter).
+
+.auth-recipe-login {
+	display: grid;
+	grid-template-columns: 1fr;
+	row-gap: $grid-unit-20;
+}
+
+.auth-recipe-login__or {
+	font-size: $font-size-small;
+	color: $gray-700;
+	text-transform: uppercase;
+	text-align: center;
+	position: relative;
+}
+
+.auth-recipe-login__or::before {
+	content: '';
+	position: absolute;
+	inset-inline: 0;
+	inset-block-start: 50%;
+	border-block-start: $border-width solid $gray-200;
+	z-index: 0;
+}
+
+.auth-recipe-login__or > span {
+	position: relative;
+	background: var(--dashboard__background-color, #fcfcfc);
+	padding-inline: $grid-unit-10;
+	z-index: 1;
+}
+
+@include break-medium {
+	.auth-recipe-login {
+		grid-template-columns: 1fr 34px 1fr;
+		column-gap: $grid-unit-30;
+		row-gap: 0;
+		// Vertically center the shorter column against the taller one so the
+		// input-CTA reads as aligned to the middle of the row, matching the
+		// Figma's auth-desktop-template-2col (input-cta at y:14 inside a
+		// 208-tall row = centered).
+		align-items: center;
+	}
+
+	.auth-recipe-login__or {
+		inline-size: 34px;
+		min-block-size: 100%;
+	}
+
+	.auth-recipe-login__or::before {
+		inset-inline: 50%;
+		inset-block: 0;
+		border-block-start: 0;
+		border-inline-start: $border-width solid $gray-200;
+	}
+
+	.auth-recipe-login__or > span {
+		display: inline-block;
+		position: absolute;
+		inset-block-start: 50%;
+		inset-inline-start: 50%;
+		transform: translate(-50%, -50%);
+		padding-inline: 0;
+		padding-block: $grid-unit-10;
+	}
+}

--- a/client/blocks/authentication/stories/recipes.stories.tsx
+++ b/client/blocks/authentication/stories/recipes.stories.tsx
@@ -1,0 +1,199 @@
+import { Button, TextControl, __experimentalVStack as VStack } from '@wordpress/components';
+import { useState } from 'react';
+import CurrentUser from '../current-user';
+import Screen from '../screen';
+import SocialButton from '../social-button';
+import SocialConnectWidget from '../social-connect-widget';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import './recipes.scss';
+
+const meta: Meta = {
+	title: 'client/blocks/authentication/Recipes',
+	tags: [ 'autodocs' ],
+	parameters: {
+		layout: 'fullscreen',
+	},
+	// `.wp-brand-font` only applies Recoleta when the parent has `lang` set
+	// to a supported language; Storybook's iframe has no lang attribute so
+	// the brand font silently falls back to the default serif. Match prod.
+	decorators: [
+		( Story ) => (
+			<div lang="en">
+				<Story />
+			</div>
+		),
+	],
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+const fullWidth = { width: '100%' };
+
+const LostPasswordRecipe = () => {
+	const [ email, setEmail ] = useState( '' );
+	return (
+		<Screen
+			heading="Lost your password?"
+			subheading="Enter the email address or username you use to sign in, and we'll send you a reset link."
+			topBarAction={
+				<Button variant="link" href="/log-in">
+					Back to log in
+				</Button>
+			}
+		>
+			<VStack spacing={ 4 }>
+				<TextControl
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
+					label="Email address or username"
+					value={ email }
+					onChange={ setEmail }
+					type="text"
+					autoComplete="username"
+				/>
+				<Button variant="primary" __next40pxDefaultSize type="submit" style={ fullWidth }>
+					Reset my password
+				</Button>
+			</VStack>
+		</Screen>
+	);
+};
+
+const LoginRecipe = () => {
+	const [ email, setEmail ] = useState( '' );
+	return (
+		<Screen
+			heading="Log in to WordPress.com"
+			subheading="By continuing, you agree to our Terms of Service and Privacy Policy."
+			topBarAction={
+				<Button variant="link" href="/start">
+					Create an account
+				</Button>
+			}
+			wide
+		>
+			<div className="auth-recipe-login">
+				<VStack spacing={ 4 } className="auth-recipe-login__input">
+					<TextControl
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+						label="Email address or username"
+						value={ email }
+						onChange={ setEmail }
+						type="text"
+						autoComplete="username"
+					/>
+					<Button variant="primary" __next40pxDefaultSize type="submit" style={ fullWidth }>
+						Continue
+					</Button>
+				</VStack>
+				<div className="auth-recipe-login__or">
+					<span>or</span>
+				</div>
+				<VStack spacing={ 2 } role="group">
+					<SocialButton provider="google">Continue with Google</SocialButton>
+					<SocialButton provider="apple">Continue with Apple</SocialButton>
+					<SocialButton provider="github">Continue with GitHub</SocialButton>
+					<SocialButton provider="email">Continue with email</SocialButton>
+				</VStack>
+			</div>
+		</Screen>
+	);
+};
+
+const SocialConnectRecipe = () => (
+	<Screen
+		heading="Connect your account"
+		subheading="Connect your WordPress.com account to your Google profile. You will be able to use Google to log in to WordPress.com."
+		topBarAction={
+			<Button variant="link" href="/log-in">
+				Log in
+			</Button>
+		}
+	>
+		<VStack spacing={ 4 }>
+			<SocialConnectWidget service="google" />
+			<Button variant="primary" __next40pxDefaultSize type="button" style={ fullWidth }>
+				Connect
+			</Button>
+		</VStack>
+	</Screen>
+);
+
+const ContinueAsUserRecipe = () => (
+	<Screen
+		heading="Log in to WordPress.com"
+		topBarAction={
+			<Button variant="link" href="/start">
+				Create an account
+			</Button>
+		}
+	>
+		<VStack spacing={ 4 }>
+			<CurrentUser
+				avatarUrl="https://gravatar.com/avatar/0?d=mp&s=96"
+				name="Jane Doe"
+				email="jane@example.com"
+			/>
+			<Button variant="primary" __next40pxDefaultSize type="button" style={ fullWidth }>
+				Continue as Jane Doe
+			</Button>
+			<Button variant="link" href="#">
+				Log in with another account
+			</Button>
+		</VStack>
+	</Screen>
+);
+
+const TwoFactorCodeRecipe = () => {
+	const [ code, setCode ] = useState( '' );
+	return (
+		<Screen
+			heading="Two-step authentication"
+			subheading="Enter the code from your authenticator app."
+		>
+			<VStack spacing={ 4 }>
+				<TextControl
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
+					label="6-digit code"
+					value={ code }
+					onChange={ setCode }
+					type="tel"
+					autoComplete="one-time-code"
+					pattern="[0-9 ]*"
+					placeholder="123 456"
+				/>
+				<Button variant="primary" __next40pxDefaultSize type="submit" style={ fullWidth }>
+					Continue
+				</Button>
+				<Button variant="link" href="#">
+					Use a different method
+				</Button>
+			</VStack>
+		</Screen>
+	);
+};
+
+export const LostPassword: Story = {
+	render: () => <LostPasswordRecipe />,
+};
+
+export const Login: Story = {
+	render: () => <LoginRecipe />,
+};
+
+export const SocialConnect: Story = {
+	render: () => <SocialConnectRecipe />,
+};
+
+export const ContinueAsUser: Story = {
+	render: () => <ContinueAsUserRecipe />,
+};
+
+export const TwoFactorCode: Story = {
+	render: () => <TwoFactorCodeRecipe />,
+};

--- a/client/blocks/authentication/stories/recipes.stories.tsx
+++ b/client/blocks/authentication/stories/recipes.stories.tsx
@@ -94,7 +94,7 @@ const LoginRecipe = () => {
 				<div className="auth-recipe-login__or">
 					<span>or</span>
 				</div>
-				<VStack spacing={ 2 } role="group">
+				<VStack spacing={ 2 } role="group" aria-label="Social login options">
 					<SocialButton provider="google">Continue with Google</SocialButton>
 					<SocialButton provider="apple">Continue with Apple</SocialButton>
 					<SocialButton provider="github">Continue with GitHub</SocialButton>

--- a/client/blocks/authentication/stories/recipes.stories.tsx
+++ b/client/blocks/authentication/stories/recipes.stories.tsx
@@ -1,4 +1,5 @@
 import { Button, TextControl, __experimentalVStack as VStack } from '@wordpress/components';
+import { chevronLeft } from '@wordpress/icons';
 import { useState } from 'react';
 import CurrentUser from '../current-user';
 import Screen from '../screen';
@@ -38,9 +39,9 @@ const LostPasswordRecipe = () => {
 		<Screen
 			heading="Lost your password?"
 			subheading="Enter the email address or username you use to sign in, and we'll send you a reset link."
-			topBarAction={
-				<Button variant="link" href="/log-in">
-					Back to log in
+			backAction={
+				<Button variant="link" href="/log-in" icon={ chevronLeft } iconPosition="left">
+					Back
 				</Button>
 			}
 		>


### PR DESCRIPTION
Part of DES-619 (RSM)

## Proposed Changes

Add four shared building blocks under `client/blocks/authentication/` that every WordPress.com auth surface (login, signup, 2FA, magic link, social-connect, continue-as-user, lost password) can render through:

- **`Screen`** — page shell with top bar (WordPress logo + optional action) and centered content area. Caps at 400px (1-col) or 768px (`wide`, for the 2-col login/signup layout).
- **`SocialButton`** — neutral-gray social-login button (`Continue with Google/Apple/GitHub/PayPal/email`).
- **`CurrentUser`** — bordered card with avatar + name/email for "continue as X" surfaces.
- **`SocialConnectWidget`** — provider-logo + dotted-line + WordPress-logo composition for the `/log-in/social-connect` prompt.

The blocks compose WPDS primitives directly at the call site — `Button`, `TextControl`, `__experimentalVStack`, `Notice` — rather than wrapping them. Five Storybook recipes (`LostPassword`, `Login`, `SocialConnect`, `ContinueAsUser`, `TwoFactorCode`) document the call-site idiom every future migration will follow.

`Screen` is hand-rolled on plain HTML + `WordPressLogo`/`WordPressWordmark` from `@automattic/components`. Composing `@automattic/onboarding`'s `Step.*` was attempted in the closed predecessor (#110671) but required too many overrides of internal CSS.

## Why are these changes being made?

WordPress.com auth surfaces have drifted apart — each re-implements the same shell, social buttons, and heading typography slightly differently. 

<img width="1339" height="775" alt="Screenshot 2026-05-12 at 17 32 03" src="https://github.com/user-attachments/assets/f9bfa504-fc45-4c35-bfc2-2074d465bad6" />

This foundation lets every surface render through one canonical `Screen` shell with a handful of bespoke composition blocks. Future visual or behavior changes ship in one place instead of twelve. Unblocks the migration sequence DES-620 → DES-631.

## Testing Instructions

1. `yarn storybook:start`.
2. Open the `client/blocks/authentication` stories.
3. Walk the **Recipes** group at desktop (≥782px) and mobile (375px):
   - **LostPassword** — heading + input + CTA, left-aligned in 400px column.
   - **Login** — `wide` variant; 2-col grid at ≥782px, stacks 1-col below.
   - **SocialConnect** — Google logo + dotted connector + WordPress logo + primary CTA.
   - **ContinueAsUser** — bordered card with avatar bleeding to leading edge, primary CTA, link button.
   - **TwoFactorCode** — code input + CTA + alternate-method link.
4. Per-block stories (`Screen`, `SocialButton`, `CurrentUser`, `SocialConnectWidget`) cover each block's variants in isolation.

This PR is purely additive — no existing consumer is touched.

## Follow-ups

- The dashboard `Notice` from `client/dashboard/components/notice` depends on `--dashboard__background-color-*` CSS variables defined only inside the dashboard's `:root`. `Screen` declares fallbacks for those vars so the Notice renders correctly outside the dashboard scope. Worth a follow-up to globalize the variables or swap to a self-contained Notice.
- Auth surfaces don't currently support dark mode; this PR doesn't change that.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?