### PR TITLE
A4A: extract A4APopoverTrigger with built-in keyboard a11y

### DIFF
--- a/client/a8c-for-agencies/components/a4a-popover/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-popover/index.tsx
@@ -24,6 +24,7 @@ interface Props {
 	anchor?: HTMLElement | null;
 	title: string;
 	className?: string;
+	focusOnMount?: React.ComponentProps< typeof Popover >[ 'focusOnMount' ];
 	onFocusOutside: ( event: React.SyntheticEvent ) => void;
 	children: React.ReactNode;
 }
@@ -35,6 +36,7 @@ export default function A4APopover( {
 	anchor,
 	title,
 	className,
+	focusOnMount,
 	onFocusOutside,
 	children,
 }: Props ) {
@@ -46,6 +48,7 @@ export default function A4APopover( {
 			className={ clsx( 'a4a-popover', className ) }
 			anchor={ anchor ?? undefined }
 			position={ position }
+			focusOnMount={ focusOnMount }
 			onFocusOutside={ onFocusOutside }
 		>
 			<div className="a4a-popover__content">

--- a/client/a8c-for-agencies/components/a4a-popover/style.scss
+++ b/client/a8c-for-agencies/components/a4a-popover/style.scss
@@ -2,6 +2,17 @@
 @import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/variables";
 
+.a4a-popover-trigger {
+	cursor: pointer;
+	display: inline-flex;
+	border-radius: 2px;
+
+	&:focus-visible {
+		outline: 2px solid var(--color-primary);
+		outline-offset: 2px;
+	}
+}
+
 .a4a-popover__content {
 	display: flex;
 	flex-direction: column;

--- a/client/a8c-for-agencies/components/a4a-popover/trigger.tsx
+++ b/client/a8c-for-agencies/components/a4a-popover/trigger.tsx
@@ -1,0 +1,42 @@
+import clsx from 'clsx';
+import { forwardRef } from 'react';
+
+interface Props extends Omit< React.HTMLAttributes< HTMLSpanElement >, 'role' | 'tabIndex' > {
+	onActivate: () => void;
+	className?: string;
+	children: React.ReactNode;
+}
+
+const A4APopoverTrigger = forwardRef< HTMLSpanElement, Props >( function A4APopoverTrigger(
+	{ onActivate, className, children, onClick, onKeyDown, ...rest },
+	ref
+) {
+	const handleClick = ( event: React.MouseEvent< HTMLSpanElement > ) => {
+		onClick?.( event );
+		onActivate();
+	};
+
+	const handleKeyDown = ( event: React.KeyboardEvent< HTMLSpanElement > ) => {
+		onKeyDown?.( event );
+		if ( event.key === 'Enter' || event.key === ' ' ) {
+			event.preventDefault();
+			onActivate();
+		}
+	};
+
+	return (
+		<span
+			{ ...rest }
+			ref={ ref }
+			className={ clsx( 'a4a-popover-trigger', className ) }
+			role="button"
+			tabIndex={ 0 }
+			onClick={ handleClick }
+			onKeyDown={ handleKeyDown }
+		>
+			{ children }
+		</span>
+	);
+} );
+
+export default A4APopoverTrigger;

--- a/client/a8c-for-agencies/components/a4a-popover/trigger.tsx
+++ b/client/a8c-for-agencies/components/a4a-popover/trigger.tsx
@@ -1,6 +1,8 @@
 import clsx from 'clsx';
 import { forwardRef } from 'react';
 
+import './style.scss';
+
 interface Props extends Omit< React.HTMLAttributes< HTMLSpanElement >, 'role' | 'tabIndex' > {
 	onActivate: () => void;
 	className?: string;

--- a/client/a8c-for-agencies/components/consolidated-stats-card/index.tsx
+++ b/client/a8c-for-agencies/components/consolidated-stats-card/index.tsx
@@ -6,6 +6,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useState, useRef } from 'react';
 import InfoModal from 'calypso/a8c-for-agencies/components/a4a-info-modal';
 import A4APopover from 'calypso/a8c-for-agencies/components/a4a-popover';
+import A4APopoverTrigger from 'calypso/a8c-for-agencies/components/a4a-popover/trigger';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 
 import './style.scss';
@@ -33,19 +34,12 @@ const CardInfo = ( { children, wrapperRef, footerText, title, footerAction }: Ca
 				<div className="consolidated-stats-card__label">
 					{ footerText }
 					{ ! isMobile && (
-						<span
+						<A4APopoverTrigger
 							className="consolidated-stats-card__info-icon"
-							onClick={ () => setShowPopover( true ) }
-							role="button"
-							tabIndex={ 0 }
-							onKeyDown={ ( event ) => {
-								if ( event.key === 'Enter' ) {
-									setShowPopover( true );
-								}
-							} }
+							onActivate={ () => setShowPopover( true ) }
 						>
 							<Gridicon icon="info-outline" size={ 16 } />
-						</span>
+						</A4APopoverTrigger>
 					) }
 				</div>
 				{ isMobile && (

--- a/client/a8c-for-agencies/components/consolidated-stats-card/index.tsx
+++ b/client/a8c-for-agencies/components/consolidated-stats-card/index.tsx
@@ -36,6 +36,7 @@ const CardInfo = ( { children, wrapperRef, footerText, title, footerAction }: Ca
 					{ ! isMobile && (
 						<A4APopoverTrigger
 							className="consolidated-stats-card__info-icon"
+							aria-label={ translate( 'More info' ) }
 							onActivate={ () => setShowPopover( true ) }
 						>
 							<Gridicon icon="info-outline" size={ 16 } />
@@ -65,6 +66,7 @@ const CardInfo = ( { children, wrapperRef, footerText, title, footerAction }: Ca
 						title=""
 						offset={ 12 }
 						wrapperRef={ wrapperRef }
+						focusOnMount={ false }
 						onFocusOutside={ () => setShowPopover( false ) }
 					>
 						{ children }

--- a/client/a8c-for-agencies/components/consolidated-stats-card/index.tsx
+++ b/client/a8c-for-agencies/components/consolidated-stats-card/index.tsx
@@ -66,7 +66,7 @@ const CardInfo = ( { children, wrapperRef, footerText, title, footerAction }: Ca
 						title=""
 						offset={ 12 }
 						wrapperRef={ wrapperRef }
-						focusOnMount={ false }
+						focusOnMount="container"
 						onFocusOutside={ () => setShowPopover( false ) }
 					>
 						{ children }

--- a/client/a8c-for-agencies/components/consolidated-stats-card/style.scss
+++ b/client/a8c-for-agencies/components/consolidated-stats-card/style.scss
@@ -85,7 +85,6 @@
 }
 
 .consolidated-stats-card__info-icon {
-	cursor: pointer;
 	position: relative;
 	inset-block-start: 4px;
 	inset-inline-start: 4px;

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/influenced-revenue.scss
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/influenced-revenue.scss
@@ -8,8 +8,6 @@
 }
 
 .influenced-revenue__info-icon {
-	cursor: pointer;
-	display: inline-flex;
 	color: var(--color-neutral-70);
 }
 

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/influenced-revenue.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/influenced-revenue.tsx
@@ -61,6 +61,7 @@ function InfluencedRevenueStrapline() {
 			{ title }
 			<A4APopoverTrigger
 				className="influenced-revenue__info-icon"
+				aria-label={ translate( 'More information about influenced revenue' ) }
 				ref={ setIconNode }
 				onActivate={ openInfo }
 			>
@@ -76,6 +77,7 @@ function InfluencedRevenueStrapline() {
 						title=""
 						offset={ 12 }
 						anchor={ iconNode }
+						focusOnMount={ false }
 						onFocusOutside={ () => setShowPopover( false ) }
 					>
 						{ content }

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/influenced-revenue.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/influenced-revenue.tsx
@@ -6,6 +6,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import InfoModal from 'calypso/a8c-for-agencies/components/a4a-info-modal';
 import A4APopover from 'calypso/a8c-for-agencies/components/a4a-popover';
+import A4APopoverTrigger from 'calypso/a8c-for-agencies/components/a4a-popover/trigger';
 import { Stat } from 'calypso/a8c-for-agencies/components/stat';
 import useHelpCenter from 'calypso/a8c-for-agencies/hooks/use-help-center';
 import { useDispatch } from 'calypso/state';
@@ -58,20 +59,13 @@ function InfluencedRevenueStrapline() {
 	return (
 		<span className="influenced-revenue__strapline">
 			{ title }
-			<span
+			<A4APopoverTrigger
 				className="influenced-revenue__info-icon"
 				ref={ setIconNode }
-				onClick={ openInfo }
-				role="button"
-				tabIndex={ 0 }
-				onKeyDown={ ( event ) => {
-					if ( event.key === 'Enter' ) {
-						openInfo();
-					}
-				} }
+				onActivate={ openInfo }
 			>
 				<Gridicon icon="info-outline" size={ 16 } />
-			</span>
+			</A4APopoverTrigger>
 			{ showPopover &&
 				( isMobile ? (
 					<InfoModal title={ title as string } onClose={ () => setShowPopover( false ) }>

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/influenced-revenue.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/influenced-revenue.tsx
@@ -77,7 +77,7 @@ function InfluencedRevenueStrapline() {
 						title=""
 						offset={ 12 }
 						anchor={ iconNode }
-						focusOnMount={ false }
+						focusOnMount="container"
 						onFocusOutside={ () => setShowPopover( false ) }
 					>
 						{ content }

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -8,6 +8,7 @@ import { useCallback, useEffect, useState, useContext, useRef } from 'react';
 import useShowFeedback from 'calypso/a8c-for-agencies/components/a4a-feedback/hooks/use-show-a4a-feedback';
 import { FeedbackType } from 'calypso/a8c-for-agencies/components/a4a-feedback/types';
 import A4APopover from 'calypso/a8c-for-agencies/components/a4a-popover';
+import A4APopoverTrigger from 'calypso/a8c-for-agencies/components/a4a-popover/trigger';
 import {
 	A4A_SITES_LINK_NEEDS_SETUP,
 	A4A_FEEDBACK_LINK,
@@ -211,17 +212,10 @@ export default function LicensePreview( {
 		const wrapperRef = useRef< HTMLSpanElement | null >( null );
 
 		return (
-			<span
+			<A4APopoverTrigger
 				className="license-preview__migration-wrapper"
-				onClick={ () => setShowPopover( true ) }
-				role="button"
-				tabIndex={ 0 }
 				ref={ wrapperRef }
-				onKeyDown={ ( event ) => {
-					if ( event.key === 'Enter' ) {
-						setShowPopover( true );
-					}
-				} }
+				onActivate={ () => setShowPopover( true ) }
 			>
 				<Badge className="license-preview__migration-badge" type="info-green">
 					{ translate( 'Transferred' ) }
@@ -260,7 +254,7 @@ export default function LicensePreview( {
 						</div>
 					</A4APopover>
 				) }
-			</span>
+			</A4APopoverTrigger>
 		);
 	};
 

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
@@ -155,6 +155,7 @@ const AssignedTo = ( { purchase, handleAssignToSite, data, isFetching }: Props )
 			{ cancellationInfo && (
 				<A4APopoverTrigger
 					className="status-card__info-icon"
+					aria-label={ translate( 'More information about cancellation' ) }
 					ref={ wrapperRef }
 					onActivate={ () => setShowPopover( ( prev ) => ! prev ) }
 				>

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
@@ -5,6 +5,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useState, useRef, useEffect } from 'react';
 import InfoModal from 'calypso/a8c-for-agencies/components/a4a-info-modal';
 import A4APopover from 'calypso/a8c-for-agencies/components/a4a-popover';
+import A4APopoverTrigger from 'calypso/a8c-for-agencies/components/a4a-popover/trigger';
 import { A4A_SITES_LINK_NEEDS_SETUP } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import StatusBadge from 'calypso/a8c-for-agencies/components/step-section-item/status-badge';
 import { useSubscriptionDetails } from 'calypso/a8c-for-agencies/hooks/use-subscription-details';
@@ -60,7 +61,7 @@ const AssignedTo = ( { purchase, handleAssignToSite, data, isFetching }: Props )
 	const { expiryDate, isFetchingProductInfo } = useSubscriptionDetails( purchase );
 	const [ showPopover, setShowPopover ] = useState( false );
 
-	const wrapperRef = useRef< HTMLDivElement >( null );
+	const wrapperRef = useRef< HTMLSpanElement | null >( null );
 	const popoverContentRef = useRef< HTMLDivElement >( null );
 
 	useEffect( () => {
@@ -152,20 +153,13 @@ const AssignedTo = ( { purchase, handleAssignToSite, data, isFetching }: Props )
 				} }
 			/>
 			{ cancellationInfo && (
-				<span
+				<A4APopoverTrigger
 					className="status-card__info-icon"
-					onClick={ () => setShowPopover( ! showPopover ) }
-					role="button"
-					tabIndex={ 0 }
-					onKeyDown={ ( event ) => {
-						if ( event.key === 'Enter' ) {
-							setShowPopover( ! showPopover );
-						}
-					} }
 					ref={ wrapperRef }
+					onActivate={ () => setShowPopover( ( prev ) => ! prev ) }
 				>
 					<Gridicon icon="info-outline" size={ 18 } />
-				</span>
+				</A4APopoverTrigger>
 			) }
 			{ cancellationInfo &&
 				showPopover &&

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
@@ -5,6 +5,7 @@ import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { memo, useState, useRef } from 'react';
 import A4APopover from 'calypso/a8c-for-agencies/components/a4a-popover';
+import A4APopoverTrigger from 'calypso/a8c-for-agencies/components/a4a-popover/trigger';
 import { A4A_WOOPAYMENTS_SITE_SETUP_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import StatusBadge from 'calypso/a8c-for-agencies/components/step-section-item/status-badge';
 import { urlToSlug } from 'calypso/lib/url/http-utils';
@@ -210,19 +211,12 @@ export const CommissionEligibilityColumn = ( {
 			/>
 			{ statusProps.showInfoIcon && (
 				<>
-					<span
+					<A4APopoverTrigger
 						className="woopayments-status-column__info-icon"
-						onClick={ () => setShowPopover( true ) }
-						role="button"
-						tabIndex={ 0 }
-						onKeyDown={ ( event ) => {
-							if ( event.key === 'Enter' ) {
-								setShowPopover( true );
-							}
-						} }
+						onActivate={ () => setShowPopover( true ) }
 					>
 						<Gridicon icon="info-outline" size={ 16 } />
-					</span>
+					</A4APopoverTrigger>
 					{ showPopover && (
 						<A4APopover
 							title=""

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
@@ -213,6 +213,7 @@ export const CommissionEligibilityColumn = ( {
 				<>
 					<A4APopoverTrigger
 						className="woopayments-status-column__info-icon"
+						aria-label={ translate( 'More information about commission eligibility' ) }
 						onActivate={ () => setShowPopover( true ) }
 					>
 						<Gridicon icon="info-outline" size={ 16 } />
@@ -222,6 +223,7 @@ export const CommissionEligibilityColumn = ( {
 							title=""
 							offset={ 12 }
 							wrapperRef={ wrapperRef }
+							focusOnMount={ false }
 							onFocusOutside={ () => setShowPopover( false ) }
 						>
 							{ popoverContent }

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
@@ -223,7 +223,7 @@ export const CommissionEligibilityColumn = ( {
 							title=""
 							offset={ 12 }
 							wrapperRef={ wrapperRef }
-							focusOnMount={ false }
+							focusOnMount="container"
 							onFocusOutside={ () => setShowPopover( false ) }
 						>
 							{ popoverContent }

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/style.scss
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/style.scss
@@ -93,21 +93,13 @@
 	position: relative;
 
 	.woopayments-status-column__info-icon {
-		display: inline-flex;
 		align-items: center;
 		justify-content: center;
-		cursor: pointer;
 		color: var(--color-neutral-60);
 		transition: color 0.2s ease;
 
 		&:hover {
 			color: var(--color-neutral-80);
-		}
-
-		&:focus-visible {
-			outline: 2px solid var(--color-primary);
-			outline-offset: 2px;
-			border-radius: 2px;
 		}
 	}
 }


### PR DESCRIPTION
Follow-up to #111013.

## Proposed Changes

<img width="253" height="119" alt="Screenshot 2026-05-26 at 10 21 52" src="https://github.com/user-attachments/assets/fa862750-6be9-4ef0-af44-0f86fec0640f" />


* Add a new shared `A4APopoverTrigger` component (`client/a8c-for-agencies/components/a4a-popover/trigger.tsx`) that centralizes the popover-trigger pattern: `role="button"`, `tabIndex={0}`, Enter + Space activation (with `preventDefault` for Space), forwarded ref, and a built-in `:focus-visible` outline.
* Migrate 5 existing trigger call sites to use it, removing the duplicated `<span role="button" tabIndex={0} onClick onKeyDown>` boilerplate and the per-site `cursor: pointer` / `display: inline-flex` / redundant `:focus-visible` rules:
  * `agency-tier/overview-content/influenced-revenue.tsx`
  * `components/consolidated-stats-card/index.tsx`
  * `woopayments/dashboard-content/site-columns.tsx`
  * `purchases/licenses/license-preview/index.tsx` (TransferredBadge)
  * `referrals/referral-details/components/assigned-to.tsx`

## Why are these changes being made?

Review feedback on #111013 noted that tabbing to the influenced-revenue info icon left no visible focus indicator. The same `<span role="button" tabIndex={0}>` pattern was duplicated across multiple A4A surfaces, all sharing the same accessibility gaps (no focus indicator, no Space-key activation). Extracting a shared component fixes the indicator everywhere at once and prevents the pattern from drifting further.

Two existing popover-related files are intentionally untouched:
* `partner-directory/dashboard/status-badge.tsx` — hover-driven, different interaction model (and was already missing a keyboard handler).
* `marketplace/checkout/pending-payment-popover.tsx` — renders the popover itself, not a trigger.

## Testing Instructions

* Visit any of the migrated surfaces (e.g. Agency Tier overview → influenced revenue, Consolidated Stats Card info icons, WooPayments dashboard status info icon, the Transferred badge on a transferred license in Purchases, and the cancellation info icon in Referrals → referral details).
* Tab through the page until focus lands on the info icon / badge — a visible outline should appear.
* Press Enter or Space — the popover should open. Tab outside or click away to close.
* Mouse click should continue to work as before.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?