### PR TITLE
E2E: tolerate slow LOHP theme document response

### DIFF
--- a/packages/calypso-e2e/.eslintrc.js
+++ b/packages/calypso-e2e/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
 	rules: {
 		...nodeConfig.rules,
 
-		'require-jsdoc': [
+		'jsdoc/require-jsdoc': [
 			'error',
 			{
 				require: {

--- a/packages/calypso-e2e/src/lib/pages/logged-out-home-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/logged-out-home-page.ts
@@ -48,10 +48,20 @@ export class LoggedOutHomePage {
 			}
 		);
 
-		await this.page.goto( new URL( themesHref, this.page.url() ).href, {
-			timeout: 30_000,
+		const response = await this.page.goto( new URL( themesHref, this.page.url() ).href, {
+			// CI traces in wp-calypso#111117 showed this route can spend over 50s server-side
+			// before the document loads.
+			timeout: 60_000,
 			waitUntil: 'domcontentloaded',
 		} );
+
+		if ( ! response?.ok() ) {
+			throw new Error(
+				`Themes page failed to load: ${ response?.status() ?? 'no response' } ${
+					response?.url() ?? themesHref
+				}`
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Proposed Changes

* Keep the logged-out themes navigation waiting for `DOMContentLoaded`, but allow 60s for the document to load.
* Fail clearly if the final themes page response is not OK. `LoggedOutThemesPage` still waits for the View filter before interacting.
* Update the `calypso-e2e` ESLint override to use `jsdoc/require-jsdoc`, since ESLint 9 removed the old core `require-jsdoc` rule.

## Why are these changes being made?

* Recent pre-release failures timed out while `/themes?ref=logged-out-homepage-lp` was still waiting on the document response. One trace showed the page eventually returned 200 after more than 50s server-side.
* This keeps the critical LOHP theme signup flow covered without treating a slow first byte as a broken theme-selection UI.

## Testing Instructions

* `yarn prettier --check packages/calypso-e2e/.eslintrc.js packages/calypso-e2e/src/lib/pages/logged-out-home-page.ts`
* `ESLINT_USE_FLAT_CONFIG=false ./node_modules/.bin/eslint --quiet packages/calypso-e2e/src/lib/pages/logged-out-home-page.ts packages/calypso-e2e/.eslintrc.js`
* `yarn jest packages/calypso-e2e/src/test/lib/pages/logged-out-themes-page.test.ts --runInBand`
* Local Pixel-style Playwright probe from WordPress.com home to `/themes?ref=logged-out-homepage-lp`, then waited for the View filter.
* `git diff --check`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?