### PR TITLE
A4A Plugins: align header and table padding with portal standard

### DIFF
--- a/client/a8c-for-agencies/sections/plugins/style.scss
+++ b/client/a8c-for-agencies/sections/plugins/style.scss
@@ -54,19 +54,19 @@
 
 			.dataviews-view-table tr td:first-child:not(.dataviews-view-table__checkbox-column),
 			.dataviews-view-table tr th:first-child:not(.dataviews-view-table__checkbox-column) {
-				padding-left: 16px;
+				padding-inline-start: 16px;
 
 				@media (min-width: $break-small) {
-					padding-left: 64px;
+					padding-inline-start: 64px;
 				}
 			}
 
 			.dataviews-view-table tr td:last-child,
 			.dataviews-view-table tr th:last-child {
-				padding-right: 16px;
+				padding-inline-end: 16px;
 
 				@media (min-width: $break-small) {
-					padding-right: 64px;
+					padding-inline-end: 64px;
 				}
 			}
 		}

--- a/client/a8c-for-agencies/sections/plugins/style.scss
+++ b/client/a8c-for-agencies/sections/plugins/style.scss
@@ -1,3 +1,6 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
 .is-section-a8c-for-agencies-plugins {
 	.wpcom-site {
 		.main.hosting-dashboard-layout.sites-dashboard.sites-dashboard__layout:not(.preview-hidden) {
@@ -6,6 +9,64 @@
 
 				.hosting-dashboard-layout__top-wrapper {
 					display: block;
+				}
+			}
+		}
+
+		// Multi-list view: restore the standard A4A header L/R padding (64px,
+		// constrained to 1500px and centered). The Dotcom Sites Dashboard
+		// stylesheet (dotcom-style.scss) overrides this to 24px / revert for
+		// any with-columns container, and gets pulled in transitively via
+		// plugins-scheduled-updates-multisite — which shifts the Plugins
+		// header inward versus Overview / Tiers / Exclusive Offers.
+		.main.hosting-dashboard-layout.sites-dashboard.sites-dashboard__layout.preview-hidden {
+			.hosting-dashboard-layout-with-columns__container .hosting-dashboard-layout__top-wrapper > * {
+				@include breakpoint-deprecated('>660px') {
+					padding-inline: 64px;
+					max-width: 1500px;
+				}
+			}
+
+			// Align the DataViews action bar (search + filters) and the table's
+			// first/last columns with the header inset above, matching the A4A
+			// Sites Dashboard pattern.
+			.dataviews__view-actions,
+			.dataviews-filters__container {
+				padding: 16px;
+
+				@media (min-width: $break-small) {
+					padding: 16px 64px;
+				}
+			}
+
+			// Size the bulk-select checkbox column so its right edge lands at 64px
+			// from the card edge. The checkbox keeps DataViews' default 24px L
+			// padding (so it sits within the "outside" zone), and the first data
+			// column starts at 64px — aligned with the search box above. For
+			// tables without a checkbox column, fall back to padding the first
+			// column directly.
+			.dataviews-view-table .dataviews-view-table__checkbox-column {
+				@media (min-width: $break-small) {
+					width: 64px;
+					box-sizing: border-box;
+				}
+			}
+
+			.dataviews-view-table tr td:first-child:not(.dataviews-view-table__checkbox-column),
+			.dataviews-view-table tr th:first-child:not(.dataviews-view-table__checkbox-column) {
+				padding-left: 16px;
+
+				@media (min-width: $break-small) {
+					padding-left: 64px;
+				}
+			}
+
+			.dataviews-view-table tr td:last-child,
+			.dataviews-view-table tr th:last-child {
+				padding-right: 16px;
+
+				@media (min-width: $break-small) {
+					padding-right: 64px;
 				}
 			}
 		}

--- a/client/my-sites/plugins/plugins-dashboard/index.tsx
+++ b/client/my-sites/plugins/plugins-dashboard/index.tsx
@@ -333,7 +333,7 @@ const PluginsDashboard = ( {
 					{ isA8CForAgencies() && ! pluginSlug && <A4APluginsJetpackBanner /> }
 					<LayoutHeader>
 						<Title>{ translate( 'Manage plugins' ) }</Title>
-						{ ! pluginSlug && ! isJetpackCloudOrA8CForAgencies && (
+						{ ! pluginSlug && ! isA8CForAgencies() && (
 							<Subtitle>{ translate( 'Manage all your plugins in one place' ) }</Subtitle>
 						) }
 						{ ! pluginSlug && ! isJetpackCloudOrA8CForAgencies && (

--- a/client/my-sites/plugins/plugins-dashboard/index.tsx
+++ b/client/my-sites/plugins/plugins-dashboard/index.tsx
@@ -333,7 +333,7 @@ const PluginsDashboard = ( {
 					{ isA8CForAgencies() && ! pluginSlug && <A4APluginsJetpackBanner /> }
 					<LayoutHeader>
 						<Title>{ translate( 'Manage plugins' ) }</Title>
-						{ ! pluginSlug && (
+						{ ! pluginSlug && ! isJetpackCloudOrA8CForAgencies && (
 							<Subtitle>{ translate( 'Manage all your plugins in one place' ) }</Subtitle>
 						) }
 						{ ! pluginSlug && ! isJetpackCloudOrA8CForAgencies && (


### PR DESCRIPTION
Part of A4A-2638
<!-- Link the related A4A Plugins Linear issue. -->

## Proposed Changes

* **`plugins-dashboard/index.tsx`** — gate the "Manage all your plugins in one place" subtitle on `! isA8CForAgencies()`. The subtitle is a Calypso/Jetpack Cloud artifact; no A4A portal page renders one, so it's dropped only on the A4A surface — Jetpack Cloud and Calypso keep their existing behavior.
* **`a8c-for-agencies/sections/plugins/style.scss`** — restore the standard A4A 64px L/R inset on the multi-list view (`.preview-hidden`):
  * **Header viewport** — re-apply `padding-inline: 64px; max-width: 1500px;` to override the Dotcom Sites Dashboard rule in `client/sites/components/dotcom-style.scss:12-27` (which sets `padding-inline: 24px; max-width: revert;` for any `.hosting-dashboard-layout-with-columns__container`, and gets pulled in transitively via `plugins-scheduled-updates-multisite/index.tsx:13`).
  * **DataViews action bar** (`.dataviews__view-actions`, `.dataviews-filters__container`) — `padding: 16px 64px` at `>= break-small`, mirroring `client/a8c-for-agencies/sections/sites/sites-dashboard/style.scss:32-39`.
  * **Table columns** — size the bulk-select `.dataviews-view-table__checkbox-column` to `width: 64px` so the first data column starts at 64px from the card edge (the checkbox keeps DataViews' default 24px L padding inside that zone), and add `padding-right: 64px` on the last column so the actions kebab aligns with the right edge of "Update available (n)" above. A `:first-child:not(.dataviews-view-table__checkbox-column)` fallback handles the case of a table rendered without bulk-select.

## Why are these changes being made?

The Plugin Management page header has noticeably tighter L/R padding than every other page in the A4A portal (Agency Overview, Agency Tiers, Exclusive Offers), and the page also surfaces an inline subtitle that no other A4A surface uses — so the header reads as cramped/abrupt next to its siblings. This aligns the Plugins page header inset, action bar, and table columns with the portal standard.

The horizontal-padding mismatch comes from `client/sites/components/dotcom-style.scss:12-27`, which targets any `.hosting-dashboard-layout-with-columns__container` (the Plugins page uses one because it renders `<LayoutColumn>` for the optional split-view detail) and overrides the shared 64px / 1500px rule to 24px / `revert`. That stylesheet is loaded for the A4A Plugins route via the `plugins-scheduled-updates-multisite` import chain in `client/my-sites/plugins/controller.jsx`, so the rule applies even though Plugins isn't the Dotcom Sites Dashboard. Restoring the portal default locally is the same idiom used by other A4A sections (e.g. Sites Dashboard, Subscriptions list, Marketplace product listing, Referrals overview).

## Testing Instructions

1. Open the live link and go to **A4A → Plugins**.
2. Confirm the "Manage all your plugins in one place" subtitle is no longer rendered below the **Manage plugins** title.
3. Compare the L/R padding of the **Manage plugins** title against **A4A → Agency tier**, **A4A → Overview**, and **A4A → Exclusive offers** — they should all sit at the same horizontal inset from the card edge.
4. Inside the plugins table:
   * The bulk-select checkbox sits within the 64px L "outside" zone (~24px from the card edge).
   * The "Installed plugins" column header / plugin icon aligns with the left edge of the search box above.
   * The actions kebab column aligns with the right edge of the "Update available (n)" toggle in the action bar.
5. Open a plugin (e.g. `/plugins/manage/sites/jetpack`) to enter the split-view detail mode and confirm that layout is unchanged.
6. Sanity-check `/plugins/manage/sites` in Calypso and in Jetpack Cloud — the subtitle and the dotcom action-bar inset should be unchanged on both.
7. Resize to mobile width and confirm the page collapses to the 16px L/R inset without breaking.
8. Verify there are no TypeScript / React console errors.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
