### PR TITLE
Dashboard: clarify latest and stable WP versions in settings

### DIFF
--- a/client/dashboard/sites/settings-wordpress/test/index.test.tsx
+++ b/client/dashboard/sites/settings-wordpress/test/index.test.tsx
@@ -83,9 +83,9 @@ describe( '<WordPressSettings>', () => {
 		await screen.findByRole( 'heading', { name: 'WordPress' } );
 
 		const versionSelect = await screen.findByRole( 'combobox', { name: 'WordPress version' } );
-		expect( versionSelect ).toHaveDisplayValue( '6.8.1 (Latest)' );
+		expect( versionSelect ).toHaveDisplayValue( 'Stable (6.8.1)' );
 
-		await user.selectOptions( versionSelect, '6.8.1 (Beta)' );
+		await user.selectOptions( versionSelect, 'Beta (6.8.1)' );
 		const scope = mockWordPressVersionSaved( 'beta' );
 
 		const saveButton = screen.getByRole( 'button', { name: 'Save' } );

--- a/client/dashboard/utils/wp-version.ts
+++ b/client/dashboard/utils/wp-version.ts
@@ -4,7 +4,7 @@ import type { Site } from '@automattic/api-core';
 
 function getWordPressVersionTagName( versionTag: string ) {
 	if ( versionTag === 'latest' ) {
-		return __( 'Latest' );
+		return __( 'Stable' );
 	}
 	if ( versionTag === 'beta' ) {
 		return __( 'Beta' );
@@ -42,7 +42,7 @@ export function formatWordPressVersion(
 	}
 
 	if ( versionTag ) {
-		wpVersion = `${ wpVersion } (${ getWordPressVersionTagName( versionTag ) })`;
+		wpVersion = `${ getWordPressVersionTagName( versionTag ) } (${ wpVersion })`;
 	}
 
 	return wpVersion;


### PR DESCRIPTION
## Proposed Changes

Swap the labels of PHP settings in dashboard, putting the version number inside the parentheses, to clarify that the site will continue use the latest version (stable or beta) instead of that fixed version number.

|Before|After|
|-|-|
|<img width="577" height="159" alt="image" src="https://github.com/user-attachments/assets/ba7dc18e-272d-47b7-a832-be162e36fa78" />|<img width="577" height="158" alt="image" src="https://github.com/user-attachments/assets/a62bea52-8c74-4d98-a3ea-8f64f2e8fbe8" />|


## Testing Instructions

1. Go to /sites
2. Click an Atomic site
3. Go to Settings -> WordPress
4. Verify the options as per above screenshot.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
