### PR TITLE
Help Center: track FAB impressions and tidy click location

### DIFF
--- a/client/components/help-center-fab/index.tsx
+++ b/client/components/help-center-fab/index.tsx
@@ -41,10 +41,17 @@ const HelpCenterFab = ( { sectionName }: HelpCenterFabProps ) => {
 		return () => document.body.classList.remove( 'has-help-center-fab' );
 	}, [] );
 
+	useEffect( () => {
+		recordTracksEvent( 'calypso_inlinehelp_impression', {
+			location: 'fab',
+			section: sectionName,
+		} );
+	}, [ sectionName ] );
+
 	const handleClick = () => {
 		const willShow = ! isHelpCenterShown;
 		recordTracksEvent( `calypso_inlinehelp_${ willShow ? 'show' : 'close' }`, {
-			location: 'help-center-fab',
+			location: 'fab',
 			section: sectionName,
 		} );
 		setShowHelpCenter( willShow );


### PR DESCRIPTION
## Proposed Changes

Add a Tracks impression event on the logged-out Help Center FAB and rename the existing click event's \`location\` property for consistency with the rest of the \`calypso_inlinehelp_*\` family.

**New event:** \`calypso_inlinehelp_impression\` — fires when the FAB mounts and on subsequent \`sectionName\` changes.

| Property | Value |
|---|---|
| \`location\` | \`'fab'\` |
| \`section\` | the current \`sectionName\` (e.g. \`'login'\`, \`'signup'\`, \`'reader'\`, \`'stepper'\`, \`'checkout'\`, …) |

**Renamed click property:** the existing \`calypso_inlinehelp_show\` / \`calypso_inlinehelp_close\` events on the FAB now report \`location: 'fab'\` instead of \`'help-center-fab'\`.

## Why are these changes being made?

**Impressions.** The FAB rollout (HAP-2869) shipped click tracking but no impression tracking. To measure pre-sales-chat funnel performance — impressions → clicks → chat starts — we need an impression event scoped to the FAB surface.

**Location naming.** Other inlinehelp triggers use bare values: \`'masterbar'\`, \`'masterbar-agents-manager'\`, \`'eligibility-warnings'\`. The \`'help-center-fab'\` value was doubling up because the event prefix (\`calypso_inlinehelp_*\`) already implies the Help Center context. Switching to \`'fab'\` matches the convention and makes prefix-based filtering (\`location LIKE 'fab%'\`) work cleanly if more FAB variants ever appear.

User state (logged-out vs logged-in) is intentionally not encoded into the location string or a separate property — Tracks already attaches \`user_id\` for identified users, so analysts derive that from identity rather than from explicit properties.

## Testing Instructions

1. Enable \`help-center/logged-out-fab\`.
2. Sign out and visit \`/log-in\`, \`/discover\`, \`/start/free\`, \`/setup/onboarding/user\`, etc.
3. With Tracks debug tooling open, confirm:
   - One \`calypso_inlinehelp_impression\` event fires per page load when the FAB renders.
   - A new \`calypso_inlinehelp_impression\` event fires after navigating between FAB-eligible sections (e.g., \`/discover\` → \`/tag/wordpress\`).
   - Clicking the FAB still fires \`calypso_inlinehelp_show\` / \`calypso_inlinehelp_close\`, now with \`location: 'fab'\`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you checked for TypeScript, React or other console errors?