### PR TITLE
Reader Fediverse: add Notifications tab

### DIFF
--- a/client/reader/atmosphere/notifications-panel.tsx
+++ b/client/reader/atmosphere/notifications-panel.tsx
@@ -1,60 +1,17 @@
 import { useAtmosphereNotificationsInfiniteQuery } from '@automattic/api-queries';
-import { useMemo, useState } from 'react';
-import { useDispatch } from 'react-redux';
-import { UnknownAction } from 'redux';
-import { ThunkDispatch } from 'redux-thunk';
-import { SocialNotificationsList } from 'calypso/reader/social';
-import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import { SocialNotificationsPanel } from 'calypso/reader/social';
 import type { AtmosphereConnection } from '@automattic/api-core';
-import type { ChipFilter } from 'calypso/reader/social';
-import type { AppState } from 'calypso/types';
 
 interface Props {
 	connection: AtmosphereConnection;
 }
 
 export function NotificationsPanel( { connection }: Props ) {
-	const [ filter, setFilter ] = useState< ChipFilter >( 'all' );
-	const dispatch = useDispatch< ThunkDispatch< AppState, void, UnknownAction > >();
-	const { data, isPending, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
-		useAtmosphereNotificationsInfiniteQuery( connection.id, { filter } );
-
-	const items = useMemo( () => data?.pages.flatMap( ( p ) => p.items ) ?? [], [ data ] );
-
 	return (
-		<SocialNotificationsList
-			items={ items }
-			isLoading={ isPending }
-			isLoadingMore={ isFetchingNextPage }
-			isError={ isError }
-			hasMore={ !! hasNextPage }
-			onLoadMore={ () => {
-				fetchNextPage();
-			} }
-			filter={ filter }
-			onFilterChange={ ( next ) => {
-				setFilter( next );
-				dispatch(
-					recordReaderTracksEvent( 'calypso_reader_atmosphere_notifications_filter_changed', {
-						connection_id: connection.id,
-						filter: next,
-					} )
-				);
-			} }
-			onStackExpandedChange={ ( expanded, member_count ) => {
-				dispatch(
-					recordReaderTracksEvent(
-						expanded
-							? 'calypso_reader_atmosphere_notifications_stack_expanded'
-							: 'calypso_reader_atmosphere_notifications_stack_collapsed',
-						{
-							connection_id: connection.id,
-							member_count,
-							canonical_type: 'follow',
-						}
-					)
-				);
-			} }
+		<SocialNotificationsPanel
+			connectionId={ connection.id }
+			source="atmosphere"
+			useNotificationsInfiniteQuery={ useAtmosphereNotificationsInfiniteQuery }
 		/>
 	);
 }

--- a/client/reader/fediverse/fediverse-account-view.tsx
+++ b/client/reader/fediverse/fediverse-account-view.tsx
@@ -12,11 +12,12 @@ import ReaderMain from 'calypso/reader/components/reader-main';
 import { ComposeFab, ComposerModal, ComposerProvider } from 'calypso/reader/social/composer';
 import { fediverseComposerConfig } from './composer-config';
 import { FediverseNavigation } from './fediverse-navigation';
-import { PROFILE_TAB, TIMELINE_TAB } from './helper';
+import { NOTIFICATIONS_TAB, PROFILE_TAB, TIMELINE_TAB } from './helper';
+import { NotificationsPanel } from './notifications-panel';
 import { ProfilePanel } from './profile-panel';
 import { TimelinePanel } from './timeline-panel';
 
-const VALID_TABS = new Set< string >( [ TIMELINE_TAB, PROFILE_TAB ] );
+const VALID_TABS = new Set< string >( [ TIMELINE_TAB, PROFILE_TAB, NOTIFICATIONS_TAB ] );
 
 interface Props {
 	connectionId: number;
@@ -101,6 +102,7 @@ export function FediverseAccountView( { connectionId, tab }: Props ) {
 				<VStack spacing={ 4 } className="fediverse-view__body">
 					{ tab === TIMELINE_TAB && <TimelinePanel connection={ connection } /> }
 					{ tab === PROFILE_TAB && <ProfilePanel connection={ connection } /> }
+					{ tab === NOTIFICATIONS_TAB && <NotificationsPanel connection={ connection } /> }
 				</VStack>
 			</ReaderMain>
 			<ComposeFab />

--- a/client/reader/fediverse/fediverse-navigation.tsx
+++ b/client/reader/fediverse/fediverse-navigation.tsx
@@ -4,7 +4,7 @@ import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
 import { useDispatch } from 'calypso/state';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
-import { TIMELINE_TAB, PROFILE_TAB } from './helper';
+import { TIMELINE_TAB, PROFILE_TAB, NOTIFICATIONS_TAB } from './helper';
 
 interface Tab {
 	slug: string;
@@ -35,6 +35,11 @@ export function FediverseNavigation( { connectionId, selectedTab }: Props ) {
 			slug: TIMELINE_TAB,
 			title: translate( 'Timeline' ),
 			path: `/reader/fediverse/${ connectionId }/${ TIMELINE_TAB }`,
+		},
+		{
+			slug: NOTIFICATIONS_TAB,
+			title: translate( 'Notifications' ),
+			path: `/reader/fediverse/${ connectionId }/${ NOTIFICATIONS_TAB }`,
 		},
 		{
 			slug: PROFILE_TAB,

--- a/client/reader/fediverse/helper.ts
+++ b/client/reader/fediverse/helper.ts
@@ -1,4 +1,5 @@
 export const FEDIVERSE_PREFIX = 'reader/fediverse';
 export const TIMELINE_TAB = 'timeline';
 export const PROFILE_TAB = 'profile';
+export const NOTIFICATIONS_TAB = 'notifications';
 export const DEFAULT_FEDIVERSE_TAB = TIMELINE_TAB;

--- a/client/reader/fediverse/notifications-panel.tsx
+++ b/client/reader/fediverse/notifications-panel.tsx
@@ -1,0 +1,17 @@
+import { useFediverseNotificationsInfiniteQuery } from '@automattic/api-queries';
+import { SocialNotificationsPanel } from 'calypso/reader/social';
+import type { FediverseConnection } from '@automattic/api-core';
+
+interface Props {
+	connection: FediverseConnection;
+}
+
+export function NotificationsPanel( { connection }: Props ) {
+	return (
+		<SocialNotificationsPanel
+			connectionId={ connection.id }
+			source="fediverse"
+			useNotificationsInfiniteQuery={ useFediverseNotificationsInfiniteQuery }
+		/>
+	);
+}

--- a/client/reader/fediverse/test/fediverse-navigation.test.tsx
+++ b/client/reader/fediverse/test/fediverse-navigation.test.tsx
@@ -29,13 +29,15 @@ describe( 'FediverseNavigation', () => {
 	} );
 	afterEach( () => jest.restoreAllMocks() );
 
-	it( 'renders the Timeline and Profile tabs with paths scoped to the connection id', () => {
+	it( 'renders the Timeline, Notifications, and Profile tabs with paths scoped to the connection id', () => {
 		renderWithProvider( <FediverseNavigation connectionId={ 7 } selectedTab="timeline" /> );
 
 		const timeline = screen.getByRole( 'menuitem', { name: 'Timeline' } );
+		const notifications = screen.getByRole( 'menuitem', { name: 'Notifications' } );
 		const profile = screen.getByRole( 'menuitem', { name: 'Profile' } );
 
 		expect( timeline ).toHaveAttribute( 'href', '/reader/fediverse/7/timeline' );
+		expect( notifications ).toHaveAttribute( 'href', '/reader/fediverse/7/notifications' );
 		expect( profile ).toHaveAttribute( 'href', '/reader/fediverse/7/profile' );
 		// Settings tab was removed alongside the Mastodon / ATmosphere drop —
 		// no dead nav item leaks through.

--- a/client/reader/fediverse/test/notifications-panel.test.tsx
+++ b/client/reader/fediverse/test/notifications-panel.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { NotificationsPanel } from '../notifications-panel';
+import type { FediverseConnection } from '@automattic/api-core';
+
+jest.mock( 'calypso/state/reader/analytics/actions', () => ( {
+	recordReaderTracksEvent: () => ( { type: '@@TEST/NOOP' } ),
+} ) );
+
+const BASE = 'https://public-api.wordpress.com';
+
+const connection: FediverseConnection = {
+	id: 101,
+	blog_id: 12345,
+	url: 'https://myblog.wordpress.com',
+	name: 'My Blog',
+	icon: '',
+	webfinger: '@myblog@myblog.wordpress.com',
+};
+
+describe( 'Fediverse NotificationsPanel', () => {
+	afterEach( () => nock.cleanAll() );
+
+	it( 'renders fetched notifications via the shared list', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/fediverse/connections/101/notifications' )
+			.query( {} )
+			.reply( 200, {
+				items: [
+					{
+						id: '13371337',
+						// Raw AP activity kind; the canonical enum normalizes to
+						// 'like' so the shared renderer can emit the same phrase
+						// across protocols.
+						protocol_type: 'Like',
+						canonical_type: 'like',
+						actor: {
+							handle: 'jane@example.com',
+							display_name: 'Jane',
+							avatar_url: null,
+							profile_uri: 'https://example.com/users/jane',
+						},
+						// `''` excerpt is the documented contract for likes
+						// (subject post text isn't fetched).
+						target: {
+							kind: 'post',
+							uri: 'https://example.com/users/me/statuses/110000000000000001',
+							excerpt: '',
+						},
+						target_url: 'https://example.com/users/me/statuses/110000000000000001',
+						created_at: '2026-05-11T12:34:56Z',
+						is_read: false,
+					},
+				],
+				next_cursor: null,
+				seen_at: null,
+			} );
+		renderWithProvider( <NotificationsPanel connection={ connection } /> );
+		await waitFor( () => expect( screen.getByText( /jane/i ) ).toBeVisible() );
+		expect( screen.getByText( /liked your post/i ) ).toBeVisible();
+	} );
+
+	it( 'renders AP "Announce" notifications as repost via canonical_type', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/fediverse/connections/101/notifications' )
+			.query( {} )
+			.reply( 200, {
+				items: [
+					{
+						id: '13371338',
+						protocol_type: 'Announce',
+						canonical_type: 'repost',
+						actor: {
+							handle: 'jane@example.com',
+							display_name: 'Jane',
+							avatar_url: null,
+							profile_uri: 'https://example.com/users/jane',
+						},
+						target: {
+							kind: 'post',
+							uri: 'https://example.com/users/me/statuses/110000000000000002',
+							excerpt: '',
+						},
+						target_url: 'https://example.com/users/me/statuses/110000000000000002',
+						created_at: '2026-05-11T13:00:00Z',
+						is_read: false,
+					},
+				],
+				next_cursor: null,
+				seen_at: null,
+			} );
+		renderWithProvider( <NotificationsPanel connection={ connection } /> );
+		await waitFor( () => expect( screen.getByText( /reposted your post/i ) ).toBeVisible() );
+	} );
+
+	it( 'falls back to the generic phrase for unknown canonical types (forward-compat)', async () => {
+		// The wpcom envelope deliberately omits a `raw` passthrough; the
+		// frontend renders unknown upstream kinds via canonical_type='other'
+		// and a generic phrase. Guards the long-tail rendering path so a
+		// future AP activity (Move, Block, etc.) projected as 'other'
+		// renders sensibly even before a bespoke template ships.
+		nock( BASE )
+			.get( '/wpcom/v2/reader/fediverse/connections/101/notifications' )
+			.query( {} )
+			.reply( 200, {
+				items: [
+					{
+						id: '13371339',
+						protocol_type: 'Move',
+						canonical_type: 'other',
+						actor: {
+							handle: 'mover@example.com',
+							display_name: 'Mover',
+							avatar_url: null,
+							profile_uri: 'https://example.com/users/mover',
+						},
+						target: null,
+						target_url: '',
+						created_at: '2026-05-11T14:00:00Z',
+						is_read: false,
+					},
+				],
+				next_cursor: null,
+				seen_at: null,
+			} );
+		renderWithProvider( <NotificationsPanel connection={ connection } /> );
+		await waitFor( () => expect( screen.getByText( /interacted with you/i ) ).toBeVisible() );
+	} );
+
+	it( 'renders an empty state when no notifications', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/fediverse/connections/101/notifications' )
+			.query( {} )
+			.reply( 200, { items: [], next_cursor: null, seen_at: null } );
+		renderWithProvider( <NotificationsPanel connection={ connection } /> );
+		await waitFor( () => expect( screen.getByText( /no notifications yet/i ) ).toBeVisible() );
+	} );
+
+	it( 'switching to the Likes chip refetches with types=like', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/fediverse/connections/101/notifications' )
+			.query( {} )
+			.reply( 200, { items: [], next_cursor: null, seen_at: null } )
+			.get( '/wpcom/v2/reader/fediverse/connections/101/notifications' )
+			.query( { types: 'like' } )
+			.reply( 200, { items: [], next_cursor: null, seen_at: null } );
+
+		const user = userEvent.setup();
+		renderWithProvider( <NotificationsPanel connection={ connection } /> );
+		await waitFor( () => expect( screen.getByText( /no notifications yet/i ) ).toBeVisible() );
+
+		await user.click( screen.getByRole( 'radio', { name: /^likes$/i } ) );
+		await waitFor( () => expect( screen.getByText( /no likes yet/i ) ).toBeVisible() );
+		expect( nock.isDone() ).toBe( true );
+	} );
+} );

--- a/client/reader/mastodon/notifications-panel.tsx
+++ b/client/reader/mastodon/notifications-panel.tsx
@@ -1,60 +1,17 @@
 import { useMastodonNotificationsInfiniteQuery } from '@automattic/api-queries';
-import { useMemo, useState } from 'react';
-import { useDispatch } from 'react-redux';
-import { UnknownAction } from 'redux';
-import { ThunkDispatch } from 'redux-thunk';
-import { SocialNotificationsList } from 'calypso/reader/social';
-import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import { SocialNotificationsPanel } from 'calypso/reader/social';
 import type { MastodonConnection } from '@automattic/api-core';
-import type { ChipFilter } from 'calypso/reader/social';
-import type { AppState } from 'calypso/types';
 
 interface Props {
 	connection: MastodonConnection;
 }
 
 export function NotificationsPanel( { connection }: Props ) {
-	const [ filter, setFilter ] = useState< ChipFilter >( 'all' );
-	const dispatch = useDispatch< ThunkDispatch< AppState, void, UnknownAction > >();
-	const { data, isPending, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
-		useMastodonNotificationsInfiniteQuery( connection.id, { filter } );
-
-	const items = useMemo( () => data?.pages.flatMap( ( p ) => p.items ) ?? [], [ data ] );
-
 	return (
-		<SocialNotificationsList
-			items={ items }
-			isLoading={ isPending }
-			isLoadingMore={ isFetchingNextPage }
-			isError={ isError }
-			hasMore={ !! hasNextPage }
-			onLoadMore={ () => {
-				fetchNextPage();
-			} }
-			filter={ filter }
-			onFilterChange={ ( next ) => {
-				setFilter( next );
-				dispatch(
-					recordReaderTracksEvent( 'calypso_reader_mastodon_notifications_filter_changed', {
-						connection_id: connection.id,
-						filter: next,
-					} )
-				);
-			} }
-			onStackExpandedChange={ ( expanded, member_count ) => {
-				dispatch(
-					recordReaderTracksEvent(
-						expanded
-							? 'calypso_reader_mastodon_notifications_stack_expanded'
-							: 'calypso_reader_mastodon_notifications_stack_collapsed',
-						{
-							connection_id: connection.id,
-							member_count,
-							canonical_type: 'follow',
-						}
-					)
-				);
-			} }
+		<SocialNotificationsPanel
+			connectionId={ connection.id }
+			source="mastodon"
+			useNotificationsInfiniteQuery={ useMastodonNotificationsInfiniteQuery }
 		/>
 	);
 }

--- a/client/reader/social/AGENTS.md
+++ b/client/reader/social/AGENTS.md
@@ -490,13 +490,19 @@ loaded row lands in a single bucket the lone divider is also suppressed
 (it would feel like noise). `now` is captured inside the bucketing
 `useMemo`, not lifted to its own hook.
 
-**Stacking** — `groupNotifications( items )` in
+**Stacking** — `groupNotifications( items, now )` in
 `group-notifications.ts` is a pure function that buckets a flat
 newest-first `SocialNotification[]` into `GroupedRow[]`. Group key:
-`canonical_type:target.uri` for like/repost/mention/reply/quote, the
-literal `'follow'` for follow rows (no target needed), and a per-item
+`canonical_type:target.uri` for like/repost/mention/reply/quote,
+`follow:<date-bucket>` for follow rows (using the same `bucketFor`
+vocabulary the renderer uses for date dividers — a long-tailed
+follower history would otherwise collapse into a single mega-stack,
+since every follow shares the same target = "you"), and a per-item
 singleton key for `other` (never stacks) or for any row missing a
-`target.uri`. Stacks form only at `members.length >= 2`; singletons
+`target.uri`. The `now` argument is shared by `<SocialNotificationsList>`
+with the divider computation so each follow stack lands under the
+matching bucket heading. Stacks form only at `members.length >= 2`;
+singletons
 render via `<SocialNotificationItem>` unchanged. Position of a stack in
 the rendered list is the position of its newest member, which falls out
 of the algorithm because the first time a key is seen creates its

--- a/client/reader/social/components/notifications-list/group-notifications.ts
+++ b/client/reader/social/components/notifications-list/group-notifications.ts
@@ -1,14 +1,18 @@
+import { bucketFor } from './date-bucket';
 import type {
 	AtmosphereNotification,
 	AtmosphereNotificationCanonicalType,
+	FediverseNotification,
+	FediverseNotificationCanonicalType,
 	MastodonNotification,
 	MastodonNotificationCanonicalType,
 } from '@automattic/api-core';
 
-type SocialNotification = AtmosphereNotification | MastodonNotification;
+type SocialNotification = AtmosphereNotification | MastodonNotification | FediverseNotification;
 export type SocialNotificationCanonicalType =
 	| AtmosphereNotificationCanonicalType
-	| MastodonNotificationCanonicalType;
+	| MastodonNotificationCanonicalType
+	| FediverseNotificationCanonicalType;
 
 /**
  * Canonical types that may form a stack. `keyFor` returns `null` for
@@ -32,12 +36,17 @@ export type StackedRow = {
 };
 export type GroupedRow = SingleRow | StackedRow;
 
-function keyFor( n: SocialNotification ): string | null {
+function keyFor( n: SocialNotification, now: Date ): string | null {
 	if ( n.canonical_type === 'other' ) {
 		return null;
 	}
 	if ( n.canonical_type === 'follow' ) {
-		return 'follow';
+		// Bucket follows by date so a long-tailed follower history doesn't
+		// collapse into a single mega-stack. Each of today / yesterday /
+		// this_week / earlier gets its own follow stack — same bucket
+		// vocabulary `<SocialNotificationsList>` already uses for date
+		// dividers, so stacks sit under matching headings.
+		return `follow:${ bucketFor( n.created_at ?? '', now ) }`;
 	}
 	const uri = n.target?.uri;
 	if ( ! uri ) {
@@ -46,13 +55,16 @@ function keyFor( n: SocialNotification ): string | null {
 	return `${ n.canonical_type }:${ uri }`;
 }
 
-export function groupNotifications( items: SocialNotification[] ): GroupedRow[] {
+export function groupNotifications(
+	items: SocialNotification[],
+	now: Date = new Date()
+): GroupedRow[] {
 	type Bucket = { key: string; members: SocialNotification[] };
 	const buckets: Bucket[] = [];
 	const byKey = new Map< string, Bucket >();
 
 	for ( const item of items ) {
-		const k = keyFor( item );
+		const k = keyFor( item, now );
 		if ( k === null ) {
 			// Singleton: always its own bucket, placed in input order.
 			const bucket: Bucket = { key: `__single:${ item.id }`, members: [ item ] };

--- a/client/reader/social/components/notifications-list/index.tsx
+++ b/client/reader/social/components/notifications-list/index.tsx
@@ -9,9 +9,13 @@ import { groupNotifications, type GroupedRow } from './group-notifications';
 import { SocialNotificationItem } from './notification-item';
 import { StackedNotification } from './stacked-notification';
 import type { ChipFilter } from './filter';
-import type { AtmosphereNotification, MastodonNotification } from '@automattic/api-core';
+import type {
+	AtmosphereNotification,
+	FediverseNotification,
+	MastodonNotification,
+} from '@automattic/api-core';
 
-type SocialNotification = AtmosphereNotification | MastodonNotification;
+type SocialNotification = AtmosphereNotification | MastodonNotification | FediverseNotification;
 
 interface Props {
 	items: SocialNotification[];
@@ -74,16 +78,22 @@ export function SocialNotificationsList( {
 }: Props ) {
 	const translate = useTranslate();
 
-	const grouped = useMemo( () => groupNotifications( items ), [ items ] );
+	// Share a single `now` across grouping and divider-bucketing so the
+	// follow-stack key (which buckets by date) and its rendered divider
+	// resolve to the same bucket. Re-derives only when items change — any
+	// stale-by-a-render jitter is well below the bucket granularity.
+	const grouped = useMemo( () => {
+		const now = new Date();
+		return { rows: groupNotifications( items, now ), now };
+	}, [ items ] );
 
 	const withBuckets = useMemo( () => {
-		const now = new Date();
 		const out: Array< { kind: 'divider'; bucket: DateBucket } | { kind: 'row'; row: GroupedRow } > =
 			[];
 		const bucketsSeen: DateBucket[] = [];
 		let lastBucket: DateBucket | null = null;
-		for ( const row of grouped ) {
-			const b = bucketFor( rowTimestamp( row ), now );
+		for ( const row of grouped.rows ) {
+			const b = bucketFor( rowTimestamp( row ), grouped.now );
 			if ( b !== lastBucket ) {
 				out.push( { kind: 'divider', bucket: b } );
 				bucketsSeen.push( b );
@@ -142,7 +152,7 @@ export function SocialNotificationsList( {
 		<div className="social-notifications-list">
 			{ filterBar }
 			<VStack spacing={ 0 }>
-				{ withBuckets.map( ( entry ) => {
+				{ withBuckets.map( ( entry, index ) => {
 					if ( entry.kind === 'divider' ) {
 						// Visual-only separator. Rendered as a presentational
 						// `<div>` rather than a heading so the surrounding
@@ -150,9 +160,15 @@ export function SocialNotificationsList( {
 						// surface that mounts this list already supplies its
 						// own page heading, and an `<h3>` here would land
 						// without a parent `<h2>` on some of them.
+						//
+						// Key includes the entry index because a bucket can
+						// appear more than once when wire items aren't strictly
+						// monotonic by created_at (e.g. paginated pages re-merged,
+						// or backend ordering quirks). The bucket name alone is
+						// not unique in that case and would collide.
 						return (
 							<div
-								key={ `divider-${ entry.bucket }` }
+								key={ `divider-${ entry.bucket }-${ index }` }
 								className="social-notifications-list__divider"
 								role="presentation"
 							>

--- a/client/reader/social/components/notifications-list/notification-item.tsx
+++ b/client/reader/social/components/notifications-list/notification-item.tsx
@@ -11,19 +11,25 @@ import { SocialAvatar } from '../../avatar';
 import type {
 	AtmosphereNotification,
 	AtmosphereNotificationCanonicalType,
+	FediverseNotification,
+	FediverseNotificationCanonicalType,
 	MastodonNotification,
 	MastodonNotificationCanonicalType,
 } from '@automattic/api-core';
 
 // The wpcom backend ships byte-compatible notification envelopes across
-// protocols; both per-protocol types share the same canonical_type union.
-// Aliased here so the renderer takes either without per-protocol branching.
-// Keep both arms in the union so a future per-protocol widening surfaces as
+// protocols; the per-protocol types share the same canonical_type union.
+// Aliased here so the renderer takes any of them without per-protocol branching.
+// Keep all arms in the union so a future per-protocol widening surfaces as
 // a switch-exhaustiveness error instead of being silently funneled to 'other'.
-type SocialNotification = AtmosphereNotification | MastodonNotification;
+export type SocialNotification =
+	| AtmosphereNotification
+	| MastodonNotification
+	| FediverseNotification;
 type SocialNotificationCanonicalType =
 	| AtmosphereNotificationCanonicalType
-	| MastodonNotificationCanonicalType;
+	| MastodonNotificationCanonicalType
+	| FediverseNotificationCanonicalType;
 
 interface Props {
 	notification: SocialNotification;

--- a/client/reader/social/components/notifications-list/test/group-notifications.test.ts
+++ b/client/reader/social/components/notifications-list/test/group-notifications.test.ts
@@ -74,13 +74,15 @@ describe( 'groupNotifications', () => {
 		expect( out.map( ( r ) => r.kind ) ).toEqual( [ 'single', 'single' ] );
 	} );
 
-	it( 'stacks all follows together (no target)', () => {
+	it( 'stacks follows that fall in the same date bucket', () => {
+		const now = new Date( '2026-05-19T12:00:00Z' );
 		const f1 = makeItem( {
 			id: 'f1',
 			canonical_type: 'follow',
 			protocol_type: 'follow',
 			target: null,
 			target_url: 'https://bsky.app/profile/a',
+			created_at: '2026-05-19T10:00:00Z', // today
 		} );
 		const f2 = makeItem( {
 			id: 'f2',
@@ -88,12 +90,60 @@ describe( 'groupNotifications', () => {
 			protocol_type: 'follow',
 			target: null,
 			target_url: 'https://bsky.app/profile/b',
+			created_at: '2026-05-19T11:00:00Z', // today
 		} );
-		const out = groupNotifications( [ f1, f2 ] );
+		const out = groupNotifications( [ f1, f2 ], now );
 		expect( out ).toHaveLength( 1 );
 		assertStack( out[ 0 ] );
 		expect( out[ 0 ].canonicalType ).toBe( 'follow' );
 		expect( out[ 0 ].members ).toHaveLength( 2 );
+	} );
+
+	it( 'splits follow rows into separate stacks per date bucket', () => {
+		// Long-tailed follower histories used to collapse into one mega-stack
+		// because `keyFor` returned the literal `'follow'` for every follow.
+		// Bucketing the follow key by date instead means each of today /
+		// yesterday / this_week / earlier renders as its own stack, sitting
+		// under the matching date divider.
+		const now = new Date( '2026-05-19T12:00:00Z' );
+		const today1 = makeItem( {
+			id: 't1',
+			canonical_type: 'follow',
+			protocol_type: 'follow',
+			target: null,
+			target_url: 'https://bsky.app/profile/t1',
+			created_at: '2026-05-19T10:00:00Z',
+		} );
+		const today2 = makeItem( {
+			id: 't2',
+			canonical_type: 'follow',
+			protocol_type: 'follow',
+			target: null,
+			target_url: 'https://bsky.app/profile/t2',
+			created_at: '2026-05-19T11:00:00Z',
+		} );
+		const earlier1 = makeItem( {
+			id: 'e1',
+			canonical_type: 'follow',
+			protocol_type: 'follow',
+			target: null,
+			target_url: 'https://bsky.app/profile/e1',
+			created_at: '2026-03-01T12:00:00Z',
+		} );
+		const earlier2 = makeItem( {
+			id: 'e2',
+			canonical_type: 'follow',
+			protocol_type: 'follow',
+			target: null,
+			target_url: 'https://bsky.app/profile/e2',
+			created_at: '2026-03-02T12:00:00Z',
+		} );
+		const out = groupNotifications( [ today1, today2, earlier1, earlier2 ], now );
+		expect( out ).toHaveLength( 2 );
+		assertStack( out[ 0 ] );
+		assertStack( out[ 1 ] );
+		expect( out[ 0 ].members ).toHaveLength( 2 );
+		expect( out[ 1 ].members ).toHaveLength( 2 );
 	} );
 
 	it( 'never stacks "other" items', () => {

--- a/client/reader/social/components/notifications-list/test/index.test.tsx
+++ b/client/reader/social/components/notifications-list/test/index.test.tsx
@@ -135,4 +135,36 @@ describe( 'SocialNotificationsList', () => {
 		);
 		expect( screen.queryByRole( 'heading', { name: /today/i, level: 3 } ) ).toBeNull();
 	} );
+
+	it( 'does not emit duplicate-key warnings when a bucket re-appears in non-monotonic input', () => {
+		// Some wire orderings (paginated pages re-merged out-of-order, backend
+		// quirks) can interleave buckets — e.g. earlier → this_week → earlier.
+		// The divider key must stay unique across such layouts so React doesn't
+		// drop or duplicate dividers. See the divider-key construction in the
+		// list renderer.
+		const now = Date.now();
+		const days = ( n: number ) => new Date( now - n * 24 * 60 * 60 * 1000 ).toISOString();
+		const items = [
+			makeNotification( { id: 'a', created_at: days( 10 ) } ), // earlier
+			makeNotification( { id: 'b', created_at: days( 3 ) } ), // this_week
+			makeNotification( { id: 'c', created_at: days( 15 ) } ), // earlier (again)
+		];
+		const errorSpy = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+		try {
+			renderWithProvider(
+				<SocialNotificationsList
+					{ ...defaultProps }
+					items={ items }
+					filter="all"
+					onFilterChange={ jest.fn() }
+				/>
+			);
+			const dupKeyCalls = errorSpy.mock.calls.filter( ( args ) =>
+				args.some( ( arg ) => String( arg ).includes( 'two children with the same key' ) )
+			);
+			expect( dupKeyCalls ).toEqual( [] );
+		} finally {
+			errorSpy.mockRestore();
+		}
+	} );
 } );

--- a/client/reader/social/index.ts
+++ b/client/reader/social/index.ts
@@ -23,6 +23,11 @@ export { SocialFeedList } from './components/feed-list';
 export { SocialNotificationItem } from './components/notifications-list/notification-item';
 export { SocialNotificationsList } from './components/notifications-list';
 export type { ChipFilter } from './components/notifications-list/filter';
+export { SocialNotificationsPanel } from './social-notifications-panel';
+export type {
+	SocialNotificationsSource,
+	UseSocialNotificationsInfiniteQuery,
+} from './social-notifications-panel';
 export { SocialAnalyticsProvider } from './components/post-card/analytics-context';
 
 export type {

--- a/client/reader/social/social-notifications-panel.tsx
+++ b/client/reader/social/social-notifications-panel.tsx
@@ -1,0 +1,91 @@
+import { useMemo, useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import { SocialNotificationsList } from './components/notifications-list';
+import type { ChipFilter } from './components/notifications-list/filter';
+import type { SocialNotification } from './components/notifications-list/notification-item';
+import type { InfiniteData, UseInfiniteQueryResult } from '@tanstack/react-query';
+import type { AppState } from 'calypso/types';
+import type { UnknownAction } from 'redux';
+import type { ThunkDispatch } from 'redux-thunk';
+
+export type SocialNotificationsSource = 'atmosphere' | 'mastodon' | 'fediverse';
+
+interface NotificationsPageShape< TItem > {
+	items: TItem[];
+	next_cursor: string | null;
+	seen_at: string | null;
+}
+
+export type UseSocialNotificationsInfiniteQuery< TItem extends SocialNotification > = (
+	connectionId: number,
+	options: { filter: ChipFilter }
+) => UseInfiniteQueryResult< InfiniteData< NotificationsPageShape< TItem > >, unknown >;
+
+interface Props< TItem extends SocialNotification > {
+	connectionId: number;
+	source: SocialNotificationsSource;
+	useNotificationsInfiniteQuery: UseSocialNotificationsInfiniteQuery< TItem >;
+}
+
+/**
+ * Shared notifications-tab body for all Reader social protocols. Owns the
+ * filter chip state, the infinite-query flatMap, and the per-protocol Tracks
+ * dispatches; takes the protocol-specific infinite-query hook as a prop so
+ * the per-protocol wrappers can shrink to ~4 lines and stay byte-symmetric
+ * by construction. `source` interpolates into the Tracks event names; the
+ * wpcom backend ships a byte-compatible envelope across protocols so the
+ * shared `<SocialNotificationsList>` renders any of them without branching.
+ */
+export function SocialNotificationsPanel< TItem extends SocialNotification >( {
+	connectionId,
+	source,
+	useNotificationsInfiniteQuery,
+}: Props< TItem > ) {
+	const [ filter, setFilter ] = useState< ChipFilter >( 'all' );
+	const dispatch = useDispatch< ThunkDispatch< AppState, void, UnknownAction > >();
+	const { data, isPending, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
+		useNotificationsInfiniteQuery( connectionId, { filter } );
+
+	const items = useMemo< SocialNotification[] >(
+		() => data?.pages.flatMap( ( p ) => p.items ) ?? [],
+		[ data ]
+	);
+
+	return (
+		<SocialNotificationsList
+			items={ items }
+			isLoading={ isPending }
+			isLoadingMore={ isFetchingNextPage }
+			isError={ isError }
+			hasMore={ !! hasNextPage }
+			onLoadMore={ () => {
+				fetchNextPage();
+			} }
+			filter={ filter }
+			onFilterChange={ ( next ) => {
+				setFilter( next );
+				dispatch(
+					recordReaderTracksEvent( `calypso_reader_${ source }_notifications_filter_changed`, {
+						connection_id: connectionId,
+						filter: next,
+					} )
+				);
+			} }
+			onStackExpandedChange={ ( expanded, member_count ) => {
+				dispatch(
+					recordReaderTracksEvent(
+						expanded
+							? `calypso_reader_${ source }_notifications_stack_expanded`
+							: `calypso_reader_${ source }_notifications_stack_collapsed`,
+						{
+							connection_id: connectionId,
+							member_count,
+							canonical_type: 'follow',
+						}
+					)
+				);
+			} }
+		/>
+	);
+}

--- a/client/reader/social/test/social-notifications-panel.test.tsx
+++ b/client/reader/social/test/social-notifications-panel.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { SocialNotificationsPanel } from '../social-notifications-panel';
+import type {
+	SocialNotificationsSource,
+	UseSocialNotificationsInfiniteQuery,
+} from '../social-notifications-panel';
+
+// `recordReaderTracksEvent` is mocked so the test asserts on its call site
+// without dispatching against state.reader.follows. The shared panel owns
+// the per-`source` event-name interpolation; the test exists to pin that
+// contract — a future rename would surface here rather than only on the
+// per-protocol smoke tests.
+const mockRecordReaderTracksEvent = jest.fn<
+	{ type: string },
+	[ string, Record< string, unknown >? ]
+>( () => ( { type: '@@TEST/NOOP' } ) );
+jest.mock( 'calypso/state/reader/analytics/actions', () => ( {
+	recordReaderTracksEvent: ( event: string, props?: Record< string, unknown > ) =>
+		mockRecordReaderTracksEvent( event, props ),
+} ) );
+
+function makeStubHook(): UseSocialNotificationsInfiniteQuery< never > {
+	// A minimal stand-in for `useXxxNotificationsInfiniteQuery`. The shared
+	// panel only reads the listed fields, so a hand-built stub is enough to
+	// drive the contract test without booting React Query and nock. Cast
+	// shape conformance at the boundary — the stub is intentionally narrower
+	// than the full `UseInfiniteQueryResult`.
+	return () =>
+		( {
+			data: { pages: [ { items: [], next_cursor: null, seen_at: null } ], pageParams: [] },
+			isPending: false,
+			isError: false,
+			fetchNextPage: () => undefined,
+			hasNextPage: false,
+			isFetchingNextPage: false,
+		} ) as unknown as ReturnType< UseSocialNotificationsInfiniteQuery< never > >;
+}
+
+describe.each< [ SocialNotificationsSource ] >( [
+	[ 'atmosphere' ],
+	[ 'mastodon' ],
+	[ 'fediverse' ],
+] )( 'SocialNotificationsPanel — source="%s"', ( source ) => {
+	beforeEach( () => mockRecordReaderTracksEvent.mockClear() );
+
+	it( 'invokes the provided hook with the connection id + filter', () => {
+		const useNotificationsInfiniteQuery = jest.fn( makeStubHook() );
+		renderWithProvider(
+			<SocialNotificationsPanel
+				connectionId={ 42 }
+				source={ source }
+				useNotificationsInfiniteQuery={ useNotificationsInfiniteQuery }
+			/>
+		);
+		expect( useNotificationsInfiniteQuery ).toHaveBeenCalledWith( 42, { filter: 'all' } );
+	} );
+
+	it( 'fires calypso_reader_<source>_notifications_filter_changed on chip click', async () => {
+		const user = userEvent.setup();
+		renderWithProvider(
+			<SocialNotificationsPanel
+				connectionId={ 42 }
+				source={ source }
+				useNotificationsInfiniteQuery={ makeStubHook() }
+			/>
+		);
+
+		await user.click( screen.getByRole( 'radio', { name: /^likes$/i } ) );
+
+		await waitFor( () =>
+			expect( mockRecordReaderTracksEvent ).toHaveBeenCalledWith(
+				`calypso_reader_${ source }_notifications_filter_changed`,
+				{ connection_id: 42, filter: 'likes' }
+			)
+		);
+	} );
+
+	it( 're-invokes the hook with the new filter when the chip changes', async () => {
+		const useNotificationsInfiniteQuery = jest.fn( makeStubHook() );
+		const user = userEvent.setup();
+		renderWithProvider(
+			<SocialNotificationsPanel
+				connectionId={ 42 }
+				source={ source }
+				useNotificationsInfiniteQuery={ useNotificationsInfiniteQuery }
+			/>
+		);
+
+		await user.click( screen.getByRole( 'radio', { name: /^likes$/i } ) );
+
+		await waitFor( () =>
+			expect( useNotificationsInfiniteQuery ).toHaveBeenCalledWith( 42, { filter: 'likes' } )
+		);
+	} );
+} );

--- a/packages/api-core/src/reader-fediverse/__tests__/fetchers.test.ts
+++ b/packages/api-core/src/reader-fediverse/__tests__/fetchers.test.ts
@@ -1,6 +1,7 @@
 import nock from 'nock';
 import { wpcom } from '../../wpcom-fetcher';
-import { createFediversePost } from '../fetchers';
+import { createFediversePost, getFediverseNotifications } from '../fetchers';
+import type { FediverseNotificationsPage } from '../types';
 
 const BASE = 'https://public-api.wordpress.com';
 
@@ -154,5 +155,82 @@ describe( 'createFediversePost', () => {
 		await expect(
 			createFediversePost( { connectionId: 7, content: 'hi', visibility: 'public' } )
 		).rejects.toEqual( { kind: 'rate_limited', retry_after: 30 } );
+	} );
+} );
+
+describe( 'getFediverseNotifications', () => {
+	afterEach( () => nock.cleanAll() );
+
+	it( 'hits the connection-scoped path with cursor + limit', async () => {
+		const page: FediverseNotificationsPage = {
+			items: [
+				{
+					id: '13371337',
+					protocol_type: 'Like',
+					canonical_type: 'like',
+					actor: {
+						handle: 'jane@example.com',
+						display_name: 'Jane',
+						avatar_url: null,
+						profile_uri: 'https://example.com/users/jane',
+					},
+					target: {
+						kind: 'post',
+						uri: 'https://example.com/users/me/statuses/110000000000000001',
+						excerpt: '',
+					},
+					target_url: 'https://example.com/users/me/statuses/110000000000000001',
+					created_at: '2026-05-11T12:34:56Z',
+					is_read: false,
+				},
+			],
+			next_cursor: 'next',
+			seen_at: '2026-05-10T00:00:00Z',
+		};
+		nock( BASE )
+			.get( '/wpcom/v2/reader/fediverse/connections/101/notifications' )
+			.query( { cursor: 'abc', limit: '30' } )
+			.reply( 200, page );
+
+		const res = await getFediverseNotifications( {
+			connectionId: 101,
+			cursor: 'abc',
+			limit: 30,
+		} );
+		expect( res ).toEqual( page );
+	} );
+
+	it( 'omits cursor + limit when not provided', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/fediverse/connections/101/notifications' )
+			.query( {} )
+			.reply( 200, { items: [], next_cursor: null, seen_at: null } );
+
+		const res = await getFediverseNotifications( { connectionId: 101 } );
+		expect( res.items ).toEqual( [] );
+		expect( res.next_cursor ).toBeNull();
+	} );
+
+	it( 'forwards types when provided', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/fediverse/connections/101/notifications' )
+			.query( { types: 'like,repost' } )
+			.reply( 200, { items: [], next_cursor: null, seen_at: null } );
+
+		const res = await getFediverseNotifications( {
+			connectionId: 101,
+			types: 'like,repost',
+		} );
+		expect( res.items ).toEqual( [] );
+	} );
+
+	it( 'classifies wpcom 401 as auth_required', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/fediverse/connections/101/notifications' )
+			.query( {} )
+			.reply( 401, { code: 'reader_fediverse_auth_required' } );
+		await expect( getFediverseNotifications( { connectionId: 101 } ) ).rejects.toMatchObject( {
+			kind: 'auth_required',
+		} );
 	} );
 } );

--- a/packages/api-core/src/reader-fediverse/fetchers.ts
+++ b/packages/api-core/src/reader-fediverse/fetchers.ts
@@ -12,6 +12,7 @@ import type {
 	FediverseCreatePostResult,
 	FediverseDeleteFollowParams,
 	FediverseFollowResponse,
+	FediverseNotificationsPage,
 	FediverseTimelinePage,
 } from './types';
 
@@ -82,6 +83,47 @@ export async function getFediverseTimeline(
 			},
 			query
 		) ) as FediverseTimelinePage;
