### PR TITLE
Dashboard: remove tautological setEnqueued typeof test

### DIFF
--- a/client/dashboard/sites/backups/test/use-backup-state.test.tsx
+++ b/client/dashboard/sites/backups/test/use-backup-state.test.tsx
@@ -358,14 +358,5 @@ describe( 'useBackupState', () => {
 			} );
 		} );
 
-		it( 'should provide setEnqueued function in returned state', async () => {
-			const { result } = renderHook( () => useBackupState( mockSiteId ), {
-				wrapper: TestWrapper,
-			} );
-
-			await waitFor( () => {
-				expect( typeof result.current.setEnqueued ).toBe( 'function' );
-			} );
-		} );
 	} );
 } );

--- a/client/dashboard/sites/backups/test/use-backup-state.test.tsx
+++ b/client/dashboard/sites/backups/test/use-backup-state.test.tsx
@@ -357,6 +357,5 @@ describe( 'useBackupState', () => {
 				expect( result.current.status ).toBe( 'idle' );
 			} );
 		} );
-
 	} );
 } );


### PR DESCRIPTION
Part of dotmsd-1231

## Proposed Changes

* Delete `'should provide setEnqueued function in returned state'` from `client/dashboard/sites/backups/test/use-backup-state.test.tsx`.

## Why are these changes being made?

The deleted test only asserted `typeof result.current.setEnqueued === 'function'`. That is tautological — the hook's return shape is already type-checked, and `setEnqueued` is exercised implicitly by every other test that calls it. Removing the noise tightens the suite without losing coverage.

## Testing Instructions

* `yarn test-client client/dashboard/sites/backups/test/use-backup-state.test.tsx`
* Remaining specs in the file pass.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?