### PR TITLE
Experiment with hosting button in My Home header

### DIFF
--- a/client/my-sites/customer-home/components/home-content/index.jsx
+++ b/client/my-sites/customer-home/components/home-content/index.jsx
@@ -187,7 +187,7 @@ const HomeContentControl = ( {
 				compactBreadcrumb={ false }
 				navigationItems={ [] }
 				mobileItem={ null }
-				title={ translate( 'My Home' ) }
+				title={ translate( 'Home' ) }
 				subtitle={ translate( 'Your hub for next steps, support center, and quick links.' ) }
 			>
 				{ headerActions }
@@ -474,7 +474,7 @@ const HomeContentTreatment = ( {
 				compactBreadcrumb={ false }
 				navigationItems={ [] }
 				mobileItem={ null }
-				title={ translate( 'My Home' ) }
+				title={ translate( 'Home' ) }
 				subtitle={ translate( 'Your hub for next steps, support center, and quick links.' ) }
 			>
 				{ headerActions }

--- a/client/my-sites/customer-home/components/home-content/index.jsx
+++ b/client/my-sites/customer-home/components/home-content/index.jsx
@@ -174,7 +174,7 @@ const HomeContent = ( {
 						dashboardOptIn ? dashboardLink( `/sites/${ site.slug }` ) : `/overview/${ site.slug }`
 					}
 				>
-					{ dashboardOptIn ? translate( 'Hosting Dashboard' ) : translate( 'Hosting Overview' ) }
+					{ dashboardOptIn ? translate( 'Hosting Dashboard' ) : translate( 'Site Management' ) }
 				</Button>
 			) }
 		</>

--- a/client/my-sites/customer-home/components/home-content/index.jsx
+++ b/client/my-sites/customer-home/components/home-content/index.jsx
@@ -187,7 +187,7 @@ const HomeContentControl = ( {
 				compactBreadcrumb={ false }
 				navigationItems={ [] }
 				mobileItem={ null }
-				title={ translate( 'Home' ) }
+				title={ translate( 'Your Home' ) }
 				subtitle={ translate( 'Your hub for next steps, support center, and quick links.' ) }
 			>
 				{ headerActions }
@@ -474,7 +474,7 @@ const HomeContentTreatment = ( {
 				compactBreadcrumb={ false }
 				navigationItems={ [] }
 				mobileItem={ null }
-				title={ translate( 'Home' ) }
+				title={ translate( 'Your Home' ) }
 				subtitle={ translate( 'Your hub for next steps, support center, and quick links.' ) }
 			>
 				{ headerActions }

--- a/client/my-sites/customer-home/components/home-content/index.jsx
+++ b/client/my-sites/customer-home/components/home-content/index.jsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent as __explatRecordExposure } from '@automattic/calypso-analytics';
 import { Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { SET_UP_EMAIL_AUTHENTICATION_FOR_YOUR_DOMAIN } from '@automattic/urls';
@@ -19,6 +20,7 @@ import useHomeLayoutQuery, { getCacheKey } from 'calypso/data/home/use-home-layo
 import { usePurchasePlanNotification } from 'calypso/landing/stepper/declarative-flow/internals/hooks/use-purchase-plan-notification';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { setDomainNotice } from 'calypso/lib/domains/set-domain-notice';
+import { useExperiment } from 'calypso/lib/explat';
 import { preventWidows } from 'calypso/lib/formatting';
 import { getQueryArgs } from 'calypso/lib/query-args';
 import Primary from 'calypso/my-sites/customer-home/locations/primary';
@@ -59,7 +61,294 @@ const loadTrackResurrections = () =>
 		/* webpackChunkName: "async-load-calypso-lib-analytics-track-resurrections" */ 'calypso/lib/analytics/track-resurrections'
 	);
 
-const HomeContent = ( {
+const HomeContentControl = ( {
+	canUserUseCustomerHome,
+	hasWooCommerceInstalled,
+	isJetpack,
+	isPossibleJetpackConnectionProblem,
+	isRequestingSitePlugins,
+	isSiteLaunching,
+	site,
+	siteId,
+	trackViewSiteAction,
+	trackStudioSyncConnectSite,
+	isSiteWooExpressEcommerceTrial,
+	ssoModuleActive,
+	fetchingJetpackModules,
+	handleVerifyIcannEmail,
+	isAdmin,
+	dashboardOptIn,
+} ) => {
+	const celebrateLaunchModalIsOpen = useSelector( ( state ) =>
+		getIsSiteLaunchCelebrationModalOpen( state, siteId )
+	);
+	const [ launchedSiteId, setLaunchedSiteId ] = useState( null );
+	const queryClient = useQueryClient();
+	const translate = useTranslate();
+	const isP2 = site?.options?.is_wpforteams_site;
+
+	const { data: layout, isLoading, error: homeLayoutError } = useHomeLayoutQuery( siteId );
+
+	const siteDomains = useSelector( ( state ) => getDomainsBySiteId( state, siteId ) );
+	const customDomains = siteDomains?.filter( ( domain ) => ! domain.isWPCOMDomain );
+	const customDomain = customDomains?.length ? customDomains[ 0 ] : undefined;
+	const primaryDomain = customDomains?.find( ( domain ) => domain.isPrimary );
+
+	const {
+		data: domainDiagnosticData,
+		isFetching: isFetchingDomainDiagnostics,
+		refetch: refetchDomainDiagnosticData,
+	} = useDomainDiagnosticsQuery( primaryDomain?.name, {
+		staleTime: 5 * 60 * 1000,
+		gcTime: 5 * 60 * 1000,
+		enabled: primaryDomain !== undefined && primaryDomain.isMappedToAtomicSite,
+	} );
+	const emailDnsDiagnostics = domainDiagnosticData?.email_dns_records;
+	const [ dismissedEmailDnsDiagnostics, setDismissedEmailDnsDiagnostics ] = useState( false );
+
+	usePurchasePlanNotification( siteId, site?.plan?.product_slug );
+
+	useEffect( () => {
+		if ( ! isSiteLaunching && launchedSiteId === siteId ) {
+			queryClient.invalidateQueries( { queryKey: getCacheKey( siteId ) } );
+			setLaunchedSiteId( null );
+		}
+	}, [ isSiteLaunching, launchedSiteId, queryClient, siteId ] );
+
+	useEffect( () => {
+		if ( isSiteLaunching ) {
+			setLaunchedSiteId( siteId );
+		}
+	}, [ isSiteLaunching, siteId ] );
+
+	useEffect( () => {
+		if ( emailDnsDiagnostics?.dismissed_email_dns_issues_notice ) {
+			setDismissedEmailDnsDiagnostics( true );
+		}
+	}, [ emailDnsDiagnostics ] );
+
+	useEffect( () => {
+		const queryArgs = getQueryArgs();
+		const studioSiteId = queryArgs.studioSiteId;
+		const autoOpenPush = queryArgs.autoOpenPush === 'true';
+
+		if ( ! studioSiteId ) {
+			return;
+		}
+		trackStudioSyncConnectSite( {
+			click: false,
+			blogId: siteId,
+			studioSiteId,
+		} );
+		openSyncUrlInStudio( studioSiteId, siteId, autoOpenPush );
+	}, [ siteId, trackStudioSyncConnectSite ] );
+
+	const isFirstSecondaryCardInPrimaryLocation =
+		Array.isArray( layout?.primary ) &&
+		layout.primary.length === 0 &&
+		Array.isArray( layout?.secondary ) &&
+		layout.secondary.length > 0;
+
+	if ( ! canUserUseCustomerHome ) {
+		const title = translate( 'This page is not available on this site.' );
+		return <EmptyContent title={ preventWidows( title ) } />;
+	}
+
+	// Ecommerce Plan's Home redirects to WooCommerce Home, so we show a placeholder
+	// while doing the redirection.
+	if (
+		isSiteWooExpressEcommerceTrial &&
+		( isRequestingSitePlugins || hasWooCommerceInstalled ) &&
+		( fetchingJetpackModules || ssoModuleActive )
+	) {
+		return <WooCommerceHomePlaceholder />;
+	}
+
+	const headerActions = (
+		<>
+			<Button href={ site.URL } onClick={ trackViewSiteAction }>
+				{ translate( 'View site' ) }
+			</Button>
+			{ isAdmin && ! isP2 && (
+				<Button
+					primary
+					href={
+						dashboardOptIn ? dashboardLink( `/sites/${ site.slug }` ) : `/overview/${ site.slug }`
+					}
+				>
+					{ dashboardOptIn ? translate( 'Hosting Dashboard' ) : translate( 'Hosting Overview' ) }
+				</Button>
+			) }
+		</>
+	);
+	const header = (
+		<div className="customer-home__heading">
+			<NavigationHeader
+				compactBreadcrumb={ false }
+				navigationItems={ [] }
+				mobileItem={ null }
+				title={ translate( 'My Home' ) }
+				subtitle={ translate( 'Your hub for next steps, support center, and quick links.' ) }
+			>
+				{ headerActions }
+			</NavigationHeader>
+
+			<div className="customer-home__site-content">
+				<SiteIcon site={ site } size={ 58 } />
+				<div className="customer-home__site-info">
+					<div className="customer-home__site-title">{ site.name }</div>
+					<a
+						href={ site.URL }
+						className="customer-home__site-domain"
+						onClick={ trackViewSiteAction }
+					>
+						<span className="customer-home__site-domain-text">{ site.domain }</span>
+					</a>
+				</div>
+			</div>
+		</div>
+	);
+
+	const renderUnverifiedEmailNotice = () => {
+		if ( customDomain?.isPendingIcannVerification ) {
+			return (
+				<Notice
+					text={ translate(
+						'You must respond to the ICANN email to verify your domain email address or your domain will stop working. Please check your inbox and respond to the email.'
+					) }
+					icon="cross-circle"
+					showDismiss={ false }
+					status="is-warning"
+				>
+					<NoticeAction onClick={ () => handleVerifyIcannEmail( customDomain.name ) }>
+						{ translate( 'Resend Email' ) }
+					</NoticeAction>
+				</Notice>
+			);
+		}
+		return null;
+	};
+
+	const renderDnsSettingsDiagnosticNotice = () => {
+		if (
+			dismissedEmailDnsDiagnostics ||
+			isFetchingDomainDiagnostics ||
+			! emailDnsDiagnostics ||
+			emailDnsDiagnostics.code === 'domain_not_mapped_to_atomic_site' ||
+			emailDnsDiagnostics.all_essential_email_dns_records_are_correct
+		) {
+			return null;
+		}
+
+		return (
+			<Notice
+				text={ translate(
+					"There are some issues with your domain's email DNS settings. {{diagnosticLink}}Click here{{/diagnosticLink}} to see the full diagnostic for your domain. {{supportLink}}Learn more{{/supportLink}}.",
+					{
+						components: {
+							diagnosticLink: (
+								<a
+									href={ domainManagementEdit( siteId, primaryDomain.name, null, {
+										diagnostics: true,
+									} ) }
+								/>
+							),
+							supportLink: (
+								<a href={ localizeUrl( SET_UP_EMAIL_AUTHENTICATION_FOR_YOUR_DOMAIN ) } />
+							),
+						},
+					}
+				) }
+				icon="cross-circle"
+				showDismiss
+				onDismissClick={ () => {
+					setDismissedEmailDnsDiagnostics( true );
+					setDomainNotice( primaryDomain.name, 'email-dns-records-diagnostics', 'ignored', () => {
+						refetchDomainDiagnosticData();
+					} );
+				} }
+				status="is-warning"
+			/>
+		);
+	};
+
+	const renderStudioSyncNotice = () => {
+		const studioSiteId = getQueryArgs().studioSiteId;
+		const autoOpenPush = getQueryArgs().autoOpenPush === 'true';
+		if ( ! studioSiteId ) {
+			return null;
+		}
+
+		return (
+			<Notice
+				className="customer-home__studio-sync-notice"
+				text={ translate( 'Open your Studio site to start syncing.' ) }
+				icon="sync"
+				showDismiss={ false }
+				status="is-info"
+			>
+				<NoticeAction
+					onClick={ () => {
+						trackStudioSyncConnectSite( {
+							click: true,
+							blogId: siteId,
+							studioSiteId,
+						} );
+						openSyncUrlInStudio( studioSiteId, siteId, autoOpenPush );
+					} }
+					external
+				>
+					{ translate( 'Open Studio' ) }
+				</NoticeAction>
+			</Notice>
+		);
+	};
+
+	return (
+		<div className="customer-home__main">
+			{ siteId && isJetpack && isPossibleJetpackConnectionProblem && (
+				<JetpackConnectionHealthBanner siteId={ siteId } />
+			) }
+			{ header }
+			{ ! isLoading && ! layout && homeLayoutError ? (
+				<TrackComponentView
+					eventName="calypso_customer_home_my_site_view_layout_error"
+					eventProperties={ {
+						site_id: siteId,
+						error: homeLayoutError?.message ?? 'Layout is not available.',
+					} }
+				/>
+			) : null }
+
+			{ renderStudioSyncNotice() }
+			{ renderUnverifiedEmailNotice() }
+			{ renderDnsSettingsDiagnosticNotice() }
+
+			{ isLoading && <div className="customer-home__loading-placeholder"></div> }
+			{ ! isLoading && layout && ! homeLayoutError ? (
+				<>
+					<Primary cards={ layout?.primary } />
+					<div className="customer-home__layout">
+						<div className="customer-home__layout-col customer-home__layout-col-left">
+							<Secondary
+								cards={ layout?.secondary }
+								siteId={ siteId }
+								trackFirstCardAsPrimary={ isFirstSecondaryCardInPrimaryLocation }
+							/>
+						</div>
+						<div className="customer-home__layout-col customer-home__layout-col-right">
+							<Tertiary cards={ layout?.tertiary } />
+						</div>
+					</div>
+				</>
+			) : null }
+			<ResurrectedWelcomeModalGate isSuppressed={ celebrateLaunchModalIsOpen } />
+			<AsyncLoad require={ loadTrackResurrections } placeholder={ null } />
+		</div>
+	);
+};
+
+const HomeContentTreatment = ( {
 	canUserUseCustomerHome,
 	hasWooCommerceInstalled,
 	isJetpack,
@@ -344,6 +633,30 @@ const HomeContent = ( {
 			<AsyncLoad require={ loadTrackResurrections } placeholder={ null } />
 		</div>
 	);
+};
+
+const HomeContent = ( props ) => {
+	const [ __explatLoading, __explatVariation ] = useExperiment(
+		'wpcom_wp_myhome_hosting_button_202605'
+	);
+	useEffect( () => {
+		if ( __explatLoading ) {
+			return;
+		}
+		if ( ! __explatVariation ) {
+			return;
+		}
+		__explatRecordExposure( 'wpcom_myhome_hosting_button_view', {
+			experiment_variation: __explatVariation,
+		} );
+	}, [ __explatLoading, __explatVariation ] );
+	if ( __explatLoading ) {
+		return null;
+	}
+	if ( __explatVariation === 'treatment' ) {
+		return HomeContentTreatment( props );
+	}
+	return HomeContentControl( props );
 };
 
 const mapStateToProps = ( state ) => {

--- a/client/my-sites/customer-home/components/home-content/style.scss
+++ b/client/my-sites/customer-home/components/home-content/style.scss
@@ -76,6 +76,20 @@ body.is-section-home.theme-default.color-scheme {
 		}
 	}
 
+	.navigation-header__actions .button:not(.is-primary) {
+		background-color: var(--studio-green-50);
+		border-color: var(--studio-green-50);
+		color: var(--studio-white);
+
+		&:hover,
+		&:focus {
+			background-color: var(--studio-green-60);
+			border-color: var(--studio-green-60);
+			color: var(--studio-white);
+			box-shadow: 0 0 0 2px var(--studio-green-20);
+		}
+	}
+
 }
 
 .customer-home__heading + .customer-home__layout {

--- a/client/my-sites/customer-home/components/home-content/style.scss
+++ b/client/my-sites/customer-home/components/home-content/style.scss
@@ -77,16 +77,16 @@ body.is-section-home.theme-default.color-scheme {
 	}
 
 	.navigation-header__actions .button:not(.is-primary) {
-		background-color: var(--studio-green-50);
-		border-color: var(--studio-green-50);
-		color: var(--studio-white);
+		background-color: var(--studio-white);
+		border-color: var(--studio-gray-10);
+		color: var(--studio-gray-90);
 
 		&:hover,
 		&:focus {
-			background-color: var(--studio-green-60);
-			border-color: var(--studio-green-60);
-			color: var(--studio-white);
-			box-shadow: 0 0 0 2px var(--studio-green-20);
+			background-color: var(--studio-white);
+			border-color: var(--studio-gray-30);
+			color: var(--studio-gray-90);
+			box-shadow: 0 0 0 2px var(--studio-gray-5);
 		}
 	}
 

--- a/client/my-sites/customer-home/locations/card-components.ts
+++ b/client/my-sites/customer-home/locations/card-components.ts
@@ -4,15 +4,6 @@ import {
 	FEATURE_READER,
 	FEATURE_STATS,
 	FEATURE_SUPPORT,
-	LAUNCHPAD_ENTREPRENEUR_SITE_SETUP,
-	LAUNCHPAD_INTENT_BUILD,
-	LAUNCHPAD_INTENT_FREE_NEWSLETTER,
-	LAUNCHPAD_INTENT_HOSTING,
-	LAUNCHPAD_INTENT_PAID_NEWSLETTER,
-	LAUNCHPAD_INTENT_WRITE,
-	LAUNCHPAD_PRE_LAUNCH,
-	LAUNCHPAD_LEGACY_SITE_SETUP,
-	LAUNCHPAD_POST_MIGRATION,
 	NOTICE_CELEBRATE_SITE_CREATION,
 	NOTICE_CELEBRATE_SITE_LAUNCH,
 	NOTICE_CELEBRATE_SITE_MIGRATION,
@@ -45,24 +36,11 @@ import {
 	TASK_USE_BUILT_BY,
 	TASK_VERIFY_EMAIL,
 	TASK_WEBINARS,
-	LAUNCHPAD_INTENT_NEWSLETTER_GOAL,
 } from 'calypso/my-sites/customer-home/cards/constants';
 import DomainUpsellFeature from 'calypso/my-sites/customer-home/cards/features/domain-upsell';
 import HelpSearch from 'calypso/my-sites/customer-home/cards/features/help-search';
 import ReaderCard from 'calypso/my-sites/customer-home/cards/features/reader';
 import Stats from 'calypso/my-sites/customer-home/cards/features/stats';
-import LaunchpadEntrepreneurSiteSetup from 'calypso/my-sites/customer-home/cards/launchpad/entrepreneur-site-setup';
-import LaunchpadIntentBuild from 'calypso/my-sites/customer-home/cards/launchpad/intent-build';
-import LaunchpadIntentHosting from 'calypso/my-sites/customer-home/cards/launchpad/intent-hosting';
-import {
-	LaunchpadIntentNewsletterGoal,
-	LaunchpadIntentFreeNewsletter,
-	LaunchpadIntentPaidNewsletter,
-} from 'calypso/my-sites/customer-home/cards/launchpad/intent-newsletter';
-import LaunchpadIntentWrite from 'calypso/my-sites/customer-home/cards/launchpad/intent-write';
-import { LaunchpadPostMigration } from 'calypso/my-sites/customer-home/cards/launchpad/post-migration';
-import LaunchpadPreLaunch from 'calypso/my-sites/customer-home/cards/launchpad/pre-launch';
-import { LaunchpadSiteSetup } from 'calypso/my-sites/customer-home/cards/launchpad/site-setup';
 import CelebrateSiteCopy from 'calypso/my-sites/customer-home/cards/notices/celebrate-site-copy';
 import CelebrateSiteCreation from 'calypso/my-sites/customer-home/cards/notices/celebrate-site-creation';
 import CelebrateSiteLaunch from 'calypso/my-sites/customer-home/cards/notices/celebrate-site-launch';
@@ -97,8 +75,6 @@ type CardComponentMap = Record<
 >;
 
 const PRIMARY_CARD_COMPONENTS: CardComponentMap = {
-	[ LAUNCHPAD_INTENT_BUILD ]: LaunchpadIntentBuild,
-	[ LAUNCHPAD_INTENT_HOSTING ]: LaunchpadIntentHosting,
 	[ NOTICE_CELEBRATE_SITE_COPY ]: CelebrateSiteCopy,
 	[ NOTICE_CELEBRATE_SITE_CREATION ]: CelebrateSiteCreation,
 	[ NOTICE_CELEBRATE_SITE_LAUNCH ]: CelebrateSiteLaunch,
@@ -136,16 +112,6 @@ const CARD_COMPONENTS: CardComponentMap = {
 	[ FEATURE_READER ]: ReaderCard,
 	[ FEATURE_SUPPORT ]: HelpSearch,
 	[ FEATURE_STATS ]: Stats,
-	[ LAUNCHPAD_ENTREPRENEUR_SITE_SETUP ]: LaunchpadEntrepreneurSiteSetup,
-	[ LAUNCHPAD_INTENT_BUILD ]: LaunchpadIntentBuild,
-	[ LAUNCHPAD_INTENT_FREE_NEWSLETTER ]: LaunchpadIntentFreeNewsletter,
-	[ LAUNCHPAD_INTENT_HOSTING ]: LaunchpadIntentHosting,
-	[ LAUNCHPAD_INTENT_PAID_NEWSLETTER ]: LaunchpadIntentPaidNewsletter,
-	[ LAUNCHPAD_INTENT_WRITE ]: LaunchpadIntentWrite,
-	[ LAUNCHPAD_PRE_LAUNCH ]: LaunchpadPreLaunch,
-	[ LAUNCHPAD_LEGACY_SITE_SETUP ]: LaunchpadSiteSetup,
-	[ LAUNCHPAD_INTENT_NEWSLETTER_GOAL ]: LaunchpadIntentNewsletterGoal,
-	[ LAUNCHPAD_POST_MIGRATION ]: LaunchpadPostMigration,
 	[ SECTION_BLOGGING_PROMPT ]: BloggingPrompt,
 	[ SECTION_BLOGANUARY_BLOGGING_PROMPT ]: BloggingPrompt,
 	[ SECTION_LEARN_GROW ]: LearnGrow,

--- a/client/my-sites/customer-home/locations/tertiary/manage-site/index.jsx
+++ b/client/my-sites/customer-home/locations/tertiary/manage-site/index.jsx
@@ -1,22 +1,14 @@
 import { createElement, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import useHomeLayoutQuery from 'calypso/data/home/use-home-layout-query';
-import QuickLinks from 'calypso/my-sites/customer-home/cards/actions/quick-links';
-import QuickLinksForEcommerceSites from 'calypso/my-sites/customer-home/cards/actions/quick-links-for-ecommerce-sites';
-import QuickLinksForHostedSites from 'calypso/my-sites/customer-home/cards/actions/quick-links-for-hosted-sites';
 import QuickPost from 'calypso/my-sites/customer-home/cards/actions/quick-post';
-import WpForTeamsQuickLinks from 'calypso/my-sites/customer-home/cards/actions/wp-for-teams-quick-links';
 import {
-	ACTION_QUICK_LINKS,
-	ACTION_QUICK_LINKS_FOR_HOSTED_SITES,
 	ACTION_QUICK_POST,
-	ACTION_WP_FOR_TEAMS_QUICK_LINKS,
 	FEATURE_GO_MOBILE,
 	FEATURE_QUICK_START,
 	FEATURE_SUPPORT,
 	FEATURE_SITE_PREVIEW,
 	FEATURE_STATS,
-	ACTION_QUICK_LINKS_FOR_ECOMMERCE_SITES,
 } from 'calypso/my-sites/customer-home/cards/constants';
 import AppPromo from 'calypso/my-sites/customer-home/cards/features/app-promo';
 import HelpSearch from 'calypso/my-sites/customer-home/cards/features/help-search';
@@ -32,11 +24,7 @@ const cardComponents = {
 	[ FEATURE_GO_MOBILE ]: AppPromo,
 	[ FEATURE_SUPPORT ]: HelpSearch,
 	[ FEATURE_SITE_PREVIEW ]: SitePreview,
-	[ ACTION_QUICK_LINKS ]: QuickLinks,
 	[ FEATURE_QUICK_START ]: QuickStart,
-	[ ACTION_WP_FOR_TEAMS_QUICK_LINKS ]: WpForTeamsQuickLinks,
-	[ ACTION_QUICK_LINKS_FOR_ECOMMERCE_SITES ]: QuickLinksForEcommerceSites,
-	[ ACTION_QUICK_LINKS_FOR_HOSTED_SITES ]: QuickLinksForHostedSites,
 	[ ACTION_QUICK_POST ]: QuickPost,
 	[ FEATURE_STATS ]: Stats,
 };


### PR DESCRIPTION
## Summary

Wraps the customer-home `HomeContent` component in an ExPlat gate (`wpcom_wp_myhome_hosting_button_202605`) that renders a redesigned header treatment alongside the existing control. The treatment renames the page title to "Your Home", adds a "View site" action plus a primary "Site Management"/"Hosting Dashboard" button, and styles secondary header buttons. The card registries also drop the Launchpad intent and quick-links cards from My Home for all users. The matching backend ships in `myhome-hosting-button` on Automattic/wpcom.

## Changes

- Split `HomeContent` into `HomeContentControl` and `HomeContentTreatment`, selected at runtime by the `wpcom_wp_myhome_hosting_button_202605` ExPlat experiment via `useExperiment`.
- Record a `wpcom_myhome_hosting_button_view` exposure event with `experiment_variation` once the assignment loads.
- Treatment header: title "Your Home", a "View site" button, and a primary "Site Management" (or "Hosting Dashboard" when dashboard opt-in is set) button for admins on non-P2 sites.
- Rename the control header title from "My Home" to "Your Home".
- Style non-primary header buttons with a white background, studio-gray border, and hover/focus states.
- Remove Launchpad intent cards and quick-links cards (and their imports) from the customer-home card registries and the tertiary manage-site location, affecting both variants.

## Screenshots

### Before

![Before](https://github.com/Automattic/wp-calypso/raw/bow-screenshots/myhome-hosting-button/1779302507616-0-before.jpg)

### After

![After](https://github.com/Automattic/wp-calypso/raw/bow-screenshots/myhome-hosting-button/1779302507616-1-after.jpg)

## Cross-repo PRs

This change spans multiple repositories. Review together:

- **wpcom** (Automattic/wpcom): 218984-ghe-Automattic/wpcom

## How to test

1. As an admin, visit `/home/:site` and confirm the header title reads "Your Home".
2. Force the control assignment for `wpcom_wp_myhome_hosting_button_202605` and confirm the existing My Home layout renders.
3. Force the treatment assignment and confirm the header shows "View site" plus a primary "Site Management" button (or "Hosting Dashboard" with dashboard opt-in enabled); verify the button is hidden for P2 sites and non-admins.
4. With dev tools / Tracks open, reload `/home/:site` and confirm a single `wpcom_myhome_hosting_button_view` event fires with the `experiment_variation` property.
5. Confirm secondary header buttons (e.g. "View site") render with a white background and studio-gray border, including hover/focus states.
6. Confirm Launchpad intent cards and quick-links cards no longer appear in My Home.
7. Run `yarn typecheck-client` and confirm it passes.

## Checklist

- [ ] Visual changes match the expected design
- [ ] No console errors introduced
- [ ] Tested with different user roles (if applicable)

---
_Created as a **draft** by Build on WP.com. The author will mark this ready for review when they choose to._

---

## ⚠️ SecEx pre-PR review couldn't run

BoW's mandatory pre-PR SecEx review (Anthropic claude-sonnet-4 via the wpcom `AI_Coder_Diff_Reviewer`) failed for this PR:

```
calypso: review: review_diff threw: Typed property AI_Coder_Reviewer::$logger must not be accessed before initialization | wpcom: review: review_diff threw: Typed property AI_Coder_Reviewer::$logger must not be accessed before initialization
```

The PR was created anyway so the change isn't blocked. This is typically a sandbox-side issue (PHP class bug, library missing, network blip) that BoW can't fix client-side. **Please review this diff manually** before approving — the usual SecEx automated pass did not happen.
