### PR TITLE
Reader Social: fix compose FAB hover/active contrast

### DIFF
--- a/client/reader/social/composer/style.scss
+++ b/client/reader/social/composer/style.scss
@@ -93,15 +93,6 @@
 	z-index: 25;
 	transition: background-color 150ms ease, box-shadow 150ms ease;
 
-	// Background, text color, and the hover/active darkening are inherited
-	// from `variant="primary"` (see Button JSX). Calypso pins
-	// `.components-button.is-primary:not(.is-destructive)` to
-	// `--color-accent` / `--color-accent-60` globally, which keeps the
-	// text `--wp-components-color-accent-inverted` (white) through every
-	// state and avoids the dark-text-on-dark-blue contrast bug that the
-	// default (no-variant) Button hover styling produced — same pattern
-	// the Reader's `.quick-post` "Post" button uses.
-
 	&.is-hidden {
 		display: none;
 	}

--- a/client/reader/social/composer/style.scss
+++ b/client/reader/social/composer/style.scss
@@ -84,8 +84,6 @@
 	// Reader's compose surfaces (search, stream input, `.quick-post`).
 	/* stylelint-disable-next-line scales/radii */
 	border-radius: 6px;
-	background: var(--studio-blue-50, #3858e9);
-	color: var( --color-text-inverted, var( --studio-white, #fff ) );
 	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
 	// `.main` sits at z-index 20 in Calypso's global stacking scheme
 	// (see `_z-index.scss`), and the FAB is rendered as its sibling.
@@ -95,15 +93,14 @@
 	z-index: 25;
 	transition: background-color 150ms ease, box-shadow 150ms ease;
 
-	&:hover {
-		background: var(--studio-blue-60, #1d35b4);
-		color: var( --color-text-inverted, var( --studio-white, #fff ) );
-	}
-
-	&:focus-visible {
-		outline: 2px solid var(--studio-blue-30, #7b90ff);
-		outline-offset: 2px;
-	}
+	// Background, text color, and the hover/active darkening are inherited
+	// from `variant="primary"` (see Button JSX). Calypso pins
+	// `.components-button.is-primary:not(.is-destructive)` to
+	// `--color-accent` / `--color-accent-60` globally, which keeps the
+	// text `--wp-components-color-accent-inverted` (white) through every
+	// state and avoids the dark-text-on-dark-blue contrast bug that the
+	// default (no-variant) Button hover styling produced — same pattern
+	// the Reader's `.quick-post` "Post" button uses.
 
 	&.is-hidden {
 		display: none;

--- a/client/reader/social/composer/triggers/compose-fab.tsx
+++ b/client/reader/social/composer/triggers/compose-fab.tsx
@@ -20,6 +20,7 @@ export function ComposeFab() {
 
 	return (
 		<Button
+			variant="primary"
 			className={ clsx( 'social-compose-fab', { 'is-hidden': isHidden } ) }
 			icon={ edit }
 			text={ translate( 'Compose' ) as string }


### PR DESCRIPTION
Fixes CM-782

## Proposed Changes

* Switch the Reader Social compose FAB (`<ComposeFab>`) to `variant="primary"` so its hover/active states inherit the correct white-on-darker-blue colors from `@wordpress/components` instead of the default-variant Button styling that turned the text blue on hover.
* Drop the now-redundant manual `background`, `color`, and `:hover` declarations from `.social-compose-fab`. Calypso's global `.components-button.is-primary:not(.is-destructive)` selector takes over the background and darker-shade pinning, and `is-primary` handles the focus ring.

## Why are these changes being made?

The Compose floating action button on Reader Social surfaces (`/reader/atmosphere/<id>/timeline`, `/reader/mastodon/<id>/timeline`, …) had a low-contrast hover/active state: WP's default Button hover rule sets `color: var(--wp-components-color-accent)` (blue), colliding with the FAB's dark-blue hover background. Result: dark-blue text on dark-blue background, hard to read.

`variant="primary"` is the same pattern the Reader's `.quick-post` "Post" button uses — it pins `--wp-components-color-accent-inverted` (white) through hover, active, and focus states.

## Testing Instructions

1. Visit `/reader/atmosphere/<id>/timeline` (or any other Reader Social timeline / thread / profile route).
2. Locate the Compose FAB in the bottom-right corner.
3. Hover the button — background should darken from `#3858e9` to `#2145e6`, text should stay white.
4. Press and hold the button (active) — background should match the hover darker shade, text should stay white.
5. Tab to the button — a visible focus ring should appear; text should stay white.
6. Repeat in dark mode.

### Before / after

| State | Before | After |
| --- | --- | --- |
| Hover | dark blue text on dark blue bg | white text on dark blue bg |
| Active | dark blue text on dark blue bg | white text on dark blue bg |

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?