### PR TITLE
Add smart dictation quota upgrade action

### DIFF
--- a/packages/wpcom-smart-dictation/src/live-ai-assistant/index.tsx
+++ b/packages/wpcom-smart-dictation/src/live-ai-assistant/index.tsx
@@ -133,8 +133,6 @@ function getStatusLabel( status: ReturnType< typeof useRealtimeSession >[ 'statu
 			return __( 'Connecting…' );
 		case 'active':
 			return __( 'Listening' );
-		case 'ending':
-			return __( 'Stopping…' );
 		case 'error':
 			return __( 'Something went wrong' );
 		case 'idle':
@@ -197,10 +195,7 @@ export function LiveAIAssistant( { contextualInstructions }: LiveAIAssistantProp
 
 	const isSessionActive = status === 'active';
 	const isSessionBusy =
-		status === 'requesting-token' ||
-		status === 'requesting-mic' ||
-		status === 'connecting' ||
-		status === 'ending';
+		status === 'requesting-token' || status === 'requesting-mic' || status === 'connecting';
 	const sessionTimeLimit = sessionTimeLimitMs ?? 0;
 	const sessionTimeRemaining = sessionTimeRemainingMs ?? 0;
 	const hasSessionTimeRemaining = sessionTimeLimit > 0;

--- a/packages/wpcom-smart-dictation/src/live-ai-assistant/index.tsx
+++ b/packages/wpcom-smart-dictation/src/live-ai-assistant/index.tsx
@@ -18,7 +18,9 @@ type TimelineRow =
 	| { kind: 'message'; timestamp: number; entry: RealtimeTranscriptEntry }
 	| { kind: 'tool'; timestamp: number; evt: RealtimeToolEvent };
 
-const DICTATION_UPGRADE_URL = 'https://wordpress.com/checkout';
+const DICTATION_UPGRADE_URL = `https://wordpress.com/checkout/${ encodeURIComponent(
+	window.location.host
+) }/premium?redirect_to=${ encodeURIComponent( window.location.href ) }`;
 
 function buildTimelineRows(
 	transcript: RealtimeTranscriptEntry[],
@@ -221,6 +223,11 @@ export function LiveAIAssistant( { contextualInstructions }: LiveAIAssistantProp
 			start();
 		}
 	};
+	const handleUpgradeClick = () => {
+		recordTracksEvent( 'calypso_smart_dictation_upgrade_clicked', {
+			source: 'quota_exhausted',
+		} );
+	};
 	const statusContent = isSessionActive ? (
 		<>
 			<AudioFftBlobs
@@ -243,8 +250,9 @@ export function LiveAIAssistant( { contextualInstructions }: LiveAIAssistantProp
 				variant="primary"
 				className="live-ai-assistant__call-button"
 				href={ DICTATION_UPGRADE_URL }
+				onClick={ handleUpgradeClick }
 			>
-				<span>{ __( 'Upgrade' ) }</span>
+				<span>{ __( 'Upgrade to premium' ) }</span>
 			</Button>
 		);
 	} else if ( showQuotaReachedButton ) {

--- a/packages/wpcom-smart-dictation/src/live-ai-assistant/index.tsx
+++ b/packages/wpcom-smart-dictation/src/live-ai-assistant/index.tsx
@@ -322,6 +322,14 @@ export function LiveAIAssistant( { contextualInstructions }: LiveAIAssistantProp
 										'Tap Start dictation and speak naturally. This is more than a dictation tool: it gives you full voice control of the editor. Format text, insert pictures, manipulate any available block, and even save the post.'
 									) }
 								</p>
+								<a
+									className="live-ai-assistant__intro-learn-more"
+									href={ smartDictationSupportUrl }
+									target="_blank"
+									rel="noreferrer"
+								>
+									{ __( 'Learn more' ) }
+								</a>
 							</div>
 						) }
 
@@ -338,18 +346,9 @@ export function LiveAIAssistant( { contextualInstructions }: LiveAIAssistantProp
 							<Notice.Root intent="info">
 								<Notice.Title>{ __( 'Daily quota limit reached' ) }</Notice.Title>
 								<Notice.Description>
-									{ createInterpolateElement(
-										canUpgrade
-											? __(
-													'It will reset at midnight. Upgrade to keep writing by voice. <link>Learn more</link>.'
-											  )
-											: __( 'It will reset at midnight. <link>Learn more</link>.' ),
-										{
-											link: (
-												<a href={ smartDictationSupportUrl } target="_blank" rel="noreferrer" />
-											),
-										}
-									) }
+									{ canUpgrade
+										? __( 'It will reset at midnight. Upgrade to keep writing by voice.' )
+										: __( 'It will reset at midnight.' ) }
 								</Notice.Description>
 							</Notice.Root>
 						) }

