### PR TITLE
Fix subject-verb agreement in dashboard README

### DIFF
--- a/client/dashboard/README.md
+++ b/client/dashboard/README.md
@@ -24,7 +24,7 @@ This dashboard uses TanStack Query and TanStack Router.
 
 ## Bugs
 
-- Importing SASS files bring unexpected CSS variables to our bundles (e.g., --masterbar-height, --sidebar-width), it also brings fonts (Recoleta, Noto) and some global classes. Why? Imports should ideally be explicit.
+- Importing SASS files brings unexpected CSS variables to our bundles (e.g., --masterbar-height, --sidebar-width), it also brings fonts (Recoleta, Noto) and some global classes. Why? Imports should ideally be explicit.
 
 ## Hacks
 


### PR DESCRIPTION
## Proposed Changes

* Fix subject-verb agreement in `client/dashboard/README.md`: "Importing SASS files bring" -> "brings".

## Why

Tiny real fix used as a smoke test for the AI Code Review telemetry rollout (path: `client/dashboard/**`). Opening this PR should auto-fire the dashboard-area review caller and we want to confirm telemetry lands in ES with `source = "wp-calypso-dashboard"`.

## Testing

* Watch the AI Code Review workflow run on this PR.
* Confirm the `Send telemetry to wpcom` step logs `telemetry: HTTP 200`.
* Confirm a row in ES with `source = "wp-calypso-dashboard"`, `repo = "Automattic/wp-calypso"`, non-zero `cost_usd` / token counts.