### PR TITLE
Onboarding plans: redirect free plan selections to choose test

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -70,9 +70,9 @@ const onboarding: FlowV2< typeof initialize > = {
 			setHideFreePlan,
 		} = useDispatch( ONBOARD_STORE ) as OnboardActions;
 		const locale = useFlowLocale();
-		const { signupDomainOrigin, planCartItem, blueprint } = useSelect(
+		// Restore `signupDomainOrigin` here if the PWYW /choose A/B test is reverted in the 'plans' submit case below.
+		const { planCartItem, blueprint } = useSelect(
 			( select ) => ( {
-				signupDomainOrigin: ( select( ONBOARD_STORE ) as OnboardSelect ).getSignupDomainOrigin(),
 				planCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getPlanCartItem(),
 				blueprint: ( select( ONBOARD_STORE ) as OnboardSelect ).getBlueprint(),
 			} ),
@@ -194,15 +194,22 @@ const onboarding: FlowV2< typeof initialize > = {
 					setPlanCartItem( pickedPlan );
 
 					if ( ! pickedPlan ) {
+						// Redirect free plan selections to /choose for the PWYW A/B test.
+						// See https://radicalupdates.wordpress.com/2026/05/07/pwyw-pick-your-reward-on-dotcom/
+						// If we end the A/B test without shipping it, restore the
+						// commented-out block below and remove this redirect.
+						window.location.assign( '/choose' );
+						return;
+
 						// Since we're removing the paid domain, it means that the user chose to continue
 						// with a free domain. Because signupDomainOrigin should reflect the last domain
 						// selection status before they land on the checkout page, this value can be
 						// 'free' or 'choose-later'
-						if ( signupDomainOrigin === 'choose-later' ) {
-							setSignupDomainOrigin( signupDomainOrigin );
-						} else {
-							setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.FREE );
-						}
+						// if ( signupDomainOrigin === 'choose-later' ) {
+						// 	setSignupDomainOrigin( signupDomainOrigin );
+						// } else {
+						// 	setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.FREE );
+						// }
 					}
 
 					// Make sure to put the rest of products into the cart, e.g. the storage add-ons.

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -195,10 +195,11 @@ const onboarding: FlowV2< typeof initialize > = {
 
 					if ( ! pickedPlan ) {
 						// Redirect free plan selections to /choose for the PWYW A/B test.
-						// See https://radicalupdates.wordpress.com/2026/05/07/pwyw-pick-your-reward-on-dotcom/
 						// If we end the A/B test without shipping it, restore the
 						// commented-out block below and remove this redirect.
-						window.location.assign( '/choose' );
+						window.location.assign(
+							addQueryArgs( '/choose', getQueryArgs( window.location.href ) )
+						);
 						return;
 
 						// Since we're removing the paid domain, it means that the user chose to continue


### PR DESCRIPTION


## Proposed Changes

* When a user clicks **Start with Free** (or the deemphasized **start with our free plan** subheader link) on `/setup/onboarding/plans`, redirect them to `wordpress.com/choose` instead of continuing through site creation.

The previous behavior (setting `signupDomainOrigin` and proceeding to `create-site`) is preserved as a commented-out block so we can revert quickly if the A/B test doesn't win.

## Why are these changes being made?

* Following Aaron's recommendation
* The A/B bucketing happens on `/choose` itself, so we just need to route free-plan clicks there.

## Testing Instructions

* Visit `/setup/onboarding/plans` (after the domain step).
* Click **Start with Free**. Verify you land on `/choose`.
* Click any paid plan card. Verify the regular checkout flow still works.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?