### PR TITLE
Dashboard: pass onReset to DataViews as it's now supported upstream

### DIFF
--- a/client/dashboard/components/dataviews/dataviews.tsx
+++ b/client/dashboard/components/dataviews/dataviews.tsx
@@ -1,6 +1,4 @@
-import { Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { DataViews as WPDataViews } from '@wordpress/dataviews';
-import { __ } from '@wordpress/i18n';
 import { useEffect, useLayoutEffect, useRef } from 'react';
 import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { sanitizeView } from './sanitize-view';
@@ -10,19 +8,9 @@ type WPDataViewsProps< Item > = ComponentProps< typeof WPDataViews< Item > >;
 
 export type DataViewsProps< Item > = WPDataViewsProps< Item > & {
 	isPlaceholderData?: boolean;
-	onResetView?: () => void;
 };
 
-export function DataViews< Item >( {
-	view,
-	isPlaceholderData,
-	onResetView,
-	header,
-	search = true,
-	searchLabel,
-	children,
-	...props
-}: DataViewsProps< Item > ) {
+export function DataViews< Item >( { view, isPlaceholderData, ...props }: DataViewsProps< Item > ) {
 	const previousPage = useRef( view.page );
 	const dataviewsRef = useRef< HTMLDivElement | null >( null );
 
@@ -51,55 +39,7 @@ export function DataViews< Item >( {
 
 	const sanitizedView = sanitizeView( view, props.fields );
 
-	const resetViewAction = onResetView && (
-		<Button variant="tertiary" size="compact" onClick={ onResetView }>
-			{ __( 'Reset view' ) }
-		</Button>
-	);
-
-	const renderChildren = () => {
-		if ( children ) {
-			return children;
-		}
-
-		return (
-			<>
-				<HStack
-					alignment="top"
-					justify="space-between"
-					className="dataviews__view-actions"
-					spacing={ 1 }
-				>
-					<HStack justify="start" expanded={ false } className="dataviews__search">
-						{ search && <WPDataViews.Search label={ searchLabel } /> }
-						<WPDataViews.FiltersToggle />
-					</HStack>
-					<HStack spacing={ 1 } expanded={ false } style={ { flexShrink: 0 } }>
-						{ resetViewAction }
-						<WPDataViews.LayoutSwitcher />
-						<WPDataViews.ViewConfig />
-						{ header }
-					</HStack>
-				</HStack>
-				<WPDataViews.FiltersToggled className="dataviews-filters__container" />
-				<WPDataViews.Layout />
-				<WPDataViews.Footer />
-			</>
-		);
-	};
-
-	// TODO: apply local styles if necessary.
-	return (
-		<WPDataViews< Item >
-			view={ sanitizedView }
-			header={ header }
-			search={ search }
-			searchLabel={ searchLabel }
-			{ ...( props as any ) }
-		>
-			{ renderChildren() }
-		</WPDataViews>
-	);
+	return <WPDataViews< Item > view={ sanitizedView } { ...( props as any ) } />;
 }
 
 DataViews.Layout = WPDataViews.Layout;

--- a/client/dashboard/components/dataviews/readme.md
+++ b/client/dashboard/components/dataviews/readme.md
@@ -6,7 +6,7 @@ This component is a wrapper around WordPress's `@wordpress/dataviews` package. I
 
 The `index.tsx` file exports the following components:
 
-- **`DataViews`** - The main wrapper component that extends WordPress's DataViews with additional props like `onResetView` and view sanitization
+- **`DataViews`** - The main wrapper component that extends WordPress's DataViews with view sanitization
 - **`DataViewsCard`** - A card wrapper component for DataViews content
 - **`DataViewsEmptyState`** - A custom empty state component for use with DataViews
 

--- a/client/dashboard/domains/index.tsx
+++ b/client/dashboard/domains/index.tsx
@@ -97,7 +97,7 @@ function Domains() {
 							data={ filteredData || [] }
 							fields={ fields }
 							onChangeView={ updateView }
-							onResetView={ resetView }
+							onReset={ resetView }
 							view={ view }
 							actions={ actions }
 							search

--- a/client/dashboard/emails/index.tsx
+++ b/client/dashboard/emails/index.tsx
@@ -136,7 +136,7 @@ function Emails() {
 					fields={ emailFields }
 					view={ view }
 					onChangeView={ updateView }
-					onResetView={ resetView }
+					onReset={ resetView }
 					selection={ selection.map( ( item ) => item.id ) }
 					onChangeSelection={ ( ids ) =>
 						setSelection( emails.filter( ( email ) => ids.includes( email.id ) ) )

--- a/client/dashboard/me/billing-history/index.tsx
+++ b/client/dashboard/me/billing-history/index.tsx
@@ -80,7 +80,7 @@ export default function BillingHistory() {
 						fields={ fields }
 						view={ view }
 						onChangeView={ updateView }
-						onResetView={ resetView }
+						onReset={ resetView }
 						defaultLayouts={ { table: {} } }
 						actions={ actions }
 						getItemId={ getItemId }

--- a/client/dashboard/me/billing-purchases/index.tsx
+++ b/client/dashboard/me/billing-purchases/index.tsx
@@ -143,7 +143,7 @@ export default function PurchasesList() {
 						fields={ purchasesDataFields }
 						view={ view }
 						onChangeView={ updateView }
-						onResetView={ resetView }
+						onReset={ resetView }
 						defaultLayouts={ { table: {} } }
 						actions={ actions }
 						getItemId={ getItemId }

--- a/client/dashboard/sites-ciab/index.tsx
+++ b/client/dashboard/sites-ciab/index.tsx
@@ -161,7 +161,7 @@ export default function CIABSites() {
 					paginationInfo={ paginationInfo }
 					empty={ emptyState }
 					onChangeView={ handleViewChange }
-					onResetView={ resetView }
+					onReset={ resetView }
 				/>
 			</PageLayout>
 		</>

--- a/client/dashboard/sites/backups/backups-list.tsx
+++ b/client/dashboard/sites/backups/backups-list.tsx
@@ -95,7 +95,7 @@ export function BackupsList( {
 				fields={ fields }
 				view={ view }
 				onChangeView={ updateView }
-				onResetView={ resetView }
+				onReset={ resetView }
 				isLoading={ isLoadingActivityLog }
 				defaultLayouts={ { list: {} } }
 				paginationInfo={ paginationInfo }

--- a/client/dashboard/sites/dataviews/sites-dataviews.tsx
+++ b/client/dashboard/sites/dataviews/sites-dataviews.tsx
@@ -19,7 +19,7 @@ export function SitesDataViews( {
 	empty,
 	paginationInfo,
 	onChangeView,
-	onResetView,
+	onReset,
 }: {
 	view: View;
 	sites: Site[];
@@ -30,7 +30,7 @@ export function SitesDataViews( {
 	empty: ReactNode;
 	paginationInfo: ComponentProps< typeof DataViews< Site > >[ 'paginationInfo' ];
 	onChangeView: ( view: View ) => void;
-	onResetView?: () => void;
+	onReset?: () => void;
 } ) {
 	const { recordTracksEvent } = useAnalytics();
 
@@ -47,7 +47,7 @@ export function SitesDataViews( {
 					isLoading={ isLoading }
 					isPlaceholderData={ isPlaceholderData }
 					onChangeView={ onChangeView }
-					onResetView={ onResetView }
+					onReset={ onReset }
 					defaultLayouts={ DEFAULT_LAYOUTS }
 					paginationInfo={ paginationInfo }
 					config={ DEFAULT_CONFIG }

--- a/client/dashboard/sites/deployments-list/index.tsx
+++ b/client/dashboard/sites/deployments-list/index.tsx
@@ -201,7 +201,7 @@ function DeploymentsList() {
 					fields={ fields }
 					view={ view }
 					onChangeView={ updateView }
-					onResetView={ resetView }
+					onReset={ resetView }
 					isLoading={ isLoading }
 					defaultLayouts={ DEFAULT_LAYOUTS }
 					paginationInfo={ paginationInfo }

--- a/client/dashboard/sites/domains/index.tsx
+++ b/client/dashboard/sites/domains/index.tsx
@@ -114,7 +114,7 @@ function SiteDomains() {
 					data={ filteredData || [] }
 					fields={ fields }
 					onChangeView={ updateView }
-					onResetView={ resetView }
+					onReset={ resetView }
 					view={ view }
 					actions={ hasEligibleActions ? actions : [] }
 					search

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -255,7 +255,7 @@ export default function Sites() {
 						}
 						paginationInfo={ paginationInfo }
 						onChangeView={ handleViewChange }
-						onResetView={ resetView }
+						onReset={ resetView }
 					/>
 				) : (
 					<DataViewsEmptyStateLayout

--- a/client/dashboard/sites/logs-activity/dataviews/index.tsx
+++ b/client/dashboard/sites/logs-activity/dataviews/index.tsx
@@ -203,7 +203,7 @@ function SiteActivityLogsDataViews( {
 				search
 				defaultLayouts={ { table: {} } }
 				onChangeView={ onChangeView }
-				onResetView={ resetView }
+				onReset={ resetView }
 				empty={ <p>{ view.search ? __( 'No activity found' ) : __( 'No activities' ) }</p> }
 				children={ hasActivityLogsAccess ? undefined : <DataViews.Layout /> } // showing only the layout when on the free plan.
 			/>

--- a/client/dashboard/sites/logs/dataviews/index.tsx
+++ b/client/dashboard/sites/logs/dataviews/index.tsx
@@ -338,7 +338,7 @@ function SiteLogsDataViews( {
 					search={ false }
 					defaultLayouts={ { table: {} } }
 					onChangeView={ onChangeView }
-					onResetView={ resetView }
+					onReset={ resetView }
 					header={ LogsHeader }
 				/>
 			) : (
@@ -353,7 +353,7 @@ function SiteLogsDataViews( {
 					search={ false }
 					defaultLayouts={ { table: {} } }
 					onChangeView={ onChangeView }
-					onResetView={ resetView }
+					onReset={ resetView }
 					header={ LogsHeader }
 				/>
 			) }

--- a/client/dashboard/sites/scan-active/index.tsx
+++ b/client/dashboard/sites/scan-active/index.tsx
@@ -103,7 +103,7 @@ export function ActiveThreatsDataViews( {
 				isLoading={ isLoading }
 				onChangeSelection={ setSelection }
 				onChangeView={ updateView }
-				onResetView={ resetView }
+				onReset={ resetView }
 				paginationInfo={ paginationInfo }
 				searchLabel={ __( 'Search' ) }
 				selection={ selection }

--- a/client/dashboard/sites/scan-history/index.tsx
+++ b/client/dashboard/sites/scan-history/index.tsx
@@ -96,7 +96,7 @@ export function ScanHistoryDataViews( {
 				getItemId={ ( item ) => item.id.toString() }
 				isLoading={ isLoading }
 				onChangeView={ updateView }
-				onResetView={ resetView }
+				onReset={ resetView }
 				paginationInfo={ paginationInfo }
 				searchLabel={ __( 'Search' ) }
 				view={ view }

--- a/client/dashboard/sites/settings-repositories/index.tsx
+++ b/client/dashboard/sites/settings-repositories/index.tsx
@@ -141,7 +141,7 @@ function RepositoriesList() {
 				fields={ fields }
 				view={ view }
 				onChangeView={ updateView }
-				onResetView={ resetView }
+				onReset={ resetView }
 				actions={ actions }
 				isLoading={ isLoadingDeployments || isLoadingInstallations }
 				defaultLayouts={ DEFAULT_LAYOUTS }

--- a/client/sites/components/sites-dataviews/default-sites.tsx
+++ b/client/sites/components/sites-dataviews/default-sites.tsx
@@ -118,7 +118,7 @@ export default function DefaultSitesDataViews( {
 			paginationInfo={ paginationInfo }
 			config={ DEFAULT_CONFIG }
 			defaultLayouts={ { list: {} } }
-			onResetView={ resetView }
+			onReset={ resetView }
 			selection={ [ selectedSiteId.toString() ] }
 			onChangeSelection={ onSelectionChange }
 		/>


### PR DESCRIPTION
Fixes DOTMSD-1096

## Proposed Changes

Use DataViews' native `onReset` introduced in https://github.com/WordPress/gutenberg/pull/75093, instead of using our own custom one.

|Before|After|
|-|-|
|<img width="263" height="128" alt="image" src="https://github.com/user-attachments/assets/657d0375-35f2-491e-b1e8-c655b494aba3" />|<img width="404" height="303" alt="image" src="https://github.com/user-attachments/assets/a571aac2-1667-425d-aab7-d966b9e38604" />


## Why are these changes being made?

Core-first design.

## Testing Instructions

1. Go to /sites
2. Try modifying the DataViews appearances using the top-right gear icon
3. Verify it shows a blue dot and when clicked you see the `Reset view` button as screenshot above.
4. Smoke-test other DataViews in other pages in MSD.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
