### PR TITLE
my-sites (scattered): typed-`@wordpress/i18n` migration

### DIFF
--- a/client/my-sites/customer-home/cards/features/site-preview/site-preview-ellipsis-menu.tsx
+++ b/client/my-sites/customer-home/cards/features/site-preview/site-preview-ellipsis-menu.tsx
@@ -26,7 +26,7 @@ export const SitePreviewEllipsisMenu = () => {
 				aria-label={ sprintf(
 					/* translators: %s is the site name */
 					__( 'More options for site %s' ),
-					selectedSite?.name
+					selectedSite?.name ?? ''
 				) }
 				ref={ moreButtonRef }
 				onClick={ () => setIsShowingPopover( ! isShowingPopover ) }

--- a/client/my-sites/domains/domain-management/settings/cards/domain-diagnostics-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-diagnostics-card.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { SET_UP_EMAIL_AUTHENTICATION_FOR_YOUR_DOMAIN } from '@automattic/urls';
-import { sprintf } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import Accordion from 'calypso/components/domains/accordion';
@@ -90,16 +90,16 @@ export default function DomainDiagnosticsCard( { domain }: { domain: ResponseDom
 			message = records[ recordType ].error_message ?? null;
 		} else if ( records[ recordType ].status === 'incorrect' ) {
 			message = sprintf(
-				/* translators: dnsRecordType is a DNS record type, e.g. SPF, DKIM or DMARC */
-				translate( 'Your %(dnsRecordType)s record is incorrect. The correct record should be:' ),
+				/* translators: %(dnsRecordType)s is a DNS record type, e.g. SPF, DKIM or DMARC */
+				__( 'Your %(dnsRecordType)s record is incorrect. The correct record should be:' ),
 				{
 					dnsRecordType: uppercaseRecord,
 				}
 			);
 		} else if ( records[ recordType ].status === 'not_found' ) {
 			message = sprintf(
-				/* translators: dnsRecordType is a DNS record type, e.g. SPF, DKIM or DMARC */
-				translate( 'There is no %(dnsRecordType)s record. The correct record should be:' ),
+				/* translators: %(dnsRecordType)s is a DNS record type, e.g. SPF, DKIM or DMARC */
+				__( 'There is no %(dnsRecordType)s record. The correct record should be:' ),
 				{
 					dnsRecordType: uppercaseRecord,
 				}

--- a/client/my-sites/email/email-forwards-add/add-new-form/utils.tsx
+++ b/client/my-sites/email/email-forwards-add/add-new-form/utils.tsx
@@ -1,4 +1,4 @@
-import { sprintf } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import emailValidator from 'email-validator';
 import type { ValidationError } from './types';
 import type { EmailAccountEmail } from 'calypso/data/emails/types';
@@ -42,8 +42,8 @@ export function isValidDestination(
 			return {
 				severity: 'warning',
 				message: sprintf(
-					/* translators: %s: email address %s: email address */
-					translate( 'There is already a forward from (%1$s) to (%2$s).' ),
+					/* translators: %1$s is the existing forward source email address, %2$s is the existing forward destination email address */
+					__( 'There is already a forward from (%1$s) to (%2$s).' ),
 					`${ mailbox }@${ selectedDomainName }`,
 					value
 				),

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/no-plans.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/no-plans.tsx
@@ -67,11 +67,11 @@ export default function NoPlans( { cardData, selectedSite, engine, onStartImport
 			<div className="no-plans__info">
 				<p>
 					{ sprintf(
-						// translators: %d is the Stripe account name
+						// translators: %s is the Stripe account name
 						__(
 							'It looks like the Stripe Account (%s) does not have any active plans. Are you sure you connected the same Stripe account that you use on Substack?'
 						),
-						cardData?.account_display
+						cardData?.account_display ?? ''
 					) }
 				</p>
 			</div>

--- a/client/my-sites/importer/newsletter/summary/index.tsx
+++ b/client/my-sites/importer/newsletter/summary/index.tsx
@@ -161,7 +161,7 @@ export default function Summary( {
 					{ sprintf(
 						// translators: %s the site name
 						__( 'Here’s a summary of the imported data to %s:' ),
-						selectedSite.name
+						selectedSite.name ?? ''
 					) }
 				</p>
 				<div className="summary__content">

--- a/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
@@ -79,13 +79,13 @@ export default function CampaignItem( props: Props ) {
 		spendString = is_evergreen
 			? sprintf(
 					/* translators: %s is a formatted amount */
-					translate( '%s weekly' ),
+					__( '%s weekly' ),
 					formattedTotalSpend
 			  )
 			: formattedTotalSpend;
 		spendStringMobile = sprintf(
 			/* translators: %s is a formatted amount */
-			translate( '%s spend' ),
+			__( '%s spend' ),
 			formattedTotalSpend
 		);
 	}

--- a/client/my-sites/promote-post-i2/components/debt-notifier/index.tsx
+++ b/client/my-sites/promote-post-i2/components/debt-notifier/index.tsx
@@ -1,18 +1,18 @@
-import { sprintf } from '@wordpress/i18n';
-import { useTranslate } from 'i18n-calypso';
+import { __, sprintf } from '@wordpress/i18n';
 import React from 'react';
 import useBillingSummaryQuery from 'calypso/data/promote-post/use-promote-post-billing-summary-query';
 
 function DebtNotifier() {
-	const translate = useTranslate();
-
 	const { data } = useBillingSummaryQuery();
 	const debt = data?.debt ?? '0.00';
 
 	if ( debt !== '0.00' ) {
 		return (
 			<div className="promote-post-i2__debt-notifier">
-				{ sprintf( translate( 'Current debt is $%s.' ), debt.replace( '.00', '' ) ) }
+				{
+					/* translators: %s is the current debt amount in dollars */
+					sprintf( __( 'Current debt is $%s.' ), debt.replace( '.00', '' ) )
+				}
 			</div>
 		);
 	}


### PR DESCRIPTION
Fixes DOTCOM-17298

Part of #105909. Final my-sites sub-area; covers seven small surfaces that didn't fit the checkout, plans/trials, or earn buckets.

## Proposed Changes

Resolves 9 type errors across 7 files so the code compiles against both `@wordpress/i18n@^5.23.0` (trunk's pin) and `@wordpress/i18n@^6.x` (what #105909 wants).

Two patterns:

**Pattern A — sprintf positional arg of type `string | undefined` fed a `%s` placeholder.** Coerced with `?? ''` at the call site:

* `customer-home/.../site-preview-ellipsis-menu.tsx` — `selectedSite?.name`
* `importer/newsletter/subscribers/paid-subscribers/no-plans.tsx` — `cardData?.account_display`
* `importer/newsletter/summary/index.tsx` — `selectedSite.name`

**Pattern B — `sprintf( translate( 'fmt %s' ), x )` where `translate()` from `i18n-calypso` returns plain `string`,** defeating the typed-sprintf parser. Switched these specific format strings to `__()` from `@wordpress/i18n` (keeping the rest of each file's `translate()` usage):

* `domains/domain-management/settings/cards/domain-diagnostics-card.tsx` — two formats (incorrect record / record not found)
* `email/email-forwards-add/add-new-form/utils.tsx` — the "There is already a forward …" validation message
* `promote-post-i2/components/campaign-item/index.tsx` — `'%s weekly'` and `'%s spend'`
* `promote-post-i2/components/debt-notifier/index.tsx` — `'Current debt is $%s.'`. Also dropped the now-unused `useTranslate()` import + local from this file.

## Drive-by lint cleanups

Pre-existing on trunk, caught by per-file `lint-staged`: tightened the translator comments in the touched files to reference the actual placeholder names (`%(...)`/`%1$s`), and added a translator comment above the debt-notifier sprintf.

## Testing Instructions

* `yarn typecheck-client` — clean on `trunk`. Verified locally clean against a dev `@wordpress/i18n@^6.20.0` install too.
* Smoke-test the affected surfaces: a site's ellipsis menu in customer-home → site preview; the Substack importer's "no plans" warning; the newsletter import success summary; domain diagnostics with bad SPF/DKIM/DMARC; the email-forward "already a forward" validation; a promote-post campaign card; the debt-notifier on a billed promote-post account.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?
