### PR TITLE
Reader Fediverse: match account view header to Mastodon / ATmosphere

### DIFF
--- a/client/reader/fediverse/fediverse-account-view.tsx
+++ b/client/reader/fediverse/fediverse-account-view.tsx
@@ -7,6 +7,7 @@ import { useEffect, useRef } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { logToLogstash } from 'calypso/lib/logstash';
+import { ReaderFediverseIcon } from 'calypso/reader/components/icons/fediverse-icon';
 import ReaderMain from 'calypso/reader/components/reader-main';
 import { ComposeFab, ComposerModal, ComposerProvider } from 'calypso/reader/social/composer';
 import { fediverseComposerConfig } from './composer-config';
@@ -75,21 +76,29 @@ export function FediverseAccountView( { connectionId, tab }: Props ) {
 		);
 	}
 
-	const title = connection.name?.trim() || connection.webfinger;
+	const documentTitle = connection.name?.trim() || connection.webfinger;
+	const subtitle = translate(
+		'Catch up with the latest from the people you follow on the Fediverse.'
+	);
+
+	const title = (
+		<span className="fediverse-view__section-title">
+			<span data-testid="fediverse-section-logo" aria-hidden="true">
+				<ReaderFediverseIcon />
+			</span>
+			<span>Fediverse</span>
+		</span>
+	);
 
 	return (
 		<ComposerProvider connectionId={ connection.id } config={ fediverseComposerConfig }>
 			<ReaderMain className="fediverse-view">
 				<DocumentHead
-					title={
-						translate( '%(handle)s ‹ Fediverse ‹ Reader', {
-							args: { handle: connection.webfinger },
-						} ) as string
-					}
+					title={ translate( '%s ‹ Fediverse ‹ Reader', { args: documentTitle } ) as string }
 				/>
-				<VStack spacing={ 4 }>
-					<NavigationHeader title={ title } subtitle={ connection.webfinger } compactBreadcrumb />
-					<FediverseNavigation connectionId={ connection.id } selectedTab={ tab } />
+				<NavigationHeader title={ title } subtitle={ subtitle } />
+				<FediverseNavigation connectionId={ connection.id } selectedTab={ tab } />
+				<VStack spacing={ 4 } className="fediverse-view__body">
 					{ tab === TIMELINE_TAB && <TimelinePanel connection={ connection } /> }
 					{ tab === PROFILE_TAB && <ProfilePanel connection={ connection } /> }
 				</VStack>

--- a/client/reader/fediverse/style.scss
+++ b/client/reader/fediverse/style.scss
@@ -24,6 +24,21 @@
 	}
 }
 
+.fediverse-view__section-title {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+}
+
+.fediverse-view__section-title svg {
+	display: block;
+	flex-shrink: 0;
+	// The icon component bakes in the `.sidebar__menu-icon` class so the
+	// sidebar can spec its own spacing. In the header we lay things out
+	// with `gap`, so reset the inherited margin to keep the gap honest.
+	margin: 0;
+}
+
 .fediverse-landing__header h1 {
 	margin-block-end: 8px;
 }


### PR DESCRIPTION
Fixes CM-728

## Proposed Changes

* Update the `/reader/fediverse/:id/:tab` `NavigationHeader` to mirror the Mastodon and ATmosphere account views:
  - Title is now a section-style label: Fediverse asterism icon (`ReaderFediverseIcon`) + "Fediverse" inside a `.fediverse-view__section-title` wrapper.
  - Subtitle is "Catch up with the latest from the people you follow on the Fediverse."
* Drop the `compactBreadcrumb` flag and the per-connection title that used the raw `webfinger`.
* Document title now uses `connection.name` (or `webfinger` as fallback) via the shared `%s ‹ Fediverse ‹ Reader` template, matching the Mastodon shape.
* Add `.fediverse-view__section-title` styles matching the Mastodon / ATmosphere icon row.

## Why are these changes being made?

The Mastodon and ATmosphere account views already share a consistent header pattern: a protocol-branded section title with a generic subtitle. The Fediverse account view was the odd one out, surfacing the raw webfinger as both title and subtitle.

The handle is intentionally left out of the subtitle (unlike Mastodon / ATmosphere) because fully-qualified Fediverse webfinger handles like `@myblog@myblog.worpdress.com` are long enough to wrap onto a second line and look awkward.

## Testing Instructions

* Visit `/reader/fediverse/:id/timeline` for any connected Fediverse account.
* Confirm the header now shows the Fediverse asterism icon + "Fediverse" label, with "Catch up with the latest from the people you follow on the Fediverse." underneath.
* Confirm the Timeline / Profile sub-navigation still works.
* Compare side-by-side with `/reader/mastodon/:id/timeline` and `/reader/atmosphere/:id/timeline` — the three headers should match in shape.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?