### PR TITLE
Revert "Migrate the #wpcom root to createRoot / hydrateRoot"

### DIFF
--- a/client/controller/index.web.jsx
+++ b/client/controller/index.web.jsx
@@ -95,8 +95,8 @@ export const ProviderWrappedLayout = ( {
 export const makeLayout = makeLayoutMiddleware( ProviderWrappedLayout );
 
 /**
- * For logged in users with bootstrap (production), hydrate the server-rendered
- * markup (`hydrateRoot`). Otherwise (development), render from scratch (`createRoot`).
+ * For logged in users with bootstrap (production), ReactDOM.hydrate().
+ * Otherwise (development), ReactDOM.render().
  * See: https://wp.me/pd2qbF-P#comment-20
  * @param context - Middleware context
  */

--- a/client/controller/web-util.js
+++ b/client/controller/web-util.js
@@ -1,38 +1,9 @@
-import config from '@automattic/calypso-config';
 import ReactDom from 'react-dom';
-import { createRoot, hydrateRoot } from 'react-dom/client';
-
-// Gates the React 18 `createRoot`/`hydrateRoot` adoption. When disabled, the
-// `#wpcom` root keeps mounting via the legacy `ReactDOM.render`/`hydrate` APIs
-// (React-17 update semantics — synchronous, no automatic batching).
-const useCreateRoot = config.isEnabled( 'calypso/react-18-create-root' );
-
-// The classic Calypso app mounts into a single, long-lived `#wpcom` container.
-// `createRoot`/`hydrateRoot` must be called exactly once per container; every
-// subsequent route navigation reuses the same root via `root.render()`. (The
-// legacy `ReactDOM.render`/`hydrate` APIs were idempotent per container, so the
-// previous implementation could call them on every navigation.)
-let root;
 
 export function render( context ) {
-	if ( ! useCreateRoot ) {
-		ReactDom.render( context.layout, document.getElementById( 'wpcom' ) );
-		return;
-	}
-	if ( ! root ) {
-		root = createRoot( document.getElementById( 'wpcom' ) );
-	}
-	root.render( context.layout );
+	ReactDom.render( context.layout, document.getElementById( 'wpcom' ) );
 }
 
 export function hydrate( context ) {
-	if ( ! useCreateRoot ) {
-		ReactDom.hydrate( context.layout, document.getElementById( 'wpcom' ) );
-		return;
-	}
-	if ( ! root ) {
-		root = hydrateRoot( document.getElementById( 'wpcom' ), context.layout );
-	} else {
-		root.render( context.layout );
-	}
+	ReactDom.hydrate( context.layout, document.getElementById( 'wpcom' ) );
 }

--- a/config/development.json
+++ b/config/development.json
@@ -57,7 +57,6 @@
 		"calypso/all-domain-management": true,
 		"calypso/big-sky": true,
 		"calypso/domains-dataviews": true,
-		"calypso/react-18-create-root": true,
 		"calypso/refund-eligibility-notice": false,
 		"cancel-flow/solutions-cards-upsell": false,
 		"checkout/checkout-version": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -18,7 +18,6 @@
 		"calypso/all-domain-management": false,
 		"calypso/big-sky": true,
 		"calypso/domains-dataviews": true,
-		"calypso/react-18-create-root": true,
 		"catch-js-errors": true,
 		"checkout/checkout-version": false,
 		"checkout/google-pay": true,

--- a/config/production.json
+++ b/config/production.json
@@ -31,7 +31,6 @@
 		"calypso/all-domain-management": true,
 		"calypso/big-sky": true,
 		"calypso/domains-dataviews": true,
-		"calypso/react-18-create-root": false,
 		"catch-js-errors": true,
 		"checkout/checkout-version": false,
 		"checkout/google-pay": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -28,7 +28,6 @@
 		"calypso/all-domain-management": true,
 		"calypso/big-sky": true,
 		"calypso/domains-dataviews": true,
-		"calypso/react-18-create-root": true,
 		"catch-js-errors": true,
 		"checkout/checkout-version": true,
 		"checkout/google-pay": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -27,7 +27,6 @@
 		"calypso/all-domain-management": true,
 		"calypso/big-sky": true,
 		"calypso/domains-dataviews": true,
-		"calypso/react-18-create-root": true,
 		"catch-js-errors": false,
 		"checkout/checkout-version": true,
 		"checkout/google-pay": true,


### PR DESCRIPTION
Reverts Automattic/wp-calypso#110857. Just in case.