### PR TITLE
Show feedback when loading the HC

### DIFF
--- a/apps/happy-blocks/block-library/search-card/style.scss
+++ b/apps/happy-blocks/block-library/search-card/style.scss
@@ -7,6 +7,11 @@ $breakpoint-desktop: 1440px; //Desktop size.
 	padding: 0;
 }
 
+.support-search-form-container[disabled] {
+	cursor: not-allowed;
+	opacity: 0.6;
+}
+
 .happy-blocks-search-card {
 	background: #f7f8fe url( ./assets/hero-bg.webp ) no-repeat bottom right;
 	background-size: contain;

--- a/apps/happy-blocks/block-library/search-card/view-odie.js
+++ b/apps/happy-blocks/block-library/search-card/view-odie.js
@@ -13,6 +13,7 @@ document.addEventListener( 'help-center-ready-to-load', resolveHelpCenterReadyTo
 document.addEventListener( 'DOMContentLoaded', function () {
 	const links = document.querySelectorAll( 'button[data-search-query]' );
 	const submitButton = document.querySelector( '.search-submit-button' );
+	const fieldset = document.querySelector( '.support-search-form-container' );
 	const form = document.getElementById( 'support-search-form' );
 	const input = document.getElementById( 'support-search-input' );
 
@@ -65,7 +66,11 @@ document.addEventListener( 'DOMContentLoaded', function () {
 
 				if ( isLoggedOut ) {
 					await helpCenterReadyToLoadPromise;
+					fieldset.setAttribute( 'aria-busy', 'true' );
+					fieldset.setAttribute( 'disabled', 'true' );
 					window.helpCenter?.loadHelpCenter().then( () => {
+						fieldset.removeAttribute( 'aria-busy' );
+						fieldset.removeAttribute( 'disabled' );
 						if ( window.wp?.data?.dispatch ) {
 							const helpCenterDispatch = window.wp.data.dispatch( 'automattic/help-center' );
 

--- a/apps/happy-blocks/block-library/search-card/view-odie.js
+++ b/apps/happy-blocks/block-library/search-card/view-odie.js
@@ -65,9 +65,9 @@ document.addEventListener( 'DOMContentLoaded', function () {
 				const isLoggedOut = ! helpCenterData?.currentUser?.ID;
 
 				if ( isLoggedOut ) {
-					await helpCenterReadyToLoadPromise;
 					fieldset.setAttribute( 'aria-busy', 'true' );
 					fieldset.setAttribute( 'disabled', 'true' );
+					await helpCenterReadyToLoadPromise;
 					window.helpCenter?.loadHelpCenter().then( () => {
 						fieldset.removeAttribute( 'aria-busy' );
 						fieldset.removeAttribute( 'disabled' );


### PR DESCRIPTION
## Summary

This PR updates the wordpress.com/support form submission with additional feedback while we wait for the required scripts to loaded. After the form submits, we disable the inputs until the chat opens. 

<img width="1659" height="1478" alt="image" src="https://github.com/user-attachments/assets/38257bcb-1af8-44b0-819f-b9b789e380f4" />


## Test plan
- [ ] Load `wordpress.com/support` logged out — submit arrow and suggestion buttons should appear dimmed
- [ ] After Help Center scripts load, buttons should become interactive
- [ ] Load `wordpress.com/support` logged in — no visible disabled flash, buttons work immediately
- [ ] Type a query and click a suggestion button — verify Help Center opens with the query

## Checklist
- [x] No new translations needed (no user-facing string changes)
- [ ] Has been tested on mobile viewports
- [ ] Server-side rendering verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)