### PR TITLE
Temporary hide Zendesk chat button

### DIFF
--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -176,7 +176,10 @@ export default function AgentDock( {
 		}
 	}, [ agentId ] );
 
-	const shouldShowUnifiedSupport = shouldUseUnifiedAgent && ! isReaderChat;
+	// Woo AI sites (sectionName 'wooai-admin') don't have HVM tagging yet,
+	// so Zendesk escalation is disabled until routing is in place.
+	const isWooAiAdmin = sectionName === 'wooai-admin';
+	const shouldShowUnifiedSupport = shouldUseUnifiedAgent && ! isReaderChat && ! isWooAiAdmin;
 
 	const handleChatHasMessagesChange = useCallback(
 		( hasMessages: boolean ) => setIsOrchestratorChatEmpty( ! hasMessages ),


### PR DESCRIPTION
Part of WOOAI-516

## Proposed Changes

* For `wooai-admin` section do not show the Zendesk chat button

## Why are these changes being made?

* Currently we don't have ability to tag HVM, so we need to hide the ability to access Zendesk chat

## Testing Instructions

- Use WooCommerce AI plugin,
- Open docked chat,
- Make sure you don't see the button

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td valign="top"><img width="737" height="339" alt="Screenshot 2026-05-27 at 17 03 02" src="https://github.com/user-attachments/assets/211c5b89-7585-4e7b-926a-9485f90c42b2" /></td>
<td valign="top"><img width="401" height="248" alt="Screenshot 2026-05-27 at 17 03 23" src="https://github.com/user-attachments/assets/5be9dba0-d362-4b9b-9b49-0ea4264b08fe" /></td>
</tr>
</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
