### PR TITLE
Reader onboarding, memberships redirect: Fix render-phase dispatches

### DIFF
--- a/client/me/memberships/cancelled-subscription-redirect-return.jsx
+++ b/client/me/memberships/cancelled-subscription-redirect-return.jsx
@@ -15,7 +15,7 @@ function CancelledSubscriptionRedirectReturn( { translate } ) {
 			successNotice( translate( 'This item has been removed.' ), { displayOnNextPage: true } )
 		);
 		page( purchasesRoot );
-	} );
+	}, [ dispatch, translate ] );
 }
 
 export default connect( () => ( {} ) )(

--- a/client/reader/onboarding/index.tsx
+++ b/client/reader/onboarding/index.tsx
@@ -55,10 +55,12 @@ const ReaderOnboarding = ( {
 	const hasFollowedSites = follows?.filter( ( follow ) => ! follow.is_owner )?.length > 2;
 
 	// If the user has completed the onboarding, save the preference and track the event.
-	if ( ! hasCompletedOnboarding && hasFollowedTags && hasFollowedSites && profileCompleted ) {
-		dispatch( savePreference( READER_ONBOARDING_PREFERENCE_KEY, true ) );
-		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }completed` );
-	}
+	useEffect( () => {
+		if ( ! hasCompletedOnboarding && hasFollowedTags && hasFollowedSites && profileCompleted ) {
+			dispatch( savePreference( READER_ONBOARDING_PREFERENCE_KEY, true ) );
+			recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }completed` );
+		}
+	}, [ dispatch, hasCompletedOnboarding, hasFollowedTags, hasFollowedSites, profileCompleted ] );
 
 	const meetsEligibility =
 		preferencesLoaded &&


### PR DESCRIPTION
## Summary

Follow-up to #110997 + #110999. Two latent dispatch-hygiene bugs found while auditing for React 18 / \`useSyncExternalStore\` re-entry patterns. Both pre-date that work — they were never safe and are more likely to misbehave under React 18 + concurrent rendering.

- \`client/reader/onboarding/index.tsx\`: \`dispatch(savePreference(...))\` and a \`recordTracksEvent\` ran directly during render, gated only by a redux-derived flag that the dispatch itself flips. Wrap in \`useEffect\` with proper deps.
- \`client/me/memberships/cancelled-subscription-redirect-return.jsx\`: \`useEffect\` was missing a deps array, so the success-notice dispatch + \`page()\` navigation fired on every render. Add \`[ dispatch, translate ]\`.

## Sweep results

I ran a wider sweep across \`client/\`, \`apps/\`, and \`packages/\` looking for the same anti-patterns. The agents flagged ~13 candidates; after reading each, only these two are real bugs. The rest fall into:

- already guarded with \`useRef\` (\`processing-step\`)
- navigates away on dispatch, no loop (\`site-migration-ssh-share-access\`)
- dispatch clears its own condition (\`note-panel/actions\`, \`notifications/app/index.tsx\`)
- empty \`[]\` deps, mount-only (\`substack/index.tsx\`)
- selectors with custom equality bailing out (\`use-plugins-thank-you-data.tsx\`)

I am NOT claiming this is exhaustive. It's a targeted sweep for the specific shape that caused #110997, not a general lint pass.

## Test plan

- [ ] Visit Reader following page and confirm no console errors / infinite-loop warnings, especially under React 18 dev mode.
- [ ] Trigger a Reader onboarding completion (follow >2 tags + >2 sites + complete profile) and confirm the \`READER_ONBOARDING_PREFERENCE_KEY\` preference is saved exactly once.
- [ ] Cancel a membership subscription, hit \`/me/purchases/cancelled-subscription-redirect-return\`, and confirm the success notice appears once and you land on \`/me/purchases\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)