### PR TITLE
Reader: link to new Social support doc from connection surfaces

### DIFF
--- a/client/reader/atmosphere/atmosphere-connect-view.tsx
+++ b/client/reader/atmosphere/atmosphere-connect-view.tsx
@@ -1,6 +1,7 @@
 import { useCreateConnectionMutation } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
-import { __experimentalVStack as VStack } from '@wordpress/components';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { ExternalLink, __experimentalVStack as VStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import NavigationHeader from 'calypso/components/navigation-header';
@@ -44,6 +45,11 @@ export function AtmosphereConnectView() {
 					error={ create.error ?? null }
 					onSubmit={ handleSubmit }
 				/>
+				<p className="atmosphere-view__learn-more">
+					<ExternalLink href={ localizeUrl( 'https://wordpress.com/support/reader/social/' ) }>
+						{ translate( 'Learn more about social in the Reader' ) }
+					</ExternalLink>
+				</p>
 			</VStack>
 		</ReaderMain>
 	);

--- a/client/reader/atmosphere/atmosphere-connect-view.tsx
+++ b/client/reader/atmosphere/atmosphere-connect-view.tsx
@@ -47,7 +47,7 @@ export function AtmosphereConnectView() {
 				/>
 				<p className="atmosphere-view__learn-more">
 					<ExternalLink href={ localizeUrl( 'https://wordpress.com/support/reader/social/' ) }>
-						{ translate( 'Learn more about social in the Reader' ) }
+						{ translate( 'Learn more about your social accounts in the Reader' ) }
 					</ExternalLink>
 				</p>
 			</VStack>

--- a/client/reader/connections/connections-new-view.tsx
+++ b/client/reader/connections/connections-new-view.tsx
@@ -59,8 +59,8 @@ export function ConnectionsNewView() {
 	);
 
 	const fediverseDocHref = localizeUrl( 'https://wordpress.com/support/enter-the-fediverse/' );
-	const blueskyDocHref = localizeUrl( 'https://wordpress.com/support/reader/' );
-	const mastodonDocHref = localizeUrl( 'https://wordpress.com/support/reader/' );
+	const blueskyDocHref = localizeUrl( 'https://wordpress.com/support/reader/social/' );
+	const mastodonDocHref = localizeUrl( 'https://wordpress.com/support/reader/social/' );
 	const learnMoreLabel = String( translate( 'Learn more' ) );
 
 	const fediverse: ProtocolOption = ( () => {

--- a/client/reader/connections/social-overview-view.tsx
+++ b/client/reader/connections/social-overview-view.tsx
@@ -242,7 +242,7 @@ export function SocialOverviewView() {
 					</Button>
 					<p className="social-empty__learn-more">
 						<ExternalLink href={ localizeUrl( 'https://wordpress.com/support/reader/social/' ) }>
-							{ translate( 'Learn more about social in the Reader' ) }
+							{ translate( 'Learn more about your social accounts in the Reader' ) }
 						</ExternalLink>
 					</p>
 				</Card>

--- a/client/reader/connections/social-overview-view.tsx
+++ b/client/reader/connections/social-overview-view.tsx
@@ -5,7 +5,8 @@ import {
 	useMastodonConnectionQuery,
 	useMastodonConnectionsQuery,
 } from '@automattic/api-queries';
-import { Button, Card, Spinner } from '@wordpress/components';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { Button, Card, ExternalLink, Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -239,6 +240,11 @@ export function SocialOverviewView() {
 					<Button variant="primary" href="/reader/connections/new">
 						{ translate( 'Pick a network →' ) }
 					</Button>
+					<p className="social-empty__learn-more">
+						<ExternalLink href={ localizeUrl( 'https://wordpress.com/support/reader/social/' ) }>
+							{ translate( 'Learn more about social in the Reader' ) }
+						</ExternalLink>
+					</p>
 				</Card>
 			) }
 

--- a/client/reader/mastodon/mastodon-connect-view.tsx
+++ b/client/reader/mastodon/mastodon-connect-view.tsx
@@ -111,7 +111,7 @@ export function MastodonConnectView() {
 				) : null }
 				<p className="mastodon-view__learn-more">
 					<ExternalLink href={ localizeUrl( 'https://wordpress.com/support/reader/social/' ) }>
-						{ translate( 'Learn more about social in the Reader' ) }
+						{ translate( 'Learn more about your social accounts in the Reader' ) }
 					</ExternalLink>
 				</p>
 			</VStack>

--- a/client/reader/mastodon/mastodon-connect-view.tsx
+++ b/client/reader/mastodon/mastodon-connect-view.tsx
@@ -1,5 +1,6 @@
 import { useAuthorizeMastodonConnectionMutation } from '@automattic/api-queries';
-import { __experimentalVStack as VStack } from '@wordpress/components';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { ExternalLink, __experimentalVStack as VStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -108,6 +109,11 @@ export function MastodonConnectView() {
 						) }
 					</p>
 				) : null }
+				<p className="mastodon-view__learn-more">
+					<ExternalLink href={ localizeUrl( 'https://wordpress.com/support/reader/social/' ) }>
+						{ translate( 'Learn more about social in the Reader' ) }
+					</ExternalLink>
+				</p>
 			</VStack>
 		</ReaderMain>
 	);

--- a/client/reader/sidebar/reader-sidebar-connections/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-connections/index.tsx
@@ -4,6 +4,8 @@ import {
 	useMastodonConnectionsQuery,
 } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { ExternalLink } from '@wordpress/components';
 import { Icon, people } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo, useState } from 'react';
