### PR TITLE
Fix email clicks fallback display

### DIFF
--- a/client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx
+++ b/client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx
@@ -23,6 +23,7 @@ import {
 	OpensTooltipContent,
 	ClicksTooltipContent,
 	hasUniqueMetrics,
+	getClicksDisplayValue,
 	EmailStatsItem,
 } from './tooltips';
 import type { StatsDefaultModuleProps, StatsStateProps } from '../types';
@@ -116,23 +117,12 @@ const StatsEmails: React.FC< StatsDefaultModuleProps > = ( {
 					metricLabel={ translate( 'Clicks' ) }
 					valueField="clicks_rate"
 					formatValue={ ( value: number, item: EmailStatsItem ) => {
-						if ( ! item?.opens ) {
+						if ( ! item ) {
 							return value;
 						}
-						const clicksUnique = parseInt( String( item.unique_clicks ), 10 );
-						const clicks = parseInt( String( item.clicks ), 10 );
-						const hasUniques = hasUniqueMetrics( clicksUnique, clicks );
 						return (
 							<TooltipWrapper
-								value={
-									hasUniques
-										? `${ formatNumber( item.clicks_rate, {
-												numberFormatOptions: {
-													maximumFractionDigits: 2,
-												},
-										  } ) }%`
-										: '—'
-								}
+								value={ getClicksDisplayValue( item ) }
 								item={ item }
 								TooltipContent={ ClicksTooltipContent }
 							/>

--- a/client/my-sites/stats/features/modules/stats-emails/test/tooltips.tsx
+++ b/client/my-sites/stats/features/modules/stats-emails/test/tooltips.tsx
@@ -1,0 +1,33 @@
+import { getClicksDisplayValue } from '../tooltips';
+
+describe( 'getClicksDisplayValue', () => {
+	it( 'shows total clicks when unique click data is unavailable', () => {
+		expect(
+			getClicksDisplayValue( {
+				clicks: 5,
+				unique_clicks: 0,
+				clicks_rate: 0,
+			} )
+		).toBe( '5' );
+	} );
+
+	it( 'keeps showing click rate when unique click data is available', () => {
+		expect(
+			getClicksDisplayValue( {
+				clicks: 10,
+				unique_clicks: 5,
+				clicks_rate: 50,
+			} )
+		).toBe( '50%' );
+	} );
+
+	it( 'shows a dash when there are no clicks', () => {
+		expect(
+			getClicksDisplayValue( {
+				clicks: 0,
+				unique_clicks: 0,
+				clicks_rate: 0,
+			} )
+		).toBe( '—' );
+	} );
+} );

--- a/client/my-sites/stats/features/modules/stats-emails/tooltips.tsx
+++ b/client/my-sites/stats/features/modules/stats-emails/tooltips.tsx
@@ -48,6 +48,28 @@ export const hasUniqueMetrics = ( uniqueValue: number, totalValue: number ) => {
 	return uniqueValue > 0 && totalValue > 0;
 };
 
+export const getClicksDisplayValue = (
+	item: Pick< EmailStatsItem, 'unique_clicks' | 'clicks' | 'clicks_rate' >
+) => {
+	const clicksUnique = parseInt( String( item.unique_clicks ), 10 );
+	const clicks = parseInt( String( item.clicks ), 10 );
+	const hasUniques = hasUniqueMetrics( clicksUnique, clicks );
+
+	if ( hasUniques ) {
+		return `${ formatNumber( item.clicks_rate, {
+			numberFormatOptions: {
+				maximumFractionDigits: 2,
+			},
+		} ) }%`;
+	}
+
+	if ( clicks > 0 ) {
+		return formatNumber( item.clicks );
+	}
+
+	return '—';
+};
+
 export const OpensTooltipContent: React.FC< { item: EmailStatsItem } > = ( { item } ) => {
 	const translate = useTranslate();
 	const hasUniques = hasUniqueMetrics(


### PR DESCRIPTION
Part of DOTCOM-12613

## Proposed Changes

* Update the Subscribers > Emails card so the Clicks cell shows formatted total clicks when total clicks exist but unique-click metrics are unavailable.
* Keep showing the click percentage when unique-click metrics are available.
* Keep the existing tooltip details, including total clicks and the unavailable unique-click state.
* Add unit coverage for the total-click fallback, percentage behavior, and no-click dash state.

## Why are these changes being made?

The Emails card could show a dash in the Clicks column even when the row had total click data. That made the row look like it had no clicks, while the tooltip still showed total clicks.

**Before:** the Clicks cell showed `—` even though the tooltip had `Total clicks: 5`.


<img width="1508" height="964" alt="Markup on 2026-05-15 at 8:08:30 PM" src="https://github.com/user-attachments/assets/e2b20200-6497-49fa-b891-b103cfd5d5ca" />


**After:** the Clicks cell shows `5`.


<img width="1402" height="974" alt="Markup on 2026-05-15 at 8:09:08 PM" src="https://github.com/user-attachments/assets/ab148a5a-4314-4322-a3be-552fbbcf77a0" />


## Testing Instructions

* `node .yarn/releases/yarn-4.0.2.cjs test-client client/my-sites/stats/features/modules/stats-emails/test/tooltips.tsx`
* `node .yarn/releases/yarn-4.0.2.cjs eslint client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx client/my-sites/stats/features/modules/stats-emails/tooltips.tsx client/my-sites/stats/features/modules/stats-emails/test/tooltips.tsx`
* Sandbox verified via Calypso Live against a WordPress.com sandbox.
* In Stats > Subscribers > Emails, verified the affected row shows total clicks `5` in the Clicks cell and the tooltip still shows `Total clicks: 5` with `Unique clicks: -`.
* Odyssey Stats app bundle verified on sandbox with `install-plugin.sh odyssey-stats fix-dotcom-12613-email-clicks-total`; the same affected row shows total clicks `5` in the Clicks cell and the tooltip still shows `Total clicks: 5` with `Unique clicks: -`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed?
- [x] Have you written new tests for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites? Calypso display fallback verified on a WordPress.com sandbox; Atomic and self-hosted Jetpack were not part of this bug reproduction.
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [x] Have you used memoizing on expensive computations? Not applicable; no expensive computation added.
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation? Not applicable; no strings added.
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use? Not applicable; display-only change.
