### PR TITLE
Themes: show Active badge on single theme sheet

### DIFF
--- a/client/components/theme-tier/theme-tier-badge/index.jsx
+++ b/client/components/theme-tier/theme-tier-badge/index.jsx
@@ -5,6 +5,7 @@ import { useSelector } from 'calypso/state';
 import { useIsThemeAllowedOnSite } from 'calypso/state/themes/hooks/use-is-theme-allowed-on-site';
 import { useThemeTierForTheme } from 'calypso/state/themes/hooks/use-theme-tier-for-theme';
 import { getThemeType } from 'calypso/state/themes/selectors';
+import ThemeTierActiveBadge from './theme-tier-active-badge';
 import { ThemeTierBadgeContextProvider } from './theme-tier-badge-context';
 import ThemeTierBundledBadge from './theme-tier-bundled-badge';
 import ThemeTierCommunityBadge from './theme-tier-community-badge';
@@ -112,7 +113,7 @@ export default function ThemeTierBadge( {
 		isThemeActiveForSite,
 	] );
 
-	if ( ! badge ) {
+	if ( ! badge && ! isThemeActiveForSite ) {
 		return null;
 	}
 
@@ -127,6 +128,7 @@ export default function ThemeTierBadge( {
 				siteId={ siteId }
 				siteSlug={ siteSlug }
 			>
+				{ isThemeActiveForSite && <ThemeTierActiveBadge /> }
 				{ badge }
 			</ThemeTierBadgeContextProvider>
 		</div>

--- a/client/components/theme-tier/theme-tier-badge/style.scss
+++ b/client/components/theme-tier/theme-tier-badge/style.scss
@@ -54,6 +54,17 @@
 		white-space: nowrap;
 		font-size: $font-body-extra-small;
 	}
+
+	.theme-tier-active-label {
+		background-color: var(--color-primary);
+		border-radius: 4px;
+		color: var(--studio-white);
+		font-family: $sans;
+		font-size: $font-body-extra-small;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
 }
 
 .theme-tier-badge-tooltip,

--- a/client/components/theme-tier/theme-tier-badge/test/index.tsx
+++ b/client/components/theme-tier/theme-tier-badge/test/index.tsx
@@ -96,6 +96,20 @@ describe( 'ThemeTierBadge', () => {
 		expect( screen.getByText( 'Partner' ) ).toBeInTheDocument();
 	} );
 
+	it( 'should render the active badge when the theme is active on the site', () => {
+		render(
+			<ThemeTierBadge
+				themeId="twentysixteen"
+				siteId={ 123 }
+				siteSlug="test-site"
+				isLockedStyleVariation={ false }
+				isThemeActiveForSite
+			/>
+		);
+
+		expect( screen.getByText( 'Active' ) ).toBeInTheDocument();
+	} );
+
 	it( 'should render nothing for inactive & retired themes', () => {
 		const { container } = render(
 			<ThemeTierBadge

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-active-badge.jsx
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-active-badge.jsx
@@ -1,0 +1,14 @@
+import { Badge } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+
+export default function ThemeTierActiveBadge() {
+	const translate = useTranslate();
+
+	return (
+		<Badge type="info" className="theme-tier-active-label">
+			{ translate( 'Active', {
+				context: 'singular noun, the currently active theme',
+			} ) }
+		</Badge>
+	);
+}


### PR DESCRIPTION
Part of DOTTHEM-313
Fixes #53175

## Proposed Changes

* Add a new `ThemeTierActiveBadge` component that renders a dark "Active" pill using the shared `Badge` component.
* Update `ThemeTierBadge` to render the Active badge alongside the existing tier badge (Free, Included with plan, etc.) whenever `isThemeActiveForSite` is true, instead of replacing it.
* Add a unit test covering the new active-badge path.

## Why are these changes being made?

When viewing the single theme sheet for a theme that is already active on the selected site, there is no visual indication that the theme is active. The top-bar action changes from Activate to Customize, but customers consistently miss that signal and ask whether the theme is in use. The theme grid already shows an Active badge on the active theme, and WP Admin also surfaces an "Active Theme" label on the theme details view — this brings the same affordance to the Calypso single theme sheet while keeping the tier badge visible so the plan-tier context isn't lost.

## Screenshots

**Before** — Calypso single theme sheet, no Active badge:

<img src="https://raw.githubusercontent.com/Gustavo-Hilario/wpcomghdeploy/main/dotthem-313/before.png" width="800" alt="Calypso theme sheet before the change, showing only the Free tier badge">

**After** — Active badge renders alongside the tier badge:

<img src="https://raw.githubusercontent.com/Gustavo-Hilario/wpcomghdeploy/main/dotthem-313/after.png" width="800" alt="Calypso theme sheet after the change, showing the Active badge next to the Free tier badge">

**WP Admin parity** — the equivalent WP Admin theme details view already shows an "Active Theme" label:

<img src="https://raw.githubusercontent.com/Gustavo-Hilario/wpcomghdeploy/main/dotthem-313/wp-admin.png" width="800" alt="WP Admin theme details view showing the Active Theme label">

## Testing Instructions

* Pick a site you own and note its currently active theme slug.
* Navigate to the single theme sheet for the active theme (`/theme/<active-slug>/<site-slug>`). Expected: a dark "Active" pill renders in the header next to the existing tier badge (Free / Included with plan / etc.).
* Navigate to the single theme sheet for any non-active theme on the same site. Expected: only the tier badge renders — no Active pill.
* Try a retired theme that is still active on the site. Expected: the Active pill renders even though the tier badge is suppressed.
* Try a retired theme that is not active on the site. Expected: nothing renders (existing behavior preserved).
* Run `yarn test-client client/components/theme-tier/theme-tier-badge`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
