### PR TITLE
APM: Use site locale for ms values in response time breakdown chart

### DIFF
--- a/client/dashboard/sites/performance/backend/overview/chart-slot.tsx
+++ b/client/dashboard/sites/performance/backend/overview/chart-slot.tsx
@@ -32,11 +32,11 @@ function toSeriesData( timeseries: ApmTimePoint[] ): SeriesData[] {
 	} ) );
 }
 
-function formatMsValue( value: number ): string {
+function formatMsValue( value: number, locale: string ): string {
 	return sprintf(
 		/* translators: %s is a formatted number of milliseconds, e.g. 2,500 */
 		__( '%s ms' ),
-		Math.round( value ).toLocaleString()
+		Math.round( value ).toLocaleString( locale )
 	);
 }
 
@@ -138,7 +138,7 @@ export default function ChartSlot( {
 														<Text style={ { whiteSpace: 'nowrap' } }>{ entry.key }</Text>
 													</HStack>
 													<Text weight={ 500 } style={ { whiteSpace: 'nowrap' } }>
-														{ formatMsValue( value ) }
+														{ formatMsValue( value, locale ) }
 													</Text>
 												</HStack>
 											);
@@ -149,7 +149,7 @@ export default function ChartSlot( {
 						} }
 						options={ {
 							axis: {
-								y: { tickFormat: ( value ) => formatMsValue( value as number ) },
+								y: { tickFormat: ( value ) => formatMsValue( value as number, locale ) },
 							},
 						} }
 					/>


### PR DESCRIPTION
Follow-up to #110898.

## Proposed Changes

* Thread the site locale (from `useLocale()`) through `formatMsValue` so `Math.round( value ).toLocaleString( locale )` formats the thousands separator using the site language instead of the browser language.
* Apply the same locale to the Y-axis `tickFormat` callback that reuses `formatMsValue`.

## Why are these changes being made?

#110898 fixed the tooltip date/time to use `useLocale()` instead of the browser locale, but `formatMsValue` (used for both tooltip values and Y-axis ticks) was still calling `toLocaleString()` with no argument. That meant the same chart could mix locales (e.g. an English-language site running in a `pt-BR` browser would format the date in English but the numbers with `pt-BR` separators). All formatted values in the chart should follow one locale.

## Testing Instructions

* Visit `/sites/<site>/performance/backend` for a site with APM data and values large enough to show thousands separators (~1,000+ ms).
* Switch the WordPress.com interface language between languages that use different group separators (e.g. English vs. Portuguese/German/French).
* Hover the chart and confirm the tooltip values and the Y-axis tick labels use the same thousand separator format as the rest of the dashboard (matching the interface language, not the browser language).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?