+	} catch ( raw ) {
+		throw classifyFediverseError( raw );
+	}
+}
+
+export interface GetFediverseNotificationsParams {
+	connectionId: number;
+	cursor?: string;
+	limit?: number;
+	types?: string;
+}
+
+/**
+ * Fetches the home notifications for a Fediverse connection. Cursor-paginated
+ * — pass the previous page's `next_cursor` in subsequent calls. The optional
+ * `types` filter is the wire-comma-joined list (`like,repost,…`) produced by
+ * the shared `mapNotificationsFilter` helper. Mirrors
+ * `getMastodonNotifications`.
+ */
+export async function getFediverseNotifications(
+	params: GetFediverseNotificationsParams
+): Promise< FediverseNotificationsPage > {
+	const { connectionId, cursor, limit, types } = params;
+	const query: Record< string, string > = {};
+	if ( cursor ) {
+		query.cursor = cursor;
+	}
+	if ( limit ) {
+		query.limit = String( limit );
+	}
+	if ( types ) {
+		query.types = types;
+	}
+	try {
+		return ( await wpcom.req.get(
+			{
+				path: `/reader/fediverse/connections/${ connectionId }/notifications`,
+				apiNamespace: NAMESPACE,
+			},
+			query
+		) ) as FediverseNotificationsPage;
 	} catch ( raw ) {
 		throw classifyFediverseError( raw );
 	}

--- a/packages/api-core/src/reader-fediverse/query-keys.ts
+++ b/packages/api-core/src/reader-fediverse/query-keys.ts
@@ -1,9 +1,13 @@
+import type { NotificationsFilter } from '../reader-social/notifications-filter';
+
 export const readerFediverseKeys = {
 	all: [ 'reader', 'fediverse' ] as const,
 	connections: () => [ ...readerFediverseKeys.all, 'connections' ] as const,
 	connection: ( id: number | null ) => [ ...readerFediverseKeys.all, 'connection', id ] as const,
 	timeline: ( connectionId: number ) =>
 		[ ...readerFediverseKeys.all, 'timeline', connectionId ] as const,
+	notifications: ( connectionId: number, filter: NotificationsFilter ) =>
+		[ ...readerFediverseKeys.all, 'notifications', connectionId, filter ] as const,
 	authorProfile: ( connectionId: number, actor: string ) =>
 		[ ...readerFediverseKeys.all, 'profile', connectionId, actor ] as const,
 	authorFeed: ( connectionId: number, actor: string ) =>

--- a/packages/api-core/src/reader-fediverse/types.ts
+++ b/packages/api-core/src/reader-fediverse/types.ts
@@ -358,3 +358,79 @@ export interface FediverseCreatePostParams {
 export interface FediverseCreatePostResult {
 	post: FediverseFeedItem;
 }
+
+/**
+ * Normalized cross-protocol notification kind. Identical to
+ * `AtmosphereNotificationCanonicalType` / `MastodonNotificationCanonicalType`
+ * by design — the wpcom backend commits to a byte-compatible envelope across
+ * protocols so the shared frontend renderer doesn't have to branch on
+ * `source`. `'other'` is the forward-compat bucket for upstream AP activity
+ * kinds we don't yet render with bespoke templates. The shared renderer
+ * falls through to a generic phrase that humanizes `protocol_type` for the
+ * label.
+ */
+export type FediverseNotificationCanonicalType =
+	| 'like'
+	| 'repost'
+	| 'follow'
+	| 'mention'
+	| 'reply'
+	| 'quote'
+	| 'other';
+
+export interface FediverseNotificationActor {
+	handle: string;
+	display_name: string | null;
+	avatar_url: string | null;
+	profile_uri: string;
+}
+
+export interface FediverseNotificationTarget {
+	kind: 'post' | 'profile';
+	uri: string;
+	excerpt: string;
+}
+
+/**
+ * Envelope shape returned by
+ * `/wpcom/v2/reader/fediverse/connections/:id/notifications`. Byte-compatible
+ * with `AtmosphereNotification` and `MastodonNotification` — the wpcom backend
+ * normalizes all three protocols to the same shape so the shared frontend
+ * renderer takes any of them.
+ *
+ * `protocol_type` is the raw upstream AP activity kind (verbatim, lossless:
+ * `Like`, `Announce`, `Follow`, `Create`, …); `canonical_type` is the
+ * normalized enum. There is no `raw` passthrough — `protocol_type` is the
+ * long-tail escape hatch for upstream kinds we don't yet render with
+ * bespoke templates. `target.excerpt` is `''` for `like`/`repost` (the
+ * subject post text isn't fetched for these — only mention/reply/quote
+ * shapes populate it). `target_url` is best-effort: the post URL when
+ * buildable, otherwise the actor profile URL, otherwise the empty string
+ * (the frontend skips linkification when empty). `created_at` is normalized
+ * to `YYYY-MM-DDTHH:MM:SSZ` (UTC, no fractional seconds) and is nullable
+ * when the upstream timestamp is missing or unparseable. `is_read` is
+ * server-computed against the user's `last_read_id` watermark.
+ */
+export interface FediverseNotification {
+	id: string;
+	/** Raw upstream type string, e.g. AP activity kind (`Like`, `Announce`, …). */
+	protocol_type: string;
+	canonical_type: FediverseNotificationCanonicalType;
+	actor: FediverseNotificationActor;
+	target: FediverseNotificationTarget | null;
+	target_url: string;
+	created_at: string | null;
+	is_read: boolean;
+}
+
+/**
+ * Single page from the cursor-paginated notifications endpoint.
+ * `next_cursor: null` means end-of-list. `seen_at` is the server's watermark
+ * timestamp, exposed at the page level (not per-item) so subsequent "Load
+ * more" pages can classify items without re-fetching.
+ */
+export interface FediverseNotificationsPage {
+	items: FediverseNotification[];
+	next_cursor: string | null;
+	seen_at: string | null;
+}

--- a/packages/api-queries/src/__tests__/reader-fediverse.test.tsx
+++ b/packages/api-queries/src/__tests__/reader-fediverse.test.tsx
@@ -25,6 +25,7 @@ import {
 	followFediverseActorMutation,
 	normalizeFediverseActor,
 	unfollowFediverseActorMutation,
+	useFediverseNotificationsInfiniteQuery,
 } from '../reader-fediverse';
 
 const BASE = 'https://public-api.wordpress.com';
@@ -604,5 +605,148 @@ describe( 'createFediversePostMutation', () => {
 		await act( async () => {
 			await Promise.all( [ firstSubmit, secondSubmit ] );
 		} );
+	} );
+} );
+
+describe( 'useFediverseNotificationsInfiniteQuery', () => {
+	const PATH = '/wpcom/v2/reader/fediverse/connections/42/notifications';
+
+	function createWrapper() {
+		const client = new QueryClient( {
+			defaultOptions: { queries: { retry: false } },
+		} );
+		return makeWrapper( client );
+	}
+
+	// Touch tracked properties inside the render callback so React Query's
+	// `notifyOnChangeProps: 'tracked'` observer fires on later updates.
+	// Without this, `fetchNextPage()` resolves but the rendered `data` /
+	// `hasNextPage` lag, producing flaky pagination assertions. Mirrors
+	// the mastodon notifications-query helper.
+	const renderNotificationsHook = (
+		connectionId: number,
+		wrapper: ReturnType< typeof createWrapper >
+	) =>
+		renderHook(
+			() => {
+				const q = useFediverseNotificationsInfiniteQuery( connectionId );
+				void q.data;
+				void q.hasNextPage;
+				void q.isFetchingNextPage;
+				void q.isError;
+				void q.error;
+				return q;
+			},
+			{ wrapper }
+		);
+
+	afterEach( () => nock.cleanAll() );
+
+	it( 'is disabled when connectionId is 0', () => {
+		const { result } = renderNotificationsHook( 0, createWrapper() );
+		expect( result.current.fetchStatus ).toBe( 'idle' );
+		expect( result.current.data ).toBeUndefined();
+	} );
+
+	it( 'fetches the first page on mount', async () => {
+		nock( BASE ).get( PATH ).query( {} ).reply( 200, {
+			items: [],
+			next_cursor: null,
+			seen_at: null,
+		} );
+		const { result } = renderNotificationsHook( 42, createWrapper() );
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+		expect( result.current.data?.pages[ 0 ].items ).toEqual( [] );
+	} );
+
+	it( 'paginates via next_cursor returned by the previous page', async () => {
+		nock( BASE ).get( PATH ).query( {} ).reply( 200, {
+			items: [],
+			next_cursor: 'page-2',
+			seen_at: null,
+		} );
+		nock( BASE )
+			.get( PATH )
+			.query( { cursor: 'page-2' } )
+			.reply( 200, { items: [], next_cursor: null, seen_at: null } );
+
+		const { result } = renderNotificationsHook( 42, createWrapper() );
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+		expect( result.current.hasNextPage ).toBe( true );
+
+		await act( async () => {
+			await result.current.fetchNextPage();
+		} );
+		expect( result.current.data?.pages.length ).toBe( 2 );
+		expect( result.current.hasNextPage ).toBe( false );
+	} );
+
+	it( 'does not retry terminal errors', async () => {
+		// Mirror the timeline test policy: auth_required is terminal — no
+		// extra requests beyond the first. nock would throw if a retry
+		// happened (only one interceptor registered).
+		nock( BASE ).get( PATH ).query( {} ).reply( 401, {
+			code: 'reader_fediverse_auth_required',
+		} );
+		const { result } = renderNotificationsHook( 42, createWrapper() );
+		await waitFor( () => expect( result.current.isError ).toBe( true ) );
+		expect( ( result.current.error as { kind: string } ).kind ).toBe( 'auth_required' );
+	} );
+} );
+
+describe( 'useFediverseNotificationsInfiniteQuery — filter', () => {
+	let wrapper: ReturnType< typeof makeWrapper >;
+
+	beforeEach( () => {
+		const client = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+		wrapper = makeWrapper( client );
+	} );
+
+	afterEach( () => nock.cleanAll() );
+
+	it( 'forwards filter as types= query param', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/fediverse/connections/101/notifications' )
+			.query( { types: 'like' } )
+			.reply( 200, { items: [], next_cursor: null, seen_at: null } );
+
+		const { result } = renderHook(
+			() => useFediverseNotificationsInfiniteQuery( 101, { filter: 'likes' } ),
+			{ wrapper }
+		);
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+	} );
+
+	it( 'omits types= when filter is "all"', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/fediverse/connections/101/notifications' )
+			.query( {} )
+			.reply( 200, { items: [], next_cursor: null, seen_at: null } );
+
+		const { result } = renderHook(
+			() => useFediverseNotificationsInfiniteQuery( 101, { filter: 'all' } ),
+			{ wrapper }
+		);
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+	} );
+
+	it( 'each filter caches under its own query key', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/fediverse/connections/101/notifications' )
+			.query( {} )
+			.reply( 200, { items: [], next_cursor: null, seen_at: null } )
+			.get( '/wpcom/v2/reader/fediverse/connections/101/notifications' )
+			.query( { types: 'like' } )
+			.reply( 200, { items: [], next_cursor: null, seen_at: null } );
+
+		const { result, rerender } = renderHook(
+			( { filter }: { filter: 'all' | 'likes' } ) =>
+				useFediverseNotificationsInfiniteQuery( 101, { filter } ),
+			{ wrapper, initialProps: { filter: 'all' as const } }
+		);
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+		rerender( { filter: 'likes' as const } );
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+		expect( nock.isDone() ).toBe( true );
 	} );
 } );

