### PR TITLE
Email no-domain: replace free-plan upsell with richer benefits + provider picker

### DIFF
--- a/client/my-sites/email/email-management/home/email-no-domain-upsell.scss
+++ b/client/my-sites/email/email-management/home/email-no-domain-upsell.scss
@@ -1,0 +1,127 @@
+@import "@automattic/typography/styles/variables";
+@import "@wordpress/base-styles/breakpoints";
+
+.email-no-domain-upsell {
+	.email-no-domain-upsell__hero {
+		text-align: center;
+		margin-block-start: 48px;
+		margin-block-end: 48px;
+	}
+
+	.email-no-domain-upsell__hero-title {
+		@extend .wp-brand-font;
+		font-size: $font-title-large;
+		line-height: 1.2;
+		margin: 0 0 12px;
+		color: var(--color-text);
+	}
+
+	.email-no-domain-upsell__hero-subtitle {
+		max-inline-size: 640px;
+		margin: 0 auto 40px;
+		font-size: $font-body;
+		line-height: 1.5;
+		color: var(--color-text-subtle);
+	}
+
+	.email-no-domain-upsell__benefits {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+		gap: 24px;
+		list-style: none;
+		margin: 0 auto;
+		padding: 0;
+		max-inline-size: 1080px;
+		text-align: start;
+	}
+
+	.email-no-domain-upsell__benefit {
+		padding: 20px;
+		border: 1px solid var(--color-border-subtle);
+		border-radius: 4px;
+		background: var(--color-surface);
+	}
+
+	.email-no-domain-upsell__benefit-icon {
+		color: var(--color-accent);
+		margin-block-end: 8px;
+	}
+
+	.email-no-domain-upsell__benefit-title {
+		font-size: $font-body;
+		font-weight: 600;
+		margin: 0 0 4px;
+		color: var(--color-text);
+	}
+
+	.email-no-domain-upsell__benefit-description {
+		font-size: $font-body-small;
+		line-height: 1.4;
+		margin: 0;
+		color: var(--color-text-subtle);
+	}
+
+	.email-no-domain-upsell__providers {
+		padding-block-start: 80px;
+	}
+
+	.email-no-domain-upsell__providers-heading {
+		@extend .wp-brand-font;
+		font-size: $font-title-medium;
+		margin: 0 0 8px;
+		text-align: center;
+		color: var(--color-text);
+	}
+
+	.email-no-domain-upsell__providers-subheading {
+		text-align: center;
+		margin: 0 auto 32px;
+		max-inline-size: 640px;
+		font-size: $font-body-small;
+		color: var(--color-text-subtle);
+	}
+
+	.email-no-domain-upsell__google-logos {
+		margin-inline-start: 0;
+		margin-block-end: 24px;
+	}
+
+	.email-provider-stacked-card__provider-form-and-right-panel {
+		align-items: flex-start;
+	}
+
+	.email-provider-stacked-card__provider-right-panel {
+		align-self: flex-start;
+	}
+
+	@include break-xlarge {
+		.email-providers-stacked-comparison__provider-card {
+			.action-panel__body {
+				display: grid;
+				grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+				grid-template-rows: auto auto;
+				column-gap: 30px;
+			}
+
+			.email-provider-stacked-card__header {
+				grid-column: 1 / 2;
+				grid-row: 1;
+			}
+
+			.email-provider-stacked-card__provider-form-and-right-panel {
+				display: contents;
+			}
+
+			.email-provider-stacked-card__provider-form {
+				grid-column: 1 / 2;
+				grid-row: 2;
+			}
+
+			.email-provider-stacked-card__provider-right-panel {
+				grid-column: 2 / 3;
+				grid-row: 1 / 3;
+				margin-inline-start: 0;
+			}
+		}
+	}
+}

