### PR TITLE
AI review telemetry smoke test (3 area paths)

### DIFF
--- a/docs/dependency-management.md
+++ b/docs/dependency-management.md
@@ -15,7 +15,7 @@ cd packages/calypso-analytics
 yarn add ...
 ```
 
-**Option 2**: Run `yarn` commands in teh root of the project, but prepend `workspace <packageName>`. Example
+**Option 2**: Run `yarn` commands in the root of the project, but prepend `workspace <packageName>`. Example
 
 ```
 yarn workspace @automattic/calypso-analytics add...


### PR DESCRIPTION
## Proposed Changes

* Commit 1 (general path): fix "teh" typo in `docs/dependency-management.md`.

Follow-up commits will add benign changes under `client/a8c-for-agencies/` and `client/dashboard/` to exercise the other two area paths.

## Why

End-to-end smoke test of the AI review telemetry rollout on this repo (PR #111073). Each `@claude /review` re-trigger should route to a different area based on the cumulative diff, and we want to confirm `telemetry: HTTP 200` for each: `wp-calypso-general`, then `wp-calypso-a4a`, then `wp-calypso-dashboard`.

## Testing

* Comment `@claude /review` on this PR after each commit lands. The `pr-review-on-ping` workflow detects area from the cumulative file paths (priority: dashboard > a4a > general).
* Watch the `Send telemetry to wpcom` step for HTTP 200.
* Confirm the corresponding row in ES with the right `source` value.