### PR TITLE
Reader Social: link mentions in posts via data-handle (CM-725)

### DIFF
--- a/client/reader/social/components/post-card/analytics-context.tsx
+++ b/client/reader/social/components/post-card/analytics-context.tsx
@@ -11,11 +11,21 @@ import type { SocialPost } from '../../types';
 
 export interface SocialProfileRefInput {
 	// Universal protocol-agnostic identifier — DID for atmosphere, numeric
-	// account id for Mastodon. Per-protocol resolvers decide which they
-	// understand and which to validate.
+	// account id for Mastodon, canonical AP actor URL for Fediverse. Per-
+	// protocol resolvers decide which they understand and which to validate.
 	id?: string | null;
 	// Atmosphere-named alias kept for back-compat with the slice-6 wiring.
 	did?: string | null;
+	// User-readable identifier. Across protocols: a bsky handle
+	// (`alice.bsky.social`) for atmosphere, a webfinger handle
+	// (`alice@example.com`) for Mastodon and Fediverse. Mention anchors
+	// in post HTML can stamp `data-handle="<value>"` alongside `data-id`
+	// (CM-725 wires this for Fediverse and Mastodon); the body / bio
+	// click handlers read it and pass it here so per-protocol resolvers
+	// can build a cleaner user-readable URL than they would from the
+	// raw `data-id` (which carries actor URLs or numeric ids). When
+	// `data-handle` is absent the handlers broadcast `data-id` to this
+	// field as a back-compat fallback (atmosphere today).
 	handle?: string | null;
 }
 

--- a/client/reader/social/components/post-card/post-card-body.tsx
+++ b/client/reader/social/components/post-card/post-card-body.tsx
@@ -41,33 +41,44 @@ export function PostCardBody( { post }: PostCardBodyProps ) {
 			return;
 		}
 		const dataId = anchor.getAttribute( 'data-id' );
