### PR TITLE
Refine email forwarding add form layout and inputs

### DIFF
--- a/client/my-sites/email/email-forwards-add/add-new-form/destination-input.tsx
+++ b/client/my-sites/email/email-forwards-add/add-new-form/destination-input.tsx
@@ -34,11 +34,12 @@ export function DestinationsInput( props: DestinationsInputProps ) {
 	}
 
 	return (
-		<>
+		<div className="email-forwarding__forward-to">
 			<FormTokenField
 				disabled={ disabled }
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom
+				help=""
 				label={ translate( 'Forward to' ) }
 				onChange={ handleChange }
 				value={ values.slice( 0, limit ) }
@@ -59,10 +60,12 @@ export function DestinationsInput( props: DestinationsInputProps ) {
 					}
 					return error;
 				} }
-				placeholder={ translate(
-					'These are the target email addresses where your emails will be forwarded.'
-				) }
+				placeholder={ translate( 'your.email@example.com' ) }
 			/>
+			<p className="email-forwarding__forward-to-description">
+				{ translate( 'These are the target email addresses where your emails will be forwarded.' ) }{ ' ' }
+				{ translate( 'Separate with commas or the Enter key.' ) }
+			</p>
 			{ values.map( ( value ) => (
 				<input key={ value } type="hidden" name="destinations" value={ value } />
 			) ) }
@@ -71,6 +74,6 @@ export function DestinationsInput( props: DestinationsInputProps ) {
 					{ error.message }
 				</Notice>
 			) }
-		</>
+		</div>
 	);
 }

--- a/client/my-sites/email/email-forwards-add/add-new-form/source-input.tsx
+++ b/client/my-sites/email/email-forwards-add/add-new-form/source-input.tsx
@@ -1,4 +1,4 @@
-import { TextControl } from '@wordpress/components';
+import { __experimentalInputControl as InputControl } from '@wordpress/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
@@ -6,32 +6,38 @@ import type { SourceInputProps } from './types';
 import './styles.scss';
 
 export function SourceInput( props: SourceInputProps ) {
-	const { onChange, suffix, ...rest } = props;
+	const { onChange, suffix, value, disabled } = props;
 	const translate = useTranslate();
 	const [ highlightSuffix, setHighlightSuffix ] = React.useState( 0 );
 
 	return (
 		<div className="email-forwarding__mailbox-input-wrapper">
-			<TextControl
+			<InputControl
+				__next40pxDefaultSize
 				label={ translate( 'Forward from' ) }
 				className="email-forwarding__mailbox-input"
 				name="mailbox"
 				maxLength={ 64 }
-				onChange={ ( value ) => onChange( value.replace( /@.*/gi, '' ) ) }
+				value={ value }
+				disabled={ disabled }
+				onChange={ ( next ) => onChange( ( next ?? '' ).replace( /@.*/gi, '' ) ) }
 				onKeyUp={ ( event ) => {
 					if ( event.key === '@' ) {
 						setHighlightSuffix( ( s ) => s + 1 );
 					}
 				} }
-				{ ...rest }
+				suffix={
+					/* Blink the suffix when the user enters @ */
+					<span
+						key={ highlightSuffix }
+						className={ clsx( 'email-forwarding__mailbox-suffix', {
+							animate: highlightSuffix,
+						} ) }
+					>
+						{ suffix }
+					</span>
+				}
 			/>
-			{ /* Blink the suffix when the user enters @ */ }
-			<p
-				key={ highlightSuffix }
-				className={ clsx( 'email-forwarding__mailbox-suffix', { animate: highlightSuffix } ) }
-			>
-				{ suffix }
-			</p>
 		</div>
 	);
 }

--- a/client/my-sites/email/email-forwards-add/add-new-form/styles.scss
+++ b/client/my-sites/email/email-forwards-add/add-new-form/styles.scss
@@ -7,40 +7,39 @@
 	div.components-base-control__field {
 		margin-bottom: 0;
 	}
