### PR TITLE
Reader: fold reader/fediverse flag into reader/social

### DIFF
--- a/client/reader/connections/connections-new-view.tsx
+++ b/client/reader/connections/connections-new-view.tsx
@@ -1,5 +1,4 @@
 import { useFediverseConnectionsQuery } from '@automattic/api-queries';
-import { isEnabled } from '@automattic/calypso-config';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Card, __experimentalVStack as VStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
@@ -25,7 +24,6 @@ interface ProtocolOption {
 	docHref: string;
 	docLabel: string;
 	icon: JSX.Element;
-	available: boolean;
 }
 
 /**
@@ -53,11 +51,8 @@ export function ConnectionsNewView() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const socialEnabled = isEnabled( 'reader/social' );
-
-	const fediverseConnectionsQuery = useFediverseConnectionsQuery( { enabled: socialEnabled } );
-	const fediverseConnectionCount = fediverseConnectionsQuery.data?.connections?.length ?? 0;
-	const hasFediverseConnection = socialEnabled && fediverseConnectionCount > 0;
+	const fediverseConnectionsQuery = useFediverseConnectionsQuery();
+	const hasFediverseConnection = ( fediverseConnectionsQuery.data?.connections?.length ?? 0 ) > 0;
 
 	const adminSites = useSelector( ( state ) =>
 		getSites( state ).filter( ( site ) => !! site?.capabilities?.manage_options )
@@ -73,7 +68,6 @@ export function ConnectionsNewView() {
 			key: 'fediverse' as const,
 			label: 'Fediverse',
 			icon: <ReaderFediverseIcon viewBox="4 3 16 18" />,
-			available: socialEnabled,
 			docHref: fediverseDocHref,
 			docLabel: learnMoreLabel,
 		};
@@ -143,7 +137,6 @@ export function ConnectionsNewView() {
 		),
 		href: '/reader/atmosphere/connect',
 		icon: <ReaderBlueskyIcon filled viewBox="2 3 20 18" />,
-		available: socialEnabled,
 		docHref: blueskyDocHref,
 		docLabel: learnMoreLabel,
 	};
@@ -159,14 +152,11 @@ export function ConnectionsNewView() {
 		),
 		href: '/reader/mastodon/connect',
 		icon: <ReaderMastodonIcon viewBox="0 0 74 78" />,
-		available: socialEnabled,
 		docHref: mastodonDocHref,
 		docLabel: learnMoreLabel,
 	};
 
-	const options: ProtocolOption[] = [ fediverse, atmosphere, mastodon ].filter(
-		( option ) => option.available
-	);
+	const options: ProtocolOption[] = [ fediverse, atmosphere, mastodon ];
 
 	const handlePrimaryClick = ( option: ProtocolOption ) => {
 		dispatch(

--- a/client/reader/connections/connections-new-view.tsx
+++ b/client/reader/connections/connections-new-view.tsx
@@ -54,11 +54,10 @@ export function ConnectionsNewView() {
 	const dispatch = useDispatch();
 
 	const socialEnabled = isEnabled( 'reader/social' );
-	const fediverseEnabled = isEnabled( 'reader/fediverse' );
 
-	const fediverseConnectionsQuery = useFediverseConnectionsQuery( { enabled: fediverseEnabled } );
+	const fediverseConnectionsQuery = useFediverseConnectionsQuery( { enabled: socialEnabled } );
 	const fediverseConnectionCount = fediverseConnectionsQuery.data?.connections?.length ?? 0;
-	const hasFediverseConnection = fediverseEnabled && fediverseConnectionCount > 0;
+	const hasFediverseConnection = socialEnabled && fediverseConnectionCount > 0;
 
 	const adminSites = useSelector( ( state ) =>
 		getSites( state ).filter( ( site ) => !! site?.capabilities?.manage_options )
@@ -74,7 +73,7 @@ export function ConnectionsNewView() {
 			key: 'fediverse' as const,
 			label: 'Fediverse',
 			icon: <ReaderFediverseIcon viewBox="4 3 16 18" />,
-			available: fediverseEnabled,
+			available: socialEnabled,
 			docHref: fediverseDocHref,
 			docLabel: learnMoreLabel,
 		};

--- a/client/reader/connections/social-overview-view.tsx
+++ b/client/reader/connections/social-overview-view.tsx
@@ -156,23 +156,23 @@ export function SocialOverviewView() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const fediverseEnabled = isEnabled( 'reader/fediverse' );
+	const socialEnabled = isEnabled( 'reader/social' );
 	const atmosphere = useConnectionsQuery();
 	const mastodon = useMastodonConnectionsQuery();
-	const fediverse = useFediverseConnectionsQuery( { enabled: fediverseEnabled } );
+	const fediverse = useFediverseConnectionsQuery( { enabled: socialEnabled } );
 
 	const isLoading =
-		atmosphere.isPending || mastodon.isPending || ( fediverseEnabled && fediverse.isPending );
+		atmosphere.isPending || mastodon.isPending || ( socialEnabled && fediverse.isPending );
 	const hasAllErrored =
-		atmosphere.isError && mastodon.isError && ( ! fediverseEnabled || fediverse.isError );
+		atmosphere.isError && mastodon.isError && ( ! socialEnabled || fediverse.isError );
 
 	const cards: SocialCard[] = useMemo(
 		() => [
 			...( atmosphere.data?.connections ?? [] ).map( mapAtmosphere ),
 			...( mastodon.data?.connections ?? [] ).map( mapMastodon ),
-			...( fediverseEnabled ? ( fediverse.data?.connections ?? [] ).map( mapFediverse ) : [] ),
+			...( socialEnabled ? ( fediverse.data?.connections ?? [] ).map( mapFediverse ) : [] ),
 		],
-		[ atmosphere.data, mastodon.data, fediverse.data, fediverseEnabled ]
+		[ atmosphere.data, mastodon.data, fediverse.data, socialEnabled ]
 	);
 
 	// Flat protocol+id (+instance/host) list for the Spotlight strip.

--- a/client/reader/connections/social-overview-view.tsx
+++ b/client/reader/connections/social-overview-view.tsx
@@ -5,7 +5,6 @@ import {
 	useMastodonConnectionQuery,
 	useMastodonConnectionsQuery,
 } from '@automattic/api-queries';
-import { isEnabled } from '@automattic/calypso-config';
 import { Card, Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
@@ -156,23 +155,20 @@ export function SocialOverviewView() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const socialEnabled = isEnabled( 'reader/social' );
 	const atmosphere = useConnectionsQuery();
 	const mastodon = useMastodonConnectionsQuery();
-	const fediverse = useFediverseConnectionsQuery( { enabled: socialEnabled } );
+	const fediverse = useFediverseConnectionsQuery();
 
-	const isLoading =
-		atmosphere.isPending || mastodon.isPending || ( socialEnabled && fediverse.isPending );
-	const hasAllErrored =
-		atmosphere.isError && mastodon.isError && ( ! socialEnabled || fediverse.isError );
+	const isLoading = atmosphere.isPending || mastodon.isPending || fediverse.isPending;
+	const hasAllErrored = atmosphere.isError && mastodon.isError && fediverse.isError;
 
 	const cards: SocialCard[] = useMemo(
 		() => [
 			...( atmosphere.data?.connections ?? [] ).map( mapAtmosphere ),
 			...( mastodon.data?.connections ?? [] ).map( mapMastodon ),
-			...( socialEnabled ? ( fediverse.data?.connections ?? [] ).map( mapFediverse ) : [] ),
+			...( fediverse.data?.connections ?? [] ).map( mapFediverse ),
 		],
-		[ atmosphere.data, mastodon.data, fediverse.data, socialEnabled ]
+		[ atmosphere.data, mastodon.data, fediverse.data ]
 	);
 
 	// Flat protocol+id (+instance/host) list for the Spotlight strip.

--- a/client/reader/fediverse/controller.tsx
+++ b/client/reader/fediverse/controller.tsx
@@ -21,7 +21,7 @@ const loadFediverseFollowingView = () =>
 	);
 
 function ensureFediverseEnabled(): boolean {
-	if ( ! isEnabled( 'reader/fediverse' ) ) {
+	if ( ! isEnabled( 'reader/social' ) ) {
 		page.redirect( '/reader' );
 		return false;
 	}

--- a/client/reader/fediverse/controller.tsx
+++ b/client/reader/fediverse/controller.tsx
@@ -20,7 +20,7 @@ const loadFediverseFollowingView = () =>
 		/* webpackChunkName: "async-load-calypso-reader-fediverse-following-view" */ 'calypso/reader/fediverse/following-view'
 	);
 
