### PR TITLE
Magic Login: forward redirectTo in the code variant

### DIFF
--- a/client/login/magic-login/request-login-code.jsx
+++ b/client/login/magic-login/request-login-code.jsx
@@ -11,7 +11,10 @@ import Notice from 'calypso/components/notice';
 import { sendEmailLogin } from 'calypso/state/auth/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { hideMagicLoginRequestNotice } from 'calypso/state/login/magic-login/actions';
-import { getLastCheckedUsernameOrEmail } from 'calypso/state/login/selectors';
+import {
+	getLastCheckedUsernameOrEmail,
+	getRedirectToOriginal,
+} from 'calypso/state/login/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 import getMagicLoginRequestEmailError from 'calypso/state/selectors/get-magic-login-request-email-error';
@@ -185,10 +188,11 @@ RequestLoginCode.propTypes = {
 	onPublicTokenReceived: PropTypes.func,
 };
 
-const mapState = ( state ) => ( {
+export const mapState = ( state ) => ( {
 	currentUser: getCurrentUser( state ),
 	isFetching: isFetchingMagicLoginEmail( state ),
 	requestError: getMagicLoginRequestEmailError( state ),
+	redirectTo: getRedirectToOriginal( state ),
 	userEmail:
 		getLastCheckedUsernameOrEmail( state ) ||
 		getCurrentQueryArguments( state ).email_address ||

--- a/client/login/magic-login/test/request-login-code.test.jsx
+++ b/client/login/magic-login/test/request-login-code.test.jsx
@@ -1,0 +1,43 @@
+/** @jest-environment jsdom */
+import { mapState } from '../request-login-code';
+
+describe( 'RequestLoginCode mapState', () => {
+	const baseState = {
+		currentUser: { id: null },
+		users: { items: {} },
+		login: {
+			isFormDisabled: false,
+			lastCheckedUsernameOrEmail: '',
+			magicLogin: {
+				requestEmailError: null,
+				isFetchingEmail: false,
+				currentView: null,
+				requestedEmailSuccessfully: false,
+				requestAuthError: null,
+				rememberMe: false,
+			},
+			redirectTo: { original: '' },
+		},
+		route: { query: { current: {}, initial: {} } },
+	};
+
+	it( 'forwards redirectTo from state so the magic-code POST to /auth/send-login-email carries `redirect_to`', () => {
+		// Regression: previously RequestLoginCode's mapState did not read redirectTo,
+		// so the POST omitted `redirect_to` and the wpcom unified-connection magic-link
+		// block could not parse `from=jetpack-connector` out of it.
+		const state = {
+			...baseState,
+			login: {
+				...baseState.login,
+				redirectTo: {
+					original:
+						'https://wordpress.com/jetpack/connect/authorize?from=jetpack-connector&plugins=jetpack',
+				},
+			},
+		};
+
+		expect( mapState( state ).redirectTo ).toBe(
+			'https://wordpress.com/jetpack/connect/authorize?from=jetpack-connector&plugins=jetpack'
+		);
+	} );
+} );


### PR DESCRIPTION
Related to CONNECT-186

## Proposed changes

* Read `redirectTo` from Redux in `RequestLoginCode`'s `mapState` and forward it to the `sendEmailLogin` action — same plumbing `RequestLoginEmailForm` already has; the code variant was missing it.
* Export `mapState` and add a unit test asserting `redirectTo` is forwarded.

## Why are these changes being made?

* The magic-code POST to `/auth/send-login-email` was going out without a `redirect_to` field at all — `mapState` never read `redirectTo`, so the prop reached the action as `undefined` and JSON serialisation dropped the field.
* Wpcom's unified-connection magic-link routing (shipped in 217399-ghe-Automattic/wpcom) parses `from` out of the POST's `redirect_to` query string. With the field missing, the parse yields an empty string, the `from === 'jetpack-connector'` check fails, and routing silently falls back to the legacy `wpcom-2022 / magic-login-web-jetpack` family. End result: connector-flow magic-code emails kept rendering the old green-Jetpack template.
* The magic-link button variant was unaffected — its `mapState` already reads `redirectTo` via `getRedirectToOriginal`.

## Testing instructions

* In the connector flow on a fresh Jetpack site, click "Already have a WordPress.com account? Log in", then "Email me a login code". In DevTools → Network, the POST to `/auth/send-login-email` should now carry a `redirect_to` field pointing at the authorize URL (which has `from=jetpack-connector` in its query).
* The resulting email should be the new unified-connection white-card template ("Log in to continue" / "Confirm your email to finish creating your account"), not the legacy green-Jetpack one.
* Regression: the magic-link button variant still works.
* `yarn test-client client/login/magic-login/test/request-login-code.test.jsx`.