--- a/client/my-sites/email/email-management/home/email-no-domain-upsell.tsx
+++ b/client/my-sites/email/email-management/home/email-no-domain-upsell.tsx
@@ -1,0 +1,198 @@
+import { Button, Gridicon } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import googleWorkspaceIcon from 'calypso/assets/images/email-providers/google-workspace/icon.svg';
+import poweredByTitanLogo from 'calypso/assets/images/email-providers/titan/powered-by-titan-caps.svg';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
+import { getTitanProductName } from 'calypso/lib/titan';
+import { recordEmailUpsellTracksEvent } from 'calypso/my-sites/email/email-management/home/utils';
+import { getGoogleAppLogos } from 'calypso/my-sites/email/email-provider-features/list';
+import EmailProvidersStackedCard from 'calypso/my-sites/email/email-providers-comparison/stacked/email-provider-stacked-card';
+import type { SiteDetails } from '@automattic/data-stores';
+import type { TranslateResult } from 'i18n-calypso';
+
+import './email-no-domain-upsell.scss';
+
+type EmailNoDomainUpsellProps = {
+	selectedSite: SiteDetails;
+	source: string;
+};
+
+type Benefit = {
+	key: string;
+	icon: string;
+	title: TranslateResult;
+	description: TranslateResult;
+};
+
+const EmailNoDomainUpsell = ( { selectedSite, source }: EmailNoDomainUpsellProps ) => {
+	const translate = useTranslate();
+
+	const upgradeUrl = `/plans/${ selectedSite.slug }`;
+
+	const handleUpgradeClick = () => {
+		recordEmailUpsellTracksEvent( source || 'email', 'plan' );
+	};
+
+	const upgradeButton = (
+		<Button primary href={ upgradeUrl } onClick={ handleUpgradeClick }>
+			{ translate( 'Upgrade to add email' ) }
+		</Button>
+	);
+
+	const googleAppLogos = getGoogleAppLogos();
+	const googleFormFields = (
+		<>
+			<div className="email-provider-stacked-features__logos email-no-domain-upsell__google-logos">
+				{ googleAppLogos.map(
+					(
+						{ image, imageAltText, title }: { image: string; imageAltText: string; title: string },
+						index: number
+					) => (
+						<img alt={ imageAltText } key={ index } src={ image } title={ title } />
+					)
+				) }
+			</div>
+			{ upgradeButton }
+		</>
+	);
+
+	const benefits: Benefit[] = [
+		{
+			key: 'brand',
+			icon: 'mail',
+			title: translate( 'Look professional' ),
+			description: translate(
+				'Use a custom email address that matches your domain and your brand.'
+			),
+		},
+		{
+			key: 'storage',
+			icon: 'cloud',
+			title: translate( 'Plenty of storage' ),
+			description: translate( '30GB per mailbox for messages, attachments, and shared files.' ),
+		},
+		{
+			key: 'security',
+			icon: 'lock',
+			title: translate( 'Secure and ad-free' ),
+			description: translate(
+				'Industry-leading anti-spam, privacy, and zero ads on every message.'
+			),
+		},
+		{
+			key: 'devices',
+			icon: 'phone',
+			title: translate( 'Works on every device' ),
+			description: translate(
+				'Access your inbox from desktop, mobile, or the web — no extra setup.'
+			),
+		},
+	];
+
+	return (
+		<div className="email-no-domain-upsell">
+			<header className="email-no-domain-upsell__hero">
+				<h1 className="email-no-domain-upsell__hero-title">
+					{ translate( 'Get email that matches your brand' ) }
+				</h1>
+				<p className="email-no-domain-upsell__hero-subtitle">
+					{ translate(
+						'A professional email address builds trust, keeps your business top of mind, and helps customers reach you. Upgrade your plan to unlock it.'
+					) }
+				</p>
+
+				<ul className="email-no-domain-upsell__benefits">
+					{ benefits.map( ( benefit ) => (
+						<li key={ benefit.key } className="email-no-domain-upsell__benefit">
+							<Gridicon
+								className="email-no-domain-upsell__benefit-icon"
+								icon={ benefit.icon }
+								size={ 24 }
+							/>
+							<h3 className="email-no-domain-upsell__benefit-title">{ benefit.title }</h3>
+							<p className="email-no-domain-upsell__benefit-description">{ benefit.description }</p>
+						</li>
+					) ) }
+				</ul>
+			</header>
+
+			<div className="email-no-domain-upsell__providers">
+				<h2 className="email-no-domain-upsell__providers-heading">
+					{ translate( 'Pick an email solution' ) }
+				</h2>
+				<p className="email-no-domain-upsell__providers-subheading">
+					{ translate(
+						'Both options work with a custom domain you’ll set up after upgrading.{{br/}}Additional service fees for the email offerings will apply.',
+						{ components: { br: <br /> } }
+					) }
+				</p>
+
+				<EmailProvidersStackedCard
+					className="professional-email-card"
+					description={ translate(
+						'Integrated email solution with powerful features. Manage your email and more on any device.'
+					) }
+					detailsExpanded
+					expandButtonLabel={ translate( 'Select' ) }
+					features={ [
+						translate( 'Send and receive from your custom domain' ),
+						translate( '30GB storage' ),
+						translate( 'Email, calendars, and contacts' ),
+						translate( '24/7 support via email' ),
+					] }
+					footerBadge={
+						<img
+							src={ poweredByTitanLogo }
+							alt={ translate( 'Powered by Titan', { textOnly: true } ) }
+						/>
+					}
+					formFields={ upgradeButton }
+					logo={
+						<Gridicon
+							className="professional-email-card__logo"
+							icon="my-sites"
+							aria-hidden="true"
+						/>
+					}
+					productName={ getTitanProductName() }
+					providerKey="titan"
+					showExpandButton={ false }
+				/>
+
+				<EmailProvidersStackedCard
+					className="google-workspace-card"
+					description={ translate(
+						'Business email with Gmail. Includes other collaboration and productivity tools from Google.'
+					) }
+					detailsExpanded
+					expandButtonLabel={ translate( 'Select' ) }
+					features={ [
+						translate( 'Send and receive from your custom domain' ),
+						translate( '30GB storage' ),
+						translate( 'Email, calendars, and contacts' ),
+						translate( 'Video calls, docs, spreadsheets, and more' ),
+						translate( 'Real-time collaboration' ),
+						translate( 'Store and share files in the cloud' ),
+						translate( '24/7 support via email' ),
+					] }
+					formFields={ googleFormFields }
+					logo={ { path: googleWorkspaceIcon, className: 'google-workspace-icon' } }
+					productName={ getGoogleMailServiceFamily() }
+					providerKey="google"
+					showExpandButton={ false }
+				/>
+			</div>
+
+			<TrackComponentView
+				eventName="calypso_email_management_no_domain"
+				eventProperties={ {
+					context: 'free-plan-upsell',
+					source: source || 'email',
+				} }
+			/>
+		</div>
+	);
+};
+
+export default EmailNoDomainUpsell;

