### PR TITLE
Reader composer FAB: prepend profile handle when opened on a profile page

### DIFF
--- a/client/reader/atmosphere/author-profile-view.tsx
+++ b/client/reader/atmosphere/author-profile-view.tsx
@@ -99,10 +99,10 @@ export function AuthorProfileView( { connectionId, actor }: Props ) {
 /**
  * Reads the canonical handle from the scoped-profile cache so the FAB
  * seeds the composer with `@<handle> ` even when the URL keys the
- * profile by DID. Falls back to the URL actor while the query is in
- * flight or errors — gives a plausible mention starter immediately
- * rather than a no-op compose. The query is shared with
- * `AuthorProfilePanel`, so this hook does not add a network hit.
+ * profile by DID. Falls back to the URL actor only when it's a usable
+ * handle — DID-keyed URLs open with an empty composer while the query
+ * is in flight rather than flashing `@did:plc:…`. The query is shared
+ * with `AuthorProfilePanel`, so this hook does not add a network hit.
  */
 function AuthorProfileComposeFab( {
 	connectionId,
@@ -112,8 +112,10 @@ function AuthorProfileComposeFab( {
 	actor: string;
 } ) {
 	const profile = useAtmosphereScopedProfileQuery( { connectionId, actor } );
-	const handle = profile.data?.handle ?? actor;
-	return <ComposeFab initialText={ `@${ handle } ` } />;
+	// `||` (not `??`) so an empty-string `handle` from a malformed
+	// response also falls through to the actor branch.
+	const handle = profile.data?.handle || ( actor.startsWith( 'did:' ) ? null : actor );
+	return <ComposeFab initialText={ handle ? `@${ handle } ` : undefined } />;
 }
 
 export default AuthorProfileView;

--- a/client/reader/atmosphere/author-profile-view.tsx
+++ b/client/reader/atmosphere/author-profile-view.tsx
@@ -1,4 +1,4 @@
-import { useConnectionsQuery } from '@automattic/api-queries';
+import { useAtmosphereScopedProfileQuery, useConnectionsQuery } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
 import { Button, Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
@@ -90,10 +90,30 @@ export function AuthorProfileView( { connectionId, actor }: Props ) {
 					subtabBasePath={ subtabBasePath }
 				/>
 			</ReaderMain>
-			<ComposeFab />
+			<AuthorProfileComposeFab connectionId={ connection.id } actor={ actor } />
 			<ComposerModal />
 		</ComposerProvider>
 	);
+}
+
+/**
+ * Reads the canonical handle from the scoped-profile cache so the FAB
+ * seeds the composer with `@<handle> ` even when the URL keys the
+ * profile by DID. Falls back to the URL actor while the query is in
+ * flight or errors — gives a plausible mention starter immediately
+ * rather than a no-op compose. The query is shared with
+ * `AuthorProfilePanel`, so this hook does not add a network hit.
+ */
+function AuthorProfileComposeFab( {
+	connectionId,
+	actor,
+}: {
+	connectionId: number;
+	actor: string;
+} ) {
+	const profile = useAtmosphereScopedProfileQuery( { connectionId, actor } );
+	const handle = profile.data?.handle ?? actor;
+	return <ComposeFab initialText={ `@${ handle } ` } />;
 }
 
 export default AuthorProfileView;

--- a/client/reader/atmosphere/test/author-profile-view.test.tsx
+++ b/client/reader/atmosphere/test/author-profile-view.test.tsx
@@ -123,6 +123,73 @@ describe( 'AuthorProfileView', () => {
 		expect( await screen.findByRole( 'heading', { level: 2, name: 'Alice' } ) ).toBeVisible();
 	} );
 
+	it( 'seeds the compose FAB with @handle when the actor is a handle', async () => {
+		const user = userEvent.setup();
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/wpcom/v2/reader/atmosphere/connections' )
+			.reply( 200, {
+				connections: [
+					{
+						id: 42,
+						did: 'did:plc:viewer',
+						handle: 'viewer.bsky.social',
+						display_name: 'Viewer',
+						avatar: null,
+					},
+				],
+			} );
+		// Delay the profile query so the FAB sees `profile.data === undefined`
+		// at click time and exercises the URL-actor fallback.
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social' )
+			.delay( 5000 )
+			.reply( 200, {} );
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/alice.bsky.social/feed' )
+			.delay( 5000 )
+			.reply( 200, { items: [], cursor: null } );
+
+		renderWithProvider( <AuthorProfileView connectionId={ 42 } actor="alice.bsky.social" /> );
+
+		const fab = await screen.findByRole( 'button', { name: /compose/i } );
+		await user.click( fab );
+
+		expect( screen.getByRole( 'textbox' ) ).toHaveValue( '@alice.bsky.social ' );
+	} );
+
+	it( 'opens the compose FAB empty when the actor is a DID and the profile is still loading', async () => {
+		const user = userEvent.setup();
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/wpcom/v2/reader/atmosphere/connections' )
+			.reply( 200, {
+				connections: [
+					{
+						id: 42,
+						did: 'did:plc:viewer',
+						handle: 'viewer.bsky.social',
+						display_name: 'Viewer',
+						avatar: null,
+					},
+				],
+			} );
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/did%3Aplc%3Aabc' )
+			.delay( 5000 )
+			.reply( 200, {} );
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/wpcom/v2/reader/atmosphere/connections/42/profile/did%3Aplc%3Aabc/feed' )
+			.delay( 5000 )
+			.reply( 200, { items: [], cursor: null } );
+
+		renderWithProvider( <AuthorProfileView connectionId={ 42 } actor="did:plc:abc" /> );
+
+		const fab = await screen.findByRole( 'button', { name: /compose/i } );
+		await user.click( fab );
+
+		// DID actor should NOT flash through to the textarea.
+		expect( screen.getByRole( 'textbox' ) ).toHaveValue( '' );
+	} );
+
 	it( 'renders the back-to-timeline button above the panel', async () => {
 		const user = userEvent.setup();
 		// Force history.length === 1 so BackButton routes via page() instead of history.back().

--- a/client/reader/mastodon/author-profile-view.tsx
+++ b/client/reader/mastodon/author-profile-view.tsx
@@ -82,12 +82,31 @@ export function MastodonAuthorProfileView( { connectionId, actor }: Props ) {
 			</ReaderMain>
 			{ ! needsReauth && (
 				<>
-					<ComposeFab />
+					<MastodonAuthorProfileComposeFab connectionId={ connection.id } actor={ actor } />
 					<ComposerModal />
 				</>
 			) }
 		</ComposerProvider>
 	);
+}
+
+/**
+ * Reads the canonical webfinger handle from the profile cache so the FAB
+ * seeds the composer with `@<acct> ` even when the URL keys the profile
+ * by numeric account id. Falls back to the URL actor while the query is
+ * pending or errors. The query is shared with the title and the panel,
+ * so this hook does not add a network hit.
+ */
+function MastodonAuthorProfileComposeFab( {
+	connectionId,
+	actor,
+}: {
+	connectionId: number;
+	actor: string;
+} ) {
+	const { data } = useMastodonAuthorProfileQuery( connectionId, actor );
+	const handle = data?.acct ?? actor;
+	return <ComposeFab initialText={ `@${ handle } ` } />;
 }
 
 // Pulls the canonical webfinger handle from the profile cache so the document

--- a/client/reader/mastodon/author-profile-view.tsx
+++ b/client/reader/mastodon/author-profile-view.tsx
@@ -105,7 +105,9 @@ function MastodonAuthorProfileComposeFab( {
 	actor: string;
 } ) {
 	const { data } = useMastodonAuthorProfileQuery( connectionId, actor );
-	const handle = data?.acct ?? actor;
+	// `||` (not `??`) so an empty-string `acct` from a malformed response
+	// also falls through to the URL actor.
+	const handle = data?.acct || actor;
 	return <ComposeFab initialText={ `@${ handle } ` } />;
 }
 

--- a/client/reader/social/composer/composer-modal.tsx
+++ b/client/reader/social/composer/composer-modal.tsx
@@ -14,7 +14,7 @@ import { useComposerConfig } from './composer-config';
 import { ComposerFooter } from './composer-footer';
 import { ComposerOverflowHandoff } from './composer-overflow-handoff';
 import { ComposerPinnedContext } from './composer-pinned-context';
-import { useComposer } from './composer-provider';
+import { useComposer, type ActiveMode } from './composer-provider';
 import { ComposerTextarea } from './composer-textarea';
 import { countGraphemes, countWords } from './grapheme-count';
 import type { AppState } from 'calypso/types';
@@ -44,8 +44,16 @@ export function ComposerModal< TError, TParams, TResult >() {
 	// extend resolves.
 	const [ isExtending, setIsExtending ] = useState( false );
 	const lastErrorSignatureRef = useRef< string | null >( null );
+	// Tracks the previous `mode` so `initialText` seeds only on the
+	// null→non-null transition. Without the guard, a future change that
+	// updates a field on the active `mode` (e.g. a `replyTo` mutation, or
+	// a parent passing a new object ref) would re-fire the seed branch
+	// and wipe the user's in-flight typing.
+	const prevModeRef = useRef< ActiveMode | null >( null );
 
 	useEffect( () => {
+		const prevMode = prevModeRef.current;
+		prevModeRef.current = mode;
 		if ( ! mode ) {
 			setText( '' );
 			setConfirmDiscard( false );
@@ -53,7 +61,7 @@ export function ComposerModal< TError, TParams, TResult >() {
 			setIsExtending( false );
 			mutation.reset();
 			lastErrorSignatureRef.current = null;
-		} else if ( mode.kind === 'standalone' && mode.initialText ) {
+		} else if ( ! prevMode && mode.kind === 'standalone' && mode.initialText ) {
 			setText( mode.initialText );
 		}
 		// mutation.reset is stable across renders; intentionally not in deps.

--- a/client/reader/social/composer/composer-modal.tsx
+++ b/client/reader/social/composer/composer-modal.tsx
@@ -53,6 +53,8 @@ export function ComposerModal< TError, TParams, TResult >() {
 			setIsExtending( false );
 			mutation.reset();
 			lastErrorSignatureRef.current = null;
+		} else if ( mode.kind === 'standalone' && mode.initialText ) {
+			setText( mode.initialText );
 		}
 		// mutation.reset is stable across renders; intentionally not in deps.
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client/reader/social/composer/composer-provider.tsx
+++ b/client/reader/social/composer/composer-provider.tsx
@@ -105,7 +105,18 @@ export type ComposerMode =
 			previewPost: PreviewPost;
 			replyTo?: { root: ComposerParentRef; parent: ComposerParentRef };
 	  }
-	| { kind: 'standalone'; entry_point: ComposerEntryPoint; initialText?: string };
+	| {
+			kind: 'standalone';
+			entry_point: ComposerEntryPoint;
+			/**
+			 * Raw textarea content (including any trailing space) seeded into
+			 * the composer on open. Used by profile-page FABs to prepend
+			 * `@<handle> ` so the compose surface kicks off a mention. Seeded
+			 * exactly once on the null→non-null mode transition; later edits
+			 * by the user are not clobbered.
+			 */
+			initialText?: string;
+	  };
 
 export type ActiveMode = ComposerMode & { connectionId: number };
 

--- a/client/reader/social/composer/composer-provider.tsx
+++ b/client/reader/social/composer/composer-provider.tsx
@@ -105,7 +105,7 @@ export type ComposerMode =
 			previewPost: PreviewPost;
 			replyTo?: { root: ComposerParentRef; parent: ComposerParentRef };
 	  }
-	| { kind: 'standalone'; entry_point: ComposerEntryPoint };
+	| { kind: 'standalone'; entry_point: ComposerEntryPoint; initialText?: string };
 
 export type ActiveMode = ComposerMode & { connectionId: number };
 

--- a/client/reader/social/composer/test/composer-modal.test.tsx
+++ b/client/reader/social/composer/test/composer-modal.test.tsx
@@ -171,6 +171,39 @@ describe( '<ComposerModal>', () => {
 		expect( screen.getByRole( 'textbox' ) ).toHaveValue( '@alice.bsky.social ' );
 	} );
 
+	it( 'does not reseed initialText when mode changes while the composer stays open', async () => {
+		// Regression test for the `prevModeRef` guard: re-firing the seed
+		// branch on a mode-reference change while non-null would wipe the
+		// user's in-flight typing.
+		const user = userEvent.setup();
+		renderModal( testComposerConfig );
+
+		act(
+			() =>
+				openFn?.( {
+					kind: 'standalone',
+					entry_point: 'fab',
+					initialText: '@alice.bsky.social ',
+				} )
+		);
+		await user.type( screen.getByRole( 'textbox' ), 'hello' );
+		expect( screen.getByRole( 'textbox' ) ).toHaveValue( '@alice.bsky.social hello' );
+
+		// Re-open with a fresh mode object (different ref, same kind +
+		// initialText). The guard should suppress the seed so the user's
+		// typing survives.
+		act(
+			() =>
+				openFn?.( {
+					kind: 'standalone',
+					entry_point: 'fab',
+					initialText: '@bob.bsky.social ',
+				} )
+		);
+
+		expect( screen.getByRole( 'textbox' ) ).toHaveValue( '@alice.bsky.social hello' );
+	} );
+
 	it( 'disables the Post button when grapheme count exceeds config.limit', async () => {
 		const user = userEvent.setup();
 		const tinyLimitConfig: ComposerConfig< TestError, TestParams, TestResult > = {

--- a/client/reader/social/composer/test/composer-modal.test.tsx
+++ b/client/reader/social/composer/test/composer-modal.test.tsx
@@ -157,6 +157,20 @@ describe( '<ComposerModal>', () => {
 		expect( screen.getByRole( 'button', { name: /post/i } ) ).toBeDisabled();
 	} );
 
+	it( 'seeds the textarea with mode.initialText when opening in standalone mode', () => {
+		renderModal( testComposerConfig );
+		act(
+			() =>
+				openFn?.( {
+					kind: 'standalone',
+					entry_point: 'fab',
+					initialText: '@alice.bsky.social ',
+				} )
+		);
+
+		expect( screen.getByRole( 'textbox' ) ).toHaveValue( '@alice.bsky.social ' );
+	} );
+
 	it( 'disables the Post button when grapheme count exceeds config.limit', async () => {
 		const user = userEvent.setup();
 		const tinyLimitConfig: ComposerConfig< TestError, TestParams, TestResult > = {

--- a/client/reader/social/composer/triggers/compose-fab.tsx
+++ b/client/reader/social/composer/triggers/compose-fab.tsx
@@ -4,6 +4,15 @@ import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useComposer } from '../composer-provider';
 
+interface Props {
+	/**
+	 * Optional starter text seeded into the standalone composer on open.
+	 * Used by profile pages to prepend the profile's `@handle` so the
+	 * compose surface kicks off a mention.
+	 */
+	initialText?: string;
+}
+
 /**
  * Floating Action Button that opens the composer in standalone mode.
  *
@@ -13,7 +22,7 @@ import { useComposer } from '../composer-provider';
  * referenced by `<ComposerProvider>`'s `triggerRef`, which silently breaks
  * focus restoration after the modal closes.
  */
-export function ComposeFab() {
+export function ComposeFab( { initialText }: Props = {} ) {
 	const translate = useTranslate();
 	const { mode, openComposer } = useComposer();
 	const isHidden = mode != null;
@@ -26,7 +35,7 @@ export function ComposeFab() {
 			text={ translate( 'Compose' ) as string }
 			aria-hidden={ isHidden || undefined }
 			tabIndex={ isHidden ? -1 : undefined }
-			onClick={ () => openComposer( { kind: 'standalone', entry_point: 'fab' } ) }
+			onClick={ () => openComposer( { kind: 'standalone', entry_point: 'fab', initialText } ) }
 		/>
 	);
 }

--- a/client/reader/social/composer/triggers/test/compose-fab.test.tsx
+++ b/client/reader/social/composer/triggers/test/compose-fab.test.tsx
@@ -42,6 +42,28 @@ describe( '<ComposeFab>', () => {
 		);
 	} );
 
+	it( 'forwards initialText into the standalone mode payload', async () => {
+		const user = userEvent.setup();
+		const onMode = jest.fn();
+		render(
+			<ComposerProvider connectionId={ 7 } config={ testComposerConfig }>
+				<ComposeFab initialText="@alice.bsky.social " />
+				<Spy onMode={ onMode } />
+			</ComposerProvider>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Compose' } ) );
+
+		expect( onMode ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				kind: 'standalone',
+				entry_point: 'fab',
+				initialText: '@alice.bsky.social ',
+				connectionId: 7,
+			} )
+		);
+	} );
+
 	it( 'is removed from the accessibility tree while a mode is active', async () => {
 		let openFn: ( ( m: ComposerMode ) => void ) | null = null;
 		function Trigger() {


### PR DESCRIPTION
Fixes CM-785

## Proposed Changes

* Add an optional `initialText` field to the standalone variant of `ComposerMode`; `<ComposerModal>` seeds its textarea from it on open.
* `<ComposeFab>` accepts an `initialText` prop and forwards it through `openComposer`.
* Atmosphere and Mastodon author-profile views wrap the FAB in a small sibling that reads the canonical handle from the shared profile query and passes `@<handle> ` as the starter text.
* The sibling component reuses the existing scoped-profile query (dedupe with the panel's query — no extra network hit). Falls back to the URL `actor` while the query is pending or errored, so the mention starter is always populated, even on DID / numeric-id URLs.

## Why are these changes being made?

When the user is on a profile page (e.g. `/reader/atmosphere/:id/profile/jeherve.com` or `/reader/mastodon/:id/profile/:numeric_id`) and clicks the Compose FAB, the standalone composer should kick off a mention of that profile instead of opening blank. Small UX polish that turns the FAB into a contextual action on profile pages, matching the behaviour users expect from native Bluesky / Mastodon clients.

## Testing Instructions

1. Go to an atmosphere profile page (e.g. `/reader/atmosphere/<connection-id>/profile/<handle>`).
2. Click the bottom-right "Compose" FAB.
3. The composer opens with the textarea pre-filled with `@<handle> ` (trailing space), cursor positioned after it.
4. Repeat on a mastodon profile page — even when the URL keys by numeric account id, the textarea should show the canonical webfinger handle (e.g. `@FediTips@social.growyourown.services `).
5. Regression: from a timeline or thread view, clicking the FAB should still open an empty composer.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?