### PR TITLE
A4A DataViews: hide layout switcher via free composition

### DIFF
--- a/client/a8c-for-agencies/components/items-dashboard/items-dataviews/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/items-dataviews/index.tsx
@@ -1,6 +1,6 @@
 import { usePrevious } from '@wordpress/compose';
 import { useTranslate } from 'i18n-calypso';
-import { useRef, useLayoutEffect } from 'react';
+import { ReactNode, useRef, useLayoutEffect } from 'react';
 import { DataViews } from 'calypso/components/dataviews';
 import { ItemsDataViewsType } from './interfaces';
 
@@ -22,9 +22,15 @@ export type ItemsDataViewsProps = {
 	data: ItemsDataViewsType< any >;
 	isLoading?: boolean;
 	className?: string;
+	children?: ReactNode;
 };
 
-const ItemsDataViews = ( { data, isLoading = false, className }: ItemsDataViewsProps ) => {
+const ItemsDataViews = ( {
+	data,
+	isLoading = false,
+	className,
+	children,
+}: ItemsDataViewsProps ) => {
 	const translate = useTranslate();
 	const scrollContainerRef = useRef< HTMLElement >();
 	const previousDataViewsState = usePrevious( data.dataViewsState );
@@ -74,7 +80,9 @@ const ItemsDataViews = ( { data, isLoading = false, className }: ItemsDataViewsP
 				selection={ data.selection }
 				onChangeSelection={ data.onSelectionChange }
 				header={ data.header }
-			/>
+			>
+				{ children }
+			</DataViews>
 		</div>
 	);
 };

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/index.tsx
@@ -1,9 +1,11 @@
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
+import { __experimentalHStack as HStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, ReactNode, useState } from 'react';
 import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
+import { DataViews } from 'calypso/components/dataviews';
 import RequestReviewModal from '../request-review-modal';
 import { MigratedOnColumn, ReviewStatusColumn, SiteColumn } from './commission-columns';
 import MigrationsCommissionsListMobileView from './mobile-view';
@@ -121,7 +123,17 @@ export default function MigrationsCommissionsList( {
 							dataViewsState,
 							defaultLayouts: { table: {} },
 						} }
-					/>
+					>
+						<HStack
+							className="dataviews__view-actions"
+							justify="end"
+							style={ { paddingInline: '64px' } }
+						>
+							<DataViews.ViewConfig />
+						</HStack>
+						<DataViews.Layout />
+						<DataViews.Footer />
+					</ItemsDataViews>
 				</div>
 			) : (
 				<MigrationsCommissionsListMobileView

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/index.tsx
@@ -1,4 +1,5 @@
-import { useDesktopBreakpoint } from '@automattic/viewport-react';
+import { useDesktopBreakpoint, useBreakpoint } from '@automattic/viewport-react';
+import { __experimentalHStack as HStack } from '@wordpress/components';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { chevronRight } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -6,6 +7,7 @@ import { useMemo, useCallback, ReactNode, useEffect } from 'react';
 import { DATAVIEWS_LIST } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
+import { DataViews } from 'calypso/components/dataviews';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import CommissionsColumn from './commissions-column';
@@ -25,6 +27,8 @@ export default function ReferralList( { referrals, dataViewsState, setDataViewsS
 	const isDesktop = useDesktopBreakpoint();
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+
+	const isNarrowView = useBreakpoint( '<660px' );
 
 	const openSitePreviewPane = useCallback(
 		( referral: Referral ) => {
@@ -193,7 +197,17 @@ export default function ReferralList( { referrals, dataViewsState, setDataViewsS
 					dataViewsState,
 					defaultLayouts: { table: {}, list: {} },
 				} }
-			/>
+			>
+				<HStack
+					className="dataviews__view-actions"
+					justify="end"
+					style={ { paddingInline: isNarrowView || dataViewsState.selectedItem ? '16px' : '64px' } }
+				>
+					<DataViews.ViewConfig />
+				</HStack>
+				<DataViews.Layout />
+				<DataViews.Footer />
+			</ItemsDataViews>
 		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/reports/primary/dashboard/reports-list.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/dashboard/reports-list.tsx
@@ -1,4 +1,5 @@
-import { useDesktopBreakpoint } from '@automattic/viewport-react';
+import { useBreakpoint, useDesktopBreakpoint } from '@automattic/viewport-react';
+import { __experimentalHStack as HStack } from '@wordpress/components';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { chevronRight } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -6,6 +7,7 @@ import { useMemo, useCallback } from 'react';
 import { DATAVIEWS_LIST } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
+import { DataViews } from 'calypso/components/dataviews';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
@@ -28,6 +30,7 @@ export default function ReportsList( {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const isDesktop = useDesktopBreakpoint();
+	const isNarrowView = useBreakpoint( '<660px' );
 
 	const openReportPreviewPane = useCallback(
 		( report: SiteReports ) => {
@@ -135,7 +138,19 @@ export default function ReportsList( {
 					dataViewsState,
 					defaultLayouts: { table: {}, list: {} },
 				} }
-			/>
+			>
+				<HStack
+					className="dataviews__view-actions"
+					justify="end"
+					style={ {
+						paddingInline: isNarrowView || dataViewsState.selectedItem ? '16px' : '64px',
+					} }
+				>
+					<DataViews.ViewConfig />
+				</HStack>
+				<DataViews.Layout />
+				<DataViews.Footer />
+			</ItemsDataViews>
 		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { __experimentalHStack as HStack } from '@wordpress/components';
 import { Icon, starFilled } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -13,6 +14,7 @@ import SiteSetFavorite from 'calypso/a8c-for-agencies/sections/sites/site-set-fa
 import SitesDashboardContext from 'calypso/a8c-for-agencies/sections/sites/sites-dashboard-context';
 import { SitesDataViewsProps } from 'calypso/a8c-for-agencies/sections/sites/sites-dataviews/interfaces';
 import SiteDataField from 'calypso/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field';
+import { DataViews } from 'calypso/components/dataviews';
 import { GuidedTourStep } from 'calypso/components/guided-tour/step';
 import SiteStatusContent from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content';
 import { JETPACK_MANAGE_ONBOARDING_TOURS_EXAMPLE_SITE } from 'calypso/jetpack-cloud/sections/onboarding-tours/constants';
@@ -470,7 +472,25 @@ export const JetpackSitesDataViews = ( {
 		} ) );
 	}, [ fields, dataViewsState, setDataViewsState, data, actions ] );
 
-	return <ItemsDataViews data={ itemsData } isLoading={ isLoading } className={ className } />;
+	return (
+		<ItemsDataViews data={ itemsData } isLoading={ isLoading } className={ className }>
+			<HStack
+				className="dataviews__view-actions"
+				alignment="top"
+				justify="space-between"
+				spacing={ 2 }
+			>
+				<HStack className="dataviews__search" justify="start" spacing={ 2 } expanded={ false }>
+					<DataViews.Search label={ translate( 'Search for sites' ) } />
+					<DataViews.FiltersToggle />
+				</HStack>
+				<DataViews.ViewConfig />
+			</HStack>
+			<DataViews.FiltersToggled className="dataviews-filters__container" />
+			<DataViews.Layout />
+			<DataViews.Footer />
+		</ItemsDataViews>
+	);
 };
 
 export default JetpackSitesDataViews;

--- a/client/a8c-for-agencies/sections/team/primary/team-list/invite-table.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/invite-table.tsx
@@ -1,11 +1,13 @@
 import { getCurrentUser } from '@automattic/calypso-analytics';
-import { useDesktopBreakpoint } from '@automattic/viewport-react';
+import { useBreakpoint, useDesktopBreakpoint } from '@automattic/viewport-react';
+import { __experimentalHStack as HStack } from '@wordpress/components';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
 import { ReactNode, useCallback, useMemo, useState } from 'react';
 import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
+import { DataViews } from 'calypso/components/dataviews';
 import { useSelector } from 'calypso/state';
 import useHandleMemberAction from '../../hooks/use-handle-member-action';
 import { TeamMember } from '../../types';
@@ -22,6 +24,7 @@ export function TeamInviteTable( { members, onRefresh }: Props ) {
 	const translate = useTranslate();
 
 	const isDesktop = useDesktopBreakpoint();
+	const isNarrowView = useBreakpoint( '<660px' );
 
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
 		...initialDataViewsState,
@@ -109,7 +112,17 @@ export function TeamInviteTable( { members, onRefresh }: Props ) {
 						dataViewsState: dataViewsState,
 						defaultLayouts: { table: {} },
 					} }
-				/>
+				>
+					<HStack
+						className="dataviews__view-actions"
+						justify="end"
+						style={ { paddingInline: isNarrowView ? '16px' : '64px' } }
+					>
+						<DataViews.ViewConfig />
+					</HStack>
+					<DataViews.Layout />
+					<DataViews.Footer />
+				</ItemsDataViews>
 			</div>
 
 			{ activeRequest && (

--- a/client/a8c-for-agencies/sections/team/primary/team-list/member-table.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/member-table.tsx
@@ -1,11 +1,13 @@
 import { getCurrentUser } from '@automattic/calypso-analytics';
-import { useDesktopBreakpoint } from '@automattic/viewport-react';
+import { useBreakpoint, useDesktopBreakpoint } from '@automattic/viewport-react';
+import { __experimentalHStack as HStack } from '@wordpress/components';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
 import { ReactNode, useCallback, useMemo, useState } from 'react';
 import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
+import { DataViews } from 'calypso/components/dataviews';
 import { useSelector } from 'calypso/state';
 import { hasAgencyCapability } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { A4AStore } from 'calypso/state/a8c-for-agencies/types';
@@ -24,6 +26,7 @@ export function TeamMemberTable( { members, onRefresh }: Props ) {
 	const translate = useTranslate();
 
 	const isDesktop = useDesktopBreakpoint();
+	const isNarrowView = useBreakpoint( '<660px' );
 
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
 		...initialDataViewsState,
@@ -124,7 +127,17 @@ export function TeamMemberTable( { members, onRefresh }: Props ) {
 						dataViewsState: dataViewsState,
 						defaultLayouts: { table: {} },
 					} }
-				/>
+				>
+					<HStack
+						className="dataviews__view-actions"
+						justify="end"
+						style={ { paddingInline: isNarrowView ? '16px' : '64px' } }
+					>
+						<DataViews.ViewConfig />
+					</HStack>
+					<DataViews.Layout />
+					<DataViews.Footer />
+				</ItemsDataViews>
 			</div>
 
 			{ activeRequest && (

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/sites-with-woopayments.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/sites-with-woopayments.tsx
@@ -1,5 +1,5 @@
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
-import { Button, Modal, Spinner } from '@wordpress/components';
+import { __experimentalHStack as HStack, Button, Modal, Spinner } from '@wordpress/components';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { Icon, external, download, close } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -8,6 +8,7 @@ import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items
 import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
+import { DataViews } from 'calypso/components/dataviews';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { useWooPaymentsContext } from '../context';
@@ -222,7 +223,17 @@ export default function SitesWithWooPayments() {
 							dataViewsState,
 							defaultLayouts: { table: {} },
 						} }
-					/>
+					>
+						<HStack
+							className="dataviews__view-actions"
+							justify="end"
+							style={ { paddingInline: '64px' } }
+						>
+							<DataViews.ViewConfig />
+						</HStack>
+						<DataViews.Layout />
+						<DataViews.Footer />
+					</ItemsDataViews>
 				</div>
 			) }
 


### PR DESCRIPTION
Resolves A4A-2636
Resolves A4A-2629
Resolves A4A-2628
Resolves A4A-2623


Stacked on top of #111005 (`fix/a4a-migrations-commissions-actions-alignment`). The PR diff currently includes trunk commits that haven't landed on the base branch yet — those will disappear once #111005 is rebased onto trunk (or merged). Only the last commit (`A4A DataViews: compose toolbar via children to hide layout switcher`) is from this PR.

## Proposed Changes

* Add an optional `children?: ReactNode` prop to `ItemsDataViews` that forwards through to `<DataViews>`. When provided, DataViews skips its default toolbar and renders the supplied subcomponents instead — the standard compound ("free composition") pattern.
* Use that to recompose the DataViews toolbar across six A4A pages without rendering `<DataViews.LayoutSwitcher />`. Each page renders just the cog (`<DataViews.ViewConfig />`) inside an `HStack` plus `<DataViews.Layout />` and `<DataViews.Footer />`. Sites additionally renders `<DataViews.Search />`, `<DataViews.FiltersToggle />`, and `<DataViews.FiltersToggled />` because that page uses search and has a filterable field.
* Both `table` and `list` layouts stay registered on Sites, Referrals, and Reports so the list-mode preview pane keeps working internally — the user-toggleable switcher button is what disappears. The other three pages (Team Active / Invited, WooPayments, Migrations Commissions) already had a single layout registered; they adopt the same toolbar shape for consistency and gain a properly right-aligned cog via the HStack's `paddingInline`.
* `paddingInline` per page:
  * Referrals and Reports — `isNarrowView || dataViewsState.selectedItem ? '16px' : '64px'` (matches the table's column padding while collapsing tightly when the preview pane is open).
  * Team — `isNarrowView ? '16px' : '64px'` (team's DataViews table renders on both desktop and narrow viewports).
  * Migrations Commissions and WooPayments — static `'64px'` (both fall back to a `ListItemCards` mobile view on narrow viewports, so the DataViews table is desktop-only).
* No new authored CSS. The only `dataviews-*` references are className hooks on our own HStack that opt into DataViews' default toolbar styling (padding, sticky positioning, transitions).

## Why are these changes being made?

The Sites, Referrals, and Reports pages registered both `table` and `list` layouts so the preview pane could swap into list mode internally. DataViews then drew a user-toggleable switcher button in the toolbar next to the cog, even though switching is meant to be driven by clicking a row / "View Details" — not by the user. The compound children API is DataViews' designed escape hatch for this: register both layouts (preview pane keeps working) but render only the cog (no manual switcher). Applying the same shape to the other three pages aligns the toolbar position with each page's `64px` page-edge offset and removes the cog-vs-column misalignment that existed when the cog inherited DataViews' default `30px` padding while the cell padding was overridden to `64px`.

## Testing Instructions

### Sites — search and filters must match production

1. Visit `/sites`.
2. **Toolbar inventory:** left side has a `Search for sites` input and a filter toggle icon; right side has only the cog (no layout-switcher icon next to it).
3. **Search:** type a partial site URL into the search input (e.g. `deep`). The list should debounce and filter in place; the matched site(s) should remain visible. Clearing the search restores the full list.
4. **Filter:** the `Status` filter chip is visible below the toolbar. Clicking it should open the filter panel; selecting a status (e.g. `Needs attention`) should filter the list to matching sites. `Reset` clears it.
5. **Cog popover:** open the cog. It should show **Sort by / Order / Density / Items per page only** — there is no `Item layout` row.
6. **Preview pane:** click any row → preview pane opens (narrow list of sites on the left in list mode, site details on the right). Click another row in the narrow list → preview switches to that site.
7. Compare each behavior above against the live production `/sites` page — search debounce timing, filter chip behavior, and the cog popover entries should match (the only intentional difference is the absent layout-switcher button).
8. Verify it looks good on small screens.

<img width="1920" height="714" alt="Screenshot 2026-05-26 at 3 16 26 PM" src="https://github.com/user-attachments/assets/05c9d5fe-5f97-44b6-93e9-bd56550d6f04" />

### Referrals and Reports

1. Visit `/referrals/dashboard` and `/reports/dashboard`.
   * The toolbar should show only the cog (no layout-switcher icon next to it).
   * Click "View Details" or a row → the preview pane opens with the narrow `<ul>` list on the left and details on the right (list mode is still the rendering mode internally).
   * Verify you can view details for multiple items by clicking on the left item list.
   * Open the cog popover — confirm it shows Density / Items per page only (no "Item layout" radio).
   * Verify it looks good on small screens.

<img width="1920" height="598" alt="Screenshot 2026-05-26 at 3 17 48 PM" src="https://github.com/user-attachments/assets/49a52426-0ffa-41d7-ac63-4145a72a165e" />

<img width="1920" height="598" alt="Screenshot 2026-05-26 at 3 22 02 PM" src="https://github.com/user-attachments/assets/25ed03e6-2bed-4080-a0e1-3a29508e764a" />

<img width="1920" height="598" alt="Screenshot 2026-05-26 at 3 22 28 PM" src="https://github.com/user-attachments/assets/08ef52e0-73b5-4a2c-bb4d-65ea52d095dd" />

<img width="1920" height="525" alt="Screenshot 2026-05-26 at 3 23 07 PM" src="https://github.com/user-attachments/assets/7a300776-b3c3-4963-b2b3-7c9ccd75f260" />


### Team

1. Visit `/team` (Active members tab). Toolbar shows only the cog, right-aligned at the `64px` page-edge offset (aligned above the ACTIONS column). Switch to the Invited tab — same.
2. Verify it looks good on small screens.

<img width="1920" height="740" alt="Screenshot 2026-05-26 at 3 33 07 PM" src="https://github.com/user-attachments/assets/6461f3e2-8cdb-4832-9feb-8af05f7af27f" />

<img width="1920" height="740" alt="Screenshot 2026-05-26 at 3 32 52 PM" src="https://github.com/user-attachments/assets/0662a279-b2fa-47f3-b487-6313461baf90" />


### WooPayments

1. Visit `/woopayments`. Cog aligned at `64px`, no switcher.
2. Verify it looks good on small screens.

<img width="1920" height="555" alt="Screenshot 2026-05-26 at 3 24 02 PM" src="https://github.com/user-attachments/assets/1d6b26ad-5ea2-48ff-a5af-a043b58bafe7" />



### Migrations Commissions

1. Visit `/migrations/commissions`. Cog aligned at `64px`, no switcher. The mobile (narrow viewport) card view still works.
2. Verify it looks good on small screens.

<img width="1920" height="525" alt="Screenshot 2026-05-26 at 3 23 37 PM" src="https://github.com/user-attachments/assets/132b92f7-9ce5-44cf-87b4-f46a99129c61" />

### Regression checks

1. No console errors or React warnings on any of the pages.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?