### PR TITLE
Reader Social: route notifications to the in-app thread

### DIFF
--- a/client/reader/atmosphere/notifications-panel.tsx
+++ b/client/reader/atmosphere/notifications-panel.tsx
@@ -1,17 +1,36 @@
 import { useAtmosphereNotificationsInfiniteQuery } from '@automattic/api-queries';
+import { useCallback } from 'react';
 import { SocialNotificationsPanel } from 'calypso/reader/social';
+import { getThreadUrl } from './route';
 import type { AtmosphereConnection } from '@automattic/api-core';
+import type { NotificationInAppUrlResolver } from 'calypso/reader/social';
 
 interface Props {
 	connection: AtmosphereConnection;
 }
 
 export function NotificationsPanel( { connection }: Props ) {
+	const connectionId = connection.id;
+	// Mention / reply / quote / like / repost notifications all carry an at://
+	// post URI on the target. Route the row to the in-app thread view instead
+	// of letting it bounce the user out to bsky.app via target_url.
+	const getInAppUrl = useCallback< NotificationInAppUrlResolver >(
+		( notification ) => {
+			const target = notification.target;
+			if ( ! target || target.kind !== 'post' ) {
+				return null;
+			}
+			return getThreadUrl( connectionId, target.uri );
+		},
+		[ connectionId ]
+	);
+
 	return (
 		<SocialNotificationsPanel
-			connectionId={ connection.id }
+			connectionId={ connectionId }
 			source="atmosphere"
 			useNotificationsInfiniteQuery={ useAtmosphereNotificationsInfiniteQuery }
+			getInAppUrl={ getInAppUrl }
 		/>
 	);
 }

--- a/client/reader/atmosphere/test/notifications-panel.test.tsx
+++ b/client/reader/atmosphere/test/notifications-panel.test.tsx
@@ -64,6 +64,44 @@ describe( 'NotificationsPanel', () => {
 		await waitFor( () => expect( screen.getByText( /no notifications yet/i ) ).toBeVisible() );
 	} );
 
