### PR TITLE
Reader Achievements: display daily post streaks

### DIFF
--- a/client/data/reader/test/use-achievements-query.test.tsx
+++ b/client/data/reader/test/use-achievements-query.test.tsx
@@ -133,4 +133,54 @@ describe( 'useAchievementsQuery', () => {
 
 		expect( result.current.lockedAchievements ).toEqual( [] );
 	} );
+
+	test( 'should filter inactive daily post streaks and sort by current_streak descending', async () => {
+		mockGet.mockResolvedValue( {
+			found: 0,
+			achievements: [],
+			daily_post_streak: [
+				{
+					blog_id: 1,
+					url: 'https://one.example.com',
+					current_streak: 4,
+					last_check_date: '2026-05-27',
+					oldest_post_date: '2026-05-23 18:40:11',
+					is_active: true,
+				},
+				{
+					blog_id: 2,
+					url: 'https://two.example.com',
+					current_streak: 23,
+					last_check_date: '2026-02-08',
+					oldest_post_date: '2026-01-17 11:05:50',
+					is_active: false,
+				},
+				{
+					blog_id: 3,
+					url: 'https://three.example.com',
+					current_streak: 14,
+					last_check_date: '2026-05-27',
+					oldest_post_date: '2026-05-14 09:12:34',
+					is_active: true,
+				},
+			],
+		} );
+
+		const { result } = renderHook( () => useAchievementsQuery( 'testuser' ), { wrapper } );
+
+		await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+
+		expect( result.current.dailyPostStreaks ).toHaveLength( 2 );
+		expect( result.current.dailyPostStreaks.map( ( s ) => s.blog_id ) ).toEqual( [ 3, 1 ] );
+	} );
+
+	test( 'should default dailyPostStreaks to an empty array when absent', async () => {
+		mockGet.mockResolvedValue( { found: 0, achievements: [] } );
+
+		const { result } = renderHook( () => useAchievementsQuery( 'testuser' ), { wrapper } );
+
+		await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+
+		expect( result.current.dailyPostStreaks ).toEqual( [] );
+	} );
 } );

--- a/client/data/reader/test/use-achievements-query.test.tsx
+++ b/client/data/reader/test/use-achievements-query.test.tsx
@@ -134,35 +134,14 @@ describe( 'useAchievementsQuery', () => {
 		expect( result.current.lockedAchievements ).toEqual( [] );
 	} );
 