--- a/packages/api-queries/src/reader-fediverse.ts
+++ b/packages/api-queries/src/reader-fediverse.ts
@@ -8,7 +8,9 @@ import {
 	getFediverseAuthorProfile,
 	getFediverseConnection,
 	getFediverseConnections,
+	getFediverseNotifications,
 	getFediverseTimeline,
+	mapNotificationsFilter,
 	PENDING_FEDIVERSE_POST_URI,
 	readerFediverseKeys,
 } from '@automattic/api-core';
@@ -33,9 +35,11 @@ import type {
 	FediverseError,
 	FediverseFeedItem,
 	FediverseFollowResponse,
+	FediverseNotificationsPage,
 	FediverseTimelinePage,
 	GetFediverseAuthorFeedParams,
 	GetFediverseTimelineParams,
+	NotificationsFilter,
 } from '@automattic/api-core';
 
 export const fediverseConnectionsQueryOptions = () =>
@@ -118,6 +122,58 @@ export const fediverseTimelineInfiniteQuery = ( connectionId: number ) =>
 
 export function useFediverseTimelineInfiniteQuery( connectionId: number ) {
 	return useInfiniteQuery( fediverseTimelineInfiniteQuery( connectionId ) );
+}
+
+export interface UseFediverseNotificationsOptions {
+	filter?: NotificationsFilter;
+}
+
+export const fediverseNotificationsInfiniteQuery = (
+	connectionId: number,
+	filter: NotificationsFilter = 'all'
+) =>
+	infiniteQueryOptions<
+		FediverseNotificationsPage,
+		FediverseError,
+		InfiniteData< FediverseNotificationsPage >,
+		QueryKey,
+		string | undefined
+	>( {
+		queryKey: readerFediverseKeys.notifications( connectionId, filter ),
+		queryFn: ( { pageParam } ) =>
+			getFediverseNotifications( {
+				connectionId,
+				cursor: pageParam,
+				types: mapNotificationsFilter( filter ),
+			} ),
+		initialPageParam: undefined,
+		getNextPageParam: ( lastPage ) => lastPage.next_cursor ?? undefined,
+		enabled: connectionId > 0,
+		staleTime: 30_000,
+		gcTime: 5 * 60_000,
+		// Same retry posture as the Fediverse timeline / author-profile queries:
+		// terminal errors fail fast; transient errors (rate_limited,
+		// upstream_unavailable) retry once with retry_after-aware backoff.
+		retry: ( failureCount, error ) => {
+			if ( error.kind === 'rate_limited' || error.kind === 'upstream_unavailable' ) {
+				return failureCount < 2;
+			}
+			return false;
+		},
+		retryDelay: ( _attempt, error ) => {
+			if ( error.kind === 'rate_limited' && error.retry_after !== undefined ) {
+				return Math.min( error.retry_after * 1000, 30_000 );
+			}
+			return 2_000;
+		},
+	} );
+
+export function useFediverseNotificationsInfiniteQuery(
+	connectionId: number,
+	options: UseFediverseNotificationsOptions = {}
+) {
+	const { filter = 'all' } = options;
+	return useInfiniteQuery( fediverseNotificationsInfiniteQuery( connectionId, filter ) );
 }
 
 // Normalise an actor string for cache keying.


