### PR TITLE
Agents Manager: deduplicate split-screen handling in AgentDock

### DIFF
--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -268,9 +268,6 @@ export default function AgentDock( {
 					onClick: () => {
 						undock();
 						setIsDocked( false );
-						// Split screen only makes sense while docked; clear the
-						// flag so the option returns cleanly when re-docked.
-						setIsSplitScreen( false );
 					},
 				},
 			! isReaderChat &&

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -134,7 +134,11 @@ export default function AgentDock( {
 		sectionName,
 		maybeOpenChat: () => {
 			if ( ! isPersistedOpen ) {
-				isDocked ? openSidebar() : setOpenState( true );
+				if ( isDocked ) {
+					openSidebar();
+				} else {
+					setOpenState( true );
+				}
 			}
 		},
 		navigate,
@@ -150,23 +154,6 @@ export default function AgentDock( {
 		setShouldRenderChat,
 		setDesktopMediaQuery,
 	} );
-
-	// Reflect split-screen state on the sidebar container element. The
-	// container class is added by `useAgentLayoutManager` when docked; we
-	// only toggle the extra `is-split-screen` modifier on it so the CSS
-	// override in `agent-dock/style.scss` (`--am-sidebar-width: 50vw`)
-	// wins at runtime. No-op if the sidebar isn't mounted (floating or
-	// closed), and auto-clears on unmount to avoid leaking the class.
-	useEffect( () => {
-		const container = document.querySelector( '.agents-manager-sidebar-container' );
-		if ( ! container ) {
-			return;
-		}
-		container.classList.toggle( 'is-split-screen', !! isSplitScreen );
-		return () => {
-			container.classList.remove( 'is-split-screen' );
-		};
-	}, [ isSplitScreen, isDocked, isPersistedOpen ] );
 
 	const handleAbort = useCallback( () => {
 		const agentManager = getAgentManager();

--- a/packages/agents-manager/src/hooks/__tests__/use-agent-layout-manager.test.tsx
+++ b/packages/agents-manager/src/hooks/__tests__/use-agent-layout-manager.test.tsx
@@ -22,6 +22,7 @@ jest.mock( '@wordpress/element', () => ( {
 
 const CLOSING_CLASS = 'agents-manager-sidebar-container--closing';
 const OPEN_CLASS = 'agents-manager-sidebar-container--sidebar-open';
+const SPLIT_SCREEN_CLASS = 'is-split-screen';
 const TRANSITION_MS = 200;
 
 const FULLSCREEN_BODY_CLASS = 'is-fullscreen-mode';
@@ -220,5 +221,63 @@ describe( 'useAgentLayoutManager — fullscreen gate', () => {
 			await Promise.resolve();
 		} );
 		expect( result.current.canDock ).toBe( false );
+	} );
+} );
+
+describe( 'useAgentLayoutManager — split-screen class', () => {
+	let container: HTMLElement;
+
+	beforeEach( () => {
+		container = document.createElement( 'div' );
+		document.body.appendChild( container );
+	} );
+
+	afterEach( () => {
+		container.remove();
+	} );
+
+	function renderWithSplitScreen( isSplitScreen: boolean ) {
+		return renderHook(
+			( props: { isSplitScreen: boolean } ) =>
+				useAgentLayoutManager( {
+					sidebarContainer: container,
+					defaultDocked: true,
+					defaultOpen: true,
+					isSplitScreen: props.isSplitScreen,
+				} ),
+			{ initialProps: { isSplitScreen } }
+		);
+	}
+
+	it( 'adds the class when `isSplitScreen` flips from `false` to `true`', () => {
+		const { rerender } = renderWithSplitScreen( false );
+
+		expect( container.classList.contains( SPLIT_SCREEN_CLASS ) ).toBe( false );
+
+		rerender( { isSplitScreen: true } );
+
+		expect( container.classList.contains( SPLIT_SCREEN_CLASS ) ).toBe( true );
+	} );
+
+	it( 'removes the class when `isSplitScreen` flips from `true` to `false`', () => {
+		const { rerender } = renderWithSplitScreen( true );
+
+		expect( container.classList.contains( SPLIT_SCREEN_CLASS ) ).toBe( true );
+
+		rerender( { isSplitScreen: false } );
+
+		expect( container.classList.contains( SPLIT_SCREEN_CLASS ) ).toBe( false );
+	} );
+
+	it( 'removes the class on unmount', () => {
+		const { unmount } = renderWithSplitScreen( true );
+
+		expect( container.classList.contains( SPLIT_SCREEN_CLASS ) ).toBe( true );
+
+		act( () => {
+			unmount();
+		} );
+
+		expect( container.classList.contains( SPLIT_SCREEN_CLASS ) ).toBe( false );
 	} );
 } );

--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/README.md
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/README.md
@@ -75,6 +75,7 @@ The hook automatically manages these CSS classes based on the chat state:
 - `agents-manager-sidebar-container--sidebar-open` is added when the sidebar is open
 - `agents-manager-sidebar-container--closing` is added during the close transition and removed once complete
 - `agents-manager-chat--docked` or `agents-manager-chat--undocked` based on mode
+- `is-split-screen` is toggled on the container when the `isSplitScreen` option is `true`, letting consumer SCSS opt into a wider docked layout
 
 **SCSS Example:**
 
@@ -138,6 +139,8 @@ The hook accepts a single options object. All properties are optional.
 - **`onDock`** (`() => void`, default: `() => {}`) - Callback fired when the chat switches to docked (sidebar) mode.
 
 - **`onUndock`** (`() => void`, default: `() => {}`) - Callback fired when the chat switches to floating (undocked) mode.
+
+- **`isSplitScreen`** (`boolean`, default: `false`) - When `true`, the hook toggles an `is-split-screen` modifier class on the sidebar container so consumer SCSS can opt into a wider docked layout (e.g. `--am-sidebar-width: 50vw`). The hook only mirrors the flag into the DOM and doesn't change layout dimensions itself.
 
 ### Return Value
 

--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/README.md
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/README.md
@@ -140,7 +140,7 @@ The hook accepts a single options object. All properties are optional.
 
 - **`onUndock`** (`() => void`, default: `() => {}`) - Callback fired when the chat switches to floating (undocked) mode.
 
-- **`isSplitScreen`** (`boolean`, default: `false`) - When `true`, the hook toggles an `is-split-screen` modifier class on the sidebar container so consumer SCSS can opt into a wider docked layout (e.g. `--am-sidebar-width: 50vw`). The hook only mirrors the flag into the DOM and doesn't change layout dimensions itself.
+- **`isSplitScreen`** (`boolean`, default: `false`) - When `true`, the hook toggles an `is-split-screen` modifier class on the sidebar container so consumer SCSS can opt into a wider docked layout (e.g. `--am-sidebar-width: 50vw`).
 
 ### Return Value
 

--- a/packages/data-stores/src/agents-manager/reducer.ts
+++ b/packages/data-stores/src/agents-manager/reducer.ts
@@ -72,10 +72,9 @@ export const isSplitScreen: Reducer< boolean, AgentsManagerAction > = ( state = 
 	switch ( action.type ) {
 		case 'AGENTS_MANAGER_SET_SPLIT_SCREEN':
 			return action.isSplitScreen;
-		// Split-screen only makes sense while docked. Reset on every undock
-		// so a stale `true` can't re-apply on the next dock — single source
-		// of truth covering in-React callers (e.g. AgentDock's undock menu)
-		// as well as out-of-band paths (e.g. `window.__agentsManagerActions`).
+		// Split-screen only makes sense while docked. Reset on undock in
+		// the reducer so every undock path clears it — including out-of-band
+		// ones like `window.__agentsManagerActions`.
 		case 'AGENTS_MANAGER_SET_DOCKED':
 			return action.isDocked ? state : false;
 	}

--- a/packages/data-stores/src/agents-manager/reducer.ts
+++ b/packages/data-stores/src/agents-manager/reducer.ts
@@ -72,9 +72,9 @@ export const isSplitScreen: Reducer< boolean, AgentsManagerAction > = ( state = 
 	switch ( action.type ) {
 		case 'AGENTS_MANAGER_SET_SPLIT_SCREEN':
 			return action.isSplitScreen;
-		// Split-screen only makes sense while docked. Reset on undock in
-		// the reducer so every undock path clears it — including out-of-band
-		// ones like `window.__agentsManagerActions`.
+		// Split-screen only makes sense while docked. Reset on undock so an
+		// out-of-band `setIsDocked(false)` (e.g. from `window.__agentsManagerActions`)
+		// can't leave a stale `true` that re-applies on the next dock.
 		case 'AGENTS_MANAGER_SET_DOCKED':
 			return action.isDocked ? state : false;
 	}

--- a/packages/data-stores/src/agents-manager/reducer.ts
+++ b/packages/data-stores/src/agents-manager/reducer.ts
@@ -72,9 +72,10 @@ export const isSplitScreen: Reducer< boolean, AgentsManagerAction > = ( state = 
 	switch ( action.type ) {
 		case 'AGENTS_MANAGER_SET_SPLIT_SCREEN':
 			return action.isSplitScreen;
-		// Split-screen only makes sense while docked. Reset on undock so an
-		// out-of-band `setIsDocked(false)` (e.g. from `window.__agentsManagerActions`)
-		// can't leave a stale `true` that re-applies on the next dock.
+		// Split-screen only makes sense while docked. Reset on every undock
+		// so a stale `true` can't re-apply on the next dock — single source
+		// of truth covering in-React callers (e.g. AgentDock's undock menu)
+		// as well as out-of-band paths (e.g. `window.__agentsManagerActions`).
 		case 'AGENTS_MANAGER_SET_DOCKED':
 			return action.isDocked ? state : false;
 	}


### PR DESCRIPTION
Part of #

## Proposed Changes

* Remove a redundant `useEffect` in `AgentDock` that toggled the `is-split-screen` class on the sidebar container via `document.querySelector`. `useAgentLayoutManager` already handles this via `useLayoutEffect` using the container ref it owns, with cleanup on unmount.
* Drop a redundant `setIsSplitScreen( false )` call in `AgentDock`'s "Pop out sidebar" handler. The reducer at `packages/data-stores/src/agents-manager/reducer.ts` already auto-resets `isSplitScreen` whenever `setIsDocked( false )` is dispatched — verified empirically that the reset lands synchronously before any follow-up read, so the explicit dispatch was dead code.
* Add unit tests in `use-agent-layout-manager.test.tsx` covering the hook's split-screen behavior (false→true, true→false, unmount cleanup) so the contract the deletion relies on is guarded.
* Document the `isSplitScreen` option and the `is-split-screen` class in the hook's `README.md`.
* Minor: convert a ternary-as-statement in `useAdminBarIntegration`'s `maybeOpenChat` to an `if`/`else` so pre-commit lint (`@typescript-eslint/no-unused-expressions`) passes on the whole file.

## Why are these changes being made?

Two instances of the same anti-pattern in `AgentDock` — the component re-implementing concerns that the underlying primitives already own:

1. **DOM-level:** the duplicate `useEffect` was added after the hook-side handling had shipped, leaving two writers for the same `is-split-screen` class on `<body>`. The component's version was strictly worse — it queried the DOM imperatively from outside the layout manager (which owns the container), ran post-paint via `useEffect` instead of pre-paint via `useLayoutEffect`, and had broader dependencies (`isDocked`, `isPersistedOpen`) that caused redundant cleanup/re-application cycles. The CSS rule in `agent-dock/style.scss` gates on `body.agents-manager-sidebar-container.is-split-screen` anyway, so the component's "conditional" check added no real safety the CSS itself wasn't already providing.
2. **State-level:** the explicit `setIsSplitScreen( false )` after `setIsDocked( false )` in the undock handler. The reducer already handles this via a cross-slice case on `AGENTS_MANAGER_SET_DOCKED` — the comment there explicitly frames the reducer-level reset as the safety net for out-of-band callers (e.g. `window.__agentsManagerActions`). The explicit dispatch was the same belt-and-suspenders duplication.

The hook had no unit test for the split-screen class behavior, so the tests added here lock the hook-side contract in place. The README updates close the discovery gap so the next consumer can find the option without grepping.

## Testing Instructions

* Sandbox this PR
* Edit a post from `https://wellyshen-jinue.wordpress.com/wp-admin/edit.php`, and check the `is-split-screen` option; it should still work the same:

https://github.com/user-attachments/assets/c6f2b5b5-7bdb-4309-842f-439c8a0d489a

* After undocking, the split screen mode will be reset:

https://github.com/user-attachments/assets/2392bc6d-f33c-47d1-8bdf-28a358571e54

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?