### PR TITLE
Revert domains-mini-cart changes from #111072

### DIFF
--- a/packages/domain-search/src/ui/domains-mini-cart/index.tsx
+++ b/packages/domain-search/src/ui/domains-mini-cart/index.tsx
@@ -49,11 +49,7 @@ export const DomainsMiniCart = ( {
 		<>
 			<div className="domains-mini-cart__cushion" />
 			<motion.div
-				className={ clsx(
-					'domains-mini-cart__container',
-					{ 'is-open': isMiniCartOpen },
-					className
-				) }
+				className={ clsx( 'domains-mini-cart__container', className ) }
 				initial={ animation.initial }
 				animate={ isMiniCartOpen ? animation.animateIn : animation.animateOut }
 				transition={ { type: 'tween', duration: 0.25 } }

--- a/packages/domain-search/src/ui/domains-mini-cart/style.scss
+++ b/packages/domain-search/src/ui/domains-mini-cart/style.scss
@@ -6,11 +6,6 @@
 	height: var( --domain-search-mini-cart-height );
 }
 
-// Global layout signal for fixed-bottom UI — parallels `--masterbar-height`.
-:root:has( .domains-mini-cart__container.is-open ) {
-	--bottom-bar-height: 80px;
-}
-
 .domains-mini-cart__container {
 	position: fixed !important;
 	left: 0;


### PR DESCRIPTION
Part of #

## Proposed Changes

* Revert the two `packages/domain-search/src/ui/domains-mini-cart/` changes introduced by #111072:
  * Remove the `is-open` class toggle on `.domains-mini-cart__container` in `index.tsx`.
  * Remove the `:root:has( .domains-mini-cart__container.is-open ) { --bottom-bar-height: 80px; }` rule in `style.scss`.
* Intentionally **keep** the FAB-side changes from #111072 (`client/components/help-center-fab/style.scss`). The FAB still reads `--bottom-bar-height` via `var(..., 0px)` and falls back cleanly to its standard `max(24px, safe-area-inset-bottom)` inset when no producer sets the var — matching the pre-#111072 FAB position whenever the mini-cart is open.

## Why are these changes being made?

* The mini-cart side of #111072 is being reverted on request. The FAB-side layout-var plumbing is retained so future persistent bottom bars can opt in via the same `--bottom-bar-height` convention without re-introducing the cart-specific producer.

## Testing Instructions

* Open a flow that surfaces the domains mini-cart (e.g. the domain search in onboarding) and confirm the Help Center FAB sits at its standard viewport-edge inset rather than shifted above the cart.
* Confirm there are no console / TypeScript errors from the mini-cart component.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)