### PR TITLE
Dashboard: open notification details side-by-side

### DIFF
--- a/apps/notifications/src/app/hooks.ts
+++ b/apps/notifications/src/app/hooks.ts
@@ -1,0 +1,42 @@
+import { useNavigator } from '@wordpress/components';
+import { useRef } from 'react';
+import { getFilters } from '../panel/templates/filters';
+
+export type FilterName = keyof ReturnType< typeof getFilters >;
+
+/**
+ * Notifications routing state, parsed from the Navigator path.
+ *
+ * Parsed from the path (rather than `useNavigator().params`) to accommodate
+ * components that live outside any `Navigator.Screen`.
+ *
+ * - `filterName`: the active filter tab.
+ * - `selectedNoteId`: the currently selected note, or `undefined` when no note
+ *   detail pane is open.
+ * - `activeNoteId`: like `selectedNoteId`, but sticks to the last note while the
+ *   note detail pane is being animated out (even when the path no longer matches).
+ * - `goTo`: navigate to a new path (re-exposed from `useNavigator()`).
+ */
+export function useNotificationsRoute() {
+	const { location, goTo } = useNavigator();
+	const [ , pathFilter, section, pathNoteId ] = location.path?.split( '/' ) ?? [];
+
+	const filterName: FilterName =
+		pathFilter && pathFilter in getFilters() ? ( pathFilter as FilterName ) : 'all';
+	const selectedNoteId = section === 'notes' ? pathNoteId : undefined;
+	const activeNoteId = useLastDefined( selectedNoteId );
+
+	return { filterName, selectedNoteId, activeNoteId, goTo };
+}
+
+/**
+ * Returns `value`, or the last non-nullish value seen if `value` is currently
+ * nullish.
+ */
+function useLastDefined< T >( value: T | undefined ): T | undefined {
+	const ref = useRef< T | undefined >( value );
+	if ( value != null ) {
+		ref.current = value;
+	}
+	return ref.current;
+}

