### PR TITLE
Fix cancel mutation never firing for Jetpack/Akismet/domain cancels

### DIFF
--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -385,6 +385,14 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 
 		// For Jetpack/Akismet products and domain registrations, call onCancellationComplete to show the dialog
 		if ( isJetpack || isAkismet || isDomainRegistrationPurchase ) {
+			// Capture the intent before opening the dialog. onSurveyComplete reads
+			// state.cancelIntent when it falls through to the mutation block; without
+			// this, intent=cancel / intent=auto-renew on a refundable purchase would
+			// route through cancelAndRefund (issuing an unwanted refund) instead of
+			// the auto-renew disable path.
+			if ( intent && this.state.cancelIntent !== intent ) {
+				this.setState( { cancelIntent: intent } );
+			}
 			this.onCancellationComplete();
 			return;
 		}
@@ -608,12 +616,20 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 	};
 
 	onSurveyComplete = async () => {
+		const { isJetpack, isAkismet, isDomainRegistrationPurchase } = this.props;
+		// Dialog products (Jetpack/Akismet/domain registrations) bypass the
+		// fire-on-confirm path: their onCancellationStart early-returns to
+		// onCancellationComplete to open a survey dialog without firing the
+		// mutation. They must fall through to the post-survey mutation block
+		// below so the cancel request actually fires when the dialog closes.
+		const isDialogProduct = isJetpack || isAkismet || isDomainRegistrationPurchase;
+
 		// Flag-on path: the mutation already fired at confirm-click via
 		// fireMutationFromConfirm. fireMutationFromConfirm intentionally
 		// skipped clearPurchases / refreshSitePlans so they wouldn't flip
 		// isDataLoading mid-survey; we run them here, immediately before
 		// the redirect, so the destination page picks up fresh server data.
-		if ( this.shouldFireMutationOnConfirm() ) {
+		if ( this.shouldFireMutationOnConfirm() && ! isDialogProduct ) {
 			this.props.refreshSitePlans( this.props.purchase.siteId );
 			this.props.clearPurchases();
 			if ( this.state.fireMutationWasRefund ) {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2039/

## Proposed Changes

* Fix a flag-on regression where cancelling a Jetpack, Akismet, or domain registration purchase from the Classic Manage Purchase page via `?intent=cancel` or `?intent=auto-renew` never issues a cancellation request. The user clicks Cancel, completes the in-button survey dialog, and lands on the post-cancellation screen — but no API call is ever made and the subscription continues to renew.
* The fix lives in `client/me/purchases/cancel-purchase/index.tsx`:
  * `onCancellationStart` now captures the incoming `intent` on `state.cancelIntent` before the early-return that opens the dialog for these product types.
  * `onSurveyComplete` excludes those same dialog products from the `shouldFireMutationOnConfirm()` early-return so they fall through to the existing post-survey mutation block.

## Why are these changes being made?

* `shouldFireMutationOnConfirm()` was introduced in #110353 to fire the cancel mutation immediately at confirm-click for `?intent=cancel`/`?intent=auto-renew` (so the survey becomes optional, post-cancel). But that change didn't account for the older `onCancellationStart` early-return that routes Jetpack/Akismet/domain registrations to an in-button survey dialog instead of the unified flow.
* The result: `onCancellationStart` opens the dialog without firing the mutation, then `onSurveyComplete` sees `shouldFireMutationOnConfirm()` is true and skips the mutation again on the assumption it already ran.
* Dashboard is unaffected — its `onCancellationStart` doesn't have the dialog-product early-return, so the mutation fires on confirm as expected.
* On a refundable purchase, simply removing the early-return without capturing the intent would route through `submitCancelAndRefundPurchase` and issue an unwanted refund instead of disabling auto-renew. Threading the intent into `state.cancelIntent` lets the existing post-survey block branch correctly on `isAutoRenewIntent`.

## Testing Instructions

> The flag can be force-enabled in DevTools console:
> ```
> localStorage.setItem( 'flags', 'purchases/split-cancel-remove' )
> ```
> Then reload.

Set up a Classic purchase in each of these states (or repro on real data):

1. **Domain registration, auto-renew on, outside refund window**: from Manage Purchase, click **Cancel**. Complete the `DomainCancellationSurvey` dialog. Verify a disable-auto-renew API call fires (network tab) and the purchase lands on the manage screen with `?cancelled=true`. Reload — auto-renew should now read off.
2. **Same domain, toggle auto-renew off via the toggle**: should route to `?intent=auto-renew`. Confirm the dialog appears, completing it fires the disable-auto-renew call.
3. **Jetpack product or Akismet subscription, auto-renew on**: click Cancel, complete the in-button survey, confirm a cancel request fires.
4. **Refundable domain registration**: in `?intent=cancel`, click Cancel (NOT the "Remove plan and claim refund" link). Confirm the dialog opens, completing it disables auto-renew **without** issuing a refund. Then go back and click the refund link — the refund flow (`?intent=remove`) should still work and issue the refund.

Off-flag verification (unset `flags`, reload): no change from current trunk behavior — Classic continues to fire the mutation at survey-end as it always has.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?