### PR TITLE
Handle stale selected block ids for Jetpack AI edits

### DIFF
--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -20,7 +20,7 @@ jest.mock(
 jest.mock( '@wordpress/data', () => ( {
 	useSelect: () => undefined,
 } ) );
-jest.mock( '@wordpress/element', () => require( 'react' ) );
+jest.mock( '@wordpress/element', () => jest.requireActual( 'react' ) );
 jest.mock( '@wordpress/i18n', () => ( { __: ( text: string ) => text } ) );
 jest.mock( 'react-router-dom', () => ( {
 	useNavigate: () => jest.fn(),
@@ -109,7 +109,7 @@ describe( 'OrchestratorChat', () => {
 				onExpand={ jest.fn() }
 				chatHeaderOptions={ [] }
 				markdownComponents={ {} }
-				markdownExtensions={ [] }
+				markdownExtensions={ {} }
 				isCompactMode={ false }
 				onHasMessagesChange={ jest.fn() }
 			/>

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-disable import/order -- jest.mock calls must precede imports */
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { Suggestion } from '@automattic/agenttic-ui';
+
+const mockUseAgentChat = jest.fn();
+
+jest.mock(
+	'@automattic/agenttic-client',
+	() => ( {
+		getAgentManager: () => ( {
+			updateSessionId: jest.fn(),
+		} ),
+		useAgentChat: () => mockUseAgentChat(),
+	} ),
+	{ virtual: true }
+);
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: () => undefined,
+} ) );
+jest.mock( '@wordpress/element', () => require( 'react' ) );
+jest.mock( '@wordpress/i18n', () => ( { __: ( text: string ) => text } ) );
+jest.mock( 'react-router-dom', () => ( {
+	useNavigate: () => jest.fn(),
+} ) );
+jest.mock( '../../contexts', () => ( {
+	useAgentsManagerContext: () => ( {
+		agentConfig: { agentId: 'wp-orchestrator' },
+		getActiveSessionId: () => 'session-id',
+		siteKey: 'site-1',
+	} ),
+} ) );
+jest.mock( '../../hooks/use-conversation', () => () => ( { isLoading: false } ) );
+jest.mock( '../../hooks/use-save-new-chat-route', () => () => {} );
+jest.mock( '../../hooks/use-checkpoint-action', () => () => {} );
+jest.mock( '../../hooks/use-feedback-action', () => () => ( {
+	showFeedbackInput: false,
+	submitFeedbackText: jest.fn(),
+	resetFeedback: jest.fn(),
+} ) );
+jest.mock( '../../hooks/use-copy-action', () => () => {} );
+jest.mock( '../../hooks/use-sources-action', () => () => {} );
+jest.mock( '../../hooks/use-zoom-action', () => () => {} );
+jest.mock( '../../utils/agent-session', () => ( { markSessionUsed: jest.fn() } ) );
+jest.mock( '../../utils/convert-tool-messages-to-components', () => ( {
+	__esModule: true,
+	default: ( { messages }: { messages: unknown[] } ) => messages,
+} ) );
+jest.mock( '../../utils/external-context', () => ( {
+	consumeNextMessageExternalContextEntries: jest.fn(),
+	removeExternalContextCard: jest.fn(),
+	removeExternalContextEntry: jest.fn(),
+} ) );
+jest.mock( '../../utils/is-reader-chat-agent', () => ( {
+	isReaderChatAgent: () => false,
+} ) );
+jest.mock( '../../utils/persist-last-activity', () => ( {
+	persistLastActivity: jest.fn(),
+} ) );
+jest.mock( '../agent-chat', () => ( {
+	__esModule: true,
+	default: ( { onSuggestionClick }: { onSuggestionClick: ( suggestion: Suggestion ) => void } ) => (
+		<button
+			onClick={ () =>
+				onSuggestionClick( {
+					id: 'simplify-text',
+					label: 'Simplify text',
+					prompt: 'Simplify this text to make it easier to read',
+				} )
+			}
+		>
+			Click suggestion
+		</button>
+	),
+} ) );
+
+import OrchestratorChat from '../orchestrator-chat';
+
+describe( 'OrchestratorChat', () => {
+	beforeEach( () => {
+		mockUseAgentChat.mockReturnValue( {
+			addMessage: jest.fn(),
+			messages: [],
+			suggestions: [],
+			isProcessing: false,
+			error: null,
+			loadMessages: jest.fn(),
+			onSubmit: jest.fn(),
+			abortCurrentRequest: jest.fn(),
+			clearSuggestions: jest.fn(),
+			registerSuggestions: jest.fn(),
+			registerMessageActions: jest.fn(),
+			progressMessage: null,
+		} );
+	} );
+
+	it( 'dispatches the inline suggestion event when an Agenttic suggestion is clicked', () => {
+		const listener = jest.fn();
+		window.addEventListener( 'big-sky-inline-suggestion-click', listener );
+
+		render(
+			<OrchestratorChat
+				emptyViewSuggestions={ [] }
+				isDocked={ false }
+				isOpen
+				onClose={ jest.fn() }
+				onExpand={ jest.fn() }
+				chatHeaderOptions={ [] }
+				markdownComponents={ {} }
+				markdownExtensions={ [] }
+				isCompactMode={ false }
+				onHasMessagesChange={ jest.fn() }
+			/>
+		);
+
+		fireEvent.click( screen.getByText( 'Click suggestion' ) );
+
+		expect( listener ).toHaveBeenCalledTimes( 1 );
+		expect( ( listener.mock.calls[ 0 ][ 0 ] as CustomEvent ).detail ).toEqual( {
+			value: 'Simplify this text to make it easier to read',
+		} );
+
+		window.removeEventListener( 'big-sky-inline-suggestion-click', listener );
+	} );
+} );

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -59,6 +59,11 @@ interface Props {
 	onExpand: () => void;
 	/** Called to clear the suggestions. */
 	clearSuggestions?: () => void;
+	/** Called when a suggestion is clicked. */
+	onSuggestionClick?: (
+		selectedSuggestion: Suggestion,
+		availableSuggestions: Suggestion[]
+	) => void;
 	/** Called when the typing status changes. */
 	onTypingStatusChange?: ( isTyping: boolean ) => void;
 	/** Custom components for rendering markdown. */
@@ -161,6 +166,7 @@ export default function AgentChat( {
 	onClose,
 	onExpand,
 	clearSuggestions,
+	onSuggestionClick,
 	notice,
 	markdownComponents = {},
 	markdownExtensions = {},
@@ -220,6 +226,7 @@ export default function AgentChat( {
 			variant={ isDocked ? 'embedded' : 'floating' }
 			suggestions={ suggestions }
 			clearSuggestions={ clearSuggestions }
+			onSuggestionClick={ onSuggestionClick }
 			floatingChatState={ floatingChatState }
 			onClose={ onClose }
 			onExpand={ onExpand }

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -387,6 +387,7 @@ export default function OrchestratorChat( {
 		clearMessages: () => loadMessages( [] ),
 		clearSuggestions,
 		getAgentManager,
+		isProcessing,
 		setIsThinking,
 		deleteMarkedMessages: ( msgs ) => {
 			setDeletedMessageIds(

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -340,7 +340,7 @@ export default function OrchestratorChat( {
 		pathname: window.location.pathname,
 	} );
 
-	// Listen for inline suggestion clicks dispatched by Big Sky's InlineSuggestions component.
+	// Listen for inline suggestion clicks dispatched by external providers or the Agenttic bridge below.
 	useEffect( () => {
 		const handleInlineSuggestionClick = ( event: Event ) => {
 			const { value } = ( event as CustomEvent ).detail;
@@ -363,6 +363,13 @@ export default function OrchestratorChat( {
 		return () => {
 			window.removeEventListener( 'big-sky-inline-suggestion-click', handleInlineSuggestionClick );
 		};
+	}, [] );
+
+	const handleSuggestionClick = useCallback( ( suggestion: Suggestion ) => {
+		const value = suggestion.prompt ?? suggestion.label;
+		window.dispatchEvent(
+			new CustomEvent( 'big-sky-inline-suggestion-click', { detail: { value } } )
+		);
 	}, [] );
 
 	// Invoke abilities setup hook to register hook-based abilities that utilize React context.
@@ -473,6 +480,7 @@ export default function OrchestratorChat( {
 			onClose={ onClose }
 			onExpand={ onExpand }
 			clearSuggestions={ clearSuggestions }
+			onSuggestionClick={ handleSuggestionClick }
 			chatHeaderOptions={ chatHeaderOptions }
 			markdownComponents={ markdownComponents }
 			markdownExtensions={ markdownExtensions }

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -59,6 +59,7 @@ export type AbilitiesSetupHook = ( actions: {
 	clearMessages: () => void;
 	clearSuggestions: UseAgentChatReturn[ 'clearSuggestions' ];
 	getAgentManager: typeof getAgentManager;
+	isProcessing?: boolean;
 	setIsThinking: ( isThinking: boolean ) => void;
 	deleteMarkedMessages: ( messages: Record< 'id', string >[] ) => void;
 	getSessionId: () => string | undefined;

--- a/packages/jetpack-ai-sidebar/src/components/review-mediation.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/review-mediation.tsx
@@ -540,7 +540,7 @@ export default function ReviewMediation( {
 				if ( result?.success ) {
 					return {
 						success: true,
-						clientId,
+						clientId: result.clientId ?? clientId,
 						contentBefore: result.contentBefore,
 						contentAfter: result.contentAfter,
 					};

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -1050,6 +1050,13 @@ describe( 'findBlockElement', () => {
 		expect( findBlockElement( '550e8400-e29b-41d4-a716-446655440000' ) ).toBe( el );
 	} );
 
+	it( 'supports short mixed-case Gutenberg clientIds', () => {
+		const el = document.createElement( 'div' );
+		el.setAttribute( 'data-block', 'lQ0k' );
+		document.body.appendChild( el );
+		expect( findBlockElement( 'lQ0k' ) ).toBe( el );
+	} );
+
 	it( 'returns null when the clientId is not in the DOM', () => {
 		// Returns null from the regex guard, the main-doc querySelector miss,
 		// or the optional editor-canvas iframe lookup chain (coerced via ?? null).
@@ -1059,8 +1066,7 @@ describe( 'findBlockElement', () => {
 	it( 'rejects malformed clientIds to prevent selector injection', () => {
 		expect( findBlockElement( '"][onerror="alert(1)"]' ) ).toBeNull();
 		expect( findBlockElement( 'contains space' ) ).toBeNull();
-		// Non-hex characters fail the regex guard.
-		expect( findBlockElement( 'not-a-real-clientid-g' ) ).toBeNull();
+		expect( findBlockElement( 'client.id' ) ).toBeNull();
 	} );
 } );
 

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -361,6 +361,40 @@ describe( 'useSuggestions', () => {
 		expect( mockSetIsSplitScreen ).not.toHaveBeenCalled();
 	} );
 
+	it( 're-shows block suggestions when a block action completes', () => {
+		installAiEditorialReviewData();
+		mockSelectedBlock = { clientId: 'b1', name: 'core/paragraph' };
+		const onSuggestions = jest.fn();
+
+		render( React.createElement( SuggestionsProbe, { onSuggestions } ) );
+
+		act( () => {
+			window.dispatchEvent(
+				new CustomEvent( 'big-sky-inline-suggestion-click', {
+					detail: { value: 'Check the grammar and spelling of this text' },
+				} )
+			);
+		} );
+
+		let latestSuggestions =
+			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
+		expect( latestSuggestions ).toEqual( [] );
+
+		act( () => {
+			window.dispatchEvent( new Event( 'jetpack-ai-sidebar-block-action-complete' ) );
+		} );
+
+		latestSuggestions =
+			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
+		expect( latestSuggestions.map( ( suggestion: any ) => suggestion.label ) ).toEqual( [
+			'Translate content',
+			'Change tone',
+			'Check grammar',
+			'Simplify text',
+			'AI Editorial Review',
+		] );
+	} );
+
 	it( 'starts the selected block shimmer when AM starts processing', () => {
 		jest.useFakeTimers();
 		installPostTypeMock( 'post' );
@@ -624,6 +658,7 @@ function installWpDataMockWithBlockEditor(
 ) {
 	const editorState: { title: string } = { title: 'original' };
 	const blockUpdates: Array< { clientId: string; attrs: Record< string, unknown > } > = [];
+	const selectedClientIds: string[] = [];
 	( window as any ).wp = {
 		data: {
 			select: ( store: string ) => {
@@ -660,6 +695,15 @@ function installWpDataMockWithBlockEditor(
 					return {
 						updateBlockAttributes: ( clientId: string, attrs: Record< string, unknown > ) => {
 							blockUpdates.push( { clientId, attrs } );
+							if ( blocks[ clientId ] ) {
+								blocks[ clientId ].attributes = {
+									...blocks[ clientId ].attributes,
+									...attrs,
+								};
+							}
+						},
+						selectBlock: ( clientId: string ) => {
+							selectedClientIds.push( clientId );
 						},
 					};
 				}
@@ -667,7 +711,7 @@ function installWpDataMockWithBlockEditor(
 			},
 		},
 	};
-	return { editorState, blockUpdates, blocks };
+	return { editorState, blockUpdates, blocks, selectedClientIds };
 }
 
 describe( 'applyReviewEdit', () => {
@@ -754,7 +798,7 @@ describe( 'applyReviewEdit', () => {
 		expect( blockEl.classList.contains( 'jetpack-ai-is-processing' ) ).toBe( false );
 	} );
 
-	it( 'posts the rationale as an assistant message to the chat when a summary is provided', async () => {
+	it( 'returns the rationale as an agent message so AM can attach feedback actions', async () => {
 		installWpDataMockWithBlockEditor();
 		const addMessage = jest.fn();
 		useAbilitiesSetup( {
@@ -768,15 +812,10 @@ describe( 'applyReviewEdit', () => {
 			'Follows Copy guideline on specific dates.'
 		);
 		jest.advanceTimersByTime( 1000 );
-		await promise;
+		const result = await promise;
 
-		expect( addMessage ).toHaveBeenCalledTimes( 1 );
-		const message = addMessage.mock.calls[ 0 ][ 0 ];
-		expect( message.role ).toBe( 'assistant' );
-		expect( message.content[ 0 ] ).toEqual( {
-			type: 'text',
-			text: 'Follows Copy guideline on specific dates.',
-		} );
+		expect( addMessage ).not.toHaveBeenCalled();
+		expect( result.agentMessage ).toBe( 'Follows Copy guideline on specific dates.' );
 	} );
 
 	it( 'does not emit a chat message when summary is omitted', async () => {
@@ -792,6 +831,54 @@ describe( 'applyReviewEdit', () => {
 		await promise;
 
 		expect( addMessage ).not.toHaveBeenCalled();
+	} );
+
+	it( 'supports repeated edits against the updated selected block content', async () => {
+		const { blockUpdates, selectedClientIds } = installWpDataMockWithBlockEditor( {
+			'550e8400-e29b-41d4-a716-446655440000': {
+				name: 'core/paragraph',
+				attributes: { content: 'hello world this is my firsst post' },
+			},
+		} );
+		useAbilitiesSetup( { addMessage: () => undefined, clearSuggestions: () => undefined } as any );
+
+		const first = applyReviewEdit(
+			'550e8400-e29b-41d4-a716-446655440000',
+			'Hello world, this is my first post.',
+			undefined,
+			'hello world this is my firsst post'
+		);
+		jest.advanceTimersByTime( 1000 );
+		await first;
+
+		const second = applyReviewEdit(
+			'550e8400-e29b-41d4-a716-446655440000',
+			'Hello world, this is my first post!',
+			undefined,
+			'Hello world, this is my first post.'
+		);
+		jest.advanceTimersByTime( 1000 );
+		const result = await second;
+
+		expect( result ).toMatchObject( {
+			success: true,
+			contentBefore: 'Hello world, this is my first post.',
+			contentAfter: 'Hello world, this is my first post!',
+		} );
+		expect( blockUpdates ).toEqual( [
+			{
+				clientId: '550e8400-e29b-41d4-a716-446655440000',
+				attrs: { content: 'Hello world, this is my first post.' },
+			},
+			{
+				clientId: '550e8400-e29b-41d4-a716-446655440000',
+				attrs: { content: 'Hello world, this is my first post!' },
+			},
+		] );
+		expect( selectedClientIds ).toEqual( [
+			'550e8400-e29b-41d4-a716-446655440000',
+			'550e8400-e29b-41d4-a716-446655440000',
+		] );
 	} );
 
 	// Intentionally no direct unit test for the `setCheckpoint` call inside

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -360,6 +360,38 @@ describe( 'useSuggestions', () => {
 
 		expect( mockSetIsSplitScreen ).not.toHaveBeenCalled();
 	} );
+
+	it( 'starts the selected block shimmer when AM starts processing', () => {
+		jest.useFakeTimers();
+		installPostTypeMock( 'post' );
+		mockSelectedBlock = { clientId: 'lQ0k', name: 'core/paragraph' };
+		const blockEl = document.createElement( 'div' );
+		blockEl.setAttribute( 'data-block', 'lQ0k' );
+		document.body.appendChild( blockEl );
+
+		useAbilitiesSetup( {
+			addMessage: () => undefined,
+			clearSuggestions: () => undefined,
+			isProcessing: false,
+		} as any );
+		useAbilitiesSetup( {
+			addMessage: () => undefined,
+			clearSuggestions: () => undefined,
+			isProcessing: true,
+		} as any );
+
+		expect( blockEl.classList.contains( 'jetpack-ai-is-processing' ) ).toBe( true );
+		expect( blockEl.classList.contains( 'jetpack-ai-is-processing-content' ) ).toBe( true );
+		useAbilitiesSetup( {
+			addMessage: () => undefined,
+			clearSuggestions: () => undefined,
+			isProcessing: false,
+		} as any );
+		expect( blockEl.classList.contains( 'jetpack-ai-is-processing' ) ).toBe( false );
+		expect( blockEl.classList.contains( 'jetpack-ai-is-processing-content' ) ).toBe( false );
+		jest.runOnlyPendingTimers();
+		jest.useRealTimers();
+	} );
 } );
 
 describe( 'contextProvider', () => {

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -580,7 +580,10 @@ describe( 'useCheckpoint', () => {
 // core/block-editor (for updateBlockAttributes / getBlock). Tracks calls so
 // tests can assert exact dispatches.
 function installWpDataMockWithBlockEditor(
-	blocks: Record< string, { name: string; attributes: { content?: string } } > = {
+	blocks: Record<
+		string,
+		{ name: string; attributes: { content?: string }; innerBlocks?: any[] }
+	> = {
 		'550e8400-e29b-41d4-a716-446655440000': {
 			name: 'core/paragraph',
 			attributes: { content: 'original block content' },
@@ -600,7 +603,13 @@ function installWpDataMockWithBlockEditor(
 				}
 				if ( store === 'core/block-editor' ) {
 					return {
-						getBlock: ( clientId: string ) => blocks[ clientId ] ?? null,
+						getBlock: ( clientId: string ) =>
+							blocks[ clientId ] ? { clientId, ...blocks[ clientId ] } : null,
+						getBlocks: () =>
+							Object.entries( blocks ).map( ( [ clientId, block ] ) => ( {
+								clientId,
+								...block,
+							} ) ),
 					};
 				}
 				return undefined;
@@ -789,6 +798,40 @@ describe( 'applyReviewEdit', () => {
 				attrs: { content: 'The board voted on Tuesday on the proposal.' },
 			},
 		] );
+	} );
+
+	it( 'falls back to a unique currentText match when the clientId is stale', async () => {
+		const { blockUpdates } = installWpDataMockWithBlockEditor( {
+			'live-client-id': {
+				name: 'core/paragraph',
+				attributes: { content: 'hello world this is my firsst post' },
+			},
+		} );
+		useAbilitiesSetup( { addMessage: () => undefined, clearSuggestions: () => undefined } as any );
+		const warn = jest.spyOn( console, 'warn' ).mockImplementation( () => undefined );
+
+		const promise = applyReviewEdit(
+			'stale-client-id',
+			'Hello world, this is my first post.',
+			undefined,
+			'hello world this is my firsst post'
+		);
+		jest.advanceTimersByTime( 1000 );
+		const result = await promise;
+
+		expect( result ).toMatchObject( {
+			success: true,
+			clientId: 'live-client-id',
+			contentBefore: 'hello world this is my firsst post',
+			contentAfter: 'Hello world, this is my first post.',
+		} );
+		expect( blockUpdates ).toEqual( [
+			{
+				clientId: 'live-client-id',
+				attrs: { content: 'Hello world, this is my first post.' },
+			},
+		] );
+		warn.mockRestore();
 	} );
 
 	it( 'revalidates currentText against the latest block content before writing', async () => {

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -1063,10 +1063,22 @@ describe( 'findBlockElement', () => {
 		expect( findBlockElement( '550e8400-e29b-41d4-a716-446655440001' ) ).toBeNull();
 	} );
 
-	it( 'rejects malformed clientIds to prevent selector injection', () => {
+	it( 'escapes clientIds to prevent selector injection', () => {
+		const el = document.createElement( 'div' );
+		el.setAttribute( 'data-block', 'client.id' );
+		document.body.appendChild( el );
+		expect( findBlockElement( 'client.id' ) ).toBe( el );
 		expect( findBlockElement( '"][onerror="alert(1)"]' ) ).toBeNull();
 		expect( findBlockElement( 'contains space' ) ).toBeNull();
-		expect( findBlockElement( 'client.id' ) ).toBeNull();
+	} );
+
+	it( 'finds blocks in accessible editor iframes', () => {
+		const iframe = document.createElement( 'iframe' );
+		document.body.appendChild( iframe );
+		const el = iframe.contentDocument?.createElement( 'div' );
+		el?.setAttribute( 'data-block', 'lQ0k' );
+		iframe.contentDocument?.body.appendChild( el as HTMLElement );
+		expect( findBlockElement( 'lQ0k' ) ).toBe( el );
 	} );
 } );
 

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -30,6 +30,9 @@ import {
 	setModuleCheckpointApi,
 	getModuleCheckpointApi,
 	startBlockShimmer,
+	stopBlockShimmer,
+	getSelectedOrRememberedBlock,
+	rememberSelectedBlock,
 } from './utils/block-actions';
 import {
 	UPDATE_BLOCK_CONTENT_TOOL_ID,
@@ -48,6 +51,7 @@ export { applyReviewEdit, findBlockElement, findBlockListLayout };
 // ---------- Module state ----------
 
 let clearSuggestionsFn: ( () => void ) | null = null;
+let wasAgentProcessing = false;
 
 /** Whether `_suggestion_rendered` has fired this page life (once-per-session). */
 let suggestionRenderedFiredOnce = false;
@@ -270,12 +274,21 @@ function hasAbilitiesApi(): boolean {
 export function useAbilitiesSetup( actions: {
 	addMessage: ( message: any ) => void;
 	clearSuggestions?: () => void;
+	isProcessing?: boolean;
 	[ key: string ]: unknown;
 } ): void {
 	setAddMessageFn( actions.addMessage );
 	if ( actions.clearSuggestions ) {
 		clearSuggestionsFn = actions.clearSuggestions;
 	}
+
+	const isProcessing = actions.isProcessing === true;
+	if ( isProcessing && ! wasAgentProcessing ) {
+		startBlockShimmer();
+	} else if ( ! isProcessing && wasAgentProcessing ) {
+		stopBlockShimmer();
+	}
+	wasAgentProcessing = isProcessing;
 }
 
 // ---------- toolProvider ----------
@@ -432,11 +445,11 @@ export const contextProvider = {
 			if ( blockEditor ) {
 				const blocks = blockEditor.getBlocks?.() ?? [];
 				currentPageContent = blocks.map( serializeBlock );
-				selectedBlockClientId = blockEditor.getSelectedBlockClientId?.() ?? '';
-
-				if ( selectedBlockClientId ) {
-					const selectedBlock = blockEditor.getSelectedBlock?.();
-					if ( selectedBlock?.attributes?.content ) {
+				const selectedBlock = getSelectedOrRememberedBlock();
+				if ( selectedBlock?.clientId ) {
+					selectedBlockClientId = selectedBlock.clientId;
+					rememberSelectedBlock( selectedBlock );
+					if ( selectedBlock.attributes?.content ) {
 						selectedBlockContent = resolveBlockContent( selectedBlock.attributes.content );
 					}
 				}
@@ -561,7 +574,7 @@ const IMAGE_BLOCK_TYPES = [ 'core/image', 'core/media-text', 'core/cover', 'core
 /** Block-aware suggestion definitions with optional condition per block type. */
 const BLOCK_SUGGESTIONS = [
 	{
-		id: 'translate-content',
+		id: 'translate',
 		label: __( 'Translate content', 'jetpack' ),
 		prompt: __( 'Translate this block content to:', 'jetpack' ),
 		condition: ( block: any ) => TEXT_BLOCK_TYPES.includes( block?.name ),
@@ -662,7 +675,12 @@ export function useSuggestions(): {
 		return { suggestions: [] };
 	}
 
-	if ( ! editorContext.selectedBlock ) {
+	const selectedBlock = editorContext.selectedBlock ?? getSelectedOrRememberedBlock();
+	if ( editorContext.selectedBlock ) {
+		rememberSelectedBlock( editorContext.selectedBlock );
+	}
+
+	if ( ! selectedBlock ) {
 		return { suggestions: getPostLevelSuggestions( editorContext.postType ) };
 	}
 
@@ -672,9 +690,7 @@ export function useSuggestions(): {
 		return { suggestions: aiEditorialReviewSuggestions };
 	}
 
-	const applicable = BLOCK_SUGGESTIONS.filter( ( s ) =>
-		s.condition( editorContext.selectedBlock )
-	);
+	const applicable = BLOCK_SUGGESTIONS.filter( ( s ) => s.condition( selectedBlock ) );
 	return {
 		suggestions: [
 			...applicable.map( ( { id, label, prompt } ) => ( { id, label, prompt } ) ),

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -26,13 +26,14 @@ import {
 	findBlockElement,
 	findBlockListLayout,
 	handleUpdateBlockContent,
-	setAddMessageFn,
 	setModuleCheckpointApi,
 	getModuleCheckpointApi,
 	startBlockShimmer,
 	stopBlockShimmer,
 	getSelectedOrRememberedBlock,
 	rememberSelectedBlock,
+	notifyBlockActionComplete,
+	BLOCK_ACTION_COMPLETE_EVENT,
 } from './utils/block-actions';
 import {
 	UPDATE_BLOCK_CONTENT_TOOL_ID,
@@ -277,7 +278,6 @@ export function useAbilitiesSetup( actions: {
 	isProcessing?: boolean;
 	[ key: string ]: unknown;
 } ): void {
-	setAddMessageFn( actions.addMessage );
 	if ( actions.clearSuggestions ) {
 		clearSuggestionsFn = actions.clearSuggestions;
 	}
@@ -287,6 +287,7 @@ export function useAbilitiesSetup( actions: {
 		startBlockShimmer();
 	} else if ( ! isProcessing && wasAgentProcessing ) {
 		stopBlockShimmer();
+		notifyBlockActionComplete();
 	}
 	wasAgentProcessing = isProcessing;
 }
@@ -654,6 +655,16 @@ export function useSuggestions(): {
 		window.addEventListener( 'big-sky-inline-suggestion-click', handleSuggestionClick );
 		return () => {
 			window.removeEventListener( 'big-sky-inline-suggestion-click', handleSuggestionClick );
+		};
+	}, [] );
+
+	useEffect( () => {
+		const handleBlockActionComplete = () => {
+			setHidden( false );
+		};
+		window.addEventListener( BLOCK_ACTION_COMPLETE_EVENT, handleBlockActionComplete );
+		return () => {
+			window.removeEventListener( BLOCK_ACTION_COMPLETE_EVENT, handleBlockActionComplete );
 		};
 	}, [] );
 

--- a/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
@@ -43,8 +43,8 @@ export function getModuleCheckpointApi(): CheckpointApi | null {
  * @returns The block element, or null.
  */
 export function findBlockElement( clientId: string ): HTMLElement | null {
-	// Validate clientId format to prevent selector injection.
-	if ( ! /^[0-9a-f-]+$/i.test( clientId ) ) {
+	// Gutenberg clientIds can be short mixed-case strings, not only UUIDs.
+	if ( ! /^[A-Za-z0-9_-]+$/.test( clientId ) ) {
 		return null;
 	}
 

--- a/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
@@ -35,6 +35,21 @@ export function getModuleCheckpointApi(): CheckpointApi | null {
 
 // ---------- Block element helpers ----------
 
+function getAccessibleFrameDocuments(): Document[] {
+	const docs: Document[] = [];
+	document.querySelectorAll( 'iframe' ).forEach( ( iframe ) => {
+		try {
+			const frameDocument = ( iframe as HTMLIFrameElement ).contentDocument;
+			if ( frameDocument ) {
+				docs.push( frameDocument );
+			}
+		} catch {
+			// Cross-origin frames are not relevant to the block editor.
+		}
+	} );
+	return docs;
+}
+
 /**
  * Find a block element by clientId in the main document or editor iframe.
  * Exported so peer components (e.g. ReviewMediation) can scroll a block into
@@ -43,27 +58,25 @@ export function getModuleCheckpointApi(): CheckpointApi | null {
  * @returns The block element, or null.
  */
 export function findBlockElement( clientId: string ): HTMLElement | null {
-	// Gutenberg clientIds can be short mixed-case strings, not only UUIDs.
-	if ( ! /^[A-Za-z0-9_-]+$/.test( clientId ) ) {
+	if ( ! clientId ) {
 		return null;
 	}
 
+	const selector = `[data-block="${ CSS.escape( clientId ) }"]`;
 	try {
-		const el = document.querySelector( `[data-block="${ clientId }"]` ) as HTMLElement | null;
+		const el = document.querySelector( selector ) as HTMLElement | null;
 		if ( el ) {
 			return el;
 		}
-		const iframe = document.querySelector(
-			'iframe[name="editor-canvas"]'
-		) as HTMLIFrameElement | null;
-		return (
-			( iframe?.contentDocument?.querySelector(
-				`[data-block="${ clientId }"]`
-			) as HTMLElement | null ) ?? null
-		);
+		for ( const frameDocument of getAccessibleFrameDocuments() ) {
+			const frameEl = frameDocument.querySelector( selector ) as HTMLElement | null;
+			if ( frameEl ) {
+				return frameEl;
+			}
+		}
 	} catch {
-		return null;
 	}
+	return null;
 }
 
 /**
@@ -79,13 +92,15 @@ export function findBlockListLayout(): HTMLElement | null {
 		if ( el ) {
 			return el;
 		}
-		const iframe = document.querySelector(
-			'iframe[name="editor-canvas"]'
-		) as HTMLIFrameElement | null;
-		return ( iframe?.contentDocument?.querySelector( selector ) as HTMLElement | null ) ?? null;
+		for ( const frameDocument of getAccessibleFrameDocuments() ) {
+			const frameEl = frameDocument.querySelector( selector ) as HTMLElement | null;
+			if ( frameEl ) {
+				return frameEl;
+			}
+		}
 	} catch {
-		return null;
 	}
+	return null;
 }
 
 // ---------- Processing effect (Flow Block shimmer) ----------

--- a/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
@@ -18,15 +18,12 @@ export interface CheckpointApi {
 
 // ---------- Module state ----------
 
-let addMessageFn: ( ( message: any ) => void ) | null = null;
 let moduleCheckpointApi: CheckpointApi | null = null;
 const processingEffectTimeouts = new WeakMap< HTMLElement, ReturnType< typeof setTimeout > >();
 const processingEffectElements = new Set< HTMLElement >();
 let rememberedSelectedBlockClientId: string | null = null;
 
-export function setAddMessageFn( fn: ( ( message: any ) => void ) | null ): void {
-	addMessageFn = fn;
-}
+export const BLOCK_ACTION_COMPLETE_EVENT = 'jetpack-ai-sidebar-block-action-complete';
 
 export function setModuleCheckpointApi( api: CheckpointApi | null ): void {
 	moduleCheckpointApi = api;
@@ -53,6 +50,13 @@ export function getSelectedOrRememberedBlock(): any | null {
 	return rememberedSelectedBlockClientId
 		? blockEditor?.getBlock?.( rememberedSelectedBlockClientId )
 		: null;
+}
+
+export function notifyBlockActionComplete(): void {
+	if ( typeof window === 'undefined' ) {
+		return;
+	}
+	window.dispatchEvent( new Event( BLOCK_ACTION_COMPLETE_EVENT ) );
 }
 
 function clearProcessingEffectTimeout( el: HTMLElement ): void {
@@ -455,6 +459,7 @@ export function handleUpdateBlockContent( input: any ): any {
 				if ( blockEl ) {
 					removeProcessingEffect( blockEl );
 				}
+				notifyBlockActionComplete();
 				resolve( { success: false, error, returnToAgent: false } );
 			};
 
@@ -509,16 +514,7 @@ export function handleUpdateBlockContent( input: any ): any {
 				removeProcessingEffect( blockEl );
 			}
 
-			// Show summary in chat
-			if ( addMessageFn && summary ) {
-				addMessageFn( {
-					id: `block-update-${ Date.now() }`,
-					role: 'assistant',
-					content: [ { type: 'text', text: summary } ],
-					created_at: Math.floor( Date.now() / 1000 ),
-					showIcon: true,
-				} );
-			}
+			notifyBlockActionComplete();
 
 			resolve( {
 				success: true,
@@ -526,6 +522,7 @@ export function handleUpdateBlockContent( input: any ): any {
 				contentBefore: latestSnapshot.content,
 				contentAfter: nextContent,
 				returnToAgent: false,
+				...( summary ? { agentMessage: summary } : {} ),
 			} );
 		}, 800 );
 	} );
@@ -551,6 +548,7 @@ export async function applyReviewEdit(
 	clientId?: string;
 	contentBefore?: string;
 	contentAfter?: string;
+	agentMessage?: string;
 	error?: string;
 	returnToAgent?: boolean;
 } > {

--- a/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
@@ -20,6 +20,9 @@ export interface CheckpointApi {
 
 let addMessageFn: ( ( message: any ) => void ) | null = null;
 let moduleCheckpointApi: CheckpointApi | null = null;
+const processingEffectTimeouts = new WeakMap< HTMLElement, ReturnType< typeof setTimeout > >();
+const processingEffectElements = new Set< HTMLElement >();
+let rememberedSelectedBlockClientId: string | null = null;
 
 export function setAddMessageFn( fn: ( ( message: any ) => void ) | null ): void {
 	addMessageFn = fn;
@@ -31,6 +34,33 @@ export function setModuleCheckpointApi( api: CheckpointApi | null ): void {
 
 export function getModuleCheckpointApi(): CheckpointApi | null {
 	return moduleCheckpointApi;
+}
+
+export function rememberSelectedBlock( block: any ): void {
+	if ( block?.clientId ) {
+		rememberedSelectedBlockClientId = block.clientId;
+	}
+}
+
+export function getSelectedOrRememberedBlock(): any | null {
+	const blockEditor = ( window as any ).wp?.data?.select( 'core/block-editor' );
+	const selectedBlock = blockEditor?.getSelectedBlock?.();
+	if ( selectedBlock?.clientId ) {
+		rememberSelectedBlock( selectedBlock );
+		return selectedBlock;
+	}
+
+	return rememberedSelectedBlockClientId
+		? blockEditor?.getBlock?.( rememberedSelectedBlockClientId )
+		: null;
+}
+
+function clearProcessingEffectTimeout( el: HTMLElement ): void {
+	const timeout = processingEffectTimeouts.get( el );
+	if ( timeout ) {
+		clearTimeout( timeout );
+		processingEffectTimeouts.delete( el );
+	}
 }
 
 // ---------- Block element helpers ----------
@@ -103,7 +133,7 @@ export function findBlockListLayout(): HTMLElement | null {
 
 // ---------- Processing effect (Flow Block shimmer) ----------
 
-/** Inject processing-effect styles. Uses system fonts so no external font fetch is needed. */
+/** Inject processing-effect styles, matching Big Sky's Flow Block shimmer. */
 function ensureProcessingStyles( doc: Document ): void {
 	if ( doc.getElementById( 'jetpack-ai-processing-styles' ) ) {
 		return;
@@ -111,6 +141,8 @@ function ensureProcessingStyles( doc: Document ): void {
 	const style = doc.createElement( 'style' );
 	style.id = 'jetpack-ai-processing-styles';
 	style.textContent = `
+		@import url(https://fonts.googleapis.com/css2?family=Flow+Block&display=swap);
+
 		@keyframes jetpack-ai-flash-text {
 			0% { opacity: 0.4; }
 			50% { opacity: 0.8; }
@@ -122,13 +154,31 @@ function ensureProcessingStyles( doc: Document ): void {
 		}
 		.jetpack-ai-is-processing,
 		.jetpack-ai-is-processing .wp-block-heading,
-		.jetpack-ai-is-processing .wp-block-paragraph {
-			font-style: italic;
-			transition: transform 1s;
-		}
-		.jetpack-ai-is-processing:not(:has(img)) {
-			animation: jetpack-ai-flash-text 2s infinite;
-		}
+			.jetpack-ai-is-processing .wp-block-paragraph,
+			.jetpack-ai-is-processing-content,
+			.jetpack-ai-is-processing-content .wp-block-heading,
+			.jetpack-ai-is-processing-content .wp-block-paragraph,
+			.big-sky__is-processing-content,
+			.big-sky__is-processing-content .wp-block-heading,
+			.big-sky__is-processing-content .wp-block-paragraph {
+				font-family: "Flow Block", system-ui !important;
+				font-weight: 200;
+				font-style: normal;
+				transition: transform 1s;
+			}
+			.jetpack-ai-is-processing div,
+			.jetpack-ai-is-processing-content div,
+			.big-sky__is-processing-content div {
+				font-family: "Flow Block", system-ui !important;
+				font-weight: 200;
+				font-style: normal;
+				overflow: hidden;
+			}
+			.jetpack-ai-is-processing:not(:has(img)),
+			.jetpack-ai-is-processing-content:not(:has(img)),
+			.big-sky__is-processing-content:not(:has(img)) {
+				animation: jetpack-ai-flash-text 2s infinite;
+			}
 		.jetpack-ai-has-processed {
 			outline: 2px solid rgba(56, 88, 233, 0.8);
 			outline-offset: 2px;
@@ -139,13 +189,39 @@ function ensureProcessingStyles( doc: Document ): void {
 	doc.head.appendChild( style );
 }
 
+function removeProcessingClasses( el: HTMLElement ): void {
+	el.classList.remove( 'jetpack-ai-is-processing' );
+	el.classList.remove( 'jetpack-ai-is-processing-content' );
+	el.classList.remove( 'big-sky__is-processing-content' );
+	delete el.dataset.bigSkyProcessingState;
+	delete el.dataset.bigSkyProcessingFeatures;
+	processingEffectElements.delete( el );
+}
+
+function clearProcessingEffect( el: HTMLElement ): void {
+	clearProcessingEffectTimeout( el );
+	removeProcessingClasses( el );
+}
+
 /**
  * Apply processing effect to a block element.
  * @param el - The block element.
  */
 export function applyProcessingEffect( el: HTMLElement ): void {
 	ensureProcessingStyles( el.ownerDocument );
+	clearProcessingEffectTimeout( el );
 	el.classList.add( 'jetpack-ai-is-processing' );
+	el.classList.add( 'jetpack-ai-is-processing-content' );
+	el.classList.add( 'big-sky__is-processing-content' );
+	el.dataset.bigSkyProcessingState = 'processing';
+	el.dataset.bigSkyProcessingFeatures = 'content';
+	processingEffectElements.add( el );
+	processingEffectTimeouts.set(
+		el,
+		setTimeout( () => {
+			clearProcessingEffect( el );
+		}, 30000 )
+	);
 }
 
 /**
@@ -153,11 +229,18 @@ export function applyProcessingEffect( el: HTMLElement ): void {
  * @param el - The block element.
  */
 function removeProcessingEffect( el: HTMLElement ): void {
-	el.classList.remove( 'jetpack-ai-is-processing' );
+	clearProcessingEffect( el );
 	el.classList.add( 'jetpack-ai-has-processed' );
 	setTimeout( () => {
 		el.classList.remove( 'jetpack-ai-has-processed' );
 	}, 1000 );
+}
+
+/**
+ * Stop shimmer on any block currently marked as processing.
+ */
+export function stopBlockShimmer(): void {
+	Array.from( processingEffectElements ).forEach( clearProcessingEffect );
 }
 
 /**
@@ -168,7 +251,7 @@ export function startBlockShimmer(): void {
 	if ( ! wpData ) {
 		return;
 	}
-	const block = wpData.select( 'core/block-editor' ).getSelectedBlock();
+	const block = getSelectedOrRememberedBlock();
 	if ( block?.clientId ) {
 		const blockEl = findBlockElement( block.clientId );
 		if ( blockEl ) {
@@ -419,6 +502,8 @@ export function handleUpdateBlockContent( input: any ): any {
 			}
 
 			blockEditor.updateBlockAttributes( targetClientId, { content: nextContent } );
+			blockEditor.selectBlock?.( targetClientId );
+			rememberedSelectedBlockClientId = targetClientId;
 
 			if ( blockEl ) {
 				removeProcessingEffect( blockEl );

--- a/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
@@ -74,8 +74,7 @@ export function findBlockElement( clientId: string ): HTMLElement | null {
 				return frameEl;
 			}
 		}
-	} catch {
-	}
+	} catch {}
 	return null;
 }
 
@@ -98,8 +97,7 @@ export function findBlockListLayout(): HTMLElement | null {
 				return frameEl;
 			}
 		}
-	} catch {
-	}
+	} catch {}
 	return null;
 }
 
@@ -219,12 +217,17 @@ function getBlockSnapshot(
 	if ( ! block ) {
 		return null;
 	}
-	return { clientId: block.clientId ?? clientId, name: block.name, content: getEditableBlockContent( block ) };
+	return {
+		clientId: block.clientId ?? clientId,
+		name: block.name,
+		content: getEditableBlockContent( block ),
+	};
 }
 
-function findBlockSnapshotByCurrentText(
-	currentText: string
-): { snapshot?: { clientId: string; name: string; content: string }; error?: string } {
+function findBlockSnapshotByCurrentText( currentText: string ): {
+	snapshot?: { clientId: string; name: string; content: string };
+	error?: string;
+} {
 	const blocks = ( window as any ).wp?.data?.select( 'core/block-editor' )?.getBlocks?.() ?? [];
 	const matches: Array< { clientId: string; name: string; content: string } > = [];
 

--- a/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
@@ -192,14 +192,56 @@ function countOccurrences( source: string, needle: string ): number {
 	}
 }
 
-function getBlockSnapshot( clientId: string ): { name: string; content: string } | null {
+function getEditableBlockContent( block: any ): string {
+	const raw = block.attributes?.content;
+	return typeof raw === 'string' ? raw : raw?.toHTMLString?.() ?? '';
+}
+
+function getBlockSnapshot(
+	clientId: string
+): { clientId: string; name: string; content: string } | null {
 	const block = ( window as any ).wp?.data?.select( 'core/block-editor' )?.getBlock?.( clientId );
 	if ( ! block ) {
 		return null;
 	}
-	const raw = block.attributes?.content;
-	const content = typeof raw === 'string' ? raw : raw?.toHTMLString?.() ?? '';
-	return { name: block.name, content };
+	return { clientId: block.clientId ?? clientId, name: block.name, content: getEditableBlockContent( block ) };
+}
+
+function findBlockSnapshotByCurrentText(
+	currentText: string
+): { snapshot?: { clientId: string; name: string; content: string }; error?: string } {
+	const blocks = ( window as any ).wp?.data?.select( 'core/block-editor' )?.getBlocks?.() ?? [];
+	const matches: Array< { clientId: string; name: string; content: string } > = [];
+
+	const visit = ( block: any ) => {
+		if ( ! block ) {
+			return;
+		}
+		const snapshot = {
+			clientId: block.clientId,
+			name: block.name,
+			content: getEditableBlockContent( block ),
+		};
+
+		if ( snapshot.clientId && isSupportedEditBlockType( snapshot.name ) ) {
+			const matchCount = countOccurrences( snapshot.content, currentText );
+			for ( let i = 0; i < matchCount; i++ ) {
+				matches.push( snapshot );
+			}
+		}
+
+		( block.innerBlocks ?? [] ).forEach( visit );
+	};
+
+	blocks.forEach( visit );
+
+	if ( matches.length === 1 ) {
+		return { snapshot: matches[ 0 ] };
+	}
+	if ( matches.length > 1 ) {
+		return { error: 'currentText matches multiple spans in block content' };
+	}
+	return {};
 }
 
 /**
@@ -231,9 +273,37 @@ export function handleUpdateBlockContent( input: any ): any {
 		return { success: false, error: 'context changed', returnToAgent: false };
 	}
 
-	const snapshot = getBlockSnapshot( clientId );
+	const hasCurrentText = typeof currentText === 'string' && currentText !== '';
+	let targetClientId = clientId;
+	let snapshot = getBlockSnapshot( targetClientId );
 	if ( ! snapshot ) {
-		return { success: false, error: 'block not found', returnToAgent: false };
+		if ( hasCurrentText ) {
+			const fallback = findBlockSnapshotByCurrentText( currentText );
+			if ( fallback.error ) {
+				// eslint-disable-next-line no-console
+				console.warn( '[ReviewMediation] currentText matches multiple spans in block content', {
+					clientId,
+				} );
+				return {
+					success: false,
+					error: fallback.error,
+					returnToAgent: false,
+				};
+			}
+			if ( fallback.snapshot ) {
+				targetClientId = fallback.snapshot.clientId;
+				snapshot = fallback.snapshot;
+				// eslint-disable-next-line no-console
+				console.warn( '[ReviewMediation] stale clientId matched by currentText', {
+					clientId,
+					targetClientId,
+				} );
+			}
+		}
+
+		if ( ! snapshot ) {
+			return { success: false, error: 'block not found', returnToAgent: false };
+		}
 	}
 	if ( ! isSupportedEditBlockType( snapshot.name ) ) {
 		return {
@@ -246,7 +316,6 @@ export function handleUpdateBlockContent( input: any ): any {
 	// Substring replace when currentText is a non-empty span present in the block.
 	// If that span no longer exists, fail rather than replacing the whole block
 	// with a partial suggested edit.
-	const hasCurrentText = typeof currentText === 'string' && currentText !== '';
 	if ( hasCurrentText ) {
 		const matchCount = countOccurrences( snapshot.content, currentText );
 		if ( matchCount === 0 ) {
@@ -272,7 +341,7 @@ export function handleUpdateBlockContent( input: any ): any {
 	}
 
 	// Apply shimmer briefly, then update content and show highlight
-	const blockEl = findBlockElement( clientId );
+	const blockEl = findBlockElement( targetClientId );
 	if ( blockEl ) {
 		applyProcessingEffect( blockEl );
 	}
@@ -280,7 +349,7 @@ export function handleUpdateBlockContent( input: any ): any {
 	// Short delay so the shimmer is visible before content swaps
 	return new Promise< any >( ( resolve ) => {
 		setTimeout( () => {
-			const latestSnapshot = getBlockSnapshot( clientId );
+			const latestSnapshot = getBlockSnapshot( targetClientId );
 			const resolveFailure = ( error: string ) => {
 				if ( blockEl ) {
 					removeProcessingEffect( blockEl );
@@ -307,14 +376,16 @@ export function handleUpdateBlockContent( input: any ): any {
 				const matchCount = countOccurrences( latestSnapshot.content, currentText );
 				if ( matchCount === 0 ) {
 					// eslint-disable-next-line no-console
-					console.warn( '[ReviewMediation] currentText not found in block content', { clientId } );
+					console.warn( '[ReviewMediation] currentText not found in block content', {
+						clientId: targetClientId,
+					} );
 					resolveFailure( 'currentText not found in block content' );
 					return;
 				}
 				if ( matchCount > 1 ) {
 					// eslint-disable-next-line no-console
 					console.warn( '[ReviewMediation] currentText matches multiple spans in block content', {
-						clientId,
+						clientId: targetClientId,
 					} );
 					resolveFailure( 'currentText matches multiple spans in block content' );
 					return;
@@ -322,12 +393,14 @@ export function handleUpdateBlockContent( input: any ): any {
 				nextContent = latestSnapshot.content.replace( currentText, content );
 			} else if ( latestSnapshot.content !== snapshot.content ) {
 				// eslint-disable-next-line no-console
-				console.warn( '[ReviewMediation] block content changed while applying edit', { clientId } );
+				console.warn( '[ReviewMediation] block content changed while applying edit', {
+					clientId: targetClientId,
+				} );
 				resolveFailure( 'block content changed while applying edit' );
 				return;
 			}
 
-			blockEditor.updateBlockAttributes( clientId, { content: nextContent } );
+			blockEditor.updateBlockAttributes( targetClientId, { content: nextContent } );
 
 			if ( blockEl ) {
 				removeProcessingEffect( blockEl );
@@ -346,6 +419,7 @@ export function handleUpdateBlockContent( input: any ): any {
 
 			resolve( {
 				success: true,
+				clientId: targetClientId,
 				contentBefore: latestSnapshot.content,
 				contentAfter: nextContent,
 				returnToAgent: false,
@@ -371,6 +445,7 @@ export async function applyReviewEdit(
 	shouldApply?: () => boolean
 ): Promise< {
 	success: boolean;
+	clientId?: string;
 	contentBefore?: string;
 	contentAfter?: string;
 	error?: string;


### PR DESCRIPTION
## Proposed changes

- Fall back from a stale selected block `clientId` to a unique live block matching `currentText`.
- Apply edits and return the resolved live `clientId` so review undo state stays aligned.
- Add test coverage for stale client IDs.

## Why

The backend can pass the selected block ID from request context, but Gutenberg may remount the block before the frontend tool message is handled. In that case `getBlock(clientId)` returns null even though the selected block content still exists. Matching unique `currentText` lets the existing frontend ability update the intended live block safely.

## Testing

- `yarn test-packages packages/jetpack-ai-sidebar --runInBand`
- Manual sandbox validation: selected paragraph edit updates in the editor after `wpcom/update-block-content` is called.

Stacked on #110864.