### PR TITLE
Fix launch-site domain redirect E2E assertion

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -54,6 +54,16 @@ const selectors = {
 };
 
 /**
+ * Escapes a string so it can be safely used in a regular expression.
+ *
+ * @param {string} value String to escape.
+ * @returns {string} Escaped string.
+ */
+function escapeRegExp( value: string ): string {
+	return value.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' );
+}
+
+/**
  * Page representing the Plans page under `/plans` endpoint.
  *
  * Also forms a component of the `SignupPickPlanPage` used in the
@@ -161,7 +171,46 @@ export class PlansPage {
 	 * Validates that the "Domain redirect" warning is visible in the escape hatch modal.
 	 */
 	async validateDomainRedirectWarning( domainName: string, siteSlug: string ): Promise< void > {
-		await this.page.getByText( `${ domainName } redirects to ${ siteSlug }` ).waitFor();
+		const redirectedDomain = await this.getDomainFromRedirectWarning( siteSlug );
+		if ( redirectedDomain !== domainName ) {
+			throw new Error(
+				`Expected domain redirect warning for ${ domainName }, but found ${ redirectedDomain }.`
+			);
+		}
+	}
+
+	/**
+	 * Returns the domain shown in the "Domain redirect" warning.
+	 */
+	async getDomainFromRedirectWarning( siteSlug: string ): Promise< string > {
+		const warningPattern = new RegExp( `^(\\S+) redirects to ${ escapeRegExp( siteSlug ) }$` );
+		const warning = this.page.getByText( warningPattern ).first();
+		await warning.waitFor();
+
+		const warningText = ( await warning.textContent() )?.trim();
+		const match = warningText?.match( warningPattern );
+		if ( ! match?.[ 1 ] ) {
+			throw new Error( `Failed to read domain redirect warning for ${ siteSlug }.` );
+		}
+
+		return match[ 1 ];
+	}
+
+	/**
+	 * Returns the domain shown as included on the plans grid.
+	 */
+	async getIncludedDomain(): Promise< string > {
+		const includedDomainPattern = /^(\S+) is included$/;
+		const includedDomain = this.page.getByText( includedDomainPattern ).first();
+		await includedDomain.waitFor();
+
+		const includedDomainText = ( await includedDomain.textContent() )?.trim();
+		const match = includedDomainText?.match( includedDomainPattern );
+		if ( ! match?.[ 1 ] ) {
+			throw new Error( 'Failed to read included domain from plans grid.' );
+		}
+
+		return match[ 1 ];
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
@@ -180,6 +180,25 @@ export class SignupPickPlanPage {
 	}
 
 	/**
+	 * Returns the domain shown in the "Domain redirect" warning.
+	 *
+	 * @param {string} siteSlug The site slug.
+	 * @returns {Promise<string>} Domain shown in the redirect warning.
+	 */
+	async getDomainFromRedirectWarning( siteSlug: string ): Promise< string > {
+		return this.plansPage.getDomainFromRedirectWarning( siteSlug );
+	}
+
+	/**
+	 * Returns the domain shown as included on the plans grid.
+	 *
+	 * @returns {Promise<string>} Domain shown as included.
+	 */
+	async getIncludedDomain(): Promise< string > {
+		return this.plansPage.getIncludedDomain();
+	}
+
+	/**
 	 * Clicks the "Continue with Free" button in the escape hatch modal and waits for navigation.
 	 *
 	 * Intended for use after `openEscapeHatch()` when skipping to a free plan with no domain.

--- a/test/e2e/specs/flows/start-launch-site__flows.spec.ts
+++ b/test/e2e/specs/flows/start-launch-site__flows.spec.ts
@@ -70,7 +70,8 @@ test.describe(
 			} );
 
 			await test.step( 'And I add the first suggestion to the cart', async function () {
-				selectedDomain = await componentDomainSearch.selectFirstSuggestion( false );
+				await componentDomainSearch.selectFirstSuggestion( false );
+				selectedDomain = await pageSignupPickPlan.getIncludedDomain();
 			} );
 
 			await test.step( `And I select the ${ planName } plan`, async function () {
@@ -261,7 +262,7 @@ test.describe(
 			} );
 
 			await test.step( 'And I add the first suggestion to the cart', async function () {
-				selectedDomain = await componentDomainSearch.selectFirstSuggestion( false );
+				await componentDomainSearch.selectFirstSuggestion( false );
 			} );
 
 			await test.step( 'And I open the escape hatch in the plans step', async function () {
@@ -269,8 +270,7 @@ test.describe(
 			} );
 
 			await test.step( 'Then I see the domain redirect warning', async function () {
-				await pageSignupPickPlan.validateDomainRedirectWarning(
-					selectedDomain,
+				selectedDomain = await pageSignupPickPlan.getDomainFromRedirectWarning(
 					newSiteDetails.blog_details.site_slug
 				);
 			} );
@@ -334,7 +334,8 @@ test.describe(
 			} );
 
 			await test.step( 'And I add the first suggestion to the cart', async function () {
-				selectedDomain = await componentDomainSearch.selectFirstSuggestion( false );
+				await componentDomainSearch.selectFirstSuggestion( false );
+				selectedDomain = await pageSignupPickPlan.getIncludedDomain();
 			} );
 
 			await test.step( `And I select the ${ planName } plan via the escape hatch`, async function () {


### PR DESCRIPTION
Part of #110925

## Proposed Changes

* Read the domain from the plans grid after launch-site domain selection.
* Read the domain from the escape-hatch redirect warning before continuing to checkout.
* Use that UI-confirmed domain for checkout assertions in launch-site E2E flows.

## Why are these changes being made?

* The post-#110925 pre-release run failed because the test kept the domain returned by the domain-search row, but the plans step showed a different generated `.blog` domain as the selected domain.
* This keeps the E2E assertion tied to the product state the user sees before checkout.

## Testing Instructions

* `yarn workspace @automattic/calypso-e2e build`
* `./node_modules/.bin/tsc --project packages/calypso-e2e/tsconfig.json --noEmit`
* `./node_modules/.bin/tsc --project test/e2e/tsconfig.json --noEmit`
* `yarn eslint-branch`
* Verify the pre-release Playwright run for this branch, especially `flows/start-launch-site__flows.spec.ts` desktop.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
