### PR TITLE
Reader: match social account card hover ring to brand accent

### DIFF
--- a/client/reader/connections/style.scss
+++ b/client/reader/connections/style.scss
@@ -42,13 +42,16 @@
 	cursor: pointer;
 	transition: transform 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
 
+	// Reuse the per-card brand accent so the hover/focus ring matches the
+	// leading edge stripe (pink for Fediverse, blue for Bluesky, purple
+	// for Mastodon). Falls back to --color-primary if no accent is set.
 	&:hover {
 		transform: translateY( -2px );
-		box-shadow: 0 0 0 2px var( --color-primary );
+		box-shadow: 0 0 0 2px var( --connections-new-card-accent, var( --color-primary ) );
 	}
 
 	&:focus-within {
-		box-shadow: 0 0 0 2px var( --color-primary );
+		box-shadow: 0 0 0 2px var( --connections-new-card-accent, var( --color-primary ) );
 	}
 }
 


### PR DESCRIPTION
Fixes READ-517

## Proposed Changes

* On `/reader/connections/new`, swap the card-wide hover/focus ring colour from `--color-primary` to the per-card `--connections-new-card-accent` variable (with `--color-primary` as the fallback).

## Why are these changes being made?

Every card on the "Add a social account" screen has a coloured leading-edge stripe in the platform brand colour (pink Fediverse, blue Bluesky, purple Mastodon). The card-wide hover ring was always blue, which clashed with the non-blue stripes — most visibly on Mastodon (blue ring + purple stripe) and Fediverse (blue ring + pink stripe). Reusing the existing brand accent makes the hover state read as one visual unit per card.

## Testing Instructions

* Visit `/reader/connections/new`.
* Hover (and tab to focus) each card in turn:
  * Fediverse → pink ring matches the pink leading stripe.
  * Bluesky → blue ring matches the blue stripe (unchanged from before).
  * Mastodon → purple ring matches the purple stripe.
* Verify in dark mode that the rings remain readable against the surface.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?