### PR TITLE
calypso-jest: exclude .d.ts files from test discovery

### DIFF
--- a/packages/calypso-jest/jest-preset.js
+++ b/packages/calypso-jest/jest-preset.js
@@ -9,7 +9,7 @@ module.exports = {
 	resolver: require.resolve( './src/module-resolver.js' ),
 	setupFilesAfterEnv: [ require.resolve( './src/setup.js' ) ],
 	testEnvironment: 'node',
-	testMatch: [ '<rootDir>/**/test/*.[jt]s?(x)', '!**/.eslintrc.*' ],
+	testMatch: [ '<rootDir>/**/test/*.[jt]s?(x)', '!**/*.d.ts', '!**/.eslintrc.*' ],
 	transform: {
 		'\\.(?:[jt]sx?|mjs)$': [ 'babel-jest', { rootMode: 'upward' } ],
 		'\\.(gif|jpg|jpeg|png|svg|webp|scss|mp4|sass|css)$': require.resolve(


### PR DESCRIPTION
## Proposed Changes

* Add `!**/*.d.ts` to `testMatch` in `packages/calypso-jest/jest-preset.js` so TypeScript declaration files are never treated as test files.

## Why are these changes being made?

`test-packages` has been intermittently failing on PRs (e.g. #110813) with:

```
FAIL packages/ui/.tsup/declaration/badge/test/index.d.ts
FAIL packages/ui/.tsup/declaration/icon/test/index.d.ts
FAIL packages/ui/.tsup/declaration/calendar/date-calendar/test/index.d.ts
FAIL packages/ui/.tsup/declaration/calendar/date-range-calendar/test/index.d.ts
  ● Test suite failed to run
    Your test suite must contain at least one test.
```

The underlying defect is in the preset itself, not in any particular package. `testMatch` is `'<rootDir>/**/test/*.[jt]s?(x)'` — the `*.ts` token greedy-matches `.d.ts` filenames. `.d.ts` files contain no runtime code and are never valid test files, but Jest tries to load them anyway.

The trap was armed in June 2025 when `@automattic/ui` was set up to use tsup with `experimentalDts: true` (#104191). tsup writes intermediate per-file declarations into `packages/ui/.tsup/declaration/`, mirroring the `src/` tree. Source tests like `src/badge/test/index.tsx` produce shadow declarations at `.tsup/declaration/badge/test/index.d.ts` containing just `import '@testing-library/jest-dom';` — no test cases.

When any CI step transitively builds `@automattic/ui` via tsup before `test-packages` runs (Calypso Apps builds for help-center et al. depend on it), Jest discovers the ghost declarations and fails them.

### Why fix `testMatch` instead of ignoring `.tsup/`

Adding `/\.tsup/` to `testPathIgnorePatterns` (alongside the existing `/dist/`) would treat the symptom for this particular tool. But `.d.ts` files are *never* tests, regardless of where any build tool writes them — fixing the matcher addresses the root cause and is future-proof against other tools that emit declarations.

I checked that no source `test/` or `__tests__/` directory in the repo contains a legitimate `.d.ts` file, and the codebase doesn't use `tsd`-style type-level tests, so the exclusion is risk-free.

## Testing Instructions

1. `cd packages/ui && yarn build` to populate `.tsup/declaration/`.
2. From repo root, `yarn test-packages --ci`.
3. Expected: all suites pass.

Before this PR with `.tsup/declaration/` populated: `Test Suites: 4 failed, 347 passed`.
After this PR: `Test Suites: 347 passed, 347 total`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?