### PR TITLE
Plugin Compass: Frontend Tweaks

### DIFF
--- a/client/my-sites/plugins/marketplace-ai-experience/agent-provider.ts
+++ b/client/my-sites/plugins/marketplace-ai-experience/agent-provider.ts
@@ -90,9 +90,9 @@ function ensureRegistered( onPicks: ( picks: Pick[] ) => void ): Promise< void >
 						picks: {
 							type: 'array',
 							description:
-								'Ordered list of plugin recommendations. The first pick is treated as the lead/hero. Provide 1–8 picks (3–5 is the typical sweet spot).',
+								'Ordered list of plugin recommendations. The first pick is treated as the lead/hero. Provide 1–10 picks (4 is the typical sweet spot).',
 							minItems: 1,
-							maxItems: 8,
+							maxItems: 10,
 							items: {
 								type: 'object',
 								additionalProperties: false,

--- a/client/my-sites/plugins/plugin-compass-agent-loader.tsx
+++ b/client/my-sites/plugins/plugin-compass-agent-loader.tsx
@@ -6,6 +6,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { WPCOM_FEATURES_INSTALL_PLUGINS } from '@automattic/calypso-products';
 import { useEffect, useState } from '@wordpress/element';
+import { translate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import {
@@ -20,8 +21,7 @@ import {
 	getSelectedSiteId,
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
-
-const PLUGIN_COMPASS_AGENT_ID = 'wpcom-workflow-plugin_compass';
+import type { Suggestion } from '@automattic/agenttic-ui';
 
 const importAgentsManager = () =>
 	import(
@@ -33,24 +33,10 @@ const importAgentProvider = () =>
 		/* webpackChunkName: "plugin-compass" */ 'calypso/my-sites/plugins/marketplace-ai-experience/agent-provider'
 	);
 
+const PLUGIN_COMPASS_AGENT_ID = 'wpcom-workflow-plugin_compass';
+
 // Module-scoped so the provider object's identity is stable across re-renders.
 let cachedProvider: { toolProvider: object } | null = null;
-
-function registerInlineProvider( provider: object ): void {
-	if ( typeof window === 'undefined' ) {
-		return;
-	}
-
-	type AMData = { agentProviders?: ( string | object )[] };
-	const w = window as unknown as { agentsManagerData?: AMData };
-	w.agentsManagerData = w.agentsManagerData || {};
-
-	const existing = w.agentsManagerData.agentProviders;
-	const providers = Array.isArray( existing ) ? existing : [];
-	if ( ! providers.includes( provider ) ) {
-		w.agentsManagerData.agentProviders = [ ...providers, provider ];
-	}
-}
 
 export default function PluginCompassAgentLoader( {
 	sectionName,
@@ -90,6 +76,8 @@ function PluginCompassAgentLoaderInner(): JSX.Element | null {
 		if ( ! gatesPassed ) {
 			return;
 		}
+
+		applyEmbeddedHostOverrides();
 
 		if ( cachedProvider ) {
 			registerInlineProvider( cachedProvider );
@@ -132,4 +120,69 @@ function PluginCompassAgentLoaderInner(): JSX.Element | null {
 			currentSiteId={ selectedSite.ID }
 		/>
 	);
+}
+
+function registerInlineProvider( provider: object ): void {
+	if ( typeof window === 'undefined' ) {
+		return;
+	}
+
+	type AMData = { agentProviders?: ( string | object )[] };
+	const w = window as unknown as { agentsManagerData?: AMData };
+	w.agentsManagerData = w.agentsManagerData || {};
+
+	const existing = w.agentsManagerData.agentProviders;
+	const providers = Array.isArray( existing ) ? existing : [];
+	if ( ! providers.includes( provider ) ) {
+		w.agentsManagerData.agentProviders = [ ...providers, provider ];
+	}
+}
+
+// Set the host customizations (greeting, help text, suggestion chips)
+// once before the AsyncLoad mounts AgentsManager so the empty view
+// reads Plugin Compass copy instead of the Orchestrator defaults.
+function applyEmbeddedHostOverrides(): void {
+	if ( typeof window === 'undefined' ) {
+		return;
+	}
+
+	type AMData = {
+		agentId?: string;
+		emptyViewHeading?: string;
+		emptyViewHelp?: string;
+		compassSuggestions?: Suggestion[];
+	};
+	const w = window as unknown as { agentsManagerData?: AMData };
+	w.agentsManagerData = w.agentsManagerData || {};
+
+	// Idempotent: once we've stamped our agentId, skip re-running translate()
+	// and reassigning globals on every effect fire.
+	if ( w.agentsManagerData.agentId === PLUGIN_COMPASS_AGENT_ID ) {
+		return;
+	}
+
+	w.agentsManagerData.agentId = PLUGIN_COMPASS_AGENT_ID;
+	w.agentsManagerData.emptyViewHeading = String(
+		translate( 'Howdy! What plugin features are you looking for today?' )
+	);
+
+	w.agentsManagerData.emptyViewHelp = String( translate( 'Have a specific request? Ask away.' ) );
+
+	w.agentsManagerData.compassSuggestions = [
+		{
+			id: 'plugin-compass-seo',
+			label: String( translate( 'Rank higher in search results' ) ),
+			prompt: String( translate( 'Help me rank higher in search results.' ) ),
+		},
+		{
+			id: 'plugin-compass-sell',
+			label: String( translate( 'Sell products online' ) ),
+			prompt: String( translate( 'I want to sell products online.' ) ),
+		},
+		{
+			id: 'plugin-compass-marketing-emails',
+			label: String( translate( 'Send marketing emails' ) ),
+			prompt: String( translate( 'I want to send marketing emails to my customers.' ) ),
+		},
+	];
 }

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -74,6 +74,18 @@ body.is-section-plugins {
 		}
 	}
 
+	// When the agents-manager (AI) sidebar is open, AM applies
+	// `#content { overflow: auto !important }` on plugins routes,
+	// which causes these ::before pseudo-elements to end up overflowing
+	// the container and causing unnecessary scrollbars.
+	&.agents-manager-sidebar-container--sidebar-open {
+		.plugins-browser :has(> .section-header-container)::before,
+		.is-plugin-details :has(> .section-header-container)::before {
+			width: auto;
+			height: auto;
+		}
+	}
+
 	.is-logged-in main:not( .hosting-dashboard-layout ):not( .hosting-dashboard-layout-column ) {
 		&:not( .plugins-browser ),
 		&.plugins-browser .plugins-browser__content-wrapper {

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -15,6 +15,7 @@ import { useMemo, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { AGENTS_MANAGER_STORE } from '../../stores';
+import { isPluginCompassHost } from '../../utils/is-plugin-compass-agent';
 import { isReaderChatHost } from '../../utils/is-reader-chat-agent';
 import ChatHeader, { type Options as ChatHeaderOptions } from '../chat-header';
 import ChatMessageSkeleton from '../chat-message-skeleton';
@@ -106,16 +107,22 @@ const DEFAULT_ACCEPTED_IMAGE_TYPES = [
 ];
 
 /**
- * Read a string override from `window.agentsManagerData[key]`. Reader-chat
- * hosts can customize the empty-view greeting/help copy by setting these
- * keys before AgentsManager mounts.
+ * Read a string override from `window.agentsManagerData[key]`. Embedded
+ * hosts (reader-chat on blog frontends, Plugin Compass on Calypso's plugins
+ * marketplace) can customize the empty-view greeting/help copy by setting
+ * these keys before AgentsManager mounts.
  */
 function readAgentsManagerDataString(
 	key: 'emptyViewHeading' | 'emptyViewHelp'
 ): string | undefined {
-	if ( typeof window === 'undefined' || ! isReaderChatHost() ) {
+	if ( typeof window === 'undefined' ) {
 		return undefined;
 	}
+
+	if ( ! isReaderChatHost() && ! isPluginCompassHost() ) {
+		return undefined;
+	}
+
 	const data = ( window as unknown as { agentsManagerData?: Record< string, unknown > } )
 		.agentsManagerData;
 	const value = data?.[ key ];

--- a/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
+++ b/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
@@ -3,6 +3,7 @@ import { useSelect } from '@wordpress/data';
 import { useEffect, useState, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useAgentsManagerContext } from '../contexts';
+import { isPluginCompassHost } from '../utils/is-plugin-compass-agent';
 import { isReaderChatHost } from '../utils/is-reader-chat-agent';
 import type { LoadedProviders } from '../utils/load-external-providers';
 
@@ -32,28 +33,45 @@ const SITE_EDITOR_ONLY_SUGGESTION_IDS = new Set( [
  */
 /**
  * Direct override path: a host that renders AgentsManager (e.g. reader-chat
- * on a blog frontend) can set `window.agentsManagerData.readerSuggestions`
- * to a Suggestion[] and this hook will return it verbatim, bypassing the
- * provider flow. Reassigning the global and forcing a re-render causes
- * the empty view to update with fresh suggestions.
+ * on a blog frontend, Plugin Compass on the plugins marketplace) can set
+ * `window.agentsManagerData.readerSuggestions` / `.compassSuggestions` to a
+ * Suggestion[] and this hook will return it verbatim, bypassing the provider
+ * flow (and the Big Sky theme-readiness gate further below). Reassigning the
+ * global and forcing a re-render causes the empty view to update with fresh
+ * suggestions.
  */
 function readOverrideSuggestions(): Suggestion[] | null {
-	if ( typeof window === 'undefined' || ! isReaderChatHost() ) {
+	if ( typeof window === 'undefined' ) {
 		return null;
 	}
-	const data = ( window as unknown as { agentsManagerData?: { readerSuggestions?: unknown } } )
-		.agentsManagerData;
-	const override = data?.readerSuggestions;
+
+	const data = (
+		window as unknown as {
+			agentsManagerData?: { readerSuggestions?: unknown; compassSuggestions?: unknown };
+		}
+	 ).agentsManagerData;
+
+	let override: unknown;
+	if ( isReaderChatHost() ) {
+		override = data?.readerSuggestions;
+	} else if ( isPluginCompassHost() ) {
+		override = data?.compassSuggestions;
+	} else {
+		return null;
+	}
+
 	// Key absent entirely — no host override, fall through to defaults.
 	if ( ! Array.isArray( override ) ) {
 		return null;
 	}
+
 	// Empty array is an explicit "no chips yet" signal (host is fetching
 	// AI suggestions and wants the empty view to show nothing until they
 	// arrive). Return it verbatim rather than falling through to defaults.
 	if ( override.length === 0 ) {
 		return [];
 	}
+
 	const valid = override.filter(
 		( s ): s is Suggestion =>
 			!! s &&
@@ -65,6 +83,7 @@ function readOverrideSuggestions(): Suggestion[] | null {
 			typeof s.label === 'string' &&
 			typeof s.prompt === 'string'
 	);
+
 	return valid.length > 0 ? valid : null;
 }
 

--- a/packages/agents-manager/src/utils/is-plugin-compass-agent.ts
+++ b/packages/agents-manager/src/utils/is-plugin-compass-agent.ts
@@ -1,0 +1,24 @@
+/**
+ * Plugin Compass agent identification helper.
+ *
+ * Plugin Compass mounts AgentsManager directly on Calypso's plugins
+ * marketplace pages with a host-customized empty view (greeting, help copy,
+ * suggestion chips that route into the plugin-discovery workflow).
+ */
+
+const PLUGIN_COMPASS_AGENT_ID = 'wpcom-workflow-plugin_compass';
+
+/**
+ * True if the current host is running under the Plugin Compass agent.
+ * Reads from `window.agentsManagerData.agentId` (set by the Plugin Compass
+ * loader before AgentsManager mounts).
+ */
+export function isPluginCompassHost(): boolean {
+	if ( typeof window === 'undefined' ) {
+		return false;
+	}
+
+	const agentId = ( window as unknown as { agentsManagerData?: { agentId?: string } } )
+		.agentsManagerData?.agentId;
+	return agentId === PLUGIN_COMPASS_AGENT_ID;
+}


### PR DESCRIPTION
- Set up default AI intro & suggestion chips for the sidebar that better explain what's available during the marketplace ai experience.
- Fix a styling issue with the marketplace that that caused excess scrollbars when the AI sidebar was docked & open.
- Increase the frontend rendering tool to allow up to 10 picks (1 featured, then 3 rows of 3 underneath).