### PR TITLE
Help Center: add logged-out FAB launcher on /themes and /plugins

### DIFF
--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -170,6 +170,11 @@ $z-layers: (
 
 		".wpcom-site__global-noscript": 300000,
 
+		// Sits above the @automattic/privacy-toolset cookie banner (z-index 50001).
+		// The Help Center panel itself ($help-center-z-index: 500000) renders on
+		// top — that's intentional, since the panel has its own close button.
+		".help-center-fab": 50002,
+
 		".is-section-woocommerce .global-notices": 999999,
 		".people-list-item.card.is-compact:focus": 1,
 		".reader-join-conversation-dialog__overlay": 10000001,

--- a/client/components/help-center-fab/async.tsx
+++ b/client/components/help-center-fab/async.tsx
@@ -1,0 +1,11 @@
+import AsyncLoad from 'calypso/components/async-load';
+import type { HelpCenterFabProps } from './index';
+
+const loadHelpCenterFab = () =>
+	import( /* webpackChunkName: "async-load-calypso-components-help-center-fab" */ './index' );
+
+const AsyncHelpCenterFab = ( props: HelpCenterFabProps ) => (
+	<AsyncLoad require={ loadHelpCenterFab } placeholder={ null } { ...props } />
+);
+
+export default AsyncHelpCenterFab;

--- a/client/components/help-center-fab/index.tsx
+++ b/client/components/help-center-fab/index.tsx
@@ -1,0 +1,78 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { Button } from '@wordpress/components';
+import { useI18n } from '@wordpress/react-i18n';
+import clsx from 'clsx';
+import useShowHelpCenter from 'calypso/components/help-center/use-show-help-center';
+import { useCurrentRoute } from 'calypso/components/route';
+import HelpCenterLoader from 'calypso/layout/help-center-loader';
+
+import './style.scss';
+
+const QuestionMarkIcon = () => (
+	<svg
+		width="24"
+		height="24"
+		viewBox="0 0 24 24"
+		xmlns="http://www.w3.org/2000/svg"
+		aria-hidden="true"
+		focusable="false"
+	>
+		<path
+			fill="currentColor"
+			d="M11.07 12.85c.77-1.39 2.25-2.21 3.11-3.44.91-1.29.4-3.7-2.18-3.7-1.69 0-2.52 1.28-2.87 2.34L6.54 6.96C7.25 4.83 9.18 3 11.99 3c2.35 0 3.96 1.07 4.78 2.41.7 1.15 1.11 3.3.03 4.9-1.2 1.77-2.35 2.31-2.97 3.45-.25.46-.35.76-.35 2.24h-2.89c-.01-.78-.13-2.05.48-3.15zM14 20c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2z"
+		/>
+	</svg>
+);
+
+export type HelpCenterFabProps = {
+	sectionName: string;
+};
+
+const HelpCenterFab = ( { sectionName }: HelpCenterFabProps ) => {
+	const { __ } = useI18n();
+	const { isShown: isHelpCenterShown, setShowHelpCenter } = useShowHelpCenter();
+	const { currentRoute } = useCurrentRoute();
+
+	const handleClick = () => {
+		const willShow = ! isHelpCenterShown;
+		recordTracksEvent( `calypso_inlinehelp_${ willShow ? 'show' : 'close' }`, {
+			force_site_id: true,
+			location: 'help-center-fab',
+			section: sectionName,
+		} );
+		setShowHelpCenter( willShow );
+	};
+
+	const label = isHelpCenterShown
+		? /* translators: Tooltip on the floating Help button when the Help Center panel is open. */
+		  __( 'Close help' )
+		: /* translators: Tooltip on the floating Help button that opens the Help Center. */
+		  __( 'Help' );
+
+	return (
+		<>
+			{
+				// Mount lazily so we don't expose an empty role="dialog" container at idle.
+				isHelpCenterShown && (
+					<HelpCenterLoader
+						sectionName={ sectionName }
+						loadHelpCenter
+						currentRoute={ currentRoute }
+					/>
+				)
+			}
+			<Button
+				className={ clsx( 'help-center-fab', { 'is-active': isHelpCenterShown } ) }
+				onClick={ handleClick }
+				label={ label }
+				showTooltip
+				aria-haspopup="dialog"
+				aria-expanded={ isHelpCenterShown }
+			>
+				<QuestionMarkIcon />
+			</Button>
+		</>
+	);
+};
+
+export default HelpCenterFab;

--- a/client/components/help-center-fab/index.tsx
+++ b/client/components/help-center-fab/index.tsx
@@ -36,7 +36,6 @@ const HelpCenterFab = ( { sectionName }: HelpCenterFabProps ) => {
 	const handleClick = () => {
 		const willShow = ! isHelpCenterShown;
 		recordTracksEvent( `calypso_inlinehelp_${ willShow ? 'show' : 'close' }`, {
-			force_site_id: true,
 			location: 'help-center-fab',
 			section: sectionName,
 		} );

--- a/client/components/help-center-fab/style.scss
+++ b/client/components/help-center-fab/style.scss
@@ -1,0 +1,73 @@
+$help-center-fab-size: 48px;
+$help-center-fab-offset: 24px;
+$help-center-fab-gap: 8px;
+
+.components-button.help-center-fab {
+	position: fixed;
+	// `env(safe-area-inset-*)` keeps the FAB clear of the iOS home indicator and
+	// any browser UI overlap on the inline-end edge. For the inline axis we max
+	// over both physical insets so the rule works the same in LTR and RTL —
+	// only one of them is ever non-zero (landscape notch on a single side).
+	inset-block-end: max( #{ $help-center-fab-offset }, env( safe-area-inset-bottom ) );
+	inset-inline-end: max(
+		#{ $help-center-fab-offset },
+		env( safe-area-inset-left ),
+		env( safe-area-inset-right )
+	);
+	z-index: z-index( "root", ".help-center-fab" );
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	inline-size: $help-center-fab-size;
+	block-size: $help-center-fab-size;
+	padding: 0;
+	border-radius: 50%;
+	background: var( --color-primary );
+	color: var( --color-text-inverted );
+	@include elevation( 4 );
+	transition: background-color 0.15s ease-in-out;
+
+	&:hover,
+	&.is-active {
+		background: var( --color-primary-dark );
+		color: var( --color-text-inverted );
+	}
+
+	// Suppress the default WordPress Button focus ring for non-keyboard focus
+	// (mouse / touch), since we already convey state via background colour.
+	&:focus:not( :focus-visible ):not( :disabled ) {
+		@include elevation( 4 );
+		outline: none;
+	}
+
+	// Restore a visible keyboard-focus indicator. Uses an outline so it sits
+	// outside the FAB without competing with the drop shadow.
+	&:focus-visible:not( :disabled ) {
+		@include elevation( 4 );
+		outline: 2px solid var( --color-primary-dark );
+		outline-offset: 3px;
+	}
+
+	svg {
+		fill: currentColor;
+	}
+}
+
+// Anchor the panel above the FAB. The base `is-desktop` rule pins
+// `right: 50px; bottom: 50px;` via a `forwards` `slideIn` animation, so we
+// disable the animation and clear the physical insets before declaring the
+// logical ones — otherwise RTL ends up constrained by both `right: 50px`
+// and `left: <offset>`.
+body.has-help-center-fab .help-center .help-center__container.is-desktop {
+	animation: none;
+	right: auto;
+	left: auto;
+	bottom: auto;
+	inset-inline-end: $help-center-fab-offset;
+	// Mirror the FAB's safe-area offset so the panel stays 8px above the FAB
+	// on iOS devices with a non-zero `safe-area-inset-bottom`.
+	inset-block-end: calc(
+		max( #{ $help-center-fab-offset }, env( safe-area-inset-bottom ) ) +
+			#{ $help-center-fab-size + $help-center-fab-gap }
+	);
+}

--- a/client/components/help-center-fab/style.scss
+++ b/client/components/help-center-fab/style.scss
@@ -53,16 +53,15 @@ $help-center-fab-gap: 8px;
 	}
 }
 
-// Anchor the panel above the FAB. The base `is-desktop` rule pins
-// `right: 50px; bottom: 50px;` via a `forwards` `slideIn` animation, so we
-// disable the animation and clear the physical insets before declaring the
-// logical ones — otherwise RTL ends up constrained by both `right: 50px`
-// and `left: <offset>`.
+// Anchor the panel above the FAB by overriding the base `is-desktop`
+// rule (which pins `right: 50px; bottom: 50px` and runs a `slideIn`
+// animation `forwards`). `inset-inline-start: auto` clears the base's
+// physical `right` in RTL; we use only logical properties because the
+// CSS pipeline alphabetises declarations, so a physical `right: auto`
+// declared alongside `inset-inline-end` would clobber it in LTR.
 body.has-help-center-fab .help-center .help-center__container.is-desktop {
 	animation: none;
-	right: auto;
-	left: auto;
-	bottom: auto;
+	inset-inline-start: auto;
 	inset-inline-end: $help-center-fab-offset;
 	// Mirror the FAB's safe-area offset so the panel stays 8px above the FAB
 	// on iOS devices with a non-zero `safe-area-inset-bottom`.

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -10,6 +10,7 @@ import { connect, useSelector } from 'react-redux';
 import { CookieBannerContainerSSR } from 'calypso/blocks/cookie-banner';
 import ReaderJoinConversationDialog from 'calypso/blocks/reader-join-conversation/dialog';
 import AsyncLoad from 'calypso/components/async-load';
+import AsyncHelpCenterFab from 'calypso/components/help-center-fab/async';
 import { withCurrentRoute } from 'calypso/components/route';
 import SympathyDevWarning from 'calypso/components/sympathy-dev-warning';
 import { getDashboardFromHostname } from 'calypso/dashboard/app/routing';
@@ -78,6 +79,8 @@ const loadSupportArticleDialog = () =>
 	import(
 		/* webpackChunkName: "async-load-calypso-blocks-support-article-dialog" */ 'calypso/blocks/support-article-dialog'
 	);
+
+const HELP_CENTER_FAB_SECTIONS = [ 'plugins', 'theme', 'themes' ];
 
 const LayoutLoggedOut = ( {
 	isAkismet,
@@ -153,6 +156,14 @@ const LayoutLoggedOut = ( {
 		! hasGravPoweredClientClass &&
 		! isJetpackCloud &&
 		! isWooOAuth2Client( oauth2Client );
+
+	// FAB launches Help Center for logged-out visitors on showcase pages.
+	// Logged-in users use the masterbar control instead.
+	const showHelpCenterFab =
+		! isLoggedIn &&
+		isEnabled( 'help-center/logged-out-fab' ) &&
+		HELP_CENTER_FAB_SECTIONS.includes( sectionName ) &&
+		userAllowedToHelpCenter;
 
 	const loadHelpCenter =
 		isLoggedIn &&
@@ -285,6 +296,10 @@ const LayoutLoggedOut = ( {
 	}
 
 	const bodyClass = [ 'font-smoothing-antialiased' ];
+	if ( showHelpCenterFab ) {
+		// See `body.has-help-center-fab` in `help-center-fab/style.scss`.
+		bodyClass.push( 'has-help-center-fab' );
+	}
 
 	return (
 		<Step.StepContainerV2Provider value={ stepContainerV2Context }>
@@ -296,6 +311,7 @@ const LayoutLoggedOut = ( {
 						currentRoute={ currentRoute }
 					/>
 				) }
+				{ showHelpCenterFab && <AsyncHelpCenterFab sectionName={ sectionName } /> }
 				{ 'development' === process.env.NODE_ENV && <SympathyDevWarning /> }
 				<BodySectionCssClass
 					group={ sectionGroup }

--- a/config/development.json
+++ b/config/development.json
@@ -86,6 +86,7 @@
 		"google-my-business": true,
 		"help": true,
 		"help-center/logged-out": true,
+		"help-center/logged-out-fab": true,
 		"help/gpt-response": true,
 		"home/layout-dev": true,
 		"hosting-server-settings-enhancements": true,


### PR DESCRIPTION
Part of HAP-2841

## Proposed Changes

* Adds a new `<HelpCenterFab>` floating launcher in `client/components/help-center-fab/`, opened/closed via the existing `automattic/help-center` store (`useShowHelpCenter`).
* Renders the FAB on `/themes`, `/theme`, and `/plugins` for **logged-out** visitors only, gated behind a new `help-center/logged-out-fab` Calypso config flag (true only in `development.json`).
* The FAB chunk and the `@automattic/help-center` panel are lazy-loaded. The panel itself only mounts on first open and unmounts on close, so the page never exposes an empty `role="dialog"` / `aria-modal="true"` container at idle.
* A `has-help-center-fab` body class re-anchors the Help Center panel 8px above the FAB (LTR + RTL safe), tracking iOS `safe-area-inset-bottom`.
* Registers `.help-center-fab: 50002` in the shared z-index registry — above the privacy-toolset cookie banner; the Help Center panel itself sits on top because it has its own close button.

## Why are these changes being made?

So logged-out visitors have an in-app help affordance there too. Logged-in users continue to use the masterbar help control, which already routes correctly through `AGENTS_MANAGER_STORE` when the unified-agent experience is enabled.

## Testing Instructions

In local dev with the flag on by default:

1. Open an **Incognito** window (or otherwise log out of WordPress.com on `calypso.localhost`) — SSR + the FAB only apply on the logged-out path.
2. Visit `http://calypso.localhost:3000/themes` (also try `/plugins` and a single theme page like `/theme/twentytwentyfive`).
3. A blue circular question-mark button should appear in the bottom-end corner (right in LTR, left in RTL).
4. Click the FAB → Help Center panel slides in, anchored 8px above the FAB. FAB gains `is-active` state and turns `--color-primary-dark`.
5. Click the FAB again → panel closes, FAB returns to default state. Inspect: no `<div class="help-center" role="dialog">` left in the DOM while closed.
6. Tab to the FAB → keyboard-focus outline visible. Mouse click → no focus ring.
7. Resize to a mobile viewport → FAB still renders. Open the panel → panel goes full-screen and covers the FAB; close via the panel's own close button.
8. Log in (or visit a route the layout treats as `isLoggedIn`) → FAB does not render; existing masterbar help control still works.
9. Disable the flag (`?flags=-help-center/logged-out-fab` or remove from `config/development.json`) → FAB disappears entirely.
10. Production / stage / horizon / wpcalypso configs do not set the flag → the FAB stays off in those environments.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed?
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [x] Have you tested accessibility for your changes? `aria-haspopup="dialog"`, `aria-expanded`, keyboard-focus ring, no empty `role="dialog"` at idle.
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?

🤖 Generated with [Claude Code](https://claude.com/claude-code)