### PR TITLE
Tighten choose redirect E2E URL assertion

### DIFF
--- a/test/e2e/specs/onboarding/onboarding__write.ts
+++ b/test/e2e/specs/onboarding/onboarding__write.ts
@@ -62,7 +62,7 @@ describe( DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ), function () 
 			// https://wordpress.com/choose for the PWYW A/B test instead of
 			// creating a site directly. No /sites/new call is made here, so we
 			// use selectPlanWithoutSiteCreation.
-			const redirectUrl = /wordpress\.com\/choose/;
+			const redirectUrl = /^https:\/\/wordpress\.com\/choose(?:[?#]|$)/;
 			await signupPickPlanPage.selectPlanWithoutSiteCreation( 'Free', redirectUrl );
 		} );
 	} );


### PR DESCRIPTION
Part of #110928

## Proposed Changes

* Anchor the `onboarding__write.ts` Free-plan redirect matcher to `https://wordpress.com/choose`, allowing only query or hash suffixes.

## Why are these changes being made?

* The previous regex could also match `wpcalypso.wordpress.com/choose`, which is the broken pre-release host this assertion should catch.
* This is split from #110928 so the temporary experiment can stay lightweight and non-blocking.

## Testing Instructions

* Confirmed with `git diff --check`.
* Not run full E2E; this is a one-line test assertion follow-up.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?