### PR TITLE
A4A: Enable a4a-ai-mcp feature flag on Stage

### DIFF
--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -28,7 +28,7 @@
 	"oauth_client_id": 95931,
 	"features": {
 		"a4a-agent-studio": false,
-		"a4a-ai-mcp": false,
+		"a4a-ai-mcp": true,
 		"a4a-benchmarks": false,
 		"a4a-bd-checkout": false,
 		"a4a-bd-term-pricing": true,


### PR DESCRIPTION
Related to A4A-2605

## Proposed Changes

* Flip `a4a-ai-mcp` from `false` → `true` in `config/a8c-for-agencies-stage.json`.

## Why are these changes being made?

* The A4A MCP settings UI (`/resources-and-tools/ai-mcp`) is ready for broader internal testing on Stage. The flag is already enabled on Development and Horizon; Production stays disabled.

## Testing Instructions

* Confirm `a4a-ai-mcp` is `true` in `config/a8c-for-agencies-stage.json`. Production remains `false`.
* On `agencies-stage.wpcalypso.wordpress.com`, the MCP entry under Resources and tools is reachable and the settings page renders the categorized cards.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)