### PR TITLE
Update @automattic/number-formatters to ^1.1.9

### DIFF
--- a/apps/blaze-dashboard/package.json
+++ b/apps/blaze-dashboard/package.json
@@ -33,7 +33,7 @@
 		"@automattic/calypso-url": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
-		"@automattic/number-formatters": "^1.1.0",
+		"@automattic/number-formatters": "^1.1.9",
 		"@tanstack/react-query": "^5.83.0",
 		"@wordpress/components": "^30.9.0",
 		"@wordpress/data": "^10.23.0",

--- a/apps/happy-blocks/package.json
+++ b/apps/happy-blocks/package.json
@@ -29,7 +29,7 @@
 		"@automattic/calypso-products": "workspace:^",
 		"@automattic/color-studio": "^4.1.0",
 		"@automattic/components": "workspace:^",
-		"@automattic/number-formatters": "^1.1.0",
+		"@automattic/number-formatters": "^1.1.9",
 		"@automattic/typography": "workspace:^",
 		"@automattic/wp-babel-makepot": "workspace:^",
 		"@automattic/wpcom-template-parts": "workspace:^",

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/languages": "workspace:^",
 		"@automattic/launchpad": "workspace:^",
-		"@automattic/number-formatters": "^1.1.0",
+		"@automattic/number-formatters": "^1.1.9",
 		"@automattic/omnibar": "workspace:^",
 		"@automattic/plans-grid-next": "workspace:^",
 		"@automattic/privacy-toolset": "workspace:^",

--- a/packages/calypso-products/package.json
+++ b/packages/calypso-products/package.json
@@ -47,7 +47,7 @@
 		"@automattic/calypso-config": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
-		"@automattic/number-formatters": "^1.1.0",
+		"@automattic/number-formatters": "^1.1.9",
 		"@automattic/shopping-cart": "workspace:^",
 		"@automattic/urls": "workspace:^",
 		"i18n-calypso": "workspace:^"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -49,7 +49,7 @@
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/load-script": "workspace:^",
 		"@automattic/material-design-icons": "workspace:^",
-		"@automattic/number-formatters": "^1.1.0",
+		"@automattic/number-formatters": "^1.1.9",
 		"@automattic/typography": "workspace:^",
 		"@automattic/ui": "workspace:^",
 		"@automattic/viewport-react": "workspace:^",

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -51,7 +51,7 @@
 		"@automattic/design-types": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/js-utils": "workspace:^",
-		"@automattic/number-formatters": "^1.1.0",
+		"@automattic/number-formatters": "^1.1.9",
 		"@automattic/oauth-token": "workspace:^",
 		"@automattic/shopping-cart": "workspace:^",
 		"@tanstack/react-query": "^5.83.0",

