### PR TITLE
webpack: resolve `.mjs` extensions

### DIFF
--- a/apps/blaze-dashboard/webpack.config.js
+++ b/apps/blaze-dashboard/webpack.config.js
@@ -113,7 +113,7 @@ module.exports = {
 		],
 	},
 	resolve: {
-		extensions: [ '.json', '.js', '.jsx', '.ts', '.tsx' ],
+		extensions: [ '.json', '.js', '.mjs', '.jsx', '.ts', '.tsx' ],
 		mainFields: [ 'browser', 'calypso:src', 'module', 'main' ],
 		conditionNames: [ 'calypso:src', 'import', 'module', 'require' ],
 	},

--- a/apps/odyssey-stats/webpack.config.js
+++ b/apps/odyssey-stats/webpack.config.js
@@ -106,7 +106,7 @@ module.exports = {
 		],
 	},
 	resolve: {
-		extensions: [ '.json', '.js', '.jsx', '.ts', '.tsx' ],
+		extensions: [ '.json', '.js', '.mjs', '.jsx', '.ts', '.tsx' ],
 		mainFields: [ 'browser', 'calypso:src', 'module', 'main' ],
 		conditionNames: [ 'calypso:src', 'import', 'module', 'require' ],
 		alias: {

--- a/client/webpack.config.desktop.js
+++ b/client/webpack.config.desktop.js
@@ -84,7 +84,7 @@ module.exports = {
 		'webpack.config',
 	],
 	resolve: {
-		extensions: [ '.json', '.js', '.jsx', '.ts', '.tsx' ],
+		extensions: [ '.json', '.js', '.mjs', '.jsx', '.ts', '.tsx' ],
 		mainFields: [ 'calypso:src', 'module', 'main' ],
 		modules: [ __dirname, 'node_modules' ],
 		alias: {

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -323,7 +323,7 @@ const webpackConfig = {
 		],
 	},
 	resolve: {
-		extensions: [ '.json', '.js', '.jsx', '.ts', '.tsx' ],
+		extensions: [ '.json', '.js', '.mjs', '.jsx', '.ts', '.tsx' ],
 		mainFields: [ 'browser', 'calypso:src', 'module', 'main' ],
 		conditionNames: [ 'calypso:src', 'import', 'module', 'require' ],
 		alias: Object.assign( {

--- a/client/webpack.config.node.js
+++ b/client/webpack.config.node.js
@@ -146,7 +146,7 @@ const webpackConfig = {
 		],
 	},
 	resolve: {
-		extensions: [ '.json', '.js', '.jsx', '.ts', '.tsx' ],
+		extensions: [ '.json', '.js', '.mjs', '.jsx', '.ts', '.tsx' ],
 		mainFields: [ 'calypso:src', 'module', 'main' ],
 		conditionNames: [ 'calypso:src', 'import', 'module', 'require' ],
 		alias: {

--- a/desktop/webpack.config.js
+++ b/desktop/webpack.config.js
@@ -32,7 +32,7 @@ module.exports = {
 		__dirname: false,
 	},
 	resolve: {
-		extensions: [ '.json', '.js', '.jsx', '.ts', '.tsx' ],
+		extensions: [ '.json', '.js', '.mjs', '.jsx', '.ts', '.tsx' ],
 		modules: [ 'node_modules' ],
 	},
 	externals: [ 'superagent', 'ws' ],

--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -112,7 +112,7 @@ function getWebpackConfig(
 			],
 		},
 		resolve: {
-			extensions: [ '.json', '.js', '.jsx', '.ts', '.tsx' ],
+			extensions: [ '.json', '.js', '.mjs', '.jsx', '.ts', '.tsx' ],
 			mainFields: [ 'browser', 'calypso:src', 'module', 'main' ],
 			conditionNames: [ 'calypso:src', 'import', 'module', 'require' ],
 			modules: [ 'node_modules' ],


### PR DESCRIPTION
Fixes DOTCOM-17305

Related to #105909

## Proposed Changes

* Add `.mjs` to `resolve.extensions` in all Calypso webpack configs (`client/webpack.config.js`, `client/webpack.config.node.js`, `client/webpack.config.desktop.js`, `desktop/webpack.config.js`, `packages/calypso-build/webpack.config.js`, `apps/odyssey-stats/webpack.config.js`, `apps/blaze-dashboard/webpack.config.js`).
* `.mjs` is placed after `.js`, so existing `.js` resolution precedence is unchanged.

## Why are these changes being made?

`@wordpress/block-library` 9.46+ ships its `build-module/` directory as `.mjs` files instead of `.js`. Deep imports such as `@wordpress/block-library/build-module/heading` — used by `client/reader/components/quick-post` and `packages/verbum-block-editor` — resolve to a directory whose index file is now `index.mjs`.

webpack's resolver could not find that index file because `.mjs` was missing from `resolve.extensions`, producing `Module not found: Can't resolve '@wordpress/block-library/build-module/heading'` build failures.

This surfaced in #105909 (the WordPress monorepo dependency bump), which fails the `Build ICFY stats` check for exactly this reason. Landing this fix separately on `trunk` lets that check pass once #105909 rebases. The change is a no-op on the current `trunk` dependency versions — it only adds a fallback extension — so it is safe to merge independently.

## Testing Instructions

* `resolve.extensions` is the only change; existing builds are unaffected on current `trunk` (`@wordpress/block-library` still ships `.js` there).
* Verified against `@wordpress/block-library@9.46.0` using webpack's own resolver (`enhanced-resolve`) with the package `exports` field active:
  * Old extensions → `Can't resolve '@wordpress/block-library/build-module/heading'` (reproduces the CI failure).
  * New extensions → resolves to `build-module/heading/index.mjs`.
* CI build checks exercise the real webpack builds.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

