### PR TITLE
Add Stepper component to @automattic/ui

### DIFF
--- a/docs/brainstorms/stepper-requirements.md
+++ b/docs/brainstorms/stepper-requirements.md
@@ -1,0 +1,285 @@
+# Stepper Component — Requirements
+
+**Date:** 2026-05-25
+**Package:** `@automattic/ui` (`packages/ui/`)
+**Status:** Ready for planning
+
+---
+
+## Summary
+
+A reusable `Stepper` component that communicates progress through a sequence of steps and supports navigation between them. Two orientations are supported: horizontal (tabs pattern) and vertical (accordion pattern). Both ship in v1.
+
+---
+
+## Two-Tier API
+
+### Tier 1 — High-level (recommended for most consumers)
+
+Two composed components with identical JSX shape. The only difference is which component is imported:
+
+- `VerticalStepper` + `VerticalStepper.Step`
+- `HorizontalStepper` + `HorizontalStepper.Step`
+
+Each `*.Step` accepts metadata props (`value`, `title`, `description`, `status`, `optional`, `disabled`, `indicator`) and panel content via `children`. The component handles DOM structure, ARIA attributes, heading wrappers, and keyboard behavior.
+
+### Tier 2 — Low-level primitives (escape hatch)
+
+Eight sub-components exported under the `Stepper` namespace for consumers who need full control:
+
+`Stepper.Root`, `Stepper.List`, `Stepper.Step`, `Stepper.Trigger`, `Stepper.Panel`, `Stepper.Indicator`, `Stepper.Title`, `Stepper.Description`
+
+---
+
+## Props
+
+### `VerticalStepper` / `HorizontalStepper`
+
+| Prop | Type | Default | Notes |
+|------|------|---------|-------|
+| `aria-label` or `aria-labelledby` | `string` | — | One is required |
+| `value` | `string` | — | Controlled active step |
+| `defaultValue` | `string` | — | Uncontrolled initial step |
+| `onValueChange` | `(value: string) => void` | — | |
+| `linear` | `boolean` | `false` | Constrains navigation to current + completed steps |
+| `headingLevel` | `2\|3\|4\|5\|6` | `3` | Vertical only; heading wrapping each trigger |
+| `activationMode` | `'auto'\|'manual'` | `'manual'` | Horizontal only; whether focus immediately activates |
+| `formatStepLabel` | `(step, total, status?) => string` | English default | For i18n of indicator accessible text |
+| `className` | `string` | — | |
+| `ref` | `Ref<StepperRef>` | — | Imperative focus handle |
+
+### `*.Step`
+
+| Prop | Type | Notes |
+|------|------|-------|
+| `value` | `string` | Required, unique |
+| `title` | `string` | Required |
+| `description` | `string` | Optional subtitle |
+| `status` | `'completed'\|'error'` | Mutually exclusive validation states |
+| `optional` | `boolean` | Step can be skipped |
+| `disabled` | `boolean` | Step cannot be activated |
+| `indicator` | `ReactNode` | Custom indicator content |
+| `forceMount` | `boolean` | Keep panel mounted when inactive (horizontal) |
+| `children` | `ReactNode` | Panel content |
+| `className` | `string` | |
+
+### Imperative handle
+
+```ts
+type StepperRef = {
+  focusStep: (value: string) => void;
+};
+```
+
+---
+
+## State Model
+
+`current` is derived (matches root `value`). `upcoming` is derived (no status, appears after current in registration order).
+
+`status` uses an enum (`'completed' | 'error'`) because these are mutually exclusive. `optional` and `disabled` are separate booleans because they can combine with any status.
+
+`disabled` always takes priority over `linear` constraints.
+
+### Linear flow
+
+When `linear={true}`, a step is navigable only if it is current or has `status="completed"`. Future steps get `aria-disabled="true"` (focusable, non-activatable). Programmatic `value` changes bypass linear constraints.
+
+---
+
+## Accessibility
+
+### Vertical (accordion + headings)
+
+- Trigger: `<hN><button aria-expanded aria-controls aria-current="step"></button></hN>`
+- Panel: `<div role="region" aria-labelledby>` when `totalSteps <= 5`; plain `<div>` when `totalSteps > 5` to avoid landmark noise
+
+### Horizontal (tabs)
+
+- List: `<div role="tablist">`
+- Trigger: `<button role="tab" aria-selected aria-controls aria-current="step">`
+- Panel: `<div role="tabpanel" aria-labelledby>`
+
+### Why `<div>` containers, not `<ol>/<li>`
+
+The Indicator's visually-hidden "Step N of M" text already provides richer positional context (including status). Using `<ol>/<li>` would create redundant announcements ("item 1 of 3" + "Step 1 of 3"). `<div>` containers match APG accordion and tabs examples.
+
+### Disabled triggers
+
+Use `aria-disabled="true"` (not HTML `disabled`) so the trigger remains focusable. Keyboard users can arrow to it and hear its label and state.
+
+---
+
+## Keyboard Interaction
+
+### Vertical
+
+| Key | Behavior |
+|-----|----------|
+| `ArrowDown` | Next trigger |
+| `ArrowUp` | Previous trigger |
+| `Home` | First trigger |
+| `End` | Last trigger |
+| `Enter` / `Space` | Activate (expand/collapse) |
+| `Tab` | Move focus into/out of stepper and between triggers and panel content |
+
+### Horizontal
+
+| Key | Behavior |
+|-----|----------|
+| `ArrowRight` / `ArrowLeft` | Next / previous trigger (reversed in RTL) |
+| `Home` | First trigger |
+| `End` | Last trigger |
+| `Enter` / `Space` | Activate when `activationMode="manual"` |
+| `Tab` | Move focus to active tab, then into active panel |
+
+When `activationMode="auto"`, arrow key focus immediately activates.
+
+---
+
+## Focus Management
+
+| Transition | Focus behavior |
+|------------|---------------|
+| User activates trigger | Focus stays on trigger |
+| Programmatic `value` change | Focus does not move; consumer uses `StepperRef.focusStep()` |
+| Active panel unmounts (horizontal) | If focus was inside, moves to newly active panel's first focusable element or panel container |
+
+---
+
+## Visual Design
+
+### Indicators
+
+| State | Visual | Accessible label |
+|-------|--------|-----------------|
+| Upcoming | Number in dashed circle | "Step N of M" |
+| Current | Number in filled circle (emphasized) | "Step N of M" |
+| Completed | Check icon | "Step N of M, completed" |
+| Error | Warning icon | "Step N of M, error" |
+
+Custom indicator content is accepted via `indicator` prop (Tier 1) or `children` (Tier 2). When provided, the built-in visually-hidden label is still generated; custom content is `aria-hidden="true"`.
+
+### Connectors
+
+Purely decorative lines between steps. Rendered via CSS `::after` pseudo-elements on the step container. Not a separate component. Color reflects prior step's status (default stroke, success green for completed, error red for error step).
+
+### Responsive behavior
+
+On mobile, step labels (title/description) are hidden via a CSS breakpoint. Indicators remain visible. This is always-on CSS behavior with no prop. The breakpoint is determined during implementation to match the design system's existing breakpoints.
+
+### Transitions
+
+- Vertical panel expand/collapse: CSS transition on `grid-template-rows: 0fr -> 1fr`
+- Horizontal panel switch: CSS transition on `opacity` and/or `transform`
+- All transitions respect `@media (prefers-reduced-motion: reduce)`
+
+---
+
+## Internationalization
+
+The `formatStepLabel` callback generates the Indicator's visually-hidden text. Default implementation (English):
+
+```ts
+function defaultFormatStepLabel(step, total, status) {
+  let label = `Step ${step} of ${total}`;
+  if (status === 'completed') label += ', completed';
+  if (status === 'error') label += ', error';
+  return label;
+}
+```
+
+RTL: horizontal arrow key directions and connector layout automatically follow the nearest `dir` attribute. No explicit `direction` prop needed.
+
+---
+
+## Implementation Strategy
+
+### Primitive dependency
+
+Add `@ariakit/react` as an explicit dependency to `@automattic/ui`. Ariakit is already present in the monorepo as a transitive dep of `@wordpress/components`.
+
+| Orientation | Ariakit primitive |
+|-------------|------------------|
+| Vertical | `disclosure` (Disclosure.Root, Disclosure.Trigger, Disclosure.Content) |
+| Horizontal | `tab` (Tab.Provider, Tab.List, Tab, Tab.Panel) |
+
+### Tier 1 internals
+
+`VerticalStepper` and `HorizontalStepper` are implemented using the Tier 2 primitives. Each `*.Step` registers its metadata with root via context on mount (not `React.Children` iteration, to support conditional/dynamic steps). Registration order determines step index.
+
+### Dev-mode warnings
+
+| Situation | Warning |
+|-----------|---------|
+| Duplicate `value` across steps | "Two steps share value '{value}'. Each step must have a unique value." |
+| Root `value` matches no step | "No step found with value '{value}'. Falling back to the first step." |
+| `Stepper.List` used in vertical mode | "Stepper.List is only used in horizontal mode. It will be ignored." |
+| `Stepper.Panel` in horizontal without `value` | "Stepper.Panel requires a 'value' prop in horizontal mode." |
+| Missing `aria-label` and `aria-labelledby` | "Stepper requires either 'aria-label' or 'aria-labelledby' for accessibility." |
+
+---
+
+## File Structure
+
+```
+packages/ui/src/
+├── vertical-stepper/
+│   ├── index.ts
+│   ├── vertical-stepper.tsx
+│   ├── vertical-stepper-step.tsx
+│   ├── style.module.scss
+│   ├── stories/
+│   │   └── index.story.tsx
+│   └── test/
+│       └── index.test.tsx
+├── horizontal-stepper/
+│   ├── index.ts
+│   ├── horizontal-stepper.tsx
+│   ├── horizontal-stepper-step.tsx
+│   ├── style.module.scss
+│   ├── stories/
+│   │   └── index.story.tsx
+│   └── test/
+│       └── index.test.tsx
+└── stepper/
+    ├── index.ts
+    ├── types.ts
+    ├── context.tsx
+    ├── root.tsx
+    ├── list.tsx
+    ├── step.tsx
+    ├── trigger.tsx
+    ├── panel.tsx
+    ├── indicator.tsx
+    ├── title.tsx
+    ├── description.tsx
+    ├── style.module.scss
+    ├── stories/
+    │   └── index.story.tsx
+    └── test/
+        └── index.test.tsx
+```
+
+### Styling conventions
+
+- CSS Modules with `.module.scss` (matching existing package convention)
+- Use `--wp-components-*` custom properties and `_theme-variables.scss` for colors (not `--wpds-*`)
+- Use `when-dark-theme` mixin for dark mode per `packages/ui/AGENTS.md`
+- Use `clsx` for class merging
+- `forwardRef` on all components
+- `ComponentProps` for type extension
+
+---
+
+## Out of Scope (v1)
+
+| Idea | Rationale |
+|------|-----------|
+| Progress-only / non-interactive stepper | Different ARIA pattern; separate component |
+| `Stepper.Connector` component | CSS pseudo-elements are sufficient |
+| `Stepper.Actions` (Next/Back/Finish) | A `Stack` with buttons is sufficient |
+| Navigation stepper with links | Better served by a breadcrumb/progress nav component |
+| Responsive orientation switching | Consumer conditionally renders `VerticalStepper` or `HorizontalStepper` |
+| `animated` prop | CSS-only transitions are sufficient |
+| `sortOrder` prop | Registration order is the source of truth |

