### PR TITLE
Dashboard: fix Latest Activity card not loading required CSS

### DIFF
--- a/client/dashboard/sites/overview-latest-activity-card/index.tsx
+++ b/client/dashboard/sites/overview-latest-activity-card/index.tsx
@@ -1,10 +1,10 @@
 import { siteLastFiveActivityLogEntriesQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { Icon } from '@wordpress/components';
-import { DataViews } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useAnalytics } from '../../app/analytics';
 import { Card, CardHeader, CardBody } from '../../components/card';
+import { DataViews } from '../../components/dataviews';
 import { SectionHeader } from '../../components/section-header';
 import { SummaryButtonCardFooter } from '../../components/summary-button-card-footer';
 import { TextSkeleton } from '../../components/text-skeleton';


### PR DESCRIPTION
Fixes DOTMSD-1104

## Proposed Changes

The Latest Activity card in Dashboard site overview relies on the following CSS:

https://github.com/Automattic/wp-calypso/blob/1bbf37bd1776d8c1577bf02eac21d46caa0f9c28/client/dashboard/components/dataviews/styles.scss#L5-L12

We switch the import from `@wordpress/dataviews` to `client/dashboard/components/dataviews`, which reexport the component and loads the above CSS.

|Before|After|
|-|-|
|<img width="934" height="430" alt="image" src="https://github.com/user-attachments/assets/808a4c53-dce5-4f89-8b0b-572860854124" />|<img width="934" height="412" alt="image" src="https://github.com/user-attachments/assets/51e41429-cb7c-48eb-820b-d717bf3aa3c0" />


## Why are these changes being made?

Fixes a visual bug.

## Testing Instructions

1. Go to /sites/:siteSlug
2. Verify the latest activity card has no strange top double border.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
