### PR TITLE
Domain Search: mobile sticky search bar with compact promo banner

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -482,7 +482,16 @@ const DomainSearchStep: StepType< {
 				}
 				columnWidth={ 10 }
 				className="step-container-v2--domain-search"
-				heading={ <Step.Heading text={ headerText } subText={ subHeaderText } /> }
+				heading={
+					// On mobile, once the user has searched the persistent fixed
+					// search overlay (rendered by @automattic/domain-search) is the
+					// page's primary affordance — the H1/subText are dropped so
+					// high-quality results can fill the limited vertical space.
+					// The empty/initial state keeps the heading on mobile.
+					isMobileViewport && query ? undefined : (
+						<Step.Heading text={ headerText } subText={ subHeaderText } />
+					)
+				}
 			>
 				{ domainSearchElement }
 			</Step.CenteredColumnLayout>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/style.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/breakpoints";
+
 .domain-search--step-container {
 	--domain-search-content-max-width: 1040px;
 	--domain-search-mini-cart-inline-padding: 16px;
@@ -51,6 +53,36 @@
 
 		@include break-small {
 			display: revert;
+		}
+	}
+}
+
+// On mobile, the domain-search results page renders a persistent fixed search
+// overlay (see @automattic/domain-search). Pin the WP top bar to the viewport
+// so it sits directly above that overlay and the two surfaces read as one
+// fixed top region. Fixed (not sticky) to keep both surfaces decoupled from
+// scroll — sticky on iOS gets pulled with rubber-band overscroll while the
+// fixed overlay below it stays put, opening a visible gap on bounce-back.
+// Scoped to the results state (.domain-search--results) so the initial/empty
+// state keeps its trunk-identical scrolling top bar.
+.step-container-v2:has( .domain-search--results ) {
+	@media ( max-width: #{ $break-small - 1px } ) {
+		> .step-container-v2__top-bar-wrapper {
+			position: fixed;
+			inset-block-start: 0;
+			inset-inline: 0;
+			z-index: var( --domain-search-sticky-overlay-z-index, 1 );
+			background-color: var( --color-surface );
+		}
+
+		// Compensate for the now out-of-flow top bar so content still starts
+		// below it. Falls back to the wrapper's existing padding when the
+		// top-bar height variable isn't available.
+		> .step-container-v2__content-wrapper {
+			padding-block-start: calc(
+				var( --step-container-v2-content-block-padding ) +
+					var( --step-container-v2-top-bar-height, 0px )
+			);
 		}
 	}
 }

--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -1,4 +1,8 @@
 import { __experimentalVStack as VStack } from '@wordpress/components';
+import { chevronDown, chevronUp, Icon } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
+import clsx from 'clsx';
+import { useEffect, useRef, useState } from 'react';
 import { Cart } from '../components/cart';
 import { FeaturedSearchResults } from '../components/featured-search-results';
 import { SearchBar } from '../components/search-bar';
@@ -9,6 +13,36 @@ import { UnavailableSearchResult } from '../components/unavailable-search-result
 import { useRequestTracking } from '../hooks/use-request-tracking';
 import { useSuggestionsList } from '../hooks/use-suggestions-list';
 import { useDomainSearch } from './context';
