### PR TITLE
Blaze Dashboard: preserve host-provided Stripe publishable key

### DIFF
--- a/apps/blaze-dashboard/src/load-config.js
+++ b/apps/blaze-dashboard/src/load-config.js
@@ -30,6 +30,11 @@ productionConfig.features.is_running_in_woo_site = isWooStore;
 
 productionConfig.features.blaze_setup_mode = !! needSetup;
 
+// Overrides the dsp stripe key (used for testing environments)
+if ( window.configData?.dsp_stripe_pub_key ) {
+	productionConfig.dsp_stripe_pub_key = window.configData.dsp_stripe_pub_key;
+}
+
 // The option enables loading of the whole translation file, and could be optimized by setting it to `true`, which needs the translation chunks in place.
 // @see https://github.com/Automattic/wp-calypso/blob/trunk/docs/translation-chunks.md
 productionConfig.features[ 'use-translation-chunks' ] = false;


### PR DESCRIPTION
Part of [ADS-595](https://linear.app/a8c/issue/ADS-595/clean-up-error-logs)

## Proposed Changes

* Preserve the `dsp_stripe_pub_key` from `window.configData` (provided by the host) when it exists, instead of always overwriting it with the production key from `production.json`.

## Why are these changes being made?

The `load-config.js` merges `productionConfig` over `window.configData`, which overwrites the Stripe publishable key even when the host explicitly provides one. This prevents dev/test environments from using Stripe test mode — the browser creates SetupIntents against the test account, but the bundled live publishable key is used for confirmation, causing a mode mismatch error from Stripe.

This follows the same pattern already used in `load-config.js` for other host-provided values (`is_running_in_jetpack_site`, `is_running_in_blaze_plugin`, etc.).

In production, neither Jetpack nor Woo set `dsp_stripe_pub_key` in `configData`, so the bundled live key continues to apply. Worst case, if a host provides an invalid key, Stripe calls fail — no security implications since publishable keys are public by design and the server-side secret key is the actual gatekeeper.

## Testing Instructions

* Checkout this branch and sync the blaze-dashboard app to your sandbox:
```
$ cd apps/blaze-dashboard
$ yarn dev --sync
```
* To make the test easier, update the file `wp-calypso/apps/blaze-dashboard/src/load-config.js` and include this console.log: 
```
if ( window.configData?.dsp_stripe_pub_key ) {
	productionConfig.dsp_stripe_pub_key = window.configData.dsp_stripe_pub_key;
}

console.log( productionConfig.dsp_stripe_pub_key );
```
* Now, move the traffic from `widgets.wp.com` to your sandbox and access the advertising dashboard from any Jetpack site
* Check in the browser console that the logged stripe key is the pk_live key that is defined in `/Users/sebastianbarbosa/GIT/wp-calypso/config/production.json` (`dsp_stripe_pub_key` prop).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?