### PR TITLE
my-sites/earn: typed-`@wordpress/i18n` migration

### DIFF
--- a/client/my-sites/earn/components/add-edit-coupon-modal/products-selector.tsx
+++ b/client/my-sites/earn/components/add-edit-coupon-modal/products-selector.tsx
@@ -69,7 +69,7 @@ const ProductsSelector = ( {
 
 	/** Product functions */
 	const getProductDescription = ( product: Product ): string => {
-		const { title, currency, renewal_schedule, price } = product;
+		const { title = '', currency, renewal_schedule, price } = product;
 		const amount = formatCurrency( price ?? 0, currency ?? 'USD' );
 		switch ( renewal_schedule ) {
 			case '1 month':
@@ -99,7 +99,7 @@ const ProductsSelector = ( {
 					__( '%1$s : %2$s / %3$s', 'calypso' ),
 					title,
 					amount,
-					renewal_schedule
+					renewal_schedule ?? ''
 				);
 		}
 	};
@@ -108,7 +108,7 @@ const ProductsSelector = ( {
 		if ( allowMultiple ) {
 			if ( quantity > 1 ) {
 				// translators: the %s is a number representing the number of products which are currently selected
-				return sprintf( __( '%s products selected.' ), quantity );
+				return sprintf( __( '%s products selected.' ), String( quantity ) );
 			}
 			if ( quantity === 1 ) {
 				return __( '1 product selected' );


### PR DESCRIPTION
Fixes DOTCOM-17297

Part of #105909. Continues the decomposition of the renovate `@wordpress/i18n` 5.x → 6.x bump; this one covers `client/my-sites/earn/components/add-edit-coupon-modal/products-selector.tsx`.

## Proposed Changes

Resolves 5 type errors that surface when `@wordpress/i18n` is at `^6.x`, while remaining compatible with trunk's current `^5.23.0` pin.

The file's `getProductDescription` helper destructures four optional fields off `Product` (`title`, `currency`, `renewal_schedule`, `price`) and passes them as positional sprintf args into formats with `%s` placeholders. `Product.title`, `Product.renewal_schedule`, etc. are all `string | undefined`, but sprintf expects `string`.

* Defaulted `title` to `''` at the destructure site so all four branches benefit.
* Coerced `renewal_schedule ?? ''` at the only branch that uses it (the `'%1$s : %2$s / %3$s'` default branch).
* Coerced `quantity` (a `number`) to `String( quantity )` in the `selectedProductSummary` callback's `'%s products selected.'` sprintf.

## Testing Instructions

* `yarn typecheck-client` — clean on `trunk`. Verified locally clean against a dev `@wordpress/i18n@^6.20.0` install too.
* Smoke-test: open the Earn → Memberships → coupon modal, expand the product selector, and confirm the per-product description lines still render correctly (monthly / yearly / one-time / other schedules) and that the "X products selected." summary is correct.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?
