### PR TITLE
Dashboard: fix Latest Activity card not loading required CSS (alt 2)

### DIFF
--- a/client/dashboard/app/dataviews-overrides.scss
+++ b/client/dashboard/app/dataviews-overrides.scss
@@ -1,0 +1,53 @@
+@import "@wordpress/base-styles/variables";
+@import '@wordpress/base-styles/colors';
+
+// @wordpress/dataviews v13 shipped a rule that neutralized the surrounding CardBody padding
+// when it wrapped a dataviews wrapper. v14 dropped that rule, so the default CardBody padding
+// leaks through. Restore the previous behavior here.
+.components-card__body:has( > .dataviews-wrapper ),
+.components-card__body:has( > .dataviews-picker-wrapper ) {
+	padding: $grid-unit-10 0 0;
+	overflow: hidden;
+}
+
+// We manually compose the UI of the dataview without including the view actions, which results in extra padding and a border.
+.components-card__header + .components-card__body:has( > .dataviews-wrapper ):not( :has( .dataviews__view-actions ) ) {
+	padding-top: 0;
+
+	.dataviews-view-list div[role="row"]:first-child {
+		border-top: none;
+	}
+}
+
+// When displaying URLs in the DataViews, using the --wp-admin-theme-color link color is overwhelming.
+// Using this class name, we override the link color with the text color.
+a.dataviews-url-field {
+	&,
+	&:visited {
+		color: $gray-700;
+	}
+
+	&:hover {
+		color: var(--wp-admin-theme-color);
+	}
+
+	span {
+		text-decoration: none;
+	}
+}
+
+// Temporary overrides for the dataviews wrapper to match the new design system.
+@media ( max-width: 782px ) { // Matches medium breakpoint from Core.
+	.dataviews-filters__container,
+	.dataviews-footer,
+	.dataviews-view-grid,
+	.dataviews-loading,
+	.dataviews-no-results,
+	.dataviews__view-actions,
+	.dataviews-view-table tr td:first-child,
+	.dataviews-view-table tr th:first-child,
+	.dataviews-view-list div[role="row"] .dataviews-view-list__item-wrapper,
+	.dataviews-view-list div[role="article"] .dataviews-view-list__item-wrapper {
+		padding-inline: #{$grid-unit-20} !important;
+	}
+}

--- a/client/dashboard/app/style.scss
+++ b/client/dashboard/app/style.scss
@@ -9,6 +9,7 @@
 
 // Core component overrides.
 @import './dataforms-overrides.scss';
+@import './dataviews-overrides.scss';
 
 // Global Styles
 html,

--- a/client/dashboard/components/dataviews/styles.scss
+++ b/client/dashboard/components/dataviews/styles.scss
@@ -2,41 +2,6 @@
 @import "@wordpress/base-styles/mixins";
 @import '@wordpress/base-styles/colors';
 
-// @wordpress/dataviews v13 shipped a rule that neutralized the surrounding CardBody padding
-// when it wrapped a dataviews wrapper. v14 dropped that rule, so the default CardBody padding
-// leaks through. Restore the previous behavior here.
-.components-card__body:has( > .dataviews-wrapper ),
-.components-card__body:has( > .dataviews-picker-wrapper ) {
-	padding: $grid-unit-10 0 0;
-	overflow: hidden;
-}
-
-// We manually compose the UI of the dataview without including the view actions, which results in extra padding and a border.
-.components-card__header + .components-card__body:has( > .dataviews-wrapper ):not( :has( .dataviews__view-actions ) ) {
-	padding-top: 0;
-
-	.dataviews-view-list div[role="row"]:first-child {
-		border-top: none;
-	}
-}
-
-// When displaying URLs in the DataViews, using the --wp-admin-theme-color link color is overwhelming.
-// Using this class name, we override the link color with the text color.
-a.dataviews-url-field {
-	&,
-	&:visited {
-		color: $gray-700;
-	}
-
-	&:hover {
-		color: var(--wp-admin-theme-color);
-	}
-
-	span {
-		text-decoration: none;
-	}
-}
-
 .dashboard-dataviews-empty-state {
 	max-width: 480px;
 	padding-block: $grid-unit-20;
@@ -53,20 +18,4 @@ a.dataviews-url-field {
 // Extra specificity to override <Text> component styles
 .dashboard-dataviews-empty-state .dashboard-dataviews-empty-state__sub-heading {
 	text-wrap: balance;
-}
-
-// Temporary overrides for the dataviews wrapper to match the new design system.
-@media ( max-width: 782px ) { // Matches medium breakpoint from Core.
-	.dataviews-filters__container,
-	.dataviews-footer,
-	.dataviews-view-grid,
-	.dataviews-loading,
-	.dataviews-no-results,
-	.dataviews__view-actions,
-	.dataviews-view-table tr td:first-child,
-	.dataviews-view-table tr th:first-child,
-	.dataviews-view-list div[role="row"] .dataviews-view-list__item-wrapper,
-	.dataviews-view-list div[role="article"] .dataviews-view-list__item-wrapper {
-		padding-inline: #{$grid-unit-20} !important;
-	}
 }


### PR DESCRIPTION
Fixes DOTMSD-1104

## Proposed Changes

This is an alternative of https://github.com/Automattic/wp-calypso/pull/111001, where instead of switching import, we extract the css overrides explicitly and import it from the app root. With this, all DataViews instances in dashboard will receive the fix (overrides). This is very similar to the existing `dataforms-overrides.scss`.

Note that the revert (https://github.com/Automattic/wp-calypso/pull/111004) seems to be a red herring. See p1779706153974049-slack-CRWCHQGUB.

## Testing Instructions

See: https://github.com/Automattic/wp-calypso/pull/111001

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?