### PR TITLE
Help Center: enable logged-out FAB on /log-in

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -82,6 +82,7 @@ const loadSupportArticleDialog = () =>
 
 const HELP_CENTER_FAB_SECTIONS = [
 	'accept-invite',
+	'login',
 	'mailing-lists',
 	'patterns',
 	'performance-profiler',

--- a/client/login/index.web.jsx
+++ b/client/login/index.web.jsx
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { getLanguageRouteParam } from '@automattic/i18n-utils';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { Provider as ReduxProvider } from 'react-redux';
 import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
 import { RouteProvider } from 'calypso/components/route';
@@ -33,6 +34,7 @@ export const LOGIN_SECTION_DEFINITION = {
 
 const ReduxWrappedLayout = ( {
 	store,
+	queryClient,
 	currentSection,
 	currentRoute,
 	currentQuery,
@@ -49,14 +51,16 @@ const ReduxWrappedLayout = ( {
 				currentRoute={ currentRoute }
 				currentQuery={ currentQuery }
 			>
-				<ReduxProvider store={ store }>
-					<LayoutLoggedOut
-						primary={ primary }
-						secondary={ secondary }
-						redirectUri={ redirectUri }
-						showGdprBanner={ showGdprBanner }
-					/>
-				</ReduxProvider>
+				<QueryClientProvider client={ queryClient }>
+					<ReduxProvider store={ store }>
+						<LayoutLoggedOut
+							primary={ primary }
+							secondary={ secondary }
+							redirectUri={ redirectUri }
+							showGdprBanner={ showGdprBanner }
+						/>
+					</ReduxProvider>
+				</QueryClientProvider>
 			</RouteProvider>
 		</CalypsoI18nProvider>
 	);


### PR DESCRIPTION
Part of HAP-2869. Companion to #110778.

## Proposed Changes

* Add `<QueryClientProvider client={ queryClient }>` to `client/login/index.web.jsx`'s custom `ReduxWrappedLayout`. The `queryClient` is already passed in by `makeLayoutMiddleware`; this just consumes it. Brings the login wrapper in line with the standard `ProviderWrappedLayout` in `client/controller/index.web.jsx`.
* Add `'login'` to `HELP_CENTER_FAB_SECTIONS` in `client/layout/logged-out.jsx` so the logged-out Help Center FAB renders on `/log-in`.

## Why are these changes being made?

`/log-in` uses a bespoke layout wrapper that omits `<QueryClientProvider>`. Anything in the login tree that mounts a TanStack Query hook currently throws:

> Error: No QueryClient set, use QueryClientProvider to set one

The logged-out Help Center FAB (introduced in #110752) lazily mounts a `HelpCenter` component that calls `useQuery` internally, so without the provider the FAB crashes on `/log-in`. The two changes are paired here so `/log-in` lands working in a single PR.

The remaining HAP-2869 routes (`/accept-invite`, `/me/account/closed`) live in #110778, which only depends on the FAB array.

## Testing Instructions

In an Incognito window (logged out), with `help-center/logged-out-fab` enabled (default in `development.json`):

1. Visit `http://calypso.localhost:3000/log-in`. Confirm:
   * Login form renders normally with no `No QueryClient set` errors in the console.
   * Blue question-mark FAB appears in the bottom-end corner.
   * Click the FAB → Help Center panel slides in.
   * Click again → panel closes.
2. Sanity-check `/log-in/jetpack`, magic-login, and the QR-code login pages — no regressions.
3. Log in → FAB does not render; existing masterbar help control still works as before.
4. With `?flags=-help-center/logged-out-fab` the FAB disappears.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed?
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [x] Have you tested accessibility for your changes? Same FAB component as #110752 (`aria-haspopup`, `aria-expanded`, keyboard-focus ring).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
