### PR TITLE
APM: Add /hosting/apm/aggregate endpoint plumbing

### DIFF
--- a/packages/api-core/src/site-hosting-apm/fetchers.ts
+++ b/packages/api-core/src/site-hosting-apm/fetchers.ts
@@ -1,0 +1,15 @@
+import { wpcom } from '../wpcom-fetcher';
+import type { ApmAggregateParams, ApmAggregateResponse } from './types';
+
+export async function fetchSiteApmAggregate(
+	siteId: number,
+	params?: ApmAggregateParams
+): Promise< ApmAggregateResponse > {
+	return wpcom.req.get(
+		{
+			path: `/sites/${ siteId }/hosting/apm/aggregate`,
+			apiNamespace: 'wpcom/v2',
+		},
+		params ?? {}
+	);
+}

--- a/packages/api-core/src/site-hosting-apm/index.ts
+++ b/packages/api-core/src/site-hosting-apm/index.ts
@@ -1,2 +1,3 @@
+export * from './fetchers';
 export * from './mutators';
 export * from './types';

--- a/packages/api-core/src/site-hosting-apm/types.ts
+++ b/packages/api-core/src/site-hosting-apm/types.ts
@@ -88,3 +88,137 @@ export interface ApmExternalRequest {
 	call_count: number;
 	total_ms: number;
 }
+
+export interface ApmAggregateParams {
+	start?: number;
+	end?: number;
+}
+
+export interface ApmAggregateBreakdownItem {
+	self_sum: number;
+	span_count: number;
+	avg: number;
+}
+
+export interface ApmAggregateCacheBreakdownItem extends ApmAggregateBreakdownItem {
+	by_op?: Record< string, ApmAggregateBreakdownItem >;
+}
+
+export interface ApmAggregateBreakdown {
+	db: ApmAggregateBreakdownItem;
+	wp: ApmAggregateBreakdownItem;
+	wp_core: ApmAggregateBreakdownItem;
+	plugins: ApmAggregateBreakdownItem;
+	cache: ApmAggregateCacheBreakdownItem;
+	external: ApmAggregateBreakdownItem;
+	template: ApmAggregateBreakdownItem;
+	other: ApmAggregateBreakdownItem;
+}
+
+export interface ApmAggregateDurationStats {
+	sum: number;
+	avg: number;
+	max: number;
+}
+
+export interface ApmAggregateTransactions {
+	count: number;
+	duration_ms: ApmAggregateDurationStats;
+	span_count_sum: number;
+}
+
+export interface ApmAggregateSlowestRoute {
+	method: string;
+	route: string;
+	tx_count: number;
+	duration_ms: ApmAggregateDurationStats;
+}
+
+export interface ApmAggregateSlowestTransaction {
+	trace_id: string;
+	method: string;
+	route: string;
+	url: string;
+	duration_ms: number;
+	outcome: string;
+	http_status: number;
+	timestamp: string;
+}
+
+export interface ApmAggregateSlowestPlugin {
+	name: string;
+	self_sum_ms: number;
+	count: number;
+	max_wallclock_ms: number;
+}
+
+export interface ApmAggregateSlowestHook {
+	action: string;
+	total_sum_ms: number;
+	count: number;
+	max_wallclock_ms: number;
+}
+
+export interface ApmAggregateSlowestTemplate {
+	name: string;
+	total_sum_ms: number;
+	count: number;
+	max_wallclock_ms: number;
+}
+
+export interface ApmAggregateSlowestDbQuery {
+	fingerprint: string;
+	fingerprint_id: string;
+	op: string;
+	table?: string;
+	self_sum_ms: number;
+	count: number;
+	max_wallclock_ms: number;
+}
+
+export interface ApmAggregateSlowestCache {
+	op: string;
+	key_prefix: string;
+	self_sum_ms: number;
+	count: number;
+	max_wallclock_ms: number;
+}
+
+export interface ApmAggregateSlowestExternal {
+	host: string;
+	method: string;
+	self_sum_ms: number;
+	count: number;
+	max_wallclock_ms: number;
+}
+
+export interface ApmAggregateSlowest {
+	routes: ApmAggregateSlowestRoute[];
+	transactions?: ApmAggregateSlowestTransaction[];
+	plugins: ApmAggregateSlowestPlugin[];
+	hooks: ApmAggregateSlowestHook[];
+	templates: ApmAggregateSlowestTemplate[];
+	db_queries: ApmAggregateSlowestDbQuery[];
+	cache: ApmAggregateSlowestCache[];
+	externals: ApmAggregateSlowestExternal[];
+}
+
+export interface ApmAggregateBucketExtra {
+	bucket_minute: string;
+	transactions: ApmAggregateTransactions;
+	breakdown_ms: ApmAggregateBreakdown;
+	slowest: ApmAggregateSlowest;
+}
+
+export interface ApmAggregateBucket {
+	feature: string;
+	atomic_site_id: number;
+	blog_id: number;
+	'@timestamp'?: string;
+	message?: string;
+	extra: ApmAggregateBucketExtra;
+}
+
+export interface ApmAggregateResponse {
+	aggregates: ApmAggregateBucket[];
+}

