### PR TITLE
Fix Reader Chat theme style leakage

### DIFF
--- a/apps/agents-manager/__tests__/reader-chat.test.js
+++ b/apps/agents-manager/__tests__/reader-chat.test.js
@@ -49,11 +49,14 @@ jest.mock(
 
 // Provide a minimal JetpackReaderChatConfig so the module-level readerConfig
 // is safe to read (no currentPost by default — exercises the no-post branch).
+let getElementByIdSpy;
+const getElementById = document.getElementById.bind( document );
+
 beforeAll( () => {
 	globalThis.window.JetpackReaderChatConfig = {};
 	// Suppress the top-level DOM mount — the container lookup returns null so
 	// the `if ( container )` branch is skipped entirely.
-	jest.spyOn( document, 'getElementById' ).mockReturnValue( null );
+	getElementByIdSpy = jest.spyOn( document, 'getElementById' ).mockReturnValue( null );
 } );
 
 // Import after mocks are registered.
@@ -72,7 +75,57 @@ const {
 	normalizeSuggestions,
 	parseSuggestionsResponse,
 	getSuggestionsFetchHeaders,
+	injectScopedReset,
 } = require( '../reader-chat' );
+
+// ---------------------------------------------------------------------------
+// injectScopedReset
+// ---------------------------------------------------------------------------
+
+describe( 'injectScopedReset', () => {
+	beforeEach( () => {
+		document.head.querySelector( '#jetpack-reader-chat-reset' )?.remove();
+		getElementByIdSpy.mockImplementation( getElementById );
+	} );
+
+	afterEach( () => {
+		getElementByIdSpy.mockReturnValue( null );
+	} );
+
+	it( 'pins widget typography and resets leaked theme button styles', () => {
+		injectScopedReset();
+
+		const css = document.head.querySelector( '#jetpack-reader-chat-reset' ).textContent;
+
+		expect( css ).toContain( 'font-size: 16px !important;' );
+		expect( css ).toContain( '--base-font-size: 16px !important;' );
+		expect( css ).toContain( '.agents-manager-chat .components-button.has-icon' );
+		expect( css ).toContain(
+			'.agents-manager-chat .agents-manager-copy-action-button.components-button.has-icon'
+		);
+		expect( css ).toContain( 'text-transform: none !important;' );
+		expect( css ).toContain( 'letter-spacing: inherit !important;' );
+		expect( css ).toContain( 'background: transparent !important;' );
+		expect( css ).toContain( 'color: var( --color-foreground, #1e1e1e ) !important;' );
+		expect( css ).toContain(
+			'background: var( --color-muted, rgba( 0, 0, 0, 0.06 ) ) !important;'
+		);
+		expect( css ).toContain( ':not([aria-disabled="true"])' );
+		expect( css ).toContain( '.agents-manager-chat-header__menu-popover' );
+		expect( css ).toContain(
+			'.agents-manager-chat-header__menu-popover .components-dropdown-menu__menu-item[aria-disabled="true"]'
+		);
+		expect( css ).toContain( 'cursor: default !important;' );
+		expect( css ).toContain( 'opacity: 0.5 !important;' );
+	} );
+
+	it( 'does not inject duplicate reset styles', () => {
+		injectScopedReset();
+		injectScopedReset();
+
+		expect( document.head.querySelectorAll( '#jetpack-reader-chat-reset' ) ).toHaveLength( 1 );
+	} );
+} );
 
 // ---------------------------------------------------------------------------
 // parseAgentSseResponse

--- a/apps/agents-manager/reader-chat.js
+++ b/apps/agents-manager/reader-chat.js
@@ -77,6 +77,8 @@ function injectScopedReset() {
 		.agents-manager-chat button {
 			font-family: inherit !important;
 			font-size: inherit !important;
+			letter-spacing: inherit !important;
+			text-transform: none !important;
 		}
 		/*
 		 * Themes often give inputs/textareas thick borders that leak
@@ -94,8 +96,100 @@ function injectScopedReset() {
 		}
 		#jetpack-reader-chat,
 		.agents-manager-chat {
+			font-size: 16px !important;
 			line-height: 1.5 !important;
 			color: #1e1e1e !important;
+		}
+		/*
+		 * The .agenttic widget's sizes are derived from --base-font-size. Some blog
+		 * themes set html { font-size: 62.5%; }, which shrinks every rem in
+		 * the widget. Pin the wrapper and widget base to px so inherited em
+		 * text and rem-derived spacing do not inherit the host page's scale.
+		 */
+		.agents-manager-chat .agenttic {
+			--base-font-size: 16px !important;
+		}
+		.agents-manager-chat .components-button {
+			-webkit-appearance: none !important;
+			appearance: none !important;
+			font-family: inherit !important;
+			font-size: inherit !important;
+			font-weight: 400 !important;
+			letter-spacing: normal !important;
+			line-height: normal !important;
+			text-decoration: none !important;
+			text-transform: none !important;
+		}
+		.agents-manager-chat .components-button.has-icon {
+			align-items: center !important;
+			background: transparent !important;
+			border: 0 !important;
+			border-radius: 4px !important;
+			box-shadow: none !important;
+			color: var( --color-foreground, #1e1e1e ) !important;
+			display: inline-flex !important;
+			justify-content: center !important;
+			margin: 0 !important;
+		}
+		.agents-manager-chat .agents-manager-chat-header .components-button.has-icon,
+		.agents-manager-chat .agents-manager-copy-action-button.components-button.has-icon,
+		.agents-manager-chat .agents-manager-zoom-action-button.components-button.has-icon {
+			height: 32px !important;
+			padding: 6px !important;
+			width: 32px !important;
+		}
+		.agents-manager-chat .agents-manager-chat-header .components-button.has-icon:hover:not(:disabled):not([aria-disabled="true"]),
+		.agents-manager-chat .agents-manager-copy-action-button.components-button.has-icon:hover:not(:disabled):not([aria-disabled="true"]),
+		.agents-manager-chat .agents-manager-zoom-action-button.components-button.has-icon:hover:not(:disabled):not([aria-disabled="true"]) {
+			background: var( --color-muted, rgba( 0, 0, 0, 0.06 ) ) !important;
+		}
+		.agents-manager-chat-header__menu-popover {
+			--color-foreground: #1e1e1e;
+			--color-muted: rgba( 0, 0, 0, 0.06 );
+			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", Arial, sans-serif !important;
+			font-size: 13px !important;
+			line-height: 1.4 !important;
+			color: var( --color-foreground, #1e1e1e ) !important;
+		}
+		.agents-manager-chat-header__menu-popover .components-button,
+		.agents-manager-chat-header__menu-popover .components-dropdown-menu__menu-item {
+			-webkit-appearance: none !important;
+			appearance: none !important;
+			background: transparent !important;
+			border: 0 !important;
+			box-shadow: none !important;
+			color: var( --color-foreground, #1e1e1e ) !important;
+			font-family: inherit !important;
+			font-size: inherit !important;
+			font-weight: 400 !important;
+			letter-spacing: normal !important;
+			line-height: inherit !important;
+			text-decoration: none !important;
+			text-transform: none !important;
+		}
+		.agents-manager-chat-header__menu-popover .components-dropdown-menu__menu-item {
+			align-items: center !important;
+			display: flex !important;
+			gap: 8px !important;
+			height: auto !important;
+			justify-content: flex-start !important;
+			min-height: 32px !important;
+			padding: 6px 8px !important;
+			text-align: left !important;
+			width: 100% !important;
+		}
+		.agents-manager-chat-header__menu-popover .components-dropdown-menu__menu-item:hover:not(:disabled):not([aria-disabled="true"]) {
+			background: var( --color-muted, rgba( 0, 0, 0, 0.06 ) ) !important;
+		}
+		.agents-manager-chat-header__menu-popover .components-dropdown-menu__menu-item[aria-disabled="true"],
+		.agents-manager-chat-header__menu-popover .components-dropdown-menu__menu-item:disabled {
+			background: transparent !important;
+			color: var( --color-foreground, #1e1e1e ) !important;
+			cursor: default !important;
+			opacity: 0.5 !important;
+		}
+		.agents-manager-chat-header__menu-popover .components-dropdown-menu__menu-item svg {
+			fill: currentColor !important;
 		}
 		/*
 		 * wp-components dropdown/menu fix: the popover is portalled to body
@@ -969,7 +1063,7 @@ if ( container ) {
 	setupInitialSuggestions();
 }
 
-// Exported for unit tests only — these are pure helpers with no side effects.
+// Exported for unit tests only; injectScopedReset mutates document.head.
 export {
 	parseAgentSseResponse,
 	slugify,
@@ -982,4 +1076,5 @@ export {
 	normalizeSuggestions,
 	parseSuggestionsResponse,
 	getSuggestionsFetchHeaders,
+	injectScopedReset,
 };

--- a/packages/agents-manager/src/components/chat-header/index.tsx
+++ b/packages/agents-manager/src/components/chat-header/index.tsx
@@ -40,6 +40,10 @@ export default function ChatHeader( { onClose, options, title, onBack }: Props )
 					controls={ options }
 					icon={ moreVertical }
 					label={ __( 'More Options', '__i18n_text_domain__' ) }
+					// Body-level popovers need a stable anchor for public host style isolation.
+					popoverProps={ {
+						className: 'agents-manager-chat-header__menu-popover',
+					} }
 					toggleProps={ { size: 'small' } }
 				/>
 				{ /*


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Pin the public Reader Chat reset to a 16px widget base so host themes that change the root `rem` scale do not shrink the chat UI.
* Reset Reader Chat header `@wordpress/components` icon buttons inside the widget so global theme button styles do not leak into the More/Close controls.
* Add unit coverage for the injected reset CSS and duplicate-style idempotency.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Reader Chat runs directly in the host blog DOM. On the affected GoDaddy/Twenty Twenty test site, the host page sets `html { font-size: 62.5%; }` and broad `button` styles, which made Reader Chat text render too small and turned the header icon buttons into theme-colored buttons.
* The widget already has a scoped reset for public blog frontends; this extends that reset to cover the observed font scale and button leakage without changing shared Agents Manager behavior elsewhere.

## Testing Instructions
- Install this PR to your sandbox `install-plugin.sh am fix/reader-chat-css-isolation`
- Sandbox widgets.wp.com
- Visit https://gd.testjetpack.blog/ and verify Reader Chat is loading properly and styles are fixed
- Also verify with normal WP account https://kat3samsinsandbox.wordpress.com
<img width="444" height="557" alt="image" src="https://github.com/user-attachments/assets/4d3789b5-4506-4a94-8f19-6e113815d909" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
