### PR TITLE
Plans Comparison Grid: stop popular badge from sliding when sticky header re-engages

### DIFF
--- a/packages/plans-grid-next/src/components/comparison-grid/style.scss
+++ b/packages/plans-grid-next/src/components/comparison-grid/style.scss
@@ -92,7 +92,6 @@
 					/* stylelint-disable-next-line */
 					border-radius: 5px 5px 0 0;
 					border-style: solid;
-					transition: top 0.2s ease;
 				}
 
 				.popular-badge-is-stuck {


### PR DESCRIPTION
## Summary

In the onboarding extended pricing grid (plan comparison grid), the "POPULAR" badge above the highlighted plan column has a CSS `transition: top 0.2s ease` that animates a ~33px slide between its unstuck (`top: -43px`) and stuck (`top: -10px`) positions. Each time the sticky comparison header re-engages — most noticeably when you scroll past the footer and back up — the badge replays that slide, which reads as the table's small header labels animating inconsistently.

This PR removes the transition so the badge snaps between the two positions, matching the rest of the sticky header which has no entrance animation.

Fixes Linear DOTCOM-12836 / #100224.

### Before
Badge slides ~33px every time the sticky header toggles state.

### After
Badge snaps cleanly between positions.

## Testing

- [x] Verified the only animation on `.plan-features-2023-grid__popular-badge` was the `top` transition — no other selectors, JS handlers (transitionend, etc.), tests, or storybook baselines depend on it.
- [x] Confirmed `.popular-badge-is-stuck` is toggled via `isStuck` from `StickyContainer`'s IntersectionObserver (`packages/plans-grid-next/src/components/sticky-container.tsx`) — that mechanism is unchanged.
- [ ] To verify visually: load the onboarding plans-comparison step on a wide viewport, scroll the comparison grid past the footer, then back up — the "POPULAR" pill above the highlighted plan should snap into the sticky header instead of sliding into place.