### PR TITLE
Fix wp-admin sidebar customize ordering

### DIFF
--- a/client/layout/sidebar/expandable-heading.jsx
+++ b/client/layout/sidebar/expandable-heading.jsx
@@ -19,6 +19,8 @@ const ExpandableSidebarHeading = ( {
 	hideExpandableIcon,
 	inlineText,
 	expandableIconClick,
+	prependContent,
+	appendContent,
 	...props
 } ) => {
 	const translate = useTranslate();
@@ -28,6 +30,7 @@ const ExpandableSidebarHeading = ( {
 			aria-expanded={ expanded ? 'true' : 'false' }
 			{ ...props }
 		>
+			{ prependContent }
 			{ icon && <Gridicon className="sidebar__menu-icon" icon={ icon } /> }
 			{ materialIcon && (
 				<MaterialIcon
@@ -42,6 +45,7 @@ const ExpandableSidebarHeading = ( {
 				{ undefined !== count && <Count count={ count } /> }
 				{ inlineText && <span className="sidebar__inline-text">{ inlineText }</span> }
 			</span>
+			{ appendContent }
 			{ ! hideExpandableIcon &&
 				( expandableIconClick ? (
 					<Button
@@ -79,6 +83,8 @@ ExpandableSidebarHeading.propTypes = {
 	materialIconStyle: PropTypes.string,
 	hideExpandableIcon: PropTypes.bool,
 	expandableIconClick: PropTypes.func,
+	prependContent: PropTypes.node,
+	appendContent: PropTypes.node,
 };
 
 export default ExpandableSidebarHeading;

--- a/client/layout/sidebar/expandable.jsx
+++ b/client/layout/sidebar/expandable.jsx
@@ -36,19 +36,22 @@ const offScreen = ( submenu ) => {
 	return rect.y + rect.height > window.innerHeight;
 };
 
-export const ExpandableSidebarMenu = ( {
-	className,
-	title,
-	count,
-	onClick,
-	icon,
-	materialIcon,
-	materialIconStyle,
-	customIcon,
-	children,
-	disableFlyout,
-	...props
-} ) => {
+export const ExpandableSidebarMenu = ( menuProps ) => {
+	const {
+		className,
+		title,
+		count,
+		onClick,
+		icon,
+		materialIcon,
+		materialIconStyle,
+		customIcon,
+		children,
+		disableFlyout,
+		prependContent,
+		appendContent,
+		...props
+	} = menuProps;
 	let { expanded } = props;
 	const menu = createRef(); // Needed for HoverIntent.
 	const submenu = useRef();
@@ -119,6 +122,8 @@ export const ExpandableSidebarMenu = ( {
 					materialIconStyle={ materialIconStyle }
 					expanded={ expanded }
 					menuId={ menuId }
+					prependContent={ prependContent }
+					appendContent={ appendContent }
 					{ ...props }
 				/>
 				<li
@@ -136,6 +141,7 @@ export const ExpandableSidebarMenu = ( {
 };
 
 ExpandableSidebarMenu.propTypes = {
+	className: PropTypes.string,
 	title: PropTypes.oneOfType( [ TranslatableString, PropTypes.element ] ).isRequired,
 	count: PropTypes.number,
 	onClick: PropTypes.func,
@@ -146,6 +152,9 @@ ExpandableSidebarMenu.propTypes = {
 	expanded: PropTypes.bool,
 	disableFlyout: PropTypes.bool,
 	expandableIconClick: PropTypes.func,
+	prependContent: PropTypes.node,
+	appendContent: PropTypes.node,
+	children: PropTypes.node,
 };
 
 export default ExpandableSidebarMenu;

--- a/client/my-sites/sidebar/body.jsx
+++ b/client/my-sites/sidebar/body.jsx
@@ -86,12 +86,17 @@ function MySitesSidebarUnifiedBodyContent( {
 		() => ( isAdminSidebarDevMockActive() ? getAdminSidebarDevMockGroups() : groups ),
 		[ groups ]
 	);
+	const hasCustomizablePluginsGroup = useMemo(
+		() =>
+			Array.isArray( renderGroups ) && renderGroups.some( ( group ) => group?.id === 'plugins' ),
+		[ renderGroups ]
+	);
 	const { ungroupedItems, groupedSections } = useMemo(
 		() =>
 			groupMenuItems( menuItems ?? [], renderGroups, {
-				includeEmptyGroups: customizeCtx?.isCustomizing === true,
+				includeEmptyGroups: customizeCtx?.isCustomizing === true || hasCustomizablePluginsGroup,
 			} ),
-		[ menuItems, renderGroups, customizeCtx?.isCustomizing ]
+		[ menuItems, renderGroups, customizeCtx?.isCustomizing, hasCustomizablePluginsGroup ]
 	);
 
 	const renderItem = ( item, i ) => {

--- a/client/my-sites/sidebar/customize/customize-mode.scss
+++ b/client/my-sites/sidebar/customize/customize-mode.scss
@@ -40,7 +40,8 @@ body.is-admin-sidebar-customize-mode {
 			cursor: grabbing;
 		}
 
-		.sidebar__menu-link {
+		> .sidebar__menu-link,
+		> .sidebar__menu.is-togglable > li > .sidebar__heading {
 			// The grip + more-options span live INSIDE the link (matches
 			// the public plugin's "decorate inside <a>" layout). Hover/click
 			// on the link itself starts a drag (drag-drop.ts intercepts
@@ -53,6 +54,26 @@ body.is-admin-sidebar-customize-mode {
 			transition: none;
 		}
 
+		> .sidebar__menu.is-togglable > li > .sidebar__heading {
+			display: flex;
+			align-items: center;
+		}
+
+		> .sidebar__menu.is-togglable > li > .sidebar__heading .sidebar__expandable-title {
+			flex: 1 1 auto;
+			min-width: 0;
+		}
+
+		// Reassignable expandable rows still receive Calypso's hover-intent
+		// `.hovered` class. Keep customize mode focused on drag placement,
+		// without opening the normal submenu flyout.
+		> .sidebar__menu.is-togglable.hovered {
+			.sidebar__heading::after,
+			.sidebar__expandable-content {
+				display: none !important;
+			}
+		}
+
 		// Suppress every Calypso legacy paint path. Each rule maps to a
 		// rule in `client/layout/sidebar/style.scss` that paints during
 		// hover, focus, or `.selected`:
@@ -61,11 +82,14 @@ body.is-admin-sidebar-customize-mode {
 		//   - `.sidebar__menu-link:focus` → focus paint (less common).
 		//   - `.selected .sidebar__menu-link:hover` → both at once.
 		// All four collapse to the static gray bg + idle text color.
-		.sidebar__menu-link,
-		.sidebar__menu-link:hover,
-		.sidebar__menu-link:focus,
-		&.selected .sidebar__menu-link,
-		&.selected .sidebar__menu-link:hover {
+		> .sidebar__menu-link,
+		> .sidebar__menu-link:hover,
+		> .sidebar__menu-link:focus,
+		&.selected > .sidebar__menu-link,
+		&.selected > .sidebar__menu-link:hover,
+		> .sidebar__menu.is-togglable > li > .sidebar__heading,
+		> .sidebar__menu.is-togglable > li > .sidebar__heading:hover,
+		> .sidebar__menu.is-togglable > li > .sidebar__heading:focus {
 			background-color: transparent;
 			color: var(--color-sidebar-text);
 			box-shadow: none;
@@ -75,9 +99,11 @@ body.is-admin-sidebar-customize-mode {
 		// the public plugin's `color: inherit` rule for `.wp-menu-image`).
 		// Calypso's icon is `.sidebar__menu-icon`; keep its color tied to
 		// the LI text color so it doesn't paint blue on hover/selected.
-		.sidebar__menu-link:hover .sidebar__menu-icon,
-		.sidebar__menu-link:focus .sidebar__menu-icon,
-		&.selected .sidebar__menu-link .sidebar__menu-icon {
+		> .sidebar__menu-link:hover .sidebar__menu-icon,
+		> .sidebar__menu-link:focus .sidebar__menu-icon,
+		&.selected > .sidebar__menu-link .sidebar__menu-icon,
+		> .sidebar__menu.is-togglable > li > .sidebar__heading:hover .sidebar__menu-icon,
+		> .sidebar__menu.is-togglable > li > .sidebar__heading:focus .sidebar__menu-icon {
 			fill: var(--color-sidebar-text);
 			color: var(--color-sidebar-text);
 		}
@@ -132,7 +158,7 @@ body.is-admin-sidebar-customize-mode {
 	// `<MySitesSidebarUnifiedMenu>` → `<ExpandableSidebarMenu>` renders a bare
 	// `<li>` wrapping `.sidebar__menu.is-togglable`, which the inert rule above
 	// doesn't catch. Same suppression treatment + kill the hover-intent flyout.
-	.sidebar .sidebar__menu.is-togglable {
+	.sidebar > li:not([data-wp-admin-sidebar-item-id]) .sidebar__menu.is-togglable {
 		.sidebar__menu-link,
 		.sidebar__heading {
 			pointer-events: none;

--- a/client/my-sites/sidebar/customize/dom-layout.ts
+++ b/client/my-sites/sidebar/customize/dom-layout.ts
@@ -1,0 +1,16 @@
+const NON_LAYOUT_ROW_SELECTOR = [
+	'.admin-sidebar-drop-indicator',
+	'.sidebar__region',
+	'.collapse-sidebar__toggle',
+	'.wp-admin-sidebar-group',
+].join( ',' );
+
+export function layoutRowsForContainer( container: Element ): Element[] {
+	return Array.from( container.children ).filter(
+		( child ) => child.tagName === 'LI' && ! child.matches( NON_LAYOUT_ROW_SELECTOR )
+	);
+}
+
+export function layoutIndexOf( container: Element, li: Element ): number {
+	return layoutRowsForContainer( container ).indexOf( li );
+}

--- a/client/my-sites/sidebar/customize/drag-drop.ts
+++ b/client/my-sites/sidebar/customize/drag-drop.ts
@@ -32,6 +32,7 @@
  * @see WordPress/wp-admin-sidebar v0.1.4 src/customizer/drag-drop.js
  */
 import { translate } from 'i18n-calypso';
+import { layoutIndexOf, layoutRowsForContainer } from './dom-layout';
 import { BODY_DRAGGING_CLASS } from './index';
 import type { LayoutPosition } from 'calypso/state/admin-sidebar/layout/types';
 
@@ -40,15 +41,16 @@ const INDICATOR_CLASS = 'admin-sidebar-drop-indicator';
 const SOURCE_DRAGGING_CLASS = 'is-admin-sidebar-source-dragging';
 const REASSIGNABLE_SELECTOR = 'li[data-wp-admin-sidebar-item-id]';
 const GROUP_SELECTOR = 'li.wp-admin-sidebar-group';
+const CALYPSO_ROW_SELECTOR = '.wp-admin-sidebar-group__children > li, .sidebar > li';
 // Broad drop-target selector — mirrors the public plugin's
 // `li.menu-top, li.wp-admin-sidebar-group`. Any top-level Calypso item
 // (`.sidebar__menu-item-parent` for leaf items, bare `<li>` for expandable
 // items rendered via `<MySitesSidebarUnifiedMenu>`) is a valid drop
-// neighbour even if it's not itself reassignable. `.sidebar > li` is the
-// catch-all for the expandable wrappers that don't carry the
-// `sidebar__menu-item-parent` class.
+// neighbour even if it's not itself reassignable. `.sidebar > li` and
+// `.wp-admin-sidebar-group__children > li` are the catch-alls for expandable
+// wrappers that don't carry the `sidebar__menu-item-parent` class.
 const DROP_NEIGHBOUR_SELECTOR =
-	'li[data-wp-admin-sidebar-item-id], li.sidebar__menu-item-parent, li.wp-admin-sidebar-group, .sidebar > li';
+	'li[data-wp-admin-sidebar-item-id], li.sidebar__menu-item-parent, li.wp-admin-sidebar-group, .sidebar > li, .wp-admin-sidebar-group__children > li';
 
 export interface DragDropController {
 	commitMove: ( itemId: string, position: LayoutPosition ) => void;
@@ -197,7 +199,7 @@ export function attachDragDrop( controller: DragDropController ): () => void {
 		// elements and find the actual sidebar row beneath the cursor.
 		const elements = document.elementsFromPoint( x, y );
 		for ( const el of elements ) {
-			const li = el.closest( DROP_NEIGHBOUR_SELECTOR );
+			const li = findDropNeighbour( el );
 			if ( ! li || li === activeItem?.li ) {
 				continue;
 			}
@@ -221,13 +223,14 @@ export function attachDragDrop( controller: DragDropController ): () => void {
 				const isExpanded = li.getAttribute( 'data-expanded' ) === 'true';
 				const isEmpty = childList.querySelectorAll( ':scope > li' ).length === 0;
 				if ( ! isExpanded || isEmpty ) {
+					const slot = layoutRowsForContainer( childList ).length;
 					return {
 						container: childList,
 						beforeLi: null,
 						position: {
 							kind: 'in_group',
 							group_id: groupId,
-							index: childList.children.length,
+							index: slot,
 						},
 					};
 				}
@@ -243,14 +246,17 @@ export function attachDragDrop( controller: DragDropController ): () => void {
 				continue;
 			}
 			const enclosingGroup = container.closest( GROUP_SELECTOR );
-			const baseIndex = Array.prototype.indexOf.call( container.children, li );
+			const baseIndex = layoutIndexOf( container, li );
+			if ( baseIndex === -1 ) {
+				continue;
+			}
 			let slot = above ? baseIndex : baseIndex + 1;
 			// Same-container -1 adjustment (Phase 2 row 27). When the source
 			// is in the same container at a lower index, dropping it later
 			// requires `-1` because removing the source shifts everything
 			// past its position up by one slot.
 			if ( activeItem?.li.parentElement === container ) {
-				const sourceIndex = Array.prototype.indexOf.call( container.children, activeItem.li );
+				const sourceIndex = layoutIndexOf( container, activeItem.li );
 				if ( sourceIndex !== -1 && sourceIndex < slot ) {
 					slot -= 1;
 				}
@@ -308,6 +314,13 @@ export function attachDragDrop( controller: DragDropController ): () => void {
 	};
 }
 
+function findDropNeighbour( el: Element ): Element | null {
+	// Expandable Calypso rows contain an inner `<li>` inside
+	// `.sidebar__menu.is-togglable`. Hit-testing can land on that inner LI;
+	// slot math must use the real rendered sidebar row instead.
+	return el.closest( CALYPSO_ROW_SELECTOR ) || el.closest( DROP_NEIGHBOUR_SELECTOR );
+}
+
 /**
  * Build the floating ghost from the source LI. Width/height match the
  * source row (Phase 2 row 17). The ghost is a shallow clone of the link
@@ -343,9 +356,7 @@ function createGhost( li: HTMLElement, rect: DOMRect ): HTMLDivElement {
  */
 export function positionForElement( li: HTMLElement ): LayoutPosition {
 	const groupContainer = li.parentElement ? li.parentElement.closest( GROUP_SELECTOR ) : null;
-	const siblings = li.parentElement
-		? Array.prototype.indexOf.call( li.parentElement.children, li )
-		: 0;
+	const siblings = li.parentElement ? Math.max( 0, layoutIndexOf( li.parentElement, li ) ) : 0;
 	if ( groupContainer ) {
 		return {
 			kind: 'in_group',

--- a/client/my-sites/sidebar/customize/keyboard-reorder.ts
+++ b/client/my-sites/sidebar/customize/keyboard-reorder.ts
@@ -13,6 +13,7 @@
  * @see WordPress/wp-admin-sidebar v0.1.4 src/customizer/keyboard-reorder.js
  */
 import { translate } from 'i18n-calypso';
+import { layoutIndexOf, layoutRowsForContainer } from './dom-layout';
 import type { DragDropController } from './drag-drop';
 
 const REASSIGNABLE_SELECTOR = 'li[data-wp-admin-sidebar-item-id]';
@@ -40,9 +41,7 @@ export function attachKeyboardReorder( controller: DragDropController ): () => v
 		ev.preventDefault();
 
 		const direction = ev.key === 'ArrowUp' ? -1 : 1;
-		const siblings = Array.from( container.children ).filter(
-			( el ) => el.tagName === 'LI' && ! el.classList.contains( 'admin-sidebar-drop-indicator' )
-		) as HTMLElement[];
+		const siblings = layoutRowsForContainer( container ) as HTMLElement[];
 		const current = siblings.indexOf( li );
 		let target_idx = current + direction;
 		if ( target_idx < 0 || target_idx >= siblings.length ) {
@@ -68,9 +67,10 @@ export function attachKeyboardReorder( controller: DragDropController ): () => v
 
 		const enclosingGroup = container.closest( GROUP_SELECTOR );
 		const groupId = enclosingGroup ? enclosingGroup.getAttribute( 'data-group' ) : null;
+		const targetIndex = Math.max( 0, layoutIndexOf( container, siblings[ target_idx ] ) );
 		const position = groupId
-			? { kind: 'in_group' as const, group_id: groupId, index: target_idx }
-			: { kind: 'top_level' as const, index: target_idx };
+			? { kind: 'in_group' as const, group_id: groupId, index: targetIndex }
+			: { kind: 'top_level' as const, index: targetIndex };
 
 		controller.commitMove( itemId, position );
 		const total = siblings.length;

--- a/client/my-sites/sidebar/customize/move-menu.tsx
+++ b/client/my-sites/sidebar/customize/move-menu.tsx
@@ -21,6 +21,7 @@
 import { translate } from 'i18n-calypso';
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { layoutIndexOf, layoutRowsForContainer } from './dom-layout';
 import { useCustomizeContext } from './index';
 import type { LayoutPosition } from 'calypso/state/admin-sidebar/layout/types';
 
@@ -320,7 +321,7 @@ function positionForMoveTarget(
 		}
 		return {
 			kind: 'top_level',
-			index: Array.prototype.indexOf.call( parent.children, target ),
+			index: layoutRowsForContainer( parent ).length,
 		};
 	}
 
@@ -328,10 +329,13 @@ function positionForMoveTarget(
 	if ( ! container ) {
 		return null;
 	}
-	const targetIndex = Array.prototype.indexOf.call( container.children, target );
+	const targetIndex = layoutIndexOf( container, target );
+	if ( targetIndex === -1 ) {
+		return null;
+	}
 	let slot = direction > 0 ? targetIndex + 1 : targetIndex;
 	if ( source.parentElement === container ) {
-		const sourceIndex = Array.prototype.indexOf.call( container.children, source );
+		const sourceIndex = layoutIndexOf( container, source );
 		if ( sourceIndex !== -1 && sourceIndex < slot ) {
 			slot -= 1;
 		}
@@ -366,6 +370,13 @@ function collectRows( source?: HTMLElement ): HTMLLIElement[] {
 	const walkChildren = ( parent: Element ) => {
 		for ( const child of Array.from( parent.children ) ) {
 			if ( child.tagName !== 'LI' ) {
+				continue;
+			}
+			if (
+				child.classList.contains( 'admin-sidebar-drop-indicator' ) ||
+				child.classList.contains( 'sidebar__region' ) ||
+				child.classList.contains( 'collapse-sidebar__toggle' )
+			) {
 				continue;
 			}
 			rows.push( child as HTMLLIElement );

--- a/client/my-sites/sidebar/customize/test/drag-drop.ts
+++ b/client/my-sites/sidebar/customize/test/drag-drop.ts
@@ -23,6 +23,18 @@ function makePointerDown(): Event {
 	return ev;
 }
 
+function makePointerEvent( type: 'pointermove' | 'pointerup', x = 0, y = 0 ): Event {
+	if ( typeof PointerEvent !== 'undefined' ) {
+		return new PointerEvent( type, { bubbles: true, clientX: x, clientY: y } );
+	}
+	const ev = new Event( type, { bubbles: true } );
+	Object.defineProperties( ev, {
+		clientX: { value: x },
+		clientY: { value: y },
+	} );
+	return ev;
+}
+
 function makeReassignableLi( id: string, group: string | null = null ): HTMLLIElement {
 	const li = document.createElement( 'li' );
 	li.setAttribute( 'data-wp-admin-sidebar-item-id', id );
@@ -56,6 +68,24 @@ describe( 'positionForElement', () => {
 		ul.appendChild( c );
 		expect( positionForElement( a ) ).toEqual( { kind: 'top_level', index: 0 } );
 		expect( positionForElement( b ) ).toEqual( { kind: 'top_level', index: 1 } );
+	} );
+
+	it( 'ignores chrome rows while preserving separator slots in top_level position', () => {
+		const ul = document.createElement( 'ul' );
+		ul.className = 'sidebar';
+		const skip = document.createElement( 'li' );
+		skip.className = 'sidebar__region';
+		const separator = document.createElement( 'li' );
+		separator.className = 'sidebar__separator';
+		const a = makeReassignableLi( 'a' );
+		const group = document.createElement( 'li' );
+		group.className = 'wp-admin-sidebar-group';
+		const b = makeReassignableLi( 'b' );
+		const collapse = document.createElement( 'li' );
+		collapse.className = 'collapse-sidebar__toggle';
+		ul.append( skip, separator, a, group, b, collapse );
+		expect( positionForElement( a ) ).toEqual( { kind: 'top_level', index: 1 } );
+		expect( positionForElement( b ) ).toEqual( { kind: 'top_level', index: 2 } );
 	} );
 
 	it( 'reads in_group position when ancestor is a group container', () => {
@@ -129,5 +159,264 @@ describe( 'attachDragDrop', () => {
 			'a',
 			expect.objectContaining( { kind: 'top_level' } )
 		);
+	} );
+
+	it( 'drops into an expanded group when the neighbour is an expandable wrapper row', () => {
+		const sidebar = document.createElement( 'ul' );
+		sidebar.className = 'sidebar';
+		const source = makeReassignableLi( 'stats' );
+		const groupContainer = document.createElement( 'li' );
+		groupContainer.classList.add( 'wp-admin-sidebar-group' );
+		groupContainer.setAttribute( 'data-group', 'plugins' );
+		groupContainer.setAttribute( 'data-expanded', 'true' );
+		const childList = document.createElement( 'ul' );
+		childList.classList.add( 'wp-admin-sidebar-group__children' );
+		const expandableWrapper = document.createElement( 'li' );
+		expandableWrapper.innerHTML =
+			'<ul class="sidebar__menu is-togglable"><li><a class="sidebar__heading">Upgrades</a></li></ul>';
+		childList.appendChild( expandableWrapper );
+		groupContainer.appendChild( childList );
+		sidebar.appendChild( source );
+		sidebar.appendChild( groupContainer );
+		document.body.appendChild( sidebar );
+
+		source.getBoundingClientRect = jest.fn( () => ( {
+			top: 0,
+			left: 0,
+			width: 200,
+			height: 34,
+			bottom: 34,
+			right: 200,
+			x: 0,
+			y: 0,
+			toJSON: jest.fn(),
+		} ) );
+		expandableWrapper.getBoundingClientRect = jest.fn( () => ( {
+			top: 100,
+			left: 0,
+			width: 200,
+			height: 34,
+			bottom: 134,
+			right: 200,
+			x: 0,
+			y: 100,
+			toJSON: jest.fn(),
+		} ) );
+		document.elementsFromPoint = jest.fn( () => [ expandableWrapper ] );
+
+		detach = attachDragDrop( controller );
+		source.dispatchEvent( makePointerDown() );
+		document.dispatchEvent( makePointerEvent( 'pointermove', 10, 130 ) );
+		document.dispatchEvent( makePointerEvent( 'pointerup', 10, 130 ) );
+
+		expect( controller.commitMove ).toHaveBeenCalledWith( 'stats', {
+			kind: 'in_group',
+			group_id: 'plugins',
+			index: 1,
+		} );
+	} );
+
+	it( 'normalizes expandable inner rows before computing top-level slots', () => {
+		const sidebar = document.createElement( 'ul' );
+		sidebar.className = 'sidebar';
+		const source = makeReassignableLi( 'stats' );
+		const expandableWrapper = document.createElement( 'li' );
+		expandableWrapper.setAttribute( 'data-wp-admin-sidebar-item-id', 'feedback' );
+		expandableWrapper.innerHTML =
+			'<ul class="sidebar__menu is-togglable"><li class="sidebar__menu-item-parent"><a class="sidebar__heading">Feedback</a></li></ul>';
+		const after = makeReassignableLi( 'jetpack' );
+		sidebar.appendChild( source );
+		sidebar.appendChild( expandableWrapper );
+		sidebar.appendChild( after );
+		document.body.appendChild( sidebar );
+
+		source.getBoundingClientRect = jest.fn( () => ( {
+			top: 0,
+			left: 0,
+			width: 200,
+			height: 34,
+			bottom: 34,
+			right: 200,
+			x: 0,
+			y: 0,
+			toJSON: jest.fn(),
+		} ) );
+		expandableWrapper.getBoundingClientRect = jest.fn( () => ( {
+			top: 100,
+			left: 0,
+			width: 200,
+			height: 34,
+			bottom: 134,
+			right: 200,
+			x: 0,
+			y: 100,
+			toJSON: jest.fn(),
+		} ) );
+		const innerLi = expandableWrapper.querySelector( 'li.sidebar__menu-item-parent' )!;
+		document.elementsFromPoint = jest.fn( () => [ innerLi ] );
+
+		detach = attachDragDrop( controller );
+		source.dispatchEvent( makePointerDown() );
+		document.dispatchEvent( makePointerEvent( 'pointermove', 10, 130 ) );
+		document.dispatchEvent( makePointerEvent( 'pointerup', 10, 130 ) );
+
+		expect( controller.commitMove ).toHaveBeenCalledWith( 'stats', {
+			kind: 'top_level',
+			index: 1,
+		} );
+	} );
+
+	it( 'normalizes expandable inner rows before computing group slots', () => {
+		const sidebar = document.createElement( 'ul' );
+		sidebar.className = 'sidebar';
+		const source = makeReassignableLi( 'stats' );
+		const groupContainer = document.createElement( 'li' );
+		groupContainer.classList.add( 'wp-admin-sidebar-group' );
+		groupContainer.setAttribute( 'data-group', 'plugins' );
+		groupContainer.setAttribute( 'data-expanded', 'true' );
+		const childList = document.createElement( 'ul' );
+		childList.classList.add( 'wp-admin-sidebar-group__children' );
+		const expandableWrapper = document.createElement( 'li' );
+		expandableWrapper.setAttribute( 'data-wp-admin-sidebar-item-id', 'feedback' );
+		expandableWrapper.innerHTML =
+			'<ul class="sidebar__menu is-togglable"><li class="sidebar__menu-item-parent"><a class="sidebar__heading">Feedback</a></li></ul>';
+		childList.appendChild( expandableWrapper );
+		groupContainer.appendChild( childList );
+		sidebar.appendChild( source );
+		sidebar.appendChild( groupContainer );
+		document.body.appendChild( sidebar );
+
+		source.getBoundingClientRect = jest.fn( () => ( {
+			top: 0,
+			left: 0,
+			width: 200,
+			height: 34,
+			bottom: 34,
+			right: 200,
+			x: 0,
+			y: 0,
+			toJSON: jest.fn(),
+		} ) );
+		expandableWrapper.getBoundingClientRect = jest.fn( () => ( {
+			top: 100,
+			left: 0,
+			width: 200,
+			height: 34,
+			bottom: 134,
+			right: 200,
+			x: 0,
+			y: 100,
+			toJSON: jest.fn(),
+		} ) );
+		const innerLi = expandableWrapper.querySelector( 'li.sidebar__menu-item-parent' )!;
+		document.elementsFromPoint = jest.fn( () => [ innerLi ] );
+
+		detach = attachDragDrop( controller );
+		source.dispatchEvent( makePointerDown() );
+		document.dispatchEvent( makePointerEvent( 'pointermove', 10, 130 ) );
+		document.dispatchEvent( makePointerEvent( 'pointerup', 10, 130 ) );
+
+		expect( controller.commitMove ).toHaveBeenCalledWith( 'stats', {
+			kind: 'in_group',
+			group_id: 'plugins',
+			index: 1,
+		} );
+	} );
+
+	it( 'ignores Calypso chrome rows when computing a top-level drop slot', () => {
+		const sidebar = document.createElement( 'ul' );
+		sidebar.className = 'sidebar';
+		const skip = document.createElement( 'li' );
+		skip.className = 'sidebar__region';
+		const settings = document.createElement( 'li' );
+		settings.innerHTML =
+			'<ul class="sidebar__menu is-togglable"><li><a class="sidebar__heading">Settings</a></li></ul>';
+		const separator = document.createElement( 'li' );
+		separator.className = 'sidebar__separator';
+		const group = document.createElement( 'li' );
+		group.className = 'wp-admin-sidebar-group';
+		const source = makeReassignableLi( 'stats' );
+		const collapse = document.createElement( 'li' );
+		collapse.className = 'collapse-sidebar__toggle';
+		sidebar.append( skip, settings, separator, group, source, collapse );
+		document.body.appendChild( sidebar );
+
+		source.getBoundingClientRect = jest.fn( () => ( {
+			top: 200,
+			left: 0,
+			width: 200,
+			height: 34,
+			bottom: 234,
+			right: 200,
+			x: 0,
+			y: 200,
+			toJSON: jest.fn(),
+		} ) );
+		settings.getBoundingClientRect = jest.fn( () => ( {
+			top: 100,
+			left: 0,
+			width: 200,
+			height: 34,
+			bottom: 134,
+			right: 200,
+			x: 0,
+			y: 100,
+			toJSON: jest.fn(),
+		} ) );
+		const innerLi = settings.querySelector( 'li' )!;
+		document.elementsFromPoint = jest.fn( () => [ innerLi ] );
+
+		detach = attachDragDrop( controller );
+		source.dispatchEvent( makePointerDown() );
+		document.dispatchEvent( makePointerEvent( 'pointermove', 10, 105 ) );
+		document.dispatchEvent( makePointerEvent( 'pointerup', 10, 105 ) );
+
+		expect( controller.commitMove ).toHaveBeenCalledWith( 'stats', {
+			kind: 'top_level',
+			index: 0,
+		} );
+	} );
+
+	it( 'drops into an expanded empty group from the group header', () => {
+		const sidebar = document.createElement( 'ul' );
+		sidebar.className = 'sidebar';
+		const source = makeReassignableLi( 'stats' );
+		const groupContainer = document.createElement( 'li' );
+		groupContainer.classList.add( 'wp-admin-sidebar-group' );
+		groupContainer.setAttribute( 'data-group', 'plugins' );
+		groupContainer.setAttribute( 'data-expanded', 'true' );
+		const header = document.createElement( 'div' );
+		header.classList.add( 'wp-admin-sidebar-group__header' );
+		const childList = document.createElement( 'ul' );
+		childList.classList.add( 'wp-admin-sidebar-group__children' );
+		groupContainer.appendChild( header );
+		groupContainer.appendChild( childList );
+		sidebar.appendChild( source );
+		sidebar.appendChild( groupContainer );
+		document.body.appendChild( sidebar );
+
+		source.getBoundingClientRect = jest.fn( () => ( {
+			top: 0,
+			left: 0,
+			width: 200,
+			height: 34,
+			bottom: 34,
+			right: 200,
+			x: 0,
+			y: 0,
+			toJSON: jest.fn(),
+		} ) );
+		document.elementsFromPoint = jest.fn( () => [ header, groupContainer ] );
+
+		detach = attachDragDrop( controller );
+		source.dispatchEvent( makePointerDown() );
+		document.dispatchEvent( makePointerEvent( 'pointermove', 10, 100 ) );
+		document.dispatchEvent( makePointerEvent( 'pointerup', 10, 100 ) );
+
+		expect( controller.commitMove ).toHaveBeenCalledWith( 'stats', {
+			kind: 'in_group',
+			group_id: 'plugins',
+			index: 0,
+		} );
 	} );
 } );

--- a/client/my-sites/sidebar/customize/test/menu-keyboard.tsx
+++ b/client/my-sites/sidebar/customize/test/menu-keyboard.tsx
@@ -1,0 +1,135 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import MySitesSidebarUnifiedMenu from '../../menu';
+import { CustomizeProvider, useCustomizeContext } from '../index';
+
+function renderInProvider( ui: JSX.Element ) {
+	const store = configureStore()( {
+		ui: { selectedSiteId: 12345, sidebar: { isCollapsed: false } },
+		mySites: { sidebarSections: {} },
+		sites: { items: {} },
+		adminSidebarLayout: { bySite: {} },
+		adminSidebarExpandState: { bySite: {} },
+	} );
+	return render( <Provider store={ store }>{ ui }</Provider> );
+}
+
+function EnterButton() {
+	const ctx = useCustomizeContext();
+	return (
+		<button type="button" onClick={ () => ctx?.enter() }>
+			Enter
+		</button>
+	);
+}
+
+describe( '<MySitesSidebarUnifiedMenu> customize keyboard behaviour', () => {
+	beforeEach( () => {
+		window.scrollTo = jest.fn();
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	it( 'marks expandable parent rows as reassignable in customize mode', () => {
+		const { container } = renderInProvider(
+			<CustomizeProvider>
+				<EnterButton />
+				<MySitesSidebarUnifiedMenu
+					title="Upgrades"
+					slug="paid-upgrades-php"
+					path="/home/example.wordpress.com"
+					link="/plans/example.wordpress.com"
+					icon="cart"
+					inlineText="Premium"
+					itemId="plugin:unknown:-:paid-upgrades.php"
+					reassignable
+					selected={ false }
+					sidebarCollapsed={ false }
+					shouldOpenExternalLinksInCurrentTab
+					isUnifiedSiteSidebarVisible
+				>
+					{ [
+						{
+							title: 'Plans',
+							url: '/plans/example.wordpress.com',
+							icon: null,
+							type: 'submenu-item',
+							itemId:
+								'plugin:unknown:paid-upgrades.php:https://wordpress.com/plans/example.wordpress.com',
+							reassignable: true,
+						},
+					] }
+				</MySitesSidebarUnifiedMenu>
+			</CustomizeProvider>
+		);
+
+		act( () => {
+			screen.getByRole( 'button', { name: 'Enter' } ).click();
+		} );
+
+		const row = container.querySelector(
+			'li[data-wp-admin-sidebar-item-id="plugin:unknown:-:paid-upgrades.php"]'
+		);
+		const heading = container.querySelector( 'a.sidebar__heading' ) as HTMLAnchorElement;
+
+		expect( row ).toBeInTheDocument();
+		expect( heading ).toHaveAttribute( 'tabindex', '-1' );
+		expect( screen.getByRole( 'button', { name: 'Reorder Upgrades' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'More options' } ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Reorder Plans' } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'does not enable expandable hover flyouts in customize mode', () => {
+		jest.useFakeTimers();
+
+		const { container } = renderInProvider(
+			<CustomizeProvider>
+				<EnterButton />
+				<MySitesSidebarUnifiedMenu
+					title="Jetpack"
+					slug="jetpack"
+					path="/home/example.wordpress.com"
+					link="/wp-admin/admin.php?page=jetpack"
+					icon="jetpack"
+					itemId="plugin:jetpack/jetpack.php:-:jetpack"
+					reassignable
+					selected={ false }
+					sidebarCollapsed={ false }
+					shouldOpenExternalLinksInCurrentTab
+					isUnifiedSiteSidebarVisible
+				>
+					{ [
+						{
+							title: 'Social',
+							url: '/wp-admin/admin.php?page=jetpack-social',
+							icon: null,
+							type: 'submenu-item',
+							itemId: 'plugin:jetpack/jetpack.php:jetpack-social:jetpack-social',
+							reassignable: true,
+						},
+					] }
+				</MySitesSidebarUnifiedMenu>
+			</CustomizeProvider>
+		);
+
+		act( () => {
+			screen.getByRole( 'button', { name: 'Enter' } ).click();
+		} );
+
+		const menu = container.querySelector( '.sidebar__menu.is-togglable' ) as HTMLElement;
+
+		act( () => {
+			fireEvent.mouseOver( menu, { clientX: 120, clientY: 120 } );
+			jest.advanceTimersByTime( 220 );
+		} );
+
+		expect( menu ).not.toHaveClass( 'hovered' );
+	} );
+} );

--- a/client/my-sites/sidebar/item.jsx
+++ b/client/my-sites/sidebar/item.jsx
@@ -65,11 +65,8 @@ export const MySitesSidebarUnifiedItem = ( {
 	// customize mode, AND this item carries a compound itemId marked as
 	// reassignable by the classifier. The data attribute below is what
 	// drag-drop.ts reads, so non-reassignable rows must not receive it.
-	const showCustomizeDecorations = canCustomizeSidebarItem(
-		customizeCtx?.isCustomizing,
-		itemId,
-		reassignable
-	);
+	const showCustomizeDecorations =
+		canCustomizeSidebarItem( customizeCtx?.isCustomizing, itemId, reassignable ) && ! isSubItem;
 	const isCustomizing = customizeCtx?.isCustomizing === true;
 	const gripLabel = title
 		? translate( 'Reorder %(label)s', { args: { label: title } } )

--- a/client/my-sites/sidebar/menu.jsx
+++ b/client/my-sites/sidebar/menu.jsx
@@ -7,7 +7,9 @@
 
 import { isWooExpressPlan, PLAN_ECOMMERCE_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { isWithinBreakpoint } from '@automattic/viewport';
+import { translate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
+import { useCallback, useRef, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import SidebarCustomIcon from 'calypso/layout/sidebar/custom-icon';
 import ExpandableSidebarMenu from 'calypso/layout/sidebar/expandable';
@@ -18,23 +20,28 @@ import { isSidebarSectionOpen } from 'calypso/state/my-sites/sidebar/selectors';
 import { getSitePlanSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { useCustomizeContext } from './customize';
-import MySitesSidebarUnifiedItem from './item';
+import { MoveMenu } from './customize/move-menu';
+import MySitesSidebarUnifiedItem, { canCustomizeSidebarItem } from './item';
 import { itemLinkMatches } from './utils';
 
-export const MySitesSidebarUnifiedMenu = ( {
-	count,
-	slug,
-	title,
-	icon,
-	children,
-	path,
-	link,
-	selected,
-	sidebarCollapsed,
-	shouldOpenExternalLinksInCurrentTab,
-	isUnifiedSiteSidebarVisible,
-	...props
-} ) => {
+export const MySitesSidebarUnifiedMenu = ( menuProps ) => {
+	const {
+		count,
+		slug,
+		title,
+		icon,
+		children,
+		path,
+		link,
+		selected,
+		sidebarCollapsed,
+		shouldOpenExternalLinksInCurrentTab,
+		isUnifiedSiteSidebarVisible,
+		inlineText,
+		itemId,
+		reassignable,
+		...props
+	} = menuProps;
 	const reduxDispatch = useDispatch();
 	const sectionId = 'SIDEBAR_SECTION_' + slug;
 	const isExpanded = useSelector( ( state ) => isSidebarSectionOpen( state, sectionId ) );
@@ -48,6 +55,19 @@ export const MySitesSidebarUnifiedMenu = ( {
 	const isMobile = ! isDesktop;
 	const customizeCtx = useCustomizeContext();
 	const isCustomizing = customizeCtx?.isCustomizing === true;
+	const showCustomizeDecorations = canCustomizeSidebarItem( isCustomizing, itemId, reassignable );
+	const gripLabel = title
+		? translate( 'Reorder %(label)s', { args: { label: title } } )
+		: translate( 'Reorder' );
+	const moreLabel = translate( 'More options' );
+	const moreRef = useRef( null );
+	const [ moveMenuOpen, setMoveMenuOpen ] = useState( false );
+	const handleMoreClick = useCallback( ( ev ) => {
+		ev.preventDefault();
+		ev.stopPropagation();
+		setMoveMenuOpen( ( open ) => ! open );
+	}, [] );
+	const handleMoveMenuClose = useCallback( () => setMoveMenuOpen( false ), [] );
 	const showAsExpanded =
 		( isMobile && ( childIsSelected || isExpanded ) ) || // For mobile breakpoints, we dont' care about the sidebar collapsed status.
 		( isDesktop && childIsSelected && ! sidebarCollapsed ); // For desktop breakpoints, a child should be selected and the sidebar being expanded.
@@ -107,19 +127,63 @@ export const MySitesSidebarUnifiedMenu = ( {
 	};
 
 	return (
-		<li>
+		<li data-wp-admin-sidebar-item-id={ showCustomizeDecorations ? itemId : undefined }>
 			<ExpandableSidebarMenu
 				onClick={ onClick }
 				expanded={ showAsExpanded }
 				title={ title }
 				customIcon={ <SidebarCustomIcon icon={ icon } /> }
-				className={ ( selected || childIsSelected ) && 'sidebar__menu--selected' }
+				className={ selected || childIsSelected ? 'sidebar__menu--selected' : undefined }
 				count={ count }
 				hideExpandableIcon
-				inlineText={ props.inlineText }
+				inlineText={ inlineText }
 				href={ link }
 				{ ...props }
+				disableFlyout={ isCustomizing }
 				tabIndex={ isCustomizing ? -1 : undefined }
+				prependContent={
+					showCustomizeDecorations ? (
+						<span
+							className="admin-sidebar-item__grip"
+							role="button"
+							tabIndex={ 0 }
+							aria-label={ gripLabel }
+						>
+							⠿
+						</span>
+					) : undefined
+				}
+				appendContent={
+					showCustomizeDecorations ? (
+						<>
+							<span
+								ref={ moreRef }
+								className="admin-sidebar-item__more"
+								role="button"
+								tabIndex={ 0 }
+								aria-label={ moreLabel }
+								aria-haspopup="menu"
+								aria-expanded={ moveMenuOpen ? 'true' : 'false' }
+								onClick={ handleMoreClick }
+								onKeyDown={ ( ev ) => {
+									if ( ev.key === 'Enter' || ev.key === ' ' ) {
+										handleMoreClick( ev );
+									}
+								} }
+							>
+								⋯
+							</span>
+							{ moveMenuOpen && (
+								<MoveMenu
+									itemId={ itemId }
+									itemLabel={ title }
+									triggerEl={ moreRef.current }
+									onClose={ handleMoveMenuClose }
+								/>
+							) }
+						</>
+					) : undefined
+				}
 			>
 				{ children.map( ( item, index ) => {
 					if ( ! shouldShowAdvertisingOption && item?.url?.includes( '/advertising/' ) ) {
@@ -152,8 +216,13 @@ MySitesSidebarUnifiedMenu.propTypes = {
 	icon: PropTypes.string,
 	children: PropTypes.array.isRequired,
 	link: PropTypes.string,
+	selected: PropTypes.bool,
 	sidebarCollapsed: PropTypes.bool,
 	shouldOpenExternalLinksInCurrentTab: PropTypes.bool.isRequired,
+	isUnifiedSiteSidebarVisible: PropTypes.bool,
+	inlineText: PropTypes.string,
+	itemId: PropTypes.string,
+	reassignable: PropTypes.bool,
 	/*
 	Example of children shape:
 	[

--- a/client/my-sites/sidebar/use-site-menu-items.js
+++ b/client/my-sites/sidebar/use-site-menu-items.js
@@ -22,6 +22,7 @@ import buildFallbackResponse from './static-data/fallback-menu';
 import globalSidebarMenu from './static-data/global-sidebar-menu';
 import jetpackMenu from './static-data/jetpack-fallback-menu';
 import { applyLayoutDelta } from './utils/apply-layout-delta';
+import { normalizeWpcomAdminSidebarHostLinks } from './utils/normalize-wpcom-admin-sidebar-host-links';
 
 const useSiteMenuItems = ( layoutDeltaOverride, transformBaseMenu ) => {
 	const currentRoute = useSelector( ( state ) => getCurrentRoute( state ) );
@@ -128,11 +129,12 @@ const useSiteMenuItems = ( layoutDeltaOverride, transformBaseMenu ) => {
 	const baseMenu = menuItems ?? buildFallbackResponse( fallbackDataOverrides );
 	const transformedBaseMenu =
 		typeof transformBaseMenu === 'function' ? transformBaseMenu( baseMenu ) : baseMenu;
+	const normalizedBaseMenu = normalizeWpcomAdminSidebarHostLinks( transformedBaseMenu );
 	// Apply the user's saved layout-delta (Phase 2 task 2.5). When no delta
 	// is stored, `applyLayoutDelta` returns a copy of `baseMenu` unmodified.
 	// The cost on the no-delta path is one shallow array clone per render;
 	// memoisation lives upstream where the menu is read.
-	return applyLayoutDelta( transformedBaseMenu, layoutDelta );
+	return applyLayoutDelta( normalizedBaseMenu, layoutDelta );
 };
 
 export default useSiteMenuItems;

--- a/client/my-sites/sidebar/utils/admin-sidebar-dev-mock.js
+++ b/client/my-sites/sidebar/utils/admin-sidebar-dev-mock.js
@@ -139,11 +139,21 @@ function canUseItemAsMockSource( item ) {
 	return item?.type !== 'separator' && item?.type !== 'current-site' && ! isExemptItem( item );
 }
 
+function normalizeExemptItem( item ) {
+	if ( item?.group_id || item?.reassignable === true ) {
+		return {
+			...item,
+			group_id: null,
+			reassignable: false,
+		};
+	}
+	return item;
+}
+
 function buildMockItem( item, sourceId, index, count ) {
 	const slug = item.slug || `idx-${ sourceId }`;
 	return {
 		...item,
-		children: undefined,
 		group_id: MOCK_GROUP_ID,
 		itemId: `mock:menu:${ MOCK_GROUP_ID }:${ slug }`,
 		reassignable: true,
@@ -158,6 +168,10 @@ export function buildAdminSidebarDevMock( menuItems ) {
 
 	let picked = 0;
 	const mockedMenuItems = menuItems.map( ( item, index ) => {
+		if ( isExemptItem( item ) ) {
+			return normalizeExemptItem( item );
+		}
+
 		if ( picked >= MOCK_ITEM_TARGET_COUNT || ! canUseItemAsMockSource( item ) ) {
 			return item;
 		}

--- a/client/my-sites/sidebar/utils/apply-layout-delta.ts
+++ b/client/my-sites/sidebar/utils/apply-layout-delta.ts
@@ -60,7 +60,9 @@ export function applyLayoutDelta(
 	const byId = new Map< ItemId, AdminMenuItem >();
 	for ( const item of menu ) {
 		const itemId =
-			item && typeof ( item as AdminMenuItem & { itemId?: unknown } ).itemId === 'string'
+			item &&
+			item.reassignable === true &&
+			typeof ( item as AdminMenuItem & { itemId?: unknown } ).itemId === 'string'
 				? ( ( item as AdminMenuItem & { itemId: string } ).itemId as ItemId )
 				: null;
 		if ( itemId ) {

--- a/client/my-sites/sidebar/utils/normalize-wpcom-admin-sidebar-host-links.ts
+++ b/client/my-sites/sidebar/utils/normalize-wpcom-admin-sidebar-host-links.ts
@@ -1,0 +1,80 @@
+import type { AdminMenuItem } from 'calypso/state/admin-menu/types';
+
+const WPCOM_HOST_ROUTE_PREFIXES = [
+	'/home/',
+	'/overview/',
+	'/plugins/',
+	'/plans/',
+	'/add-ons/',
+	'/email/',
+	'/domains/manage/',
+	'/purchases/subscriptions/',
+];
+
+function getPathname( url: unknown ): string | null {
+	if ( typeof url !== 'string' || url.trim() === '' ) {
+		return null;
+	}
+
+	const value = url.trim();
+	if ( value.startsWith( '/' ) ) {
+		return value;
+	}
+
+	try {
+		return new URL( value ).pathname;
+	} catch {
+		return null;
+	}
+}
+
+export function isWpcomAdminSidebarHostLink( item: AdminMenuItem | null | undefined ): boolean {
+	if ( ! item ) {
+		return false;
+	}
+
+	const itemId = typeof item.itemId === 'string' ? item.itemId : '';
+	if ( itemId.endsWith( ':paid-upgrades.php' ) ) {
+		return true;
+	}
+
+	const pathname = getPathname( item.url );
+	if ( ! pathname ) {
+		return false;
+	}
+
+	return WPCOM_HOST_ROUTE_PREFIXES.some( ( prefix ) => pathname.startsWith( prefix ) );
+}
+
+export function normalizeWpcomAdminSidebarHostLinks(
+	menuItems: readonly AdminMenuItem[] | null | undefined
+): AdminMenuItem[] {
+	if ( ! Array.isArray( menuItems ) ) {
+		return [];
+	}
+
+	let changed = false;
+	const normalized = menuItems.map( ( item ) => {
+		if ( ! isWpcomAdminSidebarHostLink( item ) ) {
+			return item;
+		}
+
+		const children = Array.isArray( item.children )
+			? normalizeWpcomAdminSidebarHostLinks( item.children )
+			: item.children;
+
+		if ( item.group_id === null && item.reassignable === false && children === item.children ) {
+			return item;
+		}
+
+		changed = true;
+		return {
+			...item,
+			children,
+			group_id: null,
+			reassignable: false,
+		};
+	} );
+
+	return changed ? normalized : menuItems.slice();
+}

--- a/client/my-sites/sidebar/utils/test/admin-sidebar-dev-mock.js
+++ b/client/my-sites/sidebar/utils/test/admin-sidebar-dev-mock.js
@@ -33,7 +33,7 @@ describe( 'buildAdminSidebarDevMock()', () => {
 		} );
 	} );
 
-	it( 'uses child-bearing non-core items as leaf mock rows', () => {
+	it( 'preserves child-bearing non-core items as grouped mock rows', () => {
 		const { menuItems } = buildAdminSidebarDevMock( [
 			{ slug: 'dashboard', title: 'Dashboard', type: 'menu-item' },
 			{
@@ -49,10 +49,40 @@ describe( 'buildAdminSidebarDevMock()', () => {
 		expect( groupedItems ).toHaveLength( 3 );
 		expect( groupedItems[ 0 ] ).toMatchObject( {
 			slug: 'jetpack',
-			children: undefined,
+			children: [ { slug: 'jetpack-backup', title: 'Backup' } ],
 			reassignable: true,
 		} );
 		expect( groupedItems[ 1 ].slug ).toBe( 'stats' );
 		expect( groupedItems[ 2 ].slug ).toBe( 'mock-plugin-forms' );
+	} );
+
+	it( 'keeps exempt host links ungrouped and non-reassignable', () => {
+		const { menuItems } = buildAdminSidebarDevMock( [
+			{
+				slug: 'plugins',
+				title: 'Plugins',
+				type: 'menu-item',
+				group_id: 'plugins',
+				reassignable: true,
+			},
+			{
+				slug: 'stats',
+				title: 'Stats',
+				type: 'menu-item',
+				group_id: 'plugins',
+				reassignable: true,
+			},
+		] );
+
+		expect( menuItems[ 0 ] ).toMatchObject( {
+			slug: 'plugins',
+			group_id: null,
+			reassignable: false,
+		} );
+		expect( menuItems[ 1 ] ).toMatchObject( {
+			slug: 'stats',
+			group_id: 'plugins',
+			reassignable: true,
+		} );
 	} );
 } );

--- a/client/my-sites/sidebar/utils/test/apply-layout-delta.ts
+++ b/client/my-sites/sidebar/utils/test/apply-layout-delta.ts
@@ -16,6 +16,7 @@ function makeItem( id: string, group: string | null = null ): ItemWithId {
 		group_id: group,
 		signal: null,
 		itemId: id,
+		reassignable: true,
 	};
 }
 
@@ -86,6 +87,37 @@ describe( 'applyLayoutDelta', () => {
 		};
 		const out = applyLayoutDelta( menu, delta );
 		expect( out ).toEqual( menu );
+	} );
+
+	it( 'silently skips overrides for non-reassignable items', () => {
+		const menu = [ { ...makeItem( 'a' ), reassignable: false }, makeItem( 'b' ) ];
+		const delta: LayoutDelta = {
+			version: 1,
+			updated_at: 0,
+			overrides: [
+				{
+					itemId: 'a',
+					position: { kind: 'in_group', group_id: 'plugins', index: 0 },
+				},
+				{
+					itemId: 'b',
+					position: { kind: 'in_group', group_id: 'plugins', index: 0 },
+				},
+			],
+		};
+
+		const out = applyLayoutDelta( menu, delta );
+
+		expect( out[ 0 ] ).toMatchObject( {
+			itemId: 'a',
+			group_id: null,
+			reassignable: false,
+		} );
+		expect( out[ 1 ] ).toMatchObject( {
+			itemId: 'b',
+			group_id: 'plugins',
+			reassignable: true,
+		} );
 	} );
 
 	it( 'clamps an out-of-range index to the bucket end rather than no-op', () => {

--- a/client/my-sites/sidebar/utils/test/normalize-wpcom-admin-sidebar-host-links.ts
+++ b/client/my-sites/sidebar/utils/test/normalize-wpcom-admin-sidebar-host-links.ts
@@ -1,0 +1,83 @@
+import {
+	isWpcomAdminSidebarHostLink,
+	normalizeWpcomAdminSidebarHostLinks,
+} from '../normalize-wpcom-admin-sidebar-host-links';
+
+describe( 'isWpcomAdminSidebarHostLink()', () => {
+	it( 'recognizes WordPress.com admin shell paths', () => {
+		expect(
+			isWpcomAdminSidebarHostLink( {
+				slug: 'plugins',
+				title: 'Plugins',
+				type: 'menu-item',
+				url: '/plugins/example.wordpress.com',
+			} )
+		).toBe( true );
+
+		expect(
+			isWpcomAdminSidebarHostLink( {
+				slug: 'hosting',
+				title: 'Hosting',
+				type: 'menu-item',
+				url: 'https://wordpress.com/overview/example.wordpress.com',
+			} )
+		).toBe( true );
+	} );
+
+	it( 'recognizes the legacy Upgrades item id', () => {
+		expect(
+			isWpcomAdminSidebarHostLink( {
+				slug: 'paid-upgrades-php',
+				title: 'Upgrades',
+				type: 'menu-item',
+				url: '/wp-admin/paid-upgrades.php',
+				itemId: 'plugin:unknown:-:paid-upgrades.php',
+			} )
+		).toBe( true );
+	} );
+
+	it( 'does not treat WP Admin plugin management as a WordPress.com admin shell path', () => {
+		expect(
+			isWpcomAdminSidebarHostLink( {
+				slug: 'plugins.php',
+				title: 'Plugins',
+				type: 'menu-item',
+				url: 'https://example.wordpress.com/wp-admin/plugins.php',
+			} )
+		).toBe( false );
+	} );
+} );
+
+describe( 'normalizeWpcomAdminSidebarHostLinks()', () => {
+	it( 'keeps WordPress.com host links ungrouped and non-reassignable', () => {
+		const menuItems = normalizeWpcomAdminSidebarHostLinks( [
+			{
+				slug: 'home',
+				title: 'My Home',
+				type: 'menu-item',
+				url: '/home/example.wordpress.com',
+				group_id: 'plugins',
+				itemId: 'wpcom:home',
+				reassignable: true,
+			},
+			{
+				slug: 'jetpack',
+				title: 'Jetpack',
+				type: 'menu-item',
+				url: '/wp-admin/admin.php?page=jetpack',
+				group_id: 'plugins',
+				itemId: 'plugin:jetpack',
+				reassignable: true,
+			},
+		] );
+
+		expect( menuItems[ 0 ] ).toMatchObject( {
+			group_id: null,
+			reassignable: false,
+		} );
+		expect( menuItems[ 1 ] ).toMatchObject( {
+			group_id: 'plugins',
+			reassignable: true,
+		} );
+	} );
+} );

--- a/client/state/data-layer/wpcom/sites/admin-menu/index.js
+++ b/client/state/data-layer/wpcom/sites/admin-menu/index.js
@@ -1,4 +1,5 @@
 import { addQueryArgs } from 'calypso/lib/url';
+import { normalizeWpcomAdminSidebarHostLinks } from 'calypso/my-sites/sidebar/utils/normalize-wpcom-admin-sidebar-host-links';
 import { ADMIN_MENU_REQUEST } from 'calypso/state/action-types';
 import { receiveAdminMenu } from 'calypso/state/admin-menu/actions';
 import { receiveAdminSidebarLayout } from 'calypso/state/admin-sidebar/layout/actions';
@@ -88,13 +89,12 @@ export const handleSuccess =
 		const state = getState();
 		const wpAdminUrl = getSiteAdminUrl( state, siteId );
 		const siteSlug = getSiteSlug( state, siteId );
+		const sanitizedMenuItems = rawMenuItems.map( ( menuItem ) =>
+			sanitizeMenuItem( menuItem, siteSlug, wpAdminUrl )
+		);
 
 		return dispatch(
-			receiveAdminMenu(
-				siteId,
-				rawMenuItems.map( ( menuItem ) => sanitizeMenuItem( menuItem, siteSlug, wpAdminUrl ) ),
-				groups
-			)
+			receiveAdminMenu( siteId, normalizeWpcomAdminSidebarHostLinks( sanitizedMenuItems ), groups )
 		);
 	};
 

--- a/client/state/data-layer/wpcom/sites/admin-menu/test/index.js
+++ b/client/state/data-layer/wpcom/sites/admin-menu/test/index.js
@@ -100,4 +100,53 @@ describe( 'handlers', () => {
 		expect( dispatch ).toHaveBeenCalledTimes( 1 );
 		expect( dispatch ).toHaveBeenCalledWith( expect.objectContaining( action ) );
 	} );
+
+	test( 'should normalize WordPress.com admin shell links', () => {
+		const dispatch = jest.fn();
+		const menu = [
+			{
+				icon: 'dashicons-admin-home',
+				slug: 'httpswordpress-comhomeexample-wordpress-com',
+				title: 'My Home',
+				type: 'menu-item',
+				url: '/home/example.wordpress.com',
+				group_id: 'plugins',
+				itemId: 'plugin:unknown:-:https://wordpress.com/home/example.wordpress.com',
+				reassignable: true,
+			},
+			{
+				icon: 'dashicons-admin-plugins',
+				slug: 'jetpack',
+				title: 'Jetpack',
+				type: 'menu-item',
+				url: 'https://example.wordpress.com/wp-admin/admin.php?page=jetpack',
+				group_id: 'plugins',
+				itemId: 'plugin:unknown:-:jetpack',
+				reassignable: true,
+			},
+		];
+
+		handleSuccess( { siteId: 73738 }, { menu, groups: [] } )( dispatch, getState );
+
+		expect( dispatch ).toHaveBeenCalledWith(
+			expect.objectContaining(
+				receiveAdminMenu(
+					73738,
+					[
+						expect.objectContaining( {
+							title: 'My Home',
+							group_id: null,
+							reassignable: false,
+						} ),
+						expect.objectContaining( {
+							title: 'Jetpack',
+							group_id: 'plugins',
+							reassignable: true,
+						} ),
+					],
+					[]
+				)
+			)
+		);
+	} );
 } );


### PR DESCRIPTION
Part of the wp-admin sidebar redesign rollout.

## Proposed Changes

* Make expandable plugin rows participate correctly in sidebar customize mode, including drag handles and move menu controls.
* Normalize drag, keyboard, and move-menu slot calculations so Calypso-only chrome rows do not throw off ordering.
* Keep WPCOM host-owned sidebar links from being treated as movable plugin items when using the admin menu response.
* Disable expandable flyouts while customize mode is active.

## Why are these changes being made?

After the Jetpack API changes reached production, Calypso was receiving the real sidebar data shape instead of the earlier mocked shape. That exposed a few issues: WPCOM shell links could appear as draggable plugin rows, expandable plugin rows like Jetpack were not consistently draggable, and reorder placement could use the wrong DOM slot because the rendered sidebar includes non-layout rows.

This aligns Calypso customize mode with the real production response and keeps the editing UI focused on placement rather than normal sidebar navigation or flyouts.

## Testing Instructions

* Open `http://calypso.localhost:3000/home/[site]` against a stickered sandbox site.
* Enter customize mode from the My Plugins group.
* Confirm WPCOM shell links like My Home, Hosting, and Upgrades are not draggable plugin rows.
* Confirm plugin rows like Jetpack, Stats, and Feedback are draggable.
* Drag plugin rows within My Plugins and into non-adjacent top-level positions, then confirm the row lands in the expected slot.
* Hover Jetpack while customize mode is active and confirm its submenu flyout does not open.
* Confirm Save is disabled until there is an actual change.

Validated locally:

* `corepack yarn test-client client/my-sites/sidebar/customize/test/drag-drop.ts client/my-sites/sidebar/customize/test/menu-keyboard.tsx client/my-sites/sidebar/customize/test/item-keyboard.tsx client/my-sites/sidebar/customize/test/move-menu.tsx client/my-sites/sidebar/utils/test/admin-sidebar-dev-mock.js client/my-sites/sidebar/utils/test/apply-layout-delta.ts client/my-sites/sidebar/utils/test/normalize-wpcom-admin-sidebar-host-links.ts client/state/data-layer/wpcom/sites/admin-menu/test/index.js client/my-sites/sidebar/test/sidebar-group.jsx --runInBand`
* `corepack yarn eslint ...` for changed JS and TS files
* `corepack yarn stylelint client/my-sites/sidebar/customize/customize-mode.scss`
* `git diff --check`
* Browser verified through local Calypso.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
