### PR TITLE
Dashboard: Keep sidebar menu item text gray on hover

### DIFF
--- a/client/dashboard/components/sidebar/sidebar-menu-item.scss
+++ b/client/dashboard/components/sidebar/sidebar-menu-item.scss
@@ -9,6 +9,10 @@
 	width: 100%;
 	color: var( --dashboard-menu-item__color );
 
+	&:hover:not( .active ) {
+		color: var( --dashboard-menu-item__color );
+	}
+
 	&.active {
 		background: color-mix( in srgb, var( --wp-admin-theme-color ) 8%, transparent );
 		color: var( --wp-admin-theme-color );


### PR DESCRIPTION
## Proposed Changes

* Add a `:hover:not(.active)` rule to `sidebar-menu-item.scss` so non-active sidebar items keep the base gray text color (`--dashboard-menu-item__color`) when hovered.

## Why are these changes being made?

The `@wordpress/components` Button `is-tertiary` variant applies a darker accent color (blue) on hover. The dashboard's sidebar styles override the base text color to gray (`--dashboard-menu-item__color`) but never override the hover color, so non-active items flipped to blue on hover. This brings the hover styling in line with the base styling.

Specificity check: the new selector `.components-button.dashboard-sidebar__menu-item:hover:not(.active)` resolves to `(0,3,1)`, matching the wp-components tertiary hover rule, and wins by source order since the dashboard SCSS loads after wp-components.

Active item hover styling (added in #109951) is unaffected because `.active` has higher specificity.

## Testing Instructions

1. Open the Dashboard at `/sites`.
2. Hover over any non-active menu item (e.g., **Themes**, **Plugins**, **Emails**) — text should stay gray (`#757575`) and not turn blue.
3. Hover over the active menu item — background and text should remain unchanged (theme-color blue, light blue tint).
4. Expand **Plugins** and hover the sub-menu items (**Manage plugins**, **Scheduled updates**) — they should also stay gray on hover.

<img width="320" height="416" alt="image" src="https://github.com/user-attachments/assets/dab48ad0-d543-4a9d-8a10-828037f979d6" />

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? (PCYsg-S3g-p2)