### PR TITLE
Omnibar: Add missing key props on OmnibarSiteNode siblings

### DIFF
--- a/packages/omnibar/src/components/omnibar-site.tsx
+++ b/packages/omnibar/src/components/omnibar-site.tsx
@@ -25,8 +25,8 @@ export function OmnibarSiteNode( {
 
 	return [
 		<OmnibarMenu key={ siteNode.id } node={ siteNode } style={ { minWidth: 0 } } />,
-		pluginNodes && <OmnibarSitePluginsNode nodes={ pluginNodes } />,
-		siteActionNodes && <OmnibarSiteActionsNode nodes={ siteActionNodes } />,
+		pluginNodes && <OmnibarSitePluginsNode key="plugins" nodes={ pluginNodes } />,
+		siteActionNodes && <OmnibarSiteActionsNode key="actions" nodes={ siteActionNodes } />,
 	].filter( Boolean );
 }
 


### PR DESCRIPTION
## Proposed Changes

`OmnibarSiteNode` returns an array of three sibling elements, but only the first one carried a `key`. React's "Each child in a list should have a unique 'key' prop" warning fires whenever any sibling in such an array is missing one, even if some siblings have keys. This adds stable string keys for the plugins and actions siblings.

```diff
 return [
   <OmnibarMenu key={ siteNode.id } node={ siteNode } style={ { minWidth: 0 } } />,
-  pluginNodes && <OmnibarSitePluginsNode nodes={ pluginNodes } />,
-  siteActionNodes && <OmnibarSiteActionsNode nodes={ siteActionNodes } />,
+  pluginNodes && <OmnibarSitePluginsNode key="plugins" nodes={ pluginNodes } />,
+  siteActionNodes && <OmnibarSiteActionsNode key="actions" nodes={ siteActionNodes } />,
 ].filter( Boolean );
```

Array order is fixed (site, plugins, actions), so static string keys are appropriate and won't cause unintended remounts.

## Why are these changes being made?

The warning shows up in the console for any page that renders the dashboard omnibar with a selected site (the trigger is reaching the `node.site` render path with plugin nodes). Non-behavioral fix, just clears the noise.

## Testing Instructions

1. Run the dashboard locally.
2. Navigate to a site so the omnibar shows the site menu.
3. Open the devtools console. Confirm the previous warning no longer appears:
    > Warning: Each child in a list should have a unique "key" prop. ... at OmnibarSiteNode (omnibar-site.tsx) ... at Omnibar ... at OmnibarContainer

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?