### PR TITLE
Admin sidebar: port public plugin parity fixes

### DIFF
--- a/client/my-sites/sidebar/customize/customize-mode.scss
+++ b/client/my-sites/sidebar/customize/customize-mode.scss
@@ -225,7 +225,7 @@ body.is-admin-sidebar-customize-mode {
 		// override this below with their static gray bg.
 		//
 		// `:not(.admin-sidebar-drop-indicator)` excludes the drop indicator
-		// from this catch-all so its own `background: var(--color-accent)`
+		// from this catch-all so its own customizer accent background
 		// rule isn't overridden into transparent — without the exclusion,
 		// the indicator becomes invisible because this selector has higher
 		// specificity than `li.admin-sidebar-drop-indicator` even when both
@@ -315,7 +315,7 @@ li.admin-sidebar-drop-indicator {
 	padding: 0;
 	height: 2px;
 	width: 100%;
-	background: var(--color-accent, #3858e9) !important;
+	background: var(--wp-admin-sidebar-customizer-theme, #2271b1) !important;
 	pointer-events: none;
 }
 
@@ -342,13 +342,13 @@ li.admin-sidebar-drop-indicator {
 
 	&__cancel {
 		background: transparent;
-		border: 1px solid var(--color-accent, #3858e9);
-		color: var(--color-accent, #3858e9);
+		border: 1px solid var(--wp-admin-sidebar-customizer-theme, #2271b1);
+		color: var(--wp-admin-sidebar-customizer-theme, #2271b1);
 	}
 
 	&__save {
-		background: var(--color-accent, #3858e9);
-		border: 1px solid var(--color-accent, #3858e9);
+		background: var(--wp-admin-sidebar-customizer-theme, #2271b1);
+		border: 1px solid var(--wp-admin-sidebar-customizer-theme, #2271b1);
 		color: #fff;
 
 		&[disabled] {
@@ -379,7 +379,7 @@ li.admin-sidebar-drop-indicator {
 	line-height: 1;
 
 	&:focus-visible {
-		outline: 2px solid var(--color-accent, #3858e9);
+		outline: 2px solid var(--wp-admin-sidebar-customizer-theme, #2271b1);
 		outline-offset: -2px;
 	}
 }
@@ -411,7 +411,7 @@ li.admin-sidebar-drop-indicator {
 	border: 0;
 
 	&:focus-visible {
-		outline: 2px solid var(--color-accent, #3858e9);
+		outline: 2px solid var(--wp-admin-sidebar-customizer-theme, #2271b1);
 		outline-offset: -2px;
 	}
 }

--- a/client/my-sites/sidebar/customize/customize-mode.scss
+++ b/client/my-sites/sidebar/customize/customize-mode.scss
@@ -154,6 +154,20 @@ body.is-admin-sidebar-customize-mode {
 		}
 	}
 
+	// Group collapse is locked while customize mode is active. The toggle is
+	// disabled in React, and the chevron gets a matching visual cue.
+	.wp-admin-sidebar-group--reorder-locked {
+		.wp-admin-sidebar-group__toggle {
+			cursor: not-allowed;
+		}
+
+		.wp-admin-sidebar-group__chevron {
+			cursor: not-allowed;
+			opacity: 0.4;
+			pointer-events: none;
+		}
+	}
+
 	// === EXPANDABLE ITEMS ===
 	// `<MySitesSidebarUnifiedMenu>` → `<ExpandableSidebarMenu>` renders a bare
 	// `<li>` wrapping `.sidebar__menu.is-togglable`, which the inert rule above

--- a/client/my-sites/sidebar/customize/index.tsx
+++ b/client/my-sites/sidebar/customize/index.tsx
@@ -40,7 +40,6 @@ import {
 	useState,
 } from 'react';
 import { useDispatch as useReduxDispatch, useSelector } from 'react-redux';
-import { setAdminSidebarGroupExpanded } from 'calypso/state/admin-sidebar/expand-state/actions';
 import { getAdminSidebarLayout } from 'calypso/state/admin-sidebar/layout/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import {
@@ -188,16 +187,8 @@ export function CustomizeProvider( {
 		// sees the freshly-persisted state.
 		dispatch( { type: 'set', state: createDraftState( savedDelta ) } );
 		setCustomizing( true );
-		// Expand all groups containing reassignable items so the user can see
-		// what they're meant to be reordering. Mirrors `expandGroupsForCustomizing`
-		// in the public plugin's `customizer.js`. (Phase 2 row 16.)
-		// We delegate to the expand-state slice, so entering customize mode
-		// persists the expanded state as the user's current preference.
-		if ( siteId ) {
-			dispatch_expandReassignableGroups( reduxDispatch, siteId );
-		}
 		announce( translate( 'Customize mode entered.' ) as string );
-	}, [ enableCustomize, savedDelta, siteId, reduxDispatch, announce ] );
+	}, [ enableCustomize, savedDelta, announce ] );
 
 	const exit = useCallback(
 		( options: { confirmIfDirty?: boolean } = {} ) => {
@@ -352,21 +343,4 @@ export function CustomizeProvider( {
 			/>
 		</CustomizeContext.Provider>
 	);
-}
-
-/**
- * Force every group containing reassignable items into the expanded state for
- * the duration of customize mode. The expand-state slice records the change;
- * exit doesn't undo it because the user's expanded preference is now this.
- *
- * Mirrors `expandGroupsForCustomizing()` in the public plugin's
- * `customizer.js`. (Phase 2 row 16.) The simplified Calypso version expands
- * the `plugins` group unconditionally — that's the only group that surfaces
- * reassignable items today.
- */
-function dispatch_expandReassignableGroups(
-	reduxDispatch: ReturnType< typeof useReduxDispatch >,
-	siteId: number | string
-): void {
-	reduxDispatch( setAdminSidebarGroupExpanded( siteId, 'plugins', true ) );
 }

--- a/client/my-sites/sidebar/customize/move-menu.tsx
+++ b/client/my-sites/sidebar/customize/move-menu.tsx
@@ -174,6 +174,19 @@ export const MoveMenu = ( { itemId, itemLabel, triggerEl, onClose }: MoveMenuPro
 
 	// Close on click-outside, scroll, resize, ESC.
 	useEffect( () => {
+		const handlePointerDown = ( ev: PointerEvent ) => {
+			const target = ev.target instanceof Element ? ev.target : null;
+			if ( ! target ) {
+				return;
+			}
+			if ( menuRef.current?.contains( target ) ) {
+				return;
+			}
+			if ( triggerEl?.contains( target ) ) {
+				return;
+			}
+			onClose();
+		};
 		const handleClickAway = ( ev: MouseEvent ) => {
 			const target = ev.target instanceof Element ? ev.target : null;
 			if ( ! target ) {
@@ -198,11 +211,13 @@ export const MoveMenu = ( { itemId, itemLabel, triggerEl, onClose }: MoveMenuPro
 		const timer = window.setTimeout( () => {
 			document.addEventListener( 'click', handleClickAway, true );
 		}, 0 );
+		document.addEventListener( 'pointerdown', handlePointerDown, true );
 		document.addEventListener( 'keydown', handleKey );
 		window.addEventListener( 'scroll', handleScrollResize, { passive: true } );
 		window.addEventListener( 'resize', handleScrollResize, { passive: true } );
 		return () => {
 			window.clearTimeout( timer );
+			document.removeEventListener( 'pointerdown', handlePointerDown, true );
 			document.removeEventListener( 'click', handleClickAway, true );
 			document.removeEventListener( 'keydown', handleKey );
 			window.removeEventListener( 'scroll', handleScrollResize );

--- a/client/my-sites/sidebar/customize/move-menu.tsx
+++ b/client/my-sites/sidebar/customize/move-menu.tsx
@@ -4,10 +4,10 @@
  * Calypso-side mirror of the public plugin's `move-menu.js`
  * (`WordPress/wp-admin-sidebar` v0.1.6 `src/customizer/move-menu.js`).
  *
- * Renders a popup with "Move up / Move down / Reset to default" (and, when
- * the layout has multiple destinations, "Move to <group>" / "Move to top
- * level") for the row whose 3-dot trigger was clicked. Commits via the
- * customize controller; the working delta is the source of truth.
+ * Renders a popup with "Move up / Move down / Move to top level" (when the
+ * row is inside a group) and "Reset to default" for the row whose 3-dot
+ * trigger was clicked. Commits via the customize controller; the working
+ * delta is the source of truth.
  *
  * Identical-behaviour anchors:
  * - Position relative to trigger with flip + clamp into viewport (plugin
@@ -41,7 +41,7 @@ export const MoveMenu = ( { itemId, itemLabel, triggerEl, onClose }: MoveMenuPro
 	const customizeCtx = useCustomizeContext();
 	const menuRef = useRef< HTMLUListElement >( null );
 	const [ position, setPosition ] = useState< { top: number; left: number } | null >( null );
-	const destinations = getMoveDestinations( itemId );
+	const isInGroup = getMoveDestinations( itemId ).isInGroup;
 
 	// Compute one-step move directions from the rendered DOM so the menu
 	// crosses group / top-level boundaries naturally (matches plugin's
@@ -90,28 +90,6 @@ export const MoveMenu = ( { itemId, itemLabel, triggerEl, onClose }: MoveMenuPro
 		);
 	}, [ itemId, itemLabel, customizeCtx ] );
 
-	const moveToGroup = useCallback(
-		( groupId: string, groupLabel: string ) => {
-			if ( ! customizeCtx ) {
-				return;
-			}
-			customizeCtx.commitMove( itemId, {
-				kind: 'in_group',
-				group_id: groupId,
-				index: 0,
-			} );
-			customizeCtx.announce(
-				translate( 'Moved %(label)s to %(destination)s.', {
-					args: {
-						label: itemLabel,
-						destination: groupLabel,
-					},
-				} ) as string
-			);
-		},
-		[ itemId, itemLabel, customizeCtx ]
-	);
-
 	const moveToTopLevel = useCallback( () => {
 		if ( ! customizeCtx ) {
 			return;
@@ -127,13 +105,7 @@ export const MoveMenu = ( { itemId, itemLabel, triggerEl, onClose }: MoveMenuPro
 	const choices: MenuChoice[] = [
 		{ label: translate( 'Move up' ) as string, action: () => moveByDirection( -1 ) },
 		{ label: translate( 'Move down' ) as string, action: () => moveByDirection( 1 ) },
-		...destinations.groups.map( ( group ) => ( {
-			label: translate( 'Move to %(destination)s', {
-				args: { destination: group.label },
-			} ) as string,
-			action: () => moveToGroup( group.id, group.label ),
-		} ) ),
-		...( destinations.isInGroup
+		...( isInGroup
 			? [ { label: translate( 'Move to top level' ) as string, action: moveToTopLevel } ]
 			: [] ),
 		{ label: translate( 'Reset to default' ) as string, action: resetToDefault },
@@ -275,46 +247,17 @@ function itemSelector( itemId: string ): string {
 	return `li[data-wp-admin-sidebar-item-id="${ escapeSelectorValue( itemId ) }"]`;
 }
 
-interface GroupDestination {
-	id: string;
-	label: string;
-}
-
 function getMoveDestinations( itemId: string ): {
-	groups: GroupDestination[];
 	isInGroup: boolean;
 } {
 	if ( typeof document === 'undefined' ) {
-		return { groups: [], isInGroup: false };
+		return { isInGroup: false };
 	}
 	const li = document.querySelector( itemSelector( itemId ) ) as HTMLElement | null;
-	const sidebar =
-		( li?.closest( 'ul.sidebar' ) as HTMLElement | null ) ||
-		( document.querySelector( 'ul.sidebar' ) as HTMLElement | null );
 	const currentGroupId = li
 		? li.parentElement?.closest( 'li.wp-admin-sidebar-group' )?.getAttribute( 'data-group' ) ?? null
 		: null;
-	if ( ! sidebar ) {
-		return { groups: [], isInGroup: currentGroupId !== null };
-	}
-	const groups = Array.from(
-		sidebar.querySelectorAll( ':scope > li.wp-admin-sidebar-group[data-group]' )
-	)
-		.map( ( groupEl ) => {
-			const id = groupEl.getAttribute( 'data-group' );
-			if ( ! id || id === currentGroupId ) {
-				return null;
-			}
-			const label =
-				groupEl
-					.querySelector(
-						':scope > .wp-admin-sidebar-group__header .wp-admin-sidebar-group__label'
-					)
-					?.textContent?.trim() || id;
-			return { id, label };
-		} )
-		.filter( ( group ): group is GroupDestination => group !== null );
-	return { groups, isInGroup: currentGroupId !== null };
+	return { isInGroup: currentGroupId !== null };
 }
 
 function positionForMoveTarget(

--- a/client/my-sites/sidebar/customize/test/move-menu.tsx
+++ b/client/my-sites/sidebar/customize/test/move-menu.tsx
@@ -106,4 +106,25 @@ describe( '<MoveMenu>', () => {
 			},
 		] );
 	} );
+
+	it( 'closes on pointerdown outside the menu and trigger', () => {
+		const trigger = setupSidebar( 'plugins' );
+		const onClose = jest.fn();
+
+		renderInProvider(
+			<CustomizeProvider>
+				<ExposeContext />
+				<MoveMenu itemId="stats" itemLabel="Stats" triggerEl={ trigger } onClose={ onClose } />
+			</CustomizeProvider>
+		);
+
+		fireEvent.pointerDown( screen.getByRole( 'menu' ) );
+		fireEvent.pointerDown( trigger );
+
+		expect( onClose ).not.toHaveBeenCalled();
+
+		fireEvent.pointerDown( document.body );
+
+		expect( onClose ).toHaveBeenCalledTimes( 1 );
+	} );
 } );

--- a/client/my-sites/sidebar/customize/test/move-menu.tsx
+++ b/client/my-sites/sidebar/customize/test/move-menu.tsx
@@ -57,7 +57,7 @@ describe( '<MoveMenu>', () => {
 		exposedCtx = null;
 	} );
 
-	it( 'offers group destinations for top-level items and commits the selected group move', () => {
+	it( 'does not offer group destinations for top-level items', () => {
 		const trigger = setupSidebar( 'top_level' );
 
 		renderInProvider(
@@ -67,19 +67,13 @@ describe( '<MoveMenu>', () => {
 			</CustomizeProvider>
 		);
 
-		expect( screen.getByRole( 'menuitem', { name: 'Move to My Plugins' } ) ).toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'menuitem', { name: 'Move to My Plugins' } )
+		).not.toBeInTheDocument();
 		expect(
 			screen.queryByRole( 'menuitem', { name: 'Move to top level' } )
 		).not.toBeInTheDocument();
-
-		fireEvent.click( screen.getByRole( 'menuitem', { name: 'Move to My Plugins' } ) );
-
-		expect( exposedCtx?.draft.workingDelta.overrides ).toEqual( [
-			{
-				itemId: 'stats',
-				position: { kind: 'in_group', group_id: 'plugins', index: 0 },
-			},
-		] );
+		expect( screen.getByRole( 'menuitem', { name: 'Reset to default' } ) ).toBeInTheDocument();
 	} );
 
 	it( 'offers a top-level destination for grouped items', () => {

--- a/client/my-sites/sidebar/sidebar-group.jsx
+++ b/client/my-sites/sidebar/sidebar-group.jsx
@@ -35,11 +35,12 @@
  * State strategy:
  * - Initial expanded state: stored value from the
  * `adminSidebarExpandState` slice if the user has toggled this group
- * before; otherwise the group's `default_expanded` from the response.
+ * before; otherwise the `plugins` group defaults expanded and other
+ * groups follow their `default_expanded` response value.
  * Auto-expand-on-current-URL is Phase 1.4.x polish (kept on the to-do
  * list — not in this PR scope per the task scope's "deferred" list).
- * - Toggle dispatches the `toggleAdminSidebarGroup` action so the slice
- * records the change; `withPersistence` round-trips it across reloads.
+ * - Toggle dispatches an explicit `setAdminSidebarGroupExpanded` action
+ * so collapsing the default-expanded `plugins` group stores `false`.
  * - The actual REST POST flow (server-side persistence) is deferred to
  * Phase 2 task 2.3 (alongside Save in customize mode).
  * @see WordPress/wp-admin-sidebar v0.1.4 src/browse-rail/grouping.js
@@ -52,7 +53,7 @@ import { translate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { useCallback, useId } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { toggleAdminSidebarGroup } from 'calypso/state/admin-sidebar/expand-state/actions';
+import { setAdminSidebarGroupExpanded } from 'calypso/state/admin-sidebar/expand-state/actions';
 import { getAdminSidebarGroupExpanded } from 'calypso/state/admin-sidebar/expand-state/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { useCustomizeContext } from './customize';
@@ -80,17 +81,21 @@ function notifyMenuHeightChanged() {
  * Resolve the rendered expanded state from the prop / stored / default chain.
  * Extracted to a named helper to avoid the nested-ternary lint and to make
  * the priority chain explicit.
+ * @param {string}            groupId          Group id from the endpoint.
  * @param {boolean|undefined} expandedProp     Caller-supplied prop (highest priority).
  * @param {boolean|undefined} storedExpanded   User's stored toggle.
  * @param {boolean|undefined} defaultExpanded  Group metadata default.
  * @returns {boolean}
  */
-function resolveExpanded( expandedProp, storedExpanded, defaultExpanded ) {
+function resolveExpanded( groupId, expandedProp, storedExpanded, defaultExpanded ) {
 	if ( typeof expandedProp === 'boolean' ) {
 		return expandedProp;
 	}
 	if ( typeof storedExpanded === 'boolean' ) {
 		return storedExpanded;
+	}
+	if ( groupId === GROUP_ID_PLUGINS ) {
+		return true;
 	}
 	return defaultExpanded ?? false;
 }
@@ -118,9 +123,15 @@ export const MySitesSidebarUnifiedSidebarGroup = ( {
 	// Resolve initial state in priority order:
 	//   1. caller-supplied `expanded` prop (Storybook / explicit control).
 	//   2. user's stored toggle for this group.
-	//   3. group metadata's `default_expanded`.
-	//   4. fall back to collapsed (matches the public plugin's default).
-	const expanded = resolveExpanded( expandedProp, storedExpanded, group.default_expanded );
+	//   3. `plugins` starts expanded on first encounter.
+	//   4. group metadata's `default_expanded`.
+	//   5. fall back to collapsed.
+	const expanded = resolveExpanded(
+		group.id,
+		expandedProp,
+		storedExpanded,
+		group.default_expanded
+	);
 
 	const labelId = useId();
 	const childrenId = `wp-admin-sidebar-group-${ group.id }-${ labelId }`;
@@ -143,7 +154,7 @@ export const MySitesSidebarUnifiedSidebarGroup = ( {
 			if ( typeof onToggle === 'function' ) {
 				onToggle( event, ! expanded );
 			} else if ( siteId ) {
-				dispatch( toggleAdminSidebarGroup( siteId, group.id ) );
+				dispatch( setAdminSidebarGroupExpanded( siteId, group.id, ! expanded ) );
 			}
 			// Fire after the React state update settles so the new height is
 			// in the DOM by the time listeners read it. requestAnimationFrame

--- a/client/my-sites/sidebar/sidebar-group.jsx
+++ b/client/my-sites/sidebar/sidebar-group.jsx
@@ -20,6 +20,9 @@
  * label + ::after pseudo-element with 250ms show-delay / 100ms hide).
  * Renders only when `customizable` is true (plugins group only today).
  * Stays disabled until Phase 2 wires the click handler.
+ * - Customize mode locks group collapse. Reassignable groups render forced
+ * expanded, with the toggle disabled and the chevron inert, so rows remain
+ * visible while users edit their order.
  * - Group-level signal: an 8×8 `#d63638` dot rendered inline next to the
  * label when the group is collapsed AND `group.signal.attention` is
  * true. Suppressed when expanded — children carry their own item-level
@@ -119,6 +122,9 @@ export const MySitesSidebarUnifiedSidebarGroup = ( {
 	const storedExpanded = useSelector( ( state ) =>
 		getAdminSidebarGroupExpanded( state, siteId, group.id )
 	);
+	const customizeCtx = useCustomizeContext();
+	const isCustomizable = customizable ?? group.id === GROUP_ID_PLUGINS;
+	const isCustomizeLocked = isCustomizable && customizeCtx?.isCustomizing === true;
 
 	// Resolve initial state in priority order:
 	//   1. caller-supplied `expanded` prop (Storybook / explicit control).
@@ -126,23 +132,22 @@ export const MySitesSidebarUnifiedSidebarGroup = ( {
 	//   3. `plugins` starts expanded on first encounter.
 	//   4. group metadata's `default_expanded`.
 	//   5. fall back to collapsed.
-	const expanded = resolveExpanded(
+	const resolvedExpanded = resolveExpanded(
 		group.id,
 		expandedProp,
 		storedExpanded,
 		group.default_expanded
 	);
+	const expanded = isCustomizeLocked ? true : resolvedExpanded;
 
 	const labelId = useId();
 	const childrenId = `wp-admin-sidebar-group-${ group.id }-${ labelId }`;
-	const isCustomizable = customizable ?? group.id === GROUP_ID_PLUGINS;
 	const showAttentionDot = ! expanded && !! group.signal?.attention;
 
 	// When the customize provider is mounted (Phase 2), the customize button
 	// becomes live and clicking it enters customize mode. When no provider is
 	// present (Phase 1 callers, isolated tests, Storybook), the button stays
 	// inert per Phase 1's behaviour — preserves backwards compatibility.
-	const customizeCtx = useCustomizeContext();
 	const handleCustomizeClick = useCallback( () => {
 		if ( customizeCtx ) {
 			customizeCtx.enter();
@@ -151,6 +156,9 @@ export const MySitesSidebarUnifiedSidebarGroup = ( {
 
 	const handleToggle = useCallback(
 		( event ) => {
+			if ( isCustomizeLocked ) {
+				return;
+			}
 			if ( typeof onToggle === 'function' ) {
 				onToggle( event, ! expanded );
 			} else if ( siteId ) {
@@ -163,7 +171,7 @@ export const MySitesSidebarUnifiedSidebarGroup = ( {
 				window.requestAnimationFrame( notifyMenuHeightChanged );
 			}
 		},
-		[ dispatch, group.id, expanded, onToggle, siteId ]
+		[ dispatch, group.id, expanded, isCustomizeLocked, onToggle, siteId ]
 	);
 
 	// Translators: aria-label for the plugins-group customize reorder button.
@@ -182,7 +190,14 @@ export const MySitesSidebarUnifiedSidebarGroup = ( {
 
 	return (
 		<li
-			className={ clsx( 'wp-admin-sidebar-group', 'sidebar-group', className ) }
+			className={ clsx(
+				'wp-admin-sidebar-group',
+				'sidebar-group',
+				{
+					'wp-admin-sidebar-group--reorder-locked': isCustomizeLocked,
+				},
+				className
+			) }
 			data-group={ group.id }
 			data-expanded={ expanded ? 'true' : 'false' }
 		>
@@ -193,6 +208,7 @@ export const MySitesSidebarUnifiedSidebarGroup = ( {
 					aria-expanded={ expanded ? 'true' : 'false' }
 					aria-controls={ childrenId }
 					onClick={ handleToggle }
+					disabled={ isCustomizeLocked }
 				>
 					<span className="wp-admin-sidebar-group__label sidebar-group__label">
 						{ group.label }

--- a/client/my-sites/sidebar/sidebar-group.jsx
+++ b/client/my-sites/sidebar/sidebar-group.jsx
@@ -16,7 +16,7 @@
  * - Header geometry: 34px min-height, padding `4px 4px 4px 8px`,
  * `box-sizing: border-box`. Outer group `margin-top: 16px`. Hover
  * paint is removed at the LI level (matches public plugin issue #35).
- * - Customize button: tooltip `Customize plugins` (data-tooltip + aria-
+ * - Customize button: tooltip `Edit plugin order` (data-tooltip + aria-
  * label + ::after pseudo-element with 250ms show-delay / 100ms hide).
  * Renders only when `customizable` is true (plugins group only today).
  * Stays disabled until Phase 2 wires the click handler.
@@ -166,10 +166,9 @@ export const MySitesSidebarUnifiedSidebarGroup = ( {
 		[ dispatch, group.id, expanded, onToggle, siteId ]
 	);
 
-	// Translators: aria-label for the per-group customize button. Today the
-	// only group surfacing this button is `plugins`, so "Customize plugins"
-	// is accurate. If new groups gain customize buttons, parameterise this.
-	const customizeLabel = translate( 'Customize plugins' );
+	// Translators: aria-label for the plugins-group customize reorder button.
+	// The only action this mode performs is editing plugin order.
+	const customizeLabel = translate( 'Edit plugin order' );
 
 	// Translators: SR-only label announcing how many items in this group
 	// need attention when the group is collapsed.

--- a/client/my-sites/sidebar/sidebar-group.scss
+++ b/client/my-sites/sidebar/sidebar-group.scss
@@ -149,22 +149,21 @@
 		align-items: center;
 		justify-content: center;
 
-		// Lucas's list-view icon (Figma 3505:74996) — public plugin's
-		// `src/browse-rail/icons/list-view.svg` vendored as an inline data-URI
-		// so this file has no asset-pipeline deps. `background: currentColor`
-		// + CSS mask keeps the icon tinted to the &__customize color above
-		// (literal #71aee2, matches the &__toggle color).
+		// Pencil icon from @wordpress/icons, matching public plugin issue #56.
+		// Vendored as an inline data-URI so this file has no asset-pipeline
+		// deps. `background: currentColor` + CSS mask keeps the icon tinted to
+		// the &__customize color above.
 		&::before {
 			content: "";
 			display: block;
-				width: 20px;
-				height: 20px;
-				background: currentColor;
-				/* stylelint-disable function-url-quotes */
-				mask: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 15 10.4167'%3E%3Cpath d='M0 0H9.16667V1.25H0V0ZM2.91667 4.58333H12.0833V5.83333H2.91667V4.58333ZM15 9.16667H5.83333V10.4167H15V9.16667Z'/%3E%3C/svg%3E") no-repeat center / contain;
-				-webkit-mask: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 15 10.4167'%3E%3Cpath d='M0 0H9.16667V1.25H0V0ZM2.91667 4.58333H12.0833V5.83333H2.91667V4.58333ZM15 9.16667H5.83333V10.4167H15V9.16667Z'/%3E%3C/svg%3E") no-repeat center / contain;
-				/* stylelint-enable function-url-quotes */
-			}
+			width: 20px;
+			height: 20px;
+			background: currentColor;
+			/* stylelint-disable function-url-quotes */
+			mask: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='m19 7-3-3-8.5 8.5-1 4 4-1L19 7Zm-7 11.5H5V20h7v-1.5Z'/%3E%3C/svg%3E") no-repeat center / contain;
+			-webkit-mask: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='m19 7-3-3-8.5 8.5-1 4 4-1L19 7Zm-7 11.5H5V20h7v-1.5Z'/%3E%3C/svg%3E") no-repeat center / contain;
+			/* stylelint-enable function-url-quotes */
+		}
 
 		&:hover:not(:disabled) {
 			opacity: 1;
@@ -189,7 +188,8 @@
 			content: attr(data-tooltip);
 			position: absolute;
 			bottom: calc(100% + 6px);
-			right: 0;
+			left: 50%;
+			transform: translateX(-50%);
 			padding: 4px 8px;
 			background: #1d2327;
 			color: #f0f0f1;

--- a/client/my-sites/sidebar/sidebar-group.scss
+++ b/client/my-sites/sidebar/sidebar-group.scss
@@ -38,12 +38,19 @@
 		padding: 0;
 		margin: 0;
 		cursor: pointer;
-		// Literal #71aee2 (wp-admin dashicons-alternative blue). Calypso's
-		// `--color-sidebar-text-alternative` is overridden to a gray in
-		// client/my-sites/sidebar/style.scss, which would win over the var
-		// fallback. Anchor to the literal so the group header reads as
-		// "MY PLUGINS" in blue, matching the public plugin 1:1.
-		color: #71aee2;
+		color: var(--wp-admin-sidebar-group-label-fg, #2271b1);
+		font-family: var(
+			--wp-admin-sidebar-font,
+			-apple-system,
+			BlinkMacSystemFont,
+			"Segoe UI",
+			Roboto,
+			Oxygen-Sans,
+			Ubuntu,
+			Cantarell,
+			"Helvetica Neue",
+			sans-serif
+		);
 		font-size: 11px;
 		font-weight: 600;
 		line-height: 20px;
@@ -52,7 +59,7 @@
 		text-align: left;
 
 		&:focus-visible {
-			outline: 2px solid var(--color-accent, #3858e9);
+			outline: 2px solid var(--wp-admin-sidebar-customizer-theme, #2271b1);
 			outline-offset: 2px;
 		}
 	}
@@ -97,14 +104,14 @@
 	 * Uses the public plugin's outline-chevron SVG (icons/chevron-down.svg)
 	 * vendored inline as a data-URI so this file has no asset-pipeline deps.
 	 * `background: currentColor` + CSS mask keeps the icon tinted to the
-	 * label color (literal #71aee2, see &__toggle above).
+	 * label color.
 	 */
 	&__chevron {
 		flex: 0 0 auto;
 		margin-left: 4px;
 		width: 20px;
 			height: 20px;
-			color: #71aee2;
+			color: var(--wp-admin-sidebar-group-label-fg, #2271b1);
 			background: currentColor;
 			/* stylelint-disable function-url-quotes */
 			mask: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M17.5 11.6004L12 16.0004L6.5 11.6004L7.4 10.4004L12 14.0004L16.5 10.4004L17.5 11.6004Z'/%3E%3C/svg%3E") no-repeat center / 150%;
@@ -143,7 +150,7 @@
 		border: 0;
 		padding: 0;
 		cursor: pointer;
-		color: #71aee2;
+		color: var(--wp-admin-sidebar-group-label-fg, #2271b1);
 		opacity: 0.7;
 		display: inline-flex;
 		align-items: center;
@@ -175,7 +182,7 @@
 		}
 
 		&:focus-visible {
-			outline: 2px solid var(--color-accent, #3858e9);
+			outline: 2px solid var(--wp-admin-sidebar-customizer-theme, #2271b1);
 			outline-offset: 2px;
 		}
 

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -160,6 +160,11 @@ $font-size: rem(14px);
 
 	// client/layout/sidebar/style.scss
 	.sidebar {
+		--wp-admin-sidebar-group-label-fg: var(--wp-admin-theme-color, var(--color-accent, #2271b1));
+		--wp-admin-sidebar-customizer-theme: var(--wp-admin-theme-color, var(--color-accent, #2271b1));
+		--wp-admin-sidebar-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+			Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+
 		position: relative;
 		background-color: var(--color-sidebar-background);
 		padding-bottom: 12px;

--- a/client/my-sites/sidebar/test/sidebar-group.jsx
+++ b/client/my-sites/sidebar/test/sidebar-group.jsx
@@ -4,6 +4,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
+import { ADMIN_SIDEBAR_GROUP_SET_EXPANDED } from 'calypso/state/action-types';
 import { MySitesSidebarUnifiedSidebarGroup } from '../sidebar-group';
 
 const renderInProvider = ( ui, state = {} ) => {
@@ -171,6 +172,52 @@ describe( '<MySitesSidebarUnifiedSidebarGroup>', () => {
 			<MySitesSidebarUnifiedSidebarGroup group={ addonsGroup }>
 				<li>child</li>
 			</MySitesSidebarUnifiedSidebarGroup>
+		);
+		expect( container.querySelector( '.wp-admin-sidebar-group' ) ).toHaveAttribute(
+			'data-expanded',
+			'false'
+		);
+	} );
+
+	it( 'defaults the plugins group to expanded on first encounter', () => {
+		const { container } = renderInProvider(
+			<MySitesSidebarUnifiedSidebarGroup group={ pluginsGroup }>
+				<li>child</li>
+			</MySitesSidebarUnifiedSidebarGroup>
+		);
+		expect( container.querySelector( '.wp-admin-sidebar-group' ) ).toHaveAttribute(
+			'data-expanded',
+			'true'
+		);
+	} );
+
+	it( 'stores collapsed when toggling the default-expanded plugins group', () => {
+		const { store } = renderInProvider(
+			<MySitesSidebarUnifiedSidebarGroup group={ pluginsGroup }>
+				<li>child</li>
+			</MySitesSidebarUnifiedSidebarGroup>
+		);
+
+		fireEvent.click( screen.getByRole( 'button', { name: /My Plugins/i } ) );
+
+		expect( store.getActions() ).toContainEqual( {
+			type: ADMIN_SIDEBAR_GROUP_SET_EXPANDED,
+			siteId: 12345,
+			groupId: 'plugins',
+			expanded: false,
+		} );
+	} );
+
+	it( 'honors stored collapsed state for the plugins group', () => {
+		const { container } = renderInProvider(
+			<MySitesSidebarUnifiedSidebarGroup group={ pluginsGroup }>
+				<li>child</li>
+			</MySitesSidebarUnifiedSidebarGroup>,
+			{
+				adminSidebarExpandState: {
+					bySite: { 12345: { plugins: false } },
+				},
+			}
 		);
 		expect( container.querySelector( '.wp-admin-sidebar-group' ) ).toHaveAttribute(
 			'data-expanded',

--- a/client/my-sites/sidebar/test/sidebar-group.jsx
+++ b/client/my-sites/sidebar/test/sidebar-group.jsx
@@ -104,8 +104,8 @@ describe( '<MySitesSidebarUnifiedSidebarGroup>', () => {
 		);
 		const customize = container.querySelector( '.wp-admin-sidebar-group__customize' );
 		expect( customize ).toBeInTheDocument();
-		expect( customize ).toHaveAttribute( 'aria-label', 'Customize plugins' );
-		expect( customize ).toHaveAttribute( 'data-tooltip', 'Customize plugins' );
+		expect( customize ).toHaveAttribute( 'aria-label', 'Edit plugin order' );
+		expect( customize ).toHaveAttribute( 'data-tooltip', 'Edit plugin order' );
 		// Phase 1 keeps it disabled until Phase 2 wires the click handler.
 		expect( customize ).toBeDisabled();
 	} );

--- a/client/my-sites/sidebar/test/sidebar-group.jsx
+++ b/client/my-sites/sidebar/test/sidebar-group.jsx
@@ -5,7 +5,14 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import { ADMIN_SIDEBAR_GROUP_SET_EXPANDED } from 'calypso/state/action-types';
+import { useCustomizeContext } from '../customize';
 import { MySitesSidebarUnifiedSidebarGroup } from '../sidebar-group';
+
+jest.mock( '../customize', () => ( {
+	useCustomizeContext: jest.fn(),
+} ) );
+
+const mockUseCustomizeContext = useCustomizeContext;
 
 const renderInProvider = ( ui, state = {} ) => {
 	const store = configureStore()( {
@@ -33,6 +40,10 @@ const addonsGroup = {
 };
 
 describe( '<MySitesSidebarUnifiedSidebarGroup>', () => {
+	beforeEach( () => {
+		mockUseCustomizeContext.mockReturnValue( null );
+	} );
+
 	it( 'renders the group label', () => {
 		renderInProvider(
 			<MySitesSidebarUnifiedSidebarGroup group={ pluginsGroup }>
@@ -223,6 +234,35 @@ describe( '<MySitesSidebarUnifiedSidebarGroup>', () => {
 			'data-expanded',
 			'false'
 		);
+	} );
+
+	it( 'locks the plugins group expanded during customize mode', () => {
+		mockUseCustomizeContext.mockReturnValue( {
+			isCustomizing: true,
+			enter: jest.fn(),
+		} );
+		const { container, store } = renderInProvider(
+			<MySitesSidebarUnifiedSidebarGroup group={ pluginsGroup }>
+				<li>child</li>
+			</MySitesSidebarUnifiedSidebarGroup>,
+			{
+				adminSidebarExpandState: {
+					bySite: { 12345: { plugins: false } },
+				},
+			}
+		);
+		const group = container.querySelector( '.wp-admin-sidebar-group' );
+		const toggle = container.querySelector( '.wp-admin-sidebar-group__toggle' );
+		const chevron = container.querySelector( '.wp-admin-sidebar-group__chevron' );
+
+		expect( group ).toHaveClass( 'wp-admin-sidebar-group--reorder-locked' );
+		expect( group ).toHaveAttribute( 'data-expanded', 'true' );
+		expect( toggle ).toBeDisabled();
+
+		fireEvent.click( chevron );
+
+		expect( store.getActions() ).toEqual( [] );
+		expect( group ).toHaveAttribute( 'data-expanded', 'true' );
 	} );
 
 	it( 'reads stored expand state from Redux when no prop is supplied', () => {


### PR DESCRIPTION
Part of https://github.com/WordPress/wp-admin-sidebar/issues/54

## Proposed Changes

* Port the verified public `wp-admin-sidebar` fixes from PRs:
  * https://github.com/WordPress/wp-admin-sidebar/pull/64
  * https://github.com/WordPress/wp-admin-sidebar/pull/65
  * https://github.com/WordPress/wp-admin-sidebar/pull/66
  * https://github.com/WordPress/wp-admin-sidebar/pull/70
  * https://github.com/WordPress/wp-admin-sidebar/pull/71
  * https://github.com/WordPress/wp-admin-sidebar/pull/72 
* Default-expand the My Plugins group on first encounter, clarify the plugin-order entry point, lock groups while editing, close the More options menu when drag starts, simplify move destinations, and bind the redesign accent to Calypso's active admin color scheme.
* Keep the Calypso implementation aligned with the now-merged public plugin changes before the next plugin release and wpcom vendoring pass.

### Media

https://github.com/user-attachments/assets/99a76a59-7734-4209-9d0e-d1020bf9f281

## Why are these changes being made?

The public plugin parity fixes have been verified one by one in Calypso on a stickered site. This PR collects the matching Calypso frontend changes in one branch so the Calypso surface does not drift from the public plugin behavior.

## Testing Instructions

1. Open `http://calypso.localhost:3000/home/[site]` on a stickered site with the redesigned sidebar active.
2. Confirm the My Plugins group is expanded on first visit and can be collapsed and reopened.
3. Click `Edit plugin order` and confirm group collapse is locked while editing.
4. Open a row's More options menu, start dragging a row, and confirm the menu closes.
5. Confirm the row menu only offers valid moves: top-level items show Move up, Move down, Reset to default, and grouped items also show Move to top level.
6. Confirm the group label, pencil icon, chevron, Save button, Cancel outline, focus rings, and drag indicator all follow the active admin color-scheme accent.

Focused checks run:

* `yarn stylelint client/my-sites/sidebar/style.scss client/my-sites/sidebar/sidebar-group.scss client/my-sites/sidebar/customize/customize-mode.scss`
* `yarn test-client --runTestsByPath client/my-sites/sidebar/test/sidebar-group.jsx client/my-sites/sidebar/customize/test/move-menu.tsx client/my-sites/sidebar/customize/test/drag-drop.ts client/my-sites/sidebar/customize/test/footer.tsx`
* Browser verification on local Calypso using `chriskmnds.wordpress.com`, including Modern, Sunrise, and Midnight accent checks.
* Browser console error check, no console errors found.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
