### PR TITLE
Domain Search: show free subdomain when FQDN search fails

### DIFF
--- a/packages/domain-search/src/hooks/use-suggestions-list.ts
+++ b/packages/domain-search/src/hooks/use-suggestions-list.ts
@@ -11,6 +11,7 @@ import { addAvailabilityAsSuggestion } from '../helpers/add-availability-as-sugg
 import { isSupportedPremiumDomain } from '../helpers/is-supported-premium-domain';
 import { partitionSuggestions } from '../helpers/partition-suggestions';
 import { useDomainSearch } from '../page/context';
+import type { DomainSearchContextType } from '../page/types';
 
 const hasDataAndIsSupportedPremiumDomain = (
 	result: UseQueryResult< DomainAvailability, Error >
@@ -29,6 +30,29 @@ const availablePremiumDomainsCombinator = (
 	};
 };
 
+/**
+ * Whether the FQDN the user searched for can itself be offered as a suggestion
+ * (available to register, an owned domain we can resurface, or a supported
+ * premium domain).
+ */
+const canUseFqdnAsSuggestion = (
+	availability: DomainAvailability,
+	config: DomainSearchContextType[ 'config' ]
+): boolean => {
+	if ( availability.status === DomainAvailabilityStatus.AVAILABLE ) {
+		return true;
+	}
+
+	if (
+		config.includeOwnedDomainInSuggestions &&
+		availability.status === DomainAvailabilityStatus.REGISTERED_OTHER_SITE_SAME_USER
+	) {
+		return true;
+	}
+
+	return isSupportedPremiumDomain( availability );
+};
+
 export const useSuggestionsList = () => {
 	const { query, queries, config } = useDomainSearch();
 
@@ -44,14 +68,22 @@ export const useSuggestionsList = () => {
 
 	const isFqdnQuery = ! isFreeSubdomain && !! getTld( query );
 
-	const { isLoading: isLoadingFreeSuggestion } = useQuery( {
-		...queries.freeSuggestion( freeSuggestionQuery ),
-		enabled: config.skippable && ! isFqdnQuery,
-	} );
-
 	const { isLoading: isLoadingQueryAvailability, data: fqdnAvailability } = useQuery( {
 		...queries.domainAvailability( query ),
 		enabled: isFqdnQuery,
+	} );
+
+	// A non-FQDN search always offers the free subdomain. For an FQDN search,
+	// we only offer the subdomain once the FQDN check confirms the user can't
+	// use the domain they entered (registered elsewhere, invalid name,
+	// unsupported TLD, etc.) — when the FQDN is usable, intent to purchase is
+	// high and we let them proceed with their custom domain.
+	const isFqdnUnusable =
+		isFqdnQuery && !! fqdnAvailability && ! canUseFqdnAsSuggestion( fqdnAvailability, config );
+
+	const { isLoading: isLoadingFreeSuggestion } = useQuery( {
+		...queries.freeSuggestion( freeSuggestionQuery ),
+		enabled: config.skippable && ( ! isFqdnQuery || isFqdnUnusable ),
 	} );
 
 	const premiumSuggestions = useMemo(
@@ -96,28 +128,13 @@ export const useSuggestionsList = () => {
 						return false;
 					}
 
-					if (
-						fqdnAvailability.status === DomainAvailabilityStatus.AVAILABLE ||
-						( config.includeOwnedDomainInSuggestions &&
-							fqdnAvailability.status === DomainAvailabilityStatus.REGISTERED_OTHER_SITE_SAME_USER )
-					) {
-						return true;
-					}
-
-					return isSupportedPremiumDomain( fqdnAvailability );
+					return canUseFqdnAsSuggestion( fqdnAvailability, config );
 				} )
 				.map( ( suggestion ) => suggestion.domain_name ),
 			query,
 			deemphasizedTlds: config.deemphasizedTlds,
 		} );
-	}, [
-		suggestions,
-		query,
-		config.deemphasizedTlds,
-		availablePremiumDomains,
-		fqdnAvailability,
-		config.includeOwnedDomainInSuggestions,
-	] );
+	}, [ suggestions, query, config, availablePremiumDomains, fqdnAvailability ] );
 
 	return {
 		isLoading,

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -683,7 +683,7 @@ describe( 'ResultsPage', () => {
 			).toBeInTheDocument();
 		} );
 
