### PR TITLE
E2E: stabilise SignupPickPlanPage.selectPlan waitForURL timeout

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
@@ -87,8 +87,13 @@ export class SignupPickPlanPage {
 
 		const responsePromise = this.captureNewSiteResponse();
 
+		// The Free-plan chain navigates plans -> create-site -> processing -> final.
+		// A single 90s budget for the whole chain is brittle: a slow /sites/new
+		// response or a slow processing step can blow the cap even when each
+		// segment is healthy. Give the entire chain a more generous budget that
+		// accommodates the slow site-creation + processing hops observed in CI.
 		await Promise.all( [
-			this.page.waitForURL( redirectUrl, { timeout: 90 * 1000 } ),
+			this.page.waitForURL( redirectUrl, { timeout: 180 * 1000 } ),
 			this.plansPage.selectPlan( name ),
 		] );
 


### PR DESCRIPTION
> **Draft — automated fix attempt converged on the original failure but verification revealed unrelated flakiness elsewhere in the test.** A human should decide whether to merge the targeted fix or broaden the stabilisation.

## Proposed Changes

- Raise `SignupPickPlanPage.selectPlan` `waitForURL` budget from **90s → 180s** (`packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts`).

## Why are these changes being made?

The `selectPlan` helper used `Promise.all([waitForURL(redirectUrl, { timeout: 90s }), plansPage.selectPlan(name)])`. For the Free-plan path, the post-click navigation chain is **plans → create-site → processing → `/home/<slug>`** — three sequential product hops including `POST /sites/new`. A single 90s cap on the whole chain is brittle: any slow segment pushes the cumulative latency past 90s even when each individual hop is healthy. TeamCity build [17846521](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Pre_Release/17846521) shows the page parked on `/choose` when the wait timed out.

Bumping the budget to 180s gives the chain headroom for slow segments without changing the final-URL assertion. Change is isolated to the test harness; product code is untouched.

Evidence of the original failure: <https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Pre_Release/17846521>

## Status

- Iterations (reproduction): 1
- Iterations (fix): 1
- Verification:
  - **C.1 (10x with reproduction injection + fix)**: ✅ 10/10 passed
  - **C.3 (10x without injection)**: ⚠️ 8/10 passed — 2 unrelated failures in *other* test steps (see below)
  - C.4 (whole-spec regression check): skipped after C.3 failure

## What was tried

- **Reproduction iter 1** — injected a ~60s delay in `create-site/index.tsx` after `createSite` resolved, plus a 45s delay before the final `window.location.replace('/home/<slug>')` in `onboarding.ts`. Reproduced the 90s `waitForURL` timeout. Tightened the injection to a single 92s delay in `create-site/index.tsx` so the test fits inside Playwright's 120s per-test budget.
- **Fix iter 1** — bumped the `selectPlan` `waitForURL` timeout from 90s to 180s. Test passes 10/10 with the reproduction injection in place (C.1).

## Where C.3 got stuck (unrelated flakiness)

Two of the ten C.3 runs failed at completely different points in the spec — neither in the `selectPlan` flow this PR addresses:

```
1) repeat3 — And I add the first suggestion to the cart
TimeoutError: locator.waitFor: Timeout 30000ms exceeded.
  - waiting for getByRole('listitem').first().getByRole('button', { name: 'Continue' }) to be visible
at packages/calypso-e2e/src/lib/components/domain-search-component.ts:200

2) repeat8 — And I see the domain at checkout
TimeoutError: locator.waitFor: Timeout 30000ms exceeded.
  - waiting for locator('[data-testid=\"review-order-step--visible\"] .checkout-line-item:has-text(...)') to be visible
at packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts:132
```

These are pre-existing flakiness in `DomainSearchComponent.selectSuggestion` (Continue-button wait) and `CartCheckoutPage.validateCartItem` (cart-item wait). Both have 30s timeouts. Out of scope for this PR — but they suggest this spec has broader stabilisation work needed.

## Reproduction Notes

These injections were **not committed**; they live only in `output/reproduction.patch` for reviewer reference. They emulate the production race that the CI failure hit.

```diff
diff --git a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -268,6 +268,9 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
                throw new Error( 'Failed to create site' );
        }

+       // REPRODUCTION-INJECTION: simulate slow site-creation downstream to provoke 90s waitForURL timeout on /choose.
+       await new Promise( ( resolve ) => setTimeout( resolve, 92000 ) );
+
        const additionalCartItems = [
                ...( planCartItem ? [ planCartItem ] : [] ),
                ...( productCartItems ?? [] ),
```

## Testing Instructions

Run locally with PW_WORKERS=1 to confirm:

\`\`\`
PW_WORKERS=1 yarn --cwd test/e2e playwright test flows/setup-domain__flows.spec.ts --project=chrome --reporter=list --grep \"As a new user, I can create a free site and then add a domain WITH a plan upgrade\" --repeat-each=10
\`\`\`

The selectPlan-related failure should not recur. Some runs may still fail at the unrelated domain-search/checkout steps noted above.

## Suggested next steps

- Decide whether to land this targeted fix as-is, or to extend stabilisation to `DomainSearchComponent.selectSuggestion` and `CartCheckoutPage.validateCartItem` in the same PR.
- Consider whether 30s waits on those locators should be raised, or whether the underlying surfaces have render-time issues.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the \"[Status] String Freeze\" label as soon as any new strings were ready for translation?
- [ ] For changes affecting Jetpack: Have we added the \"[Status] Needs Privacy Updates\" label?