### PR TITLE
Bump Site Spec widget to v1.6.0

### DIFF
--- a/config/_shared.json
+++ b/config/_shared.json
@@ -224,8 +224,8 @@
 	"blackbox_url": "https://blackbox-api.wp.com/v1/dist/v.js",
 	"blackbox_api_key": "e16ecd5d7848b169d97088e4c69065d8",
 	"site_spec": {
-		"script_url": "https://widgets.wp.com/site-spec/v1.5.0/index.js",
-		"css_url": "https://widgets.wp.com/site-spec/v1.5.0/style.css"
+		"script_url": "https://widgets.wp.com/site-spec/v1.6.0/index.js",
+		"css_url": "https://widgets.wp.com/site-spec/v1.6.0/style.css"
 	},
 	"dashboard_opt_in_oldest_eligible_user": 275231967
 }


### PR DESCRIPTION
## Summary

Activates Site Spec v1.6.0 (`277-gh-Automattic/site-spec`) on the standalone AI Site Builder funnel (`wordpress.com/ai-site-builder-site-spec/`). v1.6.0 ships the Gravatar pre-fill flow (avatar editor, email/phone/social rows in spec preview).

The Gravatar UI stays dormant on this release until the companion WPCOM PR deploys (the `_gravatar_flow` gate).

## What's in this PR

`config/_shared.json` — `script_url` + `css_url` bumped from `v1.5.0` → `v1.6.0`.

## Companion PRs

- **site-spec** v1.6.0 release: `277-gh-Automattic/site-spec`
- **big-sky-plugin** bump: `5991-gh-Automattic/big-sky-plugin`
- **wpcom** — `add/site-spec-v1.6.0` (already produced by the sync script).

## Test plan

- [ ] After deploy, open `https://wordpress.com/ai-site-builder-site-spec/`
- [ ] DevTools Network → confirm `https://widgets.wp.com/site-spec/v1.6.0/index.js` loads
- [ ] Submit a non-Gravatar spec — Gravatar UI remains dormant