-		it( 'does not render the skip suggestion when searching for a FQDN', async () => {
+		it( 'does not render the skip suggestion when searching for an available FQDN', async () => {
 			mockGetSuggestionsQuery( {
 				params: { query: 'test.com' },
 				suggestions: [ buildSuggestion( { domain_name: 'test.com' } ) ],
@@ -716,6 +716,44 @@ describe( 'ResultsPage', () => {
 				screen.queryByLabelText( 'Skip purchase and continue with testcom.wordpress.com' )
 			).not.toBeInTheDocument();
 		} );
+
+		it.each( [
+			[ 'already registered', DomainAvailabilityStatus.REGISTERED ],
+			[ 'an unsupported TLD', DomainAvailabilityStatus.TLD_NOT_SUPPORTED ],
+			[ 'an invalid domain name', DomainAvailabilityStatus.INVALID ],
+		] )(
+			'renders the skip suggestion when the FQDN search returns %s',
+			async ( _label, status ) => {
+				mockGetSuggestionsQuery( {
+					params: { query: 'taken.com' },
+					suggestions: [],
+				} );
+
+				mockGetAvailabilityQuery( {
+					params: { domainName: 'taken.com' },
+					availability: buildAvailability( {
+						domain_name: 'taken.com',
+						tld: 'com',
+						status,
+					} ),
+				} );
+
+				mockGetFreeSuggestionQuery( {
+					params: { query: 'taken.com' },
+					freeSuggestion: buildFreeSuggestion( { domain_name: 'takencom.wordpress.com' } ),
+				} );
+
+				render(
+					<TestDomainSearch config={ { skippable: true } } query="taken.com">
+						<ResultsPage />
+					</TestDomainSearch>
+				);
+
+				expect(
+					await screen.findByLabelText( 'Skip purchase and continue with takencom.wordpress.com' )
+				).toBeInTheDocument();
+			}
+		);
 
 		it( 'renders the skip suggestion when searching for an available WordPress.com subdomain', async () => {
 			mockGetSuggestionsQuery( {


### PR DESCRIPTION
Part of [DOMAINS-2134](https://linear.app/a8c/issue/DOMAINS-2134/show-free-subdomain-option-after-failed-domain-search)

## Proposed Changes

* In `packages/domain-search/src/hooks/use-suggestions-list.ts`, enable the `freeSuggestion` query when the FQDN availability check confirms the searched domain can't be used (registered, invalid, unsupported TLD, etc.). Previously the query was gated on `! isFqdnQuery`, so any search containing a TLD short-circuited the subdomain offer regardless of the result.
* Extract a `canUseFqdnAsSuggestion` helper and reuse it from both the suggestion filter and the new free-suggestion gate so the two places can't drift.
* Update the existing "doesn't render for FQDN" test to be precise about *available* FQDNs and add a parametrized test covering `REGISTERED`, `TLD_NOT_SUPPORTED`, and `INVALID`.

## Why are these changes being made?

According to the issue, already-registered domain searches alone account for ~8.5% of searches (~5,600/day). When a user typed a full domain that turned out to be taken, invalid, or had an unsupported TLD, the page showed only a notice and no path forward — no free-subdomain skip option — so users had to come up with a different domain to proceed. The intent-to-purchase signal that justifies hiding the subdomain only holds when the FQDN is actually available; in failure cases the subdomain should be back on the table.

## Testing Instructions

1. `yarn start` and visit `/setup/onboarding/domains` (e.g. starting from the sites dashboard new-site flow).
2. Search for an already-registered domain like `example.com`. The free `*.wordpress.com` subdomain skip card should appear below the search.
3. Search for an FQDN with an unsupported TLD (e.g. `something.invalidtld`). Same — subdomain should appear.
4. Search for an invalid domain name (e.g. an FQDN that returns `invalid_domain`). Same.
5. Search for an *available* FQDN like `<unique>.com`. The subdomain skip card should **not** appear (regression check — purchase intent is high).
6. `npx jest src/` from `packages/domain-search/` — all 317 tests pass, including the new parametrized cases.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

## Follow-up

The Linear issue also mentions a secondary "additional bug": when an already-registered domain like `example.com` is searched, the FQDN itself should appear as a "taken" card (similar to `TRANSFERRABLE`/`MAPPED`), in addition to the free subdomain. That requires changes to `UnavailableSearchResult` and `SearchNotice` to avoid duplicate notices and is left for a separate PR to keep this one focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)