### PR TITLE
Secure AI editorial review avatar URLs

### DIFF
--- a/packages/jetpack-ai-sidebar/package.json
+++ b/packages/jetpack-ai-sidebar/package.json
@@ -46,6 +46,7 @@
 	"dependencies": {
 		"@automattic/agenttic-client": "^0.1.58",
 		"@automattic/calypso-analytics": "workspace:^",
+		"@automattic/calypso-url": "workspace:^",
 		"@wordpress/abilities": "^0.12.0",
 		"@wordpress/components": "^33.1.0",
 		"@wordpress/i18n": "^5.23.0"

--- a/packages/jetpack-ai-sidebar/src/components/reviewer-chip.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/reviewer-chip.test.tsx
@@ -18,18 +18,56 @@ function getRawStyle( el: Element ): string {
 }
 
 describe( 'ReviewerChip', () => {
-	it( 'renders an <img> when avatar_url is provided', () => {
+	it( 'renders an <img> when avatar_url is safe', () => {
 		const { container } = render(
 			<ReviewerChip
 				name="Marcus Holloway"
-				metadata={ { avatar_url: 'https://example.test/avatar.png' } }
+				metadata={ { avatar_url: 'https://secure.gravatar.com/avatar/example' } }
 			/>
 		);
 		// `alt=""` demotes role to "presentation"; query by selector instead.
 		const img = container.querySelector( 'img' ) as HTMLImageElement;
 		expect( img ).not.toBeNull();
-		expect( img.getAttribute( 'src' ) ).toBe( 'https://example.test/avatar.png' );
+		expect( img.getAttribute( 'src' ) ).toBe( 'https://secure.gravatar.com/avatar/example' );
 		expect( screen.getByText( 'Marcus Holloway' ) ).toBeInTheDocument();
+	} );
+
+	it( 'promotes Automattic avatar URLs to HTTPS before rendering', () => {
+		const { container } = render(
+			<ReviewerChip
+				name="Priya Desai"
+				metadata={ { avatar_url: 'http://files.wordpress.com/avatar.png' } }
+			/>
+		);
+
+		const img = container.querySelector( 'img' ) as HTMLImageElement;
+		expect( img ).not.toBeNull();
+		expect( img.getAttribute( 'src' ) ).toBe( 'https://files.wordpress.com/avatar.png' );
+	} );
+
+	it( 'proxies external avatar URLs before rendering', () => {
+		const { container } = render(
+			<ReviewerChip
+				name="Priya Desai"
+				metadata={ { avatar_url: 'https://example.test/avatar.png' } }
+			/>
+		);
+
+		const img = container.querySelector( 'img' ) as HTMLImageElement;
+		expect( img ).not.toBeNull();
+		expect( img.getAttribute( 'src' ) ).toBe( 'https://i0.wp.com/example.test/avatar.png?ssl=1' );
+	} );
+
+	it( 'falls back to pill when avatar_url cannot be made safe', () => {
+		const { container } = render(
+			<ReviewerChip
+				name="Priya Desai"
+				metadata={ { avatar_url: 'https://example.test/avatar.png?token=abc123' } }
+			/>
+		);
+
+		expect( container.querySelector( 'img' ) ).toBeNull();
+		expect( container.querySelector( '.jetpack-ai-reviewer-chip.is-pill' ) ).not.toBeNull();
 	} );
 
 	it( 'renders the full name in a coloured pill when no avatar_url', () => {

--- a/packages/jetpack-ai-sidebar/src/components/reviewer-chip.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/reviewer-chip.tsx
@@ -1,8 +1,10 @@
 /**
- * ReviewerChip — avatar + name when `reviewers_metadata` gives a Gravatar,
+ * ReviewerChip — avatar + name when `reviewers_metadata` gives a safe avatar URL,
  * otherwise a coloured full-name pill (hue deterministic from name, so the
  * same reviewer reads the same colour across cards).
  */
+
+import { safeImageUrl } from '@automattic/calypso-url';
 
 export interface ReviewerMetadata {
 	display_name?: string;
@@ -60,11 +62,6 @@ function getPillColours( name: string ): { background: string; border: string } 
  * @param           props.variant    Visual variant — 'inline' (default) or 'compact' for dense lists.
  * @returns React element.
  */
-/** Avatar URLs are server-built from WordPress avatar APIs; keep only a scheme guard here. */
-function isSafeAvatarUrl( url: string | null | undefined ): url is string {
-	return typeof url === 'string' && /^https:\/\//i.test( url );
-}
-
 export default function ReviewerChip( {
 	name,
 	metadata,
@@ -72,7 +69,7 @@ export default function ReviewerChip( {
 	variant = 'inline',
 }: ReviewerChipProps ) {
 	const tooltip = title ?? metadata?.bio ?? name;
-	const avatarUrl = isSafeAvatarUrl( metadata?.avatar_url ) ? metadata.avatar_url : null;
+	const avatarUrl = safeImageUrl( metadata?.avatar_url );
 
 	if ( avatarUrl ) {
 		return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -1612,6 +1612,7 @@ __metadata:
     "@automattic/agenttic-client": "npm:^0.1.58"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
+    "@automattic/calypso-url": "workspace:^"
     "@types/react": "npm:^18.3.1"
     "@types/react-dom": "npm:^18.3.1"
     "@wordpress/abilities": "npm:^0.12.0"


### PR DESCRIPTION
## Proposed Changes

  * Use `safeImageUrl()` before rendering AI Editorial Review reviewer avatars.
  * Fall back to the existing colored reviewer pill when an avatar URL cannot be made safe.
  * Add ReviewerChip coverage for trusted Gravatar URLs, Automattic HTTP-to-HTTPS promotion, external avatar Photon proxying, and unsafe URL fallback.

  ## Why are these changes being made?

  AI Editorial Review reviewer avatars are server-provided, but the client should still apply the established Calypso image-safety path before rendering image URLs. This prevents
  direct rendering of arbitrary external avatar URLs while preserving existing reviewer chip behavior when a safe avatar can be produced.

  ## Testing Instructions

  * Run `yarn test-packages packages/jetpack-ai-sidebar --runInBand`.
  * On a WPCOM sandbox, install this Agents Manager bundle on sandboxed `widgets.wp.com`:
    * `install-plugin.sh am update/ai-editorial-review-avatar-safety`
  * Open a Simple site post editor using sandboxed `widgets.wp.com`.
  * Open AI Editorial Review in the Jetpack AI sidebar.
  * Trigger a review that includes reviewer metadata with avatars.
  * Confirm reviewer avatars still render when the avatar URL is valid.
  * Confirm reviewer names still fall back to colored pills when no avatar is available.
  * Confirm there are no TypeScript, React, or image-loading console errors while rendering review results.

  ## Pre-merge Checklist

  - [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
  - [x] Have you written new tests for your changes?
  - [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
  - [ ] Have you checked for TypeScript, React or other console errors?
  - [ ] For UI changes, have you tested the affected components in dark mode?
  - [ ] Have you tested accessibility for your changes?
  - [x] Have you used memoizing on expensive computations? N/A
  - [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation? N/A
  - [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?
