### PR TITLE
dashboard/sites: typed-`@wordpress/i18n` migration

### DIFF
--- a/client/dashboard/sites-ciab/index.tsx
+++ b/client/dashboard/sites-ciab/index.tsx
@@ -73,7 +73,7 @@ export default function CIABSites() {
 
 	const emptyTitle = hasFilterOrSearch ? __( 'No stores found' ) : __( 'No stores' );
 
-	let emptyDescription = __( 'Get started by creating a new store.' );
+	let emptyDescription: string = __( 'Get started by creating a new store.' );
 	if ( view.search ) {
 		emptyDescription = sprintf(
 			// Translators: %s is the search term used when looking for stores by title or domain name.

--- a/client/dashboard/sites/jetpack-site-disconnect/index.tsx
+++ b/client/dashboard/sites/jetpack-site-disconnect/index.tsx
@@ -148,7 +148,7 @@ function ContentConfirmDisconnect( {
 					{ createInterpolateElement(
 						/* translators: <siteDomain />: site domain */
 						__(
-							'Disconnecting <siteDomain /> will remove the Jetpack connection between this site and WordPress.com. You will lose access to Jetpack features like <link>backups, security, and stats</link>.'
+							'Disconnecting <siteDomain/> will remove the Jetpack connection between this site and WordPress.com. You will lose access to Jetpack features like <link>backups, security, and stats</link>.'
 						),
 						{
 							siteDomain: <strong>{ site.slug }</strong>,

--- a/client/dashboard/sites/logs/downloader.tsx
+++ b/client/dashboard/sites/logs/downloader.tsx
@@ -271,7 +271,7 @@ export function LogsDownloader( {
 							? sprintf(
 									/* translators: %s: percentage value */
 									__( '%s%% downloaded' ),
-									Math.round( progress * 100 )
+									String( Math.round( progress * 100 ) )
 							  )
 							: label
 					}

--- a/client/dashboard/sites/logs/utils.ts
+++ b/client/dashboard/sites/logs/utils.ts
@@ -151,7 +151,7 @@ export function getDateTimeLabel( {
 	gmtOffset?: number;
 	isLargeScreen: boolean;
 } ) {
-	let dateTimeLabel = __( 'Date & time' );
+	let dateTimeLabel: string = __( 'Date & time' );
 
 	/* translators: %s is the site's timezone (e.g., "Europe/London") or UTC offset (e.g., "UTC+02:00") */
 	const dateTimeWithTz = __( 'Date & time (%s)' );

--- a/client/dashboard/sites/overview-flex-usage-card/index.tsx
+++ b/client/dashboard/sites/overview-flex-usage-card/index.tsx
@@ -19,7 +19,7 @@ function formatBytes( bytes: number ) {
 function formatHours( hours: number ) {
 	const rounded = Math.round( hours * 10 ) / 10;
 	// translators: %s is the number of hours of compute used
-	return sprintf( _n( '%s hr', '%s hrs', rounded === 1 ? 1 : 2 ), rounded );
+	return sprintf( _n( '%s hr', '%s hrs', rounded === 1 ? 1 : 2 ), String( rounded ) );
 }
 
 const symbolsBytesPerMonth = {

--- a/client/dashboard/sites/overview-plan-card/index.tsx
+++ b/client/dashboard/sites/overview-plan-card/index.tsx
@@ -128,7 +128,7 @@ function WpcomStagingSitePlanCard( { site }: { site: Site } ) {
 	const description = sprintf(
 		/* translators: %s: the site plan name */
 		__( 'Included with your %s plan.' ),
-		productionSite?.plan?.product_name_short
+		productionSite?.plan?.product_name_short ?? ''
 	);
 
 	return (

--- a/client/dashboard/sites/performance/core-metrics-chart.tsx
+++ b/client/dashboard/sites/performance/core-metrics-chart.tsx
@@ -160,22 +160,22 @@ export default function CoreMetricsChart( {
 		const unit = getDisplayUnit( metric );
 		if ( valuation === 'good' ) {
 			return sprintf( '(0–%(to)s%(unit)s)', {
-				to: getFormattedValue( metric, good ),
+				to: String( getFormattedValue( metric, good ) ),
 				unit,
 			} );
 		}
 
 		if ( valuation === 'needsImprovement' ) {
 			return sprintf( '(%(from)s–%(to)s%(unit)s)', {
-				from: getFormattedValue( metric, good ),
-				to: getFormattedValue( metric, needsImprovement ),
+				from: String( getFormattedValue( metric, good ) ),
+				to: String( getFormattedValue( metric, needsImprovement ) ),
 				unit,
 			} );
 		}
 
 		if ( valuation === 'bad' ) {
 			return sprintf( '(Over %(from)s%(unit)s)', {
-				from: getFormattedValue( metric, needsImprovement ),
+				from: String( getFormattedValue( metric, needsImprovement ) ),
 				unit,
 			} );
 		}

--- a/client/dashboard/sites/scan-active/index.tsx
+++ b/client/dashboard/sites/scan-active/index.tsx
@@ -64,8 +64,8 @@ export function ActiveThreatsDataViews( {
 	const recentScanRelativeTime = useTimeSince( lastScanTime || '' );
 
 	const NoActiveThreatsFound = () => {
-		let title = __( 'Don’t worry about a thing' );
-		let description = sprintf(
+		let title: string = __( 'Don’t worry about a thing' );
+		let description: string = sprintf(
 			/** translators: %s: relative time string like "2 hours ago" */
 			__( 'The last scan ran %s and found no security issues.' ),
 			recentScanRelativeTime

--- a/client/dashboard/sites/scan-history/index.tsx
+++ b/client/dashboard/sites/scan-history/index.tsx
@@ -62,8 +62,8 @@ export function ScanHistoryDataViews( {
 	const { data: filteredData, paginationInfo } = filterSortAndPaginate( threats, view, fields );
 
 	const NoArchivedThreatsFound = () => {
-		let title = __( 'No history yet' );
-		let description = __( 'So far, there are no archived threats on your site.' );
+		let title: string = __( 'No history yet' );
+		let description: string = __( 'So far, there are no archived threats on your site.' );
 
 		if ( view.search || view.filters ) {
 			title = __( 'No history found' );

--- a/client/dashboard/sites/settings-repositories/configure-repository.tsx
+++ b/client/dashboard/sites/settings-repositories/configure-repository.tsx
@@ -5,7 +5,7 @@ import {
 } from '@automattic/api-queries';
 import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import Breadcrumbs from '../../app/breadcrumbs';
 import {
 	siteRoute,
@@ -77,9 +77,12 @@ export default function ConfigureRepository() {
 							initialValues={ initialValues }
 							submitText={ __( 'Update Connection' ) }
 							successMessage={ __( 'Repository settings updated successfully.' ) }
-							errorMessage={
-								// translators: "reason" is why updating the repository failed.
-								__( 'Failed to update repository: %(reason)s' )
+							errorMessage={ ( reason ) =>
+								sprintf(
+									// translators: %(reason)s: why updating the repository failed.
+									__( 'Failed to update repository: %(reason)s' ),
+									{ reason }
+								)
 							}
 							navigateFrom={ navigateFrom }
 						/>

--- a/client/dashboard/sites/settings-repositories/connect-repository-form.tsx
+++ b/client/dashboard/sites/settings-repositories/connect-repository-form.tsx
@@ -24,7 +24,7 @@ import {
 import { useDispatch } from '@wordpress/data';
 import { DataForm, Field, type DataFormControlProps } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { Icon, lock } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useEffect, useMemo, useState, useCallback, useRef } from 'react';
@@ -53,7 +53,7 @@ interface ConnectRepositoryFormProps {
 	initialValues: ConnectRepositoryFormData;
 	submitText: string;
 	successMessage: string;
-	errorMessage: string;
+	errorMessage: ( reason: string ) => string;
 	navigateFrom: NavigateOptions[ 'from' ];
 }
 
@@ -435,7 +435,7 @@ export const ConnectRepositoryForm = ( {
 				navigate( { to: '/sites/$siteSlug/settings/repositories' } );
 			},
 			onError: ( error ) => {
-				createErrorNotice( sprintf( errorMessage, { reason: error.message } ), {
+				createErrorNotice( errorMessage( error.message ), {
 					type: 'snackbar',
 				} );
 			},

--- a/client/dashboard/sites/settings-repositories/connect-repository.tsx
+++ b/client/dashboard/sites/settings-repositories/connect-repository.tsx
@@ -5,7 +5,7 @@ import {
 } from '@automattic/api-queries';
 import { useSuspenseQuery, useQuery, useMutation } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import Breadcrumbs from '../../app/breadcrumbs';
 import {
 	siteRoute,
@@ -64,9 +64,12 @@ export default function ConnectRepository() {
 						initialValues={ initialValues }
 						submitText={ __( 'Connect Repository' ) }
 						successMessage={ __( 'Repository connected successfully.' ) }
-						errorMessage={
-							// translators: "reason" is why connecting the repository failed.
-							__( 'Failed to connect repository: %(reason)s' )
+						errorMessage={ ( reason ) =>
+							sprintf(
+								// translators: %(reason)s: why connecting the repository failed.
+								__( 'Failed to connect repository: %(reason)s' ),
+								{ reason }
+							)
 						}
 						navigateFrom={ navigateFrom }
 					/>

--- a/client/dashboard/sites/settings-sftp-ssh/sftp-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/sftp-card.tsx
@@ -60,7 +60,7 @@ export default function SftpCard( {
 			sprintf(
 				/* translators: %s is the copied field */
 				__( 'Copied %s to clipboard.' ),
-				label
+				String( label )
 			),
 			{
 				type: 'snackbar',

--- a/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
@@ -152,7 +152,7 @@ export default function SshCard( {
 			sprintf(
 				/* translators: %s is the copied field */
 				__( 'Copied %s to clipboard.' ),
-				label
+				String( label )
 			),
 			{
 				type: 'snackbar',
@@ -316,7 +316,7 @@ export default function SshCard( {
 						title={ __( 'SSH' ) }
 						description={ createInterpolateElement(
 							__(
-								'SSH lets you access your site’s backend via a terminal, so you can manage files and use <wpCliLink>WP-CLI</wpCliLink> for quick changes and troubleshooting. <learnMoreLink />'
+								'SSH lets you access your site’s backend via a terminal, so you can manage files and use <wpCliLink>WP-CLI</wpCliLink> for quick changes and troubleshooting. <learnMoreLink/>'
 							),
 							{
 								wpCliLink: <ExternalLink href="https://wp-cli.org/" children={ null } />,

--- a/client/dashboard/sites/site-change-address-modal/content.tsx
+++ b/client/dashboard/sites/site-change-address-modal/content.tsx
@@ -149,7 +149,7 @@ const NewSiteAddressForm = ( {
 				{ sprintf(
 					/* translators: %s: site domain */
 					__( 'Once you change your site address, %s will no longer be available.' ),
-					wpcomDomain?.domain
+					wpcomDomain?.domain ?? ''
 				) }
 			</Text>
 			<form onSubmit={ handleSubmit }>

--- a/client/dashboard/sites/staging-site-sync-modal/index.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/index.tsx
@@ -393,7 +393,7 @@ function StagingSiteSyncModalInner( {
 			description: sprintf(
 				/* translators: %s: site domain */
 				__( 'The site domain is: %s' ),
-				productionSiteSlug
+				productionSiteSlug ?? ''
 			),
 		},
 	];

--- a/client/sites-dashboard/components/sites-site-coming-soon.tsx
+++ b/client/sites-dashboard/components/sites-site-coming-soon.tsx
@@ -44,7 +44,7 @@ const comingSoonTranslations: Record< string, string > = {
 };
 
 const getTranslation = ( lang?: string ) => {
-	let text = __( 'Coming Soon' );
+	let text: string = __( 'Coming Soon' );
 	let isRtl = isRTL();
 
 	if ( lang ) {

--- a/client/sites-dashboard/components/sites-sorting-dropdown.tsx
+++ b/client/sites-dashboard/components/sites-sorting-dropdown.tsx
@@ -88,8 +88,11 @@ export const SitesSortingDropdown = ( {
 				<SortingButton
 					icon={ <SortingButtonIcon icon={ isOpen ? 'chevron-up' : 'chevron-down' } /> }
 					iconSize={ 16 }
-					// translators: %s is the current sorting mode.
-					aria-label={ sprintf( __( 'Sorting by %s. Switch sorting mode' ), validSortingLabel ) }
+					aria-label={ sprintf(
+						// translators: %s is the current sorting mode.
+						__( 'Sorting by %s. Switch sorting mode' ),
+						validSortingLabel ?? ''
+					) }
 					onClick={ onToggle }
 					aria-expanded={ isOpen }
 					onKeyDown={ ( event: React.KeyboardEvent ) => {
@@ -101,7 +104,7 @@ export const SitesSortingDropdown = ( {
 				>
 					{
 						// translators: %s is the current sorting mode.
-						sprintf( __( 'Sort: %s' ), validSortingLabel )
+						sprintf( __( 'Sort: %s' ), validSortingLabel ?? '' )
 					}
 				</SortingButton>
 			) }


### PR DESCRIPTION
Fixes DOTCOM-17290

Part of #105909

## Proposed Changes

Forward-compatible TypeScript fixes for the `@wordpress/i18n` 5.x → 6.x bump in `client/dashboard/sites/`, `client/sites-dashboard/`, and `client/dashboard/sites-ciab/`. All changes compile against both `^5.23.0` (current trunk pin) and `^6.x` because `TransformedText<T> extends string`.

Patterns applied:

* **TS2322 (`let` initialised from `__()` infers too narrowly)** — widen the variable to `let x: string = __('foo')` in `sites-ciab/index.tsx`, `sites/logs/utils.ts`, `sites/scan-active/index.tsx`, `sites/scan-history/index.tsx`, and `sites-dashboard/components/sites-site-coming-soon.tsx`.
* **TS2769 (sprintf arg has wrong type)** — coerce `string | undefined` args with `?? ''` in `sites/overview-plan-card/index.tsx`, `sites/site-change-address-modal/content.tsx`, `sites/staging-site-sync-modal/index.tsx`, and `sites-dashboard/components/sites-sorting-dropdown.tsx`; coerce numeric args bound to `%s` with `String(...)` in `sites/logs/downloader.tsx`, `sites/overview-flex-usage-card/index.tsx`, and `sites/performance/core-metrics-chart.tsx`; coerce `React.ReactNode` clipboard labels with `String(label)` in `sites/settings-sftp-ssh/{sftp,ssh}-card.tsx`.
* **`createInterpolateElement` self-closing tags** — drop the space before `/>` so the type-level tag extractor matches (runtime tokenizer is unchanged): `sites/jetpack-site-disconnect/index.tsx` (`<siteDomain/>`) and `sites/settings-sftp-ssh/ssh-card.tsx` (`<learnMoreLink/>`).
* **TS2353 in `connect-repository-form.tsx`** — the prop `errorMessage: string` made the typed sprintf parser collapse to `[]`, rejecting the `{ reason }` arg. Lifted the `sprintf` to the two call sites (`connect-repository.tsx`, `configure-repository.tsx`) and changed the prop to `errorMessage: ( reason: string ) => string` so the named placeholder is statically visible.

## Why are these changes being made?

`#105909` bumps the WordPress monorepo, including `@wordpress/i18n` 6.x which adds typed format-string checks. To keep that bump mergeable, parallel PRs (this is one) land the source fixes ahead of time. No runtime behavior changes.

## Testing Instructions

1. From a fresh tree:
   ```bash
   grep -rl '"@wordpress/i18n": "\^5\.23\.0"' --include=package.json . \
     | grep -v node_modules \
     | xargs sed -i 's|"@wordpress/i18n": "\^5\.23\.0"|"@wordpress/i18n": "^6.19.0"|g'
   yarn install
   NODE_OPTIONS=--max-old-space-size=10240 yarn typecheck-client 2>&1 \
     | grep "error TS" \
     | grep -E "^(client/dashboard/sites/|client/sites-dashboard/|client/dashboard/sites-ciab/)"
   ```
   Should print nothing.
2. With the 5.x pin restored (trunk), `yarn typecheck-client` still passes.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
