### PR TITLE
Layout: restore universal header on /themes and /plugins

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -570,7 +570,7 @@ export default withCurrentRoute(
 
 		const hasUniversalHeader =
 			dashboardOptIn &&
-			! siteId &&
+			! getSelectedSiteId( state ) &&
 			( isEnabledThemeUniversalHeader || isEnabledPluginsUniversalHeader );
 
 		return {

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -287,7 +287,7 @@ class Layout extends Component {
 					/>
 				) }
 				<MasterbarComponent
-					siteId={ this.props.siteId }
+					siteId={ this.props.siteIdForLaunch }
 					section={ this.props.sectionGroup }
 					isCheckout={ this.props.sectionName === 'checkout' }
 					isCheckoutPending={ this.props.sectionName === 'checkout-pending' }
@@ -308,7 +308,7 @@ class Layout extends Component {
 			<AsyncLoad
 				require={ loadCelebrateSiteLaunchModal }
 				placeholder={ null }
-				siteId={ this.props.siteId }
+				siteId={ this.props.siteIdForLaunch }
 			/>
 		);
 	}
@@ -472,12 +472,14 @@ export default withCurrentRoute(
 		const sectionGroup = currentSection?.group ?? null;
 		const sectionName = currentSection?.name ?? null;
 
+		const siteId = getSelectedSiteId( state );
 		// Falls back to using the user's primary site if no site has been selected
-		// by the user yet
-		const siteId =
-			getSelectedSiteId( state ) ||
-			getMostRecentlySelectedSiteId( state ) ||
-			getPrimarySiteId( state );
+		// by the user yet. Only consumed by the masterbar launch button and the
+		// site launch celebration modal — other layout logic (sidebar type,
+		// universal header, color scheme, jetpack detection) must keep using the
+		// actually-selected site.
+		const siteIdForLaunch =
+			siteId || getMostRecentlySelectedSiteId( state ) || getPrimarySiteId( state );
 		const sectionJitmPath = getMessagePathForJITM( currentRoute );
 		const isJetpackLogin = currentRoute.startsWith( '/log-in/jetpack' );
 		const isJetpack =
@@ -570,7 +572,7 @@ export default withCurrentRoute(
 
 		const hasUniversalHeader =
 			dashboardOptIn &&
-			! getSelectedSiteId( state ) &&
+			! siteId &&
 			( isEnabledThemeUniversalHeader || isEnabledPluginsUniversalHeader );
 
 		return {
@@ -597,7 +599,8 @@ export default withCurrentRoute(
 			needsColorScheme,
 			isFetchingColorScheme: isFetchingAdminColor( state, siteId ),
 			siteId,
-			site: getSite( state, siteId ),
+			siteIdForLaunch,
+			site: getSite( state, siteIdForLaunch ),
 			// We avoid requesting sites in the Jetpack Connect authorization step, because this would
 			// request all sites before authorization has finished. That would cause the "all sites"
 			// request to lack the newly authorized site, and when the request finishes after


### PR DESCRIPTION
## Proposed Changes

* Split the `siteId` introduced in #109896 into two variables in `client/layout/index.jsx`:
  * `siteId` — back to `getSelectedSiteId( state )` (its original semantics). Used by all pre-existing layout logic: `getSidebarType`, color scheme, universal header, jetpack detection, `QuerySite*` queries.
  * `siteIdForLaunch` — the new fallback chain (`selected → most recently selected → primary`). Passed only to the two consumers added in #109896: `MasterbarComponent` (masterbar launch button) and the celebrate-site-launch modal. Also feeds the `site` prop that drives the `initiallyUnlaunchedSite` derived state.

## Why are these changes being made?

#109896 changed `siteId` in the layout connector to fall back to the most-recently-selected or primary site, so the new masterbar launch button and celebrate-launch modal could resolve a site even when none is selected. But that same `siteId` flows into other layout decisions, so on routes like `/themes` and `/plugins` (no selected site) the fallback now made the layout behave as if a site were selected.

Two concrete regressions:

1. `getSidebarType` (`client/state/global-sidebar/selectors.ts:35`) — `group === 'sites' && ! siteId` returns `SidebarType.Global` (light sidebar). With a truthy fallback siteId it returns `UnifiedSiteDefault`/`UnifiedSiteClassic` — the dark wp-admin-style sidebar shown in the linked screenshots.
2. `hasUniversalHeader` in `client/layout/index.jsx` — requires `! siteId`, so the light universal header on `/themes` and `/plugins` stopped rendering.

Scoping the fallback to only the launch-button/modal consumers restores the pre-#109896 behavior for everything else, while keeping the celebrate-launch modal working.

## Testing Instructions

As a logged-in user with no selected site:

* Visit `/themes` — expect the light universal header and light global sidebar (not the dark wp-admin sidebar).
* Visit `/plugins` — same.
* Visit any path that triggers the celebrate-launch modal (e.g. masterbar launch button on a site you own) — the modal should still appear; the masterbar launch button should still work.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?

🤖 Generated with [Claude Code](https://claude.com/claude-code)