### PR DESCRIPTION
Part of CM-744

## Proposed Changes

Adds a **Notifications tab** to the Reader Fediverse pane, mirroring the existing ATmosphere (CM-705) and Mastodon (CM-709) Notifications tabs. Tab sits in the second position (Timeline / **Notifications** / Profile) to match the other two protocols.

- **api-core** (`packages/api-core/src/reader-fediverse/`): adds `FediverseNotification*` types, `getFediverseNotifications` fetcher, and `notifications()` query-key.
- **api-queries** (`packages/api-queries/src/reader-fediverse.ts`): adds `fediverseNotificationsInfiniteQuery` + `useFediverseNotificationsInfiniteQuery` with the same retry / staleTime policy as the existing Fediverse timeline query; filter `types=` via the shared `mapNotificationsFilter`.
- **Shared `<SocialNotificationsPanel>`**: new component parameterised by `source` + `connectionId` + `useNotificationsInfiniteQuery`. ATmosphere and Mastodon `notifications-panel.tsx` files shrink to 4-line wrappers; the new Fediverse wrapper follows the same shape. The previous AGENTS.md "byte-for-byte symmetric panels" contract is now true by construction.
- **Type union widen**: `SocialNotification` and `SocialNotificationCanonicalType` widened to include the Fediverse variants at every union site (`notification-item.tsx`, list `index.tsx`, `group-notifications.ts`). The `_exhaustive: never` arms stay — the discriminated union flattens to the same string union, so no switch-arm edits are needed.
- **Wiring** (`client/reader/fediverse/`): `NOTIFICATIONS_TAB` constant; navigation gets the third tab entry; `fediverse-account-view.tsx` mounts the panel when `tab === NOTIFICATIONS_TAB` and adds it to `VALID_TABS`.

