### PR TITLE
Fix eslint 9.0 lack of files to lint

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -690,22 +690,31 @@ object CheckCodeStyleBranch : BuildType({
 						| awk -v"n=${'$'}BATCH_SIZE" '{printf "%%s%%s", $0, (NR%%n?"\t":"\n")}' \
 						| nl \
 						| xargs -L1 -P"${'$'}MAX_PARALLEL_BATCHES" bash -c '
-							BATCH_NUM="${'$'}1"; shift
-							BATCH_FILES="${'$'}@"
-							yarn run eslint \
-								--format checkstyle \
-								--output-file "${'$'}RESULTS_DIR/batch_${'$'}{BATCH_NUM}.xml" \
-								${'$'}BATCH_FILES
+								if [ "${'$'}#" -eq 0 ]; then
+									echo "No affected files to lint"
+									printf "%%s\n" \
+										'\''<?xml version="1.0" encoding="utf-8"?>'\'' \
+										'\''<checkstyle version="4.3"></checkstyle>'\'' \
+										> "${'$'}RESULTS_DIR/results.xml"
+									exit 0
+								fi
 
-							# xargs will return 123 if any run returns a non-zero value. Ensure we
-							# only catch relevant issues. ESLint exit codes seem to be:
-							# - 0 for no errors
-							# - 1 for linting errors (should ignore)
-							# - 2 for other errors (should propagate)
-							status=${'$'}?
-							if [ ${'$'}status -gt 1 ]; then
-								exit ${'$'}status
-							fi
+								BATCH_NUM="${'$'}1"; shift
+								BATCH_FILES="${'$'}@"
+								yarn run eslint \
+									--format checkstyle \
+									--output-file "${'$'}RESULTS_DIR/batch_${'$'}{BATCH_NUM}.xml" \
+									${'$'}BATCH_FILES
+
+								# xargs will return 123 if any run returns a non-zero value. Ensure we
+								# only catch relevant issues. ESLint exit codes seem to be:
+								# - 0 for no errors
+								# - 1 for linting errors (should ignore)
+								# - 2 for other errors (should propagate)
+								status=${'$'}?
+								if [ ${'$'}status -gt 1 ]; then
+									exit ${'$'}status
+								fi
 						' yarn-batch # Arbitrary name to be used as each batch's progname
 				fi
 			"""


### PR DESCRIPTION
Follow up to https://github.com/Automattic/wp-calypso/pull/111100

Part of #

## Proposed Changes

* Prevent the branch ESLint TeamCity step from invoking ESLint with an empty file list.
* When there are no affected JS/TS/JSON/MD files, write an empty Checkstyle report and exit successfully.

## Why are these changes being made?

ESLint 9 errors when called without file patterns:

`'patterns' must be a non-empty string or an array of non-empty strings`

This can happen on branches that only touch files handled by other linters, such as SCSS. The existing file discovery command allows an empty result, but the batch command can still invoke ESLint without any files. This change handles that no-op case explicitly while preserving the existing batching flow for non-empty file lists.

## Testing Instructions

* Confirm the branch only changes non-ESLint-target files, such as `.scss` or Stylelint config.
* Run the affected-file discovery command and verify it returns no JS/TS/JSON/MD files:
  `git diff --name-only --diff-filter=d refs/remotes/origin/trunk...HEAD | grep -E '(\.[jt]sx?|\.json|\.md)$' || true`
* Verify the no-files path prints `No affected files to lint` and creates a valid empty Checkstyle XML report.
* Run `git diff --check`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?