### PR TITLE
Fix P2 default block readiness in E2E

### DIFF
--- a/packages/calypso-e2e/src/lib/components/isolated-block-editor-component.ts
+++ b/packages/calypso-e2e/src/lib/components/isolated-block-editor-component.ts
@@ -43,7 +43,15 @@ export class IsolatedBlockEditorComponent {
 		// Click on the editor title. This has the effect of dismissing the block inserter
 		// if open, and restores focus back to the editor root container, allowing insertion
 		// of blocks.
-		await this.page.waitForSelector( selectors.firstParagraph );
+		const firstParagraph = this.page.locator( selectors.firstParagraph );
+		const defaultBlockButton = this.page.getByRole( 'button', { name: 'Add default block' } );
+
+		await firstParagraph.or( defaultBlockButton ).first().waitFor( { state: 'visible' } );
+		if ( await defaultBlockButton.isVisible() ) {
+			await defaultBlockButton.click();
+			await firstParagraph.waitFor( { state: 'visible' } );
+		}
+
 		await this.page.click( selectors.blockInserterToggle );
 		await this.page.fill( selectors.blockInserterSearch, blockName );
 		await this.page.click( `${ selectors.blockInserterResultItem } span:text("${ blockName }")` );


### PR DESCRIPTION
## Proposed Changes

* Make the P2 isolated editor helper handle the current editor startup state where the canvas shows the default-block button before a selected paragraph exists.

## Why are these changes being made?

* The scheduled P2 E2E job is failing because `addBlock()` waits for `p[role="document"].is-selected`, but the editor now loads with the “Add default block” affordance visible first. Clicking that affordance restores the selected paragraph state the rest of the helper expects.

## Testing Instructions

* `yarn prettier --check packages/calypso-e2e/src/lib/components/isolated-block-editor-component.ts`
* `ESLINT_USE_FLAT_CONFIG=false yarn eslint --ext .ts --cache packages/calypso-e2e/src/lib/components/isolated-block-editor-component.ts`
* `yarn workspace wp-e2e-tests build`
* Ran the targeted P2 spec locally against wpcalypso for `chrome` and `pixel`; both passed.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
