### PR TITLE
App Banner: hide on the social reader surfaces

### DIFF
--- a/client/state/selectors/should-display-app-banner.ts
+++ b/client/state/selectors/should-display-app-banner.ts
@@ -11,11 +11,14 @@ import {
 import { isE2ETest } from 'calypso/lib/e2e';
 import { isWpMobileApp, isWcMobileApp } from 'calypso/lib/mobile-app';
 import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
 import { shouldDisplayTosUpdateBanner } from 'calypso/state/selectors/should-display-tos-update-banner';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import { getSectionName, appBannerIsEnabled, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { AppState } from 'calypso/types';
+
+const SOCIAL_READER_PATH_REGEX = /^\/reader\/(atmosphere|mastodon|fediverse|connections)(\/|$)/;
 
 /**
  * Returns true if the App Banner should be displayed
@@ -40,6 +43,13 @@ export const shouldDisplayAppBanner = ( state: AppState ): boolean | undefined =
 	}
 
 	if ( ! hasReceivedRemotePreferences( state ) ) {
+		return false;
+	}
+
+	// Hide the banner on the social reader (atmosphere/mastodon/fediverse/connections):
+	// these surfaces aren't available in the Jetpack mobile app, so promoting it here is misleading.
+	const currentRoute = getCurrentRoute( state );
+	if ( currentRoute && SOCIAL_READER_PATH_REGEX.test( currentRoute ) ) {
 		return false;
 	}
 
@@ -69,6 +79,7 @@ export default createSelector( shouldDisplayAppBanner, [
 	appBannerIsEnabled,
 	getSelectedSiteId,
 	hasReceivedRemotePreferences,
+	getCurrentRoute,
 	getSectionName,
 	isNotificationsOpen,
 	( state: AppState ) => getPreference( state, APP_BANNER_DISMISS_TIMES_PREFERENCE ),

--- a/client/state/selectors/test/should-display-app-banner.js
+++ b/client/state/selectors/test/should-display-app-banner.js
@@ -214,6 +214,71 @@ describe( 'shouldDisplayAppBanner()', () => {
 		expect( output ).toBe( false );
 	} );
 
+	describe.each( [
+		'/reader/atmosphere',
+		'/reader/atmosphere/',
+		'/reader/atmosphere/connect',
+		'/reader/mastodon/123',
+		'/reader/fediverse/456/profile/someone',
+		'/reader/connections',
+		'/reader/connections/',
+	] )( 'when current route is the social reader (%s)', ( path ) => {
+		test( 'should return false even if the section is allowed', () => {
+			const state = {
+				ui: {
+					appBannerVisibility: true,
+					layoutFocus: {
+						current: 'not-sidebar',
+					},
+					section: {
+						name: 'reader',
+					},
+				},
+				preferences: {
+					remoteValues: [ 'something' ],
+				},
+				route: {
+					path: {
+						current: path,
+					},
+				},
+			};
+			const output = shouldDisplayAppBanner( state );
+			expect( output ).toBe( false );
+		} );
+	} );
+
+	describe.each( [
+		'/reader/atmospheres',
+		'/reader/connectionsfoo',
+		'/reader/discover',
+		'/reader',
+	] )( 'when current route looks similar but is not the social reader (%s)', ( path ) => {
+		test( 'should not be short-circuited by the social reader guard', () => {
+			const state = {
+				ui: {
+					appBannerVisibility: true,
+					layoutFocus: {
+						current: 'not-sidebar',
+					},
+					section: {
+						name: 'reader',
+					},
+				},
+				preferences: {
+					remoteValues: [ 'something' ],
+				},
+				route: {
+					path: {
+						current: path,
+					},
+				},
+			};
+			const output = shouldDisplayAppBanner( state );
+			expect( output ).toBe( true );
+		} );
+	} );
+
 	describe( 'when current section is HOME', () => {
 		test( 'should return false if launchpad_screen is "full"', () => {
 			const state = {


### PR DESCRIPTION
Fixes CM-793

## Proposed Changes

* Short-circuit `shouldDisplayAppBanner` in `client/state/selectors/should-display-app-banner.ts` when the current route matches one of the social reader path prefixes: `/reader/atmosphere`, `/reader/mastodon`, `/reader/fediverse`, `/reader/connections`.
* Add unit tests covering the four prefixes (including trailing-slash and nested-path forms) plus look-alike paths (`/reader/atmospheres`, `/reader/connectionsfoo`, `/reader/discover`, `/reader`) that must still flow through the rest of the selector.

## Why are these changes being made?

The "install the Jetpack app" banner currently renders on the social reader surfaces. None of those surfaces are available in the Jetpack mobile app today, so promoting it from these views is misleading — clicking through doesn't take the user to an equivalent experience.

## Testing Instructions

* Open Calypso on a mobile viewport (or DevTools mobile emulation) with a logged-in user whose `appBannerDismissTimes` preference for the Reader is unset / past.
* Visit `/reader` — the AppBanner should still appear (subject to the existing dismiss / launchpad rules).
* Visit `/reader/atmosphere`, `/reader/mastodon`, `/reader/fediverse`, and `/reader/connections` — the banner should not render on any of them.
* Run the selector tests: `yarn test-client client/state/selectors/test/should-display-app-banner.js`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?