### PR TITLE
[RSM-3193] Fix receipt print styling

### DIFF
--- a/client/dashboard/app/root/style.scss
+++ b/client/dashboard/app/root/style.scss
@@ -2,7 +2,7 @@
 // Old layout (no sidebar): sticky header
 // For pages without sub menus, the first header is the sticky header
 // For pages with sub menus, the second header is the sticky header
-.dashboard-root__layout:not(:has(main > .dashboard-header-bar)) > .dashboard-header-bar,
+.dashboard-root__layout:not( :has( main > .dashboard-header-bar ) ) > .dashboard-header-bar,
 .dashboard-root__layout > main > .dashboard-header-bar {
 	position: sticky;
 	top: 0;
@@ -16,13 +16,13 @@
 
 .dashboard-root__body {
 	display: flex;
-	min-height: calc(100vh - var(--masterbar-height) );
+	min-height: calc( 100vh - var( --masterbar-height ) );
 
-	&:has(> .dashboard-responsive-sidebar__sidebar) {
+	&:has( > .dashboard-responsive-sidebar__sidebar ) {
 		padding-inline-start: $sidebar-width;
 	}
 
-	&:has(.dashboard-responsive-sidebar) {
+	&:has( .dashboard-responsive-sidebar ) {
 		overflow-x: hidden;
 	}
 }
@@ -35,8 +35,28 @@
 	min-width: 0;
 	transition: transform 0.3s ease-in;
 
-	.dashboard-root__body:has(.dashboard-responsive-sidebar.is-open) & {
-			transform: translateX( $sidebar-width );
-			overflow: hidden;
+	.dashboard-root__body:has( .dashboard-responsive-sidebar.is-open ) & {
+		transform: translateX( $sidebar-width );
+		overflow: hidden;
+	}
+}
+
+@media print {
+	.dashboard-root__layout > .dashboard-header-bar,
+	.dashboard-root__layout > main > .dashboard-header-bar,
+	.dashboard-responsive-sidebar,
+	.dashboard-responsive-sidebar__sidebar,
+	.dashboard-responsive-sidebar__overlay {
+		display: none;
+	}
+
+	.dashboard-root__body {
+		padding-inline-start: 0;
+		overflow-x: visible;
+	}
+
+	.dashboard-root__content {
+		transform: none;
+		overflow: visible;
 	}
 }

--- a/client/dashboard/app/style.scss
+++ b/client/dashboard/app/style.scss
@@ -42,19 +42,34 @@ a {
 // Currently, there is an issue with @automattic/charts where svgLabelSmall.fill is defined with var().
 // This causes the visx tooltip to render a malformed box-shadow value, given that it interpolates the color. e.g: `${theme?.color}55`.
 // Pie charts also use @visx/tooltip directly, so they do not get the background from the chart theme.
-.visx-tooltip:has(div[role="tooltip"]) {
+.visx-tooltip:has( div[role='tooltip'] ) {
 	box-shadow: 0 1px 2px var( --dashboard-surface__border-color ) !important;
 	background: var( --dashboard-surface__background-color ) !important;
 	border: 1px solid var( --dashboard-surface__border-color );
 	color: var( --dashboard__text-color ) !important;
 }
 
-:root[data-theme='dark'] {
-	@include dashboard-dark-theme;
+// Keep dashboard dark mode out of browser print/PDF output. Printed pages should
+// fall back to the default light theme variables even when the screen is dark.
+@media screen {
+	:root[data-theme='dark'] {
+		@include dashboard-dark-theme;
+	}
 }
 
-@media (prefers-color-scheme: dark) {
+@media screen and ( prefers-color-scheme: dark ) {
 	:root[data-theme='system'] {
 		@include dashboard-dark-theme;
+	}
+}
+
+@media print {
+	#wpcom-omnibar {
+		display: none;
+	}
+
+	body:has( #wpcom-omnibar ) #wpcom {
+		padding-block-start: 0;
+		min-height: auto;
 	}
 }

--- a/packages/ui/src/utils/_mixins.scss
+++ b/packages/ui/src/utils/_mixins.scss
@@ -2,11 +2,13 @@
 // OS prefers dark. Intended to be nested inside a CSS-module selector so `&`
 // resolves to the scoped class.
 @mixin when-dark-theme {
-	:root[data-theme="dark"] & {
-		@content;
+	@media screen {
+		:root[data-theme="dark"] & {
+			@content;
+		}
 	}
 
-	@media (prefers-color-scheme: dark) {
+	@media screen and (prefers-color-scheme: dark) {
 		:root[data-theme="system"] & {
 			@content;
 		}


### PR DESCRIPTION
Part of RSM-3193

## Proposed Changes

* Scope Dashboard dark theme variables to screen media so browser print/PDF output falls back to the default light theme tokens.
* Hide Dashboard chrome during print, including the omnibar, header bars, responsive sidebar, and sidebar overlay.
* Reset print layout offsets and transforms that are normally reserved for the Dashboard sidebar and omnibar.

## Why are these changes being made?

Billing receipt PDFs could inherit Dashboard dark-mode styling, which made navigation chrome low contrast in the generated PDF. The print output could also keep Dashboard navigation elements, including the responsive sidebar, even though printed receipts should focus on the receipt content.

This keeps the on-screen Dashboard unchanged in dark mode while making print/PDF output use light styling and removing app chrome from the printed document.

## Testing Instructions

* Visit `http://my.localhost:3000/me/billing/history`.
* Open an invoice or receipt from the billing history.
* Click `Print Receipt`.
* Confirm the print preview/PDF uses light styling and does not include the Dashboard omnibar, header bar, or responsive sidebar.
* Confirm the receipt page still renders normally in dark mode on screen.
* Confirm CSS lint passes for the changed Dashboard stylesheets.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
