### PR TITLE
Dashboard: show the loader back on the interim omnibar

### DIFF
--- a/client/dashboard/app/omnibar/style.scss
+++ b/client/dashboard/app/omnibar/style.scss
@@ -2,5 +2,5 @@
 	position: fixed;
 	top: 0;
 	inset-inline: 0;
-	z-index: 99999;
+	z-index: 999;
 }


### PR DESCRIPTION
## Proposed Changes

In the dashboard, show the loader line when interim omnibar is shown.

It was working previously, but I broke it when I introduced the radical omnibar, where the z-index (99999) is greater than the loader's (1000):

https://github.com/Automattic/wp-calypso/blob/34d8b4b2c49dcce3f27f47c75235cf9b7b77f901/client/dashboard/components/loading-line/style.scss#L28

This PR updates the value to 999.

## Why are these changes being made?

Fixes a regression.

## Testing Instructions

Click around dashboard; verify you can see the loader on top of the interim omnibar.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
