### PR TITLE
date-range: code-split DateRangePicker

### DIFF
--- a/client/components/date-range/index.jsx
+++ b/client/components/date-range/index.jsx
@@ -556,7 +556,7 @@ export class DateRange extends Component {
 	 */
 	renderDatePicker() {
 		return (
-			<Suspense fallback={ <div className="date-range__picker-placeholder" /> }>
+			<Suspense fallback={ null }>
 				<DateRangePicker
 					firstSelectableDate={ this.props.firstSelectableDate }
 					lastSelectableDate={ this.props.lastSelectableDate }

--- a/client/components/date-range/index.jsx
+++ b/client/components/date-range/index.jsx
@@ -4,9 +4,8 @@ import { localize } from 'i18n-calypso';
 import { debounce } from 'lodash';
 import moment from 'moment';
 import PropTypes from 'prop-types';
-import { createRef, Component } from 'react';
+import { createRef, Component, lazy, Suspense } from 'react';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
-import DateRangePicker from './date-range-picker';
 import DateRangeFooter from './footer';
 import DateRangeHeader from './header';
 import DateRangeInputs from './inputs';
@@ -14,6 +13,12 @@ import Shortcuts from './shortcuts';
 import DateRangeTrigger from './trigger';
 
 import './style.scss';
+
+const loadDateRangePicker = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-components-date-range-date-range-picker" */ './date-range-picker'
+	);
+const DateRangePicker = lazy( loadDateRangePicker );
 
 /**
  * Module variables
@@ -141,6 +146,8 @@ export class DateRange extends Component {
 
 	componentDidMount() {
 		window.addEventListener( 'resize', this.throttledHandleResize );
+		// Pre-warm the picker chunk so it's ready by the time the popover opens.
+		loadDateRangePicker();
 	}
 
 	componentWillUnmount() {
@@ -549,16 +556,18 @@ export class DateRange extends Component {
 	 */
 	renderDatePicker() {
 		return (
-			<DateRangePicker
-				firstSelectableDate={ this.props.firstSelectableDate }
-				lastSelectableDate={ this.props.lastSelectableDate }
-				selectedStartDate={ this.state.startDate }
-				selectedEndDate={ this.state.endDate }
-				onDateRangeChange={ this.handleDateRangeChange }
-				focusedMonth={ this.state.focusedMonth }
-				numberOfMonths={ this.state.numberOfMonths }
-				useArrowNavigation={ this.props.useArrowNavigation }
-			/>
+			<Suspense fallback={ <div className="date-range__picker-placeholder" /> }>
+				<DateRangePicker
+					firstSelectableDate={ this.props.firstSelectableDate }
+					lastSelectableDate={ this.props.lastSelectableDate }
+					selectedStartDate={ this.state.startDate }
+					selectedEndDate={ this.state.endDate }
+					onDateRangeChange={ this.handleDateRangeChange }
+					focusedMonth={ this.state.focusedMonth }
+					numberOfMonths={ this.state.numberOfMonths }
+					useArrowNavigation={ this.props.useArrowNavigation }
+				/>
+			</Suspense>
 		);
 	}
 

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -81,6 +81,10 @@ $date-range-mobile-layout-switch: $break-small;
 	}
 }
 
+.date-range__picker-placeholder {
+	min-height: 290px;
+}
+
 .date-range__controls {
 	order: 1;
 	display: flex;
@@ -304,7 +308,9 @@ $date-range-mobile-layout-switch: $break-small;
 			}
 		}
 	}
-	.DayPicker-Day--range:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
+	// DateRangePicker is lazy-loaded; extra `&.date-picker` specificity
+	// ensures this rule wins regardless of CSS chunk load order.
+	&.date-picker .DayPicker-Day--range:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
 		background-color: var(--date-range-picker-highlight-color);
 		.date-picker__day {
 			background-color: transparent;

--- a/client/components/date-range/style.scss
+++ b/client/components/date-range/style.scss
@@ -81,10 +81,6 @@ $date-range-mobile-layout-switch: $break-small;
 	}
 }
 
-.date-range__picker-placeholder {
-	min-height: 290px;
-}
-
 .date-range__controls {
 	order: 1;
 	display: flex;


### PR DESCRIPTION
## Proposed Changes

Lazy-loads `client/components/date-range`'s picker chunk (`react-day-picker` + `date-fns`) via `React.lazy` + `Suspense`. The chunk is pre-warmed in `componentDidMount` so the popover opens without a Suspense flash on first click.

Module-scoped `lazy()` persists across `Popover` unmount/remount cycles, so only the **very first** open in a session can suspend — every subsequent open is synchronous.

Also bumps the range-middle highlight selector with an extra `&.date-picker` so it still beats `date-picker/style.scss` after that file moves into the lazy CSS chunk and lands later in the cascade.

## Why are these changes being made?

`DateRangePicker` is heavy (the picker + its locale data) but only appears inside popovers — it's never on the page on first paint. Eagerly bundling it inflates the critical path on every surface that imports `DateRange`, including odyssey-stats where it has been the largest single chunk.

Deferring it:

- **Removes it from odyssey-stats' eager `build.min.js`** — relevant because odyssey-stats has a hard 495 KiB size-limit cap (`apps/odyssey-stats/AGENTS.md`).
- **Shrinks the Calypso main bundle** for every surface that loads `DateRange` (activity log, stats, site logs, backup).
- **Costs ~0 UX** because the chunk pre-warms as soon as the host component mounts, well before the user clicks the trigger.

This is also a prerequisite for #110626 (react-day-picker v9 migration): v9 has a hard runtime dep on `date-fns` that v7 didn't, which would otherwise push odyssey-stats over its size cap. Landing the code-split first lets that PR ship without the budget bust.

## Testing Instructions

Run \`yarn start\` and exercise each surface — picker should appear normally on first click (chunk is pre-warmed at mount):

- **Activity log filterbar** — \`/activity-log/:site\` → open range trigger.
- **Stats date control** — \`/stats/day/:site\`, \`/stats/week/:site\`, \`/stats/month/:site\`, \`/stats/year/:site\`.
- **Site logs** — \`/site-logs/:site/php\`, \`/site-logs/:site/web\`.

Check DevTools Network tab — the picker chunk should load as a separate async chunk, not part of the main bundle.

Range-middle highlight: select a date range and confirm the middle days still show the highlight styling correctly (the CSS specificity bump).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation? — no new strings.