### PR TITLE
Reader sidebar: only mark Social as selected when on a connections route

### DIFF
--- a/client/reader/sidebar/reader-sidebar-connections/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-connections/index.tsx
@@ -240,7 +240,7 @@ function ReaderSidebarConnections( { path }: Props ) {
 				onClick={ handleMainClick }
 				expandableIconClick={ () => setIsOpen( ! isOpen ) }
 				disableFlyout
-				className={ ! isOpen ? 'sidebar__menu--selected' : undefined }
+				className={ ! isOpen && isOnConnections ? 'sidebar__menu--selected' : undefined }
 				count={ undefined }
 				icon={ null }
 				materialIcon={ null }


### PR DESCRIPTION
Fixes CM-795

## Proposed Changes

* In `client/reader/sidebar/reader-sidebar-connections/index.tsx`, gate the `sidebar__menu--selected` class on both `!isOpen` **and** `isOnConnections`, matching the pattern used by the sibling Recent menu.

## Why are these changes being made?

The Social expandable menu header applied the `sidebar__menu--selected` class purely based on the menu being collapsed. Since the menu defaults to closed on any non-connections route, the Social entry appeared visually selected on every Reader page (Recent, Discover, Search, …) — not just when the user was actually inside the Social section.

The Recent menu (`client/reader/sidebar/reader-sidebar-recent/index.tsx:106`) already uses the correct two-condition gating; the Connections menu now mirrors that pattern.

## Testing Instructions

1. Open the Reader at `/reader/`.
2. Verify the **Social** entry in the left nav is **not** highlighted.
3. Navigate to `/reader/discover`, `/reader/search`, `/activities/likes`, etc. — Social should remain unhighlighted.
4. Navigate to `/reader/connections` (or any `/reader/atmosphere/...`, `/reader/mastodon/...`, `/reader/fediverse/...` route). The Social menu auto-expands and the active connection row carries the selection.
5. Manually collapse the Social menu while still on a connections route — the header should now show the selected style.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?