### PR TITLE
A4A Agent Studio: Add page-scoped refine chat dock

### DIFF
--- a/client/a8c-for-agencies/sections/agent-studio/data/use-agent-studio-run.ts
+++ b/client/a8c-for-agencies/sections/agent-studio/data/use-agent-studio-run.ts
@@ -39,10 +39,6 @@ export const getAgentStudioRunQueryKey = ( agencyId: number | undefined, runId: 
 // (empty-payload) response and never recover without a reload.
 export const NON_TERMINAL_RUN_STATUSES = new Set( [ 'a4a_pending', 'a4a_running' ] );
 
-// Statuses that end a run. Consumers that react to completion (e.g. the
-// refine dock) match against this instead of re-listing the literals.
-export const TERMINAL_RUN_STATUSES = new Set( [ 'a4a_completed', 'a4a_failed', 'a4a_cancelled' ] );
-
 const RUN_POLL_INTERVAL_MS = 2000;
 
 export default function useAgentStudioRun( runId: string | undefined ) {

--- a/client/a8c-for-agencies/sections/agent-studio/data/use-agent-studio-run.ts
+++ b/client/a8c-for-agencies/sections/agent-studio/data/use-agent-studio-run.ts
@@ -39,6 +39,10 @@ export const getAgentStudioRunQueryKey = ( agencyId: number | undefined, runId: 
 // (empty-payload) response and never recover without a reload.
 export const NON_TERMINAL_RUN_STATUSES = new Set( [ 'a4a_pending', 'a4a_running' ] );
 
+// Statuses that end a run. Consumers that react to completion (e.g. the
+// refine dock) match against this instead of re-listing the literals.
+export const TERMINAL_RUN_STATUSES = new Set( [ 'a4a_completed', 'a4a_failed', 'a4a_cancelled' ] );
+
 const RUN_POLL_INTERVAL_MS = 2000;
 
 export default function useAgentStudioRun( runId: string | undefined ) {

--- a/client/a8c-for-agencies/sections/agent-studio/data/use-agent-studio-variant-html.ts
+++ b/client/a8c-for-agencies/sections/agent-studio/data/use-agent-studio-variant-html.ts
@@ -13,7 +13,15 @@ export const getAgentStudioVariantHtmlQueryKey = ( htmlUrl: string | undefined )
 
 export const fetchAgentStudioVariantHtml = async ( htmlUrl: string ): Promise< string > => {
 	const token = oauthToken.getToken();
+	// `cache: 'no-cache'` forces a conditional request against the origin
+	// on every fetch. Refine writes new HTML to the same html_url, so
+	// without revalidation the browser's HTTP cache can serve the pre-
+	// refine body even after React Query has invalidated its in-memory
+	// entry — the symptom is "I refined page 5 but the iframe still
+	// shows the old layout." A 304 round-trip is cheap; a stale render
+	// is not.
 	const response = await fetch( htmlUrl, {
+		cache: 'no-cache',
 		headers: {
 			Accept: 'text/html',
 			...( typeof token === 'string' ? { Authorization: `Bearer ${ token }` } : {} ),

--- a/client/a8c-for-agencies/sections/agent-studio/data/use-agent-studio-variant-html.ts
+++ b/client/a8c-for-agencies/sections/agent-studio/data/use-agent-studio-variant-html.ts
@@ -13,13 +13,9 @@ export const getAgentStudioVariantHtmlQueryKey = ( htmlUrl: string | undefined )
 
 export const fetchAgentStudioVariantHtml = async ( htmlUrl: string ): Promise< string > => {
 	const token = oauthToken.getToken();
-	// `cache: 'no-cache'` forces a conditional request against the origin
-	// on every fetch. Refine writes new HTML to the same html_url, so
-	// without revalidation the browser's HTTP cache can serve the pre-
-	// refine body even after React Query has invalidated its in-memory
-	// entry — the symptom is "I refined page 5 but the iframe still
-	// shows the old layout." A 304 round-trip is cheap; a stale render
-	// is not.
+	// Refine rewrites HTML to the same html_url, so force revalidation —
+	// otherwise the browser HTTP cache can serve the pre-refine body even
+	// after React Query has invalidated its in-memory entry.
 	const response = await fetch( htmlUrl, {
 		cache: 'no-cache',
 		headers: {

--- a/client/a8c-for-agencies/sections/agent-studio/data/use-refine-collateral-page.ts
+++ b/client/a8c-for-agencies/sections/agent-studio/data/use-refine-collateral-page.ts
@@ -1,21 +1,9 @@
 /**
  * `POST /agency/<id>/a4a/collaterals/<post_id>/refine` — dispatches a
- * page-scoped refinement run against an existing collateral. The
- * wpcom endpoint parses the page number out of the natural-language
- * `instruction` server-side, so callers only pass the raw text.
- *
- * Two distinct outcomes the chat UI needs to distinguish:
- *
- *   - Success: `{ run_id, status, page, page_index }`. The UI starts
- *     polling `/a4a/runs/<run_id>` and bumps a thinking indicator.
- *   - Clarification: `400` with `data.kind === 'clarification_needed'`.
- *     The error's `message` is suitable for rendering inline as an
- *     assistant reply ("Which page?", "Page 99 doesn't exist…",
- *     "Page 1 is the cover…"). The UI surfaces this message and lets
- *     the user retry — no run was created.
- *
- * Hard errors (auth, server, network) come through as rejected
- * mutations and the UI shows a brief generic fallback message.
+ * page-scoped refinement run; the endpoint parses the page number out of
+ * the `instruction` server-side. Two outcomes the UI distinguishes:
+ * success (`run_id` to poll) and clarification (a `400` whose message is
+ * shown inline, no run created). Hard errors reject the mutation.
  */
 import { useMutation } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
@@ -39,11 +27,7 @@ export interface RefineCollateralPageClarification {
 	message: string;
 }
 
-/**
- * Shape wpcom.req raises for a WP_Error response. `error` carries the
- * WP_Error code; `data` carries the `[ 'status' => …, 'kind' => … ]`
- * payload the endpoint attached.
- */
+// Shape wpcom.req raises for a WP_Error: `error` is the code, `data` the payload.
 interface WpcomReqError {
 	error?: string;
 	message?: string;
@@ -63,9 +47,7 @@ const isClarification = (
 	if ( data.kind === 'clarification_needed' ) {
 		return true;
 	}
-	// Fall back to inspecting the WP_Error code in case `data.kind` is
-	// dropped by a transport layer. The endpoint uses the code
-	// `a4a_clarification_needed` for the same condition.
+	// Fall back to the WP_Error code if `data.kind` is dropped in transport.
 	return ( err as WpcomReqError ).error === 'a4a_clarification_needed';
 };
 
@@ -92,10 +74,8 @@ export default function useRefineCollateralPage() {
 				if ( isClarification( err ) ) {
 					const message =
 						typeof err.message === 'string' ? err.message : 'I need more detail to do that.';
-					// Throw a typed clarification so the caller's
-					// `onError` branch can render the message as an
-					// assistant chat reply without surfacing a generic
-					// hard-error banner.
+					// Typed clarification so the caller can render it inline
+					// instead of a generic hard-error banner.
 					const clarification: RefineCollateralPageClarification = {
 						kind: 'clarification_needed',
 						message,

--- a/client/a8c-for-agencies/sections/agent-studio/data/use-refine-collateral-page.ts
+++ b/client/a8c-for-agencies/sections/agent-studio/data/use-refine-collateral-page.ts
@@ -1,0 +1,118 @@
+/**
+ * `POST /agency/<id>/a4a/collaterals/<post_id>/refine` — dispatches a
+ * page-scoped refinement run against an existing collateral. The
+ * wpcom endpoint parses the page number out of the natural-language
+ * `instruction` server-side, so callers only pass the raw text.
+ *
+ * Two distinct outcomes the chat UI needs to distinguish:
+ *
+ *   - Success: `{ run_id, status, page, page_index }`. The UI starts
+ *     polling `/a4a/runs/<run_id>` and bumps a thinking indicator.
+ *   - Clarification: `400` with `data.kind === 'clarification_needed'`.
+ *     The error's `message` is suitable for rendering inline as an
+ *     assistant reply ("Which page?", "Page 99 doesn't exist…",
+ *     "Page 1 is the cover…"). The UI surfaces this message and lets
+ *     the user retry — no run was created.
+ *
+ * Hard errors (auth, server, network) come through as rejected
+ * mutations and the UI shows a brief generic fallback message.
+ */
+import { useMutation } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { useSelector } from 'calypso/state';
+import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
+
+export interface RefineCollateralPageInput {
+	collateralPostId: number;
+	instruction: string;
+}
+
+export interface RefineCollateralPageResponse {
+	run_id: number;
+	status: string;
+	page: number;
+	page_index: number;
+}
+
+export interface RefineCollateralPageClarification {
+	kind: 'clarification_needed';
+	message: string;
+}
+
+/**
+ * Shape wpcom.req raises for a WP_Error response. `error` carries the
+ * WP_Error code; `data` carries the `[ 'status' => …, 'kind' => … ]`
+ * payload the endpoint attached.
+ */
+interface WpcomReqError {
+	error?: string;
+	message?: string;
+	data?: { status?: number; kind?: string; [ key: string ]: unknown };
+}
+
+const isClarification = (
+	err: unknown
+): err is WpcomReqError & { data: { kind: 'clarification_needed' } } => {
+	if ( ! err || typeof err !== 'object' ) {
+		return false;
+	}
+	const data = ( err as WpcomReqError ).data;
+	if ( ! data || typeof data !== 'object' ) {
+		return false;
+	}
+	if ( data.kind === 'clarification_needed' ) {
+		return true;
+	}
+	// Fall back to inspecting the WP_Error code in case `data.kind` is
+	// dropped by a transport layer. The endpoint uses the code
+	// `a4a_clarification_needed` for the same condition.
+	return ( err as WpcomReqError ).error === 'a4a_clarification_needed';
+};
+
+export default function useRefineCollateralPage() {
+	const agencyId = useSelector( getActiveAgencyId );
+
+	return useMutation<
+		RefineCollateralPageResponse,
+		RefineCollateralPageClarification | Error,
+		RefineCollateralPageInput
+	>( {
+		mutationFn: async ( { collateralPostId, instruction } ) => {
+			if ( ! agencyId ) {
+				throw new Error( 'useRefineCollateralPage: no active agency.' );
+			}
+			try {
+				const response: RefineCollateralPageResponse = await wpcom.req.post( {
+					apiNamespace: 'wpcom/v2',
+					path: `/agency/${ agencyId }/a4a/collaterals/${ collateralPostId }/refine`,
+					body: { instruction },
+				} );
+				return response;
+			} catch ( err: unknown ) {
+				if ( isClarification( err ) ) {
+					const message =
+						typeof ( err as WpcomReqError ).message === 'string'
+							? ( ( err as WpcomReqError ).message as string )
+							: 'I need more detail to do that.';
+					// Throw a typed clarification so the caller's
+					// `onError` branch can render the message as an
+					// assistant chat reply without surfacing a generic
+					// hard-error banner.
+					const clarification: RefineCollateralPageClarification = {
+						kind: 'clarification_needed',
+						message,
+					};
+					throw clarification;
+				}
+				throw err instanceof Error ? err : new Error( 'Refine request failed.' );
+			}
+		},
+	} );
+}
+
+export const isRefineClarification = ( err: unknown ): err is RefineCollateralPageClarification => {
+	if ( ! err || typeof err !== 'object' ) {
+		return false;
+	}
+	return ( err as RefineCollateralPageClarification ).kind === 'clarification_needed';
+};

--- a/client/a8c-for-agencies/sections/agent-studio/data/use-refine-collateral-page.ts
+++ b/client/a8c-for-agencies/sections/agent-studio/data/use-refine-collateral-page.ts
@@ -22,75 +22,44 @@ export interface RefineCollateralPageResponse {
 	page_index: number;
 }
 
-export interface RefineCollateralPageClarification {
-	kind: 'clarification_needed';
-	message: string;
-}
-
-// Shape wpcom.req raises for a WP_Error: `error` is the code, `data` the payload.
+// Shape wpcom.req rejects with for a WP_Error: `error` is the code, `data`
+// the payload the endpoint attached.
 interface WpcomReqError {
 	error?: string;
 	message?: string;
-	data?: { status?: number; kind?: string; [ key: string ]: unknown };
+	data?: { kind?: string };
 }
 
-const isClarification = (
-	err: unknown
-): err is WpcomReqError & { data: { kind: 'clarification_needed' } } => {
+/**
+ * When the endpoint asks for a clearer instruction (no run created), returns
+ * the message to show inline; otherwise null so the caller falls back to a
+ * generic hard-error reply. Checks `data.kind` and the WP_Error code, since a
+ * transport layer can drop one or the other.
+ */
+export const getRefineClarificationMessage = ( err: unknown ): string | null => {
 	if ( ! err || typeof err !== 'object' ) {
-		return false;
+		return null;
 	}
-	const data = ( err as WpcomReqError ).data;
-	if ( ! data || typeof data !== 'object' ) {
-		return false;
+	const { error, message, data } = err as WpcomReqError;
+	if ( data?.kind !== 'clarification_needed' && error !== 'a4a_clarification_needed' ) {
+		return null;
 	}
-	if ( data.kind === 'clarification_needed' ) {
-		return true;
-	}
-	// Fall back to the WP_Error code if `data.kind` is dropped in transport.
-	return ( err as WpcomReqError ).error === 'a4a_clarification_needed';
+	return message || 'I need more detail to do that.';
 };
 
 export default function useRefineCollateralPage() {
 	const agencyId = useSelector( getActiveAgencyId );
 
-	return useMutation<
-		RefineCollateralPageResponse,
-		RefineCollateralPageClarification | Error,
-		RefineCollateralPageInput
-	>( {
-		mutationFn: async ( { collateralPostId, instruction } ) => {
+	return useMutation< RefineCollateralPageResponse, unknown, RefineCollateralPageInput >( {
+		mutationFn: ( { collateralPostId, instruction } ) => {
 			if ( ! agencyId ) {
 				throw new Error( 'useRefineCollateralPage: no active agency.' );
 			}
-			try {
-				const response: RefineCollateralPageResponse = await wpcom.req.post( {
-					apiNamespace: 'wpcom/v2',
-					path: `/agency/${ agencyId }/a4a/collaterals/${ collateralPostId }/refine`,
-					body: { instruction },
-				} );
-				return response;
-			} catch ( err: unknown ) {
-				if ( isClarification( err ) ) {
-					const message =
-						typeof err.message === 'string' ? err.message : 'I need more detail to do that.';
-					// Typed clarification so the caller can render it inline
-					// instead of a generic hard-error banner.
-					const clarification: RefineCollateralPageClarification = {
-						kind: 'clarification_needed',
-						message,
-					};
-					throw clarification;
-				}
-				throw err instanceof Error ? err : new Error( 'Refine request failed.' );
-			}
+			return wpcom.req.post( {
+				apiNamespace: 'wpcom/v2',
+				path: `/agency/${ agencyId }/a4a/collaterals/${ collateralPostId }/refine`,
+				body: { instruction },
+			} );
 		},
 	} );
 }
-
-export const isRefineClarification = ( err: unknown ): err is RefineCollateralPageClarification => {
-	if ( ! err || typeof err !== 'object' ) {
-		return false;
-	}
-	return ( err as RefineCollateralPageClarification ).kind === 'clarification_needed';
-};

--- a/client/a8c-for-agencies/sections/agent-studio/data/use-refine-collateral-page.ts
+++ b/client/a8c-for-agencies/sections/agent-studio/data/use-refine-collateral-page.ts
@@ -91,9 +91,7 @@ export default function useRefineCollateralPage() {
 			} catch ( err: unknown ) {
 				if ( isClarification( err ) ) {
 					const message =
-						typeof ( err as WpcomReqError ).message === 'string'
-							? ( ( err as WpcomReqError ).message as string )
-							: 'I need more detail to do that.';
+						typeof err.message === 'string' ? err.message : 'I need more detail to do that.';
 					// Throw a typed clarification so the caller's
 					// `onError` branch can render the message as an
 					// assistant chat reply without surfacing a generic

--- a/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/output-detail-content.tsx
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/output-detail-content.tsx
@@ -63,17 +63,24 @@ function StateMessage( { children, spinner }: { children: ReactNode; spinner?: b
 	);
 }
 
+interface RefineSeed {
+	text: string;
+	token: number;
+}
+
 function OnePagerOutputDetail( { output }: Props ) {
 	const dispatch = useDispatch();
 	const run = useAgentStudioRun( output.id );
 	const postId = extractPostId( run.data?.payload );
 	const collateral = useAgentStudioCollateral( postId );
 	const [ isRefineOpen, setIsRefineOpen ] = useState( false );
-	const [ refineSeed, setRefineSeed ] = useState( '' );
+	// `token` bumps on every open request so re-opening the same page re-seeds
+	// the dock input even when the seed text is identical.
+	const [ refineSeed, setRefineSeed ] = useState< RefineSeed >( { text: '', token: 0 } );
 
 	const openRefine = useCallback(
 		( seedText: string, source: 'launcher' | 'page', page?: number ) => {
-			setRefineSeed( seedText );
+			setRefineSeed( ( prev ) => ( { text: seedText, token: prev.token + 1 } ) );
 			setIsRefineOpen( true );
 			dispatch(
 				recordTracksEvent( 'calypso_a4a_agent_studio_refine_open', {
@@ -236,7 +243,8 @@ function OnePagerOutputDetail( { output }: Props ) {
 				<RefineWithAiDock
 					collateralPostId={ postId }
 					totalPages={ pages.length }
-					seedText={ refineSeed }
+					seedText={ refineSeed.text }
+					seedToken={ refineSeed.token }
 					onClose={ () => setIsRefineOpen( false ) }
 				/>
 			) }

--- a/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/output-detail-content.tsx
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/output-detail-content.tsx
@@ -74,9 +74,7 @@ function OnePagerOutputDetail( { output }: Props ) {
 	const postId = extractPostId( run.data?.payload );
 	const collateral = useAgentStudioCollateral( postId );
 	const [ isRefineOpen, setIsRefineOpen ] = useState( false );
-	// Seed for the refine dock's input. `token` bumps on every open request
-	// so re-opening for the same page (identical `text`) still re-seeds and
-	// re-focuses the input.
+	// `token` bumps on every open request so re-opening the same page re-seeds.
 	const [ refineSeed, setRefineSeed ] = useState< RefineSeed >( { text: '', token: 0 } );
 
 	const openRefine = useCallback(
@@ -97,8 +95,7 @@ function OnePagerOutputDetail( { output }: Props ) {
 	const handleEditPage = useCallback(
 		( pageNumber: number ) => {
 			openRefine(
-				// Trailing space is appended outside the translatable string so
-				// the caret lands one space after the prompt when the dock opens.
+				// Trailing space added outside the translatable string.
 				sprintf(
 					/* translators: %d is the 1-based page number, cover included. */
 					__( 'On page %d, make the following edits:' ),

--- a/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/output-detail-content.tsx
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/output-detail-content.tsx
@@ -63,23 +63,17 @@ function StateMessage( { children, spinner }: { children: ReactNode; spinner?: b
 	);
 }
 
-interface RefineSeed {
-	text: string;
-	token: number;
-}
-
 function OnePagerOutputDetail( { output }: Props ) {
 	const dispatch = useDispatch();
 	const run = useAgentStudioRun( output.id );
 	const postId = extractPostId( run.data?.payload );
 	const collateral = useAgentStudioCollateral( postId );
 	const [ isRefineOpen, setIsRefineOpen ] = useState( false );
-	// `token` bumps on every open request so re-opening the same page re-seeds.
-	const [ refineSeed, setRefineSeed ] = useState< RefineSeed >( { text: '', token: 0 } );
+	const [ refineSeed, setRefineSeed ] = useState( '' );
 
 	const openRefine = useCallback(
 		( seedText: string, source: 'launcher' | 'page', page?: number ) => {
-			setRefineSeed( ( prev ) => ( { text: seedText, token: prev.token + 1 } ) );
+			setRefineSeed( seedText );
 			setIsRefineOpen( true );
 			dispatch(
 				recordTracksEvent( 'calypso_a4a_agent_studio_refine_open', {
@@ -242,8 +236,7 @@ function OnePagerOutputDetail( { output }: Props ) {
 				<RefineWithAiDock
 					collateralPostId={ postId }
 					totalPages={ pages.length }
-					seedText={ refineSeed.text }
-					seedToken={ refineSeed.token }
+					seedText={ refineSeed }
 					onClose={ () => setIsRefineOpen( false ) }
 				/>
 			) }

--- a/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/output-detail-content.tsx
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/output-detail-content.tsx
@@ -8,6 +8,7 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { sparkles } from '@wordpress/icons';
 import { useMemo, useState, type ReactNode } from 'react';
 import useAgentStudioCollateral, {
 	type AgentStudioCollateralVariant,
@@ -23,6 +24,7 @@ import {
 	type ServerSocialBrief,
 } from '../../social-design/create-social-assets';
 import PdfViewer, { type PdfViewerPage } from './pdf-viewer';
+import RefineWithAiDock from './refine-with-ai-dock';
 import SocialAssetsViewer from './social-assets-viewer';
 import { splitIntoPages, wrapAsDocument } from './split-pages';
 import type { AgentStudioOutput } from '../../types';
@@ -63,6 +65,7 @@ function OnePagerOutputDetail( { output }: Props ) {
 	const run = useAgentStudioRun( output.id );
 	const postId = extractPostId( run.data?.payload );
 	const collateral = useAgentStudioCollateral( postId );
+	const [ isRefineOpen, setIsRefineOpen ] = useState( false );
 
 	const variants = useMemo< AgentStudioCollateralVariant[] >(
 		() => collateral.data?.variants ?? [],
@@ -157,6 +160,14 @@ function OnePagerOutputDetail( { output }: Props ) {
 	return (
 		<VStack spacing={ 4 } className="a4a-agent-studio-output-detail__content">
 			<HStack className="a4a-agent-studio-output-detail__actions" justify="flex-end" spacing={ 2 }>
+				<Button
+					variant="secondary"
+					icon={ sparkles }
+					onClick={ () => setIsRefineOpen( ( open ) => ! open ) }
+					aria-pressed={ isRefineOpen }
+				>
+					{ __( 'Refine with AI' ) }
+				</Button>
 				{ selectedVariant?.pdf_download_url && (
 					<Button
 						variant="primary"
@@ -184,6 +195,13 @@ function OnePagerOutputDetail( { output }: Props ) {
 							  }
 							: undefined
 					}
+				/>
+			) }
+			{ isRefineOpen && postId && (
+				<RefineWithAiDock
+					collateralPostId={ postId }
+					totalPages={ pages.length }
+					onClose={ () => setIsRefineOpen( false ) }
 				/>
 			) }
 		</VStack>

--- a/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/output-detail-content.tsx
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/output-detail-content.tsx
@@ -7,9 +7,10 @@ import {
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import { sparkles } from '@wordpress/icons';
-import { useMemo, useState, type ReactNode } from 'react';
+import { __, sprintf } from '@wordpress/i18n';
+import { useCallback, useMemo, useState, type ReactNode } from 'react';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import useAgentStudioCollateral, {
 	type AgentStudioCollateralVariant,
 } from '../../data/use-agent-studio-collateral';
@@ -24,6 +25,7 @@ import {
 	type ServerSocialBrief,
 } from '../../social-design/create-social-assets';
 import PdfViewer, { type PdfViewerPage } from './pdf-viewer';
+import RefineLauncher from './refine-launcher';
 import RefineWithAiDock from './refine-with-ai-dock';
 import SocialAssetsViewer from './social-assets-viewer';
 import { splitIntoPages, wrapAsDocument } from './split-pages';
@@ -61,11 +63,53 @@ function StateMessage( { children, spinner }: { children: ReactNode; spinner?: b
 	);
 }
 
+interface RefineSeed {
+	text: string;
+	token: number;
+}
+
 function OnePagerOutputDetail( { output }: Props ) {
+	const dispatch = useDispatch();
 	const run = useAgentStudioRun( output.id );
 	const postId = extractPostId( run.data?.payload );
 	const collateral = useAgentStudioCollateral( postId );
 	const [ isRefineOpen, setIsRefineOpen ] = useState( false );
+	// Seed for the refine dock's input. `token` bumps on every open request
+	// so re-opening for the same page (identical `text`) still re-seeds and
+	// re-focuses the input.
+	const [ refineSeed, setRefineSeed ] = useState< RefineSeed >( { text: '', token: 0 } );
+
+	const openRefine = useCallback(
+		( seedText: string, source: 'launcher' | 'page', page?: number ) => {
+			setRefineSeed( ( prev ) => ( { text: seedText, token: prev.token + 1 } ) );
+			setIsRefineOpen( true );
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_agent_studio_refine_open', {
+					output_id: output.id,
+					source,
+					...( page ? { page } : {} ),
+				} )
+			);
+		},
+		[ dispatch, output.id ]
+	);
+
+	const handleEditPage = useCallback(
+		( pageNumber: number ) => {
+			openRefine(
+				// Trailing space is appended outside the translatable string so
+				// the caret lands one space after the prompt when the dock opens.
+				sprintf(
+					/* translators: %d is the 1-based page number, cover included. */
+					__( 'On page %d, make the following edits:' ),
+					pageNumber
+				) + ' ',
+				'page',
+				pageNumber
+			);
+		},
+		[ openRefine ]
+	);
 
 	const variants = useMemo< AgentStudioCollateralVariant[] >(
 		() => collateral.data?.variants ?? [],
@@ -159,16 +203,12 @@ function OnePagerOutputDetail( { output }: Props ) {
 
 	return (
 		<VStack spacing={ 4 } className="a4a-agent-studio-output-detail__content">
-			<HStack className="a4a-agent-studio-output-detail__actions" justify="flex-end" spacing={ 2 }>
-				<Button
-					variant="secondary"
-					icon={ sparkles }
-					onClick={ () => setIsRefineOpen( ( open ) => ! open ) }
-					aria-pressed={ isRefineOpen }
+			{ selectedVariant?.pdf_download_url && (
+				<HStack
+					className="a4a-agent-studio-output-detail__actions"
+					justify="flex-end"
+					spacing={ 2 }
 				>
-					{ __( 'Refine with AI' ) }
-				</Button>
-				{ selectedVariant?.pdf_download_url && (
 					<Button
 						variant="primary"
 						href={ selectedVariant.pdf_download_url }
@@ -177,8 +217,8 @@ function OnePagerOutputDetail( { output }: Props ) {
 					>
 						{ __( 'Download PDF' ) }
 					</Button>
-				) }
-			</HStack>
+				</HStack>
+			) }
 			{ ! coverSrcDoc && ( selectedVariantHtml.isLoading || baseVariantHtml.isLoading ) ? (
 				<StateMessage spinner>
 					<Text>{ __( 'Loading preview…' ) }</Text>
@@ -195,12 +235,18 @@ function OnePagerOutputDetail( { output }: Props ) {
 							  }
 							: undefined
 					}
+					onEditPage={ postId ? handleEditPage : undefined }
 				/>
+			) }
+			{ ! isRefineOpen && postId && (
+				<RefineLauncher onClick={ () => openRefine( '', 'launcher' ) } />
 			) }
 			{ isRefineOpen && postId && (
 				<RefineWithAiDock
 					collateralPostId={ postId }
 					totalPages={ pages.length }
+					seedText={ refineSeed.text }
+					seedToken={ refineSeed.token }
 					onClose={ () => setIsRefineOpen( false ) }
 				/>
 			) }

--- a/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/pdf-viewer.scss
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/pdf-viewer.scss
@@ -101,3 +101,57 @@
 	opacity: 1;
 	pointer-events: auto;
 }
+
+.a4a-one-pager-viewer__page-edit {
+	position: absolute;
+	inset-block-start: 12px;
+	inset-inline-end: 12px;
+	z-index: 4;
+	opacity: 0;
+	pointer-events: none;
+	transition: opacity 120ms ease;
+}
+
+.a4a-one-pager-viewer__frame:hover .a4a-one-pager-viewer__page-edit,
+.a4a-one-pager-viewer__frame:focus-within .a4a-one-pager-viewer__page-edit {
+	opacity: 1;
+	pointer-events: auto;
+}
+
+// A plain, quiet label button — the per-page affordance stays understated so
+// the colourful floating launcher remains the one attention-grabbing CTA.
+.a4a-one-pager-viewer__page-edit-button {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	margin: 0;
+	padding-block: 8px;
+	padding-inline: 12px;
+	border: 1px solid rgba(255, 255, 255, 0.18);
+	border-radius: 4px;
+	background-color: rgba(18, 18, 18, 0.88);
+	color: rgba(255, 255, 255, 0.95);
+	box-sizing: border-box;
+	cursor: pointer;
+	font-size: 0.75rem;
+	font-weight: 500;
+	line-height: 1;
+	appearance: none;
+	box-shadow: 0 14px 32px rgba(0, 0, 0, 0.26);
+	backdrop-filter: blur(10px);
+	transition: background-color 120ms ease;
+}
+
+.a4a-one-pager-viewer__page-edit-button svg,
+.a4a-one-pager-viewer__page-edit-button svg path {
+	fill: currentColor;
+}
+
+.a4a-one-pager-viewer__page-edit-button:hover {
+	background-color: rgba(34, 34, 34, 0.94);
+}
+
+.a4a-one-pager-viewer__page-edit-button:focus-visible {
+	outline: 2px solid rgba(255, 255, 255, 0.72);
+	outline-offset: 2px;
+}

--- a/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/pdf-viewer.scss
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/pdf-viewer.scss
@@ -118,8 +118,7 @@
 	pointer-events: auto;
 }
 
-// A plain, quiet label button — the per-page affordance stays understated so
-// the colourful floating launcher remains the one attention-grabbing CTA.
+// Quiet per-page button, kept understated so the floating launcher stays the CTA.
 .a4a-one-pager-viewer__page-edit-button {
 	display: inline-flex;
 	align-items: center;

--- a/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/pdf-viewer.tsx
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/pdf-viewer.tsx
@@ -28,11 +28,8 @@ interface Props {
 	/** Hover-revealed chevrons over the cover page. */
 	coverNavigation?: CoverNavigation;
 	/**
-	 * Called when the user clicks a body page's hover-revealed "Edit this
-	 * page" button. The argument is the 1-based page number including the
-	 * cover (i.e. `index + 1`), matching what the refine endpoint expects.
-	 * Omit to hide the per-page edit affordance. The cover (page 1) never
-	 * shows it — the refine endpoint doesn't support editing the cover.
+	 * Called with the 1-based page number (cover included) when a body page's
+	 * "Edit with AI" button is clicked. Omit to hide it; the cover never shows it.
 	 */
 	onEditPage?: ( pageNumber: number ) => void;
 }

--- a/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/pdf-viewer.tsx
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/pdf-viewer.tsx
@@ -1,6 +1,6 @@
 import { useResizeObserver } from '@wordpress/compose';
-import { __ } from '@wordpress/i18n';
-import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
+import { __, sprintf } from '@wordpress/i18n';
+import { Icon, chevronLeft, chevronRight, starFilled } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useEffect, useRef, useState, type ReactNode } from 'react';
 
@@ -27,13 +27,21 @@ interface Props {
 	pages: PdfViewerPage[];
 	/** Hover-revealed chevrons over the cover page. */
 	coverNavigation?: CoverNavigation;
+	/**
+	 * Called when the user clicks a body page's hover-revealed "Edit this
+	 * page" button. The argument is the 1-based page number including the
+	 * cover (i.e. `index + 1`), matching what the refine endpoint expects.
+	 * Omit to hide the per-page edit affordance. The cover (page 1) never
+	 * shows it — the refine endpoint doesn't support editing the cover.
+	 */
+	onEditPage?: ( pageNumber: number ) => void;
 }
 
 // US Letter at 96dpi. The natural height only appears in CSS (see
 // `aspect-ratio: 816 / 1056` on the wrap).
 const PAGE_NATURAL_WIDTH = 816;
 
-export default function PdfViewer( { pages, coverNavigation }: Props ) {
+export default function PdfViewer( { pages, coverNavigation, onEditPage }: Props ) {
 	if ( pages.length === 0 ) {
 		return null;
 	}
@@ -52,6 +60,23 @@ export default function PdfViewer( { pages, coverNavigation }: Props ) {
 							srcDoc={ page.srcDoc }
 							title={ page.role === 'cover' ? __( 'Cover' ) : __( 'Page' ) }
 						/>
+						{ idx > 0 && onEditPage && (
+							<div className="a4a-one-pager-viewer__page-edit">
+								<button
+									type="button"
+									className="a4a-one-pager-viewer__page-edit-button"
+									onClick={ () => onEditPage( idx + 1 ) }
+									aria-label={ sprintf(
+										/* translators: %d is the 1-based page number, cover included. */
+										__( 'Edit page %d with AI' ),
+										idx + 1
+									) }
+								>
+									<Icon icon={ starFilled } size={ 18 } />
+									<span>{ __( 'Edit with AI' ) }</span>
+								</button>
+							</div>
+						) }
 						{ idx === 0 && coverNavigation && coverNavigation.count > 1 && (
 							<div className="a4a-one-pager-viewer__cover-nav">
 								<CircleButton

--- a/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-launcher.scss
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-launcher.scss
@@ -26,7 +26,8 @@
 	);
 	background-size: 150% 150%;
 	background-position: 0% 50%;
-	box-shadow: 0 8px 24px rgba(108, 92, 231, 0.45);
+	// Neutral drop shadow — no coloured halo glowing around the button.
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
 	cursor: pointer;
 	transition: transform 160ms ease, box-shadow 160ms ease, background-position 480ms ease;
 }
@@ -40,7 +41,7 @@
 .components-button.a4a-refine-launcher.a4a-refine-launcher:focus {
 	color: rgba(255, 255, 255, 1);
 	background-position: 100% 50%;
-	box-shadow: 0 12px 30px rgba(236, 72, 153, 0.5);
+	box-shadow: 0 8px 20px rgba(0, 0, 0, 0.24);
 	transform: translateY(-2px) scale(1.08);
 }
 
@@ -58,34 +59,18 @@
 	outline-offset: 3px;
 }
 
-// Motion is opt-in: a gentle breathing glow draws the eye to the launcher
-// while idle, and the star twinkles on entry. Skipped entirely for users who
-// prefer reduced motion.
+// Motion is opt-in: the star gives a subtle periodic twinkle. Skipped
+// entirely for users who prefer reduced motion.
 @media (prefers-reduced-motion: no-preference) {
-	.components-button.a4a-refine-launcher.a4a-refine-launcher {
-		animation: a4a-refine-launcher-glow 2800ms ease-in-out infinite;
-	}
-
 	.components-button.a4a-refine-launcher.a4a-refine-launcher svg {
 		animation: a4a-refine-launcher-twinkle 2800ms ease-in-out infinite;
 	}
 
-	// Pause the idle glow while the user is interacting so hover/active feel
+	// Pause the twinkle while the user is interacting so hover/active feel
 	// crisp rather than fighting the keyframes.
-	.components-button.a4a-refine-launcher.a4a-refine-launcher:hover,
-	.components-button.a4a-refine-launcher.a4a-refine-launcher:focus {
+	.components-button.a4a-refine-launcher.a4a-refine-launcher:hover svg,
+	.components-button.a4a-refine-launcher.a4a-refine-launcher:focus svg {
 		animation-play-state: paused;
-	}
-}
-
-@keyframes a4a-refine-launcher-glow {
-	0%,
-	100% {
-		box-shadow: 0 8px 24px rgba(108, 92, 231, 0.4);
-	}
-
-	50% {
-		box-shadow: 0 10px 30px rgba(236, 72, 153, 0.55);
 	}
 }
 

--- a/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-launcher.scss
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-launcher.scss
@@ -1,6 +1,12 @@
 // Doubled selector raises specificity above `@wordpress/components`' own
 // `.components-button.has-icon` rules regardless of stylesheet order.
 .components-button.a4a-refine-launcher.a4a-refine-launcher {
+	// Intentional tri-tone brand gradient (indigo → blue → magenta). These
+	// vivid stops have no equivalent in the studio palette, so they're
+	// centralised as scoped custom properties rather than inlined per stop.
+	--a4a-refine-gradient-start: #6c5ce7;
+	--a4a-refine-gradient-mid: #387cf6;
+	--a4a-refine-gradient-end: #ec4899;
 	position: fixed;
 	inset-block-end: 24px;
 	inset-inline-end: 24px;
@@ -12,13 +18,13 @@
 	padding: 0;
 	border: 0;
 	border-radius: 50%;
-	color: rgba(255, 255, 255, 0.98);
-	// Tri-tone gradient, oversized so hover can pan across it for a shimmer.
+	color: var(--color-text-inverted);
+	// Oversized so the hover state can pan across it for a shimmer.
 	background-image: linear-gradient(
 		135deg,
-		rgba(108, 92, 231, 1) 0%,
-		rgba(56, 124, 246, 1) 45%,
-		rgba(236, 72, 153, 1) 100%
+		var(--a4a-refine-gradient-start) 0%,
+		var(--a4a-refine-gradient-mid) 45%,
+		var(--a4a-refine-gradient-end) 100%
 	);
 	background-size: 150% 150%;
 	background-position: 0% 50%;
@@ -35,7 +41,6 @@
 
 .components-button.a4a-refine-launcher.a4a-refine-launcher:hover,
 .components-button.a4a-refine-launcher.a4a-refine-launcher:focus {
-	color: rgba(255, 255, 255, 1);
 	background-position: 100% 50%;
 	box-shadow: 0 8px 20px rgba(0, 0, 0, 0.24);
 	transform: translateY(-2px) scale(1.08);
@@ -51,7 +56,7 @@
 }
 
 .components-button.a4a-refine-launcher.a4a-refine-launcher:focus-visible {
-	outline: 2px solid rgba(255, 255, 255, 0.9);
+	outline: 2px solid var(--color-text-inverted);
 	outline-offset: 3px;
 }
 

--- a/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-launcher.scss
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-launcher.scss
@@ -1,7 +1,5 @@
-// The doubled `.components-button` + repeated class raises specificity above
-// `@wordpress/components`' own `.components-button.has-icon` rules so the
-// gradient, circular shape, and fixed positioning win regardless of
-// stylesheet order.
+// Doubled selector raises specificity above `@wordpress/components`' own
+// `.components-button.has-icon` rules regardless of stylesheet order.
 .components-button.a4a-refine-launcher.a4a-refine-launcher {
 	position: fixed;
 	inset-block-end: 24px;
@@ -15,9 +13,7 @@
 	border: 0;
 	border-radius: 50%;
 	color: rgba(255, 255, 255, 0.98);
-	// Playful tri-tone gradient — indigo → blue → magenta — instead of the
-	// flat primary blue, sized larger than the button so the hover state can
-	// pan across it for a subtle shimmer.
+	// Tri-tone gradient, oversized so hover can pan across it for a shimmer.
 	background-image: linear-gradient(
 		135deg,
 		rgba(108, 92, 231, 1) 0%,

--- a/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-launcher.scss
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-launcher.scss
@@ -1,0 +1,106 @@
+// The doubled `.components-button` + repeated class raises specificity above
+// `@wordpress/components`' own `.components-button.has-icon` rules so the
+// gradient, circular shape, and fixed positioning win regardless of
+// stylesheet order.
+.components-button.a4a-refine-launcher.a4a-refine-launcher {
+	position: fixed;
+	inset-block-end: 24px;
+	inset-inline-end: 24px;
+	z-index: 90;
+	display: inline-grid;
+	place-items: center;
+	width: 56px;
+	height: 56px;
+	padding: 0;
+	border: 0;
+	border-radius: 50%;
+	color: rgba(255, 255, 255, 0.98);
+	// Playful tri-tone gradient — indigo → blue → magenta — instead of the
+	// flat primary blue, sized larger than the button so the hover state can
+	// pan across it for a subtle shimmer.
+	background-image: linear-gradient(
+		135deg,
+		rgba(108, 92, 231, 1) 0%,
+		rgba(56, 124, 246, 1) 45%,
+		rgba(236, 72, 153, 1) 100%
+	);
+	background-size: 150% 150%;
+	background-position: 0% 50%;
+	box-shadow: 0 8px 24px rgba(108, 92, 231, 0.45);
+	cursor: pointer;
+	transition: transform 160ms ease, box-shadow 160ms ease, background-position 480ms ease;
+}
+
+.components-button.a4a-refine-launcher.a4a-refine-launcher svg {
+	fill: currentColor;
+	transition: transform 220ms ease;
+}
+
+.components-button.a4a-refine-launcher.a4a-refine-launcher:hover,
+.components-button.a4a-refine-launcher.a4a-refine-launcher:focus {
+	color: rgba(255, 255, 255, 1);
+	background-position: 100% 50%;
+	box-shadow: 0 12px 30px rgba(236, 72, 153, 0.5);
+	transform: translateY(-2px) scale(1.08);
+}
+
+.components-button.a4a-refine-launcher.a4a-refine-launcher:hover svg,
+.components-button.a4a-refine-launcher.a4a-refine-launcher:focus svg {
+	transform: rotate(-18deg) scale(1.12);
+}
+
+.components-button.a4a-refine-launcher.a4a-refine-launcher:active {
+	transform: translateY(0) scale(0.96);
+}
+
+.components-button.a4a-refine-launcher.a4a-refine-launcher:focus-visible {
+	outline: 2px solid rgba(255, 255, 255, 0.9);
+	outline-offset: 3px;
+}
+
+// Motion is opt-in: a gentle breathing glow draws the eye to the launcher
+// while idle, and the star twinkles on entry. Skipped entirely for users who
+// prefer reduced motion.
+@media (prefers-reduced-motion: no-preference) {
+	.components-button.a4a-refine-launcher.a4a-refine-launcher {
+		animation: a4a-refine-launcher-glow 2800ms ease-in-out infinite;
+	}
+
+	.components-button.a4a-refine-launcher.a4a-refine-launcher svg {
+		animation: a4a-refine-launcher-twinkle 2800ms ease-in-out infinite;
+	}
+
+	// Pause the idle glow while the user is interacting so hover/active feel
+	// crisp rather than fighting the keyframes.
+	.components-button.a4a-refine-launcher.a4a-refine-launcher:hover,
+	.components-button.a4a-refine-launcher.a4a-refine-launcher:focus {
+		animation-play-state: paused;
+	}
+}
+
+@keyframes a4a-refine-launcher-glow {
+	0%,
+	100% {
+		box-shadow: 0 8px 24px rgba(108, 92, 231, 0.4);
+	}
+
+	50% {
+		box-shadow: 0 10px 30px rgba(236, 72, 153, 0.55);
+	}
+}
+
+@keyframes a4a-refine-launcher-twinkle {
+	0%,
+	72%,
+	100% {
+		transform: rotate(0deg) scale(1);
+	}
+
+	80% {
+		transform: rotate(-12deg) scale(1.16);
+	}
+
+	88% {
+		transform: rotate(8deg) scale(1.08);
+	}
+}

--- a/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-launcher.tsx
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-launcher.tsx
@@ -1,0 +1,36 @@
+/**
+ * Floating "Refine with AI" launcher for the output-detail screen.
+ *
+ * The refine entry point used to be a button in the action bar, which
+ * scrolled away with the deck. This pins a persistent circular icon to the
+ * bottom-inline-end corner so refining is always one click away no matter
+ * how far down the preview the user has scrolled. Clicking it opens the
+ * dock with an empty input; per-page editing is handled separately by the
+ * icon buttons revealed on each page.
+ *
+ * The launcher hides while the dock is open (the dock owns the 400px right
+ * rail and its own close control), so the button never sits underneath it.
+ */
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { starFilled } from '@wordpress/icons';
+
+import './refine-launcher.scss';
+
+interface Props {
+	onClick: () => void;
+}
+
+export default function RefineLauncher( { onClick }: Props ) {
+	return (
+		<Button
+			className="a4a-refine-launcher"
+			variant="primary"
+			icon={ starFilled }
+			iconSize={ 24 }
+			label={ __( 'Refine with AI' ) }
+			showTooltip
+			onClick={ onClick }
+		/>
+	);
+}

--- a/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-launcher.tsx
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-launcher.tsx
@@ -1,15 +1,7 @@
 /**
- * Floating "Refine with AI" launcher for the output-detail screen.
- *
- * The refine entry point used to be a button in the action bar, which
- * scrolled away with the deck. This pins a persistent circular icon to the
- * bottom-inline-end corner so refining is always one click away no matter
- * how far down the preview the user has scrolled. Clicking it opens the
- * dock with an empty input; per-page editing is handled separately by the
- * icon buttons revealed on each page.
- *
- * The launcher hides while the dock is open (the dock owns the 400px right
- * rail and its own close control), so the button never sits underneath it.
+ * Floating "Refine with AI" launcher pinned to the bottom-inline-end corner
+ * of the output-detail screen. Opens the dock with an empty input; the caller
+ * hides it while the dock is open. Per-page editing is handled separately.
  */
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';

--- a/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-with-ai-dock.scss
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-with-ai-dock.scss
@@ -1,30 +1,67 @@
-@use '@wordpress/base-styles/colors' as colors;
-
 .a4a-refine-with-ai-dock {
+	// Calypso doesn't set border-box globally on this surface, so without
+	// this the header's width + horizontal padding overflows the dock and
+	// pushes the close button off the right edge.
+	box-sizing: border-box;
 	display: flex;
 	flex-direction: column;
 	position: fixed;
-	right: 0;
-	top: 0;
-	bottom: 0;
-	width: min(380px, 100vw);
+	inset-block: 0;
+	inset-inline-end: 0;
+	width: min(400px, 100vw);
 	z-index: 100;
-	background: #fff;
-	border-left: 1px solid var(--wp-admin-theme-color, #1e1e1e);
+	background: var(--color-surface);
+	border-inline-start: 1px solid var(--color-border-subtle);
 	box-shadow: -2px 0 12px rgba(0, 0, 0, 0.08);
+}
 
-	&__header {
-		flex-shrink: 0;
-		padding: 12px 16px;
-		border-bottom: 1px solid #eee;
-		background: #fafafa;
-	}
+.a4a-refine-with-ai-dock__header {
+	box-sizing: border-box;
+	flex-shrink: 0;
+	padding-block: 12px;
+	padding-inline: 16px;
+	border-block-end: 1px solid var(--color-border-subtle);
+}
 
-	&__body {
+.a4a-refine-with-ai-dock__header strong {
+	font-size: 0.875rem;
+}
+
+.a4a-refine-with-ai-dock__body {
+	flex: 1 1 auto;
+	min-height: 0;
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+
+	// AgentUI's embedded variant lays itself out as a flex column; let it
+	// fill the dock so the input pins to the bottom and the transcript
+	// scrolls in the space above it.
+	.agenttic {
 		flex: 1 1 auto;
 		min-height: 0;
-		display: flex;
-		flex-direction: column;
-		overflow: hidden;
+
+		// agenttic's embedded message list ships with no horizontal padding
+		// — it expects the embedding surface to supply it (the floating
+		// variant gets it from its own wrapper). Inset the transcript and
+		// input so bubbles and agent replies don't run edge to edge, and
+		// lift the input off the panel's bottom edge.
+		padding-inline: 16px;
+		padding-block-end: 16px;
 	}
+}
+
+.a4a-refine-with-ai-dock__empty {
+	max-width: 280px;
+	margin: auto;
+	padding-block: 24px;
+	padding-inline: 16px;
+}
+
+.a4a-refine-with-ai-dock__empty-icon {
+	fill: var(--color-neutral-40);
+}
+
+.a4a-refine-with-ai-dock__empty-hint {
+	line-height: 1.5;
 }

--- a/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-with-ai-dock.scss
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-with-ai-dock.scss
@@ -1,7 +1,6 @@
 .a4a-refine-with-ai-dock {
-	// Calypso doesn't set border-box globally on this surface, so without
-	// this the header's width + horizontal padding overflows the dock and
-	// pushes the close button off the right edge.
+	// Calypso doesn't set border-box globally here; without it the padded
+	// header overflows and pushes the close button off the edge.
 	box-sizing: border-box;
 	display: flex;
 	flex-direction: column;
@@ -34,18 +33,14 @@
 	flex-direction: column;
 	overflow: hidden;
 
-	// AgentUI's embedded variant lays itself out as a flex column; let it
-	// fill the dock so the input pins to the bottom and the transcript
-	// scrolls in the space above it.
+	// Let AgentUI's embedded flex column fill the dock (input pinned bottom,
+	// transcript scrolling above).
 	.agenttic {
 		flex: 1 1 auto;
 		min-height: 0;
 
-		// agenttic's embedded message list ships with no horizontal padding
-		// — it expects the embedding surface to supply it (the floating
-		// variant gets it from its own wrapper). Inset the transcript and
-		// input so bubbles and agent replies don't run edge to edge, and
-		// lift the input off the panel's bottom edge.
+		// The embedded message list ships with no horizontal padding; supply it
+		// so bubbles don't run edge to edge, and lift the input off the bottom.
 		padding-inline: 16px;
 		padding-block-end: 16px;
 	}

--- a/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-with-ai-dock.scss
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-with-ai-dock.scss
@@ -1,0 +1,30 @@
+@use '@wordpress/base-styles/colors' as colors;
+
+.a4a-refine-with-ai-dock {
+	display: flex;
+	flex-direction: column;
+	position: fixed;
+	right: 0;
+	top: 0;
+	bottom: 0;
+	width: min(380px, 100vw);
+	z-index: 100;
+	background: #fff;
+	border-left: 1px solid var(--wp-admin-theme-color, #1e1e1e);
+	box-shadow: -2px 0 12px rgba(0, 0, 0, 0.08);
+
+	&__header {
+		flex-shrink: 0;
+		padding: 12px 16px;
+		border-bottom: 1px solid #eee;
+		background: #fafafa;
+	}
+
+	&__body {
+		flex: 1 1 auto;
+		min-height: 0;
+		display: flex;
+		flex-direction: column;
+		overflow: hidden;
+	}
+}

--- a/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-with-ai-dock.tsx
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-with-ai-dock.tsx
@@ -33,6 +33,13 @@ interface Props {
 	totalPages: number;
 	/** Text to seed the input with (empty opens an empty input). */
 	seedText: string;
+	/**
+	 * Bumped on every open request. The per-page "Edit with AI" button can be
+	 * re-clicked while the dock is already open — and after a submit clears the
+	 * input — so re-seeding the same `seedText` must still fire. The token is
+	 * the trigger; `seedText` alone wouldn't change.
+	 */
+	seedToken: number;
 	onClose: () => void;
 }
 
@@ -69,6 +76,7 @@ export default function RefineWithAiDock( {
 	collateralPostId,
 	totalPages,
 	seedText,
+	seedToken,
 	onClose,
 }: Props ) {
 	const [ messages, setMessages ] = useState< Message[] >( [] );
@@ -78,8 +86,9 @@ export default function RefineWithAiDock( {
 	const queryClient = useQueryClient();
 	const refine = useRefineCollateralPage();
 
-	// Seed the input when the seed text changes, then move the caret to the end
-	// of AgentUI's internal textarea so the user types right after the prompt.
+	// Seed the input on each open request (tracked by `seedToken`), then move
+	// the caret to the end of AgentUI's internal textarea. `seedText` is left
+	// out of the deps so re-clicking the same page's Edit button re-seeds.
 	useEffect( () => {
 		setInputValue( seedText );
 		const raf = requestAnimationFrame( () => {
@@ -91,7 +100,8 @@ export default function RefineWithAiDock( {
 			}
 		} );
 		return () => cancelAnimationFrame( raf );
-	}, [ seedText ] );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ seedToken ] );
 
 	// `useAgentStudioRun` self-polls while non-terminal; undefined keeps it idle.
 	const run = useAgentStudioRun( activeRun?.runId );

--- a/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-with-ai-dock.tsx
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-with-ai-dock.tsx
@@ -18,7 +18,7 @@ import { useEffect, useRef, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { close, comment } from '@wordpress/icons';
 import { getAgentStudioCollateralQueryKey } from '../../data/use-agent-studio-collateral';
-import useAgentStudioRun, { TERMINAL_RUN_STATUSES } from '../../data/use-agent-studio-run';
+import useAgentStudioRun, { NON_TERMINAL_RUN_STATUSES } from '../../data/use-agent-studio-run';
 import { getAgentStudioVariantHtmlQueryKey } from '../../data/use-agent-studio-variant-html';
 import useRefineCollateralPage, {
 	isRefineClarification,
@@ -107,8 +107,10 @@ export default function RefineWithAiDock( {
 		if ( ! activeRun || ! run.data ) {
 			return;
 		}
+		// Settled once the run leaves the non-terminal set — same signal the
+		// hook uses to stop polling.
 		const status = run.data.status;
-		if ( ! TERMINAL_RUN_STATUSES.has( status ) ) {
+		if ( NON_TERMINAL_RUN_STATUSES.has( status ) ) {
 			return;
 		}
 		if ( handledRunIdRef.current === activeRun.runId ) {

--- a/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-with-ai-dock.tsx
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-with-ai-dock.tsx
@@ -21,7 +21,7 @@ import { getAgentStudioCollateralQueryKey } from '../../data/use-agent-studio-co
 import useAgentStudioRun, { NON_TERMINAL_RUN_STATUSES } from '../../data/use-agent-studio-run';
 import { getAgentStudioVariantHtmlQueryKey } from '../../data/use-agent-studio-variant-html';
 import useRefineCollateralPage, {
-	isRefineClarification,
+	getRefineClarificationMessage,
 } from '../../data/use-refine-collateral-page';
 import type { Message } from '@automattic/agenttic-ui/dist/types';
 
@@ -165,9 +165,10 @@ export default function RefineWithAiDock( {
 				userFacingPage: response.page,
 			} );
 		} catch ( err: unknown ) {
-			if ( isRefineClarification( err ) ) {
+			const clarification = getRefineClarificationMessage( err );
+			if ( clarification ) {
 				// Server asked for clarification (no run created); show it inline.
-				setMessages( ( current ) => [ ...current, agentMessage( err.message ) ] );
+				setMessages( ( current ) => [ ...current, agentMessage( clarification ) ] );
 				return;
 			}
 			setMessages( ( current ) => [

--- a/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-with-ai-dock.tsx
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-with-ai-dock.tsx
@@ -31,11 +31,11 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
 } from '@wordpress/components';
-import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { close, comment } from '@wordpress/icons';
 import { getAgentStudioCollateralQueryKey } from '../../data/use-agent-studio-collateral';
-import useAgentStudioRun from '../../data/use-agent-studio-run';
+import useAgentStudioRun, { TERMINAL_RUN_STATUSES } from '../../data/use-agent-studio-run';
 import { getAgentStudioVariantHtmlQueryKey } from '../../data/use-agent-studio-variant-html';
 import useRefineCollateralPage, {
 	isRefineClarification,
@@ -84,23 +84,18 @@ const newMessageId = (): string => {
 	return `refine-msg-${ Date.now() }-${ messageIdCounter }`;
 };
 
-const userMessage = ( text: string ): Message => ( {
+const makeMessage = ( role: 'user' | 'agent', text: string ): Message => ( {
 	id: newMessageId(),
-	role: 'user',
+	role,
 	content: [ { type: 'text', text } ],
 	timestamp: Date.now(),
 	archived: false,
-	showIcon: false,
+	// The agent's replies carry the assistant avatar; the user's don't.
+	showIcon: role === 'agent',
 } );
 
-const agentMessage = ( text: string ): Message => ( {
-	id: newMessageId(),
-	role: 'agent',
-	content: [ { type: 'text', text } ],
-	timestamp: Date.now(),
-	archived: false,
-	showIcon: true,
-} );
+const userMessage = ( text: string ): Message => makeMessage( 'user', text );
+const agentMessage = ( text: string ): Message => makeMessage( 'agent', text );
 
 export default function RefineWithAiDock( {
 	collateralPostId,
@@ -136,25 +131,10 @@ export default function RefineWithAiDock( {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ seedToken ] );
 
-	// Poll the active refine run. `useAgentStudioRun` is the existing
-	// runs poll hook; passing undefined keeps it idle.
+	// Poll the active refine run. `useAgentStudioRun` self-polls via
+	// react-query's `refetchInterval` while the status is non-terminal and
+	// stops once it settles; passing undefined keeps it idle.
 	const run = useAgentStudioRun( activeRun?.runId );
-
-	// React-Query polls on a default interval when `refetchInterval` is
-	// set. The runs hook doesn't set one — opt in here while a run is
-	// in-flight, then turn it off on terminal status. `run.refetch` is
-	// stable across renders in react-query v5; depending only on
-	// `activeRun` keeps the interval from restarting every render.
-	const refetch = run.refetch;
-	useEffect( () => {
-		if ( ! activeRun ) {
-			return;
-		}
-		const interval = setInterval( () => {
-			void refetch();
-		}, 2000 );
-		return () => clearInterval( interval );
-	}, [ activeRun, refetch ] );
 
 	// Track terminal transitions so we only post the success/failure
 	// message once per run. Without this the polling-driven re-render
@@ -165,9 +145,7 @@ export default function RefineWithAiDock( {
 			return;
 		}
 		const status = run.data.status;
-		const isTerminal =
-			status === 'a4a_completed' || status === 'a4a_failed' || status === 'a4a_cancelled';
-		if ( ! isTerminal ) {
+		if ( ! TERMINAL_RUN_STATUSES.has( status ) ) {
 			return;
 		}
 		if ( handledRunIdRef.current === activeRun.runId ) {
@@ -245,25 +223,22 @@ export default function RefineWithAiDock( {
 	};
 
 	const isProcessing = activeRun !== null || refine.isPending;
-	const thinkingMessage = useMemo( () => {
-		if ( ! activeRun ) {
-			return undefined;
-		}
-		return sprintf(
-			/* translators: %d is the 1-based page number being refined. */
-			__( 'Updating page %d…' ),
-			activeRun.userFacingPage
-		);
-	}, [ activeRun ] );
 
-	const placeholderHint = useMemo( () => {
-		// totalPages includes the cover; the lowest refinable page is 2.
-		return sprintf(
-			/* translators: %d is the highest body page number, 1-based with cover. */
-			__( 'Tell me what to change. e.g. "page %d is clipped".' ),
-			Math.max( 2, totalPages )
-		);
-	}, [ totalPages ] );
+	// Plain strings — primitives compared by value, so memoizing buys nothing.
+	const thinkingMessage = activeRun
+		? sprintf(
+				/* translators: %d is the 1-based page number being refined. */
+				__( 'Updating page %d…' ),
+				activeRun.userFacingPage
+		  )
+		: undefined;
+
+	// totalPages includes the cover; the lowest refinable page is 2.
+	const placeholderHint = sprintf(
+		/* translators: %d is the highest body page number, 1-based with cover. */
+		__( 'Tell me what to change. e.g. "page %d is clipped".' ),
+		Math.max( 2, totalPages )
+	);
 
 	const emptyView = (
 		<VStack className="a4a-refine-with-ai-dock__empty" spacing={ 3 } alignment="center">

--- a/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-with-ai-dock.tsx
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-with-ai-dock.tsx
@@ -21,12 +21,19 @@
  * persists with the latest body_pages; the conversation about it
  * doesn't. See `~/Projects/wpcom-specs/one-pager-refinement-chat/`.
  */
+import '@automattic/agenttic-ui/index.css';
 import { AgentUI } from '@automattic/agenttic-ui';
 import { useQueryClient } from '@tanstack/react-query';
-import { Button, __experimentalHStack as HStack } from '@wordpress/components';
+import {
+	Button,
+	Icon,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+} from '@wordpress/components';
 import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { close } from '@wordpress/icons';
+import { close, comment } from '@wordpress/icons';
 import { getAgentStudioCollateralQueryKey } from '../../data/use-agent-studio-collateral';
 import useAgentStudioRun from '../../data/use-agent-studio-run';
 import { getAgentStudioVariantHtmlQueryKey } from '../../data/use-agent-studio-variant-html';
@@ -41,6 +48,19 @@ interface Props {
 	collateralPostId: number;
 	/** Total visible pages (cover + body pages). Used in the empty-state hint. */
 	totalPages: number;
+	/**
+	 * Text to seed the input with — set when the user opens the dock from a
+	 * page-scoped "Edit this page" affordance (e.g. "On page 3, make the
+	 * following edits: "). Empty string opens an empty input.
+	 */
+	seedText: string;
+	/**
+	 * Bumped every time a seed is requested. Re-seeding with the same text
+	 * (clicking the same page's Edit button twice) still needs to re-focus
+	 * and reset the input, which an identical `seedText` alone wouldn't
+	 * trigger.
+	 */
+	seedToken: number;
 	onClose: () => void;
 }
 
@@ -82,11 +102,39 @@ const agentMessage = ( text: string ): Message => ( {
 	showIcon: true,
 } );
 
-export default function RefineWithAiDock( { collateralPostId, totalPages, onClose }: Props ) {
+export default function RefineWithAiDock( {
+	collateralPostId,
+	totalPages,
+	seedText,
+	seedToken,
+	onClose,
+}: Props ) {
 	const [ messages, setMessages ] = useState< Message[] >( [] );
 	const [ activeRun, setActiveRun ] = useState< ActiveRun | null >( null );
+	const [ inputValue, setInputValue ] = useState( '' );
+	const rootRef = useRef< HTMLElement >( null );
 	const queryClient = useQueryClient();
 	const refine = useRefineCollateralPage();
+
+	// Seed the input when the dock opens from a page-scoped affordance, and
+	// re-seed when a new request comes in (tracked by `seedToken`). AgentUI's
+	// textarea is internal, so we reach it through the dock root to move the
+	// caret to the end after filling — the user picks up typing right where
+	// the prompt leaves off. `seedText` is intentionally excluded from the
+	// deps: the token is the trigger, so re-clicking the same page re-seeds.
+	useEffect( () => {
+		setInputValue( seedText );
+		const raf = requestAnimationFrame( () => {
+			const textarea = rootRef.current?.querySelector( 'textarea' );
+			if ( textarea ) {
+				textarea.focus();
+				const end = textarea.value.length;
+				textarea.setSelectionRange( end, end );
+			}
+		} );
+		return () => cancelAnimationFrame( raf );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ seedToken ] );
 
 	// Poll the active refine run. `useAgentStudioRun` is the existing
 	// runs poll hook; passing undefined keeps it idle.
@@ -168,6 +216,8 @@ export default function RefineWithAiDock( { collateralPostId, totalPages, onClos
 		if ( '' === trimmed || activeRun ) {
 			return;
 		}
+		// Input is controlled, so clear it ourselves once the message is sent.
+		setInputValue( '' );
 		setMessages( ( current ) => [ ...current, userMessage( trimmed ) ] );
 
 		try {
@@ -215,8 +265,26 @@ export default function RefineWithAiDock( { collateralPostId, totalPages, onClos
 		);
 	}, [ totalPages ] );
 
+	const emptyView = (
+		<VStack className="a4a-refine-with-ai-dock__empty" spacing={ 3 } alignment="center">
+			<Icon className="a4a-refine-with-ai-dock__empty-icon" icon={ comment } size={ 28 } />
+			<Text as="p" weight={ 500 } align="center">
+				{ __( 'Refine your one-pager' ) }
+			</Text>
+			<Text as="p" variant="muted" align="center" className="a4a-refine-with-ai-dock__empty-hint">
+				{ __(
+					'Point me at a page and tell me what to fix, like “page 3 is clipped” or “tighten the intro”. I’ll update that page in place and refresh the preview.'
+				) }
+			</Text>
+		</VStack>
+	);
+
 	return (
-		<aside className="a4a-refine-with-ai-dock" aria-label={ __( 'Refine with AI' ) }>
+		<aside
+			ref={ rootRef }
+			className="a4a-refine-with-ai-dock"
+			aria-label={ __( 'Refine with AI' ) }
+		>
 			<HStack className="a4a-refine-with-ai-dock__header" justify="space-between" spacing={ 2 }>
 				<strong>{ __( 'Refine with AI' ) }</strong>
 				<Button
@@ -233,6 +301,9 @@ export default function RefineWithAiDock( { collateralPostId, totalPages, onClos
 					isProcessing={ isProcessing }
 					thinkingMessage={ thinkingMessage }
 					placeholder={ placeholderHint }
+					emptyView={ emptyView }
+					inputValue={ inputValue }
+					onInputChange={ setInputValue }
 					onSubmit={ handleSubmit }
 				/>
 			</div>

--- a/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-with-ai-dock.tsx
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-with-ai-dock.tsx
@@ -33,8 +33,6 @@ interface Props {
 	totalPages: number;
 	/** Text to seed the input with (empty opens an empty input). */
 	seedText: string;
-	/** Bumped per open request so re-seeding identical text still re-seeds. */
-	seedToken: number;
 	onClose: () => void;
 }
 
@@ -71,7 +69,6 @@ export default function RefineWithAiDock( {
 	collateralPostId,
 	totalPages,
 	seedText,
-	seedToken,
 	onClose,
 }: Props ) {
 	const [ messages, setMessages ] = useState< Message[] >( [] );
@@ -81,9 +78,8 @@ export default function RefineWithAiDock( {
 	const queryClient = useQueryClient();
 	const refine = useRefineCollateralPage();
 
-	// Seed the input on each open request (tracked by `seedToken`), then move
-	// the caret to the end of AgentUI's internal textarea. `seedText` is left
-	// out of the deps so re-clicking the same page still re-seeds.
+	// Seed the input when the seed text changes, then move the caret to the end
+	// of AgentUI's internal textarea so the user types right after the prompt.
 	useEffect( () => {
 		setInputValue( seedText );
 		const raf = requestAnimationFrame( () => {
@@ -95,8 +91,7 @@ export default function RefineWithAiDock( {
 			}
 		} );
 		return () => cancelAnimationFrame( raf );
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ seedToken ] );
+	}, [ seedText ] );
 
 	// `useAgentStudioRun` self-polls while non-terminal; undefined keeps it idle.
 	const run = useAgentStudioRun( activeRun?.runId );

--- a/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-with-ai-dock.tsx
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-with-ai-dock.tsx
@@ -1,0 +1,233 @@
+/**
+ * Refine-with-AI dock attached to the output-detail screen.
+ *
+ * Conversational refinement layer over the existing
+ * `compose-one-pager-ela-v2` pipeline. The user looks at a rendered
+ * one-pager, opens this dock, and says something like "page 5 is
+ * clipped". The wpcom endpoint
+ * `/agency/<id>/a4a/collaterals/<post_id>/refine` parses the page
+ * number out of the instruction, validates it, and dispatches the
+ * `refine-one-pager-ela-v2` recipe. We poll the run and re-render
+ * the preview iframe on completion.
+ *
+ * The chat surface is `AgentUI` from `@automattic/agenttic-ui` — the
+ * framework-agnostic pure-UI primitive that `AgentChat` wraps. We
+ * use it directly so we can drive everything from local React state
+ * without dragging in `AGENTS_MANAGER_STORE`, `AgentsManagerContext`,
+ * `agenttic-client`'s agent registry, or React Router.
+ *
+ * Thread state is ephemeral by design — closing the dock or
+ * refreshing the page resets the transcript. The collateral itself
+ * persists with the latest body_pages; the conversation about it
+ * doesn't. See `~/Projects/wpcom-specs/one-pager-refinement-chat/`.
+ */
+import { AgentUI } from '@automattic/agenttic-ui';
+import { useQueryClient } from '@tanstack/react-query';
+import { Button, __experimentalHStack as HStack } from '@wordpress/components';
+import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { close } from '@wordpress/icons';
+import useAgentStudioRun from '../../data/use-agent-studio-run';
+import { getAgentStudioVariantHtmlQueryKey } from '../../data/use-agent-studio-variant-html';
+import useRefineCollateralPage, {
+	isRefineClarification,
+} from '../../data/use-refine-collateral-page';
+import type { Message } from '@automattic/agenttic-ui/dist/types';
+
+import './refine-with-ai-dock.scss';
+
+interface Props {
+	collateralPostId: number;
+	/** Total visible pages (cover + body pages). Used in the empty-state hint. */
+	totalPages: number;
+	onClose: () => void;
+}
+
+interface ActiveRun {
+	runId: string;
+	userFacingPage: number;
+}
+
+/**
+ * Stable message id factory — `crypto.randomUUID` when available,
+ * monotonic counter fallback for older environments. agenttic-ui keys
+ * its list off `Message.id`, so collisions cause React reconciliation
+ * bugs in long threads.
+ */
+let messageIdCounter = 0;
+const newMessageId = (): string => {
+	if ( typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function' ) {
+		return crypto.randomUUID();
+	}
+	messageIdCounter += 1;
+	return `refine-msg-${ Date.now() }-${ messageIdCounter }`;
+};
+
+const userMessage = ( text: string ): Message => ( {
+	id: newMessageId(),
+	role: 'user',
+	content: [ { type: 'text', text } ],
+	timestamp: Date.now(),
+	archived: false,
+	showIcon: false,
+} );
+
+const agentMessage = ( text: string ): Message => ( {
+	id: newMessageId(),
+	role: 'agent',
+	content: [ { type: 'text', text } ],
+	timestamp: Date.now(),
+	archived: false,
+	showIcon: true,
+} );
+
+export default function RefineWithAiDock( { collateralPostId, totalPages, onClose }: Props ) {
+	const [ messages, setMessages ] = useState< Message[] >( [] );
+	const [ activeRun, setActiveRun ] = useState< ActiveRun | null >( null );
+	const queryClient = useQueryClient();
+	const refine = useRefineCollateralPage();
+
+	// Poll the active refine run. `useAgentStudioRun` is the existing
+	// runs poll hook; passing undefined keeps it idle.
+	const run = useAgentStudioRun( activeRun?.runId );
+
+	// React-Query polls on a default interval when `refetchInterval` is
+	// set. The runs hook doesn't set one — opt in here while a run is
+	// in-flight, then turn it off on terminal status. `run.refetch` is
+	// stable across renders in react-query v5; depending only on
+	// `activeRun` keeps the interval from restarting every render.
+	const refetch = run.refetch;
+	useEffect( () => {
+		if ( ! activeRun ) {
+			return;
+		}
+		const interval = setInterval( () => {
+			void refetch();
+		}, 2000 );
+		return () => clearInterval( interval );
+	}, [ activeRun, refetch ] );
+
+	// Track terminal transitions so we only post the success/failure
+	// message once per run. Without this the polling-driven re-render
+	// would repeatedly append the same "Updated page N." reply.
+	const handledRunIdRef = useRef< string | null >( null );
+	useEffect( () => {
+		if ( ! activeRun || ! run.data ) {
+			return;
+		}
+		const status = run.data.status;
+		const isTerminal =
+			status === 'a4a_completed' || status === 'a4a_failed' || status === 'a4a_cancelled';
+		if ( ! isTerminal ) {
+			return;
+		}
+		if ( handledRunIdRef.current === activeRun.runId ) {
+			return;
+		}
+		handledRunIdRef.current = activeRun.runId;
+
+		if ( status === 'a4a_completed' ) {
+			setMessages( ( current ) => [
+				...current,
+				agentMessage(
+					sprintf(
+						/* translators: %d is the 1-based page number the user pointed at. */
+						__( 'Updated page %d.' ),
+						activeRun.userFacingPage
+					)
+				),
+			] );
+			// Refresh the rendered preview. The variant-html cache is
+			// keyed on the html_url; invalidate-by-prefix nukes every
+			// variant's entry so all surfaces refetch. Browser HTTP
+			// caching may still serve stale HTML; if that becomes a
+			// problem we add a cache-bust query param to the url at
+			// the renderer side.
+			void queryClient.invalidateQueries( {
+				queryKey: getAgentStudioVariantHtmlQueryKey( undefined ).slice( 0, 1 ),
+			} );
+		} else {
+			setMessages( ( current ) => [
+				...current,
+				agentMessage( __( "I couldn't update that page. Try rephrasing your request." ) ),
+			] );
+		}
+		setActiveRun( null );
+	}, [ activeRun, run.data, queryClient ] );
+
+	const handleSubmit = async ( instruction: string ): Promise< void > => {
+		const trimmed = instruction.trim();
+		if ( '' === trimmed || activeRun ) {
+			return;
+		}
+		setMessages( ( current ) => [ ...current, userMessage( trimmed ) ] );
+
+		try {
+			const response = await refine.mutateAsync( {
+				collateralPostId,
+				instruction: trimmed,
+			} );
+			setActiveRun( {
+				runId: String( response.run_id ),
+				userFacingPage: response.page,
+			} );
+		} catch ( err: unknown ) {
+			if ( isRefineClarification( err ) ) {
+				// Server told us what to ask for. Render the message as
+				// an assistant reply; user retries with a clearer
+				// instruction. No run was created.
+				setMessages( ( current ) => [ ...current, agentMessage( err.message ) ] );
+				return;
+			}
+			setMessages( ( current ) => [
+				...current,
+				agentMessage( __( 'Something went wrong. Please try again in a moment.' ) ),
+			] );
+		}
+	};
+
+	const isProcessing = activeRun !== null || refine.isPending;
+	const thinkingMessage = useMemo( () => {
+		if ( ! activeRun ) {
+			return undefined;
+		}
+		return sprintf(
+			/* translators: %d is the 1-based page number being refined. */
+			__( 'Updating page %d…' ),
+			activeRun.userFacingPage
+		);
+	}, [ activeRun ] );
+
+	const placeholderHint = useMemo( () => {
+		// totalPages includes the cover; the lowest refinable page is 2.
+		return sprintf(
+			/* translators: %d is the highest body page number, 1-based with cover. */
+			__( 'Tell me what to change. e.g. "page %d is clipped".' ),
+			Math.max( 2, totalPages )
+		);
+	}, [ totalPages ] );
+
+	return (
+		<aside className="a4a-refine-with-ai-dock" aria-label={ __( 'Refine with AI' ) }>
+			<HStack className="a4a-refine-with-ai-dock__header" justify="space-between" spacing={ 2 }>
+				<strong>{ __( 'Refine with AI' ) }</strong>
+				<Button
+					icon={ close }
+					label={ __( 'Close refine panel' ) }
+					onClick={ onClose }
+					size="small"
+				/>
+			</HStack>
+			<div className="a4a-refine-with-ai-dock__body">
+				<AgentUI
+					variant="embedded"
+					messages={ messages }
+					isProcessing={ isProcessing }
+					thinkingMessage={ thinkingMessage }
+					placeholder={ placeholderHint }
+					onSubmit={ handleSubmit }
+				/>
+			</div>
+		</aside>
+	);
+}

--- a/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-with-ai-dock.tsx
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-with-ai-dock.tsx
@@ -1,25 +1,8 @@
 /**
- * Refine-with-AI dock attached to the output-detail screen.
- *
- * Conversational refinement layer over the existing
- * `compose-one-pager-ela-v2` pipeline. The user looks at a rendered
- * one-pager, opens this dock, and says something like "page 5 is
- * clipped". The wpcom endpoint
- * `/agency/<id>/a4a/collaterals/<post_id>/refine` parses the page
- * number out of the instruction, validates it, and dispatches the
- * `refine-one-pager-ela-v2` recipe. We poll the run and re-render
- * the preview iframe on completion.
- *
- * The chat surface is `AgentUI` from `@automattic/agenttic-ui` — the
- * framework-agnostic pure-UI primitive that `AgentChat` wraps. We
- * use it directly so we can drive everything from local React state
- * without dragging in `AGENTS_MANAGER_STORE`, `AgentsManagerContext`,
- * `agenttic-client`'s agent registry, or React Router.
- *
- * Thread state is ephemeral by design — closing the dock or
- * refreshing the page resets the transcript. The collateral itself
- * persists with the latest body_pages; the conversation about it
- * doesn't. See `~/Projects/wpcom-specs/one-pager-refinement-chat/`.
+ * Refine-with-AI dock for the output-detail screen: a chat layer over
+ * the `refine` endpoint that page-scopes edits to a rendered one-pager.
+ * Uses `AgentUI` directly (driven from local state) rather than the
+ * agenttic-client stack. Thread state is ephemeral by design.
  */
 import '@automattic/agenttic-ui/index.css';
 import { AgentUI } from '@automattic/agenttic-ui';
@@ -48,18 +31,9 @@ interface Props {
 	collateralPostId: number;
 	/** Total visible pages (cover + body pages). Used in the empty-state hint. */
 	totalPages: number;
-	/**
-	 * Text to seed the input with — set when the user opens the dock from a
-	 * page-scoped "Edit this page" affordance (e.g. "On page 3, make the
-	 * following edits: "). Empty string opens an empty input.
-	 */
+	/** Text to seed the input with (empty opens an empty input). */
 	seedText: string;
-	/**
-	 * Bumped every time a seed is requested. Re-seeding with the same text
-	 * (clicking the same page's Edit button twice) still needs to re-focus
-	 * and reset the input, which an identical `seedText` alone wouldn't
-	 * trigger.
-	 */
+	/** Bumped per open request so re-seeding identical text still re-seeds. */
 	seedToken: number;
 	onClose: () => void;
 }
@@ -69,12 +43,8 @@ interface ActiveRun {
 	userFacingPage: number;
 }
 
-/**
- * Stable message id factory — `crypto.randomUUID` when available,
- * monotonic counter fallback for older environments. agenttic-ui keys
- * its list off `Message.id`, so collisions cause React reconciliation
- * bugs in long threads.
- */
+// Stable message id (agenttic-ui keys its list off `Message.id`).
+// `crypto.randomUUID` when available, monotonic counter otherwise.
 let messageIdCounter = 0;
 const newMessageId = (): string => {
 	if ( typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function' ) {
@@ -111,12 +81,9 @@ export default function RefineWithAiDock( {
 	const queryClient = useQueryClient();
 	const refine = useRefineCollateralPage();
 
-	// Seed the input when the dock opens from a page-scoped affordance, and
-	// re-seed when a new request comes in (tracked by `seedToken`). AgentUI's
-	// textarea is internal, so we reach it through the dock root to move the
-	// caret to the end after filling — the user picks up typing right where
-	// the prompt leaves off. `seedText` is intentionally excluded from the
-	// deps: the token is the trigger, so re-clicking the same page re-seeds.
+	// Seed the input on each open request (tracked by `seedToken`), then move
+	// the caret to the end of AgentUI's internal textarea. `seedText` is left
+	// out of the deps so re-clicking the same page still re-seeds.
 	useEffect( () => {
 		setInputValue( seedText );
 		const raf = requestAnimationFrame( () => {
@@ -131,14 +98,10 @@ export default function RefineWithAiDock( {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ seedToken ] );
 
-	// Poll the active refine run. `useAgentStudioRun` self-polls via
-	// react-query's `refetchInterval` while the status is non-terminal and
-	// stops once it settles; passing undefined keeps it idle.
+	// `useAgentStudioRun` self-polls while non-terminal; undefined keeps it idle.
 	const run = useAgentStudioRun( activeRun?.runId );
 
-	// Track terminal transitions so we only post the success/failure
-	// message once per run. Without this the polling-driven re-render
-	// would repeatedly append the same "Updated page N." reply.
+	// Post the success/failure reply once per run, not on every poll re-render.
 	const handledRunIdRef = useRef< string | null >( null );
 	useEffect( () => {
 		if ( ! activeRun || ! run.data ) {
@@ -164,16 +127,8 @@ export default function RefineWithAiDock( {
 					)
 				),
 			] );
-			// Refresh the rendered preview. Two caches sit between us
-			// and the new HTML:
-			//   1. The variant-html query (keyed on html_url). Invalidate
-			//      by prefix so every variant's entry refetches; the
-			//      fetch itself uses `cache: 'no-cache'` to bypass the
-			//      browser's HTTP cache for the same URL.
-			//   2. The collateral query (keyed on agencyId + postId).
-			//      Refine may bump variant.html_url to a new versioned
-			//      path; without invalidating the collateral we'd keep
-			//      rendering the pre-refine URL.
+			// Refresh the preview: invalidate the variant-html and collateral
+			// queries by prefix (refine may also bump html_url on the collateral).
 			void queryClient.invalidateQueries( {
 				queryKey: getAgentStudioVariantHtmlQueryKey( undefined ).slice( 0, 1 ),
 			} );
@@ -209,9 +164,7 @@ export default function RefineWithAiDock( {
 			} );
 		} catch ( err: unknown ) {
 			if ( isRefineClarification( err ) ) {
-				// Server told us what to ask for. Render the message as
-				// an assistant reply; user retries with a clearer
-				// instruction. No run was created.
+				// Server asked for clarification (no run created); show it inline.
 				setMessages( ( current ) => [ ...current, agentMessage( err.message ) ] );
 				return;
 			}

--- a/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-with-ai-dock.tsx
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-with-ai-dock.tsx
@@ -17,6 +17,8 @@ import {
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { close, comment } from '@wordpress/icons';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getAgentStudioCollateralQueryKey } from '../../data/use-agent-studio-collateral';
 import useAgentStudioRun, { NON_TERMINAL_RUN_STATUSES } from '../../data/use-agent-studio-run';
 import { getAgentStudioVariantHtmlQueryKey } from '../../data/use-agent-studio-variant-html';
@@ -83,6 +85,7 @@ export default function RefineWithAiDock( {
 	const [ activeRun, setActiveRun ] = useState< ActiveRun | null >( null );
 	const [ inputValue, setInputValue ] = useState( '' );
 	const rootRef = useRef< HTMLElement >( null );
+	const dispatch = useDispatch();
 	const queryClient = useQueryClient();
 	const refine = useRefineCollateralPage();
 
@@ -142,14 +145,28 @@ export default function RefineWithAiDock( {
 			void queryClient.invalidateQueries( {
 				queryKey: getAgentStudioCollateralQueryKey( undefined, undefined ).slice( 0, 1 ),
 			} );
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_agent_studio_refine_complete', {
+					run_id: activeRun.runId,
+					page: activeRun.userFacingPage,
+					status,
+				} )
+			);
 		} else {
 			setMessages( ( current ) => [
 				...current,
 				agentMessage( __( "I couldn't update that page. Try rephrasing your request." ) ),
 			] );
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_agent_studio_refine_error', {
+					run_id: activeRun.runId,
+					page: activeRun.userFacingPage,
+					status,
+				} )
+			);
 		}
 		setActiveRun( null );
-	}, [ activeRun, run.data, queryClient ] );
+	}, [ activeRun, run.data, queryClient, dispatch ] );
 
 	const handleSubmit = async ( instruction: string ): Promise< void > => {
 		const trimmed = instruction.trim();
@@ -159,6 +176,12 @@ export default function RefineWithAiDock( {
 		// Input is controlled, so clear it ourselves once the message is sent.
 		setInputValue( '' );
 		setMessages( ( current ) => [ ...current, userMessage( trimmed ) ] );
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_agent_studio_refine_submit', {
+				collateral_post_id: collateralPostId,
+				instruction_length: trimmed.length,
+			} )
+		);
 
 		try {
 			const response = await refine.mutateAsync( {
@@ -174,12 +197,23 @@ export default function RefineWithAiDock( {
 			if ( clarification ) {
 				// Server asked for clarification (no run created); show it inline.
 				setMessages( ( current ) => [ ...current, agentMessage( clarification ) ] );
+				dispatch(
+					recordTracksEvent( 'calypso_a4a_agent_studio_refine_clarification', {
+						collateral_post_id: collateralPostId,
+					} )
+				);
 				return;
 			}
 			setMessages( ( current ) => [
 				...current,
 				agentMessage( __( 'Something went wrong. Please try again in a moment.' ) ),
 			] );
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_agent_studio_refine_error', {
+					collateral_post_id: collateralPostId,
+					reason: 'request_failed',
+				} )
+			);
 		}
 	};
 

--- a/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-with-ai-dock.tsx
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/output-detail/refine-with-ai-dock.tsx
@@ -27,6 +27,7 @@ import { Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { close } from '@wordpress/icons';
+import { getAgentStudioCollateralQueryKey } from '../../data/use-agent-studio-collateral';
 import useAgentStudioRun from '../../data/use-agent-studio-run';
 import { getAgentStudioVariantHtmlQueryKey } from '../../data/use-agent-studio-variant-html';
 import useRefineCollateralPage, {
@@ -137,14 +138,21 @@ export default function RefineWithAiDock( { collateralPostId, totalPages, onClos
 					)
 				),
 			] );
-			// Refresh the rendered preview. The variant-html cache is
-			// keyed on the html_url; invalidate-by-prefix nukes every
-			// variant's entry so all surfaces refetch. Browser HTTP
-			// caching may still serve stale HTML; if that becomes a
-			// problem we add a cache-bust query param to the url at
-			// the renderer side.
+			// Refresh the rendered preview. Two caches sit between us
+			// and the new HTML:
+			//   1. The variant-html query (keyed on html_url). Invalidate
+			//      by prefix so every variant's entry refetches; the
+			//      fetch itself uses `cache: 'no-cache'` to bypass the
+			//      browser's HTTP cache for the same URL.
+			//   2. The collateral query (keyed on agencyId + postId).
+			//      Refine may bump variant.html_url to a new versioned
+			//      path; without invalidating the collateral we'd keep
+			//      rendering the pre-refine URL.
 			void queryClient.invalidateQueries( {
 				queryKey: getAgentStudioVariantHtmlQueryKey( undefined ).slice( 0, 1 ),
+			} );
+			void queryClient.invalidateQueries( {
+				queryKey: getAgentStudioCollateralQueryKey( undefined, undefined ).slice( 0, 1 ),
 			} );
 		} else {
 			setMessages( ( current ) => [


### PR DESCRIPTION
Part of the one-pager refinement chat workstream.

## Proposed Changes

- Add a **Refine with AI** dock to the Agent Studio one-pager output-detail screen (`/resources-and-tools/agent-studio/outputs/<id>`). It is a conversational layer over the existing `compose-one-pager-ela-v2` pipeline.
- Add two entry points into the dock:
  - A floating launcher pinned to the bottom-inline-end corner so it stays reachable no matter how far the user scrolls the preview.
  - A per-page **Edit with AI** button revealed on hover over each body page, which opens the dock pre-seeded with `On page N, make the following edits:`.
- Wire the dock to a new wpcom endpoint, `POST /agency/<id>/a4a/collaterals/<post_id>/refine`. The endpoint parses the target page number out of the natural-language instruction server-side, so the client only sends the raw text. Success returns a `run_id` the dock polls; a `clarification_needed` response (for example "which page?" or "page 99 doesn't exist") is surfaced inline as an assistant reply without creating a run.
- On run completion, re-render the affected page in place and refresh the preview, then post an "Updated page N." reply.
- Fix a stale-preview bug where the rendered preview kept showing pre-refine content even though the PDF was correct (see "Why" below).

The dock uses `AgentUI` from `@automattic/agenttic-ui` directly (the framework-agnostic primitive that `AgentChat` wraps) so the whole thing is driven from local React state, without pulling in the agents-manager store, context, or router. Thread state is intentionally ephemeral: closing the dock or refreshing the page resets the transcript, while the collateral itself persists with its latest pages.

## Why are these changes being made?

Before this change, the one-pager output-detail screen could only render a finished deliverable and offer a "Download PDF" button. The only way to alter a generated one-pager was to regenerate the whole thing from a new brief. There was no way to make a small, targeted fix to a single page ("page 3 is clipped", "tighten the intro") and see it applied.

This adds an iterative, page-scoped refinement loop so agencies can correct or tweak individual pages conversationally instead of regenerating from scratch.

The stale-preview fix addresses a separate, confusing symptom: after a refine completed, the preview iframe often kept showing the old layout while the downloaded PDF showed the corrected one. The composed deck HTML is served with `Cache-Control: max-age=60`, and refine rewrites the new HTML to the same `html_url`. React Query invalidated its in-memory entry, but a plain `fetch(html_url)` still hit the browser's HTTP cache and returned the pre-refine body. That made it intermittent: edits more than 60s apart looked fine, rapid successive edits did not. The fetch now uses `cache: 'no-cache'` to force revalidation, and the dock invalidates both the variant-html and collateral query caches on completion.

## Testing Instructions

Prerequisites:
- An A8C-for-Agencies account with an active agency.
- The wpcom `.../collaterals/<post_id>/refine` endpoint available in your environment (sandbox or deployed).
- An existing one-pager deliverable that has finished generating.

1. Open a one-pager deliverable: `/resources-and-tools/agent-studio/outputs/<id>`.
2. Confirm the floating **Refine with AI** launcher appears in the bottom-inline-end corner and that it has no glowing halo around it (a plain drop shadow only).
3. Hover a body page (any page after the cover). Confirm an **Edit with AI** button appears; the cover (page 1) should never show one.
4. Click **Edit with AI** on a page. Confirm the dock opens with the input pre-filled with `On page N, make the following edits: ` and the caret at the end.
5. Type an instruction and submit. Confirm an "Updating page N…" indicator shows while the run is in progress, then an "Updated page N." reply appears and the preview re-renders with the change.
6. Clarification path: open the dock from the floating launcher (empty input) and submit a vague instruction with no page reference. Confirm the assistant replies asking which page, and that you can retry without the panel showing a hard-error banner.
7. Stale-cache regression check: refine the same page twice within ~60 seconds. Confirm the preview updates after the second refine too (not only the downloaded PDF).
8. Keyboard/close: confirm the dock can be closed with its close button and that the launcher reappears.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
