### PR TITLE
Add expired-plan downgrade flow: entry points, stepper, and post-checkout redirect

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -340,63 +340,6 @@ export const purchaseSettingsIndexRoute = createRoute( {
 	)
 );
 
-export const purchaseBySiteResolverRoute = createRoute( {
-	getParentRoute: () => purchasesRoute,
-	path: 'by-site/$siteSlug',
-	beforeLoad: async ( { params: { siteSlug } } ) => {
-		// Invalidate the cache and fetch fresh purchases — the new plan
-		// purchase was just created and likely isn't in any cached response.
-		await queryClient.invalidateQueries( { queryKey: userPurchasesQuery().queryKey } );
-		const purchases = await queryClient.fetchQuery( userPurchasesQuery() );
-
-		// Normalize .wpcomstaging.com ↔ .wordpress.com so either form matches.
-		const normalize = ( d: string | undefined | null ) =>
-			( d ?? '' ).replace( /\.wpcomstaging\.com$/, '.wordpress.com' );
-		const targetSlug = normalize( decodeURIComponent( siteSlug ) );
-
-		const now = Date.now();
-
-		// Find the active plan purchase for the site.
-		// The old expired plan may still be in the list, so we filter by
-		// expiry_date in the future and sort by highest ID (most recent
-		// purchase) to land on the newly purchased plan.
-		const sitePlans = purchases
-			.filter( ( p ) => {
-				if ( ! p.is_plan ) {
-					return false;
-				}
-				// Skip purchases with an expiry date in the past.
-				if ( p.expiry_date && new Date( p.expiry_date ).getTime() <= now ) {
-					return false;
-				}
-				// Skip purchases with explicit expired status.
-				if ( p.expiry_status === 'expired' ) {
-					return false;
-				}
-				return normalize( p.site_slug ) === targetSlug || normalize( p.domain ) === targetSlug;
-			} )
-			.sort( ( a, b ) => Number( b.ID ) - Number( a.ID ) );
-
-		const planPurchase = sitePlans[ 0 ];
-
-		if ( planPurchase ) {
-			throw dashboardRedirect( {
-				to: '/me/billing/purchases/$purchaseId',
-				params: { purchaseId: String( planPurchase.ID ) },
-				search: { plan_changed: true },
-				replace: true,
-			} );
-		}
-
-		// Fallback: no matching plan found, go to the purchases list.
-		throw dashboardRedirect( {
-			to: '/me/billing/purchases',
-			search: { plan_changed: true },
-			replace: true,
-		} );
-	},
-} );
-
 export const changePaymentMethodRoute = createRoute( {
 	head: () => ( {
 		meta: [
@@ -1280,7 +1223,6 @@ export const createMeRoutes = ( config: AppConfig ) => {
 				: [] ),
 			purchasesRoute.addChildren( [
 				purchasesIndexRoute,
-				purchaseBySiteResolverRoute,
 				purchaseSettingsRoute.addChildren( [
 					purchaseSettingsIndexRoute,
 					changePaymentMethodRoute,

--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -245,7 +245,9 @@ export const purchasesIndexRoute = createRoute( {
 		removed?: string;
 		removedDomain?: string;
 		removedId?: number;
+		plan_changed?: true;
 	} => {
+		const isPlanChanged = search.plan_changed === true || search.plan_changed === 'true';
 		return {
 			page: typeof search.page === 'number' ? search.page : undefined,
 			search: typeof search.search === 'string' ? search.search : undefined,
@@ -253,6 +255,7 @@ export const purchasesIndexRoute = createRoute( {
 			removed: typeof search.removed === 'string' ? search.removed : undefined,
 			removedDomain: typeof search.removedDomain === 'string' ? search.removedDomain : undefined,
 			removedId: typeof search.removedId === 'number' ? search.removedId : undefined,
+			...( isPlanChanged ? { plan_changed: true } : {} ),
 		};
 	},
 } ).lazy( () =>
@@ -286,18 +289,21 @@ export const purchaseSettingsRoute = createRoute( {
 		upgraded?: true;
 		cancelled?: true;
 		downgraded?: true;
+		plan_changed?: true;
 		intent?: 'auto-renew';
 	} => {
 		const isRefunded = search.refunded === true || search.refunded === 'true';
 		const isUpgraded = search.upgraded === true || search.upgraded === 'true';
 		const isCancelled = search.cancelled === true || search.cancelled === 'true';
 		const isDowngraded = search.downgraded === true || search.downgraded === 'true';
+		const isPlanChanged = search.plan_changed === true || search.plan_changed === 'true';
 		const intent = search.intent === 'auto-renew' ? ( 'auto-renew' as const ) : undefined;
 		return {
 			...( isRefunded ? { refunded: true } : {} ),
 			...( isUpgraded ? { upgraded: true } : {} ),
 			...( isCancelled ? { cancelled: true } : {} ),
 			...( isDowngraded ? { downgraded: true } : {} ),
+			...( isPlanChanged ? { plan_changed: true } : {} ),
 			...( intent ? { intent } : {} ),
 		};
 	},
@@ -333,6 +339,63 @@ export const purchaseSettingsIndexRoute = createRoute( {
 		} )
 	)
 );
+
+export const purchaseBySiteResolverRoute = createRoute( {
+	getParentRoute: () => purchasesRoute,
+	path: 'by-site/$siteSlug',
+	beforeLoad: async ( { params: { siteSlug } } ) => {
+		// Invalidate the cache and fetch fresh purchases — the new plan
+		// purchase was just created and likely isn't in any cached response.
+		await queryClient.invalidateQueries( { queryKey: userPurchasesQuery().queryKey } );
+		const purchases = await queryClient.fetchQuery( userPurchasesQuery() );
+
+		// Normalize .wpcomstaging.com ↔ .wordpress.com so either form matches.
+		const normalize = ( d: string | undefined | null ) =>
+			( d ?? '' ).replace( /\.wpcomstaging\.com$/, '.wordpress.com' );
+		const targetSlug = normalize( decodeURIComponent( siteSlug ) );
+
+		const now = Date.now();
+
+		// Find the active plan purchase for the site.
+		// The old expired plan may still be in the list, so we filter by
+		// expiry_date in the future and sort by highest ID (most recent
+		// purchase) to land on the newly purchased plan.
+		const sitePlans = purchases
+			.filter( ( p ) => {
+				if ( ! p.is_plan ) {
+					return false;
+				}
+				// Skip purchases with an expiry date in the past.
+				if ( p.expiry_date && new Date( p.expiry_date ).getTime() <= now ) {
+					return false;
+				}
+				// Skip purchases with explicit expired status.
+				if ( p.expiry_status === 'expired' ) {
+					return false;
+				}
+				return normalize( p.site_slug ) === targetSlug || normalize( p.domain ) === targetSlug;
+			} )
+			.sort( ( a, b ) => Number( b.ID ) - Number( a.ID ) );
+
+		const planPurchase = sitePlans[ 0 ];
+
+		if ( planPurchase ) {
+			throw dashboardRedirect( {
+				to: '/me/billing/purchases/$purchaseId',
+				params: { purchaseId: String( planPurchase.ID ) },
+				search: { plan_changed: true },
+				replace: true,
+			} );
+		}
+
+		// Fallback: no matching plan found, go to the purchases list.
+		throw dashboardRedirect( {
+			to: '/me/billing/purchases',
+			search: { plan_changed: true },
+			replace: true,
+		} );
+	},
+} );
 
 export const changePaymentMethodRoute = createRoute( {
 	head: () => ( {
@@ -1217,6 +1280,7 @@ export const createMeRoutes = ( config: AppConfig ) => {
 				: [] ),
 			purchasesRoute.addChildren( [
 				purchasesIndexRoute,
+				purchaseBySiteResolverRoute,
 				purchaseSettingsRoute.addChildren( [
 					purchaseSettingsIndexRoute,
 					changePaymentMethodRoute,

--- a/client/dashboard/me/billing-purchases/index.tsx
+++ b/client/dashboard/me/billing-purchases/index.tsx
@@ -14,6 +14,7 @@ import { usePersistentView } from '../../app/hooks/use-persistent-view';
 import { PerformanceTrackerStop } from '../../app/performance-tracking';
 import { purchasesIndexRoute, purchasesRoute } from '../../app/router/me';
 import { DataViews, DataViewsCard } from '../../components/dataviews';
+import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { adjustDataViewFieldsForWidth } from '../../utils/dataviews-width';
@@ -32,7 +33,7 @@ import { PurchaseRemovedNotice } from './purchase-removed-notice';
 export default function PurchasesList() {
 	const isSplitCancelRemoveEnabled = useIsSplitCancelRemoveEnabled();
 	const currentSearchParams = purchasesRoute.useSearch();
-	const { removed, removedDomain, removedId } = purchasesIndexRoute.useSearch();
+	const { removed, removedDomain, removedId, plan_changed } = purchasesIndexRoute.useSearch();
 	// Capture notice data on first render — useSearch() may lose the values
 	// after replaceState strips the URL params.
 	const [ removedNoticeData ] = useState( () =>
@@ -134,6 +135,7 @@ export default function PurchasesList() {
 					onClose={ () => setShowRemovedNotice( false ) }
 				/>
 			) }
+			{ plan_changed && <Notice variant="success">{ __( 'Your plan has been updated.' ) }</Notice> }
 			<div ref={ ref }>
 				<DataViewsCard className="purchases-list__wrapper">
 					{ ! isLoading && <PerformanceTrackerStop /> }

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -73,7 +73,7 @@ import SiteIcon from '../../../components/site-icon';
 import SiteBandwidthStat from '../../../sites/overview-plan-card/site-bandwidth-stat';
 import SiteStorageStat from '../../../sites/overview-plan-card/site-storage-stat';
 import { formatDate } from '../../../utils/datetime';
-import { redirectToDashboardLink, wpcomLink } from '../../../utils/link';
+import { dashboardLink, redirectToDashboardLink, wpcomLink } from '../../../utils/link';
 import {
 	getBillPeriodLabel,
 	getTitleForDisplay,
@@ -144,6 +144,7 @@ function getExpiredNewPlanUrl( purchase: Purchase, isDowngrade = false ): string
 			return addQueryArgs( url, {
 				expired_downgrade: 'true',
 				intervalType: intervalMap[ purchase.bill_period_days ] ?? 'yearly',
+				redirect_to: dashboardLink( '/me/billing/purchases/:purchaseId?plan_changed=true' ),
 			} );
 		}
 		return url;
@@ -453,6 +454,14 @@ function UpgradeActionButton( { purchase }: { purchase: Purchase } ) {
 	if ( ! purchase.is_upgradable ) {
 		return null;
 	}
+
+	// Expired/grace-period plans are handled by ReSubscribeActionButton
+	// ("Change plan" or "Pick another plan") — hide the standalone upgrade
+	// button to avoid showing two entry points.
+	if ( ( isExpired( purchase ) || isInExpirationGracePeriod( purchase ) ) && purchase.is_plan ) {
+		return null;
+	}
+
 	const upgradeUrl = getSitePurchaseUpgradeUrl( purchase, getUpgradedPurchaseRedirectUrl() );
 	if ( ! upgradeUrl ) {
 		return null;
@@ -500,12 +509,12 @@ function ReSubscribeActionButton( { purchase }: { purchase: Purchase } ) {
 		migrationStatus.startsWith( 'migration-started' ) ||
 		migrationStatus.startsWith( 'migration-in-progress' );
 
-	// Match the wpcom plan slugs: Personal, Premium (value_bundle), Business.
+	// Match the wpcom plan slugs: Premium (value_bundle), Business, Ecommerce.
+	// Personal is excluded — it's the lowest tier, nothing to downgrade to.
 	// Includes monthly, 2y, 3y variants.
-	const isDowngradeEligiblePlan =
-		/^(personal-bundle|value_bundle|business-bundle|ecommerce-bundle)/.test(
-			purchase.product_slug
-		);
+	const isDowngradeEligiblePlan = /^(value_bundle|business-bundle|ecommerce-bundle)/.test(
+		purchase.product_slug
+	);
 
 	const isEligibleForDowngrade =
 		isEnabled( 'plans/expired-plan-downgrade' ) &&

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -502,9 +502,10 @@ function ReSubscribeActionButton( { purchase }: { purchase: Purchase } ) {
 
 	// Match the wpcom plan slugs: Personal, Premium (value_bundle), Business.
 	// Includes monthly, 2y, 3y variants.
-	const isDowngradeEligiblePlan = /^(personal-bundle|value_bundle|business-bundle)/.test(
-		purchase.product_slug
-	);
+	const isDowngradeEligiblePlan =
+		/^(personal-bundle|value_bundle|business-bundle|ecommerce-bundle)/.test(
+			purchase.product_slug
+		);
 
 	const isEligibleForDowngrade =
 		isEnabled( 'plans/expired-plan-downgrade' ) &&

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -15,6 +15,7 @@ import {
 	reinstallMarketplacePluginsQuery,
 	siteBySlugQuery,
 } from '@automattic/api-queries';
+import { isEnabled } from '@automattic/calypso-config';
 import { domainManagementEdit, domainUseMyDomain } from '@automattic/domains-table/src/utils/paths';
 import { formatCurrency } from '@automattic/number-formatters';
 import { INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS } from '@automattic/urls';
@@ -122,7 +123,7 @@ function renewPurchase( purchase: Purchase ): void {
 	window.location.href = getRenewalUrlFromPurchase( purchase );
 }
 
-function getExpiredNewPlanUrl( purchase: Purchase ): string {
+function getExpiredNewPlanUrl( purchase: Purchase, isDowngrade = false ): string {
 	if ( purchase.is_jetpack_backup_t1 || isJetpackT1SecurityPlan( purchase ) ) {
 		return wpcomLink( `/plans/storage/${ purchase.site_slug }` );
 	}
@@ -132,7 +133,20 @@ function getExpiredNewPlanUrl( purchase: Purchase ): string {
 	}
 
 	if ( purchase.is_plan ) {
-		return getWpcomPlanGridUrl( purchase.site_slug );
+		const url = getWpcomPlanGridUrl( purchase.site_slug );
+		if ( isDowngrade ) {
+			const intervalMap: Record< number, string > = {
+				31: 'monthly',
+				365: 'yearly',
+				730: '2yearly',
+				1095: '3yearly',
+			};
+			return addQueryArgs( url, {
+				expired_downgrade: 'true',
+				intervalType: intervalMap[ purchase.bill_period_days ] ?? 'yearly',
+			} );
+		}
+		return url;
 	}
 
 	return wpcomLink( `/plans/${ purchase.site_slug }` );
@@ -468,12 +482,67 @@ function UpgradeActionButton( { purchase }: { purchase: Purchase } ) {
 
 function ReSubscribeActionButton( { purchase }: { purchase: Purchase } ) {
 	const { recordTracksEvent } = useAnalytics();
-	if ( ! isExpired( purchase ) ) {
+	const { data: site } = useQuery( {
+		...siteBySlugQuery( purchase.site_slug ?? '' ),
+		enabled: Boolean( purchase.site_slug ),
+	} );
+	const isPurchaseExpiredOrGracePeriod =
+		isExpired( purchase ) || isInExpirationGracePeriod( purchase );
+
+	if ( ! isPurchaseExpiredOrGracePeriod ) {
 		return null;
 	}
+
+	// Exclude sites with a pending migration — checkout fails for these.
+	const migrationStatus = site?.site_migration?.migration_status ?? '';
+	const isMigrating =
+		migrationStatus.startsWith( 'migration-pending' ) ||
+		migrationStatus.startsWith( 'migration-started' ) ||
+		migrationStatus.startsWith( 'migration-in-progress' );
+
+	// Match the wpcom plan slugs: Personal, Premium (value_bundle), Business.
+	// Includes monthly, 2y, 3y variants.
+	const isDowngradeEligiblePlan = /^(personal-bundle|value_bundle|business-bundle)/.test(
+		purchase.product_slug
+	);
+
+	const isEligibleForDowngrade =
+		isEnabled( 'plans/expired-plan-downgrade' ) &&
+		purchase.is_plan &&
+		! isMigrating &&
+		isDowngradeEligiblePlan;
+
+	if ( isEligibleForDowngrade ) {
+		return (
+			<ActionList.ActionItem
+				title={ __( 'Change plan' ) }
+				description={ __( 'Find the best fit for your needs.' ) }
+				actions={
+					<Button
+						variant="secondary"
+						size="compact"
+						onClick={ () => {
+							recordTracksEvent( 'calypso_expired_plan_change_plan_click', {
+								current_plan: purchase.product_slug,
+							} );
+							window.location.href = getExpiredNewPlanUrl( purchase, true );
+						} }
+					>
+						{ __( 'See plans' ) }
+					</Button>
+				}
+			/>
+		);
+	}
+
+	// Only show "Pick another plan" for plan purchases, not domains, migrating sites, or other products.
+	if ( ! purchase.is_plan || isMigrating ) {
+		return null;
+	}
+
 	return (
 		<ActionList.ActionItem
-			title={ purchase.is_plan ? __( 'Pick another plan' ) : __( 'Pick another product' ) }
+			title={ __( 'Pick another plan' ) }
 			description={ __( 'Find the best fit for your needs.' ) }
 			actions={
 				<Button
@@ -487,7 +556,7 @@ function ReSubscribeActionButton( { purchase }: { purchase: Purchase } ) {
 						window.location.href = getExpiredNewPlanUrl( purchase );
 					} }
 				>
-					{ purchase.is_plan ? __( 'Pick another plan' ) : __( 'Pick another product' ) }
+					{ __( 'Pick another plan' ) }
 				</Button>
 			}
 		/>

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -516,7 +516,7 @@ function ReSubscribeActionButton( { purchase }: { purchase: Purchase } ) {
 		return (
 			<ActionList.ActionItem
 				title={ __( 'Change plan' ) }
-				description={ __( 'Find the best fit for your needs.' ) }
+				description={ __( 'Upgrade or downgrade to a plan that works for you.' ) }
 				actions={
 					<Button
 						variant="secondary"

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -48,7 +48,8 @@ import type { Purchase } from '@automattic/api-core';
 export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 	const { user } = useAuth();
 	const isSplitCancelRemoveEnabled = useIsSplitCancelRemoveEnabled();
-	const { refunded, upgraded, cancelled, downgraded, intent } = purchaseSettingsRoute.useSearch();
+	const { refunded, upgraded, cancelled, downgraded, plan_changed, intent } =
+		purchaseSettingsRoute.useSearch();
 	const navigate = purchaseSettingsRoute.useNavigate();
 	// Show the transient cancelled success notice once after a cancel redirects
 	// here. The URL search param is cleared immediately so that a refresh / back
@@ -146,6 +147,19 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 		return (
 			<Notice variant="success" onClose={ () => setShowUpgradedNotice( false ) }>
 				{ __( 'Thank you for your purchase. Your site has been upgraded.' ) }
+			</Notice>
+		);
+	}
+
+	// Show success notice after a plan change (e.g. expired-plan downgrade checkout).
+	if ( plan_changed ) {
+		return (
+			<Notice variant="success">
+				{ sprintf(
+					// translators: %s is the name of the plan, e.g. "WordPress.com Personal"
+					__( 'Your plan has been updated to %s.' ),
+					purchase.product_name
+				) }
 			</Notice>
 		);
 	}

--- a/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
+++ b/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
@@ -129,9 +129,11 @@ const planUpgradeFlow: FlowV2< typeof initialize > = {
 							// Checkout validates redirect_to to prevent open redirects
 							const postCheckoutUrl = redirectTo || dashboardLink( '/sites' );
 
+							const isExpiredDowngrade = query.get( 'expired_downgrade' ) === 'true';
 							const finalUrl = addQueryArgs( checkoutUrl, {
 								redirect_to: postCheckoutUrl,
 								cancel_to: currentPath,
+								...( isExpiredDowngrade && { expired_downgrade: 'true' } ),
 							} );
 
 							window.location.assign( finalUrl );

--- a/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
+++ b/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
@@ -110,7 +110,6 @@ const planUpgradeFlow: FlowV2< typeof initialize > = {
 		const query = useQuery();
 		const siteSlug = query.get( 'siteSlug' );
 		const redirectTo = query.get( 'redirect_to' );
-		const isExpiredDowngrade = query.get( 'expired_downgrade' ) === 'true';
 
 		const submit: SubmitHandler< typeof initialize > = ( submittedStep ) => {
 			const { slug, providedDependencies } = submittedStep;
@@ -128,11 +127,7 @@ const planUpgradeFlow: FlowV2< typeof initialize > = {
 							// Build checkout URL with query params
 							// Note: Not using goToCheckout utility because it hardcodes signup=1
 							// Checkout validates redirect_to to prevent open redirects
-							const postCheckoutUrl = isExpiredDowngrade
-								? dashboardLink(
-										`/me/billing/purchases/by-site/${ encodeURIComponent( siteSlug ) }`
-								  )
-								: redirectTo || dashboardLink( '/sites' );
+							const postCheckoutUrl = redirectTo || dashboardLink( '/sites' );
 
 							const finalUrl = addQueryArgs( checkoutUrl, {
 								redirect_to: postCheckoutUrl,

--- a/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
+++ b/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
@@ -1,3 +1,4 @@
+import { getPlanPath } from '@automattic/calypso-products';
 import { PLAN_UPGRADE_FLOW } from '@automattic/onboarding';
 import { resolveSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -64,6 +65,7 @@ const planUpgradeFlow: FlowV2< typeof initialize > = {
 	useStepsProps() {
 		const query = useQuery();
 		const selectedFeature = query.get( 'feature' ) ?? undefined;
+		const isExpiredDowngrade = query.get( 'expired_downgrade' ) === 'true';
 		const backTo = query.get( 'back_to' ) ?? query.get( 'cancel_to' ) ?? undefined;
 
 		// Validate back_to to prevent open redirect - must not be external (expect for allowed origins).
@@ -84,6 +86,17 @@ const planUpgradeFlow: FlowV2< typeof initialize > = {
 				// Pass the feature parameter for feature-based plan filtering
 				selectedFeature,
 
+				// For expired-plan downgrades, hide plans that aren't eligible targets
+				// and show a helpful subtitle.
+				hideFreePlan: isExpiredDowngrade || undefined,
+				hideEcommercePlan: isExpiredDowngrade || undefined,
+				hideEnterprisePlan: isExpiredDowngrade || undefined,
+				hidePlanTypeSelector: isExpiredDowngrade || undefined,
+				headerText: isExpiredDowngrade ? __( 'Find your best fit' ) : undefined,
+				fallbackSubHeaderText: isExpiredDowngrade
+					? __( 'Compare plans and pick the one that works for where your site is headed.' )
+					: undefined,
+
 				// Provide a custom back handler that goes to back_to or /sites
 				wrapperProps: {
 					goBack: () => {
@@ -98,6 +111,7 @@ const planUpgradeFlow: FlowV2< typeof initialize > = {
 		const query = useQuery();
 		const siteSlug = query.get( 'siteSlug' );
 		const redirectTo = query.get( 'redirect_to' );
+		const isExpiredDowngrade = query.get( 'expired_downgrade' ) === 'true';
 
 		const submit: SubmitHandler< typeof initialize > = ( submittedStep ) => {
 			const { slug, providedDependencies } = submittedStep;
@@ -106,16 +120,23 @@ const planUpgradeFlow: FlowV2< typeof initialize > = {
 				case STEPS.UNIFIED_PLANS.slug: {
 					// User selected plan, go directly to checkout
 					if ( providedDependencies?.cartItems && providedDependencies.cartItems.length > 0 ) {
-						const selectedPlan = providedDependencies.cartItems[ 0 ]?.product_slug;
-						if ( selectedPlan && siteSlug ) {
-							const checkoutUrl = `/checkout/${ encodeURIComponent( siteSlug ) }/${ selectedPlan }`;
+						const selectedPlanSlug = providedDependencies.cartItems[ 0 ]?.product_slug;
+						const planPath = selectedPlanSlug ? getPlanPath( selectedPlanSlug ) : undefined;
+						if ( planPath && siteSlug ) {
+							const checkoutUrl = `/checkout/${ encodeURIComponent( siteSlug ) }/${ planPath }`;
 							const currentPath = window.location.href.replace( window.location.origin, '' );
 
 							// Build checkout URL with query params
 							// Note: Not using goToCheckout utility because it hardcodes signup=1
 							// Checkout validates redirect_to to prevent open redirects
+							const postCheckoutUrl = isExpiredDowngrade
+								? dashboardLink(
+										`/me/billing/purchases/by-site/${ encodeURIComponent( siteSlug ) }`
+								  )
+								: redirectTo || dashboardLink( '/sites' );
+
 							const finalUrl = addQueryArgs( checkoutUrl, {
-								redirect_to: redirectTo || dashboardLink( '/sites' ),
+								redirect_to: postCheckoutUrl,
 								cancel_to: currentPath,
 							} );
 

--- a/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
+++ b/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
@@ -89,7 +89,6 @@ const planUpgradeFlow: FlowV2< typeof initialize > = {
 				// For expired-plan downgrades, hide plans that aren't eligible targets
 				// and show a helpful subtitle.
 				hideFreePlan: isExpiredDowngrade || undefined,
-				hideEcommercePlan: isExpiredDowngrade || undefined,
 				hideEnterprisePlan: isExpiredDowngrade || undefined,
 				hidePlanTypeSelector: isExpiredDowngrade || undefined,
 				headerText: isExpiredDowngrade ? __( 'Find your best fit' ) : undefined,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
@@ -77,6 +77,11 @@ function getPlansIntent( flowName: string | null ): PlansIntent | null {
 		case ONBOARDING_UNIFIED_FLOW:
 			return 'plans-affiliate';
 		case PLAN_UPGRADE_FLOW:
+			// For expired-plan downgrades, use an intent that shows all paid tiers
+			// (Free/Commerce/Enterprise are hidden via props instead).
+			if ( search.has( 'expired_downgrade' ) ) {
+				return 'plans-new-hosted-site';
+			}
 			return 'plans-upgrade';
 		case WOO_HOSTED_PLANS_FLOW:
 			return 'plans-woo-hosted';
@@ -98,6 +103,13 @@ const PlansStepAdaptor: StepType< {
 		isStepperUpgradeFlow?: boolean;
 		selectedFeature?: string;
 		displayedIntervals?: SupportedIntervalTypes[];
+		headerText?: string;
+		fallbackSubHeaderText?: string;
+		hideFreePlan?: boolean;
+		hideEcommercePlan?: boolean;
+		hideEnterprisePlan?: boolean;
+		hidePlansFeatureComparison?: boolean;
+		hidePlanTypeSelector?: boolean;
 		wrapperProps?: {
 			hideBack?: boolean;
 			goBack?: () => void;
@@ -106,8 +118,19 @@ const PlansStepAdaptor: StepType< {
 		};
 	};
 } > = ( props ) => {
-	const { displayedIntervals, isInSignup, isStepperUpgradeFlow, selectedFeature, wrapperProps } =
-		props;
+	const {
+		displayedIntervals,
+		headerText,
+		fallbackSubHeaderText,
+		isInSignup,
+		isStepperUpgradeFlow,
+		selectedFeature,
+		hideEcommercePlan: hideEcommercePlanProp,
+		hideEnterprisePlan: hideEnterprisePlanProp,
+		hidePlansFeatureComparison: hidePlansFeatureComparisonProp,
+		hidePlanTypeSelector: hidePlanTypeSelectorProp,
+		wrapperProps,
+	} = props;
 	const [ stepState, setStepState ] = useStepPersistedState< ProvidedDependencies >( 'plans-step' );
 	const siteSlug = useSiteSlug();
 
@@ -209,7 +232,7 @@ const PlansStepAdaptor: StepType< {
 	return (
 		<UnifiedPlansStep
 			{ ...getHidePlanPropsBasedOnThemeType( selectedThemeType || '' ) }
-			hideFreePlan={ hideFreePlan }
+			hideFreePlan={ hideFreePlan || props.hideFreePlan }
 			selectedSite={ site ?? undefined }
 			saveSignupStep={ ( step ) => {
 				setStepState( ( mostRecentState = { ...stepState, ...step } as ProvidedDependencies ) );
@@ -252,6 +275,12 @@ const PlansStepAdaptor: StepType< {
 			isInSignup={ isInSignup }
 			isStepperUpgradeFlow={ isStepperUpgradeFlow }
 			selectedFeature={ selectedFeature }
+			headerText={ headerText }
+			fallbackSubHeaderText={ fallbackSubHeaderText }
+			hideEcommercePlan={ hideEcommercePlanProp }
+			hideEnterprisePlan={ hideEnterprisePlanProp }
+			hidePlansFeatureComparison={ hidePlansFeatureComparisonProp }
+			hidePlanTypeSelector={ hidePlanTypeSelectorProp }
 		/>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -71,6 +71,8 @@ export interface UnifiedPlansStepProps {
 	hidePremiumPlan?: boolean;
 	hideEnterprisePlan?: boolean;
 	hideEcommercePlan?: boolean;
+	hidePlansFeatureComparison?: boolean;
+	hidePlanTypeSelector?: boolean;
 
 	flowName: string;
 	stepName: string;
@@ -219,6 +221,8 @@ function UnifiedPlansStep( {
 	hidePersonalPlan,
 	hidePremiumPlan,
 	hideEnterprisePlan,
+	hidePlansFeatureComparison,
+	hidePlanTypeSelector,
 	saveSignupStep: saveSignupStepFromProps,
 	submitSignupStep: submitSignupStepFromProps,
 	customerType: customerTypeFromProps,
@@ -661,6 +665,8 @@ function UnifiedPlansStep( {
 				hidePremiumPlan={ hidePremiumPlan }
 				hideEcommercePlan={ shouldHideEcommercePlan() }
 				hideEnterprisePlan={ hideEnterprisePlan }
+				hidePlansFeatureComparison={ hidePlansFeatureComparison }
+				hidePlanTypeSelector={ hidePlanTypeSelector }
 				removePaidDomain={ handleRemovePaidDomain }
 				setSiteUrlAsFreeDomainSuggestion={ handleSetSiteUrlAsFreeDomainSuggestion }
 				coupon={ coupon ?? undefined }

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -619,12 +619,16 @@ class ManagePurchase extends Component<
 				730: '2yearly',
 				1095: '3yearly',
 			};
+			const redirectTo = this.props.isSiteLevel
+				? `/purchases/subscriptions/${ siteSlug }/:purchaseId?plan_changed=true`
+				: `/me/purchases/${ siteSlug }/:purchaseId?plan_changed=true`;
 			return addQueryArgs(
 				{
 					siteSlug,
 					cancel_to: cancelTo,
 					expired_downgrade: 'true',
 					intervalType: intervalMap[ purchase.billPeriodDays ] ?? 'yearly',
+					redirect_to: redirectTo,
 				},
 				'/setup/plan-upgrade'
 			);

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -65,6 +65,7 @@ import {
 	Icon,
 	payment,
 	reusableBlock,
+	shuffle,
 	tool,
 	trash,
 	upload,
@@ -119,6 +120,7 @@ import {
 	shouldRenderMonthlyRenewalOption,
 	getDIFMTieredPurchaseDetails,
 	canExplicitRenew,
+	isInExpirationGracePeriod,
 } from 'calypso/lib/purchases';
 import { getPurchaseCancellationFlowType } from 'calypso/lib/purchases/utils';
 import { hasCustomDomain } from 'calypso/lib/site/utils';
@@ -597,6 +599,34 @@ class ManagePurchase extends Component<
 			return `/plans/storage/${ siteSlug }`;
 		}
 
+		// For expired plans eligible for self-serve downgrade, use the simpler plan-upgrade flow.
+		if (
+			config.isEnabled( 'plans/expired-plan-downgrade' ) &&
+			purchase &&
+			( isExpired( purchase ) || isInExpirationGracePeriod( purchase ) ) &&
+			isPlan( purchase ) &&
+			( isPersonal( purchase ) || isPremium( purchase ) || isBusiness( purchase ) )
+		) {
+			const cancelTo = this.props.isSiteLevel
+				? `/purchases/subscriptions/${ siteSlug }/${ purchase.id }`
+				: `/me/purchases/${ siteSlug }/${ purchase.id }`;
+			const intervalMap: Record< number, string > = {
+				31: 'monthly',
+				365: 'yearly',
+				730: '2yearly',
+				1095: '3yearly',
+			};
+			return addQueryArgs(
+				{
+					siteSlug,
+					cancel_to: cancelTo,
+					expired_downgrade: 'true',
+					intervalType: intervalMap[ purchase.billPeriodDays ] ?? 'yearly',
+				},
+				'/setup/plan-upgrade'
+			);
+		}
+
 		return `/plans/${ siteSlug }`;
 	}
 
@@ -631,7 +661,16 @@ class ManagePurchase extends Component<
 		let icon;
 		let buttonText;
 
-		if ( isExpired( purchase ) ) {
+		const isDowngradeEligible =
+			isExpired( purchase ) &&
+			isUpgradeablePlan &&
+			config.isEnabled( 'plans/expired-plan-downgrade' ) &&
+			( isPersonal( purchase ) || isPremium( purchase ) || isBusiness( purchase ) );
+
+		if ( isDowngradeEligible ) {
+			icon = shuffle;
+			buttonText = translate( 'Change plan' );
+		} else if ( isExpired( purchase ) ) {
 			icon = column;
 			buttonText = isUpgradeablePlan
 				? translate( 'Pick another plan' )

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -662,7 +662,7 @@ class ManagePurchase extends Component<
 		let buttonText;
 
 		const isDowngradeEligible =
-			isExpired( purchase ) &&
+			( isExpired( purchase ) || isInExpirationGracePeriod( purchase ) ) &&
 			isUpgradeablePlan &&
 			config.isEnabled( 'plans/expired-plan-downgrade' ) &&
 			( isPersonal( purchase ) || isPremium( purchase ) || isBusiness( purchase ) );

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -605,7 +605,10 @@ class ManagePurchase extends Component<
 			purchase &&
 			( isExpired( purchase ) || isInExpirationGracePeriod( purchase ) ) &&
 			isPlan( purchase ) &&
-			( isPersonal( purchase ) || isPremium( purchase ) || isBusiness( purchase ) )
+			( isPersonal( purchase ) ||
+				isPremium( purchase ) ||
+				isBusiness( purchase ) ||
+				isEcommerce( purchase ) )
 		) {
 			const cancelTo = this.props.isSiteLevel
 				? `/purchases/subscriptions/${ siteSlug }/${ purchase.id }`
@@ -654,18 +657,21 @@ class ManagePurchase extends Component<
 		 ).includes( purchase.productSlug );
 		const isUpgradeableProduct = isUpgradeableBackupProduct;
 
-		if ( ! isUpgradeablePlan && ! isUpgradeableProduct ) {
+		const isDowngradeEligible =
+			( isExpired( purchase ) || isInExpirationGracePeriod( purchase ) ) &&
+			isPlan( purchase ) &&
+			config.isEnabled( 'plans/expired-plan-downgrade' ) &&
+			( isPersonal( purchase ) ||
+				isPremium( purchase ) ||
+				isBusiness( purchase ) ||
+				isEcommerce( purchase ) );
+
+		if ( ! isUpgradeablePlan && ! isUpgradeableProduct && ! isDowngradeEligible ) {
 			return null;
 		}
 
 		let icon;
 		let buttonText;
-
-		const isDowngradeEligible =
-			( isExpired( purchase ) || isInExpirationGracePeriod( purchase ) ) &&
-			isUpgradeablePlan &&
-			config.isEnabled( 'plans/expired-plan-downgrade' ) &&
-			( isPersonal( purchase ) || isPremium( purchase ) || isBusiness( purchase ) );
 
 		if ( isDowngradeEligible ) {
 			icon = shuffle;

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -119,6 +119,9 @@ class PurchaseNotice extends Component<
 		showDowngradedRedirectNotice:
 			typeof window !== 'undefined' &&
 			new URLSearchParams( window.location.search ).get( 'downgraded' ) === 'true',
+		showPlanChangedNotice:
+			typeof window !== 'undefined' &&
+			new URLSearchParams( window.location.search ).get( 'plan_changed' ) === 'true',
 	};
 
 	componentDidMount() {
@@ -136,6 +139,10 @@ class PurchaseNotice extends Component<
 			params.delete( 'downgraded' );
 			changed = true;
 		}
+		if ( params.get( 'plan_changed' ) === 'true' ) {
+			params.delete( 'plan_changed' );
+			changed = true;
+		}
 		if ( changed ) {
 			const newSearch = params.toString();
 			const newUrl =
@@ -150,6 +157,10 @@ class PurchaseNotice extends Component<
 
 	dismissDowngradedRedirectNotice = () => {
 		this.setState( { showDowngradedRedirectNotice: false } );
+	};
+
+	dismissPlanChangedNotice = () => {
+		this.setState( { showPlanChangedNotice: false } );
 	};
 
 	/**
@@ -239,6 +250,24 @@ class PurchaseNotice extends Component<
 				onDismissClick={ this.dismissDowngradedRedirectNotice }
 				status="is-success"
 				text={ this.props.translate( 'You\u2019ve switched to monthly billing.' ) }
+			/>
+		);
+	}
+
+	renderPlanChangedNotice() {
+		const { purchase, translate } = this.props;
+		if ( ! this.state.showPlanChangedNotice || ! purchase ) {
+			return null;
+		}
+		return (
+			<Notice
+				className="manage-purchase__purchase-expiring-notice"
+				showDismiss
+				onDismissClick={ this.dismissPlanChangedNotice }
+				status="is-success"
+				text={ translate( 'Your plan has been updated to %(planName)s.', {
+					args: { planName: getName( purchase ) },
+				} ) }
 			/>
 		);
 	}
@@ -1453,6 +1482,11 @@ class PurchaseNotice extends Component<
 		const downgradedRedirectNotice = this.renderDowngradedRedirectNotice();
 		if ( downgradedRedirectNotice ) {
 			return downgradedRedirectNotice;
+		}
+
+		const planChangedNotice = this.renderPlanChangedNotice();
+		if ( planChangedNotice ) {
+			return planChangedNotice;
 		}
 
 		if ( purchase.asyncPendingPaymentBlockIsSet ) {

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -6,6 +6,9 @@ import {
 	isPlan,
 	isDomainRegistration,
 	isAkismetFreeProduct,
+	isPersonalPlan,
+	isPremiumPlan,
+	isBusinessPlan,
 	PLAN_BUSINESS,
 	PLAN_PERSONAL_TRIAL_MONTHLY,
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
@@ -407,6 +410,37 @@ class PurchaseNotice extends Component<
 		}
 
 		return null;
+	}
+
+	renderSeeOtherPlansAction( currentPurchase: Purchase ) {
+		const { selectedSite, translate } = this.props;
+
+		if ( ! selectedSite ) {
+			return null;
+		}
+
+		if ( ! config.isEnabled( 'plans/expired-plan-downgrade' ) ) {
+			return null;
+		}
+
+		if ( ! isPlan( currentPurchase ) ) {
+			return null;
+		}
+
+		const planSlug = currentPurchase.productSlug;
+		if (
+			! isPersonalPlan( planSlug ) &&
+			! isPremiumPlan( planSlug ) &&
+			! isBusinessPlan( planSlug )
+		) {
+			return null;
+		}
+
+		return (
+			<NoticeAction href={ `/plans/${ selectedSite.slug }` }>
+				{ translate( 'See other plans' ) }
+			</NoticeAction>
+		);
 	}
 
 	trackImpression( warning: string ) {

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -265,6 +265,8 @@ export default function CheckoutMain( {
 		source: productSourceFromUrl,
 		isGiftPurchase,
 		hostingIntent,
+		isExpiredDowngrade:
+			new URLSearchParams( window.location.search ).get( 'expired_downgrade' ) === 'true',
 	} );
 
 	const {

--- a/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
@@ -52,6 +52,7 @@ export default function usePrepareProductsForCart( {
 	source,
 	isGiftPurchase,
 	hostingIntent,
+	isExpiredDowngrade,
 }: {
 	productAliasFromUrl: string | null | undefined;
 	purchaseId: string | number | null | undefined;
@@ -66,6 +67,7 @@ export default function usePrepareProductsForCart( {
 	source?: string;
 	isGiftPurchase?: boolean;
 	hostingIntent?: string | undefined;
+	isExpiredDowngrade?: boolean;
 } ): PreparedProductsForCart {
 	const [ state, dispatch ] = useReducer( preparedProductsReducer, initialPreparedProductsState );
 
@@ -119,6 +121,7 @@ export default function usePrepareProductsForCart( {
 		jetpackPurchaseToken,
 		source,
 		hostingIntent,
+		isExpiredDowngrade,
 	} );
 	useAddProductFromBillingIntent( {
 		intentId: productAliasFromUrl,
@@ -525,6 +528,7 @@ function useAddProductFromSlug( {
 	jetpackPurchaseToken,
 	source,
 	hostingIntent,
+	isExpiredDowngrade,
 }: {
 	productAliasFromUrl: string | undefined | null;
 	dispatch: ( action: PreparedProductsAction ) => void;
@@ -536,6 +540,7 @@ function useAddProductFromSlug( {
 	jetpackPurchaseToken?: string;
 	source?: string;
 	hostingIntent?: string | undefined;
+	isExpiredDowngrade?: boolean;
 } ) {
 	const translate = useTranslate();
 
@@ -571,6 +576,7 @@ function useAddProductFromSlug( {
 				jetpackPurchaseToken,
 				source,
 				hostingIntent,
+				isExpiredDowngrade,
 			} )
 		);
 
@@ -610,6 +616,7 @@ function useAddProductFromSlug( {
 		jetpackSiteSlug,
 		jetpackPurchaseToken,
 		hostingIntent,
+		isExpiredDowngrade,
 		source,
 	] );
 }
@@ -726,6 +733,7 @@ function createItemToAddToCart( {
 	jetpackPurchaseToken,
 	source,
 	hostingIntent,
+	isExpiredDowngrade,
 }: {
 	productSlug: string;
 	productAlias: string;
@@ -734,6 +742,7 @@ function createItemToAddToCart( {
 	jetpackPurchaseToken?: string;
 	source?: string;
 	hostingIntent?: string | undefined;
+	isExpiredDowngrade?: boolean;
 } ): RequestCartProduct {
 	// Allow setting meta (theme name or domain name) from products in the URL by
 	// using a colon between the product slug and the meta.
@@ -767,6 +776,7 @@ function createItemToAddToCart( {
 			context: 'calypstore',
 			source: source ?? undefined,
 			hosting_intent: hostingIntent,
+			...( isExpiredDowngrade && { hideProductVariants: true } ),
 		},
 		...( cartMeta ? { meta: cartMeta } : {} ),
 	} );

--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -76,6 +76,7 @@ const FeaturesContainer = ( props: {
 		enableCategorisedFeatures,
 		enableLogosOnlyForEnterprisePlan,
 		enableReducedFeatureGroupSpacing,
+		hideFeatureGroupTitles,
 	} = usePlansGridContext();
 
 	return (
@@ -91,6 +92,7 @@ const FeaturesContainer = ( props: {
 				<div
 					className={ clsx( 'plans-grid-next-features-grid__feature-group-row', {
 						'is-reduced-feature-group-spacing': enableReducedFeatureGroupSpacing,
+						'is-hidden-feature-group-titles': hideFeatureGroupTitles,
 					} ) }
 					key={ featureGroupSlug }
 				>

--- a/packages/plans-grid-next/src/components/features-grid/style.scss
+++ b/packages/plans-grid-next/src/components/features-grid/style.scss
@@ -391,6 +391,20 @@
 	&.is-reduced-feature-group-spacing > .plan-features-2023-grid__table-item {
 		padding-top: 0;
 	}
+
+	// Hidden-titles spacing adjustments: when enableReducedFeatureGroupSpacing + hideFeatureGroupTitles
+	// are both active, the grid loses all visual group separation. These rules restore it.
+	&.is-reduced-feature-group-spacing .plans-grid-next-storage-feature-label__volume:not(.is-badge) {
+		line-height: 20px;
+	}
+
+	&.is-reduced-feature-group-spacing.is-hidden-feature-group-titles:not(.is-first-feature-group-row) > .plan-features-2023-grid__table-item {
+		padding-top: 10px;
+	}
+
+	&.is-hidden-feature-group-titles:last-child > .plan-features-2023-grid__table-item {
+		padding-bottom: 16px;
+	}
 }
 
 .plan-features-2023-grid__item-info {

--- a/packages/plans-grid-next/src/components/features-grid/table.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/table.tsx
@@ -58,6 +58,7 @@ const Table = ( {
 		enableCategorisedFeatures,
 		enableLogosOnlyForEnterprisePlan,
 		enableReducedFeatureGroupSpacing,
+		hideFeatureGroupTitles,
 	} = usePlansGridContext();
 	const featureGroups = useMemo(
 		() => Object.keys( featureGroupMap ) as FeatureGroupSlug[],
@@ -162,6 +163,7 @@ const Table = ( {
 						className={ clsx( 'plans-grid-next-features-grid__feature-group-row', {
 							'is-first-feature-group-row': featureGroupIndex === 0,
 							'is-reduced-feature-group-spacing': enableReducedFeatureGroupSpacing,
+							'is-hidden-feature-group-titles': hideFeatureGroupTitles,
 						} ) }
 						key={ featureGroupSlug }
 					>


### PR DESCRIPTION
Depends on #111066
Requires: 211315-ghe-Automattic/wpcom

## Proposed Changes

This is PR 2 of 2. It adds change plans buttons to the purchase management screen to connect to the downgrade flow in the stepper. Extracted and rebased from https://github.com/Automattic/wp-calypso/pull/109944 (test/downgrades), which had diverged significantly from trunk.

<img width="1839" height="1162" alt="image" src="https://github.com/user-attachments/assets/bb6eb194-4de2-4f7a-a9d1-985f5b4b3b9f" />

<img width="1839" height="1162" alt="image" src="https://github.com/user-attachments/assets/0453a7ea-1738-420c-8519-783c329064fc" />


Feature flag: plans/expired-plan-downgrade (false in production)

Technical details:
- Dashboard and legacy Calypso entry points for expired-plan downgrades ("Change plan" nav item with shuffle icon, "See plans" CTA on dashboard purchase settings)
- Plan-upgrade stepper flow with `expired_downgrade` param: hides Free/Enterprise, shows "Find your best fit" header, locks billing interval
- Post-checkout redirect back to dashboard purchase settings
- Ecommerce included as both upgrade target and downgrade source across all entry points
- Tracks event `calypso_expired_plan_lower_tier_purchase_click` guarded to only fire for actual lower-tier purchases

## Why are these changes being made?

When a user's plan expires, they currently have to contact support to purchase a lower-tier plan. This PR adds self-serve entry points so expired-plan holders can browse lower-tier plans and check out directly, reducing support volume (~408 HE-assisted downgrade threads/month).

Stacks on #111066 (foundation: utility, config flags, plans grid rendering).

## Testing Instructions

1. Enable feature flag `plans/expired-plan-downgrade` (already enabled in dev/stage/test configs)
2. Expire a site's plan via sandbox or use a test site with an expired Personal/Premium/Business/Ecommerce plan
3. **Legacy Calypso** (`calypso.localhost:3000`): Navigate to Purchases → select the expired plan → verify "Change plan" nav item appears with shuffle icon → click through to plan-upgrade stepper
4. **Dashboard** (`my.localhost:3000`): Navigate to Billing → select the expired plan → verify "Change plan" action with "See plans" button → click through to stepper
5. In the stepper, verify lower-tier plans show "Downgrade" buttons, current plan shows "Renew {plan}", higher-tier plans show "Upgrade"
6. Select a lower-tier plan → verify checkout loads with correct plan → complete purchase → verify redirect back to dashboard purchase settings

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?