### PR TITLE
Reader achievements: stop ActivityStreak tests breaking at midnight

### DIFF
--- a/client/reader/user-profile/views/achievements/activity-streak/test/index.test.tsx
+++ b/client/reader/user-profile/views/achievements/activity-streak/test/index.test.tsx
@@ -3,11 +3,20 @@
  */
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import MockDate from 'mockdate';
 import { ActivityStreak } from '../index';
 import type { EngagementStreak } from '@automattic/api-core';
 
 const TODAY = '2026-05-13';
 const YESTERDAY = '2026-05-12';
+
+beforeEach( () => {
+	MockDate.set( `${ TODAY }T12:00:00Z` );
+} );
+
+afterEach( () => {
+	MockDate.reset();
+} );
 
 const baseStreak: EngagementStreak = {
 	current_streak: 12,


### PR DESCRIPTION
## Summary

The ActivityStreak test suite hardcodes \`TODAY = '2026-05-13'\` and \`YESTERDAY = '2026-05-12'\`, but the component derives \"today\" from the real clock via \`moment().format( 'YYYY-MM-DD' )\`. Every assertion that depends on \"engaged today\" or \"freeze used yesterday\" starts failing as soon as the real date rolls past May 13 — which it now has.

Wrap the suite with \`MockDate.set( ${ TODAY }T12:00:00Z )\` / \`afterEach( MockDate.reset )\` so the component sees the same date the fixtures assume. Same pattern used by the \`DateRangePicker\` tests.

## Test plan

- \`yarn test-client client/reader/user-profile/views/achievements/activity-streak/test/index.test.tsx\` → 23/23 pass on any wall-clock date.