### PR TITLE
Add Jetpack AI Sidebar preview controls

### DIFF
--- a/packages/agents-manager/src/components/__tests__/agent-dock.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-dock.test.tsx
@@ -13,6 +13,15 @@ const mockUseAgentLayoutManager = jest.fn();
 let mockShouldUseUnifiedAgent = false;
 let mockContext: Partial< AgentsManagerContextType > = {};
 
+type AgentsManagerTestGlobal = typeof globalThis & {
+	agentsManagerData?: {
+		jetpackAiSidebarPreview?: {
+			enabled: boolean;
+			features?: Record< string, boolean >;
+		};
+	};
+};
+
 jest.mock(
 	'@automattic/agenttic-client',
 	() => ( {
@@ -108,6 +117,15 @@ function renderAgentDock( initialEntry = '/chat' ) {
 	);
 }
 
+function installJetpackAiSidebarPreviewData( features: Record< string, boolean > ) {
+	( globalThis as AgentsManagerTestGlobal ).agentsManagerData = {
+		jetpackAiSidebarPreview: {
+			enabled: true,
+			features,
+		},
+	};
+}
+
 describe( 'AgentDock', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
@@ -119,6 +137,10 @@ describe( 'AgentDock', () => {
 				agentId: 'reader-chat',
 			},
 		} as Partial< AgentsManagerContextType >;
+	} );
+
+	afterEach( () => {
+		delete ( globalThis as AgentsManagerTestGlobal ).agentsManagerData;
 	} );
 
 	it( 'does not expose Zendesk chat for Reader Chat when Unified Chat is enabled', async () => {
@@ -149,6 +171,63 @@ describe( 'AgentDock', () => {
 		renderAgentDock();
 
 		expect( screen.getByTestId( 'orchestrator-chat' ).textContent ).toContain( 'New Zendesk chat' );
+	} );
+
+	it( 'hides support guides when Jetpack AI Sidebar Preview disables them', async () => {
+		installJetpackAiSidebarPreviewData( { supportGuides: false } );
+		mockContext = {
+			siteKey: 'site-1',
+			sectionName: 'wp-admin',
+			agentConfig: {
+				agentId: 'wp-orchestrator',
+			},
+		} as Partial< AgentsManagerContextType >;
+
+		renderAgentDock();
+
+		expect( screen.getByTestId( 'orchestrator-chat' ).textContent ).not.toContain(
+			'Support guides'
+		);
+
+		renderAgentDock( '/support-guides' );
+
+		await waitFor( () => expect( screen.queryByTestId( 'support-guides' ) ).toBeNull() );
+	} );
+
+	it( 'hides history route when Jetpack AI Sidebar Preview disables chat history', async () => {
+		installJetpackAiSidebarPreviewData( { chatHistory: false } );
+		mockContext = {
+			siteKey: 'site-1',
+			sectionName: 'wp-admin',
+			agentConfig: {
+				agentId: 'wp-orchestrator',
+			},
+		} as Partial< AgentsManagerContextType >;
+
+		renderAgentDock( '/history' );
+
+		await waitFor( () => expect( screen.queryByTestId( 'agent-history' ) ).toBeNull() );
+	} );
+
+	it( 'treats missing Jetpack AI Sidebar Preview features as disabled', async () => {
+		installJetpackAiSidebarPreviewData( {} );
+		mockContext = {
+			siteKey: 'site-1',
+			sectionName: 'wp-admin',
+			agentConfig: {
+				agentId: 'wp-orchestrator',
+			},
+		} as Partial< AgentsManagerContextType >;
+
+		renderAgentDock();
+
+		expect( screen.getByTestId( 'orchestrator-chat' ).textContent ).not.toContain(
+			'Support guides'
+		);
+
+		renderAgentDock( '/history' );
+
+		await waitFor( () => expect( screen.queryByTestId( 'agent-history' ) ).toBeNull() );
 	} );
 
 	it( 'opens Reader Chat without saving shared Agents Manager state', () => {

--- a/packages/agents-manager/src/components/__tests__/chat-header.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/chat-header.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-disable import/order -- jest.mock calls must precede imports */
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+type AgentsManagerTestGlobal = typeof globalThis & {
+	agentsManagerData?: {
+		jetpackAiSidebarPreview?: {
+			enabled: boolean;
+			features?: Record< string, boolean >;
+		};
+	};
+};
+
+jest.mock( '@wordpress/components', () => ( {
+	Button: ( {
+		children,
+		className,
+		label,
+		onClick,
+	}: {
+		children?: React.ReactNode;
+		className?: string;
+		label?: string;
+		onClick?: () => void;
+	} ) => (
+		<button className={ className } onClick={ onClick }>
+			{ label }
+			{ children }
+		</button>
+	),
+	DropdownMenu: ( { label }: { label?: string } ) => <button>{ label }</button>,
+} ) );
+jest.mock( '@wordpress/i18n', () => ( { __: ( text: string ) => text } ) );
+jest.mock( '@wordpress/icons', () => ( {
+	backup: 'backup',
+	chevronLeft: 'chevronLeft',
+	close: 'close',
+	Icon: () => null,
+	moreVertical: 'moreVertical',
+} ) );
+jest.mock( '../chat-header/style.scss', () => ( {} ) );
+
+import ChatHeader from '../chat-header';
+
+function installJetpackAiSidebarPreviewData( features: Record< string, boolean > ) {
+	( globalThis as AgentsManagerTestGlobal ).agentsManagerData = {
+		jetpackAiSidebarPreview: {
+			enabled: true,
+			features,
+		},
+	};
+}
+
+function renderChatHeader() {
+	return render(
+		<MemoryRouter>
+			<ChatHeader onClose={ jest.fn() } options={ [] } />
+		</MemoryRouter>
+	);
+}
+
+describe( 'ChatHeader', () => {
+	afterEach( () => {
+		delete ( globalThis as AgentsManagerTestGlobal ).agentsManagerData;
+	} );
+
+	it( 'shows the history button by default', () => {
+		renderChatHeader();
+
+		expect( screen.getByText( 'View history' ) ).toBeInTheDocument();
+	} );
+
+	it( 'hides the history button when Jetpack AI Sidebar Preview disables chat history', () => {
+		installJetpackAiSidebarPreviewData( { chatHistory: false } );
+
+		renderChatHeader();
+
+		expect( screen.queryByText( 'View history' ) ).toBeNull();
+	} );
+
+	it( 'hides the history button when Jetpack AI Sidebar Preview omits chat history', () => {
+		installJetpackAiSidebarPreviewData( {} );
+
+		renderChatHeader();
+
+		expect( screen.queryByText( 'View history' ) ).toBeNull();
+	} );
+} );

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-disable import/order -- jest.mock calls must precede imports */
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { Suggestion } from '@automattic/agenttic-ui';
+
+const mockUseAgentChat = jest.fn();
+
+jest.mock(
+	'@automattic/agenttic-client',
+	() => ( {
+		getAgentManager: () => ( {
+			updateSessionId: jest.fn(),
+		} ),
+		useAgentChat: () => mockUseAgentChat(),
+	} ),
+	{ virtual: true }
+);
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: () => undefined,
+} ) );
+jest.mock( '@wordpress/element', () => jest.requireActual( 'react' ) );
+jest.mock( '@wordpress/i18n', () => ( { __: ( text: string ) => text } ) );
+jest.mock( 'react-router-dom', () => ( {
+	useNavigate: () => jest.fn(),
+} ) );
+jest.mock( '../../contexts', () => ( {
+	useAgentsManagerContext: () => ( {
+		agentConfig: { agentId: 'wp-orchestrator' },
+		getActiveSessionId: () => 'session-id',
+		siteKey: 'site-1',
+	} ),
+} ) );
+jest.mock( '../../hooks/use-conversation', () => () => ( { isLoading: false } ) );
+jest.mock( '../../hooks/use-save-new-chat-route', () => () => {} );
+jest.mock( '../../hooks/use-checkpoint-action', () => () => {} );
+jest.mock( '../../hooks/use-feedback-action', () => () => ( {
+	showFeedbackInput: false,
+	submitFeedbackText: jest.fn(),
+	resetFeedback: jest.fn(),
+} ) );
+jest.mock( '../../hooks/use-copy-action', () => () => {} );
+jest.mock( '../../hooks/use-sources-action', () => () => {} );
+jest.mock( '../../hooks/use-zoom-action', () => () => {} );
+jest.mock( '../../utils/agent-session', () => ( { markSessionUsed: jest.fn() } ) );
+jest.mock( '../../utils/convert-tool-messages-to-components', () => ( {
+	__esModule: true,
+	default: ( { messages }: { messages: unknown[] } ) => messages,
+} ) );
+jest.mock( '../../utils/external-context', () => ( {
+	consumeNextMessageExternalContextEntries: jest.fn(),
+	removeExternalContextCard: jest.fn(),
+	removeExternalContextEntry: jest.fn(),
+} ) );
+jest.mock( '../../utils/is-reader-chat-agent', () => ( {
+	isReaderChatAgent: () => false,
+} ) );
+jest.mock( '../../utils/persist-last-activity', () => ( {
+	persistLastActivity: jest.fn(),
+} ) );
+jest.mock( '../agent-chat', () => ( {
+	__esModule: true,
+	default: ( { onSuggestionClick }: { onSuggestionClick: ( suggestion: Suggestion ) => void } ) => (
+		<button
+			onClick={ () =>
+				onSuggestionClick( {
+					id: 'simplify-text',
+					label: 'Simplify text',
+					prompt: 'Simplify this text to make it easier to read',
+				} )
+			}
+		>
+			Click suggestion
+		</button>
+	),
+} ) );
+
+import OrchestratorChat from '../orchestrator-chat';
+
+describe( 'OrchestratorChat', () => {
+	beforeEach( () => {
+		mockUseAgentChat.mockReturnValue( {
+			addMessage: jest.fn(),
+			messages: [],
+			suggestions: [],
+			isProcessing: false,
+			error: null,
+			loadMessages: jest.fn(),
+			onSubmit: jest.fn(),
+			abortCurrentRequest: jest.fn(),
+			clearSuggestions: jest.fn(),
+			registerSuggestions: jest.fn(),
+			registerMessageActions: jest.fn(),
+			progressMessage: null,
+		} );
+	} );
+
+	it( 'dispatches the inline suggestion event when an Agenttic suggestion is clicked', () => {
+		const listener = jest.fn();
+		window.addEventListener( 'big-sky-inline-suggestion-click', listener );
+
+		render(
+			<OrchestratorChat
+				emptyViewSuggestions={ [] }
+				isDocked={ false }
+				isOpen
+				onClose={ jest.fn() }
+				onExpand={ jest.fn() }
+				chatHeaderOptions={ [] }
+				markdownComponents={ {} }
+				markdownExtensions={ {} }
+				isCompactMode={ false }
+				onHasMessagesChange={ jest.fn() }
+			/>
+		);
+
+		fireEvent.click( screen.getByText( 'Click suggestion' ) );
+
+		expect( listener ).toHaveBeenCalledTimes( 1 );
+		expect( ( listener.mock.calls[ 0 ][ 0 ] as CustomEvent ).detail ).toEqual( {
+			value: 'Simplify this text to make it easier to read',
+		} );
+
+		window.removeEventListener( 'big-sky-inline-suggestion-click', listener );
+	} );
+} );

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -59,6 +59,11 @@ interface Props {
 	onExpand: () => void;
 	/** Called to clear the suggestions. */
 	clearSuggestions?: () => void;
+	/** Called when a suggestion is clicked. */
+	onSuggestionClick?: (
+		selectedSuggestion: Suggestion,
+		availableSuggestions: Suggestion[]
+	) => void;
 	/** Called when the typing status changes. */
 	onTypingStatusChange?: ( isTyping: boolean ) => void;
 	/** Custom components for rendering markdown. */
@@ -161,6 +166,7 @@ export default function AgentChat( {
 	onClose,
 	onExpand,
 	clearSuggestions,
+	onSuggestionClick,
 	notice,
 	markdownComponents = {},
 	markdownExtensions = {},
@@ -220,6 +226,7 @@ export default function AgentChat( {
 			variant={ isDocked ? 'embedded' : 'floating' }
 			suggestions={ suggestions }
 			clearSuggestions={ clearSuggestions }
+			onSuggestionClick={ onSuggestionClick }
 			floatingChatState={ floatingChatState }
 			onClose={ onClose }
 			onExpand={ onExpand }

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -17,6 +17,7 @@ import { useShouldUseUnifiedAgent } from '../../hooks/use-should-use-unified-age
 import { AGENTS_MANAGER_STORE } from '../../stores';
 import { LocalConversationListItem } from '../../types';
 import { isReaderChatAgent } from '../../utils/is-reader-chat-agent';
+import { isJetpackAiSidebarPreviewFeatureEnabled } from '../../utils/jetpack-ai-sidebar-preview';
 import { persistLastActivity } from '../../utils/persist-last-activity';
 import AgentHistory from '../agent-history';
 import { type Options as ChatHeaderOptions } from '../chat-header';
@@ -108,6 +109,10 @@ export default function AgentDock( {
 	// don't apply and avoid persisting open/close state through the logged-in
 	// Agents Manager REST state endpoint.
 	const isReaderChat = isReaderChatAgent( agentId );
+	const showChatHistory =
+		! isReaderChat && isJetpackAiSidebarPreviewFeatureEnabled( 'chatHistory' );
+	const showSupportGuides =
+		! isReaderChat && isJetpackAiSidebarPreviewFeatureEnabled( 'supportGuides' );
 	const setOpenState = useCallback(
 		( isOpen: boolean ) => setIsOpen( isOpen, ! isReaderChat ),
 		[ isReaderChat, setIsOpen ]
@@ -257,8 +262,7 @@ export default function AgentDock( {
 					navigate( '/zendesk' );
 				},
 			},
-			// TODO: For testing. Remove before release.
-			! isReaderChat && {
+			showSupportGuides && {
 				icon: help,
 				title: __( 'Support guides', '__i18n_text_domain__' ),
 				isDisabled: pathname === '/support-guides',
@@ -378,10 +382,10 @@ export default function AgentDock( {
 			// NOTE: Use route state to pass data that needs to be accessed throughout the app.
 			<Routes>
 				<Route path="/chat" element={ OrchestratorChatRoute } />
-				{ ! isReaderChat && <Route path="/post" element={ SupportGuideRoute } /> }
+				{ showSupportGuides && <Route path="/post" element={ SupportGuideRoute } /> }
 				{ shouldShowUnifiedSupport && <Route path="/zendesk" element={ ZendeskChatRoute } /> }
-				{ ! isReaderChat && <Route path="/support-guides" element={ SupportGuidesRoute } /> }
-				{ ! isReaderChat && <Route path="/history" element={ HistoryRoute } /> }
+				{ showSupportGuides && <Route path="/support-guides" element={ SupportGuidesRoute } /> }
+				{ showChatHistory && <Route path="/history" element={ HistoryRoute } /> }
 				<Route path="*" element={ <Navigate to="/chat" state={ { isNewChat: true } } replace /> } />
 			</Routes>
 		)

--- a/packages/agents-manager/src/components/chat-header/index.tsx
+++ b/packages/agents-manager/src/components/chat-header/index.tsx
@@ -3,6 +3,7 @@ import { __ } from '@wordpress/i18n';
 import { close, moreVertical, backup, chevronLeft, Icon } from '@wordpress/icons';
 import { useNavigate } from 'react-router-dom';
 import { isReaderChatHost } from '../../utils/is-reader-chat-agent';
+import { isJetpackAiSidebarPreviewFeatureEnabled } from '../../utils/jetpack-ai-sidebar-preview';
 import type { ComponentProps } from 'react';
 import './style.scss';
 
@@ -17,6 +18,8 @@ interface Props {
 
 export default function ChatHeader( { onClose, options, title, onBack }: Props ) {
 	const navigate = useNavigate();
+	const showChatHistory =
+		! isReaderChatHost() && isJetpackAiSidebarPreviewFeatureEnabled( 'chatHistory' );
 
 	return (
 		<div className="agents-manager-chat-header">
@@ -42,10 +45,10 @@ export default function ChatHeader( { onClose, options, title, onBack }: Props )
 				{ /*
 				 * Public reader-chat runs on blog frontends where session history
 				 * isn't user-accessible (no account, per-visit local storage).
-				 * Hide the history icon for that context — it navigates to a
-				 * route with nothing to show.
+				 * Jetpack AI Sidebar Preview can also opt out of chat history
+				 * while exposing only a smaller feature set.
 				 */ }
-				{ ! isReaderChatHost() && (
+				{ showChatHistory && (
 					<Button
 						className="agents-manager-chat-header__history-btn"
 						icon={ backup }

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -340,7 +340,7 @@ export default function OrchestratorChat( {
 		pathname: window.location.pathname,
 	} );
 
-	// Listen for inline suggestion clicks dispatched by Big Sky's InlineSuggestions component.
+	// Listen for inline suggestion clicks dispatched by external providers or the Agenttic bridge below.
 	useEffect( () => {
 		const handleInlineSuggestionClick = ( event: Event ) => {
 			const { value } = ( event as CustomEvent ).detail;
@@ -365,6 +365,13 @@ export default function OrchestratorChat( {
 		};
 	}, [] );
 
+	const handleSuggestionClick = useCallback( ( suggestion: Suggestion ) => {
+		const value = suggestion.prompt ?? suggestion.label;
+		window.dispatchEvent(
+			new CustomEvent( 'big-sky-inline-suggestion-click', { detail: { value } } )
+		);
+	}, [] );
+
 	// Invoke abilities setup hook to register hook-based abilities that utilize React context.
 	// Provides custom action handlers for agent and chat interaction within Big Sky's AI store.
 	// The hook is stable as `OrchestratorChat` only renders after external providers have been loaded.
@@ -387,6 +394,7 @@ export default function OrchestratorChat( {
 		clearMessages: () => loadMessages( [] ),
 		clearSuggestions,
 		getAgentManager,
+		isProcessing,
 		setIsThinking,
 		deleteMarkedMessages: ( msgs ) => {
 			setDeletedMessageIds(
@@ -472,6 +480,7 @@ export default function OrchestratorChat( {
 			onClose={ onClose }
 			onExpand={ onExpand }
 			clearSuggestions={ clearSuggestions }
+			onSuggestionClick={ handleSuggestionClick }
 			chatHeaderOptions={ chatHeaderOptions }
 			markdownComponents={ markdownComponents }
 			markdownExtensions={ markdownExtensions }

--- a/packages/agents-manager/src/global.d.ts
+++ b/packages/agents-manager/src/global.d.ts
@@ -15,6 +15,16 @@ declare const agentsManagerData:
 			useUnifiedExperience?: boolean;
 			agentId?: string;
 			helpCenterUrl?: string;
+			jetpackAiSidebarPreview?: {
+				enabled: boolean;
+				features?: {
+					aiEditorialReview?: boolean;
+					blockTransformations?: boolean;
+					optimizeTitleSuggestion?: boolean;
+					chatHistory?: boolean;
+					supportGuides?: boolean;
+				};
+			};
 	  }
 	| undefined;
 

--- a/packages/agents-manager/src/utils/jetpack-ai-sidebar-preview.ts
+++ b/packages/agents-manager/src/utils/jetpack-ai-sidebar-preview.ts
@@ -1,0 +1,26 @@
+type JetpackAiSidebarPreviewFeature =
+	| 'aiEditorialReview'
+	| 'blockTransformations'
+	| 'optimizeTitleSuggestion'
+	| 'chatHistory'
+	| 'supportGuides';
+
+function getJetpackAiSidebarPreview() {
+	return typeof agentsManagerData !== 'undefined'
+		? agentsManagerData?.jetpackAiSidebarPreview
+		: undefined;
+}
+
+export function isJetpackAiSidebarPreviewFeatureEnabled(
+	feature: JetpackAiSidebarPreviewFeature,
+	defaultValue = true
+): boolean {
+	const preview = getJetpackAiSidebarPreview();
+	if ( ! preview ) {
+		return defaultValue;
+	}
+	if ( ! preview.enabled ) {
+		return false;
+	}
+	return preview.features?.[ feature ] === true;
+}

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -59,6 +59,7 @@ export type AbilitiesSetupHook = ( actions: {
 	clearMessages: () => void;
 	clearSuggestions: UseAgentChatReturn[ 'clearSuggestions' ];
 	getAgentManager: typeof getAgentManager;
+	isProcessing?: boolean;
 	setIsThinking: ( isThinking: boolean ) => void;
 	deleteMarkedMessages: ( messages: Record< 'id', string >[] ) => void;
 	getSessionId: () => string | undefined;

--- a/packages/jetpack-ai-sidebar/src/components/review-mediation.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/review-mediation.tsx
@@ -540,7 +540,7 @@ export default function ReviewMediation( {
 				if ( result?.success ) {
 					return {
 						success: true,
-						clientId,
+						clientId: result.clientId ?? clientId,
 						contentBefore: result.contentBefore,
 						contentAfter: result.contentAfter,
 					};

--- a/packages/jetpack-ai-sidebar/src/global.d.ts
+++ b/packages/jetpack-ai-sidebar/src/global.d.ts
@@ -3,6 +3,17 @@
  */
 declare const agentsManagerData:
 	| {
+			aiEditorialReviewEnabled?: boolean;
 			reviewMediatorEnabled?: boolean;
+			jetpackAiSidebarPreview?: {
+				enabled: boolean;
+				features?: {
+					aiEditorialReview?: boolean;
+					blockTransformations?: boolean;
+					optimizeTitleSuggestion?: boolean;
+					chatHistory?: boolean;
+					supportGuides?: boolean;
+				};
+			};
 	  }
 	| undefined;

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -267,7 +267,7 @@ describe( 'useSuggestions', () => {
 		delete ( window as any ).wp;
 	} );
 
-	it( 'does not append AI Editorial Review to block-specific suggestions', () => {
+	it( 'appends AI Editorial Review to block-specific suggestions', () => {
 		installAiEditorialReviewData();
 		mockSelectedBlock = { clientId: 'b1', name: 'core/paragraph' };
 		const onSuggestions = jest.fn();
@@ -276,12 +276,16 @@ describe( 'useSuggestions', () => {
 
 		const latestSuggestions =
 			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
-		expect( latestSuggestions.map( ( suggestion: any ) => suggestion.label ) ).not.toContain(
-			'AI Editorial Review'
-		);
+		expect( latestSuggestions.map( ( suggestion: any ) => suggestion.label ) ).toEqual( [
+			'Translate content',
+			'Change tone',
+			'Check grammar',
+			'Simplify text',
+			'AI Editorial Review',
+		] );
 	} );
 
-	it( 'hides block transformation suggestions when the preview feature disables them', () => {
+	it( 'keeps AI Editorial Review when the preview feature disables block transformations', () => {
 		installAiEditorialReviewData( { blockTransformations: false } );
 		mockSelectedBlock = { clientId: 'b1', name: 'core/paragraph' };
 		const onSuggestions = jest.fn();
@@ -290,10 +294,12 @@ describe( 'useSuggestions', () => {
 
 		const latestSuggestions =
 			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
-		expect( latestSuggestions ).toEqual( [] );
+		expect( latestSuggestions.map( ( suggestion: any ) => suggestion.label ) ).toEqual( [
+			'AI Editorial Review',
+		] );
 	} );
 
-	it( 'hides block transformation suggestions when the preview feature is missing', () => {
+	it( 'keeps AI Editorial Review when the block transformations preview feature is missing', () => {
 		( globalThis as any ).agentsManagerData = {
 			aiEditorialReviewEnabled: true,
 			jetpackAiSidebarPreview: {
@@ -308,7 +314,9 @@ describe( 'useSuggestions', () => {
 
 		const latestSuggestions =
 			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
-		expect( latestSuggestions ).toEqual( [] );
+		expect( latestSuggestions.map( ( suggestion: any ) => suggestion.label ) ).toEqual( [
+			'AI Editorial Review',
+		] );
 	} );
 
 	it( 'opens split-screen when the AI Editorial Review suggestion is clicked', () => {

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -360,6 +360,72 @@ describe( 'useSuggestions', () => {
 
 		expect( mockSetIsSplitScreen ).not.toHaveBeenCalled();
 	} );
+
+	it( 're-shows block suggestions when a block action completes', () => {
+		installAiEditorialReviewData();
+		mockSelectedBlock = { clientId: 'b1', name: 'core/paragraph' };
+		const onSuggestions = jest.fn();
+
+		render( React.createElement( SuggestionsProbe, { onSuggestions } ) );
+
+		act( () => {
+			window.dispatchEvent(
+				new CustomEvent( 'big-sky-inline-suggestion-click', {
+					detail: { value: 'Check the grammar and spelling of this text' },
+				} )
+			);
+		} );
+
+		let latestSuggestions =
+			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
+		expect( latestSuggestions ).toEqual( [] );
+
+		act( () => {
+			window.dispatchEvent( new Event( 'jetpack-ai-sidebar-block-action-complete' ) );
+		} );
+
+		latestSuggestions =
+			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
+		expect( latestSuggestions.map( ( suggestion: any ) => suggestion.label ) ).toEqual( [
+			'Translate content',
+			'Change tone',
+			'Check grammar',
+			'Simplify text',
+			'AI Editorial Review',
+		] );
+	} );
+
+	it( 'starts the selected block shimmer when AM starts processing', () => {
+		jest.useFakeTimers();
+		installPostTypeMock( 'post' );
+		mockSelectedBlock = { clientId: 'lQ0k', name: 'core/paragraph' };
+		const blockEl = document.createElement( 'div' );
+		blockEl.setAttribute( 'data-block', 'lQ0k' );
+		document.body.appendChild( blockEl );
+
+		useAbilitiesSetup( {
+			addMessage: () => undefined,
+			clearSuggestions: () => undefined,
+			isProcessing: false,
+		} as any );
+		useAbilitiesSetup( {
+			addMessage: () => undefined,
+			clearSuggestions: () => undefined,
+			isProcessing: true,
+		} as any );
+
+		expect( blockEl.classList.contains( 'jetpack-ai-is-processing' ) ).toBe( true );
+		expect( blockEl.classList.contains( 'jetpack-ai-is-processing-content' ) ).toBe( true );
+		useAbilitiesSetup( {
+			addMessage: () => undefined,
+			clearSuggestions: () => undefined,
+			isProcessing: false,
+		} as any );
+		expect( blockEl.classList.contains( 'jetpack-ai-is-processing' ) ).toBe( false );
+		expect( blockEl.classList.contains( 'jetpack-ai-is-processing-content' ) ).toBe( false );
+		jest.runOnlyPendingTimers();
+		jest.useRealTimers();
+	} );
 } );
 
 describe( 'contextProvider', () => {
@@ -580,7 +646,10 @@ describe( 'useCheckpoint', () => {
 // core/block-editor (for updateBlockAttributes / getBlock). Tracks calls so
 // tests can assert exact dispatches.
 function installWpDataMockWithBlockEditor(
-	blocks: Record< string, { name: string; attributes: { content?: string } } > = {
+	blocks: Record<
+		string,
+		{ name: string; attributes: { content?: string }; innerBlocks?: any[] }
+	> = {
 		'550e8400-e29b-41d4-a716-446655440000': {
 			name: 'core/paragraph',
 			attributes: { content: 'original block content' },
@@ -589,6 +658,7 @@ function installWpDataMockWithBlockEditor(
 ) {
 	const editorState: { title: string } = { title: 'original' };
 	const blockUpdates: Array< { clientId: string; attrs: Record< string, unknown > } > = [];
+	const selectedClientIds: string[] = [];
 	( window as any ).wp = {
 		data: {
 			select: ( store: string ) => {
@@ -600,7 +670,13 @@ function installWpDataMockWithBlockEditor(
 				}
 				if ( store === 'core/block-editor' ) {
 					return {
-						getBlock: ( clientId: string ) => blocks[ clientId ] ?? null,
+						getBlock: ( clientId: string ) =>
+							blocks[ clientId ] ? { clientId, ...blocks[ clientId ] } : null,
+						getBlocks: () =>
+							Object.entries( blocks ).map( ( [ clientId, block ] ) => ( {
+								clientId,
+								...block,
+							} ) ),
 					};
 				}
 				return undefined;
@@ -619,6 +695,15 @@ function installWpDataMockWithBlockEditor(
 					return {
 						updateBlockAttributes: ( clientId: string, attrs: Record< string, unknown > ) => {
 							blockUpdates.push( { clientId, attrs } );
+							if ( blocks[ clientId ] ) {
+								blocks[ clientId ].attributes = {
+									...blocks[ clientId ].attributes,
+									...attrs,
+								};
+							}
+						},
+						selectBlock: ( clientId: string ) => {
+							selectedClientIds.push( clientId );
 						},
 					};
 				}
@@ -626,7 +711,7 @@ function installWpDataMockWithBlockEditor(
 			},
 		},
 	};
-	return { editorState, blockUpdates, blocks };
+	return { editorState, blockUpdates, blocks, selectedClientIds };
 }
 
 describe( 'applyReviewEdit', () => {
@@ -713,7 +798,7 @@ describe( 'applyReviewEdit', () => {
 		expect( blockEl.classList.contains( 'jetpack-ai-is-processing' ) ).toBe( false );
 	} );
 
-	it( 'posts the rationale as an assistant message to the chat when a summary is provided', async () => {
+	it( 'returns the rationale as an agent message so AM can attach feedback actions', async () => {
 		installWpDataMockWithBlockEditor();
 		const addMessage = jest.fn();
 		useAbilitiesSetup( {
@@ -727,15 +812,10 @@ describe( 'applyReviewEdit', () => {
 			'Follows Copy guideline on specific dates.'
 		);
 		jest.advanceTimersByTime( 1000 );
-		await promise;
+		const result = await promise;
 
-		expect( addMessage ).toHaveBeenCalledTimes( 1 );
-		const message = addMessage.mock.calls[ 0 ][ 0 ];
-		expect( message.role ).toBe( 'assistant' );
-		expect( message.content[ 0 ] ).toEqual( {
-			type: 'text',
-			text: 'Follows Copy guideline on specific dates.',
-		} );
+		expect( addMessage ).not.toHaveBeenCalled();
+		expect( result.agentMessage ).toBe( 'Follows Copy guideline on specific dates.' );
 	} );
 
 	it( 'does not emit a chat message when summary is omitted', async () => {
@@ -751,6 +831,54 @@ describe( 'applyReviewEdit', () => {
 		await promise;
 
 		expect( addMessage ).not.toHaveBeenCalled();
+	} );
+
+	it( 'supports repeated edits against the updated selected block content', async () => {
+		const { blockUpdates, selectedClientIds } = installWpDataMockWithBlockEditor( {
+			'550e8400-e29b-41d4-a716-446655440000': {
+				name: 'core/paragraph',
+				attributes: { content: 'hello world this is my firsst post' },
+			},
+		} );
+		useAbilitiesSetup( { addMessage: () => undefined, clearSuggestions: () => undefined } as any );
+
+		const first = applyReviewEdit(
+			'550e8400-e29b-41d4-a716-446655440000',
+			'Hello world, this is my first post.',
+			undefined,
+			'hello world this is my firsst post'
+		);
+		jest.advanceTimersByTime( 1000 );
+		await first;
+
+		const second = applyReviewEdit(
+			'550e8400-e29b-41d4-a716-446655440000',
+			'Hello world, this is my first post!',
+			undefined,
+			'Hello world, this is my first post.'
+		);
+		jest.advanceTimersByTime( 1000 );
+		const result = await second;
+
+		expect( result ).toMatchObject( {
+			success: true,
+			contentBefore: 'Hello world, this is my first post.',
+			contentAfter: 'Hello world, this is my first post!',
+		} );
+		expect( blockUpdates ).toEqual( [
+			{
+				clientId: '550e8400-e29b-41d4-a716-446655440000',
+				attrs: { content: 'Hello world, this is my first post.' },
+			},
+			{
+				clientId: '550e8400-e29b-41d4-a716-446655440000',
+				attrs: { content: 'Hello world, this is my first post!' },
+			},
+		] );
+		expect( selectedClientIds ).toEqual( [
+			'550e8400-e29b-41d4-a716-446655440000',
+			'550e8400-e29b-41d4-a716-446655440000',
+		] );
 	} );
 
 	// Intentionally no direct unit test for the `setCheckpoint` call inside
@@ -789,6 +917,40 @@ describe( 'applyReviewEdit', () => {
 				attrs: { content: 'The board voted on Tuesday on the proposal.' },
 			},
 		] );
+	} );
+
+	it( 'falls back to a unique currentText match when the clientId is stale', async () => {
+		const { blockUpdates } = installWpDataMockWithBlockEditor( {
+			'live-client-id': {
+				name: 'core/paragraph',
+				attributes: { content: 'hello world this is my firsst post' },
+			},
+		} );
+		useAbilitiesSetup( { addMessage: () => undefined, clearSuggestions: () => undefined } as any );
+		const warn = jest.spyOn( console, 'warn' ).mockImplementation( () => undefined );
+
+		const promise = applyReviewEdit(
+			'stale-client-id',
+			'Hello world, this is my first post.',
+			undefined,
+			'hello world this is my firsst post'
+		);
+		jest.advanceTimersByTime( 1000 );
+		const result = await promise;
+
+		expect( result ).toMatchObject( {
+			success: true,
+			clientId: 'live-client-id',
+			contentBefore: 'hello world this is my firsst post',
+			contentAfter: 'Hello world, this is my first post.',
+		} );
+		expect( blockUpdates ).toEqual( [
+			{
+				clientId: 'live-client-id',
+				attrs: { content: 'Hello world, this is my first post.' },
+			},
+		] );
+		warn.mockRestore();
 	} );
 
 	it( 'revalidates currentText against the latest block content before writing', async () => {
@@ -1007,17 +1169,35 @@ describe( 'findBlockElement', () => {
 		expect( findBlockElement( '550e8400-e29b-41d4-a716-446655440000' ) ).toBe( el );
 	} );
 
+	it( 'supports short mixed-case Gutenberg clientIds', () => {
+		const el = document.createElement( 'div' );
+		el.setAttribute( 'data-block', 'lQ0k' );
+		document.body.appendChild( el );
+		expect( findBlockElement( 'lQ0k' ) ).toBe( el );
+	} );
+
 	it( 'returns null when the clientId is not in the DOM', () => {
 		// Returns null from the regex guard, the main-doc querySelector miss,
 		// or the optional editor-canvas iframe lookup chain (coerced via ?? null).
 		expect( findBlockElement( '550e8400-e29b-41d4-a716-446655440001' ) ).toBeNull();
 	} );
 
-	it( 'rejects malformed clientIds to prevent selector injection', () => {
+	it( 'escapes clientIds to prevent selector injection', () => {
+		const el = document.createElement( 'div' );
+		el.setAttribute( 'data-block', 'client.id' );
+		document.body.appendChild( el );
+		expect( findBlockElement( 'client.id' ) ).toBe( el );
 		expect( findBlockElement( '"][onerror="alert(1)"]' ) ).toBeNull();
 		expect( findBlockElement( 'contains space' ) ).toBeNull();
-		// Non-hex characters fail the regex guard.
-		expect( findBlockElement( 'not-a-real-clientid-g' ) ).toBeNull();
+	} );
+
+	it( 'finds blocks in accessible editor iframes', () => {
+		const iframe = document.createElement( 'iframe' );
+		document.body.appendChild( iframe );
+		const el = iframe.contentDocument?.createElement( 'div' );
+		el?.setAttribute( 'data-block', 'lQ0k' );
+		iframe.contentDocument?.body.appendChild( el as HTMLElement );
+		expect( findBlockElement( 'lQ0k' ) ).toBe( el );
 	} );
 } );
 

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -127,6 +127,23 @@ function installPostTypeMock( postType?: string ) {
 	};
 }
 
+function installAiEditorialReviewData( features: Record< string, boolean > = {} ) {
+	( globalThis as any ).agentsManagerData = {
+		aiEditorialReviewEnabled: true,
+		jetpackAiSidebarPreview: {
+			enabled: true,
+			features: {
+				aiEditorialReview: true,
+				blockTransformations: true,
+				optimizeTitleSuggestion: false,
+				chatHistory: false,
+				supportGuides: false,
+				...features,
+			},
+		},
+	};
+}
+
 function SuggestionsProbe( { onSuggestions }: { onSuggestions: ( suggestions: any[] ) => void } ) {
 	const { suggestions } = useSuggestions();
 	React.useEffect( () => {
@@ -168,10 +185,10 @@ describe( 'getEmptyViewSuggestions', () => {
 	} );
 
 	it( 'shows AI Editorial Review when enabled by agentsManagerData', () => {
-		( globalThis as any ).agentsManagerData = { reviewMediatorEnabled: true };
+		installAiEditorialReviewData();
 		installPostTypeMock( 'post' );
 		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
-		expect( labels ).toContain( 'Optimize Title' );
+		expect( labels ).not.toContain( 'Optimize Title' );
 		expect( labels ).toContain( 'AI Editorial Review' );
 		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
 			'jetpack_ai_editorial_review_suggestion_rendered',
@@ -179,24 +196,60 @@ describe( 'getEmptyViewSuggestions', () => {
 		);
 	} );
 
-	it( 'hides AI Editorial Review on page editors', () => {
+	it( 'supports the legacy reviewMediatorEnabled flag while bundles roll forward', () => {
 		( globalThis as any ).agentsManagerData = { reviewMediatorEnabled: true };
+		installPostTypeMock( 'post' );
+
+		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
+
+		expect( labels ).toContain( 'Optimize Title' );
+		expect( labels ).toContain( 'AI Editorial Review' );
+	} );
+
+	it( 'hides AI Editorial Review on page editors', () => {
+		installAiEditorialReviewData();
 		installPostTypeMock( 'page' );
 
 		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
 
-		expect( labels ).toContain( 'Optimize Title' );
+		expect( labels ).not.toContain( 'Optimize Title' );
 		expect( labels ).not.toContain( 'AI Editorial Review' );
 	} );
 
 	it( 'hides AI Editorial Review until the post type is known', () => {
-		( globalThis as any ).agentsManagerData = { reviewMediatorEnabled: true };
+		installAiEditorialReviewData();
 		installPostTypeMock();
 
 		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
 
-		expect( labels ).toContain( 'Optimize Title' );
+		expect( labels ).not.toContain( 'Optimize Title' );
 		expect( labels ).not.toContain( 'AI Editorial Review' );
+	} );
+
+	it( 'hides Optimize Title when the preview feature disables it', () => {
+		installAiEditorialReviewData( { aiEditorialReview: false, optimizeTitleSuggestion: false } );
+		installPostTypeMock( 'post' );
+
+		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
+
+		expect( labels ).not.toContain( 'Optimize Title' );
+		expect( labels ).not.toContain( 'AI Editorial Review' );
+	} );
+
+	it( 'treats missing preview features as disabled', () => {
+		( globalThis as any ).agentsManagerData = {
+			aiEditorialReviewEnabled: true,
+			jetpackAiSidebarPreview: {
+				enabled: true,
+				features: { aiEditorialReview: true },
+			},
+		};
+		installPostTypeMock( 'post' );
+
+		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
+
+		expect( labels ).not.toContain( 'Optimize Title' );
+		expect( labels ).toContain( 'AI Editorial Review' );
 	} );
 } );
 
@@ -215,7 +268,7 @@ describe( 'useSuggestions', () => {
 	} );
 
 	it( 'does not append AI Editorial Review to block-specific suggestions', () => {
-		( globalThis as any ).agentsManagerData = { reviewMediatorEnabled: true };
+		installAiEditorialReviewData();
 		mockSelectedBlock = { clientId: 'b1', name: 'core/paragraph' };
 		const onSuggestions = jest.fn();
 
@@ -228,8 +281,38 @@ describe( 'useSuggestions', () => {
 		);
 	} );
 
+	it( 'hides block transformation suggestions when the preview feature disables them', () => {
+		installAiEditorialReviewData( { blockTransformations: false } );
+		mockSelectedBlock = { clientId: 'b1', name: 'core/paragraph' };
+		const onSuggestions = jest.fn();
+
+		render( React.createElement( SuggestionsProbe, { onSuggestions } ) );
+
+		const latestSuggestions =
+			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
+		expect( latestSuggestions ).toEqual( [] );
+	} );
+
+	it( 'hides block transformation suggestions when the preview feature is missing', () => {
+		( globalThis as any ).agentsManagerData = {
+			aiEditorialReviewEnabled: true,
+			jetpackAiSidebarPreview: {
+				enabled: true,
+				features: { aiEditorialReview: true },
+			},
+		};
+		mockSelectedBlock = { clientId: 'b1', name: 'core/paragraph' };
+		const onSuggestions = jest.fn();
+
+		render( React.createElement( SuggestionsProbe, { onSuggestions } ) );
+
+		const latestSuggestions =
+			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
+		expect( latestSuggestions ).toEqual( [] );
+	} );
+
 	it( 'opens split-screen when the AI Editorial Review suggestion is clicked', () => {
-		( globalThis as any ).agentsManagerData = { reviewMediatorEnabled: true };
+		installAiEditorialReviewData();
 		installPostTypeMock( 'post' );
 		const mediationPrompt = getEmptyViewSuggestions().find(
 			( suggestion ) => suggestion.id === 'mediate-review-notes'
@@ -253,7 +336,7 @@ describe( 'useSuggestions', () => {
 	} );
 
 	it( 'does not open split-screen when AI Editorial Review is unavailable', () => {
-		( globalThis as any ).agentsManagerData = { reviewMediatorEnabled: true };
+		installAiEditorialReviewData();
 		mockCurrentPostType = 'page';
 		installPostTypeMock( 'page' );
 
@@ -293,6 +376,11 @@ describe( 'toolProvider', () => {
 		( window as any ).wp = {};
 	} );
 
+	afterEach( () => {
+		delete ( globalThis as any ).agentsManagerData;
+		delete ( window as any ).wp;
+	} );
+
 	describe( 'getAbilities', () => {
 		it( 'includes update-block-content and big_sky__show_component', async () => {
 			const abilities = await toolProvider.getAbilities();
@@ -309,6 +397,16 @@ describe( 'toolProvider', () => {
 
 			expect( typeof showComponent?.callback ).toBe( 'function' );
 			expect( typeof updateBlock?.callback ).toBe( 'function' );
+		} );
+
+		it( 'omits update-block-content when block transformations are disabled', async () => {
+			installAiEditorialReviewData( { blockTransformations: false } );
+
+			const abilities = await toolProvider.getAbilities();
+			const names = abilities.map( ( a: any ) => a.name );
+
+			expect( names ).not.toContain( 'wpcom/update-block-content' );
+			expect( names ).toContain( 'big_sky__show_component' );
 		} );
 	} );
 

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -395,6 +395,28 @@ describe( 'useSuggestions', () => {
 		] );
 	} );
 
+	it( 'does not start the selected block shimmer when a suggestion is only selected', () => {
+		installAiEditorialReviewData();
+		installPostTypeMock( 'post' );
+		mockSelectedBlock = { clientId: 'b1', name: 'core/paragraph' };
+		const blockEl = document.createElement( 'div' );
+		blockEl.setAttribute( 'data-block', 'b1' );
+		document.body.appendChild( blockEl );
+
+		render( React.createElement( SuggestionsProbe, { onSuggestions: jest.fn() } ) );
+
+		act( () => {
+			window.dispatchEvent(
+				new CustomEvent( 'big-sky-inline-suggestion-click', {
+					detail: { value: 'Check the grammar and spelling of this text' },
+				} )
+			);
+		} );
+
+		expect( blockEl.classList.contains( 'jetpack-ai-is-processing' ) ).toBe( false );
+		expect( blockEl.classList.contains( 'jetpack-ai-is-processing-content' ) ).toBe( false );
+	} );
+
 	it( 'starts the selected block shimmer when AM starts processing', () => {
 		jest.useFakeTimers();
 		installPostTypeMock( 'post' );

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -633,7 +633,6 @@ export function useSuggestions(): {
 		const handleSuggestionClick = ( event: Event ) => {
 			setHidden( true );
 			clearSuggestionsFn?.();
-			startBlockShimmer();
 
 			// AI Editorial Review output is too dense for the 350px sidebar.
 			// Auto-expand to 50vw on that suggestion only (matched by prompt).

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -26,10 +26,14 @@ import {
 	findBlockElement,
 	findBlockListLayout,
 	handleUpdateBlockContent,
-	setAddMessageFn,
 	setModuleCheckpointApi,
 	getModuleCheckpointApi,
 	startBlockShimmer,
+	stopBlockShimmer,
+	getSelectedOrRememberedBlock,
+	rememberSelectedBlock,
+	notifyBlockActionComplete,
+	BLOCK_ACTION_COMPLETE_EVENT,
 } from './utils/block-actions';
 import {
 	UPDATE_BLOCK_CONTENT_TOOL_ID,
@@ -48,6 +52,7 @@ export { applyReviewEdit, findBlockElement, findBlockListLayout };
 // ---------- Module state ----------
 
 let clearSuggestionsFn: ( () => void ) | null = null;
+let wasAgentProcessing = false;
 
 /** Whether `_suggestion_rendered` has fired this page life (once-per-session). */
 let suggestionRenderedFiredOnce = false;
@@ -270,12 +275,21 @@ function hasAbilitiesApi(): boolean {
 export function useAbilitiesSetup( actions: {
 	addMessage: ( message: any ) => void;
 	clearSuggestions?: () => void;
+	isProcessing?: boolean;
 	[ key: string ]: unknown;
 } ): void {
-	setAddMessageFn( actions.addMessage );
 	if ( actions.clearSuggestions ) {
 		clearSuggestionsFn = actions.clearSuggestions;
 	}
+
+	const isProcessing = actions.isProcessing === true;
+	if ( isProcessing && ! wasAgentProcessing ) {
+		startBlockShimmer();
+	} else if ( ! isProcessing && wasAgentProcessing ) {
+		stopBlockShimmer();
+		notifyBlockActionComplete();
+	}
+	wasAgentProcessing = isProcessing;
 }
 
 // ---------- toolProvider ----------
@@ -432,11 +446,11 @@ export const contextProvider = {
 			if ( blockEditor ) {
 				const blocks = blockEditor.getBlocks?.() ?? [];
 				currentPageContent = blocks.map( serializeBlock );
-				selectedBlockClientId = blockEditor.getSelectedBlockClientId?.() ?? '';
-
-				if ( selectedBlockClientId ) {
-					const selectedBlock = blockEditor.getSelectedBlock?.();
-					if ( selectedBlock?.attributes?.content ) {
+				const selectedBlock = getSelectedOrRememberedBlock();
+				if ( selectedBlock?.clientId ) {
+					selectedBlockClientId = selectedBlock.clientId;
+					rememberSelectedBlock( selectedBlock );
+					if ( selectedBlock.attributes?.content ) {
 						selectedBlockContent = resolveBlockContent( selectedBlock.attributes.content );
 					}
 				}
@@ -561,7 +575,7 @@ const IMAGE_BLOCK_TYPES = [ 'core/image', 'core/media-text', 'core/cover', 'core
 /** Block-aware suggestion definitions with optional condition per block type. */
 const BLOCK_SUGGESTIONS = [
 	{
-		id: 'translate-content',
+		id: 'translate',
 		label: __( 'Translate content', 'jetpack' ),
 		prompt: __( 'Translate this block content to:', 'jetpack' ),
 		condition: ( block: any ) => TEXT_BLOCK_TYPES.includes( block?.name ),
@@ -644,6 +658,16 @@ export function useSuggestions(): {
 		};
 	}, [] );
 
+	useEffect( () => {
+		const handleBlockActionComplete = () => {
+			setHidden( false );
+		};
+		window.addEventListener( BLOCK_ACTION_COMPLETE_EVENT, handleBlockActionComplete );
+		return () => {
+			window.removeEventListener( BLOCK_ACTION_COMPLETE_EVENT, handleBlockActionComplete );
+		};
+	}, [] );
+
 	const editorContext = useSelect( ( select ) => {
 		const blockEditor = select( 'core/block-editor' ) as { getSelectedBlock: () => any };
 		const editor = select( 'core/editor' ) as { getCurrentPostType?: () => string | undefined };
@@ -662,7 +686,12 @@ export function useSuggestions(): {
 		return { suggestions: [] };
 	}
 
-	if ( ! editorContext.selectedBlock ) {
+	const selectedBlock = editorContext.selectedBlock ?? getSelectedOrRememberedBlock();
+	if ( editorContext.selectedBlock ) {
+		rememberSelectedBlock( editorContext.selectedBlock );
+	}
+
+	if ( ! selectedBlock ) {
 		return { suggestions: getPostLevelSuggestions( editorContext.postType ) };
 	}
 
@@ -672,9 +701,7 @@ export function useSuggestions(): {
 		return { suggestions: aiEditorialReviewSuggestions };
 	}
 
-	const applicable = BLOCK_SUGGESTIONS.filter( ( s ) =>
-		s.condition( editorContext.selectedBlock )
-	);
+	const applicable = BLOCK_SUGGESTIONS.filter( ( s ) => s.condition( selectedBlock ) );
 	return {
 		suggestions: [
 			...applicable.map( ( { id, label, prompt } ) => ( { id, label, prompt } ) ),

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -74,8 +74,51 @@ const AI_EDITORIAL_REVIEW_SUGGESTION = {
 	),
 };
 
+type JetpackAiSidebarPreviewFeature =
+	| 'aiEditorialReview'
+	| 'blockTransformations'
+	| 'optimizeTitleSuggestion'
+	| 'chatHistory'
+	| 'supportGuides';
+
+function getAgentsManagerData() {
+	return typeof agentsManagerData !== 'undefined' ? agentsManagerData : undefined;
+}
+
+function isJetpackAiSidebarPreviewFeatureEnabled(
+	feature: JetpackAiSidebarPreviewFeature,
+	defaultValue: boolean
+): boolean {
+	const preview = getAgentsManagerData()?.jetpackAiSidebarPreview;
+	if ( ! preview ) {
+		return defaultValue;
+	}
+	if ( ! preview.enabled ) {
+		return false;
+	}
+	return preview.features?.[ feature ] === true;
+}
+
 function isAiEditorialReviewEnabled(): boolean {
-	return typeof agentsManagerData !== 'undefined' && !! agentsManagerData?.reviewMediatorEnabled;
+	const data = getAgentsManagerData();
+	if ( ! data ) {
+		return false;
+	}
+	if ( data.jetpackAiSidebarPreview ) {
+		return isJetpackAiSidebarPreviewFeatureEnabled(
+			'aiEditorialReview',
+			!! data.aiEditorialReviewEnabled
+		);
+	}
+	return !! data.aiEditorialReviewEnabled || !! data.reviewMediatorEnabled;
+}
+
+function isOptimizeTitleSuggestionEnabled(): boolean {
+	return isJetpackAiSidebarPreviewFeatureEnabled( 'optimizeTitleSuggestion', true );
+}
+
+function isBlockTransformationsEnabled(): boolean {
+	return isJetpackAiSidebarPreviewFeatureEnabled( 'blockTransformations', true );
 }
 
 function getCurrentEditorPostType(): string | undefined {
@@ -108,7 +151,10 @@ function getAiEditorialReviewSuggestions( currentPostType?: string ) {
 }
 
 function getPostLevelSuggestions( currentPostType?: string ) {
-	return [ OPTIMIZE_TITLE_SUGGESTION, ...getAiEditorialReviewSuggestions( currentPostType ) ];
+	return [
+		...( isOptimizeTitleSuggestionEnabled() ? [ OPTIMIZE_TITLE_SUGGESTION ] : [] ),
+		...getAiEditorialReviewSuggestions( currentPostType ),
+	];
 }
 
 // ---------- Show-component ability ----------
@@ -285,17 +331,21 @@ export const toolProvider = {
 
 		abilities = filterAbility( abilities, UPDATE_BLOCK_CONTENT_TOOL_ID );
 		abilities = filterAbility( abilities, SHOW_COMPONENT_TOOL_ID );
-		abilities.unshift(
-			{
-				...UPDATE_BLOCK_CONTENT_ABILITY,
-				callback: handleUpdateBlockContent,
-			},
+		const jetpackAbilities = [
+			...( isBlockTransformationsEnabled()
+				? [
+						{
+							...UPDATE_BLOCK_CONTENT_ABILITY,
+							callback: handleUpdateBlockContent,
+						},
+				  ]
+				: [] ),
 			{
 				...SHOW_COMPONENT_ABILITY,
 				callback: handleShowComponent,
-			}
-		);
-
+			},
+		];
+		abilities.unshift( ...jetpackAbilities );
 		return abilities;
 	},
 
@@ -614,6 +664,10 @@ export function useSuggestions(): {
 
 	if ( ! editorContext.selectedBlock ) {
 		return { suggestions: getPostLevelSuggestions( editorContext.postType ) };
+	}
+
+	if ( ! isBlockTransformationsEnabled() ) {
+		return { suggestions: [] };
 	}
 
 	const applicable = BLOCK_SUGGESTIONS.filter( ( s ) =>

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -666,14 +666,19 @@ export function useSuggestions(): {
 		return { suggestions: getPostLevelSuggestions( editorContext.postType ) };
 	}
 
+	const aiEditorialReviewSuggestions = getAiEditorialReviewSuggestions( editorContext.postType );
+
 	if ( ! isBlockTransformationsEnabled() ) {
-		return { suggestions: [] };
+		return { suggestions: aiEditorialReviewSuggestions };
 	}
 
 	const applicable = BLOCK_SUGGESTIONS.filter( ( s ) =>
 		s.condition( editorContext.selectedBlock )
 	);
 	return {
-		suggestions: applicable.map( ( { id, label, prompt } ) => ( { id, label, prompt } ) ),
+		suggestions: [
+			...applicable.map( ( { id, label, prompt } ) => ( { id, label, prompt } ) ),
+			...aiEditorialReviewSuggestions,
+		],
 	};
 }

--- a/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
@@ -18,12 +18,12 @@ export interface CheckpointApi {
 
 // ---------- Module state ----------
 
-let addMessageFn: ( ( message: any ) => void ) | null = null;
 let moduleCheckpointApi: CheckpointApi | null = null;
+const processingEffectTimeouts = new WeakMap< HTMLElement, ReturnType< typeof setTimeout > >();
+const processingEffectElements = new Set< HTMLElement >();
+let rememberedSelectedBlockClientId: string | null = null;
 
-export function setAddMessageFn( fn: ( ( message: any ) => void ) | null ): void {
-	addMessageFn = fn;
-}
+export const BLOCK_ACTION_COMPLETE_EVENT = 'jetpack-ai-sidebar-block-action-complete';
 
 export function setModuleCheckpointApi( api: CheckpointApi | null ): void {
 	moduleCheckpointApi = api;
@@ -33,7 +33,56 @@ export function getModuleCheckpointApi(): CheckpointApi | null {
 	return moduleCheckpointApi;
 }
 
+export function rememberSelectedBlock( block: any ): void {
+	if ( block?.clientId ) {
+		rememberedSelectedBlockClientId = block.clientId;
+	}
+}
+
+export function getSelectedOrRememberedBlock(): any | null {
+	const blockEditor = ( window as any ).wp?.data?.select( 'core/block-editor' );
+	const selectedBlock = blockEditor?.getSelectedBlock?.();
+	if ( selectedBlock?.clientId ) {
+		rememberSelectedBlock( selectedBlock );
+		return selectedBlock;
+	}
+
+	return rememberedSelectedBlockClientId
+		? blockEditor?.getBlock?.( rememberedSelectedBlockClientId )
+		: null;
+}
+
+export function notifyBlockActionComplete(): void {
+	if ( typeof window === 'undefined' ) {
+		return;
+	}
+	window.dispatchEvent( new Event( BLOCK_ACTION_COMPLETE_EVENT ) );
+}
+
+function clearProcessingEffectTimeout( el: HTMLElement ): void {
+	const timeout = processingEffectTimeouts.get( el );
+	if ( timeout ) {
+		clearTimeout( timeout );
+		processingEffectTimeouts.delete( el );
+	}
+}
+
 // ---------- Block element helpers ----------
+
+function getAccessibleFrameDocuments(): Document[] {
+	const docs: Document[] = [];
+	document.querySelectorAll( 'iframe' ).forEach( ( iframe ) => {
+		try {
+			const frameDocument = ( iframe as HTMLIFrameElement ).contentDocument;
+			if ( frameDocument ) {
+				docs.push( frameDocument );
+			}
+		} catch {
+			// Cross-origin frames are not relevant to the block editor.
+		}
+	} );
+	return docs;
+}
 
 /**
  * Find a block element by clientId in the main document or editor iframe.
@@ -43,27 +92,24 @@ export function getModuleCheckpointApi(): CheckpointApi | null {
  * @returns The block element, or null.
  */
 export function findBlockElement( clientId: string ): HTMLElement | null {
-	// Validate clientId format to prevent selector injection.
-	if ( ! /^[0-9a-f-]+$/i.test( clientId ) ) {
+	if ( ! clientId ) {
 		return null;
 	}
 
+	const selector = `[data-block="${ CSS.escape( clientId ) }"]`;
 	try {
-		const el = document.querySelector( `[data-block="${ clientId }"]` ) as HTMLElement | null;
+		const el = document.querySelector( selector ) as HTMLElement | null;
 		if ( el ) {
 			return el;
 		}
-		const iframe = document.querySelector(
-			'iframe[name="editor-canvas"]'
-		) as HTMLIFrameElement | null;
-		return (
-			( iframe?.contentDocument?.querySelector(
-				`[data-block="${ clientId }"]`
-			) as HTMLElement | null ) ?? null
-		);
-	} catch {
-		return null;
-	}
+		for ( const frameDocument of getAccessibleFrameDocuments() ) {
+			const frameEl = frameDocument.querySelector( selector ) as HTMLElement | null;
+			if ( frameEl ) {
+				return frameEl;
+			}
+		}
+	} catch {}
+	return null;
 }
 
 /**
@@ -79,18 +125,19 @@ export function findBlockListLayout(): HTMLElement | null {
 		if ( el ) {
 			return el;
 		}
-		const iframe = document.querySelector(
-			'iframe[name="editor-canvas"]'
-		) as HTMLIFrameElement | null;
-		return ( iframe?.contentDocument?.querySelector( selector ) as HTMLElement | null ) ?? null;
-	} catch {
-		return null;
-	}
+		for ( const frameDocument of getAccessibleFrameDocuments() ) {
+			const frameEl = frameDocument.querySelector( selector ) as HTMLElement | null;
+			if ( frameEl ) {
+				return frameEl;
+			}
+		}
+	} catch {}
+	return null;
 }
 
 // ---------- Processing effect (Flow Block shimmer) ----------
 
-/** Inject processing-effect styles. Uses system fonts so no external font fetch is needed. */
+/** Inject processing-effect styles, matching Big Sky's Flow Block shimmer. */
 function ensureProcessingStyles( doc: Document ): void {
 	if ( doc.getElementById( 'jetpack-ai-processing-styles' ) ) {
 		return;
@@ -98,6 +145,8 @@ function ensureProcessingStyles( doc: Document ): void {
 	const style = doc.createElement( 'style' );
 	style.id = 'jetpack-ai-processing-styles';
 	style.textContent = `
+		@import url(https://fonts.googleapis.com/css2?family=Flow+Block&display=swap);
+
 		@keyframes jetpack-ai-flash-text {
 			0% { opacity: 0.4; }
 			50% { opacity: 0.8; }
@@ -109,13 +158,31 @@ function ensureProcessingStyles( doc: Document ): void {
 		}
 		.jetpack-ai-is-processing,
 		.jetpack-ai-is-processing .wp-block-heading,
-		.jetpack-ai-is-processing .wp-block-paragraph {
-			font-style: italic;
-			transition: transform 1s;
-		}
-		.jetpack-ai-is-processing:not(:has(img)) {
-			animation: jetpack-ai-flash-text 2s infinite;
-		}
+			.jetpack-ai-is-processing .wp-block-paragraph,
+			.jetpack-ai-is-processing-content,
+			.jetpack-ai-is-processing-content .wp-block-heading,
+			.jetpack-ai-is-processing-content .wp-block-paragraph,
+			.big-sky__is-processing-content,
+			.big-sky__is-processing-content .wp-block-heading,
+			.big-sky__is-processing-content .wp-block-paragraph {
+				font-family: "Flow Block", system-ui !important;
+				font-weight: 200;
+				font-style: normal;
+				transition: transform 1s;
+			}
+			.jetpack-ai-is-processing div,
+			.jetpack-ai-is-processing-content div,
+			.big-sky__is-processing-content div {
+				font-family: "Flow Block", system-ui !important;
+				font-weight: 200;
+				font-style: normal;
+				overflow: hidden;
+			}
+			.jetpack-ai-is-processing:not(:has(img)),
+			.jetpack-ai-is-processing-content:not(:has(img)),
+			.big-sky__is-processing-content:not(:has(img)) {
+				animation: jetpack-ai-flash-text 2s infinite;
+			}
 		.jetpack-ai-has-processed {
 			outline: 2px solid rgba(56, 88, 233, 0.8);
 			outline-offset: 2px;
@@ -126,13 +193,39 @@ function ensureProcessingStyles( doc: Document ): void {
 	doc.head.appendChild( style );
 }
 
+function removeProcessingClasses( el: HTMLElement ): void {
+	el.classList.remove( 'jetpack-ai-is-processing' );
+	el.classList.remove( 'jetpack-ai-is-processing-content' );
+	el.classList.remove( 'big-sky__is-processing-content' );
+	delete el.dataset.bigSkyProcessingState;
+	delete el.dataset.bigSkyProcessingFeatures;
+	processingEffectElements.delete( el );
+}
+
+function clearProcessingEffect( el: HTMLElement ): void {
+	clearProcessingEffectTimeout( el );
+	removeProcessingClasses( el );
+}
+
 /**
  * Apply processing effect to a block element.
  * @param el - The block element.
  */
 export function applyProcessingEffect( el: HTMLElement ): void {
 	ensureProcessingStyles( el.ownerDocument );
+	clearProcessingEffectTimeout( el );
 	el.classList.add( 'jetpack-ai-is-processing' );
+	el.classList.add( 'jetpack-ai-is-processing-content' );
+	el.classList.add( 'big-sky__is-processing-content' );
+	el.dataset.bigSkyProcessingState = 'processing';
+	el.dataset.bigSkyProcessingFeatures = 'content';
+	processingEffectElements.add( el );
+	processingEffectTimeouts.set(
+		el,
+		setTimeout( () => {
+			clearProcessingEffect( el );
+		}, 30000 )
+	);
 }
 
 /**
@@ -140,11 +233,18 @@ export function applyProcessingEffect( el: HTMLElement ): void {
  * @param el - The block element.
  */
 function removeProcessingEffect( el: HTMLElement ): void {
-	el.classList.remove( 'jetpack-ai-is-processing' );
+	clearProcessingEffect( el );
 	el.classList.add( 'jetpack-ai-has-processed' );
 	setTimeout( () => {
 		el.classList.remove( 'jetpack-ai-has-processed' );
 	}, 1000 );
+}
+
+/**
+ * Stop shimmer on any block currently marked as processing.
+ */
+export function stopBlockShimmer(): void {
+	Array.from( processingEffectElements ).forEach( clearProcessingEffect );
 }
 
 /**
@@ -155,7 +255,7 @@ export function startBlockShimmer(): void {
 	if ( ! wpData ) {
 		return;
 	}
-	const block = wpData.select( 'core/block-editor' ).getSelectedBlock();
+	const block = getSelectedOrRememberedBlock();
 	if ( block?.clientId ) {
 		const blockEl = findBlockElement( block.clientId );
 		if ( blockEl ) {
@@ -192,14 +292,61 @@ function countOccurrences( source: string, needle: string ): number {
 	}
 }
 
-function getBlockSnapshot( clientId: string ): { name: string; content: string } | null {
+function getEditableBlockContent( block: any ): string {
+	const raw = block.attributes?.content;
+	return typeof raw === 'string' ? raw : raw?.toHTMLString?.() ?? '';
+}
+
+function getBlockSnapshot(
+	clientId: string
+): { clientId: string; name: string; content: string } | null {
 	const block = ( window as any ).wp?.data?.select( 'core/block-editor' )?.getBlock?.( clientId );
 	if ( ! block ) {
 		return null;
 	}
-	const raw = block.attributes?.content;
-	const content = typeof raw === 'string' ? raw : raw?.toHTMLString?.() ?? '';
-	return { name: block.name, content };
+	return {
+		clientId: block.clientId ?? clientId,
+		name: block.name,
+		content: getEditableBlockContent( block ),
+	};
+}
+
+function findBlockSnapshotByCurrentText( currentText: string ): {
+	snapshot?: { clientId: string; name: string; content: string };
+	error?: string;
+} {
+	const blocks = ( window as any ).wp?.data?.select( 'core/block-editor' )?.getBlocks?.() ?? [];
+	const matches: Array< { clientId: string; name: string; content: string } > = [];
+
+	const visit = ( block: any ) => {
+		if ( ! block ) {
+			return;
+		}
+		const snapshot = {
+			clientId: block.clientId,
+			name: block.name,
+			content: getEditableBlockContent( block ),
+		};
+
+		if ( snapshot.clientId && isSupportedEditBlockType( snapshot.name ) ) {
+			const matchCount = countOccurrences( snapshot.content, currentText );
+			for ( let i = 0; i < matchCount; i++ ) {
+				matches.push( snapshot );
+			}
+		}
+
+		( block.innerBlocks ?? [] ).forEach( visit );
+	};
+
+	blocks.forEach( visit );
+
+	if ( matches.length === 1 ) {
+		return { snapshot: matches[ 0 ] };
+	}
+	if ( matches.length > 1 ) {
+		return { error: 'currentText matches multiple spans in block content' };
+	}
+	return {};
 }
 
 /**
@@ -231,9 +378,37 @@ export function handleUpdateBlockContent( input: any ): any {
 		return { success: false, error: 'context changed', returnToAgent: false };
 	}
 
-	const snapshot = getBlockSnapshot( clientId );
+	const hasCurrentText = typeof currentText === 'string' && currentText !== '';
+	let targetClientId = clientId;
+	let snapshot = getBlockSnapshot( targetClientId );
 	if ( ! snapshot ) {
-		return { success: false, error: 'block not found', returnToAgent: false };
+		if ( hasCurrentText ) {
+			const fallback = findBlockSnapshotByCurrentText( currentText );
+			if ( fallback.error ) {
+				// eslint-disable-next-line no-console
+				console.warn( '[ReviewMediation] currentText matches multiple spans in block content', {
+					clientId,
+				} );
+				return {
+					success: false,
+					error: fallback.error,
+					returnToAgent: false,
+				};
+			}
+			if ( fallback.snapshot ) {
+				targetClientId = fallback.snapshot.clientId;
+				snapshot = fallback.snapshot;
+				// eslint-disable-next-line no-console
+				console.warn( '[ReviewMediation] stale clientId matched by currentText', {
+					clientId,
+					targetClientId,
+				} );
+			}
+		}
+
+		if ( ! snapshot ) {
+			return { success: false, error: 'block not found', returnToAgent: false };
+		}
 	}
 	if ( ! isSupportedEditBlockType( snapshot.name ) ) {
 		return {
@@ -246,7 +421,6 @@ export function handleUpdateBlockContent( input: any ): any {
 	// Substring replace when currentText is a non-empty span present in the block.
 	// If that span no longer exists, fail rather than replacing the whole block
 	// with a partial suggested edit.
-	const hasCurrentText = typeof currentText === 'string' && currentText !== '';
 	if ( hasCurrentText ) {
 		const matchCount = countOccurrences( snapshot.content, currentText );
 		if ( matchCount === 0 ) {
@@ -272,7 +446,7 @@ export function handleUpdateBlockContent( input: any ): any {
 	}
 
 	// Apply shimmer briefly, then update content and show highlight
-	const blockEl = findBlockElement( clientId );
+	const blockEl = findBlockElement( targetClientId );
 	if ( blockEl ) {
 		applyProcessingEffect( blockEl );
 	}
@@ -280,11 +454,12 @@ export function handleUpdateBlockContent( input: any ): any {
 	// Short delay so the shimmer is visible before content swaps
 	return new Promise< any >( ( resolve ) => {
 		setTimeout( () => {
-			const latestSnapshot = getBlockSnapshot( clientId );
+			const latestSnapshot = getBlockSnapshot( targetClientId );
 			const resolveFailure = ( error: string ) => {
 				if ( blockEl ) {
 					removeProcessingEffect( blockEl );
 				}
+				notifyBlockActionComplete();
 				resolve( { success: false, error, returnToAgent: false } );
 			};
 
@@ -307,14 +482,16 @@ export function handleUpdateBlockContent( input: any ): any {
 				const matchCount = countOccurrences( latestSnapshot.content, currentText );
 				if ( matchCount === 0 ) {
 					// eslint-disable-next-line no-console
-					console.warn( '[ReviewMediation] currentText not found in block content', { clientId } );
+					console.warn( '[ReviewMediation] currentText not found in block content', {
+						clientId: targetClientId,
+					} );
 					resolveFailure( 'currentText not found in block content' );
 					return;
 				}
 				if ( matchCount > 1 ) {
 					// eslint-disable-next-line no-console
 					console.warn( '[ReviewMediation] currentText matches multiple spans in block content', {
-						clientId,
+						clientId: targetClientId,
 					} );
 					resolveFailure( 'currentText matches multiple spans in block content' );
 					return;
@@ -322,33 +499,30 @@ export function handleUpdateBlockContent( input: any ): any {
 				nextContent = latestSnapshot.content.replace( currentText, content );
 			} else if ( latestSnapshot.content !== snapshot.content ) {
 				// eslint-disable-next-line no-console
-				console.warn( '[ReviewMediation] block content changed while applying edit', { clientId } );
+				console.warn( '[ReviewMediation] block content changed while applying edit', {
+					clientId: targetClientId,
+				} );
 				resolveFailure( 'block content changed while applying edit' );
 				return;
 			}
 
-			blockEditor.updateBlockAttributes( clientId, { content: nextContent } );
+			blockEditor.updateBlockAttributes( targetClientId, { content: nextContent } );
+			blockEditor.selectBlock?.( targetClientId );
+			rememberedSelectedBlockClientId = targetClientId;
 
 			if ( blockEl ) {
 				removeProcessingEffect( blockEl );
 			}
 
-			// Show summary in chat
-			if ( addMessageFn && summary ) {
-				addMessageFn( {
-					id: `block-update-${ Date.now() }`,
-					role: 'assistant',
-					content: [ { type: 'text', text: summary } ],
-					created_at: Math.floor( Date.now() / 1000 ),
-					showIcon: true,
-				} );
-			}
+			notifyBlockActionComplete();
 
 			resolve( {
 				success: true,
+				clientId: targetClientId,
 				contentBefore: latestSnapshot.content,
 				contentAfter: nextContent,
 				returnToAgent: false,
+				...( summary ? { agentMessage: summary } : {} ),
 			} );
 		}, 800 );
 	} );
@@ -371,8 +545,10 @@ export async function applyReviewEdit(
 	shouldApply?: () => boolean
 ): Promise< {
 	success: boolean;
+	clientId?: string;
 	contentBefore?: string;
 	contentAfter?: string;
+	agentMessage?: string;
 	error?: string;
 	returnToAgent?: boolean;
 } > {


### PR DESCRIPTION
## Proposed Changes

* Add Jetpack AI Sidebar Preview support in Agents Manager and `@automattic/jetpack-ai-sidebar`.
* Read preview feature flags from `agentsManagerData.jetpackAiSidebarPreview.features`.
* Hide Optimize Title, Chat History, and Support Guides when preview disables them.
* Keep AI Editorial Review and block transformations independently controlled by preview feature flags.
* Keep AI Editorial Review visible when a supported block is selected.
* Restore Jetpack AI Sidebar suggestion clicks so inline/footer suggestion chips populate the chat input.
* Keep Jetpack AI block actions synced with the current editor state, including stale selected block IDs and block animation targets across editor frames.
* Improve block update safety by using current selected/remembered block context and `currentText` checks.
* Keep `reviewMediatorEnabled` as a temporary fallback for older server payloads while companion PRs roll forward.
* Add focused tests for preview-gated suggestions, abilities, Chat History, Support Guides, suggestion clicks, and block action behavior.

## Why

AI Editorial Review is being opened to public users through the Jetpack AI Sidebar. The full sidebar surface is not ready for a broad public launch, so this PR supports a limited Jetpack AI Sidebar Preview where hosts can expose only the features declared in the preview payload.

The sidebar also carries selected-block prompts, so this PR keeps those prompts gated by the preview payload and preserves the existing block-update path when hosts expose block transformations.

## Behavior after this PR

* Without preview data, existing Agents Manager and Jetpack AI Sidebar behavior is unchanged.
* With Jetpack AI Sidebar Preview enabled:
  * AI Editorial Review can appear in post-level suggestions.
  * AI Editorial Review remains available when a block is selected.
  * Optimize Title can be hidden.
  * Chat History can be hidden.
  * Support Guides can be hidden.
  * Block-level suggestions follow the `blockTransformations` preview flag.
  * Block suggestion clicks populate the chat input and can safely update the selected/remembered block.

## Companion PRs

* Jetpack: Automattic/jetpack#48961
* WordPress.com: Automattic/wpcom#218494

## Does this pull request change what data or activity we track or use?

No new tracking events or properties are added.

This broadens access to AI Editorial Review through the sidebar preview, so existing AI Editorial Review events may now be emitted by users who can access the feature after rollout.

## Testing Instructions

1. Apply the companion Jetpack and WordPress.com branches in a sandbox.
2. Load this Calypso branch / Agents Manager bundle.
3. Open the post editor for a post as a user with edit access.
4. Confirm the AI FAB/sidebar appears.
5. Confirm AI Editorial Review appears and runs.
6. Confirm Optimize Title is not shown.
7. Confirm Chat History is not shown.
8. Confirm Support Guides is not shown.
9. Select a paragraph or heading block and confirm block-level suggestions appear alongside AI Editorial Review.
10. Click a block suggestion and confirm it populates the chat input.
11. Submit the block prompt and confirm the selected block updates safely.
12. Start a new chat, hard refresh, and navigate to another post; confirm block suggestions still target the selected block.
13. Confirm footer suggestion chips appear after agent replies and clicking them fills the input.
14. Sanity check that the page editor does not expose AI Editorial Review through this preview path.
