### PR TITLE
Fix MarTech ToS signup screenshot readiness

### DIFF
--- a/test/e2e/lib/martech-tos-helper.js
+++ b/test/e2e/lib/martech-tos-helper.js
@@ -21,14 +21,15 @@ export default async function uploadScreenshotsToBlog( zipFilename, globPattern 
 
 	const form = new FormData();
 	const bearerToken = DataHelper.getTosUploadToken();
-	form.append( 'media[]', fs.createReadStream( zipFilename ) );
+	form.append( 'media[]', fs.readFileSync( zipFilename ), { filename: zipFilename } );
 	const response = await fetch(
 		`https://public-api.wordpress.com/rest/v1.1/sites/${ DataHelper.getTosUploadDestination() }/media/new`,
 		{
 			method: 'POST',
-			body: form,
+			body: form.getBuffer(),
 			headers: {
 				Authorization: `Bearer ${ bearerToken }`,
+				...form.getHeaders(),
 			},
 		}
 	);

--- a/test/e2e/specs/martech/tos-screenshots__signup.ts
+++ b/test/e2e/specs/martech/tos-screenshots__signup.ts
@@ -1,7 +1,7 @@
 /**
  * @group legal
  */
-import { DataHelper, UserSignupPage } from '@automattic/calypso-e2e';
+import { DataHelper } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
 import uploadScreenshotsToBlog from '../../lib/martech-tos-helper';
 
@@ -37,11 +37,12 @@ describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), 
 		];
 
 		it( 'Screenshot white background signup page in en and Mag-16 locales', async function () {
-			const userSignupPage = new UserSignupPage( page );
 			for ( const locale of [ ...magnificientNonEnLocales, 'en' ] ) {
 				page.setViewportSize( { width: 1280, height: 720 } );
-				await userSignupPage.visit( { path: locale } );
-				page.waitForSelector( selectors.isSignup );
+				await page.goto( DataHelper.getCalypsoURL( `start/${ locale }` ), {
+					waitUntil: 'domcontentloaded',
+				} );
+				await page.waitForSelector( selectors.isSignup );
 				await page.screenshot( {
 					path: `tos_white_signup_desktop_${ locale }.png`,
 					fullPage: true,


### PR DESCRIPTION
Follow-up to #110895

## Proposed Changes

* Update the MarTech ToS signup screenshot spec to wait for the signup shell instead of waiting for global `networkidle`.
* Await the existing signup sentinel before taking screenshots.

## Why are these changes being made?

* After #110895 fixed screenshot uploads, MarTech ToS runs still failed twice on `/start/pt-br` while waiting for `networkidle`.
* The screenshot test only needs the signup page shell before capture. Waiting for global network silence makes this CI-only screenshot flow more fragile than the product behavior it is checking.

## Testing Instructions

* `./node_modules/.bin/eslint test/e2e/specs/martech/tos-screenshots__signup.ts`
* Manual MarTech ToS Acceptance Tracking run #12587 passed with 24/24 tests.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?