### PR TITLE
DIFM: fix content form page-level saves on reload

### DIFF
--- a/client/signup/difm/page-instances.ts
+++ b/client/signup/difm/page-instances.ts
@@ -16,8 +16,3 @@ export interface PageInstance {
 export function newInstanceId(): string {
 	return crypto.randomUUID();
 }
-
-/** Build PageInstance[] from a list of page types (e.g. API selected_page_titles fallback). */
-export function synthesizeInstancesFromTitles( titles: PageId[] ): PageInstance[] {
-	return titles.map( ( type ) => ( { id: newInstanceId(), type } ) );
-}

--- a/client/state/signup/steps/website-content/actions.ts
+++ b/client/state/signup/steps/website-content/actions.ts
@@ -4,6 +4,7 @@ import {
 	PageId,
 	CUSTOM_PAGE,
 } from 'calypso/signup/difm/constants';
+import { newInstanceId } from 'calypso/signup/difm/page-instances';
 import {
 	SIGNUP_STEPS_WEBSITE_CONTENT_UPDATE_CURRENT_INDEX,
 	SIGNUP_STEPS_WEBSITE_CONTENT_MEDIA_UPLOAD_COMPLETED,
@@ -262,7 +263,7 @@ export function initializeWebsiteContentForm(
 		usedIndexById[ pageId ] = usedIndex + 1;
 
 		return {
-			id: pageId,
+			id: newInstanceId(),
 			type: pageId,
 			title: getInitialTitle( {
 				pageId,

--- a/client/state/signup/steps/website-content/actions.ts
+++ b/client/state/signup/steps/website-content/actions.ts
@@ -4,7 +4,6 @@ import {
 	PageId,
 	CUSTOM_PAGE,
 } from 'calypso/signup/difm/constants';
-import { newInstanceId } from 'calypso/signup/difm/page-instances';
 import {
 	SIGNUP_STEPS_WEBSITE_CONTENT_UPDATE_CURRENT_INDEX,
 	SIGNUP_STEPS_WEBSITE_CONTENT_MEDIA_UPLOAD_COMPLETED,
@@ -263,7 +262,7 @@ export function initializeWebsiteContentForm(
 		usedIndexById[ pageId ] = usedIndex + 1;
 
 		return {
-			id: newInstanceId(),
+			id: pageId,
 			type: pageId,
 			title: getInitialTitle( {
 				pageId,

--- a/client/state/signup/steps/website-content/hooks/use-get-website-content-query.ts
+++ b/client/state/signup/steps/website-content/hooks/use-get-website-content-query.ts
@@ -1,9 +1,49 @@
 import { mapRecordKeysRecursively, snakeToCamelCase } from '@automattic/js-utils';
 import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
-import { synthesizeInstancesFromTitles } from 'calypso/signup/difm/page-instances';
 import type { WebsiteContentResponseDTO, WebsiteContentServerState } from '../types';
 import type { SiteId, SiteSlug } from 'calypso/types';
+
+export function selectWebsiteContent( data: WebsiteContentResponseDTO ): WebsiteContentServerState {
+	const selectedPageTitles = data.selected_page_titles ?? [];
+	const pages = data.pages?.length
+		? data.pages.map( ( page: Record< string, unknown > ) =>
+				mapRecordKeysRecursively( page, snakeToCamelCase )
+		  )
+		: [];
+	// Server-provided instances win. Otherwise pair stored pages with
+	// selected_page_titles positionally (server preserves order) so
+	// instance.id === stored page.id and the saved-content lookup hits —
+	// critical for distinguishing multiple CUSTOM_PAGE entries. When
+	// lengths diverge, leave instances undefined and let the reducer
+	// fall through to its type-based path.
+	const selectedPageInstances =
+		data.selected_page_instances?.map( ( i ) => ( {
+			id: i.id,
+			type: i.type,
+			...( i.title ? { title: i.title } : {} ),
+		} ) ) ??
+		( pages.length === selectedPageTitles.length && pages.length > 0
+			? pages.map( ( p: Record< string, unknown >, i: number ) => {
+					const title = p.title;
+					return {
+						id: String( p.id ),
+						type: selectedPageTitles[ i ],
+						...( typeof title === 'string' && title ? { title } : {} ),
+					};
+			  } )
+			: undefined );
+	return {
+		selectedPageTitles,
+		selectedPageInstances,
+		isWebsiteContentSubmitted: data.is_website_content_submitted,
+		isStoreFlow: data.is_store_flow,
+		pages,
+		siteLogoUrl: data.site_logo_url,
+		genericFeedback: data.generic_feedback,
+		searchTerms: data.search_terms,
+	};
+}
 
 export function useGetWebsiteContentQuery( siteSlugOrId: SiteSlug | SiteId | undefined | null ) {
 	return useQuery< WebsiteContentResponseDTO, unknown, WebsiteContentServerState >( {
@@ -15,26 +55,7 @@ export function useGetWebsiteContentQuery( siteSlugOrId: SiteSlug | SiteId | und
 			} ),
 		enabled: !! siteSlugOrId,
 		meta: { persist: false },
-		select: ( data: WebsiteContentResponseDTO ) => {
-			const selectedPageTitles = data.selected_page_titles ?? [];
-			const selectedPageInstances =
-				data.selected_page_instances?.map( ( i ) => ( { id: i.id, type: i.type } ) ) ??
-				synthesizeInstancesFromTitles( selectedPageTitles );
-			return {
-				selectedPageTitles,
-				selectedPageInstances,
-				isWebsiteContentSubmitted: data.is_website_content_submitted,
-				isStoreFlow: data.is_store_flow,
-				pages: data.pages?.length
-					? data.pages.map( ( page: Record< string, unknown > ) =>
-							mapRecordKeysRecursively( page, snakeToCamelCase )
-					  )
-					: [],
-				siteLogoUrl: data.site_logo_url,
-				genericFeedback: data.generic_feedback,
-				searchTerms: data.search_terms,
-			};
-		},
+		select: selectWebsiteContent,
 		staleTime: Infinity,
 	} );
 }

--- a/client/state/signup/steps/website-content/test/reducer.ts
+++ b/client/state/signup/steps/website-content/test/reducer.ts
@@ -1,4 +1,13 @@
 // @ts-nocheck - TODO: Fix TypeScript issues
+let mockInstanceIdCounter = 0;
+jest.mock( 'calypso/signup/difm/page-instances', () => {
+	const actual = jest.requireActual( 'calypso/signup/difm/page-instances' );
+	return {
+		...actual,
+		newInstanceId: jest.fn( () => `instance-${ ++mockInstanceIdCounter }` ),
+	};
+} );
+
 import { SIGNUP_COMPLETE_RESET } from 'calypso/state/action-types';
 import {
 	ABOUT_PAGE,
@@ -99,6 +108,10 @@ const translatedPageTitles = {
 };
 
 describe( 'reducer', () => {
+	beforeEach( () => {
+		mockInstanceIdCounter = 0;
+	} );
+
 	test( 'should update the current index', () => {
 		expect(
 			websiteContentCollectionReducer(
@@ -134,7 +147,7 @@ describe( 'reducer', () => {
 				...initialTestState.websiteContent,
 				pages: [
 					{
-						id: CONTACT_PAGE,
+						id: 'instance-1',
 						type: CONTACT_PAGE,
 						title: 'Contact',
 						content: '',
@@ -147,7 +160,7 @@ describe( 'reducer', () => {
 						],
 					},
 					{
-						id: VIDEO_GALLERY_PAGE,
+						id: 'instance-2',
 						type: VIDEO_GALLERY_PAGE,
 						title: 'Video Gallery',
 						content: '',
@@ -160,7 +173,7 @@ describe( 'reducer', () => {
 						],
 					},
 					{
-						id: PORTFOLIO_PAGE,
+						id: 'instance-3',
 						type: PORTFOLIO_PAGE,
 						title: 'Portfolio',
 						content: '',
@@ -226,7 +239,7 @@ describe( 'reducer', () => {
 				...initialTestState.websiteContent,
 				pages: [
 					{
-						id: CONTACT_PAGE,
+						id: 'instance-1',
 						type: CONTACT_PAGE,
 						title: 'Contact',
 						content: 'test contact page content',
@@ -239,7 +252,7 @@ describe( 'reducer', () => {
 						useFillerContent: false,
 					},
 					{
-						id: VIDEO_GALLERY_PAGE,
+						id: 'instance-2',
 						type: VIDEO_GALLERY_PAGE,
 						title: 'Video Gallery',
 						content: 'test video gallery page content',
@@ -252,7 +265,7 @@ describe( 'reducer', () => {
 						useFillerContent: true,
 					},
 					{
-						id: PORTFOLIO_PAGE,
+						id: 'instance-3',
 						type: PORTFOLIO_PAGE,
 						title: 'Portfolio',
 						content: 'test portfolio page content',

--- a/client/state/signup/steps/website-content/test/reducer.ts
+++ b/client/state/signup/steps/website-content/test/reducer.ts
@@ -1,17 +1,9 @@
 // @ts-nocheck - TODO: Fix TypeScript issues
-let mockInstanceIdCounter = 0;
-jest.mock( 'calypso/signup/difm/page-instances', () => {
-	const actual = jest.requireActual( 'calypso/signup/difm/page-instances' );
-	return {
-		...actual,
-		newInstanceId: jest.fn( () => `instance-${ ++mockInstanceIdCounter }` ),
-	};
-} );
-
 import { SIGNUP_COMPLETE_RESET } from 'calypso/state/action-types';
 import {
 	ABOUT_PAGE,
 	CONTACT_PAGE,
+	CUSTOM_PAGE,
 	HOME_PAGE,
 	PORTFOLIO_PAGE,
 	VIDEO_GALLERY_PAGE,
@@ -107,10 +99,6 @@ const translatedPageTitles = {
 };
 
 describe( 'reducer', () => {
-	beforeEach( () => {
-		mockInstanceIdCounter = 0;
-	} );
-
 	test( 'should update the current index', () => {
 		expect(
 			websiteContentCollectionReducer(
@@ -146,7 +134,7 @@ describe( 'reducer', () => {
 				...initialTestState.websiteContent,
 				pages: [
 					{
-						id: 'instance-1',
+						id: CONTACT_PAGE,
 						type: CONTACT_PAGE,
 						title: 'Contact',
 						content: '',
@@ -159,7 +147,7 @@ describe( 'reducer', () => {
 						],
 					},
 					{
-						id: 'instance-2',
+						id: VIDEO_GALLERY_PAGE,
 						type: VIDEO_GALLERY_PAGE,
 						title: 'Video Gallery',
 						content: '',
@@ -172,7 +160,7 @@ describe( 'reducer', () => {
 						],
 					},
 					{
-						id: 'instance-3',
+						id: PORTFOLIO_PAGE,
 						type: PORTFOLIO_PAGE,
 						title: 'Portfolio',
 						content: '',
@@ -238,7 +226,7 @@ describe( 'reducer', () => {
 				...initialTestState.websiteContent,
 				pages: [
 					{
-						id: 'instance-1',
+						id: CONTACT_PAGE,
 						type: CONTACT_PAGE,
 						title: 'Contact',
 						content: 'test contact page content',
@@ -251,7 +239,7 @@ describe( 'reducer', () => {
 						useFillerContent: false,
 					},
 					{
-						id: 'instance-2',
+						id: VIDEO_GALLERY_PAGE,
 						type: VIDEO_GALLERY_PAGE,
 						title: 'Video Gallery',
 						content: 'test video gallery page content',
@@ -264,7 +252,7 @@ describe( 'reducer', () => {
 						useFillerContent: true,
 					},
 					{
-						id: 'instance-3',
+						id: PORTFOLIO_PAGE,
 						type: PORTFOLIO_PAGE,
 						title: 'Portfolio',
 						content: 'test portfolio page content',
@@ -283,6 +271,77 @@ describe( 'reducer', () => {
 				],
 			},
 		} );
+	} );
+
+	test( 'instances path: server-UUID-keyed pages with multiple CUSTOM_PAGE entries stay distinct on reload', () => {
+		// Reproduces HAPD-3969: the standard DIFM flow saves pages with UUID ids
+		// and reloads with the query hook pairing pages[i] to selected_page_titles[i].
+		// Each CUSTOM_PAGE instance must retain its own title/content/media.
+		const homeUuid = 'uuid-home-1';
+		const custom1Uuid = 'uuid-custom-1';
+		const custom2Uuid = 'uuid-custom-2';
+		expect(
+			websiteContentCollectionReducer(
+				{ ...initialState },
+				initializeWebsiteContentForm(
+					{
+						selectedPageTitles: [ HOME_PAGE, CUSTOM_PAGE, CUSTOM_PAGE ],
+						selectedPageInstances: [
+							{ id: homeUuid, type: HOME_PAGE },
+							{ id: custom1Uuid, type: CUSTOM_PAGE },
+							{ id: custom2Uuid, type: CUSTOM_PAGE },
+						],
+						isWebsiteContentSubmitted: false,
+						isStoreFlow: false,
+						pages: [
+							{
+								id: homeUuid,
+								title: 'Home',
+								content: 'home content',
+								media: [],
+								useFillerContent: false,
+							},
+							{
+								id: custom1Uuid,
+								title: 'Custom page 1 test 2',
+								content: 'Custom page 1 test 2',
+								media: [],
+								useFillerContent: false,
+							},
+							{
+								id: custom2Uuid,
+								title: '',
+								content: '',
+								media: [],
+								useFillerContent: false,
+							},
+						],
+						siteLogoUrl: '',
+						genericFeedback: '',
+						searchTerms: '',
+					},
+					translatedPageTitles
+				)
+			).websiteContent.pages
+		).toEqual( [
+			expect.objectContaining( {
+				id: homeUuid,
+				type: HOME_PAGE,
+				title: 'Home',
+				content: 'home content',
+			} ),
+			expect.objectContaining( {
+				id: custom1Uuid,
+				type: CUSTOM_PAGE,
+				title: 'Custom page 1 test 2',
+				content: 'Custom page 1 test 2',
+			} ),
+			expect.objectContaining( {
+				id: custom2Uuid,
+				type: CUSTOM_PAGE,
+				content: '',
+			} ),
+		] );
 	} );
 
 	test( 'image data should be accurately updated', () => {

--- a/client/state/signup/steps/website-content/test/use-get-website-content-query.ts
+++ b/client/state/signup/steps/website-content/test/use-get-website-content-query.ts
@@ -1,0 +1,119 @@
+/**
+ * @jest-environment jsdom
+ */
+import { HOME_PAGE, ABOUT_PAGE, CONTACT_PAGE, CUSTOM_PAGE } from 'calypso/signup/difm/constants';
+import { selectWebsiteContent } from '../hooks/use-get-website-content-query';
+import type { WebsiteContentResponseDTO } from '../types';
+
+const baseResponse: WebsiteContentResponseDTO = {
+	pages: [],
+	site_logo_url: '',
+	generic_feedback: '',
+	search_terms: '',
+	selected_page_titles: [],
+	is_website_content_submitted: false,
+	is_store_flow: false,
+};
+
+describe( 'selectWebsiteContent', () => {
+	test( 'uses server-provided selected_page_instances when present', () => {
+		const result = selectWebsiteContent( {
+			...baseResponse,
+			selected_page_titles: [ HOME_PAGE, CUSTOM_PAGE ],
+			selected_page_instances: [
+				{ id: 'srv-home', type: HOME_PAGE },
+				{ id: 'srv-custom', type: CUSTOM_PAGE, title: 'My Custom' },
+			],
+			pages: [
+				{ id: 'srv-home', title: 'Home', content: 'home c', media: [], use_filler_content: false },
+				{
+					id: 'srv-custom',
+					title: 'My Custom',
+					content: 'custom c',
+					media: [],
+					use_filler_content: false,
+				},
+			],
+		} );
+		expect( result.selectedPageInstances ).toEqual( [
+			{ id: 'srv-home', type: HOME_PAGE },
+			{ id: 'srv-custom', type: CUSTOM_PAGE, title: 'My Custom' },
+		] );
+	} );
+
+	test( 'pairs pages with selected_page_titles positionally when instances are omitted (HAPD-3969 repro)', () => {
+		const result = selectWebsiteContent( {
+			...baseResponse,
+			selected_page_titles: [ HOME_PAGE, ABOUT_PAGE, CUSTOM_PAGE, CUSTOM_PAGE, CUSTOM_PAGE ],
+			pages: [
+				{ id: 'uuid-1', title: 'Home', content: '', media: [], use_filler_content: false },
+				{ id: 'uuid-2', title: 'About', content: '', media: [], use_filler_content: false },
+				{
+					id: 'uuid-3',
+					title: 'Custom page 1 test 2',
+					content: 'Custom page 1 test 2',
+					media: [],
+					use_filler_content: false,
+				},
+				{ id: 'uuid-4', title: '', content: '', media: [], use_filler_content: false },
+				{ id: 'uuid-5', title: '', content: '', media: [], use_filler_content: false },
+			],
+		} );
+		expect( result.selectedPageInstances ).toEqual( [
+			{ id: 'uuid-1', type: HOME_PAGE, title: 'Home' },
+			{ id: 'uuid-2', type: ABOUT_PAGE, title: 'About' },
+			{ id: 'uuid-3', type: CUSTOM_PAGE, title: 'Custom page 1 test 2' },
+			{ id: 'uuid-4', type: CUSTOM_PAGE },
+			{ id: 'uuid-5', type: CUSTOM_PAGE },
+		] );
+	} );
+
+	test( 'returns undefined selectedPageInstances when pages and titles length diverge', () => {
+		const result = selectWebsiteContent( {
+			...baseResponse,
+			selected_page_titles: [ HOME_PAGE, ABOUT_PAGE, CONTACT_PAGE ],
+			pages: [ { id: 'uuid-1', title: 'Home', content: '', media: [], use_filler_content: false } ],
+		} );
+		expect( result.selectedPageInstances ).toBeUndefined();
+		expect( result.selectedPageTitles ).toEqual( [ HOME_PAGE, ABOUT_PAGE, CONTACT_PAGE ] );
+	} );
+
+	test( 'returns undefined selectedPageInstances when no pages are returned yet', () => {
+		const result = selectWebsiteContent( {
+			...baseResponse,
+			selected_page_titles: [ HOME_PAGE, ABOUT_PAGE ],
+			pages: [],
+		} );
+		expect( result.selectedPageInstances ).toBeUndefined();
+	} );
+
+	test( 'maps response fields to camelCase', () => {
+		const result = selectWebsiteContent( {
+			...baseResponse,
+			selected_page_titles: [ HOME_PAGE ],
+			pages: [
+				{
+					id: 'uuid-1',
+					title: 'Home',
+					content: 'home content',
+					media: [],
+					use_filler_content: true,
+				},
+			],
+			site_logo_url: 'https://example.com/logo.png',
+			generic_feedback: 'fb',
+			search_terms: 'st',
+		} );
+		expect( result.pages[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				id: 'uuid-1',
+				title: 'Home',
+				content: 'home content',
+				useFillerContent: true,
+			} )
+		);
+		expect( result.siteLogoUrl ).toBe( 'https://example.com/logo.png' );
+		expect( result.genericFeedback ).toBe( 'fb' );
+		expect( result.searchTerms ).toBe( 'st' );
+	} );
+} );


### PR DESCRIPTION
Fixes [HAPD-3969](https://linear.app/a8c/issue/HAPD-3969)
Related to https://github.com/Automattic/wp-calypso/pull/110835

## Proposed Changes

* `client/state/signup/steps/website-content/hooks/use-get-website-content-query.ts`: extract `selectWebsiteContent` as a pure mapper. When the server omits `selected_page_instances`, pair stored `pages[i]` with `selected_page_titles[i]` positionally so the synthesized instance ids match the page ids the reducer looks up. When lengths diverge, leave `selectedPageInstances` undefined so the reducer falls through to the type-based path.
* `client/state/signup/steps/website-content/actions.ts`: align the type-based fallback so each generated `PageData` has `id: pageId` (instead of a fresh UUID per render), matching what `pagesById` keys by.
* `client/signup/difm/page-instances.ts`: remove the now-unused `synthesizeInstancesFromTitles` (it minted fresh UUIDs every fetch, which was the root cause).
* Tests: add a reducer test reproducing the multi-`CUSTOM_PAGE` reload scenario; add five mapper tests covering all branches of `selectWebsiteContent`.

## Why are these changes being made?

After the UUID switch in #110562, `useGetWebsiteContentQuery` synthesized instance arrays with fresh `crypto.randomUUID()` ids on every fetch when the server response did not include `selected_page_instances`. `initializeWebsiteContentForm` then built `pagesByInstanceId` keyed by server-stored page ids and looked it up by the freshly-minted instance ids — guaranteed miss, so every page initialized blank. The standard DIFM Express flow never receives `selected_page_instances`, so all page-level saves (title, content, media) appeared to drop on reload. Custom pages made the bug visible because users had actually entered content there; standard pages had nothing to lose.

Server response shows `pages` and `selected_page_titles` arrive in the same order, so pairing them positionally yields stable instance ids that match the stored page ids and recovers existing saved data without requiring a re-save.

## Testing Instructions

* `yarn typecheck-client` — clean for the touched files.
* `yarn eslint <touched files>` — clean.
* `yarn test-client client/state/signup/steps/website-content` — 3 suites, 23 tests passing.
* Smoke: `yarn start` → DIFM Express signup  `/start/do-it-for-me/new-or-existing-site`→ page picker → select multiple Custom pages → fill Custom Page 1 with title + content + image → save → reload `/start/site-content-collection/website-content?siteSlug=...`. Custom Page 1 should retain title, content, and media. Repeat for Custom Page 2 to confirm distinct instances stay distinct. Search Terms and Submit Content (already working) should continue to persist.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

Supersedes #110835.