### PR TITLE
APM: Show a prominent empty state when capturing is off

### DIFF
--- a/client/dashboard/sites/performance/backend/backend-empty-state.tsx
+++ b/client/dashboard/sites/performance/backend/backend-empty-state.tsx
@@ -1,0 +1,35 @@
+import { type Site } from '@automattic/api-core';
+import { __, sprintf } from '@wordpress/i18n';
+import EmptyState from '../../../components/empty-state';
+import StartCapturingButton from './start-capturing-button';
+import { getLowercaseTimeframeLabel, type Timeframe } from './timeframe';
+
+export default function BackendEmptyState( {
+	site,
+	timeframe,
+}: {
+	site: Site;
+	timeframe: Timeframe;
+} ) {
+	const title = sprintf(
+		/* translators: %s is a timeframe like "last hour" or "last 15 minutes". */
+		__( 'No APM data in the %s' ),
+		getLowercaseTimeframeLabel( timeframe )
+	);
+
+	return (
+		<EmptyState.Wrapper>
+			<EmptyState>
+				<EmptyState.Header>
+					<EmptyState.Title>{ title }</EmptyState.Title>
+					<EmptyState.Description>
+						{ __(
+							'Capturing is off. Turn it on to collect performance data for your site. New requests will appear here within about 30 seconds.'
+						) }
+					</EmptyState.Description>
+				</EmptyState.Header>
+				<StartCapturingButton site={ site } context="empty_state" />
+			</EmptyState>
+		</EmptyState.Wrapper>
+	);
+}

--- a/client/dashboard/sites/performance/backend/index.tsx
+++ b/client/dashboard/sites/performance/backend/index.tsx
@@ -1,22 +1,16 @@
 import { type Site } from '@automattic/api-core';
-import {
-	siteApmAggregateQuery,
-	siteApmEnabledMutation,
-	siteBySlugQuery,
-} from '@automattic/api-queries';
-import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import { siteApmAggregateQuery, siteBySlugQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
-	Button,
 	privateApis,
 } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
-import { useEffect, useMemo } from 'react';
-import { useAnalytics } from '../../../app/analytics';
+import { useMemo } from 'react';
 import { Card } from '../../../components/card';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
@@ -26,11 +20,13 @@ import { getBackendCalloutProps } from '../backend-callout';
 import { VIEWPORT_BREAKPOINTS } from '../constants';
 import PerformanceTabs from '../performance-tabs';
 import { mergeAggregates } from './aggregate';
+import BackendEmptyState from './backend-empty-state';
 import BackendStatusNotice from './backend-status';
 import BackendTabs from './backend-tabs';
 import Database from './database';
 import ExternalRequests from './external-requests';
 import Overview from './overview';
