### PR TITLE
Auth: migrate lost-password to the foundation Screen shell

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -435,7 +435,6 @@ class Login extends Component {
 							redirectToAfterLoginUrl={ this.props.redirectTo }
 							oauth2ClientId={ this.props.oauth2Client && this.props.oauth2Client.id }
 							locale={ locale }
-							isWoo={ isWoo }
 							isWooJPC={ isWooJPC }
 							from={ get( currentQuery, 'from' ) }
 							isJetpack={ isJetpack }

--- a/client/blocks/login/lost-password-form.jsx
+++ b/client/blocks/login/lost-password-form.jsx
@@ -1,13 +1,15 @@
 import page from '@automattic/calypso-router';
-import { FormInputValidation, FormLabel } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { Button, Spinner, ExternalLink } from '@wordpress/components';
+import { Button, TextControl, __experimentalVStack as VStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useRef, useEffect } from 'react';
-import FormTextInput from 'calypso/components/forms/form-text-input';
+import { useState } from 'react';
+import { Screen } from 'calypso/blocks/authentication';
 import { login } from 'calypso/lib/paths';
 import { useDispatch } from 'calypso/state';
 import { sendEmailLogin } from 'calypso/state/auth/actions';
+
+const submitButtonStyle = { width: '100%' };
+const externalArrowStyle = { marginInlineStart: '0.5ch' };
 
 const LostPasswordForm = ( {
 	redirectToAfterLoginUrl,
@@ -15,7 +17,6 @@ const LostPasswordForm = ( {
 	locale,
 	from,
 	isWooJPC,
-	isWoo,
 	isJetpack,
 } ) => {
 	const translate = useTranslate();
@@ -23,11 +24,6 @@ const LostPasswordForm = ( {
 	const [ error, setError ] = useState( null );
 	const [ isBusy, setBusy ] = useState( false );
 	const dispatch = useDispatch();
-
-	const inputRef = useRef( null );
-	useEffect( () => {
-		inputRef.current?.focus();
-	}, [] );
 
 	const validateUserLogin = () => {
 		// Allow empty input or any non-empty value (username or email)
@@ -164,60 +160,87 @@ const LostPasswordForm = ( {
 	};
 
 	const showError = !! error;
+	const backToLoginHref = login( {
+		locale,
+		oauth2ClientId,
+		from,
+		isJetpack,
+	} );
+
 	return (
-		<form
-			name="lostpasswordform"
-			className="login__lostpassword-form"
-			method="post"
-			onSubmit={ onSubmit }
-		>
-			<div className="login__form-userdata">
-				<FormLabel htmlFor="userLogin">{ translate( 'Email address or username' ) }</FormLabel>
-				<FormTextInput
-					autoCapitalize="off"
-					autoCorrect="off"
-					spellCheck="false"
-					autoComplete="username"
-					id="userLogin"
-					name="userLogin"
-					type="text"
-					value={ userLogin }
-					isError={ showError }
-					onBlur={ validateUserLogin }
-					onChange={ ( event ) => {
-						const newValue = event.target.value.trim();
-						setUserLogin( newValue );
-						// Clear error immediately when user starts typing to fix input
-						if ( error ) {
-							setError( null );
-						}
-					} }
-					ref={ inputRef }
-				/>
-				{ showError && <FormInputValidation isError text={ error } /> }
-			</div>
-			<div className="login__form-action">
-				<Button
-					variant="primary"
-					type="submit"
-					disabled={ userLogin.length === 0 || showError || isBusy }
-					isBusy={ isBusy }
-					__next40pxDefaultSize
-				>
-					{ isBusy && isWoo ? <Spinner /> : translate( 'Reset my password' ) }
+		<Screen
+			heading={ translate( 'Lost your password?' ) }
+			subheading={ translate(
+				"Please enter your username or email address. You'll receive a link to create a new password via email."
+			) }
+			topBarAction={
+				<Button variant="link" href={ backToLoginHref }>
+					{ translate( 'Login' ) }
 				</Button>
-			</div>
-			<div className="login__form-help">
-				<ExternalLink
-					href={ localizeUrl(
-						'https://wordpress.com/support/account-recovery/#verify-your-account-ownership',
-						locale
-					) }
-				>
-					{ translate( 'Need more help?' ) }
-				</ExternalLink>
-			</div>
-		</form>
+			}
+		>
+			<form
+				name="lostpasswordform"
+				className="login__lostpassword-form"
+				method="post"
+				onSubmit={ onSubmit }
+			>
+				<VStack spacing={ 4 }>
+					<div>
+						<TextControl
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+							label={ translate( 'Email address or username' ) }
+							value={ userLogin }
+							onChange={ ( newValue ) => {
+								const trimmed = newValue.trim();
+								setUserLogin( trimmed );
+								// Clear error immediately when user starts typing to fix input
+								if ( error ) {
+									setError( null );
+								}
+							} }
+							onBlur={ validateUserLogin }
+							type="text"
+							autoComplete="username"
+							autoCapitalize="off"
+							autoCorrect="off"
+							spellCheck="false"
+							autoFocus // eslint-disable-line jsx-a11y/no-autofocus
+						/>
+						{ showError && (
+							<p className="login__lostpassword-error" role="alert">
+								{ error }
+							</p>
+						) }
+					</div>
+					<Button
+						variant="primary"
+						__next40pxDefaultSize
+						type="submit"
+						disabled={ userLogin.length === 0 || showError || isBusy }
+						isBusy={ isBusy }
+						style={ submitButtonStyle }
+					>
+						{ translate( 'Reset my password' ) }
+					</Button>
+					<Button
+						variant="link"
+						href={ localizeUrl(
+							'https://wordpress.com/support/account-recovery/#verify-your-account-ownership',
+							locale
+						) }
+						target="_blank"
+						rel="external noopener noreferrer"
+					>
+						{ translate( 'Need more help?' ) }
+						<span style={ externalArrowStyle } aria-label={ translate( '(opens in a new tab)' ) }>
+							↗
+						</span>
+					</Button>
+				</VStack>
+			</form>
+		</Screen>
 	);
 };
 

--- a/client/blocks/login/lost-password-form.jsx
+++ b/client/blocks/login/lost-password-form.jsx
@@ -233,9 +233,10 @@ const LostPasswordForm = ( {
 						) }
 						target="_blank"
 						rel="external noopener noreferrer"
+						aria-label={ translate( 'Need more help? (opens in a new tab)' ) }
 					>
 						{ translate( 'Need more help?' ) }
-						<span style={ externalArrowStyle } aria-label={ translate( '(opens in a new tab)' ) }>
+						<span style={ externalArrowStyle } aria-hidden="true">
 							↗
 						</span>
 					</Button>

--- a/client/blocks/login/lost-password-form.jsx
+++ b/client/blocks/login/lost-password-form.jsx
@@ -1,6 +1,7 @@
 import page from '@automattic/calypso-router';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Button, TextControl, __experimentalVStack as VStack } from '@wordpress/components';
+import { chevronLeft } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { Screen } from 'calypso/blocks/authentication';
@@ -173,9 +174,9 @@ const LostPasswordForm = ( {
 			subheading={ translate(
 				"Please enter your username or email address. You'll receive a link to create a new password via email."
 			) }
-			topBarAction={
-				<Button variant="link" href={ backToLoginHref }>
-					{ translate( 'Login' ) }
+			backAction={
+				<Button variant="link" href={ backToLoginHref } icon={ chevronLeft } iconPosition="left">
+					{ translate( 'Back' ) }
 				</Button>
 			}
 		>

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -321,10 +321,12 @@ $breakpoint-mobile: 782px; //Mobile size.
 	text-transform: initial;
 }
 
-.layout:not(.is-grav-powered-client) {
-	&.is-mobile {
-		.login__lostpassword-form  {
-			padding: 16px 16px 0;
-		}
-	}
+// Inline validation / server-error text rendered below the lost-password
+// input. DES-620 replaced the previous `FormInputValidation` component with
+// a plain <p role="alert"> — this rule preserves the red treatment the
+// previous component provided.
+.login__lostpassword-error {
+	color: var(--color-error);
+	font-size: 0.875rem;
+	margin-block-start: 4px;
 }

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -261,17 +261,16 @@ export class Login extends Component {
 			! currentRoute.startsWith( '/log-in/backup' );
 
 		// On the lost-password route the form renders its own foundation
-		// `Screen` shell (DES-619 / DES-620) with the "Back to log in" link
-		// in the top bar and the "Need more help?" link inside the form, so
-		// the OneLoginFooter ("Back to Login" + "Support") is redundant.
-		// Gravatar-powered clients keep their own bespoke footer.
-		const isLostPasswordContent =
-			( action === 'lostpassword' || action === 'jetpack/lostpassword' ) && ! isGravPoweredClient;
+		// `Screen` shell with the "Back to log in" link in the top bar and
+		// the "Need more help?" link inside the form, so the OneLoginFooter
+		// ("Back to Login" + "Support") is redundant. Gravatar-powered
+		// clients keep their own bespoke footer.
+		const skipOneLoginFooter = this.isLostPasswordView() && ! isGravPoweredClient;
 
 		let footer = null;
 		if ( isGravPoweredLoginPage ) {
 			footer = <GravPoweredLoginBlockFooter />;
-		} else if ( ! isLostPasswordContent ) {
+		} else if ( ! skipOneLoginFooter ) {
 			footer = (
 				<OneLoginFooter
 					isLoginView={ isLoginView }
@@ -328,16 +327,14 @@ export class Login extends Component {
 		} );
 	}
 
+	isLostPasswordView() {
+		const { action } = this.props;
+		return action === 'lostpassword' || action === 'jetpack/lostpassword';
+	}
+
 	render() {
-		const {
-			locale,
-			translate,
-			isGenericOauth,
-			isGravPoweredClient,
-			isJetpack,
-			action,
-			partnerConfig,
-		} = this.props;
+		const { locale, translate, isGenericOauth, isGravPoweredClient, isJetpack, partnerConfig } =
+			this.props;
 
 		const canonicalUrl = localizeUrl( 'https://wordpress.com/log-in', locale );
 
@@ -377,12 +374,12 @@ export class Login extends Component {
 			</Main>
 		);
 
-		const isLostPasswordView = action === 'lostpassword' || action === 'jetpack/lostpassword';
+		const isLostPasswordView = this.isLostPasswordView();
 
 		// The lost-password form renders its own foundation `Screen` shell
-		// from `client/blocks/authentication/` (DES-619 / DES-620), so skip
-		// the `OneLoginLayout` wrap for this route. Other login routes keep
-		// `OneLoginLayout` until they migrate to the foundation in turn.
+		// from `client/blocks/authentication/`, so skip the `OneLoginLayout`
+		// wrap for this route. Other login routes keep `OneLoginLayout`
+		// until they migrate to the foundation in turn.
 		if ( isLostPasswordView && ! isGravPoweredClient ) {
 			return mainContent;
 		}

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -260,6 +260,28 @@ export class Login extends Component {
 			! currentRoute.startsWith( '/log-in/webauthn' ) &&
 			! currentRoute.startsWith( '/log-in/backup' );
 
+		// On the lost-password route the form renders its own foundation
+		// `Screen` shell (DES-619 / DES-620) with the "Back to log in" link
+		// in the top bar and the "Need more help?" link inside the form, so
+		// the OneLoginFooter ("Back to Login" + "Support") is redundant.
+		// Gravatar-powered clients keep their own bespoke footer.
+		const isLostPasswordContent =
+			( action === 'lostpassword' || action === 'jetpack/lostpassword' ) && ! isGravPoweredClient;
+
+		let footer = null;
+		if ( isGravPoweredLoginPage ) {
+			footer = <GravPoweredLoginBlockFooter />;
+		} else if ( ! isLostPasswordContent ) {
+			footer = (
+				<OneLoginFooter
+					isLoginView={ isLoginView }
+					lostPasswordLink={ this.getLostPasswordLink() }
+					loginLink={ this.getLoginLink() }
+					supportLink={ this.getSupportLink() }
+				/>
+			);
+		}
+
 		return (
 			<LoginBlock
 				action={ action }
@@ -274,18 +296,7 @@ export class Login extends Component {
 				socialServiceResponse={ socialServiceResponse }
 				domain={ domain }
 				fromSite={ fromSite }
-				footer={
-					isGravPoweredLoginPage ? (
-						<GravPoweredLoginBlockFooter />
-					) : (
-						<OneLoginFooter
-							isLoginView={ isLoginView }
-							lostPasswordLink={ this.getLostPasswordLink() }
-							loginLink={ this.getLoginLink() }
-							supportLink={ this.getSupportLink() }
-						/>
-					)
-				}
+				footer={ footer }
 				locale={ locale }
 				handleUsernameChange={ this.handleUsernameChange.bind( this ) }
 				signupUrl={ signupUrl }
@@ -367,6 +378,14 @@ export class Login extends Component {
 		);
 
 		const isLostPasswordView = action === 'lostpassword' || action === 'jetpack/lostpassword';
+
+		// The lost-password form renders its own foundation `Screen` shell
+		// from `client/blocks/authentication/` (DES-619 / DES-620), so skip
+		// the `OneLoginLayout` wrap for this route. Other login routes keep
+		// `OneLoginLayout` until they migrate to the foundation in turn.
+		if ( isLostPasswordView && ! isGravPoweredClient ) {
+			return mainContent;
+		}
 
 		return (
 			<>


### PR DESCRIPTION
Part of DES-620 — the first consumer migration on the auth-screens foundation (DES-619, PR #110697). Stacked on #110697; mark ready-for-review once that lands and this branch rebases cleanly onto trunk.

## Proposed Changes

* Render `/log-in/lostpassword` through the foundation's `<Screen>` shell from `client/blocks/authentication/`, with a `backAction` "Back" chevron on the leading edge and a `VStack` body composed of WPDS primitives directly (`TextControl`, `Button`, `__experimentalVStack`). Matches the `Recipes / LostPassword` template.
* Swap form internals: `FormLabel + FormTextInput + FormInputValidation` → `TextControl` + `<p role="alert">` (preserves existing tests' a11y query + studio-red treatment via a small `.login__lostpassword-error` SCSS rule).
* Skip both `OneLoginLayout` and `OneLoginFooter` for the lostpassword route in `wp-login/index.jsx`. The form now owns its own foundation chrome (top bar with the Back chevron, heading, subheading, content column), and the body's "Need more help? ↗" link (`Button variant="link"` with Unicode arrow + `(opens in a new tab)` a11y label) replaces the bottom Support footer.
* Drop the now-unused `isWoo` pass-through from the `LoginBlock` `AsyncLoad` call.
* Drop the obsolete `.layout.is-mobile .login__lostpassword-form` mobile padding override — `Screen` provides its own responsive padding.
* Small intentional behavior changes: drop the Woo-only `<Spinner />` substitution inside the submit button (`Button.isBusy` already renders a spinner); replace `useRef`/`useEffect` autofocus with the `autoFocus` prop.

## Why are these changes being made?

DES-619 establishes a shared foundation under `client/blocks/authentication/` to unify the visual treatment of every WordPress.com auth surface. DES-620 is the first consumer migration — proves the foundation works in real usage and unblocks the remaining 11 surfaces (DES-621 → DES-631).

All form logic is preserved verbatim: validation rules, `sendEmailLogin` Redux dispatch, server-error parsing (DOMParser + `.wp-die-message` lookup), `page( login( … ) )` redirects, and every copy string. All 10 existing RTL tests pass without modification.

Device | Before | After |
| --- | --- | --- |
| Desktop | <img width="2880" height="1800" alt="lostpassword-desktop-before" src="https://github.com/user-attachments/assets/8f149a7b-d4c7-4bb0-a414-4c5d79f2dcf0" /> | <img width="2880" height="1800" alt="lostpassword-desktop-after" src="https://github.com/user-attachments/assets/16e37a97-1bea-43b2-a6ce-f8598d8a8e16" /> |
| Mobile | <img width="750" height="1334" alt="lostpassword-mobile-before" src="https://github.com/user-attachments/assets/2df6a6cd-2fd1-42ea-9190-2ca14609603b" /> | <img width="750" height="1334" alt="lostpassword-mobile-after" src="https://github.com/user-attachments/assets/eb39e896-86fd-4b77-8d8d-fb6d40810e01" /> |


## Testing Instructions

* Run `yarn start`, then visit `/log-in/lostpassword` in a browser.
* Verify the new foundation chrome: WordPress wordmark on the leading edge of the top bar, a "< Back" chevron + label next to it (links to `/log-in`), Recoleta-brand heading "Lost your password?", subheading from `get-heading-subtext.tsx`, content column capped at 400px on desktop, light surface color from `Screen`.
* Submit empty → button is disabled. Type an invalid email → blur → red `Please enter a valid email address.` appears under the input. Type a valid email or username → button enables → submit triggers the same redirect / mailer path as before.
* Confirm the "Need more help? ↗" link opens `/support/account-recovery/#verify-your-account-ownership` in a new tab.
* Mobile (≤ 600px): compact W logo, "Back" still visible next to it, full-width form, no bottom footer.
* Storybook: `yarn storybook:start` → `client/blocks/authentication/Recipes` → `Lost Password` for visual parity reference.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
