### PR TITLE
Help Center FAB: redesign per Figma spec

### DIFF
--- a/client/components/help-center-fab/index.tsx
+++ b/client/components/help-center-fab/index.tsx
@@ -11,8 +11,8 @@ import './style.scss';
 
 const QuestionMarkIcon = () => (
 	<svg
-		width="24"
-		height="24"
+		width="20"
+		height="20"
 		viewBox="0 0 24 24"
 		xmlns="http://www.w3.org/2000/svg"
 		aria-hidden="true"

--- a/client/components/help-center-fab/style.scss
+++ b/client/components/help-center-fab/style.scss
@@ -2,10 +2,6 @@
 $help-center-fab-size: 44px;
 $help-center-fab-offset: 24px;
 $help-center-fab-gap: 8px;
-// Per design: each state is a solid Blueberry-over-surface mix.
-//   default: rgba(235, 238, 253, 1) ≈ 10% Blueberry
-//   hover:   rgba(222, 228, 251, 1) ≈ 16% Blueberry
-//   active:  rgba(200, 209, 247, 1) ≈ 28% Blueberry
 $help-center-fab-bg-default: color-mix(
 	in srgb,
 	var( --studio-blue-50 ) 10%,
@@ -21,8 +17,6 @@ $help-center-fab-bg-active: color-mix(
 	var( --studio-blue-50 ) 28%,
 	var( --color-surface )
 );
-// Shared drop-shadow stack — also re-applied on focus to override the
-// WordPress Button's accent-coloured focus-ring box-shadow.
 $help-center-fab-shadow:
 	0 4px 4px color-mix( in srgb, var( --color-neutral-100 ) 1%, transparent ),
 	0 3px 3px color-mix( in srgb, var( --color-neutral-100 ) 2%, transparent ),
@@ -48,7 +42,6 @@ $help-center-fab-shadow:
 	inline-size: $help-center-fab-size;
 	block-size: $help-center-fab-size;
 	padding: 0;
-	// 10% black border per design.
 	border: 1px solid color-mix( in srgb, var( --color-neutral-100 ) 10%, transparent );
 	border-radius: 50%;
 	background: $help-center-fab-bg-default;
@@ -58,22 +51,18 @@ $help-center-fab-shadow:
 
 	&:hover {
 		background: $help-center-fab-bg-hover;
-		// 14% black border on hover per design.
 		border-color: color-mix( in srgb, var( --color-neutral-100 ) 14%, transparent );
-		// Keep the question-mark icon dark; @wordpress/components Button would
-		// otherwise tint it with the WP admin theme colour on hover.
+		// Override @wordpress/components Button's hover tint so the icon stays dark.
 		color: var( --color-neutral-100 );
 	}
 
 	&.is-active {
 		background: $help-center-fab-bg-active;
-		// 16% black border on active per design.
 		border-color: color-mix( in srgb, var( --color-neutral-100 ) 16%, transparent );
 		color: var( --color-neutral-100 );
 	}
 
-	// Replace the @wordpress/components Button accent focus-ring box-shadow
-	// with our regular drop shadow; outline (below) handles keyboard focus.
+	// Override the @wordpress/components Button accent focus-ring box-shadow.
 	&:focus:not( :disabled ) {
 		box-shadow: $help-center-fab-shadow;
 	}

--- a/client/components/help-center-fab/style.scss
+++ b/client/components/help-center-fab/style.scss
@@ -1,6 +1,33 @@
-$help-center-fab-size: 48px;
+// 44px matches Apple HIG's minimum tap target.
+$help-center-fab-size: 44px;
 $help-center-fab-offset: 24px;
 $help-center-fab-gap: 8px;
+// Per design: each state is a solid Blueberry-over-surface mix.
+//   default: rgba(235, 238, 253, 1) ≈ 10% Blueberry
+//   hover:   rgba(222, 228, 251, 1) ≈ 16% Blueberry
+//   active:  rgba(200, 209, 247, 1) ≈ 28% Blueberry
+$help-center-fab-bg-default: color-mix(
+	in srgb,
+	var( --studio-blue-50 ) 10%,
+	var( --color-surface )
+);
+$help-center-fab-bg-hover: color-mix(
+	in srgb,
+	var( --studio-blue-50 ) 16%,
+	var( --color-surface )
+);
+$help-center-fab-bg-active: color-mix(
+	in srgb,
+	var( --studio-blue-50 ) 28%,
+	var( --color-surface )
+);
+// Shared drop-shadow stack — also re-applied on focus to override the
+// WordPress Button's accent-coloured focus-ring box-shadow.
+$help-center-fab-shadow:
+	0 4px 4px color-mix( in srgb, var( --color-neutral-100 ) 1%, transparent ),
+	0 3px 3px color-mix( in srgb, var( --color-neutral-100 ) 2%, transparent ),
+	0 1px 2px color-mix( in srgb, var( --color-neutral-100 ) 2%, transparent ),
+	0 1px 1px color-mix( in srgb, var( --color-neutral-100 ) 3%, transparent );
 
 .components-button.help-center-fab {
 	position: fixed;
@@ -21,31 +48,43 @@ $help-center-fab-gap: 8px;
 	inline-size: $help-center-fab-size;
 	block-size: $help-center-fab-size;
 	padding: 0;
+	// 10% black border per design.
+	border: 1px solid color-mix( in srgb, var( --color-neutral-100 ) 10%, transparent );
 	border-radius: 50%;
-	background: var( --color-primary );
-	color: var( --color-text-inverted );
-	@include elevation( 4 );
-	transition: background-color 0.15s ease-in-out;
+	background: $help-center-fab-bg-default;
+	color: var( --color-neutral-100 );
+	box-shadow: $help-center-fab-shadow;
+	transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out;
 
-	&:hover,
-	&.is-active {
-		background: var( --color-primary-dark );
-		color: var( --color-text-inverted );
+	&:hover {
+		background: $help-center-fab-bg-hover;
+		// 14% black border on hover per design.
+		border-color: color-mix( in srgb, var( --color-neutral-100 ) 14%, transparent );
+		// Keep the question-mark icon dark; @wordpress/components Button would
+		// otherwise tint it with the WP admin theme colour on hover.
+		color: var( --color-neutral-100 );
 	}
 
-	// Suppress the default WordPress Button focus ring for non-keyboard focus
-	// (mouse / touch), since we already convey state via background colour.
+	&.is-active {
+		background: $help-center-fab-bg-active;
+		// 16% black border on active per design.
+		border-color: color-mix( in srgb, var( --color-neutral-100 ) 16%, transparent );
+		color: var( --color-neutral-100 );
+	}
+
+	// Replace the @wordpress/components Button accent focus-ring box-shadow
+	// with our regular drop shadow; outline (below) handles keyboard focus.
+	&:focus:not( :disabled ) {
+		box-shadow: $help-center-fab-shadow;
+	}
+
 	&:focus:not( :focus-visible ):not( :disabled ) {
-		@include elevation( 4 );
 		outline: none;
 	}
 
-	// Restore a visible keyboard-focus indicator. Uses an outline so it sits
-	// outside the FAB without competing with the drop shadow.
 	&:focus-visible:not( :disabled ) {
-		@include elevation( 4 );
-		outline: 2px solid var( --color-primary-dark );
-		outline-offset: 3px;
+		outline: 2px solid var( --studio-blue-50 );
+		outline-offset: 2px;
 	}
 
 	svg {


### PR DESCRIPTION
## Proposed Changes

* Restyle the logged-out Help Center FAB to match the Figma design (Domains — Search, node 10393-28688).
* Resize from 48×48 to 44×44 (Apple HIG minimum tap target); icon scales from 24px to 20px.
* Replace the solid \`--color-primary\` fill with a Blueberry-over-surface mix that deepens by state.
* Drop the WordPress Button accent focus-ring box-shadow; keep keyboard focus visible via outline on \`:focus-visible\`.

## Why are these changes being made?

Aligns the FAB with the design system's Blueberry palette so it reads as ambient support rather than a prominent CTA. The smaller footprint and lighter visual weight reduce visual collision with bottom-anchored components (e.g., the domains mini-cart).

### State spec

| State | Background | Border | Box-shadow |
|---|---|---|---|
| Default | \`color-mix(in srgb, var(--studio-blue-50) 10%, var(--color-surface))\` ≈ \`rgba(235, 238, 253, 1)\` | 10% black | 4-stop subtle drop shadow |
| Hover | \`color-mix(... 16%, ...)\` ≈ \`rgba(223, 228, 251)\` ≈ spec \`(222, 228, 251)\` | 14% black | same |
| Active | \`color-mix(... 28%, ...)\` ≈ \`rgb(199, 208, 249)\` ≈ spec \`(200, 209, 247)\` | 16% black | same |

The question-mark icon stays \`var(--color-neutral-100)\` across all states.

## Testing Instructions

* Logged out, visit \`/log-in\`, \`/log-in/lostpassword\`, \`/start/user\`, or \`/setup/onboarding/user\`. Confirm the FAB:
  * Renders as a 44px pale-blue circle with a dark question mark and a soft drop shadow.
  * Darkens on hover and again when the panel is open (\`.is-active\`).
  * Does not show a blue focus-ring when clicked.
  * Shows a clear outline when navigated to via keyboard (Tab).
* Open the Help Center panel and confirm it still anchors 8px above the FAB.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?