### PR TITLE
A4A WooPayments: align overview section backgrounds to portal neutral

### DIFF
--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-overview/index.tsx
@@ -295,7 +295,7 @@ const WooPaymentsOverview = () => {
 				<PageSectionColumns
 					heading={ translate( 'Earn more from every project' ) }
 					background={ {
-						color: '#FAF7F3',
+						color: 'var(--color-neutral-0)',
 					} }
 				>
 					<PageSectionColumns.Column>
@@ -479,7 +479,7 @@ const WooPaymentsOverview = () => {
 
 				<PageSectionColumns
 					background={ {
-						color: '#F1F1F2',
+						color: 'var(--color-neutral-0)',
 					} }
 				>
 					<PageSectionColumns.Column heading={ translate( 'About WooPayments' ) }>
@@ -518,7 +518,7 @@ const WooPaymentsOverview = () => {
 						</>
 					}
 					background={ {
-						color: '#FAF7F3',
+						color: 'var(--color-neutral-0)',
 					} }
 				>
 					<PageSectionColumns.Column>

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-overview/style.scss
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-overview/style.scss
@@ -2,7 +2,7 @@
 @import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/variables";
 
-$alt-color: #FAF7F3;
+$alt-color: var(--color-neutral-0);
 
 .woopayments-overview {
 	.hosting-dashboard-layout__header-actions {


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="1441" height="520" alt="Screenshot 2026-05-27 at 3 47 03 PM" src="https://github.com/user-attachments/assets/2d32ad87-4160-4c5b-a8d4-f9fb4051e2e1" /> | <img width="1442" height="511" alt="Screenshot 2026-05-27 at 3 47 21 PM" src="https://github.com/user-attachments/assets/30ebed44-c974-4509-8fc3-d4cfb55e08f8" /> | 


Closes https://linear.app/a8c/issue/A4A-2633/woopayments-standardize-page-header-background-vip-purple-portal

## Proposed Changes

Replace cream #FAF7F3 with `var(--color-neutral-0)` so the WooPayments overview section backgrounds match the portal-neutral standard flagged in the May 15 QA walkthrough (A4A-2633, parent A4A-2642).


## Why are these changes being made?

* This makes our page more consistent. The cream color is exclusive for WPVIP-related pages, so we should only use that for WPVIP.

## Testing Instructions

* Use the A4A live link and navigate to `/woopayments/overview` page.
* Confirm that the background of some of the sections uses the correct color.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
