### PR TITLE
Cancel/refund: blend split-cancel-remove A/B test variants

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -117,6 +117,7 @@ type TopNoticeArgs = {
 	displayVariant: DisplayVariant;
 	purchase: Purchase;
 	intent: CancelIntent | null;
+	isSplitCancelRemoveEnabled: boolean;
 };
 
 /**
@@ -126,15 +127,32 @@ type TopNoticeArgs = {
 const CACHE_GUARD_DURATION_MS = 15_000;
 
 function renderTopNotice( args: TopNoticeArgs ) {
-	const { surveyShown, showDomainOptionsStep, displayVariant, purchase, intent } = args;
+	const {
+		surveyShown,
+		showDomainOptionsStep,
+		displayVariant,
+		purchase,
+		intent,
+		isSplitCancelRemoveEnabled,
+	} = args;
 
 	if ( surveyShown || showDomainOptionsStep ) {
 		return null;
 	}
 
+	// Intent-cancel with a refund (flag-on) → promo notice with inline link to
+	// switch the user into the remove flow.
+	if (
+		isSplitCancelRemoveEnabled &&
+		displayVariant === 'cancel' &&
+		hasAmountAvailableToRefund( purchase )
+	) {
+		return <RefundEligibilityNotice mode="refund-eligibility" purchase={ purchase } />;
+	}
+
 	// Intent-remove with a refund → confirmed refund-amount notice (no CTA).
 	if ( displayVariant === 'remove' && hasAmountAvailableToRefund( purchase ) ) {
-		return <RefundEligibilityNotice purchase={ purchase } />;
+		return <RefundEligibilityNotice mode="confirmed" purchase={ purchase } />;
 	}
 
 	// Everything else → time-remaining notice (itself suppressed on
@@ -1652,6 +1670,7 @@ function CancelPurchaseInner() {
 				displayVariant,
 				purchase,
 				intent,
+				isSplitCancelRemoveEnabled,
 			} ) }
 		>
 			{ isSolutionsStep ? (

--- a/client/dashboard/me/billing-purchases/cancel-purchase/refund-eligibility-notice.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/refund-eligibility-notice.tsx
@@ -25,21 +25,25 @@ export default function RefundEligibilityNotice( props: RefundEligibilityNoticeP
 
 	if ( props.mode === 'refund-eligibility' ) {
 		return (
-			<Notice variant="info">
+			<Notice
+				variant="info"
+				actions={
+					<Link
+						to={ cancelPurchaseRoute.fullPath }
+						params={ { purchaseId: String( purchase.ID ) } }
+						search={ { intent: 'remove' as const } }
+					>
+						{ __( 'Remove plan and claim refund.' ) }
+					</Link>
+				}
+			>
 				{ sprintf(
 					/* translators: %(refundAmount)s is a monetary amount, e.g. "$96.00" */
 					__(
 						'You’re eligible for a %(refundAmount)s refund if you remove your plan now. Your features will be unavailable right away.'
 					),
 					{ refundAmount }
-				) }{ ' ' }
-				<Link
-					to={ cancelPurchaseRoute.fullPath }
-					params={ { purchaseId: String( purchase.ID ) } }
-					search={ { intent: 'remove' as const } }
-				>
-					{ __( 'Remove plan and claim refund.' ) }
-				</Link>
+				) }
 			</Notice>
 		);
 	}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/refund-eligibility-notice.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/refund-eligibility-notice.tsx
@@ -40,6 +40,7 @@ export default function RefundEligibilityNotice( props: RefundEligibilityNoticeP
 				>
 					{ __( 'Remove plan and claim refund' ) }
 				</Link>
+				.
 			</Notice>
 		);
 	}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/refund-eligibility-notice.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/refund-eligibility-notice.tsx
@@ -38,9 +38,8 @@ export default function RefundEligibilityNotice( props: RefundEligibilityNoticeP
 					params={ { purchaseId: String( purchase.ID ) } }
 					search={ { intent: 'remove' as const } }
 				>
-					{ __( 'Remove plan and claim refund' ) }
+					{ __( 'Remove plan and claim refund.' ) }
 				</Link>
-				.
 			</Notice>
 		);
 	}

