### PR TITLE
Add A4A payment-risk notice banner

### DIFF
--- a/client/a8c-for-agencies/components/payment-risk-notice-banner/constants.ts
+++ b/client/a8c-for-agencies/components/payment-risk-notice-banner/constants.ts
@@ -1,0 +1,9 @@
+import { isEnabled } from '@automattic/calypso-config';
+
+export const PAYMENT_RISK_NOTICE_BANNER_FLAG = 'a4a-payment-risk-notice-banner';
+
+export type PaymentRiskNoticeSeverity = 'warning' | 'error';
+
+export const PAYMENT_RISK_NOTICE_SEVERITY: PaymentRiskNoticeSeverity = 'error';
+
+export const isPaymentRiskNoticeBannerEnabled = () => isEnabled( PAYMENT_RISK_NOTICE_BANNER_FLAG );

--- a/client/a8c-for-agencies/components/payment-risk-notice-banner/index.tsx
+++ b/client/a8c-for-agencies/components/payment-risk-notice-banner/index.tsx
@@ -72,7 +72,15 @@ export default function PaymentRiskNoticeBanner( {
 	}
 
 	const fixPaymentMethodCta = (
-		<Button key="update-payment-method" variant="primary" href={ ctaUrl } onClick={ onCtaClick }>
+		<Button
+			key="update-payment-method"
+			variant="primary"
+			href={ ctaUrl }
+			onClick={ onCtaClick }
+			target="_blank"
+			rel="noopener noreferrer"
+			__next40pxDefaultSize
+		>
 			{ translate( 'Fix payment method' ) }
 		</Button>
 	);
@@ -83,6 +91,7 @@ export default function PaymentRiskNoticeBanner( {
 			variant="secondary"
 			href={ CONTACT_URL_HASH_FRAGMENT }
 			onClick={ onContactUsClick }
+			__next40pxDefaultSize
 		>
 			{ translate( 'Contact us' ) }
 		</Button>

--- a/client/a8c-for-agencies/components/payment-risk-notice-banner/index.tsx
+++ b/client/a8c-for-agencies/components/payment-risk-notice-banner/index.tsx
@@ -1,7 +1,10 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { HelpCenter } from '@automattic/data-stores';
 import { Button } from '@wordpress/components';
+import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, type MouseEvent } from 'react';
+import { CONTACT_URL_HASH_FRAGMENT } from 'calypso/a8c-for-agencies/components/a4a-contact-support-widget';
 import LayoutBanner from 'calypso/a8c-for-agencies/components/layout/banner';
 import {
 	A4A_PAYMENT_METHODS_LINK,
@@ -12,6 +15,8 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isPaymentRiskNoticeBannerEnabled } from './constants';
 
 import './style.scss';
+
+const HELP_CENTER_STORE = HelpCenter.register();
 
 type PaymentRiskNoticeBannerProps = {
 	isFullWidth?: boolean;
@@ -24,6 +29,7 @@ export default function PaymentRiskNoticeBanner( {
 }: PaymentRiskNoticeBannerProps ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const { setShowHelpCenter, setNavigateToRoute } = useDataStoreDispatch( HELP_CENTER_STORE );
 	const isPaymentRiskNoticeEnabled = isPaymentRiskNoticeBannerEnabled();
 	const ctaUrl = isEnabled( 'a4a-bd-checkout' )
 		? EXTERNAL_WPCOM_PAYMENT_METHODS_URL
@@ -47,13 +53,38 @@ export default function PaymentRiskNoticeBanner( {
 		);
 	}, [ dispatch, source ] );
 
+	const onContactUsClick = useCallback(
+		( event: MouseEvent< HTMLAnchorElement > ) => {
+			event.preventDefault();
+			setShowHelpCenter( true );
+			setNavigateToRoute( '/contact-form' );
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_payment_risk_notice_banner_contact_us_click', {
+					source,
+				} )
+			);
+		},
+		[ dispatch, setNavigateToRoute, setShowHelpCenter, source ]
+	);
+
 	if ( ! isPaymentRiskNoticeEnabled ) {
 		return null;
 	}
 
