### PR TITLE
Activity Log: add Performed by filter to the wordpress.com filterbar

### DIFF
--- a/client/data/activity-log/use-activity-log-actors-query.js
+++ b/client/data/activity-log/use-activity-log-actors-query.js
@@ -1,0 +1,29 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { filterStateToApiQuery } from 'calypso/state/activity-log/utils';
+import { getFilterKey } from './utils';
+
+const transformActors = ( apiResponse ) =>
+	( apiResponse?.actors ?? [] )
+		.filter( ( actor ) => actor?.id )
+		.map( ( actor ) => ( {
+			key: actor.id,
+			name: actor.name || actor.id,
+			count: actor.count,
+		} ) );
+
+export default function useActivityLogActorsQuery( siteId, filter, options ) {
+	return useQuery( {
+		queryKey: [ 'activity-log-actors', siteId, getFilterKey( filter ) ],
+		queryFn: () =>
+			wpcom.req
+				.get(
+					{ path: `/sites/${ siteId }/activity/actors`, apiNamespace: 'wpcom/v2' },
+					filterStateToApiQuery( filter, false )
+				)
+				.then( transformActors ),
+		enabled: !! siteId,
+		staleTime: 10 * 1000,
+		...options,
+	} );
+}

--- a/client/data/activity-log/use-activity-log-actors-query.js
+++ b/client/data/activity-log/use-activity-log-actors-query.js
@@ -1,7 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import { filterStateToApiQuery } from 'calypso/state/activity-log/utils';
-import { getFilterKey } from './utils';
 
 const transformActors = ( apiResponse ) =>
 	( apiResponse?.actors ?? [] )
@@ -12,14 +11,24 @@ const transformActors = ( apiResponse ) =>
 			count: actor.count,
 		} ) );
 
