### PR TITLE
E2E: fix flaky setup-domain cancel-plan submit timeout

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/cancel-purchase-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/cancel-purchase-flow.ts
@@ -42,6 +42,27 @@ export async function cancelSubscriptionFlow( page: Page ) {
 }
 
 /**
+ * Returns a locator that matches the cancellation survey's primary step button.
+ *
+ * The button's label depends on the survey step and the active experiment
+ * variant: a non-final step renders "Continue", while the final step renders
+ * "Submit" (legacy variant) or "Complete" (the split cancel/remove experiment
+ * with an `intent=cancel` deep link). Matching all three keeps the flow robust
+ * regardless of which variant is served.
+ *
+ * @param {Page} page Page object the survey is rendered on.
+ * @returns {Locator} Locator matching the survey's primary step button.
+ */
+function surveyStepButton( page: Page ): Locator {
+	// Exact matching avoids accidentally resolving to longer labels used by
+	// other survey variants (e.g. "Continue removal", "Complete removal").
+	return page
+		.getByRole( 'button', { name: 'Submit', exact: true } )
+		.or( page.getByRole( 'button', { name: 'Continue', exact: true } ) )
+		.or( page.getByRole( 'button', { name: 'Complete', exact: true } ) );
+}
+
+/**
  * Cancels a purchased Atomic site.
  */
 export async function cancelAtomicPurchaseFlow(
@@ -59,31 +80,23 @@ export async function cancelAtomicPurchaseFlow(
 		.getByRole( 'textbox', { name: 'Can you please specify?' } )
 		.fill( feedback.customReasonText );
 
-	// Submit first step - could be "Submit" or "Continue"
-	const firstButton = page
-		.getByRole( 'button', { name: 'Submit' } )
-		.or( page.getByRole( 'button', { name: 'Continue' } ) );
-	await clickWhenEnabled( firstButton );
+	// Submit the feedback step. This is not the final step, so the button is
+	// labelled "Continue", but match the other labels too to ride out variant
+	// differences.
+	await clickWhenEnabled( surveyStepButton( page ) );
 
-	// Select dropdown value to enable the next button
+	// The next (and final) step asks where the user is headed next. Selecting an
+	// answer enables the final step button.
 	await page
 		.getByRole( 'combobox', { name: 'Where is your next adventure taking you?' } )
 		.selectOption( "I'm staying here and using the free plan." );
 
-	// Submit second step - could be "Submit" or "Continue"
-	const secondButton = page
-		.getByRole( 'button', { name: 'Submit' } )
-		.or( page.getByRole( 'button', { name: 'Continue' } ) );
-	await clickWhenEnabled( secondButton );
-
-	const finalButton = page
-		.getByRole( 'button', { name: 'Submit' } )
-		.or( page.getByRole( 'button', { name: 'Continue' } ) );
-
-	// The final button renders visible but `disabled`/`is-busy` while the
-	// cancellation request is in flight, so visibility alone is not enough to
-	// click it reliably. Wait for it to become enabled first.
-	await clickWhenEnabled( finalButton );
+	// Submit the final step. The survey for a plan cancellation only has these
+	// two steps, so there is no third button to click. The final button renders
+	// visible but `disabled`/`is-busy` while the cancellation request is in
+	// flight, so visibility alone is not enough to click it reliably — wait for
+	// it to become enabled first.
+	await clickWhenEnabled( surveyStepButton( page ) );
 
 	// Confirming the cancellation does not trigger a full-page navigation: the
 	// purchases view updates in place as a single-page-app state change. The


### PR DESCRIPTION
## Proposed Changes

- Fix `cancelAtomicPurchaseFlow` in `packages/calypso-e2e/src/lib/flows/cancel-purchase-flow.ts` to submit exactly the two survey steps the plan-cancellation flow actually renders, removing a spurious third `clickWhenEnabled` call that waited on a button that never appears.
- Add a shared `surveyStepButton()` helper whose locator matches `Submit`, `Continue` and `Complete` — each exact-matched so it cannot resolve to longer variant labels like `Continue removal` — so the final-step button is found whether the legacy or the split cancel/remove experiment variant is served.
- Keep the existing busy/disabled-state wait so the final button is only clicked once the cancellation request settles.

## Why are these changes being made?

The E2E test `Setup Domain Flows › As a new user, I can create a paid site, add a domain, then cancel the plan` failed consistently in CI — on both the `chrome` and `pixel` projects and the automatic retry — with `TimeoutError: locator.waitFor: Timeout 27674ms exceeded` at `cancel-purchase-flow.ts:31`.

Root cause: `cancelAtomicPurchaseFlow` performed three `clickWhenEnabled` calls (feedback submit, next-adventure submit, and a third "final" submit), but the cancellation survey for a plan only ever renders two steps. `getAllSurveySteps()` returns `[FEEDBACK_STEP, NEXT_ADVENTURE_STEP]` for a plan cancellation, and the test's chosen reason (`Another reason…`) triggers neither an upsell step nor a solutions step. After the helper clicked the two real step buttons, the third `clickWhenEnabled` waited ~27s for a `Submit`/`Continue` button that does not exist and timed out. The helper's locator also only matched `Submit`/`Continue`, so it would miss the `Complete` label served by the split cancel/remove experiment variant.

Evidence of the failure: TeamCity build https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Playwright_Test_Matrix/17888246

## Testing Instructions

Run `yarn playwright test test/e2e/specs/flows/setup-domain__flows.spec.ts --reporter=list --repeat-each=10` locally; all runs should pass.