### PR TITLE
Add AI assistant email address settings

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -870,7 +870,7 @@ export const siteSettingsAIToolsRoute = createRoute( {
 			queryClient.prefetchQuery( sitePostByEmailSettingsQuery( site ) );
 		}
 
-		await Promise.all( [ queryClient.ensureQueryData( userSettingsQuery() ) ] );
+		await queryClient.ensureQueryData( userSettingsQuery() );
 	},
 } );
 

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -21,6 +21,7 @@ import {
 	siteJetpackSettingsQuery,
 	siteMediaStorageQuery,
 	sitePHPVersionQuery,
+	sitePostByEmailSettingsQuery,
 	siteCurrentPlanQuery,
 	sitePlansQuery,
 	siteBySlugQuery,
@@ -863,10 +864,13 @@ export const siteSettingsAIToolsRoute = createRoute( {
 	},
 	loader: async ( { params: { siteSlug } } ) => {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
-		await Promise.all( [
-			queryClient.ensureQueryData( bigSkyPluginQuery( site.ID ) ),
-			queryClient.ensureQueryData( userSettingsQuery() ),
-		] );
+		const pluginStatus = await queryClient.ensureQueryData( bigSkyPluginQuery( site.ID ) );
+
+		if ( pluginStatus?.available ) {
+			queryClient.prefetchQuery( sitePostByEmailSettingsQuery( site ) );
+		}
+
+		await Promise.all( [ queryClient.ensureQueryData( userSettingsQuery() ) ] );
 	},
 } );
 

--- a/client/dashboard/sites/settings-ai-tools/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/index.tsx
@@ -30,6 +30,7 @@ import {
 	help,
 	image,
 	pencil,
+	send,
 	seen,
 	termDescription,
 } from '@wordpress/icons';
@@ -109,6 +110,8 @@ const features = [
 	__( 'Draft and revise content in one place' ),
 	__( 'Create beautiful images without leaving WordPress' ),
 ];
+
+const TELEGRAM_CONNECTION_PATH = '/me/developer';
 
 const INVALID_POST_BY_EMAIL_VALUES = new Set( [
 	'',
@@ -480,6 +483,21 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 					) }
 				</Card>
 				<EmailAssistantCard site={ site } recordTracksEvent={ recordTracksEvent } />
