### PR TITLE
Site launch celebration modal: improve test fixtures and assertions

### DIFF
--- a/client/dashboard/sites/site-launch-celebration-modal/test/index.test.tsx
+++ b/client/dashboard/sites/site-launch-celebration-modal/test/index.test.tsx
@@ -48,10 +48,6 @@ describe( '<SiteLaunchCelebrationModal>', () => {
 		mockDomainsApi( [] );
 	} );
 
-	afterEach( () => {
-		nock.cleanAll();
-	} );
-
 	describe( 'Modal Display', () => {
 		test( 'renders modal with proper structure when conditions are met', async () => {
 			setupCelebrateLaunchUrl();
@@ -95,17 +91,15 @@ describe( '<SiteLaunchCelebrationModal>', () => {
 			const user = userEvent.setup();
 			const mockSite = createMockSite();
 			const customDomain = createMockDomain( 'example.com', true );
-			navigator.clipboard.writeText = jest.fn();
 
 			nock.cleanAll();
 			mockDomainsApi( [ customDomain ] );
 			render( <SiteLaunchCelebrationModal site={ mockSite } /> );
 
 			await screen.findByText( 'example.com' );
-			const copyButton = screen.getByRole( 'button', { name: 'Copy URL' } );
-			await user.click( copyButton );
+			await user.click( screen.getByRole( 'button', { name: 'Copy URL' } ) );
 
-			expect( navigator.clipboard.writeText ).toHaveBeenCalledWith( 'example.com' );
+			expect( await navigator.clipboard.readText() ).toBe( 'example.com' );
 		} );
 
 		test( 'copies first domain when multiple domains exist', async () => {
@@ -114,18 +108,16 @@ describe( '<SiteLaunchCelebrationModal>', () => {
 			const mockSite = createMockSite();
 			const domain1 = createMockDomain( 'first.com', true );
 			const domain2 = createMockDomain( 'second.com', true );
-			navigator.clipboard.writeText = jest.fn();
 
 			nock.cleanAll();
 			mockDomainsApi( [ domain1, domain2 ] );
 			render( <SiteLaunchCelebrationModal site={ mockSite } /> );
 
 			await screen.findByText( 'first.com' );
-			const copyButton = screen.getByRole( 'button', { name: 'Copy URL' } );
-			await user.click( copyButton );
+			await user.click( screen.getByRole( 'button', { name: 'Copy URL' } ) );
 
 			// Should copy first domain, not second
-			expect( navigator.clipboard.writeText ).toHaveBeenCalledWith( 'first.com' );
+			expect( await navigator.clipboard.readText() ).toBe( 'first.com' );
 		} );
 
 		test( 'skips domains without active subscription', async () => {
@@ -134,18 +126,16 @@ describe( '<SiteLaunchCelebrationModal>', () => {
 			const mockSite = createMockSite();
 			const unsubscribedDomain = createMockDomain( 'unsubscribed.com', false );
 			const activeDomain = createMockDomain( 'active.com', true );
-			navigator.clipboard.writeText = jest.fn();
 
 			nock.cleanAll();
 			mockDomainsApi( [ unsubscribedDomain, activeDomain ] );
 			render( <SiteLaunchCelebrationModal site={ mockSite } /> );
 
 			await screen.findByText( 'active.com' );
-			const copyButton = screen.getByRole( 'button', { name: 'Copy URL' } );
-			await user.click( copyButton );
+			await user.click( screen.getByRole( 'button', { name: 'Copy URL' } ) );
 
 			// Should skip unsubscribed domain and use the active one
-			expect( navigator.clipboard.writeText ).toHaveBeenCalledWith( 'active.com' );
+			expect( await navigator.clipboard.readText() ).toBe( 'active.com' );
 		} );
 	} );
 
@@ -174,7 +164,6 @@ describe( '<SiteLaunchCelebrationModal>', () => {
 			setupCelebrateLaunchUrl();
 			const user = userEvent.setup();
 			const mockSite = createMockSite();
-			navigator.clipboard.writeText = jest.fn();
 
 			render( <SiteLaunchCelebrationModal site={ mockSite } /> );
 
@@ -186,8 +175,8 @@ describe( '<SiteLaunchCelebrationModal>', () => {
 			// Click button
 			await user.click( copyButton );
 
-			// Verify clipboard was called
-			expect( navigator.clipboard.writeText ).toHaveBeenCalled();
+			// Verify clipboard was written to
+			expect( await navigator.clipboard.readText() ).toBe( mockSite.slug );
 
 			// After click, title should change to "Copied!"
 			expect( copyButton ).toHaveAttribute( 'title', 'Copied!' );
@@ -224,7 +213,17 @@ describe( '<SiteLaunchCelebrationModal>', () => {
 	describe( 'Upsell Display Logic', () => {
 		test( 'shows upsell when no custom domain exists and plan is free', async () => {
 			setupCelebrateLaunchUrl();
-			const mockSite = createMockSite( { plan: { is_free: true } as any } );
+			const mockSite = createMockSite( {
+				plan: {
+					product_id: 1,
+					product_slug: 'free_plan',
+					product_name_short: 'Free',
+					product_name_en: 'WordPress.com Free',
+					expired: false,
+					is_free: true,
+					features: { active: [] },
+				},
+			} );
 			render( <SiteLaunchCelebrationModal site={ mockSite } /> );
 
 			// Wait for modal to render first
@@ -240,7 +239,17 @@ describe( '<SiteLaunchCelebrationModal>', () => {
 
 		test( 'does not show upsell when custom domain exists', async () => {
 			setupCelebrateLaunchUrl();
-			const mockSite = createMockSite( { plan: { is_free: true } as any } );
+			const mockSite = createMockSite( {
+				plan: {
+					product_id: 1,
+					product_slug: 'free_plan',
+					product_name_short: 'Free',
+					product_name_en: 'WordPress.com Free',
+					expired: false,
+					is_free: true,
+					features: { active: [] },
+				},
+			} );
 			const customDomain = createMockDomain( 'example.com', true );
 
 			nock.cleanAll();
@@ -272,7 +281,7 @@ describe( '<SiteLaunchCelebrationModal>', () => {
 			);
 		} );
 
-		test( 'tracks event with undefined product_slug when plan is missing', async () => {
+		test( 'still fires modal view event when site has no plan', async () => {
 			setupCelebrateLaunchUrl();
 			const mockSite = createMockSite( { plan: undefined } );
 			const { recordTracksEvent } = render( <SiteLaunchCelebrationModal site={ mockSite } /> );


### PR DESCRIPTION
Fixes DOTMSD-1228.

## Proposed Changes

- Replace `{ is_free: true } as any` cast on the free-plan upsell fixture with a fully-typed `SitePlan`.
- Drop `navigator.clipboard.writeText = jest.fn()` inline mutations; assert against userEvent v14's built-in clipboard stub via `await navigator.clipboard.readText()`. The stub auto-resets between tests.
- Drop the local `nock.cleanAll()` afterEach — the dashboard test framework already cleans up.
- Rewrite the `'tracks event with undefined product_slug when plan is missing'` test, which recomputed production's exact `{ product_slug: undefined }` shape, into an assertion that the view event fires with the correct name.

## Why are these changes being made?

The previous fixture cast hid the rest of the `SitePlan` shape behind `as any`, so production code that grew to depend on fields like `features` or `product_slug` would still pass this test. The clipboard test was mutating a global without restore, making it order-dependent. The analytics test recomputed the same expression as production, so any regression that broke the call would also break the expectation and produce a passing test.

## Testing Instructions

```
yarn test-client client/dashboard/sites/site-launch-celebration-modal/
```

All 15 tests pass.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?