### PR TITLE
Add downgrade confirmation modal with accurate feature deltas

### DIFF
--- a/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/index.tsx
+++ b/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/index.tsx
@@ -1,0 +1,152 @@
+import {
+	getFeatureDifference,
+	getFeatureByKey,
+	getPlan,
+	getPlanPath,
+	type PlanSlug,
+} from '@automattic/calypso-products';
+import {
+	Modal,
+	Button,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	Icon,
+} from '@wordpress/components';
+import { close } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import { addQueryArgs } from 'calypso/lib/url';
+import { useSelector } from 'calypso/state';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
+
+import './style.scss';
+
+interface DowngradeConfirmationModalProps {
+	isOpen: boolean;
+	currentPlanSlug: PlanSlug;
+	targetPlanSlug: PlanSlug | null;
+	siteId: number | null | undefined;
+	redirectTo?: string;
+	onClose: () => void;
+}
+
+const DowngradeConfirmationModal = ( {
+	isOpen,
+	currentPlanSlug,
+	targetPlanSlug,
+	siteId,
+	redirectTo,
+	onClose,
+}: DowngradeConfirmationModalProps ) => {
+	const translate = useTranslate();
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
+
+	const lostFeatures = useMemo( () => {
+		if ( ! targetPlanSlug ) {
+			return [];
+		}
+		const featureSlugs = getFeatureDifference(
+			targetPlanSlug,
+			currentPlanSlug,
+			'getCancellationFeatures'
+		);
+		return featureSlugs
+			.map( ( slug ) => getFeatureByKey( slug ) )
+			.filter( ( feature ): feature is NonNullable< typeof feature > => !! feature );
+	}, [ targetPlanSlug, currentPlanSlug ] );
+
+	if ( ! targetPlanSlug || ! isOpen ) {
+		return null;
+	}
+
+	const currentPlanTitle = getPlan( currentPlanSlug )?.getTitle() ?? '';
+	const targetPlanTitle = getPlan( targetPlanSlug )?.getTitle() ?? '';
+
+	const handleConfirm = () => {
+		const planPath = getPlanPath( targetPlanSlug );
+		if ( ! planPath || ! siteSlug ) {
+			return;
+		}
+		const checkoutUrl = `/checkout/${ encodeURIComponent( siteSlug ) }/${ planPath }`;
+		const cancelTo = window.location.href.replace( window.location.origin, '' );
+		const finalUrl = addQueryArgs(
+			{
+				...( redirectTo && { redirect_to: redirectTo } ),
+				cancel_to: cancelTo,
+				expired_downgrade: 'true',
+			},
+			checkoutUrl
+		);
+		window.location.assign( finalUrl );
+	};
+
+	return (
+		<Modal
+			title={ String(
+				translate( 'Confirm your plan change', {
+					comment: 'Title of the confirmation modal when downgrading an expired plan',
+				} )
+			) }
+			onRequestClose={ onClose }
+			className="downgrade-confirmation-modal"
+		>
+			<VStack spacing={ 4 }>
+				{ lostFeatures.length > 0 ? (
+					<>
+						<p>
+							{ translate(
+								"You're changing from %(currentPlan)s to %(targetPlan)s. You'll lose access to these features:",
+								{
+									args: {
+										currentPlan: currentPlanTitle,
+										targetPlan: targetPlanTitle,
+									},
+									comment:
+										'Message shown when downgrading an expired plan, listing features that will be lost',
+								}
+							) }
+						</p>
+						<VStack as="ul" spacing={ 1 } className="downgrade-confirmation-modal__feature-list">
+							{ lostFeatures.map( ( feature ) => (
+								<HStack as="li" key={ feature.getSlug() } spacing={ 2 } justify="flex-start">
+									<Icon
+										icon={ close }
+										size={ 24 }
+										className="downgrade-confirmation-modal__feature-icon"
+									/>
+									<span>{ feature.getTitle() }</span>
+								</HStack>
+							) ) }
+						</VStack>
+					</>
+				) : (
+					<p>
+						{ translate( "You're changing from %(currentPlan)s to %(targetPlan)s.", {
+							args: {
+								currentPlan: currentPlanTitle,
+								targetPlan: targetPlanTitle,
+							},
+							comment: 'Message shown when downgrading an expired plan with no feature differences',
+						} ) }
+					</p>
+				) }
+				<HStack spacing={ 3 } justify="flex-start">
+					<Button __next40pxDefaultSize variant="primary" onClick={ handleConfirm }>
+						{ translate( 'Downgrade to %(planName)s', {
+							args: { planName: targetPlanTitle },
+							comment: 'Button label to confirm downgrading to a lower-tier plan',
+						} ) }
+					</Button>
+					<Button __next40pxDefaultSize variant="secondary" onClick={ onClose }>
+						{ translate( 'Keep %(planName)s', {
+							args: { planName: currentPlanTitle },
+							comment: 'Button label to dismiss the downgrade modal and keep the current plan',
+						} ) }
+					</Button>
+				</HStack>
+			</VStack>
+		</Modal>
+	);
+};
+
+export default DowngradeConfirmationModal;

