### PR TITLE
@automattic/date-range-picker: restore *.scss in sideEffects

### DIFF
--- a/packages/date-range-picker/CHANGELOG.md
+++ b/packages/date-range-picker/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.3
+
+- Fix: restore `*.scss` in `sideEffects` so Calypso (which consumes the package via `calypso:src`) doesn't tree-shake the `import './style.scss'` and lose all of the picker's styles.
+
 ## 1.0.2
 
 - Packaging: pre-compile SCSS to CSS in `dist/{esm,cjs}/style.css` so external consumers no longer need a Sass loader. SCSS variables from `@wordpress/base-styles` are resolved at build time.

--- a/packages/date-range-picker/package.json
+++ b/packages/date-range-picker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/date-range-picker",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"description": "A date-range picker built on top of @automattic/ui's DateRangeCalendar, with timezone-aware site-day handling, preset shortcuts, and accessible inputs.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",
@@ -20,7 +20,8 @@
 		}
 	},
 	"sideEffects": [
-		"*.css"
+		"*.css",
+		"*.scss"
 	],
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Part of #110738

## Proposed Changes

* Re-add `"*.scss"` to `sideEffects` in `packages/date-range-picker/package.json`.
* Bump to `1.0.3` and add a changelog entry.

## Why are these changes being made?

#110738 trimmed `sideEffects` from `["*.css", "*.scss"]` to `["*.css"]`. That's fine for external/npm consumers — they resolve to `dist/{esm,cjs}/index.js`, which only imports `./style.css` (rewritten at build time by `bin/build-styles.js`), and `*.css` is still listed.

But Calypso resolves the package via the `calypso:src` exports condition, so it pulls `packages/date-range-picker/src/index.ts` and hits `import './style.scss'` directly. With `.scss` no longer flagged as a side effect, webpack's tree shaker drops the import, sass-loader never processes the file, and zero `.daterange-*` rules end up in the built chunks. The picker renders unstyled (plain tertiary button, no border/background) on the dashboard logs page.

Adding `"*.scss"` back is purely additive for the dist path — there are no `.scss` files in `dist/`, so external consumers are unaffected. It just restores the Calypso path.

## Testing Instructions

Before this change, visit a dashboard page that uses the picker (e.g. `/sites/<site>/logs/php`) and the date range button renders as a borderless blue text-only button. After this change, the button has the proper background, border, padding, and icon styling.

Locally:
1. `yarn start-dashboard`
2. Open a site's PHP logs page.
3. Confirm the date range button has a white background, 1px border, and the calendar icon is laid out correctly.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
