### PR TITLE
Fix themes empty-state dark mode

### DIFF
--- a/client/my-sites/themes/_dark-mode.scss
+++ b/client/my-sites/themes/_dark-mode.scss
@@ -90,6 +90,50 @@
 		background-color: var( --dashboard-surface__border-color );
 	}
 
+	.themes-list__empty-search-text,
+	.themes-list__options-subheading,
+	.themes-list__option-description,
+	.themes-list__option-description > ul,
+	.themes-list__option-icon {
+		color: var( --dashboard__text-muted-color );
+	}
+
+	.themes-list__option-icon {
+		fill: currentColor;
+	}
+
+	.themes-list__options {
+		background-color: var( --dashboard-surface__background-color );
+		border-color: var( --dashboard-surface__border-color );
+		color: var( --dashboard__text-color );
+	}
+
+	.themes-list__option-content {
+		border-bottom-color: var( --dashboard-surface__border-color );
+	}
+
+	.themes-list__option-description > ul > li::before {
+		border-color: var( --dashboard__text-muted-color );
+		color: var( --dashboard__text-muted-color );
+	}
+
+	.themes-list__option-button.button.is-primary {
+		background-color: var( --wp-admin-theme-color );
+		border-color: var( --wp-admin-theme-color );
+		color: var( --wp-components-color-accent-inverted );
+
+		&:visited {
+			color: var( --wp-components-color-accent-inverted );
+		}
+
+		&:focus,
+		&:hover {
+			background-color: var( --wp-admin-theme-color-darker-10 );
+			border-color: var( --wp-admin-theme-color-darker-10 );
+			color: var( --wp-components-color-accent-inverted );
+		}
+	}
+
 	.theme-tier-badge .badge--info {
 		background-color: var( --dashboard-item-selected__background-color );
 		color: var( --wp-admin-theme-color-darker-20 );
@@ -114,6 +158,7 @@
 		right: -1px; // fixes a 1px gap between the fade and the edge of the container
 	}
 
+	.themes-list__option-button.button:not( .is-primary ),
 	.theme-download-card .button,
 	.theme__sheet-demo-button {
 		background-color: transparent;
@@ -124,6 +169,7 @@
 			color: var( --dashboard__text-color );
 		}
 
+		&:focus,
 		&:hover {
 			background-color: transparent;
 			border-color: var( --dashboard__text-muted-color );


### PR DESCRIPTION
Part of #

## Proposed Changes
<img width="3152" height="3726" alt="CleanShot 2026-05-28 at 16 11 03@2x" src="https://github.com/user-attachments/assets/55fea97b-6274-425c-a7b5-8ab2681401b7" />

* Fix the Themes empty-search panel so its text, icons, surfaces, dividers, and buttons use the existing Themes dark-mode tokens.
* Reuse the existing dark secondary button treatment for secondary empty-state actions, and the existing dark accent tokens for the primary action.

## Why are these changes being made?

The Themes search empty state at `/themes/all?s=wrongtheme` could still look partly light-mode while the rest of the Themes surface was dark. The panel inherited a dark wrapper, but its nested option icons and action buttons kept default SVG/button colors, leaving black icons and mismatched button treatments in the 404-style area.

## Testing Instructions

* Enable dark mode for the Themes surface.
* Visit `/themes/all?s=wrongtheme`.
* Confirm the empty-search panel is dark, the option icons are not black, and the primary/secondary action buttons use dark-mode colors.
* Confirm the empty-state panel remains readable on hover/focus for the action buttons.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
