### PR TITLE
Jetpack Connect: keep 'Use a different account' link visible during auth

### DIFF
--- a/client/jetpack-connect/authorize.jsx
+++ b/client/jetpack-connect/authorize.jsx
@@ -1211,28 +1211,29 @@ export class JetpackAuthorize extends Component {
 
 	/**
 	 * Render the "Use a different account" link that sits directly beneath
-	 * the user card on the unified connect-account surfaces. The link is
-	 * suppressed while the connection is in flight (or already succeeded)
-	 * so it doesn't offer a switch-account escape hatch mid-handshake —
-	 * matching the loading-state guard the action button uses below.
+	 * the user card on the unified connect-account surfaces. The link stays
+	 * visible but becomes inert and visually muted while the connection is
+	 * in flight so the layout doesn't shift when the spinner appears.
 	 */
 	renderUseDifferentAccountLink() {
 		if ( this.props.isSiteBlocked ) {
 			return null;
 		}
 
-		if ( this.isInFlight ) {
-			return null;
-		}
-
+		const disabled = this.isInFlight;
 		const { from } = this.props.authQuery;
 		const loginURL = login( { isJetpack: true, redirectTo: window.location.href, from } );
 
 		return (
 			<LoggedOutFormLinkItem
-				className="jetpack-connect__switch-account-link"
-				href={ loginURL }
-				onClick={ ( e ) => this.handleSignIn( e, loginURL ) }
+				className={ clsx( 'jetpack-connect__switch-account-link', {
+					'is-disabled': disabled,
+				} ) }
+				href={ disabled ? undefined : loginURL }
+				onClick={
+					disabled ? ( e ) => e.preventDefault() : ( e ) => this.handleSignIn( e, loginURL )
+				}
+				aria-disabled={ disabled }
 			>
 				{ this.props.translate( 'Use a different account' ) }
 			</LoggedOutFormLinkItem>

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -459,6 +459,12 @@ body:not( .is-jetpack-sso-partner-branded--woo ) {
 	padding: 0;
 	margin: 1rem 0 2rem;
 	text-align: center;
+
+	&.is-disabled {
+		color: var( --studio-gray-20, #ccc );
+		pointer-events: none;
+		cursor: default;
+	}
 }
 
 // "Already have a WordPress.com account? Log in" link rendered between the


### PR DESCRIPTION
Related CONNECT-186

## Proposed Changes

* Keep the "Use a different account" link visible (but disabled) while the Jetpack authorization handshake is in flight, instead of hiding it entirely.
* Add an `is-disabled` CSS modifier that mutes the link to light grey and blocks pointer events.

## Why are these changes being made?

When the user clicks "Connect your account" and the authorization spinner appears, the "Use a different account" link was removed from the DOM. This caused the feature cards / permissions list below it to jump upward, creating a jarring layout shift. By keeping the link rendered but inert, the layout remains stable during the loading state.

## Testing Instructions

1. Navigate to a Jetpack connection authorization screen (unified connection or Jetpack Connector flow).
2. Observe the "Use a different account" link below the user card.
3. Click the connect/authorize button to start the handshake.
4. Verify the link stays visible but turns light grey and is not clickable.
5. Verify the feature cards / permissions list below do not jump up.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in Memoizing with create-selector and Using memoizing selectors and Our Approach to Data
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?


Made with [Cursor](https://cursor.com)