## Two latent bugs surfaced while testing in the browser

Both fixed in the shared list:

1. **Duplicate React keys for date dividers.** Divider key was `divider-${bucket}` and collided when wire items weren't strictly monotonic across buckets. Now `divider-${bucket}-${index}`. Regression test added.
2. **All follow notifications collapsing into one mega-stack.** `keyFor` used the literal string `'follow'` for every follow row, regardless of date. Now `` `follow:${bucketFor(created_at, now)}` `` so each of `today` / `yesterday` / `this_week` / `earlier` renders as its own follow stack, sitting under the matching date divider. The renderer shares a single `now` between grouping and divider computation so stack and divider always agree. `client/reader/social/AGENTS.md` updated; new test pins the behavior.

## Why are these changes being made?

CM-744 is the third slice of the Reader social protocols' Notifications work — backend is already byte-compatible across protocols, so the only remaining work is wiring + a thin per-protocol fetcher + query. Extracting the shared panel as part of the same PR keeps the three protocols genuinely symmetric instead of growing a third near-byte-clone.

## Backend dependency

The wpcom Fediverse adapter does not currently populate `created_at` for AP `Follow` activities (and at least some `Announce` activities). Until the backend lands `published`-field extraction, undated follow rows all bucket to `'earlier'` and collapse into one stack under a suppressed single-bucket divider. This is a separate backend ticket — frontend behavior is correct given the wire shape.

