### PR TITLE
Fix: make SFTP/SSH Reset Password button persistent (DOTCOM-12666)

### DIFF
--- a/client/dashboard/sites/settings-sftp-ssh/sftp-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/sftp-card.tsx
@@ -41,8 +41,16 @@ export default function SftpCard( {
 	sftpUsers: SftpUser[];
 } ) {
 	const { username = '', password = '' } = sftpUsers[ 0 ] ?? {};
-	const mutation = useMutation( siteSftpUsersResetPasswordMutation( siteId ) );
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const mutation = useMutation( {
+		...siteSftpUsersResetPasswordMutation( siteId ),
+		meta: {
+			snackbar: {
+				success: __( 'SFTP password reset.' ),
+				error: __( 'Failed to reset SFTP password. Please try again.' ),
+			},
+		},
+	} );
+	const { createSuccessNotice } = useDispatch( noticesStore );
 	const [ showResetPasswordConfirmDialog, setShowResetPasswordConfirmDialog ] = useState( false );
 	const formData = {
 		url: SFTP_URL,
@@ -132,18 +140,7 @@ export default function SftpCard( {
 	};
 
 	const handleConfirmResetPassword = () => {
-		mutation.mutate( username, {
-			onError: () => {
-				createErrorNotice(
-					__(
-						'Sorry, we had a problem retrieving your SFTP user details. Please refresh the page and try again.'
-					),
-					{
-						type: 'snackbar',
-					}
-				);
-			},
-		} );
+		mutation.mutate( username );
 
 		setShowResetPasswordConfirmDialog( false );
 	};
@@ -170,17 +167,16 @@ export default function SftpCard( {
 						form={ form }
 						onChange={ noop }
 					/>
-					{ ! password && (
-						<ButtonStack justify="flex-start">
-							<Button
-								variant="secondary"
-								isBusy={ mutation.isPending }
-								onClick={ () => setShowResetPasswordConfirmDialog( true ) }
-							>
-								{ __( 'Reset password' ) }
-							</Button>
-						</ButtonStack>
-					) }
+					<ButtonStack justify="flex-start">
+						<Button
+							variant="secondary"
+							isBusy={ mutation.isPending }
+							disabled={ mutation.isPending }
+							onClick={ () => setShowResetPasswordConfirmDialog( true ) }
+						>
+							{ __( 'Reset password' ) }
+						</Button>
+					</ButtonStack>
 				</VStack>
 			</CardBody>
 			<ConfirmDialog


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-12666

## Proposed Changes

  - Make the **Reset password** button on the site's SFTP/SSH settings card always visible, instead of hiding it once the password is reset.
  - Disable the button (in addition to showing the busy state) while the reset mutation is in flight, to prevent double-submits.
  - Migrate the success/error feedback to the mutation's `meta.snackbar` pattern and replace the misleading error copy ("Sorry, we had a problem retrieving your SFTP user details…") with an accurate one ("Failed to reset SFTP password. Please try again.").

## Why are these changes being made?

The previous behavior hid the button when the password was reset. And to reset it again, we need to reload the window. Also, with this change, we are making this button more consistent with the Clear cache buttons.

## Testing Instructions

  1. Navigate to a site's **Settings → SFTP/SSH** screen.
  2. Verify the **Reset password** button is visible.
  3. Click **Reset password** and confirm in the dialog.
  4. While the request is in flight, confirm the button shows the busy spinner and cannot be clicked again.
  5. On success, confirm the snackbar reads "SFTP password reset." and the new password appears in the card.
  6. Check that the button is not hidden after the password is reset.
  7. Repeat on a site with no existing SFTP password to confirm the initial-creation flow still works.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
