### PR TITLE
A4A: restore Menu popover visibility (@wordpress/components 33.x workaround)

### DIFF
--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -692,3 +692,32 @@ html {
 .is-opacity-50 {
 	opacity: 0.5;
 }
+
+/* @wordpress/components Menu workaround for v33.x regression -------------------------- */
+/*
+ * In @wordpress/components 33.0.0, Menu.Popover was refactored to split the
+ * popover into MenuMotionRoot (carries the transition) + MenuSurface (receives
+ * Ariakit's data-enter/data-leave). Ariakit auto-detects animation by reading
+ * transition-duration on the element it manages — MenuSurface — but the
+ * refactor left that element without any transition. As a result Ariakit
+ * never sets data-enter, MenuMotionRoot's `:has(> [data-enter])` rule never
+ * matches, and the popover stays stuck at opacity: 0 (visible in DOM, invisible
+ * on screen). Affects every DataViews kebab/actions menu in A4A (sites
+ * dashboard, referral details, report details).
+ *
+ * Adding any transition to MenuSurface restores Ariakit's lifecycle. The
+ * visible motion stays on MenuMotionRoot; this transition isn't visible
+ * because MenuSurface's opacity never changes.
+ *
+ * Scoped to A4A only for now — the same bug affects other Calypso surfaces
+ * (/sites, /plugins/manage/sites, /p2s) but those will be unblocked once
+ * the upstream fix lands. See A4A-2655 and Gutenberg #77460. Remove once
+ * @wordpress/components ships a fix.
+ *
+ * Note: the selector deliberately starts with `.theme-a8c-for-agencies`
+ * (which lives on <body>) so it matches portaled popovers, which Ariakit
+ * appends as siblings of the page content under <body>.
+ */
+.theme-a8c-for-agencies [role="menu"][data-side] {
+	transition: opacity 200ms;
+}


### PR DESCRIPTION
Fixes A4A-2655

## Proposed Changes

* Add a single CSS override in `client/a8c-for-agencies/style.scss`, scoped to `.theme-a8c-for-agencies`, that puts a `transition` on `[role="menu"][data-side]` (i.e. `MenuSurface`) so Ariakit's animation auto-detection succeeds and the popover becomes visible when opened on A4A pages.

## Why are these changes being made?

`@wordpress/components@33.0.0` (shipped to Calypso via #110764) refactored `Menu.Popover` to split the popover into two emotion-styled elements ([Gutenberg #77460](https://github.com/WordPress/gutenberg/pull/77460)):

* `MenuMotionRoot` — outer wrapper that carries the fade/slide transition and gates visibility behind `:has(> MenuSurface[data-enter]) { opacity: 1 }`
* `MenuSurface` — inner element that receives Ariakit's `htmlProps`, including `data-enter` / `data-leave`

Ariakit auto-detects animation by reading `transition-duration` on the element it manages (`MenuSurface`). The refactor left `MenuSurface` without any transition, so the lifecycle never starts, `data-enter` is never set, the `:has()` rule never matches, and the popover stays stuck at `opacity: 0` — visible in the DOM but invisible on screen.

This affects every DataViews kebab/actions menu in A4A: sites dashboard, referral details, and report details. (The same regression affects other Calypso surfaces like `/sites`, `/plugins/manage/sites`, and `/p2s`, but A4A-2655 is the urgent ticket — those will be unblocked when the upstream fix lands and we bump the package.)

Adding a transition on `MenuSurface` restores Ariakit's lifecycle. The visible motion still happens on `MenuMotionRoot`; the override's `transition: opacity` doesn't animate anything visually because `MenuSurface`'s opacity never changes.

The selector starts with `.theme-a8c-for-agencies` (which lives on `<body>`) so it correctly matches the popover even though Ariakit portals it into `<body>` as a sibling of the page content.

This is a workaround, not a permanent fix. The proper fix belongs upstream in `packages/components/src/menu/styles.ts` — a follow-up issue/PR against `WordPress/gutenberg` will be filed. The comment block in the override explicitly marks it for removal once a fixed `@wordpress/components` ships.

## Testing Instructions

Before this change, on `trunk`:

1. Visit `/referrals/dashboard`, click any row's *View details*, switch to the Referrals tab, click the ⋮ — nothing visible appears.
2. Same on the A4A Sites dashboard (Actions column kebab) and `/reports/:id` (report actions kebab).

After this change, each kebab opens a visible popover at the correct position with the standard fade-in.

DevTools sanity check on any open popover:

```js
const surface = document.querySelector('[role="menu"][data-side]');
surface.hasAttribute('data-enter');              // true
getComputedStyle(surface.parentElement).opacity; // "1"
```

Regression spot-check on A4A: confirm other popovers/menus elsewhere in A4A (sidebar, profile dropdown, breadcrumb menus, etc.) still animate as expected.

Non-A4A surfaces (`/sites`, `/plugins/manage/sites`, `/p2s`) deliberately remain in their pre-PR (broken) state under this scoping decision and will be unblocked separately when `@wordpress/components` ships a fix.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes?