### PR TITLE
A4A: Update Claude Desktop MCP instructions to use Connectors flow

### DIFF
--- a/client/a8c-for-agencies/sections/ai-mcp/primary/connect-agent/agent-configs.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/connect-agent/agent-configs.tsx
@@ -89,20 +89,19 @@ export const AGENT_CONFIGS: AgentConfig[] = [
 		id: 'claude-desktop',
 		label: 'Claude Desktop',
 		quickSetup: [
-			__( 'Install Node 20 or later (required by mcp-remote).' ),
-			__(
-				'Open Claude Desktop → Settings → Developer, then click “Edit Config” under Local MCP servers.'
-			),
+			__( 'Open Claude Desktop and go to Settings → Connectors (or Customize).' ),
+			__( 'Click “Add custom connector”.' ),
 			createInterpolateElement(
-				__(
-					'Add the configuration below to <code>claude_desktop_config.json</code> (typically at <code>~/Library/Application Support/Claude/claude_desktop_config.json</code>).'
+				sprintf(
+					/* translators: %s: A4A MCP server URL, kept inside <code> */
+					__(
+						'Enter a name (for example, “A4A MCP”) and paste <code>%s</code> into the Remote MCP server URL field.'
+					),
+					A4A_MCP_URL
 				),
 				{ code: <code /> }
 			),
-			__( 'Restart Claude Desktop.' ),
-			__(
-				'If you haven’t authenticated yet, Claude Desktop will prompt you in your browser as soon as it reopens.'
-			),
+			__( 'Authenticate when Claude Desktop prompts you in your browser.' ),
 		],
 		manualSetupFile: 'claude_desktop_config.json',
 		manualSetupLanguage: 'json',


### PR DESCRIPTION
Part of A4A-2608

## Proposed Changes

* Rewrite the Claude Desktop Quick setup steps on the A4A AI MCP → Connect agent page to use Claude Desktop's built-in Connectors UI (Settings → Connectors / Customize → Add custom connector) instead of editing `claude_desktop_config.json` with `mcp-remote`.
* Drop the Node 20 prerequisite and the Edit Config / restart steps — they're no longer needed for the native remote MCP flow.
* Use the existing `A4A_MCP_URL` constant via `sprintf` + `<code>` interpolation so the URL stays in one place.

## Why are these changes being made?

Claude Desktop now supports remote MCP servers natively through the Connectors UI, which is far simpler than the previous `mcp-remote` workaround (no Node install, no JSON config, no restart). Updating the in-product instructions to match the recommended flow reduces setup friction for agencies connecting their AI assistant.

## Testing Instructions

* Run `yarn start` and open A4A → AI MCP → Connect agent.
* Select **Claude Desktop** in the assistant dropdown.
* Verify the Quick setup section now shows four steps:
  1. Open Claude Desktop and go to Settings → Connectors (or Customize).
  2. Click "Add custom connector".
  3. Enter a name (for example, "A4A MCP") and paste `https://public-api.wordpress.com/wpcom/v2/a4a-mcp/v1` into the Remote MCP server URL field.
  4. Authenticate when Claude Desktop prompts you in your browser.
* Confirm the URL renders inside a `<code>` element and matches `A4A_MCP_URL`.
* Confirm the Manual setup section (mcp-remote fallback) still renders unchanged.

<img width="1920" height="961" alt="Screenshot 2026-05-15 at 11 16 45 AM" src="https://github.com/user-attachments/assets/4b71f967-f40f-4fd2-9df4-8a69d597346a" />


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?