### PR TITLE
Invites: fix logged-out accept-invite layout issues

### DIFF
--- a/client/my-sites/invites/invite-accept-logged-out/style.scss
+++ b/client/my-sites/invites/invite-accept-logged-out/style.scss
@@ -2,6 +2,7 @@
 @import '@wordpress/base-styles/breakpoints';
 
 $font-sf-pro-text: 'SF Pro Text', $sans;
+$recoleta-font-family: 'Recoleta', sans-serif;
 body.is-section-accept-invite {
 	.logged-out-wp-logo {
 		position: absolute;
@@ -39,6 +40,20 @@ body.is-section-accept-invite {
 		max-height: 340px;
 	}
 
+	.signup-form {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+	}
+
+	.invite-form-header--logged-out.is-wpcom-brand .connect-screen-brand-header__title {
+		font-family: $recoleta-font-family;
+	}
+
+	.invite-form-header--logged-out .connect-screen-brand-header__description {
+		text-wrap: balance;
+	}
+
 	.invite-form-header--logged-out .connect-screen-brand-header__description a {
 		color: var( --studio-gray-70 );
 		text-decoration-line: underline;
@@ -57,6 +72,7 @@ body.is-section-accept-invite {
 		box-shadow: none;
 		padding: 0;
 		margin: 0 auto;
+		max-width: none;
 		background: none;
 
 		button.is-primary {
@@ -91,13 +107,6 @@ body.is-section-accept-invite {
 			margin-bottom: 0;
 		}
 	}
-	.signup-form {
-		flex: 1;
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-	}
-
 	.signup-form__passwordless-form-wrapper {
 		.signup-form__terms-of-service-link {
 			margin: 30px 0 16px;

--- a/client/my-sites/invites/invite-accept-logged-out/style.scss
+++ b/client/my-sites/invites/invite-accept-logged-out/style.scss
@@ -2,7 +2,6 @@
 @import '@wordpress/base-styles/breakpoints';
 
 $font-sf-pro-text: 'SF Pro Text', $sans;
-$recoleta-font-family: 'Recoleta', sans-serif;
 body.is-section-accept-invite {
 	.logged-out-wp-logo {
 		position: absolute;
@@ -47,7 +46,7 @@ body.is-section-accept-invite {
 	}
 
 	.invite-form-header--logged-out.is-wpcom-brand .connect-screen-brand-header__title {
-		font-family: $recoleta-font-family;
+		@extend .wp-brand-font;
 	}
 
 	.invite-form-header--logged-out .connect-screen-brand-header__description {

--- a/client/my-sites/invites/invite-form-header-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-form-header-logged-out/index.jsx
@@ -1,6 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { createInterpolateElement } from '@wordpress/element';
+import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { BrandHeader } from 'calypso/components/connect-screen/brand-header';
 import { getPartnerSignupTosElement } from 'calypso/lib/partner-branding';
@@ -53,7 +54,11 @@ function InviteFormHeaderLoggedOut( { site, partnerConfig } ) {
 		);
 
 	return (
-		<div className="invite-form-header invite-form-header--logged-out">
+		<div
+			className={ clsx( 'invite-form-header invite-form-header--logged-out', {
+				'is-wpcom-brand': ! partnerConfig,
+			} ) }
+		>
 			<BrandHeader title={ title } description={ description } />
 		</div>
 	);


### PR DESCRIPTION
Part of #

## Proposed Changes

* Use Recoleta as the heading brand font on the logged-out accept-invite screen. Scoped to WordPress.com — partner/CIAB invites keep the default sans-serif via an `is-wpcom-brand` class on the header wrapper.
* Stop spreading the email form, OR divider, and social buttons apart on tall viewports by removing `justify-content: space-between` from `.signup-form`. `flex: 1` is preserved so the form still fills the remaining column height.
* Make the email card the same width as the social buttons card by overriding the base `.card.logged-out-form` `max-width: 360px` from `client/components/logged-out-form/style.scss`.
* Balance the "by continuing…" description with `text-wrap: balance` so "Privacy Policy." no longer wraps as an orphan line.

| Before | After |
| --- | --- |
| <img width="1464" height="1188" alt="SCR-20260520-lrdu" src="https://github.com/user-attachments/assets/9dc30fd6-0bb7-41a5-ae5c-7d2d2cf8d98d" /> | <img width="1467" height="1187" alt="SCR-20260520-lrcg" src="https://github.com/user-attachments/assets/844954f7-d85d-458f-ac9a-5da2cb3cce9b" /> |

## Why are these changes being made?

On tall viewports the heading column was getting flex-stretched and `justify-content: space-between` pushed huge gaps between the email form, OR separator, and social buttons. The email card was also visibly narrower than the social buttons card. The description's last line was a "Privacy Policy." orphan, and the heading used the generic sans-serif instead of the WP.com brand serif.

## Testing Instructions

* Open an accept-invite URL while logged out, e.g. `/accept-invite/<site-id>/<key>?email_verification_secret=…`.
* Verify on tall and short viewports:
  * The heading "Create an account for `<site>`" renders in Recoleta.
  * The OR separator sits immediately below the Continue button and immediately above the social buttons (no large vertical gaps).
  * The email input + Continue button match the width of the social buttons stack.
  * The description below the heading does not strand "Privacy Policy." on its own line.
* Repeat on a partner/CIAB-branded invite (with `partnerConfig`): the heading should keep the default sans-serif, not Recoleta.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)