### PR TITLE
Cancellation Features: add support for AB treatment

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -434,6 +434,8 @@ export const cancelPurchaseRoute = createRoute( {
 			queryClient.ensureQueryData( productsQuery() ),
 			queryClient.ensureQueryData( siteFeaturesQuery( purchase.blog_id ) ),
 			queryClient.ensureQueryData( plansQuery() ),
+			// Prefetch the default (control) variant; the component refetches
+			// under the 'treatment' key when the split-cancel-remove flag is on.
 			queryClient.ensureQueryData( purchaseCancelFeaturesQuery( purchase.ID ) ),
 		] );
 		return { purchase, intent };

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -389,8 +389,12 @@ function CancelPurchaseInner() {
 		siteFeaturesQuery( purchase.blog_id )
 	);
 	const { data: plans } = useSuspenseQuery( plansQuery() );
+	const isSplitCancelRemoveEnabled = useIsSplitCancelRemoveEnabled();
 	const { data: purchaseCancelFeatures } = useQuery(
-		purchaseCancelFeaturesQuery( parseInt( purchaseId, 10 ) )
+		purchaseCancelFeaturesQuery(
+			parseInt( purchaseId, 10 ),
+			isSplitCancelRemoveEnabled ? 'treatment' : 'control'
+		)
 	);
 
 	const lastSiteQueryIsError = useRef< boolean >( false );
@@ -438,8 +442,6 @@ function CancelPurchaseInner() {
 		error: offerApplyError,
 	} = useMutation( applyCancellationOfferMutation( purchase.blog_id, purchase.ID ) );
 	const marketingSurveyMutate = useMutation( marketingSurveyMutation() );
-
-	const isSplitCancelRemoveEnabled = useIsSplitCancelRemoveEnabled();
 
 	// Handler helpers
 	const purchases = purchase && sitePurchases;

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -1,4 +1,5 @@
 import { removePurchase as removePurchaseRequest } from '@automattic/api-core';
+import { purchaseCancelFeaturesQuery } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
 import {
 	isDomainRegistration,
@@ -18,6 +19,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { formatCurrency } from '@automattic/number-formatters';
 import { invokeSurvicateEvent } from '@automattic/survicate';
 import { useCanConnectToZendeskMessaging } from '@automattic/zendesk-client';
+import { useQuery } from '@tanstack/react-query';
 import { Button as GutenbergButton } from '@wordpress/components';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { localize, LocalizeProps } from 'i18n-calypso';
@@ -1381,10 +1383,18 @@ const ConnectedCancelPurchase = connect(
 
 function CancelPurchaseWithExperiment( props: CancelPurchaseProps ) {
 	const isSplitCancelRemoveEnabled = useIsSplitCancelRemoveEnabled();
+	const { data: purchaseCancelFeatures, isPending: isPurchaseCancelFeaturesLoading } = useQuery(
+		purchaseCancelFeaturesQuery(
+			props.purchaseId,
+			isSplitCancelRemoveEnabled ? 'treatment' : 'control'
+		)
+	);
 	return (
 		<ConnectedCancelPurchase
 			{ ...props }
 			isSplitCancelRemoveEnabled={ isSplitCancelRemoveEnabled }
+			purchaseCancelFeatures={ purchaseCancelFeatures }
+			isPurchaseCancelFeaturesLoading={ isPurchaseCancelFeaturesLoading }
 		/>
 	);
 }

--- a/packages/api-core/src/upgrades/fetchers.ts
+++ b/packages/api-core/src/upgrades/fetchers.ts
@@ -63,10 +63,14 @@ export async function hasExtendedPurchase( purchaseId: number ): Promise< boolea
 }
 
 export async function fetchCancellationFeatures(
-	purchaseId: number
+	purchaseId: number,
+	variant?: 'control' | 'treatment'
 ): Promise< UpgradesCancelFeaturesResponse > {
-	return await wpcom.req.get( {
-		path: `/upgrades/${ purchaseId }/cancel-features`,
-		apiNamespace: 'wpcom/v2',
-	} );
+	return await wpcom.req.get(
+		{
+			path: `/upgrades/${ purchaseId }/cancel-features`,
+			apiNamespace: 'wpcom/v2',
+		},
+		variant ? { variant } : {}
+	);
 }

--- a/packages/api-queries/src/upgrades.ts
+++ b/packages/api-queries/src/upgrades.ts
@@ -44,10 +44,13 @@ export const purchaseQuery = ( purchaseId: number ) =>
 		queryFn: () => fetchPurchase( purchaseId ),
 	} );
 
