### PR TITLE
Use advertised storage in purchase feature list

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy.ts
@@ -25,6 +25,7 @@ export type PurchaseForCopy = {
 	meta?: string;
 	domain: string;
 	site_slug: string;
+	advertised_total_upload_space_in_gb?: number | null;
 };
 
 /**

--- a/client/dashboard/me/billing-purchases/cancel-purchase/get-override-features.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/get-override-features.ts
@@ -60,6 +60,16 @@ function getDomainFeature( domain: string ): string {
 	return __( 'Custom domain for your site' );
 }
 
+function getStorageFeature( purchase: PurchaseForCopy, fallbackStorageInGb: number ): string {
+	const storageInGb = purchase.advertised_total_upload_space_in_gb ?? fallbackStorageInGb;
+
+	return sprintf(
+		/* translators: %(storage)d is the amount of storage in GB. */
+		__( '%(storage)d GB of storage' ),
+		{ storage: storageInGb }
+	);
+}
+
 function getWpcomPlanFeatures( purchase: PurchaseForCopy ): CancellationFeature[] | null {
 	const slug = purchase.product_slug;
 	const isMonthly = slug.includes( '-monthly' );
@@ -96,7 +106,7 @@ function getWpcomPlanFeatures( purchase: PurchaseForCopy ): CancellationFeature[
 		return features(
 			...( [
 				domainFeature,
-				__( '50 GB of storage' ),
+				getStorageFeature( purchase, 50 ),
 				__( 'An ad-free experience for your visitors' ),
 				__( 'Plugins and themes to extend your site' ),
 				! isMonthly && __( 'Priority 24/7 support' ),
@@ -111,7 +121,7 @@ function getWpcomPlanFeatures( purchase: PurchaseForCopy ): CancellationFeature[
 			...( [
 				domainFeature,
 				__( 'Plugins and themes to extend your site' ),
-				__( '50 GB of storage' ),
+				getStorageFeature( purchase, 50 ),
 				__( 'Payments in 60+ countries' ),
 				__( 'Sell and ship products worldwide' ),
 				__( 'Integrations with shipping carriers' ),

--- a/client/dashboard/me/billing-purchases/cancel-purchase/test/get-override-features.test.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/test/get-override-features.test.ts
@@ -76,6 +76,19 @@ describe( 'getOverrideCancellationFeatures', () => {
 			const result = getOverrideCancellationFeatures( purchase );
 			expect( result ).toHaveLength( 8 );
 			expect( result![ 0 ].title ).toBe( 'example.com as your primary domain' );
+			expect( result!.map( ( feature ) => feature.title ) ).toContain( '50 GB of storage' );
+		} );
+
+		it( 'uses advertised storage for business-bundle when provided', () => {
+			const purchase = makePurchase( {
+				is_plan: true,
+				product_slug: 'business-bundle',
+				product_name: 'WordPress.com Business',
+				advertised_total_upload_space_in_gb: 200,
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result!.map( ( feature ) => feature.title ) ).toContain( '200 GB of storage' );
+			expect( result!.map( ( feature ) => feature.title ) ).not.toContain( '50 GB of storage' );
 		} );
 
 		it( 'returns 8 features for ecommerce-bundle', () => {
@@ -87,6 +100,19 @@ describe( 'getOverrideCancellationFeatures', () => {
 			const result = getOverrideCancellationFeatures( purchase );
 			expect( result ).toHaveLength( 8 );
 			expect( result![ 0 ].title ).toBe( 'example.com as your primary domain' );
+			expect( result!.map( ( feature ) => feature.title ) ).toContain( '50 GB of storage' );
+		} );
+
+		it( 'uses advertised storage for ecommerce-bundle when provided', () => {
+			const purchase = makePurchase( {
+				is_plan: true,
+				product_slug: 'ecommerce-bundle',
+				product_name: 'WordPress.com eCommerce',
+				advertised_total_upload_space_in_gb: 200,
+			} );
+			const result = getOverrideCancellationFeatures( purchase );
+			expect( result!.map( ( feature ) => feature.title ) ).toContain( '200 GB of storage' );
+			expect( result!.map( ( feature ) => feature.title ) ).not.toContain( '50 GB of storage' );
 		} );
 
 		it( 'returns 7 features for ecommerce-trial-bundle-monthly (omits support)', () => {


### PR DESCRIPTION
## Proposed Changes

- Use `advertised_total_upload_space_in_gb` when rendering Business and Commerce purchase feature-list storage copy.
- Keep the existing 50 GB fallback for purchase API responses that do not have the new field yet.
- Add regression coverage for 200 GB legacy-entitlement purchases.

## Testing

- `yarn test-client client/dashboard/me/billing-purchases/cancel-purchase/test/get-override-features.test.ts --runInBand`
- `yarn eslint --ext .js,.jsx,.ts,.tsx,.mjs,.json --cache client/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy.ts client/dashboard/me/billing-purchases/cancel-purchase/get-override-features.ts client/dashboard/me/billing-purchases/cancel-purchase/test/get-override-features.test.ts`
- `git diff --check origin/update/business-feature-plans...HEAD`

## Notes

This expects the purchase API to provide `advertised_total_upload_space_in_gb`; until then, the UI keeps the current 50 GB fallback.