-	const cta = (
+	const fixPaymentMethodCta = (
 		<Button key="update-payment-method" variant="primary" href={ ctaUrl } onClick={ onCtaClick }>
-			{ translate( 'Update payment method' ) }
+			{ translate( 'Fix payment method' ) }
+		</Button>
+	);
+
+	const contactUsCta = (
+		<Button
+			key="contact-us"
+			variant="secondary"
+			href={ CONTACT_URL_HASH_FRAGMENT }
+			onClick={ onContactUsClick }
+		>
+			{ translate( 'Contact us' ) }
 		</Button>
 	);
 
@@ -62,15 +93,15 @@ export default function PaymentRiskNoticeBanner( {
 			isFullWidth={ isFullWidth }
 			className="a4a-payment-risk-notice-banner"
 			level="error"
-			title={ translate( 'Payment issue needs attention' ) }
-			actions={ [ cta ] }
+			title={ translate( 'Action required: We’re unable to renew your subscription(s)' ) }
+			actions={ [ fixPaymentMethodCta, contactUsCta ] }
 			hideCloseButton
 			allowTemporaryDismissal
 			preferenceName="a4a-payment-risk-notice-banner-temporary-dismissed"
 		>
 			<div>
 				{ translate(
-					'Your agency has a payment issue. Update your payment method to avoid service interruption.'
+					'We couldn’t process payment for one or more of your subscriptions with the payment method we have on file. If this isn’t resolved, your subscriptions will be cancelled and your sites may go offline. Please update your payment method to stay covered.'
 				) }
 			</div>
 		</LayoutBanner>

--- a/client/a8c-for-agencies/components/payment-risk-notice-banner/index.tsx
+++ b/client/a8c-for-agencies/components/payment-risk-notice-banner/index.tsx
@@ -1,0 +1,78 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useEffect } from 'react';
+import LayoutBanner from 'calypso/a8c-for-agencies/components/layout/banner';
+import {
+	A4A_PAYMENT_METHODS_LINK,
+	EXTERNAL_WPCOM_PAYMENT_METHODS_URL,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { isPaymentRiskNoticeBannerEnabled } from './constants';
+
+import './style.scss';
+
+type PaymentRiskNoticeBannerProps = {
+	isFullWidth?: boolean;
+	source: string;
+};
+
+export default function PaymentRiskNoticeBanner( {
+	isFullWidth,
+	source,
+}: PaymentRiskNoticeBannerProps ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const isPaymentRiskNoticeEnabled = isPaymentRiskNoticeBannerEnabled();
+	const ctaUrl = isEnabled( 'a4a-bd-checkout' )
+		? EXTERNAL_WPCOM_PAYMENT_METHODS_URL
+		: A4A_PAYMENT_METHODS_LINK;
+
+	useEffect( () => {
+		if ( isPaymentRiskNoticeEnabled ) {
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_payment_risk_notice_banner_view', {
+					source,
+				} )
+			);
+		}
+	}, [ dispatch, isPaymentRiskNoticeEnabled, source ] );
+
+	const onCtaClick = useCallback( () => {
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_payment_risk_notice_banner_cta_click', {
+				source,
+			} )
+		);
+	}, [ dispatch, source ] );
+
+	if ( ! isPaymentRiskNoticeEnabled ) {
+		return null;
+	}
+
+	const cta = (
+		<Button key="update-payment-method" variant="primary" href={ ctaUrl } onClick={ onCtaClick }>
+			{ translate( 'Update payment method' ) }
+		</Button>
+	);
+
+	return (
+		<LayoutBanner
+			isFullWidth={ isFullWidth }
+			className="a4a-payment-risk-notice-banner"
+			level="error"
+			title={ translate( 'Payment issue needs attention' ) }
+			actions={ [ cta ] }
+			hideCloseButton
+			allowTemporaryDismissal
+			preferenceName="a4a-payment-risk-notice-banner-temporary-dismissed"
+		>
+			<div>
+				{ translate(
+					'Your agency has a payment issue. Update your payment method to avoid service interruption.'
+				) }
+			</div>
+		</LayoutBanner>
+	);
+}

