### PR TITLE
[RSM] Blog Talks Back: Add error message handling to Reader Chat 

### DIFF
--- a/apps/agents-manager/__tests__/reader-chat.test.js
+++ b/apps/agents-manager/__tests__/reader-chat.test.js
@@ -271,7 +271,9 @@ describe( 'getSuggestionsFetchHeaders', () => {
 			Authorization: 'Bearer test-token-247750866',
 		} );
 
-		expect( createCalypsoAuthProvider ).toHaveBeenCalledWith( 247750866 );
+		expect( createCalypsoAuthProvider ).toHaveBeenCalledWith( 247750866, {
+			logWpcomJwtFailure: false,
+		} );
 	} );
 } );
 

--- a/apps/agents-manager/reader-chat.js
+++ b/apps/agents-manager/reader-chat.js
@@ -153,6 +153,9 @@ function injectScopedReset() {
 			left: 16px !important;
 			right: auto !important;
 		}
+		.agents-manager-chat--undocked [data-slot="chat-footer"] > [data-slot="suggestions"] button {
+			background: #ffffff !important;
+		}
 
 	`;
 	document.head.appendChild( style );
@@ -396,7 +399,7 @@ function normalizeSuggestions( items, resultIdPrefix ) {
 }
 
 function getSuggestionsFetchHeaders( siteId = readerSiteId ) {
-	return createCalypsoAuthProvider( siteId )();
+	return createCalypsoAuthProvider( siteId, { logWpcomJwtFailure: false } )();
 }
 
 /**
@@ -826,7 +829,7 @@ function setupTracksEvents() {
 		if ( ! target || typeof target.closest !== 'function' ) {
 			return;
 		}
-		const suggestionBtn = target.closest( '.Suggestions-module_button' );
+		const suggestionBtn = target.closest( '[data-slot="suggestions"] button' );
 		if ( suggestionBtn ) {
 			recordTracksEvent( 'jetpack_reader_chat_suggestion_click', {
 				...baseProps,

--- a/packages/agents-manager/src/auth/calypso-auth-provider.ts
+++ b/packages/agents-manager/src/auth/calypso-auth-provider.ts
@@ -16,6 +16,10 @@ interface CalypsoAuthError {
 	message?: string;
 }
 
+interface CalypsoAuthProviderOptions {
+	logWpcomJwtFailure?: boolean;
+}
+
 const JWT_TOKEN_ID = 'jetpack-ai-jwt-token';
 const JWT_TOKEN_EXPIRATION_TIME = 30 * 60 * 1000; // 30 minutes
 
@@ -148,7 +152,8 @@ async function requestJWTToken(
  */
 async function requestJWTTokenViaWpcom(
 	siteId?: string | number,
-	useCachedToken = true
+	useCachedToken = true,
+	logFailure = true
 ): Promise< string | null > {
 	const cacheKey = siteId ? `${ JWT_TOKEN_ID }-wpcom-${ siteId }` : `${ JWT_TOKEN_ID }-wpcom`;
 
@@ -179,8 +184,10 @@ async function requestJWTTokenViaWpcom(
 
 		return token || null;
 	} catch ( error ) {
-		// eslint-disable-next-line no-console
-		console.error( 'Failed to get JWT token via wpcomRequest:', error );
+		if ( logFailure ) {
+			// eslint-disable-next-line no-console
+			console.error( 'Failed to get JWT token via wpcomRequest:', error );
+		}
 		return null;
 	}
 }
@@ -218,9 +225,13 @@ function getOAuthToken(): string | null {
  * Uses OAuth Bearer token in Calypso environments (wordpress.com, *.calypso.live),
  * or JWT token via apiFetch in non-Calypso environments (wp-admin, widgets.wp.com).
  * @param siteId - Optional site ID for simple sites (used when requesting JWT tokens)
+ * @param options - Optional authentication behavior.
  * @returns Authentication provider function that returns headers
  */
-export const createCalypsoAuthProvider = ( siteId?: string | number ): AuthProvider => {
+export const createCalypsoAuthProvider = (
+	siteId?: string | number,
+	options: CalypsoAuthProviderOptions = {}
+): AuthProvider => {
 	return async () => {
 		const headers: Record< string, string > = {
 			'Content-Type': 'application/json',
@@ -234,7 +245,11 @@ export const createCalypsoAuthProvider = ( siteId?: string | number ): AuthProvi
 			}
 
 			// Fallback to JWT via /ai/jwt (works with or without siteId)
-			const jwtToken = await requestJWTTokenViaWpcom( siteId );
+			const jwtToken = await requestJWTTokenViaWpcom(
+				siteId,
+				true,
+				options.logWpcomJwtFailure ?? true
+			);
 			if ( jwtToken ) {
 				headers.Authorization = `Bearer ${ jwtToken }`;
 				return headers;

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -28,6 +28,7 @@ import {
 } from '../../utils/external-context';
 import { isReaderChatAgent } from '../../utils/is-reader-chat-agent';
 import { persistLastActivity } from '../../utils/persist-last-activity';
+import { getReaderChatErrorMessage } from '../../utils/reader-chat-error-message';
 import AgentChat from '../agent-chat';
 import { type Options as ChatHeaderOptions } from '../chat-header';
 import type { BigSkyMessage } from '../../types';
@@ -130,6 +131,7 @@ export default function OrchestratorChat( {
 	const isReaderChat = isReaderChatAgent( agentConfig?.agentId );
 	const shouldLoadConversation =
 		! isReaderChat || ( ! hasUserSentMessage && messages.length === 0 && ! isProcessing );
+	const chatError = isReaderChat ? getReaderChatErrorMessage( error ) : error;
 
 	const { isLoading: isLoadingConversation } = useConversation( {
 		maxPages: isReaderChat ? 1 : 10,
@@ -463,7 +465,7 @@ export default function OrchestratorChat( {
 			emptyViewSuggestions={ displayedEmptyViewSuggestions }
 			isProcessing={ isProcessing || ( isThinking && ! isBuildingSite ) }
 			thinkingMessage={ progressMessage }
-			error={ error }
+			error={ chatError }
 			onSubmit={ onSubmitWithImages }
 			onAbort={ abortCurrentRequest }
 			isLoadingConversation={ isLoadingConversation }

--- a/packages/agents-manager/src/utils/__tests__/create-agent-config.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/create-agent-config.test.ts
@@ -12,8 +12,10 @@ jest.mock( '../can-connect-to-zendesk', () => ( {
 
 import { createAgentConfig } from '../create-agent-config';
 import { canConnectToZendesk } from '../can-connect-to-zendesk';
+import { createCalypsoAuthProvider } from '../../auth/calypso-auth-provider';
 
 const mockCanConnectToZendesk = canConnectToZendesk as jest.Mock;
+const mockCreateCalypsoAuthProvider = createCalypsoAuthProvider as jest.Mock;
 
 function setAgentsManagerData( data: Record< string, unknown > ) {
 	( window as unknown as { agentsManagerData?: Record< string, unknown > } ).agentsManagerData =
@@ -23,6 +25,7 @@ function setAgentsManagerData( data: Record< string, unknown > ) {
 describe( 'createAgentConfig', () => {
 	beforeEach( () => {
 		mockCanConnectToZendesk.mockClear();
+		mockCreateCalypsoAuthProvider.mockClear();
 	} );
 
 	afterEach( () => {
@@ -44,6 +47,9 @@ describe( 'createAgentConfig', () => {
 		const context = config.contextProvider?.getClientContext();
 
 		expect( mockCanConnectToZendesk ).toHaveBeenCalledTimes( 1 );
+		expect( mockCreateCalypsoAuthProvider ).toHaveBeenCalledWith( undefined, {
+			logWpcomJwtFailure: true,
+		} );
 		expect( context ).not.toHaveProperty( 'currentPost' );
 		expect( context ).not.toHaveProperty( 'siteName' );
 		expect( context ).not.toHaveProperty( 'siteUrl' );
@@ -64,6 +70,9 @@ describe( 'createAgentConfig', () => {
 		const context = config.contextProvider?.getClientContext();
 
 		expect( mockCanConnectToZendesk ).not.toHaveBeenCalled();
+		expect( mockCreateCalypsoAuthProvider ).toHaveBeenCalledWith( undefined, {
+			logWpcomJwtFailure: false,
+		} );
 		expect( context ).toEqual( expect.objectContaining( { can_access_zendesk: false } ) );
 		expect( context ).toEqual(
 			expect.objectContaining( {

--- a/packages/agents-manager/src/utils/__tests__/reader-chat-error-message.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/reader-chat-error-message.test.ts
@@ -1,0 +1,130 @@
+import { getReaderChatErrorMessage } from '../reader-chat-error-message';
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text: string ) => text,
+} ) );
+
+describe( 'getReaderChatErrorMessage', () => {
+	it( 'returns null when there is no error', () => {
+		expect( getReaderChatErrorMessage( null ) ).toBeNull();
+	} );
+
+	it( 'maps Search usage errors to stable Reader Chat copy', () => {
+		expect( getReaderChatErrorMessage( { code: 'reader_chat_search_ai_over_limit' } ) ).toBe(
+			'Reader Chat is temporarily unavailable because this site has reached its Jetpack Search usage limit.'
+		);
+	} );
+
+	it( 'maps production Search usage message strings to stable Reader Chat copy', () => {
+		expect(
+			getReaderChatErrorMessage(
+				'Reader Chat is temporarily unavailable because this site has reached its Jetpack Search AI usage limit.'
+			)
+		).toBe(
+			'Reader Chat is temporarily unavailable because this site has reached its Jetpack Search usage limit.'
+		);
+	} );
+
+	it( 'maps wrapped Search usage Error messages to stable Reader Chat copy', () => {
+		expect(
+			getReaderChatErrorMessage(
+				new Error(
+					'HTTP 403: Reader Chat is temporarily unavailable because this site has reached its Jetpack Search AI usage limit.'
+				)
+			)
+		).toBe(
+			'Reader Chat is temporarily unavailable because this site has reached its Jetpack Search usage limit.'
+		);
+	} );
+
+	it( 'maps JSON-encoded Search usage error codes to stable Reader Chat copy', () => {
+		expect(
+			getReaderChatErrorMessage( new Error( '{"code":"reader_chat_search_over_limit"}' ) )
+		).toBe(
+			'Reader Chat is temporarily unavailable because this site has reached its Jetpack Search usage limit.'
+		);
+	} );
+
+	it( 'maps unavailable target errors to stable Reader Chat copy', () => {
+		expect(
+			getReaderChatErrorMessage( { data: { code: 'reader_chat_search_not_supported' } } )
+		).toBe( 'Reader Chat is not available for this site.' );
+	} );
+
+	it( 'maps production unavailable message strings to stable Reader Chat copy', () => {
+		expect(
+			getReaderChatErrorMessage(
+				'Reader Chat is not available because Jetpack Search is not available for this site.'
+			)
+		).toBe( 'Reader Chat is not available for this site.' );
+	} );
+
+	it( 'maps rate limit errors by status', () => {
+		expect( getReaderChatErrorMessage( { status: 429 } ) ).toBe(
+			'Too many requests. Please try again later.'
+		);
+	} );
+
+	it( 'maps rate limit errors by string status', () => {
+		expect( getReaderChatErrorMessage( { status: '429' } ) ).toBe(
+			'Too many requests. Please try again later.'
+		);
+	} );
+
+	it( 'maps rate limit errors by response status', () => {
+		expect( getReaderChatErrorMessage( { response: { status: '429' } } ) ).toBe(
+			'Too many requests. Please try again later.'
+		);
+	} );
+
+	it( 'maps rate limit errors by status code', () => {
+		expect( getReaderChatErrorMessage( { statusCode: 429 } ) ).toBe(
+			'Too many requests. Please try again later.'
+		);
+	} );
+
+	it( 'maps rate limit errors by code', () => {
+		expect( getReaderChatErrorMessage( { code: 'request_limit_exceeded' } ) ).toBe(
+			'Too many requests. Please try again later.'
+		);
+	} );
+
+	it( 'maps production rate limit message strings', () => {
+		expect( getReaderChatErrorMessage( 'Too many requests. Please try again later.' ) ).toBe(
+			'Too many requests. Please try again later.'
+		);
+	} );
+
+	it( 'maps wrapped rate limit Error messages', () => {
+		expect(
+			getReaderChatErrorMessage(
+				new Error( 'HTTP 429: Too many requests. Please try again later.' )
+			)
+		).toBe( 'Too many requests. Please try again later.' );
+	} );
+
+	it( 'uses generic copy for unknown string errors', () => {
+		expect( getReaderChatErrorMessage( 'Unexpected failure' ) ).toBe(
+			'Reader Chat is unavailable. Please try again later.'
+		);
+	} );
+
+	it( 'reads nested agentic error codes', () => {
+		expect( getReaderChatErrorMessage( { error: { code: 'jetpack_ai_usage' } } ) ).toBe(
+			'Reader Chat is temporarily unavailable because this site has reached its Jetpack Search usage limit.'
+		);
+	} );
+
+	it( 'reads nested agentic error messages', () => {
+		expect(
+			getReaderChatErrorMessage( {
+				error: {
+					message:
+						'Reader Chat is temporarily unavailable because this site has reached its Jetpack Search usage limit.',
+				},
+			} )
+		).toBe(
+			'Reader Chat is temporarily unavailable because this site has reached its Jetpack Search usage limit.'
+		);
+	} );
+} );

--- a/packages/agents-manager/src/utils/__tests__/reader-chat-error-message.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/reader-chat-error-message.test.ts
@@ -51,6 +51,12 @@ describe( 'getReaderChatErrorMessage', () => {
 		).toBe( 'Reader Chat is not available for this site.' );
 	} );
 
+	it( 'maps JSON-encoded unavailable error codes to stable Reader Chat copy', () => {
+		expect(
+			getReaderChatErrorMessage( new Error( '{"code":"reader_chat_search_not_supported"}' ) )
+		).toBe( 'Reader Chat is not available for this site.' );
+	} );
+
 	it( 'maps production unavailable message strings to stable Reader Chat copy', () => {
 		expect(
 			getReaderChatErrorMessage(

--- a/packages/agents-manager/src/utils/create-agent-config.ts
+++ b/packages/agents-manager/src/utils/create-agent-config.ts
@@ -216,7 +216,9 @@ export async function createAgentConfig(
 		agentUrl: ORCHESTRATOR_AGENT_URL,
 		sessionId,
 		sessionIdStorageKey: getSessionStorageKey( agentId ),
-		authProvider: createCalypsoAuthProvider( siteId ),
+		authProvider: createCalypsoAuthProvider( siteId, {
+			logWpcomJwtFailure: ! isReaderChatAgent( agentId ),
+		} ),
 		enableStreaming: true,
 	};
 

--- a/packages/agents-manager/src/utils/reader-chat-error-message.ts
+++ b/packages/agents-manager/src/utils/reader-chat-error-message.ts
@@ -1,0 +1,192 @@
+import { __ } from '@wordpress/i18n';
+
+type ReaderChatError = {
+	code?: unknown;
+	message?: unknown;
+	response?: {
+		status?: unknown;
+	};
+	status?: unknown;
+	statusCode?: unknown;
+	data?: {
+		code?: unknown;
+		message?: unknown;
+		status?: unknown;
+		statusCode?: unknown;
+	};
+	error?: {
+		code?: unknown;
+		message?: unknown;
+		status?: unknown;
+		statusCode?: unknown;
+	};
+};
+
+const SEARCH_LIMIT_ERROR_CODES = new Set( [
+	'reader_chat_search_ai_over_limit',
+	'reader_chat_search_over_limit',
+	'instant_search_overage',
+	'jetpack_ai_usage',
+] );
+
+const UNAVAILABLE_ERROR_CODES = new Set( [
+	'reader_chat_invalid_target',
+	'reader_chat_search_not_supported',
+	'ai_search_inactive',
+] );
+
+const RATE_LIMIT_ERROR_MESSAGE = 'Too many requests. Please try again later.';
+
+function readString( value: unknown ): string | undefined {
+	return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function readNumber( value: unknown ): number | undefined {
+	if ( typeof value === 'number' ) {
+		return Number.isFinite( value ) ? value : undefined;
+	}
+
+	if ( typeof value !== 'string' || value.trim().length === 0 ) {
+		return undefined;
+	}
+
+	const numberValue = Number( value );
+	return Number.isFinite( numberValue ) ? numberValue : undefined;
+}
+
+function getErrorCode( error: unknown ): string | undefined {
+	if ( ! error || typeof error !== 'object' ) {
+		return undefined;
+	}
+
+	const structuredError = error as ReaderChatError;
+	return (
+		readString( structuredError.code ) ||
+		readString( structuredError.data?.code ) ||
+		readString( structuredError.error?.code )
+	);
+}
+
+function getErrorMessage( error: unknown ): string | undefined {
+	if ( typeof error === 'string' ) {
+		return readString( error );
+	}
+
+	if ( ! error || typeof error !== 'object' ) {
+		return undefined;
+	}
+
+	const structuredError = error as ReaderChatError;
+	return (
+		readString( structuredError.message ) ||
+		readString( structuredError.data?.message ) ||
+		readString( structuredError.error?.message )
+	);
+}
+
+function getErrorCodeFromMessage( message: string | undefined ): string | undefined {
+	if ( ! message ) {
+		return undefined;
+	}
+
+	const codeMatch = message.match( /"code"\s*:\s*"([^"]+)"/ );
+	const code = codeMatch?.[ 1 ];
+	if ( code && SEARCH_LIMIT_ERROR_CODES.has( code ) ) {
+		return code;
+	}
+
+	if ( code && UNAVAILABLE_ERROR_CODES.has( code ) ) {
+		return code;
+	}
+
+	if ( 'request_limit_exceeded' === code ) {
+		return code;
+	}
+
+	return undefined;
+}
+
+function isSearchLimitMessage( message: string | undefined ): boolean {
+	if ( ! message ) {
+		return false;
+	}
+
+	const normalizedMessage = message.toLowerCase();
+	return (
+		normalizedMessage.includes( 'reached its jetpack search' ) &&
+		normalizedMessage.includes( 'usage limit' )
+	);
+}
+
+function isUnavailableMessage( message: string | undefined ): boolean {
+	if ( ! message ) {
+		return false;
+	}
+
+	const normalizedMessage = message.toLowerCase();
+	return normalizedMessage.includes( 'reader chat is not available' );
+}
+
+function isRateLimitMessage( message: string | undefined ): boolean {
+	if ( ! message ) {
+		return false;
+	}
+
+	const normalizedMessage = message.toLowerCase();
+	return (
+		normalizedMessage.includes( RATE_LIMIT_ERROR_MESSAGE.toLowerCase() ) ||
+		( /\b429\b/.test( message ) &&
+			( normalizedMessage.includes( 'too many requests' ) ||
+				normalizedMessage.includes( 'rate limit' ) ) )
+	);
+}
+
+function getErrorStatus( error: unknown ): number | undefined {
+	if ( ! error || typeof error !== 'object' ) {
+		return undefined;
+	}
+
+	const structuredError = error as ReaderChatError;
+	return (
+		readNumber( structuredError.status ) ??
+		readNumber( structuredError.statusCode ) ??
+		readNumber( structuredError.response?.status ) ??
+		readNumber( structuredError.data?.status ) ??
+		readNumber( structuredError.data?.statusCode ) ??
+		readNumber( structuredError.error?.status ) ??
+		readNumber( structuredError.error?.statusCode )
+	);
+}
+
+export function getReaderChatErrorMessage( error: unknown ): string | null {
+	if ( ! error ) {
+		return null;
+	}
+
+	const message = getErrorMessage( error );
+	const code = getErrorCode( error ) || getErrorCodeFromMessage( message );
+	const hasSearchLimitCode = code && SEARCH_LIMIT_ERROR_CODES.has( code );
+	const hasSearchLimitMessage = isSearchLimitMessage( message );
+	if ( hasSearchLimitCode || hasSearchLimitMessage ) {
+		return __(
+			'Reader Chat is temporarily unavailable because this site has reached its Jetpack Search usage limit.',
+			'__i18n_text_domain__'
+		);
+	}
+
+	const hasUnavailableCode = code && UNAVAILABLE_ERROR_CODES.has( code );
+	const hasUnavailableMessage = isUnavailableMessage( message );
+	if ( hasUnavailableCode || hasUnavailableMessage ) {
+		return __( 'Reader Chat is not available for this site.', '__i18n_text_domain__' );
+	}
+
+	if (
+		'request_limit_exceeded' === code ||
+		429 === getErrorStatus( error ) ||
+		isRateLimitMessage( message )
+	) {
+		return __( 'Too many requests. Please try again later.', '__i18n_text_domain__' );
+	}
+
+	return __( 'Reader Chat is unavailable. Please try again later.', '__i18n_text_domain__' );
+}


### PR DESCRIPTION
Part of #

## Proposed Changes

* Add a Reader Chat-specific error normalizer for Search plan, usage-limit, target, and rate-limit errors.
* Use the normalized error copy only for Reader Chat agents in the shared orchestrator chat component.
* Add unit coverage for the new normalizer.

## Why are these changes being made?

* Reader Chat is becoming public-facing and WPCOM can now reject requests because the site is not eligible for Jetpack Search or has reached its Search usage limit. The widget should show stable Reader Chat copy instead of raw backend error details.


## Strings for translation
- Reader Chat is temporarily unavailable because this site has reached its Jetpack Search usage limit.
- Reader Chat is unavailable. Please try again later.
<img width="399" height="556" alt="image" src="https://github.com/user-attachments/assets/ec802ff9-7af7-4215-9a10-3cf9adfd419c" />
<img width="388" height="542" alt="image" src="https://github.com/user-attachments/assets/6bc95a0d-7469-4196-9ab2-e25d43ca4f6f" />

## Testing Instructions

See WPCOM PR 218039

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?