### PR TITLE
Skip completed-survey shortcut under split-cancel-remove flag

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -577,7 +577,9 @@ function CancelPurchaseInner() {
 		cancellationOffer,
 		hasQuestionTwo: Boolean( state.questionTwoOrder?.length ),
 		plans,
-		userHasCompletedCancelSurveyForPurchase,
+		userHasCompletedCancelSurveyForPurchase: isSplitCancelRemoveEnabled
+			? false
+			: userHasCompletedCancelSurveyForPurchase,
 	} );
 
 	const initSurveyState = () => {
@@ -1440,7 +1442,7 @@ function CancelPurchaseInner() {
 			survey_responses: enrichedSurveyData( surveyData, purchase ),
 		} );
 
-		if ( flowType === CANCEL_FLOW_TYPE.CANCEL_AUTORENEW ) {
+		if ( flowType === CANCEL_FLOW_TYPE.CANCEL_AUTORENEW && ! isSplitCancelRemoveEnabled ) {
 			cancelPurchaseSurveyCompleted();
 		}
 


### PR DESCRIPTION
## Summary

The following screen currently only shows in the MSD after you confirm your cancellation if you have previously completed the cancellation survey:

<img width="1840" height="1162" alt="image" src="https://github.com/user-attachments/assets/38eb03a8-c37f-4f09-af49-52d2d1a65884" />

It's redundant, broken, and not necessary anymore now that we have skip links for the cancellation survey. This PR removes the ability to skip the survey and always presents it after you cancel or try remove your purchase.

Technical details:
- Always pass `false` for `userHasCompletedCancelSurveyForPurchase` under the flag so the full survey (FEEDBACK_STEP + NEXT_ADVENTURE_STEP) always renders
- Stop saving the survey-completed preference under the flag since it will never be read

## Test plan

- [ ] Under `purchases/split-cancel-remove`, cancel a subscription twice — verify the full survey renders both times (no `REMOVE_PLAN_STEP` shortcut)
- [ ] With the flag off, cancel a subscription twice — verify the second cancellation still skips to `REMOVE_PLAN_STEP` as before


🤖 Generated with [Claude Code](https://claude.com/claude-code)