### PR TITLE
A4A Agent Studio: drive the generating overlay from real run status

### DIFF
--- a/client/a8c-for-agencies/sections/agent-studio/primary/brief/generating-overlay.tsx
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/brief/generating-overlay.tsx
@@ -7,47 +7,38 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import useAgentStudioRun from '../../data/use-agent-studio-run';
 
 import './generating-overlay.scss';
 
 interface Props {
 	agentName: string;
-	isOpen: boolean;
+	/** When set, the overlay polls this run id and reflects its status. */
+	runId: string | null;
+	/** Whether the brief form is still uploading + firing POST /a4a/runs. */
+	isUploading: boolean;
+	/** Fires when the polled run flips to a ready terminal status. */
+	onReady: ( runId: string ) => void;
+	/** Fires when the polled run flips to a failed terminal status. */
+	onFailed: ( errorMessage?: string ) => void;
+	/** Fires when the user clicks Cancel. */
 	onCancel: () => void;
 }
 
-const THINKING_LINES = [
-	__( 'Reading the brief' ),
-	__( 'Studying the brand' ),
-	__( 'Considering the hierarchy' ),
-	__( 'Sketching a grid' ),
-	__( 'Picking type sizes' ),
-	__( 'Composing the layout' ),
-	__( 'Balancing the columns' ),
-	__( 'Weighing the negative space' ),
-	__( 'Choosing the accents' ),
-	__( 'Assembling the page' ),
-];
+const STEP_COPY: Record< string, string > = {
+	extract_brief: __( 'Reading the brief' ),
+	compose_page_frame: __( 'Composing cover variants' ),
+	layout_director_ela: __( 'Designing the layout' ),
+	layout_director_ela_v2: __( 'Designing the layout' ),
+	persist_as_html_post: __( 'Finalizing the deliverable' ),
+};
 
