### PR TITLE
Backup: restore internal scroll on contents file browser + clone flow (regression from #109899)

### DIFF
--- a/client/components/jetpack-page-layout/_admin-ui-page.scss
+++ b/client/components/jetpack-page-layout/_admin-ui-page.scss
@@ -23,67 +23,65 @@
 	}
 }
 
-// Stick the Jetpack footer to the viewport bottom while letting the page
-// body absorb remaining vertical space. Flex chain runs
-// .layout__content → .layout__primary → .main, with the footer pinned via
-// `position: fixed` and width-matched to the content column on desktop.
+// Clamp the primary to the viewport so the Jetpack footer can pin to the
+// bottom and the page body scrolls internally — independent of the shell's
+// (sometimes tall) sidebar. `.main` is the generic scroll container, so pages
+// need no per-page scroll hacks; on migrated pages the admin-ui `<Page>` fills
+// `.main` exactly and scrolls itself, leaving this overflow inert.
+//
+// Gated off Jetpack Cloud / A8C-for-Agencies: those shells render no footer,
+// use a fixed sidebar, and clamp `.layout__content` to the viewport — there we
+// just release the overflow and let the page scroll naturally.
 // Usage: @include admin-ui-page-sticky-footer;
 // Must be called inside a `body.is-section-<name>` selector.
 @mixin admin-ui-page-sticky-footer {
-	.layout__content {
-		display: flex;
-
-		.layout__primary {
-			flex: 1;
+	&:not(.theme-jetpack-cloud):not(.theme-a8c-for-agencies) {
+		.layout__content {
 			display: flex;
-			position: fixed;
-			top: var( --masterbar-height );
-			height: calc(100vh - var(--masterbar-height));
-			width: 100vw;
 
-			// Jetpack Cloud uses 100vh except on mobile where it shows a sidebar navigation on top (73px)
-			&:has(header.current-section) {
-				height: calc(100vh - 73px);
+			.layout__primary {
+				flex: 1;
+				display: flex;
+				position: fixed;
+				top: var( --masterbar-height );
+				height: calc(100vh - var(--masterbar-height));
+				width: 100vw;
+
 				@include break-medium {
-					height: 100vh;
+					width: calc(100vw - var(--sidebar-width-max));
 				}
-			}
 
-			@include break-medium {
-				width: calc(100vw - var(--sidebar-width-max));
-			}
+				.main {
+					flex-grow: 1;
+					position: relative;
+					margin-block: 0;
+					overflow-y: auto;
 
-			.main {
-				flex-grow: 1;
-				position: relative;
-				margin-block: 0;
-
-				@include break-medium {
-					body.theme-jetpack-cloud &,
-					body.theme-a8c-for-agencies & {
-						margin-block: var(--wpds-dimension-padding-2xl);
+					// Reserve room for the fixed footer when one is rendered.
+					&:has(> .jetpack-footer) {
+						padding-bottom: 65px;
 					}
-				}
 
-				// Only reserve bottom space when a Jetpack footer is actually
-				// rendered. Pages without a footer (e.g. Jetpack Cloud views)
-				// get the fixed-primary structural hack without the wasted
-				// padding.
-				&:has(> .jetpack-footer) {
-					padding-bottom: 65px;
-				}
+					.jetpack-footer {
+						position: fixed;
+						z-index: 1;
+						bottom: 0;
+						background-color: var(--wpds-color-bg-surface-neutral);
 
-				.jetpack-footer {
-					position: fixed;
-					z-index: 1;
-					bottom: 0;
-					background-color: var(--wpds-color-bg-surface-neutral);
-
-					@include break-medium {
-						max-width: calc(100% - var(--sidebar-width-max));
+						@include break-medium {
+							max-width: calc(100% - var(--sidebar-width-max));
+						}
 					}
 				}
 			}
+		}
+	}
+
+	// Jetpack Cloud / A4A: scroll naturally; release the shell's overflow clamp.
+	&.theme-jetpack-cloud,
+	&.theme-a8c-for-agencies {
+		.layout__content {
+			overflow: visible;
 		}
 	}
 }

--- a/client/my-sites/backup/backup-contents-page/style.scss
+++ b/client/my-sites/backup/backup-contents-page/style.scss
@@ -6,29 +6,8 @@
 }
 
 .backup-contents-page {
-	// BACKUP-392: the #109899 fixed-primary layout clamps `.main` to the
-	// viewport height while `.layout__content` hides overflow, so a long file
-	// list was clipped off-screen with no scrollbar. Turn the page into a
-	// constrained flex column (.main -> .card -> .__body) so the file list
-	// scrolls internally instead of overflowing.
-	&.main {
-		display: flex;
-		flex-direction: column;
-		min-height: 0;
-	}
-
 	.card {
 		padding: 24px 22px;
-		// Fill the height left below the back-button and host the flex
-		// context for the (fixed) status header + the scrollable body.
-		flex: 1 1 auto;
-		min-height: 0;
-		display: flex;
-		flex-direction: column;
-		overflow: hidden;
-		// Neutralise the base Card's auto inline margins, which would
-		// otherwise center and shrink the card once it becomes a flex item.
-		margin-inline: 0;
 	}
 
 	&__back-button.components-button.is-link {
@@ -79,8 +58,8 @@
 	}
 
 	&__header {
-		// Keep the status card at its natural height; only the body scrolls.
-		flex: 0 0 auto;
+		// TODO: migrate this page to the admin-ui <Page>.
+		background: var(--color-surface);
 		padding-left: 2px;
 		padding-right: 2px;
 
@@ -97,11 +76,6 @@
 	&__body {
 		overflow-x: auto;
 		padding-bottom: 14px;
-		// Fill the remaining card height and scroll the file list vertically
-		// (the core of the BACKUP-392 fix).
-		flex: 1 1 auto;
-		min-height: 0;
-		overflow-y: auto;
 	}
 
 	.file-browser-node {

--- a/client/my-sites/backup/backup-contents-page/style.scss
+++ b/client/my-sites/backup/backup-contents-page/style.scss
@@ -6,8 +6,29 @@
 }
 
 .backup-contents-page {
+	// BACKUP-392: the #109899 fixed-primary layout clamps `.main` to the
+	// viewport height while `.layout__content` hides overflow, so a long file
+	// list was clipped off-screen with no scrollbar. Turn the page into a
+	// constrained flex column (.main -> .card -> .__body) so the file list
+	// scrolls internally instead of overflowing.
+	&.main {
+		display: flex;
+		flex-direction: column;
+		min-height: 0;
+	}
+
 	.card {
 		padding: 24px 22px;
+		// Fill the height left below the back-button and host the flex
+		// context for the (fixed) status header + the scrollable body.
+		flex: 1 1 auto;
+		min-height: 0;
+		display: flex;
+		flex-direction: column;
+		overflow: hidden;
+		// Neutralise the base Card's auto inline margins, which would
+		// otherwise center and shrink the card once it becomes a flex item.
+		margin-inline: 0;
 	}
 
 	&__back-button.components-button.is-link {
@@ -58,6 +79,8 @@
 	}
 
 	&__header {
+		// Keep the status card at its natural height; only the body scrolls.
+		flex: 0 0 auto;
 		padding-left: 2px;
 		padding-right: 2px;
 
@@ -74,6 +97,11 @@
 	&__body {
 		overflow-x: auto;
 		padding-bottom: 14px;
+		// Fill the remaining card height and scroll the file list vertically
+		// (the core of the BACKUP-392 fix).
+		flex: 1 1 auto;
+		min-height: 0;
+		overflow-y: auto;
 	}
 
 	.file-browser-node {

--- a/client/my-sites/backup/clone-flow/style.scss
+++ b/client/my-sites/backup/clone-flow/style.scss
@@ -12,22 +12,8 @@
 	}
 }
 
-// BACKUP-394: same #109899 fixed-primary regression as the contents page —
-// the clone flow renders in `<Main className="clone-flow">` with no internal
-// scroll container, so Step 2's clone-point list was clipped with no
-// scrollbar. Make `.main` a flex column and let `.clone-flow__content` absorb
-// the remaining height and scroll vertically.
-.clone-flow.main {
-	display: flex;
-	flex-direction: column;
-	min-height: 0;
-}
-
 .clone-flow__content {
 	margin-top: 16px;
-	flex: 1 1 auto;
-	min-height: 0;
-	overflow-y: auto;
 }
 
 .clone-flow__title {

--- a/client/my-sites/backup/clone-flow/style.scss
+++ b/client/my-sites/backup/clone-flow/style.scss
@@ -12,8 +12,22 @@
 	}
 }
 
+// BACKUP-394: same #109899 fixed-primary regression as the contents page —
+// the clone flow renders in `<Main className="clone-flow">` with no internal
+// scroll container, so Step 2's clone-point list was clipped with no
+// scrollbar. Make `.main` a flex column and let `.clone-flow__content` absorb
+// the remaining height and scroll vertically.
+.clone-flow.main {
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
+}
+
 .clone-flow__content {
 	margin-top: 16px;
+	flex: 1 1 auto;
+	min-height: 0;
+	overflow-y: auto;
 }
 
 .clone-flow__title {


### PR DESCRIPTION
Fixes BACKUP-392
Fixes BACKUP-394

## Proposed Changes

Restores vertical scrolling on two Jetpack Backup screens that lost it after #109899 — the **contents file browser** (`/backup/:site/contents/:id`, BACKUP-392) and the **Copy Site / clone flow** (`/backup/:site/clone`, BACKUP-394) — from a **single place** rather than per-page hacks, so it behaves consistently across **wp-admin, Calypso, Jetpack Cloud, and A8C-for-Agencies**.

The fix lives in `admin-ui-page-sticky-footer` (`_admin-ui-page.scss`):

- **wp-admin / Calypso** (`:not(.theme-jetpack-cloud):not(.theme-a8c-for-agencies)`): clamp `.layout__primary` to the viewport and make `.main` the **generic** scroll container. Content scrolls independently of the (sometimes tall) shell sidebar, and the Jetpack footer can stay pinned. Pages already migrated to `@wordpress/admin-ui` `<Page>` fill `.main` exactly and scroll inside their own `.admin-ui-page__content`, so the `.main` overflow is inert for them.
- **Jetpack Cloud / A8C-for-Agencies** (`.theme-jetpack-cloud, .theme-a8c-for-agencies`): no footer to pin and a fixed-sidebar shell, so just release the overflow clamp and let the page scroll naturally.

Because `.main` is now the shared scroll container, the per-page scroll containers in `clone-flow/style.scss` and `backup-contents-page/style.scss` are removed. The mixin also drops two now-dead Jetpack Cloud patches (the `:has(header.current-section)` height override and a `body.theme-jetpack-cloud body.is-section-backup …` rule that could never match — two `<body>` in a descendant combinator).

> Follow-up (not in this PR): the contents and clone pages still render a bare `<Main>` and aren't migrated to `<Page>`, so they have no admin-ui header/footer. Migrating them would make Backup fully consistent. Left as a `TODO` in the code.

## Why are these changes being made?

#109899 moved scrolling off the document into the layout: `.layout__primary` became `position: fixed` at viewport height with `.layout__content { overflow: hidden }`. Migrated `<Page>` screens get an internal scroller and are fine; these two backup screens render in a plain `<Main>` with none, so once content exceeded the viewport it was clipped with **no scrollbar**.

The first iteration fixed each page individually, but that wasn't robust across shells: keying on the footer's presence sent the (footerless) contents/clone pages down a natural-scroll path even on wp-admin/Calypso, where the Classic admin sidebar is tall and in-flow — so the document scrolled with the sidebar and dragged the content around. Clamping per shell keeps content-scroll isolated from the sidebar everywhere, and one generic `.main` scroller removes the per-page tax.

## Testing Instructions

For each environment, use a short window (or a backup with many files / a long clone-point list) so content exceeds the viewport.

**Calypso (Default) + wp-admin (Classic interface):**
1. **Contents:** Backup → a backup → View files (`/backup/:site/contents/:id`). The file list scrolls within the card; the page sidebar stays put (no "scrolls with the sidebar" quirk); card stays full-width.
2. **Clone:** `/backup/:site/clone` → enter a destination (incl. the credentials form) and reach Step 2's clone-point list — both scroll and everything below the fold is reachable; the Jetpack footer stays pinned where it renders.

**Jetpack Cloud & A8C-for-Agencies:**
3. Same two screens — content scrolls naturally, nothing clipped. (This is what was still broken on JPC in the earlier review.)

Verified on the live build across Calypso (Default + Classic/wp-admin) and Jetpack Cloud; A4A confirmed by the reporter.

## Screenshots

| Clone, wp-admin (content scrolls, sidebar isolated) | Clone step 1, Jetpack Cloud (full form reachable) |
| --- | --- |
| _drag here_ | _drag here_ |
