### PR TITLE
agents-manager, onboarding: forward-compatible select() casts

### DIFF
--- a/packages/agents-manager/src/hooks/use-persisted-history.ts
+++ b/packages/agents-manager/src/hooks/use-persisted-history.ts
@@ -149,14 +149,15 @@ class MemoryHistory {
  * Read the full router history map from the store (synchronous, outside React).
  */
 function getFullRouterHistory(): PerSiteRouterHistory | undefined {
-	return ( storeSelect( AGENTS_MANAGER_STORE ) as AgentsManagerSelect ).getAgentsManagerState()
-		.routerHistory;
+	return (
+		storeSelect( AGENTS_MANAGER_STORE ) as unknown as AgentsManagerSelect
+	 ).getAgentsManagerState().routerHistory;
 }
 
 export const usePersistedHistory = ( siteKey: string ) => {
 	const { persistedHistory, lastActive } = useSelect(
 		( select ) => {
-			const store = select( AGENTS_MANAGER_STORE ) as AgentsManagerSelect;
+			const store = select( AGENTS_MANAGER_STORE ) as unknown as AgentsManagerSelect;
 			return {
 				persistedHistory: store.getRouterHistory( siteKey ),
 				lastActive: store.getLastActivity( siteKey ),

--- a/packages/agents-manager/src/hooks/use-save-new-chat-route.ts
+++ b/packages/agents-manager/src/hooks/use-save-new-chat-route.ts
@@ -11,7 +11,7 @@ import type { AgentsManagerSelect } from '@automattic/data-stores';
  * Saves the chat route so the conversation can be restored later.
  */
 function saveNewChatRoute( sessionId: string, siteKey: string ): void {
-	const store = select( AGENTS_MANAGER_STORE ) as AgentsManagerSelect;
+	const store = select( AGENTS_MANAGER_STORE ) as unknown as AgentsManagerSelect;
 	const current = store.getRouterHistory( siteKey );
 
 	const entry = {

--- a/packages/agents-manager/src/utils/persist-last-activity.ts
+++ b/packages/agents-manager/src/utils/persist-last-activity.ts
@@ -8,7 +8,7 @@ import { persistAgentsManagerState } from './persist-agents-manager-state';
  * Merges with existing activity data for other sites.
  */
 export function persistLastActivity( siteKey: string ): void {
-	const store = select( AGENTS_MANAGER_STORE ) as AgentsManagerSelect;
+	const store = select( AGENTS_MANAGER_STORE ) as unknown as AgentsManagerSelect;
 	const existing = store.getAgentsManagerState().lastActivity || {};
 
 	persistAgentsManagerState( {

--- a/packages/onboarding/src/setup-tailored-site-after-creation.ts
+++ b/packages/onboarding/src/setup-tailored-site-after-creation.ts
@@ -39,10 +39,12 @@ interface SetupOnboardingSiteOptions {
 
 export function setupSiteAfterCreation( { siteId, flowName }: SetupOnboardingSiteOptions ) {
 	// const { resetOnboardStore } = dispatch( ONBOARD_STORE );
-	const goals = ( select( ONBOARD_STORE ) as OnboardSelect ).getGoals();
-	const siteTitle = ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedSiteTitle();
-	const siteDescription = ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedSiteDescription();
-	const siteLogo = ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedSiteLogo();
+	const goals = ( select( ONBOARD_STORE ) as unknown as OnboardSelect ).getGoals();
+	const siteTitle = ( select( ONBOARD_STORE ) as unknown as OnboardSelect ).getSelectedSiteTitle();
+	const siteDescription = (
+		select( ONBOARD_STORE ) as unknown as OnboardSelect
+	 ).getSelectedSiteDescription();
+	const siteLogo = ( select( ONBOARD_STORE ) as unknown as OnboardSelect ).getSelectedSiteLogo();
 
 	if ( siteId && flowName ) {
 		const formData: ( string | File )[][] = [];

--- a/packages/onboarding/src/step-container-v2/helpers/decorateButtonWithTracksEventRecording.ts
+++ b/packages/onboarding/src/step-container-v2/helpers/decorateButtonWithTracksEventRecording.ts
@@ -20,7 +20,7 @@ export const decorateButtonWithTracksEventRecording = (
 		stepContext?.recordTracksEvent?.( tracksEventName, {
 			flow: stepContext?.flowName,
 			step: stepContext?.stepName,
-			intent: ( select( Onboard.register() ) as OnboardSelect ).getIntent(),
+			intent: ( select( Onboard.register() ) as unknown as OnboardSelect ).getIntent(),
 		} );
 	};
 


### PR DESCRIPTION
Fixes DOTCOM-17282

Related to #105909

## Proposed Changes

Route the `select( … ) as AgentsManagerSelect` / `as OnboardSelect` type assertions in the `agents-manager` and `onboarding` packages through `unknown` (`as unknown as …`). 9 cast sites across 5 files.

## Why are these changes being made?

The WordPress monorepo bump (#105909) updates `@wordpress/data`, which changes the return type of `select()`. The existing direct assertions no longer have sufficient type overlap with the target select types, producing `TS2352` build failures (`Conversion of type '… & MetadataSelectors<…>' to type 'AgentsManagerSelect' may be a mistake…`).

Routing through `unknown` is the assertion the compiler itself recommends, and it is valid against **both** the current and the bumped `@wordpress/data` versions. Per the decompose plan for #105909, this forward-compatible fix lands on `trunk` first so the bump stays a trivial lockfile change.

This is the same fix as #110972 (which covered `data-stores` / `api-core`), applied to the remaining two packages whose workspace builds run during `yarn install`.

## Testing Instructions

* `yarn workspace @automattic/agents-manager run build` and `yarn workspace @automattic/onboarding run build` both pass on `trunk`'s current lockfile.
* No runtime behavior change — the casts are type-only.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

