### PR TITLE
Cancel survey: wire plugin/theme conflicts to solutions cards

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/cancellation-reasons.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/cancellation-reasons.ts
@@ -244,6 +244,12 @@ export const CANCELLATION_REASONS: CancellationReason[] = [
 				},
 			},
 			{
+				value: 'pluginOrThemeConflicts',
+				get label() {
+					return translate( 'Plugin or theme conflicts' );
+				},
+			},
+			{
 				value: 'otherTechnicalIssues',
 				get label() {
 					return translate( 'Something else related to technical problems' );

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solution-cards-config.ts
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solution-cards-config.ts
@@ -7,6 +7,9 @@ import type { ReactElement } from 'react';
 const BUILT_BY_URL = 'https://wordpress.com/website-design-service/?ref=wpcom-cancel-flow';
 const RENEW_COUPON = 'DONTGO25';
 const SUPPORT_URL = localizeUrl( 'https://wordpress.com/support/' );
+const PLUGIN_TROUBLESHOOTING_URL = localizeUrl(
+	'https://wordpress.com/support/plugins/troubleshooting/'
+);
 const SITE_SPEED_URL = localizeUrl( 'https://wordpress.com/support/site-speed/' );
 const SITE_MIGRATION_URL = localizeUrl( 'https://wordpress.com/support/site-migration/' );
 const DOMAINS_SUPPORT_URL = localizeUrl( 'https://wordpress.com/support/domains/' );
@@ -166,6 +169,15 @@ export const SOLUTION_CARD_CONFIG: SolutionCardConfigEntry[] = [
 		getHref: () => SUPPORT_URL,
 		onClick: () => {
 			window.open( SUPPORT_URL, '_blank' );
+		},
+	},
+	{
+		id: 'use-plugin-troubleshooting-guide',
+		title: 'Use our guide',
+		subtitle: 'Follow our troubleshooting guide to find and fix conflicts.',
+		getHref: () => PLUGIN_TROUBLESHOOTING_URL,
+		onClick: () => {
+			window.open( PLUGIN_TROUBLESHOOTING_URL, '_blank' );
 		},
 	},
 	{

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -52,6 +52,7 @@ const CARD_ICONS: Record< string, React.ReactElement > = {
 	'upgrade-for-full-access': upload,
 	'get-theme-addon': brush,
 	'find-guides': postList,
+	'use-plugin-troubleshooting-guide': postList,
 	'make-site-faster': trendingUp,
 	'use-migration-tools': shipping,
 	'use-domain-guide': globe,
@@ -100,6 +101,8 @@ function getTranslatedTitle( id: string, translate: ( s: string ) => string ): s
 			return translate( 'Change your plan' );
 		case 'find-guides':
 			return translate( 'Find easy step-by-step guides' );
+		case 'use-plugin-troubleshooting-guide':
+			return translate( 'Use our guide' );
 		case 'make-site-faster':
 			return translate( 'Make your site faster' );
 		case 'use-migration-tools':
@@ -140,6 +143,8 @@ function getTranslatedSubtitle(
 			return translate( 'Unlock premium themes on another plan.' );
 		case 'find-guides':
 			return translate( 'Browse our guides and get back on track quickly.' );
+		case 'use-plugin-troubleshooting-guide':
+			return translate( 'Follow our troubleshooting guide to find and fix conflicts.' );
 		case 'make-site-faster':
 			return translate( 'Run our free speed test and get personalized recommendations.' );
 		case 'use-migration-tools':

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/test/solutions-cards-upsell-step.test.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/test/solutions-cards-upsell-step.test.tsx
@@ -106,6 +106,33 @@ describe( '<SolutionsCardsUpsellStep /> (legacy)', () => {
 		expect( closeDialog ).not.toHaveBeenCalled();
 	} );
 
+	test( 'pluginOrThemeConflicts shows "Use our guide" card that opens troubleshooting URL in a new tab', async () => {
+		const user = userEvent.setup();
+		const openSpy = jest.spyOn( window, 'open' ).mockImplementation( () => null );
+
+		try {
+			render(
+				<SolutionsCardsUpsellStep
+					cancellationReason="pluginOrThemeConflicts"
+					purchase={ purchase }
+					site={ site }
+					closeDialog={ jest.fn() }
+					onDeclineUpsell={ jest.fn() }
+				/>
+			);
+
+			const guideCard = screen.getByRole( 'button', { name: /Use our guide/ } );
+			await user.click( guideCard );
+
+			expect( openSpy ).toHaveBeenCalledWith(
+				'https://wordpress.com/support/plugins/troubleshooting/',
+				'_blank'
+			);
+		} finally {
+			openSpy.mockRestore();
+		}
+	} );
+
 	test( 'speak-with-support opens Odie fallback when not Zendesk eligible', async () => {
 		mockCanConnectToZendesk = false;
 		const user = userEvent.setup();

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/cancellation-reasons.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/cancellation-reasons.tsx
@@ -227,6 +227,12 @@ export const CANCELLATION_REASONS: CancellationReason[] = [
 				},
 			},
 			{
+				value: 'pluginOrThemeConflicts',
+				get label() {
+					return __( 'Plugin or theme conflicts' );
+				},
+			},
+			{
 				value: 'otherTechnicalIssues',
 				get label() {
 					return __( 'Something else related to technical problems' );

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/solutions-cards-upsell-step.tsx
@@ -50,6 +50,7 @@ const CARD_ICONS: Record< string, IconType > = {
 	'upgrade-for-full-access': upload,
 	'get-theme-addon': brush,
 	'find-guides': postList,
+	'use-plugin-troubleshooting-guide': postList,
 	'make-site-faster': trendingUp,
 	'use-migration-tools': shipping,
 	'use-domain-guide': globe,
@@ -73,6 +74,7 @@ function isAnnualOrLongerPlan( purchase: Purchase ): boolean {
 }
 
 const SUPPORT_GUIDES_URL = localizeUrl( wpcomLink( '/support/' ) );
+const PLUGIN_TROUBLESHOOTING_URL = localizeUrl( wpcomLink( '/support/plugins/troubleshooting/' ) );
 const SITE_SPEED_URL = localizeUrl( wpcomLink( '/support/site-speed/' ) );
 const SITE_MIGRATION_URL = localizeUrl( wpcomLink( '/support/site-migration/' ) );
 const DOMAIN_GUIDE_URL = localizeUrl( wpcomLink( '/support/domains/' ) );
@@ -99,6 +101,9 @@ function getCardHref(
 	}
 	if ( cardId === 'find-guides' ) {
 		return SUPPORT_GUIDES_URL;
+	}
+	if ( cardId === 'use-plugin-troubleshooting-guide' ) {
+		return PLUGIN_TROUBLESHOOTING_URL;
 	}
 	if ( cardId === 'make-site-faster' ) {
 		return SITE_SPEED_URL;
@@ -131,6 +136,7 @@ function getCardOnClick(
 		'upgrade-for-full-access',
 		'get-theme-addon',
 		'find-guides',
+		'use-plugin-troubleshooting-guide',
 		'make-site-faster',
 		'use-migration-tools',
 		'use-domain-guide',
@@ -170,6 +176,8 @@ function getCardTitle( cardId: string ): string {
 			return __( 'Change your plan' );
 		case 'find-guides':
 			return __( 'Find easy step-by-step guides' );
+		case 'use-plugin-troubleshooting-guide':
+			return __( 'Use our guide' );
 		case 'make-site-faster':
 			return __( 'Make your site faster' );
 		case 'use-migration-tools':
@@ -206,6 +214,8 @@ function getCardDescription( cardId: string ): string {
 			return __( 'Unlock premium themes on another plan.' );
 		case 'find-guides':
 			return __( 'Browse our guides and get back on track quickly.' );
+		case 'use-plugin-troubleshooting-guide':
+			return __( 'Follow our troubleshooting guide to find and fix conflicts.' );
 		case 'make-site-faster':
 			return __( 'Run our free speed test and get personalized recommendations.' );
 		case 'use-migration-tools':
@@ -367,6 +377,9 @@ export default function SolutionsCardsUpsellStep( {
 			case 'find-guides':
 				window.open( SUPPORT_GUIDES_URL, '_blank' );
 				break;
+			case 'use-plugin-troubleshooting-guide':
+				window.open( PLUGIN_TROUBLESHOOTING_URL, '_blank' );
+				break;
 			case 'make-site-faster':
 				window.open( SITE_SPEED_URL, '_blank' );
 				break;
@@ -419,6 +432,7 @@ export default function SolutionsCardsUpsellStep( {
 							card.id === 'upgrade-for-full-access' ||
 							card.id === 'get-theme-addon' ||
 							card.id === 'find-guides' ||
+							card.id === 'use-plugin-troubleshooting-guide' ||
 							card.id === 'make-site-faster' ||
 							card.id === 'use-migration-tools' ||
 							card.id === 'use-domain-guide' ||

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/test/solutions-cards-upsell-step.test.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/test/solutions-cards-upsell-step.test.tsx
@@ -71,6 +71,32 @@ describe( '<SolutionsCardsUpsellStep />', () => {
 		expect( closeDialog ).not.toHaveBeenCalled();
 	} );
 
+	test( 'pluginOrThemeConflicts shows "Use our guide" card that opens troubleshooting URL in a new tab', async () => {
+		const user = userEvent.setup();
+		const openSpy = jest.spyOn( window, 'open' ).mockImplementation( () => null );
+
+		try {
+			render(
+				<SolutionsCardsUpsellStep
+					cancellationReason="pluginOrThemeConflicts"
+					purchase={ purchase }
+					closeDialog={ jest.fn() }
+					onDeclineUpsell={ jest.fn() }
+				/>
+			);
+
+			const guideCard = await screen.findByRole( 'button', { name: /Use our guide/ } );
+			await user.click( guideCard );
+
+			expect( openSpy ).toHaveBeenCalledWith(
+				'https://wordpress.com/support/plugins/troubleshooting/',
+				'_blank'
+			);
+		} finally {
+			openSpy.mockRestore();
+		}
+	} );
+
 	test( 'speak-with-support opens Odie fallback when not Zendesk eligible', async () => {
 		mockCanConnectToZendesk = false;
 		const user = userEvent.setup();

--- a/client/dashboard/me/billing-purchases/cancel-purchase/get-solutions-for-reason.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/get-solutions-for-reason.ts
@@ -29,6 +29,7 @@ const SOLUTION_IDS = {
 	UPGRADE_FULL_ACCESS: 'upgrade-for-full-access',
 	GET_THEME_ADDON: 'get-theme-addon',
 	FIND_GUIDES: 'find-guides',
+	USE_PLUGIN_TROUBLESHOOTING_GUIDE: 'use-plugin-troubleshooting-guide',
 	MAKE_SITE_FASTER: 'make-site-faster',
 	USE_MIGRATION_TOOLS: 'use-migration-tools',
 	USE_DOMAIN_GUIDE: 'use-domain-guide',
@@ -138,6 +139,13 @@ const SOLUTIONS_MIGRATION_PROBLEMS: SolutionCardConfig[] = [
 /** Downtime */
 const SOLUTIONS_DOWNTIME: SolutionCardConfig[] = [
 	{ id: SOLUTION_IDS.RENEW_NOW_PAY_LESS },
+	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
+];
+
+/** Plugin or theme conflicts */
+const SOLUTIONS_PLUGIN_OR_THEME_CONFLICTS: SolutionCardConfig[] = [
+	{ id: SOLUTION_IDS.USE_PLUGIN_TROUBLESHOOTING_GUIDE },
+	{ id: SOLUTION_IDS.ASK_AI_ASSISTANT },
 	{ id: SOLUTION_IDS.SPEAK_WITH_SUPPORT },
 ];
 
@@ -276,6 +284,8 @@ export function getSolutionsForReason( reason: string ): SolutionCardConfig[] | 
 			return [ ...SOLUTIONS_BUGS_OR_GLITCHES ];
 		case 'migrationProblems':
 			return [ ...SOLUTIONS_MIGRATION_PROBLEMS ];
+		case 'pluginOrThemeConflicts':
+			return [ ...SOLUTIONS_PLUGIN_OR_THEME_CONFLICTS ];
 		case 'downtime':
 			return [ ...SOLUTIONS_DOWNTIME ];
 


### PR DESCRIPTION
Depends on: https://github.com/Automattic/wp-calypso/pull/111064

## Summary
This PR adds interventions if people select the newly added `Plugin or Theme conflicts` option for the Technical problem answer in the cancelation/removal survey. 

| Calypso | MSD | 
| -- | -- |
| <img width="1839" height="1162" alt="image" src="https://github.com/user-attachments/assets/311d7bff-fbc4-47cf-8d54-89a4ad1f2131" /> | <img width="1839" height="1162" alt="image" src="https://github.com/user-attachments/assets/b018a246-173f-410f-b57b-24a060c8af92" /> |

Technical details:
- Wires the new `pluginOrThemeConflicts` cancellation sub-option (added in #111064) to a solutions step with 3 cards: a new "Use our guide" card linking to the plugin troubleshooting support page in a new tab, plus the existing "Ask our AI assistant" and "Speak with our support team" (Zendesk-gated) cards.
- Both surfaces (legacy + dashboard). No new feature flag — gating inherits from upstream `useIsSplitCancelRemoveEnabled()`.

## Test plan
- [ ] On both legacy (`/me/purchases/<site>/<id>`) and dashboard (`/me/billing/purchases/<id>`): start a cancel flow, pick **Technical problems** → **Plugin or theme conflicts**, click Continue.
- [ ] Verify 3 cards render in order: Use our guide / Ask our AI assistant / Speak with our support team.
- [ ] Click "Use our guide" — confirm it opens the plugin troubleshooting page in a new tab and the survey state is preserved on the original tab.
- [ ] Click "Speak with our support team" — confirm Zendesk routing (chat when eligible, Odie fallback otherwise).
- [ ] Pick a different sub-option (e.g. Downtime) — confirm its cards still render correctly (regression check on the switch statement).