### PR TITLE
A4A: Refresh MCP setup snippets for the agencies-mcp endpoint

### DIFF
--- a/client/a8c-for-agencies/sections/ai-mcp/primary/connect-agent/agent-configs.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/connect-agent/agent-configs.tsx
@@ -3,7 +3,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import type { ReactNode } from 'react';
 
-export const A4A_MCP_URL = 'https://public-api.wordpress.com/wpcom/v2/a4a-mcp/v1';
+export const A4A_MCP_URL = 'https://public-api.wordpress.com/wpcom/v2/agencies-mcp/v1';
 
 // `@automattic/mcp-remote` is our published fork of `mcp-remote` that preserves the
 // WWW-Authenticate `resource_metadata` URL across OAuth transport instances, which
@@ -14,17 +14,11 @@ const MCP_REMOTE_PACKAGE = '@automattic/mcp-remote';
 
 const MCP_SERVER_NAME = 'automattic-agencies-mcp';
 
-export interface QuickSetupGroup {
-	title: ReactNode;
-	steps: ReactNode[];
-}
-
 export interface AgentConfig {
 	id: string;
 	label: string;
 	quickSetupDescription?: string;
 	quickSetup?: ReactNode[];
-	quickSetupGroups?: QuickSetupGroup[];
 	installAction?: {
 		label: string;
 		deepLink: string;
@@ -119,45 +113,21 @@ export const AGENT_CONFIGS: AgentConfig[] = [
 	{
 		id: 'claude-desktop',
 		label: 'Claude Desktop',
-		quickSetupDescription: __( 'Choose the method that matches your Claude Desktop account.' ),
-		quickSetupGroups: [
-			{
-				title: __( 'Connectors (recommended)' ),
-				steps: [
-					__( 'Open Claude Desktop and go to Settings → Connectors (or Customize).' ),
-					__( 'Click “Add custom connector”.' ),
-					createInterpolateElement(
-						sprintf(
-							/* translators: %s: MCP server URL, kept inside <code> */
-							__(
-								'Enter a name (for example, “Automattic for Agencies”) and paste <code>%s</code> into the Remote MCP server URL field.'
-							),
-							A4A_MCP_URL
-						),
-						{ code: <code /> }
-					),
-					__( 'Authenticate when Claude Desktop prompts you in your browser.' ),
-				],
-			},
-			{
-				title: __( 'Developer config (for Claude Enterprise accounts)' ),
-				steps: [
-					installNodeStep,
-					__(
-						'Open Claude Desktop → Settings → Developer, then click “Edit Config” under Local MCP servers.'
-					),
-					createInterpolateElement(
-						__(
-							'Add the configuration below to <code>claude_desktop_config.json</code> (typically at <code>~/Library/Application Support/Claude/claude_desktop_config.json</code>).'
-						),
-						{ code: <code /> }
-					),
-					__( 'Restart Claude Desktop.' ),
-					__(
-						'If you haven’t authenticated yet, Claude Desktop will prompt you in your browser as soon as it reopens.'
-					),
-				],
-			},
+		quickSetup: [
+			installNodeStep,
+			__(
+				'Open Claude Desktop → Settings → Developer, then click “Edit Config” under Local MCP servers.'
+			),
+			createInterpolateElement(
+				__(
+					'Add the configuration below to <code>claude_desktop_config.json</code> (typically at <code>~/Library/Application Support/Claude/claude_desktop_config.json</code>).'
+				),
+				{ code: <code /> }
+			),
+			__( 'Restart Claude Desktop.' ),
+			__(
+				'If you haven’t authenticated yet, Claude Desktop will prompt you in your browser as soon as it reopens.'
+			),
 		],
 		manualSetupFile: 'claude_desktop_config.json',
 		manualSetupLanguage: 'json',

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/connect-agent/agent-configs.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/connect-agent/agent-configs.tsx
@@ -12,6 +12,8 @@ export const A4A_MCP_URL = 'https://public-api.wordpress.com/wpcom/v2/a4a-mcp/v1
 // https://github.com/automattic/mcp-remote
 const MCP_REMOTE_PACKAGE = '@automattic/mcp-remote';
 
+const MCP_SERVER_NAME = 'automattic-agencies-mcp';
+
 export interface QuickSetupGroup {
 	title: ReactNode;
 	steps: ReactNode[];
@@ -34,7 +36,7 @@ export interface AgentConfig {
 	docsLabel: string;
 }
 
-const cursorInstallDeepLink = `cursor://anysphere.cursor-deeplink/mcp/install?name=a4a-mcp&config=${ encodeURIComponent(
+const cursorInstallDeepLink = `cursor://anysphere.cursor-deeplink/mcp/install?name=${ MCP_SERVER_NAME }&config=${ encodeURIComponent(
 	btoa( JSON.stringify( { command: `npx -y ${ MCP_REMOTE_PACKAGE } ${ A4A_MCP_URL }` } ) )
 ) }`;
 
@@ -73,8 +75,9 @@ export const AGENT_CONFIGS: AgentConfig[] = [
 			),
 			createInterpolateElement(
 				sprintf(
-					/* translators: %s: A4A MCP server URL, kept inside <code> */
-					__( 'Run in your terminal: <code>claude mcp add --transport http a4a-mcp %s</code>' ),
+					/* translators: %1$s: MCP server name, kept inside <code>; %2$s: MCP server URL, kept inside <code> */
+					__( 'Run in your terminal: <code>claude mcp add --transport http %1$s %2$s</code>' ),
+					MCP_SERVER_NAME,
 					A4A_MCP_URL
 				),
 				{ code: <code /> }
@@ -86,8 +89,12 @@ export const AGENT_CONFIGS: AgentConfig[] = [
 				{ code: <code /> }
 			),
 			createInterpolateElement(
-				__(
-					'Run <code>claude</code> in your terminal, select <code>/mcp</code>, then select <code>a4a-mcp</code> and authenticate. Your browser opens to complete the OAuth flow.'
+				sprintf(
+					/* translators: %s: MCP server name, kept inside <code> */
+					__(
+						'Run <code>claude</code> in your terminal, select <code>/mcp</code>, then select <code>%s</code> and authenticate. Your browser opens to complete the OAuth flow.'
+					),
+					MCP_SERVER_NAME
 				),
 				{ code: <code /> }
 			),
@@ -97,7 +104,7 @@ export const AGENT_CONFIGS: AgentConfig[] = [
 		manualSetupSnippet: JSON.stringify(
 			{
 				mcpServers: {
-					'a4a-mcp': {
+					[ MCP_SERVER_NAME ]: {
 						type: 'http',
 						url: A4A_MCP_URL,
 					},
@@ -121,9 +128,9 @@ export const AGENT_CONFIGS: AgentConfig[] = [
 					__( 'Click “Add custom connector”.' ),
 					createInterpolateElement(
 						sprintf(
-							/* translators: %s: A4A MCP server URL, kept inside <code> */
+							/* translators: %s: MCP server URL, kept inside <code> */
 							__(
-								'Enter a name (for example, “A4A MCP”) and paste <code>%s</code> into the Remote MCP server URL field.'
+								'Enter a name (for example, “Automattic for Agencies”) and paste <code>%s</code> into the Remote MCP server URL field.'
 							),
 							A4A_MCP_URL
 						),
@@ -157,7 +164,7 @@ export const AGENT_CONFIGS: AgentConfig[] = [
 		manualSetupSnippet: JSON.stringify(
 			{
 				mcpServers: {
-					'a4a-mcp': {
+					[ MCP_SERVER_NAME ]: {
 						command: 'npx',
 						args: [ '-y', MCP_REMOTE_PACKAGE, A4A_MCP_URL ],
 					},
@@ -194,7 +201,7 @@ export const AGENT_CONFIGS: AgentConfig[] = [
 		manualSetupSnippet: JSON.stringify(
 			{
 				mcpServers: {
-					'a4a-mcp': {
+					[ MCP_SERVER_NAME ]: {
 						command: 'npx',
 						args: [ '-y', MCP_REMOTE_PACKAGE, A4A_MCP_URL ],
 					},
@@ -220,7 +227,7 @@ export const AGENT_CONFIGS: AgentConfig[] = [
 		manualSetupFile: '~/.codex/config.toml',
 		manualSetupLanguage: 'toml',
 		manualSetupSnippet: [
-			'[mcp_servers.a4a-mcp]',
+			`[mcp_servers.${ MCP_SERVER_NAME }]`,
 			`url = "${ A4A_MCP_URL }"`,
 			`oauth_resource = "${ A4A_MCP_URL }"`,
 		].join( '\n' ),
@@ -251,7 +258,7 @@ export const AGENT_CONFIGS: AgentConfig[] = [
 		manualSetupSnippet: JSON.stringify(
 			{
 				servers: {
-					'a4a-mcp': {
+					[ MCP_SERVER_NAME ]: {
 						command: 'npx',
 						args: [ '-y', MCP_REMOTE_PACKAGE, A4A_MCP_URL ],
 					},
@@ -270,7 +277,7 @@ export const AGENT_CONFIGS: AgentConfig[] = [
 		manualSetupSnippet: JSON.stringify(
 			{
 				mcpServers: {
-					'a4a-mcp': {
+					[ MCP_SERVER_NAME ]: {
 						url: A4A_MCP_URL,
 					},
 				},

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/connect-agent/connect-agent-content.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/connect-agent/connect-agent-content.tsx
@@ -96,8 +96,7 @@ export default function AiMcpConnectAgentContent() {
 					</CardBody>
 				</Card>
 
-				{ ( ( selectedAgent.quickSetup && selectedAgent.quickSetup.length > 0 ) ||
-					( selectedAgent.quickSetupGroups && selectedAgent.quickSetupGroups.length > 0 ) ) && (
+				{ selectedAgent.quickSetup && selectedAgent.quickSetup.length > 0 && (
 					<Card>
 						<CardBody>
 							<VStack spacing={ 3 }>
@@ -107,28 +106,13 @@ export default function AiMcpConnectAgentContent() {
 								{ selectedAgent.quickSetupDescription && (
 									<Text variant="muted">{ selectedAgent.quickSetupDescription }</Text>
 								) }
-								{ selectedAgent.quickSetupGroups ? (
-									selectedAgent.quickSetupGroups.map( ( group, gIdx ) => (
-										<VStack key={ gIdx } spacing={ 2 }>
-											<Text weight={ 500 }>{ group.title }</Text>
-											<ol>
-												{ group.steps.map( ( step, idx ) => (
-													<li key={ idx }>
-														<Text>{ step }</Text>
-													</li>
-												) ) }
-											</ol>
-										</VStack>
-									) )
-								) : (
-									<ol>
-										{ selectedAgent.quickSetup?.map( ( step, idx ) => (
-											<li key={ idx }>
-												<Text>{ step }</Text>
-											</li>
-										) ) }
-									</ol>
-								) }
+								<ol>
+									{ selectedAgent.quickSetup.map( ( step, idx ) => (
+										<li key={ idx }>
+											<Text>{ step }</Text>
+										</li>
+									) ) }
+								</ol>
 								{ selectedAgent.installAction && (
 									<>
 										<Text>

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/connect-agent/connect-agent-content.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/connect-agent/connect-agent-content.tsx
@@ -131,7 +131,11 @@ export default function AiMcpConnectAgentContent() {
 								) }
 								{ selectedAgent.installAction && (
 									<>
-										<Text>{ __( 'Or use the one-click install to add the A4A MCP app.' ) }</Text>
+										<Text>
+											{ __(
+												'Or use the one-click install to add the Automattic for Agencies MCP app.'
+											) }
+										</Text>
 										<Button
 											style={ { width: 'fit-content' } }
 											variant="primary"


### PR DESCRIPTION
## Proposed Changes

* **Local server key rename**: replace nine `'a4a-mcp'` literals across the install snippets with a new `MCP_SERVER_NAME = 'automattic-agencies-mcp'` constant. Affects the Cursor install deep link, Claude Code CLI command, Claude Code `/mcp` selection copy, Claude Code/Claude Desktop/Cursor/VS Code/Other JSON snippet keys, and the Codex TOML section header. Two translatable strings refactored to `sprintf` so the identifier is parameterized.
* **Server URL update**: bump `A4A_MCP_URL` from `/wpcom/v2/a4a-mcp/v1` to `/wpcom/v2/agencies-mcp/v1`. The server-side endpoint has already shipped under the new path — the snippets just need to point at it.
* **Claude Desktop**: simplify Quick setup to a single Developer-config flow (Node prereq → Settings → Developer → paste config → restart → auth). Drop the parallel Connectors-based group and the `quickSetupDescription` ("Choose the method…") that selected between them. Users who prefer the Connectors flow can still add the server through Claude Desktop's UI directly with the URL exposed in the Manual setup section.
* **Type cleanup**: drop the now-unused `QuickSetupGroup` interface and the `quickSetupGroups?` field on `AgentConfig`. Collapse the matching `if (quickSetupGroups) … else …` branch in `AiMcpConnectAgentContent` so Quick setup always renders a single ordered list from `quickSetup`.
* **User-visible copy**: rename the Claude Desktop one-click install copy from "A4A MCP app" to "Automattic for Agencies MCP app" in `connect-agent-content.tsx`.

## Why are these changes being made?

External agencies setting up the MCP saw `a4a-mcp` everywhere — in their config files, in their tool transcripts, and in the URL. "A4A" is internal A8C shorthand and doesn't read as anything to a customer. Two coordinated moves remove it from customer-facing surfaces:

1. The server now serves the endpoint at `/wpcom/v2/agencies-mcp/v1`. Pointing the snippets there lines the URL up with the consumer-facing product brand on the same host.
2. The local config key (the `mcpServers` entry name, Claude Code's `claude mcp add` server arg, the Codex section header) becomes `automattic-agencies-mcp`. That lives alongside other companies' MCPs in the user's polyglot config, so it carries the brand prefix the URL doesn't need (since the URL is qualified by `public-api.wordpress.com`).

Existing installs keep working unchanged — the `mcpServers` key is purely a local label and the old `/wpcom/v2/a4a-mcp/v1` URL continues to work server-side during the transition. Only fresh installs picked up from this UI get the new naming.

While in there, Claude Desktop's two-method Quick setup was simplified. The Connectors flow was duplicative with what the always-visible Manual setup card already shows — the Developer config flow is the linear, single path now. The `quickSetupGroups` type that supported the two-method chooser is gone, taking a chunk of branching JSX with it.

<img width="1920" height="891" alt="Screenshot 2026-05-20 at 3 27 06 PM" src="https://github.com/user-attachments/assets/704b25cc-7a8a-4381-9734-88db7ee1fc3c" />


## Testing Instructions

1. Open A4A → AI assistants → Connect agent.
2. For each agent option (Claude Code, Claude Desktop, Cursor, Codex, VS Code, Other):
   * Verify the rendered config snippet uses `"automattic-agencies-mcp"` as the key (or `[mcp_servers.automattic-agencies-mcp]` for Codex).
   * Verify the URL inside the snippet is `https://public-api.wordpress.com/wpcom/v2/agencies-mcp/v1` (note: new slug).
3. Claude Code-specific:
   * CLI command reads `claude mcp add --transport http automattic-agencies-mcp https://public-api.wordpress.com/wpcom/v2/agencies-mcp/v1`.
   * `/mcp` flow copy reads `select automattic-agencies-mcp`.
4. Claude Desktop:
   * Quick setup shows a single ordered list (no method chooser): Node prereq, Settings → Developer, paste config into `claude_desktop_config.json`, restart, auth.
   * No "Connectors (recommended)" or "Developer config (for Claude Enterprise accounts)" group titles appear.
5. Cursor: click **Install in Cursor**. Inspect the deep link — `name=automattic-agencies-mcp` in the query string; inner base64 config points at the new URL.
6. End-to-end (Cursor): paste the rendered snippet into `~/.cursor/mcp.json`, clear `~/.mcp-auth/`, restart Cursor, complete OAuth against the new endpoint. Confirm the MCP server appears as `automattic-agencies-mcp` in Cursor's MCP panel and tool calls (now `agencies-*` prefixed) resolve normally.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes? — N/A (constant/string/JSX-branch change in config snippets)
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)? — N/A (A4A-only surface)
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? — Quick setup remains a single `<ol>`; keyboard / screen-reader order unaffected.
- [ ] Have you used memoizing on expensive computations? — N/A
- [ ] Have we added the "[Status] String Freeze" label? — Translatable strings changed; per request, not adding the label on this PR.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label? — N/A