### PR TITLE
[codex] Fix Jetpack Search settings URL

### DIFF
--- a/client/state/sites/selectors/get-jetpack-search-customize-url.js
+++ b/client/state/sites/selectors/get-jetpack-search-customize-url.js
@@ -2,12 +2,12 @@ import versionCompare from 'calypso/lib/version-compare';
 import { getSiteAdminUrl, getJetpackVersion, isJetpackSite } from 'calypso/state/sites/selectors';
 
 /**
- * Returns the appropriate URL for customizing the Jetpack Search experience.
+ * Returns the appropriate URL for managing the Jetpack Search experience.
  * This function supports both Jetpack and WordPress.com sites.
  * @param  {Object}    state  Global state tree
  * @param  {?number}   siteId Site ID
- * @returns {?string}         URL for customizing Jetpack Search.
- *                            Can be the the Customizer or Customberg.
+ * @returns {?string}         URL for managing Jetpack Search.
+ *                            Can be the Customizer or Jetpack Search settings.
  */
 export default function getJetpackSearchCustomizeUrl( state, siteId ) {
 	const adminUrl = getSiteAdminUrl( state, siteId );
@@ -19,11 +19,11 @@ export default function getJetpackSearchCustomizeUrl( state, siteId ) {
 		const jetpackVersion = getJetpackVersion( state, siteId );
 		let url = adminUrl + 'customize.php?autofocus[section]=jetpack_search';
 		if ( jetpackVersion && versionCompare( jetpackVersion, '10.1', '>=' ) ) {
-			url = adminUrl + 'admin.php?page=jetpack-search-configure';
+			url = adminUrl + 'admin.php?page=jetpack-search&tab=settings';
 		}
 		return url;
 	}
 
-	// All WPCOM sites, both Simple and Atomic, support Customberg.
-	return adminUrl + 'admin.php?page=jetpack-search-configure';
+	// All WPCOM sites, both Simple and Atomic, support Jetpack Search settings.
+	return adminUrl + 'admin.php?page=jetpack-search&tab=settings';
 }

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -32,6 +32,7 @@ import {
 	canJetpackSiteUpdateFiles,
 	canJetpackSiteAutoUpdateFiles,
 	canJetpackSiteAutoUpdateCore,
+	getJetpackSearchCustomizeUrl,
 	getJetpackSearchDashboardUrl,
 	isJetpackSiteMultiSite,
 	isJetpackSiteSecondaryNetworkSite,
@@ -2581,6 +2582,92 @@ describe( 'selectors', () => {
 
 			expect( dashboardUrl ).toEqual(
 				'https://example.wordpress.com/wp-admin/admin.php?page=jetpack-search'
+			);
+		} );
+	} );
+
+	describe( 'getJetpackSearchCustomizeUrl()', () => {
+		test( "should return null if we can't find the adminUrl", () => {
+			const customizeUrl = getJetpackSearchCustomizeUrl(
+				{
+					sites: {
+						items: {},
+					},
+				},
+				2916284
+			);
+
+			expect( customizeUrl ).toBeNull();
+		} );
+
+		test( 'should return the Customizer for old JP versions', () => {
+			const customizeUrl = getJetpackSearchCustomizeUrl(
+				{
+					sites: {
+						items: {
+							2916284: {
+								ID: 2916284,
+								jetpack: true,
+								options: {
+									admin_url: 'https://example.wordpress.com/wp-admin/',
+									jetpack_version: '10.0',
+								},
+							},
+						},
+					},
+				},
+				2916284
+			);
+
+			expect( customizeUrl ).toEqual(
+				'https://example.wordpress.com/wp-admin/customize.php?autofocus[section]=jetpack_search'
+			);
+		} );
+
+		test( 'should return Search settings for new JP versions', () => {
+			const customizeUrl = getJetpackSearchCustomizeUrl(
+				{
+					sites: {
+						items: {
+							2916284: {
+								ID: 2916284,
+								jetpack: true,
+								options: {
+									admin_url: 'https://example.wordpress.com/wp-admin/',
+									jetpack_version: '10.1',
+								},
+							},
+						},
+					},
+				},
+				2916284
+			);
+
+			expect( customizeUrl ).toEqual(
+				'https://example.wordpress.com/wp-admin/admin.php?page=jetpack-search&tab=settings'
+			);
+		} );
+
+		test( 'should return Search settings for WordPress.com sites', () => {
+			const customizeUrl = getJetpackSearchCustomizeUrl(
+				{
+					sites: {
+						items: {
+							2916284: {
+								ID: 2916284,
+								jetpack: false,
+								options: {
+									admin_url: 'https://example.wordpress.com/wp-admin/',
+								},
+							},
+						},
+					},
+				},
+				2916284
+			);
+
+			expect( customizeUrl ).toEqual(
+				'https://example.wordpress.com/wp-admin/admin.php?page=jetpack-search&tab=settings'
 			);
 		} );
 	} );


### PR DESCRIPTION
Part of #

## Proposed Changes

* Update the shared Jetpack Search customize URL selector so modern Jetpack and WordPress.com sites open `wp-admin/admin.php?page=jetpack-search&tab=settings` instead of the legacy configure page.
* Keep the existing Customizer fallback for older Jetpack versions.
* Add selector coverage for missing admin URLs, old Jetpack versions, modern Jetpack versions, and WordPress.com sites.

## Why are these changes being made?

* The post-purchase Jetpack Search CTA should send users directly to the Search settings tab in wp-admin. Previously, the shared selector generated the legacy `jetpack-search-configure` target for supported sites.

## Testing Instructions

* Run `yarn test-client client/state/sites/test/selectors.js --runInBand --testNamePattern="getJetpackSearchCustomizeUrl"`.
* Run `./node_modules/.bin/eslint client/state/sites/selectors/get-jetpack-search-customize-url.js client/state/sites/test/selectors.js`.
* Run `git diff --check -- client/state/sites/selectors/get-jetpack-search-customize-url.js client/state/sites/test/selectors.js`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?