### PR TITLE
Theme activation modal: Fix minor browser quirks

### DIFF
--- a/client/my-sites/themes/activation-modal.scss
+++ b/client/my-sites/themes/activation-modal.scss
@@ -15,14 +15,16 @@
 	// centered at every breakpoint.
 	margin-inline: auto;
 
-	// Mobile: drop our desktop overrides and let @wordpress/components Modal's
-	// default treatment take over — top-anchored, full-width, natural content
-	// height. That's the most common Calypso pattern (used by ConfirmModal,
-	// the various theme/import dialogs, etc.).
+	// Mobile: top-anchored, full-width. Bound max-height to the dynamic
+	// viewport so the modal's inner overflow:auto can scroll — without an
+	// explicit max-height the flex stretch in WP's screen-overlay isn't
+	// authoritative once content exceeds the viewport, and the top gets
+	// clipped with no way to scroll back up. `dvh` accounts for iOS Safari's
+	// dynamic address bar.
 	@media (max-width: $break-small) {
 		width: 100%;
 		max-width: none;
-		max-height: none;
+		max-height: calc(100dvh - 40px);
 		margin: 40px 0 0 0;
 	}
 

--- a/client/my-sites/themes/iframe-preview-card.scss
+++ b/client/my-sites/themes/iframe-preview-card.scss
@@ -107,12 +107,20 @@
 	// Override it so the iframe truly renders at 1200px before being scaled down.
 	max-width: none;
 	border: 0;
-	// `tan(atan2(y, x))` mathematically equals `y / x` and is a widely-compatible
-	// way to convert length-over-length into a unitless number. The simpler
-	// `calc(100cqw / 1200px)` form would require CSS Values 4 support, which
-	// is below our browser floor. The expression is wrapped in `#{"..."}` so
-	// Sass passes it through verbatim instead of trying to evaluate at build time.
+	// Fallback for older browsers (notably iOS Safari 16.x) without CSS
+	// Values 4 length/length-to-unitless `calc()`. Safari handles
+	// `tan(atan2(<length>, <length>))` correctly; Firefox 108–120 had a bug
+	// here but those versions are long out of the support window.
+	// Expression wrapped in `#{"..."}` so Sass passes it through verbatim
+	// instead of evaluating at build time.
 	transform: #{"scale(tan(atan2(100cqw, 1200px)))"};
+
+	// Preferred for browsers that support length/length-to-unitless calc:
+	// Chrome 116+, Firefox 121+, Safari 17.4+. Wins by cascade order at equal
+	// specificity, fully overriding the fallback above.
+	@supports ( transform: scale( calc( 1px / 1px ) ) ) {
+		transform: #{"scale(calc(100cqw / 1200px))"};
+	}
 	transform-origin: top left;
 	pointer-events: none;
 }

--- a/client/my-sites/themes/iframe-preview-card.scss
+++ b/client/my-sites/themes/iframe-preview-card.scss
@@ -74,9 +74,6 @@
 	border: 1px solid var(--color-neutral-10);
 	border-radius: 4px;
 	background: var(--color-neutral-0);
-	// Establishes a containment context so the iframe inside can size itself
-	// against the wrapper's width via container query units (cqw).
-	container-type: inline-size;
 }
 
 .iframe-preview-card__loading {
@@ -107,23 +104,10 @@
 	// Override it so the iframe truly renders at 1200px before being scaled down.
 	max-width: none;
 	border: 0;
-	// Fallback for older browsers (notably iOS Safari 16.x) without CSS
-	// Values 4 length/length-to-unitless `calc()`. Safari handles
-	// `tan(atan2(<length>, <length>))` correctly; Firefox 108–120 had a bug
-	// here but those versions are long out of the support window.
-	// Expression wrapped in `#{"..."}` so Sass passes it through verbatim
-	// instead of evaluating at build time.
-	transform: #{"scale(tan(atan2(100cqw, 1200px)))"};
-
-	// Preferred for browsers that support length/length-to-unitless calc:
-	// Chrome 116+, Firefox 121+, Safari 17.4+. Wins by cascade order at equal
-	// specificity, fully overriding the fallback above.
-	@supports ( transform: scale( calc( 1px / 1px ) ) ) {
-		// Routed through a CSS variable so postcss-calc (v8) doesn't try to
-		// evaluate the length-over-length division at build time.
-		--iframe-target-width: 1200px;
-		transform: #{"scale(calc(100cqw / var(--iframe-target-width)))"};
-	}
+	// `--iframe-scale` is set on the wrapper by a ResizeObserver in the
+	// component. Defaults to 0 so the iframe is invisible until the observer
+	// fires (avoids a flash of unscaled 1200px content on first paint).
+	transform: scale(var(--iframe-scale, 0));
 	transform-origin: top left;
 	pointer-events: none;
 }

