### PR TITLE
APM: Add timeframe selector and meaningful empty-state notices

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -619,20 +619,22 @@ export const sitePerformanceBackendRoute = createRoute( {
 	path: 'backend',
 } );
 
+async function prefetchApmAggregate( siteSlug: string ) {
+	const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
+	const [ { siteApmAggregateQuery }, { getStoredOrDefaultTimeframe, timeframeToParams } ] =
+		await Promise.all( [
+			import( '@automattic/api-queries' ),
+			import( '../../sites/performance/backend/timeframe' ),
+		] );
+	await queryClient.ensureQueryData(
+		siteApmAggregateQuery( site.ID, timeframeToParams( getStoredOrDefaultTimeframe() ) )
+	);
+}
+
 export const sitePerformanceBackendIndexRoute = createRoute( {
 	getParentRoute: () => sitePerformanceBackendRoute,
 	path: '/',
-	loader: async ( { params: { siteSlug } } ) => {
-		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		const [ { siteApmAggregateQuery }, { getStoredOrDefaultTimeframe, timeframeToParams } ] =
-			await Promise.all( [
-				import( '@automattic/api-queries' ),
-				import( '../../sites/performance/backend/timeframe' ),
-			] );
-		await queryClient.ensureQueryData(
-			siteApmAggregateQuery( site.ID, timeframeToParams( getStoredOrDefaultTimeframe() ) )
-		);
-	},
+	loader: ( { params: { siteSlug } } ) => prefetchApmAggregate( siteSlug ),
 } ).lazy( () =>
 	import( '../../sites/performance/backend' ).then( ( d ) =>
 		createLazyRoute( 'site-performance-backend' )( {
@@ -651,17 +653,7 @@ export const sitePerformanceBackendTransactionsRoute = createRoute( {
 	} ),
 	getParentRoute: () => sitePerformanceBackendRoute,
 	path: 'transactions',
-	loader: async ( { params: { siteSlug } } ) => {
-		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		const [ { siteApmAggregateQuery }, { getStoredOrDefaultTimeframe, timeframeToParams } ] =
-			await Promise.all( [
-				import( '@automattic/api-queries' ),
-				import( '../../sites/performance/backend/timeframe' ),
-			] );
-		await queryClient.ensureQueryData(
-			siteApmAggregateQuery( site.ID, timeframeToParams( getStoredOrDefaultTimeframe() ) )
-		);
-	},
+	loader: ( { params: { siteSlug } } ) => prefetchApmAggregate( siteSlug ),
 } ).lazy( () =>
 	import( '../../sites/performance/backend' ).then( ( d ) =>
 		createLazyRoute( 'site-performance-backend-transactions' )( {
@@ -680,17 +672,7 @@ export const sitePerformanceBackendDatabaseRoute = createRoute( {
 	} ),
 	getParentRoute: () => sitePerformanceBackendRoute,
 	path: 'database',
-	loader: async ( { params: { siteSlug } } ) => {
-		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		const [ { siteApmAggregateQuery }, { getStoredOrDefaultTimeframe, timeframeToParams } ] =
-			await Promise.all( [
-				import( '@automattic/api-queries' ),
-				import( '../../sites/performance/backend/timeframe' ),
-			] );
-		await queryClient.ensureQueryData(
-			siteApmAggregateQuery( site.ID, timeframeToParams( getStoredOrDefaultTimeframe() ) )
-		);
-	},
+	loader: ( { params: { siteSlug } } ) => prefetchApmAggregate( siteSlug ),
 } ).lazy( () =>
 	import( '../../sites/performance/backend' ).then( ( d ) =>
 		createLazyRoute( 'site-performance-backend-database' )( {
@@ -709,17 +691,7 @@ export const sitePerformanceBackendExternalRequestsRoute = createRoute( {
 	} ),
 	getParentRoute: () => sitePerformanceBackendRoute,
 	path: 'external-requests',
-	loader: async ( { params: { siteSlug } } ) => {
-		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		const [ { siteApmAggregateQuery }, { getStoredOrDefaultTimeframe, timeframeToParams } ] =
-			await Promise.all( [
-				import( '@automattic/api-queries' ),
-				import( '../../sites/performance/backend/timeframe' ),
-			] );
-		await queryClient.ensureQueryData(
-			siteApmAggregateQuery( site.ID, timeframeToParams( getStoredOrDefaultTimeframe() ) )
-		);
-	},
+	loader: ( { params: { siteSlug } } ) => prefetchApmAggregate( siteSlug ),
 } ).lazy( () =>
 	import( '../../sites/performance/backend' ).then( ( d ) =>
 		createLazyRoute( 'site-performance-backend-external-requests' )( {
@@ -740,17 +712,7 @@ export const sitePerformanceBackendWordPressRoute = createRoute( {
 	} ),
 	getParentRoute: () => sitePerformanceBackendRoute,
 	path: 'wordpress',
-	loader: async ( { params: { siteSlug } } ) => {
-		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		const [ { siteApmAggregateQuery }, { getStoredOrDefaultTimeframe, timeframeToParams } ] =
-			await Promise.all( [
-				import( '@automattic/api-queries' ),
-				import( '../../sites/performance/backend/timeframe' ),
-			] );
-		await queryClient.ensureQueryData(
-			siteApmAggregateQuery( site.ID, timeframeToParams( getStoredOrDefaultTimeframe() ) )
-		);
-	},
+	loader: ( { params: { siteSlug } } ) => prefetchApmAggregate( siteSlug ),
 } ).lazy( () =>
 	import( '../../sites/performance/backend' ).then( ( d ) =>
 		createLazyRoute( 'site-performance-backend-wordpress' )( {

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -624,8 +624,14 @@ export const sitePerformanceBackendIndexRoute = createRoute( {
 	path: '/',
 	loader: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		const { siteApmAggregateQuery } = await import( '@automattic/api-queries' );
-		await queryClient.ensureQueryData( siteApmAggregateQuery( site.ID ) );
+		const [ { siteApmAggregateQuery }, { getStoredOrDefaultTimeframe, timeframeToParams } ] =
+			await Promise.all( [
+				import( '@automattic/api-queries' ),
+				import( '../../sites/performance/backend/timeframe' ),
+			] );
+		await queryClient.ensureQueryData(
+			siteApmAggregateQuery( site.ID, timeframeToParams( getStoredOrDefaultTimeframe() ) )
+		);
 	},
 } ).lazy( () =>
 	import( '../../sites/performance/backend' ).then( ( d ) =>
@@ -647,8 +653,14 @@ export const sitePerformanceBackendTransactionsRoute = createRoute( {
 	path: 'transactions',
 	loader: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		const { siteApmAggregateQuery } = await import( '@automattic/api-queries' );
-		await queryClient.ensureQueryData( siteApmAggregateQuery( site.ID ) );
+		const [ { siteApmAggregateQuery }, { getStoredOrDefaultTimeframe, timeframeToParams } ] =
+			await Promise.all( [
+				import( '@automattic/api-queries' ),
+				import( '../../sites/performance/backend/timeframe' ),
+			] );
+		await queryClient.ensureQueryData(
+			siteApmAggregateQuery( site.ID, timeframeToParams( getStoredOrDefaultTimeframe() ) )
+		);
 	},
 } ).lazy( () =>
 	import( '../../sites/performance/backend' ).then( ( d ) =>
@@ -670,8 +682,14 @@ export const sitePerformanceBackendDatabaseRoute = createRoute( {
 	path: 'database',
 	loader: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		const { siteApmAggregateQuery } = await import( '@automattic/api-queries' );
-		await queryClient.ensureQueryData( siteApmAggregateQuery( site.ID ) );
+		const [ { siteApmAggregateQuery }, { getStoredOrDefaultTimeframe, timeframeToParams } ] =
+			await Promise.all( [
+				import( '@automattic/api-queries' ),
+				import( '../../sites/performance/backend/timeframe' ),
+			] );
+		await queryClient.ensureQueryData(
+			siteApmAggregateQuery( site.ID, timeframeToParams( getStoredOrDefaultTimeframe() ) )
+		);
 	},
 } ).lazy( () =>
 	import( '../../sites/performance/backend' ).then( ( d ) =>
@@ -693,8 +711,14 @@ export const sitePerformanceBackendExternalRequestsRoute = createRoute( {
 	path: 'external-requests',
 	loader: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		const { siteApmAggregateQuery } = await import( '@automattic/api-queries' );
-		await queryClient.ensureQueryData( siteApmAggregateQuery( site.ID ) );
+		const [ { siteApmAggregateQuery }, { getStoredOrDefaultTimeframe, timeframeToParams } ] =
+			await Promise.all( [
+				import( '@automattic/api-queries' ),
+				import( '../../sites/performance/backend/timeframe' ),
+			] );
+		await queryClient.ensureQueryData(
+			siteApmAggregateQuery( site.ID, timeframeToParams( getStoredOrDefaultTimeframe() ) )
+		);
 	},
 } ).lazy( () =>
 	import( '../../sites/performance/backend' ).then( ( d ) =>
@@ -718,8 +742,14 @@ export const sitePerformanceBackendWordPressRoute = createRoute( {
 	path: 'wordpress',
 	loader: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		const { siteApmAggregateQuery } = await import( '@automattic/api-queries' );
-		await queryClient.ensureQueryData( siteApmAggregateQuery( site.ID ) );
+		const [ { siteApmAggregateQuery }, { getStoredOrDefaultTimeframe, timeframeToParams } ] =
+			await Promise.all( [
+				import( '@automattic/api-queries' ),
+				import( '../../sites/performance/backend/timeframe' ),
+			] );
+		await queryClient.ensureQueryData(
+			siteApmAggregateQuery( site.ID, timeframeToParams( getStoredOrDefaultTimeframe() ) )
+		);
 	},
 } ).lazy( () =>
 	import( '../../sites/performance/backend' ).then( ( d ) =>

--- a/client/dashboard/sites/performance/backend/backend-status.tsx
+++ b/client/dashboard/sites/performance/backend/backend-status.tsx
@@ -26,13 +26,8 @@ export default function BackendStatusNotice( {
 		}
 
 		if ( ! apmEnabled ) {
-			return (
-				<Notice variant="info" title={ __( 'Capturing is off' ) }>
-					{ __(
-						'Turn capturing on to start collecting performance data for the selected timeframe.'
-					) }
-				</Notice>
-			);
+			// The subtitle already says "Capturing is off..." — skip the duplicate notice.
+			return null;
 		}
 
 		return (

--- a/client/dashboard/sites/performance/backend/backend-status.tsx
+++ b/client/dashboard/sites/performance/backend/backend-status.tsx
@@ -1,10 +1,51 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { Notice } from '../../../components/notice';
 import { BACKEND_THRESHOLDS_MS, bucketByMs, formatMs } from './utils';
+import type { ApmSummary } from '@automattic/api-core';
 
-export default function BackendStatusNotice( { avgResponseMs }: { avgResponseMs: number } ) {
-	const intent = bucketByMs( avgResponseMs, BACKEND_THRESHOLDS_MS.response );
-	const formatted = formatMs( avgResponseMs );
+export default function BackendStatusNotice( {
+	summary,
+	apmEnabled,
+	isRollingWindow,
+}: {
+	summary: ApmSummary;
+	apmEnabled: boolean;
+	isRollingWindow: boolean;
+} ) {
+	const hasData = summary.transaction_count > 0;
+
+	if ( ! hasData ) {
+		if ( ! isRollingWindow ) {
+			return (
+				<Notice variant="info" title={ __( 'No data in the selected timeframe' ) }>
+					{ __(
+						'Try a different timeframe, or check back later if you just changed the capture settings.'
+					) }
+				</Notice>
+			);
+		}
+
+		if ( ! apmEnabled ) {
+			return (
+				<Notice variant="info" title={ __( 'Capturing is off' ) }>
+					{ __(
+						'Turn capturing on to start collecting performance data for the selected timeframe.'
+					) }
+				</Notice>
+			);
+		}
+
+		return (
+			<Notice variant="info" title={ __( 'Capturing' ) }>
+				{ __(
+					'Performance data is being collected. New requests will show up here within about 30 seconds.'
+				) }
+			</Notice>
+		);
+	}
+
+	const intent = bucketByMs( summary.avg_response_ms, BACKEND_THRESHOLDS_MS.response );
+	const formatted = formatMs( summary.avg_response_ms );
 
 	if ( intent === 'error' ) {
 		return (

--- a/client/dashboard/sites/performance/backend/database/index.tsx
+++ b/client/dashboard/sites/performance/backend/database/index.tsx
@@ -1,10 +1,6 @@
-import { siteApmAggregateQuery } from '@automattic/api-queries';
-import { useSuspenseQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
-import { useMemo } from 'react';
-import { mergeAggregates, type MergedDbQuery } from '../aggregate';
 import SlowList, { type SlowListItem } from '../slow-list';
-import type { Site } from '@automattic/api-core';
+import type { MergedAggregate, MergedDbQuery } from '../aggregate';
 
 function toItems( queries: MergedDbQuery[] ): SlowListItem[] {
 	return queries.map( ( query ) => ( {
@@ -15,10 +11,7 @@ function toItems( queries: MergedDbQuery[] ): SlowListItem[] {
 	} ) );
 }
 
-export default function Database( { site }: { site: Site } ) {
-	const { data } = useSuspenseQuery( siteApmAggregateQuery( site.ID ) );
-	const merged = useMemo( () => mergeAggregates( data.aggregates ), [ data.aggregates ] );
-
+export default function Database( { merged }: { merged: MergedAggregate } ) {
 	return (
 		<SlowList
 			title={ __( 'Slowest queries' ) }

--- a/client/dashboard/sites/performance/backend/external-requests/index.tsx
+++ b/client/dashboard/sites/performance/backend/external-requests/index.tsx
@@ -1,10 +1,6 @@
-import { siteApmAggregateQuery } from '@automattic/api-queries';
-import { useSuspenseQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
-import { useMemo } from 'react';
-import { mergeAggregates, type MergedExternal } from '../aggregate';
 import SlowList, { type SlowListItem } from '../slow-list';
-import type { Site } from '@automattic/api-core';
+import type { MergedAggregate, MergedExternal } from '../aggregate';
 
 function toItems( externals: MergedExternal[] ): SlowListItem[] {
 	return externals.map( ( external ) => ( {
@@ -15,10 +11,7 @@ function toItems( externals: MergedExternal[] ): SlowListItem[] {
 	} ) );
 }
 
-export default function ExternalRequests( { site }: { site: Site } ) {
-	const { data } = useSuspenseQuery( siteApmAggregateQuery( site.ID ) );
-	const merged = useMemo( () => mergeAggregates( data.aggregates ), [ data.aggregates ] );
-
+export default function ExternalRequests( { merged }: { merged: MergedAggregate } ) {
 	return (
 		<SlowList
 			title={ __( 'Slowest external requests' ) }

--- a/client/dashboard/sites/performance/backend/index.tsx
+++ b/client/dashboard/sites/performance/backend/index.tsx
@@ -32,6 +32,13 @@ import Database from './database';
 import ExternalRequests from './external-requests';
 import Overview from './overview';
 import BackendSubtitle from './subtitle';
+import {
+	isRollingTimeframe,
+	timeframeToParams,
+	usePersistedTimeframe,
+	type Timeframe,
+} from './timeframe';
+import TimeframeSelector from './timeframe-selector';
 import Transactions from './transactions';
 import WordPress from './wordpress';
 
@@ -81,12 +88,25 @@ function StartCapturingButton( { site }: { site: Site } ) {
 	);
 }
 
-function ApmDashboard( { site, tab }: { site: Site; tab: ApmTab } ) {
+function ApmDashboard( {
+	site,
+	tab,
+	timeframe,
+}: {
+	site: Site;
+	tab: ApmTab;
+	timeframe: Timeframe;
+} ) {
 	const router = useRouter();
 	const siteSlug = site.slug;
 	const isDesktop = useViewportMatch( VIEWPORT_BREAKPOINTS.desktop );
-	const { data } = useSuspenseQuery( siteApmAggregateQuery( site.ID ) );
-	const { summary } = useMemo( () => mergeAggregates( data.aggregates ), [ data.aggregates ] );
+	const params = useMemo( () => timeframeToParams( timeframe ), [ timeframe ] );
+	const { data } = useSuspenseQuery( siteApmAggregateQuery( site.ID, params ) );
+	const merged = useMemo( () => mergeAggregates( data.aggregates ), [ data.aggregates ] );
+	const { summary } = merged;
+
+	const apmEnabled = !! site.options?.apm_enabled;
+	const isRollingWindow = isRollingTimeframe( timeframe );
 
 	const handleTabChange = ( name: string ) => {
 		const next = name as ApmTab;
@@ -104,21 +124,25 @@ function ApmDashboard( { site, tab }: { site: Site; tab: ApmTab } ) {
 	const renderTab = () => {
 		switch ( tab ) {
 			case 'overview':
-				return <Overview site={ site } />;
+				return <Overview merged={ merged } />;
 			case 'transactions':
-				return <Transactions site={ site } />;
+				return <Transactions merged={ merged } />;
 			case 'wordpress':
-				return <WordPress site={ site } />;
+				return <WordPress merged={ merged } />;
 			case 'database':
-				return <Database site={ site } />;
+				return <Database merged={ merged } />;
 			case 'external-requests':
-				return <ExternalRequests site={ site } />;
+				return <ExternalRequests merged={ merged } />;
 		}
 	};
 
 	return (
 		<VStack spacing={ 6 }>
-			<BackendStatusNotice avgResponseMs={ summary.avg_response_ms } />
+			<BackendStatusNotice
+				summary={ summary }
+				apmEnabled={ apmEnabled }
+				isRollingWindow={ isRollingWindow }
+			/>
 			<Tabs
 				orientation={ isDesktop ? 'vertical' : 'horizontal' }
 				selectedTabId={ tab }
@@ -153,6 +177,7 @@ export default function SitePerformanceBackend( {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const userHasBackendAccess = hasBackendAccess( site.plan?.product_slug );
 	const apmEnabled = !! site.options?.apm_enabled;
+	const [ timeframe, setTimeframe ] = usePersistedTimeframe();
 
 	return (
 		<PageLayout
@@ -163,8 +188,11 @@ export default function SitePerformanceBackend( {
 						userHasBackendAccess ? <BackendSubtitle capturing={ apmEnabled } /> : undefined
 					}
 					actions={
-						userHasBackendAccess && ! apmEnabled ? (
-							<StartCapturingButton site={ site } />
+						userHasBackendAccess ? (
+							<HStack spacing={ 2 } justify="flex-end" expanded={ false }>
+								<TimeframeSelector value={ timeframe } onChange={ setTimeframe } />
+								{ ! apmEnabled && <StartCapturingButton site={ site } /> }
+							</HStack>
 						) : undefined
 					}
 				/>
@@ -172,7 +200,7 @@ export default function SitePerformanceBackend( {
 		>
 			<PerformanceTabs siteSlug={ siteSlug } activeTab="backend" />
 			{ userHasBackendAccess ? (
-				<ApmDashboard site={ site } tab={ tab } />
+				<ApmDashboard site={ site } tab={ tab } timeframe={ timeframe } />
 			) : (
 				<UpsellCallout site={ site } { ...getBackendCalloutProps() } />
 			) }

--- a/client/dashboard/sites/performance/backend/index.tsx
+++ b/client/dashboard/sites/performance/backend/index.tsx
@@ -82,13 +82,7 @@ function StartCapturingButton( { site }: { site: Site } ) {
 	};
 
 	return (
-		<Button
-			__next40pxDefaultSize
-			variant="primary"
-			isBusy={ isPending }
-			disabled={ isPending }
-			onClick={ handleClick }
-		>
+		<Button variant="primary" isBusy={ isPending } disabled={ isPending } onClick={ handleClick }>
 			{ __( 'Start capturing' ) }
 		</Button>
 	);

--- a/client/dashboard/sites/performance/backend/index.tsx
+++ b/client/dashboard/sites/performance/backend/index.tsx
@@ -82,7 +82,13 @@ function StartCapturingButton( { site }: { site: Site } ) {
 	};
 
 	return (
-		<Button variant="primary" isBusy={ isPending } disabled={ isPending } onClick={ handleClick }>
+		<Button
+			__next40pxDefaultSize
+			variant="primary"
+			isBusy={ isPending }
+			disabled={ isPending }
+			onClick={ handleClick }
+		>
 			{ __( 'Start capturing' ) }
 		</Button>
 	);

--- a/client/dashboard/sites/performance/backend/overview/index.tsx
+++ b/client/dashboard/sites/performance/backend/overview/index.tsx
@@ -1,17 +1,9 @@
-import { siteApmAggregateQuery } from '@automattic/api-queries';
-import { useSuspenseQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack } from '@wordpress/components';
-import { useMemo } from 'react';
-import { mergeAggregates } from '../aggregate';
 import ChartSlot from './chart-slot';
 import SlowRequestsList from './slow-requests-list';
-import type { Site } from '@automattic/api-core';
+import type { MergedAggregate } from '../aggregate';
 
-export default function Overview( { site }: { site: Site } ) {
-	const { data } = useSuspenseQuery( siteApmAggregateQuery( site.ID ) );
-
-	const merged = useMemo( () => mergeAggregates( data.aggregates ), [ data.aggregates ] );
-
+export default function Overview( { merged }: { merged: MergedAggregate } ) {
 	return (
 		<VStack spacing={ 6 }>
 			<ChartSlot timeseries={ merged.timeseries } />

--- a/client/dashboard/sites/performance/backend/test/index.test.tsx
+++ b/client/dashboard/sites/performance/backend/test/index.test.tsx
@@ -62,8 +62,7 @@ function mockApmToggle( expectedActive: boolean ) {
 
 function mockApmAggregate( response: ApmAggregateResponse = { aggregates: [] } ) {
 	nock( 'https://public-api.wordpress.com' )
-		.get( `/wpcom/v2/sites/${ siteId }/hosting/apm/aggregate` )
-		.query( true )
+		.get( ( uri ) => uri.includes( `/wpcom/v2/sites/${ siteId }/hosting/apm/aggregate` ) )
 		.reply( 200, response );
 }
 
@@ -213,14 +212,14 @@ describe( '<SitePerformanceBackend>', () => {
 		expect( screen.getByText( /api\.stripe\.com/ ) ).toBeVisible();
 	} );
 
-	test( 'shows a status notice with the average response time', async () => {
+	test( 'shows an intent-based status notice when data is present', async () => {
 		mockSite( businessSite( true ) );
-		mockApmAggregate();
+		mockApmAggregate( aggregateFixture() );
 
 		render( <SitePerformanceBackend siteSlug={ siteSlug } /> );
 
-		// The notice variant depends on seeded mock data, but one of these three
-		// titles must always appear and must include the formatted avg duration.
+		// With real data, the notice variant depends on the avg response time,
+		// but one of these three titles must always appear with the formatted avg.
 		expect(
 			await screen.findByText(
 				/(Healthy backend|Backend needs improvement|Backend is slow) — avg /
@@ -228,9 +227,30 @@ describe( '<SitePerformanceBackend>', () => {
 		).toBeVisible();
 	} );
 
-	test( 'toggling Avg/Max on Slowest requests updates the description', async () => {
+	test( 'shows the Capturing notice when APM is on but no data has come in yet', async () => {
 		mockSite( businessSite( true ) );
 		mockApmAggregate();
+
+		render( <SitePerformanceBackend siteSlug={ siteSlug } /> );
+
+		expect( await screen.findByText( /Performance data is being collected/ ) ).toBeVisible();
+		expect(
+			screen.queryByText( /(Healthy backend|Backend needs improvement|Backend is slow) — avg / )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'shows the Capturing-is-off notice when APM is off and no data has come in yet', async () => {
+		mockSite( businessSite( false ) );
+		mockApmAggregate();
+
+		render( <SitePerformanceBackend siteSlug={ siteSlug } /> );
+
+		expect( await screen.findByText( /Turn capturing on to start collecting/ ) ).toBeVisible();
+	} );
+
+	test( 'toggling Avg/Max on Slowest requests updates the description', async () => {
+		mockSite( businessSite( true ) );
+		mockApmAggregate( aggregateFixture() );
 
 		render( <SitePerformanceBackend siteSlug={ siteSlug } /> );
 

--- a/client/dashboard/sites/performance/backend/test/index.test.tsx
+++ b/client/dashboard/sites/performance/backend/test/index.test.tsx
@@ -62,7 +62,8 @@ function mockApmToggle( expectedActive: boolean ) {
 
 function mockApmAggregate( response: ApmAggregateResponse = { aggregates: [] } ) {
 	nock( 'https://public-api.wordpress.com' )
-		.get( ( uri ) => uri.includes( `/wpcom/v2/sites/${ siteId }/hosting/apm/aggregate` ) )
+		.get( `/wpcom/v2/sites/${ siteId }/hosting/apm/aggregate` )
+		.query( true )
 		.reply( 200, response );
 }
 

--- a/client/dashboard/sites/performance/backend/test/index.test.tsx
+++ b/client/dashboard/sites/performance/backend/test/index.test.tsx
@@ -239,13 +239,22 @@ describe( '<SitePerformanceBackend>', () => {
 		).not.toBeInTheDocument();
 	} );
 
-	test( 'shows the Capturing-is-off notice when APM is off and no data has come in yet', async () => {
+	test( 'omits the status notice when APM is off and no data has come in yet', async () => {
+		// The subtitle already says "Capturing is off..." so we skip the
+		// redundant notice in this state.
 		mockSite( businessSite( false ) );
 		mockApmAggregate();
 
 		render( <SitePerformanceBackend siteSlug={ siteSlug } /> );
 
-		expect( await screen.findByText( /Turn capturing on to start collecting/ ) ).toBeVisible();
+		// Wait for the page to render before asserting absence.
+		await screen.findByRole( 'heading', { name: 'Response time breakdown' } );
+
+		expect( screen.queryByText( /Turn capturing on to start collecting/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /Performance data is being collected/ ) ).not.toBeInTheDocument();
+		expect(
+			screen.queryByText( /(Healthy backend|Backend needs improvement|Backend is slow) — avg / )
+		).not.toBeInTheDocument();
 	} );
 
 	test( 'toggling Avg/Max on Slowest requests updates the description', async () => {

--- a/client/dashboard/sites/performance/backend/timeframe-selector.tsx
+++ b/client/dashboard/sites/performance/backend/timeframe-selector.tsx
@@ -1,0 +1,23 @@
+import { SelectControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { DEFAULT_TIMEFRAME, TIMEFRAME_OPTIONS, type Timeframe } from './timeframe';
+
+export default function TimeframeSelector( {
+	value,
+	onChange,
+}: {
+	value: Timeframe;
+	onChange: ( value: Timeframe ) => void;
+} ) {
+	return (
+		<SelectControl
+			__next40pxDefaultSize
+			__nextHasNoMarginBottom
+			label={ __( 'Timeframe' ) }
+			hideLabelFromVision
+			value={ value }
+			options={ TIMEFRAME_OPTIONS }
+			onChange={ ( next ) => onChange( ( next as Timeframe ) || DEFAULT_TIMEFRAME ) }
+		/>
+	);
+}

--- a/client/dashboard/sites/performance/backend/timeframe-selector.tsx
+++ b/client/dashboard/sites/performance/backend/timeframe-selector.tsx
@@ -11,7 +11,6 @@ export default function TimeframeSelector( {
 } ) {
 	return (
 		<SelectControl
-			__next40pxDefaultSize
 			__nextHasNoMarginBottom
 			label={ __( 'Timeframe' ) }
 			hideLabelFromVision

--- a/client/dashboard/sites/performance/backend/timeframe.ts
+++ b/client/dashboard/sites/performance/backend/timeframe.ts
@@ -61,10 +61,16 @@ function writeStoredTimeframe( timeframe: Timeframe ): void {
 
 /**
  * Convert a Timeframe preset into Unix-seconds start/end params for the
- * aggregate endpoint. Presets always end at the current time ("rolling window").
+ * aggregate endpoint. Presets always end at the current time ("rolling
+ * window"). The end is snapped down to the nearest minute so adjacent
+ * calls within the same minute return identical params, sharing the
+ * React Query cache instead of triggering a fresh fetch per render.
+ * The aggregate data is per-minute anyway, so the snap matches the
+ * natural granularity of the response.
  */
 export function timeframeToParams( timeframe: Timeframe ): Required< ApmAggregateParams > {
-	const end = Math.floor( Date.now() / 1000 );
+	const nowSec = Math.floor( Date.now() / 1000 );
+	const end = nowSec - ( nowSec % 60 );
 	const start = end - TIMEFRAME_SECONDS[ timeframe ];
 	return { start, end };
 }

--- a/client/dashboard/sites/performance/backend/timeframe.ts
+++ b/client/dashboard/sites/performance/backend/timeframe.ts
@@ -1,0 +1,98 @@
+import { __ } from '@wordpress/i18n';
+import { useCallback, useState } from 'react';
+import type { ApmAggregateParams } from '@automattic/api-core';
+
+export type Timeframe = 'last-15-min' | 'last-hour' | 'last-6-hours' | 'last-24-hours';
+
+const TIMEFRAME_SECONDS: Record< Timeframe, number > = {
+	'last-15-min': 15 * 60,
+	'last-hour': 60 * 60,
+	'last-6-hours': 6 * 60 * 60,
+	'last-24-hours': 24 * 60 * 60,
+};
+
+export const DEFAULT_TIMEFRAME: Timeframe = 'last-hour';
+
+export const TIMEFRAME_OPTIONS: Array< { value: Timeframe; label: string } > = [
+	{ value: 'last-15-min', label: __( 'Last 15 minutes' ) },
+	{ value: 'last-hour', label: __( 'Last hour' ) },
+	{ value: 'last-6-hours', label: __( 'Last 6 hours' ) },
+	{ value: 'last-24-hours', label: __( 'Last 24 hours' ) },
+];
+
+const TIMEFRAME_STORAGE_KEY = 'dashboard-apm-backend-timeframe';
+
+const VALID_TIMEFRAMES = new Set< string >( Object.keys( TIMEFRAME_SECONDS ) );
+
+function isTimeframe( value: string | null | undefined ): value is Timeframe {
+	return !! value && VALID_TIMEFRAMES.has( value );
+}
+
+function canUseLocalStorage(): boolean {
+	return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+}
+
+export function getStoredOrDefaultTimeframe(): Timeframe {
+	return readStoredTimeframe() ?? DEFAULT_TIMEFRAME;
+}
+
+function readStoredTimeframe(): Timeframe | null {
+	if ( ! canUseLocalStorage() ) {
+		return null;
+	}
+	try {
+		const value = window.localStorage.getItem( TIMEFRAME_STORAGE_KEY );
+		return isTimeframe( value ) ? value : null;
+	} catch {
+		return null;
+	}
+}
+
+function writeStoredTimeframe( timeframe: Timeframe ): void {
+	if ( ! canUseLocalStorage() ) {
+		return;
+	}
+	try {
+		window.localStorage.setItem( TIMEFRAME_STORAGE_KEY, timeframe );
+	} catch {
+		// Ignore — quota exceeded or storage disabled.
+	}
+}
+
+/**
+ * Convert a Timeframe preset into Unix-seconds start/end params for the
+ * aggregate endpoint. Presets always end at the current time ("rolling window").
+ */
+export function timeframeToParams( timeframe: Timeframe ): Required< ApmAggregateParams > {
+	const end = Math.floor( Date.now() / 1000 );
+	const start = end - TIMEFRAME_SECONDS[ timeframe ];
+	return { start, end };
+}
+
+// Whether the timeframe's end is "now" (a rolling window) vs. a fixed
+// historical range. Today only rolling presets are exposed; the switch keeps
+// the API exhaustive so a future custom-range variant has to opt in.
+export function isRollingTimeframe( timeframe: Timeframe ): boolean {
+	switch ( timeframe ) {
+		case 'last-15-min':
+		case 'last-hour':
+		case 'last-6-hours':
+		case 'last-24-hours':
+			return true;
+	}
+}
+
+/**
+ * Returns the current timeframe selection backed by localStorage. The setter
+ * writes through to storage so the choice survives reloads.
+ */
+export function usePersistedTimeframe(): [ Timeframe, ( next: Timeframe ) => void ] {
+	const [ value, setValue ] = useState< Timeframe >(
+		() => readStoredTimeframe() ?? DEFAULT_TIMEFRAME
+	);
+	const setAndPersist = useCallback( ( next: Timeframe ) => {
+		setValue( next );
+		writeStoredTimeframe( next );
+	}, [] );
+	return [ value, setAndPersist ];
+}

--- a/client/dashboard/sites/performance/backend/transactions/index.tsx
+++ b/client/dashboard/sites/performance/backend/transactions/index.tsx
@@ -1,10 +1,6 @@
-import { siteApmAggregateQuery } from '@automattic/api-queries';
-import { useSuspenseQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
-import { useMemo } from 'react';
-import { mergeAggregates, type MergedRoute } from '../aggregate';
 import SlowList, { type SlowListItem } from '../slow-list';
-import type { Site } from '@automattic/api-core';
+import type { MergedAggregate, MergedRoute } from '../aggregate';
 
 function toItems( routes: MergedRoute[] ): SlowListItem[] {
 	return routes.map( ( route ) => ( {
@@ -15,10 +11,7 @@ function toItems( routes: MergedRoute[] ): SlowListItem[] {
 	} ) );
 }
 
-export default function Transactions( { site }: { site: Site } ) {
-	const { data } = useSuspenseQuery( siteApmAggregateQuery( site.ID ) );
-	const merged = useMemo( () => mergeAggregates( data.aggregates ), [ data.aggregates ] );
-
+export default function Transactions( { merged }: { merged: MergedAggregate } ) {
 	return (
 		<SlowList
 			title={ __( 'Slowest transactions' ) }

--- a/client/dashboard/sites/performance/backend/wordpress/index.tsx
+++ b/client/dashboard/sites/performance/backend/wordpress/index.tsx
@@ -1,22 +1,18 @@
-import { siteApmAggregateQuery } from '@automattic/api-queries';
-import { useSuspenseQuery } from '@tanstack/react-query';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useMemo } from 'react';
 import { Card, CardBody, CardHeader } from '../../../../components/card';
 import { Text } from '../../../../components/text';
 import {
-	mergeAggregates,
+	type MergedAggregate,
 	type MergedHook,
 	type MergedPlugin,
 	type MergedTemplate,
 } from '../aggregate';
 import BarList, { type BarListRow } from '../bar-list';
 import { formatMs } from '../utils';
-import type { Site } from '@automattic/api-core';
 
 function Section( {
 	title,
@@ -79,10 +75,7 @@ function sumValues( rows: BarListRow[] ): number {
 	return rows.reduce( ( sum, row ) => sum + row.value, 0 );
 }
 
-export default function WordPress( { site }: { site: Site } ) {
-	const { data } = useSuspenseQuery( siteApmAggregateQuery( site.ID ) );
-	const merged = useMemo( () => mergeAggregates( data.aggregates ), [ data.aggregates ] );
-
+export default function WordPress( { merged }: { merged: MergedAggregate } ) {
 	const pluginRows = pluginsToRows( merged.slowest.plugins );
 	const hookRows = hooksToRows( merged.slowest.hooks );
 	const templateRows = templatesToRows( merged.slowest.templates );

--- a/packages/api-queries/src/site-apm.ts
+++ b/packages/api-queries/src/site-apm.ts
@@ -23,4 +23,7 @@ export const siteApmAggregateQuery = ( siteId: number, params?: ApmAggregatePara
 	queryOptions( {
 		queryKey: [ 'site', siteId, 'apm', 'aggregate', params ],
 		queryFn: () => fetchSiteApmAggregate( siteId, params ),
+		// Data is bucketed per minute and ingestion lags ~30s; keep cached
+		// data fresh for a minute so remounts don't trigger silent refetches.
+		staleTime: 60_000,
 	} );


### PR DESCRIPTION
## Proposed Changes

Adds a Timeframe dropdown next to the *Start capturing* button on the Backend page header (Last 15 minutes / Last hour / Last 6 hours / Last 24 hours). The selection persists via `localStorage`, and the value feeds `start` / `end` into `siteApmAggregateQuery` so every backend tab respects the chosen window. Router loaders prefetch with the same params so navigation stays snappy.

Reworks `BackendStatusNotice` to stop showing the misleading "Healthy backend - avg 0 ms" notice when the response has no transactions. New notice variants:

- **Rolling window, capturing, no data**: "Capturing - performance data is being collected. New requests will show up here within about 30 seconds."
- **Rolling window, not capturing, no data**: "Capturing is off - turn capturing on to start collecting performance data." (The header's *Start capturing* button is the CTA.)
- **Non-rolling window, no data**: "No data in the selected timeframe" (placeholder for a future custom-range picker; all current presets are rolling).
- **Has data**: existing intent variants (Healthy / needs improvement / slow) based on avg response time.

To keep the new params from triggering duplicate fetches across tabs, the aggregate query is now centralised in `ApmDashboard`. Each tab subpage takes a `merged: MergedAggregate` prop and renders its slice, which also makes the per-tab files smaller.

## Why are these changes being made?

* Users want to look at windows other than the API default (last hour), and have that choice survive reloads.
* The previous shell rendered "Healthy backend - avg 0 ms" any time the aggregate response was empty, which is wrong: zero transactions doesn't mean a healthy backend, it means we don't know yet. The new notices accurately reflect "still warming up", "capturing isn't on", or "no data for the chosen window".
* Centralising the query removes a class of subtle bugs where each subpage was fetching the same data independently (which the previous code did, working only because the queryKey was identical).

## Testing Instructions

APM data collection is still being wired up server-side, so the aggregate may return empty in real use. The point is that the dashboard handles all states gracefully.

1. Open a site with APM enabled.
2. The header should show a *Timeframe* dropdown next to the *Start capturing* button (when capturing is off) or alone (when capturing is on).
3. Change the timeframe. Confirm the response updates and the value persists across reloads (close the tab, reopen, the same option is selected).
4. With an empty aggregate response, confirm the notice reads either:
    * **Capturing** (APM on) - "Performance data is being collected..."
    * **Capturing is off** (APM off) - "Turn capturing on to start collecting performance data..."
5. With data present, confirm the notice still shows the appropriate Healthy / needs improvement / slow variant.
6. Navigate between Overview / Transactions / Database / External requests / WordPress. Devtools Network should show **one** aggregate fetch (cached across tabs); changing the timeframe should refetch once.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

---

Stacked on top of `add/wpcom-apm-aggregate-tabs` (#110851). Once that lands, GitHub will auto-retarget this PR to trunk.