### PR TITLE
Cancel survey: add "Plugin or theme conflicts" sub-option under Technical problems

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/cancellation-reasons.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/cancellation-reasons.ts
@@ -244,6 +244,12 @@ export const CANCELLATION_REASONS: CancellationReason[] = [
 				},
 			},
 			{
+				value: 'pluginOrThemeConflicts',
+				get label() {
+					return translate( 'Plugin or theme conflicts' );
+				},
+			},
+			{
 				value: 'otherTechnicalIssues',
 				get label() {
 					return translate( 'Something else related to technical problems' );

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/cancellation-reasons.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/cancellation-reasons.tsx
@@ -227,6 +227,12 @@ export const CANCELLATION_REASONS: CancellationReason[] = [
 				},
 			},
 			{
+				value: 'pluginOrThemeConflicts',
+				get label() {
+					return __( 'Plugin or theme conflicts' );
+				},
+			},
+			{
 				value: 'otherTechnicalIssues',
 				get label() {
 					return __( 'Something else related to technical problems' );


### PR DESCRIPTION
## Proposed Changes

This PR adds a new "Plugin or theme conflicts" option to the Why is that branch of our Cancel survey when you'd like to cancel/remove for "Technical problems". 

| Calypso | MSD |
| -- | -- |
| <img width="1839" height="1162" alt="image" src="https://github.com/user-attachments/assets/f46989a6-34ca-4574-8d34-9ec06dae4543" /> | <img width="1839" height="1162" alt="image" src="https://github.com/user-attachments/assets/9e8ebc06-de18-4e8e-b49d-44519fc359c0" /> |

Technical details"
* Adds a new sub-option, **"Plugin or theme conflicts"**, to the "Why is that?" dropdown under the "Technical problems" reason in the cancel survey.
* Positioned as the 5th sub-option — between "Site was down or inaccessible" and "Something else related to technical problems".
* Applied to **both surfaces**:
  * Legacy: `client/components/marketing-survey/cancel-purchase-form/cancellation-reasons.ts`
  * Dashboard: `client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/cancellation-reasons.tsx`
* No upsell, no solutions card, no flow logic — falls through to default (same as picking nothing matching). These will be added in a [separate PR](https://github.com/Automattic/wp-calypso/pull/111067).

## Why are these changes being made?

The current 5 sub-options under "Technical problems" (slow, bugs, migration, downtime, other) don't surface plugin- or theme-related friction as a distinct category. Customers experiencing conflicts with their installed plugins or themes today fall into the broad "Encountered bugs, errors, or glitches" or "Something else" buckets, which makes it harder to spot this pattern in survey data.

Adding the category lets us measure how often it appears, and later wire it to a targeted remediation or upsell if the signal is strong enough.

Part of the Billing Ticket Buster sprint — reduce avoidable refund/cancel/unknown-charge support volume through copy, IA, and survey changes.

## Testing Instructions

1. Open the cancel survey on either surface:
   * Dashboard: `my.localhost:3000` → My Billing → any active purchase → Cancel subscription
   * Legacy: `calypso.localhost:3000/me/purchases` → any active purchase → Cancel plan
2. Pick **"Technical problems"** from the first dropdown.
3. Open the **"Why is that?"** dropdown.
4. Verify the options appear in this order:
   1. Site is slow or experiences performance issues
   2. Encountered bugs, errors, or glitches
   3. Problems migrating my existing site or content
   4. Site was down or inaccessible
   5. **Plugin or theme conflicts** ← new
   6. Something else related to technical problems
5. Select "Plugin or theme conflicts". Verify:
   * No upsell card appears.
   * No solutions card appears.
   * Survey submits cleanly with value `pluginOrThemeConflicts`.
   * Browser devtools "Network" tab → look for `tracks.pw.s` requests:
     * `calypso_purchases_cancel_form_select_radio_option` fires with `option=radio_1_2` and `value=pluginOrThemeConflicts`.
     * `calypso_purchases_cancel_form_submit` fires on submit, payload includes the same value.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?