### PR TITLE
Help Center: Make icon accessible in Post Editor at narrow viewports (DOTSUP-448)

### DIFF
--- a/apps/help-center/help-center-gutenberg-disconnected.jsx
+++ b/apps/help-center/help-center-gutenberg-disconnected.jsx
@@ -2,6 +2,7 @@ import './config';
 import { HelpIcon } from '@automattic/help-center';
 import { Button, Fill } from '@wordpress/components';
 import { useMediaQuery } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
 import { useEffect, useReducer } from '@wordpress/element';
 import { registerPlugin } from '@wordpress/plugins';
 import ReactDOM from 'react-dom';
@@ -12,8 +13,10 @@ function HelpCenterContent() {
 	const [ , forceUpdate ] = useReducer( ( x ) => x + 1, 0 );
 	const isDesktop = useMediaQuery( '(min-width: 480px)' );
 	const canvasMode = useCanvasMode();
+	const isPostEditor = useSelect( ( select ) => !! select( 'core/edit-post' ), [] );
 
 	const sidebarActionsContainer = document.querySelector( '.edit-site-site-hub__actions' );
+	const postEditorMobileContainer = document.querySelector( '.editor-header__settings' );
 
 	const content = (
 		<>
@@ -37,6 +40,10 @@ function HelpCenterContent() {
 
 	if ( canvasMode === 'view' ) {
 		return sidebarActionsContainer && ReactDOM.createPortal( content, sidebarActionsContainer );
+	}
+
+	if ( ! isDesktop && isPostEditor && postEditorMobileContainer ) {
+		return ReactDOM.createPortal( content, postEditorMobileContainer );
 	}
 
 	return isDesktop && <Fill name="PinnedItems/core">{ content }</Fill>;

--- a/apps/help-center/help-center-gutenberg-disconnected.jsx
+++ b/apps/help-center/help-center-gutenberg-disconnected.jsx
@@ -11,7 +11,8 @@ import './help-center.scss';
 
 function HelpCenterContent() {
 	const [ , forceUpdate ] = useReducer( ( x ) => x + 1, 0 );
-	const isDesktop = useMediaQuery( '(min-width: 480px)' );
+	// Gutenberg's PinnedItems/core slot is CSS-hidden under 600px.
+	const canRenderPinnedItem = useMediaQuery( '(min-width: 600px)' );
 	const canvasMode = useCanvasMode();
 	const isPostEditor = useSelect( ( select ) => !! select( 'core/edit-post' ), [] );
 
@@ -42,11 +43,11 @@ function HelpCenterContent() {
 		return sidebarActionsContainer && ReactDOM.createPortal( content, sidebarActionsContainer );
 	}
 
-	if ( ! isDesktop && isPostEditor && postEditorMobileContainer ) {
+	if ( ! canRenderPinnedItem && isPostEditor && postEditorMobileContainer ) {
 		return ReactDOM.createPortal( content, postEditorMobileContainer );
 	}
 
-	return isDesktop && <Fill name="PinnedItems/core">{ content }</Fill>;
+	return canRenderPinnedItem && <Fill name="PinnedItems/core">{ content }</Fill>;
 }
 
 registerPlugin( 'jetpack-help-center', {

--- a/apps/help-center/help-center-gutenberg.jsx
+++ b/apps/help-center/help-center-gutenberg.jsx
@@ -22,6 +22,8 @@ const queryClient = new QueryClient();
 
 function HelpCenterContent() {
 	const isDesktop = useMediaQuery( '(min-width: 480px)' );
+	// Gutenberg's PinnedItems/core slot is CSS-hidden under 600px.
+	const canRenderPinnedItem = useMediaQuery( '(min-width: 600px)' );
 	const [ showHelpIcon, setShowHelpIcon ] = useState( false );
 	const [ helpCenterPage, setHelpCenterPage ] = useState( null );
 	const { setShowHelpCenter, setNavigateToRoute } = useDispatch( 'automattic/help-center' );
@@ -243,12 +245,12 @@ function HelpCenterContent() {
 				canvasMode === 'view' &&
 				sidebarActionsContainer &&
 				ReactDOM.createPortal( content, sidebarActionsContainer ) }
-			{ ! isDesktop &&
+			{ ! canRenderPinnedItem &&
 				isPostEditor &&
 				showHelpIcon &&
 				postEditorMobileContainer &&
 				ReactDOM.createPortal( content, postEditorMobileContainer ) }
-			{ isDesktop && showHelpIcon && <Fill name="PinnedItems/core">{ content }</Fill> }
+			{ canRenderPinnedItem && showHelpIcon && <Fill name="PinnedItems/core">{ content }</Fill> }
 			<HelpCenter
 				locale={ helpCenterData.locale }
 				sectionName={ helpCenterData.sectionName || 'gutenberg-editor' }

--- a/apps/help-center/help-center-gutenberg.jsx
+++ b/apps/help-center/help-center-gutenberg.jsx
@@ -30,6 +30,7 @@ function HelpCenterContent() {
 	const isShown = useSelect( ( s ) => s( 'automattic/help-center' ).isHelpCenterShown(), [] );
 
 	const canvasMode = useCanvasMode();
+	const isPostEditor = useSelect( ( select ) => !! select( 'core/edit-post' ), [] );
 
 	const trackIconInteraction = useCallback( () => {
 		recordTracksEvent( 'wpcom_help_center_icon_interaction', {
@@ -103,6 +104,7 @@ function HelpCenterContent() {
 	);
 
 	const sidebarActionsContainer = document.querySelector( '.edit-site-site-hub__actions' );
+	const postEditorMobileContainer = document.querySelector( '.editor-header__settings' );
 
 	const hasInitialized = useRef( false );
 	// On mobile the SlotFill button is hidden by Gutenberg's own CSS, so wire up the
@@ -241,6 +243,11 @@ function HelpCenterContent() {
 				canvasMode === 'view' &&
 				sidebarActionsContainer &&
 				ReactDOM.createPortal( content, sidebarActionsContainer ) }
+			{ ! isDesktop &&
+				isPostEditor &&
+				showHelpIcon &&
+				postEditorMobileContainer &&
+				ReactDOM.createPortal( content, postEditorMobileContainer ) }
 			{ isDesktop && showHelpIcon && <Fill name="PinnedItems/core">{ content }</Fill> }
 			<HelpCenter
 				locale={ helpCenterData.locale }


### PR DESCRIPTION
Fixes DOTSUP-448

## Proposed Changes

* Add a new render path in `apps/help-center/help-center-gutenberg.jsx` that portals the Help Center button into `.editor-header__settings` when in the Post Editor at narrow viewports (< 600px).
* Mirror the same fix in the disconnected variant (`help-center-gutenberg-disconnected.jsx`).
* Replace the `isDesktop` (480px) gate on the existing `PinnedItems/core` Fill with a new `canRenderPinnedItem` (600px) gate matching where Gutenberg's CSS actually makes the slot visible.

## Why are these changes being made?

The Help Center `?` icon button is rendered into Gutenberg's `PinnedItems/core` slot, which is CSS-hidden under 600px. The existing render logic had three paths:

1. A view-mode portal for the Site Editor (`.edit-site-site-hub__actions`) — works at any width.
2. The `PinnedItems/core` Fill — gated on `isDesktop` (480px) but the slot is actually CSS-hidden until 600px.
3. An admin-bar wire-up — only fires when `#wp-admin-bar-help-center` exists, which isn't reliable in the Post Editor.

Result: in the Post Editor on phone or tablet-portrait viewports (anywhere under 600px), all three paths failed silently and the icon disappeared with no fallback.

This PR adds a fourth path that mirrors the Site Editor view-mode pattern: portal into `.editor-header__settings` (the Post Editor's right-side toolbar actions container) when we're in the Post Editor at a width where the `PinnedItems/core` slot isn't visible. No CSS changes — bypasses Gutenberg core's mobile-hidden styling by portaling outside that container.

**Scope note:** the original bug report mentioned "< 480px" only. During testing we found the same gap also affects 480-599px — the original assumption about Gutenberg's breakpoint was off. Same root cause, same fix; this PR covers both ranges.

## Testing Instructions

1. Sandbox `widgets.wp.com` (the sites themselves do not need sandboxing).
2. `cd apps/help-center && WPCOM_SANDBOX=sandbox yarn dev --sync` (or omit the env var if your SSH alias is `wpcom-sandbox`).
3. Open the Post Editor (`wp-admin/post-new.php`) on a sandboxed Simple or Atomic site.
4. Resize the window:
   - **< 480px**: `?` icon should appear at the top-right of the editor toolbar (in `.editor-header__settings`).
   - **480-599px**: same — `?` icon visible at top-right via the same portal.
   - **≥ 600px**: `?` icon visible via the original `PinnedItems/core` slot.
5. Click the `?` icon at < 600px — the Help Center panel should slide in normally, positioned below the editor toolbar.
6. **Regression checks:** in the Site Editor (`?path=/patterns`) at the same widths, the icon should remain visible via the existing `.edit-site-site-hub__actions` portal path (Site Editor view mode unchanged).

Tested on Simple + Atomic at 375px, 516px, and 1280px+. Self-hosted Jetpack (disconnected variant) not directly tested but mirrors the same pattern.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?
