### PR TITLE
APM: Read plugin span context from the nested plugins object

### DIFF
--- a/client/dashboard/sites/performance/backend/request-detail/span-tree.tsx
+++ b/client/dashboard/sites/performance/backend/request-detail/span-tree.tsx
@@ -99,11 +99,11 @@ function SpanRowContent( { node, rootMaxMs }: { node: SpanNode; rootMaxMs: numbe
 	const fraction = rootMaxMs > 0 ? totalMs / rootMaxMs : 0;
 	const intent = CATEGORY_INTENT[ node.category ] ?? 'default';
 	const subtitleParts: string[] = [];
-	if ( node.plugin ) {
-		subtitleParts.push( node.plugin );
+	if ( node.plugins?.plugin ) {
+		subtitleParts.push( node.plugins.plugin );
 	}
-	if ( node.callback_source ) {
-		subtitleParts.push( node.callback_source );
+	if ( node.plugins?.callback_source ) {
+		subtitleParts.push( node.plugins.callback_source );
 	}
 	const showSelf = selfMs > 0 && selfMs < totalMs;
 	const callsPerTx = node.count / Math.max( 1, node.tx_count );

--- a/packages/api-core/src/site-hosting-apm/types.ts
+++ b/packages/api-core/src/site-hosting-apm/types.ts
@@ -239,6 +239,12 @@ export interface ApmDetailSpanPrunedChildren {
 	total_sum_ms: number;
 }
 
+export interface ApmDetailSpanPluginInfo {
+	plugin?: string;
+	action?: string;
+	callback_source?: string;
+}
+
 export interface ApmDetailSpan {
 	id: string;
 	parent_id: string | null;
@@ -247,8 +253,9 @@ export interface ApmDetailSpan {
 	method?: string;
 	route?: string;
 	action?: string;
-	plugin?: string;
-	callback_source?: string;
+	// Category-specific payload. The API nests context under a key that
+	// matches the span category (e.g. `plugins` for category="plugins").
+	plugins?: ApmDetailSpanPluginInfo;
 	pruned_children?: ApmDetailSpanPrunedChildren;
 	count: number;
 	tx_count: number;


### PR DESCRIPTION
Part of #

## Proposed Changes

* Model the `plugins` sub-object on `ApmDetailSpan` (new `ApmDetailSpanPluginInfo` interface with `plugin`, `action`, `callback_source`).
* Read `node.plugins?.plugin` and `node.plugins?.callback_source` in the request-detail span tree renderer, instead of the flat (always-undefined) `node.plugin` / `node.callback_source`.

## Why are these changes being made?

The `/sites/{id}/hosting/apm/detail` endpoint returns plugin context nested under a `plugins` key on each span, e.g.:

```json
{
  "id": "...",
  "category": "plugins",
  "name": "APM_Slow_Simulator->on_wp()",
  "plugins": {
    "plugin": "apm-slow-simulator",
    "action": "wp",
    "callback_source": "/srv/htdocs/wp-content/plugins/apm-slow-simulator/apm-slow-simulator.php:50"
  },
  ...
}
```

The TypeScript type and the renderer in #111025 expected those fields flat on the span (`node.plugin`, `node.callback_source`), so the subtitle line under plugin rows (plugin slug + source file) never rendered.

## Testing Instructions

* On a site that has APM capturing enabled and traffic flowing through a plugin (e.g. the `apm-slow-simulator` plugin or any real plugin that hooks into request handling), open Performance > Backend, click into a slow request to open the per-route detail screen.
* Confirm that rows with a `plugins` badge now show a muted subtitle line below the duration bar containing `<plugin-slug> . <file-path:line>` (or just one of them if the other is absent), e.g. `apm-slow-simulator . /srv/htdocs/wp-content/plugins/apm-slow-simulator/apm-slow-simulator.php:50`.
* Confirm non-plugin spans (`wp_core`, `db`, etc.) still render without a subtitle (no regression).
* `yarn typecheck-client` passes.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?