+// The actors endpoint feeds the "Performed by" dropdown, so it should
+// reflect every actor active in the date window — not narrow down to the
+// current actor selection. Forward only the date-range fields and key the
+// cache on the same, mirroring `ActivityTypeSelector`.
 export default function useActivityLogActorsQuery( siteId, filter, options ) {
+	const dateRangeFilter = {
+		before: filter?.before,
+		after: filter?.after,
+		on: filter?.on,
+		dateRange: filter?.dateRange,
+	};
 	return useQuery( {
-		queryKey: [ 'activity-log-actors', siteId, getFilterKey( filter ) ],
+		queryKey: [ 'activity-log-actors', siteId, dateRangeFilter ],
 		queryFn: () =>
 			wpcom.req
 				.get(
 					{ path: `/sites/${ siteId }/activity/actors`, apiNamespace: 'wpcom/v2' },
-					filterStateToApiQuery( filter, false )
+					filterStateToApiQuery( dateRangeFilter, false )
 				)
 				.then( transformActors ),
 		enabled: !! siteId,

--- a/client/data/activity-log/utils.js
+++ b/client/data/activity-log/utils.js
@@ -1,5 +1,6 @@
 const KNOWN_FILTER_OPTIONS = [
 	'action',
+	'actor',
 	'after',
 	'aggregate',
 	'before',

--- a/client/my-sites/activity/filterbar/actor-selector.jsx
+++ b/client/my-sites/activity/filterbar/actor-selector.jsx
@@ -1,0 +1,90 @@
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+import useActivityLogActorsQuery from 'calypso/data/activity-log/use-activity-log-actors-query';
+import { updateFilter } from 'calypso/state/activity-log/actions';
+import { recordTracksEvent, withAnalytics } from 'calypso/state/analytics/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { TypeSelector } from './type-selector/type-selector';
+
+const ActorSelector = ( { translate, variant = 'default', ...otherProps } ) => {
+	return (
+		<TypeSelector
+			{ ...otherProps }
+			title={ translate( 'Performed by' ) }
+			typeKey="actor"
+			showAppliedFiltersCount
+			variant={ variant }
+			translate={ translate }
+		/>
+	);
+};
+
+const withActors = ( WrappedComponent ) => {
+	const WithActors = ( props ) => {
+		const { siteId, filter } = props;
+		const { data } = useActivityLogActorsQuery( siteId, filter );
+		return <WrappedComponent { ...props } types={ data ?? [] } />;
+	};
+	WithActors.displayName = `withActors(${
+		WrappedComponent.displayName || WrappedComponent.name || 'Component'
+	})`;
+	return WithActors;
+};
+
+// `actor` values are opaque synthetic ids (e.g. `wpcom:123`, `mcp:cursor`).
+// `actor_kinds` is derived as the distinct set of id prefixes so analytics
+// can compare MCP-vs-wpcom usage without leaking the underlying ids.
+const selectActor = ( siteId, actors, allActors ) => ( dispatch ) => {
+	if ( 0 === actors.length ) {
+		return dispatch(
+			withAnalytics(
+				recordTracksEvent( 'calypso_activitylog_actor_filter_changed', { actor_count: 0 } ),
+				updateFilter( siteId, { actor: null, page: 1 } )
+			)
+		);
+	}
+
+	const actorKinds = Array.from(
+		new Set(
+			actors
+				.map( ( id ) => {
+					const idx = id.indexOf( ':' );
+					return idx > 0 ? id.slice( 0, idx ) : '';
+				} )
+				.filter( Boolean )
+		)
+	)
+		.sort()
+		.join( ',' );
+
+	return dispatch(
+		withAnalytics(
+			recordTracksEvent( 'calypso_activitylog_actor_filter_changed', {
+				actor_count: actors.length,
+				actor_kinds: actorKinds,
+				num_actors_available: allActors.length,
+			} ),
+			updateFilter( siteId, { actor: actors, page: 1 } )
+		)
+	);
+};
+
+export default withActors(
+	connect(
+		( state ) => ( {
+			siteId: getSelectedSiteId( state ),
+		} ),
+		{ selectActor },
+		( stateProps, dispatchProps, ownProps ) => {
+			const { types } = ownProps;
+			const { siteId } = stateProps;
+
+			return {
+				...ownProps,
+				...stateProps,
+				selectType: ( selectedActors ) =>
+					dispatchProps.selectActor( siteId, selectedActors, types ),
+			};
+		}
+	)( localize( ActorSelector ) )
+);

--- a/client/my-sites/activity/filterbar/actor-selector.jsx
+++ b/client/my-sites/activity/filterbar/actor-selector.jsx
@@ -34,17 +34,8 @@ const withActors = ( WrappedComponent ) => {
 // `actor` values are opaque synthetic ids (e.g. `wpcom:123`, `mcp:cursor`).
 // `actor_kinds` is derived as the distinct set of id prefixes so analytics
 // can compare MCP-vs-wpcom usage without leaking the underlying ids.
-const selectActor = ( siteId, actors, allActors ) => ( dispatch ) => {
-	if ( 0 === actors.length ) {
-		return dispatch(
-			withAnalytics(
-				recordTracksEvent( 'calypso_activitylog_actor_filter_changed', { actor_count: 0 } ),
-				updateFilter( siteId, { actor: null, page: 1 } )
-			)
-		);
-	}
-
-	const actorKinds = Array.from(
+const getActorKinds = ( actors ) =>
+	Array.from(
 		new Set(
 			actors
 				.map( ( id ) => {
@@ -57,13 +48,25 @@ const selectActor = ( siteId, actors, allActors ) => ( dispatch ) => {
 		.sort()
 		.join( ',' );
 
+const selectActor = ( siteId, actors, allActors ) => ( dispatch ) => {
+	const eventProps = {
+		actor_count: actors.length,
+		actor_kinds: getActorKinds( actors ),
+		num_actors_available: allActors.length,
+	};
+
+	if ( 0 === actors.length ) {
+		return dispatch(
+			withAnalytics(
+				recordTracksEvent( 'calypso_activitylog_actor_filter_changed', eventProps ),
+				updateFilter( siteId, { actor: null, page: 1 } )
+			)
+		);
+	}
+
 	return dispatch(
 		withAnalytics(
-			recordTracksEvent( 'calypso_activitylog_actor_filter_changed', {
-				actor_count: actors.length,
-				actor_kinds: actorKinds,
-				num_actors_available: allActors.length,
-			} ),
+			recordTracksEvent( 'calypso_activitylog_actor_filter_changed', eventProps ),
 			updateFilter( siteId, { actor: actors, page: 1 } )
 		)
 	);

--- a/client/my-sites/activity/filterbar/index.jsx
+++ b/client/my-sites/activity/filterbar/index.jsx
@@ -8,6 +8,7 @@ import BackButton from 'calypso/components/back-button';
 import { updateFilter } from 'calypso/state/activity-log/actions';
 import { recordTracksEvent, withAnalytics } from 'calypso/state/analytics/actions';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
+import ActorSelector from './actor-selector';
 import DateRangeSelector from './date-range-selector';
 import TextSelector from './text-selector';
 import ActivityTypeSelector from './type-selector/activity-type-selector';
@@ -17,7 +18,7 @@ import './style.scss';
 
 export class Filterbar extends Component {
 	static defaultProps = {
-		selectorTypes: { dateRange: true, actionType: true, text: true },
+		selectorTypes: { dateRange: true, actionType: true, actor: true, text: true },
 		variant: 'default',
 	};
 
@@ -25,6 +26,7 @@ export class Filterbar extends Component {
 		showActivityTypes: false,
 		showActivityDates: false,
 		showIssueTypes: false,
+		showActors: false,
 	};
 
 	goBack = () => {
@@ -41,6 +43,7 @@ export class Filterbar extends Component {
 			showActivityDates: ! this.state.showActivityDates,
 			showActivityTypes: false,
 			showIssueTypes: false,
+			showActors: false,
 		} );
 		this.scrollIntoView();
 	};
@@ -54,12 +57,27 @@ export class Filterbar extends Component {
 			showActivityTypes: ! this.state.showActivityTypes,
 			showActivityDates: false,
 			showIssueTypes: false,
+			showActors: false,
 		} );
 		this.scrollIntoView();
 	};
 
 	closeActivityTypes = () => {
 		this.setState( { showActivityTypes: false } );
+	};
+
+	toggleActorsSelector = () => {
+		this.setState( {
+			showActors: ! this.state.showActors,
+			showActivityTypes: false,
+			showActivityDates: false,
+			showIssueTypes: false,
+		} );
+		this.scrollIntoView();
+	};
+
+	closeActors = () => {
+		this.setState( { showActors: false } );
 	};
 
 	toggleIssueTypesSelector = () => {
@@ -88,7 +106,7 @@ export class Filterbar extends Component {
 			return;
 		}
 
-		if ( filter && ( filter.group || filter.before || filter.after ) ) {
+		if ( filter && ( filter.group || filter.before || filter.after || filter.actor ) ) {
 			return (
 				<Button onClick={ this.handleRemoveFilters } borderless className="filterbar__icon-reset">
 					<Gridicon icon="cross" />
@@ -113,7 +131,14 @@ export class Filterbar extends Component {
 		if ( ! filter ) {
 			return true;
 		}
-		if ( filter.group || filter.on || filter.before || filter.after || filter.textSearch ) {
+		if (
+			filter.group ||
+			filter.on ||
+			filter.before ||
+			filter.after ||
+			filter.textSearch ||
+			filter.actor
+		) {
 			return false;
 		}
 		if ( filter.page !== 1 ) {
@@ -189,6 +214,18 @@ export class Filterbar extends Component {
 								/>
 							</li>
 						) }
+						{ selectorTypes.actor && (
+							<li>
+								<ActorSelector
+									filter={ filter }
+									siteId={ siteId }
+									isVisible={ this.state.showActors }
+									onButtonClick={ this.toggleActorsSelector }
+									onClose={ this.closeActors }
+									variant={ variant }
+								/>
+							</li>
+						) }
 						{ selectorTypes.issueType && (
 							<li>
 								<IssueTypeSelector
@@ -218,7 +255,14 @@ const mapDispatchToProps = ( dispatch ) => ( {
 		dispatch(
 			withAnalytics(
 				recordTracksEvent( 'calypso_activitylog_filterbar_reset' ),
-				updateFilter( siteId, { group: null, after: null, before: null, on: null, page: 1 } )
+				updateFilter( siteId, {
+					group: null,
+					after: null,
+					before: null,
+					on: null,
+					actor: null,
+					page: 1,
+				} )
 			)
 		),
 } );

--- a/client/state/activity-log/utils.js
+++ b/client/state/activity-log/utils.js
@@ -4,6 +4,7 @@ export const filterStateToApiQuery = ( filter, addAggregate = true ) => {
 		// by default, we'll tell the api to create aggregate events
 		addAggregate && { aggregate: filter.aggregate ?? true },
 		filter.action && { action: filter.action },
+		filter.actor && { actor: filter.actor },
 		filter.on && { on: filter.on },
 		filter.after && { after: filter.after },
 		filter.before && { before: filter.before },
@@ -22,6 +23,7 @@ export const filterStateToQuery = ( filter ) =>
 	Object.assign(
 		{},
 		filter.action && { action: filter.action.join( ',' ) },
+		filter.actor && { actor: filter.actor.join( ',' ) },
 		typeof filter.aggregate !== 'undefined' && { aggregate: filter.aggregate },
 		filter.backButton && { back_button: true },
 		filter.on && { on: filter.on },
@@ -40,6 +42,7 @@ export const queryToFilterState = ( query ) =>
 	Object.assign(
 		{},
 		query.action && { action: decodeURI( query.action ).split( ',' ) },
+		query.actor && { actor: decodeURI( query.actor ).split( ',' ) },
 		typeof query.aggregate !== 'undefined' && { aggregate: query.aggregate },
 		query.on && { on: query.on },
 		query.after && { after: query.after },


### PR DESCRIPTION
Part of AIINT-425

## Proposed Changes

* Add an `ActorSelector` to the Calypso activity filterbar at `wordpress.com/activity-log/<site>`, alongside Date / Activity Type / Text Search.
* New data hook `client/data/activity-log/use-activity-log-actors-query.js` calls `/sites/<id>/activity/actors` for the active date range and transforms the response into `{ key, name, count }` entries for the dropdown.
* Extend `filterStateToApiQuery` / `filterStateToQuery` / `queryToFilterState` in `client/state/activity-log/utils.js` to round-trip `actor[]` through the WPCOM request and through the URL (`?actor=<comma-joined>`).
* Add `actor` to the filter cache key (`client/data/activity-log/utils.js`), the empty-filter check, the close-button visibility check, and the reset-filters dispatch in `client/my-sites/activity/filterbar/index.jsx`.
* Fire `calypso_activitylog_actor_filter_changed` on selection change with `actor_count`, `actor_kinds` (distinct id prefixes — `mcp`, `wpcom`, `app`, …), and `num_actors_available`.

The new selector reuses the existing `TypeSelector` via its `typeKey` prop, so the popover, checkbox layout, applied-filters count, and reset behaviour all match Activity Type's UX.

## Why are these changes being made?

The Jetpack-plugin standalone Activity Log already exposes a "Performed by" filter (AIINT-396 / [jetpack#48594](https://github.com/Automattic/jetpack/pull/48594)). The wordpress.com / Calypso Activity Log does not — wpcom-Simple sites and Atomic sites visiting the activity log via Calypso miss out on the same MCP / system-vs-user filtering that the Jetpack-plugin UI already offers. The backend is in place (`actor[]` on `/activity` shipped via AIINT-400, `/activity/actors` shipped via AIINT-399), so this is a Calypso-side UI addition.

The filterbar treats actor ids as opaque strings, so the in-flight wpcom changes (AIINT-423 splitting the `wpcom:-1` system sentinel; AIINT-424 merging `app:jetpack` / `app:wordpress`) land transparently — the dropdown options update without any further Calypso change.

## Testing Instructions

* Start Calypso (`yarn start`) and visit the activity log for a site you have access to.
* Confirm a "Performed by" selector appears in the filterbar header alongside Date / Activity Type / Text Search.
* Open it: the dropdown is populated dynamically from `/sites/<id>/activity/actors` for the active date range, with the running count next to each entry.
* Pick one or more entries and Apply — the visible events narrow; the URL updates with `?actor=<comma-joined>`.
* Deep-link with `?actor=wpcom:5146963` (or any combo): the filter applies on load and the dropdown pre-selects those entries.
* Change the date range: the actor dropdown options refetch for the new window.
* Use the "Clear filters" / cross button: `actor` clears alongside the others.
* Confirm `calypso_activitylog_actor_filter_changed` fires on change with `actor_count`, `actor_kinds`, `num_actors_available`.
* Regression: existing Date / Activity Type / Text Search filters, pagination, and the agency-dashboard site filters (which pass an explicit `selectorTypes` of `issueType` only and should not see the new selector) all behave as before.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
