### PR TITLE
[RSM] Blog Talks Back: Fix Reader Chat suggestions auth

### DIFF
--- a/apps/agents-manager/__tests__/reader-chat.test.js
+++ b/apps/agents-manager/__tests__/reader-chat.test.js
@@ -12,6 +12,16 @@
 jest.mock( '../config', () => {}, { virtual: true } );
 jest.mock( '@automattic/agents-manager', () => ( { default: () => null } ), { virtual: true } );
 jest.mock(
+	'@automattic/agents-manager/src/auth/calypso-auth-provider',
+	() => ( {
+		createCalypsoAuthProvider: jest.fn( ( siteId ) => async () => ( {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer test-token-${ siteId }`,
+		} ) ),
+	} ),
+	{ virtual: true }
+);
+jest.mock(
 	'@tanstack/react-query',
 	() => ( {
 		QueryClient: jest.fn( () => ( {} ) ),
@@ -48,6 +58,9 @@ beforeAll( () => {
 
 // Import after mocks are registered.
 const {
+	createCalypsoAuthProvider,
+} = require( '@automattic/agents-manager/src/auth/calypso-auth-provider' );
+const {
 	parseAgentSseResponse,
 	slugify,
 	getFallbackSuggestions,
@@ -58,6 +71,7 @@ const {
 	getReaderClientContext,
 	normalizeSuggestions,
 	parseSuggestionsResponse,
+	getSuggestionsFetchHeaders,
 } = require( '../reader-chat' );
 
 // ---------------------------------------------------------------------------
@@ -243,6 +257,21 @@ describe( 'getReaderClientContext', () => {
 		expect( getReaderClientContext( null, 247750866 ) ).toEqual( {
 			selectedSiteId: 247750866,
 		} );
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// getSuggestionsFetchHeaders
+// ---------------------------------------------------------------------------
+
+describe( 'getSuggestionsFetchHeaders', () => {
+	it( 'uses the Calypso auth provider with the selected site ID', async () => {
+		await expect( getSuggestionsFetchHeaders( 247750866 ) ).resolves.toEqual( {
+			'Content-Type': 'application/json',
+			Authorization: 'Bearer test-token-247750866',
+		} );
+
+		expect( createCalypsoAuthProvider ).toHaveBeenCalledWith( 247750866 );
 	} );
 } );
 

--- a/apps/agents-manager/reader-chat.js
+++ b/apps/agents-manager/reader-chat.js
@@ -11,6 +11,7 @@
 
 import './config';
 import AgentsManager, { AGENTS_MANAGER_STORE } from '@automattic/agents-manager';
+import { createCalypsoAuthProvider } from '@automattic/agents-manager/src/auth/calypso-auth-provider';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { dispatch, select, subscribe } from '@wordpress/data';
 import { useState, useEffect } from '@wordpress/element';
@@ -394,6 +395,10 @@ function normalizeSuggestions( items, resultIdPrefix ) {
 	} );
 }
 
+function getSuggestionsFetchHeaders( siteId = readerSiteId ) {
+	return createCalypsoAuthProvider( siteId )();
+}
+
 /**
  * Call the reader-chat-suggestions agent with an arbitrary user message and
  * return a list of {id,label,prompt} suggestions, or null on failure.
@@ -447,7 +452,7 @@ async function fetchSuggestions( { messageText, requestIdPrefix, resultIdPrefix,
 		const fetchOptions = {
 			method: 'POST',
 			credentials: 'omit',
-			headers: { 'Content-Type': 'application/json' },
+			headers: await getSuggestionsFetchHeaders(),
 			body: JSON.stringify( body ),
 		};
 		if ( controller ) {
@@ -973,4 +978,5 @@ export {
 	getReaderClientContext,
 	normalizeSuggestions,
 	parseSuggestionsResponse,
+	getSuggestionsFetchHeaders,
 };

--- a/apps/agents-manager/webpack.config.js
+++ b/apps/agents-manager/webpack.config.js
@@ -100,7 +100,6 @@ function getIndividualConfig( options = {} ) {
  * Omits DependencyExtractionWebpackPlugin entirely so React, @wordpress/data,
  * and other WP packages are inlined. The resulting reader-chat.min.js is
  * self-contained and safe to load on the frontend (no WP script loader needed).
- *
  * @param   {Object}  options                       options
  * @param   {Object}  options.env                   environment options
  * @param   {Object}  options.argv                  webpack CLI args
@@ -119,6 +118,8 @@ function getReaderConfig( options = {} ) {
 			...webpackConfig.output,
 			path: outputPath,
 			filename: '[name].min.js',
+			chunkLoadingGlobal: 'webpackChunkJetpackReaderChat',
+			uniqueName: 'JetpackReaderChat',
 		},
 		module: {
 			...webpackConfig.module,


### PR DESCRIPTION
## Summary
- isolate the Reader Chat webpack runtime global from host-page webpack runtimes
- authenticate reader-chat-suggestions requests with the shared Calypso auth provider
- add unit coverage for the suggestion auth headers helper

## Testing
- yarn test-apps apps/agents-manager/__tests__/reader-chat.test.js --runInBand
- git diff --check

See WPCOM PR 217139