### PR TITLE
Reader: clarify activity streak wording

### DIFF
--- a/client/reader/user-profile/views/achievements/activity-streak/index.tsx
+++ b/client/reader/user-profile/views/achievements/activity-streak/index.tsx
@@ -107,15 +107,15 @@ function getModeContent(
 		case 'pending':
 			return {
 				badgeState: 'inactive',
-				badgeLabel: translate( 'Don’t break it!' ) as string,
-				description: translate( 'Like, comment, follow, or post every day to build your streak.' ),
+				badgeLabel: translate( 'Keep it going!' ) as string,
+				description: translate( 'Like, comment, follow, or post today to keep your streak going.' ),
 			};
 		case 'pending-frozen':
 			return {
 				badgeState: 'frozen',
-				badgeLabel: translate( 'Streak frozen' ) as string,
+				badgeLabel: translate( 'Close call!' ) as string,
 				description: translate(
-					'A {{term}}streak freeze{{/term}} protected your streak yesterday.{{br/}}Like, comment, follow, or post every day to build your streak.',
+					'A {{term}}streak freeze{{/term}} protected your streak yesterday.{{br/}}Like, comment, follow, or post today to keep it going.',
 					{ components: { term: <StreakFreezeTerm />, br: <br /> } }
 				),
 			};
@@ -124,7 +124,7 @@ function getModeContent(
 				badgeState: 'active',
 				badgeLabel: translate( 'You’re on a streak!' ) as string,
 				description: translate(
-					'Like, comment, follow, or post every day to keep building your streak.'
+					'Today counted! Like, comment, follow, or post every day to keep building your streak.'
 				),
 			};
 		case 'engaged-record':

--- a/client/reader/user-profile/views/achievements/activity-streak/test/index.test.tsx
+++ b/client/reader/user-profile/views/achievements/activity-streak/test/index.test.tsx
@@ -104,17 +104,17 @@ describe( 'ActivityStreak', () => {
 			last_streak_date: '2026-05-10',
 		};
 
-		test( 'renders the build-your-streak description', () => {
+		test( 'renders the keep-it-going description', () => {
 			render( <ActivityStreak streak={ streak } isOwnProfile /> );
 			expect(
-				screen.getByText( 'Like, comment, follow, or post every day to build your streak.' )
+				screen.getByText( 'Like, comment, follow, or post today to keep your streak going.' )
 			).toBeVisible();
 		} );
 
-		test( 'badge is inactive with the "Don’t break it!" label', () => {
+		test( 'badge is inactive with the "Keep it going!" label', () => {
 			render( <ActivityStreak streak={ streak } isOwnProfile /> );
 			expect( getBadgeStateClass() ).toBe( 'is-inactive' );
-			expect( getBadgeLabel() ).toBe( 'Don’t break it!' );
+			expect( getBadgeLabel() ).toBe( 'Keep it going!' );
 		} );
 	} );
 
@@ -147,10 +147,10 @@ describe( 'ActivityStreak', () => {
 			).toBeVisible();
 		} );
 
-		test( 'badge state is frozen with the "Streak frozen" label', () => {
+		test( 'badge state is frozen with the "Close call!" label', () => {
 			render( <ActivityStreak streak={ streak } isOwnProfile /> );
 			expect( getBadgeStateClass() ).toBe( 'is-frozen' );
-			expect( getBadgeLabel() ).toBe( 'Streak frozen' );
+			expect( getBadgeLabel() ).toBe( 'Close call!' );
 		} );
 	} );
 
@@ -162,10 +162,12 @@ describe( 'ActivityStreak', () => {
 			last_streak_date: TODAY,
 		};
 
-		test( 'renders the keep-building description', () => {
+		test( 'renders the today-counted description', () => {
 			render( <ActivityStreak streak={ streak } isOwnProfile /> );
 			expect(
-				screen.getByText( 'Like, comment, follow, or post every day to keep building your streak.' )
+				screen.getByText(
+					'Today counted! Like, comment, follow, or post every day to keep building your streak.'
+				)
 			).toBeVisible();
 		} );
 


### PR DESCRIPTION
Part of RSM-2919

## Proposed Changes

* Clarified the badge label and description for the `pending` state to emphasize that today's activity is what extends the streak.
* Updated the `pending-frozen` badge label and description so the user understands they still need to engage today after a freeze saved them yesterday.
* Updated the `engaged` description to acknowledge today's activity before nudging toward continued daily engagement.

## Why are these changes being made?

The prior copy for `pending`, `pending-frozen`, and `engaged` all referenced engaging "every day", which made it unclear whether the streak was already safe for today or still waiting on the user. The new wording makes today's call-to-action explicit on the pending states and congratulates the user once today's activity has counted.

## Testing Instructions

* Visit your own Reader user profile and confirm the Activity Streak badge shows the expected label and description for each of the three states:
  * `pending` — streak active but no activity logged today.
  * `pending-frozen` — streak active but the prior day was covered by a streak freeze.
  * `engaged` — activity already logged today.
* Confirm the streak-freeze tooltip term still renders correctly in the `pending-frozen` description.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?