### PR TITLE
A4A Agent Studio: swap mock service for wpcom endpoints

### DIFF
--- a/client/a8c-for-agencies/sections/agent-studio/CONTEXT.md
+++ b/client/a8c-for-agencies/sections/agent-studio/CONTEXT.md
@@ -1,0 +1,69 @@
+# Agent Studio — domain glossary
+
+Short reference for the surprising vocabulary that crosses the
+wpcom (`wp-content/lib/a4a-agents/`) / wp-calypso seam. Keep entries
+to terms that aren't obvious from reading the code; don't catalogue
+every type.
+
+## Agent
+
+A named persona the agency briefs ("Iris", "June", "Remy"). Each Agent
+maps to a recipe slug on the server (today: `June` → `compose-one-pager`).
+Agents not yet backed by a recipe ship `disabled: true` in `lib/agents.ts`.
+
+## Brief
+
+The form an agency fills out before dispatch. Distinct from the
+`extract_brief` step inside the one-pager recipe, which is an LLM call
+that turns the free-form pasted text into a structured `Brief` object
+(headline + body sections + stats + CTA). Same word; different things.
+
+## Project
+
+Server-side container for a set of runs. Hidden from the client behind
+a single auto-provisioned "Default" project per agency. The legacy
+project CRUD lives in `data/use-agent-studio-project*.ts` and
+`primary/project-detail/` — unreachable from the active UI, kept so
+projects can resurface when more agents land.
+
+## Run
+
+A single execution of a recipe on the server (`a4a_agent_run` post type,
+DTO `\A4A\Agents\Run`). The async-jobs worker walks the recipe steps;
+the run's status (`a4a_pending` / `a4a_running` / `a4a_completed` /
+`a4a_failed` / `a4a_cancelled`) is what the projection maps to the
+client's `generating` / `ready` / `failed`.
+
+## Output (server) = Deliverable (client)
+
+What an agency sees on a card on the Agent Studio overview. Server-side
+it's a projection over a `Run`, never a distinct entity — see
+`Project_Output_Projection`. Client-side the type is `AgentStudioOutput`
+but the user-facing label and copy uses "deliverable" everywhere.
+
+## Collateral
+
+The persisted artifact a one-pager run produces (`a4a_mc_collateral`
+post). One collateral has many `Variants`. The Calypso card opens the
+first variant's PDF; a future detail view will let agencies pick.
+
+## Variant
+
+A single (frame layout × theme) combination of a Collateral. Each
+variant has an `html_url` (HTML preview) and `pdf_download_url`. Server
+computes URLs deterministically from `(agency_id, post_id, variant_id)`
+— no per-variant attachments are stored.
+
+## Recipe
+
+The YAML pipeline a Run executes
+(`wp-content/lib/a4a-agents/recipes/*.yaml`). Each step is an ability
+that emits output the next step reads. Recipes the REST endpoint will
+dispatch are listed in `PUBLIC_RECIPES`
+(`agency-a4a-agent-runs.php:51`).
+
+## Ability
+
+A single step inside a recipe. Either deterministic (PHP class doing
+work directly) or an LLM call wrapped by `Agent_Ability`. Registered
+under the `a4a-agents` ability category (`0-load.php:88`).

--- a/client/a8c-for-agencies/sections/agent-studio/data/agent-studio-service.ts
+++ b/client/a8c-for-agencies/sections/agent-studio/data/agent-studio-service.ts
@@ -1,4 +1,165 @@
-import { mockAgentStudioService } from './mock-agent-studio-service';
-import type { AgentStudioService } from '../types';
+import wpcom from 'calypso/lib/wp';
+import type {
+	AgentStudioOutput,
+	AgentStudioOutputStatus,
+	AgentStudioProject,
+	AgentStudioProjectSummary,
+	AgentStudioService,
+	CreateAgentStudioOutputInput,
+	OnePagerContentField,
+} from '../types';
 
-export const agentStudioService: AgentStudioService = mockAgentStudioService;
+interface MediaUploadResponse {
+	url: string;
+}
+
+interface RunDispatchResponse {
+	run_id: string | number;
+	status?: string;
+}
+
+interface ListOutputsResponse {
+	outputs: AgentStudioOutput[];
+}
+
+const agencyPath = ( agencyId: number, path: string ) =>
+	`/agency/${ agencyId }/a4a${ path.startsWith( '/' ) ? path : `/${ path }` }`;
+
+const toStatus = ( status: string | undefined ): AgentStudioOutputStatus => {
+	if ( status === 'ready' || status === 'failed' ) {
+		return status;
+	}
+	return 'generating';
+};
+
+/**
+ * Uploads a single image to the agency's shared media bucket and returns the
+ * URL the renderer can fetch. The endpoint accepts one file at a time so each
+ * image is posted in series.
+ * @param agencyId - The active agency id.
+ * @param file - The image to upload.
+ * @returns The hosted URL of the uploaded image.
+ */
+const uploadMedia = async ( agencyId: number, file: File ): Promise< string > => {
+	const formData = new FormData();
+	formData.append( 'media', file );
+
+	const response: MediaUploadResponse = await wpcom.req.post( {
+		apiNamespace: 'wpcom/v2',
+		path: agencyPath( agencyId, '/media' ),
+		body: formData,
+	} );
+
+	return response.url;
+};
+
+const notImplemented = ( name: string ) =>
+	new Error(
+		`${ name } is not implemented on wpcomAgentStudioService; projects are server-managed`
+	);
+
+export const wpcomAgentStudioService: AgentStudioService = {
+	// Legacy project surface — unreachable from the active UI. The server
+	// auto-provisions a "Default" project per agency, so the client never
+	// touches projects directly.
+	listProjects(): Promise< AgentStudioProjectSummary[] > {
+		return Promise.resolve( [] );
+	},
+
+	getProject(): Promise< AgentStudioProject | undefined > {
+		return Promise.resolve( undefined );
+	},
+
+	createProject(): Promise< AgentStudioProject > {
+		return Promise.reject( notImplemented( 'createProject' ) );
+	},
+
+	deleteProject(): Promise< void > {
+		return Promise.reject( notImplemented( 'deleteProject' ) );
+	},
+
+	listProjectOutputs(): Promise< AgentStudioOutput[] > {
+		return Promise.resolve( [] );
+	},
+
+	async listOutputs( agencyId: number ): Promise< AgentStudioOutput[] > {
+		const response: ListOutputsResponse = await wpcom.req.get( {
+			apiNamespace: 'wpcom/v2',
+			path: agencyPath( agencyId, '/outputs' ),
+		} );
+
+		return response.outputs ?? [];
+	},
+
+	async createOutput(
+		agencyId: number,
+		input: CreateAgentStudioOutputInput
+	): Promise< AgentStudioOutput > {
+		// Step 1: upload the cover image, if one was provided. The recipe today
+		// only consumes `hero_url` — additional files are dropped (see the
+		// migration doc's "Deferred gaps" → multi-image support).
+		const heroUrl = input.images.length > 0 ? await uploadMedia( agencyId, input.images[ 0 ] ) : '';
+
+		// Step 2: dispatch the recipe. `project_id` is omitted so the server
+		// resolves the Default project for this agency.
+		const runResponse: RunDispatchResponse = await wpcom.req.post( {
+			apiNamespace: 'wpcom/v2',
+			path: agencyPath( agencyId, '/runs' ),
+			body: {
+				recipe: 'compose-one-pager',
+				input: {
+					text: input.brief,
+					blurb: input.blurb,
+					hero_url: heroUrl,
+				},
+			},
+		} );
+
+		// Step 3: synthesize the row the caller will optimistically render
+		// while the polling tick waits for the projection to catch up.
+		const now = new Date().toISOString();
+		return {
+			id: String( runResponse.run_id ),
+			projectId: '',
+			title: input.title,
+			description: input.description,
+			agentName: input.agentName,
+			deliverableType: input.deliverableType,
+			status: toStatus( runResponse.status ),
+			createdAt: now,
+			updatedAt: now,
+		};
+	},
+
+	async deleteOutput( agencyId: number, outputId: string ): Promise< void > {
+		await wpcom.req.post( {
+			method: 'DELETE',
+			apiNamespace: 'wpcom/v2',
+			path: agencyPath( agencyId, `/runs/${ outputId }` ),
+		} );
+	},
+
+	async suggestOnePagerContent( brief: string, field: OnePagerContentField ): Promise< string > {
+		// TODO: real suggest endpoint — see docs/api-migration.md "Deferred gaps".
+		// Heuristic stand-in for the AI suggestion: the first line tends to be
+		// the headline, the sentences after it frame the document.
+		const lines = brief
+			.split( '\n' )
+			.map( ( line ) => line.trim() )
+			.filter( Boolean );
+
+		if ( field === 'title' ) {
+			const firstLine = lines[ 0 ] ?? '';
+			return firstLine.length > 80 ? `${ firstLine.slice( 0, 79 ).trimEnd() }…` : firstLine;
+		}
+
+		const body = lines.slice( 1 ).join( ' ' ).trim();
+		const sentences = ( body.match( /[^.!?]+[.!?]+/g ) ?? ( body ? [ body ] : [] ) ).map(
+			( sentence ) => sentence.trim()
+		);
+		const blurbText = sentences.slice( 0, 2 ).join( ' ' ).trim();
+		return blurbText.length > 200 ? `${ blurbText.slice( 0, 199 ).trimEnd() }…` : blurbText;
+	},
+};
+
+export const agentStudioService: AgentStudioService = wpcomAgentStudioService;

