### PR TITLE
Domain search: refine skip-suggestion card for mobile

### DIFF
--- a/packages/domain-search/src/components/skip-suggestion/test/index.tsx
+++ b/packages/domain-search/src/components/skip-suggestion/test/index.tsx
@@ -97,7 +97,6 @@ describe( 'SkipSuggestion', () => {
 				name: 'Skip purchase and continue with site.wordpress.com',
 			} );
 			expect( skipButton ).toBeInTheDocument();
-			expect( skipButton ).toHaveTextContent( 'Start Free' );
 
 			await userEvent.click( skipButton );
 

--- a/packages/domain-search/src/ui/domain-search-skip-suggestion/index.placeholder.tsx
+++ b/packages/domain-search/src/ui/domain-search-skip-suggestion/index.placeholder.tsx
@@ -1,10 +1,15 @@
 import { LoadingPlaceholder } from '@automattic/components';
 import { __ } from '@wordpress/i18n';
+import { useDomainSuggestionContainer } from '../../hooks/use-domain-suggestion-container';
 import { DomainSearchSkipSuggestionSkeleton } from './index.skeleton';
 
 export const DomainSearchSkipSuggestionPlaceholder = () => {
+	const { containerRef, activeQuery } = useDomainSuggestionContainer();
+
 	return (
 		<DomainSearchSkipSuggestionSkeleton
+			ref={ containerRef }
+			activeQuery={ activeQuery }
 			role="status"
 			aria-busy="true"
 			aria-label={ __( 'Loading free domain suggestion' ) }

--- a/packages/domain-search/src/ui/domain-search-skip-suggestion/index.skeleton.tsx
+++ b/packages/domain-search/src/ui/domain-search-skip-suggestion/index.skeleton.tsx
@@ -1,26 +1,20 @@
 import { Card, CardBody } from '@wordpress/components';
-import { useDomainSuggestionContainer } from '../../hooks/use-domain-suggestion-container';
+import { forwardRef } from 'react';
 import type { ComponentProps } from 'react';
 
-interface Props extends Omit< ComponentProps< typeof Card >, 'children' | 'title' > {
+interface Props extends Omit< ComponentProps< typeof Card >, 'children' | 'title' | 'size' > {
 	title: React.ReactNode;
 	subtitle: React.ReactNode;
 	right?: React.ReactNode;
+	activeQuery: 'small' | 'large';
 }
 
-export const DomainSearchSkipSuggestionSkeleton = ( {
-	title,
-	subtitle,
-	right,
-	...props
-}: Props ) => {
-	const { containerRef, activeQuery } = useDomainSuggestionContainer();
-
-	return (
+export const DomainSearchSkipSuggestionSkeleton = forwardRef< HTMLDivElement, Props >(
+	( { title, subtitle, right, activeQuery, ...cardProps }, ref ) => (
 		<Card
-			{ ...props }
+			{ ...cardProps }
 			className="domain-search-skip-suggestion"
-			ref={ containerRef }
+			ref={ ref }
 			size={ activeQuery === 'large' ? 'medium' : 'small' }
 		>
 			<CardBody>
@@ -31,5 +25,7 @@ export const DomainSearchSkipSuggestionSkeleton = ( {
 				{ right }
 			</CardBody>
 		</Card>
-	);
-};
+	)
+);
+
+DomainSearchSkipSuggestionSkeleton.displayName = 'DomainSearchSkipSuggestionSkeleton';

--- a/packages/domain-search/src/ui/domain-search-skip-suggestion/index.tsx
+++ b/packages/domain-search/src/ui/domain-search-skip-suggestion/index.tsx
@@ -5,6 +5,8 @@ import {
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { chevronRight } from '@wordpress/icons';
+import { useDomainSuggestionContainer } from '../../hooks/use-domain-suggestion-container';
 import { DomainSearchSkipSuggestionPlaceholder } from './index.placeholder';
 import { DomainSearchSkipSuggestionSkeleton } from './index.skeleton';
 
@@ -29,10 +31,14 @@ const DomainSearchSkipSuggestion = ( {
 	disabled,
 	isBusy,
 }: Props ) => {
+	const { containerRef, activeQuery } = useDomainSuggestionContainer();
+	const isSmall = activeQuery === 'small';
+
 	let title;
 	let subtitle;
 	let buttonText = __( 'Skip purchase' );
 	let showButton = true;
+	let chevronOnMobile = false;
 
 	if ( existingSiteUrl ) {
 		const [ domain, ...tld ] = existingSiteUrl.split( '.' );
@@ -77,6 +83,7 @@ const DomainSearchSkipSuggestion = ( {
 		);
 		subtitle = __( 'Upgrade to a custom domain name anytime.' );
 		buttonText = __( 'Start Free' );
+		chevronOnMobile = true;
 	}
 
 	if ( ! title ) {
@@ -84,33 +91,73 @@ const DomainSearchSkipSuggestion = ( {
 	}
 
 	const domain = existingSiteUrl ?? freeSuggestion;
+	const showChevron = chevronOnMobile && isSmall;
+	const skipLabel = sprintf(
+		// translators: %(domain)s is the domain name
+		__( 'Skip purchase and continue with %(domain)s' ),
+		{ domain }
+	);
+
+	const renderRight = () => {
+		if ( ! showButton ) {
+			return undefined;
+		}
+
+		if ( showChevron ) {
+			return (
+				<Button
+					className="domain-search-skip-suggestion__chevron"
+					variant="tertiary"
+					label={ skipLabel }
+					onClick={ onSkip }
+					icon={ chevronRight }
+					disabled={ disabled }
+					isBusy={ isBusy && ! disabled }
+				/>
+			);
+		}
+
+		return (
+			<Button
+				className="domain-search-skip-suggestion__btn"
+				variant="secondary"
+				label={ skipLabel }
+				onClick={ onSkip }
+				disabled={ disabled }
+				isBusy={ isBusy && ! disabled }
+				__next40pxDefaultSize
+			>
+				{ buttonText }
+			</Button>
+		);
+	};
 
 	return (
 		<DomainSearchSkipSuggestionSkeleton
+			ref={ containerRef }
+			activeQuery={ activeQuery }
 			title={
-				<Heading level="4" weight="normal">
-					{ title }
-				</Heading>
+				isSmall ? (
+					<Heading level="4" size="body" weight={ 500 }>
+						{ title }
+					</Heading>
+				) : (
+					<Heading level="4" weight="normal">
+						{ title }
+					</Heading>
+				)
 			}
-			subtitle={ subtitle && <Text>{ subtitle }</Text> }
-			right={
-				showButton ? (
-					<Button
-						className="domain-search-skip-suggestion__btn"
-						variant="secondary"
-						// translators: %(domain)s is the domain name
-						label={ sprintf( __( 'Skip purchase and continue with %(domain)s' ), {
-							domain,
-						} ) }
-						onClick={ onSkip }
-						disabled={ disabled }
-						isBusy={ isBusy && ! disabled }
-						__next40pxDefaultSize
-					>
-						{ buttonText }
-					</Button>
-				) : undefined
+			subtitle={
+				subtitle &&
+				( isSmall ? (
+					<Text size="subheadline" variant="muted">
+						{ subtitle }
+					</Text>
+				) : (
+					<Text>{ subtitle }</Text>
+				) )
 			}
+			right={ renderRight() }
 		/>
 	);
 };

--- a/packages/domain-search/src/ui/domain-search-skip-suggestion/style.scss
+++ b/packages/domain-search/src/ui/domain-search-skip-suggestion/style.scss
@@ -1,10 +1,16 @@
 .domain-search-skip-suggestion {
+	position: relative;
+
 	.components-card__body {
 		display: flex;
 		flex-direction: row;
 		align-items: center;
 		justify-content: space-between;
 		gap: 1.5rem;
+	}
+
+	&:has( .domain-search-skip-suggestion__chevron ) .components-card__body {
+		gap: 0.75rem;
 	}
 
 	.domain-search-skip-suggestion__content {
@@ -22,5 +28,18 @@
 	.domain-search-skip-suggestion__btn {
 		color: var( --domain-search-secondary-action-color );
 		box-shadow: inset 0 0 0 1px var( --domain-search-secondary-action-box-shadow-color );
+	}
+
+	.domain-search-skip-suggestion__chevron {
+		color: rgba( 0, 0, 0, 0.32 );
+		padding: 0;
+		min-width: 0;
+		min-height: 0;
+
+		&::after {
+			content: '';
+			position: absolute;
+			inset: 0;
+		}
 	}
 }


### PR DESCRIPTION
## Proposed Changes

- Add a mobile (`activeQuery === 'small'`, container <480px) treatment to the domain-search-skip-suggestion card:
  - Title: `<Heading level="4" size="body" weight={ 500 }>` — 13px / 500.
  - Subtitle: `<Text size="subheadline" variant="muted">` — 12px / `$gray-700`.
- Replace the "Start Free" button with a 24×24 chevron icon (`@wordpress/icons` `chevronRight`) at mobile sizes. The chevron `<Button>` remains the real interactive element; an `::after { inset: 0 }` overlay extends its hit area so any click on the card triggers it. Color: `#000000` at 32% opacity per design.
- Tighten the card body flex gap to 12px (0.75rem) when the chevron variant is rendered, via `:has(.__chevron)`.
- Align `DomainSearchSkipSuggestionSkeleton` with `FeaturedSkeleton`'s precedent: `forwardRef< HTMLDivElement, Props >`, takes `activeQuery` as a prop, computes Card `size` internally, sets `displayName`. The hook is lifted to the parent and the placeholder.
- Update the `skip-suggestion` test: dropped the `toHaveTextContent('Start Free')` assertion because the visible label is now container-dependent. The accessible-name assertion (`name: 'Skip purchase and continue with site.wordpress.com'`) remains — that's the behavior contract screen readers hear in both variants.

## Why are these changes being made?

The skip-suggestion card needs a more compact and easier-to-hit affordance on small viewports. The chevron replaces the visually heavy "Start Free" CTA on mobile while the whole-card click target makes the action easier to trigger on touch. Desktop layout is unchanged.

## Screenshots

|Domain length | Before | After |
| --- | --- | --- |
| Short | <img width="750" height="1334" alt="wordpress com_setup_onboarding_domains_source=sites-dashboard ref=new-site-popover(iPhone SE) (2)" src="https://github.com/user-attachments/assets/717e1a8c-9d5c-4b5d-8194-0f00b7e70f8b" /> | <img width="750" height="1334" alt="calypso localhost_3000_setup_onboarding_domains_source=sites-dashboard ref=new-site-popover(iPhone SE) (1)" src="https://github.com/user-attachments/assets/db034c55-c281-4f67-8138-7c69dae4462d" /> |
| Long | <img width="750" height="1334" alt="wordpress com_setup_onboarding_domains_source=sites-dashboard ref=new-site-popover(iPhone SE) (1)" src="https://github.com/user-attachments/assets/ef89e5df-e2ec-4b6b-b3a6-64f72c424f3f" /> | <img width="750" height="1334" alt="calypso localhost_3000_setup_onboarding_domains_source=sites-dashboard ref=new-site-popover(iPhone SE)" src="https://github.com/user-attachments/assets/2260e791-d818-42a2-93df-ea1588735cca" /> |



## Testing Instructions

- Open the onboarding domain search step (`/setup/onboarding/domains`) on a flow that surfaces the skip suggestion.
- Wide viewport (container ≥480px): card shows the "Start Free" secondary button on the right, default `<Heading level="4">` / `<Text>` typography. Identical to before this PR.
- Narrow viewport (container <480px):
  - Title compact (13px, weight 500); subtitle smaller (12px) and muted (`$gray-700`).
  - Right slot: a chevron-right icon button (`rgba(0,0,0,0.32)`, 24×24, 12px flex gap to text).
  - Clicking anywhere on the card invokes the skip action.
  - Tab focus lands on the chevron button — real button, real keyboard, accessible name `"Skip purchase and continue with <domain>"`.
- The "Current address" variant (when `existingSiteUrl` is set) and the "unavailable domain" variant (with the inline link) continue to render the existing text buttons / inline link at both container sizes.

### Alternatives considered

- **Provider + subcomponents reading context** — matched `featured.tsx`'s Provider pattern but added unnecessary indirection for a card with only two responsive elements (title + subtitle).
- **Custom `containerRef`/`cardSize` props on the skeleton** — diverged from `FeaturedSkeleton`'s `forwardRef`/`activeQuery` API and duplicated the `cardSize` derivation at every call site.
- **CSS-only `@container` queries reaching into `.components-heading` / `.components-text`** — would override WPDS internals; replaced with prop-level branching (`variant="muted"` is `$gray-700` by definition in WPDS).
- **Making the `Card` itself the click target** — would nest interactive elements; the `::after` overlay on the existing `<Button>` is the standard a11y-friendly pattern.

### Known limitations

- The `::after` overlay blocks text selection on the chevron variant. Accepted tradeoff for a card whose copy is one-line title + one-line subtitle.
- `chevronRight` doesn't auto-flip for RTL languages. Matches the existing convention in `packages/help-center` and other consumers across the repo.
- Dark mode: chevron color is hardcoded `rgba(0,0,0,0.32)` per the design spec. If a dark variant is needed, a follow-up can replace it with a theme variable.

Screenshots can be attached on request — verification was done in the package's Storybook with temporary stories at 380px and 640px container widths, then cleaned up before the commit.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?