+	it( 'routes post-target rows to the in-app thread URL', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/atmosphere/connections/101/notifications' )
+			.query( {} )
+			.reply( 200, {
+				items: [
+					{
+						id: 'a',
+						protocol_type: 'mention',
+						canonical_type: 'mention',
+						actor: {
+							handle: 'jane.bsky.social',
+							display_name: 'Jane',
+							avatar_url: null,
+							profile_uri: 'at://did:plc:jane',
+						},
+						target: {
+							kind: 'post',
+							uri: 'at://did:plc:abcdefghijklmnopqrstuvwx/app.bsky.feed.post/3abcdefghijkl',
+							excerpt: '@me hi',
+						},
+						target_url: 'https://bsky.app/profile/jane.bsky.social/post/3abcdefghijkl',
+						created_at: '2026-05-11T12:34:56Z',
+						is_read: false,
+					},
+				],
+				next_cursor: null,
+				seen_at: null,
+			} );
+		renderWithProvider( <NotificationsPanel connection={ connection } /> );
+		const link = await screen.findByRole( 'link', { name: /jane mentioned you/i } );
+		expect( link ).toHaveAttribute(
+			'href',
+			'/reader/atmosphere/101/thread/did:plc:abcdefghijklmnopqrstuvwx/3abcdefghijkl'
+		);
+		expect( link ).not.toHaveAttribute( 'target' );
+	} );
+
 	it( 'switching to the Likes chip refetches with types=like', async () => {
 		nock( BASE )
 			.get( '/wpcom/v2/reader/atmosphere/connections/101/notifications' )

--- a/client/reader/mastodon/notifications-panel.tsx
+++ b/client/reader/mastodon/notifications-panel.tsx
@@ -1,17 +1,43 @@
 import { useMastodonNotificationsInfiniteQuery } from '@automattic/api-queries';
+import { useCallback } from 'react';
 import { SocialNotificationsPanel } from 'calypso/reader/social';
+import { getThreadUrl } from './route';
 import type { MastodonConnection } from '@automattic/api-core';
+import type { NotificationInAppUrlResolver } from 'calypso/reader/social';
+
+// The wpcom backend emits Mastodon notification target URIs as
+// `mastodon:<instance>:<status_id>` (see NotificationsNormalizerTest). The
+// status id is the home-instance local id, which is exactly what the
+// in-app thread route expects.
+const MASTODON_TARGET_URI_RE = /^mastodon:[^:]+:([0-9]{1,32})$/;
 
 interface Props {
 	connection: MastodonConnection;
 }
 
 export function NotificationsPanel( { connection }: Props ) {
+	const connectionId = connection.id;
+	const getInAppUrl = useCallback< NotificationInAppUrlResolver >(
+		( notification ) => {
+			const target = notification.target;
+			if ( ! target || target.kind !== 'post' ) {
+				return null;
+			}
+			const matched = target.uri.match( MASTODON_TARGET_URI_RE );
+			if ( ! matched ) {
+				return null;
+			}
+			return getThreadUrl( connectionId, matched[ 1 ] );
+		},
+		[ connectionId ]
+	);
+
 	return (
 		<SocialNotificationsPanel
-			connectionId={ connection.id }
+			connectionId={ connectionId }
 			source="mastodon"
 			useNotificationsInfiniteQuery={ useMastodonNotificationsInfiniteQuery }
+			getInAppUrl={ getInAppUrl }
 		/>
 	);
 }

--- a/client/reader/mastodon/test/notifications-panel.test.tsx
+++ b/client/reader/mastodon/test/notifications-panel.test.tsx
@@ -130,6 +130,82 @@ describe( 'Mastodon NotificationsPanel', () => {
 		await waitFor( () => expect( screen.getByText( /interacted with you/i ) ).toBeVisible() );
 	} );
 
+	it( 'routes post-target rows to the in-app thread URL using the wire status_id', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/mastodon/connections/101/notifications' )
+			.query( {} )
+			.reply( 200, {
+				items: [
+					{
+						id: '13371340',
+						protocol_type: 'mention',
+						canonical_type: 'mention',
+						actor: {
+							handle: 'jane@mastodon.social',
+							display_name: 'Jane',
+							avatar_url: null,
+							profile_uri: 'https://mastodon.social/@jane',
+						},
+						// Wire format per the wpcom NotificationsNormalizer:
+						// `mastodon:<instance>:<status_id>`. The status id is the
+						// home-instance local id, exactly what the in-app thread
+						// route expects.
+						target: {
+							kind: 'post',
+							uri: 'mastodon:mastodon.social:200',
+							excerpt: '@me hi',
+						},
+						target_url: 'https://mastodon.social/@jane/200',
+						created_at: '2026-05-11T15:00:00Z',
+						is_read: false,
+					},
+				],
+				next_cursor: null,
+				seen_at: null,
+			} );
+		renderWithProvider( <NotificationsPanel connection={ connection } /> );
+		const link = await screen.findByRole( 'link', { name: /jane mentioned you/i } );
+		expect( link ).toHaveAttribute( 'href', '/reader/mastodon/101/thread/200' );
+		expect( link ).not.toHaveAttribute( 'target' );
+	} );
+
+	it( 'falls back to target_url when the wire target.uri does not match the expected shape', async () => {
+		nock( BASE )
+			.get( '/wpcom/v2/reader/mastodon/connections/101/notifications' )
+			.query( {} )
+			.reply( 200, {
+				items: [
+					{
+						id: '13371341',
+						protocol_type: 'mention',
+						canonical_type: 'mention',
+						actor: {
+							handle: 'jane@mastodon.social',
+							display_name: 'Jane',
+							avatar_url: null,
+							profile_uri: 'https://mastodon.social/@jane',
+						},
+						// Malformed: status id is non-numeric. The resolver returns
+						// null and the row should render the external target_url.
+						target: {
+							kind: 'post',
+							uri: 'mastodon:mastodon.social:abc',
+							excerpt: '@me hi',
+						},
+						target_url: 'https://mastodon.social/@jane/abc',
+						created_at: '2026-05-11T15:30:00Z',
+						is_read: false,
+					},
+				],
+				next_cursor: null,
+				seen_at: null,
+			} );
+		renderWithProvider( <NotificationsPanel connection={ connection } /> );
+		const link = await screen.findByRole( 'link', { name: /jane mentioned you/i } );
+		expect( link ).toHaveAttribute( 'href', 'https://mastodon.social/@jane/abc' );
+		expect( link ).toHaveAttribute( 'target', '_blank' );
+	} );
+
 	it( 'renders an empty state when no notifications', async () => {
 		nock( BASE )
 			.get( '/wpcom/v2/reader/mastodon/connections/101/notifications' )

--- a/client/reader/social/components/notifications-list/index.tsx
+++ b/client/reader/social/components/notifications-list/index.tsx
@@ -6,7 +6,7 @@ import { useMemo } from 'react';
 import { bucketFor, type DateBucket } from './date-bucket';
 import { NotificationsFilterBar } from './filter-bar';
 import { groupNotifications, type GroupedRow } from './group-notifications';
-import { SocialNotificationItem } from './notification-item';
+import { SocialNotificationItem, type NotificationInAppUrlResolver } from './notification-item';
 import { StackedNotification } from './stacked-notification';
 import type { ChipFilter } from './filter';
 import type {
@@ -27,6 +27,7 @@ interface Props {
 	filter: ChipFilter;
 	onFilterChange: ( next: ChipFilter ) => void;
 	onStackExpandedChange?: ( expanded: boolean, memberCount: number ) => void;
+	getInAppUrl?: NotificationInAppUrlResolver;
 }
 
 function emptyMessage( filter: ChipFilter, translate: ReturnType< typeof useTranslate > ): string {
@@ -75,6 +76,7 @@ export function SocialNotificationsList( {
 	filter,
 	onFilterChange,
 	onStackExpandedChange,
+	getInAppUrl,
 }: Props ) {
 	const translate = useTranslate();
 
@@ -182,11 +184,16 @@ export function SocialNotificationsList( {
 								key={ entry.row.groupKey }
 								stack={ entry.row }
 								onExpandedChange={ onStackExpandedChange }
+								getInAppUrl={ getInAppUrl }
 							/>
 						);
 					}
 					return (
-						<SocialNotificationItem key={ entry.row.item.id } notification={ entry.row.item } />
+						<SocialNotificationItem
+							key={ entry.row.item.id }
+							notification={ entry.row.item }
+							getInAppUrl={ getInAppUrl }
+						/>
 					);
 				} ) }
 				{ showRetry && (

--- a/client/reader/social/components/notifications-list/notification-item.tsx
+++ b/client/reader/social/components/notifications-list/notification-item.tsx
@@ -1,5 +1,6 @@
 import './style.scss';
 
+import page from '@automattic/calypso-router';
 import { TimeSince } from '@automattic/components';
 import {
 	__experimentalHStack as HStack,
@@ -7,6 +8,7 @@ import {
 } from '@wordpress/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import { type MouseEvent } from 'react';
 import { SocialAvatar } from '../../avatar';
 import type {
 	AtmosphereNotification,
@@ -31,8 +33,18 @@ type SocialNotificationCanonicalType =
 	| MastodonNotificationCanonicalType
 	| FediverseNotificationCanonicalType;
 
+/**
+ * Resolves an in-app URL for a notification's target. Returns `null` to fall
+ * back to the external `target_url`. Per-protocol notifications panels supply
+ * the resolver so a mention / reply / quote opens its thread inside the Reader
+ * instead of bouncing the user to the upstream client (bsky.app, the home
+ * Mastodon instance, etc.).
+ */
+export type NotificationInAppUrlResolver = ( notification: SocialNotification ) => string | null;
+
 interface Props {
 	notification: SocialNotification;
+	getInAppUrl?: NotificationInAppUrlResolver;
 }
 
 function isSafeUrl( url: string ): boolean {
@@ -44,7 +56,7 @@ function isSafeUrl( url: string ): boolean {
 	}
 }
 
-export function SocialNotificationItem( { notification }: Props ) {
+export function SocialNotificationItem( { notification, getInAppUrl }: Props ) {
 	const translate = useTranslate();
 	const { actor, target, target_url, canonical_type, is_read, created_at } = notification;
 	const actorName = actor.display_name || actor.handle;
@@ -57,6 +69,7 @@ export function SocialNotificationItem( { notification }: Props ) {
 		? actionLabel
 		: ( translate( 'Unread. %(label)s', { args: { label: actionLabel } } ) as string );
 
+	const inAppUrl = getInAppUrl?.( notification ) ?? null;
 	const safe = isSafeUrl( target_url );
 	const className = clsx( 'social-notification-item', { 'is-unread': ! is_read } );
 
@@ -86,6 +99,30 @@ export function SocialNotificationItem( { notification }: Props ) {
 			{ ! is_read && <span className="social-notification-item__unread-dot" aria-hidden /> }
 		</HStack>
 	);
+
+	if ( inAppUrl ) {
+		const onClick = ( event: MouseEvent< HTMLAnchorElement > ) => {
+			// Defer to the browser for modifier-clicks (new tab / new window /
+			// download) so users can still pop a notification into a side tab.
+			if (
+				event.defaultPrevented ||
+				event.button !== 0 ||
+				event.metaKey ||
+				event.ctrlKey ||
+				event.shiftKey ||
+				event.altKey
+			) {
+				return;
+			}
+			event.preventDefault();
+			page( inAppUrl );
+		};
+		return (
+			<a className={ className } href={ inAppUrl } aria-label={ ariaLabel } onClick={ onClick }>
+				{ body }
+			</a>
+		);
+	}
 
 	if ( safe ) {
 		return (

--- a/client/reader/social/components/notifications-list/stacked-notification.tsx
+++ b/client/reader/social/components/notifications-list/stacked-notification.tsx
@@ -1,3 +1,4 @@
+import page from '@automattic/calypso-router';
 import { TimeSince } from '@automattic/components';
 import {
 	__experimentalHStack as HStack,
@@ -5,9 +6,9 @@ import {
 } from '@wordpress/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useId, useState } from 'react';
+import { type MouseEvent, useId, useState } from 'react';
 import { SocialAvatar } from '../../avatar';
-import { SocialNotificationItem } from './notification-item';
+import { SocialNotificationItem, type NotificationInAppUrlResolver } from './notification-item';
 import type { StackedRow, StackableCanonicalType } from './group-notifications';
 
 const MAX_AVATARS = 3;
@@ -16,6 +17,7 @@ const FOLLOW_TRUNCATE_AT = 50;
 interface Props {
 	stack: StackedRow;
 	onExpandedChange?: ( expanded: boolean, memberCount: number ) => void;
+	getInAppUrl?: NotificationInAppUrlResolver;
 }
 
 function isSafeUrl( url: string ): boolean {
@@ -151,12 +153,16 @@ function stackedPhrase(
 	}
 }
 
-export function StackedNotification( { stack, onExpandedChange }: Props ) {
+export function StackedNotification( { stack, onExpandedChange, getInAppUrl }: Props ) {
 	const translate = useTranslate();
 	const reactId = useId();
 	const [ expanded, setExpanded ] = useState( false );
 	const isFollowStack = stack.canonicalType === 'follow';
 	const safe = isSafeUrl( stack.targetUrl );
+	// Stacks share the same target (head member's target/target_url), so we
+	// resolve the in-app URL against the head — `keyFor` guarantees every
+	// member of a like/repost/mention/reply/quote stack shares `target.uri`.
+	const inAppUrl = ! isFollowStack ? getInAppUrl?.( stack.members[ 0 ] ) ?? null : null;
 
 	const firstActor = stack.members[ 0 ].actor.display_name || stack.members[ 0 ].actor.handle;
 	const secondActor = stack.members[ 1 ]
@@ -211,6 +217,27 @@ export function StackedNotification( { stack, onExpandedChange }: Props ) {
 	);
 
 	if ( ! isFollowStack ) {
+		if ( inAppUrl ) {
+			const onClick = ( event: MouseEvent< HTMLAnchorElement > ) => {
+				if (
+					event.defaultPrevented ||
+					event.button !== 0 ||
+					event.metaKey ||
+					event.ctrlKey ||
+					event.shiftKey ||
+					event.altKey
+				) {
+					return;
+				}
+				event.preventDefault();
+				page( inAppUrl );
+			};
+			return (
+				<a className={ className } href={ inAppUrl } onClick={ onClick }>
+					{ visualHeader }
+				</a>
+			);
+		}
 		if ( safe ) {
 			return (
 				<a
@@ -258,7 +285,7 @@ export function StackedNotification( { stack, onExpandedChange }: Props ) {
 			{ expanded && (
 				<div id={ childListId } className="social-notifications-stack__children" role="list">
 					{ visibleMembers.map( ( m ) => (
-						<SocialNotificationItem key={ m.id } notification={ m } />
+						<SocialNotificationItem key={ m.id } notification={ m } getInAppUrl={ getInAppUrl } />
 					) ) }
 				</div>
 			) }

--- a/client/reader/social/components/notifications-list/test/notification-item.test.tsx
+++ b/client/reader/social/components/notifications-list/test/notification-item.test.tsx
@@ -1,10 +1,15 @@
 /**
  * @jest-environment jsdom
  */
+import page from '@automattic/calypso-router';
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { SocialNotificationItem } from '../notification-item';
 import type { AtmosphereNotification } from '@automattic/api-core';
+
+jest.mock( '@automattic/calypso-router', () => jest.fn() );
+const pageMock = jest.mocked( page );
 
 function makeItem( overrides: Partial< AtmosphereNotification > = {} ): AtmosphereNotification {
 	return {
@@ -26,6 +31,10 @@ function makeItem( overrides: Partial< AtmosphereNotification > = {} ): Atmosphe
 }
 
 describe( 'SocialNotificationItem', () => {
+	beforeEach( () => {
+		pageMock.mockReset();
+	} );
+
 	it( 'renders a like notification with actor + excerpt', () => {
 		renderWithProvider( <SocialNotificationItem notification={ makeItem() } /> );
 		expect( screen.getByText( /jane/i ) ).toBeVisible();
@@ -124,6 +133,44 @@ describe( 'SocialNotificationItem', () => {
 	it( 'omits the unread prefix from the aria-label when is_read is true', () => {
 		renderWithProvider( <SocialNotificationItem notification={ makeItem( { is_read: true } ) } /> );
 		expect( screen.getByRole( 'link' ) ).toHaveAccessibleName( /^jane liked your post/i );
+	} );
+
+	it( 'links to the in-app URL with SPA navigation when getInAppUrl returns a path', async () => {
+		const user = userEvent.setup();
+		renderWithProvider(
+			<SocialNotificationItem
+				notification={ makeItem( { canonical_type: 'mention', protocol_type: 'mention' } ) }
+				getInAppUrl={ () => '/reader/atmosphere/42/thread/did:plc:abc/post1' }
+			/>
+		);
+		const link = screen.getByRole( 'link' );
+		expect( link ).toHaveAttribute( 'href', '/reader/atmosphere/42/thread/did:plc:abc/post1' );
+		expect( link ).not.toHaveAttribute( 'target' );
+		await user.click( link );
+		expect( pageMock ).toHaveBeenCalledWith( '/reader/atmosphere/42/thread/did:plc:abc/post1' );
+	} );
+
+	it( 'falls back to the external target_url when getInAppUrl returns null', () => {
+		renderWithProvider(
+			<SocialNotificationItem notification={ makeItem() } getInAppUrl={ () => null } />
+		);
+		const link = screen.getByRole( 'link' );
+		expect( link ).toHaveAttribute( 'href', 'https://bsky.app/profile/me/post/3k' );
+		expect( link ).toHaveAttribute( 'target', '_blank' );
+	} );
+
+	it( 'defers to the browser on modifier-click so users can open in a new tab', async () => {
+		const user = userEvent.setup();
+		renderWithProvider(
+			<SocialNotificationItem
+				notification={ makeItem() }
+				getInAppUrl={ () => '/reader/atmosphere/42/thread/did:plc:abc/post1' }
+			/>
+		);
+		await user.keyboard( '[ControlLeft>]' );
+		await user.click( screen.getByRole( 'link' ) );
+		await user.keyboard( '[/ControlLeft]' );
+		expect( pageMock ).not.toHaveBeenCalled();
 	} );
 
 	it( 'falls back to the actor handle when display_name is null', () => {

--- a/client/reader/social/components/notifications-list/test/stacked-notification.test.tsx
+++ b/client/reader/social/components/notifications-list/test/stacked-notification.test.tsx
@@ -1,12 +1,16 @@
 /**
  * @jest-environment jsdom
  */
+import page from '@automattic/calypso-router';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { StackedNotification } from '../stacked-notification';
 import type { StackedRow } from '../group-notifications';
 import type { AtmosphereNotification } from '@automattic/api-core';
+
+jest.mock( '@automattic/calypso-router', () => jest.fn() );
+const pageMock = jest.mocked( page );
 
 function makeMember(
 	id: string,
@@ -69,6 +73,10 @@ function makeFollowStack( count: number ): StackedRow {
 }
 
 describe( 'StackedNotification', () => {
+	beforeEach( () => {
+		pageMock.mockReset();
+	} );
+
 	it( 'renders a like stack of 2 with both names and no "others"', () => {
 		renderWithProvider( <StackedNotification stack={ makeLikeStack( 2 ) } /> );
 		expect( screen.getByText( /M0 and M1 liked your post/i ) ).toBeVisible();
@@ -99,6 +107,35 @@ describe( 'StackedNotification', () => {
 		expect( link ).toHaveAttribute( 'href', 'https://bsky.app/profile/me/post/p1' );
 		expect( link ).toHaveAttribute( 'target', '_blank' );
 		expect( link ).toHaveAttribute( 'rel', expect.stringContaining( 'noopener' ) );
+	} );
+
+	it( 'routes a non-follow stack in-app when getInAppUrl returns a path', async () => {
+		const user = userEvent.setup();
+		renderWithProvider(
+			<StackedNotification
+				stack={ makeLikeStack( 3 ) }
+				getInAppUrl={ () => '/reader/atmosphere/42/thread/did:plc:abc/post1' }
+			/>
+		);
+		const link = screen.getByRole( 'link', { name: /liked your post/i } );
+		expect( link ).toHaveAttribute( 'href', '/reader/atmosphere/42/thread/did:plc:abc/post1' );
+		expect( link ).not.toHaveAttribute( 'target' );
+		await user.click( link );
+		expect( pageMock ).toHaveBeenCalledWith( '/reader/atmosphere/42/thread/did:plc:abc/post1' );
+	} );
+
+	it( 'defers to the browser on modifier-click of a stacked in-app link', async () => {
+		const user = userEvent.setup();
+		renderWithProvider(
+			<StackedNotification
+				stack={ makeLikeStack( 3 ) }
+				getInAppUrl={ () => '/reader/atmosphere/42/thread/did:plc:abc/post1' }
+			/>
+		);
+		await user.keyboard( '[ControlLeft>]' );
+		await user.click( screen.getByRole( 'link', { name: /liked your post/i } ) );
+		await user.keyboard( '[/ControlLeft]' );
+		expect( pageMock ).not.toHaveBeenCalled();
 	} );
 
 	it( 'a follow stack is a button (not a link) with aria-expanded=false initially', () => {

--- a/client/reader/social/index.ts
+++ b/client/reader/social/index.ts
@@ -22,6 +22,7 @@ export { SocialPostCard } from './components/post-card';
 export type { PostCardReactionsConfig } from './components/post-card/post-card-counts';
 export { SocialFeedList } from './components/feed-list';
 export { SocialNotificationItem } from './components/notifications-list/notification-item';
+export type { NotificationInAppUrlResolver } from './components/notifications-list/notification-item';
 export { SocialNotificationsList } from './components/notifications-list';
 export type { ChipFilter } from './components/notifications-list/filter';
 export { SocialNotificationsPanel } from './social-notifications-panel';

--- a/client/reader/social/social-notifications-panel.tsx
+++ b/client/reader/social/social-notifications-panel.tsx
@@ -3,7 +3,10 @@ import { useDispatch } from 'react-redux';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import { SocialNotificationsList } from './components/notifications-list';
 import type { ChipFilter } from './components/notifications-list/filter';
-import type { SocialNotification } from './components/notifications-list/notification-item';
+import type {
+	NotificationInAppUrlResolver,
+	SocialNotification,
+} from './components/notifications-list/notification-item';
 import type { InfiniteData, UseInfiniteQueryResult } from '@tanstack/react-query';
 import type { AppState } from 'calypso/types';
 import type { UnknownAction } from 'redux';
@@ -26,6 +29,15 @@ interface Props< TItem extends SocialNotification > {
 	connectionId: number;
 	source: SocialNotificationsSource;
 	useNotificationsInfiniteQuery: UseSocialNotificationsInfiniteQuery< TItem >;
+	/**
+	 * Resolver mapping a notification to an in-app URL (typically the Reader's
+	 * own thread view for that protocol). When the resolver returns `null`,
+	 * the row falls back to the external `target_url`. Per-protocol panels
+	 * supply this so mentions / replies / quotes open inside the Reader
+	 * instead of bouncing the user to bsky.app or their home Mastodon
+	 * instance.
+	 */
+	getInAppUrl?: NotificationInAppUrlResolver;
 }
 
 /**
@@ -41,6 +53,7 @@ export function SocialNotificationsPanel< TItem extends SocialNotification >( {
 	connectionId,
 	source,
 	useNotificationsInfiniteQuery,
+	getInAppUrl,
 }: Props< TItem > ) {
 	const [ filter, setFilter ] = useState< ChipFilter >( 'all' );
 	const dispatch = useDispatch< ThunkDispatch< AppState, void, UnknownAction > >();
@@ -72,6 +85,7 @@ export function SocialNotificationsPanel< TItem extends SocialNotification >( {
 					} )
 				);
 			} }
+			getInAppUrl={ getInAppUrl }
 			onStackExpandedChange={ ( expanded, member_count ) => {
 				dispatch(
 					recordReaderTracksEvent(


### PR DESCRIPTION
Fixes CM-791

## Proposed Changes

* Thread an optional `getInAppUrl(notification): string | null` resolver from per-protocol notifications panels through `SocialNotificationsPanel` → `SocialNotificationsList` → `SocialNotificationItem` / `StackedNotification`.
* When the resolver returns a path, the row renders as a same-tab `<a href={path}>` and the click is intercepted to SPA-navigate via `page()`. Modifier-clicks (cmd/ctrl/middle/shift/alt) still defer to the browser so opening in a new tab keeps working.
* When the resolver returns `null` — follow rows, profile targets, malformed URIs — the row falls back to the existing external `target_url` link with `target="_blank" rel="noopener noreferrer"`.
* Atmosphere panel passes `notification.target.uri` (at://...) through the existing `getThreadUrl(connectionId, postUri)` route builder.
* Mastodon panel parses the backend's `mastodon:<instance>:<status_id>` wire format and passes the home-instance status id through Mastodon's `getThreadUrl`.

## Why are these changes being made?

Clicking a mention / reply / quote / like / repost in the Reader's Atmosphere or Mastodon notifications tab currently bounces the user out to bsky.app or their home Mastodon instance because each row's anchor was hard-wired to the external `target_url`. The Reader already has its own in-app thread view at `/reader/<protocol>/:id/thread/...` — that's where the click should land.

Fediverse is left unchanged for now — its notifications panel continues to use the external fallback. The plumbing is in place if/when we want to wire its resolver later.

## Testing Instructions

1. Connect at least one Atmosphere account (and ideally one Mastodon account) to the Reader.
2. Visit `/reader/atmosphere/<id>/notifications` (and the Mastodon equivalent).
3. Click a mention / reply / quote / like / repost row — it should open the matching post inside the social Reader at `/reader/<protocol>/<id>/thread/...`, not redirect to bsky.app or your home Mastodon instance.
4. Cmd/Ctrl-click (or middle-click) the same row — it should still open in a new tab.
5. Click a follow notification — it should keep falling back to the external `target_url` (no in-app profile route yet for follows).
6. Expand a follow stack — clicking individual member rows should also keep falling back to the external profile URL.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?