### PR TITLE
Fix: Plan features grid spacing (DOTMSD-1222)

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/style.scss
@@ -33,7 +33,7 @@
 		padding: 0;
 	}
 
-	.is-last-feature .plan-features-2023-grid__item {
+	.plan-features-2023-grid__mobile-view .is-last-feature .plan-features-2023-grid__item {
 		padding-bottom: 0;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/style.scss
@@ -37,6 +37,11 @@
 		padding-bottom: 0;
 	}
 
+	.plan-features-2023-grid__desktop-view .plans-grid-next-features-grid__feature-group-row:last-of-type .is-last-feature .plan-features-2023-grid__item,
+	.plan-features-2023-grid__tablet-view .plans-grid-next-features-grid__feature-group-row:last-of-type .is-last-feature .plan-features-2023-grid__item {
+		padding-bottom: 20px;
+	}
+
 	// Style the inline `start with a free plan` CTA inside Step.Heading subText
 	// to look like a link instead of a default borderless button. The legacy
 	// <PlansPageSubheader> applied equivalent styles to the same button via its


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes #DOTMSD-1222

## Proposed Changes

Fixes spacing for the Plan grid features in the plan upgrade flow, which were optimized for mobile on #110297. However, that change introduced a lack of spacing on the feature plan list items for desktop widths.

Fixes spacing for the plan grid features in the stepper unified-plans step (used by `plan-upgrade` and the other onboarding flows). #110297 optimized the layout for mobile, but its last feature `padding-bottom: 0` rule wasn't scoped to the mobile view, so it also collapsed the spacing on desktop/tablet. 

This PR scopes that override to the mobile view only.

## Why are these changes being made?

* This change is made to fix the incorrect spacing for plan features that were optimized for mobile/tablet devices. 
* Right now, the plan features are condensed when upgrading the plan, for example: 

| Before | After |
|--------|--------|
| <img width="2276" height="1844" alt="CleanShot 2026-05-19 at 14 17 04@2x" src="https://github.com/user-attachments/assets/e5a625b7-67f9-4457-939e-02a07aa911e3" /> | <img width="2214" height="1912" alt="CleanShot 2026-05-19 at 14 17 22@2x" src="https://github.com/user-attachments/assets/18352a65-e9b5-4c69-80ad-91c0126ecd93" /> |


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

  1. Start with a site that can be upgraded to a higher plan, like a site with a Free or Premium plan.
  2. Trigger the flow to upgrade the plan, like from the Hosting Dashboard (URL: `/setup/plan-upgrade/plans?siteSlug=<your-test-site>`)
  3. On desktop/mobile widths, confirm the gap between plan features is consistent. On mobile, it should be condensed, and on desktop, with some padding between items.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
