### PR TITLE
@automattic/date-range-picker: 1.0.2 packaging cleanup

### DIFF
--- a/packages/date-range-picker/CHANGELOG.md
+++ b/packages/date-range-picker/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.0.2
+
+- Packaging: pre-compile SCSS to CSS in `dist/{esm,cjs}/style.css` so external consumers no longer need a Sass loader. SCSS variables from `@wordpress/base-styles` are resolved at build time.
+- Packaging: move `@wordpress/components`, `@wordpress/compose`, `@wordpress/date`, `@wordpress/i18n`, and `@wordpress/icons` to `peerDependencies` (with `>=` ranges) to prevent duplicate installs and to accommodate hosts pinned to newer `@wordpress/*` majors.
+- Packaging: stop shipping `src/test/**` and `dist/*.tsbuildinfo` in the published tarball.
+- Packaging: drop unused `tslib` runtime dependency.
+- Styles: add sensible fallbacks (`#fff`, `#1e1e1e`, `#949494`) to the dashboard CSS custom properties so the picker renders correctly outside the Calypso dashboard shell.
+- Docs: add a "Using outside Calypso" section to the README documenting peer-deps, the required `@automattic/ui/style.css` import, and the themable CSS custom properties.
+
 ## 1.0.1
 
 - Fix packaging: include `style.scss` in `dist/esm/` and `dist/cjs/` so the compiled `import './style.scss'` resolves for consumers that don't use the `calypso:src` exports condition.

--- a/packages/date-range-picker/README.md
+++ b/packages/date-range-picker/README.md
@@ -11,19 +11,6 @@ site-day handling.
 npm install @automattic/date-range-picker
 ```
 
-Consumers must also load the calendar styles from `@automattic/ui` and import
-the picker's own stylesheet. The package ships SCSS source; compile it via
-your own build pipeline (sass-loader, etc.):
-
-```ts
-import '@automattic/ui/style.css';
-import '@automattic/date-range-picker/src/style.scss';
-```
-
-The SCSS expects `$grid-unit-*`, `$radius-small`, and `$gray-600` from
-`@wordpress/base-styles` to be in scope (either via a global `@import` or via
-sass-loader's `additionalData`).
-
 ## Usage
 
 ```tsx
@@ -43,6 +30,11 @@ function Example() {
 	);
 }
 ```
+
+The picker's stylesheet is side-effect imported from the component module, so a
+plain `import { DateRangePicker }` is enough — there's no separate CSS import to
+remember. The package ships pre-compiled CSS in `dist/`, so consumers don't
+need a Sass loader.
 
 ### Props
 
@@ -72,6 +64,51 @@ import {
 	type PresetId,
 } from '@automattic/date-range-picker';
 ```
+
+## Using outside Calypso
+
+The package is published to npm and works for any React app — Jetpack, custom
+WordPress plugins, etc. A few things to know:
+
+### Required peer dependencies
+
+The host application must install these alongside the picker:
+
+- `react` and `react-dom` (`^18.3.1`)
+- `@wordpress/components` (`>=32.1.0`)
+- `@wordpress/compose` (`>=7.23.0`)
+- `@wordpress/date` (`>=5.23.0`)
+- `@wordpress/i18n` (`>=5.23.0`)
+- `@wordpress/icons` (`>=10.23.0`)
+
+These are peer dependencies (not bundled) so that the host can control the
+exact version and avoid duplicate copies of WordPress packages — multiple
+copies of `@wordpress/compose` will silently break hooks shared across the
+picker and the host.
+
+### Calendar styles
+
+The picker renders `@automattic/ui`'s `DateRangeCalendar`. Make sure the
+host loads its stylesheet once:
+
+```ts
+import '@automattic/ui/style.css';
+```
+
+### Skinning via CSS custom properties
+
+The picker honours these CSS custom properties on a wrapping element, with
+sensible defaults when they're not set:
+
+| Custom property                         | Default       | Purpose                                |
+| --------------------------------------- | ------------- | -------------------------------------- |
+| `--dashboard-surface__background-color` | `#fff`        | Trigger button background.             |
+| `--dashboard__text-color`               | `#1e1e1e`     | Trigger button text and icon colour.   |
+| `--dashboard-field__border-color`       | `#949494`     | Trigger button border colour.          |
+
+Set them on `:root` (or any ancestor of the picker) to theme it. The Calypso
+dashboard shell sets these globally; outside Calypso, set whichever you'd like
+to override.
 
 ## Translations
 

