### PR TITLE
Preferences language: simplify util, drop tautological tests

### DIFF
--- a/client/dashboard/me/preferences-language/languages.ts
+++ b/client/dashboard/me/preferences-language/languages.ts
@@ -35,14 +35,5 @@ export const getLocaleVariantOrLanguage = ( locale: string | undefined ): Langua
  * Adapted from https://github.com/Automattic/wp-calypso/blob/fbeb9c37266e2bfac7af881b1672a9f6d72a0670/client/me/account/main.jsx#L299
  * In this case the data.language is the locale variant if we're using one, so we can skip the "isLocaleVariant checks and see if the locale can be translated or not"
  */
-export const shouldDisplayCommunityTranslator = ( locale: string | undefined ): boolean => {
-	if ( ! locale ) {
-		return false;
-	}
-	// disable for locales
-	if ( ! canBeTranslated( locale ) ) {
-		return false;
-	}
-
-	return true;
-};
+export const shouldDisplayCommunityTranslator = ( locale: string | undefined ): boolean =>
+	!! locale && canBeTranslated( locale );

--- a/client/dashboard/me/preferences-language/test/languages.test.ts
+++ b/client/dashboard/me/preferences-language/test/languages.test.ts
@@ -1,44 +1,9 @@
 /**
  * @jest-environment jsdom
  */
-import languages from '@automattic/languages';
-import {
-	languagesAsOptions,
-	getLocaleVariantOrLanguage,
-	shouldDisplayCommunityTranslator,
-} from '../languages';
+import { getLocaleVariantOrLanguage, shouldDisplayCommunityTranslator } from '../languages';
 
 describe( 'languages utilities', () => {
-	describe( 'languagesAsOptions', () => {
-		it( 'should transform languages into options format', () => {
-			// Test with real languages data
-			expect( languagesAsOptions ).toBeDefined();
-			expect( Array.isArray( languagesAsOptions ) ).toBe( true );
-
-			// Check that each option has the correct structure
-			languagesAsOptions.forEach( ( option ) => {
-				expect( option ).toHaveProperty( 'value' );
-				expect( option ).toHaveProperty( 'label' );
-				expect( typeof option.value ).toBe( 'string' );
-				expect( typeof option.label ).toBe( 'string' );
-			} );
-		} );
-
-		it( 'should include common languages', () => {
-			const languageSlugs = languagesAsOptions.map( ( option ) => option.value );
-
-			// Test that common languages are present
-			expect( languageSlugs ).toContain( 'en' );
-			expect( languageSlugs ).toContain( 'es' );
-			expect( languageSlugs ).toContain( 'fr' );
-			expect( languageSlugs ).toContain( 'de' );
-		} );
-
-		it( 'should match the original languages array length', () => {
-			expect( languagesAsOptions ).toHaveLength( languages.length );
-		} );
-	} );
-
 	describe( 'getLocaleVariantOrLanguage', () => {
 		it( 'should return parent language when locale is a variant (es-cl)', () => {
 			// es-cl is a real locale variant in the languages package
@@ -82,10 +47,9 @@ describe( 'languages utilities', () => {
 			expect( result ).toBe( false );
 		} );
 
-		it( 'should handle unknown locale', () => {
+		it( 'should return true for an unknown locale (canBeTranslated defaults to true)', () => {
 			const result = shouldDisplayCommunityTranslator( 'xyz-unknown' );
-			// The actual result depends on how canBeTranslated handles unknown locales
-			expect( typeof result ).toBe( 'boolean' );
+			expect( result ).toBe( true );
 		} );
 	} );
 } );


### PR DESCRIPTION
Part of DOTMSD-1230

## Proposed Changes

* Collapse `shouldDisplayCommunityTranslator` to a single expression.
* Drop the `languagesAsOptions` test block — its assertions (shape, types, array-ness) are already guaranteed by TypeScript, and the "common languages" / length checks were really testing `@automattic/languages`.
* Tighten the unknown-locale test from `expect( typeof result ).toBe( 'boolean' )` (a tautology) to assert the actual behavior of `canBeTranslated` for unknown locales.

## Why are these changes being made?

Audit of dashboard unit tests turned up assertions that can't fail and a util with three returns where one suffices.

## Testing Instructions

* `yarn test-client client/dashboard/me/preferences-language`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?