--- a/client/a8c-for-agencies/sections/agent-studio/data/mock-agent-studio-service.ts
+++ b/client/a8c-for-agencies/sections/agent-studio/data/mock-agent-studio-service.ts
@@ -211,7 +211,9 @@ export const mockAgentStudioService: AgentStudioService = {
 		);
 	},
 
-	async listOutputs() {
+	// The mock ignores `agencyId` — it shares a single localStorage bucket.
+	async listOutputs( agencyId: number ) {
+		void agencyId;
 		const { project, state } = ensureDefaultProject( readState() );
 		const resolved = resolveGeneratingOutputs( state );
 
@@ -220,7 +222,8 @@ export const mockAgentStudioService: AgentStudioService = {
 		);
 	},
 
-	async createOutput( input: CreateAgentStudioOutputInput ) {
+	async createOutput( agencyId: number, input: CreateAgentStudioOutputInput ) {
+		void agencyId;
 		const { project, state } = ensureDefaultProject( readState() );
 		const now = new Date().toISOString();
 		const output: AgentStudioOutput = {
@@ -243,7 +246,8 @@ export const mockAgentStudioService: AgentStudioService = {
 		return output;
 	},
 
-	async deleteOutput( outputId ) {
+	async deleteOutput( agencyId: number, outputId: string ) {
+		void agencyId;
 		const state = readState();
 		writeState( {
 			...state,

--- a/client/a8c-for-agencies/sections/agent-studio/data/test/agent-studio-service.test.ts
+++ b/client/a8c-for-agencies/sections/agent-studio/data/test/agent-studio-service.test.ts
@@ -1,0 +1,194 @@
+/**
+ * @jest-environment jsdom
+ */
+import wpcom from 'calypso/lib/wp';
+import { wpcomAgentStudioService } from '../agent-studio-service';
+
+jest.mock( 'calypso/lib/wp', () => ( {
+	__esModule: true,
+	default: {
+		req: {
+			get: jest.fn(),
+			post: jest.fn(),
+		},
+	},
+} ) );
+
+const mockedGet = wpcom.req.get as jest.MockedFunction< typeof wpcom.req.get >;
+const mockedPost = wpcom.req.post as jest.MockedFunction< typeof wpcom.req.post >;
+
+const AGENCY_ID = 42;
+
+beforeEach( () => {
+	jest.clearAllMocks();
+} );
+
+describe( 'wpcomAgentStudioService.listOutputs', () => {
+	it( 'fetches outputs for the active agency and unwraps the envelope', async () => {
+		const fakeOutputs = [
+			{
+				id: 'run-1',
+				projectId: '',
+				title: 'Launch one-pager',
+				description: 'Pitch leave-behind.',
+				agentName: 'June',
+				deliverableType: 'PDF',
+				status: 'ready' as const,
+				downloadUrl: 'https://example.com/run-1.pdf',
+				pageCount: 4,
+				createdAt: '2026-05-20T10:00:00Z',
+				updatedAt: '2026-05-20T10:05:00Z',
+			},
+		];
+		mockedGet.mockResolvedValueOnce( { outputs: fakeOutputs } );
+
+		const outputs = await wpcomAgentStudioService.listOutputs( AGENCY_ID );
+
+		expect( outputs ).toEqual( fakeOutputs );
+		expect( mockedGet ).toHaveBeenCalledWith( {
+			apiNamespace: 'wpcom/v2',
+			path: '/agency/42/a4a/outputs',
+		} );
+	} );
+
+	it( 'returns an empty array when the response envelope is missing outputs', async () => {
+		mockedGet.mockResolvedValueOnce( {} );
+
+		expect( await wpcomAgentStudioService.listOutputs( AGENCY_ID ) ).toEqual( [] );
+	} );
+} );
+
+describe( 'wpcomAgentStudioService.createOutput', () => {
+	it( 'uploads the first image, dispatches the recipe, and synthesizes the row', async () => {
+		mockedPost.mockResolvedValueOnce( { url: 'https://example.com/hero.png' } );
+		mockedPost.mockResolvedValueOnce( { run_id: 99, status: 'pending' } );
+
+		const file = new File( [ 'image-bytes' ], 'hero.png', { type: 'image/png' } );
+
+		const output = await wpcomAgentStudioService.createOutput( AGENCY_ID, {
+			agentId: 'one-pager',
+			agentName: 'June',
+			deliverableType: 'PDF',
+			title: 'Launch one-pager',
+			description: 'Pitch leave-behind.',
+			brief: 'Launch copy paragraph.',
+			blurb: 'A short blurb.',
+			images: [ file ],
+		} );
+
+		// Step 1: media upload.
+		expect( mockedPost ).toHaveBeenNthCalledWith( 1, {
+			apiNamespace: 'wpcom/v2',
+			path: '/agency/42/a4a/media',
+			body: expect.any( FormData ),
+		} );
+		const firstCall = mockedPost.mock.calls[ 0 ][ 0 ] as { body: FormData };
+		expect( firstCall.body.get( 'media' ) ).toBe( file );
+
+		// Step 2: recipe dispatch — note no project_id in the body.
+		expect( mockedPost ).toHaveBeenNthCalledWith( 2, {
+			apiNamespace: 'wpcom/v2',
+			path: '/agency/42/a4a/runs',
+			body: {
+				recipe: 'compose-one-pager',
+				input: {
+					text: 'Launch copy paragraph.',
+					blurb: 'A short blurb.',
+					hero_url: 'https://example.com/hero.png',
+				},
+			},
+		} );
+
+		// Step 3: synthesized output.
+		expect( output.id ).toBe( '99' );
+		expect( output.status ).toBe( 'generating' );
+		expect( output.title ).toBe( 'Launch one-pager' );
+		expect( output.agentName ).toBe( 'June' );
+	} );
+
+	it( 'omits the upload call when no images are provided', async () => {
+		mockedPost.mockResolvedValueOnce( { run_id: 100 } );
+
+		await wpcomAgentStudioService.createOutput( AGENCY_ID, {
+			agentId: 'one-pager',
+			agentName: 'June',
+			deliverableType: 'PDF',
+			title: 'Text-only one-pager',
+			description: '',
+			brief: 'Just words.',
+			blurb: '',
+			images: [],
+		} );
+
+		expect( mockedPost ).toHaveBeenCalledTimes( 1 );
+		expect( mockedPost ).toHaveBeenCalledWith( {
+			apiNamespace: 'wpcom/v2',
+			path: '/agency/42/a4a/runs',
+			body: {
+				recipe: 'compose-one-pager',
+				input: { text: 'Just words.', blurb: '', hero_url: '' },
+			},
+		} );
+	} );
+
+	it( 'maps an unknown server status to generating', async () => {
+		mockedPost.mockResolvedValueOnce( { run_id: 'abc-123' } );
+
+		const output = await wpcomAgentStudioService.createOutput( AGENCY_ID, {
+			agentId: 'one-pager',
+			agentName: 'June',
+			deliverableType: 'PDF',
+			title: '',
+			description: '',
+			brief: '',
+			blurb: '',
+			images: [],
+		} );
+
+		expect( output.status ).toBe( 'generating' );
+		expect( output.id ).toBe( 'abc-123' );
+	} );
+} );
+
+describe( 'wpcomAgentStudioService.deleteOutput', () => {
+	it( 'issues a DELETE request against the run', async () => {
+		mockedPost.mockResolvedValueOnce( undefined );
+
+		await wpcomAgentStudioService.deleteOutput( AGENCY_ID, 'run-7' );
+
+		expect( mockedPost ).toHaveBeenCalledWith( {
+			method: 'DELETE',
+			apiNamespace: 'wpcom/v2',
+			path: '/agency/42/a4a/runs/run-7',
+		} );
+	} );
+} );
+
+describe( 'wpcomAgentStudioService.suggestOnePagerContent', () => {
+	const content =
+		'A faster path from first sale to repeat customer\n' +
+		'We help agencies cut launch time. Clients see results in weeks. Extra detail here.';
+
+	it( 'suggests a title from the first line of content', async () => {
+		expect( await wpcomAgentStudioService.suggestOnePagerContent( content, 'title' ) ).toBe(
+			'A faster path from first sale to repeat customer'
+		);
+	} );
+
+	it( 'suggests a blurb from the sentences after the first line', async () => {
+		expect( await wpcomAgentStudioService.suggestOnePagerContent( content, 'blurb' ) ).toBe(
+			'We help agencies cut launch time. Clients see results in weeks.'
+		);
+	} );
+
+	it( 'returns an empty string for empty content', async () => {
+		expect( await wpcomAgentStudioService.suggestOnePagerContent( '   ', 'title' ) ).toBe( '' );
+		expect( await wpcomAgentStudioService.suggestOnePagerContent( '   ', 'blurb' ) ).toBe( '' );
+	} );
+
+	it( 'does not call the network', async () => {
+		await wpcomAgentStudioService.suggestOnePagerContent( content, 'title' );
+		expect( mockedGet ).not.toHaveBeenCalled();
+		expect( mockedPost ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/a8c-for-agencies/sections/agent-studio/data/test/mock-agent-studio-service.test.ts
+++ b/client/a8c-for-agencies/sections/agent-studio/data/test/mock-agent-studio-service.test.ts
@@ -3,12 +3,17 @@
  */
 import { mockAgentStudioService } from '../mock-agent-studio-service';
 
+const AGENCY_ID = 1234;
+
 const briefInput = {
 	agentId: 'one-pager',
 	agentName: 'June',
 	deliverableType: 'One-pager',
 	title: 'Client launch one-pager',
 	description: 'A leave-behind for the pitch.',
+	brief: '',
+	blurb: '',
+	images: [],
 };
 
 describe( 'mockAgentStudioService default project', () => {
@@ -17,7 +22,7 @@ describe( 'mockAgentStudioService default project', () => {
 	} );
 
 	it( 'creates the default project when listing outputs before any exist', async () => {
-		const outputs = await mockAgentStudioService.listOutputs();
+		const outputs = await mockAgentStudioService.listOutputs( AGENCY_ID );
 		expect( outputs ).toEqual( [] );
 
 		const projects = await mockAgentStudioService.listProjects();
@@ -25,8 +30,8 @@ describe( 'mockAgentStudioService default project', () => {
 	} );
 
 	it( 'routes new outputs into a single shared default project', async () => {
-		await mockAgentStudioService.createOutput( briefInput );
-		await mockAgentStudioService.createOutput( {
+		await mockAgentStudioService.createOutput( AGENCY_ID, briefInput );
+		await mockAgentStudioService.createOutput( AGENCY_ID, {
 			...briefInput,
 			agentId: 'social-assets',
 			agentName: 'Iris',
@@ -37,7 +42,7 @@ describe( 'mockAgentStudioService default project', () => {
 		);
 		expect( defaultProjects ).toHaveLength( 1 );
 
-		const outputs = await mockAgentStudioService.listOutputs();
+		const outputs = await mockAgentStudioService.listOutputs( AGENCY_ID );
 		expect( outputs ).toHaveLength( 2 );
 		expect( outputs.every( ( output ) => output.projectId === defaultProjects[ 0 ].id ) ).toBe(
 			true
@@ -45,7 +50,7 @@ describe( 'mockAgentStudioService default project', () => {
 	} );
 
 	it( 'starts every created output in the generating state', async () => {
-		const output = await mockAgentStudioService.createOutput( briefInput );
+		const output = await mockAgentStudioService.createOutput( AGENCY_ID, briefInput );
 		expect( output.status ).toBe( 'generating' );
 	} );
 
@@ -53,13 +58,13 @@ describe( 'mockAgentStudioService default project', () => {
 		jest.useFakeTimers();
 		try {
 			jest.setSystemTime( new Date( '2026-05-19T10:00:00Z' ) );
-			await mockAgentStudioService.createOutput( briefInput );
+			await mockAgentStudioService.createOutput( AGENCY_ID, briefInput );
 
-			const [ stillGenerating ] = await mockAgentStudioService.listOutputs();
+			const [ stillGenerating ] = await mockAgentStudioService.listOutputs( AGENCY_ID );
 			expect( stillGenerating.status ).toBe( 'generating' );
 
 			jest.setSystemTime( new Date( '2026-05-19T10:00:10Z' ) );
-			const [ resolved ] = await mockAgentStudioService.listOutputs();
+			const [ resolved ] = await mockAgentStudioService.listOutputs( AGENCY_ID );
 			expect( resolved.status ).toBe( 'ready' );
 			expect( resolved.previewUrls?.length ).toBeGreaterThan( 0 );
 			expect( resolved.assetCount ).toBeGreaterThan( 0 );
@@ -69,10 +74,10 @@ describe( 'mockAgentStudioService default project', () => {
 	} );
 
 	it( 'removes a deliverable from the list when deleted', async () => {
-		const output = await mockAgentStudioService.createOutput( briefInput );
-		await mockAgentStudioService.deleteOutput( output.id );
+		const output = await mockAgentStudioService.createOutput( AGENCY_ID, briefInput );
+		await mockAgentStudioService.deleteOutput( AGENCY_ID, output.id );
 
-		expect( await mockAgentStudioService.listOutputs() ).toEqual( [] );
+		expect( await mockAgentStudioService.listOutputs( AGENCY_ID ) ).toEqual( [] );
 	} );
 } );
 

--- a/client/a8c-for-agencies/sections/agent-studio/data/use-agent-studio-outputs.ts
+++ b/client/a8c-for-agencies/sections/agent-studio/data/use-agent-studio-outputs.ts
@@ -1,13 +1,21 @@
 import { useQuery } from '@tanstack/react-query';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { agentStudioService } from './agent-studio-service';
 import type { AgentStudioOutput } from '../types';
 
-export const getAgentStudioOutputsQueryKey = () => [ 'a4a-agent-studio-outputs' ];
+export const getAgentStudioOutputsQueryKey = ( agencyId: number | undefined ) => [
+	'a4a-agent-studio-outputs',
+	agencyId,
+];
 
 export default function useAgentStudioOutputs() {
+	const agencyId = useSelector( getActiveAgencyId );
+
 	return useQuery< AgentStudioOutput[] >( {
-		queryKey: getAgentStudioOutputsQueryKey(),
-		queryFn: () => agentStudioService.listOutputs(),
+		queryKey: getAgentStudioOutputsQueryKey( agencyId ),
+		queryFn: () => agentStudioService.listOutputs( agencyId as number ),
+		enabled: !! agencyId,
 		refetchOnWindowFocus: false,
 		// Poll while a deliverable is generating so the card flips to ready
 		// without the agency having to reload the page.

--- a/client/a8c-for-agencies/sections/agent-studio/data/use-create-agent-studio-output.ts
+++ b/client/a8c-for-agencies/sections/agent-studio/data/use-create-agent-studio-output.ts
@@ -1,4 +1,6 @@
 import { useMutation, useQueryClient, type UseMutationOptions } from '@tanstack/react-query';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { agentStudioService } from './agent-studio-service';
 import { getAgentStudioOutputsQueryKey } from './use-agent-studio-outputs';
 import type { AgentStudioOutput, CreateAgentStudioOutputInput } from '../types';
@@ -7,12 +9,18 @@ type Options = UseMutationOptions< AgentStudioOutput, Error, CreateAgentStudioOu
 
 export default function useCreateAgentStudioOutput( options?: Options ) {
 	const queryClient = useQueryClient();
+	const agencyId = useSelector( getActiveAgencyId );
 
 	return useMutation< AgentStudioOutput, Error, CreateAgentStudioOutputInput >( {
 		...options,
-		mutationFn: ( input ) => agentStudioService.createOutput( input ),
+		mutationFn: ( input ) => {
+			if ( ! agencyId ) {
+				return Promise.reject( new Error( 'Missing agency id' ) );
+			}
+			return agentStudioService.createOutput( agencyId, input );
+		},
 		onSuccess: ( output, variables, context ) => {
-			queryClient.invalidateQueries( { queryKey: getAgentStudioOutputsQueryKey() } );
+			queryClient.invalidateQueries( { queryKey: getAgentStudioOutputsQueryKey( agencyId ) } );
 			options?.onSuccess?.( output, variables, context );
 		},
 	} );

--- a/client/a8c-for-agencies/sections/agent-studio/data/use-delete-agent-studio-output.ts
+++ b/client/a8c-for-agencies/sections/agent-studio/data/use-delete-agent-studio-output.ts
@@ -1,4 +1,6 @@
 import { useMutation, useQueryClient, type UseMutationOptions } from '@tanstack/react-query';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { agentStudioService } from './agent-studio-service';
 import { getAgentStudioOutputsQueryKey } from './use-agent-studio-outputs';
 
@@ -6,12 +8,18 @@ type Options = UseMutationOptions< void, Error, string >;
 
 export default function useDeleteAgentStudioOutput( options?: Options ) {
 	const queryClient = useQueryClient();
+	const agencyId = useSelector( getActiveAgencyId );
 
 	return useMutation< void, Error, string >( {
 		...options,
-		mutationFn: ( outputId ) => agentStudioService.deleteOutput( outputId ),
+		mutationFn: ( outputId ) => {
+			if ( ! agencyId ) {
+				return Promise.reject( new Error( 'Missing agency id' ) );
+			}
+			return agentStudioService.deleteOutput( agencyId, outputId );
+		},
 		onSuccess: ( result, outputId, context ) => {
-			queryClient.invalidateQueries( { queryKey: getAgentStudioOutputsQueryKey() } );
+			queryClient.invalidateQueries( { queryKey: getAgentStudioOutputsQueryKey( agencyId ) } );
 			options?.onSuccess?.( result, outputId, context );
 		},
 	} );

--- a/client/a8c-for-agencies/sections/agent-studio/docs/api-migration.md
+++ b/client/a8c-for-agencies/sections/agent-studio/docs/api-migration.md
@@ -1,0 +1,247 @@
+# Agent Studio — real API migration
+
+Agent Studio ships against `mockAgentStudioService` (a localStorage stand-in
+that lives in `data/mock-agent-studio-service.ts`). This doc is the bridge
+between that mock and the real wpcom endpoints under
+`/wpcom/v2/agency/<agency_id>/a4a/`. It captures what's missing on the server,
+what changes on the client, and the order in which they ship.
+
+The `Project` entity from #110716 is intentionally **not removed** — the
+client hides it behind a server-provisioned "Default" project, the server-side
+types stay intact so we can resurface projects when more agents land. See
+"Default project bridge" below.
+
+## What ships today
+
+**Client surface** (`data/agent-studio-service.ts` → `mock-agent-studio-service.ts`):
+
+- `listOutputs()` — overview's deliverable grid, polled every 2s while
+  anything is `generating`.
+- `createOutput({ agentId, agentName, deliverableType, title, description })`
+  — invoked by every brief form.
+- `deleteOutput(outputId)` — card's destructive action.
+- `suggestOnePagerContent(brief, field)` — heuristic stand-in behind
+  one-pager's "Suggest" button.
+- Legacy `listProjects` / `getProject` / `createProject` / `deleteProject` /
+  `listProjectOutputs` — unreachable from the active UI; left in place per
+  the project-resurrection plan.
+
+**wpcom endpoints** (rest-api-plugins/centralized/agency/):
+
+- `GET/POST /a4a/projects`, `GET/DELETE /a4a/projects/<id>`,
+  `GET /a4a/projects/<id>/outputs` — full project CRUD + per-project output
+  projection.
+- `POST /a4a/runs`, `GET/DELETE /a4a/runs/<id>` — recipe dispatch + polling.
+  Public recipes: `compose-one-pager`, `amplify-ai`.
+- `GET /a4a/collateral/<post_id>` — variants + `html_url` /
+  `pdf_download_url` for a finished one-pager.
+- `POST /a4a/media` — image upload to `a8cforagenciesportfolio.wordpress.com`.
+
+## Decisions
+
+1. **Default project bridge.** Server auto-provisions a single "Default"
+   project per agency on first need. `project_id` becomes optional on
+   `POST /a4a/runs`; the dispatcher resolves it from the default. The
+   client never sees projects.
+2. **Suggest title/blurb.** The heuristic from the mock moves into the real
+   `agentStudioService` as a temporary implementation, marked TODO. Replaced
+   by a real LLM call when the wpcom endpoint lands (see "Server gaps").
+3. **Image upload.** Happens at submit, inside `agentStudioService.createOutput`.
+   Files upload serially to `POST /a4a/media`; returned URLs thread into the
+   recipe input. One error path; submit gets slower; form stays simple.
+4. **Image → recipe slot mapping.** First file → `hero_url`; remaining files
+   ignored. `logo_url` / `partner_logo_url` stay empty (the renderer already
+   handles missing brand assets). Multi-image UI stays; gap documented.
+5. **Polling.** Bulk list against a new `GET /a4a/outputs` (flat across all
+   projects). `useAgentStudioOutputs` keeps its 2s tick.
+6. **Card preview.** No image thumbnails. The card swaps the thumb strip for
+   a single page icon + "X pages" on `ready` outputs. Server projection emits
+   `pageCount`; `previewUrls` stays undefined.
+7. **Delete.** `DELETE /a4a/runs/<id>` hard-deletes the run AND its linked
+   collateral when terminal; existing cancel path keeps for non-terminal. The
+   projection filters cancelled runs so a mid-flight cancel disappears too.
+8. **Iris status.** Flip `disabled: true` on Iris (`lib/agents.ts`) — same
+   "Joining soon" treatment as Remy — until a `compose-social-assets` recipe
+   exists. Brief form code stays so we can re-enable in one line.
+9. **Retrieval.** Click on a `ready` card opens the PDF in a new tab. The
+   projection adds `downloadUrl` to ready outputs, derived from the linked
+   collateral's first variant `pdf_download_url`.
+
+## Sequencing
+
+**PR1 — wpcom** (`~/Projects/wpcom`): all server changes ship together. Lands
+and deploys before PR2.
+
+**PR2 — wp-calypso** (this repo): client swap from mock to real service.
+Lands once PR1 is in production.
+
+## PR1: wpcom server changes
+
+**`wp-content/rest-api-plugins/centralized/agency/agency-a4a-agent-runs.php`**
+
+- Make `project_id` optional on `POST /a4a/runs`. When absent, the handler
+  calls `Project_Repository::find_or_create_default( $agency_id )` (new) and
+  injects the resulting id into `$raw_input['project_id']` before
+  `Dispatcher::enqueue_recipe`.
+- `DELETE /a4a/runs/<run_id>`: when the run is terminal
+  (`STATUS_COMPLETED` / `STATUS_FAILED` / `STATUS_CANCELLED`), `wp_delete_post`
+  the run and any `a4a_mc_collateral` post linked via `_a4a_run_id`. Keep the
+  existing transition-to-cancelled path for non-terminal runs.
+
+**`wp-content/lib/a4a-agents/projects/class-a4a-project-repository.php`**
+
+- New `find_or_create_default( int $agency_id ): Project|WP_Error`. Looks for
+  an existing project with `META_IS_DEFAULT = '1'`; creates one named
+  `"Default"` with that meta if missing. Idempotent; safe to call on every
+  run. Doesn't count against `MAX_PROJECTS_PER_AGENCY`.
+
+**`wp-content/lib/a4a-agents/cpts/class-a4a-project-cpt.php`**
+
+- Add `META_IS_DEFAULT` constant.
+
+**New: `wp-content/rest-api-plugins/centralized/agency/agency-a4a-agent-outputs.php`**
+
+- `GET /wpcom/v2/agency/<agency_id>/a4a/outputs` → `{ outputs: AgentStudioOutput[] }`.
+- Internally: load all projects for the agency, run
+  `Project_Output_Projection::project_outputs` for each, concatenate, sort by
+  `updatedAt` desc, return.
+- Auth + capability: `AUTH_A4A_USER` + `a4a_run_agents`, same as siblings.
+
+**`wp-content/lib/a4a-agents/projects/class-a4a-project-output-projection.php`**
+
+- Add `downloadUrl` to projected outputs in `ready` state: read the linked
+  collateral post (already bulk-fetched), pick its first variant's
+  `pdf_download_url`. Null when no collateral is linked yet.
+- Add `pageCount`: derive from collateral's `post_content` using the same
+  `<!-- PAGE -->` counting `agency-a4a-collateral.php` already does (extract
+  to a shared helper). Null when no collateral is linked yet.
+- Filter cancelled runs out of `project_outputs`. The runs endpoint still
+  returns them on direct `GET /a4a/runs/<id>` for any caller that needs them.
+
+**`wp-content/lib/a4a-agents/recipes/compose-one-pager.yaml`**
+
+- No change. `project_id` continues to be passed through; the runs handler
+  populates it from the default project when the client omits it.
+
+## PR2: wp-calypso client changes
+
+**`client/a8c-for-agencies/sections/agent-studio/data/agent-studio-service.ts`**
+
+- Replace the `mockAgentStudioService` re-export with a real
+  `wpcomAgentStudioService` that:
+  - reads the active agency id via `getActiveAgencyId` (selector already used
+    by other A4A hooks — see `sections/benchmarks/hooks/use-fetch-benchmarks-aggregates.ts`),
+  - issues requests through `wpcom.req.{get,post,delete}` with
+    `apiNamespace: 'wpcom/v2'` and path `/agency/<id>/a4a/...`,
+  - implements `listOutputs` / `createOutput` / `deleteOutput` against the
+    new endpoints,
+  - keeps `suggestOnePagerContent` as the existing heuristic (literally the
+    same code, moved verbatim) with a `// TODO: real endpoint` and a link
+    to this doc.
+
+**`client/a8c-for-agencies/sections/agent-studio/types.ts`**
+
+- `CreateAgentStudioOutputInput` grows to carry the recipe-relevant input:
+
+  ```ts
+  export interface CreateAgentStudioOutputInput {
+  	agentId: AgentStudioAgentId;
+  	agentName: string;
+  	deliverableType: string;
+  	// User-typed metadata, surfaced on the card.
+  	title: string;
+  	description: string;
+  	// Recipe input — used only when the agent has a recipe (today: one-pager).
+  	brief: string;
+  	blurb: string;
+  	images: File[];
+  }
+  ```
+
+- `AgentStudioOutput` gains `downloadUrl?: string` and `pageCount?: number`.
+
+**`client/a8c-for-agencies/sections/agent-studio/data/use-agent-studio-outputs.ts`**
+
+- Query key includes the agency id.
+- Calls `GET /agency/<id>/a4a/outputs`; service returns `data.outputs`.
+- Keep the existing 2s `refetchInterval` while anything is `generating`.
+
+**`client/a8c-for-agencies/sections/agent-studio/data/use-create-agent-studio-output.ts`**
+
+- No change in shape — still a `useMutation` that delegates to the service.
+- Service internally:
+  1. Upload `images[0]` via `POST /a4a/media`, capture the returned `url`.
+  2. `POST /a4a/runs` with `{ recipe: 'compose-one-pager', input: { text: brief, blurb, hero_url } }`.
+  3. Return a synthesized `AgentStudioOutput` from `{ run_id, status }` plus
+     the input metadata (title, description, agentName, deliverableType,
+     `createdAt: new Date().toISOString()`, `status: 'generating'`).
+  4. Caller invalidates `outputs` query; the next tick picks up the real row.
+
+**`client/a8c-for-agencies/sections/agent-studio/data/use-delete-agent-studio-output.ts`**
+
+- No change. Service `deleteOutput` calls `DELETE /a4a/runs/<id>`.
+
+**`client/a8c-for-agencies/sections/agent-studio/primary/brief/one-pager-brief-form.tsx`**
+
+- `mutation.mutate(...)` payload grows to carry `brief` (from `brief` state)
+  and `images: File[]` (from `images` state) in addition to today's fields.
+
+**`client/a8c-for-agencies/sections/agent-studio/primary/brief/social-assets-brief-form.tsx`**
+
+- No code changes today; the form becomes unreachable once Iris is disabled.
+
+**`client/a8c-for-agencies/sections/agent-studio/lib/agents.ts`**
+
+- Iris: `disabled: true`. Greeting and copy stay.
+
+**`client/a8c-for-agencies/sections/agent-studio/primary/overview/deliverable-card.tsx`**
+
+- `DeliverablePreview` for `ready`: when `output.previewUrls` is absent
+  (current reality), render a single page icon + `output.pageCount` "pages"
+  copy. The strip stays for forward-compat when previews land.
+- Card wraps in an anchor (or `onClick`) that opens `output.downloadUrl` in a
+  new tab when status is `ready` and `downloadUrl` is set. Delete button
+  stops propagation.
+- `getMetaLabel`: prefer `pageCount` over `assetCount` for the one-pager
+  agent, fall back to the existing `assetCount` heuristic. Keeps the social
+  branch ready for when Iris ships.
+
+**Mock removal**
+
+- `data/mock-agent-studio-service.ts` and its test stay for one release as a
+  development-only fallback (toggled by a build flag, or kept as a reference
+  for the project-resurrection PR). Delete in a follow-up once PR2 is stable.
+
+## Deferred gaps
+
+These are real product gaps the migration creates or surfaces, but doesn't
+close:
+
+- **Suggest title/blurb endpoint.** Today's heuristic is good enough for the
+  shape of the brief. A real `POST /a4a/suggest-content` (or similar) would
+  call the LLM with the brief and field requested. Tracking:
+  `client/a8c-for-agencies/sections/agent-studio/data/agent-studio-service.ts`
+  → look for `TODO: real suggest endpoint`.
+- **`compose-social-assets` recipe** for Iris. UI form already exists with
+  source/manual modes. Needs an ability pipeline that emits the four social
+  sizes (`1200×630`, `1080×1080`, `600×300`, `1080×1920`).
+- **`compose-event-assets` recipe** for Remy. Form does not yet exist.
+- **Multi-image support in `compose-one-pager`.** Today only `hero_url` is
+  wired. The brief form already lets agencies reorder up to N files. A
+  recipe-input change (e.g., `images: string[]`) plus a placement strategy
+  in `op-layout-director-ela` would close this.
+- **Image thumbnails on `DeliverableCard`.** A Browserless screenshot step
+  appended to the one-pager recipe (or a separate post-render job) would
+  emit a small PNG of the cover, stored on the collateral and surfaced as
+  `previewUrls` by the projection.
+- **Output detail view.** Click-opens-PDF is the MVP. A real detail route
+  (`/agents/:agentId/outputs/:outputId`) with variant picking and HTML
+  preview is the next step, modelled on the legacy `project-detail` page.
+- **Trash / undo.** Hard delete is destructive. A trashed-runs view with a
+  restore action would be a meaningful follow-up; it'd swap the projection
+  filter from "drop cancelled" to "drop trashed unless trashed view".
+
+## Open questions
+
+None at handoff time. Decisions 1–9 above were resolved through the
+`/grill-with-docs` session attached to the PR review on #110840.

--- a/client/a8c-for-agencies/sections/agent-studio/lib/agents.ts
+++ b/client/a8c-for-agencies/sections/agent-studio/lib/agents.ts
@@ -44,6 +44,9 @@ export function useAgentStudioAgents(): AgentStudioAgent[] {
 				],
 				icon: image,
 				previewImage: socialAssetsPreview,
+				// No `compose-social-assets` recipe on the server yet — see the
+				// "Deferred gaps" section in docs/api-migration.md.
+				disabled: true,
 			},
 			{
 				id: 'one-pager',

--- a/client/a8c-for-agencies/sections/agent-studio/primary/brief/one-pager-brief-form.tsx
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/brief/one-pager-brief-form.tsx
@@ -65,6 +65,9 @@ export default function OnePagerBriefForm( { agent }: Props ) {
 			deliverableType: agent.deliverableType,
 			title: title.trim(),
 			description: blurb.trim() || getBriefExcerpt( brief ),
+			brief: brief.trim(),
+			blurb: blurb.trim(),
+			images,
 		} );
 	};
 

--- a/client/a8c-for-agencies/sections/agent-studio/primary/brief/social-assets-brief-form.tsx
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/brief/social-assets-brief-form.tsx
@@ -77,6 +77,12 @@ export default function SocialAssetsBriefForm( { agent }: Props ) {
 			deliverableType: agent.deliverableType,
 			title,
 			description,
+			// Iris is currently disabled (no `compose-social-assets` recipe yet),
+			// so this branch is unreachable. The recipe-input fields are kept
+			// empty to satisfy the typed mutation contract.
+			brief: mode === 'source' ? sourceText.trim() : '',
+			blurb: mode === 'manual' ? statContext.trim() : '',
+			images,
 		} );
 	};
 

--- a/client/a8c-for-agencies/sections/agent-studio/primary/overview/deliverable-card.tsx
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/overview/deliverable-card.tsx
@@ -10,8 +10,11 @@ import {
 } from '@wordpress/components';
 import { dateI18n } from '@wordpress/date';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { Icon, warning } from '@wordpress/icons';
-import { useState } from 'react';
+import { Icon, page, warning } from '@wordpress/icons';
+import clsx from 'clsx';
+import { useState, type MouseEvent } from 'react';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import DeleteDeliverableDialog from './delete-deliverable-dialog';
 import type { AgentStudioOutput } from '../../types';
 
@@ -23,9 +26,36 @@ interface Props {
 
 export default function DeliverableCard( { output }: Props ) {
 	const [ isDeleteDialogOpen, setIsDeleteDialogOpen ] = useState( false );
+	const dispatch = useDispatch();
+
+	const isOpenable = output.status === 'ready' && !! output.downloadUrl;
+
+	const onCardClick = () => {
+		if ( ! isOpenable || ! output.downloadUrl ) {
+			return;
+		}
+
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_agent_studio_output_opened', {
+				output_id: output.id,
+			} )
+		);
+		window.open( output.downloadUrl, '_blank', 'noopener,noreferrer' );
+	};
+
+	const onDeleteClick = ( event: MouseEvent< HTMLButtonElement > ) => {
+		event.stopPropagation();
+		setIsDeleteDialogOpen( true );
+	};
 
 	return (
-		<Card size="small" className="a4a-agent-studio-deliverable-card">
+		<Card
+			size="small"
+			className={ clsx( 'a4a-agent-studio-deliverable-card', {
+				'is-openable': isOpenable,
+			} ) }
+			onClick={ isOpenable ? onCardClick : undefined }
+		>
 			<CardMedia className="a4a-agent-studio-deliverable-card__media">
 				<DeliverablePreview output={ output } />
 			</CardMedia>
@@ -38,7 +68,7 @@ export default function DeliverableCard( { output }: Props ) {
 					<Text variant="muted">{ getMetaLabel( output ) }</Text>
 				</VStack>
 				<HStack justify="flex-end">
-					<Button variant="secondary" isDestructive onClick={ () => setIsDeleteDialogOpen( true ) }>
+					<Button variant="secondary" isDestructive onClick={ onDeleteClick }>
 						{ __( 'Delete' ) }
 					</Button>
 				</HStack>
@@ -73,9 +103,32 @@ function DeliverablePreview( { output }: Props ) {
 		);
 	}
 
+	// Real one-pager outputs don't ship preview images yet — render a single
+	// page icon + page count. The strip stays for forward-compat when image
+	// previews land (see "Deferred gaps" in docs/api-migration.md).
+	if ( ! output.previewUrls?.length ) {
+		const pageCount = output.pageCount ?? 0;
+		return (
+			<div className="a4a-agent-studio-deliverable-card__state">
+				<Icon icon={ page } size={ 32 } />
+				{ pageCount > 0 && (
+					<Text>
+						{ sprintf(
+							/* translators: %d is the number of pages in the deliverable. */
+							_n( '%d page', '%d pages', pageCount ),
+							pageCount
+						) }
+					</Text>
+				) }
+			</div>
+		);
+	}
+
 	return (
 		<div className="a4a-agent-studio-deliverable-card__strip">
-			{ output.previewUrls?.map( ( url ) => <img key={ url } src={ url } alt="" /> ) }
+			{ output.previewUrls.map( ( url ) => (
+				<img key={ url } src={ url } alt="" />
+			) ) }
 		</div>
 	);
 }
@@ -87,6 +140,16 @@ function getMetaLabel( output: AgentStudioOutput ) {
 
 	if ( output.status === 'failed' ) {
 		return __( 'Generation failed' );
+	}
+
+	// Prefer pageCount for one-pager-shaped outputs; fall back to assetCount
+	// for social-assets-shape outputs.
+	if ( output.pageCount !== undefined ) {
+		return sprintf(
+			/* translators: %d is the number of pages in the deliverable. */
+			_n( '%d page', '%d pages', output.pageCount ),
+			output.pageCount
+		);
 	}
 
 	const count = output.assetCount ?? output.previewUrls?.length ?? 0;

--- a/client/a8c-for-agencies/sections/agent-studio/primary/overview/style.scss
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/overview/style.scss
@@ -22,6 +22,14 @@
 	height: 100%;
 }
 
+.a4a-agent-studio-deliverable-card.is-openable {
+	cursor: pointer;
+}
+
+.a4a-agent-studio-deliverable-card.is-openable:hover {
+	box-shadow: 0 0 0 1px var( --color-border-subtle );
+}
+
 .a4a-agent-studio-deliverable-card__media.components-card__media {
 	display: flex;
 	align-items: center;

--- a/client/a8c-for-agencies/sections/agent-studio/primary/overview/test/deliverable-card.test.tsx
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/overview/test/deliverable-card.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
+import DeliverableCard from '../deliverable-card';
+import type { AgentStudioOutput } from '../../../types';
+
+// Stub the delete dialog — its render path is independent and pulls in extra
+// Redux state we don't need for this card's behavior.
+jest.mock( '../delete-deliverable-dialog', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+
+function renderWithStore( ui: React.ReactElement ) {
+	const store = createStore( ( state = {} ) => state );
+	return render( <Provider store={ store }>{ ui }</Provider> );
+}
+
+function makeOutput( overrides: Partial< AgentStudioOutput > = {} ): AgentStudioOutput {
+	return {
+		id: 'run-1',
+		projectId: '',
+		title: 'Launch one-pager',
+		description: 'Pitch leave-behind.',
+		agentName: 'June',
+		deliverableType: 'PDF',
+		status: 'ready',
+		createdAt: '2026-05-20T10:00:00Z',
+		updatedAt: '2026-05-20T10:05:00Z',
+		...overrides,
+	};
+}
+
+beforeEach( () => {
+	jest.restoreAllMocks();
+} );
+
+describe( 'DeliverableCard', () => {
+	it( 'shows the page count copy when a ready one-pager has no preview images', () => {
+		const output = makeOutput( { pageCount: 4 } );
+
+		renderWithStore( <DeliverableCard output={ output } /> );
+
+		expect( screen.getAllByText( '4 pages' ).length ).toBeGreaterThan( 0 );
+	} );
+
+	it( 'falls back to assetCount when pageCount is absent', () => {
+		const output = makeOutput( {
+			pageCount: undefined,
+			assetCount: 6,
+			deliverableType: 'Social assets',
+			previewUrls: [ 'https://example.com/a.png' ],
+		} );
+
+		renderWithStore( <DeliverableCard output={ output } /> );
+
+		expect( screen.getByText( '6 assets' ) ).toBeVisible();
+	} );
+
+	it( 'opens the PDF in a new tab when a ready card with a downloadUrl is clicked', async () => {
+		const open = jest.spyOn( window, 'open' ).mockImplementation( () => null );
+		const user = userEvent.setup();
+
+		const output = makeOutput( {
+			pageCount: 2,
+			downloadUrl: 'https://example.com/run-1.pdf',
+		} );
+
+		renderWithStore( <DeliverableCard output={ output } /> );
+
+		await user.click( screen.getByText( 'Launch one-pager' ) );
+
+		expect( open ).toHaveBeenCalledWith(
+			'https://example.com/run-1.pdf',
+			'_blank',
+			'noopener,noreferrer'
+		);
+	} );
+
+	it( 'does not open anything when the card is generating', async () => {
+		const open = jest.spyOn( window, 'open' ).mockImplementation( () => null );
+		const user = userEvent.setup();
+
+		const output = makeOutput( { status: 'generating', downloadUrl: undefined } );
+
+		renderWithStore( <DeliverableCard output={ output } /> );
+
+		await user.click( screen.getByText( 'Launch one-pager' ) );
+
+		expect( open ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not open anything when the Delete button is clicked on an openable card', async () => {
+		const open = jest.spyOn( window, 'open' ).mockImplementation( () => null );
+		const user = userEvent.setup();
+
+		const output = makeOutput( {
+			pageCount: 2,
+			downloadUrl: 'https://example.com/run-1.pdf',
+		} );
+
+		renderWithStore( <DeliverableCard output={ output } /> );
+
+		await user.click( screen.getByRole( 'button', { name: 'Delete' } ) );
+
+		expect( open ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/a8c-for-agencies/sections/agent-studio/types.ts
+++ b/client/a8c-for-agencies/sections/agent-studio/types.ts
@@ -22,6 +22,10 @@ export interface AgentStudioOutput {
 	previewUrls?: string[];
 	/** Total number of assets the agent produced, populated once status is ready. */
 	assetCount?: number;
+	/** PDF download URL for a ready one-pager deliverable. */
+	downloadUrl?: string;
+	/** Page count for a ready one-pager deliverable. */
+	pageCount?: number;
 	createdAt: string;
 	updatedAt: string;
 }
@@ -41,8 +45,13 @@ export interface CreateAgentStudioOutputInput {
 	agentId: string;
 	agentName: string;
 	deliverableType: string;
+	// User-typed metadata, surfaced on the card.
 	title: string;
 	description: string;
+	// Recipe input — used only when the agent has a recipe (today: one-pager).
+	brief: string;
+	blurb: string;
+	images: File[];
 }
 
 export type OnePagerContentField = 'title' | 'blurb';
@@ -53,8 +62,11 @@ export interface AgentStudioService {
 	createProject( input: CreateAgentStudioProjectInput ): Promise< AgentStudioProject >;
 	deleteProject( projectId: string ): Promise< void >;
 	listProjectOutputs( projectId: string ): Promise< AgentStudioOutput[] >;
-	listOutputs(): Promise< AgentStudioOutput[] >;
-	createOutput( input: CreateAgentStudioOutputInput ): Promise< AgentStudioOutput >;
-	deleteOutput( outputId: string ): Promise< void >;
+	listOutputs( agencyId: number ): Promise< AgentStudioOutput[] >;
+	createOutput(
+		agencyId: number,
+		input: CreateAgentStudioOutputInput
+	): Promise< AgentStudioOutput >;
+	deleteOutput( agencyId: number, outputId: string ): Promise< void >;
 	suggestOnePagerContent( brief: string, field: OnePagerContentField ): Promise< string >;
 }


### PR DESCRIPTION
Part of #110840

## Proposed Changes

- Replace `mockAgentStudioService` with a real `wpcomAgentStudioService` in `data/agent-studio-service.ts` that talks to `POST /a4a/media`, `POST /a4a/runs`, `GET /a4a/outputs`, and `DELETE /a4a/runs/<id>` under `/agency/<id>/`.
- Reshape `CreateAgentStudioOutputInput` (`types.ts`) to carry `brief`, `blurb`, and `images: File[]` alongside the existing card metadata, and add `downloadUrl?` / `pageCount?` to `AgentStudioOutput` so the projection can light up the ready card.
- Thread the active agency id (`getActiveAgencyId`) through `useAgentStudioOutputs`, `useCreateAgentStudioOutput`, and `useDeleteAgentStudioOutput`; key the outputs query on it.
- `OnePagerBriefForm` forwards `brief` and `images` into the mutation. `SocialAssetsBriefForm` is updated for the typed mutation contract but stays unreachable while Iris is disabled.
- Flip `disabled: true` on Iris in `lib/agents.ts` — there is no `compose-social-assets` recipe yet (see "Deferred gaps" in the migration doc).
- `DeliverableCard`: when a ready one-pager has no preview images, show a single page icon + "X pages" copy using `pageCount`; preview-strip path stays for forward-compat. The card opens `downloadUrl` in a new tab on click for ready outputs, and the Delete button stops propagation. `getMetaLabel` prefers `pageCount`, falls back to `assetCount`.
- `suggestOnePagerContent` keeps the heuristic from the mock as a TODO; a real endpoint is tracked in the doc.
- Mock service and its test remain — flagged for removal in a follow-up per the migration doc.
- Adds service-level tests that mock `wpcom.req` (`data/test/agent-studio-service.test.ts`) and card-level tests covering the openable behavior and the pages/assets meta fork (`primary/overview/test/deliverable-card.test.tsx`).

## Why are these changes being made?

PR2 of the Agent Studio API migration. The wpcom server PR (in flight separately) provisions a Default project per agency, ships a flat `GET /a4a/outputs` projection (with `downloadUrl` and `pageCount`), and hard-deletes terminal runs. This PR swaps the localStorage mock for those endpoints so submitting a brief actually dispatches the `compose-one-pager` recipe and the overview reflects real runs.

Full migration plan and the nine decisions behind the shape lives at `client/a8c-for-agencies/sections/agent-studio/docs/api-migration.md`.

The `a4a-agent-studio` feature flag is dev-only across `a8c-for-agencies-stage.json`, `a8c-for-agencies-horizon.json`, and `a8c-for-agencies-production.json` (only `a8c-for-agencies-development.json` has it `true`). All Agent Studio routes are gated behind `isEnabled('a4a-agent-studio')` in `client/a8c-for-agencies/sections/learn/index.ts`, so landing this before the wpcom PR deploys is safe — production users never hit the new code paths.

## Testing Instructions

1. Make sure the wpcom PR is on your sandbox (the new endpoints will not exist on production yet).
2. `yarn start-a8c-for-agencies` and visit `/agent-studio` in dev (the flag is on by default in `a8c-for-agencies-development.json`).
3. Click **New deliverable**, pick **June** (Iris should be greyed out with the "Joining soon" treatment).
4. Paste a paragraph into the brief, add at least one image, click **Send it to June**.
5. You should land back on the overview with a generating card. Within a few polling ticks (2s each) it should flip to ready and show a `page` icon plus an "X pages" line.
6. Click anywhere on the ready card except the Delete button — the one-pager PDF should open in a new tab.
7. Click Delete; confirm in the dialog; the card should disappear.
8. Try the same with no images and a long brief — it should still dispatch (`hero_url` will be empty in the recipe input).
9. Verify in DevTools that the network calls land on `/wpcom/v2/agency/<id>/a4a/{media,runs,outputs}` and that no `project_id` is sent in the run dispatch body.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?