+
+	.email-forwarding__mailbox-input-wrapper,
+	.email-forwarding__forward-to {
+		max-inline-size: 500px;
+	}
+}
+
+.email-forwarding__forward-to {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+
+	.email-forwarding__forward-to-description {
+		margin: 0;
+		font-size: $font-body-extra-small;
+		color: var(--studio-gray-50);
+	}
 }
 
 .email-forwarding__mailbox-input-wrapper {
-	position: relative;
-
-	// These margins mess our suffix.
-	div.components-base-control__field {
-		margin-bottom: 0;
-	}
-
-	& div.components-base-control.email-forwarding__mailbox-input {
-		margin-right: 0 !important;
-	}
-
-	& input {
-		// Make sure the suffix doesn't cross the input border.
-		background: transparent;
-		z-index: 2;
-		position: relative;
-	}
-
+	max-inline-size: 500px;
 
 	.email-forwarding__mailbox-suffix {
-		margin: 0;
-		position: absolute;
-		right: 1px;
-		bottom: 1px;
-		padding: 5px 10px;
+		display: flex;
+		align-items: center;
+		align-self: stretch;
+		flex: 0 0 auto;
+		white-space: nowrap;
+		padding-inline: 12px;
 		background: var(--studio-gray-0);
-		border-top: 1px solid var(--studio-gray-0);
-		border-left: 1px solid var(--studio-gray-10);
+		border-inline-start: 1px solid var(--studio-gray-10);
 		color: var(--studio-gray-50);
 		font-size: $font-body-small;
-		z-index: 1;
 
 		&.animate {
 			animation: blink 3s forwards;
@@ -69,8 +68,8 @@
 
 
 /* If the user didn't add any tokens, show a shimmer effect, because they may not know to press Enter. */
-.components-form-token-field:not(:has(.components-form-token-field__token)):focus-within {
-	.components-form-token-field__help {
+.email-forwarding__forward-to:has(.components-form-token-field:not(:has(.components-form-token-field__token)):focus-within) {
+	.email-forwarding__forward-to-description {
 		animation: shimmer 15s infinite;
 		background-size: 110%;
 		color: transparent;


### PR DESCRIPTION
## Summary

We have a somewhat hidden feature that allows users to create email addresses on their domain that forward to any external email address.
The current form has a few issues:
- Design inconsistencies: input fields are excessively wide and have inconsistent heights
- Unclear input expectations: it's not obvious what users should enter in each field

Specifically, the first field expects only the local part of the email (without the @domain suffix), while the second field expects a complete email address — but nothing in the UI communicates this.
This PR is an attempt to address these issues:

Reworks the email forwarding add form's two inputs for a cleaner layout. The "Forward from" field switches from TextControl to InputControl so the domain suffix renders as a native inline suffix instead of an absolutely positioned overlay, and the "Forward to" field gains a concise placeholder with the longer guidance moved to a description line below.

## Changes

- Replace `TextControl` with `__experimentalInputControl` in `source-input.tsx`, rendering the domain suffix via the control's `suffix` prop instead of an absolutely positioned `<p>`
- Pass explicit `value`/`disabled` props and `__next40pxDefaultSize` to the source input; keep the @ keypress blink animation on the suffix span
- Wrap the `FormTokenField` in `destination-input.tsx` in a `.email-forwarding__forward-to` container; shorten the placeholder to `your.email@example.com` and move the full guidance into a description paragraph
- Rewrite `styles.scss`: flex-column layout for the forward-to block, inline flexed suffix with logical (`inline-start`/`inline-size`) properties, and `max-inline-size: 500px` on both inputs
- Update the empty-field shimmer selector to target the new `.email-forwarding__forward-to-description` element

## Screenshots

### Before

![Before](https://github.com/Automattic/wp-calypso/raw/bow-screenshots/emails--forwarding/1779640279753-0-before.jpg)

### After

<img width="1844" height="889" alt="image" src="https://github.com/user-attachments/assets/0f2857fb-1c86-4047-8de8-2d7f592ff38a" />


## How to test

1. Navigate to a site's Emails section and open the email forwarding add form (`/email/<domain>/forwarding/add/<site>`)
2. Confirm the "Forward from" field shows the domain suffix inline within the input border, flush to the right edge with no overlap
3. Type `@` in the "Forward from" field and verify the suffix blinks
4. Confirm the "Forward to" field shows the `your.email@example.com` placeholder with the forwarding guidance and "Separate with commas or the Enter key." text below it
5. Focus the empty "Forward to" field and verify the description line shimmers; add a token and confirm the shimmer stops
6. Verify both inputs are capped at 500px wide and the layout holds in dark mode and at narrow viewports

## Checklist

- [ ] Visual changes match the expected design
- [ ] No console errors introduced
- [ ] Tested with different user roles (if applicable)

---
Created as a draft by Build on WP.com.

_Created with Build on WP.com — the author will mark this ready for review when they choose to._

---

## ⚠️ SecEx pre-PR review couldn't run

BoW's mandatory pre-PR SecEx review (Anthropic claude-sonnet-4 via the wpcom `AI_Coder_Diff_Reviewer`) failed for this PR:

```
calypso: review: review_diff threw: Typed property AI_Coder_Diff_Reviewer::$logger must not be accessed before initialization
```

The PR was created anyway so the change isn't blocked. This is typically a sandbox-side issue (PHP class bug, library missing, network blip) that BoW can't fix client-side. **Please review this diff manually** before approving — the usual SecEx automated pass did not happen.
