### PR TITLE
[DOTMSD-1253] Improve Help Center dark guide link contrast

### DIFF
--- a/packages/support-articles/src/components/help-center-article/help-center-article.scss
+++ b/packages/support-articles/src/components/help-center-article/help-center-article.scss
@@ -1,3 +1,5 @@
+@use "calypso/assets/stylesheets/shared/mixins/dark-theme" as ui-mixins;
+
 @import '@automattic/typography/styles/variables';
 @import '@wordpress/base-styles/mixins';
 @import '@wordpress/base-styles/variables';
@@ -109,6 +111,14 @@
 					ol {
 						margin-left: 1em;
 					}
+				}
+			}
+
+			a:not( .button ):not( .wp-block-button__link ) {
+				@include ui-mixins.when-dark-theme {
+					color: var( --wp-admin-theme-color-darker-20 );
+					text-decoration: underline;
+					text-underline-offset: 0.12em;
 				}
 			}
 

--- a/packages/support-articles/src/components/help-center-article/help-center-article.scss
+++ b/packages/support-articles/src/components/help-center-article/help-center-article.scss
@@ -114,7 +114,9 @@
 				}
 			}
 
-			a:not( .button ):not( .wp-block-button__link ) {
+			p a:not( .button ):not( .wp-block-button__link ),
+			li:not( .wp-block-a8c-support-table-of-contents li )
+				a:not( .button ):not( .wp-block-button__link ) {
 				@include ui-mixins.when-dark-theme {
 					color: var( --wp-admin-theme-color-darker-20 );
 					text-decoration: underline;


### PR DESCRIPTION
Part of DOTMSD-1253

## Proposed Changes

<img width="1746" height="1634" alt="CleanShot 2026-05-28 at 12 41 11@2x" src="https://github.com/user-attachments/assets/3aff6428-e0e6-4cb7-94b1-e89b3018c633" />


* Improve dark-mode contrast for inline links inside rendered Help Center support guide body content.

## Why are these changes being made?

Support guide paragraphs can contain several inline links, and in dark mode those links were inheriting the standard WordPress.com blue. Against the dark Help Center surface, that color does not meet body-copy contrast expectations and can be difficult to distinguish from surrounding text.

The support guide body is rendered from article HTML inside the Help Center article container, so raw anchors need a scoped dark-mode rule. This change applies the existing dark-mode token used for Dashboard interactive text and adds an underline so inline links rely on both contrast and text decoration instead of color alone.

## Testing Instructions

* Open a Help Center support guide in dark mode.
* Confirm inline links inside paragraph copy are visibly lighter than before and underlined.
* Confirm button-style links in support guide content keep their existing button styling.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
