### PR TITLE
A4A: Consolidate welcome banners into the onboarding tour

### DIFF
--- a/client/a8c-for-agencies/components/a4a-agency-approval-notice/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-agency-approval-notice/index.tsx
@@ -1,14 +1,12 @@
 import { useTranslate } from 'i18n-calypso';
 import LayoutBanner from 'calypso/a8c-for-agencies/components/layout/banner';
 import { useDispatch, useSelector } from 'calypso/state';
-import {
-	getActiveAgency,
-	hasApprovedAgencyStatus,
-} from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { ApprovalStatus } from 'calypso/state/a8c-for-agencies/types';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import { CONTACT_URL_HASH_FRAGMENT } from '../a4a-contact-support-widget';
+import type { ReactNode } from 'react';
 
 import './style.scss';
 
@@ -27,35 +25,19 @@ const A4AAgencyApprovalNotice = ( { isFullWidth }: { isFullWidth?: boolean } ) =
 		getPreference( state, AGENCY_APPROVAL_DISMISS_PREFERENCE )
 	);
 
-	const isAgencyApproved = useSelector( hasApprovedAgencyStatus );
-
 	if ( isDismissed ) {
 		return null;
 	}
 
-	// If approved, only show banner for 1 week after signup
-	if (
-		isAgencyApproved &&
-		agency?.created_at &&
-		new Date( agency.created_at ) < new Date( Date.now() - 7 * 24 * 60 * 60 * 1000 ) // 7 days
-	) {
-		return null;
-	}
-
-	const availableBannerDetails = {
+	const availableBannerDetails: Partial<
+		Record< ApprovalStatus, { text: ReactNode; level: string; hideCloseButton: boolean } >
+	> = {
 		[ ApprovalStatus.PENDING ]: {
 			text: translate(
 				"Welcome to Automattic for Agencies! While we review your agency, feel free to explore. Purchases and referrals will be unlocked once you're approved for the program. Don't worry, we review most applications within a few hours!"
 			),
 			level: 'warning',
 			hideCloseButton: true,
-		},
-		[ ApprovalStatus.APPROVED ]: {
-			text: translate(
-				'Welcome to Automattic for Agencies. Your application has been approved! You can now make purchases in the portal.'
-			),
-			level: 'success',
-			hideCloseButton: false,
 		},
 		[ ApprovalStatus.REJECTED ]: {
 			text: translate(
@@ -82,7 +64,7 @@ const A4AAgencyApprovalNotice = ( { isFullWidth }: { isFullWidth?: boolean } ) =
 	return (
 		<LayoutBanner
 			isFullWidth={ isFullWidth }
-			level={ bannerDetails.level as 'warning' | 'success' | 'error' }
+			level={ bannerDetails.level as 'warning' | 'error' }
 			onClose={ dismissNotice }
 			hideCloseButton={ bannerDetails.hideCloseButton }
 			allowTemporaryDismissal={ bannerDetails.hideCloseButton }

--- a/client/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-onboarding-tour-sections.tsx
+++ b/client/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-onboarding-tour-sections.tsx
@@ -2,7 +2,10 @@ import { formatCurrency } from '@automattic/number-formatters';
 import { ExternalLink } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
-import { A4A_ONBOARDING_TOUR_COMPLETED_PREFERENCE_NAME } from 'calypso/a8c-for-agencies/sections/onboarding-tours/constants';
+import {
+	A4A_ONBOARDING_TOUR_COMPLETED_PREFERENCE_NAME,
+	A4A_ONBOARDING_TOUR_WELCOME_SECTION_ID,
+} from 'calypso/a8c-for-agencies/sections/onboarding-tours/constants';
 import OverviewSidebarGrowthAcceleratorCta from 'calypso/a8c-for-agencies/sections/overview/sidebar/growth-accelerator/cta';
 import { A4A_REPORTS_OVERVIEW_LINK } from 'calypso/a8c-for-agencies/sections/reports/constants';
 import OnboardingTourBannerAgencyTiers from 'calypso/assets/images/a8c-for-agencies/onboarding-tour-banner-agency-tiers.svg';
@@ -67,7 +70,7 @@ export default function useOnboardingTourSections() {
 
 		const sections = [
 			{
-				id: 'overview',
+				id: A4A_ONBOARDING_TOUR_WELCOME_SECTION_ID,
 				title: translate( 'Welcome' ),
 				bannerImage: OnboardingTourBannerWelcome,
 				isDarkBanner: true,
@@ -467,7 +470,7 @@ export default function useOnboardingTourSections() {
 		];
 
 		return hasCompletedTour
-			? sections.filter( ( section ) => section.id !== 'overview' )
+			? sections.filter( ( section ) => section.id !== A4A_ONBOARDING_TOUR_WELCOME_SECTION_ID )
 			: sections;
 	}, [ dispatch, hasCompletedTour, saveCurrentSection, translate ] );
 }

--- a/client/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-onboarding-tour-sections.tsx
+++ b/client/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-onboarding-tour-sections.tsx
@@ -2,6 +2,7 @@ import { formatCurrency } from '@automattic/number-formatters';
 import { ExternalLink } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
+import { A4A_ONBOARDING_TOUR_COMPLETED_PREFERENCE_NAME } from 'calypso/a8c-for-agencies/sections/onboarding-tours/constants';
 import OverviewSidebarGrowthAcceleratorCta from 'calypso/a8c-for-agencies/sections/overview/sidebar/growth-accelerator/cta';
 import { A4A_REPORTS_OVERVIEW_LINK } from 'calypso/a8c-for-agencies/sections/reports/constants';
 import OnboardingTourBannerAgencyTiers from 'calypso/assets/images/a8c-for-agencies/onboarding-tour-banner-agency-tiers.svg';
@@ -16,8 +17,9 @@ import OnboardingTourBannerSites from 'calypso/assets/images/a8c-for-agencies/on
 import OnboardingTourBannerTeam from 'calypso/assets/images/a8c-for-agencies/onboarding-tour-banner-team.svg';
 import OnboardingTourBannerWelcome from 'calypso/assets/images/a8c-for-agencies/onboarding-tour-banner-welcome.svg';
 import OnboardingTourBannerWooPayments from 'calypso/assets/images/a8c-for-agencies/onboarding-tour-banner-woopayments.svg';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getPreference } from 'calypso/state/preferences/selectors';
 import { RenderableAction, RenderableActionProps } from '../../../onboarding-tour-modal/section';
 import {
 	A4A_MARKETPLACE_LINK,
@@ -39,6 +41,10 @@ export default function useOnboardingTourSections() {
 
 	const { saveCurrentSection } = useCurrentOnboardingSection();
 
+	const hasCompletedTour = useSelector( ( state ) =>
+		Boolean( getPreference( state, A4A_ONBOARDING_TOUR_COMPLETED_PREFERENCE_NAME ) )
+	);
+
 	return useMemo( () => {
 		const onNextBenefit = ( section: string, onNext: () => void ) => {
 			dispatch(
@@ -59,7 +65,7 @@ export default function useOnboardingTourSections() {
 			onClose();
 		};
 
-		return [
+		const sections = [
 			{
 				id: 'overview',
 				title: translate( 'Welcome' ),
@@ -459,5 +465,9 @@ export default function useOnboardingTourSections() {
 				},
 			},
 		];
-	}, [ dispatch, saveCurrentSection, translate ] );
+
+		return hasCompletedTour
+			? sections.filter( ( section ) => section.id !== 'overview' )
+			: sections;
+	}, [ dispatch, hasCompletedTour, saveCurrentSection, translate ] );
 }

--- a/client/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-onboarding-tour.ts
+++ b/client/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-onboarding-tour.ts
@@ -1,13 +1,9 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useCallback, useEffect, useState } from 'react';
-import { A4A_ONBOARDING_TOUR_COMPLETED_PREFERENCE_NAME } from 'calypso/a8c-for-agencies/sections/onboarding-tours/constants';
-import { useDispatch } from 'calypso/state';
-import { savePreference } from 'calypso/state/preferences/actions';
 
 export const ONBOARDING_TOUR_HASH = '#onboarding-tour';
 
 export default function useOnboardingTour() {
-	const dispatch = useDispatch();
 	const [ isOpen, setIsOpen ] = useState( false );
 
 	useEffect( () => {
@@ -33,8 +29,7 @@ export default function useOnboardingTour() {
 		setIsOpen( false );
 		// Remove the hash from the URL
 		window.history.replaceState( '', '', window.location.pathname );
-		dispatch( savePreference( A4A_ONBOARDING_TOUR_COMPLETED_PREFERENCE_NAME, true ) );
-	}, [ dispatch ] );
+	}, [] );
 
 	return {
 		isOpen,

--- a/client/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-onboarding-tour.ts
+++ b/client/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-onboarding-tour.ts
@@ -1,9 +1,13 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useCallback, useEffect, useState } from 'react';
+import { A4A_ONBOARDING_TOUR_COMPLETED_PREFERENCE_NAME } from 'calypso/a8c-for-agencies/sections/onboarding-tours/constants';
+import { useDispatch } from 'calypso/state';
+import { savePreference } from 'calypso/state/preferences/actions';
 
 export const ONBOARDING_TOUR_HASH = '#onboarding-tour';
 
 export default function useOnboardingTour() {
+	const dispatch = useDispatch();
 	const [ isOpen, setIsOpen ] = useState( false );
 
 	useEffect( () => {
@@ -29,7 +33,8 @@ export default function useOnboardingTour() {
 		setIsOpen( false );
 		// Remove the hash from the URL
 		window.history.replaceState( '', '', window.location.pathname );
-	}, [] );
+		dispatch( savePreference( A4A_ONBOARDING_TOUR_COMPLETED_PREFERENCE_NAME, true ) );
+	}, [ dispatch ] );
 
 	return {
 		isOpen,

--- a/client/a8c-for-agencies/components/onboarding-tour-modal/index.tsx
+++ b/client/a8c-for-agencies/components/onboarding-tour-modal/index.tsx
@@ -12,10 +12,14 @@ import {
 	useState,
 } from 'react';
 import useMinimizeHelpCenterOnMount from 'calypso/a8c-for-agencies/hooks/use-minimize-help-center-on-mount';
-import { A4A_ONBOARDING_TOUR_COMPLETED_PREFERENCE_NAME } from 'calypso/a8c-for-agencies/sections/onboarding-tours/constants';
-import { useDispatch } from 'calypso/state';
+import {
+	A4A_ONBOARDING_TOUR_COMPLETED_PREFERENCE_NAME,
+	A4A_ONBOARDING_TOUR_WELCOME_SECTION_ID,
+} from 'calypso/a8c-for-agencies/sections/onboarding-tours/constants';
+import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
+import { getPreference } from 'calypso/state/preferences/selectors';
 import { ONBOARDING_TOUR_HASH } from '../hoc/with-onboarding-tour/hooks/use-onboarding-tour';
 import OnboardingTourModalMobileNavigation from './mobile-navigation';
 import OnboardingTourModalSection, {
@@ -36,6 +40,10 @@ function OnboardingTourModal( { onClose, children }: OnboardingTourModalProps ) 
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	useMinimizeHelpCenterOnMount();
+
+	const hasCompletedTour = useSelector( ( state ) =>
+		Boolean( getPreference( state, A4A_ONBOARDING_TOUR_COMPLETED_PREFERENCE_NAME ) )
+	);
 
 	const sections: ReactElement< OnboardingTourModalSectionProps >[] = Children.toArray(
 		children
@@ -102,11 +110,15 @@ function OnboardingTourModal( { onClose, children }: OnboardingTourModalProps ) 
 			);
 			// Once the user navigates past the welcome section, mark the tour
 			// as completed so the welcome is hidden on subsequent opens.
-			if ( currentSection.props.id !== 'overview' ) {
+			if (
+				currentSection.props.id !== A4A_ONBOARDING_TOUR_WELCOME_SECTION_ID &&
+				! hasCompletedTour
+			) {
+				dispatch( recordTracksEvent( 'calypso_a4a_onboarding_tour_completed' ) );
 				dispatch( savePreference( A4A_ONBOARDING_TOUR_COMPLETED_PREFERENCE_NAME, true ) );
 			}
 		}
-	}, [ currentSection, dispatch ] );
+	}, [ currentSection, dispatch, hasCompletedTour ] );
 
 	return (
 		<Modal

--- a/client/a8c-for-agencies/components/onboarding-tour-modal/index.tsx
+++ b/client/a8c-for-agencies/components/onboarding-tour-modal/index.tsx
@@ -12,8 +12,10 @@ import {
 	useState,
 } from 'react';
 import useMinimizeHelpCenterOnMount from 'calypso/a8c-for-agencies/hooks/use-minimize-help-center-on-mount';
+import { A4A_ONBOARDING_TOUR_COMPLETED_PREFERENCE_NAME } from 'calypso/a8c-for-agencies/sections/onboarding-tours/constants';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { savePreference } from 'calypso/state/preferences/actions';
 import { ONBOARDING_TOUR_HASH } from '../hoc/with-onboarding-tour/hooks/use-onboarding-tour';
 import OnboardingTourModalMobileNavigation from './mobile-navigation';
 import OnboardingTourModalSection, {
@@ -98,6 +100,11 @@ function OnboardingTourModal( { onClose, children }: OnboardingTourModalProps ) 
 					section: currentSection?.props?.id,
 				} )
 			);
+			// Once the user navigates past the welcome section, mark the tour
+			// as completed so the welcome is hidden on subsequent opens.
+			if ( currentSection.props.id !== 'overview' ) {
+				dispatch( savePreference( A4A_ONBOARDING_TOUR_COMPLETED_PREFERENCE_NAME, true ) );
+			}
 		}
 	}, [ currentSection, dispatch ] );
 

