### PR TITLE
Omnibar: truncate long site titles with ellipsis

### DIFF
--- a/packages/omnibar/src/components/omnibar-menu.tsx
+++ b/packages/omnibar/src/components/omnibar-menu.tsx
@@ -64,7 +64,7 @@ function OmnibarMenuContent( { nodes }: { nodes: OmnibarNode[] } ) {
 	);
 }
 
-export function OmnibarMenu( { node }: { node: OmnibarNode } ) {
+export function OmnibarMenu( { node, style }: { node: OmnibarNode; style?: React.CSSProperties } ) {
 	const label = node.title || node.label || '';
 
 	if ( ! node.children ) {
@@ -72,6 +72,7 @@ export function OmnibarMenu( { node }: { node: OmnibarNode } ) {
 			<Button
 				variant="unstyled"
 				className="omnibar__menu"
+				style={ style }
 				render={ node.href ? <a href={ node.href } /> : undefined }
 				onClick={ node.onClick }
 				aria-label={ label }
@@ -85,7 +86,7 @@ export function OmnibarMenu( { node }: { node: OmnibarNode } ) {
 		<Menu>
 			<Menu.TriggerButton
 				render={
-					<Button variant="unstyled" className="omnibar__menu" aria-label={ label }>
+					<Button variant="unstyled" className="omnibar__menu" style={ style } aria-label={ label }>
 						<OmnibarNodeContent node={ node } />
 					</Button>
 				}

--- a/packages/omnibar/src/components/omnibar-node.tsx
+++ b/packages/omnibar/src/components/omnibar-node.tsx
@@ -7,9 +7,18 @@ export function OmnibarNodeContent( { node }: { node: OmnibarNode } ) {
 	}
 	if ( node.icon && node.title ) {
 		return (
-			<Stack direction="row" gap="sm" align="center">
-				{ node.icon }
-				<span>{ node.title }</span>
+			<Stack direction="row" gap="sm" align="center" style={ { minWidth: 0 } }>
+				<span style={ { flexShrink: 0 } }>{ node.icon }</span>
+				<span
+					style={ {
+						overflow: 'hidden',
+						textOverflow: 'ellipsis',
+						whiteSpace: 'nowrap',
+						minWidth: 0,
+					} }
+				>
+					{ node.title }
+				</span>
 			</Stack>
 		);
 	}

--- a/packages/omnibar/src/components/omnibar-site.tsx
+++ b/packages/omnibar/src/components/omnibar-site.tsx
@@ -24,7 +24,7 @@ export function OmnibarSiteNode( {
 	const siteActionNodes = isDesktop ? actionNodes : undefined;
 
 	return [
-		<OmnibarMenu key={ siteNode.id } node={ siteNode } />,
+		<OmnibarMenu key={ siteNode.id } node={ siteNode } style={ { minWidth: 0 } } />,
 		pluginNodes && <OmnibarSitePluginsNode nodes={ pluginNodes } />,
 		siteActionNodes && <OmnibarSiteActionsNode nodes={ siteActionNodes } />,
 	].filter( Boolean );


### PR DESCRIPTION
## Proposed Changes

* Let the omnibar site button shrink and ellipsize its title when the omnibar runs out of horizontal space.
* Keep the site icon at its natural size (no flex-shrink) and keep all other buttons (home, user, plugin icons) at their natural width — only the site button shrinks.

| Before | After |
| - | - |
|<img width="392" height="62" alt="image" src="https://github.com/user-attachments/assets/1890b0e1-a921-4c96-881b-6e5d8df9a05f" />|<img width="387" height="55" alt="image" src="https://github.com/user-attachments/assets/e253596b-fc1c-4f9d-bc88-734b89842fbd" />|

## Why are these changes being made?

A long site title pushed the secondary toolbar items off-screen because the site button had no overflow handling.

## Testing Instructions

* Load the dashboard with a site that has a very long title (or rename one).
* At desktop widths, the title shows in full.
* Narrow the viewport — the title should truncate with an ellipsis instead of pushing the user/plugin icons off-screen.
* Confirm the icon-only buttons (home, notifications, help, user avatar) stay the same size at all widths.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?