### PR TITLE
Site logs tests: remove many many mocks

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -330,7 +330,9 @@ export const siteLogsPhpRoute = createRoute( {
 } ).lazy( () =>
 	import( '../../sites/logs' ).then( ( d ) =>
 		createLazyRoute( 'site-logs-php' )( {
-			component: () => <d.default logType={ LogType.PHP } />,
+			component: () => (
+				<d.default logType={ LogType.PHP } siteSlug={ siteRoute.useParams().siteSlug } />
+			),
 		} )
 	)
 );
@@ -349,7 +351,9 @@ export const siteLogsServerRoute = createRoute( {
 } ).lazy( () =>
 	import( '../../sites/logs' ).then( ( d ) =>
 		createLazyRoute( 'site-logs-server' )( {
-			component: () => <d.default logType={ LogType.SERVER } />,
+			component: () => (
+				<d.default logType={ LogType.SERVER } siteSlug={ siteRoute.useParams().siteSlug } />
+			),
 		} )
 	)
 );
@@ -368,7 +372,9 @@ export const siteLogsActivityRoute = createRoute( {
 } ).lazy( () =>
 	import( '../../sites/logs' ).then( ( d ) =>
 		createLazyRoute( 'site-logs-activity' )( {
-			component: () => <d.default logType={ LogType.ACTIVITY } />,
+			component: () => (
+				<d.default logType={ LogType.ACTIVITY } siteSlug={ siteRoute.useParams().siteSlug } />
+			),
 		} )
 	)
 );

--- a/client/dashboard/sites/logs/index.tsx
+++ b/client/dashboard/sites/logs/index.tsx
@@ -10,7 +10,6 @@ import { __ } from '@wordpress/i18n';
 import { useEffect, useState } from 'react';
 import { useDateRange } from '../../app/hooks/use-date-range';
 import { useLocale } from '../../app/locale';
-import { siteRoute } from '../../app/router/sites';
 import { Card, CardBody, CardHeader } from '../../components/card';
 import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
@@ -30,8 +29,7 @@ const selectTimeZone = ( s: SiteSettings | undefined ) => ( {
 	timezoneString: s?.timezone_string || undefined,
 } );
 
