### PR TITLE
Dashboard WordPress settings: hide beta notice and skip backup when versions match

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -37,6 +37,7 @@ import {
 	siteSshAccessStatusQuery,
 	siteStaticFile404SettingQuery,
 	siteWordPressVersionQuery,
+	wpOrgCoreVersionQuery,
 	queryClient,
 } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
@@ -1025,7 +1026,11 @@ export const siteSettingsWordPressRoute = createRoute( {
 	loader: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 		if ( canSwitchWordPressVersion( site ) || canOptOutOfWordPressBeta( site, 'beta' ) ) {
-			await queryClient.ensureQueryData( siteWordPressVersionQuery( site.ID ) );
+			await Promise.all( [
+				queryClient.ensureQueryData( siteWordPressVersionQuery( site.ID ) ),
+				queryClient.ensureQueryData( wpOrgCoreVersionQuery() ),
+				queryClient.ensureQueryData( wpOrgCoreVersionQuery( 'beta' ) ),
+			] );
 		}
 	},
 } ).lazy( () =>

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -1026,11 +1026,12 @@ export const siteSettingsWordPressRoute = createRoute( {
 	loader: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 		if ( canSwitchWordPressVersion( site ) || canOptOutOfWordPressBeta( site, 'beta' ) ) {
-			await Promise.all( [
-				queryClient.ensureQueryData( siteWordPressVersionQuery( site.ID ) ),
-				queryClient.ensureQueryData( wpOrgCoreVersionQuery() ),
-				queryClient.ensureQueryData( wpOrgCoreVersionQuery( 'beta' ) ),
-			] );
+			// Fire-and-forget the external wp.org queries so a slow upstream
+			// doesn't hang navigation; the component suspends on them via
+			// useSuspenseQuery and falls back to the route's Suspense boundary.
+			queryClient.prefetchQuery( wpOrgCoreVersionQuery() );
+			queryClient.prefetchQuery( wpOrgCoreVersionQuery( 'beta' ) );
+			await queryClient.ensureQueryData( siteWordPressVersionQuery( site.ID ) );
 		}
 	},
 } ).lazy( () =>

--- a/client/dashboard/sites/settings-wordpress/index.tsx
+++ b/client/dashboard/sites/settings-wordpress/index.tsx
@@ -35,9 +35,12 @@ function VersionManagement( { site }: { site: Site } ) {
 	// Resolve the target version tag (e.g. "beta") to a display string (e.g. "7.0-RC2").
 	const { data: latestVersion = '' } = useQuery( wpOrgCoreVersionQuery() );
 	const { data: betaVersion = '' } = useQuery( wpOrgCoreVersionQuery( 'beta' ) );
+	const versionsMatch = !! latestVersion && latestVersion === betaVersion;
 
 	let notice;
-	if ( isSwitching ) {
+	if ( versionsMatch ) {
+		notice = null;
+	} else if ( isSwitching ) {
 		notice = (
 			<VersionSwitchNotice
 				backupState={ backupState }
@@ -78,11 +81,13 @@ function BetaProgramContent( { site }: { site: Site } ) {
 		enabled: isEligible,
 	} );
 
-	if ( justOptedOut ) {
+	const versionsMatch = !! latestVersion && latestVersion === betaVersion;
+
+	if ( justOptedOut && ! versionsMatch ) {
 		return <LatestVersionNotice wpVersion={ latestVersion } />;
 	}
 
-	if ( canOptOutOfWordPressBeta( site, currentVersion ) ) {
+	if ( canOptOutOfWordPressBeta( site, currentVersion ) && ! versionsMatch ) {
 		return (
 			<BetaProgramNotice
 				site={ site }

--- a/client/dashboard/sites/settings-wordpress/test/index.test.tsx
+++ b/client/dashboard/sites/settings-wordpress/test/index.test.tsx
@@ -35,7 +35,10 @@ function mockSite( mockedSite: Site ) {
 		.reply( 200, mockedSite );
 }
 
-function mockWpOrgCoreVersions( { latest = '6.8.1', beta = '7.0-RC2' }: { latest?: string; beta?: string } = {} ) {
+function mockWpOrgCoreVersions( {
+	latest = '6.8.1',
+	beta = '7.0-RC2',
+}: { latest?: string; beta?: string } = {} ) {
 	nock( 'https://api.wordpress.org' )
 		.persist()
 		.get( '/core/version-check/1.7/' )

--- a/client/dashboard/sites/settings-wordpress/test/index.test.tsx
+++ b/client/dashboard/sites/settings-wordpress/test/index.test.tsx
@@ -2,7 +2,9 @@
  * @jest-environment jsdom
  */
 
+import { wpOrgCoreVersionQuery } from '@automattic/api-queries';
 import { disable, enable } from '@automattic/calypso-config';
+import { QueryClient } from '@tanstack/react-query';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
@@ -35,23 +37,19 @@ function mockSite( mockedSite: Site ) {
 		.reply( 200, mockedSite );
 }
 
-function mockWpOrgCoreVersions( {
-	latest = '6.8.1',
-	beta = '7.0-RC2',
-}: { latest?: string; beta?: string } = {} ) {
-	nock( 'https://api.wordpress.org' )
-		.persist()
-		.get( '/core/version-check/1.7/' )
-		.query( true )
-		.reply( 200, ( uri ) => {
-			const channel = new URL( `https://api.wordpress.org${ uri }` ).searchParams.get( 'channel' );
-			return { offers: [ { version: channel === 'beta' ? beta : latest } ] };
-		} );
+// Seed the wp.org core version queries — production primes these via the route
+// loader's ensureQueryData, so doing the same in tests mirrors the real flow
+// rather than going through native fetch (which jsdom doesn't expose).
+function seedWpOrgCoreVersions(
+	queryClient: QueryClient,
+	{ latest = '6.8.1', beta = '7.0-RC2' }: { latest?: string; beta?: string } = {}
+) {
+	queryClient.setQueryData( wpOrgCoreVersionQuery().queryKey, latest );
+	queryClient.setQueryData( wpOrgCoreVersionQuery( 'beta' ).queryKey, beta );
 }
 
 function mockApi( versionTag: string = 'latest', mockedSite: Site = site ) {
 	mockSite( mockedSite );
-	mockWpOrgCoreVersions();
 
 	nock( 'https://public-api.wordpress.com' )
 		.get( `/wpcom/v2/sites/${ site.ID }/hosting/wp-version` )
@@ -93,8 +91,10 @@ describe( '<WordPressSettings>', () => {
 		const user = userEvent.setup();
 
 		mockApi();
+		const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+		seedWpOrgCoreVersions( queryClient );
 
-		render( <WordPressSettings siteSlug={ site.slug } /> );
+		render( <WordPressSettings siteSlug={ site.slug } />, { queryClient } );
 		await screen.findByRole( 'heading', { name: 'WordPress' } );
 
 		const versionSelect = await screen.findByRole( 'combobox', { name: 'WordPress version' } );
@@ -160,8 +160,10 @@ describe( '<WordPressSettings>', () => {
 		} as unknown as Site;
 
 		mockApi( 'beta', autoEnrolledSite );
+		const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+		seedWpOrgCoreVersions( queryClient );
 
-		render( <WordPressSettings siteSlug={ site.slug } /> );
+		render( <WordPressSettings siteSlug={ site.slug } />, { queryClient } );
 		await screen.findByRole( 'heading', { name: 'WordPress' } );
 
 		expect(
@@ -217,8 +219,10 @@ describe( '<WordPressSettings>', () => {
 
 		test( 'renders the form for a staging site', async () => {
 			mockApi();
+			const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+			seedWpOrgCoreVersions( queryClient );
 
-			render( <WordPressSettings siteSlug={ site.slug } /> );
+			render( <WordPressSettings siteSlug={ site.slug } />, { queryClient } );
 			await screen.findByRole( 'heading', { name: 'WordPress' } );
 
 			expect( await screen.findByRole( 'combobox', { name: 'WordPress version' } ) ).toBeVisible();

--- a/client/dashboard/sites/settings-wordpress/test/index.test.tsx
+++ b/client/dashboard/sites/settings-wordpress/test/index.test.tsx
@@ -42,14 +42,11 @@ function mockWpOrgCoreVersions( {
 	nock( 'https://api.wordpress.org' )
 		.persist()
 		.get( '/core/version-check/1.7/' )
-		.query( ( q ) => q.channel === 'latest' )
-		.reply( 200, { offers: [ { version: latest } ] } );
-
-	nock( 'https://api.wordpress.org' )
-		.persist()
-		.get( '/core/version-check/1.7/' )
-		.query( ( q ) => q.channel === 'beta' )
-		.reply( 200, { offers: [ { version: beta } ] } );
+		.query( true )
+		.reply( 200, ( uri ) => {
+			const channel = new URL( `https://api.wordpress.org${ uri }` ).searchParams.get( 'channel' );
+			return { offers: [ { version: channel === 'beta' ? beta : latest } ] };
+		} );
 }
 
 function mockApi( versionTag: string = 'latest', mockedSite: Site = site ) {

--- a/client/dashboard/sites/settings-wordpress/test/index.test.tsx
+++ b/client/dashboard/sites/settings-wordpress/test/index.test.tsx
@@ -35,8 +35,23 @@ function mockSite( mockedSite: Site ) {
 		.reply( 200, mockedSite );
 }
 
+function mockWpOrgCoreVersions( { latest = '6.8.1', beta = '7.0-RC2' }: { latest?: string; beta?: string } = {} ) {
+	nock( 'https://api.wordpress.org' )
+		.persist()
+		.get( '/core/version-check/1.7/' )
+		.query( ( q ) => q.channel === 'latest' )
+		.reply( 200, { offers: [ { version: latest } ] } );
+
+	nock( 'https://api.wordpress.org' )
+		.persist()
+		.get( '/core/version-check/1.7/' )
+		.query( ( q ) => q.channel === 'beta' )
+		.reply( 200, { offers: [ { version: beta } ] } );
+}
+
 function mockApi( versionTag: string = 'latest', mockedSite: Site = site ) {
 	mockSite( mockedSite );
+	mockWpOrgCoreVersions();
 
 	nock( 'https://public-api.wordpress.com' )
 		.get( `/wpcom/v2/sites/${ site.ID }/hosting/wp-version` )
@@ -85,7 +100,7 @@ describe( '<WordPressSettings>', () => {
 		const versionSelect = await screen.findByRole( 'combobox', { name: 'WordPress version' } );
 		expect( versionSelect ).toHaveDisplayValue( 'Stable (6.8.1)' );
 
-		await user.selectOptions( versionSelect, 'Beta (6.8.1)' );
+		await user.selectOptions( versionSelect, 'Beta (7.0-RC2)' );
 		const scope = mockWordPressVersionSaved( 'beta' );
 
 		const saveButton = screen.getByRole( 'button', { name: 'Save' } );

--- a/client/dashboard/sites/settings-wordpress/use-version-switch.ts
+++ b/client/dashboard/sites/settings-wordpress/use-version-switch.ts
@@ -5,6 +5,7 @@ import {
 	sitePendingWordPressVersionQuery,
 	siteWordPressVersionQuery,
 	siteWordPressVersionMutation,
+	wpOrgCoreVersionQuery,
 } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
 import { useQuery, useMutation } from '@tanstack/react-query';
@@ -55,8 +56,14 @@ export interface VersionSwitchState {
 }
 
 export function useVersionSwitch( site: Site ): VersionSwitchState {
+	// When the public latest and beta releases point to the same version, switching
+	// between them is a no-op — skip the backup flow.
+	const { data: latestVersion } = useQuery( wpOrgCoreVersionQuery() );
+	const { data: betaVersion } = useQuery( wpOrgCoreVersionQuery( 'beta' ) );
+	const versionsMatch = !! latestVersion && latestVersion === betaVersion;
+
 	const deferUntilBackupComplete =
-		isEnabled( 'dashboard/wp-beta-program' ) && ! site.is_wpcom_staging_site;
+		isEnabled( 'dashboard/wp-beta-program' ) && ! site.is_wpcom_staging_site && ! versionsMatch;
 
 	const backupState = useBackupState( site.ID );
 	const [ phase, dispatch ] = useReducer( reducer, { status: 'idle' } );

--- a/client/dashboard/sites/settings-wordpress/use-version-switch.ts
+++ b/client/dashboard/sites/settings-wordpress/use-version-switch.ts
@@ -8,7 +8,7 @@ import {
 	wpOrgCoreVersionQuery,
 } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
-import { useQuery, useMutation } from '@tanstack/react-query';
+import { useQuery, useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import { usePrevious } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useReducer } from 'react';
@@ -57,9 +57,10 @@ export interface VersionSwitchState {
 
 export function useVersionSwitch( site: Site ): VersionSwitchState {
 	// When the public latest and beta releases point to the same version, switching
-	// between them is a no-op — skip the backup flow.
-	const { data: latestVersion } = useQuery( wpOrgCoreVersionQuery() );
-	const { data: betaVersion } = useQuery( wpOrgCoreVersionQuery( 'beta' ) );
+	// between them is a no-op — skip the backup flow. Suspend so the comparison is
+	// resolved before the user can submit.
+	const { data: latestVersion } = useSuspenseQuery( wpOrgCoreVersionQuery() );
+	const { data: betaVersion } = useSuspenseQuery( wpOrgCoreVersionQuery( 'beta' ) );
 	const versionsMatch = !! latestVersion && latestVersion === betaVersion;
 
 	const deferUntilBackupComplete =

--- a/client/dashboard/sites/settings-wordpress/use-version-switch.ts
+++ b/client/dashboard/sites/settings-wordpress/use-version-switch.ts
@@ -57,8 +57,7 @@ export interface VersionSwitchState {
 
 export function useVersionSwitch( site: Site ): VersionSwitchState {
 	// When the public latest and beta releases point to the same version, switching
-	// between them is a no-op — skip the backup flow. Suspend so the comparison is
-	// resolved before the user can submit.
+	// between them is a no-op — skip the backup flow. Primed by the route loader.
 	const { data: latestVersion } = useSuspenseQuery( wpOrgCoreVersionQuery() );
 	const { data: betaVersion } = useSuspenseQuery( wpOrgCoreVersionQuery( 'beta' ) );
 	const versionsMatch = !! latestVersion && latestVersion === betaVersion;

--- a/test/client/setup-dashboard-test-framework.js
+++ b/test/client/setup-dashboard-test-framework.js
@@ -15,17 +15,6 @@ afterEach( () => {
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;
 
-// jsdom doesn't expose fetch on its global, so tests that go through native
-// fetch() (e.g. wp.org REST endpoints) need a polyfill. node-fetch is the
-// closest fit because nock can intercept it.
-if ( typeof global.fetch === 'undefined' ) {
-	const nodeFetch = require( 'node-fetch' );
-	global.fetch = nodeFetch.default;
-	global.Headers = nodeFetch.Headers;
-	global.Request = nodeFetch.Request;
-	global.Response = nodeFetch.Response;
-}
-
 global.ResizeObserver = require( 'resize-observer-polyfill' );
 
 // jsdom doesn't implement IntersectionObserver, which is used by

--- a/test/client/setup-dashboard-test-framework.js
+++ b/test/client/setup-dashboard-test-framework.js
@@ -15,6 +15,17 @@ afterEach( () => {
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;
 
+// jsdom doesn't expose fetch on its global, so tests that go through native
+// fetch() (e.g. wp.org REST endpoints) need a polyfill. node-fetch is the
+// closest fit because nock can intercept it.
+if ( typeof global.fetch === 'undefined' ) {
+	const nodeFetch = require( 'node-fetch' );
+	global.fetch = nodeFetch.default;
+	global.Headers = nodeFetch.Headers;
+	global.Request = nodeFetch.Request;
+	global.Response = nodeFetch.Response;
+}
+
 global.ResizeObserver = require( 'resize-observer-polyfill' );
 
 // jsdom doesn't implement IntersectionObserver, which is used by


### PR DESCRIPTION
Part of #

## Proposed Changes

* In the dashboard WordPress settings, suppress all version notices (switching/switched/beta-program) when wp.org's `latest` and `beta` channels resolve to the same version string.
* In `useVersionSwitch`, fall back to the plain mutation path (no backup deferral) in the same case.

## Why are these changes being made?

Between WordPress releases, `latest` and `beta` can point to the same version. Switching between them in that window is a no-op, so the beta-program notice is misleading and the backup-deferred flow does unnecessary work.

## Testing Instructions

* Navigate to a site's `Settings → WordPress` page.
* Mock or wait for a moment where `wpOrgCoreVersionQuery()` and `wpOrgCoreVersionQuery('beta')` return the same version.
  * Confirm no `BetaProgramNotice`, `LatestVersionNotice`, or `VersionSwitchNotice` is rendered.
  * Submitting the form fires the mutation directly without enqueuing a backup.
* With latest ≠ beta, confirm the existing notice behavior and backup-deferred flow are unchanged.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?