### PR TITLE
Reader Social: keep composer modal above the mobile keyboard

### DIFF
--- a/client/reader/social/composer/composer-modal.tsx
+++ b/client/reader/social/composer/composer-modal.tsx
@@ -76,6 +76,35 @@ export function ComposerModal< TError, TParams, TResult >() {
 		dispatch( recordReaderTracksEvent( event, props ) );
 	}, [ mode, dispatch, config.tracks ] );
 
+	// Mobile keyboard handling. The WordPress Modal overlay is anchored to the
+	// layout viewport, but browsers shrink the *visual* viewport when the
+	// on-screen keyboard appears — so the bottom of the bottom-sheet (Post
+	// button + media controls) ends up hidden behind the keyboard. Mirror
+	// `window.visualViewport.height` into a CSS variable that the overlay
+	// reads on narrow widths. See style.scss.
+	const isOpen = mode != null;
+	useEffect( () => {
+		if ( ! isOpen ) {
+			return;
+		}
+		const vv = window.visualViewport;
+		if ( ! vv ) {
+			return;
+		}
+		const root = document.documentElement;
+		const update = () => {
+			root.style.setProperty( '--composer-modal-viewport-height', `${ vv.height }px` );
+		};
+		update();
+		vv.addEventListener( 'resize', update );
+		vv.addEventListener( 'scroll', update );
+		return () => {
+			vv.removeEventListener( 'resize', update );
+			vv.removeEventListener( 'scroll', update );
+			root.style.removeProperty( '--composer-modal-viewport-height' );
+		};
+	}, [ isOpen ] );
+
 	// Merge mutation errors with pre-mutation `extendBuildParams` rejections so
 	// both paths render through `config.errorMessage` and fire `errorShown`.
 	// `extendError` takes precedence on the (rare) chance both are non-null

--- a/client/reader/social/composer/style.scss
+++ b/client/reader/social/composer/style.scss
@@ -1,4 +1,24 @@
+@use "@wordpress/base-styles/breakpoints" as bp;
 @use "calypso/assets/stylesheets/shared/mixins/dark-theme" as ui-mixins;
+
+// Below `$break-small` the WordPress Modal renders as a bottom sheet —
+// the overlay covers the layout viewport (`top: 0; bottom: 0`) and the
+// modal frame is `align-self: flex-end`. When the on-screen keyboard
+// opens, mobile browsers shrink the *visual* viewport but leave the
+// *layout* viewport unchanged, so the bottom of the overlay (and the
+// sheet's footer + Post button) ends up behind the keyboard.
+//
+// `composer-modal.tsx` writes `window.visualViewport.height` into
+// `--composer-modal-viewport-height` while the modal is open. Releasing
+// `bottom` and setting `height` to that variable lets the overlay shrink
+// with the keyboard. `:has(.social-composer)` scopes the override to
+// this modal instead of monkey-patching every WordPress Modal in Calypso.
+@media (max-width: bp.$break-small) {
+	.components-modal__screen-overlay:has(.social-composer) {
+		bottom: auto;
+		height: var(--composer-modal-viewport-height, 100dvh);
+	}
+}
 
 .social-compose-pill {
 	display: flex;


### PR DESCRIPTION
Fixes CM-792

## Proposed Changes

* Mirror `window.visualViewport.height` into `--composer-modal-viewport-height` while the composer modal is open.
* Below `$break-small`, override the WordPress `<Modal>` overlay (`.components-modal__screen-overlay:has(.social-composer)`) to release `bottom` and set `height` to the CSS variable so it shrinks with the keyboard.

## Why are these changes being made?

The WordPress `<Modal>` overlay uses `position: fixed; top: 0; bottom: 0` and the modal frame is `align-self: flex-end` on mobile (bottom-sheet pattern). Mobile browsers shrink only the *visual* viewport when the on-screen keyboard appears — the *layout* viewport stays put — so the bottom of the overlay (textarea controls + Post button) ends up hidden behind the keyboard.

`:has(.social-composer)` scopes the override to this modal instead of monkey-patching every WordPress Modal in Calypso.

## Testing Instructions

1. Open a Social Reader timeline (e.g. an ATmosphere or Mastodon connection).
2. Open the composer modal via the **Compose** FAB or a **Reply** button.
3. Focus the textarea so the on-screen keyboard opens (Chrome DevTools "Toggle device toolbar" + iOS/Android profile, or a real device).
4. Verify the modal frame slides up so the textarea, character counter, and **Post** button stay visible above the keyboard.
5. Close and reopen — focus / submit behaviour should be unchanged on desktop.

Verified locally with Chrome DevTools mobile emulation (390x844, simulated visual viewport shrunk to 400px): the overlay shrinks to match and the modal frame's bottom anchors to the visible viewport instead of being hidden 444px below it.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?