### PR TITLE
icons: use non-deprecated @wordpress/icons export names

### DIFF
--- a/apps/notifications/src/app/templates/button-edit.jsx
+++ b/apps/notifications/src/app/templates/button-edit.jsx
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import { edit } from '@wordpress/icons';
+import { pencil as edit } from '@wordpress/icons';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { getEditCommentLink } from '../../panel/helpers/notes';

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-sites-menu-items.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-sites-menu-items.ts
@@ -1,4 +1,4 @@
-import { category, code, starEmpty, tool, warning } from '@wordpress/icons';
+import { category, code, starEmpty, tool, cautionFilled as warning } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import useFetchPendingSites from 'calypso/a8c-for-agencies/data/sites/use-fetch-pending-sites';

--- a/client/a8c-for-agencies/sections/agent-studio/primary/overview/deliverable-card.tsx
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/overview/deliverable-card.tsx
@@ -11,7 +11,7 @@ import {
 } from '@wordpress/components';
 import { dateI18n } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
-import { Icon, moreVertical, page, trash, warning } from '@wordpress/icons';
+import { Icon, moreVertical, page, trash, cautionFilled as warning } from '@wordpress/icons';
 import { useState } from 'react';
 import { getAgentStudioOutputPath } from '../../lib/paths';
 import DeleteDeliverableDialog from './delete-deliverable-dialog';

--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import { FormLabel, Tooltip } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { Button, __experimentalVStack as VStack } from '@wordpress/components';
-import { customLink, Icon, send, warning } from '@wordpress/icons';
+import { customLink, Icon, send, cautionFilled as warning } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 import clsx from 'clsx';
 import emailValidator from 'email-validator';

--- a/client/blocks/post-edit-button/index.jsx
+++ b/client/blocks/post-edit-button/index.jsx
@@ -1,4 +1,4 @@
-import { Icon, edit } from '@wordpress/icons';
+import { Icon, pencil as edit } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { getEditURL } from 'calypso/state/posts/utils';

--- a/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
+++ b/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
@@ -1,5 +1,5 @@
 import page from '@automattic/calypso-router';
-import { edit, external, Icon, seen, published, unseen } from '@wordpress/icons';
+import { pencil as edit, external, Icon, seen, published, unseen } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import { size, map } from 'lodash';
 import PropTypes from 'prop-types';

--- a/client/components/connect-screen/stories/index.stories.tsx
+++ b/client/components/connect-screen/stories/index.stories.tsx
@@ -1,7 +1,15 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { StoryObj, Meta } from '@storybook/react';
 import { IconType } from '@wordpress/components';
-import { seen, edit, cog, check, chartBar, postList, commentAuthorAvatar } from '@wordpress/icons';
+import {
+	seen,
+	pencil as edit,
+	cog,
+	check,
+	chartBar,
+	postList,
+	commentAuthorAvatar,
+} from '@wordpress/icons';
 import { useState } from 'react';
 import { Provider } from 'react-redux';
 import { createStore } from 'redux';

--- a/client/dashboard/domains/domain-dns/actions.tsx
+++ b/client/dashboard/domains/domain-dns/actions.tsx
@@ -3,7 +3,7 @@ import { useMutation } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { edit, trash } from '@wordpress/icons';
+import { pencil as edit, trash } from '@wordpress/icons';
 import { useMemo } from 'react';
 import { domainRoute, domainDnsEditRoute } from '../../app/router/domains';
 import type { DnsRecord } from '@automattic/api-core';

--- a/client/dashboard/me/billing-payment-methods/index.tsx
+++ b/client/dashboard/me/billing-payment-methods/index.tsx
@@ -18,7 +18,7 @@ import { useResizeObserver } from '@wordpress/compose';
 import { useDispatch } from '@wordpress/data';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __, sprintf } from '@wordpress/i18n';
-import { info, warning } from '@wordpress/icons';
+import { info, cautionFilled as warning } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState, useMemo } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';