+
+const StickyCompactBanner = () => {
+	const { __ } = useI18n();
+	const [ isExpanded, setIsExpanded ] = useState( false );
+
+	return (
+		<button
+			type="button"
+			className="domain-search--results__compact-banner"
+			aria-expanded={ isExpanded }
+			onClick={ () => setIsExpanded( ( prev ) => ! prev ) }
+		>
+			<span className="domain-search--results__compact-banner-title">
+				{ __( 'Claim your free domain name with a paid plan' ) }
+			</span>
+			<Icon
+				icon={ isExpanded ? chevronUp : chevronDown }
+				size={ 24 }
+				className="domain-search--results__compact-banner-chevron"
+			/>
+			{ isExpanded && (
+				<span className="domain-search--results__compact-banner-subtitle">
+					{ __(
+						'Choose a domain name, then purchase an annual plan, and your first year’s domain name is on us. Discount automatically applied at checkout.'
+					) }
+				</span>
+			) }
+		</button>
+	);
+};
 
 export const ResultsPage = () => {
 	const { slots, config } = useDomainSearch();
@@ -23,12 +57,69 @@ export const ResultsPage = () => {
 
 	useRequestTracking();
 
+	// Sentinel-based sticky detection: place a zero-height sentinel immediately
+	// below the in-flow search bar. When the sentinel crosses the top edge of the
+	// viewport, the search bar has just scrolled out of view — slide the fixed
+	// overlay in. Only flips when the value actually changes.
+	const sentinelRef = useRef< HTMLDivElement >( null );
+	const [ isStuck, setIsStuck ] = useState( false );
+
+	useEffect( () => {
+		const sentinel = sentinelRef.current;
+		if ( ! sentinel ) {
+			return;
+		}
+
+		const observer = new IntersectionObserver(
+			( entries ) => {
+				const next = ! entries[ 0 ].isIntersecting;
+				setIsStuck( ( prev ) => ( prev !== next ? next : prev ) );
+			},
+			{ threshold: 0 }
+		);
+
+		observer.observe( sentinel );
+
+		return () => {
+			observer.disconnect();
+		};
+	}, [] );
+
+	const showCompactBanner = !! slots?.BeforeResults;
+
 	return (
 		<VStack spacing={ 8 } className="domain-search--results">
-			<VStack spacing={ 4 }>
-				<SearchBar />
-				{ ! isLoadingSuggestions && <SearchNotice /> }
-			</VStack>
+			{ /* In-flow search bar — trunk-identical, always rendered, never moves.
+			     Wrapped in a single div so the outer VStack sees one child (not two),
+			     preventing a double gap between the search bar and BeforeResults.
+			     The sentinel sits immediately below the SearchBar VStack so the
+			     IntersectionObserver fires exactly when the search bar scrolls out. */ }
+			<div className="domain-search--results__search-region">
+				<VStack spacing={ 4 }>
+					<SearchBar />
+					{ ! isLoadingSuggestions && <SearchNotice /> }
+				</VStack>
+				<div ref={ sentinelRef } aria-hidden="true" className="domain-search--results__sentinel" />
+			</div>
+
+			{ /* Fixed overlay — always in the DOM on mobile, positioned off-screen
+			     above the viewport by default (transform: translateY(-100%)).
+			     When isStuck is true the overlay slides into view via transform only —
+			     no layout/paint work, no effect on the in-flow render tree. */ }
+			{ showCompactBanner && (
+				<div
+					className={ clsx( 'domain-search--results__sticky-overlay', { 'is-stuck': isStuck } ) }
+					aria-hidden={ ! isStuck }
+				>
+					<div className="domain-search--results__compact-banner-container">
+						<StickyCompactBanner />
+					</div>
+					<div className="domain-search--results__search-bar-row">
+						<SearchBar />
+					</div>
+				</div>
+			) }
+
 			{ slots?.BeforeResults && <slots.BeforeResults /> }
 			<VStack spacing={ 4 }>
 				{ config.skippable && (

--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -1,8 +1,7 @@
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { chevronDown, chevronUp, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import clsx from 'clsx';
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import { Cart } from '../components/cart';
 import { FeaturedSearchResults } from '../components/featured-search-results';
 import { SearchBar } from '../components/search-bar';
@@ -57,70 +56,36 @@ export const ResultsPage = () => {
 
 	useRequestTracking();
 
-	// Sentinel-based sticky detection: place a zero-height sentinel immediately
-	// below the in-flow search bar. When the sentinel crosses the top edge of the
-	// viewport, the search bar has just scrolled out of view — slide the fixed
-	// overlay in. Only flips when the value actually changes.
-	const sentinelRef = useRef< HTMLDivElement >( null );
-	const [ isStuck, setIsStuck ] = useState( false );
-
-	useEffect( () => {
-		const sentinel = sentinelRef.current;
-		if ( ! sentinel ) {
-			return;
-		}
-
-		const observer = new IntersectionObserver(
-			( entries ) => {
-				const next = ! entries[ 0 ].isIntersecting;
-				setIsStuck( ( prev ) => ( prev !== next ? next : prev ) );
-			},
-			{ threshold: 0 }
-		);
-
-		observer.observe( sentinel );
-
-		return () => {
-			observer.disconnect();
-		};
-	}, [] );
-
 	const showCompactBanner = !! slots?.BeforeResults;
 
 	return (
 		<VStack spacing={ 8 } className="domain-search--results">
-			{ /* In-flow search bar — trunk-identical, always rendered, never moves.
-			     Wrapped in a single div so the outer VStack sees one child (not two),
-			     preventing a double gap between the search bar and BeforeResults.
-			     The sentinel sits immediately below the SearchBar VStack so the
-			     IntersectionObserver fires exactly when the search bar scrolls out. */ }
-			<div className="domain-search--results__search-region">
-				<VStack spacing={ 4 }>
-					<SearchBar />
-					{ ! isLoadingSuggestions && <SearchNotice /> }
-				</VStack>
-				<div ref={ sentinelRef } aria-hidden="true" className="domain-search--results__sentinel" />
+			{ /* Desktop in-flow SearchBar. CSS-hidden on mobile (the persistent
+			     overlay below is the only search affordance there). */ }
+			<div className="domain-search--results__in-flow-search">
+				<SearchBar />
 			</div>
+			{ ! isLoadingSuggestions && <SearchNotice /> }
 
-			{ /* Fixed overlay — always in the DOM on mobile, positioned off-screen
-			     above the viewport by default (transform: translateY(-100%)).
-			     When isStuck is true the overlay slides into view via transform only —
-			     no layout/paint work, no effect on the in-flow render tree. */ }
+			{ /* Persistent mobile overlay — always rendered when the BeforeResults
+			     slot is provided. position: fixed pins it below the WP top bar
+			     for the entire lifetime of the page (no scroll detection). */ }
 			{ showCompactBanner && (
-				<div
-					className={ clsx( 'domain-search--results__sticky-overlay', { 'is-stuck': isStuck } ) }
-					aria-hidden={ ! isStuck }
-				>
-					<div className="domain-search--results__compact-banner-container">
-						<StickyCompactBanner />
-					</div>
+				<div className="domain-search--results__sticky-overlay">
+					<StickyCompactBanner />
 					<div className="domain-search--results__search-bar-row">
 						<SearchBar />
 					</div>
 				</div>
 			) }
 
-			{ slots?.BeforeResults && <slots.BeforeResults /> }
+			{ /* Desktop in-flow promo card. CSS-hidden on mobile, where the
+			     compact banner inside the overlay supersedes it. */ }
+			{ slots?.BeforeResults && (
+				<div className="domain-search--results__in-flow-before-results">
+					<slots.BeforeResults />
+				</div>
+			) }
 			<VStack spacing={ 4 }>
 				{ config.skippable && (
 					<>{ isLoadingSuggestions ? <SkipSuggestion.Placeholder /> : <SkipSuggestion /> }</>

--- a/packages/domain-search/src/page/style.scss
+++ b/packages/domain-search/src/page/style.scss
@@ -84,49 +84,51 @@
 	}
 }
 
-// Zero-height sentinel — positioned immediately after the in-flow search bar.
-// IntersectionObserver fires when this element crosses the top viewport edge,
-// which coincides with the search bar having just scrolled out of view.
-.domain-search--results__sentinel {
-	block-size: 0;
-	overflow: hidden;
-	// aria-hidden="true" is set in TSX; no further a11y work needed.
+// The in-flow SearchBar and in-flow promo card are the desktop affordances. On
+// mobile, the persistent fixed overlay below replaces both, so we hide these
+// in-flow nodes via CSS rather than unmounting them — keeping desktop markup
+// trunk-identical.
+@media ( max-width: #{ $break-small - 1px } ) {
+	.domain-search--results__in-flow-search,
+	.domain-search--results__in-flow-before-results {
+		display: none;
+	}
+
+	// The persistent fixed overlay (position: fixed at top:
+	// var(--step-container-v2-top-bar-height)) visually obscures the first
+	// ~123px of in-flow content. Reserve that vertical space at the top of the
+	// results region so the first row of suggestions renders just below the
+	// overlay rather than behind it.
+	//   - compact banner (collapsed): 12px + 24px + 12px + 2px borders = 50px
+	//   - search-bar row: 12px + var(--domain-search-input-size) + 12px + 1px border
+	// When the banner is expanded inline (subtitle visible), the additional
+	// ~20px briefly overlaps the first result — acceptable for a user-initiated
+	// affordance, the user can scroll to recover.
+	.domain-search--results {
+		padding-block-start: calc(
+			50px + ( 12px * 2 ) + var( --domain-search-input-size ) + 1px
+		);
+	}
 }
 
-// Fixed overlay — always in the DOM on mobile (when a BeforeResults slot is
-// present), always at position:fixed. Default state: slid fully above the
-// viewport via transform. When .is-stuck is applied the overlay slides into
-// view. Only `transform` is animated → compositor-only, zero layout/paint cost.
-// The in-flow render tree is never affected: no min-height placeholder needed.
+// Persistent fixed overlay — mobile-only. Always pinned at the top of the
+// viewport, directly below the WP top bar (the stepper makes the top bar
+// position:sticky on this step so the two surfaces read as one fixed region).
 .domain-search--results__sticky-overlay {
-	// Hidden from non-mobile viewports — the overlay is mobile-only.
-	// On desktop the in-flow promo card (slots.BeforeResults) is always visible.
+	// The overlay is mobile-only; on desktop the in-flow promo card +
+	// SearchBar carry the layout.
 	display: none;
 
 	@media ( max-width: #{ $break-small - 1px } ) {
 		display: flex;
 		flex-direction: column;
 		position: fixed;
-		inset-block-start: 0;
+		// Sit immediately below the WP top bar so they form a single fixed
+		// top region. Falls back to 0 when consumers don't render inside
+		// StepContainerV2.
+		inset-block-start: var( --step-container-v2-top-bar-height, 0 );
 		inset-inline: 0;
 		z-index: var( --domain-search-sticky-overlay-z-index );
-		// Start fully above the viewport; slide in by adding .is-stuck.
-		// Exit transition: accelerate (cubic-bezier(0.4,0,1,1)) — feels intentional.
-		transform: translateY( -100% );
-		opacity: 0;
-		transition:
-			transform 220ms cubic-bezier( 0.4, 0, 1, 1 ),
-			opacity 160ms ease-in;
-		will-change: transform, opacity;
-
-		&.is-stuck {
-			transform: translateY( 0 );
-			opacity: 1;
-			// Enter transition: decelerate (cubic-bezier(0,0,0.2,1)) — softer arrival.
-			transition:
-				transform 280ms cubic-bezier( 0, 0, 0.2, 1 ),
-				opacity 200ms ease-out;
-		}
 	}
 }
 
@@ -141,8 +143,7 @@
 	box-shadow: 0 1px 1px rgba( 0, 0, 0, 0.02 );
 }
 
-// Compact sticky banner — rendered inside the overlay, animates as part of the
-// single transform slide. No independent animation needed.
+// Compact sticky banner — sits at the top of the overlay, above the search bar.
 .domain-search--results__compact-banner {
 	// Reset button defaults.
 	appearance: none;

--- a/packages/domain-search/src/page/style.scss
+++ b/packages/domain-search/src/page/style.scss
@@ -17,6 +17,8 @@
 	--domain-search-warning-badge-background-color: #f9edb4;
 	--domain-search-success-badge-border-color: #b8e5be;
 	--domain-search-success-badge-background-color: #d1eed5;
+	--domain-search-sticky-overlay-z-index: 1;
+	--domain-search-full-cart-z-index: 2;
 	--domain-search-mini-cart-height: 80px;
 	--domain-search-mini-cart-inline-padding: 1rem;
 	--domain-search-content-max-width: 64rem;
@@ -80,4 +82,120 @@
 	@media ( max-width: #{ $break-small - 1px } ) {
 		gap: 1.5rem;
 	}
+}
+
+// Zero-height sentinel — positioned immediately after the in-flow search bar.
+// IntersectionObserver fires when this element crosses the top viewport edge,
+// which coincides with the search bar having just scrolled out of view.
+.domain-search--results__sentinel {
+	block-size: 0;
+	overflow: hidden;
+	// aria-hidden="true" is set in TSX; no further a11y work needed.
+}
+
+// Fixed overlay — always in the DOM on mobile (when a BeforeResults slot is
+// present), always at position:fixed. Default state: slid fully above the
+// viewport via transform. When .is-stuck is applied the overlay slides into
+// view. Only `transform` is animated → compositor-only, zero layout/paint cost.
+// The in-flow render tree is never affected: no min-height placeholder needed.
+.domain-search--results__sticky-overlay {
+	// Hidden from non-mobile viewports — the overlay is mobile-only.
+	// On desktop the in-flow promo card (slots.BeforeResults) is always visible.
+	display: none;
+
+	@media ( max-width: #{ $break-small - 1px } ) {
+		display: flex;
+		flex-direction: column;
+		position: fixed;
+		inset-block-start: 0;
+		inset-inline: 0;
+		z-index: var( --domain-search-sticky-overlay-z-index );
+		// Start fully above the viewport; slide in by adding .is-stuck.
+		// Exit transition: accelerate (cubic-bezier(0.4,0,1,1)) — feels intentional.
+		transform: translateY( -100% );
+		opacity: 0;
+		transition:
+			transform 220ms cubic-bezier( 0.4, 0, 1, 1 ),
+			opacity 160ms ease-in;
+		will-change: transform, opacity;
+
+		&.is-stuck {
+			transform: translateY( 0 );
+			opacity: 1;
+			// Enter transition: decelerate (cubic-bezier(0,0,0.2,1)) — softer arrival.
+			transition:
+				transform 280ms cubic-bezier( 0, 0, 0.2, 1 ),
+				opacity 200ms ease-out;
+		}
+	}
+}
+
+// Search bar row inside the overlay — white background, padding, and bottom
+// border matching the Figma spec. These styles apply only inside the overlay;
+// the identical in-flow <SearchBar> has no wrapper and retains trunk styling.
+.domain-search--results__search-bar-row {
+	background-color: var( --color-surface );
+	padding-block: 12px;
+	padding-inline: var( --step-container-v2-content-inline-padding, 1rem );
+	border-block-end: 1px solid rgba( 0, 0, 0, 0.08 ); // exact Figma spec; no semantic token matches
+	box-shadow: 0 1px 1px rgba( 0, 0, 0, 0.02 );
+}
+
+// Compact sticky banner — rendered inside the overlay, animates as part of the
+// single transform slide. No independent animation needed.
+.domain-search--results__compact-banner {
+	// Reset button defaults.
+	appearance: none;
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.5rem;
+	width: 100%;
+	border: none;
+	border-block-start: 1px solid rgba( 0, 0, 0, 0.08 ); // exact Figma spec; no semantic token matches
+	border-block-end: 1px solid rgba( 0, 0, 0, 0.08 ); // exact Figma spec; no semantic token matches
+	padding-block: 12px;
+	padding-inline: var( --step-container-v2-content-inline-padding, 1rem );
+	// #f6f7f9 is the exact Figma spec. --studio-gray-0 resolves to #f6f7f7
+	// (2-channel delta); no semantic token matches this value.
+	background-color: #f6f7f9;
+	cursor: pointer;
+	text-align: start;
+	box-shadow: none;
+}
+
+.domain-search--results__compact-banner-title {
+	flex: 1;
+	font-size: 13px;
+	font-weight: 400;
+	// Figma line-height 24px on a 13px element.
+	line-height: 24px;
+	// #2f2f2f is the Figma-exact value. --studio-gray-80 resolves to #2c3338
+	// (3-channel delta on R); no semantic token matches this value.
+	color: #2f2f2f;
+	letter-spacing: -0.08px;
+}
+
+.domain-search--results__compact-banner-chevron {
+	flex-shrink: 0;
+	// rgba(0,0,0,0.32) is Figma-exact. No semantic token matches this value.
+	// `fill` (not `color`) is required: @wordpress/icons chevron-down has no
+	// explicit `fill="currentColor"`, so SVG fill must be set directly.
+	fill: rgba( 0, 0, 0, 0.32 );
+}
+
+.domain-search--results__compact-banner-subtitle {
+	// Force the subtitle onto its own line by taking full width.
+	width: 100%;
+	display: block;
+	font-size: 13px;
+	font-weight: 400;
+	// Figma line-height 20px on a 13px element.
+	line-height: 20px;
+	// #757575 is the Figma-exact value. --studio-gray-50 resolves to #646970
+	// (3-channel delta on G and B); no semantic token matches this value.
+	color: #757575;
+	letter-spacing: -0.08px;
+	text-align: start;
 }

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -562,6 +562,49 @@ describe( 'ResultsPage', () => {
 		expect( screen.getByText( 'Before Results' ) ).toBeInTheDocument();
 	} );
 
+	describe( 'compact banner', () => {
+		it( 'toggles the expanded subtitle when clicked', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<TestDomainSearch slots={ { BeforeResults: () => <div>Before Results</div> } }>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			const banner = screen.getByRole( 'button', {
+				name: /Claim your free domain name with a paid plan/,
+			} );
+
+			expect( banner ).toHaveAttribute( 'aria-expanded', 'false' );
+			expect( screen.queryByText( /Choose a domain name/ ) ).not.toBeInTheDocument();
+
+			await user.click( banner );
+
+			expect( banner ).toHaveAttribute( 'aria-expanded', 'true' );
+			expect( screen.getByText( /Choose a domain name/ ) ).toBeInTheDocument();
+
+			await user.click( banner );
+
+			expect( banner ).toHaveAttribute( 'aria-expanded', 'false' );
+			expect( screen.queryByText( /Choose a domain name/ ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'is not rendered when no BeforeResults slot is passed', () => {
+			render(
+				<TestDomainSearch>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			expect(
+				screen.queryByRole( 'button', {
+					name: /Claim your free domain name with a paid plan/,
+				} )
+			).not.toBeInTheDocument();
+		} );
+	} );
+
 	it( 'renders the placeholders while loading', () => {
 		render(
 			<TestDomainSearch>

--- a/packages/domain-search/src/test-helpers/setup.ts
+++ b/packages/domain-search/src/test-helpers/setup.ts
@@ -1,6 +1,20 @@
 import nock from 'nock';
 import { queryClient } from './renderer';
 
+// jsdom does not implement IntersectionObserver. Provide a no-op stub so that
+// ResultsPage (which uses one for the sticky sentinel) renders without error.
+(
+	globalThis as typeof globalThis & { IntersectionObserver: typeof IntersectionObserver }
+ ).IntersectionObserver = jest.fn( () => ( {
+	observe: jest.fn(),
+	unobserve: jest.fn(),
+	disconnect: jest.fn(),
+	root: null,
+	rootMargin: '',
+	thresholds: [],
+	takeRecords: jest.fn( () => [] ),
+} ) ) as unknown as typeof IntersectionObserver;
+
 // Disables all network requests for all tests.
 nock.disableNetConnect();
 

--- a/packages/domain-search/src/test-helpers/setup.ts
+++ b/packages/domain-search/src/test-helpers/setup.ts
@@ -1,20 +1,6 @@
 import nock from 'nock';
 import { queryClient } from './renderer';
 
-// jsdom does not implement IntersectionObserver. Provide a no-op stub so that
-// ResultsPage (which uses one for the sticky sentinel) renders without error.
-(
-	globalThis as typeof globalThis & { IntersectionObserver: typeof IntersectionObserver }
- ).IntersectionObserver = jest.fn( () => ( {
-	observe: jest.fn(),
-	unobserve: jest.fn(),
-	disconnect: jest.fn(),
-	root: null,
-	rootMargin: '',
-	thresholds: [],
-	takeRecords: jest.fn( () => [] ),
-} ) ) as unknown as typeof IntersectionObserver;
-
 // Disables all network requests for all tests.
 nock.disableNetConnect();
 


### PR DESCRIPTION
Part of RSM https://linear.app/a8c/initiative/rsm-mobile-experience-overhaul-02aa29651285/overview

## Why are these changes being made?

The mobile Domains step buries the search input below a tall promo card. Once the user scrolls past the card, they can't refine their query without scrolling back up. The sticky overlay keeps the search bar accessible at all scroll positions while still surfacing the free-domain-with-plan messaging in a non-intrusive collapsed form.

## Screenshots

https://github.com/user-attachments/assets/1e99676d-8538-4f76-9433-d1a3ee0ecf19



## Proposed Changes

* On mobile (below `$break-small`), once the in-flow search bar scrolls out of view, slide a fixed overlay in from the top of the viewport. The overlay contains a compact disclosure banner ("Claim your free domain name with a paid plan", expandable to a longer subtitle) plus a second `<SearchBar />` wired to the same `useDomainSearch()` query state so typing in either updates both.
* The in-flow render tree is trunk-identical: the original promo card (`slots.BeforeResults`) and `<SearchBar />` are always rendered and never repositioned. The overlay is a separate always-in-DOM element at `position: fixed` that's hidden (`transform: translateY(-100%); opacity: 0`) by default and revealed via a `.is-stuck` class.
* Sticky detection uses an `IntersectionObserver` on a zero-height sentinel placed immediately after the in-flow search bar. State only flips when the value actually changes.
* Animation is compositor-only (`transform` + `opacity`) with asymmetric enter/exit easing — decelerate on entry, accelerate on exit — for a softer reveal and a more intentional dismissal.
* Overlay z-index is layered below the full cart via two new `.domain-search`-scoped CSS variables (`--domain-search-sticky-overlay-z-index: 1`, `--domain-search-full-cart-z-index: 2`), so consumers can override both if needed without forking the package.


## Testing Instructions

1. Open `/setup/onboarding/domains` (or any onboarding flow that lands on the domain search step) at a mobile viewport (`<600px`, e.g. 390×844).
2. Confirm the page initially looks identical to trunk: full promo card visible, search bar in normal position.
3. Scroll down. As the in-flow search bar leaves the viewport top, the overlay should slide in from above — slim banner first, search bar below, edge-to-edge, pinned at `top: 0`.
4. Tap the chevron on the banner. The subtitle should expand inline below the title.
5. Type in the sticky search input. The query state should update; results filter accordingly. Scrolling back up reveals the in-flow search bar with the same query.
6. Scroll back to the top. The overlay should slide out with a slightly faster, accelerating curve.
7. Click "View cart" to open the full cart modal. The modal should layer above the sticky overlay (overlay z-index is below cart z-index).
8. Tap the filter button in the sticky search bar. The filter popover should appear below the button (not flipped above).
9. Confirm desktop (≥600px) shows no overlay — only the standard in-flow layout.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?