+				{ config.isEnabled( 'dolly/telegram' ) && (
+					<SummaryButton
+						href={ TELEGRAM_CONNECTION_PATH }
+						title={ __( 'Connect Telegram' ) }
+						description={ __(
+							'Connect your WordPress.com account to Telegram. This connection is shared across multiple sites.'
+						) }
+						decoration={ <Icon icon={ send } size={ 24 } /> }
+						onClick={ () => {
+							recordTracksEvent( 'calypso_dashboard_ai_tool_connect_telegram_click', {
+								site_id: site.ID,
+							} );
+						} }
+					/>
+				) }
 				{ config.isEnabled( 'mcp-settings' ) && (
 					<>
 						<Card className="mcp-settings__access-card">

--- a/client/dashboard/sites/settings-ai-tools/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/index.tsx
@@ -1,19 +1,22 @@
 import './style.scss';
 
-import { HostingFeatures } from '@automattic/api-core';
+import { HostingFeatures, type Site } from '@automattic/api-core';
 import {
 	bigSkyPluginMutation,
 	bigSkyPluginQuery,
 	siteBySlugQuery,
+	sitePostByEmailSettingsMutation,
+	sitePostByEmailSettingsQuery,
 	userSettingsMutation,
 	userSettingsQuery,
 } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
-import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	__experimentalText as Text,
+	Button,
 	Icon,
 	ToggleControl,
 } from '@wordpress/components';
@@ -42,8 +45,10 @@ import { useAnalytics } from '../../app/analytics';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { useHelpCenter } from '../../app/help-center';
 import { Card, CardBody, CardDivider, CardFooter } from '../../components/card';
+import ClipboardInputControl from '../../components/clipboard-input-control';
 import ConfirmModal from '../../components/confirm-modal';
 import InlineSupportLink from '../../components/inline-support-link';
+import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
@@ -105,6 +110,194 @@ const features = [
 	__( 'Create beautiful images without leaving WordPress' ),
 ];
 
+const INVALID_POST_BY_EMAIL_VALUES = new Set( [
+	'',
+	'null',
+	'noop',
+	'create',
+	'regenerate',
+	'delete',
+] );
+
+export function getAgentEmailAddress( postByEmailAddress?: string | null ) {
+	const trimmedAddress = postByEmailAddress?.trim() ?? '';
+	const normalizedAddress = trimmedAddress.toLowerCase();
+
+	if ( INVALID_POST_BY_EMAIL_VALUES.has( normalizedAddress ) ) {
+		return null;
+	}
+
+	const [ localPart, domain, ...extraParts ] = trimmedAddress.split( '@' );
+
+	if ( ! localPart || ! domain || extraParts.length > 0 ) {
+		return null;
+	}
+
+	const agentLocalPart = localPart.startsWith( 'agent+' ) ? localPart : `agent+${ localPart }`;
+
+	return `${ agentLocalPart }@${ domain }`;
+}
+
+function escapeVCardValue( value: string ) {
+	return value
+		.replace( /\\/g, '\\\\' )
+		.replace( /\r\n|\r|\n/g, '\\n' )
+		.replace( /,/g, '\\,' )
+		.replace( /;/g, '\\;' );
+}
+
+export function getAgentEmailVCard( siteDomain: string, agentEmailAddress: string ) {
+	const escapedSiteDomain = escapeVCardValue( siteDomain );
+	const escapedAgentEmailAddress = escapeVCardValue( agentEmailAddress );
+
+	return [
+		'BEGIN:VCARD',
+		'VERSION:3.0',
+		`FN:${ escapedSiteDomain }`,
+		`N:${ escapedSiteDomain };;;;`,
+		`EMAIL;TYPE=INTERNET:${ escapedAgentEmailAddress }`,
+		'END:VCARD',
+		'',
+	].join( '\r\n' );
+}
+
+function getVCardDataUrl( siteDomain: string, agentEmailAddress: string ) {
+	return `data:text/vcard;charset=utf-8,${ encodeURIComponent(
+		getAgentEmailVCard( siteDomain, agentEmailAddress )
+	) }`;
+}
+
+function getVCardFileName( siteDomain: string ) {
+	const fileName = siteDomain.replace( /[^a-z0-9.-]+/gi, '-' ).replace( /^-+|-+$/g, '' );
+
+	return `${ fileName || 'ai-agent' }.vcf`;
+}
+
+function EmailAssistantCard( {
+	site,
+	recordTracksEvent,
+}: {
+	site: Site;
+	recordTracksEvent: ReturnType< typeof useAnalytics >[ 'recordTracksEvent' ];
+} ) {
+	const { data: postByEmailSettings, isLoading: isPostByEmailSettingsLoading } = useQuery(
+		sitePostByEmailSettingsQuery( site )
+	);
+	const agentEmailAddress = getAgentEmailAddress( postByEmailSettings?.post_by_email_address );
+	const isAgentEmailEnabled = !! agentEmailAddress;
+	const vCardHref = agentEmailAddress ? getVCardDataUrl( site.slug, agentEmailAddress ) : undefined;
+	const vCardFileName = getVCardFileName( site.slug );
+
+	const emailAddressMutation = useMutation( {
+		...sitePostByEmailSettingsMutation( site ),
+		meta: {
+			snackbar: {
+				success: __( 'AI agent email address settings saved.' ),
+				error: __( 'Failed to save AI agent email address settings.' ),
+			},
+		},
+	} );
+	const isEmailAddressActionDisabled =
+		isPostByEmailSettingsLoading || emailAddressMutation.isPending;
+
+	const handleEmailAddressToggle = ( enabled: boolean ) => {
+		emailAddressMutation.mutate(
+			{
+				post_by_email_address: enabled ? 'create' : 'delete',
+			},
+			{
+				onSuccess: () => {
+					recordTracksEvent( 'calypso_dashboard_ai_tool_email_agent_toggled', {
+						enabled,
+						site_id: site.ID,
+					} );
+				},
+			}
+		);
+	};
+
+	const handleRegenerateAddress = () => {
+		emailAddressMutation.mutate(
+			{
+				post_by_email_address: 'regenerate',
+			},
+			{
+				onSuccess: () => {
+					recordTracksEvent( 'calypso_dashboard_ai_tool_email_agent_regenerated', {
+						site_id: site.ID,
+					} );
+				},
+			}
+		);
+	};
+
+	const handleCopyAddress = () => {
+		recordTracksEvent( 'calypso_dashboard_ai_tool_email_agent_copied', {
+			site_id: site.ID,
+		} );
+	};
+
+	const handleAddToContacts = () => {
+		recordTracksEvent( 'calypso_dashboard_ai_tool_email_agent_vcard_downloaded', {
+			site_id: site.ID,
+		} );
+	};
+
+	return (
+		<Card>
+			<CardBody>
+				<VStack spacing={ 4 }>
+					<SectionHeader
+						title={ __( 'Email your assistant' ) }
+						description={ __( 'Email this site’s AI agent using a private address.' ) }
+						level={ 3 }
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						checked={ isAgentEmailEnabled }
+						disabled={ isEmailAddressActionDisabled }
+						label={ __( 'Enable AI agent email address' ) }
+						onChange={ handleEmailAddressToggle }
+					/>
+					<Notice density="medium">
+						{ __(
+							'Enabling this also enables Post by Email. Disabling it deletes the Post by Email address, so both Post by Email and this AI agent address will stop working.'
+						) }
+					</Notice>
+					{ agentEmailAddress && (
+						<VStack spacing={ 3 }>
+							<ClipboardInputControl
+								label={ __( 'AI agent email address' ) }
+								value={ agentEmailAddress }
+								readOnly
+								onCopy={ handleCopyAddress }
+							/>
+							<HStack justify="flex-start">
+								<Button
+									variant="secondary"
+									href={ vCardHref }
+									download={ vCardFileName }
+									onClick={ handleAddToContacts }
+								>
+									{ __( 'Add to contacts' ) }
+								</Button>
+								<Button
+									variant="secondary"
+									isBusy={ emailAddressMutation.isPending }
+									disabled={ isEmailAddressActionDisabled }
+									onClick={ handleRegenerateAddress }
+								>
+									{ __( 'Regenerate address' ) }
+								</Button>
+							</HStack>
+						</VStack>
+					) }
+				</VStack>
+			</CardBody>
+		</Card>
+	);
+}
+
 export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 	const { recordTracksEvent } = useAnalytics();
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
@@ -139,8 +332,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 	// When there are no site-specific overrides, use site_level_enabled_default as the effective
 	// state. True when account MCP is on for sites, false when disabled.
 	const hasSiteAbilityOverrides = Object.keys( siteAbilities ).length > 0;
-	const defaultToolEnabled =
-		( userSettings as any )?.mcp_abilities?.site_level_enabled_default ?? false;
+	const defaultToolEnabled = userSettings?.mcp_abilities?.site_level_enabled_default ?? false;
 	const defaultBadge = defaultToolEnabled
 		? { text: __( 'All enabled' ), intent: 'success' as const }
 		: { text: __( 'Disabled' ) };
@@ -287,6 +479,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 						</CardFooter>
 					) }
 				</Card>
