### PR TITLE
Help Center: suppress FAB tooltip and tidy keyboard tab order

### DIFF
--- a/client/components/help-center-fab/index.tsx
+++ b/client/components/help-center-fab/index.tsx
@@ -58,9 +58,9 @@ const HelpCenterFab = ( { sectionName }: HelpCenterFabProps ) => {
 	};
 
 	const label = isHelpCenterShown
-		? /* translators: Tooltip on the floating Help button when the Help Center panel is open. */
+		? /* translators: Accessible label on the floating Help button when the Help Center panel is open. */
 		  __( 'Close help' )
-		: /* translators: Tooltip on the floating Help button that opens the Help Center. */
+		: /* translators: Accessible label on the floating Help button that opens the Help Center. */
 		  __( 'Help' );
 
 	return (
@@ -79,7 +79,6 @@ const HelpCenterFab = ( { sectionName }: HelpCenterFabProps ) => {
 				className={ clsx( 'help-center-fab', { 'is-active': isHelpCenterShown } ) }
 				onClick={ handleClick }
 				label={ label }
-				showTooltip
 				aria-haspopup="dialog"
 				aria-expanded={ isHelpCenterShown }
 			>

--- a/client/components/help-center-fab/index.tsx
+++ b/client/components/help-center-fab/index.tsx
@@ -78,7 +78,7 @@ const HelpCenterFab = ( { sectionName }: HelpCenterFabProps ) => {
 			<Button
 				className={ clsx( 'help-center-fab', { 'is-active': isHelpCenterShown } ) }
 				onClick={ handleClick }
-				label={ label }
+				aria-label={ label }
 				aria-haspopup="dialog"
 				aria-expanded={ isHelpCenterShown }
 			>

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -365,7 +365,6 @@ const LayoutLoggedOut = ( {
 						currentRoute={ currentRoute }
 					/>
 				) }
-				{ showHelpCenterFab && <AsyncHelpCenterFab sectionName={ sectionName } /> }
 				{ 'development' === process.env.NODE_ENV && <SympathyDevWarning /> }
 				<BodySectionCssClass
 					group={ sectionGroup }
@@ -431,6 +430,8 @@ const LayoutLoggedOut = ( {
 							} }
 						/>
 					) }
+				{ /* Rendered last so the FAB tabs after the form, just before the dev badge. */ }
+				{ showHelpCenterFab && <AsyncHelpCenterFab sectionName={ sectionName } /> }
 			</div>
 		</Step.StepContainerV2Provider>
 	);


### PR DESCRIPTION
## Proposed Changes

* Drop the hover tooltip from the floating Help button. The `@wordpress/components` Button auto-renders a tooltip for icon-only buttons whenever `label` is set, even without `showTooltip`, so switch to `aria-label` directly to keep an accessible name without the tooltip UI.
* Render `AsyncHelpCenterFab` as the **last** child of `.layout` in `client/layout/logged-out.jsx` (previously it was the first). This puts the FAB into tab order right after the page content and before the dev environment badge — tabbing forward from the form lands on the FAB instead of wrapping past the badge first.

## Why are these changes being made?

* The hover tooltip on the FAB is redundant with the icon and adds visual noise.
* With the FAB rendered first in DOM, tabbing forward from an auto-focused form input went through all other focusables (including the dev badge) before wrapping back to the FAB, which made the FAB feel hard to reach via the keyboard. Moving it to the end of the layout matches its bottom-right visual position and gives a natural tab-order landing point.

## Testing Instructions

Tooltip:
* Open any page that renders the Help Center FAB (e.g. `/log-in`).
* Hover the floating "?" button — confirm no tooltip appears.
* Inspect the button — confirm it still has an `aria-label` ("Help" when closed, "Close help" when the panel is open).
* Click the button — confirm it still opens and closes the Help Center.

Tab order:
* Open `/log-in` in a browser.
* Press <kbd>Tab</kbd> repeatedly starting from the focused email field.
* Confirm the FAB receives focus after "Lost your password?" and before the dev environment badge / "Report an issue" link.
* Press <kbd>Shift</kbd>+<kbd>Tab</kbd> from "Create an account" — focus should stay within the page header (no longer jumps back to the FAB).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
