### PR TITLE
A4A: standardize header CTA buttons on @wordpress/components

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/index.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/index.tsx
@@ -1,5 +1,6 @@
 import page from '@automattic/calypso-router';
 import { Popover, Gridicon, Button, WordPressLogo, JetpackLogo } from '@automattic/components';
+import { Button as WPButton } from '@wordpress/components';
 import { Icon } from '@wordpress/icons';
 import clsx from 'clsx';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
@@ -255,7 +256,7 @@ export default function AddNewSiteButton( {
 
 	return (
 		<>
-			<Button
+			<WPButton
 				className="site-selector-and-importer__button"
 				ref={ popoverMenuContext }
 				onClick={ toggleMenu }
@@ -267,8 +268,9 @@ export default function AddNewSiteButton( {
 						{ mobile: ! showMainButtonLabel }
 					) }
 					icon={ showMainButtonLabel ? 'chevron-down' : 'plus' }
+					size={ 18 }
 				/>
-			</Button>
+			</WPButton>
 			<Popover
 				className="site-selector-and-importer__popover dev-sites-enabled"
 				context={ popoverMenuContext?.current }

--- a/client/a8c-for-agencies/sections/marketplace/assign-license/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/assign-license/index.tsx
@@ -255,18 +255,12 @@ export default function AssignLicense( { initialPage, initialSearch }: Props ) {
 
 					<Actions>
 						<div className="assign-license__controls">
-							<Button
-								variant="tertiary"
-								onClick={ onClickAssignLater }
-								disabled={ isPending }
-								className="assign-license-form__assign-later"
-							>
+							<Button variant="tertiary" onClick={ onClickAssignLater } disabled={ isPending }>
 								{ translate( 'Assign later' ) }
 							</Button>
 
 							<Button
 								variant="primary"
-								className="assign-license__assign-now"
 								disabled={ selectedSite?.ID === 0 }
 								isBusy={ isPending }
 								onClick={ onClickAssignLicenses }

--- a/client/a8c-for-agencies/sections/marketplace/assign-license/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/assign-license/index.tsx
@@ -1,5 +1,6 @@
 import page from '@automattic/calypso-router';
-import { Button, Card } from '@automattic/components';
+import { Card } from '@automattic/components';
+import { Button } from '@wordpress/components';
 import { getQueryArg } from '@wordpress/url';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -255,7 +256,7 @@ export default function AssignLicense( { initialPage, initialSearch }: Props ) {
 					<Actions>
 						<div className="assign-license__controls">
 							<Button
-								borderless
+								variant="tertiary"
 								onClick={ onClickAssignLater }
 								disabled={ isPending }
 								className="assign-license-form__assign-later"
@@ -264,10 +265,10 @@ export default function AssignLicense( { initialPage, initialSearch }: Props ) {
 							</Button>
 
 							<Button
-								primary
+								variant="primary"
 								className="assign-license__assign-now"
 								disabled={ selectedSite?.ID === 0 }
-								busy={ isPending }
+								isBusy={ isPending }
 								onClick={ onClickAssignLicenses }
 							>
 								{ translate( 'Assign %(numLicenses)d License', 'Assign %(numLicenses)d Licenses', {

--- a/client/a8c-for-agencies/sections/marketplace/assign-license/styles.scss
+++ b/client/a8c-for-agencies/sections/marketplace/assign-license/styles.scss
@@ -10,14 +10,6 @@
 	display: flex;
 	gap: 16px;
 	align-items: center;
-
-	.assign-license-form__assign-later.button {
-		margin-inline-end: 0;
-		font-weight: 700;
-		text-decoration: underline;
-		white-space: nowrap;
-	}
-
 }
 
 .assign-license__search-field {

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/migrate-site-button.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/migrate-site-button.tsx
@@ -106,7 +106,11 @@ const MigrateSiteButton = () => {
 				onClick={ toggleMenu }
 			>
 				{ translate( 'Migrate your sites' ) }
-				<Gridicon className={ clsx( { reverse: isMenuVisible } ) } icon="chevron-down" />
+				<Gridicon
+					className={ clsx( { reverse: isMenuVisible } ) }
+					icon="chevron-down"
+					size={ 18 }
+				/>
 			</Button>
 			<Popover
 				noArrow={ false }

--- a/client/a8c-for-agencies/sections/overview/header-actions/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/header-actions/index.tsx
@@ -1,6 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { Button } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
@@ -47,7 +47,7 @@ export default function OverviewHeaderActions() {
 			) }
 			{ ! isNarrowView && (
 				<Button
-					primary
+					variant="primary"
 					href={ A4A_MARKETPLACE_PRODUCTS_LINK }
 					onClick={ () => {
 						dispatch( recordTracksEvent( 'calypso_a4a_overview_add_products_click' ) );

--- a/client/a8c-for-agencies/sections/overview/header-actions/style.scss
+++ b/client/a8c-for-agencies/sections/overview/header-actions/style.scss
@@ -3,11 +3,6 @@
 	align-items: center;
 	gap: 8px;
 
-	.button {
-		border-radius: 4px;
-		border: 1px solid var(--color-neutral-10);
-	}
-
 	.button.split-button__main {
 		border-radius: 4px 0 0 4px;
 		border-right: none;

--- a/client/a8c-for-agencies/sections/purchases/billing/billing-dashboard.tsx
+++ b/client/a8c-for-agencies/sections/purchases/billing/billing-dashboard.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@automattic/components';
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
@@ -35,7 +35,11 @@ export default function BillingDashboard() {
 					<Title>{ title } </Title>
 					<Actions className="a4a-billing__header-actions">
 						<MobileSidebarNavigation />
-						<Button href={ A4A_MARKETPLACE_LINK } onClick={ onIssueNewLicenseClick } primary>
+						<Button
+							href={ A4A_MARKETPLACE_LINK }
+							onClick={ onIssueNewLicenseClick }
+							variant="primary"
+						>
 							{ translate( 'Issue new license' ) }
 						</Button>
 					</Actions>

--- a/client/a8c-for-agencies/sections/purchases/billing/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/billing/style.scss
@@ -11,8 +11,4 @@
 			margin-block-end: 1rem;
 		}
 	}
-
-	.button {
-		font-weight: 500;
-	}
 }

--- a/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/index.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@automattic/components';
+import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
@@ -73,7 +73,11 @@ export default function LicensesOverview( {
 						<Title>{ title } </Title>
 						<Actions className="a4a-licenses__header-actions">
 							<MobileSidebarNavigation />
-							<Button href={ A4A_MARKETPLACE_LINK } onClick={ onIssueNewLicenseClick } primary>
+							<Button
+								href={ A4A_MARKETPLACE_LINK }
+								onClick={ onIssueNewLicenseClick }
+								variant="primary"
+							>
 								{ translate( 'Issue new license' ) }
 							</Button>
 						</Actions>

--- a/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/style.scss
@@ -24,10 +24,6 @@
 			width: 100%;
 		}
 	}
-
-	.button {
-		font-weight: 500;
-	}
 }
 
 .hosting-dashboard-layout__navigation-wrapper {

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/index.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@automattic/components';
+import { Button } from '@wordpress/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useState } from 'react';
@@ -134,7 +134,7 @@ export default function PaymentMethodOverview() {
 						<MobileSidebarNavigation />
 
 						{ hasStoredCards && (
-							<Button href={ addCardURL } onClick={ onAddNewCardClick } primary>
+							<Button href={ addCardURL } onClick={ onAddNewCardClick } variant="primary">
 								{ translate( 'Add new card' ) }
 							</Button>
 						) }

--- a/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
@@ -1,6 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { Button } from '@automattic/components';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
+import { Button } from '@wordpress/components';
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
@@ -63,7 +63,7 @@ export default function SitesHeaderActions( { onWPCOMImport }: Props ) {
 			</div>
 			<GuidedTourStep id="add-new-site" tourId="addSiteStep1" context={ tourStepRef } />
 			<Button
-				primary
+				variant="primary"
 				href={ A4A_MARKETPLACE_PRODUCTS_LINK }
 				onClick={ () => {
 					dispatch( recordTracksEvent( 'calypso_a4a_sites_add_products_click' ) );

--- a/client/a8c-for-agencies/sections/sites/sites-header-actions/style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-header-actions/style.scss
@@ -6,12 +6,6 @@
 	align-items: center;
 	gap: 8px;
 
-	.button {
-		border-radius: 4px;
-		border: 1px solid var(--color-neutral-10);
-		@include body-medium;
-	}
-
 	.button.split-button__main {
 		border-radius: 4px 0 0 4px;
 		border-right: none;


### PR DESCRIPTION
Part of A4A-2632
<!-- Link the related A4A Linear issue. -->

## Proposed Changes

Standardize the A4A portal's header CTAs on `Button` from `@wordpress/components`. Roughly half the page headers were already on the WP Button, the other half were on `@automattic/components` Button — which meant sibling pages rendered their primary CTA through different Button primitives with slightly different padding, font-size, border-radius, and hover styling. After this PR every header CTA renders through the same primitive.

* **`components/add-new-site-button/index.tsx`** — switch the main "Add sites" dropdown trigger to `@wordpress/components` Button, imported as `WPButton` because the popover menu items inside the dropdown still use the legacy `@automattic/components` Button; updating those is out of scope for this PR. Also pass `size={ 18 }` to the chevron `Gridicon` — the `@automattic` Button clamped `.gridicon` to 18px via `packages/components/src/button/style.scss:36-46`; the WP Button doesn't, so without this the chevron would render at the Gridicon default of 24px.
* **`sections/migrations/primary/migrations-overview-v2/migrate-site-button.tsx`** — pass `size={ 18 }` to the chevron `Gridicon` for the same reason (this button was already on `@wordpress/components`, so its chevron was rendering at 24px while the `Add sites` chevron was 18px).
* **`sections/overview/header-actions/index.tsx`** — swap "Add products" Button source; `primary` → `variant="primary"`.
* **`sections/sites/sites-header-actions/index.tsx`** — same swap for "Add products".
* **`sections/purchases/licenses/licenses-overview/index.tsx`** — same swap for "Issue new license".
* **`sections/purchases/payment-methods/payment-method-overview/index.tsx`** — same swap for "Add new card".
* **`sections/purchases/billing/billing-dashboard.tsx`** — same swap for "Issue new license".
* **`sections/marketplace/assign-license/index.tsx`** — swap both CTAs: "Assign later" (`borderless` → `variant="tertiary"`) and "Assign N License(s)" (`primary` → `variant="primary"`, `busy` → `isBusy`). The `Card` import stays on `@automattic/components`.

Also drops the now-dead `.button` overrides in the corresponding SCSS files (`assign-license/styles.scss`, `purchases/billing/style.scss`, `purchases/licenses/licenses-overview/style.scss`, `overview/header-actions/style.scss`, `sites/sites-header-actions/style.scss`) — those selectors no longer match because `@wordpress/components` Button renders `.components-button`.

## Why are these changes being made?

To standardize the portal's header CTAs on a single Button primitive, per the project's component recommendations.

This standardization has one piece of visible collateral damage: the **Assign later** button on the assign-license header was previously rendered with a bold + underlined link-style override, and now renders as a default `variant="tertiary"` WP Button. Given that the change removes a bespoke per-button override and brings that CTA in line with every other secondary action in the portal, the trade-off feels justified and worth it.

| Before | After |
|--------|--------|
| <img width="255" height="61" alt="Screenshot 2026-05-26 at 16 01 08" src="https://github.com/user-attachments/assets/44c18090-a12c-4184-b6f2-9ef01d5ccfea" /> | <img width="253" height="55" alt="Screenshot 2026-05-26 at 16 00 02" src="https://github.com/user-attachments/assets/e843cbb0-ce46-4c33-b390-11fa94d9028b" /> |


## Testing Instructions

1. Open the live link.
2. Click through each surface and confirm the header CTA renders and triggers its existing flow (navigation, popover, mutation):
   * **A4A → Overview** — `Add sites` dropdown + `Add products`.
   * **A4A → Sites** — same two buttons.
   * **A4A → Sites → Needs setup** — same two buttons.
   * **A4A → Migrations** — `Migrate your sites` dropdown.
   * **A4A → Purchases → Licenses** — `Issue new license`.
   * **A4A → Purchases → Payment methods** — `Add new card` (visible only when there are stored cards).
   * **A4A → Purchases → Billing** — `Issue new license`.
   * **A4A → Marketplace → Assign license** (open a license assignment flow) — `Assign later` + `Assign N License(s)`. The "Assign" button should still show its busy spinner while assigning.
3. Open the `Add sites` and `Migrate your sites` dropdowns and confirm the chevron sizes match.
4. Verify there are no TypeScript / React console errors.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
