### PR TITLE
Jetpack Connect signup: forward from and plugins to the activation email

### DIFF
--- a/client/jetpack-connect/signup.jsx
+++ b/client/jetpack-connect/signup.jsx
@@ -187,6 +187,14 @@ export class JetpackSignup extends Component {
 						...userData.extra,
 						jpc: true,
 						source: this.isWooJPC() ? 'woo-passwordless-jpc' + '-' + this.props.authQuery.from : '',
+						// Forwarded so the wpcom-side activation mailer can route on
+						// the originating flow (`from=jetpack-connector` triggers the
+						// unified-connection email theme) and pick the right family
+						// lockup logo from the active plugin set. Both are already
+						// present on the URL — we're just lifting them from the
+						// auth-query state into the signup payload's `extra` bag.
+						from: this.props.authQuery.from,
+						plugins: this.props.authQuery.plugins,
 					},
 				} )
 				.then( this.handleUserCreationSuccess, this.handleUserCreationError )

--- a/client/jetpack-connect/signup.jsx
+++ b/client/jetpack-connect/signup.jsx
@@ -187,12 +187,6 @@ export class JetpackSignup extends Component {
 						...userData.extra,
 						jpc: true,
 						source: this.isWooJPC() ? 'woo-passwordless-jpc' + '-' + this.props.authQuery.from : '',
-						// Forwarded so the wpcom-side activation mailer can route on
-						// the originating flow (`from=jetpack-connector` triggers the
-						// unified-connection email theme) and pick the right family
-						// lockup logo from the active plugin set. Both are already
-						// present on the URL — we're just lifting them from the
-						// auth-query state into the signup payload's `extra` bag.
 						from: this.props.authQuery.from,
 						plugins: this.props.authQuery.plugins,
 					},

--- a/client/jetpack-connect/test/signup.js
+++ b/client/jetpack-connect/test/signup.js
@@ -1,8 +1,9 @@
 /**
  * @jest-environment jsdom
  */
-import { screen } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 import deepFreeze from 'deep-freeze';
+import { createRef } from 'react';
 import loginReducer from 'calypso/state/login/reducer';
 import siteConnectionReducer from 'calypso/state/site-connection/reducer';
 import uiReducer from 'calypso/state/ui/reducer';
@@ -164,6 +165,37 @@ describe( 'JetpackSignup', () => {
 			screen.queryByText( /Already have a WordPress.com account\?/ )
 		).not.toBeInTheDocument();
 		expect( container.querySelector( '.connect-screen-features-section' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'handleSubmitSignup forwards from and plugins from authQuery into the signup extra bag', async () => {
+		const createAccount = jest.fn().mockResolvedValue( {} );
+		const signupRef = createRef();
+
+		render(
+			<JetpackSignup
+				ref={ signupRef }
+				{ ...DEFAULT_PROPS }
+				createAccount={ createAccount }
+				authQuery={ {
+					...DEFAULT_PROPS.authQuery,
+					from: 'jetpack-connector',
+					plugins: [ 'woocommerce', 'jetpack' ],
+				} }
+			/>
+		);
+
+		await act( async () => {
+			signupRef.current.handleSubmitSignup( null, { extra: {} } );
+		} );
+
+		expect( createAccount ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				extra: expect.objectContaining( {
+					from: 'jetpack-connector',
+					plugins: [ 'woocommerce', 'jetpack' ],
+				} ),
+			} )
+		);
 	} );
 
 	describe( 'isFromJetpackConnector', () => {


### PR DESCRIPTION
Part of CONNECT-186

## Proposed Changes

- Forward `from` and `plugins` from the Jetpack Connect authorize query into the `extra` bag of the new-user signup request in `JetpackSignup`.
- Both values are already present on the authorize URL; this just lifts them from auth-query state into the signup payload, alongside the existing `jpc` and `source` keys.

## Why are these changes being made?

- The wpcom-side activation-email mailer gates a new `jetpack-unified-connection` email theme on `meta['from'] === 'jetpack-connector'`, and uses `meta['plugins']` to pick the right family-lockup logo. That gate reads `extra.from` / `extra.plugins` from the new-user endpoint payload.
- Without this change, every Jetpack Connect signup reaches the endpoint with no `extra.from`, the gate never matches, and users always receive the legacy `activation-jetpack` email instead of the redesigned one.
- The matching wpcom change (endpoint capture + gate + new theme) already merged in 216434-ghe-Automattic/wpcom. This Calypso PR is the missing half — the feature is inert in production until it lands.

## Testing Instructions

- Check out this branch and run Calypso.
- Go through the Jetpack Connect flow for a connector site so you reach the authorize page with `from=jetpack-connector` in the URL (e.g. connect a fresh Jetpack site).
- Choose to create a new WordPress.com account.
- Complete signup and open the activation email that arrives.
- **Expected:** the email uses the new unified-connection theme introduced in 216434-ghe-Automattic/wpcom — Recoleta-style heading "Confirm your email to finish creating your account", a studio-blue CTA, and a family-keyed lockup logo. Before this change it was the legacy green-Jetpack-lockup "Activate your account" email.
- Regression: a Jetpack signup that is *not* `from=jetpack-connector` should still receive the legacy activation email.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

