### PR TITLE
Dashboard: disable radical omnibar in dev envs

### DIFF
--- a/client/dashboard/app/omnibar/style.scss
+++ b/client/dashboard/app/omnibar/style.scss
@@ -4,9 +4,3 @@
 	inset-inline: 0;
 	z-index: 99999;
 }
-
-body:has( #wpcom-omnibar ) #wpcom {
-	padding-block-start: var(--omnibar-height);
-	height: auto;
-	min-height: calc( 100vh - var(--omnibar-height) );
-}

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -25,7 +25,7 @@
 		"cookie-banner": false,
 		"dark-mode": true,
 		"dashboard/omnibar": true,
-		"dashboard/omnibar-radical": true,
+		"dashboard/omnibar-radical": false,
 		"dashboard/plans": true,
 		"dashboard/v2": false,
 		"dashboard/wp-beta-program": true,

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -26,7 +26,6 @@
 		"cookie-banner": false,
 		"dark-mode": true,
 		"dashboard/omnibar": true,
-		"dashboard/omnibar-radical": true,
 		"dashboard/plans": true,
 		"dashboard/v2": false,
 		"dashboard/wp-beta-program": true,

--- a/config/development.json
+++ b/config/development.json
@@ -69,7 +69,7 @@
 		"current-site/notice": true,
 		"dark-mode": false,
 		"dashboard/omnibar": true,
-		"dashboard/omnibar-radical": true,
+		"dashboard/omnibar-radical": false,
 		"dashboard/opt-in-banners": false,
 		"dashboard/plans": true,
 		"dashboard/v2": true,

--- a/test/e2e/specs/dashboard/dashboard__rum-tracking.spec.ts
+++ b/test/e2e/specs/dashboard/dashboard__rum-tracking.spec.ts
@@ -133,7 +133,7 @@ test.describe( 'Dashboard: RUM Performance Tracking', { tag: [ tags.DASHBOARD_PR
 				if ( viewportName === 'mobile' ) {
 					await page.getByTitle( 'Menu', { exact: true } ).click();
 				}
-				await page.getByRole( 'link', { name: 'Domains' } ).click();
+				await page.locator( '#wpcom' ).getByRole( 'link', { name: 'Domains' } ).click();
 			} else if ( viewportName === 'mobile' ) {
 				await page.getByRole( 'button', { name: 'Menu' } ).click();
 				await page

--- a/test/e2e/specs/dashboard/dashboard__rum-tracking.spec.ts
+++ b/test/e2e/specs/dashboard/dashboard__rum-tracking.spec.ts
@@ -131,7 +131,7 @@ test.describe( 'Dashboard: RUM Performance Tracking', { tag: [ tags.DASHBOARD_PR
 				// With omnibar: click Domains in the responsive sidebar.
 				// On mobile, open the sidebar first via the masterbar menu button.
 				if ( viewportName === 'mobile' ) {
-					await page.getByRole( 'button', { name: 'Menu', exact: true } ).click();
+					await page.getByTitle( 'Menu', { exact: true } ).click();
 				}
 				await page.getByRole( 'link', { name: 'Domains' } ).click();
 			} else if ( viewportName === 'mobile' ) {


### PR DESCRIPTION
## Proposed Changes

Disable radically redesigned omnibar.

## Why are these changes being made?

The experiment is over.

## Testing Instructions

1. Go to /sites
2. Verify the old masterbar is shown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
