### PR TITLE
Skip marketplace subscriptions confirmation modal

### DIFF
--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -1041,6 +1041,7 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			cancelBundledDomain: this.state.cancelBundledDomain,
 			purchaseListUrl: purchaseListUrl ?? purchasesRoot,
 			displayVariant: this.props.intent ?? undefined,
+			showMarketplaceDialog: ! isSplitCancelRemoveEnabled,
 			cancelIntentOverride:
 				urlIntentOverride ??
 				( this.shouldUseAutoRenewFlow() ? ( 'autorenew' as const ) : undefined ),


### PR DESCRIPTION
## Summary

This PR removes a redundant modal when you try cancel a plan subscription that has plugins that have their own subscription installed. Marketplace subscriptions are still cancelled by the mutation success handlers — this only removes the extra confirmation UI.

| Before | After | 
| -- | -- |
| <img width="1840" height="1162" alt="image" src="https://github.com/user-attachments/assets/84e19a4f-0734-4361-979a-3fc5ad458e43" /> | <img width="1840" height="1162" alt="image" src="https://github.com/user-attachments/assets/c7450c0c-da8d-4313-ad79-704ecf3c40d5" /> |

## Test plan

- [ ] Cancel a plan with active marketplace subscriptions (e.g. Gravity Forms) on the dashboard — confirm no extra modal appears between confirmation and survey
- [ ] Same flow on legacy (`calypso.localhost:3000`) — confirm no extra modal
- [ ] Toggle the `purchases/split-cancel-remove` flag off — confirm the modal still appears as before
- [ ] Verify marketplace subscriptions are still cancelled after the flow completes


🤖 Generated with [Claude Code](https://claude.com/claude-code)