### PR TITLE
E2E: dismiss Jetpack podcast promo in social editor tests

### DIFF
--- a/test/e2e/specs/jetpack/social__editor-features.ts
+++ b/test/e2e/specs/jetpack/social__editor-features.ts
@@ -32,6 +32,26 @@ const features4BusinessPlan = {
 	socialImageGenerator: true,
 };
 
+async function dismissPodcastPostPublishPromo( editorPage: EditorPage ): Promise< void > {
+	const editorParent = await editorPage.getEditorParent();
+	const dialog = editorParent
+		.getByRole( 'dialog' )
+		.filter( { hasText: 'Ready for the podcast version?' } )
+		.first();
+
+	const isVisible = await dialog
+		.waitFor( { state: 'visible', timeout: 1000 } )
+		.then( () => true )
+		.catch( () => false );
+
+	if ( ! isVisible ) {
+		return;
+	}
+
+	await dialog.getByRole( 'button', { name: /close/i } ).first().click();
+	await dialog.waitFor( { state: 'hidden', timeout: 5 * 1000 } );
+}
+
 const testCases: Array< {
 	plan: string;
 	platform: 'Simple' | 'Atomic';
@@ -176,6 +196,7 @@ describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () 
 				// Publish the post.
 				await editorPage.publish();
 				connectionTestPromise = socialConnectionsManager.waitForConnectionTests();
+				await dismissPodcastPostPublishPromo( editorPage );
 				await editorPage.closeAllPanels();
 
 				// Open the Jetpack sidebar.
@@ -255,6 +276,7 @@ describe( DataHelper.createSuiteTitle( 'Social: Editor features' ), function () 
 
 				// Publish the post.
 				await editorPage.publish();
+				await dismissPodcastPostPublishPromo( editorPage );
 
 				// Verify whether the manual sharing is available on post publish panel
 				manualSharing = ( await editorPage.getPublishPanelRoot() ).getByRole( 'button', {


### PR DESCRIPTION
## Proposed Changes

* Dismiss the optional Podcast post-publish promo in Jetpack Social editor feature tests after publishing.
* Keep the existing Jetpack Social assertions unchanged.

## Why are these changes being made?

* The Podcast promo can cover the editor after publish and block the test from reopening Jetpack settings.
* The test should still verify Jetpack Social behavior, not fail on an unrelated post-publish promo.

## Testing Instructions

* `yarn prettier --check test/e2e/specs/jetpack/social__editor-features.ts`
* `yarn eslint --ext .ts test/e2e/specs/jetpack/social__editor-features.ts`
* `git diff --check`
* `CALYPSO_BASE_URL=<staging Calypso URL> yarn workspace wp-e2e-tests test specs/jetpack/social__editor-features.ts --runInBand --testNamePattern='Should verify that resharing'`
* `CALYPSO_BASE_URL=<staging Calypso URL> yarn workspace wp-e2e-tests test specs/jetpack/social__editor-features.ts --runInBand --testNamePattern='Should verify that manual sharing'`
* `CALYPSO_BASE_URL=<staging Calypso URL> yarn workspace wp-e2e-tests test specs/jetpack/social__editor-features.ts --runInBand`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