--- a/packages/api-queries/src/site-apm.ts
+++ b/packages/api-queries/src/site-apm.ts
@@ -1,8 +1,8 @@
-import { updateApmEnabled } from '@automattic/api-core';
-import { mutationOptions } from '@tanstack/react-query';
+import { fetchSiteApmAggregate, updateApmEnabled } from '@automattic/api-core';
+import { mutationOptions, queryOptions } from '@tanstack/react-query';
 import { queryClient } from './query-client';
 import { siteQueryFilter } from './site';
-import type { Site } from '@automattic/api-core';
+import type { ApmAggregateParams, Site } from '@automattic/api-core';
 
 export const siteApmEnabledMutation = ( siteId: number ) =>
 	mutationOptions( {
@@ -17,4 +17,10 @@ export const siteApmEnabledMutation = ( siteId: number ) =>
 					: site
 			);
 		},
+	} );
+
+export const siteApmAggregateQuery = ( siteId: number, params?: ApmAggregateParams ) =>
+	queryOptions( {
+		queryKey: [ 'site', siteId, 'apm', 'aggregate', params ],
+		queryFn: () => fetchSiteApmAggregate( siteId, params ),
 	} );


### PR DESCRIPTION
## Proposed Changes

* Add `ApmAggregateResponse` + `ApmAggregateBucket` + the nested `transactions` / `breakdown_ms` / `slowest.*` types in `packages/api-core/src/site-hosting-apm/types.ts`, mirroring the shape the Atomic APM aggregate endpoint returns (per-minute buckets, newest-first).
* Add `fetchSiteApmAggregate` in a new `packages/api-core/src/site-hosting-apm/fetchers.ts`, hitting `GET /wpcom/v2/sites/{siteId}/hosting/apm/aggregate` with optional `start` / `end` query params.
* Add `siteApmAggregateQuery` in `packages/api-queries/src/site-apm.ts` so screens can consume the response via `useSuspenseQuery` and router loaders can prefetch.

## Why are these changes being made?

First step in migrating the backend APM tabs off the temporary `mock-data` scaffold and onto the real `/hosting/apm/aggregate` endpoint. This PR is a pure data-layer addition: no UI changes, no consumer migrations, no behavior changes in the rendered dashboard. The point is to land the API surface so subsequent PRs can review the UI wiring against a stable set of types and a stable query key.

## Testing Instructions

This PR has no UI surface, so testing is light:

1. `yarn typecheck-packages` should pass.
2. `yarn eslint packages/api-core/src/site-hosting-apm packages/api-queries/src/site-apm.ts` should pass.
3. (Optional) Build the dashboard and confirm no runtime regressions. Nothing consumes `siteApmAggregateQuery` yet, so the dashboard should be identical to trunk.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

---

Part 1 of a 3-PR series:

- **PR 1 (this PR):** API plumbing
- **PR 2:** Wire the Overview tab and dashboard shell (alert + KPI rail) to the real aggregate endpoint
- **PR 3:** Migrate Transactions / Database / External requests / WordPress tabs and retire the mock scaffold