-		if ( dataId ) {
-			// Set all three fields to the data-id value: per-protocol resolvers
-			// pick whichever they understand and validate. Atmosphere validates
-			// handle then DID; Mastodon reads `id`. The backend stamps either a
-			// DID (atmosphere) or a numeric account id (Mastodon) when available
-			// and falls back to a handle on atmosphere when no DID is known.
+		const dataHandle = anchor.getAttribute( 'data-handle' );
+		if ( dataId || dataHandle ) {
+			// Per-protocol resolvers pick whichever field they understand and
+			// validate. Atmosphere validates handle then DID; Mastodon reads
+			// `id`; Fediverse (CM-725) prefers the user-readable webfinger from
+			// `data-handle` over the canonical AP actor URL in `data-id`. The
+			// backend stamps either a DID (atmosphere), a numeric account id
+			// (Mastodon), or an AP actor URL + webfinger pair (Fediverse).
+			// When `data-handle` is absent (atmosphere / Mastodon), broadcast
+			// `data-id` to the handle slot so the existing resolver fallback
+			// keeps working.
 			const inAppUrl =
-				analytics?.getProfileUrl?.( { id: dataId, handle: dataId, did: dataId } ) ?? null;
+				analytics?.getProfileUrl?.( {
+					id: dataId,
+					handle: dataHandle ?? dataId,
+					did: dataId,
+				} ) ?? null;
 			if ( inAppUrl ) {
 				event.preventDefault();
 				page( inAppUrl );
 				return;
 			}
-			// data-id present but resolver returned null — likely a backend ↔
-			// frontend desync (validator rejected an id shape we didn't anticipate,
-			// or the protocol shell forgot to bind getProfileUrl). Surface so it's
-			// observable instead of silently routing to the external host with no
-			// analytics signal.
+			// data-id / data-handle present but resolver returned null — likely
+			// a backend ↔ frontend desync (validator rejected a shape we didn't
+			// anticipate, or the protocol shell forgot to bind getProfileUrl).
+			// Surface so it's observable instead of silently routing to the
+			// external host with no analytics signal.
 			// eslint-disable-next-line no-console
-			console.warn( '[reader-social] data-id mention anchor not resolved to in-app URL', {
+			console.warn( '[reader-social] mention anchor not resolved to in-app URL', {
 				dataId,
+				dataHandle,
 				href: anchor.getAttribute( 'href' ),
 				source: analytics?.source,
 			} );
 			analytics?.onClick( `calypso_reader_${ analytics.source }_timeline_mention_unresolved`, {
 				connection_id: analytics.connectionId,
 				data_id: dataId,
+				data_handle: dataHandle,
 			} );
 			return;
 		}

--- a/client/reader/social/components/post-card/post-card-body.tsx
+++ b/client/reader/social/components/post-card/post-card-body.tsx
@@ -63,6 +63,9 @@ export function PostCardBody( { post }: PostCardBodyProps ) {
 				page( inAppUrl );
 				return;
 			}
+			if ( ! analytics ) {
+				return;
+			}
 			// data-id / data-handle present but resolver returned null — likely
 			// a backend ↔ frontend desync (validator rejected a shape we didn't
 			// anticipate, or the protocol shell forgot to bind getProfileUrl).
@@ -73,9 +76,9 @@ export function PostCardBody( { post }: PostCardBodyProps ) {
 				dataId,
 				dataHandle,
 				href: anchor.getAttribute( 'href' ),
-				source: analytics?.source,
+				source: analytics.source,
 			} );
-			analytics?.onClick( `calypso_reader_${ analytics.source }_timeline_mention_unresolved`, {
+			analytics.onClick( `calypso_reader_${ analytics.source }_timeline_mention_unresolved`, {
 				connection_id: analytics.connectionId,
 				data_id: dataId,
 				data_handle: dataHandle,
@@ -90,15 +93,18 @@ export function PostCardBody( { post }: PostCardBodyProps ) {
 				page( inAppTagUrl );
 				return;
 			}
+			if ( ! analytics ) {
+				return;
+			}
 			// data-tag present but resolver returned null — backend ↔ frontend desync.
 			// Same observability pattern as the data-id miss path.
 			// eslint-disable-next-line no-console
 			console.warn( '[reader-social] data-tag anchor not resolved to in-app URL', {
 				dataTag,
 				href: anchor.getAttribute( 'href' ),
-				source: analytics?.source,
+				source: analytics.source,
 			} );
-			analytics?.onClick( `calypso_reader_${ analytics.source }_timeline_tag_unresolved`, {
+			analytics.onClick( `calypso_reader_${ analytics.source }_timeline_tag_unresolved`, {
 				connection_id: analytics.connectionId,
 				data_tag: dataTag,
 			} );

--- a/client/reader/social/components/post-card/sanitize-post-html.ts
+++ b/client/reader/social/components/post-card/sanitize-post-html.ts
@@ -4,10 +4,13 @@ import type { Config } from 'dompurify';
 const CONFIG = {
 	ALLOWED_TAGS: [ 'p', 'br', 'a' ],
 	// `data-id` carries the protocol's stable author identifier (DID for
-	// atmosphere, numeric account id for Mastodon) on @-mention anchors,
-	// emitted by the backend so the client can route mentions in-app
-	// without parsing the href.
-	ALLOWED_ATTR: [ 'href', 'rel', 'target', 'data-id', 'data-tag' ],
+	// atmosphere, numeric account id for Mastodon, canonical AP actor URL
+	// for Fediverse) on @-mention anchors, emitted by the backend so the
+	// client can route mentions in-app without parsing the href.
+	// `data-handle` carries a user-readable webfinger handle alongside
+	// `data-id` for Fediverse mentions (CM-725) so the in-app URL surfaces
+	// the readable handle instead of the long actor URL.
+	ALLOWED_ATTR: [ 'href', 'rel', 'target', 'data-id', 'data-handle', 'data-tag' ],
 	// DOMPurify allows every data-* attribute by default; restrict to the
 	// explicit allow-list above so a future backend change can't smuggle
 	// a new data-* attribute (e.g. `data-tracking`) through to the DOM.

--- a/client/reader/social/components/post-card/test/post-card-body.test.tsx
+++ b/client/reader/social/components/post-card/test/post-card-body.test.tsx
@@ -236,6 +236,29 @@ describe( 'PostCardBody', () => {
 				} )
 			);
 		} );
+
+		it( 'is a no-op when no analytics provider is in scope (slim layout)', async () => {
+			// Defensive guard: when the body is rendered outside a
+			// `<SocialAnalyticsProvider>` (tests, embedded contexts), the
+			// click handler must short-circuit without throwing. The
+			// optional-chained resolver call already returns null on its own,
+			// but the explicit `if ( ! analytics ) return;` keeps the warn /
+			// tracks path on the safe side of any future refactor that drops
+			// the optional chain on `analytics.source` / `connectionId`.
+			const user = userEvent.setup();
+			const { getByText } = render(
+				<PostCardBody
+					post={ baseHtml(
+						'<p><a href="https://example.com/@alice"' +
+							' data-id="https://example.com/users/alice"' +
+							' data-handle="alice@example.com">@alice</a></p>'
+					) }
+				/>
+			);
+			await user.click( getByText( '@alice' ) );
+			expect( pageMock ).not.toHaveBeenCalled();
+			expect( onClick ).not.toHaveBeenCalled();
+		} );
 	} );
 
 	describe( 'data-tag hashtag interception', () => {

--- a/client/reader/social/components/post-card/test/post-card-body.test.tsx
+++ b/client/reader/social/components/post-card/test/post-card-body.test.tsx
@@ -177,6 +177,65 @@ describe( 'PostCardBody', () => {
 			await user.keyboard( '[/MetaLeft]' );
 			expect( pageMock ).not.toHaveBeenCalled();
 		} );
+
+		it( 'passes data-handle as ref.handle separately from data-id (CM-725 Fediverse / Mastodon)', async () => {
+			// When the backend stamps both `data-id` (canonical id — actor URL
+			// for Fediverse, numeric for Mastodon) and `data-handle`
+			// (webfinger), the click handler routes them to distinct fields so
+			// per-protocol resolvers can build a clean user-readable URL from
+			// the handle rather than the raw id.
+			const user = userEvent.setup();
+			const getProfileUrl = jest.fn( ( ref: { handle?: string | null } ) =>
+				ref.handle ? `/reader/fediverse/7/profile/${ ref.handle }` : null
+			);
+			const { getByText } = renderWithAnalytics(
+				'<p><a href="https://example.com/@alice"' +
+					' data-id="https://example.com/users/alice"' +
+					' data-handle="alice@example.com">@alice</a></p>',
+				getProfileUrl
+			);
+			await user.click( getByText( '@alice' ) );
+			expect( getProfileUrl ).toHaveBeenCalledWith( {
+				id: 'https://example.com/users/alice',
+				handle: 'alice@example.com',
+				did: 'https://example.com/users/alice',
+			} );
+			expect( pageMock ).toHaveBeenCalledWith( '/reader/fediverse/7/profile/alice@example.com' );
+		} );
+
+		it( 'routes when only data-handle is present (no data-id) — pure-webfinger anchor', async () => {
+			const user = userEvent.setup();
+			const getProfileUrl = jest.fn( ( ref: { handle?: string | null } ) =>
+				ref.handle ? `/reader/fediverse/7/profile/${ ref.handle }` : null
+			);
+			const { getByText } = renderWithAnalytics(
+				'<p><a href="https://example.com/@alice"' +
+					' data-handle="alice@example.com">@alice</a></p>',
+				getProfileUrl
+			);
+			await user.click( getByText( '@alice' ) );
+			expect( pageMock ).toHaveBeenCalledWith( '/reader/fediverse/7/profile/alice@example.com' );
+		} );
+
+		it( 'includes data_handle on the unresolved Tracks payload when present', async () => {
+			const user = userEvent.setup();
+			const getProfileUrl = jest.fn( () => null );
+			const { getByText } = renderWithAnalytics(
+				'<p><a href="https://example.com/@alice"' +
+					' data-id="https://example.com/users/alice"' +
+					' data-handle="alice@example.com">@alice</a></p>',
+				getProfileUrl
+			);
+			await user.click( getByText( '@alice' ) );
+			expect( onClick ).toHaveBeenCalledWith(
+				'calypso_reader_mastodon_timeline_mention_unresolved',
+				expect.objectContaining( {
+					connection_id: 7,
+					data_id: 'https://example.com/users/alice',
+					data_handle: 'alice@example.com',
+				} )
+			);
+		} );
 	} );
 
 	describe( 'data-tag hashtag interception', () => {

--- a/client/reader/social/components/post-card/test/sanitize-post-html.test.ts
+++ b/client/reader/social/components/post-card/test/sanitize-post-html.test.ts
@@ -91,6 +91,14 @@ describe( 'sanitizePostHtml', () => {
 		expect( out ).toContain( 'data-id="alice.bsky.social"' );
 	} );
 
+	it( 'preserves data-handle alongside data-id on Fediverse / Mastodon @-mention anchors (CM-725)', () => {
+		const html =
+			'<p><a href="https://example.com/@alice" data-id="https://example.com/users/alice" data-handle="alice@example.com">@alice@example.com</a></p>';
+		const out = sanitizePostHtml( html );
+		expect( out ).toContain( 'data-id="https://example.com/users/alice"' );
+		expect( out ).toContain( 'data-handle="alice@example.com"' );
+	} );
+
 	it( 'strips other data-* attributes', () => {
 		const html =
 			'<p><a href="https://x.example" data-id="42" data-evil="payload" data-tracking="x">y</a></p>';

--- a/client/reader/social/profile-card.tsx
+++ b/client/reader/social/profile-card.tsx
@@ -54,7 +54,7 @@ export interface SocialProfileCardProps {
 // route hashtag clicks in-app via `getTagUrl` instead of leaking to bsky.app.
 const BIO_SANITIZE_CONFIG = {
 	ALLOWED_TAGS: [ 'p', 'br', 'a', 'span' ],
-	ALLOWED_ATTR: [ 'href', 'rel', 'target', 'class', 'data-id', 'data-tag' ],
+	ALLOWED_ATTR: [ 'href', 'rel', 'target', 'class', 'data-id', 'data-handle', 'data-tag' ],
 	// DOMPurify allows every data-* attribute by default; restrict to the
 	// explicit allow-list above so a future backend change can't smuggle a
 	// new data-* attribute (e.g. `data-tracking`) through to the DOM.
@@ -120,14 +120,23 @@ export function SocialProfileCard( {
 			return;
 		}
 		const dataId = anchor.getAttribute( 'data-id' );
-		if ( dataId ) {
-			// Set all three fields to the data-id value: per-protocol resolvers
-			// pick whichever they understand and validate. Atmosphere validates
-			// handle then DID; Mastodon reads `id`. The backend stamps either a
-			// DID (atmosphere) or a numeric account id (Mastodon) when available
-			// and falls back to a handle on atmosphere when no DID is known.
+		const dataHandle = anchor.getAttribute( 'data-handle' );
+		if ( dataId || dataHandle ) {
+			// Per-protocol resolvers pick whichever field they understand and
+			// validate. Atmosphere validates handle then DID; Mastodon reads
+			// `id`; Fediverse (CM-725) prefers the user-readable webfinger from
+			// `data-handle` over the canonical AP actor URL in `data-id`. The
+			// backend stamps either a DID (atmosphere), a numeric account id +
+			// webfinger (Mastodon), or an AP actor URL + webfinger pair
+			// (Fediverse). When `data-handle` is absent (atmosphere today),
+			// broadcast `data-id` to the handle slot so the existing resolver
+			// fallback keeps working.
 			const inAppUrl =
-				analytics?.getProfileUrl?.( { id: dataId, handle: dataId, did: dataId } ) ?? null;
+				analytics?.getProfileUrl?.( {
+					id: dataId,
+					handle: dataHandle ?? dataId,
+					did: dataId,
+				} ) ?? null;
 			if ( inAppUrl ) {
 				event.preventDefault();
 				page( inAppUrl );
@@ -136,18 +145,21 @@ export function SocialProfileCard( {
 			if ( ! analytics ) {
 				return;
 			}
-			// data-id present but resolver returned null — likely a backend ↔
-			// frontend desync. Surface the event so it's observable instead of
-			// silently routing to the external host with no analytics signal.
+			// data-id / data-handle present but resolver returned null — likely
+			// a backend ↔ frontend desync. Surface the event so it's observable
+			// instead of silently routing to the external host with no
+			// analytics signal.
 			// eslint-disable-next-line no-console
-			console.warn( '[reader-social] data-id mention anchor not resolved to in-app URL', {
+			console.warn( '[reader-social] mention anchor not resolved to in-app URL', {
 				dataId,
+				dataHandle,
 				href: anchor.getAttribute( 'href' ),
 				source: analytics.source,
 			} );
 			analytics.onClick( `calypso_reader_${ analytics.source }_timeline_mention_unresolved`, {
 				connection_id: analytics.connectionId,
 				data_id: dataId,
+				data_handle: dataHandle,
 			} );
 			return;
 		}

--- a/client/reader/social/test/profile-card.test.tsx
+++ b/client/reader/social/test/profile-card.test.tsx
@@ -289,6 +289,23 @@ describe( 'SocialProfileCard', () => {
 		expect( link ).toHaveAttribute( 'data-id', 'alice.bsky.social' );
 	} );
 
+	it( 'preserves data-handle alongside data-id on bio mention anchors (CM-725)', () => {
+		const { container } = render(
+			<SocialProfileCard
+				bioHtml={
+					'<p><a href="https://example.com/@alice"' +
+					' data-id="https://example.com/users/alice"' +
+					' data-handle="alice@example.com">@alice@example.com</a></p>'
+				}
+				statsLabel="Profile stats"
+				stats={ [ { key: 'followers', count: 0, label: 'followers' } ] }
+			/>
+		);
+		const link = container.querySelector( '.social-profile-card__bio a' );
+		expect( link ).toHaveAttribute( 'data-id', 'https://example.com/users/alice' );
+		expect( link ).toHaveAttribute( 'data-handle', 'alice@example.com' );
+	} );
+
 	it( 'strips arbitrary data-* attributes from bio anchors', () => {
 		const { container } = render(
 			<SocialProfileCard
@@ -455,6 +472,31 @@ describe( 'SocialProfileCard — bio mention click routing', () => {
 		);
 		await user.click( getByText( '@alice' ) );
 		expect( pageMock ).not.toHaveBeenCalled();
+	} );
+
+	it( 'passes data-handle as ref.handle separately from data-id (CM-725)', async () => {
+		// Bios on Fediverse / Mastodon profile pages can carry mention
+		// anchors stamped with both `data-id` (canonical id — actor URL
+		// or numeric) and `data-handle` (webfinger). The bio click
+		// handler routes them to distinct ref fields so resolvers can
+		// build a clean user-readable URL from the handle.
+		const user = userEvent.setup();
+		const getProfileUrl = jest.fn( ( ref: { handle?: string | null } ) =>
+			ref.handle ? `/reader/fediverse/7/profile/${ ref.handle }` : null
+		);
+		const { getByText } = renderInsideProvider(
+			'<p><a href="https://example.com/@alice"' +
+				' data-id="https://example.com/users/alice"' +
+				' data-handle="alice@example.com">@alice</a></p>',
+			getProfileUrl
+		);
+		await user.click( getByText( '@alice' ) );
+		expect( getProfileUrl ).toHaveBeenCalledWith( {
+			id: 'https://example.com/users/alice',
+			handle: 'alice@example.com',
+			did: 'https://example.com/users/alice',
+		} );
+		expect( pageMock ).toHaveBeenCalledWith( '/reader/fediverse/7/profile/alice@example.com' );
 	} );
 } );
 


### PR DESCRIPTION
Part of CM-725

## Proposed Changes

* Add `data-handle` to the DOMPurify allow-list in `sanitize-post-html.ts` (post body) and `BIO_SANITIZE_CONFIG` (profile-card bio) so the attribute survives sanitisation.
* `PostCardBody.handleClick` and `SocialProfileCard.handleBioClick` now read `data-handle` alongside `data-id`. When present, the webfinger is passed as `ref.handle` separately from the canonical id in `ref.id`. When absent, the existing broadcast-`data-id`-to-all-three-fields behaviour is preserved (atmosphere back-compat).
* The unresolved-mention Tracks payload gains a `data_handle` field so dashboards can split a backend ↔ frontend desync by which attribute was present.

## Why are these changes being made?

Fediverse mention anchors in post HTML stamp `data-id="<actor-URL>"` + `data-handle="<webfinger>"` (Mastodon ships the same shape after its backend rewrite). Today the client only reads `data-id` and broadcasts it to all three ref fields, so Fediverse routes via the long actor URL rather than the user-readable handle.

With this change, Fediverse's existing `buildProfileUrl` (which already prefers `ref.handle` over `ref.id`) produces clean URLs like `/reader/fediverse/<id>/profile/alice@example.com` for free. Mastodon likewise gets the option of cleaner handle-routed URLs once its panel-level preference is flipped to handle-first. Atmosphere keeps working unchanged: it doesn't stamp `data-handle`, the click handlers fall back to the `data-id` broadcast, and atmosphere's resolver validates `ref.handle` against `HANDLE_RE` as before.

## Testing Instructions

1. Make sure the Fediverse plugin and wpcom backend land the `data-handle` HTML stamp.
2. In Reader, navigate to `/reader/fediverse/<connection-id>/timeline`.
3. Find a post containing an `@-mention` to another Fediverse user (e.g. `@alice@example.com`).
4. Click the mention link.
5. **Expected**: the page navigates in-app to `/reader/fediverse/<connection-id>/profile/alice@example.com` (user-readable webfinger in the URL), the profile loads, and you stay within Reader.
6. Repeat for a Mastodon mention on a Mastodon post once that backend ships `data-handle` — the same handle-shaped URL should land if the panel's resolver preference is flipped.
7. Atmosphere mentions (no `data-handle`) should continue to route via the existing `data-id` path.
8. Modifier-clicks (cmd / ctrl / middle / shift / alt) on mentions should still open the external link in a new tab.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed?
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [x] Have you tested accessibility for your changes? Modifier-clicks still pass through; keyboard activation on the underlying anchor still works.
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?
