### PR TITLE
Agents Manager: Add opt-in regenerate action

### DIFF
--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 /* eslint-disable import/order -- jest.mock calls must precede imports */
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { Suggestion } from '@automattic/agenttic-ui';
 
 const mockUseAgentChat = jest.fn();
@@ -631,6 +631,202 @@ describe( 'OrchestratorChat', () => {
 		rerender( chat() );
 
 		// Regenerate again: the picker disappears once more while streaming.
+		mockUseAgentChat.mockReturnValue( agentChatReturn( [ userMessage ], true ) );
+		rerender( chat() );
+
+		const lastMessages = mockAgentChat.mock.calls.at( -1 )![ 0 ].messages as Array< {
+			content?: Array< { text?: string } >;
+		} >;
+		expect( countShowComponentMessages( lastMessages ) ).toBe( 1 );
+	} );
+
+	it( 'hides the previous component while a regeneration is processing', async () => {
+		const showComponentContent = JSON.stringify( {
+			tool_id: 'big_sky__show_component',
+			tool_call_id: 'title-picker-call',
+			data: { type: 'titlePicker', summary: 'Optimize title' },
+		} );
+		const userMessage = {
+			id: 'user-1',
+			role: 'user',
+			content: [ { type: 'text', text: 'Optimize the title' } ],
+			timestamp: 0,
+			archived: false,
+			showIcon: true,
+		};
+		const showComponentMessage = ( id: string ) => ( {
+			id,
+			role: 'agent',
+			content: [ { type: 'text', text: showComponentContent } ],
+			timestamp: 1,
+			archived: false,
+			showIcon: true,
+		} );
+		const agentChatReturn = ( messages: unknown[], isProcessing: boolean ) => ( {
+			addMessage: jest.fn(),
+			messages,
+			suggestions: [],
+			isProcessing,
+			error: null,
+			loadMessages: jest.fn(),
+			onSubmit: jest.fn(),
+			abortCurrentRequest: jest.fn(),
+			clearSuggestions: jest.fn(),
+			registerSuggestions: jest.fn(),
+			registerMessageActions: jest.fn(),
+			// Mirror production: agenttic hands back a real regenerate handler for
+			// the completed latest turn.
+			getRegenerateHandler: jest.fn( () => jest.fn() ),
+			progressMessage: null,
+		} );
+		const countShowComponentMessages = (
+			messages: Array< { content?: Array< { text?: string } > } >
+		) =>
+			messages.filter( ( message ) => {
+				const text = message?.content?.[ 0 ]?.text;
+				if ( typeof text !== 'string' ) {
+					return false;
+				}
+				try {
+					return JSON.parse( text )?.tool_id === 'big_sky__show_component';
+				} catch ( _error ) {
+					return false;
+				}
+			} ).length;
+		const chat = () => (
+			<OrchestratorChat
+				emptyViewSuggestions={ [] }
+				isDocked={ false }
+				isOpen
+				onClose={ jest.fn() }
+				onExpand={ jest.fn() }
+				chatHeaderOptions={ [] }
+				markdownComponents={ {} }
+				markdownExtensions={ {} }
+				isCompactMode={ false }
+				capabilities={ { supportsRegenerateAction: true } }
+				onHasMessagesChange={ jest.fn() }
+			/>
+		);
+
+		// Steady state: the picker is showing for the completed turn.
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( [ userMessage, showComponentMessage( 'agent-1' ) ], false )
+		);
+		const { rerender } = render( chat() );
+
+		// Click regenerate: invoke the wrapped handler the component hands to the
+		// regenerate-action hook.
+		const config = mockUseRegenerateAction.mock.calls.at( -1 )![ 0 ] as {
+			getRegenerateHandler?: ( message: unknown ) => ( () => Promise< void > ) | null | undefined;
+		};
+		const wrappedHandler = config.getRegenerateHandler?.( showComponentMessage( 'agent-1' ) );
+		await act( async () => {
+			await wrappedHandler?.();
+		} );
+
+		// agenttic rewinds the turn and streams the new response; the old picker is
+		// gone from the live messages while it processes.
+		mockUseAgentChat.mockReturnValue( agentChatReturn( [ userMessage ], true ) );
+		rerender( chat() );
+
+		const lastMessages = mockAgentChat.mock.calls.at( -1 )![ 0 ].messages as Array< {
+			content?: Array< { text?: string } >;
+		} >;
+		expect( countShowComponentMessages( lastMessages ) ).toBe( 0 );
+	} );
+
+	it( 'restores component retention after a regeneration finishes', async () => {
+		const showComponentContent = JSON.stringify( {
+			tool_id: 'big_sky__show_component',
+			tool_call_id: 'title-picker-call',
+			data: { type: 'titlePicker', summary: 'Optimize title' },
+		} );
+		const userMessage = {
+			id: 'user-1',
+			role: 'user',
+			content: [ { type: 'text', text: 'Optimize the title' } ],
+			timestamp: 0,
+			archived: false,
+			showIcon: true,
+		};
+		const showComponentMessage = ( id: string ) => ( {
+			id,
+			role: 'agent',
+			content: [ { type: 'text', text: showComponentContent } ],
+			timestamp: 1,
+			archived: false,
+			showIcon: true,
+		} );
+		const agentChatReturn = ( messages: unknown[], isProcessing: boolean ) => ( {
+			addMessage: jest.fn(),
+			messages,
+			suggestions: [],
+			isProcessing,
+			error: null,
+			loadMessages: jest.fn(),
+			onSubmit: jest.fn(),
+			abortCurrentRequest: jest.fn(),
+			clearSuggestions: jest.fn(),
+			registerSuggestions: jest.fn(),
+			registerMessageActions: jest.fn(),
+			getRegenerateHandler: jest.fn( () => jest.fn() ),
+			progressMessage: null,
+		} );
+		const countShowComponentMessages = (
+			messages: Array< { content?: Array< { text?: string } > } >
+		) =>
+			messages.filter( ( message ) => {
+				const text = message?.content?.[ 0 ]?.text;
+				if ( typeof text !== 'string' ) {
+					return false;
+				}
+				try {
+					return JSON.parse( text )?.tool_id === 'big_sky__show_component';
+				} catch ( _error ) {
+					return false;
+				}
+			} ).length;
+		const chat = () => (
+			<OrchestratorChat
+				emptyViewSuggestions={ [] }
+				isDocked={ false }
+				isOpen
+				onClose={ jest.fn() }
+				onExpand={ jest.fn() }
+				chatHeaderOptions={ [] }
+				markdownComponents={ {} }
+				markdownExtensions={ {} }
+				isCompactMode={ false }
+				capabilities={ { supportsRegenerateAction: true } }
+				onHasMessagesChange={ jest.fn() }
+			/>
+		);
+
+		// Steady state, then a full regeneration cycle.
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( [ userMessage, showComponentMessage( 'agent-1' ) ], false )
+		);
+		const { rerender } = render( chat() );
+
+		const config = mockUseRegenerateAction.mock.calls.at( -1 )![ 0 ] as {
+			getRegenerateHandler?: ( message: unknown ) => ( () => Promise< void > ) | null | undefined;
+		};
+		const wrappedHandler = config.getRegenerateHandler?.( showComponentMessage( 'agent-1' ) );
+		await act( async () => {
+			await wrappedHandler?.();
+		} );
+
+		// Regeneration streams, then settles with the fresh component.
+		mockUseAgentChat.mockReturnValue( agentChatReturn( [ userMessage ], true ) );
+		rerender( chat() );
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( [ userMessage, showComponentMessage( 'agent-2' ) ], false )
+		);
+		rerender( chat() );
+
+		// A later turn (not a regeneration) transiently drops the component —
+		// retention should cover it again now the flag has cleared.
 		mockUseAgentChat.mockReturnValue( agentChatReturn( [ userMessage ], true ) );
 		rerender( chat() );
 

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -543,4 +543,100 @@ describe( 'OrchestratorChat', () => {
 			{ isLatestAgentMessage: true, isStreaming: true }
 		);
 	} );
