### PR TITLE
Choose plans: enable upgrades to Personal/Premium/Business/eCommerce

### DIFF
--- a/packages/calypso-products/src/constants/wpcom.ts
+++ b/packages/calypso-products/src/constants/wpcom.ts
@@ -71,6 +71,12 @@ export const PLAN_PERSONAL_3_YEARS = 'personal-bundle-3y';
 export const PLAN_WPCOM_CHOOSE_LOW_YEARLY = 'wp_bundle_choose_low_yearly';
 export const PLAN_WPCOM_CHOOSE_MID_YEARLY = 'wp_bundle_choose_mid_yearly';
 export const PLAN_WPCOM_CHOOSE_HIGH_YEARLY = 'wp_bundle_choose_high_yearly';
+
+export const WPCOM_CHOOSE_PLANS = < const >[
+	PLAN_WPCOM_CHOOSE_LOW_YEARLY,
+	PLAN_WPCOM_CHOOSE_MID_YEARLY,
+	PLAN_WPCOM_CHOOSE_HIGH_YEARLY,
+];
 export const PLAN_BLOGGER = 'blogger-bundle';
 export const PLAN_BLOGGER_2_YEARS = 'blogger-bundle-2y';
 export const PLAN_ECOMMERCE_MONTHLY = 'ecommerce-bundle-monthly';

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -200,6 +200,7 @@ import {
 	PLAN_WPCOM_CHOOSE_LOW_YEARLY,
 	PLAN_WPCOM_CHOOSE_MID_YEARLY,
 	PLAN_WPCOM_CHOOSE_HIGH_YEARLY,
+	WPCOM_CHOOSE_PLANS,
 	PLAN_PREMIUM,
 	PLAN_PREMIUM_2_YEARS,
 	PLAN_PREMIUM_3_YEARS,
@@ -3135,9 +3136,13 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		...getPlanPersonalDetails(),
 		...getMonthlyTimeframe(),
 		availableFor: ( plan ) =>
-			[ PLAN_FREE, PLAN_BLOGGER, PLAN_BLOGGER_2_YEARS, PLAN_PERSONAL_TRIAL_MONTHLY ].includes(
-				plan
-			),
+			[
+				PLAN_FREE,
+				...WPCOM_CHOOSE_PLANS,
+				PLAN_BLOGGER,
+				PLAN_BLOGGER_2_YEARS,
+				PLAN_PERSONAL_TRIAL_MONTHLY,
+			].includes( plan ),
 		getProductId: () => 1019,
 		getStoreSlug: () => PLAN_PERSONAL_MONTHLY,
 		getPathSlug: () => 'personal-monthly',
@@ -3150,6 +3155,7 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		availableFor: ( plan ) =>
 			[
 				PLAN_FREE,
+				...WPCOM_CHOOSE_PLANS,
 				PLAN_BLOGGER,
 				PLAN_BLOGGER_2_YEARS,
 				PLAN_PERSONAL_TRIAL_MONTHLY,
@@ -3167,6 +3173,7 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		availableFor: ( plan ) =>
 			[
 				PLAN_FREE,
+				...WPCOM_CHOOSE_PLANS,
 				PLAN_BLOGGER,
 				PLAN_BLOGGER_2_YEARS,
 				PLAN_PERSONAL_TRIAL_MONTHLY,
@@ -3185,6 +3192,7 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		availableFor: ( plan ) =>
 			[
 				PLAN_FREE,
+				...WPCOM_CHOOSE_PLANS,
 				PLAN_BLOGGER,
 				PLAN_BLOGGER_2_YEARS,
 				PLAN_PERSONAL_TRIAL_MONTHLY,
@@ -3255,6 +3263,7 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		availableFor: ( plan ) =>
 			[
 				PLAN_FREE,
+				...WPCOM_CHOOSE_PLANS,
 				PLAN_BLOGGER,
 				PLAN_BLOGGER_2_YEARS,
 				PLAN_PERSONAL_TRIAL_MONTHLY,
@@ -3274,6 +3283,7 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		availableFor: ( plan ) =>
 			[
 				PLAN_FREE,
+				...WPCOM_CHOOSE_PLANS,
 				PLAN_BLOGGER,
 				PLAN_BLOGGER_2_YEARS,
 				PLAN_PERSONAL_TRIAL_MONTHLY,
@@ -3295,6 +3305,7 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		availableFor: ( plan ) =>
 			[
 				PLAN_FREE,
+				...WPCOM_CHOOSE_PLANS,
 				PLAN_BLOGGER,
 				PLAN_BLOGGER_2_YEARS,
 				PLAN_PERSONAL_TRIAL_MONTHLY,
@@ -3316,6 +3327,7 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		availableFor: ( plan ) =>
 			[
 				PLAN_FREE,
+				...WPCOM_CHOOSE_PLANS,
 				PLAN_BLOGGER,
 				PLAN_BLOGGER_2_YEARS,
 				PLAN_PERSONAL_TRIAL_MONTHLY,
@@ -3339,6 +3351,7 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 			isEnabled( 'upgrades/wpcom-monthly-plans' ) &&
 			[
 				PLAN_FREE,
+				...WPCOM_CHOOSE_PLANS,
 				PLAN_BLOGGER,
 				PLAN_BLOGGER_2_YEARS,
 				PLAN_PERSONAL_TRIAL_MONTHLY,
@@ -3364,6 +3377,7 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		availableFor: ( plan ) =>
 			[
 				PLAN_FREE,
+				...WPCOM_CHOOSE_PLANS,
 				PLAN_WPCOM_STARTER,
 				PLAN_WPCOM_PRO,
 				PLAN_BLOGGER,
@@ -3392,6 +3406,7 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		availableFor: ( plan ) =>
 			[
 				PLAN_FREE,
+				...WPCOM_CHOOSE_PLANS,
 				PLAN_WPCOM_STARTER,
 				PLAN_BLOGGER,
 				PLAN_BLOGGER_2_YEARS,
@@ -3422,6 +3437,7 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		availableFor: ( plan ) =>
 			[
 				PLAN_FREE,
+				...WPCOM_CHOOSE_PLANS,
 				PLAN_WPCOM_STARTER,
 				PLAN_BLOGGER,
 				PLAN_BLOGGER_2_YEARS,
@@ -3514,6 +3530,7 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		availableFor: ( plan ) =>
 			[
 				PLAN_FREE,
+				...WPCOM_CHOOSE_PLANS,
 				PLAN_BLOGGER,
 				PLAN_BLOGGER_2_YEARS,
 				PLAN_PERSONAL_TRIAL_MONTHLY,
@@ -3543,6 +3560,7 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		availableFor: ( plan ) =>
 			[
 				PLAN_FREE,
+				...WPCOM_CHOOSE_PLANS,
 				PLAN_WPCOM_STARTER,
 				PLAN_WPCOM_PRO,
 				PLAN_BLOGGER,
@@ -3575,6 +3593,7 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		availableFor: ( plan ) =>
 			[
 				PLAN_FREE,
+				...WPCOM_CHOOSE_PLANS,
 				PLAN_WPCOM_STARTER,
 				PLAN_WPCOM_PRO_MONTHLY,
 				PLAN_WPCOM_PRO,
@@ -3770,6 +3789,7 @@ export const PLANS_LIST: Record< string, Plan | JetpackPlan | WPComPlan > = {
 		availableFor: ( plan ) =>
 			[
 				PLAN_FREE,
+				...WPCOM_CHOOSE_PLANS,
 				PLAN_WPCOM_STARTER,
 				PLAN_WPCOM_PRO_MONTHLY,
 				PLAN_WPCOM_PRO,


### PR DESCRIPTION
Part of #<!-- Linear ID -->

## Proposed Changes

* Add the three Choose yearly plans (`PLAN_WPCOM_CHOOSE_LOW_YEARLY`, `_MID_YEARLY`, `_HIGH_YEARLY`) to the `availableFor` arrays of every higher-tier WordPress.com plan: Personal, Premium, Business, eCommerce — across their monthly, annual, 2-year, and 3-year variants (16 entries total).
* Introduce a `WPCOM_CHOOSE_PLANS` tuple in the wpcom constants module so the three slugs can be spread into each `availableFor` instead of inlined sixteen times.

## Why are these changes being made?

* `canUpgradeToPlan()` decides whether each plan card in the grid shows an "Upgrade" or "Downgrade" button by calling the target plan's `availableFor()` function with the user's current plan slug. Choose plans weren't listed in any higher-tier plan's `availableFor` array, so every paid plan card incorrectly rendered "Downgrade" for users currently on a Choose plan. The Free plan card should still show "Downgrade" — and continues to, because `PLAN_FREE` has no `availableFor` and defaults to `false`.

## Testing Instructions

* Sign up for one of the Choose yearly plans (`/checkout/<plan>/<site>` with `choose-12-yearly`, `choose-24-yearly`, or `choose-36-yearly`).
* Visit the plans grid for that site. Confirm:
  * `Free` → "Downgrade" button.
  * `Personal`, `Premium`, `Business`, `eCommerce` → "Upgrade" buttons.
* Run the unit tests:
  ```
  yarn test-packages packages/calypso-products
  ```

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?