### PR TITLE
Reader onboarding RSM - enable most subscribed pack

### DIFF
--- a/client/reader/onboarding-rsm/curated-blogs/index.tsx
+++ b/client/reader/onboarding-rsm/curated-blogs/index.tsx
@@ -1,6 +1,7 @@
 import { creativeArtsBlogs } from './creative-arts';
 import { industryBlogs } from './industry';
 import { lifestyleBlogs } from './lifestyle';
+import { popularBlogs } from './popular';
 import { societyBlogs } from './society';
 import { technologyBlogs } from './technology';
 
@@ -10,6 +11,7 @@ export const curatedBlogs = {
 	...creativeArtsBlogs,
 	...societyBlogs,
 	...industryBlogs,
+	...popularBlogs,
 };
 
 export type CuratedBlog = {

--- a/client/reader/onboarding-rsm/curated-blogs/popular.tsx
+++ b/client/reader/onboarding-rsm/curated-blogs/popular.tsx
@@ -1,0 +1,46 @@
+import { CuratedBlogsList } from './index';
+
+export const popularBlogs: CuratedBlogsList = {
+	'most-subscribed': [
+		{
+			feed_ID: 107535240,
+			site_ID: 179338616,
+			site_URL: 'https://variety.com/',
+			site_name: 'Variety',
+			feed_URL: 'http://pmc-variety.go-vip.net/feed',
+			has_icon: true,
+		},
+		{
+			feed_ID: 84452094,
+			site_ID: 148354167,
+			site_URL: 'https://www.rollingstone.com/',
+			site_name: 'Rolling Stone',
+			feed_URL: 'http://www.rollingstone.com/feed',
+			has_icon: true,
+		},
+		{
+			feed_ID: 116988393,
+			site_ID: 186757698,
+			site_URL: 'https://magazine.atavist.com/',
+			site_name: 'The Atavist Magazine',
+			feed_URL: 'http://magazine.atavist.com/feed',
+			has_icon: true,
+		},
+		{
+			feed_ID: 138734090,
+			site_ID: 211646052,
+			site_URL: 'https://longreads.com/',
+			site_name: 'Longreads',
+			feed_URL: 'http://longreads.com/feed',
+			has_icon: true,
+		},
+		{
+			feed_ID: 101852522,
+			site_ID: 0,
+			site_URL: 'https://time.com/',
+			site_name: 'Time',
+			feed_URL: 'http://time.com/feed',
+			has_icon: false,
+		},
+	],
+};

--- a/client/reader/onboarding-rsm/interests-modal/get-pack-blogs.ts
+++ b/client/reader/onboarding-rsm/interests-modal/get-pack-blogs.ts
@@ -5,6 +5,8 @@ export type GetPackBlogsOptions = {
 	count?: number;
 	curatedBlogs?: CuratedBlogsList;
 	random?: () => number;
+	/** When set, resolve blogs from `curatedBlogs[ directKey ]` (e.g. tagless pack id). Ignores `tags`. */
+	directKey?: string;
 };
 
 const pickRandom = < T >( items: T[], count: number, random: () => number ): T[] => {
@@ -65,12 +67,31 @@ const distributeSlots = ( tagCount: number, count: number ): number[] => {
  * - The returned pack is ordered with `has_icon` blogs first so the interests
  *   card can show icon-backed avatars in its first slots without excluding
  *   non-icon feeds from packs.
+ * - When `directKey` is set, returns up to `count` blogs from `curatedBlogs[ directKey ]`
+ *   with the same icon-first ordering (for tagless packs keyed by pack id).
  */
 export const getPackBlogs = (
 	tags: string[],
-	{ count = 5, curatedBlogs = defaultCuratedBlogs, random = Math.random }: GetPackBlogsOptions = {}
+	{
+		count = 5,
+		curatedBlogs = defaultCuratedBlogs,
+		random = Math.random,
+		directKey,
+	}: GetPackBlogsOptions = {}
 ): CuratedBlog[] => {
-	if ( ! tags?.length || count <= 0 ) {
+	if ( count <= 0 ) {
+		return [];
+	}
+
+	if ( directKey !== undefined && directKey !== '' ) {
+		const directList = curatedBlogs[ directKey ];
+		if ( Array.isArray( directList ) && directList.length > 0 ) {
+			return orderPackWithIconsFirst( directList.slice( 0, count ) );
+		}
+		return [];
+	}
+
+	if ( ! tags?.length ) {
 		return [];
 	}
 

--- a/client/reader/onboarding-rsm/interests-modal/index.tsx
+++ b/client/reader/onboarding-rsm/interests-modal/index.tsx
@@ -84,7 +84,10 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { onContinue, promptVe
 	const packBlogsByIdRef = useRef< Map< string, CuratedBlog[] > | null >( null );
 	if ( ! packBlogsByIdRef.current ) {
 		packBlogsByIdRef.current = new Map(
-			topicGroups.map( ( group ) => [ group.id, getPackBlogs( group.tags ) ] )
+			topicGroups.map( ( group ) => [
+				group.id,
+				getPackBlogs( group.tags, group.tags.length === 0 ? { directKey: group.id } : undefined ),
+			] )
 		);
 	}
 	const packBlogsById = packBlogsByIdRef.current;
@@ -94,7 +97,8 @@ const InterestsModal: React.FC< InterestsModalProps > = ( { onContinue, promptVe
 			...group,
 			blogs: packBlogsById.get( group.id ) ?? [],
 		} ) )
-		// Hide the "Most Subscribed" pack while it has nothing to subscribe to.
+		// Defensive: hide any pack that resolves to nothing to subscribe to
+		// (e.g., a tagless pack id with no curated entry).
 		.filter( ( pack ) => pack.tags.length > 0 || pack.blogs.length > 0 );
 
 	const isBlogFollowed = ( blog: CuratedBlog ): boolean =>

--- a/client/reader/onboarding-rsm/interests-modal/test/get-pack-blogs.test.ts
+++ b/client/reader/onboarding-rsm/interests-modal/test/get-pack-blogs.test.ts
@@ -180,4 +180,92 @@ describe( 'getPackBlogs', () => {
 		} );
 		expect( a ).toEqual( b );
 	} );
+
+	describe( 'directKey', () => {
+		it( 'returns the curated list when directKey is provided and tags are empty', () => {
+			const curated: CuratedBlogsList = {
+				'most-subscribed': makeBlogs( '8', 5 ),
+			};
+			const blogs = getPackBlogs( [], {
+				curatedBlogs: curated,
+				directKey: 'most-subscribed',
+			} );
+
+			expect( blogs ).toHaveLength( 5 );
+			expect( blogs.every( ( b ) => b.site_name.startsWith( '8-' ) ) ).toBe( true );
+		} );
+
+		it( 'respects count when using directKey', () => {
+			const curated: CuratedBlogsList = {
+				'most-subscribed': makeBlogs( '9', 10 ),
+			};
+			const blogs = getPackBlogs( [], {
+				curatedBlogs: curated,
+				directKey: 'most-subscribed',
+				count: 2,
+			} );
+
+			expect( blogs ).toHaveLength( 2 );
+		} );
+
+		it( 'orders the returned pack with has_icon blogs first when using directKey', () => {
+			const curated: CuratedBlogsList = {
+				'most-subscribed': [
+					{
+						feed_ID: 601,
+						site_ID: 601,
+						site_URL: 'https://no-icon.example',
+						site_name: 'No icon',
+						feed_URL: 'https://no-icon.example/feed',
+						has_icon: false,
+					},
+					{
+						feed_ID: 602,
+						site_ID: 602,
+						site_URL: 'https://has-icon-b.example',
+						site_name: 'Has icon B',
+						feed_URL: 'https://has-icon-b.example/feed',
+						has_icon: true,
+					},
+					{
+						feed_ID: 603,
+						site_ID: 603,
+						site_URL: 'https://has-icon-c.example',
+						site_name: 'Has icon C',
+						feed_URL: 'https://has-icon-c.example/feed',
+						has_icon: true,
+					},
+				],
+			};
+			const blogs = getPackBlogs( [], {
+				curatedBlogs: curated,
+				directKey: 'most-subscribed',
+				count: 3,
+			} );
+
+			expect( blogs.map( ( b ) => b.site_name ) ).toEqual( [
+				'Has icon B',
+				'Has icon C',
+				'No icon',
+			] );
+		} );
+
+		it( 'returns an empty array when directKey is not present in curatedBlogs', () => {
+			expect(
+				getPackBlogs( [], {
+					curatedBlogs: fixture,
+					directKey: 'missing-pack-id',
+				} )
+			).toEqual( [] );
+		} );
+
+		it( 'returns an empty array when directKey points to an empty list', () => {
+			expect(
+				getPackBlogs( [], {
+					curatedBlogs: { 'most-subscribed': [] },
+					directKey: 'most-subscribed',
+				} )
+			).toEqual( [] );
+		} );
+	} );
 } );

--- a/client/reader/onboarding-rsm/interests-modal/test/index.test.tsx
+++ b/client/reader/onboarding-rsm/interests-modal/test/index.test.tsx
@@ -6,7 +6,9 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { getPackBlogs } from '../get-pack-blogs';
 import InterestsModal from '../index';
+import { getTopicGroups } from '../topic-groups';
 
 // ── External data hooks ──────────────────────────────────────────────────────
 
@@ -21,17 +23,39 @@ jest.mock( 'calypso/data/reader/use-reader-tags', () => ( {
 // ── Internal helpers / child components ─────────────────────────────────────
 
 jest.mock( '../get-pack-blogs', () => ( {
-	getPackBlogs: () => [],
+	getPackBlogs: jest.fn( () => [] ),
 } ) );
 
 jest.mock( '../topic-groups', () => ( {
-	getTopicGroups: () => [],
+	getTopicGroups: jest.fn( () => [] ),
 } ) );
 
-jest.mock( '../topic-group-card', () => ( {
-	__esModule: true,
-	default: () => null,
-} ) );
+jest.mock( '../topic-group-card', () => {
+	const React = require( 'react' );
+	return {
+		__esModule: true,
+		default: ( {
+			title,
+			blogs,
+			onSubscribe,
+		}: {
+			title: string;
+			blogs: { length: number }[];
+			onSubscribe: () => void;
+		} ) =>
+			React.createElement(
+				'button',
+				{
+					type: 'button',
+					'data-testid': 'topic-pack-card',
+					'data-title': title,
+					'data-blog-count': String( blogs.length ),
+					onClick: onSubscribe,
+				},
+				'Pack subscribe'
+			),
+	};
+} );
 
 // Give the nudge a stable test-id so tests can assert on its presence.
 jest.mock( '../verificationNudge', () => ( {
@@ -129,5 +153,54 @@ describe( 'InterestsModal – verification nudge', () => {
 			'true'
 		);
 		expect( screen.queryByTestId( 'interests-verification-nudge' ) ).not.toBeInTheDocument();
+	} );
+} );
+
+describe( 'InterestsModal – most subscribed pack', () => {
+	const fivePackBlogs = Array.from( { length: 5 }, ( _, i ) => ( {
+		feed_ID: 900 + i,
+		site_ID: 800 + i,
+		site_URL: `https://pack-${ i }.example`,
+		site_name: `Pack site ${ i }`,
+		feed_URL: `https://pack-${ i }.example/feed`,
+		has_icon: true,
+	} ) );
+
+	afterEach( () => {
+		jest.mocked( getTopicGroups ).mockReset().mockReturnValue( [] );
+		jest.mocked( getPackBlogs ).mockReset().mockReturnValue( [] );
+	} );
+
+	it( 'renders the tagless pack with blog count from getPackBlogs( [], { directKey } ) and keeps Continue disabled after subscribe', async () => {
+		const user = userEvent.setup();
+
+		jest.mocked( getTopicGroups ).mockReturnValue( [
+			{
+				id: 'most-subscribed',
+				title: 'Most Subscribed',
+				description: 'Popular reads.',
+				imageUrl: 'https://images.example/subscribed.webp',
+				tags: [],
+			},
+		] );
+
+		jest.mocked( getPackBlogs ).mockImplementation( ( tags, opts ) => {
+			expect( tags ).toEqual( [] );
+			expect( opts ).toEqual( { directKey: 'most-subscribed' } );
+			return fivePackBlogs;
+		} );
+
+		renderWithProvider( <InterestsModal onContinue={ jest.fn() } promptVerification={ false } /> );
+
+		const packCard = screen.getByTestId( 'topic-pack-card' );
+		expect( packCard ).toHaveAttribute( 'data-title', 'Most Subscribed' );
+		expect( packCard ).toHaveAttribute( 'data-blog-count', '5' );
+
+		await user.click( packCard );
+
+		expect( screen.getByRole( 'button', { name: 'Continue' } ) ).toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # https://linear.app/a8c/issue/RSM-2947/curate-blogs-for-and-add-most-subscribed-pack

## Proposed Changes

* Adds curations for and enables the "Most subscribed" onboarding pack.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Changes can be seen on `*/reader?flags=reader/onboarding-rsm,reader/force-onboarding`
* Click to open the onboarding modals, in the interests step (2nd step) there should be a "Most subscribed" pack now visible.
* Click "Subscribe" and verify you are subscribed to the 5 blogs (go to manage subscriptions and see what you have been recently subscribed to).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
