### PR TITLE
Help Center FAB: clear persistent bottom bars via --bottom-bar-height

### DIFF
--- a/client/components/help-center-fab/style.scss
+++ b/client/components/help-center-fab/style.scss
@@ -29,7 +29,12 @@ $help-center-fab-shadow:
 	// any browser UI overlap on the inline-end edge. For the inline axis we max
 	// over both physical insets so the rule works the same in LTR and RTL —
 	// only one of them is ever non-zero (landscape notch on a single side).
-	inset-block-end: max( #{ $help-center-fab-offset }, env( safe-area-inset-bottom ) );
+	// `--bottom-bar-height` is a global signal (e.g. set by the domains
+	// mini-cart) so the FAB shifts up to clear any persistent bottom bar.
+	inset-block-end: calc(
+		max( #{ $help-center-fab-offset }, env( safe-area-inset-bottom ) ) +
+			var( --bottom-bar-height, 0px )
+	);
 	inset-inline-end: max(
 		#{ $help-center-fab-offset },
 		env( safe-area-inset-left ),
@@ -47,7 +52,10 @@ $help-center-fab-shadow:
 	background: $help-center-fab-bg-default;
 	color: var( --color-neutral-100 );
 	box-shadow: $help-center-fab-shadow;
-	transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out;
+	transition:
+		background-color 0.15s ease-in-out,
+		border-color 0.15s ease-in-out,
+		inset-block-end 0.2s ease-in-out;
 
 	&:hover {
 		background: $help-center-fab-bg-hover;
@@ -91,10 +99,12 @@ body.has-help-center-fab .help-center .help-center__container.is-desktop {
 	animation: none;
 	inset-inline-start: auto;
 	inset-inline-end: $help-center-fab-offset;
-	// Mirror the FAB's safe-area offset so the panel stays 8px above the FAB
-	// on iOS devices with a non-zero `safe-area-inset-bottom`.
+	// Mirror the FAB's safe-area offset and bottom-bar shift so the panel stays
+	// 8px above the FAB on iOS devices and when a bottom bar (e.g. the domains
+	// mini-cart) is present.
 	inset-block-end: calc(
 		max( #{ $help-center-fab-offset }, env( safe-area-inset-bottom ) ) +
+			var( --bottom-bar-height, 0px ) +
 			#{ $help-center-fab-size + $help-center-fab-gap }
 	);
 }

--- a/client/components/help-center-fab/style.scss
+++ b/client/components/help-center-fab/style.scss
@@ -7,7 +7,8 @@ $help-center-fab-gap: 8px;
 // clears the iOS home indicator with a 24px minimum from the viewport edge.
 $help-center-fab-inset-block-end: max(
 	calc( var( --bottom-bar-height, 0px ) + #{ $help-center-fab-bottom-bar-gap } ),
-	max( #{ $help-center-fab-offset }, env( safe-area-inset-bottom ) )
+	#{ $help-center-fab-offset },
+	env( safe-area-inset-bottom )
 );
 $help-center-fab-bg-default: color-mix(
 	in srgb,

--- a/client/components/help-center-fab/style.scss
+++ b/client/components/help-center-fab/style.scss
@@ -29,8 +29,6 @@ $help-center-fab-shadow:
 	// any browser UI overlap on the inline-end edge. For the inline axis we max
 	// over both physical insets so the rule works the same in LTR and RTL —
 	// only one of them is ever non-zero (landscape notch on a single side).
-	// `--bottom-bar-height` is a global signal (e.g. set by the domains
-	// mini-cart) so the FAB shifts up to clear any persistent bottom bar.
 	inset-block-end: calc(
 		max( #{ $help-center-fab-offset }, env( safe-area-inset-bottom ) ) +
 			var( --bottom-bar-height, 0px )
@@ -99,9 +97,7 @@ body.has-help-center-fab .help-center .help-center__container.is-desktop {
 	animation: none;
 	inset-inline-start: auto;
 	inset-inline-end: $help-center-fab-offset;
-	// Mirror the FAB's safe-area offset and bottom-bar shift so the panel stays
-	// 8px above the FAB on iOS devices and when a bottom bar (e.g. the domains
-	// mini-cart) is present.
+	// Stay 8px above the FAB, mirroring its safe-area and bottom-bar offsets.
 	inset-block-end: calc(
 		max( #{ $help-center-fab-offset }, env( safe-area-inset-bottom ) ) +
 			var( --bottom-bar-height, 0px ) +

--- a/client/components/help-center-fab/style.scss
+++ b/client/components/help-center-fab/style.scss
@@ -1,7 +1,14 @@
 // 44px matches Apple HIG's minimum tap target.
 $help-center-fab-size: 44px;
 $help-center-fab-offset: 24px;
+$help-center-fab-bottom-bar-gap: 16px;
 $help-center-fab-gap: 8px;
+// Sits 16px above any persistent bottom bar (--bottom-bar-height); otherwise
+// clears the iOS home indicator with a 24px minimum from the viewport edge.
+$help-center-fab-inset-block-end: max(
+	calc( var( --bottom-bar-height, 0px ) + #{ $help-center-fab-bottom-bar-gap } ),
+	max( #{ $help-center-fab-offset }, env( safe-area-inset-bottom ) )
+);
 $help-center-fab-bg-default: color-mix(
 	in srgb,
 	var( --studio-blue-50 ) 10%,
@@ -25,14 +32,10 @@ $help-center-fab-shadow:
 
 .components-button.help-center-fab {
 	position: fixed;
-	// `env(safe-area-inset-*)` keeps the FAB clear of the iOS home indicator and
-	// any browser UI overlap on the inline-end edge. For the inline axis we max
-	// over both physical insets so the rule works the same in LTR and RTL —
-	// only one of them is ever non-zero (landscape notch on a single side).
-	inset-block-end: calc(
-		max( #{ $help-center-fab-offset }, env( safe-area-inset-bottom ) ) +
-			var( --bottom-bar-height, 0px )
-	);
+	inset-block-end: $help-center-fab-inset-block-end;
+	// On the inline axis we max over both physical insets so the rule works the
+	// same in LTR and RTL — only one of them is ever non-zero (landscape notch
+	// on a single side).
 	inset-inline-end: max(
 		#{ $help-center-fab-offset },
 		env( safe-area-inset-left ),
@@ -97,10 +100,8 @@ body.has-help-center-fab .help-center .help-center__container.is-desktop {
 	animation: none;
 	inset-inline-start: auto;
 	inset-inline-end: $help-center-fab-offset;
-	// Stay 8px above the FAB, mirroring its safe-area and bottom-bar offsets.
+	// Stay 8px above the FAB, mirroring its inset-block-end shift.
 	inset-block-end: calc(
-		max( #{ $help-center-fab-offset }, env( safe-area-inset-bottom ) ) +
-			var( --bottom-bar-height, 0px ) +
-			#{ $help-center-fab-size + $help-center-fab-gap }
+		#{ $help-center-fab-inset-block-end } + #{ $help-center-fab-size + $help-center-fab-gap }
 	);
 }

--- a/packages/domain-search/src/ui/domains-mini-cart/index.tsx
+++ b/packages/domain-search/src/ui/domains-mini-cart/index.tsx
@@ -49,7 +49,11 @@ export const DomainsMiniCart = ( {
 		<>
 			<div className="domains-mini-cart__cushion" />
 			<motion.div
-				className={ clsx( 'domains-mini-cart__container', className ) }
+				className={ clsx(
+					'domains-mini-cart__container',
+					{ 'is-open': isMiniCartOpen },
+					className
+				) }
 				initial={ animation.initial }
 				animate={ isMiniCartOpen ? animation.animateIn : animation.animateOut }
 				transition={ { type: 'tween', duration: 0.25 } }

--- a/packages/domain-search/src/ui/domains-mini-cart/style.scss
+++ b/packages/domain-search/src/ui/domains-mini-cart/style.scss
@@ -6,10 +6,7 @@
 	height: var( --domain-search-mini-cart-height );
 }
 
-// Publish the cart's height as a global layout signal so fixed-bottom UI
-// (e.g. the Help Center FAB) can shift up to clear it. Mirrors the
-// `--masterbar-height` convention for top bars. Value matches
-// `--domain-search-mini-cart-height` in page/style.scss; keep in sync.
+// Global layout signal for fixed-bottom UI — parallels `--masterbar-height`.
 :root:has( .domains-mini-cart__container.is-open ) {
 	--bottom-bar-height: 80px;
 }

--- a/packages/domain-search/src/ui/domains-mini-cart/style.scss
+++ b/packages/domain-search/src/ui/domains-mini-cart/style.scss
@@ -6,6 +6,14 @@
 	height: var( --domain-search-mini-cart-height );
 }
 
+// Publish the cart's height as a global layout signal so fixed-bottom UI
+// (e.g. the Help Center FAB) can shift up to clear it. Mirrors the
+// `--masterbar-height` convention for top bars. Value matches
+// `--domain-search-mini-cart-height` in page/style.scss; keep in sync.
+:root:has( .domains-mini-cart__container.is-open ) {
+	--bottom-bar-height: 80px;
+}
+
 .domains-mini-cart__container {
 	position: fixed !important;
 	left: 0;


### PR DESCRIPTION
## Summary

Introduces `--bottom-bar-height`, a CSS custom property on `:root` that publishes the height of any persistent bottom bar. The Help Center FAB reads it and sits 16px above the bar's top edge when present, otherwise keeps its standard 24px / safe-area inset.

Parallels the existing `--masterbar-height` convention for top bars. No JS — any future bottom-anchored UI can opt in by publishing the same var.

## Changes

- `DomainsMiniCart` (`packages/domain-search/src/ui/domains-mini-cart/`): adds `.is-open` class when visible (mirrors the `ResponsiveSidebar` convention at `client/dashboard/app/responsive-sidebar/index.tsx:50`).
- `domains-mini-cart/style.scss`: publishes `--bottom-bar-height: 80px` on `:root` via `:root:has(.domains-mini-cart__container.is-open)` (same `:has()` shape as `.dashboard-root__body:has(.dashboard-responsive-sidebar.is-open)` in `client/dashboard/app/root/style.scss:38`).
- `help-center-fab/style.scss`: extracts the bottom-inset into `$help-center-fab-inset-block-end = max(bar-height + 16px, max(24px, safe-area))`; the panel-positioning rule reuses it so it keeps tracking the FAB. Adds an `inset-block-end` transition for the shift.

## Testing

* `/setup/onboarding/domains`: add a domain → cart slides up → FAB shifts to 96px (= 80 + 16) from the viewport bottom. Remove → FAB slides back to 24px.
* `getComputedStyle(document.documentElement).getPropertyValue('--bottom-bar-height')` returns `80px` when the cart is open, empty otherwise.
* Routes without a bottom bar: FAB stays at its baseline 24px (or `safe-area-inset-bottom` on iOS).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
