### PR TITLE
Reader: fix Full-post view click handling and blank stream

### DIFF
--- a/client/reader/data/stream/build-query-params.js
+++ b/client/reader/data/stream/build-query-params.js
@@ -155,7 +155,15 @@ export function buildStreamQueryParams( {
 		number = gap ? PER_GAP : fetchCount;
 	}
 	const lang = localeSlug || i18n.getLocaleSlug();
-	const commonQueryParams = { ...algorithm, feed_id: feedId };
+	// Omit `feed_id` when not set: the new `wpcom/v2/read/streams/*` endpoints
+	// validate it as an integer and reject the empty string the URL serializer
+	// would produce from `null`/`undefined`. The legacy `rest/v1.2/read/*`
+	// endpoints tolerated the empty value, which is why this only surfaced
+	// after the stream-data-layer migration (f3b2cddb32e).
+	const commonQueryParams = {
+		...algorithm,
+		...( feedId != null ? { feed_id: feedId } : {} ),
+	};
 
 	if ( isPoll ) {
 		if ( streamType === 'user' ) {

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -38,11 +38,8 @@ interface RecentProps {
 	viewToggle?: React.ReactNode;
 }
 
-// Unique row key for a stream item. `postId` alone is not unique across
-// feeds/blogs (numeric IDs collide), so we prefix with the source identifier
-// — `blogId` for WP.com / Jetpack-connected sites, `feedId` for external
-// feeds — to keep `getItemId`, the `selection` prop, the `posts` lookup and
-// `itemRefs` consistent. See READ-476.
+// `postId` is not unique across feeds/blogs; prefix with `b{blogId}` for
+// WP.com/Jetpack sites or `f{feedId}` for external feeds so row keys stay unique.
 export const getStreamItemKey = ( item: StreamListItem ): string => {
 	if ( isPaddingStreamItem( item ) ) {
 		return item.postId;

--- a/client/reader/recent/index.tsx
+++ b/client/reader/recent/index.tsx
@@ -38,7 +38,21 @@ interface RecentProps {
 	viewToggle?: React.ReactNode;
 }
 
-const postIdString = ( item: StreamListItem ) => item.postId?.toString() ?? '';
+// Unique row key for a stream item. `postId` alone is not unique across
+// feeds/blogs (numeric IDs collide), so we prefix with the source identifier
+// — `blogId` for WP.com / Jetpack-connected sites, `feedId` for external
+// feeds — to keep `getItemId`, the `selection` prop, the `posts` lookup and
+// `itemRefs` consistent. See READ-476.
+export const getStreamItemKey = ( item: StreamListItem ): string => {
+	if ( isPaddingStreamItem( item ) ) {
+		return item.postId;
+	}
+	if ( item.postId == null ) {
+		return '';
+	}
+	const source = item.blogId != null ? `b${ item.blogId }` : `f${ item.feedId ?? '' }`;
+	return `${ source }-${ item.postId }`;
+};
 
 const Recent = ( { viewToggle }: RecentProps ) => {
 	const dispatch = useDispatch();
@@ -119,7 +133,7 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 				return acc;
 			}
 
-			acc[ `${ item.feedId }-${ item.postId }` ] = {
+			acc[ getStreamItemKey( item ) ] = {
 				...post,
 				site_icon: post.site_icon ?? siteIconsByFeedId[ Number( item.feedId ) ],
 			} as PostItem;
@@ -129,10 +143,7 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 	}, [ cachedPosts, postItems, siteIconsByFeedId ] );
 
 	const getPostFromItem = useCallback(
-		( item: StreamItem ) => {
-			const postKey = `${ item?.feedId }-${ item?.postId }`;
-			return posts[ postKey ];
-		},
+		( item: StreamItem ) => posts[ getStreamItemKey( item ) ],
 		[ posts ]
 	);
 
@@ -197,10 +208,10 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 						);
 					}
 					return (
-						<div onFocus={ () => handleItemFocus( postIdString( item ) ) }>
+						<div onFocus={ () => handleItemFocus( getStreamItemKey( item ) ) }>
 							<RecentPostField
 								ref={ ( el ) => {
-									itemRefs.current[ postIdString( item ) ] = el;
+									itemRefs.current[ getStreamItemKey( item ) ] = el;
 								} }
 								post={ getPostFromItem( item ) }
 								onClick={ () => selectItem( item ) }
@@ -264,7 +275,7 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 			if ( event.key === 'Enter' && focusedIndexRef.current !== null ) {
 				// Use the focused index to determine the selected item
 				const focusedItem = shownData.find(
-					( item ) => item.postId?.toString() === focusedIndexRef.current
+					( item ) => getStreamItemKey( item ) === focusedIndexRef.current
 				);
 				if ( focusedItem && ! isPaddingStreamItem( focusedItem ) ) {
 					selectItem( focusedItem );
@@ -284,7 +295,7 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 					<DataViews< StreamListItem >
 						config={ { perPageSizes: [ 15, 30, 50, 100 ] } }
 						getItemId={ ( item: StreamListItem, index = 0 ) =>
-							item.postId?.toString() ?? `item-${ index }`
+							getStreamItemKey( item ) || `item-${ index }`
 						}
 						view={ view }
 						fields={ fields }
@@ -297,10 +308,10 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 						paginationInfo={ view.search === '' ? defaultPaginationInfo : paginationInfo }
 						defaultLayouts={ { list: {} } }
 						isLoading={ isLoading }
-						selection={ selectedItem ? [ postIdString( selectedItem ) ] : [] }
+						selection={ selectedItem ? [ getStreamItemKey( selectedItem ) ] : [] }
 						onChangeSelection={ ( newSelection: string[] ) => {
 							const selectedPost = streamItems.find(
-								( item: StreamListItem ) => item.postId?.toString() === newSelection[ 0 ]
+								( item: StreamListItem ) => getStreamItemKey( item ) === newSelection[ 0 ]
 							);
 							if ( selectedPost && ! isPaddingStreamItem( selectedPost ) ) {
 								selectItem( selectedPost );
@@ -328,7 +339,7 @@ const Recent = ( { viewToggle }: RecentProps ) => {
 							feedId={ selectedItem.feedId }
 							postId={ selectedItem.postId }
 							onClose={ () => {
-								const focusItem = itemRefs.current[ selectedItem?.postId?.toString() ?? '' ];
+								const focusItem = itemRefs.current[ getStreamItemKey( selectedItem ) ];
 								if ( ! isWide ) {
 									setSelectedItem( null );
 								}

--- a/client/reader/recent/test/get-stream-item-key.test.ts
+++ b/client/reader/recent/test/get-stream-item-key.test.ts
@@ -1,0 +1,36 @@
+import { getStreamItemKey } from '../index';
+import type { StreamItem } from 'calypso/reader/data/stream';
+
+const wpcomPost = ( blogId: number, postId: number ): StreamItem => ( { blogId, postId } );
+const externalPost = ( feedId: number, postId: number ): StreamItem => ( { feedId, postId } );
+
+describe( 'getStreamItemKey', () => {
+	it( 'returns distinct keys for two WP.com/Jetpack posts that share a postId across blogs', () => {
+		// Regression for READ-476: Dawn's repro had two Jetpack-on-custom-domain
+		// blogs (Skeptic's Kaddish, Iris Carden) whose posts shared a `postId`.
+		// Keyed on `postId` alone, `DataViews.onChangeSelection` returned the
+		// already-selected post and the reading pane never updated.
+		const a = getStreamItemKey( wpcomPost( 200, 7 ) );
+		const b = getStreamItemKey( wpcomPost( 300, 7 ) );
+		expect( a ).not.toEqual( b );
+	} );
+
+	it( 'returns distinct keys for an external feed item and a blog item that share a postId', () => {
+		const blog = getStreamItemKey( wpcomPost( 200, 7 ) );
+		const feed = getStreamItemKey( externalPost( 200, 7 ) );
+		expect( blog ).not.toEqual( feed );
+	} );
+
+	it( 'returns the same key for repeated lookups of the same item', () => {
+		const item = wpcomPost( 200, 7 );
+		expect( getStreamItemKey( item ) ).toEqual( getStreamItemKey( item ) );
+	} );
+
+	it( 'returns the padding postId verbatim for padding rows', () => {
+		expect( getStreamItemKey( { isPadding: true, postId: 'padding-3' } ) ).toBe( 'padding-3' );
+	} );
+
+	it( 'returns an empty string when postId is missing on a real item', () => {
+		expect( getStreamItemKey( { blogId: 200 } as StreamItem ) ).toBe( '' );
+	} );
+} );

--- a/client/reader/recent/test/get-stream-item-key.test.ts
+++ b/client/reader/recent/test/get-stream-item-key.test.ts
@@ -6,10 +6,9 @@ const externalPost = ( feedId: number, postId: number ): StreamItem => ( { feedI
 
 describe( 'getStreamItemKey', () => {
 	it( 'returns distinct keys for two WP.com/Jetpack posts that share a postId across blogs', () => {
-		// Regression for READ-476: Dawn's repro had two Jetpack-on-custom-domain
-		// blogs (Skeptic's Kaddish, Iris Carden) whose posts shared a `postId`.
-		// Keyed on `postId` alone, `DataViews.onChangeSelection` returned the
-		// already-selected post and the reading pane never updated.
+		// Two Jetpack blogs whose posts share a `postId`: keyed on `postId`
+		// alone, `DataViews.onChangeSelection` returned the already-selected
+		// post and the reading pane never updated.
 		const a = getStreamItemKey( wpcomPost( 200, 7 ) );
 		const b = getStreamItemKey( wpcomPost( 300, 7 ) );
 		expect( a ).not.toEqual( b );


### PR DESCRIPTION
Fixes READ-476

## Proposed Changes

* Key Recent-view rows on `b{blogId}` / `f{feedId}` + `postId` instead of `postId` alone, so DataViews `getItemId` / `selection` / `onChangeSelection` / `itemRefs` and the internal `posts` lookup never collide between two items that share a numeric `postId`.
* Omit `feed_id` from `buildStreamQueryParams` when the caller doesn't pass one — the new `wpcom/v2/read/streams/*` endpoints reject `feed_id=` (empty string) with a 400.
* Add a unit test that locks in the different-blog-same-`postId` case.

## Why are these changes being made?

In the Reader Full-post view, clicking a row sometimes failed to update the reading pane — the row highlighted blue but the pane stayed stuck on the previously selected post. Cause: every selection-related slot keyed on `postId` alone. `postId` is unique within a feed/blog but not across them, so `onChangeSelection`'s `find()` returned the first colliding match (the already-selected item) and React skipped the re-render because the reference was unchanged. The reproducible case came from Jetpack-on-custom-domain sites — those arrive as `{ blogId, postId }` with no `feedId`, so keying on `feedId-postId` (as the `posts` lookup already did) would still collide between any pair of such blogs sharing a `postId`.

While verifying the fix in the browser I found a sibling regression introduced by f3b2cddb32e (#110971): `usePaginatedStream` and `useInfiniteStream` always serialize `feed_id`, sending `feed_id=` when no feed is scoped. The legacy `rest/v1.2/read/*` endpoints tolerated that; the new v2 endpoints validate it as an integer and 400 the request, leaving DataViews in `no-results` — which is the "reading pane stays completely blank" half of the user reports. Bundled here because it was blocking the smoke test.

## Testing Instructions

1. Go to `/reader/` and switch the view toggle to **Full post**.
2. Confirm the post list populates (before this PR the underlying `wpcom/v2/read/streams/following` call 400'd on `feed_id=` and the list rendered "No results").
3. Click a row that isn't the auto-selected first one. The reading pane should load that post.
4. Click several more rows in succession, including re-clicking one you visited earlier. The pane should update on every click — no stuck state, no rows that highlight blue without changing the pane.
5. Bonus repro for the original collision: anywhere you have two Jetpack-on-custom-domain feeds whose latest posts share a numeric `postId` (the original user surfaced this with `skepticskaddish.com` and `iriscardenauthor.blog`), both should now be selectable independently.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?