### PR TITLE
A4A: Add Enterprise method to Claude Desktop MCP setup

### DIFF
--- a/client/a8c-for-agencies/sections/ai-mcp/primary/connect-agent/agent-configs.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/connect-agent/agent-configs.tsx
@@ -5,11 +5,17 @@ import type { ReactNode } from 'react';
 
 export const A4A_MCP_URL = 'https://public-api.wordpress.com/wpcom/v2/a4a-mcp/v1';
 
+export interface QuickSetupGroup {
+	title: ReactNode;
+	steps: ReactNode[];
+}
+
 export interface AgentConfig {
 	id: string;
 	label: string;
 	quickSetupDescription?: string;
 	quickSetup?: ReactNode[];
+	quickSetupGroups?: QuickSetupGroup[];
 	installAction?: {
 		label: string;
 		deepLink: string;
@@ -88,20 +94,45 @@ export const AGENT_CONFIGS: AgentConfig[] = [
 	{
 		id: 'claude-desktop',
 		label: 'Claude Desktop',
-		quickSetup: [
-			__( 'Open Claude Desktop and go to Settings → Connectors (or Customize).' ),
-			__( 'Click “Add custom connector”.' ),
-			createInterpolateElement(
-				sprintf(
-					/* translators: %s: A4A MCP server URL, kept inside <code> */
-					__(
-						'Enter a name (for example, “A4A MCP”) and paste <code>%s</code> into the Remote MCP server URL field.'
+		quickSetupDescription: __( 'Choose the method that matches your Claude Desktop account.' ),
+		quickSetupGroups: [
+			{
+				title: __( 'Connectors (recommended)' ),
+				steps: [
+					__( 'Open Claude Desktop and go to Settings → Connectors (or Customize).' ),
+					__( 'Click “Add custom connector”.' ),
+					createInterpolateElement(
+						sprintf(
+							/* translators: %s: A4A MCP server URL, kept inside <code> */
+							__(
+								'Enter a name (for example, “A4A MCP”) and paste <code>%s</code> into the Remote MCP server URL field.'
+							),
+							A4A_MCP_URL
+						),
+						{ code: <code /> }
 					),
-					A4A_MCP_URL
-				),
-				{ code: <code /> }
-			),
-			__( 'Authenticate when Claude Desktop prompts you in your browser.' ),
+					__( 'Authenticate when Claude Desktop prompts you in your browser.' ),
+				],
+			},
+			{
+				title: __( 'Developer config (for Claude Enterprise accounts)' ),
+				steps: [
+					__( 'Install Node 20 or later (required by mcp-remote).' ),
+					__(
+						'Open Claude Desktop → Settings → Developer, then click “Edit Config” under Local MCP servers.'
+					),
+					createInterpolateElement(
+						__(
+							'Add the configuration below to <code>claude_desktop_config.json</code> (typically at <code>~/Library/Application Support/Claude/claude_desktop_config.json</code>).'
+						),
+						{ code: <code /> }
+					),
+					__( 'Restart Claude Desktop.' ),
+					__(
+						'If you haven’t authenticated yet, Claude Desktop will prompt you in your browser as soon as it reopens.'
+					),
+				],
+			},
 		],
 		manualSetupFile: 'claude_desktop_config.json',
 		manualSetupLanguage: 'json',

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/connect-agent/connect-agent-content.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/connect-agent/connect-agent-content.tsx
@@ -96,7 +96,8 @@ export default function AiMcpConnectAgentContent() {
 					</CardBody>
 				</Card>
 
-				{ selectedAgent.quickSetup && selectedAgent.quickSetup.length > 0 && (
+				{ ( ( selectedAgent.quickSetup && selectedAgent.quickSetup.length > 0 ) ||
+					( selectedAgent.quickSetupGroups && selectedAgent.quickSetupGroups.length > 0 ) ) && (
 					<Card>
 						<CardBody>
 							<VStack spacing={ 3 }>
@@ -106,13 +107,28 @@ export default function AiMcpConnectAgentContent() {
 								{ selectedAgent.quickSetupDescription && (
 									<Text variant="muted">{ selectedAgent.quickSetupDescription }</Text>
 								) }
-								<ol>
-									{ selectedAgent.quickSetup.map( ( step, idx ) => (
-										<li key={ idx }>
-											<Text>{ step }</Text>
-										</li>
-									) ) }
-								</ol>
+								{ selectedAgent.quickSetupGroups ? (
+									selectedAgent.quickSetupGroups.map( ( group, gIdx ) => (
+										<VStack key={ gIdx } spacing={ 2 }>
+											<Text weight={ 500 }>{ group.title }</Text>
+											<ol>
+												{ group.steps.map( ( step, idx ) => (
+													<li key={ idx }>
+														<Text>{ step }</Text>
+													</li>
+												) ) }
+											</ol>
+										</VStack>
+									) )
+								) : (
+									<ol>
+										{ selectedAgent.quickSetup?.map( ( step, idx ) => (
+											<li key={ idx }>
+												<Text>{ step }</Text>
+											</li>
+										) ) }
+									</ol>
+								) }
 								{ selectedAgent.installAction && (
 									<>
 										<Text>{ __( 'Or use the one-click install to add the A4A MCP app.' ) }</Text>


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/A4A-2608/update-claude-desktop-setup-instructions-to-use-the-connectors-flow

## Proposed Changes

* Show both Claude Desktop setup methods on the A4A → AI MCP → Connect agent page so users can pick the one that matches their account:
  * **Connectors (recommended)** — Settings → Connectors (or Customize) → Add custom connector, paste the A4A MCP URL, authenticate in the browser.
  * **Developer config (for Claude Enterprise accounts)** — Install Node 20, open Settings → Developer → "Edit Config", add the mcp-remote block to `claude_desktop_config.json`, restart, authenticate.
* Add a `QuickSetupGroup` shape (`{ title, steps }`) and an optional `quickSetupGroups` field on `AgentConfig`. When present, the Quick setup card renders each group as a labelled sub-block with its own ordered list; otherwise it falls back to the existing flat `quickSetup` array used by Claude Code, Cursor, Codex, and VS Code.
* Add a `quickSetupDescription` prompting the user to choose.

## Why are these changes being made?

Claude Enterprise accounts don't expose the Connectors menu, so the simplified flow we shipped in #110749 isn't usable for them — they still need the Settings → Developer → "Edit Config" path with `mcp-remote`. Rather than picking one audience over the other, surface both methods side-by-side under clear sub-headings so each user can follow the right one.

## Testing Instructions

* Open the A4A live link > open A4A → AI MCP → Connect agent.
* Select **Claude Desktop** in the assistant dropdown. The Quick setup card should now show:
  * Description: "Choose the method that matches your Claude Desktop account."
  * Sub-heading **Connectors (recommended)** with 4 numbered steps, including the URL `https://public-api.wordpress.com/wpcom/v2/a4a-mcp/v1` inside a `<code>` element.
  * Sub-heading **Developer config (for Claude Enterprise accounts)** with 5 numbered steps (Node 20 → Edit Config → add JSON → restart → auth).
* Switch to **Claude Code**, **Cursor**, **Codex**, **VS Code**, and **Other MCP client** — each should render unchanged (single ordered list, no group headings).
* Confirm the Manual setup section still renders the `mcp-remote` snippet below.

<img width="1920" height="961" alt="Screenshot 2026-05-18 at 3 05 42 PM" src="https://github.com/user-attachments/assets/353261e1-58e1-4643-b663-121bb3a07c5a" />


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?