### PR TITLE
Fix Reader quick post dark mode badges

### DIFF
--- a/client/reader/components/quick-post/style.scss
+++ b/client/reader/components/quick-post/style.scss
@@ -55,6 +55,29 @@
 			--wp-components-color-accent-inverted: var( --color-text-inverted );
 		}
 
+		.site__badge:not( .is-p2 ):not( .is-p2-workspace ) {
+			background-color: var( --wp-components-color-gray-200 );
+			border: 0;
+			box-shadow: inset 0 0 0 1px var( --wp-components-color-gray-300 );
+			color: var( --wp-components-color-gray-800 );
+
+			&[class*="SitesStagingBadge"] {
+				background-color: var( --color-warning-10 );
+				box-shadow: inset 0 0 0 1px var( --color-warning-30 );
+				color: var( --color-warning-80 );
+			}
+		}
+
+		.site-selector .site.is-selected {
+			.site__title {
+				color: var( --color-text );
+			}
+
+			.site__domain {
+				color: var( --color-text-subtle );
+			}
+		}
+
 		.sites-dropdown__selected {
 			.site__title,
 			.site__title-chevron-icon {
@@ -67,14 +90,6 @@
 
 			.site__domain {
 				color: var( --color-text-subtle );
-			}
-
-			.site__badge.site__badge-private,
-			.site__badge.site__badge-coming-soon {
-				background-color: var( --wp-components-color-gray-200 );
-				border: 0;
-				box-shadow: inset 0 0 0 1px var( --wp-components-color-gray-300 );
-				color: var( --wp-components-color-gray-800 );
 			}
 		}
 	}

--- a/client/reader/components/quick-post/style.scss
+++ b/client/reader/components/quick-post/style.scss
@@ -73,6 +73,10 @@
 				color: var( --color-text );
 			}
 
+			&.is-private .site__title::before {
+				color: var( --color-text );
+			}
+
 			.site__domain {
 				color: var( --color-text-subtle );
 			}


### PR DESCRIPTION
## Proposed Changes
<img width="1544" height="782" alt="CleanShot 2026-05-18 at 17 33 55@2x" src="https://github.com/user-attachments/assets/51ecc975-762e-4ccd-b8fd-7b8845fcfa48" />


* Update Reader Quick Post dark-mode styles for site badges in the site picker.
* Keep ordinary non-P2 site badges on dark-compatible neutral tokens.
* Give staging badges a warning-token treatment so they remain distinct without using light-mode hardcoded colors.
* Keep selected site title and domain text on Reader dark text tokens instead of the accent/link color.

## Why are these changes being made?

The Quick Post site picker reused shared site selector and staging badge styles that were designed for light surfaces. In Reader dark mode, the staging badge could become light-on-light, and selected site domains could inherit the accent color in a way that looked like an off-token link rather than secondary site metadata.

This change scopes the overrides to Quick Post dark mode and maps the affected pieces back to existing Reader/Dashboard color roles. Site titles use the primary text token, domains use the subtle text token, regular badges use dark neutral badge tokens, and staging badges use warning tokens.

## Testing Instructions

* Open Reader in dark mode.
* In the Quick Post composer, open the site picker.
* Confirm the selected site title and domain use normal Reader text colors, not the accent/link blue.
* Confirm private/coming-soon badges remain readable on dark surfaces.
* Confirm staging badges use a dark warning-tinted treatment and remain readable.
* Stylelint passed for the updated stylesheet; whitespace validation passed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
