### PR TITLE
dashboard/utils,components,domains: typed-`@wordpress/i18n` migration

### DIFF
--- a/client/dashboard/components/clipboard-input-control/index.tsx
+++ b/client/dashboard/components/clipboard-input-control/index.tsx
@@ -35,7 +35,7 @@ export default function ClipboardInputControl( {
 		? sprintf(
 				/* translators: %s is the field to copy */
 				__( 'Copy %s' ),
-				props.label
+				String( props.label )
 		  )
 		: __( 'Copy' );
 

--- a/client/dashboard/components/guided-tour/step/index.tsx
+++ b/client/dashboard/components/guided-tour/step/index.tsx
@@ -134,8 +134,8 @@ export function GuidedTourStep( {
 									// translators: %(currentStep)s is the number of the current step and %(totalSteps)s is the number of total steps.
 									__( '%(currentStep)s of %(totalSteps)s' ),
 									{
-										currentStep: currentStep + 1,
-										totalSteps,
+										currentStep: String( currentStep + 1 ),
+										totalSteps: String( totalSteps ),
 									}
 								) }
 							</Text>

--- a/client/dashboard/components/logs-activity/activity-actor.tsx
+++ b/client/dashboard/components/logs-activity/activity-actor.tsx
@@ -21,7 +21,7 @@ function getMcpIndicator( actor?: ActivityActorDetails ): string | null {
 }
 
 function getActorPresentation( actor?: ActivityActorDetails ) {
-	let actorName = __( 'Unknown' );
+	let actorName: string = __( 'Unknown' );
 
 	if ( ! actor ) {
 		return {

--- a/client/dashboard/components/pending-primary-domain-notice/index.tsx
+++ b/client/dashboard/components/pending-primary-domain-notice/index.tsx
@@ -61,7 +61,7 @@ export default function PendingPrimaryDomainNotice( {
 		<Notice variant="info" title={ __( 'Setting up your custom domain' ) }>
 			{ createInterpolateElement(
 				__(
-					'We’re preparing <domain /> to be your site’s <strong>primary address</strong>. This usually takes a few moments, but can sometimes take up to 15 minutes.'
+					'We’re preparing <domain/> to be your site’s <strong>primary address</strong>. This usually takes a few moments, but can sometimes take up to 15 minutes.'
 				),
 				{
 					domain: <strong>{ domainName }</strong>,

--- a/client/dashboard/components/purchase-dialogs/remove-domain-dialog.tsx
+++ b/client/dashboard/components/purchase-dialogs/remove-domain-dialog.tsx
@@ -98,7 +98,7 @@ export default function RemoveDomainDialog( {
 							<Text as="p">
 								{ createInterpolateElement(
 									__(
-										'If you want to use <domain /> with another provider you can <transferLink>transfer it</transferLink>.'
+										'If you want to use <domain/> with another provider you can <transferLink>transfer it</transferLink>.'
 									),
 									{
 										domain: <strong>{ domain.domain }</strong>,

--- a/client/dashboard/domains/domain-connection-setup/steps/login.tsx
+++ b/client/dashboard/domains/domain-connection-setup/steps/login.tsx
@@ -57,7 +57,6 @@ export function Login( {
 												'Open a new browser tab and go to the domain’s settings page. If the domain is under another WordPress.com account, use a different browser, log in to that account and follow the previous instructions. <a>More info can be found here</a>.'
 											),
 											{
-												em: <em />,
 												a: <InlineSupportLink supportContext="connect-subdomain" />,
 											}
 										) }

--- a/client/dashboard/domains/domain-overview/featured-card-renew.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-renew.tsx
@@ -22,7 +22,7 @@ export default function FeaturedCardRenew( { domain }: Props ) {
 	}
 
 	let intent: 'error' | 'success' | 'warning' | 'upsell' = 'warning';
-	let title = __( 'Expires' );
+	let title: string = __( 'Expires' );
 
 	if ( domain.expired ) {
 		intent = 'error';

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-other-user.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-other-user.tsx
@@ -115,13 +115,11 @@ export default function TransferDomainToOtherUser() {
 			onSuccess: () => {
 				createSuccessNotice(
 					sprintf(
-						/* Translators: %s: domainName is the domain name, %s: selectedUserDisplay is the selected user display */
+						/* Translators: %(selectedDomainName)s is the domain name, %(selectedUserDisplay)s is the selected user display */
 						__( '%(selectedDomainName)s has been transferred to %(selectedUserDisplay)s' ),
 						{
-							args: {
-								selectedDomainName: domainName,
-								selectedUserDisplay: selectedUser ? getUserDisplayName( selectedUser ) : '',
-							},
+							selectedDomainName: domainName,
+							selectedUserDisplay: selectedUser ? getUserDisplayName( selectedUser ) : '',
 						}
 					)
 				);
@@ -131,9 +129,9 @@ export default function TransferDomainToOtherUser() {
 			onError: () => {
 				createErrorNotice(
 					sprintf(
-						/* Translators: %s: domainName is the domain name */
+						/* Translators: %(selectedDomainName)s is the domain name */
 						__( 'Failed to transfer %(selectedDomainName)s, please try again or contact support.' ),
-						{ args: { selectedDomainName: domainName } }
+						{ selectedDomainName: domainName }
 					)
 				);
 				setIsDialogOpen( false );

--- a/client/dashboard/domains/name-servers/form.tsx
+++ b/client/dashboard/domains/name-servers/form.tsx
@@ -22,12 +22,12 @@ const createNameServerField = ( index: number, formData: FormData, isBusy?: bool
 		label: sprintf(
 			// translators: %s is the name server number (1-4)
 			__( 'Name server %s' ),
-			index
+			String( index )
 		),
 		placeholder: sprintf(
 			// translators: %s is the name server number (1-4)
 			__( 'ns%s.example.com' ),
-			index
+			String( index )
 		),
 		isValid: {
 			required: index <= MIN_NAME_SERVERS_LENGTH,

--- a/client/dashboard/utils/datetime.ts
+++ b/client/dashboard/utils/datetime.ts
@@ -117,27 +117,27 @@ export function getRelativeTimeString( date: Date ): string {
 			case 'year':
 				// translators: value is a number
 				return sprintf( _n( '%(value)s year ago', '%(value)s years ago', value ), {
-					value,
+					value: String( value ),
 				} );
 			case 'month':
 				// translators: value is a number
 				return sprintf( _n( '%(value)s month ago', '%(value)s months ago', value ), {
-					value,
+					value: String( value ),
 				} );
 			case 'day':
 				// translators: value is a number
 				return sprintf( _n( '%(value)s day ago', '%(value)s days ago', value ), {
-					value,
+					value: String( value ),
 				} );
 			case 'hour':
 				// translators: value is a number
 				return sprintf( _n( '%(value)s hour ago', '%(value)s hours ago', value ), {
-					value,
+					value: String( value ),
 				} );
 			case 'minute':
 				// translators: value is a number
 				return sprintf( _n( '%(value)s minute ago', '%(value)s minutes ago', value ), {
-					value,
+					value: String( value ),
 				} );
 			default:
 				return __( 'just now' );
@@ -147,27 +147,27 @@ export function getRelativeTimeString( date: Date ): string {
 		case 'year':
 			// translators: value is a number
 			return sprintf( _n( 'in %(value)s year', 'in %(value)s years', value ), {
-				value,
+				value: String( value ),
 			} );
 		case 'month':
 			// translators: value is a number
 			return sprintf( _n( 'in %(value)s month', 'in %(value)s months', value ), {
-				value,
+				value: String( value ),
 			} );
 		case 'day':
 			// translators: value is a number
 			return sprintf( _n( 'in %(value)s day', 'in %(value)s days', value ), {
-				value,
+				value: String( value ),
 			} );
 		case 'hour':
 			// translators: value is a number
 			return sprintf( _n( 'in %(value)s hour', 'in %(value)s hours', value ), {
-				value,
+				value: String( value ),
 			} );
 		case 'minute':
 			// translators: value is a number
 			return sprintf( _n( 'in %(value)s minute', 'in %(value)s minutes', value ), {
-				value,
+				value: String( value ),
 			} );
 		default:
 			return __( 'just now' );

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -303,10 +303,10 @@ export function getTitleForDisplay( purchase: Purchase ): string {
 		'wordpress_com_1gb_space_addon_yearly' === purchase.product_slug &&
 		purchase.renewal_price_tier_usage_quantity
 	) {
-		// translators: productName is the name of the product and quantity is a number (GB stands for GigaBytes)
+		// translators: %(productName)s is the name of the product and %(quantity)s is a number (GB stands for GigaBytes)
 		return sprintf( __( '%(productName)s %(quantity)s GB' ), {
 			productName: purchase.product_name,
-			quantity: purchase.renewal_price_tier_usage_quantity,
+			quantity: String( purchase.renewal_price_tier_usage_quantity ),
 		} );
 	}
 
@@ -319,7 +319,7 @@ export function getTitleForDisplay( purchase: Purchase ): string {
 		purchase.renewal_price_tier_usage_quantity &&
 		purchase.renewal_price_tier_usage_quantity > 1
 	) {
-		/* translators: %s is the product name "Akismet Pro", %d is a number of requests/month */
+		/* translators: %(productName)s is the product name "Akismet Pro", %(requests)d is a number of requests/month */
 		return sprintf( __( '%(productName)s (%(requests)d requests/month)' ), {
 			productName: purchase.product_name.replace( /\s*\(.*$/, '' ).trim(),
 			requests: 500 * purchase.renewal_price_tier_usage_quantity,
@@ -391,7 +391,7 @@ export function getSubtitleForDisplay( purchase: Purchase ): string | null {
 
 	if ( purchase.is_google_workspace_product && purchase.meta ) {
 		return sprintf(
-			// translators: The domain is the domain name of the site
+			// translators: %(domain)s is the domain name of the site
 			__( 'Mailboxes and Productivity Tools at %(domain)s' ),
 			{
 				domain: purchase.meta,
@@ -401,7 +401,7 @@ export function getSubtitleForDisplay( purchase: Purchase ): string | null {
 
 	if ( purchase.is_titan_mail_product && purchase.meta ) {
 		return sprintf(
-			// translators: The domain is the domain name of the site
+			// translators: %(domain)s is the domain name of the site
 			__( 'Mailboxes at %(domain)s' ),
 			{
 				domain: purchase.meta,


### PR DESCRIPTION
Fixes DOTCOM-17294

Part of #105909. Continues the decomposition of the renovate `@wordpress/i18n` 5.x → 6.x bump into small, forward-compatible PRs against trunk; this one covers the Dashboard shared infrastructure (`client/dashboard/utils`, `client/dashboard/components`, `client/dashboard/domains`).

## Proposed Changes

Resolves 23 type errors that surface when `@wordpress/i18n` is at `^6.x`, while remaining compatible with trunk's current `^5.23.0` pin.

Three patterns applied:

1. **TS2769 — sprintf args of type `number` fed a `%(...)s` placeholder.** Coerced with `String(...)`. Heaviest hit: `utils/datetime.ts` (10 occurrences, the "in X year(s)" / "X year(s) ago" relative-time formatters).
2. **TS2353 — `createInterpolateElement` self-closing tag with a space before `/>`.** The runtime tokenizer matches `<tag />`, but the type-level `ExtractTags` only recognises `<tag/>` (no space). Stripped the space in `<domain/>` (two files). Runtime unchanged.
3. **TS2322 — over-narrow `TransformedText<T>` inference.** A `let` initialised from one `__()` and reassigned to a different literal. Widened the annotation to `: string` in `logs-activity/activity-actor.tsx` and `domain-overview/featured-card-renew.tsx`.

## Real bugs fixed along the way

- `domains/domain-transfer/transfer-domain-to-other-user.tsx` — two `sprintf` calls were passing `{ args: { ... } }` instead of the flat placeholder map sprintf expects. The placeholders would have rendered literally (e.g. `%(selectedDomainName)s has been transferred to %(selectedUserDisplay)s`) on the success and error notices. Flattened the args and tightened the translator comments to reference the actual placeholder names.
- `domains/domain-connection-setup/steps/login.tsx` — the `wpcom` branch's `createInterpolateElement` args carried a stale `em: <em />` property that the format string no longer declares (the second branch does use `<em>`). Removed.

## Drive-by lint cleanups

Pre-existing on trunk, caught by per-file `lint-staged` once these files were touched: expanded three incomplete `/* translators: */` comments in `utils/purchase.ts` to reference the actual placeholder names.

## Testing Instructions

* `yarn typecheck-client` — clean on `trunk`. Verified locally clean against a dev `@wordpress/i18n@^6.20.0` install too.
* Manual smoke-test of the two real-bug fixes:
  * Use the Dashboard's *Transfer this domain to another user* flow — the success and error snackbars should now show the domain name and target user, not the literal `%(selectedDomainName)s` / `%(selectedUserDisplay)s` placeholders.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?
