### PR TITLE
Onboarding plans: redirect free plan selections to the choose page (re-land)

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -70,9 +70,8 @@ const onboarding: FlowV2< typeof initialize > = {
 			setHideFreePlan,
 		} = useDispatch( ONBOARD_STORE ) as OnboardActions;
 		const locale = useFlowLocale();
-		const { signupDomainOrigin, planCartItem, blueprint } = useSelect(
+		const { planCartItem, blueprint } = useSelect(
 			( select ) => ( {
-				signupDomainOrigin: ( select( ONBOARD_STORE ) as OnboardSelect ).getSignupDomainOrigin(),
 				planCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getPlanCartItem(),
 				blueprint: ( select( ONBOARD_STORE ) as OnboardSelect ).getBlueprint(),
 			} ),
@@ -194,15 +193,14 @@ const onboarding: FlowV2< typeof initialize > = {
 					setPlanCartItem( pickedPlan );
 
 					if ( ! pickedPlan ) {
-						// Since we're removing the paid domain, it means that the user chose to continue
-						// with a free domain. Because signupDomainOrigin should reflect the last domain
-						// selection status before they land on the checkout page, this value can be
-						// 'free' or 'choose-later'
-						if ( signupDomainOrigin === 'choose-later' ) {
-							setSignupDomainOrigin( signupDomainOrigin );
-						} else {
-							setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.FREE );
-						}
+						// Redirect free plan selections to the choose page for the PWYW A/B test.
+						// `/choose` is a WordPress.com PHP route, not a Calypso route, so we need an
+						// absolute URL — a relative path resolves to the current Calypso host (e.g.
+						// wpcalypso.wordpress.com/choose) and 404s on pre-release. See TESTOPS-106.
+						window.location.assign(
+							addQueryArgs( 'https://wordpress.com/choose', getQueryArgs( window.location.href ) )
+						);
+						return;
 					}
 
 					// Make sure to put the rest of products into the cart, e.g. the storage add-ons.

--- a/test/e2e/specs/onboarding/onboarding__write.ts
+++ b/test/e2e/specs/onboarding/onboarding__write.ts
@@ -62,7 +62,7 @@ describe( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), function () 
 			// https://wordpress.com/choose for the PWYW A/B test instead of
 			// creating a site directly. No /sites/new call is made here, so we
 			// use selectPlanWithoutSiteCreation.
-			const redirectUrl = /wordpress\.com\/choose/;
+			const redirectUrl = /^https:\/\/wordpress\.com\/choose(?:[?#]|$)/;
 			await signupPickPlanPage.selectPlanWithoutSiteCreation( 'Free', redirectUrl );
 		} );
 	} );

--- a/test/e2e/specs/onboarding/onboarding__write.ts
+++ b/test/e2e/specs/onboarding/onboarding__write.ts
@@ -7,6 +7,7 @@ import {
 	StartSiteFlow,
 	RestAPIClient,
 	SignupPickPlanPage,
+	NewSiteResponse,
 	NewUserResponse,
 	LoginPage,
 	UserSignupPage,
@@ -14,7 +15,7 @@ import {
 	DomainSearchComponent,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
-import { apiCloseAccount, fixme_retry } from '../shared';
+import { apiCloseAccount, apiCreateFreeSiteForUser, apiDeleteSite, fixme_retry } from '../shared';
 
 declare const browser: Browser;
 
@@ -25,8 +26,8 @@ describe( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), function () 
 	} );
 
 	let newUserDetails: NewUserResponse;
+	let newSiteDetails: NewSiteResponse;
 	let page: Page;
-	let selectedFreeDomain: string;
 
 	beforeAll( async function () {
 		page = await browser.newPage();
@@ -52,29 +53,45 @@ describe( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), function () 
 		it( 'Select a .wordpress.com domain name', async function () {
 			const domainSearchComponent = new DomainSearchComponent( page );
 			await domainSearchComponent.search( blogName );
-			selectedFreeDomain = await domainSearchComponent.skipPurchase();
+			await domainSearchComponent.skipPurchase();
 		} );
 
 		it( 'Select WordPress.com Free plan', async function () {
 			const signupPickPlanPage = new SignupPickPlanPage( page );
-			const redirectUrl = new RegExp( 'home/.+\\?ref=onboarding' );
-			await signupPickPlanPage.selectPlan( 'Free', redirectUrl );
+			// After this PR, picking Free on /setup/onboarding/plans redirects to
+			// https://wordpress.com/choose for the PWYW A/B test instead of
+			// creating a site directly. No /sites/new call is made here, so we
+			// use selectPlanWithoutSiteCreation.
+			const redirectUrl = /wordpress\.com\/choose/;
+			await signupPickPlanPage.selectPlanWithoutSiteCreation( 'Free', redirectUrl );
 		} );
 	} );
 
