### PR TITLE
Reader connections: add header above the social accounts grid

### DIFF
--- a/client/reader/connections/social-overview-view.tsx
+++ b/client/reader/connections/social-overview-view.tsx
@@ -251,26 +251,33 @@ export function SocialOverviewView() {
 			{ showSpotlight && <SocialSpotlight connections={ spotlightConnections } /> }
 
 			{ ! isLoading && cards.length > 0 && (
-				<div className="social-grid">
-					{ cards.map( ( card ) => (
-						<SocialCardItem
-							key={ `${ card.protocol }-${ card.id }` }
-							card={ card }
-							onClick={ () => handleCardClick( card ) }
-						/>
-					) ) }
-					<a className="social-card social-card--add" href="/reader/connections/new">
-						<div className="social-card__plus" aria-hidden="true">
-							+
-						</div>
-						<div className="social-card__body">
-							<div className="social-card__name">{ translate( 'Add another' ) }</div>
-							<div className="social-card__handle">
-								{ translate( 'Bluesky, Mastodon, or your own site' ) }
+				<section className="social-accounts" aria-labelledby="social-accounts-heading">
+					<header className="social-accounts__header">
+						<h2 id="social-accounts-heading" className="social-accounts__title">
+							{ translate( 'Your accounts' ) }
+						</h2>
+					</header>
+					<div className="social-grid">
+						{ cards.map( ( card ) => (
+							<SocialCardItem
+								key={ `${ card.protocol }-${ card.id }` }
+								card={ card }
+								onClick={ () => handleCardClick( card ) }
+							/>
+						) ) }
+						<a className="social-card social-card--add" href="/reader/connections/new">
+							<div className="social-card__plus" aria-hidden="true">
+								+
 							</div>
-						</div>
-					</a>
-				</div>
+							<div className="social-card__body">
+								<div className="social-card__name">{ translate( 'Add another' ) }</div>
+								<div className="social-card__handle">
+									{ translate( 'Bluesky, Mastodon, or your own site' ) }
+								</div>
+							</div>
+						</a>
+					</div>
+				</section>
 			) }
 		</ReaderMain>
 	);

--- a/client/reader/connections/style.scss
+++ b/client/reader/connections/style.scss
@@ -190,6 +190,23 @@
 	max-width: 960px;
 }
 
+.social-accounts {
+	margin-block-start: 24px;
+}
+
+.social-accounts__header {
+	margin-block-end: 12px;
+}
+
+.social-accounts__title {
+	margin: 0;
+	font-size: 0.95rem; /* stylelint-disable-line scales/font-sizes */
+	font-weight: 600;
+	letter-spacing: 0.02em;
+	text-transform: uppercase;
+	color: var( --color-text-subtle );
+}
+
 .social-grid {
 	display: grid;
 	grid-template-columns: repeat( auto-fill, minmax( 240px, 1fr ) );


### PR DESCRIPTION
Part of CM-775
fixes CM-775

## Proposed Changes

* Add a `Your accounts` eyebrow heading above the social accounts grid on `/reader/connections`, styled to mirror the existing `What's hot` title (uppercase, subtle color, same scale).
* The new section uses semantic `<section aria-labelledby>` + `<h2>` so the grid has a programmatic label for assistive tech.

## Why are these changes being made?

When the `What's hot` spotlight renders above the connected accounts (CM-775), the accounts grid below it looked unmoored — no label, no transition from one block to the other. #110931 added a divider line between the two. Pairing that divider with a heading turns the two surfaces into deliberate, separate regions instead of one continuous list.

## Testing Instructions

1. Visit `/reader/connections` with at least one connection.
2. Confirm a `YOUR ACCOUNTS` heading appears above the accounts grid.
3. With the `What's hot` strip visible (i.e. at least one connection has scoreable posts), confirm the divider + heading combination separates the two regions cleanly.
4. Confirm the heading is announced by screen readers (the grid `<section>` is `aria-labelledby` the new `<h2>`).

Before:

After (with spotlight): see the screenshot attached to the Linear issue / the in-app `/reader/connections` view.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?