### PR TITLE
Reader connections: add divider between What's hot and Your accounts

### DIFF
--- a/client/reader/connections/social-spotlight-skeleton.tsx
+++ b/client/reader/connections/social-spotlight-skeleton.tsx
@@ -1,0 +1,45 @@
+import Skeleton from 'calypso/reader/components/skeleton';
+
+const PLACEHOLDER_COUNT = 4;
+
+/**
+ * Layout-stable placeholder for `<SocialSpotlight>`. Mirrors the strip's
+ * eventual layout (header band + grid of cards) so the social-grid below
+ * doesn't shift when timeline queries resolve. aria-hidden so screen
+ * readers don't announce empty boxes; surrounding live regions cover the
+ * loading state.
+ */
+export function SocialSpotlightSkeleton() {
+	return (
+		<section className="social-spotlight" aria-hidden="true">
+			<header className="social-spotlight__header">
+				<Skeleton height="14px" width="80px" />
+				<Skeleton className="social-spotlight-skeleton__subtitle" height="14px" width="60%" />
+			</header>
+			<ul className="social-spotlight__list">
+				{ Array.from( { length: PLACEHOLDER_COUNT } ).map( ( _, index ) => (
+					<li key={ index } className="social-spotlight__card social-spotlight-skeleton__card">
+						<div className="social-spotlight__link">
+							<div className="social-spotlight__card-header">
+								<Skeleton height="32px" width="32px" shape="circle" />
+								<div className="social-spotlight-skeleton__author">
+									<Skeleton height="12px" width="60%" />
+									<Skeleton height="10px" width="40%" />
+								</div>
+							</div>
+							<div className="social-spotlight-skeleton__text">
+								<Skeleton height="10px" width="100%" />
+								<Skeleton height="10px" width="95%" />
+								<Skeleton height="10px" width="70%" />
+							</div>
+							<div className="social-spotlight-skeleton__counts">
+								<Skeleton height="10px" width="40px" />
+								<Skeleton height="10px" width="40px" />
+							</div>
+						</div>
+					</li>
+				) ) }
+			</ul>
+		</section>
+	);
+}

--- a/client/reader/connections/social-spotlight.tsx
+++ b/client/reader/connections/social-spotlight.tsx
@@ -22,6 +22,7 @@ import { mapFediverseFeedItemToSocialPost } from 'calypso/reader/social/mappers/
 import { mapMastodonFeedItemToSocialPost } from 'calypso/reader/social/mappers/mastodon';
 import { useDispatch } from 'calypso/state';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import { SocialSpotlightSkeleton } from './social-spotlight-skeleton';
 import type { SocialPost } from 'calypso/reader/social/types';
 
 /**
@@ -224,11 +225,14 @@ export function SocialSpotlight( { connections }: Props ) {
 
 	const isLoading = queries.some( ( q ) => q.isPending );
 
-	// While first pages are still loading, render nothing — the Social
-	// overview's own spinner already covers the slow case, and a flash of
-	// "no posts yet" before items resolve would read as broken. Same for
-	// the steady state with no scoreable posts; the strip is opt-in noise.
-	if ( isLoading || items.length === 0 ) {
+	// While first pages load, render a layout-stable skeleton so the
+	// accounts grid below doesn't shift down when items resolve. In the
+	// steady state with no scoreable posts the strip is opt-in noise, so
+	// the section still collapses to null once loading completes.
+	if ( isLoading ) {
+		return <SocialSpotlightSkeleton />;
+	}
+	if ( items.length === 0 ) {
 		return null;
 	}
 

--- a/client/reader/connections/style.scss
+++ b/client/reader/connections/style.scss
@@ -525,3 +525,39 @@
 	color: var( --color-text-subtle );
 }
 
+.social-spotlight-skeleton__subtitle {
+	margin-block-start: 6px;
+}
+
+// The skeleton cards reuse the live card's border, padding, and protocol
+// border-top would imply a protocol we don't yet know — keep them neutral
+// while loading so the strip doesn't flash a colour stripe before
+// settling on the real cards.
+.social-spotlight-skeleton__card {
+	&:hover,
+	&:focus-within {
+		transform: none;
+		box-shadow: none;
+	}
+}
+
+.social-spotlight-skeleton__author {
+	flex: 1;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.social-spotlight-skeleton__text {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	margin-block-end: 8px;
+}
+
+.social-spotlight-skeleton__counts {
+	display: flex;
+	gap: 16px;
+}
+

--- a/client/reader/connections/style.scss
+++ b/client/reader/connections/style.scss
@@ -367,6 +367,8 @@
 
 .social-spotlight {
 	margin-block: 24px;
+	padding-block-end: 24px;
+	border-block-end: 1px solid var( --color-border-subtle );
 }
 
 .social-spotlight__header {


### PR DESCRIPTION
Fixes CM-773

## Proposed Changes

* Add a bottom border and bottom padding to the `.social-spotlight` block on the `/reader/connections` overview so the "What's hot" strip is visually separated from the social accounts grid below it.
* Render a layout-stable `SocialSpotlightSkeleton` while the per-protocol timeline queries are still pending. Previously the strip returned `null` until the first scoreable post resolved, which pushed the accounts grid down once items appeared.

## Why are these changes being made?

When the "What's hot" section appears on `/reader/connections`, it sits flush against the grid of connected accounts with only vertical margin — there's no obvious break between the two areas. The strip can also take a moment to resolve (one first-page fetch per connected network), and while it loads nothing is shown — so the accounts grid below jumps down when items arrive.

## Testing Instructions

1. Connect at least one social account (Bluesky, Mastodon, or Fediverse) that has recent posts with likes/reposts so the spotlight is eligible to render.
2. Visit `/reader/connections`.
3. While the timeline queries are still in flight, confirm a placeholder grid of 4 shimmer cards is shown under a header band, and the accounts grid below sits at its eventual position (no downward jump when items load).
4. Once items resolve, verify the real spotlight strip replaces the skeleton at the same height.
5. Verify a thin horizontal divider sits below the strip and above the accounts grid.
6. Confirm both the skeleton and the divider use the standard `--color-border-subtle` token (theme-aware, dark-mode-safe).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?