### PR TITLE
Reader: Rename sidebar item from Social to Social Feeds

### DIFF
--- a/client/reader/sidebar/reader-sidebar-connections/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-connections/index.tsx
@@ -235,7 +235,7 @@ function ReaderSidebarConnections( { path }: Props ) {
 		<li>
 			<ExpandableSidebarMenu
 				expanded={ isOpen }
-				title={ translate( 'Social' ) }
+				title={ translate( 'Social Feeds' ) }
 				customIcon={ <Icon className="sidebar__menu-icon" icon={ people } /> }
 				onClick={ handleMainClick }
 				expandableIconClick={ () => setIsOpen( ! isOpen ) }


### PR DESCRIPTION
Fixes CM-804

## Proposed Changes

* Rename the Reader sidebar item from "Social" to "Social Feeds".

## Why are these changes being made?

* "Social Feeds" is a clearer description of what this sidebar section contains.

## Testing Instructions

* Open the Reader.
* In the sidebar, confirm the menu item previously labeled "Social" now reads "Social Feeds".

Note: the page-level title in `client/reader/connections/social-overview-view.tsx` (NavigationHeader + DocumentHead) still reads "Social". This PR is scoped to the sidebar only — the overview view can be updated as follow-up if needed.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?