--- a/packages/components/src/tabs/index.tsx
+++ b/packages/components/src/tabs/index.tsx
@@ -51,12 +51,12 @@ export const Tabs = Object.assign(
 			selectOnMove,
 			orientation,
 			defaultSelectedId: externalToInternalTabId( defaultTabId, instanceId ),
-			setSelectedId: ( newSelectedId ) => {
+			setSelectedId: ( newSelectedId: string | null | undefined ) => {
 				onSelect?.( internalToExternalTabId( newSelectedId, instanceId ) );
 			},
 			selectedId: externalToInternalTabId( selectedTabId, instanceId ),
 			defaultActiveId: externalToInternalTabId( defaultActiveTabId, instanceId ),
-			setActiveId: ( newActiveId ) => {
+			setActiveId: ( newActiveId: string | null | undefined ) => {
 				onActiveTabIdChange?.( internalToExternalTabId( newActiveId, instanceId ) );
 			},
 			activeId: externalToInternalTabId( activeTabId, instanceId ),
@@ -70,7 +70,10 @@ export const Tabs = Object.assign(
 			requestAnimationFrame( () => {
 				const focusedElement = items?.[ 0 ]?.element?.ownerDocument.activeElement;
 
-				if ( ! focusedElement || ! items.some( ( item ) => focusedElement === item.element ) ) {
+				if (
+					! focusedElement ||
+					! items.some( ( item: { element?: Element | null } ) => focusedElement === item.element )
+				) {
 					return; // Return early if no tabs are focused.
 				}
 

--- a/packages/components/src/tabs/tablist.tsx
+++ b/packages/components/src/tabs/tablist.tsx
@@ -117,7 +117,7 @@ export const TabList = forwardRef<
 		<Ariakit.TabList
 			ref={ refs }
 			store={ store }
-			render={ ( props ) => (
+			render={ ( props: React.ComponentPropsWithRef< 'div' > ) => (
 				<div
 					{ ...props }
 					// Fallback to -1 to prevent browsers from making the tablist

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -40,6 +40,7 @@
 	],
 	"types": "dist",
 	"dependencies": {
+		"@ariakit/react": "^0.4.23",
 		"@wordpress/base-styles": "5.23.0",
 		"@wordpress/compose": "7.23.0",
 		"@wordpress/element": "^6.23.0",

--- a/packages/ui/src/horizontal-stepper/horizontal-stepper-step.tsx
+++ b/packages/ui/src/horizontal-stepper/horizontal-stepper-step.tsx
@@ -1,0 +1,32 @@
+import type { StepStatus } from '../stepper/types';
+import type { ReactNode } from 'react';
+
+/**
+ * Metadata carrier for a HorizontalStepper step.
+ *
+ * This component does not render anything itself. HorizontalStepper reads its
+ * props to build the tab list and panels.
+ */
+export interface HorizontalStepperStepProps {
+	value: string;
+	title: string;
+	description?: string;
+	status?: StepStatus;
+	optional?: boolean;
+	disabled?: boolean;
+	indicator?: ReactNode;
+	/** Keep panel mounted even when inactive. */
+	forceMount?: boolean;
+	/** Panel content. */
+	children: ReactNode;
+	className?: string;
+}
+
+/**
+ * Placeholder component used only to carry props. HorizontalStepper reads
+ * children of type HorizontalStepperStep and renders them into the correct
+ * tabs DOM structure.
+ */
+export const HorizontalStepperStep: React.FC< HorizontalStepperStepProps > = () => null;
+
+HorizontalStepperStep.displayName = 'HorizontalStepper.Step';

--- a/packages/ui/src/horizontal-stepper/horizontal-stepper.tsx
+++ b/packages/ui/src/horizontal-stepper/horizontal-stepper.tsx
@@ -1,0 +1,86 @@
+import { Children, forwardRef, isValidElement } from '@wordpress/element';
+import clsx from 'clsx';
+import { StepperDescription } from '../stepper/description';
+import { StepperIndicator } from '../stepper/indicator';
+import { StepperList } from '../stepper/list';
+import { StepperPanel } from '../stepper/panel';
+import { StepperRoot } from '../stepper/root';
+import { StepperStep } from '../stepper/step';
+import { StepperTitle } from '../stepper/title';
+import { StepperTrigger } from '../stepper/trigger';
+import { HorizontalStepperStep } from './horizontal-stepper-step';
+import styles from './style.module.scss';
+import type { HorizontalStepperStepProps } from './horizontal-stepper-step';
+import type { StepperProps, StepperRef } from '../stepper/types';
+
+export const HorizontalStepper = Object.assign(
+	forwardRef< StepperRef, StepperProps >( function HorizontalStepper(
+		{ children, className, ...props },
+		ref
+	) {
+		const steps = Children.toArray( children ).filter(
+			( child ): child is React.ReactElement< HorizontalStepperStepProps > =>
+				isValidElement( child ) &&
+				( child.type as { displayName?: string } ).displayName === 'HorizontalStepper.Step'
+		);
+
+		return (
+			<StepperRoot
+				{ ...props }
+				orientation="horizontal"
+				ref={ ref }
+				className={ clsx( styles.root, className ) }
+			>
+				{ /* Tab list: all triggers in a row. */ }
+				<StepperList className={ styles.list }>
+					{ steps.map( ( step ) => {
+						const {
+							value,
+							title,
+							description,
+							status,
+							optional,
+							disabled,
+							indicator,
+							className: stepClassName,
+						} = step.props;
+
+						return (
+							<StepperStep
+								key={ value }
+								value={ value }
+								status={ status }
+								optional={ optional }
+								disabled={ disabled }
+								className={ stepClassName }
+							>
+								<StepperTrigger>
+									{ indicator !== undefined ? (
+										<StepperIndicator>{ indicator }</StepperIndicator>
+									) : (
+										<StepperIndicator />
+									) }
+									<StepperTitle>{ title }</StepperTitle>
+									{ description && <StepperDescription>{ description }</StepperDescription> }
+								</StepperTrigger>
+							</StepperStep>
+						);
+					} ) }
+				</StepperList>
+
+				{ /* Panels rendered below the tab list. */ }
+				{ steps.map( ( step ) => {
+					const { value, forceMount, children: panelContent } = step.props;
+					return (
+						<StepperPanel key={ value } value={ value } forceMount={ forceMount }>
+							{ panelContent }
+						</StepperPanel>
+					);
+				} ) }
+			</StepperRoot>
+		);
+	} ),
+	{ Step: HorizontalStepperStep }
+);
+
+HorizontalStepper.displayName = 'HorizontalStepper';

--- a/packages/ui/src/horizontal-stepper/index.ts
+++ b/packages/ui/src/horizontal-stepper/index.ts
@@ -1,0 +1,3 @@
+export { HorizontalStepper } from './horizontal-stepper';
+export type { HorizontalStepperStepProps } from './horizontal-stepper-step';
+export type { StepperProps as HorizontalStepperProps } from '../stepper/types';

--- a/packages/ui/src/horizontal-stepper/stories/index.story.tsx
+++ b/packages/ui/src/horizontal-stepper/stories/index.story.tsx
@@ -1,0 +1,126 @@
+import { useState } from '@wordpress/element';
+import { HorizontalStepper } from '..';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta = {
+	title: 'Automattic UI/HorizontalStepper',
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+export const Default: Story = {
+	render: () => (
+		<HorizontalStepper defaultValue="shipping" aria-label="Checkout">
+			<HorizontalStepper.Step value="info" title="Purchase info" status="completed">
+				<p>Purchase info panel content</p>
+			</HorizontalStepper.Step>
+			<HorizontalStepper.Step value="shipping" title="Shipping details">
+				<p>Shipping details panel content</p>
+			</HorizontalStepper.Step>
+			<HorizontalStepper.Step value="review" title="Review">
+				<p>Review panel content</p>
+			</HorizontalStepper.Step>
+		</HorizontalStepper>
+	),
+};
+
+export const WithError: Story = {
+	render: () => (
+		<HorizontalStepper defaultValue="shipping" aria-label="Checkout with error">
+			<HorizontalStepper.Step value="info" title="Purchase info" status="completed">
+				<p>Purchase info panel</p>
+			</HorizontalStepper.Step>
+			<HorizontalStepper.Step value="shipping" title="Shipping details" status="error">
+				<p>Shipping details panel</p>
+			</HorizontalStepper.Step>
+			<HorizontalStepper.Step value="review" title="Review">
+				<p>Review panel</p>
+			</HorizontalStepper.Step>
+		</HorizontalStepper>
+	),
+};
+
+export const FiveSteps: Story = {
+	render: () => (
+		<HorizontalStepper defaultValue="shipping" aria-label="Multi-step checkout">
+			<HorizontalStepper.Step value="info" title="Purchase info" status="completed">
+				<p>Purchase info</p>
+			</HorizontalStepper.Step>
+			<HorizontalStepper.Step value="shipping" title="Shipping details">
+				<p>Shipping details</p>
+			</HorizontalStepper.Step>
+			<HorizontalStepper.Step value="review" title="Review">
+				<p>Review</p>
+			</HorizontalStepper.Step>
+			<HorizontalStepper.Step value="review2" title="Review again">
+				<p>Review again</p>
+			</HorizontalStepper.Step>
+			<HorizontalStepper.Step value="review3" title="Review once again">
+				<p>Review once again</p>
+			</HorizontalStepper.Step>
+		</HorizontalStepper>
+	),
+};
+
+function LinearFlowDemo() {
+	const [ step, setStep ] = useState( 'info' );
+	return (
+		<HorizontalStepper value={ step } onValueChange={ setStep } linear aria-label="Linear checkout">
+			<HorizontalStepper.Step value="info" title="Purchase info">
+				<div>
+					<p>Fill in purchase info.</p>
+					<button onClick={ () => setStep( 'shipping' ) }>Next</button>
+				</div>
+			</HorizontalStepper.Step>
+			<HorizontalStepper.Step
+				value="shipping"
+				title="Shipping details"
+				status={ step === 'review' ? 'completed' : undefined }
+			>
+				<div>
+					<p>Fill in shipping details.</p>
+					<button onClick={ () => setStep( 'review' ) }>Next</button>
+				</div>
+			</HorizontalStepper.Step>
+			<HorizontalStepper.Step value="review" title="Review">
+				<p>Review your order.</p>
+			</HorizontalStepper.Step>
+		</HorizontalStepper>
+	);
+}
+
+export const LinearFlow: Story = {
+	render: () => <LinearFlowDemo />,
+};
+
+export const WithDescription: Story = {
+	render: () => (
+		<HorizontalStepper defaultValue="shipping" aria-label="Checkout with descriptions">
+			<HorizontalStepper.Step
+				value="info"
+				title="Purchase info"
+				description="Provide purchase details"
+				status="completed"
+			>
+				<p>Purchase info panel</p>
+			</HorizontalStepper.Step>
+			<HorizontalStepper.Step
+				value="shipping"
+				title="Shipping details"
+				description="Provide shipping details"
+			>
+				<p>Shipping details panel</p>
+			</HorizontalStepper.Step>
+			<HorizontalStepper.Step
+				value="review"
+				title="Review"
+				description="Review before submitting"
+				optional
+			>
+				<p>Review panel</p>
+			</HorizontalStepper.Step>
+		</HorizontalStepper>
+	),
+};

--- a/packages/ui/src/horizontal-stepper/style.module.scss
+++ b/packages/ui/src/horizontal-stepper/style.module.scss
@@ -1,0 +1,9 @@
+@use '@wordpress/base-styles/variables';
+
+.root {
+	// Tier 1 horizontal root — inherits shared stepper styles.
+}
+
+.list {
+	// Inherits shared list styles.
+}

--- a/packages/ui/src/horizontal-stepper/test/index.tsx
+++ b/packages/ui/src/horizontal-stepper/test/index.tsx
@@ -1,0 +1,127 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { HorizontalStepper } from '..';
+
+function ThreeSteps( {
+	value,
+	onValueChange,
+	linear = false,
+}: {
+	value?: string;
+	onValueChange?: ( v: string ) => void;
+	linear?: boolean;
+} ) {
+	return (
+		<HorizontalStepper
+			aria-label="Test stepper"
+			value={ value }
+			onValueChange={ onValueChange }
+			linear={ linear }
+		>
+			<HorizontalStepper.Step value="a" title="Step A" status="completed">
+				Panel A
+			</HorizontalStepper.Step>
+			<HorizontalStepper.Step value="b" title="Step B">
+				Panel B
+			</HorizontalStepper.Step>
+			<HorizontalStepper.Step value="c" title="Step C">
+				Panel C
+			</HorizontalStepper.Step>
+		</HorizontalStepper>
+	);
+}
+
+describe( 'HorizontalStepper', () => {
+	it( 'renders step titles', async () => {
+		render( <ThreeSteps value="b" /> );
+		await waitFor( () => {
+			expect( screen.getByText( 'Step A' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Step B' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Step C' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'shows the active panel only', async () => {
+		render( <ThreeSteps value="b" /> );
+		await waitFor( () => {
+			expect( screen.getByText( 'Panel B' ) ).toBeInTheDocument();
+		} );
+		expect( screen.queryByText( 'Panel A' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Panel C' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'marks the current step trigger with aria-current="step"', async () => {
+		render( <ThreeSteps value="b" /> );
+		await waitFor( () => {
+			const trigger = screen.getByRole( 'tab', { name: /Step B/i } );
+			expect( trigger ).toHaveAttribute( 'aria-current', 'step' );
+		} );
+	} );
+
+	it( 'calls onValueChange when a tab is clicked', async () => {
+		const user = userEvent.setup();
+		const onValueChange = jest.fn();
+		render( <ThreeSteps value="b" onValueChange={ onValueChange } /> );
+		await waitFor( () => screen.getByRole( 'tab', { name: /Step A/i } ) );
+		await user.click( screen.getByRole( 'tab', { name: /Step A/i } ) );
+		expect( onValueChange ).toHaveBeenCalledWith( 'a' );
+	} );
+
+	it( 'works uncontrolled with defaultValue', async () => {
+		render(
+			<HorizontalStepper aria-label="Uncontrolled" defaultValue="a">
+				<HorizontalStepper.Step value="a" title="A">
+					Panel A
+				</HorizontalStepper.Step>
+				<HorizontalStepper.Step value="b" title="B">
+					Panel B
+				</HorizontalStepper.Step>
+			</HorizontalStepper>
+		);
+		await waitFor( () => {
+			expect( screen.getByText( 'Panel A' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'marks a completed step with data-status="completed"', async () => {
+		render( <ThreeSteps value="b" /> );
+		await waitFor( () => screen.getByRole( 'tab', { name: /Step A/i } ) );
+		// The step container (parent of the trigger) carries data-status.
+		const trigger = screen.getByRole( 'tab', { name: /Step A/i } );
+		const stepContainer = trigger.closest( '[data-status]' );
+		expect( stepContainer ).toHaveAttribute( 'data-status', 'completed' );
+	} );
+
+	describe( 'linear mode', () => {
+		it( 'marks future steps as aria-disabled', async () => {
+			render( <ThreeSteps value="a" linear /> );
+			await waitFor( () => screen.getByRole( 'tab', { name: /Step C/i } ) );
+			const futureTab = screen.getByRole( 'tab', { name: /Step C/i } );
+			expect( futureTab ).toHaveAttribute( 'aria-disabled', 'true' );
+		} );
+
+		it( 'does not fire onValueChange for a disabled future step', async () => {
+			const user = userEvent.setup();
+			const onValueChange = jest.fn();
+			render( <ThreeSteps value="a" onValueChange={ onValueChange } linear /> );
+			await waitFor( () => screen.getByRole( 'tab', { name: /Step C/i } ) );
+			await user.click( screen.getByRole( 'tab', { name: /Step C/i } ) );
+			expect( onValueChange ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	it( 'includes accessible step label in indicator', async () => {
+		render( <ThreeSteps value="b" /> );
+		await waitFor( () => {
+			// Screen-reader text like "Step 2 of 3" should be in the document.
+			expect( screen.getByText( /Step 2 of 3/i ) ).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'renders a tablist', async () => {
+		render( <ThreeSteps value="b" /> );
+		await waitFor( () => {
+			expect( screen.getByRole( 'tablist' ) ).toBeInTheDocument();
+		} );
+	} );
+} );

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,2 +1,19 @@
 export { Badge } from './badge';
 export { DateCalendar, DateRangeCalendar, TZDate } from './calendar';
+export { HorizontalStepper } from './horizontal-stepper';
+export { VerticalStepper } from './vertical-stepper';
+export { Stepper } from './stepper';
+export type {
+	StepperRef,
+	StepStatus,
+	StepperRootProps,
+	StepperListProps,
+	StepperStepProps,
+	StepperTriggerProps,
+	StepperPanelProps,
+	StepperIndicatorProps,
+	StepperTitleProps,
+	StepperDescriptionProps,
+} from './stepper';
+export type { HorizontalStepperProps, HorizontalStepperStepProps } from './horizontal-stepper';
+export type { VerticalStepperProps, VerticalStepperStepProps } from './vertical-stepper';

--- a/packages/ui/src/stepper/context.tsx
+++ b/packages/ui/src/stepper/context.tsx
@@ -1,0 +1,81 @@
+import { createContext, useCallback, useContext, useReducer } from '@wordpress/element';
+import type { StepContextValue, StepMeta, StepStatus, StepperContextValue } from './types';
+
+// ─── Stepper root context ────────────────────────────────────────────────────
+
+export const StepperContext = createContext< StepperContextValue | null >( null );
+
+export function useStepperContext(): StepperContextValue {
+	const ctx = useContext( StepperContext );
+	if ( ! ctx ) {
+		throw new Error( 'Stepper components must be rendered inside Stepper.Root.' );
+	}
+	return ctx;
+}
+
+// ─── Per-step context ────────────────────────────────────────────────────────
+
+export const StepContext = createContext< StepContextValue | null >( null );
+
+export function useStepContext(): StepContextValue {
+	const ctx = useContext( StepContext );
+	if ( ! ctx ) {
+		throw new Error( 'Stepper sub-components must be rendered inside Stepper.Step.' );
+	}
+	return ctx;
+}
+
+// ─── Step registration reducer ───────────────────────────────────────────────
+
+type RegisterAction = { type: 'register'; meta: Omit< StepMeta, 'index' > };
+type UnregisterAction = { type: 'unregister'; value: string };
+type UpdateAction = { type: 'update'; meta: Omit< StepMeta, 'index' > };
+
+type StepsAction = RegisterAction | UnregisterAction | UpdateAction;
+
+function stepsReducer( state: StepMeta[], action: StepsAction ): StepMeta[] {
+	switch ( action.type ) {
+		case 'register': {
+			if ( state.some( ( s ) => s.value === action.meta.value ) ) {
+				// Already registered (e.g. Strict Mode double-mount); skip.
+				return state;
+			}
+			return [ ...state, { ...action.meta, index: state.length } ];
+		}
+		case 'unregister': {
+			const next = state.filter( ( s ) => s.value !== action.value );
+			return next.map( ( s, i ) => ( { ...s, index: i } ) );
+		}
+		case 'update': {
+			return state.map( ( s ) => ( s.value === action.meta.value ? { ...s, ...action.meta } : s ) );
+		}
+	}
+}
+
+/** Returns a stable registerStep function and the current ordered steps array. */
+export function useStepRegistry(): {
+	steps: StepMeta[];
+	registerStep: ( meta: Omit< StepMeta, 'index' > ) => () => void;
+} {
+	const [ steps, dispatch ] = useReducer( stepsReducer, [] );
+
+	const registerStep = useCallback( ( meta: Omit< StepMeta, 'index' > ): ( () => void ) => {
+		dispatch( { type: 'register', meta } );
+		return () => dispatch( { type: 'unregister', value: meta.value } );
+	}, [] );
+
+	return { steps, registerStep };
+}
+
+// ─── Default formatStepLabel ─────────────────────────────────────────────────
+
+export function defaultFormatStepLabel( step: number, total: number, status?: StepStatus ): string {
+	let label = `Step ${ step } of ${ total }`;
+	if ( status === 'completed' ) {
+		label += ', completed';
+	}
+	if ( status === 'error' ) {
+		label += ', error';
+	}
+	return label;
+}

--- a/packages/ui/src/stepper/description.tsx
+++ b/packages/ui/src/stepper/description.tsx
@@ -1,0 +1,13 @@
+import clsx from 'clsx';
+import styles from './style.module.scss';
+import type { StepperDescriptionProps } from './types';
+
+export function StepperDescription( { children, className, ...props }: StepperDescriptionProps ) {
+	return (
+		<span className={ clsx( styles.description, className ) } { ...props }>
+			{ children }
+		</span>
+	);
+}
+
+StepperDescription.displayName = 'Stepper.Description';

--- a/packages/ui/src/stepper/index.ts
+++ b/packages/ui/src/stepper/index.ts
@@ -1,0 +1,41 @@
+import { StepperDescription } from './description';
+import { StepperIndicator } from './indicator';
+import { StepperList } from './list';
+import { StepperPanel } from './panel';
+import { StepperRoot } from './root';
+import { StepperStep } from './step';
+import { StepperTitle } from './title';
+import { StepperTrigger } from './trigger';
+
+export { StepperDescription } from './description';
+export { StepperIndicator } from './indicator';
+export { StepperList } from './list';
+export { StepperPanel } from './panel';
+export { StepperRoot } from './root';
+export { StepperStep } from './step';
+export { StepperTitle } from './title';
+export { StepperTrigger } from './trigger';
+export type {
+	StepperDescriptionProps,
+	StepperIndicatorProps,
+	StepperListProps,
+	StepperPanelProps,
+	StepperRef,
+	StepperRootProps,
+	StepperStepProps,
+	StepperTitleProps,
+	StepperTriggerProps,
+	StepStatus,
+} from './types';
+
+/** Namespace object for Tier 2 primitive usage: `<Stepper.Root>`, `<Stepper.Step>`, etc. */
+export const Stepper = {
+	Root: StepperRoot,
+	List: StepperList,
+	Step: StepperStep,
+	Trigger: StepperTrigger,
+	Panel: StepperPanel,
+	Indicator: StepperIndicator,
+	Title: StepperTitle,
+	Description: StepperDescription,
+} as const;

--- a/packages/ui/src/stepper/indicator.tsx
+++ b/packages/ui/src/stepper/indicator.tsx
@@ -1,0 +1,53 @@
+import { check, error } from '@wordpress/icons';
+import clsx from 'clsx';
+import { Icon } from '../icon';
+import { useStepContext, useStepperContext } from './context';
+import styles from './style.module.scss';
+import type { StepperIndicatorProps } from './types';
+
+export function StepperIndicator( { children, className }: StepperIndicatorProps ) {
+	const { formatStepLabel } = useStepperContext();
+	const { index, totalSteps, isCurrent, status } = useStepContext();
+
+	// 1-based step number for display and accessible label.
+	const stepNumber = index + 1;
+	const accessibleLabel = formatStepLabel( stepNumber, totalSteps, status );
+
+	const hasCustomContent = children !== undefined;
+
+	let defaultContent: React.ReactNode;
+	if ( status === 'completed' ) {
+		defaultContent = <Icon icon={ check } size={ 16 } />;
+	} else if ( status === 'error' ) {
+		defaultContent = <Icon icon={ error } size={ 16 } />;
+	} else {
+		defaultContent = stepNumber;
+	}
+
+	return (
+		<span
+			className={ clsx(
+				styles.indicator,
+				{
+					[ styles[ 'indicator--current' ] ]: isCurrent,
+					[ styles[ 'indicator--completed' ] ]: status === 'completed',
+					[ styles[ 'indicator--error' ] ]: status === 'error',
+				},
+				className
+			) }
+		>
+			{ /* Visually-hidden accessible label — always present. */ }
+			<span className={ styles[ 'indicator__sr-label' ] }>{ accessibleLabel }</span>
+
+			{ hasCustomContent ? (
+				<span aria-hidden="true">{ children }</span>
+			) : (
+				<span aria-hidden="true" className={ styles[ 'indicator__visual' ] }>
+					{ defaultContent }
+				</span>
+			) }
+		</span>
+	);
+}
+
+StepperIndicator.displayName = 'Stepper.Indicator';

--- a/packages/ui/src/stepper/list.tsx
+++ b/packages/ui/src/stepper/list.tsx
@@ -1,0 +1,18 @@
+import { TabList } from '@ariakit/react/tab';
+import clsx from 'clsx';
+import { useStepperContext } from './context';
+import styles from './style.module.scss';
+import type { StepperListProps } from './types';
+
+export function StepperList( { children, className }: StepperListProps ) {
+	const { orientation } = useStepperContext();
+
+	if ( orientation === 'vertical' ) {
+		// eslint-disable-next-line no-console
+		console.warn( '[Stepper] Stepper.List is only used in horizontal mode. It will be ignored.' );
+	}
+
+	return <TabList className={ clsx( styles.list, className ) }>{ children }</TabList>;
+}
+
+StepperList.displayName = 'Stepper.List';

--- a/packages/ui/src/stepper/panel.tsx
+++ b/packages/ui/src/stepper/panel.tsx
@@ -1,0 +1,82 @@
+import { DisclosureContent } from '@ariakit/react/disclosure';
+import { TabPanel } from '@ariakit/react/tab';
+import clsx from 'clsx';
+import { useStepContext, useStepperContext } from './context';
+import styles from './style.module.scss';
+import { stepPanelId, stepTriggerId } from './types';
+import type { StepperPanelProps } from './types';
+
+// ─── Vertical panel (always inside Stepper.Step) ─────────────────────────────
+
+function VerticalPanel( {
+	forceMount,
+	children,
+	className,
+	...props
+}: Omit< StepperPanelProps, 'value' > ) {
+	const { rootId } = useStepperContext();
+	const { value, totalSteps } = useStepContext();
+
+	const triggerId = stepTriggerId( rootId, value );
+	const panelId = stepPanelId( rootId, value );
+	const useRegion = totalSteps <= 5;
+
+	return (
+		<DisclosureContent
+			{ ...props }
+			id={ panelId }
+			role={ useRegion ? 'region' : undefined }
+			aria-labelledby={ useRegion ? triggerId : undefined }
+			className={ clsx( styles.panel, styles[ 'panel--vertical' ], className ) }
+		>
+			{ children }
+		</DisclosureContent>
+	);
+}
+
+// ─── Horizontal panel (outside Stepper.Step, must have value prop) ────────────
+
+function HorizontalPanel( {
+	value: valueProp,
+	forceMount = false,
+	children,
+	className,
+	...props
+}: StepperPanelProps ) {
+	const { rootId } = useStepperContext();
+
+	if ( ! valueProp ) {
+		// eslint-disable-next-line no-console
+		console.warn(
+			"[Stepper] Stepper.Panel requires a 'value' prop in horizontal mode to associate it with a step."
+		);
+	}
+
+	const triggerId = valueProp ? stepTriggerId( rootId, valueProp ) : undefined;
+	const panelId = valueProp ? stepPanelId( rootId, valueProp ) : undefined;
+
+	return (
+		<TabPanel
+			{ ...props }
+			id={ panelId }
+			tabId={ triggerId }
+			unmountOnHide={ ! forceMount }
+			className={ clsx( styles.panel, styles[ 'panel--horizontal' ], className ) }
+		>
+			{ children }
+		</TabPanel>
+	);
+}
+
+// ─── Public export ────────────────────────────────────────────────────────────
+
+export function StepperPanel( props: StepperPanelProps ) {
+	const { orientation } = useStepperContext();
+
+	if ( orientation === 'vertical' ) {
+		return <VerticalPanel { ...props } />;
+	}
+	return <HorizontalPanel { ...props } />;
+}
+
+StepperPanel.displayName = 'Stepper.Panel';

--- a/packages/ui/src/stepper/root.tsx
+++ b/packages/ui/src/stepper/root.tsx
@@ -88,7 +88,7 @@ export const StepperRoot = forwardRef< StepperRef, StepperRootProps >( function 
 			{ orientation === 'horizontal' ? (
 				<TabProvider
 					selectedId={ activeTriggerId }
-					setSelectedId={ ( id ) => {
+					setSelectedId={ ( id: string | null | undefined ) => {
 						if ( ! id ) {
 							return;
 						}

--- a/packages/ui/src/stepper/root.tsx
+++ b/packages/ui/src/stepper/root.tsx
@@ -1,0 +1,111 @@
+import { TabProvider } from '@ariakit/react/tab';
+import {
+	forwardRef,
+	useCallback,
+	useId,
+	useImperativeHandle,
+	useRef,
+	useState,
+} from '@wordpress/element';
+import clsx from 'clsx';
+import { StepperContext, defaultFormatStepLabel, useStepRegistry } from './context';
+import styles from './style.module.scss';
+import { stepTriggerId } from './types';
+import type { StepperRef, StepperRootProps } from './types';
+
+export const StepperRoot = forwardRef< StepperRef, StepperRootProps >( function StepperRoot(
+	{
+		orientation,
+		value: controlledValue,
+		defaultValue,
+		onValueChange,
+		linear = false,
+		headingLevel = 3,
+		activationMode = 'manual',
+		formatStepLabel = defaultFormatStepLabel,
+		children,
+		className,
+		...ariaProps
+	},
+	ref
+) {
+	const rootId = useId();
+	const isControlled = controlledValue !== undefined;
+	const [ uncontrolledValue, setUncontrolledValue ] = useState< string >( defaultValue ?? '' );
+
+	const activeValue = isControlled ? ( controlledValue as string ) : uncontrolledValue;
+
+	const triggerElementsRef = useRef< Map< string, HTMLElement > >( new Map() );
+
+	const handleValueChange = useCallback(
+		( newValue: string ) => {
+			if ( ! isControlled ) {
+				setUncontrolledValue( newValue );
+			}
+			onValueChange?.( newValue );
+		},
+		[ isControlled, onValueChange ]
+	);
+
+	const { steps, registerStep } = useStepRegistry();
+
+	useImperativeHandle( ref, () => ( {
+		focusStep( value: string ) {
+			triggerElementsRef.current.get( value )?.focus();
+		},
+	} ) );
+
+	const contextValue = {
+		rootId,
+		value: activeValue,
+		onValueChange: handleValueChange,
+		orientation,
+		linear,
+		headingLevel,
+		activationMode,
+		formatStepLabel,
+		steps,
+		registerStep,
+	};
+
+	const rootEl = (
+		<div
+			className={ clsx( styles.root, styles[ `is-${ orientation }` ], className ) }
+			data-orientation={ orientation }
+			{ ...ariaProps }
+		>
+			{ children }
+		</div>
+	);
+
+	// Ariakit Tab uses the Tab component's `id` as the selectedId, which we
+	// set to stepTriggerId(rootId, value). Map back and forth here.
+	const activeTriggerId = activeValue ? stepTriggerId( rootId, activeValue ) : null;
+	const triggerPrefix = `stepper-${ rootId }-trigger-`;
+
+	return (
+		<StepperContext.Provider value={ contextValue }>
+			{ orientation === 'horizontal' ? (
+				<TabProvider
+					selectedId={ activeTriggerId }
+					setSelectedId={ ( id ) => {
+						if ( ! id ) {
+							return;
+						}
+						const stepValue = id.startsWith( triggerPrefix )
+							? id.slice( triggerPrefix.length )
+							: id;
+						handleValueChange( stepValue );
+					} }
+					selectOnMove={ activationMode === 'auto' }
+				>
+					{ rootEl }
+				</TabProvider>
+			) : (
+				rootEl
+			) }
+		</StepperContext.Provider>
+	);
+} );
+
+StepperRoot.displayName = 'Stepper.Root';

--- a/packages/ui/src/stepper/step.tsx
+++ b/packages/ui/src/stepper/step.tsx
@@ -70,7 +70,7 @@ export function StepperStep( {
 		return (
 			<DisclosureProvider
 				open={ isCurrent }
-				setOpen={ ( open ) => {
+				setOpen={ ( open: boolean ) => {
 					if ( open && ! isDisabled ) {
 						onValueChange( value );
 					}

--- a/packages/ui/src/stepper/step.tsx
+++ b/packages/ui/src/stepper/step.tsx
@@ -1,0 +1,88 @@
+import { DisclosureProvider } from '@ariakit/react/disclosure';
+import { useEffect } from '@wordpress/element';
+import clsx from 'clsx';
+import { StepContext, useStepperContext } from './context';
+import styles from './style.module.scss';
+import type { StepContextValue, StepperStepProps } from './types';
+
+export function StepperStep( {
+	value,
+	status,
+	optional = false,
+	disabled = false,
+	children,
+	className,
+}: StepperStepProps ) {
+	const {
+		orientation,
+		value: activeValue,
+		onValueChange,
+		linear,
+		steps,
+		registerStep,
+	} = useStepperContext();
+
+	// Register this step with the root on mount.
+	useEffect( () => {
+		return registerStep( { value, status, disabled, optional } );
+		// Re-register only if the value identity changes (dynamic steps).
+		// status/disabled/optional changes are read directly from props at render time
+		// and reflected in stepContext below.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ value ] );
+
+	const stepMeta = steps.find( ( s ) => s.value === value );
+	const index = stepMeta?.index ?? 0;
+	const totalSteps = steps.length;
+	const isCurrent = activeValue === value;
+
+	const activeIndex = steps.findIndex( ( s ) => s.value === activeValue );
+	const isLinearBlocked = linear && ! isCurrent && status !== 'completed' && index > activeIndex;
+	const isDisabled = disabled || isLinearBlocked;
+
+	const stepContext: StepContextValue = {
+		value,
+		index,
+		totalSteps,
+		isCurrent,
+		status,
+		isDisabled,
+		optional,
+	};
+
+	const dataAttrs = {
+		'data-current': isCurrent ? '' : undefined,
+		'data-status': status,
+		'data-disabled': isDisabled ? '' : undefined,
+		'data-optional': optional ? '' : undefined,
+	};
+
+	const stepEl = (
+		<StepContext.Provider value={ stepContext }>
+			<div className={ clsx( styles.step, className ) } { ...dataAttrs }>
+				{ children }
+			</div>
+		</StepContext.Provider>
+	);
+
+	// Vertical: each step owns a DisclosureProvider to manage expand/collapse.
+	if ( orientation === 'vertical' ) {
+		return (
+			<DisclosureProvider
+				open={ isCurrent }
+				setOpen={ ( open ) => {
+					if ( open && ! isDisabled ) {
+						onValueChange( value );
+					}
+				} }
+			>
+				{ stepEl }
+			</DisclosureProvider>
+		);
+	}
+
+	// Horizontal: step context only; the TabProvider in Root manages tab state.
+	return stepEl;
+}
+
+StepperStep.displayName = 'Stepper.Step';

--- a/packages/ui/src/stepper/style.module.scss
+++ b/packages/ui/src/stepper/style.module.scss
@@ -2,6 +2,7 @@
 @use '@wordpress/base-styles/mixins';
 @use '@wordpress/base-styles/variables';
 @use 'calypso/assets/stylesheets/shared/mixins/dark-theme' as ui-mixins;
+@use 'calypso/assets/stylesheets/shared/mixins/hide-content-accessibly' as a11y-mixins;
 @use '../utils/_theme-variables' as theme;
 
 // ─── Design tokens ────────────────────────────────────────────────────────────
@@ -228,7 +229,7 @@ $stepper-step-gap: variables.$grid-unit-20;
 }
 
 .indicator__sr-label {
-	@include mixins.visually-hidden;
+	@include a11y-mixins.hide-content-accessibly;
 }
 
 .indicator__visual {

--- a/packages/ui/src/stepper/style.module.scss
+++ b/packages/ui/src/stepper/style.module.scss
@@ -124,7 +124,7 @@ $stepper-step-gap: variables.$grid-unit-20;
 	color: theme.$components-color-foreground;
 	font-size: variables.$default-font-size;
 	font-weight: 400;
-	line-height: variables.$font-line-height-body;
+	line-height: variables.$font-line-height-medium;
 	transition: color 0.15s ease;
 
 	.is-horizontal .list & {
@@ -240,7 +240,7 @@ $stepper-step-gap: variables.$grid-unit-20;
 .title {
 	font-size: variables.$default-font-size;
 	font-weight: 400;
-	line-height: variables.$font-line-height-body;
+	line-height: variables.$font-line-height-medium;
 	color: theme.$components-color-foreground;
 
 	[ data-current ] & {

--- a/packages/ui/src/stepper/style.module.scss
+++ b/packages/ui/src/stepper/style.module.scss
@@ -1,0 +1,273 @@
+@use '@wordpress/base-styles/colors';
+@use '@wordpress/base-styles/mixins';
+@use '@wordpress/base-styles/variables';
+@use 'calypso/assets/stylesheets/shared/mixins/dark-theme' as ui-mixins;
+@use '../utils/_theme-variables' as theme;
+
+// ─── Design tokens ────────────────────────────────────────────────────────────
+
+$stepper-indicator-size: 24px;
+$stepper-indicator-border-width: 1.5px;
+$stepper-connector-thickness: 1px;
+$stepper-connector-gap: variables.$grid-unit-10;
+$stepper-step-gap: variables.$grid-unit-20;
+
+// ─── Root ─────────────────────────────────────────────────────────────────────
+
+.root {
+	display: flex;
+
+	&.is-vertical {
+		flex-direction: column;
+		gap: 0;
+	}
+
+	&.is-horizontal {
+		flex-direction: column;
+	}
+}
+
+// ─── List (horizontal tablist wrapper) ───────────────────────────────────────
+
+.list {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: 0;
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+// ─── Step ─────────────────────────────────────────────────────────────────────
+
+.step {
+	position: relative;
+	display: flex;
+
+	.is-vertical & {
+		flex-direction: column;
+	}
+
+	.is-horizontal .list & {
+		flex: 1;
+		flex-direction: row;
+		align-items: center;
+		justify-content: center;
+	}
+}
+
+// Connector line after each step (except last).
+.step:not( :last-child ) {
+	.is-vertical & {
+		&::after {
+			content: '';
+			position: absolute;
+			inset-inline-start: calc( #{ $stepper-indicator-size } / 2 - #{ $stepper-connector-thickness } / 2 );
+			top: $stepper-indicator-size;
+			bottom: 0;
+			width: $stepper-connector-thickness;
+			background: theme.$components-color-border;
+			pointer-events: none;
+		}
+
+		&[ data-status='completed' ]::after {
+			background: colors.$alert-green;
+		}
+
+		&[ data-status='error' ]::after {
+			background: colors.$alert-red;
+		}
+	}
+
+	.is-horizontal .list & {
+		&::after {
+			content: '';
+			position: absolute;
+			top: calc( #{ $stepper-indicator-size } / 2 - #{ $stepper-connector-thickness } / 2 );
+			// Span from this step's indicator edge to the next step's indicator edge.
+			inset-inline-start: calc( 50% + #{ $stepper-indicator-size } / 2 + #{ $stepper-connector-gap } );
+			inset-inline-end: calc( -50% + #{ $stepper-indicator-size } / 2 + #{ $stepper-connector-gap } );
+			height: $stepper-connector-thickness;
+			background: theme.$components-color-border;
+			pointer-events: none;
+		}
+
+		&[ data-status='completed' ]::after {
+			background: colors.$alert-green;
+		}
+	}
+}
+
+// ─── Trigger heading wrapper (vertical only) ──────────────────────────────────
+
+.trigger-heading {
+	margin: 0;
+	font-size: inherit;
+	font-weight: inherit;
+	line-height: inherit;
+}
+
+// ─── Trigger button ───────────────────────────────────────────────────────────
+
+.trigger {
+	@include mixins.reset;
+
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: variables.$grid-unit-10;
+	cursor: pointer;
+	text-align: start;
+	width: 100%;
+	padding: variables.$grid-unit-10 0;
+	color: theme.$components-color-foreground;
+	font-size: variables.$default-font-size;
+	font-weight: 400;
+	line-height: variables.$font-line-height-body;
+	transition: color 0.15s ease;
+
+	.is-horizontal .list & {
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: variables.$grid-unit-05;
+		padding: variables.$grid-unit-10 variables.$grid-unit-20;
+	}
+
+	&[ aria-disabled='true' ] {
+		cursor: default;
+		color: theme.$components-color-disabled;
+	}
+
+	// Hide labels on small screens (horizontal only).
+	@media ( max-width: 600px ) {
+		.is-horizontal .list & {
+			.title,
+			.description {
+				display: none;
+			}
+		}
+	}
+}
+
+// ─── Panel ────────────────────────────────────────────────────────────────────
+
+.panel {
+	&--vertical {
+		// Collapse animation via grid-template-rows trick.
+		display: grid;
+		grid-template-rows: 0fr;
+		overflow: hidden;
+		transition: grid-template-rows 0.2s ease;
+
+		// Ariakit adds data-open when disclosure is open.
+		&[ data-open ] {
+			grid-template-rows: 1fr;
+		}
+
+		> * {
+			overflow: hidden;
+			padding-inline-start: calc( #{ $stepper-indicator-size } + #{ variables.$grid-unit-10 } );
+			padding-block-end: variables.$grid-unit-20;
+		}
+
+		@media ( prefers-reduced-motion: reduce ) {
+			transition: none;
+		}
+	}
+
+	&--horizontal {
+		margin-block-start: variables.$grid-unit-20;
+	}
+}
+
+// ─── Indicator ────────────────────────────────────────────────────────────────
+
+.indicator {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex-shrink: 0;
+	width: $stepper-indicator-size;
+	height: $stepper-indicator-size;
+	border-radius: 50%;
+	border: $stepper-indicator-border-width solid theme.$components-color-border;
+	background: transparent;
+	color: theme.$components-color-foreground;
+	font-size: variables.$font-size-small;
+	font-weight: 500;
+	line-height: 1;
+
+	&--current {
+		background: theme.$components-color-foreground;
+		border-color: theme.$components-color-foreground;
+		color: theme.$components-color-background;
+	}
+
+	&--completed {
+		border-color: colors.$alert-green;
+		color: colors.$alert-green;
+	}
+
+	&--error {
+		border-color: colors.$alert-red;
+		color: colors.$alert-red;
+	}
+
+	@include ui-mixins.when-dark-theme {
+		border-color: theme.$components-color-gray-600;
+		color: theme.$components-color-foreground;
+
+		&--current {
+			background: theme.$components-color-foreground;
+			border-color: theme.$components-color-foreground;
+			color: theme.$components-color-background;
+		}
+	}
+}
+
+.indicator__sr-label {
+	@include mixins.visually-hidden;
+}
+
+.indicator__visual {
+	display: contents;
+}
+
+// ─── Title ────────────────────────────────────────────────────────────────────
+
+.title {
+	font-size: variables.$default-font-size;
+	font-weight: 400;
+	line-height: variables.$font-line-height-body;
+	color: theme.$components-color-foreground;
+
+	[ data-current ] & {
+		font-weight: 600;
+	}
+
+	[ data-disabled ] & {
+		color: theme.$components-color-disabled;
+	}
+}
+
+// ─── Description ─────────────────────────────────────────────────────────────
+
+.description {
+	display: block;
+	font-size: variables.$font-size-small;
+	color: theme.$components-color-gray-600;
+	line-height: variables.$font-line-height-small;
+
+	[ data-disabled ] & {
+		color: theme.$components-color-gray-600;
+	}
+
+	// Hide on small screens in horizontal mode.
+	@media ( max-width: 600px ) {
+		.is-horizontal .list & {
+			display: none;
+		}
+	}
+}

--- a/packages/ui/src/stepper/title.tsx
+++ b/packages/ui/src/stepper/title.tsx
@@ -1,0 +1,13 @@
+import clsx from 'clsx';
+import styles from './style.module.scss';
+import type { StepperTitleProps } from './types';
+
+export function StepperTitle( { children, className, ...props }: StepperTitleProps ) {
+	return (
+		<span className={ clsx( styles.title, className ) } { ...props }>
+			{ children }
+		</span>
+	);
+}
+
+StepperTitle.displayName = 'Stepper.Title';

--- a/packages/ui/src/stepper/trigger.tsx
+++ b/packages/ui/src/stepper/trigger.tsx
@@ -6,6 +6,7 @@ import { useStepContext, useStepperContext } from './context';
 import styles from './style.module.scss';
 import { stepPanelId, stepTriggerId } from './types';
 import type { StepperTriggerProps } from './types';
+import type { ComponentPropsWithRef } from 'react';
 
 export function StepperTrigger( { children, className, ...props }: StepperTriggerProps ) {
 	const { orientation, headingLevel, rootId } = useStepperContext();
@@ -30,7 +31,7 @@ export function StepperTrigger( { children, className, ...props }: StepperTrigge
 				{ ...sharedAttrs }
 				{ ...props }
 				aria-controls={ panelId }
-				render={ ( p ) => (
+				render={ ( p: ComponentPropsWithRef< 'button' > ) => (
 					<button
 						{ ...p }
 						aria-disabled={ isDisabled ? true : undefined }
@@ -50,7 +51,7 @@ export function StepperTrigger( { children, className, ...props }: StepperTrigge
 			{ ...props }
 			id={ triggerId }
 			aria-controls={ panelId }
-			render={ ( p ) => (
+			render={ ( p: ComponentPropsWithRef< 'button' > ) => (
 				<button
 					{ ...p }
 					aria-disabled={ isDisabled ? true : undefined }

--- a/packages/ui/src/stepper/trigger.tsx
+++ b/packages/ui/src/stepper/trigger.tsx
@@ -1,0 +1,66 @@
+import { Disclosure } from '@ariakit/react/disclosure';
+import { Tab } from '@ariakit/react/tab';
+import { createElement } from '@wordpress/element';
+import clsx from 'clsx';
+import { useStepContext, useStepperContext } from './context';
+import styles from './style.module.scss';
+import { stepPanelId, stepTriggerId } from './types';
+import type { StepperTriggerProps } from './types';
+
+export function StepperTrigger( { children, className, ...props }: StepperTriggerProps ) {
+	const { orientation, headingLevel, rootId } = useStepperContext();
+	const { value, isCurrent, isDisabled } = useStepContext();
+
+	const triggerId = stepTriggerId( rootId, value );
+	const panelId = stepPanelId( rootId, value );
+
+	const sharedAttrs = {
+		id: triggerId,
+		className: clsx( styles.trigger, className ),
+		'aria-current': isCurrent ? ( 'step' as const ) : undefined,
+	};
+
+	if ( orientation === 'vertical' ) {
+		const HeadingTag = `h${ headingLevel }` as 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+
+		return createElement(
+			HeadingTag,
+			{ className: styles[ 'trigger-heading' ] },
+			<Disclosure
+				{ ...sharedAttrs }
+				{ ...props }
+				aria-controls={ panelId }
+				render={ ( p ) => (
+					<button
+						{ ...p }
+						aria-disabled={ isDisabled ? true : undefined }
+						onClick={ isDisabled ? ( e ) => e.preventDefault() : p.onClick }
+					/>
+				) }
+			>
+				{ children }
+			</Disclosure>
+		);
+	}
+
+	// Horizontal: Tab from Ariakit handles role="tab", aria-selected, keyboard nav.
+	return (
+		<Tab
+			{ ...sharedAttrs }
+			{ ...props }
+			id={ triggerId }
+			aria-controls={ panelId }
+			render={ ( p ) => (
+				<button
+					{ ...p }
+					aria-disabled={ isDisabled ? true : undefined }
+					onClick={ isDisabled ? ( e ) => e.preventDefault() : p.onClick }
+				/>
+			) }
+		>
+			{ children }
+		</Tab>
+	);
+}
+
+StepperTrigger.displayName = 'Stepper.Trigger';

--- a/packages/ui/src/stepper/types.ts
+++ b/packages/ui/src/stepper/types.ts
@@ -1,0 +1,149 @@
+import type { ReactNode, Ref } from 'react';
+
+export type StepStatus = 'completed' | 'error';
+export type StepOrientation = 'vertical' | 'horizontal';
+
+/** Internal metadata about a registered step. */
+export type StepMeta = {
+	value: string;
+	index: number; // 0-based registration order
+	status?: StepStatus;
+	disabled: boolean;
+	optional: boolean;
+};
+
+/** Imperative handle exposed via ref. */
+export type StepperRef = {
+	focusStep: ( value: string ) => void;
+};
+
+// ─── Tier 1 props ────────────────────────────────────────────────────────────
+
+type AriaLabelProps =
+	| { 'aria-label': string; 'aria-labelledby'?: never }
+	| { 'aria-label'?: never; 'aria-labelledby': string };
+
+export type StepperProps = AriaLabelProps & {
+	value?: string;
+	defaultValue?: string;
+	onValueChange?: ( value: string ) => void;
+	linear?: boolean;
+	/** Vertical only. Heading level wrapping each trigger. @default 3 */
+	headingLevel?: 2 | 3 | 4 | 5 | 6;
+	/** Horizontal only. Whether focus immediately activates a tab. @default 'manual' */
+	activationMode?: 'auto' | 'manual';
+	formatStepLabel?: ( step: number, total: number, status?: StepStatus ) => string;
+	children: ReactNode;
+	className?: string;
+	ref?: Ref< StepperRef >;
+};
+
+export type StepProps = {
+	value: string;
+	title: string;
+	description?: string;
+	status?: StepStatus;
+	optional?: boolean;
+	disabled?: boolean;
+	indicator?: ReactNode;
+	/** Keep panel mounted when inactive (horizontal only). */
+	forceMount?: boolean;
+	children: ReactNode;
+	className?: string;
+};
+
+// ─── Tier 2 props ────────────────────────────────────────────────────────────
+
+export type StepperRootProps = AriaLabelProps & {
+	orientation: StepOrientation;
+	value?: string;
+	defaultValue?: string;
+	onValueChange?: ( value: string ) => void;
+	linear?: boolean;
+	headingLevel?: 2 | 3 | 4 | 5 | 6;
+	activationMode?: 'auto' | 'manual';
+	formatStepLabel?: ( step: number, total: number, status?: StepStatus ) => string;
+	children: ReactNode;
+	className?: string;
+	ref?: Ref< StepperRef >;
+};
+
+export type StepperListProps = {
+	children: ReactNode;
+	className?: string;
+};
+
+export type StepperStepProps = {
+	value: string;
+	status?: StepStatus;
+	optional?: boolean;
+	disabled?: boolean;
+	children: ReactNode;
+	className?: string;
+};
+
+export type StepperTriggerProps = React.ComponentPropsWithoutRef< 'button' > & {
+	children: ReactNode;
+	className?: string;
+};
+
+export type StepperPanelProps = React.ComponentPropsWithoutRef< 'div' > & {
+	/** Required in horizontal mode to associate panel with a step. */
+	value?: string;
+	forceMount?: boolean;
+	children: ReactNode;
+	className?: string;
+};
+
+export type StepperIndicatorProps = {
+	children?: ReactNode;
+	className?: string;
+};
+
+export type StepperTitleProps = React.ComponentPropsWithoutRef< 'span' > & {
+	children: ReactNode;
+	className?: string;
+};
+
+export type StepperDescriptionProps = React.ComponentPropsWithoutRef< 'span' > & {
+	children: ReactNode;
+	className?: string;
+};
+
+// ─── Context values ──────────────────────────────────────────────────────────
+
+export type StepperContextValue = {
+	rootId: string;
+	value: string;
+	onValueChange: ( value: string ) => void;
+	orientation: StepOrientation;
+	linear: boolean;
+	headingLevel: 2 | 3 | 4 | 5 | 6;
+	activationMode: 'auto' | 'manual';
+	formatStepLabel: ( step: number, total: number, status?: StepStatus ) => string;
+	steps: StepMeta[];
+	registerStep: ( meta: Omit< StepMeta, 'index' > ) => () => void;
+};
+
+export type StepContextValue = {
+	value: string;
+	index: number; // 0-based
+	totalSteps: number;
+	isCurrent: boolean;
+	status?: StepStatus;
+	/** True if explicitly disabled OR blocked by linear flow. */
+	isDisabled: boolean;
+	optional: boolean;
+};
+
+// ─── ID helpers ──────────────────────────────────────────────────────────────
+
+/** Returns a stable, unique trigger button id for a given step. */
+export function stepTriggerId( rootId: string, value: string ): string {
+	return `stepper-${ rootId }-trigger-${ value }`;
+}
+
+/** Returns a stable, unique panel id for a given step. */
+export function stepPanelId( rootId: string, value: string ): string {
+	return `stepper-${ rootId }-panel-${ value }`;
+}

--- a/packages/ui/src/vertical-stepper/index.ts
+++ b/packages/ui/src/vertical-stepper/index.ts
@@ -1,0 +1,3 @@
+export { VerticalStepper } from './vertical-stepper';
+export type { VerticalStepperStepProps } from './vertical-stepper-step';
+export type { StepperProps as VerticalStepperProps } from '../stepper/types';

--- a/packages/ui/src/vertical-stepper/stories/index.story.tsx
+++ b/packages/ui/src/vertical-stepper/stories/index.story.tsx
@@ -1,0 +1,104 @@
+import { useState } from '@wordpress/element';
+import { VerticalStepper } from '..';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta = {
+	title: 'Automattic UI/VerticalStepper',
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+export const Default: Story = {
+	render: () => (
+		<VerticalStepper defaultValue="shipping" aria-label="Checkout">
+			<VerticalStepper.Step value="info" title="Purchase info" status="completed">
+				<p>Purchase info panel content</p>
+			</VerticalStepper.Step>
+			<VerticalStepper.Step value="shipping" title="Shipping details">
+				<p>Shipping details panel content</p>
+			</VerticalStepper.Step>
+			<VerticalStepper.Step value="review" title="Review">
+				<p>Review panel content</p>
+			</VerticalStepper.Step>
+		</VerticalStepper>
+	),
+};
+
+export const WithDescription: Story = {
+	render: () => (
+		<VerticalStepper defaultValue="shipping" aria-label="Checkout with descriptions">
+			<VerticalStepper.Step
+				value="info"
+				title="Purchase info"
+				description="Provide purchase details"
+				status="completed"
+			>
+				<p>Purchase info panel</p>
+			</VerticalStepper.Step>
+			<VerticalStepper.Step
+				value="shipping"
+				title="Shipping details"
+				description="Provide shipping details"
+			>
+				<p>Shipping details panel</p>
+			</VerticalStepper.Step>
+			<VerticalStepper.Step
+				value="review"
+				title="Review"
+				description="Review before submitting"
+				optional
+			>
+				<p>Review panel</p>
+			</VerticalStepper.Step>
+		</VerticalStepper>
+	),
+};
+
+export const WithError: Story = {
+	render: () => (
+		<VerticalStepper defaultValue="shipping" aria-label="Checkout with error">
+			<VerticalStepper.Step value="info" title="Purchase info" status="completed">
+				<p>Purchase info panel</p>
+			</VerticalStepper.Step>
+			<VerticalStepper.Step value="shipping" title="Shipping details" status="error">
+				<p>Shipping details panel</p>
+			</VerticalStepper.Step>
+			<VerticalStepper.Step value="review" title="Review">
+				<p>Review panel</p>
+			</VerticalStepper.Step>
+		</VerticalStepper>
+	),
+};
+
+function LinearFlowDemo() {
+	const [ step, setStep ] = useState( 'info' );
+	return (
+		<VerticalStepper value={ step } onValueChange={ setStep } linear aria-label="Linear checkout">
+			<VerticalStepper.Step value="info" title="Purchase info">
+				<div>
+					<p>Fill in purchase info.</p>
+					<button onClick={ () => setStep( 'shipping' ) }>Next</button>
+				</div>
+			</VerticalStepper.Step>
+			<VerticalStepper.Step
+				value="shipping"
+				title="Shipping details"
+				status={ step === 'review' ? 'completed' : undefined }
+			>
+				<div>
+					<p>Fill in shipping details.</p>
+					<button onClick={ () => setStep( 'review' ) }>Next</button>
+				</div>
+			</VerticalStepper.Step>
+			<VerticalStepper.Step value="review" title="Review">
+				<p>Review your order.</p>
+			</VerticalStepper.Step>
+		</VerticalStepper>
+	);
+}
+
+export const LinearFlow: Story = {
+	render: () => <LinearFlowDemo />,
+};

--- a/packages/ui/src/vertical-stepper/style.module.scss
+++ b/packages/ui/src/vertical-stepper/style.module.scss
@@ -1,0 +1,12 @@
+@use '@wordpress/base-styles/variables';
+
+.root {
+	// Tier 1 vertical root — inherits shared stepper styles.
+}
+
+// Step text container (title + optional description stacked).
+.step-text {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}

--- a/packages/ui/src/vertical-stepper/test/index.tsx
+++ b/packages/ui/src/vertical-stepper/test/index.tsx
@@ -1,0 +1,130 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { VerticalStepper } from '..';
+
+function ThreeSteps( {
+	value,
+	onValueChange,
+	linear = false,
+}: {
+	value?: string;
+	onValueChange?: ( v: string ) => void;
+	linear?: boolean;
+} ) {
+	return (
+		<VerticalStepper
+			aria-label="Test stepper"
+			value={ value }
+			onValueChange={ onValueChange }
+			linear={ linear }
+		>
+			<VerticalStepper.Step value="a" title="Step A" status="completed">
+				Panel A
+			</VerticalStepper.Step>
+			<VerticalStepper.Step value="b" title="Step B">
+				Panel B
+			</VerticalStepper.Step>
+			<VerticalStepper.Step value="c" title="Step C">
+				Panel C
+			</VerticalStepper.Step>
+		</VerticalStepper>
+	);
+}
+
+describe( 'VerticalStepper', () => {
+	it( 'renders step titles', async () => {
+		render( <ThreeSteps value="b" /> );
+		await waitFor( () => {
+			expect( screen.getByText( 'Step A' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Step B' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Step C' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'marks the active trigger with aria-current="step"', async () => {
+		render( <ThreeSteps value="b" /> );
+		await waitFor( () => {
+			const trigger = screen.getByRole( 'button', { name: /Step B/i } );
+			expect( trigger ).toHaveAttribute( 'aria-current', 'step' );
+		} );
+	} );
+
+	it( 'marks the active trigger with aria-expanded="true"', async () => {
+		render( <ThreeSteps value="b" /> );
+		await waitFor( () => {
+			const trigger = screen.getByRole( 'button', { name: /Step B/i } );
+			expect( trigger ).toHaveAttribute( 'aria-expanded', 'true' );
+		} );
+	} );
+
+	it( 'calls onValueChange when a trigger is clicked', async () => {
+		const user = userEvent.setup();
+		const onValueChange = jest.fn();
+		render( <ThreeSteps value="b" onValueChange={ onValueChange } /> );
+		await waitFor( () => screen.getByRole( 'button', { name: /Step A/i } ) );
+		await user.click( screen.getByRole( 'button', { name: /Step A/i } ) );
+		expect( onValueChange ).toHaveBeenCalledWith( 'a' );
+	} );
+
+	it( 'wraps triggers in heading elements', async () => {
+		render( <ThreeSteps value="a" /> );
+		await waitFor( () => screen.getByRole( 'button', { name: /Step A/i } ) );
+		const trigger = screen.getByRole( 'button', { name: /Step A/i } );
+		// Default headingLevel is 3, so the parent should be h3.
+		expect( trigger.closest( 'h3' ) ).toBeInTheDocument();
+	} );
+
+	it( 'respects headingLevel prop', async () => {
+		render(
+			<VerticalStepper aria-label="Test" value="a" headingLevel={ 2 }>
+				<VerticalStepper.Step value="a" title="Step A">
+					Panel A
+				</VerticalStepper.Step>
+			</VerticalStepper>
+		);
+		await waitFor( () => screen.getByRole( 'button', { name: /Step A/i } ) );
+		const trigger = screen.getByRole( 'button', { name: /Step A/i } );
+		expect( trigger.closest( 'h2' ) ).toBeInTheDocument();
+	} );
+
+	it( 'includes accessible step label in indicator', async () => {
+		render( <ThreeSteps value="b" /> );
+		await waitFor( () => {
+			expect( screen.getByText( /Step 2 of 3/i ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'linear mode', () => {
+		it( 'marks future steps as aria-disabled', async () => {
+			render( <ThreeSteps value="a" linear /> );
+			await waitFor( () => screen.getByRole( 'button', { name: /Step C/i } ) );
+			const futureTrigger = screen.getByRole( 'button', { name: /Step C/i } );
+			expect( futureTrigger ).toHaveAttribute( 'aria-disabled', 'true' );
+		} );
+
+		it( 'does not fire onValueChange for a disabled future step', async () => {
+			const user = userEvent.setup();
+			const onValueChange = jest.fn();
+			render( <ThreeSteps value="a" onValueChange={ onValueChange } linear /> );
+			await waitFor( () => screen.getByRole( 'button', { name: /Step C/i } ) );
+			await user.click( screen.getByRole( 'button', { name: /Step C/i } ) );
+			expect( onValueChange ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	it( 'works uncontrolled with defaultValue', async () => {
+		render(
+			<VerticalStepper aria-label="Uncontrolled" defaultValue="a">
+				<VerticalStepper.Step value="a" title="A">
+					Panel A
+				</VerticalStepper.Step>
+				<VerticalStepper.Step value="b" title="B">
+					Panel B
+				</VerticalStepper.Step>
+			</VerticalStepper>
+		);
+		await waitFor( () => screen.getByRole( 'button', { name: /A/i } ) );
+		const trigger = screen.getByRole( 'button', { name: /A/i } );
+		expect( trigger ).toHaveAttribute( 'aria-expanded', 'true' );
+	} );
+} );

--- a/packages/ui/src/vertical-stepper/vertical-stepper-step.tsx
+++ b/packages/ui/src/vertical-stepper/vertical-stepper-step.tsx
@@ -1,0 +1,32 @@
+import type { StepStatus } from '../stepper/types';
+import type { ReactNode } from 'react';
+
+/**
+ * Metadata carrier for a VerticalStepper step.
+ *
+ * This component does not render anything itself. VerticalStepper reads its
+ * props to build the trigger + panel for each step.
+ */
+export interface VerticalStepperStepProps {
+	value: string;
+	title: string;
+	description?: string;
+	status?: StepStatus;
+	optional?: boolean;
+	disabled?: boolean;
+	indicator?: ReactNode;
+	/** Keep panel mounted even when inactive. */
+	forceMount?: boolean;
+	/** Panel content. */
+	children: ReactNode;
+	className?: string;
+}
+
+/**
+ * Placeholder component used only to carry props. VerticalStepper reads
+ * children of type VerticalStepperStep and renders them into the correct
+ * accordion DOM structure.
+ */
+export const VerticalStepperStep: React.FC< VerticalStepperStepProps > = () => null;
+
+VerticalStepperStep.displayName = 'VerticalStepper.Step';

--- a/packages/ui/src/vertical-stepper/vertical-stepper.tsx
+++ b/packages/ui/src/vertical-stepper/vertical-stepper.tsx
@@ -1,0 +1,77 @@
+import { Children, forwardRef, isValidElement } from '@wordpress/element';
+import clsx from 'clsx';
+import { StepperDescription } from '../stepper/description';
+import { StepperIndicator } from '../stepper/indicator';
+import { StepperPanel } from '../stepper/panel';
+import { StepperRoot } from '../stepper/root';
+import { StepperStep } from '../stepper/step';
+import { StepperTitle } from '../stepper/title';
+import { StepperTrigger } from '../stepper/trigger';
+import styles from './style.module.scss';
+import { VerticalStepperStep } from './vertical-stepper-step';
+import type { VerticalStepperStepProps } from './vertical-stepper-step';
+import type { StepperProps, StepperRef } from '../stepper/types';
+
+export const VerticalStepper = Object.assign(
+	forwardRef< StepperRef, StepperProps >( function VerticalStepper(
+		{ children, className, ...props },
+		ref
+	) {
+		const steps = Children.toArray( children ).filter(
+			( child ): child is React.ReactElement< VerticalStepperStepProps > =>
+				isValidElement( child ) &&
+				( child.type as { displayName?: string } ).displayName === 'VerticalStepper.Step'
+		);
+
+		return (
+			<StepperRoot
+				{ ...props }
+				orientation="vertical"
+				ref={ ref }
+				className={ clsx( styles.root, className ) }
+			>
+				{ steps.map( ( step ) => {
+					const {
+						value,
+						title,
+						description,
+						status,
+						optional,
+						disabled,
+						indicator,
+						forceMount,
+						children: panelContent,
+						className: stepClassName,
+					} = step.props;
+
+					return (
+						<StepperStep
+							key={ value }
+							value={ value }
+							status={ status }
+							optional={ optional }
+							disabled={ disabled }
+							className={ stepClassName }
+						>
+							<StepperTrigger>
+								{ indicator !== undefined ? (
+									<StepperIndicator>{ indicator }</StepperIndicator>
+								) : (
+									<StepperIndicator />
+								) }
+								<span className={ styles[ 'step-text' ] }>
+									<StepperTitle>{ title }</StepperTitle>
+									{ description && <StepperDescription>{ description }</StepperDescription> }
+								</span>
+							</StepperTrigger>
+							<StepperPanel forceMount={ forceMount }>{ panelContent }</StepperPanel>
+						</StepperStep>
+					);
+				} ) }
+			</StepperRoot>
+		);
+	} ),
+	{ Step: VerticalStepperStep }
+);
+
+VerticalStepper.displayName = 'VerticalStepper';

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,6 +36,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ariakit/components@npm:0.1.1":
+  version: 0.1.1
+  resolution: "@ariakit/components@npm:0.1.1"
+  dependencies:
+    "@ariakit/store": "npm:0.1.1"
+    "@ariakit/utils": "npm:0.1.1"
+  checksum: de51c3825d15f31b951760cea34f5e8f33523222c728fae8ef27224811c567e96d59a69169135b29dc0aec49ad63c5438470cabd14565ceadb19130f3f49df1c
+  languageName: node
+  linkType: hard
+
 "@ariakit/core@npm:0.4.14":
   version: 0.4.14
   resolution: "@ariakit/core@npm:0.4.14"
@@ -47,6 +57,23 @@ __metadata:
   version: 0.4.20
   resolution: "@ariakit/core@npm:0.4.20"
   checksum: c9f90af371858a0251a58e6ed68263be25ef175e0710c867a2c30f04894c2cd81716ca450c60414004eb3ce962e76bfe039b381867bc92c1cef2c27c7eb13784
+  languageName: node
+  linkType: hard
+
+"@ariakit/react-components@npm:0.1.1":
+  version: 0.1.1
+  resolution: "@ariakit/react-components@npm:0.1.1"
+  dependencies:
+    "@ariakit/components": "npm:0.1.1"
+    "@ariakit/react-store": "npm:0.1.1"
+    "@ariakit/react-utils": "npm:0.1.1"
+    "@ariakit/store": "npm:0.1.1"
+    "@ariakit/utils": "npm:0.1.1"
+    "@floating-ui/dom": "npm:^1.0.0"
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: f923775e17f57ef7be74cbcd8e455a1b58588f918bff061658005f943ab2588e7dbaebd06474b9abd6d0f83d6321204ceba840be0b6d2f386ce424870a59d3cc
   languageName: node
   linkType: hard
 
@@ -64,6 +91,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ariakit/react-store@npm:0.1.1":
+  version: 0.1.1
+  resolution: "@ariakit/react-store@npm:0.1.1"
+  dependencies:
+    "@ariakit/react-utils": "npm:0.1.1"
+    "@ariakit/store": "npm:0.1.1"
+    "@ariakit/utils": "npm:0.1.1"
+    use-sync-external-store: "npm:^1.6.0"
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 275894eec1872705c82eede4c3f9ea8ce69705499a50d5f33e250dee63632bb644c7dfa40db9cdd877fbe08ec132c7445f735dfd15e09a71bec987456125230b
+  languageName: node
+  linkType: hard
+
+"@ariakit/react-utils@npm:0.1.1":
+  version: 0.1.1
+  resolution: "@ariakit/react-utils@npm:0.1.1"
+  dependencies:
+    "@ariakit/store": "npm:0.1.1"
+    "@ariakit/utils": "npm:0.1.1"
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 4e86dca2a92fcc6beb073245954292b015b8c65d8d0d92f6d3e0ee3cc78146dd94f9d338cfd4c15b6884f4ac9c5ac1849a2d9c22d79db02c562a2798a5f06e06
+  languageName: node
+  linkType: hard
+
 "@ariakit/react@npm:^0.4.15, @ariakit/react@npm:^0.4.21, @ariakit/react@npm:^0.4.22":
   version: 0.4.26
   resolution: "@ariakit/react@npm:0.4.26"
@@ -73,6 +126,27 @@ __metadata:
     react: ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
   checksum: fc88b5f755acd787bc55d2c6d6b8406dd06cbf2aeb20d3b86f67d3ed492d0460952a1e5b7eced151f79305c8735f84124327d3b3deaa883e7f6fdd0c808dcfc5
+  languageName: node
+  linkType: hard
+
+"@ariakit/react@npm:^0.4.23":
+  version: 0.4.28
+  resolution: "@ariakit/react@npm:0.4.28"
+  dependencies:
+    "@ariakit/react-components": "npm:0.1.1"
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 4eaa2c3fc5a05003b5572e0b948444ab573ba0f65d6c28a8294da419e2ccede3679d71e6f729d6278f2f6aaf97d178262e45a5e0f1add7b66fed15fc41f26231
+  languageName: node
+  linkType: hard
+
+"@ariakit/store@npm:0.1.1":
+  version: 0.1.1
+  resolution: "@ariakit/store@npm:0.1.1"
+  dependencies:
+    "@ariakit/utils": "npm:0.1.1"
+  checksum: 275f656d52f41de6bd5e483d42dce4bf89d26b7c92a7064175558e16a0b2f6b05207d0d27e5fd2ed8c7040221f2aa57bff91af96953a6bff7eec71f6cc578068
   languageName: node
   linkType: hard
 
@@ -94,6 +168,13 @@ __metadata:
     react:
       optional: true
   checksum: 47d29ac8285b91762b640a881d51aa2515ebf381716b27bd781bc3b78f75e404f89c1537c4b07e76ed8bc9db0b1f3d126d6bc7577a3a3c60714b6681f2e96403
+  languageName: node
+  linkType: hard
+
+"@ariakit/utils@npm:0.1.1":
+  version: 0.1.1
+  resolution: "@ariakit/utils@npm:0.1.1"
+  checksum: cb9815daae95aeabbee0339a0d54d21a9607727be0c82e4205798646ef758b7b4d975c4d53f0b22bc5ee346a043edf15a092e2316a3d6e5614c1aa00303ad293
   languageName: node
   linkType: hard
 
@@ -2374,6 +2455,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/ui@workspace:packages/ui"
   dependencies:
+    "@ariakit/react": "npm:^0.4.23"
     "@automattic/calypso-storybook": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@microsoft/api-extractor": "npm:^7.52.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -53,13 +53,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ariakit/core@npm:0.4.20":
-  version: 0.4.20
-  resolution: "@ariakit/core@npm:0.4.20"
-  checksum: c9f90af371858a0251a58e6ed68263be25ef175e0710c867a2c30f04894c2cd81716ca450c60414004eb3ce962e76bfe039b381867bc92c1cef2c27c7eb13784
-  languageName: node
-  linkType: hard
-
 "@ariakit/react-components@npm:0.1.1":
   version: 0.1.1
   resolution: "@ariakit/react-components@npm:0.1.1"
@@ -74,20 +67,6 @@ __metadata:
     react: ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
   checksum: f923775e17f57ef7be74cbcd8e455a1b58588f918bff061658005f943ab2588e7dbaebd06474b9abd6d0f83d6321204ceba840be0b6d2f386ce424870a59d3cc
-  languageName: node
-  linkType: hard
-
-"@ariakit/react-core@npm:0.4.26":
-  version: 0.4.26
-  resolution: "@ariakit/react-core@npm:0.4.26"
-  dependencies:
-    "@ariakit/core": "npm:0.4.20"
-    "@floating-ui/dom": "npm:^1.0.0"
-    use-sync-external-store: "npm:^1.6.0"
-  peerDependencies:
-    react: ^17.0.0 || ^18.0.0 || ^19.0.0
-    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: fa81563035779a5722ee36968de2ee4ae6fdbeae98cdeb0fd75ea4ba8c002fdc3b1a1929bf9bc8c8362a0c4be49a674257bf554eee5bbfea22007eeceb7f7903
   languageName: node
   linkType: hard
 
@@ -117,19 +96,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ariakit/react@npm:^0.4.15, @ariakit/react@npm:^0.4.21, @ariakit/react@npm:^0.4.22":
-  version: 0.4.26
-  resolution: "@ariakit/react@npm:0.4.26"
-  dependencies:
-    "@ariakit/react-core": "npm:0.4.26"
-  peerDependencies:
-    react: ^17.0.0 || ^18.0.0 || ^19.0.0
-    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: fc88b5f755acd787bc55d2c6d6b8406dd06cbf2aeb20d3b86f67d3ed492d0460952a1e5b7eced151f79305c8735f84124327d3b3deaa883e7f6fdd0c808dcfc5
-  languageName: node
-  linkType: hard
-
-"@ariakit/react@npm:^0.4.23":
+"@ariakit/react@npm:^0.4.15, @ariakit/react@npm:^0.4.21, @ariakit/react@npm:^0.4.22, @ariakit/react@npm:^0.4.23":
   version: 0.4.28
   resolution: "@ariakit/react@npm:0.4.28"
   dependencies:


### PR DESCRIPTION
Part of #

## Proposed Changes

`@automattic/ui` now ships a `Stepper` component for multi-step flows. Products can render a horizontal (tab-based) or vertical (accordion-based) stepper with a shared declarative JSX shape — switching orientations is a one-prop change.

Two-tier API:

- **Tier 1** (`HorizontalStepper`, `VerticalStepper`): declarative, batteries-included. Children are `<*.Step>` placeholder components; the parent reads their props and builds the full ARIA structure.
- **Tier 2** (`Stepper.*` primitives): full composition control for custom layouts. `Stepper.Root`, `Stepper.List`, `Stepper.Step`, `Stepper.Trigger`, `Stepper.Panel`, `Stepper.Indicator`, `Stepper.Title`, `Stepper.Description`.

Key capabilities:

- **Linear mode** — future steps are marked `aria-disabled` (stays focusable) and ignore clicks; past/current steps remain navigable.
- **Step statuses** — `completed`, `error`, or unset; reflected via `data-status` for CSS targeting and an accessible indicator (check/error icon with screen-reader label).
- **Custom indicators** — override the default number/icon via the `indicator` prop on any step.
- **Imperative focus** — `StepperRef.focusStep(value)` for programmatic navigation.
- **i18n** — `formatStepLabel` prop replaces the default "Step N of M" accessible label.

## Why are these changes being made?

Multi-step flows appear across several Automattic products (checkout, onboarding, setup wizards). This component consolidates that pattern into the shared design system package so teams share a consistent, accessible implementation rather than building bespoke steppers per product.

## Testing Instructions

Storybook stories are included for both orientations under `Automattic UI/HorizontalStepper` and `Automattic UI/VerticalStepper`. Stories cover: default three-step flow, error state, five-step layout, linear flow (with Next buttons), and steps with descriptions.

Unit tests cover: rendering, active panel isolation, `aria-current="step"`, `onValueChange` firing, uncontrolled `defaultValue`, `data-status` attribute, linear mode `aria-disabled`, linear mode click suppression, accessible step label, and tablist presence.

```bash
yarn test-packages --testPathPattern="packages/ui/src/(horizontal|vertical)-stepper"
```

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have we used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude_Sonnet_4.6_%28200K%29](https://img.shields.io/badge/Claude_Sonnet_4.6_%28200K%29-D97757?logo=claude&logoColor=white)
