### PR TITLE
Reader Mastodon: normalize instance input on the connect form

### DIFF
--- a/client/reader/mastodon/connect-form.tsx
+++ b/client/reader/mastodon/connect-form.tsx
@@ -7,6 +7,7 @@ import {
 } from '@wordpress/components';
 import { useTranslate, type TranslateResult } from 'i18n-calypso';
 import { useState, type FormEvent } from 'react';
+import { normalizeInstance } from './utils/normalize-instance';
 import type { MastodonError } from '@automattic/api-core';
 
 interface ConnectFormProps {
@@ -25,7 +26,11 @@ export function ConnectForm( { onSubmit, isSubmitting, error }: ConnectFormProps
 		if ( ! canSubmit ) {
 			return;
 		}
-		onSubmit( { instance: instance.trim() } );
+		const normalized = normalizeInstance( instance );
+		if ( ! normalized ) {
+			return;
+		}
+		onSubmit( { instance: normalized } );
 	};
 
 	return (

--- a/client/reader/mastodon/test/connect-form.test.tsx
+++ b/client/reader/mastodon/test/connect-form.test.tsx
@@ -33,6 +33,21 @@ describe( 'ConnectForm', () => {
 		expect( onSubmit ).toHaveBeenCalledWith( { instance: 'mastodon.social' } );
 	} );
 
+	it.each( [
+		[ 'https://mastodon.social', 'mastodon.social' ],
+		[ 'https://mastodon.social/', 'mastodon.social' ],
+		[ 'https://mastodon.social/@user', 'mastodon.social' ],
+		[ '@user@mastodon.social', 'mastodon.social' ],
+		[ 'Mastodon.Social', 'mastodon.social' ],
+	] )( 'normalizes %s to %s before submitting', async ( typed, expected ) => {
+		const user = userEvent.setup();
+		const onSubmit = jest.fn();
+		render( <ConnectForm onSubmit={ onSubmit } isSubmitting={ false } error={ null } /> );
+		await user.type( screen.getByLabelText( /instance/i ), typed );
+		await user.click( screen.getByRole( 'button', { name: /continue/i } ) );
+		expect( onSubmit ).toHaveBeenCalledWith( { instance: expected } );
+	} );
+
 	it( 'disables submit and shows busy state while submitting', () => {
 		render( <ConnectForm onSubmit={ jest.fn() } isSubmitting error={ null } /> );
 		const button = screen.getByRole( 'button', { name: /continue/i } );

--- a/client/reader/mastodon/utils/normalize-instance.ts
+++ b/client/reader/mastodon/utils/normalize-instance.ts
@@ -1,0 +1,78 @@
+/**
+ * Normalize user input into a bare Mastodon instance host.
+ *
+ * The backend `/reader/mastodon/connections` endpoint expects an `instance`
+ * value shaped like `mastodon.social`, not a URL or a handle. We accept a
+ * range of natural inputs and reduce them to that shape:
+ *
+ * - `mastodon.social`              → `mastodon.social`
+ * - `https://mastodon.social`      → `mastodon.social`
+ * - `https://mastodon.social/`     → `mastodon.social`
+ * - `https://mastodon.social/@me`  → `mastodon.social`
+ * - `@user@mastodon.social`        → `mastodon.social`
+ * - `user@mastodon.social`         → `mastodon.social`
+ * - `Mastodon.Social`              → `mastodon.social`
+ * - `mastodon.social:8443`         → `mastodon.social:8443`
+ * - `mastodon.social.`             → `mastodon.social` (trailing dot)
+ *
+ * If the input can't be parsed into a host, return the trimmed original so
+ * the backend's `invalid_instance` error surfaces normally rather than
+ * sending an empty body.
+ */
+export function normalizeInstance( input: string ): string {
+	const trimmed = input.trim();
+	if ( ! trimmed ) {
+		return '';
+	}
+
+	// Strip a leading Mastodon-style handle prefix (`@user@`) so what remains
+	// is something `URL` can parse. The inner `@` in userinfo can confuse
+	// URL parsers across engines; pre-stripping is the safer path.
+	const withoutHandle = trimmed.replace( /^@[^@/\s]+@/, '' );
+
+	const explicitScheme = withoutHandle.match( /^([a-z][a-z0-9+.-]*):\/\//i );
+	if ( explicitScheme && ! /^https?$/i.test( explicitScheme[ 1 ] ) ) {
+		return trimmed;
+	}
+
+	if ( ! explicitScheme ) {
+		const bareHandle = withoutHandle.match( /^[^@:/\s]+@(.+)$/ );
+		if ( bareHandle ) {
+			return hostFromInput( bareHandle[ 1 ] ) ?? trimmed;
+		}
+	}
+
+	try {
+		const url = new URL( explicitScheme ? withoutHandle : `https://${ withoutHandle }` );
+		if ( url.username || url.password ) {
+			return trimmed;
+		}
+
+		const remoteProfile = url.pathname.match( /^\/@[^@/\s]+@([^/?#]+)/ );
+		if ( remoteProfile ) {
+			return hostFromInput( remoteProfile[ 1 ] ) ?? trimmed;
+		}
+
+		return formatUrlHost( url );
+	} catch {
+		return trimmed;
+	}
+}
+
+function hostFromInput( input: string ): string | null {
+	try {
+		const url = new URL( `https://${ input }` );
+		if ( url.username || url.password ) {
+			return null;
+		}
+		return formatUrlHost( url );
+	} catch {
+		return null;
+	}
+}
+
+function formatUrlHost( url: URL ): string {
+	// `URL.hostname` is already lowercased per the WHATWG URL spec.
+	const hostname = url.hostname.endsWith( '.' ) ? url.hostname.slice( 0, -1 ) : url.hostname;
+	return url.port ? `${ hostname }:${ url.port }` : hostname;
+}

--- a/client/reader/mastodon/utils/test/normalize-instance.test.ts
+++ b/client/reader/mastodon/utils/test/normalize-instance.test.ts
@@ -1,0 +1,90 @@
+import { normalizeInstance } from '../normalize-instance';
+
+describe( 'normalizeInstance', () => {
+	it( 'returns a bare host unchanged', () => {
+		expect( normalizeInstance( 'mastodon.social' ) ).toBe( 'mastodon.social' );
+	} );
+
+	it( 'strips https:// scheme', () => {
+		expect( normalizeInstance( 'https://mastodon.social' ) ).toBe( 'mastodon.social' );
+	} );
+
+	it( 'strips http:// scheme', () => {
+		expect( normalizeInstance( 'http://mastodon.social' ) ).toBe( 'mastodon.social' );
+	} );
+
+	it( 'strips a trailing slash', () => {
+		expect( normalizeInstance( 'https://mastodon.social/' ) ).toBe( 'mastodon.social' );
+		expect( normalizeInstance( 'mastodon.social/' ) ).toBe( 'mastodon.social' );
+	} );
+
+	it( 'strips a profile path', () => {
+		expect( normalizeInstance( 'https://mastodon.social/@user' ) ).toBe( 'mastodon.social' );
+	} );
+
+	it( 'strips an arbitrary path, query, and fragment', () => {
+		expect( normalizeInstance( 'https://mastodon.social/explore?foo=bar#top' ) ).toBe(
+			'mastodon.social'
+		);
+	} );
+
+	it( 'extracts host from a full Mastodon handle (@user@host)', () => {
+		expect( normalizeInstance( '@user@mastodon.social' ) ).toBe( 'mastodon.social' );
+	} );
+
+	it( 'extracts host from a handle without a leading @ (user@host)', () => {
+		expect( normalizeInstance( 'user@mastodon.social' ) ).toBe( 'mastodon.social' );
+	} );
+
+	it( 'extracts host from a remote profile URL path', () => {
+		expect( normalizeInstance( 'https://mastodon.social/@alice@example.com' ) ).toBe(
+			'example.com'
+		);
+	} );
+
+	it( 'lowercases the host', () => {
+		expect( normalizeInstance( 'Mastodon.Social' ) ).toBe( 'mastodon.social' );
+		expect( normalizeInstance( 'HTTPS://Mastodon.Social' ) ).toBe( 'mastodon.social' );
+	} );
+
+	it( 'trims surrounding whitespace', () => {
+		expect( normalizeInstance( '   mastodon.social   ' ) ).toBe( 'mastodon.social' );
+		expect( normalizeInstance( '  https://mastodon.social/  ' ) ).toBe( 'mastodon.social' );
+	} );
+
+	it( 'strips a trailing dot from the host', () => {
+		expect( normalizeInstance( 'mastodon.social.' ) ).toBe( 'mastodon.social' );
+	} );
+
+	it( 'preserves an explicit port', () => {
+		expect( normalizeInstance( 'mastodon.social:8443' ) ).toBe( 'mastodon.social:8443' );
+		expect( normalizeInstance( 'https://mastodon.social:8443' ) ).toBe( 'mastodon.social:8443' );
+	} );
+
+	it( 'passes through unsupported schemes for backend validation', () => {
+		expect( normalizeInstance( 'ftp://mastodon.social' ) ).toBe( 'ftp://mastodon.social' );
+		expect( normalizeInstance( 'javascript://mastodon.social/%0Aalert(1)' ) ).toBe(
+			'javascript://mastodon.social/%0Aalert(1)'
+		);
+		expect( normalizeInstance( 'mailto:user@mastodon.social' ) ).toBe(
+			'mailto:user@mastodon.social'
+		);
+	} );
+
+	it( 'passes through explicit URLs with userinfo for backend validation', () => {
+		expect( normalizeInstance( 'https://mastodon.social@evil.example' ) ).toBe(
+			'https://mastodon.social@evil.example'
+		);
+	} );
+
+	it( 'returns an empty string for empty input', () => {
+		expect( normalizeInstance( '' ) ).toBe( '' );
+		expect( normalizeInstance( '   ' ) ).toBe( '' );
+	} );
+
+	it( 'returns the trimmed input when it cannot be parsed', () => {
+		// A space inside a hostname makes URL parsing throw. We pass it through
+		// so the backend surfaces the usual `invalid_instance` error.
+		expect( normalizeInstance( '  not a host  ' ) ).toBe( 'not a host' );
+	} );
+} );

--- a/client/reader/mastodon/utils/test/normalize-instance.test.ts
+++ b/client/reader/mastodon/utils/test/normalize-instance.test.ts
@@ -56,6 +56,21 @@ describe( 'normalizeInstance', () => {
 		expect( normalizeInstance( 'mastodon.social.' ) ).toBe( 'mastodon.social' );
 	} );
 
+	it.each( [
+		[ 'fedi.instance.tld', 'fedi.instance.tld' ],
+		[ 'https://fedi.instance.tld', 'fedi.instance.tld' ],
+		[ 'https://fedi.instance.tld/', 'fedi.instance.tld' ],
+		[ 'https://fedi.instance.tld/@user', 'fedi.instance.tld' ],
+		[ 'https://fedi.instance.tld/web/timelines/home', 'fedi.instance.tld' ],
+		[ '@user@fedi.instance.tld', 'fedi.instance.tld' ],
+		[ 'user@fedi.instance.tld', 'fedi.instance.tld' ],
+		[ 'Fedi.Instance.TLD', 'fedi.instance.tld' ],
+		[ 'fedi.instance.tld:8443', 'fedi.instance.tld:8443' ],
+		[ 'social.fedi.instance.tld', 'social.fedi.instance.tld' ],
+	] )( 'normalizes subdomain host %s to %s', ( input, expected ) => {
+		expect( normalizeInstance( input ) ).toBe( expected );
+	} );
+
 	it( 'preserves an explicit port', () => {
 		expect( normalizeInstance( 'mastodon.social:8443' ) ).toBe( 'mastodon.social:8443' );
 		expect( normalizeInstance( 'https://mastodon.social:8443' ) ).toBe( 'mastodon.social:8443' );


### PR DESCRIPTION
Fixes CM-737

## Proposed Changes

* Add `client/reader/mastodon/utils/normalize-instance.ts` that reduces a range of natural inputs (`https://example.tld`, `https://example.tld/@user`, `@user@example.tld`, `user@example.tld`, mixed case, trailing slashes, trailing dots) down to the bare host the backend expects.
* Call the helper from `ConnectForm.handleSubmit` so the connect view sends a clean `instance` to `/reader/mastodon/connections`. Unsupported schemes (`ftp:`, `javascript:`, `mailto:`) and userinfo-bearing URLs pass through trimmed so the backend's `invalid_instance` error surfaces instead of being silently rewritten. Explicit ports are preserved.
* Add a focused test suite for the helper and a parameterized integration test on `ConnectForm` that exercises the five most common shapes.

## Why are these changes being made?

* The connect form currently expects exactly `example.tld`. A user who pastes `https://example.tld` (or a profile URL, or a full Mastodon handle) hits an `invalid_instance` error with no indication of what's wrong. Normalizing on submit removes that paper cut while keeping the field forgiving for paste, edit, and partial typing.

## Testing Instructions

* Visit `/reader/mastodon/connect`.
* Try each of these in the Instance field and confirm Continue proceeds to OAuth for the expected host: `mastodon.social`, `https://mastodon.social`, `https://mastodon.social/`, `https://mastodon.social/@user`, `@user@mastodon.social`, `Mastodon.Social`.
* Try `ftp://mastodon.social` and confirm the backend still rejects it as `invalid_instance` (we don't rewrite unsupported schemes).
* `yarn test-client client/reader/mastodon/utils client/reader/mastodon/test/connect-form.test.tsx` — 34 tests pass.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?