--- a/client/a8c-for-agencies/components/payment-risk-notice-banner/menu-indicator.tsx
+++ b/client/a8c-for-agencies/components/payment-risk-notice-banner/menu-indicator.tsx
@@ -1,0 +1,28 @@
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import type { PaymentRiskNoticeSeverity } from './constants';
+
+import './style.scss';
+
+type PaymentRiskNoticeMenuIndicatorProps = {
+	severity: PaymentRiskNoticeSeverity;
+};
+
+export default function PaymentRiskNoticeMenuIndicator( {
+	severity,
+}: PaymentRiskNoticeMenuIndicatorProps ) {
+	const translate = useTranslate();
+
+	return (
+		<span
+			aria-label={ translate( 'Payment issue' ) }
+			className={ clsx( 'a4a-payment-risk-notice-menu-indicator', {
+				'a4a-payment-risk-notice-menu-indicator--error': severity === 'error',
+				'a4a-payment-risk-notice-menu-indicator--warning': severity === 'warning',
+			} ) }
+			role="img"
+		>
+			!
+		</span>
+	);
+}

--- a/client/a8c-for-agencies/components/payment-risk-notice-banner/style.scss
+++ b/client/a8c-for-agencies/components/payment-risk-notice-banner/style.scss
@@ -1,13 +1,28 @@
 .a4a-payment-risk-notice-banner {
 	.notice-banner__action-bar {
 		margin-block-start: 16px;
+
+		a.components-button.is-primary,
+		a.components-button.is-primary:hover,
+		a.components-button.is-primary:focus,
+		a.components-button.is-primary:active {
+			color: var( --color-text-inverted );
+		}
+
+		a.components-button.is-secondary,
+		a.components-button.is-secondary:hover,
+		a.components-button.is-secondary:focus,
+		a.components-button.is-secondary:active {
+			color: var( --color-primary-50 );
+			border-color: var( --color-primary-50 );
+		}
 	}
 }
 
 .a4a-payment-risk-notice-menu-indicator {
 	align-items: center;
 	border-radius: 50%;
-	color: var(--color-text-inverted);
+	color: var( --color-text-inverted );
 	display: inline-flex;
 	flex-shrink: 0;
 	font-size: 10px;
@@ -31,9 +46,9 @@
 }
 
 .a4a-payment-risk-notice-menu-indicator--error {
-	background-color: var(--color-error-50);
+	background-color: var( --color-error-50 );
 }
 
 .a4a-payment-risk-notice-menu-indicator--warning {
-	background-color: var(--color-warning-50);
+	background-color: var( --color-warning-50 );
 }

--- a/client/a8c-for-agencies/components/payment-risk-notice-banner/style.scss
+++ b/client/a8c-for-agencies/components/payment-risk-notice-banner/style.scss
@@ -1,0 +1,39 @@
+.a4a-payment-risk-notice-banner {
+	.notice-banner__action-bar {
+		margin-block-start: 16px;
+	}
+}
+
+.a4a-payment-risk-notice-menu-indicator {
+	align-items: center;
+	border-radius: 50%;
+	color: var(--color-text-inverted);
+	display: inline-flex;
+	flex-shrink: 0;
+	font-size: 10px;
+	font-weight: 600;
+	height: 14px;
+	justify-content: center;
+	line-height: 14px;
+	margin-inline-start: 4px;
+	min-width: 14px;
+	vertical-align: middle;
+}
+
+.a4a-payment-risk-notice-menu-title {
+	align-items: center;
+	display: inline-flex;
+	gap: 12px;
+
+	.a4a-payment-risk-notice-menu-indicator {
+		margin-inline-start: 0;
+	}
+}
+
+.a4a-payment-risk-notice-menu-indicator--error {
+	background-color: var(--color-error-50);
+}
+
+.a4a-payment-risk-notice-menu-indicator--warning {
+	background-color: var(--color-warning-50);
+}

