### PR TITLE
my-sites/checkout: typed-`@wordpress/i18n` migration

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/akismet-checkout-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/akismet-checkout-thank-you.tsx
@@ -67,7 +67,7 @@ const AkismetCheckoutThankYou: FunctionComponent< AkismetCheckoutThankYouProps >
 					'Thanks for your purchase. We have sent you an email with your receipt and further instructions on how to activate <strong>%s</strong>.',
 					'akismet-thank-you'
 				),
-				productName
+				productName ?? ''
 			),
 			{ strong: <strong /> }
 		);
@@ -87,7 +87,7 @@ const AkismetCheckoutThankYou: FunctionComponent< AkismetCheckoutThankYouProps >
 						'Thanks for your purchase. We have sent you an email with your receipt for <strong>%s</strong>.',
 						'akismet-thank-you'
 					),
-					productName
+					productName ?? ''
 				),
 				{ strong: <strong /> }
 			);

--- a/client/my-sites/checkout/purchase-modal/content.tsx
+++ b/client/my-sites/checkout/purchase-modal/content.tsx
@@ -9,7 +9,7 @@ import {
 	LineItemType,
 	getCouponLineItemFromCart,
 } from '@automattic/wpcom-checkout';
-import { sprintf } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import React, { useCallback } from 'react';
@@ -136,7 +136,7 @@ function PaymentMethodStep( {
 		page( ( event.target as HTMLAnchorElement ).href );
 	}, [] );
 	// translators: %s will be replaced with the last 4 digits of a credit card.
-	const maskedCard = sprintf( translate( '**** %s' ), card?.card_last_4 || '' );
+	const maskedCard = sprintf( __( '**** %s' ), card?.card_last_4 || '' );
 
 	return (
 		<PurchaseModalStep>
@@ -213,11 +213,11 @@ function PayButton( {
 	totalCostDisplay: string;
 } ) {
 	const translate = useTranslate();
-	// translators: %s is the total to be paid in localized currency
 	const payText =
 		totalCost === 0
 			? translate( 'Complete Checkout' )
-			: sprintf( translate( 'Pay %s' ), totalCostDisplay );
+			: // translators: %s is the total to be paid in localized currency
+			  sprintf( __( 'Pay %s' ), totalCostDisplay );
 	const processingText = translate( 'Processing…' );
 
 	return (

--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
@@ -38,10 +38,10 @@ function getUpsellVariant( currentVariant: WPCOMProductVariant, variants: WPCOMP
 function getUpsellTextForVariant(
 	upsellVariant: WPCOMProductVariant,
 	percentSavings: number,
-	__: any
+	__: typeof import('@wordpress/i18n').__
 ) {
 	if ( upsellVariant.productBillingTermInMonths === 12 ) {
-		// translators: "percentSavings" is the savings percentage for the upgrade as a number, like '20' for '20%'.
+		// translators: %(percentSavings)d%% is the savings percentage for the upgrade as a number, like '20' for '20%'.
 		const cardTitle = __( '<strong>Save %(percentSavings)d%%</strong> by paying annually' );
 		return {
 			cardTitle: createInterpolateElement( sprintf( cardTitle, { percentSavings } ), {
@@ -53,7 +53,7 @@ function getUpsellTextForVariant(
 	}
 
 	if ( upsellVariant.productBillingTermInMonths === 24 ) {
-		// translators: "percentSavings" is the savings percentage for the upgrade as a number, like '20' for '20%'.
+		// translators: %(percentSavings)d%% is the savings percentage for the upgrade as a number, like '20' for '20%'.
 		const cardTitle = __(
 			'<strong>Save %(percentSavings)d%% extra</strong> by paying for two years'
 		);
@@ -67,7 +67,7 @@ function getUpsellTextForVariant(
 	}
 
 	if ( upsellVariant.productBillingTermInMonths === 36 ) {
-		// translators: "percentSavings" is the savings percentage for the upgrade as a number, like '20' for '20%'.
+		// translators: %(percentSavings)d%% is the savings percentage for the upgrade as a number, like '20' for '20%'.
 		const cardTitle = __(
 			'<strong>Save %(percentSavings)d%% extra</strong> by paying for three years'
 		);


### PR DESCRIPTION
Fixes DOTCOM-17295

Part of #105909. Continues the decomposition of the renovate `@wordpress/i18n` 5.x → 6.x bump into small, forward-compatible PRs against trunk; this one covers `client/my-sites/checkout`.

## Proposed Changes

Resolves 7 type errors that surface when `@wordpress/i18n` is at `^6.x`, while remaining compatible with trunk's current `^5.23.0` pin.

* `checkout-thank-you/akismet-checkout-thank-you.tsx` — `productName` is `string | null` (the selector returns `null` when the slug is `'no_product'`). Coerced with `?? ''` at the two `sprintf` call sites.
* `purchase-modal/content.tsx` — two `sprintf( translate( 'foo %s' ), x )` calls. `translate()` from `i18n-calypso` returns plain `string`, so the typed-sprintf parser collapses to the 0-arg overload and rejects the positional argument. Switched those two formats to `__()` from `@wordpress/i18n` (which returns `TransformedText<T>`). The rest of the file continues to use `translate()`.
* `src/components/checkout-sidebar-plan-upsell/index.tsx` — `getUpsellTextForVariant` accepts `__` as an injected dependency typed as `any`, which erased the format-string brand on the `cardTitle` constants and broke `sprintf( cardTitle, { percentSavings } )` typing in all three branches. Tightened the parameter to `typeof import( '@wordpress/i18n' ).__`. No runtime change — the same function from `useI18n()` is passed in.

## Drive-by lint cleanups

Pre-existing on trunk, caught by per-file `lint-staged` once these files were touched: tightened the three `percentSavings` translator comments to use the `%(...)d%%` placeholder syntax the i18n linter recognises, and moved the "Pay %s" translator comment directly above the `sprintf` call in `purchase-modal/content.tsx`.

## Testing Instructions

* `yarn typecheck-client` — clean on `trunk`. Verified locally clean against a dev `@wordpress/i18n@^6.20.0` install too.
* Smoke-test the Akismet thank-you page and a non-zero-cost checkout's "Pay $X" button.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?