-function SiteLogs( { logType }: { logType: LogType } ) {
-	const { siteSlug } = siteRoute.useParams();
+function SiteLogs( { logType, siteSlug }: { logType: LogType; siteSlug: string } ) {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 
 	// Sites with a Jetpack connection error can't reach the settings endpoint;

--- a/client/dashboard/sites/logs/test/index.test.tsx
+++ b/client/dashboard/sites/logs/test/index.test.tsx
@@ -6,7 +6,6 @@ import '@testing-library/jest-dom';
 import { LogType } from '@automattic/api-core';
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import MockDate from 'mockdate';
 import nock from 'nock';
 import { render } from '../../../test-utils';
 import SiteLogs from '../index';
@@ -41,14 +40,8 @@ function mockSiteAndSettings( {
 }
 
 beforeEach( () => {
-	// Freeze "today" so the date-range picker's preset math is deterministic.
-	MockDate.set( '2026-05-27T12:00:00Z' );
 	mockUserPreferences();
 	mockSiteAndSettings();
-} );
-
-afterEach( () => {
-	MockDate.reset();
 } );
 
 describe( 'SiteLogs page', () => {

--- a/client/dashboard/sites/logs/test/index.test.tsx
+++ b/client/dashboard/sites/logs/test/index.test.tsx
@@ -4,159 +4,24 @@
 
 import '@testing-library/jest-dom';
 import { LogType } from '@automattic/api-core';
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import MockDate from 'mockdate';
 import nock from 'nock';
 import { render } from '../../../test-utils';
 import SiteLogs from '../index';
-import type { SiteLogsDataViewsProps } from '../dataviews';
 
 const API_BASE = 'https://public-api.wordpress.com';
 const mockSiteId = 123;
 
-jest.mock( '../../../components/time-mismatch-notice', () => ( {
-	__esModule: true,
-	default: () => null,
-} ) );
-
-jest.mock( '@wordpress/i18n', () => ( {
-	__: ( text: string ) => text,
-	_x: ( text: string ) => text,
-	isRTL: () => false,
-	sprintf: ( text: string ) => text,
-} ) );
-
-jest.mock( '@wordpress/data', () => ( {
-	useDispatch: () => ( {
-		createSuccessNotice: jest.fn(),
-		createErrorNotice: jest.fn(),
-	} ),
-	useRegistry: () => ( {} ),
-	combineReducers: jest.fn(),
-	createReduxStore: jest.fn(),
-	register: jest.fn(),
-	createSelector: jest.fn( ( selector ) => selector ),
-	store: jest.fn(),
-	select: jest.fn(),
-	dispatch: jest.fn(),
-} ) );
-
-jest.mock( '../../../app/router/sites', () => ( {
-	siteRoute: {
-		useParams: () => ( { siteSlug: 'test-site' } ),
-	},
-} ) );
-
-jest.mock( '@tanstack/react-router', () => {
-	const actual = jest.requireActual( '@tanstack/react-router' );
-	const navigate = jest.fn();
-	return {
-		...actual,
-		useRouter: () => ( {
-			navigate,
-			state: { location: { pathname: '/', search: '', hash: '', href: '/' } },
-		} ),
-		__mocks: { navigate },
-	};
-} );
-
-jest.mock( '../../../utils/site-features', () => {
-	const hasHostingFeatureMock = jest.fn();
-	const hasPlanFeatureMock = jest.fn();
-	return {
-		hasHostingFeature: ( ...args: unknown[] ) => hasHostingFeatureMock( ...args ),
-		hasPlanFeature: ( ...args: unknown[] ) => hasPlanFeatureMock( ...args ),
-		__mocks: { hasHostingFeatureMock, hasPlanFeatureMock },
-	};
-} );
-
-// Child heavy components: stub to avoid additional network
-jest.mock( '../dataviews', () => ( props: SiteLogsDataViewsProps ) => (
-	<button onClick={ () => props.onAutoRefreshRequest?.( true ) }>Toggle auto</button>
-) );
-jest.mock( '../../logs-activity/dataviews', () => () => null );
-
-// DateRangePicker: stub with controls; isLast7Days is overridden via a per-test jest.fn
-const mockIsLast7Days = jest.fn().mockReturnValue( true );
-jest.mock( '@automattic/date-range-picker', () => ( {
-	...jest.requireActual( '@automattic/date-range-picker' ),
-	DateRangePicker: () => (
-		<div>
-			{ /* Keep the buttons in the DOM so tests find them, but remove onClick handlers */ }
-			<button>Set non-last7 (yesterday)</button>
-			<button>Set last7</button>
-		</div>
-	),
-	isLast7Days: ( ...args: unknown[] ) => mockIsLast7Days( ...args ),
-} ) );
-
-type VStackProps = {
-	children: React.ReactNode;
-	as?: keyof JSX.IntrinsicElements;
-};
-
-type TabPanelProps = {
-	onSelect: ( tab: string ) => void;
-};
-
-jest.mock( '@wordpress/components', () => ( {
-	__experimentalVStack: ( { children, as = 'div', ...rest }: VStackProps ) => {
-		const Tag = as;
-		return <Tag { ...rest }>{ children }</Tag>;
-	},
-	TabPanel: ( { onSelect }: TabPanelProps ) => (
-		<div>
-			<button onClick={ () => onSelect( 'php' ) }>PHP errors</button>
-			<button onClick={ () => onSelect( 'server' ) }>Web server</button>
-			<button onClick={ () => onSelect( 'activity' ) }>Activity</button>
-		</div>
-	),
-} ) );
-
-type ChildrenProps = { children?: React.ReactNode };
-
-// Minimal stubs for app components used by the page
-jest.mock( '../../../components/card', () => ( {
-	Card: ( { children }: ChildrenProps ) => <div>{ children }</div>,
-	CardBody: ( { children }: ChildrenProps ) => <div>{ children }</div>,
-	CardHeader: ( { children }: ChildrenProps ) => <div>{ children }</div>,
-} ) );
-
-interface PageLayoutMockProps {
-	children?: React.ReactNode;
-	header?: React.ReactNode;
-	notices?: React.ReactNode;
+function mockUserPreferences() {
+	nock( API_BASE )
+		.persist()
+		.get( '/rest/v1.1/me/preferences' )
+		.reply( 200, { calypso_preferences: {} } );
 }
 
-interface PageHeaderMockProps {
-	actions?: React.ReactNode;
-}
-
-jest.mock( '../../../components/page-layout', () => ( {
-	__esModule: true,
-	default: ( { children, header, notices }: PageLayoutMockProps ) => (
-		<div>
-			<div>{ header }</div>
-			<div>{ notices }</div>
-			<div>{ children }</div>
-		</div>
-	),
-} ) );
-
-jest.mock( '../../../components/page-header', () => ( {
-	PageHeader: ( { actions }: PageHeaderMockProps ) => <div>{ actions }</div>,
-} ) );
-
-jest.mock( '../../../components/notice', () => ( {
-	__esModule: true,
-	default: ( { children }: ChildrenProps ) => <div>{ children }</div>,
-} ) );
-
-const { __mocks: featureMocks } = jest.requireMock( '../../../utils/site-features' ) as {
-	__mocks: { hasHostingFeatureMock: jest.Mock; hasPlanFeatureMock: jest.Mock };
-};
-
-function nockSiteAndSettings( {
+function mockSiteAndSettings( {
 	gmtOffset = 0,
 	timezoneString = '',
 }: { gmtOffset?: number; timezoneString?: string } = {} ) {
@@ -167,6 +32,8 @@ function nockSiteAndSettings( {
 			ID: mockSiteId,
 			slug: 'test-site',
 			options: { admin_url: 'https://example.com/wp-admin/' },
+			is_wpcom_atomic: true,
+			plan: { features: { active: [ 'full-activity-log', 'logs' ] } },
 		} );
 	nock( API_BASE )
 		.get( `/rest/v1.4/sites/${ mockSiteId }/settings` )
@@ -174,30 +41,33 @@ function nockSiteAndSettings( {
 }
 
 beforeEach( () => {
-	featureMocks.hasHostingFeatureMock.mockReturnValue( true );
-	nockSiteAndSettings();
+	// Freeze "today" so the date-range picker's preset math is deterministic.
+	MockDate.set( '2026-05-27T12:00:00Z' );
+	mockUserPreferences();
+	mockSiteAndSettings();
+} );
+
+afterEach( () => {
+	MockDate.reset();
 } );
 
 describe( 'SiteLogs page', () => {
-	test.each( Object.entries( LogType ) )(
-		'on selecting tab %s, navigates to /%s',
-		async ( logType, logTypeName ) => {
-			// Different initial log type that the one under test
-			const initialLogType = logTypeName !== LogType.PHP ? LogType.PHP : LogType.SERVER;
-			render( <SiteLogs logType={ initialLogType } /> );
+	test.each( [
+		[ LogType.ACTIVITY, 'Activity' ],
+		[ LogType.PHP, 'PHP errors' ],
+		[ LogType.SERVER, 'Web server' ],
+	] )( 'on selecting tab %s, navigates to /%s', async ( logSlug, tabLabel ) => {
+		// Different initial log type that the one under test
+		const initialLogType = logSlug !== LogType.PHP ? LogType.PHP : LogType.SERVER;
+		const { router } = render( <SiteLogs logType={ initialLogType } siteSlug="test-site" /> );
 
-			// Click another tab
-			await userEvent.click(
-				await screen.findByRole( 'button', { name: new RegExp( logTypeName, 'i' ) } )
-			);
-			const { __mocks: routerMocks } = jest.requireMock( '@tanstack/react-router' ) as {
-				__mocks: { navigate: jest.Mock };
-			};
-			expect( routerMocks.navigate ).toHaveBeenCalledWith( {
-				to: `/sites/test-site/logs/${ logTypeName }`,
-			} );
-		}
-	);
+		// Click another tab
+		await userEvent.click( await screen.findByRole( 'tab', { name: tabLabel } ) );
+
+		await waitFor( () => {
+			expect( router.state.location.pathname ).toBe( `/sites/test-site/logs/${ logSlug }` );
+		} );
+	} );
 
 	test( 'URL from/to params are normalized from ms to seconds', async () => {
 		const replaceSpy = jest.spyOn( window.history, 'replaceState' );
@@ -209,7 +79,7 @@ describe( 'SiteLogs page', () => {
 			writable: true,
 		} );
 
-		render( <SiteLogs logType={ LogType.PHP } /> );
+		render( <SiteLogs logType={ LogType.PHP } siteSlug="test-site" /> );
 
 		await waitFor( () => expect( replaceSpy ).toHaveBeenCalled() );
 		const hrefArgs = replaceSpy.mock.calls
@@ -227,29 +97,35 @@ describe( 'SiteLogs page', () => {
 		replaceSpy.mockRestore();
 	} );
 
-	test( 'auto-refresh is blocked for non-last-7 (yesterday) range and shows warning notice', async () => {
-		mockIsLast7Days.mockReturnValue( false );
+	test( 'auto-refresh is blocked for non-last-7 range and shows warning notice', async () => {
+		render( <SiteLogs logType={ LogType.PHP } siteSlug="test-site" /> );
 
-		render( <SiteLogs logType={ LogType.PHP } /> );
+		// Open the picker and choose a preset which isn't auto-refresh compatible
+		await userEvent.click( await screen.findByRole( 'button', { name: /^Date range:/ } ) );
+		const listbox = await screen.findByRole( 'listbox', { name: 'Date range presets' } );
+		await userEvent.click( within( listbox ).getByRole( 'option', { name: 'Year to date' } ) );
 
-		await userEvent.click( await screen.findByRole( 'button', { name: 'Toggle auto' } ) );
+		const checkbox = screen.getByRole( 'checkbox', { name: 'Auto-refresh' } );
+		await userEvent.click( checkbox );
 
+		expect( checkbox ).not.toBeChecked();
 		expect(
-			await screen.findByText(
-				'Auto-refresh only works with "Last 7 days" preset',
-				{},
-				{ timeout: 5000 }
-			)
+			await screen.findByText( 'Auto-refresh only works with "Last 7 days" preset' )
 		).toBeVisible();
 	} );
 
 	test( 'auto-refresh is allowed for last-7 range and does not show warning notice', async () => {
-		mockIsLast7Days.mockReturnValue( true );
+		render( <SiteLogs logType={ LogType.PHP } siteSlug="test-site" /> );
 
-		render( <SiteLogs logType={ LogType.PHP } /> );
+		// Open the picker and explicitly choose preset which is auto-refresh compatible
+		await userEvent.click( await screen.findByRole( 'button', { name: /^Date range:/ } ) );
+		const listbox = await screen.findByRole( 'listbox', { name: 'Date range presets' } );
+		await userEvent.click( within( listbox ).getByRole( 'option', { name: 'Last 7 days' } ) );
 
-		await userEvent.click( await screen.findByRole( 'button', { name: 'Toggle auto' } ) );
+		const checkbox = screen.getByRole( 'checkbox', { name: 'Auto-refresh' } );
+		await userEvent.click( checkbox );
 
+		expect( checkbox ).toBeChecked();
 		expect(
 			screen.queryByText( 'Auto-refresh only works with "Last 7 days" preset' )
 		).not.toBeInTheDocument();


### PR DESCRIPTION
Fixes DOTMSD-1223

## Proposed Changes

* Rewrite `client/dashboard/sites/logs/test/index.test.tsx` to drive the real router and query client instead of mocking router internals and history APIs.
* Minor adjustments in `client/dashboard/app/router/sites.tsx` and `client/dashboard/sites/logs/index.tsx` to support testing without the previous mocks.

## Why are these changes being made?

The previous test relied on heavy mocking of router and `window.history`/`window.location`, which made the test brittle and decoupled from real routing behavior. Driving the real router exercises the same code paths users hit and is less fragile.

## Testing Instructions

* `yarn test-client client/dashboard/sites/logs/test/index.test.tsx`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label.