### PR TITLE
Fix stale .rules/*.mdc reference in playwright agent descriptions

### DIFF
--- a/.claude/agents/playwright-test-generator.md
+++ b/.claude/agents/playwright-test-generator.md
@@ -1,6 +1,6 @@
 ---
 name: Playwright Test Generator
-description: "Use this agent to create and convert automated browser tests using Playwright Test. Generate Playwright Test code. Follow AGENTS.md and relevant .rules/*.mdc files. When generating tests, conform to the repo's Playwright/E2E conventions. If unsure, ask for clarification."
+description: "Use this agent to create and convert automated browser tests using Playwright Test. Generate Playwright Test code. Follow relevant CLAUDE.md rules (e.g. `test/e2e/CLAUDE.md`). When generating tests, conform to the repo's Playwright/E2E conventions. If unsure, ask for clarification."
 tools: Glob, Grep, Read, LS, mcp__playwright-test__browser_click, mcp__playwright-test__browser_drag, mcp__playwright-test__browser_evaluate, mcp__playwright-test__browser_file_upload, mcp__playwright-test__browser_handle_dialog, mcp__playwright-test__browser_hover, mcp__playwright-test__browser_navigate, mcp__playwright-test__browser_press_key, mcp__playwright-test__browser_select_option, mcp__playwright-test__browser_snapshot, mcp__playwright-test__browser_type, mcp__playwright-test__browser_verify_element_visible, mcp__playwright-test__browser_verify_list_visible, mcp__playwright-test__browser_verify_text_visible, mcp__playwright-test__browser_verify_value, mcp__playwright-test__browser_wait_for, mcp__playwright-test__generator_read_log, mcp__playwright-test__generator_setup_page, mcp__playwright-test__generator_write_test
 color: blue
 ---

--- a/.claude/agents/playwright-test-generator.md
+++ b/.claude/agents/playwright-test-generator.md
@@ -1,6 +1,6 @@
 ---
 name: Playwright Test Generator
-description: "Use this agent to create and convert automated browser tests using Playwright Test. Generate Playwright Test code. Follow relevant CLAUDE.md rules (e.g. `test/e2e/CLAUDE.md`). When generating tests, conform to the repo's Playwright/E2E conventions. If unsure, ask for clarification."
+description: "Use this agent to create and convert automated browser tests using Playwright Test. Follow the E2E conventions in `test/e2e/CLAUDE.md`. If unsure, ask for clarification."
 tools: Glob, Grep, Read, LS, mcp__playwright-test__browser_click, mcp__playwright-test__browser_drag, mcp__playwright-test__browser_evaluate, mcp__playwright-test__browser_file_upload, mcp__playwright-test__browser_handle_dialog, mcp__playwright-test__browser_hover, mcp__playwright-test__browser_navigate, mcp__playwright-test__browser_press_key, mcp__playwright-test__browser_select_option, mcp__playwright-test__browser_snapshot, mcp__playwright-test__browser_type, mcp__playwright-test__browser_verify_element_visible, mcp__playwright-test__browser_verify_list_visible, mcp__playwright-test__browser_verify_text_visible, mcp__playwright-test__browser_verify_value, mcp__playwright-test__browser_wait_for, mcp__playwright-test__generator_read_log, mcp__playwright-test__generator_setup_page, mcp__playwright-test__generator_write_test
 color: blue
 ---

--- a/.claude/agents/playwright-test-healer.md
+++ b/.claude/agents/playwright-test-healer.md
@@ -1,6 +1,6 @@
 ---
 name: Playwright Test Healer
-description: "Use this agent when you need to debug and fix failing Playwright tests. Follow relevant CLAUDE.md rules (e.g. `test/e2e/CLAUDE.md`). When generating tests, conform to the repo's Playwright/E2E conventions. If unsure, ask for clarification."
+description: "Use this agent when you need to debug and fix failing Playwright tests. Follow the E2E conventions in `test/e2e/CLAUDE.md`. If unsure, ask for clarification."
 tools: Glob, Grep, Read, LS, Edit, MultiEdit, Write, mcp__playwright-test__browser_console_messages, mcp__playwright-test__browser_evaluate, mcp__playwright-test__browser_generate_locator, mcp__playwright-test__browser_network_requests, mcp__playwright-test__browser_snapshot, mcp__playwright-test__test_debug, mcp__playwright-test__test_list, mcp__playwright-test__test_run
 color: red
 ---

--- a/.claude/agents/playwright-test-healer.md
+++ b/.claude/agents/playwright-test-healer.md
@@ -1,6 +1,6 @@
 ---
 name: Playwright Test Healer
-description: "Use this agent when you need to debug and fix failing Playwright tests. Follow AGENTS.md and relevant .rules/*.mdc files. When generating tests, conform to the repo's Playwright/E2E conventions. If unsure, ask for clarification."
+description: "Use this agent when you need to debug and fix failing Playwright tests. Follow relevant CLAUDE.md rules (e.g. `test/e2e/CLAUDE.md`). When generating tests, conform to the repo's Playwright/E2E conventions. If unsure, ask for clarification."
 tools: Glob, Grep, Read, LS, Edit, MultiEdit, Write, mcp__playwright-test__browser_console_messages, mcp__playwright-test__browser_evaluate, mcp__playwright-test__browser_generate_locator, mcp__playwright-test__browser_network_requests, mcp__playwright-test__browser_snapshot, mcp__playwright-test__test_debug, mcp__playwright-test__test_list, mcp__playwright-test__test_run
 color: red
 ---

--- a/.claude/agents/playwright-test-planner.md
+++ b/.claude/agents/playwright-test-planner.md
@@ -1,6 +1,6 @@
 ---
 name: Playwright Test Planner
-description: "Use this agent when you need to create comprehensive test plan for a web application or website. Follow AGENTS.md and relevant .rules/*.mdc files. When generating tests, conform to the repo's Playwright/E2E conventions. If unsure, ask for clarification."
+description: "Use this agent when you need to create comprehensive test plan for a web application or website. Follow relevant CLAUDE.md rules (e.g. `test/e2e/CLAUDE.md`). When generating tests, conform to the repo's Playwright/E2E conventions. If unsure, ask for clarification."
 tools: Glob, Grep, Read, LS, mcp__playwright-test__browser_click, mcp__playwright-test__browser_close, mcp__playwright-test__browser_console_messages, mcp__playwright-test__browser_drag, mcp__playwright-test__browser_evaluate, mcp__playwright-test__browser_file_upload, mcp__playwright-test__browser_handle_dialog, mcp__playwright-test__browser_hover, mcp__playwright-test__browser_navigate, mcp__playwright-test__browser_navigate_back, mcp__playwright-test__browser_network_requests, mcp__playwright-test__browser_press_key, mcp__playwright-test__browser_select_option, mcp__playwright-test__browser_snapshot, mcp__playwright-test__browser_take_screenshot, mcp__playwright-test__browser_type, mcp__playwright-test__browser_wait_for, mcp__playwright-test__planner_setup_page, mcp__playwright-test__planner_save_plan
 model: sonnet
 color: green

--- a/.claude/agents/playwright-test-planner.md
+++ b/.claude/agents/playwright-test-planner.md
@@ -1,6 +1,6 @@
 ---
 name: Playwright Test Planner
-description: "Use this agent when you need to create comprehensive test plan for a web application or website. Follow relevant CLAUDE.md rules (e.g. `test/e2e/CLAUDE.md`). When generating tests, conform to the repo's Playwright/E2E conventions. If unsure, ask for clarification."
+description: "Use this agent when you need to create a comprehensive test plan for a web application or website. Follow the E2E conventions in `test/e2e/CLAUDE.md`. If unsure, ask for clarification."
 tools: Glob, Grep, Read, LS, mcp__playwright-test__browser_click, mcp__playwright-test__browser_close, mcp__playwright-test__browser_console_messages, mcp__playwright-test__browser_drag, mcp__playwright-test__browser_evaluate, mcp__playwright-test__browser_file_upload, mcp__playwright-test__browser_handle_dialog, mcp__playwright-test__browser_hover, mcp__playwright-test__browser_navigate, mcp__playwright-test__browser_navigate_back, mcp__playwright-test__browser_network_requests, mcp__playwright-test__browser_press_key, mcp__playwright-test__browser_select_option, mcp__playwright-test__browser_snapshot, mcp__playwright-test__browser_take_screenshot, mcp__playwright-test__browser_type, mcp__playwright-test__browser_wait_for, mcp__playwright-test__planner_setup_page, mcp__playwright-test__planner_save_plan
 model: sonnet
 color: green


### PR DESCRIPTION
## Proposed Changes

* Update the description in the three Playwright agent files under `.claude/agents/` to drop the stale reference to `.rules/*.mdc` and point at `test/e2e/CLAUDE.md` instead.

## Why are these changes being made?

These agents were introduced in 5123279871719ecf71798574a8bbcaa07ca1db7d (#108184), when the repo still had a `.rules/` directory of `.mdc` files https://github.com/Automattic/wp-calypso/blob/5123279871719ecf71798574a8bbcaa07ca1db7d/.rules/e2e-test-rules.mdc. The E2E `.mdc` files have since moved into `test/e2e/AGENTS.md` (loaded via `test/e2e/CLAUDE.md`), so `.rules/` no longer exists and the agent descriptions pointed at nothing.

## Testing Instructions

* Confirm the diff only changes the `description` frontmatter in the three agent files.
* Spawn a Playwright Test agent and check the description renders with the new wording.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?