### PR TITLE
E2E: extend Create your account heading timeout in start-writing-tailored

### DIFF
--- a/test/e2e/specs/onboarding/signup__start-writing-tailored.spec.ts
+++ b/test/e2e/specs/onboarding/signup__start-writing-tailored.spec.ts
@@ -29,7 +29,14 @@ test.describe(
 			} );
 
 			await test.step( 'Then I see the Create your account page', async function () {
-				await expect( flowStartWriting.userSignupPage.createYourAccountHeading ).toBeVisible();
+				// The Start Writing flow first lands on `/setup/start-writing`, then
+				// redirects to `/setup/start-writing/check-sites`, and finally to
+				// `/start/account/user-social?...`. On mobile in CI, this chain plus
+				// the lazy-loaded signup chunk can easily exceed the default 10s
+				// expect timeout, so allow more time for the heading to render.
+				await expect( flowStartWriting.userSignupPage.createYourAccountHeading ).toBeVisible( {
+					timeout: 30000,
+				} );
 			} );
 
 			await test.step( 'When I sign up with my email', async function () {


### PR DESCRIPTION
## Proposed Changes

- Extend the `toBeVisible()` assertion on `createYourAccountHeading` in `signup__start-writing-tailored.spec.ts` to use `{ timeout: 30000 }`.
- Add a short comment documenting the redirect chain that makes the longer timeout necessary.

## Why are these changes being made?

The Start Writing flow visits `/setup/start-writing`, which redirects through `/setup/start-writing/check-sites` to `/start/account/user-social?variationName=start-writing&...`. Each hop loads a different Webpack chunk (stepper code, then signup section code that renders `UserStep` + `OneLoginLayout` + `SignupForm`). On the `[Mobile]` pixel project under CI load, this chain plus the chunked React render reliably blows past the default 10s expect timeout configured in `test/e2e/playwright.config.ts`.

The locator itself is correct — once the page finally renders, the heading text matches and the same page object's internal `waitForSignupForm()` already uses a 30s timeout, which is why `signupWithEmail` itself never flakes. Only this standalone visibility assertion was running with the default budget.

Failure evidence: [TeamCity build 17791947](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Playwright_Test_Matrix/17791947) — both the initial attempt and Retry #1 failed identically after navigation completed, confirming the slowness is environmental rather than transient.

## Testing Instructions

Run `yarn playwright test test/e2e/specs/onboarding/signup__start-writing-tailored.spec.ts --reporter=list --repeat-each=10` locally; all runs should pass. Has not been verified locally by me — please validate before merging.