### PR TITLE
Add CHANGELOG.md to @automattic/date-range-picker

### DIFF
--- a/packages/date-range-picker/CHANGELOG.md
+++ b/packages/date-range-picker/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial release ([#110712](https://github.com/Automattic/wp-calypso/pull/110712))


### PR DESCRIPTION
## Summary

Pre-publish prep — the package was added in #110712 without a CHANGELOG.md. Adds one in the same format as `@automattic/launchpad` so the 1.0.0 release is documented before it goes to npm.

## Test plan

- N/A (docs only)