### PR TITLE
Reader Social composer: show destination account in modal header

### DIFF
--- a/client/reader/atmosphere/composer-config.tsx
+++ b/client/reader/atmosphere/composer-config.tsx
@@ -1,6 +1,8 @@
-import { createPostMutation } from '@automattic/api-queries';
+import { createPostMutation, useConnectionsQuery } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
 import { logToLogstash } from 'calypso/lib/logstash';
+import { ReaderBlueskyIcon } from 'calypso/reader/components/icons/bluesky-icon';
+import { normalizeHandle } from 'calypso/reader/social/utils/normalize-handle';
 import { useAtmosphereInteractionSettings } from './interaction-settings';
 import { getThreadUrl } from './route';
 import { useAtmosphereComposerMedia } from './use-atmosphere-composer-media';
@@ -16,12 +18,23 @@ import type { ReactNode } from 'react';
 const LIMIT = 300;
 const useAtmosphereComposerLimit = (): number => LIMIT;
 
+function useAtmosphereAuthorHandle( connectionId: number | null ): string | null {
+	const { data } = useConnectionsQuery( { enabled: connectionId !== null } );
+	if ( connectionId === null ) {
+		return null;
+	}
+	const connection = data?.connections?.find( ( c ) => c.id === connectionId );
+	return connection?.handle ? normalizeHandle( connection.handle ) : null;
+}
+
 export const atmosphereComposerConfig: ComposerConfig<
 	AtmosphereError,
 	CreatePostParams,
 	CreatePostResult
 > = {
 	useLimit: useAtmosphereComposerLimit,
+	useAuthorHandle: useAtmosphereAuthorHandle,
+	headerIcon: <ReaderBlueskyIcon filled />,
 	protocolLabel: 'Bluesky',
 	supportedModes: [ 'reply', 'quote', 'standalone' ],
 	mutationFactory: createPostMutation,
@@ -133,7 +146,7 @@ export const atmosphereComposerConfig: ComposerConfig<
 		} ),
 	},
 	copy: {
-		title: ( mode, translate ) => titleForMode( mode, translate ),
+		title: ( mode, translate, handle ) => titleForMode( mode, translate, handle ),
 		placeholder: ( mode, translate, handle ) => placeholderForMode( mode, translate, handle ),
 	},
 	logBadRequest: ( mode, error ) => {
@@ -158,7 +171,16 @@ export const atmosphereComposerConfig: ComposerConfig<
 	useProtocolExtras: useAtmosphereInteractionSettings,
 };
 
