### PR TITLE
Big Sky post-checkout: roll out treatment to all eligible users

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -320,7 +320,7 @@ const onboarding: FlowV2< typeof initialize > = {
 							isEnabled( 'onboarding/woo-hosting-post-purchase-setup-choice' )
 						) {
 							return navigate( 'setup-your-site-ai' );
-						} else if ( providedDependencies?.postCheckoutBigSkyVariation === 'big_sky' ) {
+						} else if ( providedDependencies?.postCheckoutBigSky ) {
 							return navigate( 'setup-your-site-ai' );
 						} else {
 							// replace the location to delete processing step from history.

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
@@ -19,7 +19,6 @@ import { useQuery as useUrlParams } from 'calypso/landing/stepper/hooks/use-quer
 import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
 import { waitForPluginsActive } from 'calypso/landing/stepper/utils/wait-for-plugins-active';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { useExperiment } from 'calypso/lib/explat';
 import { useMarketplaceThemeProducts } from '../../../../hooks/use-marketplace-theme-products';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
 import { useSiteTransferStatusQuery } from '../../../../hooks/use-site-transfer/query';
@@ -62,15 +61,11 @@ const PostCheckoutOnboarding: StepType< {
 		enabled: !! siteSlug,
 	} );
 
-	const eligibleForExperiment =
+	const showBigSkyChoice =
 		isEnabled( 'onboarding/post-checkout-ai-step' ) &&
 		!! site?.plan &&
 		( isPersonal( site.plan ) || isPremium( site.plan ) || isBusiness( site.plan ) ) &&
 		site.plan.features?.active?.includes( FEATURE_BIG_SKY );
-	const [ isLoadingExperiment, experimentAssignment ] = useExperiment(
-		'calyso_post_onboarding_big_sky_202601_v1',
-		{ isEligible: eligibleForExperiment }
-	);
 
 	const intent = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(),
@@ -180,8 +175,7 @@ const PostCheckoutOnboarding: StepType< {
 			! siteSlug ||
 			isLoadingSite ||
 			isLoadingMarketplaceThemeProducts ||
-			isLoadingSiteTransferStatusData ||
-			isLoadingExperiment
+			isLoadingSiteTransferStatusData
 		) {
 			return;
 		}
@@ -191,12 +185,7 @@ const PostCheckoutOnboarding: StepType< {
 				siteSlug,
 				hasExternalTheme,
 				hasPluginByGoal,
-				...( eligibleForExperiment
-					? {
-							postCheckoutBigSky: true,
-							postCheckoutBigSkyVariation: experimentAssignment?.variationName ?? 'control',
-					  }
-					: {} ),
+				...( showBigSkyChoice ? { postCheckoutBigSky: true } : {} ),
 			};
 
 			if ( ! isJetpackOrAtomic ) {
@@ -231,7 +220,6 @@ const PostCheckoutOnboarding: StepType< {
 		isLoadingSite,
 		isLoadingMarketplaceThemeProducts,
 		isLoadingSiteTransferStatusData,
-		isLoadingExperiment,
 		isJetpackOrAtomic,
 		siteTransferStatusData,
 		selectedDesign,


### PR DESCRIPTION
Part of DOTOBRD-435

## Proposed Changes

* Remove the ExPlat gate (`calyso_post_onboarding_big_sky_202601_v1`) from the post-checkout onboarding step so every eligible user is routed to the "Build with AI / blank site / migrate" choice screen.
* Switch the onboarding flow router to branch on `postCheckoutBigSky` (eligibility) rather than the experiment variation name.

## Why are these changes being made?

* The experiment concluded and the analysis recommends shipping the treatment: -11.3% refunds and positive 30-day net cash, concentrated in Personal-plan users who choose Big Sky.
* This was flagged as a quick rollout follow-up that did not get picked up during RSM; tracked in DOTOBRD-435.

## Testing Instructions

Eligibility (unchanged): Personal, Premium, or Business plan with the Big Sky feature active. Commerce and free plans are excluded.

* Check out this branch and run `yarn start`.
* Make sure `onboarding/post-checkout-ai-step` is `true` (default in development/stage/horizon/wpcalypso/production).
* Go through the onboarding flow at `/setup/onboarding` and purchase a Personal, Premium, or Business plan.
* After checkout, the post-checkout step should land on the `setup-your-site-ai` choice screen for every run — no ExPlat bucketing.
* Repeat with a Commerce plan: the choice screen should be skipped, just like today.
* Repeat with a free site: the choice screen should be skipped.
* Confirm the Woo hosting-solutions ref path (`?ref=hosting-woocommerce`) still routes to `setup-your-site-ai` via its existing branch above this one.

## Follow-ups (not in this PR)

* Stop the ExPlat experiment.
* Once the rollout is stable, remove the `onboarding/post-checkout-ai-step` kill-switch flag. Note: that flag is also used in `client/landing/stepper/hooks/use-is-site-big-sky-eligible.ts` to gate Big Sky eligibility for `SITE_SETUP_FLOW`, so removing it is a behavior change on a second surface and should be reviewed with that flow's owners.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)