### PR TITLE
Add sidebar drop hint parity

### DIFF
--- a/client/my-sites/sidebar/customize/customize-mode.scss
+++ b/client/my-sites/sidebar/customize/customize-mode.scss
@@ -261,6 +261,15 @@ body.is-admin-sidebar-customize-mode {
 			background-color: transparent !important;
 			color: var( --color-sidebar-text ) !important;
 		}
+		.sidebar > li:not( .admin-sidebar-drop-indicator )::before,
+		.sidebar .wp-admin-sidebar-group__children > li:not( .admin-sidebar-drop-indicator )::before,
+		.sidebar > li:not( .admin-sidebar-drop-indicator ):last-child::after,
+		.sidebar
+			.wp-admin-sidebar-group__children
+			> li:not( .admin-sidebar-drop-indicator ):last-child::after {
+			opacity: 0;
+			transform: scaleX( 0.7 );
+		}
 	}
 
 	// Disable Calypso's fold-sidebar control during customize.
@@ -290,9 +299,12 @@ body.is-admin-sidebar-customize-mode {
 		left: 10px;
 		right: 10px;
 		height: 0;
-		border-top: 1px solid var( --wp-admin-sidebar-customizer-theme, #2271b1 );
+		border-top: 1px dashed var( --wp-admin-sidebar-customizer-theme, #2271b1 );
 		opacity: 0.42;
 		pointer-events: none;
+		transform: scaleX( 1 );
+		transform-origin: center;
+		transition: opacity 160ms ease, transform 160ms ease;
 	}
 
 	.sidebar > li:not( .admin-sidebar-drop-indicator )::before,
@@ -306,6 +318,7 @@ body.is-admin-sidebar-customize-mode {
 		> li:not( .admin-sidebar-drop-indicator ):last-child::after {
 		bottom: 0;
 	}
+
 }
 
 // Source row fades while the ghost follows the cursor (Phase 2 row 17 visual).

--- a/client/my-sites/sidebar/customize/customize-mode.scss
+++ b/client/my-sites/sidebar/customize/customize-mode.scss
@@ -16,6 +16,8 @@
 // - Transitions are disabled on the customize overrides so there's no
 //   trailing blue "ease-out" when the cursor leaves a row.
 // - Drag-time hover suppression on every row (plugin v0.1.6, l.329-347).
+// - Solid drop-zone hints stay visible throughout customization
+//   (WordPress/wp-admin-sidebar#81).
 //
 // @see WordPress/wp-admin-sidebar v0.1.6 src/customizer/customizer.css
 
@@ -269,6 +271,40 @@ body.is-admin-sidebar-customize-mode {
 		.sidebar__menu-link {
 			cursor: not-allowed;
 		}
+	}
+
+	.sidebar > li:not( .admin-sidebar-drop-indicator ),
+	.sidebar .wp-admin-sidebar-group__children > li:not( .admin-sidebar-drop-indicator ) {
+		position: relative;
+	}
+
+	.sidebar > li:not( .admin-sidebar-drop-indicator )::before,
+	.sidebar .wp-admin-sidebar-group__children > li:not( .admin-sidebar-drop-indicator )::before,
+	.sidebar > li:not( .admin-sidebar-drop-indicator ):last-child::after,
+	.sidebar
+		.wp-admin-sidebar-group__children
+		> li:not( .admin-sidebar-drop-indicator ):last-child::after {
+		content: '';
+		position: absolute;
+		z-index: 1;
+		left: 10px;
+		right: 10px;
+		height: 0;
+		border-top: 1px solid var( --wp-admin-sidebar-customizer-theme, #2271b1 );
+		opacity: 0.42;
+		pointer-events: none;
+	}
+
+	.sidebar > li:not( .admin-sidebar-drop-indicator )::before,
+	.sidebar .wp-admin-sidebar-group__children > li:not( .admin-sidebar-drop-indicator )::before {
+		top: 0;
+	}
+
+	.sidebar > li:not( .admin-sidebar-drop-indicator ):last-child::after,
+	.sidebar
+		.wp-admin-sidebar-group__children
+		> li:not( .admin-sidebar-drop-indicator ):last-child::after {
+		bottom: 0;
 	}
 }
 


### PR DESCRIPTION
Part of WordPress/wp-admin-sidebar#81

## Proposed Changes

* Adds Calypso parity for the sidebar customizer drop-zone hints.
* Uses the final upstream behavior: subtle dashed hints show available drop slots while customization mode is open.
* Fades the hints out during active drag, then returns them after the drag ends.
* Leaves the active drop indicator as the exact placement signal during drag.

## Why are these changes being made?

* The Calypso sidebar customizer should match the public plugin behavior for WordPress/wp-admin-sidebar#81. The hints make available drop slots easier to discover without changing how drag and drop works.

## Testing Instructions

* Open `http://calypso.localhost:3000/home/[site]`.
* Enter plugin order customization from the `MY PLUGINS` section.
* Confirm dashed drop hints appear before dragging.
* Drag a plugin item and confirm the hints fade out while the regular drop indicator marks the exact landing position.
* Release the drag and confirm the dashed hints return.
* Click Done and confirm the sidebar returns to normal.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