+
+	it( 'does not stack retained show-component messages across repeated regenerations', () => {
+		// A "show component" payload (e.g. a title picker). Its identity —
+		// tool_call_id|type|summary — is stable across regenerations even though
+		// each regenerated agent turn gets a fresh message id.
+		const showComponentContent = JSON.stringify( {
+			tool_id: 'big_sky__show_component',
+			tool_call_id: 'title-picker-call',
+			data: { type: 'titlePicker', summary: 'Optimize title' },
+		} );
+		const userMessage = {
+			id: 'user-1',
+			role: 'user',
+			content: [ { type: 'text', text: 'Optimize the title' } ],
+			timestamp: 0,
+			archived: false,
+			showIcon: true,
+		};
+		const showComponentMessage = ( id: string ) => ( {
+			id,
+			role: 'agent',
+			content: [ { type: 'text', text: showComponentContent } ],
+			timestamp: 1,
+			archived: false,
+			showIcon: true,
+		} );
+		const agentChatReturn = ( messages: unknown[], isProcessing: boolean ) => ( {
+			addMessage: jest.fn(),
+			messages,
+			suggestions: [],
+			isProcessing,
+			error: null,
+			loadMessages: jest.fn(),
+			onSubmit: jest.fn(),
+			abortCurrentRequest: jest.fn(),
+			clearSuggestions: jest.fn(),
+			registerSuggestions: jest.fn(),
+			registerMessageActions: jest.fn(),
+			getRegenerateHandler: jest.fn(),
+			progressMessage: null,
+		} );
+		const countShowComponentMessages = (
+			messages: Array< { content?: Array< { text?: string } > } >
+		) =>
+			messages.filter( ( message ) => {
+				const text = message?.content?.[ 0 ]?.text;
+				if ( typeof text !== 'string' ) {
+					return false;
+				}
+				try {
+					return JSON.parse( text )?.tool_id === 'big_sky__show_component';
+				} catch ( _error ) {
+					return false;
+				}
+			} ).length;
+		const chat = () => (
+			<OrchestratorChat
+				emptyViewSuggestions={ [] }
+				isDocked={ false }
+				isOpen
+				onClose={ jest.fn() }
+				onExpand={ jest.fn() }
+				chatHeaderOptions={ [] }
+				markdownComponents={ {} }
+				markdownExtensions={ {} }
+				isCompactMode={ false }
+				capabilities={ { supportsRegenerateAction: true } }
+				onHasMessagesChange={ jest.fn() }
+			/>
+		);
+
+		// Steady state: the title picker is showing.
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( [ userMessage, showComponentMessage( 'agent-1' ) ], false )
+		);
+		const { rerender } = render( chat() );
+
+		// Regenerate: the picker briefly disappears while the new turn streams.
+		mockUseAgentChat.mockReturnValue( agentChatReturn( [ userMessage ], true ) );
+		rerender( chat() );
+
+		// New picker arrives — same identity, fresh agent message id.
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( [ userMessage, showComponentMessage( 'agent-2' ) ], false )
+		);
+		rerender( chat() );
+
+		// Regenerate again: the picker disappears once more while streaming.
+		mockUseAgentChat.mockReturnValue( agentChatReturn( [ userMessage ], true ) );
+		rerender( chat() );
+
+		const lastMessages = mockAgentChat.mock.calls.at( -1 )![ 0 ].messages as Array< {
+			content?: Array< { text?: string } >;
+		} >;
+		expect( countShowComponentMessages( lastMessages ) ).toBe( 1 );
+	} );
 } );

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -118,6 +118,9 @@ import OrchestratorChat from '../orchestrator-chat';
 describe( 'OrchestratorChat', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
+		// useRegenerateAction now returns a per-message action getter (like the
+		// copy action). Default to one that contributes nothing.
+		mockUseRegenerateAction.mockReturnValue( () => [] );
 		mockUseAgentChat.mockReturnValue( {
 			addMessage: jest.fn(),
 			messages: [],
@@ -397,6 +400,21 @@ describe( 'OrchestratorChat', () => {
 
 	it( 'disables stale regenerate actions on older agent messages before render', () => {
 		const onRegenerate = jest.fn();
+		// Mirror production: the getter enables regenerate only on the latest
+		// agent message and disables it on older ones.
+		mockUseRegenerateAction.mockReturnValue(
+			( message: { role: string }, options: { isLatestAgentMessage: boolean } ) =>
+				message.role === 'agent'
+					? [
+							{
+								id: 'regenerate',
+								label: 'Regenerate',
+								onClick: onRegenerate,
+								disabled: ! options.isLatestAgentMessage,
+							},
+					  ]
+					: []
+		);
 		mockUseAgentChat.mockReturnValue( {
 			addMessage: jest.fn(),
 			messages: [
@@ -407,14 +425,6 @@ describe( 'OrchestratorChat', () => {
 					timestamp: 1,
 					archived: false,
 					showIcon: true,
-					actions: [
-						{
-							id: 'regenerate',
-							label: 'Regenerate',
-							onClick: onRegenerate,
-							disabled: false,
-						},
-					],
 				},
 				{
 					id: 'agent-2',
@@ -423,14 +433,6 @@ describe( 'OrchestratorChat', () => {
 					timestamp: 2,
 					archived: false,
 					showIcon: true,
-					actions: [
-						{
-							id: 'regenerate',
-							label: 'Regenerate',
-							onClick: onRegenerate,
-							disabled: false,
-						},
-					],
 				},
 			],
 			suggestions: [],
@@ -442,7 +444,6 @@ describe( 'OrchestratorChat', () => {
 			clearSuggestions: jest.fn(),
 			registerSuggestions: jest.fn(),
 			registerMessageActions: jest.fn(),
-			unregisterMessageActions: jest.fn(),
 			getRegenerateHandler: jest.fn(),
 			progressMessage: null,
 		} );
@@ -478,6 +479,68 @@ describe( 'OrchestratorChat', () => {
 				id: 'regenerate',
 				disabled: false,
 			} )
+		);
+	} );
+
+	it( 'tells the regenerate getter which message is latest and whether it is streaming', () => {
+		const getRegenerateActions = jest.fn( () => [] );
+		mockUseRegenerateAction.mockReturnValue( getRegenerateActions );
+		mockUseAgentChat.mockReturnValue( {
+			addMessage: jest.fn(),
+			messages: [
+				{
+					id: 'agent-1',
+					role: 'agent',
+					content: [ { type: 'text', text: 'First response' } ],
+					timestamp: 1,
+					archived: false,
+					showIcon: true,
+				},
+				{
+					id: 'agent-2',
+					role: 'agent',
+					content: [ { type: 'text', text: 'Streaming response' } ],
+					timestamp: 2,
+					archived: false,
+					showIcon: true,
+				},
+			],
+			suggestions: [],
+			isProcessing: true,
+			error: null,
+			loadMessages: jest.fn(),
+			onSubmit: jest.fn(),
+			abortCurrentRequest: jest.fn(),
+			clearSuggestions: jest.fn(),
+			registerSuggestions: jest.fn(),
+			registerMessageActions: jest.fn(),
+			getRegenerateHandler: jest.fn(),
+			progressMessage: null,
+		} );
+
+		render(
+			<OrchestratorChat
+				emptyViewSuggestions={ [] }
+				isDocked={ false }
+				isOpen
+				onClose={ jest.fn() }
+				onExpand={ jest.fn() }
+				chatHeaderOptions={ [] }
+				markdownComponents={ {} }
+				markdownExtensions={ {} }
+				isCompactMode={ false }
+				capabilities={ { supportsRegenerateAction: true } }
+				onHasMessagesChange={ jest.fn() }
+			/>
+		);
+
+		expect( getRegenerateActions ).toHaveBeenCalledWith(
+			expect.objectContaining( { id: 'agent-1' } ),
+			{ isLatestAgentMessage: false, isStreaming: true }
+		);
+		expect( getRegenerateActions ).toHaveBeenCalledWith(
+			expect.objectContaining( { id: 'agent-2' } ),
+			{ isLatestAgentMessage: true, isStreaming: true }
 		);
 	} );
 } );

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -82,12 +82,13 @@ jest.mock( '../../hooks/use-feedback-action', () => () => ( {
 	showFeedbackInput: false,
 	submitFeedbackText: jest.fn(),
 	resetFeedback: jest.fn(),
+	getFeedbackActionsForMessage: () => [],
 } ) );
 jest.mock( '../../hooks/use-regenerate-action', () => ( {
 	__esModule: true,
 	default: ( config: unknown ) => mockUseRegenerateAction( config ),
 } ) );
-jest.mock( '../../hooks/use-copy-action', () => () => {} );
+jest.mock( '../../hooks/use-copy-action', () => () => () => [] );
 jest.mock( '../../hooks/use-sources-action', () => () => {} );
 jest.mock( '../../hooks/use-zoom-action', () => () => {} );
 jest.mock( '../../utils/agent-session', () => ( { markSessionUsed: jest.fn() } ) );

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -6,6 +6,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { Suggestion } from '@automattic/agenttic-ui';
 
 const mockUseAgentChat = jest.fn();
+const mockUseRegenerateAction = jest.fn();
 
 jest.mock(
 	'@automattic/agenttic-client',
@@ -46,6 +47,10 @@ jest.mock( '../../hooks/use-feedback-action', () => () => ( {
 	showFeedbackInput: false,
 	submitFeedbackText: jest.fn(),
 	resetFeedback: jest.fn(),
+} ) );
+jest.mock( '../../hooks/use-regenerate-action', () => ( {
+	__esModule: true,
+	default: ( config: unknown ) => mockUseRegenerateAction( config ),
 } ) );
 jest.mock( '../../hooks/use-copy-action', () => () => {} );
 jest.mock( '../../hooks/use-sources-action', () => () => {} );
@@ -120,6 +125,8 @@ describe( 'OrchestratorChat', () => {
 			clearSuggestions: jest.fn(),
 			registerSuggestions: jest.fn(),
 			registerMessageActions: jest.fn(),
+			unregisterMessageActions: jest.fn(),
+			getRegenerateHandler: jest.fn(),
 			progressMessage: null,
 		} );
 	} );
@@ -338,5 +345,48 @@ describe( 'OrchestratorChat', () => {
 				count: 2,
 			} );
 		} );
+	} );
+
+	it( 'keeps regenerate disabled unless a provider opts in', () => {
+		render(
+			<OrchestratorChat
+				emptyViewSuggestions={ [] }
+				isDocked={ false }
+				isOpen
+				onClose={ jest.fn() }
+				onExpand={ jest.fn() }
+				chatHeaderOptions={ [] }
+				markdownComponents={ {} }
+				markdownExtensions={ {} }
+				isCompactMode={ false }
+				onHasMessagesChange={ jest.fn() }
+			/>
+		);
+
+		expect( mockUseRegenerateAction ).toHaveBeenCalledWith(
+			expect.objectContaining( { enabled: false } )
+		);
+	} );
+
+	it( 'enables regenerate when a provider opts in', () => {
+		render(
+			<OrchestratorChat
+				emptyViewSuggestions={ [] }
+				isDocked={ false }
+				isOpen
+				onClose={ jest.fn() }
+				onExpand={ jest.fn() }
+				chatHeaderOptions={ [] }
+				markdownComponents={ {} }
+				markdownExtensions={ {} }
+				isCompactMode={ false }
+				capabilities={ { supportsRegenerateAction: true } }
+				onHasMessagesChange={ jest.fn() }
+			/>
+		);
+
+		expect( mockUseRegenerateAction ).toHaveBeenCalledWith(
+			expect.objectContaining( { enabled: true } )
+		);
 	} );
 } );

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -118,8 +118,7 @@ import OrchestratorChat from '../orchestrator-chat';
 describe( 'OrchestratorChat', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
-		// useRegenerateAction now returns a per-message action getter (like the
-		// copy action). Default to one that contributes nothing.
+		// Default getter: contributes no actions.
 		mockUseRegenerateAction.mockReturnValue( () => [] );
 		mockUseAgentChat.mockReturnValue( {
 			addMessage: jest.fn(),

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -7,6 +7,41 @@ import type { Suggestion } from '@automattic/agenttic-ui';
 
 const mockUseAgentChat = jest.fn();
 const mockUseRegenerateAction = jest.fn();
+const mockAgentChat = jest.fn(
+	( {
+		onSuggestionClick,
+		onSubmit,
+		emptyViewSuggestions = [],
+	}: {
+		messages?: unknown[];
+		onSuggestionClick: ( suggestion: Suggestion | string ) => void;
+		onSubmit: ( message: string ) => void;
+		emptyViewSuggestions?: Suggestion[];
+	} ) => (
+		<>
+			<button
+				onClick={ () =>
+					onSuggestionClick( {
+						id: 'simplify-text',
+						label: 'Simplify text',
+						prompt: 'Simplify this text to make it easier to read',
+					} )
+				}
+			>
+				Click suggestion
+			</button>
+			<button onClick={ () => onSuggestionClick( 'Check the grammar and spelling of this text' ) }>
+				Click string suggestion
+			</button>
+			<button onClick={ () => onSubmit( 'Describe these images' ) }>Submit with images</button>
+			<ul data-testid="empty-view-suggestions">
+				{ emptyViewSuggestions.map( ( suggestion ) => (
+					<li key={ suggestion.id }>{ suggestion.label }</li>
+				) ) }
+			</ul>
+		</>
+	)
+);
 
 jest.mock(
 	'@automattic/agenttic-client',
@@ -73,38 +108,7 @@ jest.mock( '../../utils/persist-last-activity', () => ( {
 } ) );
 jest.mock( '../agent-chat', () => ( {
 	__esModule: true,
-	default: ( {
-		onSuggestionClick,
-		onSubmit,
-		emptyViewSuggestions = [],
-	}: {
-		onSuggestionClick: ( suggestion: Suggestion | string ) => void;
-		onSubmit: ( message: string ) => void;
-		emptyViewSuggestions?: Suggestion[];
-	} ) => (
-		<>
-			<button
-				onClick={ () =>
-					onSuggestionClick( {
-						id: 'simplify-text',
-						label: 'Simplify text',
-						prompt: 'Simplify this text to make it easier to read',
-					} )
-				}
-			>
-				Click suggestion
-			</button>
-			<button onClick={ () => onSuggestionClick( 'Check the grammar and spelling of this text' ) }>
-				Click string suggestion
-			</button>
-			<button onClick={ () => onSubmit( 'Describe these images' ) }>Submit with images</button>
-			<ul data-testid="empty-view-suggestions">
-				{ emptyViewSuggestions.map( ( suggestion ) => (
-					<li key={ suggestion.id }>{ suggestion.label }</li>
-				) ) }
-			</ul>
-		</>
-	),
+	default: ( props: unknown ) => mockAgentChat( props as Parameters< typeof mockAgentChat >[ 0 ] ),
 } ) );
 
 import { recordBigSkyTracksEvent } from '../../utils/tracks';
@@ -387,6 +391,92 @@ describe( 'OrchestratorChat', () => {
 
 		expect( mockUseRegenerateAction ).toHaveBeenCalledWith(
 			expect.objectContaining( { enabled: true } )
+		);
+	} );
+
+	it( 'disables stale regenerate actions on older agent messages before render', () => {
+		const onRegenerate = jest.fn();
+		mockUseAgentChat.mockReturnValue( {
+			addMessage: jest.fn(),
+			messages: [
+				{
+					id: 'agent-1',
+					role: 'agent',
+					content: [ { type: 'text', text: 'First response' } ],
+					timestamp: 1,
+					archived: false,
+					showIcon: true,
+					actions: [
+						{
+							id: 'regenerate',
+							label: 'Regenerate',
+							onClick: onRegenerate,
+							disabled: false,
+						},
+					],
+				},
+				{
+					id: 'agent-2',
+					role: 'agent',
+					content: [ { type: 'text', text: 'Second response' } ],
+					timestamp: 2,
+					archived: false,
+					showIcon: true,
+					actions: [
+						{
+							id: 'regenerate',
+							label: 'Regenerate',
+							onClick: onRegenerate,
+							disabled: false,
+						},
+					],
+				},
+			],
+			suggestions: [],
+			isProcessing: false,
+			error: null,
+			loadMessages: jest.fn(),
+			onSubmit: jest.fn(),
+			abortCurrentRequest: jest.fn(),
+			clearSuggestions: jest.fn(),
+			registerSuggestions: jest.fn(),
+			registerMessageActions: jest.fn(),
+			unregisterMessageActions: jest.fn(),
+			getRegenerateHandler: jest.fn(),
+			progressMessage: null,
+		} );
+
+		render(
+			<OrchestratorChat
+				emptyViewSuggestions={ [] }
+				isDocked={ false }
+				isOpen
+				onClose={ jest.fn() }
+				onExpand={ jest.fn() }
+				chatHeaderOptions={ [] }
+				markdownComponents={ {} }
+				markdownExtensions={ {} }
+				isCompactMode={ false }
+				capabilities={ { supportsRegenerateAction: true } }
+				onHasMessagesChange={ jest.fn() }
+			/>
+		);
+
+		const messages = mockAgentChat.mock.calls[ 0 ][ 0 ].messages as Array< {
+			actions: Array< { id: string; disabled?: boolean } >;
+		} >;
+
+		expect( messages[ 0 ].actions[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				id: 'regenerate',
+				disabled: true,
+			} )
+		);
+		expect( messages[ 1 ].actions[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				id: 'regenerate',
+				disabled: false,
+			} )
 		);
 	} );
 } );

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -322,6 +322,7 @@ export default function AgentDock( {
 			siteBuildUtils={ siteBuildUtils }
 			useImageUpload={ useImageUpload }
 			useCheckpoint={ useCheckpoint }
+			capabilities={ capabilities }
 			onHasMessagesChange={ handleChatHasMessagesChange }
 		/>
 	);

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -50,6 +50,49 @@ import type {
 	UseCheckpointHook,
 	ProviderCapabilities,
 } from '../../utils/load-external-providers';
+import type { UIMessageAction } from '@automattic/agenttic-client';
+
+const REGENERATE_ACTION_ID = 'regenerate';
+
+function getLatestAgentMessageId( messages: UIMessage[] ): string | null {
+	for ( let index = messages.length - 1; index >= 0; index-- ) {
+		if ( messages[ index ].role === 'agent' ) {
+			return messages[ index ].id;
+		}
+	}
+
+	return null;
+}
+
+function disableRegenerateActionForOlderAgentMessages( messages: UIMessage[] ): UIMessage[] {
+	const latestAgentMessageId = getLatestAgentMessageId( messages );
+
+	return messages.map( ( message ) => {
+		if ( message.role !== 'agent' || ! message.actions?.length ) {
+			return message;
+		}
+
+		const shouldDisableRegenerate = message.id !== latestAgentMessageId;
+		let changed = false;
+		const actions = message.actions.map( ( action: UIMessageAction ) => {
+			if ( action.id !== REGENERATE_ACTION_ID || action.type === 'component' ) {
+				return action;
+			}
+
+			if ( action.disabled === shouldDisableRegenerate ) {
+				return action;
+			}
+
+			changed = true;
+			return {
+				...action,
+				disabled: shouldDisableRegenerate,
+			};
+		} );
+
+		return changed ? { ...message, actions } : message;
+	} );
+}
 
 /**
  * Pipe-delimited list of suggestion ids (e.g. `|id1|id2|`), matching Big Sky's
@@ -680,6 +723,8 @@ export default function OrchestratorChat( {
 				),
 			};
 		} );
+
+		currentMessages = disableRegenerateActionForOlderAgentMessages( currentMessages );
 
 		return currentMessages;
 	}, [

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -50,9 +50,6 @@ import type {
 	UseCheckpointHook,
 	ProviderCapabilities,
 } from '../../utils/load-external-providers';
-import type { UIMessageAction } from '@automattic/agenttic-client';
-
-const REGENERATE_ACTION_ID = 'regenerate';
 
 function getLatestAgentMessageId( messages: UIMessage[] ): string | null {
 	for ( let index = messages.length - 1; index >= 0; index-- ) {
@@ -62,36 +59,6 @@ function getLatestAgentMessageId( messages: UIMessage[] ): string | null {
 	}
 
 	return null;
-}
-
-function disableRegenerateActionForOlderAgentMessages( messages: UIMessage[] ): UIMessage[] {
-	const latestAgentMessageId = getLatestAgentMessageId( messages );
-
-	return messages.map( ( message ) => {
-		if ( message.role !== 'agent' || ! message.actions?.length ) {
-			return message;
-		}
-
-		const shouldDisableRegenerate = message.id !== latestAgentMessageId;
-		let changed = false;
-		const actions = message.actions.map( ( action: UIMessageAction ) => {
-			if ( action.id !== REGENERATE_ACTION_ID || action.type === 'component' ) {
-				return action;
-			}
-
-			if ( action.disabled === shouldDisableRegenerate ) {
-				return action;
-			}
-
-			changed = true;
-			return {
-				...action,
-				disabled: shouldDisableRegenerate,
-			};
-		} );
-
-		return changed ? { ...message, actions } : message;
-	} );
 }
 
 /**
@@ -248,7 +215,6 @@ export default function OrchestratorChat( {
 		clearSuggestions,
 		registerSuggestions,
 		registerMessageActions,
-		unregisterMessageActions,
 		getRegenerateHandler,
 		progressMessage,
 	} = useAgentChat( agentConfig! );
@@ -386,12 +352,11 @@ export default function OrchestratorChat( {
 			messages,
 		} );
 
-	// Register Agenttic's built-in regenerate action for providers that opt in.
-	useRegenerateAction( {
+	// Add Agenttic's built-in regenerate action on agent messages for providers
+	// that opt in. Computed during render alongside copy/feedback so the icon
+	// appears in the same paint rather than a commit later.
+	const getRegenerateActionsForMessage = useRegenerateAction( {
 		enabled: capabilities?.supportsRegenerateAction === true,
-		isProcessing,
-		registerMessageActions,
-		unregisterMessageActions,
 		getRegenerateHandler,
 	} );
 
@@ -699,6 +664,8 @@ export default function OrchestratorChat( {
 			onSubmit: onSubmitWithImages,
 		} );
 
+		const latestAgentMessageId = getLatestAgentMessageId( currentMessages );
+
 		currentMessages = currentMessages.map( ( message ) => {
 			if ( message.id.endsWith( '-next-step' ) ) {
 				return message;
@@ -707,13 +674,20 @@ export default function OrchestratorChat( {
 			const directActions = [
 				...getFeedbackActionsForMessage( message ),
 				...getCopyActionsForMessage( message ),
+				...getRegenerateActionsForMessage( message, {
+					isLatestAgentMessage: message.id === latestAgentMessageId,
+					isStreaming: isProcessing,
+				} ),
 			];
 			if ( directActions.length === 0 ) {
 				return message;
 			}
 
 			const existingActions = message.actions?.filter(
-				( action ) => ! action.id.startsWith( 'feedback-' ) && action.id !== 'copy'
+				( action ) =>
+					! action.id.startsWith( 'feedback-' ) &&
+					action.id !== 'copy' &&
+					action.id !== 'regenerate'
 			);
 
 			return {
@@ -724,8 +698,6 @@ export default function OrchestratorChat( {
 			};
 		} );
 
-		currentMessages = disableRegenerateActionForOlderAgentMessages( currentMessages );
-
 		return currentMessages;
 	}, [
 		currentPostId,
@@ -734,7 +706,9 @@ export default function OrchestratorChat( {
 		getCopyActionsForMessage,
 		getShowComponentOrder,
 		getFeedbackActionsForMessage,
+		getRegenerateActionsForMessage,
 		isBuildingSite,
+		isProcessing,
 		messages,
 		onSubmitWithImages,
 		retainedShowComponentMessages,

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -259,7 +259,9 @@ export default function OrchestratorChat( {
 
 				for ( const message of retainedCandidates ) {
 					const identity = getShowComponentIdentity( message );
-					const retainedId = `${ message.id }-retained-${ identity }`;
+					// One placeholder per identity, so regenerating a component
+					// refreshes it in place instead of stacking another copy.
+					const retainedId = `retained-${ identity }`;
 					if ( ! nextRetainedMessages.has( retainedId ) ) {
 						nextRetainedMessages.set( retainedId, { ...message, id: retainedId } );
 						changed = true;

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -16,6 +16,7 @@ import useCheckpointAction from '../../hooks/use-checkpoint-action';
 import useConversation from '../../hooks/use-conversation';
 import useCopyAction from '../../hooks/use-copy-action';
 import useFeedbackAction from '../../hooks/use-feedback-action';
+import useRegenerateAction from '../../hooks/use-regenerate-action';
 import useSaveNewChatRoute from '../../hooks/use-save-new-chat-route';
 import useSourcesAction from '../../hooks/use-sources-action';
 import useZoomAction from '../../hooks/use-zoom-action';
@@ -47,6 +48,7 @@ import type {
 	SiteBuildUtils,
 	ImageUploadHook,
 	UseCheckpointHook,
+	ProviderCapabilities,
 } from '../../utils/load-external-providers';
 
 /**
@@ -149,6 +151,8 @@ interface Props {
 	useImageUpload?: ImageUploadHook;
 	/** Hook for saving and restoring editor state so that AI actions can be undone. */
 	useCheckpoint?: UseCheckpointHook;
+	/** Optional capability flags declared by one or more loaded providers. */
+	capabilities?: ProviderCapabilities;
 	/** Called when the has-messages state changes. */
 	onHasMessagesChange: ( hasMessages: boolean ) => void;
 }