--- a/client/my-sites/email/email-management/home/email-no-domain.tsx
+++ b/client/my-sites/email/email-management/home/email-no-domain.tsx
@@ -2,6 +2,7 @@ import { isFreePlan } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import EmptyContent from 'calypso/components/empty-content';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import EmailNoDomainUpsell from 'calypso/my-sites/email/email-management/home/email-no-domain-upsell';
 import { recordEmailUpsellTracksEvent } from 'calypso/my-sites/email/email-management/home/utils';
 import { useSelector } from 'calypso/state';
 import { hasDomainCredit } from 'calypso/state/sites/plans/selectors';
@@ -22,10 +23,6 @@ const EmailNoDomain = ( {
 	);
 
 	const isFreePlanProduct = isFreePlan( selectedSite?.plan?.product_slug ?? '' );
-
-	const trackEventForPlan = () => {
-		recordEmailUpsellTracksEvent( source, 'plan' );
-	};
 
 	const trackEventForDomain = () => {
 		recordEmailUpsellTracksEvent( source, 'domain' );
@@ -53,22 +50,7 @@ const EmailNoDomain = ( {
 	};
 
 	if ( isFreePlanProduct ) {
-		return (
-			<EmptyContent
-				action={ translate( 'Upgrade to a plan' ) }
-				actionCallback={ trackEventForPlan }
-				actionURL={ `/plans/${ selectedSite.slug }` }
-				secondaryAction={ translate( 'Just search for a domain' ) }
-				secondaryActionCallback={ trackEventForDomain }
-				secondaryActionURL={ `/domains/add/${ selectedSite.slug }` }
-				line={ translate(
-					'Upgrade to a plan now, set up your domain and pick from one of our flexible options to connect your domain with email and start getting emails today.'
-				) }
-				title={ translate( 'Get your own domain for a custom email address' ) }
-			>
-				{ trackImpression( 'plan' ) }
-			</EmptyContent>
-		);
+		return <EmailNoDomainUpsell selectedSite={ selectedSite } source={ source } />;
 	}
 
 	if ( hasAvailableDomainCredit ) {


### PR DESCRIPTION
## Summary

Replaces the minimal EmptyContent upsell shown on the Email page for free-plan sites with a dedicated EmailNoDomainUpsell component. The new view leads with a benefits grid (brand, storage, security, devices) and surfaces the two stacked provider cards (Professional Email / Google Workspace) so users see what they will unlock before upgrading. Non-free-plan branches are unchanged.

## Changes

- Extract free-plan branch of EmailNoDomain into new EmailNoDomainUpsell component
- Add hero + 4-benefit grid and provider picker using EmailProvidersStackedCard for Titan and Google Workspace
- Reuse recordEmailUpsellTracksEvent for the upgrade CTA; emit calypso_email_management_no_domain impression with context=free-plan-upsell
- Add scoped SCSS for hero, benefits grid, and two-column provider card layout at xlarge breakpoint
- Remove now-unused trackEventForPlan and EmptyContent branch from email-no-domain.tsx

## Screenshots

### Before

![Before](https://github.com/Automattic/wp-calypso/raw/bow-screenshots/freePlan-email-promo/1779807961034-0-before.jpg)

### After

![After](https://github.com/Automattic/wp-calypso/raw/bow-screenshots/freePlan-email-promo/1779807961034-1-after.jpg)

## How to test

1. On a free-plan site with no domain, visit `/email/<site-slug>` and confirm the new upsell renders with hero, 4 benefit cards, and both provider cards below
2. Click `Upgrade to add email` in either provider card and confirm navigation to `/plans/<site-slug>` and that a `calypso_email_upsell_*_plan` Tracks event fires
3. Confirm the `calypso_email_management_no_domain` impression fires once with `context=free-plan-upsell` and the expected `source`
4. On a paid-plan site with no domain and domain credit available, confirm the existing `/domains/add/<site-slug>` upsell still renders unchanged
5. On a paid-plan site with no domain and no credit, confirm the existing domain-purchase upsell still renders unchanged
6. Resize to <xlarge and ≥xlarge breakpoints and verify the provider card layout switches from single-column to two-column without overflow
7. Toggle dark mode and verify text, borders, and icons remain legible
8. Run `yarn typecheck-client` and `yarn lint:js client/my-sites/email/email-management/home` and confirm both pass

## Checklist

- [ ] Visual changes match the expected design
- [ ] No console errors introduced
- [ ] Tested with different user roles (if applicable)

---
Created as a draft by Build on WP.com.

_Created with Build on WP.com — the author will mark this ready for review when they choose to._

---

## ⚠️ SecEx pre-PR review couldn't run

BoW's mandatory pre-PR SecEx review (Anthropic claude-sonnet-4 via the wpcom `AI_Coder_Diff_Reviewer`) failed for this PR:

```
calypso: review: review_diff threw: Typed property AI_Coder_Diff_Reviewer::$logger must not be accessed before initialization
```

The PR was created anyway so the change isn't blocked. This is typically a sandbox-side issue (PHP class bug, library missing, network blip) that BoW can't fix client-side. **Please review this diff manually** before approving — the usual SecEx automated pass did not happen.
