### PR TITLE
[RSM] Blog Talks Back: Save site AI agent access via site MCP endpoint

### DIFF
--- a/client/dashboard/sites/settings-ai-tools/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/index.tsx
@@ -5,7 +5,7 @@ import {
 	bigSkyPluginMutation,
 	bigSkyPluginQuery,
 	siteBySlugQuery,
-	userSettingsMutation,
+	siteMcpAbilitiesMutation,
 	userSettingsQuery,
 } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
@@ -139,21 +139,20 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 	// When there are no site-specific overrides, use site_level_enabled_default as the effective
 	// state. True when account MCP is on for sites, false when disabled.
 	const hasSiteAbilityOverrides = Object.keys( siteAbilities ).length > 0;
-	const defaultToolEnabled =
-		( userSettings as any )?.mcp_abilities?.site_level_enabled_default ?? false;
+	const defaultToolEnabled = userSettings?.mcp_abilities?.site_level_enabled_default ?? false;
 	const defaultBadge = defaultToolEnabled
 		? { text: __( 'All enabled' ), intent: 'success' as const }
 		: { text: __( 'Disabled' ) };
 	const readBadge = hasSiteAbilityOverrides ? getReadBadge( readTools ) : defaultBadge;
 	const writeBadge = hasSiteAbilityOverrides ? getWriteBadge( writeTools ) : defaultBadge;
 	const mcpMutation = useMutation( {
-		...userSettingsMutation(),
+		...siteMcpAbilitiesMutation( site.ID ),
 		meta: {
 			snackbar: {
 				success: isMcpEnabled
-					? __( 'MCP access disabled for this site.' )
-					: __( 'MCP access enabled for this site.' ),
-				error: __( 'Failed to save MCP settings.' ),
+					? __( 'External AI agent access disabled for this site.' )
+					: __( 'External AI agent access enabled for this site.' ),
+				error: __( 'Failed to save external AI agent access.' ),
 			},
 		},
 	} );
