### PR TITLE
Importer: Update getting started video and add courses link

### DIFF
--- a/client/blocks/importer/components/getting-started-video/index.tsx
+++ b/client/blocks/importer/components/getting-started-video/index.tsx
@@ -1,3 +1,5 @@
+import { localizeUrl, useHasEnTranslation } from '@automattic/i18n-utils';
+import { ExternalLink } from '@wordpress/components';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import React from 'react';
@@ -7,12 +9,13 @@ import './style.scss';
 
 const GettingStartedVideo: React.FunctionComponent = () => {
 	const { __ } = useI18n();
+	const hasEnTranslation = useHasEnTranslation();
 	const video = {
 		autoplayIframe:
-			'<iframe src="https://www.youtube.com/embed/twGLN4lug-I" width="768px" height="426px" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>',
+			'<iframe src="https://www.youtube.com/embed/sqqVQSeMO-M" width="768px" height="426px" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>',
 		iframe:
-			'<iframe src="https://www.youtube.com/embed/twGLN4lug-I" width="768px" height="426px" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>',
-		src: 'https://youtu.be/twGLN4lug-I',
+			'<iframe src="https://www.youtube.com/embed/sqqVQSeMO-M" width="768px" height="426px" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>',
+		src: 'https://youtu.be/sqqVQSeMO-M',
 		aspectRatio: 1.8,
 		width: '100%',
 		height: 'auto',
@@ -21,12 +24,27 @@ const GettingStartedVideo: React.FunctionComponent = () => {
 	return (
 		<div className="getting-started-video">
 			<p>
-				{ createInterpolateElement(
-					__( 'Watch <strong>Getting started on WordPress.com</strong> while you wait' ),
-					{
-						strong: createElement( 'strong' ),
-					}
-				) }
+				{ hasEnTranslation(
+					'Watch <strong>Create Your Site on WordPress.com</strong> while you wait, or explore our <coursesLink>free courses</coursesLink>.'
+				)
+					? createInterpolateElement(
+							__(
+								'Watch <strong>Create Your Site on WordPress.com</strong> while you wait, or explore our <coursesLink>free courses</coursesLink>.'
+							),
+							{
+								strong: createElement( 'strong' ),
+								coursesLink: createElement( ExternalLink, {
+									href: localizeUrl( 'https://wordpress.com/support/courses/' ),
+									children: null,
+								} ),
+							}
+					  )
+					: createInterpolateElement(
+							__( 'Watch <strong>Getting started on WordPress.com</strong> while you wait' ),
+							{
+								strong: createElement( 'strong' ),
+							}
+					  ) }
 			</p>
 			<ReaderFeaturedVideoBlock { ...video } videoEmbed={ video } isExpanded />
 		</div>


### PR DESCRIPTION
Part of DOTCOM-17044

## Proposed Changes

* Replace the outdated "Getting started on WordPress.com" YouTube video (`twGLN4lug-I`, ~4 years old) embedded on the importer waiting screen with the current "Create Your Site on WordPress.com" video (`sqqVQSeMO-M`).
* Add a localized link to https://wordpress.com/support/courses/ alongside the video copy, using `ExternalLink` from `@wordpress/components` and `localizeUrl` from `@automattic/i18n-utils`.
* Gate the new copy behind `useHasEnTranslation` so non-English locales keep the existing translated string until the new one ships.

The `GettingStartedVideo` component is shared, so the change is visible on the Wix, Squarespace, Medium, and Blogger importer screens. The new video is also a generic "Create Your Site on WordPress.com" tutorial, so it fits all four.

## Why are these changes being made?

The video on the Wix importer screen is four years old and outdated. The new video is a current "Create Your Site on WordPress.com" tutorial. Linking to the free WordPress.com courses gives users a second resource to use while the import is running.

## Testing Instructions

1. Run a Calypso dev server.
2. Go to **Tools → Import** on a test site.
3. Start the Wix importer with an A8c-owned test site such as https://coastcoaster.wixstudio.com/coasters.
4. Proceed with the import. On the waiting screen, confirm:
   * The embedded video is "Create Your Site on WordPress.com" (`sqqVQSeMO-M`), not the old `twGLN4lug-I` one.
   * The copy reads "Watch **Create Your Site on WordPress.com** while you wait, or explore our [free courses](https://wordpress.com/support/courses/)."
   * The "free courses" link opens https://wordpress.com/support/courses/ in a new tab (localized for non-English locales).
5. Repeat for the Squarespace, Medium, and Blogger importers — the same shared component is used.
6. Switch to a non-English locale that doesn't yet have the new translation; confirm the screen falls back to the previous English-translated copy without the courses link.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?