### PR TITLE
Reader social: enable feature flag in production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -137,7 +137,7 @@
 		"purchases/new-payment-methods": true,
 		"purchases/split-cancel-remove": false,
 		"push-notifications": true,
-		"reader/social": false,
+		"reader/social": true,
 		"reader/full-errors": false,
 		"reader/msd-enabled": true,
 		"reader/onboarding-rsm": false,


### PR DESCRIPTION
Fixes CM-781

## Proposed Changes

* Flip `reader/social` from `false` to `true` in `config/production.json`.

## Why are these changes being made?

We're soft-launching the Reader social feature this afternoon. The flag is already enabled in stage, development, horizon, and wpcalypso — production was the only environment still gating the feature off.

## Testing Instructions

* Confirm the feature is exposed on production once the change deploys.
* No UI regressions expected on other Reader surfaces — the flag toggles a self-contained section.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?