### PR TITLE
Agents Manager: gate chat docking on fullscreen mode for editor screens

### DIFF
--- a/packages/agents-manager/src/hooks/__tests__/use-agent-layout-manager.test.tsx
+++ b/packages/agents-manager/src/hooks/__tests__/use-agent-layout-manager.test.tsx
@@ -4,12 +4,13 @@
 import { renderHook, act } from '@testing-library/react';
 import useAgentLayoutManager from '../use-agent-layout-manager/index';
 
-// Stub out external deps that aren't relevant to the closing-class logic
+// Stub out viewport/responsive deps so `canDock` depends only on the hook's
+// own logic (viewport is always desktop, window is always tall enough).
 jest.mock( '@automattic/viewport', () => ( {
 	useWindowDimensions: () => ( { width: 1920, height: 1080 } ),
 } ) );
 jest.mock( '@wordpress/compose', () => ( {
-	useMediaQuery: () => true, // always "desktop" so canDock is true
+	useMediaQuery: () => true,
 } ) );
 jest.mock( '@wordpress/components', () => ( {
 	Button: () => null,
@@ -22,6 +23,9 @@ jest.mock( '@wordpress/element', () => ( {
 const CLOSING_CLASS = 'agents-manager-sidebar-container--closing';
 const OPEN_CLASS = 'agents-manager-sidebar-container--sidebar-open';
 const TRANSITION_MS = 200;
+
+const FULLSCREEN_BODY_CLASS = 'is-fullscreen-mode';
+const EDITOR_BODY_CLASSES = [ 'post-php', 'post-new-php', 'site-editor-php' ] as const;
 
 function renderLayoutManager( container: HTMLElement ) {
 	return renderHook( () =>
@@ -155,5 +159,66 @@ describe( 'useAgentLayoutManager — closing class suppression', () => {
 		} );
 
 		expect( container.classList.contains( CLOSING_CLASS ) ).toBe( false );
+	} );
+} );
+
+describe( 'useAgentLayoutManager — fullscreen gate', () => {
+	let container: HTMLElement;
+
+	beforeEach( () => {
+		// Reset in `beforeEach` (not `afterEach`) so RTL's auto-cleanup
+		// disconnects the observer first — otherwise the next test's
+		// `body` mutation triggers a re-render outside `act()`.
+		document.body.className = '';
+		container = document.createElement( 'div' );
+		document.body.appendChild( container );
+	} );
+
+	afterEach( () => {
+		container.remove();
+	} );
+
+	it( 'allows docking on non-editor screens (no gated body class)', () => {
+		const { result } = renderLayoutManager( container );
+		expect( result.current.canDock ).toBe( true );
+	} );
+
+	it.each( EDITOR_BODY_CLASSES )(
+		'blocks docking on `%s` when fullscreen mode is off',
+		( editorClass ) => {
+			document.body.classList.add( editorClass );
+			const { result } = renderLayoutManager( container );
+			expect( result.current.canDock ).toBe( false );
+		}
+	);
+
+	it.each( EDITOR_BODY_CLASSES )(
+		'allows docking on `%s` when fullscreen mode is on',
+		( editorClass ) => {
+			document.body.classList.add( editorClass, FULLSCREEN_BODY_CLASS );
+			const { result } = renderLayoutManager( container );
+			expect( result.current.canDock ).toBe( true );
+		}
+	);
+
+	it( 'reacts to runtime fullscreen-mode toggles', async () => {
+		document.body.classList.add( 'post-php' );
+		const { result } = renderLayoutManager( container );
+
+		expect( result.current.canDock ).toBe( false );
+
+		// `MutationObserver` callbacks fire on a microtask — flush one tick
+		// inside `act()` so the resulting re-render lands within it.
+		await act( async () => {
+			document.body.classList.add( FULLSCREEN_BODY_CLASS );
+			await Promise.resolve();
+		} );
+		expect( result.current.canDock ).toBe( true );
+
+		await act( async () => {
+			document.body.classList.remove( FULLSCREEN_BODY_CLASS );
+			await Promise.resolve();
+		} );
+		expect( result.current.canDock ).toBe( false );
 	} );
 } );

--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/README.md
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/README.md
@@ -6,6 +6,8 @@
 
 In order to prevent issues with the WP admin sidebar the hook will also use floating mode if the page height is less than that of the sidebar.
 
+On Gutenberg editor screens (`post-php`, `post-new-php`, `site-editor-php`), docking also requires fullscreen mode (`body.is-fullscreen-mode`) — without it, wp-admin's chrome leaves too little room for the editor alongside the chat. The gate is re-evaluated whenever the `body` class list changes, so toggling fullscreen at runtime switches the chat between docked and floating.
+
 ## Usage
 
 ### React Example
@@ -68,6 +70,7 @@ The hook manages the sidebar DOM structure and CSS classes. Customize the styles
 ```
 
 The hook automatically manages these CSS classes based on the chat state:
+
 - `agents-manager-sidebar-container` is added when docked on desktop
 - `agents-manager-sidebar-container--sidebar-open` is added when the sidebar is open
 - `agents-manager-sidebar-container--closing` is added during the close transition and removed once complete
@@ -140,9 +143,9 @@ The hook accepts a single options object. All properties are optional.
 
 The hook returns an object with the following properties:
 
-- **`isDocked`** (`boolean`) - `true` when the chat is in docked (sidebar) mode. This requires both: the viewport is desktop-sized (matches `desktopMediaQuery`) AND docked mode is enabled AND there is enough vertical space. On mobile/tablet, this is always `false`.
+- **`isDocked`** (`boolean`) - `true` when the chat is in docked (sidebar) mode. Requires `canDock` to be `true` AND docked mode to be enabled (via `defaultDocked` or `dock()`).
 
-- **`canDock`** (`boolean`) - `true` when docking is possible. This means the viewport is desktop-sized (matches `desktopMediaQuery`) AND there is enough vertical space to accommodate the docked sidebar. Use this to determine whether to show dock/undock UI controls.
+- **`canDock`** (`boolean`) - `true` when docking is possible. Requires a desktop viewport (matches `desktopMediaQuery`), enough vertical space for the docked sidebar, and — on Gutenberg editor screens (`post-php`, `post-new-php`, `site-editor-php`) — fullscreen mode (`body.is-fullscreen-mode`). Updates dynamically as these conditions change. Use this to show or hide dock/undock UI controls.
 
 - **`dock`** (`() => void`) - Switches to sidebar mode. When on desktop, this enables the docked layout and automatically opens the sidebar. No-op when `isReady` is `false` or `sidebarContainer` is not found.
 

--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/index.tsx
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/index.tsx
@@ -8,11 +8,31 @@ import {
 	useRef,
 	useState,
 	useMemo,
+	useSyncExternalStore,
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { AI } from '../../components/icons';
 
 const SIDEBAR_TRANSITION_DURATION_MS = 200;
+
+// On Gutenberg editor screens, only dock when fullscreen mode is on —
+// otherwise wp-admin's chrome leaves too little room for the editor.
+const FULLSCREEN_GATED_BODY_CLASSES = [ 'post-php', 'post-new-php', 'site-editor-php' ];
+const FULLSCREEN_BODY_CLASS = 'is-fullscreen-mode';
+
+function getIsFullscreenGateOpen(): boolean {
+	const { classList } = document.body;
+	const isGated = FULLSCREEN_GATED_BODY_CLASSES.some( ( cls ) => classList.contains( cls ) );
+	return ! isGated || classList.contains( FULLSCREEN_BODY_CLASS );
+}
+
+// Hoisted so the reference stays stable — otherwise `useSyncExternalStore`
+// would tear down and re-create the observer on every render.
+function subscribeToBodyClasses( notify: () => void ): () => void {
+	const observer = new MutationObserver( notify );
+	observer.observe( document.body, { attributes: true, attributeFilter: [ 'class' ] } );
+	return () => observer.disconnect();
+}
 
 interface Options {
 	sidebarContainer?: string | HTMLElement;
@@ -57,9 +77,13 @@ export default function useAgentLayoutManager( {
 	const { height } = useWindowDimensions();
 	const [ isDocked, setIsDocked ] = useState< boolean | null >( null );
 	const [ adminMenuHeight, setAdminMenuHeight ] = useState( 0 );
-
 	const hasEnoughHeight = height >= adminMenuHeight;
-	const canDock = isDesktop && hasEnoughHeight;
+	const isFullscreenGateOpen = useSyncExternalStore(
+		subscribeToBodyClasses,
+		getIsFullscreenGateOpen,
+		getIsFullscreenGateOpen
+	);
+	const canDock = isDesktop && hasEnoughHeight && isFullscreenGateOpen;
 	const shouldRenderSidebar = canDock && isDocked;
 	const openSidebarTimeoutRef = useRef< ReturnType< typeof setTimeout > >();
 	const closeSidebarTimeoutRef = useRef< ReturnType< typeof setTimeout > >();

--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/index.tsx
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/index.tsx
@@ -80,7 +80,6 @@ export default function useAgentLayoutManager( {
 	const hasEnoughHeight = height >= adminMenuHeight;
 	const isFullscreenGateOpen = useSyncExternalStore(
 		subscribeToBodyClasses,
-		getIsFullscreenGateOpen,
 		getIsFullscreenGateOpen
 	);
 	const canDock = isDesktop && hasEnoughHeight && isFullscreenGateOpen;


### PR DESCRIPTION
Related to AI-974

## Proposed Changes

- On Gutenberg editor screens (`post-php`, `post-new-php`, `site-editor-php`), gate chat docking on fullscreen mode (`body.is-fullscreen-mode`). Without it, the chat falls back to floating mode.
- Wire the gate via `useSyncExternalStore` + a `MutationObserver` on `body`'s class list, so toggling fullscreen at runtime updates `canDock` automatically.

## Why are these changes being made?

Without fullscreen mode, wp-admin's chrome (admin menu + toolbar) leaves too little horizontal space for the editor alongside the docked chat sidebar — the editing area becomes uncomfortably narrow. Gating docking on fullscreen mode prevents this while still letting the chat appear in floating mode.

## Testing Instructions

- Check out and sandbox this PR 
- Enable the unified AI experience
- Go to: `https://<YOUR_SITE>/wp-admin/post.php?post=3&action=edit`
- In docked mode, when you turn off the full-screen mode, the AI chat will be undocked:

https://github.com/user-attachments/assets/7360d18e-6fdc-4927-809e-071ecdcbfcfd

- In undocked mode, when you turn off the full-screen mode, the dock mode option will be hidden:

https://github.com/user-attachments/assets/a331bb51-c468-40bb-816d-b092daf251b2

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?