### PR TITLE
Reader achievements: add status labels + adopt endpoint v2 fields

### DIFF
--- a/client/reader/components/achievements/years-of-service-badge/style.scss
+++ b/client/reader/components/achievements/years-of-service-badge/style.scss
@@ -33,12 +33,12 @@
 }
 
 .years-of-service-badge.is-achievement-card {
-	width: 80px;
+	width: 100px;
 
 	.years-of-service-badge__circle {
-		width: 80px;
-		height: 80px;
-		font-size: 2rem;
+		width: 100px;
+		height: 100px;
+		font-size: 2.75rem;
 		background: url( calypso/assets/images/achievements/years-of-service-badge.svg ) no-repeat center / cover;
 	}
 }

--- a/client/reader/components/achievements/years-of-service-badge/style.scss
+++ b/client/reader/components/achievements/years-of-service-badge/style.scss
@@ -33,12 +33,12 @@
 }
 
 .years-of-service-badge.is-achievement-card {
-	width: 100px;
+	width: 80px;
 
 	.years-of-service-badge__circle {
-		width: 100px;
-		height: 100px;
-		font-size: 2.75rem;
+		width: 80px;
+		height: 80px;
+		font-size: 2rem;
 		background: url( calypso/assets/images/achievements/years-of-service-badge.svg ) no-repeat center / cover;
 	}
 }

