### PR TITLE
A4A: Fix FAQ breadcrumb spacing

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/primary/commission-overview/style.scss
+++ b/client/a8c-for-agencies/sections/referrals/primary/commission-overview/style.scss
@@ -2,10 +2,6 @@
 @import "@wordpress/base-styles/mixins";
 
 .commission-overview {
-	.hosting-dashboard-layout__top-wrapper {
-		padding-block: 24px 0;
-	}
-
 	.commission-overview__section-container {
 		display: flex;
 		flex-direction: column;


### PR DESCRIPTION
Resolves Linear A4A-2631
Part of Automattic/automattic-for-agencies-dev#3889

## Proposed Changes

* Remove the FAQ page-specific top wrapper padding override.
* Let the FAQ page use the shared hosting dashboard header/body spacing.

<img width="1451" height="401" alt="image" src="https://github.com/user-attachments/assets/28e51097-c0c1-496a-837f-6a61650d499a" />

## Why are these changes being made?

* The Referrals FAQ page had inconsistent spacing around the breadcrumb navigation and content compared with other A4A portal pages.

## Testing Instructions

* Check the code changes.
* Open the Automattic for Agencies Live link.
* Go to `/referrals/faq`.
* Verify the breadcrumb area and page content use the standard portal spacing.
* Verify there are no TypeScript, React, or console errors.

Local validation completed:

* `yarn run -T stylelint client/a8c-for-agencies/sections/referrals/primary/commission-overview/style.scss`
* `git diff --check`
* Playwright MCP on `http://agencies.localhost:3002/referrals/faq`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g. browsers), interfaces (e.g. keyboard navigation), and assistive technologies (e.g. screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md).
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

_— ClemenAgent (Powered by Codex)_