-	test( 'should filter inactive daily post streaks and sort by current_streak descending', async () => {
+	test( 'should sort daily post streaks by current_streak descending', async () => {
 		mockGet.mockResolvedValue( {
 			found: 0,
 			achievements: [],
 			daily_post_streak: [
-				{
-					blog_id: 1,
-					url: 'https://one.example.com',
-					current_streak: 4,
-					last_check_date: '2026-05-27',
-					oldest_post_date: '2026-05-23 18:40:11',
-					is_active: true,
-				},
-				{
-					blog_id: 2,
-					url: 'https://two.example.com',
-					current_streak: 23,
-					last_check_date: '2026-02-08',
-					oldest_post_date: '2026-01-17 11:05:50',
-					is_active: false,
-				},
-				{
-					blog_id: 3,
-					url: 'https://three.example.com',
-					current_streak: 14,
-					last_check_date: '2026-05-27',
-					oldest_post_date: '2026-05-14 09:12:34',
-					is_active: true,
-				},
+				{ blog_id: 1, url: 'https://one.example.com', current_streak: 4 },
+				{ blog_id: 2, url: 'https://two.example.com', current_streak: 23 },
+				{ blog_id: 3, url: 'https://three.example.com', current_streak: 14 },
 			],
 		} );
 
@@ -170,8 +149,8 @@ describe( 'useAchievementsQuery', () => {
 
 		await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
 
-		expect( result.current.dailyPostStreaks ).toHaveLength( 2 );
-		expect( result.current.dailyPostStreaks.map( ( s ) => s.blog_id ) ).toEqual( [ 3, 1 ] );
+		expect( result.current.dailyPostStreaks ).toHaveLength( 3 );
+		expect( result.current.dailyPostStreaks.map( ( s ) => s.blog_id ) ).toEqual( [ 2, 3, 1 ] );
 	} );
 
 	test( 'should default dailyPostStreaks to an empty array when absent', async () => {

--- a/client/data/reader/use-achievements-query.ts
+++ b/client/data/reader/use-achievements-query.ts
@@ -23,11 +23,16 @@ export function useAchievementsQuery(
 		...options,
 	} );
 
+	const dailyPostStreaks = ( query.data?.pages[ 0 ]?.daily_post_streak ?? [] )
+		.filter( ( streak ) => streak.is_active )
+		.sort( ( a, b ) => b.current_streak - a.current_streak );
+
 	return {
 		achievements: query.data?.pages.flatMap( ( p ) => p.achievements ?? [] ) ?? [],
 		lockedAchievements: query.data?.pages[ 0 ]?.locked_achievements ?? [],
 		yearsOfService: query.data?.pages[ 0 ]?.years_of_service,
 		engagementStreak: query.data?.pages[ 0 ]?.engagement_streak,
+		dailyPostStreaks,
 		found: query.data?.pages[ 0 ]?.found ?? 0,
 		isLoading: query.isLoading,
 		isError: query.isError,

--- a/client/data/reader/use-achievements-query.ts
+++ b/client/data/reader/use-achievements-query.ts
@@ -23,9 +23,9 @@ export function useAchievementsQuery(
 		...options,
 	} );
 
-	const dailyPostStreaks = ( query.data?.pages[ 0 ]?.daily_post_streak ?? [] )
-		.filter( ( streak ) => streak.is_active )
-		.sort( ( a, b ) => b.current_streak - a.current_streak );
+	const dailyPostStreaks = [ ...( query.data?.pages[ 0 ]?.daily_post_streak ?? [] ) ].sort(
+		( a, b ) => b.current_streak - a.current_streak
+	);
 
 	return {
 		achievements: query.data?.pages.flatMap( ( p ) => p.achievements ?? [] ) ?? [],

--- a/client/reader/user-profile/views/achievements/achievements-grid/daily-post-streak-card.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/daily-post-streak-card.tsx
@@ -22,7 +22,7 @@ export default function DailyPostStreakCard( { streak }: { streak: DailyPostStre
 	const iconUrl = site?.icon?.img;
 
 	const iconNode = iconUrl ? (
-		<img className="achievement-card__icon" src={ iconUrl } alt="" />
+		<img className="achievement-card__icon achievement-card__icon--site" src={ iconUrl } alt="" />
 	) : (
 		<div className="achievement-card__icon achievement-card__icon--site-fallback">
 			<Icon icon={ globe } />

--- a/client/reader/user-profile/views/achievements/achievements-grid/daily-post-streak-card.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/daily-post-streak-card.tsx
@@ -1,0 +1,55 @@
+import { readFeedSiteQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import { Icon } from '@wordpress/components';
+import { globe } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import AchievementCard from './achievement-card';
+import type { DailyPostStreak } from '@automattic/api-core';
+
+function getHostname( url: string ): string {
+	try {
+		return new URL( url ).hostname;
+	} catch {
+		return url;
+	}
+}
+
+export default function DailyPostStreakCard( { streak }: { streak: DailyPostStreak } ) {
+	const translate = useTranslate();
+	const { data: site } = useQuery( readFeedSiteQuery( streak.blog_id ) );
+
+	const siteName = site?.name || site?.title || getHostname( streak.url );
+	const iconUrl = site?.icon?.img;
+
+	const iconNode = iconUrl ? (
+		<img className="achievement-card__icon" src={ iconUrl } alt="" />
+	) : (
+		<div className="achievement-card__icon achievement-card__icon--site-fallback">
+			<Icon icon={ globe } />
+		</div>
+	);
+
+	const description = translate(
+		'%(count)d-day streak on {{link}}%(siteName)s{{/link}}.',
+		'%(count)d-day streak on {{link}}%(siteName)s{{/link}}.',
+		{
+			count: streak.current_streak,
+			args: { count: streak.current_streak, siteName },
+			components: {
+				link: (
+					// eslint-disable-next-line jsx-a11y/anchor-has-content
+					<a href={ streak.url } target="_blank" rel="noopener noreferrer" />
+				),
+			},
+		}
+	);
+
+	return (
+		<AchievementCard
+			className="is-daily-post-streak"
+			iconNode={ iconNode }
+			title={ translate( 'Daily Post Streak' ) }
+			description={ description }
+		/>
+	);
+}

--- a/client/reader/user-profile/views/achievements/achievements-grid/daily-post-streak-card.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/daily-post-streak-card.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Icon } from '@wordpress/components';
 import { globe } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { getSiteName } from 'calypso/reader/get-helpers';
 import AchievementCard from './achievement-card';
 import type { DailyPostStreak } from '@automattic/api-core';
 
@@ -18,7 +19,7 @@ export default function DailyPostStreakCard( { streak }: { streak: DailyPostStre
 	const translate = useTranslate();
 	const { data: site } = useQuery( readFeedSiteQuery( streak.blog_id ) );
 
-	const siteName = site?.name || site?.title || getHostname( streak.url );
+	const siteName = ( site && getSiteName( { site } ) ) || getHostname( streak.url );
 	const iconUrl = site?.icon?.img;
 
 	const iconNode = iconUrl ? (

--- a/client/reader/user-profile/views/achievements/achievements-grid/index.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/index.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 import { useAchievementsQuery } from 'calypso/data/reader/use-achievements-query';
 import { deduplicateAchievementsById, deduplicateAchievementsBySlug } from '../utils';
 import AnniversaryAchievement from './anniversary-achievement';
+import DailyPostStreakCard from './daily-post-streak-card';
 import GenericAchievement from './generic-achievement';
 import LockedAchievementCard from './locked-achievement-card';
 import SecretAchievementCard from './secret-achievement-card';
@@ -23,6 +24,7 @@ export default function AchievementsGrid( { userLogin, isOwnProfile }: Achieveme
 		achievements,
 		lockedAchievements,
 		yearsOfService,
+		dailyPostStreaks,
 		isLoading,
 		isError,
 		hasNextPage,
@@ -44,7 +46,12 @@ export default function AchievementsGrid( { userLogin, isOwnProfile }: Achieveme
 		);
 	}
 
-	if ( ! achievements.length && ! lockedAchievements.length && ! yearsOfService ) {
+	if (
+		! achievements.length &&
+		! lockedAchievements.length &&
+		! yearsOfService &&
+		! dailyPostStreaks.length
+	) {
 		return <p className="achievements-grid__empty">{ translate( 'No achievements yet.' ) }</p>;
 	}
 
@@ -77,9 +84,10 @@ export default function AchievementsGrid( { userLogin, isOwnProfile }: Achieveme
 	);
 
 	const showYearsOfService = !! yearsOfService;
+	const showStreakCards = isOwnProfile && ( dailyPostStreaks?.length ?? 0 ) > 0;
 	const showCelebratory = isOwnProfile && earned.length > 0 && lockedAchievements.length === 0;
 	const showLockedSection = isOwnProfile && sortedLocked.length > 0;
-	const showEarnedGrid = sortedEarned.length > 0 || showYearsOfService;
+	const showEarnedGrid = sortedEarned.length > 0 || showYearsOfService || showStreakCards;
 
 	return (
 		<>
@@ -111,6 +119,10 @@ export default function AchievementsGrid( { userLogin, isOwnProfile }: Achieveme
 							/>
 						);
 					} ) }
+					{ showStreakCards &&
+						dailyPostStreaks.map( ( streak ) => (
+							<DailyPostStreakCard key={ streak.blog_id } streak={ streak } />
+						) ) }
 				</div>
 			) }
 

--- a/client/reader/user-profile/views/achievements/achievements-grid/index.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/index.tsx
@@ -96,6 +96,10 @@ export default function AchievementsGrid( { userLogin, isOwnProfile }: Achieveme
 					{ showYearsOfService && (
 						<YearsOfServiceAchievementCard yearsOfService={ yearsOfService } />
 					) }
+					{ showStreakCards &&
+						dailyPostStreaks.map( ( streak ) => (
+							<DailyPostStreakCard key={ streak.blog_id } streak={ streak } />
+						) ) }
 					{ sortedEarned.map( ( a ) => {
 						if ( a.is_redacted ) {
 							return (
@@ -119,10 +123,6 @@ export default function AchievementsGrid( { userLogin, isOwnProfile }: Achieveme
 							/>
 						);
 					} ) }
-					{ showStreakCards &&
-						dailyPostStreaks.map( ( streak ) => (
-							<DailyPostStreakCard key={ streak.blog_id } streak={ streak } />
-						) ) }
 				</div>
 			) }
 

--- a/client/reader/user-profile/views/achievements/achievements-grid/style.scss
+++ b/client/reader/user-profile/views/achievements/achievements-grid/style.scss
@@ -169,7 +169,12 @@
 		}
 	}
 
-	.achievement-card__icon--lock {
+	.achievement-card__icon--site {
+		border-radius: 50%;
+	}
+
+	.achievement-card__icon--lock,
+	.achievement-card__icon--site-fallback {
 		align-items: center;
 		background: var( --studio-gray-5 );
 		border-radius: 50%;

--- a/client/reader/user-profile/views/achievements/achievements-grid/style.scss
+++ b/client/reader/user-profile/views/achievements/achievements-grid/style.scss
@@ -169,7 +169,9 @@
 		}
 	}
 
-	.achievement-card__icon--site {
+	.achievement-card__icon--site,
+	.achievement-card__icon--lock,
+	.achievement-card__icon--site-fallback {
 		border-radius: 50%;
 	}
 
@@ -177,12 +179,9 @@
 	.achievement-card__icon--site-fallback {
 		align-items: center;
 		background: var( --studio-gray-5 );
-		border-radius: 50%;
 		color: var( --studio-gray-40 );
 		display: flex;
-		height: 60px;
 		justify-content: center;
-		width: 60px;
 
 		svg,
 		path {

--- a/client/reader/user-profile/views/achievements/achievements-grid/test/daily-post-streak-card.test.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/test/daily-post-streak-card.test.tsx
@@ -19,9 +19,6 @@ const streak = ( overrides = {} ) => ( {
 	blog_id: 12345,
 	url: 'https://side-project.example.com',
 	current_streak: 14,
-	last_check_date: '2026-05-27',
-	oldest_post_date: '2026-05-14 09:12:34',
-	is_active: true,
 	...overrides,
 } );
 

--- a/client/reader/user-profile/views/achievements/achievements-grid/test/daily-post-streak-card.test.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/test/daily-post-streak-card.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import wpcom from 'calypso/lib/wp';
+import DailyPostStreakCard from '../daily-post-streak-card';
+
+jest.mock( 'calypso/lib/wp', () => ( {
+	req: {
+		get: jest.fn(),
+	},
+} ) );
+
+const mockGet = jest.mocked( wpcom.req.get );
+
+const streak = ( overrides = {} ) => ( {
+	blog_id: 12345,
+	url: 'https://side-project.example.com',
+	current_streak: 14,
+	last_check_date: '2026-05-27',
+	oldest_post_date: '2026-05-14 09:12:34',
+	is_active: true,
+	...overrides,
+} );
+
+function renderCard( props: { streak: ReturnType< typeof streak > } ) {
+	const client = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+	return render(
+		<QueryClientProvider client={ client }>
+			<DailyPostStreakCard { ...props } />
+		</QueryClientProvider>
+	);
+}
+
+describe( 'DailyPostStreakCard', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'renders the static "Daily Post Streak" card title', () => {
+		mockGet.mockReturnValue( new Promise( () => {} ) );
+
+		renderCard( { streak: streak() } );
+
+		expect( screen.getByRole( 'heading', { name: 'Daily Post Streak' } ) ).toBeVisible();
+	} );
+
+	test( 'renders the description with the day count and site link', async () => {
+		mockGet.mockResolvedValue( {
+			ID: 12345,
+			URL: 'https://side-project.example.com',
+			name: 'Side Project Blog',
+		} );
+
+		renderCard( { streak: streak() } );
+
+		const link = await screen.findByRole( 'link', { name: 'Side Project Blog' } );
+		expect( link ).toHaveAttribute( 'href', 'https://side-project.example.com' );
+		expect( link ).toHaveAttribute( 'target', '_blank' );
+		expect( link ).toHaveAttribute( 'rel', expect.stringContaining( 'noopener' ) );
+
+		const description = link.closest( '.achievement-card__description' );
+		expect( description ).not.toBeNull();
+		expect( description ).toHaveTextContent( '14-day streak on Side Project Blog' );
+	} );
+
+	test( 'uses the URL hostname inside the description link while the site query is loading', () => {
+		mockGet.mockReturnValue( new Promise( () => {} ) );
+
+		renderCard( { streak: streak() } );
+
+		const link = screen.getByRole( 'link', { name: 'side-project.example.com' } );
+		expect( link ).toHaveAttribute( 'href', 'https://side-project.example.com' );
+	} );
+
+	test( 'renders the site icon image when the site query returns one', async () => {
+		mockGet.mockResolvedValue( {
+			ID: 12345,
+			URL: 'https://side-project.example.com',
+			name: 'Side Project Blog',
+			icon: { img: 'https://i0.wp.com/icon.png', ico: '' },
+		} );
+
+		const { container } = renderCard( { streak: streak() } );
+
+		await screen.findByRole( 'link', { name: 'Side Project Blog' } );
+
+		const img = container.querySelector( 'img.achievement-card__icon' ) as HTMLImageElement | null;
+		expect( img ).not.toBeNull();
+		expect( img?.src ).toBe( 'https://i0.wp.com/icon.png' );
+	} );
+
+	test( 'renders a globe fallback icon when no site icon is available', () => {
+		mockGet.mockReturnValue( new Promise( () => {} ) );
+
+		const { container } = renderCard( { streak: streak() } );
+
+		expect( container.querySelector( 'img.achievement-card__icon' ) ).toBeNull();
+		expect(
+			container.querySelector( '.achievement-card__icon--site-fallback svg' )
+		).not.toBeNull();
+	} );
+} );

--- a/client/reader/user-profile/views/achievements/achievements-grid/test/daily-post-streak-card.test.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/test/daily-post-streak-card.test.tsx
@@ -3,7 +3,6 @@
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
-import React from 'react';
 import wpcom from 'calypso/lib/wp';
 import DailyPostStreakCard from '../daily-post-streak-card';
 
@@ -48,7 +47,7 @@ describe( 'DailyPostStreakCard', () => {
 		mockGet.mockResolvedValue( {
 			ID: 12345,
 			URL: 'https://side-project.example.com',
-			name: 'Side Project Blog',
+			title: 'Side Project Blog',
 		} );
 
 		renderCard( { streak: streak() } );
@@ -72,11 +71,24 @@ describe( 'DailyPostStreakCard', () => {
 		expect( link ).toHaveAttribute( 'href', 'https://side-project.example.com' );
 	} );
 
+	test( 'decodes HTML entities in the site title', async () => {
+		mockGet.mockResolvedValue( {
+			ID: 12345,
+			URL: 'https://side-project.example.com',
+			title: 'Joe&#039;s &amp; Jane&#039;s Blog',
+		} );
+
+		renderCard( { streak: streak() } );
+
+		const link = await screen.findByRole( 'link', { name: "Joe's & Jane's Blog" } );
+		expect( link ).toHaveAttribute( 'href', 'https://side-project.example.com' );
+	} );
+
 	test( 'renders the site icon image when the site query returns one', async () => {
 		mockGet.mockResolvedValue( {
 			ID: 12345,
 			URL: 'https://side-project.example.com',
-			name: 'Side Project Blog',
+			title: 'Side Project Blog',
 			icon: { img: 'https://i0.wp.com/icon.png', ico: '' },
 		} );
 

--- a/client/reader/user-profile/views/achievements/achievements-grid/test/index.test.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/test/index.test.tsx
@@ -4,6 +4,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, within } from '@testing-library/react';
 import React from 'react';
+import { useAchievementsQuery } from 'calypso/data/reader/use-achievements-query';
 import AchievementsGrid from '../index';
 
 jest.mock( 'calypso/data/reader/use-achievements-query' );
@@ -19,9 +20,7 @@ jest.mock( '../daily-post-streak-card', () => ( {
 	),
 } ) );
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const useAchievementsQuery = require( 'calypso/data/reader/use-achievements-query' )
-	.useAchievementsQuery as jest.Mock;
+const mockUseAchievementsQuery = useAchievementsQuery as jest.Mock;
 
 const earned = ( overrides: Record< string, unknown > = {} ) => ( {
 	achievement_id: 1,
@@ -98,7 +97,7 @@ describe( 'AchievementsGrid', () => {
 	} );
 
 	test( 'renders the empty copy when both grids are empty', () => {
-		useAchievementsQuery.mockReturnValue( { ...baseQueryReturn } );
+		mockUseAchievementsQuery.mockReturnValue( { ...baseQueryReturn } );
 
 		renderGrid( { userLogin: 'me', isOwnProfile: true } );
 
@@ -107,7 +106,7 @@ describe( 'AchievementsGrid', () => {
 	} );
 
 	test( 'renders earned grid only when not own profile and no locked', () => {
-		useAchievementsQuery.mockReturnValue( {
+		mockUseAchievementsQuery.mockReturnValue( {
 			...baseQueryReturn,
 			achievements: [ earned() ],
 		} );
@@ -120,7 +119,7 @@ describe( 'AchievementsGrid', () => {
 	} );
 
 	test( 'renders the locked section heading and locked cards on own profile', () => {
-		useAchievementsQuery.mockReturnValue( {
+		mockUseAchievementsQuery.mockReturnValue( {
 			...baseQueryReturn,
 			achievements: [ earned() ],
 			lockedAchievements: [ locked() ],
@@ -134,7 +133,7 @@ describe( 'AchievementsGrid', () => {
 	} );
 
 	test( 'hides the locked section on cross-user view even if API returns locked', () => {
-		useAchievementsQuery.mockReturnValue( {
+		mockUseAchievementsQuery.mockReturnValue( {
 			...baseQueryReturn,
 			achievements: [ earned() ],
 			lockedAchievements: [ locked() ],
@@ -149,7 +148,7 @@ describe( 'AchievementsGrid', () => {
 	} );
 
 	test( 'renders celebratory message when own profile, has earned, and zero locked', () => {
-		useAchievementsQuery.mockReturnValue( {
+		mockUseAchievementsQuery.mockReturnValue( {
 			...baseQueryReturn,
 			achievements: [ earned() ],
 			lockedAchievements: [],
@@ -164,7 +163,7 @@ describe( 'AchievementsGrid', () => {
 	} );
 
 	test( 'hides celebratory message on cross-user view', () => {
-		useAchievementsQuery.mockReturnValue( {
+		mockUseAchievementsQuery.mockReturnValue( {
 			...baseQueryReturn,
 			achievements: [ earned() ],
 			lockedAchievements: [],
@@ -176,7 +175,7 @@ describe( 'AchievementsGrid', () => {
 	} );
 
 	test( 'renders locked secret with the secret title', () => {
-		useAchievementsQuery.mockReturnValue( {
+		mockUseAchievementsQuery.mockReturnValue( {
 			...baseQueryReturn,
 			achievements: [ earned() ],
 			lockedAchievements: [ lockedSecret() ],
@@ -188,7 +187,7 @@ describe( 'AchievementsGrid', () => {
 	} );
 
 	test( 'renders masked secret in earned list with caption Unlocked: <time>', () => {
-		useAchievementsQuery.mockReturnValue( {
+		mockUseAchievementsQuery.mockReturnValue( {
 			...baseQueryReturn,
 			achievements: [ earned(), maskedSecret() ],
 			lockedAchievements: [],
@@ -202,7 +201,7 @@ describe( 'AchievementsGrid', () => {
 	} );
 
 	test( 'sorts earned + masked-secret entries by last unlock date descending', () => {
-		useAchievementsQuery.mockReturnValue( {
+		mockUseAchievementsQuery.mockReturnValue( {
 			...baseQueryReturn,
 			achievements: [
 				maskedSecret( { achievement_id: 2, date_unlocked: '2026-01-01' } ),
@@ -232,7 +231,7 @@ describe( 'AchievementsGrid', () => {
 	} );
 
 	test( 'sorts a leveled slug by its most recent unlock, not its first', () => {
-		useAchievementsQuery.mockReturnValue( {
+		mockUseAchievementsQuery.mockReturnValue( {
 			...baseQueryReturn,
 			achievements: [
 				earned( {
@@ -264,7 +263,7 @@ describe( 'AchievementsGrid', () => {
 	} );
 
 	test( 'sorts locked entries by date_created ascending', () => {
-		useAchievementsQuery.mockReturnValue( {
+		mockUseAchievementsQuery.mockReturnValue( {
 			...baseQueryReturn,
 			achievements: [ earned() ],
 			lockedAchievements: [
@@ -285,7 +284,7 @@ describe( 'AchievementsGrid', () => {
 	} );
 
 	test( 'new-user own profile with only locked entries renders the locked grid only', () => {
-		useAchievementsQuery.mockReturnValue( {
+		mockUseAchievementsQuery.mockReturnValue( {
 			...baseQueryReturn,
 			achievements: [],
 			lockedAchievements: [ locked() ],
@@ -299,7 +298,7 @@ describe( 'AchievementsGrid', () => {
 	} );
 
 	test( 'dedupes masked secrets in the earned list by achievement_id', () => {
-		useAchievementsQuery.mockReturnValue( {
+		mockUseAchievementsQuery.mockReturnValue( {
 			...baseQueryReturn,
 			achievements: [
 				earned(),
@@ -315,7 +314,7 @@ describe( 'AchievementsGrid', () => {
 	} );
 
 	test( 'dedupes locked entries by achievement_id', () => {
-		useAchievementsQuery.mockReturnValue( {
+		mockUseAchievementsQuery.mockReturnValue( {
 			...baseQueryReturn,
 			achievements: [ earned() ],
 			lockedAchievements: [
@@ -331,7 +330,7 @@ describe( 'AchievementsGrid', () => {
 
 	test( 'renders earned achievements from a legacy response that omits is_secret', () => {
 		const { is_secret: _omit, ...legacy } = earned();
-		useAchievementsQuery.mockReturnValue( {
+		mockUseAchievementsQuery.mockReturnValue( {
 			...baseQueryReturn,
 			achievements: [ legacy ],
 			lockedAchievements: [],
@@ -344,7 +343,7 @@ describe( 'AchievementsGrid', () => {
 	} );
 
 	test( 'renders a self-read earned secret (is_secret: true with full payload) as a regular card', () => {
-		useAchievementsQuery.mockReturnValue( {
+		mockUseAchievementsQuery.mockReturnValue( {
 			...baseQueryReturn,
 			achievements: [
 				earned( {
@@ -366,7 +365,7 @@ describe( 'AchievementsGrid', () => {
 	} );
 
 	test( 'prepends a Years of Service card when yearsOfService > 0', () => {
-		useAchievementsQuery.mockReturnValue( {
+		mockUseAchievementsQuery.mockReturnValue( {
 			...baseQueryReturn,
 			achievements: [ earned() ],
 			yearsOfService: 5,
@@ -388,7 +387,7 @@ describe( 'AchievementsGrid', () => {
 	} );
 
 	test( 'pluralizes the Years of Service description for 1 year', () => {
-		useAchievementsQuery.mockReturnValue( {
+		mockUseAchievementsQuery.mockReturnValue( {
 			...baseQueryReturn,
 			achievements: [ earned() ],
 			yearsOfService: 1,
@@ -400,7 +399,7 @@ describe( 'AchievementsGrid', () => {
 	} );
 
 	test( 'omits the Years of Service card when yearsOfService is 0 or undefined', () => {
-		useAchievementsQuery.mockReturnValue( {
+		mockUseAchievementsQuery.mockReturnValue( {
 			...baseQueryReturn,
 			achievements: [ earned() ],
 			yearsOfService: 0,
@@ -412,7 +411,7 @@ describe( 'AchievementsGrid', () => {
 	} );
 
 	test( 'still surfaces the Years of Service card when there are no other achievements', () => {
-		useAchievementsQuery.mockReturnValue( {
+		mockUseAchievementsQuery.mockReturnValue( {
 			...baseQueryReturn,
 			achievements: [],
 			lockedAchievements: [],
@@ -426,7 +425,7 @@ describe( 'AchievementsGrid', () => {
 	} );
 
 	test( 'renders daily post streak cards on own profile before any earned achievements', () => {
-		useAchievementsQuery.mockReturnValue( {
+		mockUseAchievementsQuery.mockReturnValue( {
 			...baseQueryReturn,
 			achievements: [ earned() ],
 			dailyPostStreaks: [
@@ -457,7 +456,7 @@ describe( 'AchievementsGrid', () => {
 	} );
 
 	test( 'renders daily post streak cards immediately after the Years of Service card', () => {
-		useAchievementsQuery.mockReturnValue( {
+		mockUseAchievementsQuery.mockReturnValue( {
 			...baseQueryReturn,
 			achievements: [ earned() ],
 			yearsOfService: 5,
@@ -474,7 +473,7 @@ describe( 'AchievementsGrid', () => {
 	} );
 
 	test( 'hides daily post streak cards on cross-user view', () => {
-		useAchievementsQuery.mockReturnValue( {
+		mockUseAchievementsQuery.mockReturnValue( {
 			...baseQueryReturn,
 			achievements: [ earned() ],
 			dailyPostStreaks: [ streak() ],
@@ -486,7 +485,7 @@ describe( 'AchievementsGrid', () => {
 	} );
 
 	test( 'renders the unlocked grid for an own profile with only streaks', () => {
-		useAchievementsQuery.mockReturnValue( {
+		mockUseAchievementsQuery.mockReturnValue( {
 			...baseQueryReturn,
 			achievements: [],
 			lockedAchievements: [],
@@ -500,7 +499,7 @@ describe( 'AchievementsGrid', () => {
 	} );
 
 	test( 'shows the loading spinner while pages are still being fetched', () => {
-		useAchievementsQuery.mockReturnValue( {
+		mockUseAchievementsQuery.mockReturnValue( {
 			...baseQueryReturn,
 			isLoading: true,
 		} );

--- a/client/reader/user-profile/views/achievements/achievements-grid/test/index.test.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/test/index.test.tsx
@@ -69,9 +69,6 @@ const streak = ( overrides: Record< string, unknown > = {} ) => ( {
 	blog_id: 111,
 	url: 'https://my-blog.example.com',
 	current_streak: 7,
-	last_check_date: '2026-05-27',
-	oldest_post_date: '2026-05-21 09:00:00',
-	is_active: true,
 	...overrides,
 } );
 
@@ -428,7 +425,7 @@ describe( 'AchievementsGrid', () => {
 		expect( screen.queryByText( 'No achievements yet.' ) ).not.toBeInTheDocument();
 	} );
 
-	test( 'renders daily post streak cards on own profile, appended to the unlocked grid', () => {
+	test( 'renders daily post streak cards on own profile before any earned achievements', () => {
 		useAchievementsQuery.mockReturnValue( {
 			...baseQueryReturn,
 			achievements: [ earned() ],
@@ -452,11 +449,28 @@ describe( 'AchievementsGrid', () => {
 			'222',
 		] );
 
-		const allCards = earnedGrid?.children;
-		const lastTwo = Array.from( allCards ?? [] ).slice( -2 );
+		const allCards = Array.from( earnedGrid?.children ?? [] );
+		const firstTwo = allCards.slice( 0, 2 );
 		expect(
-			lastTwo.every( ( el ) => el.getAttribute( 'data-testid' ) === 'daily-post-streak-card' )
+			firstTwo.every( ( el ) => el.getAttribute( 'data-testid' ) === 'daily-post-streak-card' )
 		).toBe( true );
+	} );
+
+	test( 'renders daily post streak cards immediately after the Years of Service card', () => {
+		useAchievementsQuery.mockReturnValue( {
+			...baseQueryReturn,
+			achievements: [ earned() ],
+			yearsOfService: 5,
+			dailyPostStreaks: [ streak( { blog_id: 111 } ) ],
+		} );
+
+		const { container } = renderGrid( { userLogin: 'me', isOwnProfile: true } );
+
+		const earnedGrid = container.querySelector( '.achievements-grid' );
+		const cards = Array.from( earnedGrid?.children ?? [] );
+
+		expect( cards[ 0 ]?.classList.contains( 'is-years-of-service' ) ).toBe( true );
+		expect( cards[ 1 ]?.getAttribute( 'data-testid' ) ).toBe( 'daily-post-streak-card' );
 	} );
 
 	test( 'hides daily post streak cards on cross-user view', () => {

--- a/client/reader/user-profile/views/achievements/achievements-grid/test/index.test.tsx
+++ b/client/reader/user-profile/views/achievements/achievements-grid/test/index.test.tsx
@@ -8,6 +8,17 @@ import AchievementsGrid from '../index';
 
 jest.mock( 'calypso/data/reader/use-achievements-query' );
 
+jest.mock( '../daily-post-streak-card', () => ( {
+	__esModule: true,
+	default: ( { streak }: { streak: { blog_id: number; current_streak: number } } ) => (
+		<div
+			data-testid="daily-post-streak-card"
+			data-blog-id={ streak.blog_id }
+			data-current-streak={ streak.current_streak }
+		/>
+	),
+} ) );
+
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const useAchievementsQuery = require( 'calypso/data/reader/use-achievements-query' )
 	.useAchievementsQuery as jest.Mock;
@@ -54,9 +65,20 @@ const lockedSecret = ( overrides: Record< string, unknown > = {} ) => ( {
 	...overrides,
 } );
 
+const streak = ( overrides: Record< string, unknown > = {} ) => ( {
+	blog_id: 111,
+	url: 'https://my-blog.example.com',
+	current_streak: 7,
+	last_check_date: '2026-05-27',
+	oldest_post_date: '2026-05-21 09:00:00',
+	is_active: true,
+	...overrides,
+} );
+
 const baseQueryReturn = {
 	achievements: [],
 	lockedAchievements: [],
+	dailyPostStreaks: [],
 	isLoading: false,
 	isError: false,
 	hasNextPage: false,
@@ -404,6 +426,63 @@ describe( 'AchievementsGrid', () => {
 
 		expect( screen.getByText( 'Years of Service' ) ).toBeVisible();
 		expect( screen.queryByText( 'No achievements yet.' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'renders daily post streak cards on own profile, appended to the unlocked grid', () => {
+		useAchievementsQuery.mockReturnValue( {
+			...baseQueryReturn,
+			achievements: [ earned() ],
+			dailyPostStreaks: [
+				streak( { blog_id: 111, current_streak: 14 } ),
+				streak( { blog_id: 222, current_streak: 4 } ),
+			],
+		} );
+
+		const { container } = renderGrid( { userLogin: 'me', isOwnProfile: true } );
+
+		const earnedGrid = container.querySelector( '.achievements-grid' );
+		expect( earnedGrid ).not.toBeNull();
+
+		const streakCards = within( earnedGrid as HTMLElement ).getAllByTestId(
+			'daily-post-streak-card'
+		);
+		expect( streakCards ).toHaveLength( 2 );
+		expect( streakCards.map( ( c ) => c.getAttribute( 'data-blog-id' ) ) ).toEqual( [
+			'111',
+			'222',
+		] );
+
+		const allCards = earnedGrid?.children;
+		const lastTwo = Array.from( allCards ?? [] ).slice( -2 );
+		expect(
+			lastTwo.every( ( el ) => el.getAttribute( 'data-testid' ) === 'daily-post-streak-card' )
+		).toBe( true );
+	} );
+
+	test( 'hides daily post streak cards on cross-user view', () => {
+		useAchievementsQuery.mockReturnValue( {
+			...baseQueryReturn,
+			achievements: [ earned() ],
+			dailyPostStreaks: [ streak() ],
+		} );
+
+		renderGrid( { userLogin: 'someone', isOwnProfile: false } );
+
+		expect( screen.queryByTestId( 'daily-post-streak-card' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'renders the unlocked grid for an own profile with only streaks', () => {
+		useAchievementsQuery.mockReturnValue( {
+			...baseQueryReturn,
+			achievements: [],
+			lockedAchievements: [],
+			dailyPostStreaks: [ streak() ],
+		} );
+
+		renderGrid( { userLogin: 'me', isOwnProfile: true } );
+
+		expect( screen.queryByText( 'No achievements yet.' ) ).not.toBeInTheDocument();
+		expect( screen.getByTestId( 'daily-post-streak-card' ) ).toBeInTheDocument();
 	} );
 
 	test( 'shows the loading spinner while pages are still being fetched', () => {

--- a/packages/api-core/src/read-achievements/types.ts
+++ b/packages/api-core/src/read-achievements/types.ts
@@ -121,19 +121,13 @@ export interface EngagementStreak {
 
 /**
  * A per-site daily-post streak: a contiguous run of days on which the user
- * published at least one post on the given blog. The endpoint filters expired
- * streaks older than ~1 year and returns active and recently-active entries.
- * Self-reads only.
+ * published at least one post on the given blog. The endpoint returns only
+ * currently-active streaks. Self-reads only.
  */
 export interface DailyPostStreak {
 	blog_id: number;
 	url: string;
 	current_streak: number;
-	/** Y-m-d in the site's timezone. */
-	last_check_date: string;
-	/** Y-m-d H:i:s — the date the first post in the current streak was published. */
-	oldest_post_date: string;
-	is_active: boolean;
 }
 
 export interface AchievementsResponse {

--- a/packages/api-core/src/read-achievements/types.ts
+++ b/packages/api-core/src/read-achievements/types.ts
@@ -119,6 +119,23 @@ export interface EngagementStreak {
 	days?: EngagementStreakDay[];
 }
 
+/**
+ * A per-site daily-post streak: a contiguous run of days on which the user
+ * published at least one post on the given blog. The endpoint filters expired
+ * streaks older than ~1 year and returns active and recently-active entries.
+ * Self-reads only.
+ */
+export interface DailyPostStreak {
+	blog_id: number;
+	url: string;
+	current_streak: number;
+	/** Y-m-d in the site's timezone. */
+	last_check_date: string;
+	/** Y-m-d H:i:s — the date the first post in the current streak was published. */
+	oldest_post_date: string;
+	is_active: boolean;
+}
+
 export interface AchievementsResponse {
 	found: number;
 	achievements: EarnedAchievementEntry[];
@@ -127,4 +144,6 @@ export interface AchievementsResponse {
 	years_of_service?: number;
 	/** Activity streak data. */
 	engagement_streak?: EngagementStreak;
+	/** Self-reads only. Per-site daily-post streaks. Not paginated. */
+	daily_post_streak?: DailyPostStreak[];
 }


### PR DESCRIPTION
Part of RSM-3922

## Proposed Changes

<img width="1257" height="411" alt="Screenshot 2026-05-27 at 17 30 48" src="https://github.com/user-attachments/assets/145b22cc-22e6-4d3c-88ae-16e282b8af29" />


* New per-site daily-post streak cards on the Achievements page. Each card uses the existing `AchievementCard`, with the static "Daily Post Streak" title, a description like `14-day streak on [Site Name]` linking to the site, and the site favicon (or a gray globe fallback while the site query loads).
* Streak cards render only on own-profile views, immediately after the Years of Service card and before earned achievements.
* `DailyPostStreak` type added to `@automattic/api-core` and exposed through `useAchievementsQuery` as a `dailyPostStreaks` array sorted by `current_streak` descending. The backend already returns only active streaks, so the client does no filtering.
* Site identity (name + icon) is resolved per card via `readFeedSiteQuery(blog_id)`. Until the query resolves, the URL hostname is used as the link text.
* CSS modifier classes `--site` (circular favicon crop) and `--site-fallback` (gray-circle placeholder) added to `achievement-card`.

## Why are these changes being made?

The Achievements page already surfaces a single per-user activity streak. Daily post streaks are per-site and track only post-publish — different conceptually, but worth surfacing alongside other "things you have" so users can see all their active streaks in one place.

## Testing Instructions

1. Open your own Reader profile's Achievements tab. If you have one or more active daily-post streaks, they should appear right after the Years of Service card (or at the very top if there's no Years of Service card) and before any earned achievements.
2. The card title reads "Daily Post Streak"; the description reads "X-day streak on [Site Name]." with the site name linked to the site (opens in a new tab).
3. The card icon is the site favicon (circular). If the site has no favicon, a gray globe is shown.
4. Open another user's profile — daily post streaks should not appear.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?