### PR TITLE
Image Studio: Add site context to tracks events

### DIFF
--- a/packages/image-studio/src/index.tsx
+++ b/packages/image-studio/src/index.tsx
@@ -27,6 +27,9 @@ interface ImageStudioData {
 	environment?: 'wp-admin' | 'ciab-admin';
 	isDevMode?: boolean;
 	canGenerateVideoClips?: boolean;
+	blogId?: number | string;
+	siteType?: 'simple' | 'atomic' | 'jetpack' | 'wpcom' | 'woa';
+	isA11n?: boolean;
 }
 
 declare global {

--- a/packages/image-studio/src/utils/tracking.test.ts
+++ b/packages/image-studio/src/utils/tracking.test.ts
@@ -103,6 +103,103 @@ describe( 'trackImageStudioOpened', () => {
 	} );
 } );
 
+describe( 'recordImageStudioEvent — tracking context properties', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		selectMock.mockReturnValue( {
+			getEntryPoint: jest.fn( () => null ),
+		} );
+		delete ( window as any ).imageStudioData;
+	} );
+
+	afterEach( () => {
+		delete ( window as any ).imageStudioData;
+	} );
+
+	it( 'should include blog_id, site_type, and is_a11n from imageStudioData', () => {
+		( window as any ).imageStudioData = {
+			blogId: 1234,
+			siteType: 'atomic',
+			isA11n: true,
+		};
+
+		trackImageStudioClosed( { mode: 'edit' } );
+
+		expect( recordTracksEventMock ).toHaveBeenCalledWith(
+			'jetpack_big_sky_image_studio_closed',
+			expect.objectContaining( {
+				blog_id: 1234,
+				site_type: 'atomic',
+				is_a11n: true,
+			} )
+		);
+	} );
+
+	it( 'should parse blogId when it is provided as a string', () => {
+		( window as any ).imageStudioData = {
+			blogId: '5678',
+			siteType: 'simple',
+		};
+
+		trackImageStudioClosed( { mode: 'edit' } );
+
+		expect( recordTracksEventMock ).toHaveBeenCalledWith(
+			'jetpack_big_sky_image_studio_closed',
+			expect.objectContaining( {
+				blog_id: 5678,
+				site_type: 'simple',
+			} )
+		);
+	} );
+
+	it( 'should normalize legacy wpcom and woa site type values', () => {
+		( window as any ).imageStudioData = { siteType: 'woa' };
+
+		trackImageStudioClosed( { mode: 'edit' } );
+
+		expect( recordTracksEventMock ).toHaveBeenCalledWith(
+			'jetpack_big_sky_image_studio_closed',
+			expect.objectContaining( { site_type: 'atomic' } )
+		);
+
+		jest.clearAllMocks();
+		( window as any ).imageStudioData = { siteType: 'wpcom' };
+
+		trackImageStudioClosed( { mode: 'edit' } );
+
+		expect( recordTracksEventMock ).toHaveBeenCalledWith(
+			'jetpack_big_sky_image_studio_closed',
+			expect.objectContaining( { site_type: 'simple' } )
+		);
+	} );
+
+	it( 'should default site_type to jetpack and is_a11n to false', () => {
+		trackImageStudioClosed( { mode: 'edit' } );
+
+		expect( recordTracksEventMock ).toHaveBeenCalledWith(
+			'jetpack_big_sky_image_studio_closed',
+			expect.objectContaining( {
+				site_type: 'jetpack',
+				is_a11n: false,
+			} )
+		);
+	} );
+
+	it( 'should omit blog_id when blogId is unavailable or invalid', () => {
+		( window as any ).imageStudioData = {
+			blogId: 'not-a-number',
+			siteType: 'jetpack',
+		};
+
+		trackImageStudioClosed( { mode: 'edit' } );
+
+		const call = recordTracksEventMock.mock.calls[ 0 ];
+		expect( call[ 0 ] ).toBe( 'jetpack_big_sky_image_studio_closed' );
+		expect( call[ 1 ] ).not.toHaveProperty( 'blog_id' );
+		expect( call[ 1 ] ).toMatchObject( { site_type: 'jetpack' } );
+	} );
+} );
+
 describe( 'recordImageStudioEvent — is_test property', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();

--- a/packages/image-studio/src/utils/tracking.ts
+++ b/packages/image-studio/src/utils/tracking.ts
@@ -12,6 +12,15 @@ import { getSessionId } from '../utils/session';
 import type { ImageStudioMode, MetadataField } from '../types';
 
 const TRACKS_PREFIX = 'jetpack_big_sky';
+const SITE_TYPES = [ 'simple', 'atomic', 'jetpack' ] as const;
+
+type ImageStudioSiteType = ( typeof SITE_TYPES )[ number ];
+type ImageStudioTrackingData = {
+	blogId?: number | string;
+	siteType?: string;
+	isA11n?: boolean;
+	isDevMode?: boolean;
+};
 
 /**
  * Format suggestion IDs into a pipe-delimited string for tracking
@@ -31,14 +40,48 @@ export function formatSuggestionIds( suggestions: Array< { id?: string } > ): st
  */
 function getImageStudioEntryPoint(): string | null {
 	try {
-		const imageStudioStoreData = select( imageStudioStore );
-		if ( imageStudioStoreData && imageStudioStoreData.getEntryPoint ) {
-			return imageStudioStoreData.getEntryPoint();
+		const imageStudioSelectors = select( imageStudioStore );
+		if ( imageStudioSelectors && imageStudioSelectors.getEntryPoint ) {
+			return imageStudioSelectors.getEntryPoint();
 		}
 	} catch ( error ) {
 		// Store may not be registered yet
 	}
 	return null;
+}
+
+function getImageStudioWindowData(): ImageStudioTrackingData | undefined {
+	return ( window as unknown as { imageStudioData?: ImageStudioTrackingData } ).imageStudioData;
+}
+
+function getTrackingBlogId(): number | null {
+	const blogId = getImageStudioWindowData()?.blogId;
+
+	if ( typeof blogId !== 'number' && typeof blogId !== 'string' ) {
+		return null;
+	}
+
+	const parsedBlogId = typeof blogId === 'number' ? blogId : Number( blogId );
+
+	return Number.isFinite( parsedBlogId ) && parsedBlogId > 0 ? parsedBlogId : null;
+}
+
+function getTrackingSiteType(): ImageStudioSiteType {
+	const siteType = getImageStudioWindowData()?.siteType;
+
+	if ( SITE_TYPES.includes( siteType as ImageStudioSiteType ) ) {
+		return siteType as ImageStudioSiteType;
+	}
+
+	if ( siteType === 'wpcom' ) {
+		return 'simple';
+	}
+
+	if ( siteType === 'woa' ) {
+		return 'atomic';
+	}
+
+	return 'jetpack';
 }
 
 /**
@@ -63,10 +106,19 @@ function recordImageStudioEvent(
 	properties: Record< string, string | number | boolean > = {}
 ): void {
 	const entryPoint = getImageStudioEntryPoint();
+	const blogId = getTrackingBlogId();
+	const siteType = getTrackingSiteType();
+	const imageStudioWindowData = getImageStudioWindowData();
 	const baseProps: Record< string, string | number | boolean > = {
 		...properties,
 		sessionid: getSessionId(),
 	};
+
+	if ( blogId ) {
+		baseProps.blog_id = blogId;
+	}
+
+	baseProps.site_type = siteType;
 
 	if ( entryPoint ) {
 		baseProps.placement = entryPoint;
@@ -81,8 +133,10 @@ function recordImageStudioEvent(
 		baseProps.post_type = win.typenow;
 	}
 
+	baseProps.is_a11n = !! imageStudioWindowData?.isA11n;
+
 	// Add dev mode flag for filtering test/internal traffic
-	baseProps.is_test = !! win.imageStudioData?.isDevMode;
+	baseProps.is_test = !! imageStudioWindowData?.isDevMode;
 
 	recordTracksEvent( eventName, baseProps );
 }


### PR DESCRIPTION
Part of FORNO-196

## Proposed Changes

* Add `blog_id`, `site_type`, and `is_a11n` to Image Studio Tracks events via `recordImageStudioEvent()`.
* Normalize `site_type` to `simple`, `atomic`, or `jetpack`.
* Add focused tracking tests for the new event properties.

## Why are these changes being made?

* Image Studio events need consistent site context so usage can be segmented across WordPress.com Simple, Atomic, and Jetpack sites.

## Testing Instructions

* Follow instructions in https://github.com/Automattic/jetpack/pull/49186

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