--- a/client/dashboard/me/security-ssh-key/ssh-key.tsx
+++ b/client/dashboard/me/security-ssh-key/ssh-key.tsx
@@ -9,7 +9,7 @@ import {
 	__experimentalText as Text,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { edit, trash } from '@wordpress/icons';
+import { pencil as edit, trash } from '@wordpress/icons';
 import { useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { useLocale } from '../../app/locale';

--- a/client/dashboard/sites/deployments-list/deployment-logs/deployment-logs-status.tsx
+++ b/client/dashboard/sites/deployments-list/deployment-logs/deployment-logs-status.tsx
@@ -1,7 +1,14 @@
 import { DeploymentRunStatus } from '@automattic/api-core';
 import { __experimentalText as Text, __experimentalHStack as HStack } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { Icon, published, scheduled, error, warning, info } from '@wordpress/icons';
+import {
+	Icon,
+	published,
+	scheduled,
+	error,
+	cautionFilled as warning,
+	info,
+} from '@wordpress/icons';
 
 function formatDuration( startedOn: string, completedOn: string | number | null ) {
 	if ( ! startedOn ) {

--- a/client/dashboard/sites/scan/utils.ts
+++ b/client/dashboard/sites/scan/utils.ts
@@ -1,5 +1,12 @@
 import { Threat } from '@automattic/api-core';
-import { wordpress, code, plugins, brush, blockTable, warning } from '@wordpress/icons';
+import {
+	wordpress,
+	code,
+	plugins,
+	brush,
+	blockTable,
+	cautionFilled as warning,
+} from '@wordpress/icons';
 
 export function getThreatType(
 	threat: Threat

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-share-ssh-access.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-share-ssh-access.tsx
@@ -1,5 +1,5 @@
 import { Button, Icon, Spinner } from '@wordpress/components';
-import { check, edit, copy } from '@wordpress/icons';
+import { check, pencil as edit, copy } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { FC, ReactNode, useState } from 'react';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';

--- a/client/me/purchases/manage-purchase/payment-info-block.tsx
+++ b/client/me/purchases/manage-purchase/payment-info-block.tsx
@@ -1,4 +1,4 @@
-import { Icon, warning } from '@wordpress/icons';
+import { Icon, cautionFilled as warning } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import PaymentLogo from 'calypso/components/payment-logo';

--- a/client/me/purchases/purchase-item/index.tsx
+++ b/client/me/purchases/purchase-item/index.tsx
@@ -16,7 +16,7 @@ import { formatCurrency } from '@automattic/number-formatters';
 import { CALYPSO_CONTACT } from '@automattic/urls';
 import { getPaymentMethodImageURL, razorpayImage as upiImage } from '@automattic/wpcom-checkout';
 import { ExternalLink, Button } from '@wordpress/components';
-import { Icon, warning as warningIcon } from '@wordpress/icons';
+import { Icon, cautionFilled as warningIcon } from '@wordpress/icons';
 import clsx from 'clsx';
 import { localize, useTranslate } from 'i18n-calypso';
 import { Component } from 'react';

--- a/client/my-sites/domains/domain-management/dns/dns-records-list.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records-list.jsx
@@ -1,6 +1,6 @@
 import page from '@automattic/calypso-router';
 import { MaterialIcon } from '@automattic/components';
-import { edit, Icon, info, redo, trash } from '@wordpress/icons';
+import { pencil as edit, Icon, info, redo, trash } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';

--- a/client/my-sites/importer/newsletter/subscribers/import-subscribers-error.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/import-subscribers-error.tsx
@@ -1,6 +1,6 @@
 import { FormInputValidation } from '@automattic/components';
 import { Subscriber } from '@automattic/data-stores';
-import { Icon, warning } from '@wordpress/icons';
+import { Icon, cautionFilled as warning } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 
 type Props = {

--- a/client/my-sites/stats/stats-list/action-spam.jsx
+++ b/client/my-sites/stats/stats-list/action-spam.jsx
@@ -1,6 +1,6 @@
 import { Dialog } from '@automattic/components';
 import { Tooltip } from '@wordpress/components';
-import { Icon, warning } from '@wordpress/icons';
+import { Icon, cautionFilled as warning } from '@wordpress/icons';
 import clsx from 'clsx';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';

--- a/client/my-sites/stats/stats-list/stats-list-actions.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-actions.jsx
@@ -1,4 +1,4 @@
-import { Icon, moreHorizontalMobile } from '@wordpress/icons';
+import { Icon, moreHorizontal as moreHorizontalMobile } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';

--- a/client/my-sites/stats/stats-list/stats-list-item.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-item.jsx
@@ -1,7 +1,13 @@
 import page from '@automattic/calypso-router';
 import { Gridicon } from '@automattic/components';
 import { formatNumber } from '@automattic/number-formatters';
-import { Icon, moreHorizontalMobile, tag, file, chevronDown } from '@wordpress/icons';
+import {
+	Icon,
+	moreHorizontal as moreHorizontalMobile,
+	tag,
+	file,
+	chevronDown,
+} from '@wordpress/icons';
 import clsx from 'clsx';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';

--- a/client/reader/social/composer/triggers/compose-fab.tsx
+++ b/client/reader/social/composer/triggers/compose-fab.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@wordpress/components';
-import { edit } from '@wordpress/icons';
+import { pencil as edit } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useComposer } from '../composer-provider';

--- a/packages/components/src/notice-banner/index.tsx
+++ b/packages/components/src/notice-banner/index.tsx
@@ -1,4 +1,4 @@
-import { Icon, warning, info, check, closeSmall } from '@wordpress/icons';
+import { Icon, cautionFilled as warning, info, check, closeSmall } from '@wordpress/icons';
 import clsx from 'clsx';
 import React from 'react';
 import { alert } from '../icons';

--- a/packages/content-research/src/components/ai-summary/index.tsx
+++ b/packages/content-research/src/components/ai-summary/index.tsx
@@ -2,7 +2,14 @@ import { Button, Icon, Spinner } from '@wordpress/components';
 import { dispatch } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { arrowLeft, pencil, check, chevronDown, chevronUp, warning } from '@wordpress/icons';
+import {
+	arrowLeft,
+	pencil,
+	check,
+	chevronDown,
+	chevronUp,
+	cautionFilled as warning,
+} from '@wordpress/icons';
 import SourceIcon from '../source-icon';
 import type { ResearchResult, ResearchSummary, SuggestedAngle } from '../../types';
 

--- a/packages/domain-search/src/ui/domain-suggestion-cta/error.tsx
+++ b/packages/domain-search/src/ui/domain-suggestion-cta/error.tsx
@@ -1,5 +1,5 @@
 import { Button, Tooltip } from '@wordpress/components';
-import { warning } from '@wordpress/icons';
+import { cautionFilled as warning } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import { useDomainSuggestionContainerContext } from '../../hooks/use-domain-suggestion-container';

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-nudge.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-nudge.tsx
@@ -5,7 +5,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Icon, warning } from '@wordpress/icons';
+import { Icon, cautionFilled as warning } from '@wordpress/icons';
 /**
  * Internal dependencies
  */


### PR DESCRIPTION
Fixes DOTCOM-17281

Related to #105909

## Proposed Changes

Switch three `@wordpress/icons` imports to export names that exist in **both** the current (`10.x`) and the upcoming (`13.x`) versions of the package, so the code is compatible with the `@wordpress/icons` bump in #105909 ahead of time.

* `warning` → `cautionFilled`
* `edit` → `pencil`
* `moreHorizontalMobile` → `moreHorizontal`

The v13-compatible name is imported and aliased back to the original local identifier (`import { cautionFilled as warning }`, etc.), so only the import line changes in each of the 25 files.

## Why are these changes being made?

The WordPress monorepo bump (#105909) raises `@wordpress/icons` from `10.x` to `13.x`. v13 removes the three exports above (`Module '"@wordpress/icons"' has no exported member 'warning'`). Per the decompose plan for #105909, this forward-compatible fix lands on `trunk` first so the bump itself stays a trivial lockfile change.

The replacements are safe:

* In v10, `warning` is already a `@deprecated` alias of `cautionFilled`, and `edit` is a plain re-export of `pencil` — identical glyphs, so those two are pure no-ops on `trunk` today.
* v13 drops the `moreHorizontalMobile` ("mobile" three-dots) variant. `moreHorizontal` is the standard "more actions" icon; the only visible difference is square dots instead of circle dots, in a 22px menu trigger in the Stats list.

All three replacement names are exported by both `@wordpress/icons@10` and `@wordpress/icons@13`, so this compiles against the current and bumped dependency versions.

## Testing Instructions

* `yarn typecheck-client` / `typecheck-packages` / `typecheck-apps` — the 25 changed files type-check cleanly.
* Visual: the `warning` and `edit` icons are unchanged (identical glyphs). The Stats list "more actions" menu trigger (`client/my-sites/stats/stats-list/`) shows square dots instead of circle dots.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

