### PR TITLE
Renewal pricing: display the monthly crossed-out price when the user is ineligible for intro offer

### DIFF
--- a/packages/plans-grid-next/src/components/shared/header-price/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price/index.tsx
@@ -112,7 +112,8 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 		if (
 			isGridPlanOneTimeDiscounted ||
 			isGridPlanOnIntroOffer ||
-			( enableTermSavingsPriceDisplay && savings )
+			( enableTermSavingsPriceDisplay && savings ) ||
+			( showBillingDescriptionForIncreasedRenewalPrice && !! termVariantPricing )
 		) {
 			setIsAnyPlanPriceDiscounted( true );
 		}
@@ -122,22 +123,37 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 		isGridPlanOneTimeDiscounted,
 		savings,
 		setIsAnyPlanPriceDiscounted,
+		showBillingDescriptionForIncreasedRenewalPrice,
+		termVariantPricing,
 	] );
 
 	if ( isWpcomEnterpriseGridPlan( planSlug ) || ! isPricedPlan ) {
 		return null;
 	}
 
-	if ( isGridPlanOnIntroOffer ) {
+	if (
+		isGridPlanOnIntroOffer ||
+		( showBillingDescriptionForIncreasedRenewalPrice && termVariantPricing )
+	) {
 		// Use the monthly plan price for renewal pricing, instead of the intro offer renewal price
 		const compareToMonthlyPrice =
 			( showBillingDescriptionForIncreasedRenewalPrice && termVariantPricing
 				? termVariantPricing.originalPrice.monthly
 				: originalPrice.monthly ) ?? 0;
-		const monthlyPrice =
-			typeof discountedPrice.monthly === 'number'
-				? discountedPrice.monthly
-				: introOffer.rawPrice.monthly;
+		let monthlyPrice: number;
+		if ( isGridPlanOnIntroOffer ) {
+			monthlyPrice =
+				typeof discountedPrice.monthly === 'number'
+					? discountedPrice.monthly
+					: introOffer.rawPrice.monthly;
+		} else {
+			// For a plan without an intro offer, use the discounted price
+			// if available, otherwise the regular price.
+			monthlyPrice =
+				typeof discountedPrice.monthly === 'number'
+					? discountedPrice.monthly
+					: originalPrice.monthly ?? 0;
+		}
 		// Recalculate the savings for Monthly plans with introductory offers
 		// since we are comparing the introductory price with the same plan
 		// renewal price, instead of comparing yearly to monthly costs for
@@ -166,15 +182,17 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 						'is-large-currency': isLargeCurrency,
 					} ) }
 				>
-					<PlanPrice
-						currencyCode={ currencyCode }
-						rawPrice={ compareToMonthlyPrice }
-						displayPerMonthNotation={ false }
-						isLargeCurrency={ isLargeCurrency }
-						isSmallestUnit
-						priceDisplayWrapperClassName="plans-grid-next-header-price__display-wrapper"
-						original
-					/>
+					{ compareToMonthlyPrice > monthlyPrice && (
+						<PlanPrice
+							currencyCode={ currencyCode }
+							rawPrice={ compareToMonthlyPrice }
+							displayPerMonthNotation={ false }
+							isLargeCurrency={ isLargeCurrency }
+							isSmallestUnit
+							priceDisplayWrapperClassName="plans-grid-next-header-price__display-wrapper"
+							original
+						/>
+					) }
 					<PlanPrice
 						currencyCode={ currencyCode }
 						rawPrice={ monthlyPrice }

--- a/packages/plans-grid-next/src/components/shared/header-price/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price/index.tsx
@@ -132,6 +132,7 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 	}
 
 	if ( isGridPlanOnIntroOffer ) {
+		// Use the monthly plan price for renewal pricing, instead of the intro offer renewal price
 		const compareToMonthlyPrice =
 			( showBillingDescriptionForIncreasedRenewalPrice && termVariantPricing
 				? termVariantPricing.originalPrice.monthly
@@ -140,8 +141,8 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 			typeof discountedPrice.monthly === 'number'
 				? discountedPrice.monthly
 				: introOffer.rawPrice.monthly;
-		// Recalculate the savings for monthly plans with introductory offers
-		// since we are comparing the introductory price with the same plan's
+		// Recalculate the savings for Monthly plans with introductory offers
+		// since we are comparing the introductory price with the same plan
 		// renewal price, instead of comparing yearly to monthly costs for
 		// the same period.
 		if (
@@ -168,17 +169,15 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 						'is-large-currency': isLargeCurrency,
 					} ) }
 				>
