### PR TITLE
APM: Wire Overview tab and dashboard shell to real aggregate data

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -624,8 +624,8 @@ export const sitePerformanceBackendIndexRoute = createRoute( {
 	path: '/',
 	loader: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		const { siteApmOverviewQuery } = await import( '../../sites/performance/backend/mock-data' );
-		await queryClient.ensureQueryData( siteApmOverviewQuery( site.ID ) );
+		const { siteApmAggregateQuery } = await import( '@automattic/api-queries' );
+		await queryClient.ensureQueryData( siteApmAggregateQuery( site.ID ) );
 	},
 } ).lazy( () =>
 	import( '../../sites/performance/backend' ).then( ( d ) =>

--- a/client/dashboard/sites/performance/backend/aggregate.ts
+++ b/client/dashboard/sites/performance/backend/aggregate.ts
@@ -1,0 +1,112 @@
+import type { ApmAggregateBucket, ApmSummary, ApmTimePoint } from '@automattic/api-core';
+
+export interface MergedRoute {
+	id: string;
+	method: string;
+	route: string;
+	tx_count: number;
+	duration_ms: { sum: number; avg: number; max: number };
+}
+
+export interface MergedSlowest {
+	routes: MergedRoute[];
+}
+
+export interface MergedAggregate {
+	summary: ApmSummary;
+	timeseries: ApmTimePoint[];
+	slowest: MergedSlowest;
+}
+
+const EMPTY_SUMMARY: ApmSummary = {
+	avg_response_ms: 0,
+	transaction_count: 0,
+	db_avg_ms: 0,
+	external_avg_ms: 0,
+	plugins_avg_ms: 0,
+};
+
+function bucketsToTimePoints( buckets: ApmAggregateBucket[] ): ApmTimePoint[] {
+	// API returns newest-first; chart expects chronological order.
+	return buckets
+		.slice()
+		.reverse()
+		.map( ( bucket ) => {
+			const { bucket_minute, transactions, breakdown_ms } = bucket.extra;
+			const count = Math.max( transactions.count, 1 );
+			return {
+				timestamp: new Date( bucket_minute ).getTime(),
+				db: breakdown_ms.db.self_sum / count,
+				wp_core: breakdown_ms.wp_core.self_sum / count,
+				plugins: breakdown_ms.plugins.self_sum / count,
+				external: breakdown_ms.external.self_sum / count,
+				cache: breakdown_ms.cache.self_sum / count,
+			};
+		} );
+}
+
+function mergeRoutes( buckets: ApmAggregateBucket[] ): MergedRoute[] {
+	const map = new Map< string, MergedRoute >();
+	for ( const bucket of buckets ) {
+		for ( const route of bucket.extra.slowest.routes ) {
+			const id = `${ route.method } ${ route.route }`;
+			const existing = map.get( id );
+			if ( existing ) {
+				existing.tx_count += route.tx_count;
+				existing.duration_ms.sum += route.duration_ms.sum;
+				existing.duration_ms.max = Math.max( existing.duration_ms.max, route.duration_ms.max );
+				existing.duration_ms.avg = existing.duration_ms.sum / Math.max( existing.tx_count, 1 );
+			} else {
+				map.set( id, {
+					id,
+					method: route.method,
+					route: route.route,
+					tx_count: route.tx_count,
+					duration_ms: {
+						sum: route.duration_ms.sum,
+						avg: route.duration_ms.avg,
+						max: route.duration_ms.max,
+					},
+				} );
+			}
+		}
+	}
+	return Array.from( map.values() ).sort( ( a, b ) => b.duration_ms.max - a.duration_ms.max );
+}
+
+function summarize( buckets: ApmAggregateBucket[] ): ApmSummary {
+	if ( buckets.length === 0 ) {
+		return EMPTY_SUMMARY;
+	}
+	let txCount = 0;
+	let durationSum = 0;
+	let dbSum = 0;
+	let pluginsSum = 0;
+	let externalSum = 0;
+	for ( const bucket of buckets ) {
+		const { transactions, breakdown_ms } = bucket.extra;
+		txCount += transactions.count;
+		durationSum += transactions.duration_ms.sum;
+		dbSum += breakdown_ms.db.self_sum;
+		pluginsSum += breakdown_ms.plugins.self_sum;
+		externalSum += breakdown_ms.external.self_sum;
+	}
+	const safeCount = Math.max( txCount, 1 );
+	return {
+		avg_response_ms: Math.round( durationSum / safeCount ),
+		transaction_count: txCount,
+		db_avg_ms: Math.round( dbSum / safeCount ),
+		external_avg_ms: Math.round( externalSum / safeCount ),
+		plugins_avg_ms: Math.round( pluginsSum / safeCount ),
+	};
+}
+
+export function mergeAggregates( aggregates: ApmAggregateBucket[] ): MergedAggregate {
+	return {
+		summary: summarize( aggregates ),
+		timeseries: bucketsToTimePoints( aggregates ),
+		slowest: {
+			routes: mergeRoutes( aggregates ),
+		},
+	};
+}

--- a/client/dashboard/sites/performance/backend/index.tsx
+++ b/client/dashboard/sites/performance/backend/index.tsx
@@ -1,5 +1,9 @@
 import { type Site } from '@automattic/api-core';
-import { siteApmEnabledMutation, siteBySlugQuery } from '@automattic/api-queries';
+import {
+	siteApmAggregateQuery,
+	siteApmEnabledMutation,
+	siteBySlugQuery,
+} from '@automattic/api-queries';
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import {
@@ -11,7 +15,7 @@ import {
 import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useAnalytics } from '../../../app/analytics';
 import { Card } from '../../../components/card';
 import { PageHeader } from '../../../components/page-header';
@@ -21,11 +25,11 @@ import { hasBackendAccess } from '../backend-access';
 import { getBackendCalloutProps } from '../backend-callout';
 import { VIEWPORT_BREAKPOINTS } from '../constants';
 import PerformanceTabs from '../performance-tabs';
+import { mergeAggregates } from './aggregate';
 import BackendStatusNotice from './backend-status';
 import BackendTabs from './backend-tabs';
 import Database from './database';
 import ExternalRequests from './external-requests';
-import { siteApmOverviewQuery } from './mock-data';
 import Overview from './overview';
 import BackendSubtitle from './subtitle';
 import Transactions from './transactions';
@@ -81,7 +85,8 @@ function ApmDashboard( { site, tab }: { site: Site; tab: ApmTab } ) {
 	const router = useRouter();
 	const siteSlug = site.slug;
 	const isDesktop = useViewportMatch( VIEWPORT_BREAKPOINTS.desktop );
-	const { data } = useSuspenseQuery( siteApmOverviewQuery( site.ID ) );
+	const { data } = useSuspenseQuery( siteApmAggregateQuery( site.ID ) );
+	const { summary } = useMemo( () => mergeAggregates( data.aggregates ), [ data.aggregates ] );
 
 	const handleTabChange = ( name: string ) => {
 		const next = name as ApmTab;
@@ -113,7 +118,7 @@ function ApmDashboard( { site, tab }: { site: Site; tab: ApmTab } ) {
 
 	return (
 		<VStack spacing={ 6 }>
-			<BackendStatusNotice avgResponseMs={ data.summary.avg_response_ms } />
+			<BackendStatusNotice avgResponseMs={ summary.avg_response_ms } />
 			<Tabs
 				orientation={ isDesktop ? 'vertical' : 'horizontal' }
 				selectedTabId={ tab }
@@ -127,7 +132,7 @@ function ApmDashboard( { site, tab }: { site: Site; tab: ApmTab } ) {
 							alignSelf: 'flex-start',
 						} }
 					>
-						<BackendTabs compact={ ! isDesktop } summary={ data.summary } />
+						<BackendTabs compact={ ! isDesktop } summary={ summary } />
 					</Card>
 					<div style={ { flex: '1 1 auto', minWidth: 0, width: '100%' } }>
 						<Tabs.TabPanel tabId={ tab }>{ renderTab() }</Tabs.TabPanel>

--- a/client/dashboard/sites/performance/backend/overview/chart-slot.tsx
+++ b/client/dashboard/sites/performance/backend/overview/chart-slot.tsx
@@ -42,6 +42,25 @@ function getAverageTotal( timeseries: ApmTimePoint[] ): number {
 	return Math.round( total / timeseries.length );
 }
 
+function formatMsValue( value: number ): string {
+	return `${ Math.round( value ).toLocaleString() } ms`;
+}
+
+function formatTooltipDate( date: Date ): string {
+	return date.toLocaleDateString( undefined, {
+		weekday: 'short',
+		month: 'short',
+		day: 'numeric',
+	} );
+}
+
+function formatTooltipTime( date: Date ): string {
+	return date.toLocaleTimeString( undefined, {
+		hour: '2-digit',
+		minute: '2-digit',
+	} );
+}
+
 export default function ChartSlot( { timeseries }: { timeseries: ApmTimePoint[] } ) {
 	const data = toSeriesData( timeseries );
 	const averageTotal = getAverageTotal( timeseries );
@@ -76,6 +95,54 @@ export default function ChartSlot( { timeseries }: { timeseries: ApmTimePoint[] 
 						showLegend
 						legend={ { interactive: true } }
 						withTooltips
+						renderTooltip={ ( { tooltipData, colorScale } ) => {
+							const date = tooltipData?.nearestDatum?.datum?.date;
+							if ( ! date ) {
+								return null;
+							}
+							const series = Object.values( tooltipData?.datumByKey ?? {} );
+							return (
+								<VStack spacing={ 3 } style={ { padding: '4px 2px', minWidth: 240 } }>
+									<VStack spacing={ 0 }>
+										<Text weight={ 600 }>{ formatTooltipDate( date ) }</Text>
+										<Text size={ 11 } variant="muted">
+											{ formatTooltipTime( date ) }
+										</Text>
+									</VStack>
+									<VStack spacing={ 1 }>
+										{ series.map( ( entry ) => {
+											const value = ( entry.datum as { value?: number } ).value ?? 0;
+											return (
+												<HStack key={ entry.key } justify="space-between" spacing={ 3 }>
+													<HStack spacing={ 2 } justify="flex-start">
+														<span
+															aria-hidden
+															style={ {
+																display: 'inline-block',
+																flex: '0 0 auto',
+																width: 8,
+																height: 8,
+																borderRadius: 2,
+																background: colorScale ? colorScale( entry.key ) : 'currentColor',
+															} }
+														/>
+														<Text style={ { whiteSpace: 'nowrap' } }>{ entry.key }</Text>
+													</HStack>
+													<Text weight={ 500 } style={ { whiteSpace: 'nowrap' } }>
+														{ formatMsValue( value ) }
+													</Text>
+												</HStack>
+											);
+										} ) }
+									</VStack>
+								</VStack>
+							);
+						} }
+						options={ {
+							axis: {
+								y: { tickFormat: ( value ) => formatMsValue( value as number ) },
+							},
+						} }
 					/>
 				</GlobalChartsProvider>
 			</CardBody>

--- a/client/dashboard/sites/performance/backend/overview/chart-slot.tsx
+++ b/client/dashboard/sites/performance/backend/overview/chart-slot.tsx
@@ -3,7 +3,7 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Card, CardBody, CardHeader } from '../../../../components/card';
 import { Text } from '../../../../components/text';
 import { formatMs } from '../utils';
@@ -43,7 +43,11 @@ function getAverageTotal( timeseries: ApmTimePoint[] ): number {
 }
 
 function formatMsValue( value: number ): string {
-	return `${ Math.round( value ).toLocaleString() } ms`;
+	return sprintf(
+		/* translators: %s is a formatted number of milliseconds, e.g. 2,500 */
+		__( '%s ms' ),
+		Math.round( value ).toLocaleString()
+	);
 }
 
 function formatTooltipDate( date: Date ): string {

--- a/client/dashboard/sites/performance/backend/overview/index.tsx
+++ b/client/dashboard/sites/performance/backend/overview/index.tsx
@@ -1,17 +1,21 @@
+import { siteApmAggregateQuery } from '@automattic/api-queries';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack } from '@wordpress/components';
-import { siteApmOverviewQuery } from '../mock-data';
+import { useMemo } from 'react';
+import { mergeAggregates } from '../aggregate';
 import ChartSlot from './chart-slot';
 import SlowRequestsList from './slow-requests-list';
 import type { Site } from '@automattic/api-core';
 
 export default function Overview( { site }: { site: Site } ) {
-	const { data } = useSuspenseQuery( siteApmOverviewQuery( site.ID ) );
+	const { data } = useSuspenseQuery( siteApmAggregateQuery( site.ID ) );
+
+	const merged = useMemo( () => mergeAggregates( data.aggregates ), [ data.aggregates ] );
 
 	return (
 		<VStack spacing={ 6 }>
-			<ChartSlot timeseries={ data.timeseries } />
-			<SlowRequestsList slowRequests={ data.slow_requests } />
+			<ChartSlot timeseries={ merged.timeseries } />
+			<SlowRequestsList routes={ merged.slowest.routes } />
 		</VStack>
 	);
 }

--- a/client/dashboard/sites/performance/backend/overview/slow-requests-list.tsx
+++ b/client/dashboard/sites/performance/backend/overview/slow-requests-list.tsx
@@ -1,17 +1,17 @@
 import { __ } from '@wordpress/i18n';
 import SlowList, { type SlowListItem } from '../slow-list';
-import type { ApmSlowRequest } from '@automattic/api-core';
+import type { MergedRoute } from '../aggregate';
 
-function toItems( requests: ApmSlowRequest[] ): SlowListItem[] {
-	return requests.map( ( request ) => ( {
-		id: request.id,
-		label: `${ request.method } ${ request.url }`,
-		avg_ms: request.avg_duration_ms,
-		max_ms: request.duration_ms,
+function toItems( routes: MergedRoute[] ): SlowListItem[] {
+	return routes.map( ( route ) => ( {
+		id: route.id,
+		label: `${ route.method } ${ route.route }`,
+		avg_ms: route.duration_ms.avg,
+		max_ms: route.duration_ms.max,
 	} ) );
 }
 
-export default function SlowRequestsList( { slowRequests }: { slowRequests: ApmSlowRequest[] } ) {
+export default function SlowRequestsList( { routes }: { routes: MergedRoute[] } ) {
 	return (
 		<SlowList
 			title={ __( 'Slowest requests' ) }
@@ -21,7 +21,7 @@ export default function SlowRequestsList( { slowRequests }: { slowRequests: ApmS
 			maxDescription={ __(
 				'Slowest single response observed across these endpoints in the selected period.'
 			) }
-			items={ toItems( slowRequests ) }
+			items={ toItems( routes ) }
 		/>
 	);
 }

--- a/client/dashboard/sites/performance/backend/test/index.test.tsx
+++ b/client/dashboard/sites/performance/backend/test/index.test.tsx
@@ -7,7 +7,7 @@ import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { render } from '../../../../test-utils';
 import SitePerformanceBackend from '../index';
-import type { Site } from '@automattic/api-core';
+import type { ApmAggregateResponse, Site } from '@automattic/api-core';
 
 jest.mock( '@automattic/charts', () => ( {
 	AreaChart: () => null,
@@ -60,9 +60,17 @@ function mockApmToggle( expectedActive: boolean ) {
 		.reply( 200, JSON.stringify( expectedActive ), { 'Content-Type': 'application/json' } );
 }
 
+function mockApmAggregate( response: ApmAggregateResponse = { aggregates: [] } ) {
+	nock( 'https://public-api.wordpress.com' )
+		.get( `/wpcom/v2/sites/${ siteId }/hosting/apm/aggregate` )
+		.query( true )
+		.reply( 200, response );
+}
+
 describe( '<SitePerformanceBackend>', () => {
 	test( 'renders the dashboard with a Start capturing CTA when APM is disabled', async () => {
 		mockSite( businessSite( false ) );
+		mockApmAggregate();
 
 		render( <SitePerformanceBackend siteSlug={ siteSlug } /> );
 
@@ -76,6 +84,7 @@ describe( '<SitePerformanceBackend>', () => {
 
 	test( 'renders the tabbed dashboard without the Start capturing CTA when APM is enabled', async () => {
 		mockSite( businessSite( true ) );
+		mockApmAggregate();
 
 		render( <SitePerformanceBackend siteSlug={ siteSlug } /> );
 
@@ -90,6 +99,7 @@ describe( '<SitePerformanceBackend>', () => {
 
 	test( 'renders Plugins, Hooks and Templates on the WordPress tab', async () => {
 		mockSite( businessSite( true ) );
+		mockApmAggregate();
 
 		render( <SitePerformanceBackend siteSlug={ siteSlug } tab="wordpress" /> );
 
@@ -100,6 +110,7 @@ describe( '<SitePerformanceBackend>', () => {
 
 	test( 'renders Slowest transactions on the Transactions tab', async () => {
 		mockSite( businessSite( true ) );
+		mockApmAggregate();
 
 		render( <SitePerformanceBackend siteSlug={ siteSlug } tab="transactions" /> );
 
@@ -110,6 +121,7 @@ describe( '<SitePerformanceBackend>', () => {
 
 	test( 'renders Slowest queries on the Database tab', async () => {
 		mockSite( businessSite( true ) );
+		mockApmAggregate();
 
 		render( <SitePerformanceBackend siteSlug={ siteSlug } tab="database" /> );
 
@@ -119,6 +131,7 @@ describe( '<SitePerformanceBackend>', () => {
 
 	test( 'renders Slowest external requests on the External tab', async () => {
 		mockSite( businessSite( true ) );
+		mockApmAggregate();
 
 		render( <SitePerformanceBackend siteSlug={ siteSlug } tab="external-requests" /> );
 
@@ -130,6 +143,7 @@ describe( '<SitePerformanceBackend>', () => {
 
 	test( 'shows a status notice with the average response time', async () => {
 		mockSite( businessSite( true ) );
+		mockApmAggregate();
 
 		render( <SitePerformanceBackend siteSlug={ siteSlug } /> );
 
@@ -144,6 +158,7 @@ describe( '<SitePerformanceBackend>', () => {
 
 	test( 'toggling Avg/Max on Slowest requests updates the description', async () => {
 		mockSite( businessSite( true ) );
+		mockApmAggregate();
 
 		render( <SitePerformanceBackend siteSlug={ siteSlug } /> );
 
@@ -162,6 +177,7 @@ describe( '<SitePerformanceBackend>', () => {
 
 	test( 'clicking Start capturing POSTs { active: true }', async () => {
 		mockSite( businessSite( false ) );
+		mockApmAggregate();
 		const scope = mockApmToggle( true );
 
 		render( <SitePerformanceBackend siteSlug={ siteSlug } /> );


### PR DESCRIPTION
## Proposed Changes

* New `aggregate.ts` helper at `client/dashboard/sites/performance/backend/aggregate.ts` exposes `mergeAggregates(aggregates)` returning:
  * `summary` — `avg_response_ms`, `db/plugins/external_avg_ms`, `transaction_count`. Weighted by transaction count, not bucket count.
  * `timeseries` — one point per minute, per-transaction ms per breakdown category (db/wp_core/plugins/external/cache), chronological order.
  * `slowest.routes` — per-route avg/max rolled up across the buckets, sorted by max desc.
* `backend/index.tsx` (the dashboard shell) reads `siteApmAggregateQuery` instead of the mock, so `BackendStatusNotice` (alert) and `BackendTabs` (Avg / Transactions / WP / DB / External KPI rail) reflect real windowed data.
* `overview/index.tsx` renders the chart from `merged.timeseries` and the Slowest requests card from `merged.slowest.routes`. `slow-requests-list.tsx` updated to consume the merged route shape.
* Chart polish in `overview/chart-slot.tsx`:
  * Custom tooltip shows the bucket date + minute and per-series values with a ` ms` suffix and a thousands separator, on a single line.
  * Y-axis `tickFormat` returns plain integers (`2,500 ms` instead of `2.5 mil`).
* Router loader for `/backend` prefetches `siteApmAggregateQuery` (replacing the mock prefetch).

## Why are these changes being made?

Continuation of the APM migration: PR 1 added the API plumbing. This PR puts it to work on the most user-visible surface (Overview + the persistent shell at the top of every tab) without touching the other tabs yet. The chart fixes are bundled here because they ride along the same `chart-slot.tsx` touch.

The other backend tabs (Transactions / Database / External requests / WordPress) keep rendering against `mock-data` so they don't break: the final PR in the series migrates them and retires the mock.

## Testing Instructions

1. Check out this branch, run `yarn start-dashboard`.
2. Open a site with APM enabled (or hit *Start capturing*; allow ~30s for ingestion).
3. Navigate to `/sites/{siteSlug}/performance/backend`.
4. **Shell:** Verify the top alert (`Backend is slow` / `needs improvement` / `Healthy backend`) and the KPI rail (Avg / Transactions / WP / DB / External) match the window's real averages from the aggregate response.
5. **Overview chart:**
    * Y-axis labels read like `2,500 ms`, not `2.5 mil`.
    * Hover the chart: tooltip shows date + minute (e.g. `Tue, May 19` / `15:31`) and each series on its own row, all on a single line ending in ` ms`.
6. **Slowest requests card:** Lists `method route` rows; Avg/Max toggle still works.
7. Switch to Transactions / Database / External requests / WordPress: they continue to render against the mock (no regression expected).
8. With APM disabled (or no data yet), the page should still render and the alert should show "Healthy backend - 0 ms".

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

---

Part 2 of a 3-PR series. **Targets PR 1's branch** so the diff stays focused.

- **PR 1:** API plumbing
- **PR 2 (this PR):** Wire the Overview tab and dashboard shell (alert + KPI rail) to the real aggregate endpoint, including chart tooltip + y-axis polish
- **PR 3:** Migrate Transactions / Database / External requests / WordPress tabs and retire the mock scaffold