-function useThinkingLine( active: boolean ): string {
-	const [ index, setIndex ] = useState( 0 );
-
-	useEffect( () => {
-		if ( ! active ) {
-			setIndex( 0 );
-			return;
-		}
-		const id = setInterval( () => setIndex( ( i ) => i + 1 ), 3000 );
-		return () => clearInterval( id );
-	}, [ active ] );
-
-	return THINKING_LINES[ index % THINKING_LINES.length ];
-}
+const PRE_RUN_LINE = __( 'Sending the brief to the agent' );
+const FALLBACK_LINE = __( 'Working on it' );
 
 function useElapsedMs( active: boolean ): number {
 	const [ elapsed, setElapsed ] = useState( 0 );
-
 	useEffect( () => {
 		if ( ! active ) {
 			setElapsed( 0 );
@@ -57,7 +48,6 @@ function useElapsedMs( active: boolean ): number {
 		const id = setInterval( () => setElapsed( Date.now() - startedAt ), 250 );
 		return () => clearInterval( id );
 	}, [ active ] );
-
 	return elapsed;
 }
 
@@ -80,13 +70,74 @@ function formatElapsed( ms: number ): string {
 	);
 }
 
-export default function GeneratingOverlay( { agentName, isOpen, onCancel }: Props ) {
-	const thinkingLine = useThinkingLine( isOpen );
+const isReadyStatus = ( status?: string ): boolean => status === 'ready';
+const isFailedStatus = ( status?: string ): boolean =>
+	status === 'failed' || status === 'cancelled' || status === 'error';
+
+export default function GeneratingOverlay( {
+	agentName,
+	runId,
+	isUploading,
+	onReady,
+	onFailed,
+	onCancel,
+}: Props ) {
+	const isOpen = isUploading || !! runId;
+
+	// While a run is in flight, poll its status every 2s so the
+	// overlay's copy line reflects the real pipeline step. Stops as
+	// soon as the run reaches a terminal status (handled below by the
+	// onReady / onFailed effect).
+	const runQuery = useAgentStudioRun( runId ?? undefined );
+	useEffect( () => {
+		if ( ! runId ) {
+			return;
+		}
+		const interval = setInterval( () => {
+			runQuery.refetch();
+		}, 2000 );
+		return () => clearInterval( interval );
+		// We only want this interval to attach/detach when the run id
+		// changes — `runQuery` itself is stable across refetches.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ runId ] );
+
+	const status = runQuery.data?.status;
+	const currentStep = runQuery.data?.current_step;
+	const errorMessage = runQuery.data?.error?.message;
+
+	// Fire the terminal callbacks exactly once per run id.
+	const firedRef = useRef< string | null >( null );
+	useEffect( () => {
+		if ( ! runId || firedRef.current === runId ) {
+			return;
+		}
+		if ( isReadyStatus( status ) ) {
+			firedRef.current = runId;
+			onReady( runId );
+			return;
+		}
+		if ( isFailedStatus( status ) ) {
+			firedRef.current = runId;
+			onFailed( errorMessage );
+		}
+	}, [ runId, status, errorMessage, onReady, onFailed ] );
+
 	const elapsedMs = useElapsedMs( isOpen );
 
 	if ( ! isOpen ) {
 		return null;
 	}
+
+	const copyLine = ( () => {
+		if ( isUploading || ! runId ) {
+			return PRE_RUN_LINE;
+		}
+		if ( currentStep && STEP_COPY[ currentStep ] ) {
+			return STEP_COPY[ currentStep ];
+		}
+		return FALLBACK_LINE;
+	} )();
 
 	return (
 		<Modal
@@ -113,7 +164,7 @@ export default function GeneratingOverlay( { agentName, isOpen, onCancel }: Prop
 						) }
 					</Text>
 					<Text size={ 15 } weight={ 600 }>
-						{ thinkingLine }
+						{ copyLine }
 					</Text>
 					<Text variant="muted">{ formatElapsed( elapsedMs ) }</Text>
 				</VStack>

--- a/client/a8c-for-agencies/sections/agent-studio/primary/brief/one-pager-brief-form.tsx
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/brief/one-pager-brief-form.tsx
@@ -1,3 +1,4 @@
+import pageRouter from '@automattic/calypso-router';
 import {
 	Button,
 	TextControl,
@@ -10,6 +11,10 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState } from 'react';
+import { useDispatch } from 'calypso/state';
+import { errorNotice } from 'calypso/state/notices/actions';
+import useDeleteAgentStudioOutput from '../../data/use-delete-agent-studio-output';
+import { getAgentStudioOutputPath, getAgentStudioPath } from '../../lib/paths';
 import { getBriefExcerpt } from './brief-helpers';
 import GeneratingOverlay from './generating-overlay';
 import ImageUploadField from './image-upload-field';
@@ -24,6 +29,7 @@ interface Props {
 }
 
 export default function OnePagerBriefForm( { agent }: Props ) {
+	const dispatch = useDispatch();
 	const [ brief, setBrief ] = useState( '' );
 	const [ title, setTitle ] = useState( '' );
 	const [ blurb, setBlurb ] = useState( '' );
@@ -33,9 +39,12 @@ export default function OnePagerBriefForm( { agent }: Props ) {
 	const [ images, setImages ] = useState< File[] >( [] );
 
 	const submit = useSubmitOnePagerBrief( agent );
+	const deleteOutput = useDeleteAgentStudioOutput();
+	const runId = submit.data?.id ?? null;
+	const isOverlayActive = submit.isPending || !! runId;
 
 	// At least one image is required so June has a cover to design around.
-	const canSubmit = !! brief.trim() && !! title.trim() && images.length > 0 && ! submit.isPending;
+	const canSubmit = !! brief.trim() && !! title.trim() && images.length > 0 && ! isOverlayActive;
 
 	const onSubmit = ( event: FormEvent ) => {
 		event.preventDefault();
@@ -66,7 +75,7 @@ export default function OnePagerBriefForm( { agent }: Props ) {
 						value={ brief }
 						onChange={ setBrief }
 						rows={ 8 }
-						disabled={ submit.isPending }
+						disabled={ isOverlayActive }
 						__nextHasNoMarginBottom
 					/>
 
@@ -78,7 +87,7 @@ export default function OnePagerBriefForm( { agent }: Props ) {
 							placeholder={ __( 'A clear, confident headline for the cover' ) }
 							value={ title }
 							onChange={ setTitle }
-							disabled={ submit.isPending }
+							disabled={ isOverlayActive }
 							__next40pxDefaultSize
 							__nextHasNoMarginBottom
 						/>
@@ -93,7 +102,7 @@ export default function OnePagerBriefForm( { agent }: Props ) {
 							value={ blurb }
 							onChange={ setBlurb }
 							rows={ 3 }
-							disabled={ submit.isPending }
+							disabled={ isOverlayActive }
 							__nextHasNoMarginBottom
 						/>
 					</VStack>
@@ -108,13 +117,13 @@ export default function OnePagerBriefForm( { agent }: Props ) {
 								label={ __( 'Primary logo' ) }
 								file={ logoFile }
 								onChange={ setLogoFile }
-								disabled={ submit.isPending }
+								disabled={ isOverlayActive }
 							/>
 							<LogoUploadField
 								label={ __( 'Partner logo' ) }
 								file={ partnerLogoFile }
 								onChange={ setPartnerLogoFile }
-								disabled={ submit.isPending }
+								disabled={ isOverlayActive }
 							/>
 						</HStack>
 						{ partnerLogoFile && (
@@ -122,7 +131,7 @@ export default function OnePagerBriefForm( { agent }: Props ) {
 								label={ __( 'Partner logo position' ) }
 								value={ partnerLogoOrder }
 								onChange={ ( value ) => setPartnerLogoOrder( value as DualLogoOrder ) }
-								disabled={ submit.isPending }
+								disabled={ isOverlayActive }
 								isBlock
 								__next40pxDefaultSize
 								__nextHasNoMarginBottom
@@ -139,7 +148,7 @@ export default function OnePagerBriefForm( { agent }: Props ) {
 						help={ __( 'Add at least one image and I’ll place them in the design.' ) }
 						images={ images }
 						onChange={ setImages }
-						disabled={ submit.isPending }
+						disabled={ isOverlayActive }
 						firstImageIsCover
 					/>
 
@@ -148,7 +157,7 @@ export default function OnePagerBriefForm( { agent }: Props ) {
 							variant="primary"
 							type="submit"
 							disabled={ ! canSubmit }
-							isBusy={ submit.isPending }
+							isBusy={ isOverlayActive }
 						>
 							{ sprintf(
 								/* translators: %s is an agent name. */
@@ -161,8 +170,29 @@ export default function OnePagerBriefForm( { agent }: Props ) {
 			</form>
 			<GeneratingOverlay
 				agentName={ agent.name }
-				isOpen={ submit.isPending }
-				onCancel={ () => submit.reset() }
+				runId={ runId }
+				isUploading={ submit.isPending }
+				onReady={ ( readyRunId ) => {
+					pageRouter( getAgentStudioOutputPath( readyRunId ) );
+				} }
+				onFailed={ ( message ) => {
+					dispatch(
+						errorNotice(
+							message || __( 'Something went wrong while generating your deliverable.' )
+						)
+					);
+					submit.reset();
+				} }
+				onCancel={ () => {
+					// DELETE server-side so the orphaned run doesn't keep
+					// burning pipeline cycles. Don't await — the overview
+					// skips the row once the user navigates away.
+					if ( runId ) {
+						deleteOutput.mutate( runId );
+					}
+					submit.reset();
+					pageRouter( getAgentStudioPath() );
+				} }
 			/>
 		</>
 	);

--- a/client/a8c-for-agencies/sections/agent-studio/primary/brief/use-submit-one-pager-brief.ts
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/brief/use-submit-one-pager-brief.ts
@@ -1,13 +1,11 @@
-import pageRouter from '@automattic/calypso-router';
 import { useMutation } from '@tanstack/react-query';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useDispatch, useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { errorNotice } from 'calypso/state/notices/actions';
 import useCreateAgentStudioOutput from '../../data/use-create-agent-studio-output';
 import { uploadAgentMedia } from '../../data/use-upload-agent-media';
-import { getAgentStudioPath } from '../../lib/paths';
 import type { AgentStudioAgent } from '../../lib/agents';
 import type { AgentStudioOutput, DualLogoOrder } from '../../types';
 
@@ -71,17 +69,9 @@ export default function useSubmitOnePagerBrief( agent: AgentStudioAgent ) {
 					output_id: output.id,
 				} )
 			);
-			dispatch(
-				successNotice(
-					sprintf(
-						/* translators: %s is an agent name. */
-						__( '%s is on it. Your deliverable is generating.' ),
-						output.agentName
-					),
-					{ duration: 5000 }
-				)
-			);
-			pageRouter( getAgentStudioPath() );
+			// No navigation here — the brief form keeps GeneratingOverlay
+			// open and redirects from its `onReady` callback once the run
+			// status poll hits a terminal status.
 		},
 		onError: () => {
 			dispatch( errorNotice( __( 'Could not start the deliverable. Please try again.' ) ) );


### PR DESCRIPTION
Part of #110900

## Proposed Changes

* `GeneratingOverlay` now takes a `runId` and polls `GET /a4a/runs/<id>` every 2 seconds via `useAgentStudioRun`, mapping the pipeline's `current_step` to friendly copy.
* The brief form keeps the overlay mounted across the full run (upload → POST `/a4a/runs` → recipe steps → `ready`/`failed`) and navigates straight to the deliverable's detail page on `ready`.
* On `failed | cancelled | error` the form surfaces the run's `error.message` (or a generic fallback) and resets.
* Cancel calls `DELETE /a4a/runs/<id>` when a run id is known, then navigates back to the overview. The pre-run window (before POST returns) still cancels locally — there's no server-side orphan to clean up yet.
* `use-submit-one-pager-brief` no longer redirects on success or fires a “generating…” notice. Both responsibilities now sit on the form, which owns the overlay's terminal callbacks.

## Why are these changes being made?

### How the system worked before

PR #110900 wired the real pipeline but kept the placeholder UX around it: as soon as `POST /a4a/runs` returned an id, the brief form closed the overlay, dispatched a `successNotice`, and pushed the user to `/agent-studio`. The card flipped from “Generating…” to “Ready” after the overview's 2-second `/a4a/outputs` poll caught the terminal status, and the user had to click into it from there. While the run was in flight the overlay rotated through ten generic “design thinking” lines on a 3-second interval, fully decoupled from the pipeline.

### What's the problem

The placeholder copy was a guess. The recipe actually has named phases (`compose_page_frame` → `layout_director_ela_v2` → `persist_as_html_post`), and a user watching the loading screen had no signal which phase they were in or how far along the run was. The hand-off to the overview also added a click and ~2 seconds of polling latency before the user could see the deliverable they just generated.

### What this change does

Drives the overlay from real run state instead of a timer. The Calypso side now mirrors what's actually happening on the agents stack:

- `useAgentStudioRun(runId)` provides the run record; the overlay attaches an explicit `setInterval` refetch at 2s while a run is in flight, so the copy line ticks forward as the pipeline advances.
- `current_step` is mapped to friendly lines via a `STEP_COPY` table. Both the v2 step set (`compose-one-pager-ela-v2`) and baseline `compose-one-pager`'s four-step set (`extract_brief` + the three v2 steps) are covered, so a future recipe swap doesn't need a UI change.
- Terminal callbacks fire exactly once per run id (guarded by a `firedRef`): `onReady(runId)` navigates the brief form to `/agent-studio/outputs/<runId>`; `onFailed(message)` raises an `errorNotice` and resets the mutation.
- Cancel during a known run id `DELETE`s the run server-side so the pipeline doesn't keep burning cycles after the user walks away. We don't await — the overview view skips the row regardless once the user navigates away.

Net effect: submit → focused modal that reflects the real phase → land on the freshly generated deck.

## Testing Instructions

Prerequisites: signed into A4A on a dev environment with an active agency and the `a4a-agent-studio` feature flag on. PR #110900 must be on trunk locally.

1. `yarn install` (if needed) and `yarn start-a8c-for-agencies`.
2. Open authenticated Chrome at `/resources-and-tools/agent-studio`.
3. Click **New deliverable** → June.
4. Fill in a brief, a title, and at least one body image (a logo or partner logo is optional).
5. Click **Send it to June** and watch the modal:
   - First line: “Sending the brief to the agent” (covers the upload + POST window before a run id is known).
   - Then the line transitions to “Reading the brief” / “Composing cover variants” / “Designing the layout” / “Finalizing the deliverable” as `current_step` advances. Each phase typically lasts 5–20 seconds.
   - The elapsed-time counter ticks forward through all of it.
6. When the run finishes the modal closes and the URL jumps directly to `/agent-studio/outputs/<run_id>` — the deliverable detail page renders the deck.
7. Re-open the brief form and submit another deliverable. Click **Cancel** mid-run (after the line transitions off “Sending the brief to the agent”). Network panel should show `DELETE /agency/<id>/a4a/runs/<run_id>`; the URL returns to `/agent-studio` and the cancelled card does not appear.
8. Cancel again, this time during the “Sending the brief to the agent” window (before POST returns). No `DELETE` should fire — the run id doesn't exist yet — and the form resets locally.
9. Force a failure (drop the wpcom recipe input, or kill the pipeline) and confirm the overlay reports the backend's `error.message` via `errorNotice` and resets.

Network panel during step 5:

- `POST /agency/<id>/a4a/media` per uploaded file (multipart).
- `POST /agency/<id>/a4a/runs`.
- `GET /agency/<id>/a4a/runs/<run_id>` repeated every ~2s until `status: ready` (or `failed`).
- On `ready`, navigation to `/agent-studio/outputs/<run_id>` triggers the detail page's own `runs/<id>` + `collateral/<post_id>` fetches.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)