### PR TITLE
e2e: fix "Switch to draft" flake

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -903,8 +903,15 @@ export class EditorPage {
 		// @TODO: eventually refactor this out to a ConfirmationDialogComponent.
 		// Saves the draft
 		await Promise.race( [ this.editorToolbarComponent.clickPublish(), this.confirmUnpublish() ] );
-		// @TODO: eventually refactor this out to a EditorToastNotificationComponent.
-		await editorParent.getByRole( 'button', { name: 'Dismiss this notice' } ).waitFor();
+
+		// The "Post reverted to draft" snackbar auto-dismisses after ~5s, so
+		// waiting on its dismiss button races the timer. Instead wait for the
+		// toolbar primary button to revert from "Update" to "Publish", which is
+		// only committed once the draft transition has been persisted.
+		await editorParent
+			.locator( '.editor-post-publish-button__button' )
+			.getByText( 'Publish', { exact: true } )
+			.waitFor();
 	}
 
 	/**

--- a/test/e2e/specs/onboarding/signup__start-writing-tailored.spec.ts
+++ b/test/e2e/specs/onboarding/signup__start-writing-tailored.spec.ts
@@ -29,7 +29,14 @@ test.describe(
 			} );
 
 			await test.step( 'Then I see the Create your account page', async function () {
-				await expect( flowStartWriting.userSignupPage.createYourAccountHeading ).toBeVisible();
+				// The Start Writing flow first lands on `/setup/start-writing`, then
+				// redirects to `/setup/start-writing/check-sites`, and finally to
+				// `/start/account/user-social?...`. On mobile in CI, this chain plus
+				// the lazy-loaded signup chunk can easily exceed the default 10s
+				// expect timeout, so allow more time for the heading to render.
+				await expect( flowStartWriting.userSignupPage.createYourAccountHeading ).toBeVisible( {
+					timeout: 30000,
+				} );
 			} );
 
 			await test.step( 'When I sign up with my email', async function () {


### PR DESCRIPTION
Part of #110714

## Proposed Changes

* In `EditorPage.unpublish()`, replace the wait on the snackbar "Dismiss this notice" button with a wait on the toolbar primary button label reverting from "Update" to "Publish".

## Why are these changes being made?

The test `Editor: Advanced Post Flow > Revert post to draft > Switch to draft` (in `test/e2e/specs/editor/editor__post-advanced-flow.ts`) intermittently fails on the Gutenberg-on-WPCOM rotation. Most recent observation: GB `v23.2.0-rc.1`, [TC build 17776184](https://teamcity.a8c.com/build/17776184), with:

```
locator.waitFor: Timeout 15000ms exceeded.
Call log:
  - waiting for locator('body.block-editor-page').getByRole('button', { name: 'Dismiss this notice' }) to be visible

at EditorPage.waitFor (packages/calypso-e2e/src/lib/pages/editor-page.ts:907)
```

In modern Gutenberg (>=v18.2.0) `switchToDraft()` clicks the "Draft" radio in the post-status panel, which triggers an automatic save with no confirmation dialog. The "Post reverted to draft" snackbar then appears for ~5s and auto-dismisses. The follow-up `Promise.race([clickPublish(), confirmUnpublish()])` resolves immediately (no OK button → `confirmUnpublish` no-ops), so by the time we call `waitFor` on the dismiss-notice button it may already be gone.

The toolbar primary button label transitions (`Update` → `Publish`) only after the draft state has been persisted, and that signal does not auto-dismiss. The next `it()` block in the same suite ("Ensure post is no longer visible") independently re-asserts the unpublish state by 404-checking the post URL, so this remains a robust gate rather than a redundant one.

## Testing Instructions

* On a Simple site, run the legacy spec: `yarn test test/e2e/specs/editor/editor__post-advanced-flow.ts` (an authenticated Calypso instance + GB-on-WPCOM rotation account is required). The `Switch to draft` step should pass deterministically.
* CI: the `Gutenberg simple E2E tests edge (desktop)` rotation re-runs this suite — verify on the next rotation build.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?