### PR TITLE
APM: Polish response time breakdown tooltip

### DIFF
--- a/client/dashboard/sites/performance/backend/overview/chart-slot.tsx
+++ b/client/dashboard/sites/performance/backend/overview/chart-slot.tsx
@@ -4,6 +4,7 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
+import { useLocale } from '../../../../app/locale';
 import { Card, CardBody, CardHeader } from '../../../../components/card';
 import { Text } from '../../../../components/text';
 import { formatMs } from '../utils';
@@ -50,22 +51,23 @@ function formatMsValue( value: number ): string {
 	);
 }
 
-function formatTooltipDate( date: Date ): string {
-	return date.toLocaleDateString( undefined, {
+function formatTooltipDate( date: Date, locale: string ): string {
+	return date.toLocaleDateString( locale, {
 		weekday: 'short',
 		month: 'short',
 		day: 'numeric',
 	} );
 }
 
-function formatTooltipTime( date: Date ): string {
-	return date.toLocaleTimeString( undefined, {
+function formatTooltipTime( date: Date, locale: string ): string {
+	return date.toLocaleTimeString( locale, {
 		hour: '2-digit',
 		minute: '2-digit',
 	} );
 }
 
 export default function ChartSlot( { timeseries }: { timeseries: ApmTimePoint[] } ) {
+	const locale = useLocale();
 	const data = toSeriesData( timeseries );
 	const averageTotal = getAverageTotal( timeseries );
 
@@ -107,18 +109,27 @@ export default function ChartSlot( { timeseries }: { timeseries: ApmTimePoint[] 
 							const series = Object.values( tooltipData?.datumByKey ?? {} );
 							return (
 								<VStack spacing={ 3 } style={ { padding: '4px 2px', minWidth: 240 } }>
-									<VStack spacing={ 0 }>
-										<Text weight={ 600 }>{ formatTooltipDate( date ) }</Text>
-										<Text size={ 11 } variant="muted">
-											{ formatTooltipTime( date ) }
-										</Text>
-									</VStack>
+									<HStack spacing={ 2 } expanded={ false } justify="flex-start">
+										<Text weight={ 600 }>{ formatTooltipDate( date, locale ) }</Text>
+										<span
+											aria-hidden
+											style={ {
+												flex: '0 0 auto',
+												width: 3,
+												height: 3,
+												borderRadius: '50%',
+												background: 'currentColor',
+												opacity: 0.4,
+											} }
+										/>
+										<Text variant="muted">{ formatTooltipTime( date, locale ) }</Text>
+									</HStack>
 									<VStack spacing={ 1 }>
 										{ series.map( ( entry ) => {
 											const value = ( entry.datum as { value?: number } ).value ?? 0;
 											return (
 												<HStack key={ entry.key } justify="space-between" spacing={ 3 }>
-													<HStack spacing={ 2 } justify="flex-start">
+													<HStack spacing={ 2 } justify="flex-start" expanded={ false }>
 														<span
 															aria-hidden
 															style={ {

--- a/client/dashboard/sites/performance/backend/overview/chart-slot.tsx
+++ b/client/dashboard/sites/performance/backend/overview/chart-slot.tsx
@@ -8,7 +8,7 @@ import { useLocale } from '../../../../app/locale';
 import { Card, CardBody, CardHeader } from '../../../../components/card';
 import { Text } from '../../../../components/text';
 import { formatMs } from '../utils';
-import type { ApmTimePoint } from '@automattic/api-core';
+import type { ApmSummary, ApmTimePoint } from '@automattic/api-core';
 
 import '@automattic/charts/style.css';
 
@@ -30,17 +30,6 @@ function toSeriesData( timeseries: ApmTimePoint[] ): SeriesData[] {
 			value: point[ key ],
 		} ) ),
 	} ) );
-}
-
-function getAverageTotal( timeseries: ApmTimePoint[] ): number {
-	if ( ! timeseries.length ) {
-		return 0;
-	}
-	const total = timeseries.reduce(
-		( sum, point ) => sum + point.db + point.wp_core + point.plugins + point.external + point.cache,
-		0
-	);
-	return Math.round( total / timeseries.length );
 }
 
 function formatMsValue( value: number ): string {
@@ -66,10 +55,15 @@ function formatTooltipTime( date: Date, locale: string ): string {
 	} );
 }
 
-export default function ChartSlot( { timeseries }: { timeseries: ApmTimePoint[] } ) {
+export default function ChartSlot( {
+	timeseries,
+	summary,
+}: {
+	timeseries: ApmTimePoint[];
+	summary: ApmSummary;
+} ) {
 	const locale = useLocale();
 	const data = toSeriesData( timeseries );
-	const averageTotal = getAverageTotal( timeseries );
 
 	return (
 		<Card>
@@ -80,7 +74,7 @@ export default function ChartSlot( { timeseries }: { timeseries: ApmTimePoint[] 
 							{ __( 'Response time breakdown' ) }
 						</Text>
 						<Text size={ 32 } weight={ 500 } lineHeight="40px">
-							{ formatMs( averageTotal ) }
+							{ formatMs( summary.avg_response_ms ) }
 						</Text>
 						<Text variant="muted">
 							{ __(

--- a/client/dashboard/sites/performance/backend/overview/index.tsx
+++ b/client/dashboard/sites/performance/backend/overview/index.tsx
@@ -6,7 +6,7 @@ import type { MergedAggregate } from '../aggregate';
 export default function Overview( { merged }: { merged: MergedAggregate } ) {
 	return (
 		<VStack spacing={ 6 }>
-			<ChartSlot timeseries={ merged.timeseries } />
+			<ChartSlot timeseries={ merged.timeseries } summary={ merged.summary } />
 			<SlowRequestsList routes={ merged.slowest.routes } />
 		</VStack>
 	);


### PR DESCRIPTION
## Proposed Changes

* Fix the value column in the response time breakdown tooltip so values right-align cleanly (the inner `HStack` was defaulting to `width: 100%`, which swallowed the outer `justify="space-between"`). Setting `expanded={ false }` on it restores the intended layout.
* Move the tooltip header to a single line: bold date, small dot separator, muted time.
* Use the site's locale (via `useLocale()`) instead of the browser locale when formatting the date/time, so an English site no longer shows `qua., 20 de mai.` to a browser configured for pt-BR.
* Use `summary.avg_response_ms` for the "Response time breakdown" headline number instead of recomputing it client-side from the time-bucketed series. The recomputation summed the five component averages per bucket and then averaged the buckets, which drifts from the authoritative average shown in the tab and the "Backend is slow" banner. All three places now show the same value.

## Why are these changes being made?

The tooltip on `/sites/<site>/performance/backend` had three visible issues: value numbers didn't line up against the right edge, the date/time used the browser's locale rather than the site's, and the headline average on the card disagreed with the banner / tab averages.

## Testing Instructions

* Visit `/sites/<site>/performance/backend` for a site with APM data.
* Hover the chart and confirm:
  * Values right-align under each other; the "ms" suffixes sit at the same column.
  * Date and time are on one line, separated by a small dot.
  * The date/time format follows the site language (try switching the WordPress.com interface language to confirm).
* Confirm the "Response time breakdown" headline number matches the "Avg response" tab value and the average shown in the "Backend is slow / needs improvement / healthy" banner.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
