### PR TITLE
Stepper: Add account-step improvement round 2 experiment

### DIFF
--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -49,6 +49,7 @@ interface SignupFormSocialFirst {
 	passDataToNextStep?: boolean;
 	emailLabelText?: string;
 	isEmailFirstVariant?: boolean;
+	isEmailAtBottom?: boolean;
 	allowedSocialServices?: SignupAllowedService[];
 	customTosElement?: JSX.Element;
 }
@@ -91,6 +92,7 @@ const SignupFormSocialFirst = ( {
 	backButtonInFooter = true,
 	emailLabelText,
 	isEmailFirstVariant,
+	isEmailAtBottom,
 	allowedSocialServices,
 	customTosElement,
 }: SignupFormSocialFirst ) => {
@@ -161,51 +163,50 @@ const SignupFormSocialFirst = ( {
 		} );
 	};
 
-	let emailLoginComponent = null;
-	if ( isEmailFirstVariant ) {
-		emailLoginComponent = (
-			<>
-				<div className="signup-form-social-first-email">
-					<PasswordlessSignupForm
-						stepName={ stepName }
-						flowName={ flowName }
-						goToNextStep={ goToNextStep }
-						logInUrl={ logInUrl }
-						queryArgs={ queryArgs }
-						labelText={ emailLabelText ?? __( 'Your email' ) }
-						submitButtonLabel={ __( 'Continue' ) }
-						userEmail={ userEmail }
-						passDataToNextStep={ passDataToNextStep }
-						onCreateAccountError={ ( error: { error: string }, email: string ) => {
-							if ( isExistingAccountError( error.error ) ) {
-								window.location.assign(
-									addQueryArgs(
-										{
-											email_address: email,
-											is_signup_existing_account: true,
-											redirect_to: queryArgs?.redirect_to,
-										},
-										logInUrl
-									)
-								);
-							}
-						} }
-						onCreateAccountSuccess={ onCreateAccountSuccess }
-						inputPlaceholder={ isGravatar ? __( 'Enter your email address' ) : undefined }
-						submitButtonLoadingLabel={ isGravatar ? __( 'Continue' ) : undefined }
-					/>
-				</div>
-				<FormDivider isHorizontal />
-			</>
-		);
-	}
+	const emailLoginBlock = isEmailFirstVariant ? (
+		<div className="signup-form-social-first-email">
+			<PasswordlessSignupForm
+				stepName={ stepName }
+				flowName={ flowName }
+				goToNextStep={ goToNextStep }
+				logInUrl={ logInUrl }
+				queryArgs={ queryArgs }
+				labelText={ emailLabelText ?? __( 'Your email' ) }
+				submitButtonLabel={ __( 'Continue' ) }
+				userEmail={ userEmail }
+				passDataToNextStep={ passDataToNextStep }
+				onCreateAccountError={ ( error: { error: string }, email: string ) => {
+					if ( isExistingAccountError( error.error ) ) {
+						window.location.assign(
+							addQueryArgs(
+								{
+									email_address: email,
+									is_signup_existing_account: true,
+									redirect_to: queryArgs?.redirect_to,
+								},
+								logInUrl
+							)
+						);
+					}
+				} }
+				onCreateAccountSuccess={ onCreateAccountSuccess }
+				inputPlaceholder={ isGravatar ? __( 'Enter your email address' ) : undefined }
+				submitButtonLoadingLabel={ isGravatar ? __( 'Continue' ) : undefined }
+			/>
+		</div>
+	) : null;
 
 	return (
 		<div className="signup-form signup-form-social-first">
 			<div className={ getVisibilityClassName( 'initial' ) }>
 				{ notice }
 				{ renderTermsOfService() }
-				{ emailLoginComponent }
+				{ emailLoginBlock && ! isEmailAtBottom && (
+					<>
+						{ emailLoginBlock }
+						<FormDivider isHorizontal />
+					</>
+				) }
 				<SocialSignupForm
 					handleResponse={ handleSocialResponse }
 					setCurrentStep={ setCurrentStep }
@@ -217,6 +218,12 @@ const SignupFormSocialFirst = ( {
 					shouldShowEmailButton={ ! isEmailFirstVariant }
 					allowedSocialServices={ allowedSocialServices }
 				/>
+				{ emailLoginBlock && isEmailAtBottom && (
+					<>
+						<FormDivider isHorizontal />
+						{ emailLoginBlock }
+					</>
+				) }
 				{ isEmailFirstVariant && (
 					<p className="signup-form-social-first__login-link">
 						{ createInterpolateElement( __( 'Have an account? <link>Log in</link>' ), {

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -19,6 +19,22 @@
 	.signup-form__passwordless-email {
 		transition: none !important; // The default form element transition breaks the visibility transition between steps.
 	}
+
+	// Variant B of the round-2 experiment (email block below social block):
+	// the `.card ~ .auth-form__separator { margin: -10px 0 }` rule in form-divider/style.scss
+	// pulls the OR into both neighbouring cards. That works for Variant A (the email card's
+	// own padding absorbs the negative top margin), but the social card uses
+	// `padding: 0 0 0 1px` and has nothing to absorb it, so the OR visually overlaps the
+	// last social button. Override the divider margins in this layout and add matching
+	// breathing room to the email wrapper below.
+	.auth-form__separator:has(+ .signup-form-social-first-email) {
+		margin-top: 24px;
+		margin-bottom: 0;
+	}
+
+	.auth-form__separator + .signup-form-social-first-email {
+		margin-top: 24px;
+	}
 }
 
 .signup-form .signup-form__input.form-text-input[type] {

--- a/client/blocks/signup-form/test/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/test/signup-form-social-first.tsx
@@ -106,4 +106,22 @@ describe( 'SignupFormSocialFirst', () => {
 			expect( screen.getByText( /Continue with PayPal/i ) ).toBeInTheDocument();
 		} );
 	} );
+
+	describe( 'isEmailAtBottom', () => {
+		test( 'renders the email block after the social buttons when isEmailAtBottom is true', () => {
+			const { container } = render(
+				<SignupFormSocialFirst { ...defaultProps } isEmailFirstVariant isEmailAtBottom />
+			);
+
+			const emailBlock = container.querySelector( '.signup-form-social-first-email' );
+			const googleButton = screen.getByText( /Continue with Google/i );
+
+			expect( emailBlock ).not.toBeNull();
+			// DOCUMENT_POSITION_FOLLOWING (4) → emailBlock follows googleButton in DOM order.
+			expect(
+				googleButton.compareDocumentPosition( emailBlock as Node ) &
+					Node.DOCUMENT_POSITION_FOLLOWING
+			).toBeTruthy();
+		} );
+	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -50,7 +50,7 @@ const UserStepComponent: StepType = function UserStep( {
 	const { topBarLogo, partnerConfig, signupTosElement } = usePartnerBranding();
 
 	// Woo-referrer users keep the permanent email-first + slider treatment from PR #110118.
-	// Everyone else is bucketed by calypso_account_step_improvement_202605 (round 2):
+	// Everyone else is bucketed by calypso_account_step_improvement_202605_v2 (round 2):
 	//   - control                            -> default single-column signup
 	//   - treatment_email_slider_webp        -> open email + slider, email on top
 	//   - treatment_email_bottom_slider_webp -> open email + slider, email below social

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -28,6 +28,7 @@ import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-conta
 import { Step as StepType } from '../../types';
 import { useHandleSocialResponse } from './handle-social-response';
 import { SignupSlider } from './signup-slider';
+import useAccountCreationExperiment from './use-account-creation-experiment';
 import { useSocialService } from './use-social-service';
 
 import './style.scss';
@@ -48,9 +49,15 @@ const UserStepComponent: StepType = function UserStep( {
 	const { socialServiceResponse } = useSocialService();
 	const { topBarLogo, partnerConfig, signupTosElement } = usePartnerBranding();
 
-	// Users arriving from woocommerce.com's hosting-solutions CTA see the "open email + slider"
-	// account-step variant. Everyone else sees the default single-column signup.
-	const isEmailFirstVariant = queryArgs.get( 'ref' ) === WOO_HOSTING_SOLUTIONS_REF;
+	// Woo-referrer users keep the permanent email-first + slider treatment from PR #110118.
+	// Everyone else is bucketed by calypso_account_step_improvement_202605 (round 2):
+	//   - control                            -> default single-column signup
+	//   - treatment_email_slider_webp        -> open email + slider, email on top
+	//   - treatment_email_bottom_slider_webp -> open email + slider, email below social
+	const isWooReferrer = queryArgs.get( 'ref' ) === WOO_HOSTING_SOLUTIONS_REF;
+	const { isEmailFirstVariant: isEmailFirstFromExperiment, isEmailAtBottom } =
+		useAccountCreationExperiment( { flow } );
+	const isEmailFirstVariant = isWooReferrer || isEmailFirstFromExperiment;
 
 	useEffect( () => {
 		if ( wpAccountCreateResponse && 'bearer_token' in wpAccountCreateResponse ) {
@@ -118,6 +125,7 @@ const UserStepComponent: StepType = function UserStep( {
 				backButtonInFooter={ ! isStepContainerV2 }
 				emailLabelText={ isStepContainerV2 ? translate( 'Enter your email' ) : undefined }
 				isEmailFirstVariant={ isEmailFirstVariant }
+				isEmailAtBottom={ isEmailAtBottom }
 				allowedSocialServices={ partnerConfig?.ssoProviders }
 				customTosElement={ signupTosElement }
 			/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/test/use-account-creation-experiment.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/test/use-account-creation-experiment.tsx
@@ -22,7 +22,7 @@ import { useExperiment } from 'calypso/lib/explat';
 import useAccountCreationExperiment from '../use-account-creation-experiment';
 
 const mockUseExperiment = useExperiment as jest.Mock;
-const mockUseViewportMatch = useViewportMatch as jest.Mock;
+const mockUseViewportMatch = useViewportMatch as unknown as jest.Mock;
 const mockUseQuery = useQuery as jest.Mock;
 
 describe( 'useAccountCreationExperiment', () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/test/use-account-creation-experiment.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/test/use-account-creation-experiment.tsx
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock( 'calypso/lib/explat', () => ( {
+	useExperiment: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/compose', () => ( {
+	...jest.requireActual( '@wordpress/compose' ),
+	useViewportMatch: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/landing/stepper/hooks/use-query', () => ( {
+	useQuery: jest.fn(),
+} ) );
+
+import { renderHook } from '@testing-library/react';
+import { useViewportMatch } from '@wordpress/compose';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { useExperiment } from 'calypso/lib/explat';
+import useAccountCreationExperiment from '../use-account-creation-experiment';
+
+const mockUseExperiment = useExperiment as jest.Mock;
+const mockUseViewportMatch = useViewportMatch as jest.Mock;
+const mockUseQuery = useQuery as jest.Mock;
+
+describe( 'useAccountCreationExperiment', () => {
+	beforeEach( () => {
+		jest.resetAllMocks();
+		mockUseQuery.mockReturnValue( new URLSearchParams() );
+		mockUseViewportMatch.mockReturnValue( true );
+	} );
+
+	it( 'returns control while the experiment assignment is loading', () => {
+		mockUseExperiment.mockReturnValue( [ true, { variationName: 'treatment_email_slider_webp' } ] );
+
+		const { result } = renderHook( () => useAccountCreationExperiment( { flow: 'onboarding' } ) );
+
+		expect( result.current.isLoading ).toBe( true );
+		expect( result.current.variationName ).toBe( 'control' );
+		expect( result.current.isEmailFirstVariant ).toBe( false );
+		expect( result.current.isEmailAtBottom ).toBe( false );
+	} );
+
+	it( 'returns control on sub-960 px viewports regardless of assignment', () => {
+		mockUseViewportMatch.mockReturnValue( false );
+		mockUseExperiment.mockReturnValue( [
+			false,
+			{ variationName: 'treatment_email_bottom_slider_webp' },
+		] );
+
+		const { result } = renderHook( () => useAccountCreationExperiment( { flow: 'onboarding' } ) );
+
+		expect( result.current.variationName ).toBe( 'control' );
+		expect( result.current.isEmailFirstVariant ).toBe( false );
+		expect( result.current.isEmailAtBottom ).toBe( false );
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-account-creation-experiment.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-account-creation-experiment.ts
@@ -1,4 +1,5 @@
 import { isOnboardingFlow } from '@automattic/onboarding';
+import { useViewportMatch } from '@wordpress/compose';
 import { WOO_HOSTING_SOLUTIONS_REF } from 'calypso/landing/stepper/constants';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useExperiment } from 'calypso/lib/explat';
@@ -29,17 +30,22 @@ function useAccountCreationExperiment( {
 }: UseAccountCreationExperimentParams ): AccountCreationExperimentResult {
 	const queryArgs = useQuery();
 	const isWooReferrer = queryArgs.get( 'ref' ) === WOO_HOSTING_SOLUTIONS_REF;
+	// `large` matches the 960 px breakpoint we use for the two-column slider layout.
+	const isLargeViewport = useViewportMatch( 'large' );
 
-	// Woo-referrer users already see a permanent email-first + slider treatment from PR #110118.
-	// Excluding them here keeps their behaviour stable and prevents skewed attribution.
+	// Excluded from the experiment:
+	//   - Woo-referrer users (permanent treatment from PR #110118 — preserve their UX).
+	//   - Sub-960 px viewports — mobile-web signup is owned by a separate team.
 	const [ isLoading, assignment ] = useExperiment( 'calypso_account_step_improvement_202605', {
-		isEligible: isOnboardingFlow( flow ) && ! isWooReferrer,
+		isEligible: isOnboardingFlow( flow ) && ! isWooReferrer && isLargeViewport,
 	} );
 
-	// Default to control while assignment is loading so the step renders immediately.
-	// Round 1 blocked render on assignment and cost ~300 ms of LCP — avoid that here.
+	// Default to control while assignment is loading so the step renders immediately
+	// (round 1 blocked render on assignment and cost ~300 ms of LCP — avoid that here),
+	// and force control on sub-960 px viewports as a render-time guard against any
+	// post-assignment viewport change.
 	const variationName = (
-		isLoading ? 'control' : assignment?.variationName ?? 'control'
+		isLoading || ! isLargeViewport ? 'control' : assignment?.variationName ?? 'control'
 	) as AccountCreationExperimentVariant;
 
 	return {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-account-creation-experiment.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-account-creation-experiment.ts
@@ -1,0 +1,54 @@
+import { isOnboardingFlow } from '@automattic/onboarding';
+import { WOO_HOSTING_SOLUTIONS_REF } from 'calypso/landing/stepper/constants';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { useExperiment } from 'calypso/lib/explat';
+
+type AccountCreationExperimentVariant =
+	| 'control'
+	| 'treatment_email_slider_webp'
+	| 'treatment_email_bottom_slider_webp';
+
+type AccountCreationExperimentResult = {
+	isLoading: boolean;
+	variationName: AccountCreationExperimentVariant;
+	isEmailFirstVariant: boolean;
+	isEmailAtBottom: boolean;
+};
+
+interface UseAccountCreationExperimentParams {
+	flow: string;
+}
+
+const EMAIL_FIRST_VARIATIONS: AccountCreationExperimentVariant[] = [
+	'treatment_email_slider_webp',
+	'treatment_email_bottom_slider_webp',
+];
+
+function useAccountCreationExperiment( {
+	flow,
+}: UseAccountCreationExperimentParams ): AccountCreationExperimentResult {
+	const queryArgs = useQuery();
+	const isWooReferrer = queryArgs.get( 'ref' ) === WOO_HOSTING_SOLUTIONS_REF;
+
+	// Woo-referrer users already see a permanent email-first + slider treatment from PR #110118.
+	// Excluding them here keeps their behaviour stable and prevents skewed attribution.
+	const [ isLoading, assignment ] = useExperiment( 'calypso_account_step_improvement_202605', {
+		isEligible: isOnboardingFlow( flow ) && ! isWooReferrer,
+	} );
+
+	// Default to control while assignment is loading so the step renders immediately.
+	// Round 1 blocked render on assignment and cost ~300 ms of LCP — avoid that here.
+	const variationName = (
+		isLoading ? 'control' : assignment?.variationName ?? 'control'
+	) as AccountCreationExperimentVariant;
+
+	return {
+		isLoading,
+		variationName,
+		isEmailFirstVariant: EMAIL_FIRST_VARIATIONS.includes( variationName ),
+		isEmailAtBottom: variationName === 'treatment_email_bottom_slider_webp',
+	};
+}
+
+export default useAccountCreationExperiment;
+export type { AccountCreationExperimentVariant, AccountCreationExperimentResult };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-account-creation-experiment.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-account-creation-experiment.ts
@@ -36,7 +36,7 @@ function useAccountCreationExperiment( {
 	// Excluded from the experiment:
 	//   - Woo-referrer users (permanent treatment from PR #110118 — preserve their UX).
 	//   - Sub-960 px viewports — mobile-web signup is owned by a separate team.
-	const [ isLoading, assignment ] = useExperiment( 'calypso_account_step_improvement_202605', {
+	const [ isLoading, assignment ] = useExperiment( 'calypso_account_step_improvement_202605_v2', {
 		isEligible: isOnboardingFlow( flow ) && ! isWooReferrer && isLargeViewport,
 	} );
 


### PR DESCRIPTION
Linear: https://linear.app/a8c/project/datsci-optimization-account-creation-step-improvement-ac8712dd1e4f/overview

Round 2 of the `/setup/onboarding/user` A/B experiment. Round 1 showed a clear mobile-web lift on `email_slider` (+9.2%) but cost social registrations (−3.5–3.9 pp). This round tests whether moving the open email field **below** social login protects social volume while retaining the registration lift.

| Variant | Screenshot |
|---|---|
| `control` | <img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/8712040d-dcad-48d3-b923-4a3028a92bcd" /> |
| `treatment_email_slider_webp` | <img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/67f267d4-dddf-403d-9f89-8f6156087824" /> |
| `treatment_email_bottom_slider_webp` | <img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/4f978c62-8b2f-4e54-9ca7-2afc4c93dce9" /> |

### Out of scope

Mobile-web: @crisbusquets's team is working on a separate signup redesign for mobile in parallel. To avoid two experiments running on the same users at once, this PR keeps anyone below 960 px out of the experiment


This PR [#110118](https://github.com/Automattic/wp-calypso/pull/110118) shipped the email_slider as a permanent experience for users coming in with ?ref=woo-hosting-solutions-flow—a product decision, not an experiment.

Our experiment works independently: Woo-referrer users are excluded via the hook's isEligible check, so they're never bucketed and can't affect the data. Their experience stays the same. Smoke-tested and confirmed.

### How to test

- A desktop-width browser window (≥ 960 px)
- Log out first: http://calypso.localhost:3000/log-out (clears the session)
- Visit the signup page: http://calypso.localhost:3000/setup/onboarding/user

**Force a variant.** Open DevTools Console on the dev environment and paste:

```js
localStorage.setItem(
  'explat-experiment--calypso_account_step_improvement_202605_v2',
  JSON.stringify( {
    experimentName: 'calypso_account_step_improvement_202605_v2',
    variationName: 'treatment_email_bottom_slider_webp', // ← swap this
    retrievedTimestamp: Date.now(),
    ttl: 60 * 60,
  } )
);
location.assign( '/setup/onboarding/user' );
```

Swap the `variationName` value to flip variants:

- `control` — default single-column signup
- `treatment_email_slider_webp` — open email **above** social, slider on the right
- `treatment_email_bottom_slider_webp` — open email **below** social, divider between, slider on the right

