### PR TITLE
Cancellation Flow: relaunch A/B test

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/use-is-split-cancel-remove-enabled.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/use-is-split-cancel-remove-enabled.ts
@@ -1,7 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useExperiment } from 'calypso/lib/explat';
 
-const EXPERIMENT_NAME = 'calypso_new_cancel_refund_flow_20260408';
+const EXPERIMENT_NAME = 'calypso_cancel_refund_flow_20260521';
 
 export function useIsSplitCancelRemoveEnabled(): boolean {
 	const [ isLoadingExperiment, experimentAssignment ] = useExperiment( EXPERIMENT_NAME );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

This updates the Cancellation Flow A/B test slug from `calypso_new_cancel_refund_flow_20260408` to `calypso_cancel_refund_flow_20260521` - effectively relaunching the test after recent updates to merge improvements from two prior tests.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*