### PR TITLE
[codex] Limit smart dictation mic shimmer

### DIFF
--- a/packages/wpcom-smart-dictation/src/live-ai-assistant/components/mic-icon.tsx
+++ b/packages/wpcom-smart-dictation/src/live-ai-assistant/components/mic-icon.tsx
@@ -38,28 +38,28 @@ export function MicIcon( {
 							values="-120%;120%;120%"
 							keyTimes="0;0.18;1"
 							dur="5s"
-							repeatCount="indefinite"
+							repeatCount="3"
 						/>
 						<animate
 							attributeName="x2"
 							values="-20%;220%;220%"
 							keyTimes="0;0.18;1"
 							dur="5s"
-							repeatCount="indefinite"
+							repeatCount="3"
 						/>
 						<animate
 							attributeName="y1"
 							values="120%;-120%;-120%"
 							keyTimes="0;0.18;1"
 							dur="5s"
-							repeatCount="indefinite"
+							repeatCount="3"
 						/>
 						<animate
 							attributeName="y2"
 							values="20%;-220%;-220%"
 							keyTimes="0;0.18;1"
 							dur="5s"
-							repeatCount="indefinite"
+							repeatCount="3"
 						/>
 					</linearGradient>
 				) }


### PR DESCRIPTION
Part of #

## Proposed Changes

* Limit the Smart Dictation mic icon shimmer SVG animation to three runs instead of looping forever.

## Why are these changes being made?

* The icon shimmer should provide a brief bit of motion without continuing indefinitely in the sidebar/plugin icon.

## Testing Instructions

* Run `./node_modules/.bin/prettier --check packages/wpcom-smart-dictation/src/live-ai-assistant/components/mic-icon.tsx`.
* Run `./node_modules/.bin/eslint packages/wpcom-smart-dictation/src/live-ai-assistant/components/mic-icon.tsx`.
* Run `yarn tsc --build packages/wpcom-smart-dictation/tsconfig.json packages/wpcom-smart-dictation/tsconfig-cjs.json`.
* Inspect the Smart Dictation mic icon and verify the shimmer runs three times, then stops.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?