### PR TITLE
APM: Remove total-time headline from WordPress tab sections

### DIFF
--- a/client/dashboard/sites/performance/backend/wordpress/index.tsx
+++ b/client/dashboard/sites/performance/backend/wordpress/index.tsx
@@ -16,12 +16,10 @@ import { formatMs } from '../utils';
 
 function Section( {
 	title,
-	headline,
 	description,
 	rows,
 }: {
 	title: string;
-	headline: string;
 	description: string;
 	rows: BarListRow[];
 } ) {
@@ -32,9 +30,6 @@ function Section( {
 					<VStack spacing={ 2 } alignment="flex-start">
 						<Text size="title" weight={ 500 } as="h2">
 							{ title }
-						</Text>
-						<Text size={ 32 } weight={ 500 } lineHeight="40px">
-							{ headline }
 						</Text>
 						<Text variant="muted">{ description }</Text>
 					</VStack>
@@ -71,10 +66,6 @@ function templatesToRows( templates: MergedTemplate[] ): BarListRow[] {
 	} ) );
 }
 
-function sumValues( rows: BarListRow[] ): number {
-	return rows.reduce( ( sum, row ) => sum + row.value, 0 );
-}
-
 export default function WordPress( { merged }: { merged: MergedAggregate } ) {
 	const pluginRows = pluginsToRows( merged.slowest.plugins );
 	const hookRows = hooksToRows( merged.slowest.hooks );
@@ -84,23 +75,22 @@ export default function WordPress( { merged }: { merged: MergedAggregate } ) {
 		<VStack spacing={ 6 }>
 			<Section
 				title={ __( 'Plugins' ) }
-				headline={ formatMs( sumValues( pluginRows ) ) }
-				description={ __( 'Total time consumed by each active plugin in the selected period.' ) }
+				description={ __(
+					'Time consumed by each active plugin across requests in the selected period.'
+				) }
 				rows={ pluginRows }
 			/>
 			<Section
 				title={ __( 'Hooks' ) }
-				headline={ formatMs( sumValues( hookRows ) ) }
 				description={ __(
-					'Total time spent in the slowest action and filter hooks fired during the selected period.'
+					'Time spent in the slowest action and filter hooks fired across requests in the selected period.'
 				) }
 				rows={ hookRows }
 			/>
 			<Section
 				title={ __( 'Templates' ) }
-				headline={ formatMs( sumValues( templateRows ) ) }
 				description={ __(
-					'Total time spent rendering each theme template in the selected period.'
+					'Time spent rendering each theme template across requests in the selected period.'
 				) }
 				rows={ templateRows }
 			/>


### PR DESCRIPTION
Part of #

## Proposed Changes

* Drop the cumulative "total time" headline (e.g. `482.68 s`) from the Plugins, Hooks, and Templates sections on the WordPress sub-tab of the backend performance page.
* Rephrase each section's description so it reads naturally without the headline above it.

## Why are these changes being made?

The big sum-of-time figure on top of each section was confusing rather than informative: a number like `482.68 s` is meaningless without knowing the request count, and even with a denominator the average-per-request figure is misleading at the per-plugin level (plugins that fire only on certain routes get artificially diluted). Removing the headline keeps the page honest: the per-item bar list is what users actually need, and the aggregate avg/request value is already shown one level up in the backend tab strip.

## Testing Instructions

* Start the dashboard dev server (`yarn start-dashboard`).
* Visit `/sites/<your-test-site>/performance/backend/wordpress`.
* Confirm each of the Plugins, Hooks, and Templates cards now shows just the section title, the description, and the bar list. No big time figure on top.
* Confirm the bar list itself is unchanged (per-item totals, sorted by impact).
* Spot-check the backend tab strip above still shows the aggregate "Plugins" avg/request value.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?