### PR TITLE
dashboard/me: finish typed-`@wordpress/i18n` migration

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/backup-retention-management/retention-confirmation-dialog/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/backup-retention-management/retention-confirmation-dialog/index.tsx
@@ -36,7 +36,7 @@ const RetentionConfirmationDialog: React.FC< RetentionConfirmationDialogProps > 
 							__(
 								'You are about to reduce the number of days your backups are being saved. Backups older than %(retentionDays)s days will be lost.'
 							),
-							{ retentionDays: retentionSelected }
+							{ retentionDays: String( retentionSelected ) }
 						) }
 					</p>
 					<ButtonStack justify="flex-start">

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/upsell-step.tsx
@@ -103,7 +103,7 @@ export default function UpsellStep( {
 	const { refundAmount } = props;
 	const { setSubject, setShowHelpCenter } = useHelpCenter();
 	const businessPlan = plans?.find( ( plan ) => 'business-bundle' === plan.product_slug );
-	const businessPlanName = businessPlan?.product_name;
+	const businessPlanName = businessPlan?.product_name ?? '';
 	const personalPlan = plans?.find( ( plan ) => 'personal-bundle' === plan.product_slug );
 	const personalPlanName = personalPlan?.product_name ?? '';
 	const thePlan = plans?.find( ( plan ) => purchase.product_slug === plan.product_slug );
@@ -139,7 +139,7 @@ export default function UpsellStep( {
 						setSubject( initialMessage );
 						setShowHelpCenter( true );
 
-						props.closeDialog && props.closeDialog();
+						props.closeDialog?.();
 					} }
 					intent={ props.intent }
 					declineButtonText={ props.declineButtonText }
@@ -220,11 +220,9 @@ export default function UpsellStep( {
 				>
 					{ createInterpolateElement(
 						sprintf(
-							/* translators: %(discountRate)d%% is a discount percentage like 20% or 25%, followed by an escaped percentage sign %% */
+							/* translators: %(numberOfPluginsThemes)s is a count of plugins and themes, %(businessPlanName)s is the name of the WordPress.com Business plan, %(discountRate)d%% is a discount percentage like 20% or 25% followed by an escaped percentage sign %%, %(couponCode)s is a discount coupon code */
 							__(
-								'Did you know that you can now use over %(numberOfPluginsThemes)s third-party plugins and themes on the WordPress.com %(businessPlanName)s plan? ' +
-									'Whatever feature or design you want to add to your site, you’ll find a plugin or theme to get you there. ' +
-									'Claim a %(discountRate)d%% discount when you renew your %(businessPlanName)s plan today – <b>just enter the code %(couponCode)s at checkout.</b>'
+								'Did you know that you can now use over %(numberOfPluginsThemes)s third-party plugins and themes on the WordPress.com %(businessPlanName)s plan? Whatever feature or design you want to add to your site, you’ll find a plugin or theme to get you there. Claim a %(discountRate)d%% discount when you renew your %(businessPlanName)s plan today – <b>just enter the code %(couponCode)s at checkout.</b>'
 							),
 							{
 								numberOfPluginsThemes,
@@ -310,8 +308,7 @@ export default function UpsellStep( {
 							? sprintf(
 									/* translators: %(amount)s is a monetary amount in the form of a refund */
 									__(
-										'You can downgrade and get a partial refund of %(amount)s or ' +
-											'continue to the next step and cancel the plan.'
+										'You can downgrade and get a partial refund of %(amount)s or continue to the next step and cancel the plan.'
 									),
 									{
 										amount: formatCurrency( refundAmount, currencyCode ),
@@ -335,11 +332,9 @@ export default function UpsellStep( {
 					{ sprintf(
 						/* translators: %(currentPlan)s is the name of the plan to which the customer is subscribed */
 						__(
-							'We get it – building a site takes time. ' +
-								'But we’d love to see you stick around to build on what you started. ' +
-								'How about a free month of your %(currentPlan)s plan subscription to continue building your site?'
+							'We get it – building a site takes time. But we’d love to see you stick around to build on what you started. How about a free month of your %(currentPlan)s plan subscription to continue building your site?'
 						),
-						{ planName }
+						{ currentPlan: planName }
 					) }
 				</Upsell>
 			);

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
@@ -176,7 +176,7 @@ export default function CancellationMainContent( {
 							__(
 								'All services connected to %(domain)s will become unreachable, including email and website.'
 							),
-							{ domain: purchase.meta }
+							{ domain: purchase.meta ?? '' }
 						),
 				},
 				{
@@ -185,7 +185,7 @@ export default function CancellationMainContent( {
 						sprintf(
 							/* translators: %(domain)s is the domain name being deleted */
 							__( '%(domain)s will become available for someone else to register.' ),
-							{ domain: purchase.meta }
+							{ domain: purchase.meta ?? '' }
 						),
 				}
 			);

--- a/client/dashboard/me/billing-purchases/cancel-purchase/domain-options.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/domain-options.tsx
@@ -22,8 +22,7 @@ const NonRefundableDomainMappingMessage = ( {
 				{ sprintf(
 					/* translators: %(mappedDomain)s is a domain name */
 					__(
-						'This plan includes the custom domain mapping for %(mappedDomain)s. ' +
-							'The domain will not be removed along with the plan, to avoid any interruptions for your visitors.'
+						'This plan includes the custom domain mapping for %(mappedDomain)s. The domain will not be removed along with the plan, to avoid any interruptions for your visitors.'
 					),
 					{
 						mappedDomain: includedDomainPurchase.meta,
@@ -50,8 +49,7 @@ const CancelableDomainMappingMessage = ( {
 				{ sprintf(
 					/* translators: %(mappedDomain)s is a domain name */
 					__(
-						'This plan includes mapping for the domain %(mappedDomain)s. ' +
-							"Cancelling will remove all the plan's features from your site, including the domain."
+						"This plan includes mapping for the domain %(mappedDomain)s. Cancelling will remove all the plan's features from your site, including the domain."
 					),
 					{
 						mappedDomain: includedDomainPurchase.meta,
@@ -60,7 +58,7 @@ const CancelableDomainMappingMessage = ( {
 			</p>
 			<p>
 				{ sprintf(
-					/* translators: %(mappedDomain)s and %(wordpressSiteUrl) are both domain names */
+					/* translators: %(mappedDomain)s and %(wordpressSiteUrl)s are both domain names */
 					__(
 						'Your site will no longer be available at %(mappedDomain)s. Instead, it will be at %(wordpressSiteUrl)s'
 					),
@@ -74,8 +72,7 @@ const CancelableDomainMappingMessage = ( {
 				{ sprintf(
 					/* translators: %(mappedDomain)s is a domain name */
 					__(
-						'The domain %(mappedDomain)s itself is not canceled. Only the connection between WordPress.com and ' +
-							'your domain is removed. %(mappedDomain)s is registered elsewhere and you can still use it with other sites.'
+						'The domain %(mappedDomain)s itself is not canceled. Only the connection between WordPress.com and your domain is removed. %(mappedDomain)s is registered elsewhere and you can still use it with other sites.'
 					),
 					{
 						mappedDomain: includedDomainPurchase.meta,
@@ -124,11 +121,10 @@ const CancelPlanWithoutCancellingDomainMessage = ( {
 					{ sprintf(
 						/* translators: %(refundAmount)s, %(planCost)s and %(domainCost)s are all monetary amounts */
 						__(
-							'You will receive a partial refund of %(refundAmount)s which is %(planCost)s for the plan ' +
-								'minus %(domainCost)s for the domain.'
+							'You will receive a partial refund of %(refundAmount)s which is %(planCost)s for the plan minus %(domainCost)s for the domain.'
 						),
 						{
-							domainCost: includedDomainPurchase.cost_to_unbundle_display,
+							domainCost: includedDomainPurchase.cost_to_unbundle_display ?? '',
 							planCost: planPurchase.total_refund_text,
 							refundAmount: planPurchase.refund_text,
 						}
@@ -286,13 +282,11 @@ const CancelPurchaseDomainOptions = ( {
 							description: sprintf(
 								/* translators: %(refundAmount)s and %(domainCost)s are both monetary amounts. %(productName)s is the name of the product */
 								__(
-									"You'll receive a partial refund of %(refundAmount)s -- the cost of the %(productName)s " +
-										'plan, minus %(domainCost)s for the domain. There will be no change to your domain ' +
-										"registration, and you're free to use it on WordPress.com or transfer it elsewhere."
+									"You'll receive a partial refund of %(refundAmount)s -- the cost of the %(productName)s plan, minus %(domainCost)s for the domain. There will be no change to your domain registration, and you're free to use it on WordPress.com or transfer it elsewhere."
 								),
 								{
 									productName: purchase.product_name,
-									domainCost: includedDomainPurchase.cost_to_unbundle_display,
+									domainCost: includedDomainPurchase.cost_to_unbundle_display ?? '',
 									refundAmount: purchase.refund_text,
 								}
 							),
@@ -309,8 +303,7 @@ const CancelPurchaseDomainOptions = ( {
 							description: sprintf(
 								/* translators: %(planCost)s is the monetary amount that the customer will receive in the form of a refund */
 								__(
-									"You'll receive a full refund of %(planCost)s. The domain will be cancelled, and it's possible " +
-										"you'll lose it permanently."
+									"You'll receive a full refund of %(planCost)s. The domain will be cancelled, and it's possible you'll lose it permanently."
 								),
 								{
 									planCost: purchase.total_refund_text,

--- a/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-warning-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-warning-step.tsx
@@ -67,7 +67,7 @@ export default function DomainRemovalWarningStep( {
 						? createInterpolateElement(
 								/* translators: <domainName /> is the domain name */
 								__(
-									'If you want to use <domainName /> with another provider you can <moveLink>move it to another service</moveLink> or <transferLink>transfer it to another provider</transferLink>.'
+									'If you want to use <domainName/> with another provider you can <moveLink>move it to another service</moveLink> or <transferLink>transfer it to another provider</transferLink>.'
 								),
 								{
 									domainName: <strong>{ domainName }</strong>,
@@ -90,7 +90,7 @@ export default function DomainRemovalWarningStep( {
 						: createInterpolateElement(
 								/* translators: <domainName /> is the domain name */
 								__(
-									'If you want to use <domainName /> with another provider you can <moveLink>move it to another service</moveLink>.'
+									'If you want to use <domainName/> with another provider you can <moveLink>move it to another service</moveLink>.'
 								),
 								{
 									domainName: <strong>{ domainName }</strong>,

--- a/client/dashboard/me/billing-purchases/cancel-purchase/gsuite-access-message.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/gsuite-access-message.tsx
@@ -12,7 +12,8 @@ export default function GSuiteAccessMessage( {
 	purchase,
 	selectedDomain,
 }: GSuiteAccessMessageProps ) {
-	const { meta: domainName, product_slug: productSlug } = purchase;
+	const { meta, product_slug: productSlug } = purchase;
+	const domainName = meta ?? '';
 	if ( ! productSlug || ! selectedDomain ) {
 		return null;
 	}
@@ -24,11 +25,9 @@ export default function GSuiteAccessMessage( {
 			<p>
 				{ createInterpolateElement(
 					sprintf(
-						// Translators: %(domainName) is the name of the domain (e.g. example.com) and %(googleMailService)s can be either "G Suite" or "Google Workspace"
+						// Translators: %(domainName)s is the name of the domain (e.g. example.com) and %(googleMailService)s can be either "G Suite" or "Google Workspace"
 						__(
-							'If you cancel your subscription for %(domainName)s now, <strong>you will lose access to all of ' +
-								'your %(googleMailService)s features immediately</strong>, and you will ' +
-								'need to purchase a new subscription with Google if you wish to regain access to them.'
+							'If you cancel your subscription for %(domainName)s now, <strong>you will lose access to all of your %(googleMailService)s features immediately</strong>, and you will need to purchase a new subscription with Google if you wish to regain access to them.'
 						),
 						{
 							domainName,
@@ -47,11 +46,9 @@ export default function GSuiteAccessMessage( {
 		<p>
 			{ createInterpolateElement(
 				sprintf(
-					// Translators: %(domainName) is the name of the domain (e.g. example.com), %(googleMailService)s can be either "G Suite" or "Google Workspace", and %(days)d is a number of days (usually '30')
+					// Translators: %(domainName)s is the name of the domain (e.g. example.com), %(googleMailService)s can be either "G Suite" or "Google Workspace", and %(days)d is a number of days (usually '30')
 					__(
-						'If you cancel your subscription for %(domainName)s now, <strong>you will lose access to all of ' +
-							'your %(googleMailService)s features in %(days)d days</strong>. After that time, ' +
-							'you will need to purchase a new subscription with Google if you wish to regain access to them.'
+						'If you cancel your subscription for %(domainName)s now, <strong>you will lose access to all of your %(googleMailService)s features in %(days)d days</strong>. After that time, you will need to purchase a new subscription with Google if you wish to regain access to them.'
 					),
 					{
 						domainName,

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -895,9 +895,11 @@ function CancelPurchaseInner() {
 		const cancelActiveSubscriptions: Purchase[] = [];
 		const marketplaceSubscriptions = getActiveMarketplaceSubscriptions();
 		marketplaceSubscriptions.forEach( ( subscription ) => {
-			hasAmountAvailableToRefund( subscription )
-				? cancelAndRefundActiveSubscriptions.push( subscription )
-				: cancelActiveSubscriptions.push( subscription );
+			if ( hasAmountAvailableToRefund( subscription ) ) {
+				cancelAndRefundActiveSubscriptions.push( subscription );
+			} else {
+				cancelActiveSubscriptions.push( subscription );
+			}
 		} );
 		cancelAndRefundActiveSubscriptions.forEach( ( marketplaceSubscription ) => {
 			cancelAndRefundMutation.mutate(
@@ -1237,7 +1239,7 @@ function CancelPurchaseInner() {
 					} );
 				},
 				onError: () => {
-					const purchaseName = purchase.is_domain ? purchase.meta : purchase.product_name;
+					const purchaseName = ( purchase.is_domain ? purchase.meta : purchase.product_name ) ?? '';
 					createErrorNotice(
 						sprintf(
 							/* translators: %(purchaseName)s is the name of the product that was purchased. */
@@ -1361,7 +1363,7 @@ function CancelPurchaseInner() {
 					} );
 				},
 				onError: () => {
-					const purchaseName = purchase.is_domain ? purchase.meta : purchase.product_name;
+					const purchaseName = ( purchase.is_domain ? purchase.meta : purchase.product_name ) ?? '';
 					createErrorNotice(
 						sprintf(
 							/* translators: %(purchaseName)s is the name of the product that was purchased. */
@@ -1810,7 +1812,9 @@ function CancelPurchaseInner() {
 									primaryButtonText={ __( 'Continue' ) }
 									removePlan={ handleMarketplaceDialogContinue }
 									/* Translators: %(plan)s is the name of the plan being cancelled */
-									sectionHeadingText={ sprintf( __( 'Cancel %(plan)s' ), { plan: planName } ) }
+									sectionHeadingText={ sprintf( __( 'Cancel %(plan)s' ), {
+										plan: planName ?? '',
+									} ) }
 								/>
 							) }
 						</VStack>

--- a/client/dashboard/me/billing-purchases/dataviews.tsx
+++ b/client/dashboard/me/billing-purchases/dataviews.tsx
@@ -191,7 +191,7 @@ function OwnerInfo( {
 			{ createInterpolateElement(
 				// translators: domain is a domain name
 				__(
-					'This license was activated on <domain /> by another user. If you haven’t given the license to them on purpose, <link>contact our support team</link> for more assistance.'
+					'This license was activated on <domain/> by another user. If you haven’t given the license to them on purpose, <link>contact our support team</link> for more assistance.'
 				),
 				{
 					domain: <strong>{ purchase.domain || purchase.site_slug || __( 'a site' ) }</strong>,
@@ -363,27 +363,27 @@ export function getFields( {
 			elements: [
 				{
 					value: '7',
-					// translators: %s: number of days
+					// translators: %(days)d is a number of days
 					label: sprintf( __( 'Expires in %(days)d days' ), { days: 7 } ),
 				},
 				{
 					value: '14',
-					// translators: %s: number of days
+					// translators: %(days)d is a number of days
 					label: sprintf( __( 'Expires in %(days)d days' ), { days: 14 } ),
 				},
 				{
 					value: '30',
-					// translators: %s: number of days
+					// translators: %(days)d is a number of days
 					label: sprintf( __( 'Expires in %(days)d days' ), { days: 30 } ),
 				},
 				{
 					value: '60',
-					// translators: %s: number of days
+					// translators: %(days)d is a number of days
 					label: sprintf( __( 'Expires in %(days)d days' ), { days: 60 } ),
 				},
 				{
 					value: '365',
-					// translators: %s: number of days
+					// translators: %(days)d is a number of days
 					label: sprintf( __( 'Expires in %(days)d days' ), { days: 365 } ),
 				},
 			],

--- a/client/dashboard/me/billing-purchases/purchase-payment-method.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-payment-method.tsx
@@ -66,7 +66,7 @@ export function PurchasePaymentMethod( {
 		const maskedCardNumber = sprintf(
 			/** Translators: %s is last four digits of card number */
 			_x( '**** **** **** %s', 'Long-form masked credit card number.' ),
-			purchase.payment_details
+			purchase.payment_details ?? ''
 		);
 
 		return (

--- a/client/dashboard/me/billing-purchases/purchase-settings/cancellation-offer-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/cancellation-offer-notice.tsx
@@ -26,12 +26,12 @@ export function CancellationOfferNotice( {
 					( isAkismet ? akismetHeadline : jetpackHeadline ) +
 					' ' +
 					sprintf(
-						/* Translators: %(percentDiscount)d%% should be a percentage like 15% or 20% */
+						/* Translators: %(percentDiscount)d%% should be a percentage like 15% or 20%, %(productName)s is the name of the product the discount applies to */
 						__(
 							'Your %(percentDiscount)d%% discount for %(productName)s will be applied next time you are billed.'
 						),
 						{
-							percentDiscount: purchase.cancellation_offer_notice_discount_percentage,
+							percentDiscount: purchase.cancellation_offer_notice_discount_percentage ?? 0,
 							productName: purchase.product_name,
 						}
 					)

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -708,7 +708,7 @@ function getFields( {
 						if ( isInExpirationGracePeriod( purchase ) ) {
 							return __( 'Pending renewal' );
 						}
-						// translators: date is a formatted date string
+						// translators: %(date)s is a formatted date string
 						return sprintf( __( 'You will be billed on %(date)s' ), {
 							date: formatDate( new Date( purchase.renew_date ), locale, { dateStyle: 'long' } ),
 						} );
@@ -719,13 +719,13 @@ function getFields( {
 						} );
 						if ( isExpired( purchase ) || isInExpirationGracePeriod( purchase ) ) {
 							return sprintf(
-								// translators: date is a formatted expiry date
+								// translators: %(date)s is a formatted expiry date
 								__( 'Expired on %(date)s.' ),
 								{ date }
 							);
 						}
 						return sprintf(
-							// translators: date is a formatted expiry date
+							// translators: %(date)s is a formatted expiry date
 							__( 'Expires on %(date)s.' ),
 							{ date }
 						);
@@ -897,7 +897,7 @@ function PurchasePriceCard( { purchase }: { purchase: Purchase } ) {
 	}
 	const isOffer = purchase.regular_price_integer !== purchase.price_integer;
 	const offerText = isOffer
-		? /* translators: %(regularPrice) is a monetary amount that the customer will be charged after this offer ends */
+		? /* translators: %(regularPrice)s is a monetary amount that the customer will be charged after this offer ends */
 		  sprintf( __( 'After the offer ends, the subscription price will be %(regularPrice)s.' ), {
 				regularPrice: formatCurrency( purchase.regular_price_integer, purchase.currency_code, {
 					isSmallestUnit: true,
@@ -1008,12 +1008,12 @@ function BBEPurchaseDescription( { purchase }: { purchase: Purchase } ) {
 								'A professionally built %(numberOfIncludedPages)s-page website in 4 business days or less.'
 							),
 							{
-								numberOfIncludedPages: tier0.maximum_units,
+								numberOfIncludedPages: String( tier0.maximum_units ),
 							}
 					  ) }{ ' ' }
 				{ extraPageCount > 0 &&
 					sprintf(
-						// translators: numberofPages is a number of pages
+						// translators: %(numberOfPages)d is a number of pages
 						_n(
 							'This purchase includes %(numberOfPages)d extra page.',
 							'This purchase includes %(numberOfPages)d extra pages.',
@@ -1272,7 +1272,7 @@ function PurchaseSecondSubtitle( {
 				<Text variant="muted">
 					{ description }{ ' ' }
 					{ sprintf(
-						// translators: numberOfMailboxes is a number and domain is a domain name
+						// translators: %(numberOfMailboxes)d is a number of mailboxes and %(domain)s is a domain name
 						_n(
 							'This purchase is for %(numberOfMailboxes)d mailbox for the domain %(domain)s.',
 							'This purchase is for %(numberOfMailboxes)d mailboxes for the domain %(domain)s.',
@@ -1280,7 +1280,7 @@ function PurchaseSecondSubtitle( {
 						),
 						{
 							numberOfMailboxes: purchase.renewal_price_tier_usage_quantity,
-							domain: purchase.meta,
+							domain: purchase.meta ?? '',
 						}
 					) }
 				</Text>
@@ -1309,7 +1309,7 @@ function PurchaseSubtitle( { purchase }: { purchase: Purchase } ) {
 		return (
 			<MetadataItem
 				title={ sprintf(
-					// translators: subtitle is the type of purchase (e.g. "Host Managed Plan"), partnerName is the name of the business partner
+					// translators: %(subtitle)s is the type of purchase (e.g. "Host Managed Plan"), %(partnerName)s is the name of the business partner
 					__( '%(subtitle)s. Please contact %(partnerName)s for details.' ),
 					{ subtitle, partnerName: purchase.partner_name }
 				) }

--- a/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/other-renewable-purchases-notice.tsx
@@ -622,7 +622,7 @@ export function OtherRenewablePurchasesNotice( {
 						__(
 							'Your <managePurchase>%(purchaseName)s plan</managePurchase> (which includes your %(includedPurchaseName)s subscription) is scheduled to renew, but you have <link>other upgrades</link> on this site that will expire %(earliestOtherExpiry)s unless you take action.'
 						),
-						{ purchaseName, earliestOtherExpiry }
+						{ purchaseName, earliestOtherExpiry, includedPurchaseName }
 					),
 					{ link, managePurchase }
 				);
@@ -691,9 +691,9 @@ export function OtherRenewablePurchasesNotice( {
 
 		if ( currentPurchase.payment_card_id ) {
 			const cardDetails = {
-				cardType: purchase.payment_card_type,
-				cardNumber: purchase.payment_card_id,
-				cardExpiry: purchase.payment_expiry,
+				cardType: purchase.payment_card_type ?? '',
+				cardNumber: Number( purchase.payment_card_id ) || 0,
+				cardExpiry: purchase.payment_expiry ?? '',
 			};
 
 			const translatedMessage = creditCardHasAlreadyExpired( purchase )
@@ -943,9 +943,9 @@ export function OtherRenewablePurchasesNotice( {
 
 		if ( currentPurchase.payment_card_id ) {
 			const cardDetails = {
-				cardType: purchase.payment_card_type,
-				cardNumber: purchase.payment_card_id,
-				cardExpiry: purchase.payment_expiry,
+				cardType: purchase.payment_card_type ?? '',
+				cardNumber: Number( purchase.payment_card_id ) || 0,
+				cardExpiry: purchase.payment_expiry ?? '',
 			};
 
 			const translatedMessage = creditCardHasAlreadyExpired( purchase )

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -450,7 +450,7 @@ function TrialNotice( { purchase }: { purchase: Purchase } ) {
 					daysToExpiry
 				),
 				{
-					expiry: daysToExpiry,
+					expiry: String( daysToExpiry ),
 					productType: productType as string,
 				}
 		  )
@@ -509,9 +509,9 @@ export function shouldShowCardExpiringWarning( purchase: Purchase ): boolean {
 
 function CreditCardExpiringNotice( { purchase }: { purchase: Purchase } ) {
 	const cardDetails = {
-		cardType: purchase.payment_card_type,
-		cardNumber: purchase.payment_card_id,
-		cardExpiry: purchase.payment_expiry,
+		cardType: purchase.payment_card_type ?? '',
+		cardNumber: Number( purchase.payment_card_id ) || 0,
+		cardExpiry: purchase.payment_expiry ?? '',
 	};
 
 	const linkComponent = {

--- a/client/dashboard/me/language/index.tsx
+++ b/client/dashboard/me/language/index.tsx
@@ -175,8 +175,8 @@ export default function Language() {
 			description:
 				/* translators: %(languageName)s is a localized language name, %(percentTranslated)d%% is a percentage number (0-100), followed by an escaped percent sign %%. */
 				sprintf( __( '(%(languageName)s is only %(percentTranslated)d%% translated)' ), {
-					languageName: selectedLanguage?.name,
-					percentTranslated: selectedLanguage?.calypsoPercentTranslated,
+					languageName: selectedLanguage?.name ?? '',
+					percentTranslated: selectedLanguage?.calypsoPercentTranslated ?? 0,
 				} ),
 			type: 'boolean',
 			Edit: 'checkbox',

--- a/client/dashboard/me/notifications-emails/subscription-settings/form.tsx
+++ b/client/dashboard/me/notifications-emails/subscription-settings/form.tsx
@@ -97,10 +97,9 @@ const baseFields: Field< SettingsData >[] = [
 		label: __( 'Hour' ),
 		type: 'integer' as const,
 		description: sprintf(
-			// translators: %s is the timezone E.g. America/New_York
+			// translators: %(timezone)s is the timezone E.g. America/New_York
 			__( 'Timezone: %(timezone)s' ),
 			{
-				context: 'Timezone description',
 				timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
 			}
 		),

--- a/client/dashboard/me/notifications-sites/site-list-settings/index.tsx
+++ b/client/dashboard/me/notifications-sites/site-list-settings/index.tsx
@@ -51,10 +51,10 @@ export const SiteListSettings = () => {
 						<CardBody>
 							{ createInterpolateElement(
 								sprintf(
-									// translators: %s is the search query
+									// translators: %(search)s is the search query
 									__( 'No sites found with the search query <strong>%(search)s</strong>.' ),
 									{
-										search: search,
+										search: search ?? '',
 									}
 								),
 								{

--- a/client/dashboard/me/profile-personal-details/update-username/confirmation-modal.tsx
+++ b/client/dashboard/me/profile-personal-details/update-username/confirmation-modal.tsx
@@ -36,12 +36,9 @@ export default function UsernameUpdateConfirmationModal( {
 		>
 			{ createInterpolateElement(
 				sprintf(
-					/* translators: currentUsername is the current username that will be changed.
-					newUsername is the new username */
+					/* translators: %(currentUsername)s is the current username that will be changed, %(newUsername)s is the new username */
 					__(
-						'You are about to change your username, <strong>%(currentUsername)s</strong>, to <strong>%(newUsername)s</strong>. <break />' +
-							'Once changed, you will not be able to revert it. <break />' +
-							'Changing your username will also affect your Gravatar profile and IntenseDebate profile addresses.'
+						'You are about to change your username, <strong>%(currentUsername)s</strong>, to <strong>%(newUsername)s</strong>. <break/>Once changed, you will not be able to revert it. <break/>Changing your username will also affect your Gravatar profile and IntenseDebate profile addresses.'
 					),
 					{ currentUsername, newUsername }
 				),

--- a/client/dashboard/me/security-account-recovery/recovery-email.tsx
+++ b/client/dashboard/me/security-account-recovery/recovery-email.tsx
@@ -119,7 +119,7 @@ export default function RecoveryEmail() {
 				label: __( 'Email address' ),
 				description:
 					/* translators: %s: email address */
-					sprintf( __( 'Your primary email address is %s.' ), serverData?.user_email ),
+					sprintf( __( 'Your primary email address is %s.' ), serverData?.user_email ?? '' ),
 				type: 'email',
 				Edit: ( { field, data, onChange } ) => {
 					const { id, getValue } = field;


### PR DESCRIPTION
Fixes DOTCOM-17287

Part of #105909. Sister PR to #110985, which already handled the TS2322 widening in this area; this finishes the remaining TS2353/TS2769 errors.

## Proposed Changes

Resolves the remaining ~35 `@wordpress/i18n` type errors in `client/dashboard/me/` so the code compiles against both `@wordpress/i18n@^5.23.0` (trunk's current pin) and `@wordpress/i18n@^6.x` (what #105909 will install).

Three fix patterns applied:

1. **TS2353 — sprintf format strings built with `+` concatenation.** The `+` collapses the format to plain `string`, defeating the typed-placeholder parser. Joined into single string literals (preserving curly quotes and apostrophes per `CLAUDE.md`).
2. **TS2769 — sprintf args whose type was `string | undefined` (or `number | undefined`).** Coerced with `?? ''` / `?? 0` at the use site, or `Number(...)` for `%d` placeholders fed a `number | string | undefined` value.
3. **Self-closing tag spaces in `createInterpolateElement` formats.** The runtime tokenizer matches `<tag />`, but the type-level `ExtractTags` only recognises `<tag/>` (no space before `/>`). Stripped the space in `<domainName/>`, `<domain/>`, and `<break/>` — runtime behaviour unchanged.

## Real bugs fixed along the way

- `purchase-settings/other-renewable-purchases-notice.tsx` (~L613): the bundled-plan branch declared `%(includedPurchaseName)s` in the format but the `sprintf` args only passed `{ purchaseName, earliestOtherExpiry }`. The placeholder rendered literally to users on plans that bundle another subscription. Added `includedPurchaseName` to the args.
- `cancel-purchase-form/step-components/upsell-step.tsx` (~L342): the free-month-offer step used `%(currentPlan)s` in the format but passed `{ planName }`. Renamed the arg key to `currentPlan: planName`.
- `notifications-emails/subscription-settings/form.tsx` (~L103): args object carried a stale `context: 'Timezone description'` property that the format string never declared. Removed.

## Drive-by lint cleanups

Pre-existing on trunk but caught by per-file `lint-staged` once these files were touched:

- Expanded incomplete `/* translators: */` comments to describe every placeholder the linter now sees in the typed formats.
- Replaced two short-circuit expressions used for side effects (`x && x()` → `x?.()`, ternary-as-statement → `if`/`else`) flagged by `@typescript-eslint/no-unused-expressions`.

## Testing Instructions

1. `yarn typecheck-client` — clean on `trunk` (and clean under a local `@wordpress/i18n@^6.x` install too — verified during development).
2. Manual smoke-test of the three real-bug fixes: open Dashboard → My Settings → Purchases on a site with a plan that bundles another subscription, and confirm the "other upgrades" notice no longer shows `%(includedPurchaseName)s` literally; navigate the cancel-purchase flow with the free-month upsell to confirm the current plan name renders.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?
