### PR TITLE
Help Center: relax /log-in FAB gate to a token-bearing deny-list

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -100,24 +100,29 @@ const HELP_CENTER_FAB_SECTIONS = [
 // Fallback when section name is unreliable — e.g. /me/account/closed activates as 'me'.
 const HELP_CENTER_FAB_ROUTES = [ '/me/account/closed' ];
 
-// FAB safety on /log-in: window.location.href is forwarded to Zendesk verbatim by
-// packages/odie-client (use-create-zendesk-conversation: messaging_url/source).
-// Login sub-flows put secrets in the query (social handoff, OAuth callbacks,
-// magic-link, lostpassword) or fragment (desktop finalize, social-connect), and
-// ?redirect_to can wrap arbitrary OAuth URLs with tokens at any depth. We can't
-// safely introspect those, so allow only the bare credential form (with optional
-// locale) and require an empty query + fragment.
+// /log-in briefly carries social-handoff tokens before the login controller strips
+// them (?access_token / ?id_token in query, #id_token / #client_id in hash).
+// Suppress the FAB during that window so window.location.href doesn't reach Zendesk.
 const WPCOM_LOGIN_FAB_PATHNAMES = new Set( [
 	'/log-in',
 	...getLanguageSlugs().map( ( slug ) => `/log-in/${ slug }` ),
 ] );
+
+const TOKEN_BEARING_LOGIN_QUERY_KEYS = [ 'access_token', 'id_token' ];
 
 const isFabSafeLoginUrl = () => {
 	if ( typeof window === 'undefined' ) {
 		return false;
 	}
 	const { pathname, search, hash } = window.location;
-	return WPCOM_LOGIN_FAB_PATHNAMES.has( untrailingslashit( pathname ) ) && ! search && ! hash;
+	if ( ! WPCOM_LOGIN_FAB_PATHNAMES.has( untrailingslashit( pathname ) ) || hash ) {
+		return false;
+	}
+	if ( ! search ) {
+		return true;
+	}
+	const params = new URLSearchParams( search );
+	return ! TOKEN_BEARING_LOGIN_QUERY_KEYS.some( ( key ) => params.has( key ) );
 };
 
 const LayoutLoggedOut = ( {


### PR DESCRIPTION
## Proposed Changes

Replace the empty-query/empty-fragment rule shipped in #110788 with a tiny deny-list: still gate `/log-in` to the bare credential form (pathname allowlist), still reject any hash (covers `#id_token` / `#client_id` from social-connect), but only reject query strings that carry the known social-handoff credential keys `access_token` / `id_token`.

## Why are these changes being made?

#110788 was strict enough to suppress the FAB on the most common `/log-in` URL — the link from the signup screen's "Log in" button, `/log-in?redirect_to=…&signup_url=…`. That broke pre-sales chat exactly for the visitors most likely to need it.

The strict rule was protecting `window.location.href` from being forwarded verbatim to Zendesk in `packages/odie-client/src/hooks/use-create-zendesk-conversation.ts` (`messaging_url` / `messaging_source`). But that same leak applies to `/checkout`, `/reader`, `/signup`, and every other FAB-eligible surface on trunk today — `/log-in`'s strict gate was the outlier rather than the standard.

The right centralized fix is to scrub URLs at the odie-client boundary so every Help Center surface is protected, not just `/log-in`. That's a separate issue against the odie-client owners. In the meantime, narrow `/log-in`'s gate to the only realistic credential leak vector on the pathname: the brief window between the social-handoff redirect landing on `/log-in?access_token=…&id_token=…` and `enhanceContextWithLogin` in `client/login/controller.jsx` stripping those keys via `page.redirect`. Token-bearing sub-paths (desktop finalize, magic-link use, lostpassword, 2FA, OAuth callbacks) are unchanged — they were never reachable through `WPCOM_LOGIN_FAB_PATHNAMES`.

## Testing Instructions

With `help-center/logged-out-fab` enabled, signed out:

- `/log-in` → FAB ✓
- `/log-in/de` (and other supported locales, including `de_formal`) → FAB ✓
- `/log-in?redirect_to=/setup/onboarding/domains&signup_url=/setup/onboarding/user` → FAB ✓ (the regression #110788 introduced — fixed)
- `/log-in?email_address=foo@example.com&ref=signup` → FAB ✓
- `/log-in?access_token=abc&id_token=def&service=google&email_address=foo` → no FAB (social handoff)
- `/log-in#access_token=…` or any hash on `/log-in` → no FAB
- `/log-in/desktop/finalize#access_token=…` → no FAB (pathname allowlist)
- `/log-in/link/use/…`, `/log-in/lostpassword/en`, `/log-in/authenticator/en` → no FAB (pathname allowlist)
- `/log-in/jetpack/…` → no FAB (`isJetpackLogin`)
- `/log-in` under any OAuth client (Gravatar, WPJobManager, Woo, BlazePro) → no FAB (`useOAuth2Layout`)

## Follow-up

A separate issue should land URL scrubbing at the odie-client boundary (`use-create-zendesk-conversation.ts`, `use-send-odie-message.ts`) — one helper, three call sites, protects every Help Center surface across Calypso. Once that ships, this gate can drop entirely to just the pathname check.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you checked for TypeScript, React or other console errors?