@@ -280,6 +282,13 @@ function ReaderSidebarConnections( { path }: Props ) {
 					href={ NEW_CONNECTION_PATH }
 					onClick={ recordAddAccountClick }
 				/>
+				{ showEmptyHint && (
+					<li className="sidebar-connections__empty">
+						<ExternalLink href={ localizeUrl( 'https://wordpress.com/support/reader/social/' ) }>
+							{ translate( 'Learn more about social in the Reader' ) }
+						</ExternalLink>
+					</li>
+				) }
 			</ExpandableSidebarMenu>
 		</li>
 	);

--- a/client/reader/sidebar/reader-sidebar-connections/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-connections/index.tsx
@@ -285,7 +285,7 @@ function ReaderSidebarConnections( { path }: Props ) {
 				{ showEmptyHint && (
 					<li className="sidebar-connections__empty">
 						<ExternalLink href={ localizeUrl( 'https://wordpress.com/support/reader/social/' ) }>
-							{ translate( 'Learn more about social in the Reader' ) }
+							{ translate( 'Learn more about your social accounts in the Reader' ) }
 						</ExternalLink>
 					</li>
 				) }


### PR DESCRIPTION
Fixes CM-772

## Proposed Changes

* Repoint the existing Bluesky and Mastodon "Learn more" links on the `/reader/connections/new` chooser from the generic `support/reader/` to the new dedicated `support/reader/social/` doc.
* Add the same "Learn more about social in the Reader" link in four more places where users land before they're set up:
  * the `/reader/connections` overview empty state (below the "Pick a network →" button),
  * the `/reader/atmosphere/connect` (Bluesky) form,
  * the `/reader/mastodon/connect` form,
  * the sidebar's Social section, gated on `showEmptyHint` so it only renders when the user has zero connections.

The Fediverse card on the chooser keeps its existing `support/enter-the-fediverse/` link — that doc is a better fit for the WordPress-site-led ActivityPub flow than the new Social doc.

## Why are these changes being made?

A dedicated support doc for the Reader Social feature is now live at `wordpress.com/support/reader/social/`. Linking to it from the connection surfaces gives users a clear path to documentation right when they're discovering or connecting an account.

## Testing Instructions

* Sign in to a Calypso build and visit `/reader/connections/new`. Click "Learn more" on the Bluesky card and confirm it opens `wordpress.com/support/reader/social/` (localized). Repeat for the Mastodon card.
* With zero social connections, visit `/reader/connections`. Confirm the empty-state card renders the new "Learn more about social in the Reader" link below the "Pick a network →" button, and that it opens the new doc.
* Visit `/reader/atmosphere/connect` and `/reader/mastodon/connect`. Confirm the new "Learn more" link renders below each connect form.
* With zero social connections, expand the sidebar's Social section. Confirm the new "Learn more" link appears below "Add account". Connect any social account and confirm the link disappears once at least one connection exists.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?