--- a/packages/date-range-picker/bin/build-styles.js
+++ b/packages/date-range-picker/bin/build-styles.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+/**
+ * Compile `src/style.scss` to `dist/{esm,cjs}/style.css` and rewrite the
+ * emitted JS imports from `./style.scss` to `./style.css`. The source
+ * keeps the `.scss` import so Calypso consumers using `calypso:src`
+ * continue to bundle the SCSS through their own sass-loader.
+ */
+
+const fs = require( 'fs' );
+const path = require( 'path' );
+const sass = require( 'sass' );
+
+const PKG = path.resolve( __dirname, '..' );
+const baseStyles = path.dirname( require.resolve( '@wordpress/base-styles/package.json' ) );
+const nodeModulesRoot = path.resolve( baseStyles, '..', '..' );
+
+const css = sass.compile( path.join( PKG, 'src', 'style.scss' ), {
+	loadPaths: [ nodeModulesRoot ],
+	style: 'expanded',
+} ).css;
+
+for ( const subdir of [ 'dist/esm', 'dist/cjs' ] ) {
+	const dir = path.join( PKG, subdir );
+	fs.writeFileSync( path.join( dir, 'style.css' ), css );
+	for ( const file of fs.readdirSync( dir ) ) {
+		if ( ! file.endsWith( '.js' ) ) {
+			continue;
+		}
+		const full = path.join( dir, file );
+		const content = fs.readFileSync( full, 'utf8' );
+		if ( content.includes( './style.scss' ) ) {
+			fs.writeFileSync( full, content.replaceAll( './style.scss', './style.css' ) );
+		}
+	}
+}

--- a/packages/date-range-picker/package.json
+++ b/packages/date-range-picker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/date-range-picker",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "A date-range picker built on top of @automattic/ui's DateRangeCalendar, with timezone-aware site-day handling, preset shortcuts, and accessible inputs.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",
@@ -20,8 +20,7 @@
 		}
 	},
 	"sideEffects": [
-		"*.css",
-		"*.scss"
+		"*.css"
 	],
 	"repository": {
 		"type": "git",
@@ -34,40 +33,69 @@
 	"bugs": "https://github.com/Automattic/wp-calypso/issues",
 	"files": [
 		"dist",
-		"src"
+		"src",
+		"!dist/**/*.tsbuildinfo",
+		"!src/test"
 	],
 	"types": "dist/types",
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
-		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && node ./bin/build-styles.js",
 		"prepack": "yarn run clean && yarn run build"
 	},
 	"dependencies": {
 		"@automattic/ui": "workspace:^",
-		"@wordpress/base-styles": "^5.23.0",
-		"@wordpress/components": "^32.1.0",
-		"@wordpress/compose": "7.23.0",
-		"@wordpress/date": "5.23.0",
-		"@wordpress/i18n": "^5.23.0",
-		"@wordpress/icons": "^10.23.0",
-		"date-fns": "^4.1.0",
-		"tslib": "^2.8.1"
+		"date-fns": "^4.1.0"
 	},
 	"peerDependencies": {
+		"@wordpress/components": ">=32.1.0",
+		"@wordpress/compose": ">=7.23.0",
+		"@wordpress/date": ">=5.23.0",
+		"@wordpress/i18n": ">=5.23.0",
+		"@wordpress/icons": ">=10.23.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1"
 	},
+	"peerDependenciesMeta": {
+		"@wordpress/components": {
+			"optional": false
+		},
+		"@wordpress/compose": {
+			"optional": false
+		},
+		"@wordpress/date": {
+			"optional": false
+		},
+		"@wordpress/i18n": {
+			"optional": false
+		},
+		"@wordpress/icons": {
+			"optional": false
+		},
+		"react": {
+			"optional": false
+		},
+		"react-dom": {
+			"optional": false
+		}
+	},
 	"devDependencies": {
-		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@testing-library/dom": "^10.4.1",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.0",
 		"@testing-library/user-event": "^14.6.1",
 		"@types/react": "^18.3.18",
+		"@wordpress/base-styles": "^5.23.0",
+		"@wordpress/components": "^32.1.0",
+		"@wordpress/compose": "7.23.0",
+		"@wordpress/date": "5.23.0",
+		"@wordpress/i18n": "^5.23.0",
+		"@wordpress/icons": "^10.23.0",
 		"jest": "^29.7.0",
 		"mockdate": "^2.0.5",
 		"postcss": "^8.5.3",
+		"sass": "1.77.8",
 		"typescript": "^5.8.3",
 		"webpack": "^5.99.8"
 	}

