### PR TITLE
Docs: fix stale APIs, broken links, and bad examples across docs/

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -10,7 +10,7 @@ Examples of unacceptable behavior by participants include:
 - Personal attacks
 - Trolling or insulting/derogatory comments
 - Public or private harassment
-- Publishing other's private information, such as physical or electronic addresses, without explicit permission
+- Publishing others' private information, such as physical or electronic addresses, without explicit permission
 - Other unethical or unprofessional conduct
 
 Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.

--- a/apps/blaze-dashboard/README.md
+++ b/apps/blaze-dashboard/README.md
@@ -2,7 +2,7 @@
 
 Blaze Dashboard is built as a standalone application to be used inside Jetpack, and in the future, into WooCommerce. The Jetpack counterpart of the project is in [here](https://github.com/Automattic/jetpack/tree/trunk/projects/packages/blaze).
 
-## Hiarachy
+## Hierarchy
 
 ```
 .

--- a/apps/happy-blocks/README.md
+++ b/apps/happy-blocks/README.md
@@ -4,7 +4,7 @@ This package contains the source code for the blocks used on WordPress.com sites
 
 ## Development environment
 
-1. Ensure you have a working sandbox and the its hostname is `wpcom-sandbox`
+1. Ensure you have a working sandbox and its hostname is `wpcom-sandbox`
 2. Run `yarn dev --sync` to build and sync files as you change them.
 
 ## Deployment
@@ -15,7 +15,7 @@ This package contains the source code for the blocks used on WordPress.com sites
 # Prep the latest trunk build for release
 install-plugin.sh happy-blocks --release
 # Alternatively, load changes from a branch (e.g. to test a PR.)
-install-plugin.sh happy-blocks $brach_name
+install-plugin.sh happy-blocks $branch_name
 ```
 
 see PCYsg-OT6-p2

--- a/apps/help-center/README.md
+++ b/apps/help-center/README.md
@@ -15,10 +15,10 @@ The Help Center is a bit complicated because it runs in multiple different envir
 3. In Atomic sites
    - as a plugin to Gutenberg editor.
      - A plugin when the site is connected to Jetpack.
-     - A minimal plugin when the site is disconnected from Jetpack. This plugiy simple links to wp.com/help.
+     - A minimal plugin when the site is disconnected from Jetpack. This plugin simply links to wp.com/help.
    - as a wpadminbar menu item.
      - A menu item that opens the Help Center when connected to Jetpack.
-     - A minimal plugin when the site is disconnected from Jetpack. This plugiy simple links to wp.com/help.
+     - A minimal plugin when the site is disconnected from Jetpack. This plugin simply links to wp.com/help.
 
 ### How to debug the Help Center
 
@@ -44,7 +44,7 @@ If you do want to modify PHP files. Please follow the development process of [`j
 
 ### Translations
 
-Translation are uploaded to widgets.wp.com/help-center/languages. They're then downloaded in Jetpack during the build process.
+Translations are uploaded to widgets.wp.com/help-center/languages. They're then downloaded in Jetpack during the build process.
 
 ### Deployment
 

--- a/apps/odyssey-stats/README.md
+++ b/apps/odyssey-stats/README.md
@@ -2,7 +2,7 @@
 
 Odyssey Stats is built to refresh the Stats experience in Jetpack. The counterpart of the project is in [here](https://github.com/Automattic/jetpack/tree/trunk/projects/packages/stats-admin).
 
-## Hiarachy
+## Hierarchy
 
 ```
 .
@@ -15,7 +15,7 @@ Odyssey Stats is built to refresh the Stats experience in Jetpack. The counterpa
 
 ## Routing
 
-It utilizes the [hashbang (#!) in page.js](https://github.com/visionmedia/page.js), however it doesn't work out of the box, because we are using hardcoded paths in Calypso, so some tricks are done in Jetpack to intecept the anchor clicks and covert them to hashbangs.
+It utilizes the [hashbang (#!) in page.js](https://github.com/visionmedia/page.js), however it doesn't work out of the box, because we are using hardcoded paths in Calypso, so some tricks are done in Jetpack to intercept the anchor clicks and covert them to hashbangs.
 
 ```
 $("#wpcom").on('click', 'a', function (e) {

--- a/client/blocks/like-button/README.md
+++ b/client/blocks/like-button/README.md
@@ -50,7 +50,7 @@ function handleLikeToggle( newState ) {
 
 - `likeCount`: the number of likes.
 - `showZeroCount`: (default: false) show the number of likes even if it's zero.
-- `liked`: (default: false ) a boolean indicating if the current user has liked whatever is being liked.
+- `liked`: (default: false) a boolean indicating if the current user has liked whatever is being liked.
 - `tagName`: (default: 'li' ) string. The container tag to use for the button.
 - `onLikeToggle`: a callback that is invoked when the like button toggles. It is called with the new state.
 - `isMini`: show a smaller version of the button. Used on comment likes.

--- a/client/components/breadcrumb/README.md
+++ b/client/components/breadcrumb/README.md
@@ -1,4 +1,4 @@
-# Bredcrumb (TSX)
+# Breadcrumb (TSX)
 
 This component displays an array of items as a breadcrumb.
 Each item should have at least a label.

--- a/client/components/chart/README.md
+++ b/client/components/chart/README.md
@@ -50,6 +50,6 @@ function render() {
 - <strong>minTouchBarWidth</strong> — _default: 42_ The minimum bar width on touch devices
 - <strong>minBarWidth</strong> — _default: 15_ The minimum bar width on non-touch devices
 - <strong>barClick</strong> - The function to be called when a bar is clicked on the chart, it is passed the entire data object of the bar
-- <strong>minBarsToBeShown</strong> - The minimun no of bars to be shown
+- <strong>minBarsToBeShown</strong> - The minimum no of bars to be shown
 - <strong>hideYAxis</strong> - _default: false_ A boolean value whether to hide the y-axis
 - <strong>hideXAxis</strong> - _default: false_ A boolean value whether to hide the x-axis

--- a/client/components/data/query-email-accounts/README.md
+++ b/client/components/data/query-email-accounts/README.md
@@ -30,4 +30,4 @@ export default function listEmailAccounts( { emailAccounts } ) {
 	<tr><th>Required</th><td>Yes</td></tr>
 </table>
 
-The ID of the site to fetch the email accounts users for.
+The ID of the site to fetch the email accounts for.

--- a/client/components/data/query-intro-offers/README.md
+++ b/client/components/data/query-intro-offers/README.md
@@ -1,6 +1,6 @@
 # Query Intro Offers
 
-`<QueryIntroOffers />` is a React component used in managing network requests product introductory offers.
+`<QueryIntroOffers />` is a React component used in managing network requests for product introductory offers.
 
 ## Usage
 

--- a/client/components/data/query-jitm/README.md
+++ b/client/components/data/query-jitm/README.md
@@ -33,4 +33,4 @@ The section name for which JITM data should be queried. When this is set, JITMs 
 	<tr><th>Required</th><td>Yes</td></tr>
 </table>
 
-The messagePath of the JITMs you want to retreive.
+The messagePath of the JITMs you want to retrieve.

--- a/client/components/data/query-media/README.md
+++ b/client/components/data/query-media/README.md
@@ -52,4 +52,4 @@ The query to be used in requesting media.
 	<tr><th>Default</th><td><code>null</code></td></tr>
 </table>
 
-The media ID to query (if you want to perform a single media query)
+The media ID to query (if you want to perform a single media query).

--- a/client/components/data/query-posts/README.md
+++ b/client/components/data/query-posts/README.md
@@ -42,7 +42,7 @@ The site ID for which posts should be queried.
 	<tr><th>Default</th><td><code>null</code></td></tr>
 </table>
 
-The post ID to query for. If provided a single post query will be performed
+The post ID to query for. If provided a single post query will be performed.
 
 ### `query`
 

--- a/client/components/data/query-rewind-restore-status/README.md
+++ b/client/components/data/query-rewind-restore-status/README.md
@@ -28,7 +28,7 @@ export default function MyComponent( props ) {
 	<tr><th>Required</th><td>Yes</td></tr>
 </table>
 
-The site ID for which terms should be requested.
+The site ID for which the restore status should be requested.
 
 ### `restoreId`
 

--- a/client/components/data/query-site-stats/README.md
+++ b/client/components/data/query-site-stats/README.md
@@ -14,7 +14,7 @@ export default function AmazingVisualizationOfStats( { stats } ) {
 		<ul>
 			<QuerySiteStats siteId={ 3584907 } statType="statsStreak" />
 			{ stats.map( ( stat ) => {
-				return <span>A span o { stat }</span>;
+				return <span>A span of { stat }</span>;
 			} ) }
 		</ul>
 	);

--- a/client/components/date-range/README.md
+++ b/client/components/date-range/README.md
@@ -57,7 +57,7 @@ General guidelines should be a list of tips and best practices. Example:
 - To access the date data from outside the component utilise the `onDateCommit` and `onDateSelect` callback methods to trigger state updates in your parent component.
 - If you need to heavily customise the look and feel consider using one of the render prop overides to customise the appropriate aspect.
 - You can restrict the picker to certain date ranges using either/both of the `firstSelectableDate` and `lastSelectableDate` props to define a restriction.
-- The underlying `DatePicker` uses [React Day Picker](http://react-day-picker.js.org/)/
+- The underlying `DatePicker` uses [React Day Picker](http://react-day-picker.js.org/)
 - By default the layout will switch to a single calendar view at screens smaller than <480px
 
 ## Related components

--- a/client/components/email-verification/README.md
+++ b/client/components/email-verification/README.md
@@ -1,6 +1,6 @@
 # Email Verification
 
-This module exports several utilities for handling new user's email verification flow.
+This module exports several utilities for handling new users' email verification flow.
 
 ## `page.js` handler
 

--- a/client/components/empty-content/no-sites-message/README.md
+++ b/client/components/empty-content/no-sites-message/README.md
@@ -1,6 +1,6 @@
 # NoSitesMessage
 
-This the a call-to-action we show to users that have no sites but access pages that require the user to have at least one site.
+This is a call-to-action we show to users that have no sites but access pages that require the user to have at least one site.
 
 ## Usage
 

--- a/client/components/infinite-scroll/README.md
+++ b/client/components/infinite-scroll/README.md
@@ -2,7 +2,7 @@
 
 An infinite scroll component to power list views.
 
-There is an alternative implementation called [InfiniteList](../infinite-list), which doesn't render invisible items. However, it is more complex to implement, so use it only if your list contains lot of images or other media and you expect that users will scroll a lot.
+There is an alternative implementation called [InfiniteList](../infinite-list), which doesn't render invisible items. However, it is more complex to implement, so use it only if your list contains a lot of images or other media and you expect that users will scroll a lot.
 
 ## How to use
 

--- a/client/components/info-popover/README.md
+++ b/client/components/info-popover/README.md
@@ -28,12 +28,12 @@ The `className` lets you specify the style class that the element should have.
 
 ### `gaEventCategory`
 
-The `gaEventCategory` lets you specify the Google Analyics Category that you want the toggle event to have.
+The `gaEventCategory` lets you specify the Google Analytics Category that you want the toggle event to have.
 Also requires the `popoverName` attribute.
 
 ### `popoverName`
 
-The `popoverName` lets you specify the Google Analyics Event name that you want the toggle event to have.
+The `popoverName` lets you specify the Google Analytics Event name that you want the toggle event to have.
 Also requires the `gaEventCategory` attribute.
 
 Turns into this even when opened:

--- a/client/components/inline-support-link/README.md
+++ b/client/components/inline-support-link/README.md
@@ -4,7 +4,7 @@ This component displays a link and icon.
 
 If `props.supportPostId` is supplied, when the link is clicked a SupportArticleDialog is opened with an `ExternalLink` to the `props.supportLink`. If no `props.supportPostId` is supplied, an `ExternalLink` to the `props.supportLink` is rendered. These props are now stored in context-links.js; you should not need to provide them directly within the function anymore, see new example usage.
 
-The component's `children` prop will be used for the link text; if none is supplied, it will defaut to the text "Learn more". The `showText` property (default `true`) can be set to `false` in order to display no text.
+The component's `children` prop will be used for the link text; if none is supplied, it will default to the text "Learn more". The `showText` property (default `true`) can be set to `false` in order to display no text.
 
 ## Example Usage (deprecated)
 

--- a/client/components/jetpack-colophon/README.md
+++ b/client/components/jetpack-colophon/README.md
@@ -1,6 +1,6 @@
 # JetpackColophon (JSX)
 
-This component is used to display a "Powered by Jetpack" colophon, usually on the footer of page
+This component is used to display a "Powered by Jetpack" colophon, usually on the footer of the page
 
 ---
 

--- a/client/components/multiple-choice-question/README.md
+++ b/client/components/multiple-choice-question/README.md
@@ -90,7 +90,7 @@ The question to display at the top of the multiple choice
 - **Type:** `Function`
 - **Required:** `yes`
 
-Handler for when the selected answer of the multiple choice is changeed. It is called each time a new answer is selected **OR** when the optional text input of the selected answer is changes. The arguments are `id`, and optionally `text` if the answer has a text input.
+Handler for when the selected answer of the multiple choice is changed. It is called each time a new answer is selected **OR** when the optional text input of the selected answer is changes. The arguments are `id`, and optionally `text` if the answer has a text input.
 
 ### `selectedAnswerId`
 
@@ -106,7 +106,7 @@ Sets the initial answer selection of the multiple choice to the given answer id.
 - **Required:** `no`
 - **Default:** `''`
 
-sets the text prompt of initial answer selection of the multiple choice to the given text. Only works when `selectedAnswerId` is given.
+Sets the text prompt of initial answer selection of the multiple choice to the given text. Only works when `selectedAnswerId` is given.
 
 ### `answers`
 

--- a/client/components/product-card/README.md
+++ b/client/components/product-card/README.md
@@ -222,4 +222,4 @@ The following props can be passed to the Product Card Action component:
 - `label`: ( string ) Action button text
 - `onClick`: ( func ) Action button click event handler
 - `href`: ( string ) Url that the button click will take you to
-- `primary`: ( bool ) If we the action should be primary (default true)
+- `primary`: ( bool ) If the action should be primary (default true)

--- a/client/components/promo-section/README.md
+++ b/client/components/promo-section/README.md
@@ -1,6 +1,6 @@
 # Promo Section
 
-A compontent to layout [`PromoCard` components](../../components/promo-section/promo-card) to create a page layout used in the Earn section and Marketing Tools.
+A component to layout [`PromoCard` components](../../components/promo-section/promo-card) to create a page layout used in the Earn section and Marketing Tools.
 
 ## Usage
 

--- a/client/components/site-offset/README.md
+++ b/client/components/site-offset/README.md
@@ -68,9 +68,3 @@ ReactDom.render(
 	document.getElementById( 'root' )
 );
 ```
-
-;
-
-```
-
-```

--- a/client/components/split-button/README.md
+++ b/client/components/split-button/README.md
@@ -70,7 +70,7 @@ For non primary buttons, it could be used to hide the separator, because the lin
 	<tr><td>Default</td><td><code>false</code></td></tr>
 </table>
 
-Whether the button has modified styling to warn users (delete, remove, etc).es
+Whether the button has modified styling to warn users (delete, remove, etc).
 
 ### `onClick`
 

--- a/client/components/token-field/README.md
+++ b/client/components/token-field/README.md
@@ -2,7 +2,7 @@
 
 A `TokenField` is a field similar to the tags and categories fields in the interim editor chrome, or the "to" field in Mail on OS X. Tokens can be entered by typing them or selecting them from a list of suggested tokens.
 
-Up to one hundred suggestions that match what the user has typed so far will be shown from which the user can pick from (auto-complete). Tokens are separated by the "," character. Suggetions can be selected with the up or down arrows and added with the tab or enter key.
+Up to one hundred suggestions that match what the user has typed so far will be shown from which the user can pick from (auto-complete). Tokens are separated by the "," character. Suggestions can be selected with the up or down arrows and added with the tab or enter key.
 
 The `value` property is handled in a manner similar to controlled form components. See [Forms](https://facebook.github.io/react/docs/forms.html) in the React Documentation for more information.
 

--- a/client/components/upgrades/credit-card-number-input/README.md
+++ b/client/components/upgrades/credit-card-number-input/README.md
@@ -14,4 +14,4 @@ function MyComponent() {
 
 ## Properties
 
-This component don't require any property but will pass any one assigned to the wrapped input field component.
+This component doesn't require any property but will pass any one assigned to the wrapped input field component.

--- a/client/components/wpadmin-auto-login/README.md
+++ b/client/components/wpadmin-auto-login/README.md
@@ -2,7 +2,7 @@
 
 This components opens a GET request to wp-admin of a connected site in order to log in to wp-admin.
 Because wp-login.php can automatically log in a user using SSO if `jetpack_sso_bypass_login_forward_wpcom` option is enabled, it redirects user automatically
-to a a transparent pixel.
+to a transparent pixel.
 We use this component in Automated Transfer.
 
 ## Requirements

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/README.md
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/README.md
@@ -25,7 +25,7 @@ function submit( providedDependencies: ProvidedDependencies = {} ) {
 ```
 
 4. On the main step, before calling `submit()`, set the pendingAction.
-   - Remember to `await` all `Promisse`s
+   - Remember to `await` all `Promise`s
 
 ```
 const { setPendingAction } = useDispatch( ONBOARD_STORE );

--- a/client/lib/accept/README.md
+++ b/client/lib/accept/README.md
@@ -6,7 +6,7 @@ Accept is a stylized substitute to the browser `confirm` dialog.
 
 ## Arguments
 
-- `message` - A string that gets displayed to the user in the cofirm dialog.
+- `message` - A string that gets displayed to the user in the confirm dialog.
 - `callback` - A callback that gets called after confirms or cancels the dialog.
 - `confirmButtonText` - Optional confirm button text, defaults to 'OK'.
 - `cancelButtonText` - Optional cancel button text, defaults to 'Cancel'.

--- a/client/lib/catch-js-errors/README.md
+++ b/client/lib/catch-js-errors/README.md
@@ -23,11 +23,11 @@ log( 'This is unexpected', { additionalData: 'data' } );
 
 - A piece of code you suspect is dead
 - Function that is triggered by weird parameters
-- Place you dont know how many people reach
+- Place you don't know how many people reach
 
 Generally, whenever you are wondering "what kind of users hit this place?" or you want to gather more data to debug a hard error, you can use the logger to make your life a bit easier.
 
 ### Gotchas
 
-Logger is initialized only on non-SSR environment and after initializing redux store. So you want be able to log any redux discrepencies.
-This is actually good, since you dont want to log any action that can flood the endpoint.
+Logger is initialized only on non-SSR environment and after initializing redux store. So you won't be able to log any redux discrepencies.
+This is actually good, since you don't want to log any action that can flood the endpoint.

--- a/client/lib/compare-props/README.md
+++ b/client/lib/compare-props/README.md
@@ -43,7 +43,7 @@ To compare selected properties deeply, specify a `deep` option:
 ```js
 const comparator = compareProps( { deep: [ 'query' ] } );
 
-// returns true: the `page` properties are are strictly equal and
+// returns true: the `page` properties are strictly equal and
 // the `query` objects are deeply equal, although not identical
 comparator(
 	{

--- a/client/lib/domains/whois/README.md
+++ b/client/lib/domains/whois/README.md
@@ -1,4 +1,4 @@
 # Domains WHOIS
 
 This module used to provide utility functions to deal with domain WHOIS features, but all those are now served by Redux,
-so now it only contains a few utilily functions to deal with public/protected WHOIS information.
+so now it only contains a few utility functions to deal with public/protected WHOIS information.

--- a/client/lib/payment-gateway-loader/README.md
+++ b/client/lib/payment-gateway-loader/README.md
@@ -1,7 +1,7 @@
 # Payment Gateway Loader
 
 Payment gateways often provide JS libraries used to securely generate tokens from credit card details.
-For example, `Paygate` is a library by WordPress.com we can use to send Credit card data to the Paygate server and recieve back a token which we then submit to MoneyPress.
+For example, `Paygate` is a library by WordPress.com we can use to send Credit card data to the Paygate server and receive back a token which we then submit to MoneyPress.
 
 This class, `PaymentGatewayLoader`, takes care of the details of loading the remote payment gateway JS script (i.e. `paygate.js`) asynchronously.
 You can access the `Paygate` class from within the callback of `PaygateLoader.ready` like so:

--- a/client/lib/track-form/README.md
+++ b/client/lib/track-form/README.md
@@ -73,7 +73,7 @@ It also marks the updated fields as dirty. The `callback` argument is optional.
 </table>
 
 This function replaces the field values passed as an argument without updating the dirty fields.
-This is usefull when you want to reset form fields to an already persisted value.
+This is useful when you want to reset form fields to an already persisted value.
 
 ### `clearDirtyFields`
 

--- a/client/me/profile/README.md
+++ b/client/me/profile/README.md
@@ -1,3 +1,3 @@
 # Profile
 
-This component readers the profile section of me at the /me route.
+This component renders the profile section of me at the /me route.

--- a/client/me/security-2fa-setup-backup-codes/README.md
+++ b/client/me/security-2fa-setup-backup-codes/README.md
@@ -3,7 +3,7 @@
 Used by Security2faSetup, this component manages the display and verification
 of backup codes during the 2fa activation flow. Note that because the state
 transitions and presentation are substantially different than when 2fa is
-already enable that there is a separate component, Security2faBackupCodes,
+already enabled, there is a separate component, Security2faBackupCodes,
 that is used to let the user manage backup codes when 2fa is already enabled.
 
 This component uses Security2faBackupCodesDetail (a header like component),

--- a/client/my-sites/README.md
+++ b/client/my-sites/README.md
@@ -23,4 +23,4 @@ The first component that is rendered for any section in `#primary` should be cal
 
 ## Shared modules
 
-If you are creating a shared individual component directly related to the My Sites area of Calypso, the root of `client/my-sites` may be appropiatte for placement — with its own self-documented README.md file of course!
+If you are creating a shared individual component directly related to the My Sites area of Calypso, the root of `client/my-sites` may be appropriate for placement — with its own self-documented README.md file of course!

--- a/client/my-sites/plugins/plugin-autoupdate-toggle/README.md
+++ b/client/my-sites/plugins/plugin-autoupdate-toggle/README.md
@@ -1,6 +1,6 @@
 # Plugin Autoupdate Toggle
 
-This component is used to display a plugin autupdate toggle.
+This component is used to display a plugin autoupdate toggle.
 
 ## How to use
 

--- a/client/my-sites/plugins/plugin-item/README.md
+++ b/client/my-sites/plugins/plugin-item/README.md
@@ -31,5 +31,5 @@ function render() {
 - `onClick`: onClick handler.
 - `pluginLink`: the url of the plugin.
 - `allowedActions`: an object of allowed plugin actions: `activation`, `autoupdate`. Used to display/hide plugin actions.
-- `isAutoManaged`: a boolean if the plugin is auto managed. If true it will dispaly an auto managed message. Defaults to false.
+- `isAutoManaged`: a boolean if the plugin is auto managed. If true it will display an auto managed message. Defaults to false.
 - `progress`: an array of progress steps.

--- a/client/my-sites/plugins/plugins-browser-item/README.md
+++ b/client/my-sites/plugins/plugins-browser-item/README.md
@@ -25,7 +25,7 @@ function render() {
 
 - `key`: Unique plugin key, this help react render a list better.
 - `isPlaceholder`: Boolean, it marks if the item is a placeholder
-- `iconSize`: number with the size of the icon. Defaulted to 40, since all the intertal css are adjusted around that value, it would be better to not change the default
+- `iconSize`: number with the size of the icon. Defaulted to 40, since all the internal css are adjusted around that value, it would be better to not change the default
 - `variant`: the component can be used in compact or extended view. Defaults to `Compact`.
 
   | variant  | displays                                            |

--- a/client/my-sites/plugins/plugins-browser-list/README.md
+++ b/client/my-sites/plugins/plugins-browser-list/README.md
@@ -1,6 +1,6 @@
 # Plugins Browser List
 
-This component is used to display a list with the a parametrizable number of plugins of a certain category of the wordpress.org public plugin directory.
+This component is used to display a list with a parameterizable number of plugins of a certain category of the wordpress.org public plugin directory.
 
 ## How to use
 

--- a/client/my-sites/plugins/plugins-list/README.md
+++ b/client/my-sites/plugins/plugins-list/README.md
@@ -23,4 +23,4 @@ import PluginsList from 'calypso/my-sites/plugins/plugins-list';
 - `sites`: An object describing the sites list object.
 - `selectedSite`: An object or false of the single site.
 - `pluginUpdateCount`: Number of plugin updates that need to happen.
-- `isPlaceholder`: Weather to show a placeholder.
+- `isPlaceholder`: Whether to show a placeholder.

--- a/client/my-sites/plugins/plugins-search-results-page/README.md
+++ b/client/my-sites/plugins/plugins-search-results-page/README.md
@@ -1,6 +1,6 @@
 # Plugins Search Results Page
 
-This component renders the plugins searcha results page.
+This component renders the plugins search results page.
 
 ## How to use
 

--- a/client/my-sites/stats/features/modules/readme.md
+++ b/client/my-sites/stats/features/modules/readme.md
@@ -1,3 +1,3 @@
 # Modules
 
-This direcotry contains widgets used across Stats pages called "Modules". At the moment, they mainly use horizontal bars to display relation between items.
+This directory contains widgets used across Stats pages called "Modules". At the moment, they mainly use horizontal bars to display relation between items.

--- a/client/reader/update-notice/README.md
+++ b/client/reader/update-notice/README.md
@@ -23,4 +23,4 @@ class MyComponent extends React.Component {
 ## Props
 
 - `count` - the number of updates that are available
-- `onClick` - a callback to call when the notice is cliced on
+- `onClick` - a callback to call when the notice is clicked on

--- a/client/signup/steps/woocommerce-install/hooks/use-woop-handling/Readme.md
+++ b/client/signup/steps/woocommerce-install/hooks/use-woop-handling/Readme.md
@@ -20,6 +20,7 @@ function WordPressSubdomainWarningCard() {
 		</div>
 	);
 }
+```
 
 ## API
 
@@ -44,4 +45,3 @@ The hook returns an object with the following properties:
 ### isReadyToStart
 
 ### isDataReady
-```

--- a/client/sites/marketing/connections/README.md
+++ b/client/sites/marketing/connections/README.md
@@ -10,7 +10,7 @@ The entry point for sharing connections. Renders help text and a list of `Sharin
 
 ### SharingService
 
-Renders connection status for a single service, including description, examples, tips, a list of connected accuonts, and possible user actions.
+Renders connection status for a single service, including description, examples, tips, a list of connected accounts, and possible user actions.
 
 ### SharingServiceAction
 

--- a/client/state/analytics/README_HotJar.md
+++ b/client/state/analytics/README_HotJar.md
@@ -11,7 +11,7 @@ With HotJar we can collect information from our users, communicate with them, an
 
 ## Usage
 
-HotJar is a thrid party tool and is managed through their website. Their script needs to be loaded in order for it to work. Where you load the script will have an impact on the coverage of the tool. It is recommended to restrict it's loading to a handful of screens rather than the entire app.
+HotJar is a third party tool and is managed through their website. Their script needs to be loaded in order for it to work. Where you load the script will have an impact on the coverage of the tool. It is recommended to restrict its loading to a handful of screens rather than the entire app.
 
 `loadTrackingTool ( trackingTool )`
 Use this analytics action to load HotJar in the `componentDidMount` lifecycle method for every screen you want it to appear on.

--- a/client/state/persistent-counter/README.md
+++ b/client/state/persistent-counter/README.md
@@ -18,7 +18,7 @@ dispatch( incrementCounter( MY_COUNTER_NAME ) );
 
 ### More info
 
-`incrementCounter`, `decrementCounter`, and `resetCounter` are redux actions that can be dispatched. Thier argument signature is as follows:
+`incrementCounter`, `decrementCounter`, and `resetCounter` are redux actions that can be dispatched. Their argument signature is as follows:
 
 `incrementCounter( counterName, keyedToSiteId = false, countSameDay = true );`
 

--- a/desktop/app/lib/state/README.md
+++ b/desktop/app/lib/state/README.md
@@ -1,4 +1,4 @@
 # State
 
 Provides user state functions, initially for logged in state, but easily
-extended to other cases at they rise
+extended to other cases as they arise

--- a/desktop/app/window-handlers/README.md
+++ b/desktop/app/window-handlers/README.md
@@ -1,6 +1,6 @@
 # Window Handlers
 
-Window handlers are bits of code that run before after app has started and the main window has opened.
+Window handlers are bits of code that run before and after the app has started and the main window has opened.
 
 The following handlers are available:
 

--- a/desktop/app/window-handlers/notifications/README.md
+++ b/desktop/app/window-handlers/notifications/README.md
@@ -6,5 +6,5 @@ Handles the notification badge.
 
 Listens for the following:
 
-- `clear-notices-count` - sent by Calypso when a the unread notifications count changes
+- `clear-notices-count` - sent by Calypso when the unread notifications count changes
 - `preferences-changed-notification-badge` - sent when the notification badge preference is changed

--- a/desktop/docs/notarization.md
+++ b/desktop/docs/notarization.md
@@ -16,6 +16,6 @@ Notarization status of an application bundle can be verified via the `codesign`,
 
 `codesign --test-requirement="=notarized" --verify --verbose WordPress.com.app`
 
-`xrun stapler validate WordPress.com.app`
+`xcrun stapler validate WordPress.com.app`
 
 `spctl -a -v WordPress.com.app`

--- a/desktop/docs/release.md
+++ b/desktop/docs/release.md
@@ -57,5 +57,5 @@ Refer to Windows environment requires in the [development docs](./development.md
 To build on Linux, you need the following libraries in order to be able to manually re-build native dependencies:
 
 ```
-apt-get install -y libsecret-1-devdev
+apt-get install -y libsecret-1-dev
 ```

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -32,7 +32,7 @@ For a detailed list of requirements, you can go to [the WCAG 2.0 customized quic
 
 ## Automated Testing/Checking
 
-Our ESLint rules include some basic accessibility checks using the [jsx-a11y plugin](https://github.com/evcohen/eslint-plugin-jsx-a11y).
+Our ESLint rules include some basic accessibility checks using the [jsx-a11y plugin](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y).
 
 ## Resources
 
@@ -62,8 +62,8 @@ Find tools that will help you bring accessibility into your workflow.
 
 - [Accessibility for Designers](http://webaim.org/resources/designers/): An infographic about how designers can help create good, accessible websites.
 - [The Complete Beginner's Guide to Universal Design](http://www.uxbooth.com/articles/the-complete-beginners-guide-to-universal-design/): A blog post that describes universal design, a set of considerations made to ensure that a product, service, and/or environment is usable by everyone, to the greatest extent possible, without the need for adaptation or specialized design.
-- [Colllor](http://colllor.com/) and [0to255](http://0to255.com/): Both are tools that will generate different shades, tints and tones of colors, helpful when creating an accessible color palette.
-- [Color Palette Evaluator by NC State](http://accessibility.oit.ncsu.edu/tools/color-contrast/index.php): Evaluate the contrast of different color palettes with the Color Palette Evaluator by NC State.
+- [ColorHexa](https://www.colorhexa.com/) and [0to255](http://0to255.com/): Both are tools that will generate different shades, tints and tones of colors, helpful when creating an accessible color palette.
+- [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/): Evaluate the contrast of different color palettes with the WebAIM Contrast Checker.
 - [Tanaguru Contrast-Finder](http://contrast-finder.tanaguru.com/form.html): Find high contrast colors when you need them.
 
 ### Web Developers
@@ -76,5 +76,5 @@ Find tools that will help you bring accessibility into your workflow.
 - [VoiceOver for iOS](http://www.apple.com/accessibility/iphone/vision.html): Built-in screenreader for iOS.
 - [Chrome Vox](http://www.chromevox.com/): A screenreader for ChromeOS.
 - [WCAG 2.0 Cheat Sheet](http://www.w3.org/2009/cheatsheet/#wcag2) A simplified look at WCAG 2.0.
-- [An Alt Text Decision Tree](http://dev.w3.org/html5/alt-techniques/developer.html#tree): A decision tree for deciding when and how to implement alt text in your work on the web. This is a work in progress by the editors of the HTML5 spec, but it's extremely useful in its current form.
+- [An Alt Text Decision Tree](https://www.w3.org/WAI/tutorials/images/decision-tree/): A decision tree from the W3C Web Accessibility Initiative for deciding when and how to implement alt text in your work on the web.
 

--- a/docs/coding-guidelines/css.md
+++ b/docs/coding-guidelines/css.md
@@ -139,7 +139,7 @@ Calypso already provides helpers for many common solutions. Please, use them! We
 
 Currently, all component based Sass files are imported into the respective JavaScript sources (using `import './style.scss'` statements). They are compiled by webpack as part of the bundling process into CSS chunks that are then loaded into the browser at runtime. Remember that all styles, even when loaded at different times, eventually end up on one page as part of a single HTML document. Make sure you namespace your styles for the page you are working on.
 
-Under the hood, we are using webpack and its `sass-loader`, for compiling the styles with `node-sass` (a C++ implementation of the Sass compiler which is working on parity with the reference Ruby implementation) and `mini-css-extract-plugin`, for creating the CSS chunks to be loaded as `<style>` tags into the browser.
+Under the hood, we are using webpack and its `sass-loader`, for compiling the styles with `sass` (Dart Sass, the reference implementation) and `mini-css-extract-plugin`, for creating the CSS chunks to be loaded as `<style>` tags into the browser.
 
 ## Media Queries
 
@@ -222,7 +222,7 @@ Add as much comments as needed to your Sass file, especially around clever code.
 
 ## Right-To-Left (RTL)
 
-We're using [RTLCSS](https://github.com/MohammadYounes/rtlcss) to convert `public/style.css` to rtl. This happens automatically during `yarn run build-css`.
+We're using [RTLCSS](https://github.com/MohammadYounes/rtlcss) (via [`@automattic/webpack-rtl-plugin`](https://www.npmjs.com/package/@automattic/webpack-rtl-plugin)) to generate RTL stylesheets. This happens automatically as part of the webpack build, producing paired `.css`/`.rtl.css` files for each CSS chunk.
 
 - If your css code refers to a filename with ‘left’ or ‘right’ in it, for example background: `url(arrow-left.png)`: the RTL version will reference a different file, e.g. `background: url(arrow-right.png)`. Please make sure that file exists.
 - Same goes for ‘ltr’ and ‘rtl’ in it, for example background: url(icons-ltr.png): the RTL version will link to the other direction, e.g `background: url(icons-ltr.png)`. Please make sure that file exists.
@@ -299,7 +299,7 @@ selector {
 
 When adding z-indexes use our scss z-index function. This means you'll need to
 add another entry to the `$z-layers` variable in
-`assets/stylesheets/shared/functions/_z-index.scss`.
+`client/assets/stylesheets/shared/functions/_z-index.scss`.
 
 Because browsers support a hierarchy of stacking contexts rather than a single
 global one, we use a tree with two levels of keys. The first is the name of the

--- a/docs/coding-guidelines/html.md
+++ b/docs/coding-guidelines/html.md
@@ -46,8 +46,8 @@ class Post extends React.Component {
 
 		return (
 			<div id={ 'post-' + post.ID } className="post">
-				<h1 class="post-title">{ post.title }</h1>
-				<div class="post-content">{ post.content }</div>
+				<h1 className="post-title">{ post.title }</h1>
+				<div className="post-content">{ post.content }</div>
 			</div>
 		);
 	}

--- a/docs/coding-guidelines/javascript.md
+++ b/docs/coding-guidelines/javascript.md
@@ -740,7 +740,7 @@ There are [integrations](http://eslint.org/docs/user-guide/integrations) for man
 
 In cases where ESLint incorrectly identifies code as not following our standards, you can [disable rules using inline comments](http://eslint.org/docs/user-guide/configuring#disabling-rules-with-inline-comments). Before disabling a rule, be certain and vocal that you understand the reason for it needing to be disabled. Our ESLint configuration is very well-tuned, and disabling a rule is not appropriate as an escape valve for poorly written code. If you don't understand or disagree with the existence of a rule, open an issue to start a discussion.
 
-### [Automatically Run ESLint Against Your Changesets](#setting-up-githooks)
+### [Automatically Run ESLint Against Your Changesets](#automatically-run-eslint-against-your-changesets)
 
 If you would like to have your changes automatically run through ESLint - there is a git pre-commit hook in `bin/pre-commit-hook.js` that will perform the task. It will be run everytime you do a `git commit`.
 

--- a/docs/coding-guidelines/newline-at-end-of-file.md
+++ b/docs/coding-guidelines/newline-at-end-of-file.md
@@ -27,7 +27,7 @@ Your prompt stands alone on a new line.
 
 ## Tools
 
-- The wpcalypso eslint config [deems](https://github.com/Automattic/eslint-config-wpcalypso/blob/ff0a4e6120113c40cd432d19350497d7612fde97/index.js#L26) it an error if files do not ["end with a newline (LF)"](https://eslint.org/docs/rules/eol-last)
+- The `@automattic/eslint-plugin-wpcalypso` recommended config [deems](../../packages/eslint-plugin-wpcalypso/lib/configs/recommended.js) it an error if files do not ["end with a newline (LF)"](https://eslint.org/docs/rules/eol-last)
 - Prettier reformats files to add a newline at the end ["by design"](https://github.com/prettier/prettier/issues/55#issuecomment-301301268)
 - Most (if not all) major editors have settings to add newlines at the end of source files. For example:
   - nano: enabled by default. To disable, you supply the `-L` flag

--- a/docs/coding-guidelines/trailing-whitespace.md
+++ b/docs/coding-guidelines/trailing-whitespace.md
@@ -2,7 +2,7 @@
 
 All source files should have trailing whitespace removed.
 
-It can be easy to leave whitespace at the end of lines by mistake. If you use Sublime Text you can strip this out automatically on save. Go to SublimeText 2 > Preferences > Settings - User (or just hit the Mac Standard cmd + ,). This should open your User Settings as a JSON file. Add the following to your file
+It can be easy to leave whitespace at the end of lines by mistake. If you use Sublime Text you can strip this out automatically on save. Go to SublimeText 2 > Preferences > Settings - User (or just hit the Mac Standard cmd + ,). This should open your User Settings as a JSON file. Add the following to your file:
 
 ```
 “trim_trailing_whitespace_on_save”: true

--- a/docs/coding-guidelines/typescript.md
+++ b/docs/coding-guidelines/typescript.md
@@ -45,7 +45,7 @@ start working in TypeScript so that we can form together our customs and norms a
 
 ### Primitive types
 
-Avoid primitive types when possible. These are `string`, `int`, `null`, `boolean`, etc…
+Avoid primitive types when possible. These are `string`, `number`, `null`, `boolean`, etc…
 Usually we can find more meaningful types or type aliases that better communicate our expectations.
 
 #### Avoid
@@ -239,7 +239,7 @@ const handleUpdate = ( { items }: { items: { name: string, count: number }[] } )
 #### Prefer
 
 ```ts
-const handleUpdate = ( { items }: { items: Parameters< typeof doSomethingUnknown >[] } ) => {
+const handleUpdate = ( { items }: { items: Parameters< typeof doSomethingUnknown >[ 0 ][] } ) => {
 	items.forEach( doSomethingUnknown );
 };
 ```

--- a/docs/color.md
+++ b/docs/color.md
@@ -29,7 +29,7 @@ All theme variables are prefixed with `--color-`. Their values change depending 
 
 The colors above can be suffixed with `-light` or `-dark` to quickly get a variation of the color. They are helper aliases to make picking shades easier (e.g. `--color-primary-light` or `--color-primary-dark`). In the default color scheme, these suffixes correspond to the 30 and 70 value of that color. For example, `--color-primary` points to **Blue 50**, `--color-primary-light` to **Blue 30**, and `--color-primary-dark` to **Blue 70**.
 
-The properties listed above can also be suffixed with the corresponding index number to [Color Studio](https://color-studio.blog) values. If you need a specific value that is not covered by the `light` or `dark` helper aliases, then you can append the specific value number to the end of the variable. For example, you can use `--color-accent-10` or `color-neutral-90` to get a specific shade.
+The properties listed above can also be suffixed with the corresponding index number to [Color Studio](https://color-studio.blog) values. If you need a specific value that is not covered by the `light` or `dark` helper aliases, then you can append the specific value number to the end of the variable. For example, you can use `--color-accent-10` or `--color-neutral-90` to get a specific shade.
 
 ### Additional Properties
 

--- a/docs/component-readme-template.md
+++ b/docs/component-readme-template.md
@@ -1,6 +1,6 @@
 # Component Documentation Template
 
-_Use this as a README.md template when documenting components. If you are creating a new component, you can copy and paste this entire document as a starting point. See the [Button documentation](../design/buttons) for a good example._
+_Use this as a README.md template when documenting components. If you are creating a new component, you can copy and paste this entire document as a starting point. See the [Button documentation](../packages/components/src/button/README.md) for a good example._
 
 Write a short, high-level explanation of the component with a focus on what problem it solves in the interface. Do not include any technical information in this description.
 Example:
@@ -12,8 +12,7 @@ Example:
 First, display a `jsx` code block to show an example of usage, including import statements and a React component.
 
 ```jsx
-import { Button } from '@automattic/components';
-import Gridicon from 'calypso/components/gridicons';
+import { Button, Gridicon } from '@automattic/components';
 
 export default function RockOnButton() {
 	return (

--- a/docs/components.md
+++ b/docs/components.md
@@ -10,7 +10,7 @@ You will encounter the following types of components in Calypso:
 
 - [UI components](../client/components/README.md) (UI primitives)
 - [Blocks](../client/blocks/README.md) (components which are connected to state, or otherwise directly represent application entities)
-- [Query components](./our-approach-to-data.md#query-components) (which handle data querying but don’t render anything)
+- [Query components](./our-approach-to-data.md) (which handle data querying but don’t render anything)
 - Higher-order components (which encapsulate and provide functionality)
 - Section components (which are domain specific and not meant to be reused)
 

--- a/docs/dark-mode.md
+++ b/docs/dark-mode.md
@@ -20,11 +20,15 @@ Dashboard apps opt in to color-scheme support through the app config, while clas
 Dashboard dark styles are activated from `client/dashboard/app/style.scss`:
 
 ```scss
-:root[data-theme='dark'] {
-	@include dashboard-dark-theme;
+// Keep dashboard dark mode out of browser print/PDF output. Printed pages should
+// fall back to the default light theme variables even when the screen is dark.
+@media screen {
+	:root[data-theme='dark'] {
+		@include dashboard-dark-theme;
+	}
 }
 
-@media (prefers-color-scheme: dark) {
+@media screen and (prefers-color-scheme: dark) {
 	:root[data-theme='system'] {
 		@include dashboard-dark-theme;
 	}
@@ -88,10 +92,10 @@ Common cases that may need an override include third-party components, embedded 
 
 For broad overrides to shared or third-party components, prefer adding a focused mixin in `client/dashboard/app/_dark-theme.scss`. Keep those overrides narrow and grouped by the component or surface they target.
 
-When an override truly has to live in component-specific Sass, use the `when-dark-theme` mixin from `packages/ui/src/utils/_mixins.scss`. It covers both explicit dark mode and system mode when the OS prefers dark:
+When an override truly has to live in component-specific Sass, use the `when-dark-theme` mixin from `client/assets/stylesheets/shared/mixins/_dark-theme.scss`. It covers both explicit dark mode and system mode when the OS prefers dark:
 
 ```scss
-@use '../../../../packages/ui/src/utils/mixins' as ui-mixins;
+@use 'calypso/assets/stylesheets/shared/mixins/dark-theme' as ui-mixins;
 
 .dashboard-example {
 	background: #fff;
@@ -101,8 +105,6 @@ When an override truly has to live in component-specific Sass, use the `when-dar
 	}
 }
 ```
-
-Adjust the relative import path to match the stylesheet location.
 
 ## Package Components
 

--- a/docs/data-persistence.md
+++ b/docs/data-persistence.md
@@ -186,10 +186,13 @@ A reducer for a state subtree can have a `storageKey` property that is added usi
 const readerReducer = withStorageKey(
 	'reader',
 	combineReducers( {
+		conversations,
 		feeds,
 		follows,
-		streams,
-		teams,
+		recommendedSites,
+		saved,
+		siteBlocks,
+		sites,
 	} )
 );
 ```

--- a/docs/dependency-management.md
+++ b/docs/dependency-management.md
@@ -1,6 +1,6 @@
 # Dependency management
 
-This project uses [yarn v3](https://yarnpkg.com/) to manage its dependencies. It uses workspaces[https://yarnpkg.com/features/workspaces] functionality to manage the monorepo.
+This project uses [yarn v4](https://yarnpkg.com/) to manage its dependencies. It uses workspaces[https://yarnpkg.com/features/workspaces] functionality to manage the monorepo.
 
 ## Working with sub-packages
 
@@ -36,10 +36,10 @@ yarn add <dependency>
 # yarn add lodash
 ```
 
-You should add dependencies to the root project _only_ when it will be used to test and/or build other packages. To do this, run:
+You should add dependencies to the root project _only_ when it will be used to test and/or build other packages. To do this, run `yarn add` from the repo root:
 
 ```
-yarn add -w <dependency>
+yarn add <dependency>
 ```
 
 #### Unpublished package as a dependency
@@ -66,10 +66,10 @@ yarn remove <dependency>
 # yarn remove lodash
 ```
 
-To delete a dependency of the root project, run:
+To delete a dependency of the root project, run the following from the repo root:
 
 ```
-yarn remove -w lodash
+yarn remove lodash
 ```
 
 ### Update a dependency
@@ -104,10 +104,10 @@ As before, it will update `react-query` and all its dependencies. But in this ca
 Run
 
 ```
-yarn outdated
+yarn upgrade-interactive
 ```
 
-Note that the output includes which sub-package has the dependency. It is possible that the same dependency is present in many sub-packages (or even in the root project).
+Note that the output includes which sub-package has the dependency. It is possible that the same dependency is present in many sub-packages (or even in the root project). The `yarn outdated` command was removed in yarn v4; `yarn upgrade-interactive` is its replacement.
 
 ### List duplicated dependencies
 

--- a/docs/dependency-management.md
+++ b/docs/dependency-management.md
@@ -1,6 +1,6 @@
 # Dependency management
 
-This project uses [yarn v4](https://yarnpkg.com/) to manage its dependencies. It uses workspaces[https://yarnpkg.com/features/workspaces] functionality to manage the monorepo.
+This project uses [yarn v4](https://yarnpkg.com/) to manage its dependencies. It uses [workspaces](https://yarnpkg.com/features/workspaces) functionality to manage the monorepo.
 
 ## Working with sub-packages
 

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -103,7 +103,7 @@ One such tool is [AnyBar](https://github.com/tonsky/AnyBar) (_macOS only_), a ve
 
 ### Set-up
 
-- Install [AnyBar](https://github.com/tonsky/AnyBar): `brew cask install anybar`
+- Install [AnyBar](https://github.com/tonsky/AnyBar): `brew install --cask anybar`
 - Run it at the default port: `open -a AnyBar`
 - Obtain this [handler shell script](https://gist.github.com/mcsf/56911ae03c6d87ec61429cefc7707cb7/)
 - Optionally, place the script somewhere memorable and make it executable: `chmod +x ~/bin/anybar-calypso`

--- a/docs/guide/0-values.md
+++ b/docs/guide/0-values.md
@@ -1,6 +1,6 @@
 # Calypso Development Values
 
-Before diving into the code, here are few guiding principles we have followed when working on the project. We hope you will find them helpful for better understanding some of the decisions we’ve made.
+Before diving into the code, here are a few guiding principles we have followed when working on the project. We hope you will find them helpful for better understanding some of the decisions we’ve made.
 
 ## 0. We do it all for the user
 

--- a/docs/guide/hello-world.md
+++ b/docs/guide/hello-world.md
@@ -16,7 +16,7 @@ Sections are usually bigger areas of the application that have their own chunk o
 
 Creating a new section is composed of five steps:
 
-1. Add your feature `config/development.json`.
+1. Add your feature to `config/development.json`.
 2. Setup your section folder `client/my-sites/my-section`.
 3. Create a controller `client/my-sites/my-section/controller.js`.
 4. Setup the entry routes in `client/my-sites/my-section/index.js`.
@@ -234,7 +234,7 @@ export const helloWorld = ( context, next ) => {
 };
 ```
 
-In the `Main` constant we are getting our main jsx file for our section. We then place `HelloWorld` element in `context.primary` property, which will be eventually get placed in DOM inside `#primary` div element in `Layout` element.
+In the `Main` constant we are getting our main jsx file for our section. We then place `HelloWorld` element in `context.primary` property, which will eventually be placed in DOM inside `#primary` div element in `Layout` element.
 
 (If you want to see where `context.primary` is used open `client/layout/index.jsx`.)
 

--- a/docs/guide/monorepo.md
+++ b/docs/guide/monorepo.md
@@ -10,7 +10,7 @@ Directories with packages are:
 
 - `/packages` — projects and libraries that we might publish as [NPM packages](https://docs.npmjs.com/about-packages-and-modules). Typically used also elsewhere in Calypso. See "Publishing" below.
 - `/apps` — WPCOM plugins
-- `/desktop` - WP Desktop app. Currently this is not part of the monorepo in the sense that it has its own dependency tree (its own `yarn.lock`). The reason is we want a lean `node_modules` because it will be bundled with the WP Desktop app.
+- `/desktop` - WP Desktop app. A full workspace member of the monorepo.
 - `/client` - Calypso app.
 - `/test/e2e` - Package to run e2e tests
 
@@ -114,8 +114,8 @@ failing to do so, will make your package work correctly in the dev build but tre
 	"files": [ "dist", "src" ],
 	"scripts": {
 		"clean": "npx rimraf dist",
-		"prepublish": "yarn run clean",
-		"prepare": "transpile"
+		"prepublishOnly": "yarn run clean",
+		"build": "transpile"
 	}
 }
 ```
@@ -173,10 +173,8 @@ yarn workspace @automattic/your-package run your-script
 
 When developing packages in Calypso repository that external consumers (like Jetpack repository) depend on, you might want to test them without going through the publishing flow first.
 
-1. Enter the package you're testing
-1. Run [`yarn link`](https://classic.yarnpkg.com/en/docs/cli/link/) — the package will be installed on global scope and symlinked to the folder in Calypso
 1. Enter the consumer's folder (such as Jetpack)
-1. Type `yarn link @automattic/package-name` — the package will be symlinked between Calypso and Jetpack and any modifications you make in Calypso, will show up in Jetpack.
+1. Run [`yarn link /absolute/path/to/wp-calypso/packages/your-package`](https://yarnpkg.com/cli/link) — the package will be symlinked between Calypso and the consumer, and any modifications you make in Calypso will show up in the consumer.
 1. Remember to build your changes between modifications in Calypso.
 
 Note that if you're building with Webpack, you may need to turn off [`resolve.symlinks`](https://webpack.js.org/configuration/resolve/#resolvesymlinks) for it to work as expected.

--- a/docs/guide/tech-behind-calypso.md
+++ b/docs/guide/tech-behind-calypso.md
@@ -25,12 +25,9 @@ Calypso is developed on Github, and we use Git extensively. Git is extremely pow
 Essential Git resources:
 
 - The [Pro Git](http://git-scm.com/book/en/v2) book is online and free. It's a great resource, both for beginners and for intermediate users (few dare to call themselves advanced).
-- [git ready](http://gitready.com) – byte-sized tips
 - Several shorter articles with tips:
-  - [A few git tips you didn't know about](http://mislav.uniqpath.com/2010/07/git-tips/)
-  - [25 Tips for Intermediate Git Users](https://www.andyjeffries.co.uk/25-tips-for-intermediate-git-users/)
+  - [A few git tips you didn't know about](https://mislav.net/2010/07/git-tips/)
   - [Stupid Git Tricks](http://webchick.net/stupid-git-tricks)
-  - [9 Awesome Git Tricks](http://www.tychoish.com/posts/9-awesome-git-tricks/)
 - Some operations are easier using a GUI. [GitX](http://rowanj.github.io/gitx/) is a simple one for OS X. [Fugitive](https://github.com/tpope/vim-fugitive) is a must for `vim`. The GitHub app doesn’t entirely fit our workflow, but you can use it for pulling and committing. One caveat is that you will have to do all rebasing manually.
 
 Key concepts checklist:
@@ -50,7 +47,7 @@ The way we use Git with Calypso is described in the [Git Workflow document](../g
 
 - [page.js](http://visionmedia.github.io/page.js/) – router used in most sections of Calypso. New sections are using other libraries like TanStack Router.
 - [express.js](http://expressjs.com) – light server-side framework we use to serve the initial page
-- [webpack](http://webpack.github.io) – building a JavaScript bundle of all of our modules and making sure loading them works just fine
+- [webpack](https://webpack.js.org) – building a JavaScript bundle of all of our modules and making sure loading them works just fine
 - [Babel](https://babeljs.io) – for transpiling ES2015+ and JSX
 
 ## Other technologies used in Calypso that are now deprecated

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -8,7 +8,14 @@ Translated texts are [split into chunks loaded via JSON asynchronously](translat
 
 ## Best Practices
 
-The recommended way to use [i18n-calypso](../packages/i18n-calypso/README.md) in Calypso is through `useTranslate()` for function components and custom hooks, and `props.translate()` from the `localize()` higher-order component for class components.
+Calypso has two coexisting client architectures with different i18n libraries:
+
+- **Classic Calypso** (`client/me/`, `client/my-sites/`, and other Redux-based sections) uses [i18n-calypso](../packages/i18n-calypso/README.md).
+- **Dashboard** (`client/dashboard/`) uses [`@wordpress/i18n`](https://www.npmjs.com/package/@wordpress/i18n) (with [`@wordpress/react-i18n`](https://www.npmjs.com/package/@wordpress/react-i18n) for React components). New Dashboard code should use `__()`, `_n()`, `_x()`, etc. from `@wordpress/i18n`, and `useI18n()` from `@wordpress/react-i18n` when subscription to locale changes is required.
+
+### i18n-calypso (classic Calypso)
+
+The recommended way to use [i18n-calypso](../packages/i18n-calypso/README.md) in classic Calypso is through `useTranslate()` for function components and custom hooks, and `props.translate()` from the `localize()` higher-order component for class components.
 
 Both methods ensure that the component subscribes to i18n events and re-renders when translation data is updated. This is crucial because translation data is loaded asynchronously, and components might render before translations are available. Otherwise, components could initially display English text and fail to update when translations are loaded.
 

--- a/docs/icons.md
+++ b/docs/icons.md
@@ -36,13 +36,13 @@ It was decided to make the icons medium blue instead of WordPress.com blue for c
 
 The favicon requires additional work, as it needs to be highly compressed and work at tiny sizes:
 
-- Do use the same general general design guidelines as the apps, medium blue and white.
+- Do use the same general design guidelines as the apps, medium blue and white.
 - Don't use roundrects or squares, use a circle
 - Don't bake in a drop shadow into the icon
 
 The 16px icon is the important one. It needs extra pixelhinting in order to work. But do any larger sizes (32, 64, 96) on the same grid as the 16px ones, don't change the design just because there are more pixels to work with. The 192px version is used by Android bookmarks, so if you like you can use the Android icon of the same size for this resolution.
 
-Once the favicons and saved as high quality PNGs, are designed, run the files through [ImageAlpha](https://pngmini.com/) to compress them as much as you can. The best way to compress them is to reduce the number of colors in the image. This app is amazing for that. You can shave off up to 70% of the filesize by reducing from 256 to maybe 32 colors, whatever is visually sufficient. Once they're through ImageAlpha, run them through [ImageOptim](https://imageoptim.com/) for further shavings.
+Once the favicons are designed and saved as high quality PNGs, run the files through [ImageAlpha](https://pngmini.com/) to compress them as much as you can. The best way to compress them is to reduce the number of colors in the image. This app is amazing for that. You can shave off up to 70% of the filesize by reducing from 256 to maybe 32 colors, whatever is visually sufficient. Once they're through ImageAlpha, run them through [ImageOptim](https://imageoptim.com/) for further shavings.
 
 Finally, build the favicon. Only include 16 and 32px sizes directly in the .ico file. If you need a 64px version, include it through a separate meta tag:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -14,7 +14,7 @@ You can install Calypso directly on your machine by following the next steps, or
 
 To be able to clone the repository and run the application you need:
 
-- Install the [Node.js](http://nodejs.org/) and matching [NPM](https://www.npmjs.com/) [versions](https://nodejs.org/en/download/releases/) listed in the `"engines"` section of [package.json](https://github.com/Automattic/wp-calypso/blob/HEAD/package.json) **(this bit about versions is important, that's why I'm using bold)**. On Mac OS X and Linux using [nvm](https://github.com/creationix/nvm) or [n](https://github.com/tj/n) makes it easy to manage `node` versions. On Windows you may want to try [nvm-windows](https://github.com/coreybutler/nvm-windows) or [nodist](https://github.com/marcelklehr/nodist).
+- Install the [Node.js](http://nodejs.org/) and matching [Yarn](https://yarnpkg.com/) [versions](https://nodejs.org/en/download/releases/) listed in the `"engines"` section of [package.json](https://github.com/Automattic/wp-calypso/blob/HEAD/package.json) **(this bit about versions is important, that's why I'm using bold)**. On Mac OS X and Linux using [nvm](https://github.com/creationix/nvm) or [n](https://github.com/tj/n) makes it easy to manage `node` versions. On Windows you may want to try [nvm-windows](https://github.com/coreybutler/nvm-windows) or [nodist](https://github.com/marcelklehr/nodist).
 - Please note that in Debian/Ubuntu versions of Linux, `node` command is renamed to `nodejs`. This will cause Calypso to fail during installation. Follow the instructions [here](https://stackoverflow.com/a/18130296) to create a symlink to `node`.
 - [Git](http://git-scm.com/). Try the `git` command from your terminal, if it's not found then use this [installer](http://git-scm.com/download/).
 
@@ -54,7 +54,7 @@ To find all available sections in the main entry point, you can refer to the [se
 Additionally, in Calypso, we use multiple [Webpack entry points](https://webpack.js.org/concepts/entry-points/) for separating concerns and serving smaller bundles to the user at any given time.
 Building a limited number of entry points speeds up the build process, and to allow that, the `ENTRY_LIMIT` environment variable is available to allow building and running only a specific entry point.
 
-For example: `ENTRY_LIMIT=entry-login,entry-main npm start` would start Calypso and only build the login and the main entry points.
+For example: `ENTRY_LIMIT=entry-login,entry-main yarn start` would start Calypso and only build the login and the main entry points.
 
 To find all available entry points, you can refer to the `entry` option in Calypso's primary `webpack.config.js` file.
 

--- a/docs/isomorphic-routing.md
+++ b/docs/isomorphic-routing.md
@@ -37,14 +37,7 @@ as that has a lot of dependencies that aren't ready for server-side rendering.
   `index.web.js` files for the server and client side inside your section, as many
   components needed on the client side aren't server-side ready yet. For more on
   that, see [Server-side Rendering docs](server-side-rendering.md).
-- Keep in mind that a lot of sections still render directly to the `#primary` and
-  `#secondary` `<div />`s. Unfortunately, React cannot handle switching between those
-  sections and a section that renders its entire component tree at once (a _single-tree
-  rendered_ section). For this reason, we have to unmount and re-render component
-  trees when switching between these two types of sections. We do this in a `page()`
-  handler in [`client/boot`](../client/boot/index.js). You'll have to locate that
-  handler and add your isomorphic section to the `singleTreeSections` array of allowed sections.
-- Behind the scenes, we're using a [util](../server/isomorphic-routing/README.md) that adapts `page.js` style middleware to [Express](https://expressjs.com/en/guide/routing.html)',
+- Behind the scenes, we're using a [util](../client/server/isomorphic-routing/README.md) that adapts `page.js` style middleware to [Express](https://expressjs.com/en/guide/routing.html)',
   our server router's middleware signatures. We might want to switch to an isomorphic
   router in the future.
 

--- a/docs/isomorphic-routing.md
+++ b/docs/isomorphic-routing.md
@@ -37,7 +37,7 @@ as that has a lot of dependencies that aren't ready for server-side rendering.
   `index.web.js` files for the server and client side inside your section, as many
   components needed on the client side aren't server-side ready yet. For more on
   that, see [Server-side Rendering docs](server-side-rendering.md).
-- Behind the scenes, we're using a [util](../client/server/isomorphic-routing/README.md) that adapts `page.js` style middleware to [Express](https://expressjs.com/en/guide/routing.html)',
+- Behind the scenes, we're using a [util](../client/server/isomorphic-routing/README.md) that adapts `page.js` style middleware to [Express](https://expressjs.com/en/guide/routing.html),
   our server router's middleware signatures. We might want to switch to an isomorphic
   router in the future.
 

--- a/docs/lockfile.md
+++ b/docs/lockfile.md
@@ -6,7 +6,7 @@ exact version we have installed in our node_modules.
 
 ## Generating The Lockfile
 
-Yarn will automattically generate and update the lock file whenever `yarn`, `yarn install` or `yarn add` is called. If you've manually updated a `package.json` file then Yarn will update the lock file as necessary.
+Yarn will automatically generate and update the lock file whenever `yarn`, `yarn install` or `yarn add` is called. If you've manually updated a `package.json` file then Yarn will update the lock file as necessary.
 
 ## Testing
 

--- a/docs/modularized-state.md
+++ b/docs/modularized-state.md
@@ -139,7 +139,7 @@ import Thing from '../';
 
 describe( 'Thing', () => {
 	test( 'renders correctly', () => {
-		const store = createReduxStore();
+		const store = createReduxStore( {} );
 		// Instantiate and test component
 	} );
 } );
@@ -149,13 +149,14 @@ Setting the store globally should be enough to solve these issues:
 
 ```js
 import { createReduxStore } from 'calypso/state';
+import { getStateFromCache } from 'calypso/state/initial-state';
 import { setStore } from 'calypso/state/redux-store';
 import Thing from '../';
 
 describe( 'Thing', () => {
 	test( 'renders correctly', () => {
-		const store = createReduxStore();
-		setStore( store, currentUserId );
+		const store = createReduxStore( {} );
+		setStore( store, getStateFromCache( currentUserId ) );
 		// Instantiate and test component
 	} );
 } );

--- a/docs/our-approach-to-data.md
+++ b/docs/our-approach-to-data.md
@@ -216,7 +216,7 @@ What are a few common use-cases for selectors?
 - Resolving references: A [normalized state tree](#data-normalization) is ideal from the standpoint of minimizing redundancy and synchronization concerns, but is not as developer-friendly to use. Selectors can be helpful in restoring convenient access to useful objects.
 - Derived data: A normalized state tree avoids storing duplicated data. However, it can be useful to request a value which is calculated based on state data. For example, it might be valuable to retrieve the hostname for a site, which can be calculated based on its URL property.
 - Filtering data: You can use a selector to return a subset of a state tree value. For example, a `getJetpackSites` selector could return an array of all known sites filtered to only those which are Jetpack-enabled.
-- **Side-note:** In this case, you could achieve a similar effect with a reducer function aggregating an array of Jetpack site IDs. If you were to take this route, you'd probably want a complementary selector anyways. Caching concerns on selectors can be overcome by using memoization techniques (for example, with Calypso's `lib/create-selector` or `lib/tree-select`).
+- **Side-note:** In this case, you could achieve a similar effect with a reducer function aggregating an array of Jetpack site IDs. If you were to take this route, you'd probably want a complementary selector anyways. Caching concerns on selectors can be overcome by using memoization techniques (for example, with Calypso's `createSelector` from `@automattic/state-utils` or `@automattic/tree-select`).
 
 ### UI State
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -32,10 +32,9 @@ Some notes:
 If you want to know why a certain module is bundled you can use `whybundled` to find out. See the following for an example on usage:
 
 ```sh
-yarn run preanalyze-bundles
 yarn run whybundled -- [module]
 
-npn run whybundled -- is-my-json-valid
+yarn run whybundled -- is-my-json-valid
 ```
 
 This should give you an overview on where this module got bundled and which file are requiring it:

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -42,7 +42,7 @@ The last middleware before `makeLayout` is usually section-specific; and most of
 Middleware specific to the my-sites group:
 
 - `navigation` generates the section group's sidebar in `context.secondary`
-- `siteSelection` parses the current route, looking out for something that looks like a URL or numeric site ID, and sets the currently selected site based on this information. You can then find it by using the `getSelectedSiteId` selector found in `state/sites/selectors`.
+- `siteSelection` parses the current route, looking out for something that looks like a URL or numeric site ID, and sets the currently selected site based on this information. You can then find it by using the `getSelectedSiteId` selector found in `state/ui/selectors`.
 - `sites` renders a site selector menu for the user to select a site, and will then append that site's slug to current route.
 
 Content-rendering middleware:

--- a/docs/rtl.md
+++ b/docs/rtl.md
@@ -1,10 +1,3 @@
 # RTL Testing
 
 To test the Calypso interface in RTL-mode, you need to set your interface language to something which is RTL (e.g. Hebrew) at [Me → Account](https://wordpress.com/me/account).
-
-If you are testing in your local development environment, you will also need to:
-
-- Change `rtl` to `true` in `config/development.json`.
-- Restart your local server (`Ctrl-c`, then `yarn start` again).
-
-These additional steps are required because we don't have a user on the server-side in your local environment. On WP.com, we know who the user is, so we can programmatically determine if we should be running in RTL mode.

--- a/docs/server-side-rendering.md
+++ b/docs/server-side-rendering.md
@@ -6,14 +6,14 @@ tl;dr: Don't depend on the DOM/BOM; make sure your initial render is synchronous
 
 ## React Components
 
-React components used on the server will be rendered to HTML by being passed to a [renderToString()](https://facebook.github.io/react/docs/top-level-api.html#reactdomserver.rendertostring) call, which calls `componentWillMount()` and `render()` _once_. This means that any components used by a server-side rendered section need to satisfy the following constraints:
+React components used on the server will be rendered to HTML by being passed to a [renderToString()](https://facebook.github.io/react/docs/top-level-api.html#reactdomserver.rendertostring) call, which calls `UNSAFE_componentWillMount()` (the renamed/deprecated `componentWillMount()`) and `render()` _once_. This means that any components used by a server-side rendered section need to satisfy the following constraints:
 
 - Must not rely on event handling for the initial render.
-- Must not hook up any change listeners, or do anything asynchronous, inside `componentWillMount()`.
+- Must not hook up any change listeners, or do anything asynchronous, inside `UNSAFE_componentWillMount()`.
 - All data must be available before the initial render.
 - Mutating class-level variables should be avoided, as they will be persisted until a server restart.
-- Must not change component ID during `componentWillMount`.
-- Must not assume that the DOM/BOM exists in `render()` and `componentWillMount()`.
+- Must not change component ID during `UNSAFE_componentWillMount`.
+- Must not assume that the DOM/BOM exists in `render()` and `UNSAFE_componentWillMount()`.
 
 ## Libraries
 
@@ -26,22 +26,20 @@ Because it is necessary to serve the redux state along with a server-rendered pa
 
 ### Data Cache
 
-At render time, the Redux state is [serialized and cached](../server/render/index.js), using the current path as the cache key, unless there is a query string, in which case we don't cache.
+At render time, the Redux state is [serialized and cached](../client/server/render/index.js), using the current path as the cache key, unless there is a query string, in which case we don't cache.
 
 This means that all data that was fetched to render a given page is available the next time the corresponding route is hit. A section controller thus only needs to check if the required data is available (using selectors), and dispatch the corresponding fetching action if it isn't; see the [themes controller](../client/my-sites/themes/controller.jsx) for an example.
 
 ### Render Cache
 
-There is a [shared cache](../server/render/index.js) for rendered layouts. There are some requirements for using this cache:
+There is a [shared cache](../client/server/render/index.js) for rendered layouts. There are some requirements for using this cache:
 
 1. Cache entries need a way to expire
 2. Multiple paths resulting in the same rendered content should ideally map to one cache entry
 
-These requirements are met by allowing controllers to set a key for a request in `context.renderCacheKey`. For item (1) the timestamp from the data cache is added to the request path, so a path such as `/theme/mood/overview` results in a key of `/theme/mood/overview1485514728996`. When the associated data cache entry gets a new timestamp, the server cache entry will no longer get any hits and drop out of the cache.
+These requirements are met by deriving the cache key from the request via `getCacheKey(req)` in [`client/server/isomorphic-routing/index.js`](../client/server/isomorphic-routing/index.js). The key is built from the request's normalized path (path plus sorted query string) combined with the GDPR banner flag, e.g. `/theme/mood/overview:gdpr=false`.
 
-Item (2) is solved by using an error string for the render cache key. For example, any invalid path such as `/theme/invalid` or `/theme/invalid/support` results in setting `context.renderCacheKey` to `theme not found`, meaning that the 404 page is always ready to serve and takes up only one cache slot.
-
-If `context.renderCacheKey` is not set, stringified `context.layout` is used as the key.
+For item (2), when the request has an error (e.g. an invalid path like `/theme/invalid`), the error message is used as the render cache key in place of the path-based key, so the 404 page is always ready to serve and takes up only one cache slot.
 
 When working with the SSR cache, turning on the [debug](#debugging) is very useful.
 
@@ -64,7 +62,7 @@ Here's how your module's `package.json` should look, if you really want to do th
 
 ### Stubbing a module on the server side
 
-If you know that your code will never be called on the server, you can stub-out the module using `NormalModuleReplacementPlugin` in the [config file](https://github.com/Automattic/wp-calypso/blob/HEAD/webpack.config.node.js), and make the same change in the Desktop [config](https://github.com/Automattic/wp-desktop/blob/HEAD/webpack.shared.js).
+If you know that your code will never be called on the server, you can stub-out the module using `NormalModuleReplacementPlugin` in the [config file](https://github.com/Automattic/wp-calypso/blob/HEAD/client/webpack.config.node.js), and make the same change in the Desktop [config](https://github.com/Automattic/wp-desktop/blob/HEAD/webpack.shared.js).
 
 ## Debugging
 

--- a/docs/testing/component-tests.md
+++ b/docs/testing/component-tests.md
@@ -4,13 +4,13 @@ Calypso has a lot of React UI components. (Try for example running `find . -name
 
 ## [Getting started](#getting-started)
 
-To run all current client side tests, run `yarn run test-client` from within the Calypso source. You can also run individual tests, see [Testing overview](testing-overview.md#how-to-run-a-smaller-subset-of-test-files) for more details.
+To run all current client side tests, run `yarn run test-client` from within the Calypso source. You can also run individual tests, see [Testing overview](testing-overview.md) for more details.
 
 Going through the current tests is a good way to get ideas for how different kinds of things can be tested.
 
 ### [Set up a test environment](#setting-up-environment)
 
-It's very possible that your tests will assume the existence of a browser environment to work properly. The test runner we use, [Jest](https://facebook.github.io/jest), uses the browser-like environment [jsdom](https://github.com/tmpvar/jsdom). We default to a node-like environment to make tests faster. If some tests require another environment, you can add `/** @jest-environment jsdom */` docblock. Check [this Jest doc](https://facebook.github.io/jest/docs/en/configuration.html#testenvironment-string) to learn more.
+It's very possible that your tests will assume the existence of a browser environment to work properly. The test runner we use, [Jest](https://facebook.github.io/jest), uses the browser-like environment [jsdom](https://github.com/jsdom/jsdom). We default to a node-like environment to make tests faster. If some tests require another environment, you can add `/** @jest-environment jsdom */` docblock. Check [this Jest doc](https://facebook.github.io/jest/docs/en/configuration.html#testenvironment-string) to learn more.
 
 ### [What to test?](#what-to-test)
 
@@ -76,16 +76,9 @@ test( 'should remove tokens when X icon clicked', async () => {
 
 Like their name suggests, unit tests should be targeting only one clear unit at a time. Try to minimize the amount of code you're calling outside the targeted code. This other code could be for example subcomponents, mixins, or just other functions than the one you're testing.
 
-### [Shallow rendering](#shallow-rendering)
+### [Mocking child components](#mocking-child-components)
 
-Shallow rendering helps with inspecting whether our component renders correctly, without having to render subcomponents. Lets hear it from Facebook themselves:
-
-> When writing unit tests for React, shallow rendering can be helpful. Shallow rendering lets you
-> render a component “one level deep” and assert facts about what its render method returns,
-> without worrying about the behavior of child components, which are not instantiated or rendered.
-> This does not require a DOM.
->
-> <https://reactjs.org/docs/shallow-renderer.html#overview>
+Sometimes it's useful to inspect whether our component renders correctly without exercising the behavior of its subcomponents. With `@testing-library/react` there is no equivalent of Enzyme's `shallow` renderer; the recommended technique is to stub child components with `jest.mock` so only the component under test runs its real code.
 
 For a complete example of usage, see `client/components/themes-list/test/index.jsx`.
 
@@ -109,10 +102,14 @@ class ThemesList extends React.Component {
 So we test it like this:
 
 ```javascript
-import { render, screen } from '@testing-library/react';
-import EmptyContent from 'calypso/components/empty-content';
-import Theme from 'calypso/components/theme';
+import { screen } from '@testing-library/react';
+import deepFreeze from 'deep-freeze';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { ThemesList } from '../';
+
+jest.mock( 'calypso/components/theme', () => ( { theme } ) => (
+	<div data-testid={ `theme-${ theme.id }` } />
+) );
 
 const defaultProps = deepFreeze( {
 	themes: [
@@ -123,24 +120,22 @@ const defaultProps = deepFreeze( {
 } );
 
 test( 'should render a div with a className of "themes-list"', () => {
-	const { container } = render( <ThemesList { ...defaultProps } /> );
-	expect( container ).toMatchSnapshot();
+	const { container } = renderWithProvider( <ThemesList { ...defaultProps } /> );
 	expect( container.firstChild ).toHaveClass( 'themes-list' );
-	expect( container.querySelectorAll( '.theme' ) ).toHaveLength( defaultProps.themes.length );
 } );
 
 test( 'should render a <Theme /> child for each provided theme', () => {
-	const { container } = render( <ThemesList { ...defaultProps } /> );
-	expect( container.querySelectorAll( '.theme' ) ).toHaveLength( defaultProps.themes.length );
+	renderWithProvider( <ThemesList { ...defaultProps } /> );
+	expect( screen.getAllByTestId( /theme-/ ) ).toHaveLength( defaultProps.themes.length );
 } );
 
-test( 'should display the EmptyContent component when no themes are provided', () => {
-	const { container } = render( <ThemesList { ...defaultProps } themes={ [] } /> );
-	expect( container ).toBeEmptyDOMElement();
+test( 'should display a message when no themes are found', () => {
+	renderWithProvider( <ThemesList { ...defaultProps } themes={ [] } /> );
+	expect( screen.getByText( /No themes match your search/i ) ).toBeInTheDocument();
 } );
 ```
 
-By using `shallow`, we avoid rendering the `Theme` components when testing `ThemesList`.
+By mocking `calypso/components/theme` with `jest.mock`, we avoid rendering the real `Theme` components when testing `ThemesList`.
 
 ## Troubleshooting
 
@@ -171,7 +166,7 @@ See [#18064](https://github.com/Automattic/wp-calypso/pull/18064) for full examp
 
 ## Enzyme support
 
-Historically, we used to support [`enzyme`](https://github.com/enzymejs/enzyme), but support was dropped in favor of `@testing-library/react`, the primary reason being the fact that it was incompatible with React 18, and we are aiming at unblocking the upgrade to React 18. There were additional motivations, like being able to write more accessible tests and being able to test closer to what the user actually experiences.
+Historically, we used to support [`enzyme`](https://github.com/enzymejs/enzyme), but support was dropped in favor of `@testing-library/react`, the primary reason being the fact that it was incompatible with React 18, which Calypso now uses. There were additional motivations, like being able to write more accessible tests and being able to test closer to what the user actually experiences.
 
 Previously, `enzyme` was provided by the `@automattic/calypso-jest` package as part of the testing infrastructure. Nowadays, in the Calypso monorepo, it's recommended to use `@testing-library/react` for component tests.
 

--- a/docs/testing/faq.md
+++ b/docs/testing/faq.md
@@ -10,8 +10,9 @@ End-to-end tests use [Playwright](https://playwright.dev/docs/intro) to interact
 
 ### How to run all tests?
 
-Executing `yarn test` from the root folder will run all test suites.
-Behind the scenes we maintain 4 test configurations. This is because each of them (`client`, `packages`, `server`, and `build-tools`) has their own requirements.
+Executing `yarn test` from the root folder runs four unit-test suites: `test-client`, `test-packages`, `test-server`, and `test-build-tools`. Each of those configurations has its own requirements.
+
+Integration tests are not part of `yarn test`; run them separately with `yarn test-integration`. End-to-end tests live in `test/e2e/` and are run from there — see `test/e2e/README.md`.
 
 ### How to run a smaller subset of test files?
 

--- a/docs/testing/faq.md
+++ b/docs/testing/faq.md
@@ -11,11 +11,11 @@ End-to-end tests use [Playwright](https://playwright.dev/docs/intro) to interact
 ### How to run all tests?
 
 Executing `yarn test` from the root folder will run all test suites.
-Behind the scenes we maintain 3 test configuration. This is because each of them (`client`, `server`, and `integration`) has their own requirements.
+Behind the scenes we maintain 4 test configurations. This is because each of them (`client`, `packages`, `server`, and `build-tools`) has their own requirements.
 
 ### How to run a smaller subset of test files?
 
-We have a yarn run script for each tests type: `yarn run test-client`, `yarn run test-server`, `yarn run test-integration`.
+We have a yarn run script for each tests type: `yarn run test-client`, `yarn run test-packages`, `yarn run test-server`, `yarn run test-build-tools`, `yarn run test-integration`.
 You can pass a filename, folder name or matching pattern to these scripts to narrow down number of executed tests.
 
 Example for client:

--- a/docs/testing/snapshot-testing.md
+++ b/docs/testing/snapshot-testing.md
@@ -87,7 +87,7 @@ describe( 'MyComponent', () => {
 } );
 ```
 
-Reducer tests are also be a great fit for snapshots. The firsts snapshots introduced in Calypso were
+Reducer tests are also a great fit for snapshots. The firsts snapshots introduced in Calypso were
 actually [reducer tests](https://github.com/Automattic/wp-calypso/blob/e34d15f44c261fd7daa2212017e995883866d603/client/state/comments/test/selectors.js#L133-L142).
 Reducers can be large, complex data structures that we don't want to change unexpectedly, exactly
 what snapshots excel at!

--- a/docs/testing/unit-tests.md
+++ b/docs/testing/unit-tests.md
@@ -167,8 +167,6 @@ Because we're passing the list as an argument, we can pass mock `validValuesList
 
 `expect( isValueValid( 'hulk', [ 'batman', 'superman' ] ) ).toBe( false );`
 
-`expect( isValueValid( 'hulk', null ) ).toBe( false );`
-
 `expect( isValueValid( 'hulk', [] ) ).toBe( false );`
 
 `expect( isValueValid( 'hulk', [ 'iron man', 'hulk' ] ) ).toBe( true );`
@@ -192,7 +190,7 @@ To test the behaviour under each condition, we stub the config object and use a 
 import { isEnabled } from '@automattic/calypso-config';
 import { isBilboVisible } from '../bilbo';
 
-jest.mock( 'config', () => ( {
+jest.mock( '@automattic/calypso-config', () => ( {
 	// bilbo is visible by default
 	isEnabled: jest.fn( () => false ),
 } ) );

--- a/docs/translation-chunks.md
+++ b/docs/translation-chunks.md
@@ -32,7 +32,7 @@ Build script downloads all language translations from <https://widgets.wp.com/la
 
 ### Build Script
 
-Build script can be run with `yarn run build-languages` and it will basically execute `bin/build-languages.js`, but it would only work if both `public/calypso-strings.pot` or `public/chunks-map.json` exist.
+Build script can be run with `yarn run build-languages`; it runs `yarn run translate` (generating `public/calypso-strings.pot`) and then executes `bin/build-languages.js`, but it requires `public/chunks-map.json` to already exist.
 
 To ensure you have the required files, you need to build or run a development environment with either `BUILD_TRANSLATION_CHUNKS=true yarn run build` / `ENABLE_FEATURES=use-translation-chunks yarn run build` or `BUILD_TRANSLATION_CHUNKS=true yarn run start` / `ENABLE_FEATURES=use-translation-chunks yarn run start` respectively.
 
@@ -55,13 +55,13 @@ When conditions are met, the server will load the JS format of the initially req
 
 #### Language manifest
 
-Language manifest file is resolved by either having `window.i18nLanguageManifest` when it's loaded by using a script tag and the `.js` format, or by fetching the `.json` file from `public/languages/{localeSlug}-language-manifest.json`.
+Language manifest file is resolved by either having `window.i18nLanguageManifest` when it's loaded by using a script tag and the `.js` format, or by fetching the `.json` file from `/calypso/languages/{localeSlug}-language-manifest.json`.
 
 It contains the locale data and an array of translated chunks filenames. It is used to set the locale of Calypso with the initially required locale data.
 
 #### Translation chunk files
 
-Translation chunk file is resolved by either having `window.i18nTranslationChunks[chunk]` when it's loaded by using a script tag and the `.js` format, or by fetching the `.json` file from `public/languages/{localeSlug}-{chunk}.json`.
+Translation chunk file is resolved by either having `window.i18nTranslationChunks[chunk]` when it's loaded by using a script tag and the `.js` format, or by fetching the `.json` file from `/calypso/languages/{localeSlug}-{chunk}.json`.
 
 It contains the translation strings that specific chunk includes and is used with `i18n.addTranslations` from `i18n-calypso` to extend translations in runtime.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -102,7 +102,7 @@ When you open <http://calypso.localhost:3000> in your browser and you encounter 
 
 ### It runs, but I'm not seeing any of my changes
 
-Webpack may be having issues with watching - [see their documentation on troubleshooting watching](https://webpack.github.io/docs/troubleshooting.html#watching).
+Webpack may be having issues with watching - [see their documentation on troubleshooting watching](https://webpack.js.org/configuration/watch/).
 
 #### Domain other than calypso.localhost
 

--- a/docs/typography.md
+++ b/docs/typography.md
@@ -95,6 +95,7 @@ The following variables adhere to the type scale and save you from having to cal
 | `$font-title-large`      | 32     | 2     |
 | `$font-title-medium`     | 24     | 1.5   |
 | `$font-title-small`      | 20     | 1.25  |
+| `$font-body-large`       | 18     | 1.125 |
 | `$font-body`             | 16     | 1     |
 | `$font-body-small`       | 14     | 0.875 |
 | `$font-body-extra-small` | 12     | 0.75  |

--- a/packages/components/src/circular-progress-bar/README.md
+++ b/packages/components/src/circular-progress-bar/README.md
@@ -3,7 +3,7 @@
 This component is used to display a circular progress bar as part of the cohesive Launchpad Experience and is only meant to be used in the context of Launchpad.
 See <https://cylonp2.wordpress.com/2022/12/14/a-cohesive-launchpad-experience>
 It displays a gray circle and another blue circle on top of it showing the progress.
-It renders text in the center in the center: X/Y where X is the current step and Y is the total number of steps
+It renders text in the center: X/Y where X is the current step and Y is the total number of steps
 The currentStep and numberOfSteps props are used to calculate represent the current progress as a fraction
 
 ## How to use

--- a/packages/components/src/component-swapper/README.md
+++ b/packages/components/src/component-swapper/README.md
@@ -1,6 +1,6 @@
 # ComponentSwapper
 
-`ComponentSwapper` is a react component that can be used to swap components at a specified breakpoint. For example a buttons navigation to a dropdown for samll screens.
+`ComponentSwapper` is a react component that can be used to swap components at a specified breakpoint. For example a buttons navigation to a dropdown for small screens.
 
 ## Properties
 
@@ -10,11 +10,11 @@ CSS class to be applied to a root div.
 
 ### `breakpoint { string } - default: '<660px'`
 
-A breakpoint that trigger component replacement. Only breakopints from `mediaQueryLists` from '@automattic/viewport' are accepted.
+A breakpoint that triggers component replacement. Only breakpoints from `mediaQueryLists` from '@automattic/viewport' are accepted.
 
 ### `onSwap { function }`
 
-A function that can be triggered when components are swapped. It uses `useEffect` hook so it's also triggered when the componnet loads.
+A function that can be triggered when components are swapped. It uses `useEffect` hook so it's also triggered when the component loads.
 
 ### `breakpointActiveComponent { React component }`
 
@@ -26,7 +26,7 @@ React component rendered when the breakpoint condition is inactive.
 
 ### `children`
 
-The component acceprt children nodes and renders them after `breakpointActiveComponent|breakpointInactiveComponent`.
+The component accepts children nodes and renders them after `breakpointActiveComponent|breakpointInactiveComponent`.
 
 ## Usage notes
 

--- a/packages/components/src/responsive-toolbar-group/README.md
+++ b/packages/components/src/responsive-toolbar-group/README.md
@@ -21,7 +21,7 @@ import Discover from 'calypso/my-sites/plugins/categories/responsive-toolbar-gro
 - `className`[string]: A classname to add to the ToolBarGroupComponent. (optional).
 - `hideRatio`[number]: The ratio in which the components are considered to be hidden, for example the default ratio of 0.99 will hide the element when 99% of it is visible (1% of it isn't visible). We rely on ([IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#thresholds)) (optional).
 - `showRatio`[number]: The ratio in which the components are considered to be shown, for example the default ratio of 1 will show the element when 100% of it will be visible. We rely on ([IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#thresholds)) (optional).
-- `rootMargin`[string]: take a look at ([take a look at the IntersectionObserver docs](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/rootMargin)) (optional).
+- `rootMargin`[string]: take a look at the [IntersectionObserver docs](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/rootMargin) (optional).
 - `onClick`[( index: number) => void]: A callback function that receives the index of the children being clicked. (optional).
 - `initialActiveIndex`[number]: The initial active index of the component. (optional).
 - `swipeBreakpoint`[string]: The breakpoint used to switch to a mobile friendly version of the toolbar optimized for swiping with no menu collapse. (optional, defaults to "<660px")

--- a/packages/components/src/site-thumbnail/README.md
+++ b/packages/components/src/site-thumbnail/README.md
@@ -21,7 +21,7 @@ function render() {
 - `width`: an optional number used for mShot and image style
 - `height`: an optional number used for mShot and image style
 - `dimensionsSrcset`: an optional Array of {width, height} to append to `srcSet`
-- `sizesAttr`: an optional string for image size attribute for resopnsive
+- `sizesAttr`: an optional string for image size attribute for responsive
 - `children`: an optional node to render inside if mshot fails or is empty
 - `bgColorImgUrl`: an optional string for creating a blur background
 - `viewport`: an optional number for mShot window size

--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -316,7 +316,7 @@ The signature of the function returned by this hook is: `( paymentMethodId: stri
 A React Hook that returns an object with the following properties to be used by [payment methods](#payment-methods) for storing and communicating the current status of the transaction. This differs from the current status of the _form_, which is handled by [useFormStatus](#useFormStatus). Note, however, that [CheckoutProvider](#CheckoutProvider) will automatically perform certain actions when the transaction status changes. See [CheckoutProvider](#CheckoutProvider) for the details.
 
 - `transactionStatus: `[`TransactionStatus`](#TransactionStatus). The current status of the transaction.
-- `previousTransactionStatus: `[`TransactionStatus.`](#TransactionStatus). The last status of the transaction.
+- `previousTransactionStatus: `[`TransactionStatus`](#TransactionStatus). The last status of the transaction.
 - `transactionError: string | null`. The most recent error message encountered by the transaction if its status is [`.ERROR`](#TransactionStatus).
 - `transactionRedirectUrl: string | null`. The redirect url to use if the transaction status is [`.REDIRECTING`](#TransactionStatus).
 - `transactionLastResponse: unknown | null`. The most recent full response object as returned by the transaction's endpoint and passed to `setTransactionComplete`.

--- a/packages/data-stores/README.md
+++ b/packages/data-stores/README.md
@@ -42,7 +42,7 @@ For example:
 
 ## Old registration method
 
-Some stores have not yet been migrated to use the new registration method. To use these stores, you must register them manually.)
+Some stores have not yet been migrated to use the new registration method. To use these stores, you must register them manually.
 
 ```tsx
 import { FooStore } from '@automattic/data-stores';

--- a/packages/eslint-plugin-wpcalypso/docs/rules/i18n-no-collapsible-whitespace.md
+++ b/packages/eslint-plugin-wpcalypso/docs/rules/i18n-no-collapsible-whitespace.md
@@ -5,7 +5,7 @@ it can make translation more difficult and lead to unnecessary retranslation.
 
 The short version is that this includes line-breaks, carriage-returns, tabs, and consecutive spaces. The [HTML whitespace spec](https://www.w3.org/TR/CSS21/text.html#white-space-model) allows for tabs in some cases, but we don't. Please use HTML for formatting, not whitespace, as this sidesteps any translation issues.
 
-Whitespace can be appropriate in longer translatable content, for example a whole blog post. These cases are unlikey to occur in the code scanned by eslint but if they do, [disable the rule with inline coments](http://eslint.org/docs/user-guide/configuring#disabling-rules-with-inline-comments). ( e.g. `// eslint-disable-line i18n-no-collapsible-whitespace` ).
+Whitespace can be appropriate in longer translatable content, for example a whole blog post. These cases are unlikely to occur in the code scanned by eslint but if they do, [disable the rule with inline comments](http://eslint.org/docs/user-guide/configuring#disabling-rules-with-inline-comments). ( e.g. `// eslint-disable-line i18n-no-collapsible-whitespace` ).
 
 ## Rule Details
 

--- a/packages/explat-client-react-helpers/README.md
+++ b/packages/explat-client-react-helpers/README.md
@@ -21,7 +21,7 @@ This is the React Interface for the standalone client for Automattic's ExPlat. T
 />;
 ```
 
-- The simplest and safest way to experiement, but not useful everywhere.
+- The simplest and safest way to experiment, but not useful everywhere.
 - For those not using typescript, make sure you provide all the Experience props.
 
 ## API: `useExperiment('experiment_name')`

--- a/packages/help-center/README.md
+++ b/packages/help-center/README.md
@@ -15,10 +15,10 @@ The Help Center is a bit complicated because it runs in multiple different envir
 3. In Atomic sites
    - as a plugin to Gutenberg editor.
      - A plugin when the site is connected to Jetpack.
-     - A minimal plugin when the site is disconnected from Jetpack. This plugiy simple links to wp.com/help.
+     - A minimal plugin when the site is disconnected from Jetpack. This plugin simply links to wp.com/help.
    - as a wpadminbar menu item.
      - A menu item that opens the Help Center when connected to Jetpack.
-     - A minimal plugin when the site is disconnected from Jetpack. This plugiy simple links to wp.com/help.
+     - A minimal plugin when the site is disconnected from Jetpack. This plugin simply links to wp.com/help.
 
 ### How to debug the Help Center
 

--- a/packages/onboarding/src/select-items/README.md
+++ b/packages/onboarding/src/select-items/README.md
@@ -9,5 +9,5 @@ Items used in the IntentScreen. They consist of a title, description, and icon.
 - **description** _string_ - text explaining the item, not translated or wrapped.
 - **icon**: _ReactElement_ - uses WordPress _Icon_ component and sets it to 24px
 - **value**: _string_ - passed to onClick/onSelect handler to identify the item.
-- **actionText**: _sring_ - text for the button.
+- **actionText**: _string_ - text for the button.
 - **hidden**: _boolean_ - if true, item is hidden.

--- a/packages/typography/README.md
+++ b/packages/typography/README.md
@@ -28,7 +28,7 @@ Apply font variables as needed:
 }
 ```
 
-### Import the `fonts.sccc` file
+### Import the `fonts.scss` file
 
 `@import '@automattic/typography/styles/fonts';`
 

--- a/packages/verbum-block-editor/README.md
+++ b/packages/verbum-block-editor/README.md
@@ -54,7 +54,7 @@ This package can be utilized in two primary ways:
   1. Navigate to the package's directory: `cd packages/verbum-block-editor`.
   2. Execute `yarn dev --sync`.
   3. Changes are synchronized to `/home/wpcom/public_html/widgets.wp.com/verbum-block-editor` on your sandbox.
-  4. **This this version, `wp.i18n` global is expected to be present**.
+  4. **In this version, `wp.i18n` global is expected to be present**.
 
 ### Deploying Changes
 

--- a/packages/webpack-rtl-plugin/README.md
+++ b/packages/webpack-rtl-plugin/README.md
@@ -54,7 +54,7 @@ module.exports = {
 };
 ```
 
-This will create the normal `style.css` and an additionnal `style.rtl.css`.
+This will create the normal `style.css` and an additional `style.rtl.css`.
 
 ## Options
 

--- a/packages/wpcom-xhr-request/README.md
+++ b/packages/wpcom-xhr-request/README.md
@@ -41,7 +41,7 @@ $ npm install wpcom-xhr-request
 `Params`: optional parameters
 
 - `method`: `GET` as default.
-- `apiNamespace`: `WP-API` namepsace.
+- `apiNamespace`: `WP-API` namespace.
 - `apiVersion`: `REST-API` app version - `1` as default.
 - `proxyOrigin`: `https://public-api.wordpress.com` as default.
 - `token`: token authentication.

--- a/packages/wpcom.js/docs/follow.md
+++ b/packages/wpcom.js/docs/follow.md
@@ -6,7 +6,7 @@
 
 ### Follow(site-id, WPCOM);
 
-Createa a new `Follow` instance giving `site-id` and `WPCOM` instance.
+Create a new `Follow` instance giving `site-id` and `WPCOM` instance.
 
 ```js
 const follower = Follow( '<site-id>', WPCOM );
@@ -42,7 +42,7 @@ wpcom
 	.site( 'blog.wordpress.com' )
 	.follow()
 	.del( function ( err, data ) {
-		// respnose handler
+		// response handler
 	} );
 ```
 

--- a/packages/wpcom.js/docs/post.md
+++ b/packages/wpcom.js/docs/post.md
@@ -78,7 +78,7 @@ More info in [Comment doc page](./comment.md).
 
 ### Post#comments()
 
-Recent recent comments
+Return recent comments
 
 ```js
 wpcom

--- a/packages/wpcom.js/docs/site.md
+++ b/packages/wpcom.js/docs/site.md
@@ -150,7 +150,7 @@ Returns stats [comment followers](https://developer.wordpress.com/docs/api/1.1/g
 
 ```js
 site.statsComments( function ( err, data ) {
-	// data comment-follwers response
+	// data comment-followers response
 } );
 ```
 
@@ -264,7 +264,7 @@ site.statsTags( function ( err, data ) {
 } );
 ```
 
-### Site#statsTopAutors([query, ]fn)
+### Site#statsTopAuthors([query, ]fn)
 
 Returns [top authors](https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/stats/top-authors/) data.
 

--- a/test/README.md
+++ b/test/README.md
@@ -1,11 +1,14 @@
 ## Testing configuration
 
-At the moment we maintain four different group of tests. You can find configurations for all of them in the following subfolders:
+At the moment we maintain seven different group of tests. You can find configurations for all of them in the following subfolders:
 
 - `client` - unit and component tests for code located in `client` top level folder.
 - `integration` - integration tests for code located in `bin`, `client` and `server` top level folders.
 - `server` - unit tests for code located in `server` top level folder.
 - `e2e` - automated tests for the entire project.
+- `apps` - unit tests for code located in `apps` top level folder.
+- `packages` - unit tests for code located in `packages` top level folder.
+- `build-tools` - unit tests for code located in `build-tools` top level folder.
 
 Check [testing overview](../docs/testing/testing-overview.md) to learn more how all those test configurations are consumed by [Jest](https://facebook.github.io/jest/) testing platform to ensure proper code quality of Calypso codebase.
 

--- a/test/README.md
+++ b/test/README.md
@@ -1,6 +1,6 @@
 ## Testing configuration
 
-At the moment we maintain seven different group of tests. You can find configurations for all of them in the following subfolders:
+At the moment we maintain seven different groups of tests. You can find configurations for all of them in the following subfolders:
 
 - `client` - unit and component tests for code located in `client` top level folder.
 - `integration` - integration tests for code located in `bin`, `client` and `server` top level folders.


### PR DESCRIPTION
## Proposed Changes

* Audit and fix correctness/staleness issues across 31 files under `docs/`, plus `test/README.md`.
* 61 distinct fixes spanning broken-link, stale-api, wrong-path, broken-example, version-drift, missing-context, and contradiction categories.
* Notable changes:
  * `docs/dependency-management.md`, `docs/guide/monorepo.md` — updated Yarn v1/v3 instructions to Yarn v4 (current repo version).
  * `docs/coding-guidelines/css.md` — node-sass → Dart Sass; corrected RTL pipeline description (now via `@automattic/webpack-rtl-plugin`); fixed `_z-index.scss` path.
  * `docs/dark-mode.md` — fixed `when-dark-theme` mixin location and `@use` example; added missing `@media screen` wrapper to match `client/dashboard/app/style.scss`.
  * `docs/server-side-rendering.md` — replaced `context.renderCacheKey` description with current `getCacheKey()` from `client/server/isomorphic-routing/index.js`; updated paths from `server/` to `client/server/`; `componentWillMount` → `UNSAFE_componentWillMount`.
  * `docs/data-persistence.md`, `docs/modularized-state.md` — updated reader sub-reducer example and `setStore`/`createReduxStore` call signatures to match current source.
  * `docs/our-approach-to-data.md` — `lib/create-selector`/`lib/tree-select` → `@automattic/state-utils` and `@automattic/tree-select`.
  * `docs/i18n.md` — clarified Classic Calypso uses `i18n-calypso`, Dashboard uses `@wordpress/i18n` (resolves contradiction with `client/AGENTS.md`).
  * `docs/rtl.md` — removed stale `rtl: true` config-flag instructions (the flag was removed from the config system).
  * `docs/isomorphic-routing.md` — removed obsolete `singleTreeSections` paragraph (file and array no longer exist).
  * `docs/testing/component-tests.md` — rewrote "Shallow rendering" section as "Mocking child components" to match current React Testing Library usage in `client/components/themes-list/test/index.jsx`.
  * Several broken external links replaced with current canonical URLs (W3C, jsx-eslint, webpack.js.org, etc.) or removed where no equivalent exists.
* Each commit is scoped to a single file; commit message is `docs: fix <path>` with a per-finding bullet list.

## Why are these changes being made?

Documentation drift accumulates silently — APIs get renamed, file paths move, external sites go dark — and broken docs mislead readers into copying code that no longer works or chasing 404s. This batch addresses the verifiable defects (correctness and staleness) discovered in a sweep across the repo's global documentation. Style, voice, and prose-quality issues are out of scope and unchanged.

## Testing Instructions

* Skim the diff; every change is to a markdown file.
* Spot-check the resolved findings against current source — e.g., `grep -n 'getSelectedSiteId' client/state/ui/selectors/index.js`, `grep -n 'getCacheKey' client/server/isomorphic-routing/index.js`, `grep -n 'when-dark-theme' client/assets/stylesheets/shared/mixins/_dark-theme.scss`.
* Render the affected pages on GitHub to confirm markdown structure is intact (tables in `docs/typography.md`, code fences throughout, bulleted lists in `docs/guide/tech-behind-calypso.md`).

## Known follow-ups (not blockers, but worth a separate pass)

* `docs/CONTRIBUTING.md` line 77 still links to the renamed `#setting-up-githooks` anchor — out of per-file scope here.
* Several cross-cutting URL-rot patterns (Jest `facebook.github.io/jest/...`, React `facebook.github.io/react/...`, `developer.wordpress.com/calypso/`, classic.yarnpkg.com) touch multiple files and would be best handled as one coordinated sweep.
* `docs/testing/component-tests.md` example closely mirrors a specific test file; consider generalizing if it tends to drift.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?
