### PR TITLE
fix(checkout): improve manual renewal toast copy (CHE-467)

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -2,6 +2,7 @@ import { receiptQuery } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
 import { getUrlParts } from '@automattic/calypso-url';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { Step } from '@automattic/onboarding';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { invokeSurvicateEvent } from '@automattic/survicate';
@@ -422,11 +423,25 @@ function displayRenewalSuccessNotice( {
 	// show renewal success notice
 	reduxDispatch(
 		successNotice(
-			translate( 'Success! You renewed %(productName)s.', {
-				args: {
-					productName,
-				},
-			} ),
+			translate(
+				'Success! You renewed %(productName)s. We will attempt to automatically renew it in the future. {{a}}Learn more about renewals{{/a}}',
+				{
+					args: {
+						productName,
+					},
+					components: {
+						a: (
+							<a
+								href={ localizeUrl(
+									'https://wordpress.com/support/manage-purchases/automatic-renewal/'
+								) }
+								target="_blank"
+								rel="noreferrer noopener"
+							/>
+						),
+					},
+				}
+			),
 			{ displayOnNextPage: true }
 		)
 	);

--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -1,6 +1,7 @@
 import { receiptQuery } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
 import { getUrlParts } from '@automattic/calypso-url';
+import { ExternalLink } from '@automattic/components';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Step } from '@automattic/onboarding';
@@ -431,15 +432,17 @@ function displayRenewalSuccessNotice( {
 					},
 					components: {
 						a: (
-							<a
+							<ExternalLink
 								href={ localizeUrl(
 									'https://wordpress.com/support/manage-purchases/automatic-renewal/'
 								) }
-								target="_blank"
-								rel="noreferrer noopener"
+								localizeUrl={ false }
+								icon
 							/>
 						),
 					},
+					comment:
+						'Toast shown after a manual subscription renewal. %(productName)s is the renewed product. {{a}}…{{/a}} wraps the "Learn more about renewals" link text.',
 				}
 			),
 			{ displayOnNextPage: true }


### PR DESCRIPTION
Part of [CHE-467](https://linear.app/a8c/issue/CHE-467/manual-renewal-post-checkout-toast-message-could-have-better-details)

> ℹ️ The Linear issue auto-flipped to **In Progress** when this PR opened. This is a Bug Blitz contribution that's review-ready, not actively being worked by an engineer on the owning team.

## Proposed Changes

* Restore the auto-renewal context sentence and a "Learn more about renewals" support link to the post-manual-renewal success toast (`displayRenewalSuccessNotice` in `client/my-sites/checkout/checkout-thank-you/pending/index.tsx`).
* Use the `ExternalLink` component from `@automattic/components` so the link picks up the standard external-link icon, the visually-hidden "(opens in a new tab)" screen-reader text, and the correct `rel` attribute.
* Add a translator `comment:` on the new translatable string so the `{{a}}…{{/a}}` placeholder is clear in GlotPress.

## Why are these changes being made?

The Linear issue traces about eleven years of drift in this toast's copy. The original 2014 message included an auto-renewal sentence and a "Learn more" link; PR #8058 added a `will_auto_renew` check so non-rechargeable payment methods didn't see misleading "will auto-renew" wording; PR #54993 then stripped the auto-renew sentence entirely, defeating the original purpose of the check. A recent server-side refactor on the wpcom side moved `will_auto_renew` to a bulk-loaded value that doesn't account for non-rechargeable methods, and the most recent Calypso PR (#109835) only restored the toast back to a single sentence ("Success! You renewed %(productName)s.") — it didn't tune the copy itself.

The new copy reuses the wording recommended in the Linear issue. The "We will *attempt* to automatically renew it" phrasing is deliberately defensive so the sentence stays approximately accurate even when the renewal won't actually auto-renew (auto-renew explicitly toggled off, or a non-rechargeable payment method) — same defensive intent that the old `will_auto_renew` check was originally written to satisfy, but expressed in the copy rather than as a branch. Reviewer call on whether that's enough or whether the sentence should still be gated on `is_auto_renew_enabled` / payment-method rechargeability; an earlier pre-merge review flagged this as the main open design question, and noted it's exactly the tradeoff the original Linear write-up evaluated.

## Testing Instructions

1. From a logged-in WordPress.com account on Calypso, navigate to a purchase that's eligible for manual renewal (`/me/purchases/...`).
2. Trigger a manual renewal and complete checkout.
3. After the post-checkout redirect lands on the purchase-management page, verify that the success toast reads: *"Success! You renewed \<product\>. We will attempt to automatically renew it in the future. Learn more about renewals"*.
4. Verify the "Learn more about renewals" link has the external-link icon, opens `https://wordpress.com/support/manage-purchases/automatic-renewal/` in a new tab, and that the link text/icon are present together (no broken `{{a}}` markup).
5. With a screen reader (VoiceOver / NVDA), verify the toast is announced and the link's "(opens in a new tab)" affordance is exposed.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?