### PR TITLE
Themes: Extend slug-collision override to non-retired wpcom themes (DOTTHEM-150)

### DIFF
--- a/client/components/data/query-canonical-theme/index.jsx
+++ b/client/components/data/query-canonical-theme/index.jsx
@@ -2,17 +2,16 @@ import PropTypes from 'prop-types';
 import { Fragment } from 'react';
 import { connect } from 'react-redux';
 import QueryTheme from 'calypso/components/data/query-theme';
-import { isWpcomTheme } from 'calypso/state/themes/selectors';
+import { isWpcomTheme, isWporgTheme } from 'calypso/state/themes/selectors';
 
-const QueryCanonicalTheme = ( { siteId, themeId, isWpcom } ) => {
-	// Always fetch the site's theme record when a siteId is provided so that
-	// `getCanonicalTheme` can detect slug collisions between a WP.com catalog
-	// entry and a third-party theme installed on the site with the same slug.
+const QueryCanonicalTheme = ( { siteId, themeId, isWpcom, isWporg } ) => {
+	// Fetch the site's theme record once it can either resolve a collision with
+	// a WP.com catalog entry or serve as the fallback after WP.com/WP.org miss.
 	return (
 		<Fragment>
 			<QueryTheme themeId={ themeId } siteId="wpcom" />
 			{ ! isWpcom && <QueryTheme themeId={ themeId } siteId="wporg" /> }
-			{ siteId && <QueryTheme themeId={ themeId } siteId={ siteId } /> }
+			{ siteId && ( isWpcom || ! isWporg ) && <QueryTheme themeId={ themeId } siteId={ siteId } /> }
 		</Fragment>
 	);
 };
@@ -22,8 +21,10 @@ QueryCanonicalTheme.propTypes = {
 	themeId: PropTypes.string.isRequired,
 	// Connected propTypes
 	isWpcom: PropTypes.bool.isRequired,
+	isWporg: PropTypes.bool.isRequired,
 };
 
 export default connect( ( state, { themeId } ) => ( {
 	isWpcom: isWpcomTheme( state, themeId ),
+	isWporg: isWporgTheme( state, themeId ),
 } ) )( QueryCanonicalTheme );

--- a/client/components/data/query-canonical-theme/index.jsx
+++ b/client/components/data/query-canonical-theme/index.jsx
@@ -2,20 +2,17 @@ import PropTypes from 'prop-types';
 import { Fragment } from 'react';
 import { connect } from 'react-redux';
 import QueryTheme from 'calypso/components/data/query-theme';
-import { isWpcomTheme, isWporgTheme } from 'calypso/state/themes/selectors';
-import { knownConflictingThemes } from 'calypso/state/themes/selectors/get-canonical-theme';
+import { isWpcomTheme } from 'calypso/state/themes/selectors';
 
-const QueryCanonicalTheme = ( { siteId, themeId, isWpcom, isWporg } ) => {
-	// Conflicting themes are themes we always search Jetpack+Atomic sites for information about.
-	// Usually, it's only searched if we can't find info on both Wpcom and Wporg.
-	const isConflictingTheme = knownConflictingThemes.has( themeId );
+const QueryCanonicalTheme = ( { siteId, themeId, isWpcom } ) => {
+	// Always fetch the site's theme record when a siteId is provided so that
+	// `getCanonicalTheme` can detect slug collisions between a WP.com catalog
+	// entry and a third-party theme installed on the site with the same slug.
 	return (
 		<Fragment>
 			<QueryTheme themeId={ themeId } siteId="wpcom" />
 			{ ! isWpcom && <QueryTheme themeId={ themeId } siteId="wporg" /> }
-			{ ( ( ! isWpcom && ! isWporg ) || isConflictingTheme ) && siteId && (
-				<QueryTheme themeId={ themeId } siteId={ siteId } />
-			) }
+			{ siteId && <QueryTheme themeId={ themeId } siteId={ siteId } /> }
 		</Fragment>
 	);
 };
@@ -25,10 +22,8 @@ QueryCanonicalTheme.propTypes = {
 	themeId: PropTypes.string.isRequired,
 	// Connected propTypes
 	isWpcom: PropTypes.bool.isRequired,
-	isWporg: PropTypes.bool.isRequired,
 };
 
 export default connect( ( state, { themeId } ) => ( {
 	isWpcom: isWpcomTheme( state, themeId ),
-	isWporg: isWporgTheme( state, themeId ),
 } ) )( QueryCanonicalTheme );

--- a/client/state/themes/selectors/get-canonical-theme.js
+++ b/client/state/themes/selectors/get-canonical-theme.js
@@ -4,13 +4,6 @@ import { Theme } from 'calypso/types';
 import 'calypso/state/themes/init';
 
 /**
- * Slugs whose installed copy on a site typically differs from the WP.com
- * catalog entry with the same slug. Lookup order inverts to site-first for
- * these so we don't show the wrong theme's metadata. Maintain manually.
- */
-export const knownConflictingThemes = new Set( [ 'bistro' ] );
-
-/**
  * wpcomsh rewrites `theme_uri` to this prefix only for symlinked WP.com
  * themes (`wpcomsh_add_wpcom_suffix_to_theme_endpoint_response` filter).
  * It is the signal that distinguishes a managed WP.com copy of a slug from
@@ -29,21 +22,22 @@ function isSymlinkedManagedTheme( siteTheme ) {
 }
 
 /**
- * Resolves the slug-collision case where the WP.com catalog has a retired
- * record AND the site has a same-slug unmanaged record. Returns a merged
- * theme object (site display fields override wpcom, wpcom-shape fields
- * preserved for downstream consumers, `retired` cleared), or `null` when
- * the condition does not apply. Symlinked managed copies return `null` so
- * legitimately-retired premium themes keep their canonical record.
+ * Resolves the slug-collision case where the WP.com catalog has a record
+ * AND the site has a same-slug unmanaged record. Returns a merged theme
+ * object (site display fields override wpcom, wpcom-shape fields preserved
+ * for downstream consumers, `retired` cleared), or `null` when the
+ * condition does not apply. Symlinked managed copies return `null` so
+ * legitimately-installed WP.com themes keep their canonical record (and
+ * the retired notice when applicable).
  * @param  {Object} state   Global state tree
  * @param  {number} siteId  Site ID
  * @param  {string} themeId Theme ID
  * @returns {?Object}        Merged theme object, or `null`.
  */
-function getRetiredCollisionTheme( state, siteId, themeId ) {
+function getCollisionTheme( state, siteId, themeId ) {
 	const wpcomTheme = getTheme( state, 'wpcom', themeId );
 	const siteTheme = siteId ? getTheme( state, siteId, themeId ) : null;
-	if ( ! wpcomTheme?.retired || ! siteTheme || isSymlinkedManagedTheme( siteTheme ) ) {
+	if ( ! wpcomTheme || ! siteTheme || isSymlinkedManagedTheme( siteTheme ) ) {
 		return null;
 	}
 	return {
@@ -64,16 +58,12 @@ function getRetiredCollisionTheme( state, siteId, themeId ) {
  * @returns {?Theme}         Theme object
  */
 export function getCanonicalTheme( state, siteId, themeId ) {
-	let searchOrder = [ 'wpcom', 'wporg', siteId ];
-	if ( knownConflictingThemes.has( themeId ) ) {
-		searchOrder = [ siteId, 'wpcom', 'wporg' ];
-	}
-
-	const collisionMerge = getRetiredCollisionTheme( state, siteId, themeId );
+	const collisionMerge = getCollisionTheme( state, siteId, themeId );
 	if ( collisionMerge ) {
 		return collisionMerge;
 	}
 
+	const searchOrder = [ 'wpcom', 'wporg', siteId ];
 	const source = find( searchOrder, ( s ) => getTheme( state, s, themeId ) );
 	return getTheme( state, source, themeId );
 }

--- a/client/state/themes/selectors/get-canonical-theme.js
+++ b/client/state/themes/selectors/get-canonical-theme.js
@@ -10,6 +10,21 @@ import 'calypso/state/themes/init';
  * a manually uploaded third-party theme that happens to share the slug.
  */
 const SYMLINKED_THEME_URI_PREFIX = 'https://wordpress.com/theme/';
+const SITE_THEME_OVERRIDE_FIELDS = [ 'name', 'author', 'author_uri', 'theme_uri', 'version' ];
+const URL_OVERRIDE_FIELDS = new Set( [ 'author_uri', 'theme_uri' ] );
+
+function isSafeHttpUrl( url ) {
+	if ( typeof url !== 'string' ) {
+		return false;
+	}
+
+	try {
+		const parsedUrl = new URL( url );
+		return [ 'http:', 'https:' ].includes( parsedUrl.protocol );
+	} catch {
+		return false;
+	}
+}
 
 /**
  * Whether the site's theme record represents the symlinked WP.com-managed
@@ -18,7 +33,38 @@ const SYMLINKED_THEME_URI_PREFIX = 'https://wordpress.com/theme/';
  * @returns {boolean}
  */
 function isSymlinkedManagedTheme( siteTheme ) {
-	return Boolean( siteTheme?.theme_uri?.startsWith( SYMLINKED_THEME_URI_PREFIX ) );
+	const themeUri = siteTheme?.theme_uri;
+	return (
+		typeof themeUri === 'string' &&
+		themeUri.startsWith( SYMLINKED_THEME_URI_PREFIX ) &&
+		themeUri.length > SYMLINKED_THEME_URI_PREFIX.length
+	);
+}
+
+function getSafeSiteOverride( field, siteTheme, wpcomTheme ) {
+	const siteValue = siteTheme[ field ];
+	if ( siteValue == null ) {
+		return wpcomTheme[ field ];
+	}
+
+	if ( URL_OVERRIDE_FIELDS.has( field ) && ! isSafeHttpUrl( siteValue ) ) {
+		return wpcomTheme[ field ];
+	}
+
+	return siteValue;
+}
+
+function mergeCollisionTheme( wpcomTheme, siteTheme ) {
+	return {
+		...wpcomTheme,
+		...Object.fromEntries(
+			SITE_THEME_OVERRIDE_FIELDS.map( ( field ) => [
+				field,
+				getSafeSiteOverride( field, siteTheme, wpcomTheme ),
+			] )
+		),
+		retired: false,
+	};
 }
 
 /**
@@ -40,11 +86,7 @@ function getCollisionTheme( state, siteId, themeId ) {
 	if ( ! wpcomTheme || ! siteTheme || isSymlinkedManagedTheme( siteTheme ) ) {
 		return null;
 	}
-	return {
-		...wpcomTheme,
-		...siteTheme,
-		retired: false,
-	};
+	return mergeCollisionTheme( wpcomTheme, siteTheme );
 }
 
 /**

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -357,7 +357,7 @@ describe( 'themes selectors', () => {
 			expect( theme ).toEqual( retiredWpcomPinboard );
 		} );
 
-		test( 'when wpcom record is not retired, returns the wpcom record even if the site has its own copy', () => {
+		test( 'when wpcom record is not retired and the site has its own installed theme with the same slug, merges site fields over wpcom (DOTTHEM-150)', () => {
 			const wpcomTwentySixteen = { ...twentysixteen };
 			const sideloadedTwentySixteen = {
 				id: 'twentysixteen',
@@ -374,6 +374,37 @@ describe( 'themes selectors', () => {
 							} ),
 							2916284: new ThemeQueryManager( {
 								items: { twentysixteen: sideloadedTwentySixteen },
+							} ),
+						},
+					},
+				},
+				2916284,
+				'twentysixteen'
+			);
+
+			expect( theme.name ).toEqual( 'Twenty Sixteen (local)' );
+			expect( theme.author ).toEqual( 'unrelated' );
+			expect( theme.retired ).toBe( false );
+		} );
+
+		test( 'when wpcom record is not retired and the site has the symlinked wpcom-managed copy, still returns the wpcom record (no regression)', () => {
+			const wpcomTwentySixteen = { ...twentysixteen };
+			const symlinkedTwentySixteen = {
+				id: 'twentysixteen',
+				name: 'Twenty Sixteen',
+				author: 'WordPress.com',
+				theme_uri: 'https://wordpress.com/theme/twentysixteen',
+			};
+
+			const theme = getCanonicalTheme(
+				{
+					themes: {
+						queries: {
+							wpcom: new ThemeQueryManager( {
+								items: { twentysixteen: wpcomTwentySixteen },
+							} ),
+							2916284: new ThemeQueryManager( {
+								items: { twentysixteen: symlinkedTwentySixteen },
 							} ),
 						},
 					},

--- a/client/state/themes/test/selectors.js
+++ b/client/state/themes/test/selectors.js
@@ -358,11 +358,26 @@ describe( 'themes selectors', () => {
 		} );
 
 		test( 'when wpcom record is not retired and the site has its own installed theme with the same slug, merges site fields over wpcom (DOTTHEM-150)', () => {
-			const wpcomTwentySixteen = { ...twentysixteen };
+			const wpcomTwentySixteen = {
+				...twentysixteen,
+				download: 'https://wordpress.com/theme/twentysixteen.zip',
+				descriptionLong: '<p>Canonical long description.</p>',
+				supportDocumentation: '<p>Canonical support docs.</p>',
+				taxonomies: {
+					theme_feature: [ { slug: 'block-editor-styles' } ],
+				},
+			};
 			const sideloadedTwentySixteen = {
 				id: 'twentysixteen',
 				name: 'Twenty Sixteen (local)',
 				author: 'unrelated',
+				author_uri: 'https://example.com/theme-author',
+				stylesheet: undefined,
+				download: undefined,
+				descriptionLong: '<img src=x onerror=alert(1)>',
+				supportDocumentation: '<img src=x onerror=alert(1)>',
+				taxonomies: undefined,
+				theme_tier: undefined,
 			};
 
 			const theme = getCanonicalTheme(
@@ -382,9 +397,52 @@ describe( 'themes selectors', () => {
 				'twentysixteen'
 			);
 
-			expect( theme.name ).toEqual( 'Twenty Sixteen (local)' );
-			expect( theme.author ).toEqual( 'unrelated' );
-			expect( theme.retired ).toBe( false );
+			expect( theme ).toMatchObject( {
+				name: 'Twenty Sixteen (local)',
+				author: 'unrelated',
+				author_uri: 'https://example.com/theme-author',
+				stylesheet: 'pub/twentysixteen',
+				download: 'https://wordpress.com/theme/twentysixteen.zip',
+				descriptionLong: '<p>Canonical long description.</p>',
+				supportDocumentation: '<p>Canonical support docs.</p>',
+				taxonomies: {
+					theme_feature: [ { slug: 'block-editor-styles' } ],
+				},
+				theme_tier: freeThemeTier,
+				retired: false,
+			} );
+		} );
+
+		test( 'when a colliding site theme has an unsafe author URL, ignores the site author URL', () => {
+			const wpcomTwentySixteen = {
+				...twentysixteen,
+				author_uri: 'https://wordpress.org/',
+			};
+			const sideloadedTwentySixteen = {
+				id: 'twentysixteen',
+				name: 'Twenty Sixteen (local)',
+				author: 'unrelated',
+				author_uri: 'javascript:alert(1)',
+			};
+
+			const theme = getCanonicalTheme(
+				{
+					themes: {
+						queries: {
+							wpcom: new ThemeQueryManager( {
+								items: { twentysixteen: wpcomTwentySixteen },
+							} ),
+							2916284: new ThemeQueryManager( {
+								items: { twentysixteen: sideloadedTwentySixteen },
+							} ),
+						},
+					},
+				},
+				2916284,
+				'twentysixteen'
+			);
+
+			expect( theme.author_uri ).toBe( 'https://wordpress.org/' );
 		} );
 
 		test( 'when wpcom record is not retired and the site has the symlinked wpcom-managed copy, still returns the wpcom record (no regression)', () => {
@@ -414,6 +472,36 @@ describe( 'themes selectors', () => {
 			);
 
 			expect( theme ).toEqual( wpcomTwentySixteen );
+		} );
+
+		test( 'when site theme_uri equals the symlink prefix without a slug, treats it as an unmanaged collision', () => {
+			const wpcomTwentySixteen = { ...twentysixteen };
+			const sideloadedTwentySixteen = {
+				id: 'twentysixteen',
+				name: 'Twenty Sixteen (local)',
+				author: 'unrelated',
+				theme_uri: 'https://wordpress.com/theme/',
+			};
+
+			const theme = getCanonicalTheme(
+				{
+					themes: {
+						queries: {
+							wpcom: new ThemeQueryManager( {
+								items: { twentysixteen: wpcomTwentySixteen },
+							} ),
+							2916284: new ThemeQueryManager( {
+								items: { twentysixteen: sideloadedTwentySixteen },
+							} ),
+						},
+					},
+				},
+				2916284,
+				'twentysixteen'
+			);
+
+			expect( theme.name ).toBe( 'Twenty Sixteen (local)' );
+			expect( theme.retired ).toBe( false );
 		} );
 	} );
 


### PR DESCRIPTION
Part of Automattic/wp-calypso#56179  <br>Fixes Automattic/wp-calypso#56179

> **Note:** Builds on top of Automattic/wp-calypso#110568 (Automattic/wp-calypso#57539). The base branch of this PR is set to that branch — please review Automattic/wp-calypso#110568 first. After Automattic/wp-calypso#110568 merges to trunk, this PR will be rebased onto trunk and the base updated.

## Proposed Changes

* Extend the slug-collision override added in Automattic/wp-calypso#110568 so it also fires when the [WP.com](<http://WP.com>) record is **not** retired. The site's installed theme record wins for display fields whenever it exists and is not a symlinked WP.com-managed copy.
* Drop the `knownConflictingThemes` allowlist (previously hardcoded to `['bistro']`). The same code path now handles every collision generically.
* `QueryCanonicalTheme` always fetches the site's theme record when a siteId is provided so `getCanonicalTheme` has the data it needs to detect a collision. The previous gating left the site record unfetched in the common case, which would have silently hidden the bug.
* Update the existing "non-retired same-slug" unit test to assert site override + add a new test covering the non-retired symlinked-managed-copy no-regression path.

## Why are these changes being made?

Automattic/wp-calypso#110568 fixes the slug-collision rendering bug only when the [WP.com](<http://WP.com>) record is **retired**. Automattic/wp-calypso#56179 / Automattic/wp-calypso#56179 is the same bug class against a **non-retired** [WP.com](<http://WP.com>) record: customers who install a third-party theme on a slug that matches a live [WP.com](<http://WP.com>) theme see the [WP.com](<http://WP.com>) theme's metadata in Calypso, while WP-Admin correctly shows the locally-installed `style.css` data.

The fix is the same code path with one fewer condition. The `theme_uri` symlink check from Automattic/wp-calypso#110568 remains the real safety mechanism: legitimately-installed [WP.com](<http://WP.com>) themes (managed copies) continue to render the canonical record because their record has the `https://wordpress.com/theme/` prefix.

## Screenshots

Tested on an Atomic site (`premium.groovytestsite.blog`) with a mock third-party `traveler` theme installed over the `traveler` slug.

**Before** — Calypso shows the [WP.com](<http://WP.com>) Traveler record by "Pro Theme Design" with a retired notice, even though the theme actually installed on disk is unrelated:

<img src="https://raw.githubusercontent.com/Gustavo-Hilario/wpcomghdeploy/main/dotthem-150/before.png?v=2 " alt="Calypso theme sheet before the change, showing the WP.com Traveler record" width="800" />

**After** — Calypso shows the installed theme: name "Traveler", author "Shinetheme (TEST)", description from local `style.css`. No retired notice:

<img src="https://raw.githubusercontent.com/Gustavo-Hilario/wpcomghdeploy/main/dotthem-150/after.png?v=2 " alt="Calypso theme sheet after the change, showing the installed third-party Traveler record" width="800" />

## Testing Instructions

Reproduce on an Atomic site with shell access:

1. Drop a minimal theme into the site filesystem at `/srv/htdocs/wp-content/themes/<colliding-slug>/` with a `style.css` whose `Theme Name` matches a non-retired [WP.com](<http://WP.com>) slug (e.g. `traveler`) and a distinctive `Author` value.
2. Activate the theme via WP-CLI (`wp theme activate <colliding-slug>`) so the site's record is the locally-installed one, not the symlinked WP.com-managed copy.
3. In Calypso, visit `/theme/<colliding-slug>/<site-slug>`.

Before this change:

* The theme sheet shows the [WP.com](<http://WP.com>) record's name, author, screenshot, and description.
* If the [WP.com](<http://WP.com>) record is retired, the yellow retired notice is also shown.

After this change:

* The theme sheet shows the installed theme's name, author, and description.
* No retired notice.

To verify the symlink-aware narrowing (no regression for legitimately-installed [WP.com](<http://WP.com>) themes):

1. On an Atomic site, install a non-retired [WP.com](<http://WP.com>) premium theme via `wp wpcomsh theme use-managed <slug>` (creates a symlink to the managed copy).
2. In Calypso, visit `/theme/<slug>/<site-slug>`.
3. Confirm the canonical [WP.com](<http://WP.com>) record is still shown (the symlinked theme has `theme_uri = https://wordpress.com/theme/<slug>`).

Unit tests:

```
yarn test-client client/state/themes/test/selectors.js -t getCanonicalTheme
```

All eight cases under `#getCanonicalTheme()` should pass — the four retired-collision cases from Automattic/wp-calypso#110568, the new non-retired-collision case, the new non-retired-symlinked-managed-copy no-regression case, and the two original baseline cases.

## Pre-merge Checklist

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] [Have you written new tests](<https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md>) for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](<https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md>)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](<https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md>) and [Using memoizing selectors](<https://react-redux.js.org/api/hooks#using-memoizing-selectors>) and [Our Approach to Data](<https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md>)
- [ ] Have we added the "\[Status\] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
  - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "\[Status\] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?