### PR TITLE
Date range picker: parse millisecond URL params correctly

### DIFF
--- a/client/dashboard/app/hooks/use-date-range.ts
+++ b/client/dashboard/app/hooks/use-date-range.ts
@@ -106,14 +106,28 @@ export function getDefaultDateRange(
 }
 
 /**
+ * Parse a URL param as Unix seconds. Treats values > 1e12 as milliseconds
+ * (links shared from older versions of the page) and converts to seconds.
+ */
+export function normalizeUnixSecondsParam( raw: string | null ): number | null {
+	if ( ! raw ) {
+		return null;
+	}
+	const num = parseInt( raw, 10 );
+	if ( ! Number.isFinite( num ) ) {
+		return null;
+	}
+	return num > 1e12 ? Math.floor( num / 1000 ) : num;
+}
+
+/**
  * Get the initial date range from the URL search parameters.
  */
 export function getInitialDateRangeFromSearch( search: string ): { start: Date; end: Date } | null {
 	const params = new URLSearchParams( search );
-	const valueAsNumber = ( value?: string | null ) => ( value ? Number( value ) : NaN );
-	const toDate = ( dateString?: string | null ) => {
-		const num = valueAsNumber( dateString );
-		if ( ! Number.isFinite( num ) ) {
+	const toDate = ( raw: string | null ) => {
+		const num = normalizeUnixSecondsParam( raw );
+		if ( num === null ) {
 			return undefined;
 		}
 		const date = fromUnixTime( num );

--- a/client/dashboard/sites/logs/index.tsx
+++ b/client/dashboard/sites/logs/index.tsx
@@ -8,7 +8,7 @@ import { TabPanel } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState } from 'react';
-import { useDateRange } from '../../app/hooks/use-date-range';
+import { useDateRange, normalizeUnixSecondsParam } from '../../app/hooks/use-date-range';
 import { useLocale } from '../../app/locale';
 import { Card, CardBody, CardHeader } from '../../components/card';
 import InlineSupportLink from '../../components/inline-support-link';
@@ -91,33 +91,18 @@ function SiteLogsContent( {
 
 	// Normalize any incoming ?from/&to query params to Unix seconds (canonical form)
 	useEffect( () => {
-		try {
-			const url = new URL( window.location.href );
-			const searchParams = url.searchParams;
-			let changed = false;
-			let sawParam = false;
-			( [ 'from', 'to' ] as const ).forEach( ( key ) => {
-				const raw = searchParams.get( key );
-				if ( ! raw ) {
-					return;
-				}
-				sawParam = true;
-				const number = Number.parseInt( raw, 10 );
-				if ( ! Number.isFinite( number ) ) {
-					return;
-				}
-				if ( number > 1e12 ) {
-					searchParams.set( key, String( Math.floor( number / 1000 ) ) );
-					changed = true;
-				}
-			} );
-
-			// Only rewrite if we saw a param and actually changed it; preserve hash
-			if ( sawParam && changed ) {
-				history.replaceState( null, '', url.toString() );
+		const url = new URL( window.location.href );
+		let changed = false;
+		( [ 'from', 'to' ] as const ).forEach( ( key ) => {
+			const raw = url.searchParams.get( key );
+			const normalized = normalizeUnixSecondsParam( raw );
+			if ( normalized !== null && String( normalized ) !== raw ) {
+				url.searchParams.set( key, String( normalized ) );
+				changed = true;
 			}
-		} catch ( _e ) {
-			// noop: if URL is not parseable, skip normalization
+		} );
+		if ( changed ) {
+			history.replaceState( null, '', url.toString() );
 		}
 	}, [] );
 

--- a/client/dashboard/sites/logs/test/index.test.tsx
+++ b/client/dashboard/sites/logs/test/index.test.tsx
@@ -63,31 +63,36 @@ describe( 'SiteLogs page', () => {
 	} );
 
 	test( 'URL from/to params are normalized from ms to seconds', async () => {
-		const replaceSpy = jest.spyOn( window.history, 'replaceState' );
-		const msFrom = 1730000000000; // ms
-		const msTo = 1730086400000; // ms
-		const originalHref = window.location.href;
-		Object.defineProperty( window, 'location', {
-			value: { href: `https://example.com?from=${ msFrom }&to=${ msTo }` },
-			writable: true,
+		// UTC day boundaries — buildTimeRangeInSeconds (called by the picker's
+		// onChange-on-mount) snaps to start/end of day, so day-aligned inputs
+		// round-trip exactly.
+		const msFrom = Date.UTC( 2024, 9, 27, 0, 0, 0 );
+		const msTo = Date.UTC( 2024, 9, 28, 23, 59, 59 );
+		window.history.pushState( {}, '', `/?from=${ msFrom }&to=${ msTo }` );
+
+		const { router } = render( <SiteLogs logType={ LogType.PHP } siteSlug="test-site" /> );
+
+		await waitFor( () => {
+			expect( router.state.location.search ).toMatchObject( {
+				from: msFrom / 1000,
+				to: msTo / 1000,
+			} );
 		} );
+	} );
+
+	test( 'date picker shows the dates implied by URL ms params', async () => {
+		const msFrom = Date.UTC( 2024, 9, 27, 0, 0, 0 );
+		const msTo = Date.UTC( 2024, 9, 28, 23, 59, 59 );
+		window.history.pushState( {}, '', `/?from=${ msFrom }&to=${ msTo }` );
 
 		render( <SiteLogs logType={ LogType.PHP } siteSlug="test-site" /> );
 
-		await waitFor( () => expect( replaceSpy ).toHaveBeenCalled() );
-		const hrefArgs = replaceSpy.mock.calls
-			.map( ( call ) => call?.[ 2 ] )
-			.filter( ( v ): v is string => typeof v === 'string' );
-		expect( hrefArgs.some( ( h ) => h.includes( `from=${ Math.floor( msFrom / 1000 ) }` ) ) ).toBe(
-			true
-		);
-		expect( hrefArgs.some( ( h ) => h.includes( `to=${ Math.floor( msTo / 1000 ) }` ) ) ).toBe(
-			true
-		);
-
-		// restore
-		Object.defineProperty( window, 'location', { value: { href: originalHref } } );
-		replaceSpy.mockRestore();
+		// Picker button label is "Date range: Oct 27, 2024 to Oct 28, 2024".
+		// If useDateRange parses the ms values as seconds (the bug), the label
+		// shows a date in year ~56000 instead.
+		expect(
+			await screen.findByRole( 'button', { name: /Date range:.*Oct 27, 2024.*Oct 28, 2024/ } )
+		).toBeVisible();
 	} );
 
 	test( 'auto-refresh is blocked for non-last-7 range and shows warning notice', async () => {

--- a/client/dashboard/sites/logs/utils.ts
+++ b/client/dashboard/sites/logs/utils.ts
@@ -1,10 +1,8 @@
 import { dateI18n } from '@wordpress/date';
 import { __, sprintf } from '@wordpress/i18n';
-import { startOfDay, endOfDay, fromUnixTime, isValid as isValidDate } from 'date-fns';
+import { startOfDay, endOfDay } from 'date-fns';
 import { formatDateWithOffset, getUtcOffsetDisplay } from '../../utils/datetime';
 import type { PHPLog, ServerLog } from '@automattic/api-core';
-
-type DateRange = { start: Date; end: Date };
 
 const HOUR_MS = 3_600_000;
 const SECONDS_PER_DAY = 86_400;
@@ -84,26 +82,6 @@ export function formatLogDateTimeForDisplay(
 		dateStyle: 'long',
 		timeStyle: 'short',
 	} );
-}
-
-/**
- * Get the initial date range from the URL search parameters.
- */
-export function getInitialDateRangeFromSearch( search: string ): DateRange | null {
-	const params = new URLSearchParams( search );
-	const valueAsNumber = ( value?: string | null ) => ( value ? Number( value ) : NaN );
-	const toDate = ( dateString?: string | null ) => {
-		const num = valueAsNumber( dateString );
-		if ( ! Number.isFinite( num ) ) {
-			return undefined;
-		}
-		const date = fromUnixTime( num );
-		return isValidDate( date ) ? date : undefined;
-	};
-
-	const start = toDate( params.get( 'from' ) );
-	const end = toDate( params.get( 'to' ) );
-	return start && end && start <= end ? { start, end } : null;
 }
 
 export const LOG_TABS = [


### PR DESCRIPTION
**Before**
<img width="355" height="84" alt="date-picker-broken" src="https://github.com/user-attachments/assets/5604d3d1-8e92-46fb-82e7-48ad9a04037d" />

**After**
<img width="270" height="79" alt="date-picker-fixed" src="https://github.com/user-attachments/assets/94caa6d5-66b9-4890-ae03-bbad149d1c34" />

## Proposed Changes

* Detect millisecond-scale values in `?from=`/`?to=` URL params (`> 1e12`) and convert to Unix seconds in a shared helper `normalizeUnixSecondsParam`, used by both the initial date-range parse in `useDateRange` and the URL-normalizing effect in `SiteLogs`.
* Deleted a `getInitialDateRangeFromSearch` util function, it was dead code.

## Why are these changes being made?

Links to the logs page from older versions of the page used `from`/`to` URL params in **milliseconds**. We've always had code for catching that and converting to seconds, but only _some_ of the code was behaving this way. This makes sure the date picker knows that it should behave this way.

The re-writing of the url params was introduced in #106133

Stacked on top of #111112 because the test rewrite there is what made the bug straightforward to discover and fix.

## Testing Instructions

* Open a logs page with millisecond `from`/`to`, e.g. `/sites/<slug>/logs/activity?from=1729987200000&to=1730159999000`.
* The picker label should read `Oct 27, 2024 to Oct 29, 2024` (not a year ~56,000).
* The URL should be rewritten to seconds (`?from=1729987200&to=1730159999`).
* Running `yarn test-client client/dashboard/sites/logs/test/index.test.tsx` should pass — note the two `URL from/to params are normalized from ms to seconds` and `date picker shows the dates implied by URL ms params` tests.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?