### PR TITLE
Support: disable submit and suggestions while Help Center scripts load

### DIFF
--- a/apps/happy-blocks/block-library/search-card/index.php
+++ b/apps/happy-blocks/block-library/search-card/index.php
@@ -134,7 +134,7 @@ $website                 = isset( $args['website'] ) ? $args['website'] : '';
 				<input type="hidden" name="group_id" value="blog_id:<?php echo esc_attr( get_current_blog_id() ); ?>"/>
 				<div class="input-wrapper" dir="auto">
 					<input id="support-search-input" type="search" name="odie-query"<?php echo $input_class ? ' class="' . esc_attr( $input_class ) . '"' : ''; ?> placeholder="<?php echo esc_attr( $placeholder ); ?>"/>
-					<button type="submit" class="search-submit-button button-primary" aria-label="<?php echo esc_attr( __( 'Search', 'happy-blocks' ) ); ?>" disabled>
+					<button type="submit" class="search-submit-button button-primary" aria-label="<?php echo esc_attr( __( 'Search', 'happy-blocks' ) ); ?>">
 						<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
 							<path d="M12.2197 5C12.4186 5 12.6094 5.07902 12.75 5.21967L17 9.46967C17.2929 9.76256 17.2929 10.2374 17 10.5303C16.7071 10.8232 16.2322 10.8232 15.9393 10.5303L12.9697 7.56067V18.25C12.9697 18.6642 12.6339 19 12.2197 19C11.8055 19 11.4697 18.6642 11.4697 18.25V7.56065L8.5 10.5303C8.2071 10.8232 7.73223 10.8232 7.43934 10.5303C7.14644 10.2374 7.14645 9.76256 7.43934 9.46967L11.6894 5.21967C11.83 5.07902 12.0208 5 12.2197 5Z" fill="currentColor"/>
 						</svg>
@@ -144,13 +144,42 @@ $website                 = isset( $args['website'] ) ? $args['website'] : '';
 
 			<?php if ( $show_search_suggestions ) : ?>
 				<ul class="search-terms">
-					<li><button data-search-query="<?php echo esc_attr( __( 'Connect a domain', 'happy-blocks' ) ); ?>" data-website="<?php echo esc_attr( $website ); ?>" disabled><?php echo esc_html( __( 'Connect a domain', 'happy-blocks' ) ); ?></button></li>
-					<li><button data-search-query="<?php echo esc_attr( __( 'Upgrade my plan', 'happy-blocks' ) ); ?>" data-website="<?php echo esc_attr( $website ); ?>" disabled><?php echo esc_html( __( 'Upgrade my plan', 'happy-blocks' ) ); ?></button></li>
-					<li><button data-search-query="<?php echo esc_attr( __( 'Add email', 'happy-blocks' ) ); ?>" data-website="<?php echo esc_attr( $website ); ?>" disabled><?php echo esc_html( __( 'Add email', 'happy-blocks' ) ); ?></button></li>
-					<li><button data-search-query="<?php echo esc_attr( __( 'Reset my password', 'happy-blocks' ) ); ?>" data-website="<?php echo esc_attr( $website ); ?>" disabled><?php echo esc_html( __( 'Reset my password', 'happy-blocks' ) ); ?></button></li>
+					<li><button data-search-query="<?php echo esc_attr( __( 'Connect a domain', 'happy-blocks' ) ); ?>" data-website="<?php echo esc_attr( $website ); ?>"><?php echo esc_html( __( 'Connect a domain', 'happy-blocks' ) ); ?></button></li>
+					<li><button data-search-query="<?php echo esc_attr( __( 'Upgrade my plan', 'happy-blocks' ) ); ?>" data-website="<?php echo esc_attr( $website ); ?>"><?php echo esc_html( __( 'Upgrade my plan', 'happy-blocks' ) ); ?></button></li>
+					<li><button data-search-query="<?php echo esc_attr( __( 'Add email', 'happy-blocks' ) ); ?>" data-website="<?php echo esc_attr( $website ); ?>"><?php echo esc_html( __( 'Add email', 'happy-blocks' ) ); ?></button></li>
+					<li><button data-search-query="<?php echo esc_attr( __( 'Reset my password', 'happy-blocks' ) ); ?>" data-website="<?php echo esc_attr( $website ); ?>"><?php echo esc_html( __( 'Reset my password', 'happy-blocks' ) ); ?></button></li>
 				</ul>
 			<?php endif; ?>
 		</fieldset>
