### PR TITLE
Purchases: show skip button on auto-renew survey

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -632,7 +632,7 @@ class CancelPurchaseForm extends Component {
 					>
 						{ intent === 'remove' ? translate( 'Continue removal' ) : translate( 'Continue' ) }
 					</GutenbergButton>
-					{ intent === 'cancel' && (
+					{ ( intent === 'cancel' || intent === 'auto-renew' ) && (
 						<GutenbergButton
 							isTertiary
 							isBusy={ isCancelling }
@@ -708,9 +708,11 @@ class CancelPurchaseForm extends Component {
 					disabled={ ! this.canGoNext() }
 					onClick={ this.onSubmit }
 				>
-					{ intent === 'cancel' ? translate( 'Complete' ) : translate( 'Submit' ) }
+					{ intent === 'cancel' || intent === 'auto-renew'
+						? translate( 'Complete' )
+						: translate( 'Submit' ) }
 				</GutenbergButton>
-				{ intent === 'cancel' && (
+				{ ( intent === 'cancel' || intent === 'auto-renew' ) && (
 					<GutenbergButton
 						isTertiary
 						isBusy={ isCancelling }


### PR DESCRIPTION
## Summary

This PR adds the skip buttons to the auto-renew survey after you toggle auto-renew off. 

| Before | After |
| -- | -- |
| <img width="1840" height="1162" alt="image" src="https://github.com/user-attachments/assets/e22e1be8-9fb2-4799-8010-9dca7b8763e8" /> | <img width="1840" height="1162" alt="image" src="https://github.com/user-attachments/assets/f023b625-ef81-400a-b477-4907cbd282b4" /> |

More details:
- The legacy cancel-purchase survey only showed the "No, thanks" skip button when `intent === 'cancel'`, leaving auto-renew surveys without a way to skip. This aligns the legacy shared component with the dashboard equivalent, which already handles both intents.
- Adds `intent === 'auto-renew'` to the three conditionals in `renderStepButtons`: non-last step skip, last step label ("Complete" vs "Submit"), and last step skip.

## Test plan
- [ ] Navigate to Purchase Settings → disable auto-renew on a product with a survey
- [ ] Verify "No, thanks" tertiary skip button appears on non-last survey steps
- [ ] Verify last step shows "Complete" label (not "Submit") and "No, thanks" button
- [ ] Verify cancel flow (`intent=cancel`) still behaves identically
- [ ] Verify remove flow (`intent=remove`) is unaffected (no skip button)

🤖 Generated with [Claude Code](https://claude.com/claude-code)