### PR TITLE
Cancellation Flow: fire cancellation immediately for Jetpack/Akismet/domain registrations

### DIFF
--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -383,17 +383,26 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 		const { includedDomainPurchase, purchase, isJetpack, isAkismet, isDomainRegistrationPurchase } =
 			this.props;
 
-		// For Jetpack/Akismet products and domain registrations, call onCancellationComplete to show the dialog
+		// Jetpack/Akismet products and domain registrations render their
+		// cancellation survey inside CancelPurchaseButton as a dialog rather than
+		// the unified pre-survey screen. Under the split flag with
+		// intent=cancel/auto-renew, fire the cancel mutation here so the dialog
+		// becomes an optional post-cancellation survey — matching the behavior
+		// of non-dialog products under the same intent. Off-flag (or any other
+		// intent), open the dialog first and let the mutation fire at
+		// survey-end via onSurveyComplete (legacy behavior).
 		if ( isJetpack || isAkismet || isDomainRegistrationPurchase ) {
-			// Capture the intent before opening the dialog. onSurveyComplete reads
-			// state.cancelIntent when it falls through to the mutation block; without
-			// this, intent=cancel / intent=auto-renew on a refundable purchase would
-			// route through cancelAndRefund (issuing an unwanted refund) instead of
-			// the auto-renew disable path.
+			// Capture intent before either branch: fireMutationFromConfirm reads
+			// state.cancelIntent via getCancelFlowType, and the off-flag
+			// onSurveyComplete fall-through reads it too.
 			if ( intent && this.state.cancelIntent !== intent ) {
 				this.setState( { cancelIntent: intent } );
 			}
-			this.onCancellationComplete();
+			if ( this.shouldFireMutationOnConfirm() ) {
+				this.fireMutationFromConfirm();
+			} else {
+				this.onCancellationComplete();
+			}
 			return;
 		}
 
@@ -456,6 +465,9 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 	// hasLoadedUserPurchasesFromServer and render the loading placeholder
 	// over the survey.
 	fireMutationFromConfirm = async () => {
+		const { isJetpack, isAkismet, isDomainRegistrationPurchase } = this.props;
+		const isDialogProduct = isJetpack || isAkismet || isDomainRegistrationPurchase;
+
 		this.setState( { isLoading: true } );
 		try {
 			const flowType = this.getCancelFlowType( this.props.purchase );
@@ -475,7 +487,18 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 					} );
 				}
 				invokeSurvicateEvent( refundable ? 'purchaseRefunded' : 'purchaseCancelled' );
