### PR TITLE
Agents Manager: temporary hide chat FAB when help center icon is present

### DIFF
--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -28,6 +28,7 @@ import type { UseImageUploadResult } from '../../hooks/use-image-upload';
 import type { ExternalContextCard, ExternalContextCardAction } from '../../utils/external-context';
 import type { Message, NoticeConfig } from '@automattic/agenttic-ui/dist/types';
 import type { AgentsManagerSelect } from '@automattic/data-stores';
+import './style.scss';
 
 interface Props {
 	/** Chat messages to display. */

--- a/packages/agents-manager/src/components/agent-chat/style.scss
+++ b/packages/agents-manager/src/components/agent-chat/style.scss
@@ -1,0 +1,8 @@
+// Temporary: hide the chat FAB when the help center icon is present in the WP admin bar.
+// Editors don't load the icon, so the FAB stays visible there.
+body:has( #wp-admin-bar-agents-manager ) {
+	.agenttic:has( [data-slot='collapsed-view'] ),
+	.agents-manager-sidebar-fab {
+		display: none;
+	}
+}


### PR DESCRIPTION
Part of AI-986

## Proposed Changes

* Add a temporary CSS rule in `packages/agents-manager/src/components/agent-chat/style.scss` that hides the chat FAB whenever the help center icon (`#wp-admin-bar-agents-manager`) is present in the WP admin bar. Covers both:
  * Floating mode: `agenttic-ui`'s `CollapsedView` (matched via `[data-slot='collapsed-view']`).
  * Docked mode: the sidebar FAB rendered by `useAgentLayoutManager` (`.agents-manager-sidebar-fab`).
* Wire it up by importing the new `style.scss` from `agent-chat/index.tsx`.

## Why are these changes being made?

* When the help center icon is exposed in the admin bar, users already have a primary entry point to open the chat. The FAB becomes a duplicate trigger, so it's hidden in that scenario.
* Editors (post / page / site editor) don't load the help center icon in the admin bar, so the `:has( #wp-admin-bar-agents-manager )` guard naturally lets the FAB remain visible there — no editor-specific exception is required.
* Scoped as temporary so it's easy to remove once a permanent solution lands (e.g., an opt-out prop in `@automattic/agenttic-ui`, or a layout-level toggle).

## Testing Instructions

* Sandbox this PR
* Enable the unified AI chat
* Go to `/wp-admin`, now the AI chat is opened / closed by HC > dropdown menu, instead of the FAB:

https://github.com/user-attachments/assets/1dabfb7e-4594-424c-bd90-1261be922435

* The FAB in the editors remains unchanged

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?