### PR TITLE
Dashboard: Scope multisite backup/scan messaging to self-hosted Jetpack

### DIFF
--- a/client/dashboard/sites/overview-backup-card/index.tsx
+++ b/client/dashboard/sites/overview-backup-card/index.tsx
@@ -7,6 +7,7 @@ import { useFormattedTime } from '../../components/formatted-time';
 import OverviewCard from '../../components/overview-card';
 import { useTimeSince } from '../../components/time-since';
 import { getBackupUrl } from '../../utils/site-backup';
+import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import HostingFeatureGatedWithOverviewCard from '../hosting-feature-gated-with-overview-card';
 import JetpackConnectionWarningCard from '../overview-jetpack-connection-warning-card';
 import type { Site, SiteActivityLog } from '@automattic/api-core';
@@ -106,7 +107,7 @@ export default function BackupCard( { site }: { site: Site } ) {
 		return <JetpackConnectionWarningCard { ...CARD_PROPS } />;
 	}
 
-	if ( site.is_multisite ) {
+	if ( isSelfHostedJetpackConnected( site ) && site.is_multisite ) {
 		return (
 			<OverviewCard
 				{ ...CARD_PROPS }

--- a/client/dashboard/sites/overview-backup-card/index.tsx
+++ b/client/dashboard/sites/overview-backup-card/index.tsx
@@ -7,7 +7,7 @@ import { useFormattedTime } from '../../components/formatted-time';
 import OverviewCard from '../../components/overview-card';
 import { useTimeSince } from '../../components/time-since';
 import { getBackupUrl } from '../../utils/site-backup';
-import { isSelfHostedJetpackConnected } from '../../utils/site-types';
+import { isSimple } from '../../utils/site-types';
 import HostingFeatureGatedWithOverviewCard from '../hosting-feature-gated-with-overview-card';
 import JetpackConnectionWarningCard from '../overview-jetpack-connection-warning-card';
 import type { Site, SiteActivityLog } from '@automattic/api-core';
@@ -107,7 +107,7 @@ export default function BackupCard( { site }: { site: Site } ) {
 		return <JetpackConnectionWarningCard { ...CARD_PROPS } />;
 	}
 
-	if ( isSelfHostedJetpackConnected( site ) && site.is_multisite ) {
+	if ( site.is_multisite && ! isSimple( site ) ) {
 		return (
 			<OverviewCard
 				{ ...CARD_PROPS }

--- a/client/dashboard/sites/overview-scan-card/index.tsx
+++ b/client/dashboard/sites/overview-scan-card/index.tsx
@@ -7,7 +7,7 @@ import OverviewCard from '../../components/overview-card';
 import { useTimeSince } from '../../components/time-since';
 import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { wpcomLink } from '../../utils/link';
-import { isSelfHostedJetpackConnected } from '../../utils/site-types';
+import { isSelfHostedJetpackConnected, isSimple } from '../../utils/site-types';
 import HostingFeatureGatedWithOverviewCard from '../hosting-feature-gated-with-overview-card';
 import JetpackConnectionWarningCard from '../overview-jetpack-connection-warning-card';
 import type { SiteScan, Site } from '@automattic/api-core';
@@ -98,7 +98,7 @@ export default function ScanCard( { site }: { site: Site } ) {
 		return <JetpackConnectionWarningCard { ...CARD_PROPS } />;
 	}
 
-	if ( isSelfHostedJetpackConnected( site ) && site.is_multisite ) {
+	if ( site.is_multisite && ! isSimple( site ) ) {
 		return (
 			<OverviewCard
 				{ ...CARD_PROPS }

--- a/client/dashboard/sites/overview-scan-card/index.tsx
+++ b/client/dashboard/sites/overview-scan-card/index.tsx
@@ -98,7 +98,7 @@ export default function ScanCard( { site }: { site: Site } ) {
 		return <JetpackConnectionWarningCard { ...CARD_PROPS } />;
 	}
 
-	if ( site.is_multisite ) {
+	if ( isSelfHostedJetpackConnected( site ) && site.is_multisite ) {
 		return (
 			<OverviewCard
 				{ ...CARD_PROPS }

--- a/client/dashboard/utils/site-type-feature-support.ts
+++ b/client/dashboard/utils/site-type-feature-support.ts
@@ -1,4 +1,4 @@
-import { isCommerceGarden, isSelfHostedJetpackConnected } from './site-types';
+import { isCommerceGarden, isSelfHostedJetpackConnected, isSimple } from './site-types';
 import type { Site } from '@automattic/api-core';
 
 export type SiteTypeFeatureSupports = {
@@ -64,6 +64,26 @@ export function getSiteTypeFeatureSupports( site: Site ): SiteTypeFeatureSupport
 			settingsGeneralDotcomSiteVisibility: false,
 			settingsServer: false,
 			settingsSecurity: false,
+		};
+	}
+
+	if ( site.is_multisite && ! isSimple( site ) ) {
+		return {
+			deployments: true,
+			performance: true,
+			monitoring: true,
+			logs: true,
+			backups: false,
+			scan: false,
+			domains: true,
+			emails: true,
+			settings: true,
+			settingsGeneral: true,
+			settingsGeneralAITools: true,
+			settingsGeneralRedirect: true,
+			settingsGeneralDotcomSiteVisibility: true,
+			settingsServer: true,
+			settingsSecurity: true,
 		};
 	}
 

--- a/client/dashboard/utils/site-type-feature-support.ts
+++ b/client/dashboard/utils/site-type-feature-support.ts
@@ -67,26 +67,6 @@ export function getSiteTypeFeatureSupports( site: Site ): SiteTypeFeatureSupport
 		};
 	}
 
-	if ( site.is_multisite ) {
-		return {
-			deployments: true,
-			performance: true,
-			monitoring: true,
-			logs: true,
-			backups: false,
-			scan: false,
-			domains: true,
-			emails: true,
-			settings: true,
-			settingsGeneral: true,
-			settingsGeneralAITools: true,
-			settingsGeneralRedirect: true,
-			settingsGeneralDotcomSiteVisibility: true,
-			settingsServer: true,
-			settingsSecurity: true,
-		};
-	}
-
 	return {
 		deployments: true,
 		performance: true,


### PR DESCRIPTION
Part of DOTCOM-17175

## Proposed Changes

* Scope the Overview tab's "Not supported on multisite" branch in the backup and scan cards to self-hosted Jetpack-connected sites. WordPress.com Simple sites now fall through to the existing hosting-feature gate.

## Why are these changes being made?

Every WordPress.com Simple site has `is_multisite: true` (Simple sites all live inside WP.com's own multisite network). The backup and scan Overview cards short-circuited on that flag and rendered Jetpack-inherited copy — "Backup is not available for multisite installations." / "Scan is not available for multisite installations." — which is meant for self-hosted WP installs that the customer themselves configured as multisite. For a Simple Business site, the copy was inaccurate and hid the real path forward.

After this change, a Simple Business site falls through to `HostingFeatureGatedWithOverviewCard`, which renders an "Activate to unlock / Back up your site" card linking to the Atomic activation flow that's already gated and ready for these users. Self-hosted Jetpack multisite installs continue to see the accurate "Not supported on multisite" copy.

## Testing Instructions

* On a Simple Business site, open the Overview tab at `/sites/{slug}` and confirm the backup and scan cards now show the "Activate to unlock" / "Back up your site" upsell pointing to the backup/scan pages, not "Not supported on multisite".
* On a self-hosted Jetpack-connected multisite, confirm the existing "Not supported on multisite" copy is preserved on both cards.
* On an Atomic site, confirm there is no regression — backup/scan data renders as before.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?