### PR TITLE
Gate themes dark mode behind dashboard opt-in

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -60,12 +60,17 @@ import { ClassicColorSchemeProvider, withColorScheme } from 'calypso/lib/color-s
 import { decodeEntities } from 'calypso/lib/formatting';
 import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 import { ReviewsSummary } from 'calypso/my-sites/marketplace/components/reviews-summary';
-import { localizeThemesPath, shouldSelectSite } from 'calypso/my-sites/themes/helpers';
+import {
+	localizeThemesPath,
+	shouldEnableThemesColorScheme,
+	shouldSelectSite,
+} from 'calypso/my-sites/themes/helpers';
 import { connectOptions } from 'calypso/my-sites/themes/theme-options';
 import ThemePreview from 'calypso/my-sites/themes/theme-preview';
 import { useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import { getProductsList } from 'calypso/state/products-list/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
@@ -169,6 +174,7 @@ class ThemeSheet extends Component {
 		retired: PropTypes.bool,
 		// Connected props
 		isLoggedIn: PropTypes.bool,
+		isThemesColorSchemeEnabled: PropTypes.bool,
 		siteCount: PropTypes.number,
 		isActive: PropTypes.bool,
 		isThemePurchased: PropTypes.bool,
@@ -1430,15 +1436,16 @@ const ThemeSheetWithOptions = ( props ) => {
 		/>,
 		{
 			bodyClass: 'is-themes-dark-mode',
-			enabled: ! props.isSiteRoute && props.isLoggedIn,
+			enabled: props.isThemesColorSchemeEnabled,
 			Provider: ClassicColorSchemeProvider,
 		}
 	);
 };
 
 export default connect(
-	( state, { id } ) => {
+	( state, { id, isSiteRoute } ) => {
 		const themeId = id;
+		const isLoggedIn = isUserLoggedIn( state );
 		const site = getSelectedSite( state );
 		const productionSiteId = site ? getProductionSiteId( site ) : null;
 		const siteId = getSelectedSiteId( state );
@@ -1498,7 +1505,12 @@ export default connect(
 			isWpcomTheme,
 			isWpcomStaging,
 			productionSiteSlug,
-			isLoggedIn: isUserLoggedIn( state ),
+			isLoggedIn,
+			isThemesColorSchemeEnabled: shouldEnableThemesColorScheme( {
+				isSiteRoute,
+				isLoggedIn,
+				dashboardOptIn: hasDashboardOptIn( state ),
+			} ),
 			siteCount: getCurrentUserSiteCount( state ),
 			isActive: isThemeActive( state, themeId, siteId ),
 			isAtomic,

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -211,3 +211,7 @@ export function constructThemeShowcaseUrl( {
 export function shouldSelectSite( { isLoggedIn, siteCount, siteId } ) {
 	return isLoggedIn && ! siteId && siteCount > 1;
 }
+
+export function shouldEnableThemesColorScheme( { isSiteRoute, isLoggedIn, dashboardOptIn } ) {
+	return ! isSiteRoute && isLoggedIn && dashboardOptIn;
+}

--- a/client/my-sites/themes/test/helpers.js
+++ b/client/my-sites/themes/test/helpers.js
@@ -1,4 +1,17 @@
-import { interlaceThemes } from 'calypso/my-sites/themes/helpers';
+import { interlaceThemes, shouldEnableThemesColorScheme } from 'calypso/my-sites/themes/helpers';
+
+jest.mock( 'calypso/lib/analytics/ga', () => ( {
+	gaRecordEvent: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/components/theme-tier/constants', () => ( {
+	THEME_TIERS: {
+		free: {},
+		premium: {},
+		business: {},
+		community: {},
+	},
+} ) );
 
 describe( 'helpers', () => {
 	describe( 'interlaceThemes', () => {
@@ -51,6 +64,48 @@ describe( 'helpers', () => {
 			);
 			expect( interlacedThemes[ 2 ].id ).toEqual( 'wporg-classic-theme' );
 			expect( interlacedThemes[ 3 ].id ).toEqual( 'wporg-block-theme' );
+		} );
+	} );
+
+	describe( 'shouldEnableThemesColorScheme', () => {
+		test( 'enables the themes color scheme for opted-in logged-in users on legacy non-site routes', () => {
+			expect(
+				shouldEnableThemesColorScheme( {
+					isSiteRoute: false,
+					isLoggedIn: true,
+					dashboardOptIn: true,
+				} )
+			).toBe( true );
+		} );
+
+		test( 'does not enable the themes color scheme for users who are not opted into dashboard', () => {
+			expect(
+				shouldEnableThemesColorScheme( {
+					isSiteRoute: false,
+					isLoggedIn: true,
+					dashboardOptIn: false,
+				} )
+			).toBe( false );
+		} );
+
+		test( 'does not enable the themes color scheme for logged-out users', () => {
+			expect(
+				shouldEnableThemesColorScheme( {
+					isSiteRoute: false,
+					isLoggedIn: false,
+					dashboardOptIn: true,
+				} )
+			).toBe( false );
+		} );
+
+		test( 'does not enable the themes color scheme on site routes', () => {
+			expect(
+				shouldEnableThemesColorScheme( {
+					isSiteRoute: true,
+					isLoggedIn: true,
+					dashboardOptIn: true,
+				} )
+			).toBe( false );
 		} );
 	} );
 } );

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -25,6 +25,7 @@ import ShowcaseThemeCollection from 'calypso/my-sites/themes/collections/showcas
 import ThemeCollectionViewHeader from 'calypso/my-sites/themes/collections/theme-collection-view-header';
 import FilterBarModern from 'calypso/my-sites/themes/filter-bar-modern';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors';
 import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
 import getSiteFeaturesById from 'calypso/state/selectors/get-site-features';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
@@ -52,6 +53,7 @@ import {
 	localizeThemesPath,
 	isStaticFilter,
 	constructThemeShowcaseUrl,
+	shouldEnableThemesColorScheme,
 } from './helpers';
 import SearchResultsModern from './search-results-modern';
 import RecommendedSections from './sections-modern/recommended-sections';
@@ -112,6 +114,7 @@ class ThemeShowcase extends Component {
 		isSiteECommerceFreeTrial: PropTypes.bool,
 		isSiteWooExpress: PropTypes.bool,
 		isSiteWooExpressOrEcomFreeTrial: PropTypes.bool,
+		isThemesColorSchemeEnabled: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -877,15 +880,17 @@ class ThemeShowcase extends Component {
 
 		return withColorScheme( showcase, {
 			bodyClass: 'is-themes-dark-mode',
-			enabled: ! this.props.isSiteRoute && isLoggedIn,
+			enabled: this.props.isThemesColorSchemeEnabled,
 			Provider: ClassicColorSchemeProvider,
 		} );
 	}
 }
 
-const mapStateToProps = ( state, { siteId, filter } ) => {
+const mapStateToProps = ( state, { siteId, filter, isSiteRoute } ) => {
+	const isLoggedIn = isUserLoggedIn( state );
+
 	return {
-		isLoggedIn: isUserLoggedIn( state ),
+		isLoggedIn,
 		isAtomicSite: isAtomicSite( state, siteId ),
 		areSiteFeaturesLoaded: !! getSiteFeaturesById( state, siteId ),
 		site: getSite( state, siteId ),
@@ -906,6 +911,11 @@ const mapStateToProps = ( state, { siteId, filter } ) => {
 		isSiteWooExpressOrEcomFreeTrial:
 			isSiteOnECommerceTrial( state, siteId ) || isSiteOnWooExpress( state, siteId ),
 		themeTiers: getThemeTiers( state ),
+		isThemesColorSchemeEnabled: shouldEnableThemesColorScheme( {
+			isSiteRoute,
+			isLoggedIn,
+			dashboardOptIn: hasDashboardOptIn( state ),
+		} ),
 	};
 };
 


### PR DESCRIPTION
## Proposed Changes

* Gate the legacy Themes color scheme behind the Hosting Dashboard opt-in preference, while preserving the existing logged-in and non-site-route checks.
* Reuse the same gating in both the theme showcase and individual theme entry points.
* Add helper coverage for opted-in, opted-out, logged-out, and site-route cases.

## Why are these changes being made?

The Themes experience can apply its dark color scheme on legacy non-site routes. That is correct for users who have opted into the Hosting Dashboard experience, but it leaks into the legacy Themes surface for users who have not opted in. The result is a visual mismatch where the Themes page can inherit dark-mode styling that should not be active for that user state.

This change makes the opt-in preference part of the color-scheme eligibility check. Users who are logged in, on a legacy global Themes route, and opted into the Hosting Dashboard keep the themed color-scheme behavior; users who opt out of the Hosting Dashboard see the legacy Themes page without that dark-mode override.

## Testing Instructions

* Enable dark mode.
* Visit `my.localhost:<port>/me/preferences/hosting-dashboard` and switch off the Hosting Dashboard preference.
* Visit `calypso.localhost:<port>/themes`.
* Confirm the Themes page renders properly and does not show the dark-mode Themes styling when the Hosting Dashboard preference is off.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
