### PR TITLE
Revert "Dashboard: fix Latest Activity card not loading required CSS (#111001)

### DIFF
--- a/client/dashboard/sites/overview-latest-activity-card/index.tsx
+++ b/client/dashboard/sites/overview-latest-activity-card/index.tsx
@@ -1,10 +1,10 @@
 import { siteLastFiveActivityLogEntriesQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { Icon } from '@wordpress/components';
+import { DataViews } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useAnalytics } from '../../app/analytics';
 import { Card, CardHeader, CardBody } from '../../components/card';
-import { DataViews } from '../../components/dataviews';
 import { SectionHeader } from '../../components/section-header';
 import { SummaryButtonCardFooter } from '../../components/summary-button-card-footer';
 import { TextSkeleton } from '../../components/text-skeleton';


### PR DESCRIPTION
This reverts PR #111001.

## Why are these changes being made?

Somehow there's now too much left and right padding 🤦 Seems like the solution is not that simple.

<img width="1406" height="357" alt="image" src="https://github.com/user-attachments/assets/78fd74d6-36e3-43c9-88ec-54ae2e887159" />
