### PR TITLE
Add loading and error states to subscribers overview

### DIFF
--- a/client/my-sites/stats/stats-subscribers-overview/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-overview/index.tsx
@@ -1,6 +1,8 @@
+import { Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import CountCard from 'calypso/my-sites/stats/components/highlight-cards/count-card';
+import StatsError from 'calypso/my-sites/stats/stats-error';
 import useSubscribersOverview from 'calypso/my-sites/stats/hooks/use-subscribers-overview';
 
 interface SubscribersOverviewProps {
@@ -10,13 +12,14 @@ interface SubscribersOverviewProps {
 const SubscribersOverview: React.FC< SubscribersOverviewProps > = ( { siteId } ) => {
 	const { isLoading, isError, overviewData } = useSubscribersOverview( siteId );
 	const translate = useTranslate();
+	const showSpinner = isLoading && overviewData.length === 0;
 
 	return (
 		<div className="subscribers-overview highlight-cards">
 			<div className="highlight-cards-list">
+				{ showSpinner && <Spinner /> }
 				{ overviewData.map( ( { count, heading, note }, index ) => {
 					return (
-						// TODO: Communicate loading vs error state to the user.
 						<CountCard
 							key={ index }
 							heading={ heading }
@@ -28,6 +31,7 @@ const SubscribersOverview: React.FC< SubscribersOverviewProps > = ( { siteId } )
 					);
 				} ) }
 			</div>
+			{ isError && ! isLoading && <StatsError /> }
 		</div>
 	);
 };


### PR DESCRIPTION
Part of #

## Proposed Changes

* Add loading state handling to the subscribers overview component
* Add error state handling when subscriber data fails to load
* Improve user feedback during async data fetching
* Keep implementation minimal and aligned with existing Calypso UI patterns

## Why are these changes being made?

The subscribers overview component did not clearly handle loading or error states, which could lead to confusing or incomplete UI feedback for users.

This change improves the user experience by:

* showing appropriate loading feedback while data is being fetched
* displaying a clearer state when data retrieval fails
* making the component behavior more predictable and resilient

## Testing Instructions

* Open the subscribers overview section
* Verify loading UI appears while data is fetching
* Verify error UI appears when the request fails
* Confirm normal rendering still works when data loads successfully
* Check browser console for errors

## Pre-merge Checklist

* [x] Has the general commit checklist been followed?
* [ ] Have you written new tests for your changes?
* [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
* [x] Have you checked for TypeScript, React or other console errors?
* [ ] For UI changes, have you tested the affected components in dark mode?
* [ ] Have you tested accessibility for your changes?

