### PR TITLE
Add conditional State Code (ISO) dropdown to A4A referral form (A4AOPS-381)

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/refer-hosting/form.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/refer-hosting/form.tsx
@@ -1,7 +1,7 @@
 import { SearchableDropdown } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { ChangeEvent, useCallback, useState } from 'react';
+import { ChangeEvent, useCallback, useEffect, useState } from 'react';
 import Form from 'calypso/a8c-for-agencies/components/form';
 import FormField from 'calypso/a8c-for-agencies/components/form/field';
 import FormSection from 'calypso/a8c-for-agencies/components/form/section';
@@ -121,7 +121,7 @@ export default function ReferHostingForm( {
 	const { formTitle, successTitle, ctaText, companyTitle, contactTitle, events, fields, api } =
 		config;
 
-	const { countryOptions } = useCountriesAndStates();
+	const { countryOptions, stateOptionsMap } = useCountriesAndStates();
 
 	const {
 		formData,
@@ -142,6 +142,13 @@ export default function ReferHostingForm( {
 		updateFormData( name, value );
 		updateValidationError( { [ name ]: '' } );
 	};
+
+	const stateOptions = stateOptionsMap[ formData.country ];
+
+	useEffect( () => {
+		handleInputChange( 'state', '' );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ formData.country ] );
 
 	const handleSubmit = useCallback( () => {
 		const error = validate( formData );
@@ -236,13 +243,17 @@ export default function ReferHostingForm( {
 					options={ countryOptions }
 				/>
 
-				<TextField
-					label={ translate( 'State/Province (optional)' ) }
-					name="state"
-					error={ validationError.state }
-					value={ formData.state }
-					onChange={ ( value: string ) => handleInputChange( 'state', value ) }
-				/>
+				{ stateOptions && (
+					<SearchableDropdownField
+						label={ translate( 'State' ) }
+						name="state"
+						error={ validationError.state }
+						value={ formData.state }
+						onChange={ ( value: string ) => handleInputChange( 'state', value ) }
+						placeholder={ translate( 'Select state' ) }
+						options={ stateOptions }
+					/>
+				) }
 
 				<TextField
 					label={ translate( 'City' ) }

--- a/client/a8c-for-agencies/sections/marketplace/refer-hosting/lib/get-form-data.ts
+++ b/client/a8c-for-agencies/sections/marketplace/refer-hosting/lib/get-form-data.ts
@@ -5,7 +5,7 @@ const FIELD_NAME_MAPPING: Record< keyof ReferHostingFormData, keyof ReferHosting
 		companyName: 'company_name',
 		address: 'address',
 		country: 'country_code',
-		state: 'state',
+		state: 'state_code_iso',
 		city: 'city',
 		zip: 'zip',
 		firstName: 'first_name',

--- a/client/a8c-for-agencies/sections/marketplace/refer-hosting/types.ts
+++ b/client/a8c-for-agencies/sections/marketplace/refer-hosting/types.ts
@@ -22,7 +22,7 @@ export type ReferHostingFormDataPayload = {
 	company_name: string;
 	address: string;
 	country_code: string;
-	state: string;
+	state_code_iso: string;
 	city: string;
 	zip: string;
 


### PR DESCRIPTION
Part of A4AOPS-381

## Proposed Changes

* Replace the free-text State/Province field in the A4A referral hosting form with a conditional searchable dropdown that shows ISO state options (US/CA/AU only)
* Rename the backend payload field from `state` to `state_code_iso` in the type and field-name mapping
* Add a `useEffect` to clear the selected state when the user changes country

## Why are these changes being made?

Frontend half of the A4AOPS-381 state migration. The backend already accepts a `state_code_iso` param (added in the companion wpcom PR). This PR updates the referral form to submit prefixed ISO state codes (e.g. `US-CA`) instead of free text, ensuring data consistency with HubSpot standardized state code values.

## Testing Instructions

1. Navigate to the A4A referral hosting form
2. Select United States, Canada, or Australia as the country -- a "State" dropdown should appear with the corresponding ISO state options
3. Select any other country -- the state dropdown should be hidden (no free-text fallback)
4. Select US, pick a state, change country to Canada -- verify the state selection is cleared
5. Submit the form and verify the payload includes `state_code_iso` (not `state`) with a prefixed ISO value like `US-CA`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?
