### PR TITLE
A4A Plugins: tighten icon column border around the icon

### DIFF
--- a/client/a8c-for-agencies/sections/plugins/style.scss
+++ b/client/a8c-for-agencies/sections/plugins/style.scss
@@ -11,14 +11,12 @@
 		}
 	}
 
-	.dataviews-view-table .dataviews-column-primary__media {
-		max-width: 35px;
-		min-width: 35px;
-		min-height: 35px;
-
-		&::after {
-			box-shadow: none;
-		}
+	.plugin-icon {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		float: none;
+		margin-inline-end: 0;
 	}
 
 	.plugin-manage-sites-pane {

--- a/client/a8c-for-agencies/sections/plugins/style.scss
+++ b/client/a8c-for-agencies/sections/plugins/style.scss
@@ -11,6 +11,16 @@
 		}
 	}
 
+	.dataviews-view-table .dataviews-column-primary__media {
+		max-width: 35px;
+		min-width: 35px;
+		min-height: 35px;
+
+		&::after {
+			box-shadow: none;
+		}
+	}
+
 	.plugin-manage-sites-pane {
 		.hosting-dashboard-layout-column__container {
 			.hosting-dashboard-layout__top-wrapper {


### PR DESCRIPTION
Part of A4A-2637
<!-- Link the related A4A Plugins Linear issue. -->

## Proposed Changes

| Before | After |
|--------|--------|
|  <img width="416" height="352" alt="Screenshot 2026-05-26 at 17 25 19" src="https://github.com/user-attachments/assets/2e3716e8-52ce-4c82-a160-ed6469ec9473" /> | <img width="380" height="314" alt="Screenshot 2026-05-26 at 21 26 24" src="https://github.com/user-attachments/assets/2681db83-235f-47c4-9477-95c86ca7c5de" /> |

* **`a8c-for-agencies/sections/plugins/style.scss`** — scope a `.plugin-icon` override to `.is-section-a8c-for-agencies-plugins`:
  * `display: flex; align-items: center; justify-content: center;` to center the `<img>` inside the 35×35 `.plugin-icon` wrapper.
  * `float: none; margin-inline-end: 0;` to drop the legacy float and right margin that were pushing the icon left and inflating the dataviews flex cell.

## Why are these changes being made?

`PluginIcon` renders a 35×35 `<div class="plugin-icon">` wrapping a 32×32 `<img>`, with a leftover `float: left` and `margin-right` from its classic usage. Inside the dataviews flex cell the right margin counted toward the flex item's outer width, so the cell stretched well past the icon and the inherited `dataviews-column-primary__media` box-shadow border read as a column-wide outline. Centering the `<img>` and zeroing the margin/float makes the existing border hug the icon evenly without touching any `@wordpress/dataviews` selectors.

## Testing Instructions

1. Open the live link and go to **A4A → Plugins**.
2. In the plugin-management table, confirm the icon column border now hugs the 35px icon evenly on all sides.
3. Open a plugin (e.g. `/plugins/manage/sites/jetpack`) to enter the split-view detail mode and confirm the left-pane list still renders its 52px icon correctly.
4. Resize to mobile width and confirm the list-view icon thumbnail is unaffected.
5. Verify there are no TypeScript / React console errors.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
