### PR TITLE
ai-review: send per-run telemetry to wpcom

### DIFF
--- a/.github/workflows/a4a-pr-review.yml
+++ b/.github/workflows/a4a-pr-review.yml
@@ -29,3 +29,4 @@ jobs:
       area: a4a
     secrets:
       anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+      ai_review_telemetry_token: ${{ secrets.AI_REVIEW_TELEMETRY_TOKEN }}

--- a/.github/workflows/dashboard-pr-review.yml
+++ b/.github/workflows/dashboard-pr-review.yml
@@ -29,3 +29,4 @@ jobs:
       area: dashboard
     secrets:
       anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+      ai_review_telemetry_token: ${{ secrets.AI_REVIEW_TELEMETRY_TOKEN }}

--- a/.github/workflows/pr-review-on-ping.yml
+++ b/.github/workflows/pr-review-on-ping.yml
@@ -62,3 +62,4 @@ jobs:
       area: ${{ needs.detect.outputs.area }}
     secrets:
       anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+      ai_review_telemetry_token: ${{ secrets.AI_REVIEW_TELEMETRY_TOKEN }}

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -379,7 +379,6 @@ jobs:
           T_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           T_MODEL: ${{ inputs.model || 'claude-opus-4-6' }}
           T_BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          T_EVENT_NAME: ${{ github.event_name }}
           T_AREA: ${{ inputs.area }}
         shell: bash
         run: |
@@ -405,11 +404,6 @@ jobs:
             esac
           fi
 
-          case "$T_EVENT_NAME" in
-            issue_comment|pull_request_review|pull_request_review_comment) IS_FOLLOWUP="true" ;;
-            *) IS_FOLLOWUP="false" ;;
-          esac
-
           # issue_comment payload is issue-shaped (no pull_request.head), so
           # head sha is empty on comment-triggered runs. Fall back to gh CLI.
           if [ -z "$T_PR_HEAD_SHA" ] && [ -n "$T_PR" ]; then
@@ -426,7 +420,6 @@ jobs:
             --arg model           "$T_MODEL" \
             --arg build_url       "$T_BUILD_URL" \
             --arg ci_provider     "github_actions" \
-            --arg is_followup     "$IS_FOLLOWUP" \
             '{
               source:          $source,
               outcome:         $outcome,
@@ -437,7 +430,6 @@ jobs:
               model:           $model,
               build_url:       $build_url,
               ci_provider:     $ci_provider,
