### PR TITLE
Enable Woo Hosting Big Sky flow in production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -118,7 +118,7 @@
 		"onboarding/interval-dropdown": true,
 		"onboarding/post-checkout-ai-step": true,
 		"onboarding/user-on-stepper-hosting": false,
-		"onboarding/woo-hosting-post-purchase-setup-choice": false,
+		"onboarding/woo-hosting-post-purchase-setup-choice": true,
 		"p2/p2-plus": true,
 		"performance/apm": false,
 		"plans/hosting-trial": true,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/project/enable-big-sky-for-site-design-in-woo-flow-exit-in-wc-admin-bfff0c3755a8/overview

## Proposed Changes

This launches the flow created by https://github.com/Automattic/wp-calypso/pull/110126 to production.

