### PR TITLE
Desktop: guard menu handlers against null window/view on macOS

### DIFF
--- a/desktop/app/lib/menu/app-menu.js
+++ b/desktop/app/lib/menu/app-menu.js
@@ -33,6 +33,9 @@ module.exports = function ( app, { view, window } ) {
 			enabled: false,
 			id: 'loggedin',
 			click: async function () {
+				if ( ! window || ! view ) {
+					return;
+				}
 				window.show();
 				if ( isCalypso( view ) ) {
 					ipc.signOut( view );

--- a/desktop/app/lib/menu/help-menu.js
+++ b/desktop/app/lib/menu/help-menu.js
@@ -27,11 +27,13 @@ module.exports = function ( { view, window } ) {
 			click: function () {
 				const defaultHelpUrl = 'https://en.support.wordpress.com/';
 				if ( session.isLoggedIn() ) {
-					window.show();
-					if ( isCalypso( view ) ) {
-						ipc.showHelp( view );
-					} else {
-						view.webContents.loadURL( defaultHelpUrl );
+					if ( window && view ) {
+						window.show();
+						if ( isCalypso( view ) ) {
+							ipc.showHelp( view );
+						} else {
+							view.webContents.loadURL( defaultHelpUrl );
+						}
 					}
 				} else {
 					shell.openExternal( defaultHelpUrl );

--- a/desktop/app/lib/menu/view-menu.js
+++ b/desktop/app/lib/menu/view-menu.js
@@ -88,8 +88,10 @@ menuItems.push(
 		visible: true,
 		click: function () {
 			const window = BrowserWindow.getFocusedWindow();
-			const view = window.getBrowserView();
-			view.webContents.reload();
+			const view = window && window.getBrowserView();
+			if ( view ) {
+				view.webContents.reload();
+			}
 		},
 	},
 	{
@@ -103,22 +105,28 @@ menuItems.push(
 
 function zoomIn() {
 	const window = BrowserWindow.getFocusedWindow();
-	const view = window.getBrowserView();
-	const zoom = view.webContents.getZoomLevel();
-	view.webContents.setZoomLevel( Math.min( zoom + ZOOMFACTOR, 3 ) );
+	const view = window && window.getBrowserView();
+	if ( view ) {
+		const zoom = view.webContents.getZoomLevel();
+		view.webContents.setZoomLevel( Math.min( zoom + ZOOMFACTOR, 3 ) );
+	}
 }
 
 function zoomOut() {
 	const window = BrowserWindow.getFocusedWindow();
-	const view = window.getBrowserView();
-	const zoom = view.webContents.getZoomLevel();
-	view.webContents.setZoomLevel( Math.max( zoom - ZOOMFACTOR, -1.0 ) );
+	const view = window && window.getBrowserView();
+	if ( view ) {
+		const zoom = view.webContents.getZoomLevel();
+		view.webContents.setZoomLevel( Math.max( zoom - ZOOMFACTOR, -1.0 ) );
+	}
 }
 
 function resetZoom() {
 	const window = BrowserWindow.getFocusedWindow();
-	const view = window.getBrowserView();
-	view.webContents.setZoomLevel( 0 );
+	const view = window && window.getBrowserView();
+	if ( view ) {
+		view.webContents.setZoomLevel( 0 );
+	}
 }
 
 module.exports = menuItems;


### PR DESCRIPTION
Part of DOTAPP-3

## Proposed Changes

* Guard `Reload`, `Zoom In`, `Zoom Out`, and `Reset Zoom` handlers in `view-menu.js` against a null focused window or null BrowserView before touching `webContents`.
* Guard the `Sign Out` handler in `app-menu.js` with an early return when `window` or `view` is null.
* Guard the `How Can We Help?` handler in `help-menu.js` so the `window.show()` / `view.webContents` path is skipped when either is null (the external-URL fallback for logged-out users is unaffected).

## Why are these changes being made?

On macOS the app and its menu bar stay alive after all windows are closed or minimized. `BrowserWindow.getFocusedWindow()` returns `null` in that state, so any menu-item click handler that unconditionally dereferenced the result would throw:

```
TypeError: Cannot read properties of null (reading 'webContents')
```

This caused the app to show an error dialog and freeze, blocking users from continuing their work. The Zoom/Reload shortcuts also have `acceleratorWorksWhenHidden: true`, making them reachable via keyboard even when no window is visible.

## Testing Instructions

* Build and launch the Desktop app (`cd desktop && yarn run build:main && yarn run dev`).
* Wait for the main window to fully load, then close it with Cmd+W (app stays running in the menu bar).
* Click **View → Reload** and use Cmd+R, Cmd++, Cmd+-, Cmd+0 — previously these crashed; now they should no-op silently.
* Click **Help → How Can We Help?** while logged in with no window open — should no-op instead of crashing.
* Click **WordPress.com → Sign Out** with no window open — should no-op instead of crashing.
* Reopen the window and verify Reload and Zoom still work normally.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?