### PR TITLE
Reader: cap Social Spotlight grid at 2 columns

### DIFF
--- a/client/reader/connections/style.scss
+++ b/client/reader/connections/style.scss
@@ -393,8 +393,12 @@
 	margin: 0;
 	padding: 0;
 	display: grid;
-	grid-template-columns: repeat( auto-fill, minmax( 220px, 1fr ) );
+	grid-template-columns: 1fr;
 	gap: 12px;
+
+	@include break-small {
+		grid-template-columns: repeat( 2, 1fr );
+	}
 }
 
 .social-spotlight__card {


### PR DESCRIPTION
## Proposed Changes

* Change `.social-spotlight__list` from `repeat( auto-fill, minmax( 220px, 1fr ) )` to a single column on mobile, two columns from `break-small` upward.

## Why are these changes being made?

The Social Spotlight strip previously expanded to 3–4 columns on wide displays, which made the cards feel cramped relative to the post snippets they carry. The Spotlight is intentionally a "featured" strip that should read denser than the account grid below it — a fixed 1→2 column ladder gives each card enough room without competing visually with the per-account grid that follows.

## Testing Instructions

* Navigate to `/reader/connections` with at least one social connection that has Spotlight posts.
* Resize the browser from <600px up to a wide desktop and confirm:
  * Below `break-small` (600px): one column.
  * At and above `break-small`: two columns.
* Confirm card content (avatar, title, snippet, counts) still renders correctly inside the wider cells.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?