### PR TITLE
data-stores: forward-compatible types for the @wordpress/* monorepo bump

### DIFF
--- a/packages/api-core/src/users/fetchers.ts
+++ b/packages/api-core/src/users/fetchers.ts
@@ -2,9 +2,9 @@ import { addQueryArgs } from '@wordpress/url';
 import { wpcom } from '../wpcom-fetcher';
 import type { UserResponse } from './types';
 
-interface FetchUserParams {
+type FetchUserParams = {
 	find_by_id?: boolean;
-}
+};
 
 export const fetchUserProfile = (
 	userIdOrLogin: string | number,

--- a/packages/data-stores/src/contextual-help/admin-sections.ts
+++ b/packages/data-stores/src/contextual-help/admin-sections.ts
@@ -150,7 +150,7 @@ export function generateAdminSections(
 				__(
 					"By upgrading to the %s plan, you'll be able to monetize your site through the WordAds program."
 				),
-				getPlan( PLAN_PREMIUM )?.getTitle()
+				String( getPlan( PLAN_PREMIUM )?.getTitle() ?? '' )
 			),
 			link: `/earn/${ siteSlug }`,
 			synonyms: [ 'monetize', 'wordads', 'premium', 'explorer' ],

--- a/packages/data-stores/src/help-center/utils.ts
+++ b/packages/data-stores/src/help-center/utils.ts
@@ -73,7 +73,7 @@ function getCalypsoPreferences(): Promise< Preferences[ 'calypso_preferences' ] 
 export async function getPersistedPreference<
 	T extends keyof Preferences[ 'calypso_preferences' ],
 >( key: T ): Promise< Preferences[ 'calypso_preferences' ][ T ] | undefined > {
-	const isLoggedIn = ( select( STORE_KEY ) as HelpCenterSelect ).getIsLoggedIn();
+	const isLoggedIn = ( select( STORE_KEY ) as unknown as HelpCenterSelect ).getIsLoggedIn();
 
 	if ( isLoggedIn ) {
 		const preferences = await getCalypsoPreferences();
@@ -98,7 +98,7 @@ export function persistPreference< T extends keyof Preferences[ 'calypso_prefere
 
 	const newPreferences = { [ preference ]: value };
 
-	const isLoggedIn = ( select( STORE_KEY ) as HelpCenterSelect ).getIsLoggedIn();
+	const isLoggedIn = ( select( STORE_KEY ) as unknown as HelpCenterSelect ).getIsLoggedIn();
 
 	if ( ! isLoggedIn ) {
 		// Retrieve the logged out help center preferences from localStorage to coalesce the state.

--- a/packages/data-stores/src/plans/selectors.ts
+++ b/packages/data-stores/src/plans/selectors.ts
@@ -38,7 +38,7 @@ export const getPlanByProductId = (
 		return undefined;
 	}
 
-	return ( select( STORE_KEY ) as PlansSelect )
+	return ( select( STORE_KEY ) as unknown as PlansSelect )
 		.getSupportedPlans( locale )
 		.find( ( plan: Plan ) => plan.productIds.indexOf( productId ) > -1 );
 };
@@ -51,7 +51,7 @@ export const getPlanProductById = (
 		return undefined;
 	}
 
-	return ( select( STORE_KEY ) as PlansSelect )
+	return ( select( STORE_KEY ) as unknown as PlansSelect )
 		.getPlansProducts()
 		.find( ( product: PlanProduct ) => product.productId === productId );
 };
@@ -64,19 +64,19 @@ export const getPlanByPeriodAgnosticSlug = (
 	if ( ! slug ) {
 		return undefined;
 	}
-	return ( select( STORE_KEY ) as PlansSelect )
+	return ( select( STORE_KEY ) as unknown as PlansSelect )
 		.getSupportedPlans( locale )
 		.find( ( plan: Plan ) => plan.periodAgnosticSlug === slug );
 };
 
 export const getDefaultPaidPlan = ( _: State, locale: string ): Plan | undefined => {
-	return ( select( STORE_KEY ) as PlansSelect )
+	return ( select( STORE_KEY ) as unknown as PlansSelect )
 		.getSupportedPlans( locale )
 		.find( ( plan: Plan ) => plan.periodAgnosticSlug === DEFAULT_PAID_PLAN );
 };
 
 export const getDefaultFreePlan = ( _: State, locale: string ): Plan | undefined => {
-	return ( select( STORE_KEY ) as PlansSelect )
+	return ( select( STORE_KEY ) as unknown as PlansSelect )
 		.getSupportedPlans( locale )
 		.find( ( plan: Plan ) => plan.periodAgnosticSlug === TIMELESS_PLAN_FREE );
 };
@@ -98,7 +98,7 @@ export const getPrices = ( _state: State, _locale: string ): Record< StorePlanSl
 	deprecate( 'getPrices', {
 		alternative: 'getPlanProduct().price',
 	} );
-	return ( select( STORE_KEY ) as PlansSelect ).getPlansProducts().reduce(
+	return ( select( STORE_KEY ) as unknown as PlansSelect ).getPlansProducts().reduce(
 		( prices: Record< StorePlanSlug, string >, plan: PlanProduct ) => {
 			prices[ plan.storeSlug ] = plan.price;
 			return prices;
@@ -116,7 +116,7 @@ export const getPlanByPath = (
 		return undefined;
 	}
 
-	const planProduct = ( select( STORE_KEY ) as PlansSelect )
+	const planProduct = ( select( STORE_KEY ) as unknown as PlansSelect )
 		.getPlansProducts()
 		.find( ( product: PlanProduct ) => product.pathSlug === path );
 
@@ -124,7 +124,7 @@ export const getPlanByPath = (
 		return undefined;
 	}
 
-	return ( select( STORE_KEY ) as PlansSelect )
+	return ( select( STORE_KEY ) as unknown as PlansSelect )
 		.getSupportedPlans( locale )
 		.find( ( plan: Plan ) => plan.periodAgnosticSlug === planProduct.periodAgnosticSlug );
 };
@@ -138,7 +138,7 @@ export const getPlanProduct = (
 		return undefined;
 	}
 
-	return ( select( STORE_KEY ) as PlansSelect )
+	return ( select( STORE_KEY ) as unknown as PlansSelect )
 		.getPlansProducts()
 		.find( ( product: PlanProduct ) => {
 			const matchesSlug = product.periodAgnosticSlug === periodAgnosticSlug;

--- a/packages/data-stores/src/products-list/selectors.ts
+++ b/packages/data-stores/src/products-list/selectors.ts
@@ -14,7 +14,7 @@ export const getProductBySlug = ( _state: State, slug: string ) => {
 		return undefined;
 	}
 	const products = (
-		select( STORE_KEY ) as { getProductsList: () => RawAPIProductsList | undefined }
+		select( STORE_KEY ) as unknown as { getProductsList: () => RawAPIProductsList | undefined }
 	 ).getProductsList();
 
 	if ( ! products ) {

--- a/packages/data-stores/src/queries/use-all-domains-query.ts
+++ b/packages/data-stores/src/queries/use-all-domains-query.ts
@@ -30,10 +30,10 @@ export interface AllDomainsQueryFnData {
 	domains: PartialDomainData[];
 }
 
-export interface AllDomainsQueryArgs {
+export type AllDomainsQueryArgs = {
 	no_wpcom?: boolean;
 	resolve_status?: boolean;
-}
+};
 
 export const getAllDomainsQueryKey = ( queryArgs: AllDomainsQueryArgs = {} ) => [
 	'all-domains',

--- a/packages/data-stores/src/reader/helpers/index.ts
+++ b/packages/data-stores/src/reader/helpers/index.ts
@@ -47,7 +47,7 @@ async function callApi< ReturnType >( {
 			? `https://public-api.wordpress.com/wpcom/v2${ path }`
 			: `https://public-api.wordpress.com/rest/v${ apiVersion }${ path }`;
 
-	return apiFetch( {
+	const res = await apiFetch( {
 		global: true,
 		path: apiPath,
 		apiVersion,
@@ -59,6 +59,7 @@ async function callApi< ReturnType >( {
 			'Content-Type': 'application/json',
 		},
 	} as APIFetchOptions );
+	return res as ReturnType;
 }
 
 interface PagedResult< T > {

--- a/packages/data-stores/src/site/selectors.ts
+++ b/packages/data-stores/src/site/selectors.ts
@@ -38,16 +38,16 @@ export const getSite: ( state: State, siteId: number | string ) => SiteDetails |
 };
 
 export const getSiteIdBySlug: ( _: State, slug: string ) => number | undefined = ( _, slug ) => {
-	return ( select( STORE_KEY ) as SiteSelect ).getSite( slug )?.ID;
+	return ( select( STORE_KEY ) as unknown as SiteSelect ).getSite( slug )?.ID;
 };
 
 export const getSiteTitle: ( _: State, siteId: number ) => string | undefined = ( _, siteId ) =>
-	( select( STORE_KEY ) as SiteSelect ).getSite( siteId )?.name;
+	( select( STORE_KEY ) as unknown as SiteSelect ).getSite( siteId )?.name;
 
 export const getSiteVerticalId: ( _: State, siteId: number ) => string | null | undefined = (
 	_,
 	siteId
-) => ( select( STORE_KEY ) as SiteSelect ).getSite( siteId )?.options?.site_vertical_id;
+) => ( select( STORE_KEY ) as unknown as SiteSelect ).getSite( siteId )?.options?.site_vertical_id;
 
 // @TODO: Return LaunchStatus instead of a boolean
 export const isSiteLaunched = ( state: State, siteId: number ) => {
@@ -60,7 +60,10 @@ export const isSiteLaunching = ( state: State, siteId: number ) => {
 };
 
 export const isSiteAtomic: ( _: State, siteId: number | string ) => boolean = ( state, siteId ) => {
-	return ( select( STORE_KEY ) as SiteSelect ).getSite( siteId )?.options?.is_wpcom_atomic === true;
+	return (
+		( select( STORE_KEY ) as unknown as SiteSelect ).getSite( siteId )?.options?.is_wpcom_atomic ===
+		true
+	);
 };
 
 export const isSiteWPForTeams: ( _: State, siteId: number | string ) => boolean = (
@@ -68,7 +71,8 @@ export const isSiteWPForTeams: ( _: State, siteId: number | string ) => boolean 
 	siteId
 ) => {
 	return (
-		( select( STORE_KEY ) as SiteSelect ).getSite( siteId )?.options?.is_wpforteams_site === true
+		( select( STORE_KEY ) as unknown as SiteSelect ).getSite( siteId )?.options
+			?.is_wpforteams_site === true
 	);
 };
 
@@ -104,12 +108,12 @@ export const getPrimarySiteDomain: ( _: State, siteId: number ) => Domain | unde
 	_,
 	siteId
 ) =>
-	( select( STORE_KEY ) as SiteSelect )
+	( select( STORE_KEY ) as unknown as SiteSelect )
 		.getSiteDomains( siteId )
 		?.find( ( domain: Domain ) => domain.primary_domain );
 
 export const getSiteSubdomain: ( _: State, siteId: number ) => Domain | undefined = ( _, siteId ) =>
-	( select( STORE_KEY ) as SiteSelect )
+	( select( STORE_KEY ) as unknown as SiteSelect )
 		.getSiteDomains( siteId )
 		?.find( ( domain: Domain ) => domain.is_subdomain );
 
@@ -144,7 +148,7 @@ export const siteHasFeature = (
 ): boolean => {
 	return Boolean(
 		siteId &&
-			( select( STORE_KEY ) as SiteSelect )
+			( select( STORE_KEY ) as unknown as SiteSelect )
 				.getSite( siteId )
 				?.plan?.features.active.includes( featureKey )
 	);
@@ -155,11 +159,15 @@ export const requiresUpgrade: ( state: State, siteId: number | null ) => boolean
 	state,
 	siteId
 ) => {
-	return siteId && ! ( select( STORE_KEY ) as SiteSelect ).siteHasFeature( siteId, 'woop' );
+	return (
+		siteId && ! ( select( STORE_KEY ) as unknown as SiteSelect ).siteHasFeature( siteId, 'woop' )
+	);
 };
 
 export function isJetpackSite( state: State, siteId?: number ): boolean {
-	return Boolean( siteId && ( select( STORE_KEY ) as SiteSelect ).getSite( siteId )?.jetpack );
+	return Boolean(
+		siteId && ( select( STORE_KEY ) as unknown as SiteSelect ).getSite( siteId )?.jetpack
+	);
 }
 
 export const getBundledPluginSlug = ( state: State, siteSlug: string ) =>


### PR DESCRIPTION
Fixes DOTCOM-17280

Related to #105909

## Proposed Changes

Forward-compatible TypeScript fixes for the `data-stores` and `api-core` packages, extracted from the WordPress monorepo dependency bump (#105909) so they can land on `trunk` independently, ahead of the bump.

* `select()` casts in `data-stores` (`site`, `plans`, `help-center`, `products-list`): `as XSelect` → `as unknown as XSelect`.
* `FetchUserParams` (`api-core`) and `AllDomainsQueryArgs` (`data-stores`): `interface` → `type`.
* `contextual-help/admin-sections`: coerce a possibly-`undefined` plan title to a string before `sprintf()`.
* `reader/helpers` `callApi()`: `await` `apiFetch()` and assert the result.

## Why are these changes being made?

The WordPress monorepo bump (#105909) is a single mega-PR that bundles a routine lockfile update with several genuine breaking-change migrations, which makes it unmergeable and a perpetual merge-conflict magnet. The plan is to **decompose** it: land the forward-compatible fixes on `trunk` first as small, reviewable PRs, shrinking the bump itself to a near-trivial lockfile update.

This PR is the `data-stores` / `api-core` slice. The fixes address upcoming behavior of newer `@wordpress/*` packages:

* The newer `@wordpress/data` changes `select()`'s return type, so the existing direct `as XSelect` assertions no longer have sufficient type overlap (TS2352). The double assertion through `unknown` is valid against both the current and the bumped versions.
* The newer `@wordpress/url` `addQueryArgs()` requires a `Record<string, unknown>` argument. A type-literal alias gets an implicit index signature and satisfies that; an `interface` does not.
* The newer `@wordpress/i18n` `sprintf()` rejects non-string arguments.
* The newer `@wordpress/api-fetch` widens `apiFetch()`'s return type.

All changes compile against **both** the current and bumped dependency versions — verified by building the `data-stores` workspace on `trunk`'s current lockfile.

## Testing Instructions

* `yarn install` — the `data-stores` workspace build runs as part of install and passes.
* No runtime behavior changes: the `select()` casts and `interface`→`type` changes are type-only; the `sprintf` argument is `String()`-coerced (the plan title is never actually `undefined` in practice); `callApi()` returns the same value via `await` instead of returning the promise directly.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

