### PR TITLE
Reader social: convert composer overflow text to paragraph blocks

### DIFF
--- a/client/reader/social/composer/build-paragraph-blocks.ts
+++ b/client/reader/social/composer/build-paragraph-blocks.ts
@@ -1,0 +1,26 @@
+// Convert the composer's plain-text body into Gutenberg paragraph blocks
+// so the editor opens with structured content rather than a single Classic
+// block. Blank lines separate paragraphs; single newlines inside a
+// paragraph become `<br>`. Returns an empty string for whitespace-only
+// input — `saveDraftMutation` substitutes its own empty-paragraph
+// placeholder in that case.
+function escapeHtml( s: string ): string {
+	return s.replace( /&/g, '&amp;' ).replace( /</g, '&lt;' ).replace( />/g, '&gt;' );
+}
+
+export function buildParagraphBlocks( text: string ): string {
+	const normalized = text.replace( /\r\n?/g, '\n' );
+	if ( normalized.trim() === '' ) {
+		return '';
+	}
+	const paragraphs = normalized
+		.split( /\n[\t ]*\n+/ )
+		.map( ( p ) => p.replace( /^\n+|\n+$/g, '' ) )
+		.filter( ( p ) => p.trim().length > 0 );
+	return paragraphs
+		.map( ( p ) => {
+			const inner = escapeHtml( p ).split( '\n' ).join( '<br>' );
+			return `<!-- wp:paragraph -->\n<p>${ inner }</p>\n<!-- /wp:paragraph -->`;
+		} )
+		.join( '\n\n' );
+}

--- a/client/reader/social/composer/composer-overflow-handoff.tsx
+++ b/client/reader/social/composer/composer-overflow-handoff.tsx
@@ -10,6 +10,7 @@ import { UnknownAction } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { SiteHandoff, useHandoffMutation } from 'calypso/reader/social/site-handoff';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
+import { buildParagraphBlocks } from './build-paragraph-blocks';
 import { useComposerConfig } from './composer-config';
 import { useComposer } from './composer-provider';
 import type { ActiveMode } from './composer-provider';
@@ -119,6 +120,8 @@ export function ComposerOverflowHandoff( { text }: ComposerOverflowHandoffProps 
 		  }
 		: undefined;
 
