### PR TITLE
Licensing thank-you: Fix latent auto-activate re-entry under React 18

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation.tsx
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import { Button, FormInputValidation, Gridicon, SelectDropdown } from '@automattic/components';
 import clsx from 'clsx';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
-import { FC, useState, useCallback, useEffect, useMemo } from 'react';
+import { FC, useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import footerCardImg from 'calypso/assets/images/jetpack/licensing-card.webp';
 import QueryProducts from 'calypso/components/data/query-products-list';
 import LicensingActivation from 'calypso/components/jetpack/licensing-activation';
@@ -145,14 +145,22 @@ const LicensingActivationThankYou: FC< Props > = ( {
 		[ selectedSite, handleAutoActivate, manualActivationUrl ]
 	);
 
-	// Prevent auto-activation if it will fail at the initial attempt.
-	const [ attemptAutoActivate, setAttemptAutoActivate ] = useState( true );
+	// Ref instead of state so the guard flips synchronously before the dispatch
+	// inside `handleAutoActivate`. Under React 18 + react-redux's
+	// `useSyncExternalStore`, a dispatch in an effect can force a subscriber
+	// re-render before a sibling `setState` commits, which would otherwise
+	// re-enter this effect and dispatch repeatedly.
+	const autoActivateAttemptedRef = useRef( false );
 	useEffect( () => {
-		if ( attemptAutoActivate && fromSiteSlug && initialSelectedSite.includes( fromSiteSlug ) ) {
-			setAttemptAutoActivate( false );
+		if (
+			! autoActivateAttemptedRef.current &&
+			fromSiteSlug &&
+			initialSelectedSite.includes( fromSiteSlug )
+		) {
+			autoActivateAttemptedRef.current = true;
 			handleAutoActivate( initialSelectedSite );
 		}
-	}, [ attemptAutoActivate, fromSiteSlug, handleAutoActivate, initialSelectedSite ] );
+	}, [ fromSiteSlug, handleAutoActivate, initialSelectedSite ] );
 
 	useEffect( () => {
 		if ( error || supportTicketRequestStatus === undefined ) {


### PR DESCRIPTION
## Summary

Follow-up to #110997. Same anti-pattern, different file.

`licensing-thank-you-auto-activation.tsx` guards its one-shot auto-activate effect with a `useState` flag that is flipped immediately before calling `handleAutoActivate`, which dispatches two redux actions. Under React 18 + react-redux's \`useSyncExternalStore\`, those dispatches synchronously notify subscribers and can re-render this component before the guard's \`setState\` commits — re-entering the effect and dispatching again. This is exactly the loop that bit \`/marketplace/plugin/:slug/install/:site\` in #110997 once #110904 enabled React 18 \`createRoot\` in production.

Swapping the \`useState\` guard for a \`useRef\` set synchronously before the dispatch fixes it. Behavior is unchanged on legacy \`ReactDOM.render\`.

## Other surfaces considered

- \`client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx:126\` — similar shape (dispatch in effect that mutates a dep), but the selectors use custom equality functions that keep array references stable, so it doesn't re-enter. Not changing in this PR; worth keeping an eye on.

## Test plan

- [ ] Visit \`/checkout/jetpack/thank-you/licensing-auto-activate/:product?fromSiteSlug=<slug>\` with a matching Jetpack site and confirm the auto-activate fires exactly once.
- [ ] Confirm no \"Maximum update depth exceeded\" error.
- [ ] Confirm the destination redirect (\`licensing-auto-activate-completed\`) still works after successful activation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)