### PR TITLE
Remove the calypso/react-18-create-root feature flag

### DIFF
--- a/client/controller/web-util.js
+++ b/client/controller/web-util.js
@@ -1,11 +1,4 @@
-import config from '@automattic/calypso-config';
-import ReactDom from 'react-dom';
 import { createRoot, hydrateRoot } from 'react-dom/client';
-
-// Gates the React 18 `createRoot`/`hydrateRoot` adoption. When disabled, the
-// `#wpcom` root keeps mounting via the legacy `ReactDOM.render`/`hydrate` APIs
-// (React-17 update semantics — synchronous, no automatic batching).
-const useCreateRoot = config.isEnabled( 'calypso/react-18-create-root' );
 
 // The classic Calypso app mounts into a single, long-lived `#wpcom` container.
 // `createRoot`/`hydrateRoot` must be called exactly once per container; every
@@ -15,10 +8,6 @@ const useCreateRoot = config.isEnabled( 'calypso/react-18-create-root' );
 let root;
 
 export function render( context ) {
-	if ( ! useCreateRoot ) {
-		ReactDom.render( context.layout, document.getElementById( 'wpcom' ) );
-		return;
-	}
 	if ( ! root ) {
 		root = createRoot( document.getElementById( 'wpcom' ) );
 	}
@@ -26,10 +15,6 @@ export function render( context ) {
 }
 
 export function hydrate( context ) {
-	if ( ! useCreateRoot ) {
-		ReactDom.hydrate( context.layout, document.getElementById( 'wpcom' ) );
-		return;
-	}
 	if ( ! root ) {
 		root = hydrateRoot( document.getElementById( 'wpcom' ), context.layout );
 	} else {

--- a/config/development.json
+++ b/config/development.json
@@ -57,7 +57,6 @@
 		"calypso/all-domain-management": true,
 		"calypso/big-sky": true,
 		"calypso/domains-dataviews": true,
-		"calypso/react-18-create-root": true,
 		"calypso/refund-eligibility-notice": false,
 		"cancel-flow/solutions-cards-upsell": false,
 		"checkout/checkout-version": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -18,7 +18,6 @@
 		"calypso/all-domain-management": false,
 		"calypso/big-sky": true,
 		"calypso/domains-dataviews": true,
-		"calypso/react-18-create-root": true,
 		"catch-js-errors": true,
 		"checkout/checkout-version": false,
 		"checkout/google-pay": true,

--- a/config/production.json
+++ b/config/production.json
@@ -31,7 +31,6 @@
 		"calypso/all-domain-management": true,
 		"calypso/big-sky": true,
 		"calypso/domains-dataviews": true,
-		"calypso/react-18-create-root": false,
 		"catch-js-errors": true,
 		"checkout/checkout-version": false,
 		"checkout/google-pay": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -28,7 +28,6 @@
 		"calypso/all-domain-management": true,
 		"calypso/big-sky": true,
 		"calypso/domains-dataviews": true,
-		"calypso/react-18-create-root": true,
 		"catch-js-errors": true,
 		"checkout/checkout-version": true,
 		"checkout/google-pay": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -27,7 +27,6 @@
 		"calypso/all-domain-management": true,
 		"calypso/big-sky": true,
 		"calypso/domains-dataviews": true,
-		"calypso/react-18-create-root": true,
 		"catch-js-errors": false,
 		"checkout/checkout-version": true,
 		"checkout/google-pay": true,


### PR DESCRIPTION
Part of #110857

## Proposed Changes

* Remove the `calypso/react-18-create-root` feature flag from all five environment configs (`development`, `stage`, `horizon`, `wpcalypso`, `production`).
* Drop the legacy `ReactDOM.render`/`ReactDOM.hydrate` fallback path in `client/controller/web-util.js`, along with the now-unused `react-dom` import.
* The `#wpcom` root now always mounts via React 18's `createRoot`/`hydrateRoot`.

## Why are these changes being made?

#110857 introduced the React 18 `createRoot`/`hydrateRoot` adoption for the classic Calypso `#wpcom` root, gated behind the `calypso/react-18-create-root` flag. The flag was enabled on development, stage, horizon, and wpcalypso, and disabled on production, so the behavior change could be smoke-tested broadly before shipping.

With that testing done, this PR retires the flag and the legacy fallback so the React 18 root mounting becomes the default behavior in every environment — including production. Merging this releases the change directly.

## Testing Instructions

* Load classic Calypso (e.g. `/home`, `/sites`) and navigate between sections — the app should mount and re-render normally on every route change.
* Confirm both render paths work: a logged-in bootstrapped session (`hydrateRoot`) and a non-bootstrapped session (`createRoot`).
* Verify the DataViews "Add filter" popover renders visibly (the legacy-batching race that #110857 fixed).
* Check the console for React root warnings (e.g. duplicate `createRoot` calls, hydration mismatches).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)