+import StartCapturingButton from './start-capturing-button';
 import BackendSubtitle from './subtitle';
 import {
 	isRollingTimeframe,
@@ -59,35 +55,6 @@ const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
 
 const { Tabs } = unlock( privateApis );
 
-function StartCapturingButton( { site }: { site: Site } ) {
-	const { recordTracksEvent } = useAnalytics();
-
-	useEffect( () => {
-		recordTracksEvent( 'calypso_dashboard_site_apm_enable_impression' );
-	}, [ recordTracksEvent ] );
-
-	const { mutate, isPending } = useMutation( {
-		...siteApmEnabledMutation( site.ID ),
-		meta: {
-			snackbar: {
-				success: __( 'APM enabled.' ),
-				error: __( 'Failed to enable APM.' ),
-			},
-		},
-	} );
-
-	const handleClick = () => {
-		recordTracksEvent( 'calypso_dashboard_site_apm_enable_click' );
-		mutate( true );
-	};
-
-	return (
-		<Button variant="primary" isBusy={ isPending } disabled={ isPending } onClick={ handleClick }>
-			{ __( 'Start capturing' ) }
-		</Button>
-	);
-}
-
 function ApmDashboard( {
 	site,
 	tab,
@@ -107,6 +74,14 @@ function ApmDashboard( {
 
 	const apmEnabled = !! site.options?.apm_enabled;
 	const isRollingWindow = isRollingTimeframe( timeframe );
+	const hasData = summary.transaction_count > 0;
+
+	// Only show the prominent empty state when APM is off — that's the case
+	// where the user needs to take action. When APM is on but no data has come
+	// in yet, the regular dashboard with the "Capturing" notice is enough.
+	if ( ! hasData && ! apmEnabled ) {
+		return <BackendEmptyState site={ site } timeframe={ timeframe } />;
+	}
 
 	const handleTabChange = ( name: string ) => {
 		const next = name as ApmTab;

--- a/client/dashboard/sites/performance/backend/start-capturing-button.tsx
+++ b/client/dashboard/sites/performance/backend/start-capturing-button.tsx
@@ -1,0 +1,44 @@
+import { type Site } from '@automattic/api-core';
+import { siteApmEnabledMutation } from '@automattic/api-queries';
+import { useMutation } from '@tanstack/react-query';
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useEffect } from 'react';
+import { useAnalytics } from '../../../app/analytics';
+
+export default function StartCapturingButton( {
+	site,
+	variant = 'primary',
+	context = 'header',
+}: {
+	site: Site;
+	variant?: 'primary' | 'secondary';
+	context?: 'header' | 'empty_state';
+} ) {
+	const { recordTracksEvent } = useAnalytics();
+
+	useEffect( () => {
+		recordTracksEvent( 'calypso_dashboard_site_apm_enable_impression', { context } );
+	}, [ recordTracksEvent, context ] );
+
+	const { mutate, isPending } = useMutation( {
+		...siteApmEnabledMutation( site.ID ),
+		meta: {
+			snackbar: {
+				success: __( 'APM enabled.' ),
+				error: __( 'Failed to enable APM.' ),
+			},
+		},
+	} );
+
+	const handleClick = () => {
+		recordTracksEvent( 'calypso_dashboard_site_apm_enable_click', { context } );
+		mutate( true );
+	};
+
+	return (
+		<Button variant={ variant } isBusy={ isPending } disabled={ isPending } onClick={ handleClick }>
+			{ __( 'Start capturing' ) }
+		</Button>
+	);
+}

--- a/client/dashboard/sites/performance/backend/test/index.test.tsx
+++ b/client/dashboard/sites/performance/backend/test/index.test.tsx
@@ -140,23 +140,30 @@ function aggregateFixture(): ApmAggregateResponse {
 }
 
 describe( '<SitePerformanceBackend>', () => {
-	test( 'renders the dashboard with a Start capturing CTA when APM is disabled', async () => {
+	test( 'renders the timeframe-scoped empty state with a Start capturing CTA when APM is disabled and no data', async () => {
 		mockSite( businessSite( false ) );
 		mockApmAggregate();
 
 		render( <SitePerformanceBackend siteSlug={ siteSlug } /> );
 
+		// Default timeframe is "last hour" (rolling), so the title reflects that.
 		expect(
-			await screen.findByRole( 'heading', { name: 'Response time breakdown' } )
+			await screen.findByRole( 'heading', { name: 'No APM data in the last hour' } )
 		).toBeVisible();
-		expect( screen.getByRole( 'button', { name: 'Start capturing' } ) ).toBeVisible();
+		expect( screen.getByText( /Capturing is off\. Turn it on/ ) ).toBeVisible();
+		// Empty state has its own CTA, and the header keeps the original one.
+		expect( screen.getAllByRole( 'button', { name: 'Start capturing' } )[ 0 ] ).toBeVisible();
 		expect( screen.getByRole( 'status', { name: 'Not capturing' } ) ).toBeVisible();
-		expect( screen.getByText( /Capturing is off\./ ) ).toBeVisible();
+		// Charts and tabs should NOT be visible in the empty state.
+		expect(
+			screen.queryByRole( 'heading', { name: 'Response time breakdown' } )
+		).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'heading', { name: 'Slowest requests' } ) ).not.toBeInTheDocument();
 	} );
 
-	test( 'renders the tabbed dashboard without the Start capturing CTA when APM is enabled', async () => {
+	test( 'renders the tabbed dashboard without the Start capturing CTA when APM is enabled and data is present', async () => {
 		mockSite( businessSite( true ) );
-		mockApmAggregate();
+		mockApmAggregate( aggregateFixture() );
 
 		render( <SitePerformanceBackend siteSlug={ siteSlug } /> );
 
@@ -169,9 +176,21 @@ describe( '<SitePerformanceBackend>', () => {
 		expect( screen.getByText( /Capturing performance data\./ ) ).toBeVisible();
 	} );
 
-	test( 'renders Plugins, Hooks and Templates on the WordPress tab', async () => {
+	test( 'shows the Capturing notice (not the empty state) when APM is on but no data has come in yet', async () => {
 		mockSite( businessSite( true ) );
 		mockApmAggregate();
+
+		render( <SitePerformanceBackend siteSlug={ siteSlug } /> );
+
+		// The dashboard still renders with the "Capturing" notice — the empty
+		// state is reserved for when the user has to take action (APM off).
+		expect( await screen.findByText( /Performance data is being collected/ ) ).toBeVisible();
+		expect( screen.queryByRole( 'heading', { name: /^No APM data in/ } ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'renders Plugins, Hooks and Templates on the WordPress tab', async () => {
+		mockSite( businessSite( true ) );
+		mockApmAggregate( aggregateFixture() );
 
 		render( <SitePerformanceBackend siteSlug={ siteSlug } tab="wordpress" /> );
 
@@ -228,31 +247,15 @@ describe( '<SitePerformanceBackend>', () => {
 		).toBeVisible();
 	} );
 
-	test( 'shows the Capturing notice when APM is on but no data has come in yet', async () => {
+	test( 'does not show the intent-based status notice when there is no data', async () => {
 		mockSite( businessSite( true ) );
 		mockApmAggregate();
 
 		render( <SitePerformanceBackend siteSlug={ siteSlug } /> );
 
-		expect( await screen.findByText( /Performance data is being collected/ ) ).toBeVisible();
-		expect(
-			screen.queryByText( /(Healthy backend|Backend needs improvement|Backend is slow) — avg / )
-		).not.toBeInTheDocument();
-	} );
-
-	test( 'omits the status notice when APM is off and no data has come in yet', async () => {
-		// The subtitle already says "Capturing is off..." so we skip the
-		// redundant notice in this state.
-		mockSite( businessSite( false ) );
-		mockApmAggregate();
-
-		render( <SitePerformanceBackend siteSlug={ siteSlug } /> );
-
-		// Wait for the page to render before asserting absence.
+		// Wait for the dashboard to render before asserting absence.
 		await screen.findByRole( 'heading', { name: 'Response time breakdown' } );
 
-		expect( screen.queryByText( /Turn capturing on to start collecting/ ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( /Performance data is being collected/ ) ).not.toBeInTheDocument();
 		expect(
 			screen.queryByText( /(Healthy backend|Backend needs improvement|Backend is slow) — avg / )
 		).not.toBeInTheDocument();
@@ -284,7 +287,10 @@ describe( '<SitePerformanceBackend>', () => {
 
 		render( <SitePerformanceBackend siteSlug={ siteSlug } /> );
 
-		await userEvent.click( await screen.findByRole( 'button', { name: 'Start capturing' } ) );
+		// With no data and APM off, both the header CTA and the empty-state CTA are
+		// rendered. Either one should perform the same POST; click the first one.
+		const buttons = await screen.findAllByRole( 'button', { name: 'Start capturing' } );
+		await userEvent.click( buttons[ 0 ] );
 
 		await waitFor( () => {
 			expect( scope.isDone() ).toBe( true );

--- a/client/dashboard/sites/performance/backend/timeframe.ts
+++ b/client/dashboard/sites/performance/backend/timeframe.ts
@@ -20,6 +20,21 @@ export const TIMEFRAME_OPTIONS: Array< { value: Timeframe; label: string } > = [
 	{ value: 'last-24-hours', label: __( 'Last 24 hours' ) },
 ];
 
+// Lower-case timeframe labels for use mid-sentence (e.g. "No data in the last hour").
+// Translated separately so locales that handle casing differently can override.
+export function getLowercaseTimeframeLabel( timeframe: Timeframe ): string {
+	switch ( timeframe ) {
+		case 'last-15-min':
+			return __( 'last 15 minutes' );
+		case 'last-hour':
+			return __( 'last hour' );
+		case 'last-6-hours':
+			return __( 'last 6 hours' );
+		case 'last-24-hours':
+			return __( 'last 24 hours' );
+	}
+}
+
 const TIMEFRAME_STORAGE_KEY = 'dashboard-apm-backend-timeframe';
 
 const VALID_TIMEFRAMES = new Set< string >( Object.keys( TIMEFRAME_SECONDS ) );


### PR DESCRIPTION
## Proposed Changes

* On the Backend performance page, when APM is off and no data is available, replace the empty tabs/charts/lists with a centered `EmptyState` (`backend-empty-state.tsx`). The title names the active timeframe (e.g. *"No APM data in the last hour"*) and the body invites the user to turn capturing on with a primary CTA.
* Extracted `StartCapturingButton` into its own file so the existing header button and the new empty-state button share one implementation. Added a `context` prop (`'header' | 'empty_state'`) that is attached to the impression and click Tracks events so the two surfaces can be told apart in analytics.
* Added `getLowercaseTimeframeLabel()` in `timeframe.ts` so the timeframe can be dropped mid-sentence in translated copy without relying on locale-sensitive `toLowerCase()`.
* When APM is on but no data has come in yet, the dashboard continues to render normally with the existing *"Performance data is being collected"* notice; only the APM-off case triggers the empty state.

## Why are these changes being made?

Previously, opening the Backend page with APM disabled rendered the full dashboard layout, only filled with zeros and empty bar lists. It read as *broken* rather than *inactive*, and the only call to action was a small button in the page header. The new empty state makes the state of the page explicit, ties the message to the timeframe the user is looking at, and puts the *Start capturing* affordance right next to the explanation.

## Testing Instructions

1. Open a site whose plan has APM access (Business/Commerce).
2. Make sure capturing is **off** for the site. Visit `/sites/<slug>/performance/backend`.
   * Expected: the body shows the *"No APM data in the [timeframe]"* card with the *Start capturing* button. No empty charts or tabs are visible below it. The header still has its own *Start capturing* button and the timeframe selector.
   * Change the timeframe in the header. The title updates to match (*last 15 minutes*, *last hour*, *last 6 hours*, *last 24 hours*).
3. Click *Start capturing* (either the header or empty-state button). The site's APM should be enabled.
   * Expected: the page transitions to the regular dashboard. While no data has come back yet, the existing *"Performance data is being collected"* notice is shown above the (zero-valued) tabs / charts.
4. Once real data arrives, the dashboard shows the usual intent-based status notice (*Healthy backend*, *needs improvement*, or *slow*).
5. Confirm that on a plan **below Business** the page still shows the upsell callout (unchanged).
6. `yarn test-client client/dashboard/sites/performance/backend/test/index.test.tsx` should pass (12 tests).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?