### PR TITLE
Reader Fediverse: keep timeline avatars square for non-square sources

### DIFF
--- a/client/reader/social/components/post-card/style.scss
+++ b/client/reader/social/components/post-card/style.scss
@@ -124,6 +124,11 @@ a.social-post-card-header__author:hover .social-post-card-header__display-name {
 	border-radius: 50%;
 	object-fit: cover;
 	background: var( --color-border-subtle );
+	// Calypso ships a global `img { height: auto }` rule that beats the
+	// `<img>` height attribute. Non-square source images would otherwise
+	// keep their natural aspect ratio (rendering 36×24 instead of 36×36,
+	// CM-753); pin the box to a square so `object-fit: cover` can crop.
+	aspect-ratio: 1 / 1;
 }
 
 .social-post-card-header__avatar--placeholder {

--- a/client/reader/social/components/post-card/style.scss
+++ b/client/reader/social/components/post-card/style.scss
@@ -124,10 +124,8 @@ a.social-post-card-header__author:hover .social-post-card-header__display-name {
 	border-radius: 50%;
 	object-fit: cover;
 	background: var( --color-border-subtle );
-	// Calypso ships a global `img { height: auto }` rule that beats the
-	// `<img>` height attribute. Non-square source images would otherwise
-	// keep their natural aspect ratio (rendering 36×24 instead of 36×36,
-	// CM-753); pin the box to a square so `object-fit: cover` can crop.
+	// Calypso's global `img { height: auto }` overrides the height attribute,
+	// so non-square sources skew. Square the box so object-fit can crop.
 	aspect-ratio: 1 / 1;
 }
 


### PR DESCRIPTION
Part of CM-753

## Proposed Changes

* Add `aspect-ratio: 1 / 1` to `.social-post-card-header__avatar` so non-square source images render as a 36×36 (or 24×24 in compact) square, cropped centered by the existing `object-fit: cover`.

## Why are these changes being made?

Calypso ships a global `img { height: auto }` rule that beats the `<img>` `height` attribute (which is just a presentational hint). The timeline post-card avatar relied on that attribute for sizing, so a non-square source — e.g. a Fediverse actor whose `icon` is a 2048×1365 image — kept its natural aspect ratio and rendered 36×24 instead of 36×36. Pinning the box with `aspect-ratio: 1 / 1` lets the existing `object-fit: cover` produce the expected centered-crop circle. Fix covers every protocol that mounts `SocialPostCard` (Fediverse, Mastodon, ATmosphere).

## Testing Instructions

1. Open a Fediverse author profile that hosts a non-square avatar — e.g. `/reader/fediverse/<connection_id>/profile/axplorer.jeherve.com%40axplorer.jeherve.com`.
2. Confirm the small avatars next to each timeline post render as perfect circles (cropped centered) instead of horizontally squished ellipses.
3. Spot-check the same profile via Mastodon / ATmosphere shells to confirm no regression — square sources should still look right.

DevTools-verified before/after on the reproduction URL:

| | naturalWidth | naturalHeight | rendered | computed height |
|---|---|---|---|---|
| Before | 2048 | 1365 | 36 × 23.99 | `23.9922px` |
| After  | 2048 | 1365 | 36 × 36    | `36px` |

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?