### PR TITLE
Fix free site setup in release E2E flows

### DIFF
--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -234,6 +234,11 @@ export class RestAPIClient {
 			client_secret: SecretsManager.secrets.calypsoOauthApplication.client_secret,
 			blog_name: newSiteParams.name,
 			blog_title: newSiteParams.title,
+			...( newSiteParams.public !== undefined && { public: newSiteParams.public } ),
+			...( newSiteParams.find_available_url !== undefined && {
+				find_available_url: newSiteParams.find_available_url,
+			} ),
+			...( newSiteParams.options && { options: newSiteParams.options } ),
 		};
 
 		const params: RequestParams = {

--- a/packages/calypso-e2e/src/test/rest-api-client.test.ts
+++ b/packages/calypso-e2e/src/test/rest-api-client.test.ts
@@ -153,4 +153,47 @@ describe( 'RestAPIClient: createSite', function () {
 		expect( response ).not.toHaveProperty( 'error' );
 		expect( response.success ).toBe( true );
 	} );
+
+	test( 'Optional site creation settings are sent on request', async function () {
+		let requestBody: unknown;
+		const testResponse = {
+			success: true,
+			blog_details: {
+				url: 'https://fakeblog.blog.com',
+				blogid: '420',
+				blogname: 'fake_blog_name',
+				site_slug: 'fakeblog.blog.com',
+			},
+		};
+
+		const scope = nock( requestURL.origin )
+			.post( requestURL.pathname, ( body ) => {
+				requestBody = body;
+				return true;
+			} )
+			.reply( 200, testResponse );
+
+		await restAPIClient.createSite( {
+			name: 'fake_blog_name',
+			title: 'fake_blog_title',
+			public: 0,
+			find_available_url: true,
+			options: {
+				site_creation_flow: 'onboarding',
+				wpcom_public_coming_soon: 1,
+			},
+		} );
+
+		expect( scope.isDone() ).toBe( true );
+		expect( requestBody ).toMatchObject( {
+			blog_name: 'fake_blog_name',
+			blog_title: 'fake_blog_title',
+			public: 0,
+			find_available_url: true,
+			options: {
+				site_creation_flow: 'onboarding',
+				wpcom_public_coming_soon: 1,
+			},
+		} );
+	} );
 } );

--- a/packages/calypso-e2e/src/types/rest-api-client.types.ts
+++ b/packages/calypso-e2e/src/types/rest-api-client.types.ts
@@ -20,6 +20,9 @@ export interface SiteDetails {
 export interface NewSiteParams {
 	name: string;
 	title: string;
+	public?: number;
+	find_available_url?: boolean;
+	options?: Record< string, unknown >;
 }
 
 export interface NewPostParams {

--- a/test/e2e/specs/flows/setup-domain__flows.spec.ts
+++ b/test/e2e/specs/flows/setup-domain__flows.spec.ts
@@ -7,7 +7,7 @@ import {
 	RestAPIClient,
 } from '@automattic/calypso-e2e';
 import { tags, test, expect } from '../../lib/pw-base';
-import { apiCloseAccount, apiDeleteSite } from '../shared';
+import { apiCloseAccount, apiCreateFreeSiteForUser, apiDeleteSite } from '../shared';
 
 test.describe(
 	'Setup Domain Flows',
@@ -115,7 +115,7 @@ test.describe(
 			} );
 		} );
 
