### PR TITLE
Help Center: extend logged-out FAB to /patterns, /site-profiler, /speed-test-tool

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -80,7 +80,14 @@ const loadSupportArticleDialog = () =>
 		/* webpackChunkName: "async-load-calypso-blocks-support-article-dialog" */ 'calypso/blocks/support-article-dialog'
 	);
 
-const HELP_CENTER_FAB_SECTIONS = [ 'plugins', 'theme', 'themes' ];
+const HELP_CENTER_FAB_SECTIONS = [
+	'patterns',
+	'performance-profiler',
+	'plugins',
+	'site-profiler',
+	'theme',
+	'themes',
+];
 
 const LayoutLoggedOut = ( {
 	isAkismet,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -39,6 +39,7 @@
 		"global-styles/on-personal-plan": true,
 		"google-my-business": false,
 		"help": true,
+		"help-center/logged-out-fab": true,
 		"home/layout-dev": true,
 		"hosting-server-settings-enhancements": true,
 		"i18n/empathy-mode": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -51,6 +51,7 @@
 		"google-my-business": true,
 		"help": true,
 		"help-center/logged-out": true,
+		"help-center/logged-out-fab": true,
 		"help/gpt-response": true,
 		"hosting-server-settings-enhancements": true,
 		"i18n/empathy-mode": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -51,7 +51,6 @@
 		"google-my-business": true,
 		"help": true,
 		"help-center/logged-out": true,
-		"help-center/logged-out-fab": true,
 		"help/gpt-response": true,
 		"hosting-server-settings-enhancements": true,
 		"i18n/empathy-mode": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -55,6 +55,7 @@
 		"google-my-business": true,
 		"help": true,
 		"help-center/logged-out": true,
+		"help-center/logged-out-fab": true,
 		"help/gpt-response": true,
 		"home/layout-dev": true,
 		"hosting-server-settings-enhancements": true,


### PR DESCRIPTION
Part of HAP-2841. Follow-up to #110752.

## Proposed Changes

* Extend `HELP_CENTER_FAB_SECTIONS` in `client/layout/logged-out.jsx` so the logged-out Help Center FAB also renders on:
  * `/patterns` (section `patterns`)
  * `/site-profiler` (section `site-profiler`)
  * `/speed-test-tool` (section `performance-profiler`)
* Enable `help-center/logged-out-fab` in `config/wpcalypso.json` and `config/horizon.json`. Stage and production remain off; stage will follow in a separate change after soaking on wpcalypso/horizon.

## Why are these changes being made?

#110752 introduced the logged-out FAB on `/themes`, `/theme`, and `/plugins`. These three additional surfaces are the other showcase / marketing routes that already allow logged-out visitors (`enableLoggedOut: true` in `client/sections.js`) and don't yet have an in-app help affordance for them.

Flipping the flag on `wpcalypso` and `horizon` lets us exercise the FAB on real internal traffic before we consider enabling it more broadly.

## Testing Instructions

In an Incognito window (logged out):

1. With the flag enabled locally (default in `development.json`), visit each of:
   * `http://calypso.localhost:3000/patterns`
   * `http://calypso.localhost:3000/site-profiler`
   * `http://calypso.localhost:3000/speed-test-tool`
2. Confirm the blue circular question-mark FAB appears in the bottom-end corner on each page.
3. Click the FAB → Help Center panel slides in, anchored 8px above the FAB.
4. Click again → panel closes, no leftover `role="dialog"` element in the DOM.
5. Log in (or visit any other route) → FAB does not render; masterbar help control still works as before.
6. With `?flags=-help-center/logged-out-fab` the FAB disappears on all three routes.

After deploy, sanity-check on `wpcalypso.com` and `horizon.wordpress.com` that the FAB now renders on `/themes`, `/plugins`, `/patterns`, `/site-profiler`, and `/speed-test-tool` while logged out. Production should remain unaffected.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed?
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [x] Have you tested accessibility for your changes? Same FAB component as #110752 (`aria-haspopup`, `aria-expanded`, keyboard-focus ring).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
