### PR TITLE
APM: Overview slow-requests card uses the shared SlowList component

### DIFF
--- a/client/dashboard/sites/performance/backend/overview/slow-requests-list.tsx
+++ b/client/dashboard/sites/performance/backend/overview/slow-requests-list.tsx
@@ -1,79 +1,27 @@
-import {
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-	__experimentalToggleGroupControl as ToggleGroupControl,
-	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
-} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useState } from 'react';
-import { Card, CardBody, CardHeader } from '../../../../components/card';
-import { Text } from '../../../../components/text';
-import BarList, { type BarListRow } from '../bar-list';
-import { formatMs } from '../utils';
+import SlowList, { type SlowListItem } from '../slow-list';
 import type { ApmSlowRequest } from '@automattic/api-core';
 
-type Metric = 'avg' | 'max';
-
-function toRows( requests: ApmSlowRequest[], metric: Metric ): BarListRow[] {
+function toItems( requests: ApmSlowRequest[] ): SlowListItem[] {
 	return requests.map( ( request ) => ( {
 		id: request.id,
 		label: `${ request.method } ${ request.url }`,
-		value: metric === 'avg' ? request.avg_duration_ms : request.duration_ms,
+		avg_ms: request.avg_duration_ms,
+		max_ms: request.duration_ms,
 	} ) );
 }
 
-function pickHeadlineDuration( requests: ApmSlowRequest[], metric: Metric ): number {
-	if ( ! requests.length ) {
-		return 0;
-	}
-	if ( metric === 'avg' ) {
-		const total = requests.reduce( ( sum, r ) => sum + r.avg_duration_ms, 0 );
-		return Math.round( total / requests.length );
-	}
-	return requests.reduce( ( max, r ) => Math.max( max, r.duration_ms ), 0 );
-}
-
 export default function SlowRequestsList( { slowRequests }: { slowRequests: ApmSlowRequest[] } ) {
-	const [ metric, setMetric ] = useState< Metric >( 'max' );
-
-	const rows = toRows( slowRequests, metric );
-	const headline = pickHeadlineDuration( slowRequests, metric );
-
-	const description =
-		metric === 'avg'
-			? __( 'Average response time across the slowest endpoints in the selected period.' )
-			: __( 'Slowest single response observed across these endpoints in the selected period.' );
-
 	return (
-		<Card>
-			<CardHeader>
-				<HStack wrap spacing={ 4 } justify="space-between" alignment="flex-start">
-					<VStack spacing={ 2 } alignment="flex-start">
-						<Text size="title" weight={ 500 } as="h2">
-							{ __( 'Slowest requests' ) }
-						</Text>
-						<Text size={ 32 } weight={ 500 } lineHeight="40px">
-							{ formatMs( headline ) }
-						</Text>
-						<Text variant="muted">{ description }</Text>
-					</VStack>
-					<ToggleGroupControl
-						value={ metric }
-						isBlock
-						__nextHasNoMarginBottom
-						__next40pxDefaultSize
-						onChange={ ( value ) => setMetric( ( value as Metric ) ?? 'max' ) }
-						label={ __( 'Duration metric' ) }
-						hideLabelFromVision
-					>
-						<ToggleGroupControlOption value="avg" label={ __( 'Avg' ) } />
-						<ToggleGroupControlOption value="max" label={ __( 'Max' ) } />
-					</ToggleGroupControl>
-				</HStack>
-			</CardHeader>
-			<CardBody>
-				<BarList rows={ rows } valueFormatter={ formatMs } />
-			</CardBody>
-		</Card>
+		<SlowList
+			title={ __( 'Slowest requests' ) }
+			avgDescription={ __(
+				'Average response time across the slowest endpoints in the selected period.'
+			) }
+			maxDescription={ __(
+				'Slowest single response observed across these endpoints in the selected period.'
+			) }
+			items={ toItems( slowRequests ) }
+		/>
 	);
 }


### PR DESCRIPTION
## Proposed Changes

`overview/slow-requests-list.tsx` routes through the shared `SlowList` component (added in #110676 for the Transactions / Database / External sub-tabs) instead of duplicating its Card + Avg/Max toggle + headline + `BarList`. One file, **-66 / +14 lines**.

One intentional behavior change: `SlowList` re-sorts the bars by the active metric, so toggling Max → Avg now reorders the rows to match. Previously the Overview card kept the API's Max-sorted order even in Avg mode. The three new sub-tabs already behave this way; Overview now matches.

## Testing Instructions

1. Visit `/sites/<slug>/performance/backend` on a Business+ Atomic site with `apm_enabled`. The Slowest requests card on Overview still shows Avg / Max toggle and updates bar values + headline. Toggling Max → Avg also re-orders the rows by the displayed metric.
2. `yarn test-client client/dashboard/sites/performance/backend/test/index.test.tsx` (10/10).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
