### PR TITLE
Reader connections: polish empty CTA, Fediverse copy, sidebar hint

### DIFF
--- a/client/reader/connections/connections-new-view.tsx
+++ b/client/reader/connections/connections-new-view.tsx
@@ -100,7 +100,7 @@ export function ConnectionsNewView() {
 				tagline: String( translate( 'Your WordPress site is already social.' ) ),
 				body: String(
 					translate(
-						'Flip the ActivityPub switch on your blog and it shows up here. No new account — your site already does the talking.'
+						'Flip the ActivityPub switch in your site’s settings, and your blog slots in next to everything else you read here.'
 					)
 				),
 				href: adminUrl ? `${ adminUrl }options-general.php?page=activitypub` : null,

--- a/client/reader/connections/social-overview-view.tsx
+++ b/client/reader/connections/social-overview-view.tsx
@@ -6,7 +6,7 @@ import {
 	useMastodonConnectionsQuery,
 } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
-import { Card, Spinner } from '@wordpress/components';
+import { Button, Card, Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -240,9 +240,9 @@ export function SocialOverviewView() {
 							'You haven’t connected any social accounts yet. Start with the network you already know best, or let your WordPress site do the work for you.'
 						) }
 					</p>
-					<a className="social-empty__cta" href="/reader/connections/new">
+					<Button variant="primary" href="/reader/connections/new">
 						{ translate( 'Pick a network →' ) }
-					</a>
+					</Button>
 				</Card>
 			) }
 

--- a/client/reader/connections/style.scss
+++ b/client/reader/connections/style.scss
@@ -523,16 +523,3 @@
 	color: var( --color-text-subtle );
 }
 
-.social-empty__cta {
-	display: inline-block;
-	padding: 8px 16px;
-	background-color: var( --color-primary );
-	color: var( --color-surface );
-	border-radius: 4px;
-	text-decoration: none;
-	font-weight: 500;
-
-	&:hover {
-		background-color: var( --color-primary-dark );
-	}
-}

--- a/client/reader/sidebar/reader-sidebar-connections/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-connections/index.tsx
@@ -236,7 +236,7 @@ function ReaderSidebarConnections( { path }: Props ) {
 					/>
 				) ) }
 				{ showEmptyHint && (
-					<li className="sidebar-connections__empty" aria-live="polite">
+					<li className="screen-reader-text" aria-live="polite">
 						{ translate( 'Nothing here yet — connect one below.' ) }
 					</li>
 				) }

--- a/client/reader/sidebar/reader-sidebar-connections/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-connections/index.tsx
@@ -236,7 +236,7 @@ function ReaderSidebarConnections( { path }: Props ) {
 					/>
 				) ) }
 				{ showEmptyHint && (
-					<li className="screen-reader-text" aria-live="polite">
+					<li className="screen-reader-text">
 						{ translate( 'Nothing here yet — connect one below.' ) }
 					</li>
 				) }


### PR DESCRIPTION
Fixes CM-749

## Proposed Changes

* `/reader/connections` empty state — swap the custom "Pick a network" anchor for `<Button variant="primary">` from `@wordpress/components`. Removes the unused `.social-empty__cta` SCSS block.
* `/reader/connections/new` Fediverse card (1-admin-site branch) — reword the body to match the concrete tone of the Bluesky / Mastodon cards.
* Reader sidebar — hide the "Nothing here yet — connect one below." empty hint visually (via `screen-reader-text`) while keeping the `aria-live` announcement for screen readers. The error hint remains visible.

## Why are these changes being made?

* The empty-state CTA was rendering blue text on a blue background because a parent link color rule was winning over `.social-empty__cta`. The design system's `Button` enforces correct contrast.
* The original Fediverse copy ("…No new account — your site already does the talking.") leaned AI in tone and used an em-dash that didn't match the other two cards.
* The sidebar hint is redundant when the "Add account" item sits right below it; screen-reader users still benefit from the live announcement.

## Testing Instructions

1. Sign in with an account that has **no** social connections, visit `/reader/connections`, confirm the "Pick a network" CTA is a primary `Button` (white text on the WordPress blue, with proper hover state).
2. Sign in with an account that has **one** WordPress admin site (and no Fediverse connection yet), visit `/reader/connections/new`, and confirm the Fediverse card body reads: "Flip the ActivityPub switch in your site's settings, and your blog slots in next to everything else you read here."
3. With **no** social connections, expand the "Social" menu in the Reader sidebar — confirm the "Nothing here yet" line is no longer visible, but a screen reader still announces it when the queries settle. The "Add account" item is the only visible affordance.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?