### PR TITLE
Fix split-screen publish button clipping

### DIFF
--- a/packages/agents-manager/src/components/agent-dock/style.scss
+++ b/packages/agents-manager/src/components/agent-dock/style.scss
@@ -383,6 +383,15 @@ body.post-new-php.agents-manager-sidebar-container {
 		@include sidebar-open-base( '.edit-post-layout' );
 		@include editor-save-panel-open();
 
+		// Split-screen clips the editor shell for rounded corners. Gutenberg's
+		// desktop header grid can otherwise push the settings group past that
+		// clipped shell, cutting off the Publish button at the chat boundary.
+		&.is-split-screen .editor-header:has( > .editor-header__center ) {
+			grid-template:
+				auto / 60px minmax( 0, max-content ) minmax( 0, 1fr ) minmax( 0, max-content )
+				60px;
+		}
+
 		.editor-post-publish-panel {
 			top: $layout-spacing;
 			bottom: $layout-spacing;


### PR DESCRIPTION
## Proposed Changes

  Fixes a split-screen layout issue where the Gutenberg `Publish` button can be clipped when Agents Manager is open in split-screen mode.

  In split-screen, Agents Manager narrows `.edit-post-layout` and clips it for rounded editor-shell corners. Gutenberg’s desktop header grid can still place `.editor-
  header__settings` past that clipped boundary, which cuts off the right edge of the Publish button at the chat boundary.

  This patch scopes a header-grid override to:

  - post editor only
  - Agents Manager sidebar open
  - split-screen mode only
  - headers that include `.editor-header__center`

  The `60px` edge tracks mirror Gutenberg’s current editor header grid, where `$header-height` is used for the first and last columns. The override keeps that structure and only
  makes the center/settings tracks shrink within the split-screen editor shell.

  This relies on the same `:has( > .editor-header__center )` selector shape already used by Gutenberg’s header CSS. If Gutenberg materially refactors the editor header grid or class
  names, this split-screen override should be re-verified.

## before
<img width="819" height="233" alt="image" src="https://github.com/user-attachments/assets/f52c15cb-8174-48ce-9a15-9ac524904171" />

## after
<img width="430" height="210" alt="image" src="https://github.com/user-attachments/assets/dfbaf8c0-0b46-4916-b82f-23118ca66849" />


  ## Testing Instructions

  1. Open the post editor.
  2. Open Agents Manager.
  3. Open the AI sidebar.
  4. Enable split-screen mode.
  5. Confirm the top editor bar remains visible and the `Publish` button is not clipped.
  6. Confirm normal/non-split Agents Manager mode is unchanged.
  7. Confirm the editor still behaves normally after closing Agents Manager.

  Tested locally:

  - `yarn stylelint packages/agents-manager/src/components/agent-dock/style.scss`
  - `yarn workspace @automattic/agents-manager-app build`