### PR TITLE
E2E: fix flaky setup-domain cancel-plan refund notice timeout

### DIFF
--- a/packages/calypso-e2e/src/lib/flows/cancel-purchase-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/cancel-purchase-flow.ts
@@ -91,6 +91,17 @@ export async function cancelAtomicPurchaseFlow(
 		.getByRole( 'combobox', { name: 'Where is your next adventure taking you?' } )
 		.selectOption( "I'm staying here and using the free plan." );
 
+	// Submitting the final step fires the cancel-and-refund request. Start
+	// listening for its response *before* clicking so the listener cannot miss
+	// a fast response. The request hits `wpcom/v2/purchases/<id>/cancel`; the
+	// API proxy URL contains `purchases/<id>/cancel`.
+	const cancelResponsePromise = page.waitForResponse(
+		( response ) => /\/purchases\/\d+\/cancel/.test( response.url() ),
+		// A refund is a real server round-trip and can be slow in the test
+		// environment, so allow a generous window.
+		{ timeout: 60 * 1000 }
+	);
+
 	// Submit the final step. The survey for a plan cancellation only has these
 	// two steps, so there is no third button to click. The final button renders
 	// visible but `disabled`/`is-busy` while the cancellation request is in
@@ -101,7 +112,16 @@ export async function cancelAtomicPurchaseFlow(
 	// Confirming the cancellation does not trigger a full-page navigation: the
 	// purchases view updates in place as a single-page-app state change. The
 	// previous `page.waitForNavigation()` therefore never resolved and hung
-	// until its timeout. Callers assert the resulting success notice (e.g.
-	// "Your refund has been processed and your purchase removed.") to confirm
-	// the flow completed, which is the deterministic signal to wait on.
+	// until its timeout.
+	//
+	// Clicking the final button only *fires* the survey's `onSurveyComplete`
+	// handler, which then `await`s the cancel-and-refund API request before
+	// rendering the success notice. Returning right after the click left the
+	// caller's `noticeShown()` assertion racing the entire refund round-trip:
+	// the success notice is created with a 10s auto-dismiss `duration`, so a
+	// slow refund could push the notice's brief visible window outside the
+	// assertion's budget. Block here until the cancel request actually
+	// resolves so the caller's notice assertion only has to cover the notice
+	// render, not the full network round-trip.
+	await cancelResponsePromise;
 }

--- a/test/e2e/specs/flows/setup-domain__flows.spec.ts
+++ b/test/e2e/specs/flows/setup-domain__flows.spec.ts
@@ -274,6 +274,13 @@ test.describe(
 			pageMyProfile,
 			pagePurchases,
 		} ) => {
+			// This test chains several genuinely slow flows end to end: creating a
+			// paid site, completing checkout, adding a domain, and finally
+			// cancelling the plan with a real refund round-trip. The default 120s
+			// per-test budget is too tight for all of that, so widen it for this
+			// test only.
+			test.setTimeout( 240 * 1000 );
+
 			const planName = 'Personal';
 			let selectedDomain: string;
 			const testUser = helperData.getNewTestUser();
@@ -365,6 +372,10 @@ test.describe(
 			} );
 
 			await test.step( 'And I cancel the plan renewal', async function () {
+				// cancelAtomicPurchaseFlow now blocks until the cancel-and-refund
+				// API request resolves, so by the time it returns the success
+				// notice is rendering. The notice still carries a 10s auto-dismiss
+				// duration, so keep a comfortable margin to observe it.
 				await cancelAtomicPurchaseFlow( page, {
 					reason: 'Another reason…',
 					customReasonText: 'E2E TEST CANCELLATION',
@@ -506,6 +517,13 @@ test.describe(
 			pageMyProfile,
 			pagePurchases,
 		} ) => {
+			// This test chains several genuinely slow flows end to end: creating a
+			// paid site, completing checkout, adding a domain, and finally
+			// cancelling the plan with a real refund round-trip. The default 120s
+			// per-test budget is too tight for all of that, so widen it for this
+			// test only.
+			test.setTimeout( 240 * 1000 );
+
 			const planName = 'Personal';
 			const testUser = helperData.getNewTestUser();
 			let selectedDomain: string;
@@ -586,6 +604,10 @@ test.describe(
 			} );
 
 			await test.step( 'And I cancel the plan renewal', async function () {
+				// cancelAtomicPurchaseFlow now blocks until the cancel-and-refund
+				// API request resolves, so by the time it returns the success
+				// notice is rendering. The notice still carries a 10s auto-dismiss
+				// duration, so keep a comfortable margin to observe it.
 				await cancelAtomicPurchaseFlow( page, {
 					reason: 'Another reason…',
 					customReasonText: 'E2E TEST CANCELLATION',


### PR DESCRIPTION
## Proposed Changes

- `cancelAtomicPurchaseFlow` (`packages/calypso-e2e/src/lib/flows/cancel-purchase-flow.ts`) now registers a `page.waitForResponse` for the `purchases/<id>/cancel` request before clicking the final survey button and awaits it afterwards, so the helper blocks until the cancel-and-refund round-trip actually resolves.
- The two long cancel-plan tests in `test/e2e/specs/flows/setup-domain__flows.spec.ts` get `test.setTimeout( 240 * 1000 )`, since create paid site → checkout → add domain → cancel → refund genuinely exceeds the default 120s per-test budget.
- Added explanatory comments at the `noticeShown` assertions describing why the helper is now deterministic.

## Why are these changes being made?

Follow-up to the prior cancel-plan submit-timeout fix. With the survey submit fixed, the test `Setup Domain Flows › As a new user, I can create a paid site, add a domain, then cancel the plan` began failing one step later at the `componentNotice.noticeShown( 'Your refund has been processed and your purchase removed.', … )` assertion.

Root cause: clicking the survey's final submit button only *fires* the cancel-and-refund handler, which then awaits a real refund API round-trip (`wpcom/v2/purchases/<id>/cancel`) before rendering the success notice. The helper returned immediately after the click, so the caller's `noticeShown()` assertion was racing the entire refund latency plus a notice that auto-dismisses after 10s — a slow refund pushed the notice's brief visible window outside the 30s budget, and on the first `chrome` attempt the whole 120s per-test budget was exhausted before a clean assertion could run. Making the helper wait for the cancel response removes that race; widening the per-test budget covers the genuinely long end-to-end flow.

Evidence of the failure: TeamCity build https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Playwright_Test_Matrix/17888531

## Testing Instructions

Run `yarn playwright test test/e2e/specs/flows/setup-domain__flows.spec.ts --reporter=list --repeat-each=10` locally; all runs should pass.