### PR TITLE
Fix DataViews popover invisibility & filter row layout in classic Calypso

### DIFF
--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -1,5 +1,28 @@
 @import "@wordpress/base-styles/colors";
 
+/* @wordpress/components Menu workaround ---------------------------------------------- *
+ * The `Menu.Popover` refactor in @wordpress/components 33.0.0 (Gutenberg #77460) split
+ * the popover into `MenuMotionRoot` (motion styles) > `MenuSurface` (panel chrome) and
+ * spread Ariakit's `htmlProps` on the inner `MenuSurface`. Ariakit's `useDisclosureContent`
+ * reads `getComputedStyle(MenuSurface).transitionDuration`, which is `0s` (the transitions
+ * live on the outer `MenuMotionRoot`). In isolation this still works because Ariakit also
+ * reads from the disclosure trigger element which usually has a non-zero `box-shadow`
+ * transition — Gutenberg Storybook confirms the Menu component itself is fine.
+ *
+ * In classic Calypso, something in the surrounding React tree (masterbar / Help Center /
+ * focus management) trips Ariakit's `animated` state machine into `false` before the
+ * trigger's transition can be measured, so `data-enter` is never stamped on `MenuSurface`,
+ * the companion `MenuMotionRoot:has(> MenuSurface[data-enter])` rule never matches, and
+ * the popover stays at `opacity: 0`. This breaks the DataViews "Add filter" popover on
+ * /p2s, /sites/<slug>/logs/*, etc.
+ *
+ * Adding a tiny transition directly on `MenuSurface` makes Ariakit's `getComputedStyle()`
+ * check non-zero regardless of trigger timing, so the pipeline always stamps `data-enter`.
+ * The real fade/slide motion still comes from `MenuMotionRoot`, unchanged. */
+[data-dialog][role="menu"] {
+	transition: opacity 1ms;
+}
+
 /* @wordpress/components FormToggle overrides ----------------------------------------- */
 .components-form-toggle {
 	input[type="checkbox"] {

--- a/client/sites/logs/components/style.scss
+++ b/client/sites/logs/components/style.scss
@@ -46,6 +46,18 @@
 	.dataviews-footer {
 		padding-inline: 0;
 	}
+
+	// Center-align the custom header controls (Download button + Auto-refresh
+	// toggle) with the sibling icon-only buttons (LayoutSwitcher / ViewConfig).
+	// WPDataViews' DefaultUI uses `align: top` on the actions row, and the
+	// `ToggleControl` is taller than icon buttons, so they don't share a baseline.
+	.dataviews__view-actions {
+		align-items: center;
+	}
+
+	.site-logs__auto-refresh {
+		align-self: center;
+	}
 }
 
 // https://github.com/WordPress/gutenberg/issues/69194

--- a/client/sites/logs/components/style.scss
+++ b/client/sites/logs/components/style.scss
@@ -34,6 +34,18 @@
 .site-logs .dataviews-wrapper {
 	margin-right: -24px;
 	margin-left: -24px;
+
+	// Neutralize the 24px `padding-inline` applied broadly by
+	// `client/sites/components/sites-dataviews/dataview-style.scss` (intended for
+	// the Sites dashboard listing). Logs already bleeds out of its parent padding
+	// via the negative margins above, so adding 24px back here re-indents the
+	// funnel button, filter chips, Add filter, and Reset controls inside the
+	// negative-margin frame and misaligns them with the page heading.
+	.dataviews__view-actions,
+	.dataviews-filters__container,
+	.dataviews-footer {
+		padding-inline: 0;
+	}
 }
 
 // https://github.com/WordPress/gutenberg/issues/69194


### PR DESCRIPTION
## Proposed Changes

Three classic-Calypso layout/behavior fixes for pages that use `@wordpress/dataviews`:

1. **Add a 1ms `transition: opacity` to `[data-dialog][role=\"menu\"]`** in `client/assets/stylesheets/_wp-components-overrides.scss` so the WP `Menu` popover stops being invisible (DataViews "Add filter" funnel and similar dropdowns).
2. **Neutralize the inherited 24px `padding-inline`** on `.dataviews__view-actions` / `.dataviews-filters__container` / `.dataviews-footer` inside `.site-logs .dataviews-wrapper`, so the funnel/chip/Add filter/Reset row no longer sits indented inside the negative-margin frame on `/sites/<slug>/logs/*`.
3. **Center-align the actions row** on the Logs page so the `Auto-refresh` `ToggleControl` shares a vertical center with the adjacent icon-only buttons (LayoutSwitcher / ViewConfig / Download).

## Why are these changes being made?

### 1. Invisible "Add filter" popover (DataViews)

The funnel popover on classic Calypso pages with a DataViews component (e.g. `/p2s`, `/sites/<slug>/logs/*` when no filter is active) does nothing on click. The popover IS rendered in the DOM, but `MenuMotionRoot` is stuck at `opacity: 0`.

**Regression source:** #110764 ("[RSM-549] Update @wordpress/components to 33.1.0", commit `b53f2bf3a87`) bumped `@wordpress/components` from `^32.1.0` → `^33.1.0`, crossing the `Menu.Popover` refactor in 33.0.0 (Gutenberg [PR #77460](https://github.com/WordPress/gutenberg/pull/77460)).

| | `@wordpress/components@32.1.0` | `@wordpress/components@33.1.0` |
|---|---|---|
| Popover shape | `<Styled.Menu>` (single styled `Ariakit.Menu`) | `<MenuMotionRoot><MenuSurface … /></MenuMotionRoot>` |
| Transitions live on | the same element Ariakit attaches to | `MenuMotionRoot` (outer) |
| Ariakit `htmlProps` spread on | the same element | `MenuSurface` (inner, no transition of its own) |
| `getComputedStyle(htmlPropsTarget).transitionDuration` | non-zero | `0s` |

After the bump, Ariakit's `useDisclosureContent` reads `getComputedStyle(MenuSurface).transitionDuration === '0s'`, which keeps its `useSafeLayoutEffect` dependency array `[animated, contentElement, open, mounted]` churning in some environments. In Gutenberg Storybook the double-`requestAnimationFrame` chain that schedules `setTransition(\"enter\")` still resolves and `data-enter` lands on `MenuSurface`. In classic Calypso something in the ambient React tree (masterbar / Help Center / focus-management providers) churns those deps before the rAF chain completes, so `setTransition(\"enter\")` is repeatedly cancelled, `data-enter` is never stamped, and the companion `MenuMotionRoot:has( > MenuSurface[data-enter] )` opacity:1 override never matches.

Giving `MenuSurface` a tiny `transition: opacity 1ms` keeps `getComputedStyle().transitionDuration` non-zero so Ariakit's state machine settles instead of looping. The real fade/slide motion still comes from `MenuMotionRoot`, unchanged.

Not filed upstream — the Menu component is fine in isolation (Storybook proves it). The brittleness is specific to classic Calypso's React tree.

### 2. Indented filter row on /sites/&lt;slug&gt;/logs

The rule introduced in #104490 (`client/sites/components/sites-dataviews/dataview-style.scss:56`) applies `padding-inline: 24px` to every `.dataviews-wrapper > .dataviews__view-actions / .dataviews-filters__container / …` under `.wpcom-site:has(.is-global-sidebar-visible)`. `.site-logs .dataviews-wrapper` already has `margin-inline: -24px` to bleed out of its parent's padding, so the broad rule adds the 24px back inside the negative-margin frame — re-indenting the funnel + chips + Add filter + Reset row away from the page heading.

Fix: zero out `padding-inline` on those three children inside `.site-logs .dataviews-wrapper`. Lower blast radius than narrowing #104490's selector (sites / domains / plugins keep their existing alignment).

### 3. Auto-refresh toggle misaligned

WPDataViews' DefaultUI renders the actions row with `align: top`; the `ToggleControl` is taller than the icon-only Buttons next to it, so the four controls don't share a vertical center. Center-align the row.

## Testing Instructions

1. Log in to wordpress.com.
2. **Popover fix** — go to `/p2s` (or any classic Calypso page with DataViews and no active filter). Click the funnel icon next to the search box.
   - Before: nothing visible. `[data-dialog][role=\"menu\"]` exists in the DOM but `MenuMotionRoot` is at `opacity: 0`.
   - After: the "Add filter" dropdown appears with the available filter fields.
3. **Logs layout fix** — go to `/sites/<slug>/logs/php` on a site with the LOGS feature.
   - Before: funnel button + filter chips + Add filter + Reset row is indented 24px relative to the "Logs" heading.
   - After: same row aligns with the page heading.
4. **Auto-refresh alignment** — same Logs page.
   - Before: the `Auto-refresh` toggle baseline is slightly off from the adjacent gear/download icons.
   - After: all four controls share a vertical center.

Popover fix verified live with Playwright on `/p2s`: injecting `[data-dialog][role=\"menu\"] { transition: opacity 1ms !important }` via DevTools flipped `data-enter` to `\"true\"` and `motionOpacity` to `\"1\"` on the same broken page. Gutenberg Storybook's `Components / Actions / Menu / Default` story remains correct (the rule is a no-op there).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?

🤖 Generated with [Claude Code](https://claude.com/claude-code)