### PR TITLE
Domain search: fire 'Use a domain I own' Tracks on mobile empty state

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -449,7 +449,22 @@ const DomainSearchStep: StepType< {
 			return (
 				<>
 					{ config.allowsUsingOwnDomain && (
-						<Step.LinkButton onClick={ () => events.onExternalDomainClick( query ) }>
+						<Step.LinkButton
+							onClick={ () => {
+								// Mobile empty state replaced the in-body card,
+								// which fired this Tracks event. Fire it here so
+								// the mobile metric doesn't drop. Other top-bar
+								// paths stay silent — they always have been.
+								if ( isMobileViewport && ! query ) {
+									recordTracksEvent( 'calypso_domain_search_results_use_my_domain_button_click', {
+										section: 'signup',
+										source: 'top-bar-mobile',
+										flow_name: flow,
+									} );
+								}
+								events.onExternalDomainClick( query );
+							} }
+						>
 							{ __( 'Use a domain I own' ) }
 						</Step.LinkButton>
 					) }


### PR DESCRIPTION
Part of #110624

## Proposed Changes

* Fire `calypso_domain_search_results_use_my_domain_button_click` from the mobile top-bar "Use a domain I own" link (gated to `isMobileViewport && ! query`). Reuses the existing event name and props so aggregate counts reconcile to pre-#110624; passes `source: 'top-bar-mobile'` to slice the new surface.

## Why are these changes being made?

#110624 hid the in-body "Already have a domain?" card on mobile and moved the CTA to the top bar. The top-bar `Step.LinkButton` calls `events.onExternalDomainClick` directly, bypassing `WPCOMDomainSearch`'s event merger, so the event no longer fires on mobile empty state. The dip shows up on the mobile RSM dashboard (~32% → ~13% on 5/12); desktop is unchanged.

## Testing Instructions

1. Run a flow that hits the V2 domain-search step (e.g. `/setup/onboarding`). Watch Network for `pixel.wp.com/t.gif` or the Tracks debug panel.
2. **Mobile, empty state:** tap top-bar "Use a domain I own" → fires with `{ section: 'signup', source: 'top-bar-mobile', flow_name }`.
3. **Mobile, after search / desktop:** no new firings — existing in-body and in-results paths unchanged.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label?
- [ ] For changes affecting Jetpack: privacy label?