### PR TITLE
Agents Manager: render chat quota errors as inline upgrade nudge

### DIFF
--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -457,11 +457,22 @@ export default function OrchestratorChat( {
 	}
 
 	// When the host plugin populates `agentsManagerData.upgradeNudge` +
-	// `upgradeLink`, render any chat-stream error as an inline upgrade-nudge
-	// notice instead of the generic "Streaming error: …" toast. Opt-in by
-	// configuration: surfaces that don't set both keys keep existing behavior.
+	// `upgradeLink` and the chat-stream error looks like a rate-limit / quota
+	// response, render an inline upgrade-nudge notice instead of the generic
+	// "Streaming error: …" toast. Opt-in by configuration: surfaces that
+	// don't set both keys keep existing behavior. The error-pattern check is
+	// substring-based because agenttic-client currently reduces error details
+	// to a single string; revisit if structured error info (status/code) is
+	// plumbed through useAgentChat.
 	const quotaNudge = useMemo( () => {
 		if ( ! error ) {
+			return undefined;
+		}
+		if (
+			! /(?:request_limit_exceeded|message limit|rate limit|quota)/i.test(
+				error
+			)
+		) {
 			return undefined;
 		}
 		const data = (

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -456,6 +456,34 @@ export default function OrchestratorChat( {
 		displayedEmptyViewSuggestions = emptyViewSuggestions;
 	}
 
+	// When the host plugin populates `agentsManagerData.nudge` + `upgradeLink`,
+	// render any chat-stream error as an inline upgrade-nudge notice instead of
+	// the generic "Streaming error: …" toast. Opt-in by configuration: surfaces
+	// that don't set both keys keep the existing behavior.
+	const quotaNudge = useMemo( () => {
+		if ( ! error ) {
+			return undefined;
+		}
+		const data = (
+			window as unknown as {
+				agentsManagerData?: { nudge?: string; upgradeLink?: string };
+			}
+		 ).agentsManagerData;
+		if ( ! data?.nudge || ! data?.upgradeLink ) {
+			return undefined;
+		}
+		const upgradeLink = data.upgradeLink;
+		return {
+			message: data.nudge,
+			action: {
+				label: __( 'Upgrade' ),
+				onClick: () =>
+					window.open( upgradeLink, '_blank', 'noopener,noreferrer' ),
+			},
+			status: 'warning' as const,
+		};
+	}, [ error ] );
+
 	return (
 		<AgentChat
 			messages={ displayedMessages }
@@ -463,7 +491,8 @@ export default function OrchestratorChat( {
 			emptyViewSuggestions={ displayedEmptyViewSuggestions }
 			isProcessing={ isProcessing || ( isThinking && ! isBuildingSite ) }
 			thinkingMessage={ progressMessage }
-			error={ error }
+			error={ quotaNudge ? null : error }
+			notice={ quotaNudge }
 			onSubmit={ onSubmitWithImages }
 			onAbort={ abortCurrentRequest }
 			isLoadingConversation={ isLoadingConversation }

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -456,25 +456,28 @@ export default function OrchestratorChat( {
 		displayedEmptyViewSuggestions = emptyViewSuggestions;
 	}
 
-	// When the host plugin populates `agentsManagerData.nudge` + `upgradeLink`,
-	// render any chat-stream error as an inline upgrade-nudge notice instead of
-	// the generic "Streaming error: …" toast. Opt-in by configuration: surfaces
-	// that don't set both keys keep the existing behavior.
+	// When the host plugin populates `agentsManagerData.upgradeNudge` +
+	// `upgradeLink`, render any chat-stream error as an inline upgrade-nudge
+	// notice instead of the generic "Streaming error: …" toast. Opt-in by
+	// configuration: surfaces that don't set both keys keep existing behavior.
 	const quotaNudge = useMemo( () => {
 		if ( ! error ) {
 			return undefined;
 		}
 		const data = (
 			window as unknown as {
-				agentsManagerData?: { nudge?: string; upgradeLink?: string };
+				agentsManagerData?: {
+					upgradeNudge?: string;
+					upgradeLink?: string;
+				};
 			}
 		 ).agentsManagerData;
-		if ( ! data?.nudge || ! data?.upgradeLink ) {
+		if ( ! data?.upgradeNudge || ! data?.upgradeLink ) {
 			return undefined;
 		}
 		const upgradeLink = data.upgradeLink;
 		return {
-			message: data.nudge,
+			message: data.upgradeNudge,
 			action: {
 				label: __( 'Upgrade' ),
 				onClick: () =>


### PR DESCRIPTION
## Summary

- `OrchestratorChat` now reads two optional fields from the host's `agentsManagerData` payload: `nudge` (notice copy) and `upgradeLink` (target URL).
- When both are set AND a chat-stream error is in flight, AgentChat renders an inline upgrade-nudge notice (with an "Upgrade" action button) instead of the generic "Streaming error: …" message.
- When either field is missing — or no error is in flight — behavior is unchanged.

## Why

The wpcom per-blog daily quota gate returns `WP_Error('request_limit_exceeded', …, [ 'status' => 429 ])` when a merchant exhausts their daily AI calls. Today the chat surfaces that as red "Streaming error: <wpcom message>" text — fine for transport failures, wrong tone for a quota response. The design calls for an inline amber notice with an upgrade CTA above the input.

We don't try to detect 429 specifically. The opt-in is structural: a host plugin that wants the nudge sets both `nudge` and `upgradeLink` in its `agentsManagerData`; surfaces that don't set them keep the existing error rendering. This keeps the change minimal — no `agenttic-client` changes needed, no error-shape plumbing.

## Pairs with

- woocommerce/woocommerce-ai#154 — populates the two fields on the WooCommerce AI admin page. Once both PRs are deployed, the WC AI chat shows the upgrade nudge instead of the generic streaming-error toast on quota exhaustion.

Other Agents-Manager consumers (Big Sky, Image Studio, …) can opt in the same way by adding the two keys to their own `agentsManagerData`. No code change needed in this package per consumer.

## Test plan

- [ ] Confirm a chat error in a surface that **does not** set `nudge`/`upgradeLink` still renders the existing "Streaming error: …" message (no regression).
- [ ] In a surface that **does** set both (after woocommerce-ai#154 lands), trigger a quota error → the inline notice replaces the streaming-error display, "Upgrade" button opens `upgradeLink` in a new tab.
- [ ] Cancelling / dismissing the error returns the chat to a normal state.
- [ ] TypeScript / lint pass in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)