### PR TITLE
Reader sidebar: cap social connections list and add View more link

### DIFF
--- a/client/reader/sidebar/reader-sidebar-connections/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-connections/index.tsx
@@ -261,7 +261,7 @@ function ReaderSidebarConnections( { path }: Props ) {
 							href={ BASE_PATH }
 							onClick={ recordViewMoreClick }
 						>
-							<span>{ translate( 'View more' ) }</span>
+							<span>{ translate( 'View More' ) }</span>
 						</MenuItemLink>
 					</MenuItem>
 				) }

--- a/client/reader/sidebar/reader-sidebar-connections/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-connections/index.tsx
@@ -11,6 +11,7 @@ import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
 import { DEFAULT_ATMOSPHERE_TAB } from 'calypso/reader/atmosphere/helper';
 import { DEFAULT_FEDIVERSE_TAB } from 'calypso/reader/fediverse/helper';
 import { DEFAULT_MASTODON_TAB } from 'calypso/reader/mastodon/helper';
+import { MenuItem, MenuItemLink } from 'calypso/reader/sidebar/menu';
 import { SocialAddAccountMenuItem } from 'calypso/reader/sidebar/social';
 import { useDispatch } from 'calypso/state';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
@@ -30,6 +31,7 @@ interface Props {
 
 const BASE_PATH = '/reader/connections';
 const NEW_CONNECTION_PATH = `${ BASE_PATH }/new`;
+const CONNECTION_DISPLAY_CUTOFF = 10;
 const PROTOCOL_PATHS: Record< ConnectionProtocol, string > = {
 	atmosphere: '/reader/atmosphere',
 	mastodon: '/reader/mastodon',
@@ -188,6 +190,32 @@ function ReaderSidebarConnections( { path }: Props ) {
 		dispatch( recordReaderTracksEvent( 'calypso_reader_sidebar_connections_add_account_clicked' ) );
 	};
 
+	let connectionsToShow = connections.slice( 0, CONNECTION_DISPLAY_CUTOFF );
+
+	// Keep the currently active connection visible even when it falls
+	// outside the cutoff, so the user never loses the row representing
+	// the page they're on.
+	if ( active ) {
+		const activeConnection = connections.find(
+			( c ) => c.protocol === active.protocol && c.id === active.id
+		);
+		if ( activeConnection && ! connectionsToShow.includes( activeConnection ) ) {
+			connectionsToShow = [ ...connectionsToShow, activeConnection ];
+		}
+	}
+
+	// Compare against what we actually render: if active-preservation
+	// already surfaced the overflow row, there's nothing left to reveal.
+	const hasMoreConnections = connections.length > connectionsToShow.length;
+
+	const recordViewMoreClick = () => {
+		dispatch(
+			recordReaderTracksEvent( 'calypso_reader_sidebar_connections_view_more_clicked', {
+				connections_total_count: connections.length,
+			} )
+		);
+	};
+
 	const handleMainClick = () => {
 		recordHeaderClick();
 		if ( ! isOpen ) {
@@ -218,7 +246,7 @@ function ReaderSidebarConnections( { path }: Props ) {
 				materialIcon={ null }
 				materialIconStyle={ null }
 			>
-				{ connections.map( ( connection ) => (
+				{ connectionsToShow.map( ( connection ) => (
 					<ConnectionMenuItem
 						key={ `${ connection.protocol }-${ connection.id }` }
 						connection={ connection }
@@ -226,6 +254,17 @@ function ReaderSidebarConnections( { path }: Props ) {
 						onClick={ () => recordConnectionClick( connection ) }
 					/>
 				) ) }
+				{ hasMoreConnections && (
+					<MenuItem selected={ false }>
+						<MenuItemLink
+							className="view-more-link"
+							href={ BASE_PATH }
+							onClick={ recordViewMoreClick }
+						>
+							<span>{ translate( 'View more' ) }</span>
+						</MenuItemLink>
+					</MenuItem>
+				) }
 				{ showEmptyHint && (
 					<li className="screen-reader-text">
 						{ translate( 'Nothing here yet — connect one below.' ) }


### PR DESCRIPTION
Fixes CM-756

## Proposed Changes

* Cap the inline list of social connections in the Reader sidebar's "Social" section at 10 (`CONNECTION_DISPLAY_CUTOFF`).
* When more than 10 connections exist, render a "View more" item that links to `/reader/connections`, so the full list is one click away.
* Keep the currently active connection visible even when it falls outside the cutoff, so the user never loses the row representing the page they're on.
* Track clicks on the new link with `calypso_reader_sidebar_connections_view_more_clicked`.

## Why are these changes being made?

The "Social" section rendered every connected Bluesky / Mastodon / Fediverse account inline. Users with many connections ended up with a very tall sidebar list that pushed the rest of the Reader navigation off-screen. Capping the list and linking out to the unified `/reader/connections` view keeps the sidebar scannable without hiding access to the full list.

## Testing Instructions

* Enable the `reader/social` feature flag.
* With fewer than 10 connections: the sidebar behaves exactly as before — no "View more" row.
* With more than 10 connections: only the first 10 (sorted Bluesky → Mastodon → Fediverse, then alphabetically) show, "View more" appears, and clicking it routes to `/reader/connections`.
* Visit a connection that sits past the cutoff (e.g. the 12th alphabetical Mastodon account): that row should be appended to the visible list so the active page is reflected in the sidebar, even though it's beyond the cutoff.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?