### PR TITLE
A4A Client Checkout: Show price for legacy referral

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hooks/test/use-products-by-id.test.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/test/use-products-by-id.test.tsx
@@ -2,101 +2,67 @@
  * @jest-environment jsdom
  */
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { renderHook, waitFor } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
 import wpcom from 'calypso/lib/wp';
+import { renderHookWithProvider } from 'calypso/test-helpers/testing-library';
 import useProductsById from '../use-products-by-id';
 import type { ReferralProduct } from '../../../client/types';
-import type { ReactNode } from 'react';
 
 jest.mock( 'calypso/lib/wp', () => ( {
 	__esModule: true,
-	default: {
-		req: {
-			get: jest.fn(),
-		},
-	},
+	default: { req: { get: jest.fn() } },
 } ) );
 
 const mockedGet = wpcom.req.get as jest.MockedFunction< typeof wpcom.req.get >;
 
-function wrapper( { children }: { children: ReactNode } ) {
-	const queryClient = new QueryClient( {
-		defaultOptions: { queries: { retry: false } },
-	} );
-	return <QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>;
-}
+const PRODUCT_FAMILIES = [
+	{
+		name: 'WooCommerce Extensions',
+		slug: 'woo-extensions',
+		products: [
+			{
+				name: 'Conditional Shipping and Payments',
+				slug: 'woocommerce-conditional-shipping-payments',
+				product_id: 2714,
+				yearly_product_id: 2714,
+				monthly_product_id: 3114,
+				monthly_alternative_product_id: null,
+				yearly_alternative_product_id: null,
+				currency: 'USD',
+				monthly_price: 9.08,
+				yearly_price: 109,
+				metadata: null,
+			},
+		],
+	},
+];
 
-function mockProductFamilies() {
-	mockedGet.mockResolvedValueOnce( [
-		{
-			name: 'WooCommerce Extensions',
-			slug: 'woo-extensions',
-			products: [
-				{
-					name: 'Conditional Shipping and Payments',
-					slug: 'woocommerce-conditional-shipping-payments',
-					product_id: 2714,
-					yearly_product_id: 2714,
-					monthly_product_id: 3114,
-					monthly_alternative_product_id: null,
-					yearly_alternative_product_id: null,
-					currency: 'USD',
-					monthly_price: 9.08,
-					yearly_price: 109,
-					metadata: null,
-				},
-			],
-		},
-	] );
-}
-
-const referralProduct = ( product_id: number ): ReferralProduct =>
-	( { product_id } ) as ReferralProduct;
+const referrals = ( ...ids: number[] ): ReferralProduct[] =>
+	ids.map( ( product_id ) => ( { product_id } ) as ReferralProduct );
 
 describe( 'useProductsById', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
+		mockedGet.mockResolvedValue( PRODUCT_FAMILIES );
 	} );
 