-				this.setState( { surveyShown: true, isLoading: false, fireMutationWasRefund: refundable } );
+				// Dialog products render their survey inside CancelPurchaseButton,
+				// gated on showDialog. Non-dialog products render the unified
+				// survey outside the button, gated on surveyShown. Set both:
+				// surveyShown drives the page heading ("Cancellation confirmed" /
+				// "Auto-renew disabled") for every product, and showDialog opens
+				// the in-button dialog for the dialog-product subset.
+				this.setState( {
+					surveyShown: true,
+					showDialog: isDialogProduct,
+					isLoading: false,
+					fireMutationWasRefund: refundable,
+				} );
 			} else {
 				this.props.errorNotice( result.error );
 				this.setState( { isLoading: false } );
@@ -616,20 +639,12 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 	};
 
 	onSurveyComplete = async () => {
-		const { isJetpack, isAkismet, isDomainRegistrationPurchase } = this.props;
-		// Dialog products (Jetpack/Akismet/domain registrations) bypass the
-		// fire-on-confirm path: their onCancellationStart early-returns to
-		// onCancellationComplete to open a survey dialog without firing the
-		// mutation. They must fall through to the post-survey mutation block
-		// below so the cancel request actually fires when the dialog closes.
-		const isDialogProduct = isJetpack || isAkismet || isDomainRegistrationPurchase;
-
 		// Flag-on path: the mutation already fired at confirm-click via
 		// fireMutationFromConfirm. fireMutationFromConfirm intentionally
 		// skipped clearPurchases / refreshSitePlans so they wouldn't flip
 		// isDataLoading mid-survey; we run them here, immediately before
 		// the redirect, so the destination page picks up fresh server data.
-		if ( this.shouldFireMutationOnConfirm() && ! isDialogProduct ) {
+		if ( this.shouldFireMutationOnConfirm() ) {
 			this.props.refreshSitePlans( this.props.purchase.siteId );
 			this.props.clearPurchases();
 			if ( this.state.fireMutationWasRefund ) {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/RSM-3782/

## Proposed Changes

* Under the split-cancel-remove flag, fire the cancel mutation immediately when the user confirms on `?intent=cancel` / `?intent=auto-renew` for Jetpack products, Akismet subscriptions, and domain registrations — matching how every other product type behaves under the same intent. The in-button survey dialog opens afterward as an optional follow-up.
* Off-flag (and on `?intent=refund` / `?intent=remove`), behavior is unchanged: the dialog opens first and the mutation fires at survey-end via `onSurveyComplete`.

## Why are these changes being made?

* The split-cancel-remove treatment's spec is "plan is immediately cancelled, survey is then shown and optional, finishing the survey does not remove/refund the plan." Non-dialog products already do this via `fireMutationFromConfirm` in `onCancellationStart`.
* Jetpack, Akismet, and domain registrations render their cancellation survey inside `CancelPurchaseButton` as a dialog, and take a different code path that routes through `onCancellationComplete`.
* #110892 fixed the "no request ever fires" symptom for these products by moving the mutation to survey-end, but that still required users to complete the survey to cancel — inconsistent with the rest of the treatment and a degraded UX. This PR completes the architectural alignment.

## Changes (all in `client/me/purchases/cancel-purchase/index.tsx`)

1. **`onCancellationStart`** — in the dialog-product branch, branch on `shouldFireMutationOnConfirm()`. Flag-on cancel/auto-renew calls `fireMutationFromConfirm`; flag-off or refund intent falls through to `onCancellationComplete` (legacy).
2. **`fireMutationFromConfirm`** — on success, also set `showDialog: true` for dialog products so the in-button survey appears as a post-cancellation step. `surveyShown` stays true for every product so the page heading flips to "Cancellation confirmed" / "Auto-renew disabled" as expected.
3. **`onSurveyComplete`** — revert the dialog-product exclusion that #110892 added. With the mutation now firing on confirm for dialog products too, the existing `shouldFireMutationOnConfirm()` early-return (which assumes the mutation already ran) is correct for them.

Dashboard is unaffected — its `onCancellationStart` doesn't have the dialog-product early-return and already routes through the unified `fireMutationFromConfirm` path.

## Testing Instructions

> Enable the flag in DevTools:
> ```
> localStorage.setItem( 'flags', 'purchases/split-cancel-remove' )
> ```
> Then reload.

For each of these products, observe the cancel-purchase flow on the Classic Manage Purchase page:

1. **Domain registration, auto-renew on, outside refund window** — click **Cancel**. Verify the disable-auto-renew API call fires _immediately_ (network tab). The `DomainCancellationSurvey` dialog appears with the survey questions, but the cancellation has already happened — closing or completing the survey just navigates.
2. **Same domain, toggle auto-renew off via the toggle** (routes to `?intent=auto-renew`) — same expectation: mutation fires immediately, survey is optional.
3. **Jetpack product / Akismet subscription, auto-renew on, `?intent=cancel`** — click Cancel, confirm the mutation fires immediately and the in-button survey appears afterward.
4. **Refundable domain registration, `?intent=cancel`** (click Cancel, NOT the inline refund link) — confirm the auto-renew disable call fires immediately (no refund issued). The refund flow remains available via the refund-eligibility notice link, which routes to `?intent=remove`.

Off-flag verification (unset `flags`, reload): legacy behavior preserved — the dialog opens first, the mutation fires at survey-end.