## Out of scope (per CM-744)

- Filter chips beyond the existing `types=` union (CM-713 / CM-714 follow-ups).
- "Mark all as read" write action.
- Tab-bar unread badge.
- Background polling.
- Inline Reader navigation when a notification is clicked.

## Testing Instructions

1. `yarn test-client client/reader` — full Reader suite passes locally (182 suites / 1,768 tests).
2. `yarn test-packages packages/api-core/src/reader-fediverse/__tests__/fetchers.test.ts` — 4 new `getFediverseNotifications` cases.
3. `yarn test-packages packages/api-queries/src/__tests__/reader-fediverse.test.tsx` — 7 new `useFediverseNotificationsInfiniteQuery` cases (pagination, retry, filter re-keying).
4. `yarn test-client client/reader/social/test/social-notifications-panel.test.tsx` — 9 contract tests (`it.each` across `atmosphere | mastodon | fediverse`).
5. `yarn test-client client/reader/fediverse/test/notifications-panel.test.tsx` — 5 wire-to-render tests against Fediverse-shaped fixtures.

Visual smoke (dev server):

1. `yarn start`, navigate to `/reader/fediverse/<connectionId>/notifications`.
2. Confirm the Notifications tab is the second tab, Tracks events fire under `calypso_reader_fediverse_notifications_*`.
3. Verify the same surface on `/reader/mastodon/<id>/notifications` and `/reader/atmosphere/<id>/notifications` still works (the shrunk wrappers must keep their existing behavior).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
