### PR TITLE
Help Center FAB: extend to all logged-out /start/* routes

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -100,14 +100,6 @@ const HELP_CENTER_FAB_SECTIONS = [
 // Fallback when section name is unreliable — e.g. /me/account/closed activates as 'me'.
 const HELP_CENTER_FAB_ROUTES = [ '/me/account/closed' ];
 
-// Within the `signup` section the FAB is scoped to the account-creation step
-// (`user-social` or `user`) so it appears on `/start/account/user-social` but
-// not on flow-specific steps like `/start/domain/domain-only`. The `<flow>`
-// segment is optional because the default signup flow omits it, producing
-// URLs like `/start/user` and `/start/user/<stepSection>/<lang>`. Matches up
-// to two trailing segments (`:stepSectionName` and/or `:lang`).
-const SIGNUP_ACCOUNT_STEP_PATH = /^\/start\/(?:[^/]+\/)?(?:user|user-social)(?:\/[^/]+){0,2}\/?$/;
-
 // /log-in briefly carries social-handoff tokens before the login controller strips
 // them (?access_token / ?id_token in query, #id_token / #client_id in hash).
 // Suppress the FAB during that window so window.location.href doesn't reach Zendesk.
@@ -218,10 +210,11 @@ const LayoutLoggedOut = ( {
 		sectionName === 'login' && ! useOAuth2Layout && ! isJetpackLogin && isFabSafeLoginUrl();
 
 	// OAuth client signups (Woo, BlazePro, Gravatar, WPJobManager, etc.) run under
-	// their own brand. For plain WPCOM signup we only show the FAB on the
-	// account-creation step, not on flow-specific steps like `domain-only`.
-	const isWpcomSignup =
-		sectionName === 'signup' && ! useOAuth2Layout && SIGNUP_ACCOUNT_STEP_PATH.test( currentRoute );
+	// their own brand and support paths; for all other WPCOM signup routes the
+	// FAB is the only help affordance, so we render it across the whole section.
+	// The `--bottom-bar-height` layout var prevents collision with bottom bars
+	// (e.g. the domains mini-cart on `/start/domain/domain-only`).
+	const isWpcomSignup = sectionName === 'signup' && ! useOAuth2Layout;
 
 	const isEligibleSection =
 		HELP_CENTER_FAB_SECTIONS.includes( sectionName ) &&


### PR DESCRIPTION
## Summary

Extends the logged-out Help Center FAB to every WPCOM `/start/*` signup route, not just the account-creation step. Follow-up to #111072, which solved the collision blocker.

## Changes

- `client/layout/logged-out.jsx`: drop the `SIGNUP_ACCOUNT_STEP_PATH` regex from `isWpcomSignup`. The gate is now just `sectionName === 'signup' && !useOAuth2Layout`. Constant removed.

## Why

The account-step regex was added in #111065 to keep the FAB off `/start/domain/domain-only` so it wouldn't collide with the domains mini-cart. #111072 introduced `--bottom-bar-height`, a global layout var that the FAB respects to shift above any persistent bottom bar. The regex no longer earns its place.

## Testing

- Logged out, visit `/start/domain/domain-only`: FAB visible; add a domain → mini-cart appears, FAB rides 16px above it (PR #111072 behavior).
- Logged out, visit `/start/onboarding/domains`: redirected to `/start/onboarding/user`, FAB visible there (unchanged).
- Logged out, visit `/start/woo-blaze-pro/<step>` (or any OAuth2-branded signup): FAB hidden (unchanged).
- Logged in: FAB hidden on all `/start/*` (unchanged).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
