### PR TITLE
Jetpack Connect: rebalance connector feature cards for A4A audience

### DIFF
--- a/client/components/connect-screen/features-section/index.tsx
+++ b/client/components/connect-screen/features-section/index.tsx
@@ -21,6 +21,21 @@ export interface FeatureCard {
 export interface FeaturesSectionProps {
 	cards: FeatureCard[];
 	className?: string;
+	/**
+	 * When true, the first card is rendered as a full-width hero on its
+	 * own row, with every remaining card stacked beneath it (each on its
+	 * own row). Default layout otherwise: 1 card spans the column, 2
+	 * cards share a side-by-side 2-up grid, 3 cards stack the first card
+	 * full-width with the other two sharing the row below.
+	 *
+	 * Used by the connector flow when the A4A card is present, so the
+	 * agency-context card is visually anchored even when only one
+	 * supporting card joins it (which would otherwise put A4A in a
+	 * shoulder-to-shoulder 2-up grid). Has no visual effect when only one
+	 * card is rendered — there is no second row for the supporting
+	 * card(s) to stand alone in.
+	 */
+	heroFirstCard?: boolean;
 }
 
 function renderImage( logo: ReactNode | string, logoAlt = '', wrapperClass: string ): ReactNode {
@@ -51,11 +66,18 @@ function renderImage( logo: ReactNode | string, logoAlt = '', wrapperClass: stri
  * flat (no card chrome) so the cards read as part of the surrounding
  * column rather than as separate boxes.
  *
- * Layout follows the card count: 1 card spans the column, 2 cards share a
- * two-up grid, and 3 cards stack the highest-priority card full-width on
- * top with the remaining two side-by-side underneath.
+ * Layout follows the card count by default: 1 card spans the column, 2
+ * cards share a two-up grid, and 3 cards stack the highest-priority card
+ * full-width on top with the remaining two side-by-side underneath. The
+ * optional `heroFirstCard` prop opts the 2-card layout into the same
+ * full-width hero treatment used by the 3-card layout so the first card
+ * always claims its own row when needed (see prop docs).
  */
-export function FeaturesSection( { cards, className }: FeaturesSectionProps ): JSX.Element | null {
+export function FeaturesSection( {
+	cards,
+	className,
+	heroFirstCard,
+}: FeaturesSectionProps ): JSX.Element | null {
 	if ( ! cards || cards.length === 0 ) {
 		return null;
 	}
@@ -65,6 +87,7 @@ export function FeaturesSection( { cards, className }: FeaturesSectionProps ): J
 			className={ clsx(
 				'connect-screen-features-section',
 				`has-${ cards.length }-card`,
+				heroFirstCard && cards.length > 1 && 'has-hero-card',
 				className
 			) }
 		>

--- a/client/components/connect-screen/features-section/style.scss
+++ b/client/components/connect-screen/features-section/style.scss
@@ -25,34 +25,24 @@
 		// beneath it. Used whenever A4A is one of two active cards so the
 		// agency-context hero never has to compete with a single supporting
 		// card for shoulder-to-shoulder layout space. Both rows center their
-		// bullets — when a card has the row to itself, centering reads as
-		// a deliberate hero block rather than a left-anchored list (see the
-		// bullet-text `max-width` override below).
+		// bullet list as a block (see the `__card-bullets` centering override
+		// below) so a card that has the row to itself reads as a deliberate
+		// hero block rather than a left-anchored list.
 		.connect-screen-features-section.has-2-card.has-hero-card & {
 			grid-template-columns: 1fr;
-
-			.connect-screen-features-section__card-bullet {
-				justify-content: center;
-			}
 		}
 
 		// Three cards stack the highest-priority family (A4A) full-width on
 		// top, with the remaining two (Woo + Jetpack) sharing the row below
 		// — matches the two-card layout the no-A4A scenario already uses.
-		// The full-width card centers its bullets so the wider column reads
-		// as a deliberate hero block rather than a left-anchored list. See
-		// the bullet-text override below for why the text span also needs
-		// a `max-width` cap and `text-align: center` to keep the centering
-		// readable when bullets wrap.
+		// The full-width card centers its bullet list as a block so the wider
+		// column reads as a deliberate hero block rather than a left-anchored
+		// list (see the `__card-bullets` centering override below).
 		.connect-screen-features-section.has-3-card & {
 			grid-template-columns: 1fr 1fr;
 
 			.connect-screen-features-section__card:first-child {
 				grid-column: 1 / -1;
-
-				.connect-screen-features-section__card-bullet {
-					justify-content: center;
-				}
 			}
 		}
 	}
@@ -107,42 +97,32 @@
 	color: var( --color-text, #1e1e1e );
 }
 
-// A solo card has no siblings to anchor its alignment against, so center
-// the bullets in the column the same way the full-width A4A hero does in
-// the 3-card layout. Applies at every viewport — there's no row context
-// to preserve on mobile here.
-.connect-screen-features-section.has-1-card .connect-screen-features-section__card-bullet {
-	justify-content: center;
-}
-
-// `justify-content: center` on the bullet row only has visible effect
-// when the row contents are narrower than the row. As soon as a bullet
-// wraps, the text span swells to fill the remaining row width and the
-// centering collapses — the bullet looks left-anchored. Capping the
-// text span at a comfortable reading width keeps the icon + text unit
-// narrow enough to leave slack for the row-level centering to work,
-// and `text-align: center` then centers each wrapped line within the
-// span itself. The cap is generous enough that almost every English
-// bullet still fits on one line; longer translated copy will wrap into
-// a tidy centered block instead of stranding to the left.
+// Center the bullet list as a block under the logo while keeping each
+// bullet left-aligned with its checkmark. Centering the *list* (capped
+// width + auto inline margins) instead of each bullet row keeps the
+// checkmark glued to the first line of text no matter how many lines a
+// bullet wraps into. The previous approach centered each row and capped
+// the text span at `38ch`: once a bullet wrapped, the span sat at its
+// full cap width with the text centered inside it, stranding the
+// left-anchored checkmark far to the left of the visible text.
 //
-// Applied to the same surfaces that opt into row-level centering above:
-// every card in `has-1-card`, every card in `has-2-card.has-hero-card`
-// (both rows are full-width when the hero treatment is on), and the
-// full-width A4A hero in `has-3-card`. The shared positional
-// `> span:last-child` selector targets the bullet's text wrapper (the
-// icon wrapper carries `aria-hidden`, the text wrapper is the
-// second/last span).
-.connect-screen-features-section.has-1-card .connect-screen-features-section__card-bullet > span:last-child,
-.connect-screen-features-section.has-2-card.has-hero-card .connect-screen-features-section__card-bullet > span:last-child,
-.connect-screen-features-section.has-3-card .connect-screen-features-section__card:first-child .connect-screen-features-section__card-bullet > span:last-child {
+// Applied to the surfaces that read as a deliberate hero block: the solo
+// card in `has-1-card`, both full-width rows in `has-2-card.has-hero-card`,
+// and the full-width A4A hero in `has-3-card`. The `38ch` cap keeps long
+// or translated copy in a comfortable reading column rather than
+// stretching across the full hero width.
+.connect-screen-features-section.has-1-card .connect-screen-features-section__card-bullets,
+.connect-screen-features-section.has-2-card.has-hero-card .connect-screen-features-section__card-bullets,
+.connect-screen-features-section.has-3-card .connect-screen-features-section__card:first-child .connect-screen-features-section__card-bullets {
+	width: fit-content;
+
 	// `ch` is the right unit semantically (character-count cap, not a
 	// font-size derivative) but is off the project's allowed list — the
 	// existing `28ch` / `30ch` / `55ch` overrides elsewhere in the
 	// codebase follow the same per-line escape hatch.
 	// stylelint-disable-next-line unit-allowed-list
 	max-width: 38ch;
-	text-align: center;
+	margin-inline: auto;
 }
 
 .connect-screen-features-section__card-bullet-icon {

--- a/client/components/connect-screen/features-section/style.scss
+++ b/client/components/connect-screen/features-section/style.scss
@@ -19,6 +19,23 @@
 			grid-template-columns: 1fr 1fr;
 		}
 
+		// `has-hero-card` opts the two-card layout out of the 2-up grid and
+		// into the same stacked layout the three-card scenario uses: first
+		// card full-width on top, supporting card alone in its own row
+		// beneath it. Used whenever A4A is one of two active cards so the
+		// agency-context hero never has to compete with a single supporting
+		// card for shoulder-to-shoulder layout space. Both rows center their
+		// bullets — when a card has the row to itself, centering reads as
+		// a deliberate hero block rather than a left-anchored list (see the
+		// bullet-text `max-width` override below).
+		.connect-screen-features-section.has-2-card.has-hero-card & {
+			grid-template-columns: 1fr;
+
+			.connect-screen-features-section__card-bullet {
+				justify-content: center;
+			}
+		}
+
 		// Three cards stack the highest-priority family (A4A) full-width on
 		// top, with the remaining two (Woo + Jetpack) sharing the row below
 		// — matches the two-card layout the no-A4A scenario already uses.
@@ -110,11 +127,14 @@
 // a tidy centered block instead of stranding to the left.
 //
 // Applied to the same surfaces that opt into row-level centering above:
-// every card in `has-1-card`, and the full-width A4A hero in
-// `has-3-card`. The shared positional `> span:last-child` selector
-// targets the bullet's text wrapper (the icon wrapper carries
-// `aria-hidden`, the text wrapper is the second/last span).
+// every card in `has-1-card`, every card in `has-2-card.has-hero-card`
+// (both rows are full-width when the hero treatment is on), and the
+// full-width A4A hero in `has-3-card`. The shared positional
+// `> span:last-child` selector targets the bullet's text wrapper (the
+// icon wrapper carries `aria-hidden`, the text wrapper is the
+// second/last span).
 .connect-screen-features-section.has-1-card .connect-screen-features-section__card-bullet > span:last-child,
+.connect-screen-features-section.has-2-card.has-hero-card .connect-screen-features-section__card-bullet > span:last-child,
 .connect-screen-features-section.has-3-card .connect-screen-features-section__card:first-child .connect-screen-features-section__card-bullet > span:last-child {
 	// `ch` is the right unit semantically (character-count cap, not a
 	// font-size derivative) but is off the project's allowed list — the

--- a/client/components/connect-screen/features-section/test/index.tsx
+++ b/client/components/connect-screen/features-section/test/index.tsx
@@ -111,4 +111,51 @@ describe( 'FeaturesSection', () => {
 			triple.container.querySelector( '.connect-screen-features-section.has-3-card' )
 		).toBeInTheDocument();
 	} );
+
+	describe( 'heroFirstCard prop', () => {
+		test( 'adds the has-hero-card modifier when set with multiple cards', () => {
+			const { container } = render( <FeaturesSection cards={ baseCards } heroFirstCard /> );
+			expect(
+				container.querySelector( '.connect-screen-features-section.has-2-card.has-hero-card' )
+			).toBeInTheDocument();
+		} );
+
+		test( 'omits the modifier with a single card — there is no second row to stand alone in', () => {
+			const { container } = render(
+				<FeaturesSection cards={ [ baseCards[ 0 ] ] } heroFirstCard />
+			);
+			expect(
+				container.querySelector( '.connect-screen-features-section.has-hero-card' )
+			).not.toBeInTheDocument();
+		} );
+
+		test( 'omits the modifier when the prop is false / unset', () => {
+			const { container } = render( <FeaturesSection cards={ baseCards } /> );
+			expect(
+				container.querySelector( '.connect-screen-features-section.has-hero-card' )
+			).not.toBeInTheDocument();
+		} );
+
+		test( 'still applies on the 3-card layout (idempotent with the existing has-3-card hero CSS)', () => {
+			const triple = render(
+				<FeaturesSection
+					heroFirstCard
+					cards={ [
+						...baseCards,
+						{
+							id: 'jetpack',
+							logo: '/jetpack-logo.svg',
+							title: 'Jetpack',
+							bullets: [ 'Real-time backups' ],
+						},
+					] }
+				/>
+			);
+			expect(
+				triple.container.querySelector(
+					'.connect-screen-features-section.has-3-card.has-hero-card'
+				)
+			).toBeInTheDocument();
+		} );
+	} );
 } );

--- a/client/jetpack-connect/authorize.jsx
+++ b/client/jetpack-connect/authorize.jsx
@@ -1072,13 +1072,15 @@ export class JetpackAuthorize extends Component {
 
 			// Non-admin secondary connections show no cards — SSO is the
 			// sole benefit and the subtitle already communicates it.
-			const cards =
-				isSecondary && ! isAdmin
-					? []
-					: ( isSecondary
-							? getSecondaryAdminFeatureCards( authQuery.plugins )
-							: getConnectorFeatureCards( authQuery.plugins )
-					  ).cards;
+			let featureCardsResult;
+			if ( isSecondary && ! isAdmin ) {
+				featureCardsResult = { cards: [], heroFirstCard: false };
+			} else if ( isSecondary ) {
+				featureCardsResult = getSecondaryAdminFeatureCards( authQuery.plugins );
+			} else {
+				featureCardsResult = getConnectorFeatureCards( authQuery.plugins );
+			}
+			const { cards, heroFirstCard } = featureCardsResult;
 
 			return (
 				<>
@@ -1092,7 +1094,9 @@ export class JetpackAuthorize extends Component {
 					/>
 					{ this.renderUseDifferentAccountLink() }
 
-					{ cards.length > 0 && <FeaturesSection cards={ cards } /> }
+					{ cards.length > 0 && (
+						<FeaturesSection cards={ cards } heroFirstCard={ heroFirstCard } />
+					) }
 					{ this.renderNotices() }
 					{ this.renderStateAction() }
 				</>

--- a/client/jetpack-connect/connection-content/README.md
+++ b/client/jetpack-connect/connection-content/README.md
@@ -96,26 +96,30 @@ case 'your-plugin-slug':
     return {
         title: __( 'Your Plugin Name' ),
         bullets: [
-            __( 'First key benefit of your plugin.' ),
+            __( 'First key benefit, written so it reads in isolation and in audience-neutral voice.' ),
             __( 'Second key benefit.' ),
             __( 'Third key benefit.' ),
         ],
     };
 ```
 
+**`bullets[0]` invariant:** the first bullet must be audience-neutral (no second-person `your`, prefer `the site` / `the store`) and must read sensibly on its own. When A4A is among the active plugins, `getConnectorFeatureCards()` in [`../feature-cards.tsx`](../feature-cards.tsx) slices every supporting card down to just `bullets[0]` so the agency context isn't drowned out by end-user-focused benefits. Bullets 1 and 2 only render when A4A is absent, so they can keep a warmer personal voice if that suits the direct-owner audience.
+
 #### c. Add secondary-connection card data (`family-features.ts`)
 
-Add a `case` to `getSecondaryFeatureCardData()`. Secondary bullets should describe what an additional admin user gets (narrower than the owner connection):
+Add a `case` to `getSecondaryFeatureCardData()`. Secondary bullets describe what an additional admin user gets (narrower than the owner connection):
 
 ```typescript
 case 'your-plugin-slug':
     return {
         title: __( 'Your Plugin Name' ),
         bullets: [
-            __( 'What a secondary admin can do with this plugin.' ),
+            __( 'What a secondary admin can do with this plugin, in audience-neutral voice.' ),
         ],
     };
 ```
+
+**Exactly one bullet, audience-neutral voice, no SSO.** The secondary card row scans uniformly because every card is a single management-voice line — `getSecondaryFeatureCardData` returning more or fewer bullets fails the invariant test in [`test/family-features.test.ts`](./test/family-features.test.ts). Phrasing should read for an agency teammate (`the client's site`) and a site co-owner (`my site`) alike — prefer `this site` / `this store`. Do not list SSO: it is bundled with the full Jetpack plugin only — A4A, Woo, and the individual jetpack-* plugins do not ship it — so mentioning it on any other card would be incorrect, and singling out the generic Jetpack card with an SSO bullet would break the uniform shape.
 
 #### d. Register the card key in the selector (`selectors.ts`)
 

--- a/client/jetpack-connect/connection-content/family-features.ts
+++ b/client/jetpack-connect/connection-content/family-features.ts
@@ -45,6 +45,14 @@ export interface FeatureCardData {
  * stay focused on what the listed plugin actually does. That keeps each
  * bullet a translator-ready full sentence that doesn't depend on any
  * runtime composition.
+ *
+ * Bullet[0] invariant: every non-A4A card's first bullet must read
+ * sensibly in isolation and in an audience-neutral voice ("the site",
+ * "the store", no second-person "your"). When A4A is also among the
+ * active plugins, `getConnectorFeatureCards` slices supporting cards
+ * down to just `bullets[0]` so the agency context isn't drowned out by
+ * end-user-focused benefits. Bullets 1 and 2 can keep a warmer personal
+ * voice — they only render when A4A is absent.
  */
 export function getFeatureCardData( key: FeatureCardKey ): FeatureCardData {
 	switch ( key ) {
@@ -62,8 +70,8 @@ export function getFeatureCardData( key: FeatureCardKey ): FeatureCardData {
 			return {
 				title: __( 'WooCommerce' ),
 				bullets: [
+					__( 'Manage store orders, payments, and analytics from WordPress.com.' ),
 					__( 'Run your store on the go with the Woo mobile app.' ),
-					__( 'Real-time order alerts and store analytics.' ),
 					__( 'Accept secure payments and process refunds with WooPayments.' ),
 				],
 			};
@@ -82,7 +90,7 @@ export function getFeatureCardData( key: FeatureCardKey ): FeatureCardData {
 			return {
 				title: __( 'Jetpack VaultPress Backup' ),
 				bullets: [
-					__( 'Real-time, off-site backups for every change you make.' ),
+					__( 'Real-time, off-site backups for every change.' ),
 					__( 'One-click restore from any device, even if your site is down.' ),
 					__( 'An activity log of every change, so you can see exactly what to restore.' ),
 				],
@@ -122,7 +130,7 @@ export function getFeatureCardData( key: FeatureCardKey ): FeatureCardData {
 			return {
 				title: __( 'Jetpack Social' ),
 				bullets: [
-					__( 'Auto-share new posts to your social networks.' ),
+					__( "Auto-publish new posts to the site's connected social networks." ),
 					__( 'Schedule shares for the perfect time.' ),
 					__( 'Resurface older posts to keep them in front of new readers.' ),
 				],
@@ -155,46 +163,43 @@ export function getFeatureCardData( key: FeatureCardKey ): FeatureCardData {
  *
  * Secondary connections (any user connecting after the site owner) enable
  * a narrower set of features than the owner connection. Every secondary
- * card includes SSO since that is the universal benefit of a user
- * connection. The remaining bullets reflect what a secondary admin can
- * actually access per plugin.
+ * card is exactly one management-voice bullet so the row stays scannable
+ * regardless of how many families are present.
+ *
+ * SSO is intentionally not surfaced here. It is bundled with the full
+ * Jetpack plugin only — A4A, Woo, and the individual jetpack-* plugins
+ * do not ship it — so listing it on any other card would be incorrect,
+ * and singling out the generic Jetpack card with a second bullet would
+ * break the uniform shape that lets the row scan cleanly.
+ *
+ * Bullets read in an audience-neutral voice ("this site", "this store")
+ * so the same copy works whether the connecting user is an agency
+ * teammate or a site co-owner who happens to care about the feature.
  */
 export function getSecondaryFeatureCardData( key: FeatureCardKey ): FeatureCardData {
 	switch ( key ) {
 		case 'a4a':
 			return {
 				title: __( 'Automattic for Agencies' ),
-				bullets: [
-					__( 'Access the agency dashboard to manage client sites.' ),
-					__( 'Sign in to WordPress via your WordPress.com account (SSO).' ),
-				],
+				bullets: [ __( 'Access the agency dashboard to manage client sites.' ) ],
 			};
 
 		case 'woo':
 			return {
 				title: __( 'WooCommerce' ),
-				bullets: [
-					__( 'Run your store on the go with the Woo mobile app.' ),
-					__( 'Real-time order alerts and store analytics.' ),
-				],
+				bullets: [ __( 'Help manage this store — orders, payments, and analytics.' ) ],
 			};
 
 		case 'jetpack':
 			return {
 				title: __( 'Jetpack' ),
-				bullets: [
-					__( 'Access the activity log to track every change on your site.' ),
-					__( 'Sign in to WordPress via your WordPress.com account (SSO).' ),
-				],
+				bullets: [ __( 'Access the activity log to track every change on this site.' ) ],
 			};
 
 		case 'jetpack-backup':
 			return {
 				title: __( 'Jetpack VaultPress Backup' ),
-				bullets: [
-					__( 'Access the activity log to track every change on your site.' ),
-					__( 'Monitor backup status and restore from Jetpack Cloud.' ),
-				],
+				bullets: [ __( 'Monitor backup status and restore from Jetpack Cloud.' ) ],
 			};
 
 		case 'jetpack-protect':

--- a/client/jetpack-connect/connection-content/test/family-features.test.ts
+++ b/client/jetpack-connect/connection-content/test/family-features.test.ts
@@ -1,4 +1,4 @@
-import { getFeatureCardData } from '../family-features';
+import { getFeatureCardData, getSecondaryFeatureCardData } from '../family-features';
 import type { FeatureCardKey } from '../family-features';
 
 const ALL_KEYS: FeatureCardKey[] = [
@@ -37,5 +37,25 @@ describe( 'getFeatureCardData', () => {
 		expect( getFeatureCardData( 'jetpack-social' ).title ).toBe( 'Jetpack Social' );
 		expect( getFeatureCardData( 'jetpack-videopress' ).title ).toBe( 'Jetpack VideoPress' );
 		expect( getFeatureCardData( 'other' ).title ).toBe( 'Your active plugins' );
+	} );
+} );
+
+describe( 'getSecondaryFeatureCardData', () => {
+	test( 'returns exactly one bullet for every card key', () => {
+		// Secondary cards are single-bullet by design — SSO is intentionally
+		// dropped (only the full Jetpack plugin ships it) so the row scans
+		// uniformly regardless of which families are present.
+		for ( const key of ALL_KEYS ) {
+			const data = getSecondaryFeatureCardData( key );
+			expect( data.bullets ).toHaveLength( 1 );
+			expect( data.bullets[ 0 ].length ).toBeGreaterThan( 0 );
+		}
+	} );
+
+	test( 'never surfaces SSO in any bullet', () => {
+		for ( const key of ALL_KEYS ) {
+			const data = getSecondaryFeatureCardData( key );
+			expect( data.bullets.join( ' ' ) ).not.toContain( 'SSO' );
+		}
 	} );
 } );

--- a/client/jetpack-connect/feature-cards.tsx
+++ b/client/jetpack-connect/feature-cards.tsx
@@ -48,6 +48,15 @@ function getLogoForCardKey( key: FeatureCardKey ): ReactNode | string | undefine
 
 export interface ConnectorFeatureCards {
 	cards: FeatureCard[];
+	/**
+	 * Hint for `<FeaturesSection />` that the first card should be rendered
+	 * as a full-width hero on its own row, with the remaining card(s)
+	 * stacked beneath it. Set whenever A4A is the primary card so the
+	 * agency-context card is visually anchored regardless of how many
+	 * supporting cards accompany it (1 or 2). Always `false` when no A4A
+	 * card is present.
+	 */
+	heroFirstCard: boolean;
 }
 
 /**
@@ -65,6 +74,12 @@ export interface ConnectorFeatureCards {
  * and to read sensibly in isolation, so it doubles as the condensed
  * summary in the A4A scenario and as the lead bullet when A4A is absent
  * (see the bullet[0] invariant on `getFeatureCardData`).
+ *
+ * The result also exposes `heroFirstCard` so the consumer can opt the
+ * `<FeaturesSection />` layout into the full-width hero treatment for the
+ * A4A card whenever it's present — even in the 2-card scenarios where
+ * the default 2-up grid would otherwise put A4A side-by-side with a
+ * supporting card.
  */
 export function getConnectorFeatureCards(
 	pluginSlugs: readonly string[] = []
@@ -90,7 +105,7 @@ export function getConnectorFeatureCards(
 		};
 	} );
 
-	return { cards };
+	return { cards, heroFirstCard: hasA4A };
 }
 
 /**
@@ -99,12 +114,17 @@ export function getConnectorFeatureCards(
  * Secondary admin connections enable a narrower set of features than the
  * owner connection. The card selection reuses the same plugin-aware
  * family/priority system as first connections, but the bullet copy
- * reflects the narrower scope (SSO, cloud management, etc.).
+ * reflects the narrower scope (cloud management, activity log access).
+ *
+ * `heroFirstCard` mirrors the primary-owner behavior — when A4A is
+ * present in the secondary row, it claims its own row on top so the
+ * supporting cards don't compete with it for layout space.
  */
 export function getSecondaryAdminFeatureCards(
 	pluginSlugs: readonly string[] = []
 ): ConnectorFeatureCards {
 	const { cardKeys } = getFeatureSelection( pluginSlugs );
+	const hasA4A = cardKeys.includes( 'a4a' );
 
 	const cards: FeatureCard[] = cardKeys.map( ( key ) => {
 		const data = getSecondaryFeatureCardData( key );
@@ -116,5 +136,5 @@ export function getSecondaryAdminFeatureCards(
 		};
 	} );
 
-	return { cards };
+	return { cards, heroFirstCard: hasA4A };
 }

--- a/client/jetpack-connect/feature-cards.tsx
+++ b/client/jetpack-connect/feature-cards.tsx
@@ -55,11 +55,22 @@ export interface ConnectorFeatureCards {
  * the `plugins` query parameter — picks up to three cards (per the
  * family-priority rules in `getFeatureSelection`) and resolves each one's
  * logo, title, and bullet copy.
+ *
+ * When A4A is among the selected cards, every supporting card collapses
+ * to just its first bullet. Users connecting via A4A are agencies or
+ * freelancers, not end-users of the site — surfacing the full
+ * end-user-focused bullet list (e.g. "Run your store on the go with the
+ * Woo mobile app") would drown out the agency context. The first bullet
+ * of every non-A4A card is intentionally written to be audience-neutral
+ * and to read sensibly in isolation, so it doubles as the condensed
+ * summary in the A4A scenario and as the lead bullet when A4A is absent
+ * (see the bullet[0] invariant on `getFeatureCardData`).
  */
 export function getConnectorFeatureCards(
 	pluginSlugs: readonly string[] = []
 ): ConnectorFeatureCards {
 	const { cardKeys } = getFeatureSelection( pluginSlugs );
+	const hasA4A = cardKeys.includes( 'a4a' );
 
 	// `logoAlt` is intentionally omitted: every Jetpack-family card and A4A
 	// pass a React-element logo whose `alt` is rendered by the SVG's own
@@ -70,11 +81,12 @@ export function getConnectorFeatureCards(
 	// override would have supplied.
 	const cards: FeatureCard[] = cardKeys.map( ( key ) => {
 		const data = getFeatureCardData( key );
+		const bullets = hasA4A && key !== 'a4a' ? data.bullets.slice( 0, 1 ) : data.bullets;
 		return {
 			id: key,
 			logo: getLogoForCardKey( key ),
 			title: data.title,
-			bullets: data.bullets,
+			bullets,
 		};
 	} );
 

--- a/client/jetpack-connect/test/authorize.js
+++ b/client/jetpack-connect/test/authorize.js
@@ -155,6 +155,40 @@ describe( 'JetpackAuthorize', () => {
 		expect(
 			screen.getByText( 'Real-time backups, security scanning, and downtime monitoring.' )
 		).toBeInTheDocument();
+		// No A4A in the plugin set, so the hero layout is NOT applied —
+		// Woo + Jetpack share the default 2-up grid.
+		expect(
+			container.querySelector( '.connect-screen-features-section.has-hero-card' )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'features section gives A4A its own row with Woo standing alone beneath when only those two plugins are active', () => {
+		const { container } = renderWithRedux(
+			<JetpackAuthorize
+				{ ...DEFAULT_PROPS }
+				authQuery={ {
+					...DEFAULT_PROPS.authQuery,
+					from: 'jetpack-connector',
+					plugins: [ 'automattic-for-agencies-client', 'woocommerce' ],
+				} }
+			/>
+		);
+
+		// 2-card-with-A4A scenario: both cards render, but the wrapper opts
+		// into the hero layout so A4A claims the top row full-width and
+		// Woo stands alone in the row below.
+		expect(
+			screen.getByRole( 'article', { name: 'Automattic for Agencies' } )
+		).toBeInTheDocument();
+		expect( screen.getByRole( 'article', { name: 'WooCommerce' } ) ).toBeInTheDocument();
+		const section = container.querySelector(
+			'.connect-screen-features-section.has-2-card.has-hero-card'
+		);
+		expect( section ).toBeInTheDocument();
+		const cards = section.querySelectorAll( '.connect-screen-features-section__card' );
+		expect( cards.length ).toBe( 2 );
+		expect( cards[ 0 ] ).toHaveAttribute( 'aria-label', 'Automattic for Agencies' );
+		expect( cards[ 1 ] ).toHaveAttribute( 'aria-label', 'WooCommerce' );
 	} );
 
 	test( 'features section stacks A4A on top with Woo + Jetpack underneath when all three families are present', () => {
@@ -177,8 +211,12 @@ describe( 'JetpackAuthorize', () => {
 		).toBeInTheDocument();
 		expect( screen.getByRole( 'article', { name: 'WooCommerce' } ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'article', { name: 'Jetpack' } ) ).toBeInTheDocument();
+		// `has-hero-card` is set whenever A4A leads the cards, even though
+		// the existing `has-3-card` CSS already produces the hero look in
+		// the 3-card scenario. The class stays harmless here and keeps the
+		// "A4A is the lead" signal explicit.
 		const cards = container.querySelectorAll(
-			'.connect-screen-features-section.has-3-card .connect-screen-features-section__card'
+			'.connect-screen-features-section.has-3-card.has-hero-card .connect-screen-features-section__card'
 		);
 		expect( cards.length ).toBe( 3 );
 		expect( cards[ 0 ] ).toHaveAttribute( 'aria-label', 'Automattic for Agencies' );

--- a/client/jetpack-connect/test/authorize.js
+++ b/client/jetpack-connect/test/authorize.js
@@ -217,9 +217,12 @@ describe( 'JetpackAuthorize', () => {
 				/>
 			);
 
-			// Secondary admin card with SSO bullet is rendered.
+			// Secondary admin card renders with its single management-voice bullet.
+			// The "/track every change/" substring is unique to the card bullet —
+			// the secondary subtitle also mentions "activity log", so a looser
+			// regex would match two elements.
 			expect( screen.getByRole( 'article', { name: 'Jetpack' } ) ).toBeInTheDocument();
-			expect( screen.getByText( /SSO/ ) ).toBeInTheDocument();
+			expect( screen.getByText( /track every change/ ) ).toBeInTheDocument();
 
 			// The blocking "already connected by other user" notice is NOT shown.
 			expect(

--- a/client/jetpack-connect/test/feature-cards.test.tsx
+++ b/client/jetpack-connect/test/feature-cards.test.tsx
@@ -127,4 +127,46 @@ describe( 'getConnectorFeatureCards', () => {
 			expect( a4a?.bullets.length ).toBeGreaterThanOrEqual( 2 );
 		} );
 	} );
+
+	describe( 'heroFirstCard hint', () => {
+		test( 'is true when A4A is present alongside other plugins', () => {
+			expect(
+				getConnectorFeatureCards( [ 'automattic-for-agencies-client', 'woocommerce' ] )
+					.heroFirstCard
+			).toBe( true );
+			expect(
+				getConnectorFeatureCards( [ 'automattic-for-agencies-client', 'woocommerce', 'jetpack' ] )
+					.heroFirstCard
+			).toBe( true );
+			expect(
+				getConnectorFeatureCards( [ 'automattic-for-agencies-client', 'jetpack-social' ] )
+					.heroFirstCard
+			).toBe( true );
+		} );
+
+		test( 'is true even when A4A is the only active plugin', () => {
+			// `heroFirstCard` is a presentation hint; the single-card layout
+			// is unaffected by it, so the value just reflects "A4A is the
+			// primary card".
+			expect( getConnectorFeatureCards( [ 'automattic-for-agencies-client' ] ).heroFirstCard ).toBe(
+				true
+			);
+		} );
+
+		test( 'is false when no A4A plugin is present', () => {
+			expect( getConnectorFeatureCards( [ 'woocommerce', 'jetpack' ] ).heroFirstCard ).toBe(
+				false
+			);
+			expect( getConnectorFeatureCards( [ 'jetpack' ] ).heroFirstCard ).toBe( false );
+			expect( getConnectorFeatureCards( [] ).heroFirstCard ).toBe( false );
+		} );
+
+		test( 'getSecondaryAdminFeatureCards mirrors the same A4A hint', () => {
+			expect(
+				getSecondaryAdminFeatureCards( [ 'automattic-for-agencies-client', 'jetpack' ] )
+					.heroFirstCard
+			).toBe( true );
+			expect( getSecondaryAdminFeatureCards( [ 'jetpack' ] ).heroFirstCard ).toBe( false );
+		} );
+	} );
 } );

--- a/client/jetpack-connect/test/feature-cards.test.tsx
+++ b/client/jetpack-connect/test/feature-cards.test.tsx
@@ -5,21 +5,26 @@
 import { getConnectorFeatureCards, getSecondaryAdminFeatureCards } from '../feature-cards';
 
 describe( 'getSecondaryAdminFeatureCards', () => {
-	test( 'returns a Jetpack card with SSO when only jetpack is installed', () => {
+	test( 'returns a single-bullet Jetpack card when only jetpack is installed', () => {
 		const { cards } = getSecondaryAdminFeatureCards( [ 'jetpack' ] );
 		expect( cards ).toHaveLength( 1 );
 		expect( cards[ 0 ].id ).toBe( 'jetpack' );
 		expect( cards[ 0 ].title ).toBe( 'Jetpack' );
-		expect( cards[ 0 ].bullets.join( ' ' ) ).toContain( 'SSO' );
-		expect( cards[ 0 ].bullets.join( ' ' ) ).toContain( 'activity log' );
+		expect( cards[ 0 ].bullets ).toHaveLength( 1 );
+		expect( cards[ 0 ].bullets[ 0 ] ).toContain( 'activity log' );
+		// SSO is intentionally not surfaced — only the full Jetpack plugin
+		// ships it, but listing it on this card alone would break the
+		// uniform single-bullet shape across the secondary card row.
+		expect( cards[ 0 ].bullets.join( ' ' ) ).not.toContain( 'SSO' );
 	} );
 
-	test( 'returns a Woo card when only woocommerce is installed', () => {
+	test( 'returns a Woo card with management-voice bullet when only woocommerce is installed', () => {
 		const { cards } = getSecondaryAdminFeatureCards( [ 'woocommerce' ] );
 		expect( cards ).toHaveLength( 1 );
 		expect( cards[ 0 ].id ).toBe( 'woo' );
 		expect( cards[ 0 ].title ).toBe( 'WooCommerce' );
-		expect( cards[ 0 ].bullets.join( ' ' ) ).toContain( 'Woo mobile app' );
+		expect( cards[ 0 ].bullets ).toHaveLength( 1 );
+		expect( cards[ 0 ].bullets[ 0 ] ).toContain( 'manage this store' );
 	} );
 
 	test( 'returns multiple cards when jetpack and woocommerce are installed', () => {
@@ -35,7 +40,11 @@ describe( 'getSecondaryAdminFeatureCards', () => {
 		expect( cards ).toHaveLength( 1 );
 		expect( cards[ 0 ].id ).toBe( 'jetpack-backup' );
 		expect( cards[ 0 ].title ).toBe( 'Jetpack VaultPress Backup' );
-		expect( cards[ 0 ].bullets.join( ' ' ) ).toContain( 'activity log' );
+		expect( cards[ 0 ].bullets ).toHaveLength( 1 );
+		// jetpack-backup keeps the backup-specific bullet — the duplicate
+		// activity-log bullet was dropped to avoid overlap with the generic
+		// Jetpack card.
+		expect( cards[ 0 ].bullets[ 0 ] ).toContain( 'backup status' );
 	} );
 
 	test( 'returns the "other" fallback card for empty plugin list', () => {
@@ -69,5 +78,53 @@ describe( 'getConnectorFeatureCards', () => {
 	test( 'returns a fallback card for empty plugin list', () => {
 		const { cards } = getConnectorFeatureCards( [] );
 		expect( cards.length ).toBeGreaterThan( 0 );
+	} );
+
+	describe( 'A4A-aware bullet slicing', () => {
+		test( 'supporting cards keep the full bullet list when A4A is absent', () => {
+			const { cards } = getConnectorFeatureCards( [ 'woocommerce', 'jetpack' ] );
+			const woo = cards.find( ( c ) => c.id === 'woo' );
+			const jetpack = cards.find( ( c ) => c.id === 'jetpack' );
+			expect( woo?.bullets.length ).toBeGreaterThanOrEqual( 2 );
+			expect( jetpack?.bullets.length ).toBeGreaterThanOrEqual( 2 );
+		} );
+
+		test( 'collapses supporting cards to a single bullet when A4A is present', () => {
+			const { cards } = getConnectorFeatureCards( [
+				'automattic-for-agencies-client',
+				'woocommerce',
+				'jetpack',
+			] );
+			const a4a = cards.find( ( c ) => c.id === 'a4a' );
+			const woo = cards.find( ( c ) => c.id === 'woo' );
+			const jetpack = cards.find( ( c ) => c.id === 'jetpack' );
+
+			// A4A is the primary card and keeps its full agency-focused bullet list.
+			expect( a4a?.bullets.length ).toBeGreaterThanOrEqual( 2 );
+			// Supporting cards collapse to their audience-neutral lead bullet.
+			expect( woo?.bullets ).toHaveLength( 1 );
+			expect( jetpack?.bullets ).toHaveLength( 1 );
+		} );
+
+		test( 'slices per-plugin Jetpack cards (jetpack-social) when A4A is present', () => {
+			const { cards } = getConnectorFeatureCards( [
+				'automattic-for-agencies-client',
+				'jetpack-social',
+			] );
+			const social = cards.find( ( c ) => c.id === 'jetpack-social' );
+			expect( social?.bullets ).toHaveLength( 1 );
+			// Confirm the rewritten lead bullet — makes clear the SITE does the
+			// posting, addressing the reviewer's "on their behalf" concern.
+			expect( social?.bullets[ 0 ] ).toContain( "site's connected social networks" );
+		} );
+
+		test( 'does not slice the A4A card itself', () => {
+			const { cards } = getConnectorFeatureCards( [
+				'automattic-for-agencies-client',
+				'woocommerce',
+			] );
+			const a4a = cards.find( ( c ) => c.id === 'a4a' );
+			expect( a4a?.bullets.length ).toBeGreaterThanOrEqual( 2 );
+		} );
 	} );
 } );


### PR DESCRIPTION
Closes CONNECT-237

## Proposed Changes

Rebalance the connector feature-card copy on the unified `from=jetpack-connector` flow so the agency-entry-point (A4A) and the secondary-admin row stop dumping end-user-focused benefits on audiences who don't care about them.

**Primary owner (A4A active):**

- Rewrite three first-bullets in `getFeatureCardData()` so they read in audience-neutral voice:
  - `woo` bullet[0]: `Run your store on the go with the Woo mobile app.` → `Manage store orders, payments, and analytics from WordPress.com.`
  - `jetpack-backup` bullet[0]: `Real-time, off-site backups for every change you make.` → `Real-time, off-site backups for every change.`
  - `jetpack-social` bullet[0]: `Auto-share new posts to your social networks.` → `Auto-publish new posts to the site's connected social networks.`
- When A4A is among the active plugins, `getConnectorFeatureCards()` collapses every supporting card to `bullets[0]`. A4A keeps its full three-bullet agency framing; the supporting cards stay on screen but stop drowning out the agency context with end-user copy. Bullets 1 and 2 only render when A4A is absent, so they keep their warmer personal voice for the direct-owner flows.

**Secondary admin:**

- Drop SSO bullets across every card. SSO is bundled with the full Jetpack plugin only — A4A, Woo, and the individual `jetpack-*` plugins do not ship it, so listing it on those cards was factually incorrect.
- Normalize every secondary card to a single management-voice bullet so the row scans uniformly. Adopt audience-neutral phrasing (`this site`, `this store`) that reads for both agency teammates and site co-owners.

**Tests:**

- Update SSO/Woo assertions in `feature-cards.test.tsx` and `authorize.js` to match the new copy.
- Add four P4 slicing tests covering A4A-aware slicing, per-plugin Jetpack card slicing, A4A card itself unaffected, and full bullets when A4A absent.
- Add a `getSecondaryFeatureCardData` describe block in `family-features.test.ts` locking in the single-bullet and no-SSO invariants.

**Docs:**

- JSDoc on `getFeatureCardData`, `getSecondaryFeatureCardData`, and `getConnectorFeatureCards` documents the bullet[0] invariant, the SSO scope correction, and the A4A-aware slicing rule.
- `connection-content/README.md` walks future contributors through both invariants when adding a new per-plugin card.

## Why are these changes being made?

A reviewer of the connector authorize page flagged that, with A4A and the Jetpack plugin both active, an agency or freelance user connecting a client's site is told "Jetpack can now post on social media on their behalf" — content that's pitched at a site owner, not the agency operator. The same shape applies to the Woo card ("Run your store on the go") and the Jetpack stats bullet.

The two changes here address that:

- **Primary** keeps a single string set per plugin and uses a one-line slice in the composition layer to condense supporting cards whenever A4A is the entry point. Only three first-bullet rewrites are needed because the other five cards already lead with an audience-neutral bullet.
- **Secondary** fixes the unrelated-but-adjacent issue that the secondary-admin Jetpack and A4A cards were claiming SSO as a feature — SSO is a Jetpack-plugin-only benefit, and the secondary row now reads as a uniform, one-bullet-per-card management summary that works for either agency teammates or co-owners.

## Testing Instructions

1. Run a test site with WP 7.0 and install Jetpack, WooCommerce, and A4A plugins
2. Open the Calypso live direct link from this PR and copy the URL
3. Start the connection flow from Connector with different plugin combinations then rewrite the wordpress.com part of the URL with the one from Calypso live. The auth page should look like this:
<img width="917" height="1000" alt="Screenshot 2026-05-27 at 16 41 59" src="https://github.com/user-attachments/assets/e2ebdb2d-5d75-414c-95e7-6656f92d68e4" />
<img width="848" height="1044" alt="Screenshot 2026-05-27 at 15 25 14" src="https://github.com/user-attachments/assets/0ad890e7-b89a-463c-b991-eb632abd62e1" />



## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

Made with [Cursor](https://cursor.com)