+		<script>
+		( function () {
+			var fieldset = document.querySelector( '.support-search-form-container' );
+			var form = document.getElementById( 'support-search-form' );
+			if ( ! fieldset || ! form ) return;
+
+			function disableAll() {
+				var els = fieldset.querySelectorAll( 'input, button' );
+				for ( var i = 0; i < els.length; i++ ) els[ i ].disabled = true;
+			}
+
+			form.addEventListener( 'submit', function ( e ) {
+				if ( ! window.__hcFormReady ) {
+					e.preventDefault();
+					window.__hcPendingQuery = new FormData( form ).get( 'odie-query' );
+					disableAll();
+				}
+			} );
+
+			fieldset.addEventListener( 'click', function ( e ) {
+				var btn = e.target.closest( 'button[data-search-query]' );
+				if ( btn && ! window.__hcFormReady ) {
+					e.preventDefault();
+					window.__hcPendingQuery = btn.getAttribute( 'data-search-query' );
+					disableAll();
+				}
+			} );
+		} )();
+		</script>
 	</div>
 	<?php endif; ?>
 </div>

--- a/apps/happy-blocks/block-library/search-card/index.php
+++ b/apps/happy-blocks/block-library/search-card/index.php
@@ -134,7 +134,7 @@ $website                 = isset( $args['website'] ) ? $args['website'] : '';
 				<input type="hidden" name="group_id" value="blog_id:<?php echo esc_attr( get_current_blog_id() ); ?>"/>
 				<div class="input-wrapper" dir="auto">
 					<input id="support-search-input" type="search" name="odie-query"<?php echo $input_class ? ' class="' . esc_attr( $input_class ) . '"' : ''; ?> placeholder="<?php echo esc_attr( $placeholder ); ?>"/>
-					<button type="submit" class="search-submit-button button-primary" aria-label="<?php echo esc_attr( __( 'Search', 'happy-blocks' ) ); ?>">
+					<button type="submit" class="search-submit-button button-primary" aria-label="<?php echo esc_attr( __( 'Search', 'happy-blocks' ) ); ?>" disabled>
 						<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
 							<path d="M12.2197 5C12.4186 5 12.6094 5.07902 12.75 5.21967L17 9.46967C17.2929 9.76256 17.2929 10.2374 17 10.5303C16.7071 10.8232 16.2322 10.8232 15.9393 10.5303L12.9697 7.56067V18.25C12.9697 18.6642 12.6339 19 12.2197 19C11.8055 19 11.4697 18.6642 11.4697 18.25V7.56065L8.5 10.5303C8.2071 10.8232 7.73223 10.8232 7.43934 10.5303C7.14644 10.2374 7.14645 9.76256 7.43934 9.46967L11.6894 5.21967C11.83 5.07902 12.0208 5 12.2197 5Z" fill="currentColor"/>
 						</svg>
@@ -144,10 +144,10 @@ $website                 = isset( $args['website'] ) ? $args['website'] : '';
 
 			<?php if ( $show_search_suggestions ) : ?>
 				<ul class="search-terms">
