### PR TITLE
A4A Agent Studio: upload media via existing endpoint

### DIFF
--- a/client/a8c-for-agencies/sections/agent-studio/data/use-upload-agent-media.ts
+++ b/client/a8c-for-agencies/sections/agent-studio/data/use-upload-agent-media.ts
@@ -1,8 +1,8 @@
 /**
  * Multipart upload to `POST /agency/<id>/profile/logo` with
- * `purpose=agent_media`. Same endpoint as the Partner Directory logo
- * uploader (the path is whitelisted upstream), but the `purpose` param
- * switches the server to a UUID filename and the richer payload below.
+ * `purpose=agent_media`. The `purpose` param switches the server to a
+ * UUID filename and the richer payload below; without it the server
+ * returns the Partner Directory logo shape (`{ logo_url }`).
  * Backend rules: jpeg/png only, 10 MB max, field name `media`.
  */
 import { useMutation, type UseMutationOptions } from '@tanstack/react-query';

--- a/client/a8c-for-agencies/sections/agent-studio/data/use-upload-agent-media.ts
+++ b/client/a8c-for-agencies/sections/agent-studio/data/use-upload-agent-media.ts
@@ -1,6 +1,9 @@
 /**
- * Multipart upload to `POST /a4a/media`. Backend rules: jpeg/png only,
- * 10 MB max, field name `media`.
+ * Multipart upload to `POST /agency/<id>/profile/logo` with
+ * `purpose=agent_media`. Same endpoint as the Partner Directory logo
+ * uploader (the path is whitelisted upstream), but the `purpose` param
+ * switches the server to a UUID filename and the richer payload below.
+ * Backend rules: jpeg/png only, 10 MB max, field name `media`.
  */
 import { useMutation, type UseMutationOptions } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
@@ -23,8 +26,11 @@ export const uploadAgentMedia = (
 		wpcom.req.post(
 			{
 				apiNamespace: 'wpcom/v2',
-				path: `/agency/${ agencyId }/a4a/media`,
-				formData: [ [ 'media', file ] ],
+				path: `/agency/${ agencyId }/profile/logo`,
+				formData: [
+					[ 'media', file ],
+					[ 'purpose', 'agent_media' ],
+				],
 			},
 			( error: Error | null, response: UploadAgentMediaResponse ) => {
 				if ( error ) {


### PR DESCRIPTION
## Summary

The Agent Studio "new deliverable" uploader (`useUploadAgentMedia`) currently POSTs to `POST /agency/<id>/a4a/media`, but we have an existing endpoint that mimics this. We will need to rename the endpoint eventually.

Paired wpcom PR: 219150-ghe-Automattic/wpcom

## Testing instructions

This PR needs the paired wpcom branch sandboxed.

1. On your wpcom sandbox: `git fetch && git checkout a4a/route-media-uploads-via-profile-logo`, then sandbox.
2. Run Calypso locally: `yarn start-a8c-for-agencies`.
3. Visit http://agencies.localhost:3000/resources-and-tools/agent-studio and click **New deliverable**.
4. Attach a logo, a partner logo, and one or more body images, then submit.
5. Verify all uploads complete and the output is created. In the network tab, each upload should be a multipart `POST /wpcom/v2/agency/<id>/profile/logo` with form fields `media` and `purpose=agent_media`, and each response should be `{ attachment_id, url, mime, width, height }`.
6. Regression check: still in Calypso, upload an agency logo via the Partner Directory agency-details screen (the `use-upload-logo.ts` flow). The request should still POST to `/profile/logo` (no `purpose` field) and respond with `{ logo_url }`. The logo should appear in the agency profile as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)