### PR TITLE
Reader onboarding rsm - update tracking events

### DIFF
--- a/client/reader/onboarding-rsm/curated-blogs/creative-arts.tsx
+++ b/client/reader/onboarding-rsm/curated-blogs/creative-arts.tsx
@@ -379,14 +379,6 @@ export const creativeArtsBlogs: CuratedBlogsList = {
 			has_icon: true,
 		},
 		{
-			feed_ID: 145565033,
-			site_ID: 218913951,
-			site_URL: 'diyfamilytime.com',
-			site_name: 'DIY Family Time',
-			feed_URL: 'http://diyfamilytimecom.wpcomstaging.com',
-			has_icon: false,
-		},
-		{
 			feed_ID: 46560483,
 			site_ID: 53768874,
 			site_URL: 'dreamgreendiy.com',

--- a/client/reader/onboarding-rsm/index.tsx
+++ b/client/reader/onboarding-rsm/index.tsx
@@ -79,6 +79,16 @@ const ReaderOnboardingRsm = ( {
 	// `nonSelfSubscriptionsCount` (also excludes self-owned). Use
 	// `nonSelfSubscriptionsCount` as a baseline so completion analytics do not
 	// under-report follows before the Redux follows slice has hydrated.
+	//
+	// `Math.max` is safe in onboarding because the UI only nets follow
+	// additions: discover-step recommendations exclude pre-session
+	// subscriptions (so in-session unfollows only target in-session adds),
+	// and interests-step pack subscribe never unfollows. The invariant is
+	// therefore `reduxFollowedNonSelfSitesCount >= nonSelfSubscriptionsCount`,
+	// so the max picks the live Redux value. If a future flow ever allows
+	// unfollowing a pre-session subscription from within onboarding, revisit
+	// this — gate on Redux hydration (e.g. `getReaderFollowsLastSyncTime !==
+	// null`) rather than blindly take the max.
 	const reduxFollows = useSelector( getReaderFollows );
 	const reduxFollowedNonSelfSitesCount = reduxFollows.filter(
 		( f ) => f.is_following && ! f.is_owner

--- a/client/reader/onboarding-rsm/index.tsx
+++ b/client/reader/onboarding-rsm/index.tsx
@@ -72,7 +72,15 @@ const ReaderOnboardingRsm = ( {
 	// pack subscribe) updates this slice synchronously, whereas
 	// `nonSelfSubscriptionsCount` from `useSiteSubscriptions` is a TanStack
 	// query that doesn't reflect in-session follows until its refetch resolves.
+	//
+	// `getReaderFollows` retains stale rows (`is_following: false`) and
+	// self-owned subs (`is_owner: true`); we filter both out so the count
+	// matches the rest of the onboarding eligibility logic, which uses
+	// `nonSelfSubscriptionsCount` (also excludes self-owned).
 	const reduxFollows = useSelector( getReaderFollows );
+	const followedNonSelfSitesCount = reduxFollows.filter(
+		( f ) => f.is_following && ! f.is_owner
+	).length;
 	const userRegistrationDate = useSelector( getCurrentUserDate ) as string | null;
 	const promptVerification = ! useSelector( isCurrentUserEmailVerified );
 
@@ -263,7 +271,7 @@ const ReaderOnboardingRsm = ( {
 		// record tracks for completion regardless of setting, to still track it in flows that forceShow.
 		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }completed`, {
 			followed_tags_count: followedTags?.length ?? 0,
-			followed_sites_count: reduxFollows.length,
+			followed_non_self_sites_count: followedNonSelfSitesCount,
 		} );
 		if ( hasCompletedOnboarding ) {
 			return;

--- a/client/reader/onboarding-rsm/index.tsx
+++ b/client/reader/onboarding-rsm/index.tsx
@@ -175,23 +175,31 @@ const ReaderOnboardingRsm = ( {
 		} );
 	};
 
-	// Side-effects that run when a given step is closed (whether via the X /
-	// escape, or via the "continue" button transitioning to the next step).
-	// Centralised so the same effects fire on either path.
-	const performStepCloseSideEffects = ( step: Step ) => {
+	// Non-analytics side effects that run when leaving a step (whether via the
+	// X / escape, or via the "continue"/"back"/"finish" button transitioning
+	// to the next step). Centralised so the same effects fire on either path.
+	// Analytics is intentionally split out into `recordStepClose` so the
+	// `*_modal_close` event fires only on an explicit dismiss, not on
+	// navigation actions that already have their own continue/back/finish
+	// events.
+	const runStepSideEffects = ( step: Step ) => {
 		if ( step === 'welcome' ) {
-			recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }welcome_modal_close` );
 			if ( ! hasSeenOnboarding ) {
 				dispatch( savePreference( READER_ONBOARDING_SEEN_PREFERENCE_KEY, true ) );
 			}
+		} else if ( step === 'interests' || step === 'discover' ) {
+			refreshFollowingStreams();
+			invalidateSubscriptionQueries();
+		}
+	};
+
+	const recordStepClose = ( step: Step ) => {
+		if ( step === 'welcome' ) {
+			recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }welcome_modal_close` );
 		} else if ( step === 'interests' ) {
 			recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }interests_modal_close` );
-			refreshFollowingStreams();
-			invalidateSubscriptionQueries();
 		} else if ( step === 'discover' ) {
 			recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }discover_modal_close` );
-			refreshFollowingStreams();
-			invalidateSubscriptionQueries();
 		}
 	};
 
@@ -212,48 +220,50 @@ const ReaderOnboardingRsm = ( {
 
 	const handleStepClose = () => {
 		if ( currentStep ) {
-			performStepCloseSideEffects( currentStep );
+			recordStepClose( currentStep );
+			runStepSideEffects( currentStep );
 		}
 		setCurrentStep( null );
 	};
 
 	const handleWelcomeContinue = () => {
 		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }welcome_modal_continue` );
-		performStepCloseSideEffects( 'welcome' );
+		runStepSideEffects( 'welcome' );
 		recordStepOpen( 'interests' );
 		setCurrentStep( 'interests' );
 	};
 
 	const handleInterestsContinue = () => {
 		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }interests_modal_continue` );
-		performStepCloseSideEffects( 'interests' );
+		runStepSideEffects( 'interests' );
 		recordStepOpen( 'discover' );
 		setCurrentStep( 'discover' );
 	};
 
 	const handleInterestsBack = () => {
 		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }interests_modal_back` );
