### PR TITLE
Help Center: extend logged-out FAB to /log-in

### DIFF
--- a/client/landing/login/index.js
+++ b/client/landing/login/index.js
@@ -4,6 +4,7 @@
 import '@automattic/calypso-polyfills';
 
 import page from '@automattic/calypso-router';
+import { QueryClient } from '@tanstack/react-query';
 import { setupLocale } from 'calypso/boot/locale';
 import { render } from 'calypso/controller/web-util';
 import { initializeCurrentUser } from 'calypso/lib/user/shared-utils';
@@ -22,14 +23,20 @@ async function main() {
 	configureReduxStore( currentUser, store );
 	setupMiddlewares( currentUser, store );
 	setupLocale( currentUser, store );
+	// Plain client (no persistence): /log-in is logged-out-only, so the user-keyed
+	// cache from createQueryClient would never hit. Skips the async hydrate too.
+	// If this boot ever needs to support logged-in users, switch to createQueryClient().
+	const queryClient = new QueryClient();
 
 	page( '*', ( context, next ) => {
 		context.store = store;
+		context.queryClient = queryClient;
 		next();
 	} );
 
 	page.exit( '*', ( context, next ) => {
 		context.store = store;
+		context.queryClient = queryClient;
 		next();
 	} );
 

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -83,6 +83,7 @@ const loadSupportArticleDialog = () =>
 const HELP_CENTER_FAB_SECTIONS = [
 	'accept-invite',
 	'checkout',
+	'login',
 	'mailing-lists',
 	'patterns',
 	'performance-profiler',
@@ -171,13 +172,19 @@ const LayoutLoggedOut = ( {
 		! isJetpackCloud &&
 		! isWooOAuth2Client( oauth2Client );
 
+	// OAuth client logins (Gravatar, WPJobManager, Woo, etc.) and /log-in/jetpack
+	// have their own branding and support paths.
+	const isWpcomLogin = sectionName === 'login' && ! useOAuth2Layout && ! isJetpackLogin;
+
+	const isEligibleSection =
+		HELP_CENTER_FAB_SECTIONS.includes( sectionName ) && ( sectionName !== 'login' || isWpcomLogin );
+
 	// Logged-in users use the masterbar control instead.
 	// Reader tag embeds are widgets meant to be iframed by third parties — no FAB.
 	const showHelpCenterFab =
 		! isLoggedIn &&
 		isEnabled( 'help-center/logged-out-fab' ) &&
-		( HELP_CENTER_FAB_SECTIONS.includes( sectionName ) ||
-			HELP_CENTER_FAB_ROUTES.includes( currentRoute ) ) &&
+		( isEligibleSection || HELP_CENTER_FAB_ROUTES.includes( currentRoute ) ) &&
 		! isReaderTagEmbed &&
 		userAllowedToHelpCenter;
 

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -36,6 +36,7 @@ import {
 import { usePartnerBranding } from 'calypso/lib/partner-branding';
 import { createAccountUrl } from 'calypso/lib/paths';
 import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
+import untrailingslashit from 'calypso/lib/route/untrailingslashit';
 import { getOnboardingUrl as getPatternLibraryOnboardingUrl } from 'calypso/my-sites/patterns/paths';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getRedirectToOriginal, isTwoFactorEnabled } from 'calypso/state/login/selectors';
@@ -115,8 +116,7 @@ const isFabSafeLoginUrl = () => {
 		return false;
 	}
 	const { pathname, search, hash } = window.location;
-	const normalizedPath = pathname.replace( /\/+$/, '' );
-	return WPCOM_LOGIN_FAB_PATHNAMES.has( normalizedPath ) && ! search && ! hash;
+	return WPCOM_LOGIN_FAB_PATHNAMES.has( untrailingslashit( pathname ) ) && ! search && ! hash;
 };
 
 const LayoutLoggedOut = ( {
@@ -195,8 +195,7 @@ const LayoutLoggedOut = ( {
 		! isWooOAuth2Client( oauth2Client );
 
 	// OAuth client logins (Gravatar, WPJobManager, Woo, etc.) and /log-in/jetpack
-	// have their own branding and support paths. Other login sub-flows are filtered
-	// out by isFabSafeLoginUrl, which rejects URLs that carry secrets.
+	// have their own branding and support paths.
 	const isWpcomLogin =
 		sectionName === 'login' && ! useOAuth2Layout && ! isJetpackLogin && isFabSafeLoginUrl();
 

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -1,5 +1,6 @@
 import config, { isEnabled } from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
+import { getLanguageSlugs } from '@automattic/i18n-utils';
 import { Step } from '@automattic/onboarding';
 import { UniversalNavbarHeader, UniversalNavbarFooter } from '@automattic/wpcom-template-parts';
 import clsx from 'clsx';
@@ -97,6 +98,27 @@ const HELP_CENTER_FAB_SECTIONS = [
 // Fallback when section name is unreliable — e.g. /me/account/closed activates as 'me'.
 const HELP_CENTER_FAB_ROUTES = [ '/me/account/closed' ];
 
+// FAB safety on /log-in: window.location.href is forwarded to Zendesk verbatim by
+// packages/odie-client (use-create-zendesk-conversation: messaging_url/source).
+// Login sub-flows put secrets in the query (social handoff, OAuth callbacks,
+// magic-link, lostpassword) or fragment (desktop finalize, social-connect), and
+// ?redirect_to can wrap arbitrary OAuth URLs with tokens at any depth. We can't
+// safely introspect those, so allow only the bare credential form (with optional
+// locale) and require an empty query + fragment.
+const WPCOM_LOGIN_FAB_PATHNAMES = new Set( [
+	'/log-in',
+	...getLanguageSlugs().map( ( slug ) => `/log-in/${ slug }` ),
+] );
+
+const isFabSafeLoginUrl = () => {
+	if ( typeof window === 'undefined' ) {
+		return false;
+	}
+	const { pathname, search, hash } = window.location;
+	const normalizedPath = pathname.replace( /\/+$/, '' );
+	return WPCOM_LOGIN_FAB_PATHNAMES.has( normalizedPath ) && ! search && ! hash;
+};
+
 const LayoutLoggedOut = ( {
 	isAkismet,
 	isPassport,
@@ -173,8 +195,10 @@ const LayoutLoggedOut = ( {
 		! isWooOAuth2Client( oauth2Client );
 
 	// OAuth client logins (Gravatar, WPJobManager, Woo, etc.) and /log-in/jetpack
-	// have their own branding and support paths.
-	const isWpcomLogin = sectionName === 'login' && ! useOAuth2Layout && ! isJetpackLogin;
+	// have their own branding and support paths. Other login sub-flows are filtered
+	// out by isFabSafeLoginUrl, which rejects URLs that carry secrets.
+	const isWpcomLogin =
+		sectionName === 'login' && ! useOAuth2Layout && ! isJetpackLogin && isFabSafeLoginUrl();
 
 	const isEligibleSection =
 		HELP_CENTER_FAB_SECTIONS.includes( sectionName ) && ( sectionName !== 'login' || isWpcomLogin );

--- a/client/login/index.web.jsx
+++ b/client/login/index.web.jsx
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { getLanguageRouteParam } from '@automattic/i18n-utils';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { Provider as ReduxProvider } from 'react-redux';
 import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
 import { RouteProvider } from 'calypso/components/route';
@@ -33,6 +34,7 @@ export const LOGIN_SECTION_DEFINITION = {
 
 const ReduxWrappedLayout = ( {
 	store,
+	queryClient,
 	currentSection,
 	currentRoute,
 	currentQuery,
@@ -49,14 +51,16 @@ const ReduxWrappedLayout = ( {
 				currentRoute={ currentRoute }
 				currentQuery={ currentQuery }
 			>
-				<ReduxProvider store={ store }>
-					<LayoutLoggedOut
-						primary={ primary }
-						secondary={ secondary }
-						redirectUri={ redirectUri }
-						showGdprBanner={ showGdprBanner }
-					/>
-				</ReduxProvider>
+				<QueryClientProvider client={ queryClient }>
+					<ReduxProvider store={ store }>
+						<LayoutLoggedOut
+							primary={ primary }
+							secondary={ secondary }
+							redirectUri={ redirectUri }
+							showGdprBanner={ showGdprBanner }
+						/>
+					</ReduxProvider>
+				</QueryClientProvider>
 			</RouteProvider>
 		</CalypsoI18nProvider>
 	);


### PR DESCRIPTION
Part of HAP-2869.

## Proposed Changes

- Adds `'login'` to `HELP_CENTER_FAB_SECTIONS` so the logged-out Help Center FAB renders on the WPCOM-branded `/log-in` flow.
- Excludes OAuth client logins (Gravatar, WPJobManager, Woo, etc.) and `/log-in/jetpack` via a new `isWpcomLogin` check — they have their own branding and support paths.
- Wires up a `QueryClient` for the login entry. The login bundle didn't previously set one up; the Help Center component uses TanStack Query and would crash on mount without a `QueryClientProvider`. The login boot now creates a plain `new QueryClient()` (no persistence — `/log-in` is logged-out-only and the user-keyed cache would never hit) and attaches it to page context, and `ReduxWrappedLayout` in `client/login/index.web.jsx` wraps the tree in `QueryClientProvider`. This mirrors the SSR `ProviderWrappedLoggedOutLayout` in `client/controller/index.node.jsx`.

## Why are these changes being made?

Continues the rollout of the logged-out Help Center FAB to authenticated-adjacent surfaces, giving visitors stuck on `/log-in` access to pre-sales chat without needing an account.

## Testing Instructions

1. Enable the `help-center/logged-out-fab` feature flag.
2. Sign out and visit `/log-in` → the Help Center FAB should appear.
3. Visit `/log-in/jetpack` → no FAB.
4. Visit `/log-in?client_id=…` for any OAuth client (Gravatar, WPJobManager, Woo, BlazePro) → no FAB.
5. Open the FAB and confirm no QueryClient errors in the console.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you checked for TypeScript, React or other console errors?