### PR TITLE
Agents Manager: localise Jetpack AI usage-limit error in chat banner

### DIFF
--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -27,6 +27,7 @@ import {
 	type ExternalContextCardAction,
 } from '../../utils/external-context';
 import { isReaderChatAgent } from '../../utils/is-reader-chat-agent';
+import { getOrchestratorErrorMessage } from '../../utils/orchestrator-error-message';
 import { persistLastActivity } from '../../utils/persist-last-activity';
 import { getReaderChatErrorMessage } from '../../utils/reader-chat-error-message';
 import AgentChat from '../agent-chat';
@@ -131,7 +132,9 @@ export default function OrchestratorChat( {
 	const isReaderChat = isReaderChatAgent( agentConfig?.agentId );
 	const shouldLoadConversation =
 		! isReaderChat || ( ! hasUserSentMessage && messages.length === 0 && ! isProcessing );
-	const chatError = isReaderChat ? getReaderChatErrorMessage( error ) : error;
+	const chatError = isReaderChat
+		? getReaderChatErrorMessage( error )
+		: getOrchestratorErrorMessage( error );
 
 	const { isLoading: isLoadingConversation } = useConversation( {
 		maxPages: isReaderChat ? 1 : 10,

--- a/packages/agents-manager/src/utils/__tests__/orchestrator-error-message.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/orchestrator-error-message.test.ts
@@ -1,0 +1,27 @@
+import { getOrchestratorErrorMessage } from '../orchestrator-error-message';
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text: string ) => text,
+} ) );
+
+describe( 'getOrchestratorErrorMessage', () => {
+	it( 'returns null when there is no error', () => {
+		expect( getOrchestratorErrorMessage( null ) ).toBeNull();
+	} );
+
+	it( 'maps the over-limit error code to localized upgrade copy', () => {
+		expect( getOrchestratorErrorMessage( 'review_mediator_over_limit' ) ).toBe(
+			'You have reached your Jetpack AI usage limit. Upgrade your plan to continue.'
+		);
+	} );
+
+	it( 'maps a differently-worded over-limit message to localized upgrade copy', () => {
+		expect( getOrchestratorErrorMessage( 'HTTP 429: Jetpack AI usage limit reached.' ) ).toBe(
+			'You have reached your Jetpack AI usage limit. Upgrade your plan to continue.'
+		);
+	} );
+
+	it( 'passes other errors through unchanged', () => {
+		expect( getOrchestratorErrorMessage( 'Some other error.' ) ).toBe( 'Some other error.' );
+	} );
+} );

--- a/packages/agents-manager/src/utils/orchestrator-error-message.ts
+++ b/packages/agents-manager/src/utils/orchestrator-error-message.ts
@@ -1,0 +1,19 @@
+import { __ } from '@wordpress/i18n';
+
+// Map orchestrator (Jetpack AI sidebar) errors whose server messages are not
+// client-translated to a localized copy, mirroring reader-chat-error-message.
+// Non-matching errors pass through unchanged.
+export function getOrchestratorErrorMessage( error: string | null ): string | null {
+	if ( ! error ) {
+		return null;
+	}
+
+	if ( error.includes( 'review_mediator_over_limit' ) || /jetpack ai usage limit/i.test( error ) ) {
+		return __(
+			'You have reached your Jetpack AI usage limit. Upgrade your plan to continue.',
+			'__i18n_text_domain__'
+		);
+	}
+
+	return error;
+}


### PR DESCRIPTION
Companion WPCOM PR: 220006-ghe-Automattic/wpcom

## Proposed Changes

* Add `getOrchestratorErrorMessage` mapper: returns a localized message for the Jetpack AI over-limit error, passes other errors through. Mirrors `getReaderChatErrorMessage`.
* Use it for non-reader-chat errors in `OrchestratorChat` so the over-limit shows localized copy in the chat error banner.
* Unit test for the mapper.

<img width="673" height="649" alt="image" src="https://github.com/user-attachments/assets/a4c59623-3acd-451a-af35-57bdae49e958" />


## Why are these changes being made?

* The backend over-limit message arrives as a raw server string that calypso's i18n does not translate. Mapping it client-side (like reader chat) yields a translatable banner message.

## Testing Instructions

* See WPCOM PR 220006-ghe-Automattic/wpcom for the end-to-end steps (force quota, trigger AER). This PR localizes the resulting over-limit message in the chat error banner.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?