-              is_followup:     ($is_followup == "true"),
               cost_usd:        (.total_cost_usd // 0),
               duration:        ((.duration_ms // 0) / 1000),
               api_duration_ms: (.duration_api_ms // 0),

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -7,6 +7,10 @@ on:
         description: 'Review area: dashboard | a4a | general'
         required: true
         type: string
+      model:
+        description: 'Claude model identifier; defaults to claude-opus-4-6'
+        required: false
+        type: string
     secrets:
       anthropic_api_key:
         required: true
@@ -186,7 +190,7 @@ jobs:
 
             Remember: This dashboard represents modern React patterns. Prioritize performance, accessibility, and maintainability while leveraging the WordPress ecosystem.
           claude_args: |
-            --model claude-opus-4-6
+            --model ${{ inputs.model || 'claude-opus-4-6' }}
             --max-turns 100
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git show:*),Bash(git diff:*),Bash(git log:*),Bash(git ls-files:*),Bash(git grep:*),Bash(rg *),Read,Glob,Grep"
 
@@ -254,7 +258,7 @@ jobs:
 
             Remember: A4A builds on Calypso client patterns. Prioritize performance, accessibility, and maintainability while following the A4A code style, layout, and typography guidance described in the referenced docs. We also use modern React patterns.
           claude_args: |
-            --model claude-opus-4-6
+            --model ${{ inputs.model || 'claude-opus-4-6' }}
             --max-turns 100
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git show:*),Bash(git diff:*),Bash(git log:*),Bash(git ls-files:*),Bash(git grep:*),Bash(rg *),Read,Glob,Grep"
 
@@ -353,7 +357,7 @@ jobs:
 
             Remember: Calypso is large and shared. Prioritize correctness, security, and cross-client blast radius over style. Flag intent, not taste.
           claude_args: |
-            --model claude-opus-4-6
+            --model ${{ inputs.model || 'claude-opus-4-6' }}
             --max-turns 100
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git show:*),Bash(git diff:*),Bash(git log:*),Bash(git ls-files:*),Bash(git grep:*),Bash(rg *),Read,Glob,Grep"
 
@@ -373,7 +377,7 @@ jobs:
           T_PR: ${{ github.event.pull_request.number || github.event.issue.number }}
           T_PR_AUTHOR: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
           T_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          T_MODEL: claude-opus-4-6
+          T_MODEL: ${{ inputs.model || 'claude-opus-4-6' }}
           T_BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           T_EVENT_NAME: ${{ github.event_name }}
           T_AREA: ${{ inputs.area }}

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -392,7 +392,7 @@ jobs:
           esac
 
           PAYLOAD=$(echo "$RESULT" | jq -n --slurpfile r /dev/stdin \
-            --arg source          "wp-calypso" \
+            --arg source          "wp-calypso-$T_AREA" \
             --arg outcome         "$OUTCOME" \
             --arg repo            "$T_REPO" \
             --arg pr              "$T_PR" \
@@ -401,7 +401,6 @@ jobs:
             --arg model           "$T_MODEL" \
             --arg build_url       "$T_BUILD_URL" \
             --arg ci_provider     "github_actions" \
-            --arg area            "$T_AREA" \
             --arg is_followup     "$IS_FOLLOWUP" \
             '{
               source:          $source,
@@ -413,7 +412,6 @@ jobs:
               model:           $model,
               build_url:       $build_url,
               ci_provider:     $ci_provider,
-              area:            $area,
               is_followup:     ($is_followup == "true"),
               cost_usd:        ($r[0].total_cost_usd // 0),
               duration:        (($r[0].duration_ms // 0) / 1000),

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -391,7 +391,7 @@ jobs:
             *) IS_FOLLOWUP="false" ;;
           esac
 
-          PAYLOAD=$(echo "$RESULT" | jq -n --slurpfile r /dev/stdin \
+          PAYLOAD=$(echo "$RESULT" | jq \
             --arg source          "wp-calypso-$T_AREA" \
             --arg outcome         "$OUTCOME" \
             --arg repo            "$T_REPO" \
@@ -413,16 +413,16 @@ jobs:
               build_url:       $build_url,
               ci_provider:     $ci_provider,
               is_followup:     ($is_followup == "true"),
-              cost_usd:        ($r[0].total_cost_usd // 0),
-              duration:        (($r[0].duration_ms // 0) / 1000),
-              api_duration_ms: ($r[0].duration_api_ms // 0),
-              num_turns:       ($r[0].num_turns // 0),
-              tokens_in:       ($r[0].usage.input_tokens // 0),
-              tokens_out:      ($r[0].usage.output_tokens // 0),
-              cache_read:      ($r[0].usage.cache_read_input_tokens // 0),
-              cache_creation:  ($r[0].usage.cache_creation_input_tokens // 0),
-              session_id:      ($r[0].session_id // ""),
-              ttft_ms:         ($r[0].ttft_ms // 0)
+              cost_usd:        (.total_cost_usd // 0),
+              duration:        ((.duration_ms // 0) / 1000),
+              api_duration_ms: (.duration_api_ms // 0),
+              num_turns:       (.num_turns // 0),
+              tokens_in:       (.usage.input_tokens // 0),
+              tokens_out:      (.usage.output_tokens // 0),
+              cache_read:      (.usage.cache_read_input_tokens // 0),
+              cache_creation:  (.usage.cache_creation_input_tokens // 0),
+              session_id:      (.session_id // ""),
+              ttft_ms:         (.ttft_ms // 0)
             }')
 
           curl -s -f -X POST \

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -450,11 +450,15 @@ jobs:
               ttft_ms:         (.ttft_ms // 0)
             }')
 
-          HTTP_STATUS=$(curl -s -o /tmp/telemetry_response -w "%{http_code}" -X POST \
+          if ! HTTP_STATUS=$(curl -s -o /tmp/telemetry_response -w "%{http_code}" -X POST \
             "https://public-api.wordpress.com/wpcom/v2/ai-review/telemetry" \
             -H "Content-Type: application/json" \
             -H "X-AI-Review-Token: ${TELEMETRY_TOKEN}" \
-            -d "$PAYLOAD")
+            -d "$PAYLOAD"); then
+            echo "::warning::Failed to send AI review telemetry (curl transport error)"
+            exit 0
+          fi
+
           echo "telemetry: HTTP $HTTP_STATUS"
           if [ "$HTTP_STATUS" -lt 200 ] || [ "$HTTP_STATUS" -ge 300 ]; then
             echo "::warning::Failed to send AI review telemetry (HTTP $HTTP_STATUS)"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -364,9 +364,11 @@ jobs:
             steps.review_a4a.outputs.execution_file != '' ||
             steps.review_general.outputs.execution_file != ''
           )
+        continue-on-error: true
         env:
           TELEMETRY_TOKEN: ${{ secrets.ai_review_telemetry_token }}
           EXECUTION_FILE: ${{ steps.review_dashboard.outputs.execution_file || steps.review_a4a.outputs.execution_file || steps.review_general.outputs.execution_file }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           T_REPO: ${{ github.repository }}
           T_PR: ${{ github.event.pull_request.number || github.event.issue.number }}
           T_PR_AUTHOR: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
@@ -377,19 +379,38 @@ jobs:
           T_AREA: ${{ inputs.area }}
         shell: bash
         run: |
-          RESULT=$(jq 'map(select(.type == "result")) | last' "$EXECUTION_FILE")
+          if [ ! -s "$EXECUTION_FILE" ]; then
+            echo "telemetry: execution_file missing or empty, skipping"
+            exit 0
+          fi
 
-          SUBTYPE=$(echo "$RESULT" | jq -r '.subtype')
-          case "$SUBTYPE" in
-            success)              OUTCOME="success" ;;
-            error_max_turns)      OUTCOME="error_max_turns" ;;
-            *)                    OUTCOME="is_error" ;;
-          esac
+          if ! RESULT=$(jq 'map(select(.type == "result")) | last' "$EXECUTION_FILE" 2>/dev/null); then
+            echo "telemetry: failed to parse execution_file, skipping"
+            exit 0
+          fi
+
+          if [ "$RESULT" = "null" ] || [ -z "$RESULT" ]; then
+            OUTCOME="no_result"
+            RESULT="null"
+          else
+            SUBTYPE=$(echo "$RESULT" | jq -r '.subtype')
+            case "$SUBTYPE" in
+              success)              OUTCOME="success" ;;
+              error_max_turns)      OUTCOME="error_max_turns" ;;
+              *)                    OUTCOME="is_error" ;;
+            esac
+          fi
 
           case "$T_EVENT_NAME" in
             issue_comment|pull_request_review|pull_request_review_comment) IS_FOLLOWUP="true" ;;
             *) IS_FOLLOWUP="false" ;;
           esac
+
+          # issue_comment payload is issue-shaped (no pull_request.head), so
+          # head sha is empty on comment-triggered runs. Fall back to gh CLI.
+          if [ -z "$T_PR_HEAD_SHA" ] && [ -n "$T_PR" ]; then
+            T_PR_HEAD_SHA=$(gh pr view "$T_PR" --repo "$T_REPO" --json headRefOid --jq .headRefOid 2>/dev/null || echo "")
+          fi
 
           PAYLOAD=$(echo "$RESULT" | jq \
             --arg source          "wp-calypso-$T_AREA" \
@@ -425,8 +446,14 @@ jobs:
               ttft_ms:         (.ttft_ms // 0)
             }')
 
-          curl -s -f -X POST \
+          HTTP_STATUS=$(curl -s -o /tmp/telemetry_response -w "%{http_code}" -X POST \
             "https://public-api.wordpress.com/wpcom/v2/ai-review/telemetry" \
             -H "Content-Type: application/json" \
             -H "X-AI-Review-Token: ${TELEMETRY_TOKEN}" \
-            -d "$PAYLOAD"
+            -d "$PAYLOAD")
+          echo "telemetry: HTTP $HTTP_STATUS"
+          if [ "$HTTP_STATUS" -lt 200 ] || [ "$HTTP_STATUS" -ge 300 ]; then
+            echo "::warning::Failed to send AI review telemetry (HTTP $HTTP_STATUS)"
+            echo "telemetry response body:"
+            cat /tmp/telemetry_response || true
+          fi

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -10,6 +10,8 @@ on:
     secrets:
       anthropic_api_key:
         required: true
+      ai_review_telemetry_token:
+        required: false
 
 jobs:
   guard:
@@ -119,6 +121,7 @@ jobs:
           persist-credentials: false
 
       - name: Run review (dashboard)
+        id: review_dashboard
         if: inputs.area == 'dashboard' && steps.trusted_files.outputs.skip == 'false'
         uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434 # v1.0.107
         with:
@@ -188,6 +191,7 @@ jobs:
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git show:*),Bash(git diff:*),Bash(git log:*),Bash(git ls-files:*),Bash(git grep:*),Bash(rg *),Read,Glob,Grep"
 
       - name: Run review (a4a)
+        id: review_a4a
         if: inputs.area == 'a4a' && steps.trusted_files.outputs.skip == 'false'
         uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434 # v1.0.107
         with:
@@ -255,6 +259,7 @@ jobs:
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git show:*),Bash(git diff:*),Bash(git log:*),Bash(git ls-files:*),Bash(git grep:*),Bash(rg *),Read,Glob,Grep"
 
       - name: Run review (general)
+        id: review_general
         if: inputs.area == 'general' && steps.trusted_files.outputs.skip == 'false'
         uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434 # v1.0.107
         with:
@@ -351,3 +356,79 @@ jobs:
             --model claude-opus-4-6
             --max-turns 100
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git show:*),Bash(git diff:*),Bash(git log:*),Bash(git ls-files:*),Bash(git grep:*),Bash(rg *),Read,Glob,Grep"
+
+      - name: Send telemetry to wpcom
+        if: |
+          always() && (
+            steps.review_dashboard.outputs.execution_file != '' ||
+            steps.review_a4a.outputs.execution_file != '' ||
+            steps.review_general.outputs.execution_file != ''
+          )
+        env:
+          TELEMETRY_TOKEN: ${{ secrets.ai_review_telemetry_token }}
+          EXECUTION_FILE: ${{ steps.review_dashboard.outputs.execution_file || steps.review_a4a.outputs.execution_file || steps.review_general.outputs.execution_file }}
+          T_REPO: ${{ github.repository }}
+          T_PR: ${{ github.event.pull_request.number || github.event.issue.number }}
+          T_PR_AUTHOR: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
+          T_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          T_MODEL: claude-opus-4-6
+          T_BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          T_EVENT_NAME: ${{ github.event_name }}
+          T_AREA: ${{ inputs.area }}
+        shell: bash
+        run: |
+          RESULT=$(jq 'map(select(.type == "result")) | last' "$EXECUTION_FILE")
+
+          SUBTYPE=$(echo "$RESULT" | jq -r '.subtype')
+          case "$SUBTYPE" in
+            success)              OUTCOME="success" ;;
+            error_max_turns)      OUTCOME="error_max_turns" ;;
+            *)                    OUTCOME="is_error" ;;
+          esac
+
+          case "$T_EVENT_NAME" in
+            issue_comment|pull_request_review|pull_request_review_comment) IS_FOLLOWUP="true" ;;
+            *) IS_FOLLOWUP="false" ;;
+          esac
+
+          PAYLOAD=$(echo "$RESULT" | jq -n --slurpfile r /dev/stdin \
+            --arg source          "wp-calypso" \
+            --arg outcome         "$OUTCOME" \
+            --arg repo            "$T_REPO" \
+            --arg pr              "$T_PR" \
+            --arg pr_author       "$T_PR_AUTHOR" \
+            --arg pr_head_sha     "$T_PR_HEAD_SHA" \
+            --arg model           "$T_MODEL" \
+            --arg build_url       "$T_BUILD_URL" \
+            --arg ci_provider     "github_actions" \
+            --arg area            "$T_AREA" \
+            --arg is_followup     "$IS_FOLLOWUP" \
+            '{
+              source:          $source,
+              outcome:         $outcome,
+              repo:            $repo,
+              pr:              $pr,
+              pr_author:       $pr_author,
+              pr_head_sha:     $pr_head_sha,
+              model:           $model,
+              build_url:       $build_url,
+              ci_provider:     $ci_provider,
+              area:            $area,
+              is_followup:     ($is_followup == "true"),
+              cost_usd:        ($r[0].total_cost_usd // 0),
+              duration:        (($r[0].duration_ms // 0) / 1000),
+              api_duration_ms: ($r[0].duration_api_ms // 0),
+              num_turns:       ($r[0].num_turns // 0),
+              tokens_in:       ($r[0].usage.input_tokens // 0),
+              tokens_out:      ($r[0].usage.output_tokens // 0),
+              cache_read:      ($r[0].usage.cache_read_input_tokens // 0),
+              cache_creation:  ($r[0].usage.cache_creation_input_tokens // 0),
+              session_id:      ($r[0].session_id // ""),
+              ttft_ms:         ($r[0].ttft_ms // 0)
+            }')
+
+          curl -s -f -X POST \
+            "https://public-api.wordpress.com/wpcom/v2/ai-review/telemetry" \
+            -H "Content-Type: application/json" \
+            -H "X-AI-Review-Token: ${TELEMETRY_TOKEN}" \
+            -d "$PAYLOAD"


### PR DESCRIPTION
Part of #

## Proposed Changes

* Add `id` to each of the three area-specific review steps in `pr-review.yml` (`dashboard`, `a4a`, `general`) so a downstream step can read their outputs.
* Append a `Send telemetry to wpcom` step that picks the `execution_file` from whichever area-specific step ran and POSTs cost, duration, token usage, and outcome to `https://public-api.wordpress.com/wpcom/v2/ai-review/telemetry`. Area is encoded in `source` (`wp-calypso-dashboard` / `wp-calypso-a4a` / `wp-calypso-general`).
* Declare `ai_review_telemetry_token` as an optional secret on the reusable workflow. The actual repo secret is `AI_REVIEW_TELEMETRY_TOKEN`.

## Why are these changes being made?

We want to track AI review spend and quality across `wp-calypso` and `woocommerce` callers in one place. The wpcom endpoint is the central ingest point; each run sends a single payload describing what it cost, how long it took, and whether it succeeded.

The telemetry step is gated on the review step having actually produced an `execution_file`, so it no-ops on runs that are short-circuited by the fork-reject, author-permission, or `AGENTS.md` / `CLAUDE.md` guards.

The same change is going out to the woo `.github` reusable workflow.

## Testing Instructions

* Provision `AI_REVIEW_TELEMETRY_TOKEN` as a repo secret before merging (the workflow accepts an empty value and the endpoint rejects, so a missing secret is detectable but harmless).
* Open a PR that touches `client/dashboard/**` or `client/a8c-for-agencies/**` (or comment `@claude /review` on any PR) and confirm the `Send telemetry to wpcom` step runs after the area-specific review step.
* Confirm a corresponding row lands on the wpcom dashboard with `source = "wp-calypso-dashboard"` / `wp-calypso-a4a` / `wp-calypso-general` matching the trigger, and non-zero `cost_usd` / token counts.
* Negative case: open a fork PR (or a PR that edits `AGENTS.md`) and confirm the telemetry step is skipped along with the review step.
