### PR TITLE
RSM: AI Editorial Review - Add block transform tracking

### DIFF
--- a/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
@@ -6,20 +6,21 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { Suggestion } from '@automattic/agenttic-ui';
+import type { ReactNode, Ref } from 'react';
 
 const mockSetFloatingPosition = jest.fn();
 
 jest.mock(
 	'@automattic/agenttic-ui',
 	() => {
-		const React = require( 'react' );
+		const React = jest.requireActual< typeof import('react') >( 'react' );
 
 		function MockContainer( {
 			children,
 			emptyView,
 		}: {
-			children: React.ReactNode;
-			emptyView: React.ReactNode;
+			children: ReactNode;
+			emptyView: ReactNode;
 		} ) {
 			return (
 				<div>
@@ -30,13 +31,13 @@ jest.mock(
 		}
 
 		const MockConversationView = React.forwardRef(
-			( { children }: { children: React.ReactNode }, ref: React.Ref< HTMLDivElement > ) => (
+			( { children }: { children: ReactNode }, ref: Ref< HTMLDivElement > ) => (
 				<div ref={ ref }>{ children }</div>
 			)
 		);
 		MockConversationView.displayName = 'MockConversationView';
 
-		function MockFooter( { children }: { children: React.ReactNode } ) {
+		function MockFooter( { children }: { children: ReactNode } ) {
 			return <div>{ children }</div>;
 		}
 
@@ -64,7 +65,7 @@ jest.mock(
 			);
 		}
 
-		function MockMessageRenderer( { children }: { children: React.ReactNode } ) {
+		function MockMessageRenderer( { children }: { children: ReactNode } ) {
 			return <>{ children }</>;
 		}
 

--- a/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-disable import/order -- jest.mock calls must precede imports */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { Suggestion } from '@automattic/agenttic-ui';
+
+const mockSetFloatingPosition = jest.fn();
+
+jest.mock(
+	'@automattic/agenttic-ui',
+	() => {
+		const React = require( 'react' );
+
+		function MockContainer( {
+			children,
+			emptyView,
+		}: {
+			children: React.ReactNode;
+			emptyView: React.ReactNode;
+		} ) {
+			return (
+				<div>
+					{ emptyView }
+					{ children }
+				</div>
+			);
+		}
+
+		const MockConversationView = React.forwardRef(
+			( { children }: { children: React.ReactNode }, ref: React.Ref< HTMLDivElement > ) => (
+				<div ref={ ref }>{ children }</div>
+			)
+		);
+		MockConversationView.displayName = 'MockConversationView';
+
+		function MockFooter( { children }: { children: React.ReactNode } ) {
+			return <div>{ children }</div>;
+		}
+
+		function MockEmptyView( {
+			suggestions = [],
+			onSuggestionClick,
+		}: {
+			suggestions?: Suggestion[];
+			onSuggestionClick?: (
+				selectedSuggestion: Suggestion,
+				availableSuggestions: Suggestion[]
+			) => void;
+		} ) {
+			return (
+				<div>
+					{ suggestions.map( ( suggestion ) => (
+						<button
+							key={ suggestion.id }
+							onClick={ () => onSuggestionClick?.( suggestion, suggestions ) }
+						>
+							{ suggestion.label }
+						</button>
+					) ) }
+				</div>
+			);
+		}
+
+		function MockMessageRenderer( { children }: { children: React.ReactNode } ) {
+			return <>{ children }</>;
+		}
+
+		const MockImageUploader = React.forwardRef( () => null );
+		MockImageUploader.displayName = 'MockImageUploader';
+
+		return {
+			AgentUI: {
+				Container: MockContainer,
+				ConversationView: MockConversationView,
+				Messages: () => null,
+				Footer: MockFooter,
+				Suggestions: () => null,
+				Notice: () => null,
+				Input: () => null,
+			},
+			createMessageRenderer: () => MockMessageRenderer,
+			EmptyView: MockEmptyView,
+			ImageUploader: MockImageUploader,
+		};
+	},
+	{ virtual: true }
+);
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: () => ( {
+		setFloatingPosition: mockSetFloatingPosition,
+	} ),
+	useSelect: ( selectFn: ( select: () => { getAgentsManagerState: () => object } ) => unknown ) =>
+		selectFn( () => ( {
+			getAgentsManagerState: () => ( { floatingPosition: undefined } ),
+		} ) ),
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( { __: ( text: string ) => text } ) );
+jest.mock( '../../stores', () => ( {
+	AGENTS_MANAGER_STORE: 'automattic/agents-manager',
+} ) );
+jest.mock( '../chat-header', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+jest.mock( '../context-cards', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+jest.mock( '../feedback-input', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+jest.mock( '../icons', () => ( {
+	AI: () => null,
+} ) );
+jest.mock( '../selected-block', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+jest.mock( '../../utils/is-plugin-compass-agent', () => ( {
+	isPluginCompassHost: () => false,
+} ) );
+jest.mock( '../../utils/is-reader-chat-agent', () => ( {
+	isReaderChatHost: () => false,
+} ) );
+
+import AgentChat from '../agent-chat';
+
+describe( 'AgentChat', () => {
+	it( 'forwards empty view suggestion clicks to the shared suggestion handler', async () => {
+		const user = userEvent.setup();
+		const suggestion = {
+			id: 'check-grammar',
+			label: 'Check grammar',
+			prompt: 'Check the grammar and spelling of this text',
+		};
+		const onSuggestionClick = jest.fn();
+
+		render(
+			<AgentChat
+				messages={ [] }
+				suggestions={ [] }
+				emptyViewSuggestions={ [ suggestion ] }
+				error={ null }
+				chatHeaderOptions={ [] }
+				isProcessing={ false }
+				isLoadingConversation={ false }
+				isDocked={ false }
+				isOpen
+				onSubmit={ jest.fn() }
+				onAbort={ jest.fn() }
+				onClose={ jest.fn() }
+				onExpand={ jest.fn() }
+				onSuggestionClick={ onSuggestionClick }
+			/>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Check grammar' } ) );
+
+		expect( onSuggestionClick ).toHaveBeenCalledWith( suggestion, [ suggestion ] );
+	} );
+} );

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -162,4 +162,48 @@ describe( 'OrchestratorChat', () => {
 
 		window.removeEventListener( 'big-sky-inline-suggestion-click', listener );
 	} );
+
+	it( 'passes the floating suggestion limit to external providers', () => {
+		const useSuggestions = jest.fn( () => ( { suggestions: [] } ) );
+
+		render(
+			<OrchestratorChat
+				emptyViewSuggestions={ [] }
+				isDocked={ false }
+				isOpen
+				onClose={ jest.fn() }
+				onExpand={ jest.fn() }
+				chatHeaderOptions={ [] }
+				markdownComponents={ {} }
+				markdownExtensions={ {} }
+				isCompactMode={ false }
+				useSuggestions={ useSuggestions }
+				onHasMessagesChange={ jest.fn() }
+			/>
+		);
+
+		expect( useSuggestions ).toHaveBeenCalledWith( 3, { suggestionsVisible: true } );
+	} );
+
+	it( 'does not limit external provider suggestions while docked', () => {
+		const useSuggestions = jest.fn( () => ( { suggestions: [] } ) );
+
+		render(
+			<OrchestratorChat
+				emptyViewSuggestions={ [] }
+				isDocked
+				isOpen
+				onClose={ jest.fn() }
+				onExpand={ jest.fn() }
+				chatHeaderOptions={ [] }
+				markdownComponents={ {} }
+				markdownExtensions={ {} }
+				isCompactMode={ false }
+				useSuggestions={ useSuggestions }
+				onHasMessagesChange={ jest.fn() }
+			/>
+		);
+
+		expect( useSuggestions ).toHaveBeenCalledWith( undefined, { suggestionsVisible: true } );
+	} );
 } );

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -61,18 +61,27 @@ jest.mock( '../../utils/persist-last-activity', () => ( {
 } ) );
 jest.mock( '../agent-chat', () => ( {
 	__esModule: true,
-	default: ( { onSuggestionClick }: { onSuggestionClick: ( suggestion: Suggestion ) => void } ) => (
-		<button
-			onClick={ () =>
-				onSuggestionClick( {
-					id: 'simplify-text',
-					label: 'Simplify text',
-					prompt: 'Simplify this text to make it easier to read',
-				} )
-			}
-		>
-			Click suggestion
-		</button>
+	default: ( {
+		onSuggestionClick,
+	}: {
+		onSuggestionClick: ( suggestion: Suggestion | string ) => void;
+	} ) => (
+		<>
+			<button
+				onClick={ () =>
+					onSuggestionClick( {
+						id: 'simplify-text',
+						label: 'Simplify text',
+						prompt: 'Simplify this text to make it easier to read',
+					} )
+				}
+			>
+				Click suggestion
+			</button>
+			<button onClick={ () => onSuggestionClick( 'Check the grammar and spelling of this text' ) }>
+				Click string suggestion
+			</button>
+		</>
 	),
 } ) );
 
@@ -120,6 +129,35 @@ describe( 'OrchestratorChat', () => {
 		expect( listener ).toHaveBeenCalledTimes( 1 );
 		expect( ( listener.mock.calls[ 0 ][ 0 ] as CustomEvent ).detail ).toEqual( {
 			value: 'Simplify this text to make it easier to read',
+		} );
+
+		window.removeEventListener( 'big-sky-inline-suggestion-click', listener );
+	} );
+
+	it( 'dispatches the inline suggestion event when Agenttic passes a prompt string', () => {
+		const listener = jest.fn();
+		window.addEventListener( 'big-sky-inline-suggestion-click', listener );
+
+		render(
+			<OrchestratorChat
+				emptyViewSuggestions={ [] }
+				isDocked={ false }
+				isOpen
+				onClose={ jest.fn() }
+				onExpand={ jest.fn() }
+				chatHeaderOptions={ [] }
+				markdownComponents={ {} }
+				markdownExtensions={ {} }
+				isCompactMode={ false }
+				onHasMessagesChange={ jest.fn() }
+			/>
+		);
+
+		fireEvent.click( screen.getByText( 'Click string suggestion' ) );
+
+		expect( listener ).toHaveBeenCalledTimes( 1 );
+		expect( ( listener.mock.calls[ 0 ][ 0 ] as CustomEvent ).detail ).toEqual( {
+			value: 'Check the grammar and spelling of this text',
 		} );
 
 		window.removeEventListener( 'big-sky-inline-suggestion-click', listener );

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -252,6 +252,7 @@ export default function AgentChat( {
 						heading={ getEmptyViewHeading() }
 						help={ emptyViewSuggestions.length > 0 ? getEmptyViewHelp() : undefined }
 						suggestions={ emptyViewSuggestions }
+						onSuggestionClick={ onSuggestionClick }
 						icon={ <AI size={ 32 } /> }
 					/>
 				)

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -62,8 +62,8 @@ interface Props {
 	clearSuggestions?: () => void;
 	/** Called when a suggestion is clicked. */
 	onSuggestionClick?: (
-		selectedSuggestion: Suggestion,
-		availableSuggestions: Suggestion[]
+		selectedSuggestion: Suggestion | string,
+		availableSuggestions?: Suggestion[]
 	) => void;
 	/** Called when the typing status changes. */
 	onTypingStatusChange?: ( isTyping: boolean ) => void;

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -154,7 +154,9 @@ export default function OrchestratorChat( {
 	} );
 
 	// Use dynamic suggestions from the external provider (e.g., Big Sky block-based suggestions)
-	const dynamicSuggestions = useSuggestions?.();
+	const dynamicSuggestions = useSuggestions?.( undefined, {
+		suggestionsVisible: isOpen || isCompactMode,
+	} );
 	const dynamicSuggestionsList = dynamicSuggestions?.suggestions ?? [];
 	const dynamicSuggestionsKey = JSON.stringify(
 		dynamicSuggestionsList.map( ( s ) => [ s.id, s.label, s.prompt ] )
@@ -367,8 +369,9 @@ export default function OrchestratorChat( {
 		};
 	}, [] );
 
-	const handleSuggestionClick = useCallback( ( suggestion: Suggestion ) => {
-		const value = suggestion.prompt ?? suggestion.label;
+	const handleSuggestionClick = useCallback( ( suggestion: Suggestion | string ) => {
+		const value =
+			typeof suggestion === 'string' ? suggestion : suggestion.prompt ?? suggestion.label;
 		window.dispatchEvent(
 			new CustomEvent( 'big-sky-inline-suggestion-click', { detail: { value } } )
 		);

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -154,7 +154,8 @@ export default function OrchestratorChat( {
 	} );
 
 	// Use dynamic suggestions from the external provider (e.g., Big Sky block-based suggestions)
-	const dynamicSuggestions = useSuggestions?.( undefined, {
+	const maxDynamicSuggestions = isDocked ? undefined : 3;
+	const dynamicSuggestions = useSuggestions?.( maxDynamicSuggestions, {
 		suggestionsVisible: isOpen || isCompactMode,
 	} );
 	const dynamicSuggestionsList = dynamicSuggestions?.suggestions ?? [];

--- a/packages/agents-manager/src/components/selected-block/index.tsx
+++ b/packages/agents-manager/src/components/selected-block/index.tsx
@@ -20,6 +20,8 @@ const animations = {
 	},
 };
 
+const SELECTED_BLOCK_CLEAR_EVENT = 'agents-manager-selected-block-cleared';
+
 export default function SelectedBlock() {
 	const { block, name, icon } = useSelect( ( select ) => {
 		const selectedBlock = select( blockEditorStore ).getSelectedBlock();
@@ -43,6 +45,11 @@ export default function SelectedBlock() {
 
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );
 
+	const handleClearSelectedBlock = () => {
+		clearSelectedBlock();
+		window.dispatchEvent( new Event( SELECTED_BLOCK_CLEAR_EVENT ) );
+	};
+
 	if ( ! block ) {
 		return null;
 	}
@@ -62,7 +69,7 @@ export default function SelectedBlock() {
 				className="agents-manager-selected-block__remove"
 				icon={ close }
 				iconSize={ 16 }
-				onClick={ clearSelectedBlock }
+				onClick={ handleClearSelectedBlock }
 				label={ __( 'Clear selection', 'big-sky' ) }
 			/>
 		</motion.div>

--- a/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
@@ -130,4 +130,16 @@ describe( 'mergeUseSuggestionsHooks', () => {
 			],
 		} );
 	} );
+
+	it( 'forwards suggestion visibility options to provider hooks', () => {
+		const firstHook = jest.fn( () => ( { suggestions: [] } ) ) as UseSuggestionsHook;
+		const secondHook = jest.fn( () => ( { suggestions: [] } ) ) as UseSuggestionsHook;
+		const merged = mergeUseSuggestionsHooks( [ firstHook, secondHook ] );
+		const options = { suggestionsVisible: false };
+
+		merged?.( undefined, options );
+
+		expect( firstHook ).toHaveBeenCalledWith( undefined, options );
+		expect( secondHook ).toHaveBeenCalledWith( undefined, options );
+	} );
 } );

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -71,7 +71,10 @@ export type AbilitiesSetupHook = ( actions: {
  * Suggestions hook type - for providing dynamic suggestions based on context
  * (e.g., selected block in editor). Returns an array of suggestions.
  */
-export type UseSuggestionsHook = ( maxSuggestions?: number ) => {
+export type UseSuggestionsHook = (
+	maxSuggestions?: number,
+	options?: { suggestionsVisible?: boolean }
+) => {
 	suggestions: Suggestion[];
 } | void;
 
@@ -173,11 +176,11 @@ export function mergeUseSuggestionsHooks(
 		return hooks[ 0 ];
 	}
 
-	return ( maxSuggestions?: number ) => {
+	return ( maxSuggestions?: number, options?: { suggestionsVisible?: boolean } ) => {
 		const combined: Suggestion[] = [];
 		const seenIds = new Set< string >();
 		for ( const hook of hooks ) {
-			const suggestions = hook( maxSuggestions )?.suggestions ?? [];
+			const suggestions = hook( maxSuggestions, options )?.suggestions ?? [];
 			for ( const s of suggestions ) {
 				if ( ! seenIds.has( s.id ) ) {
 					seenIds.add( s.id );

--- a/packages/jetpack-ai-sidebar/src/components/review-mediation.scss
+++ b/packages/jetpack-ai-sidebar/src/components/review-mediation.scss
@@ -99,6 +99,12 @@
 }
 
 .jetpack-ai-review-mediation {
+	--jetpack-ai-review-action-border: color-mix(in srgb, currentColor 25%, transparent);
+	--jetpack-ai-review-action-border-hover: color-mix(in srgb, currentColor 45%, transparent);
+	--jetpack-ai-review-action-bg-hover: color-mix(in srgb, currentColor 6%, transparent);
+	--jetpack-ai-review-primary: var(--color-primary, var(--wp-admin-theme-color, #3858e9));
+	--jetpack-ai-review-primary-foreground: var(--color-primary-foreground, #fff);
+
 	display: flex;
 	flex-direction: column;
 	font-size: 13px;
@@ -516,7 +522,7 @@
 		line-height: 1.35;
 		cursor: pointer;
 		border-radius: 4px;
-		border: 1px solid rgba(255, 255, 255, 0.25);
+		border: 1px solid var(--jetpack-ai-review-action-border);
 		background: transparent;
 		color: inherit;
 		text-align: center;
@@ -525,23 +531,25 @@
 			background 0.15s ease;
 
 		&:hover:not(:disabled) {
-			border-color: rgba(255, 255, 255, 0.45);
-			background: rgba(255, 255, 255, 0.06);
+			border-color: var(--jetpack-ai-review-action-border-hover);
+			background: var(--jetpack-ai-review-action-bg-hover);
 		}
 
 		&.is-accept {
-			background: var(--wp-admin-theme-color, #3858e9);
-			color: #fff;
-			border-color: var(--wp-admin-theme-color, #3858e9);
+			background: var(--jetpack-ai-review-primary);
+			color: var(--jetpack-ai-review-primary-foreground);
+			border-color: var(--jetpack-ai-review-primary);
 
 			&:hover:not(:disabled) {
-				filter: brightness(1.1);
+				background: color-mix(in srgb, var(--jetpack-ai-review-primary) 88%, #000);
+				border-color: color-mix(in srgb, var(--jetpack-ai-review-primary) 88%, #000);
+				filter: none;
 			}
 		}
 
 		&:disabled {
 			cursor: default;
-			opacity: 0.5;
+			opacity: 0.65;
 		}
 	}
 
@@ -807,8 +815,8 @@
 	&__ai-badge {
 		display: inline-flex;
 		flex: 0 0 auto;
-		background: var(--wp-admin-theme-color, #3858e9);
-		color: #fff;
+		background: var(--jetpack-ai-review-primary);
+		color: var(--jetpack-ai-review-primary-foreground);
 		font-size: 10px;
 		padding: 2px 6px;
 		border-radius: 3px;
@@ -851,11 +859,11 @@
 	&__action.is-reviewer {
 		background: transparent;
 		color: inherit;
-		border-color: rgba(255, 255, 255, 0.35);
+		border-color: var(--jetpack-ai-review-action-border);
 
 		&:hover:not(:disabled) {
-			border-color: rgba(255, 255, 255, 0.55);
-			background: rgba(255, 255, 255, 0.06);
+			border-color: var(--jetpack-ai-review-action-border-hover);
+			background: var(--jetpack-ai-review-action-bg-hover);
 		}
 	}
 
@@ -872,18 +880,19 @@
 		font-size: 13px;
 		font-weight: 600;
 		cursor: pointer;
-		border: 1px solid var(--wp-admin-theme-color, #3858e9);
-		background: var(--wp-admin-theme-color, #3858e9);
-		color: #fff;
-		transition: filter 0.15s ease, opacity 0.15s ease;
+		border: 1px solid var(--jetpack-ai-review-primary);
+		background: var(--jetpack-ai-review-primary);
+		color: var(--jetpack-ai-review-primary-foreground);
+		transition: background 0.15s ease, border-color 0.15s ease, opacity 0.15s ease;
 
 		&:hover:not(:disabled) {
-			filter: brightness(1.1);
+			background: color-mix(in srgb, var(--jetpack-ai-review-primary) 88%, #000);
+			border-color: color-mix(in srgb, var(--jetpack-ai-review-primary) 88%, #000);
 		}
 
 		&:disabled {
 			cursor: default;
-			opacity: 0.5;
+			opacity: 0.65;
 		}
 	}
 }

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -361,7 +361,7 @@ describe( 'useSuggestions', () => {
 
 	it( 'keeps AI Editorial Review visible when block suggestions are limited', () => {
 		installAiEditorialReviewData();
-		mockSelectedBlock = { clientId: 'b-limited', name: 'core/paragraph' };
+		mockSelectedBlock = { clientId: 'b-limited', name: 'core/heading' };
 		const onSuggestions = jest.fn();
 
 		render(
@@ -377,6 +377,26 @@ describe( 'useSuggestions', () => {
 			'Translate content',
 			'Check grammar',
 			'AI Editorial Review',
+		] );
+		expect( getTracksCalls( 'jetpack_ai_block_transformation_suggestion_rendered' ) ).toEqual( [
+			[
+				'jetpack_ai_block_transformation_suggestion_rendered',
+				{
+					suggestion_id: 'translate',
+					suggestion_type: 'text',
+					block_type: 'core/heading',
+					surface: 'jetpack_ai_sidebar',
+				},
+			],
+			[
+				'jetpack_ai_block_transformation_suggestion_rendered',
+				{
+					suggestion_id: 'check-grammar',
+					suggestion_type: 'text',
+					block_type: 'core/heading',
+					surface: 'jetpack_ai_sidebar',
+				},
+			],
 		] );
 	} );
 

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -152,6 +152,10 @@ function SuggestionsProbe( { onSuggestions }: { onSuggestions: ( suggestions: an
 	return null;
 }
 
+function getTracksCalls( eventName: string ) {
+	return mockedRecordTracksEvent.mock.calls.filter( ( [ name ] ) => name === eventName );
+}
+
 describe( 'getChatComponent', () => {
 	it( 'returns TitlePicker for type "title-picker"', () => {
 		expect( getChatComponent( 'title-picker' ) ).toBe( TitlePicker );
@@ -283,6 +287,70 @@ describe( 'useSuggestions', () => {
 			'Simplify text',
 			'AI Editorial Review',
 		] );
+		expect( getTracksCalls( 'jetpack_ai_block_transformation_suggestion_rendered' ) ).toEqual( [
+			[
+				'jetpack_ai_block_transformation_suggestion_rendered',
+				{
+					suggestion_id: 'translate',
+					suggestion_type: 'text',
+					block_type: 'core/paragraph',
+					surface: 'jetpack_ai_sidebar',
+				},
+			],
+			[
+				'jetpack_ai_block_transformation_suggestion_rendered',
+				{
+					suggestion_id: 'change-tone',
+					suggestion_type: 'text',
+					block_type: 'core/paragraph',
+					surface: 'jetpack_ai_sidebar',
+				},
+			],
+			[
+				'jetpack_ai_block_transformation_suggestion_rendered',
+				{
+					suggestion_id: 'check-grammar',
+					suggestion_type: 'text',
+					block_type: 'core/paragraph',
+					surface: 'jetpack_ai_sidebar',
+				},
+			],
+			[
+				'jetpack_ai_block_transformation_suggestion_rendered',
+				{
+					suggestion_id: 'simplify-text',
+					suggestion_type: 'text',
+					block_type: 'core/paragraph',
+					surface: 'jetpack_ai_sidebar',
+				},
+			],
+		] );
+	} );
+
+	it( 'tracks rendered image block transformation suggestions', () => {
+		installAiEditorialReviewData();
+		mockSelectedBlock = { clientId: 'b2', name: 'core/image' };
+		const onSuggestions = jest.fn();
+
+		render( React.createElement( SuggestionsProbe, { onSuggestions } ) );
+
+		const latestSuggestions =
+			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
+		expect( latestSuggestions.map( ( suggestion: any ) => suggestion.label ) ).toEqual( [
+			'Generate alt text',
+			'AI Editorial Review',
+		] );
+		expect( getTracksCalls( 'jetpack_ai_block_transformation_suggestion_rendered' ) ).toEqual( [
+			[
+				'jetpack_ai_block_transformation_suggestion_rendered',
+				{
+					suggestion_id: 'generate-alt-text',
+					suggestion_type: 'image',
+					block_type: 'core/image',
+					surface: 'jetpack_ai_sidebar',
+				},
+			],
+		] );
 	} );
 
 	it( 'keeps AI Editorial Review when the preview feature disables block transformations', () => {
@@ -341,6 +409,53 @@ describe( 'useSuggestions', () => {
 			'jetpack_ai_editorial_review_suggestion_click',
 			{}
 		);
+		expect( getTracksCalls( 'jetpack_ai_block_transformation_suggestion_click' ) ).toEqual( [] );
+	} );
+
+	it( 'tracks block transformation suggestion clicks', () => {
+		installAiEditorialReviewData();
+		installPostTypeMock( 'post' );
+		mockSelectedBlock = { clientId: 'b3', name: 'core/heading' };
+
+		render( React.createElement( SuggestionsProbe, { onSuggestions: jest.fn() } ) );
+		mockedRecordTracksEvent.mockClear();
+
+		act( () => {
+			window.dispatchEvent(
+				new CustomEvent( 'big-sky-inline-suggestion-click', {
+					detail: { value: 'Simplify this text to make it easier to read' },
+				} )
+			);
+		} );
+
+		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_ai_block_transformation_suggestion_click',
+			{
+				suggestion_id: 'simplify-text',
+				suggestion_type: 'text',
+				block_type: 'core/heading',
+				surface: 'jetpack_ai_sidebar',
+			}
+		);
+	} );
+
+	it( 'does not track block transformation clicks for unknown prompt values', () => {
+		installAiEditorialReviewData();
+		installPostTypeMock( 'post' );
+		mockSelectedBlock = { clientId: 'b4', name: 'core/heading' };
+
+		render( React.createElement( SuggestionsProbe, { onSuggestions: jest.fn() } ) );
+		mockedRecordTracksEvent.mockClear();
+
+		act( () => {
+			window.dispatchEvent(
+				new CustomEvent( 'big-sky-inline-suggestion-click', {
+					detail: { value: 'Write an unrelated prompt' },
+				} )
+			);
+		} );
+
+		expect( getTracksCalls( 'jetpack_ai_block_transformation_suggestion_click' ) ).toEqual( [] );
 	} );
 
 	it( 'does not open split-screen when AI Editorial Review is unavailable', () => {

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -194,10 +194,6 @@ describe( 'getEmptyViewSuggestions', () => {
 		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
 		expect( labels ).not.toContain( 'Optimize Title' );
 		expect( labels ).toContain( 'AI Editorial Review' );
-		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
-			'jetpack_ai_editorial_review_suggestion_rendered',
-			{}
-		);
 	} );
 
 	it( 'supports the legacy reviewMediatorEnabled flag while bundles roll forward', () => {
@@ -287,6 +283,10 @@ describe( 'useSuggestions', () => {
 			'Simplify text',
 			'AI Editorial Review',
 		] );
+		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_ai_editorial_review_suggestion_rendered',
+			{}
+		);
 		expect( getTracksCalls( 'jetpack_ai_block_transformation_suggestion_rendered' ) ).toEqual( [
 			[
 				'jetpack_ai_block_transformation_suggestion_rendered',

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -144,8 +144,14 @@ function installAiEditorialReviewData( features: Record< string, boolean > = {} 
 	};
 }
 
-function SuggestionsProbe( { onSuggestions }: { onSuggestions: ( suggestions: any[] ) => void } ) {
-	const { suggestions } = useSuggestions();
+function SuggestionsProbe( {
+	onSuggestions,
+	suggestionsVisible = true,
+}: {
+	onSuggestions: ( suggestions: any[] ) => void;
+	suggestionsVisible?: boolean;
+} ) {
+	const { suggestions } = useSuggestions( undefined, { suggestionsVisible } );
 	React.useEffect( () => {
 		onSuggestions( suggestions );
 	}, [ onSuggestions, suggestions ] );
@@ -265,6 +271,26 @@ describe( 'useSuggestions', () => {
 	afterEach( () => {
 		delete ( globalThis as any ).agentsManagerData;
 		delete ( window as any ).wp;
+	} );
+
+	it( 'does not track rendered suggestions when the suggestions are not visible', () => {
+		installAiEditorialReviewData();
+		mockSelectedBlock = { clientId: 'b-hidden', name: 'core/paragraph' };
+		const onSuggestions = jest.fn();
+
+		render( React.createElement( SuggestionsProbe, { onSuggestions, suggestionsVisible: false } ) );
+
+		const latestSuggestions =
+			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
+		expect( latestSuggestions.map( ( suggestion: any ) => suggestion.label ) ).toEqual( [
+			'Translate content',
+			'Change tone',
+			'Check grammar',
+			'Simplify text',
+			'AI Editorial Review',
+		] );
+		expect( getTracksCalls( 'jetpack_ai_editorial_review_suggestion_rendered' ) ).toEqual( [] );
+		expect( getTracksCalls( 'jetpack_ai_block_transformation_suggestion_rendered' ) ).toEqual( [] );
 	} );
 
 	it( 'appends AI Editorial Review to block-specific suggestions', () => {
@@ -439,10 +465,65 @@ describe( 'useSuggestions', () => {
 		);
 	} );
 
+	it( 'tracks block transformation suggestion clicks by label', () => {
+		installAiEditorialReviewData();
+		installPostTypeMock( 'post' );
+		mockSelectedBlock = { clientId: 'b4', name: 'core/paragraph' };
+
+		render( React.createElement( SuggestionsProbe, { onSuggestions: jest.fn() } ) );
+		mockedRecordTracksEvent.mockClear();
+
+		act( () => {
+			window.dispatchEvent(
+				new CustomEvent( 'big-sky-inline-suggestion-click', {
+					detail: { value: 'Check grammar' },
+				} )
+			);
+		} );
+
+		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_ai_block_transformation_suggestion_click',
+			{
+				suggestion_id: 'check-grammar',
+				suggestion_type: 'text',
+				block_type: 'core/paragraph',
+				surface: 'jetpack_ai_sidebar',
+			}
+		);
+	} );
+
+	it( 'tracks block transformation suggestion clicks after block selection is cleared', () => {
+		installAiEditorialReviewData();
+		installPostTypeMock( 'post' );
+		mockSelectedBlock = { clientId: 'b5', name: 'core/paragraph' };
+
+		render( React.createElement( SuggestionsProbe, { onSuggestions: jest.fn() } ) );
+		mockedRecordTracksEvent.mockClear();
+		mockSelectedBlock = null;
+
+		act( () => {
+			window.dispatchEvent(
+				new CustomEvent( 'big-sky-inline-suggestion-click', {
+					detail: { value: 'Check the grammar and spelling of this text' },
+				} )
+			);
+		} );
+
+		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_ai_block_transformation_suggestion_click',
+			{
+				suggestion_id: 'check-grammar',
+				suggestion_type: 'text',
+				block_type: 'core/paragraph',
+				surface: 'jetpack_ai_sidebar',
+			}
+		);
+	} );
+
 	it( 'does not track block transformation clicks for unknown prompt values', () => {
 		installAiEditorialReviewData();
 		installPostTypeMock( 'post' );
-		mockSelectedBlock = { clientId: 'b4', name: 'core/heading' };
+		mockSelectedBlock = { clientId: 'b6', name: 'core/heading' };
 
 		render( React.createElement( SuggestionsProbe, { onSuggestions: jest.fn() } ) );
 		mockedRecordTracksEvent.mockClear();

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -36,6 +36,7 @@ const mockedRecordTracksEvent = recordTracksEvent as jest.MockedFunction<
 >;
 let mockSelectedBlock: any = null;
 let mockCurrentPostType: string | undefined = 'post';
+let mockBlocksByClientId: Record< string, any > = {};
 
 jest.mock( '@wordpress/components', () => {
 	const React = require( 'react' );
@@ -61,6 +62,7 @@ jest.mock( '@wordpress/data', () => ( {
 			if ( store === 'core/block-editor' ) {
 				return {
 					getSelectedBlock: () => mockSelectedBlock,
+					getBlock: ( clientId: string ) => mockBlocksByClientId[ clientId ],
 					getBlocks: () => [],
 				};
 			}
@@ -118,6 +120,7 @@ function installPostTypeMock( postType?: string ) {
 				if ( store === 'core/block-editor' ) {
 					return {
 						getSelectedBlock: () => mockSelectedBlock,
+						getBlock: ( clientId: string ) => mockBlocksByClientId[ clientId ],
 						getBlocks: () => [],
 					};
 				}
@@ -146,12 +149,14 @@ function installAiEditorialReviewData( features: Record< string, boolean > = {} 
 
 function SuggestionsProbe( {
 	onSuggestions,
+	maxSuggestions,
 	suggestionsVisible = true,
 }: {
 	onSuggestions: ( suggestions: any[] ) => void;
+	maxSuggestions?: number;
 	suggestionsVisible?: boolean;
 } ) {
-	const { suggestions } = useSuggestions( undefined, { suggestionsVisible } );
+	const { suggestions } = useSuggestions( maxSuggestions, { suggestionsVisible } );
 	React.useEffect( () => {
 		onSuggestions( suggestions );
 	}, [ onSuggestions, suggestions ] );
@@ -262,6 +267,7 @@ describe( 'getEmptyViewSuggestions', () => {
 describe( 'useSuggestions', () => {
 	beforeEach( () => {
 		mockSelectedBlock = null;
+		mockBlocksByClientId = {};
 		mockCurrentPostType = 'post';
 		mockSetIsSplitScreen.mockReset();
 		mockedRecordTracksEvent.mockClear();
@@ -350,6 +356,55 @@ describe( 'useSuggestions', () => {
 					surface: 'jetpack_ai_sidebar',
 				},
 			],
+		] );
+	} );
+
+	it( 'keeps AI Editorial Review visible when block suggestions are limited', () => {
+		installAiEditorialReviewData();
+		mockSelectedBlock = { clientId: 'b-limited', name: 'core/paragraph' };
+		const onSuggestions = jest.fn();
+
+		render(
+			React.createElement( SuggestionsProbe, {
+				onSuggestions,
+				maxSuggestions: 3,
+			} )
+		);
+
+		const latestSuggestions =
+			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
+		expect( latestSuggestions.map( ( suggestion: any ) => suggestion.label ) ).toEqual( [
+			'Translate content',
+			'Check grammar',
+			'AI Editorial Review',
+		] );
+	} );
+
+	it( 'shows post-level suggestions after the selected-block chip is cleared', () => {
+		installAiEditorialReviewData();
+		const block = { clientId: 'b-clear', name: 'core/paragraph' };
+		mockSelectedBlock = block;
+		mockBlocksByClientId[ block.clientId ] = block;
+		const onSuggestions = jest.fn();
+
+		const { rerender } = render( React.createElement( SuggestionsProbe, { onSuggestions } ) );
+
+		let latestSuggestions =
+			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
+		expect( latestSuggestions.map( ( suggestion: any ) => suggestion.label ) ).toContain(
+			'Translate content'
+		);
+
+		mockSelectedBlock = null;
+		act( () => {
+			window.dispatchEvent( new Event( 'agents-manager-selected-block-cleared' ) );
+		} );
+		rerender( React.createElement( SuggestionsProbe, { onSuggestions } ) );
+
+		latestSuggestions =
+			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
+		expect( latestSuggestions.map( ( suggestion: any ) => suggestion.label ) ).toEqual( [
+			'AI Editorial Review',
 		] );
 	} );
 

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -10,7 +10,7 @@
  * WordPress dependencies
  */
 import { dispatch, useSelect } from '@wordpress/data';
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useEffect, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
@@ -150,13 +150,17 @@ function isAiEditorialReviewAvailable(
 	return isAiEditorialReviewEnabled() && currentPostType === 'post';
 }
 
+function trackAiEditorialReviewSuggestionRenderedOnce(): void {
+	if ( suggestionRenderedFiredOnce ) {
+		return;
+	}
+	suggestionRenderedFiredOnce = true;
+	trackAiEditorialReviewSuggestionRendered();
+}
+
 function getAiEditorialReviewSuggestions( currentPostType?: string ) {
 	if ( ! isAiEditorialReviewAvailable( currentPostType ) ) {
 		return [];
-	}
-	if ( ! suggestionRenderedFiredOnce ) {
-		suggestionRenderedFiredOnce = true;
-		trackAiEditorialReviewSuggestionRendered();
 	}
 	return [ AI_EDITORIAL_REVIEW_SUGGESTION ];
 }
@@ -752,27 +756,57 @@ export function useSuggestions(): {
 		setHidden( false );
 	}, [ editorContext.selectedBlock?.clientId ] );
 
+	const selectedBlock = editorContext.selectedBlock ?? getSelectedOrRememberedBlock();
+	const aiEditorialReviewSuggestions = getAiEditorialReviewSuggestions( editorContext.postType );
+	const blockTransformationsEnabled = isBlockTransformationsEnabled();
+	const applicable = useMemo(
+		() =>
+			selectedBlock && blockTransformationsEnabled
+				? BLOCK_SUGGESTIONS.filter( ( suggestion ) => suggestion.condition( selectedBlock ) )
+				: [],
+		[ blockTransformationsEnabled, selectedBlock ]
+	);
+	const applicableSuggestionsKey = applicable.map( ( suggestion ) => suggestion.id ).join( '|' );
+
+	useEffect( () => {
+		if ( editorContext.selectedBlock ) {
+			rememberSelectedBlock( editorContext.selectedBlock );
+		}
+	}, [ editorContext.selectedBlock?.clientId, editorContext.selectedBlock ] );
+
+	useEffect( () => {
+		if ( hidden || aiEditorialReviewSuggestions.length === 0 ) {
+			return;
+		}
+		trackAiEditorialReviewSuggestionRenderedOnce();
+	}, [ hidden, aiEditorialReviewSuggestions.length ] );
+
+	useEffect( () => {
+		if ( hidden || ! selectedBlock || ! blockTransformationsEnabled ) {
+			return;
+		}
+		trackRenderedBlockTransformationSuggestions( applicable, selectedBlock );
+	}, [
+		applicable,
+		applicableSuggestionsKey,
+		blockTransformationsEnabled,
+		hidden,
+		selectedBlock,
+		selectedBlock?.name,
+	] );
+
 	if ( hidden ) {
 		return { suggestions: [] };
-	}
-
-	const selectedBlock = editorContext.selectedBlock ?? getSelectedOrRememberedBlock();
-	if ( editorContext.selectedBlock ) {
-		rememberSelectedBlock( editorContext.selectedBlock );
 	}
 
 	if ( ! selectedBlock ) {
 		return { suggestions: getPostLevelSuggestions( editorContext.postType ) };
 	}
 
-	const aiEditorialReviewSuggestions = getAiEditorialReviewSuggestions( editorContext.postType );
-
-	if ( ! isBlockTransformationsEnabled() ) {
+	if ( ! blockTransformationsEnabled ) {
 		return { suggestions: aiEditorialReviewSuggestions };
 	}
 
-	const applicable = BLOCK_SUGGESTIONS.filter( ( s ) => s.condition( selectedBlock ) );
-	trackRenderedBlockTransformationSuggestions( applicable, selectedBlock );
 	return {
 		suggestions: [
 			...applicable.map( ( { id, label, prompt } ) => ( { id, label, prompt } ) ),

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -862,7 +862,53 @@ export function useSuggestions(
 				: [],
 		[ blockTransformationsEnabled, selectedBlock ]
 	);
-	const applicableSuggestionsKey = applicable.map( ( suggestion ) => suggestion.id ).join( '|' );
+	const blockTransformationSuggestions = useMemo(
+		() => applicable.map( ( { id, label, prompt } ) => ( { id, label, prompt } ) ),
+		[ applicable ]
+	);
+	const visibleSuggestions = useMemo( () => {
+		if ( hidden ) {
+			return [];
+		}
+
+		if ( ! selectedBlock ) {
+			return applySuggestionLimit(
+				getPostLevelSuggestions( editorContext.postType ),
+				maxSuggestions
+			);
+		}
+
+		if ( ! blockTransformationsEnabled ) {
+			return applySuggestionLimit( aiEditorialReviewSuggestions, maxSuggestions );
+		}
+
+		return applySuggestionLimit(
+			[ ...blockTransformationSuggestions, ...aiEditorialReviewSuggestions ],
+			maxSuggestions
+		);
+	}, [
+		aiEditorialReviewSuggestions,
+		blockTransformationSuggestions,
+		blockTransformationsEnabled,
+		editorContext.postType,
+		hidden,
+		maxSuggestions,
+		selectedBlock,
+	] );
+	const visibleSuggestionIds = useMemo(
+		() => new Set( visibleSuggestions.map( ( suggestion ) => suggestion.id ) ),
+		[ visibleSuggestions ]
+	);
+	const visibleBlockTransformationSuggestions = useMemo(
+		() => applicable.filter( ( suggestion ) => visibleSuggestionIds.has( suggestion.id ) ),
+		[ applicable, visibleSuggestionIds ]
+	);
+	const visibleBlockTransformationSuggestionsKey = visibleBlockTransformationSuggestions
+		.map( ( suggestion ) => suggestion.id )
+		.join( '|' );
+	const isAiEditorialReviewSuggestionVisible = visibleSuggestionIds.has(
+		AI_EDITORIAL_REVIEW_SUGGESTION.id
+	);
 
 	useEffect( () => {
 		if ( editorContext.selectedBlock ) {
@@ -871,51 +917,36 @@ export function useSuggestions(
 	}, [ editorContext.selectedBlock?.clientId, editorContext.selectedBlock ] );
 
 	useEffect( () => {
-		if ( ! suggestionsVisible || hidden || aiEditorialReviewSuggestions.length === 0 ) {
+		if ( ! suggestionsVisible || hidden || ! isAiEditorialReviewSuggestionVisible ) {
 			return;
 		}
 		trackAiEditorialReviewSuggestionRenderedOnce();
-	}, [ hidden, aiEditorialReviewSuggestions.length, suggestionsVisible ] );
+	}, [ hidden, isAiEditorialReviewSuggestionVisible, suggestionsVisible ] );
 
 	useEffect( () => {
-		if ( ! suggestionsVisible || hidden || ! selectedBlock || ! blockTransformationsEnabled ) {
+		if (
+			! suggestionsVisible ||
+			hidden ||
+			! selectedBlock ||
+			! blockTransformationsEnabled ||
+			visibleBlockTransformationSuggestions.length === 0
+		) {
 			return;
 		}
-		trackRenderedBlockTransformationSuggestions( applicable, selectedBlock );
+		trackRenderedBlockTransformationSuggestions(
+			visibleBlockTransformationSuggestions,
+			selectedBlock
+		);
 	}, [
-		applicable,
-		applicableSuggestionsKey,
 		blockTransformationsEnabled,
 		hidden,
 		selectedBlock,
 		selectedBlock?.name,
 		suggestionsVisible,
+		visibleBlockTransformationSuggestions,
+		visibleBlockTransformationSuggestions.length,
+		visibleBlockTransformationSuggestionsKey,
 	] );
 
-	if ( hidden ) {
-		return { suggestions: [] };
-	}
-
-	if ( ! selectedBlock ) {
-		return {
-			suggestions: applySuggestionLimit(
-				getPostLevelSuggestions( editorContext.postType ),
-				maxSuggestions
-			),
-		};
-	}
-
-	if ( ! blockTransformationsEnabled ) {
-		return { suggestions: applySuggestionLimit( aiEditorialReviewSuggestions, maxSuggestions ) };
-	}
-
-	return {
-		suggestions: applySuggestionLimit(
-			[
-				...applicable.map( ( { id, label, prompt } ) => ( { id, label, prompt } ) ),
-				...aiEditorialReviewSuggestions,
-			],
-			maxSuggestions
-		),
-	};
+	return { suggestions: visibleSuggestions };
 }

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -32,8 +32,10 @@ import {
 	stopBlockShimmer,
 	getSelectedOrRememberedBlock,
 	rememberSelectedBlock,
+	clearRememberedSelectedBlock,
 	notifyBlockActionComplete,
 	BLOCK_ACTION_COMPLETE_EVENT,
+	SELECTED_BLOCK_CLEAR_EVENT,
 } from './utils/block-actions';
 import {
 	UPDATE_BLOCK_CONTENT_TOOL_ID,
@@ -89,6 +91,14 @@ const AI_EDITORIAL_REVIEW_SUGGESTION = {
 		'jetpack'
 	),
 };
+
+const LIMITED_BLOCK_SUGGESTION_PRIORITY = [
+	'translate',
+	'check-grammar',
+	'change-tone',
+	'simplify-text',
+	'generate-alt-text',
+];
 
 type JetpackAiSidebarPreviewFeature =
 	| 'aiEditorialReview'
@@ -175,6 +185,43 @@ function getPostLevelSuggestions( currentPostType?: string ) {
 		...( isOptimizeTitleSuggestionEnabled() ? [ OPTIMIZE_TITLE_SUGGESTION ] : [] ),
 		...getAiEditorialReviewSuggestions( currentPostType ),
 	];
+}
+
+function applySuggestionLimit< T extends { id: string } >(
+	suggestions: T[],
+	maxSuggestions?: number
+): T[] {
+	if (
+		typeof maxSuggestions !== 'number' ||
+		! Number.isFinite( maxSuggestions ) ||
+		suggestions.length <= maxSuggestions
+	) {
+		return suggestions;
+	}
+
+	const limit = Math.floor( maxSuggestions );
+	if ( limit <= 0 ) {
+		return [];
+	}
+
+	const aiEditorialReviewSuggestion = suggestions.find(
+		( suggestion ) => suggestion.id === AI_EDITORIAL_REVIEW_SUGGESTION.id
+	);
+	if ( ! aiEditorialReviewSuggestion ) {
+		return suggestions.slice( 0, limit );
+	}
+
+	const nonAiSuggestions = suggestions
+		.filter( ( suggestion ) => suggestion.id !== AI_EDITORIAL_REVIEW_SUGGESTION.id )
+		.sort( ( a, b ) => {
+			const aPriority = LIMITED_BLOCK_SUGGESTION_PRIORITY.indexOf( a.id );
+			const bPriority = LIMITED_BLOCK_SUGGESTION_PRIORITY.indexOf( b.id );
+			const normalizedAPriority = aPriority === -1 ? Number.MAX_SAFE_INTEGER : aPriority;
+			const normalizedBPriority = bPriority === -1 ? Number.MAX_SAFE_INTEGER : bPriority;
+			return normalizedAPriority - normalizedBPriority;
+		} );
+
+	return [ ...nonAiSuggestions.slice( 0, limit - 1 ), aiEditorialReviewSuggestion ];
 }
 
 // ---------- Show-component ability ----------
@@ -732,7 +779,7 @@ export const capabilities = {
  * @returns {Object} Object containing a suggestions array.
  */
 export function useSuggestions(
-	_maxSuggestions?: number,
+	maxSuggestions?: number,
 	{ suggestionsVisible = true }: { suggestionsVisible?: boolean } = {}
 ): {
 	suggestions: Array< { id: string; label: string; prompt?: string } >;
@@ -780,6 +827,17 @@ export function useSuggestions(
 		};
 	}, [] );
 
+	useEffect( () => {
+		const handleSelectedBlockClear = () => {
+			clearRememberedSelectedBlock();
+			setHidden( false );
+		};
+		window.addEventListener( SELECTED_BLOCK_CLEAR_EVENT, handleSelectedBlockClear );
+		return () => {
+			window.removeEventListener( SELECTED_BLOCK_CLEAR_EVENT, handleSelectedBlockClear );
+		};
+	}, [] );
+
 	const editorContext = useSelect( ( select ) => {
 		const blockEditor = select( 'core/block-editor' ) as { getSelectedBlock: () => any };
 		const editor = select( 'core/editor' ) as { getCurrentPostType?: () => string | undefined };
@@ -794,7 +852,7 @@ export function useSuggestions(
 		setHidden( false );
 	}, [ editorContext.selectedBlock?.clientId ] );
 
-	const selectedBlock = editorContext.selectedBlock ?? getSelectedOrRememberedBlock();
+	const selectedBlock = editorContext.selectedBlock;
 	const aiEditorialReviewSuggestions = getAiEditorialReviewSuggestions( editorContext.postType );
 	const blockTransformationsEnabled = isBlockTransformationsEnabled();
 	const applicable = useMemo(
@@ -839,17 +897,25 @@ export function useSuggestions(
 	}
 
 	if ( ! selectedBlock ) {
-		return { suggestions: getPostLevelSuggestions( editorContext.postType ) };
+		return {
+			suggestions: applySuggestionLimit(
+				getPostLevelSuggestions( editorContext.postType ),
+				maxSuggestions
+			),
+		};
 	}
 
 	if ( ! blockTransformationsEnabled ) {
-		return { suggestions: aiEditorialReviewSuggestions };
+		return { suggestions: applySuggestionLimit( aiEditorialReviewSuggestions, maxSuggestions ) };
 	}
 
 	return {
-		suggestions: [
-			...applicable.map( ( { id, label, prompt } ) => ( { id, label, prompt } ) ),
-			...aiEditorialReviewSuggestions,
-		],
+		suggestions: applySuggestionLimit(
+			[
+				...applicable.map( ( { id, label, prompt } ) => ( { id, label, prompt } ) ),
+				...aiEditorialReviewSuggestions,
+			],
+			maxSuggestions
+		),
 	};
 }

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -41,8 +41,11 @@ import {
 	isUpdateBlockContentTool,
 } from './utils/tool-provider';
 import {
+	type BlockTransformationSuggestionType,
 	trackAiEditorialReviewSuggestionClick,
 	trackAiEditorialReviewSuggestionRendered,
+	trackBlockTransformationSuggestionClick,
+	trackBlockTransformationSuggestionRendered,
 } from './utils/tracking';
 import type { ComponentType } from 'react';
 
@@ -56,6 +59,9 @@ let wasAgentProcessing = false;
 
 /** Whether `_suggestion_rendered` has fired this page life (once-per-session). */
 let suggestionRenderedFiredOnce = false;
+
+/** Block transformation suggestions whose rendered event has fired this page life. */
+const blockTransformationSuggestionRenderedKeys = new Set< string >();
 
 /** Default suggestion shown when no block is selected. */
 const OPTIMIZE_TITLE_SUGGESTION = {
@@ -572,39 +578,101 @@ const TEXT_BLOCK_TYPES = [ 'core/paragraph', 'core/heading' ];
 /** Block types that support image-related suggestions. */
 const IMAGE_BLOCK_TYPES = [ 'core/image', 'core/media-text', 'core/cover', 'core/gallery' ];
 
+type BlockSuggestion = {
+	id: string;
+	label: string;
+	prompt: string;
+	type: BlockTransformationSuggestionType;
+	condition: ( block: any ) => boolean;
+};
+
 /** Block-aware suggestion definitions with optional condition per block type. */
-const BLOCK_SUGGESTIONS = [
+const BLOCK_SUGGESTIONS: BlockSuggestion[] = [
 	{
 		id: 'translate',
 		label: __( 'Translate content', 'jetpack' ),
 		prompt: __( 'Translate this block content to:', 'jetpack' ),
+		type: 'text',
 		condition: ( block: any ) => TEXT_BLOCK_TYPES.includes( block?.name ),
 	},
 	{
 		id: 'change-tone',
 		label: __( 'Change tone', 'jetpack' ),
 		prompt: __( 'Change the tone of this text to be more:', 'jetpack' ),
+		type: 'text',
 		condition: ( block: any ) => TEXT_BLOCK_TYPES.includes( block?.name ),
 	},
 	{
 		id: 'check-grammar',
 		label: __( 'Check grammar', 'jetpack' ),
 		prompt: __( 'Check the grammar and spelling of this text', 'jetpack' ),
+		type: 'text',
 		condition: ( block: any ) => TEXT_BLOCK_TYPES.includes( block?.name ),
 	},
 	{
 		id: 'simplify-text',
 		label: __( 'Simplify text', 'jetpack' ),
 		prompt: __( 'Simplify this text to make it easier to read', 'jetpack' ),
+		type: 'text',
 		condition: ( block: any ) => TEXT_BLOCK_TYPES.includes( block?.name ),
 	},
 	{
 		id: 'generate-alt-text',
 		label: __( 'Generate alt text', 'jetpack' ),
 		prompt: __( 'Generate descriptive alt text for this image', 'jetpack' ),
+		type: 'image',
 		condition: ( block: any ) => IMAGE_BLOCK_TYPES.includes( block?.name ),
 	},
 ];
+
+function getBlockTransformationSuggestionForPrompt(
+	value: string,
+	block: any
+): BlockSuggestion | undefined {
+	return BLOCK_SUGGESTIONS.find(
+		( suggestion ) => suggestion.prompt === value && suggestion.condition( block )
+	);
+}
+
+function trackRenderedBlockTransformationSuggestions(
+	suggestions: BlockSuggestion[],
+	block: any
+): void {
+	if ( typeof block?.name !== 'string' ) {
+		return;
+	}
+
+	suggestions.forEach( ( suggestion ) => {
+		const renderedKey = `${ suggestion.id }:${ block.name }`;
+		if ( blockTransformationSuggestionRenderedKeys.has( renderedKey ) ) {
+			return;
+		}
+		blockTransformationSuggestionRenderedKeys.add( renderedKey );
+		trackBlockTransformationSuggestionRendered( {
+			suggestionId: suggestion.id,
+			suggestionType: suggestion.type,
+			blockType: block.name,
+		} );
+	} );
+}
+
+function trackBlockTransformationSuggestionClickForValue( value: string ): void {
+	if ( ! isBlockTransformationsEnabled() ) {
+		return;
+	}
+
+	const selectedBlock = getSelectedOrRememberedBlock();
+	const suggestion = getBlockTransformationSuggestionForPrompt( value, selectedBlock );
+	if ( ! suggestion || typeof selectedBlock?.name !== 'string' ) {
+		return;
+	}
+
+	trackBlockTransformationSuggestionClick( {
+		suggestionId: suggestion.id,
+		suggestionType: suggestion.type,
+		blockType: selectedBlock.name,
+	} );
+}
 
 // ---------- capabilities ----------
 
@@ -637,6 +705,9 @@ export function useSuggestions(): {
 			// AI Editorial Review output is too dense for the 350px sidebar.
 			// Auto-expand to 50vw on that suggestion only (matched by prompt).
 			const value = ( event as CustomEvent ).detail?.value;
+			if ( typeof value === 'string' ) {
+				trackBlockTransformationSuggestionClickForValue( value );
+			}
 			if (
 				isAiEditorialReviewAvailable() &&
 				typeof value === 'string' &&
@@ -701,6 +772,7 @@ export function useSuggestions(): {
 	}
 
 	const applicable = BLOCK_SUGGESTIONS.filter( ( s ) => s.condition( selectedBlock ) );
+	trackRenderedBlockTransformationSuggestions( applicable, selectedBlock );
 	return {
 		suggestions: [
 			...applicable.map( ( { id, label, prompt } ) => ( { id, label, prompt } ) ),

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -63,6 +63,11 @@ let suggestionRenderedFiredOnce = false;
 /** Block transformation suggestions whose rendered event has fired this page life. */
 const blockTransformationSuggestionRenderedKeys = new Set< string >();
 
+let lastBlockTransformationSuggestionContext: {
+	blockType: string;
+	suggestions: BlockSuggestion[];
+} | null = null;
+
 /** Default suggestion shown when no block is selected. */
 const OPTIMIZE_TITLE_SUGGESTION = {
 	id: 'optimize-title',
@@ -629,12 +634,19 @@ const BLOCK_SUGGESTIONS: BlockSuggestion[] = [
 	},
 ];
 
-function getBlockTransformationSuggestionForPrompt(
+function matchesBlockTransformationSuggestion(
+	suggestion: BlockSuggestion,
+	value: string
+): boolean {
+	return [ suggestion.id, suggestion.label, suggestion.prompt ].includes( value );
+}
+
+function getBlockTransformationSuggestionForValue(
 	value: string,
-	block: any
+	suggestions: BlockSuggestion[]
 ): BlockSuggestion | undefined {
-	return BLOCK_SUGGESTIONS.find(
-		( suggestion ) => suggestion.prompt === value && suggestion.condition( block )
+	return suggestions.find( ( suggestion ) =>
+		matchesBlockTransformationSuggestion( suggestion, value )
 	);
 }
 
@@ -645,6 +657,11 @@ function trackRenderedBlockTransformationSuggestions(
 	if ( typeof block?.name !== 'string' ) {
 		return;
 	}
+
+	lastBlockTransformationSuggestionContext = {
+		blockType: block.name,
+		suggestions,
+	};
 
 	suggestions.forEach( ( suggestion ) => {
 		const renderedKey = `${ suggestion.id }:${ block.name }`;
@@ -666,15 +683,33 @@ function trackBlockTransformationSuggestionClickForValue( value: string ): void 
 	}
 
 	const selectedBlock = getSelectedOrRememberedBlock();
-	const suggestion = getBlockTransformationSuggestionForPrompt( value, selectedBlock );
-	if ( ! suggestion || typeof selectedBlock?.name !== 'string' ) {
+	if ( typeof selectedBlock?.name === 'string' ) {
+		const selectedBlockSuggestion = getBlockTransformationSuggestionForValue(
+			value,
+			BLOCK_SUGGESTIONS.filter( ( suggestion ) => suggestion.condition( selectedBlock ) )
+		);
+		if ( selectedBlockSuggestion ) {
+			trackBlockTransformationSuggestionClick( {
+				suggestionId: selectedBlockSuggestion.id,
+				suggestionType: selectedBlockSuggestion.type,
+				blockType: selectedBlock.name,
+			} );
+			return;
+		}
+	}
+
+	const lastRenderedContext = lastBlockTransformationSuggestionContext;
+	const lastRenderedSuggestion = lastRenderedContext
+		? getBlockTransformationSuggestionForValue( value, lastRenderedContext.suggestions )
+		: undefined;
+	if ( ! lastRenderedContext || ! lastRenderedSuggestion ) {
 		return;
 	}
 
 	trackBlockTransformationSuggestionClick( {
-		suggestionId: suggestion.id,
-		suggestionType: suggestion.type,
-		blockType: selectedBlock.name,
+		suggestionId: lastRenderedSuggestion.id,
+		suggestionType: lastRenderedSuggestion.type,
+		blockType: lastRenderedContext.blockType,
 	} );
 }
 
@@ -696,7 +731,10 @@ export const capabilities = {
  * Hides permanently once the conversation becomes active.
  * @returns {Object} Object containing a suggestions array.
  */
-export function useSuggestions(): {
+export function useSuggestions(
+	_maxSuggestions?: number,
+	{ suggestionsVisible = true }: { suggestionsVisible?: boolean } = {}
+): {
 	suggestions: Array< { id: string; label: string; prompt?: string } >;
 } {
 	const [ hidden, setHidden ] = useState( false );
@@ -775,14 +813,14 @@ export function useSuggestions(): {
 	}, [ editorContext.selectedBlock?.clientId, editorContext.selectedBlock ] );
 
 	useEffect( () => {
-		if ( hidden || aiEditorialReviewSuggestions.length === 0 ) {
+		if ( ! suggestionsVisible || hidden || aiEditorialReviewSuggestions.length === 0 ) {
 			return;
 		}
 		trackAiEditorialReviewSuggestionRenderedOnce();
-	}, [ hidden, aiEditorialReviewSuggestions.length ] );
+	}, [ hidden, aiEditorialReviewSuggestions.length, suggestionsVisible ] );
 
 	useEffect( () => {
-		if ( hidden || ! selectedBlock || ! blockTransformationsEnabled ) {
+		if ( ! suggestionsVisible || hidden || ! selectedBlock || ! blockTransformationsEnabled ) {
 			return;
 		}
 		trackRenderedBlockTransformationSuggestions( applicable, selectedBlock );
@@ -793,6 +831,7 @@ export function useSuggestions(): {
 		hidden,
 		selectedBlock,
 		selectedBlock?.name,
+		suggestionsVisible,
 	] );
 
 	if ( hidden ) {

--- a/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
@@ -24,6 +24,7 @@ const processingEffectElements = new Set< HTMLElement >();
 let rememberedSelectedBlockClientId: string | null = null;
 
 export const BLOCK_ACTION_COMPLETE_EVENT = 'jetpack-ai-sidebar-block-action-complete';
+export const SELECTED_BLOCK_CLEAR_EVENT = 'agents-manager-selected-block-cleared';
 
 export function setModuleCheckpointApi( api: CheckpointApi | null ): void {
 	moduleCheckpointApi = api;
@@ -37,6 +38,10 @@ export function rememberSelectedBlock( block: any ): void {
 	if ( block?.clientId ) {
 		rememberedSelectedBlockClientId = block.clientId;
 	}
+}
+
+export function clearRememberedSelectedBlock(): void {
+	rememberedSelectedBlockClientId = null;
 }
 
 export function getSelectedOrRememberedBlock(): any | null {

--- a/packages/jetpack-ai-sidebar/src/utils/tracking.test.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/tracking.test.ts
@@ -12,6 +12,8 @@ import {
 	trackAiEditorialReviewResultRendered,
 	trackAiEditorialReviewSuggestionClick,
 	trackAiEditorialReviewSuggestionRendered,
+	trackBlockTransformationSuggestionClick,
+	trackBlockTransformationSuggestionRendered,
 } from './tracking';
 
 const mockedRecordTracksEvent = recordTracksEvent as jest.MockedFunction<
@@ -31,6 +33,11 @@ const expectPrivacySafePayload = ( properties: Record< string, unknown > ) => {
 	expect( properties ).not.toHaveProperty( 'success_count' );
 	expect( properties ).not.toHaveProperty( 'failure_count' );
 	expect( properties ).not.toHaveProperty( 'text' );
+	expect( properties ).not.toHaveProperty( 'prompt' );
+	expect( properties ).not.toHaveProperty( 'label' );
+	expect( properties ).not.toHaveProperty( 'client_id' );
+	expect( properties ).not.toHaveProperty( 'clientId' );
+	expect( properties ).not.toHaveProperty( 'content' );
 	expect( properties ).not.toHaveProperty( 'reviewer' );
 };
 
@@ -116,6 +123,46 @@ describe( 'AI Editorial Review tracking', () => {
 				target: 'mixed',
 				outcome: 'partial_failed',
 				item_count: 4,
+				sessionid: 'test-session-id',
+			}
+		);
+		expectPrivacySafePayload( mockedRecordTracksEvent.mock.calls[ 0 ][ 1 ] );
+	} );
+
+	it( 'tracks block transformation suggestion exposure with stable metadata', () => {
+		trackBlockTransformationSuggestionRendered( {
+			suggestionId: 'check-grammar',
+			suggestionType: 'text',
+			blockType: 'core/paragraph',
+		} );
+
+		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_ai_block_transformation_suggestion_rendered',
+			{
+				suggestion_id: 'check-grammar',
+				suggestion_type: 'text',
+				block_type: 'core/paragraph',
+				surface: 'jetpack_ai_sidebar',
+				sessionid: 'test-session-id',
+			}
+		);
+		expectPrivacySafePayload( mockedRecordTracksEvent.mock.calls[ 0 ][ 1 ] );
+	} );
+
+	it( 'tracks block transformation suggestion clicks with stable metadata', () => {
+		trackBlockTransformationSuggestionClick( {
+			suggestionId: 'simplify-text',
+			suggestionType: 'text',
+			blockType: 'core/heading',
+		} );
+
+		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_ai_block_transformation_suggestion_click',
+			{
+				suggestion_id: 'simplify-text',
+				suggestion_type: 'text',
+				block_type: 'core/heading',
+				surface: 'jetpack_ai_sidebar',
 				sessionid: 'test-session-id',
 			}
 		);

--- a/packages/jetpack-ai-sidebar/src/utils/tracking.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/tracking.ts
@@ -55,6 +55,14 @@ interface TrackAiEditorialReviewItemActionOptions {
 	itemCount?: number;
 }
 
+export type BlockTransformationSuggestionType = 'text' | 'image';
+
+interface TrackBlockTransformationSuggestionOptions {
+	suggestionId: string;
+	suggestionType: BlockTransformationSuggestionType;
+	blockType: string;
+}
+
 /**
  * Tracks the empty-view "AI Editorial Review" suggestion appearing.
  */
@@ -67,6 +75,46 @@ export function trackAiEditorialReviewSuggestionRendered(): void {
  */
 export function trackAiEditorialReviewSuggestionClick(): void {
 	recordTracksEvent( 'ai_editorial_review_suggestion_click' );
+}
+
+/**
+ * Tracks a block transformation suggestion appearing for a selected block.
+ * @param options                - Tracking options
+ * @param options.suggestionId   - Stable suggestion identifier.
+ * @param options.suggestionType - Transformation category.
+ * @param options.blockType      - Core block type the suggestion applies to.
+ */
+export function trackBlockTransformationSuggestionRendered( {
+	suggestionId,
+	suggestionType,
+	blockType,
+}: TrackBlockTransformationSuggestionOptions ): void {
+	recordTracksEvent( 'ai_block_transformation_suggestion_rendered', {
+		suggestion_id: suggestionId,
+		suggestion_type: suggestionType,
+		block_type: blockType,
+		surface: 'jetpack_ai_sidebar',
+	} );
+}
+
+/**
+ * Tracks a user clicking a block transformation suggestion.
+ * @param options                - Tracking options
+ * @param options.suggestionId   - Stable suggestion identifier.
+ * @param options.suggestionType - Transformation category.
+ * @param options.blockType      - Core block type the suggestion applies to.
+ */
+export function trackBlockTransformationSuggestionClick( {
+	suggestionId,
+	suggestionType,
+	blockType,
+}: TrackBlockTransformationSuggestionOptions ): void {
+	recordTracksEvent( 'ai_block_transformation_suggestion_click', {
+		suggestion_id: suggestionId,
+		suggestion_type: suggestionType,
+		block_type: blockType,
+		surface: 'jetpack_ai_sidebar',
+	} );
 }
 
 /**


### PR DESCRIPTION
## Proposed Changes

- Add Tracks helpers for Jetpack AI Sidebar block transformation suggestion render and click events.
- Track selected-block transformation suggestions: translate, change tone, check grammar, simplify text, and generate alt text.
- Gate block transformation and AI Editorial Review rendered tracking on visible suggestions so collapsed/sidebar-hidden state is not counted as an exposure.
- Forward empty-view suggestion clicks through the shared Agents Manager suggestion handler.
- Harden suggestion click tracking for Agenttic string/object click payloads and sidebar-focus block selection loss.
- Send stable, low-cardinality metadata only: `suggestion_id`, `suggestion_type`, `block_type`, `surface`, and existing `sessionid` when available.
- Limit floating/popped-out dynamic suggestions while leaving docked/sidebar view unlimited.
- Keep AI Editorial Review visible in the floating suggestion list when block transformation suggestions are also available.
- Clear Jetpack AI Sidebar's remembered selected-block context when the selected-block chip is removed, so post-level suggestions return without a page refresh.
- Fix AI Editorial Review action button contrast in popped-out sidebar view by using Agenttic/current-color based button borders and primary colors instead of translucent white styles.
- Add unit coverage for tracking helpers, render/click paths, visibility gating, suggestion limiting, selected-block clear behavior, and the Agents Manager suggestion click bridge.

## Why are these changes being made?

- The Jetpack AI Sidebar preview exposes selected-block transformations, but usage was not directly visible in Tracks.
- This adds observability for which transformation prompts are shown and clicked without sending prompt text, labels, block content, post IDs, or client IDs.
- Rendered events now reflect suggestions that are visible to the user instead of suggestions computed while the chat is collapsed.
- Click events now survive both Agenttic prompt-string callbacks and the editor clearing block selection when focus moves into the sidebar.
- Manual validation found two sidebar UX issues while testing the tracking flow:
  - AI Editorial Review could be crowded out in the popped-out/floating sidebar when a block was selected.
  - Clearing the selected-block chip left stale block transformation suggestions visible until refresh.
- Manual validation also found that popped-out AI Editorial Review buttons could become unreadable on hover in the light sidebar surface.

## Testing Instructions

1. Install the AM plugin to sandbox: `install-plugin.sh am update/jetpack-ai-block-transformation-tracks`
2. Sandbox `widgets.wp.com`.
3. Go to a draft post on a Simple site.
4. Select a paragraph block and open the sidebar.
5. Confirm the floating/popped-out suggestion list includes AI Editorial Review alongside block transformation suggestions.
6. Clear the selected-block chip and confirm the block transformation suggestions are replaced by post-level suggestions without refreshing.
7. Select the "Check grammar" suggestion.
8. Confirm the response is generated.
9. Confirm the event is queued/sent in an analytics-enabled session:
   - `jetpack_ai_block_transformation_suggestion_rendered`
   - `jetpack_ai_block_transformation_suggestion_click`
11. Open AI Editorial Review in popped-out sidebar view and hover the Accept/Dismiss actions.
12. Confirm the action text remains readable on hover.

## Local Verification

- `yarn test-packages --runTestsByPath packages/jetpack-ai-sidebar/src/index.test.ts packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx`
- `yarn eslint packages/jetpack-ai-sidebar/src/index.ts packages/jetpack-ai-sidebar/src/utils/block-actions.ts packages/jetpack-ai-sidebar/src/index.test.ts packages/agents-manager/src/components/orchestrator-chat/index.tsx packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx packages/agents-manager/src/components/selected-block/index.tsx`
- `yarn tsc --build packages/agents-manager/tsconfig.json --pretty false`
- `yarn tsc --build packages/jetpack-ai-sidebar/tsconfig.json --pretty false`
- `yarn stylelint packages/jetpack-ai-sidebar/src/components/review-mediation.scss`
- `git diff --check`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed?
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?
