### PR TITLE
fix(stepper): initiate the atomic transfer in the direct-to-cart flow

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/direct-to-cart/build-checkout-url.ts
+++ b/client/landing/stepper/declarative-flow/flows/direct-to-cart/build-checkout-url.ts
@@ -14,7 +14,7 @@ export function appendReturnSignals( externalUrl: string, siteSlug: string ): st
 	} );
 }
 
-interface BuildChainedCheckoutUrlArgs {
+interface BuildTransferringUrlArgs {
 	siteSlug: string;
 	/**
 	 * Numeric site ID. Optional because the resume path doesn't store it.
@@ -22,18 +22,52 @@ interface BuildChainedCheckoutUrlArgs {
 	 * WAIT_FOR_ATOMIC's useSiteData() hook can pick it up and start polling.
 	 */
 	siteId?: number;
-	/** Plan slug to embed in the checkout path so checkout auto-adds it to the cart. */
-	plan: string;
 	/** Sanitized external URL (already includes return signals), or null to fall back to /home/<slug>. */
 	externalRedirect: string | null;
+}
+
+/**
+ * Builds the post-checkout destination: the `/setup/transferring-hosted-site`
+ * URL that initiates and waits for the atomic transfer, or `/home/<slug>` when
+ * there's no valid external redirect.
+ *
+ * `initiate_transfer_context: 'hosting'` is required: buying a Business /
+ * Commerce plan only grants the `atomic` capability — it does not start the
+ * transfer. WAIT_FOR_ATOMIC only calls `initiateThemeTransfer()` when this
+ * param is present; without it, nothing creates a transfer record and the
+ * step polls `/atomic/transfers/latest` forever (404 `no_transfer_record`).
+ * This mirrors the dashboard "Activate hosting features" flow.
+ *
+ * This is the single source of truth for the transferring URL — both the
+ * checkout `redirect_to` and the persisted signup destination use it, so they
+ * can't drift apart.
+ */
+export function buildTransferringUrl( args: BuildTransferringUrlArgs ): string {
+	const { siteSlug, siteId, externalRedirect } = args;
+
+	if ( ! externalRedirect ) {
+		return `/home/${ siteSlug }`;
+	}
+
+	return addQueryArgs( TRANSFERRING_FLOW_PATH, {
+		redirect_to: externalRedirect,
+		siteSlug,
+		siteId: siteId !== undefined ? String( siteId ) : undefined,
+		initiate_transfer_context: 'hosting',
+		initiate_transfer_geo_affinity: '',
+	} );
+}
+
+interface BuildChainedCheckoutUrlArgs extends BuildTransferringUrlArgs {
+	/** Plan slug to embed in the checkout path so checkout auto-adds it to the cart. */
+	plan: string;
 	coupon: string | null;
 }
 
 /**
  * Builds the URL we navigate to from PROCESSING. The user lands on /checkout,
  * which on success navigates to redirect_to. We chain through
- * /setup/transferring-hosted-site (which waits for atomic transfer) and then
- * to the external redirect.
+ * /setup/transferring-hosted-site and then to the external redirect.
  *
  * Encoding: addQueryArgs handles one level of URL-encoding. The external URL
  * is passed in already-formed (no manual encoding here); addQueryArgs encodes
@@ -43,13 +77,7 @@ interface BuildChainedCheckoutUrlArgs {
 export function buildChainedCheckoutUrl( args: BuildChainedCheckoutUrlArgs ): string {
 	const { siteSlug, siteId, plan, externalRedirect, coupon } = args;
 
-	const transferringOrHome = externalRedirect
-		? addQueryArgs( TRANSFERRING_FLOW_PATH, {
-				redirect_to: externalRedirect,
-				siteSlug,
-				siteId: siteId !== undefined ? String( siteId ) : undefined,
-		  } )
-		: `/home/${ siteSlug }`;
+	const transferringOrHome = buildTransferringUrl( { siteSlug, siteId, externalRedirect } );
 
 	// Path: /checkout/<plan>/<site>. The plan-first form makes checkout
 	// auto-populate the cart if it's empty — this matters for the

--- a/client/landing/stepper/declarative-flow/flows/direct-to-cart/direct-to-cart.ts
+++ b/client/landing/stepper/declarative-flow/flows/direct-to-cart/direct-to-cart.ts
@@ -2,7 +2,6 @@ import { DIRECT_TO_CART_FLOW } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { addQueryArgs } from '@wordpress/url';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { logToLogstash } from 'calypso/lib/logstash';
 import wpcom from 'calypso/lib/wp';
@@ -17,7 +16,11 @@ import { ONBOARD_STORE, SITE_STORE } from '../../../stores';
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
 import { STEPS } from '../../internals/steps';
 import { ProcessingResult } from '../../internals/steps-repository/processing-step/constants';
-import { appendReturnSignals, buildChainedCheckoutUrl } from './build-checkout-url';
+import {
+	appendReturnSignals,
+	buildChainedCheckoutUrl,
+	buildTransferringUrl,
+} from './build-checkout-url';
 import { resolveResumability, type SitePlanStatusResult } from './resolve-resumability';
 import { resumeKey, writeResumeRecord } from './resume-storage';
 import { sanitizeDirectToCartRedirect } from './sanitize-redirect';
@@ -207,13 +210,11 @@ const flow: FlowV2< typeof initialize > = {
 					} );
 
 					// Persist standard signup state so post-checkout machinery has
-					// what it expects.
-					const outerRedirect = externalRedirect
-						? addQueryArgs( '/setup/transferring-hosted-site', {
-								redirect_to: externalRedirect,
-						  } )
-						: `/home/${ siteSlug }`;
-					persistSignupDestination( outerRedirect );
+					// what it expects. Reuse buildTransferringUrl so the persisted
+					// destination can't drift from checkout's redirect_to.
+					persistSignupDestination(
+						buildTransferringUrl( { siteSlug, siteId, externalRedirect } )
+					);
 					setSignupCompleteFlowName( DIRECT_TO_CART_FLOW );
 					setSignupCompleteSlug( siteSlug );
 					if ( siteId ) {

--- a/client/landing/stepper/declarative-flow/flows/direct-to-cart/test/build-checkout-url.ts
+++ b/client/landing/stepper/declarative-flow/flows/direct-to-cart/test/build-checkout-url.ts
@@ -1,4 +1,8 @@
-import { buildChainedCheckoutUrl, appendReturnSignals } from '../build-checkout-url';
+import {
+	buildChainedCheckoutUrl,
+	buildTransferringUrl,
+	appendReturnSignals,
+} from '../build-checkout-url';
 
 describe( 'appendReturnSignals', () => {
 	it( 'appends wpcom_purchase=1 and wpcom_site to a URL with no existing params', () => {
@@ -53,6 +57,9 @@ describe( 'buildChainedCheckoutUrl', () => {
 		// useSiteData() hook can read them and start polling.
 		expect( parsedInner.searchParams.get( 'siteSlug' ) ).toBe( 'example.wordpress.com' );
 		expect( parsedInner.searchParams.get( 'siteId' ) ).toBe( '12345' );
+		// initiate_transfer_context is what makes WAIT_FOR_ATOMIC actually
+		// initiate the transfer — without it the step polls forever.
+		expect( parsedInner.searchParams.get( 'initiate_transfer_context' ) ).toBe( 'hosting' );
 		expect( parsedInner.searchParams.get( 'redirect_to' ) ).toBe(
 			'https://allowed.example/return?wpcom_purchase=1&wpcom_site=example.wordpress.com'
 		);
@@ -115,5 +122,42 @@ describe( 'buildChainedCheckoutUrl', () => {
 			coupon: null,
 		} );
 		expect( url ).toContain( '/checkout/business%20bundle/example.wordpress.com' );
+	} );
+} );
+
+describe( 'buildTransferringUrl', () => {
+	it( 'builds a transferring URL that initiates the atomic transfer', () => {
+		const url = buildTransferringUrl( {
+			siteSlug: 'example.wordpress.com',
+			siteId: 12345,
+			externalRedirect: 'https://allowed.example/return?wpcom_purchase=1',
+		} );
+		const parsed = new URL( url, 'https://wordpress.com' );
+		expect( parsed.pathname ).toBe( '/setup/transferring-hosted-site' );
+		expect( parsed.searchParams.get( 'siteSlug' ) ).toBe( 'example.wordpress.com' );
+		expect( parsed.searchParams.get( 'siteId' ) ).toBe( '12345' );
+		expect( parsed.searchParams.get( 'initiate_transfer_context' ) ).toBe( 'hosting' );
+		expect( parsed.searchParams.has( 'initiate_transfer_geo_affinity' ) ).toBe( true );
+		expect( parsed.searchParams.get( 'redirect_to' ) ).toBe(
+			'https://allowed.example/return?wpcom_purchase=1'
+		);
+	} );
+
+	it( 'omits siteId when not provided', () => {
+		const url = buildTransferringUrl( {
+			siteSlug: 'example.wordpress.com',
+			externalRedirect: 'https://allowed.example/return',
+		} );
+		const parsed = new URL( url, 'https://wordpress.com' );
+		expect( parsed.searchParams.has( 'siteId' ) ).toBe( false );
+		expect( parsed.searchParams.get( 'initiate_transfer_context' ) ).toBe( 'hosting' );
+	} );
+
+	it( 'falls back to /home/<slug> when externalRedirect is null', () => {
+		const url = buildTransferringUrl( {
+			siteSlug: 'example.wordpress.com',
+			externalRedirect: null,
+		} );
+		expect( url ).toBe( '/home/example.wordpress.com' );
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/flows/direct-to-cart/test/direct-to-cart.tsx
+++ b/client/landing/stepper/declarative-flow/flows/direct-to-cart/test/direct-to-cart.tsx
@@ -1,7 +1,21 @@
 /**
  * @jest-environment jsdom
  */
+import { render } from '@testing-library/react';
+import React, { useEffect } from 'react';
+import { MemoryRouter, useNavigate } from 'react-router';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { logToLogstash } from 'calypso/lib/logstash';
+import {
+	persistSignupDestination,
+	setSignupCompleteFlowName,
+	setSignupCompleteSiteID,
+	setSignupCompleteSlug,
+} from 'calypso/signup/storageUtils';
+import { STEPS } from '../../../internals/steps';
+import { ProcessingResult } from '../../../internals/steps-repository/processing-step/constants';
 import directToCart from '../direct-to-cart';
+import { writeResumeRecord } from '../resume-storage';
 
 jest.mock( 'calypso/my-sites/checkout/get-thank-you-page-url', () => ( {
 	getAllowedExternalRedirectHosts: () => [ 'allowed.example' ],
@@ -12,9 +26,34 @@ jest.mock( 'calypso/lib/wp', () => ( {
 	default: { req: { get: jest.fn() } },
 } ) );
 
+jest.mock( 'calypso/signup/storageUtils', () => ( {
+	persistSignupDestination: jest.fn(),
+	setSignupCompleteFlowName: jest.fn(),
+	setSignupCompleteSlug: jest.fn(),
+	setSignupCompleteSiteID: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {
+	recordTracksEvent: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/lib/logstash', () => ( {
+	logToLogstash: jest.fn(),
+} ) );
+
+jest.mock( '../resume-storage', () => ( {
+	resumeKey: jest.fn(
+		( integration, contextId ) => `key:${ integration ?? '' }:${ contextId ?? '' }`
+	),
+	writeResumeRecord: jest.fn(),
+	readResumeRecord: jest.fn(),
+	clearResumeRecord: jest.fn(),
+} ) );
+
 function setLocation( search: string ): void {
 	Object.defineProperty( window, 'location', {
 		writable: true,
+		configurable: true,
 		value: new URL( `https://wordpress.com/setup/direct-to-cart${ search }` ),
 	} );
 }
@@ -52,5 +91,195 @@ describe( 'direct-to-cart flow — initialize', () => {
 		const steps = await ( directToCart.initialize as () => Promise< Array< { slug: string } > > )();
 		const slugs = steps.map( ( s ) => s.slug );
 		expect( slugs ).toContain( 'create-site' );
+	} );
+} );
+
+/**
+ * Minimal harness for driving `flow.useStepNavigation()`'s submit handler.
+ * Avoids `renderFlow` from ../../../test/helpers because that pulls in the
+ * themes reducer + redux Provider, which we don't need — the submit handler
+ * only depends on MemoryRouter (for `useQuery` → `useLocation`).
+ */
+function submitProcessing( {
+	currentURL,
+	dependencies,
+}: {
+	currentURL: string;
+	dependencies: Record< string, unknown >;
+} ): void {
+	const Harness = () => {
+		const navigate = useNavigate();
+		const fakeNavigate = ( pathname: string ) => navigate( pathname );
+		const { submit } = directToCart.useStepNavigation(
+			STEPS.PROCESSING.slug,
+			fakeNavigate as unknown as Parameters< typeof directToCart.useStepNavigation >[ 1 ]
+		);
+		useEffect( () => {
+			submit?.( {
+				slug: STEPS.PROCESSING.slug,
+				providedDependencies: dependencies,
+			} as Parameters< NonNullable< typeof submit > >[ 0 ] );
+			// eslint-disable-next-line react-hooks/exhaustive-deps
+		}, [] );
+		return null;
+	};
+
+	render(
+		<MemoryRouter initialEntries={ [ currentURL ] }>
+			<Harness />
+		</MemoryRouter>
+	);
+}
+
+describe( 'direct-to-cart flow — useStepNavigation submit (PROCESSING)', () => {
+	const originalLocation = window.location;
+	let replaceMock: jest.Mock;
+
+	beforeEach( () => {
+		replaceMock = jest.fn();
+		Object.defineProperty( window, 'location', {
+			writable: true,
+			configurable: true,
+			value: { ...originalLocation, replace: replaceMock },
+		} );
+		( persistSignupDestination as jest.Mock ).mockClear();
+		( setSignupCompleteFlowName as jest.Mock ).mockClear();
+		( setSignupCompleteSlug as jest.Mock ).mockClear();
+		( setSignupCompleteSiteID as jest.Mock ).mockClear();
+		( recordTracksEvent as jest.Mock ).mockClear();
+		( logToLogstash as jest.Mock ).mockClear();
+		( writeResumeRecord as jest.Mock ).mockClear();
+	} );
+
+	afterAll( () => {
+		Object.defineProperty( window, 'location', {
+			writable: true,
+			configurable: true,
+			value: originalLocation,
+		} );
+	} );
+
+	it( 'persists a transferring destination that initiates the atomic transfer (drift-guard regression)', () => {
+		submitProcessing( {
+			currentURL: `/setup/direct-to-cart/${
+				STEPS.PROCESSING.slug
+			}?plan=business-bundle&redirect_to=${ encodeURIComponent(
+				'https://allowed.example/return'
+			) }&coupon=SAVE20`,
+			dependencies: {
+				processingResult: ProcessingResult.SUCCESS,
+				siteSlug: 'example.wordpress.com',
+				siteId: 12345,
+			},
+		} );
+
+		// The bug being guarded: persistSignupDestination was previously passed
+		// a hand-rolled URL missing siteId/siteSlug and — crucially —
+		// initiate_transfer_context. Without that param, WAIT_FOR_ATOMIC never
+		// initiates the transfer and polls /atomic/transfers/latest forever.
+		expect( persistSignupDestination ).toHaveBeenCalledTimes( 1 );
+		const persisted = ( persistSignupDestination as jest.Mock ).mock.calls[ 0 ][ 0 ];
+		const persistedParsed = new URL( persisted, 'https://wordpress.com' );
+		expect( persistedParsed.pathname ).toBe( '/setup/transferring-hosted-site' );
+		expect( persistedParsed.searchParams.get( 'initiate_transfer_context' ) ).toBe( 'hosting' );
+		expect( persistedParsed.searchParams.get( 'siteSlug' ) ).toBe( 'example.wordpress.com' );
+		expect( persistedParsed.searchParams.get( 'siteId' ) ).toBe( '12345' );
+		expect( persistedParsed.searchParams.get( 'redirect_to' ) ).toContain(
+			'allowed.example/return'
+		);
+		expect( persistedParsed.searchParams.get( 'redirect_to' ) ).toContain( 'wpcom_purchase=1' );
+
+		// Sibling signup-state writes the post-checkout machinery expects.
+		expect( setSignupCompleteFlowName ).toHaveBeenCalledWith( 'direct-to-cart' );
+		expect( setSignupCompleteSlug ).toHaveBeenCalledWith( 'example.wordpress.com' );
+		expect( setSignupCompleteSiteID ).toHaveBeenCalledWith( 12345 );
+
+		// The chained checkout URL navigated to.
+		expect( replaceMock ).toHaveBeenCalledTimes( 1 );
+		const checkoutUrl = replaceMock.mock.calls[ 0 ][ 0 ];
+		expect( checkoutUrl ).toContain( '/checkout/business-bundle/example.wordpress.com' );
+		expect( checkoutUrl ).toContain( 'coupon=SAVE20' );
+
+		// Drift guard: redirect_to embedded in checkout MUST equal what we
+		// persisted. The fix's whole point is that they can't drift.
+		const checkoutParsed = new URL( checkoutUrl, 'https://wordpress.com' );
+		expect( checkoutParsed.searchParams.get( 'redirect_to' ) ).toBe( persisted );
+
+		// Resume record written so a revisit can short-circuit.
+		expect( writeResumeRecord ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'persists /home/<slug> when no external redirect is provided', () => {
+		submitProcessing( {
+			currentURL: `/setup/direct-to-cart/${ STEPS.PROCESSING.slug }?plan=business-bundle`,
+			dependencies: {
+				processingResult: ProcessingResult.SUCCESS,
+				siteSlug: 'example.wordpress.com',
+				siteId: 12345,
+			},
+		} );
+
+		expect( persistSignupDestination ).toHaveBeenCalledWith( '/home/example.wordpress.com' );
+
+		// Same fallback should appear as the checkout redirect_to.
+		const checkoutUrl = replaceMock.mock.calls[ 0 ][ 0 ];
+		const checkoutParsed = new URL( checkoutUrl, 'https://wordpress.com' );
+		expect( checkoutParsed.searchParams.get( 'redirect_to' ) ).toBe(
+			'/home/example.wordpress.com'
+		);
+	} );
+
+	it( 'omits setSignupCompleteSiteID when siteId is missing', () => {
+		submitProcessing( {
+			currentURL: `/setup/direct-to-cart/${ STEPS.PROCESSING.slug }?plan=business-bundle`,
+			dependencies: {
+				processingResult: ProcessingResult.SUCCESS,
+				siteSlug: 'example.wordpress.com',
+			},
+		} );
+
+		expect( setSignupCompleteSlug ).toHaveBeenCalledWith( 'example.wordpress.com' );
+		expect( setSignupCompleteSiteID ).not.toHaveBeenCalled();
+	} );
+
+	it( 'skips persistence and navigation when processing failed', () => {
+		submitProcessing( {
+			currentURL: `/setup/direct-to-cart/${ STEPS.PROCESSING.slug }?plan=business-bundle`,
+			dependencies: {
+				processingResult: ProcessingResult.FAILURE,
+				siteSlug: 'example.wordpress.com',
+				siteId: 12345,
+			},
+		} );
+
+		expect( persistSignupDestination ).not.toHaveBeenCalled();
+		expect( replaceMock ).not.toHaveBeenCalled();
+		expect( writeResumeRecord ).not.toHaveBeenCalled();
+	} );
+
+	it( 'records tracks + logstash and skips navigation when siteSlug is missing', () => {
+		submitProcessing( {
+			currentURL: `/setup/direct-to-cart/${ STEPS.PROCESSING.slug }?plan=business-bundle`,
+			dependencies: {
+				processingResult: ProcessingResult.SUCCESS,
+				// siteSlug intentionally omitted
+				siteId: 12345,
+			},
+		} );
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_direct_to_cart_missing_site_slug',
+			{}
+		);
+		expect( logToLogstash ).toHaveBeenCalledTimes( 1 );
+		const logArg = ( logToLogstash as jest.Mock ).mock.calls[ 0 ][ 0 ];
+		expect( logArg ).toMatchObject( {
+			feature: 'calypso_client',
+			severity: 'error',
+			tags: expect.arrayContaining( [ 'direct_to_cart' ] ),
+		} );
+
+		expect( persistSignupDestination ).not.toHaveBeenCalled();
+		expect( replaceMock ).not.toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
## Summary
The [newly created](https://github.com/Automattic/wp-calypso/pull/110686) direct-to-cart flow's post-checkout step polls for an atomic transfer record that nothing ever created, leaving users stuck on an endless "transferring" loading screen. Pass `initiate_transfer_context: 'hosting'` so the transfer is actually initiated.

## Why
Buying a Business/Commerce plan only grants the `atomic` capability — it does not start the transfer. The transferring-hosted-site step's WAIT_FOR_ATOMIC only calls `initiateThemeTransfer()` when the URL carries `initiate_transfer_context`; without it, nothing creates a transfer record and the step polls `/atomic/transfers/latest` forever (404 `no_transfer_record`).

## How
Add `initiate_transfer_context: 'hosting'` (plus an empty geo affinity) to the transferring-hosted-site URL, mirroring the dashboard "Activate hosting features" flow. Extract `buildTransferringUrl` as the single source of truth for that URL so the checkout `redirect_to` and the persisted signup destination can't drift — the persisted copy was previously also missing `siteId`/`siteSlug`.

## Testing
- [x] `yarn test-client client/landing/stepper/declarative-flow/flows/direct-to-cart/` — 62 tests pass
- [x] End-to-end: complete a Business-plan checkout via the direct-to-cart flow; confirm the transferring step initiates a transfer (no `no_transfer_record` 404) and lands on the partner redirect.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
