### PR TITLE
Switch email forwards mailbox input suffix to flex layout

### DIFF
--- a/client/my-sites/email/email-forwards-add/add-new-form/styles.scss
+++ b/client/my-sites/email/email-forwards-add/add-new-form/styles.scss
@@ -10,7 +10,9 @@
 }
 
 .email-forwarding__mailbox-input-wrapper {
-	position: relative;
+	display: flex;
+	align-items: flex-end;
+	gap: 8px;
 
 	// These margins mess our suffix.
 	div.components-base-control__field {
@@ -19,28 +21,17 @@
 
 	& div.components-base-control.email-forwarding__mailbox-input {
 		margin-right: 0 !important;
+		width: 50%;
+		flex: 0 0 50%;
 	}
-
-	& input {
-		// Make sure the suffix doesn't cross the input border.
-		background: transparent;
-		z-index: 2;
-		position: relative;
-	}
-
 
 	.email-forwarding__mailbox-suffix {
 		margin: 0;
-		position: absolute;
-		right: 1px;
-		bottom: 1px;
-		padding: 5px 10px;
-		background: var(--studio-gray-0);
-		border-top: 1px solid var(--studio-gray-0);
-		border-left: 1px solid var(--studio-gray-10);
+		padding: 5px 0;
 		color: var(--studio-gray-50);
 		font-size: $font-body-small;
-		z-index: 1;
+		white-space: nowrap;
+		line-height: 1.5;
 
 		&.animate {
 			animation: blink 3s forwards;


### PR DESCRIPTION
## Summary

The email forwards add-new form previously positioned the domain suffix absolutely over the mailbox input, relying on transparent input backgrounds and z-index stacking to avoid overlap. This reworks the wrapper into a flexbox row so the input and suffix sit side by side, removing the absolute positioning, faux borders, and background hacks.

## Changes

- Make `.email-forwarding__mailbox-input-wrapper` a flex container with `align-items: flex-end` and an 8px gap instead of `position: relative`.
- Constrain the mailbox input to 50% width via `width: 50%` and `flex: 0 0 50%`.
- Drop the input's transparent background, relative positioning, and z-index overrides now that overlap is no longer possible.
- Replace the suffix's absolute positioning, gray background, and faux borders with simple padding, `white-space: nowrap`, and `line-height: 1.5`.

## Screenshots

### Before

![Before](https://github.com/Automattic/wp-calypso/raw/bow-screenshots/email-forwarding/1779539231354-0-before.jpg)

### After

![After] 
<img width="1888" height="889" alt="image" src="https://github.com/user-attachments/assets/eb552d80-c931-4c07-9fec-a666cbd855ea" />


## How to test

1. Open the email management section for a site with a custom domain and start adding a new email forward.
2. Confirm the mailbox input and the `@domain` suffix render on a single row, with the suffix aligned to the input's baseline and no overlap.
3. Type a long mailbox name and verify the suffix stays on one line and does not wrap or cross the input border.
4. Resize the viewport down to a narrow width and confirm the input/suffix row remains readable and aligned.
5. Verify in dark mode that the suffix text color and spacing still look correct without the previous background/border.

## Checklist

- [ ] Visual changes match the expected design
- [ ] No console errors introduced
- [ ] Tested with different user roles (if applicable)

---
Created as a draft by Build on WP.com.

_Created with Build on WP.com — the author will mark this ready for review when they choose to._

---

## ⚠️ SecEx pre-PR review couldn't run

BoW's mandatory pre-PR SecEx review (Anthropic claude-sonnet-4 via the wpcom `AI_Coder_Diff_Reviewer`) failed for this PR:

```
calypso: review: review_diff threw: Typed property AI_Coder_Diff_Reviewer::$logger must not be accessed before initialization
```

The PR was created anyway so the change isn't blocked. This is typically a sandbox-side issue (PHP class bug, library missing, network blip) that BoW can't fix client-side. **Please review this diff manually** before approving — the usual SecEx automated pass did not happen.
