### PR TITLE
A4A: dim empty-state placeholder across portal tables

### DIFF
--- a/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/wpcom-sites-table.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/import-from-wpcom-modal/wpcom-sites-table.tsx
@@ -1,9 +1,10 @@
-import { WordPressLogo, JetpackLogo, Gridicon } from '@automattic/components';
+import { WordPressLogo, JetpackLogo } from '@automattic/components';
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { CheckboxControl } from '@wordpress/components';
 import { Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useCallback } from 'react';
+import EmptyValueIndicator from 'calypso/a8c-for-agencies/components/empty-value-indicator';
 import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dashboard-sites';
 import { urlToSlug } from 'calypso/lib/url/http-utils';
 import { useSelector } from 'calypso/state';
@@ -38,7 +39,7 @@ const TypeIcon = ( { siteId }: { siteId: number } ) => {
 	if ( isJetpack ) {
 		return <Icon className="wpcom-sites-table__icon" icon={ <JetpackLogo /> } />;
 	}
-	return <Gridicon icon="minus" />;
+	return <EmptyValueIndicator />;
 };
 
 export default function WPCOMSitesTable( {

--- a/client/a8c-for-agencies/components/empty-value-indicator/index.tsx
+++ b/client/a8c-for-agencies/components/empty-value-indicator/index.tsx
@@ -1,0 +1,17 @@
+import { Gridicon } from '@automattic/components';
+import clsx from 'clsx';
+
+import './style.scss';
+
+type Props = {
+	className?: string;
+};
+
+/**
+ * Shared "no value" placeholder for A4A tables. Renders the minus glyph used
+ * across the portal in a dimmed gray so empty cells don't compete with real
+ * data. See A4A-2640.
+ */
+export default function EmptyValueIndicator( { className }: Props ) {
+	return <Gridicon icon="minus" className={ clsx( 'a4a-empty-value-indicator', className ) } />;
+}

--- a/client/a8c-for-agencies/components/empty-value-indicator/style.scss
+++ b/client/a8c-for-agencies/components/empty-value-indicator/style.scss
@@ -1,0 +1,4 @@
+.a4a-empty-value-indicator {
+	color: var(--color-neutral-10);
+	fill: var(--color-neutral-10);
+}

--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/index.tsx
@@ -1,9 +1,9 @@
-import { Gridicon } from '@automattic/components';
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, ReactNode, useState, useCallback } from 'react';
+import EmptyValueIndicator from 'calypso/a8c-for-agencies/components/empty-value-indicator';
 import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
@@ -77,7 +77,7 @@ export default function SubscriptionsList() {
 				getValue: () => '-',
 				render: ( { item }: { item: Subscription } ): ReactNode => {
 					if ( isBillingTypeBD && item.status === 'error' ) {
-						return <Gridicon icon="minus" />;
+						return <EmptyValueIndicator />;
 					}
 					let amount = '';
 					let currency = 'USD';

--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/mobile-view/index.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/mobile-view/index.tsx
@@ -1,5 +1,5 @@
-import { Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import EmptyValueIndicator from 'calypso/a8c-for-agencies/components/empty-value-indicator';
 import { useSelector } from 'calypso/state';
 import { getUserBillingType } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import {
@@ -61,7 +61,7 @@ const SubscriptionItem = ( {
 				<h3>{ translate( 'PRICE' ).toUpperCase() }</h3>
 				<p>
 					{ isBillingTypeBD && subscription.status === 'error' ? (
-						<Gridicon icon="minus" />
+						<EmptyValueIndicator />
 					) : (
 						<SubscriptionPrice
 							isFetching={ isFetching }

--- a/client/a8c-for-agencies/sections/purchases/billing/billing-details/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/billing/billing-details/index.tsx
@@ -1,6 +1,7 @@
-import { Card, Gridicon } from '@automattic/components';
+import { Card } from '@automattic/components';
 import { formatCurrency } from '@automattic/number-formatters';
 import { useTranslate } from 'i18n-calypso';
+import EmptyValueIndicator from 'calypso/a8c-for-agencies/components/empty-value-indicator';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import useFetchBillingSummary from 'calypso/a8c-for-agencies/data/purchases/use-fetch-billing-summary';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
@@ -93,25 +94,25 @@ export default function BillingDetails() {
 						<div className="billing-details__product">
 							{ billing.isLoading && <TextPlaceholder /> }
 
-							{ billing.isError && <Gridicon icon="minus" /> }
+							{ billing.isError && <EmptyValueIndicator /> }
 						</div>
 
 						<div className="billing-details__assigned">
 							{ billing.isLoading && <TextPlaceholder /> }
 
-							{ billing.isError && <Gridicon icon="minus" /> }
+							{ billing.isError && <EmptyValueIndicator /> }
 						</div>
 
 						<div className="billing-details__unassigned">
 							{ billing.isLoading && <TextPlaceholder /> }
 
-							{ billing.isError && <Gridicon icon="minus" /> }
+							{ billing.isError && <EmptyValueIndicator /> }
 						</div>
 
 						<div className="billing-details__subtotal">
 							{ billing.isLoading && <TextPlaceholder /> }
 
-							{ billing.isError && <Gridicon icon="minus" /> }
+							{ billing.isError && <EmptyValueIndicator /> }
 						</div>
 					</div>
 				</Card>
@@ -154,7 +155,7 @@ export default function BillingDetails() {
 
 						{ billing.isLoading && <TextPlaceholder /> }
 
-						{ billing.isError && <Gridicon icon="minus" /> }
+						{ billing.isError && <EmptyValueIndicator /> }
 					</strong>
 				</div>
 			</Card>

--- a/client/a8c-for-agencies/sections/purchases/billing/billing-summary/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/billing/billing-summary/index.tsx
@@ -2,6 +2,7 @@ import { Button, Card, Gridicon, Tooltip } from '@automattic/components';
 import { formatCurrency, formatNumber } from '@automattic/number-formatters';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useRef, useState } from 'react';
+import EmptyValueIndicator from 'calypso/a8c-for-agencies/components/empty-value-indicator';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import useFetchBillingSummary from 'calypso/a8c-for-agencies/data/purchases/use-fetch-billing-summary';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
@@ -73,7 +74,7 @@ export default function BillingSummary() {
 					{ billing.isSuccess && formatNumber( billing.data.licenses.total ) }
 					{ billing.isLoading && <TextPlaceholder /> }
 
-					{ billing.isError && <Gridicon icon="minus" /> }
+					{ billing.isError && <EmptyValueIndicator /> }
 				</strong>
 			</div>
 			<div className="billing-summary__stat billing-summary__assigned-licenses">
@@ -83,7 +84,7 @@ export default function BillingSummary() {
 
 					{ billing.isLoading && <TextPlaceholder /> }
 
-					{ billing.isError && <Gridicon icon="minus" /> }
+					{ billing.isError && <EmptyValueIndicator /> }
 				</strong>
 			</div>
 			<div className="billing-summary__stat billing-summary__unassigned-licenses">
@@ -93,7 +94,7 @@ export default function BillingSummary() {
 
 					{ billing.isLoading && <TextPlaceholder /> }
 
-					{ billing.isError && <Gridicon icon="minus" /> }
+					{ billing.isError && <EmptyValueIndicator /> }
 				</strong>
 			</div>
 			<div className="billing-summary__stat billing-summary__cost">
@@ -115,7 +116,7 @@ export default function BillingSummary() {
 
 					{ billing.isLoading && <TextPlaceholder /> }
 
-					{ billing.isError && <Gridicon icon="minus" /> }
+					{ billing.isError && <EmptyValueIndicator /> }
 				</strong>
 			</div>
 		</Card>

--- a/client/a8c-for-agencies/sections/purchases/invoices/invoices-list-card/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/invoices/invoices-list-card/index.tsx
@@ -1,7 +1,8 @@
-import { Badge, Button, Gridicon } from '@automattic/components';
+import { Badge, Button } from '@automattic/components';
 import { formatCurrency } from '@automattic/number-formatters';
 import { useTranslate } from 'i18n-calypso';
 import { memo } from 'react';
+import EmptyValueIndicator from 'calypso/a8c-for-agencies/components/empty-value-indicator';
 import FormattedDate from 'calypso/components/formatted-date';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import usePayInvoiceMutation from '../hooks/use-pay-invoice-mutation';
@@ -52,7 +53,7 @@ function InvoicesListCard( { id, number, dueDate, status, total, currency, pdfUr
 			<div>{ number }</div>
 			<div>
 				{ dueDate && <FormattedDate date={ moment( dueDate ) } format="ll" /> }
-				{ ! dueDate && <Gridicon icon="minus" /> }
+				{ ! dueDate && <EmptyValueIndicator /> }
 			</div>
 			<div>
 				<Badge type={ badgeType }>{ badgeLabel }</Badge>

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
@@ -1,6 +1,7 @@
 import { Badge, Card, Gridicon } from '@automattic/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import EmptyValueIndicator from 'calypso/a8c-for-agencies/components/empty-value-indicator';
 import PressableUsageDetails from 'calypso/a8c-for-agencies/components/pressable-usage-details';
 import {
 	isPressableAddonProduct,
@@ -166,7 +167,7 @@ export default function LicenseDetails( {
 				{ ! isPressableLicense && licenseState === LicenseState.Attached && (
 					<li className="license-details__list-item">
 						<h4 className="license-details__label">{ translate( 'Site ID' ) }</h4>
-						{ blogId ? <span>{ blogId }</span> : <Gridicon icon="minus" /> }
+						{ blogId ? <span>{ blogId }</span> : <EmptyValueIndicator /> }
 					</li>
 				) }
 

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -9,6 +9,7 @@ import useShowFeedback from 'calypso/a8c-for-agencies/components/a4a-feedback/ho
 import { FeedbackType } from 'calypso/a8c-for-agencies/components/a4a-feedback/types';
 import A4APopover from 'calypso/a8c-for-agencies/components/a4a-popover';
 import A4APopoverTrigger from 'calypso/a8c-for-agencies/components/a4a-popover/trigger';
+import EmptyValueIndicator from 'calypso/a8c-for-agencies/components/empty-value-indicator';
 import {
 	A4A_SITES_LINK_NEEDS_SETUP,
 	A4A_FEEDBACK_LINK,
@@ -302,7 +303,7 @@ export default function LicensePreview( {
 				<div>
 					{ quantity ? (
 						<div className="license-preview__bundle">
-							<Gridicon icon="minus" className="license-preview__no-value" />
+							<EmptyValueIndicator className="license-preview__no-value" />
 							<div className="license-preview__product-small">{ productName }</div>
 							<div>{ bundleCountContent }</div>
 						</div>
@@ -339,7 +340,7 @@ export default function LicensePreview( {
 
 				<div>
 					{ quantity ? (
-						<Gridicon icon="minus" className="license-preview__no-value" />
+						<EmptyValueIndicator className="license-preview__no-value" />
 					) : (
 						<>
 							<div className="license-preview__label">{ translate( 'Issued on:' ) }</div>
@@ -358,7 +359,7 @@ export default function LicensePreview( {
 						) }
 
 						{ licenseState !== LicenseState.Attached && (
-							<Gridicon icon="minus" className="license-preview__no-value" />
+							<EmptyValueIndicator className="license-preview__no-value" />
 						) }
 					</div>
 				) : (
@@ -370,7 +371,7 @@ export default function LicensePreview( {
 						) }
 
 						{ licenseState !== LicenseState.Revoked && (
-							<Gridicon icon="minus" className="license-preview__no-value" />
+							<EmptyValueIndicator className="license-preview__no-value" />
 						) }
 					</div>
 				) }

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/date.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/date.tsx
@@ -1,4 +1,4 @@
-import { Gridicon } from '@automattic/components';
+import EmptyValueIndicator from 'calypso/a8c-for-agencies/components/empty-value-indicator';
 import { ReferralPurchase } from '../../types';
 
 type Props = {
@@ -9,7 +9,7 @@ const DateAssigned = ( { purchase }: Props ) => {
 	return purchase.license?.attached_at ? (
 		new Date( purchase.license.attached_at ).toLocaleDateString()
 	) : (
-		<Gridicon icon="minus" />
+		<EmptyValueIndicator />
 	);
 };
 

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/total-amount.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/total-amount.tsx
@@ -1,6 +1,6 @@
-import { Gridicon } from '@automattic/components';
 import { formatCurrency } from '@automattic/number-formatters';
 import { useTranslate } from 'i18n-calypso';
+import EmptyValueIndicator from 'calypso/a8c-for-agencies/components/empty-value-indicator';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
 import { ReferralPurchase } from '../../types';
 import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
@@ -32,7 +32,7 @@ const TotalAmount = ( { purchase, data, isFetching }: Props ) => {
 	}
 
 	if ( ! amount ) {
-		return <Gridicon icon="minus" />;
+		return <EmptyValueIndicator />;
 	}
 
 	const formatted = formatCurrency( amount, currency );

--- a/client/a8c-for-agencies/sections/reports/primary/dashboard/report-columns.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/dashboard/report-columns.tsx
@@ -1,7 +1,8 @@
-import { type BadgeType, Gridicon, Tooltip } from '@automattic/components';
+import { type BadgeType, Tooltip } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useState } from 'react';
+import EmptyValueIndicator from 'calypso/a8c-for-agencies/components/empty-value-indicator';
 import StatusBadge from 'calypso/a8c-for-agencies/components/step-section-item/status-badge';
 import { getTimeframeText } from 'calypso/a8c-for-agencies/sections/reports/lib/timeframes';
 import FormattedDate from 'calypso/components/formatted-date';
@@ -35,7 +36,7 @@ export const ReportStatusColumn = ( { status }: { status: ReportStatus } ) => {
 	const config = statusConfig[ status ];
 
 	if ( ! config ) {
-		return <Gridicon icon="minus" />;
+		return <EmptyValueIndicator />;
 	}
 
 	return <StatusBadge statusProps={ { children: config.text, type: config.type as BadgeType } } />;
@@ -43,7 +44,7 @@ export const ReportStatusColumn = ( { status }: { status: ReportStatus } ) => {
 
 export const ReportDateColumn = ( { date }: { date: number | null } ) => {
 	if ( ! date ) {
-		return <Gridicon icon="minus" />;
+		return <EmptyValueIndicator />;
 	}
 
 	const dateObj = new Date( date * 1000 );
@@ -99,7 +100,7 @@ export const ReportClientEmailsColumn = ( { emails }: { emails: string[] } ) => 
 	const translate = useTranslate();
 
 	if ( ! emails || emails.length === 0 ) {
-		return <Gridicon icon="minus" />;
+		return <EmptyValueIndicator />;
 	}
 
 	if ( emails.length === 1 ) {

--- a/client/a8c-for-agencies/sections/team/primary/team-list/columns.tsx
+++ b/client/a8c-for-agencies/sections/team/primary/team-list/columns.tsx
@@ -1,6 +1,7 @@
-import { Badge, Gravatar, Gridicon } from '@automattic/components';
+import { Badge, Gravatar } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { ReactNode } from 'react';
+import EmptyValueIndicator from 'calypso/a8c-for-agencies/components/empty-value-indicator';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { OWNER_ROLE } from '../../constants';
 import { TeamMember } from '../../types';
@@ -73,6 +74,6 @@ export const DateColumn = ( { date }: { date?: string } ): ReactNode => {
 	return formattedDate ? (
 		moment.unix( formattedDate ).format( 'MMMM D, YYYY' )
 	) : (
-		<Gridicon icon="minus" />
+		<EmptyValueIndicator />
 	);
 };

--- a/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/dashboard-content/site-columns.tsx
@@ -6,6 +6,7 @@ import { useTranslate } from 'i18n-calypso';
 import { memo, useState, useRef } from 'react';
 import A4APopover from 'calypso/a8c-for-agencies/components/a4a-popover';
 import A4APopoverTrigger from 'calypso/a8c-for-agencies/components/a4a-popover/trigger';
+import EmptyValueIndicator from 'calypso/a8c-for-agencies/components/empty-value-indicator';
 import { A4A_WOOPAYMENTS_SITE_SETUP_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import StatusBadge from 'calypso/a8c-for-agencies/components/step-section-item/status-badge';
 import { urlToSlug } from 'calypso/lib/url/http-utils';
@@ -72,12 +73,12 @@ export const SiteColumn = ( { site }: { site: string } ) => {
 };
 
 export const TransactionsColumn = memo( ( { transactions }: { transactions: number | null } ) => {
-	return transactions ?? <Gridicon icon="minus" />;
+	return transactions ?? <EmptyValueIndicator />;
 } );
 TransactionsColumn.displayName = 'TransactionsColumn';
 
 export const CommissionsPaidColumn = memo( ( { payout }: { payout: number | null } ) => {
-	return payout ? formatCurrency( payout, 'USD', { stripZeros: true } ) : <Gridicon icon="minus" />;
+	return payout ? formatCurrency( payout, 'USD', { stripZeros: true } ) : <EmptyValueIndicator />;
 } );
 CommissionsPaidColumn.displayName = 'CommissionsPaidColumn';
 
@@ -86,7 +87,7 @@ export const TimeframeCommissionsColumn = memo(
 		return estimatedPayout ? (
 			formatCurrency( estimatedPayout, 'USD', { stripZeros: true } )
 		) : (
-			<Gridicon icon="minus" />
+			<EmptyValueIndicator />
 		);
 	}
 );
@@ -160,7 +161,7 @@ export const CommissionEligibilityColumn = ( {
 
 	// Don't show eligibility status if WooPayments is not active.
 	if ( state !== 'active' ) {
-		return <Gridicon icon="minus" />;
+		return <EmptyValueIndicator />;
 	}
 
 	// Check if site is commission eligible.


### PR DESCRIPTION

Closes https://linear.app/a8c/issue/A4A-2640/team-dim-empty-state-m-dashes-to-lighter-gray

## Proposed Changes

Introduce a shared EmptyValueIndicator component that wraps the minus gridicon used as the "no value" placeholder in A4A tables, and color it in --color-neutral-10 so empty cells no longer compete with real data. Replace the existing bare <Gridicon icon="minus" /> usages in Team, WooPayments, Invoices, Licenses, Billing, Referrals, Client subscriptions, Reports, and the add-site-from-WPCOM modal.


## Why are these changes being made?
The em-dashes (—) used as empty-state placeholders in the page table are rendered at full text contrast, causing them to visually compete with real data in the same columns.


## Testing Instructions

* Use the A4A live link and navigate to pages that use the em-dash placeholder (e.g., Teams, WooPayments table, etc.)
* Confirm that the em-dashes use less contrast this time.

| Before | After |
|--------|--------|
| <img width="1464" height="960" alt="Screenshot 2026-05-27 at 5 18 44 PM" src="https://github.com/user-attachments/assets/14069d58-4cee-4f42-bc3c-74087d4e4b32" /> | <img width="1461" height="951" alt="Screenshot 2026-05-27 at 5 18 56 PM" src="https://github.com/user-attachments/assets/2e7590be-b036-4d8e-8990-371e2c8731e1" /> | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