-export const purchaseCancelFeaturesQuery = ( purchaseId: number ) =>
+export const purchaseCancelFeaturesQuery = (
+	purchaseId: number,
+	variant?: 'control' | 'treatment'
+) =>
 	queryOptions( {
-		queryKey: [ 'upgrades', purchaseId, 'cancel-features' ],
-		queryFn: () => fetchCancellationFeatures( purchaseId ),
+		queryKey: [ 'upgrades', purchaseId, 'cancel-features', variant ?? 'control' ],
+		queryFn: () => fetchCancellationFeatures( purchaseId, variant ),
 	} );
 
 export const hasPurchaseBeenExtendedQuery = ( purchaseId: number ) =>

--- a/packages/api-queries/src/upgrades.ts
+++ b/packages/api-queries/src/upgrades.ts
@@ -46,10 +46,10 @@ export const purchaseQuery = ( purchaseId: number ) =>
 
 export const purchaseCancelFeaturesQuery = (
 	purchaseId: number,
-	variant?: 'control' | 'treatment'
+	variant: 'control' | 'treatment' = 'control'
 ) =>
 	queryOptions( {
-		queryKey: [ 'upgrades', purchaseId, 'cancel-features', variant ?? 'control' ],
+		queryKey: [ 'upgrades', purchaseId, 'cancel-features', variant ],
 		queryFn: () => fetchCancellationFeatures( purchaseId, variant ),
 	} );
 


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/RSM-478/

Depends on 217198-ghe-Automattic/wpcom adding the `variant` query param to `/wpcom/v2/upgrades/{id}/cancel-features` (link once filed).

## Proposed changes

This wires both cancellation surfaces (Dashboard and legacy Calypso) to fetch the `/wpcom/v2/upgrades/{id}/cancel-features` endpoint with a `variant` field driven by the `useIsSplitCancelRemoveEnabled` gate. When the experiment is on, the client requests `variant=treatment` and the backend returns benefit-oriented plan copy; otherwise it requests `variant=control` and gets today's response. Replaces the client-side override approach from #110478.

* Add `variant?: 'control' | 'treatment'` arg to `fetchCancellationFeatures()`; emits `?variant=…` only when provided.
* Add `variant?` arg to `purchaseCancelFeaturesQuery()` and include it in the `queryKey` so cache entries don't collide between variants.
* Dashboard `cancel-purchase/index.tsx`: hoist `useIsSplitCancelRemoveEnabled()` to the top of the component and pass `'treatment'` or `'control'` to the query.
* Dashboard route prefetch in `app/router/me.tsx`: keeps prefetching the control variant (the loader can't call hooks); the component refetches under the treatment key when the flag is on. Brief comment explains this.
* Legacy `cancel-purchase/index.tsx`: `CancelPurchaseWithExperiment` now actually fetches the query and passes `purchaseCancelFeatures` + `isPurchaseCancelFeaturesLoading` into `ConnectedCancelPurchase`. Previously the prop was declared but never passed, so the legacy surface always fell through to static fallback copy.

## Why are these changes being made?

#110478 introduced a parallel JS routing layer (`getOverrideCancellationFeatures`) keyed by product category, but the backend endpoint already routes by category and has access to dynamic subscription data (primary domain via `meta` / atomic-transfer redirect, etc.) that the client doesn't have without extra queries. Moving variant routing into the existing endpoint avoids duplicating that routing in two places, and it lets us close the gap where the legacy Calypso surface had wired the prop but never actually called the endpoint — every legacy cancel/remove screen was showing the per-product-type fallback copy.

The trade-off is one extra round-trip when the flag flips (the route prefetch only covers control), but the cache key includes the variant so subsequent renders are warm.

## Testing instructions

TC:
```
yarn typecheck
yarn jest client/dashboard/me/billing-purchases/cancel-purchase client/me/purchases/cancel-purchase
```

Manual testing:
* Backend PR deployed to sandbox / your local Calypso pointed at a sandbox that has it.
* Toggle `purchases/split-cancel-remove` in Calypso config (or get assigned to the `calypso_new_cancel_refund_flow_20260408` experiment treatment).
* **Dashboard surface** (`/me/billing/purchases/{id}/cancel`):
  * Flag off → loads control variant; feature list matches trunk exactly.
  * Flag on → loads treatment variant; feature list shows benefit-oriented bullets (e.g. "6 GB of storage", "Audio uploads") for personal/premium/business/ecommerce plans.
  * Check Network tab: requests hit `?variant=control` or `?variant=treatment` as expected and cache under separate keys.
* **Legacy surface** (`/purchases/subscriptions/{site}/{id}/cancel`):
  * Flag off → feature list now reflects the API response (was previously always falling back to static copy on this surface). Compare against the response payload in DevTools.
  * Flag on → same treatment copy as Dashboard.
* Non-plan subscriptions (Jetpack, GSuite, marketplace add-on): both surfaces, both flag states, should match the API response (treatment falls through to control on the backend for these).