### PR TITLE
E2E: fix flaky cancel-plan submit click in setup-domain flow

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/cancel-purchase-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/cancel-purchase-flow.ts
@@ -1,6 +1,38 @@
-import { Page } from 'playwright';
+import { Locator, Page } from 'playwright';
 
 type CancelReason = 'Another reason…';
+
+/**
+ * Clicks a button locator once it is both visible and actually enabled.
+ *
+ * The cancellation flow renders its primary buttons with the
+ * `@wordpress/components` "busy" state (`class="is-busy"` plus the `disabled`
+ * attribute) while an async request is in flight. Such a button is visible but
+ * not actionable, so `click()` alone can exhaust its action timeout before the
+ * button settles. Waiting for the `disabled` attribute to be removed first
+ * guarantees the subsequent click targets an enabled element. The button may
+ * also re-render between states; polling the live locator rides that out.
+ *
+ * @param {Locator} button Button locator to wait on and click.
+ * @param {number} timeout Maximum time, in milliseconds, to wait for the enabled state.
+ */
+async function clickWhenEnabled( button: Locator, timeout = 30 * 1000 ): Promise< void > {
+	const deadline = Date.now() + timeout;
+
+	await button.waitFor( { state: 'visible', timeout } );
+
+	while ( ( await button.getAttribute( 'disabled' ) ) !== null ) {
+		if ( Date.now() >= deadline ) {
+			throw new Error(
+				`Timed out after ${ timeout }ms waiting for button to become enabled before clicking.`
+			);
+		}
+		await button.page().waitForTimeout( 100 );
+		await button.waitFor( { state: 'visible', timeout: Math.max( deadline - Date.now(), 1 ) } );
+	}
+
+	await button.click();
+}
 
 /**
  * Cancels a purchased subscription.
@@ -31,8 +63,7 @@ export async function cancelAtomicPurchaseFlow(
 	const firstButton = page
 		.getByRole( 'button', { name: 'Submit' } )
 		.or( page.getByRole( 'button', { name: 'Continue' } ) );
-	await firstButton.waitFor( { state: 'visible' } );
-	await firstButton.click();
+	await clickWhenEnabled( firstButton );
 
 	// Select dropdown value to enable the next button
 	await page
@@ -43,18 +74,16 @@ export async function cancelAtomicPurchaseFlow(
 	const secondButton = page
 		.getByRole( 'button', { name: 'Submit' } )
 		.or( page.getByRole( 'button', { name: 'Continue' } ) );
-	await secondButton.waitFor( { state: 'visible' } );
-	await secondButton.click();
+	await clickWhenEnabled( secondButton );
 
 	const finalButton = page
 		.getByRole( 'button', { name: 'Submit' } )
 		.or( page.getByRole( 'button', { name: 'Continue' } ) );
 
-	// Wait for the final button to be present and actionable before clicking.
-	// `click()` auto-waits for visibility and the enabled state, so an explicit
-	// `waitForFunction` on the disabled attribute is no longer needed.
-	await finalButton.waitFor( { state: 'visible' } );
-	await finalButton.click();
+	// The final button renders visible but `disabled`/`is-busy` while the
+	// cancellation request is in flight, so visibility alone is not enough to
+	// click it reliably. Wait for it to become enabled first.
+	await clickWhenEnabled( finalButton );
 
 	// Confirming the cancellation does not trigger a full-page navigation: the
 	// purchases view updates in place as a single-page-app state change. The


### PR DESCRIPTION
## Proposed Changes

- Add a `clickWhenEnabled` helper to `cancel-purchase-flow.ts` that waits for a button to be visible **and** for its `disabled` attribute to clear before clicking, re-resolving the live locator on each poll iteration to ride out busy-state re-renders.
- Route all three button interactions in `cancelAtomicPurchaseFlow` through the new helper, replacing the previous visibility-only `waitFor` plus bare `click()` pattern.
- This stabilizes the `And I cancel the plan renewal` step of the `setup-domain__flows.spec.ts` Atomic cancellation tests.

## Why are these changes being made?

The final submit button in the Atomic plan cancellation flow is rendered by `@wordpress/components` in its "busy" state (`class="is-busy"` plus the `disabled` attribute) while the cancellation API request is in flight. The shared helper `cancelAtomicPurchaseFlow` waited only for `waitFor({ state: 'visible' })` before calling `click()`. Visibility is satisfied while the button is still disabled/busy, so the `click()` had to absorb the entire wait for the enabled state inside its own 10-second action timeout. When the busy state outlasted that timeout — and especially when the button re-rendered (`element was detached from the DOM`) — the click timed out with `element is not enabled`. The failure was observed on the E2E Test Matrix build: https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Playwright_Test_Matrix/17887151

## Testing Instructions

Run `yarn playwright test test/e2e/specs/flows/setup-domain__flows.spec.ts --reporter=list --repeat-each=10` locally; all runs should pass.