### PR TITLE
Revert "Onboarding plans: redirect free plan selections to choose test"

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -70,9 +70,9 @@ const onboarding: FlowV2< typeof initialize > = {
 			setHideFreePlan,
 		} = useDispatch( ONBOARD_STORE ) as OnboardActions;
 		const locale = useFlowLocale();
-		// Restore `signupDomainOrigin` here if the PWYW /choose A/B test is reverted in the 'plans' submit case below.
-		const { planCartItem, blueprint } = useSelect(
+		const { signupDomainOrigin, planCartItem, blueprint } = useSelect(
 			( select ) => ( {
+				signupDomainOrigin: ( select( ONBOARD_STORE ) as OnboardSelect ).getSignupDomainOrigin(),
 				planCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getPlanCartItem(),
 				blueprint: ( select( ONBOARD_STORE ) as OnboardSelect ).getBlueprint(),
 			} ),
@@ -194,23 +194,15 @@ const onboarding: FlowV2< typeof initialize > = {
 					setPlanCartItem( pickedPlan );
 
 					if ( ! pickedPlan ) {
-						// Redirect free plan selections to /choose for the PWYW A/B test.
-						// If we end the A/B test without shipping it, restore the
-						// commented-out block below and remove this redirect.
-						window.location.assign(
-							addQueryArgs( '/choose', getQueryArgs( window.location.href ) )
-						);
-						return;
-
 						// Since we're removing the paid domain, it means that the user chose to continue
 						// with a free domain. Because signupDomainOrigin should reflect the last domain
 						// selection status before they land on the checkout page, this value can be
 						// 'free' or 'choose-later'
-						// if ( signupDomainOrigin === 'choose-later' ) {
-						// 	setSignupDomainOrigin( signupDomainOrigin );
-						// } else {
-						// 	setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.FREE );
-						// }
+						if ( signupDomainOrigin === 'choose-later' ) {
+							setSignupDomainOrigin( signupDomainOrigin );
+						} else {
+							setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.FREE );
+						}
 					}
 
 					// Make sure to put the rest of products into the cart, e.g. the storage add-ons.


### PR DESCRIPTION
Reverts Automattic/wp-calypso#110877