+	// Picking Free now redirects to https://wordpress.com/choose for the PWYW
+	// A/B test instead of creating a site, so the original UI path into the
+	// onboarding/write/launchpad flow is no longer reachable. To preserve
+	// downstream coverage, this block API-creates a free site and navigates
+	// directly into /home with the onboarding ref before continuing.
 	describe( 'Onboarding', function () {
 		const themeName = 'Retrospect';
 		let startSiteFlow: StartSiteFlow;
 
 		beforeAll( async function () {
 			startSiteFlow = new StartSiteFlow( page );
+
+			newSiteDetails = await apiCreateFreeSiteForUser( testUser, newUserDetails, blogName );
+			await page.goto(
+				DataHelper.getCalypsoURL(
+					`/home/${ newSiteDetails.blog_details.site_slug }?ref=onboarding`
+				)
+			);
 		} );
 
 		it( 'Enter Onboarding flow for the selected domain', async function () {
 			await page.waitForURL( /home\/.*ref=onboarding/, { timeout: 60 * 1000 } );
 
-			// Additional assertions for the URL.
-			expect( page.url() ).toContain( selectedFreeDomain );
+			// Assert we're on the home view for the API-created site.
+			expect( page.url() ).toContain( newSiteDetails.blog_details.site_slug );
 		} );
 
 		it( 'Select "Publish a blog" goal', async function () {
@@ -189,6 +206,14 @@ describe( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), function () 
 			{ username: testUser.username, password: testUser.password },
 			newUserDetails.body.bearer_token
 		);
+
+		if ( newSiteDetails ) {
+			await apiDeleteSite( restAPIClient, {
+				url: newSiteDetails.blog_details.url,
+				id: newSiteDetails.blog_details.blogid,
+				name: newSiteDetails.blog_details.blogname,
+			} );
+		}
 
 		await apiCloseAccount( restAPIClient, {
 			userID: newUserDetails.body.user_id,


### PR DESCRIPTION
## Proposed Changes

* Re-lands the change reverted in #110924 (originally #110877 / #110916).
* When a user clicks **Start with Free** (or the deemphasized **start with our free plan** subheader link) on `/setup/onboarding/plans`, redirect them to the choose page instead of continuing through site creation.
* **Why the previous attempts broke pre-release:**
  * #110877 (first attempt): used a relative path. Pre-release resolved it to the Calypso host and 404'd.
  * #110916 (second attempt): used an absolute URL, but tests piggybacking on the UI Free-plan flow asserted the old `/home/...` landing and broke. See TESTOPS-106.
* **Fixes both this time:**
  * Calypso side: absolute `https://wordpress.com/choose` URL so it works in pre-release too.
  * Test side: Lance's #110925 already decoupled the piggyback specs (`launch-site__wp-admin`, `start-launch-site`, `setup-domain`). This PR keeps `onboarding__write.ts` working end-to-end: the Free-plan step asserts the `wordpress.com/choose` redirect, then the Onboarding describe API-creates a site and navigates into `/home` directly so the downstream goal/theme/write/launchpad coverage is preserved.

## Why are these changes being made?

* Following Aaron's recommendation.
* The A/B bucketing happens on the choose page itself, so we just need to route free-plan clicks there.

## Testing Instructions

* Visit `/setup/onboarding/plans` (after the domain step).
* Click **Start with Free**. Verify you land on the choose page (absolute URL), and that query args from the current URL are preserved.
* Click any paid plan card. Verify the regular checkout flow still works.
* On pre-release, verify the redirect goes to the production choose page, not a Calypso-host equivalent.
* E2E: run `onboarding__write.ts` against a local Calypso build and verify it passes with the new redirect assertion and API-based site creation.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed?
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?