-function ensureFediverseEnabled(): boolean {
+function ensureSocialEnabled(): boolean {
 	if ( ! isEnabled( 'reader/social' ) ) {
 		page.redirect( '/reader' );
 		return false;
@@ -33,14 +33,14 @@ function ensureFediverseEnabled(): boolean {
  * route now owns the "find a connection or send to chooser" decision.
  */
 export const fediverseLanding = () => {
-	if ( ! ensureFediverseEnabled() ) {
+	if ( ! ensureSocialEnabled() ) {
 		return;
 	}
 	page.redirect( '/reader/connections' );
 };
 
 export const fediverseIdRedirect = ( context: Context ) => {
-	if ( ! ensureFediverseEnabled() ) {
+	if ( ! ensureSocialEnabled() ) {
 		return;
 	}
 	const id = Number( context.params.id );
@@ -52,7 +52,7 @@ export const fediverseIdRedirect = ( context: Context ) => {
 };
 
 export const fediverseAccount = ( context: Context, next: () => void ) => {
-	if ( ! ensureFediverseEnabled() ) {
+	if ( ! ensureSocialEnabled() ) {
 		return;
 	}
 	const id = Number( context.params.id );
@@ -69,7 +69,7 @@ export const fediverseAccount = ( context: Context, next: () => void ) => {
 };
 
 export const fediverseAuthorProfile = ( context: Context, next: () => void ) => {
-	if ( ! ensureFediverseEnabled() ) {
+	if ( ! ensureSocialEnabled() ) {
 		return;
 	}
 	const id = Number( context.params.id );
@@ -94,7 +94,7 @@ export const fediverseAuthorProfile = ( context: Context, next: () => void ) => 
 };
 
 export const fediverseProfileFollowers = ( context: Context, next: () => void ) => {
-	if ( ! ensureFediverseEnabled() ) {
+	if ( ! ensureSocialEnabled() ) {
 		return;
 	}
 	const id = Number( context.params.id );
@@ -119,7 +119,7 @@ export const fediverseProfileFollowers = ( context: Context, next: () => void ) 
 };
 
 export const fediverseProfileFollowing = ( context: Context, next: () => void ) => {
-	if ( ! ensureFediverseEnabled() ) {
+	if ( ! ensureSocialEnabled() ) {
 		return;
 	}
 	const id = Number( context.params.id );

--- a/client/reader/fediverse/helper.ts
+++ b/client/reader/fediverse/helper.ts
@@ -1,4 +1,3 @@
-export const FEDIVERSE_PREFIX = 'reader/fediverse';
 export const TIMELINE_TAB = 'timeline';
 export const PROFILE_TAB = 'profile';
 export const DEFAULT_FEDIVERSE_TAB = TIMELINE_TAB;

--- a/client/reader/sidebar/reader-sidebar-connections/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-connections/index.tsx
@@ -146,37 +146,35 @@ function ReaderSidebarConnections( { path }: Props ) {
 	// Reader page (e.g. `/reader/search`) would see no connections at all
 	// because the queries never fire. The queries don't refetch every
 	// render thanks to React Query caching.
-	const fediverseEnabled = isEnabled( 'reader/fediverse' );
+	const socialEnabled = isEnabled( 'reader/social' );
 	const shouldFetch = isOnConnections || isOpen;
 	const atmosphereQuery = useConnectionsQuery( { enabled: shouldFetch } );
 	const mastodonQuery = useMastodonConnectionsQuery( { enabled: shouldFetch } );
 	const fediverseQuery = useFediverseConnectionsQuery( {
-		enabled: shouldFetch && fediverseEnabled,
+		enabled: shouldFetch && socialEnabled,
 	} );
 
 	const connections = useMemo( () => {
 		const all: UnifiedConnection[] = [
 			...( atmosphereQuery.data?.connections ?? [] ).map( mapAtmosphere ),
 			...( mastodonQuery.data?.connections ?? [] ).map( mapMastodon ),
-			...( fediverseEnabled ? ( fediverseQuery.data?.connections ?? [] ).map( mapFediverse ) : [] ),
+			...( socialEnabled ? ( fediverseQuery.data?.connections ?? [] ).map( mapFediverse ) : [] ),
 		];
 		return all.sort( sortConnections );
-	}, [ atmosphereQuery.data, mastodonQuery.data, fediverseQuery.data, fediverseEnabled ] );
+	}, [ atmosphereQuery.data, mastodonQuery.data, fediverseQuery.data, socialEnabled ] );
 
 	// Distinguish "we haven't fetched yet" from "we fetched and found none",
 	// and separate both from "the fetch errored". A query that errors stays
 	// at `data: undefined` forever, so without the explicit error check the
 	// menu would sit silently empty when the backend is degraded. When the
-	// fediverse flag is off its query never runs, so it doesn't gate settled
-	// or error state.
+	// social flag is off the fediverse query never runs, so it doesn't gate
+	// settled or error state.
 	const hasSettled =
 		( atmosphereQuery.isSuccess || atmosphereQuery.isError ) &&
 		( mastodonQuery.isSuccess || mastodonQuery.isError ) &&
-		( ! fediverseEnabled || fediverseQuery.isSuccess || fediverseQuery.isError );
+		( ! socialEnabled || fediverseQuery.isSuccess || fediverseQuery.isError );
 	const hasError =
-		atmosphereQuery.isError ||
-		mastodonQuery.isError ||
-		( fediverseEnabled && fediverseQuery.isError );
+		atmosphereQuery.isError || mastodonQuery.isError || ( socialEnabled && fediverseQuery.isError );
 	const showEmptyHint = shouldFetch && hasSettled && ! hasError && connections.length === 0;
 	const showErrorHint = shouldFetch && hasError && connections.length === 0;
 

--- a/client/reader/sidebar/reader-sidebar-connections/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-connections/index.tsx
@@ -3,7 +3,6 @@ import {
 	useFediverseConnectionsQuery,
 	useMastodonConnectionsQuery,
 } from '@automattic/api-queries';
-import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Icon, people } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -146,35 +145,29 @@ function ReaderSidebarConnections( { path }: Props ) {
 	// Reader page (e.g. `/reader/search`) would see no connections at all
 	// because the queries never fire. The queries don't refetch every
 	// render thanks to React Query caching.
-	const socialEnabled = isEnabled( 'reader/social' );
 	const shouldFetch = isOnConnections || isOpen;
 	const atmosphereQuery = useConnectionsQuery( { enabled: shouldFetch } );
 	const mastodonQuery = useMastodonConnectionsQuery( { enabled: shouldFetch } );
-	const fediverseQuery = useFediverseConnectionsQuery( {
-		enabled: shouldFetch && socialEnabled,
-	} );
+	const fediverseQuery = useFediverseConnectionsQuery( { enabled: shouldFetch } );
 
 	const connections = useMemo( () => {
 		const all: UnifiedConnection[] = [
 			...( atmosphereQuery.data?.connections ?? [] ).map( mapAtmosphere ),
 			...( mastodonQuery.data?.connections ?? [] ).map( mapMastodon ),
-			...( socialEnabled ? ( fediverseQuery.data?.connections ?? [] ).map( mapFediverse ) : [] ),
+			...( fediverseQuery.data?.connections ?? [] ).map( mapFediverse ),
 		];
 		return all.sort( sortConnections );
-	}, [ atmosphereQuery.data, mastodonQuery.data, fediverseQuery.data, socialEnabled ] );
+	}, [ atmosphereQuery.data, mastodonQuery.data, fediverseQuery.data ] );
 
 	// Distinguish "we haven't fetched yet" from "we fetched and found none",
 	// and separate both from "the fetch errored". A query that errors stays
 	// at `data: undefined` forever, so without the explicit error check the
-	// menu would sit silently empty when the backend is degraded. When the
-	// social flag is off the fediverse query never runs, so it doesn't gate
-	// settled or error state.
+	// menu would sit silently empty when the backend is degraded.
 	const hasSettled =
 		( atmosphereQuery.isSuccess || atmosphereQuery.isError ) &&
 		( mastodonQuery.isSuccess || mastodonQuery.isError ) &&
-		( ! socialEnabled || fediverseQuery.isSuccess || fediverseQuery.isError );
-	const hasError =
-		atmosphereQuery.isError || mastodonQuery.isError || ( socialEnabled && fediverseQuery.isError );
+		( fediverseQuery.isSuccess || fediverseQuery.isError );
+	const hasError = atmosphereQuery.isError || mastodonQuery.isError || fediverseQuery.isError;
 	const showEmptyHint = shouldFetch && hasSettled && ! hasError && connections.length === 0;
 	const showErrorHint = shouldFetch && hasError && connections.length === 0;
 

--- a/config/development.json
+++ b/config/development.json
@@ -184,7 +184,6 @@
 		"push-notifications": true,
 		"reader/achievements": true,
 		"reader/social": true,
-		"reader/fediverse": true,
 		"reader/full-errors": true,
 		"reader/msd-enabled": true,
 		"reader/onboarding-rsm": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -107,7 +107,6 @@
 		"purchases/split-cancel-remove": false,
 		"reader/achievements": true,
 		"reader/social": true,
-		"reader/fediverse": true,
 		"reader/full-errors": false,
 		"reader/msd-enabled": true,
 		"reader/onboarding-rsm": false,

--- a/config/production.json
+++ b/config/production.json
@@ -138,7 +138,6 @@
 		"push-notifications": true,
 		"reader/achievements": true,
 		"reader/social": false,
-		"reader/fediverse": false,
 		"reader/full-errors": false,
 		"reader/msd-enabled": true,
 		"reader/onboarding-rsm": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -136,7 +136,6 @@
 		"push-notifications": true,
 		"reader/achievements": true,
 		"reader/social": true,
-		"reader/fediverse": false,
 		"reader/full-errors": false,
 		"reader/msd-enabled": true,
 		"reader/onboarding-rsm": false,

--- a/config/test.json
+++ b/config/test.json
@@ -94,7 +94,6 @@
 		"purchases/split-cancel-remove": true,
 		"reader/achievements": true,
 		"reader/social": true,
-		"reader/fediverse": true,
 		"reader/full-errors": true,
 		"reader/msd-enabled": true,
 		"reader/onboarding-rsm": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -138,7 +138,6 @@
 		"purchases/split-cancel-remove": false,
 		"reader/achievements": true,
 		"reader/social": true,
-		"reader/fediverse": true,
 		"reader/full-errors": true,
 		"reader/msd-enabled": true,
 		"reader/onboarding-rsm": false,


### PR DESCRIPTION
Fixes CM-748

## Proposed Changes

* Replace every `isEnabled( 'reader/fediverse' )` call with `isEnabled( 'reader/social' )` across the Reader connections, sidebar, and fediverse controller.
* Remove the unused `FEDIVERSE_PREFIX` export from `client/reader/fediverse/helper.ts`.
* Drop the `reader/fediverse` key from every `config/*.json`.
* Rename the gating locals to `socialEnabled` for consistency between the three call sites.

## Why are these changes being made?

The dedicated `reader/fediverse` flag duplicated the social gate it lived inside — every call site already paired it with `reader/social`, and the two flags were always rolled out together. Collapsing them removes a maintenance burden and makes the gating story one switch instead of two.

Behavior change to call out: stage previously had `reader/social: true` plus `reader/fediverse: false`, which gated off the fediverse query and the `/reader/fediverse/:id` redirect guard. Both now follow `reader/social` on stage, matching the intent of this consolidation. Production is unchanged — both flags were `false`.

## Testing Instructions

* On Calypso `wpcalypso` / dev (where `reader/social` is `true`), visit `/reader/connections`, `/reader/connections/new`, and the Reader sidebar — fediverse cards/rows still appear alongside ATmosphere and Mastodon connections.
* Visit `/reader/fediverse/:id` — should still redirect to `/reader` when `reader/social` is off, and load normally when it's on.
* Confirm production behavior is unchanged when `reader/social` is `false`: no fediverse query fires, no fediverse row in the sidebar, `/reader/fediverse/...` redirects to `/reader`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?