+				<EmailAssistantCard site={ site } recordTracksEvent={ recordTracksEvent } />
 				{ config.isEnabled( 'mcp-settings' ) && (
 					<>
 						<Card className="mcp-settings__access-card">

--- a/client/dashboard/sites/settings-ai-tools/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/index.tsx
@@ -57,6 +57,7 @@ import { SectionHeader } from '../../components/section-header';
 import SummaryButton from '../../components/summary-button';
 import { SummaryButtonList } from '../../components/summary-button-list';
 import { isWriteTool } from '../../me/mcp/categories';
+import { wpcomLink } from '../../utils/link';
 import UpsellCallout from '../hosting-feature-gated-with-callout/upsell';
 import upsellIllustrationUrl from './upsell-illustration.svg';
 
@@ -485,7 +486,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 				<EmailAssistantCard site={ site } recordTracksEvent={ recordTracksEvent } />
 				{ config.isEnabled( 'dolly/telegram' ) && (
 					<SummaryButton
-						href={ TELEGRAM_CONNECTION_PATH }
+						href={ wpcomLink( TELEGRAM_CONNECTION_PATH ) }
 						title={ __( 'Connect Telegram' ) }
 						description={ __(
 							'Connect your WordPress.com account to Telegram. This connection is shared across multiple sites.'

--- a/client/dashboard/sites/settings-ai-tools/test/index.test.tsx
+++ b/client/dashboard/sites/settings-ai-tools/test/index.test.tsx
@@ -1,0 +1,354 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+	bigSkyPluginQuery,
+	queryClient,
+	siteBySlugQuery,
+	sitePostByEmailSettingsQuery,
+	userSettingsQuery,
+} from '@automattic/api-queries';
+import '@testing-library/jest-dom';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import { render } from '../../../test-utils';
+import AIToolsSettings, { getAgentEmailAddress, getAgentEmailVCard } from '../index';
+import type { Site, UserSettings } from '@automattic/api-core';
+
+const site = {
+	ID: 123,
+	slug: 'email-assistant.wordpress.com',
+	name: 'Email Assistant',
+	title: 'Email Assistant',
+	is_wpcom_atomic: true,
+	options: {
+		admin_url: 'https://email-assistant.wordpress.com/wp-admin/',
+	},
+} as unknown as Site;
+
+const simpleSite = {
+	...site,
+	ID: 456,
+	slug: 'simple-email-assistant.wordpress.com',
+	is_wpcom_atomic: false,
+	jetpack: false,
+} as Site;
+
+let clipboardWriteText: jest.Mock;
+
+function seedQueries( postByEmailAddress = '', seedPostByEmailSettings = true, activeSite = site ) {
+	queryClient.setQueryData( siteBySlugQuery( activeSite.slug ).queryKey, activeSite );
+	queryClient.setQueryData( bigSkyPluginQuery( activeSite.ID ).queryKey, {
+		blog_id: activeSite.ID,
+		enabled: false,
+		available: true,
+		on_free_trial: false,
+	} );
+	queryClient.setQueryData( userSettingsQuery().queryKey, {
+		mcp_abilities: {},
+	} as UserSettings );
+	if ( seedPostByEmailSettings ) {
+		queryClient.setQueryData( sitePostByEmailSettingsQuery( activeSite ).queryKey, {
+			post_by_email_address: postByEmailAddress,
+		} );
+	}
+}
+
+function mockJetpackPostByEmailMutation(
+	action: string,
+	postByEmailAddress?: string,
+	activeSite = site
+) {
+	return nock( 'https://public-api.wordpress.com' )
+		.post( `/rest/v1.1/jetpack-blogs/${ activeSite.ID }/rest-api/`, ( body ) => {
+			expect( body.path ).toBe( '/jetpack/v4/settings/' );
+			expect( body.json ).toBe( true );
+			expect( JSON.parse( body.body ) ).toEqual( {
+				post_by_email_address: action,
+			} );
+			return true;
+		} )
+		.query( true )
+		.reply( 200, {
+			post_by_email_address: postByEmailAddress ?? 'noop',
+		} );
+}
+
+function mockWpcomPostByEmailMutation(
+	action: 'create' | 'regenerate' | 'delete',
+	postByEmailAddress?: string,
+	activeSite = simpleSite
+) {
+	const path = `/wpcom/v2/sites/${ activeSite.ID }/post-by-email`;
+	const scope = nock( 'https://public-api.wordpress.com' );
+
+	if ( action === 'create' ) {
+		return scope.post( path ).reply( 200, {
+			is_enabled: true,
+			email: postByEmailAddress,
+		} );
+	}
+
+	if ( action === 'regenerate' ) {
+		return scope.put( path ).reply( 200, {
+			email: postByEmailAddress,
+		} );
+	}
+
+	return scope.delete( path ).reply( 200 );
+}
+
+function mockWpcomPostByEmailStatus( activeSite = simpleSite ) {
+	return nock( 'https://public-api.wordpress.com' )
+		.get( `/wpcom/v2/sites/${ activeSite.ID }/post-by-email` )
+		.reply( 200, {
+			is_enabled: false,
+		} );
+}
+
+function mockJetpackPostByEmailSettingsFailure() {
+	return nock( 'https://public-api.wordpress.com' )
+		.get( `/rest/v1.1/jetpack-blogs/${ site.ID }/rest-api/` )
+		.query( true )
+		.reply( 404, {
+			message: 'No route was found matching the URL and request method.',
+		} );
+}
+
+function renderAIToolsSettings(
+	postByEmailAddress = '',
+	seedPostByEmailSettings = true,
+	activeSite = site
+) {
+	seedQueries( postByEmailAddress, seedPostByEmailSettings, activeSite );
+
+	return render( <AIToolsSettings siteSlug={ activeSite.slug } />, { queryClient } );
+}
+
+function mockClipboard() {
+	Object.defineProperty( window.navigator, 'clipboard', {
+		value: {
+			writeText: clipboardWriteText,
+		},
+		configurable: true,
+	} );
+}
+
+beforeEach( () => {
+	clipboardWriteText = jest.fn().mockResolvedValue( undefined );
+	queryClient.clear();
+	queryClient.setDefaultOptions( {
+		queries: {
+			retry: false,
+			refetchOnMount: false,
+			refetchOnWindowFocus: false,
+			staleTime: Infinity,
+		},
+		mutations: {
+			retry: false,
+		},
+	} );
+	mockClipboard();
+} );
+
+afterEach( () => {
+	nock.cleanAll();
+} );
+
+describe( 'getAgentEmailAddress', () => {
+	test.each( [ '', 'NULL', 'noop', 'not-an-email' ] )(
+		'returns null for an unusable Post by Email value: %s',
+		( postByEmailAddress ) => {
+			expect( getAgentEmailAddress( postByEmailAddress ) ).toBeNull();
+		}
+	);
+
+	test( 'adds the agent prefix to a Post by Email address', () => {
+		expect( getAgentEmailAddress( 'secret@post.wordpress.com' ) ).toBe(
+			'agent+secret@post.wordpress.com'
+		);
+	} );
+
+	test( 'does not double-prefix an agent address', () => {
+		expect( getAgentEmailAddress( 'agent+secret@post.wordpress.com' ) ).toBe(
+			'agent+secret@post.wordpress.com'
+		);
+	} );
+} );
+
+describe( 'getAgentEmailVCard', () => {
+	test( 'generates a contact card named after the site domain', () => {
+		expect(
+			getAgentEmailVCard( 'email-assistant.wordpress.com', 'agent+secret@post.wordpress.com' )
+		).toBe(
+			[
+				'BEGIN:VCARD',
+				'VERSION:3.0',
+				'FN:email-assistant.wordpress.com',
+				'N:email-assistant.wordpress.com;;;;',
+				'EMAIL;TYPE=INTERNET:agent+secret@post.wordpress.com',
+				'END:VCARD',
+				'',
+			].join( '\r\n' )
+		);
+	} );
+} );
+
+describe( '<AIToolsSettings>', () => {
+	test( 'enables, copies, regenerates, and disables the AI agent email address', async () => {
+		const user = userEvent.setup();
+		mockClipboard();
+		renderAIToolsSettings();
+
+		expect( screen.getByRole( 'heading', { name: 'Email your assistant' } ) ).toBeVisible();
+		expect(
+			screen.getByText(
+				'Enabling this also enables Post by Email. Disabling it deletes the Post by Email address, so both Post by Email and this AI agent address will stop working.'
+			)
+		).toBeVisible();
+
+		const toggle = screen.getByRole( 'checkbox', {
+			name: 'Enable AI agent email address',
+		} );
+		expect( toggle ).not.toBeChecked();
+		expect( screen.queryByLabelText( 'AI agent email address' ) ).not.toBeInTheDocument();
+
+		const createScope = mockJetpackPostByEmailMutation(
+			'create',
+			'first-secret@post.wordpress.com'
+		);
+		await user.click( toggle );
+
+		await waitFor( () => {
+			expect( createScope.isDone() ).toBe( true );
+		} );
+
+		const addressInput = await screen.findByLabelText( 'AI agent email address' );
+		expect( addressInput ).toHaveValue( 'agent+first-secret@post.wordpress.com' );
+		expect( toggle ).toBeChecked();
+
+		const addToContactsLink = screen.getByRole( 'link', { name: 'Add to contacts' } );
+		expect( addToContactsLink ).toHaveAttribute( 'download', 'email-assistant.wordpress.com.vcf' );
+		expect(
+			decodeURIComponent(
+				addToContactsLink.getAttribute( 'href' )?.replace( 'data:text/vcard;charset=utf-8,', '' ) ??
+					''
+			)
+		).toContain( 'FN:email-assistant.wordpress.com\r\n' );
+		expect(
+			decodeURIComponent(
+				addToContactsLink.getAttribute( 'href' )?.replace( 'data:text/vcard;charset=utf-8,', '' ) ??
+					''
+			)
+		).toContain( 'EMAIL;TYPE=INTERNET:agent+first-secret@post.wordpress.com' );
+
+		await user.click( screen.getByRole( 'button', { name: 'Copy AI agent email address' } ) );
+		expect( clipboardWriteText ).toHaveBeenCalledWith( 'agent+first-secret@post.wordpress.com' );
+
+		const regenerateScope = mockJetpackPostByEmailMutation(
+			'regenerate',
+			'second-secret@post.wordpress.com'
+		);
+		await user.click( screen.getByRole( 'button', { name: 'Regenerate address' } ) );
+
+		await waitFor( () => {
+			expect( regenerateScope.isDone() ).toBe( true );
+		} );
+		await waitFor( () => {
+			expect( screen.getByLabelText( 'AI agent email address' ) ).toHaveValue(
+				'agent+second-secret@post.wordpress.com'
+			);
+		} );
+
+		const deleteScope = mockJetpackPostByEmailMutation( 'delete' );
+		await user.click( toggle );
+
+		await waitFor( () => {
+			expect( deleteScope.isDone() ).toBe( true );
+		} );
+		await waitFor( () => {
+			expect( toggle ).not.toBeChecked();
+			expect( screen.queryByLabelText( 'AI agent email address' ) ).not.toBeInTheDocument();
+		} );
+	} );
+
+	test( 'uses the WordPress.com Post by Email endpoint for simple sites', async () => {
+		const user = userEvent.setup();
+		renderAIToolsSettings( '', true, simpleSite );
+
+		const toggle = screen.getByRole( 'checkbox', {
+			name: 'Enable AI agent email address',
+		} );
+
+		const createScope = mockWpcomPostByEmailMutation(
+			'create',
+			'simple-secret@post.wordpress.com'
+		);
+		await user.click( toggle );
+
+		await waitFor( () => {
+			expect( createScope.isDone() ).toBe( true );
+		} );
+		expect( await screen.findByLabelText( 'AI agent email address' ) ).toHaveValue(
+			'agent+simple-secret@post.wordpress.com'
+		);
+
+		const regenerateScope = mockWpcomPostByEmailMutation(
+			'regenerate',
+			'new-simple-secret@post.wordpress.com'
+		);
+		await user.click( screen.getByRole( 'button', { name: 'Regenerate address' } ) );
+
+		await waitFor( () => {
+			expect( regenerateScope.isDone() ).toBe( true );
+		} );
+		await waitFor( () => {
+			expect( screen.getByLabelText( 'AI agent email address' ) ).toHaveValue(
+				'agent+new-simple-secret@post.wordpress.com'
+			);
+		} );
+
+		const deleteScope = mockWpcomPostByEmailMutation( 'delete' );
+		await user.click( toggle );
+
+		await waitFor( () => {
+			expect( deleteScope.isDone() ).toBe( true );
+		} );
+		await waitFor( () => {
+			expect( screen.queryByLabelText( 'AI agent email address' ) ).not.toBeInTheDocument();
+		} );
+	} );
+
+	test( 'loads simple site Post by Email status from the WordPress.com endpoint', async () => {
+		const settingsScope = mockWpcomPostByEmailStatus();
+
+		renderAIToolsSettings( '', false, simpleSite );
+
+		await waitFor( () => {
+			expect( settingsScope.isDone() ).toBe( true );
+		} );
+		expect(
+			screen.getByRole( 'checkbox', {
+				name: 'Enable AI agent email address',
+			} )
+		).not.toBeChecked();
+	} );
+
+	test( 'does not fail the page when Jetpack settings are unavailable', async () => {
+		const settingsScope = mockJetpackPostByEmailSettingsFailure();
+
+		renderAIToolsSettings( '', false );
+
+		expect( screen.getByRole( 'heading', { name: 'Email your assistant' } ) ).toBeVisible();
+		await waitFor( () => {
+			expect( settingsScope.isDone() ).toBe( true );
+		} );
+		expect(
+			screen.getByRole( 'checkbox', {
+				name: 'Enable AI agent email address',
+			} )
+		).not.toBeChecked();
+	} );
+} );

--- a/client/dashboard/sites/settings-ai-tools/test/index.test.tsx
+++ b/client/dashboard/sites/settings-ai-tools/test/index.test.tsx
@@ -162,10 +162,6 @@ beforeEach( () => {
 	mockClipboard();
 } );
 
-afterEach( () => {
-	nock.cleanAll();
-} );
-
 describe( 'getAgentEmailAddress', () => {
 	test.each( [ '', 'NULL', 'noop', 'not-an-email' ] )(
 		'returns null for an unusable Post by Email value: %s',
@@ -214,7 +210,7 @@ describe( '<AIToolsSettings>', () => {
 		expect( screen.getByRole( 'heading', { name: 'Email your assistant' } ) ).toBeVisible();
 		expect( screen.getByRole( 'link', { name: /Connect Telegram/ } ) ).toHaveAttribute(
 			'href',
-			'/me/developer'
+			'https://wordpress.com/me/developer'
 		);
 		expect(
 			screen.getByText(

--- a/client/dashboard/sites/settings-ai-tools/test/index.test.tsx
+++ b/client/dashboard/sites/settings-ai-tools/test/index.test.tsx
@@ -9,6 +9,7 @@ import {
 	sitePostByEmailSettingsQuery,
 	userSettingsQuery,
 } from '@automattic/api-queries';
+import { disable, enable } from '@automattic/calypso-config';
 import '@testing-library/jest-dom';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -37,6 +38,14 @@ const simpleSite = {
 } as Site;
 
 let clipboardWriteText: jest.Mock;
+
+beforeAll( () => {
+	enable( 'dolly/telegram' );
+} );
+
+afterAll( () => {
+	disable( 'dolly/telegram' );
+} );
 
 function seedQueries( postByEmailAddress = '', seedPostByEmailSettings = true, activeSite = site ) {
 	queryClient.setQueryData( siteBySlugQuery( activeSite.slug ).queryKey, activeSite );
@@ -203,6 +212,15 @@ describe( '<AIToolsSettings>', () => {
 		renderAIToolsSettings();
 
 		expect( screen.getByRole( 'heading', { name: 'Email your assistant' } ) ).toBeVisible();
+		expect( screen.getByRole( 'link', { name: /Connect Telegram/ } ) ).toHaveAttribute(
+			'href',
+			'/me/developer'
+		);
+		expect(
+			screen.getByText(
+				'Connect your WordPress.com account to Telegram. This connection is shared across multiple sites.'
+			)
+		).toBeVisible();
 		expect(
 			screen.getByText(
 				'Enabling this also enables Post by Email. Disabling it deletes the Post by Email address, so both Post by Email and this AI agent address will stop working.'

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -23,6 +23,10 @@ import {
 	redirectIfCantStartSiteOwnerTransfer,
 } from 'calypso/sites/settings/administration/controller';
 
+function redirectToAiToolsSettings( context ) {
+	return page.redirect( `/sites/${ context.params.site }/settings/ai-tools` );
+}
+
 export default function () {
 	page( '/settings', redirectSettingsIfDuplciatedViewsEnabled );
 
@@ -127,6 +131,9 @@ export default function () {
 	page( '/settings/analytics/:site_id?', redirectToTraffic );
 	page( '/settings/seo/:site_id?', redirectToTraffic );
 	page( '/settings/theme-setup/:site_id?', redirectToGeneral );
+
+	page( '/settings/ai-tools', siteSelection, sites, makeLayout, clientRender );
+	page( '/settings/ai-tools/:site', siteSelection, redirectToAiToolsSettings );
 
 	page( '/settings/:section', legacyRedirects, siteSelection, sites, makeLayout, clientRender );
 }

--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -127,6 +127,7 @@ export * from './site-media-storage';
 export * from './site-migration-status';
 export * from './site-owner-transfer';
 export * from './site-plans';
+export * from './site-post-by-email';
 export * from './site-plugins';
 export * from './site-preview-links';
 export * from './site-performance';

--- a/packages/api-core/src/me-settings/types.ts
+++ b/packages/api-core/src/me-settings/types.ts
@@ -36,6 +36,7 @@ export type McpAbilities = {
 	account?: Record< string, McpAbility >;
 	site?: Record< string, McpAbility >; // Site-scoped ability defaults
 	sites?: McpSiteOverride[]; // Array of site-specific overrides
+	site_level_enabled_default?: boolean;
 };
 
 export interface UserSettings {

--- a/packages/api-core/src/site-jetpack-settings/types.ts
+++ b/packages/api-core/src/site-jetpack-settings/types.ts
@@ -7,4 +7,5 @@ export interface JetpackSettings {
 	jetpack_waf_ip_block_list?: string;
 	jetpack_sso_match_by_email?: boolean;
 	jetpack_sso_require_two_step?: boolean;
+	post_by_email_address?: string;
 }

--- a/packages/api-core/src/site-post-by-email/fetchers.ts
+++ b/packages/api-core/src/site-post-by-email/fetchers.ts
@@ -1,0 +1,24 @@
+import { fetchJetpackSettings } from '../site-jetpack-settings/fetchers';
+import { wpcom } from '../wpcom-fetcher';
+import {
+	getSettingsFromJetpackResponse,
+	isSimpleWpcomSite,
+	normalizeWpcomPostByEmailStatus,
+} from './utils';
+import type { SitePostByEmailSettings, SitePostByEmailStatus } from './types';
+import type { Site } from '../site/types';
+
+export async function fetchSitePostByEmailSettings(
+	site: Pick< Site, 'ID' | 'jetpack' | 'is_wpcom_atomic' >
+): Promise< SitePostByEmailSettings > {
+	if ( ! isSimpleWpcomSite( site ) ) {
+		return getSettingsFromJetpackResponse( await fetchJetpackSettings( site.ID ) );
+	}
+
+	const status = await wpcom.req.get( {
+		path: `/sites/${ site.ID }/post-by-email`,
+		apiNamespace: 'wpcom/v2',
+	} );
+
+	return normalizeWpcomPostByEmailStatus( status as SitePostByEmailStatus );
+}

--- a/packages/api-core/src/site-post-by-email/index.ts
+++ b/packages/api-core/src/site-post-by-email/index.ts
@@ -1,0 +1,4 @@
+export * from './fetchers';
+export * from './mutators';
+export * from './types';
+export * from './utils';

--- a/packages/api-core/src/site-post-by-email/mutators.ts
+++ b/packages/api-core/src/site-post-by-email/mutators.ts
@@ -1,0 +1,66 @@
+import { updateJetpackSettings } from '../site-jetpack-settings/mutators';
+import { wpcom } from '../wpcom-fetcher';
+import {
+	getSettingsFromJetpackResponse,
+	isPostByEmailAddress,
+	isSimpleWpcomSite,
+	normalizeWpcomPostByEmailStatus,
+} from './utils';
+import type {
+	SitePostByEmailAction,
+	SitePostByEmailSettings,
+	SitePostByEmailStatus,
+} from './types';
+import type { Site } from '../site/types';
+
+function normalizeWpcomPostByEmailMutationResponse(
+	action: SitePostByEmailAction,
+	response: unknown
+): SitePostByEmailSettings {
+	if ( action === 'delete' ) {
+		return { post_by_email_address: undefined };
+	}
+
+	if ( response && typeof response === 'object' && 'email' in response ) {
+		const { email } = response as SitePostByEmailStatus;
+		return {
+			post_by_email_address: isPostByEmailAddress( email ) ? email : undefined,
+		};
+	}
+
+	return normalizeWpcomPostByEmailStatus( response as SitePostByEmailStatus );
+}
+
+export async function updateSitePostByEmailSettings(
+	site: Pick< Site, 'ID' | 'jetpack' | 'is_wpcom_atomic' >,
+	action: SitePostByEmailAction
+): Promise< SitePostByEmailSettings > {
+	if ( ! isSimpleWpcomSite( site ) ) {
+		const response = await updateJetpackSettings( site.ID, {
+			post_by_email_address: action,
+		} );
+
+		return action === 'delete'
+			? { post_by_email_address: undefined }
+			: getSettingsFromJetpackResponse( response );
+	}
+
+	const path = `/sites/${ site.ID }/post-by-email`;
+
+	if ( action === 'delete' ) {
+		await wpcom.req.post( {
+			method: 'DELETE',
+			path,
+			apiNamespace: 'wpcom/v2',
+		} );
+
+		return { post_by_email_address: undefined };
+	}
+
+	const response =
+		action === 'regenerate'
+			? await wpcom.req.put( { method: 'PUT', path, apiNamespace: 'wpcom/v2' } )
+			: await wpcom.req.post( { path, apiNamespace: 'wpcom/v2' } );
+
+	return normalizeWpcomPostByEmailMutationResponse( action, response );
+}

--- a/packages/api-core/src/site-post-by-email/types.ts
+++ b/packages/api-core/src/site-post-by-email/types.ts
@@ -1,0 +1,14 @@
+import type { JetpackSettings } from '../site-jetpack-settings/types';
+
+export type SitePostByEmailAction = 'create' | 'regenerate' | 'delete';
+
+export interface SitePostByEmailStatus {
+	is_enabled: boolean;
+	email?: string;
+}
+
+export type SitePostByEmailSettings = Pick< Partial< JetpackSettings >, 'post_by_email_address' >;
+
+export interface SitePostByEmailSettingsUpdate {
+	post_by_email_address: SitePostByEmailAction;
+}

--- a/packages/api-core/src/site-post-by-email/utils.ts
+++ b/packages/api-core/src/site-post-by-email/utils.ts
@@ -1,7 +1,14 @@
 import type { SitePostByEmailSettings, SitePostByEmailStatus } from './types';
 import type { Site } from '../site/types';
 
-const POST_BY_EMAIL_ACTIONS = new Set( [ '', 'null', 'create', 'regenerate', 'delete', 'noop' ] );
+export const POST_BY_EMAIL_ACTIONS = new Set( [
+	'',
+	'null',
+	'create',
+	'regenerate',
+	'delete',
+	'noop',
+] );
 
 export function isSimpleWpcomSite( site: Pick< Site, 'jetpack' | 'is_wpcom_atomic' > ) {
 	return ! site.jetpack && ! site.is_wpcom_atomic;
@@ -29,7 +36,7 @@ export function normalizeWpcomPostByEmailStatus(
 	};
 }
 
-function isPlainObject( value: unknown ): value is Record< string, unknown > {
+export function isPlainObject( value: unknown ): value is Record< string, unknown > {
 	return !! value && typeof value === 'object' && ! Array.isArray( value );
 }
 

--- a/packages/api-core/src/site-post-by-email/utils.ts
+++ b/packages/api-core/src/site-post-by-email/utils.ts
@@ -1,0 +1,51 @@
+import type { SitePostByEmailSettings, SitePostByEmailStatus } from './types';
+import type { Site } from '../site/types';
+
+const POST_BY_EMAIL_ACTIONS = new Set( [ '', 'null', 'create', 'regenerate', 'delete', 'noop' ] );
+
+export function isSimpleWpcomSite( site: Pick< Site, 'jetpack' | 'is_wpcom_atomic' > ) {
+	return ! site.jetpack && ! site.is_wpcom_atomic;
+}
+
+export function isPostByEmailAddress( value: unknown ): value is string {
+	if ( typeof value !== 'string' ) {
+		return false;
+	}
+
+	const normalizedValue = value.trim().toLowerCase();
+	return (
+		!! normalizedValue &&
+		normalizedValue.includes( '@' ) &&
+		! POST_BY_EMAIL_ACTIONS.has( normalizedValue )
+	);
+}
+
+export function normalizeWpcomPostByEmailStatus(
+	status: SitePostByEmailStatus | null | undefined
+): SitePostByEmailSettings {
+	return {
+		post_by_email_address:
+			status?.is_enabled && isPostByEmailAddress( status.email ) ? status.email : undefined,
+	};
+}
+
+function isPlainObject( value: unknown ): value is Record< string, unknown > {
+	return !! value && typeof value === 'object' && ! Array.isArray( value );
+}
+
+export function getSettingsFromJetpackResponse( response: unknown ): SitePostByEmailSettings {
+	const payload =
+		isPlainObject( response ) && isPlainObject( response.data ) ? response.data : response;
+
+	if ( ! isPlainObject( payload ) ) {
+		return {};
+	}
+
+	const postByEmailAddress = payload.post_by_email_address;
+
+	return {
+		post_by_email_address: isPostByEmailAddress( postByEmailAddress )
+			? postByEmailAddress
+			: undefined,
+	};
+}

--- a/packages/api-queries/src/index.ts
+++ b/packages/api-queries/src/index.ts
@@ -117,6 +117,7 @@ export * from './site-migration-status';
 export * from './site-owner-transfer';
 export * from './site-php-version';
 export * from './site-plans';
+export * from './site-post-by-email';
 export * from './site-plugins';
 export * from './site-performance';
 export * from './site-preview-links';

--- a/packages/api-queries/src/site-jetpack-settings.ts
+++ b/packages/api-queries/src/site-jetpack-settings.ts
@@ -1,14 +1,14 @@
-import { fetchJetpackSettings, updateJetpackSettings } from '@automattic/api-core';
+import {
+	fetchJetpackSettings,
+	isPlainObject,
+	isPostByEmailAddress,
+	POST_BY_EMAIL_ACTIONS,
+	updateJetpackSettings,
+} from '@automattic/api-core';
 import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import { queryClient } from './query-client';
 import { siteQueryFilter } from './site';
 import type { JetpackSettings } from '@automattic/api-core';
-
-const POST_BY_EMAIL_ACTIONS = new Set( [ '', 'null', 'create', 'regenerate', 'delete', 'noop' ] );
-
-function isPlainObject( value: unknown ): value is Record< string, unknown > {
-	return !! value && typeof value === 'object' && ! Array.isArray( value );
-}
 
 function getSettingsFromMutationResponse( response: unknown ): Partial< JetpackSettings > {
 	const payload =
@@ -24,19 +24,6 @@ function getSettingsFromMutationResponse( response: unknown ): Partial< JetpackS
 	delete settings.message;
 
 	return settings as Partial< JetpackSettings >;
-}
-
-function isReturnedPostByEmailAddress( value: unknown ): value is string {
-	if ( typeof value !== 'string' ) {
-		return false;
-	}
-
-	const normalizedValue = value.trim().toLowerCase();
-	return (
-		!! normalizedValue &&
-		normalizedValue.includes( '@' ) &&
-		! POST_BY_EMAIL_ACTIONS.has( normalizedValue )
-	);
 }
 
 function normalizeJetpackSettingsMutationResult(
@@ -55,7 +42,7 @@ function normalizeJetpackSettingsMutationResult(
 
 		if ( requestedPostByEmailAddress === 'delete' ) {
 			normalizedSettings.post_by_email_address = undefined;
-		} else if ( isReturnedPostByEmailAddress( returnedPostByEmailAddress ) ) {
+		} else if ( isPostByEmailAddress( returnedPostByEmailAddress ) ) {
 			normalizedSettings.post_by_email_address = returnedPostByEmailAddress;
 		} else if (
 			typeof normalizedSettings.post_by_email_address === 'string' &&

--- a/packages/api-queries/src/site-jetpack-settings.ts
+++ b/packages/api-queries/src/site-jetpack-settings.ts
@@ -4,6 +4,70 @@ import { queryClient } from './query-client';
 import { siteQueryFilter } from './site';
 import type { JetpackSettings } from '@automattic/api-core';
 
+const POST_BY_EMAIL_ACTIONS = new Set( [ '', 'null', 'create', 'regenerate', 'delete', 'noop' ] );
+
+function isPlainObject( value: unknown ): value is Record< string, unknown > {
+	return !! value && typeof value === 'object' && ! Array.isArray( value );
+}
+
+function getSettingsFromMutationResponse( response: unknown ): Partial< JetpackSettings > {
+	const payload =
+		isPlainObject( response ) && isPlainObject( response.data ) ? response.data : response;
+
+	if ( ! isPlainObject( payload ) ) {
+		return {};
+	}
+
+	const settings = { ...payload };
+	delete settings.code;
+	delete settings.data;
+	delete settings.message;
+
+	return settings as Partial< JetpackSettings >;
+}
+
+function isReturnedPostByEmailAddress( value: unknown ): value is string {
+	if ( typeof value !== 'string' ) {
+		return false;
+	}
+
+	const normalizedValue = value.trim().toLowerCase();
+	return (
+		!! normalizedValue &&
+		normalizedValue.includes( '@' ) &&
+		! POST_BY_EMAIL_ACTIONS.has( normalizedValue )
+	);
+}
+
+function normalizeJetpackSettingsMutationResult(
+	response: unknown,
+	settings: Partial< JetpackSettings >
+): Partial< JetpackSettings > {
+	const responseSettings = getSettingsFromMutationResponse( response );
+	const normalizedSettings: Partial< JetpackSettings > = {
+		...settings,
+		...responseSettings,
+	};
+
+	if ( 'post_by_email_address' in settings ) {
+		const requestedPostByEmailAddress = settings.post_by_email_address;
+		const returnedPostByEmailAddress = responseSettings.post_by_email_address;
+
+		if ( requestedPostByEmailAddress === 'delete' ) {
+			normalizedSettings.post_by_email_address = undefined;
+		} else if ( isReturnedPostByEmailAddress( returnedPostByEmailAddress ) ) {
+			normalizedSettings.post_by_email_address = returnedPostByEmailAddress;
+		} else if (
+			typeof normalizedSettings.post_by_email_address === 'string' &&
+			POST_BY_EMAIL_ACTIONS.has( normalizedSettings.post_by_email_address.trim().toLowerCase() )
+		) {
+			delete normalizedSettings.post_by_email_address;
+		}
+	}
+
+	return normalizedSettings;
+}
+
 export const siteJetpackSettingsQuery = ( siteId: number ) =>
 	queryOptions( {
 		queryKey: [ 'site', siteId, 'jetpack-settings' ],
@@ -15,9 +79,11 @@ export const siteJetpackSettingsMutation = ( siteId: number ) =>
 		mutationFn: ( settings: Partial< JetpackSettings > ) =>
 			updateJetpackSettings( siteId, settings ),
 		onSuccess: ( newData: unknown, newSettings: Partial< JetpackSettings > ) => {
+			const normalizedSettings = normalizeJetpackSettingsMutationResult( newData, newSettings );
+
 			queryClient.setQueryData( siteJetpackSettingsQuery( siteId ).queryKey, ( oldData ) => ( {
 				...oldData,
-				...newSettings,
+				...normalizedSettings,
 			} ) );
 			queryClient.invalidateQueries( siteQueryFilter( siteId ) );
 		},

--- a/packages/api-queries/src/site-post-by-email.ts
+++ b/packages/api-queries/src/site-post-by-email.ts
@@ -1,0 +1,32 @@
+import { fetchSitePostByEmailSettings, updateSitePostByEmailSettings } from '@automattic/api-core';
+import { queryOptions, mutationOptions } from '@tanstack/react-query';
+import { queryClient } from './query-client';
+import { siteQueryFilter } from './site';
+import type { Site, SitePostByEmailSettingsUpdate } from '@automattic/api-core';
+
+export const sitePostByEmailSettingsQuery = ( site: Site ) => {
+	const { ID: siteId, jetpack, is_wpcom_atomic: isWpcomAtomic } = site;
+
+	return queryOptions( {
+		queryKey: [ 'site', siteId, 'post-by-email', jetpack, isWpcomAtomic ],
+		queryFn: () =>
+			fetchSitePostByEmailSettings( {
+				ID: siteId,
+				jetpack,
+				is_wpcom_atomic: isWpcomAtomic,
+			} ),
+	} );
+};
+
+export const sitePostByEmailSettingsMutation = ( site: Site ) =>
+	mutationOptions( {
+		mutationFn: ( settings: SitePostByEmailSettingsUpdate ) =>
+			updateSitePostByEmailSettings( site, settings.post_by_email_address ),
+		onSuccess: ( postByEmailSettings ) => {
+			queryClient.setQueryData( sitePostByEmailSettingsQuery( site ).queryKey, ( oldData ) => ( {
+				...oldData,
+				...postByEmailSettings,
+			} ) );
+			queryClient.invalidateQueries( siteQueryFilter( site.ID ) );
+		},
+	} );


### PR DESCRIPTION
This introduces the entrypoint for the WordPress Agent over email

<img width="762" height="610" alt="Zrzut ekranu 2026-05-28 o 14 34 58" src="https://github.com/user-attachments/assets/0dc79262-e219-4f3c-8caa-e7dd39ba29ad" />


## Proposed Changes

* Introduce a field to copy the ai agent email address
* Route `/settings/ai-tools` through the site picker and redirect selected sites to `/sites/:site/settings/ai-tools`. This will allow us to send people there before we know the site
* Add a Telegram connection link.

## Testing Instructions

Go to http://calypso.localhost:3000/settings/ai-tools
Turn on email agent
send email and wait for it to respond
