### PR TITLE
Checkout: success toast for plan + domain purchases

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -26,6 +26,10 @@ import getOrderTransactionError from 'calypso/state/selectors/get-order-transact
 import { requestSite } from 'calypso/state/sites/actions';
 import usePurchaseOrder from '../../src/hooks/use-purchase-order';
 import { logStashLoadErrorEvent } from '../../src/lib/analytics';
+import {
+	PLAN_AND_DOMAIN_NOTICE_QUERY_VALUE,
+	appendNoticeQueryParam,
+} from '../purchase-notice-constants';
 import type { RedirectInstructions } from 'calypso/my-sites/checkout/src/lib/pending-page';
 import type {
 	OrderTransaction,
@@ -34,19 +38,6 @@ import type {
 import type { CalypsoDispatch } from 'calypso/state/types';
 
 import './style.scss';
-
-/**
- * Query param key + value that mark a redirect URL as needing a post-purchase
- * success toast. Read by `client/my-sites/customer-home/main.tsx` (and possibly
- * other destinations) on mount, which dispatches the toast and strips the param.
- */
-export const PURCHASE_NOTICE_QUERY_KEY = 'notice';
-export const PLAN_AND_DOMAIN_NOTICE_QUERY_VALUE = 'plan-and-domain';
-
-function appendNoticeQueryParam( url: string, value: string ): string {
-	const separator = url.includes( '?' ) ? '&' : '?';
-	return `${ url }${ separator }${ PURCHASE_NOTICE_QUERY_KEY }=${ value }`;
-}
 
 interface CheckoutPendingProps {
 	orderId: number | ':orderId';

--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -1,4 +1,5 @@
 import { receiptQuery } from '@automattic/api-queries';
+import { isDomainRegistration, isPlan } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { getUrlParts } from '@automattic/calypso-url';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
@@ -20,6 +21,7 @@ import { useSelector, useDispatch } from 'calypso/state';
 import { fetchCurrentUser } from 'calypso/state/current-user/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { SUCCESS } from 'calypso/state/order-transactions/constants';
+import { getReceiptById } from 'calypso/state/receipts/selectors';
 import getOrderTransactionError from 'calypso/state/selectors/get-order-transaction-error';
 import { requestSite } from 'calypso/state/sites/actions';
 import usePurchaseOrder from '../../src/hooks/use-purchase-order';
@@ -196,6 +198,19 @@ function useRedirectOnTransactionSuccess( {
 	const firstItem = receipt?.items[ 0 ];
 	const isRenewal = receipt?.items.some( ( item ) => item.type === 'recurring' ) ?? false;
 	const productName = firstItem?.variation || firstItem?.product || '';
+
+	// The `domain-and-plan` flow sets `redirect_to=/home/<site>`, so a successful
+	// plan + domain purchase lands the user on `/home/<site>` instead of the
+	// thank-you page. Detect that purchase shape here (via Redux receipts state,
+	// populated by the post-payment callback before redirect) so the pending page
+	// can dispatch a success toast right before the final navigation.
+	const purchases = useSelector(
+		( state ) => getReceiptById( state, finalReceiptId ).data?.purchases
+	);
+	const isPlanAndDomainPurchase =
+		( purchases?.some( ( purchase ) => isPlan( purchase ) ) &&
+			purchases?.some( ( purchase ) => isDomainRegistration( purchase ) ) ) ??
+		false;
 	const blogId = firstItem?.site_id;
 	const saasRedirectUrl = receipt?.items.reduce< string | undefined >(
 		( url, item ) => url ?? ( item.saas_redirect_url || undefined ),
@@ -319,6 +334,7 @@ function useRedirectOnTransactionSuccess( {
 		triggerPostRedirectNotices( {
 			redirectInstructions,
 			isRenewal,
+			isPlanAndDomainPurchase,
 			productName,
 			translate,
 			reduxDispatch,
@@ -342,6 +358,7 @@ function useRedirectOnTransactionSuccess( {
 		finalReceiptId,
 		isReceiptLoaded,
 		isRenewal,
+		isPlanAndDomainPurchase,
 		blogId,
 		orderId,
 		productName,
@@ -368,12 +385,14 @@ function isTransactionSuccessful(
 function triggerPostRedirectNotices( {
 	redirectInstructions,
 	isRenewal,
+	isPlanAndDomainPurchase,
 	productName,
 	translate,
 	reduxDispatch,
 }: {
 	redirectInstructions: RedirectInstructions;
 	isRenewal: boolean;
+	isPlanAndDomainPurchase: boolean;
 	productName: string;
 	translate: ReturnType< typeof useTranslate >;
 	reduxDispatch: CalypsoDispatch;
@@ -406,6 +425,21 @@ function triggerPostRedirectNotices( {
 			translate,
 			reduxDispatch,
 		} );
+		return;
+	}
+
+	if ( isPlanAndDomainPurchase ) {
+		// `displayOnNextPage: true` keeps the notice through the single route
+		// change between this dispatch and `notifyAndPerformRedirect` below, so the
+		// user sees it on the destination (e.g. `/home/<site>`), not the pending
+		// loading screen.
+		reduxDispatch(
+			successNotice( translate( 'Your plan and domain are ready!' ), {
+				id: 'plan-and-domain-purchase-success',
+				displayOnNextPage: true,
+				duration: 10000,
+			} )
+		);
 		return;
 	}
 }

--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -19,7 +19,7 @@ import { sendMessageToOpener } from 'calypso/my-sites/checkout/src/lib/popup';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { useSelector, useDispatch } from 'calypso/state';
 import { fetchCurrentUser } from 'calypso/state/current-user/actions';
-import { errorNotice } from 'calypso/state/notices/actions';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { SUCCESS } from 'calypso/state/order-transactions/constants';
 import { getReceiptById } from 'calypso/state/receipts/selectors';
 import getOrderTransactionError from 'calypso/state/selectors/get-order-transaction-error';

--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -19,7 +19,7 @@ import { sendMessageToOpener } from 'calypso/my-sites/checkout/src/lib/popup';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { useSelector, useDispatch } from 'calypso/state';
 import { fetchCurrentUser } from 'calypso/state/current-user/actions';
-import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { errorNotice } from 'calypso/state/notices/actions';
 import { SUCCESS } from 'calypso/state/order-transactions/constants';
 import { getReceiptById } from 'calypso/state/receipts/selectors';
 import getOrderTransactionError from 'calypso/state/selectors/get-order-transaction-error';
@@ -34,6 +34,19 @@ import type {
 import type { CalypsoDispatch } from 'calypso/state/types';
 
 import './style.scss';
+
+/**
+ * Query param key + value that mark a redirect URL as needing a post-purchase
+ * success toast. Read by `client/my-sites/customer-home/main.tsx` (and possibly
+ * other destinations) on mount, which dispatches the toast and strips the param.
+ */
+export const PURCHASE_NOTICE_QUERY_KEY = 'notice';
+export const PLAN_AND_DOMAIN_NOTICE_QUERY_VALUE = 'plan-and-domain';
+
+function appendNoticeQueryParam( url: string, value: string ): string {
+	const separator = url.includes( '?' ) ? '&' : '?';
+	return `${ url }${ separator }${ PURCHASE_NOTICE_QUERY_KEY }=${ value }`;
+}
 
 interface CheckoutPendingProps {
 	orderId: number | ':orderId';
@@ -334,7 +347,6 @@ function useRedirectOnTransactionSuccess( {
 		triggerPostRedirectNotices( {
 			redirectInstructions,
 			isRenewal,
-			isPlanAndDomainPurchase,
 			productName,
 			translate,
 			reduxDispatch,
@@ -346,7 +358,22 @@ function useRedirectOnTransactionSuccess( {
 			reduxDispatch( requestSite( blogId ) );
 		}
 
-		notifyAndPerformRedirect( siteSlug, redirectInstructions );
+		// For plan + domain purchases the `domain-and-plan` flow sends the user to
+		// `/home/<site>` instead of the thank-you page. Tag the destination URL with
+		// a `notice` query param so the destination can dispatch a success toast on
+		// arrival - we cannot dispatch from here because the global notice renderer
+		// has no concept of "show only on the next page".
+		const finalRedirectInstructions = isPlanAndDomainPurchase
+			? {
+					...redirectInstructions,
+					url: appendNoticeQueryParam(
+						redirectInstructions.url,
+						PLAN_AND_DOMAIN_NOTICE_QUERY_VALUE
+					),
+			  }
+			: redirectInstructions;
+
+		notifyAndPerformRedirect( siteSlug, finalRedirectInstructions );
 	}, [
 		isLoadingOrder,
 		saasRedirectUrl,
@@ -385,14 +412,12 @@ function isTransactionSuccessful(
 function triggerPostRedirectNotices( {
 	redirectInstructions,
 	isRenewal,
-	isPlanAndDomainPurchase,
 	productName,
 	translate,
 	reduxDispatch,
 }: {
 	redirectInstructions: RedirectInstructions;
 	isRenewal: boolean;
-	isPlanAndDomainPurchase: boolean;
 	productName: string;
 	translate: ReturnType< typeof useTranslate >;
 	reduxDispatch: CalypsoDispatch;
@@ -425,21 +450,6 @@ function triggerPostRedirectNotices( {
 			translate,
 			reduxDispatch,
 		} );
-		return;
-	}
-
-	if ( isPlanAndDomainPurchase ) {
-		// `displayOnNextPage: true` keeps the notice through the single route
-		// change between this dispatch and `notifyAndPerformRedirect` below, so the
-		// user sees it on the destination (e.g. `/home/<site>`), not the pending
-		// loading screen.
-		reduxDispatch(
-			successNotice( translate( 'Your plan and domain are ready!' ), {
-				id: 'plan-and-domain-purchase-success',
-				displayOnNextPage: true,
-				duration: 10000,
-			} )
-		);
 		return;
 	}
 }

--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -1,5 +1,4 @@
 import { receiptQuery } from '@automattic/api-queries';
-import { isDomainRegistration, isPlan } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { getUrlParts } from '@automattic/calypso-url';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
@@ -21,7 +20,6 @@ import { useSelector, useDispatch } from 'calypso/state';
 import { fetchCurrentUser } from 'calypso/state/current-user/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { SUCCESS } from 'calypso/state/order-transactions/constants';
-import { getReceiptById } from 'calypso/state/receipts/selectors';
 import getOrderTransactionError from 'calypso/state/selectors/get-order-transaction-error';
 import { requestSite } from 'calypso/state/sites/actions';
 import usePurchaseOrder from '../../src/hooks/use-purchase-order';
@@ -205,15 +203,11 @@ function useRedirectOnTransactionSuccess( {
 
 	// The `domain-and-plan` flow sets `redirect_to=/home/<site>`, so a successful
 	// plan + domain purchase lands the user on `/home/<site>` instead of the
-	// thank-you page. Detect that purchase shape here (via Redux receipts state,
-	// populated by the post-payment callback before redirect) so the pending page
-	// can dispatch a success toast right before the final navigation.
-	const purchases = useSelector(
-		( state ) => getReceiptById( state, finalReceiptId ).data?.purchases
-	);
+	// thank-you page. Detect that purchase shape from the receipt items so the
+	// destination can dispatch a success toast on arrival.
 	const isPlanAndDomainPurchase =
-		( purchases?.some( ( purchase ) => isPlan( purchase ) ) &&
-			purchases?.some( ( purchase ) => isDomainRegistration( purchase ) ) ) ??
+		( receipt?.items.some( ( item ) => item.is_plan ) &&
+			receipt?.items.some( ( item ) => item.is_domain_registration ) ) ??
 		false;
 	const blogId = firstItem?.site_id;
 	const saasRedirectUrl = receipt?.items.reduce< string | undefined >(

--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -1,4 +1,5 @@
 import { receiptQuery } from '@automattic/api-queries';
+import { isDomainRegistration, isPlan } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { getUrlParts } from '@automattic/calypso-url';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
@@ -196,6 +197,10 @@ function useRedirectOnTransactionSuccess( {
 	const firstItem = receipt?.items[ 0 ];
 	const isRenewal = receipt?.items.some( ( item ) => item.type === 'recurring' ) ?? false;
 	const productName = firstItem?.variation || firstItem?.product || '';
+	const isPlanAndDomainPurchase =
+		( receipt?.items.some( ( item ) => isPlan( item ) ) &&
+			receipt?.items.some( ( item ) => isDomainRegistration( item ) ) ) ??
+		false;
 	const blogId = firstItem?.site_id;
 	const saasRedirectUrl = receipt?.items.reduce< string | undefined >(
 		( url, item ) => url ?? ( item.saas_redirect_url || undefined ),
@@ -319,6 +324,7 @@ function useRedirectOnTransactionSuccess( {
 		triggerPostRedirectNotices( {
 			redirectInstructions,
 			isRenewal,
+			isPlanAndDomainPurchase,
 			productName,
 			translate,
 			reduxDispatch,
@@ -342,6 +348,7 @@ function useRedirectOnTransactionSuccess( {
 		finalReceiptId,
 		isReceiptLoaded,
 		isRenewal,
+		isPlanAndDomainPurchase,
 		blogId,
 		orderId,
 		productName,
@@ -368,12 +375,14 @@ function isTransactionSuccessful(
 function triggerPostRedirectNotices( {
 	redirectInstructions,
 	isRenewal,
+	isPlanAndDomainPurchase,
 	productName,
 	translate,
 	reduxDispatch,
 }: {
 	redirectInstructions: RedirectInstructions;
 	isRenewal: boolean;
+	isPlanAndDomainPurchase: boolean;
 	productName: string;
 	translate: ReturnType< typeof useTranslate >;
 	reduxDispatch: CalypsoDispatch;
@@ -406,6 +415,20 @@ function triggerPostRedirectNotices( {
 			translate,
 			reduxDispatch,
 		} );
+		return;
+	}
+
+	if ( isPlanAndDomainPurchase ) {
+		// The `domain-and-plan` flow sets `redirect_to=/home/<site>`, sending users
+		// to their site home instead of the thank-you page. Surface a success toast
+		// there so the purchase is acknowledged.
+		reduxDispatch(
+			successNotice( translate( 'Your plan and domain are ready!' ), {
+				id: 'plan-and-domain-purchase-success',
+				displayOnNextPage: true,
+				duration: 10000,
+			} )
+		);
 		return;
 	}
 }

--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -1,5 +1,4 @@
 import { receiptQuery } from '@automattic/api-queries';
-import { isDomainRegistration, isPlan } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { getUrlParts } from '@automattic/calypso-url';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
@@ -197,10 +196,6 @@ function useRedirectOnTransactionSuccess( {
 	const firstItem = receipt?.items[ 0 ];
 	const isRenewal = receipt?.items.some( ( item ) => item.type === 'recurring' ) ?? false;
 	const productName = firstItem?.variation || firstItem?.product || '';
-	const isPlanAndDomainPurchase =
-		( receipt?.items.some( ( item ) => isPlan( item ) ) &&
-			receipt?.items.some( ( item ) => isDomainRegistration( item ) ) ) ??
-		false;
 	const blogId = firstItem?.site_id;
 	const saasRedirectUrl = receipt?.items.reduce< string | undefined >(
 		( url, item ) => url ?? ( item.saas_redirect_url || undefined ),
@@ -324,7 +319,6 @@ function useRedirectOnTransactionSuccess( {
 		triggerPostRedirectNotices( {
 			redirectInstructions,
 			isRenewal,
-			isPlanAndDomainPurchase,
 			productName,
 			translate,
 			reduxDispatch,
@@ -348,7 +342,6 @@ function useRedirectOnTransactionSuccess( {
 		finalReceiptId,
 		isReceiptLoaded,
 		isRenewal,
-		isPlanAndDomainPurchase,
 		blogId,
 		orderId,
 		productName,
@@ -375,14 +368,12 @@ function isTransactionSuccessful(
 function triggerPostRedirectNotices( {
 	redirectInstructions,
 	isRenewal,
-	isPlanAndDomainPurchase,
 	productName,
 	translate,
 	reduxDispatch,
 }: {
 	redirectInstructions: RedirectInstructions;
 	isRenewal: boolean;
-	isPlanAndDomainPurchase: boolean;
 	productName: string;
 	translate: ReturnType< typeof useTranslate >;
 	reduxDispatch: CalypsoDispatch;
@@ -415,20 +406,6 @@ function triggerPostRedirectNotices( {
 			translate,
 			reduxDispatch,
 		} );
-		return;
-	}
-
-	if ( isPlanAndDomainPurchase ) {
-		// The `domain-and-plan` flow sets `redirect_to=/home/<site>`, sending users
-		// to their site home instead of the thank-you page. Surface a success toast
-		// there so the purchase is acknowledged.
-		reduxDispatch(
-			successNotice( translate( 'Your plan and domain are ready!' ), {
-				id: 'plan-and-domain-purchase-success',
-				displayOnNextPage: true,
-				duration: 10000,
-			} )
-		);
 		return;
 	}
 }

--- a/client/my-sites/checkout/checkout-thank-you/purchase-notice-constants.ts
+++ b/client/my-sites/checkout/checkout-thank-you/purchase-notice-constants.ts
@@ -1,0 +1,22 @@
+/**
+ * Constants for tagging post-checkout redirect URLs with a marker that tells
+ * the destination page to dispatch a success toast on arrival.
+ *
+ * Sources:
+ * - `checkout-thank-you/pending/index.tsx` appends `?<KEY>=<VALUE>` to the
+ *   redirect URL when the receipt matches a known purchase shape.
+ * - The destination (e.g. `customer-home/main.tsx`) reads the param, dispatches
+ *   the toast, and strips the param via `history.replaceState`.
+ *
+ * Kept in its own module so that destinations can pull in the constants
+ * without transitively importing the pending page's heavy dependency graph
+ * (page.js, shopping-cart hooks, calypso-products, etc.) — which can break
+ * unrelated unit-test environments.
+ */
+export const PURCHASE_NOTICE_QUERY_KEY = 'notice';
+export const PLAN_AND_DOMAIN_NOTICE_QUERY_VALUE = 'plan-and-domain';
+
+export function appendNoticeQueryParam( url: string, value: string ): string {
+	const separator = url.includes( '?' ) ? '&' : '?';
+	return `${ url }${ separator }${ PURCHASE_NOTICE_QUERY_KEY }=${ value }`;
+}

--- a/client/my-sites/checkout/src/hooks/use-create-payment-submitted-and-processing-callback.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-submitted-and-processing-callback.tsx
@@ -1,14 +1,9 @@
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { isURL } from '@wordpress/url';
 import debugFactory from 'debug';
-import { translate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { recordPurchase } from 'calypso/lib/analytics/record-purchase';
-import {
-	hasDomainRegistration,
-	hasEcommercePlan,
-	hasPlan,
-} from 'calypso/lib/cart-values/cart-items';
+import { hasEcommercePlan } from 'calypso/lib/cart-values/cart-items';
 import getThankYouPageUrl from 'calypso/my-sites/checkout/get-thank-you-page-url';
 import useSiteDomains from 'calypso/my-sites/checkout/src/hooks/use-site-domains';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
@@ -17,7 +12,6 @@ import {
 	clearSignupDestinationCookie,
 } from 'calypso/signup/storageUtils';
 import { useSelector, useDispatch } from 'calypso/state';
-import { successNotice } from 'calypso/state/notices/actions';
 import { clearPurchases } from 'calypso/state/purchases/actions';
 import { fetchReceiptCompleted } from 'calypso/state/receipts/actions';
 import hasGravatarDomainQueryParam from 'calypso/state/selectors/has-gravatar-domain-query-param';
@@ -202,22 +196,6 @@ export default function useCreatePaymentSubmittedAndProcessingCallback( {
 			) {
 				debug( 'fetching receipt' );
 				reduxDispatch( fetchReceiptCompleted( receiptId, transactionResult ) );
-			}
-
-			// When the cart includes both a plan and a domain registration, the user is
-			// typically redirected back to their site home (via `redirect_to`) instead of
-			// the thank-you page. Surface a success toast so the purchase is acknowledged
-			// wherever they land. `isPersistent: true` keeps the notice through the
-			// multiple route changes between here and the destination; `duration` makes
-			// it auto-dismiss.
-			if ( hasPlan( responseCart ) && hasDomainRegistration( responseCart ) ) {
-				reduxDispatch(
-					successNotice( translate( 'Your plan and domain are ready!' ), {
-						id: 'plan-and-domain-purchase-success',
-						isPersistent: true,
-						duration: 10000,
-					} )
-				);
 			}
 
 			if ( siteId ) {

--- a/client/my-sites/checkout/src/hooks/use-create-payment-submitted-and-processing-callback.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-submitted-and-processing-callback.tsx
@@ -1,9 +1,14 @@
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { isURL } from '@wordpress/url';
 import debugFactory from 'debug';
+import { translate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { recordPurchase } from 'calypso/lib/analytics/record-purchase';
-import { hasEcommercePlan } from 'calypso/lib/cart-values/cart-items';
+import {
+	hasDomainRegistration,
+	hasEcommercePlan,
+	hasPlan,
+} from 'calypso/lib/cart-values/cart-items';
 import getThankYouPageUrl from 'calypso/my-sites/checkout/get-thank-you-page-url';
 import useSiteDomains from 'calypso/my-sites/checkout/src/hooks/use-site-domains';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
@@ -12,6 +17,7 @@ import {
 	clearSignupDestinationCookie,
 } from 'calypso/signup/storageUtils';
 import { useSelector, useDispatch } from 'calypso/state';
+import { successNotice } from 'calypso/state/notices/actions';
 import { clearPurchases } from 'calypso/state/purchases/actions';
 import { fetchReceiptCompleted } from 'calypso/state/receipts/actions';
 import hasGravatarDomainQueryParam from 'calypso/state/selectors/has-gravatar-domain-query-param';
@@ -196,6 +202,22 @@ export default function useCreatePaymentSubmittedAndProcessingCallback( {
 			) {
 				debug( 'fetching receipt' );
 				reduxDispatch( fetchReceiptCompleted( receiptId, transactionResult ) );
+			}
+
+			// When the cart includes both a plan and a domain registration, the user is
+			// typically redirected back to their site home (via `redirect_to`) instead of
+			// the thank-you page. Surface a success toast so the purchase is acknowledged
+			// wherever they land. `isPersistent: true` keeps the notice through the
+			// multiple route changes between here and the destination; `duration` makes
+			// it auto-dismiss.
+			if ( hasPlan( responseCart ) && hasDomainRegistration( responseCart ) ) {
+				reduxDispatch(
+					successNotice( translate( 'Your plan and domain are ready!' ), {
+						id: 'plan-and-domain-purchase-success',
+						isPersistent: true,
+						duration: 10000,
+					} )
+				);
 			}
 
 			if ( siteId ) {

--- a/client/my-sites/checkout/src/hooks/use-create-payment-submitted-and-processing-callback.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-submitted-and-processing-callback.tsx
@@ -1,9 +1,14 @@
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { isURL } from '@wordpress/url';
 import debugFactory from 'debug';
+import { translate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { recordPurchase } from 'calypso/lib/analytics/record-purchase';
-import { hasEcommercePlan } from 'calypso/lib/cart-values/cart-items';
+import {
+	hasDomainRegistration,
+	hasEcommercePlan,
+	hasPlan,
+} from 'calypso/lib/cart-values/cart-items';
 import getThankYouPageUrl from 'calypso/my-sites/checkout/get-thank-you-page-url';
 import useSiteDomains from 'calypso/my-sites/checkout/src/hooks/use-site-domains';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
@@ -12,6 +17,7 @@ import {
 	clearSignupDestinationCookie,
 } from 'calypso/signup/storageUtils';
 import { useSelector, useDispatch } from 'calypso/state';
+import { successNotice } from 'calypso/state/notices/actions';
 import { clearPurchases } from 'calypso/state/purchases/actions';
 import { fetchReceiptCompleted } from 'calypso/state/receipts/actions';
 import hasGravatarDomainQueryParam from 'calypso/state/selectors/has-gravatar-domain-query-param';
@@ -196,6 +202,19 @@ export default function useCreatePaymentSubmittedAndProcessingCallback( {
 			) {
 				debug( 'fetching receipt' );
 				reduxDispatch( fetchReceiptCompleted( receiptId, transactionResult ) );
+			}
+
+			// When the cart includes both a plan and a domain registration, the user is
+			// typically redirected back to their site home (via `redirect_to`) instead of
+			// the thank-you page. Surface a success toast so the purchase is acknowledged
+			// wherever they land.
+			if ( hasPlan( responseCart ) && hasDomainRegistration( responseCart ) ) {
+				reduxDispatch(
+					successNotice( translate( 'Your plan and domain are ready!' ), {
+						id: 'plan-and-domain-purchase-success',
+						duration: 10000,
+					} )
+				);
 			}
 
 			if ( siteId ) {

--- a/client/my-sites/checkout/src/hooks/use-create-payment-submitted-and-processing-callback.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-submitted-and-processing-callback.tsx
@@ -1,14 +1,9 @@
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { isURL } from '@wordpress/url';
 import debugFactory from 'debug';
-import { translate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { recordPurchase } from 'calypso/lib/analytics/record-purchase';
-import {
-	hasDomainRegistration,
-	hasEcommercePlan,
-	hasPlan,
-} from 'calypso/lib/cart-values/cart-items';
+import { hasEcommercePlan } from 'calypso/lib/cart-values/cart-items';
 import getThankYouPageUrl from 'calypso/my-sites/checkout/get-thank-you-page-url';
 import useSiteDomains from 'calypso/my-sites/checkout/src/hooks/use-site-domains';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
@@ -17,7 +12,6 @@ import {
 	clearSignupDestinationCookie,
 } from 'calypso/signup/storageUtils';
 import { useSelector, useDispatch } from 'calypso/state';
-import { successNotice } from 'calypso/state/notices/actions';
 import { clearPurchases } from 'calypso/state/purchases/actions';
 import { fetchReceiptCompleted } from 'calypso/state/receipts/actions';
 import hasGravatarDomainQueryParam from 'calypso/state/selectors/has-gravatar-domain-query-param';
@@ -202,19 +196,6 @@ export default function useCreatePaymentSubmittedAndProcessingCallback( {
 			) {
 				debug( 'fetching receipt' );
 				reduxDispatch( fetchReceiptCompleted( receiptId, transactionResult ) );
-			}
-
-			// When the cart includes both a plan and a domain registration, the user is
-			// typically redirected back to their site home (via `redirect_to`) instead of
-			// the thank-you page. Surface a success toast so the purchase is acknowledged
-			// wherever they land.
-			if ( hasPlan( responseCart ) && hasDomainRegistration( responseCart ) ) {
-				reduxDispatch(
-					successNotice( translate( 'Your plan and domain are ready!' ), {
-						id: 'plan-and-domain-purchase-success',
-						duration: 10000,
-					} )
-				);
 			}
 
 			if ( siteId ) {

--- a/client/my-sites/customer-home/main.tsx
+++ b/client/my-sites/customer-home/main.tsx
@@ -6,7 +6,7 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import {
 	PLAN_AND_DOMAIN_NOTICE_QUERY_VALUE,
 	PURCHASE_NOTICE_QUERY_KEY,
-} from 'calypso/my-sites/checkout/checkout-thank-you/pending';
+} from 'calypso/my-sites/checkout/checkout-thank-you/purchase-notice-constants';
 import { useDispatch } from 'calypso/state';
 import { successNotice } from 'calypso/state/notices/actions';
 import HomeContent from './components/home-content';

--- a/client/my-sites/customer-home/main.tsx
+++ b/client/my-sites/customer-home/main.tsx
@@ -1,12 +1,52 @@
 import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import {
+	PLAN_AND_DOMAIN_NOTICE_QUERY_VALUE,
+	PURCHASE_NOTICE_QUERY_KEY,
+} from 'calypso/my-sites/checkout/checkout-thank-you/pending';
+import { useDispatch } from 'calypso/state';
+import { successNotice } from 'calypso/state/notices/actions';
 import HomeContent from './components/home-content';
 import type { SiteDetails } from '@automattic/data-stores';
 
+/**
+ * Pending checkout pages (`checkout-thank-you/pending`) tag certain redirect
+ * URLs with `?notice=<value>` so the destination can show a post-purchase
+ * success toast on arrival. Read the param, dispatch the matching notice once,
+ * then strip it from the URL so a refresh doesn't re-fire.
+ */
+function usePostPurchaseNotice(): void {
+	const reduxDispatch = useDispatch();
+	const translate = useTranslate();
+
+	useEffect( () => {
+		const params = new URLSearchParams( window.location.search );
+		if ( params.get( PURCHASE_NOTICE_QUERY_KEY ) !== PLAN_AND_DOMAIN_NOTICE_QUERY_VALUE ) {
+			return;
+		}
+
+		reduxDispatch(
+			successNotice( translate( 'Your plan and domain are ready!' ), {
+				id: 'plan-and-domain-purchase-success',
+				duration: 10000,
+			} )
+		);
+
+		params.delete( PURCHASE_NOTICE_QUERY_KEY );
+		const newSearch = params.toString();
+		const newUrl =
+			window.location.pathname + ( newSearch ? `?${ newSearch }` : '' ) + window.location.hash;
+		window.history.replaceState( window.history.state, '', newUrl );
+	}, [ reduxDispatch, translate ] );
+}
+
 export default function CustomerHome( { site }: { site: SiteDetails } ) {
 	const translate = useTranslate();
+
+	usePostPurchaseNotice();
 
 	return (
 		<Main wideLayout>

--- a/packages/api-core/src/me-billing-history/types.ts
+++ b/packages/api-core/src/me-billing-history/types.ts
@@ -79,6 +79,8 @@ export interface ReceiptItem {
 	introductory_offer_terms: IntroductoryOfferTerms | null;
 	price_tier_slug: string;
 	saas_redirect_url: string;
+	is_plan: boolean;
+	is_domain_registration: boolean;
 }
 
 export interface Receipt {


### PR DESCRIPTION
## Summary

When a user buys both a plan and a domain registration in a single checkout, the `domain-and-plan` flow sets `redirect_to=/home/<site>`, so after a successful purchase the user lands on their site home rather than the thank-you page. Without any acknowledgement on the destination, the purchase can feel silent.

This PR adds a green success toast — **"Your plan and domain are ready!"** — that appears **only on the destination page (`/home/<site>`)**, not on the intermediate `checkout-thank-you/pending` loading screen.

This replaces an earlier prototype on this branch that introduced a dedicated celebratory thank-you screen (`PlanAndDomainThankYou`). After product discussion in p1779896970935009/1778516227.181149-slack-C097SQTJV9S we decided a toast is the lighter, lower-risk treatment for this case and avoids overriding the user's `redirect_to` context.

## Approach

Calypso's notice renderer (`client/components/global-notices/index.jsx`) shows every notice in Redux state without filtering by `displayOnNextPage` — that flag only controls whether a notice **survives** a `ROUTE_SET`, not whether it's **hidden** on the dispatching page. Dispatching from the pending page (or the post-payment callback) caused the toast to appear during the pending loading screen, which is the wrong moment UX-wise.

To get "show only on the destination" cleanly, the toast is communicated via a URL query param rather than Redux state:

1. **`checkout-thank-you/pending/index.tsx`** detects plan + domain registration purchases from the Redux receipts state (`getReceiptById(state, finalReceiptId).data?.purchases`, populated by the callback's `fetchReceiptCompleted` before navigation). When that's the case, it appends `?notice=plan-and-domain` to the destination URL before calling `notifyAndPerformRedirect`. Two constants (`PURCHASE_NOTICE_QUERY_KEY`, `PLAN_AND_DOMAIN_NOTICE_QUERY_VALUE`) are exported so the consumer can stay in sync.

2. **`customer-home/main.tsx`** uses a new `usePostPurchaseNotice` hook that, on mount, reads the param from `window.location.search`, dispatches `successNotice` (`duration: 10000`), and strips the param via `history.replaceState` so a refresh doesn't re-fire it.

## Changes

- `client/my-sites/checkout/checkout-thank-you/pending/index.tsx`:
  - Detect plan + domain purchases via the Redux receipts state and the camelCase `ReceiptPurchase[]` shape that `isPlan` / `isDomainRegistration` from `@automattic/calypso-products` actually understand.
  - When detected, append `?notice=plan-and-domain` to `redirectInstructions.url` before `notifyAndPerformRedirect`.
  - Export `PURCHASE_NOTICE_QUERY_KEY` and `PLAN_AND_DOMAIN_NOTICE_QUERY_VALUE` for the destination handler.
- `client/my-sites/customer-home/main.tsx`:
  - New `usePostPurchaseNotice` hook reads the param, dispatches the success toast, and clears the param via `history.replaceState`.

<img width="1509" height="826" alt="success-toast-screenshot" src="https://github.com/user-attachments/assets/73807338-da7a-42c4-94b6-2bca79b80a1c" />


## How to test

1. Check out the branch, run `yarn` and `yarn start`, and sign in as an existing user with a site that does not yet have a paid plan.
2. Visit `/setup/domain-and-plan/domains?siteSlug=<your-site>`.
3. Select a domain, add a plan, and complete checkout ('assign a payment method later' is the simplest path).
4. After payment, confirm you land on `/home/<site>` and a green success toast reading **"Your plan and domain are ready!"** appears, auto-dismissing after ~10s. The toast should NOT appear during the pending loading screen.
5. Confirm the `?notice=plan-and-domain` query param has been stripped from the URL.
6. Refresh `/home/<site>` and confirm the toast does NOT re-fire.
7. Repeat checkout with **only a plan** (e.g. `/checkout/<site>/premium`) — no toast should appear and the URL should have no `notice` param.
8. Repeat with **only a domain** — no toast should appear and the URL should have no `notice` param.

## Notes for reviewers

- Earlier WIP on this branch added a `PlanAndDomainThankYou` page, modifications to `CheckoutThankYou`, and a `redirect_to` override in `getThankYouPageUrl`. Those were all reverted; this PR is now a focused two-file change. (TeamCity's previously-failing "Code style" and "Unit tests" jobs were caused by that prototype code and should clear on this push.)
- The hook is on `CustomerHome` because `/home/<site>` is the default destination for the `domain-and-plan` flow. If a user has a non-default `redirect_to` (e.g. `back_to` set to something else) that bypasses CustomerHome, the toast won't fire. Acceptable fallback — silently skipping the toast is better than showing it at the wrong time, and we can mount the hook in additional destinations later if needed.
- Detection in the pending page reads from Redux receipts state, which is populated by the post-payment callback's `fetchReceiptCompleted` before navigation. Redirect-based payment methods (PayPal, Bancontact, some 3DS) don't go through that callback, so for those flows the param won't be appended and the toast won't fire. Same acceptable-fallback reasoning.
- One known edge case: Calypso's "Sympathy" dev simulator (`client/components/sympathy-dev-warning/index.tsx`) randomly wipes persisted Redux state in dev builds. Our query-param signal is independent of Redux, so the destination still fires the toast correctly. The detection in the pending page does read Redux receipts state, which is in-memory (not persisted), so a wipe between the callback's `fetchReceiptCompleted` and the pending page mounting would skip the toast for that purchase. Rare race, easy to harden later by switching detection to the TanStack-Query receipt items if it matters.

## Checklist

- [ ] Visual changes match the expected design
- [ ] No console errors introduced
- [ ] Tested with different user roles (if applicable)