### PR TITLE
Add dark mode agent guidance

### DIFF
--- a/client/dashboard/AGENTS.md
+++ b/client/dashboard/AGENTS.md
@@ -17,6 +17,7 @@ This is the new hosting dashboard for WordPress.com.
 
 ### Dark mode
 
-- Shared dark-mode tokens and cross-surface component overrides live in `client/lib/color-scheme/dark-theme.scss`. Add dashboard-only exceptions to `client/dashboard/app/_dark-theme.scss` using the existing `dashboard-dark-theme-*` mixins (or add a new one and `@include` it from `dashboard-dark-theme`) instead of writing ad-hoc `:root[data-theme='dark']` blocks elsewhere.
+- Shared dark-mode tokens and component-wide overrides for components used across multiple Calypso surfaces live in `client/lib/color-scheme/dark-theme.scss`. Add dashboard-only exceptions to `client/dashboard/app/_dark-theme.scss` using the existing `dashboard-dark-theme-*` mixins (or add a new one and `@include` it from `dashboard-dark-theme`) instead of writing ad-hoc `:root[data-theme='dark']` blocks elsewhere.
+- When adding a component that is not already used in a dark-mode-supported surface, verify it in dark mode and add or reuse overrides where needed. If the component is already covered by the existing dark-mode baseline, assume the shared styling holds unless the new usage introduces new variants, states, wrappers, or local CSS.
 - Prefer overriding the existing CSS custom properties (`--dashboard-*`, `--wp-components-*`, `--jp-*`) over hardcoding hex values in component styles.
 - For styles authored inside a CSS Module (`*.module.scss`), `:root`-based overrides cannot reach the scope-hashed class. Use the shared `when-dark-theme` mixin from `calypso/assets/stylesheets/shared/mixins/dark-theme` — see `packages/ui/AGENTS.md`.

--- a/client/my-sites/themes/AGENTS.md
+++ b/client/my-sites/themes/AGENTS.md
@@ -1,0 +1,11 @@
+# Themes
+
+The Themes surface renders the Theme Showcase on `/themes` and related views for logged-in, logged-out, single-site, and Jetpack-site flows.
+
+## Dark mode
+
+- Themes dark mode is supported for logged-in users who have opted in to the Dashboard experience. The current route gate lives in `shouldEnableThemesColorScheme()` and applies to non-site Themes routes when `isLoggedIn` and `dashboardOptIn` are both true.
+- Shared dark-mode tokens and component-wide overrides for components used across multiple Calypso surfaces live in `client/lib/color-scheme/dark-theme.scss`. Prefer adding or reusing values there when the style belongs to shared components outside Themes or affects multiple areas.
+- Themes-only dark-mode exceptions live in `client/my-sites/themes/_dark-mode.scss`. Keep local overrides there when the styling is specific to the Theme Showcase.
+- When adding a component that is not already used in a dark-mode-supported surface, verify it in dark mode and add or reuse overrides where needed. If the component is already covered by the existing dark-mode baseline, assume the shared styling holds unless the new usage introduces new variants, states, wrappers, or local CSS.
+- Prefer overriding existing CSS custom properties over hardcoded colors.

--- a/client/reader/AGENTS.md
+++ b/client/reader/AGENTS.md
@@ -15,6 +15,13 @@ yarn test-client:watch client/reader/<path>  # Run Reader tests in watch mode
 
 ## Architecture decisions
 
+### Dark mode
+
+- Shared dark-mode tokens and component-wide overrides for components used across multiple Calypso surfaces live in `client/lib/color-scheme/dark-theme.scss`. Prefer adding or reusing values there when the style belongs to shared components outside Reader or affects multiple areas.
+- When adding a component that is not already used in a dark-mode-supported surface, verify it in dark mode and add or reuse overrides where needed. If the component is already covered by the existing dark-mode baseline, assume the shared styling holds unless the new usage introduces new variants, states, wrappers, or local CSS.
+- Keep Reader-only dark-mode exceptions close to the Reader stylesheet that owns the surface, and prefer overriding existing CSS custom properties over hardcoded colors.
+- For styles authored inside a CSS Module (`*.module.scss`), `:root`-based overrides cannot reach the scope-hashed class. Use the shared `when-dark-theme` mixin from `calypso/assets/stylesheets/shared/mixins/dark-theme`; see `packages/ui/AGENTS.md`.
+
 ### Data fetching migration
 
 The Reader is migrating from **Redux + data-layer** to **React Query** using the `@automattic/api-core` and `@automattic/api-queries` packages from the same codebase.

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -24,4 +24,8 @@ Component styles in this package live in CSS Modules (`*.module.scss`), so the l
 
 The mixin emits rules for both `:root[data-theme='dark']` and `:root[data-theme='system']` under `prefers-color-scheme: dark`, so consumers of either toggle behave the same.
 
-Prefer reading colors from `_theme-variables.scss` (which resolves to the `--wp-components-*` custom properties the dashboard overrides in dark mode) over hardcoded hex values, so most components need no dark-mode branch at all.
+Prefer reading colors from `_theme-variables.scss` (which resolves to the `--wp-components-*` custom properties overridden by the shared color-scheme layer) over hardcoded hex values, so most components need no dark-mode branch at all.
+
+Shared dark-mode tokens and component-wide overrides for components used across multiple Calypso surfaces live in `client/lib/color-scheme/dark-theme.scss`; add package-local dark-mode rules only when the component itself owns the exceptional styling.
+
+When adding a component that is not already used in a dark-mode-supported surface, verify it in dark mode and add or reuse overrides where needed. If the component is already covered by the existing dark-mode baseline, assume the shared styling holds unless the new usage introduces new variants, states, wrappers, or local CSS.


### PR DESCRIPTION
Part of #

## Proposed Changes

* Add Reader dark-mode agent guidance covering shared tokens, component-wide overrides, Reader-only exceptions, CSS Module handling, and the dark-mode baseline rule for newly introduced components.
* Add a Themes agent guide that records the logged-in Dashboard opt-in dark-mode support path and points Themes-only exceptions to the Themes dark-mode stylesheet.
* Align Dashboard and shared UI agent guidance with the shared color-scheme layer and the same baseline rule for component verification.

## Why are these changes being made?

Dark mode now spans Dashboard, Reader, shared UI components, and Themes for logged-in users who have opted in to the Dashboard experience. The existing guidance was Dashboard-centered and did not clearly tell agents how to distinguish shared tokens, component-wide overrides, and surface-local exceptions. That gap makes future dark-mode work more likely to duplicate overrides or miss a component that needs verification.

This updates the agent docs so shared tokens and multi-surface component overrides point to the shared color-scheme layer, while Reader and Themes exceptions stay with their owning surfaces. It also records the baseline rule: components already covered by dark-mode-supported surfaces can rely on existing styling unless new variants, states, wrappers, or local CSS are introduced.

## Testing Instructions

* Reviewed the dark-mode agent guidance for Dashboard, Reader, Themes, and shared UI.
* Checked the diff for whitespace errors with `git diff --check`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
