### PR TITLE
Reader: release achievements page to all users

### DIFF
--- a/client/data/reader/test/use-achievements-query.test.tsx
+++ b/client/data/reader/test/use-achievements-query.test.tsx
@@ -1,7 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-import { isEnabled } from '@automattic/calypso-config';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import React from 'react';
@@ -14,11 +13,6 @@ jest.mock( 'calypso/lib/wp', () => ( {
 	},
 } ) );
 
-jest.mock( '@automattic/calypso-config', () => ( {
-	isEnabled: jest.fn(),
-} ) );
-
-const mockIsEnabled = isEnabled as jest.MockedFunction< typeof isEnabled >;
 const mockGet = jest.mocked( wpcom.req.get );
 
 describe( 'useAchievementsQuery', () => {
@@ -27,7 +21,6 @@ describe( 'useAchievementsQuery', () => {
 
 	beforeEach( () => {
 		jest.clearAllMocks();
-		mockIsEnabled.mockReturnValue( true );
 
 		queryClient = new QueryClient( {
 			defaultOptions: { queries: { retry: false } },
@@ -35,14 +28,6 @@ describe( 'useAchievementsQuery', () => {
 		wrapper = ( { children } ) => (
 			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
 		);
-	} );
-
-	test( 'should not fire a request when feature flag is disabled', () => {
-		mockIsEnabled.mockReturnValue( false );
-
-		renderHook( () => useAchievementsQuery( 'testuser' ), { wrapper } );
-
-		expect( mockGet ).not.toHaveBeenCalled();
 	} );
 
 	test( 'should not fire a request when userIdOrLogin is undefined', () => {

--- a/client/data/reader/use-achievements-query.ts
+++ b/client/data/reader/use-achievements-query.ts
@@ -1,5 +1,4 @@
 import { readAchievementsQuery } from '@automattic/api-queries';
-import { isEnabled } from '@automattic/calypso-config';
 import { useInfiniteQuery } from '@tanstack/react-query';
 
 interface UseAchievementsQueryOptions {
@@ -18,10 +17,9 @@ export function useAchievementsQuery(
 	userIdOrLogin?: number | string,
 	options: UseAchievementsQueryOptions = {}
 ) {
-	const enabled = isEnabled( 'reader/achievements' ) && userIdOrLogin != null;
 	const query = useInfiniteQuery( {
 		...readAchievementsQuery( userIdOrLogin ),
-		enabled,
+		enabled: userIdOrLogin != null,
 		...options,
 	} );
 

--- a/client/reader/components/achievements/test/use-achievements-visibility.test.ts
+++ b/client/reader/components/achievements/test/use-achievements-visibility.test.ts
@@ -4,11 +4,6 @@
 import { renderHook } from '@testing-library/react';
 import useAchievementsVisibility from '../use-achievements-visibility';
 
-const mockIsEnabled = jest.fn();
-jest.mock( '@automattic/calypso-config', () => ( {
-	isEnabled: ( ...args: unknown[] ) => mockIsEnabled( ...args ),
-} ) );
-
 const mockUseQuery = jest.fn();
 jest.mock( '@tanstack/react-query', () => ( {
 	useQuery: ( options: unknown ) => mockUseQuery( options ),
@@ -18,7 +13,6 @@ jest.mock( '@automattic/api-queries', () => ( {
 	readAchievementsSettingsQuery: ( userIdOrLogin: string ) => ( {
 		queryKey: [ 'read', 'achievements', userIdOrLogin, 'settings' ],
 	} ),
-	readTeamsQuery: () => ( { queryKey: [ 'read', 'teams' ] } ),
 } ) );
 
 const mockGetCurrentUser = jest.fn();
@@ -31,15 +25,12 @@ jest.mock( 'calypso/state/current-user/selectors', () => ( {
 
 type QueryOptions = { queryKey: unknown[]; enabled?: boolean };
 type QueryResult = { data?: unknown; isLoading?: boolean };
-type QueryResponses = { teams?: QueryResult; settings?: QueryResult };
 
-function setupUseQuery( responses: QueryResponses = {} ) {
+function setupUseQuery( response: QueryResult = {} ) {
 	mockUseQuery.mockImplementation( ( options: QueryOptions ) => {
 		if ( options.enabled === false ) {
 			return { data: undefined, isLoading: false };
 		}
-		const isTeams = options.queryKey[ 1 ] === 'teams';
-		const response = ( isTeams ? responses.teams : responses.settings ) ?? {};
 		return { data: response.data, isLoading: response.isLoading ?? false };
 	} );
 }
@@ -53,68 +44,11 @@ function findCall( mock: jest.Mock, predicate: ( options: QueryOptions ) => bool
 describe( 'useAchievementsVisibility', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
-		mockIsEnabled.mockReturnValue( true );
 		mockGetCurrentUser.mockReturnValue( { username: 'myself' } );
-		setupUseQuery( {
-			teams: { data: { teams: [ { slug: 'a8c' } ] } },
-		} );
+		setupUseQuery();
 	} );
 
-	test( 'returns isVisible false when feature flag is disabled', () => {
-		mockIsEnabled.mockReturnValue( false );
-
-		const { result } = renderHook( () => useAchievementsVisibility( 'myself' ) );
-
-		expect( result.current.isVisible ).toBe( false );
-		expect( result.current.isLoading ).toBe( false );
-	} );
-
-	test( 'does not fetch teams or settings when flag is disabled', () => {
-		mockIsEnabled.mockReturnValue( false );
-
-		renderHook( () => useAchievementsVisibility( 'other_user' ) );
-
-		const teamsCall = findCall( mockUseQuery, ( o ) => o.queryKey[ 1 ] === 'teams' );
-		const settingsCall = findCall( mockUseQuery, ( o ) => o.queryKey[ 1 ] === 'achievements' );
-		expect( teamsCall?.[ 0 ].enabled ).toBe( false );
-		expect( settingsCall?.[ 0 ].enabled ).toBe( false );
-	} );
-
-	test( 'returns isLoading true while teams query loads', () => {
-		setupUseQuery( {
-			teams: { isLoading: true },
-		} );
-
-		const { result } = renderHook( () => useAchievementsVisibility( 'myself' ) );
-
-		expect( result.current.isLoading ).toBe( true );
-		expect( result.current.isVisible ).toBe( false );
-	} );
-
-	test( 'returns isVisible false when viewer is not an automattician', () => {
-		setupUseQuery( {
-			teams: { data: { teams: [] } },
-			settings: { data: { settings: { 'achievements-visibility': 'public' } } },
-		} );
-
-		const { result } = renderHook( () => useAchievementsVisibility( 'myself' ) );
-
-		expect( result.current.isVisible ).toBe( false );
-		expect( result.current.isLoading ).toBe( false );
-	} );
-
-	test( 'does not fetch settings when viewer is not an automattician', () => {
-		setupUseQuery( {
-			teams: { data: { teams: [] } },
-		} );
-
-		renderHook( () => useAchievementsVisibility( 'other_user' ) );
-
-		const settingsCall = findCall( mockUseQuery, ( o ) => o.queryKey[ 1 ] === 'achievements' );
-		expect( settingsCall?.[ 0 ].enabled ).toBe( false );
-	} );
-
-	test( 'returns isOwnProfile and isVisible true for own profile when viewer is A8C', () => {
+	test( 'returns isOwnProfile and isVisible true for own profile', () => {
 		const { result } = renderHook( () => useAchievementsVisibility( 'myself' ) );
 
 		expect( result.current.isOwnProfile ).toBe( true );
@@ -129,10 +63,16 @@ describe( 'useAchievementsVisibility', () => {
 		expect( settingsCall?.[ 0 ].enabled ).toBe( false );
 	} );
 
-	test( 'returns isVisible true when other user has public achievements and viewer is A8C', () => {
+	test( 'does not fetch settings when profileUserLogin is undefined', () => {
+		renderHook( () => useAchievementsVisibility( undefined ) );
+
+		const settingsCall = findCall( mockUseQuery, ( o ) => o.queryKey[ 1 ] === 'achievements' );
+		expect( settingsCall?.[ 0 ].enabled ).toBe( false );
+	} );
+
+	test( 'returns isVisible true when other user has public achievements', () => {
 		setupUseQuery( {
-			teams: { data: { teams: [ { slug: 'a8c' } ] } },
-			settings: { data: { settings: { 'achievements-visibility': 'public' } } },
+			data: { settings: { 'achievements-visibility': 'public' } },
 		} );
 
 		const { result } = renderHook( () => useAchievementsVisibility( 'other_user' ) );
@@ -144,8 +84,7 @@ describe( 'useAchievementsVisibility', () => {
 
 	test( 'returns isVisible false when other user has private achievements', () => {
 		setupUseQuery( {
-			teams: { data: { teams: [ { slug: 'a8c' } ] } },
-			settings: { data: { settings: { 'achievements-visibility': 'private' } } },
+			data: { settings: { 'achievements-visibility': 'private' } },
 		} );
 
 		const { result } = renderHook( () => useAchievementsVisibility( 'other_user' ) );
@@ -155,10 +94,7 @@ describe( 'useAchievementsVisibility', () => {
 	} );
 
 	test( 'returns isLoading true while fetching other user settings', () => {
-		setupUseQuery( {
-			teams: { data: { teams: [ { slug: 'a8c' } ] } },
-			settings: { isLoading: true },
-		} );
+		setupUseQuery( { isLoading: true } );
 
 		const { result } = renderHook( () => useAchievementsVisibility( 'other_user' ) );
 

--- a/client/reader/components/achievements/use-achievements-visibility.ts
+++ b/client/reader/components/achievements/use-achievements-visibility.ts
@@ -1,32 +1,21 @@
-import { readAchievementsSettingsQuery, readTeamsQuery } from '@automattic/api-queries';
-import { isEnabled } from '@automattic/calypso-config';
+import { readAchievementsSettingsQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
-import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
 import { useSelector } from 'calypso/state';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 
 export default function useAchievementsVisibility( profileUserLogin?: string ) {
-	const featureEnabled = isEnabled( 'reader/achievements' );
 	const currentUser = useSelector( getCurrentUser );
 	const isOwnProfile = currentUser?.username === profileUserLogin;
 
-	const { data: teamsData, isLoading: teamsLoading } = useQuery( {
-		...readTeamsQuery(),
-		enabled: featureEnabled,
-	} );
-	const isAutomattician = isAutomatticTeamMember( teamsData?.teams ?? [] );
-
 	const { data: settingsData, isLoading: settingsLoading } = useQuery( {
 		...readAchievementsSettingsQuery( profileUserLogin ),
-		enabled: featureEnabled && isAutomattician && ! isOwnProfile && profileUserLogin != null,
+		enabled: ! isOwnProfile && profileUserLogin != null,
 	} );
 	const isPublic = settingsData?.settings[ 'achievements-visibility' ] === 'public';
 
 	return {
 		isOwnProfile,
-		isVisible: featureEnabled && isAutomattician && ( isOwnProfile || isPublic ),
-		isLoading:
-			featureEnabled &&
-			( teamsLoading || ( ! isOwnProfile && isAutomattician && settingsLoading ) ),
+		isVisible: isOwnProfile || isPublic,
+		isLoading: ! isOwnProfile && settingsLoading,
 	};
 }

--- a/config/development.json
+++ b/config/development.json
@@ -182,7 +182,6 @@
 		"purchases/new-payment-methods": true,
 		"purchases/split-cancel-remove": true,
 		"push-notifications": true,
-		"reader/achievements": true,
 		"reader/social": true,
 		"reader/full-errors": true,
 		"reader/msd-enabled": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -105,7 +105,6 @@
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
 		"purchases/split-cancel-remove": false,
-		"reader/achievements": true,
 		"reader/social": true,
 		"reader/full-errors": false,
 		"reader/msd-enabled": true,

--- a/config/production.json
+++ b/config/production.json
@@ -136,7 +136,6 @@
 		"purchases/new-payment-methods": true,
 		"purchases/split-cancel-remove": false,
 		"push-notifications": true,
-		"reader/achievements": true,
 		"reader/social": false,
 		"reader/full-errors": false,
 		"reader/msd-enabled": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -134,7 +134,6 @@
 		"purchases/new-payment-methods": true,
 		"purchases/split-cancel-remove": false,
 		"push-notifications": true,
-		"reader/achievements": true,
 		"reader/social": true,
 		"reader/full-errors": false,
 		"reader/msd-enabled": true,

--- a/config/test.json
+++ b/config/test.json
@@ -92,7 +92,6 @@
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
 		"purchases/split-cancel-remove": true,
-		"reader/achievements": true,
 		"reader/social": true,
 		"reader/full-errors": true,
 		"reader/msd-enabled": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -136,7 +136,6 @@
 		"publicize-preview": true,
 		"purchases/new-payment-methods": true,
 		"purchases/split-cancel-remove": false,
-		"reader/achievements": true,
 		"reader/social": true,
 		"reader/full-errors": true,
 		"reader/msd-enabled": true,


### PR DESCRIPTION
Part of RSM-3557

## Proposed Changes

* Remove the automattician-only gate in `useAchievementsVisibility`. Visibility now rests solely on the user's `achievements-visibility` setting (with own profile always visible).
* Drop the now-redundant `reader/achievements` feature flag from all environments and from `useAchievementsQuery` / `useAchievementsVisibility`.
* Update unit tests to cover the new visibility logic (own profile / public / private / loading / no-login).

## Why are these changes being made?

The achievements page is ready for general availability, so the A8C gate and the per-env feature flag are no longer needed.

## Testing Instructions

* Sign in as a non-A8C user and visit `/reader/users/<your-login>/achievements` — your own achievements tab and page should always be visible.
* Visit `/reader/users/<other-user>/achievements` for a user who has set their achievements to public — the achievements tab and page should render.
* Repeat for a user with private achievements — the achievements tab should be hidden and the page should render nothing.
* Confirm there are no console / TypeScript errors and that `yarn test-client client/reader/components/achievements client/reader/user-profile/views/achievements` still passes.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?