@@ -170,6 +174,7 @@ export default function OrchestratorChat( {
 	siteBuildUtils,
 	useImageUpload,
 	useCheckpoint,
+	capabilities,
 	onHasMessagesChange,
 }: Props ) {
 	const { agentConfig, getActiveSessionId, siteKey } = useAgentsManagerContext();
@@ -200,6 +205,8 @@ export default function OrchestratorChat( {
 		clearSuggestions,
 		registerSuggestions,
 		registerMessageActions,
+		unregisterMessageActions,
+		getRegenerateHandler,
 		progressMessage,
 	} = useAgentChat( agentConfig! );
 	const messagesRef = useRef( messages );
@@ -335,6 +342,15 @@ export default function OrchestratorChat( {
 			registerMessageActions,
 			messages,
 		} );
+
+	// Register Agenttic's built-in regenerate action for providers that opt in.
+	useRegenerateAction( {
+		enabled: capabilities?.supportsRegenerateAction === true,
+		isProcessing,
+		registerMessageActions,
+		unregisterMessageActions,
+		getRegenerateHandler,
+	} );
 
 	// Add a "Copy" action on plain-text agent messages.
 	const getCopyActionsForMessage = useCopyAction();

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -198,6 +198,7 @@ export default function OrchestratorChat( {
 	const [ retainedShowComponentMessages, setRetainedShowComponentMessages ] = useState<
 		Map< string, UIMessage >
 	>( new Map() );
+	const [ isRegenerating, setIsRegenerating ] = useState( false );
 	const [ hasUserSentMessage, setHasUserSentMessage ] = useState( false );
 	const currentPostId = useSelect( ( select ) => {
 		return ( select( 'core/editor' ) as { getCurrentPostId?: () => number } )?.getCurrentPostId?.();
@@ -222,7 +223,44 @@ export default function OrchestratorChat( {
 	const previousMessagesRef = useRef( messages );
 	const showComponentOrderRef = useRef< Map< string, number > >( new Map() );
 	const nextShowComponentOrderRef = useRef( 0 );
+	const wasProcessingRef = useRef( isProcessing );
 	messagesRef.current = messages;
+
+	// A regeneration is finished once its streaming turn settles — either the new
+	// response arrives or an error restores the previous one. Re-enable component
+	// retention then so transient drops on later turns are covered again.
+	useEffect( () => {
+		const wasProcessing = wasProcessingRef.current;
+		wasProcessingRef.current = isProcessing;
+		if ( isRegenerating && wasProcessing && ! isProcessing ) {
+			setIsRegenerating( false );
+		}
+	}, [ isProcessing, isRegenerating ] );
+
+	// Wrap Agenttic's regenerate handler so a click marks a regeneration in
+	// progress. While it runs, the component being regenerated is deliberately
+	// dropped from the live messages (Agenttic sends `preserveUiOnlyMessages:
+	// false`), so retention must not resurrect the old picker as a stale copy.
+	const handleRegenerate = useCallback(
+		( message?: UIMessage ) => {
+			const handler = getRegenerateHandler?.( message );
+			if ( ! handler ) {
+				return handler;
+			}
+
+			return async () => {
+				setIsRegenerating( true );
+				// Drop any retained placeholders up front; the turn is being
+				// rewound, so a leftover picker would otherwise reappear once
+				// regeneration settles if the new response omits the component.
+				setRetainedShowComponentMessages( ( previousRetainedMessages ) =>
+					previousRetainedMessages.size > 0 ? new Map() : previousRetainedMessages
+				);
+				await handler();
+			};
+		},
+		[ getRegenerateHandler ]
+	);
 
 	const getShowComponentOrder = useCallback( ( message: UIMessage ): number | undefined => {
 		const identity = getShowComponentIdentity( message );
@@ -241,6 +279,14 @@ export default function OrchestratorChat( {
 	}, [] );
 
 	useEffect( () => {
+		// While regenerating, the dropped component is being replaced, not lost —
+		// don't retain it. Keep the ref current so the next non-regenerating run
+		// compares against the post-regeneration messages.
+		if ( isRegenerating ) {
+			previousMessagesRef.current = messages;
+			return;
+		}
+
 		const previousMessages = previousMessagesRef.current;
 		messages.filter( isShowComponentMessage ).forEach( getShowComponentOrder );
 
@@ -259,8 +305,8 @@ export default function OrchestratorChat( {
 
 				for ( const message of retainedCandidates ) {
 					const identity = getShowComponentIdentity( message );
-					// One placeholder per identity, so regenerating a component
-					// refreshes it in place instead of stacking another copy.
+					// One placeholder per identity, so a component that drops and
+					// returns refreshes in place instead of stacking another copy.
 					const retainedId = `retained-${ identity }`;
 					if ( ! nextRetainedMessages.has( retainedId ) ) {
 						nextRetainedMessages.set( retainedId, { ...message, id: retainedId } );
@@ -273,7 +319,7 @@ export default function OrchestratorChat( {
 		}
 
 		previousMessagesRef.current = messages;
-	}, [ getShowComponentOrder, messages ] );
+	}, [ getShowComponentOrder, messages, isRegenerating ] );
 
 	// Reader-chat sessions are short (usually < 50 messages) — don't waste
 	// time paginating 10 pages deep. One page covers typical use.
@@ -359,7 +405,7 @@ export default function OrchestratorChat( {
 	// appears in the same paint rather than a commit later.
 	const getRegenerateActionsForMessage = useRegenerateAction( {
 		enabled: capabilities?.supportsRegenerateAction === true,
-		getRegenerateHandler,
+		getRegenerateHandler: handleRegenerate,
 	} );
 
 	// Add a "Copy" action on plain-text agent messages.

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -237,8 +237,7 @@ export default function OrchestratorChat( {
 		}
 	}, [ isProcessing, isRegenerating ] );
 
-	// Wrap Agenttic's regenerate handler so a click marks a regeneration in
-	// progress. While it runs, the component being regenerated is deliberately
+	// While a regeneration runs, the component being regenerated is deliberately
 	// dropped from the live messages (Agenttic sends `preserveUiOnlyMessages:
 	// false`), so retention must not resurrect the old picker as a stale copy.
 	const handleRegenerate = useCallback(

--- a/packages/agents-manager/src/hooks/__tests__/use-regenerate-action.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-regenerate-action.test.ts
@@ -22,9 +22,9 @@ const createMessage = ( id: string, role: 'user' | 'agent' ): UIMessage => ( {
 	showIcon: true,
 } );
 
+const latestComplete = { isLatestAgentMessage: true, isStreaming: false };
+
 describe( 'useRegenerateAction', () => {
-	const registerMessageActions = jest.fn();
-	const unregisterMessageActions = jest.fn();
 	const onRegenerate = jest.fn();
 	const getRegenerateHandler = jest.fn( () => onRegenerate );
 
@@ -32,46 +32,37 @@ describe( 'useRegenerateAction', () => {
 		jest.clearAllMocks();
 	} );
 
-	it( 'does not register the action until enabled', () => {
-		renderHook( () =>
-			useRegenerateAction( {
-				enabled: false,
-				isProcessing: false,
-				registerMessageActions,
-				unregisterMessageActions,
-				getRegenerateHandler,
-			} )
+	it( 'returns no action when disabled', () => {
+		const { result } = renderHook( () =>
+			useRegenerateAction( { enabled: false, getRegenerateHandler } )
 		);
 
-		expect( registerMessageActions ).not.toHaveBeenCalled();
-		expect( unregisterMessageActions ).toHaveBeenCalledWith( 'agents-manager-regenerate' );
+		expect( result.current( createMessage( 'agent-1', 'agent' ), latestComplete ) ).toEqual( [] );
+		expect( getRegenerateHandler ).not.toHaveBeenCalled();
 	} );
 
-	it( 'builds the regenerate action spec from the handler', () => {
-		renderHook( () =>
-			useRegenerateAction( {
-				enabled: true,
-				isProcessing: false,
-				registerMessageActions,
-				unregisterMessageActions,
-				getRegenerateHandler,
-			} )
+	it( 'returns no action when the handler getter is unavailable', () => {
+		const { result } = renderHook( () =>
+			useRegenerateAction( { enabled: true, getRegenerateHandler: undefined } )
 		);
 
-		expect( registerMessageActions ).toHaveBeenCalledWith( {
-			id: 'agents-manager-regenerate',
-			actions: expect.any( Function ),
-		} );
+		expect( result.current( createMessage( 'agent-1', 'agent' ), latestComplete ) ).toEqual( [] );
+	} );
 
-		const registration = registerMessageActions.mock.calls[ 0 ][ 0 ];
+	it( 'builds an enabled regenerate action for the latest completed agent message', () => {
+		const { result } = renderHook( () =>
+			useRegenerateAction( { enabled: true, getRegenerateHandler } )
+		);
+
 		const message = createMessage( 'agent-1', 'agent' );
 
-		expect( registration.actions( message ) ).toEqual( [
+		expect( result.current( message, latestComplete ) ).toEqual( [
 			expect.objectContaining( {
 				id: 'regenerate',
 				label: 'Regenerate',
 				tooltip: 'Regenerate response',
 				onClick: onRegenerate,
+				disabled: false,
 				icon: expect.objectContaining( {
 					props: expect.objectContaining( {
 						className: 'agents-manager-message-action-icon',
@@ -83,71 +74,66 @@ describe( 'useRegenerateAction', () => {
 		expect( getRegenerateHandler ).toHaveBeenCalledWith( message );
 	} );
 
-	it( 'returns no action when the message is not regeneratable', () => {
+	it( 'disables the action on older agent messages', () => {
+		const { result } = renderHook( () =>
+			useRegenerateAction( { enabled: true, getRegenerateHandler } )
+		);
+
+		const [ action ] = result.current( createMessage( 'agent-1', 'agent' ), {
+			isLatestAgentMessage: false,
+			isStreaming: false,
+		} );
+
+		expect( action ).toEqual(
+			expect.objectContaining( { id: 'regenerate', disabled: true, onClick: onRegenerate } )
+		);
+	} );
+
+	it( 'shows a disabled placeholder on the latest message while streaming', () => {
+		// Mid-stream the turn is not yet regeneratable, so agenttic returns no handler.
 		getRegenerateHandler.mockReturnValueOnce( null as unknown as typeof onRegenerate );
 
-		renderHook( () =>
-			useRegenerateAction( {
-				enabled: true,
-				isProcessing: false,
-				registerMessageActions,
-				unregisterMessageActions,
-				getRegenerateHandler,
+		const { result } = renderHook( () =>
+			useRegenerateAction( { enabled: true, getRegenerateHandler } )
+		);
+
+		const [ action ] = result.current( createMessage( 'agent-1', 'agent' ), {
+			isLatestAgentMessage: true,
+			isStreaming: true,
+		} );
+
+		expect( action ).toEqual(
+			expect.objectContaining( {
+				id: 'regenerate',
+				disabled: true,
+				onClick: expect.any( Function ),
 			} )
 		);
-
-		const registration = registerMessageActions.mock.calls[ 0 ][ 0 ];
-		const message = createMessage( 'user-1', 'user' );
-
-		expect( registration.actions( message ) ).toEqual( [] );
 	} );
 
-	it( 'does not register the action when the handler getter is unavailable', () => {
-		renderHook( () =>
-			useRegenerateAction( {
-				enabled: true,
-				isProcessing: false,
-				registerMessageActions,
-				unregisterMessageActions,
-				getRegenerateHandler: undefined,
+	it( 'returns no action for a non-latest message with no handler', () => {
+		getRegenerateHandler.mockReturnValueOnce( null as unknown as typeof onRegenerate );
+
+		const { result } = renderHook( () =>
+			useRegenerateAction( { enabled: true, getRegenerateHandler } )
+		);
+
+		expect(
+			result.current( createMessage( 'agent-1', 'agent' ), {
+				isLatestAgentMessage: false,
+				isStreaming: true,
 			} )
-		);
-
-		expect( registerMessageActions ).not.toHaveBeenCalled();
-		expect( unregisterMessageActions ).toHaveBeenCalledWith( 'agents-manager-regenerate' );
+		).toEqual( [] );
 	} );
 
-	it( 'refreshes registration when processing state changes', () => {
-		const { rerender } = renderHook(
-			( { isProcessing } ) =>
-				useRegenerateAction( {
-					enabled: true,
-					isProcessing,
-					registerMessageActions,
-					unregisterMessageActions,
-					getRegenerateHandler,
-				} ),
-			{ initialProps: { isProcessing: true } }
+	it( 'keeps the getter stable while its inputs are unchanged', () => {
+		const { result, rerender } = renderHook( () =>
+			useRegenerateAction( { enabled: true, getRegenerateHandler } )
 		);
 
-		rerender( { isProcessing: false } );
+		const firstGetter = result.current;
+		rerender();
 
-		expect( registerMessageActions ).toHaveBeenCalledTimes( 2 );
-	} );
-
-	it( 'unregisters the action on unmount', () => {
-		const { unmount } = renderHook( () =>
-			useRegenerateAction( {
-				enabled: true,
-				isProcessing: false,
-				registerMessageActions,
-				unregisterMessageActions,
-				getRegenerateHandler,
-			} )
-		);
-
-		unmount();
-
-		expect( unregisterMessageActions ).toHaveBeenCalledWith( 'agents-manager-regenerate' );
+		expect( result.current ).toBe( firstGetter );
 	} );
 } );

--- a/packages/agents-manager/src/hooks/__tests__/use-regenerate-action.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-regenerate-action.test.ts
@@ -102,6 +102,21 @@ describe( 'useRegenerateAction', () => {
 		expect( registration.actions( message ) ).toEqual( [] );
 	} );
 
+	it( 'does not register the action when the handler getter is unavailable', () => {
+		renderHook( () =>
+			useRegenerateAction( {
+				enabled: true,
+				isProcessing: false,
+				registerMessageActions,
+				unregisterMessageActions,
+				getRegenerateHandler: undefined,
+			} )
+		);
+
+		expect( registerMessageActions ).not.toHaveBeenCalled();
+		expect( unregisterMessageActions ).toHaveBeenCalledWith( 'agents-manager-regenerate' );
+	} );
+
 	it( 'refreshes registration when processing state changes', () => {
 		const { rerender } = renderHook(
 			( { isProcessing } ) =>

--- a/packages/agents-manager/src/hooks/__tests__/use-regenerate-action.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-regenerate-action.test.ts
@@ -1,0 +1,138 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import useRegenerateAction from '../use-regenerate-action';
+import type { UIMessage } from '@automattic/agenttic-client';
+
+jest.mock(
+	'@automattic/agenttic-ui',
+	() => ( {
+		RegenerateAltIcon: () => null,
+	} ),
+	{ virtual: true }
+);
+
+const createMessage = ( id: string, role: 'user' | 'agent' ): UIMessage => ( {
+	id,
+	role,
+	content: [ { type: 'text', text: 'Message text' } ],
+	timestamp: Date.now(),
+	archived: false,
+	showIcon: true,
+} );
+
+describe( 'useRegenerateAction', () => {
+	const registerMessageActions = jest.fn();
+	const unregisterMessageActions = jest.fn();
+	const onRegenerate = jest.fn();
+	const getRegenerateHandler = jest.fn( () => onRegenerate );
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'does not register the action until enabled', () => {
+		renderHook( () =>
+			useRegenerateAction( {
+				enabled: false,
+				isProcessing: false,
+				registerMessageActions,
+				unregisterMessageActions,
+				getRegenerateHandler,
+			} )
+		);
+
+		expect( registerMessageActions ).not.toHaveBeenCalled();
+		expect( unregisterMessageActions ).toHaveBeenCalledWith( 'agents-manager-regenerate' );
+	} );
+
+	it( 'builds the regenerate action spec from the handler', () => {
+		renderHook( () =>
+			useRegenerateAction( {
+				enabled: true,
+				isProcessing: false,
+				registerMessageActions,
+				unregisterMessageActions,
+				getRegenerateHandler,
+			} )
+		);
+
+		expect( registerMessageActions ).toHaveBeenCalledWith( {
+			id: 'agents-manager-regenerate',
+			actions: expect.any( Function ),
+		} );
+
+		const registration = registerMessageActions.mock.calls[ 0 ][ 0 ];
+		const message = createMessage( 'agent-1', 'agent' );
+
+		expect( registration.actions( message ) ).toEqual( [
+			expect.objectContaining( {
+				id: 'regenerate',
+				label: 'Regenerate',
+				tooltip: 'Regenerate response',
+				onClick: onRegenerate,
+				icon: expect.objectContaining( {
+					props: expect.objectContaining( {
+						className: 'agents-manager-message-action-icon',
+					} ),
+				} ),
+				order: 3.5,
+			} ),
+		] );
+		expect( getRegenerateHandler ).toHaveBeenCalledWith( message );
+	} );
+
+	it( 'returns no action when the message is not regeneratable', () => {
+		getRegenerateHandler.mockReturnValueOnce( null as unknown as typeof onRegenerate );
+
+		renderHook( () =>
+			useRegenerateAction( {
+				enabled: true,
+				isProcessing: false,
+				registerMessageActions,
+				unregisterMessageActions,
+				getRegenerateHandler,
+			} )
+		);
+
+		const registration = registerMessageActions.mock.calls[ 0 ][ 0 ];
+		const message = createMessage( 'user-1', 'user' );
+
+		expect( registration.actions( message ) ).toEqual( [] );
+	} );
+
+	it( 'refreshes registration when processing state changes', () => {
+		const { rerender } = renderHook(
+			( { isProcessing } ) =>
+				useRegenerateAction( {
+					enabled: true,
+					isProcessing,
+					registerMessageActions,
+					unregisterMessageActions,
+					getRegenerateHandler,
+				} ),
+			{ initialProps: { isProcessing: true } }
+		);
+
+		rerender( { isProcessing: false } );
+
+		expect( registerMessageActions ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'unregisters the action on unmount', () => {
+		const { unmount } = renderHook( () =>
+			useRegenerateAction( {
+				enabled: true,
+				isProcessing: false,
+				registerMessageActions,
+				unregisterMessageActions,
+				getRegenerateHandler,
+			} )
+		);
+
+		unmount();
+
+		expect( unregisterMessageActions ).toHaveBeenCalledWith( 'agents-manager-regenerate' );
+	} );
+} );

--- a/packages/agents-manager/src/hooks/use-regenerate-action.ts
+++ b/packages/agents-manager/src/hooks/use-regenerate-action.ts
@@ -1,0 +1,65 @@
+import { RegenerateAltIcon } from '@automattic/agenttic-ui';
+import { createElement, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import type { UIMessage, UseAgentChatReturn } from '@automattic/agenttic-client';
+
+const REGENERATE_ACTION_REGISTRATION_ID = 'agents-manager-regenerate';
+const REGENERATE_ACTION_ORDER = 3.5;
+
+interface UseRegenerateActionConfig {
+	enabled: boolean;
+	isProcessing: boolean;
+	registerMessageActions: UseAgentChatReturn[ 'registerMessageActions' ];
+	unregisterMessageActions: UseAgentChatReturn[ 'unregisterMessageActions' ];
+	getRegenerateHandler: UseAgentChatReturn[ 'getRegenerateHandler' ];
+}
+
+/**
+ * Registers Agenttic's built-in regenerate action in AM's message action row.
+ */
+export default function useRegenerateAction( {
+	enabled,
+	isProcessing,
+	registerMessageActions,
+	unregisterMessageActions,
+	getRegenerateHandler,
+}: UseRegenerateActionConfig ): void {
+	useEffect( () => {
+		if ( ! enabled ) {
+			unregisterMessageActions( REGENERATE_ACTION_REGISTRATION_ID );
+			return;
+		}
+
+		registerMessageActions( {
+			id: REGENERATE_ACTION_REGISTRATION_ID,
+			actions: ( message: UIMessage ) => {
+				const onRegenerate = getRegenerateHandler( message );
+
+				return onRegenerate
+					? [
+							{
+								id: 'regenerate',
+								label: __( 'Regenerate', '__i18n_text_domain__' ),
+								tooltip: __( 'Regenerate response', '__i18n_text_domain__' ),
+								icon: createElement( RegenerateAltIcon, {
+									className: 'agents-manager-message-action-icon',
+								} ),
+								order: REGENERATE_ACTION_ORDER,
+								onClick: onRegenerate,
+							},
+					  ]
+					: [];
+			},
+		} );
+
+		return () => {
+			unregisterMessageActions( REGENERATE_ACTION_REGISTRATION_ID );
+		};
+	}, [
+		enabled,
+		getRegenerateHandler,
+		isProcessing,
+		registerMessageActions,
+		unregisterMessageActions,
+	] );
+}

--- a/packages/agents-manager/src/hooks/use-regenerate-action.ts
+++ b/packages/agents-manager/src/hooks/use-regenerate-action.ts
@@ -1,10 +1,12 @@
 import { RegenerateAltIcon } from '@automattic/agenttic-ui';
-import { createElement, useEffect } from '@wordpress/element';
+import { createElement, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import type { UIMessage, UseAgentChatReturn } from '@automattic/agenttic-client';
+import type { UIMessage } from '@automattic/agenttic-client';
+import type { MessageAction } from '@automattic/agenttic-ui/dist/types';
 
-const REGENERATE_ACTION_REGISTRATION_ID = 'agents-manager-regenerate';
 const REGENERATE_ACTION_ORDER = 3.5;
+
+const noop = () => {};
 
 type RegenerateHandlerGetter = (
 	message?: UIMessage
@@ -12,58 +14,62 @@ type RegenerateHandlerGetter = (
 
 interface UseRegenerateActionConfig {
 	enabled: boolean;
-	isProcessing: boolean;
-	registerMessageActions: UseAgentChatReturn[ 'registerMessageActions' ];
-	unregisterMessageActions: UseAgentChatReturn[ 'unregisterMessageActions' ];
 	getRegenerateHandler?: RegenerateHandlerGetter;
 }
 
+interface RegenerateActionOptions {
+	/** Whether this message is the most recent agent message. */
+	isLatestAgentMessage: boolean;
+	/** Whether a response is currently streaming. */
+	isStreaming: boolean;
+}
+
 /**
- * Registers Agenttic's built-in regenerate action in AM's message action row.
+ * Builds Agenttic's built-in regenerate action for a given agent message.
+ *
+ * Only the latest agent message can be regenerated, and only once its response
+ * has finished streaming (agenttic exposes a handler for the completed turn).
  */
 export default function useRegenerateAction( {
 	enabled,
-	isProcessing,
-	registerMessageActions,
-	unregisterMessageActions,
 	getRegenerateHandler,
-}: UseRegenerateActionConfig ): void {
-	useEffect( () => {
-		if ( ! enabled || typeof getRegenerateHandler !== 'function' ) {
-			unregisterMessageActions( REGENERATE_ACTION_REGISTRATION_ID );
-			return;
-		}
+}: UseRegenerateActionConfig ): (
+	message: UIMessage,
+	options: RegenerateActionOptions
+) => MessageAction[] {
+	return useCallback(
+		( message: UIMessage, { isLatestAgentMessage, isStreaming }: RegenerateActionOptions ) => {
+			if ( ! enabled ) {
+				return [];
+			}
 
-		registerMessageActions( {
-			id: REGENERATE_ACTION_REGISTRATION_ID,
-			actions: ( message: UIMessage ) => {
-				const onRegenerate = getRegenerateHandler( message );
+			const onRegenerate =
+				typeof getRegenerateHandler === 'function' ? getRegenerateHandler( message ) : null;
 
-				return onRegenerate
-					? [
-							{
-								id: 'regenerate',
-								label: __( 'Regenerate', '__i18n_text_domain__' ),
-								tooltip: __( 'Regenerate response', '__i18n_text_domain__' ),
-								icon: createElement( RegenerateAltIcon, {
-									className: 'agents-manager-message-action-icon',
-								} ),
-								order: REGENERATE_ACTION_ORDER,
-								onClick: onRegenerate,
-							},
-					  ]
-					: [];
-			},
-		} );
+			// Show the icon when the turn is regeneratable, or as a disabled
+			// placeholder on the latest message while its response is streaming.
+			const showStreamingPlaceholder = isLatestAgentMessage && isStreaming && ! onRegenerate;
+			if ( ! onRegenerate && ! showStreamingPlaceholder ) {
+				return [];
+			}
 
-		return () => {
-			unregisterMessageActions( REGENERATE_ACTION_REGISTRATION_ID );
-		};
-	}, [
-		enabled,
-		getRegenerateHandler,
-		isProcessing,
-		registerMessageActions,
-		unregisterMessageActions,
-	] );
+			// Enabled only for the latest agent message once its turn is complete.
+			const isEnabled = isLatestAgentMessage && Boolean( onRegenerate );
+
+			return [
+				{
+					id: 'regenerate',
+					label: __( 'Regenerate', '__i18n_text_domain__' ),
+					tooltip: __( 'Regenerate response', '__i18n_text_domain__' ),
+					icon: createElement( RegenerateAltIcon, {
+						className: 'agents-manager-message-action-icon',
+					} ),
+					order: REGENERATE_ACTION_ORDER,
+					disabled: ! isEnabled,
+					onClick: onRegenerate ?? noop,
+				},
+			];
+		},
+		[ enabled, getRegenerateHandler ]
+	);
 }

--- a/packages/agents-manager/src/hooks/use-regenerate-action.ts
+++ b/packages/agents-manager/src/hooks/use-regenerate-action.ts
@@ -6,12 +6,16 @@ import type { UIMessage, UseAgentChatReturn } from '@automattic/agenttic-client'
 const REGENERATE_ACTION_REGISTRATION_ID = 'agents-manager-regenerate';
 const REGENERATE_ACTION_ORDER = 3.5;
 
+type RegenerateHandlerGetter = (
+	message?: UIMessage
+) => ( () => void | Promise< void > ) | null | undefined;
+
 interface UseRegenerateActionConfig {
 	enabled: boolean;
 	isProcessing: boolean;
 	registerMessageActions: UseAgentChatReturn[ 'registerMessageActions' ];
 	unregisterMessageActions: UseAgentChatReturn[ 'unregisterMessageActions' ];
-	getRegenerateHandler: UseAgentChatReturn[ 'getRegenerateHandler' ];
+	getRegenerateHandler?: RegenerateHandlerGetter;
 }
 
 /**
@@ -25,7 +29,7 @@ export default function useRegenerateAction( {
 	getRegenerateHandler,
 }: UseRegenerateActionConfig ): void {
 	useEffect( () => {
-		if ( ! enabled ) {
+		if ( ! enabled || typeof getRegenerateHandler !== 'function' ) {
 			unregisterMessageActions( REGENERATE_ACTION_REGISTRATION_ID );
 			return;
 		}

--- a/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
@@ -44,6 +44,12 @@ describe( 'mergeCapabilitiesInto', () => {
 		expect( merged.supportsSplitScreen ).toBe( true );
 	} );
 
+	it( 'sets supportsRegenerateAction when the provider declares it', () => {
+		const merged: ProviderCapabilities = {};
+		mergeCapabilitiesInto( merged, { supportsRegenerateAction: true } );
+		expect( merged.supportsRegenerateAction ).toBe( true );
+	} );
+
 	it( 'leaves supportsSplitScreen unset when the provider declares false', () => {
 		const merged: ProviderCapabilities = {};
 		mergeCapabilitiesInto( merged, { supportsSplitScreen: false } );
@@ -56,8 +62,10 @@ describe( 'mergeCapabilitiesInto', () => {
 		// silently opt in via JavaScript truthiness.
 		mergeCapabilitiesInto( merged, { supportsSplitScreen: 'false' } );
 		mergeCapabilitiesInto( merged, { supportsSplitScreen: 'true' } );
+		mergeCapabilitiesInto( merged, { supportsRegenerateAction: 'true' } );
 		mergeCapabilitiesInto( merged, { supportsSplitScreen: 1 } );
 		expect( merged.supportsSplitScreen ).toBeUndefined();
+		expect( merged.supportsRegenerateAction ).toBeUndefined();
 	} );
 
 	it( 'OR-merges across providers — any true wins', () => {
@@ -75,11 +83,15 @@ describe( 'mergeCapabilitiesInto', () => {
 		// probe each known key by direct access to hit the get trap.
 		const lazyCapabilities = new Proxy(
 			{},
-			{ get: ( _target, prop ) => ( prop === 'supportsSplitScreen' ? true : undefined ) }
+			{
+				get: ( _target, prop ) =>
+					prop === 'supportsSplitScreen' || prop === 'supportsRegenerateAction' ? true : undefined,
+			}
 		);
 		const merged: ProviderCapabilities = {};
 		mergeCapabilitiesInto( merged, lazyCapabilities );
 		expect( merged.supportsSplitScreen ).toBe( true );
+		expect( merged.supportsRegenerateAction ).toBe( true );
 	} );
 } );
 

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -125,6 +125,8 @@ export type { ImageUploadHook };
 export interface ProviderCapabilities {
 	/** Adds the "Split screen sidebar" chat-header menu item when true. */
 	supportsSplitScreen?: boolean;
+	/** Adds Agenttic's built-in regenerate action to agent messages when true. */
+	supportsRegenerateAction?: boolean;
 }
 
 /**
@@ -140,6 +142,9 @@ export function mergeCapabilitiesInto( merged: ProviderCapabilities, capabilitie
 	// runtime-imported modules; a stray `'false'` string would otherwise opt in.
 	if ( caps.supportsSplitScreen === true ) {
 		merged.supportsSplitScreen = true;
+	}
+	if ( caps.supportsRegenerateAction === true ) {
+		merged.supportsRegenerateAction = true;
 	}
 }
 

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -853,7 +853,8 @@ function trackBlockTransformationSuggestionClickForValue( value: string ): void 
  */
 export const capabilities = {
 	supportsSplitScreen: true,
-	supportsRegenerateAction: true,
+	// Flip to `true` to enable regenerate in the Jetpack AI sidebar.
+	supportsRegenerateAction: false,
 };
 
 /**

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -848,11 +848,12 @@ function trackBlockTransformationSuggestionClickForValue( value: string ): void 
 
 /**
  * Provider capability flags (OR-merged across providers by AM's
- * loadExternalProviders). `supportsSplitScreen` exposes the 50vw chat-header
- * toggle here only — block-notes / image-studio / Big Sky don't opt in.
+ * loadExternalProviders). These opt the Jetpack AI sidebar into AM features
+ * that are not enabled globally.
  */
 export const capabilities = {
 	supportsSplitScreen: true,
+	supportsRegenerateAction: true,
 };
 
 /**


### PR DESCRIPTION
Part of FORNO-325

## Proposed Changes

* Add a provider capability, `supportsRegenerateAction`, for opting into Agenttic’s built-in regenerate message action (added by 334-ghe-Automattic/agenttic)
* Register the regenerate action in Agents Manager only when a loaded provider declares that capability.
* Pass provider capabilities through `AgentDock` to `OrchestratorChat`.
* Opt the Jetpack AI sidebar provider into the regenerate action.
* Add unit coverage for capability merging, regenerate action registration, and Orchestrator Chat capability gating.

## Why are these changes being made?

* The regenerate action should be available for Jetpack AI sidebar conversations, but it should not be enabled globally for every Agents Manager provider. Making this capability-based lets providers opt in explicitly while preserving existing behaviour elsewhere.

## Testing Instructions

This PR depends on unpublished Agenttic package changes, so local manual testing currently needs temporary `package.json` resolutions that link `@automattic/agenttic-client` and `@automattic/agenttic-ui` to a local Agenttic checkout. These `link:` changes are for testing only and are intentionally not included in this PR.

* Check out this branch.
* `yarn install`
* `cd apps/agents-manager && yarn dev --sync`
* Sandbox `widgets.wp.com`
* Enable Jetpack AI sidebar on your test site
* Send a message and wait for an agent response.
* Confirm the regenerate action appears for regeneratable agent messages.
* Confirm clicking regenerate requests a fresh response.
* Confirm providers that do not export `supportsRegenerateAction: true` do not show the regenerate action.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