@@ -169,15 +168,8 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 		// When disabling, send abilities: {} to clear all site-level tool access.
 		mcpMutation.mutate(
 			{
-				mcp_abilities: {
-					sites: [
-						{
-							blog_id: site.ID,
-							site_level_enabled: enabled,
-							abilities,
-						},
-					],
-				},
+				site_level_enabled: enabled,
+				abilities,
 			},
 			{
 				onSuccess: () => {
@@ -301,7 +293,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 										__nextHasNoMarginBottom
 										checked={ isMcpEnabled }
 										disabled={ mcpMutation.isPending }
-										label={ __( 'Enable MCP access for this site' ) }
+										label={ __( 'Enable external AI agent access for this site' ) }
 										onChange={ handleMcpToggle }
 									/>
 								</VStack>

--- a/client/dashboard/sites/settings-ai-tools/setup/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/setup/index.tsx
@@ -117,17 +117,19 @@ function SiteAIToolsSetup() {
 							<SectionHeader level={ 3 } title={ __( 'Setup Required' ) } />
 							<VStack spacing={ 4 }>
 								<Text as="p" variant="muted">
-									{ __( 'MCP access is not enabled for this site.' ) }
+									{ __( 'External AI agent access is not enabled for this site.' ) }
 								</Text>
 								<Text as="p" variant="muted">
-									{ __( 'Enable MCP access for this site before connecting your AI agent.' ) }
+									{ __(
+										'Enable external AI agent access for this site before connecting your AI agent.'
+									) }
 								</Text>
 								<RouterLinkButton
 									to={ `/sites/${ siteSlug }/settings/ai-tools` }
 									variant="primary"
 									className="mcp-setup__action-button"
 								>
-									{ __( 'Go to Site MCP settings' ) }
+									{ __( 'Go to AI tools settings' ) }
 								</RouterLinkButton>
 							</VStack>
 						</VStack>

--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -125,6 +125,7 @@ export * from './site-logs';
 export * from './site-marketplace';
 export * from './site-media-storage';
 export * from './site-migration-status';
+export * from './site-mcp-abilities';
 export * from './site-owner-transfer';
 export * from './site-plans';
 export * from './site-plugins';

--- a/packages/api-core/src/me-settings/types.ts
+++ b/packages/api-core/src/me-settings/types.ts
@@ -36,6 +36,7 @@ export type McpAbilities = {
 	account?: Record< string, McpAbility >;
 	site?: Record< string, McpAbility >; // Site-scoped ability defaults
 	sites?: McpSiteOverride[]; // Array of site-specific overrides
+	site_level_enabled_default?: boolean;
 };
 
 export interface UserSettings {

--- a/packages/api-core/src/site-mcp-abilities/index.ts
+++ b/packages/api-core/src/site-mcp-abilities/index.ts
@@ -1,0 +1,2 @@
+export * from './mutators';
+export * from './types';

--- a/packages/api-core/src/site-mcp-abilities/mutators.ts
+++ b/packages/api-core/src/site-mcp-abilities/mutators.ts
@@ -1,0 +1,15 @@
+import { wpcom } from '../wpcom-fetcher';
+import type { SiteMcpAbilitiesResponse, SiteMcpAbilitiesUpdateRequest } from './types';
+
+export async function updateSiteMcpAbilities(
+	siteId: number,
+	data: SiteMcpAbilitiesUpdateRequest
+): Promise< SiteMcpAbilitiesResponse > {
+	return wpcom.req.post(
+		{
+			path: `/sites/${ siteId }/mcp-abilities`,
+			apiNamespace: 'wpcom/v2',
+		},
+		data
+	);
+}

--- a/packages/api-core/src/site-mcp-abilities/types.ts
+++ b/packages/api-core/src/site-mcp-abilities/types.ts
@@ -1,0 +1,25 @@
+export interface SiteMcpAbilitiesUpdateRequest {
+	site_level_enabled?: boolean;
+	abilities?: Record< string, boolean >;
+}
+
+export interface SiteMcpAbility {
+	name: string;
+	title: string;
+	description: string;
+	category: string;
+	type: string;
+	readonly: boolean;
+	site_context: boolean;
+	enabled: boolean;
+}
+
+export interface SiteMcpAbilitiesResponse {
+	has_mcp_plan: boolean;
+	site_level_enabled: boolean;
+	abilities: SiteMcpAbility[];
+	user_overrides: {
+		site_level_enabled?: boolean;
+		abilities: Record< string, boolean >;
+	};
+}

--- a/packages/api-queries/src/index.ts
+++ b/packages/api-queries/src/index.ts
@@ -113,6 +113,7 @@ export * from './site-marketplace';
 export * from './site-media-storage';
 export * from './site-metrics';
 export * from './site-migration-status';
+export * from './site-mcp-abilities';
 export * from './site-owner-transfer';
 export * from './site-php-version';
 export * from './site-plans';

--- a/packages/api-queries/src/site-mcp-abilities.ts
+++ b/packages/api-queries/src/site-mcp-abilities.ts
@@ -1,0 +1,49 @@
+import { updateSiteMcpAbilities } from '@automattic/api-core';
+import { mutationOptions } from '@tanstack/react-query';
+import { userSettingsQuery } from './me-settings';
+import { queryClient } from './query-client';
+import type {
+	McpSiteOverride,
+	SiteMcpAbilitiesUpdateRequest,
+	UserSettings,
+} from '@automattic/api-core';
+
+export const siteMcpAbilitiesMutation = ( siteId: number ) =>
+	mutationOptions( {
+		mutationFn: ( data: SiteMcpAbilitiesUpdateRequest ) => updateSiteMcpAbilities( siteId, data ),
+		onSuccess: ( _data, variables ) => {
+			queryClient.setQueryData< UserSettings >( userSettingsQuery().queryKey, ( oldData ) => {
+				if ( ! oldData?.mcp_abilities ) {
+					return oldData;
+				}
+
+				const sites = oldData.mcp_abilities.sites ?? [];
+				const siteIndex = sites.findIndex( ( site ) => site.blog_id === siteId );
+				const nextSite: McpSiteOverride = {
+					...( siteIndex >= 0 ? sites[ siteIndex ] : { blog_id: siteId } ),
+				};
+
+				if ( Object.prototype.hasOwnProperty.call( variables, 'site_level_enabled' ) ) {
+					nextSite.site_level_enabled = variables.site_level_enabled;
+				}
+
+				if ( Object.prototype.hasOwnProperty.call( variables, 'abilities' ) ) {
+					nextSite.abilities = variables.abilities ?? {};
+				}
+
+				const nextSites =
+					siteIndex >= 0
+						? sites.map( ( site, index ) => ( index === siteIndex ? nextSite : site ) )
+						: [ ...sites, nextSite ];
+
+				return {
+					...oldData,
+					mcp_abilities: {
+						...oldData.mcp_abilities,
+						sites: nextSites,
+					},
+				};
+			} );
+			queryClient.invalidateQueries( { queryKey: userSettingsQuery().queryKey } );
+		},
+	} );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Add API core/query helpers for the site-scoped `/wpcom/v2/sites/{siteId}/mcp-abilities` endpoint.
* Update the site AI tools External AI agent access toggle to save through the site-scoped endpoint instead of account-level `/me/settings`.
* Keep the `/me/settings` cache responsive after saves, then invalidate it for the canonical server response.
* Update setup copy to use External AI agent access wording.

## Why are these changes being made?

The public AI Agent Access toggle is site publication consent, not account-level MCP access. Saving through the site-scoped WPCOM endpoint lets the backend mirror the canonical `jetpack_ai_agents_enabled` opt-in while leaving account-level `/me/mcp` behavior separate.

## Testing Instructions

* `yarn workspace @automattic/api-core build`
* `yarn workspace @automattic/api-queries build`
* `yarn eslint client/dashboard/sites/settings-ai-tools/index.tsx client/dashboard/sites/settings-ai-tools/setup/index.tsx packages/api-core/src/me-settings/types.ts packages/api-core/src/site-mcp-abilities/index.ts packages/api-core/src/site-mcp-abilities/mutators.ts packages/api-core/src/site-mcp-abilities/types.ts packages/api-queries/src/site-mcp-abilities.ts`
* `git diff --check`
* Claude review completed with no blockers.
* Note: the fresh PR worktree could not run Yarn scripts because it does not have the local install state file; the checks above were run in the original Calypso worktree with the same diff applied.

Manual checks:

1. Open a site's AI tools settings with `mcp-settings` enabled.
2. Toggle External AI agent access on and verify the request posts to `/wpcom/v2/sites/{siteId}/mcp-abilities` with `site_level_enabled: true` and read-tool abilities.
3. Verify the toggle remains enabled and the Read, Write, and Connect external AI agent rows are visible.
4. Toggle it off and verify the request posts `site_level_enabled: false` with an empty abilities object, and the sub-rows are hidden.
5. Open the setup route while disabled and verify the required-state copy refers to External AI agent access.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?
