### PR TITLE
A4A: Use @automattic/mcp-remote in MCP setup snippets

### DIFF
--- a/client/a8c-for-agencies/sections/ai-mcp/primary/connect-agent/agent-configs.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/connect-agent/agent-configs.tsx
@@ -38,6 +38,17 @@ const cursorInstallDeepLink = `cursor://anysphere.cursor-deeplink/mcp/install?na
 	btoa( JSON.stringify( { command: `npx -y ${ MCP_REMOTE_PACKAGE } ${ A4A_MCP_URL }` } ) )
 ) }`;
 
+// Shared quick-setup step for clients that shell out to `@automattic/mcp-remote` via npx
+// (Claude Desktop Developer config, Cursor, VS Code).
+const installNodeStep = createInterpolateElement(
+	sprintf(
+		/* translators: %s: npm package name, kept inside <code> */
+		__( 'Install Node 20 or later (required by <code>%s</code>).' ),
+		MCP_REMOTE_PACKAGE
+	),
+	{ code: <code /> }
+);
+
 export const AGENT_CONFIGS: AgentConfig[] = [
 	{
 		id: 'claude-code',
@@ -124,14 +135,7 @@ export const AGENT_CONFIGS: AgentConfig[] = [
 			{
 				title: __( 'Developer config (for Claude Enterprise accounts)' ),
 				steps: [
-					createInterpolateElement(
-						sprintf(
-							/* translators: %s: npm package name, kept inside <code> */
-							__( 'Install Node 20 or later (required by <code>%s</code>).' ),
-							MCP_REMOTE_PACKAGE
-						),
-						{ code: <code /> }
-					),
+					installNodeStep,
 					__(
 						'Open Claude Desktop → Settings → Developer, then click “Edit Config” under Local MCP servers.'
 					),
@@ -173,14 +177,7 @@ export const AGENT_CONFIGS: AgentConfig[] = [
 			deepLink: cursorInstallDeepLink,
 		},
 		quickSetup: [
-			createInterpolateElement(
-				sprintf(
-					/* translators: %s: npm package name, kept inside <code> */
-					__( 'Install Node 20 or later (required by <code>%s</code>).' ),
-					MCP_REMOTE_PACKAGE
-				),
-				{ code: <code /> }
-			),
+			installNodeStep,
 			createInterpolateElement( __( 'Open <code>~/.cursor/mcp.json</code> in your editor.' ), {
 				code: <code />,
 			} ),
@@ -234,14 +231,7 @@ export const AGENT_CONFIGS: AgentConfig[] = [
 		id: 'vscode',
 		label: 'VS Code',
 		quickSetup: [
-			createInterpolateElement(
-				sprintf(
-					/* translators: %s: npm package name, kept inside <code> */
-					__( 'Install Node 20 or later (required by <code>%s</code>).' ),
-					MCP_REMOTE_PACKAGE
-				),
-				{ code: <code /> }
-			),
+			installNodeStep,
 			createInterpolateElement(
 				__(
 					'Open <code>~/Library/Application Support/Code/User/mcp.json</code> (create if missing).'

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/connect-agent/agent-configs.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/connect-agent/agent-configs.tsx
@@ -124,7 +124,14 @@ export const AGENT_CONFIGS: AgentConfig[] = [
 			{
 				title: __( 'Developer config (for Claude Enterprise accounts)' ),
 				steps: [
-					__( 'Install Node 20 or later (required by mcp-remote).' ),
+					createInterpolateElement(
+						sprintf(
+							/* translators: %s: npm package name, kept inside <code> */
+							__( 'Install Node 20 or later (required by <code>%s</code>).' ),
+							MCP_REMOTE_PACKAGE
+						),
+						{ code: <code /> }
+					),
 					__(
 						'Open Claude Desktop → Settings → Developer, then click “Edit Config” under Local MCP servers.'
 					),
@@ -166,7 +173,14 @@ export const AGENT_CONFIGS: AgentConfig[] = [
 			deepLink: cursorInstallDeepLink,
 		},
 		quickSetup: [
-			__( 'Install Node 20 or later (required by mcp-remote).' ),
+			createInterpolateElement(
+				sprintf(
+					/* translators: %s: npm package name, kept inside <code> */
+					__( 'Install Node 20 or later (required by <code>%s</code>).' ),
+					MCP_REMOTE_PACKAGE
+				),
+				{ code: <code /> }
+			),
 			createInterpolateElement( __( 'Open <code>~/.cursor/mcp.json</code> in your editor.' ), {
 				code: <code />,
 			} ),
@@ -220,7 +234,14 @@ export const AGENT_CONFIGS: AgentConfig[] = [
 		id: 'vscode',
 		label: 'VS Code',
 		quickSetup: [
-			__( 'Install Node 20 or later (required by mcp-remote).' ),
+			createInterpolateElement(
+				sprintf(
+					/* translators: %s: npm package name, kept inside <code> */
+					__( 'Install Node 20 or later (required by <code>%s</code>).' ),
+					MCP_REMOTE_PACKAGE
+				),
+				{ code: <code /> }
+			),
 			createInterpolateElement(
 				__(
 					'Open <code>~/Library/Application Support/Code/User/mcp.json</code> (create if missing).'

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/connect-agent/agent-configs.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/connect-agent/agent-configs.tsx
@@ -5,6 +5,13 @@ import type { ReactNode } from 'react';
 
 export const A4A_MCP_URL = 'https://public-api.wordpress.com/wpcom/v2/a4a-mcp/v1';
 
+// `@automattic/mcp-remote` is our published fork of `mcp-remote` that preserves the
+// WWW-Authenticate `resource_metadata` URL across OAuth transport instances, which
+// upstream loses. Without this fix, OAuth to wpcom-hosted MCP servers fails with
+// "Protected resource ... does not match expected ...". See:
+// https://github.com/automattic/mcp-remote
+const MCP_REMOTE_PACKAGE = '@automattic/mcp-remote';
+
 export interface QuickSetupGroup {
 	title: ReactNode;
 	steps: ReactNode[];
@@ -28,7 +35,7 @@ export interface AgentConfig {
 }
 
 const cursorInstallDeepLink = `cursor://anysphere.cursor-deeplink/mcp/install?name=a4a-mcp&config=${ encodeURIComponent(
-	btoa( JSON.stringify( { command: `npx -y mcp-remote ${ A4A_MCP_URL }` } ) )
+	btoa( JSON.stringify( { command: `npx -y ${ MCP_REMOTE_PACKAGE } ${ A4A_MCP_URL }` } ) )
 ) }`;
 
 export const AGENT_CONFIGS: AgentConfig[] = [
@@ -141,7 +148,7 @@ export const AGENT_CONFIGS: AgentConfig[] = [
 				mcpServers: {
 					'a4a-mcp': {
 						command: 'npx',
-						args: [ '-y', 'mcp-remote', A4A_MCP_URL ],
+						args: [ '-y', MCP_REMOTE_PACKAGE, A4A_MCP_URL ],
 					},
 				},
 			},
@@ -178,7 +185,7 @@ export const AGENT_CONFIGS: AgentConfig[] = [
 				mcpServers: {
 					'a4a-mcp': {
 						command: 'npx',
-						args: [ '-y', 'mcp-remote', A4A_MCP_URL ],
+						args: [ '-y', MCP_REMOTE_PACKAGE, A4A_MCP_URL ],
 					},
 				},
 			},
@@ -235,7 +242,7 @@ export const AGENT_CONFIGS: AgentConfig[] = [
 				servers: {
 					'a4a-mcp': {
 						command: 'npx',
-						args: [ '-y', 'mcp-remote', A4A_MCP_URL ],
+						args: [ '-y', MCP_REMOTE_PACKAGE, A4A_MCP_URL ],
 					},
 				},
 			},


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-2609/fix-the-issue-with-mcp-remote-not-working

## Proposed Changes

* Replace the four `mcp-remote` literals in `agent-configs.tsx` (Cursor deep link, Claude Desktop config, Cursor config, VS Code config) with a shared `MCP_REMOTE_PACKAGE` constant set to `@automattic/mcp-remote`.

## Why are these changes being made?

Upstream `mcp-remote` has a bug where the `WWW-Authenticate` `resource_metadata` URL captured during the protocol probe is dropped when a fresh transport runs `finishAuth(code)` after the browser OAuth callback. The SDK then falls back to discovering metadata from the bare `/.well-known/oauth-protected-resource` URL, which on `public-api.wordpress.com` returns the resource identifier for the customer-facing MCP (`/wpcom/v2/mcp/v1`). The RFC 9728 prefix check rejects that for any other MCP path and the user sees:

```
Protected resource https://public-api.wordpress.com/wpcom/v2/mcp/v1 does not match expected https://public-api.wordpress.com/wpcom/v2/a4a-mcp/v1 (or origin)
```

The upstream fix is open with no maintainer response. We've published [`@automattic/mcp-remote`](https://www.npmjs.com/package/@automattic/mcp-remote) (source at https://github.com/automattic/mcp-remote), which carries the minimal patch — preserving the metadata URL by reusing the probe transport for the live connection. Pointing the public install snippets at the fork unblocks agencies trying to connect Cursor / Claude Desktop / VS Code today.

A server-side mitigation is also in flight on the wpcom side (broadening the bare-endpoint resource to the host origin so upstream mcp-remote stops tripping the prefix check). Once that lands, the fork is no longer strictly required, but keeping the published package recommended protects users from future upstream regressions in the same area.

## Testing Instructions

1. Open the A4A "Connect an agent" UI.
2. For Cursor: click "Install in Cursor" — verify the deep link config now references `@automattic/mcp-remote`.
3. For Cursor / Claude Desktop / VS Code manual snippets: verify the rendered JSON has `"args": ["-y", "@automattic/mcp-remote", "https://public-api.wordpress.com/wpcom/v2/a4a-mcp/v1"]`.
4. Codex (URL-based) and "Other MCP client" snippets should be unchanged.
5. End-to-end: paste the rendered Cursor snippet into `~/.cursor/mcp.json`, clear `~/.mcp-auth/`, restart Cursor, complete the OAuth flow. Confirm the A4A MCP tools become available without the prefix-mismatch error.

<img width="1920" height="962" alt="Screenshot 2026-05-20 at 11 00 11 AM" src="https://github.com/user-attachments/assets/a253d335-7364-40b9-a54b-03da90262285" />


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes? — N/A (string change in config snippets)
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)? — N/A (not a site-scoped surface)
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)? — N/A (no visual changes)
- [ ] Have you tested accessibility for your changes? — N/A
- [ ] Have you used memoizing on expensive computations? — N/A
- [ ] Have we added the "[Status] String Freeze" label? — N/A (no translatable strings changed)
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label? — N/A