-		performStepCloseSideEffects( 'interests' );
+		runStepSideEffects( 'interests' );
 		openStep( 'welcome' );
 	};
 
 	const handleDiscoverBack = () => {
 		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }discover_modal_back` );
-		performStepCloseSideEffects( 'discover' );
+		runStepSideEffects( 'discover' );
 		openStep( 'interests' );
 	};
 
 	const recordOnboardingCompleted = () => {
+		// record completion regardless of setting, to still track it in flows that forceShow.
+		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }completed` );
 		if ( hasCompletedOnboarding ) {
 			return;
 		}
 		dispatch( savePreference( READER_ONBOARDING_PREFERENCE_KEY, true ) );
-		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }completed` );
 	};
 
 	const handleDiscoverFinish = () => {
 		recordOnboardingCompleted();
-		performStepCloseSideEffects( 'discover' );
+		runStepSideEffects( 'discover' );
 		setCurrentStep( null );
 		setHasFinished( true );
 	};

--- a/client/reader/onboarding-rsm/index.tsx
+++ b/client/reader/onboarding-rsm/index.tsx
@@ -30,6 +30,7 @@ import {
 } from 'calypso/state/current-user/selectors';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
+import { getReaderFollows } from 'calypso/state/reader/follows/selectors';
 import { useSiteSubscriptions } from '../following/use-site-subscriptions';
 import { getReloadStep } from './get-reload-step';
 import { useRefreshFollowingStreams } from './use-refresh-following-streams';
@@ -66,6 +67,12 @@ const ReaderOnboardingRsm = ( {
 	} = useSiteSubscriptions();
 
 	const { data: followedTags, isPending: tagsPending } = useFollowedReaderTags();
+	// Used in the `completed` event for an instant in-session site-follow
+	// count: legacy `READER_FOLLOW` (used by the discover step and interests
+	// pack subscribe) updates this slice synchronously, whereas
+	// `nonSelfSubscriptionsCount` from `useSiteSubscriptions` is a TanStack
+	// query that doesn't reflect in-session follows until its refetch resolves.
+	const reduxFollows = useSelector( getReaderFollows );
 	const userRegistrationDate = useSelector( getCurrentUserDate ) as string | null;
 	const promptVerification = ! useSelector( isCurrentUserEmailVerified );
 
@@ -254,7 +261,10 @@ const ReaderOnboardingRsm = ( {
 
 	const recordOnboardingCompleted = () => {
 		// record tracks for completion regardless of setting, to still track it in flows that forceShow.
-		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }completed` );
+		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }completed`, {
+			followed_tags_count: followedTags?.length ?? 0,
+			followed_sites_count: reduxFollows.length,
+		} );
 		if ( hasCompletedOnboarding ) {
 			return;
 		}

--- a/client/reader/onboarding-rsm/index.tsx
+++ b/client/reader/onboarding-rsm/index.tsx
@@ -253,7 +253,7 @@ const ReaderOnboardingRsm = ( {
 	};
 
 	const recordOnboardingCompleted = () => {
-		// record completion regardless of setting, to still track it in flows that forceShow.
+		// record tracks for completion regardless of setting, to still track it in flows that forceShow.
 		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }completed` );
 		if ( hasCompletedOnboarding ) {
 			return;

--- a/client/reader/onboarding-rsm/index.tsx
+++ b/client/reader/onboarding-rsm/index.tsx
@@ -76,11 +76,17 @@ const ReaderOnboardingRsm = ( {
 	// `getReaderFollows` retains stale rows (`is_following: false`) and
 	// self-owned subs (`is_owner: true`); we filter both out so the count
 	// matches the rest of the onboarding eligibility logic, which uses
-	// `nonSelfSubscriptionsCount` (also excludes self-owned).
+	// `nonSelfSubscriptionsCount` (also excludes self-owned). Use
+	// `nonSelfSubscriptionsCount` as a baseline so completion analytics do not
+	// under-report follows before the Redux follows slice has hydrated.
 	const reduxFollows = useSelector( getReaderFollows );
-	const followedNonSelfSitesCount = reduxFollows.filter(
+	const reduxFollowedNonSelfSitesCount = reduxFollows.filter(
 		( f ) => f.is_following && ! f.is_owner
 	).length;
+	const followedNonSelfSitesCount = Math.max(
+		nonSelfSubscriptionsCount,
+		reduxFollowedNonSelfSitesCount
+	);
 	const userRegistrationDate = useSelector( getCurrentUserDate ) as string | null;
 	const promptVerification = ! useSelector( isCurrentUserEmailVerified );
 

--- a/client/reader/onboarding-rsm/interests-modal/index.tsx
+++ b/client/reader/onboarding-rsm/interests-modal/index.tsx
@@ -17,8 +17,10 @@ import {
 	READER_ONBOARDING_TRACKS_EVENT_PREFIX,
 } from 'calypso/reader/onboarding-rsm/constants';
 import { StepIndicator } from 'calypso/reader/onboarding-rsm/step-indicator';
+import { recordFollow } from 'calypso/reader/stats';
 import { useSelector, useDispatch } from 'calypso/state';
 import { errorNotice } from 'calypso/state/notices/actions';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import { follow } from 'calypso/state/reader/follows/actions';
 import { getReaderFollows } from 'calypso/state/reader/follows/selectors';
 import { getPackBlogs } from './get-pack-blogs';
@@ -166,14 +168,15 @@ const InterestsModal: React.FC< InterestsModalProps > = ( {
 			followedTagsRef.current = nextTags;
 			setFollowedTags( nextTags );
 
-			recordTracksEvent(
-				`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }interests_modal_tag_${
-					checked ? 'followed' : 'unfollowed'
-				}`,
-				{
-					tag,
-					total_followed: nextTags.length,
-				}
+			dispatch(
+				recordReaderTracksEvent(
+					checked ? 'calypso_reader_reader_tag_followed' : 'calypso_reader_reader_tag_unfollowed',
+					{
+						tag,
+						follow_source: 'reader-onboarding-modal',
+						total_followed: nextTags.length,
+					}
+				)
 			);
 
 			try {
@@ -248,6 +251,7 @@ const InterestsModal: React.FC< InterestsModalProps > = ( {
 				`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }interests_modal_pack_subscribed`,
 				{
 					pack_id: pack.id,
+					pack_name: pack.title,
 					tag_count: pack.tags.length,
 					blog_count: pack.blogs.length,
 				}
@@ -265,6 +269,12 @@ const InterestsModal: React.FC< InterestsModalProps > = ( {
 				// Best effort only: site-specific failures are handled by existing
 				// follow data-layer notices and should not block pack completion.
 				dispatch( follow( blog.feed_URL, followData, null ) );
+				// Mirror how the rest of Reader tracks site follows so pack-blog
+				// follows show up under the standard `calypso_reader_site_followed`
+				// event with a `reader-onboarding-modal` follow source.
+				recordFollow( blog.feed_URL, undefined, {
+					follow_source: 'reader-onboarding-modal',
+				} );
 			}
 		} finally {
 			setProcessingPacks( ( current ) => {

--- a/client/reader/onboarding-rsm/interests-modal/index.tsx
+++ b/client/reader/onboarding-rsm/interests-modal/index.tsx
@@ -251,7 +251,6 @@ const InterestsModal: React.FC< InterestsModalProps > = ( {
 				`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }interests_modal_pack_subscribed`,
 				{
 					pack_id: pack.id,
-					pack_name: pack.title,
 					tag_count: pack.tags.length,
 					blog_count: pack.blogs.length,
 				}

--- a/client/reader/onboarding-rsm/interests-modal/test/index.test.tsx
+++ b/client/reader/onboarding-rsm/interests-modal/test/index.test.tsx
@@ -2,9 +2,12 @@
  * @jest-environment jsdom
  */
 
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React, { useState } from 'react';
+import { recordFollow } from 'calypso/reader/stats';
+import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { getPackBlogs } from '../get-pack-blogs';
 import InterestsModal from '../index';
@@ -102,6 +105,23 @@ jest.mock( '@automattic/calypso-analytics', () => ( {
 	recordTracksEvent: jest.fn(),
 } ) );
 
+// Mock as a thunk action creator so `dispatch( recordReaderTracksEvent(...) )`
+// still works against the real Redux store inside `renderWithProvider`, while
+// letting tests assert on the call arguments.
+jest.mock( 'calypso/state/reader/analytics/actions', () => ( {
+	recordReaderTracksEvent: jest.fn(
+		( name: string, properties: Record< string, unknown > ) => () => ( {
+			type: 'READER_RECORD_TRACKS_EVENT',
+			name,
+			properties,
+		} )
+	),
+} ) );
+
+jest.mock( 'calypso/reader/stats', () => ( {
+	recordFollow: jest.fn(),
+} ) );
+
 jest.mock( 'i18n-calypso', () => ( {
 	...jest.requireActual( 'i18n-calypso' ),
 	fixMe: ( { newCopy }: { newCopy: string } ) => newCopy,
@@ -111,7 +131,7 @@ jest.mock( 'i18n-calypso', () => ( {
 
 jest.mock( '@tanstack/react-query', () => ( {
 	...jest.requireActual( '@tanstack/react-query' ),
-	useMutation: () => ( { mutateAsync: jest.fn() } ),
+	useMutation: () => ( { mutateAsync: jest.fn().mockResolvedValue( undefined ) } ),
 } ) );
 
 jest.mock( '@automattic/api-queries', () => ( {
@@ -278,6 +298,127 @@ describe( 'InterestsModal – most subscribed pack', () => {
 		expect( screen.getByRole( 'button', { name: 'Continue' } ) ).not.toHaveAttribute(
 			'aria-disabled',
 			'true'
+		);
+	} );
+} );
+
+describe( 'InterestsModal – analytics for pack subscribe', () => {
+	const fivePackBlogs = Array.from( { length: 3 }, ( _, i ) => ( {
+		feed_ID: 900 + i,
+		site_ID: 800 + i,
+		site_URL: `https://pack-${ i }.example`,
+		site_name: `Pack site ${ i }`,
+		feed_URL: `https://pack-${ i }.example/feed`,
+		has_icon: true,
+	} ) );
+
+	beforeEach( () => {
+		jest.mocked( recordTracksEvent ).mockClear();
+		jest.mocked( recordFollow ).mockClear();
+		jest.mocked( recordReaderTracksEvent ).mockClear();
+	} );
+
+	afterEach( () => {
+		jest.mocked( getTopicGroups ).mockReset().mockReturnValue( [] );
+		jest.mocked( getPackBlogs ).mockReset().mockReturnValue( [] );
+	} );
+
+	it( 'records pack_subscribed with pack_id when a pack is subscribed', async () => {
+		const user = userEvent.setup();
+
+		jest.mocked( getTopicGroups ).mockReturnValue( [
+			{
+				id: 'most-subscribed',
+				title: 'Most Subscribed',
+				description: 'Popular reads.',
+				imageUrl: 'https://images.example/subscribed.webp',
+				tags: [],
+			},
+		] );
+		jest.mocked( getPackBlogs ).mockReturnValue( fivePackBlogs );
+
+		renderWithProvider(
+			<InterestsModalWithFollowedState onContinue={ jest.fn() } promptVerification={ false } />
+		);
+
+		await user.click( screen.getByTestId( 'topic-pack-card' ) );
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_reader_onboarding_interests_modal_pack_subscribed',
+			expect.objectContaining( {
+				pack_id: 'most-subscribed',
+				tag_count: 0,
+				blog_count: 3,
+			} )
+		);
+	} );
+
+	it( 'records calypso_reader_site_followed with reader-onboarding-modal follow_source for each pack blog', async () => {
+		const user = userEvent.setup();
+
+		jest.mocked( getTopicGroups ).mockReturnValue( [
+			{
+				id: 'most-subscribed',
+				title: 'Most Subscribed',
+				description: 'Popular reads.',
+				imageUrl: 'https://images.example/subscribed.webp',
+				tags: [],
+			},
+		] );
+		jest.mocked( getPackBlogs ).mockReturnValue( fivePackBlogs );
+
+		renderWithProvider(
+			<InterestsModalWithFollowedState onContinue={ jest.fn() } promptVerification={ false } />
+		);
+
+		await user.click( screen.getByTestId( 'topic-pack-card' ) );
+
+		expect( recordFollow ).toHaveBeenCalledTimes( fivePackBlogs.length );
+		for ( const blog of fivePackBlogs ) {
+			expect( recordFollow ).toHaveBeenCalledWith( blog.feed_URL, undefined, {
+				follow_source: 'reader-onboarding-modal',
+			} );
+		}
+	} );
+
+	it( 'records calypso_reader_reader_tag_followed via recordReaderTracksEvent for each tag in the pack', async () => {
+		const user = userEvent.setup();
+
+		jest.mocked( getTopicGroups ).mockReturnValue( [
+			{
+				id: 'tech',
+				title: 'Tech',
+				description: 'Tech reads.',
+				imageUrl: 'https://images.example/tech.webp',
+				tags: [ 'javascript', 'react' ],
+			},
+		] );
+		jest.mocked( getPackBlogs ).mockReturnValue( [] );
+
+		renderWithProvider(
+			<InterestsModalWithFollowedState onContinue={ jest.fn() } promptVerification={ false } />
+		);
+
+		await user.click( screen.getByTestId( 'topic-pack-card' ) );
+
+		expect( recordReaderTracksEvent ).toHaveBeenCalledWith(
+			'calypso_reader_reader_tag_followed',
+			expect.objectContaining( {
+				tag: 'javascript',
+				follow_source: 'reader-onboarding-modal',
+			} )
+		);
+		expect( recordReaderTracksEvent ).toHaveBeenCalledWith(
+			'calypso_reader_reader_tag_followed',
+			expect.objectContaining( {
+				tag: 'react',
+				follow_source: 'reader-onboarding-modal',
+			} )
+		);
+		// Confirm the legacy onboarding-specific event name is no longer used.
+		expect( recordTracksEvent ).not.toHaveBeenCalledWith(
+			'calypso_reader_onboarding_interests_modal_tag_followed',
+			expect.anything()
 		);
 	} );
 } );

--- a/client/reader/onboarding-rsm/interests-modal/test/index.test.tsx
+++ b/client/reader/onboarding-rsm/interests-modal/test/index.test.tsx
@@ -303,7 +303,7 @@ describe( 'InterestsModal – most subscribed pack', () => {
 } );
 
 describe( 'InterestsModal – analytics for pack subscribe', () => {
-	const fivePackBlogs = Array.from( { length: 3 }, ( _, i ) => ( {
+	const packBlogs = Array.from( { length: 3 }, ( _, i ) => ( {
 		feed_ID: 900 + i,
 		site_ID: 800 + i,
 		site_URL: `https://pack-${ i }.example`,
@@ -335,7 +335,7 @@ describe( 'InterestsModal – analytics for pack subscribe', () => {
 				tags: [],
 			},
 		] );
-		jest.mocked( getPackBlogs ).mockReturnValue( fivePackBlogs );
+		jest.mocked( getPackBlogs ).mockReturnValue( packBlogs );
 
 		renderWithProvider(
 			<InterestsModalWithFollowedState onContinue={ jest.fn() } promptVerification={ false } />
@@ -348,7 +348,7 @@ describe( 'InterestsModal – analytics for pack subscribe', () => {
 			expect.objectContaining( {
 				pack_id: 'most-subscribed',
 				tag_count: 0,
-				blog_count: 3,
+				blog_count: packBlogs.length,
 			} )
 		);
 	} );
@@ -365,7 +365,7 @@ describe( 'InterestsModal – analytics for pack subscribe', () => {
 				tags: [],
 			},
 		] );
-		jest.mocked( getPackBlogs ).mockReturnValue( fivePackBlogs );
+		jest.mocked( getPackBlogs ).mockReturnValue( packBlogs );
 
 		renderWithProvider(
 			<InterestsModalWithFollowedState onContinue={ jest.fn() } promptVerification={ false } />
@@ -373,8 +373,8 @@ describe( 'InterestsModal – analytics for pack subscribe', () => {
 
 		await user.click( screen.getByTestId( 'topic-pack-card' ) );
 
-		expect( recordFollow ).toHaveBeenCalledTimes( fivePackBlogs.length );
-		for ( const blog of fivePackBlogs ) {
+		expect( recordFollow ).toHaveBeenCalledTimes( packBlogs.length );
+		for ( const blog of packBlogs ) {
 			expect( recordFollow ).toHaveBeenCalledWith( blog.feed_URL, undefined, {
 				follow_source: 'reader-onboarding-modal',
 			} );

--- a/client/reader/onboarding-rsm/subscribe-modal/index.tsx
+++ b/client/reader/onboarding-rsm/subscribe-modal/index.tsx
@@ -155,6 +155,14 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { promptVerification, 
 				if ( previewContainer ) {
 					previewContainer.scrollTop = 0;
 				}
+				recordTracksEvent(
+					`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }discover_modal_site_previewed`,
+					{
+						feed_id: site.feed_ID,
+						site_id: site.site_ID,
+						site_name: site.site_name,
+					}
+				);
 			}
 			setSelectedSite( site );
 		},

--- a/client/reader/onboarding-rsm/subscribe-modal/test/index.test.tsx
+++ b/client/reader/onboarding-rsm/subscribe-modal/test/index.test.tsx
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
@@ -10,16 +11,20 @@ import SubscribeModal from '../index';
 
 // ── Recommendations hook ─────────────────────────────────────────────────────
 
+const defaultRecommendationsHookValue = {
+	combinedRecommendations: [],
+	recommendations: [],
+	isLoading: false,
+	isValidating: false,
+	hasNoRecommendations: false,
+	followedTagSlugs: [],
+	markSessionFollow: jest.fn(),
+};
+
+const mockedRecommendationsHook = jest.fn( () => defaultRecommendationsHookValue );
+
 jest.mock( '../use-subscribe-recommendations', () => ( {
-	useSubscribeRecommendations: () => ( {
-		combinedRecommendations: [],
-		recommendations: [],
-		isLoading: false,
-		isValidating: false,
-		hasNoRecommendations: false,
-		followedTagSlugs: [],
-		markSessionFollow: jest.fn(),
-	} ),
+	useSubscribeRecommendations: () => mockedRecommendationsHook(),
 } ) );
 
 // ── Heavy UI dependencies ────────────────────────────────────────────────────
@@ -29,9 +34,23 @@ jest.mock( 'calypso/reader/stream', () => ( {
 	default: () => null,
 } ) );
 
+// Render the list item as a button so tests can click it and exercise the
+// `onItemClick` callback (which is what fires the site-previewed event).
 jest.mock( 'calypso/blocks/reader-subscription-list-item/connected', () => ( {
 	__esModule: true,
-	default: () => null,
+	default: ( {
+		feedId,
+		site,
+		onItemClick,
+	}: {
+		feedId: number;
+		site: { site_name: string };
+		onItemClick: () => void;
+	} ) => (
+		<button type="button" data-testid={ `reader-list-item-${ feedId }` } onClick={ onItemClick }>
+			{ site.site_name }
+		</button>
+	),
 } ) );
 
 jest.mock( 'calypso/blocks/site-icon', () => ( {
@@ -138,5 +157,70 @@ describe( 'SubscribeModal – verification nudge', () => {
 		const button = screen.getByRole( 'button', { name: 'Finish' } );
 		expect( button ).not.toHaveAttribute( 'aria-disabled', 'true' );
 		expect( button ).not.toBeDisabled();
+	} );
+} );
+
+describe( 'SubscribeModal – site preview analytics', () => {
+	const makeRecommendation = ( i: number ) => ( {
+		feed_ID: 100 + i,
+		site_ID: 200 + i,
+		site_URL: `https://site-${ i }.example`,
+		site_name: `Site ${ i }`,
+		feed_URL: `https://site-${ i }.example/feed`,
+		has_icon: true,
+	} );
+
+	beforeEach( () => {
+		jest.mocked( recordTracksEvent ).mockClear();
+		mockedRecommendationsHook.mockReturnValue( defaultRecommendationsHookValue );
+	} );
+
+	it( 'records discover_modal_site_previewed when the user picks a different site in the list', async () => {
+		const user = userEvent.setup();
+		const recommendations = [ makeRecommendation( 0 ), makeRecommendation( 1 ) ];
+		mockedRecommendationsHook.mockReturnValue( {
+			...defaultRecommendationsHookValue,
+			combinedRecommendations: recommendations,
+			recommendations,
+		} );
+
+		renderWithProvider( <SubscribeModal onFinish={ jest.fn() } promptVerification={ false } /> );
+
+		// First recommendation is auto-selected on mount, so clicking it again is
+		// a no-op and must NOT fire the previewed event. Clicking a *different*
+		// site is what should fire it.
+		jest.mocked( recordTracksEvent ).mockClear();
+		await user.click( screen.getByTestId( 'reader-list-item-101' ) );
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_reader_onboarding_discover_modal_site_previewed',
+			expect.objectContaining( {
+				feed_id: 101,
+				site_id: 201,
+				site_name: 'Site 1',
+			} )
+		);
+	} );
+
+	it( 'does not record discover_modal_site_previewed when the same site is clicked again', async () => {
+		const user = userEvent.setup();
+		const recommendations = [ makeRecommendation( 0 ) ];
+		mockedRecommendationsHook.mockReturnValue( {
+			...defaultRecommendationsHookValue,
+			combinedRecommendations: recommendations,
+			recommendations,
+		} );
+
+		renderWithProvider( <SubscribeModal onFinish={ jest.fn() } promptVerification={ false } /> );
+
+		// First (and only) recommendation is auto-selected; clicking it should not
+		// fire a duplicate previewed event.
+		jest.mocked( recordTracksEvent ).mockClear();
+		await user.click( screen.getByTestId( 'reader-list-item-100' ) );
+
+		expect( recordTracksEvent ).not.toHaveBeenCalledWith(
+			'calypso_reader_onboarding_discover_modal_site_previewed',
+			expect.anything()
+		);
 	} );
 } );

--- a/client/reader/onboarding-rsm/subscribe-modal/test/index.test.tsx
+++ b/client/reader/onboarding-rsm/subscribe-modal/test/index.test.tsx
@@ -8,16 +8,20 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import SubscribeModal from '../index';
+import type { CardData } from '../use-subscribe-recommendations';
 
 // ── Recommendations hook ─────────────────────────────────────────────────────
 
+// Explicit array element types so per-test overrides that supply `CardData[]`
+// (or `string[]` for `followedTagSlugs`) don't get inferred as `never[]` from
+// the empty defaults — keeps TypeScript happy without an `as` cast.
 const defaultRecommendationsHookValue = {
-	combinedRecommendations: [],
-	recommendations: [],
+	combinedRecommendations: [] as CardData[],
+	recommendations: [] as CardData[],
 	isLoading: false,
 	isValidating: false,
 	hasNoRecommendations: false,
-	followedTagSlugs: [],
+	followedTagSlugs: [] as string[],
 	markSessionFollow: jest.fn(),
 };
 

--- a/client/reader/onboarding-rsm/test/index.test.tsx
+++ b/client/reader/onboarding-rsm/test/index.test.tsx
@@ -149,7 +149,7 @@ jest.mock( 'calypso/state/reader/streams/actions', () => ( {
 
 // The real selector traverses `state.reader.follows`, which the lightweight
 // test store does not seed. Default to an empty follow list so the parent
-// completion event still has a valid `followed_sites_count`.
+// completion event still has a valid `followed_non_self_sites_count`.
 jest.mock( 'calypso/state/reader/follows/selectors', () => ( {
 	getReaderFollows: jest.fn().mockReturnValue( [] ),
 } ) );

--- a/client/reader/onboarding-rsm/test/index.test.tsx
+++ b/client/reader/onboarding-rsm/test/index.test.tsx
@@ -147,6 +147,13 @@ jest.mock( 'calypso/state/reader/streams/actions', () => ( {
 	requestPaginatedStream: jest.fn( () => ( { type: 'READER_REQUEST_PAGINATED_STREAM' } ) ),
 } ) );
 
+// The real selector traverses `state.reader.follows`, which the lightweight
+// test store does not seed. Default to an empty follow list so the parent
+// completion event still has a valid `followed_sites_count`.
+jest.mock( 'calypso/state/reader/follows/selectors', () => ( {
+	getReaderFollows: jest.fn().mockReturnValue( [] ),
+} ) );
+
 const mockRefreshFollowingStreams = jest.fn();
 jest.mock( '../use-refresh-following-streams', () => ( {
 	useRefreshFollowingStreams: () => mockRefreshFollowingStreams,
@@ -496,7 +503,8 @@ describe( 'ReaderOnboardingRsm – step close vs navigation analytics', () => {
 		await user.click( screen.getByRole( 'button', { name: 'Finish' } ) );
 
 		expect( recordTracksEvent ).toHaveBeenCalledWith(
-			`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }completed`
+			`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }completed`,
+			expect.any( Object )
 		);
 		expect( recordTracksEvent ).not.toHaveBeenCalledWith( closeEventFor( 'discover' ) );
 	} );
@@ -542,7 +550,8 @@ describe( 'ReaderOnboardingRsm – step close vs navigation analytics', () => {
 
 		expect( recordTracksEvent ).toHaveBeenCalledWith( closeEventFor( 'discover' ) );
 		expect( recordTracksEvent ).not.toHaveBeenCalledWith(
-			`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }completed`
+			`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }completed`,
+			expect.anything()
 		);
 	} );
 } );
@@ -565,7 +574,11 @@ describe( 'ReaderOnboardingRsm – onboarding completion', () => {
 
 		expect( savePreference ).toHaveBeenCalledWith( READER_ONBOARDING_PREFERENCE_KEY, true );
 		expect( recordTracksEvent ).toHaveBeenCalledWith(
-			`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }completed`
+			`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }completed`,
+			expect.objectContaining( {
+				followed_tags_count: expect.any( Number ),
+				followed_sites_count: expect.any( Number ),
+			} )
 		);
 	} );
 
@@ -578,8 +591,60 @@ describe( 'ReaderOnboardingRsm – onboarding completion', () => {
 
 		expect( savePreference ).not.toHaveBeenCalledWith( READER_ONBOARDING_PREFERENCE_KEY, true );
 		expect( recordTracksEvent ).not.toHaveBeenCalledWith(
-			`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }completed`
+			`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }completed`,
+			expect.anything()
 		);
+	} );
+
+	it( 'records completed with followed_tags_count and followed_sites_count reflecting the user\u2019s current follows', async () => {
+		const { useFollowedReaderTags } = jest.requireMock( 'calypso/data/reader/use-reader-tags' ) as {
+			useFollowedReaderTags: jest.Mock;
+		};
+		useFollowedReaderTags.mockImplementation( () => ( {
+			data: [ { slug: 'tech' }, { slug: 'food' } ],
+			isPending: false,
+		} ) );
+
+		const user = userEvent.setup();
+		renderWithProvider( <ReaderOnboardingRsm /> );
+
+		await navigateToSubscribeStep( user );
+		await user.click( screen.getByRole( 'button', { name: 'Finish' } ) );
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }completed`,
+			expect.objectContaining( {
+				followed_tags_count: 2,
+				followed_sites_count: expect.any( Number ),
+			} )
+		);
+	} );
+
+	it( 'still records completed (without re-saving preference) when the user has already completed onboarding', async () => {
+		// Mirrors the forceShow case: a returning user can re-enter the modal
+		// and click Finish again — the `completed` event should still fire so
+		// we can attribute the funnel, but the preference is already set so we
+		// skip the redundant write.
+		const { getPreference } = jest.requireMock( 'calypso/state/preferences/selectors' ) as {
+			getPreference: jest.Mock;
+		};
+		getPreference.mockImplementation( ( _state: unknown, key: string ) =>
+			key === READER_ONBOARDING_PREFERENCE_KEY ? true : null
+		);
+
+		const user = userEvent.setup();
+		renderWithProvider( <ReaderOnboardingRsm /> );
+
+		await navigateToSubscribeStep( user );
+		await user.click( screen.getByRole( 'button', { name: 'Finish' } ) );
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }completed`,
+			expect.any( Object )
+		);
+		expect( savePreference ).not.toHaveBeenCalledWith( READER_ONBOARDING_PREFERENCE_KEY, true );
+
+		getPreference.mockReturnValue( null );
 	} );
 
 	it( 'does not auto-save completion when the user has enough follows without clicking Finish', async () => {
@@ -609,7 +674,8 @@ describe( 'ReaderOnboardingRsm – onboarding completion', () => {
 
 		expect( savePreference ).not.toHaveBeenCalledWith( READER_ONBOARDING_PREFERENCE_KEY, true );
 		expect( recordTracksEvent ).not.toHaveBeenCalledWith(
-			`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }completed`
+			`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }completed`,
+			expect.anything()
 		);
 	} );
 } );

--- a/client/reader/onboarding-rsm/test/index.test.tsx
+++ b/client/reader/onboarding-rsm/test/index.test.tsx
@@ -55,7 +55,9 @@ jest.mock( '@automattic/launchpad', () => ( {
 } ) );
 
 // Render the WP Modal without a portal so headerActions and children
-// are reachable via standard screen queries.
+// are reachable via standard screen queries. Expose `onRequestClose` as a
+// dedicated "Close modal" button so tests can simulate the X / escape /
+// outside-click dismiss path that the real <Modal> wires up.
 jest.mock( '@wordpress/components', () => {
 	const { Button } =
 		jest.requireActual< typeof import('@wordpress/components') >( '@wordpress/components' );
@@ -64,12 +66,17 @@ jest.mock( '@wordpress/components', () => {
 		Modal: ( {
 			children,
 			headerActions,
+			onRequestClose,
 		}: {
 			children: React.ReactNode;
 			headerActions?: React.ReactNode;
+			onRequestClose?: () => void;
 		} ) => (
 			<div role="dialog">
 				{ headerActions }
+				<button type="button" onClick={ onRequestClose }>
+					Close modal
+				</button>
 				{ children }
 			</div>
 		),
@@ -396,6 +403,147 @@ describe( 'ReaderOnboardingRsm – subscription query invalidation on step close
 		expect( invalidateSpy ).toHaveBeenCalledWith( {
 			queryKey: SubscriptionManager.siteSubscriptionsQueryKeyPrefix,
 		} );
+	} );
+} );
+
+describe( 'ReaderOnboardingRsm – step close vs navigation analytics', () => {
+	// The *_modal_close events should fire only when the user explicitly
+	// dismisses a step (X / escape / outside click), not when they navigate
+	// forward via Continue/Finish or backward via Back. Each navigation path
+	// has its own dedicated continue/back/finish event so the close event no
+	// longer doubles up on every transition.
+
+	const closeEventFor = ( step: 'welcome' | 'interests' | 'discover' ) =>
+		`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }${ step }_modal_close`;
+
+	it( 'does not record welcome_modal_close when the user clicks Continue from welcome', async () => {
+		const user = userEvent.setup();
+		renderWithProvider( <ReaderOnboardingRsm /> );
+
+		await screen.findByTestId( 'welcome-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Pick your topics' } ) );
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }welcome_modal_continue`
+		);
+		expect( recordTracksEvent ).not.toHaveBeenCalledWith( closeEventFor( 'welcome' ) );
+	} );
+
+	it( 'does not record interests_modal_close when the user clicks Continue from interests', async () => {
+		const user = userEvent.setup();
+		renderWithProvider( <ReaderOnboardingRsm /> );
+
+		await screen.findByTestId( 'welcome-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Pick your topics' } ) );
+		await screen.findByTestId( 'interests-modal-content' );
+
+		jest.mocked( recordTracksEvent ).mockClear();
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }interests_modal_continue`
+		);
+		expect( recordTracksEvent ).not.toHaveBeenCalledWith( closeEventFor( 'interests' ) );
+	} );
+
+	it( 'does not record interests_modal_close when the user clicks Back from interests', async () => {
+		const user = userEvent.setup();
+		renderWithProvider( <ReaderOnboardingRsm /> );
+
+		await screen.findByTestId( 'welcome-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Pick your topics' } ) );
+		await screen.findByTestId( 'interests-modal-content' );
+
+		jest.mocked( recordTracksEvent ).mockClear();
+		await user.click( screen.getByRole( 'button', { name: 'Back' } ) );
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }interests_modal_back`
+		);
+		expect( recordTracksEvent ).not.toHaveBeenCalledWith( closeEventFor( 'interests' ) );
+	} );
+
+	it( 'does not record discover_modal_close when the user clicks Back from discover', async () => {
+		const user = userEvent.setup();
+		renderWithProvider( <ReaderOnboardingRsm /> );
+
+		await screen.findByTestId( 'welcome-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Pick your topics' } ) );
+		await screen.findByTestId( 'interests-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
+		await screen.findByTestId( 'subscribe-modal-content' );
+
+		jest.mocked( recordTracksEvent ).mockClear();
+		await user.click( screen.getByRole( 'button', { name: 'Back' } ) );
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }discover_modal_back`
+		);
+		expect( recordTracksEvent ).not.toHaveBeenCalledWith( closeEventFor( 'discover' ) );
+	} );
+
+	it( 'does not record discover_modal_close when the user clicks Finish from discover', async () => {
+		const user = userEvent.setup();
+		renderWithProvider( <ReaderOnboardingRsm /> );
+
+		await screen.findByTestId( 'welcome-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Pick your topics' } ) );
+		await screen.findByTestId( 'interests-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
+		await screen.findByTestId( 'subscribe-modal-content' );
+
+		jest.mocked( recordTracksEvent ).mockClear();
+		await user.click( screen.getByRole( 'button', { name: 'Finish' } ) );
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }completed`
+		);
+		expect( recordTracksEvent ).not.toHaveBeenCalledWith( closeEventFor( 'discover' ) );
+	} );
+
+	it( 'records welcome_modal_close when the user dismisses the welcome step (X / outside click)', async () => {
+		const user = userEvent.setup();
+		renderWithProvider( <ReaderOnboardingRsm /> );
+
+		await screen.findByTestId( 'welcome-modal-content' );
+
+		jest.mocked( recordTracksEvent ).mockClear();
+		await user.click( screen.getByRole( 'button', { name: 'Close modal' } ) );
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith( closeEventFor( 'welcome' ) );
+	} );
+
+	it( 'records interests_modal_close when the user dismisses the interests step (X / outside click)', async () => {
+		const user = userEvent.setup();
+		renderWithProvider( <ReaderOnboardingRsm /> );
+
+		await screen.findByTestId( 'welcome-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Pick your topics' } ) );
+		await screen.findByTestId( 'interests-modal-content' );
+
+		jest.mocked( recordTracksEvent ).mockClear();
+		await user.click( screen.getByRole( 'button', { name: 'Close modal' } ) );
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith( closeEventFor( 'interests' ) );
+	} );
+
+	it( 'records discover_modal_close when the user dismisses the discover step (X / outside click)', async () => {
+		const user = userEvent.setup();
+		renderWithProvider( <ReaderOnboardingRsm /> );
+
+		await screen.findByTestId( 'welcome-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Pick your topics' } ) );
+		await screen.findByTestId( 'interests-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
+		await screen.findByTestId( 'subscribe-modal-content' );
+
+		jest.mocked( recordTracksEvent ).mockClear();
+		await user.click( screen.getByRole( 'button', { name: 'Close modal' } ) );
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith( closeEventFor( 'discover' ) );
+		expect( recordTracksEvent ).not.toHaveBeenCalledWith(
+			`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }completed`
+		);
 	} );
 } );
 

--- a/client/reader/onboarding-rsm/test/index.test.tsx
+++ b/client/reader/onboarding-rsm/test/index.test.tsx
@@ -610,6 +610,9 @@ describe( 'ReaderOnboardingRsm – onboarding completion', () => {
 		} ) );
 		// Mix of active non-self, stale (unfollowed), and self-owned to verify
 		// the filter — only the two active non-self entries should be counted.
+		// `nonSelfSubscriptionsCount` defaults to 0 here (per beforeEach), so
+		// the reported count comes from the Redux-derived count, not the
+		// TanStack-query baseline.
 		getReaderFollows.mockReturnValue( [
 			{ is_following: true, is_owner: false },
 			{ is_following: true, is_owner: false },
@@ -632,6 +635,33 @@ describe( 'ReaderOnboardingRsm – onboarding completion', () => {
 		);
 
 		getReaderFollows.mockReturnValue( [] );
+	} );
+
+	it( 'falls back to nonSelfSubscriptionsCount when the Redux follows slice has not hydrated yet', async () => {
+		// Guards the `Math.max( nonSelfSubscriptionsCount, reduxCount )` merge:
+		// if the Redux follows slice is empty (e.g. slow network, lazy load)
+		// but `useSiteSubscriptions` is already populated, the completion event
+		// should report the TanStack-query count rather than 0.
+		const { useSiteSubscriptions } = jest.requireMock(
+			'../../following/use-site-subscriptions'
+		) as { useSiteSubscriptions: jest.Mock };
+		useSiteSubscriptions.mockImplementation( () => ( {
+			isLoading: false,
+			hasNonSelfSubscriptions: true,
+			nonSelfSubscriptionsCount: 5,
+		} ) );
+		// Redux follows slice intentionally empty — default mock returns [].
+
+		const user = userEvent.setup();
+		renderWithProvider( <ReaderOnboardingRsm /> );
+
+		await navigateToSubscribeStep( user );
+		await user.click( screen.getByRole( 'button', { name: 'Finish' } ) );
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }completed`,
+			expect.objectContaining( { followed_non_self_sites_count: 5 } )
+		);
 	} );
 
 	it( 'still records completed (without re-saving preference) when the user has already completed onboarding', async () => {

--- a/client/reader/onboarding-rsm/test/index.test.tsx
+++ b/client/reader/onboarding-rsm/test/index.test.tsx
@@ -577,7 +577,7 @@ describe( 'ReaderOnboardingRsm – onboarding completion', () => {
 			`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }completed`,
 			expect.objectContaining( {
 				followed_tags_count: expect.any( Number ),
-				followed_sites_count: expect.any( Number ),
+				followed_non_self_sites_count: expect.any( Number ),
 			} )
 		);
 	} );
@@ -596,14 +596,26 @@ describe( 'ReaderOnboardingRsm – onboarding completion', () => {
 		);
 	} );
 
-	it( 'records completed with followed_tags_count and followed_sites_count reflecting the user\u2019s current follows', async () => {
+	it( 'records completed with followed_tags_count and followed_non_self_sites_count reflecting the user\u2019s current follows', async () => {
 		const { useFollowedReaderTags } = jest.requireMock( 'calypso/data/reader/use-reader-tags' ) as {
 			useFollowedReaderTags: jest.Mock;
 		};
+		const { getReaderFollows } = jest.requireMock( 'calypso/state/reader/follows/selectors' ) as {
+			getReaderFollows: jest.Mock;
+		};
+
 		useFollowedReaderTags.mockImplementation( () => ( {
 			data: [ { slug: 'tech' }, { slug: 'food' } ],
 			isPending: false,
 		} ) );
+		// Mix of active non-self, stale (unfollowed), and self-owned to verify
+		// the filter — only the two active non-self entries should be counted.
+		getReaderFollows.mockReturnValue( [
+			{ is_following: true, is_owner: false },
+			{ is_following: true, is_owner: false },
+			{ is_following: false, is_owner: false },
+			{ is_following: true, is_owner: true },
+		] );
 
 		const user = userEvent.setup();
 		renderWithProvider( <ReaderOnboardingRsm /> );
@@ -615,9 +627,11 @@ describe( 'ReaderOnboardingRsm – onboarding completion', () => {
 			`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }completed`,
 			expect.objectContaining( {
 				followed_tags_count: 2,
-				followed_sites_count: expect.any( Number ),
+				followed_non_self_sites_count: 2,
 			} )
 		);
+
+		getReaderFollows.mockReturnValue( [] );
 	} );
 
 	it( 'still records completed (without re-saving preference) when the user has already completed onboarding', async () => {


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # https://linear.app/a8c/issue/RSM-1203/audit-tracking-events-define-funnels-for-measurement

## Proposed Changes

Updates the tracking events in reader onboarding
* pack subscribes now trigger individual site/tag subscribe events with follow source pointing to onboarding
* following a tag on interests uses the standard tag followed event, with source attributing onboarding
* added event for selecting a blog to preview on interests page
* separate close events from continue and back events
* added subscription and tag follow counts to completion event
* removed a broken curation

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* to better monitor reader onboarding analytics

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* smoke test reader onboating on `*/reader?flags=reader/onboarding-rsm,reader/force-onboarding`
* verify tracking events fire when expected for onboarding actions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
