### PR TITLE
Preserve Telegram bot on connect

### DIFF
--- a/client/telegram-connect/controller.js
+++ b/client/telegram-connect/controller.js
@@ -36,6 +36,7 @@ export function telegramConnect( context, next ) {
 		telegramId: context.query.telegram_id,
 		token: context.query.token,
 		ts: context.query.ts,
+		bot: context.query.bot,
 	} );
 	next();
 }

--- a/client/telegram-connect/main.jsx
+++ b/client/telegram-connect/main.jsx
@@ -1,5 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import config from '@automattic/calypso-config';
+import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
@@ -21,8 +21,7 @@ import './style.scss';
 const DEVELOPER_PATH = '/me/developer';
 
 function getTelegramBotUrl( bot ) {
-	const botUsername = bot || config( 'dolly_telegram_bot_username' );
-	return botUsername ? `https://t.me/${ encodeURIComponent( botUsername ) }` : null;
+	return bot ? `https://t.me/${ encodeURIComponent( bot ) }` : null;
 }
 
 function TelegramConnectMessageLayout( { documentTitle, title, children } ) {
@@ -91,7 +90,11 @@ export default function TelegramConnectPage( { telegramId, token, ts, bot } ) {
 						TELEGRAM_TRANSIENT_NOTICE
 					)
 				);
-				setStatus( 'success' );
+				if ( bot ) {
+					setStatus( 'success' );
+				} else {
+					page.redirect( DEVELOPER_PATH );
+				}
 			} )
 			.catch( ( err ) => {
 				recordTracksEvent( 'calypso_telegram_connect_via_token_error', {

--- a/client/telegram-connect/main.jsx
+++ b/client/telegram-connect/main.jsx
@@ -1,5 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import page from '@automattic/calypso-router';
+import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
@@ -20,6 +20,11 @@ import './style.scss';
 
 const DEVELOPER_PATH = '/me/developer';
 
+function getTelegramBotUrl( bot ) {
+	const botUsername = bot || config( 'dolly_telegram_bot_username' );
+	return botUsername ? `https://t.me/${ encodeURIComponent( botUsername ) }` : null;
+}
+
 function TelegramConnectMessageLayout( { documentTitle, title, children } ) {
 	return (
 		<>
@@ -32,7 +37,7 @@ function TelegramConnectMessageLayout( { documentTitle, title, children } ) {
 	);
 }
 
-export default function TelegramConnectPage( { telegramId, token, ts } ) {
+export default function TelegramConnectPage( { telegramId, token, ts, bot } ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const displayName = useSelector( getCurrentUserDisplayName );
@@ -48,6 +53,7 @@ export default function TelegramConnectPage( { telegramId, token, ts } ) {
 	const [ hasStarted, setHasStarted ] = useState( false );
 
 	const showProgress = status === 'loading' || status === 'success';
+	const telegramBotUrl = getTelegramBotUrl( bot );
 
 	useInterval(
 		() => setTick( ( t ) => t + 1 ),
@@ -68,7 +74,12 @@ export default function TelegramConnectPage( { telegramId, token, ts } ) {
 		wpcom.req
 			.post(
 				{ path: '/telegram-bot/connect-via-token', apiNamespace: 'wpcom/v2' },
-				{ telegram_id: telegramId, token, ts }
+				{
+					telegram_id: telegramId,
+					token,
+					ts,
+					...( bot ? { bot } : {} ),
+				}
 			)
 			.then( () => {
 				recordTracksEvent( 'calypso_telegram_connect_via_token_success', {
@@ -81,7 +92,6 @@ export default function TelegramConnectPage( { telegramId, token, ts } ) {
 					)
 				);
 				setStatus( 'success' );
-				page.redirect( DEVELOPER_PATH );
 			} )
 			.catch( ( err ) => {
 				recordTracksEvent( 'calypso_telegram_connect_via_token_error', {
@@ -96,7 +106,7 @@ export default function TelegramConnectPage( { telegramId, token, ts } ) {
 				);
 				setStatus( 'error' );
 			} );
-	}, [ telegramId, token, ts, dispatch, translate ] );
+	}, [ telegramId, token, ts, bot, dispatch, translate ] );
 
 	if ( status === 'confirm' ) {
 		const title = username
@@ -139,6 +149,27 @@ export default function TelegramConnectPage( { telegramId, token, ts } ) {
 					{ translate( 'Go to Developer Features' ) }
 				</Button>
 			</TelegramConnectMessageLayout>
+		);
+	}
+
+	if ( status === 'success' ) {
+		const title = translate( 'Telegram connected successfully.' );
+		return (
+			<>
+				<DocumentHead title={ title } />
+				<EmptyContent
+					title={ title }
+					action={
+						telegramBotUrl ? (
+							<Button primary className="empty-content__action" href={ telegramBotUrl }>
+								{ translate( 'Return to Telegram' ) }
+							</Button>
+						) : null
+					}
+					secondaryAction={ translate( 'Go to Developer Features' ) }
+					secondaryActionURL={ DEVELOPER_PATH }
+				/>
+			</>
 		);
 	}
 


### PR DESCRIPTION
This will be a nicer experience when connecting telegram. It offers redirection back tot he original bot, not developer features

## Testing instructions

Disconnect

<img width="557" height="384" alt="Zrzut ekranu 2026-05-20 o 18 39 02" src="https://github.com/user-attachments/assets/6f86fde8-b99f-4eab-acf9-78ac26e84dda" />


Then copy the url replace with your built calypso and go

You should see

<img width="1448" height="515" alt="Zrzut ekranu 2026-05-20 o 18 38 00" src="https://github.com/user-attachments/assets/8170a13a-7b1f-450a-82ab-97e6f3207f09" />


Click back to telegram, be connected
