### PR TITLE
A4A Agent studio: Replace mock projects service with wpcom backend

### DIFF
--- a/client/a8c-for-agencies/sections/agent-studio/data/agent-studio-service.ts
+++ b/client/a8c-for-agencies/sections/agent-studio/data/agent-studio-service.ts
@@ -1,4 +1,24 @@
+import { useMemo } from 'react';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { mockAgentStudioService } from './mock-agent-studio-service';
+import { createWpcomAgentStudioService } from './wpcom-agent-studio-service';
 import type { AgentStudioService } from '../types';
 
-export const agentStudioService: AgentStudioService = mockAgentStudioService;
+/**
+ * Returns the Agent Studio service bound to the currently active agency.
+ *
+ * Falls back to the localStorage-backed mock when there is no active agency in
+ * context (Storybook, isolated tests, pre-onboarding states). The mock is kept
+ * as an offline fallback and will be removed in a follow-up cycle.
+ */
+export function useAgentStudioService(): AgentStudioService {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	return useMemo( () => {
+		if ( ! agencyId ) {
+			return mockAgentStudioService;
+		}
+		return createWpcomAgentStudioService( agencyId );
+	}, [ agencyId ] );
+}

--- a/client/a8c-for-agencies/sections/agent-studio/data/use-agent-studio-project-outputs.ts
+++ b/client/a8c-for-agencies/sections/agent-studio/data/use-agent-studio-project-outputs.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { agentStudioService } from './agent-studio-service';
+import { useAgentStudioService } from './agent-studio-service';
 import type { AgentStudioOutput } from '../types';
 
 export const getAgentStudioProjectOutputsQueryKey = ( projectId?: string ) => [
@@ -8,9 +8,11 @@ export const getAgentStudioProjectOutputsQueryKey = ( projectId?: string ) => [
 ];
 
 export default function useAgentStudioProjectOutputs( projectId?: string ) {
+	const service = useAgentStudioService();
+
 	return useQuery< AgentStudioOutput[] >( {
 		queryKey: getAgentStudioProjectOutputsQueryKey( projectId ),
-		queryFn: () => agentStudioService.listProjectOutputs( projectId as string ),
+		queryFn: () => service.listProjectOutputs( projectId as string ),
 		enabled: !! projectId,
 		refetchOnWindowFocus: false,
 	} );

--- a/client/a8c-for-agencies/sections/agent-studio/data/use-agent-studio-project.ts
+++ b/client/a8c-for-agencies/sections/agent-studio/data/use-agent-studio-project.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { agentStudioService } from './agent-studio-service';
+import { useAgentStudioService } from './agent-studio-service';
 import type { AgentStudioProject } from '../types';
 
 export const getAgentStudioProjectQueryKey = ( projectId?: string ) => [
@@ -8,9 +8,11 @@ export const getAgentStudioProjectQueryKey = ( projectId?: string ) => [
 ];
 
 export default function useAgentStudioProject( projectId?: string ) {
+	const service = useAgentStudioService();
+
 	return useQuery< AgentStudioProject | undefined >( {
 		queryKey: getAgentStudioProjectQueryKey( projectId ),
-		queryFn: () => agentStudioService.getProject( projectId as string ),
+		queryFn: () => service.getProject( projectId as string ),
 		enabled: !! projectId,
 		refetchOnWindowFocus: false,
 	} );

--- a/client/a8c-for-agencies/sections/agent-studio/data/use-agent-studio-projects.ts
+++ b/client/a8c-for-agencies/sections/agent-studio/data/use-agent-studio-projects.ts
@@ -1,13 +1,15 @@
 import { useQuery } from '@tanstack/react-query';
-import { agentStudioService } from './agent-studio-service';
+import { useAgentStudioService } from './agent-studio-service';
 import type { AgentStudioProjectSummary } from '../types';
 
 export const getAgentStudioProjectsQueryKey = () => [ 'a4a-agent-studio-projects' ];
 
 export default function useAgentStudioProjects() {
+	const service = useAgentStudioService();
+
 	return useQuery< AgentStudioProjectSummary[] >( {
 		queryKey: getAgentStudioProjectsQueryKey(),
-		queryFn: () => agentStudioService.listProjects(),
+		queryFn: () => service.listProjects(),
 		refetchOnWindowFocus: false,
 	} );
 }

--- a/client/a8c-for-agencies/sections/agent-studio/data/use-create-agent-studio-project.ts
+++ b/client/a8c-for-agencies/sections/agent-studio/data/use-create-agent-studio-project.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient, type UseMutationOptions } from '@tanstack/react-query';
-import { agentStudioService } from './agent-studio-service';
+import { useAgentStudioService } from './agent-studio-service';
 import { getAgentStudioProjectQueryKey } from './use-agent-studio-project';
 import { getAgentStudioProjectsQueryKey } from './use-agent-studio-projects';
 import type {
@@ -11,10 +11,11 @@ type Options = UseMutationOptions< AgentStudioProject, Error, CreateAgentStudioP
 
 export default function useCreateAgentStudioProject( options?: Options ) {
 	const queryClient = useQueryClient();
+	const service = useAgentStudioService();
 
 	return useMutation< AgentStudioProject, Error, CreateAgentStudioProjectInput >( {
 		...options,
-		mutationFn: ( input ) => agentStudioService.createProject( input ),
+		mutationFn: ( input ) => service.createProject( input ),
 		onSuccess: ( project, variables, context ) => {
 			queryClient.setQueryData( getAgentStudioProjectQueryKey( project.id ), project );
 			queryClient.invalidateQueries( { queryKey: getAgentStudioProjectsQueryKey() } );

--- a/client/a8c-for-agencies/sections/agent-studio/data/use-delete-agent-studio-project.ts
+++ b/client/a8c-for-agencies/sections/agent-studio/data/use-delete-agent-studio-project.ts
@@ -1,15 +1,16 @@
 import { useMutation, useQueryClient, type UseMutationOptions } from '@tanstack/react-query';
-import { agentStudioService } from './agent-studio-service';
+import { useAgentStudioService } from './agent-studio-service';
 import { getAgentStudioProjectsQueryKey } from './use-agent-studio-projects';
 
 type Options = UseMutationOptions< void, Error, string >;
 
 export default function useDeleteAgentStudioProject( options?: Options ) {
 	const queryClient = useQueryClient();
+	const service = useAgentStudioService();
 
 	return useMutation< void, Error, string >( {
 		...options,
-		mutationFn: ( projectId ) => agentStudioService.deleteProject( projectId ),
+		mutationFn: ( projectId ) => service.deleteProject( projectId ),
 		onSuccess: ( result, projectId, context ) => {
 			queryClient.invalidateQueries( { queryKey: getAgentStudioProjectsQueryKey() } );
 			options?.onSuccess?.( result, projectId, context );

--- a/client/a8c-for-agencies/sections/agent-studio/data/wpcom-agent-studio-service.ts
+++ b/client/a8c-for-agencies/sections/agent-studio/data/wpcom-agent-studio-service.ts
@@ -1,0 +1,73 @@
+import wpcom from 'calypso/lib/wp';
+import type {
+	AgentStudioOutput,
+	AgentStudioProject,
+	AgentStudioProjectSummary,
+	AgentStudioService,
+	CreateAgentStudioProjectInput,
+} from '../types';
+
+type WpRestError = { data?: { status?: number } };
+
+const isNotFoundError = ( error: unknown ): boolean =>
+	( error as WpRestError )?.data?.status === 404;
+
+export function createWpcomAgentStudioService( agencyId: number ): AgentStudioService {
+	const basePath = ( rest = '' ) => `/agency/${ agencyId }/a4a/projects${ rest }`;
+
+	return {
+		async listProjects() {
+			const response: { projects: AgentStudioProjectSummary[] } = await wpcom.req.get( {
+				apiNamespace: 'wpcom/v2',
+				path: basePath(),
+			} );
+
+			return response?.projects ?? [];
+		},
+
+		async getProject( projectId ) {
+			try {
+				return ( await wpcom.req.get( {
+					apiNamespace: 'wpcom/v2',
+					path: basePath( `/${ projectId }` ),
+				} ) ) as AgentStudioProject;
+			} catch ( error ) {
+				if ( isNotFoundError( error ) ) {
+					return undefined;
+				}
+				throw error;
+			}
+		},
+
+		async createProject( input: CreateAgentStudioProjectInput ) {
+			return ( await wpcom.req.post(
+				{
+					apiNamespace: 'wpcom/v2',
+					path: basePath(),
+				},
+				{
+					name: input.name,
+					clientName: input.clientName,
+					brief: input.brief,
+				}
+			) ) as AgentStudioProject;
+		},
+
+		async deleteProject( projectId ) {
+			await wpcom.req.post( {
+				method: 'DELETE',
+				apiNamespace: 'wpcom/v2',
+				path: basePath( `/${ projectId }` ),
+			} );
+		},
+
+		async listProjectOutputs( projectId ) {
+			const response: { outputs: AgentStudioOutput[] } = await wpcom.req.get( {
+				apiNamespace: 'wpcom/v2',
+				path: basePath( `/${ projectId }/outputs` ),
+			} );
+
+			return response?.outputs ?? [];
+		},
+	};
+}


### PR DESCRIPTION
## Context

[PR #110716](https://github.com/Automattic/wp-calypso/pull/110716) shipped the Agent Studio Projects experience inside the A8C-for-Agencies "Agent studio" surface, behind the `a4a-agent-studio` dev feature flag. Because the REST API did not exist yet, it was wired up to a `mockAgentStudioService` that stored projects in `localStorage`.

The wpcom backend has just landed in internal PR 217422-ghe-Automattic/wpcom. It exposes five routes under `/wpcom/v2/agency/<agency_id>/a4a/projects` whose response shapes already match the TypeScript types in `client/a8c-for-agencies/sections/agent-studio/types.ts`.

## What this PR does

- Adds `data/wpcom-agent-studio-service.ts` — a `wpcom.req`-backed `AgentStudioService` factory bound to an agency id. Unwraps the `{ projects }` and `{ outputs }` envelopes server-side, treats `getProject` 404 as `undefined`, and lets every other error bubble.
- Converts `data/agent-studio-service.ts` from a module-level constant into a `useAgentStudioService()` hook. It picks the real wpcom service when there's an active agency id, and falls back to the existing mock when there isn't (Storybook, isolated tests, pre-onboarding states). The service is memoised on `agencyId`.
- Switches all five project hooks to read the service from the hook instead of importing the module-level constant.
- Keeps `mock-agent-studio-service.ts` as the offline fallback. The plan is to remove it in a follow-up cycle.

Marked **draft** because the wpcom backend PR has not merged yet — please mark ready once #217422 is in.

## Test plan

With the wpcom branch `a4a-agent-studio/backend` (PR #217422) applied to a dev sandbox or staging environment, and the `a4a-agent-studio` feature flag enabled:

1. Sign in to A8C-for-Agencies and pick the agency you want to test against (`<agency_id>`).
2. Navigate to **Agent studio** in the sidebar. The overview should load with no projects and no console errors. The network tab should show `GET /wpcom/v2/agency/<agency_id>/a4a/projects`.
3. Click **Create project**, fill in a name + optional client name / brief, submit. Confirm the dialog closes, the new project appears in the overview list, and `POST /wpcom/v2/agency/<agency_id>/a4a/projects` returned 2xx with the project body.
4. Open the project detail page. Confirm `GET /wpcom/v2/agency/<agency_id>/a4a/projects/<pid>` and `GET /wpcom/v2/agency/<agency_id>/a4a/projects/<pid>/outputs` both fire and that the page renders the project + (empty) outputs list.
5. Trigger delete from the project detail dialog. Confirm `DELETE /wpcom/v2/agency/<agency_id>/a4a/projects/<pid>` returns 2xx and the project disappears from the list on return to the overview.

Sanity check: log out / switch to an account without an active agency. The hooks should fall back to the localStorage mock without crashing.