### PR TITLE
Help Center: extend logged-out FAB to /mailing-lists/unsubscribe

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -82,6 +82,7 @@ const loadSupportArticleDialog = () =>
 
 const HELP_CENTER_FAB_SECTIONS = [
 	'accept-invite',
+	'mailing-lists',
 	'patterns',
 	'performance-profiler',
 	'plugins',


### PR DESCRIPTION
Part of HAP-2869. Follow-up to #110752 and #110778.

## Proposed Changes

Adds `'mailing-lists'` to `HELP_CENTER_FAB_SECTIONS` in `client/layout/logged-out.jsx` so the logged-out Help Center FAB renders on `/mailing-lists/unsubscribe`.

## Why are these changes being made?

`/mailing-lists/unsubscribe` auto-unsubscribes on mount, which works fine for the happy path. The trouble is the silent-failure paths:

* Malformed or expired `hmac`, mismatched `email`/`category`, or API failure → \`deleteSubscriber\` rejects, an `errorNotice` fires, but the page stays on "You're subscribed". The notice is transient and easy to miss.
* The in-page "Manage all your email subscriptions" button redirects to `/me/notifications/updates`, which requires login. Logged-out visitors who don't have an account, or don't want to log in, hit a dead end.

These users currently have no in-page help affordance. Adding the FAB lets them search Help Center or contact support without losing context. The happy-path cost is one small floating button.

## Testing Instructions

In an Incognito window (logged out), with `help-center/logged-out-fab` enabled (default in `development.json`):

1. **Error path** — visit:
   ```
   http://calypso.localhost:3000/mailing-lists/unsubscribe?email=test@example.com&category=marketing&hmac=fake
   ```
   The page shows "You're subscribed" with an error notice. Confirm the blue question-mark FAB appears in the bottom-end corner. Click it → Help Center panel slides in.
2. **Happy path** — open any real WordPress.com mailing-list email, copy the unsubscribe link, swap the host for `calypso.localhost:3000`, open in incognito. The page should show "We've unsubscribed your email" and the FAB renders alongside the Resubscribe button.
3. Log in (or visit a route the layout treats as `isLoggedIn`) → FAB does not render; existing masterbar help control still works as before.
4. With `?flags=-help-center/logged-out-fab` the FAB disappears.

After deploy, sanity-check on `wpcalypso.com` and `horizon.wordpress.com` that the FAB renders on `/mailing-lists/unsubscribe` while logged out. Production is still gated off.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed?
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [x] Have you tested accessibility for your changes? Same FAB component as #110752 (`aria-haspopup`, `aria-expanded`, keyboard-focus ring).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?

🤖 Generated with [Claude Code](https://claude.com/claude-code)