### PR TITLE
Staging site sync modal: point support link to sync-staging-site guide

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -143,6 +143,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/how-to-create-a-staging-site/',
 		post_id: 239448,
 	},
+	'hosting-staging-site-sync': {
+		link: 'https://wordpress.com/support/how-to-create-a-staging-site/sync-staging-site/',
+		post_id: 386882,
+	},
 	'hosting-edge-cache': {
 		link: 'https://wordpress.com/support/clear-your-sites-cache/',
 		post_id: 164969,

--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -592,7 +592,7 @@ function StagingSiteSyncModalInner( {
 									a: (
 										<InlineSupportLink
 											onClick={ handleClose }
-											supportContext="hosting-staging-site"
+											supportContext="hosting-staging-site-sync"
 										/>
 									),
 								} ) }

--- a/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
+++ b/client/sites/staging-site/components/staging-site-sync-modal/index.tsx
@@ -614,7 +614,7 @@ function SyncModal( {
 									a: (
 										<InlineSupportLink
 											onClick={ handleClose }
-											supportContext="hosting-staging-site"
+											supportContext="hosting-staging-site-sync"
 										/>
 									),
 								} ) }


### PR DESCRIPTION
Part of DOTCOM-17131

## Proposed Changes

* In the staging-site sync modal (both the legacy `client/sites/staging-site/components/staging-site-sync-modal` and the Dashboard's `client/dashboard/sites/staging-site-sync-modal`), the "Read more about environment pull/push" footer link now opens the `how-to-create-a-staging-site/sync-staging-site/` support article instead of the generic `how-to-create-a-staging-site/` article.
* Added a new `hosting-staging-site-sync` entry in `client/components/inline-support-link/context-links.js` (post_id `386882`). The existing `hosting-staging-site` context is unchanged and still used by the hosting features card and the developer features list — both of which describe *creating* a staging site, where the original target is correct.

## Why are these changes being made?

* The sync modal's "Read more" link was pointing at the introductory "Create a staging site" article, which doesn't cover the push/pull behavior the modal is asking the user to confirm. The sync-specific guide is a better landing page from this entry point.

## Testing Instructions

* Open a staging site sync modal:
  1. Go to a site with a staging site (legacy Sites → Hosting, or the new Dashboard's site view).
  2. Click the **Sync** button.
  3. Choose **Pull** or **Push** in the modal.
* In the modal footer, click the "environment pull" / "environment push" link in "Read more about environment pull/push.".
* Verify it opens the **Sync between staging and production sites** support article (URL ends in `/how-to-create-a-staging-site/sync-staging-site/`), not the **Create a staging site** article.
* Repeat in the new Dashboard variant of the modal.
* Confirm the "Learn more" link on the hosting features card and in the developer features list still opens the **Create a staging site** article (unchanged).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)