### PR TITLE
A4A: Reports: restore the site list panel after selecting a report

### DIFF
--- a/client/a8c-for-agencies/sections/reports/primary/dashboard/index.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/dashboard/index.tsx
@@ -51,7 +51,8 @@ export default function ReportsDashboard() {
 
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
 		...initialDataViewsState,
-		fields: [ 'site', 'reportCount', 'latestStatus', 'dateSent' ],
+		fields: [ 'reportCount', 'latestStatus', 'dateSent' ],
+		titleField: 'site',
 	} );
 
 	// To ensure the selected item is updated when the reports list is updated

--- a/client/a8c-for-agencies/sections/reports/primary/dashboard/reports-list.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/dashboard/reports-list.tsx
@@ -133,7 +133,7 @@ export default function ReportsList( {
 					actions,
 					setDataViewsState,
 					dataViewsState,
-					defaultLayouts: { table: {} },
+					defaultLayouts: { table: {}, list: {} },
 				} }
 			/>
 		</div>


### PR DESCRIPTION
Resolves A4A-2661

## Proposed Changes

- Allow the `list` layout in the Reports dashboard `DataViews` by adding it to `defaultLayouts`.
- Declare `site` as the `titleField` of the initial `dataViewsState` (and drop it from `view.fields`) so the list row renders the site name inline.

## Why are these changes being made?

On the Reports dashboard, clicking **View details** on a row swaps the left-hand list from a table layout into a list layout used as a navigation rail next to the selected report.

After the `@wordpress/dataviews@13.1.0` upgrade (#109190), `DataViewsLayout` enforces a strict allowlist:

```js
VIEW_LAYOUTS.find( v => v.type === view.type && defaultLayouts[ v.type ] )
```

The Reports dashboard was passing `defaultLayouts={ { table: {} } }`, so when the view switched to `'list'` no matching layout was found and the panel rendered empty. Sibling dashboards (Referrals, Sites, Jetpack Sites) already declare both `table` and `list`.

While restoring the list, this also matches their pattern of declaring a `titleField`. Without it, the site name renders as an "other field" below an empty `dataviews-title-field` row, leaving a visible gap above each item. With `titleField: 'site'`, the row collapses to a single line. The table view is unchanged because the title field renders as the primary column.

## Testing Instructions

1. Visit the A4A Reports dashboard with at least one site that has reports.
2. Confirm the table view of sites renders normally (Site Name / URL, Reports, Latest Status, Last Generated columns).
3. Click **View details** on any row.
4. Confirm the left panel switches to a compact list of sites with the selected site highlighted, and the right panel shows the report details. Before this PR the left list was empty.
5. Click a different site in the list and confirm the selection moves and the right panel updates.
6. Resize the viewport above and below the `break-wide` (1280px) breakpoint and confirm the list panel collapses / expands as expected.

### Before / After

_Before:_ left panel empty after clicking View details.

<img width="1920" height="757" alt="Screenshot 2026-05-20 at 2 16 40 PM" src="https://github.com/user-attachments/assets/5f4902db-2bf7-431a-9264-b1864ffb35ad" />


_After:_ list of sites visible in left panel; rows render in a single compact line.

<img width="1920" height="757" alt="Screenshot 2026-05-20 at 2 18 27 PM" src="https://github.com/user-attachments/assets/fb6241e5-2cbf-4f3a-ba93-c61516074600" />


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?