--- a/client/a8c-for-agencies/components/onboarding-tour-modal/index.tsx
+++ b/client/a8c-for-agencies/components/onboarding-tour-modal/index.tsx
@@ -114,7 +114,6 @@ function OnboardingTourModal( { onClose, children }: OnboardingTourModalProps ) 
 				currentSection.props.id !== A4A_ONBOARDING_TOUR_WELCOME_SECTION_ID &&
 				! hasCompletedTour
 			) {
-				dispatch( recordTracksEvent( 'calypso_a4a_onboarding_tour_completed' ) );
 				dispatch( savePreference( A4A_ONBOARDING_TOUR_COMPLETED_PREFERENCE_NAME, true ) );
 			}
 		}

--- a/client/a8c-for-agencies/components/onboarding-tour-modal/index.tsx
+++ b/client/a8c-for-agencies/components/onboarding-tour-modal/index.tsx
@@ -101,23 +101,31 @@ function OnboardingTourModal( { onClose, children }: OnboardingTourModalProps ) 
 			} );
 	}, [ currentSection?.props, onClose, sections, currentSectionIndex ] );
 
+	const currentSectionPropsId = currentSection?.props?.id;
+
+	// Track a section view whenever the active section changes. Keyed on the
+	// section id alone so saving the completed preference below doesn't refire it.
 	useEffect( () => {
-		if ( currentSection?.props?.id ) {
+		if ( currentSectionPropsId ) {
 			dispatch(
 				recordTracksEvent( 'calypso_onboarding_tour_modal_section_view', {
-					section: currentSection?.props?.id,
+					section: currentSectionPropsId,
 				} )
 			);
-			// Once the user navigates past the welcome section, mark the tour
-			// as completed so the welcome is hidden on subsequent opens.
-			if (
-				currentSection.props.id !== A4A_ONBOARDING_TOUR_WELCOME_SECTION_ID &&
-				! hasCompletedTour
-			) {
-				dispatch( savePreference( A4A_ONBOARDING_TOUR_COMPLETED_PREFERENCE_NAME, true ) );
-			}
 		}
-	}, [ currentSection, dispatch, hasCompletedTour ] );
+	}, [ currentSectionPropsId, dispatch ] );
+
+	// Once the user navigates past the welcome section, mark the tour as
+	// completed so the welcome is hidden on subsequent opens.
+	useEffect( () => {
+		if (
+			currentSectionPropsId &&
+			currentSectionPropsId !== A4A_ONBOARDING_TOUR_WELCOME_SECTION_ID &&
+			! hasCompletedTour
+		) {
+			dispatch( savePreference( A4A_ONBOARDING_TOUR_COMPLETED_PREFERENCE_NAME, true ) );
+		}
+	}, [ currentSectionPropsId, dispatch, hasCompletedTour ] );
 
 	return (
 		<Modal

--- a/client/a8c-for-agencies/sections/onboarding-tours/constants.ts
+++ b/client/a8c-for-agencies/sections/onboarding-tours/constants.ts
@@ -18,3 +18,5 @@ export const A4A_ONBOARDING_TOURS_EVENT_NAMES: Record< string, string > = {
 };
 
 export const A4A_ONBOARDING_TOURS_DISMISSED_PREFERENCE_NAME = 'a4a-onboarding-tour-dismissed';
+
+export const A4A_ONBOARDING_TOUR_COMPLETED_PREFERENCE_NAME = 'a4a-onboarding-tour-completed';

--- a/client/a8c-for-agencies/sections/onboarding-tours/constants.ts
+++ b/client/a8c-for-agencies/sections/onboarding-tours/constants.ts
@@ -20,3 +20,5 @@ export const A4A_ONBOARDING_TOURS_EVENT_NAMES: Record< string, string > = {
 export const A4A_ONBOARDING_TOURS_DISMISSED_PREFERENCE_NAME = 'a4a-onboarding-tour-dismissed';
 
 export const A4A_ONBOARDING_TOUR_COMPLETED_PREFERENCE_NAME = 'a4a-onboarding-tour-completed';
+
+export const A4A_ONBOARDING_TOUR_WELCOME_SECTION_ID = 'overview';


### PR DESCRIPTION
 Closes https://linear.app/a8c/issue/A4A-2617/overview-consolidate-notice-banners-into-onboarding-guide
 
## Proposed Changes
  
  * Remove the green "Welcome to Automattic for Agencies — Your application has been approved!" banner from
  `A4AAgencyApprovalNotice`. Pending and rejected variants stay as-is.
  * Track unified-tour completion via a new `a4a-onboarding-tour-completed` user preference. The preference is saved once the modal's current section is anything other than the welcome (id `overview`) — i.e. after the user clicks "Start tour" or jumps to another section via the sidebar.
  * Filter the welcome section out of `useOnboardingTourSections` when that preference is set, so the tour opens at
  "Sites" for returning users.

  ## Why are these changes being made?

  The overview page surfaced two redundant welcome notices above the fold: the green approval banner and the onboarding tour's "Welcome to Automattic for Agencies!" section. The intent (per Noam's design call) is for the onboarding tour to be the single welcome surface, and for users who have already been through the tour to not see either welcome again.

  After this change:
  - Brand-new approved users see only the tour's welcome section (auto-opened via the post-signup `#onboarding-tour` redirect).
  - Once they've engaged with the tour past the welcome, subsequent opens (e.g. via sidebar → "Relaunch welcome tour")  start at "Sites" — no duplicate welcome.
  - Users who open the modal and immediately dismiss it without navigating still see the welcome on their next open.
  Completion is gated on actually leaving the welcome section, not on any close.
  - Pending/Rejected approval banners still render so agencies know where they stand.

  ## Testing Instructions

  1. Sign in as an approved agency.
  2. Visit `/overview` — the green "Your application has been approved" banner should not appear.
  3. Visit `/overview#onboarding-tour` (or sign up fresh) — the modal should open at the "Welcome" section.
  4. Close the modal immediately without clicking anything else. Reopen via sidebar → "Relaunch welcome tour" — the "Welcome" section should still be the first item.
  5. Open the modal again, click "Start tour" (or click any non-welcome menu item in the sidebar). Close.
  6. Click "Relaunch welcome tour" again — the modal should now open at "Sites"; the "Welcome" item should be gone from the left-hand menu.
  7. Sanity-check the Pending banner: temporarily set an agency to `pending` and confirm the warning banner still
  renders. Same for `rejected`.
  8. Confirm no console / TypeScript errors.