### PR TITLE
Image Studio: keep 9:16 aspect ratio when the Feature Clip preview goes fullscreen

### DIFF
--- a/packages/image-studio/src/extensions/feature-clip-sidebar.scss
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar.scss
@@ -42,8 +42,28 @@
 		display: block;
 		width: 100%;
 		height: 100%;
+		// `cover` fills the 9:16 inline frame edge-to-edge even if a clip's
+		// intrinsic ratio is slightly off 9:16 (no inner letterbox bars in
+		// the small preview). It only turns destructive once the element's
+		// box stops being 9:16 — which is exactly what native fullscreen
+		// does. Chromium used to ignore author object-fit for fullscreened
+		// <video> (always letterboxed); it now honors it, so `cover` crops
+		// the 9:16 clip to fill the 16:9 screen. Force `contain` in
+		// fullscreen so the whole frame stays visible. Separate rule blocks,
+		// not a grouped selector: an engine that doesn't know one fullscreen
+		// pseudo would otherwise drop the whole group (CSS selector-list
+		// error recovery). Harmless/no-op on Firefox and Safari, which
+		// letterbox natively regardless.
 		object-fit: cover;
 		border-radius: inherit;
+
+		&:fullscreen {
+			object-fit: contain;
+		}
+
+		&:-webkit-full-screen {
+			object-fit: contain;
+		}
 	}
 
 	&__share-cta {

--- a/packages/image-studio/src/extensions/feature-clip-sidebar.scss
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar.scss
@@ -42,21 +42,12 @@
 		display: block;
 		width: 100%;
 		height: 100%;
-		// `cover` fills the 9:16 inline frame edge-to-edge even if a clip's
-		// intrinsic ratio is slightly off 9:16 (no inner letterbox bars in
-		// the small preview). It only turns destructive once the element's
-		// box stops being 9:16 — which is exactly what native fullscreen
-		// does. Chromium used to ignore author object-fit for fullscreened
-		// <video> (always letterboxed); it now honors it, so `cover` crops
-		// the 9:16 clip to fill the 16:9 screen. Force `contain` in
-		// fullscreen so the whole frame stays visible. Separate rule blocks,
-		// not a grouped selector: an engine that doesn't know one fullscreen
-		// pseudo would otherwise drop the whole group (CSS selector-list
-		// error recovery). Harmless/no-op on Firefox and Safari, which
-		// letterbox natively regardless.
 		object-fit: cover;
 		border-radius: inherit;
 
+		// Fullscreen makes the box 16:9; switch to contain so the 9:16 clip
+		// letterboxes instead of cropping. Separate blocks, not a group: an
+		// unknown pseudo would invalidate the whole selector list.
 		&:fullscreen {
 			object-fit: contain;
 		}


### PR DESCRIPTION
## Problem

Playing the Feature Clip sidebar preview in native fullscreen no longer preserves the 9:16 aspect ratio — the clip is scaled up and cropped (top/bottom cut off) to fill the 16:9 screen instead of letterboxing.

## Root cause

**Not a regression in our code.** Git history shows the preview `<video>` has had `object-fit: cover`, unchanged, since the panel first shipped (#110583). `cover` is correct for the *inline* preview — it fills the small 9:16 frame edge-to-edge even when a clip's intrinsic ratio is slightly off 9:16, with no inner letterbox bars. It only turns destructive once the element's box stops being 9:16, which is exactly what native fullscreen does (the box becomes the monitor's 16:9).

What changed is **Chromium**: native `<video>` fullscreen used to ignore author `object-fit` and always letterbox to the intrinsic aspect ratio. It now honors `object-fit`, so the same `cover` that was previously ignored in fullscreen now crops the 9:16 clip to fill the screen.

The modal canvas video is unaffected — it uses `object-fit: contain`, which preserves aspect ratio in any box.

## Fix

Force `object-fit: contain` while the element is the fullscreen target, so the whole 9:16 frame stays visible (letterboxed). The inline `cover` framing is unchanged.

## Cross-browser

- **Chrome / Edge (Blink):** the only engine where the bug occurs — this is the actual fix.
- **Firefox:** letterboxes natively regardless; the bug doesn't manifest. The override is a harmless reinforcement.
- **Safari (macOS / iOS):** the built-in controls fullscreen uses the OS-level AVKit player, which preserves aspect ratio and is immune to CSS `object-fit`; the bug never manifested there and the override is a no-op.
- `contain` is strictly the aspect-preserving direction, so this rule cannot regress any engine — worst case is a no-op.

The two fullscreen pseudo-classes are written as **separate rule blocks**, not a grouped selector: per CSS selector-list error recovery, an engine that doesn't recognize one pseudo would drop the entire group and take the standard `:fullscreen` fix down with it.

## Test plan

- [ ] Chrome: open a post with a Feature Clip, click the preview's native fullscreen button → the full 9:16 clip is visible, letterboxed (pillarboxed) on a 16:9 screen, not cropped.
- [ ] Exit fullscreen → inline preview still fills the 9:16 frame edge-to-edge (unchanged).
- [ ] Firefox: fullscreen still letterboxes correctly (no regression).
- [ ] Safari: built-in fullscreen still letterboxes via the native player (no change).
- [ ] Modal canvas video fullscreen unaffected (already `contain`).
- [x] `yarn stylelint` clean on the modified file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)