### PR TITLE
Dashboard DataViews: Promote CardBody padding override to dashboard-wide stylesheet

### DIFF
--- a/client/dashboard/app/dataviews-overrides.scss
+++ b/client/dashboard/app/dataviews-overrides.scss
@@ -1,0 +1,19 @@
+@import "@wordpress/base-styles/variables";
+
+// @wordpress/dataviews v13 shipped a rule that neutralized the surrounding CardBody padding
+// when it wrapped a dataviews wrapper. v14 dropped that rule, so the default CardBody padding
+// leaks through. Restore the previous behavior here.
+.components-card__body:has( > .dataviews-wrapper ),
+.components-card__body:has( > .dataviews-picker-wrapper ) {
+	padding: $grid-unit-10 0 0;
+	overflow: hidden;
+}
+
+// We manually compose the UI of the dataview without including the view actions, which results in extra padding and a border.
+.components-card__header + .components-card__body:has( > .dataviews-wrapper ):not( :has( .dataviews__view-actions ) ) {
+	padding-top: 0;
+
+	.dataviews-view-list div[role="row"]:first-child {
+		border-top: none;
+	}
+}

--- a/client/dashboard/app/style.scss
+++ b/client/dashboard/app/style.scss
@@ -9,6 +9,7 @@
 
 // Core component overrides.
 @import './dataforms-overrides.scss';
+@import './dataviews-overrides.scss';
 
 // Global Styles
 html,

--- a/client/dashboard/components/dataviews/styles.scss
+++ b/client/dashboard/components/dataviews/styles.scss
@@ -2,24 +2,6 @@
 @import "@wordpress/base-styles/mixins";
 @import '@wordpress/base-styles/colors';
 
-// @wordpress/dataviews v13 shipped a rule that neutralized the surrounding CardBody padding
-// when it wrapped a dataviews wrapper. v14 dropped that rule, so the default CardBody padding
-// leaks through. Restore the previous behavior here.
-.components-card__body:has( > .dataviews-wrapper ),
-.components-card__body:has( > .dataviews-picker-wrapper ) {
-	padding: $grid-unit-10 0 0;
-	overflow: hidden;
-}
-
-// We manually compose the UI of the dataview without including the view actions, which results in extra padding and a border.
-.components-card__header + .components-card__body:has( > .dataviews-wrapper ):not( :has( .dataviews__view-actions ) ) {
-	padding-top: 0;
-
-	.dataviews-view-list div[role="row"]:first-child {
-		border-top: none;
-	}
-}
-
 // When displaying URLs in the DataViews, using the --wp-admin-theme-color link color is overwhelming.
 // Using this class name, we override the link color with the text color.
 a.dataviews-url-field {


### PR DESCRIPTION
Follow-up to #111014.

## Proposed Changes

* Move the v14 CardBody padding override out of `client/dashboard/components/dataviews/styles.scss` into a new app-level `client/dashboard/app/dataviews-overrides.scss`.
* Import the new file from `client/dashboard/app/style.scss`, mirroring the existing `dataforms-overrides.scss` pattern.

## Why are these changes being made?

The previous fix lived inside `client/dashboard/components/dataviews/styles.scss`, which is only pulled in transitively via `dataviews-empty-state.tsx` (`import './styles.scss'`). That means any dashboard screen that renders `DataViews`/`DataViewsCard` without also importing `DataViewsEmptyState` never loaded the CardBody padding override, so the default `@wordpress/components` CardBody padding (`16px 24px`) still leaked through.

Promoting the override to `client/dashboard/app/dataviews-overrides.scss` and importing it from the dashboard entry stylesheet guarantees the rule applies wherever DataViews appears inside a CardBody within the dashboard, regardless of which subcomponent a screen imports.

## Testing Instructions

* Visit any dashboard surface that renders DataViews inside a Card (Sites list, Domains, Plugins, Backups, Logs, etc.).
* Confirm the list/grid views have no extra padding around them — content sits flush against the card edges, matching the look after #111014.
* Visit a surface that previously did not import `DataViewsEmptyState` (if any) and confirm the same flush layout.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?