### PR TITLE
Reader quick post: drop duplicate .site-selector .site.is-selected rule

### DIFF
--- a/client/reader/components/quick-post/style.scss
+++ b/client/reader/components/quick-post/style.scss
@@ -96,16 +96,6 @@
 				color: var( --color-text-subtle );
 			}
 		}
-
-		.site-selector .site.is-selected {
-			.site__title {
-				color: var( --color-text );
-			}
-
-			.site__domain {
-				color: var( --color-text-subtle );
-			}
-		}
 	}
 
 	.sites-dropdown__wrapper {


### PR DESCRIPTION
Part of #110818

## Proposed Changes

* Remove the duplicate `.site-selector .site.is-selected` block from `client/reader/components/quick-post/style.scss`.

## Why are these changes being made?

The Reader quick post stylesheet ended up with two `.site-selector .site.is-selected` blocks:

* One added while introducing quick-post dark-mode support (#110759 / #110806).
* A second, identical-selector block added later by #110818 while centralizing the dark-mode tokens.

Each PR passed the "Code style" check in isolation, because in each branch only one block existed. Once both landed on trunk, the duplicate exists in the combination. `lint:css` is a whole-repo `stylelint` run with no diff scoping, so `no-duplicate-selectors` now fails for **every** open branch cut from trunk — not just the PRs that touched this file:

```
client/reader/components/quick-post/style.scss
  100:3  ✖  Unexpected duplicate selector ".site-selector .site.is-selected", first used at line 71  no-duplicate-selectors
  101:4  ✖  Unexpected duplicate selector ".site__title", first used at line 72                      no-duplicate-selectors
  105:4  ✖  Unexpected duplicate selector ".site__domain", first used at line 80                     no-duplicate-selectors
```

The second block is a strict subset of the first — identical `.site__title` and `.site__domain` rules — and the first block additionally covers `&.is-private .site__title::before`. Removing the second block is a no-op for the rendered styles and restores a green "Code style" check repo-wide.

## Testing Instructions

* Run `yarn stylelint client/reader/components/quick-post/style.scss` — it should report no errors.
* In the Reader quick post site selector, confirm the selected site's title/domain colors are unchanged in both light and dark mode.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)