### PR TITLE
A4A Checkout: align client referral inputs with portal typography

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -1,5 +1,5 @@
 import page from '@automattic/calypso-router';
-import { Tooltip } from '@automattic/components';
+import { FormLabel, Tooltip } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
 import {
 	Button,
@@ -369,9 +369,10 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 		<>
 			<div className="checkout__client-referral-form">
 				<FormFieldset>
+					<FormLabel htmlFor="referral-email">{ translate( 'Client’s email address' ) }</FormLabel>
 					<TextControl
 						__nextHasNoMarginBottom
-						label={ translate( 'Client’s email address' ) }
+						id="referral-email"
 						name="email"
 						value={ email }
 						onChange={ onEmailChange }
@@ -389,9 +390,10 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 					</div>
 				</FormFieldset>
 				<FormFieldset>
+					<FormLabel htmlFor="referral-message">{ translate( 'Custom message' ) }</FormLabel>
 					<TextareaControl
 						__nextHasNoMarginBottom
-						label={ translate( 'Custom message' ) }
+						id="referral-message"
 						name="message"
 						placeholder={ translate(
 							'Send a message to your client about this request for payment.'

--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -1,13 +1,18 @@
 import page from '@automattic/calypso-router';
-import { FormLabel, Tooltip } from '@automattic/components';
+import { Tooltip } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
-import { Button, __experimentalVStack as VStack } from '@wordpress/components';
+import {
+	Button,
+	TextControl,
+	TextareaControl,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
 import { customLink, Icon, send, cautionFilled as warning } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 import clsx from 'clsx';
 import emailValidator from 'email-validator';
 import { useTranslate } from 'i18n-calypso';
-import { ChangeEvent, useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import useShowFeedback from 'calypso/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback';
 import { FeedbackType } from 'calypso/a8c-for-agencies/components/a4a-feedback/types';
 import {
@@ -23,8 +28,6 @@ import { getLogoUrlForPreview } from 'calypso/a8c-for-agencies/lib/logo-url-util
 import { useUploadLogo } from 'calypso/a8c-for-agencies/sections/partner-directory/agency-details/hooks/use-upload-logo';
 import { ReferralOrderFlowType } from 'calypso/a8c-for-agencies/sections/referrals/types';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
-import FormTextInput from 'calypso/components/forms/form-text-input';
-import FormTextarea from 'calypso/components/forms/form-textarea';
 import { useDispatch, useSelector } from 'calypso/state';
 import { updateAgencyReferralsLogo } from 'calypso/state/a8c-for-agencies/agency/actions';
 import {
@@ -95,15 +98,15 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 
 	const { onClearCart } = useShoppingCart();
 
-	const onEmailChange = ( event: ChangeEvent< HTMLInputElement > ) => {
-		setEmail( event.currentTarget.value );
+	const onEmailChange = ( value: string ) => {
+		setEmail( value );
 		if ( validationError.email ) {
 			setValidationError( { email: undefined } );
 		}
 	};
 
-	const onMessageChange = useCallback( ( event: ChangeEvent< HTMLInputElement > ) => {
-		setMessage( event.currentTarget.value );
+	const onMessageChange = useCallback( ( value: string ) => {
+		setMessage( value );
 	}, [] );
 
 	const onReferralLogoChange = useCallback( ( choice: ReferralLogoChoice ) => {
@@ -366,10 +369,10 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 		<>
 			<div className="checkout__client-referral-form">
 				<FormFieldset>
-					<FormLabel htmlFor="email">{ translate( 'Client’s email address' ) }</FormLabel>
-					<FormTextInput
+					<TextControl
+						__nextHasNoMarginBottom
+						label={ translate( 'Client’s email address' ) }
 						name="email"
-						id="email"
 						value={ email }
 						onChange={ onEmailChange }
 						onClick={ () =>
@@ -386,10 +389,10 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 					</div>
 				</FormFieldset>
 				<FormFieldset>
-					<FormLabel htmlFor="message">{ translate( 'Custom message' ) }</FormLabel>
-					<FormTextarea
+					<TextareaControl
+						__nextHasNoMarginBottom
+						label={ translate( 'Custom message' ) }
 						name="message"
-						id="message"
 						placeholder="Send a message to your client about this request for payment."
 						value={ message }
 						onChange={ onMessageChange }

--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -393,7 +393,9 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 						__nextHasNoMarginBottom
 						label={ translate( 'Custom message' ) }
 						name="message"
-						placeholder="Send a message to your client about this request for payment."
+						placeholder={ translate(
+							'Send a message to your client about this request for payment.'
+						) }
 						value={ message }
 						onChange={ onMessageChange }
 						onClick={ () =>

--- a/client/a8c-for-agencies/sections/marketplace/checkout/style-v1.scss
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/style-v1.scss
@@ -171,7 +171,7 @@
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
-	@include heading-medium;
+	@include heading-large;
 }
 
 .checkout__summary-notice {


### PR DESCRIPTION
Part of A4A-2627
<!-- Link the related A4A Linear issue. -->

## Proposed Changes

This PR groups two small typography adjustments to the **Refer to client** checkout side panel so it reads as one consistent portal surface.

### 1. Align client referral form input sizes with the rest of the portal

| Before    | After |
| -------- | ------- |
| <img width="470" height="406" alt="Screenshot 2026-05-26 at 12 44 19" src="https://github.com/user-attachments/assets/9b4a56bb-9de1-458b-bab4-336ee654fcd1" /> <img width="469" height="388" alt="Screenshot 2026-05-26 at 12 44 14" src="https://github.com/user-attachments/assets/7724c616-3c20-43ad-b2b2-9a2485e844fa" /> | <img width="476" height="412" alt="Screenshot 2026-05-26 at 12 39 48" src="https://github.com/user-attachments/assets/3652c588-1853-403b-a2da-4f37aded2f90" /> <img width="465" height="385" alt="Screenshot 2026-05-26 at 12 40 15" src="https://github.com/user-attachments/assets/2ec6dcec-ab30-4454-9f25-e9e45bd2bf7c" /> |  

* **`request-client-payment.tsx`** — swap `FormTextInput` / `FormTextarea` (from `calypso/components/forms`) for `TextControl` / `TextareaControl` from `@wordpress/components` on the client referral request form (email + custom message). The `onChange` handlers are updated to receive a `value: string` instead of a `ChangeEvent`. The existing `FormFieldset` wrapper, inline `checkout__client-referral-form-footer-error` validation message, `recordTracksEvent` `onClick` events, and the `Send` / `Copy` enablement logic (`hasCompletedForm`) all stay as-is. `__nextHasNoMarginBottom` is passed so the WP control's default bottom margin doesn't compound with the fieldset spacing.

### 2. Keep label and summary typography consistent across the panel

Follow-up to review feedback: with `TextControl` / `TextareaControl` rendering their own labels, the `Client’s email address` / `Custom message` labels became 11px uppercase while `Your logo (Optional)` (still rendered via `FormLabel`) stayed 14px sentence case + bold, and the totals row felt visually lighter than the “Your estimated commission” line below it.

* **`request-client-payment.tsx`** — drop the `label` prop on `TextControl` / `TextareaControl` and render a `FormLabel htmlFor=…` above each input (with matching `id="referral-email"` / `id="referral-message"` on the controls for accessibility). All three referral form labels (email, message, logo) now share the same `FormLabel` typography without overriding any `@wordpress/components` label CSS.
* **`checkout/style-v1.scss`** — `.checkout__summary-total` switches from `@include heading-medium` (13px) to `@include heading-large`, matching the existing `.commissions-info` (“Your estimated commission”) treatment so the totals row reads as a primary summary heading.

## Why are these changes being made?

The email and custom-message inputs in `marketplace/checkout` were rendering noticeably larger than every other form in the A4A portal because `FormTextInput` / `FormTextarea` use Calypso's `%form-field` placeholder (`client/assets/stylesheets/shared/_extends-forms.scss:7-13`) which sets `font-size: $font-body` = 16px, while the rest of the portal renders form inputs at 13px — either via `@wordpress/components` `TextControl` / `TextareaControl` (which default to `$default-font-size = $font-size-medium = 13px`, e.g. `migrations/tag-sites-modal`, `migrations/request-review-modal`, `ai-mcp/connect-agent`), or via an explicit `@include body-medium` override on `.form-text-input` (e.g. `signup/signup-v2/components/multi-step-form/style.scss:44-54`).

Swapping to the `@wordpress/components` controls is also what `client/a8c-for-agencies/AGENTS.md` recommends (“prefer `@wordpress/components` form controls and patterns directly”), so this aligns the surface with both the visual standard and the documented convention in one step instead of layering a local font-size override on top of the legacy components.

For the labels: rather than override `components-base-control__label` to look like `FormLabel`, we simply don’t ask the WP control to draw its label and render `FormLabel` ourselves. That keeps the existing portal label styling (14px / sentence case) intact across all three fields without touching any vendor CSS, and avoids re-introducing the heavier 16px input.

The totals row bump mirrors the existing `.commissions-info` heading so the two summary lines now read at the same level instead of the totals feeling like body copy underneath a larger commission line.

## Testing Instructions

1. Open the live link and go to **A4A → Marketplace**, add any product to the cart, then choose **Refer to client** so the checkout side panel shows the **Request payment from a client** form.
2. Confirm the **Client’s email address** field and the **Custom message** textarea render at the same ~13px size as the inputs in **A4A → Migrations → Sites → Tag sites** and **A4A → Migrations → request another verification** (and noticeably smaller than they did before).
3. Confirm all three form labels — **Client’s email address**, **Custom message**, and **Your logo (Optional)** — render at the same size, weight, and casing (14px, sentence case, bold via `FormLabel`).
4. In the summary above, confirm **Total your client will pay** and **Your estimated commission** render at the same heading size (both `heading-large`).
5. Type an invalid email and click **Send** — the inline **Please provide correct email address** error should appear under the field; typing again should clear it (same behavior as before).
6. Type a valid email + a message — **Send** and **Copy referral link** should enable; click **Preview referral email** and confirm the preview opens.
7. Click into both fields and confirm the `calypso_a4a_client_referral_form_email_click` and `calypso_a4a_client_referral_form_message_click` Tracks events still fire.
8. Resize to mobile width and confirm the inputs still fill the panel width and the label / error spacing looks correct.
9. Verify there are no TypeScript / React console errors.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
