### PR TITLE
Fix Reader Chat UUID fallback

### DIFF
--- a/packages/agents-manager/src/hooks/use-persisted-history.ts
+++ b/packages/agents-manager/src/hooks/use-persisted-history.ts
@@ -7,6 +7,7 @@ import { select as storeSelect, useSelect } from '@wordpress/data';
 import { useState, useLayoutEffect, useCallback, useMemo } from '@wordpress/element';
 import { Action, Location } from 'history';
 import { AGENTS_MANAGER_STORE } from '../stores';
+import { generateUUID } from '../utils/generate-uuid';
 import { persistAgentsManagerState } from '../utils/persist-agents-manager-state';
 
 const DEFAULT_INACTIVITY_TIMEOUT_MS = 60 * 60 * 1000; // 1 hour
@@ -133,7 +134,7 @@ class MemoryHistory {
 			search: search ? `?${ search }` : '',
 			hash: hash ? `#${ hash }` : '',
 			state,
-			key: crypto.randomUUID(),
+			key: generateUUID(),
 		};
 	}
 

--- a/packages/agents-manager/src/hooks/use-save-new-chat-route.ts
+++ b/packages/agents-manager/src/hooks/use-save-new-chat-route.ts
@@ -4,6 +4,7 @@ import { useLocation } from 'react-router-dom';
 import { useAgentsManagerContext } from '../contexts';
 import { AGENTS_MANAGER_STORE } from '../stores';
 import { getSessionId } from '../utils/agent-session';
+import { generateUUID } from '../utils/generate-uuid';
 import { persistAgentsManagerState } from '../utils/persist-agents-manager-state';
 import type { AgentsManagerSelect } from '@automattic/data-stores';
 
@@ -18,7 +19,7 @@ function saveNewChatRoute( sessionId: string, siteKey: string ): void {
 		pathname: '/chat',
 		search: '',
 		hash: '',
-		key: crypto.randomUUID(),
+		key: generateUUID(),
 		state: { sessionId },
 	};
 

