### PR TITLE
A4A Sites: replace gradient avatar fallback with first-grapheme

### DIFF
--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/sites-dataviews-style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/sites-dataviews-style.scss
@@ -13,6 +13,13 @@
 
 .sites-dataviews__site-favicon {
 	margin-right: 16px;
+
+	// Back loaded site icons with the white surface so logos with transparent
+	// backgrounds read as a clean card instead of showing the gray base tile.
+	// The fallback tiles (is-blank / is-primary) keep their own backgrounds.
+	.site-icon:not(.is-blank):not(.is-primary) {
+		background: var(--color-surface);
+	}
 }
 
 .sites-dataviews__site-name {

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field.tsx
@@ -35,7 +35,7 @@ const SiteDataField = ( {
 		>
 			<SiteFavicon
 				blogId={ site.blog_id }
-				fallback={ site.is_atomic ? 'wordpress-logo' : 'color' }
+				fallback={ site.is_atomic ? 'wordpress-logo' : 'first-grapheme' }
 				className="sites-dataviews__site-favicon"
 			/>
 			<div className="sites-dataviews__site-name">

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field.tsx
@@ -36,6 +36,7 @@ const SiteDataField = ( {
 			<SiteFavicon
 				blogId={ site.blog_id }
 				fallback={ site.is_atomic ? 'wordpress-logo' : 'first-grapheme' }
+				siteName={ site.blogname }
 				className="sites-dataviews__site-favicon"
 			/>
 			<div className="sites-dataviews__site-name">

--- a/client/blocks/site-favicon/index.tsx
+++ b/client/blocks/site-favicon/index.tsx
@@ -17,6 +17,7 @@ interface SiteFaviconProps {
 	size?: number;
 	className?: string;
 	fallback?: SiteFaviconFallback;
+	siteName?: string;
 	lazy?: boolean;
 	variant?: SiteIconVariant;
 }
@@ -27,6 +28,7 @@ const SiteFavicon = ( {
 	size = 40,
 	className = '',
 	fallback = 'color',
+	siteName,
 	lazy = false,
 	variant,
 }: SiteFaviconProps ) => {
@@ -47,7 +49,7 @@ const SiteFavicon = ( {
 					aria-label={ __( 'Site Icon' ) }
 					style={ size <= 36 ? { fontSize: size * 0.6 } : {} }
 				>
-					{ getFirstGrapheme( site?.title ?? '' ) }
+					{ getFirstGrapheme( siteName ?? site?.title ?? '' ) }
 				</div>
 			);
 			defaultFaviconClass = 'is-first-grapheme';


### PR DESCRIPTION

| Before | After |
|--------|--------|
| <img width="711" height="360" alt="Screenshot 2026-05-27 at 3 21 52 PM" src="https://github.com/user-attachments/assets/6da598cc-a005-458c-a9a8-fe74f4a0adf3" /> | <img width="785" height="349" alt="Screenshot 2026-05-27 at 3 21 57 PM" src="https://github.com/user-attachments/assets/7fcc2318-3e52-4a3b-8de2-3fe19e41f879" /> | 

Closes https://linear.app/a8c/issue/A4A-2624/sites-dashboard-remove-decorative-gradient-images

## Proposed Changes
The Sites Dashboard previously rendered a colorful diagonal gradient as the site avatar fallback for non-Atomic sites with no favicon. This was carried over from Jetpack Manage and felt decorative rather than functional. Switch the fallback to `first-grapheme`, which renders the site's first character on a neutral surface — matching the wpcom Sites Dashboard treatment and aligning with the portal's neutral aesthetic direction.

Atomic sites continue to fall back to the WordPress logo, unchanged.


## Why are these changes being made?

* The gradient color draws visual attention without providing functional value and doesn't serve as a proper empty state.



## Testing Instructions

* Use the A4A live link and navigate to `/sites` page.
* Verify that the site image placeholder uses text as seen on the screen.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
