### PR TITLE
A4A WooPayments: compact density and hide view options in add-site modal

### DIFF
--- a/client/a8c-for-agencies/sections/woopayments/add-woopayments-to-site/add-site-table.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/add-woopayments-to-site/add-site-table.tsx
@@ -1,3 +1,4 @@
+import { __experimentalHStack as HStack } from '@wordpress/components';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useState } from 'react';
@@ -5,6 +6,7 @@ import A4ATablePlaceholder from 'calypso/a8c-for-agencies/components/a4a-table-p
 import { initialDataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/constants';
 import ItemsDataViews from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews';
 import { DataViewsState } from 'calypso/a8c-for-agencies/components/items-dashboard/items-dataviews/interfaces';
+import { DataViews } from 'calypso/components/dataviews';
 import FormRadio from 'calypso/components/forms/form-radio';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -47,6 +49,7 @@ const AddWooPaymentsToSiteTable = ( {
 	const [ dataViewsState, setDataViewsState ] = useState< DataViewsState >( {
 		...initialDataViewsState,
 		fields: [ 'site' ],
+		layout: { density: 'compact' },
 	} );
 
 	const onSelectSite = useCallback(
@@ -102,7 +105,13 @@ const AddWooPaymentsToSiteTable = ( {
 						setDataViewsState: setDataViewsState,
 						defaultLayouts: { table: {} },
 					} }
-				/>
+				>
+					<HStack className="dataviews__view-actions" justify="start">
+						<DataViews.Search />
+					</HStack>
+					<DataViews.Layout />
+					<DataViews.Footer />
+				</ItemsDataViews>
 			) }
 		</div>
 	);


### PR DESCRIPTION
Part of A4A-2634

## Proposed Changes

| Before | After |
|--------|--------|
|  <img width="815" height="356" alt="Screenshot 2026-05-27 at 15 48 12" src="https://github.com/user-attachments/assets/d2d961d6-2663-4f0a-b828-ebccd64b4adc" /> |  <img width="818" height="325" alt="Screenshot 2026-05-27 at 15 47 10" src="https://github.com/user-attachments/assets/68a6bf7d-7f2a-4670-af7b-1679a8dd2676" /> | 

* **`a8c-for-agencies/sections/woopayments/add-woopayments-to-site/add-site-table.tsx`** — adjust the DataViews instance behind the **Add WooPayments to site** modal's site picker via the DataViews APIs (no CSS):
  * Set `layout: { density: 'compact' }` on the initial view state so the table renders compact rows by default.
  * Switch to DataViews' free-composition mode by passing children (`<DataViews.Search />`, `<DataViews.Layout />`, `<DataViews.Footer />`) to `ItemsDataViews`. This replaces the default toolbar, which is what hides the “View options” cog dropdown. Same composition pattern already used in `sections/woopayments/dashboard-content/sites-with-woopayments.tsx`.

## Why are these changes being made?

The picker is a single-column radio list — there's nothing to configure under the cog (no column toggles, no layout switch, no useful sort), so it just adds noise. Compact density also fits more sites on screen without scrolling, which matters in the modal.

## Testing Instructions

1. Open the live link and go to **A4A → WooPayments**.
2. Open the **Add WooPayments to site** modal.
3. Confirm rows render at compact density and that the “View options” cog button no longer appears in the toolbar.
4. Confirm search still filters the list and selecting a row still enables the primary CTA.
5. Verify there are no TypeScript / React console errors.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?