### PR TITLE
Arcade Mode: bump MC stat on activation

### DIFF
--- a/client/layout/arcade-mode/activate.ts
+++ b/client/layout/arcade-mode/activate.ts
@@ -1,5 +1,6 @@
 import { unlockAchievement } from '@automattic/api-core';
 import { __ } from '@wordpress/i18n';
+import { bumpStat } from 'calypso/lib/analytics/mc';
 import { getCalypsoQueryClient } from 'calypso/state/query-client';
 import './style.scss';
 
@@ -112,6 +113,8 @@ export function activateArcadeMode(): void {
 	}
 
 	active = true;
+
+	bumpStat( 'calypso_easter_eggs', 'arcade_mode_activated' );
 
 	document.body.classList.add( BODY_CLASS );
 	mountLivesCounter( section );


### PR DESCRIPTION
Follow-up to #110422.

## Proposed Changes

- Bump the MC stat `calypso_easter_eggs/arcade_mode_activated` from inside the lazy `activateArcadeMode` activator (`client/layout/arcade-mode/activate.ts`), gated behind the same `active` flag so we only count genuine activations — not no-masterbar bailouts and not idempotent re-entries while already active.

## Why are these changes being made?

So we can see, in MC, how often anyone actually triggers the Konami easter egg. Placing the bump in `activate.ts` (the lazy chunk) means the analytics pixel only loads after the sequence matches, preserving the near-zero initial-bundle cost from the original PR.

The group name `calypso_easter_eggs` is reusable if more easter eggs land later; the action name `arcade_mode_activated` matches the existing verb-style convention (`banner_open`, `subscribed_blog`, …).

## Testing Instructions

1. Start Calypso (`yarn start`) and log in.
2. Open DevTools → Network and filter for `pixel.wp.com`.
3. On any logged-in page, type ↑ ↑ ↓ ↓ ← → ← → B A.
4. Expect a single request to `https://pixel.wp.com/g.gif?v=wpcom-no-pv&x_calypso_easter_eggs=arcade_mode_activated&t=…` at the moment arcade mode activates.
5. Press ESC and re-enter the sequence — a second pixel request should fire (one per activation).
6. Type the sequence on a surface without a masterbar (e.g. a logged-out page) — no pixel should fire, since the activator bails before flipping `active`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed?
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [x] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?

🤖 Generated with [Claude Code](https://claude.com/claude-code)