### PR TITLE
Reader social: swap WordPress logomark on Blog About button for arrow glyph

### DIFF
--- a/client/reader/social/components/post-card/blog-about-button.tsx
+++ b/client/reader/social/components/post-card/blog-about-button.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@wordpress/components';
-import { wordpress } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useSocialAnalytics } from './analytics-context';
@@ -9,6 +8,17 @@ import type { SocialPost } from '../../types';
 interface BlogAboutButtonProps {
 	post: SocialPost;
 }
+
+const blogAboutIcon = (
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none">
+		<path
+			fill="currentColor"
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M18.1829 4.48645L23.0291 9.64418L18.1829 14.8019L17.0898 13.7748L20.2662 10.3942H15.4545C15.3059 10.3942 15.041 10.3921 14.7075 10.3894C13.6949 10.3813 12.0504 10.3682 11.1114 10.3939L11.1012 10.3942H11.0909C9.82855 10.3942 8.21568 10.7119 6.94269 11.5722C5.70975 12.4055 4.75 13.773 4.75 16.0299V18.5C4.75 18.5 4.41421 18.5 4 18.5C3.58579 18.5 3.25 18.5 3.25 18.5V16.0299C3.25 13.257 4.47206 11.4315 6.10276 10.3294C7.68965 9.25694 9.61685 8.89589 11.0805 8.89419C12.0526 8.86799 13.7608 8.88167 14.7635 8.8897C15.0782 8.89222 15.3234 8.89418 15.4545 8.89418H20.2662L17.0898 5.51358L18.1829 4.48645Z"
+		/>
+	</svg>
+);
 
 export function BlogAboutButton( { post }: BlogAboutButtonProps ) {
 	const translate = useTranslate();
@@ -31,7 +41,8 @@ export function BlogAboutButton( { post }: BlogAboutButtonProps ) {
 				className="social-post-card-counts__blog-about-button"
 				variant="tertiary"
 				size="small"
-				icon={ wordpress }
+				icon={ blogAboutIcon }
+				iconSize={ 18 }
 				label={ label }
 				showTooltip
 				onClick={ handleClick }


### PR DESCRIPTION
Fixes READ-518

## Proposed Changes

* In the Reader social post-card row, replace the WordPress logomark on the Blog About button with a custom curved-arrow glyph, sized at 18px to match the like / repost / reply icons in the same row.

## Why are these changes being made?

* The WordPress logomark read as attribution ("this post is from WordPress") rather than as the available action. A directional curved-arrow glyph communicates "pull this into your blog" and avoids the false-attribution ambiguity, while staying visually consistent with the other engagement icons in the row.

## Testing Instructions

* Open a Reader social surface that renders `SocialPostCard` (ATmosphere timeline / thread, Mastodon timeline / thread).
* Confirm the rightmost button in the post-card row now shows a curved-arrow glyph (not the WordPress mark), is the same visual size as the like / repost / reply icons, and the tooltip on hover/focus still reads "Blog about this post".
* Click the button — the Blog About modal opens as before. Light + dark mode pass; keyboard activation still works.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?