### PR TITLE
Renewal pricing: display the correct billing text for monthly intro offers

### DIFF
--- a/packages/plans-grid-next/src/hooks/data-store/get-renewal-pricing-text.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/get-renewal-pricing-text.ts
@@ -1,6 +1,7 @@
 import {
 	PLAN_ANNUAL_PERIOD,
 	PLAN_BIENNIAL_PERIOD,
+	PLAN_MONTHLY_PERIOD,
 	PLAN_TRIENNIAL_PERIOD,
 } from '@automattic/calypso-products';
 import { formatCurrency } from '@automattic/number-formatters';
@@ -34,10 +35,21 @@ export function getRenewalPricingText( {
 		return null;
 	}
 
+	if ( ! showBillingDescriptionForIncreasedRenewalPrice ) {
+		return null;
+	}
+
 	const formattedMonthlyPrice = formatCurrency( monthlyPrice, currencyCode, {
 		stripZeros: true,
 		isSmallestUnit: true,
 	} );
+
+	if ( billingPeriod === PLAN_MONTHLY_PERIOD ) {
+		return translate( 'Auto-renews at %(price)s per month. Billed every month.', {
+			args: { price: formattedMonthlyPrice },
+			comment: '%(price)s is a formatted price like $10',
+		} );
+	}
 
 	// Determine the billing period in months
 	let billingMonths = 12; // default to annual
@@ -50,17 +62,12 @@ export function getRenewalPricingText( {
 		billingMonths = 12;
 	}
 
-	// Renewal pricing experiment: crossed-price copy for all active variants
-	if ( showBillingDescriptionForIncreasedRenewalPrice ) {
-		return translate( 'Auto-renews at %(price)s per month. Billed every %(months)s months.', {
-			args: {
-				price: formattedMonthlyPrice,
-				months: billingMonths,
-			},
-			comment:
-				'%(price)s is a formatted price like $10, %(months)s is the billing period in months (12, 24, or 36)',
-		} );
-	}
-
-	return null;
+	return translate( 'Auto-renews at %(price)s per month. Billed every %(months)s months.', {
+		args: {
+			price: formattedMonthlyPrice,
+			months: billingMonths,
+		},
+		comment:
+			'%(price)s is a formatted price like $10, %(months)s is the billing period in months (12, 24, or 36)',
+	} );
 }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-17170

## Proposed Changes

* Fix the billing details text for monthly introductory offers to say "Billed every month." instead of "Billed every 12 months."

**Before**
<img width="1294" height="775" alt="Screenshot 2026-05-19 at 18 00 32" src="https://github.com/user-attachments/assets/47045969-3c56-47f4-b35f-80bb1d19fa61" />

**After**
<img width="1294" height="775" alt="Screenshot 2026-05-19 at 17 50 36" src="https://github.com/user-attachments/assets/1a609d62-b17e-46e5-a4dc-dafa17bd236b" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Previously we didn't need the text for the monthly introductory offers and the default was the "12 months".

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using the large_increase variant, navigate to the /plans page, select the Monthly interval and confirm that it shows the correct billing text.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
