### PR TITLE
E2E: handle FSE template duplication prompt

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts
@@ -178,6 +178,28 @@ export class FullSiteEditorPage {
 	 */
 	async openTemplateEditor( text: string ): Promise< void > {
 		await this.fullSiteEditorDataViewsComponent.clickPrimaryFieldByExactText( text );
+		await this.confirmTemplateDuplicationIfRequired();
+	}
+
+	/**
+	 * Bundled templates may require duplicating before they can be edited.
+	 */
+	private async confirmTemplateDuplicationIfRequired(): Promise< void > {
+		const editorParent = await this.editor.parent();
+		const duplicateDialog = editorParent.getByRole( 'dialog', { name: 'Duplicate' } );
+		const duplicateButton = duplicateDialog.getByRole( 'button', {
+			name: 'Duplicate',
+			exact: true,
+		} );
+		const editDuplicatedTemplateButton = editorParent
+			.locator( '.components-snackbar' )
+			.getByRole( 'button', { name: 'Edit', exact: true } );
+
+		if ( await duplicateButton.isVisible( { timeout: 5000 } ).catch( () => false ) ) {
+			await duplicateButton.click();
+			await duplicateDialog.waitFor( { state: 'hidden' } );
+			await editDuplicatedTemplateButton.click();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Follow-up to #110954.

## Proposed Changes

* Confirm the "Duplicate" prompt when opening a bundled Full Site Editor template from DataViews.
* Click the duplicate-created notice's "Edit" action so the flow opens the real template editor.
* Keep the final canvas wait in place so the smoke test still proves the editor actually loads.

## Why are these changes being made?

* Atomic Build Smoke E2E desktop started failing at #10655 in `fse__temp-smoke-test.ts` while waiting for the editor canvas.
* Artifacts show the flow stopped on the "Duplicate" modal after selecting the Index template. After confirming the modal, the flow stayed on the created-template list until the notice's "Edit" action was clicked.
* #110954 removed a stale cached canvas locator, which made this test stop false-passing. This PR completes the real UI path instead of loosening the canvas assertion.

## Testing Instructions

* `yarn eslint packages/calypso-e2e/src/lib/pages/full-site-editor-page.ts`
* `yarn workspace @automattic/calypso-e2e build`
* `yarn typecheck-packages`
* Personal Atomic Build Smoke desktop run passed: https://teamcity.a8c.com/buildConfiguration/calypso_WPComTests_jetpack_atomic_build_smoke_e2e_desktop/17881013

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?