### PR TITLE
Fix MarTech ToS screenshot uploads

### DIFF
--- a/test/e2e/lib/martech-tos-helper.js
+++ b/test/e2e/lib/martech-tos-helper.js
@@ -21,14 +21,15 @@ export default async function uploadScreenshotsToBlog( zipFilename, globPattern 
 
 	const form = new FormData();
 	const bearerToken = DataHelper.getTosUploadToken();
-	form.append( 'media[]', fs.createReadStream( zipFilename ) );
+	form.append( 'media[]', fs.readFileSync( zipFilename ), { filename: zipFilename } );
 	const response = await fetch(
 		`https://public-api.wordpress.com/rest/v1.1/sites/${ DataHelper.getTosUploadDestination() }/media/new`,
 		{
 			method: 'POST',
-			body: form,
+			body: form.getBuffer(),
 			headers: {
 				Authorization: `Bearer ${ bearerToken }`,
+				...form.getHeaders(),
 			},
 		}
 	);


### PR DESCRIPTION
Part of #110894

## Proposed Changes

* Update the MarTech ToS screenshot upload helper to send the multipart body as a Buffer and include the generated multipart headers when using native `fetch`.

## Why are these changes being made?

* #110894 gets the job past screenshot capture. The remaining three failures all happen in the shared upload step, where `result.media[0]` is undefined.
* The helper still used the pre-native-fetch request shape. The existing `RestAPIClient.uploadMedia()` pattern sends `form.getHeaders()` and `form.getBuffer()` for the same media endpoint.

## Testing Instructions

* `./node_modules/.bin/eslint test/e2e/lib/martech-tos-helper.js`
* Run MarTech ToS Acceptance Tracking against this branch and verify the upload tests pass.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?