-		test( 'As a new user, I can create a free site and then add a domain WITHOUT a plan upgrade', async ( {
+		test( 'As a new user with a free site, I can add a domain WITHOUT a plan upgrade', async ( {
 			page,
 			componentDomainSearch,
 			componentSelectItems,
@@ -125,7 +125,6 @@ test.describe(
 			pageSignupPickPlan,
 			pageUserSignUp,
 		} ) => {
-			const siteCreationPlan = 'Free';
 			const testUser = helperData.getNewTestUser();
 			let newUserDetails: NewUserResponse;
 			let newSiteDetails: NewSiteResponse;
@@ -139,15 +138,11 @@ test.describe(
 				newUserDetails = await pageUserSignUp.signupSocialFirstWithEmail( testUser.email );
 			} );
 
-			await test.step( 'And I skip the domains step', async function () {
-				await componentDomainSearch.search( helperData.getBlogName() );
-				await componentDomainSearch.skipPurchase();
-			} );
-
-			await test.step( `And I select the ${ siteCreationPlan } plan`, async function () {
-				newSiteDetails = await pageSignupPickPlan.selectPlan(
-					siteCreationPlan,
-					new RegExp( '.*/home/.*' )
+			await test.step( 'Given I have a free site', async function () {
+				newSiteDetails = await apiCreateFreeSiteForUser(
+					testUser,
+					newUserDetails,
+					helperData.getBlogName()
 				);
 				accountsToCleanup.push( { testUser, newUserDetails, newSiteDetails } );
 			} );
@@ -192,7 +187,7 @@ test.describe(
 			} );
 		} );
 
-		test( 'As a new user, I can create a free site and then add a domain WITH a plan upgrade', async ( {
+		test( 'As a new user with a free site, I can add a domain WITH a plan upgrade', async ( {
 			page,
 			componentDomainSearch,
 			componentSelectItems,
@@ -202,7 +197,6 @@ test.describe(
 			pageSignupPickPlan,
 			pageUserSignUp,
 		} ) => {
-			const siteCreationPlan = 'Free';
 			const domainAdditionPlan = 'Personal';
 			const testUser = helperData.getNewTestUser();
 			let newUserDetails: NewUserResponse;
@@ -217,15 +211,11 @@ test.describe(
 				newUserDetails = await pageUserSignUp.signupSocialFirstWithEmail( testUser.email );
 			} );
 
-			await test.step( 'And I skip the domains step', async function () {
-				await componentDomainSearch.search( helperData.getBlogName() );
-				await componentDomainSearch.skipPurchase();
-			} );
-
-			await test.step( `And I select the ${ siteCreationPlan } plan`, async function () {
-				newSiteDetails = await pageSignupPickPlan.selectPlan(
-					siteCreationPlan,
-					new RegExp( '.*/home/.*' )
+			await test.step( 'Given I have a free site', async function () {
+				newSiteDetails = await apiCreateFreeSiteForUser(
+					testUser,
+					newUserDetails,
+					helperData.getBlogName()
 				);
 				accountsToCleanup.push( { testUser, newUserDetails, newSiteDetails } );
 			} );

--- a/test/e2e/specs/flows/start-launch-site__flows.spec.ts
+++ b/test/e2e/specs/flows/start-launch-site__flows.spec.ts
@@ -6,7 +6,7 @@ import {
 	RestAPIClient,
 } from '@automattic/calypso-e2e';
 import { tags, test } from '../../lib/pw-base';
-import { apiCloseAccount, apiDeleteSite } from '../shared';
+import { apiCloseAccount, apiCreateUnlaunchedFreeSiteForUser, apiDeleteSite } from '../shared';
 
 test.describe(
 	'Launch Site Flows',
@@ -20,7 +20,7 @@ test.describe(
 			newSiteDetails?: NewSiteResponse;
 		}[] = [];
 
-		test( 'As a new user, I can create a free site then use launch-site flow to purchase domain and plan', async ( {
+		test( 'As a new user with a free site, I can use launch-site flow to purchase domain and plan', async ( {
 			page,
 			componentDomainSearch,
 			helperData,
@@ -48,13 +48,12 @@ test.describe(
 				newUserDetails = await pageUserSignUp.signupSocialFirstWithEmail( testUser.email );
 			} );
 
-			await test.step( 'And I select a .wordpress.com domain name', async function () {
-				await componentDomainSearch.search( helperData.getBlogName() );
-				await componentDomainSearch.skipPurchase();
-			} );
-
-			await test.step( 'And I select WordPress.com Free plan', async function () {
-				newSiteDetails = await pageSignupPickPlan.selectPlan( 'Free', new RegExp( '.*/home/.*' ) );
+			await test.step( 'Given I have an unlaunched free site', async function () {
+				newSiteDetails = await apiCreateUnlaunchedFreeSiteForUser(
+					testUser,
+					newUserDetails,
+					helperData.getBlogName()
+				);
 				accountsToCleanup.push( { testUser, newUserDetails, newSiteDetails } );
 			} );
 
@@ -87,7 +86,7 @@ test.describe(
 			} );
 		} );
 
-		test( 'As a new user, I can create a free site then use launch-site flow to purchase a plan only', async ( {
+		test( 'As a new user with a free site, I can use launch-site flow to purchase a plan only', async ( {
 			page,
 			componentDomainSearch,
 			helperData,
@@ -113,13 +112,12 @@ test.describe(
 				newUserDetails = await pageUserSignUp.signupSocialFirstWithEmail( testUser.email );
 			} );
 
-			await test.step( 'And I select a .wordpress.com domain name', async function () {
-				await componentDomainSearch.search( helperData.getBlogName() );
-				await componentDomainSearch.skipPurchase();
-			} );
-
-			await test.step( 'And I select WordPress.com Free plan', async function () {
-				newSiteDetails = await pageSignupPickPlan.selectPlan( 'Free', new RegExp( '.*/home/.*' ) );
+			await test.step( 'Given I have an unlaunched free site', async function () {
+				newSiteDetails = await apiCreateUnlaunchedFreeSiteForUser(
+					testUser,
+					newUserDetails,
+					helperData.getBlogName()
+				);
 				accountsToCleanup.push( { testUser, newUserDetails, newSiteDetails } );
 			} );
 
@@ -148,7 +146,7 @@ test.describe(
 			} );
 		} );
 
-		test( 'As a new user, I can create a free site and launch it without purchasing a domain or a plan', async ( {
+		test( 'As a new user with a free site, I can launch it without purchasing a domain or a plan', async ( {
 			page,
 			componentDomainSearch,
 			componentLaunchCelebration,
@@ -174,13 +172,12 @@ test.describe(
 				newUserDetails = await pageUserSignUp.signupSocialFirstWithEmail( testUser.email );
 			} );
 
-			await test.step( 'And I select a .wordpress.com domain name', async function () {
-				await componentDomainSearch.search( helperData.getBlogName() );
-				await componentDomainSearch.skipPurchase();
-			} );
-
-			await test.step( 'And I select WordPress.com Free plan', async function () {
-				newSiteDetails = await pageSignupPickPlan.selectPlan( 'Free', new RegExp( '.*/home/.*' ) );
+			await test.step( 'Given I have an unlaunched free site', async function () {
+				newSiteDetails = await apiCreateUnlaunchedFreeSiteForUser(
+					testUser,
+					newUserDetails,
+					helperData.getBlogName()
+				);
 				accountsToCleanup.push( { testUser, newUserDetails, newSiteDetails } );
 			} );
 
@@ -215,7 +212,7 @@ test.describe(
 			} );
 		} );
 
-		test( 'As a new user, I can create a free site then use launch-site flow to purchase a domain only', async ( {
+		test( 'As a new user with a free site, I can use launch-site flow to purchase a domain only', async ( {
 			page,
 			componentDomainSearch,
 			helperData,
@@ -242,13 +239,12 @@ test.describe(
 				newUserDetails = await pageUserSignUp.signupSocialFirstWithEmail( testUser.email );
 			} );
 
-			await test.step( 'And I select a .wordpress.com domain name', async function () {
-				await componentDomainSearch.search( helperData.getBlogName() );
-				await componentDomainSearch.skipPurchase();
-			} );
-
-			await test.step( 'And I select WordPress.com Free plan', async function () {
-				newSiteDetails = await pageSignupPickPlan.selectPlan( 'Free', new RegExp( '.*/home/.*' ) );
+			await test.step( 'Given I have an unlaunched free site', async function () {
+				newSiteDetails = await apiCreateUnlaunchedFreeSiteForUser(
+					testUser,
+					newUserDetails,
+					helperData.getBlogName()
+				);
 				accountsToCleanup.push( { testUser, newUserDetails, newSiteDetails } );
 			} );
 
@@ -288,7 +284,7 @@ test.describe(
 			} );
 		} );
 
-		test( 'As a new user, I can create a free site then use the launch-site flow to pick a domain, and continue to checkout by picking the plan within the escape hatch', async ( {
+		test( 'As a new user with a free site, I can use the launch-site flow to pick a domain, and continue to checkout by picking the plan within the escape hatch', async ( {
 			page,
 			componentDomainSearch,
 			helperData,
@@ -316,13 +312,12 @@ test.describe(
 				newUserDetails = await pageUserSignUp.signupSocialFirstWithEmail( testUser.email );
 			} );
 
-			await test.step( 'And I select a .wordpress.com domain name', async function () {
-				await componentDomainSearch.search( helperData.getBlogName() );
-				await componentDomainSearch.skipPurchase();
-			} );
-
-			await test.step( 'And I select WordPress.com Free plan', async function () {
-				newSiteDetails = await pageSignupPickPlan.selectPlan( 'Free', new RegExp( '.*/home/.*' ) );
+			await test.step( 'Given I have an unlaunched free site', async function () {
+				newSiteDetails = await apiCreateUnlaunchedFreeSiteForUser(
+					testUser,
+					newUserDetails,
+					helperData.getBlogName()
+				);
 				accountsToCleanup.push( { testUser, newUserDetails, newSiteDetails } );
 			} );
 

--- a/test/e2e/specs/onboarding/launch-site__wp-admin.spec.ts
+++ b/test/e2e/specs/onboarding/launch-site__wp-admin.spec.ts
@@ -5,7 +5,12 @@ import {
 	type NewUserResponse,
 } from '@automattic/calypso-e2e';
 import { expect, tags, test } from '../../lib/pw-base';
-import { apiCloseAccount, apiDeleteSite, swapBaseUrl } from '../shared';
+import {
+	apiCloseAccount,
+	apiCreateUnlaunchedFreeSiteForUser,
+	apiDeleteSite,
+	swapBaseUrl,
+} from '../shared';
 
 test.describe(
 	'Onboarding: Launch site from WP Admin',
@@ -45,13 +50,12 @@ test.describe(
 				newUserDetails = await pageUserSignUp.signupSocialFirstWithEmail( testUser.email );
 			} );
 
-			await test.step( 'And I select a .wordpress.com domain name', async function () {
-				await componentDomainSearch.search( helperData.getBlogName() );
-				await componentDomainSearch.skipPurchase();
-			} );
-
-			await test.step( 'And I select the WordPress.com Free plan', async function () {
-				newSiteDetails = await pageSignupPickPlan.selectPlan( 'Free', new RegExp( '.*/home/.*' ) );
+			await test.step( 'Given I have an unlaunched free site', async function () {
+				newSiteDetails = await apiCreateUnlaunchedFreeSiteForUser(
+					testUser,
+					newUserDetails,
+					helperData.getBlogName()
+				);
 				siteSlug = newSiteDetails.blog_details.site_slug;
 				accountsToCleanup.push( { testUser, newUserDetails, newSiteDetails } );
 			} );

--- a/test/e2e/specs/shared/api-create-free-site.ts
+++ b/test/e2e/specs/shared/api-create-free-site.ts
@@ -1,0 +1,51 @@
+import { RestAPIClient } from '@automattic/calypso-e2e';
+import type {
+	NewSiteParams,
+	NewSiteResponse,
+	NewTestUserDetails,
+	NewUserResponse,
+} from '@automattic/calypso-e2e';
+
+type FreeSiteParams = Partial< Pick< NewSiteParams, 'find_available_url' | 'public' | 'options' > >;
+
+/**
+ * Creates the free site needed as setup by domain flows.
+ */
+export async function apiCreateFreeSiteForUser(
+	testUser: NewTestUserDetails,
+	newUserDetails: NewUserResponse,
+	siteName: string,
+	siteParams: FreeSiteParams = {}
+): Promise< NewSiteResponse > {
+	const restAPIClient = new RestAPIClient(
+		{
+			username: testUser.username,
+			password: testUser.password,
+		},
+		newUserDetails.body.bearer_token
+	);
+
+	return restAPIClient.createSite( {
+		name: siteName,
+		title: siteName,
+		find_available_url: true,
+		...siteParams,
+	} );
+}
+
+/**
+ * Creates the unlaunched free site needed as setup by launch flows.
+ */
+export async function apiCreateUnlaunchedFreeSiteForUser(
+	testUser: NewTestUserDetails,
+	newUserDetails: NewUserResponse,
+	siteName: string
+): Promise< NewSiteResponse > {
+	return apiCreateFreeSiteForUser( testUser, newUserDetails, siteName, {
+		public: 0,
+		options: {
+			site_creation_flow: 'onboarding',
+			wpcom_public_coming_soon: 1,
+		},
+	} );
+}

--- a/test/e2e/specs/shared/index.ts
+++ b/test/e2e/specs/shared/index.ts
@@ -1,4 +1,5 @@
 export * from './api-close-account';
+export * from './api-create-free-site';
 export * from './api-delete-site';
 export * from './swap-base-url';
 


### PR DESCRIPTION
Follow-up to #110916

## Proposed Changes

* Add an API helper for creating free test sites after signup.
* Use API-created free sites as setup for domain release flows.
* Use API-created unlaunched free sites as setup for launch release flows.
* Set `find_available_url: true` by default for API-created setup sites, matching onboarding site creation.
* Allow `RestAPIClient.createSite()` to pass optional site creation settings.

## Why are these changes being made?

#110916 intentionally sends Free plan selections in onboarding to `/choose`. Several release E2E tests used that Free plan click only to create prerequisite sites before testing domain and launch flows.

That setup path now waits for site creation that no longer happens. This keeps the meaningful domain and launch E2E coverage in place while moving prerequisite setup to the cheaper API layer.

This does not replace E2E coverage for the onboarding Free plan or `/choose` behavior. That should stay in a test whose purpose is signup/onboarding.

## Testing Instructions

* `yarn test-packages packages/calypso-e2e/src/test/rest-api-client.test.ts --runInBand`
* `yarn eslint-branch`
* `./node_modules/.bin/tsc --project packages/calypso-e2e/tsconfig.json --noEmit`
* `./node_modules/.bin/tsc --project test/e2e/tsconfig.json --noEmit`
* Ran affected Playwright specs against staging Calypso:
  * `specs/flows/start-launch-site__flows.spec.ts` with one worker: 6/6 passed
  * `specs/flows/setup-domain__flows.spec.ts` / `WITHOUT a plan upgrade`: passed
  * `specs/flows/setup-domain__flows.spec.ts` / `WITH a plan upgrade`: passed
  * `specs/onboarding/launch-site__wp-admin.spec.ts`: passed

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
