### PR TITLE
Reader connections: freeze What's hot strip after first load

### DIFF
--- a/client/reader/connections/social-spotlight.tsx
+++ b/client/reader/connections/social-spotlight.tsx
@@ -54,7 +54,6 @@ interface SpotlightItem {
 }
 
 const SPOTLIGHT_LIMIT = 4;
-const STALE_TIME_MS = 60_000;
 const MAX_SNIPPET_CHARS = 140;
 
 function scoreFor( post: SocialPost ): number {
@@ -99,6 +98,15 @@ export function SocialSpotlight( { connections }: Props ) {
 	// is small enough that re-fetching here is fine; a future iteration
 	// could share by reading the infinite cache directly through
 	// `queryClient.getQueryData`.
+	//
+	// Fetch once per visit and don't refresh in the background. A late
+	// refetch on window focus would reshuffle the keyed `<li>` list (the
+	// sort is score-derived from like/repost counts) and reconcile through
+	// `insertBefore`, which fails with a `DOMException` when something
+	// outside React — translation extensions, password managers, dark-mode
+	// injectors — has wrapped any of the post text nodes. The strip is a
+	// discovery hook, not a live feed, so freezing it sidesteps the entire
+	// class of mid-life reorder failures.
 	const queries = useQueries( {
 		queries: connections.map( ( connection ) => ( {
 			queryKey: [ 'reader', 'social-spotlight', connection.protocol, connection.id ],
@@ -111,7 +119,9 @@ export function SocialSpotlight( { connections }: Props ) {
 				}
 				return getFediverseTimeline( { connectionId: connection.id } );
 			},
-			staleTime: STALE_TIME_MS,
+			staleTime: Infinity,
+			refetchOnWindowFocus: false,
+			refetchOnReconnect: false,
 			retry: false,
 			// Don't block the rest of the overview if one upstream is angry.
 		} ) ),


### PR DESCRIPTION
Fixes CM-777

## Proposed Changes

* Freeze the Social Spotlight queries in `client/reader/connections/social-spotlight.tsx` with `staleTime: Infinity` and explicit `refetchOnWindowFocus: false` / `refetchOnReconnect: false`.

## Why are these changes being made?

Leaving `/reader/connections` open in the browser eventually produces:

```
DOMException: Node.insertBefore: Child to insert before is not a child of this node
```

`SocialSpotlight` runs one per-protocol timeline fetch via `useQueries` with `staleTime: 60_000` but no other refetch overrides. Calypso's `QueryClient` uses TanStack defaults (`refetchOnWindowFocus: true`, `refetchOnMount: true`, `refetchOnReconnect: true`), so once the 60s staleness window passes, any focus/visibility event refires all three queries. The refreshed payload changes like/repost counts, `scoreFor()` recomputes, items resort, and React reconciles the keyed `<li>` list via `insertBefore`. When a browser extension (translation, password manager, dark-mode injector) has wrapped any of the post text nodes, the reference node React expected is no longer a child of its parent and the call throws.

The strip is a discovery hook, not a live feed, so freezing it after first load sidesteps the entire class of mid-life reorder failures without changing what users see on initial render. `staleTime: Infinity` is the load-bearing change since `refetchOnMount`/`refetchOnWindowFocus`/`refetchOnReconnect` all short-circuit when data is fresh; the explicit `false` flags are belt-and-braces against future regressions if `staleTime` is ever tightened.

## Testing Instructions

1. Connect at least one social account (ATproto, Mastodon, or Fediverse) so the "What's hot" strip renders.
2. Open `/reader/connections` and confirm the strip loads as before.
3. Leave the tab open for more than a minute, switch to another window/tab, then return.
4. Open DevTools console and confirm no `DOMException: Node.insertBefore...` is logged.
5. Optionally, in the Network tab, filter to the relevant timeline endpoints and confirm they fire once on first load and not again on tab focus.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?