### PR TITLE
My Home: drop support center from subtitle when card is absent

### DIFF
--- a/client/my-sites/customer-home/components/home-content/index.jsx
+++ b/client/my-sites/customer-home/components/home-content/index.jsx
@@ -1,5 +1,5 @@
 import { Button } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
+import { localizeUrl, useHasEnTranslation } from '@automattic/i18n-utils';
 import { SET_UP_EMAIL_AUTHENTICATION_FOR_YOUR_DOMAIN } from '@automattic/urls';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
@@ -21,6 +21,7 @@ import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { setDomainNotice } from 'calypso/lib/domains/set-domain-notice';
 import { preventWidows } from 'calypso/lib/formatting';
 import { getQueryArgs } from 'calypso/lib/query-args';
+import { FEATURE_SUPPORT } from 'calypso/my-sites/customer-home/cards/constants';
 import Primary from 'calypso/my-sites/customer-home/locations/primary';
 import Secondary from 'calypso/my-sites/customer-home/locations/secondary';
 import Tertiary from 'calypso/my-sites/customer-home/locations/tertiary';
@@ -83,6 +84,7 @@ const HomeContent = ( {
 	const [ launchedSiteId, setLaunchedSiteId ] = useState( null );
 	const queryClient = useQueryClient();
 	const translate = useTranslate();
+	const hasEnTranslation = useHasEnTranslation();
 	const isP2 = site?.options?.is_wpforteams_site;
 
 	const { data: layout, isLoading, error: homeLayoutError } = useHomeLayoutQuery( siteId );
@@ -147,6 +149,26 @@ const HomeContent = ( {
 		Array.isArray( layout?.secondary ) &&
 		layout.secondary.length > 0;
 
+	const getHeaderSubtitle = () => {
+		if ( isLoading ) {
+			return undefined;
+		}
+		const defaultSubtitle = translate(
+			'Your hub for next steps, support center, and quick links.'
+		);
+		const hasSupportCard =
+			layout?.secondary?.includes( FEATURE_SUPPORT ) ||
+			layout?.[ 'tertiary.manage-site' ]?.includes( FEATURE_SUPPORT );
+		if ( hasSupportCard ) {
+			return defaultSubtitle;
+		}
+		const noSupportSubtitle = 'Your hub for next steps and quick links to manage your site.';
+		if ( hasEnTranslation( noSupportSubtitle ) ) {
+			return translate( noSupportSubtitle );
+		}
+		return defaultSubtitle;
+	};
+
 	if ( ! canUserUseCustomerHome ) {
 		const title = translate( 'This page is not available on this site.' );
 		return <EmptyContent title={ preventWidows( title ) } />;
@@ -186,7 +208,7 @@ const HomeContent = ( {
 				navigationItems={ [] }
 				mobileItem={ null }
 				title={ translate( 'My Home' ) }
-				subtitle={ translate( 'Your hub for next steps, support center, and quick links.' ) }
+				subtitle={ getHeaderSubtitle() }
 			>
 				{ headerActions }
 			</NavigationHeader>

--- a/client/my-sites/customer-home/components/home-content/index.jsx
+++ b/client/my-sites/customer-home/components/home-content/index.jsx
@@ -162,9 +162,8 @@ const HomeContent = ( {
 		if ( hasSupportCard ) {
 			return defaultSubtitle;
 		}
-		const noSupportSubtitle = 'Your hub for next steps and quick links to manage your site.';
-		if ( hasEnTranslation( noSupportSubtitle ) ) {
-			return translate( noSupportSubtitle );
+		if ( hasEnTranslation( 'Your hub for next steps and quick links to manage your site.' ) ) {
+			return translate( 'Your hub for next steps and quick links to manage your site.' );
 		}
 		return defaultSubtitle;
 	};

--- a/packages/eslint-plugin-wpcalypso/lib/rules/redux-no-bound-selectors.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/redux-no-bound-selectors.js
@@ -118,7 +118,8 @@ module.exports = {
 				 * which should be readily available in scope.
 				 */
 				const mapStateName = mapStateNode.name;
-				const variable = context.getScope().set.get( mapStateName );
+				const scope = context.sourceCode ? context.sourceCode.getScope( node ) : context.getScope();
+				const variable = scope.set.get( mapStateName );
 				const definition = variable && variable.defs && variable.defs[ 0 ];
 				mapStateBody =
 					definition && definition.node && definition.node.init && definition.node.init.body;


### PR DESCRIPTION
Part of DOTCOM-17125

## Proposed Changes

* Make the My Home header subtitle conditional on whether the support center card (\`FEATURE_SUPPORT\`) is actually present in the layout returned by \`/sites/:id/home/layout\`.
* When the support card is absent — typically new sites with an incomplete Launchpad, per DOTOBRD-385 — the subtitle drops the "support center" mention and reads: *"Your hub for next steps and quick links to manage your site."*
* Falls back to the existing copy when the new string isn't translated yet in the user's locale, and renders no subtitle while the layout query is still loading.

## Why are these changes being made?

The current subtitle, *"Your hub for next steps, support center, and quick links."*, advertises a support center that isn't rendered for sites whose Launchpad is incomplete, because the layout API doesn't return the \`home-feature-support\` card in that case. The copy was misleading on every newly-created site.

The reporter noted that older/launched sites still see the support center card, so the wording must remain accurate there too — hence the layout-aware branching rather than a blanket rewrite.

## Testing Instructions

* On an existing site where the support center card is visible on My Home: subtitle should still read *"Your hub for next steps, support center, and quick links."*
* On a freshly-created site where the support center card is not present: subtitle should read *"Your hub for next steps and quick links to manage your site."*
* While My Home is still loading the layout: subtitle should be empty (no flash of either copy).
* In a non-English locale before the new string is translated: subtitle should fall back to the existing copy when the support card is absent.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)