### PR TITLE
Help Center: extend logged-out FAB to /start and /setup

### DIFF
--- a/client/components/help-center-fab/index.tsx
+++ b/client/components/help-center-fab/index.tsx
@@ -2,6 +2,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
+import { useEffect } from 'react';
 import useShowHelpCenter from 'calypso/components/help-center/use-show-help-center';
 import { useCurrentRoute } from 'calypso/components/route';
 import HelpCenterLoader from 'calypso/layout/help-center-loader';
@@ -32,6 +33,13 @@ const HelpCenterFab = ( { sectionName }: HelpCenterFabProps ) => {
 	const { __ } = useI18n();
 	const { isShown: isHelpCenterShown, setShowHelpCenter } = useShowHelpCenter();
 	const { currentRoute } = useCurrentRoute();
+
+	// The Help Center panel's "above the FAB" positioning keys off this body
+	// class — see `body.has-help-center-fab` in `./style.scss`.
+	useEffect( () => {
+		document.body.classList.add( 'has-help-center-fab' );
+		return () => document.body.classList.remove( 'has-help-center-fab' );
+	}, [] );
 
 	const handleClick = () => {
 		const willShow = ! isHelpCenterShown;

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -26,6 +26,7 @@ import { setupLocale } from 'calypso/boot/locale';
 import AsyncLoad from 'calypso/components/async-load';
 import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
 import { AsyncHelpCenterApp } from 'calypso/components/help-center';
+import AsyncHelpCenterFab from 'calypso/components/help-center-fab/async';
 import getSuperProps from 'calypso/lib/analytics/super-props';
 import { setupErrorLogger } from 'calypso/lib/error-logger/setup-error-logger';
 import loadDevHelpers from 'calypso/lib/load-dev-helpers';
@@ -291,6 +292,11 @@ async function main() {
 									sectionName={ flowName }
 									loadAgentsManager
 								/>
+								{ /* The stepper has no masterbar or help button, so logged-out visitors
+								   have no way to summon the Help Center otherwise. */ }
+								{ ! user && config.isEnabled( 'help-center/logged-out-fab' ) && (
+									<AsyncHelpCenterFab sectionName="stepper" />
+								) }
 							</>
 						) ) }
 					{ 'development' === process.env.NODE_ENV && (

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -91,6 +91,7 @@ const HELP_CENTER_FAB_SECTIONS = [
 	'performance-profiler',
 	'plugins',
 	'reader',
+	'signup',
 	'site-profiler',
 	'theme',
 	'themes',
@@ -199,8 +200,14 @@ const LayoutLoggedOut = ( {
 	const isWpcomLogin =
 		sectionName === 'login' && ! useOAuth2Layout && ! isJetpackLogin && isFabSafeLoginUrl();
 
+	// OAuth client signups (Woo, BlazePro, Gravatar, WPJobManager, etc.) likewise
+	// run under their own brand and route support elsewhere.
+	const isWpcomSignup = sectionName === 'signup' && ! useOAuth2Layout;
+
 	const isEligibleSection =
-		HELP_CENTER_FAB_SECTIONS.includes( sectionName ) && ( sectionName !== 'login' || isWpcomLogin );
+		HELP_CENTER_FAB_SECTIONS.includes( sectionName ) &&
+		( sectionName !== 'login' || isWpcomLogin ) &&
+		( sectionName !== 'signup' || isWpcomSignup );
 
 	// Logged-in users use the masterbar control instead.
 	// Reader tag embeds are widgets meant to be iframed by third parties — no FAB.
@@ -342,10 +349,6 @@ const LayoutLoggedOut = ( {
 	}
 
 	const bodyClass = [ 'font-smoothing-antialiased' ];
-	if ( showHelpCenterFab ) {
-		// See `body.has-help-center-fab` in `help-center-fab/style.scss`.
-		bodyClass.push( 'has-help-center-fab' );
-	}
 
 	return (
 		<Step.StepContainerV2Provider value={ stepContainerV2Context }>


### PR DESCRIPTION
Part of HAP-2869.

## Proposed Changes

Cover the two signup entry points still missing from the logged-out Help Center FAB rollout:

- **Legacy `/start/*` flows** — every flow other than `/start/onboarding` (which redirects to the Stepper). Adds `'signup'` to `HELP_CENTER_FAB_SECTIONS` in `client/layout/logged-out.jsx`, with the same OAuth-context carveout that `/log-in` already uses so Woo, BlazePro, Gravatar, and WPJobManager signups continue to route their own support flow.
- **`/setup` (Stepper bundle)** — render `AsyncHelpCenterFab` for logged-out visitors when the `help-center/logged-out-fab` flag is on. The Stepper has no masterbar or help button, so logged-out visitors had no way to summon the panel before. Gated by the existing `FLOWS_WITHOUT_HELP_CENTER` set and the Woo-hosted-plans branch.

Also moves the `has-help-center-fab` body class management into the `HelpCenterFab` component itself. The Help Center panel's "above the FAB" positioning keys off that class, and the Stepper has no equivalent of `LayoutLoggedOut`'s `bodyClass` mechanism — owning the class in the FAB fixes positioning anywhere it mounts and removes a duplicate push.

## Why are these changes being made?

Continues the rollout of the logged-out Help Center FAB to give signup visitors access to pre-sales chat. `/start` and `/setup` are the primary entry points new users see.

## Testing Instructions

1. Enable the `help-center/logged-out-fab` feature flag.
2. Sign out and visit `/start/onboarding` → redirects to `/setup/onboarding/user` → FAB should appear and the panel should open 8px above the button.
3. Visit `/start/free`, `/start/business`, `/start/import` (or any non-onboarding `/start/*` flow) → FAB should appear.
4. Visit `/start/wpcc` (Woo) → no FAB (OAuth carveout).
5. Visit `/setup/ai-site-builder` → no FAB (`FLOWS_WITHOUT_HELP_CENTER` excludes it).
6. Open the FAB and confirm no console errors.

## Follow-ups out of scope here

- `/log-in?redirect_to=…&signup_url=…` (the link from the signup screen's "Log in" button) still suppresses the FAB because of the strict empty-query rule shipped in #110788. A separate issue will sanitize URLs at the odie-client boundary so the gate can relax.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you checked for TypeScript, React or other console errors?