### PR TITLE
Reader achievements: add an informational privacy notice for private own profiles

### DIFF
--- a/client/reader/components/achievements/use-set-achievements-visibility.ts
+++ b/client/reader/components/achievements/use-set-achievements-visibility.ts
@@ -1,10 +1,11 @@
-import { userPreferenceOptimisticMutation } from '@automattic/api-queries';
-import { useMutation } from '@tanstack/react-query';
+import { rawUserPreferencesQuery, userPreferenceOptimisticMutation } from '@automattic/api-queries';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
 import { recordAction } from 'calypso/reader/stats';
 import { useDispatch } from 'calypso/state';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { useRecordReaderTracksEvent } from 'calypso/state/reader/analytics/useRecordReaderTracksEvent';
+import type { UserPreferences } from '@automattic/api-core';
 
 export type AchievementsVisibility = 'public' | 'private';
 
@@ -12,6 +13,7 @@ export default function useSetAchievementsVisibility() {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const recordReaderTracksEvent = useRecordReaderTracksEvent();
+	const queryClient = useQueryClient();
 
 	const { mutate, isPending } = useMutation(
 		userPreferenceOptimisticMutation( 'achievements-visibility' )
@@ -20,6 +22,14 @@ export default function useSetAchievementsVisibility() {
 	const setVisibility = ( next: AchievementsVisibility ) => {
 		mutate( next, {
 			onSuccess() {
+				// `userPreferenceOptimisticMutation` patches the singleton QueryClient
+				// in `@automattic/api-queries`, not the Calypso one this surface reads
+				// from. Mirror the write here so `useQuery(userPreferenceQuery(...))`
+				// in the notice and popover reflect the new value immediately.
+				queryClient.setQueryData< UserPreferences >(
+					rawUserPreferencesQuery().queryKey,
+					( oldData ) => ( { ...oldData, 'achievements-visibility': next } )
+				);
 				dispatch(
 					successNotice(
 						next === 'public'

--- a/client/reader/components/achievements/use-set-achievements-visibility.ts
+++ b/client/reader/components/achievements/use-set-achievements-visibility.ts
@@ -1,0 +1,48 @@
+import { userPreferenceOptimisticMutation } from '@automattic/api-queries';
+import { useMutation } from '@tanstack/react-query';
+import { useTranslate } from 'i18n-calypso';
+import { recordAction } from 'calypso/reader/stats';
+import { useDispatch } from 'calypso/state';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { useRecordReaderTracksEvent } from 'calypso/state/reader/analytics/useRecordReaderTracksEvent';
+
+export type AchievementsVisibility = 'public' | 'private';
+
+export default function useSetAchievementsVisibility() {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+	const recordReaderTracksEvent = useRecordReaderTracksEvent();
+
+	const { mutate, isPending } = useMutation(
+		userPreferenceOptimisticMutation( 'achievements-visibility' )
+	);
+
+	const setVisibility = ( next: AchievementsVisibility ) => {
+		mutate( next, {
+			onSuccess() {
+				dispatch(
+					successNotice(
+						next === 'public'
+							? translate( 'Your achievements page is now public.' )
+							: translate( 'Your achievements page is now private.' ),
+						{ duration: 4000 }
+					)
+				);
+				recordAction( `set_achievements_visibility_${ next }` );
+				recordReaderTracksEvent( 'calypso_reader_achievements_settings_saved', {
+					setting: 'achievements-visibility',
+					value: next,
+				} );
+			},
+			onError() {
+				dispatch(
+					errorNotice( translate( 'Failed to save the achievements visibility settings.' ), {
+						duration: 4000,
+					} )
+				);
+			},
+		} );
+	};
+
+	return { setVisibility, isPending };
+}

--- a/client/reader/user-profile/views/achievements/achievements-privacy-notice/index.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-privacy-notice/index.tsx
@@ -1,6 +1,6 @@
 import { userPreferenceQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
-import { Notice } from '@wordpress/components';
+import { Notice } from '@wordpress/ui';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import useSetAchievementsVisibility from 'calypso/reader/components/achievements/use-set-achievements-visibility';
@@ -36,23 +36,23 @@ export default function AchievementsPrivacyNotice() {
 
 	return (
 		<div className="achievements-privacy-notice">
-			<Notice
-				status="info"
-				isDismissible={ false }
-				actions={ [
-					{
-						label: translate( 'Make public' ),
-						onClick: handleMakePublic,
-						variant: 'primary',
-						disabled: isPending,
-					},
-				] }
-			>
-				{ translate(
-					'Your achievements are private — only you can see them. ' +
-						'Share them with the WordPress.com community by making your page public.'
-				) }
-			</Notice>
+			<Notice.Root intent="info">
+				<Notice.Title>{ translate( 'Your achievements are private' ) }</Notice.Title>
+				<Notice.Description>
+					{ translate(
+						'Only you can see them. Share them with the WordPress.com community by making your page public.'
+					) }
+				</Notice.Description>
+				<Notice.Actions>
+					<Notice.ActionButton
+						onClick={ handleMakePublic }
+						loading={ isPending }
+						loadingAnnouncement={ translate( 'Making your achievements page public…' ) }
+					>
+						{ translate( 'Make public' ) }
+					</Notice.ActionButton>
+				</Notice.Actions>
+			</Notice.Root>
 		</div>
 	);
 }

--- a/client/reader/user-profile/views/achievements/achievements-privacy-notice/index.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-privacy-notice/index.tsx
@@ -3,8 +3,6 @@ import { useQuery } from '@tanstack/react-query';
 import { Notice } from '@wordpress/ui';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
-import useSetAchievementsVisibility from 'calypso/reader/components/achievements/use-set-achievements-visibility';
-import { recordAction } from 'calypso/reader/stats';
 import { useRecordReaderTracksEvent } from 'calypso/state/reader/analytics/useRecordReaderTracksEvent';
 
 import './style.scss';
@@ -16,8 +14,6 @@ export default function AchievementsPrivacyNotice() {
 	const { data: savedVisibility } = useQuery( userPreferenceQuery( 'achievements-visibility' ) );
 	const isPrivate = ( savedVisibility ?? 'private' ) === 'private';
 
-	const { setVisibility, isPending } = useSetAchievementsVisibility();
-
 	useEffect( () => {
 		if ( isPrivate ) {
 			recordReaderTracksEvent( 'calypso_reader_achievements_privacy_notice_displayed' );
@@ -28,30 +24,15 @@ export default function AchievementsPrivacyNotice() {
 		return null;
 	}
 
-	const handleMakePublic = () => {
-		recordAction( 'achievements_privacy_notice_make_public_clicked' );
-		recordReaderTracksEvent( 'calypso_reader_achievements_privacy_notice_make_public_clicked' );
-		setVisibility( 'public' );
-	};
-
 	return (
 		<div className="achievements-privacy-notice">
 			<Notice.Root intent="info">
 				<Notice.Title>{ translate( 'Your achievements are private' ) }</Notice.Title>
 				<Notice.Description>
 					{ translate(
-						'Only you can see them. Share them with the WordPress.com community by making your page public.'
+						'Only you can see them. Open the achievement settings below to share them with the WordPress.com community.'
 					) }
 				</Notice.Description>
-				<Notice.Actions>
-					<Notice.ActionButton
-						onClick={ handleMakePublic }
-						loading={ isPending }
-						loadingAnnouncement={ translate( 'Making your achievements page public…' ) }
-					>
-						{ translate( 'Make public' ) }
-					</Notice.ActionButton>
-				</Notice.Actions>
 			</Notice.Root>
 		</div>
 	);

--- a/client/reader/user-profile/views/achievements/achievements-privacy-notice/index.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-privacy-notice/index.tsx
@@ -1,0 +1,58 @@
+import { userPreferenceQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import { Notice } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import useSetAchievementsVisibility from 'calypso/reader/components/achievements/use-set-achievements-visibility';
+import { recordAction } from 'calypso/reader/stats';
+import { useRecordReaderTracksEvent } from 'calypso/state/reader/analytics/useRecordReaderTracksEvent';
+
+import './style.scss';
+
+export default function AchievementsPrivacyNotice() {
+	const translate = useTranslate();
+	const recordReaderTracksEvent = useRecordReaderTracksEvent();
+
+	const { data: savedVisibility } = useQuery( userPreferenceQuery( 'achievements-visibility' ) );
+	const isPrivate = ( savedVisibility ?? 'private' ) === 'private';
+
+	const { setVisibility, isPending } = useSetAchievementsVisibility();
+
+	useEffect( () => {
+		if ( isPrivate ) {
+			recordReaderTracksEvent( 'calypso_reader_achievements_privacy_notice_displayed' );
+		}
+	}, [ isPrivate, recordReaderTracksEvent ] );
+
+	if ( ! isPrivate ) {
+		return null;
+	}
+
+	const handleMakePublic = () => {
+		recordAction( 'achievements_privacy_notice_make_public_clicked' );
+		recordReaderTracksEvent( 'calypso_reader_achievements_privacy_notice_make_public_clicked' );
+		setVisibility( 'public' );
+	};
+
+	return (
+		<div className="achievements-privacy-notice">
+			<Notice
+				status="info"
+				isDismissible={ false }
+				actions={ [
+					{
+						label: translate( 'Make public' ),
+						onClick: handleMakePublic,
+						variant: 'primary',
+						disabled: isPending,
+					},
+				] }
+			>
+				{ translate(
+					'Your achievements are private — only you can see them. ' +
+						'Share them with the WordPress.com community by making your page public.'
+				) }
+			</Notice>
+		</div>
+	);
+}

--- a/client/reader/user-profile/views/achievements/achievements-privacy-notice/style.scss
+++ b/client/reader/user-profile/views/achievements/achievements-privacy-notice/style.scss
@@ -1,11 +1,4 @@
 .achievements-privacy-notice {
 	max-width: 720px;
 	margin: 16px auto 24px;
-
-	// @wordpress/ui Button resolves to `cursor: default` because the WPDS
-	// `--wpds-cursor-control` token is set to `default` for non-link controls
-	// (Mac convention). Restore the web-conventional pointer cursor here.
-	button:not([disabled]):not([data-disabled]) {
-		cursor: pointer;
-	}
 }

--- a/client/reader/user-profile/views/achievements/achievements-privacy-notice/style.scss
+++ b/client/reader/user-profile/views/achievements/achievements-privacy-notice/style.scss
@@ -1,6 +1,6 @@
 .achievements-privacy-notice {
 	max-width: 720px;
-	margin: 16px auto 0;
+	margin: 16px auto 24px;
 
 	// @wordpress/ui Button resolves to `cursor: default` because the WPDS
 	// `--wpds-cursor-control` token is set to `default` for non-link controls

--- a/client/reader/user-profile/views/achievements/achievements-privacy-notice/style.scss
+++ b/client/reader/user-profile/views/achievements/achievements-privacy-notice/style.scss
@@ -1,4 +1,11 @@
 .achievements-privacy-notice {
 	max-width: 720px;
 	margin: 16px auto 0;
+
+	// @wordpress/ui Button resolves to `cursor: default` because the WPDS
+	// `--wpds-cursor-control` token is set to `default` for non-link controls
+	// (Mac convention). Restore the web-conventional pointer cursor here.
+	button:not([disabled]):not([data-disabled]) {
+		cursor: pointer;
+	}
 }

--- a/client/reader/user-profile/views/achievements/achievements-privacy-notice/style.scss
+++ b/client/reader/user-profile/views/achievements/achievements-privacy-notice/style.scss
@@ -1,0 +1,8 @@
+.achievements-privacy-notice {
+	max-width: 720px;
+	margin: 16px auto 0;
+
+	.components-notice {
+		margin: 0;
+	}
+}

--- a/client/reader/user-profile/views/achievements/achievements-privacy-notice/style.scss
+++ b/client/reader/user-profile/views/achievements/achievements-privacy-notice/style.scss
@@ -1,8 +1,4 @@
 .achievements-privacy-notice {
 	max-width: 720px;
 	margin: 16px auto 0;
-
-	.components-notice {
-		margin: 0;
-	}
 }

--- a/client/reader/user-profile/views/achievements/achievements-privacy-notice/test/index.test.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-privacy-notice/test/index.test.tsx
@@ -1,8 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render } from '@testing-library/react';
 import AchievementsPrivacyNotice from '../index';
 
 const mockUseQuery = jest.fn();
@@ -14,19 +13,9 @@ jest.mock( '@automattic/api-queries', () => ( {
 	userPreferenceQuery: ( key: string ) => ( { queryKey: [ 'user-preference', key ] } ),
 } ) );
 
-const mockSetVisibility = jest.fn();
-jest.mock( 'calypso/reader/components/achievements/use-set-achievements-visibility', () => ( {
-	__esModule: true,
-	default: () => ( { setVisibility: mockSetVisibility, isPending: false } ),
-} ) );
-
 const mockRecordReaderTracksEvent = jest.fn();
 jest.mock( 'calypso/state/reader/analytics/useRecordReaderTracksEvent', () => ( {
 	useRecordReaderTracksEvent: () => mockRecordReaderTracksEvent,
-} ) );
-
-jest.mock( 'calypso/reader/stats', () => ( {
-	recordAction: jest.fn(),
 } ) );
 
 describe( 'AchievementsPrivacyNotice', () => {
@@ -42,14 +31,13 @@ describe( 'AchievementsPrivacyNotice', () => {
 		expect( container.innerHTML ).toBe( '' );
 	} );
 
-	test( 'renders notice with Make public action when visibility is private', () => {
+	test( 'renders the privacy notice copy when visibility is private', () => {
 		mockUseQuery.mockReturnValue( { data: 'private' } );
 
 		const { container } = render( <AchievementsPrivacyNotice /> );
 
 		expect( container ).toHaveTextContent( 'Your achievements are private' );
-		expect( container ).toHaveTextContent( 'Only you can see them.' );
-		expect( screen.getByRole( 'button', { name: 'Make public' } ) ).toBeVisible();
+		expect( container ).toHaveTextContent( 'Open the achievement settings below' );
 	} );
 
 	test( 'fires impression event when rendered as private', () => {
@@ -59,20 +47,6 @@ describe( 'AchievementsPrivacyNotice', () => {
 
 		expect( mockRecordReaderTracksEvent ).toHaveBeenCalledWith(
 			'calypso_reader_achievements_privacy_notice_displayed'
-		);
-	} );
-
-	test( 'clicking Make public calls setVisibility with "public" and fires tracks event', async () => {
-		const user = userEvent.setup();
-		mockUseQuery.mockReturnValue( { data: 'private' } );
-
-		render( <AchievementsPrivacyNotice /> );
-
-		await user.click( screen.getByRole( 'button', { name: 'Make public' } ) );
-
-		expect( mockSetVisibility ).toHaveBeenCalledWith( 'public' );
-		expect( mockRecordReaderTracksEvent ).toHaveBeenCalledWith(
-			'calypso_reader_achievements_privacy_notice_make_public_clicked'
 		);
 	} );
 } );

--- a/client/reader/user-profile/views/achievements/achievements-privacy-notice/test/index.test.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-privacy-notice/test/index.test.tsx
@@ -47,9 +47,8 @@ describe( 'AchievementsPrivacyNotice', () => {
 
 		const { container } = render( <AchievementsPrivacyNotice /> );
 
-		expect( container ).toHaveTextContent(
-			'Your achievements are private — only you can see them.'
-		);
+		expect( container ).toHaveTextContent( 'Your achievements are private' );
+		expect( container ).toHaveTextContent( 'Only you can see them.' );
 		expect( screen.getByRole( 'button', { name: 'Make public' } ) ).toBeVisible();
 	} );
 

--- a/client/reader/user-profile/views/achievements/achievements-privacy-notice/test/index.test.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-privacy-notice/test/index.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AchievementsPrivacyNotice from '../index';
+
+const mockUseQuery = jest.fn();
+jest.mock( '@tanstack/react-query', () => ( {
+	useQuery: ( options: unknown ) => mockUseQuery( options ),
+} ) );
+
+jest.mock( '@automattic/api-queries', () => ( {
+	userPreferenceQuery: ( key: string ) => ( { queryKey: [ 'user-preference', key ] } ),
+} ) );
+
+const mockSetVisibility = jest.fn();
+jest.mock( 'calypso/reader/components/achievements/use-set-achievements-visibility', () => ( {
+	__esModule: true,
+	default: () => ( { setVisibility: mockSetVisibility, isPending: false } ),
+} ) );
+
+const mockRecordReaderTracksEvent = jest.fn();
+jest.mock( 'calypso/state/reader/analytics/useRecordReaderTracksEvent', () => ( {
+	useRecordReaderTracksEvent: () => mockRecordReaderTracksEvent,
+} ) );
+
+jest.mock( 'calypso/reader/stats', () => ( {
+	recordAction: jest.fn(),
+} ) );
+
+describe( 'AchievementsPrivacyNotice', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'renders nothing when visibility is public', () => {
+		mockUseQuery.mockReturnValue( { data: 'public' } );
+
+		const { container } = render( <AchievementsPrivacyNotice /> );
+
+		expect( container.innerHTML ).toBe( '' );
+	} );
+
+	test( 'renders notice with Make public action when visibility is private', () => {
+		mockUseQuery.mockReturnValue( { data: 'private' } );
+
+		const { container } = render( <AchievementsPrivacyNotice /> );
+
+		expect( container ).toHaveTextContent(
+			'Your achievements are private — only you can see them.'
+		);
+		expect( screen.getByRole( 'button', { name: 'Make public' } ) ).toBeVisible();
+	} );
+
+	test( 'fires impression event when rendered as private', () => {
+		mockUseQuery.mockReturnValue( { data: 'private' } );
+
+		render( <AchievementsPrivacyNotice /> );
+
+		expect( mockRecordReaderTracksEvent ).toHaveBeenCalledWith(
+			'calypso_reader_achievements_privacy_notice_displayed'
+		);
+	} );
+
+	test( 'clicking Make public calls setVisibility with "public" and fires tracks event', async () => {
+		const user = userEvent.setup();
+		mockUseQuery.mockReturnValue( { data: 'private' } );
+
+		render( <AchievementsPrivacyNotice /> );
+
+		await user.click( screen.getByRole( 'button', { name: 'Make public' } ) );
+
+		expect( mockSetVisibility ).toHaveBeenCalledWith( 'public' );
+		expect( mockRecordReaderTracksEvent ).toHaveBeenCalledWith(
+			'calypso_reader_achievements_privacy_notice_make_public_clicked'
+		);
+	} );
+} );

--- a/client/reader/user-profile/views/achievements/achievements-settings/index.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-settings/index.tsx
@@ -4,6 +4,7 @@ import { Button, Dropdown, ToggleControl } from '@wordpress/components';
 import { settings } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect } from 'react';
+import useSetAchievementsVisibility from 'calypso/reader/components/achievements/use-set-achievements-visibility';
 import { recordAction } from 'calypso/reader/stats';
 import { useDispatch } from 'calypso/state';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
@@ -30,9 +31,7 @@ export default function AchievementsSettings() {
 		[ savedNotifications ]
 	);
 
-	const { mutate: setVisibility, isPending: isSetVisibilityPending } = useMutation(
-		userPreferenceOptimisticMutation( 'achievements-visibility' )
-	);
+	const { setVisibility, isPending: isSetVisibilityPending } = useSetAchievementsVisibility();
 	const { mutate: setNotifications, isPending: isSetNotificationsPending } = useMutation(
 		userPreferenceOptimisticMutation( 'achievements-global-notifications' )
 	);
@@ -40,30 +39,7 @@ export default function AchievementsSettings() {
 	const handleSetVisibility = ( checked: boolean ) => {
 		const newVisibility = checked ? 'public' : 'private';
 		setLocalVisibility( newVisibility );
-		setVisibility( newVisibility, {
-			onSuccess() {
-				dispatch(
-					successNotice(
-						newVisibility === 'public'
-							? translate( 'Your achievements page is now public.' )
-							: translate( 'Your achievements page is now private.' ),
-						{ duration: 4000 }
-					)
-				);
-				recordAction( `set_achievements_visibility_${ newVisibility }` );
-				recordReaderTracksEvent( 'calypso_reader_achievements_settings_saved', {
-					setting: 'achievements-visibility',
-					value: newVisibility,
-				} );
-			},
-			onError() {
-				dispatch(
-					errorNotice( translate( 'Failed to save the achievements visibility settings.' ), {
-						duration: 4000,
-					} )
-				);
-			},
-		} );
+		setVisibility( newVisibility );
 	};
 
 	const handleSetNotifications = ( checked: boolean ) => {

--- a/client/reader/user-profile/views/achievements/achievements-settings/index.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-settings/index.tsx
@@ -31,8 +31,8 @@ export default function AchievementsSettings() {
 		[ savedNotifications ]
 	);
 
-	const { setVisibility, isPending: isSetVisibilityPending } = useSetAchievementsVisibility();
-	const { mutate: setNotifications, isPending: isSetNotificationsPending } = useMutation(
+	const { setVisibility } = useSetAchievementsVisibility();
+	const { mutate: setNotifications } = useMutation(
 		userPreferenceOptimisticMutation( 'achievements-global-notifications' )
 	);
 
@@ -98,14 +98,12 @@ export default function AchievementsSettings() {
 				<div className="achievements-settings__content">
 					<ToggleControl
 						checked={ visibility === 'public' }
-						disabled={ isSetVisibilityPending }
 						onChange={ handleSetVisibility }
 						label={ translate( 'Public achievements' ) }
 						help={ translate( 'When enabled, your achievements page is visible to other users.' ) }
 					/>
 					<ToggleControl
 						checked={ notifications !== 'disabled' }
-						disabled={ isSetNotificationsPending }
 						onChange={ handleSetNotifications }
 						label={ translate( 'Achievement notifications' ) }
 						help={ translate(

--- a/client/reader/user-profile/views/achievements/achievements-settings/style.scss
+++ b/client/reader/user-profile/views/achievements/achievements-settings/style.scss
@@ -1,3 +1,11 @@
+// @wordpress/components Button resolves to `cursor: default` once the WPDS
+// `--wpds-cursor-control` token has been loaded into the document (some
+// other Reader pages import `@wordpress/theme/design-tokens.css`, and the
+// var leaks across the SPA). Restore the web-conventional pointer cursor.
+.achievements-settings__button:not([disabled]):not([data-disabled]) {
+	cursor: pointer;
+}
+
 .achievements-settings__popover {
 	.achievements-settings__content {
 		padding: 16px;

--- a/client/reader/user-profile/views/achievements/index.tsx
+++ b/client/reader/user-profile/views/achievements/index.tsx
@@ -3,6 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useAchievementsQuery } from 'calypso/data/reader/use-achievements-query';
 import useAchievementsVisibility from 'calypso/reader/components/achievements/use-achievements-visibility';
 import AchievementsGrid from './achievements-grid';
+import AchievementsPrivacyNotice from './achievements-privacy-notice';
 import AchievementsSettings from './achievements-settings';
 import { ActivityStreak } from './activity-streak';
 import type { ReaderUser } from '@automattic/api-core';
@@ -34,6 +35,7 @@ const UserAchievements = ( { user }: UserAchievementsProps ): JSX.Element | null
 
 	return (
 		<div className="achievements">
+			{ isOwnProfile && <AchievementsPrivacyNotice /> }
 			<div className="achievements__header">
 				<ActivityStreak streak={ engagementStreak } isOwnProfile={ isOwnProfile } />
 				{ isOwnProfile && (

--- a/client/reader/user-profile/views/achievements/test/index.test.tsx
+++ b/client/reader/user-profile/views/achievements/test/index.test.tsx
@@ -23,6 +23,11 @@ jest.mock( '../achievements-settings', () => ( {
 	default: () => <button data-testid="achievements-settings">Settings</button>,
 } ) );
 
+jest.mock( '../achievements-privacy-notice', () => ( {
+	__esModule: true,
+	default: () => <div data-testid="achievements-privacy-notice" />,
+} ) );
+
 const mockActivityStreakProps = jest.fn();
 jest.mock( '../activity-streak', () => ( {
 	__esModule: true,


### PR DESCRIPTION
Part of RSM-3620

## Proposed Changes

<img width="754" height="177" alt="Screenshot 2026-05-20 at 15 27 58" src="https://github.com/user-attachments/assets/7e4b819e-47ff-4324-b83c-78b45ab19291" />

- Add an informational `Notice` at the top of the Reader achievements page for owners whose page is set to private. The notice directs them to the existing achievement settings popover to flip visibility.
- Use the new compound `Notice` API from `@wordpress/ui` — the first Notice usage of that package in this repo.
- Extract a shared `useSetAchievementsVisibility` hook so the popover's visibility toggle and any future caller share the same mutation, toasts, and tracking. Patch the active `QueryClient` on success so consumers reading via `useQuery( userPreferenceQuery( … ) )` see the new value immediately — `userPreferenceOptimisticMutation` only writes to the `@automattic/api-queries` singleton client, which the Reader does not read from.
- Drop `disabled={ isPending }` from the visibility and notifications toggles in the settings popover. Disabling a focused input auto-blurs it, which left the Popover wrapper with no focusable anchor inside and silently broke click-outside detection after toggling.
- Restore `cursor: pointer` on the new notice's button surfaces and the existing settings gear. Both `@wordpress/components` and `@wordpress/ui` buttons resolve `cursor: var( --wpds-cursor-control, … )` to `default` once `@wordpress/theme/design-tokens.css` is loaded in the document.

## Why are these changes being made?

The achievements page is private by default. Since rollout, only 45 of ~1.6k page views opened the settings popover, and just 11 made the page public. The settings gear is intentionally small but offers no nudge for owners who might want to share. A soft informational notice pointing at the existing settings popover adds discoverability without committing to an aggressive one-click CTA — we can revisit if the impression-event data still shows low conversion later.

## Testing Instructions

1. As a logged-in WordPress.com user, visit your own Reader profile achievements view (`/reader/users/<your-handle>/achievements`).
2. If your `achievements-visibility` user preference is still at its default (`private`), the notice appears at the top of the page with the heading "Your achievements are private".
3. Open the gear ("Achievement settings") to the right of the activity streak header.
4. Toggle "Public achievements" on. The success toast appears and the notice disappears immediately.
5. Click outside the popover — it closes. (It should also close after step 4 without needing to re-focus anything inside the popover first.)
6. Visit another user's profile achievements view — the notice never renders.
7. Hover the gear and any new button surfaces — cursor is `pointer`, not the arrow.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?