### PR TITLE
Reader Social: shared <SocialAvatar> with onError fallback

### DIFF
--- a/client/reader/social/account-row.tsx
+++ b/client/reader/social/account-row.tsx
@@ -1,6 +1,7 @@
 import './account-row.scss';
 
 import { useTranslate } from 'i18n-calypso';
+import { SocialAvatar } from './avatar';
 import { FollowButton } from './follow-button';
 
 export interface SocialAccountRowFollowState {
@@ -55,8 +56,10 @@ export function SocialAccountRow( props: SocialAccountRowProps ) {
 			<div className="social-account-row__avatar">
 				{ /* The display name is rendered as a sibling text node; mark the
 				   avatar decorative so screen readers don't double-announce it.
-				   Mirrors the SocialProfileCard pattern at profile-card.tsx. */ }
-				{ avatarUrl ? <img src={ avatarUrl } alt="" /> : null }
+				   Mirrors the SocialProfileCard pattern at profile-card.tsx.
+				   The container's `background` SCSS color is the visible fallback
+				   when there is no avatar URL or when the image fails to load. */ }
+				<SocialAvatar src={ avatarUrl } alt="" />
 			</div>
 			<div className="social-account-row__main">
 				<div className="social-account-row__identity">

--- a/client/reader/social/avatar.tsx
+++ b/client/reader/social/avatar.tsx
@@ -1,0 +1,57 @@
+/**
+ * Thin `<img>` wrapper used by every Reader Social surface that renders
+ * a remote avatar or banner image. Two reasons it exists:
+ *
+ *  1. Reader Social surfaces consume URLs from third-party services
+ *     (Bluesky CDN, Mastodon instances, AP servers). Those URLs can 404,
+ *     resolve to a stale path after an instance migration, or fail at
+ *     load time on a slow network. Without an `onError` fallback the
+ *     browser leaves a broken-image icon in the layout — visible in
+ *     every avatar slot across timeline / profile / notifications /
+ *     account-row / compose-pill surfaces.
+ *  2. Each surface already has a "no src" branch with a tailored
+ *     placeholder element (a `<div>` sized to the avatar slot, a
+ *     `<span>` with placeholder styling, etc.). The fallback for a
+ *     load failure should reuse that same placeholder, not introduce a
+ *     second visual state. This component takes the placeholder as a
+ *     `fallback` prop and renders it on either branch (no src OR
+ *     `onError`), so the call site stays the single source of truth
+ *     for what "no image" looks like.
+ *
+ * The `errored` flag resets when `src` changes so a new URL gets a
+ * fresh chance to load — useful for surfaces that re-render with a
+ * different actor (account-row inside an infinite feed, compose-pill
+ * after the user switches connections).
+ */
+
+import { useEffect, useState } from 'react';
+import type { ImgHTMLAttributes, ReactNode } from 'react';
+
+export interface SocialAvatarProps
+	extends Omit< ImgHTMLAttributes< HTMLImageElement >, 'onError' | 'src' > {
+	src: string | null | undefined;
+	/**
+	 * Rendered when `src` is null/empty OR when the `<img>` fired its
+	 * `onError` event. Defaults to `null` (no element) so callers that
+	 * only want to hide a broken banner without showing anything in its
+	 * place don't have to pass `fallback={ null }` explicitly.
+	 */
+	fallback?: ReactNode;
+}
+
+export function SocialAvatar( { src, fallback = null, alt = '', ...imgProps }: SocialAvatarProps ) {
+	const [ errored, setErrored ] = useState( false );
+
+	// Reset on src change so a re-render with a different URL gets to try
+	// loading from scratch (the previous URL's error shouldn't poison the
+	// new one).
+	useEffect( () => {
+		setErrored( false );
+	}, [ src ] );
+
+	if ( ! src || errored ) {
+		return <>{ fallback }</>;
+	}
+
+	return <img src={ src } alt={ alt } onError={ () => setErrored( true ) } { ...imgProps } />;
+}

--- a/client/reader/social/components/notifications-list/notification-item.tsx
+++ b/client/reader/social/components/notifications-list/notification-item.tsx
@@ -7,6 +7,7 @@ import {
 } from '@wordpress/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import { SocialAvatar } from '../../avatar';
 import type {
 	AtmosphereNotification,
 	AtmosphereNotificationCanonicalType,
@@ -55,12 +56,15 @@ export function SocialNotificationItem( { notification }: Props ) {
 
 	const body = (
 		<HStack alignment="flex-start" spacing={ 3 }>
-			{ actor.avatar_url ? (
-				// Decorative: the actor identity is announced via the row aria-label.
-				<img className="social-notification-item__avatar" src={ actor.avatar_url } alt="" />
-			) : (
-				<span className="social-notification-item__avatar is-placeholder" aria-hidden />
-			) }
+			{ /* Decorative: the actor identity is announced via the row aria-label. */ }
+			<SocialAvatar
+				className="social-notification-item__avatar"
+				src={ actor.avatar_url }
+				alt=""
+				fallback={
+					<span className="social-notification-item__avatar is-placeholder" aria-hidden />
+				}
+			/>
 			<VStack spacing={ 1 } className="social-notification-item__body">
 				<span className="social-notification-item__line">
 					<span className="social-notification-item__actor">{ actorName }</span>{ ' ' }

--- a/client/reader/social/components/notifications-list/stacked-notification.tsx
+++ b/client/reader/social/components/notifications-list/stacked-notification.tsx
@@ -6,6 +6,7 @@ import {
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useId, useState } from 'react';
+import { SocialAvatar } from '../../avatar';
 import { SocialNotificationItem } from './notification-item';
 import type { StackedRow, StackableCanonicalType } from './group-notifications';
 
@@ -176,22 +177,17 @@ export function StackedNotification( { stack, onExpandedChange }: Props ) {
 	const visualHeader = (
 		<HStack alignment="flex-start" spacing={ 3 }>
 			<div className="social-notifications-stack__avatars">
-				{ visibleAvatars.map( ( m ) =>
-					m.actor.avatar_url ? (
-						<img
-							key={ m.id }
-							className="social-notifications-stack__avatar"
-							src={ m.actor.avatar_url }
-							alt=""
-						/>
-					) : (
-						<span
-							key={ m.id }
-							className="social-notifications-stack__avatar is-placeholder"
-							aria-hidden
-						/>
-					)
-				) }
+				{ visibleAvatars.map( ( m ) => (
+					<SocialAvatar
+						key={ m.id }
+						className="social-notifications-stack__avatar"
+						src={ m.actor.avatar_url }
+						alt=""
+						fallback={
+							<span className="social-notifications-stack__avatar is-placeholder" aria-hidden />
+						}
+					/>
+				) ) }
 				{ overflowCount > 0 && (
 					<span className="social-notifications-stack__overflow" aria-hidden>
 						{ '+' + overflowCount }

--- a/client/reader/social/components/post-card/post-card-header.tsx
+++ b/client/reader/social/components/post-card/post-card-header.tsx
@@ -1,6 +1,7 @@
 import { TimeSince } from '@automattic/components';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { SocialAvatar } from '../../avatar';
 import { useSocialAnalytics } from './analytics-context';
 import type { SocialPost } from '../../types';
 import type React from 'react';
@@ -89,20 +90,22 @@ export function PostCardHeader( {
 		} );
 	};
 
-	const avatarEl: ReactNode = post.author.avatar ? (
-		<img
+	const avatarPlaceholder: ReactNode = (
+		<div
+			className="social-post-card-header__avatar social-post-card-header__avatar--placeholder"
+			style={ { width: avatarSize, height: avatarSize } }
+			aria-hidden="true"
+		/>
+	);
+	const avatarEl: ReactNode = (
+		<SocialAvatar
 			src={ post.author.avatar }
 			alt=""
 			width={ avatarSize }
 			height={ avatarSize }
 			loading="lazy"
 			className="social-post-card-header__avatar"
-		/>
-	) : (
-		<div
-			className="social-post-card-header__avatar social-post-card-header__avatar--placeholder"
-			style={ { width: avatarSize, height: avatarSize } }
-			aria-hidden="true"
+			fallback={ avatarPlaceholder }
 		/>
 	);
 

--- a/client/reader/social/composer/triggers/timeline-compose-pill.tsx
+++ b/client/reader/social/composer/triggers/timeline-compose-pill.tsx
@@ -1,6 +1,7 @@
 import { Icon, plus } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import { SocialAvatar } from '../../avatar';
 import { useComposer, type ComposerEntryPoint } from '../composer-provider';
 
 interface Props {
@@ -30,14 +31,18 @@ export function TimelineComposePill( { avatar, placeholder, entryPoint, classNam
 			aria-label={ placeholderText }
 			onClick={ () => openComposer( { kind: 'standalone', entry_point: entryPoint } ) }
 		>
-			{ avatar ? (
-				<img className="social-compose-pill__avatar" src={ avatar } alt="" aria-hidden="true" />
-			) : (
-				<span
-					className="social-compose-pill__avatar social-compose-pill__avatar--placeholder"
-					aria-hidden="true"
-				/>
-			) }
+			<SocialAvatar
+				src={ avatar }
+				alt=""
+				className="social-compose-pill__avatar"
+				aria-hidden="true"
+				fallback={
+					<span
+						className="social-compose-pill__avatar social-compose-pill__avatar--placeholder"
+						aria-hidden="true"
+					/>
+				}
+			/>
 			<span className="social-compose-pill__placeholder">{ placeholderText }</span>
 			<Icon className="social-compose-pill__icon" icon={ plus } size={ 18 } />
 		</button>

--- a/client/reader/social/index.ts
+++ b/client/reader/social/index.ts
@@ -1,5 +1,8 @@
 import './style.scss';
 
+export { SocialAvatar } from './avatar';
+export type { SocialAvatarProps } from './avatar';
+
 export { SocialProfileCard } from './profile-card';
 export type { SocialProfileCardProps, SocialProfileStat } from './profile-card';
 

--- a/client/reader/social/profile-card.tsx
+++ b/client/reader/social/profile-card.tsx
@@ -1,6 +1,7 @@
 import page from '@automattic/calypso-router';
 import { formatNumberCompact } from '@automattic/number-formatters';
 import { useMemo } from 'react';
+import { SocialAvatar } from './avatar';
 import { useSocialAnalytics } from './components/post-card/analytics-context';
 import { sanitizeReaderSocialHtml } from './components/post-card/sanitize-post-html';
 import type { TranslateResult } from 'i18n-calypso';
@@ -221,27 +222,9 @@ export function SocialProfileCard( {
 
 	return (
 		<div className="social-profile-card">
-			{ banner ? (
-				<img
-					src={ banner }
-					alt=""
-					className="social-profile-card__banner"
-					onError={ ( event ) => {
-						event.currentTarget.style.display = 'none';
-					} }
-				/>
-			) : null }
+			<SocialAvatar src={ banner } alt="" className="social-profile-card__banner" />
 			<div className="social-profile-card__header-row">
-				{ avatar ? (
-					<img
-						src={ avatar }
-						alt=""
-						className="social-profile-card__avatar"
-						onError={ ( event ) => {
-							event.currentTarget.style.display = 'none';
-						} }
-					/>
-				) : null }
+				<SocialAvatar src={ avatar } alt="" className="social-profile-card__avatar" />
 				{ headerActions ? (
 					<div className="social-profile-card__header-actions">{ headerActions }</div>
 				) : null }

--- a/client/reader/social/profile-card.tsx
+++ b/client/reader/social/profile-card.tsx
@@ -222,9 +222,24 @@ export function SocialProfileCard( {
 
 	return (
 		<div className="social-profile-card">
-			<SocialAvatar src={ banner } alt="" className="social-profile-card__banner" />
+			{ /* `fallback` shares the same SCSS class as the `<img>` so the
+			   placeholder div keeps the avatar/banner box dimensions and the
+			   solid background color when the URL is missing or the image
+			   fails to load. Without it the layout slot collapses entirely
+			   and we get a "no placeholder" gap in the card. */ }
+			<SocialAvatar
+				src={ banner }
+				alt=""
+				className="social-profile-card__banner"
+				fallback={ <div className="social-profile-card__banner" aria-hidden="true" /> }
+			/>
 			<div className="social-profile-card__header-row">
-				<SocialAvatar src={ avatar } alt="" className="social-profile-card__avatar" />
+				<SocialAvatar
+					src={ avatar }
+					alt=""
+					className="social-profile-card__avatar"
+					fallback={ <div className="social-profile-card__avatar" aria-hidden="true" /> }
+				/>
 				{ headerActions ? (
 					<div className="social-profile-card__header-actions">{ headerActions }</div>
 				) : null }

--- a/client/reader/social/style.scss
+++ b/client/reader/social/style.scss
@@ -13,7 +13,7 @@
 	// Visible behind the `<img>` while it loads, and serves as the
 	// placeholder colour when `<SocialAvatar>` swaps the failed image
 	// out for the same-class placeholder `<div>`.
-	background: var( --studio-gray-5, #dcdcde );
+	background: var( --studio-gray-5 );
 }
 
 .social-profile-card__header-row {

--- a/client/reader/social/style.scss
+++ b/client/reader/social/style.scss
@@ -10,6 +10,10 @@
 	block-size: clamp( 80px, 28vw, 200px );
 	object-fit: cover;
 	border-radius: 4px;
+	// Visible behind the `<img>` while it loads, and serves as the
+	// placeholder colour when `<SocialAvatar>` swaps the failed image
+	// out for the same-class placeholder `<div>`.
+	background: var( --studio-gray-5, #dcdcde );
 }
 
 .social-profile-card__header-row {

--- a/client/reader/social/test/profile-card.test.tsx
+++ b/client/reader/social/test/profile-card.test.tsx
@@ -731,7 +731,7 @@ describe( 'SocialProfileCard — rich variant', () => {
 		expect( screen.getByRole( 'heading', { level: 2, name: 'Alice' } ) ).toBeVisible();
 	} );
 
-	it( 'unmounts the banner image on load failure (SocialAvatar onError → null fallback)', () => {
+	it( 'swaps the banner image for a same-class placeholder div on load failure', () => {
 		const { container } = render(
 			<SocialProfileCard
 				banner="https://cdn.example/broken.jpg"
@@ -740,17 +740,18 @@ describe( 'SocialProfileCard — rich variant', () => {
 				statsLabel="Profile stats"
 			/>
 		);
-		const banner = container.querySelector( '.social-profile-card__banner' );
-		expect( banner ).not.toBeNull();
+		const bannerImg = container.querySelector( 'img.social-profile-card__banner' );
+		expect( bannerImg ).not.toBeNull();
 		// `fireEvent.error` triggers React's synthetic onError handler, which
 		// flips the SocialAvatar's `errored` state and renders the fallback
-		// (`null` for the banner — the band collapses entirely so a broken
-		// CDN URL doesn't leak a broken-image icon into the layout).
-		fireEvent.error( banner! );
-		expect( container.querySelector( '.social-profile-card__banner' ) ).toBeNull();
+		// (a `<div>` with the same SCSS class) so the band keeps its
+		// dimensions + background colour instead of collapsing.
+		fireEvent.error( bannerImg! );
+		expect( container.querySelector( 'img.social-profile-card__banner' ) ).toBeNull();
+		expect( container.querySelector( 'div.social-profile-card__banner' ) ).not.toBeNull();
 	} );
 
-	it( 'unmounts the avatar image on load failure (SocialAvatar onError → null fallback)', () => {
+	it( 'swaps the avatar image for a same-class placeholder div on load failure', () => {
 		const { container } = render(
 			<SocialProfileCard
 				avatar="https://cdn.example/broken.jpg"
@@ -759,9 +760,10 @@ describe( 'SocialProfileCard — rich variant', () => {
 				statsLabel="Profile stats"
 			/>
 		);
-		const avatar = container.querySelector( '.social-profile-card__avatar' );
-		expect( avatar ).not.toBeNull();
-		fireEvent.error( avatar! );
-		expect( container.querySelector( '.social-profile-card__avatar' ) ).toBeNull();
+		const avatarImg = container.querySelector( 'img.social-profile-card__avatar' );
+		expect( avatarImg ).not.toBeNull();
+		fireEvent.error( avatarImg! );
+		expect( container.querySelector( 'img.social-profile-card__avatar' ) ).toBeNull();
+		expect( container.querySelector( 'div.social-profile-card__avatar' ) ).not.toBeNull();
 	} );
 } );

--- a/client/reader/social/test/profile-card.test.tsx
+++ b/client/reader/social/test/profile-card.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import page from '@automattic/calypso-router';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SocialAnalyticsProvider } from '../components/post-card/analytics-context';
 import { SocialProfileCard } from '../profile-card';
@@ -731,7 +731,7 @@ describe( 'SocialProfileCard — rich variant', () => {
 		expect( screen.getByRole( 'heading', { level: 2, name: 'Alice' } ) ).toBeVisible();
 	} );
 
-	it( 'hides the banner image on load failure', () => {
+	it( 'unmounts the banner image on load failure (SocialAvatar onError → null fallback)', () => {
 		const { container } = render(
 			<SocialProfileCard
 				banner="https://cdn.example/broken.jpg"
@@ -740,11 +740,28 @@ describe( 'SocialProfileCard — rich variant', () => {
 				statsLabel="Profile stats"
 			/>
 		);
-		const banner = container.querySelector(
-			'.social-profile-card__banner'
-		) as HTMLImageElement | null;
+		const banner = container.querySelector( '.social-profile-card__banner' );
 		expect( banner ).not.toBeNull();
-		banner!.dispatchEvent( new Event( 'error', { bubbles: true } ) );
-		expect( banner!.style.display ).toBe( 'none' );
+		// `fireEvent.error` triggers React's synthetic onError handler, which
+		// flips the SocialAvatar's `errored` state and renders the fallback
+		// (`null` for the banner — the band collapses entirely so a broken
+		// CDN URL doesn't leak a broken-image icon into the layout).
+		fireEvent.error( banner! );
+		expect( container.querySelector( '.social-profile-card__banner' ) ).toBeNull();
+	} );
+
+	it( 'unmounts the avatar image on load failure (SocialAvatar onError → null fallback)', () => {
+		const { container } = render(
+			<SocialProfileCard
+				avatar="https://cdn.example/broken.jpg"
+				displayName="Alice"
+				stats={ [] }
+				statsLabel="Profile stats"
+			/>
+		);
+		const avatar = container.querySelector( '.social-profile-card__avatar' );
+		expect( avatar ).not.toBeNull();
+		fireEvent.error( avatar! );
+		expect( container.querySelector( '.social-profile-card__avatar' ) ).toBeNull();
 	} );
 } );

--- a/client/reader/social/test/social-avatar.test.tsx
+++ b/client/reader/social/test/social-avatar.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * @jest-environment jsdom
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { SocialAvatar } from '../avatar';
+
+describe( 'SocialAvatar', () => {
+	it( 'renders an <img> with the src + alt when both are set', () => {
+		render(
+			<SocialAvatar
+				src="https://example.test/avatar.jpg"
+				alt="Alice's avatar"
+				className="my-class"
+			/>
+		);
+		const img = screen.getByAltText( "Alice's avatar" ) as HTMLImageElement;
+		expect( img ).toBeVisible();
+		expect( img ).toHaveAttribute( 'src', 'https://example.test/avatar.jpg' );
+		expect( img ).toHaveClass( 'my-class' );
+	} );
+
+	it( 'forwards arbitrary <img> props (width / height / loading / aria-hidden)', () => {
+		const { container } = render(
+			<SocialAvatar
+				src="https://example.test/avatar.jpg"
+				width={ 32 }
+				height={ 32 }
+				loading="lazy"
+				aria-hidden="true"
+			/>
+		);
+		// `aria-hidden="true"` removes the img from the a11y tree, so
+		// `getByRole` can't find it; query the DOM directly.
+		const img = container.querySelector( 'img' );
+		expect( img ).not.toBeNull();
+		expect( img ).toHaveAttribute( 'width', '32' );
+		expect( img ).toHaveAttribute( 'height', '32' );
+		expect( img ).toHaveAttribute( 'loading', 'lazy' );
+		expect( img ).toHaveAttribute( 'aria-hidden', 'true' );
+	} );
+
+	it( 'renders the fallback when src is null', () => {
+		render(
+			<SocialAvatar src={ null } fallback={ <span data-testid="placeholder">placeholder</span> } />
+		);
+		expect( screen.getByTestId( 'placeholder' ) ).toBeVisible();
+		expect( screen.queryByRole( 'img' ) ).toBeNull();
+		expect( screen.queryByRole( 'presentation' ) ).toBeNull();
+	} );
+
+	it( 'renders the fallback when src is undefined', () => {
+		render(
+			<SocialAvatar
+				src={ undefined }
+				fallback={ <span data-testid="placeholder">placeholder</span> }
+			/>
+		);
+		expect( screen.getByTestId( 'placeholder' ) ).toBeVisible();
+	} );
+
+	it( 'renders the fallback when src is an empty string', () => {
+		// Some upstream APIs return `""` rather than `null` for "no avatar".
+		// Both should land on the fallback so the broken-image icon never
+		// reaches the DOM.
+		render(
+			<SocialAvatar src="" fallback={ <span data-testid="placeholder">placeholder</span> } />
+		);
+		expect( screen.getByTestId( 'placeholder' ) ).toBeVisible();
+	} );
+
+	it( 'renders nothing when src is null and no fallback is provided', () => {
+		// Banner pattern in SocialProfileCard: when the banner URL is null
+		// the band collapses to no element. Default fallback is `null`.
+		const { container } = render( <SocialAvatar src={ null } alt="" /> );
+		expect( container.firstChild ).toBeNull();
+	} );
+
+	it( 'swaps to the fallback after the <img> fires onError', () => {
+		// Real-world trigger: stale CDN URL, instance migration, network
+		// failure during load. Without this swap the browser leaves a
+		// broken-image icon in the avatar slot — the whole reason this
+		// component exists.
+		render(
+			<SocialAvatar
+				src="https://example.test/dead.jpg"
+				alt=""
+				fallback={ <span data-testid="placeholder">placeholder</span> }
+			/>
+		);
+		const img = screen.getByRole( 'presentation' );
+		fireEvent.error( img );
+		expect( screen.queryByRole( 'presentation' ) ).toBeNull();
+		expect( screen.getByTestId( 'placeholder' ) ).toBeVisible();
+	} );
+
+	it( 'resets the errored state when src changes (new URL gets a fresh chance)', () => {
+		// Use case: account-row inside an infinite feed re-renders with a
+		// different actor's avatar, or compose-pill after a connection
+		// switch. The previous URL's error must not poison the new one.
+		const { rerender } = render(
+			<SocialAvatar
+				src="https://example.test/dead.jpg"
+				alt=""
+				fallback={ <span data-testid="placeholder">placeholder</span> }
+			/>
+		);
+		fireEvent.error( screen.getByRole( 'presentation' ) );
+		expect( screen.getByTestId( 'placeholder' ) ).toBeVisible();
+
+		rerender(
+			<SocialAvatar
+				src="https://example.test/live.jpg"
+				alt=""
+				fallback={ <span data-testid="placeholder">placeholder</span> }
+			/>
+		);
+		// Fallback is gone, fresh <img> is back.
+		expect( screen.queryByTestId( 'placeholder' ) ).toBeNull();
+		const img = screen.getByRole( 'presentation' ) as HTMLImageElement;
+		expect( img ).toHaveAttribute( 'src', 'https://example.test/live.jpg' );
+	} );
+} );


### PR DESCRIPTION
## Proposed Changes

* New `<SocialAvatar>` component (`client/reader/social/avatar.tsx`) — a thin `<img>` wrapper that renders a `fallback` prop when `src` is null/undefined/empty **or** when the `<img>` fires `onError`. Resets the errored state when `src` changes.
* Adopted across every Reader Social surface that renders a remote image:
  * `<SocialProfileCard>` avatar + banner — replaces the previous DOM-mutating `event.currentTarget.style.display = 'none'` with the React-state pattern.
  * `<PostCardHeader>` author avatar — `--placeholder <div>` is now the unified fallback for both "no src" and "load failed".
  * `<SocialAccountRow>` avatar — null fallback; the `.social-account-row__avatar` container's SCSS background color is the visible fallback.
  * `<TimelineComposePill>` avatar — `--placeholder <span>` is now the unified fallback.
  * `<SocialNotificationItem>` and `<StackedNotification>` avatar cluster — `is-placeholder <span>` is now the unified fallback.
* New `client/reader/social/test/social-avatar.test.tsx` (8 cases).
* `profile-card.test.tsx` banner-error test rewritten for the new pattern; sibling avatar-error case added.

## Why are these changes being made?

Reader Social surfaces consume avatar / banner URLs from third-party services (Bluesky CDN, Mastodon instances, AP servers). Those URLs can 404, resolve to a stale path after an instance migration, or fail at load time on a slow network. Today only `<SocialProfileCard>` handles load failures (via a DOM-mutating `display: none`), and even there the avatar uses the same fragile pattern. Every other surface — post-card header, account-row, compose-pill, notifications — silently leaves a broken-image icon in the layout when an image fails to load.

`<SocialAvatar>` is a single source of truth for the failure-handling contract, so all surfaces share the same behaviour and each call site keeps responsibility for what "no image" looks like (the existing per-surface placeholder elements).

## Testing Instructions

1. Visit `/reader/atmosphere/<id>` (or `/reader/mastodon/<id>` or `/reader/fediverse/<id>`) and observe the timeline, profile header, account-row sidebars, and notifications panel. Confirm avatars + banners render normally.
2. In DevTools Network panel, **block** the avatar CDN host (`cdn.bsky.app`, the Mastodon instance domain, etc.) and refresh. Confirm:
   * The post-card avatar slot shows the placeholder `<div>` (not a broken icon).
   * The profile-card avatar + banner slots are empty (no broken icon).
   * The account-row avatar slot keeps its grey background (SCSS fallback).
   * The compose-pill avatar slot shows the placeholder `<span>`.
   * Notifications avatars (single and stacked clusters) show their `is-placeholder` `<span>`s.
3. Unblock the host; the surfaces should recover on the next render (errored state resets when `src` changes).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed?
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [x] Have you tested accessibility for your changes? Decorative-image semantics (alt="", aria-hidden, presentation role) preserved verbatim at every call site.
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?
