### PR TITLE
Fix dark mode surface regressions

### DIFF
--- a/client/my-sites/themes/_dark-mode.scss
+++ b/client/my-sites/themes/_dark-mode.scss
@@ -133,7 +133,7 @@
 		color: var( --wp-components-color-accent-darker-20 );
 
 		&:hover {
-			color: var( --wp-components-color-accent-darker-40 );
+			color: var( --wp-components-color-accent-darker-10 );
 		}
 	}
 

--- a/packages/wpcom-template-parts/package.json
+++ b/packages/wpcom-template-parts/package.json
@@ -42,6 +42,7 @@
 		"@automattic/components": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@wordpress/url": "^4.23.0",
+		"clsx": "^2.1.1",
 		"i18n-calypso": "workspace:^",
 		"social-logos": "^3.1.18"
 	},

--- a/test/e2e/specs/color-scheme/dark-mode-surfaces.spec.ts
+++ b/test/e2e/specs/color-scheme/dark-mode-surfaces.spec.ts
@@ -392,8 +392,6 @@ async function expectSelectedDarkModeControl( page: Page ) {
 }
 
 test.describe( 'Dashboard dark-mode surface', { tag: [ tags.DASHBOARD_PR ] }, () => {
-	test.skip( true, 'Skipping it while we investigate the flakyness' );
-
 	test( 'applies shared dark-mode tokens on sites, site overview, and appearance routes', async ( {
 		accountGivenByEnvironment,
 		page,
@@ -454,8 +452,6 @@ test.describe( 'Dashboard dark-mode surface', { tag: [ tags.DASHBOARD_PR ] }, ()
 } );
 
 test.describe( 'Reader dark-mode surface', { tag: [ tags.CALYPSO_PR ] }, () => {
-	test.skip( true, 'Skipping it while we investigate the flakyness' );
-
 	test( 'applies shared dark-mode tokens on primary and secondary Reader routes', async ( {
 		accountGivenByEnvironment,
 		page,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2710,6 +2710,7 @@ __metadata:
     "@automattic/components": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
     "@wordpress/url": "npm:^4.23.0"
+    clsx: "npm:^2.1.1"
     i18n-calypso: "workspace:^"
     social-logos: "npm:^3.1.18"
     typescript: "npm:^5.8.3"


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Restore a defined dark-mode hover color for the Themes close/back control.
* Declare `clsx` as a direct runtime dependency of `@automattic/wpcom-template-parts`.
* Re-enable the Dashboard and Reader dark-mode E2E coverage now that the skipped cases pass locally.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The shared dark-mode token work left the Themes close/back control pointing at a token that is not defined in the dark theme bridge, which meant the hover state could disappear in dark mode. This switches the hover state to an adjacent defined accent token so the interaction remains visible without adding a new one-off color.

The template-parts package imports `clsx`, but the package did not declare it as its own dependency. Adding the direct dependency keeps package consumers from relying on incidental workspace hoisting. The previously skipped dark-mode surface tests are also enabled again after local validation showed they are stable when Calypso is run with all sections available and the dark-mode feature enabled.

## Testing Instructions

* Start Calypso with the dark-mode feature enabled, visit the Primarium theme detail page in dark mode, and confirm the close/back control keeps a visible hover state.
* Confirm Dashboard, Reader, and Themes dark-mode surfaces render with dark roots and shared tokens.
* Local validation completed: immutable install check, changed stylesheet CSS lint, template-parts package build, color-scheme unit coverage, and repeated focused Playwright dark-mode coverage.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
