### PR TITLE
wpcom-block-editor: Track Classic block deprecation notice actions

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/delegate-event-tracking.js
@@ -1,6 +1,7 @@
 import debugFactory from 'debug';
 import wpcomBlockDonationsPlanUpgrade from './wpcom-block-donations-plan-upgrade';
 import wpcomBlockDonationsStripeConnect from './wpcom-block-donations-stripe-connect';
+import wpcomBlockEditorClassicBlockDeprecationActionClick from './wpcom-block-editor-classic-block-deprecation-action-click';
 import wpcomBlockEditorCloseClick from './wpcom-block-editor-close-click';
 import wpcomBlockEditorDetailsOpen from './wpcom-block-editor-details-open';
 import wpcomBlockEditorGlobalStylesMenuSelected from './wpcom-block-editor-global-styles-menu-selected';
@@ -72,6 +73,7 @@ const EVENTS_MAPPING = [
 	wpcomTemplatePartChooseCapture(),
 	wpcomTemplatePartChooseBubble(),
 	wpcomTemplatePartReplaceBubble(),
+	wpcomBlockEditorClassicBlockDeprecationActionClick(),
 	wpcomBlockEditorListViewSelect(),
 	wpcomBlockEditorMissingBlockActionClick(),
 	wpcomBlockEditorTemplatePartDetachBlocks(),

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-classic-block-deprecation-action-click.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking/wpcom-block-editor-classic-block-deprecation-action-click.js
@@ -1,0 +1,33 @@
+import { __ } from '@wordpress/i18n';
+import tracksRecordEvent from './track-record-event';
+
+/**
+ * Map a translated button label to a locale-independent action id.
+ * @param {string} label The button's trimmed innerText.
+ * @returns {string} A stable identifier for the action, or `'unknown'`.
+ */
+const getActionId = ( label ) => {
+	const mapLabelToAction = {
+		[ __( 'Convert to blocks' ) ]: 'convert_to_blocks',
+		[ __( 'Convert to HTML' ) ]: 'convert_to_html',
+	};
+	return mapLabelToAction[ label ] ?? 'unknown';
+};
+
+/**
+ * Track clicks on the experimental deprecation notice action buttons inside a
+ * Classic (`core/freeform`) block.
+ * @returns {import('./types').DelegateEventHandler} event object definition.
+ */
+export default () => ( {
+	id: 'wpcom-block-editor-classic-block-deprecation-action-click',
+	selector: '.wp-block-freeform .block-editor-warning__action > button',
+	type: 'click',
+	capture: true,
+	handler: ( _event, target ) => {
+		const action = getActionId( target.innerText?.trim() ?? '' );
+		tracksRecordEvent( 'wpcom_block_editor_classic_block_deprecation_action_click', {
+			action,
+		} );
+	},
+} );


### PR DESCRIPTION
## Proposed Changes

* Record `wpcom_block_editor_classic_block_deprecation_action_click` when the user clicks an action button inside the experimental deprecation notice on a Classic (`core/freeform`) block. Payload: `action` - `convert_to_blocks`, `convert_to_html`, or `unknown`).

## Why are these changes being made?

* We want to track how users respond to the experimental deprecation notice on the Classic block - i.e. whether they choose "Convert to blocks" or "Convert to HTML".

## Testing Instructions

* Sandbox `widgets.wp.com`.
* Run `cd apps/wpcom-block-editor && yarn dev --sync`.
* Navigate to a Simple site and open the block editor for a post or page.
* Add a Classic block. Note that Classic block might be missing in the inserter, so you can do it by switching to "Code editor" mode and pasting:
  ```html
  <!-- wp:freeform -->
  test
  <!-- /wp:freeform -->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
