### PR TITLE
Fix MarTech ToS screenshot target URL

### DIFF
--- a/.teamcity/_self/projects/MarTech.kt
+++ b/.teamcity/_self/projects/MarTech.kt
@@ -41,6 +41,7 @@ object ToSAcceptanceTracking: BuildType ({
 
 	params {
 		param("env.NODE_CONFIG_ENV", "test")
+		param("env.CALYPSO_BASE_URL", "https://wordpress.com")
 		param("env.PLAYWRIGHT_BROWSERS_PATH", "0")
 		param("env.HEADLESS", "true")
 		param("env.LOCALE", "en")


### PR DESCRIPTION
## Proposed Changes

* Set `CALYPSO_BASE_URL` explicitly for the MarTech ToS screenshot TeamCity job.

## Why are these changes being made?

* The job runs E2E screenshot specs without starting a local Calypso server. After the global E2E default changed to local Calypso, this scheduled job started failing with connection refused errors. This restores the job-specific production target.

## Testing Instructions

* Confirm the diff only changes `.teamcity/_self/projects/MarTech.kt`.
* Run the ToS Acceptance Tracking TeamCity job and confirm the generated environment includes `CALYPSO_BASE_URL`.
* Confirm the job no longer fails while navigating to local Calypso.

Manual branch verification confirmed the environment variable is exported and the screenshot navigation tests pass. The job now fails later on upload assertions, which is a separate pre-existing issue that was hidden by the connection failure.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