-					{ compareToMonthlyPrice > monthlyPrice && (
-						<PlanPrice
-							currencyCode={ currencyCode }
-							rawPrice={ compareToMonthlyPrice }
-							displayPerMonthNotation={ false }
-							isLargeCurrency={ isLargeCurrency }
-							isSmallestUnit
-							priceDisplayWrapperClassName="plans-grid-next-header-price__display-wrapper"
-							original
-						/>
-					) }
+					<PlanPrice
+						currencyCode={ currencyCode }
+						rawPrice={ compareToMonthlyPrice }
+						displayPerMonthNotation={ false }
+						isLargeCurrency={ isLargeCurrency }
+						isSmallestUnit
+						priceDisplayWrapperClassName="plans-grid-next-header-price__display-wrapper"
+						original
+					/>
 					<PlanPrice
 						currencyCode={ currencyCode }
 						rawPrice={ monthlyPrice }

--- a/packages/plans-grid-next/src/components/shared/header-price/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price/index.tsx
@@ -131,31 +131,14 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 		return null;
 	}
 
-	if (
-		isGridPlanOnIntroOffer ||
-		( showBillingDescriptionForIncreasedRenewalPrice && termVariantPricing )
-	) {
-		// Use the monthly plan price for renewal pricing, instead of the intro offer renewal price
-		const compareToMonthlyPrice =
-			( showBillingDescriptionForIncreasedRenewalPrice && termVariantPricing
-				? termVariantPricing.originalPrice.monthly
-				: originalPrice.monthly ) ?? 0;
-		let monthlyPrice: number;
-		if ( isGridPlanOnIntroOffer ) {
-			monthlyPrice =
-				typeof discountedPrice.monthly === 'number'
-					? discountedPrice.monthly
-					: introOffer.rawPrice.monthly;
-		} else {
-			// For a plan without an intro offer, use the discounted price
-			// if available, otherwise the regular price.
-			monthlyPrice =
-				typeof discountedPrice.monthly === 'number'
-					? discountedPrice.monthly
-					: originalPrice.monthly ?? 0;
-		}
-		// Recalculate the savings for Monthly plans with introductory offers
-		// since we are comparing the introductory price with the same plan
+	if ( isGridPlanOnIntroOffer ) {
+		const compareToMonthlyPrice = originalPrice.monthly ?? 0;
+		const monthlyPrice =
+			typeof discountedPrice.monthly === 'number'
+				? discountedPrice.monthly
+				: introOffer.rawPrice.monthly;
+		// Recalculate the savings for monthly plans with introductory offers
+		// since we are comparing the introductory price with the same plan's
 		// renewal price, instead of comparing yearly to monthly costs for
 		// the same period.
 		if (
@@ -177,6 +160,57 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 							: translate( 'Special Offer' ) }
 					</div>
 				) }
