### PR TITLE
Add On This Day notification setting

### DIFF
--- a/client/me/notification-settings/main.jsx
+++ b/client/me/notification-settings/main.jsx
@@ -14,6 +14,7 @@ import {
 } from 'calypso/state/notification-settings/selectors';
 import BlogsSettings from './blogs-settings';
 import Navigation from './navigation';
+import OnThisDayNotificationSettings from './on-this-day-notification-settings';
 import PushNotificationSettings from './push-notification-settings';
 import SubscriptionManagementBackButton from './subscription-management-back-button';
 
@@ -63,6 +64,7 @@ class NotificationSettings extends Component {
 
 				<Navigation path={ this.props.path } />
 				<PushNotificationSettings pushNotifications={ this.props.pushNotifications } />
+				<OnThisDayNotificationSettings />
 				<BlogsSettings
 					settings={ this.props.settings }
 					hasUnsavedChanges={ this.props.hasUnsavedChanges }

--- a/client/me/notification-settings/on-this-day-notification-settings/index.jsx
+++ b/client/me/notification-settings/on-this-day-notification-settings/index.jsx
@@ -10,6 +10,8 @@ import {
 	isFetchingNotificationsSettings,
 } from 'calypso/state/notification-settings/selectors';
 
+import './style.scss';
+
 const ON_THIS_DAY_SETTING = 'on_this_day';
 
 class OnThisDayNotificationSettings extends Component {

--- a/client/me/notification-settings/on-this-day-notification-settings/index.jsx
+++ b/client/me/notification-settings/on-this-day-notification-settings/index.jsx
@@ -1,0 +1,65 @@
+import { Card } from '@automattic/components';
+import { ToggleControl } from '@wordpress/components';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import { connect } from 'react-redux';
+import { saveSettings, toggle } from 'calypso/state/notification-settings/actions';
+import {
+	getNotificationSettings,
+	isFetchingNotificationsSettings,
+} from 'calypso/state/notification-settings/selectors';
+
+const ON_THIS_DAY_SETTING = 'on_this_day';
+
+class OnThisDayNotificationSettings extends Component {
+	static propTypes = {
+		isFetching: PropTypes.bool,
+		saveSettings: PropTypes.func.isRequired,
+		settings: PropTypes.object,
+		toggle: PropTypes.func.isRequired,
+	};
+
+	toggleSetting = ( toggleValue ) => {
+		if ( ! this.props.settings ) {
+			return;
+		}
+
+		this.props.toggle( 'other', 'timeline', ON_THIS_DAY_SETTING );
+		this.props.saveSettings( 'other', {
+			...this.props.settings,
+			timeline: {
+				...this.props.settings.timeline,
+				[ ON_THIS_DAY_SETTING ]: toggleValue,
+			},
+		} );
+	};
+
+	render() {
+		const { isFetching, settings, translate } = this.props;
+
+		return (
+			<Card
+				id="on-this-day"
+				className="notification-settings-on-this-day-notification-settings__settings"
+			>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					checked={ !! settings?.timeline?.[ ON_THIS_DAY_SETTING ] }
+					disabled={ isFetching || ! settings }
+					help={ translate( 'Reminders about your posts from past years' ) }
+					label={ translate( 'On this day' ) }
+					onChange={ this.toggleSetting }
+				/>
+			</Card>
+		);
+	}
+}
+
+export default connect(
+	( state ) => ( {
+		isFetching: isFetchingNotificationsSettings( state ),
+		settings: getNotificationSettings( state, 'other' ),
+	} ),
+	{ saveSettings, toggle }
+)( localize( OnThisDayNotificationSettings ) );

--- a/client/me/notification-settings/on-this-day-notification-settings/style.scss
+++ b/client/me/notification-settings/on-this-day-notification-settings/style.scss
@@ -1,0 +1,4 @@
+.card.notification-settings-on-this-day-notification-settings__settings {
+	position: relative;
+	margin-top: 1em;
+}

--- a/client/me/notification-settings/push-notification-settings/style.scss
+++ b/client/me/notification-settings/push-notification-settings/style.scss
@@ -16,8 +16,3 @@
 	position: relative;
 	margin-top: 1em;
 }
-
-.card.notification-settings-on-this-day-notification-settings__settings {
-	position: relative;
-	margin-top: 1em;
-}

--- a/client/me/notification-settings/push-notification-settings/style.scss
+++ b/client/me/notification-settings/push-notification-settings/style.scss
@@ -1,5 +1,5 @@
-@import "@wordpress/base-styles/breakpoints";
-@import "@wordpress/base-styles/mixins";
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .notification-settings-push-notification-settings__instruction {
 	margin: 24px 0 0;
@@ -13,6 +13,11 @@
 }
 
 .card.notification-settings-push-notification-settings__settings {
+	position: relative;
+	margin-top: 1em;
+}
+
+.card.notification-settings-on-this-day-notification-settings__settings {
 	position: relative;
 	margin-top: 1em;
 }

--- a/packages/api-core/src/me-notification-settings/types.ts
+++ b/packages/api-core/src/me-notification-settings/types.ts
@@ -39,6 +39,7 @@ export interface NotificationSettings {
 	recommended_blog: boolean;
 	comment_reply: boolean;
 	form_response: boolean;
+	on_this_day?: boolean;
 }
 
 export interface DeviceNotificationSettings extends NotificationSettings {
@@ -50,7 +51,7 @@ export type OtherDeviceNotificationSettings = Pick<
 	'device_id' | 'comment_like' | 'comment_reply'
 >;
 export interface OtherNotificationSettings {
-	timeline: Pick< NotificationSettings, 'comment_like' | 'comment_reply' >;
+	timeline: Pick< NotificationSettings, 'comment_like' | 'comment_reply' | 'on_this_day' >;
 	email: Pick< NotificationSettings, 'comment_like' | 'comment_reply' >;
 	devices: OtherDeviceNotificationSettings[];
 }


### PR DESCRIPTION
Fixes DOTCOM-16925

## Proposed Changes

* Add an `On this day` toggle card to the first `/me/notifications` tab under the browser notification card.
* Persist the setting as `other.timeline.on_this_day` using the existing notification settings flow.
* Add `on_this_day` to the shared notification settings type so the timeline settings shape includes it.

## Why are these changes being made?

* Users need a dedicated preference for reminders about posts from past years.
* Placing it on the Notifications tab makes it available alongside web notification preferences and provides an anchor target via `#on-this-day`.

## Testing Instructions

1. Apply wpcom#219798 and sandbox public API.
3. Visit the live link.
4. Click on this day notification. Doesn't have to be new.
5. It should have "Adjust settings" button.
6. It should take you to wordpress.com/me/notifications.
7. Adjust the host to the live link host.
8. You should see a new toggle.
9. Toggle it. Refresh the page. It should stay off.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?