--- a/packages/date-range-picker/src/style.scss
+++ b/packages/date-range-picker/src/style.scss
@@ -1,3 +1,5 @@
+@use "@wordpress/base-styles/variables" as v;
+
 /* Popover sizing */
 .daterange-popover .components-popover__content {
 	overflow: visible;
@@ -14,20 +16,20 @@
 	&__field {
 		// The extra class is to make sure it overrides the default button styles
 		&.components-button {
-			background: var( --dashboard-surface__background-color );
-			padding: $grid-unit-05 $grid-unit-05 $grid-unit-05 $grid-unit-10;
+			background: var(--dashboard-surface__background-color, #fff);
+			padding: v.$grid-unit-05 v.$grid-unit-05 v.$grid-unit-05 v.$grid-unit-10;
 			box-shadow: none;
-			border-radius: $radius-small;
-			border: 1px solid var(--dashboard-field__border-color, $gray-600);
+			border-radius: v.$radius-small;
+			border: 1px solid var(--dashboard-field__border-color, #{v.$gray-600});
 		}
 		svg {
-			color: var(--dashboard__text-color);
-			padding: $grid-unit-05;
+			color: var(--dashboard__text-color, #{v.$gray-900});
+			padding: v.$grid-unit-05;
 		}
 	}
 	&__text {
-		color: var(--dashboard__text-color);
-		padding: 0 $grid-unit-05;
+		color: var(--dashboard__text-color, #{v.$gray-900});
+		padding: 0 v.$grid-unit-05;
 	}
 }
 

--- a/packages/date-range-picker/src/types.d.ts
+++ b/packages/date-range-picker/src/types.d.ts
@@ -1,1 +1,2 @@
 declare module '*.scss';
+declare module '*.css';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1097,7 +1097,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/date-range-picker@workspace:packages/date-range-picker"
   dependencies:
-    "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/ui": "workspace:^"
     "@testing-library/dom": "npm:^10.4.1"
@@ -1115,12 +1114,32 @@ __metadata:
     jest: "npm:^29.7.0"
     mockdate: "npm:^2.0.5"
     postcss: "npm:^8.5.3"
-    tslib: "npm:^2.8.1"
+    sass: "npm:1.77.8"
     typescript: "npm:^5.8.3"
     webpack: "npm:^5.99.8"
   peerDependencies:
+    "@wordpress/components": ">=32.1.0"
+    "@wordpress/compose": ">=7.23.0"
+    "@wordpress/date": ">=5.23.0"
+    "@wordpress/i18n": ">=5.23.0"
+    "@wordpress/icons": ">=10.23.0"
     react: ^18.3.1
     react-dom: ^18.3.1
+  peerDependenciesMeta:
+    "@wordpress/components":
+      optional: false
+    "@wordpress/compose":
+      optional: false
+    "@wordpress/date":
+      optional: false
+    "@wordpress/i18n":
+      optional: false
+    "@wordpress/icons":
+      optional: false
+    react:
+      optional: false
+    react-dom:
+      optional: false
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Proposed Changes

* Pre-compile SCSS to CSS in `dist/{esm,cjs}/style.css` so external consumers no longer need a Sass loader; `@wordpress/base-styles` vars resolve at build time.
* Move `@wordpress/*` deps to `peerDependencies` (with `>=` ranges) to prevent duplicate installs and accommodate hosts pinned to newer majors.
* Stop shipping `src/test` and `dist/*.tsbuildinfo` in the published tarball.
* Drop unused `tslib` runtime dep.
* Add fallback values to the dashboard CSS custom properties so the picker renders correctly outside the dashboard shell.
* README: add a "Using outside Calypso" section.

## Why are these changes being made?

`@automattic/date-range-picker@1.0.1` ships SCSS that uses unresolved vars and references Calypso-internal CSS custom properties without fallbacks, and pins `@wordpress/*` as regular deps. External consumers (Jetpack) hit each of these in sequence. Bumping to 1.0.2 with one comprehensive fix instead of more whack-a-mole patches.

## Testing Instructions

* `yarn workspace @automattic/date-range-picker run clean && yarn workspace @automattic/date-range-picker run build`
* `ls packages/date-range-picker/dist/{esm,cjs}` — confirm `style.css` is present, no `style.scss`, no `*.tsbuildinfo`.
* `grep -rE '\$grid|\$gray|\$radius' packages/date-range-picker/dist/` — zero hits.
* `cd packages/date-range-picker && yarn pack --dry-run` — no test files, no tsbuildinfo, no `.scss` in `dist/`.
* The two Calypso consumers (`client/dashboard/sites/logs`, `client/dashboard/sites/backups`) still render via `calypso:src`; spot check both.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?