### PR TITLE
A4A > Tiers: fix locked-tier text contrast and non-link hover color

### DIFF
--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/style.scss
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/style.scss
@@ -1,6 +1,7 @@
 @import "@wordpress/base-styles/colors";
 
 :root {
+	--color-gray-100: #{$gray-100};
 	--color-gray-700: #{$gray-700};
 }
 
@@ -15,9 +16,6 @@
 		div[role="row"]:not(.is-selected) {
 			&, &:hover {
 				background-color: $white;
-				.dataviews-view-list__fields {
-					color: $gray-700;
-				}
 			}
 		}
 	}
@@ -33,14 +31,3 @@
 	}
 }
 
-.agency-tier-overview-revamped__icon-container {
-	align-items: center;
-	background: $gray-100;
-	display: flex;
-	height: 100%;
-	justify-content: center;
-
-	svg {
-		fill: $gray-700;
-	}
-}

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-benefits.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-benefits.tsx
@@ -26,6 +26,10 @@ import type { ComponentProps } from 'react';
 
 import './style.scss';
 
+// Local view-model: pairs each Benefit with the per-tier UI state that the
+// DataViews field renderers need access to via `item`.
+type BenefitItem = Benefit & { isLocked: boolean };
+
 export default function TierBenefits( {
 	currentAgencyTierId,
 }: {
@@ -73,14 +77,22 @@ export default function TierBenefits( {
 	// Combine all tiers in the desired order
 	const allTiersToShow = [ currentTier, ...lowerTiers, ...higherTiers ];
 
-	const fields: Field< Benefit >[] = [
+	const fields: Field< BenefitItem >[] = [
 		{
 			id: 'icon',
 			render: ( { item } ) =>
 				item.icon ? (
-					<div className="agency-tier-overview-revamped__icon-container">
-						<Icon icon={ item.icon } size={ 32 } />
-					</div>
+					<HStack
+						alignment="center"
+						justify="center"
+						style={ {
+							background: 'var(--color-gray-100)',
+							height: '100%',
+							opacity: item.isLocked ? 0.5 : undefined,
+						} }
+					>
+						<Icon icon={ item.icon } size={ 32 } fill="var(--color-gray-700)" />
+					</HStack>
 				) : null,
 		},
 		{
@@ -89,7 +101,9 @@ export default function TierBenefits( {
 			render: ( { item } ) => {
 				return (
 					<HStack spacing={ 2 } style={ { justifyContent: 'flex-start' } }>
-						<Text weight={ 500 }>{ item.title }</Text>
+						<Text weight={ 500 } variant={ item.isLocked ? 'muted' : undefined }>
+							{ item.title }
+						</Text>
 						{ item.status && <Badge intent="default" children={ item.status } /> }
 					</HStack>
 				);
@@ -98,12 +112,20 @@ export default function TierBenefits( {
 		{
 			id: 'description',
 			getValue: ( { item } ) => item.description,
+			render: ( { item } ) => {
+				return (
+					<Text size={ 12 } variant="muted">
+						{ item.description }
+					</Text>
+				);
+			},
 		},
 		{
 			id: 'actions',
 			getValue: ( { item } ) => item.actions,
 			render: ( { item } ) => {
-				if ( ! item.actions ) {
+				// Locked (higher) tiers don't expose actions yet.
+				if ( item.isLocked || ! item.actions ) {
 					return null;
 				}
 				const buttons = item.actions.map( ( action ) => {
@@ -210,16 +232,13 @@ export default function TierBenefits( {
 						<CardHeader isBorderless>
 							<SectionHeader title={ tierHeading } level={ 3 } />
 						</CardHeader>
-						<CardBody style={ { padding: '0', opacity: isHigherTier ? 0.5 : 1 } }>
-							<DataViews< Benefit >
-								data={ tier.benefits as Benefit[] }
-								fields={ fields.map( ( field ) => {
-									// Remove actions from higher tiers as they are not available yet
-									if ( isHigherTier && field.id === 'actions' ) {
-										return { ...field, render: () => null };
-									}
-									return field;
-								} ) }
+						<CardBody style={ { padding: '0' } }>
+							<DataViews< BenefitItem >
+								data={ tier.benefits.map( ( benefit ) => ( {
+									...benefit,
+									isLocked: isHigherTier,
+								} ) ) }
+								fields={ fields }
 								view={ view }
 								onChangeView={ () => {} }
 								getItemId={ ( item ) => item.title }


### PR DESCRIPTION
Resolves A4A-2620
Resolves A4A-2619

## Proposed Changes

* **A4A-2620 (locked-tier text contrast):** Drop `opacity: 0.5` from the entire locked-tier `CardBody`. Move the muting to the decorative icon container (inline `opacity` on the wrapping `HStack`) and add `variant="muted"` to the title `Text`. Body text now renders at full contrast.
* **A4A-2619 (hover color on non-link text):** Render the title and description through `Text` with explicit `variant`s so they no longer pick up the DataViews row hover color. Drop the now-unnecessary `.dataviews-view-list__fields` color override.
* Thread `isLocked` through DataViews items via a local `BenefitItem` view-model, so per-tier UI state flows through `item` instead of a `fields.map` swap. Action visibility for locked tiers is now an inline check inside the actions renderer.

## Why are these changes being made?

`#757575` on white sits at ~4.66:1 — right on the WCAG AA threshold. Applying `opacity: 0.5` to the whole card body pushed the effective contrast to ~1.9:1, well below AA. Because opacity is uniform, opacity alone can't restore AA at this base color (it would need ≥99% to hit 4.5:1). The right fix is to mute only the decorative parts and keep text at full contrast.

The hover bug came from DataViews applying a link-style color to row text on hover. The existing CSS hack overrode field colors but missed the title field, so titles flashed blue on hover even though they aren't clickable.

## Testing Instructions

1. Run Calypso locally and sign in as an agency that has at least one *higher* tier than current (so a locked tier card is visible).
2. Navigate to **Agency tier** overview.
3. **Hover** over a benefit row in any tier card — confirm the title and description text no longer change color (no blue link-style hover).
4. Scroll to a locked higher-tier card — confirm:
   - The decorative icon is muted (50% opacity), but the title and description text are fully readable.
   - The card no longer shows action buttons (existing behavior, now driven by `item.isLocked`).
   - The "What you'll unlock when you become a X" heading is unchanged.
5. Verify the current-tier and lower-tier cards are visually unchanged.
6. Quick contrast check on the locked card text using browser dev tools — should report ≥4.5:1 against the white background.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?