--- a/packages/wpcom-smart-dictation/src/live-ai-assistant/index.tsx
+++ b/packages/wpcom-smart-dictation/src/live-ai-assistant/index.tsx
@@ -202,10 +202,11 @@ export function LiveAIAssistant( { contextualInstructions }: LiveAIAssistantProp
 	const sessionTimeLimit = sessionTimeLimitMs ?? 0;
 	const sessionTimeRemaining = sessionTimeRemainingMs ?? 0;
 	const hasSessionTimeRemaining = sessionTimeLimit > 0;
+	const hasKnownSessionTimeRemaining = sessionTimeRemainingMs !== null;
 	const sessionTimeProgress = hasSessionTimeRemaining
 		? Math.max( 0, Math.min( 100, ( sessionTimeRemaining / sessionTimeLimit ) * 100 ) )
 		: 0;
-	const hasExhaustedQuota = hasSessionTimeRemaining && sessionTimeRemaining <= 0;
+	const hasExhaustedQuota = hasKnownSessionTimeRemaining && sessionTimeRemaining <= 0;
 	const showQuotaLimitNotice = hasExhaustedQuota && ! isSessionActive;
 	const showUpgradeButton = canUpgrade && hasExhaustedQuota && ! isSessionActive && ! isSessionBusy;
 	const showQuotaReachedButton =

--- a/packages/wpcom-smart-dictation/src/live-ai-assistant/index.tsx
+++ b/packages/wpcom-smart-dictation/src/live-ai-assistant/index.tsx
@@ -1,6 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { localizeUrl, useLocale } from '@automattic/i18n-utils';
-import { Button } from '@wordpress/components';
+import { Button, ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Notice } from '@wordpress/ui';
@@ -322,14 +322,12 @@ export function LiveAIAssistant( { contextualInstructions }: LiveAIAssistantProp
 										'Tap Start dictation and speak naturally. This is more than a dictation tool: it gives you full voice control of the editor. Format text, insert pictures, manipulate any available block, and even save the post.'
 									) }
 								</p>
-								<a
+								<ExternalLink
 									className="live-ai-assistant__intro-learn-more"
 									href={ smartDictationSupportUrl }
-									target="_blank"
-									rel="noreferrer"
 								>
 									{ __( 'Learn more' ) }
-								</a>
+								</ExternalLink>
 							</div>
 						) }
 