--- a/packages/agents-manager/src/utils/__tests__/generate-uuid.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/generate-uuid.test.ts
@@ -1,0 +1,53 @@
+import { generateUUID } from '../generate-uuid';
+
+describe( 'generateUUID', () => {
+	const savedRandomUUID = globalThis.crypto.randomUUID;
+
+	afterEach( () => {
+		globalThis.crypto.randomUUID = savedRandomUUID;
+		jest.restoreAllMocks();
+	} );
+
+	it( 'uses crypto.randomUUID when available', () => {
+		const randomUUIDSpy = jest
+			.spyOn( globalThis.crypto, 'randomUUID' )
+			.mockReturnValue( 'crypto-uuid' as ReturnType< Crypto[ 'randomUUID' ] > );
+
+		expect( generateUUID() ).toBe( 'crypto-uuid' );
+		expect( randomUUIDSpy ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'falls back when crypto.randomUUID is unavailable', () => {
+		// @ts-expect-error - Simulating an older browser.
+		delete globalThis.crypto.randomUUID;
+
+		expect( generateUUID() ).toMatch(
+			/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+		);
+	} );
+
+	it( 'uses crypto.getRandomValues for fallback randomness when available', () => {
+		// @ts-expect-error - Simulating an older browser.
+		delete globalThis.crypto.randomUUID;
+		const getRandomValuesSpy = jest.spyOn( globalThis.crypto, 'getRandomValues' );
+
+		generateUUID();
+
+		expect( getRandomValuesSpy ).toHaveBeenCalled();
+	} );
+
+	it( 'keeps fallback UUIDs valid when getRandomValues returns the maximum byte', () => {
+		// @ts-expect-error - Simulating an older browser.
+		delete globalThis.crypto.randomUUID;
+		jest.spyOn( globalThis.crypto, 'getRandomValues' ).mockImplementation( ( array ) => {
+			if ( array ) {
+				new Uint8Array( array.buffer, array.byteOffset, array.byteLength ).fill( 255 );
+			}
+			return array;
+		} );
+
+		expect( generateUUID() ).toMatch(
+			/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+		);
+	} );
+} );

--- a/packages/agents-manager/src/utils/agent-session.ts
+++ b/packages/agents-manager/src/utils/agent-session.ts
@@ -3,6 +3,7 @@
  * Session IDs are written to `localStorage` by `agenttic-client` and expire after 24 hours.
  */
 import { ORCHESTRATOR_AGENT_ID } from '../constants';
+import { generateUUID } from './generate-uuid';
 
 export const SESSION_STORAGE_KEY = 'agents-manager-session-id';
 const SESSION_EXPIRY_MS = 24 * 60 * 60 * 1000; // 24 hours
@@ -114,15 +115,7 @@ export function getOrCreateSessionId( isNewChat: boolean, agentId?: string ): st
 		return existing;
 	}
 	try {
-		const newId =
-			typeof crypto !== 'undefined' && crypto.randomUUID
-				? crypto.randomUUID()
-				: // Fallback for older browsers.
-				  'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace( /[xy]/g, ( c ) => {
-						const r = ( Math.random() * 16 ) | 0;
-						const v = c === 'x' ? r : ( r & 0x3 ) | 0x8;
-						return v.toString( 16 );
-				  } );
+		const newId = generateUUID();
 		localStorage.setItem(
 			getSessionStorageKey( agentId ),
 			JSON.stringify( { sessionId: newId, timestamp: Date.now() } )

--- a/packages/agents-manager/src/utils/generate-uuid.ts
+++ b/packages/agents-manager/src/utils/generate-uuid.ts
@@ -1,0 +1,18 @@
+export function generateUUID(): string {
+	if ( typeof globalThis.crypto?.randomUUID === 'function' ) {
+		return globalThis.crypto.randomUUID();
+	}
+
+	const randomValues =
+		typeof globalThis.crypto?.getRandomValues === 'function'
+			? globalThis.crypto.getRandomValues( new Uint8Array( 32 ) )
+			: undefined;
+	let randomIndex = 0;
+
+	return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace( /[xy]/g, ( c ) => {
+		// Last-resort Math.random fallback is for local IDs, not authentication.
+		const r = randomValues ? randomValues[ randomIndex++ ] & 0x0f : ( Math.random() * 16 ) | 0;
+		const v = c === 'x' ? r : ( r & 0x3 ) | 0x8;
+		return v.toString( 16 );
+	} );
+}


### PR DESCRIPTION
Part of #

## Proposed Changes

* Add a package-local `generateUUID()` helper for Agents Manager that uses `crypto.randomUUID()`, falls back to `crypto.getRandomValues()`, and only uses `Math.random()` as a last resort for local IDs.
* Replace unguarded `crypto.randomUUID()` calls in persisted history, saved chat route, and session creation.

## Why are these changes being made?

* Reader Chat can run in frontend contexts where `crypto.randomUUID` is unavailable, such as a non-secure test-site origin. Those contexts currently throw during route creation and prevent the widget from loading.
* Centralizing UUID creation keeps fallback behavior consistent across the Reader Chat bundle.

## Testing Instructions

Automated/local checks:

* `yarn install --immutable`
* `yarn test-packages packages/agents-manager/src/utils/__tests__/generate-uuid.test.ts packages/agents-manager/src/utils/__tests__/agent-session.test.ts --runInBand`
* `yarn test-apps apps/agents-manager/__tests__/reader-chat.test.js --runInBand`
* `./node_modules/.bin/tsc --project packages/agents-manager/tsconfig.json --noEmit --pretty false`
* `yarn eslint packages/agents-manager/src/utils/generate-uuid.ts packages/agents-manager/src/utils/__tests__/generate-uuid.test.ts packages/agents-manager/src/hooks/use-persisted-history.ts packages/agents-manager/src/hooks/use-save-new-chat-route.ts packages/agents-manager/src/utils/agent-session.ts`
* Claude review: clean after follow-up.

Manual testing steps:

1. Install this PR on your sandbox `install-plugin.sh am fix/reader-chat-uuid-fallback`
2. Go to this site https://gd.testjetpack.blog/ make sure the Reader Chat widget is loaded
<img width="915" height="1000" alt="image" src="https://github.com/user-attachments/assets/f9121db7-997a-4894-af64-f18f11d757f3" />

Note: Styles are still broken due to aggressive styling of the site. I will address this in the next PR.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