-function titleForMode( mode: ActiveMode, t: Translate ): string {
+function titleForMode( mode: ActiveMode, t: Translate, handle?: string | null ): string {
+	const base = baseTitleForMode( mode, t );
+	// "@handle" and the middle-dot separator are unlocalized — the handle is a
+	// fixed ATProto identifier and the dot is the same in every locale we
+	// ship. Composing here keeps the protocol-specific title format inside
+	// the protocol-specific config.
+	return handle ? `${ base } · @${ handle }` : base;
+}
+
+function baseTitleForMode( mode: ActiveMode, t: Translate ): string {
 	if ( mode.kind === 'reply' ) {
 		return t( 'Reply' ) as string;
 	}

--- a/client/reader/atmosphere/test/composer-config.test.tsx
+++ b/client/reader/atmosphere/test/composer-config.test.tsx
@@ -212,19 +212,32 @@ describe( 'atmosphereComposerConfig', () => {
 	} );
 
 	describe( 'copy', () => {
-		it( 'reply title is "Reply"', () => {
+		it( 'reply title is "Reply" with no handle', () => {
 			const t = getTranslate();
 			expect( atmosphereComposerConfig.copy.title( replyMode, t ) ).toBe( 'Reply' );
 		} );
 
-		it( 'quote title is "Quote post"', () => {
+		it( 'quote title is "Quote post" with no handle', () => {
 			const t = getTranslate();
 			expect( atmosphereComposerConfig.copy.title( quoteMode, t ) ).toBe( 'Quote post' );
 		} );
 
-		it( 'standalone title is "New post"', () => {
+		it( 'standalone title is "New post" with no handle', () => {
 			const t = getTranslate();
 			expect( atmosphereComposerConfig.copy.title( standaloneMode, t ) ).toBe( 'New post' );
+		} );
+
+		it( 'appends "· @handle" to the title when a handle is supplied', () => {
+			const t = getTranslate();
+			expect(
+				atmosphereComposerConfig.copy.title( standaloneMode, t, 'jordesign.bsky.social' )
+			).toBe( 'New post · @jordesign.bsky.social' );
+			expect( atmosphereComposerConfig.copy.title( replyMode, t, 'alice.bsky.social' ) ).toBe(
+				'Reply · @alice.bsky.social'
+			);
+			expect( atmosphereComposerConfig.copy.title( quoteMode, t, 'alice.bsky.social' ) ).toBe(
+				'Quote post · @alice.bsky.social'
+			);
 		} );
 
 		it( 'reply placeholder mentions the handle', () => {

--- a/client/reader/atmosphere/test/standalone-compose.test.tsx
+++ b/client/reader/atmosphere/test/standalone-compose.test.tsx
@@ -147,7 +147,9 @@ describe( 'Standalone compose end-to-end', () => {
 		const fab = await screen.findByRole( 'button', { name: 'Compose' } );
 		await user.click( fab );
 
-		expect( await screen.findByRole( 'dialog', { name: 'New post' } ) ).toBeVisible();
+		expect(
+			await screen.findByRole( 'dialog', { name: 'New post · @a.bsky.social' } )
+		).toBeVisible();
 
 		await user.type( screen.getByRole( 'textbox' ), 'hello world' );
 		await user.click( screen.getByRole( 'button', { name: 'Post' } ) );
@@ -213,7 +215,9 @@ describe( 'Standalone compose end-to-end', () => {
 		const pill = await screen.findByRole( 'button', { name: /what['’]s up/i } );
 		await user.click( pill );
 
-		expect( await screen.findByRole( 'dialog', { name: 'New post' } ) ).toBeVisible();
+		expect(
+			await screen.findByRole( 'dialog', { name: 'New post · @a.bsky.social' } )
+		).toBeVisible();
 
 		// _compose_opened fires with the pill's entry_point dimension.
 		await waitFor( () =>

--- a/client/reader/fediverse/composer-config.tsx
+++ b/client/reader/fediverse/composer-config.tsx
@@ -1,6 +1,8 @@
 import { createFediversePostMutation, useFediverseConnectionsQuery } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
 import { logToLogstash } from 'calypso/lib/logstash';
+import { ReaderFediverseIcon } from 'calypso/reader/components/icons/fediverse-icon';
+import { normalizeHandle } from 'calypso/reader/social/utils/normalize-handle';
 import { useFediverseComposerExtras } from './use-fediverse-composer-extras';
 import { useFediverseComposerLimit } from './use-fediverse-composer-limit';
 import { useFediverseComposerMedia } from './use-fediverse-composer-media';
@@ -11,6 +13,27 @@ import type {
 } from '@automattic/api-core';
 import type { ActiveMode, ComposerConfig, Translate } from 'calypso/reader/social/composer';
 import type { ReactNode } from 'react';
+
+function useFediverseAuthorHandle( connectionId: number | null ): string | null {
+	const { data } = useFediverseConnectionsQuery( { enabled: connectionId !== null } );
+	if ( connectionId === null ) {
+		return null;
+	}
+	const connection = data?.connections?.find( ( c ) => c.id === connectionId );
+	if ( ! connection?.webfinger ) {
+		return null;
+	}
+	// `FediverseConnection` exposes the destination identity as `webfinger`
+	// — for WordPress.com / Jetpack blog actors that shape is
+	// `user@domain` where `user` and `domain` collapse to the same blog
+	// hostname (e.g. `@example.com@example.com`). Showing both halves in
+	// the modal title doubles the width and wraps onto a second line, so
+	// keep just the trailing `@domain` segment — it's the part users
+	// recognize and matches the destination the post will publish to.
+	const segments = normalizeHandle( connection.webfinger ).split( '@' );
+	const domain = segments[ segments.length - 1 ];
+	return domain || null;
+}
 
 /**
  * Returns the blog id behind the active Fediverse connection so the
@@ -47,6 +70,8 @@ export const fediverseComposerConfig: ComposerConfig<
 	FediverseCreatePostResult
 > = {
 	useLimit: useFediverseComposerLimit,
+	useAuthorHandle: useFediverseAuthorHandle,
+	headerIcon: <ReaderFediverseIcon />,
 	// Count words rather than graphemes. AP posts are blog-post-shaped,
 	// so a word threshold maps onto "open the blog editor" handoff better
 	// than a grapheme cap. Backend enforces wire-level char limits and
@@ -113,7 +138,14 @@ export const fediverseComposerConfig: ComposerConfig<
 		} ),
 	},
 	copy: {
-		title: ( _mode, t ) => t( 'New post' ) as string,
+		// Fediverse posts target a specific blog connection, so the title
+		// follows the same "New post · @handle" composition as atmosphere /
+		// mastodon for visual consistency. The handle is the webfinger
+		// identity of the source blog (e.g. `@myblog@myblog.wordpress.com`).
+		title: ( _mode, t, handle ) => {
+			const base = t( 'New post' ) as string;
+			return handle ? `${ base } · @${ handle }` : base;
+		},
 		placeholder: ( _mode, t ) => t( 'What’s up?' ) as string,
 	},
 	logBadRequest: ( _mode, error ) => {

--- a/client/reader/fediverse/composer-config.tsx
+++ b/client/reader/fediverse/composer-config.tsx
@@ -14,7 +14,7 @@ import type {
 import type { ActiveMode, ComposerConfig, Translate } from 'calypso/reader/social/composer';
 import type { ReactNode } from 'react';
 
-function useFediverseAuthorHandle( connectionId: number | null ): string | null {
+export function useFediverseAuthorHandle( connectionId: number | null ): string | null {
 	const { data } = useFediverseConnectionsQuery( { enabled: connectionId !== null } );
 	if ( connectionId === null ) {
 		return null;

--- a/client/reader/fediverse/composer-config.tsx
+++ b/client/reader/fediverse/composer-config.tsx
@@ -23,14 +23,16 @@ export function useFediverseAuthorHandle( connectionId: number | null ): string 
 	if ( ! connection?.webfinger ) {
 		return null;
 	}
-	// `FediverseConnection` exposes the destination identity as `webfinger`
-	// — for WordPress.com / Jetpack blog actors that shape is
-	// `user@domain` where `user` and `domain` collapse to the same blog
-	// hostname (e.g. `@example.com@example.com`). Showing both halves in
-	// the modal title doubles the width and wraps onto a second line, so
-	// keep just the trailing `@domain` segment — it's the part users
-	// recognize and matches the destination the post will publish to.
-	const segments = normalizeHandle( connection.webfinger ).split( '@' );
+	// WP/JP blog actors have `webfinger` shaped `@user@domain` where both
+	// halves are the same hostname; show just the trailing domain so the
+	// title doesn't render `@example.com@example.com` and wrap onto a
+	// second line. A malformed value without an `@` separator returns
+	// null rather than surfacing the raw string as if it were a domain.
+	const normalized = normalizeHandle( connection.webfinger );
+	if ( ! normalized.includes( '@' ) ) {
+		return null;
+	}
+	const segments = normalized.split( '@' );
 	const domain = segments[ segments.length - 1 ];
 	return domain || null;
 }

--- a/client/reader/fediverse/test/use-fediverse-author-handle.test.tsx
+++ b/client/reader/fediverse/test/use-fediverse-author-handle.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * @jest-environment jsdom
+ */
+import { readerFediverseKeys, type FediverseConnectionsResponse } from '@automattic/api-core';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+import { useFediverseAuthorHandle } from '../composer-config';
+
+function seedConnections( client: QueryClient, response: FediverseConnectionsResponse ) {
+	client.setQueryData( readerFediverseKeys.connections(), response );
+}
+
+function wrapperFor( client: QueryClient ) {
+	return function Wrapper( { children }: { children: React.ReactNode } ) {
+		return <QueryClientProvider client={ client }>{ children }</QueryClientProvider>;
+	};
+}
+
+const baseConnection = {
+	id: 1,
+	blog_id: 100,
+	url: 'https://myblog.wordpress.com',
+	name: 'My Blog',
+	icon: '',
+	webfinger: '@myblog@myblog.wordpress.com',
+};
+
+describe( 'useFediverseAuthorHandle', () => {
+	it( 'returns null when connectionId is null (skips the query)', () => {
+		const client = new QueryClient();
+		const { result } = renderHook( () => useFediverseAuthorHandle( null ), {
+			wrapper: wrapperFor( client ),
+		} );
+		expect( result.current ).toBeNull();
+	} );
+
+	it( 'returns the trailing @domain segment from the webfinger handle', () => {
+		const client = new QueryClient();
+		seedConnections( client, { connections: [ baseConnection ] } );
+
+		const { result } = renderHook( () => useFediverseAuthorHandle( 1 ), {
+			wrapper: wrapperFor( client ),
+		} );
+
+		expect( result.current ).toBe( 'myblog.wordpress.com' );
+	} );
+
+	it( 'returns null when the matching connection has no webfinger', () => {
+		const client = new QueryClient();
+		seedConnections( client, {
+			connections: [ { ...baseConnection, webfinger: '' } ],
+		} );
+
+		const { result } = renderHook( () => useFediverseAuthorHandle( 1 ), {
+			wrapper: wrapperFor( client ),
+		} );
+
+		expect( result.current ).toBeNull();
+	} );
+
+	it( 'returns null when no connection matches the connectionId', () => {
+		const client = new QueryClient();
+		seedConnections( client, { connections: [ baseConnection ] } );
+
+		const { result } = renderHook( () => useFediverseAuthorHandle( 999 ), {
+			wrapper: wrapperFor( client ),
+		} );
+
+		expect( result.current ).toBeNull();
+	} );
+
+	it( 'handles a webfinger without a leading @ by keeping only the trailing segment', () => {
+		const client = new QueryClient();
+		seedConnections( client, {
+			connections: [ { ...baseConnection, webfinger: 'myblog@myblog.wordpress.com' } ],
+		} );
+
+		const { result } = renderHook( () => useFediverseAuthorHandle( 1 ), {
+			wrapper: wrapperFor( client ),
+		} );
+
+		expect( result.current ).toBe( 'myblog.wordpress.com' );
+	} );
+
+	it( 'returns null when the webfinger has no @ separator (malformed shape)', () => {
+		// Don't surface a raw hostname as if it were a domain — the modal
+		// title would lie about the destination ("New post · @bare-host").
+		const client = new QueryClient();
+		seedConnections( client, {
+			connections: [ { ...baseConnection, webfinger: 'bare-host' } ],
+		} );
+
+		const { result } = renderHook( () => useFediverseAuthorHandle( 1 ), {
+			wrapper: wrapperFor( client ),
+		} );
+
+		expect( result.current ).toBeNull();
+	} );
+} );

--- a/client/reader/mastodon/composer-config.tsx
+++ b/client/reader/mastodon/composer-config.tsx
@@ -1,6 +1,8 @@
-import { createMastodonPostMutation } from '@automattic/api-queries';
+import { createMastodonPostMutation, useMastodonConnectionsQuery } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
 import { logToLogstash } from 'calypso/lib/logstash';
+import { ReaderMastodonIcon } from 'calypso/reader/components/icons/mastodon-icon';
+import { normalizeHandle } from 'calypso/reader/social/utils/normalize-handle';
 import { getThreadUrl } from './route';
 import { useMastodonComposerExtras } from './use-mastodon-composer-extras';
 import { useMastodonComposerLimit } from './use-mastodon-composer-limit';
@@ -13,6 +15,15 @@ import type {
 import type { ActiveMode, ComposerConfig, Translate } from 'calypso/reader/social/composer';
 import type { ReactNode } from 'react';
 
+function useMastodonAuthorHandle( connectionId: number | null ): string | null {
+	const { data } = useMastodonConnectionsQuery( { enabled: connectionId !== null } );
+	if ( connectionId === null ) {
+		return null;
+	}
+	const connection = data?.connections?.find( ( c ) => c.id === connectionId );
+	return connection?.handle ? normalizeHandle( connection.handle ) : null;
+}
+
 export const mastodonComposerConfig: ComposerConfig<
 	MastodonError,
 	MastodonCreatePostMutationParams,
@@ -22,6 +33,8 @@ export const mastodonComposerConfig: ComposerConfig<
 	// configuration via `useMastodonInstanceConfigQuery` and falls back to
 	// 500 (stock Mastodon default) when the query is pending or errors.
 	useLimit: useMastodonComposerLimit,
+	useAuthorHandle: useMastodonAuthorHandle,
+	headerIcon: <ReaderMastodonIcon />,
 	protocolLabel: 'Mastodon',
 	// Quote mode uses Mastodon 4.5+'s native `quoted_status_id` with a
 	// text-based fallback (permalink appended to status) for older
@@ -159,7 +172,7 @@ export const mastodonComposerConfig: ComposerConfig<
 		} ),
 	},
 	copy: {
-		title: ( mode, translate ) => titleForMode( mode, translate ),
+		title: ( mode, translate, handle ) => titleForMode( mode, translate, handle ),
 		placeholder: ( mode, translate, handle ) => placeholderForMode( mode, translate, handle ),
 	},
 	logBadRequest: ( mode, error ) => {
@@ -182,7 +195,15 @@ export const mastodonComposerConfig: ComposerConfig<
 	useProtocolExtras: useMastodonComposerExtras,
 };
 
-function titleForMode( mode: ActiveMode, t: Translate ): string {
+function titleForMode( mode: ActiveMode, t: Translate, handle?: string | null ): string {
+	const base = baseTitleForMode( mode, t );
+	// "@handle" and the middle-dot separator are unlocalized — the handle is
+	// a fixed `user@instance` identifier and the dot is the same in every
+	// locale we ship. Mirrors the atmosphere title format.
+	return handle ? `${ base } · @${ handle }` : base;
+}
+
+function baseTitleForMode( mode: ActiveMode, t: Translate ): string {
 	if ( mode.kind === 'reply' ) {
 		return t( 'Reply' ) as string;
 	}

--- a/client/reader/mastodon/composer-config.tsx
+++ b/client/reader/mastodon/composer-config.tsx
@@ -15,7 +15,7 @@ import type {
 import type { ActiveMode, ComposerConfig, Translate } from 'calypso/reader/social/composer';
 import type { ReactNode } from 'react';
 
-function useMastodonAuthorHandle( connectionId: number | null ): string | null {
+export function useMastodonAuthorHandle( connectionId: number | null ): string | null {
 	const { data } = useMastodonConnectionsQuery( { enabled: connectionId !== null } );
 	if ( connectionId === null ) {
 		return null;

--- a/client/reader/mastodon/test/composer-config.test.tsx
+++ b/client/reader/mastodon/test/composer-config.test.tsx
@@ -5,7 +5,7 @@ import { readerMastodonKeys } from '@automattic/api-core';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, renderHook } from '@testing-library/react';
 import { useTranslate } from 'i18n-calypso';
-import { mastodonComposerConfig } from '../composer-config';
+import { mastodonComposerConfig, useMastodonAuthorHandle } from '../composer-config';
 import type { MastodonError } from '@automattic/api-core';
 import type { ActiveMode, Translate } from 'calypso/reader/social/composer';
 
@@ -282,20 +282,93 @@ describe( 'mastodonComposerConfig', () => {
 	} );
 
 	describe( 'copy', () => {
-		it( 'reply title is "Reply"', () => {
+		it( 'reply title is "Reply" with no handle', () => {
 			const t = getTranslate();
 			expect( mastodonComposerConfig.copy.title( replyMode, t ) ).toBe( 'Reply' );
 		} );
 
-		it( 'standalone title is "New post"', () => {
+		it( 'quote title is "Quote post" with no handle', () => {
+			const t = getTranslate();
+			expect( mastodonComposerConfig.copy.title( quoteMode, t ) ).toBe( 'Quote post' );
+		} );
+
+		it( 'standalone title is "New post" with no handle', () => {
 			const t = getTranslate();
 			expect( mastodonComposerConfig.copy.title( standaloneMode, t ) ).toBe( 'New post' );
+		} );
+
+		it( 'appends "· @handle" to the title when a handle is supplied', () => {
+			const t = getTranslate();
+			expect(
+				mastodonComposerConfig.copy.title( standaloneMode, t, 'alice@mastodon.social' )
+			).toBe( 'New post · @alice@mastodon.social' );
+			expect( mastodonComposerConfig.copy.title( replyMode, t, 'alice@mastodon.social' ) ).toBe(
+				'Reply · @alice@mastodon.social'
+			);
+			expect( mastodonComposerConfig.copy.title( quoteMode, t, 'alice@mastodon.social' ) ).toBe(
+				'Quote post · @alice@mastodon.social'
+			);
 		} );
 
 		it( 'reply placeholder mentions the handle', () => {
 			const t = getTranslate();
 			const placeholder = mastodonComposerConfig.copy.placeholder( replyMode, t, 'alice' );
 			expect( placeholder ).toContain( 'alice' );
+		} );
+	} );
+
+	describe( 'useMastodonAuthorHandle', () => {
+		function wrapperFor( client: QueryClient ) {
+			return function Wrapper( { children }: { children: React.ReactNode } ) {
+				return <QueryClientProvider client={ client }>{ children }</QueryClientProvider>;
+			};
+		}
+
+		const baseConnection = {
+			id: 42,
+			handle: '@alice@mastodon.social',
+			instance: 'mastodon.social',
+			display_name: 'Alice',
+			avatar: null,
+		};
+
+		it( 'returns null when connectionId is null (skips the query)', () => {
+			const client = new QueryClient();
+			const { result } = renderHook( () => useMastodonAuthorHandle( null ), {
+				wrapper: wrapperFor( client ),
+			} );
+			expect( result.current ).toBeNull();
+		} );
+
+		it( 'returns the normalized handle for the matching connection', () => {
+			const client = new QueryClient();
+			client.setQueryData( readerMastodonKeys.connections(), { connections: [ baseConnection ] } );
+			const { result } = renderHook( () => useMastodonAuthorHandle( 42 ), {
+				wrapper: wrapperFor( client ),
+			} );
+			// `normalizeHandle` strips leading `@`s so the modal's `@%(handle)s`
+			// template doesn't double up.
+			expect( result.current ).toBe( 'alice@mastodon.social' );
+		} );
+
+		it( 'returns null when no connection matches the connectionId', () => {
+			const client = new QueryClient();
+			client.setQueryData( readerMastodonKeys.connections(), { connections: [ baseConnection ] } );
+			const { result } = renderHook( () => useMastodonAuthorHandle( 999 ), {
+				wrapper: wrapperFor( client ),
+			} );
+			expect( result.current ).toBeNull();
+		} );
+
+		it( 'returns null when the matching connection has no handle', () => {
+			const client = new QueryClient();
+			client.setQueryData( readerMastodonKeys.connections(), {
+				connections: [ { ...baseConnection, handle: '' } ],
+			} );
+			const { result } = renderHook( () => useMastodonAuthorHandle( 42 ), {
+				wrapper: wrapperFor( client ),
+			} );
+			expect( result.current ).toBeNull();
 		} );
 	} );
 } );

--- a/client/reader/social/AGENTS.md
+++ b/client/reader/social/AGENTS.md
@@ -595,7 +595,26 @@ Per-protocol `ComposerConfig` supplies:
   and Mastodon both wire it as `calypso_reader_<protocol>_overflow_handoff_{shown,editor_opened}`
   with `connection_id` + `mode_kind` props (plus `site_id` on the
   click event).
-- `copy.{title, placeholder}` — per-mode strings.
+- `copy.{title, placeholder}` — per-mode strings. `copy.title( mode, t,
+  handle )` is called by the modal with the resolved `useAuthorHandle`
+  value (or `null` when the hook is omitted / pending) so each protocol
+  can render "New post · @handle" — the destination context the issue
+  CM-799 surfaced. All three protocols (atmosphere, mastodon, fediverse)
+  wire this; fediverse's handle is the webfinger identity of the source
+  blog (e.g. `@myblog@myblog.wordpress.com`).
+- `headerIcon?` — optional `ReactElement` rendered before the modal
+  title via `<Modal icon>`. Atmosphere passes `<ReaderBlueskyIcon
+  filled />`, Mastodon passes `<ReaderMastodonIcon />`, Fediverse passes
+  `<ReaderFediverseIcon />`. Together with the `· @handle` title suffix
+  this communicates "you're posting to Bluesky as @jordesign.bsky.social"
+  without a destination picker.
+- `useAuthorHandle?` — optional hook returning the connected account's
+  handle for the given `connectionId` (or `null` for `null` / pending /
+  missing). Called unconditionally inside `<ComposerModal>` (rules of
+  hooks) — same contract as `useLimit`. Atmosphere reads it from
+  `useConnectionsQuery`, Mastodon from `useMastodonConnectionsQuery`,
+  Fediverse from `useFediverseConnectionsQuery`, all running the result
+  through `normalizeHandle()` so the leading `@` doesn't double up.
 - `logBadRequest?` — fire-and-forget hook for the `bad_request` body
   log. Lives in the per-protocol adapter so `calypso/lib/logstash`
   doesn't have to be imported from `packages/api-queries` (which is

--- a/client/reader/social/composer/composer-config.tsx
+++ b/client/reader/social/composer/composer-config.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext } from 'react';
 import type { ActiveMode, ComposerMode } from './composer-provider';
 import type { QueryClient, UseMutationOptions } from '@tanstack/react-query';
 import type { useTranslate } from 'i18n-calypso';
-import type { ReactNode } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 
 /**
  * Optional media-attachment slot exposed by per-protocol configs. The shared
@@ -203,9 +203,39 @@ export interface ComposerConfig< TError, TParams, TResult > {
 			meta: { siteId: number }
 		) => { event: string; props: Record< string, unknown > };
 	};
+	/**
+	 * Optional icon rendered before the modal title (e.g. the Bluesky logo for
+	 * atmosphere, the Mastodon logo for mastodon). Forwarded to the WP
+	 * `<Modal>` `icon` prop, which is typed as `React.JSX.Element` — pass a
+	 * single element, not a fragment or array. Surfacing the network glyph
+	 * in the modal header is half of the destination context the modal
+	 * communicates — see `useAuthorHandle` for the other half.
+	 */
+	headerIcon?: ReactElement;
+	/**
+	 * Optional hook returning the handle of the account the user is posting
+	 * from, given the active connection id (or `null` when no mode is
+	 * active). The shared modal appends "@%(handle)s" to the mode-specific
+	 * title via `copy.title` so the destination account is unambiguous —
+	 * the "New post" header otherwise reads like a generic WordPress post.
+	 *
+	 * Called unconditionally inside `<ComposerModal>` (rules of hooks).
+	 * Implementations must accept `null` for the connection id and return
+	 * `null` when the handle isn't resolvable yet (query pending, missing
+	 * connection). Keep it cheap: cached query reads only.
+	 */
+	useAuthorHandle?: ( connectionId: number | null ) => string | null;
 	/** Per-mode title and placeholder copy. */
 	copy: {
-		title: ( mode: ActiveMode, translate: Translate ) => string;
+		/**
+		 * `handle` is the value returned by `useAuthorHandle` (`null` if the
+		 * config doesn't supply that hook or the handle isn't resolvable
+		 * yet, omitted entirely by tests that don't care). Per-protocol
+		 * configs are free to compose it into the title — atmosphere /
+		 * mastodon render "New post · @handle"; fediverse ignores it
+		 * because the destination is a blog, not a social account.
+		 */
+		title: ( mode: ActiveMode, translate: Translate, handle?: string | null ) => string;
 		placeholder: ( mode: ActiveMode, translate: Translate, handle?: string ) => string;
 	};
 	/**

--- a/client/reader/social/composer/composer-config.tsx
+++ b/client/reader/social/composer/composer-config.tsx
@@ -204,12 +204,8 @@ export interface ComposerConfig< TError, TParams, TResult > {
 		) => { event: string; props: Record< string, unknown > };
 	};
 	/**
-	 * Optional icon rendered before the modal title (e.g. the Bluesky logo for
-	 * atmosphere, the Mastodon logo for mastodon). Forwarded to the WP
-	 * `<Modal>` `icon` prop, which is typed as `React.JSX.Element` — pass a
-	 * single element, not a fragment or array. Surfacing the network glyph
-	 * in the modal header is half of the destination context the modal
-	 * communicates — see `useAuthorHandle` for the other half.
+	 * Optional icon forwarded to the WP `<Modal>` `icon` prop (typed as
+	 * `React.JSX.Element` — pass a single element, not a fragment or array).
 	 */
 	headerIcon?: ReactElement;
 	/**

--- a/client/reader/social/composer/composer-modal.tsx
+++ b/client/reader/social/composer/composer-modal.tsx
@@ -159,10 +159,7 @@ export function ComposerModal< TError, TParams, TResult >() {
 	// always called (rules of hooks). When `mode` is null the modal isn't
 	// rendering interactive content anyway, so the value is unused.
 	const limit = config.useLimit( mode?.connectionId ?? null );
-	// Per-protocol useAuthorHandle hook — resolves the user's handle for
-	// the active connection so the modal title can append "· @handle".
-	// Same rules-of-hooks contract as `useLimit`: always called, accepts
-	// `null` when no mode is active, returns `null` until resolved.
+	// Same rules-of-hooks contract as `useLimit` above.
 	const useAuthorHandle = config.useAuthorHandle ?? NOOP_USE_AUTHOR_HANDLE;
 	const authorHandle = useAuthorHandle( mode?.connectionId ?? null );
 	const tooLong = graphemeCount > limit;

--- a/client/reader/social/composer/composer-modal.tsx
+++ b/client/reader/social/composer/composer-modal.tsx
@@ -19,6 +19,8 @@ import { ComposerTextarea } from './composer-textarea';
 import { countGraphemes, countWords } from './grapheme-count';
 import type { AppState } from 'calypso/types';
 
+const NOOP_USE_AUTHOR_HANDLE = (): string | null => null;
+
 export function ComposerModal< TError, TParams, TResult >() {
 	const translate = useTranslate();
 	const config = useComposerConfig< TError, TParams, TResult >();
@@ -157,6 +159,12 @@ export function ComposerModal< TError, TParams, TResult >() {
 	// always called (rules of hooks). When `mode` is null the modal isn't
 	// rendering interactive content anyway, so the value is unused.
 	const limit = config.useLimit( mode?.connectionId ?? null );
+	// Per-protocol useAuthorHandle hook — resolves the user's handle for
+	// the active connection so the modal title can append "· @handle".
+	// Same rules-of-hooks contract as `useLimit`: always called, accepts
+	// `null` when no mode is active, returns `null` until resolved.
+	const useAuthorHandle = config.useAuthorHandle ?? NOOP_USE_AUTHOR_HANDLE;
+	const authorHandle = useAuthorHandle( mode?.connectionId ?? null );
 	const tooLong = graphemeCount > limit;
 	useEffect( () => {
 		if ( tooLong ) {
@@ -182,8 +190,14 @@ export function ComposerModal< TError, TParams, TResult >() {
 		mediaSlot.isAllUploaded &&
 		( ! empty || mediaSlot.hasUploaded );
 
+	// Destructure the unstable `mutation` object so `useCallback` deps below
+	// can track the referentially-stable pieces individually — `useMutation`
+	// returns a fresh object on every render and pulling `mutation` straight
+	// into the deps array would invalidate the callback unnecessarily.
+	const { isPending: mutationIsPending, mutate: mutationMutate } = mutation;
+
 	const handleSubmit = useCallback( async () => {
-		if ( ! mode || mutation.isPending || isExtending ) {
+		if ( ! mode || mutationIsPending || isExtending ) {
 			return;
 		}
 		if ( ! canSubmit ) {
@@ -221,7 +235,7 @@ export function ComposerModal< TError, TParams, TResult >() {
 		// A previous extend rejection shouldn't linger across a successful
 		// retry — clear it before invoking the mutation.
 		setExtendError( null );
-		mutation.mutate( params, {
+		mutationMutate( params, {
 			onSuccess: ( result ) => {
 				mediaSlot.onPublishSuccess( queryClient, result );
 				const { event, props } = config.tracks.published( mode, result );
@@ -239,7 +253,8 @@ export function ComposerModal< TError, TParams, TResult >() {
 		} );
 	}, [
 		mode,
-		mutation,
+		mutationIsPending,
+		mutationMutate,
 		isExtending,
 		text,
 		canSubmit,
@@ -259,7 +274,7 @@ export function ComposerModal< TError, TParams, TResult >() {
 	const handle =
 		mode.kind === 'reply' || mode.kind === 'quote' ? mode.previewPost.author.handle : undefined;
 
-	const title = config.copy.title( mode, translate );
+	const title = config.copy.title( mode, translate, authorHandle );
 	const placeholder = config.copy.placeholder( mode, translate, handle );
 	const errorMessage = displayError ? config.errorMessage( displayError, translate ) : null;
 
@@ -267,6 +282,7 @@ export function ComposerModal< TError, TParams, TResult >() {
 		<>
 			<Modal
 				title={ title }
+				icon={ config.headerIcon ?? undefined }
 				onRequestClose={ handleClose }
 				className="social-composer"
 				focusOnMount

--- a/client/reader/social/composer/style.scss
+++ b/client/reader/social/composer/style.scss
@@ -123,6 +123,36 @@
 }
 
 .social-composer {
+	// Per-protocol header icon (Bluesky / Mastodon glyph) passed via the WP
+	// `<Modal icon>` slot. The icon components bake in `.sidebar__menu-icon`
+	// so the sidebar can spec its own size and color — that class has a
+	// global `color/fill: var(--color-sidebar-gridicon-fill)` rule which
+	// would otherwise paint the glyph near-white inside the modal header
+	// and ship the `margin-right: 11px` sidebar offset on top of the WP
+	// heading-container's own spacing. Reset to inherit from the heading,
+	// and size the glyph to track the 16px heading instead of the sidebar's
+	// 24px default so it doesn't overshoot the cap-height of the title.
+	.components-modal__icon-container {
+		display: inline-flex;
+		align-items: center;
+		margin-inline-end: 6px;
+
+		.sidebar__menu-icon {
+			color: currentColor;
+			fill: currentColor;
+			width: 18px;
+			height: 18px;
+			margin: 0;
+		}
+	}
+
+	// The default 20px WP modal heading reads oversized against the
+	// "New post · @handle" composition — drop a couple of sizes so the
+	// destination context sits closer to a label than a hero title.
+	.components-modal__header-heading {
+		font-size: 16px;
+	}
+
 	.social-composer__pinned-context {
 		padding: 8px 12px;
 		background: var( --studio-gray-0, #f6f7f7 );

--- a/client/reader/social/composer/test/composer-modal.test.tsx
+++ b/client/reader/social/composer/test/composer-modal.test.tsx
@@ -138,6 +138,48 @@ describe( '<ComposerModal>', () => {
 		void queryClient;
 	} );
 
+	it( 'passes config.headerIcon to the Modal and calls config.useAuthorHandle for the title', () => {
+		const useAuthorHandle = jest.fn( ( id: number | null ) =>
+			id === 7 ? 'jordesign.bsky.social' : null
+		);
+		const config: ComposerConfig< TestError, TestParams, TestResult > = {
+			...testComposerConfig,
+			useAuthorHandle,
+			headerIcon: <span data-testid="composer-header-icon" />,
+			copy: {
+				...testComposerConfig.copy,
+				title: ( mode, _t, handle ) =>
+					handle ? `Title:${ mode.kind } · @${ handle }` : `Title:${ mode.kind }`,
+			},
+		};
+		renderModal( config );
+
+		act( () => openFn?.( standaloneMode ) );
+
+		expect( useAuthorHandle ).toHaveBeenCalledWith( 7 );
+		expect(
+			screen.getByRole( 'dialog', { name: 'Title:standalone · @jordesign.bsky.social' } )
+		).toBeVisible();
+		expect( screen.getByTestId( 'composer-header-icon' ) ).toBeVisible();
+	} );
+
+	it( 'falls back to the bare title when config.useAuthorHandle returns null', () => {
+		const config: ComposerConfig< TestError, TestParams, TestResult > = {
+			...testComposerConfig,
+			useAuthorHandle: () => null,
+			copy: {
+				...testComposerConfig.copy,
+				title: ( mode, _t, handle ) =>
+					handle ? `Title:${ mode.kind } · @${ handle }` : `Title:${ mode.kind }`,
+			},
+		};
+		renderModal( config );
+
+		act( () => openFn?.( standaloneMode ) );
+
+		expect( screen.getByRole( 'dialog', { name: 'Title:standalone' } ) ).toBeVisible();
+	} );
+
 	it( 'fires tracks.opened on mount when a mode is active', () => {
 		const recordSpy = analytics.recordReaderTracksEvent as unknown as jest.Mock;
 		renderModal( testComposerConfig );


### PR DESCRIPTION
Fixes CM-799

## Proposed Changes

* Add `headerIcon` and `useAuthorHandle` slots to `ComposerConfig`; the shared `<ComposerModal>` forwards the icon to WP `<Modal icon>` and appends the resolved handle to `copy.title` so the composer header reads "🦋 New post · @jordesign.bsky.social" instead of just "New post."
* Wire the per-protocol icon + handle hook for atmosphere (`ReaderBlueskyIcon` + `useConnectionsQuery.handle`), mastodon (`ReaderMastodonIcon` + `useMastodonConnectionsQuery.handle`), and fediverse (`ReaderFediverseIcon` + `useFediverseConnectionsQuery.webfinger`, trimmed to `@domain` so WordPress.com blog actors don't wrap).
* Scope the social composer SCSS to override the global `.sidebar__menu-icon` color / size leak inside the modal header, size the glyph to 18px to match the new 16px heading, and trim the WP modal heading from 20px → 16px so the title reads as a label rather than a hero.
* Destructure the `useMutation` return value before threading it into `useCallback` deps — pre-existing `@tanstack/query/no-unstable-deps` violation that the husky hook now blocks because this PR touches the file.

## Why are these changes being made?

The "New post" modal previously gave no destination signal — neither the network nor the connected account — so a user who arrived via something other than the in-context Compose button had to infer the destination from indirect cues (the 300-grapheme counter for Bluesky, the "Anyone can reply" pill, etc.). Surfacing the network glyph + handle in the modal header makes the destination unambiguous without adding a picker (the user is already inside a section scoped to one account).

## Testing Instructions

1. From the Reader sidebar, open a Bluesky account (`/reader/atmosphere/<id>/timeline`), click the FAB or the "What's up?" pill, and confirm the modal header reads "🦋 New post · @<your-bsky-handle>" with the butterfly glyph visible (not white on white).
2. Repeat for a Mastodon account (`/reader/mastodon/<id>/timeline`) — expect "🐘 New post · @user@instance".
3. Repeat for a Fediverse blog (`/reader/fediverse/<id>/timeline`) — expect "⁂ New post · @<your-blog-domain>" on a single line, even for WordPress.com-hosted blogs whose webfinger is `@domain@domain`.
4. Try Reply and Quote modes on Bluesky / Mastodon to confirm the suffix also appends to those titles.
5. Sanity-check that the close button, focus ring, dark mode, and existing media / visibility controls still render correctly.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?