### PR TITLE
Help Center: Enable logged-out FAB in stage and production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -51,6 +51,7 @@
 		"global-styles/on-personal-plan": true,
 		"google-my-business": true,
 		"help": true,
+		"help-center/logged-out-fab": true,
 		"help/gpt-response": true,
 		"hosting-server-settings-enhancements": true,
 		"i18n/empathy-mode": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -51,6 +51,7 @@
 		"google-my-business": true,
 		"help": true,
 		"help-center/logged-out": true,
+		"help-center/logged-out-fab": true,
 		"help/gpt-response": true,
 		"hosting-server-settings-enhancements": true,
 		"i18n/empathy-mode": true,


### PR DESCRIPTION
## Proposed Changes

* Enable the `help-center/logged-out-fab` feature flag in `config/stage.json` and `config/production.json`.

The flag was already enabled in `development.json`, `wpcalypso.json`, and `horizon.json` — this rolls it out to the remaining environments.

## Why are these changes being made?

* Ship the logged-out Help Center FAB to all environments.

## Testing Instructions

* On stage/production, confirm the logged-out Help Center FAB renders on pages where it is expected.
* Verify there are no console errors related to the Help Center.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?