### PR TITLE
Dashboard: Fix workflow recipes link in Deployments tab

### DIFF
--- a/client/dashboard/sites/settings-repositories/advanced-workflow-style.tsx
+++ b/client/dashboard/sites/settings-repositories/advanced-workflow-style.tsx
@@ -1,4 +1,5 @@
 import { githubWorkflowTemplatesQuery } from '@automattic/api-queries';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useQuery } from '@tanstack/react-query';
 import {
 	ExternalLink,
@@ -104,7 +105,9 @@ export const AdvancedWorkflowStyle = ( {
 						{
 							a: (
 								<ExternalLink
-									href="https://developer.wordpress.com/docs/developer-tools/github-deployments/github-deployments-workflow-recipes/"
+									href={ localizeUrl(
+										'https://wordpress.com/support/github-deployments/workflow-recipes/'
+									) }
 									children={ null }
 								/>
 							),

--- a/client/sites/deployments/components/deployment-style/advanced-workflow-style.tsx
+++ b/client/sites/deployments/components/deployment-style/advanced-workflow-style.tsx
@@ -1,4 +1,5 @@
 import { ExternalLink } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { createInterpolateElement } from '@wordpress/element';
 import { translate } from 'i18n-calypso';
 import { GitHubRepositoryData } from '../../use-github-repositories-query';
@@ -82,7 +83,11 @@ export const AdvancedWorkflowStyle = ( {
 					),
 					{
 						a: (
-							<ExternalLink href="https://developer.wordpress.com/docs/developer-tools/github-deployments/github-deployments-workflow-recipes/" />
+							<ExternalLink
+								href={ localizeUrl(
+									'https://wordpress.com/support/github-deployments/workflow-recipes/'
+								) }
+							/>
 						),
 					}
 				) }


### PR DESCRIPTION
Part of DOTCOM-17132

## Proposed Changes

* Update the "workflow recipes" link in the repository's advanced workflow style settings to point to the new support article at `wordpress.com/support/github-deployments/workflow-recipes/` instead of the legacy `developer.wordpress.com` URL, which now 404s.

## Why are these changes being made?

The developer docs were moved to the support site, so the existing link is broken. Pointing users to the live support article restores the inline learning resource in the Deployments settings.

## Testing Instructions

* In the dashboard, open a site's Repositories settings and select a connected repository's Advanced workflow.
* Locate the helper text "You can start with our basic workflow file and extend it. Looking for inspiration? Check out our workflow recipes."
* Click "workflow recipes" and confirm it opens https://wordpress.com/support/github-deployments/workflow-recipes/ (no 404).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)