### PR TITLE
E2E: keep shared page objects runner-neutral

### DIFF
--- a/packages/calypso-e2e/src/element-helper.ts
+++ b/packages/calypso-e2e/src/element-helper.ts
@@ -54,6 +54,62 @@ export async function waitForElementEnabled(
 }
 
 /**
+ * Waits for a locator attribute to match the expected pattern.
+ *
+ * This keeps shared helpers runner-neutral: callers can use it from both legacy
+ * Jest E2E and Playwright Test without importing `playwright/test`.
+ *
+ * @param {Locator} locator Target locator.
+ * @param {string} attributeName Attribute to read.
+ * @param {RegExp} pattern Expected attribute value pattern.
+ * @param {Object} options Optional timeout and diagnostic label.
+ * @param {number} options.timeout Timeout in milliseconds.
+ * @param {string} options.description Human-readable target description for errors.
+ * @param {string} options.state Locator state to wait for before reading the attribute.
+ * @returns {Promise<string>} Matching attribute value.
+ */
+export async function waitForLocatorAttribute(
+	locator: Locator,
+	attributeName: string,
+	pattern: RegExp,
+	options?: { timeout?: number; description?: string; state?: 'attached' | 'visible' }
+): Promise< string > {
+	const timeout = options?.timeout ?? 10000;
+	const description = options?.description ?? 'locator';
+	const state = options?.state ?? 'attached';
+	const deadline = Date.now() + timeout;
+	const interval = 250;
+	let lastValue: string | null = null;
+
+	do {
+		const timeRemaining = Math.max( deadline - Date.now(), 1 );
+		try {
+			await locator.waitFor( {
+				state,
+				timeout: Math.min( interval, timeRemaining ),
+			} );
+			lastValue = await locator.getAttribute( attributeName, {
+				timeout: Math.min( interval, timeRemaining ),
+			} );
+			pattern.lastIndex = 0;
+			if ( lastValue && pattern.test( lastValue ) ) {
+				return lastValue;
+			}
+		} catch {
+			// Retry until the explicit timeout below so callers get one clear error.
+		}
+
+		if ( Date.now() < deadline ) {
+			await locator.page().waitForTimeout( Math.min( interval, deadline - Date.now() ) );
+		}
+	} while ( Date.now() < deadline );
+
+	throw new Error(
+		`Timed out after ${ timeout }ms waiting for ${ description } to be ${ state } and ${ attributeName } to match ${ pattern }. Last value: ${ lastValue }`
+	);
+}
+
+/**
  * Locates and clicks on a specified tab on the NavTab.
  *
  * NavTabs are used throughout calypso to contain sub-pages within the parent page.

--- a/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
@@ -1,5 +1,5 @@
-import { expect } from 'playwright/test';
 import { getCalypsoURL } from '../../data-helper';
+import { waitForElementEnabled } from '../../element-helper';
 import envVariables from '../../env-variables';
 import type { PaymentDetails, RegistrarDetails } from '../../types/data-helper.types';
 import type { Frame, Page } from 'playwright';
@@ -320,9 +320,13 @@ export class CartCheckoutPage {
 		// wait for the form fields that prove the payment method is ready.
 		const cardPaymentRadio = this.page.locator( selectors.cardPaymentRadio );
 		await cardPaymentRadio.waitFor( { state: 'attached', timeout: 15 * 1000 } );
-		await expect( cardPaymentRadio ).toBeEnabled( { timeout: 30 * 1000 } );
+		await waitForElementEnabled( this.page, selectors.cardPaymentRadio, { timeout: 30 * 1000 } );
 		await cardPaymentRadio.dispatchEvent( 'click' );
-		await expect( cardPaymentRadio ).toHaveJSProperty( 'checked', true );
+		await this.page.waitForFunction(
+			( selector ) => document.querySelector< HTMLInputElement >( selector )?.checked === true,
+			selectors.cardPaymentRadio,
+			{ timeout: 30 * 1000 }
+		);
 		await this.validatePaymentForm();
 
 		// Begin filling in the card details from

--- a/packages/calypso-e2e/src/lib/pages/logged-out-home-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/logged-out-home-page.ts
@@ -1,5 +1,5 @@
-import { expect } from 'playwright/test';
 import { BrowserManager, envVariables } from '../..';
+import { waitForLocatorAttribute } from '../../element-helper';
 import type { Locator, Page } from 'playwright';
 
 /**
@@ -37,15 +37,16 @@ export class LoggedOutHomePage {
 	 * returns {Promise<void>}
 	 */
 	async exploreThemes(): Promise< void > {
-		await expect( this.exploreThemesLink ).toBeVisible( { timeout: 10_000 } );
-		await expect( this.exploreThemesLink ).toHaveAttribute( 'href', /\/themes\/?(?:[?#].*)?$/, {
-			timeout: 10_000,
-		} );
-
-		const themesHref = await this.exploreThemesLink.getAttribute( 'href' );
-		if ( ! themesHref ) {
-			throw new Error( 'Explore themes URL not found' );
-		}
+		const themesHref = await waitForLocatorAttribute(
+			this.exploreThemesLink,
+			'href',
+			/\/themes\/?(?:[?#].*)?$/,
+			{
+				timeout: 10_000,
+				description: 'Explore themes link',
+				state: 'visible',
+			}
+		);
 
 		await this.page.goto( new URL( themesHref, this.page.url() ).href, {
 			timeout: 30_000,

--- a/packages/calypso-e2e/src/lib/pages/logged-out-themes-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/logged-out-themes-page.ts
@@ -1,5 +1,5 @@
-import { expect } from 'playwright/test';
 import { getCalypsoURL } from '../../data-helper';
+import { waitForLocatorAttribute } from '../../element-helper';
 import type { Locator, Page } from 'playwright';
 
 const THEME_ACTION_TIMEOUT_MS = 10 * 1000;
@@ -57,7 +57,7 @@ export class LoggedOutThemesPage {
 			timeout: THEME_NAVIGATION_TIMEOUT_MS,
 			waitUntil: 'domcontentloaded',
 		} );
-		await expect( this.viewFilter ).toBeVisible( { timeout: THEME_ACTION_TIMEOUT_MS } );
+		await this.viewFilter.waitFor( { state: 'visible', timeout: THEME_ACTION_TIMEOUT_MS } );
 	}
 
 	/**
@@ -72,20 +72,7 @@ export class LoggedOutThemesPage {
 				? /\/themes(?:[?#].*)?$/
 				: new RegExp( `/themes/${ filterSlug }(?:[?#].*)?$` );
 
-		await expect( async () => {
-			await this.waitUntilLoaded();
-			await this.viewFilter.scrollIntoViewIfNeeded();
-			await this.viewFilter.click();
-			await this.page.getByRole( 'option', { name: filter, exact: true } ).click();
-			await this.page.waitForURL( filterUrlPattern, {
-				waitUntil: 'domcontentloaded',
-			} );
-			await expect( this.viewFilter ).toContainText( filter );
-			await expect( this.firstThemeCard ).toBeVisible();
-		} ).toPass( {
-			timeout: THEME_NAVIGATION_TIMEOUT_MS,
-			intervals: [ 1_000, 2_000, 5_000 ],
-		} );
+		await this.retryFilterSelection( filter, filterUrlPattern );
 	}
 
 	/**
@@ -94,17 +81,16 @@ export class LoggedOutThemesPage {
 	 * @returns {Promise<string>} The slug of the selected theme.
 	 */
 	async startWithFirstTheme(): Promise< string > {
-		await expect( this.firstThemeGetStartedLink ).toBeVisible( {
-			timeout: THEME_ACTION_TIMEOUT_MS,
-		} );
-		await expect( this.firstThemeGetStartedLink ).toHaveAttribute( 'href', /theme=/, {
-			timeout: THEME_ACTION_TIMEOUT_MS,
-		} );
-
-		const getStartedRoute = await this.firstThemeGetStartedLink.getAttribute( 'href' );
-		if ( ! getStartedRoute ) {
-			throw new Error( 'First theme Get started URL not found' );
-		}
+		const getStartedRoute = await waitForLocatorAttribute(
+			this.firstThemeGetStartedLink,
+			'href',
+			/theme=/,
+			{
+				timeout: THEME_ACTION_TIMEOUT_MS,
+				description: 'First theme Get started link',
+				state: 'visible',
+			}
+		);
 
 		const { themeSlug, url: getStartedUrl } = getCalypsoGetStartedUrlFromHref(
 			getStartedRoute,
@@ -117,5 +103,54 @@ export class LoggedOutThemesPage {
 		} );
 
 		return themeSlug;
+	}
+
+	/**
+	 * Retries the filter interaction because the logged-out theme grid can re-render during navigation.
+	 */
+	private async retryFilterSelection( filter: string, filterUrlPattern: RegExp ): Promise< void > {
+		const intervals = [ 1_000, 2_000, 5_000 ];
+		const deadline = Date.now() + THEME_NAVIGATION_TIMEOUT_MS;
+		let attempt = 0;
+		let lastError: unknown;
+
+		while ( Date.now() < deadline ) {
+			try {
+				await this.waitUntilLoaded();
+				await this.viewFilter.scrollIntoViewIfNeeded();
+				await this.viewFilter.click();
+				await this.page.getByRole( 'option', { name: filter, exact: true } ).click();
+				await this.page.waitForURL( filterUrlPattern, {
+					timeout: Math.max( deadline - Date.now(), 500 ),
+					waitUntil: 'domcontentloaded',
+				} );
+				const filterText = await this.viewFilter.textContent( {
+					timeout: THEME_ACTION_TIMEOUT_MS,
+				} );
+				if ( ! filterText?.includes( filter ) ) {
+					throw new Error(
+						`Expected theme filter to contain "${ filter }", got "${ filterText }"`
+					);
+				}
+				await this.firstThemeCard.waitFor( {
+					state: 'visible',
+					timeout: THEME_ACTION_TIMEOUT_MS,
+				} );
+				return;
+			} catch ( error ) {
+				lastError = error;
+				if ( Date.now() >= deadline ) {
+					break;
+				}
+				const wait = Math.min(
+					intervals[ Math.min( attempt, intervals.length - 1 ) ],
+					deadline - Date.now()
+				);
+				attempt += 1;
+				await this.page.waitForTimeout( wait );
+			}
+		}
+
+		throw lastError;
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -1,4 +1,3 @@
-import { expect } from 'playwright/test';
 import { getCalypsoURL } from '../../data-helper';
 import { clickNavTab } from '../../element-helper';
 import envVariables from '../../env-variables';
@@ -135,7 +134,7 @@ export class PlansPage {
 				exact: true,
 			} )
 			.first();
-		await expect( trigger ).toBeVisible( { timeout: 30_000 } );
+		await trigger.waitFor( { state: 'visible', timeout: 30_000 } );
 		await trigger.click();
 
 		const escapeHatchDialog = this.page
@@ -146,7 +145,7 @@ export class PlansPage {
 				} ),
 			} )
 			.first();
-		await expect( escapeHatchDialog ).toBeVisible();
+		await escapeHatchDialog.waitFor( { state: 'visible' } );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/test/runner-neutral-imports.test.ts
+++ b/packages/calypso-e2e/src/test/runner-neutral-imports.test.ts
@@ -1,0 +1,37 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, test } from '@jest/globals';
+
+const sourceRoot = path.resolve( __dirname, '..' );
+const forbiddenPlaywrightTestImport =
+	/(?:from\s+['"](?:@playwright\/test|playwright\/test)['"])|(?:require\(\s*['"](?:@playwright\/test|playwright\/test)['"]\s*\))/;
+
+/**
+ * Recursively lists TypeScript source files outside test directories.
+ */
+function getSourceFiles( directory: string ): string[] {
+	const entries = fs.readdirSync( directory, { withFileTypes: true } );
+
+	return entries.flatMap( ( entry ) => {
+		const fullPath = path.join( directory, entry.name );
+
+		if ( entry.isDirectory() ) {
+			if ( entry.name === 'test' ) {
+				return [];
+			}
+			return getSourceFiles( fullPath );
+		}
+
+		return fullPath.endsWith( '.ts' ) ? [ fullPath ] : [];
+	} );
+}
+
+describe( 'calypso-e2e shared package imports', function () {
+	test( 'does not import Playwright Test from shared runtime files', function () {
+		const filesWithPlaywrightTestImports = getSourceFiles( sourceRoot ).filter( ( file ) =>
+			forbiddenPlaywrightTestImport.test( fs.readFileSync( file, 'utf8' ) )
+		);
+
+		expect( filesWithPlaywrightTestImports ).toEqual( [] );
+	} );
+} );


### PR DESCRIPTION
Part of TESTOPS-49

## Proposed Changes

* Remove runtime `playwright/test` imports from shared `@automattic/calypso-e2e` page objects.
* Replace those Playwright Test assertions with runner-neutral Playwright core waits and explicit errors.
* Add a package test that prevents `playwright/test` imports from shared runtime files.

## Why are these changes being made?

Legacy Jest E2E and Playwright Test both consume `@automattic/calypso-e2e` during the migration. Importing Playwright Test from shared page objects can make legacy Jest single-file runs fail during suite load with `Requiring @playwright/test second time`.

This is a regression from recent E2E hardening work. Runtime `playwright/test` imports were first added to shared page objects in #110561, then expanded in #110639, #110654, and #110655. #108051 fixed the same class of local Jest crash earlier by removing `@playwright/test` from a page object.

Keep the shared package runner-neutral until the Jest runner is fully retired.

## Testing Instructions

* `yarn eslint packages/calypso-e2e/src/element-helper.ts packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts packages/calypso-e2e/src/lib/pages/logged-out-home-page.ts packages/calypso-e2e/src/lib/pages/logged-out-themes-page.ts packages/calypso-e2e/src/lib/pages/plans-page.ts`
* `yarn eslint packages/calypso-e2e/src/test/runner-neutral-imports.test.ts`
* `yarn workspace @automattic/calypso-e2e build`
* `yarn test-packages packages/calypso-e2e/src/test/runner-neutral-imports.test.ts packages/calypso-e2e/src/test/lib/pages/logged-out-themes-page.test.ts`
* `yarn typecheck-packages`
* `ATOMIC_VARIATION="php-new" TEST_ON_ATOMIC="true" VIEWPORT_NAME="desktop" JETPACK_TARGET="wpcom-deployment" yarn workspace wp-e2e-tests test "test/e2e/specs/jetpack/social__editor-features.ts"`
  * Before this change: failed during suite load with `Requiring @playwright/test second time`.
  * After this change locally: suite loaded and reached the browser login flow; my local run then timed out waiting for the login username field.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?