-	it( 'maps a yearly product_id to the yearly price as amount', async () => {
-		mockProductFamilies();
-
-		const { result } = renderHook( () => useProductsById( [ referralProduct( 2714 ) ] ), {
-			wrapper,
-		} );
+	it.each( [
+		[ 'yearly', 2714, '109' ],
+		[ 'monthly', 3114, '9.08' ],
+	] as const )( 'maps a %s product_id to its price as amount', async ( _, productId, price ) => {
+		const { result } = renderHookWithProvider( () => useProductsById( referrals( productId ) ) );
 
 		await waitFor( () => expect( result.current.referredProducts ).toHaveLength( 1 ) );
 
 		const [ product ] = result.current.referredProducts;
-		expect( product.product_id ).toBe( 2714 );
-		expect( product.amount ).toBe( '109' );
-		expect( product.price_per_unit_display ).toBe( '109' );
+		expect( product.product_id ).toBe( productId );
+		expect( product.amount ).toBe( price );
+		expect( product.price_per_unit_display ).toBe( price );
 	} );
 
-	it( 'maps a monthly product_id to the monthly price as amount', async () => {
-		mockProductFamilies();
+	it( 'returns no product when the referral does not match', async () => {
+		const { result } = renderHookWithProvider( () => useProductsById( referrals( 99999 ) ) );
 
-		const { result } = renderHook( () => useProductsById( [ referralProduct( 3114 ) ] ), {
-			wrapper,
-		} );
-
-		await waitFor( () => expect( result.current.referredProducts ).toHaveLength( 1 ) );
-
-		const [ product ] = result.current.referredProducts;
-		expect( product.product_id ).toBe( 3114 );
-		expect( product.amount ).toBe( '9.08' );
-		expect( product.price_per_unit_display ).toBe( '9.08' );
-	} );
-
-	it( 'returns no product when the referral product_id does not match any product', async () => {
-		mockProductFamilies();
-
-		const { result } = renderHook( () => useProductsById( [ referralProduct( 99999 ) ] ), {
-			wrapper,
-		} );
-
-		// Wait for the fetch to settle so we know the hook ran its effect.
 		await waitFor( () => expect( mockedGet ).toHaveBeenCalled() );
 
 		expect( result.current.referredProducts ).toEqual( [] );

--- a/client/a8c-for-agencies/sections/marketplace/hooks/test/use-products-by-id.test.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/test/use-products-by-id.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import wpcom from 'calypso/lib/wp';
+import useProductsById from '../use-products-by-id';
+import type { ReferralProduct } from '../../../client/types';
+import type { ReactNode } from 'react';
+
+jest.mock( 'calypso/lib/wp', () => ( {
+	__esModule: true,
+	default: {
+		req: {
+			get: jest.fn(),
+		},
+	},
+} ) );
+
+const mockedGet = wpcom.req.get as jest.MockedFunction< typeof wpcom.req.get >;
+
+function wrapper( { children }: { children: ReactNode } ) {
+	const queryClient = new QueryClient( {
+		defaultOptions: { queries: { retry: false } },
+	} );
+	return <QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>;
+}
+
+function mockProductFamilies() {
+	mockedGet.mockResolvedValueOnce( [
+		{
+			name: 'WooCommerce Extensions',
+			slug: 'woo-extensions',
+			products: [
+				{
+					name: 'Conditional Shipping and Payments',
+					slug: 'woocommerce-conditional-shipping-payments',
+					product_id: 2714,
+					yearly_product_id: 2714,
+					monthly_product_id: 3114,
+					monthly_alternative_product_id: null,
+					yearly_alternative_product_id: null,
+					currency: 'USD',
+					monthly_price: 9.08,
+					yearly_price: 109,
+					metadata: null,
+				},
+			],
+		},
+	] );
+}
+
+const referralProduct = ( product_id: number ): ReferralProduct =>
+	( { product_id } ) as ReferralProduct;
+
+describe( 'useProductsById', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'maps a yearly product_id to the yearly price as amount', async () => {
+		mockProductFamilies();
+
+		const { result } = renderHook( () => useProductsById( [ referralProduct( 2714 ) ] ), {
+			wrapper,
+		} );
+
+		await waitFor( () => expect( result.current.referredProducts ).toHaveLength( 1 ) );
+
+		const [ product ] = result.current.referredProducts;
+		expect( product.product_id ).toBe( 2714 );
+		expect( product.amount ).toBe( '109' );
+		expect( product.price_per_unit_display ).toBe( '109' );
+	} );
+
+	it( 'maps a monthly product_id to the monthly price as amount', async () => {
+		mockProductFamilies();
+
+		const { result } = renderHook( () => useProductsById( [ referralProduct( 3114 ) ] ), {
+			wrapper,
+		} );
+
+		await waitFor( () => expect( result.current.referredProducts ).toHaveLength( 1 ) );
+
+		const [ product ] = result.current.referredProducts;
+		expect( product.product_id ).toBe( 3114 );
+		expect( product.amount ).toBe( '9.08' );
+		expect( product.price_per_unit_display ).toBe( '9.08' );
+	} );
+
+	it( 'returns no product when the referral product_id does not match any product', async () => {
+		mockProductFamilies();
+
+		const { result } = renderHook( () => useProductsById( [ referralProduct( 99999 ) ] ), {
+			wrapper,
+		} );
+
+		// Wait for the fetch to settle so we know the hook ran its effect.
+		await waitFor( () => expect( mockedGet ).toHaveBeenCalled() );
+
+		expect( result.current.referredProducts ).toEqual( [] );
+	} );
+} );

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-products-by-id.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-products-by-id.ts
@@ -43,9 +43,7 @@ export default function useProductsById( products: ReferralProduct[] | [], isEna
 					} );
 
 					if ( product && matchedProductId !== undefined ) {
-						// The client-products endpoint returns prices as monthly_price / yearly_price.
-						// Populate amount / price_per_unit_display for the matched term so downstream
-						// pricing code (which reads those legacy field names) can render a price.
+						// Mirror the matched term's price onto the legacy field names that downstream pricing code reads.
 						const matchedPriceString =
 							matchedPrice !== undefined ? String( matchedPrice ) : product.amount;
 
@@ -54,7 +52,7 @@ export default function useProductsById( products: ReferralProduct[] | [], isEna
 							product_id: matchedProductId,
 							alternative_product_id: matchedAlternativeProductId,
 							amount: matchedPriceString,
-							price_per_unit_display: product.price_per_unit_display ?? matchedPriceString,
+							price_per_unit_display: matchedPriceString,
 							quantity: 1,
 						};
 					}

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-products-by-id.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-products-by-id.ts
@@ -18,31 +18,43 @@ export default function useProductsById( products: ReferralProduct[] | [], isEna
 					let matchedProduct: ShoppingCartItem | undefined;
 					let matchedProductId: number | undefined;
 					let matchedAlternativeProductId: number | undefined;
+					let matchedPrice: number | undefined;
 
 					const product = data.find( ( product ) => {
 						if ( product.monthly_product_id === p.product_id ) {
 							matchedProductId = product.monthly_product_id;
 							matchedAlternativeProductId = product.monthly_alternative_product_id;
+							matchedPrice = product.monthly_price;
 							return true;
 						}
 						if ( product.yearly_product_id === p.product_id ) {
 							matchedProductId = product.yearly_product_id;
 							matchedAlternativeProductId = product.yearly_alternative_product_id;
+							matchedPrice = product.yearly_price;
 							return true;
 						}
 						if ( product.product_id === p.product_id ) {
 							matchedProductId = product.product_id;
 							matchedAlternativeProductId = product.alternative_product_id;
+							matchedPrice = product.yearly_price ?? product.monthly_price;
 							return true;
 						}
 						return false;
 					} );
 
 					if ( product && matchedProductId !== undefined ) {
+						// The client-products endpoint returns prices as monthly_price / yearly_price.
+						// Populate amount / price_per_unit_display for the matched term so downstream
+						// pricing code (which reads those legacy field names) can render a price.
+						const matchedPriceString =
+							matchedPrice !== undefined ? String( matchedPrice ) : product.amount;
+
 						matchedProduct = {
 							...product,
 							product_id: matchedProductId,
 							alternative_product_id: matchedAlternativeProductId,
+							amount: matchedPriceString,
+							price_per_unit_display: product.price_per_unit_display ?? matchedPriceString,
 							quantity: 1,
 						};
 					}


### PR DESCRIPTION
Part of A4A-2683

## Proposed Changes

* In `useProductsById`, set `amount` and `price_per_unit_display` on each shaped referral product, using the matched term's `monthly_price` or `yearly_price`.
* Add unit tests for `useProductsById` covering the monthly, yearly, and unmatched cases.

## Why are these changes being made?

Legacy (non-BD) clients opening a referral checkout link see €0,00 / $0.00 and can't continue.

The pricing code in `checkout-v1.tsx` reads `product.amount`, but the client products endpoint only returns `monthly_price` and `yearly_price`. The math resolves to NaN and the UI renders zero. The newer branch that does handle `monthly_price` / `yearly_price` is gated on the `a4a-bd-checkout` flag, which is off in production.

The smallest fix is to populate `amount` from the matched term so the existing math has something to read.

Slack: p1779481770675899/1779292288.639899-slack-C0707KYCAN9

## Testing Instructions

1. Send a referral to a legacy or new client.
2. Open the referral checkout link as the client: `/client/checkout?agency_id=...&referral_id=...`.
  - If testing with a new client you'll default to the BD checkout but can remove `/v2` from the url to access the legacy checkout.
3. Confirm the cart shows the right price instead of $0.00.

**AFTER**
<img width="1378" height="656" alt="Screenshot 2026-05-25 at 1 53 27 PM" src="https://github.com/user-attachments/assets/28b4a560-25c3-489f-96bb-42f3bfe36b17" />

**BEFORE**
<img width="1370" height="663" alt="Screenshot 2026-05-25 at 1 52 53 PM" src="https://github.com/user-attachments/assets/06f52345-b7ac-4469-b6cf-32dd2833930d" />

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Crafted by Travbot (Claude Code)