### PR TITLE
dashboard/emails: typed-`@wordpress/i18n` migration

### DIFF
--- a/client/dashboard/emails/add-forwarder/index.tsx
+++ b/client/dashboard/emails/add-forwarder/index.tsx
@@ -217,7 +217,7 @@ function AddEmailForwarder() {
 
 						createErrorNotice(
 							sprintf(
-								/* Translators: %s: emailAddress is the email address the user was attempting to add a forwarder for, %s: message is the error message returned by the API */
+								/* Translators: %(emailAddress)s is the email address the user was attempting to add a forwarder for, %(message)s is the error message returned by the API. */
 								__(
 									'Failed to add email forwarder for %(emailAddress)s with message "%(message)s". Please try again or contact support.'
 								),
@@ -231,7 +231,7 @@ function AddEmailForwarder() {
 					} else {
 						createErrorNotice(
 							sprintf(
-								/* Translators: %s: emailAddress is the email address the user was attempting to add a forwarder for */
+								/* Translators: %(emailAddress)s is the email address the user was attempting to add a forwarder for. */
 								__(
 									'Failed to add email forwarder for %(emailAddress)s. Please try again or contact support.'
 								),
@@ -325,7 +325,7 @@ function AddEmailForwarder() {
 								{ newForwardingAddresses.length > 0 && (
 									<Notice>
 										{ sprintf(
-											/* Translators: %s: emailAddress is the email address the user was attempting to add a forwarder for */
+											/* Translators: %(emailAddresses)s is the comma-separated list of email addresses the user is attempting to add forwarders for. */
 											_n(
 												"This is the first time you've set up an email forwarder to %(emailAddresses)s. Look out for a verification email to confirm you have access to that email after saving.",
 												"This is the first time you've set up an email forwarder to %(emailAddresses)s. Look out for a verification email to confirm you have access to those emails after saving.",
@@ -341,12 +341,12 @@ function AddEmailForwarder() {
 								{ isDomainMaxForwardsReached && (
 									<Notice variant="warning">
 										{ sprintf(
-											// translators: %(maxForwards) is the maximum number of email forwards allowed for a domain.
+											// translators: %(maxForwards)d is the maximum number of email forwards allowed for a domain.
 											__(
 												"You can't add another email forwarder for this domain because you've reached the maximum number %(maxForwards)d of Email Forwards allowed on it. Please delete an existing forwarder in order to add a new one."
 											),
 											{
-												maxForwards,
+												maxForwards: maxForwards ?? DEFAULT_MAX_DOMAIN_FORWARDS,
 											}
 										) }
 									</Notice>
@@ -361,7 +361,7 @@ function AddEmailForwarder() {
 											),
 											{
 												forwardingAddressesCount: forwardingAddresses.length,
-												maxForwards,
+												maxForwards: maxForwards ?? DEFAULT_MAX_DOMAIN_FORWARDS,
 												existingForwardersCount: forwards?.length ?? 0,
 											}
 										) }

--- a/client/dashboard/emails/add-mailbox/components/cart.tsx
+++ b/client/dashboard/emails/add-mailbox/components/cart.tsx
@@ -44,7 +44,7 @@ export const Cart = ( {
 		// translators: %(mailboxes)s is the number of mailboxes selected.
 		_n( '%(mailboxes)s mailbox', '%(mailboxes)s mailboxes', totalItems ),
 		{
-			mailboxes: totalItems,
+			mailboxes: String( totalItems ),
 		}
 	);
 

--- a/client/dashboard/emails/add-mailbox/components/mailbox-form.tsx
+++ b/client/dashboard/emails/add-mailbox/components/mailbox-form.tsx
@@ -160,7 +160,10 @@ export const MailboxForm = ( {
 								__(
 									'Your password reset email is <strong>%(userEmail)s</strong>. <passwordChangeLink>Change it</passwordChangeLink>.'
 								),
-								{ userEmail: mailboxEntity.getFieldValue( FIELD_PASSWORD_RESET_EMAIL ) }
+								{
+									userEmail:
+										mailboxEntity.getFieldValue< string >( FIELD_PASSWORD_RESET_EMAIL ) ?? '',
+								}
 							),
 							{
 								strong: <strong />,

--- a/client/dashboard/emails/components/email-non-domain-owner-notice.tsx
+++ b/client/dashboard/emails/components/email-non-domain-owner-notice.tsx
@@ -25,10 +25,7 @@ export const EmailNonDomainOwnerNotice = ( props: EmailNonDomainOwnerMessageProp
 		redirect_to: window.location.pathname,
 	} );
 
-	const placeholders = {
-		ownerUserName,
-		selectedDomainName: domain?.domain ?? '',
-	};
+	const selectedDomainName = domain?.domain ?? '';
 	const elements = {
 		contactSupportLink: <a href={ CALYPSO_CONTACT } rel="noopener noreferrer" target="_blank" />,
 		loginLink: <a href={ loginUrl } rel="external" />,
@@ -47,12 +44,9 @@ export const EmailNonDomainOwnerNotice = ( props: EmailNonDomainOwnerMessageProp
 			sprintf(
 				// Translators: %(ownerUserName)s is the user name of the owner of the domain, %(selectedDomainName)s is the domain name.
 				__(
-					'Email service can only be purchased by <strong>%(ownerUserName)s</strong>, ' +
-						'who is the owner of <strong>%(selectedDomainName)s</strong>. ' +
-						'If you have access to that account, please <loginLink>log in with the account</loginLink> to make a purchase. ' +
-						'Otherwise, please <reachOutLink>reach out to %(ownerUserName)s</reachOutLink> or <contactSupportLink>contact support</contactSupportLink>.'
+					'Email service can only be purchased by <strong>%(ownerUserName)s</strong>, who is the owner of <strong>%(selectedDomainName)s</strong>. If you have access to that account, please <loginLink>log in with the account</loginLink> to make a purchase. Otherwise, please <reachOutLink>reach out to %(ownerUserName)s</reachOutLink> or <contactSupportLink>contact support</contactSupportLink>.'
 				),
-				placeholders
+				{ ownerUserName, selectedDomainName }
 			),
 			elements
 		);
@@ -61,11 +55,9 @@ export const EmailNonDomainOwnerNotice = ( props: EmailNonDomainOwnerMessageProp
 			sprintf(
 				// Translators: %(selectedDomainName)s is the domain name.
 				__(
-					'Email service can only be purchased by the owner of <strong>%(selectedDomainName)s</strong>. ' +
-						'If you have access to that account, please log in with the account to make a purchase. ' +
-						'Otherwise, please <contactSupportLink>contact support</contactSupportLink>.'
+					'Email service can only be purchased by the owner of <strong>%(selectedDomainName)s</strong>. If you have access to that account, please log in with the account to make a purchase. Otherwise, please <contactSupportLink>contact support</contactSupportLink>.'
 				),
-				placeholders
+				{ selectedDomainName }
 			),
 			elements
 		);

--- a/client/dashboard/emails/dataviews/actions/delete-email-forward.tsx
+++ b/client/dashboard/emails/dataviews/actions/delete-email-forward.tsx
@@ -81,7 +81,7 @@ export const useDeleteEmailForwardAction = (): Action< Email > => {
 							/* translators: %1$s is the email and %2$s is the forwarding destination address. */
 							__( 'Emails sent to %1$s address will no longer be forwarded to %2$s.' ),
 							email.emailAddress,
-							email.forwardingTo
+							email.forwardingTo ?? ''
 						) }
 					</Text>
 					<HStack justify="right">

--- a/client/dashboard/emails/dataviews/actions/resend-verification.ts
+++ b/client/dashboard/emails/dataviews/actions/resend-verification.ts
@@ -39,7 +39,7 @@ export const useResendVerificationAction = (): Action< Email > => {
 							/* translators: %1$s is the forwarding source email address, %2$s is the destination address. */
 							__( 'Successfully sent confirmation email for %1$s to %2$s.' ),
 							email.emailAddress,
-							email.forwardingTo
+							email.forwardingTo ?? ''
 						),
 						{ type: 'snackbar' }
 					);
@@ -53,7 +53,7 @@ export const useResendVerificationAction = (): Action< Email > => {
 							/* translators: %1$s is the forwarding source email address, %2$s is the destination address. */
 							__( 'Failed to send confirmation email for %1$s to %2$s. Please try again.' ),
 							email.emailAddress,
-							email.forwardingTo
+							email.forwardingTo ?? ''
 						),
 						{ type: 'snackbar' }
 					);

--- a/client/dashboard/emails/dataviews/fields/email-address.tsx
+++ b/client/dashboard/emails/dataviews/fields/email-address.tsx
@@ -36,7 +36,7 @@ export const emailAddressField: Field< Email > = {
 							{ sprintf(
 								/* translators: %s is the email messages will be forwarded to. */
 								__( 'forwards to %s' ),
-								item.forwardingTo
+								item.forwardingTo ?? ''
 							) }
 						</Text>
 					</VStack>

--- a/client/dashboard/emails/entities/validators.ts
+++ b/client/dashboard/emails/entities/validators.ts
@@ -65,8 +65,11 @@ class MaximumStringLengthValidator extends BaseValidator< string > {
 	}
 
 	static getFieldTooLongError( maximumStringLength: number ): FieldError {
-		// Translators: %s is the maximum length in characters.
-		return sprintf( __( "This field can't be longer than %s characters." ), maximumStringLength );
+		return sprintf(
+			// Translators: %s is the maximum length in characters.
+			__( "This field can't be longer than %s characters." ),
+			String( maximumStringLength )
+		);
 	}
 
 	validateField( field: MailboxFormFieldBase< string > ): void {
@@ -200,7 +203,7 @@ class PasswordValidator extends BaseValidator< string > {
 		return sprintf(
 			// Translators: %s is the maximum length in characters.
 			__( "This field can't be longer than %s characters." ),
-			PasswordValidator.maximumPasswordLength
+			String( PasswordValidator.maximumPasswordLength )
 		);
 	}
 
@@ -215,8 +218,11 @@ class PasswordValidator extends BaseValidator< string > {
 	static getPasswordContainsForbiddenCharacterError(
 		firstForbiddenCharacter: string | undefined
 	): FieldError {
-		// Translators: %s denotes a single character that is not allowed in this field
-		return sprintf( __( "This field can't accept '%s' as character." ), firstForbiddenCharacter );
+		return sprintf(
+			// Translators: %s denotes a single character that is not allowed in this field
+			__( "This field can't accept '%s' as character." ),
+			firstForbiddenCharacter ?? ''
+		);
 	}
 
 	validateField( field: MailboxFormFieldBase< string > ): void {

--- a/client/dashboard/emails/mappers/mailbox-to-email-mapper.ts
+++ b/client/dashboard/emails/mappers/mailbox-to-email-mapper.ts
@@ -6,7 +6,7 @@ import type { Email } from '../types';
 export const mapMailboxToEmail = ( box: EmailBox, emailAccount: EmailAccount ): Email => {
 	const provider = emailAccount.account_type;
 
-	let providerDisplayName = __( 'Email Forwarding' );
+	let providerDisplayName: string = __( 'Email Forwarding' );
 	if ( provider === 'titan' ) {
 		providerDisplayName = __( 'Titan Mail' );
 	} else if ( provider === 'google_workspace' ) {
@@ -33,7 +33,7 @@ export const mapMailboxToEmail = ( box: EmailBox, emailAccount: EmailAccount ): 
 
 	return {
 		id,
-		subscriptionId: String( emailAccount.subscription_id ) ?? emailAccount.account_id,
+		subscriptionId: emailAccount.subscription_id?.toString() ?? emailAccount.account_id?.toString(),
 		emailAddress: `${ box.mailbox }@${ box.domain }`,
 		type,
 		provider,

--- a/client/dashboard/emails/utils/get-mailbox-cost.ts
+++ b/client/dashboard/emails/utils/get-mailbox-cost.ts
@@ -65,7 +65,7 @@ export const getMailboxCost = ( {
 			};
 		}
 
-		let message = sprintf(
+		let message: string = sprintf(
 			// Translators: %(proratedPrice)s is a formatted price for an email subscription (e.g. $3.50, €3.75, or PLN 4.50).
 			__(
 				'You can purchase new mailboxes at the prorated price of <strong>%(proratedPrice)s</strong> per mailbox.'


### PR DESCRIPTION
Fixes DOTCOM-17291

Part of #105909

## Proposed Changes

Fix the TypeScript errors in `client/dashboard/emails/` that surface when `@wordpress/i18n` is upgraded from `^5.23.0` to `^6.x` (the renovate WordPress monorepo bump in #105909). All changes are forward-compatible because `TransformedText<T> extends string` — the area compiles against both the current trunk pin and the in-flight 6.x bump.

Patterns applied:

- Coerce `string | undefined` and `number` sprintf args so they match the typed placeholders (`?? ''`, `String(...)`).
- Collapse a multi-line `__()` format in `email-non-domain-owner-notice.tsx` that was joined with `+` (the concat erased the format literal type) into a single string literal, and pass per-branch placeholder objects so the else-branch doesn't carry the unused `ownerUserName` key.
- Widen `let providerDisplayName: string` and `let message: string` where the initial `__()` / `sprintf()` call would otherwise infer the narrow `TransformedText<"…">` brand and then break on later reassignments.
- Pass `<string>` to `MailboxFormEntity.getFieldValue` so `userEmail` keeps its expected `string` type at the call site.

### Drive-by fixes

The pre-commit hook lints touched files in full, so a couple of pre-existing issues had to be fixed:

- `add-forwarder/index.tsx`: rewrite four translator comments that used the unrecognised `%s: name` syntax (or referenced the wrong placeholder name) so the `@wordpress/i18n-translator-comments` rule passes.
- `mailbox-to-email-mapper.ts`: `String(x) ?? y` always evaluates to `String(x)` (caught by `no-constant-binary-expression`), so the `account_id` fallback never ran when `subscription_id` was `null`. Switched to `subscription_id?.toString() ?? account_id?.toString()` so the fallback runs as intended — previously `subscriptionId` could be the literal string `"null"`, which would route users to `/purchases/null` via `dataviews/actions/payment-details`.

## Why are these changes being made?

To unblock the `@wordpress/i18n` 5.x → 6.x bump (#105909) without a single mega-PR. Each area is migrated independently and merged ahead of the renovate bump.

## Testing Instructions

This is a type-only refactor — there are no behavioural changes in the i18n portion. To verify locally:

1. Bump `@wordpress/i18n` to `^6.19.0` across all workspace `package.json` files and reinstall.
2. Run `yarn typecheck-client`. There should be no errors prefixed `client/dashboard/emails/`.
3. Revert the version bump (do not commit it).

For the `subscriptionId` drive-by fix: open the email dataview for an account whose subscription has lapsed (`subscription_id === null`) and click the purchase action — it should now use `account_id` instead of routing to `/purchases/null`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