--- a/client/dashboard/me/billing-purchases/cancel-purchase/refund-eligibility-notice.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/refund-eligibility-notice.tsx
@@ -1,14 +1,19 @@
+import { Link } from '@tanstack/react-router';
+import { __, sprintf } from '@wordpress/i18n';
+import { cancelPurchaseRoute } from '../../../app/router/me';
 import Notice from '../../../components/notice';
 import { hasAmountAvailableToRefund } from '../../../utils/purchase';
 import { getRefundNoticeCopy } from './get-confirmation-copy';
 import RefundAmountString from './refund-amount-string';
 import type { Purchase } from '@automattic/api-core';
 
-interface RefundEligibilityNoticeProps {
-	purchase: Purchase;
-}
+type RefundEligibilityNoticeProps =
+	| { mode?: 'confirmed'; purchase: Purchase }
+	| { mode: 'refund-eligibility'; purchase: Purchase };
 
-export default function RefundEligibilityNotice( { purchase }: RefundEligibilityNoticeProps ) {
+export default function RefundEligibilityNotice( props: RefundEligibilityNoticeProps ) {
+	const { purchase } = props;
+
 	if ( ! hasAmountAvailableToRefund( purchase ) ) {
 		return null;
 	}
@@ -16,6 +21,27 @@ export default function RefundEligibilityNotice( { purchase }: RefundEligibility
 	const refundAmount = RefundAmountString( { purchase, cancelBundledDomain: false } );
 	if ( ! refundAmount ) {
 		return null;
+	}
+
+	if ( props.mode === 'refund-eligibility' ) {
+		return (
+			<Notice variant="info">
+				{ sprintf(
+					/* translators: %(refundAmount)s is a monetary amount, e.g. "$96.00" */
+					__(
+						'You’re eligible for a %(refundAmount)s refund if you remove your plan now. Your features will be unavailable right away.'
+					),
+					{ refundAmount }
+				) }{ ' ' }
+				<Link
+					to={ cancelPurchaseRoute.fullPath }
+					params={ { purchaseId: String( purchase.ID ) } }
+					search={ { intent: 'remove' as const } }
+				>
+					{ __( 'Remove plan and claim refund' ) }
+				</Link>
+			</Notice>
+		);
 	}
 
 	return <Notice variant="info">{ getRefundNoticeCopy( { purchase, refundAmount } ) }</Notice>;

--- a/client/dashboard/me/billing-purchases/cancel-purchase/test/refund-eligibility-notice.test.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/test/refund-eligibility-notice.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen } from '@testing-library/react';
+import { render } from '../../../../test-utils';
+import RefundEligibilityNotice from '../refund-eligibility-notice';
+import type { Purchase } from '@automattic/api-core';
+
+function makeRefundablePurchase( overrides: Partial< Purchase > = {} ): Purchase {
+	return {
+		ID: 123,
+		product_name: 'WordPress.com Business',
+		product_slug: 'business-bundle',
+		is_plan: true,
+		refund_integer: 9600,
+		total_refund_integer: 9600,
+		total_refund_currency: 'USD',
+		refund_amount: 96,
+		...overrides,
+	} as Purchase;
+}
+
+describe( '<RefundEligibilityNotice />', () => {
+	test( 'confirmed mode renders refund copy without an inline link', () => {
+		render( <RefundEligibilityNotice purchase={ makeRefundablePurchase() } /> );
+
+		expect(
+			screen.getByText( /You’ll receive a \$96\.00 refund when you remove your plan\./ )
+		).toBeVisible();
+		expect( screen.queryByRole( 'link', { name: /remove plan and claim refund/i } ) ).toBeNull();
+	} );
+
+	test( 'refund-eligibility mode renders promo copy and a link to ?intent=remove', () => {
+		render(
+			<RefundEligibilityNotice mode="refund-eligibility" purchase={ makeRefundablePurchase() } />
+		);
+
+		expect(
+			screen.getByText( /You’re eligible for a \$96\.00 refund if you remove your plan now\./ )
+		).toBeVisible();
+		const link = screen.getByRole( 'link', { name: /remove plan and claim refund/i } );
+		expect( link ).toBeVisible();
+		expect( link ).toHaveAttribute( 'href', expect.stringContaining( 'intent=remove' ) );
+	} );
+
+	test( 'returns null when no refund is available', () => {
+		const { container } = render(
+			<RefundEligibilityNotice
+				mode="refund-eligibility"
+				purchase={ makeRefundablePurchase( {
+					refund_integer: 0,
+					total_refund_integer: 0,
+					refund_amount: 0,
+				} ) }
+			/>
+		);
+		expect( container ).toBeEmptyDOMElement();
+	} );
+} );

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -308,7 +308,13 @@ function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase } ) {
 		// delete endpoints all accept the call in pending-renewal state, so we
 		// don't need to special-case it.
 		const showCancel = autoRenewOn && ! isTransferNonRefundable;
-		const showRemove = ! autoRenewOn || hasRefund;
+		// When auto-renew is on and a refund is available we used to show both
+		// Cancel and Remove side-by-side. Per the blended treatment the entry
+		// point is now a single "Cancel" CTA; the refund path is surfaced inside
+		// the cancel flow via RefundEligibilityNotice. Remove only appears when
+		// auto-renew is already off (cancelled subscriptions awaiting removal,
+		// expired-grace, etc.).
+		const showRemove = ! autoRenewOn;
 
 		if ( ! showCancel && ! showRemove ) {
 			return null;

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -303,17 +303,15 @@ function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase } ) {
 		const isTransferNonRefundable = isDomainTransfer( purchase ) && ! hasRefund;
 		// Visibility is driven purely by what the user controls:
 		// - Cancel: auto-renew is on (stopping it halts any upcoming retry too).
-		// - Remove: auto-renew is off, or a refund is available (dual-button).
+		// - Remove: auto-renew is already off (cancelled subscriptions awaiting
+		//   removal, expired-grace, etc.).
+		// When a refund is available with auto-renew still on, the refund path is
+		// surfaced inside the cancel flow via RefundEligibilityNotice instead of
+		// a second CTA here.
 		// Verified against wpcom-billing backend — cancel / disable-auto-renew /
 		// delete endpoints all accept the call in pending-renewal state, so we
 		// don't need to special-case it.
 		const showCancel = autoRenewOn && ! isTransferNonRefundable;
-		// When auto-renew is on and a refund is available we used to show both
-		// Cancel and Remove side-by-side. Per the blended treatment the entry
-		// point is now a single "Cancel" CTA; the refund path is surfaced inside
-		// the cancel flow via RefundEligibilityNotice. Remove only appears when
-		// auto-renew is already off (cancelled subscriptions awaiting removal,
-		// expired-grace, etc.).
 		const showRemove = ! autoRenewOn;
 
 		if ( ! showCancel && ! showRemove ) {

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -1364,23 +1364,6 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 					/>
 
 					{ ! this.state.showDomainOptionsStep &&
-						this.props.isSplitCancelRemoveEnabled &&
-						refundAmountString &&
-						intent === 'cancel' && (
-							<RefundEligibilityNotice
-								mode="refund-eligibility"
-								refundAmount={ refundAmountString }
-								purchase={ purchase }
-							/>
-						) }
-					{ ! this.state.showDomainOptionsStep && refundAmountString && intent === 'remove' && (
-						<RefundEligibilityNotice
-							refundAmount={ refundAmountString }
-							mode="confirmed"
-							purchase={ purchase }
-						/>
-					) }
-					{ ! this.state.showDomainOptionsStep &&
 						( ! refundAmountString ||
 							intent === 'auto-renew' ||
 							( intent === 'cancel' && ! this.props.isSplitCancelRemoveEnabled ) ) && (
@@ -1393,6 +1376,23 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 
 					<div className="cancel-purchase__inner-wrapper">
 						<div className="cancel-purchase__left">
+							{ ! this.state.showDomainOptionsStep &&
+								this.props.isSplitCancelRemoveEnabled &&
+								refundAmountString &&
+								intent === 'cancel' && (
+									<RefundEligibilityNotice
+										mode="refund-eligibility"
+										refundAmount={ refundAmountString }
+										purchase={ purchase }
+									/>
+								) }
+							{ ! this.state.showDomainOptionsStep && refundAmountString && intent === 'remove' && (
+								<RefundEligibilityNotice
+									refundAmount={ refundAmountString }
+									mode="confirmed"
+									purchase={ purchase }
+								/>
+							) }
 							{ this.state.showDomainOptionsStep
 								? this.renderDomainOptionsContent()
 								: this.renderMainContent() }

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -1363,6 +1363,17 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 						align="left"
 					/>
 
+					{ ! this.state.showDomainOptionsStep &&
+						this.props.isSplitCancelRemoveEnabled &&
+						refundAmountString &&
+						intent === 'cancel' && (
+							<RefundEligibilityNotice
+								mode="refund-eligibility"
+								refundAmount={ refundAmountString }
+								purchase={ purchase }
+								siteSlug={ this.props.siteSlug }
+							/>
+						) }
 					{ ! this.state.showDomainOptionsStep && refundAmountString && intent === 'remove' && (
 						<RefundEligibilityNotice
 							refundAmount={ refundAmountString }
@@ -1371,7 +1382,9 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 						/>
 					) }
 					{ ! this.state.showDomainOptionsStep &&
-						( ! refundAmountString || intent === 'cancel' || intent === 'auto-renew' ) && (
+						( ! refundAmountString ||
+							intent === 'auto-renew' ||
+							( intent === 'cancel' && ! this.props.isSplitCancelRemoveEnabled ) ) && (
 							<TimeRemainingNotice
 								purchase={ purchase }
 								displayVariant={ displayVariant }

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -1371,7 +1371,6 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 								mode="refund-eligibility"
 								refundAmount={ refundAmountString }
 								purchase={ purchase }
-								siteSlug={ this.props.siteSlug }
 							/>
 						) }
 					{ ! this.state.showDomainOptionsStep && refundAmountString && intent === 'remove' && (

--- a/client/me/purchases/cancel-purchase/refund-eligibility-notice.tsx
+++ b/client/me/purchases/cancel-purchase/refund-eligibility-notice.tsx
@@ -10,11 +10,11 @@ import type { Purchases } from '@automattic/data-stores';
 interface RefundEligibilityNoticeBaseProps {
 	refundAmount: string;
 	purchase: Purchases.Purchase;
-	siteSlug?: string;
 }
 
 interface RefundEligibilityNoticeRefundEligibilityProps extends RefundEligibilityNoticeBaseProps {
 	mode?: 'refund-eligibility';
+	siteSlug: string;
 }
 
 interface RefundEligibilityNoticeConfirmedProps extends RefundEligibilityNoticeBaseProps {
@@ -41,11 +41,7 @@ const RefundEligibilityNotice = ( props: RefundEligibilityNoticeProps ) => {
 		);
 	}
 
-	const onRemoveClick = ( event: React.MouseEvent ) => {
-		event.preventDefault();
-		if ( ! props.siteSlug ) {
-			return;
-		}
+	const onRemoveClick = () => {
 		page( `${ cancelPurchase( props.siteSlug, props.purchase.id ) }?intent=remove` );
 	};
 

--- a/client/me/purchases/cancel-purchase/refund-eligibility-notice.tsx
+++ b/client/me/purchases/cancel-purchase/refund-eligibility-notice.tsx
@@ -3,7 +3,6 @@ import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import Notice from 'calypso/components/notice';
 import { getRefundNoticeCopy } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy';
-import { cancelPurchase } from 'calypso/me/purchases/paths';
 import { toPurchaseForCopy } from './to-purchase-for-copy';
 import type { Purchases } from '@automattic/data-stores';
 
@@ -14,7 +13,6 @@ interface RefundEligibilityNoticeBaseProps {
 
 interface RefundEligibilityNoticeRefundEligibilityProps extends RefundEligibilityNoticeBaseProps {
 	mode?: 'refund-eligibility';
-	siteSlug: string;
 }
 
 interface RefundEligibilityNoticeConfirmedProps extends RefundEligibilityNoticeBaseProps {
@@ -42,7 +40,7 @@ const RefundEligibilityNotice = ( props: RefundEligibilityNoticeProps ) => {
 	}
 
 	const onRemoveClick = () => {
-		page( `${ cancelPurchase( props.siteSlug, props.purchase.id ) }?intent=remove` );
+		page( `${ window.location.pathname }?intent=remove` );
 	};
 
 	return (
@@ -62,6 +60,7 @@ const RefundEligibilityNotice = ( props: RefundEligibilityNoticeProps ) => {
 				>
 					{ translate( 'Remove plan and claim refund' ) }
 				</Button>
+				.
 			</p>
 		</Notice>
 	);

--- a/client/me/purchases/cancel-purchase/refund-eligibility-notice.tsx
+++ b/client/me/purchases/cancel-purchase/refund-eligibility-notice.tsx
@@ -1,27 +1,28 @@
+import page from '@automattic/calypso-router';
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import Notice from 'calypso/components/notice';
 import { getRefundNoticeCopy } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy';
-import CancelPurchaseButton from './button';
+import { cancelPurchase } from 'calypso/me/purchases/paths';
 import { toPurchaseForCopy } from './to-purchase-for-copy';
-import type { CancelPurchaseButtonProps } from './button';
 import type { Purchases } from '@automattic/data-stores';
-import type moment from 'moment';
 
-interface RefundEligibilityNoticePromoProps {
+interface RefundEligibilityNoticeBaseProps {
 	refundAmount: string;
-	mode?: 'promo';
-	cancelButtonProps: CancelPurchaseButtonProps & { moment: typeof moment };
+	purchase: Purchases.Purchase;
+	siteSlug?: string;
 }
 
-interface RefundEligibilityNoticeConfirmedProps {
-	refundAmount: string;
+interface RefundEligibilityNoticeRefundEligibilityProps extends RefundEligibilityNoticeBaseProps {
+	mode?: 'refund-eligibility';
+}
+
+interface RefundEligibilityNoticeConfirmedProps extends RefundEligibilityNoticeBaseProps {
 	mode: 'confirmed';
-	purchase: Purchases.Purchase;
-	cancelButtonProps?: never;
 }
 
 type RefundEligibilityNoticeProps =
-	| RefundEligibilityNoticePromoProps
+	| RefundEligibilityNoticeRefundEligibilityProps
 	| RefundEligibilityNoticeConfirmedProps;
 
 const RefundEligibilityNotice = ( props: RefundEligibilityNoticeProps ) => {
@@ -40,6 +41,14 @@ const RefundEligibilityNotice = ( props: RefundEligibilityNoticeProps ) => {
 		);
 	}
 
+	const onRemoveClick = ( event: React.MouseEvent ) => {
+		event.preventDefault();
+		if ( ! props.siteSlug ) {
+			return;
+		}
+		page( `${ cancelPurchase( props.siteSlug, props.purchase.id ) }?intent=remove` );
+	};
+
 	return (
 		<Notice className="cancel-purchase__refund-eligibility-notice" showDismiss={ false }>
 			<p className="cancel-purchase__refund-eligibility-text">
@@ -50,13 +59,13 @@ const RefundEligibilityNotice = ( props: RefundEligibilityNoticeProps ) => {
 						context: 'refundText is a monetary amount in the form "[currency-symbol][amount]"',
 					}
 				) }{ ' ' }
-				<CancelPurchaseButton
-					{ ...props.cancelButtonProps }
-					textVariant="remove-plan-and-claim-refund"
-					isLinkStyle
-					isInline
-					cancelIntentOverride="refund"
-				/>
+				<Button
+					variant="link"
+					className="cancel-purchase__refund-eligibility-link"
+					onClick={ onRemoveClick }
+				>
+					{ translate( 'Remove plan and claim refund' ) }
+				</Button>
 			</p>
 		</Notice>
 	);

--- a/client/me/purchases/cancel-purchase/refund-eligibility-notice.tsx
+++ b/client/me/purchases/cancel-purchase/refund-eligibility-notice.tsx
@@ -58,9 +58,8 @@ const RefundEligibilityNotice = ( props: RefundEligibilityNoticeProps ) => {
 					className="cancel-purchase__refund-eligibility-link"
 					onClick={ onRemoveClick }
 				>
-					{ translate( 'Remove plan and claim refund' ) }
+					{ translate( 'Remove plan and claim refund.' ) }
 				</Button>
-				.
 			</p>
 		</Notice>
 	);

--- a/client/me/purchases/cancel-purchase/style.scss
+++ b/client/me/purchases/cancel-purchase/style.scss
@@ -247,7 +247,7 @@
 	display: inline;
 }
 
-.cancel-purchase__refund-eligibility-notice .cancel-purchase__button.cancel-purchase__button--link {
+.cancel-purchase__refund-eligibility-notice .cancel-purchase__refund-eligibility-link.cancel-purchase__refund-eligibility-link {
 	margin: 0;
 	background: none;
 	color: var(--color-text-inverted);

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -786,11 +786,11 @@ class ManagePurchase extends Component<
 
 		// Visibility:
 		//   Off flag → mutually exclusive with Cancel (preserves today's behavior).
-		//   On flag  → show when the subscription is already off (auto-renew off,
-		//              expired), OR when auto-renew is still on and a refund is
-		//              available (the new dual-button case alongside Cancel).
+		//   On flag  → Remove only when auto-renew is already off. The refund-eligible
+		//              case is surfaced inside the cancel flow via
+		//              RefundEligibilityNotice instead of a parallel Remove CTA.
 		if ( isSplitEnabled ) {
-			if ( autoRenewOn && ! canRefund ) {
+			if ( autoRenewOn ) {
 				return null;
 			}
 		} else if ( canAutoRenewBeTurnedOff( purchase ) ) {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/RSM-3661/

## Proposed Changes

This combines parts of both cancellation flow tests together behind the `useIsSplitCancelRemoveEnabled()` feature gating. Users with a refundable purchase with auto-renew on will see a single "Cancel Purchase" CTA on the purchase management page with a refund eligibility notice above the feature list in the first step of the cancellation flow (test 1).

Changes from test 2 include:
- cancellation immediately after confirmation in the cancellation flow
- auto-renew toggle has been returned to both Calypso and MSD
- clicking the auto-renew toggle kicks off the cancellation flow
- all loading, text, and general polish improvements from test 2 have been maintained

## Why are these changes being made?

The initial cancellation/refund test (#108541) outperformed the current split cancel/refund CTA test, but a number of flow improvements were made during the second test (loading improvements, back-end feature lists, flow navigation, text improvements, etc.).

This PR attempts to merge a combination of the two flows behind the current `useIsSplitCancelRemoveEnabled()` gating logic. We'll likely spin up a new A/B test after this merges.

## Testing Instructions

Manual matrix to verify on a refundable plan (e.g., a recent WordPress.com Business plan within the refund window):

| Surface | State | Expected on Purchase Settings | Expected on Cancel page |
| --- | --- | --- | --- |
| Dashboard | refundable, auto-renew on | Single **Cancel** CTA | `?intent=cancel` → promo refund-eligibility notice with inline "Remove plan and claim refund" link |
| Dashboard | non-refundable, auto-renew on | Single **Cancel** CTA | `?intent=cancel` → TimeRemainingNotice |
| Dashboard | auto-renew off, refundable | Single **Remove** CTA | `?intent=remove` → confirmed-mode refund notice |
| Dashboard | auto-renew off, non-refundable | Single **Remove** CTA | `?intent=remove` → TimeRemainingNotice (or none if expired) |
| Dashboard | toggle auto-renew off | n/a | `?intent=auto-renew` → TimeRemainingNotice only (no refund notice even if refundable) |
| Classic | (mirror all above) | (mirror) | (mirror) |

Cross-flow check on both surfaces: from `?intent=cancel` with a refundable plan, click the "Remove plan and claim refund" link inside the notice. The URL should switch to `?intent=remove` and the page should rerender with the confirmed-mode notice. Confirming and submitting the survey should issue the refund and remove the plan.