### PR TITLE
Migrate the #wpcom root to createRoot / hydrateRoot

### DIFF
--- a/client/controller/index.web.jsx
+++ b/client/controller/index.web.jsx
@@ -95,8 +95,8 @@ export const ProviderWrappedLayout = ( {
 export const makeLayout = makeLayoutMiddleware( ProviderWrappedLayout );
 
 /**
- * For logged in users with bootstrap (production), ReactDOM.hydrate().
- * Otherwise (development), ReactDOM.render().
+ * For logged in users with bootstrap (production), hydrate the server-rendered
+ * markup (`hydrateRoot`). Otherwise (development), render from scratch (`createRoot`).
  * See: https://wp.me/pd2qbF-P#comment-20
  * @param context - Middleware context
  */

--- a/client/controller/web-util.js
+++ b/client/controller/web-util.js
@@ -1,9 +1,23 @@
-import ReactDom from 'react-dom';
+import { createRoot, hydrateRoot } from 'react-dom/client';
+
+// The classic Calypso app mounts into a single, long-lived `#wpcom` container.
+// `createRoot`/`hydrateRoot` must be called exactly once per container; every
+// subsequent route navigation reuses the same root via `root.render()`. (The
+// legacy `ReactDOM.render`/`hydrate` APIs were idempotent per container, so the
+// previous implementation could call them on every navigation.)
+let root;
 
 export function render( context ) {
-	ReactDom.render( context.layout, document.getElementById( 'wpcom' ) );
+	if ( ! root ) {
+		root = createRoot( document.getElementById( 'wpcom' ) );
+	}
+	root.render( context.layout );
 }
 
 export function hydrate( context ) {
-	ReactDom.hydrate( context.layout, document.getElementById( 'wpcom' ) );
+	if ( ! root ) {
+		root = hydrateRoot( document.getElementById( 'wpcom' ), context.layout );
+	} else {
+		root.render( context.layout );
+	}
 }

--- a/client/controller/web-util.js
+++ b/client/controller/web-util.js
@@ -1,4 +1,11 @@
+import config from '@automattic/calypso-config';
+import ReactDom from 'react-dom';
 import { createRoot, hydrateRoot } from 'react-dom/client';
+
+// Gates the React 18 `createRoot`/`hydrateRoot` adoption. When disabled, the
+// `#wpcom` root keeps mounting via the legacy `ReactDOM.render`/`hydrate` APIs
+// (React-17 update semantics — synchronous, no automatic batching).
+const useCreateRoot = config.isEnabled( 'calypso/react-18-create-root' );
 
 // The classic Calypso app mounts into a single, long-lived `#wpcom` container.
 // `createRoot`/`hydrateRoot` must be called exactly once per container; every
@@ -8,6 +15,10 @@ import { createRoot, hydrateRoot } from 'react-dom/client';
 let root;
 
 export function render( context ) {
+	if ( ! useCreateRoot ) {
+		ReactDom.render( context.layout, document.getElementById( 'wpcom' ) );
+		return;
+	}
 	if ( ! root ) {
 		root = createRoot( document.getElementById( 'wpcom' ) );
 	}
@@ -15,6 +26,10 @@ export function render( context ) {
 }
 
 export function hydrate( context ) {
+	if ( ! useCreateRoot ) {
+		ReactDom.hydrate( context.layout, document.getElementById( 'wpcom' ) );
+		return;
+	}
 	if ( ! root ) {
 		root = hydrateRoot( document.getElementById( 'wpcom' ), context.layout );
 	} else {

--- a/config/development.json
+++ b/config/development.json
@@ -57,6 +57,7 @@
 		"calypso/all-domain-management": true,
 		"calypso/big-sky": true,
 		"calypso/domains-dataviews": true,
+		"calypso/react-18-create-root": true,
 		"calypso/refund-eligibility-notice": false,
 		"cancel-flow/solutions-cards-upsell": false,
 		"checkout/checkout-version": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -18,6 +18,7 @@
 		"calypso/all-domain-management": false,
 		"calypso/big-sky": true,
 		"calypso/domains-dataviews": true,
+		"calypso/react-18-create-root": true,
 		"catch-js-errors": true,
 		"checkout/checkout-version": false,
 		"checkout/google-pay": true,

--- a/config/production.json
+++ b/config/production.json
@@ -31,6 +31,7 @@
 		"calypso/all-domain-management": true,
 		"calypso/big-sky": true,
 		"calypso/domains-dataviews": true,
+		"calypso/react-18-create-root": false,
 		"catch-js-errors": true,
 		"checkout/checkout-version": false,
 		"checkout/google-pay": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -28,6 +28,7 @@
 		"calypso/all-domain-management": true,
 		"calypso/big-sky": true,
 		"calypso/domains-dataviews": true,
+		"calypso/react-18-create-root": true,
 		"catch-js-errors": true,
 		"checkout/checkout-version": true,
 		"checkout/google-pay": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -27,6 +27,7 @@
 		"calypso/all-domain-management": true,
 		"calypso/big-sky": true,
 		"calypso/domains-dataviews": true,
+		"calypso/react-18-create-root": true,
 		"catch-js-errors": false,
 		"checkout/checkout-version": true,
 		"checkout/google-pay": true,


### PR DESCRIPTION
## Proposed Changes

* `client/controller/web-util.js`: replace the legacy `ReactDOM.render` / `ReactDOM.hydrate` calls for the classic-Calypso `#wpcom` root with `createRoot` / `hydrateRoot` from `react-dom/client`.
* Because `createRoot`/`hydrateRoot` must be called **once** per container (the legacy APIs were idempotent per container), the root is now cached module-side and reused via `root.render()` on every subsequent route navigation.
* Gate the migration behind a new feature flag, `calypso/react-18-create-root`. When disabled, `web-util.js` falls back to the legacy `ReactDOM.render` / `hydrate` APIs. Enabled on development, stage, horizon, and wpcalypso; **disabled on production** so the behavior change can be smoke-tested before it ships to users.
* Update a stale doc comment in `client/controller/index.web.jsx` that named the old APIs.

## ⚠️ Prior art — this was tried before and reverted

This exact migration was done in **#95513**, merged 2024-10-25, and **reverted 45 minutes later** by **#95704**. A debug re-attempt (**#95750**) and a later attempt (**#104844**) also did not land. Tracking issue: **#95339** (still open).

It was reverted because the **pre-release E2E suite consistently failed** — `createRoot` switches classic Calypso into React 18 automatic batching / concurrent-mode timing, which shifted route-transition timing in the onboarding signup flow. The reproduced/diagnosed failure was `signup__start-writing-tailored`. Full history, mechanism, and the suspected app-side cause are written up in #95339.

This PR opens with the change **gated behind a feature flag, off on production** — so it can be merged and the new path validated on non-production environments without the historical E2E blocker holding up the world. See the verification comment below for what has and has not been checked.

## Why are these changes being made?

Classic Calypso mounts its entire `#wpcom` app via the legacy `ReactDOM.render` / `ReactDOM.hydrate` APIs. On `react@18.3.1` those entry points keep the app in **legacy mode**: synchronous updates, **no automatic batching** outside React event handlers — i.e. React-17 update semantics. (The Stepper and the v2 Dashboard already use `createRoot`.)

This is both the correct React 18 adoption and a fix for a class of legacy-mode-only bugs. Concrete example — the invisible WP `Menu` popover (the DataViews "Add filter" funnel, reported on `/p2s` and `/sites/<slug>/logs/*`):

- A modal `Menu` mounts two Ariakit `useDisclosureContent` instances — the dialog backdrop and the popover surface — sharing one Ariakit store, hence one `animated` flag.
- On open, each schedules `setTransition("enter")` via a double-`requestAnimationFrame`.
- The backdrop's rAF callback reads `getComputedStyle(backdrop).transitionDuration` → `0s` → `store.setState("animated", false)`.
- **Legacy root:** that `setState`, fired from a rAF callback (not a React event), flushes **synchronously**. `animated` flips `false` immediately → the surface's effect re-runs and cancels its still-pending rAF → `setTransition("enter")` never runs → `data-enter` is never stamped → the popover stays at `opacity: 0`.
- **`createRoot`:** automatic batching defers that `setState`; the surface's own rAF fires first and stamps `data-enter` before `animated` is processed → no bug.

This is why the popover bug reproduces in classic Calypso but not in the v2 Dashboard, the Stepper, or Gutenberg Storybook — those all use `createRoot`. A separate CSS workaround for that specific popover already shipped (#110829); this PR removes the underlying cause for the whole class of issues. (Verified on this PR's Calypso Live build — see the verification comment.)

## ⚠️ Risk

This is a large, behavior-affecting change. `createRoot` opts classic Calypso into **React 18 concurrent-mode semantics app-wide** — automatic batching everywhere, stricter effect timing, etc. Two distinct risks:

1. **Known historical failure mode — onboarding/E2E timing.** This is what reverted #95513. Must be validated against a real pre-release E2E run (`Calypso_E2E_Pre_Release`, the `CALYPSO_RELEASE`-tagged onboarding specs); PR-CI's E2E subset does **not** cover it.
2. **Forward-looking risk — SSR hydration strictness.** React 18 `hydrateRoot` discards & re-renders mismatched subtrees instead of silently patching them (as `ReactDOM.hydrate` did). Not a past failure, but needs checking on the production-like logged-in bootstrap-hydrate path — ideally with an `onRecoverableError` handler wired to error reporting.

Both risks are now **gated by the `calypso/react-18-create-root` flag, which is off on production** — so neither reaches users until the flag is deliberately flipped. The flag is enabled on development/stage/horizon/wpcalypso to exercise the new path. Still opened as **draft** until the E2E and hydration paths above are validated.

## Testing Instructions

The new path is active wherever `calypso/react-18-create-root` is enabled (development, stage, horizon, wpcalypso); production runs the legacy path until the flag is flipped.

- [x] Open a DataViews "Add filter" popover (`/p2s`) with the #110829 CSS workaround disabled — popover is visible (root-cause fix confirmed; 5/5 deterministic on the Calypso Live build — see verification comment).
- [x] App boots & renders under `createRoot`; no React hydration errors across `/home`, `/p2s`, `/sites`, `/setup/start-writing` on the Calypso Live build.
- [ ] With the flag **off**, verify the app still mounts via the legacy `ReactDOM.render` / `hydrate` path (production parity).
- [ ] **Logged-in production-style load (bootstrap hydrate path)** — verify no hydration mismatch errors. *Not coverable on Calypso Live.*
- [ ] **Pre-release E2E run** covering the onboarding specs (the #95513 revert risk).
- [ ] Development load (`render` path) — verify the app mounts.
- [ ] Navigate across several sections (My Sites, Reader, checkout, me/purchases) — verify route transitions still render.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
