### PR TITLE
Login: fix oversized Last used badge

### DIFF
--- a/client/blocks/login/login-form.scss
+++ b/client/blocks/login/login-form.scss
@@ -5,9 +5,10 @@
 $breakpoint-mobile: 782px; //Mobile size.
 
 // Inline "Last used" badge next to the email/username label (used when the
-// last-used method was `password`). Margin and vertical-align are the only
-// positional styles we own — colors come from the Badge's default
-// `intent="informational"` styling.
+// last-used method was `password`). Margin is the only positional style we
+// own — colors come from the Badge's default `intent="informational"`
+// styling, and vertical alignment falls back to the default baseline so the
+// badge sits on the same line as the label text.
 //
 // font-size / line-height / padding / radius repeats are a Calypso-cascade
 // workaround: the Badge sets them inside `@layer wp-ui-components`, which
@@ -17,7 +18,6 @@ $breakpoint-mobile: 782px; //Mobile size.
 // browser defaults on staging.
 .login__form-last-used-badge {
 	margin-inline-start: 8px;
-	vertical-align: middle;
 	font-size: 12px;
 	line-height: 16px;
 	padding: 4px 8px;

--- a/client/blocks/login/login-form.scss
+++ b/client/blocks/login/login-form.scss
@@ -9,17 +9,19 @@ $breakpoint-mobile: 782px; //Mobile size.
 // positional styles we own — colors come from the Badge's default
 // `intent="informational"` styling.
 //
-// The font-size / line-height / padding / radius repeats are a Calypso-
-// cascade workaround: the Badge sets them inside `@layer wp-ui-components`,
-// which Calypso's unlayered resets always beat. Same workaround as
-// `.social-buttons__last-used-pill` and `client/my-sites/podcast/style.scss`.
+// font-size / line-height / padding / radius repeats are a Calypso-cascade
+// workaround: the Badge sets them inside `@layer wp-ui-components`, which
+// Calypso's unlayered resets always beat. Values are hardcoded (not
+// `var(--wpds-*)`) because the tokens stylesheet doesn't reliably reach this
+// override in production builds, which made the badge balloon to inherited
+// browser defaults on staging.
 .login__form-last-used-badge {
 	margin-inline-start: 8px;
 	vertical-align: middle;
-	font-size: var( --wpds-font-size-sm );
-	line-height: var( --wpds-font-line-height-xs );
-	padding: var( --wpds-dimension-padding-xs ) var( --wpds-dimension-padding-sm );
-	border-radius: var( --wpds-border-radius-lg );
+	font-size: 12px;
+	line-height: 16px;
+	padding: 4px 8px;
+	border-radius: 8px;
 }
 
 // Bump the label's margin-bottom from the shared 6px to 8px when the inline

--- a/client/components/social-buttons/style.scss
+++ b/client/components/social-buttons/style.scss
@@ -1,10 +1,11 @@
 /*rtl:ignore*/
 @import '@automattic/typography/styles/variables';
 
-// Load the WPDS design tokens so @wordpress/ui components (e.g. Badge) can
-// resolve their --wpds-* CSS variables. Without this, font-size, padding,
-// and radius rules in the Badge silently fall back to inherited/browser
-// defaults (e.g. 16px font instead of the WPDS-spec 12px).
+// Load the WPDS design tokens so the @wordpress/ui Badge's own layered
+// styles (intent colors, etc.) resolve. This import only reliably feeds
+// styles defined inside the Badge component itself — overrides in this
+// file should NOT depend on `var(--wpds-*)` because the tokens don't
+// always reach our unlayered rules in production builds.
 @import '@wordpress/theme/design-tokens.css';
 
 .social-buttons__button {
@@ -49,17 +50,19 @@
 // element. Position is the only style we own here — colors come from the
 // Badge's default `intent="informational"` styling.
 //
-// The font-size / line-height / padding / radius repeats are a Calypso-
-// cascade workaround: the Badge sets them inside `@layer wp-ui-components`,
-// which Calypso's unlayered resets always beat. Same workaround as
-// `client/my-sites/podcast/style.scss`.
+// font-size / line-height / padding / radius repeats are a Calypso-cascade
+// workaround: the Badge sets them inside `@layer wp-ui-components`, which
+// Calypso's unlayered resets always beat. Values are hardcoded (not
+// `var(--wpds-*)`) because the tokens stylesheet doesn't reliably reach this
+// override in production builds, which made the badge balloon to inherited
+// browser defaults on staging.
 .social-buttons__last-used-pill {
 	position: absolute;
 	top: -10px;
 	right: -6px;
 	z-index: 1;
-	font-size: var( --wpds-font-size-sm );
-	line-height: var( --wpds-font-line-height-xs );
-	padding: var( --wpds-dimension-padding-xs ) var( --wpds-dimension-padding-sm );
-	border-radius: var( --wpds-border-radius-lg );
+	font-size: 12px;
+	line-height: 16px;
+	padding: 4px 8px;
+	border-radius: 8px;
 }


### PR DESCRIPTION
Follow-up to [#110447](https://github.com/Automattic/wp-calypso/pull/110447).

## What
The "Last used" badge is rendering much larger than designed, about 16px font and oversized padding/radius instead of the small pill we shipped in the original mockups. 

<img width="2874" height="1620" alt="Screenshot 2026-05-26 at 13 48 37" src="https://github.com/user-attachments/assets/84658102-b033-4f4c-9231-770c5e890f44" />


## Why
The badge was reading its font-size, padding, line-height and border-radius from the WPDS design token CSS variables (`var(--wpds-*)`). Those variables aren't reaching this style override in the bundled CSS, so the values fall back to inherited browser defaults — that's the ballooned look.

Replacing those variable references with the literal pixel values (the same numbers the tokens were supposed to resolve to) makes the override self-contained.

**Note**: This is a patch, not a root fix. The underlying issue is that `@wordpress/ui` (used by the Badge here) doesn't play well with Calypso's older CSS, so we override them. In the long term, I hope Calypso gets some fixes to adopt the newer libraries.


## How to test
1. On this PR's `calypso.live` preview, open `/log-in/?last_used=google`
2. The "Last used" pill on Continue with Google should be small (~12px font, tight padding) — matches the original design mockup.
3. Try `?last_used=password` to see the inline badge next to the email field — should also be small.