### PR TITLE
Guard AI editorial reviews by post context

### DIFF
--- a/packages/jetpack-ai-sidebar/src/components/review-mediation.scss
+++ b/packages/jetpack-ai-sidebar/src/components/review-mediation.scss
@@ -105,6 +105,15 @@
 	line-height: 1.5;
 	color: inherit;
 
+	&.is-post-stale {
+		.jetpack-ai-review-mediation__stats,
+		.jetpack-ai-review-mediation__panel,
+		.jetpack-ai-review-mediation__footer {
+			opacity: 0.5;
+			pointer-events: none;
+		}
+	}
+
 	// ---------- Panel / PanelBody overrides ----------
 	// Strip Gutenberg's white bg + bottom divider; replace with a translucent
 	// top divider so sections read as separate panes on the chat surface.
@@ -214,6 +223,15 @@
 		&.is-manual {
 			color: #f0b849;
 		}
+	}
+
+	&__stale-warning {
+		margin: 0 0 0.75rem;
+		padding: 0.5rem 0.75rem;
+		font-size: 12px;
+		font-weight: 600;
+		border-left: 3px solid #d63638;
+		background: rgba(214, 54, 56, 0.08);
 	}
 
 	// ---------- Suggested edit cards ----------
@@ -466,11 +484,16 @@
 			border-color 0.15s ease,
 			background 0.15s ease;
 
-		&:hover,
-		&:focus-visible {
+		&:hover:not(:disabled),
+		&:focus-visible:not(:disabled) {
 			border-color: rgba(255, 255, 255, 0.5);
 			background: rgba(255, 255, 255, 0.06);
 			outline: none;
+		}
+
+		&:disabled {
+			cursor: default;
+			opacity: 0.55;
 		}
 	}
 
@@ -600,7 +623,7 @@
 				border-color 0.15s ease,
 				background 0.15s ease;
 
-			&:hover {
+			&:hover:not(:disabled) {
 				border-color: rgba(255, 255, 255, 0.4);
 				background: rgba(255, 255, 255, 0.06);
 			}
@@ -611,12 +634,17 @@
 			}
 		}
 
+		&:disabled {
+			cursor: default;
+			opacity: 0.55;
+		}
+
 		&.is-conflicts {
 			color: #e8a520;
 			border-color: rgba(232, 165, 32, 0.45);
 			background: rgba(232, 165, 32, 0.08);
 
-			&.is-clickable:hover {
+			&.is-clickable:hover:not(:disabled) {
 				border-color: rgba(232, 165, 32, 0.7);
 				background: rgba(232, 165, 32, 0.14);
 			}

--- a/packages/jetpack-ai-sidebar/src/components/review-mediation.scss
+++ b/packages/jetpack-ai-sidebar/src/components/review-mediation.scss
@@ -168,8 +168,12 @@
 		fill: currentColor;
 	}
 
-	// Content region indent — flush left looks naked in a chat bubble.
-	.components-panel__body.is-opened > :not(.components-panel__body-title) {
+	// Content region bottom spacing. Keep cards out of this broad PanelBody
+	// rule so their own internal padding is not overwritten.
+	.components-panel__body.is-opened
+		> :not(.components-panel__body-title):not(.jetpack-ai-review-mediation__card):not(
+			.jetpack-ai-review-mediation__conflict-card
+		) {
 		padding: 0 0 0.75rem;
 	}
 
@@ -699,6 +703,16 @@
 		}
 	}
 
