### PR TITLE
Plans: align modal-backed subheader with Step.Heading subText

### DIFF
--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -8,23 +8,48 @@ import { shouldUseStepContainerV2 } from 'calypso/landing/stepper/declarative-fl
 import { SelectedFeatureData } from '../hooks/use-selected-feature';
 
 const Subheader = styled.p< { isUsingStepContainerV2?: boolean; isVisualSplitIntent?: boolean } >`
-	margin: ${ ( props ) => ( props.isVisualSplitIntent ? '-40px 0 30px 0' : '-32px 0 40px 0' ) };
-	color: var( --studio-gray-60 );
-	font-size: 1rem;
-	text-align: ${ ( props ) => ( props.isUsingStepContainerV2 ? 'left' : 'center' ) };
-	button.is-borderless {
-		font-weight: ${ ( props ) => ( props.isVisualSplitIntent ? 'inherit' : '500' ) };
-		color: var( --studio-gray-90 );
-		text-decoration: underline;
-		font-size: 16px;
-		padding: 0;
-	}
-	@media ( max-width: 960px ) {
-		margin-top: -16px;
-	}
-	@media ( min-width: 600px ) {
-		text-align: center;
-	}
+	${ ( props ) =>
+		props.isUsingStepContainerV2
+			? `
+				margin: -2.5rem 0 3rem;
+				color: var( --color-text );
+				font-size: 0.875rem;
+				line-height: 1.5;
+				text-wrap: balance;
+				text-align: left;
+				button.is-borderless {
+					font-weight: 500;
+					color: inherit;
+					text-decoration: underline;
+					font-size: inherit;
+					padding: 0;
+				}
+				@media ( min-width: 600px ) {
+					text-align: center;
+				}
+				@media ( min-width: 960px ) {
+					font-size: 1rem;
+				}
+			`
+			: `
+				margin: ${ props.isVisualSplitIntent ? '-40px 0 30px 0' : '-32px 0 40px 0' };
+				color: var( --studio-gray-60 );
+				font-size: 1rem;
+				text-align: center;
+				button.is-borderless {
+					font-weight: ${ props.isVisualSplitIntent ? 'inherit' : '500' };
+					color: var( --studio-gray-90 );
+					text-decoration: underline;
+					font-size: 16px;
+					padding: 0;
+				}
+				@media ( max-width: 960px ) {
+					margin-top: -16px;
+				}
+				@media ( min-width: 600px ) {
+					text-align: center;
+				}
+			` }
 `;
 
 const SecondaryFormattedHeader = ( {


### PR DESCRIPTION
Follow-up to #110598, that fixed a regression #110305 introduced.

## Proposed Changes

  * Restyle the modal-backed `<Subheader>` in `plans-page-subheader.tsx` to match `Step.Heading` subText typography.
  * Move the `.step-container-v2__content-wrapper` `gap: 3rem` from above the paragraph to below it (`margin: -2.5rem 0 3rem`).
  * Non-stepper paths unchanged.

## Screenshots

| Device | Before | After |
| --- | --- | --- |
| Mobile | <img width="375" alt="wordpress com_setup_onboarding_domains_ref=logged-out-homepage-lp(iPhone SE) (2)" src="https://github.com/user-attachments/assets/2031fcf6-810f-482c-a25a-07166f7c0fbc" /> | <img width="375" alt="calypso localhost_3000_setup_onboarding_domains_ref=logged-out-homepage-lp(iPhone SE)" src="https://github.com/user-attachments/assets/7467d05e-0054-4815-b288-c58f6b6f5d9b" /> |
| Desktop | <img width="1024" alt="wordpress com_setup_onboarding_plans_ref=logged-out-homepage-lp(Default (Cris))" src="https://github.com/user-attachments/assets/d3545816-2d51-488c-aaac-0543a308aeb1" /> | <img width="1024" alt="calypso localhost_3000_setup_onboarding_domains(Default (Cris)) (4)" src="https://github.com/user-attachments/assets/1bae6f74-7627-47f0-ae6f-7f9a26db4691" /> |



## Why are these changes being made?

#110598 reintroduced the negative-margin `<Subheader>` (mismatched typography stacked above the heading) as the cost of restoring the modal-backed free-plan CTA. This branch restyles that paragraph; CTA wiring and its E2E coverage are untouched.

## Testing Instructions

1. Pick a paid TLD in onboarding, continue to `/setup/domain/plans`. The "Unlock a powerful bundle…" paragraph should match the `Step.Heading` subText above it, with `3rem` of space below before the plans grid.
2. Click `start with a free plan` — `PlanUpsellModal` (`Continue with Free plan`) opens before checkout.
4. `setup-domain__flows.spec.ts` "WITHOUT a plan upgrade" passes on desktop + mobile.

  ## Pre-merge Checklist

  - [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
  - [ ] [Have you written new
  tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for
  your changes?
  - [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and
  self-hosted Jetpack sites (PCYsg-g6b-p2)?
  - [x] Have you checked for TypeScript, React or other console errors?
  - [ ] For UI changes, have you tested the affected components in [dark
  mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
  - [ ] Have you tested accessibility for your changes? Ensure the feature remains usable
  with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and
  assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
  - [ ] Have you used memoizing on expensive computations? More info in [Memoizing with
  create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils
  /src/create-selector/README.md) and [Using memoizing
  selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our
  Approach to
  Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
  - [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were
  ready for translation (p4TIVU-5Jq-p2)?
      - [ ] For UI changes, have we tested the change in various languages (for example,
  ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
  - [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates"
  label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?