### PR TITLE
Reader achievements: move Years of Service into a hero achievement card

### DIFF
--- a/client/reader/components/achievements/years-of-service-badge/index.tsx
+++ b/client/reader/components/achievements/years-of-service-badge/index.tsx
@@ -5,10 +5,11 @@ import { getUserProfileUrl } from 'calypso/reader/user-profile/user-profile.util
 import './style.scss';
 
 interface YearsOfServiceBadgeProps {
-	size: 'large' | 'medium' | 'small';
+	size: 'large' | 'achievement-card' | 'medium' | 'small';
 	yearsOfService: number;
 	linked?: boolean;
 	userLogin?: string;
+	label?: string;
 }
 
 export const YearsOfServiceBadge = ( {
@@ -16,6 +17,7 @@ export const YearsOfServiceBadge = ( {
 	yearsOfService,
 	linked,
 	userLogin,
+	label,
 }: YearsOfServiceBadgeProps ): JSX.Element => {
 	const translate = useTranslate();
 	const description = String(
@@ -24,23 +26,25 @@ export const YearsOfServiceBadge = ( {
 			args: { years: yearsOfService },
 		} )
 	);
+	const resolvedLabel =
+		label ??
+		translate( 'Year on WordPress.com', 'Years on WordPress.com', {
+			count: yearsOfService,
+		} );
 
 	const className = clsx( 'years-of-service-badge', `is-${ size }` );
+	const isInlineSize = size === 'medium' || size === 'small';
 	const content = (
 		<>
 			<div
 				className="years-of-service-badge__circle"
-				title={ size !== 'large' ? description : undefined }
-				aria-label={ size !== 'large' ? description : undefined }
+				title={ isInlineSize ? description : undefined }
+				aria-label={ isInlineSize ? description : undefined }
 			>
 				{ yearsOfService }
 			</div>
-			{ size === 'large' && (
-				<span className="years-of-service-badge__label">
-					{ translate( 'Year on WordPress.com', 'Years on WordPress.com', {
-						count: yearsOfService,
-					} ) }
-				</span>
+			{ size === 'large' && resolvedLabel && (
+				<span className="years-of-service-badge__label">{ resolvedLabel }</span>
 			) }
 		</>
 	);

--- a/client/reader/components/achievements/years-of-service-badge/style.scss
+++ b/client/reader/components/achievements/years-of-service-badge/style.scss
@@ -32,6 +32,17 @@
 	}
 }
 
+.years-of-service-badge.is-achievement-card {
+	width: 80px;
+
+	.years-of-service-badge__circle {
+		width: 80px;
+		height: 80px;
+		font-size: 2rem;
+		background: url( calypso/assets/images/achievements/years-of-service-badge.svg ) no-repeat center / cover;
+	}
+}
+
 .years-of-service-badge.is-medium .years-of-service-badge__circle {
 	width: 22px;
 	height: 22px;

--- a/client/reader/components/achievements/years-of-service-badge/test/index.test.tsx
+++ b/client/reader/components/achievements/years-of-service-badge/test/index.test.tsx
@@ -11,16 +11,31 @@ describe( 'YearsOfServiceBadge', () => {
 		expect( screen.getByText( '5' ) ).toBeVisible();
 	} );
 
-	test( 'should render plural label text for large size when years > 1', () => {
+	test( 'defaults the large-size label to the plural form when years > 1', () => {
 		render( <YearsOfServiceBadge size="large" yearsOfService={ 5 } /> );
 
 		expect( screen.getByText( 'Years on WordPress.com' ) ).toBeVisible();
 	} );
 
-	test( 'should render singular label text for large size when years === 1', () => {
+	test( 'defaults the large-size label to the singular form when years === 1', () => {
 		render( <YearsOfServiceBadge size="large" yearsOfService={ 1 } /> );
 
 		expect( screen.getByText( 'Year on WordPress.com' ) ).toBeVisible();
+	} );
+
+	test( 'renders a custom label when one is provided', () => {
+		render( <YearsOfServiceBadge size="large" yearsOfService={ 5 } label="Years of Service" /> );
+
+		expect( screen.getByText( 'Years of Service' ) ).toBeVisible();
+		expect( screen.queryByText( 'Years on WordPress.com' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'suppresses the label when an empty string is passed', () => {
+		const { container } = render(
+			<YearsOfServiceBadge size="large" yearsOfService={ 5 } label="" />
+		);
+
+		expect( container.querySelector( '.years-of-service-badge__label' ) ).toBeNull();
 	} );
 
 	test( 'should not render label text for medium size', () => {
@@ -53,5 +68,24 @@ describe( 'YearsOfServiceBadge', () => {
 		const { container } = render( <YearsOfServiceBadge size="large" yearsOfService={ 10 } /> );
 
 		expect( container.querySelector( '.years-of-service-badge.is-large' ) ).toBeInTheDocument();
+	} );
+
+	test( 'applies .is-achievement-card for the achievement-card size', () => {
+		const { container } = render(
+			<YearsOfServiceBadge size="achievement-card" yearsOfService={ 5 } />
+		);
+
+		expect(
+			container.querySelector( '.years-of-service-badge.is-achievement-card' )
+		).toBeInTheDocument();
+	} );
+
+	test( 'omits the visible label and the circle aria-label for the achievement-card size', () => {
+		const { container } = render(
+			<YearsOfServiceBadge size="achievement-card" yearsOfService={ 5 } />
+		);
+
+		expect( container.querySelector( '.years-of-service-badge__label' ) ).toBeNull();
+		expect( screen.queryByLabelText( /years on WordPress\.com/i ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/reader/user-profile/views/achievements/achievements-grid/achievement-card.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/achievement-card.tsx
@@ -10,15 +10,18 @@ interface AchievementCardProps {
 	badge?: ReactNode;
 	description?: ReactNode;
 	caption?: ReactNode;
+	iconNode?: ReactNode;
 	image?: string;
 	locked?: boolean;
 	secret?: boolean;
 	progressCurrent?: number;
 	progressTarget?: number;
+	className?: string;
 }
 
 export default function AchievementCard( {
 	image,
+	iconNode,
 	title,
 	badge,
 	description,
@@ -27,22 +30,31 @@ export default function AchievementCard( {
 	secret,
 	progressCurrent,
 	progressTarget,
+	className,
 }: AchievementCardProps ) {
 	const showLockIcon = locked || secret;
-	const rootClass = clsx( 'achievement-card', {
+	const rootClass = clsx( 'achievement-card', className, {
 		'is-locked': locked,
 		'is-secret': secret,
 	} );
 
-	return (
-		<div className={ rootClass }>
-			{ showLockIcon ? (
+	const renderIcon = () => {
+		if ( showLockIcon ) {
+			return (
 				<div className="achievement-card__icon achievement-card__icon--lock">
 					<Icon icon={ lock } />
 				</div>
-			) : (
-				<img className="achievement-card__icon" src={ image } alt="" />
-			) }
+			);
+		}
+		if ( iconNode ) {
+			return iconNode;
+		}
+		return <img className="achievement-card__icon" src={ image } alt="" />;
+	};
+
+	return (
+		<div className={ rootClass }>
+			{ renderIcon() }
 			<div className="achievement-card__details">
 				<h3 className="achievement-card__title">
 					{ title }

--- a/client/reader/user-profile/views/achievements/achievements-grid/index.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/index.tsx
@@ -12,6 +12,7 @@ import AnniversaryAchievement from './anniversary-achievement';
 import GenericAchievement from './generic-achievement';
 import LockedAchievementCard from './locked-achievement-card';
 import SecretAchievementCard from './secret-achievement-card';
+import YearsOfServiceAchievementCard from './years-of-service-achievement-card';
 
 import './style.scss';
 
@@ -25,6 +26,7 @@ export default function AchievementsGrid( { userLogin, isOwnProfile }: Achieveme
 	const {
 		achievements,
 		lockedAchievements,
+		yearsOfService,
 		isLoading,
 		isError,
 		hasNextPage,
@@ -46,7 +48,7 @@ export default function AchievementsGrid( { userLogin, isOwnProfile }: Achieveme
 		);
 	}
 
-	if ( ! achievements.length && ! lockedAchievements.length ) {
+	if ( ! achievements.length && ! lockedAchievements.length && ! yearsOfService ) {
 		return <p className="achievements-grid__empty">{ translate( 'No achievements yet.' ) }</p>;
 	}
 
@@ -57,13 +59,18 @@ export default function AchievementsGrid( { userLogin, isOwnProfile }: Achieveme
 		[ ...lockedAchievements ].sort( ( a, b ) => a.date_created.localeCompare( b.date_created ) )
 	);
 
+	const showYearsOfService = !! yearsOfService;
 	const showCelebratory = isOwnProfile && earned.length > 0 && lockedAchievements.length === 0;
 	const showLockedSection = isOwnProfile && sortedLocked.length > 0;
+	const showEarnedGrid = dedupedEarned.length > 0 || maskedSecrets.length > 0 || showYearsOfService;
 
 	return (
 		<>
-			{ ( dedupedEarned.length > 0 || maskedSecrets.length > 0 ) && (
+			{ showEarnedGrid && (
 				<div className="achievements-grid">
+					{ showYearsOfService && (
+						<YearsOfServiceAchievementCard yearsOfService={ yearsOfService } />
+					) }
 					{ dedupedEarned.map( ( a ) =>
 						a.slug === 'user_anniversary' ? (
 							<AnniversaryAchievement

--- a/client/reader/user-profile/views/achievements/achievements-grid/style.scss
+++ b/client/reader/user-profile/views/achievements/achievements-grid/style.scss
@@ -1,3 +1,4 @@
+@import '@automattic/color-studio/dist/color-properties-rgb.css';
 @import '@automattic/components/src/styles/typography';
 @import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
@@ -95,6 +96,41 @@
 		opacity: 0.5;
 	}
 
+	.achievement-card.is-years-of-service {
+		transition: box-shadow 250ms ease-out;
+
+		&:hover {
+			box-shadow: 0 6px 24px rgba( var( --studio-blue-50-rgb ), 0.35 );
+		}
+
+		// The white sweep runs across the blue badge circle (where it actually
+		// shows up) rather than across the mostly-white card body.
+		.years-of-service-badge__circle {
+			position: relative;
+			overflow: hidden;
+			isolation: isolate;
+
+			&::after {
+				content: '';
+				position: absolute;
+				inset: 0;
+				background: linear-gradient(
+					115deg,
+					transparent 40%,
+					rgba( var( --studio-white-rgb ), 0.7 ) 50%,
+					transparent 60%
+				);
+				transform: translateX( -110% );
+				pointer-events: none;
+			}
+		}
+
+		&:hover .years-of-service-badge__circle::after {
+			animation: years-of-service-achievement-shine 1100ms cubic-bezier( 0.25, 0.8, 0.3, 1 )
+				forwards;
+		}
+	}
+
 	.achievement-card__icon--lock {
 		align-items: center;
 		background: var( --studio-gray-5 );
@@ -123,5 +159,22 @@
 		margin: 24px auto 0;
 		max-width: 720px;
 		text-align: center;
+	}
+}
+
+@keyframes years-of-service-achievement-shine {
+	from {
+		transform: translateX( -110% );
+	}
+	to {
+		transform: translateX( 110% );
+	}
+}
+
+@media ( prefers-reduced-motion: reduce ) {
+	.is-reader-page
+		.achievement-card.is-years-of-service:hover
+		.years-of-service-badge__circle::after {
+		animation: none;
 	}
 }

--- a/client/reader/user-profile/views/achievements/achievements-grid/test/index.test.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/test/index.test.tsx
@@ -259,6 +259,66 @@ describe( 'AchievementsGrid', () => {
 		expect( screen.queryByText( 'No achievements yet.' ) ).not.toBeInTheDocument();
 	} );
 
+	test( 'prepends a Years of Service card when yearsOfService > 0', () => {
+		useAchievementsQuery.mockReturnValue( {
+			...baseQueryReturn,
+			achievements: [ earned() ],
+			yearsOfService: 5,
+		} );
+
+		const { container } = renderGrid( { userLogin: 'me', isOwnProfile: true } );
+
+		expect( screen.getByText( 'Years of Service' ) ).toBeVisible();
+		expect( screen.getByText( '5 years on WordPress.com.' ) ).toBeVisible();
+
+		const titles = within( container.querySelector( '.achievements-grid' ) as HTMLElement )
+			.getAllByRole( 'heading', { level: 3 } )
+			.map( ( h ) => h.textContent );
+		expect( titles[ 0 ] ).toBe( 'Years of Service' );
+
+		expect(
+			container.querySelector( '.achievement-card.is-years-of-service' )
+		).toBeInTheDocument();
+	} );
+
+	test( 'pluralizes the Years of Service description for 1 year', () => {
+		useAchievementsQuery.mockReturnValue( {
+			...baseQueryReturn,
+			achievements: [ earned() ],
+			yearsOfService: 1,
+		} );
+
+		renderGrid( { userLogin: 'me', isOwnProfile: true } );
+
+		expect( screen.getByText( '1 year on WordPress.com.' ) ).toBeVisible();
+	} );
+
+	test( 'omits the Years of Service card when yearsOfService is 0 or undefined', () => {
+		useAchievementsQuery.mockReturnValue( {
+			...baseQueryReturn,
+			achievements: [ earned() ],
+			yearsOfService: 0,
+		} );
+
+		renderGrid( { userLogin: 'me', isOwnProfile: true } );
+
+		expect( screen.queryByText( 'Years of Service' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'still surfaces the Years of Service card when there are no other achievements', () => {
+		useAchievementsQuery.mockReturnValue( {
+			...baseQueryReturn,
+			achievements: [],
+			lockedAchievements: [],
+			yearsOfService: 3,
+		} );
+
+		renderGrid( { userLogin: 'me', isOwnProfile: true } );
+
+		expect( screen.getByText( 'Years of Service' ) ).toBeVisible();
+		expect( screen.queryByText( 'No achievements yet.' ) ).not.toBeInTheDocument();
+	} );
+
 	test( 'shows the loading spinner while pages are still being fetched', () => {
 		useAchievementsQuery.mockReturnValue( {
 			...baseQueryReturn,

--- a/client/reader/user-profile/views/achievements/achievements-grid/years-of-service-achievement-card.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/years-of-service-achievement-card.tsx
@@ -1,0 +1,26 @@
+import { useTranslate } from 'i18n-calypso';
+import { YearsOfServiceBadge } from 'calypso/reader/components/achievements/years-of-service-badge';
+import AchievementCard from './achievement-card';
+
+export default function YearsOfServiceAchievementCard( {
+	yearsOfService,
+}: {
+	yearsOfService: number;
+} ) {
+	const translate = useTranslate();
+	return (
+		<AchievementCard
+			className="is-years-of-service"
+			iconNode={ <YearsOfServiceBadge size="achievement-card" yearsOfService={ yearsOfService } /> }
+			title={ translate( 'Years of Service' ) }
+			description={ translate(
+				'%(years)d year on WordPress.com.',
+				'%(years)d years on WordPress.com.',
+				{
+					count: yearsOfService,
+					args: { years: yearsOfService },
+				}
+			) }
+		/>
+	);
+}

--- a/client/reader/user-profile/views/achievements/index.tsx
+++ b/client/reader/user-profile/views/achievements/index.tsx
@@ -2,7 +2,6 @@ import { Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useAchievementsQuery } from 'calypso/data/reader/use-achievements-query';
 import useAchievementsVisibility from 'calypso/reader/components/achievements/use-achievements-visibility';
-import { YearsOfServiceBadge } from 'calypso/reader/components/achievements/years-of-service-badge';
 import AchievementsGrid from './achievements-grid';
 import AchievementsSettings from './achievements-settings';
 import { ActivityStreak } from './activity-streak';
@@ -17,12 +16,9 @@ interface UserAchievementsProps {
 const UserAchievements = ( { user }: UserAchievementsProps ): JSX.Element | null => {
 	const translate = useTranslate();
 	const { isOwnProfile, isVisible, isLoading } = useAchievementsVisibility( user.user_login );
-	const { yearsOfService, engagementStreak } = useAchievementsQuery(
-		isVisible ? user.user_login : undefined,
-		{
-			refetchOnMount: 'always',
-		}
-	);
+	const { engagementStreak } = useAchievementsQuery( isVisible ? user.user_login : undefined, {
+		refetchOnMount: 'always',
+	} );
 
 	if ( isLoading ) {
 		return (
@@ -40,9 +36,6 @@ const UserAchievements = ( { user }: UserAchievementsProps ): JSX.Element | null
 		<div className="achievements">
 			<div className="achievements__header">
 				<ActivityStreak streak={ engagementStreak } isOwnProfile={ isOwnProfile } />
-				{ !! yearsOfService && (
-					<YearsOfServiceBadge size="large" yearsOfService={ yearsOfService } />
-				) }
 				{ isOwnProfile && (
 					<div className="achievements__settings">
 						<AchievementsSettings />

--- a/client/reader/user-profile/views/achievements/style.scss
+++ b/client/reader/user-profile/views/achievements/style.scss
@@ -1,32 +1,18 @@
 .is-reader-page {
 	.achievements__header {
 		display: flex;
-		flex-wrap: wrap;
 		align-items: flex-start;
 		gap: 24px;
 		margin: 16px auto 48px;
 		max-width: 720px;
-		position: relative;
-		// Reserve room on the right for the absolutely-positioned settings button
-		// so flex children never run into it. `border-box` keeps the padding
-		// inside the 720px cap so the header doesn't grow past its alignment.
-		box-sizing: border-box;
-		padding-inline-end: 48px;
 	}
 
 	.achievements__header > .activity-streak {
-		// 360px is the wrap floor: as long as the row can seat the streak at
-		// 360px (alongside YOS), it stays a single row. Below that, YOS drops to
-		// its own row and the streak shrinks to the available width — at which
-		// point the streak's internal layout wraps its content under the badge.
-		flex: 1 1 360px;
+		flex: 1 1 auto;
+		min-width: 0;
 	}
 
-	// Pinned top-right of the header, regardless of which other items are
-	// present or how the row wraps.
 	.achievements__header > .achievements__settings {
-		position: absolute;
-		inset-block-start: 0;
-		inset-inline-end: 0;
+		flex: 0 0 auto;
 	}
 }

--- a/client/reader/user-profile/views/achievements/test/index.test.tsx
+++ b/client/reader/user-profile/views/achievements/test/index.test.tsx
@@ -23,12 +23,6 @@ jest.mock( '../achievements-settings', () => ( {
 	default: () => <button data-testid="achievements-settings">Settings</button>,
 } ) );
 
-jest.mock( 'calypso/reader/components/achievements/years-of-service-badge', () => ( {
-	YearsOfServiceBadge: ( { yearsOfService }: { yearsOfService: number } ) => (
-		<div data-testid="years-of-service-badge">{ yearsOfService }</div>
-	),
-} ) );
-
 const mockActivityStreakProps = jest.fn();
 jest.mock( '../activity-streak', () => ( {
 	__esModule: true,
@@ -65,7 +59,6 @@ describe( 'UserAchievements', () => {
 		mockAchievementsGridProps.mockClear();
 		mockActivityStreakProps.mockClear();
 		useAchievementsQuery.mockReturnValue( {
-			yearsOfService: undefined,
 			lockedAchievements: [],
 			isLoading: false,
 		} );
@@ -133,50 +126,6 @@ describe( 'UserAchievements', () => {
 		expect( screen.queryByTestId( 'achievements-settings' ) ).not.toBeInTheDocument();
 	} );
 
-	test( 'should render YearsOfServiceBadge when years_of_service > 0', () => {
-		useAchievementsVisibility.mockReturnValue( {
-			isOwnProfile: false,
-			isVisible: true,
-			isLoading: false,
-		} );
-		useAchievementsQuery.mockReturnValue( { yearsOfService: 5, isLoading: false } );
-
-		render( <UserAchievements user={ defaultUser } /> );
-
-		expect( screen.getByTestId( 'years-of-service-badge' ) ).toBeVisible();
-		expect( screen.getByText( '5' ) ).toBeVisible();
-	} );
-
-	test( 'should not render YearsOfServiceBadge when years_of_service is 0', () => {
-		useAchievementsVisibility.mockReturnValue( {
-			isOwnProfile: false,
-			isVisible: true,
-			isLoading: false,
-		} );
-		useAchievementsQuery.mockReturnValue( { yearsOfService: 0, isLoading: false } );
-
-		render( <UserAchievements user={ defaultUser } /> );
-
-		expect( screen.queryByTestId( 'years-of-service-badge' ) ).not.toBeInTheDocument();
-	} );
-
-	test( 'should not render YearsOfServiceBadge when years_of_service is undefined', () => {
-		useAchievementsVisibility.mockReturnValue( {
-			isOwnProfile: false,
-			isVisible: true,
-			isLoading: false,
-		} );
-		useAchievementsQuery.mockReturnValue( {
-			yearsOfService: undefined,
-			lockedAchievements: [],
-			isLoading: false,
-		} );
-
-		render( <UserAchievements user={ defaultUser } /> );
-
-		expect( screen.queryByTestId( 'years-of-service-badge' ) ).not.toBeInTheDocument();
-	} );
-
 	test( 'forwards isOwnProfile=true to AchievementsGrid on own profile', () => {
 		useAchievementsVisibility.mockReturnValue( {
 			isOwnProfile: true,
@@ -212,7 +161,6 @@ describe( 'UserAchievements', () => {
 			isLoading: false,
 		} );
 		useAchievementsQuery.mockReturnValue( {
-			yearsOfService: undefined,
 			lockedAchievements: [],
 			engagementStreak: {
 				current_streak: 7,
@@ -241,7 +189,6 @@ describe( 'UserAchievements', () => {
 			isLoading: false,
 		} );
 		useAchievementsQuery.mockReturnValue( {
-			yearsOfService: undefined,
 			lockedAchievements: [],
 			engagementStreak: undefined,
 			isLoading: false,


### PR DESCRIPTION
Part of RSM-2919

Stacked on #110708 (the streak-view PR). Reviewing as `rsm-2919-streak-view ← rsm-2919-yos-achievement-card` keeps the diff focused on the YOS-card refactor.

## Proposed Changes

<img width="1283" height="559" alt="Screenshot 2026-05-13 at 18 02 07" src="https://github.com/user-attachments/assets/5da7ec57-3ca2-4f00-9958-b26b63415fe0" />


* New `YearsOfServiceAchievement` card, prepended to the unlocked achievements grid whenever `yearsOfService > 0`. It uses an 80px YOS badge as the card icon, a "Years of Service" title, and a pluralized "X year(s) on WordPress.com." description — no caption, no unlocked byline.
* New `achievementCard` size on `YearsOfServiceBadge` (80×80, 2rem digits, same blue shadow + SVG background as the 120px hero). Inline sizes (`medium`/`small`) are untouched. Hosted-inside-a-container sizes (`large`/`achievementCard`) skip the redundant title/aria-label on the circle.
* New `label` prop on `YearsOfServiceBadge` — defaults to the existing pluralized "Year(s) on WordPress.com" so prior call sites are unchanged. Consumers can override or suppress (via `""`) without touching CSS.
* `AchievementCard` gains an `iconNode` escape hatch (for non-`<img>` icons) and a `className` pass-through (so variants can opt into their own styling).
* Hero treatment: a diagonal shine sweeps across the YOS card on hover, adapted from the existing YOS-badge linked-variant animation. Respects `prefers-reduced-motion`.
* Achievements header is stripped down to `ActivityStreak` + the settings button — no more container query, responsive flex basis, padding-inline-end reservation, or absolute settings positioning. YOS leaving the header removed the entire alignment-balancing problem.

## Why are these changes being made?

The previous layout tried to balance YOS, ActivityStreak, and the settings button in the same header row, which required a stack of responsive tricks (container queries, per-child flex bases, an absolutely-positioned settings button on a `box-sizing: border-box` shell with reserved padding-inline-end). At small viewports the badges still bumped into each other and the inner content broke alignment.

Treating YOS as just another achievement — and giving it a hero card slot — collapses the header to a single component and lets the existing grid handle YOS responsively for free.

## Testing Instructions

* Visit `/reader/users/<some-user>/achievements` for a user with `years_of_service > 0`. The first card in the unlocked grid should be the YOS hero card (80px badge on the left, "Years of Service" title, pluralized description, no byline). Hover the card to see the diagonal shine sweep across.
* Same view for a user with `years_of_service === 0`: no YOS card; the rest of the grid behaves as before.
* Same view for a user with no other achievements but `years_of_service > 0`: the YOS card surfaces alone (the "No achievements yet." copy is suppressed).
* Resize the viewport down to mobile widths. The header (now just `ActivityStreak` + settings) should keep its existing internal wrap behavior; the grid handles the YOS card responsively alongside other cards.
* `AuthorAchievementBadges` (the inline YOS badge next to author names) still renders at `medium`/`small` — its props didn't change.
* Toggle `prefers-reduced-motion: reduce` in the OS / devtools; hovering the YOS card should not animate.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?