### PR TITLE
Override number-formatters currency decimal places with endpoint response

### DIFF
--- a/apps/blaze-dashboard/package.json
+++ b/apps/blaze-dashboard/package.json
@@ -33,7 +33,7 @@
 		"@automattic/calypso-url": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
-		"@automattic/number-formatters": "^1.1.9",
+		"@automattic/number-formatters": "^1.2.0",
 		"@tanstack/react-query": "^5.83.0",
 		"@wordpress/components": "^33.1.0",
 		"@wordpress/data": "^10.46.0",

--- a/apps/happy-blocks/package.json
+++ b/apps/happy-blocks/package.json
@@ -29,7 +29,7 @@
 		"@automattic/calypso-products": "workspace:^",
 		"@automattic/color-studio": "^4.1.0",
 		"@automattic/components": "workspace:^",
-		"@automattic/number-formatters": "^1.1.9",
+		"@automattic/number-formatters": "^1.2.0",
 		"@automattic/typography": "workspace:^",
 		"@automattic/wp-babel-makepot": "workspace:^",
 		"@automattic/wpcom-template-parts": "workspace:^",

--- a/client/boot/locale.js
+++ b/client/boot/locale.js
@@ -8,6 +8,7 @@ import {
 import { setLocale as setLocaleNumberFormatters } from '@automattic/number-formatters';
 import i18n from 'i18n-calypso';
 import { initLanguageEmpathyMode } from 'calypso/lib/i18n-utils/empathy-mode';
+import { loadAndSetCurrencyOverrides } from 'calypso/lib/i18n-utils/load-currency-overrides';
 import { loadUserUndeployedTranslations } from 'calypso/lib/i18n-utils/switch-locale';
 import { LOCALE_SET } from 'calypso/state/action-types';
 import { setLocale } from 'calypso/state/ui/language/actions';
@@ -52,6 +53,7 @@ export const setupLocale = async ( currentUser, reduxStore ) => {
 		await reduxStore.dispatch( { type: LOCALE_SET, localeSlug, localeVariant } );
 		// Propagate the locale to @automattic/number-formatters
 		setLocaleNumberFormatters( localeVariant || localeSlug );
+		loadAndSetCurrencyOverrides();
 
 		if ( localeSlug ) {
 			loadUserUndeployedTranslations( localeSlug );

--- a/client/components/calypso-i18n-provider/index.tsx
+++ b/client/components/calypso-i18n-provider/index.tsx
@@ -4,6 +4,7 @@ import { defaultI18n } from '@wordpress/i18n';
 import { I18nProvider } from '@wordpress/react-i18n';
 import defaultCalypsoI18n, { I18NContext } from 'i18n-calypso';
 import { useState, useEffect } from 'react';
+import { loadAndSetCurrencyOverrides } from 'calypso/lib/i18n-utils/load-currency-overrides';
 import type { LocaleData } from '@wordpress/i18n';
 import type { I18N } from 'i18n-calypso';
 import type { FunctionComponent } from 'react';
@@ -29,8 +30,9 @@ const CalypsoI18nProvider: FunctionComponent< { i18n?: I18N; children?: React.Re
 		if ( localeSlug ) {
 			// Propagate the locale to @automattic/number-formatters
 			setLocaleNumberFormatters( localeSlug );
+			loadAndSetCurrencyOverrides();
 		}
-	}, [ localeSlug ] );
+	}, [ localeSlug, i18n ] );
 
 	return (
 		<I18NContext.Provider value={ i18n }>

--- a/client/lib/i18n-utils/load-currency-overrides.js
+++ b/client/lib/i18n-utils/load-currency-overrides.js
@@ -1,0 +1,45 @@
+import { setCurrencyOverrides } from '@automattic/number-formatters';
+import debugFactory from 'debug';
+
+const debug = debugFactory( 'calypso:i18n:currency-overrides' );
+
+const CURRENCY_OVERRIDES_URL = 'https://public-api.wordpress.com/wpcom/v2/currency-overrides';
+
+let pendingLoad = null;
+
+/**
+ * Fetches the currency overrides from the wpcom endpoint and propagates them
+ * to `@automattic/number-formatters`. The fetch is memoized so repeated calls
+ * (e.g. from each locale switch) only hit the network once per page load.
+ * @returns {Promise<void>}
+ */
+export function loadAndSetCurrencyOverrides() {
+	if ( typeof window === 'undefined' ) {
+		return Promise.resolve();
+	}
+
+	if ( pendingLoad ) {
+		return pendingLoad;
+	}
+
+	pendingLoad = globalThis
+		.fetch( CURRENCY_OVERRIDES_URL )
+		.then( ( response ) => {
+			if ( ! response.ok ) {
+				throw new Error( `Unexpected status ${ response.status }` );
+			}
+			return response.json();
+		} )
+		.then( ( overrides ) => {
+			if ( overrides && typeof overrides === 'object' ) {
+				setCurrencyOverrides( overrides );
+			}
+		} )
+		.catch( ( error ) => {
+			debug( 'Failed to load currency overrides', error );
+			// Allow a retry on the next call if the fetch failed.
+			pendingLoad = null;
+		} );
+
+	return pendingLoad;
+}

--- a/client/lib/i18n-utils/load-currency-overrides.js
+++ b/client/lib/i18n-utils/load-currency-overrides.js
@@ -1,9 +1,8 @@
+import { fetchCurrencyOverrides } from '@automattic/api-core';
 import { setCurrencyOverrides } from '@automattic/number-formatters';
 import debugFactory from 'debug';
 
 const debug = debugFactory( 'calypso:i18n:currency-overrides' );
-
-const CURRENCY_OVERRIDES_URL = 'https://public-api.wordpress.com/wpcom/v2/currency-overrides';
 
 let pendingLoad = null;
 
@@ -22,14 +21,7 @@ export function loadAndSetCurrencyOverrides() {
 		return pendingLoad;
 	}
 
-	pendingLoad = globalThis
-		.fetch( CURRENCY_OVERRIDES_URL )
-		.then( ( response ) => {
-			if ( ! response.ok ) {
-				throw new Error( `Unexpected status ${ response.status }` );
-			}
-			return response.json();
-		} )
+	pendingLoad = fetchCurrencyOverrides()
 		.then( ( overrides ) => {
 			if ( overrides && typeof overrides === 'object' ) {
 				setCurrencyOverrides( overrides );

--- a/client/lib/i18n-utils/load-currency-overrides.ts
+++ b/client/lib/i18n-utils/load-currency-overrides.ts
@@ -4,15 +4,14 @@ import debugFactory from 'debug';
 
 const debug = debugFactory( 'calypso:i18n:currency-overrides' );
 
-let pendingLoad = null;
+let pendingLoad: Promise< void > | null = null;
 
 /**
  * Fetches the currency overrides from the wpcom endpoint and propagates them
  * to `@automattic/number-formatters`. The fetch is memoized so repeated calls
  * (e.g. from each locale switch) only hit the network once per page load.
- * @returns {Promise<void>}
  */
-export function loadAndSetCurrencyOverrides() {
+export function loadAndSetCurrencyOverrides(): Promise< void > {
 	if ( typeof window === 'undefined' ) {
 		return Promise.resolve();
 	}

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -7,6 +7,7 @@ import { defaultI18n } from '@wordpress/i18n';
 import debugFactory from 'debug';
 import i18n from 'i18n-calypso';
 import { forEach, throttle } from 'lodash';
+import { loadAndSetCurrencyOverrides } from 'calypso/lib/i18n-utils/load-currency-overrides';
 const debug = debugFactory( 'calypso:i18n' );
 
 const getPromises = {};
@@ -340,6 +341,7 @@ export default async function switchLocale( localeSlug ) {
 
 	// Propagate the locale to @automattic/number-formatters
 	setLocaleNumberFormatters( localeSlug );
+	loadAndSetCurrencyOverrides();
 
 	lastRequestedLocale = localeSlug;
 

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/languages": "workspace:^",
 		"@automattic/launchpad": "workspace:^",
-		"@automattic/number-formatters": "^1.1.9",
+		"@automattic/number-formatters": "^1.2.0",
 		"@automattic/omnibar": "workspace:^",
 		"@automattic/plans-grid-next": "workspace:^",
 		"@automattic/privacy-toolset": "workspace:^",

--- a/packages/api-core/src/currency-overrides/fetchers.ts
+++ b/packages/api-core/src/currency-overrides/fetchers.ts
@@ -1,0 +1,15 @@
+import type { CurrencyOverrides } from './types';
+
+export async function fetchCurrencyOverrides( signal?: AbortSignal ): Promise< CurrencyOverrides > {
+	const response = await fetch( 'https://public-api.wordpress.com/wpcom/v2/currency-overrides', {
+		signal,
+	} );
+
+	if ( ! response.ok ) {
+		throw new Error(
+			`The /wpcom/v2/currency-overrides endpoint returned an error: ${ response.status } ${ response.statusText }`
+		);
+	}
+
+	return await response.json();
+}

--- a/packages/api-core/src/currency-overrides/index.ts
+++ b/packages/api-core/src/currency-overrides/index.ts
@@ -1,0 +1,2 @@
+export * from './fetchers';
+export * from './types';

--- a/packages/api-core/src/currency-overrides/types.ts
+++ b/packages/api-core/src/currency-overrides/types.ts
@@ -1,0 +1,6 @@
+export interface CurrencyOverride {
+	decimal?: number;
+	symbol?: string;
+}
+
+export type CurrencyOverrides = Record< string, CurrencyOverride >;

--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -7,6 +7,7 @@ export * from './agency';
 export * from './akismet-api-key';
 export * from './big-sky-plugin';
 export * from './cancellation-offers';
+export * from './currency-overrides';
 export * from './dashboard-admin-bar';
 export * from './dashboard-site-list';
 export * from './domain';

--- a/packages/calypso-products/package.json
+++ b/packages/calypso-products/package.json
@@ -47,7 +47,7 @@
 		"@automattic/calypso-config": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
-		"@automattic/number-formatters": "^1.1.9",
+		"@automattic/number-formatters": "^1.2.0",
 		"@automattic/shopping-cart": "workspace:^",
 		"@automattic/urls": "workspace:^",
 		"i18n-calypso": "workspace:^"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -49,7 +49,7 @@
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/load-script": "workspace:^",
 		"@automattic/material-design-icons": "workspace:^",
-		"@automattic/number-formatters": "^1.1.9",
+		"@automattic/number-formatters": "^1.2.0",
 		"@automattic/typography": "workspace:^",
 		"@automattic/ui": "workspace:^",
 		"@automattic/viewport-react": "workspace:^",

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -51,7 +51,7 @@
 		"@automattic/design-types": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/js-utils": "workspace:^",
-		"@automattic/number-formatters": "^1.1.9",
+		"@automattic/number-formatters": "^1.2.0",
 		"@automattic/oauth-token": "workspace:^",
 		"@automattic/shopping-cart": "workspace:^",
 		"@tanstack/react-query": "^5.83.0",

--- a/packages/mini-cart/package.json
+++ b/packages/mini-cart/package.json
@@ -47,7 +47,7 @@
 	"homepage": "https://github.com/Automattic/wp-calypso/tree/HEAD/packages/mini-cart#readme",
 	"dependencies": {
 		"@automattic/composite-checkout": "workspace:^",
-		"@automattic/number-formatters": "^1.1.9",
+		"@automattic/number-formatters": "^1.2.0",
 		"@automattic/shopping-cart": "workspace:^",
 		"@automattic/wpcom-checkout": "workspace:^",
 		"@emotion/styled": "^11.11.0",

--- a/packages/plans-grid-next/package.json
+++ b/packages/plans-grid-next/package.json
@@ -49,7 +49,7 @@
 		"@automattic/calypso-products": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",
-		"@automattic/number-formatters": "^1.1.9",
+		"@automattic/number-formatters": "^1.2.0",
 		"@automattic/onboarding": "workspace:^",
 		"@automattic/typography": "workspace:^",
 		"@emotion/react": "11.11.1",

--- a/packages/wpcom-checkout/package.json
+++ b/packages/wpcom-checkout/package.json
@@ -49,7 +49,7 @@
 		"@automattic/components": "workspace:^",
 		"@automattic/composite-checkout": "workspace:^",
 		"@automattic/js-utils": "workspace:^",
-		"@automattic/number-formatters": "^1.1.9",
+		"@automattic/number-formatters": "^1.2.0",
 		"@automattic/shopping-cart": "workspace:^",
 		"@emotion/styled": "^11.11.0",
 		"@fnando/cnpj": "2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -33499,7 +33499,7 @@ __metadata:
     "@automattic/i18n-utils": "workspace:^"
     "@automattic/languages": "workspace:^"
     "@automattic/launchpad": "workspace:^"
-    "@automattic/number-formatters": "npm:^1.1.9"
+    "@automattic/number-formatters": "npm:^1.2.0"
     "@automattic/omnibar": "workspace:^"
     "@automattic/plans-grid-next": "workspace:^"
     "@automattic/privacy-toolset": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -320,7 +320,7 @@ __metadata:
     "@automattic/components": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
     "@automattic/languages": "workspace:^"
-    "@automattic/number-formatters": "npm:^1.1.9"
+    "@automattic/number-formatters": "npm:^1.2.0"
     "@automattic/webpack-extensive-lodash-replacement-plugin": "workspace:^"
     "@automattic/webpack-inline-constant-exports-plugin": "workspace:^"
     "@automattic/wp-babel-makepot": "workspace:^"
@@ -666,7 +666,7 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
-    "@automattic/number-formatters": "npm:^1.1.9"
+    "@automattic/number-formatters": "npm:^1.2.0"
     "@automattic/shopping-cart": "workspace:^"
     "@automattic/urls": "workspace:^"
     "@wordpress/data": "npm:^10.46.0"
@@ -870,7 +870,7 @@ __metadata:
     "@automattic/i18n-utils": "workspace:^"
     "@automattic/load-script": "workspace:^"
     "@automattic/material-design-icons": "workspace:^"
-    "@automattic/number-formatters": "npm:^1.1.9"
+    "@automattic/number-formatters": "npm:^1.2.0"
     "@automattic/typography": "workspace:^"
     "@automattic/ui": "workspace:^"
     "@automattic/viewport-react": "workspace:^"
@@ -1027,7 +1027,7 @@ __metadata:
     "@automattic/design-types": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
     "@automattic/js-utils": "workspace:^"
-    "@automattic/number-formatters": "npm:^1.1.9"
+    "@automattic/number-formatters": "npm:^1.2.0"
     "@automattic/oauth-token": "workspace:^"
     "@automattic/shopping-cart": "workspace:^"
     "@remix-run/router": "npm:^1.5.0"
@@ -1762,7 +1762,7 @@ __metadata:
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/composite-checkout": "workspace:^"
-    "@automattic/number-formatters": "npm:^1.1.9"
+    "@automattic/number-formatters": "npm:^1.2.0"
     "@automattic/shopping-cart": "workspace:^"
     "@automattic/wpcom-checkout": "workspace:^"
     "@emotion/styled": "npm:^11.11.0"
@@ -1823,7 +1823,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/number-formatters@npm:^1.1.2, @automattic/number-formatters@npm:^1.1.9, @automattic/number-formatters@npm:^1.2.0":
+"@automattic/number-formatters@npm:^1.1.2, @automattic/number-formatters@npm:^1.2.0":
   version: 1.2.0
   resolution: "@automattic/number-formatters@npm:1.2.0"
   dependencies:
@@ -2031,7 +2031,7 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/data-stores": "workspace:^"
-    "@automattic/number-formatters": "npm:^1.1.9"
+    "@automattic/number-formatters": "npm:^1.2.0"
     "@automattic/onboarding": "workspace:^"
     "@automattic/shopping-cart": "workspace:^"
     "@automattic/typography": "workspace:^"
@@ -2588,7 +2588,7 @@ __metadata:
     "@automattic/components": "workspace:^"
     "@automattic/composite-checkout": "workspace:^"
     "@automattic/js-utils": "workspace:^"
-    "@automattic/number-formatters": "npm:^1.1.9"
+    "@automattic/number-formatters": "npm:^1.2.0"
     "@automattic/shopping-cart": "workspace:^"
     "@emotion/styled": "npm:^11.11.0"
     "@fnando/cnpj": "npm:2.0.0"
@@ -19916,7 +19916,7 @@ __metadata:
     "@automattic/calypso-products": "workspace:^"
     "@automattic/color-studio": "npm:^4.1.0"
     "@automattic/components": "workspace:^"
-    "@automattic/number-formatters": "npm:^1.1.9"
+    "@automattic/number-formatters": "npm:^1.2.0"
     "@automattic/typography": "workspace:^"
     "@automattic/wp-babel-makepot": "workspace:^"
     "@automattic/wpcom-template-parts": "workspace:^"


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/SHILL-36/

## Proposed changes

Fetches a list of currency overrides (currencies whose default decimal-place count needs adjustment) from the new unauthenticated `/wpcom/v2/currency-overrides` endpoint and propagates them to `@automattic/number-formatters` via its new `setCurrencyOverrides` setter, alongside the existing `setLocale` flow.

* Add `fetchCurrencyOverrides` + `CurrencyOverride`/`CurrencyOverrides` types to `@automattic/api-core` (modeled on the existing `geo/` module) so non-calypso clients can reuse the fetcher.
* Add `loadAndSetCurrencyOverrides()` in `client/lib/i18n-utils/` that wraps the fetcher with promise-level memoization and calls `setCurrencyOverrides`. Failures clear the cache to allow a retry on the next locale change.
* Wire the loader into the three places that already call `setLocaleNumberFormatters`: `client/boot/locale.js`, `client/lib/i18n-utils/switch-locale.js`, and `client/components/calypso-i18n-provider/index.tsx`.

Depends on https://github.com/Automattic/jetpack/pull/49016
Depends on 218973-ghe-Automattic/wpcom

With default decimal overrides             |  With hacked decimal overrides
:-------------------------:|:-------------------------:
<img width="405" height="337" alt="before-changing-to-decimal-0" src="https://github.com/user-attachments/assets/2ce6ecbd-c4c3-4fe4-a993-849b9f49b682" /> | <img width="407" height="313" alt="after-changing-to-decimal-0" src="https://github.com/user-attachments/assets/6b992a21-a4e4-4054-804a-61d6d51fee94" />
<img width="402" height="296" alt="Screenshot 2026-05-27 at 6 24 42 PM" src="https://github.com/user-attachments/assets/cc2ee9fb-abe1-409e-86cf-f710e1c2bb22" /> | <img width="407" height="293" alt="Screenshot 2026-05-27 at 6 24 28 PM" src="https://github.com/user-attachments/assets/6d9f674a-bdcd-4d5c-a6af-e63481ad6512" />


## Why are these changes being made?

The decimal-place override list for currencies like IDR currently lives hard-coded inside `@automattic/number-formatters`. Updating it requires a package release and a downstream version bump in every consumer. Moving the data behind a wpcom endpoint lets us correct currency formatting (decimals, symbols) without shipping new package versions — the same approach we already use for the locale and geolocation settings.

The fetch is memoized per page load because the override list is global (not locale-dependent), but it's triggered from the locale-set call sites so that boot, redux locale changes, and the React i18n provider all kick it off naturally without a separate boot hook.

This PR depends on the matching `@automattic/number-formatters` change that introduces `setCurrencyOverrides` (and extends `CurrencyOverride` with `decimal`), see https://github.com/Automattic/jetpack/pull/49016. Until that package version is published and the dependency is bumped in calypso, the `import/named` lint rule will flag the import — that's the only outstanding lint failure on this branch.

## Testing instructions

* Boot calypso, open DevTools → Network, and confirm a single request to `https://public-api.wordpress.com/wpcom/v2/currency-overrides` fires during page load.
* Render a price in a currency the endpoint overrides (e.g. IDR) somewhere in checkout or the plans grid and verify the decimal-place count matches the endpoint response. 
* To really be sure this works, modify the `currency-overrides` endpoint on your sandbox to return an incorrect value and make sure it changes how that currency is displayed in calypso.