### PR TITLE
E2E: stabilize Squarespace importer setup test

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/start-import-flow.ts
@@ -99,7 +99,7 @@ export class StartImportFlow {
 	async validateImportPage(): Promise< void > {
 		await this.page
 			.locator( selectors.startBuildingHeader( 'Your content is ready for its brand new home' ) )
-			.waitFor();
+			.waitFor( { timeout: 30_000 } );
 	}
 
 	/**

--- a/test/e2e/specs/importer/importer__site-setup.spec.ts
+++ b/test/e2e/specs/importer/importer__site-setup.spec.ts
@@ -97,7 +97,7 @@ test.describe(
 				} );
 
 				await test.step( 'And I start a valid import file', async () => {
-					await flowStartImport.enterURL( 'https://squarespace.com' );
+					await flowStartImport.enterURL( 'https://example.squarespace.com/' );
 					await flowStartImport.validateImportPage();
 					await flowStartImport.clickButton( 'Import your content' );
 					await flowStartImport.validateImporterDragPage( 'squarespace' );


### PR DESCRIPTION
Part of #

## Proposed Changes

* Use the existing sample Squarespace site for the importer setup routing assertion.
* Give the import ready screen 30s to appear after URL analysis.

## Why are these changes being made?

* Recent failures timed out while the UI was still showing the expected scanning state.
* The URL analyzer can legitimately take longer than Playwright's default 10s wait.
* A spot check of the current target returned successful responses with several calls above 10s and a max of 14.3s.
* The sample site is closer to a user-owned Squarespace site than the Squarespace marketing homepage.

## Testing Instructions

* `yarn prettier --check test/e2e/specs/importer/importer__site-setup.spec.ts packages/calypso-e2e/src/lib/flows/start-import-flow.ts`
* Targeted Playwright importer setup test passed on desktop.
* Targeted Playwright importer setup test passed on mobile.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?