### PR TITLE
A4A Navigation: Reorganize sidebar to group Sites + Plugins + Reports

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
@@ -142,6 +142,34 @@ const useMainMenuItems = ( path: string ) => {
 				},
 				withChevron: true,
 			},
+			...( isSectionNameEnabled( 'a8c-for-agencies-plugins' )
+				? [
+						{
+							icon: plugins,
+							path: '/',
+							link: A4A_PLUGINS_LINK,
+							title: translate( 'Plugins' ),
+							trackEventProps: {
+								menu_item: 'Automattic for Agencies / Plugins',
+							},
+						},
+				  ]
+				: [] ),
+			{
+				icon: chartBar,
+				path: A4A_REPORTS_LINK,
+				link: A4A_REPORTS_LINK,
+				title: (
+					<div className="sidebar-menu-item__title-with-badge">
+						<span>{ translate( 'Reports' ) }</span>
+						<Badge type="info">{ translate( 'Beta' ) }</Badge>
+					</div>
+				),
+				trackEventProps: {
+					menu_item: 'Automattic for Agencies / Reports',
+				},
+				withChevron: true,
+			},
 			{
 				icon: tag,
 				path: A4A_MARKETPLACE_LINK,
@@ -178,34 +206,6 @@ const useMainMenuItems = ( path: string ) => {
 				title: translate( 'WooPayments' ),
 				trackEventProps: {
 					menu_item: 'Automattic for Agencies / WooPayments',
-				},
-				withChevron: true,
-			},
-			...( isSectionNameEnabled( 'a8c-for-agencies-plugins' )
-				? [
-						{
-							icon: plugins,
-							path: '/',
-							link: A4A_PLUGINS_LINK,
-							title: translate( 'Plugins' ),
-							trackEventProps: {
-								menu_item: 'Automattic for Agencies / Plugins',
-							},
-						},
-				  ]
-				: [] ),
-			{
-				icon: chartBar,
-				path: A4A_REPORTS_LINK,
-				link: A4A_REPORTS_LINK,
-				title: (
-					<div className="sidebar-menu-item__title-with-badge">
-						<span>{ translate( 'Reports' ) }</span>
-						<Badge type="info">{ translate( 'Beta' ) }</Badge>
-					</div>
-				),
-				trackEventProps: {
-					menu_item: 'Automattic for Agencies / Reports',
 				},
 				withChevron: true,
 			},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Part of A4A-2644

## Proposed Changes

* Reordered A4A sidebar navigation items to group logically related sections
* Moved Plugins directly after Sites
* Moved Reports (Client Reports) after Plugins
* This creates a clear "site management" grouping (Sites → Plugins → Reports)

## Why are these changes being made?

This change addresses feedback from the product walkthrough QA review (May 15, 2026) where the team noted that Sites and Plugins should be adjacent, and Client Reports should be grouped with the same site management items.

This is scoped as a small structural reordering only — not the full navigation consolidation planned in the longer-term product vision.

**New sidebar order:**
1. Overview
2. Agency tier
3. Exclusive offers
4. Resources and tools
5. **Sites** ← site management group
6. **Plugins** ← site management group
7. **Reports** ← site management group
8. Marketplace
9. Purchases
10. Referrals
11. Migrations
12. WooPayments
13. Partner directories
14. Settings
15. Team

## Testing Instructions

1. Navigate to the A4A portal (`/a8c-for-agencies`)
2. Check the main sidebar navigation
3. Verify that Sites, Plugins, and Reports (Client Reports) appear as a grouped sequence
4. Verify all navigation items still function correctly

<img width="274" height="779" alt="Screenshot 2026-05-27 at 2 55 07 PM" src="https://github.com/user-attachments/assets/3a6fa2e1-1970-4394-938b-70b254e19959" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
<!-- CURSOR_AGENT_PR_BODY_END -->