### PR TITLE
Help Center: extend logged-out FAB to /reader

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -87,6 +87,7 @@ const HELP_CENTER_FAB_SECTIONS = [
 	'patterns',
 	'performance-profiler',
 	'plugins',
+	'reader',
 	'site-profiler',
 	'theme',
 	'themes',
@@ -171,11 +172,13 @@ const LayoutLoggedOut = ( {
 		! isWooOAuth2Client( oauth2Client );
 
 	// Logged-in users use the masterbar control instead.
+	// Reader tag embeds are widgets meant to be iframed by third parties — no FAB.
 	const showHelpCenterFab =
 		! isLoggedIn &&
 		isEnabled( 'help-center/logged-out-fab' ) &&
 		( HELP_CENTER_FAB_SECTIONS.includes( sectionName ) ||
 			HELP_CENTER_FAB_ROUTES.includes( currentRoute ) ) &&
+		! isReaderTagEmbed &&
 		userAllowedToHelpCenter;
 
 	const loadHelpCenter =


### PR DESCRIPTION
Part of HAP-2873.

## Proposed Changes

- Adds `'reader'` to `HELP_CENTER_FAB_SECTIONS` so the logged-out Help Center FAB renders on all Reader surfaces. Every Reader path uses `sectionName === 'reader'` in `client/sections.js` (`/reader`, `/read/...`, `/discover`, `/tags`, `/tag`, `/reader/search`, `/recommendations`, `/reader/feeds/...`, `/reader/blogs/...`, `/reader/a8c`, `/reader/p2`), so one allowlist entry covers them all.
- Excludes Reader tag embed pages (`/tag/<name>?type=embed`) — they're widgets meant to be iframed by third parties, and the existing layout already nulls the masterbar for them. The FAB now matches that behavior via the existing `isReaderTagEmbed` derivation.

## Why are these changes being made?

Continues the rollout of the logged-out Help Center FAB to give visitors stuck on Reader pages access to pre-sales chat without needing an account.

## Testing Instructions

1. Enable the `help-center/logged-out-fab` feature flag.
2. Sign out and visit `/reader`, `/discover`, `/tags`, `/tag/<any>`, `/reader/search`, `/recommendations` → the Help Center FAB should appear.
3. Visit `/tag/<any>?type=embed` → no FAB (and no masterbar, as today).
4. Open the FAB and confirm no console errors.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you checked for TypeScript, React or other console errors?