### PR TITLE
[RSM] Reader Chat: avoid lodash global overwrite on P2 sites

### DIFF
--- a/apps/agents-manager/__tests__/disable-lodash-amd-loader.test.js
+++ b/apps/agents-manager/__tests__/disable-lodash-amd-loader.test.js
@@ -1,0 +1,30 @@
+// eslint-disable-next-line import/no-nodejs-modules
+const fs = require( 'fs' );
+const disableLodashAmdLoader = require( '../disable-lodash-amd-loader' );
+
+describe( 'disableLodashAmdLoader', () => {
+	it( 'disables lodash AMD detection', () => {
+		const source =
+			"if (typeof define == 'function' && typeof define.amd == 'object' && define.amd) { root._ = _; }";
+
+		expect( disableLodashAmdLoader( source ) ).toBe( 'if (false) { root._ = _; }' );
+	} );
+
+	it( 'disables AMD detection in the installed lodash source', () => {
+		const lodashSource = fs.readFileSync( require.resolve( 'lodash/lodash.js' ), 'utf8' );
+		const result = disableLodashAmdLoader( lodashSource );
+
+		expect( result ).not.toContain(
+			"typeof define == 'function' && typeof define.amd == 'object' && define.amd"
+		);
+		expect( result ).toContain( 'if (false)' );
+	} );
+
+	it( 'fails loudly when the lodash AMD branch is not found', () => {
+		const source = 'module.exports = lodash;';
+
+		expect( () => disableLodashAmdLoader( source ) ).toThrow(
+			'Expected to disable lodash AMD detection'
+		);
+	} );
+} );

--- a/apps/agents-manager/disable-lodash-amd-loader.js
+++ b/apps/agents-manager/disable-lodash-amd-loader.js
@@ -1,0 +1,14 @@
+const lodashAmdCondition =
+	"typeof define == 'function' && typeof define.amd == 'object' && define.amd";
+
+module.exports = function disableLodashAmdLoader( source ) {
+	const result = source.replace( lodashAmdCondition, 'false' );
+
+	if ( result === source ) {
+		throw new Error(
+			'Expected to disable lodash AMD detection, but no matching branch was found.'
+		);
+	}
+
+	return result;
+};

--- a/apps/agents-manager/webpack.config.js
+++ b/apps/agents-manager/webpack.config.js
@@ -123,7 +123,14 @@ function getReaderConfig( options = {} ) {
 		},
 		module: {
 			...webpackConfig.module,
-			rules: [ ...( webpackConfig.module?.rules || [] ) ],
+			rules: [
+				...( webpackConfig.module?.rules || [] ),
+				{
+					// P2/O2 expects window._ to remain Underscore.
+					resource: require.resolve( 'lodash/lodash.js' ),
+					use: path.join( __dirname, 'disable-lodash-amd-loader.js' ),
+				},
+			],
 		},
 		resolve: {
 			...webpackConfig.resolve,


### PR DESCRIPTION
Part of #

## Proposed Changes

* Prevent the self-contained Reader Chat bundle from letting bundled lodash detect host-page AMD loaders.
* Add a small webpack loader scoped to `lodash/lodash.js` and wire it only into the Reader Chat webpack config.
* Add unit coverage for the loader rewrite.

## Why are these changes being made?

* P2/O2 frontends expose AMD and expect global `_` to remain Underscore. Lodash's UMD export path can otherwise overwrite `window._`, which breaks O2 calls such as `_.where()` after Reader Chat loads.

## Testing Instructions
* Install this PR on your sandbox and make sure to tunnel fornop2 requests to your sandbox
```
install-plugin.sh am fix/reader-chat-p2-globals
```
* Enable Reader Chat in fornop2 `/wp-admin/admin.php?page=jetpack-search`
* Go to fornop2 homepage and open the console and verify it no longer throws `_.where is not a function` or related Reader Chat load-time errors.
* Ensure that scrolling down loads older posts

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
