### PR TITLE
Fix themes sidebar mode

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -472,16 +472,15 @@ export default withCurrentRoute(
 		const sectionGroup = currentSection?.group ?? null;
 		const sectionName = currentSection?.name ?? null;
 
-		// Falls back to using the user's primary site if no site has been selected
-		// by the user yet
-		const siteId =
-			getSelectedSiteId( state ) ||
-			getMostRecentlySelectedSiteId( state ) ||
-			getPrimarySiteId( state );
+		const selectedSiteId = getSelectedSiteId( state );
+		// Falls back to using the user's primary site only for UI that needs a concrete site
+		// outside a site-specific route, such as the launch button and celebration modal.
+		const siteIdForSiteUi =
+			selectedSiteId || getMostRecentlySelectedSiteId( state ) || getPrimarySiteId( state );
 		const sectionJitmPath = getMessagePathForJITM( currentRoute );
 		const isJetpackLogin = currentRoute.startsWith( '/log-in/jetpack' );
 		const isJetpack =
-			( isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) ) ||
+			( isJetpackSite( state, selectedSiteId ) && ! isAtomicSite( state, selectedSiteId ) ) ||
 			currentRoute.startsWith( '/checkout/jetpack' );
 		const isWooJPC =
 			[ 'jetpack-connect', 'login' ].includes( sectionName ) && isWooJPCFlow( state );
@@ -490,7 +489,7 @@ export default withCurrentRoute(
 
 		const sidebarType = getSidebarType( {
 			state,
-			siteId,
+			siteId: selectedSiteId,
 			section: currentSection,
 			route: currentRoute,
 		} );
@@ -570,7 +569,7 @@ export default withCurrentRoute(
 
 		const hasUniversalHeader =
 			dashboardOptIn &&
-			! siteId &&
+			! selectedSiteId &&
 			( isEnabledThemeUniversalHeader || isEnabledPluginsUniversalHeader );
 
 		return {
@@ -595,9 +594,9 @@ export default withCurrentRoute(
 			currentLayoutFocus: getCurrentLayoutFocus( state ),
 			colorScheme,
 			needsColorScheme,
-			isFetchingColorScheme: isFetchingAdminColor( state, siteId ),
-			siteId,
-			site: getSite( state, siteId ),
+			isFetchingColorScheme: isFetchingAdminColor( state, selectedSiteId ),
+			siteId: siteIdForSiteUi,
+			site: getSite( state, siteIdForSiteUi ),
 			// We avoid requesting sites in the Jetpack Connect authorization step, because this would
 			// request all sites before authorization has finished. That would cause the "all sites"
 			// request to lack the newly authorized site, and when the request finishes after

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -32,6 +32,7 @@ export function getSidebarType( params: GetSidebarTypeParams ): SidebarType {
 		group === 'me' ||
 		group === 'reader' ||
 		group === 'sites-dashboard' ||
+		( group === 'sites' && route === '/themes' ) ||
 		( group === 'sites' && ! siteId ) ||
 		( group === 'sites' && siteId && route === '/domains/manage' )
 	) {

--- a/client/state/global-sidebar/test/selectors.ts
+++ b/client/state/global-sidebar/test/selectors.ts
@@ -46,6 +46,7 @@ describe( 'getSidebarType', () => {
 		[ null, '/plugins/scheduled-updates', SidebarType.Global ],
 		[ null, '/me', SidebarType.Global ],
 		[ null, '/reader', SidebarType.Global ],
+		[ siteDefault, '/themes', SidebarType.Global ],
 
 		[ site, '/overview/example.com', SidebarType.GlobalCollapsed ],
 		[ site, '/hosting-features/example.com', SidebarType.GlobalCollapsed ],


### PR DESCRIPTION
## Proposed Changes

* Treat the all-sites `/themes` route as a global-sidebar route even when a site id is available.
* Add selector coverage for the regression case where `/themes` receives a site id and should still resolve to `SidebarType.Global`.

## Why are these changes being made?

This fixes a bug introduced in #109896 where navigating from `/sites` to `/themes` could make the left sidebar switch to the site-specific dark sidebar. After updating this branch against trunk, the layout-level launch fallback split now lives in the base branch; this PR keeps the remaining diff focused on making the sidebar selector itself resilient for `/themes`.

The important behavior is that `/themes` is an all-sites browsing surface, not a selected-site management route. Even if a fallback or previously selected site id is present, the route should keep the same global sidebar treatment as `/sites`, `/plugins`, and other siteless dashboard routes.

## Testing Instructions

1. Open `/sites`.
2. Click `Themes` in the left sidebar.
3. Confirm the left sidebar keeps the same global sidebar styling and does not switch to the site-specific dark sidebar.
4. Confirm `/themes` loads normally.
5. Confirm automated selector coverage, linting, and client type checking pass locally.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
