### PR TITLE
APM: Enable performance/apm feature flag on dashboard staging

### DIFF
--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -33,7 +33,7 @@
 		"marketplace-redesign": true,
 		"mcp-settings": true,
 		"onboarding/interval-dropdown": true,
-		"performance/apm": false,
+		"performance/apm": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,


### PR DESCRIPTION
## Proposed Changes

* Flip `performance/apm` from `false` to `true` in `config/dashboard-stage.json`.

## Why are these changes being made?

* Companion to #110977, which enabled the flag in `config/stage.json`. The standalone Dashboard client (`yarn start-dashboard`) reads `config/dashboard-stage.json` on Stage, so the flag also needs to be flipped there for APM to surface in the Dashboard on staging. The flag is already enabled in `dashboard-development.json`; `dashboard-production.json` and `dashboard-horizon.json` stay disabled.

## Testing Instructions

* Confirm `performance/apm` is `true` in `config/dashboard-stage.json`. Production and Horizon remain `false`.
* On the Dashboard client deployed to Stage, the APM entry appears in the site sidebar, the APM settings summary renders under site settings, and the APM route under performance is reachable.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?