### PR TITLE
Dark mode E2E: satisfy themes opt-in gate, unskip Themes suite

### DIFF
--- a/test/e2e/specs/color-scheme/dark-mode-surfaces.spec.ts
+++ b/test/e2e/specs/color-scheme/dark-mode-surfaces.spec.ts
@@ -3,6 +3,7 @@ import { expect, tags, test } from '../../lib/pw-base';
 import type { Locator, Page } from '@playwright/test';
 
 const COLOR_SCHEME_PREFERENCE = 'hosting-dashboard-color-scheme';
+const DASHBOARD_OPT_IN_PREFERENCE = 'hosting-dashboard-opt-in';
 const REQUIRED_TOKENS = [
 	'--dashboard__background-color',
 	'--dashboard-surface__background-color',
@@ -63,6 +64,13 @@ function addDarkModePreference(
 		calypso_preferences: {
 			...calypsoPreferences,
 			[ COLOR_SCHEME_PREFERENCE ]: 'dark',
+			// Themes dark mode is additionally gated behind the dashboard opt-in
+			// (#110825 `shouldEnableThemesColorScheme`), so the preference override
+			// must also satisfy `hasDashboardOptIn` for the Themes suite.
+			[ DASHBOARD_OPT_IN_PREFERENCE ]: {
+				value: 'opt-in',
+				updated_at: '2026-01-01T00:00:00+00:00',
+			},
 		},
 	};
 
@@ -497,8 +505,6 @@ test.describe( 'Reader dark-mode surface', { tag: [ tags.CALYPSO_PR ] }, () => {
 } );
 
 test.describe( 'Themes dark-mode surfaces', { tag: [ tags.CALYPSO_PR ] }, () => {
-	test.skip( true, 'Skipping it while we investigate the flakyness' );
-
 	test( 'applies shared dark-mode tokens on the Themes listing', async ( {
 		accountGivenByEnvironment,
 		page,


### PR DESCRIPTION
Part of #110825

## Proposed Changes

* Add the `hosting-dashboard-opt-in` preference to the `GET /me/preferences` override in `dark-mode-surfaces.spec.ts` so the forced-dark-mode setup also satisfies the dashboard opt-in gate.
* Remove the `test.skip( true, … )` from the `Themes dark-mode surfaces` suite.
* Leave the `Dashboard` and `Reader` suite skips in place (see below).

## Why are these changes being made?

#110818 added `dark-mode-surfaces.spec.ts`. It forces dark mode by intercepting `GET /me/preferences` and injecting a dark `hosting-dashboard-color-scheme` preference.

#110825 then gated themes dark mode behind the dashboard opt-in:

```js
// client/my-sites/themes/helpers.js
shouldEnableThemesColorScheme = ( { isSiteRoute, isLoggedIn, dashboardOptIn } ) =>
    ! isSiteRoute && isLoggedIn && dashboardOptIn;
```

`hasDashboardOptIn` reads the `hosting-dashboard-opt-in` preference, which the test never set. So on trunk the `ClassicColorSchemeProvider` is rendered with `enabled: false`, `data-theme="dark"` is never written to `<html>`, and the `Themes dark-mode surfaces` suite fails:

```
expect(locator).toHaveAttribute('data-theme', 'dark') — Received: ""
```

#110914 skipped all three suites in the file as flaky. The Themes failure is **deterministic**, not flaky — it is a missing-preference gap, not a timing issue. This PR closes the gap by also injecting `hosting-dashboard-opt-in: { value: 'opt-in' }`, and re-enables the Themes suite.

### Why the Dashboard and Reader suites stay skipped

Their dark mode does not depend on the opt-in:

* Dashboard — `client/dashboard/app/layout.tsx` gates on `config.supports.colorScheme`.
* Reader — `client/layout/index.jsx` gates on `sectionName === 'reader' && isLoggedIn`.

So this change does not address whatever caused those two to be skipped. They are left skipped pending the flakiness investigation referenced in #110914.

## Testing Instructions

* `yarn workspace wp-e2e-tests playwright test specs/color-scheme/dark-mode-surfaces.spec.ts --grep "Themes dark-mode surfaces" --reporter=list` against a Calypso instance — the Themes listing and Theme detail tests should pass.
* Confirm the `Dashboard` and `Reader` suites still report as skipped.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)