+	const blockContent = buildParagraphBlocks( text );
+
 	return (
 		<section
 			className="social-composer__overflow-handoff"
@@ -139,14 +142,14 @@ export function ComposerOverflowHandoff( { text }: ComposerOverflowHandoffProps 
 			{ preferredSite ? (
 				<PreferredSiteHandoff
 					site={ preferredSite }
-					content={ text }
+					content={ blockContent }
 					buttonLabel={ translate( 'Move to editor' ) as string }
 					tracks={ tracks }
 				/>
 			) : (
 				<SiteHandoff
 					sites={ sites }
-					content={ text }
+					content={ blockContent }
 					buttonLabel={ translate( 'Move to editor' ) as string }
 					tracks={ tracks }
 					caller="overflow_handoff"

--- a/client/reader/social/composer/test/build-paragraph-blocks.test.ts
+++ b/client/reader/social/composer/test/build-paragraph-blocks.test.ts
@@ -38,6 +38,11 @@ describe( 'buildParagraphBlocks', () => {
 		expect( out ).toContain( '<p>5 &lt; 6 &amp; "ok"</p>' );
 	} );
 
+	it( 'escapes literal HTML tags rather than passing them through', () => {
+		const out = buildParagraphBlocks( '<br>' );
+		expect( out ).toContain( '<p>&lt;br&gt;</p>' );
+	} );
+
 	it( 'normalizes CRLF line endings', () => {
 		const out = buildParagraphBlocks( 'one\r\n\r\ntwo' );
 		const paragraphCount = ( out.match( /<!-- wp:paragraph -->/g ) ?? [] ).length;

--- a/client/reader/social/composer/test/build-paragraph-blocks.test.ts
+++ b/client/reader/social/composer/test/build-paragraph-blocks.test.ts
@@ -1,0 +1,54 @@
+import { buildParagraphBlocks } from '../build-paragraph-blocks';
+
+describe( 'buildParagraphBlocks', () => {
+	it( 'wraps a single line in a wp:paragraph block', () => {
+		expect( buildParagraphBlocks( 'hello world' ) ).toBe(
+			[ '<!-- wp:paragraph -->', '<p>hello world</p>', '<!-- /wp:paragraph -->' ].join( '\n' )
+		);
+	} );
+
+	it( 'splits on blank lines into separate paragraph blocks', () => {
+		const out = buildParagraphBlocks( 'first paragraph\n\nsecond paragraph' );
+		expect( out ).toBe(
+			[
+				'<!-- wp:paragraph -->',
+				'<p>first paragraph</p>',
+				'<!-- /wp:paragraph -->',
+				'',
+				'<!-- wp:paragraph -->',
+				'<p>second paragraph</p>',
+				'<!-- /wp:paragraph -->',
+			].join( '\n' )
+		);
+	} );
+
+	it( 'turns single newlines inside a paragraph into <br>', () => {
+		const out = buildParagraphBlocks( 'line one\nline two' );
+		expect( out ).toContain( '<p>line one<br>line two</p>' );
+	} );
+
+	it( 'collapses runs of blank lines into one paragraph break', () => {
+		const out = buildParagraphBlocks( 'a\n\n\n\nb' );
+		const paragraphCount = ( out.match( /<!-- wp:paragraph -->/g ) ?? [] ).length;
+		expect( paragraphCount ).toBe( 2 );
+	} );
+
+	it( 'HTML-escapes ampersands and angle brackets in paragraph text', () => {
+		const out = buildParagraphBlocks( '5 < 6 & "ok"' );
+		expect( out ).toContain( '<p>5 &lt; 6 &amp; "ok"</p>' );
+	} );
+
+	it( 'normalizes CRLF line endings', () => {
+		const out = buildParagraphBlocks( 'one\r\n\r\ntwo' );
+		const paragraphCount = ( out.match( /<!-- wp:paragraph -->/g ) ?? [] ).length;
+		expect( paragraphCount ).toBe( 2 );
+		expect( out ).toContain( '<p>one</p>' );
+		expect( out ).toContain( '<p>two</p>' );
+	} );
+
+	it( 'returns an empty string for empty or whitespace-only input', () => {
+		expect( buildParagraphBlocks( '' ) ).toBe( '' );
+		expect( buildParagraphBlocks( '   ' ) ).toBe( '' );
+		expect( buildParagraphBlocks( '\n\n\n' ) ).toBe( '' );
+	} );
+} );


### PR DESCRIPTION
Fixes CM-780

## Proposed Changes

* Add `buildParagraphBlocks( text )` helper next to the composer that turns plain text into `wp:paragraph` block markup (blank-line-separated, single newlines as `<br>`, HTML-escaped, whitespace-only → empty string).
* Wire it into `composer-overflow-handoff.tsx` so the content handed to `<SiteHandoff>` / `<PreferredSiteHandoff>` is already block markup before it reaches `POST /sites/:id/posts/new`.
* Unit tests for the helper cover: single line, blank-line split, `<br>` inside a paragraph, multi-blank-line collapse, HTML escaping, CRLF normalization, empty/whitespace.

`<SiteHandoff>` itself stays content-agnostic; the existing `<BlogAboutModal>` caller continues to work unchanged because it already builds `wp:embed` block markup at its own call site (via `buildEmbedBlock`).

## Why are these changes being made?

When a post in the Reader social composer exceeds the protocol's character limit, the overflow handoff path opens a draft on the user's WordPress site. Until now, the textarea's raw plain text was sent through as the post body, which the editor then parsed as a single Classic block.

A separate team is currently deprecating the Classic block as part of RSM, and the editor now emits a deprecation warning whenever it opens a draft created via this flow. Converting to `wp:paragraph` blocks at the source removes that warning and gives users a more useful starting point (structured paragraph blocks they can edit, rather than one opaque Classic block).

## Testing Instructions

1. Open `/reader/atmosphere/<connection_id>/profile` (or any atmosphere/mastodon view with the composer).
2. Click "Compose" and type more than 300 characters across multiple paragraphs, including a line with a single `\n` line break and a line containing `<` / `&`.
3. Wait for the "Publish on your own site" / "Too long for…" section to appear, then click "Move to editor".
4. In the editor that opens, confirm:
    * Each blank-line-separated chunk is its own Paragraph block (not a Classic block).
    * Single newlines render as `<br>` inside the same paragraph.
    * `<` and `&` are preserved as escaped characters in the rendered output.
5. (Optional) Repeat with an empty composer triggered via "Add media" on the Fediverse path — the draft should still open with the existing empty-paragraph placeholder, not as a Classic block.

For unit-test coverage:

```
yarn test-client client/reader/social/composer/test/build-paragraph-blocks.test.ts
yarn test-client client/reader/social
```

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?