### PR TITLE
Dashboard DataViews: Restore CardBody padding override after v14 upgrade

### DIFF
--- a/client/dashboard/components/dataviews/styles.scss
+++ b/client/dashboard/components/dataviews/styles.scss
@@ -2,6 +2,15 @@
 @import "@wordpress/base-styles/mixins";
 @import '@wordpress/base-styles/colors';
 
+// @wordpress/dataviews v13 shipped a rule that neutralized the surrounding CardBody padding
+// when it wrapped a dataviews wrapper. v14 dropped that rule, so the default CardBody padding
+// leaks through. Restore the previous behavior here.
+.components-card__body:has( > .dataviews-wrapper ),
+.components-card__body:has( > .dataviews-picker-wrapper ) {
+	padding: $grid-unit-10 0 0;
+	overflow: hidden;
+}
+
 // We manually compose the UI of the dataview without including the view actions, which results in extra padding and a border.
 .components-card__header + .components-card__body:has( > .dataviews-wrapper ):not( :has( .dataviews__view-actions ) ) {
 	padding-top: 0;


### PR DESCRIPTION
Follow-up to #110933.

## Proposed Changes

* Re-add the CSS rule that zeroes out `.components-card__body` padding when it wraps a `.dataviews-wrapper` or `.dataviews-picker-wrapper`, since `@wordpress/dataviews` v14 dropped this rule.

## Why are these changes being made?

`@wordpress/dataviews` v13 shipped this rule in its compiled stylesheet:

```css
.components-card__body:has(> .dataviews-wrapper),
.components-card__body:has(> .dataviews-picker-wrapper) {
  padding: 8px 0 0;
  overflow: hidden;
}
```

v14 removed it as a breaking change in WordPress/gutenberg#76282 (the DataForm card layout migrated from `@wordpress/components` Card to `@wordpress/ui` Card/CollapsibleCard, and the custom `.components-card__body` overrides were dropped along with it). So in the dashboard — where we still render DataViews inside a `@wordpress/components` `<CardBody>` — the default CardBody padding (`16px 24px`) now leaks through and shows up as extra padding around dashboard list/grid views. Restoring the override in the dashboard's local DataViews styles matches the previous look.

## Testing Instructions

* Visit any dashboard surface that renders DataViews inside a Card (e.g. Sites list, Domains, Plugins, Backups, Logs).
* Confirm the list and grid views no longer have extra padding around them — content should sit flush against the card edges, matching the look before #110933.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?