--- a/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/index.tsx
+++ b/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/index.tsx
@@ -5,14 +5,8 @@ import {
 	getPlanPath,
 	type PlanSlug,
 } from '@automattic/calypso-products';
-import {
-	Modal,
-	Button,
-	__experimentalVStack as VStack,
-	__experimentalHStack as HStack,
-	Icon,
-} from '@wordpress/components';
-import { close } from '@wordpress/icons';
+import { Gridicon } from '@automattic/components';
+import { Button, Modal, __experimentalHStack as HStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -82,69 +76,69 @@ const DowngradeConfirmationModal = ( {
 
 	return (
 		<Modal
-			title={ String(
-				translate( 'Confirm your plan change', {
-					comment: 'Title of the confirmation modal when downgrading an expired plan',
-				} )
-			) }
+			title={ String( translate( 'Confirm downgrade' ) ) }
 			onRequestClose={ onClose }
 			className="downgrade-confirmation-modal"
+			size="medium"
 		>
-			<VStack spacing={ 4 }>
-				{ lostFeatures.length > 0 ? (
-					<>
-						<p>
-							{ translate(
-								"You're changing from %(currentPlan)s to %(targetPlan)s. You'll lose access to these features:",
-								{
-									args: {
-										currentPlan: currentPlanTitle,
-										targetPlan: targetPlanTitle,
-									},
-									comment:
-										'Message shown when downgrading an expired plan, listing features that will be lost',
-								}
-							) }
-						</p>
-						<VStack as="ul" spacing={ 1 } className="downgrade-confirmation-modal__feature-list">
-							{ lostFeatures.map( ( feature ) => (
-								<HStack as="li" key={ feature.getSlug() } spacing={ 2 } justify="flex-start">
-									<Icon
-										icon={ close }
-										size={ 24 }
-										className="downgrade-confirmation-modal__feature-icon"
-									/>
-									<span>{ feature.getTitle() }</span>
-								</HStack>
-							) ) }
-						</VStack>
-					</>
-				) : (
-					<p>
-						{ translate( "You're changing from %(currentPlan)s to %(targetPlan)s.", {
+			{ lostFeatures.length > 0 ? (
+				<>
+					<p className="downgrade-confirmation-modal__description">
+						{ translate(
+							"When you change from %(currentPlan)s to %(targetPlan)s, here's what you'll lose:",
+							{
+								args: {
+									currentPlan: currentPlanTitle,
+									targetPlan: targetPlanTitle,
+								},
+								comment:
+									'Message shown when downgrading an expired plan, listing features that will be lost',
+							}
+						) }
+					</p>
+					<ul className="downgrade-confirmation-modal__feature-list">
+						{ lostFeatures.map( ( feature ) => (
+							<li key={ feature.getSlug() } className="downgrade-confirmation-modal__feature-item">
+								<Gridicon
+									icon="cross-small"
+									size={ 24 }
+									className="downgrade-confirmation-modal__feature-icon"
+								/>
+								<span className="downgrade-confirmation-modal__feature-text">
+									{ feature.getTitle() }
+								</span>
+							</li>
+						) ) }
+					</ul>
+				</>
+			) : (
+				<p className="downgrade-confirmation-modal__description">
+					{ translate(
+						'When you change from %(currentPlan)s to %(targetPlan)s, your features will stay the same.',
+						{
 							args: {
 								currentPlan: currentPlanTitle,
 								targetPlan: targetPlanTitle,
 							},
 							comment: 'Message shown when downgrading an expired plan with no feature differences',
-						} ) }
-					</p>
-				) }
-				<HStack spacing={ 3 } justify="flex-start">
-					<Button __next40pxDefaultSize variant="primary" onClick={ handleConfirm }>
-						{ translate( 'Downgrade to %(planName)s', {
-							args: { planName: targetPlanTitle },
-							comment: 'Button label to confirm downgrading to a lower-tier plan',
-						} ) }
-					</Button>
-					<Button __next40pxDefaultSize variant="secondary" onClick={ onClose }>
-						{ translate( 'Keep %(planName)s', {
-							args: { planName: currentPlanTitle },
-							comment: 'Button label to dismiss the downgrade modal and keep the current plan',
-						} ) }
-					</Button>
-				</HStack>
-			</VStack>
+						}
+					) }
+				</p>
+			) }
+			<HStack spacing={ 3 } justify="flex-end" className="downgrade-confirmation-modal__buttons">
+				<Button __next40pxDefaultSize variant="tertiary" onClick={ onClose }>
+					{ translate( 'Keep %(planName)s', {
+						args: { planName: currentPlanTitle },
+						comment: 'Button label to dismiss the downgrade modal and keep the current plan',
+					} ) }
+				</Button>
+				<Button __next40pxDefaultSize variant="primary" onClick={ handleConfirm }>
+					{ translate( 'Downgrade to %(planName)s', {
+						args: { planName: targetPlanTitle },
+						comment: 'Button label to confirm downgrading to a lower-tier plan',
+					} ) }
+				</Button>
+			</HStack>
 		</Modal>
 	);
 };

--- a/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/index.tsx
+++ b/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/index.tsx
@@ -42,7 +42,7 @@ const DowngradeConfirmationModal = ( {
 		const featureSlugs = getFeatureDifference(
 			targetPlanSlug,
 			currentPlanSlug,
-			'getCancellationFeatures'
+			'getDowngradeFeatures'
 		);
 		return featureSlugs
 			.map( ( slug ) => getFeatureByKey( slug ) )

--- a/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/style.scss
+++ b/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/style.scss
@@ -1,0 +1,10 @@
+.downgrade-confirmation-modal__feature-list {
+	list-style: none;
+	padding: 0;
+	margin: 0;
+}
+
+.downgrade-confirmation-modal__feature-icon {
+	fill: var(--color-error);
+	flex-shrink: 0;
+}

--- a/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/style.scss
+++ b/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/style.scss
@@ -1,10 +1,32 @@
+.downgrade-confirmation-modal__description {
+	font-size: $font-body-small;
+	margin-block-end: 8px;
+}
+
 .downgrade-confirmation-modal__feature-list {
 	list-style: none;
 	padding: 0;
 	margin: 0;
 }
 
+.downgrade-confirmation-modal__feature-item {
+	display: flex;
+	font-size: $font-body-small;
+}
+
+.downgrade-confirmation-modal__feature-text {
+	margin-block: auto;
+	flex: 1;
+	min-width: 0;
+}
+
 .downgrade-confirmation-modal__feature-icon {
-	fill: var(--color-error);
+	color: var(--color-error-40);
 	flex-shrink: 0;
+	margin-inline-end: 8px;
+	margin-block-start: 2px;
+}
+
+.downgrade-confirmation-modal__buttons {
+	margin-block-start: 24px;
 }

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -18,6 +18,7 @@ import {
 	isWooHostedPlan,
 	isBusinessTrial,
 	getPlan,
+	PLAN_TIER_ORDER,
 } from '@automattic/calypso-products';
 import { AddOns, PlanPricing, Plans } from '@automattic/data-stores';
 import { useState } from '@wordpress/element';
@@ -580,15 +581,8 @@ function getLoggedInPlansAction( {
 		sitePlanSlug &&
 		getPlanClass( planSlug ) !== getPlanClass( sitePlanSlug )
 	) {
-		const tierOrder: Record< string, number > = {
-			'is-free-plan': 0,
-			'is-personal-plan': 1,
-			'is-premium-plan': 2,
-			'is-business-plan': 3,
-			'is-ecommerce-plan': 4,
-		};
-		const currentTier = tierOrder[ getPlanClass( sitePlanSlug ) ] ?? 0;
-		const targetTier = tierOrder[ getPlanClass( planSlug ) ] ?? 0;
+		const currentTier = PLAN_TIER_ORDER[ getPlanClass( sitePlanSlug ) ] ?? 0;
+		const targetTier = PLAN_TIER_ORDER[ getPlanClass( planSlug ) ] ?? 0;
 
 		if ( targetTier < currentTier ) {
 			return createLoggedInPlansAction(

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -22,6 +22,7 @@ import {
 	getWordPressHostingFeaturesGroupedForFeaturesGrid,
 	isWooHostedPlan,
 	isWooHostedFreePlan,
+	PLAN_TIER_ORDER,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, Spinner } from '@automattic/components';
@@ -426,14 +427,6 @@ const PlansFeaturesMain = ( {
 
 	const eligibleForFreeHostingTrial = useSelector( isUserEligibleForFreeHostingTrial );
 
-	const tierOrder: Record< string, number > = {
-		'is-free-plan': 0,
-		'is-personal-plan': 1,
-		'is-premium-plan': 2,
-		'is-business-plan': 3,
-		'is-ecommerce-plan': 4,
-	};
-
 	// TODO: We should move the modal logic into a data store
 	const showModalAndExit = ( planSlug: PlanSlug ): boolean => {
 		// Expired-plan downgrade confirmation
@@ -441,8 +434,8 @@ const PlansFeaturesMain = ( {
 			isPlanExpired &&
 			sitePlanSlug &&
 			getPlanClass( sitePlanSlug ) !== getPlanClass( planSlug ) &&
-			( tierOrder[ getPlanClass( planSlug ) ] ?? 0 ) <
-				( tierOrder[ getPlanClass( sitePlanSlug ) ] ?? 0 )
+			( PLAN_TIER_ORDER[ getPlanClass( planSlug ) ] ?? 0 ) <
+				( PLAN_TIER_ORDER[ getPlanClass( sitePlanSlug ) ] ?? 0 )
 		) {
 			setPendingDowngradePlanSlug( planSlug );
 			return true;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -2,6 +2,7 @@ import config from '@automattic/calypso-config';
 import {
 	chooseDefaultCustomerType,
 	getPlan,
+	getPlanClass,
 	isFreePlan,
 	isPersonalPlan,
 	PLAN_PERSONAL,
@@ -77,6 +78,7 @@ import isEligibleForWpComMonthlyPlan from 'calypso/state/selectors/is-eligible-f
 import { isUserEligibleForFreeHostingTrial } from 'calypso/state/selectors/is-user-eligible-for-free-hosting-trial';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import ComparisonGridToggle from './components/comparison-grid-toggle';
+import DowngradeConfirmationModal from './components/downgrade-confirmation-modal';
 import PlanUpsellModal from './components/plan-upsell-modal';
 import { useModalResolutionCallback } from './components/plan-upsell-modal/hooks/use-modal-resolution-callback';
 import PlansPageSubheader from './components/plans-page-subheader';
@@ -255,6 +257,9 @@ const PlansFeaturesMain = ( {
 	// TODO: Remove temporary eslint disable
 	// eslint-disable-next-line
 	const [ lastClickedPlan, setLastClickedPlan ] = useState< string | null >( null );
+	const [ pendingDowngradePlanSlug, setPendingDowngradePlanSlug ] = useState< PlanSlug | null >(
+		null
+	);
 	const [ showPlansComparisonGrid, setShowPlansComparisonGrid ] = useState( false );
 	const [ comparisonGridVisiblePlansCount, setComparisonGridVisiblePlansCount ] = useState<
 		number | null
@@ -421,8 +426,28 @@ const PlansFeaturesMain = ( {
 
 	const eligibleForFreeHostingTrial = useSelector( isUserEligibleForFreeHostingTrial );
 
+	const tierOrder: Record< string, number > = {
+		'is-free-plan': 0,
+		'is-personal-plan': 1,
+		'is-premium-plan': 2,
+		'is-business-plan': 3,
+		'is-ecommerce-plan': 4,
+	};
+
 	// TODO: We should move the modal logic into a data store
 	const showModalAndExit = ( planSlug: PlanSlug ): boolean => {
+		// Expired-plan downgrade confirmation
+		if (
+			isPlanExpired &&
+			sitePlanSlug &&
+			getPlanClass( sitePlanSlug ) !== getPlanClass( planSlug ) &&
+			( tierOrder[ getPlanClass( planSlug ) ] ?? 0 ) <
+				( tierOrder[ getPlanClass( sitePlanSlug ) ] ?? 0 )
+		) {
+			setPendingDowngradePlanSlug( planSlug );
+			return true;
+		}
+
 		if (
 			sitePlanSlug &&
 			isFreePlan( sitePlanSlug ) &&
@@ -946,6 +971,14 @@ const PlansFeaturesMain = ( {
 						const cartItems = cartItemForPlan ? [ cartItemForPlan ] : null;
 						onUpgradeClick?.( cartItems );
 					} }
+				/>
+				<DowngradeConfirmationModal
+					isOpen={ !! pendingDowngradePlanSlug }
+					currentPlanSlug={ sitePlanSlug! }
+					targetPlanSlug={ pendingDowngradePlanSlug }
+					siteId={ siteId }
+					redirectTo={ redirectTo }
+					onClose={ () => setPendingDowngradePlanSlug( null ) }
 				/>
 				{ siteId && gridPlansForFeaturesGrid && (
 					<PlanNotice

--- a/packages/calypso-products/src/is-lower-plan-purchasable-for-expired-site.ts
+++ b/packages/calypso-products/src/is-lower-plan-purchasable-for-expired-site.ts
@@ -1,7 +1,7 @@
 import { isMonthly } from './is-monthly';
 import { getPlanClass } from './main';
 
-const PLAN_TIER_ORDER: Record< string, number > = {
+export const PLAN_TIER_ORDER: Record< string, number > = {
 	'is-free-plan': 0,
 	'is-flexible-plan': 0,
 	'is-blogger-plan': 1,

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -1098,6 +1098,11 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_AD_FREE_EXPERIENCE,
 		FEATURE_AUDIO_UPLOADS,
 	],
+	getDowngradeFeatures: () => [
+		FEATURE_PLUGINS_THEMES,
+		FEATURE_AD_FREE_EXPERIENCE,
+		FEATURE_STYLE_CUSTOMIZATION,
+	],
 } );
 
 const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
@@ -1406,6 +1411,26 @@ const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_SELL_SHIP,
 		FEATURE_PLUGINS_THEMES,
 		FEATURE_ADVANCED_SEO_TOOLS,
+	],
+	getDowngradeFeatures: () => [
+		// Shared with Personal (cancels out)
+		FEATURE_PLUGINS_THEMES,
+		FEATURE_AD_FREE_EXPERIENCE,
+		FEATURE_STYLE_CUSTOMIZATION,
+		// Shared with Premium (cancels out)
+		WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED,
+		FEATURE_WORDADS_INSTANT,
+		FEATURE_CONNECT_ANALYTICS,
+		// Shared with Business (cancels out in Ecommerce→Business delta)
+		FEATURE_ADVANCED_SEO_TOOLS,
+		FEATURE_DEV_TOOLS,
+		FEATURE_SEAMLESS_STAGING_PRODUCTION_SYNCING,
+		FEATURE_SITE_BACKUPS_AND_RESTORE,
+		// Ecommerce tier
+		FEATURE_ACCEPT_PAYMENTS_V2,
+		FEATURE_SHIPPING_CARRIERS,
+		FEATURE_ECOMMERCE_MARKETING,
+		FEATURE_SELL_SHIP,
 	],
 	getVisualSplitCommerceFeatures: () => [
 		// All Business hosting features
@@ -1958,6 +1983,16 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_WORDADS_INSTANT,
 		FEATURE_AD_FREE_EXPERIENCE,
 	],
+	getDowngradeFeatures: () => [
+		// Shared with Personal (cancels out in Premium→Personal delta)
+		FEATURE_PLUGINS_THEMES,
+		FEATURE_AD_FREE_EXPERIENCE,
+		FEATURE_STYLE_CUSTOMIZATION,
+		// Premium tier
+		WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED,
+		FEATURE_WORDADS_INSTANT,
+		FEATURE_CONNECT_ANALYTICS,
+	],
 } );
 
 const getPlanA4ABusinessDetails = (): IncompleteWPcomPlan => ( {
@@ -2356,6 +2391,21 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 		FEATURE_SITE_BACKUPS_AND_RESTORE,
 		FEATURE_AD_FREE_EXPERIENCE,
 		FEATURE_FAST_SUPPORT_FROM_EXPERTS,
+	],
+	getDowngradeFeatures: () => [
+		// Shared with Personal (cancels out)
+		FEATURE_PLUGINS_THEMES,
+		FEATURE_AD_FREE_EXPERIENCE,
+		FEATURE_STYLE_CUSTOMIZATION,
+		// Shared with Premium (cancels out in Business→Premium delta)
+		WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED,
+		FEATURE_WORDADS_INSTANT,
+		FEATURE_CONNECT_ANALYTICS,
+		// Business tier
+		FEATURE_ADVANCED_SEO_TOOLS,
+		FEATURE_DEV_TOOLS,
+		FEATURE_SEAMLESS_STAGING_PRODUCTION_SYNCING,
+		FEATURE_SITE_BACKUPS_AND_RESTORE,
 	],
 	getVisualSplitBusinessFeatures: () => [
 		FEATURE_UNLIMITED_TRAFFIC,

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -162,6 +162,7 @@ export interface WPComPlan extends Plan {
 	getHostingSignupFeatures?: ( term?: Product[ 'term' ] ) => () => Feature[];
 	getHostingHighlightedFeatures?: () => Feature[];
 	getCancellationFeatures?: () => Feature[];
+	getDowngradeFeatures?: () => Feature[];
 	getVisualSplitBusinessFeatures?: () => Feature[];
 	getVisualSplitCommerceFeatures?: () => Feature[];
 }

--- a/packages/plans-grid-next/src/components/shared/action-button/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/action-button/index.tsx
@@ -201,6 +201,7 @@ const ActionButton = ( {
 						busy={ busy }
 						onClick={ callback }
 						current={ current && variant !== 'primary' }
+						classes={ variant === 'secondary' ? 'is-secondary' : '' }
 						ariaLabel={ String( ariaLabel || '' ) }
 					>
 						{ text }


### PR DESCRIPTION
Depends on https://github.com/Automattic/wp-calypso/pull/111070
Related: 221519-ghe-Automattic/wpcom

## Proposed Changes
This PR is part 3 of 3. It adds a confirmation dialogue when people try to downgrade their plan. 

<img width="1706" height="1162" alt="image" src="https://github.com/user-attachments/assets/9705406d-1237-4cff-a4e8-911a0a8d96e5" />

Technical details:
- Add `getDowngradeFeatures` to `WPComPlan` interface and implement it for Personal, Premium, Business, and Ecommerce plans in `plans-list.tsx`
- Switch the downgrade confirmation modal from `getCancellationFeatures` to `getDowngradeFeatures` so feature deltas accurately reflect what's lost in each downgrade path
- Deduplicate `PLAN_TIER_ORDER`: export from `calypso-products` and import in the two client consumers that had inline copies

## Testing Instructions

- Enable `plans/expired-plan-downgrade` feature flag
- Navigate to the plans grid for a site with an expired Business plan
- Click "Downgrade" on Premium — the modal should show: Advanced SEO tools, SFTP/SSH/WP-CLI/Git/GitHub Deployments, Seamless staging sync, Automated backups & restore
- Click "Downgrade" on Personal — the modal should show the above plus: All premium themes, Site monetization, Connect Google Analytics
- Verify "Install plugins & themes" does NOT appear in any delta (it's shared across all paid plans)

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [x] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?