--- a/client/a8c-for-agencies/components/payment-risk-notice-banner/style.scss
+++ b/client/a8c-for-agencies/components/payment-risk-notice-banner/style.scss
@@ -1,6 +1,11 @@
 .a4a-payment-risk-notice-banner {
 	.notice-banner__action-bar {
+		gap: 8px;
 		margin-block-start: 16px;
+
+		> * {
+			margin: 0;
+		}
 
 		a.components-button.is-primary,
 		a.components-button.is-primary:hover,

--- a/client/a8c-for-agencies/components/payment-risk-notice-banner/test/index.test.tsx
+++ b/client/a8c-for-agencies/components/payment-risk-notice-banner/test/index.test.tsx
@@ -9,8 +9,25 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import PaymentRiskNoticeBanner from '..';
 import type { ReactNode } from 'react';
 
+const mockSetShowHelpCenter = jest.fn();
+const mockSetNavigateToRoute = jest.fn();
+const mockDispatch = jest.fn();
+
 jest.mock( '@automattic/calypso-config', () => ( {
 	isEnabled: jest.fn(),
+} ) );
+
+jest.mock( '@automattic/data-stores', () => ( {
+	HelpCenter: {
+		register: jest.fn( () => 'help-center-store' ),
+	},
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: () => ( {
+		setShowHelpCenter: mockSetShowHelpCenter,
+		setNavigateToRoute: mockSetNavigateToRoute,
+	} ),
 } ) );
 
 jest.mock( 'i18n-calypso', () => ( {
@@ -25,12 +42,16 @@ jest.mock( '@wordpress/components', () => ( {
 	}: {
 		children: ReactNode;
 		href?: string;
-		onClick?: () => void;
+		onClick?: ( event: { preventDefault: () => void } ) => void;
 	} ) => (
-		<button data-href={ href } onClick={ onClick }>
+		<button data-href={ href } onClick={ () => onClick?.( { preventDefault: jest.fn() } ) }>
 			{ children }
 		</button>
 	),
+} ) );
+
+jest.mock( 'calypso/a8c-for-agencies/components/a4a-contact-support-widget', () => ( {
+	CONTACT_URL_HASH_FRAGMENT: '#contact-support',
 } ) );
 
 jest.mock( 'calypso/a8c-for-agencies/components/layout/banner', () => ( {
@@ -51,8 +72,6 @@ jest.mock( 'calypso/a8c-for-agencies/components/layout/banner', () => ( {
 		</section>
 	),
 } ) );
-
-const mockDispatch = jest.fn();
 
 jest.mock( 'calypso/state', () => ( {
 	useDispatch: () => mockDispatch,
@@ -92,11 +111,13 @@ describe( 'PaymentRiskNoticeBanner', () => {
 		render( <PaymentRiskNoticeBanner source="overview" /> );
 
 		expect(
-			screen.getByRole( 'heading', { name: 'Payment issue needs attention' } )
+			screen.getByRole( 'heading', {
+				name: 'Action required: We’re unable to renew your subscription(s)',
+			} )
 		).toBeVisible();
 		expect(
 			screen.getByText(
-				'Your agency has a payment issue. Update your payment method to avoid service interruption.'
+				'We couldn’t process payment for one or more of your subscriptions with the payment method we have on file. If this isn’t resolved, your subscriptions will be cancelled and your sites may go offline. Please update your payment method to stay covered.'
 			)
 		).toBeVisible();
 
@@ -105,11 +126,20 @@ describe( 'PaymentRiskNoticeBanner', () => {
 			{ source: 'overview' }
 		);
 
-		await user.click( screen.getByRole( 'button', { name: 'Update payment method' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Fix payment method' } ) );
 
 		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
 			'calypso_a4a_payment_risk_notice_banner_cta_click',
 			{ source: 'overview' }
 		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Contact us' } ) );
+
+		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_a4a_payment_risk_notice_banner_contact_us_click',
+			{ source: 'overview' }
+		);
+		expect( mockSetShowHelpCenter ).toHaveBeenCalledWith( true );
+		expect( mockSetNavigateToRoute ).toHaveBeenCalledWith( '/contact-form' );
 	} );
 } );

--- a/client/a8c-for-agencies/components/payment-risk-notice-banner/test/index.test.tsx
+++ b/client/a8c-for-agencies/components/payment-risk-notice-banner/test/index.test.tsx
@@ -39,12 +39,21 @@ jest.mock( '@wordpress/components', () => ( {
 		children,
 		href,
 		onClick,
+		rel,
+		target,
 	}: {
 		children: ReactNode;
 		href?: string;
 		onClick?: ( event: { preventDefault: () => void } ) => void;
+		rel?: string;
+		target?: string;
 	} ) => (
-		<button data-href={ href } onClick={ () => onClick?.( { preventDefault: jest.fn() } ) }>
+		<button
+			data-href={ href }
+			data-rel={ rel }
+			data-target={ target }
+			onClick={ () => onClick?.( { preventDefault: jest.fn() } ) }
+		>
 			{ children }
 		</button>
 	),
@@ -126,7 +135,12 @@ describe( 'PaymentRiskNoticeBanner', () => {
 			{ source: 'overview' }
 		);
 
-		await user.click( screen.getByRole( 'button', { name: 'Fix payment method' } ) );
+		const fixPaymentMethodButton = screen.getByRole( 'button', { name: 'Fix payment method' } );
+
+		expect( fixPaymentMethodButton ).toHaveAttribute( 'data-target', '_blank' );
+		expect( fixPaymentMethodButton ).toHaveAttribute( 'data-rel', 'noopener noreferrer' );
+
+		await user.click( fixPaymentMethodButton );
 
 		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
 			'calypso_a4a_payment_risk_notice_banner_cta_click',

--- a/client/a8c-for-agencies/components/payment-risk-notice-banner/test/index.test.tsx
+++ b/client/a8c-for-agencies/components/payment-risk-notice-banner/test/index.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { isEnabled } from '@automattic/calypso-config';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import PaymentRiskNoticeBanner from '..';
+import type { ReactNode } from 'react';
+
+jest.mock( '@automattic/calypso-config', () => ( {
+	isEnabled: jest.fn(),
+} ) );
+
+jest.mock( 'i18n-calypso', () => ( {
+	useTranslate: () => ( text: string ) => text,
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	Button: ( {
+		children,
+		href,
+		onClick,
+	}: {
+		children: ReactNode;
+		href?: string;
+		onClick?: () => void;
+	} ) => (
+		<button data-href={ href } onClick={ onClick }>
+			{ children }
+		</button>
+	),
+} ) );
+
+jest.mock( 'calypso/a8c-for-agencies/components/layout/banner', () => ( {
+	__esModule: true,
+	default: ( {
+		actions,
+		children,
+		title,
+	}: {
+		actions?: ReactNode[];
+		children: ReactNode;
+		title?: string;
+	} ) => (
+		<section>
+			{ title && <h2>{ title }</h2> }
+			{ children }
+			{ actions }
+		</section>
+	),
+} ) );
+
+const mockDispatch = jest.fn();
+
+jest.mock( 'calypso/state', () => ( {
+	useDispatch: () => mockDispatch,
+} ) );
+
+jest.mock( 'calypso/state/analytics/actions', () => ( {
+	recordTracksEvent: jest.fn( ( name, properties ) => ( {
+		type: 'RECORD_TRACKS_EVENT',
+		name,
+		properties,
+	} ) ),
+} ) );
+
+const mockedIsEnabled = isEnabled as jest.MockedFunction< typeof isEnabled >;
+const mockedRecordTracksEvent = recordTracksEvent as jest.MockedFunction<
+	typeof recordTracksEvent
+>;
+
+describe( 'PaymentRiskNoticeBanner', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockedIsEnabled.mockImplementation( ( flag ) => flag === 'a4a-payment-risk-notice-banner' );
+	} );
+
+	it( 'does not render when the feature flag is disabled', () => {
+		mockedIsEnabled.mockReturnValue( false );
+
+		const { container } = render( <PaymentRiskNoticeBanner source="overview" /> );
+
+		expect( container ).toBeEmptyDOMElement();
+		expect( mockDispatch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'renders the notice and records view and CTA click events', async () => {
+		const user = userEvent.setup();
+
+		render( <PaymentRiskNoticeBanner source="overview" /> );
+
+		expect(
+			screen.getByRole( 'heading', { name: 'Payment issue needs attention' } )
+		).toBeVisible();
+		expect(
+			screen.getByText(
+				'Your agency has a payment issue. Update your payment method to avoid service interruption.'
+			)
+		).toBeVisible();
+
+		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_a4a_payment_risk_notice_banner_view',
+			{ source: 'overview' }
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Update payment method' } ) );
+
+		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_a4a_payment_risk_notice_banner_cta_click',
+			{ source: 'overview' }
+		);
+	} );
+} );

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
@@ -17,6 +17,11 @@ import {
 } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
+import {
+	isPaymentRiskNoticeBannerEnabled,
+	PAYMENT_RISK_NOTICE_SEVERITY,
+} from 'calypso/a8c-for-agencies/components/payment-risk-notice-banner/constants';
+import PaymentRiskNoticeMenuIndicator from 'calypso/a8c-for-agencies/components/payment-risk-notice-banner/menu-indicator';
 import { isPathAllowed } from 'calypso/a8c-for-agencies/lib/permission';
 import { A4A_REPORTS_LINK } from 'calypso/a8c-for-agencies/sections/reports/constants';
 import wooPaymentsIcon from 'calypso/assets/images/a8c-for-agencies/woopayments/woo-sidebar-icon.svg';
@@ -50,6 +55,7 @@ const useMainMenuItems = ( path: string ) => {
 	const translate = useTranslate();
 
 	const agency = useSelector( getActiveAgency );
+	const showPaymentRiskIndicator = isPaymentRiskNoticeBannerEnabled();
 
 	const menuItems = useMemo( () => {
 		let referralItems = [] as any[];
@@ -148,7 +154,14 @@ const useMainMenuItems = ( path: string ) => {
 				icon: currencyDollar,
 				path: A4A_PURCHASES_LINK,
 				link: A4A_LICENSES_LINK,
-				title: translate( 'Purchases' ),
+				title: showPaymentRiskIndicator ? (
+					<span className="a4a-payment-risk-notice-menu-title">
+						<span>{ translate( 'Purchases' ) }</span>
+						<PaymentRiskNoticeMenuIndicator severity={ PAYMENT_RISK_NOTICE_SEVERITY } />
+					</span>
+				) : (
+					translate( 'Purchases' )
+				),
 				trackEventProps: {
 					menu_item: 'Automattic for Agencies / Purchases',
 				},
@@ -233,7 +246,7 @@ const useMainMenuItems = ( path: string ) => {
 		]
 			.map( ( item ) => createItem( item, path ) )
 			.filter( ( item ) => isPathAllowed( item.link, agency ) );
-	}, [ agency, path, translate ] );
+	}, [ agency, path, showPaymentRiskIndicator, translate ] );
 	return menuItems;
 };
 

--- a/client/a8c-for-agencies/sections/overview/overview.tsx
+++ b/client/a8c-for-agencies/sections/overview/overview.tsx
@@ -3,6 +3,7 @@ import A4AAgencyApprovalNotice from 'calypso/a8c-for-agencies/components/a4a-age
 import ContentSidebar from 'calypso/a8c-for-agencies/components/content-sidebar';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
+import PaymentRiskNoticeBanner from 'calypso/a8c-for-agencies/components/payment-risk-notice-banner';
 import PressableUsageLimitNotice from 'calypso/a8c-for-agencies/components/pressable-usage-limit-notice';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import LayoutBody from 'calypso/layout/hosting-dashboard/body';
@@ -31,6 +32,7 @@ export default function Overview() {
 				{ ! isLoadingActivity && hasActivity && <MissingPaymentSettingsNotice /> }
 				<A4AAgencyApprovalNotice />
 				<PressableUsageLimitNotice />
+				<PaymentRiskNoticeBanner source="overview" />
 
 				<LayoutHeader className="a4a-overview-header">
 					<Title>{ title }</Title>

--- a/client/a8c-for-agencies/sections/purchases/billing/billing-dashboard.tsx
+++ b/client/a8c-for-agencies/sections/purchases/billing/billing-dashboard.tsx
@@ -2,6 +2,7 @@ import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
+import PaymentRiskNoticeBanner from 'calypso/a8c-for-agencies/components/payment-risk-notice-banner';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import { A4A_MARKETPLACE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import LayoutBody from 'calypso/layout/hosting-dashboard/body';
@@ -29,6 +30,7 @@ export default function BillingDashboard() {
 	return (
 		<Layout className="billing-dashboard" title={ title } wide>
 			<LayoutTop>
+				<PaymentRiskNoticeBanner source="purchases_billing" />
 				<LayoutHeader>
 					<Title>{ title } </Title>
 					<Actions className="a4a-billing__header-actions">

--- a/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/index.tsx
@@ -2,6 +2,7 @@ import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
+import PaymentRiskNoticeBanner from 'calypso/a8c-for-agencies/components/payment-risk-notice-banner';
 import PressableUsageLimitNotice from 'calypso/a8c-for-agencies/components/pressable-usage-limit-notice';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import { A4A_MARKETPLACE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
@@ -67,6 +68,7 @@ export default function LicensesOverview( {
 			<LicensesOverviewContext.Provider value={ context }>
 				<LayoutTop withNavigation>
 					<PressableUsageLimitNotice />
+					<PaymentRiskNoticeBanner source="purchases_licenses" />
 					<LayoutHeader>
 						<Title>{ title } </Title>
 						<Actions className="a4a-licenses__header-actions">

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/index.tsx
@@ -4,6 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useState } from 'react';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
+import PaymentRiskNoticeBanner from 'calypso/a8c-for-agencies/components/payment-risk-notice-banner';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import {
 	A4A_PAYMENT_METHODS_ADD_LINK,
@@ -123,6 +124,7 @@ export default function PaymentMethodOverview() {
 	return (
 		<Layout className="payment-method-overview" title={ translate( 'Payment methods' ) } wide>
 			<LayoutTop>
+				<PaymentRiskNoticeBanner source="purchases_payment_methods" />
 				<LayoutHeader>
 					<Title>{ translate( 'Payment methods' ) } </Title>
 					<Subtitle>

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -34,6 +34,7 @@
 		"a4a-bd-checkout": false,
 		"a4a-bd-term-pricing": true,
 		"a4a-migrations-request-verification": true,
+		"a4a-payment-risk-notice-banner": false,
 		"a4a-partner-directory": false,
 		"a4a-partner-directory-lead-matching": true,
 		"a4a-pressable-referrals": true,

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -31,6 +31,7 @@
 		"a4a-bd-checkout": false,
 		"a4a-bd-term-pricing": true,
 		"a4a-migrations-request-verification": true,
+		"a4a-payment-risk-notice-banner": false,
 		"a4a-partner-directory": false,
 		"a4a-partner-directory-lead-matching": false,
 		"a4a-pressable-referrals": true,

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -33,6 +33,7 @@
 		"a4a-bd-checkout": false,
 		"a4a-bd-term-pricing": true,
 		"a4a-migrations-request-verification": true,
+		"a4a-payment-risk-notice-banner": false,
 		"a4a-partner-directory": false,
 		"a4a-partner-directory-lead-matching": false,
 		"a4a-pressable-referrals": true,

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -33,6 +33,7 @@
 		"a4a-bd-checkout": false,
 		"a4a-bd-term-pricing": true,
 		"a4a-migrations-request-verification": true,
+		"a4a-payment-risk-notice-banner": false,
 		"a4a-partner-directory": false,
 		"a4a-partner-directory-lead-matching": false,
 		"a4a-pressable-referrals": true,


### PR DESCRIPTION
Part of A4A-2386
Part of A4A-2583

## Proposed Changes

<img width="1298" height="197" alt="image" src="https://github.com/user-attachments/assets/fa2eb19b-e7a0-4833-9807-488eec7f5232" />

<img width="1618" height="267" alt="image" src="https://github.com/user-attachments/assets/231cd477-dee6-4878-9397-ef6a47dd1725" />

<img width="262" height="383" alt="image" src="https://github.com/user-attachments/assets/251326e1-a1be-48b1-a89a-ccc57896370c" />

<img width="1350" height="756" alt="image" src="https://github.com/user-attachments/assets/164ee756-856d-4cb4-baf7-6b4715dfa285" />


- Add a temporary feature-flagged A4A payment-risk notice banner for copy/UI review.
- Show the banner on A4A Overview and Purchases surfaces.
- Add a red Purchases menu badge while the temporary review flag is enabled.
- Route the CTA to the WP.com payment methods page for the BD billing model.
- Add Tracks events for banner views and CTA clicks.

## Why are these changes being made?

- Agencies with payment failures need a visible in-product prompt to update their payment method before service interruption.
- The temporary feature flag lets the team review copy and UI before backend payment-risk state is available.

## Testing Instructions

- Open A4A with `?flags=a4a-payment-risk-notice-banner`.
- Go to Overview.
- Verify the red payment-risk banner is visible.
- Verify the Purchases menu item shows a red `!` badge after the label.
- Verify the CTA points to `https://wordpress.com/me/purchases/payment-methods`.
- Go to Purchases > Licenses with the same flag.
- Verify the banner is visible there too.
- Remove the flag and verify the banner and Purchases badge are hidden.

_— ClemenAgent (Powered by Codex)_

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
  - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
