### PR TITLE
Onboarding: align Help Center mobile sheet with the step top bar

### DIFF
--- a/packages/onboarding/src/step-container-v2/components/TopBar/TopBar.tsx
+++ b/packages/onboarding/src/step-container-v2/components/TopBar/TopBar.tsx
@@ -1,6 +1,6 @@
 import { WordPressLogo, WordPressWordmark } from '@automattic/components';
 import clsx from 'clsx';
-import { isValidElement, type ReactElement, type ReactNode } from 'react';
+import { isValidElement, useEffect, useRef, type ReactElement, type ReactNode } from 'react';
 import { useStepContainerV2Context } from '../../contexts/StepContainerV2Context';
 
 import './style.scss';
@@ -37,6 +37,38 @@ export const TopBar = ( {
 	hideLogo = false,
 }: TopBarProps ) => {
 	const context = useStepContainerV2Context();
+	const topBarRef = useRef< HTMLDivElement >( null );
+
+	// Publish the rendered height to `:root --masterbar-height` so consumers that
+	// expect "the current route's top bar height" (e.g. the Help Center mobile
+	// sheet, layout sidebars) get the right value. Without this, routes that
+	// render `Step.TopBar` but also force `<EmptyMasterbar />` (e.g. checkout
+	// invoked from a stepper-v2 flow) report `--masterbar-height: 0`, leaving the
+	// overlay misaligned. Uses `!important` to beat EmptyMasterbar's stylesheet.
+	useEffect( () => {
+		const element = topBarRef.current;
+
+		if ( ! element || typeof ResizeObserver === 'undefined' ) {
+			return;
+		}
+
+		const root = document.documentElement;
+
+		const publishHeight = () => {
+			const height = Math.round( element.getBoundingClientRect().height );
+			root.style.setProperty( '--masterbar-height', `${ height }px`, 'important' );
+		};
+
+		publishHeight();
+
+		const observer = new ResizeObserver( publishHeight );
+		observer.observe( element );
+
+		return () => {
+			observer.disconnect();
+			root.style.removeProperty( '--masterbar-height' );
+		};
+	}, [] );
 
 	// Context logo takes precedence over default WordPress logo.
 	// The `logo` prop provides an explicit override for both.
@@ -62,7 +94,7 @@ export const TopBar = ( {
 	const resolvedLogo = logo ?? context.logo ?? defaultWordPressLogo;
 
 	return (
-		<div className="step-container-v2__top-bar">
+		<div ref={ topBarRef } className="step-container-v2__top-bar">
 			{ ! hideLogo && resolvedLogo }
 
 			{ leftElement && (

--- a/packages/onboarding/src/step-container-v2/components/TopBar/TopBar.tsx
+++ b/packages/onboarding/src/step-container-v2/components/TopBar/TopBar.tsx
@@ -1,6 +1,6 @@
 import { WordPressLogo, WordPressWordmark } from '@automattic/components';
 import clsx from 'clsx';
-import { isValidElement, useEffect, useRef, type ReactElement, type ReactNode } from 'react';
+import { isValidElement, useLayoutEffect, useRef, type ReactElement, type ReactNode } from 'react';
 import { useStepContainerV2Context } from '../../contexts/StepContainerV2Context';
 
 import './style.scss';
@@ -44,11 +44,12 @@ export const TopBar = ( {
 	// sheet, layout sidebars) get the right value. Without this, routes that
 	// render `Step.TopBar` but also force `<EmptyMasterbar />` (e.g. checkout
 	// invoked from a stepper-v2 flow) report `--masterbar-height: 0`, leaving the
-	// overlay misaligned. Uses `!important` to beat EmptyMasterbar's stylesheet.
-	useEffect( () => {
+	// overlay misaligned. Uses `!important` to beat EmptyMasterbar's stylesheet,
+	// and runs before paint so first-frame consumers don't see the stale value.
+	useLayoutEffect( () => {
 		const element = topBarRef.current;
 
-		if ( ! element || typeof ResizeObserver === 'undefined' ) {
+		if ( ! element ) {
 			return;
 		}
 
@@ -61,11 +62,14 @@ export const TopBar = ( {
 
 		publishHeight();
 
-		const observer = new ResizeObserver( publishHeight );
-		observer.observe( element );
+		let observer: ResizeObserver | undefined;
+		if ( typeof ResizeObserver !== 'undefined' ) {
+			observer = new ResizeObserver( publishHeight );
+			observer.observe( element );
+		}
 
 		return () => {
-			observer.disconnect();
+			observer?.disconnect();
 			root.style.removeProperty( '--masterbar-height' );
 		};
 	}, [] );


### PR DESCRIPTION
Part of RSM: phcsdm-LZ-p2

## Proposed changes

While working on RSM, we detected that the Help Center had a bug when the user opened it from the `checkout` step in the mobile onboarding flow. That created a confusing interfaces, and was inconsistent with the way the HC renders in the `plans` step.

It was also hiding the navigation on top, so users lost context of where they were.

See screenshots:

| Step | Before | After |
| --- | --- | --- |
| `/plans` | <img width="750" height="1334" alt="calypso localhost_3000_setup_onboarding_plans_siteSlug=thisismytesting23423 wordpress com(iPhone SE) (1)" src="https://github.com/user-attachments/assets/5bca6044-7c41-4466-bb92-87bd12d929c5" /> | <img width="750" height="1334" alt="calypso localhost_3000_setup_onboarding_plans_siteSlug=thisismytesting23423 wordpress com(iPhone SE) (1)" src="https://github.com/user-attachments/assets/5bca6044-7c41-4466-bb92-87bd12d929c5" /> |
| `/checkout` | <img width="750" height="1334" alt="calypso localhost_3000_checkout_thisismytesting23423 wordpress com_redirect_to=%2Fsetup%2Fonboarding%2Fpost-checkout-onboarding%3FsiteSlug%3Dthisismytesting23423 wordpress com signup=1 checkoutBackUrl=http%3A%2F%2Fcalypso localhost%3A3000%2" src="https://github.com/user-attachments/assets/babfe257-e35e-4650-bb51-f47768672f8d" /> | <img width="750" height="1334" alt="calypso localhost_3000_checkout_thisismytesting23423 wordpress com_redirect_to=%2Fsetup%2Fonboarding%2Fpost-checkout-onboarding%3FsiteSlug%3Dthisismytesting23423 wordpress com signup=1 checkoutBackUrl=http%3A%2F%2Fcalypso localhost%3A30 (1)" src="https://github.com/user-attachments/assets/0e78bb3f-caba-440b-a7b9-fab87c094ddd" /> |

* `Step.TopBar` now publishes its rendered height to `:root --masterbar-height` via `ResizeObserver`, with `!important` priority. The observer is disconnected and the custom property is removed on unmount.


## Testing Instructions

At mobile width (e.g. DevTools device mode at 375×812), authenticated, on a Calypso dev server:

1. `http://calypso.localhost:3000/setup/onboarding/plans?siteSlug=<your-site>.wordpress.com` — open **Need help?**. The Help Center mobile sheet should sit **below** the top bar and be **flush at the bottom**.
2. `http://calypso.localhost:3000/checkout/<your-site>.wordpress.com?redirect_to=%2Fsetup%2Fonboarding%2Fpost-checkout-onboarding%3FsiteSlug%3D<your-site>.wordpress.com&signup=1` — open **Need help?**. Previously: top bar covered + 14-day money-back badge peeking. Now: top bar visible above the sheet, bottom flush, no badge peek.

Desktop sanity (1280×800) on `/sites`, `/wp-admin/`, `/wp-admin/post-new.php` — Help Center should still float at bottom-right and be unaffected.

Verifying `--masterbar-height` is set correctly:

```js
getComputedStyle(document.documentElement).getPropertyValue('--masterbar-height')
// → "56px" on the stepper/checkout routes above
document.documentElement.style.getPropertyPriority('--masterbar-height')
// → "important"
```

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?