### PR TITLE
Dashboard: show comment text in notification list

### DIFF
--- a/apps/notifications/src/app/note-list/dataviews.tsx
+++ b/apps/notifications/src/app/note-list/dataviews.tsx
@@ -99,6 +99,9 @@ export function getFields(): Field< Note >[] {
 						/* eslint-disable-next-line react/no-danger */
 						dangerouslySetInnerHTML={ { __html: field.getValue( { item } ) } }
 					/>
+					{ item.subject.length > 1 && (
+						<div className="wpnc__excerpt">{ item.subject[ 1 ].text }</div>
+					) }
 				</div>
 			),
 		},

--- a/apps/notifications/src/app/note-list/style.scss
+++ b/apps/notifications/src/app/note-list/style.scss
@@ -6,12 +6,20 @@
 	overflow: hidden;
 
 	.wpnc__note-list-item {
-		display: -webkit-box;
-		-webkit-line-clamp: 2;
-		-webkit-box-orient: vertical;
-		white-space: pre-wrap;
-		overflow: hidden;
-		text-overflow: ellipsis;
+		.wpnc__subject,
+		.wpnc__excerpt {
+			display: -webkit-box;
+			-webkit-line-clamp: 2;
+			-webkit-box-orient: vertical;
+			white-space: pre-wrap;
+			overflow: hidden;
+			text-overflow: ellipsis;
+		}
+
+		.wpnc__excerpt {
+			color: var(--color-text-subtle);
+			padding-top: 2px;
+		}
 	}
 
 	.wpnc__note-icon .wpnc__gridicon {


### PR DESCRIPTION
Fixes DOTMSD-1207

## Proposed Changes

Show comment text in notification list as follows:

|Before|After|
|-|-|
|<img width="454" height="210" alt="image" src="https://github.com/user-attachments/assets/49cef3f8-249e-41b8-8132-95272ca7f243" />|<img width="455" height="243" alt="image" src="https://github.com/user-attachments/assets/7297ed0a-4876-4fea-a222-1e1611fcbe88" />

It follows v1's logic here:

https://github.com/Automattic/wp-calypso/blob/fd997c3efa7f9e5b532c1933d1a99b0880965aad/apps/notifications/src/panel/templates/summary-in-list.jsx#L33-L35


## Why are these changes being made?

So that users can scan comments easily without having to click individual row in the list.

## Testing Instructions

Check your comments as shown in the screenshot above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