-					<li><button data-search-query="<?php echo esc_attr( __( 'Connect a domain', 'happy-blocks' ) ); ?>" data-website="<?php echo esc_attr( $website ); ?>"><?php echo esc_html( __( 'Connect a domain', 'happy-blocks' ) ); ?></button></li>
-					<li><button data-search-query="<?php echo esc_attr( __( 'Upgrade my plan', 'happy-blocks' ) ); ?>" data-website="<?php echo esc_attr( $website ); ?>"><?php echo esc_html( __( 'Upgrade my plan', 'happy-blocks' ) ); ?></button></li>
-					<li><button data-search-query="<?php echo esc_attr( __( 'Add email', 'happy-blocks' ) ); ?>" data-website="<?php echo esc_attr( $website ); ?>"><?php echo esc_html( __( 'Add email', 'happy-blocks' ) ); ?></button></li>
-					<li><button data-search-query="<?php echo esc_attr( __( 'Reset my password', 'happy-blocks' ) ); ?>" data-website="<?php echo esc_attr( $website ); ?>"><?php echo esc_html( __( 'Reset my password', 'happy-blocks' ) ); ?></button></li>
+					<li><button data-search-query="<?php echo esc_attr( __( 'Connect a domain', 'happy-blocks' ) ); ?>" data-website="<?php echo esc_attr( $website ); ?>" disabled><?php echo esc_html( __( 'Connect a domain', 'happy-blocks' ) ); ?></button></li>
+					<li><button data-search-query="<?php echo esc_attr( __( 'Upgrade my plan', 'happy-blocks' ) ); ?>" data-website="<?php echo esc_attr( $website ); ?>" disabled><?php echo esc_html( __( 'Upgrade my plan', 'happy-blocks' ) ); ?></button></li>
+					<li><button data-search-query="<?php echo esc_attr( __( 'Add email', 'happy-blocks' ) ); ?>" data-website="<?php echo esc_attr( $website ); ?>" disabled><?php echo esc_html( __( 'Add email', 'happy-blocks' ) ); ?></button></li>
+					<li><button data-search-query="<?php echo esc_attr( __( 'Reset my password', 'happy-blocks' ) ); ?>" data-website="<?php echo esc_attr( $website ); ?>" disabled><?php echo esc_html( __( 'Reset my password', 'happy-blocks' ) ); ?></button></li>
 				</ul>
 			<?php endif; ?>
 		</fieldset>

--- a/apps/happy-blocks/block-library/search-card/style.scss
+++ b/apps/happy-blocks/block-library/search-card/style.scss
@@ -288,6 +288,11 @@ $breakpoint-desktop: 1440px; //Desktop size.
 				appearance: none;
 				display: none;
 			}
