### PR TITLE
Image Studio: send currentPostId in the videoStudio client context

### DIFF
--- a/packages/image-studio/src/utils/client-context.test.ts
+++ b/packages/image-studio/src/utils/client-context.test.ts
@@ -51,6 +51,7 @@ interface VideoStoreSelectors {
 
 interface EditorStoreSelectors {
 	getEditedPostAttribute?: ( name: string ) => unknown;
+	getCurrentPostId?: () => number | undefined;
 }
 
 function setupSelect( {
@@ -219,6 +220,74 @@ describe( 'getClientContext', () => {
 
 		expect( ctx.videoStudio ).toBeDefined();
 		expect( ctx.videoStudio ).not.toHaveProperty( 'title' );
+	} );
+
+	it( 'includes currentPostId in the videoStudio payload when available', () => {
+		setupSelect( {
+			imageStudio: {
+				getImageStudioAttachmentId: () => null,
+				getIsImageStudioOpen: () => true,
+				getSelectedStyle: () => null,
+				getSelectedAspectRatio: () => null,
+				getEntryPoint: () => 'post_editor_feature_clip',
+				getBlockType: () => null,
+			},
+			videoStudio: {
+				getSelectedStyle: () => 'cinematic',
+			},
+			editor: {
+				getCurrentPostId: () => 12345,
+			},
+		} );
+
+		const ctx = getClientContext();
+
+		expect( ctx.videoStudio?.currentPostId ).toBe( 12345 );
+	} );
+
+	it( 'omits currentPostId when the editor store returns a falsy ID', () => {
+		setupSelect( {
+			imageStudio: {
+				getImageStudioAttachmentId: () => null,
+				getIsImageStudioOpen: () => true,
+				getSelectedStyle: () => null,
+				getSelectedAspectRatio: () => null,
+				getEntryPoint: () => 'post_editor_feature_clip',
+				getBlockType: () => null,
+			},
+			videoStudio: {
+				getSelectedStyle: () => 'cinematic',
+			},
+			editor: {
+				getCurrentPostId: () => 0,
+			},
+		} );
+
+		const ctx = getClientContext();
+
+		expect( ctx.videoStudio ).toBeDefined();
+		expect( ctx.videoStudio ).not.toHaveProperty( 'currentPostId' );
+	} );
+
+	it( 'omits currentPostId when the core/editor store is unavailable', () => {
+		setupSelect( {
+			imageStudio: {
+				getImageStudioAttachmentId: () => null,
+				getIsImageStudioOpen: () => true,
+				getSelectedStyle: () => null,
+				getSelectedAspectRatio: () => null,
+				getEntryPoint: () => 'post_editor_feature_clip',
+				getBlockType: () => null,
+			},
+			videoStudio: {
+				getSelectedStyle: () => 'cinematic',
+			},
+		} );
+
+		const ctx = getClientContext();
+
+		expect( ctx.videoStudio ).toBeDefined();
+		expect( ctx.videoStudio ).not.toHaveProperty( 'currentPostId' );
 	} );
 
 	it( 'sources the videoStudio id and attachment metadata from the video-studio store', () => {

--- a/packages/image-studio/src/utils/client-context.ts
+++ b/packages/image-studio/src/utils/client-context.ts
@@ -36,6 +36,7 @@ export interface VideoStudioData {
 	id: number | null;
 	style?: string;
 	title?: string;
+	currentPostId?: number;
 	metadata: ImageStudioMetadata;
 	entryPoint: ImageStudioEntryPoint | null;
 	blockType: string | null;
@@ -285,6 +286,7 @@ function detectImageEntity(): DetectedEntity | null {
 			// non-editor contexts (e.g. tests, uploads.php), so treat it as optional.
 			const editorSelect = select( 'core/editor' ) as unknown as {
 				getEditedPostAttribute?: ( name: string ) => unknown;
+				getCurrentPostId?: () => number | undefined;
 			};
 			const postTitle =
 				typeof editorSelect?.getEditedPostAttribute === 'function'
@@ -294,6 +296,17 @@ function detectImageEntity(): DetectedEntity | null {
 
 			if ( trimmedTitle ) {
 				videoStudio.title = trimmedTitle.slice( 0, POST_TITLE_MAX_LENGTH );
+			}
+
+			// Send the current post ID so the wpcom side can look up the
+			// featured image and composite the title onto it as the opener
+			// frame for the generated video.
+			const currentPostId =
+				typeof editorSelect?.getCurrentPostId === 'function'
+					? editorSelect.getCurrentPostId()
+					: undefined;
+			if ( typeof currentPostId === 'number' && currentPostId > 0 ) {
+				videoStudio.currentPostId = currentPostId;
 			}
 
 			return { videoStudio, isOpen, isVideo: true };


### PR DESCRIPTION
## Summary

Adds an optional `currentPostId` field to the `videoStudio` client-context payload sourced from `select( 'core/editor' ).getCurrentPostId()`. This lets the wpcom backend resolve the post's featured image (via `get_post_thumbnail_id()`) and composite the title onto it as the opener frame for the generated video.

The field is omitted when the editor store is unavailable or returns a falsy ID — the backend treats absence as "no featured image" and falls back to the existing text-only opener flow.

## Backend companion

Automattic/wpcom branch `rsm-feat/video-studio-featured-image-opener` (commit `5b906c8e5c3`).
That backend PR is also draft; both can ship together. Backend is null-safe — it has been on the wpcom branch ahead of this calypso change without any user-visible effect.

## Test plan

- [x] `yarn jest packages/image-studio/src/utils/client-context.test.ts` — all 24 cases pass, including 3 new cases:
  - `currentPostId` populated when the editor store returns a positive ID
  - `currentPostId` omitted when `getCurrentPostId()` returns 0
  - `currentPostId` omitted when the `core/editor` store is unavailable
- [ ] Manual: open Video Studio on a post that has a featured image, generate a video, confirm the opening frame visibly uses the featured image (requires backend PR deployed)
- [ ] Manual: open Video Studio on a post without a featured image — today's text-only opener still works

## Notes

- `currentPostId` was chosen over `featuredImageId` because the post ID is more reusable for future Video Studio features that need post context (excerpts, categories, etc.) without requiring further client-side changes.
- The backend never trusts the post ID blindly — it validates the mime type (jpeg/png only) and size (≤ 4 MB) of the resolved attachment before sending bytes to Gemini.

🤖 Generated with [Claude Code](https://claude.com/claude-code)