--- a/packages/mini-cart/package.json
+++ b/packages/mini-cart/package.json
@@ -47,7 +47,7 @@
 	"homepage": "https://github.com/Automattic/wp-calypso/tree/HEAD/packages/mini-cart#readme",
 	"dependencies": {
 		"@automattic/composite-checkout": "workspace:^",
-		"@automattic/number-formatters": "^1.1.0",
+		"@automattic/number-formatters": "^1.1.9",
 		"@automattic/shopping-cart": "workspace:^",
 		"@automattic/wpcom-checkout": "workspace:^",
 		"@emotion/styled": "^11.11.0",

--- a/packages/plans-grid-next/package.json
+++ b/packages/plans-grid-next/package.json
@@ -49,7 +49,7 @@
 		"@automattic/calypso-products": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",
-		"@automattic/number-formatters": "^1.1.0",
+		"@automattic/number-formatters": "^1.1.9",
 		"@automattic/onboarding": "workspace:^",
 		"@automattic/typography": "workspace:^",
 		"@emotion/react": "11.11.1",

--- a/packages/wpcom-checkout/package.json
+++ b/packages/wpcom-checkout/package.json
@@ -49,7 +49,7 @@
 		"@automattic/components": "workspace:^",
 		"@automattic/composite-checkout": "workspace:^",
 		"@automattic/js-utils": "workspace:^",
-		"@automattic/number-formatters": "^1.1.0",
+		"@automattic/number-formatters": "^1.1.9",
 		"@automattic/shopping-cart": "workspace:^",
 		"@emotion/styled": "^11.11.0",
 		"@fnando/cnpj": "2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -313,7 +313,7 @@ __metadata:
     "@automattic/components": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
     "@automattic/languages": "workspace:^"
-    "@automattic/number-formatters": "npm:^1.1.0"
+    "@automattic/number-formatters": "npm:^1.1.9"
     "@automattic/webpack-extensive-lodash-replacement-plugin": "workspace:^"
     "@automattic/webpack-inline-constant-exports-plugin": "workspace:^"
     "@automattic/wp-babel-makepot": "workspace:^"
@@ -659,7 +659,7 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
-    "@automattic/number-formatters": "npm:^1.1.0"
+    "@automattic/number-formatters": "npm:^1.1.9"
     "@automattic/shopping-cart": "workspace:^"
     "@automattic/urls": "workspace:^"
     "@wordpress/data": "npm:^10.23.0"
@@ -904,7 +904,7 @@ __metadata:
     "@automattic/i18n-utils": "workspace:^"
     "@automattic/load-script": "workspace:^"
     "@automattic/material-design-icons": "workspace:^"
-    "@automattic/number-formatters": "npm:^1.1.0"
+    "@automattic/number-formatters": "npm:^1.1.9"
     "@automattic/typography": "workspace:^"
     "@automattic/ui": "workspace:^"
     "@automattic/viewport-react": "workspace:^"
@@ -1061,7 +1061,7 @@ __metadata:
     "@automattic/design-types": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
     "@automattic/js-utils": "workspace:^"
-    "@automattic/number-formatters": "npm:^1.1.0"
+    "@automattic/number-formatters": "npm:^1.1.9"
     "@automattic/oauth-token": "workspace:^"
     "@automattic/shopping-cart": "workspace:^"
     "@remix-run/router": "npm:^1.5.0"
@@ -1793,7 +1793,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/composite-checkout": "workspace:^"
-    "@automattic/number-formatters": "npm:^1.1.0"
+    "@automattic/number-formatters": "npm:^1.1.9"
     "@automattic/shopping-cart": "workspace:^"
     "@automattic/wpcom-checkout": "workspace:^"
     "@emotion/styled": "npm:^11.11.0"
@@ -1854,7 +1854,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/number-formatters@npm:^1.1.0, @automattic/number-formatters@npm:^1.1.2, @automattic/number-formatters@npm:^1.1.7":
+"@automattic/number-formatters@npm:^1.1.2, @automattic/number-formatters@npm:^1.1.7":
   version: 1.1.7
   resolution: "@automattic/number-formatters@npm:1.1.7"
   dependencies:
@@ -1862,6 +1862,17 @@ __metadata:
     debug: "npm:^4.4.0"
     tslib: "npm:^2.5.0"
   checksum: b93ea434c8b1e10cb54c6f4229fc344168f83fefa7693ef595dd2a679b51792532411703f52e88a126fd12f2ac52350e3ae4d8351e60b732eabf1da46414335d
+  languageName: node
+  linkType: hard
+
+"@automattic/number-formatters@npm:^1.1.9":
+  version: 1.1.9
+  resolution: "@automattic/number-formatters@npm:1.1.9"
+  dependencies:
+    "@wordpress/date": "npm:^5.19.0"
+    debug: "npm:^4.4.0"
+    tslib: "npm:^2.5.0"
+  checksum: e43626d41a8c3fbb217cfbc990e3303793888fa880999a5cf42f29d471a8a9e3eec8e3607f139f19d58c87bf960d4b0b7e044fdf8a29d18adaae3dc98c9af3d3
   languageName: node
   linkType: hard
 
@@ -2062,7 +2073,7 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/data-stores": "workspace:^"
-    "@automattic/number-formatters": "npm:^1.1.0"
+    "@automattic/number-formatters": "npm:^1.1.9"
     "@automattic/onboarding": "workspace:^"
     "@automattic/shopping-cart": "workspace:^"
     "@automattic/typography": "workspace:^"
@@ -2619,7 +2630,7 @@ __metadata:
     "@automattic/components": "workspace:^"
     "@automattic/composite-checkout": "workspace:^"
     "@automattic/js-utils": "workspace:^"
-    "@automattic/number-formatters": "npm:^1.1.0"
+    "@automattic/number-formatters": "npm:^1.1.9"
     "@automattic/shopping-cart": "workspace:^"
     "@emotion/styled": "npm:^11.11.0"
     "@fnando/cnpj": "npm:2.0.0"
@@ -19607,7 +19618,7 @@ __metadata:
     "@automattic/calypso-products": "workspace:^"
     "@automattic/color-studio": "npm:^4.1.0"
     "@automattic/components": "workspace:^"
-    "@automattic/number-formatters": "npm:^1.1.0"
+    "@automattic/number-formatters": "npm:^1.1.9"
     "@automattic/typography": "workspace:^"
     "@automattic/wp-babel-makepot": "workspace:^"
     "@automattic/wpcom-template-parts": "workspace:^"
@@ -33587,7 +33598,7 @@ __metadata:
     "@automattic/i18n-utils": "workspace:^"
     "@automattic/languages": "workspace:^"
     "@automattic/launchpad": "workspace:^"
-    "@automattic/number-formatters": "npm:^1.1.0"
+    "@automattic/number-formatters": "npm:^1.1.9"
     "@automattic/omnibar": "workspace:^"
     "@automattic/plans-grid-next": "workspace:^"
     "@automattic/privacy-toolset": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1854,18 +1854,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/number-formatters@npm:^1.1.2, @automattic/number-formatters@npm:^1.1.7":
-  version: 1.1.7
-  resolution: "@automattic/number-formatters@npm:1.1.7"
-  dependencies:
-    "@wordpress/date": "npm:^5.19.0"
-    debug: "npm:^4.4.0"
-    tslib: "npm:^2.5.0"
-  checksum: b93ea434c8b1e10cb54c6f4229fc344168f83fefa7693ef595dd2a679b51792532411703f52e88a126fd12f2ac52350e3ae4d8351e60b732eabf1da46414335d
-  languageName: node
-  linkType: hard
-
-"@automattic/number-formatters@npm:^1.1.9":
+"@automattic/number-formatters@npm:^1.1.2, @automattic/number-formatters@npm:^1.1.7, @automattic/number-formatters@npm:^1.1.9":
   version: 1.1.9
   resolution: "@automattic/number-formatters@npm:1.1.9"
   dependencies:


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/SHILL-1761/

## Proposed changes

This bumps `@automattic/number-formatters` from `^1.1.0` to `^1.1.9` across all package.json files in the repo that depend on it, picking up the currency-formatting fixes published in that range.

Before             |  After
:-------------------------:|:-------------------------:
<img width="1100" height="431" alt="Screenshot 2026-05-19 at 2 58 14 PM" src="https://github.com/user-attachments/assets/a3969f1a-2ace-4872-89d3-683cd316251c" /> | <img width="1105" height="425" alt="Screenshot 2026-05-19 at 2 58 19 PM" src="https://github.com/user-attachments/assets/a620260e-0af8-4fc1-941d-4fa0f22e6cd6" />


## Why are these changes being made?

A CLDR update (shipped via ICU 78.2) changed the smallest unit for `IDR` from `0.01` to `1`, which broke `isSmallestUnit: true` handling in our currency formatter and produced visibly wrong prices in checkout (e.g. HUF Premium showing as Ft 2,700,000/year instead of ~Ft 27,000/year — a 100x inflation across all billing intervals). This also affects `HUF`.

This change appears to only be in Chrome right now. Firefox and Safari still treat `IDR` as having 2 decimal places. Because of this, we need to hard-code the number of decimal places in our rendering package to make sure it is consistent across browsers.

`@automattic/number-formatters` 1.1.9 contains the fixes for this behavior (see https://github.com/Automattic/jetpack/pull/48967). Pulling it into Calypso ensures every consumer in this repo — checkout, plans grid, mini-cart, Blaze Dashboard, etc. — uses the corrected zero-decimal currency handling.

## Testing instructions

* Set your currency to IDR.
* Visit somewhere that displays prices, like https://wordpress.com/plans or https://wordpress.com/checkout
* Confirm displayed plan prices match the expected amounts (no 100x inflation, no spurious decimals on zero-decimal currencies).
* Sanity-check checkout for a 2-decimal currency (e.g. `USD`, `EUR`) to confirm no regression.
* Repeat this change in Chrome, Firefox, and Safari.