--- a/packages/wpcom-smart-dictation/src/live-ai-assistant/index.tsx
+++ b/packages/wpcom-smart-dictation/src/live-ai-assistant/index.tsx
@@ -1,5 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { useLocale } from '@automattic/i18n-utils';
+import { localizeUrl, useLocale } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -151,6 +151,10 @@ function formatRemainingTime( remainingMs: number ): string {
 
 export function LiveAIAssistant( { contextualInstructions }: LiveAIAssistantProps ) {
 	const locale = useLocale();
+	const smartDictationSupportUrl = useMemo(
+		() => localizeUrl( 'https://wordpress.com/support/wordpress-editor/smart-dictation/', locale ),
+		[ locale ]
+	);
 	const instructions = useMemo(
 		() => buildInstructions( locale, contextualInstructions ),
 		[ locale, contextualInstructions ]
@@ -334,9 +338,18 @@ export function LiveAIAssistant( { contextualInstructions }: LiveAIAssistantProp
 							<Notice.Root intent="info">
 								<Notice.Title>{ __( 'Daily quota limit reached' ) }</Notice.Title>
 								<Notice.Description>
-									{ canUpgrade
-										? __( 'It will reset at midnight. Upgrade to keep writing by voice.' )
-										: __( 'It will reset at midnight.' ) }
+									{ createInterpolateElement(
+										canUpgrade
+											? __(
+													'It will reset at midnight. Upgrade to keep writing by voice. <link>Learn more</link>.'
+											  )
+											: __( 'It will reset at midnight. <link>Learn more</link>.' ),
+										{
+											link: (
+												<a href={ smartDictationSupportUrl } target="_blank" rel="noreferrer" />
+											),
+										}
+									) }
 								</Notice.Description>
 							</Notice.Root>
 						) }

--- a/packages/wpcom-smart-dictation/src/live-ai-assistant/index.tsx
+++ b/packages/wpcom-smart-dictation/src/live-ai-assistant/index.tsx
@@ -281,6 +281,17 @@ export function LiveAIAssistant( { contextualInstructions }: LiveAIAssistantProp
 							</Notice.Root>
 						) }
 
+						{ hasExhaustedUpgradeableQuota && (
+							<Notice.Root intent="info">
+								<Notice.Title>{ __( 'Keep dictating' ) }</Notice.Title>
+								<Notice.Description>
+									{ __(
+										"You've used your free Smart Dictation time for today. Upgrade to keep writing by voice."
+									) }
+								</Notice.Description>
+							</Notice.Root>
+						) }
+
 						{ timelineRows.length > 0 && (
 							<div className="live-ai-assistant__transcript">
 								{ timelineRows.map( ( row ) =>

--- a/packages/wpcom-smart-dictation/src/live-ai-assistant/index.tsx
+++ b/packages/wpcom-smart-dictation/src/live-ai-assistant/index.tsx
@@ -18,6 +18,8 @@ type TimelineRow =
 	| { kind: 'message'; timestamp: number; entry: RealtimeTranscriptEntry }
 	| { kind: 'tool'; timestamp: number; evt: RealtimeToolEvent };
 
+const DICTATION_UPGRADE_URL = 'https://wordpress.com/checkout';
+
 function buildTimelineRows(
 	transcript: RealtimeTranscriptEntry[],
 	toolEvents: RealtimeToolEvent[]
@@ -160,6 +162,7 @@ export function LiveAIAssistant( { contextualInstructions }: LiveAIAssistantProp
 		errorIntent,
 		sessionTimeLimitMs,
 		sessionTimeRemainingMs,
+		canUpgrade,
 		isMuted,
 		localStream,
 		transcript,
@@ -202,6 +205,9 @@ export function LiveAIAssistant( { contextualInstructions }: LiveAIAssistantProp
 	const sessionTimeProgress = hasSessionTimeRemaining
 		? Math.max( 0, Math.min( 100, ( sessionTimeRemaining / sessionTimeLimit ) * 100 ) )
 		: 0;
+	const hasExhaustedUpgradeableQuota =
+		canUpgrade && hasSessionTimeRemaining && sessionTimeRemaining <= 0;
+	const showUpgradeButton = hasExhaustedUpgradeableQuota && ! isSessionActive && ! isSessionBusy;
 
 	const handleSessionToggle = () => {
 		if ( isSessionActive || isSessionBusy ) {
@@ -335,26 +341,36 @@ export function LiveAIAssistant( { contextualInstructions }: LiveAIAssistantProp
 								<MicIcon muted={ isMuted } />
 								<span>{ isMuted ? __( 'Unmute' ) : __( 'Mute' ) }</span>
 							</Button>
-							<Button
-								variant="primary"
-								className={ clsx( 'live-ai-assistant__call-button', {
-									'is-hangup': isSessionActive || isSessionBusy,
-								} ) }
-								onClick={ handleSessionToggle }
-								isBusy={ isSessionBusy }
-							>
-								{ isSessionActive || isSessionBusy ? (
-									<>
-										<StopIcon />
-										<span>{ __( 'Stop dictation' ) }</span>
-									</>
-								) : (
-									<>
-										<MicIcon />
-										<span>{ __( 'Start dictation' ) }</span>
-									</>
-								) }
-							</Button>
+							{ showUpgradeButton ? (
+								<Button
+									variant="primary"
+									className="live-ai-assistant__call-button"
+									href={ DICTATION_UPGRADE_URL }
+								>
+									<span>{ __( 'Upgrade' ) }</span>
+								</Button>
+							) : (
+								<Button
+									variant="primary"
+									className={ clsx( 'live-ai-assistant__call-button', {
+										'is-hangup': isSessionActive || isSessionBusy,
+									} ) }
+									onClick={ handleSessionToggle }
+									isBusy={ isSessionBusy }
+								>
+									{ isSessionActive || isSessionBusy ? (
+										<>
+											<StopIcon />
+											<span>{ __( 'Stop dictation' ) }</span>
+										</>
+									) : (
+										<>
+											<MicIcon />
+											<span>{ __( 'Start dictation' ) }</span>
+										</>
+									) }
+								</Button>
+							) }
 						</div>
 						{ hasSessionTimeRemaining && (
 							<div className="live-ai-assistant__time">

--- a/packages/wpcom-smart-dictation/src/live-ai-assistant/index.tsx
+++ b/packages/wpcom-smart-dictation/src/live-ai-assistant/index.tsx
@@ -205,13 +205,17 @@ export function LiveAIAssistant( { contextualInstructions }: LiveAIAssistantProp
 	const sessionTimeProgress = hasSessionTimeRemaining
 		? Math.max( 0, Math.min( 100, ( sessionTimeRemaining / sessionTimeLimit ) * 100 ) )
 		: 0;
-	const hasExhaustedUpgradeableQuota =
-		canUpgrade && hasSessionTimeRemaining && sessionTimeRemaining <= 0;
-	const showUpgradeButton = hasExhaustedUpgradeableQuota && ! isSessionActive && ! isSessionBusy;
+	const hasExhaustedQuota = hasSessionTimeRemaining && sessionTimeRemaining <= 0;
+	const showQuotaLimitNotice = hasExhaustedQuota && ! isSessionActive;
+	const showUpgradeButton = canUpgrade && hasExhaustedQuota && ! isSessionActive && ! isSessionBusy;
+	const showQuotaReachedButton =
+		! canUpgrade && hasExhaustedQuota && ! isSessionActive && ! isSessionBusy;
 
 	const handleSessionToggle = () => {
 		if ( isSessionActive || isSessionBusy ) {
 			stop();
+		} else if ( hasExhaustedQuota ) {
+			return;
 		} else {
 			start();
 		}
@@ -231,6 +235,47 @@ export function LiveAIAssistant( { contextualInstructions }: LiveAIAssistantProp
 	);
 	const showSubtitle =
 		isSessionActive || isSessionBusy || timelineRows.length > 0 || status === 'error';
+	let primaryAction;
+	if ( showUpgradeButton ) {
+		primaryAction = (
+			<Button
+				variant="primary"
+				className="live-ai-assistant__call-button"
+				href={ DICTATION_UPGRADE_URL }
+			>
+				<span>{ __( 'Upgrade' ) }</span>
+			</Button>
+		);
+	} else if ( showQuotaReachedButton ) {
+		primaryAction = (
+			<Button variant="primary" className="live-ai-assistant__call-button" disabled>
+				<span>{ __( 'Quota reached' ) }</span>
+			</Button>
+		);
+	} else {
+		primaryAction = (
+			<Button
+				variant="primary"
+				className={ clsx( 'live-ai-assistant__call-button', {
+					'is-hangup': isSessionActive || isSessionBusy,
+				} ) }
+				onClick={ handleSessionToggle }
+				isBusy={ isSessionBusy }
+			>
+				{ isSessionActive || isSessionBusy ? (
+					<>
+						<StopIcon />
+						<span>{ __( 'Stop dictation' ) }</span>
+					</>
+				) : (
+					<>
+						<MicIcon />
+						<span>{ __( 'Start dictation' ) }</span>
+					</>
+				) }
+			</Button>
+		);
+	}
 
 	return (
 		<>
@@ -251,7 +296,7 @@ export function LiveAIAssistant( { contextualInstructions }: LiveAIAssistantProp
 							</div>
 						) }
 
-						{ status === 'idle' && timelineRows.length === 0 && (
+						{ status === 'idle' && timelineRows.length === 0 && ! hasExhaustedQuota && (
 							<div className="live-ai-assistant__intro">
 								<video
 									className="live-ai-assistant__intro-artwork"
@@ -281,13 +326,13 @@ export function LiveAIAssistant( { contextualInstructions }: LiveAIAssistantProp
 							</Notice.Root>
 						) }
 
-						{ hasExhaustedUpgradeableQuota && (
+						{ showQuotaLimitNotice && (
 							<Notice.Root intent="info">
-								<Notice.Title>{ __( 'Keep dictating' ) }</Notice.Title>
+								<Notice.Title>{ __( 'Daily quota limit reached' ) }</Notice.Title>
 								<Notice.Description>
-									{ __(
-										"You've used your free Smart Dictation time for today. Upgrade to keep writing by voice."
-									) }
+									{ canUpgrade
+										? __( 'It will reset at midnight. Upgrade to keep writing by voice.' )
+										: __( 'It will reset at midnight.' ) }
 								</Notice.Description>
 							</Notice.Root>
 						) }
@@ -352,36 +397,7 @@ export function LiveAIAssistant( { contextualInstructions }: LiveAIAssistantProp
 								<MicIcon muted={ isMuted } />
 								<span>{ isMuted ? __( 'Unmute' ) : __( 'Mute' ) }</span>
 							</Button>
-							{ showUpgradeButton ? (
-								<Button
-									variant="primary"
-									className="live-ai-assistant__call-button"
-									href={ DICTATION_UPGRADE_URL }
-								>
-									<span>{ __( 'Upgrade' ) }</span>
-								</Button>
-							) : (
-								<Button
-									variant="primary"
-									className={ clsx( 'live-ai-assistant__call-button', {
-										'is-hangup': isSessionActive || isSessionBusy,
-									} ) }
-									onClick={ handleSessionToggle }
-									isBusy={ isSessionBusy }
-								>
-									{ isSessionActive || isSessionBusy ? (
-										<>
-											<StopIcon />
-											<span>{ __( 'Stop dictation' ) }</span>
-										</>
-									) : (
-										<>
-											<MicIcon />
-											<span>{ __( 'Start dictation' ) }</span>
-										</>
-									) }
-								</Button>
-							) }
+							{ primaryAction }
 						</div>
 						{ hasSessionTimeRemaining && (
 							<div className="live-ai-assistant__time">

--- a/packages/wpcom-smart-dictation/src/live-ai-assistant/realtime-session/client-secret.ts
+++ b/packages/wpcom-smart-dictation/src/live-ai-assistant/realtime-session/client-secret.ts
@@ -24,6 +24,7 @@ interface DictationEndpointRequest {
 export interface DictationRemainingTime {
 	remainingTimeSeconds: number;
 	totalTimeSeconds: number;
+	canUpgrade: boolean;
 	activeSession: {
 		sessionId: string;
 		startedAt: number;
@@ -70,6 +71,7 @@ function extractRemainingTime( data: unknown ): DictationRemainingTime {
 		seconds_used?: number;
 		seconds_remaining?: number;
 		remaining_time_seconds?: number;
+		can_upgrade?: boolean;
 		active_session?: {
 			session_id?: string;
 			started_at?: number;
@@ -95,6 +97,7 @@ function extractRemainingTime( data: unknown ): DictationRemainingTime {
 	return {
 		remainingTimeSeconds,
 		totalTimeSeconds: secondsUsed + secondsRemaining,
+		canUpgrade: Boolean( body.can_upgrade ),
 		activeSession,
 	};
 }

--- a/packages/wpcom-smart-dictation/src/live-ai-assistant/realtime-session/types.ts
+++ b/packages/wpcom-smart-dictation/src/live-ai-assistant/realtime-session/types.ts
@@ -42,6 +42,7 @@ export interface UseRealtimeSessionResult {
 	errorIntent: RealtimeErrorIntent;
 	sessionTimeLimitMs: number | null;
 	sessionTimeRemainingMs: number | null;
+	canUpgrade: boolean;
 	isMuted: boolean;
 	localStream: MediaStream | null;
 	transcript: RealtimeTranscriptEntry[];

--- a/packages/wpcom-smart-dictation/src/live-ai-assistant/realtime-session/types.ts
+++ b/packages/wpcom-smart-dictation/src/live-ai-assistant/realtime-session/types.ts
@@ -4,7 +4,6 @@ export type RealtimeStatus =
 	| 'requesting-mic'
 	| 'connecting'
 	| 'active'
-	| 'ending'
 	| 'error';
 
 export type RealtimeErrorIntent = 'error' | 'warning';
@@ -49,7 +48,7 @@ export interface UseRealtimeSessionResult {
 	toolEvents: RealtimeToolEvent[];
 	imagePickerState: import('../image-picker-modal').ImagePickerState;
 	start: () => Promise< void >;
-	stop: () => void;
+	stop: ( reason?: string ) => void;
 	toggleMute: () => void;
 	sendText: ( text: string ) => Promise< void >;
 	sendEvent: ( eventName: string, details?: string ) => void;

--- a/packages/wpcom-smart-dictation/src/live-ai-assistant/realtime-session/use-realtime-session.ts
+++ b/packages/wpcom-smart-dictation/src/live-ai-assistant/realtime-session/use-realtime-session.ts
@@ -615,6 +615,23 @@ export function useRealtimeSession( options: UseRealtimeSessionOptions ): UseRea
 		setStatus( 'idle' );
 	}, [ cleanup, recordSessionEnded ] );
 
+	useEffect( () => {
+		const shouldAutoStopForUpgrade =
+			canUpgrade &&
+			sessionTimeRemainingMs !== null &&
+			sessionTimeRemainingMs <= 0 &&
+			( status === 'requesting-mic' || status === 'connecting' || status === 'active' );
+
+		if ( ! shouldAutoStopForUpgrade ) {
+			return;
+		}
+
+		recordSessionEnded( 'quota_exhausted' );
+		setStatus( 'ending' );
+		cleanup();
+		setStatus( 'idle' );
+	}, [ canUpgrade, cleanup, recordSessionEnded, sessionTimeRemainingMs, status ] );
+
 	const toggleMute = useCallback( () => {
 		const stream = localStreamRef.current;
 		if ( ! stream ) {

--- a/packages/wpcom-smart-dictation/src/live-ai-assistant/realtime-session/use-realtime-session.ts
+++ b/packages/wpcom-smart-dictation/src/live-ai-assistant/realtime-session/use-realtime-session.ts
@@ -193,6 +193,15 @@ export function useRealtimeSession( options: UseRealtimeSessionOptions ): UseRea
 		}
 	}, [ applyRemainingTime ] );
 
+	const stop = useCallback(
+		( reason = 'user_stop' ) => {
+			recordSessionEnded( reason );
+			cleanup();
+			setStatus( 'idle' );
+		},
+		[ cleanup, recordSessionEnded ]
+	);
+
 	useEffect( () => {
 		return () => cleanup();
 	}, [ cleanup ] );
@@ -221,10 +230,7 @@ export function useRealtimeSession( options: UseRealtimeSessionOptions ): UseRea
 
 	useEffect( () => {
 		const shouldTickSessionTime =
-			status === 'requesting-mic' ||
-			status === 'connecting' ||
-			status === 'active' ||
-			status === 'ending';
+			status === 'requesting-mic' || status === 'connecting' || status === 'active';
 
 		if ( sessionTimeLimitMs === null || ! shouldTickSessionTime ) {
 			return;
@@ -345,10 +351,7 @@ export function useRealtimeSession( options: UseRealtimeSessionOptions ): UseRea
 			} );
 
 			if ( shouldStopDictation ) {
-				recordSessionEnded( 'voice_stop' );
-				setStatus( 'ending' );
-				cleanup();
-				setStatus( 'idle' );
+				stop( 'voice_stop' );
 				return;
 			}
 
@@ -356,7 +359,7 @@ export function useRealtimeSession( options: UseRealtimeSessionOptions ): UseRea
 				safeCreateResponse();
 			}
 		},
-		[ cleanup, recordSessionEnded, safeCreateResponse ]
+		[ safeCreateResponse, stop ]
 	);
 
 	const handleServerEvent = useCallback(
@@ -613,13 +616,6 @@ export function useRealtimeSession( options: UseRealtimeSessionOptions ): UseRea
 		applyRemainingTime,
 	] );
 
-	const stop = useCallback( () => {
-		recordSessionEnded( 'user_stop' );
-		setStatus( 'ending' );
-		cleanup();
-		setStatus( 'idle' );
-	}, [ cleanup, recordSessionEnded ] );
-
 	useEffect( () => {
 		const shouldAutoStopForQuota =
 			sessionTimeRemainingMs !== null &&
@@ -634,11 +630,8 @@ export function useRealtimeSession( options: UseRealtimeSessionOptions ): UseRea
 			reason: 'quota_exhausted',
 			can_upgrade: canUpgrade,
 		} );
-		recordSessionEnded( 'quota_exhausted' );
-		setStatus( 'ending' );
-		cleanup();
-		setStatus( 'idle' );
-	}, [ canUpgrade, cleanup, recordSessionEnded, sessionTimeRemainingMs, status ] );
+		stop( 'quota_exhausted' );
+	}, [ canUpgrade, sessionTimeRemainingMs, status, stop ] );
 
 	const toggleMute = useCallback( () => {
 		const stream = localStreamRef.current;

--- a/packages/wpcom-smart-dictation/src/live-ai-assistant/realtime-session/use-realtime-session.ts
+++ b/packages/wpcom-smart-dictation/src/live-ai-assistant/realtime-session/use-realtime-session.ts
@@ -467,12 +467,6 @@ export function useRealtimeSession( options: UseRealtimeSessionOptions ): UseRea
 
 		setError( null );
 		setErrorIntent( 'error' );
-		setTranscript( [] );
-		setToolEvents( [] );
-		sessionStartedAtRef.current = Date.now();
-		hasTrackedSessionStartRef.current = true;
-		sessionAbortControllerRef.current = new AbortController();
-		recordTracksEvent( 'calypso_smart_dictation_started' );
 
 		let hasRequestedMicrophone = false;
 
@@ -480,6 +474,19 @@ export function useRealtimeSession( options: UseRealtimeSessionOptions ): UseRea
 			await clientSecretSettlePromiseRef.current;
 			const remainingTime = await fetchRemainingTime();
 			applyRemainingTime( remainingTime );
+			const remainingTimeSeconds =
+				remainingTime.activeSession?.remainingTimeSeconds ?? remainingTime.remainingTimeSeconds;
+
+			if ( remainingTimeSeconds <= 0 ) {
+				return;
+			}
+
+			setTranscript( [] );
+			setToolEvents( [] );
+			sessionStartedAtRef.current = Date.now();
+			hasTrackedSessionStartRef.current = true;
+			sessionAbortControllerRef.current = new AbortController();
+			recordTracksEvent( 'calypso_smart_dictation_started' );
 
 			await assertMicrophonePermission();
 

--- a/packages/wpcom-smart-dictation/src/live-ai-assistant/realtime-session/use-realtime-session.ts
+++ b/packages/wpcom-smart-dictation/src/live-ai-assistant/realtime-session/use-realtime-session.ts
@@ -51,6 +51,7 @@ export function useRealtimeSession( options: UseRealtimeSessionOptions ): UseRea
 	const [ errorIntent, setErrorIntent ] = useState< RealtimeErrorIntent >( 'error' );
 	const [ sessionTimeLimitMs, setSessionTimeLimitMs ] = useState< number | null >( null );
 	const [ sessionTimeRemainingMs, setSessionTimeRemainingMs ] = useState< number | null >( null );
+	const [ canUpgrade, setCanUpgrade ] = useState( false );
 	const [ isMuted, setIsMuted ] = useState( false );
 	const [ localStream, setLocalStream ] = useState< MediaStream | null >( null );
 	const [ transcript, setTranscript ] = useState< RealtimeTranscriptEntry[] >( [] );
@@ -106,6 +107,8 @@ export function useRealtimeSession( options: UseRealtimeSessionOptions ): UseRea
 	);
 	const applyRemainingTime = useCallback(
 		( remainingTime: DictationRemainingTime ) => {
+			setCanUpgrade( remainingTime.canUpgrade );
+
 			if ( remainingTime.activeSession?.expiresAt ) {
 				clientSecretExpiresAtMsRef.current = remainingTime.activeSession.expiresAt * 1000;
 				updateRemainingTime(
@@ -707,6 +710,7 @@ export function useRealtimeSession( options: UseRealtimeSessionOptions ): UseRea
 		errorIntent,
 		sessionTimeLimitMs,
 		sessionTimeRemainingMs,
+		canUpgrade,
 		isMuted,
 		localStream,
 		transcript,

--- a/packages/wpcom-smart-dictation/src/live-ai-assistant/realtime-session/use-realtime-session.ts
+++ b/packages/wpcom-smart-dictation/src/live-ai-assistant/realtime-session/use-realtime-session.ts
@@ -616,13 +616,12 @@ export function useRealtimeSession( options: UseRealtimeSessionOptions ): UseRea
 	}, [ cleanup, recordSessionEnded ] );
 
 	useEffect( () => {
-		const shouldAutoStopForUpgrade =
-			canUpgrade &&
+		const shouldAutoStopForQuota =
 			sessionTimeRemainingMs !== null &&
 			sessionTimeRemainingMs <= 0 &&
 			( status === 'requesting-mic' || status === 'connecting' || status === 'active' );
 
-		if ( ! shouldAutoStopForUpgrade ) {
+		if ( ! shouldAutoStopForQuota ) {
 			return;
 		}
 
@@ -630,7 +629,7 @@ export function useRealtimeSession( options: UseRealtimeSessionOptions ): UseRea
 		setStatus( 'ending' );
 		cleanup();
 		setStatus( 'idle' );
-	}, [ canUpgrade, cleanup, recordSessionEnded, sessionTimeRemainingMs, status ] );
+	}, [ cleanup, recordSessionEnded, sessionTimeRemainingMs, status ] );
 
 	const toggleMute = useCallback( () => {
 		const stream = localStreamRef.current;

--- a/packages/wpcom-smart-dictation/src/live-ai-assistant/realtime-session/use-realtime-session.ts
+++ b/packages/wpcom-smart-dictation/src/live-ai-assistant/realtime-session/use-realtime-session.ts
@@ -474,10 +474,8 @@ export function useRealtimeSession( options: UseRealtimeSessionOptions ): UseRea
 			await clientSecretSettlePromiseRef.current;
 			const remainingTime = await fetchRemainingTime();
 			applyRemainingTime( remainingTime );
-			const remainingTimeSeconds =
-				remainingTime.activeSession?.remainingTimeSeconds ?? remainingTime.remainingTimeSeconds;
 
-			if ( remainingTimeSeconds <= 0 ) {
+			if ( remainingTime.remainingTimeSeconds <= 0 ) {
 				return;
 			}
 

--- a/packages/wpcom-smart-dictation/src/live-ai-assistant/realtime-session/use-realtime-session.ts
+++ b/packages/wpcom-smart-dictation/src/live-ai-assistant/realtime-session/use-realtime-session.ts
@@ -630,11 +630,15 @@ export function useRealtimeSession( options: UseRealtimeSessionOptions ): UseRea
 			return;
 		}
 
+		recordTracksEvent( 'calypso_smart_dictation_auto_stopped', {
+			reason: 'quota_exhausted',
+			can_upgrade: canUpgrade,
+		} );
 		recordSessionEnded( 'quota_exhausted' );
 		setStatus( 'ending' );
 		cleanup();
 		setStatus( 'idle' );
-	}, [ cleanup, recordSessionEnded, sessionTimeRemainingMs, status ] );
+	}, [ canUpgrade, cleanup, recordSessionEnded, sessionTimeRemainingMs, status ] );
 
 	const toggleMute = useCallback( () => {
 		const stream = localStreamRef.current;

--- a/packages/wpcom-smart-dictation/src/live-ai-assistant/style.scss
+++ b/packages/wpcom-smart-dictation/src/live-ai-assistant/style.scss
@@ -155,6 +155,11 @@
 	}
 }
 
+.live-ai-assistant__intro-learn-more {
+	display: inline-block;
+	margin-block-start: 8px;
+}
+
 .live-ai-assistant__intro-artwork {
 	display: block;
 	width: 100%;


### PR DESCRIPTION
phcsdm-3kj-p2

## Proposed Changes

* Parse the dictation remaining-time endpoint's `can_upgrade` response field into the realtime session state.
* Expose `canUpgrade` from `useRealtimeSession` so the Smart Dictation UI can respond to exhausted free-user quota.
* Replace the Start dictation button with an Upgrade button when quota is exhausted and the endpoint says the user can upgrade.
* Point the Upgrade button to `https://wordpress.com/checkout`.

## Why are these changes being made?

Free users now have Smart Dictation access with a limited daily quota. Once that quota is finished, the endpoint can tell the frontend that the user is eligible to upgrade. The UI needs to surface that upgrade path instead of leaving the user with only a depleted quota bar.

## Testing Instructions

* `yarn typecheck-packages`
* `yarn workspace @automattic/wpcom-smart-dictation build`
* `env ESLINT_USE_FLAT_CONFIG=false yarn eslint --ext .ts,.tsx packages/wpcom-smart-dictation/src/live-ai-assistant/realtime-session/client-secret.ts packages/wpcom-smart-dictation/src/live-ai-assistant/realtime-session/types.ts packages/wpcom-smart-dictation/src/live-ai-assistant/realtime-session/use-realtime-session.ts packages/wpcom-smart-dictation/src/live-ai-assistant/index.tsx`
* `yarn workspace @automattic/wpcom-smart-dictation-app build:app`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md).
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?