### PR TITLE
Classic Calypso (scattered): typed-`@wordpress/i18n` migration

### DIFF
--- a/client/a8c-for-agencies/sections/benchmarks/lib/format-quarter.ts
+++ b/client/a8c-for-agencies/sections/benchmarks/lib/format-quarter.ts
@@ -4,19 +4,19 @@ import type { Quarter } from '../constants';
 // "Q3 24" — short label used in delta pill, trend axis, and footer caption.
 export function formatQuarterShort( { quarter, year }: Quarter ): string {
 	return sprintf(
-		/* translators: %1$d: quarter number, %2$d: 2-digit year. Example: Q3 24 */
-		__( 'Q%1$d %2$02d' ),
-		quarter,
-		year % 100
+		/* translators: %1$s: quarter number, %2$s: 2-digit year. Example: Q3 24 */
+		__( 'Q%1$s %2$s' ),
+		String( quarter ),
+		String( year % 100 ).padStart( 2, '0' )
 	);
 }
 
 // "Q3 2024" — full label used in the header quarter selector and related copy.
 export function formatQuarterLong( { quarter, year }: Quarter ): string {
 	return sprintf(
-		/* translators: %1$d: quarter number, %2$d: 4-digit year. Example: Q3 2024 */
-		__( 'Q%1$d %2$d' ),
-		quarter,
-		year
+		/* translators: %1$s: quarter number, %2$s: 4-digit year. Example: Q3 2024 */
+		__( 'Q%1$s %2$s' ),
+		String( quarter ),
+		String( year )
 	);
 }

--- a/client/blocks/import/ready/platform-details.tsx
+++ b/client/blocks/import/ready/platform-details.tsx
@@ -205,7 +205,7 @@ const ImportPlatformDetails: React.FunctionComponent< DetailsProps > = ( data ) 
 											/* translators: %(plan)s: name of plan */
 											__( 'Requires a %(plan)s plan.' ),
 											{
-												plan: plan?.getTitle() ?? '',
+												plan: ( plan?.getTitle() ?? '' ) as string,
 											}
 										) }
 									</i>

