### PR TITLE
Renewal pricing: fix upsell card calculations

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
@@ -177,26 +177,19 @@ export function CheckoutSidebarPlanUpsell() {
 
 	const currentInfo = fromVariantPriceData( currentVariant );
 	const upsellInfo = fromVariantPriceData( upsellVariant );
-	const compareToPriceForVariantTerm = getPlanPriceForDuration(
+	const currentPlanPrice = getPlanPriceForDuration( currentInfo, currentInfo.termMonths );
+	const currentPlanPriceAtUpsellTerm = getPlanPriceForDuration(
 		currentInfo,
 		upsellInfo.termMonths
 	);
+	const upsellPlanPrice = getPlanPriceForDuration( upsellInfo, upsellInfo.termMonths );
 	const percentSavings =
-		calculateDiscountPercentage(
-			compareToPriceForVariantTerm,
-			getPlanPriceForDuration( upsellInfo, upsellInfo.termMonths )
-		) ?? 0;
+		calculateDiscountPercentage( currentPlanPriceAtUpsellTerm, upsellPlanPrice ) ?? 0;
 
 	if ( percentSavings <= 0 ) {
 		debug( 'percent savings is too low', percentSavings );
 		return null;
 	}
-
-	const isComparisonWithIntroOffer =
-		upsellVariant.introductoryInterval === 2 &&
-		upsellVariant.introductoryTerm === 'year' &&
-		currentVariant.introductoryInterval === 1 &&
-		currentVariant.introductoryTerm === 'year';
 
 	const upsellText = getUpsellTextForVariant( upsellVariant, percentSavings, __ );
 
@@ -214,23 +207,18 @@ export function CheckoutSidebarPlanUpsell() {
 						{ currentVariant.variantLabel.adjective }
 					</div>
 					<div className="checkout-sidebar-plan-upsell__plan-grid-cell">
-						{ formatCurrency(
-							currentVariant.priceInteger +
-								( isComparisonWithIntroOffer ? currentVariant.priceBeforeDiscounts : 0 ),
-							currentVariant.currency,
-							{
-								stripZeros: true,
-								isSmallestUnit: true,
-							}
-						) }
+						{ formatCurrency( currentPlanPrice, currentVariant.currency, {
+							stripZeros: true,
+							isSmallestUnit: true,
+						} ) }
 					</div>
 					<div className="checkout-sidebar-plan-upsell__plan-grid-cell">
 						{ upsellVariant.variantLabel.adjective }
 					</div>
 					<div className="checkout-sidebar-plan-upsell__plan-grid-cell">
-						{ compareToPriceForVariantTerm && (
+						{ currentPlanPriceAtUpsellTerm && (
 							<del className="checkout-sidebar-plan-upsell__do-not-pay">
-								{ formatCurrency( compareToPriceForVariantTerm, currentVariant.currency, {
+								{ formatCurrency( currentPlanPriceAtUpsellTerm, currentVariant.currency, {
 									stripZeros: true,
 									isSmallestUnit: true,
 								} ) }

--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
@@ -177,7 +177,7 @@ export function CheckoutSidebarPlanUpsell() {
 
 	const currentInfo = fromVariantPriceData( currentVariant );
 	const upsellInfo = fromVariantPriceData( upsellVariant );
-	const currentPlanPrice = getPlanPriceForDuration( currentInfo, currentInfo.termMonths );
+	const currentPlanPrice = currentVariant.priceInteger;
 	const currentPlanPriceAtUpsellTerm = getPlanPriceForDuration(
 		currentInfo,
 		upsellInfo.termMonths

--- a/client/my-sites/checkout/src/components/test/checkout-sidebar-plan-upsell.test.tsx
+++ b/client/my-sites/checkout/src/components/test/checkout-sidebar-plan-upsell.test.tsx
@@ -1,0 +1,293 @@
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock( '@automattic/composite-checkout', () => ( {
+	FormStatus: {
+		READY: 'ready',
+		LOADING: 'loading',
+		VALIDATING: 'validating',
+		SUBMITTING: 'submitting',
+	},
+	useFormStatus: jest.fn(),
+} ) );
+
+jest.mock( '@automattic/shopping-cart', () => ( {
+	useShoppingCart: jest.fn(),
+} ) );
+
+jest.mock( '../../../use-cart-key', () => ( { __esModule: true, default: jest.fn() } ) );
+
+jest.mock( 'calypso/state', () => ( { useDispatch: jest.fn( () => jest.fn() ) } ) );
+
+jest.mock( 'calypso/state/analytics/actions', () => ( {
+	recordTracksEvent: () => ( { type: 'NOOP_RECORD_TRACKS_EVENT' } ),
+} ) );
+
+jest.mock( '../../hooks/product-variants', () => ( {
+	useGetProductVariants: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/react-i18n', () => ( {
+	useI18n: jest.fn( () => ( { __: ( s: string ) => s } ) ),
+} ) );
+
+jest.mock( '../wp-checkout-order-summary', () => ( {
+	CheckoutSummaryFeaturedList: () => null,
+} ) );
+
+jest.mock( '@automattic/calypso-products', () => ( {
+	isPlan: ( product: { product_slug: string } ) => product.product_slug === 'personal-bundle',
+	isJetpackPlan: () => false,
+} ) );
+
+jest.mock( 'calypso/components/promo-section/promo-card', () => {
+	return function MockPromoCard( props: {
+		title: React.ReactNode;
+		children: React.ReactNode;
+		className?: string;
+	} ) {
+		const React = require( 'react' );
+		return React.createElement(
+			'div',
+			{ className: props.className },
+			props.title,
+			props.children
+		);
+	};
+} );
+
+jest.mock( 'calypso/components/promo-section/promo-card/cta', () => {
+	return function MockPromoCardCTA( props: {
+		cta: { text: React.ReactNode; action: () => void; disabled: boolean };
+	} ) {
+		const React = require( 'react' );
+		return React.createElement(
+			'button',
+			{ onClick: props.cta.action, disabled: props.cta.disabled },
+			props.cta.text
+		);
+	};
+} );
+
+import { useFormStatus } from '@automattic/composite-checkout';
+import { useShoppingCart } from '@automattic/shopping-cart';
+import { render, screen } from '@testing-library/react';
+import { useGetProductVariants } from '../../hooks/product-variants';
+import { CheckoutSidebarPlanUpsell } from '../checkout-sidebar-plan-upsell';
+import type { WPCOMProductVariant } from '../item-variation-picker/types';
+import type React from 'react';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeVariant( overrides: Partial< WPCOMProductVariant > = {} ): WPCOMProductVariant {
+	return {
+		priceInteger: 24000,
+		priceBeforeDiscounts: 24000,
+		termIntervalInMonths: 12,
+		termIntervalInDays: 365,
+		productBillingTermInMonths: 12,
+		productId: 1009,
+		productSlug: 'personal-bundle',
+		currency: 'USD',
+		variantLabel: { noun: 'Year', adjective: 'Annual' },
+		introductoryInterval: 0,
+		introductoryTerm: 'year',
+		...overrides,
+	};
+}
+
+function makeCartWithPlan( productId: number ) {
+	return {
+		products: [
+			{
+				product_slug: 'personal-bundle',
+				product_id: productId,
+				uuid: 'plan-001',
+			},
+		],
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe( 'CheckoutSidebarPlanUpsell', () => {
+	beforeEach( () => {
+		( useFormStatus as jest.Mock ).mockReturnValue( { formStatus: 'ready' } );
+		( useShoppingCart as jest.Mock ).mockReturnValue( {
+			responseCart: makeCartWithPlan( 1009 ),
+			replaceProductInCart: jest.fn(),
+		} );
+		( useGetProductVariants as jest.Mock ).mockReturnValue( [] );
+	} );
+
+	it( 'renders nothing when the cart has no plan', () => {
+		( useShoppingCart as jest.Mock ).mockReturnValue( {
+			responseCart: {
+				products: [ { product_slug: 'domain_reg', product_id: 6, uuid: 'd-001' } ],
+			},
+			replaceProductInCart: jest.fn(),
+		} );
+		const { container } = render( <CheckoutSidebarPlanUpsell /> );
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'renders nothing when there is no higher billing term to upsell to', () => {
+		// Only one variant — no higher term exists.
+		( useGetProductVariants as jest.Mock ).mockReturnValue( [
+			makeVariant( { productBillingTermInMonths: 12, termIntervalInMonths: 12, productId: 1009 } ),
+		] );
+		const { container } = render( <CheckoutSidebarPlanUpsell /> );
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'renders nothing when the upsell plan offers no savings over the current plan', () => {
+		// Both variants have equal regularPricePerMonth (derived from priceBeforeDiscounts)
+		// and no intro offers, so calculateDiscountPercentage returns undefined → percentSavings=0.
+		( useGetProductVariants as jest.Mock ).mockReturnValue( [
+			makeVariant( {
+				productBillingTermInMonths: 1,
+				termIntervalInMonths: 1,
+				productId: 1009,
+				priceInteger: 2000,
+				priceBeforeDiscounts: 2000,
+				introductoryInterval: 0,
+			} ),
+			makeVariant( {
+				productBillingTermInMonths: 12,
+				termIntervalInMonths: 12,
+				productId: 1010,
+				priceInteger: 24000,
+				priceBeforeDiscounts: 24000,
+				introductoryInterval: 0,
+			} ),
+		] );
+		const { container } = render( <CheckoutSidebarPlanUpsell /> );
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	describe( 'monthly plan → annual plan with intro offer', () => {
+		// Monthly plan: $20/month, no intro offer.
+		// Annual plan: $120/year intro price, $240/year regular price.
+		//   12000¢ / 12 months = 1000¢/month (exact, no rounding)
+		//
+		// currentPlanPrice             = getPlanPriceForDuration(monthlyInfo, 1)  = 1 × 2000¢  = $20
+		// currentPlanPriceAtUpsellTerm = getPlanPriceForDuration(monthlyInfo, 12) = 12 × 2000¢ = $240
+		// upsellPlanPrice              = getPlanPriceForDuration(annualInfo, 12)  = 12 × 1000¢ = $120
+		// percentSavings               = floor((24000 – 12000) / 24000 × 100)    = 50
+		//
+		// Displayed upsell price uses upsellVariant.priceInteger directly = $120.
+
+		beforeEach( () => {
+			( useGetProductVariants as jest.Mock ).mockReturnValue( [
+				makeVariant( {
+					productBillingTermInMonths: 1,
+					termIntervalInMonths: 1,
+					productId: 1009,
+					priceInteger: 2000,
+					priceBeforeDiscounts: 2000,
+					introductoryInterval: 0,
+					variantLabel: { noun: 'Month', adjective: 'Monthly' },
+				} ),
+				makeVariant( {
+					productBillingTermInMonths: 12,
+					termIntervalInMonths: 12,
+					productId: 1010,
+					// Intro offer: $120/yr intro, $240/yr regular. 12000/12 = 1000 exactly.
+					priceInteger: 12000,
+					priceBeforeDiscounts: 24000,
+					introductoryInterval: 1,
+					introductoryTerm: 'year',
+					variantLabel: { noun: 'Year', adjective: 'Annual' },
+				} ),
+			] );
+		} );
+
+		it( 'shows the current plan price for its own billing term', () => {
+			render( <CheckoutSidebarPlanUpsell /> );
+			expect( screen.getByText( '$20' ) ).toBeVisible();
+		} );
+
+		it( 'shows the struck-through "what you would pay" comparison price', () => {
+			render( <CheckoutSidebarPlanUpsell /> );
+			const struckThrough = screen.getByText( '$240' );
+			expect( struckThrough ).toBeVisible();
+			expect( struckThrough.closest( 'del' ) ).not.toBeNull();
+		} );
+
+		it( 'shows the upsell plan price', () => {
+			render( <CheckoutSidebarPlanUpsell /> );
+			expect( screen.getByText( '$120' ) ).toBeVisible();
+		} );
+	} );
+
+	describe( 'annual plan with 1-year intro → biennial plan with 2-year intro', () => {
+		// Annual: $120/yr intro price, $240/yr regular. 12000/12 = 1000¢/month (exact).
+		// Biennial: $240/2yr intro price, $480/2yr regular. 24000/24 = 1000¢/month (exact).
+		//
+		// currentPlanPrice             = getPlanPriceForDuration(annualInfo, 12)  = 12 × 1000¢ = $120
+		// currentPlanPriceAtUpsellTerm = getPlanPriceForDuration(annualInfo, 24)  = 12 × 1000¢ + 12 × 2000¢ = $360
+		// upsellPlanPrice              = getPlanPriceForDuration(biennialInfo, 24) = 24 × 1000¢ = $240
+		// percentSavings               = floor((36000 – 24000) / 36000 × 100) = 33
+		//
+		// Previously the removed isComparisonWithIntroOffer guard produced the current-plan price
+		// as priceInteger + priceBeforeDiscounts = 12000 + 24000 = 36000¢ = $360, which equals the
+		// struck-through comparison and was the 2-year total at annual rates, not the 1-year intro price.
+		// The new code uses getPlanPriceForDuration(currentInfo, currentInfo.termMonths) = $120.
+
+		beforeEach( () => {
+			( useGetProductVariants as jest.Mock ).mockReturnValue( [
+				makeVariant( {
+					productBillingTermInMonths: 12,
+					termIntervalInMonths: 12,
+					productId: 1009,
+					// Intro offer: $120/yr intro, $240/yr regular. 12000/12 = 1000 exactly.
+					priceInteger: 12000,
+					priceBeforeDiscounts: 24000,
+					introductoryInterval: 1,
+					introductoryTerm: 'year',
+					variantLabel: { noun: 'Year', adjective: 'Annual' },
+				} ),
+				makeVariant( {
+					productBillingTermInMonths: 24,
+					termIntervalInMonths: 24,
+					productId: 1010,
+					// Intro offer: $240/2yr intro, $480/2yr regular. 24000/24 = 1000 exactly.
+					priceInteger: 24000,
+					priceBeforeDiscounts: 48000,
+					introductoryInterval: 2,
+					introductoryTerm: 'year',
+					variantLabel: { noun: 'Two years', adjective: 'Two-year' },
+				} ),
+			] );
+		} );
+
+		it( 'shows the intro-offer-aware current plan price ($120, not the 2-year total $360)', () => {
+			render( <CheckoutSidebarPlanUpsell /> );
+			// New: getPlanPriceForDuration uses the intro offer → 12 × 1000¢ = $120.
+			const currentPrice = screen.getByText( '$120' );
+			expect( currentPrice ).toBeVisible();
+			// Old code: priceInteger (12000¢) + priceBeforeDiscounts (24000¢) = 36000¢ = $360.
+			// $360 still appears in the DOM as the struck-through comparison, so we verify
+			// that $120 is NOT inside a <del> (i.e. it is the current-plan Row 1, not the comparison).
+			expect( currentPrice.closest( 'del' ) ).toBeNull();
+		} );
+
+		it( 'shows the struck-through comparison price (2 years at annual rates)', () => {
+			render( <CheckoutSidebarPlanUpsell /> );
+			const struckThrough = screen.getByText( '$360' );
+			expect( struckThrough ).toBeVisible();
+			expect( struckThrough.closest( 'del' ) ).not.toBeNull();
+		} );
+
+		it( 'shows the upsell plan price', () => {
+			render( <CheckoutSidebarPlanUpsell /> );
+			// upsellVariant.priceInteger = 24000¢ = $240.
+			expect( screen.getByText( '$240' ) ).toBeVisible();
+		} );
+	} );
+} );

--- a/client/my-sites/checkout/src/components/test/checkout-sidebar-plan-upsell.test.tsx
+++ b/client/my-sites/checkout/src/components/test/checkout-sidebar-plan-upsell.test.tsx
@@ -292,5 +292,36 @@ describe( 'CheckoutSidebarPlanUpsell', () => {
 			// upsellVariant.priceInteger = 24000¢ = $240.
 			expect( screen.getByText( '$240' ) ).toBeVisible();
 		} );
+
+		it( 'displays the exact current plan priceInteger when the term price does not divide evenly by months', () => {
+			// priceInteger=10000¢, termIntervalInMonths=12: 10000/12 = 833.33¢/month.
+			// getPlanPriceForDuration would accumulate 12 × 833 = 9996¢ = $99.96 (rounded down by 4¢).
+			// The component must show the exact priceInteger = 10000¢ = $100.00 instead.
+			( useGetProductVariants as jest.Mock ).mockReturnValue( [
+				makeVariant( {
+					productBillingTermInMonths: 12,
+					termIntervalInMonths: 12,
+					productId: 1009,
+					priceInteger: 10000,
+					priceBeforeDiscounts: 24000,
+					introductoryInterval: 1,
+					introductoryTerm: 'year',
+					variantLabel: { noun: 'Year', adjective: 'Annual' },
+				} ),
+				makeVariant( {
+					productBillingTermInMonths: 24,
+					termIntervalInMonths: 24,
+					productId: 1010,
+					priceInteger: 20000,
+					priceBeforeDiscounts: 48000,
+					introductoryInterval: 2,
+					introductoryTerm: 'year',
+					variantLabel: { noun: 'Two years', adjective: 'Two-year' },
+				} ),
+			] );
+			render( <CheckoutSidebarPlanUpsell /> );
+			expect( screen.getByText( '$100' ) ).toBeVisible();
+			expect( screen.queryByText( '$99.96' ) ).not.toBeInTheDocument();
+		} );
 	} );
 } );

--- a/client/my-sites/checkout/src/components/test/checkout-sidebar-plan-upsell.test.tsx
+++ b/client/my-sites/checkout/src/components/test/checkout-sidebar-plan-upsell.test.tsx
@@ -16,7 +16,10 @@ jest.mock( '@automattic/shopping-cart', () => ( {
 	useShoppingCart: jest.fn(),
 } ) );
 
-jest.mock( '../../../use-cart-key', () => ( { __esModule: true, default: jest.fn() } ) );
+jest.mock( 'calypso/my-sites/checkout/use-cart-key', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
 
 jest.mock( 'calypso/state', () => ( { useDispatch: jest.fn( () => jest.fn() ) } ) );
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of DOTCOM-17174

## Proposed Changes

* Fix the checkout upsell card to present the correct price for 1y->2y upgrade when an introductory offer is present.

**Before**
<img width="420" height="274" alt="before" src="https://github.com/user-attachments/assets/f289e220-b4e8-49c8-953a-cf67562c7560" />

**After**
<img width="420" height="274" alt="after" src="https://github.com/user-attachments/assets/0c3b867d-1243-4d74-b32f-77ee3cc597fa" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The current plan cost was showing incorrectly (showing the upgrade price instead) in the upsell card.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add a Personal yearly plan to your cart, assign yourself to the 'large_increase' variant and check the upsell card in the checkout to reproduce the issue.
* Repeat with the fix in place.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
