### PR TITLE
sites/transfer-site: typed-`@wordpress/i18n` migration

### DIFF
--- a/client/sites/settings/administration/tools/transfer-site/pending-domain-transfer.tsx
+++ b/client/sites/settings/administration/tools/transfer-site/pending-domain-transfer.tsx
@@ -1,7 +1,5 @@
 import { Button } from '@automattic/components';
 import styled from '@emotion/styled';
-import { createInterpolateElement } from '@wordpress/element';
-import { sprintf } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
 import { PanelCardHeading } from 'calypso/components/panel';
 import { ResponseDomain } from 'calypso/lib/domains/types';
@@ -17,15 +15,13 @@ const PendingDomainTransfer = ( { domain }: { domain: ResponseDomain } ) => {
 			<>
 				<PanelCardHeading>{ translate( 'Pending domain transfers' ) }</PanelCardHeading>
 				<p>
-					{ createInterpolateElement(
-						sprintf(
-							// translators: %s is the domain name
-							translate(
-								'There are pending domain transfers for <strong>%s</strong>. Please complete them before transferring the site.'
-							),
-							domain.name
-						),
-						{ strong: <Strong /> }
+					{ translate(
+						'There are pending domain transfers for {{strong}}%(domainName)s{{/strong}}. Please complete them before transferring the site.',
+						{
+							args: { domainName: domain.name },
+							components: { strong: <Strong /> },
+							comment: '%(domainName)s is the domain name',
+						}
 					) }
 				</p>
 			</>

--- a/client/sites/settings/administration/tools/transfer-site/start-site-owner-transfer.tsx
+++ b/client/sites/settings/administration/tools/transfer-site/start-site-owner-transfer.tsx
@@ -1,8 +1,6 @@
 import { Button, Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { ToggleControl } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
-import { sprintf } from '@wordpress/i18n';
 import { localize, useTranslate } from 'i18n-calypso';
 import { FormEvent, useState } from 'react';
 import { connect, useSelector } from 'react-redux';
@@ -91,31 +89,27 @@ const DomainsCard = ( {
 			{ domains.length === 0 ? (
 				<List>
 					<ListItem>
-						{ createInterpolateElement(
-							sprintf(
-								// translators: siteSlug is the current site slug, username is the user that the site is going to
-								// transer to
-								translate(
-									'The domain name <strong>%(siteSlug)s</strong> will be transferred to <strong>%(siteOwner)s</strong> and will remain working on the site.'
-								),
-								{ siteSlug, siteOwner }
-							),
-							{ strong: <Strong /> }
+						{ translate(
+							'The domain name {{strong}}%(siteSlug)s{{/strong}} will be transferred to {{strong}}%(siteOwner)s{{/strong}} and will remain working on the site.',
+							{
+								args: { siteSlug: siteSlug ?? '', siteOwner },
+								components: { strong: <Strong /> },
+								comment:
+									'%(siteSlug)s is the current site slug, %(siteOwner)s is the user that the site is going to transfer to',
+							}
 						) }
 					</ListItem>
 				</List>
 			) : (
 				<>
 					<Text>
-						{ createInterpolateElement(
-							sprintf(
-								// translators: username is the user that the site is going to transfer to
-								translate(
-									'The following domains will be transferred to <strong>%(siteOwner)s</strong> and will remain working on the site:'
-								),
-								{ siteOwner }
-							),
-							{ strong: <Strong /> }
+						{ translate(
+							'The following domains will be transferred to {{strong}}%(siteOwner)s{{/strong}} and will remain working on the site:',
+							{
+								args: { siteOwner },
+								components: { strong: <Strong /> },
+								comment: '%(siteOwner)s is the user that the site is going to transfer to',
+							}
 						) }
 					</Text>
 					<DomainsWrapper>
@@ -149,16 +143,14 @@ const UpgradesCard = ( {
 		<>
 			<Title>{ translate( 'Upgrades' ) }</Title>
 			<Text>
-				{ createInterpolateElement(
-					sprintf(
-						// translators: siteSlug is the current site slug, username is the user that the site is going to
-						// transer to
-						translate(
-							'Your paid upgrades on <strong>%(siteSlug)s</strong> will be transferred to <strong>%(siteOwner)s</strong> and will remain with the site.'
-						),
-						{ siteSlug, siteOwner }
-					),
-					{ strong: <Strong /> }
+				{ translate(
+					'Your paid upgrades on {{strong}}%(siteSlug)s{{/strong}} will be transferred to {{strong}}%(siteOwner)s{{/strong}} and will remain with the site.',
+					{
+						args: { siteSlug: siteSlug ?? '', siteOwner },
+						components: { strong: <Strong /> },
+						comment:
+							'%(siteSlug)s is the current site slug, %(siteOwner)s is the user that the site is going to transfer to',
+					}
 				) }
 			</Text>
 		</>
@@ -180,53 +172,46 @@ const ContentAndOwnershipCard = ( {
 			<Title>{ translate( 'Content and ownership' ) }</Title>
 			<List>
 				<ListItem>
-					{ createInterpolateElement(
-						sprintf(
-							// translators: siteSlug is the current site slug, userInfo is the user that the site is going to
-							// transer to
-							translate(
-								'You’ll be removed as owner of <strong>%(siteSlug)s</strong> and <strong>%(siteOwner)s</strong> will be the new owner from now on.'
-							),
-							{ siteSlug, siteOwner }
-						),
-						{ strong: <Strong /> }
+					{ translate(
+						'You’ll be removed as owner of {{strong}}%(siteSlug)s{{/strong}} and {{strong}}%(siteOwner)s{{/strong}} will be the new owner from now on.',
+						{
+							args: { siteSlug: siteSlug ?? '', siteOwner },
+							components: { strong: <Strong /> },
+							comment:
+								'%(siteSlug)s is the current site slug, %(siteOwner)s is the user that the site is going to transfer to',
+						}
 					) }
 				</ListItem>
 				<ListItem>
-					{ createInterpolateElement(
-						sprintf(
-							// translators: username is the user that the site is going to transer to
-							translate(
-								'You will keep your admin access unless <strong>%(siteOwner)s</strong> removes you.'
-							),
-							{ siteOwner }
-						),
-						{ strong: <Strong /> }
+					{ translate(
+						'You will keep your admin access unless {{strong}}%(siteOwner)s{{/strong}} removes you.',
+						{
+							args: { siteOwner },
+							components: { strong: <Strong /> },
+							comment: '%(siteOwner)s is the user that the site is going to transfer to',
+						}
 					) }
 				</ListItem>
 				<ListItem>
-					{ createInterpolateElement(
-						sprintf(
-							// translators: siteSlug is the current site slug
-							translate(
-								'Your posts on <strong>%(siteSlug)s</strong> will remain authored by your account.'
-							),
-							{ siteSlug }
-						),
-						{ strong: <Strong /> }
+					{ translate(
+						'Your posts on {{strong}}%(siteSlug)s{{/strong}} will remain authored by your account.',
+						{
+							args: { siteSlug: siteSlug ?? '' },
+							components: { strong: <Strong /> },
+							comment: '%(siteSlug)s is the current site slug',
+						}
 					) }
 				</ListItem>
 				{ isAtomicSite && (
 					<ListItem>
-						{ createInterpolateElement(
-							sprintf(
-								// translators: siteSlug is the current site slug, username is the user that the site will be transerred to
-								translate(
-									'If your site <strong>%(siteSlug)s</strong> has a staging site, it will be transferred to <strong>%(siteOwner)s</strong>.'
-								),
-								{ siteSlug, siteOwner }
-							),
-							{ strong: <Strong /> }
+						{ translate(
+							'If your site {{strong}}%(siteSlug)s{{/strong}} has a staging site, it will be transferred to {{strong}}%(siteOwner)s{{/strong}}.',
+							{
+								args: { siteSlug: siteSlug ?? '', siteOwner },
+								components: { strong: <Strong /> },
+								comment:
+									'%(siteSlug)s is the current site slug, %(siteOwner)s is the user that the site will be transferred to',
+							}
 						) }
 					</ListItem>
 				) }


### PR DESCRIPTION
Fixes DOTCOM-17289

Part of #105909.

## Proposed Changes

Fix the typed-`@wordpress/i18n` migration errors in `client/sites/settings/administration/tools/transfer-site/`.

Both affected files (`pending-domain-transfer.tsx`, `start-site-owner-transfer.tsx`) used the same hybrid pattern at all 8 error sites:

```tsx
createInterpolateElement(
    sprintf(
        translate( '... <strong>%(x)s</strong> ...' ),
        { x }
    ),
    { strong: <Strong /> }
)
```

`@wordpress/i18n@6.0`'s typed `sprintf` rejects the named-args object because `translate()` from `i18n-calypso` returns plain `string`, which erases the format-literal type the new sprintf overload needs.

Rather than cast around the erasure, replaced each call site with `i18n-calypso`'s native interpolation:

```tsx
translate(
    '... {{strong}}%(x)s{{/strong}} ...',
    { args: { x }, components: { strong: <Strong /> } }
)
```

This drops the `@wordpress/i18n` and `@wordpress/element` imports from both files (they were only pulled in for `sprintf` / `createInterpolateElement`) and matches the standard Calypso idiom used widely elsewhere.

## Why are these changes being made?

Forward-compatible decomposition of the renovate WordPress monorepo bump (#105909), specifically the `@wordpress/i18n` 5.x → 6.x migration. The code now compiles against both `^5.23.0` (current trunk pin) and `^6.x` (what #105909 wants to install). `TransformedText<T> extends string`, so all changes are forward-compatible.

### Notes

- **Translation keys change** (`<strong>` → `{{strong}}`); old translations will need to be re-extracted via the normal GlotPress workflow.
- `// translators:` JS comments moved into the `comment:` option, which is the form `i18n-calypso` extracts.
- `siteSlug` is `string | null` upstream, so a `?? ''` fallback was added where it's interpolated. Previously sprintf would have rendered the literal `"null"` if the slug were missing (unreachable in practice today, but the new code is also defensive against it).

## Testing Instructions

* `yarn typecheck-client` — passes locally with both the current `^5.23.0` pin and an `^6.20.0` bump applied.
* Visual verification of the affected screens (`Settings → Tools → Transfer site`) — strings render identically; `<strong>` styling is preserved because the `Strong` styled component is now passed through `translate()`'s `components` option.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed?
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?