--- a/client/reader/user-profile/views/achievements/achievements-grid/achievement-card.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/achievement-card.tsx
@@ -3,6 +3,7 @@ import { formatNumber } from '@automattic/number-formatters';
 import { Icon } from '@wordpress/components';
 import { lock } from '@wordpress/icons';
 import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
 import type { ReactNode } from 'react';
 
 interface AchievementCardProps {
@@ -14,6 +15,12 @@ interface AchievementCardProps {
 	image?: string;
 	locked?: boolean;
 	secret?: boolean;
+	/** Render the "Secret" status label inline next to the title. */
+	isSecret?: boolean;
+	/** Render the "Retired" status label inline next to the title. */
+	isRetired?: boolean;
+	/** Render the "A8C-only" status label inline next to the title. */
+	isA8cOnly?: boolean;
 	progressCurrent?: number;
 	progressTarget?: number;
 	className?: string;
@@ -28,10 +35,14 @@ export default function AchievementCard( {
 	caption,
 	locked,
 	secret,
+	isSecret,
+	isRetired,
+	isA8cOnly,
 	progressCurrent,
 	progressTarget,
 	className,
 }: AchievementCardProps ) {
+	const translate = useTranslate();
 	const showLockIcon = locked || secret;
 	const rootClass = clsx( 'achievement-card', className, {
 		'is-locked': locked,
@@ -59,6 +70,13 @@ export default function AchievementCard( {
 				<h3 className="achievement-card__title">
 					{ title }
 					{ badge && <span className="achievement-card__badge">{ badge }</span> }
+					{ isSecret && <span className="achievement-card__label">{ translate( 'Secret' ) }</span> }
+					{ isRetired && (
+						<span className="achievement-card__label">{ translate( 'Retired' ) }</span>
+					) }
+					{ isA8cOnly && (
+						<span className="achievement-card__label">{ translate( 'A8C-only' ) }</span>
+					) }
 				</h3>
 				{ description && <p className="achievement-card__description">{ description }</p> }
 				{ caption && <p className="achievement-card__caption">{ caption }</p> }

--- a/client/reader/user-profile/views/achievements/achievements-grid/achievement-card.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/achievement-card.tsx
@@ -44,6 +44,7 @@ export default function AchievementCard( {
 }: AchievementCardProps ) {
 	const translate = useTranslate();
 	const showLockIcon = locked || secret;
+	const hasLabels = !! ( isSecret || isRetired || isA8cOnly );
 	const rootClass = clsx( 'achievement-card', className, {
 		'is-locked': locked,
 		'is-secret': secret,
@@ -65,18 +66,28 @@ export default function AchievementCard( {
 
 	return (
 		<div className={ rootClass }>
-			{ renderIcon() }
+			<div className="achievement-card__icon-column">
+				{ renderIcon() }
+				{ hasLabels && (
+					<div className="achievement-card__labels">
+						{ isSecret && (
+							<span className="achievement-card__label is-secret">{ translate( 'Secret' ) }</span>
+						) }
+						{ isRetired && (
+							<span className="achievement-card__label is-retired">{ translate( 'Retired' ) }</span>
+						) }
+						{ isA8cOnly && (
+							<span className="achievement-card__label is-a8c-only">
+								{ translate( 'A8C-only' ) }
+							</span>
+						) }
+					</div>
+				) }
+			</div>
 			<div className="achievement-card__details">
 				<h3 className="achievement-card__title">
 					{ title }
 					{ badge && <span className="achievement-card__badge">{ badge }</span> }
-					{ isSecret && <span className="achievement-card__label">{ translate( 'Secret' ) }</span> }
-					{ isRetired && (
-						<span className="achievement-card__label">{ translate( 'Retired' ) }</span>
-					) }
-					{ isA8cOnly && (
-						<span className="achievement-card__label">{ translate( 'A8C-only' ) }</span>
-					) }
 				</h3>
 				{ description && <p className="achievement-card__description">{ description }</p> }
 				{ caption && <p className="achievement-card__caption">{ caption }</p> }

--- a/client/reader/user-profile/views/achievements/achievements-grid/anniversary-achievement.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/anniversary-achievement.tsx
@@ -13,7 +13,7 @@ export default function AnniversaryAchievement( {
 	const translate = useTranslate();
 	const anniversaries = achievements.filter( ( a ) => a.slug === 'user_anniversary' );
 	const mostRecent = anniversaries.reduce( ( a, b ) =>
-		new Date( a.date ) > new Date( b.date ) ? a : b
+		new Date( a.date_unlocked ) > new Date( b.date_unlocked ) ? a : b
 	);
 
 	return (
@@ -21,12 +21,12 @@ export default function AnniversaryAchievement( {
 			image={ achievement.image }
 			title={ achievement.name }
 			isSecret={ achievement.is_secret }
-			isRetired={ achievement.is_retired }
+			isRetired={ !! achievement.date_retired }
 			isA8cOnly={ achievement.is_a8c_only }
 			description={ achievement.description }
 			caption={ translate( 'Last unlocked: {{timeSince/}}', {
 				components: {
-					timeSince: <TimeSince date={ mostRecent.date } />,
+					timeSince: <TimeSince date={ mostRecent.date_unlocked } />,
 				},
 			} ) }
 		/>

--- a/client/reader/user-profile/views/achievements/achievements-grid/anniversary-achievement.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/anniversary-achievement.tsx
@@ -20,6 +20,9 @@ export default function AnniversaryAchievement( {
 		<AchievementCard
 			image={ achievement.image }
 			title={ achievement.name }
+			isSecret={ achievement.is_secret }
+			isRetired={ achievement.is_retired }
+			isA8cOnly={ achievement.is_a8c_only }
 			description={ achievement.description }
 			caption={ translate( 'Last unlocked: {{timeSince/}}', {
 				components: {

--- a/client/reader/user-profile/views/achievements/achievements-grid/generic-achievement.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/generic-achievement.tsx
@@ -59,6 +59,9 @@ export default function GenericAchievement( {
 					? translate( 'Level %(level)d', { args: { level: achievement.level } } )
 					: undefined
 			}
+			isSecret={ achievement.is_secret }
+			isRetired={ achievement.is_retired }
+			isA8cOnly={ achievement.is_a8c_only }
 			description={ achievement.description }
 			caption={ caption() }
 		/>

--- a/client/reader/user-profile/views/achievements/achievements-grid/generic-achievement.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/generic-achievement.tsx
@@ -16,7 +16,7 @@ export default function GenericAchievement( {
 	const translate = useTranslate();
 	const hasMultiple = achievements.filter( ( a ) => a.slug === achievement.slug ).length > 1;
 	const oldest = hasMultiple ? getOldestAchievement( achievement.slug, achievements ) : undefined;
-	const unlockDate = oldest?.date ?? achievement.date;
+	const unlockDate = oldest?.date_unlocked ?? achievement.date_unlocked;
 	const siteId = oldest?.site_ID ?? achievement.site_ID ?? 0;
 	const { data: site } = useQuery( {
 		...siteByIdQuery( siteId ),
@@ -60,7 +60,7 @@ export default function GenericAchievement( {
 					: undefined
 			}
 			isSecret={ achievement.is_secret }
-			isRetired={ achievement.is_retired }
+			isRetired={ !! achievement.date_retired }
 			isA8cOnly={ achievement.is_a8c_only }
 			description={ achievement.description }
 			caption={ caption() }

--- a/client/reader/user-profile/views/achievements/achievements-grid/index.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/index.tsx
@@ -2,17 +2,13 @@ import { Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useAchievementsQuery } from 'calypso/data/reader/use-achievements-query';
-import {
-	deduplicateAchievementsById,
-	deduplicateAchievementsBySlug,
-	isFullyEarned,
-	isMaskedSecret,
-} from '../utils';
+import { deduplicateAchievementsById, deduplicateAchievementsBySlug } from '../utils';
 import AnniversaryAchievement from './anniversary-achievement';
 import GenericAchievement from './generic-achievement';
 import LockedAchievementCard from './locked-achievement-card';
 import SecretAchievementCard from './secret-achievement-card';
 import YearsOfServiceAchievementCard from './years-of-service-achievement-card';
+import type { Achievement, MaskedSecretAchievement } from '@automattic/api-core';
 
 import './style.scss';
 
@@ -52,17 +48,38 @@ export default function AchievementsGrid( { userLogin, isOwnProfile }: Achieveme
 		return <p className="achievements-grid__empty">{ translate( 'No achievements yet.' ) }</p>;
 	}
 
-	const earned = achievements.filter( isFullyEarned );
-	const maskedSecrets = deduplicateAchievementsById( achievements.filter( isMaskedSecret ) );
-	const dedupedEarned = deduplicateAchievementsBySlug( earned );
+	const earned: Achievement[] = [];
+	const maskedSecretsRaw: MaskedSecretAchievement[] = [];
+	for ( const a of achievements ) {
+		if ( a.is_redacted ) {
+			maskedSecretsRaw.push( a );
+		} else {
+			earned.push( a );
+		}
+	}
+	const maskedSecrets = deduplicateAchievementsById( maskedSecretsRaw );
+
+	// Earned + masked secrets sorted by `date_unlocked` descending — most
+	// recently unlocked first. Dedupe by slug already returns the latest unlock
+	// per slug, so sorting on `date_unlocked` is correct for leveled achievements
+	// too. Tolerate missing values during the endpoint rollout.
+	const sortedEarned = [ ...deduplicateAchievementsBySlug( earned ), ...maskedSecrets ].sort(
+		( a, b ) => ( b.date_unlocked ?? '' ).localeCompare( a.date_unlocked ?? '' )
+	);
+
+	// Locked entries have no unlock date — sort by registry creation date,
+	// oldest first. Tolerate missing `date_created` during the endpoint rollout
+	// (otherwise `localeCompare` on undefined throws).
 	const sortedLocked = deduplicateAchievementsById(
-		[ ...lockedAchievements ].sort( ( a, b ) => a.date_created.localeCompare( b.date_created ) )
+		[ ...lockedAchievements ].sort( ( a, b ) =>
+			( a.date_created ?? '' ).localeCompare( b.date_created ?? '' )
+		)
 	);
 
 	const showYearsOfService = !! yearsOfService;
 	const showCelebratory = isOwnProfile && earned.length > 0 && lockedAchievements.length === 0;
 	const showLockedSection = isOwnProfile && sortedLocked.length > 0;
-	const showEarnedGrid = dedupedEarned.length > 0 || maskedSecrets.length > 0 || showYearsOfService;
+	const showEarnedGrid = sortedEarned.length > 0 || showYearsOfService;
 
 	return (
 		<>
@@ -71,24 +88,29 @@ export default function AchievementsGrid( { userLogin, isOwnProfile }: Achieveme
 					{ showYearsOfService && (
 						<YearsOfServiceAchievementCard yearsOfService={ yearsOfService } />
 					) }
-					{ dedupedEarned.map( ( a ) =>
-						a.slug === 'user_anniversary' ? (
-							<AnniversaryAchievement
-								key={ a.achievement_id }
-								achievement={ a }
-								achievements={ earned }
-							/>
-						) : (
+					{ sortedEarned.map( ( a ) => {
+						if ( a.is_redacted ) {
+							return (
+								<SecretAchievementCard key={ a.achievement_id } unlockedDate={ a.date_unlocked } />
+							);
+						}
+						if ( a.slug === 'user_anniversary' ) {
+							return (
+								<AnniversaryAchievement
+									key={ a.achievement_id }
+									achievement={ a }
+									achievements={ earned }
+								/>
+							);
+						}
+						return (
 							<GenericAchievement
 								key={ a.achievement_id }
 								achievement={ a }
 								achievements={ earned }
 							/>
-						)
-					) }
-					{ maskedSecrets.map( ( a ) => (
-						<SecretAchievementCard key={ a.achievement_id } unlockedDate={ a.date } />
-					) ) }
+						);
+					} ) }
 				</div>
 			) }
 

--- a/client/reader/user-profile/views/achievements/achievements-grid/locked-achievement-card.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/locked-achievement-card.tsx
@@ -1,9 +1,10 @@
+import { isLockedSecret } from '../utils';
 import AchievementCard from './achievement-card';
 import SecretAchievementCard from './secret-achievement-card';
 import type { LockedAchievementEntry } from '@automattic/api-core';
 
 export default function LockedAchievementCard( { entry }: { entry: LockedAchievementEntry } ) {
-	if ( entry.is_secret ) {
+	if ( isLockedSecret( entry ) ) {
 		return <SecretAchievementCard locked />;
 	}
 

--- a/client/reader/user-profile/views/achievements/achievements-grid/locked-achievement-card.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/locked-achievement-card.tsx
@@ -12,6 +12,7 @@ export default function LockedAchievementCard( { entry }: { entry: LockedAchieve
 		<AchievementCard
 			locked
 			title={ entry.name }
+			isA8cOnly={ entry.is_a8c_only }
 			description={ entry.description }
 			progressCurrent={ entry.progress }
 			progressTarget={ entry.target }

--- a/client/reader/user-profile/views/achievements/achievements-grid/locked-achievement-card.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/locked-achievement-card.tsx
@@ -1,10 +1,9 @@
-import { isLockedSecret } from '../utils';
 import AchievementCard from './achievement-card';
 import SecretAchievementCard from './secret-achievement-card';
 import type { LockedAchievementEntry } from '@automattic/api-core';
 
 export default function LockedAchievementCard( { entry }: { entry: LockedAchievementEntry } ) {
-	if ( isLockedSecret( entry ) ) {
+	if ( entry.is_redacted ) {
 		return <SecretAchievementCard locked />;
 	}
 

--- a/client/reader/user-profile/views/achievements/achievements-grid/style.scss
+++ b/client/reader/user-profile/views/achievements/achievements-grid/style.scss
@@ -37,8 +37,8 @@
 
 	.achievement-card__icon {
 		flex-shrink: 0;
-		height: 48px;
-		width: 48px;
+		height: 60px;
+		width: 60px;
 	}
 
 	.achievement-card__labels {
@@ -175,9 +175,9 @@
 		border-radius: 50%;
 		color: var( --studio-gray-40 );
 		display: flex;
-		height: 48px;
+		height: 60px;
 		justify-content: center;
-		width: 48px;
+		width: 60px;
 
 		svg,
 		path {

--- a/client/reader/user-profile/views/achievements/achievements-grid/style.scss
+++ b/client/reader/user-profile/views/achievements/achievements-grid/style.scss
@@ -27,10 +27,24 @@
 		}
 	}
 
+	.achievement-card__icon-column {
+		align-items: center;
+		display: flex;
+		flex-direction: column;
+		flex-shrink: 0;
+		gap: 8px;
+	}
+
 	.achievement-card__icon {
 		flex-shrink: 0;
 		height: 48px;
 		width: 48px;
+	}
+
+	.achievement-card__labels {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
 	}
 
 	.achievement-card__details {
@@ -56,16 +70,27 @@
 	}
 
 	.achievement-card__label {
-		background: var( --studio-gray-5 );
 		border-radius: 4px;
-		color: var( --studio-gray-60 );
-		display: inline-block;
 		font-size: $font-body-extra-small;
 		font-weight: 400;
 		line-height: 1.2;
-		margin-inline-start: 8px;
 		padding: 2px 4px;
-		vertical-align: text-bottom;
+		text-align: center;
+
+		&.is-secret {
+			background: var( --studio-purple-10 );
+			color: var( --studio-purple-70 );
+		}
+
+		&.is-retired {
+			background: var( --studio-gray-10 );
+			color: var( --studio-gray-70 );
+		}
+
+		&.is-a8c-only {
+			background: #3499cd;
+			color: var( --studio-white );
+		}
 	}
 
 	.achievement-card__description {

--- a/client/reader/user-profile/views/achievements/achievements-grid/style.scss
+++ b/client/reader/user-profile/views/achievements/achievements-grid/style.scss
@@ -55,6 +55,19 @@
 		margin-inline-start: 8px;
 	}
 
+	.achievement-card__label {
+		background: var( --studio-gray-5 );
+		border-radius: 4px;
+		color: var( --studio-gray-60 );
+		display: inline-block;
+		font-size: $font-body-extra-small;
+		font-weight: 400;
+		line-height: 1.2;
+		margin-inline-start: 8px;
+		padding: 2px 4px;
+		vertical-align: text-bottom;
+	}
+
 	.achievement-card__description {
 		font-size: $font-body-small;
 		margin: 4px 0 0;

--- a/client/reader/user-profile/views/achievements/achievements-grid/test/achievement-card.test.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/test/achievement-card.test.tsx
@@ -85,4 +85,48 @@ describe( 'AchievementCard', () => {
 		expect( container.querySelector( '.achievement-card__progress' ) ).toBeNull();
 		expect( screen.queryByRole( 'progressbar' ) ).toBeNull();
 	} );
+
+	test( 'renders the Secret label when isSecret is true', () => {
+		render( <AchievementCard title="Hidden Gem" description="You found it." isSecret /> );
+
+		expect( screen.getByText( 'Secret' ) ).toBeVisible();
+	} );
+
+	test( 'renders the Retired label when isRetired is true', () => {
+		render( <AchievementCard title="Old Badge" description="Long ago." isRetired /> );
+
+		expect( screen.getByText( 'Retired' ) ).toBeVisible();
+	} );
+
+	test( 'renders the A8C-only label when isA8cOnly is true', () => {
+		render( <AchievementCard title="Internal" description="Staff only." isA8cOnly /> );
+
+		expect( screen.getByText( 'A8C-only' ) ).toBeVisible();
+	} );
+
+	test( 'renders multiple status labels alongside the level badge', () => {
+		render(
+			<AchievementCard
+				title="Hidden Gem"
+				badge="Level 3"
+				description="You found it."
+				isSecret
+				isRetired
+				isA8cOnly
+			/>
+		);
+
+		expect( screen.getByText( 'Level 3' ) ).toBeVisible();
+		expect( screen.getByText( 'Secret' ) ).toBeVisible();
+		expect( screen.getByText( 'Retired' ) ).toBeVisible();
+		expect( screen.getByText( 'A8C-only' ) ).toBeVisible();
+	} );
+
+	test( 'omits all status labels by default', () => {
+		render( <AchievementCard title="Plain" description="Nothing special." /> );
+
+		expect( screen.queryByText( 'Secret' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Retired' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'A8C-only' ) ).not.toBeInTheDocument();
+	} );
 } );

--- a/client/reader/user-profile/views/achievements/achievements-grid/test/index.test.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/test/index.test.tsx
@@ -21,7 +21,7 @@ const earned = ( overrides: Record< string, unknown > = {} ) => ( {
 	level: 1,
 	date: '2026-01-15T00:00:00Z',
 	image: 'https://example.com/first.png',
-	retired: false,
+	is_retired: false,
 	is_secret: false,
 	...overrides,
 } );
@@ -257,6 +257,28 @@ describe( 'AchievementsGrid', () => {
 
 		expect( screen.getByText( 'First Post' ) ).toBeVisible();
 		expect( screen.queryByText( 'No achievements yet.' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'renders a self-read earned secret (is_secret: true with full payload) as a regular card', () => {
+		useAchievementsQuery.mockReturnValue( {
+			...baseQueryReturn,
+			achievements: [
+				earned( {
+					achievement_id: 30,
+					slug: 'hidden_gem',
+					name: 'Hidden Gem',
+					description: 'You found the easter egg.',
+					is_secret: true,
+				} ),
+			],
+			lockedAchievements: [],
+		} );
+
+		renderGrid( { userLogin: 'me', isOwnProfile: true } );
+
+		expect( screen.getByText( 'Hidden Gem' ) ).toBeVisible();
+		expect( screen.getByText( 'You found the easter egg.' ) ).toBeVisible();
+		expect( screen.queryByText( 'Secret achievement' ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'prepends a Years of Service card when yearsOfService > 0', () => {

--- a/client/reader/user-profile/views/achievements/achievements-grid/test/index.test.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/test/index.test.tsx
@@ -19,9 +19,9 @@ const earned = ( overrides: Record< string, unknown > = {} ) => ( {
 	description: 'You wrote your first post.',
 	badge_prefix: 'p',
 	level: 1,
-	date: '2026-01-15T00:00:00Z',
+	date_unlocked: '2026-01-15T00:00:00Z',
+	date_created: '2025-01-01',
 	image: 'https://example.com/first.png',
-	is_retired: false,
 	is_secret: false,
 	...overrides,
 } );
@@ -29,7 +29,9 @@ const earned = ( overrides: Record< string, unknown > = {} ) => ( {
 const maskedSecret = ( overrides: Record< string, unknown > = {} ) => ( {
 	achievement_id: 2,
 	is_secret: true,
-	date: '2026-02-15T00:00:00Z',
+	is_redacted: true,
+	date_unlocked: '2026-02-15T00:00:00Z',
+	date_created: '2025-02-01',
 	...overrides,
 } );
 
@@ -47,6 +49,7 @@ const locked = ( overrides: Record< string, unknown > = {} ) => ( {
 const lockedSecret = ( overrides: Record< string, unknown > = {} ) => ( {
 	achievement_id: 99,
 	is_secret: true,
+	is_redacted: true,
 	date_created: '2026-01-10T00:00:00Z',
 	...overrides,
 } );
@@ -179,6 +182,68 @@ describe( 'AchievementsGrid', () => {
 		expect( within( secretCard as HTMLElement ).getByText( /^Unlocked:/ ) ).toBeVisible();
 	} );
 
+	test( 'sorts earned + masked-secret entries by last unlock date descending', () => {
+		useAchievementsQuery.mockReturnValue( {
+			...baseQueryReturn,
+			achievements: [
+				maskedSecret( { achievement_id: 2, date_unlocked: '2026-01-01' } ),
+				earned( {
+					achievement_id: 3,
+					slug: 'm',
+					name: 'Mid',
+					date_unlocked: '2026-02-01',
+				} ),
+				earned( { achievement_id: 1, name: 'Zed', date_unlocked: '2026-03-01' } ),
+			],
+			lockedAchievements: [],
+		} );
+
+		const { container } = renderGrid( { userLogin: 'someone', isOwnProfile: false } );
+
+		const earnedSection = container.querySelector( '.achievements-grid' );
+		expect( earnedSection ).not.toBeNull();
+		const titles = within( earnedSection as HTMLElement ).getAllByRole( 'heading', {
+			level: 3,
+		} );
+		expect( titles.map( ( h ) => h.firstChild?.textContent ) ).toEqual( [
+			'Zed',
+			'Mid',
+			'Secret achievement',
+		] );
+	} );
+
+	test( 'sorts a leveled slug by its most recent unlock, not its first', () => {
+		useAchievementsQuery.mockReturnValue( {
+			...baseQueryReturn,
+			achievements: [
+				earned( {
+					achievement_id: 10,
+					slug: 'multi',
+					name: 'Multi',
+					level: 1,
+					date_unlocked: '2026-01-01',
+				} ),
+				earned( {
+					achievement_id: 11,
+					slug: 'multi',
+					name: 'Multi',
+					level: 2,
+					date_unlocked: '2026-05-01',
+				} ),
+				earned( { achievement_id: 20, slug: 'solo', name: 'Solo', date_unlocked: '2026-03-01' } ),
+			],
+			lockedAchievements: [],
+		} );
+
+		const { container } = renderGrid( { userLogin: 'me', isOwnProfile: true } );
+
+		const earnedSection = container.querySelector( '.achievements-grid' );
+		const titles = within( earnedSection as HTMLElement ).getAllByRole( 'heading', {
+			level: 3,
+		} );
+		expect( titles.map( ( h ) => h.firstChild?.textContent ) ).toEqual( [ 'Multi', 'Solo' ] );
+	} );
+
 	test( 'sorts locked entries by date_created ascending', () => {
 		useAchievementsQuery.mockReturnValue( {
 			...baseQueryReturn,
@@ -219,8 +284,8 @@ describe( 'AchievementsGrid', () => {
 			...baseQueryReturn,
 			achievements: [
 				earned(),
-				maskedSecret( { achievement_id: 50, date: '2026-02-01T00:00:00Z' } ),
-				maskedSecret( { achievement_id: 50, date: '2026-03-01T00:00:00Z' } ),
+				maskedSecret( { achievement_id: 50, date_unlocked: '2026-02-01T00:00:00Z' } ),
+				maskedSecret( { achievement_id: 50, date_unlocked: '2026-03-01T00:00:00Z' } ),
 			],
 			lockedAchievements: [],
 		} );

--- a/client/reader/user-profile/views/achievements/test/utils.test.ts
+++ b/client/reader/user-profile/views/achievements/test/utils.test.ts
@@ -21,8 +21,21 @@ const fullyEarned: Achievement = {
 	level: 1,
 	date: '2026-01-01T00:00:00Z',
 	image: 'https://example.com/img.png',
-	retired: false,
+	is_retired: false,
 	is_secret: false,
+};
+
+const earnedSecret: Achievement = {
+	achievement_id: 5,
+	slug: 'secret-earned',
+	name: 'Revealed Secret',
+	description: 'You found it.',
+	badge_prefix: 'p',
+	level: 1,
+	date: '2026-01-05T00:00:00Z',
+	image: 'https://example.com/secret.png',
+	is_retired: false,
+	is_secret: true,
 };
 
 const maskedSecret: MaskedSecretAchievement = {
@@ -60,6 +73,10 @@ describe( 'isFullyEarned', () => {
 		const { is_secret: _omit, ...legacy } = fullyEarned;
 		expect( isFullyEarned( legacy as Achievement ) ).toBe( true );
 	} );
+
+	test( 'returns true for an earned secret with full payload (is_secret: true + name)', () => {
+		expect( isFullyEarned( earnedSecret ) ).toBe( true );
+	} );
 } );
 
 describe( 'isMaskedSecret', () => {
@@ -67,8 +84,16 @@ describe( 'isMaskedSecret', () => {
 		expect( isMaskedSecret( maskedSecret ) ).toBe( true );
 	} );
 
+	test( 'returns true for a masked secret that sends an explicit empty name', () => {
+		expect( isMaskedSecret( { ...maskedSecret, name: '' } ) ).toBe( true );
+	} );
+
 	test( 'returns false for a fully earned Achievement', () => {
 		expect( isMaskedSecret( fullyEarned ) ).toBe( false );
+	} );
+
+	test( 'returns false for an earned secret with full payload (is_secret: true + name)', () => {
+		expect( isMaskedSecret( earnedSecret ) ).toBe( false );
 	} );
 } );
 

--- a/client/reader/user-profile/views/achievements/test/utils.test.ts
+++ b/client/reader/user-profile/views/achievements/test/utils.test.ts
@@ -1,16 +1,5 @@
-import {
-	deduplicateAchievementsById,
-	deduplicateAchievementsBySlug,
-	isFullyEarned,
-	isLockedSecret,
-	isMaskedSecret,
-} from '../utils';
-import type {
-	Achievement,
-	LockedAchievement,
-	LockedSecretAchievement,
-	MaskedSecretAchievement,
-} from '@automattic/api-core';
+import { deduplicateAchievementsById, deduplicateAchievementsBySlug } from '../utils';
+import type { Achievement } from '@automattic/api-core';
 
 const fullyEarned: Achievement = {
 	achievement_id: 1,
@@ -19,93 +8,11 @@ const fullyEarned: Achievement = {
 	description: 'desc',
 	badge_prefix: 'p',
 	level: 1,
-	date: '2026-01-01T00:00:00Z',
+	date_unlocked: '2026-01-01T00:00:00Z',
+	date_created: '2025-01-01',
 	image: 'https://example.com/img.png',
-	is_retired: false,
 	is_secret: false,
 };
-
-const earnedSecret: Achievement = {
-	achievement_id: 5,
-	slug: 'secret-earned',
-	name: 'Revealed Secret',
-	description: 'You found it.',
-	badge_prefix: 'p',
-	level: 1,
-	date: '2026-01-05T00:00:00Z',
-	image: 'https://example.com/secret.png',
-	is_retired: false,
-	is_secret: true,
-};
-
-const maskedSecret: MaskedSecretAchievement = {
-	achievement_id: 2,
-	is_secret: true,
-	date: '2026-01-02T00:00:00Z',
-};
-
-const locked: LockedAchievement = {
-	achievement_id: 3,
-	slug: 'locked',
-	name: 'Locked',
-	description: 'd',
-	badge_prefix: 'p',
-	is_secret: false,
-	date_created: '2026-01-03T00:00:00Z',
-};
-
-const lockedSecret: LockedSecretAchievement = {
-	achievement_id: 4,
-	is_secret: true,
-	date_created: '2026-01-04T00:00:00Z',
-};
-
-describe( 'isFullyEarned', () => {
-	test( 'returns true for an Achievement', () => {
-		expect( isFullyEarned( fullyEarned ) ).toBe( true );
-	} );
-
-	test( 'returns false for a MaskedSecretAchievement', () => {
-		expect( isFullyEarned( maskedSecret ) ).toBe( false );
-	} );
-
-	test( 'returns true for a legacy Achievement without is_secret set', () => {
-		const { is_secret: _omit, ...legacy } = fullyEarned;
-		expect( isFullyEarned( legacy as Achievement ) ).toBe( true );
-	} );
-
-	test( 'returns true for an earned secret with full payload (is_secret: true + name)', () => {
-		expect( isFullyEarned( earnedSecret ) ).toBe( true );
-	} );
-} );
-
-describe( 'isMaskedSecret', () => {
-	test( 'returns true for a MaskedSecretAchievement', () => {
-		expect( isMaskedSecret( maskedSecret ) ).toBe( true );
-	} );
-
-	test( 'returns true for a masked secret that sends an explicit empty name', () => {
-		expect( isMaskedSecret( { ...maskedSecret, name: '' } ) ).toBe( true );
-	} );
-
-	test( 'returns false for a fully earned Achievement', () => {
-		expect( isMaskedSecret( fullyEarned ) ).toBe( false );
-	} );
-
-	test( 'returns false for an earned secret with full payload (is_secret: true + name)', () => {
-		expect( isMaskedSecret( earnedSecret ) ).toBe( false );
-	} );
-} );
-
-describe( 'isLockedSecret', () => {
-	test( 'returns true for a LockedSecretAchievement', () => {
-		expect( isLockedSecret( lockedSecret ) ).toBe( true );
-	} );
-
-	test( 'returns false for a non-secret LockedAchievement', () => {
-		expect( isLockedSecret( locked ) ).toBe( false );
-	} );
-} );
 
 describe( 'deduplicateAchievementsById', () => {
 	test( 'keeps the first occurrence of each achievement_id', () => {
@@ -128,13 +35,18 @@ describe( 'deduplicateAchievementsById', () => {
 } );
 
 describe( 'deduplicateAchievementsBySlug', () => {
-	test( 'keeps the highest level and oldest date for a leveled slug', () => {
-		const a: Achievement = { ...fullyEarned, achievement_id: 10, level: 1, date: '2026-01-01' };
+	test( 'keeps the entry with the most recent date_unlocked for a leveled slug', () => {
+		const a: Achievement = {
+			...fullyEarned,
+			achievement_id: 10,
+			level: 1,
+			date_unlocked: '2026-01-01',
+		};
 		const b: Achievement = {
 			...fullyEarned,
 			achievement_id: 11,
 			level: 2,
-			date: '2026-02-01',
+			date_unlocked: '2026-02-01',
 			image: 'https://example.com/level2.png',
 		};
 
@@ -143,6 +55,6 @@ describe( 'deduplicateAchievementsBySlug', () => {
 		expect( result ).toHaveLength( 1 );
 		expect( result[ 0 ].level ).toBe( 2 );
 		expect( result[ 0 ].image ).toBe( 'https://example.com/level2.png' );
-		expect( result[ 0 ].date ).toBe( '2026-01-01' );
+		expect( result[ 0 ].date_unlocked ).toBe( '2026-02-01' );
 	} );
 } );

--- a/client/reader/user-profile/views/achievements/utils.ts
+++ b/client/reader/user-profile/views/achievements/utils.ts
@@ -65,11 +65,17 @@ export function deduplicateAchievementsById< T extends { achievement_id: number 
 	return result;
 }
 
-export const isFullyEarned = ( a: EarnedAchievementEntry ): a is Achievement =>
-	a.is_secret !== true;
+// A masked secret carries `is_secret: true` AND an empty/missing `name`.
+// `is_secret` alone is not enough: the endpoint now reflects the registry on
+// full payloads, so a self-read of an earned secret returns `is_secret: true`
+// with a populated name. Treat that as fully earned.
+const hasVisibleName = ( a: { name?: string } ): boolean => !! a.name;
 
 export const isMaskedSecret = ( a: EarnedAchievementEntry ): a is MaskedSecretAchievement =>
-	a.is_secret === true;
+	a.is_secret === true && ! hasVisibleName( a );
+
+export const isFullyEarned = ( a: EarnedAchievementEntry ): a is Achievement =>
+	! isMaskedSecret( a );
 
 export const isLockedSecret = ( a: LockedAchievementEntry ): a is LockedSecretAchievement =>
-	a.is_secret === true;
+	a.is_secret === true && ! hasVisibleName( a );

--- a/client/reader/user-profile/views/achievements/utils.ts
+++ b/client/reader/user-profile/views/achievements/utils.ts
@@ -1,10 +1,4 @@
-import type {
-	Achievement,
-	EarnedAchievementEntry,
-	LockedAchievementEntry,
-	LockedSecretAchievement,
-	MaskedSecretAchievement,
-} from '@automattic/api-core';
+import type { Achievement } from '@automattic/api-core';
 
 /**
  * Find the oldest achievement of a given slug by comparing dates.
@@ -16,34 +10,27 @@ export function getOldestAchievement(
 	return achievements
 		.filter( ( a ) => a.slug === slug )
 		.reduce< Achievement | undefined >(
-			( oldest, a ) => ( ! oldest || new Date( a.date ) < new Date( oldest.date ) ? a : oldest ),
+			( oldest, a ) =>
+				! oldest || new Date( a.date_unlocked ) < new Date( oldest.date_unlocked ) ? a : oldest,
 			undefined
 		);
 }
 
 /**
- * Deduplicate achievements by slug:
- * - For leveled achievements, keep the highest level.
- * - Otherwise, keep the oldest (first unlocked).
+ * Deduplicate achievements by slug, keeping the entry with the most recent
+ * `date_unlocked` (the last unlock — typically also the highest level for
+ * level-progression achievements). The "first unlocked" date used in card
+ * captions is computed separately via {@link getOldestAchievement}.
  */
 export function deduplicateAchievementsBySlug( achievements: Achievement[] ): Achievement[] {
-	// Build a map of slug → highest level for that slug.
-	const highestBySlug = achievements.reduce( ( map, achievement ) => {
-		const existing = map.get( achievement.slug );
-		if ( ! existing || achievement.level > existing.level ) {
-			map.set( achievement.slug, achievement );
+	const latestBySlug = new Map< string, Achievement >();
+	for ( const a of achievements ) {
+		const existing = latestBySlug.get( a.slug );
+		if ( ! existing || a.date_unlocked > existing.date_unlocked ) {
+			latestBySlug.set( a.slug, a );
 		}
-		return map;
-	}, new Map< string, Achievement >() );
-
-	// For each slug, merge the oldest achievement with the highest level and image.
-	return Array.from( highestBySlug.entries() ).map( ( [ slug, highest ] ) => {
-		const oldest = getOldestAchievement( slug, achievements );
-		if ( oldest && oldest !== highest ) {
-			return { ...oldest, level: highest.level, image: highest.image };
-		}
-		return highest;
-	} );
+	}
+	return Array.from( latestBySlug.values() );
 }
 
 /**
@@ -64,18 +51,3 @@ export function deduplicateAchievementsById< T extends { achievement_id: number 
 	}
 	return result;
 }
-
-// A masked secret carries `is_secret: true` AND an empty/missing `name`.
-// `is_secret` alone is not enough: the endpoint now reflects the registry on
-// full payloads, so a self-read of an earned secret returns `is_secret: true`
-// with a populated name. Treat that as fully earned.
-const hasVisibleName = ( a: { name?: string } ): boolean => !! a.name;
-
-export const isMaskedSecret = ( a: EarnedAchievementEntry ): a is MaskedSecretAchievement =>
-	a.is_secret === true && ! hasVisibleName( a );
-
-export const isFullyEarned = ( a: EarnedAchievementEntry ): a is Achievement =>
-	! isMaskedSecret( a );
-
-export const isLockedSecret = ( a: LockedAchievementEntry ): a is LockedSecretAchievement =>
-	a.is_secret === true && ! hasVisibleName( a );

--- a/packages/api-core/src/read-achievements/types.ts
+++ b/packages/api-core/src/read-achievements/types.ts
@@ -11,15 +11,23 @@ export interface Achievement {
 	description: string;
 	badge_prefix: string;
 	level: number;
-	date: string;
+	date_unlocked: string;
+	/** Y-m-d date the achievement was added to the registry. Used for sort order. */
+	date_created: string;
 	image: string;
-	is_retired: boolean;
+	/**
+	 * Y-m-d (or ISO 8601) date string when the achievement was retired, or
+	 * an empty string / omitted when not retired. Truthy ⇒ retired.
+	 */
+	date_retired?: string;
 	/**
 	 * Reflects the registry: `true` if the achievement is secret, even when
 	 * the payload is fully visible (self-read of an earned secret). Optional —
 	 * legacy responses (pre-locked-achievements rollout) omit it.
 	 */
 	is_secret?: boolean;
+	/** Always `false` (or omitted) for full payloads — see {@link MaskedSecretAchievement}. */
+	is_redacted?: false;
 	/** `true` for Automattic-only achievements. */
 	is_a8c_only?: boolean;
 	/** Only present when viewing your own achievements. */
@@ -31,14 +39,15 @@ export interface Achievement {
 /**
  * Earned by the profile owner, masked because the requester has not earned
  * the same secret. Cross-user reads only. Discriminated from {@link Achievement}
- * at runtime by an empty/missing `name`.
+ * by `is_redacted: true`.
  */
 export interface MaskedSecretAchievement {
 	achievement_id: number;
 	is_secret: true;
-	/** Empty string (or omitted) — the masked payload carries no name. */
-	name?: '';
-	date: string;
+	is_redacted: true;
+	date_unlocked: string;
+	/** Y-m-d date the achievement was added to the registry. Used for sort order. */
+	date_created: string;
 }
 
 /**
@@ -52,6 +61,8 @@ export interface LockedAchievement {
 	description: string;
 	badge_prefix: string;
 	is_secret: false;
+	/** Always `false` (or omitted) for full payloads — see {@link LockedSecretAchievement}. */
+	is_redacted?: false;
 	/** `true` for Automattic-only achievements. */
 	is_a8c_only?: boolean;
 	date_created: string;
@@ -63,13 +74,12 @@ export interface LockedAchievement {
 
 /**
  * Locked + secret. Self-reads only. Discriminated from {@link LockedAchievement}
- * at runtime by an empty/missing `name`.
+ * by `is_redacted: true`.
  */
 export interface LockedSecretAchievement {
 	achievement_id: number;
 	is_secret: true;
-	/** Empty string (or omitted) — the masked payload carries no name. */
-	name?: '';
+	is_redacted: true;
 	date_created: string;
 }
 

--- a/packages/api-core/src/read-achievements/types.ts
+++ b/packages/api-core/src/read-achievements/types.ts
@@ -1,6 +1,8 @@
 /**
  * Earned, fully-visible achievement. The shape returned for own-profile reads
- * and for non-secret entries on cross-user reads.
+ * and for non-secret entries on cross-user reads. A self-read of an earned
+ * secret achievement also uses this shape — `is_secret` then reflects the
+ * registry (`true`) but the payload is fully populated.
  */
 export interface Achievement {
 	achievement_id: number;
@@ -11,9 +13,13 @@ export interface Achievement {
 	level: number;
 	date: string;
 	image: string;
-	retired: boolean;
-	/** Optional — legacy responses (pre-locked-achievements rollout) omit it. */
-	is_secret?: false;
+	is_retired: boolean;
+	/**
+	 * Reflects the registry: `true` if the achievement is secret, even when
+	 * the payload is fully visible (self-read of an earned secret). Optional —
+	 * legacy responses (pre-locked-achievements rollout) omit it.
+	 */
+	is_secret?: boolean;
 	/** Only present when viewing your own achievements. */
 	site_ID?: number;
 	/** Only present when viewing your own achievements. */
@@ -22,11 +28,14 @@ export interface Achievement {
 
 /**
  * Earned by the profile owner, masked because the requester has not earned
- * the same secret. Cross-user reads only.
+ * the same secret. Cross-user reads only. Discriminated from {@link Achievement}
+ * at runtime by an empty/missing `name`.
  */
 export interface MaskedSecretAchievement {
 	achievement_id: number;
 	is_secret: true;
+	/** Empty string (or omitted) — the masked payload carries no name. */
+	name?: '';
 	date: string;
 }
 
@@ -49,11 +58,14 @@ export interface LockedAchievement {
 }
 
 /**
- * Locked + secret. Self-reads only.
+ * Locked + secret. Self-reads only. Discriminated from {@link LockedAchievement}
+ * at runtime by an empty/missing `name`.
  */
 export interface LockedSecretAchievement {
 	achievement_id: number;
 	is_secret: true;
+	/** Empty string (or omitted) — the masked payload carries no name. */
+	name?: '';
 	date_created: string;
 }
 

--- a/packages/api-core/src/read-achievements/types.ts
+++ b/packages/api-core/src/read-achievements/types.ts
@@ -20,6 +20,8 @@ export interface Achievement {
 	 * legacy responses (pre-locked-achievements rollout) omit it.
 	 */
 	is_secret?: boolean;
+	/** `true` for Automattic-only achievements. */
+	is_a8c_only?: boolean;
 	/** Only present when viewing your own achievements. */
 	site_ID?: number;
 	/** Only present when viewing your own achievements. */
@@ -50,6 +52,8 @@ export interface LockedAchievement {
 	description: string;
 	badge_prefix: string;
 	is_secret: false;
+	/** `true` for Automattic-only achievements. */
+	is_a8c_only?: boolean;
 	date_created: string;
 	/** Current progress toward `target`. Present alongside `target` for incremental achievements. */
 	progress?: number;


### PR DESCRIPTION
Part of RSM-3651

## Proposed Changes

<img width="836" height="311" alt="Screenshot 2026-05-22 at 14 45 36" src="https://github.com/user-attachments/assets/d6db1430-f5ee-41f6-9a29-978d7d60305b" />

* Add **Secret**, **Retired**, and **A8C-only** status labels to achievement cards. Labels stack below the icon with semantic studio colors (purple / gray / automattic-blue). They only render on fully visible cards (earned + visible locked), never on masked secret placeholders.
* Adopt the new `/read/achievements` v2 fields:
  * `retired: boolean` → `date_retired?: string` (truthy ⇒ retired)
  * `date` → `date_unlocked`
  * new `date_created` (registry creation date)
  * new `is_a8c_only` flag
  * new `is_redacted` flag — the masking discriminator (replaces the old `is_secret + empty name` check). `is_secret` now reflects the registry on full payloads too.
* Sort the **earned + masked-secrets** grid by `date_unlocked` descending (most-recently-unlocked first); the **locked** grid by `date_created` ascending.
* Visual bump: regular achievement icon 48px → 60px.
* Internal: drop `isMaskedSecret` / `isFullyEarned` / `isLockedSecret` utility wrappers — now that the discriminator is the explicit `is_redacted` boolean, inline checks narrow correctly against the discriminated union. The dedupe-by-slug now keeps the latest-unlock entry (the "First unlocked: …" caption still works because `GenericAchievement` does its own oldest lookup).

## Why are these changes being made?

The `/read/achievements` endpoint is shipping breaking schema changes; Calypso needs the matching update or the achievements view breaks. While we're touching it, the new registry fields (`is_secret`, `is_a8c_only`, `date_retired`) finally let us surface the special-achievement labels asked for in RSM-3651.

Comparator + label rendering are defensive about missing fields so this PR is safe to merge before the backend rollout completes — labels just don't render until their flags arrive, and the sort tolerates missing dates with a `?? ''` fallback.

## Testing Instructions

1. `yarn test-client client/reader/user-profile/views/achievements` — 82 tests should pass.
2. Open your own profile's achievements view in Reader. You should see:
   * Icons at 60px; Years of Service circle at 100px.
   * Cards sorted by most-recent-unlock first.
   * Locked section sorted by registry-creation-date ascending.
3. If the v2 backend is live in your test env: any retired / a8c-only / earned-secret achievements should show the corresponding pill underneath the icon.
4. View someone else's profile: masked secrets still render as the "Secret achievement" placeholder card.
5. Pre-rollout backend: grid still renders, no labels (graceful), no crashes.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?