+
+			&:disabled {
+				opacity: 0.6;
+				cursor: not-allowed;
+			}
 		}
 
 		.input-wrapper button {

--- a/apps/happy-blocks/block-library/search-card/style.scss
+++ b/apps/happy-blocks/block-library/search-card/style.scss
@@ -303,6 +303,11 @@ $breakpoint-desktop: 1440px; //Desktop size.
 			align-items: center;
 			justify-content: center;
 
+			&:disabled {
+				opacity: 0.6;
+				cursor: not-allowed;
+			}
+
 			svg {
 				fill: #2c3338;
 			}
@@ -353,6 +358,11 @@ $breakpoint-desktop: 1440px; //Desktop size.
 					font-size: 12px;
 					font-weight: 400;
 					line-height: 20px;
+
+					&:disabled {
+						opacity: 0.5;
+						cursor: not-allowed;
+					}
 
 					&:not(:disabled):hover {
 						background: #3858e9;

--- a/apps/happy-blocks/block-library/search-card/view-odie.js
+++ b/apps/happy-blocks/block-library/search-card/view-odie.js
@@ -16,18 +16,34 @@ document.addEventListener( 'DOMContentLoaded', function () {
 	const form = document.getElementById( 'support-search-form' );
 	const input = document.getElementById( 'support-search-input' );
 
+	// Track whether Help Center scripts are ready.
+	const isLoggedIn = typeof helpCenterData !== 'undefined' && helpCenterData?.currentUser?.ID;
+	let helpCenterReady = Boolean( isLoggedIn );
+
+	const disableForm = () => {
+		if ( input ) {
+			input.setAttribute( 'disabled', '' );
+		}
+		if ( submitButton ) {
+			submitButton.setAttribute( 'disabled', '' );
+		}
+		links.forEach( ( link ) => link.setAttribute( 'disabled', '' ) );
+	};
+
 	const enableForm = () => {
+		if ( input ) {
+			input.removeAttribute( 'disabled' );
+		}
 		if ( submitButton ) {
 			submitButton.removeAttribute( 'disabled' );
 		}
 		links.forEach( ( link ) => link.removeAttribute( 'disabled' ) );
 	};
 
-	const isLoggedIn = typeof helpCenterData !== 'undefined' && helpCenterData?.currentUser?.ID;
-	if ( isLoggedIn ) {
-		enableForm();
-	} else {
-		helpCenterReadyToLoadPromise.then( enableForm );
+	if ( ! helpCenterReady ) {
+		helpCenterReadyToLoadPromise.then( () => {
+			helpCenterReady = true;
+		} );
 	}
 
 	links.forEach( ( link ) => {
@@ -64,6 +80,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 
 				// Use the submitted value, not the input.value since it's already cleared.
 				const searchQuery = new FormData( form ).get( 'odie-query' );
+				input.value = '';
 
 				const website = form.getAttribute( 'data-website' ) || '';
 				recordTracksEvent(
@@ -78,12 +95,21 @@ document.addEventListener( 'DOMContentLoaded', function () {
 				const isLoggedOut = ! helpCenterData?.currentUser?.ID;
 
 				if ( isLoggedOut ) {
-					await helpCenterReadyToLoadPromise;
+					if ( ! helpCenterReady ) {
+						disableForm();
+					}
+					await Promise.race( [
+						helpCenterReadyToLoadPromise,
+						new Promise( ( resolve ) => setTimeout( resolve, 5000 ) ),
+					] );
+					enableForm();
+					if ( ! helpCenterReady ) {
+						return;
+					}
 					window.helpCenter?.loadHelpCenter().then( () => {
 						if ( window.wp?.data?.dispatch ) {
 							const helpCenterDispatch = window.wp.data.dispatch( 'automattic/help-center' );
 
-							input.value = '';
 							helpCenterDispatch.setNavigateToRoute(
 								'/odie?query=' + encodeURIComponent( searchQuery ),
 								true
@@ -93,17 +119,36 @@ document.addEventListener( 'DOMContentLoaded', function () {
 					} );
 				} else if ( window.wp?.data?.dispatch ) {
 					// Logged in variant is already loaded.
+					enableForm();
 					const helpCenterDispatch = window.wp.data.dispatch( 'automattic/help-center' );
-					input.value = '';
 					helpCenterDispatch.setNavigateToRoute(
 						'/odie?query=' + encodeURIComponent( searchQuery ),
 						true
 					);
 					helpCenterDispatch.setShowHelpCenter( true );
+				} else {
+					enableForm();
 				}
 			},
 			true
 		);
+	}
+
+	// Signal that our submit handler is attached, so the inline fallback
+	// stops blocking native form submission.
+	window.__hcFormReady = true;
+
+	// Process any query that was submitted before JS loaded.
+	if ( window.__hcPendingQuery ) {
+		const pendingQuery = window.__hcPendingQuery;
+		delete window.__hcPendingQuery;
+		input.value = pendingQuery;
+		enableForm();
+		submitButton.click();
+	} else {
+		// Only re-enable here if there's no pending query — the submit
+		// handler manages form state when processing a query.
+		enableForm();
 	}
 
 	// Mobile dropdown functionality

--- a/apps/happy-blocks/block-library/search-card/view-odie.js
+++ b/apps/happy-blocks/block-library/search-card/view-odie.js
@@ -40,6 +40,30 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		links.forEach( ( link ) => link.removeAttribute( 'disabled' ) );
 	};
 
+	const enableFormWhenChatAppears = () => {
+		if ( document.querySelector( '.help-center__container' ) ) {
+			enableForm();
+			return;
+		}
+
+		let resolved = false;
+		const observer = new MutationObserver( () => {
+			if ( document.querySelector( '.help-center__container' ) ) {
+				resolved = true;
+				enableForm();
+				observer.disconnect();
+			}
+		} );
+		observer.observe( document.body, { childList: true, subtree: true } );
+
+		setTimeout( () => {
+			if ( ! resolved ) {
+				observer.disconnect();
+				enableForm();
+			}
+		}, 10000 );
+	};
+
 	if ( ! helpCenterReady ) {
 		helpCenterReadyToLoadPromise.then( () => {
 			helpCenterReady = true;
@@ -97,15 +121,16 @@ document.addEventListener( 'DOMContentLoaded', function () {
 				if ( isLoggedOut ) {
 					if ( ! helpCenterReady ) {
 						disableForm();
+						await Promise.race( [
+							helpCenterReadyToLoadPromise,
+							new Promise( ( resolve ) => setTimeout( resolve, 5000 ) ),
+						] );
+						if ( ! helpCenterReady ) {
+							enableForm();
+							return;
+						}
 					}
-					await Promise.race( [
-						helpCenterReadyToLoadPromise,
-						new Promise( ( resolve ) => setTimeout( resolve, 5000 ) ),
-					] );
-					enableForm();
-					if ( ! helpCenterReady ) {
-						return;
-					}
+					enableFormWhenChatAppears();
 					window.helpCenter?.loadHelpCenter().then( () => {
 						if ( window.wp?.data?.dispatch ) {
 							const helpCenterDispatch = window.wp.data.dispatch( 'automattic/help-center' );
@@ -119,7 +144,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 					} );
 				} else if ( window.wp?.data?.dispatch ) {
 					// Logged in variant is already loaded.
-					enableForm();
+					enableFormWhenChatAppears();
 					const helpCenterDispatch = window.wp.data.dispatch( 'automattic/help-center' );
 					helpCenterDispatch.setNavigateToRoute(
 						'/odie?query=' + encodeURIComponent( searchQuery ),

--- a/apps/happy-blocks/block-library/search-card/view-odie.js
+++ b/apps/happy-blocks/block-library/search-card/view-odie.js
@@ -16,6 +16,20 @@ document.addEventListener( 'DOMContentLoaded', function () {
 	const form = document.getElementById( 'support-search-form' );
 	const input = document.getElementById( 'support-search-input' );
 
+	const enableForm = () => {
+		if ( submitButton ) {
+			submitButton.removeAttribute( 'disabled' );
+		}
+		links.forEach( ( link ) => link.removeAttribute( 'disabled' ) );
+	};
+
+	const isLoggedIn = typeof helpCenterData !== 'undefined' && helpCenterData?.currentUser?.ID;
+	if ( isLoggedIn ) {
+		enableForm();
+	} else {
+		helpCenterReadyToLoadPromise.then( enableForm );
+	}
+
 	links.forEach( ( link ) => {
 		link.addEventListener( 'click', function ( e ) {
 			const query = this.dataset.searchQuery;


### PR DESCRIPTION
## Summary

This PR updates the wordpress.com/support form submission with additional feedback while we wait for the required scripts to loaded. After the form submits, we disable the inputs until the chat opens. 

<img width="1659" height="1478" alt="image" src="https://github.com/user-attachments/assets/38257bcb-1af8-44b0-819f-b9b789e380f4" />


## Test plan
- [ ] Load `wordpress.com/support` logged out — submit arrow and suggestion buttons should appear dimmed
- [ ] After Help Center scripts load, buttons should become interactive
- [ ] Load `wordpress.com/support` logged in — no visible disabled flash, buttons work immediately
- [ ] Type a query and click a suggestion button — verify Help Center opens with the query

## Checklist
- [x] No new translations needed (no user-facing string changes)
- [ ] Has been tested on mobile viewports
- [ ] Server-side rendering verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)