### PR TITLE
Fix localized login locale boot race

### DIFF
--- a/client/landing/login/index.js
+++ b/client/landing/login/index.js
@@ -22,7 +22,7 @@ async function main() {
 	setStore( store, getStateFromCache( currentUser?.ID ) );
 	configureReduxStore( currentUser, store );
 	setupMiddlewares( currentUser, store );
-	setupLocale( currentUser, store );
+	await setupLocale( currentUser, store );
 	// Plain client (no persistence): /log-in is logged-out-only, so the user-keyed
 	// cache from createQueryClient would never hit. Skips the async hydrate too.
 	// If this boot ever needs to support logged-in users, switch to createQueryClient().


### PR DESCRIPTION
Follow-up to #107609

## Proposed Changes

* Await locale setup in the isolated login boot before starting the login router.

## Why are these changes being made?

* Anonymous localized login can SSR in the requested locale, then hydrate into English because the login entrypoint starts routing while async locale setup is still in flight.
* This matches the main Calypso boot pattern from #107124 and keeps the first client render in the same locale as the SSR HTML.

## Testing Instructions

* Against the wpcalypso environment, open `/log-in/nl` in a private browser.
* Before this change, the anonymous form can hydrate into English even though the page source is localized.
* After this change, the anonymous form should remain localized and the username field and primary button should be interactive.
* Ran `./node_modules/.bin/eslint --ext .js,.jsx,.ts,.tsx,.mjs,.json client/landing/login/index.js`.
* Ran `NODE_OPTIONS=--max-old-space-size=8192 yarn typecheck-client`; it failed on unrelated current type errors outside `client/landing/login/index.js`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
