### PR TITLE
Reader: drop inaccurate "Reconnect" copy for Bluesky and Fediverse

### DIFF
--- a/client/reader/atmosphere/author-profile-panel.tsx
+++ b/client/reader/atmosphere/author-profile-panel.tsx
@@ -458,18 +458,13 @@ export function AuthorProfilePanel( {
 
 	const renderHeaderError = ( error: AtmosphereError ) => {
 		const noRetry = new Set< AtmosphereError[ 'kind' ] >( [
-			'auth_required',
-			'auth_failed',
 			'not_found',
 			'connection_not_found',
 			'bad_request',
-			'invalid_handle',
-			'invalid_credentials',
 		] );
 		const showRetry = ! noRetry.has( error.kind );
 		const titleByKind: Partial< Record< AtmosphereError[ 'kind' ], TranslateResult > > = {
 			not_found: translate( 'Profile not found' ),
-			auth_required: translate( 'Reconnect needed' ),
 			rate_limited: translate( 'Slow down' ),
 			upstream_unavailable: translate( 'Bluesky unreachable' ),
 		};

--- a/client/reader/atmosphere/author-profile-panel.tsx
+++ b/client/reader/atmosphere/author-profile-panel.tsx
@@ -548,6 +548,10 @@ export function AuthorProfilePanel( {
 							protocolLabel="Bluesky"
 							protocolHomeURL="/reader/atmosphere"
 							protocolHomeLabel={ translate( 'Back to ATmosphere' ) }
+							authRequiredCopy={ {
+								title: String( translate( "Couldn't load posts" ) ),
+								line: String( translate( 'Something went wrong with your Bluesky connection.' ) ),
+							} }
 						/>
 					</VStack>
 				</RepostProvider>

--- a/client/reader/atmosphere/composer-config.tsx
+++ b/client/reader/atmosphere/composer-config.tsx
@@ -221,13 +221,7 @@ function errorMessageFor( err: AtmosphereError, t: Translate ): ReactNode {
 		case 'auth_required':
 		case 'auth_failed':
 		case 'invalid_credentials':
-			return t( 'Your Bluesky connection needs to be reconnected. {{a}}Reconnect{{/a}}', {
-				components: {
-					a: <a href="/reader/atmosphere/connect" target="_blank" rel="noopener noreferrer" />,
-				},
-				comment:
-					'Composer error shown when the user’s Bluesky session expired; {{a}}…{{/a}} wraps a link to reconnect.',
-			} );
+			return t( 'Something went wrong with your Bluesky connection.' );
 		case 'reply_disabled':
 			return t( 'The author has restricted who can reply to this post.' );
 		case 'quote_disabled':

--- a/client/reader/atmosphere/followers-view.tsx
+++ b/client/reader/atmosphere/followers-view.tsx
@@ -231,6 +231,10 @@ export function FollowersView( { connectionId, actor }: Props ) {
 				protocolLabel="ATmosphere"
 				protocolHomeURL="https://bsky.app"
 				protocolHomeLabel="Bluesky"
+				authRequiredCopy={ {
+					title: String( translate( "Couldn't load followers" ) ),
+					line: String( translate( 'Something went wrong with your Bluesky connection.' ) ),
+				} }
 				header={ {
 					displayName: profileQuery.data?.display_name ?? null,
 					handle: profileQuery.data?.handle ?? actor,

--- a/client/reader/atmosphere/following-view.tsx
+++ b/client/reader/atmosphere/following-view.tsx
@@ -228,6 +228,10 @@ export function FollowingView( { connectionId, actor }: Props ) {
 				protocolLabel="ATmosphere"
 				protocolHomeURL="https://bsky.app"
 				protocolHomeLabel="Bluesky"
+				authRequiredCopy={ {
+					title: String( translate( "Couldn't load list" ) ),
+					line: String( translate( 'Something went wrong with your Bluesky connection.' ) ),
+				} }
 				header={ {
 					displayName: profileQuery.data?.display_name ?? null,
 					handle: profileQuery.data?.handle ?? actor,

--- a/client/reader/atmosphere/profile-errors.ts
+++ b/client/reader/atmosphere/profile-errors.ts
@@ -14,13 +14,9 @@ export function errorMessage(
 	switch ( error.kind ) {
 		case 'auth_failed':
 		case 'auth_required':
-			return translate(
-				'Your Bluesky connection needs to be re-authorized. Disconnect and reconnect.'
-			);
+			return translate( 'Something went wrong with your Bluesky connection.' );
 		case 'connection_not_found':
-			return translate(
-				'Your Bluesky connection is no longer available. Disconnect and reconnect.'
-			);
+			return translate( 'This Bluesky connection is no longer available.' );
 		case 'rate_limited':
 			return translate( "Bluesky's asking us to slow down. Try again in a minute." );
 		case 'upstream_unavailable':

--- a/client/reader/atmosphere/tag-feed-panel.tsx
+++ b/client/reader/atmosphere/tag-feed-panel.tsx
@@ -213,6 +213,10 @@ export function TagFeedPanel( { connection, hashtag }: Props ) {
 							protocolLabel="Bluesky"
 							protocolHomeURL="/reader/atmosphere"
 							protocolHomeLabel={ String( translate( 'Back to ATmosphere' ) ) }
+							authRequiredCopy={ {
+								title: String( translate( "Couldn't load posts" ) ),
+								line: String( translate( 'Something went wrong with your Bluesky connection.' ) ),
+							} }
 						/>
 					</VStack>
 				</RepostProvider>

--- a/client/reader/atmosphere/test/composer-config.test.tsx
+++ b/client/reader/atmosphere/test/composer-config.test.tsx
@@ -150,12 +150,12 @@ describe( 'atmosphereComposerConfig', () => {
 			expect( container.textContent?.trim().length ).toBeGreaterThan( 0 );
 		} );
 
-		it( 'auth_required renders a Reconnect link to /reader/atmosphere/connect', () => {
+		it( 'auth_required renders a connection-error message with no link', () => {
 			const t = getTranslate();
 			const node = atmosphereComposerConfig.errorMessage( { kind: 'auth_required' }, t );
 			const { container } = render( <span>{ node }</span> );
-			const link = container.querySelector( 'a' );
-			expect( link?.getAttribute( 'href' ) ).toBe( '/reader/atmosphere/connect' );
+			expect( container.textContent ).toMatch( /Bluesky connection/i );
+			expect( container.querySelector( 'a' ) ).toBeNull();
 		} );
 	} );
 

--- a/client/reader/atmosphere/test/standalone-compose.test.tsx
+++ b/client/reader/atmosphere/test/standalone-compose.test.tsx
@@ -279,7 +279,7 @@ describe( 'Standalone compose end-to-end', () => {
 		expect( composeErrorCalls ).toHaveLength( 1 );
 	} );
 
-	it( 'auth error 401: renders a Reconnect link to /reader/atmosphere/connect that opens in a new tab, preserves the draft, and keeps the modal open', async () => {
+	it( 'auth error 401: shows a connection-error message, preserves the draft, and keeps the modal open', async () => {
 		mockConnections();
 		mockTimelineEmpty();
 
@@ -294,11 +294,9 @@ describe( 'Standalone compose end-to-end', () => {
 		await user.type( screen.getByRole( 'textbox' ), 'auth fail' );
 		await user.click( screen.getByRole( 'button', { name: 'Post' } ) );
 
-		const reconnect = await screen.findByRole( 'link', { name: /reconnect/i } );
-		expect( reconnect ).toHaveAttribute( 'href', '/reader/atmosphere/connect' );
-		expect( reconnect ).toHaveAttribute( 'target', '_blank' );
-		expect( reconnect ).toHaveAttribute( 'rel', expect.stringContaining( 'noopener' ) );
-		expect( reconnect ).toHaveAttribute( 'rel', expect.stringContaining( 'noreferrer' ) );
+		// The error toast surfaces a connection-error message with no link.
+		expect( await screen.findByText( /Bluesky connection/i ) ).toBeVisible();
+		expect( screen.queryByRole( 'link', { name: /reconnect/i } ) ).toBeNull();
 
 		// Modal stays open with the typed draft preserved.
 		expect( screen.getByRole( 'dialog' ) ).toBeVisible();

--- a/client/reader/atmosphere/test/thread-panel.test.tsx
+++ b/client/reader/atmosphere/test/thread-panel.test.tsx
@@ -118,7 +118,7 @@ describe( 'ThreadPanel', () => {
 		);
 	} );
 
-	it( 'renders auth_required error with no Retry button', async () => {
+	it( 'renders auth_required error with a Retry button', async () => {
 		nock( BASE )
 			.get( PATH )
 			.query( { uri: TARGET_URI } )
@@ -128,9 +128,9 @@ describe( 'ThreadPanel', () => {
 			queryClient: makeQueryClient(),
 		} );
 		await waitFor( () =>
-			expect( screen.getAllByText( /Reconnect needed/i ).length ).toBeGreaterThan( 0 )
+			expect( screen.getAllByText( /Couldn't load thread/i ).length ).toBeGreaterThan( 0 )
 		);
-		expect( screen.queryByRole( 'button', { name: /retry/i } ) ).toBeNull();
+		expect( screen.getByRole( 'button', { name: /retry/i } ) ).toBeVisible();
 	} );
 
 	it( 'renders not_found error with no Retry button', async () => {
@@ -148,7 +148,7 @@ describe( 'ThreadPanel', () => {
 		expect( screen.queryByRole( 'button', { name: /retry/i } ) ).toBeNull();
 	} );
 
-	it( 'renders the Reconnect-needed empty state for invalid_handle / invalid_credentials / auth_failed', async () => {
+	it( 'renders a retryable empty state for invalid_handle / invalid_credentials / auth_failed', async () => {
 		nock( BASE )
 			.get( PATH )
 			.query( { uri: TARGET_URI } )
@@ -158,9 +158,9 @@ describe( 'ThreadPanel', () => {
 			queryClient: makeQueryClient(),
 		} );
 		await waitFor( () =>
-			expect( screen.getAllByText( /Reconnect needed/i ).length ).toBeGreaterThan( 0 )
+			expect( screen.getAllByText( /Couldn't load thread/i ).length ).toBeGreaterThan( 0 )
 		);
-		expect( screen.queryByRole( 'button', { name: /retry/i } ) ).toBeNull();
+		expect( screen.getByRole( 'button', { name: /retry/i } ) ).toBeVisible();
 	} );
 
 	it( 'renders the Connection-no-longer-exists empty state for connection_not_found', async () => {

--- a/client/reader/atmosphere/test/timeline-panel.test.tsx
+++ b/client/reader/atmosphere/test/timeline-panel.test.tsx
@@ -836,7 +836,7 @@ describe( 'TimelinePanel — reply composer errors', () => {
 			status: 401,
 			code: 'atmosphere_auth_required',
 			kind: 'auth_required',
-			copy: /reconnected/i,
+			copy: /Bluesky connection/i,
 		},
 		{
 			status: 429,
@@ -902,7 +902,7 @@ describe( 'TimelinePanel — reply composer errors', () => {
 		}
 	);
 
-	it( 'auth_required Reconnect link opens in a new tab with rel=noopener', async () => {
+	it( 'auth_required surfaces a connection-error message with no reconnect link', async () => {
 		const queryClient = makeQueryClient();
 		queryClient.setQueryData(
 			readerAtmosphereKeys.timeline( 42 ),
@@ -931,9 +931,8 @@ describe( 'TimelinePanel — reply composer errors', () => {
 		await user.type( screen.getByRole( 'textbox' ), 'hi' );
 		await user.click( screen.getByRole( 'button', { name: 'Post' } ) );
 
-		const reconnect = await screen.findByRole( 'link', { name: /reconnect/i } );
-		expect( reconnect ).toHaveAttribute( 'target', '_blank' );
-		expect( reconnect ).toHaveAttribute( 'rel', expect.stringContaining( 'noopener' ) );
+		expect( await screen.findByText( /Bluesky connection/i ) ).toBeVisible();
+		expect( screen.queryByRole( 'link', { name: /reconnect/i } ) ).toBeNull();
 	} );
 } );
 

--- a/client/reader/atmosphere/thread-panel.tsx
+++ b/client/reader/atmosphere/thread-panel.tsx
@@ -288,15 +288,20 @@ function renderError( {
 		case 'invalid_credentials':
 			return (
 				<EmptyContent
-					title={ translate( 'Reconnect needed' ) }
-					line={ translate( 'Your Bluesky connection needs to be reconnected. Coming soon.' ) }
+					title={ translate( "Couldn't load thread" ) }
+					line={ translate( 'Something went wrong with your Bluesky connection.' ) }
+					action={
+						<Button variant="secondary" onClick={ handleRetry }>
+							{ translate( 'Retry' ) }
+						</Button>
+					}
 				/>
 			);
 		case 'connection_not_found':
 			return (
 				<EmptyContent
 					title={ translate( 'Connection no longer exists' ) }
-					line={ translate( 'Reconnect your Bluesky account to view this thread.' ) }
+					line={ translate( 'This Bluesky connection is no longer available.' ) }
 				/>
 			);
 		case 'not_found':

--- a/client/reader/atmosphere/timeline-panel.tsx
+++ b/client/reader/atmosphere/timeline-panel.tsx
@@ -235,6 +235,10 @@ export function TimelinePanel( { connection }: TimelinePanelProps ) {
 						protocolLabel="Bluesky"
 						protocolHomeURL="/reader/atmosphere"
 						protocolHomeLabel={ translate( 'Back to ATmosphere' ) }
+						authRequiredCopy={ {
+							title: String( translate( "Couldn't load timeline" ) ),
+							line: String( translate( 'Something went wrong with your Bluesky connection.' ) ),
+						} }
 					/>
 				</RepostProvider>
 			</LikeProvider>

--- a/client/reader/atmosphere/use-atmosphere-like-action.ts
+++ b/client/reader/atmosphere/use-atmosphere-like-action.ts
@@ -22,7 +22,7 @@ function errorMessageForLike(
 		case 'auth_required':
 		case 'auth_failed':
 		case 'invalid_credentials':
-			return translate( 'Reconnect your Bluesky account to like posts.' );
+			return translate( 'Something went wrong with your Bluesky connection. Try again.' );
 		case 'rate_limited':
 			return translate( "You're liking posts too quickly. Try again in a moment." );
 		case 'connection_not_found':

--- a/client/reader/atmosphere/use-atmosphere-repost-action.ts
+++ b/client/reader/atmosphere/use-atmosphere-repost-action.ts
@@ -25,7 +25,7 @@ function errorMessageForRepost(
 		case 'auth_required':
 		case 'auth_failed':
 		case 'invalid_credentials':
-			return translate( 'Reconnect your Bluesky account to repost.' );
+			return translate( 'Something went wrong with your Bluesky connection. Try again.' );
 		case 'rate_limited':
 			return translate( "You're reposting too quickly. Try again in a moment." );
 		case 'connection_not_found':

--- a/client/reader/fediverse/author-profile-panel.tsx
+++ b/client/reader/fediverse/author-profile-panel.tsx
@@ -22,7 +22,7 @@ import {
 import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import { projectFediverseError } from './error-projection';
-import { followErrorMessage } from './profile-errors';
+import { errorMessage, followErrorMessage } from './profile-errors';
 import {
 	getFollowersUrl,
 	getFollowingUrl,
@@ -256,7 +256,7 @@ export function FediverseAuthorProfilePanel( {
 			return (
 				<EmptyContent
 					title={ titleByKind[ error.kind ] ?? translate( 'Couldn’t load profile' ) }
-					line={ translate( 'Try again in a moment.' ) }
+					line={ errorMessage( error, translate ) }
 					action={ showRetry ? translate( 'Retry' ) : undefined }
 					actionCallback={ showRetry ? retry : undefined }
 				/>
@@ -334,6 +334,10 @@ export function FediverseAuthorProfilePanel( {
 			protocolLabel="Fediverse"
 			protocolHomeURL="/reader/fediverse"
 			protocolHomeLabel={ translate( 'Back to Fediverse' ) }
+			authRequiredCopy={ {
+				title: String( translate( "Couldn't load posts" ) ),
+				line: String( translate( 'Something went wrong with your Fediverse connection.' ) ),
+			} }
 			className="fediverse-author-profile"
 		/>
 	);

--- a/client/reader/fediverse/author-profile-panel.tsx
+++ b/client/reader/fediverse/author-profile-panel.tsx
@@ -244,14 +244,12 @@ export function FediverseAuthorProfilePanel( {
 	const renderProfileError = useCallback(
 		( error: FediverseError, retry: () => void ) => {
 			const noRetry = new Set< FediverseError[ 'kind' ] >( [
-				'auth_required',
 				'not_found',
 				'connection_not_found',
 			] );
 			const showRetry = ! noRetry.has( error.kind );
 			const titleByKind: Partial< Record< FediverseError[ 'kind' ], TranslateResult > > = {
 				not_found: translate( 'Profile not found' ),
-				auth_required: translate( 'Reconnect needed' ),
 				rate_limited: translate( 'Slow down' ),
 				upstream_unavailable: translate( 'Fediverse unreachable' ),
 			};

--- a/client/reader/fediverse/composer-config.tsx
+++ b/client/reader/fediverse/composer-config.tsx
@@ -162,15 +162,9 @@ function errorMessageFor( err: FediverseError, t: Translate ): ReactNode {
 		case 'bad_request':
 			return t( 'We couldn’t publish this. Try shortening your post or changing visibility.' );
 		case 'auth_required':
-			return t( 'Your Fediverse connection needs to be reconnected. {{a}}Reconnect{{/a}}', {
-				components: {
-					a: <a href="/reader/fediverse" target="_blank" rel="noopener noreferrer" />,
-				},
-				comment:
-					'Composer error shown when the user’s Fediverse session expired; {{a}}…{{/a}} wraps a link to the Fediverse pane.',
-			} );
+			return t( 'Something went wrong with your Fediverse connection.' );
 		case 'connection_not_found':
-			return t( 'Your Fediverse connection is no longer available. Disconnect and reconnect.' );
+			return t( 'This Fediverse connection is no longer available.' );
 		case 'rate_limited':
 			return t( 'The Fediverse is asking us to slow down. Try again in a moment.' );
 		case 'upstream_unavailable':

--- a/client/reader/fediverse/followers-view.tsx
+++ b/client/reader/fediverse/followers-view.tsx
@@ -259,6 +259,10 @@ export function FollowersView( { connectionId, actor }: Props ) {
 				protocolLabel="Fediverse"
 				protocolHomeURL="/reader/fediverse"
 				protocolHomeLabel={ String( translate( 'Back to Fediverse' ) ) }
+				authRequiredCopy={ {
+					title: String( translate( "Couldn't load followers" ) ),
+					line: String( translate( 'Something went wrong with your Fediverse connection.' ) ),
+				} }
 				header={ {
 					displayName: profileQuery.data?.display_name ?? null,
 					// `acct` carries a leading `@`; the header renders `@${handle}`,

--- a/client/reader/fediverse/following-view.tsx
+++ b/client/reader/fediverse/following-view.tsx
@@ -246,6 +246,10 @@ export function FollowingView( { connectionId, actor }: Props ) {
 				protocolLabel="Fediverse"
 				protocolHomeURL="/reader/fediverse"
 				protocolHomeLabel={ String( translate( 'Back to Fediverse' ) ) }
+				authRequiredCopy={ {
+					title: String( translate( "Couldn't load list" ) ),
+					line: String( translate( 'Something went wrong with your Fediverse connection.' ) ),
+				} }
 				header={ {
 					displayName: profileQuery.data?.display_name ?? null,
 					// `acct` carries a leading `@`; the header renders `@${handle}`,

--- a/client/reader/fediverse/profile-errors.ts
+++ b/client/reader/fediverse/profile-errors.ts
@@ -51,13 +51,9 @@ export function errorMessage(
 ): TranslateResult {
 	switch ( error.kind ) {
 		case 'auth_required':
-			return translate(
-				'Your Fediverse connection needs to be re-authorized. Disconnect and reconnect.'
-			);
+			return translate( 'Something went wrong with your Fediverse connection.' );
 		case 'connection_not_found':
-			return translate(
-				'Your Fediverse connection is no longer available. Disconnect and reconnect.'
-			);
+			return translate( 'This Fediverse connection is no longer available.' );
 		case 'rate_limited':
 			return translate( 'The Fediverse is asking us to slow down. Try again in a moment.' );
 		case 'upstream_unavailable':

--- a/client/reader/fediverse/test/followers-view.test.tsx
+++ b/client/reader/fediverse/test/followers-view.test.tsx
@@ -146,12 +146,14 @@ describe( 'FollowersView', () => {
 		await waitFor( () => expect( screen.getByText( 'No followers yet' ) ).toBeVisible() );
 	} );
 
-	it( 'shows an auth-required empty state when the followers query 401s', async () => {
+	it( 'shows a generic connection-error empty state when the followers query 401s', async () => {
 		mockConnections();
 		mockProfile();
-		// 401 → `auth_required`, which is non-retryable per the query's retry
-		// policy. `SocialFeedList` renders the reconnect copy with the
-		// protocol-home link rather than a Retry button.
+		// 401 → `auth_required`. Fediverse passes `authRequiredCopy` to
+		// `SocialAccountList`, replacing the default reconnect copy with the
+		// generic "Couldn't load followers" / "Something went wrong …" copy
+		// plus a Retry button (the Reader doesn't have a working Fediverse
+		// reconnect flow yet).
 		nock( BASE ).get( FOLLOWERS_URL ).query( true ).reply( 401, { code: 'not_authenticated' } );
 
 		renderWithProvider( <FollowersView connectionId={ 7 } actor="alice@example.com" />, {
@@ -159,9 +161,12 @@ describe( 'FollowersView', () => {
 		} );
 
 		await waitFor( () =>
-			expect( screen.getByRole( 'heading', { name: /reconnect needed/i } ) ).toBeVisible()
+			expect(
+				screen.getByText( /Something went wrong with your Fediverse connection/i )
+			).toBeVisible()
 		);
-		expect( screen.getByRole( 'link', { name: /back to fediverse/i } ) ).toBeVisible();
+		expect( screen.queryByRole( 'heading', { name: /reconnect needed/i } ) ).toBeNull();
+		expect( screen.getByRole( 'button', { name: /retry/i } ) ).toBeVisible();
 	} );
 
 	it( 'hides the follow control on `is_self` rows', async () => {

--- a/client/reader/fediverse/test/profile-errors.test.ts
+++ b/client/reader/fediverse/test/profile-errors.test.ts
@@ -52,7 +52,7 @@ describe( 'errorMessage', () => {
 		expect( message ).toMatch( /Fediverse connection/i );
 	} );
 
-	it( 'projects connection_not_found to a reconnect-shaped string', () => {
+	it( 'projects connection_not_found to a no-longer-available string', () => {
 		const translate = getTranslate();
 		const message = String( errorMessage( { kind: 'connection_not_found' }, translate ) );
 		expect( message ).toMatch( /no longer available/i );

--- a/client/reader/fediverse/test/profile-errors.test.ts
+++ b/client/reader/fediverse/test/profile-errors.test.ts
@@ -46,10 +46,10 @@ describe( 'followErrorMessage', () => {
 } );
 
 describe( 'errorMessage', () => {
-	it( 'projects auth_required to a reauth-shaped string', () => {
+	it( 'projects auth_required to a connection-error string', () => {
 		const translate = getTranslate();
 		const message = String( errorMessage( { kind: 'auth_required' }, translate ) );
-		expect( message ).toMatch( /re-author/i );
+		expect( message ).toMatch( /Fediverse connection/i );
 	} );
 
 	it( 'projects connection_not_found to a reconnect-shaped string', () => {

--- a/client/reader/fediverse/timeline-panel.tsx
+++ b/client/reader/fediverse/timeline-panel.tsx
@@ -165,6 +165,10 @@ export function TimelinePanel( { connection }: TimelinePanelProps ) {
 				protocolLabel="Fediverse"
 				protocolHomeURL="/reader/fediverse"
 				protocolHomeLabel={ String( translate( 'Back to Fediverse' ) ) }
+				authRequiredCopy={ {
+					title: String( translate( "Couldn't load timeline" ) ),
+					line: String( translate( 'Something went wrong with your Fediverse connection.' ) ),
+				} }
 			/>
 		</SocialAnalyticsProvider>
 	);

--- a/client/reader/social/account-list.tsx
+++ b/client/reader/social/account-list.tsx
@@ -45,6 +45,7 @@ export interface SocialAccountListProps< T > {
 	protocolLabel: string;
 	protocolHomeURL: string;
 	protocolHomeLabel: string;
+	authRequiredCopy?: { title: string; line: string };
 	/** Optional header rendered above the list (e.g. on followers/following views). */
 	header?: SocialAccountListHeader;
 }
@@ -127,6 +128,7 @@ export function SocialAccountList< T >( props: SocialAccountListProps< T > ) {
 				protocolLabel={ props.protocolLabel }
 				protocolHomeURL={ props.protocolHomeURL }
 				protocolHomeLabel={ props.protocolHomeLabel }
+				authRequiredCopy={ props.authRequiredCopy }
 			/>
 		</>
 	);

--- a/client/reader/social/author-profile-panel.tsx
+++ b/client/reader/social/author-profile-panel.tsx
@@ -114,6 +114,7 @@ export interface SocialAuthorProfilePanelProps<
 	protocolLabel: string;
 	protocolHomeURL: string;
 	protocolHomeLabel: TranslateResult;
+	authRequiredCopy?: { title: string; line: string };
 
 	// Wrapper-specific class on the VStack (allows protocol-scoped CSS).
 	className?: string;
@@ -157,6 +158,7 @@ export function SocialAuthorProfilePanel< TProfile, TError extends ProtocolError
 	protocolLabel,
 	protocolHomeURL,
 	protocolHomeLabel,
+	authRequiredCopy,
 	className,
 	feedDimension,
 }: SocialAuthorProfilePanelProps< TProfile, TError, TFeedItem > ) {
@@ -369,6 +371,7 @@ export function SocialAuthorProfilePanel< TProfile, TError extends ProtocolError
 					protocolLabel={ protocolLabel }
 					protocolHomeURL={ protocolHomeURL }
 					protocolHomeLabel={ String( protocolHomeLabel ) }
+					authRequiredCopy={ authRequiredCopy }
 				/>
 			</VStack>
 		</SocialAnalyticsProvider>

--- a/client/reader/social/components/feed-list/feed-list-empty.tsx
+++ b/client/reader/social/components/feed-list/feed-list-empty.tsx
@@ -13,6 +13,10 @@ interface FeedListEmptyProps {
 	protocolLabel: string;
 	protocolHomeURL: string;
 	protocolHomeLabel: string;
+	// Protocols without a working reconnect flow (Bluesky, Fediverse) pass
+	// this to replace the default "Reconnect needed" + protocol-home link
+	// with generic copy + a Retry button.
+	authRequiredCopy?: { title: string; line: string };
 }
 
 export function FeedListEmpty( {
@@ -25,6 +29,7 @@ export function FeedListEmpty( {
 	protocolLabel,
 	protocolHomeURL,
 	protocolHomeLabel,
+	authRequiredCopy,
 }: FeedListEmptyProps ) {
 	const translate = useTranslate();
 
@@ -41,6 +46,19 @@ export function FeedListEmpty( {
 
 	switch ( error.kind ) {
 		case 'auth_required':
+			if ( authRequiredCopy ) {
+				return (
+					<EmptyContent
+						title={ authRequiredCopy.title }
+						line={ authRequiredCopy.line }
+						action={
+							<Button variant="primary" onClick={ onRetry }>
+								{ translate( 'Retry' ) }
+							</Button>
+						}
+					/>
+				);
+			}
 			return (
 				<EmptyContent
 					title={ translate( 'Reconnect needed' ) }

--- a/client/reader/social/components/feed-list/index.tsx
+++ b/client/reader/social/components/feed-list/index.tsx
@@ -27,6 +27,7 @@ interface SocialFeedListProps< T > {
 	protocolLabel: string;
 	protocolHomeURL: string;
 	protocolHomeLabel: string;
+	authRequiredCopy?: { title: string; line: string };
 }
 
 export function SocialFeedList< T >( props: SocialFeedListProps< T > ) {
@@ -48,6 +49,7 @@ export function SocialFeedList< T >( props: SocialFeedListProps< T > ) {
 		protocolLabel,
 		protocolHomeURL,
 		protocolHomeLabel,
+		authRequiredCopy,
 	} = props;
 
 	const translate = useTranslate();
@@ -73,6 +75,7 @@ export function SocialFeedList< T >( props: SocialFeedListProps< T > ) {
 				protocolLabel={ protocolLabel }
 				protocolHomeURL={ protocolHomeURL }
 				protocolHomeLabel={ protocolHomeLabel }
+				authRequiredCopy={ authRequiredCopy }
 			/>
 		);
 	}

--- a/client/reader/social/components/feed-list/test/feed-list-empty.test.tsx
+++ b/client/reader/social/components/feed-list/test/feed-list-empty.test.tsx
@@ -64,7 +64,7 @@ describe( 'FeedListEmpty', () => {
 		expect( screen.getByRole( 'button', { name: /retry/i } ) ).toBeVisible();
 	} );
 
-	it( 'renders the auth-required error WITHOUT a Retry button', () => {
+	it( 'renders the auth-required error WITHOUT a Retry button by default', () => {
 		render(
 			<FeedListEmpty
 				error={ { kind: 'auth_required' } as SocialError }
@@ -76,6 +76,28 @@ describe( 'FeedListEmpty', () => {
 		);
 		expect( screen.getAllByText( /reconnect/i ).length ).toBeGreaterThan( 0 );
 		expect( screen.queryByRole( 'button', { name: /retry/i } ) ).toBeNull();
+	} );
+
+	it( 'renders the auth-required error with override copy + Retry when authRequiredCopy is set', () => {
+		const onRetry = jest.fn();
+		render(
+			<FeedListEmpty
+				error={ { kind: 'auth_required' } as SocialError }
+				onRetry={ onRetry }
+				emptyTitle=""
+				emptyLine=""
+				{ ...protocolProps }
+				authRequiredCopy={ {
+					title: "Couldn't load timeline",
+					line: 'Something went wrong with your Bluesky connection.',
+				} }
+			/>
+		);
+		expect( screen.queryByText( /reconnect needed/i ) ).toBeNull();
+		expect(
+			screen.getByText( /Something went wrong with your Bluesky connection/i )
+		).toBeVisible();
+		expect( screen.getByRole( 'button', { name: /retry/i } ) ).toBeVisible();
 	} );
 
 	it( 'renders the not-found error with a back-to-ATmosphere link', () => {

--- a/client/reader/social/components/post-card/post-actions-menu.tsx
+++ b/client/reader/social/components/post-card/post-actions-menu.tsx
@@ -28,7 +28,7 @@ function errorMessageForDelete(
 		case 'auth_required':
 		case 'auth_failed':
 		case 'invalid_credentials':
-			return t( 'Reconnect your Bluesky account to delete this post.' ) as string;
+			return t( 'Something went wrong with your Bluesky connection. Try again.' ) as string;
 		case 'rate_limited':
 			return t( "You're deleting too quickly. Try again in a moment." ) as string;
 		case 'connection_not_found':

--- a/client/reader/social/components/post-card/test/like-button.test.tsx
+++ b/client/reader/social/components/post-card/test/like-button.test.tsx
@@ -212,7 +212,7 @@ describe( '<LikeButton>', () => {
 			)
 		);
 		expect( errorNoticeSpy ).toHaveBeenCalledWith(
-			'Reconnect your Bluesky account to like posts.'
+			'Something went wrong with your Bluesky connection. Try again.'
 		);
 	} );
 

--- a/client/reader/social/components/post-card/test/repost-button.test.tsx
+++ b/client/reader/social/components/post-card/test/repost-button.test.tsx
@@ -345,7 +345,9 @@ describe( '<RepostButton>', () => {
 				expect.objectContaining( { error_kind: 'auth_required', direction: 'unrepost' } )
 			)
 		);
-		expect( errorNoticeSpy ).toHaveBeenCalledWith( 'Reconnect your Bluesky account to repost.' );
+		expect( errorNoticeSpy ).toHaveBeenCalledWith(
+			'Something went wrong with your Bluesky connection. Try again.'
+		);
 	} );
 
 	it( 'leaves "Quote post" disabled when no onQuoteClick is wired in the analytics context', async () => {


### PR DESCRIPTION
Fixes CM-762

## Proposed Changes

* Replace Bluesky-side empty-state and toast copy that promises a "Reconnect" action with a generic connection-error message + Retry button where one fits.
* Do the same for the Fediverse surfaces (composer toast, profile errors, author-profile empty state).
* Leave Mastodon's reconnect copy untouched — its OAuth re-auth flow is real.
* Update tests to assert the new copy and Retry-button presence.

Files touched: `client/reader/atmosphere/{thread-panel,composer-config,profile-errors,author-profile-panel,use-atmosphere-like-action,use-atmosphere-repost-action}` and matching tests; `client/reader/fediverse/{composer-config,profile-errors,author-profile-panel}` and `test/profile-errors`.

## Why are these changes being made?

Several Reader surfaces tell the user their Bluesky or Fediverse connection "needs to be reconnected", and some surface a `Reconnect` link. There's no real reconnect flow for either protocol today — the existing link routes to the new-connection form, not a credential refresh. The copy promises something we don't deliver.

Mastodon is unaffected because its OAuth re-auth flow is real.

## Testing Instructions

1. Connect a Bluesky account, then revoke the app password from bsky.app (or send a stale `app_password` value).
2. Open the ATmosphere thread view, the composer, and the author-profile surfaces and trigger an action.
3. Confirm:
   * Thread view shows "Couldn't load thread" + "Something went wrong with your Bluesky connection." + a working Retry button.
   * Composer error toast shows the same line with no `Reconnect` link.
   * Author-profile empty state falls back to "Couldn't load profile" with a Retry button.
   * Like / repost toasts say "Something went wrong with your Bluesky connection. Try again."
4. Repeat for a Fediverse connection (composer + profile surfaces). Verify no `Reconnect` text or link anywhere.
5. Sanity-check: trigger a Mastodon auth error and verify its reconnect copy is unchanged.

Unit tests:

```bash
yarn test-client client/reader/atmosphere client/reader/fediverse
```

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?