### PR TITLE
[RSM-3325] Fix unified chat themes dark mode

### DIFF
--- a/packages/agents-manager/src/components/agent-dock/style.scss
+++ b/packages/agents-manager/src/components/agent-dock/style.scss
@@ -186,7 +186,7 @@ body:is( [class*='is-group-'], [class*='is-section-'] ).agents-manager-sidebar-c
 
 	#content {
 		min-height: 100vh;
-		background-color: #fcfcfc !important;
+		background-color: var( --color-main-background, #fcfcfc ) !important;
 	}
 
 	&.agents-manager-sidebar-container--sidebar-open {


### PR DESCRIPTION
Part of RSM-3325

## Proposed Changes

* Allow the Agents Manager Calypso content wrapper to use the route-provided main background token instead of always forcing the light background.

## Why are these changes being made?

Unified chat adds the Agents Manager sidebar container class to Calypso pages and its shared layout CSS was forcing `#content` to the light `#fcfcfc` background. On the logged-in theme showcase, that overrode the dark-mode background when unified chat was enabled, making the page chrome appear light even though the `/themes` dark-mode provider and tokens were active.

This change keeps the same light fallback while reading `--color-main-background`, which `/themes` already maps to the expected dark page background through the shared dark-mode token bridge. It also keeps the generic Agents Manager selector scope unchanged, so routes without that token still render with the previous fallback.

## Testing Instructions

* Open the logged-in theme showcase `http://calypso.localhost:3000/themes` with dark mode enabled and unified chat active.
* Confirm the page background stays dark before and after opening the unified chat dock and select "move to sidebar"

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