--- a/client/my-sites/themes/iframe-preview-card.scss
+++ b/client/my-sites/themes/iframe-preview-card.scss
@@ -119,7 +119,10 @@
 	// Chrome 116+, Firefox 121+, Safari 17.4+. Wins by cascade order at equal
 	// specificity, fully overriding the fallback above.
 	@supports ( transform: scale( calc( 1px / 1px ) ) ) {
-		transform: #{"scale(calc(100cqw / 1200px))"};
+		// Routed through a CSS variable so postcss-calc (v8) doesn't try to
+		// evaluate the length-over-length division at build time.
+		--iframe-target-width: 1200px;
+		transform: #{"scale(calc(100cqw / var(--iframe-target-width)))"};
 	}
 	transform-origin: top left;
 	pointer-events: none;

--- a/client/my-sites/themes/iframe-preview-card.tsx
+++ b/client/my-sites/themes/iframe-preview-card.tsx
@@ -1,7 +1,7 @@
 import { Spinner } from '@automattic/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useId, useRef, useState } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
 import FormRadio from 'calypso/components/forms/form-radio';
 
 import './iframe-preview-card.scss';
@@ -38,8 +38,27 @@ const IframePreviewCard = ( {
 }: IframePreviewCardProps ) => {
 	const translate = useTranslate();
 	const radioId = useId();
+	const wrapperRef = useRef< HTMLSpanElement | null >( null );
 	const iframeRef = useRef< HTMLIFrameElement | null >( null );
 	const [ isLoaded, setIsLoaded ] = useState( false );
+
+	// Scale the iframe to fit the wrapper. The iframe renders at a fixed 1200px
+	// desktop viewport so it loads desktop styles; we then scale via a CSS
+	// variable updated from a ResizeObserver. Doing the math in JS avoids the
+	// CSS Values 4 length-over-length pitfalls (Firefox parser quirks,
+	// postcss-calc build errors) we hit with a pure-CSS implementation.
+	useEffect( () => {
+		const wrapper = wrapperRef.current;
+		if ( ! wrapper ) {
+			return;
+		}
+		const observer = new ResizeObserver( ( entries ) => {
+			const width = entries[ 0 ].contentRect.width;
+			wrapper.style.setProperty( '--iframe-scale', String( width / 1200 ) );
+		} );
+		observer.observe( wrapper );
+		return () => observer.disconnect();
+	}, [] );
 
 	const handleEnterPreview = ( event: React.MouseEvent | React.KeyboardEvent ) => {
 		// Don't bubble to the wrapping <label> — pressing Enter / Space on the
@@ -58,7 +77,7 @@ const IframePreviewCard = ( {
 				className
 			) }
 		>
-			<span className="iframe-preview-card__frame-wrapper">
+			<span ref={ wrapperRef } className="iframe-preview-card__frame-wrapper">
 				{ ! isLoaded && (
 					<span className="iframe-preview-card__loading" aria-hidden="true">
 						<Spinner size={ 50 } />


### PR DESCRIPTION
This is part of fixing phcsdm-1qF-p2.

## Proposed Changes

As a followup to https://github.com/Automattic/wp-calypso/pull/110467, I noticed a couple things:
- At mobile screen widths, the modal dialog was automatically scrolled to the bottom and wouldn't let you scroll up.  This was a regression observed after deploying to production (in previous testing it worked OK).  It's unclear what caused it exactly, but Claude says the new solution in this pull request is much more robust.
- In Firefox, the scaling of the theme preview shown inside the iframe wasn't working correctly (instead of being scaled down, the preview was rendering at full width and therefore getting clipped).

This pull request should fix both issues.

## Testing Instructions

Open up the theme activation modal dialog (currently enabled for the Russell theme) at mobile screen widths and in Firefox and make sure it looks good.