### PR TITLE
Help Center: extend logged-out FAB to /accept-invite, /me/account/closed

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -82,7 +82,6 @@ const loadSupportArticleDialog = () =>
 
 const HELP_CENTER_FAB_SECTIONS = [
 	'accept-invite',
-	'account-close',
 	'login',
 	'patterns',
 	'performance-profiler',
@@ -91,6 +90,9 @@ const HELP_CENTER_FAB_SECTIONS = [
 	'theme',
 	'themes',
 ];
+
+// Fallback when section name is unreliable — e.g. /me/account/closed activates as 'me'.
+const HELP_CENTER_FAB_ROUTES = [ '/me/account/closed' ];
 
 const LayoutLoggedOut = ( {
 	isAkismet,
@@ -172,7 +174,8 @@ const LayoutLoggedOut = ( {
 	const showHelpCenterFab =
 		! isLoggedIn &&
 		isEnabled( 'help-center/logged-out-fab' ) &&
-		HELP_CENTER_FAB_SECTIONS.includes( sectionName ) &&
+		( HELP_CENTER_FAB_SECTIONS.includes( sectionName ) ||
+			HELP_CENTER_FAB_ROUTES.includes( currentRoute ) ) &&
 		userAllowedToHelpCenter;
 
 	const loadHelpCenter =

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -81,6 +81,9 @@ const loadSupportArticleDialog = () =>
 	);
 
 const HELP_CENTER_FAB_SECTIONS = [
+	'accept-invite',
+	'account-close',
+	'login',
 	'patterns',
 	'performance-profiler',
 	'plugins',

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -82,7 +82,6 @@ const loadSupportArticleDialog = () =>
 
 const HELP_CENTER_FAB_SECTIONS = [
 	'accept-invite',
-	'login',
 	'patterns',
 	'performance-profiler',
 	'plugins',


### PR DESCRIPTION
Part of HAP-2869. Follow-up to #110752 and #110777. Companion to #110780 (which handles `/log-in`).

## Proposed Changes

Extend the logged-out Help Center FAB to two more routes:

* `accept-invite` — `/accept-invite/:site_id/:invitation_key/...` — added to `HELP_CENTER_FAB_SECTIONS`.
* `/me/account/closed` — added to a new `HELP_CENTER_FAB_ROUTES` array (matched by `currentRoute`) because the section name is overwritten by the broader `me` section at render time.

`/me/account/closed` can't be matched by section name: `pathToRegExp` in `client/utils.ts:11` produces `^path(/.*)?$`, so the broader `me` section (`paths: ['/me']`) also matches the URL. `me` is registered after `account-close` in `client/sections.js`, so its loader activates last and the section ends up as `me` at render time. Matching on `currentRoute` sidesteps this.

`/log-in` is handled in #110780 alongside the `QueryClientProvider` fix that route needs.

## Why are these changes being made?

HAP-2869 tracks rolling the logged-out Help Center FAB to the remaining dotcom logged-out surfaces. These two routes render under `LayoutLoggedOut` and have no existing help affordance.

Routes deliberately out of scope:

* `/purchase-product` — `client/my-sites/purchase-product/controller.jsx:46` hard-redirects logged-out visitors to `/log-in`, so they never reach the page.
* `/setup` (stepper) — already integrates its own `AsyncHelpCenterApp` and isn't wrapped by `LayoutLoggedOut`.
* `/checkout` and `/start` (signup) — already have their own in-flow help patterns (`useCheckoutHelpCenter`, `HelpCenterStepButton`); addressing those is a separate UX decision.
* `/mailing-lists/unsubscribe` and `/incoming-redirect` — too transient to warrant the FAB.

Production rollout follows the same gate as the prior PRs: `help-center/logged-out-fab` config flag (currently enabled in `development`, `wpcalypso`, and `horizon`).

## Testing Instructions

In an Incognito window (logged out):

1. Visit `http://calypso.localhost:3000/me/account/closed`. Confirm the FAB renders alongside the account-restore form. Click it → Help Center panel opens.
2. Generate a real invite link: log into a site in another browser, **People → Add User**, copy the invitation URL, open it in incognito. Confirm the FAB renders on the invite-accept form.
3. Log in (or visit a route the layout treats as `isLoggedIn`) → FAB does not render; existing masterbar help control still works as before.
4. With `?flags=-help-center/logged-out-fab` the FAB disappears on both routes.

After deploy, sanity-check on `wpcalypso.com` and `horizon.wordpress.com` that the FAB now also renders on `/me/account/closed` and a real invite link while logged out. Production is still gated off.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed?
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [x] Have you tested accessibility for your changes? Same FAB component as #110752 (`aria-haspopup`, `aria-expanded`, keyboard-focus ring).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