--- a/apps/notifications/src/app/index.tsx
+++ b/apps/notifications/src/app/index.tsx
@@ -149,19 +149,21 @@ const NotificationApp = ( {
 	return (
 		<Provider store={ store }>
 			<AppProvider client={ client } locale={ locale }>
-				<Navigator initialPath="/all" style={ { maxHeight: 'inherit', height: '100%' } }>
-					<Navigator.Screen
-						path="/:filterName"
-						style={ { display: 'flex', flexDirection: 'column', height: '100%' } }
-					>
-						<NotePanel isDismissible={ isDismissible } />
-					</Navigator.Screen>
-					<Navigator.Screen
-						path="/:filterName/notes/:noteId"
-						style={ { display: 'flex', flexDirection: 'column', height: '100%' } }
-					>
+				<Navigator
+					initialPath="/all"
+					className="wpnc-app__navigator"
+					style={ {
+						display: 'flex',
+						maxHeight: 'inherit',
+						height: '100%',
+					} }
+				>
+					<Navigator.Screen path="/:filterName/notes/:noteId" className="wpnc-app__detail-pane">
 						<Note isDismissible={ isDismissible } />
 					</Navigator.Screen>
+					<div className="wpnc-app__list-pane">
+						<NotePanel isDismissible={ isDismissible } />
+					</div>
 				</Navigator>
 			</AppProvider>
 		</Provider>

--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -3,7 +3,6 @@ import {
 	__experimentalText as Text,
 	ExternalLink,
 	Spinner,
-	useNavigator,
 } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { useState, useEffect, useCallback, useRef } from 'react';
@@ -13,6 +12,7 @@ import getHiddenNoteIds from '../../panel/state/selectors/get-hidden-note-ids';
 import getIsLoading from '../../panel/state/selectors/get-is-loading';
 import { getFilters } from '../../panel/templates/filters';
 import { useAppContext } from '../context';
+import { useNotificationsRoute } from '../hooks';
 import { getFields } from './dataviews';
 import {
 	useNoteListFocusToLastSelectedNote,
@@ -34,8 +34,8 @@ const DEFAULT_LAYOUTS = {
 // so the window never advances past the notes already fetched.
 const NOTES_PER_PAGE = 20;
 
-const NoteList = ( { filterName }: { filterName: keyof ReturnType< typeof getFilters > } ) => {
-	const { goTo } = useNavigator();
+const NoteList = () => {
+	const { filterName, selectedNoteId, goTo } = useNotificationsRoute();
 	const filter = getFilters()[ filterName ];
 	const allNotes = useSelector( ( state ) => getAllNotes( state ) || [] ) as Note[];
 	const notes = allNotes.filter( ( note ) => filter.filter( note ) );
@@ -61,6 +61,13 @@ const NoteList = ( { filterName }: { filterName: keyof ReturnType< typeof getFil
 
 	const onChangeSelection = ( selection: string[] ) => {
 		const noteId = selection[ 0 ];
+
+		// Unselecting notification.
+		if ( selectedNoteId && noteId === selectedNoteId ) {
+			goTo( `/${ filterName }`, { isBack: true } );
+			return;
+		}
+
 		goTo( `/${ filterName }/notes/${ noteId }` );
 	};
 
@@ -151,6 +158,7 @@ const NoteList = ( { filterName }: { filterName: keyof ReturnType< typeof getFil
 						</VStack>
 					}
 					getItemId={ ( item ) => item.id.toString() }
+					selection={ selectedNoteId ? [ selectedNoteId ] : [] }
 					onChangeView={ handleChangeView }
 					onChangeSelection={ onChangeSelection }
 				>

--- a/apps/notifications/src/app/note-list/style.scss
+++ b/apps/notifications/src/app/note-list/style.scss
@@ -19,6 +19,7 @@
 		}
 
 		.wpnc__excerpt {
+			font-weight: normal;
 			color: var(--color-text-subtle);
 			padding-top: 2px;
 

--- a/apps/notifications/src/app/note-panel/index.tsx
+++ b/apps/notifications/src/app/note-panel/index.tsx
@@ -4,7 +4,6 @@ import {
 	__experimentalHeading as Heading,
 	CardHeader,
 	Icon,
-	useNavigator,
 	privateApis,
 } from '@wordpress/components';
 import '@wordpress/components/build-style/style.css';
@@ -14,11 +13,10 @@ import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/pri
 import { useEffect, useCallback, useRef } from 'react';
 import { modifierKeyIsActive } from '../../panel/helpers/input';
 import { getFilters } from '../../panel/templates/filters';
+import { useNotificationsRoute } from '../hooks';
 import NoteList from '../note-list';
 import CloseButton from '../templates/close-button';
 import NotePanelActions from './actions';
-
-type FilterName = keyof ReturnType< typeof getFilters >;
 
 const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
 	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
@@ -35,8 +33,7 @@ export const getNotificationTabs = () =>
 
 const NotePanel = ( { isDismissible }: { isDismissible?: boolean } ) => {
 	const notificationTabs = getNotificationTabs();
-	const { params, goTo } = useNavigator();
-	const { filterName = 'all' } = params as { filterName?: string };
+	const { filterName, goTo } = useNotificationsRoute();
 	const tabRefs = useRef< Record< string, HTMLButtonElement > >( {} );
 
 	const handleSelect = useCallback(
@@ -127,7 +124,7 @@ const NotePanel = ( { isDismissible }: { isDismissible?: boolean } ) => {
 			   filter is applied outside the DataViews `view`, so DataViews'
 			   infinite-scroll row accumulation would otherwise carry stale
 			   notes from the previously selected tab. */ }
-			<NoteList key={ filterName } filterName={ filterName as FilterName } />
+			<NoteList key={ filterName } />
 		</>
 	);
 };

--- a/apps/notifications/src/app/note/hooks.ts
+++ b/apps/notifications/src/app/note/hooks.ts
@@ -1,10 +1,10 @@
-import { useNavigator } from '@wordpress/components';
 import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { modifierKeyIsActive } from '../../panel/helpers/input';
 import getIsLoading from '../../panel/state/selectors/get-is-loading';
 import getKeyboardShortcutsEnabled from '../../panel/state/selectors/get-keyboard-shortcuts-enabled';
 import { useAppContext } from '../context';
+import { useNotificationsRoute } from '../hooks';
 import type { Note } from '../types';
 
 export function useNoteNavigationViaKeyboardShortcuts( {
@@ -14,8 +14,7 @@ export function useNoteNavigationViaKeyboardShortcuts( {
 	visibleNotes: Note[];
 	note?: Note;
 } ) {
-	const { params, goTo } = useNavigator();
-	const { filterName } = params;
+	const { filterName, goTo } = useNotificationsRoute();
 
 	const areKeyboardShortcutsEnabled = useSelector( getKeyboardShortcutsEnabled );
 

--- a/apps/notifications/src/app/note/index.tsx
+++ b/apps/notifications/src/app/note/index.tsx
@@ -3,12 +3,11 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	__experimentalHeading as Heading,
+	Button,
 	CardHeader,
 	CardBody,
-	Navigator,
-	useNavigator,
 } from '@wordpress/components';
-import { isRTL } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useEffect } from 'react';
@@ -20,6 +19,7 @@ import getHiddenNoteIds from '../../panel/state/selectors/get-hidden-note-ids';
 import getIsNoteApproved from '../../panel/state/selectors/get-is-note-approved';
 import getIsNoteRead from '../../panel/state/selectors/get-is-note-read';
 import { getFilters } from '../../panel/templates/filters';
+import { useNotificationsRoute } from '../hooks';
 import ActionDropdown from '../templates/action-dropdown';
 import { NoteBody, ActionBlock } from '../templates/body';
 import CloseButton from '../templates/close-button';
@@ -72,15 +72,14 @@ const getClasses = ( {
 
 const Note = ( { isDismissible }: { isDismissible?: boolean } ) => {
 	const dispatch = useDispatch();
-	const { params, goBack } = useNavigator();
-	const { filterName, noteId } = params;
-
+	const { filterName, activeNoteId: noteId, goTo } = useNotificationsRoute();
+	const goBack = () => goTo( `/${ filterName }`, { isBack: true } );
 	const filter = getFilters()[ filterName as keyof ReturnType< typeof getFilters > ];
 	const notes = useSelector( ( state ) => ( getAllNotes( state ) || [] ) as NoteObject[] );
 	const note = notes.find( ( note ) => String( note.id ) === noteId );
 	const hiddenNoteIds = useSelector( ( state ) => getHiddenNoteIds( state ) );
 	const visibleNotes = notes.filter(
-		( note ) => filter.filter( note ) && hiddenNoteIds[ note.id ] !== true
+		( note ) => filter?.filter( note ) && hiddenNoteIds[ note.id ] !== true
 	);
 
 	const isApproved = useSelector( ( state ) => note && getIsNoteApproved( state, note ) );
@@ -111,7 +110,13 @@ const Note = ( { isDismissible }: { isDismissible?: boolean } ) => {
 			>
 				<HStack>
 					<HStack justify="flex-start">
-						<Navigator.BackButton size="small" icon={ isRTL() ? chevronRight : chevronLeft } />
+						<Button
+							className="wpnc-app__detail-back"
+							size="small"
+							icon={ isRTL() ? chevronRight : chevronLeft }
+							label={ __( 'Back' ) }
+							onClick={ goBack }
+						/>
 						<Heading level={ 3 } size={ 15 } weight={ 500 }>
 							{ note.title }
 						</Heading>

--- a/apps/notifications/src/app/note/style.scss
+++ b/apps/notifications/src/app/note/style.scss
@@ -1,5 +1,6 @@
 @import '@wordpress/base-styles/colors';
 @import '@wordpress/base-styles/variables';
+@import '@wordpress/base-styles/breakpoints';
 @import '@wordpress/base-styles/mixins';
 @import './reset.scss';
 
@@ -306,5 +307,101 @@
 	a {
 		font-weight: 600;
 		color: inherit;
+	}
+}
+
+/**
+ * List + detail panes
+ */
+$wpnc-pane-width: 448px;
+$wpnc-pane-border: 1px solid #c3c4c7;
+$wpnc-pane-radius: 4px;
+$wpnc-pane-shadow: 0 0 16px rgba(0, 0, 0, 0.12);
+
+.wpnc-app__list-pane {
+	box-sizing: border-box;
+	position: absolute;
+	inset: 0;
+	z-index: 1;
+	display: flex;
+	flex-direction: column;
+	overflow-y: auto;
+	scrollbar-gutter: stable;
+	background: #fff;
+}
+
+.wpnc-app__detail-pane {
+	box-sizing: border-box;
+	flex: 1;
+	min-width: 0;
+	height: 100%;
+	z-index: 2 !important;
+	display: flex;
+	flex-direction: column;
+	overflow-y: auto;
+	overflow-x: hidden;
+	background: #fff;
+}
+
+@media not (prefers-reduced-motion) {
+	.wpnc-app__detail-pane[data-animation-type="in"] {
+		animation: wpnc-app-detail-in 300ms cubic-bezier(0.33, 0, 0, 1) both !important;
+	}
+
+	.wpnc-app__detail-pane[data-animation-type="out"] {
+		animation: wpnc-app-detail-out 300ms cubic-bezier(0.33, 0, 0, 1) both !important;
+	}
+}
+
+@keyframes wpnc-app-detail-in {
+	from {
+		transform: translateX(100%);
+	}
+}
+
+@keyframes wpnc-app-detail-out {
+	to {
+		transform: translateX(100%);
+	}
+}
+
+@include break-xlarge {
+	.wpnc-app__list-pane {
+		inset-inline-start: auto;
+		width: $wpnc-pane-width;
+		z-index: 2;
+		border: $wpnc-pane-border !important;
+		border-radius: $wpnc-pane-radius;
+		box-shadow: $wpnc-pane-shadow;
+	}
+
+	.wpnc-app__detail-pane {
+		flex: 0 0 $wpnc-pane-width;
+		width: $wpnc-pane-width;
+		z-index: 1 !important;
+		border-start-start-radius: $wpnc-pane-radius;
+		border-end-start-radius: $wpnc-pane-radius;
+		// Top/bottom/left borders complete the combined-card outline; the list's
+		// left border is the divider, so the detail has no right border.
+		border-top: $wpnc-pane-border !important;
+		border-bottom: $wpnc-pane-border !important;
+		border-inline-start: $wpnc-pane-border !important;
+	}
+
+	// List + detail form one card: the wrapper carries the drop shadow, and the
+	// list squares off its left corners + drops its own shadow.
+	.wpnc-app__navigator:has(.wpnc-app__detail-pane) {
+		border-radius: $wpnc-pane-radius;
+		box-shadow: $wpnc-pane-shadow;
+	}
+
+	.wpnc-app__navigator:has(.wpnc-app__detail-pane) .wpnc-app__list-pane {
+		border-start-start-radius: 0;
+		border-end-start-radius: 0;
+		box-shadow: none;
+	}
+
+	.wpnc-app__detail-back {
+		display: none;
 	}
 }

--- a/client/dashboard/app/notifications/index.tsx
+++ b/client/dashboard/app/notifications/index.tsx
@@ -149,15 +149,7 @@ export default function Notifications( {
 				)
 			}
 			renderContent={ () => (
-				<div
-					style={ {
-						width: '100vw',
-						height: '100vh',
-						maxWidth: ! isMobileViewport ? '448px' : undefined,
-						maxHeight: 'inherit',
-						margin: '-8px',
-					} }
-				>
+				<div className="dashboard-notifications__content">
 					<Suspense fallback={ null }>
 						<AsyncNotificationApp
 							locale={ locale }

--- a/client/dashboard/app/notifications/style.scss
+++ b/client/dashboard/app/notifications/style.scss
@@ -1,4 +1,6 @@
 @use "calypso/assets/stylesheets/shared/mixins/dark-theme" as ui-mixins;
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 
 // The Dropdown component doesn't support to hide the header if the `expandOnMobile` is enabled.
 .dashboard-notifications.components-popover.is-expanded {
@@ -18,6 +20,39 @@
 		svg {
 			fill: var( --dashboard__text-color );
 		}
+	}
+}
+
+.dashboard-notifications__content {
+	width: 100vw;
+	height: 100vh;
+	max-height: inherit;
+	margin: -8px;
+}
+
+// Single-panel layout
+@include break-small {
+	.dashboard-notifications__content {
+		max-width: 448px;
+	}
+}
+
+// Side-by-side layout
+@include break-xlarge {
+	.dashboard-notifications__content {
+		max-width: 896px;
+	}
+
+	.dashboard-notifications.components-popover {
+		will-change: auto;
+	}
+
+	.dashboard-notifications.components-popover .components-popover__content {
+		background: transparent;
+		box-shadow: none;
+		border: none;
+		border-radius: 0;
+		overflow: visible;
 	}
 }
 

--- a/client/reader/components/header/notifications/index.tsx
+++ b/client/reader/components/header/notifications/index.tsx
@@ -92,15 +92,7 @@ export default function Notifications( { user, className }: { user: User; classN
 				/>
 			) }
 			renderContent={ () => (
-				<div
-					style={ {
-						width: '100vw',
-						height: '100vh',
-						maxWidth: ! isMobileViewport ? '448px' : undefined,
-						maxHeight: 'inherit',
-						margin: '-8px',
-					} }
-				>
+				<div className="dashboard-notifications__content">
 					<Suspense fallback={ null }>
 						<AsyncNotificationApp
 							locale={ user.language }

--- a/client/reader/components/header/notifications/style.scss
+++ b/client/reader/components/header/notifications/style.scss
@@ -1,4 +1,6 @@
 @use "calypso/assets/stylesheets/shared/mixins/dark-theme" as ui-mixins;
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 
 // The Dropdown component doesn't support to hide the header if the `expandOnMobile` is enabled.
 .dashboard-notifications.components-popover.is-expanded {
@@ -26,5 +28,38 @@
 		circle {
 			fill: var(--wp-admin-theme-color);
 		}
+	}
+}
+
+.dashboard-notifications__content {
+	width: 100vw;
+	height: 100vh;
+	max-height: inherit;
+	margin: -8px;
+}
+
+// Single-panel layout
+@include break-small {
+	.dashboard-notifications__content {
+		max-width: 448px;
+	}
+}
+
+// Side-by-side layout
+@include break-xlarge {
+	.dashboard-notifications__content {
+		max-width: 896px;
+	}
+
+	.dashboard-notifications.components-popover {
+		will-change: auto;
+	}
+
+	.dashboard-notifications.components-popover .components-popover__content {
+		background: transparent;
+		box-shadow: none;
+		border: none;
+		border-radius: 0;
+		overflow: visible;
 	}
 }


### PR DESCRIPTION
Fixes DOTMSD-1249

## Proposed Changes

When clicking notification detail, slide it out to the left side-by-side instead of replacing the list view.

## Why are these changes being made?

To follow v1's behavior, which is easier UX when a user wants to check their comments.

### Before


https://github.com/user-attachments/assets/cbdee3f9-0561-4025-b5ab-bef5a27b03de


### After

Desktop

https://github.com/user-attachments/assets/d8ea31cd-f42e-4ca9-a869-1952c2d31357

Mobile

https://github.com/user-attachments/assets/02604027-2863-4249-89ba-075135d095bb

## Implementation Details

- We previously used two `Navigator.Screen`s (list and details). Since a `Navigator` only renders one matched screen at a time, side-by-side isn't possible with that structure. So:
   - `NotePanel` (the list) now lives outside any `Navigator.Screen`, directly under `<Navigator>`, so it stays mounted.
   - Only `Note` (the detail) remains a `Navigator.Screen` (/:filterName/notes/:noteId).
   - The list is anchored to the popover's right edge; the detail renders to its left.
- Because `NotePanel`/`NoteList` are no longer inside a Screen, they can't read route params from `useNavigator().params`. We added `useNotificationsRoute()`, which parses the `path` and exposes `filterName`, ` selectedNoteId`, and `activeNoteId` instead.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?