### PR TITLE
Dashboard: cover InaccessibleJetpackNotice error edge cases

### DIFF
--- a/client/dashboard/sites/site/test/notices.test.tsx
+++ b/client/dashboard/sites/site/test/notices.test.tsx
@@ -36,4 +36,20 @@ describe( '<InaccessibleJetpackNotice>', () => {
 			expect( scope.isDone() ).toBe( true );
 		} );
 	} );
+
+	test( 'renders the notice title when the error has no message', () => {
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
+
+		render( <InaccessibleJetpackNotice error={ new Error() } /> );
+
+		expect( screen.getByText( 'Your Jetpack site cannot be reached at this time.' ) ).toBeVisible();
+	} );
+
+	test( 'renders the notice title when the error has no message property', () => {
+		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
+
+		render( <InaccessibleJetpackNotice error={ {} as Error } /> );
+
+		expect( screen.getByText( 'Your Jetpack site cannot be reached at this time.' ) ).toBeVisible();
+	} );
 } );

--- a/client/dashboard/sites/site/test/notices.test.tsx
+++ b/client/dashboard/sites/site/test/notices.test.tsx
@@ -44,12 +44,4 @@ describe( '<InaccessibleJetpackNotice>', () => {
 
 		expect( screen.getByText( 'Your Jetpack site cannot be reached at this time.' ) ).toBeVisible();
 	} );
-
-	test( 'renders the notice title when the error has no message property', () => {
-		nock( 'https://public-api.wordpress.com' ).post( '/rest/v1.1/logstash' ).reply( 200 );
-
-		render( <InaccessibleJetpackNotice error={ {} as Error } /> );
-
-		expect( screen.getByText( 'Your Jetpack site cannot be reached at this time.' ) ).toBeVisible();
-	} );
 } );


### PR DESCRIPTION
Part of DOTMSD-1229

## Proposed Changes

* Add two tests in `client/dashboard/sites/site/test/notices.test.tsx` for `InaccessibleJetpackNotice`: error with no `.message`, and error object missing `.message` entirely. Both assert the notice title still renders.

## Why are these changes being made?

Existing coverage was happy-path only; the notice could silently drop a malformed error and tests would still pass. These cases lock in the title fallback.

## Testing Instructions

* `yarn test-client client/dashboard/sites/site/test/notices.test.tsx`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?