### PR TITLE
Dashboard: Opt SelectControl uses into __next40pxDefaultSize

### DIFF
--- a/client/dashboard/sites/performance/backend/timeframe-selector.tsx
+++ b/client/dashboard/sites/performance/backend/timeframe-selector.tsx
@@ -11,6 +11,7 @@ export default function TimeframeSelector( {
 } ) {
 	return (
 		<SelectControl
+			__next40pxDefaultSize
 			__nextHasNoMarginBottom
 			label={ __( 'Timeframe' ) }
 			hideLabelFromVision

--- a/client/dashboard/sites/settings-crontab/schedule-field.tsx
+++ b/client/dashboard/sites/settings-crontab/schedule-field.tsx
@@ -48,6 +48,7 @@ export function ScheduleField( { value, onChange, disabled }: ScheduleFieldProps
 	return (
 		<VStack spacing={ 3 }>
 			<SelectControl
+				__next40pxDefaultSize
 				label={ __( 'Schedule' ) }
 				value={ scheduleType }
 				options={ PREDEFINED_SCHEDULES }
@@ -83,6 +84,7 @@ export function ScheduleField( { value, onChange, disabled }: ScheduleFieldProps
 						} }
 					/>
 					<SelectControl
+						__next40pxDefaultSize
 						label={ __( 'Frequency' ) }
 						hideLabelFromVision
 						disabled={ disabled }


### PR DESCRIPTION
## Proposed Changes

The 36px default size for `wp.components.SelectControl` was deprecated in version 6.8 and will be removed in 7.1. The console warns on every mount:

> 36px default size for wp.components.SelectControl is deprecated since version 6.8 and will be removed in version 7.1. Note: Set the `__next40pxDefaultSize` prop to true to start opting into the new default size, which will become the default in a future version.

Two dashboard files were still emitting the warning. This PR adds `__next40pxDefaultSize` to both:

* `client/dashboard/sites/performance/backend/timeframe-selector.tsx` (APM timeframe picker)
* `client/dashboard/sites/settings-crontab/schedule-field.tsx` (Schedule + Frequency pickers on the WP-Cron settings tab; two SelectControls in the same file)

## Why are these changes being made?

To remove the deprecation warnings before they become hard errors in `@wordpress/components` 7.1. Opting in now also matches what the rest of the dashboard already does (every other SelectControl I could find under `client/dashboard/` already has the prop).

## Visual impact

Each control grows from 36px to 40px tall.

* The cron pickers stack vertically inside a `VStack`, so the extra height has no neighbour to clash with.
* The APM timeframe picker sits next to the **Start capturing** button in the page header. That button still defaults to 36px (no `__next40pxDefaultSize`). The 4px difference is the price of clearing the deprecation. If we want them perfectly aligned, a follow-up should add `__next40pxDefaultSize` to that button too - I left it alone here to keep this PR strictly scoped to the deprecation.

## Testing Instructions

1. `yarn start-dashboard`.
2. **APM**: navigate to a site's *Performance > Backend* page. Open devtools. Confirm the "36px default size..." warning no longer fires when the page loads. The timeframe dropdown is now 40px tall.
3. **Cron**: navigate to a site's *Settings > WP-Cron* page and add or edit a schedule. Confirm the same warning no longer fires, and the *Schedule* / *Frequency* dropdowns now match the rest of the form controls.
4. Run the affected tests: `yarn test-client client/dashboard/sites/performance/backend/test/index.test.tsx client/dashboard/sites/settings-crontab` - should pass (53/53 locally).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?