### PR TITLE
e2e: fix Layout Grid / Blog Posts addBlockFromSidebar timeout

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-component.ts
@@ -8,7 +8,6 @@ const EDITOR_TIMEOUT = 60 * 1000;
 export class EditorComponent {
 	private page: Page;
 	private parentLocator: Locator | null;
-	private canvasLocator: Locator | null;
 
 	/**
 	 * Constructs an instance of the component.
@@ -18,7 +17,6 @@ export class EditorComponent {
 	constructor( page: Page ) {
 		this.page = page;
 		this.parentLocator = null;
-		this.canvasLocator = null;
 	}
 
 	/**
@@ -45,22 +43,18 @@ export class EditorComponent {
 	/**
 	 * Returns the Editor canvas locator. It will automatically resolve to the
 	 * proper locator, regardless if the canvas is iframed or not.
+	 *
+	 * Note: unlike the Editor parent, the canvas can switch between iframed and
+	 * non-iframed within a single session — e.g. inserting a block that doesn't
+	 * support the iframed canvas (such as Layout Grid or Blog Posts) de-iframes
+	 * it. The result is therefore re-detected on every call and never cached.
 	 */
 	async canvas(): Promise< Locator > {
-		if ( this.canvasLocator ) {
-			return this.canvasLocator;
-		}
-
 		try {
-			this.canvasLocator = await Promise.any( [
-				this.waitForFramedCanvas(),
-				this.waitForUnframedCanvas(),
-			] );
+			return await Promise.any( [ this.waitForFramedCanvas(), this.waitForUnframedCanvas() ] );
 		} catch ( _error ) {
 			throw new Error( 'Timed out waiting for the Editor canvas' );
 		}
-
-		return this.canvasLocator;
 	}
 
 	/**


### PR DESCRIPTION
Part of the Gutenberg-on-WPCOM rotation (GB v23.2.2) e2e triage.

## Proposed Changes

* `EditorComponent.canvas()` no longer caches its resolved locator. It re-detects whether the editor canvas is iframed on every call.

## Why are these changes being made?

The `blocks__core` (Layout Grid) and `blocks__etk` (Blog Posts) e2e suites started failing on the GB edge rotation: `addBlockFromSidebar` timed out for 15s waiting for the inserted block to become selected (`:is([aria-label="Block: Layout Grid"].is-selected, .has-child-selected)`).

Root cause is a stale cache in `EditorComponent.canvas()`, not the GB build or the block specs:

* The editor canvas can switch between **iframed** and **non-iframed** within a single editor session. Inserting a block that doesn't support the iframed canvas (Layout Grid, Blog Posts) makes Gutenberg de-iframe the canvas.
* `canvas()` cached its resolved locator for the lifetime of the page. The first call happens during `Enter post title`, while the canvas is still iframed, so it cached the **framed** locator (`.editor-visual-editor » frameLocator('iframe') » .editor-styles-wrapper`).
* After a later block de-iframed the canvas, `canvas()` returned that stale locator. `frameLocator('iframe')` then resolved to an unrelated embed sandbox iframe (e.g. a YouTube embed's `components-sandbox`), so `.editor-styles-wrapper` — and the inserted block — were never found.

This was confirmed from a Playwright trace: the canvas iframe is present throughout the YouTube step and gone (canvas rendered inline) once Layout Grid is inserted. Core blocks pass because they keep the canvas iframed; the cache only goes stale once a de-iframing block is added.

Re-detecting on every call keeps the iframed/non-iframed state current. `parent()`'s cache is kept, since the Gutenframe state is stable for the lifetime of a page.

## Testing Instructions

Run against a GB-edge Atomic site:

```
CALYPSO_BASE_URL=https://wordpress.com GUTENBERG_EDGE=true TEST_ON_ATOMIC=true \
  yarn jest specs/blocks/blocks__core.ts specs/blocks/blocks__etk.ts
```

Before this change: `Layout Grid: Add the block from the sidebar` and `Blog Posts: Add the block from the sidebar` time out.
After this change: both suites pass (26/26 tests, verified locally on desktop).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)