### PR TITLE
dashboard/me: typed-`@wordpress/i18n` migration

### DIFF
--- a/client/dashboard/me/billing-history/receipt.tsx
+++ b/client/dashboard/me/billing-history/receipt.tsx
@@ -543,7 +543,9 @@ function getIntroductoryOfferIntervalDisplay( {
 	context: string;
 	remainingRenewalsUsingOffer: number;
 } ): string {
-	let text = isPriceIncrease ? __( 'First billing period' ) : __( 'Discount for first period' );
+	let text: string = isPriceIncrease
+		? __( 'First billing period' )
+		: __( 'Discount for first period' );
 
 	if ( isFreeTrial ) {
 		if ( intervalUnit === 'month' ) {

--- a/client/dashboard/me/security-ssh-key/index.tsx
+++ b/client/dashboard/me/security-ssh-key/index.tsx
@@ -4,7 +4,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { securitySshKeyRoute } from '../../app/router/me';
 import InlineSupportLink from '../../components/inline-support-link';
@@ -25,7 +25,7 @@ export default function SecuritySshKey() {
 
 	const [ isEditing, setIsEditing ] = useState( false );
 
-	let description = sshKey
+	let description: ReactNode = sshKey
 		? createInterpolateElement(
 				sprintf(
 					/* translators: %(businessPlan)s is the name of the Business plan, %(commercePlan)s is the name of the Commerce plan */

--- a/client/dashboard/me/security-two-step-auth/main-page/security-keys/index.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/security-keys/index.tsx
@@ -137,7 +137,7 @@ export default function SecurityKeys() {
 				{ credential_id: selectedKeyToRemove.id },
 				{
 					onError: ( error ) => {
-						let errorMessage = __( 'Failed to delete security key.' );
+						let errorMessage: string = __( 'Failed to delete security key.' );
 						if ( error instanceof Error ) {
 							errorMessage = error.message;
 						}

--- a/client/dashboard/me/security-two-step-auth/main-page/security-keys/register-key.tsx
+++ b/client/dashboard/me/security-two-step-auth/main-page/security-keys/register-key.tsx
@@ -50,7 +50,7 @@ export default function RegisterKey( { onClose }: { onClose: () => void } ) {
 				onClose();
 			},
 			onError: ( err ) => {
-				let errorMessage = __( 'Failed to add security key. Please try again.' );
+				let errorMessage: string = __( 'Failed to add security key. Please try again.' );
 
 				// Handle WebAuthn specific errors with user-friendly messages
 				if ( err instanceof Error ) {


### PR DESCRIPTION
Fixes DOTCOM-17284

Related to #105909

## Proposed Changes

Complete the `client/dashboard/me/` slice of the typed-`@wordpress/i18n` migration: **22 files, ~73 type errors fixed**, plus **two real bugs** in user-facing notices.

Done in three commits, one per fix pattern:

### 1. Widen i18n result variables to `string` (21 `TS2322`)

A `let` initialised from one `__()` call infers an over-narrow `TransformedText<"literal">` type; later reassignment with a *different* translated string (or a plain `string`) then fails to type-check. Annotate the accumulator with its intended type.

* `billing-history/receipt.tsx` (14 errors) — `let text`
* `security-two-step-auth/main-page/security-keys/{register-key,index}.tsx` — `let errorMessage`
* `security-ssh-key/index.tsx` — `let description` (also holds an interpolated element → `ReactNode`)

### 2. Join `+`-concatenated `sprintf` formats (12 `TS2353`)

`'a' + 'b'` of two literals has type `string`, not the concatenated literal. The typed `sprintf` then computes the named-args shape as `[]` and rejects every `{ key: value }` argument. Joining the parts into a single literal lets the typed parser see the placeholders, and gives translators the full sentence in one piece (no behaviour change at runtime).

* `cancel-purchase/{domain-options,gsuite-access-message,cancel-purchase-form/step-components/upsell-step}.tsx`
* `profile-personal-details/update-username/confirmation-modal.tsx`

### 3. Coerce arg types to match the placeholders (`TS2769`)

With the format strings now literal, the typed parser strictly checks each argument. Three small sub-patterns:

* **`?? ''` / destructuring defaults** at the value's source where `string | undefined` was passed to `%s` (`Purchase.meta`, `Purchase.payment_details`, search query, recovery email, `businessPlan?.product_name`, etc.).
* **`String( … )`** where `number` was passed to `%(name)s` (`retentionDays`, `numberOfIncludedPages`, free-trial `expiry`).
* **`?? 0`** for a `number | null` value against `%d` (`cancellation_offer_notice_discount_percentage`).

A single source-level fix to the shared `cardDetails = { cardType, cardNumber, cardExpiry }` object (three identical literals across two files) clears six sprintf call sites.

### Real bugs surfaced and fixed

* **`upsell-step.tsx`** "free month offer" passed `{ planName }` to a format string whose placeholder is `%(currentPlan)s`. The mismatched key would have left `%(currentPlan)s` un-substituted in the rendered output. Now passed under the correct key.
* **`other-renewable-purchases-notice.tsx`** "plan that includes another subscription" notice had a format declaring `%(includedPurchaseName)s` but only passed `{ purchaseName, earliestOtherExpiry }`. The placeholder would have rendered literally to users. Now passes `includedPurchaseName` explicitly. A sibling call in the same file passed the *opposite* mismatch (`includedPurchaseName` to a format without it) and was cleaned up.

### Notes

* `confirmation-modal.tsx`, `domain-removal-warning-step.tsx`, and `dataviews.tsx` keep their inline self-closing tags (`<break />`, `<domainName />`, `<domain />`) in the format strings; the typed `createInterpolateElement` parser only recognises paired tags, so the conversion map is asserted to the loose shape (`Record< string, ReactElement >`) rather than reshuffling translation keys.
* The remaining dashboard/me errors against `@wordpress/i18n@6.19` are entirely `@wordpress/dataviews` `Field` typing — a separate migration.

Forward-compatible: `TransformedText` extends `string`, so all the annotations and `?? ''`/`String(...)` coercions are valid against both the current and the bumped `@wordpress/i18n`. Verified by running `yarn typecheck-client` against `@wordpress/i18n@6.19`.

## Testing Instructions

* `yarn typecheck-client` against `@wordpress/i18n@6.19`: dashboard/me has zero i18n errors.
* Visually verify the two real-bug fixes:
  * Cancel-flow free-month-offer step now shows the plan name (was rendering `%(currentPlan)s` literally).
  * "Plan includes another subscription" notice in the upcoming-renewals warning now shows the included product's name (was rendering `%(includedPurchaseName)s` literally).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

