### PR TITLE
Reader social: empty-state margin + drop sidebar learn-more link

### DIFF
--- a/client/reader/connections/style.scss
+++ b/client/reader/connections/style.scss
@@ -380,7 +380,7 @@
 	}
 }
 
-.social-empty__learn-more {
+p.social-empty__learn-more {
 	margin: 16px auto;
 }
 

--- a/client/reader/connections/style.scss
+++ b/client/reader/connections/style.scss
@@ -380,6 +380,10 @@
 	}
 }
 
+.social-empty__learn-more {
+	margin: 16px auto;
+}
+
 // ---------- Social Spotlight ----------
 
 .social-spotlight {

--- a/client/reader/sidebar/reader-sidebar-connections/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-connections/index.tsx
@@ -4,8 +4,6 @@ import {
 	useMastodonConnectionsQuery,
 } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
-import { localizeUrl } from '@automattic/i18n-utils';
-import { ExternalLink } from '@wordpress/components';
 import { Icon, people } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo, useState } from 'react';
@@ -282,13 +280,6 @@ function ReaderSidebarConnections( { path }: Props ) {
 					href={ NEW_CONNECTION_PATH }
 					onClick={ recordAddAccountClick }
 				/>
-				{ showEmptyHint && (
-					<li className="sidebar-connections__empty">
-						<ExternalLink href={ localizeUrl( 'https://wordpress.com/support/reader/social/' ) }>
-							{ translate( 'Learn more about your social accounts in the Reader' ) }
-						</ExternalLink>
-					</li>
-				) }
 			</ExpandableSidebarMenu>
 		</li>
 	);


### PR DESCRIPTION
Fixes CM-779

## Proposed Changes

* `client/reader/connections/style.scss` — add `margin: 16px auto` to `p.social-empty__learn-more` (the tag-qualified selector wins specificity against the existing `.social-empty p` rule).
* `client/reader/sidebar/reader-sidebar-connections/index.tsx` — remove the "Learn more about your social accounts in the Reader" external link that rendered under the "Add account" item in the Reader sidebar's Social menu when the user had no connections. Drop the now-unused `ExternalLink` and `localizeUrl` imports.

## Why are these changes being made?

Two small UX polish items on the Reader social surfaces:

1. **`/reader/connections` empty state** — the "Learn more about your social accounts in the Reader" link sat directly under the "Pick a network →" button with no breathing room.
2. **Reader sidebar — "Social" menu** — the same link rendered again whenever the user had no connections, duplicating what's already on the overview page and adding noise to a menu that's already wide for sidebar real estate. The overview page keeps the link for users who actually land on the empty state.

## Testing Instructions

1. Sign in to a WordPress.com account with **no** social connections of any kind (Bluesky, Mastodon, or Fediverse).
2. Visit `/reader/connections`. Confirm the "Nothing here yet" card shows the "Pick a network →" button followed by visible vertical space, then the "Learn more about your social accounts in the Reader" link.
3. Expand the "Social" menu in the Reader sidebar. Confirm it shows the "Add account" row and **no** trailing "Learn more…" external link.
4. Sign in to an account with at least one connection. Confirm the empty-state copy does not render in either surface.
5. Toggle dark mode and verify both surfaces.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?