### PR TITLE
Onboarding plans: redirect free plan selections to the choose page (re-land)

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -70,9 +70,9 @@ const onboarding: FlowV2< typeof initialize > = {
 			setHideFreePlan,
 		} = useDispatch( ONBOARD_STORE ) as OnboardActions;
 		const locale = useFlowLocale();
-		const { signupDomainOrigin, planCartItem, blueprint } = useSelect(
+		// Restore `signupDomainOrigin` here if the PWYW /choose A/B test is reverted in the 'plans' submit case below.
+		const { planCartItem, blueprint } = useSelect(
 			( select ) => ( {
-				signupDomainOrigin: ( select( ONBOARD_STORE ) as OnboardSelect ).getSignupDomainOrigin(),
 				planCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getPlanCartItem(),
 				blueprint: ( select( ONBOARD_STORE ) as OnboardSelect ).getBlueprint(),
 			} ),
@@ -194,15 +194,22 @@ const onboarding: FlowV2< typeof initialize > = {
 					setPlanCartItem( pickedPlan );
 
 					if ( ! pickedPlan ) {
-						// Since we're removing the paid domain, it means that the user chose to continue
-						// with a free domain. Because signupDomainOrigin should reflect the last domain
-						// selection status before they land on the checkout page, this value can be
-						// 'free' or 'choose-later'
-						if ( signupDomainOrigin === 'choose-later' ) {
-							setSignupDomainOrigin( signupDomainOrigin );
-						} else {
-							setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.FREE );
-						}
+						// Redirect free plan selections to wordpress.com/choose for the PWYW A/B test.
+						// `/choose` is a WordPress.com PHP route, not a Calypso route, so we need an
+						// absolute URL — a relative path resolves to the current Calypso host (e.g.
+						// wpcalypso.wordpress.com/choose) and 404s on pre-release. See TESTOPS-106.
+						// If we end the A/B test without shipping it, restore the commented-out
+						// block below and remove this redirect.
+						window.location.assign(
+							addQueryArgs( 'https://wordpress.com/choose', getQueryArgs( window.location.href ) )
+						);
+						return;
+
+						// if ( signupDomainOrigin === 'choose-later' ) {
+						// 	setSignupDomainOrigin( signupDomainOrigin );
+						// } else {
+						// 	setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.FREE );
+						// }
 					}
 
 					// Make sure to put the rest of products into the cart, e.g. the storage add-ons.


### PR DESCRIPTION
## Proposed Changes

* Re-lands #110877 (which was reverted in #110885 because it broke pre-release E2E).
* When a user clicks **Start with Free** (or the deemphasized **start with our free plan** subheader link) on `/setup/onboarding/plans`, redirect them to the choose page instead of continuing through site creation.
* **Fix vs. the original PR:** use an absolute URL for the choose page. The choose page is a WordPress.com PHP/Atlas route, not a Calypso route — a relative path resolves to the current Calypso host and 404s on pre-release. See TESTOPS-106.

The previous behavior (setting `signupDomainOrigin` and proceeding to `create-site`) is preserved as a commented-out block so we can revert quickly if the A/B test doesn't win.

## Why are these changes being made?

* Following Aaron's recommendation.
* The A/B bucketing happens on the choose page itself, so we just need to route free-plan clicks there.

## Testing Instructions

* Visit `/setup/onboarding/plans` (after the domain step).
* Click **Start with Free**. Verify you land on the choose page (absolute URL), and that query args from the current URL are preserved.
* Click any paid plan card. Verify the regular checkout flow still works.
* On pre-release, verify the redirect goes to the production choose page, not a Calypso-host equivalent.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed?
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?