+				<div
+					className={ clsx( 'plans-grid-next-header-price__pricing-group', {
+						'is-large-currency': isLargeCurrency,
+					} ) }
+				>
+					{ compareToMonthlyPrice > monthlyPrice && (
+						<PlanPrice
+							currencyCode={ currencyCode }
+							rawPrice={ compareToMonthlyPrice }
+							displayPerMonthNotation={ false }
+							isLargeCurrency={ isLargeCurrency }
+							isSmallestUnit
+							priceDisplayWrapperClassName="plans-grid-next-header-price__display-wrapper"
+							original
+						/>
+					) }
+					<PlanPrice
+						currencyCode={ currencyCode }
+						rawPrice={ monthlyPrice }
+						displayPerMonthNotation={ false }
+						isLargeCurrency={ isLargeCurrency }
+						isSmallestUnit
+						priceDisplayWrapperClassName="plans-grid-next-header-price__display-wrapper"
+						discounted
+					/>
+				</div>
+			</div>
+		);
+	}
+
+	// Handle cases where a plan is ineligible for intro offer, but we still
+	// want to show the crossed-out monthly price.
+	if ( showBillingDescriptionForIncreasedRenewalPrice && termVariantPricing ) {
+		const compareToMonthlyPrice = termVariantPricing.originalPrice.monthly ?? 0;
+		const monthlyPrice =
+			typeof discountedPrice.monthly === 'number'
+				? discountedPrice.monthly
+				: originalPrice.monthly ?? 0;
+		return (
+			<div className="plans-grid-next-header-price">
+				{ ! current &&
+					( savings > 0 ? (
+						<div className={ pricingBadgeClassName }>
+							{ translate( 'Save %(savings)d%%', {
+								args: { savings },
+								comment: 'Example: Save 35%',
+							} ) }
+						</div>
+					) : (
+						<div className={ clsx( pricingBadgeClassName, 'is-hidden' ) }>' '</div>
+					) ) }
 				<div
 					className={ clsx( 'plans-grid-next-header-price__pricing-group', {
 						'is-large-currency': isLargeCurrency,

--- a/packages/plans-grid-next/src/components/shared/header-price/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price/index.tsx
@@ -132,7 +132,10 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 	}
 
 	if ( isGridPlanOnIntroOffer ) {
-		const compareToMonthlyPrice = originalPrice.monthly ?? 0;
+		const compareToMonthlyPrice =
+			( showBillingDescriptionForIncreasedRenewalPrice && termVariantPricing
+				? termVariantPricing.originalPrice.monthly
+				: originalPrice.monthly ) ?? 0;
 		const monthlyPrice =
 			typeof discountedPrice.monthly === 'number'
 				? discountedPrice.monthly

--- a/packages/plans-grid-next/src/components/test/header-price.tsx
+++ b/packages/plans-grid-next/src/components/test/header-price.tsx
@@ -230,6 +230,163 @@ describe( 'HeaderPrice', () => {
 		expect( badge ).toHaveTextContent( 'Save 50%' );
 	} );
 
+	test( 'should show the monthly plan price crossed out and the annual monthly-equivalent as the current price', () => {
+		const pricing = {
+			currencyCode: 'USD',
+			originalPrice: { full: 120, monthly: 10 },
+			discountedPrice: { full: null, monthly: null },
+			billingPeriod: PLAN_ANNUAL_PERIOD,
+		};
+
+		mockUseHeaderPriceContext.mockReturnValue( {
+			isAnyPlanPriceDiscounted: true,
+			setIsAnyPlanPriceDiscounted: jest.fn(),
+		} );
+		( Plans.usePricingMetaForGridPlans as jest.Mock ).mockReturnValue( {
+			[ PLAN_PERSONAL_MONTHLY ]: {
+				originalPrice: { monthly: 20, full: 240 },
+				discountedPrice: { monthly: null, full: null },
+			},
+		} );
+
+		usePlansGridContext.mockImplementation( () => ( {
+			gridPlansIndex: {
+				[ PLAN_PERSONAL ]: {
+					current: false,
+					isMonthlyPlan: false,
+					pricing,
+				},
+			},
+			showBillingDescriptionForIncreasedRenewalPrice: 'crossed_price',
+		} ) );
+
+		const { container } = render( <HeaderPrice { ...defaultProps } />, { wrapper: Wrapper } );
+		const originalPrice = container.querySelector( '.plan-price.is-original' );
+		const discountedPrice = container.querySelector( '.plan-price.is-discounted' );
+
+		expect( originalPrice ).toHaveTextContent( '20' );
+		expect( discountedPrice ).toHaveTextContent( '10' );
+	} );
+
+	test( 'should not show a badge when the plan is the current plan', () => {
+		const pricing = {
+			currencyCode: 'USD',
+			originalPrice: { full: 120, monthly: 10 },
+			discountedPrice: { full: null, monthly: null },
+			billingPeriod: PLAN_ANNUAL_PERIOD,
+		};
+
+		mockUseHeaderPriceContext.mockReturnValue( {
+			isAnyPlanPriceDiscounted: true,
+			setIsAnyPlanPriceDiscounted: jest.fn(),
+		} );
+		( Plans.usePricingMetaForGridPlans as jest.Mock ).mockReturnValue( {
+			[ PLAN_PERSONAL_MONTHLY ]: {
+				originalPrice: { monthly: 20, full: 240 },
+				discountedPrice: { monthly: null, full: null },
+			},
+		} );
+
+		usePlansGridContext.mockImplementation( () => ( {
+			gridPlansIndex: {
+				[ PLAN_PERSONAL ]: {
+					current: true,
+					isMonthlyPlan: false,
+					pricing,
+				},
+			},
+			showBillingDescriptionForIncreasedRenewalPrice: 'crossed_price',
+		} ) );
+
+		const { container } = render( <HeaderPrice { ...defaultProps } />, { wrapper: Wrapper } );
+		const badge = container.querySelector( '.plans-grid-next-header-price__badge' );
+
+		expect( badge ).toBeNull();
+	} );
+
+	test( 'should not show the crossed-out price when monthly plan price does not exceed the annual price', () => {
+		const pricing = {
+			currencyCode: 'USD',
+			originalPrice: { full: 120, monthly: 10 },
+			discountedPrice: { full: null, monthly: null },
+			billingPeriod: PLAN_ANNUAL_PERIOD,
+		};
+
+		mockUseHeaderPriceContext.mockReturnValue( {
+			isAnyPlanPriceDiscounted: true,
+			setIsAnyPlanPriceDiscounted: jest.fn(),
+		} );
+		( Plans.usePricingMetaForGridPlans as jest.Mock ).mockReturnValue( {
+			[ PLAN_PERSONAL_MONTHLY ]: {
+				originalPrice: { monthly: 10, full: 120 },
+				discountedPrice: { monthly: null, full: null },
+			},
+		} );
+
+		usePlansGridContext.mockImplementation( () => ( {
+			gridPlansIndex: {
+				[ PLAN_PERSONAL ]: {
+					current: false,
+					isMonthlyPlan: false,
+					pricing,
+				},
+			},
+			showBillingDescriptionForIncreasedRenewalPrice: 'crossed_price',
+		} ) );
+
+		const { container } = render( <HeaderPrice { ...defaultProps } />, { wrapper: Wrapper } );
+		const originalPrice = container.querySelector( '.plan-price.is-original' );
+
+		expect( originalPrice ).toBeNull();
+	} );
+
+	test( 'should use the monthly plan price as the crossed-out price when intro offer and experiment are both active', () => {
+		const pricing = {
+			currencyCode: 'USD',
+			originalPrice: { full: 120, monthly: 10 },
+			discountedPrice: { full: null, monthly: null },
+			billingPeriod: PLAN_ANNUAL_PERIOD,
+			introOffer: {
+				formattedPrice: '$5.00',
+				rawPrice: { monthly: 5, full: 60 },
+				intervalUnit: 'month',
+				intervalCount: 1,
+				isOfferComplete: false,
+			},
+		};
+
+		mockUseHeaderPriceContext.mockReturnValue( {
+			isAnyPlanPriceDiscounted: true,
+			setIsAnyPlanPriceDiscounted: jest.fn(),
+		} );
+		( Plans.usePricingMetaForGridPlans as jest.Mock ).mockReturnValue( {
+			[ PLAN_PERSONAL_MONTHLY ]: {
+				originalPrice: { monthly: 20, full: 240 },
+				discountedPrice: { monthly: null, full: null },
+			},
+		} );
+
+		usePlansGridContext.mockImplementation( () => ( {
+			gridPlansIndex: {
+				[ PLAN_PERSONAL ]: {
+					current: false,
+					isMonthlyPlan: false,
+					pricing,
+				},
+			},
+			showBillingDescriptionForIncreasedRenewalPrice: 'crossed_price',
+		} ) );
+
+		const { container } = render( <HeaderPrice { ...defaultProps } />, { wrapper: Wrapper } );
+		const originalPrice = container.querySelector( '.plan-price.is-original' );
+		const discountedPrice = container.querySelector( '.plan-price.is-discounted' );
+
+		// Crossed-out price should be the monthly plan price (20), not the plan's own original price (10)
+		expect( originalPrice ).toHaveTextContent( '20' );
+		// Current price should be the intro offer price (5)
+		expect( discountedPrice ).toHaveTextContent( '5' );
+	} );
+
 	test( 'should keep the fallback badge hidden in crossed_price when savings is zero', () => {
 		const pricing = {
 			currencyCode: 'USD',


### PR DESCRIPTION

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-17173

## Proposed Changes

* When the user is not eligible for an intro offer (e.g. had the same plan in the past) - display the crossed-out monthly renewal price next to the plan price.

|**Before**|**After**|
|---|---|
|<img width="498" height="821" alt="before-yearly" src="https://github.com/user-attachments/assets/5e5d2528-3a02-4a4e-b26e-b763b9a24c89" />|<img width="498" height="821" alt="after-yearly" src="https://github.com/user-attachments/assets/0b879aeb-85a7-41f8-8616-e8b658b3027d" />|

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To achieve consistency with how the plans are presented to the user.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Find a site which previously had a specific paid plan (e.g. Premium Yearly), but not anymore.
* Assign yourself to any of the experiment variants.
* Navigate to the /plans/{site} page and confirm that the Premium Yearly plan shows the crossed-out monthly price next to it.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
