### PR TITLE
Image Studio: render the Feature Clip panel in the Jetpack sidebar too

### DIFF
--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
@@ -13,6 +13,7 @@ const mockRegisterPlugin = jest.fn();
 const mockTrackOpened = jest.fn();
 const mockTrackAddedToPost = jest.fn();
 const mockTrackPanelViewed = jest.fn();
+const mockFill = jest.fn();
 const mockSetCurrentVideoUrl = jest.fn().mockResolvedValue( undefined );
 const mockSetCurrentAttachmentId = jest.fn().mockResolvedValue( undefined );
 const mockSetCurrentDurationSeconds = jest.fn().mockResolvedValue( undefined );
@@ -55,6 +56,15 @@ jest.mock( '@wordpress/components', () => ( {
 			{ children ?? icon }
 		</button>
 	),
+	// Faithful to real SlotFill semantics: a Fill with no matching Slot
+	// mounted (none in jsdom) renders nothing. Recording the name lets us
+	// assert the Jetpack-sidebar wiring without duplicating the body in the
+	// DOM (which would break every single-match query below).
+	Fill: ( { name }: { name: string } ) => {
+		mockFill( name );
+		return null;
+	},
+	PanelBody: ( { children }: { children: React.ReactNode } ) => <>{ children }</>,
 } ) );
 
 jest.mock( '@wordpress/core-data', () => ( {
@@ -192,6 +202,7 @@ describe( 'feature-clip-sidebar-extension', () => {
 		mockTrackOpened.mockClear();
 		mockTrackAddedToPost.mockClear();
 		mockTrackPanelViewed.mockClear();
+		mockFill.mockClear();
 		mockSetCurrentVideoUrl.mockClear();
 		mockSetCurrentAttachmentId.mockClear();
 		mockSetCurrentDurationSeconds.mockClear();
@@ -244,6 +255,38 @@ describe( 'feature-clip-sidebar-extension', () => {
 
 		expect( mockRegisterPlugin ).toHaveBeenCalledTimes( 1 );
 		expect( mockRegisterPlugin.mock.calls[ 0 ][ 0 ] ).toBe( 'image-studio-feature-clip' );
+	} );
+
+	describe( 'dual-render (document + Jetpack sidebars)', () => {
+		it( 'also fills the Jetpack sidebar SlotFill', () => {
+			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			render( <FeatureClipPanel /> );
+			// The document-sidebar copy is asserted by every other test; this
+			// confirms the second render target — Jetpack's sidebar slot.
+			expect( mockFill ).toHaveBeenCalledWith( 'JetpackPluginSidebar' );
+		} );
+
+		it( 'fills the Jetpack sidebar regardless of clip state', () => {
+			mockMeta = { _jetpack_feature_clip_id: 42 };
+			mockMedia = {
+				id: 42,
+				source_url: 'https://example.com/clip.mp4',
+				mime_type: 'video/mp4',
+				media_details: { length: 8 },
+			};
+			mockHasResolvedMedia = true;
+			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			render( <FeatureClipPanel /> );
+			expect( mockFill ).toHaveBeenCalledWith( 'JetpackPluginSidebar' );
+		} );
+
+		it( 'fires the panel-viewed impression only once despite dual-render', () => {
+			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			render( <FeatureClipPanel /> );
+			// Both wrappers share one FeatureClipPanel mount, so the
+			// impression must not double-count.
+			expect( mockTrackPanelViewed ).toHaveBeenCalledTimes( 1 );
+		} );
 	} );
 
 	describe( 'empty state (no clip linked)', () => {

--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
@@ -1,15 +1,20 @@
 /**
  * "Generate Feature Clip" post-editor sidebar panel.
  *
- * Registers a PluginDocumentSettingPanel (from `@wordpress/editor`) in the
- * Gutenberg post editor. When no clip is linked to the post, shows a short
- * description + Generate clip button. Once a clip exists (via the
- * `_jetpack_feature_clip_id` post meta registered by Jetpack's Image Studio
- * extension), shows a small video preview, a share row mirroring the modal,
- * and a Regenerate button.
+ * Dual-rendered, mirroring Jetpack SEO's pattern: the same body renders into
+ * BOTH the default WordPress document sidebar (via `PluginDocumentSettingPanel`
+ * from `@wordpress/editor`) AND the Jetpack sidebar (via a `Fill` into
+ * Jetpack's `"JetpackPluginSidebar"` SlotFill). The Fill is inert when the
+ * Jetpack editor bundle isn't loaded, so the document-sidebar copy always
+ * shows and the Jetpack-sidebar copy is purely additive.
+ *
+ * When no clip is linked to the post, shows a short description + Generate
+ * clip button. Once a clip exists (via the `_jetpack_feature_clip_id` post
+ * meta registered by Jetpack's Image Studio extension), shows a small video
+ * preview, a share row mirroring the modal, and a Regenerate button.
  */
 import { createBlock } from '@wordpress/blocks';
-import { Button } from '@wordpress/components';
+import { Button, Fill, PanelBody } from '@wordpress/components';
 import { useEntityProp } from '@wordpress/core-data';
 import { dispatch, useSelect } from '@wordpress/data';
 import { PluginDocumentSettingPanel } from '@wordpress/editor';
@@ -272,30 +277,49 @@ function FeatureClipPanel(): JSX.Element {
 	// reload doesn't briefly flash the empty CTA before the preview appears.
 	const isResolvingAttachment = !! featureClipId && ! hasResolvedAttachment;
 
+	// Body is described once and rendered into both sidebars. Each SlotFill
+	// portal instantiates its own subtree, so FeatureClipPreview's share
+	// hooks get one instance per sidebar — safe: the hooks have no
+	// mount-time side effects and only the visible sidebar is interacted
+	// with (same dual-instance shape as Jetpack SEO's shared panels).
+	const body = ( () => {
+		if ( hasUsableClip ) {
+			return (
+				<FeatureClipPreview
+					videoUrl={ videoUrl }
+					attachmentId={ featureClipId }
+					durationSeconds={ durationSeconds }
+				/>
+			);
+		}
+		if ( isResolvingAttachment ) {
+			return null;
+		}
+		return <FeatureClipEmptyState />;
+	} )();
+
 	return (
-		<PluginDocumentSettingPanel
-			name={ PANEL_NAME }
-			// PluginDocumentSettingPanel.title is typed as string but renders any ReactNode at runtime;
-			// the badge must live in the title row so it stays visible when the panel is collapsed.
-			title={ titleNode as unknown as string }
-			className="image-studio-feature-clip-panel"
-		>
-			{ ( () => {
-				if ( hasUsableClip ) {
-					return (
-						<FeatureClipPreview
-							videoUrl={ videoUrl }
-							attachmentId={ featureClipId }
-							durationSeconds={ durationSeconds }
-						/>
-					);
-				}
-				if ( isResolvingAttachment ) {
-					return null;
-				}
-				return <FeatureClipEmptyState />;
-			} )() }
-		</PluginDocumentSettingPanel>
+		<>
+			<PluginDocumentSettingPanel
+				name={ PANEL_NAME }
+				// PluginDocumentSettingPanel.title is typed as string but renders any ReactNode at runtime;
+				// the badge must live in the title row so it stays visible when the panel is collapsed.
+				title={ titleNode as unknown as string }
+				className="image-studio-feature-clip-panel"
+			>
+				{ body }
+			</PluginDocumentSettingPanel>
+			<Fill name="JetpackPluginSidebar">
+				<PanelBody
+					// PanelBody.title is typed as string but renders any ReactNode
+					// at runtime — same cast rationale as the document panel above.
+					title={ titleNode as unknown as string }
+					className="image-studio-feature-clip-panel"
+				>
+					{ body }
+				</PanelBody>
+			</Fill>
+		</>
 	);
 }
 


### PR DESCRIPTION
## Summary

The Feature Clip panel only registered a `PluginDocumentSettingPanel`, which renders exclusively in the default WordPress document ("Post") sidebar. It was therefore absent from the Jetpack sidebar (the green-Jetpack-icon panel), where users working with Jetpack SEO / Improve with AI / Social would reasonably expect to find it.

This dual-renders it, mirroring the exact pattern Jetpack SEO already uses. The body is described once in `FeatureClipPanel` and rendered into both targets:

- the existing `<PluginDocumentSettingPanel>` — document sidebar (unchanged), and
- a new `<Fill name="JetpackPluginSidebar">` wrapping a `<PanelBody>` — the Jetpack sidebar's SlotFill.

## Why no Jetpack-side change is needed

Jetpack registers the `"JetpackPluginSidebar"` slot unconditionally when its editor bundle loads, and WordPress's SlotFill registry matches the fill by name string — the same way the Publicize package fills that slot from outside the Jetpack plugin. When the Jetpack editor bundle isn't loaded, the `Fill` has no matching `Slot` and renders nothing, so the document-sidebar copy always shows and the Jetpack-sidebar copy is purely additive (no behavior change, no new gating).

## Dual-instance safety

Each SlotFill portal instantiates its own subtree, so the share hooks (`useReelShare` / `useGenericShare`) get one instance per sidebar. This is safe and matches Jetpack SEO's shared-panel shape:

- The share hooks have no mount-time side effects — all tracking lives in click handlers, so a mounted-but-idle instance fires nothing.
- Only the visible sidebar is ever interacted with.
- The panel-viewed impression fires from `FeatureClipPanel`'s single mount, so it is not double-counted.

## Test plan

- [ ] On a site/editor where the Jetpack sidebar is present: open the post editor, click the Jetpack icon → the Feature Clip panel appears there, with the same empty / preview / share / Regenerate states as the Post sidebar.
- [ ] The Post-sidebar copy still works exactly as before (no regression).
- [ ] Generate a clip from one sidebar, switch to the other → preview state reflects correctly in both.
- [ ] Share / Add to post / Regenerate work from the Jetpack-sidebar copy.
- [ ] On a context without the Jetpack editor bundle: the Post-sidebar copy still shows; nothing errors.
- [x] `yarn test-packages packages/image-studio` — 38 suites, 994 tests, all green (includes a new dual-render describe block).
- [x] `yarn eslint` + `yarn typecheck` clean on the modified files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)