### PR TITLE
Marketplace: Fix infinite render loop on plugin install page

### DIFF
--- a/client/my-sites/marketplace/components/progressbar/index.tsx
+++ b/client/my-sites/marketplace/components/progressbar/index.tsx
@@ -20,7 +20,6 @@ export default function MarketplaceProgressBar( {
 	additionalStepsTimeout?: number;
 } ) {
 	const [ stepValue, setStepValue ] = useState( steps[ currentStep ] );
-	const [ additionalStepsTimeoutId, setAdditionalStepsTimeoutId ] = useState< NodeJS.Timeout >();
 	const [ currentAdditionalSteps, setCurrentAdditionalSteps ] = useState< TranslateResult[] >( [] );
 	const [ simulatedProgressPercentage, setSimulatedProgressPercentage ] = useState( 1 );
 	useEffect( () => {
@@ -39,7 +38,7 @@ export default function MarketplaceProgressBar( {
 
 	useEffect( () => {
 		setStepValue( steps[ currentStep ] );
-		setAdditionalStepsTimeoutId( undefined );
+		setCurrentAdditionalSteps( [] );
 	}, [ steps, currentStep ] );
 
 	/**
@@ -52,37 +51,24 @@ export default function MarketplaceProgressBar( {
 			newAdditionalSteps.sort( () => 0.5 - Math.random() );
 			setCurrentAdditionalSteps( newAdditionalSteps );
 		}
-	} );
+	}, [ currentAdditionalSteps, additionalSteps ] );
 
 	// Show additional messages in order when available
 	useEffect( () => {
-		function updateStepValueAfterTimeout() {
-			if ( currentAdditionalSteps?.length ) {
-				const timeoutId = setTimeout( () => {
-					const newValue = currentAdditionalSteps.shift();
-
-					if ( newValue && newValue !== stepValue ) {
-						setStepValue( newValue );
-					}
-
-					updateStepValueAfterTimeout();
-				}, additionalStepsTimeout );
-
-				if ( additionalStepsTimeoutId ) {
-					clearTimeout( additionalStepsTimeoutId );
-				}
-				setAdditionalStepsTimeoutId( timeoutId );
-			}
+		if ( ! currentAdditionalSteps?.length ) {
+			return;
 		}
-
-		updateStepValueAfterTimeout();
-
-		return () => {
-			if ( additionalStepsTimeoutId ) {
-				clearTimeout( additionalStepsTimeoutId );
-			}
-		};
-	}, [ additionalSteps, currentStep ] );
+		const timeoutId = setTimeout( () => {
+			setCurrentAdditionalSteps( ( prev ) => {
+				const [ next, ...rest ] = prev;
+				if ( next ) {
+					setStepValue( ( current ) => ( next !== current ? next : current ) );
+				}
+				return rest;
+			} );
+		}, additionalStepsTimeout );
+		return () => clearTimeout( timeoutId );
+	}, [ currentAdditionalSteps, additionalStepsTimeout ] );
 
 	const isInStepContainerV2Context = useInitialIsInStepContainerV2FlowContext();
 

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -76,7 +76,11 @@ const MarketplaceProductInstall = ( {
 }: MarketplacePluginInstallProps ) => {
 	const isPluginUploadFlow = ! pluginSlug && ! themeSlug;
 	const [ currentStep, setCurrentStep ] = useState( 0 );
-	const [ initializeInstallFlow, setInitializeInstallFlow ] = useState( false );
+	// Ref instead of state so the install effect can be guarded synchronously —
+	// the dispatch inside the effect notifies redux subscribers (via
+	// useSyncExternalStore) before a setState would commit, which would
+	// otherwise re-enter the effect and dispatch repeatedly.
+	const installFlowInitiatedRef = useRef( false );
 	const [ atomicFlow, setAtomicFlow ] = useState( false );
 	const [ nonInstallablePlanError, setNonInstallablePlanError ] = useState( false );
 	const [ noDirectAccessError, setNoDirectAccessError ] = useState( false );
@@ -167,14 +171,16 @@ const MarketplaceProductInstall = ( {
 	// Check if the user plan is enough for installation or it is a self-hosted jetpack site
 	// if not, check again in 2s and show an error message
 	useEffect( () => {
-		if ( ! supportsAtomicUpgrade.current && ! isJetpackSelfHosted ) {
-			waitFor( 2 ).then( () => {
-				if ( ! supportsAtomicUpgrade.current && ! isJetpackSelfHosted ) {
-					setNonInstallablePlanError( true );
-				}
-			} );
+		if ( hasAtomicFeature || isJetpackSelfHosted || nonInstallablePlanError ) {
+			return;
 		}
-	} );
+		const id = setTimeout( () => {
+			if ( ! supportsAtomicUpgrade.current && ! isJetpackSelfHosted ) {
+				setNonInstallablePlanError( true );
+			}
+		}, 2000 );
+		return () => clearTimeout( id );
+	}, [ hasAtomicFeature, isJetpackSelfHosted, nonInstallablePlanError ] );
 
 	const { primaryDomain } = useSelector( getPurchaseFlowState );
 
@@ -208,11 +214,11 @@ const MarketplaceProductInstall = ( {
 		if (
 			( marketplaceInstallationInProgress || directInstallationAllowed ) &&
 			! isPluginUploadFlow &&
-			! initializeInstallFlow &&
+			! installFlowInitiatedRef.current &&
 			( wporgPlugin || wpOrgTheme )
 		) {
+			installFlowInitiatedRef.current = true;
 			const triggerInstallFlow = () => {
-				setInitializeInstallFlow( true );
 				waitFor( 1 ).then( () => setCurrentStep( 1 ) );
 			};
 
@@ -242,7 +248,6 @@ const MarketplaceProductInstall = ( {
 		marketplaceInstallationInProgress,
 		directInstallationAllowed,
 		isPluginUploadFlow,
-		initializeInstallFlow,
 		siteId,
 		wporgPlugin,
 		wpOrgTheme,


### PR DESCRIPTION
## Summary

Visiting `/marketplace/plugin/:slug/install/:site` crashed with React error #185 (Maximum update depth exceeded). Three compounding bugs caused the loop:

1. `MarketplaceProductInstall`: the plan-check effect had no dependency array and re-armed a 2s timer every render.
2. `MarketplaceProductInstall`: the install-flow effect dispatched a redux action and then queued a `setState` guard. The dispatch synchronously notified subscribers (via `useSyncExternalStore`) before the guard committed, so the effect re-entered and dispatched again. Replaced the `useState` guard with a `useRef` that is set synchronously before `dispatch`.
3. `MarketplaceProgressBar`: the additional-steps refill effect had no dependency array, and the advance-step effect mutated the `currentAdditionalSteps` state in place via `.shift()`. Rewrote both with proper deps and a functional `setCurrentAdditionalSteps` update.

## Test plan

- [ ] Visit `/marketplace/plugin/give/install/<site>` on a simple WordPress.com site eligible for atomic transfer.
- [ ] Confirm no \`Maximum update depth exceeded\` error in the console.
- [ ] Confirm the progress bar advances through the steps and the page eventually redirects to wp-admin plugins.
- [ ] Repeat on an already-atomic site (direct \`installPlugin\` dispatch path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)