### PR TITLE
Help Center: scope logged-out FAB to auth/account routes

### DIFF
--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -20,7 +20,7 @@ import { useSelect, dispatch } from '@wordpress/data';
 import defaultCalypsoI18n from 'i18n-calypso';
 import { createRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
-import { BrowserRouter, useLocation } from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
 import { setupCountryCode } from 'calypso/boot/geolocation';
 import { setupLocale } from 'calypso/boot/locale';
 import AsyncLoad from 'calypso/components/async-load';
@@ -34,12 +34,13 @@ import { addQueryArgs } from 'calypso/lib/url';
 import { initializeCurrentUser } from 'calypso/lib/user/shared-utils';
 import { onDisablePersistence } from 'calypso/lib/user/store';
 import wpcom from 'calypso/lib/wp';
-import { createReduxStore } from 'calypso/state';
+import { createReduxStore, useSelector } from 'calypso/state';
 import { setCurrentUser } from 'calypso/state/current-user/actions';
 import { getInitialState, getStateFromCache, persistOnChange } from 'calypso/state/initial-state';
 import { createQueryClient } from 'calypso/state/query-client';
 import initialReducer from 'calypso/state/reducer';
 import { setStore } from 'calypso/state/redux-store';
+import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { setCurrentFlowName } from 'calypso/state/signup/flow/actions';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { FlowRenderer } from './declarative-flow/internals';
@@ -124,13 +125,16 @@ function LazyHelpCenter( { currentUser }: { currentUser: UserStore.CurrentUser }
 	return <AsyncHelpCenterApp currentUser={ currentUser } sectionName="stepper" />;
 }
 
-// Matches the user (account-creation) step path, including the optional locale
-// segment used by FlowRenderer's step routes (e.g. `/onboarding/user/es`).
-const USER_STEP_PATH = /^\/[^/]+\/user(?:\/[^/]+)?\/?$/;
+// Matches the stepper user (account-creation) step, including the optional
+// locale segment from FlowRenderer's route (e.g. `/setup/onboarding/user/es`).
+// useSyncRoute keeps the Redux `currentRoute` in sync with react-router
+// navigation, so the FAB can live outside <BrowserRouter> (mounting it inside
+// would nest the Help Center panel's own <Router> and crash).
+const USER_STEP_PATH = /^\/setup\/[^/]+\/user(?:\/[^/]+)?\/?$/;
 
 function StepperUserStepFab() {
-	const { pathname } = useLocation();
-	if ( ! USER_STEP_PATH.test( pathname ) ) {
+	const currentRoute = useSelector( getCurrentRoute );
+	if ( ! USER_STEP_PATH.test( currentRoute ) ) {
 		return null;
 	}
 	return <AsyncHelpCenterFab sectionName="stepper" />;
@@ -287,10 +291,6 @@ async function main() {
 							<AsyncLoad require={ loadCookieBanner } placeholder={ null } />
 						) }
 						<AsyncLoad require={ loadGlobalNotices } placeholder={ null } id="notices" />
-						{ ! user &&
-							! FLOWS_WITHOUT_HELP_CENTER.has( flowName ) &&
-							flowName !== WOO_HOSTED_PLANS_FLOW &&
-							config.isEnabled( 'help-center/logged-out-fab' ) && <StepperUserStepFab /> }
 					</BrowserRouter>
 					{ ! FLOWS_WITHOUT_HELP_CENTER.has( flowName ) &&
 						( flowName === WOO_HOSTED_PLANS_FLOW ? (
@@ -308,6 +308,14 @@ async function main() {
 									sectionName={ flowName }
 									loadAgentsManager
 								/>
+								{ /* The stepper has no masterbar or help button, so logged-out visitors
+								   on the account-creation step need this FAB to summon the Help Center.
+								   It reads its route gate from Redux (kept in sync by useSyncRoute) so
+								   it can live outside <BrowserRouter> — mounting it inside would nest
+								   the Help Center panel's own <Router> and crash. */ }
+								{ ! user && config.isEnabled( 'help-center/logged-out-fab' ) && (
+									<StepperUserStepFab />
+								) }
 							</>
 						) ) }
 					{ 'development' === process.env.NODE_ENV && (

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -20,7 +20,7 @@ import { useSelect, dispatch } from '@wordpress/data';
 import defaultCalypsoI18n from 'i18n-calypso';
 import { createRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter, useLocation } from 'react-router-dom';
 import { setupCountryCode } from 'calypso/boot/geolocation';
 import { setupLocale } from 'calypso/boot/locale';
 import AsyncLoad from 'calypso/components/async-load';
@@ -122,6 +122,18 @@ function LazyHelpCenter( { currentUser }: { currentUser: UserStore.CurrentUser }
 	}
 
 	return <AsyncHelpCenterApp currentUser={ currentUser } sectionName="stepper" />;
+}
+
+// Matches the user (account-creation) step path, including the optional locale
+// segment used by FlowRenderer's step routes (e.g. `/onboarding/user/es`).
+const USER_STEP_PATH = /^\/[^/]+\/user(?:\/[^/]+)?\/?$/;
+
+function StepperUserStepFab() {
+	const { pathname } = useLocation();
+	if ( ! USER_STEP_PATH.test( pathname ) ) {
+		return null;
+	}
+	return <AsyncHelpCenterFab sectionName="stepper" />;
 }
 
 async function main() {
@@ -275,6 +287,10 @@ async function main() {
 							<AsyncLoad require={ loadCookieBanner } placeholder={ null } />
 						) }
 						<AsyncLoad require={ loadGlobalNotices } placeholder={ null } id="notices" />
+						{ ! user &&
+							! FLOWS_WITHOUT_HELP_CENTER.has( flowName ) &&
+							flowName !== WOO_HOSTED_PLANS_FLOW &&
+							config.isEnabled( 'help-center/logged-out-fab' ) && <StepperUserStepFab /> }
 					</BrowserRouter>
 					{ ! FLOWS_WITHOUT_HELP_CENTER.has( flowName ) &&
 						( flowName === WOO_HOSTED_PLANS_FLOW ? (
@@ -292,11 +308,6 @@ async function main() {
 									sectionName={ flowName }
 									loadAgentsManager
 								/>
-								{ /* The stepper has no masterbar or help button, so logged-out visitors
-								   have no way to summon the Help Center otherwise. */ }
-								{ ! user && config.isEnabled( 'help-center/logged-out-fab' ) && (
-									<AsyncHelpCenterFab sectionName="stepper" />
-								) }
 							</>
 						) ) }
 					{ 'development' === process.env.NODE_ENV && (

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -100,12 +100,24 @@ const HELP_CENTER_FAB_SECTIONS = [
 // Fallback when section name is unreliable — e.g. /me/account/closed activates as 'me'.
 const HELP_CENTER_FAB_ROUTES = [ '/me/account/closed' ];
 
+// Within the `signup` section the FAB is scoped to the account-creation step
+// (`user-social` or `user`) so it appears on `/start/account/user-social` but
+// not on flow-specific steps like `/start/domain/domain-only`. The `<flow>`
+// segment is optional because the default signup flow omits it, producing
+// URLs like `/start/user` and `/start/user/<stepSection>/<lang>`. Matches up
+// to two trailing segments (`:stepSectionName` and/or `:lang`).
+const SIGNUP_ACCOUNT_STEP_PATH = /^\/start\/(?:[^/]+\/)?(?:user|user-social)(?:\/[^/]+){0,2}\/?$/;
+
 // /log-in briefly carries social-handoff tokens before the login controller strips
 // them (?access_token / ?id_token in query, #id_token / #client_id in hash).
 // Suppress the FAB during that window so window.location.href doesn't reach Zendesk.
 const WPCOM_LOGIN_FAB_PATHNAMES = new Set( [
 	'/log-in',
-	...getLanguageSlugs().map( ( slug ) => `/log-in/${ slug }` ),
+	'/log-in/lostpassword',
+	...getLanguageSlugs().flatMap( ( slug ) => [
+		`/log-in/${ slug }`,
+		`/log-in/lostpassword/${ slug }`,
+	] ),
 ] );
 
 const TOKEN_BEARING_LOGIN_QUERY_KEYS = [ 'access_token', 'id_token' ];
@@ -205,9 +217,11 @@ const LayoutLoggedOut = ( {
 	const isWpcomLogin =
 		sectionName === 'login' && ! useOAuth2Layout && ! isJetpackLogin && isFabSafeLoginUrl();
 
-	// OAuth client signups (Woo, BlazePro, Gravatar, WPJobManager, etc.) likewise
-	// run under their own brand and route support elsewhere.
-	const isWpcomSignup = sectionName === 'signup' && ! useOAuth2Layout;
+	// OAuth client signups (Woo, BlazePro, Gravatar, WPJobManager, etc.) run under
+	// their own brand. For plain WPCOM signup we only show the FAB on the
+	// account-creation step, not on flow-specific steps like `domain-only`.
+	const isWpcomSignup =
+		sectionName === 'signup' && ! useOAuth2Layout && SIGNUP_ACCOUNT_STEP_PATH.test( currentRoute );
 
 	const isEligibleSection =
 		HELP_CENTER_FAB_SECTIONS.includes( sectionName ) &&


### PR DESCRIPTION
## Proposed Changes

* In `client/layout/logged-out.jsx`: narrow `isWpcomSignup` to also require the route to match the new `SIGNUP_ACCOUNT_STEP_PATH` regex (`/start/<flow>?/{user,user-social}[/<stepSection>][/<lang>]`). The `<flow>` segment is optional because the default signup flow omits it (`/start/user`).
* Add `/log-in/lostpassword` and its locale variants to `WPCOM_LOGIN_FAB_PATHNAMES` so the FAB is allowed on the password-reset request page.
* In `client/landing/stepper/index.tsx`: move the FAB inside `<BrowserRouter>` and gate it behind a small `<StepperUserStepFab>` component that uses `useLocation()` to render only on `/<flow>/user[/<lang>]` (the stepper's account-creation step).

## Why are these changes being made?

The logged-out Help Center FAB was being rendered on every `/start/*` signup step and every stepper step. On `/start/domain/domain-only` it collides with the fixed-position `.domains-mini-cart__container` that spans the bottom of the viewport, and on most signup/stepper steps it isn't where a logged-out visitor is looking for support anyway.

After this change the FAB shows up only where a logged-out visitor is likely actively trying to authenticate or create an account:

| Route | FAB | Section |
|---|---|---|
| `/log-in/*` (incl. `/log-in/lostpassword`, locale variants) | shown | `login` |
| `/start/<flow>?/{user,user-social}[/<section>][/<lang>]` | shown | `signup` |
| `/setup/<flow>/user[/<lang>]` | shown | stepper |
| `/start/domain/domain-only`, `/start/onboarding/intro`, etc. | hidden | `signup` (non-account step) |
| Stepper non-`user` steps | hidden | stepper |

## Testing Instructions

* Logged out, visit `/start/domain/domain-only` — the FAB should be hidden (no collision with the bottom mini-cart).
* Logged out, visit `/start/user`, `/start/user/fr`, `/start/account/user-social` — the FAB should be visible.
* Logged out, visit `/log-in` and `/log-in/lostpassword` — the FAB should be visible.
* Logged out, visit `/setup/onboarding/user` and `/setup/onboarding/user/es` — the FAB should be visible; visit any other step in the same flow — the FAB should be hidden.
* The OAuth2-flavored signup/login flows (Woo, Gravatar, etc.) should still hide the FAB.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?