### PR TITLE
Add sidebar customizer autosave parity

### DIFF
--- a/client/my-sites/sidebar/customize/customize-mode.scss
+++ b/client/my-sites/sidebar/customize/customize-mode.scss
@@ -91,7 +91,7 @@ body.is-admin-sidebar-customize-mode {
 		> .sidebar__menu.is-togglable > li > .sidebar__heading:hover,
 		> .sidebar__menu.is-togglable > li > .sidebar__heading:focus {
 			background-color: transparent;
-			color: var(--color-sidebar-text);
+			color: var( --color-sidebar-text );
 			box-shadow: none;
 		}
 
@@ -104,8 +104,8 @@ body.is-admin-sidebar-customize-mode {
 		&.selected > .sidebar__menu-link .sidebar__menu-icon,
 		> .sidebar__menu.is-togglable > li > .sidebar__heading:hover .sidebar__menu-icon,
 		> .sidebar__menu.is-togglable > li > .sidebar__heading:focus .sidebar__menu-icon {
-			fill: var(--color-sidebar-text);
-			color: var(--color-sidebar-text);
+			fill: var( --color-sidebar-text );
+			color: var( --color-sidebar-text );
 		}
 	}
 
@@ -119,7 +119,10 @@ body.is-admin-sidebar-customize-mode {
 	// but leaves the LI itself hit-testable for drag-drop's
 	// `elementsFromPoint` lookup (so plugins can be dragged to between any
 	// sidebar rows, not just within the My Plugins group).
-	.sidebar li.sidebar__menu-item-parent:not([data-wp-admin-sidebar-item-id]):not(.wp-admin-sidebar-group) {
+	.sidebar
+		li.sidebar__menu-item-parent:not( [data-wp-admin-sidebar-item-id] ):not(
+			.wp-admin-sidebar-group
+		) {
 		&,
 		&:hover,
 		&.selected {
@@ -138,7 +141,7 @@ body.is-admin-sidebar-customize-mode {
 		&.selected .sidebar__menu-link:hover,
 		.sidebar__menu-link:focus {
 			background-color: transparent !important;
-			color: var(--color-sidebar-text) !important;
+			color: var( --color-sidebar-text ) !important;
 			box-shadow: none !important;
 		}
 
@@ -149,8 +152,8 @@ body.is-admin-sidebar-customize-mode {
 		// Icon stays at idle color too.
 		&:hover .sidebar__menu-link .sidebar__menu-icon,
 		&.selected .sidebar__menu-link .sidebar__menu-icon {
-			fill: var(--color-sidebar-text) !important;
-			color: var(--color-sidebar-text) !important;
+			fill: var( --color-sidebar-text ) !important;
+			color: var( --color-sidebar-text ) !important;
 		}
 	}
 
@@ -172,7 +175,7 @@ body.is-admin-sidebar-customize-mode {
 	// `<MySitesSidebarUnifiedMenu>` → `<ExpandableSidebarMenu>` renders a bare
 	// `<li>` wrapping `.sidebar__menu.is-togglable`, which the inert rule above
 	// doesn't catch. Same suppression treatment + kill the hover-intent flyout.
-	.sidebar > li:not([data-wp-admin-sidebar-item-id]) .sidebar__menu.is-togglable {
+	.sidebar > li:not( [data-wp-admin-sidebar-item-id] ) .sidebar__menu.is-togglable {
 		.sidebar__menu-link,
 		.sidebar__heading {
 			pointer-events: none;
@@ -185,7 +188,7 @@ body.is-admin-sidebar-customize-mode {
 		&.sidebar__menu--selected .sidebar__heading,
 		.sidebar__heading:hover {
 			background-color: transparent !important;
-			color: var(--color-sidebar-text) !important;
+			color: var( --color-sidebar-text ) !important;
 			box-shadow: none !important;
 		}
 		&.hovered .sidebar__heading::after,
@@ -214,7 +217,7 @@ body.is-admin-sidebar-customize-mode {
 		.sidebar .selected .sidebar__menu-link,
 		.sidebar .selected .sidebar__menu-link:hover {
 			background-color: transparent !important;
-			color: var(--color-sidebar-text) !important;
+			color: var( --color-sidebar-text ) !important;
 			box-shadow: none !important;
 		}
 		// LI-level paint suppression. Some Calypso rules paint `.selected`
@@ -230,12 +233,12 @@ body.is-admin-sidebar-customize-mode {
 		// the indicator becomes invisible because this selector has higher
 		// specificity than `li.admin-sidebar-drop-indicator` even when both
 		// rules are `!important`.
-		.sidebar > li:not(.admin-sidebar-drop-indicator),
-		.sidebar > li.selected:not(.admin-sidebar-drop-indicator),
-		.sidebar > li:hover:not(.admin-sidebar-drop-indicator),
-		.sidebar .sidebar__menu-item-parent:not(.admin-sidebar-drop-indicator),
-		.sidebar .sidebar__menu-item-parent.selected:not(.admin-sidebar-drop-indicator),
-		.sidebar .sidebar__menu-item-parent:hover:not(.admin-sidebar-drop-indicator) {
+		.sidebar > li:not( .admin-sidebar-drop-indicator ),
+		.sidebar > li.selected:not( .admin-sidebar-drop-indicator ),
+		.sidebar > li:hover:not( .admin-sidebar-drop-indicator ),
+		.sidebar .sidebar__menu-item-parent:not( .admin-sidebar-drop-indicator ),
+		.sidebar .sidebar__menu-item-parent.selected:not( .admin-sidebar-drop-indicator ),
+		.sidebar .sidebar__menu-item-parent:hover:not( .admin-sidebar-drop-indicator ) {
 			background-color: transparent !important;
 		}
 		// Reassignable rows keep their static gray bg under the transparent
@@ -254,7 +257,7 @@ body.is-admin-sidebar-customize-mode {
 		.sidebar .sidebar__menu.is-togglable .sidebar__heading,
 		.sidebar .sidebar__menu.is-togglable .sidebar__heading:hover {
 			background-color: transparent !important;
-			color: var(--color-sidebar-text) !important;
+			color: var( --color-sidebar-text ) !important;
 		}
 	}
 
@@ -286,10 +289,10 @@ body.is-admin-sidebar-customize-mode {
 	align-items: center;
 	padding: 0;
 	background: #2c3439;
-	color: var(--color-sidebar-text, #f0f0f1);
+	color: var( --color-sidebar-text, #f0f0f1 );
 	border-radius: 4px;
 	opacity: 0.95;
-	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+	box-shadow: 0 4px 12px rgba( 0, 0, 0, 0.4 );
 
 	a {
 		flex: 1 1 auto;
@@ -315,24 +318,31 @@ li.admin-sidebar-drop-indicator {
 	padding: 0;
 	height: 2px;
 	width: 100%;
-	background: var(--wp-admin-sidebar-customizer-theme, #2271b1) !important;
+	background: var( --wp-admin-sidebar-customizer-theme, #2271b1 ) !important;
 	pointer-events: none;
 }
 
-// Customize-mode footer (Phase 2 row 23). Docked at the bottom of the
-// sidebar surface with Save/Cancel stacked.
+// Customize-mode footer. Docked at the bottom of the sidebar surface with
+// auto-save status plus compact controls.
 .admin-sidebar-customize-footer {
 	display: flex;
 	flex-direction: column;
 	gap: 6px;
 	padding: 8px 12px;
-	background: var(--color-sidebar-background);
-	border-top: 1px solid rgba(240, 240, 241, 0.1);
-	box-shadow: 0 -8px 12px -8px rgba(0, 0, 0, 0.5);
+	background: var( --color-sidebar-background );
+	border-top: 1px solid rgba( 240, 240, 241, 0.1 );
+	box-shadow: 0 -8px 12px -8px rgba( 0, 0, 0, 0.5 );
 	margin-top: auto;
 
-	&__cancel,
-	&__save {
+	&__status {
+		color: rgba( 240, 240, 241, 0.75 );
+		font-size: 12px;
+		line-height: 1.4;
+	}
+
+	&__undo,
+	&__retry,
+	&__done {
 		flex: 0 0 auto;
 		padding: 6px 12px;
 		border-radius: 3px;
@@ -340,26 +350,24 @@ li.admin-sidebar-drop-indicator {
 		cursor: pointer;
 	}
 
-	&__cancel {
+	&__undo,
+	&__retry {
 		background: transparent;
-		border: 1px solid var(--wp-admin-sidebar-customizer-theme, #2271b1);
-		color: var(--wp-admin-sidebar-customizer-theme, #2271b1);
+		border: 1px solid var( --wp-admin-sidebar-customizer-theme, #2271b1 );
+		color: var( --wp-admin-sidebar-customizer-theme, #2271b1 );
 	}
 
-	&__save {
-		background: var(--wp-admin-sidebar-customizer-theme, #2271b1);
-		border: 1px solid var(--wp-admin-sidebar-customizer-theme, #2271b1);
+	&__done {
+		background: var( --wp-admin-sidebar-customizer-theme, #2271b1 );
+		border: 1px solid var( --wp-admin-sidebar-customizer-theme, #2271b1 );
 		color: #fff;
-
-		&[disabled] {
-			opacity: 0.55;
-			cursor: not-allowed;
-		}
 	}
 
-	&__error {
-		font-size: 12px;
-		color: var(--color-error, #d63638);
+	&__undo[disabled],
+	&__retry[disabled],
+	&__done[disabled] {
+		opacity: 0.55;
+		cursor: not-allowed;
 	}
 }
 
@@ -379,7 +387,7 @@ li.admin-sidebar-drop-indicator {
 	line-height: 1;
 
 	&:focus-visible {
-		outline: 2px solid var(--wp-admin-sidebar-customizer-theme, #2271b1);
+		outline: 2px solid var( --wp-admin-sidebar-customizer-theme, #2271b1 );
 		outline-offset: -2px;
 	}
 }
@@ -411,7 +419,7 @@ li.admin-sidebar-drop-indicator {
 	border: 0;
 
 	&:focus-visible {
-		outline: 2px solid var(--wp-admin-sidebar-customizer-theme, #2271b1);
+		outline: 2px solid var( --wp-admin-sidebar-customizer-theme, #2271b1 );
 		outline-offset: -2px;
 	}
 }
@@ -424,10 +432,10 @@ li.admin-sidebar-drop-indicator {
 	padding: 4px 0;
 	list-style: none;
 	background: #1d2327;
-	border: 1px solid rgba(240, 240, 241, 0.15);
+	border: 1px solid rgba( 240, 240, 241, 0.15 );
 	border-radius: 4px;
 	min-width: 180px;
-	box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+	box-shadow: 0 6px 20px rgba( 0, 0, 0, 0.4 );
 
 	li {
 		margin: 0;

--- a/client/my-sites/sidebar/customize/draft-state.ts
+++ b/client/my-sites/sidebar/customize/draft-state.ts
@@ -111,6 +111,38 @@ export function recomputeDirty( state: CustomizerDraftState ): CustomizerDraftSt
 }
 
 /**
+ * Replace the saved delta after an auto-save response without changing the
+ * current working delta. If another move happened while the request was in
+ * flight, the working copy stays ahead and remains dirty.
+ */
+export function updateSaved(
+	state: CustomizerDraftState,
+	saved: LayoutDelta
+): CustomizerDraftState {
+	const cloned = cloneDelta( saved );
+	return recomputeDirty( {
+		...state,
+		savedDelta: cloned,
+		isSaving: false,
+		saveError: null,
+	} );
+}
+
+/**
+ * Restore the working delta to a previous snapshot, used by Undo.
+ */
+export function restoreWorking(
+	state: CustomizerDraftState,
+	working: LayoutDelta
+): CustomizerDraftState {
+	return recomputeDirty( {
+		...state,
+		workingDelta: cloneDelta( working ),
+		saveError: null,
+	} );
+}
+
+/**
  * Move an item to a new position. Removes any prior override for the same
  * itemId, then appends the new one. The renderer applies overrides in array
  * order so later overrides win when duplicates ever sneak in.
@@ -167,6 +199,7 @@ export function cancel( state: CustomizerDraftState ): CustomizerDraftState {
 		...state,
 		workingDelta: cloneDelta( state.savedDelta ),
 		isDirty: false,
+		isSaving: false,
 		saveError: null,
 	};
 }

--- a/client/my-sites/sidebar/customize/drag-drop.ts
+++ b/client/my-sites/sidebar/customize/drag-drop.ts
@@ -34,6 +34,7 @@
 import { translate } from 'i18n-calypso';
 import { layoutIndexOf, layoutRowsForContainer } from './dom-layout';
 import { BODY_DRAGGING_CLASS } from './index';
+import type { CommitMoveDetails } from './index';
 import type { LayoutPosition } from 'calypso/state/admin-sidebar/layout/types';
 
 const GHOST_CLASS = 'admin-sidebar-drag-ghost';
@@ -53,7 +54,7 @@ const DROP_NEIGHBOUR_SELECTOR =
 	'li[data-wp-admin-sidebar-item-id], li.sidebar__menu-item-parent, li.wp-admin-sidebar-group, .sidebar > li, .wp-admin-sidebar-group__children > li';
 
 export interface DragDropController {
-	commitMove: ( itemId: string, position: LayoutPosition ) => void;
+	commitMove: ( itemId: string, position: LayoutPosition, details?: CommitMoveDetails ) => boolean;
 	beginDrag: ( itemId: string, sourcePosition: LayoutPosition ) => void;
 	endDrag: () => void;
 	announce: ( msg: string ) => void;
@@ -148,17 +149,22 @@ export function attachDragDrop( controller: DragDropController ): () => void {
 			return;
 		}
 		if ( lastTarget && lastTarget.position && lastTarget.container ) {
-			controller.commitMove( activeItem.itemId, lastTarget.position );
-			const label = ( activeItem.li.textContent || activeItem.itemId ).trim();
-			const indexLabel = lastTarget.position.index + 1;
-			controller.announce(
-				translate( 'Moved %(label)s to position %(index)d.', {
-					args: {
-						label,
-						index: indexLabel,
-					},
-				} ) as string
-			);
+			const label = labelForElement( activeItem.li, activeItem.itemId );
+			const moved = controller.commitMove( activeItem.itemId, lastTarget.position, {
+				previousPosition: activeItem.sourcePosition,
+				label,
+			} );
+			if ( moved ) {
+				const indexLabel = lastTarget.position.index + 1;
+				controller.announce(
+					translate( 'Moved %(label)s to position %(index)d.', {
+						args: {
+							label,
+							index: indexLabel,
+						},
+					} ) as string
+				);
+			}
 		}
 		cleanup();
 	}
@@ -365,4 +371,18 @@ export function positionForElement( li: HTMLElement ): LayoutPosition {
 		};
 	}
 	return { kind: 'top_level', index: siblings };
+}
+
+export function labelForElement( li: HTMLElement, fallback: string ): string {
+	const link = li.querySelector( ':scope > a, :scope a' );
+	if ( ! link ) {
+		return ( li.textContent || fallback ).trim();
+	}
+	const cloned = link.cloneNode( true ) as HTMLElement;
+	cloned
+		.querySelectorAll(
+			'.admin-sidebar-item__grip, .admin-sidebar-item__more, .wp-submenu, .wp-submenu-wrap'
+		)
+		.forEach( ( el ) => el.remove() );
+	return ( cloned.textContent || fallback ).trim();
 }

--- a/client/my-sites/sidebar/customize/footer.tsx
+++ b/client/my-sites/sidebar/customize/footer.tsx
@@ -1,17 +1,13 @@
 /**
- * Customize-mode footer with Save / Cancel buttons.
+ * Customize-mode footer with auto-save status, Undo, Retry, and Done.
  *
  * Mirrors `renderFooter` + `updateFooter` in the public plugin's
- * `customizer/customizer.js` v0.1.4 — same disabled-until-dirty rule, same
- * "Saving…" text while the POST is in flight, same Cancel-confirms-on-dirty
- * behaviour.
- *
- * Identical-behaviour anchor: Phase 2 row 23 (footer Save/Cancel).
- * @see WordPress/wp-admin-sidebar v0.1.4 src/customizer/customizer.js#renderFooter
+ * `customizer/customizer.js` v0.1.10.
  */
 
 import { translate } from 'i18n-calypso';
 import { useCustomizeContext } from './index';
+import type { CustomizerDraftState } from './draft-state';
 
 const FOOTER_CLASS = 'admin-sidebar-customize-footer';
 
@@ -20,36 +16,61 @@ export function CustomizeFooter() {
 	if ( ! ctx || ! ctx.isCustomizing ) {
 		return null;
 	}
-	const { draft, exit, save } = ctx;
-	const saveDisabled = ! draft.isDirty || draft.isSaving;
-	const saveLabel = draft.isSaving ? translate( 'Saving…' ) : translate( 'Save' );
+	const { draft, exit, undo, retry, canUndo, hasPendingSave, lastSavedAt } = ctx;
+	const status = getStatusText( draft, hasPendingSave, lastSavedAt );
 
 	return (
 		<div className={ FOOTER_CLASS }>
+			<div className={ `${ FOOTER_CLASS }__status` } role="status" aria-live="polite">
+				{ status }
+			</div>
 			<button
 				type="button"
-				className={ `${ FOOTER_CLASS }__cancel` }
+				className={ `${ FOOTER_CLASS }__undo` }
+				disabled={ ! canUndo }
+				onClick={ undo }
+			>
+				{ translate( 'Undo' ) }
+			</button>
+			<button
+				type="button"
+				className={ `${ FOOTER_CLASS }__retry` }
+				hidden={ ! draft.saveError }
+				disabled={ draft.isSaving }
+				onClick={ retry }
+			>
+				{ translate( 'Retry' ) }
+			</button>
+			<button
+				type="button"
+				className={ `${ FOOTER_CLASS }__done` }
+				disabled={ draft.isSaving || hasPendingSave }
 				onClick={ () => exit( { confirmIfDirty: true } ) }
 			>
-				{ translate( 'Cancel' ) }
+				{ translate( 'Done' ) }
 			</button>
-			<button
-				type="button"
-				className={ `${ FOOTER_CLASS }__save` }
-				disabled={ saveDisabled }
-				onClick={ () => {
-					void save();
-				} }
-			>
-				{ saveLabel }
-			</button>
-			{ draft.saveError && (
-				<div className={ `${ FOOTER_CLASS }__error` } role="alert">
-					{ draft.saveError.message }
-				</div>
-			) }
 		</div>
 	);
 }
 
 export default CustomizeFooter;
+
+function getStatusText(
+	draft: CustomizerDraftState,
+	hasPendingSave: boolean,
+	lastSavedAt: number
+) {
+	if ( draft.saveError ) {
+		return draft.saveError.message;
+	}
+	if ( draft.isSaving || hasPendingSave ) {
+		return translate( 'Saving…' );
+	}
+	if ( draft.isDirty ) {
+		return translate( 'Unsaved changes.' );
+	}
+	if ( lastSavedAt ) {
+		return translate( 'Saved.' );
+	}
+	return translate( 'Changes save automatically.' );
+}

--- a/client/my-sites/sidebar/customize/index.tsx
+++ b/client/my-sites/sidebar/customize/index.tsx
@@ -46,11 +46,15 @@ import {
 	applySaved,
 	beginDrag as beginDragState,
 	cancel,
+	cloneDelta,
 	createDraftState,
+	deltasEqual,
 	endDrag as endDragState,
 	moveItem,
 	resetItem,
+	restoreWorking,
 	type CustomizerDraftState,
+	updateSaved,
 } from './draft-state';
 import { attachDragDrop } from './drag-drop';
 import { attachKeyboardReorder } from './keyboard-reorder';
@@ -64,6 +68,20 @@ import type { ReactNode } from 'react';
 
 export const BODY_CUSTOMIZE_CLASS = 'is-admin-sidebar-customize-mode';
 export const BODY_DRAGGING_CLASS = 'is-admin-sidebar-dragging';
+const MAX_UNDO_STACK = 10;
+
+export interface CommitMoveDetails {
+	previousPosition?: LayoutPosition;
+	nextPosition?: LayoutPosition;
+	label?: string;
+}
+
+interface UndoFrame {
+	itemId: string;
+	previousPosition: LayoutPosition;
+	previousDelta: LayoutDelta;
+	label: string;
+}
 
 type Action =
 	| { type: 'set'; state: CustomizerDraftState }
@@ -106,11 +124,15 @@ export interface CustomizeController {
 	draft: CustomizerDraftState;
 	enter: () => void;
 	exit: ( options?: { confirmIfDirty?: boolean } ) => void;
-	commitMove: ( itemId: string, position: LayoutPosition ) => void;
-	resetItem: ( itemId: string ) => void;
+	commitMove: ( itemId: string, position: LayoutPosition, details?: CommitMoveDetails ) => boolean;
+	resetItem: ( itemId: string, details?: CommitMoveDetails ) => boolean;
 	beginDrag: ( itemId: string, sourcePosition: LayoutPosition ) => void;
 	endDrag: () => void;
-	save: () => Promise< void >;
+	undo: () => void;
+	retry: () => void;
+	canUndo: boolean;
+	hasPendingSave: boolean;
+	lastSavedAt: number;
 	announce: ( msg: string ) => void;
 }
 
@@ -150,18 +172,40 @@ function useLiveRegion(): {
 	return { liveRef, announce };
 }
 
+function positionsEqual( a?: LayoutPosition, b?: LayoutPosition ): boolean {
+	if ( ! a || ! b || a.kind !== b.kind || a.index !== b.index ) {
+		return false;
+	}
+	if ( a.kind === 'in_group' ) {
+		return b.kind === 'in_group' && a.group_id === b.group_id;
+	}
+	return true;
+}
+
+function clonePosition( position: LayoutPosition ): LayoutPosition {
+	return { ...position };
+}
+
+function errorMessage( err: unknown ): string {
+	return err && typeof err === 'object' && 'message' in err && typeof err.message === 'string'
+		? err.message
+		: ( translate( 'Save failed.' ) as string );
+}
+
 /**
  * Provider wraps the sidebar surface and exposes the controller via context.
  *
- * Owns: working-delta reducer, body-class toggling, beforeunload prompt,
- * Save dispatch.
+ * Owns: working-delta reducer, body-class toggling, autosave queue,
+ * and beforeunload prompt.
  */
 export function CustomizeProvider( {
 	children,
 	enableCustomize = true,
+	saveLayoutImpl = saveLayout,
 }: {
 	children: ReactNode;
 	enableCustomize?: boolean;
+	saveLayoutImpl?: typeof saveLayout;
 } ) {
 	const reduxDispatch = useReduxDispatch();
 	const siteId = useSelector( getSelectedSiteId );
@@ -170,84 +214,250 @@ export function CustomizeProvider( {
 	);
 	const [ isCustomizing, setCustomizing ] = useState( false );
 	const [ draft, dispatch ] = useReducer( reducer, savedDelta, createDraftState );
+	const [ undoStack, setUndoStack ] = useState< UndoFrame[] >( [] );
+	const [ hasPendingSave, setHasPendingSave ] = useState( false );
+	const [ lastSavedAt, setLastSavedAt ] = useState( 0 );
 	const { liveRef, announce } = useLiveRegion();
 
 	// Keep a ref to the latest draft so async paths (save resolution after
 	// cancel-mid-fetch) can null-check without stale closures.
 	const draftRef = useRef( draft );
+	const undoStackRef = useRef< UndoFrame[] >( [] );
+	const pendingSaveDeltaRef = useRef< LayoutDelta | null >( null );
+	const savePromiseRef = useRef< Promise< void > | null >( null );
+	const sessionIdRef = useRef( 0 );
 	useEffect( () => {
 		draftRef.current = draft;
 	}, [ draft ] );
+
+	const setDraftState = useCallback( ( next: CustomizerDraftState ) => {
+		draftRef.current = next;
+		dispatch( { type: 'set', state: next } );
+	}, [] );
+
+	const setUndoFrames = useCallback( ( next: UndoFrame[] ) => {
+		undoStackRef.current = next;
+		setUndoStack( next );
+	}, [] );
+
+	const hasUnsavedChanges = useCallback(
+		() =>
+			!! (
+				draftRef.current.isDirty ||
+				draftRef.current.isSaving ||
+				pendingSaveDeltaRef.current ||
+				draftRef.current.saveError
+			),
+		[]
+	);
+
+	const resetSessionMeta = useCallback( () => {
+		pendingSaveDeltaRef.current = null;
+		savePromiseRef.current = null;
+		setHasPendingSave( false );
+		setUndoFrames( [] );
+		setLastSavedAt( 0 );
+	}, [ setUndoFrames ] );
+
+	const runAutosaveQueue = useCallback(
+		async ( sessionId: number ) => {
+			while ( sessionIdRef.current === sessionId && pendingSaveDeltaRef.current ) {
+				const delta = pendingSaveDeltaRef.current;
+				pendingSaveDeltaRef.current = null;
+				setHasPendingSave( false );
+				try {
+					if ( ! siteId ) {
+						throw new Error( translate( 'Unable to save sidebar layout.' ) as string );
+					}
+					const persisted = await saveLayoutImpl( reduxDispatch, {
+						siteId,
+						delta,
+					} );
+					if ( sessionIdRef.current !== sessionId ) {
+						return;
+					}
+					const next = updateSaved( draftRef.current, persisted );
+					setDraftState( next );
+					setLastSavedAt( Date.now() );
+					if ( pendingSaveDeltaRef.current ) {
+						setDraftState( { ...draftRef.current, isSaving: true, saveError: null } );
+					}
+				} catch ( err ) {
+					if ( sessionIdRef.current !== sessionId ) {
+						return;
+					}
+					if ( pendingSaveDeltaRef.current ) {
+						setDraftState( { ...draftRef.current, isSaving: true, saveError: null } );
+						continue;
+					}
+					const message = errorMessage( err );
+					setDraftState( {
+						...draftRef.current,
+						isSaving: false,
+						saveError: { code: 'save_failed', message },
+					} );
+					announce( message );
+					return;
+				}
+			}
+			if ( sessionIdRef.current === sessionId ) {
+				setDraftState( { ...draftRef.current, isSaving: false } );
+			}
+		},
+		[ announce, reduxDispatch, saveLayoutImpl, setDraftState, siteId ]
+	);
+
+	const scheduleAutosave = useCallback(
+		( delta = draftRef.current.workingDelta ) => {
+			if (
+				! draftRef.current.isDirty &&
+				! savePromiseRef.current &&
+				! draftRef.current.saveError
+			) {
+				return;
+			}
+			pendingSaveDeltaRef.current = cloneDelta( delta );
+			setHasPendingSave( true );
+			setDraftState( { ...draftRef.current, isSaving: true, saveError: null } );
+			const sessionId = sessionIdRef.current;
+			if ( ! savePromiseRef.current ) {
+				const promise = runAutosaveQueue( sessionId ).finally( () => {
+					if ( sessionIdRef.current === sessionId ) {
+						savePromiseRef.current = null;
+					}
+				} );
+				savePromiseRef.current = promise;
+			}
+		},
+		[ runAutosaveQueue, setDraftState ]
+	);
+
+	const exit = useCallback(
+		( options: { confirmIfDirty?: boolean } = {} ) => {
+			if ( options.confirmIfDirty && hasUnsavedChanges() ) {
+				if ( typeof window !== 'undefined' ) {
+					const message = draftRef.current.saveError
+						? ( translate(
+								'Some changes could not be saved. Exit and discard unsaved changes?'
+						  ) as string )
+						: ( translate( 'Exit and discard unsaved changes?' ) as string );
+					// eslint-disable-next-line no-alert
+					if ( ! window.confirm( message ) ) {
+						return;
+					}
+				}
+			}
+			sessionIdRef.current += 1;
+			pendingSaveDeltaRef.current = null;
+			savePromiseRef.current = null;
+			setHasPendingSave( false );
+			setUndoFrames( [] );
+			setDraftState( cancel( draftRef.current ) );
+			setCustomizing( false );
+			announce( translate( 'Customize mode exited.' ) as string );
+		},
+		[ announce, hasUnsavedChanges, setDraftState, setUndoFrames ]
+	);
 
 	const enter = useCallback( () => {
 		if ( ! enableCustomize ) {
 			return;
 		}
+		sessionIdRef.current += 1;
+		resetSessionMeta();
 		// Re-bootstrap from the latest saved delta so re-entering after a save
 		// sees the freshly-persisted state.
-		dispatch( { type: 'set', state: createDraftState( savedDelta ) } );
+		setDraftState( createDraftState( savedDelta ) );
 		setCustomizing( true );
 		announce( translate( 'Customize mode entered.' ) as string );
-	}, [ enableCustomize, savedDelta, announce ] );
+	}, [ announce, enableCustomize, resetSessionMeta, savedDelta, setDraftState ] );
 
-	const exit = useCallback(
-		( options: { confirmIfDirty?: boolean } = {} ) => {
-			if ( options.confirmIfDirty && draftRef.current.isDirty ) {
-				if ( typeof window !== 'undefined' ) {
-					// eslint-disable-next-line no-alert
-					if ( ! window.confirm( translate( 'Discard your unsaved changes?' ) as string ) ) {
-						return;
-					}
-				}
+	const commitWorkingChange = useCallback(
+		(
+			itemId: string,
+			details: CommitMoveDetails,
+			mutateState: ( state: CustomizerDraftState ) => CustomizerDraftState
+		) => {
+			if (
+				details.previousPosition &&
+				details.nextPosition &&
+				positionsEqual( details.previousPosition, details.nextPosition )
+			) {
+				return false;
 			}
-			dispatch( { type: 'cancel' } );
-			setCustomizing( false );
-			announce( translate( 'Customize mode exited.' ) as string );
+			const previousDelta = cloneDelta( draftRef.current.workingDelta );
+			const nextState = mutateState( draftRef.current );
+			if ( deltasEqual( previousDelta, nextState.workingDelta ) ) {
+				setDraftState( nextState );
+				return false;
+			}
+
+			setDraftState( nextState );
+			if ( details.previousPosition ) {
+				const nextStack = [
+					...undoStackRef.current,
+					{
+						itemId,
+						previousPosition: clonePosition( details.previousPosition ),
+						previousDelta,
+						label: details.label || itemId,
+					},
+				].slice( -MAX_UNDO_STACK );
+				setUndoFrames( nextStack );
+			}
+			scheduleAutosave( nextState.workingDelta );
+			return true;
 		},
-		[ announce ]
+		[ scheduleAutosave, setDraftState, setUndoFrames ]
 	);
 
-	const commitMove = useCallback( ( itemId: string, position: LayoutPosition ) => {
-		dispatch( { type: 'move', itemId, position } );
-	}, [] );
+	const commitMove = useCallback(
+		( itemId: string, position: LayoutPosition, details: CommitMoveDetails = {} ) =>
+			commitWorkingChange( itemId, { ...details, nextPosition: position }, ( state ) =>
+				moveItem( state, itemId, position )
+			),
+		[ commitWorkingChange ]
+	);
 
-	const resetItemHandler = useCallback( ( itemId: string ) => {
-		dispatch( { type: 'reset_item', itemId } );
-	}, [] );
+	const resetItemHandler = useCallback(
+		( itemId: string, details: CommitMoveDetails = {} ) =>
+			commitWorkingChange( itemId, details, ( state ) => resetItem( state, itemId ) ),
+		[ commitWorkingChange ]
+	);
 
-	const beginDrag = useCallback( ( itemId: string, sourcePosition: LayoutPosition ) => {
-		dispatch( { type: 'begin_drag', itemId, sourcePosition } );
-	}, [] );
+	const beginDrag = useCallback(
+		( itemId: string, sourcePosition: LayoutPosition ) => {
+			setDraftState( beginDragState( draftRef.current, itemId, sourcePosition ) );
+		},
+		[ setDraftState ]
+	);
 
 	const endDrag = useCallback( () => {
-		dispatch( { type: 'end_drag' } );
-	}, [] );
+		setDraftState( endDragState( draftRef.current ) );
+	}, [ setDraftState ] );
 
-	const save = useCallback( async () => {
-		if ( ! siteId ) {
+	const undo = useCallback( () => {
+		if ( draftRef.current.activeDrag || undoStackRef.current.length === 0 ) {
 			return;
 		}
-		dispatch( { type: 'set_saving', isSaving: true } );
-		try {
-			const persisted = await saveLayout( reduxDispatch, {
-				siteId,
-				delta: draftRef.current.workingDelta,
-			} );
-			dispatch( { type: 'apply_saved', saved: persisted } );
-			setCustomizing( false );
-			announce( translate( 'Sidebar saved.' ) as string );
-		} catch ( err ) {
-			const message =
-				err && typeof err === 'object' && 'message' in err && typeof err.message === 'string'
-					? err.message
-					: ( translate( 'Save failed.' ) as string );
-			dispatch( {
-				type: 'set_save_error',
-				error: { code: 'save_failed', message },
-			} );
-			announce( message );
+		const frame = undoStackRef.current[ undoStackRef.current.length - 1 ];
+		setUndoFrames( undoStackRef.current.slice( 0, -1 ) );
+		const nextState = restoreWorking( draftRef.current, frame.previousDelta );
+		setDraftState( nextState );
+		scheduleAutosave( nextState.workingDelta );
+		announce(
+			translate( 'Undid last change for %(label)s.', {
+				args: { label: frame.label },
+			} ) as string
+		);
+	}, [ announce, scheduleAutosave, setDraftState, setUndoFrames ] );
+
+	const retry = useCallback( () => {
+		if ( draftRef.current.isSaving ) {
+			return;
 		}
-	}, [ siteId, reduxDispatch, announce ] );
+		scheduleAutosave();
+	}, [ scheduleAutosave ] );
 
 	// Body class toggle (Phase 2 row 16).
 	useEffect( () => {
@@ -292,7 +502,7 @@ export function CustomizeProvider( {
 	// still show a generic confirmation when `preventDefault()` is called or
 	// `returnValue` is set.
 	useEffect( () => {
-		if ( ! isCustomizing || ! draft.isDirty ) {
+		if ( ! isCustomizing || ! hasUnsavedChanges() ) {
 			return;
 		}
 		const handler = ( ev: BeforeUnloadEvent ) => {
@@ -302,7 +512,32 @@ export function CustomizeProvider( {
 		};
 		window.addEventListener( 'beforeunload', handler );
 		return () => window.removeEventListener( 'beforeunload', handler );
-	}, [ isCustomizing, draft.isDirty ] );
+	}, [ isCustomizing, draft, hasPendingSave, hasUnsavedChanges ] );
+
+	useEffect( () => {
+		if ( ! isCustomizing ) {
+			return;
+		}
+		const handler = ( ev: KeyboardEvent ) => {
+			if ( ev.key !== 'Escape' || ev.defaultPrevented ) {
+				return;
+			}
+			if ( document.querySelector( '.admin-sidebar-move-menu' ) ) {
+				return;
+			}
+			if (
+				draftRef.current.activeDrag ||
+				draftRef.current.isSaving ||
+				pendingSaveDeltaRef.current
+			) {
+				return;
+			}
+			ev.preventDefault();
+			exit( { confirmIfDirty: true } );
+		};
+		document.addEventListener( 'keydown', handler );
+		return () => document.removeEventListener( 'keydown', handler );
+	}, [ exit, isCustomizing ] );
 
 	const controller = useMemo< CustomizeController >(
 		() => ( {
@@ -314,7 +549,11 @@ export function CustomizeProvider( {
 			resetItem: resetItemHandler,
 			beginDrag,
 			endDrag,
-			save,
+			undo,
+			retry,
+			canUndo: undoStack.length > 0 && ! draft.activeDrag,
+			hasPendingSave,
+			lastSavedAt,
 			announce,
 		} ),
 		[
@@ -326,7 +565,11 @@ export function CustomizeProvider( {
 			resetItemHandler,
 			beginDrag,
 			endDrag,
-			save,
+			undo,
+			retry,
+			undoStack,
+			hasPendingSave,
+			lastSavedAt,
 			announce,
 		]
 	);

--- a/client/my-sites/sidebar/customize/keyboard-reorder.ts
+++ b/client/my-sites/sidebar/customize/keyboard-reorder.ts
@@ -14,7 +14,7 @@
  */
 import { translate } from 'i18n-calypso';
 import { layoutIndexOf, layoutRowsForContainer } from './dom-layout';
-import type { DragDropController } from './drag-drop';
+import { labelForElement, positionForElement, type DragDropController } from './drag-drop';
 
 const REASSIGNABLE_SELECTOR = 'li[data-wp-admin-sidebar-item-id]';
 const GRIP_SELECTOR = '.admin-sidebar-item__grip';
@@ -64,6 +64,7 @@ export function attachKeyboardReorder( controller: DragDropController ): () => v
 		if ( ! itemId ) {
 			return;
 		}
+		const sourcePosition = positionForElement( li );
 
 		const enclosingGroup = container.closest( GROUP_SELECTOR );
 		const groupId = enclosingGroup ? enclosingGroup.getAttribute( 'data-group' ) : null;
@@ -72,18 +73,19 @@ export function attachKeyboardReorder( controller: DragDropController ): () => v
 			? { kind: 'in_group' as const, group_id: groupId, index: targetIndex }
 			: { kind: 'top_level' as const, index: targetIndex };
 
-		controller.commitMove( itemId, position );
 		const total = siblings.length;
-		const label = ( li.textContent || itemId ).trim();
-		controller.announce(
-			translate( 'Moved %(label)s to position %(index)d of %(total)d.', {
-				args: {
-					label,
-					index: target_idx + 1,
-					total,
-				},
-			} ) as string
-		);
+		const label = labelForElement( li, itemId );
+		if ( controller.commitMove( itemId, position, { previousPosition: sourcePosition, label } ) ) {
+			controller.announce(
+				translate( 'Moved %(label)s to position %(index)d of %(total)d.', {
+					args: {
+						label,
+						index: target_idx + 1,
+						total,
+					},
+				} ) as string
+			);
+		}
 	}
 
 	document.addEventListener( 'keydown', onKeyDown );

--- a/client/my-sites/sidebar/customize/move-menu.tsx
+++ b/client/my-sites/sidebar/customize/move-menu.tsx
@@ -60,20 +60,24 @@ export const MoveMenu = ( { itemId, itemLabel, triggerEl, onClose }: MoveMenuPro
 				return;
 			}
 			const target = rows[ targetIdx ];
+			const previousPosition = positionForElement( li );
 			const nextPosition = positionForMoveTarget( li, target, direction );
 			if ( ! nextPosition ) {
 				return;
 			}
-			customizeCtx.commitMove( itemId, nextPosition );
-			customizeCtx.announce(
-				translate( 'Moved %(label)s to position %(index)d of %(total)d.', {
-					args: {
-						label: itemLabel,
-						index: targetIdx + 1,
-						total: rows.length,
-					},
-				} ) as string
-			);
+			if (
+				customizeCtx.commitMove( itemId, nextPosition, { previousPosition, label: itemLabel } )
+			) {
+				customizeCtx.announce(
+					translate( 'Moved %(label)s to position %(index)d of %(total)d.', {
+						args: {
+							label: itemLabel,
+							index: targetIdx + 1,
+							total: rows.length,
+						},
+					} ) as string
+				);
+			}
 		},
 		[ itemId, itemLabel, customizeCtx ]
 	);
@@ -82,24 +86,45 @@ export const MoveMenu = ( { itemId, itemLabel, triggerEl, onClose }: MoveMenuPro
 		if ( ! customizeCtx ) {
 			return;
 		}
-		customizeCtx.resetItem( itemId );
-		customizeCtx.announce(
-			translate( 'Reset %(label)s to default position.', {
-				args: { label: itemLabel },
-			} ) as string
-		);
+		const li = document.querySelector( itemSelector( itemId ) ) as HTMLLIElement | null;
+		const previousPosition = li ? positionForElement( li ) : undefined;
+		if ( customizeCtx.resetItem( itemId, { previousPosition, label: itemLabel } ) ) {
+			customizeCtx.announce(
+				translate( 'Reset %(label)s to default position.', {
+					args: { label: itemLabel },
+				} ) as string
+			);
+		} else {
+			customizeCtx.announce(
+				translate( '%(label)s is already at the default position.', {
+					args: { label: itemLabel },
+				} ) as string
+			);
+		}
 	}, [ itemId, itemLabel, customizeCtx ] );
 
 	const moveToTopLevel = useCallback( () => {
 		if ( ! customizeCtx ) {
 			return;
 		}
-		customizeCtx.commitMove( itemId, { kind: 'top_level', index: 0 } );
-		customizeCtx.announce(
-			translate( 'Moved %(label)s to top level.', {
-				args: { label: itemLabel },
-			} ) as string
-		);
+		const li = document.querySelector( itemSelector( itemId ) ) as HTMLLIElement | null;
+		const previousPosition = li ? positionForElement( li ) : undefined;
+		if (
+			customizeCtx.commitMove(
+				itemId,
+				{ kind: 'top_level', index: 0 },
+				{
+					previousPosition,
+					label: itemLabel,
+				}
+			)
+		) {
+			customizeCtx.announce(
+				translate( 'Moved %(label)s to top level.', {
+					args: { label: itemLabel },
+				} ) as string
+			);
+		}
 	}, [ itemId, itemLabel, customizeCtx ] );
 
 	const choices: MenuChoice[] = [
@@ -174,6 +199,8 @@ export const MoveMenu = ( { itemId, itemLabel, triggerEl, onClose }: MoveMenuPro
 		};
 		const handleKey = ( ev: KeyboardEvent ) => {
 			if ( ev.key === 'Escape' ) {
+				ev.preventDefault();
+				ev.stopPropagation();
 				onClose();
 				triggerEl?.focus();
 			}
@@ -245,6 +272,20 @@ function escapeSelectorValue( value: string ): string {
 
 function itemSelector( itemId: string ): string {
 	return `li[data-wp-admin-sidebar-item-id="${ escapeSelectorValue( itemId ) }"]`;
+}
+
+function positionForElement( li: HTMLElement ): LayoutPosition {
+	const container = li.parentElement;
+	const groupContainer = container?.closest( 'li.wp-admin-sidebar-group' ) ?? null;
+	const index = container ? Math.max( 0, layoutIndexOf( container, li ) ) : 0;
+	if ( groupContainer ) {
+		return {
+			kind: 'in_group',
+			group_id: groupContainer.getAttribute( 'data-group' ) || '',
+			index,
+		};
+	}
+	return { kind: 'top_level', index };
 }
 
 function getMoveDestinations( itemId: string ): {

--- a/client/my-sites/sidebar/customize/test/draft-state.ts
+++ b/client/my-sites/sidebar/customize/test/draft-state.ts
@@ -10,6 +10,8 @@ import {
 	moveItem,
 	recomputeDirty,
 	resetItem,
+	restoreWorking,
+	updateSaved,
 } from '../draft-state';
 import type { LayoutDelta } from 'calypso/state/admin-sidebar/layout/types';
 
@@ -166,6 +168,30 @@ describe( 'customize draft-state', () => {
 			expect( next.workingDelta.overrides[ 0 ].itemId ).toBe( 'y' );
 			expect( next.isDirty ).toBe( false );
 			expect( next.isSaving ).toBe( false );
+			expect( next.saveError ).toBeNull();
+		} );
+	} );
+
+	describe( 'updateSaved / restoreWorking', () => {
+		it( 'updates the saved delta without clobbering newer working changes', () => {
+			const state = createDraftState( null );
+			const firstMove = moveItem( state, 'x', samplePosition );
+			const secondMove = moveItem( firstMove, 'y', { kind: 'top_level', index: 2 } );
+			const next = updateSaved( secondMove, firstMove.workingDelta );
+			expect( next.savedDelta.overrides ).toEqual( firstMove.workingDelta.overrides );
+			expect( next.workingDelta.overrides ).toEqual( secondMove.workingDelta.overrides );
+			expect( next.isDirty ).toBe( true );
+			expect( next.isSaving ).toBe( false );
+			expect( next.saveError ).toBeNull();
+		} );
+
+		it( 'restores the working delta for undo', () => {
+			const state = createDraftState( null );
+			const firstMove = moveItem( state, 'x', samplePosition );
+			const secondMove = moveItem( firstMove, 'y', { kind: 'top_level', index: 2 } );
+			const next = restoreWorking( secondMove, firstMove.workingDelta );
+			expect( next.workingDelta.overrides ).toEqual( firstMove.workingDelta.overrides );
+			expect( next.isDirty ).toBe( true );
 			expect( next.saveError ).toBeNull();
 		} );
 	} );

--- a/client/my-sites/sidebar/customize/test/drag-drop.ts
+++ b/client/my-sites/sidebar/customize/test/drag-drop.ts
@@ -209,11 +209,17 @@ describe( 'attachDragDrop', () => {
 		document.dispatchEvent( makePointerEvent( 'pointermove', 10, 130 ) );
 		document.dispatchEvent( makePointerEvent( 'pointerup', 10, 130 ) );
 
-		expect( controller.commitMove ).toHaveBeenCalledWith( 'stats', {
-			kind: 'in_group',
-			group_id: 'plugins',
-			index: 1,
-		} );
+		expect( controller.commitMove ).toHaveBeenCalledWith(
+			'stats',
+			{
+				kind: 'in_group',
+				group_id: 'plugins',
+				index: 1,
+			},
+			expect.objectContaining( {
+				previousPosition: expect.objectContaining( { kind: 'top_level' } ),
+			} )
+		);
 	} );
 
 	it( 'normalizes expandable inner rows before computing top-level slots', () => {
@@ -260,10 +266,16 @@ describe( 'attachDragDrop', () => {
 		document.dispatchEvent( makePointerEvent( 'pointermove', 10, 130 ) );
 		document.dispatchEvent( makePointerEvent( 'pointerup', 10, 130 ) );
 
-		expect( controller.commitMove ).toHaveBeenCalledWith( 'stats', {
-			kind: 'top_level',
-			index: 1,
-		} );
+		expect( controller.commitMove ).toHaveBeenCalledWith(
+			'stats',
+			{
+				kind: 'top_level',
+				index: 1,
+			},
+			expect.objectContaining( {
+				previousPosition: expect.objectContaining( { kind: 'top_level' } ),
+			} )
+		);
 	} );
 
 	it( 'normalizes expandable inner rows before computing group slots', () => {
@@ -316,11 +328,17 @@ describe( 'attachDragDrop', () => {
 		document.dispatchEvent( makePointerEvent( 'pointermove', 10, 130 ) );
 		document.dispatchEvent( makePointerEvent( 'pointerup', 10, 130 ) );
 
-		expect( controller.commitMove ).toHaveBeenCalledWith( 'stats', {
-			kind: 'in_group',
-			group_id: 'plugins',
-			index: 1,
-		} );
+		expect( controller.commitMove ).toHaveBeenCalledWith(
+			'stats',
+			{
+				kind: 'in_group',
+				group_id: 'plugins',
+				index: 1,
+			},
+			expect.objectContaining( {
+				previousPosition: expect.objectContaining( { kind: 'top_level' } ),
+			} )
+		);
 	} );
 
 	it( 'ignores Calypso chrome rows when computing a top-level drop slot', () => {
@@ -371,10 +389,16 @@ describe( 'attachDragDrop', () => {
 		document.dispatchEvent( makePointerEvent( 'pointermove', 10, 105 ) );
 		document.dispatchEvent( makePointerEvent( 'pointerup', 10, 105 ) );
 
-		expect( controller.commitMove ).toHaveBeenCalledWith( 'stats', {
-			kind: 'top_level',
-			index: 0,
-		} );
+		expect( controller.commitMove ).toHaveBeenCalledWith(
+			'stats',
+			{
+				kind: 'top_level',
+				index: 0,
+			},
+			expect.objectContaining( {
+				previousPosition: expect.objectContaining( { kind: 'top_level' } ),
+			} )
+		);
 	} );
 
 	it( 'drops into an expanded empty group from the group header', () => {
@@ -413,10 +437,16 @@ describe( 'attachDragDrop', () => {
 		document.dispatchEvent( makePointerEvent( 'pointermove', 10, 100 ) );
 		document.dispatchEvent( makePointerEvent( 'pointerup', 10, 100 ) );
 
-		expect( controller.commitMove ).toHaveBeenCalledWith( 'stats', {
-			kind: 'in_group',
-			group_id: 'plugins',
-			index: 0,
-		} );
+		expect( controller.commitMove ).toHaveBeenCalledWith(
+			'stats',
+			{
+				kind: 'in_group',
+				group_id: 'plugins',
+				index: 0,
+			},
+			expect.objectContaining( {
+				previousPosition: expect.objectContaining( { kind: 'top_level' } ),
+			} )
+		);
 	} );
 } );

--- a/client/my-sites/sidebar/customize/test/footer.tsx
+++ b/client/my-sites/sidebar/customize/test/footer.tsx
@@ -37,7 +37,7 @@ describe( '<CustomizeFooter>', () => {
 		expect( container.querySelector( '.admin-sidebar-customize-footer' ) ).toBeNull();
 	} );
 
-	it( 'renders Save / Cancel after entering customize mode', () => {
+	it( 'renders auto-save controls after entering customize mode', () => {
 		const { container } = renderInProvider(
 			<CustomizeProvider>
 				<EnterButton />
@@ -49,11 +49,12 @@ describe( '<CustomizeFooter>', () => {
 		act( () => {
 			( container.querySelector( 'button' ) as HTMLButtonElement ).click();
 		} );
-		expect( screen.getByRole( 'button', { name: /Save/i } ) ).toBeInTheDocument();
-		expect( screen.getByRole( 'button', { name: /Cancel/i } ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Changes save automatically.' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: /Undo/i } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: /Done/i } ) ).toBeInTheDocument();
 	} );
 
-	it( 'disables Save until the working delta is dirty', () => {
+	it( 'disables Undo until there is a completed move', () => {
 		const { container } = renderInProvider(
 			<CustomizeProvider>
 				<EnterButton />
@@ -63,7 +64,7 @@ describe( '<CustomizeFooter>', () => {
 		act( () => {
 			( container.querySelector( 'button' ) as HTMLButtonElement ).click();
 		} );
-		const save = screen.getByRole( 'button', { name: /Save/i } );
-		expect( save ).toBeDisabled();
+		const undo = screen.getByRole( 'button', { name: /Undo/i } );
+		expect( undo ).toBeDisabled();
 	} );
 } );

--- a/client/my-sites/sidebar/customize/test/move-menu.tsx
+++ b/client/my-sites/sidebar/customize/test/move-menu.tsx
@@ -7,6 +7,7 @@ import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import { CustomizeProvider, useCustomizeContext } from '../index';
 import { MoveMenu } from '../move-menu';
+import type { LayoutDelta } from 'calypso/state/admin-sidebar/layout/types';
 
 function renderInProvider( ui: JSX.Element, state: object = {} ) {
 	const store = configureStore()( {
@@ -78,9 +79,10 @@ describe( '<MoveMenu>', () => {
 
 	it( 'offers a top-level destination for grouped items', () => {
 		const trigger = setupSidebar( 'plugins' );
+		const saveLayoutImpl = jest.fn( () => new Promise< LayoutDelta >( () => {} ) );
 
 		renderInProvider(
-			<CustomizeProvider>
+			<CustomizeProvider saveLayoutImpl={ saveLayoutImpl }>
 				<ExposeContext />
 				<MoveMenu itemId="stats" itemLabel="Stats" triggerEl={ trigger } onClose={ jest.fn() } />
 			</CustomizeProvider>

--- a/client/my-sites/sidebar/customize/test/provider.tsx
+++ b/client/my-sites/sidebar/customize/test/provider.tsx
@@ -6,6 +6,7 @@ import { act, render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import { BODY_CUSTOMIZE_CLASS, CustomizeProvider, useCustomizeContext } from '../index';
+import type { LayoutDelta } from 'calypso/state/admin-sidebar/layout/types';
 
 function renderInProvider( ui: JSX.Element ) {
 	const store = configureStore()( {
@@ -26,6 +27,7 @@ describe( '<CustomizeProvider>', () => {
 	beforeEach( () => {
 		exposedCtx = null;
 		document.body.className = '';
+		jest.restoreAllMocks();
 	} );
 
 	it( 'starts with isCustomizing=false and no body class', () => {
@@ -54,9 +56,10 @@ describe( '<CustomizeProvider>', () => {
 		expect( document.body.classList.contains( BODY_CUSTOMIZE_CLASS ) ).toBe( false );
 	} );
 
-	it( 'commitMove flips isDirty', () => {
+	it( 'commitMove marks dirty and queues an autosave', () => {
+		const saveLayoutImpl = jest.fn( () => new Promise< LayoutDelta >( () => {} ) );
 		renderInProvider(
-			<CustomizeProvider>
+			<CustomizeProvider saveLayoutImpl={ saveLayoutImpl }>
 				<ExposeContext />
 			</CustomizeProvider>
 		);
@@ -64,12 +67,22 @@ describe( '<CustomizeProvider>', () => {
 			exposedCtx?.enter();
 		} );
 		act( () => {
-			exposedCtx?.commitMove( 'plugin:foo:-:foo.php', {
-				kind: 'in_group',
-				group_id: 'plugins',
-				index: 0,
-			} );
+			exposedCtx?.commitMove(
+				'plugin:foo:-:foo.php',
+				{
+					kind: 'in_group',
+					group_id: 'plugins',
+					index: 0,
+				},
+				{
+					previousPosition: { kind: 'top_level', index: 3 },
+					label: 'Foo',
+				}
+			);
 		} );
 		expect( exposedCtx?.draft.isDirty ).toBe( true );
+		expect( exposedCtx?.draft.isSaving ).toBe( true );
+		expect( exposedCtx?.canUndo ).toBe( true );
+		expect( saveLayoutImpl ).toHaveBeenCalledTimes( 1 );
 	} );
 } );


### PR DESCRIPTION
Part of https://github.com/WordPress/wp-admin-sidebar/pull/78

## Proposed Changes

* Brings the Calypso sidebar customizer in line with the latest public plugin flow.
* Adds automatic saving, Undo, Retry, and Done controls.
* Keeps keyboard and menu behavior aligned with the public customizer, including Escape behavior.

## Why are these changes being made?

* The public plugin now uses an autosaving customizer. Calypso needs the same experience before we deploy that release into WPCOM.

## Testing Instructions

* Open `http://calypso.localhost:3000/home/[site]`.
* Enter customize mode from `MY PLUGINS`.
* Move `Stats` above `Feedback` and wait for `Saved.`
* Click `Undo` and wait for `Saved.`
* Open the More menu, press `ESC`, then press `ESC` again to exit customize mode.
* Reload and confirm the final order persists.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?