### PR TITLE
landing/stepper: typed-`@wordpress/i18n` migration

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/hooks/use-purchase-plan-notification/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/hooks/use-purchase-plan-notification/index.ts
@@ -36,8 +36,8 @@ export const usePurchasePlanNotification = (
 
 		const plan = getPlan( sitePlanSlug );
 		// Only display the notification after translation data has been loaded
-		const localeSlug = getLocaleData()[ '' ].localeSlug;
-		if ( ! localeSlug ) {
+		const metadata = getLocaleData()[ '' ] as { localeSlug?: string } | undefined;
+		if ( ! metadata?.localeSlug ) {
 			return;
 		}
 
@@ -46,7 +46,7 @@ export const usePurchasePlanNotification = (
 				sprintf(
 					/* translators: %(planName)s is the name of the plan, e.g. "Business Plan" */
 					__( "You're in! The %(planName)s Plan is now active." ),
-					{ planName: plan?.getTitle() || '' }
+					{ planName: String( plan?.getTitle() ?? '' ) }
 				)
 			)
 		);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-transfer-domains/domains.tsx
@@ -187,15 +187,15 @@ const Domains: React.FC< Props > = ( { onSubmit, variantSlug } ) => {
 				return sprintf(
 					/* translators: %1$s Number of valid domains, %2$s: total price formatted */
 					__( 'Transfer %1$s domains for %2$s' ),
-					numberOfValidDomains,
-					formattedTotalPrice
+					String( numberOfValidDomains ),
+					String( formattedTotalPrice )
 				);
 			}
 
 			return sprintf(
 				/* translators: %s: total price formatted */
 				__( 'Transfer for %s' ),
-				formattedTotalPrice
+				String( formattedTotalPrice )
 			);
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-verify-email/verify-email.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-verify-email/verify-email.tsx
@@ -22,7 +22,7 @@ const VerifyEmail = function VerifyEmail( props: Props ) {
 	const planType = PLAN_BUSINESS;
 	const plan = getPlan( planType );
 
-	const defaultButtonState = {
+	const defaultButtonState: { status: string; text: string } = {
 		status: 'default',
 		text: __( 'Resend verification email' ),
 	};
@@ -52,7 +52,7 @@ const VerifyEmail = function VerifyEmail( props: Props ) {
 					),
 					{
 						email: user.email,
-						planName: plan?.getTitle(),
+						planName: String( plan?.getTitle() ?? '' ),
 					}
 				) }
 			</SubTitle>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/components/playground-error/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/components/playground-error/index.tsx
@@ -14,7 +14,7 @@ export function PlaygroundError( { createNewPlayground }: { createNewPlayground:
 		__(
 			'The playground you are trying to access (ID: %s) does not exist or is no longer available in this browser.'
 		),
-		playgroundId
+		playgroundId ?? ''
 	);
 
 	useEffect( () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
@@ -103,13 +103,14 @@ const SitePickerStep: Step< {
 		>
 			<p>
 				{ sprintf(
-					/* translators: the `sourceSite` and `targetSite` fields could be any site URL (eg: "yourname.com") */
+					/* translators: %(sourceSite)s and %(targetSite)s are site URLs (eg: "yourname.com") */
 					__(
 						'Your site %(sourceSite)s will be migrated to %(targetSite)s, overriding all the content in your destination site.'
 					),
 					{
 						sourceSite: sourceSiteSlug,
-						targetSite: destinationSite?.slug.replace( /\b\.wordpress\.com/, '.wpcomstaging.com' ),
+						targetSite:
+							destinationSite?.slug.replace( /\b\.wordpress\.com/, '.wpcomstaging.com' ) ?? '',
 					}
 				) }
 			</p>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/migration-trial-acknowledge.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/migration-trial-acknowledge.tsx
@@ -97,7 +97,7 @@ const MigrationTrialAcknowledgeInternal = function ( props: Props ) {
 							__(
 								"You're currently enrolled in a free trial. Please wait until it expires to start a new one.<br />To migrate your site now, upgrade to the %(planName)s plan."
 							),
-							{ planName: plan?.getTitle() }
+							{ planName: String( plan?.getTitle() ?? '' ) }
 						),
 						{ br: <br /> }
 					) }
@@ -126,14 +126,14 @@ const MigrationTrialAcknowledgeInternal = function ( props: Props ) {
 				__(
 					'Give the %(planName)s plan a try with the 7-day free trial, and migrate your site without costs'
 				),
-				{ planName: plan?.getTitle() }
+				{ planName: String( plan?.getTitle() ?? '' ) }
 			) }
 			supportingCopy={ sprintf(
 				/* translators: the planName could be "Pro" or "Business" */
 				__(
 					'The 7-day trial includes every feature in the %(planName)s plan with a few exceptions. To enjoy all the features without limits, upgrade to the paid plan at any time before your trial ends.'
 				),
-				{ planName: plan?.getTitle() }
+				{ planName: String( plan?.getTitle() ?? '' ) }
 			) }
 			callToAction={
 				<NextButton isBusy={ isAddingTrial } onClick={ onStartTrialClick }>

--- a/client/landing/stepper/utils/window-locale-effect-manager.tsx
+++ b/client/landing/stepper/utils/window-locale-effect-manager.tsx
@@ -8,7 +8,7 @@ export const WindowLocaleEffectManager: React.FunctionComponent = () => {
 	const locale = useLocale();
 
 	// Some languages may need to set an html lang attribute that is different from their slug
-	let lang = __( 'html_lang_attribute' );
+	let lang: string = __( 'html_lang_attribute' );
 
 	// Some languages don't have the translation for html_lang_attribute
 	// or maybe we are dealing with the default `en` locale. Return the general purpose locale slug


### PR DESCRIPTION
Fixes DOTCOM-17288

Part of #105909

## Proposed Changes

* Fix the thirteen `client/landing/stepper/` type errors that surface when `@wordpress/i18n` is bumped from `^5.23.0` to `^6.x`. Changes are forward-compatible because `TransformedText<T> extends string`, so they compile cleanly against the current trunk pin as well.
* Patterns applied (matching the prior `dashboard/me` slice in #110985):
  * **Coerce non-`string` sprintf args** to `string` where the placeholder is typed `%s`/`%1$s`:
    * `String( plan?.getTitle() ?? '' )` for `TranslateResult` (ReactNode) values from `i18n-calypso` — `use-purchase-plan-notification`, `verify-email`, `migration-trial-acknowledge`.
    * `String( numberOfValidDomains )` / `String( formattedTotalPrice )` where a `number` / `string | 0` value reached `%s` — `domain-transfer-domains/domains.tsx`.
    * `playgroundId ?? ''` for the `string | null` value from `URLSearchParams.get()` — `playground-error`.
    * `destinationSite?.slug.replace(...) ?? ''` for the optional chain — `site-picker`.
  * **Widen `__()`-initialised variables** that are reassigned to plain `string` later: `let lang: string = __('html_lang_attribute')` (`window-locale-effect-manager`); annotate `defaultButtonState.text` as `string` so the `useState` default does not lock the state shape to `TransformedText<"Resend verification email">` (`verify-email`).
  * **Narrow `getLocaleData()[ '' ]`** (typed `I18nDomainMetadata | string[]` in 6.x) with a `{ localeSlug?: string } | undefined` cast so the Calypso-specific `localeSlug` property can be read (`use-purchase-plan-notification`).
* Pre-existing lint fix surfaced by `lint-staged` on `site-picker`: the translator comment described placeholders by name in backticks (`sourceSite`, `targetSite`) rather than in the `%(name)s` form the `@wordpress/i18n-translator-comments` rule expects.

## Why are these changes being made?

The renovate WordPress monorepo bump (#105909) is being decomposed into small, mergeable slices. This slice unblocks the `@wordpress/i18n` 5.x → 6.x migration for the `client/landing/stepper/` (onboarding/signup/migration wizards) area.

Reference slices already merged:
- #110972 `data-stores` / `api-core` — forward-compatible `select()` casts
- #110973 `@wordpress/icons` rename
- #110974 `agents-manager` / `onboarding` — `select()` casts
- #110975 `api-fetch`, sprintf option-typing
- #110985 `dashboard/me` — `TS2322` widening + sprintf coercion/joins

## Testing Instructions

* Locally bump `@wordpress/i18n` to `^6.19.0` (or `^6.20.0`) across the workspace `package.json` files (do **not** commit), then run:
  ```
  yarn install
  NODE_OPTIONS=--max-old-space-size=10240 yarn typecheck-client 2>&1 | grep "^client/landing/stepper"
  ```
  The output should be empty.
* Verify the same command on trunk (without this PR) lists the thirteen errors fixed here.
* No runtime behaviour changes — the affected sprintf calls and `useState` defaults pass identical string values; only the TypeScript types were tightened/widened.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