--- a/client/components/activity-card/activity-actor.tsx
+++ b/client/components/activity-card/activity-actor.tsx
@@ -1,6 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
-import { sprintf } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { translate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import Gravatar from 'calypso/components/gravatar';
@@ -98,7 +98,11 @@ const ActivityActor: FunctionComponent< Props > = ( {
 	let mcpIndicator = null;
 	if ( actorIsMcpAgent ) {
 		mcpIndicator = actorMcpClient
-			? sprintf( translate( 'via %s (MCP)' ), actorMcpClient )
+			? sprintf(
+					/* translators: %s is the MCP client name and version */
+					__( 'via %s (MCP)' ),
+					actorMcpClient
+			  )
 			: translate( 'via MCP' );
 	}
 

--- a/client/components/calypso-i18n-provider/index.tsx
+++ b/client/components/calypso-i18n-provider/index.tsx
@@ -4,6 +4,7 @@ import { defaultI18n } from '@wordpress/i18n';
 import { I18nProvider } from '@wordpress/react-i18n';
 import defaultCalypsoI18n, { I18NContext } from 'i18n-calypso';
 import { useState, useEffect } from 'react';
+import type { LocaleData } from '@wordpress/i18n';
 import type { I18N } from 'i18n-calypso';
 import type { FunctionComponent } from 'react';
 
@@ -15,7 +16,7 @@ const CalypsoI18nProvider: FunctionComponent< { i18n?: I18N; children?: React.Re
 
 	useEffect( () => {
 		const onChange = () => {
-			defaultI18n.setLocaleData( i18n.getLocale() );
+			defaultI18n.setLocaleData( i18n.getLocale() as LocaleData );
 			setLocaleSlug( i18n.getLocaleSlug() );
 		};
 
@@ -23,7 +24,7 @@ const CalypsoI18nProvider: FunctionComponent< { i18n?: I18N; children?: React.Re
 	}, [ i18n ] );
 
 	useEffect( () => {
-		defaultI18n.resetLocaleData( i18n.getLocale() );
+		defaultI18n.resetLocaleData( i18n.getLocale() as LocaleData );
 
 		if ( localeSlug ) {
 			// Propagate the locale to @automattic/number-formatters

--- a/client/components/eligibility-warnings/domain-warning/index.tsx
+++ b/client/components/eligibility-warnings/domain-warning/index.tsx
@@ -15,12 +15,12 @@ const DomainEligibilityWarning = ( {
 		<InfoLabel label={ __( 'New' ) }>{ stagingDomain }</InfoLabel>
 		<p>
 			{ sprintf(
-				/* translators: %s: The wordpress domain (ex.: myawesomeblog.wordpress.com) */
+				/* translators: %1$s is the current wordpress.com subdomain (e.g. myawesomeblog.wordpress.com), %2$s is the new staging subdomain that traffic will be redirected to. */
 				__(
 					'By installing this product your subdomain will change. Your old subdomain (%1$s) will redirect to your new subdomain (%2$s). You can change it to a custom domain at anytime in the future.'
 				),
-				wpcomDomain,
-				stagingDomain
+				wpcomDomain ?? '',
+				stagingDomain ?? ''
 			) }
 		</p>
 	</Card>

--- a/client/components/site-selector/sites-list.tsx
+++ b/client/components/site-selector/sites-list.tsx
@@ -76,10 +76,10 @@ const SitesList = ( {
 									sprintf(
 										// translators: maxResults is the maximum number of list results.
 										__(
-											'Only displaying the first %(maxResults)d sites.<br />Use search to refine.'
+											'Only displaying the first %(maxResults)d sites.<br/>Use search to refine.'
 										),
 										{
-											maxResults,
+											maxResults: maxResults ?? 0,
 										}
 									),
 									{

--- a/client/hosting/performance/components/PerformanceReportLoading.tsx
+++ b/client/hosting/performance/components/PerformanceReportLoading.tsx
@@ -50,7 +50,6 @@ export const PerformanceReportLoading = ( {
 										onClick={ handleRetestClick }
 									/>
 								),
-								br: <br />,
 							}
 						) }
 				</p>

--- a/client/me/security-ssh-key/security-ssh-key.tsx
+++ b/client/me/security-ssh-key/security-ssh-key.tsx
@@ -97,7 +97,7 @@ export const SecuritySSHKey = ( { queryParams }: SecuritySSHKeyProps ) => {
 			);
 			dispatch(
 				errorNotice(
-					// translators: "reason" is why adding the ssh key failed.
+					// translators: %(reason)s is why adding the ssh key failed.
 					sprintf( __( 'Failed to save SSH key: %(reason)s' ), { reason: error.message } ),
 					{
 						...noticeOptions,
@@ -121,7 +121,7 @@ export const SecuritySSHKey = ( { queryParams }: SecuritySSHKeyProps ) => {
 			);
 			dispatch(
 				errorNotice(
-					// translators: "reason" is why deleting the ssh key failed.
+					// translators: %(reason)s is why deleting the ssh key failed.
 					sprintf( __( 'Failed to delete SSH key: %(reason)s' ), { reason: error.message } ),
 					noticeOptions
 				)
@@ -148,7 +148,7 @@ export const SecuritySSHKey = ( { queryParams }: SecuritySSHKeyProps ) => {
 			);
 			dispatch(
 				errorNotice(
-					// translators: "reason" is why adding the ssh key failed.
+					// translators: %(reason)s is why adding the ssh key failed.
 					sprintf( __( 'Failed to update SSH key: %(reason)s' ), { reason: error.message } ),
 					{
 						...noticeOptions,
@@ -200,8 +200,8 @@ export const SecuritySSHKey = ( { queryParams }: SecuritySSHKeyProps ) => {
 							__(
 								'Once added, attach the SSH key to a site with a %1$s or %2$s plan to enable SSH key authentication for that site.'
 							),
-							getPlan( PLAN_BUSINESS )?.getTitle() || '',
-							getPlan( PLAN_ECOMMERCE )?.getTitle() || ''
+							( getPlan( PLAN_BUSINESS )?.getTitle() ?? '' ) as string,
+							( getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '' ) as string
 						) }
 					</p>
 					<p style={ isLoading || hasKeys ? { marginBlockEnd: 0 } : undefined }>
@@ -210,7 +210,6 @@ export const SecuritySSHKey = ( { queryParams }: SecuritySSHKeyProps ) => {
 								'If the SSH key is removed from your WordPress.com account, it will also be removed from all attached sites. <a>Read more.</a>'
 							),
 							{
-								br: <br />,
 								a: <InlineSupportLink supportContext="generate-ssh-key" showIcon={ false } />,
 							}
 						) }

--- a/client/reader/onboarding-rsm/interests-modal/topic-group-card/index.tsx
+++ b/client/reader/onboarding-rsm/interests-modal/topic-group-card/index.tsx
@@ -108,8 +108,8 @@ const TopicGroupCard: React.FC< TopicGroupCardProps > = ( {
 		  )
 		: '';
 	const meta = [ tagSummary, blogSummary ].filter( Boolean ).join( ' · ' );
-	let subscribeLabel = __( 'Subscribe' );
-	let subscribeAriaLabel = sprintf(
+	let subscribeLabel: string = __( 'Subscribe' );
+	let subscribeAriaLabel: string = sprintf(
 		/* translators: %s is the topic pack title. */
 		__( 'Subscribe to %s' ),
 		title

--- a/client/signup/steps/woocommerce-install/transfer/progress.tsx
+++ b/client/signup/steps/woocommerce-install/transfer/progress.tsx
@@ -4,7 +4,7 @@ import StepContent from './step-content';
 
 export default function Progress( { progress }: { progress: number } ) {
 	const { __ } = useI18n();
-	const [ step, setStep ] = useState( __( 'Building your store' ) );
+	const [ step, setStep ] = useState< string >( __( 'Building your store' ) );
 
 	// Progress smoothing, works out to be around 40seconds unless step polling dictates otherwise
 	const [ simulatedProgress, setSimulatedProgress ] = useState( 0.01 );


### PR DESCRIPTION
Fixes DOTCOM-17299

Part of #105909. **Final sweep PR** in the decomposition of the renovate `@wordpress/i18n` 5.x → 6.x bump.

## Proposed Changes

Resolves 16 type errors across 10 small surfaces in `client/{a8c-for-agencies,blocks,components,hosting,me,reader,signup}` so the code compiles against both `^5.23.0` (trunk's pin) and `^6.x` (what #105909 wants).

Patterns applied (matching the [other PRs in this stack](https://github.com/Automattic/wp-calypso/pulls?q=is%3Apr+is%3Aopen+typed-%40wordpress%2Fi18n+migration)):

* **TS2769 / 0-arg overload selected for `sprintf`** — caused by positional `%NN$d` placeholders that typed-sprintf doesn't parse, or by `sprintf( translate( ... ), ... )` where `translate()` from `i18n-calypso` returns plain `string`.
  * `a8c-for-agencies/sections/benchmarks/lib/format-quarter.ts` — `%1$d %2$02d` / `%1$d %2$d` formats. Pre-formatted with `String(...)` + `padStart(2, '0')` and switched to `%1$s %2$s`.
  * `components/activity-card/activity-actor.tsx` — switched the `'via %s (MCP)'` format to `__()` (rest of the file keeps `translate()`).
* **TS2345 — `sprintf` positional arg of nullable type fed a typed placeholder.** Coerced with `?? ''` / `?? 0` / `as string`:
  * `eligibility-warnings/domain-warning/index.tsx` — `wpcomDomain`, `stagingDomain`.
  * `site-selector/sites-list.tsx` — `maxResults`.
  * `blocks/import/ready/platform-details.tsx` and `me/security-ssh-key/security-ssh-key.tsx` — `plan?.getTitle()` (`TranslateResult` → `string`).
* **TS2353 — `createInterpolateElement` args contain a key not in the format string, or a `<tag />` with a space before `/>`.**
  * `site-selector/sites-list.tsx` — `<br />` → `<br/>`.
  * `hosting/performance/components/PerformanceReportLoading.tsx` and `me/security-ssh-key/security-ssh-key.tsx` — removed unused `br: <br />` entries (the format strings don't declare a `<br>`).
* **TS2322 — over-narrow `TransformedText<T>` inference.**
  * `reader/onboarding-rsm/interests-modal/topic-group-card/index.tsx` — `let subscribeLabel: string = __('Subscribe')` plus the matching `subscribeAriaLabel` reassigned across Subscribe / Subscribing / Subscribed.
  * `signup/steps/woocommerce-install/transfer/progress.tsx` — `useState< string >( __('Building your store') )` so the `setStep` calls accepting other literals type-check.
* **TS2345 — `defaultI18n.setLocaleData( i18n.getLocale() )`** in `components/calypso-i18n-provider/index.tsx`. The Calypso `i18n`'s `getLocale()` returns its own untyped `LocaleData`, while `@wordpress/i18n` types the parameter as `LocaleData<string>` (defaulted generic). Cast each call's arg to `@wordpress/i18n`'s `LocaleData`.

## Drive-by lint cleanups

Pre-existing on trunk, caught by per-file `lint-staged`: tightened the translator comments in `eligibility-warnings/domain-warning/index.tsx` and `me/security-ssh-key/security-ssh-key.tsx` to reference the actual placeholder names.

## Testing Instructions

* `yarn typecheck-client` — clean on `trunk`. Verified locally clean against a dev `@wordpress/i18n@^6.20.0` install too.
* Smoke-test the touched surfaces: the AfA benchmarks "Q3 24" labels; the Substack/Wix etc. importer "platform details" modal; an activity log entry where the actor is an MCP agent; the eligibility warning that says "your subdomain will change"; the site-selector showing more than its `maxResults`; the Reader onboarding subscribe button in its Subscribe / Subscribing / Subscribed states; the WooCommerce signup transfer progress steps.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?
