### PR TITLE
E2E: fix flaky setup-domain cancel-plan flow

### DIFF
--- a/packages/calypso-e2e/src/lib/components/me/me-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/me/me-sidebar-component.ts
@@ -1,12 +1,6 @@
 import { Page } from 'playwright';
 import envVariables from '../../../env-variables';
 
-const selectors = {
-	// Menu items
-	menuItem: ( menu: string ) =>
-		`.sidebar a:has(span:has-text("${ menu }")), .sidebar a[href="${ menu }"]`,
-};
-
 /**
  * Represents the sidebar component on /me endpoint.
  */
@@ -37,9 +31,24 @@ export class MeSidebarComponent {
 	/**
 	 * Given a string, navigate to the menu on the sidebar.
 	 *
-	 * @param {string} menu Menu item label or href to navigate to.
+	 * @param {string} menu Menu item label (e.g. "Purchases") or the link's
+	 *   href (e.g. "/me/account") to navigate to.
 	 */
 	async navigate( menu: string ): Promise< void > {
-		await this.page.click( selectors.menuItem( menu ) );
+		// The sidebar link renders a `.sidebar__menu-link-text` span carrying a
+		// `data-e2e-sidebar` attribute set to the exact menu label. Matching on
+		// that attribute (exact match) and resolving the enclosing anchor is far
+		// more robust than the previous substring `:has-text()` selector.
+		//
+		// Some callers pass an href (a path beginning with "/") instead of a
+		// label, so also support an exact `href` attribute match — unlike the
+		// previous `a[href="<label>"]` fallback, which compared the href to a
+		// label string and therefore never matched a real link.
+		const byLabel = this.page.locator( `.sidebar a:has([data-e2e-sidebar="${ menu }"])` );
+		const byHref = this.page.locator( `.sidebar a[href="${ menu }"]` );
+		const menuItem = byLabel.or( byHref ).first();
+
+		await menuItem.waitFor( { state: 'visible' } );
+		await menuItem.click();
 	}
 }

--- a/packages/calypso-e2e/src/lib/flows/cancel-purchase-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/cancel-purchase-flow.ts
@@ -50,16 +50,16 @@ export async function cancelAtomicPurchaseFlow(
 		.getByRole( 'button', { name: 'Submit' } )
 		.or( page.getByRole( 'button', { name: 'Continue' } ) );
 
-	await Promise.all( [
-		page.waitForNavigation( { timeout: 30 * 1000 } ),
-		finalButton.waitFor( { state: 'visible' } ),
-		// Wait for button to be enabled
-		page.waitForFunction(
-			() => {
-				const button = document.querySelector( 'button[class*="is-primary"]' );
-				return button && ! button.hasAttribute( 'disabled' );
-			},
-			{ timeout: 10000 }
-		),
-	] );
+	// Wait for the final button to be present and actionable before clicking.
+	// `click()` auto-waits for visibility and the enabled state, so an explicit
+	// `waitForFunction` on the disabled attribute is no longer needed.
+	await finalButton.waitFor( { state: 'visible' } );
+	await finalButton.click();
+
+	// Confirming the cancellation does not trigger a full-page navigation: the
+	// purchases view updates in place as a single-page-app state change. The
+	// previous `page.waitForNavigation()` therefore never resolved and hung
+	// until its timeout. Callers assert the resulting success notice (e.g.
+	// "Your refund has been processed and your purchase removed.") to confirm
+	// the flow completed, which is the deterministic signal to wait on.
 }


### PR DESCRIPTION
## Proposed Changes

- `cancelAtomicPurchaseFlow` (`packages/calypso-e2e/src/lib/flows/cancel-purchase-flow.ts`): restore the final confirm-button click that was dropped in #104832, which had replaced the `.click()` with a `.waitFor()` inside a `Promise.all`. Replace the never-resolving `page.waitForNavigation()` with a deterministic `waitFor({ state: 'visible' })` + `click()`; the spec's existing `noticeShown('Your refund has been processed and your purchase removed.')` assertion is the completion signal.
- `MeSidebarComponent.navigate` (`packages/calypso-e2e/src/lib/components/me/me-sidebar-component.ts`): replace the fragile selector — whose `a[href="<label>"]` clause was dead and whose substring `:has-text()` clause was order/whitespace-sensitive — with an exact `[data-e2e-sidebar="<label>"]` attribute match (rendered by the product's shared sidebar item) or an exact `href` match, and add an explicit visibility wait before clicking.
- No product code changed; both failures were test-infrastructure stability defects.

## Why are these changes being made?

The E2E test `Setup Domain Flows › As a new user, I can create a paid site, add a domain, then cancel the plan` timed out in CI ([TeamCity build](https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Playwright_Test_Matrix/17885694)). The primary failure hung in `cancelAtomicPurchaseFlow`: commit #104832 refactored the final cancellation step and accidentally replaced the confirm button's `.click()` with a `.waitFor()`, so the flow reached the final step but never confirmed it — and the paired `page.waitForNavigation()` then waited for a navigation that never occurs, hanging until the 120s test timeout. On retry the test failed earlier in `MeSidebarComponent.navigate('Purchases')`, where `page.click()` on a fragile selector timed out before the `/me` sidebar finished rendering.

## Testing Instructions

Run `yarn playwright test specs/flows/setup-domain__flows.spec.ts --reporter=list --repeat-each=10` locally; all runs should pass.