### PR TITLE
SiteLogs test: wait for the URL normalization specifically

### DIFF
--- a/client/dashboard/sites/logs/test/index.test.tsx
+++ b/client/dashboard/sites/logs/test/index.test.tsx
@@ -74,16 +74,21 @@ describe( 'SiteLogs page', () => {
 
 		render( <SiteLogs logType={ LogType.PHP } siteSlug="test-site" /> );
 
-		await waitFor( () => expect( replaceSpy ).toHaveBeenCalled() );
-		const hrefArgs = replaceSpy.mock.calls
-			.map( ( call ) => call?.[ 2 ] )
-			.filter( ( v ): v is string => typeof v === 'string' );
-		expect( hrefArgs.some( ( h ) => h.includes( `from=${ Math.floor( msFrom / 1000 ) }` ) ) ).toBe(
-			true
-		);
-		expect( hrefArgs.some( ( h ) => h.includes( `to=${ Math.floor( msTo / 1000 ) }` ) ) ).toBe(
-			true
-		);
+		// Wait for the specific normalization to land. Waiting on a bare
+		// `replaceSpy.toHaveBeenCalled()` is flaky because the router fires
+		// its own `replaceState` during initial navigation, which can
+		// satisfy the waiter before the normalization effect has run.
+		await waitFor( () => {
+			const hrefArgs = replaceSpy.mock.calls
+				.map( ( call ) => call?.[ 2 ] )
+				.filter( ( v ): v is string => typeof v === 'string' );
+			expect(
+				hrefArgs.some( ( h ) => h.includes( `from=${ Math.floor( msFrom / 1000 ) }` ) )
+			).toBe( true );
+			expect( hrefArgs.some( ( h ) => h.includes( `to=${ Math.floor( msTo / 1000 ) }` ) ) ).toBe(
+				true
+			);
+		} );
 
 		// restore
 		Object.defineProperty( window, 'location', { value: { href: originalHref } } );


### PR DESCRIPTION
Fixes DOTCOM-17269

## Proposed Changes

Move the assertions in the *URL from/to params are normalized from ms to seconds* test inside the `waitFor`, so it retries until the normalization-specific `replaceState` call appears.

## Why are these changes being made?

The test fails intermittently in CI (\"Expected: true, Received: false\" at the same `toBe(true)` assertion). The race:

1. The test sets `window.location.href` with millisecond `from`/`to` params, renders `SiteLogs`, and spies on `history.replaceState`.
2. TanStack Router fires its own `replaceState` during initial navigation.
3. `SiteLogs`'s normalization `useEffect` runs after mount and rewrites the URL with second-based params via another `replaceState`.

The test was waiting on `replaceSpy.toHaveBeenCalled()`, which is satisfied by the router's call (step 2). When that resolves before the normalization effect (step 3) has run, the captured calls contain only the router's URL and the assertion that some call includes `from=<seconds>` fires false.

This failure has surfaced on trunk CI (#194518) and on a feature branch's CI (#194529), in both cases as the only failing test in an otherwise green run.

## Testing Instructions

* `yarn test-client client/dashboard/sites/logs/test/index.test.tsx` — all 6 tests pass.
* The fix doesn't change what's asserted; it just changes when the assertion is allowed to be retried. Behavior on a green run is unchanged.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?