### PR TITLE
Arcade mode: unlock achievement on Konami code activation

### DIFF
--- a/client/layout/arcade-mode/activate.ts
+++ b/client/layout/arcade-mode/activate.ts
@@ -1,4 +1,6 @@
+import { unlockAchievement } from '@automattic/api-core';
 import { __ } from '@wordpress/i18n';
+import { getCalypsoQueryClient } from 'calypso/state/query-client';
 import './style.scss';
 
 const BODY_CLASS = 'is-arcade-mode';
@@ -64,6 +66,20 @@ function mountFlashBanner(): void {
 	document.body.appendChild( flashElement );
 }
 
+function unlockArcadeAchievement(): void {
+	unlockAchievement( 'arcade_mode' )
+		.then( ( result ) => {
+			if ( result.granted ) {
+				getCalypsoQueryClient()?.invalidateQueries( {
+					queryKey: [ 'read', 'achievements' ],
+				} );
+			}
+		} )
+		.catch( () => {
+			// Easter egg — never bother the user with errors.
+		} );
+}
+
 function deactivate(): void {
 	if ( ! active ) {
 		return;
@@ -113,4 +129,6 @@ export function activateArcadeMode(): void {
 		}
 	};
 	document.addEventListener( 'keydown', escapeListener );
+
+	unlockArcadeAchievement();
 }

--- a/client/layout/arcade-mode/test/index.test.tsx
+++ b/client/layout/arcade-mode/test/index.test.tsx
@@ -8,6 +8,16 @@ jest.mock( '../activate', () => ( {
 	activateArcadeMode: jest.fn(),
 } ) );
 
+const mockUnlockAchievement = jest.fn();
+
+jest.mock( '@automattic/api-core', () => ( {
+	unlockAchievement: ( ...args: unknown[] ) => mockUnlockAchievement( ...args ),
+} ) );
+
+jest.mock( 'calypso/state/query-client', () => ( {
+	getCalypsoQueryClient: () => null,
+} ) );
+
 const realActivate = jest.requireActual< typeof import('../activate') >( '../activate' );
 
 const KONAMI_KEYS = [
@@ -107,6 +117,8 @@ describe( 'activateArcadeMode', () => {
 
 	beforeEach( () => {
 		masterbar = mountFakeMasterbar();
+		mockUnlockAchievement.mockReset();
+		mockUnlockAchievement.mockResolvedValue( { granted: false } );
 	} );
 
 	afterEach( () => {
@@ -172,6 +184,14 @@ describe( 'activateArcadeMode', () => {
 		realActivate.activateArcadeMode();
 		dispatchKey( 'Escape' );
 		realActivate.activateArcadeMode();
+		expect( document.body.classList.contains( 'is-arcade-mode' ) ).toBe( true );
+	} );
+
+	it( 'activates normally even when the achievement unlock rejects', async () => {
+		mockUnlockAchievement.mockRejectedValue( new Error( 'network down' ) );
+		realActivate.activateArcadeMode();
+		await Promise.resolve();
+		await Promise.resolve();
 		expect( document.body.classList.contains( 'is-arcade-mode' ) ).toBe( true );
 	} );
 } );

--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -40,6 +40,7 @@ export * from './marketplace-search';
 export * from './marketing-survey';
 export * from './me';
 export * from './me-account';
+export * from './me-achieve';
 export * from './me-allowed-payment-methods';
 export * from './me-account-recovery';
 export * from './me-billing-history';

--- a/packages/api-core/src/me-achieve/index.ts
+++ b/packages/api-core/src/me-achieve/index.ts
@@ -1,0 +1,2 @@
+export * from './mutators';
+export * from './types';

--- a/packages/api-core/src/me-achieve/mutators.ts
+++ b/packages/api-core/src/me-achieve/mutators.ts
@@ -1,0 +1,14 @@
+import { wpcom } from '../wpcom-fetcher';
+import type { AchievementKey, UnlockAchievementResponse } from './types';
+
+export async function unlockAchievement(
+	key: AchievementKey
+): Promise< UnlockAchievementResponse > {
+	return wpcom.req.post(
+		{
+			path: '/me/achieve',
+			apiNamespace: 'wpcom/v2',
+		},
+		{ key }
+	);
+}

--- a/packages/api-core/src/me-achieve/types.ts
+++ b/packages/api-core/src/me-achieve/types.ts
@@ -1,0 +1,5 @@
+export type AchievementKey = 'arcade_mode';
+
+export interface UnlockAchievementResponse {
+	granted: boolean;
+}

--- a/packages/api-queries/src/index.ts
+++ b/packages/api-queries/src/index.ts
@@ -36,6 +36,7 @@ export * from './marketing-survey';
 export * from './me-a8c';
 export * from './me-account';
 export * from './me-account-recovery';
+export * from './me-achieve';
 export * from './me-billing-history';
 export * from './me-blocked-sites';
 export * from './me-connected-applications';

--- a/packages/api-queries/src/me-achieve.ts
+++ b/packages/api-queries/src/me-achieve.ts
@@ -1,0 +1,13 @@
+import { unlockAchievement } from '@automattic/api-core';
+import { mutationOptions, type QueryClient } from '@tanstack/react-query';
+import type { AchievementKey, UnlockAchievementResponse } from '@automattic/api-core';
+
+export const unlockAchievementMutation = ( queryClient: QueryClient ) =>
+	mutationOptions< UnlockAchievementResponse, Error, AchievementKey >( {
+		mutationFn: unlockAchievement,
+		onSuccess: ( result ) => {
+			if ( result.granted ) {
+				queryClient.invalidateQueries( { queryKey: [ 'read', 'achievements' ] } );
+			}
+		},
+	} );


### PR DESCRIPTION
Part of RSM-405

Backend endpoint added in 217509-ghe-Automattic/wpcom.

## Proposed Changes

* Add `unlockAchievement( key )` to `@automattic/api-core` (`me-achieve`) — posts to `POST /wpcom/v2/me/achieve`.
* Add `unlockAchievementMutation( queryClient )` to `@automattic/api-queries` (`me-achieve`) — invalidates `[ 'read', 'achievements' ]` on `granted: true`.
* Wire `client/layout/arcade-mode/activate.ts` to fire `unlockAchievement( 'arcade_mode' )` after a successful Konami activation, and invalidate the Calypso `QueryClient`'s read-achievements cache on a fresh unlock. Errors are swallowed.

## Why are these changes being made?

The backend endpoint grants a hidden `arcade_mode` achievement to users who find the Konami easter egg. This wires the Calypso client to call it after each fresh activation. The backend is idempotent (subsequent activations return `granted: false`), so no client-side first-time tracking is needed.

## Testing Instructions

1. `yarn start` and load any logged-in page that has the masterbar.
2. Type the Konami code: ↑ ↑ ↓ ↓ ← → ← → B A.
3. Arcade mode should activate (lives counter in masterbar, flash banner, body class).
4. In the network panel, confirm `POST /wpcom/v2/me/achieve` fires once with `{ \"key\": \"arcade_mode\" }`.
   - First time: response is `{ \"granted\": true }`.
   - Subsequent times: response is `{ \"granted\": false }` (no UI change).
5. Visit the Reader achievements page — the new achievement should appear after the first unlock.
6. Verify nothing breaks if the request fails (e.g. by mocking a 500 in DevTools): arcade mode should still activate.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the \"[Status] String Freeze\" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the \"[Status] Needs Privacy Updates\" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?