### PR TITLE
A4A: Hide MCP tool cards until access is enabled

### DIFF
--- a/client/a8c-for-agencies/sections/ai-mcp/primary/overview/overview-content.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/overview/overview-content.tsx
@@ -96,25 +96,30 @@ export default function AiMcpOverviewContent() {
 							/>
 						</VStack>
 					</CardBody>
-					<CardDivider style={ { borderColor: 'var(--color-neutral-5)' } } />
-					<DashboardSummaryButton
-						density="medium"
-						title={ __( 'Available tools' ) }
-						decoration={ <Icon icon={ tool } size={ 24 } /> }
-						badges={ [ availableToolsBadge ] }
-						href={ A4A_AI_MCP_AVAILABLE_TOOLS_LINK }
-						onClick={ onAvailableToolsClick }
-						disabled={ ! mainEnabled }
-					/>
+					{ mainEnabled && (
+						<>
+							<CardDivider style={ { borderColor: 'var(--color-neutral-5)' } } />
+							<DashboardSummaryButton
+								density="medium"
+								title={ __( 'Available tools' ) }
+								decoration={ <Icon icon={ tool } size={ 24 } /> }
+								badges={ [ availableToolsBadge ] }
+								href={ A4A_AI_MCP_AVAILABLE_TOOLS_LINK }
+								onClick={ onAvailableToolsClick }
+							/>
+						</>
+					) }
 				</Card>
 
-				<DashboardSummaryButton
-					title={ __( 'Connect external AI assistant' ) }
-					description={ __( 'Get instructions for connecting your external AI assistant.' ) }
-					decoration={ <Icon icon={ plugins } size={ 24 } /> }
-					href={ A4A_AI_MCP_CONNECT_LINK }
-					onClick={ onConnectClick }
-				/>
+				{ mainEnabled && (
+					<DashboardSummaryButton
+						title={ __( 'Connect external AI assistant' ) }
+						description={ __( 'Get instructions for connecting your external AI assistant.' ) }
+						decoration={ <Icon icon={ plugins } size={ 24 } /> }
+						href={ A4A_AI_MCP_CONNECT_LINK }
+						onClick={ onConnectClick }
+					/>
+				) }
 			</VStack>
 		</>
 	);


### PR DESCRIPTION

## Proposed Changes

* In `client/a8c-for-agencies/sections/ai-mcp/primary/overview/overview-content.tsx`, gate the **Available tools** summary button and its preceding `CardDivider` behind `mainEnabled`, and gate the **Connect external AI assistant** call-to-action behind `mainEnabled`.
* Drop the now-redundant `disabled={ ! mainEnabled }` prop on the Available tools button, since the button is only rendered when `mainEnabled` is true.

## Why are these changes being made?

The MCP overview screen previously showed three surfaces regardless of opt-in state: the main toggle, an Available tools summary (disabled when off), and a Connect external AI assistant card (always enabled). That left a fully-actionable Connect button reachable before the user had agreed to expose any MCP access at all, and a disabled-but-visible Available tools button as a noisy half-state.

Hiding both auxiliary surfaces collapses the screen to a single opt-in card when MCP access is off. The supporting actions appear once the toggle is on, in the same place they always were — no layout shock, just a quieter empty state.

## Testing Instructions

1. Open A4A → AI assistants → MCP overview.
2. With **Enable MCP access** off (default): confirm only the intro paragraph and the toggle card are visible. There should be no divider, no Available tools button, and no Connect external AI assistant card.
3. Toggle **Enable MCP access** on: confirm the `CardDivider` + **Available tools** button appear inside the toggle card, and the standalone **Connect external AI assistant** card appears below.
4. Click **Available tools** and **Connect external AI assistant** — both should navigate as before (`A4A_AI_MCP_AVAILABLE_TOOLS_LINK` and `A4A_AI_MCP_CONNECT_LINK`).
5. Toggle off again: both surfaces disappear, no errors.

<img width="1920" height="470" alt="Screenshot 2026-05-20 at 11 42 39 AM" src="https://github.com/user-attachments/assets/eb533ec4-d868-48b1-8867-eaa2d7ee8d32" />
<img width="1920" height="470" alt="Screenshot 2026-05-20 at 11 42 44 AM" src="https://github.com/user-attachments/assets/6eec7172-726d-4ce1-b47e-9f8b7f1f4679" />


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes? — N/A (rendering gate)
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)? — N/A (A4A-only surface)
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Keyboard focus stays inside the toggle when MCP access is off; surfaces become reachable in source order once enabled.
- [ ] Have you used memoizing on expensive computations? — N/A
- [ ] Have we added the "[Status] String Freeze" label? — N/A (no string changes)
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label? — N/A