### PR TITLE
Marketing Tools: update SEO course CTA to "Watch the course"

### DIFF
--- a/client/sites/marketing/tools/marketing-features-data.ts
+++ b/client/sites/marketing/tools/marketing-features-data.ts
@@ -2,6 +2,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
 import { PLAN_BUSINESS, getPlan, PLAN_ECOMMERCE } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
+import { hasTranslation } from '@wordpress/i18n';
 import { getLocaleSlug } from 'i18n-calypso';
 import fiverrLogo from 'calypso/assets/images/customer-home/fiverr-logo.svg';
 import rocket from 'calypso/assets/images/customer-home/illustration--rocket.svg';
@@ -164,7 +165,10 @@ export const getMarketingFeaturesData = (
 			categories: [ 'seo', 'new' ],
 			imagePath: rocket,
 			imageAlt: translate( 'A rocketship' ),
-			buttonText: translate( 'Register now' ),
+			buttonText:
+				hasTranslation( 'Watch the course' ) || isEnglish
+					? translate( 'Watch the course' )
+					: translate( 'Register now' ),
 			buttonHref: localizeUrl( 'https://wordpress.com/support/courses/seo/' ),
 			buttonTarget: '_blank',
 			onClick: () => {


### PR DESCRIPTION
Part of DOTCOM-17126

## Proposed Changes

* Rename the CTA button on the "Increase traffic to your WordPress.com site" card under Tools → Marketing from "Register now" to "Watch the course".
* Fall back to the previous "Register now" copy in any locale that doesn't yet have a translation for the new string.

## Why are these changes being made?

The card links to a free SEO course, but there is no registration step — visitors just watch the course. "Watch the course" describes the action accurately.

## Testing Instructions

* Visit Tools → Marketing on any site.
* Locate the card titled "Increase traffic to your WordPress.com site".
* Confirm the CTA button reads "Watch the course" (English) and that clicking it opens the SEO course support page in a new tab.
* The card is currently gated to English locales, so non-English translation behavior won't be visible in the UI yet.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?