+	// Keep the intended card padding anchored to this component root without
+	// changing collapsed rows or reaching for `!important`.
+	& &__card:not(.is-collapsed) {
+		padding: 1rem 1.25rem;
+	}
+
+	& &__conflict-card:not(.is-collapsed) {
+		padding: 1.25rem 1.5rem;
+	}
+
 	&__conflict-header {
 		display: flex;
 		align-items: baseline;
@@ -791,12 +805,17 @@
 	}
 
 	&__ai-badge {
+		display: inline-flex;
+		flex: 0 0 auto;
 		background: var(--wp-admin-theme-color, #3858e9);
 		color: #fff;
 		font-size: 10px;
 		padding: 2px 6px;
 		border-radius: 3px;
 		letter-spacing: 0.06em;
+		white-space: nowrap;
+		word-break: normal;
+		overflow-wrap: normal;
 	}
 
 	&__ai-text {

--- a/packages/jetpack-ai-sidebar/src/components/review-mediation.scss
+++ b/packages/jetpack-ai-sidebar/src/components/review-mediation.scss
@@ -110,7 +110,6 @@
 		.jetpack-ai-review-mediation__panel,
 		.jetpack-ai-review-mediation__footer {
 			opacity: 0.5;
-			pointer-events: none;
 		}
 	}
 

--- a/packages/jetpack-ai-sidebar/src/components/review-mediation.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/review-mediation.test.tsx
@@ -125,6 +125,20 @@ beforeEach( () => {
 	mockedRecordTracksEvent.mockClear();
 	mockBlocks = blocks;
 	mockCurrentPostId = 1;
+	( window as any ).wp = {
+		data: {
+			select: ( store: string ) => {
+				if ( store === 'core/editor' ) {
+					return { getCurrentPostId: () => mockCurrentPostId };
+				}
+				return undefined;
+			},
+		},
+	};
+} );
+
+afterEach( () => {
+	delete ( window as any ).wp;
 } );
 
 describe( 'ReviewMediation — smoke render', () => {

--- a/packages/jetpack-ai-sidebar/src/components/review-mediation.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/review-mediation.test.tsx
@@ -291,7 +291,7 @@ describe( 'ReviewMediation — smoke render', () => {
 		);
 
 		expect(
-			screen.getByText( 'Review context changed. Start a new chat to re-run this review.' )
+			screen.getByText( 'Review context changed. Start a new chat and re-run this review.' )
 		).toBeInTheDocument();
 		expect( screen.getByTitle( 'Jump to conflicts' ) ).toBeDisabled();
 		expect( screen.getByTitle( 'Jump to suggested edits' ) ).toBeDisabled();
@@ -303,6 +303,12 @@ describe( 'ReviewMediation — smoke render', () => {
 		expect(
 			screen.getByRole( 'button', { name: /Accept all AI resolutions \(2\)/ } )
 		).toBeDisabled();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Suggested edits' } ) );
+		expect( screen.queryByText( 'Concise.' ) ).not.toBeInTheDocument();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Suggested edits' } ) );
+		expect( screen.getByText( 'Concise.' ) ).toBeInTheDocument();
 
 		fireEvent.click( screen.getByRole( 'button', { name: 'Accept' } ) );
 
@@ -329,7 +335,7 @@ describe( 'ReviewMediation — smoke render', () => {
 		);
 
 		expect(
-			screen.getByText( 'Review context changed. Start a new chat to re-run this review.' )
+			screen.getByText( 'Review context changed. Start a new chat and re-run this review.' )
 		).toBeInTheDocument();
 		expect( screen.getByTitle( 'Jump to suggested edits' ) ).toBeDisabled();
 		expect( screen.getByRole( 'button', { name: 'Accept' } ) ).toBeDisabled();
@@ -658,7 +664,7 @@ describe( 'ReviewMediation — suggested-edit accept flow', () => {
 
 		render( <ReviewMediation { ...editsPayload } /> );
 
-		const card = screen.getByText( 'Concise.' ).closest( 'article' );
+		const card = screen.getByText( 'Concise.' ).closest( '.jetpack-ai-review-mediation__card' );
 		expect( card ).toBeInTheDocument();
 
 		fireEvent.click( card! );

--- a/packages/jetpack-ai-sidebar/src/components/review-mediation.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/review-mediation.test.tsx
@@ -42,12 +42,16 @@ jest.mock( '../utils/block-actions', () => ( {
 
 const mockSelectBlock = jest.fn();
 let mockBlocks: any[] = [];
+let mockCurrentPostId: number | null | undefined = 1;
 
 jest.mock( '@wordpress/data', () => ( {
 	useSelect: ( fn: any ) =>
 		fn( ( store: string ) => {
 			if ( store === 'core/block-editor' ) {
 				return { getBlocks: () => mockBlocks };
+			}
+			if ( store === 'core/editor' ) {
+				return { getCurrentPostId: () => mockCurrentPostId };
 			}
 			return {};
 		} ),
@@ -102,6 +106,7 @@ function basePayload(
 ): React.ComponentProps< typeof ReviewMediation > {
 	return {
 		summary: 'Two reviewers disagree on the procedural framing.',
+		postId: 1,
 		conflicts: [],
 		implications: [],
 		suggested_edits: [],
@@ -119,6 +124,7 @@ beforeEach( () => {
 	mockSelectBlock.mockReset();
 	mockedRecordTracksEvent.mockClear();
 	mockBlocks = blocks;
+	mockCurrentPostId = 1;
 } );
 
 describe( 'ReviewMediation — smoke render', () => {
@@ -244,6 +250,94 @@ describe( 'ReviewMediation — smoke render', () => {
 				}
 			);
 		} );
+	} );
+
+	it( 'marks a review for another post as stale and non-actionable', () => {
+		// Review was generated for post 2 (postId prop); editor is currently on post 1 (mockCurrentPostId).
+		render(
+			<ReviewMediation
+				{ ...basePayload( {
+					postId: 2,
+					conflicts: [
+						{
+							subject: 'Procedural framing',
+							positions: [],
+							guideline_anchor: null,
+							recommended_resolution: '',
+							candidate_resolutions: [
+								{
+									source: 'ai',
+									reviewer_name: null,
+									label: 'AI resolution',
+									block_index: 1,
+									current_text: 'voted last Tuesday',
+									text: 'voted on Tuesday',
+									rationale: '',
+								},
+							],
+						},
+					],
+					suggested_edits: [
+						{
+							block_index: 1,
+							current_text: 'voted last Tuesday',
+							suggested_text: 'voted on Tuesday',
+							rationale: 'Concise.',
+							supported_by_reviewers: [],
+						},
+					],
+				} ) }
+			/>
+		);
+
+		expect(
+			screen.getByText( 'Review context changed. Start a new chat to re-run this review.' )
+		).toBeInTheDocument();
+		expect( screen.getByTitle( 'Jump to conflicts' ) ).toBeDisabled();
+		expect( screen.getByTitle( 'Jump to suggested edits' ) ).toBeDisabled();
+		expect( screen.getByRole( 'button', { name: 'Accept AI resolution' } ) ).toBeDisabled();
+		expect( screen.getByRole( 'button', { name: 'Accept' } ) ).toBeDisabled();
+		screen
+			.getAllByRole( 'button', { name: 'Dismiss' } )
+			.forEach( ( button ) => expect( button ).toBeDisabled() );
+		expect(
+			screen.getByRole( 'button', { name: /Accept all AI resolutions \(2\)/ } )
+		).toBeDisabled();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Accept' } ) );
+
+		expect( mockApplyReviewEdit ).not.toHaveBeenCalled();
+		expect( mockedRecordTracksEvent ).not.toHaveBeenCalled();
+	} );
+
+	it( 'marks a review without source post context as stale', () => {
+		render(
+			<ReviewMediation
+				{ ...basePayload( {
+					postId: undefined,
+					suggested_edits: [
+						{
+							block_index: 1,
+							current_text: 'voted last Tuesday',
+							suggested_text: 'voted on Tuesday',
+							rationale: 'Concise.',
+							supported_by_reviewers: [],
+						},
+					],
+				} ) }
+			/>
+		);
+
+		expect(
+			screen.getByText( 'Review context changed. Start a new chat to re-run this review.' )
+		).toBeInTheDocument();
+		expect( screen.getByTitle( 'Jump to suggested edits' ) ).toBeDisabled();
+		expect( screen.getByRole( 'button', { name: 'Accept' } ) ).toBeDisabled();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Accept' } ) );
+
+		expect( mockApplyReviewEdit ).not.toHaveBeenCalled();
+		expect( mockedRecordTracksEvent ).not.toHaveBeenCalled();
 	} );
 
 	it.each( [

--- a/packages/jetpack-ai-sidebar/src/components/review-mediation.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/review-mediation.test.tsx
@@ -477,7 +477,8 @@ describe( 'ReviewMediation — suggested-edit accept flow', () => {
 			'b1',
 			'voted on Tuesday',
 			undefined,
-			'voted last Tuesday'
+			'voted last Tuesday',
+			expect.any( Function )
 		);
 
 		await waitFor( () => {
@@ -728,7 +729,8 @@ describe( 'ReviewMediation — suggested-edit accept flow', () => {
 			'nested-1',
 			'Updated nested paragraph text.',
 			undefined,
-			'Nested paragraph text.'
+			'Nested paragraph text.',
+			expect.any( Function )
 		);
 	} );
 
@@ -817,7 +819,8 @@ describe( 'ReviewMediation — conflict resolutions', () => {
 			'b1',
 			'voted softly on Tuesday',
 			undefined,
-			'voted last Tuesday'
+			'voted last Tuesday',
+			expect.any( Function )
 		);
 		await waitFor( () => {
 			expect( screen.getByText( 'Accepted' ) ).toBeInTheDocument();
@@ -837,7 +840,8 @@ describe( 'ReviewMediation — conflict resolutions', () => {
 			'b1',
 			'voted on Tuesday',
 			undefined,
-			'voted last Tuesday'
+			'voted last Tuesday',
+			expect.any( Function )
 		);
 	} );
 
@@ -1128,20 +1132,89 @@ describe( 'ReviewMediation — bulk Accept all AI resolutions', () => {
 			'b1',
 			'AI rewrite',
 			undefined,
-			'voted last Tuesday'
+			'voted last Tuesday',
+			expect.any( Function )
 		);
 		expect( mockApplyReviewEdit ).toHaveBeenNthCalledWith(
 			2,
 			'b2',
 			'tighter copy',
 			undefined,
-			'Funding'
+			'Funding',
+			expect.any( Function )
 		);
 
 		// Footer disappears once everything is accepted (totalPendingCount === 0).
 		await waitFor( () => {
 			expect( screen.queryByText( /Accept all AI resolutions/ ) ).not.toBeInTheDocument();
 		} );
+	} );
+
+	it( 'stops bulk applying when the editor navigates to another post mid-run', async () => {
+		let resolveFirstApply: ( value: { success: boolean } ) => void = () => {};
+		mockApplyReviewEdit.mockImplementationOnce(
+			() =>
+				new Promise( ( resolve ) => {
+					resolveFirstApply = resolve;
+				} )
+		);
+
+		const payload = basePayload( {
+			conflicts: [
+				{
+					subject: 'Procedural framing',
+					positions: [],
+					guideline_anchor: null,
+					recommended_resolution: '',
+					candidate_resolutions: [
+						{
+							source: 'ai',
+							reviewer_name: null,
+							label: 'AI',
+							block_index: 1,
+							current_text: 'voted last Tuesday',
+							text: 'AI rewrite',
+							rationale: '',
+						},
+					],
+				},
+			],
+			suggested_edits: [
+				{
+					block_index: 2,
+					current_text: 'Funding',
+					suggested_text: 'tighter copy',
+					rationale: '',
+					supported_by_reviewers: [],
+				},
+			],
+		} );
+		const { rerender } = render( <ReviewMediation { ...payload } /> );
+
+		await act( async () => {
+			fireEvent.click( screen.getByRole( 'button', { name: /Accept all AI resolutions \(2\)/ } ) );
+		} );
+
+		await waitFor( () => {
+			expect( mockApplyReviewEdit ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		mockCurrentPostId = 2;
+		rerender( <ReviewMediation { ...payload } /> );
+
+		await act( async () => {
+			resolveFirstApply( { success: true } );
+		} );
+
+		await waitFor( () => {
+			expect(
+				screen.getByText( 'Review context changed. Start a new chat and re-run this review.' )
+			).toBeInTheDocument();
+		} );
+		expect( mockApplyReviewEdit ).toHaveBeenCalledTimes( 1 );
+		expect(
+			screen.getByRole( 'button', { name: /Accept all AI resolutions \(2\)/ } )
+		).toBeDisabled();
 	} );
 } );
 

--- a/packages/jetpack-ai-sidebar/src/components/review-mediation.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/review-mediation.tsx
@@ -107,6 +107,22 @@ interface ReviewMediationProps {
 }
 
 type EditStatus = 'pending' | 'applying' | 'accepted' | 'dismissed' | 'failed';
+type WpCurrentPostStore = { getCurrentPostId?: () => number | null };
+type WpGlobal = Window & {
+	wp?: {
+		data?: {
+			select?: ( store: string ) => WpCurrentPostStore | undefined;
+		};
+	};
+};
+
+function getCurrentEditorPostIdFromStore(): number | undefined {
+	if ( typeof window === 'undefined' ) {
+		return undefined;
+	}
+	const wp = ( window as WpGlobal ).wp;
+	return wp?.data?.select?.( 'core/editor' )?.getCurrentPostId?.() ?? undefined;
+}
 
 /**
  * The five PanelBody sections we manage in controlled mode. Used as the
@@ -341,17 +357,12 @@ export default function ReviewMediation( {
 		[]
 	);
 	const isPostStale = ! postId || ! currentPostId || postId !== currentPostId;
-	const latestPostContextRef = useRef( { postId, currentPostId } );
-	useEffect( () => {
-		latestPostContextRef.current = { postId, currentPostId };
-	}, [ postId, currentPostId ] );
 	const isLatestPostContextStale = useCallback( () => {
-		const { postId: latestSourcePostId, currentPostId: latestCurrentPostId } =
-			latestPostContextRef.current;
-		return (
-			! latestSourcePostId || ! latestCurrentPostId || latestSourcePostId !== latestCurrentPostId
-		);
-	}, [] );
+		// Async edit guards must read the editor store at call time so navigation
+		// between the click and delayed block write is observed immediately.
+		const latestCurrentPostId = getCurrentEditorPostIdFromStore() ?? currentPostId;
+		return ! postId || ! latestCurrentPostId || postId !== latestCurrentPostId;
+	}, [ currentPostId, postId ] );
 
 	const [ editStatuses, setEditStatuses ] = useState< Record< number, EditStatus > >( {} );
 	const [ conflictStatuses, setConflictStatuses ] = useState< Record< number, EditStatus > >( {} );

--- a/packages/jetpack-ai-sidebar/src/components/review-mediation.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/review-mediation.tsx
@@ -370,15 +370,9 @@ export default function ReviewMediation( {
 		violations: null,
 	} );
 
-	const setSectionOpen = useCallback(
-		( key: SectionKey, opened: boolean ) => {
-			if ( isPostStale ) {
-				return;
-			}
-			setOpenSections( ( prev ) => ( { ...prev, [ key ]: opened } ) );
-		},
-		[ isPostStale ]
-	);
+	const setSectionOpen = useCallback( ( key: SectionKey, opened: boolean ) => {
+		setOpenSections( ( prev ) => ( { ...prev, [ key ]: opened } ) );
+	}, [] );
 
 	const renderedGuidelineViolations = useMemo(
 		() => guideline_violations.filter( ( v ) => hasRenderableGuidelineQuote( v.guideline_quote ) ),
@@ -920,7 +914,7 @@ export default function ReviewMediation( {
 		>
 			{ isPostStale && (
 				<p className="jetpack-ai-review-mediation__stale-warning" role="note">
-					{ __( 'Review context changed. Start a new chat to re-run this review.', 'jetpack' ) }
+					{ __( 'Review context changed. Start a new chat and re-run this review.', 'jetpack' ) }
 				</p>
 			) }
 			{ /* ---------- Stats strip ---------- *

--- a/packages/jetpack-ai-sidebar/src/components/review-mediation.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/review-mediation.tsx
@@ -88,6 +88,8 @@ interface ReviewMediationProps {
 	suggested_edits: SuggestedEdit[];
 	guideline_violations: GuidelineViolation[];
 	review_context?: ReviewContext;
+	/** Source post the review was generated for. Used to detect navigation to a different post. */
+	postId?: number;
 	/**
 	 * Server-built map keyed by reviewer display name. Optional — older
 	 * mediations or the empty-state payload may omit it; consumers degrade
@@ -326,9 +328,20 @@ export default function ReviewMediation( {
 	suggested_edits,
 	guideline_violations,
 	review_context,
+	postId,
 	reviewers_metadata,
 	cached_at,
 }: ReviewMediationProps ) {
+	// Review actions are only safe when the result can be tied to the current editor post.
+	const currentPostId = useSelect(
+		( select ) =>
+			(
+				select( 'core/editor' ) as { getCurrentPostId?: () => number | null }
+			 )?.getCurrentPostId?.() ?? undefined,
+		[]
+	);
+	const isPostStale = ! postId || ! currentPostId || postId !== currentPostId;
+
 	const [ editStatuses, setEditStatuses ] = useState< Record< number, EditStatus > >( {} );
 	const [ conflictStatuses, setConflictStatuses ] = useState< Record< number, EditStatus > >( {} );
 	const [ bulkRunning, setBulkRunning ] = useState( false );
@@ -357,9 +370,15 @@ export default function ReviewMediation( {
 		violations: null,
 	} );
 
-	const setSectionOpen = useCallback( ( key: SectionKey, opened: boolean ) => {
-		setOpenSections( ( prev ) => ( { ...prev, [ key ]: opened } ) );
-	}, [] );
+	const setSectionOpen = useCallback(
+		( key: SectionKey, opened: boolean ) => {
+			if ( isPostStale ) {
+				return;
+			}
+			setOpenSections( ( prev ) => ( { ...prev, [ key ]: opened } ) );
+		},
+		[ isPostStale ]
+	);
 
 	const renderedGuidelineViolations = useMemo(
 		() => guideline_violations.filter( ( v ) => hasRenderableGuidelineQuote( v.guideline_quote ) ),
@@ -368,6 +387,9 @@ export default function ReviewMediation( {
 
 	const handleStatClick = useCallback(
 		( key: SectionKey ) => {
+			if ( isPostStale ) {
+				return;
+			}
 			// Open first, then scroll on the next-next frame so React + layout
 			// have committed the expanded panel before scrollIntoView runs.
 			setSectionOpen( key, true );
@@ -380,7 +402,7 @@ export default function ReviewMediation( {
 				} );
 			} );
 		},
-		[ setSectionOpen ]
+		[ isPostStale, setSectionOpen ]
 	);
 
 	// Flat pre-order list of blocks; ability's `block_index` maps to this array.
@@ -427,6 +449,9 @@ export default function ReviewMediation( {
 
 	const focusBlock = useCallback(
 		( blockIndex: number | null ) => {
+			if ( isPostStale ) {
+				return;
+			}
 			const clientId = getClientId( blockIndex );
 			if ( ! clientId ) {
 				return;
@@ -438,8 +463,9 @@ export default function ReviewMediation( {
 			// index.ts commentary for why we don't use the private spotlight action).
 			findBlockListLayout()?.classList.add( FOCUS_MODE_CLASS );
 		},
-		[ getClientId, selectBlock ]
+		[ getClientId, isPostStale, selectBlock ]
 	);
+	const focusCurrentPostBlock = isPostStale ? undefined : focusBlock;
 
 	const fireItemAction = useCallback(
 		( options: {
@@ -478,6 +504,9 @@ export default function ReviewMediation( {
 			contentBefore?: string;
 			contentAfter?: string;
 		} > => {
+			if ( isPostStale ) {
+				return { success: false };
+			}
 			if ( getBlockEditDisabledReason( blockIndex, currentText ) ) {
 				return { success: false };
 			}
@@ -506,12 +535,15 @@ export default function ReviewMediation( {
 				return { success: false };
 			}
 		},
-		[ getBlockEditDisabledReason, getClientId ]
+		[ getBlockEditDisabledReason, getClientId, isPostStale ]
 	);
 
 	// ---------- Suggested edit handlers ----------
 	const handleAcceptEdit = useCallback(
 		async ( edit: SuggestedEdit, editIndex: number ) => {
+			if ( isPostStale ) {
+				return;
+			}
 			if ( isManualSuggestedEdit( edit ) ) {
 				return;
 			}
@@ -549,10 +581,13 @@ export default function ReviewMediation( {
 			} );
 			setEditStatus( editIndex, result.success ? 'accepted' : 'failed' );
 		},
-		[ applyTextToBlock, fireItemAction, setEditStatus ]
+		[ applyTextToBlock, fireItemAction, isPostStale, setEditStatus ]
 	);
 	const handleUndoEdit = useCallback(
 		( editIndex: number ) => {
+			if ( isPostStale ) {
+				return;
+			}
 			const snap = editSnapshots.current[ editIndex ];
 			if ( snap ) {
 				if ( ! undoBlockEdit( snap.clientId, snap.contentBefore, snap.contentAfter ) ) {
@@ -572,10 +607,13 @@ export default function ReviewMediation( {
 			} );
 			setEditStatus( editIndex, 'pending' );
 		},
-		[ fireItemAction, setEditStatus ]
+		[ fireItemAction, isPostStale, setEditStatus ]
 	);
 	const handleDismissEdit = useCallback(
 		( editIndex: number ) => {
+			if ( isPostStale ) {
+				return;
+			}
 			fireItemAction( {
 				action: 'dismiss',
 				target: 'edit',
@@ -583,12 +621,15 @@ export default function ReviewMediation( {
 			} );
 			setEditStatus( editIndex, 'dismissed' );
 		},
-		[ fireItemAction, setEditStatus ]
+		[ fireItemAction, isPostStale, setEditStatus ]
 	);
 
 	// ---------- Conflict handlers ----------
 	const handleAcceptCandidate = useCallback(
 		async ( conflictIndex: number, candidate: CandidateResolution ) => {
+			if ( isPostStale ) {
+				return;
+			}
 			if ( getBlockEditDisabledReason( candidate.block_index, candidate.current_text ) ) {
 				setConflictStatus( conflictIndex, 'failed' );
 				fireItemAction( {
@@ -623,10 +664,13 @@ export default function ReviewMediation( {
 			} );
 			setConflictStatus( conflictIndex, result.success ? 'accepted' : 'failed' );
 		},
-		[ applyTextToBlock, fireItemAction, getBlockEditDisabledReason, setConflictStatus ]
+		[ applyTextToBlock, fireItemAction, getBlockEditDisabledReason, isPostStale, setConflictStatus ]
 	);
 	const handleUndoConflict = useCallback(
 		( conflictIndex: number ) => {
+			if ( isPostStale ) {
+				return;
+			}
 			const snap = conflictSnapshots.current[ conflictIndex ];
 			if ( snap ) {
 				if ( ! undoBlockEdit( snap.clientId, snap.contentBefore, snap.contentAfter ) ) {
@@ -646,10 +690,13 @@ export default function ReviewMediation( {
 			} );
 			setConflictStatus( conflictIndex, 'pending' );
 		},
-		[ fireItemAction, setConflictStatus ]
+		[ fireItemAction, isPostStale, setConflictStatus ]
 	);
 	const handleDismissConflict = useCallback(
 		( conflictIndex: number ) => {
+			if ( isPostStale ) {
+				return;
+			}
 			fireItemAction( {
 				action: 'dismiss',
 				target: 'conflict',
@@ -657,7 +704,7 @@ export default function ReviewMediation( {
 			} );
 			setConflictStatus( conflictIndex, 'dismissed' );
 		},
-		[ fireItemAction, setConflictStatus ]
+		[ fireItemAction, isPostStale, setConflictStatus ]
 	);
 
 	// ---------- Bulk apply ----------
@@ -690,7 +737,7 @@ export default function ReviewMediation( {
 	const totalPendingCount = pendingAiConflictCount + pendingEditCount;
 
 	const handleAcceptAllAi = useCallback( async () => {
-		if ( bulkRunning || totalPendingCount === 0 ) {
+		if ( isPostStale || bulkRunning || totalPendingCount === 0 ) {
 			return;
 		}
 		let bulkTarget: 'edit' | 'conflict' | 'mixed' = 'edit';
@@ -804,6 +851,7 @@ export default function ReviewMediation( {
 		applyTextToBlock,
 		fireItemAction,
 		getBlockEditDisabledReason,
+		isPostStale,
 		setConflictStatus,
 		setEditStatus,
 	] );
@@ -837,7 +885,7 @@ export default function ReviewMediation( {
 	// Latch on the first effect run so re-renders do not duplicate `_result_rendered`.
 	const hasTrackedResultRef = useRef( false );
 	useEffect( () => {
-		if ( hasTrackedResultRef.current ) {
+		if ( isPostStale || hasTrackedResultRef.current ) {
 			return;
 		}
 		hasTrackedResultRef.current = true;
@@ -859,13 +907,22 @@ export default function ReviewMediation( {
 		cached_at,
 		conflicts,
 		implications,
+		isPostStale,
 		renderedGuidelineViolations,
 		review_context,
 		suggested_edits,
 	] );
 
 	return (
-		<div className="jetpack-ai-review-mediation">
+		<div
+			className={ `jetpack-ai-review-mediation${ isPostStale ? ' is-post-stale' : '' }` }
+			aria-disabled={ isPostStale || undefined }
+		>
+			{ isPostStale && (
+				<p className="jetpack-ai-review-mediation__stale-warning" role="note">
+					{ __( 'Review context changed. Start a new chat to re-run this review.', 'jetpack' ) }
+				</p>
+			) }
 			{ /* ---------- Stats strip ---------- *
 			 * Each chip that maps to a section (`conflicts`, `implications`,
 			 * `edits`, `violations`) becomes a button that scrolls — and
@@ -882,6 +939,7 @@ export default function ReviewMediation( {
 						<button
 							type="button"
 							className="jetpack-ai-review-mediation__stat is-conflicts is-clickable"
+							disabled={ isPostStale }
 							onClick={ () => handleStatClick( 'conflicts' ) }
 							title={ __( 'Jump to conflicts', 'jetpack' ) }
 						>
@@ -895,6 +953,7 @@ export default function ReviewMediation( {
 						<button
 							type="button"
 							className="jetpack-ai-review-mediation__stat is-clickable"
+							disabled={ isPostStale }
 							onClick={ () => handleStatClick( 'implications' ) }
 							title={ __( 'Jump to implications', 'jetpack' ) }
 						>
@@ -910,6 +969,7 @@ export default function ReviewMediation( {
 						<button
 							type="button"
 							className="jetpack-ai-review-mediation__stat is-clickable"
+							disabled={ isPostStale }
 							onClick={ () => handleStatClick( 'edits' ) }
 							title={ __( 'Jump to suggested edits', 'jetpack' ) }
 						>
@@ -925,6 +985,7 @@ export default function ReviewMediation( {
 						<button
 							type="button"
 							className="jetpack-ai-review-mediation__stat is-clickable"
+							disabled={ isPostStale }
 							onClick={ () => handleStatClick( 'violations' ) }
 							title={ __( 'Jump to guideline violations', 'jetpack' ) }
 						>
@@ -1021,6 +1082,7 @@ export default function ReviewMediation( {
 											blockCandidateStates[ 0 ];
 										const headerBlockIndex = headerCandidateState?.candidate.block_index ?? null;
 										const actionsDisabled =
+											isPostStale ||
 											status === 'applying' ||
 											status === 'accepted' ||
 											status === 'dismissed' ||
@@ -1065,7 +1127,7 @@ export default function ReviewMediation( {
 															<BlockRef
 																index={ headerBlockIndex }
 																blocks={ blocks }
-																onFocus={ focusBlock }
+																onFocus={ focusCurrentPostBlock }
 															/>
 															<span
 																className="jetpack-ai-review-mediation__collapsed-sep"
@@ -1081,6 +1143,7 @@ export default function ReviewMediation( {
 													<button
 														type="button"
 														className="jetpack-ai-review-mediation__collapsed-undo"
+														disabled={ isPostStale }
 														onClick={ () => handleUndoConflict( i ) }
 														title={
 															status === 'accepted'
@@ -1115,7 +1178,7 @@ export default function ReviewMediation( {
 														<BlockRef
 															index={ headerBlockIndex }
 															blocks={ blocks }
-															onFocus={ focusBlock }
+															onFocus={ focusCurrentPostBlock }
 															className="jetpack-ai-review-mediation__conflict-block-ref"
 														/>
 													) }
@@ -1234,7 +1297,11 @@ export default function ReviewMediation( {
 														{ imp.affected_blocks.map( ( b, j ) => (
 															<span key={ `imp-${ i }-aff-${ j }` }>
 																{ j > 0 && ', ' }
-																<BlockRef index={ b } blocks={ blocks } onFocus={ focusBlock } />
+																<BlockRef
+																	index={ b }
+																	blocks={ blocks }
+																	onFocus={ focusCurrentPostBlock }
+																/>
 															</span>
 														) ) }
 													</span>
@@ -1273,12 +1340,14 @@ export default function ReviewMediation( {
 										const clickable = ! isPostWide;
 										const isCollapsed = status === 'accepted' || status === 'dismissed';
 										const acceptDisabled =
+											isPostStale ||
 											!! acceptDisabledReason ||
 											status === 'applying' ||
 											status === 'accepted' ||
 											status === 'dismissed' ||
 											bulkRunning;
 										const dismissDisabled =
+											isPostStale ||
 											status === 'applying' ||
 											status === 'accepted' ||
 											status === 'dismissed' ||
@@ -1311,7 +1380,7 @@ export default function ReviewMediation( {
 													<BlockRef
 														index={ edit.block_index }
 														blocks={ blocks }
-														onFocus={ clickable ? focusBlock : undefined }
+														onFocus={ clickable ? focusCurrentPostBlock : undefined }
 													/>
 													{ edit.suggested_text && (
 														<>
@@ -1329,6 +1398,7 @@ export default function ReviewMediation( {
 													<button
 														type="button"
 														className="jetpack-ai-review-mediation__collapsed-undo"
+														disabled={ isPostStale }
 														onClick={ () => handleUndoEdit( i ) }
 														title={
 															status === 'accepted'
@@ -1355,7 +1425,7 @@ export default function ReviewMediation( {
 													<BlockRef
 														index={ edit.block_index }
 														blocks={ blocks }
-														onFocus={ clickable ? focusBlock : undefined }
+														onFocus={ clickable ? focusCurrentPostBlock : undefined }
 													/>
 												</p>
 												{ edit.current_text && (
@@ -1471,7 +1541,7 @@ export default function ReviewMediation( {
 															<BlockRef
 																index={ v.block_index }
 																blocks={ blocks }
-																onFocus={ focusBlock }
+																onFocus={ focusCurrentPostBlock }
 															/>
 														</>
 													) }
@@ -1504,7 +1574,7 @@ export default function ReviewMediation( {
 					<button
 						type="button"
 						className="jetpack-ai-review-mediation__footer-action is-accept"
-						disabled={ bulkRunning || totalPendingCount === 0 }
+						disabled={ isPostStale || bulkRunning || totalPendingCount === 0 }
 						onClick={ handleAcceptAllAi }
 					>
 						{ bulkRunning

--- a/packages/jetpack-ai-sidebar/src/components/review-mediation.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/review-mediation.tsx
@@ -341,6 +341,17 @@ export default function ReviewMediation( {
 		[]
 	);
 	const isPostStale = ! postId || ! currentPostId || postId !== currentPostId;
+	const latestPostContextRef = useRef( { postId, currentPostId } );
+	useEffect( () => {
+		latestPostContextRef.current = { postId, currentPostId };
+	}, [ postId, currentPostId ] );
+	const isLatestPostContextStale = useCallback( () => {
+		const { postId: latestSourcePostId, currentPostId: latestCurrentPostId } =
+			latestPostContextRef.current;
+		return (
+			! latestSourcePostId || ! latestCurrentPostId || latestSourcePostId !== latestCurrentPostId
+		);
+	}, [] );
 
 	const [ editStatuses, setEditStatuses ] = useState< Record< number, EditStatus > >( {} );
 	const [ conflictStatuses, setConflictStatuses ] = useState< Record< number, EditStatus > >( {} );
@@ -498,7 +509,7 @@ export default function ReviewMediation( {
 			contentBefore?: string;
 			contentAfter?: string;
 		} > => {
-			if ( isPostStale ) {
+			if ( isPostStale || isLatestPostContextStale() ) {
 				return { success: false };
 			}
 			if ( getBlockEditDisabledReason( blockIndex, currentText ) ) {
@@ -509,7 +520,12 @@ export default function ReviewMediation( {
 				return { success: false };
 			}
 			try {
-				const result = await applyReviewEdit( clientId, text, undefined, currentText );
+				const result = await applyReviewEdit( clientId, text, undefined, currentText, () => {
+					return ! isLatestPostContextStale();
+				} );
+				if ( isLatestPostContextStale() ) {
+					return { success: false };
+				}
 				if ( result?.success ) {
 					return {
 						success: true,
@@ -529,7 +545,7 @@ export default function ReviewMediation( {
 				return { success: false };
 			}
 		},
-		[ getBlockEditDisabledReason, getClientId, isPostStale ]
+		[ getBlockEditDisabledReason, getClientId, isLatestPostContextStale, isPostStale ]
 	);
 
 	// ---------- Suggested edit handlers ----------
@@ -749,90 +765,111 @@ export default function ReviewMediation( {
 			return successCount === 0 ? 'failed' : 'partial_failed';
 		};
 		setBulkRunning( true );
-		// Sequential so users see the shimmer on each block as it applies;
-		// parallel would race the same dispatch and confuse the state store.
-		for ( let i = 0; i < conflicts.length; i++ ) {
-			const status = conflictStatuses[ i ] ?? 'pending';
-			if ( status !== 'pending' && status !== 'failed' ) {
-				continue;
+		try {
+			// Sequential so users see the shimmer on each block as it applies;
+			// parallel would race the same dispatch and confuse the state store.
+			for ( let i = 0; i < conflicts.length; i++ ) {
+				if ( isLatestPostContextStale() ) {
+					return;
+				}
+				const status = conflictStatuses[ i ] ?? 'pending';
+				if ( status !== 'pending' && status !== 'failed' ) {
+					continue;
+				}
+				const aiCandidate = conflicts[ i ].candidate_resolutions?.find(
+					( c ) =>
+						c.source === 'ai' && ! getBlockEditDisabledReason( c.block_index, c.current_text )
+				);
+				if ( ! aiCandidate ) {
+					continue;
+				}
+				setConflictStatus( i, 'applying' );
+				// eslint-disable-next-line no-await-in-loop
+				const result = await applyTextToBlock(
+					aiCandidate.block_index,
+					aiCandidate.text,
+					aiCandidate.current_text
+				);
+				if ( isLatestPostContextStale() ) {
+					setConflictStatus( i, status );
+					return;
+				}
+				if (
+					result.success &&
+					result.clientId &&
+					typeof result.contentBefore === 'string' &&
+					typeof result.contentAfter === 'string'
+				) {
+					conflictSnapshots.current[ i ] = {
+						clientId: result.clientId,
+						contentBefore: result.contentBefore,
+						contentAfter: result.contentAfter,
+					};
+				}
+				if ( ! result.success ) {
+					failureCount++;
+				} else {
+					successCount++;
+				}
+				setConflictStatus( i, result.success ? 'accepted' : 'failed' );
 			}
-			const aiCandidate = conflicts[ i ].candidate_resolutions?.find(
-				( c ) => c.source === 'ai' && ! getBlockEditDisabledReason( c.block_index, c.current_text )
-			);
-			if ( ! aiCandidate ) {
-				continue;
+			for ( let i = 0; i < suggested_edits.length; i++ ) {
+				if ( isLatestPostContextStale() ) {
+					return;
+				}
+				const status = editStatuses[ i ] ?? 'pending';
+				if ( status !== 'pending' && status !== 'failed' ) {
+					continue;
+				}
+				const edit = suggested_edits[ i ];
+				if ( isManualSuggestedEdit( edit ) ) {
+					continue;
+				}
+				if ( getBlockEditDisabledReason( edit.block_index, edit.current_text ) ) {
+					continue;
+				}
+				setEditStatus( i, 'applying' );
+				// eslint-disable-next-line no-await-in-loop
+				const result = await applyTextToBlock(
+					edit.block_index,
+					edit.suggested_text,
+					edit.current_text
+				);
+				if ( isLatestPostContextStale() ) {
+					setEditStatus( i, status );
+					return;
+				}
+				if (
+					result.success &&
+					result.clientId &&
+					typeof result.contentBefore === 'string' &&
+					typeof result.contentAfter === 'string'
+				) {
+					editSnapshots.current[ i ] = {
+						clientId: result.clientId,
+						contentBefore: result.contentBefore,
+						contentAfter: result.contentAfter,
+					};
+				}
+				if ( ! result.success ) {
+					failureCount++;
+				} else {
+					successCount++;
+				}
+				setEditStatus( i, result.success ? 'accepted' : 'failed' );
 			}
-			setConflictStatus( i, 'applying' );
-			// eslint-disable-next-line no-await-in-loop
-			const result = await applyTextToBlock(
-				aiCandidate.block_index,
-				aiCandidate.text,
-				aiCandidate.current_text
-			);
-			if (
-				result.success &&
-				result.clientId &&
-				typeof result.contentBefore === 'string' &&
-				typeof result.contentAfter === 'string'
-			) {
-				conflictSnapshots.current[ i ] = {
-					clientId: result.clientId,
-					contentBefore: result.contentBefore,
-					contentAfter: result.contentAfter,
-				};
+			if ( isLatestPostContextStale() ) {
+				return;
 			}
-			if ( ! result.success ) {
-				failureCount++;
-			} else {
-				successCount++;
-			}
-			setConflictStatus( i, result.success ? 'accepted' : 'failed' );
+			fireItemAction( {
+				action: 'bulk_accept',
+				target: bulkTarget,
+				outcome: getBulkOutcome(),
+				itemCount: successCount + failureCount,
+			} );
+		} finally {
+			setBulkRunning( false );
 		}
-		for ( let i = 0; i < suggested_edits.length; i++ ) {
-			const status = editStatuses[ i ] ?? 'pending';
-			if ( status !== 'pending' && status !== 'failed' ) {
-				continue;
-			}
-			const edit = suggested_edits[ i ];
-			if ( isManualSuggestedEdit( edit ) ) {
-				continue;
-			}
-			if ( getBlockEditDisabledReason( edit.block_index, edit.current_text ) ) {
-				continue;
-			}
-			setEditStatus( i, 'applying' );
-			// eslint-disable-next-line no-await-in-loop
-			const result = await applyTextToBlock(
-				edit.block_index,
-				edit.suggested_text,
-				edit.current_text
-			);
-			if (
-				result.success &&
-				result.clientId &&
-				typeof result.contentBefore === 'string' &&
-				typeof result.contentAfter === 'string'
-			) {
-				editSnapshots.current[ i ] = {
-					clientId: result.clientId,
-					contentBefore: result.contentBefore,
-					contentAfter: result.contentAfter,
-				};
-			}
-			if ( ! result.success ) {
-				failureCount++;
-			} else {
-				successCount++;
-			}
-			setEditStatus( i, result.success ? 'accepted' : 'failed' );
-		}
-		fireItemAction( {
-			action: 'bulk_accept',
-			target: bulkTarget,
-			outcome: getBulkOutcome(),
-			itemCount: successCount + failureCount,
-		} );
-		setBulkRunning( false );
 	}, [
 		bulkRunning,
 		totalPendingCount,
@@ -845,6 +882,7 @@ export default function ReviewMediation( {
 		applyTextToBlock,
 		fireItemAction,
 		getBlockEditDisabledReason,
+		isLatestPostContextStale,
 		isPostStale,
 		setConflictStatus,
 		setEditStatus,

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -530,6 +530,7 @@ describe( 'applyReviewEdit', () => {
 
 	afterEach( () => {
 		jest.useRealTimers();
+		document.body.innerHTML = '';
 	} );
 
 	it( 'dispatches updateBlockAttributes with the suggested content', async () => {
@@ -556,6 +557,54 @@ describe( 'applyReviewEdit', () => {
 				attrs: { content: 'new text' },
 			},
 		] );
+	} );
+
+	it( 'does not snapshot or write when shouldApply is already false', async () => {
+		const { blockUpdates } = installWpDataMockWithBlockEditor();
+		useAbilitiesSetup( { addMessage: () => undefined, clearSuggestions: () => undefined } as any );
+
+		const result = await applyReviewEdit(
+			'550e8400-e29b-41d4-a716-446655440000',
+			'new text',
+			undefined,
+			undefined,
+			() => false
+		);
+
+		expect( result ).toMatchObject( {
+			success: false,
+			error: 'context changed',
+		} );
+		expect( blockUpdates ).toEqual( [] );
+	} );
+
+	it( 'does not write and clears processing state when shouldApply turns false before the delayed write', async () => {
+		const { blockUpdates } = installWpDataMockWithBlockEditor();
+		useAbilitiesSetup( { addMessage: () => undefined, clearSuggestions: () => undefined } as any );
+		const blockEl = document.createElement( 'div' );
+		blockEl.setAttribute( 'data-block', '550e8400-e29b-41d4-a716-446655440000' );
+		document.body.appendChild( blockEl );
+		let shouldApply = true;
+
+		const promise = applyReviewEdit(
+			'550e8400-e29b-41d4-a716-446655440000',
+			'new text',
+			undefined,
+			undefined,
+			() => shouldApply
+		);
+		expect( blockEl.classList.contains( 'jetpack-ai-is-processing' ) ).toBe( true );
+
+		shouldApply = false;
+		jest.advanceTimersByTime( 1000 );
+		const result = await promise;
+
+		expect( result ).toMatchObject( {
+			success: false,
+			error: 'context changed',
+		} );
+		expect( blockUpdates ).toEqual( [] );
+		expect( blockEl.classList.contains( 'jetpack-ai-is-processing' ) ).toBe( false );
 	} );
 
 	it( 'posts the rationale as an assistant message to the chat when a summary is provided', async () => {

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -74,14 +74,15 @@ jest.mock( '@wordpress/data', () => ( {
 } ) );
 
 // Stub @wordpress/data on window so useCheckpoint / handleShowComponent
-// can read/write the post title via the core/editor store.
-function installWpDataMock( initialTitle: string ) {
+// can read/write the post title and current post id via the core/editor store.
+function installWpDataMock( initialTitle: string, postId = 123 ) {
 	const state = { title: initialTitle };
 	( window as any ).wp = {
 		data: {
 			select: ( store: string ) => {
 				if ( store === 'core/editor' ) {
 					return {
+						getCurrentPostId: () => postId,
 						getEditedPostAttribute: ( attr: string ) =>
 							attr === 'title' ? state.title : undefined,
 					};
@@ -354,6 +355,7 @@ describe( 'toolProvider', () => {
 			expect( parsed.tool_id ).toBe( 'big_sky__show_component' );
 			expect( parsed.data.type ).toBe( 'title-picker' );
 			expect( parsed.data.props ).toEqual( { titles } );
+			expect( parsed.data.postId ).toBeUndefined();
 			expect( parsed.data.calypsoCheckpointId ).toBe( 'call_test_123' );
 			expect( parsed.data.isCurrent ).toBe( true );
 			expect( parsed.data.hideZoomAction ).toBe( true );
@@ -377,6 +379,28 @@ describe( 'toolProvider', () => {
 			expect( parsed.data.calypsoCheckpointId ).toBeUndefined();
 			expect( parsed.data.isCurrent ).toBe( true );
 			expect( parsed.data.hideZoomAction ).toBe( true );
+			expect( parsed.data.postId ).toBe( 123 );
+			expect( parsed.data.props.postId ).toBe( 123 );
+		} );
+
+		it( 'does not stamp review-mediation components without a saved editor post ID', async () => {
+			installWpDataMock( 'Original Title', 0 );
+
+			const { result } = ( await toolProvider.executeAbility( 'big_sky__show_component', {
+				type: 'review-mediation',
+				props: {
+					summary: 'Summary.',
+					conflicts: [],
+					implications: [],
+					suggested_edits: [],
+					guideline_violations: [],
+				},
+			} ) ) as any;
+
+			const parsed = JSON.parse( result.agentMessage );
+			expect( parsed.data.type ).toBe( 'review-mediation' );
+			expect( parsed.data.postId ).toBeUndefined();
+			expect( parsed.data.props.postId ).toBeUndefined();
 		} );
 
 		it( 'generates a checkpointId fallback when toolCallId is missing', async () => {

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -83,6 +83,11 @@ function getCurrentEditorPostType(): string | undefined {
 	return typeof postType === 'string' ? postType : undefined;
 }
 
+function getCurrentEditorPostId(): number | undefined {
+	const postId = ( window as any ).wp?.data?.select?.( 'core/editor' )?.getCurrentPostId?.();
+	return typeof postId === 'number' && postId > 0 ? postId : undefined;
+}
+
 function isAiEditorialReviewAvailable(
 	// Default arguments run at call time, so callers can omit this when they
 	// want the current editor state read live.
@@ -155,12 +160,20 @@ function handleShowComponent( input: any ): any {
 		};
 	}
 
+	const componentProps: Record< string, unknown > = { ...( props ?? {} ) };
 	const data: Record< string, unknown > = {
 		type,
-		props: props ?? {},
+		props: componentProps,
 		isCurrent: true,
 		hideZoomAction: true,
 	};
+	if ( type === 'review-mediation' ) {
+		const currentPostId = getCurrentEditorPostId();
+		if ( currentPostId ) {
+			componentProps.postId = currentPostId;
+			data.postId = currentPostId;
+		}
+	}
 
 	if ( type === 'title-picker' ) {
 		// Snapshot state for Undo. Tool call id doubles as the checkpoint id so

--- a/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
@@ -204,7 +204,10 @@ function getBlockSnapshot( clientId: string ): { name: string; content: string }
 
 /**
  * Handle the update-block-content tool call: apply text changes to a block.
- * @param {any} input - Tool input with clientId, content, and optional summary / currentText.
+ * @param {any} input - Tool input with clientId, content, optional summary / currentText,
+ *   and optional shouldApply guard. When shouldApply returns false before either the
+ *   initial snapshot or delayed write, the edit fails with "context changed" without
+ *   mutating the block.
  * @returns Result with success flag and (on success) the pre-edit `contentBefore`
  *   so callers can revert later via `undoBlockEdit`.
  */
@@ -223,6 +226,7 @@ export function handleUpdateBlockContent( input: any ): any {
 	if ( ! blockEditor ) {
 		return { success: false, error: 'Block editor not available', returnToAgent: false };
 	}
+	// Let callers veto before we snapshot if the editor context has changed.
 	if ( typeof shouldApply === 'function' && ! shouldApply() ) {
 		return { success: false, error: 'context changed', returnToAgent: false };
 	}
@@ -284,6 +288,7 @@ export function handleUpdateBlockContent( input: any ): any {
 				resolve( { success: false, error, returnToAgent: false } );
 			};
 
+			// Re-check immediately before mutation because the shimmer intentionally delays writes.
 			if ( typeof shouldApply === 'function' && ! shouldApply() ) {
 				resolveFailure( 'context changed' );
 				return;
@@ -355,7 +360,8 @@ export function handleUpdateBlockContent( input: any ): any {
  * ambiguous, the edit fails safely rather than replacing the whole block. Returns
  * `success: false` for unsupported block types so the UI can show 'failed' rather
  * than corrupting the block. On success, returns `contentBefore` so the caller can
- * pair it with `clientId` and call `undoBlockEdit` later.
+ * pair it with `clientId` and call `undoBlockEdit` later. The optional shouldApply
+ * guard lets callers abort safely if editor context changes while the edit is pending.
  */
 export async function applyReviewEdit(
 	clientId: string,

--- a/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
@@ -209,7 +209,7 @@ function getBlockSnapshot( clientId: string ): { name: string; content: string }
  *   so callers can revert later via `undoBlockEdit`.
  */
 export function handleUpdateBlockContent( input: any ): any {
-	const { clientId, content, summary, currentText } = input;
+	const { clientId, content, summary, currentText, shouldApply } = input;
 	if ( ! clientId || content === undefined || content === null ) {
 		return { success: false, error: 'clientId and content are required', returnToAgent: false };
 	}
@@ -222,6 +222,9 @@ export function handleUpdateBlockContent( input: any ): any {
 	const blockEditor = wpData.dispatch( 'core/block-editor' );
 	if ( ! blockEditor ) {
 		return { success: false, error: 'Block editor not available', returnToAgent: false };
+	}
+	if ( typeof shouldApply === 'function' && ! shouldApply() ) {
+		return { success: false, error: 'context changed', returnToAgent: false };
 	}
 
 	const snapshot = getBlockSnapshot( clientId );
@@ -281,6 +284,10 @@ export function handleUpdateBlockContent( input: any ): any {
 				resolve( { success: false, error, returnToAgent: false } );
 			};
 
+			if ( typeof shouldApply === 'function' && ! shouldApply() ) {
+				resolveFailure( 'context changed' );
+				return;
+			}
 			if ( ! latestSnapshot ) {
 				resolveFailure( 'block not found' );
 				return;
@@ -354,7 +361,8 @@ export async function applyReviewEdit(
 	clientId: string,
 	content: string,
 	summary?: string,
-	currentText?: string
+	currentText?: string,
+	shouldApply?: () => boolean
 ): Promise< {
 	success: boolean;
 	contentBefore?: string;
@@ -362,7 +370,7 @@ export async function applyReviewEdit(
 	error?: string;
 	returnToAgent?: boolean;
 } > {
-	return handleUpdateBlockContent( { clientId, content, summary, currentText } );
+	return handleUpdateBlockContent( { clientId, content, summary, currentText, shouldApply } );
 }
 
 /**


### PR DESCRIPTION
Prevents stale AI Editorial Review results from remaining actionable after the editor context changes to another post.

  When a review is rendered, the sidebar stamps the current editor post ID onto the review mediation payload. `ReviewMediation` compares that source post ID with the current editor
  post ID and treats the review as stale if the IDs are missing or different.

  For stale reviews:
  - Show a warning to start a new chat and re-run the review.
  - Dim the review content.
  - Disable stats navigation, block focus links, suggestion actions, conflict actions, and bulk apply.
  - Skip result-rendered tracking for stale review output.

  ## Testing Instructions

  1. Sandbox this PR.
  2. On the WPCOM sandbox, install this AM branch:
     ```sh
     install-plugin.sh am fix/ai-editorial-review-post-context

  3. Open a saved draft post in the editor.
  4. Open the AI sidebar and run AI Editorial Review.
  5. Keep the sidebar open.
  6. In the same tab, replace the post=<id> value in the URL with another valid post ID and load it.
  7. Open/observe the AI sidebar.
  8. Confirm the previous review is shown as stale:
      - Warning is visible.
      - Review body is dimmed.
      - Stats buttons are disabled.
      - Accept/dismiss/apply actions are disabled.
  9. Start a new chat or run a fresh review for the new post and confirm the new review is actionable.

  ## Automated Tests

  - yarn test-packages packages/jetpack-ai-sidebar/src/index.test.ts --runInBand
  - yarn test-packages packages/jetpack-ai-sidebar/src/components/review-mediation.test.tsx --runInBand
  - yarn tsc --noEmit --project packages/jetpack-ai-sidebar/tsconfig.json