### PR TITLE
logToLogstash: capture rejections to Sentry

### DIFF
--- a/client/lib/logstash/index.ts
+++ b/client/lib/logstash/index.ts
@@ -1,3 +1,4 @@
+import { captureException } from '@automattic/calypso-sentry';
 import wpcom from 'calypso/lib/wp';
 
 /**
@@ -21,7 +22,14 @@ interface LogToLogstashParams {
 /**
  * Log to logstash. This function is inefficient because
  * the data goes over the REST API, so use sparingly.
+ *
+ * Rejections from the underlying request are reported to Sentry so callers can
+ * keep the fire-and-forget pattern without producing unhandled promise rejections.
  */
 export async function logToLogstash( params: LogToLogstashParams ): Promise< void > {
-	await wpcom.req.post( '/logstash', { params: JSON.stringify( params ) } );
+	try {
+		await wpcom.req.post( '/logstash', { params: JSON.stringify( params ) } );
+	} catch ( error ) {
+		captureException( error );
+	}
 }


### PR DESCRIPTION
## Proposed Changes

* Wrap the underlying request in `logToLogstash` with `try/catch` and pipe rejections to `captureException`.

## Why are these changes being made?

`logToLogstash` is used in 40+ call sites as fire-and-forget. Today, if the request rejects (network error, 5xx from `/logstash`), the rejection floats as an unhandled promise rejection. Surfacing those to Sentry (a) preserves visibility into pipeline failures and (b) lets callers keep the bare `logToLogstash({...})` form without each one needing its own `.catch`.

This unblocks tests that exercise the failure path of `logToLogstash` (DOTMSD-1229) — once this lands, the per-call `.catch(() => {})` added there can be removed.

## Testing Instructions

* No UI surface. `yarn eslint client/lib/logstash/index.ts` is clean (pre-existing `any` warnings only).
* To verify the new behavior manually: stub `wpcom.req.post` to reject and observe a Sentry capture call.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?