### PR TITLE
Fix date range picker hidden presets test

### DIFF
--- a/packages/date-range-picker/src/test/date-range-picker.test.tsx
+++ b/packages/date-range-picker/src/test/date-range-picker.test.tsx
@@ -252,7 +252,7 @@ describe( 'DateRangePicker (new)', () => {
 		const listbox = await findByRole( 'listbox', { name: /Date range presets/i } );
 		expect( within( listbox ).queryByRole( 'option', { name: /yesterday/i } ) ).toBeNull();
 		expect( within( listbox ).queryByRole( 'option', { name: /last 3 years/i } ) ).toBeNull();
-		expect( within( listbox ).getByRole( 'option', { name: /last 7 days/i } ) ).toBeVisible();
+		expect( within( listbox ).getByRole( 'option', { name: /last 7 days/i } ) ).toBeInTheDocument();
 	} );
 
 	test( 'last-90-days preset applies a 90-day window', async () => {


### PR DESCRIPTION
## Proposed Changes

* Narrow the date-range-picker hidden presets test to assert that hidden presets are removed and a non-hidden preset remains present.

## Why are these changes being made?

* The package unit test failed in CI because it added an extra visibility assertion for a preset that was already present in the listbox.
* The test purpose is filtering behavior, so presence is the smaller and more stable assertion.

## Testing Instructions

* Run `yarn test-packages packages/date-range-picker/src/test/date-range-picker.test.tsx --runInBand`.
* Run `./node_modules/.bin/eslint --ext .js,.jsx,.ts,.tsx,.mjs,.json packages/date-range-picker/src/test/date-range-picker.test.tsx`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?