### PR TITLE
Update wpcom block editor TinyMCE

### DIFF
--- a/apps/wpcom-block-editor/package.json
+++ b/apps/wpcom-block-editor/package.json
@@ -52,7 +52,7 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"redux": "^5.0.1",
-		"tinymce": "^5.0.0"
+		"tinymce": "^7.9.3"
 	},
 	"devDependencies": {
 		"@automattic/calypso-apps-builder": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2570,7 +2570,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     redux: "npm:^5.0.1"
-    tinymce: "npm:^5.0.0"
+    tinymce: "npm:^7.9.3"
     webpack: "npm:^5.99.8"
     webpack-bundle-analyzer: "npm:^4.10.2"
   languageName: unknown
@@ -32082,10 +32082,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinymce@npm:^5.0.0":
-  version: 5.10.9
-  resolution: "tinymce@npm:5.10.9"
-  checksum: 8b0d8602259d54ab89ffbf7bc4ea08f1bb35fa1f523748358d22550fed1abbffda3a2168af7c7a562a6bb8828c1c9dedb41e8ed1cd63b21a00f31ef39e708443
+"tinymce@npm:^7.9.3":
+  version: 7.9.3
+  resolution: "tinymce@npm:7.9.3"
+  checksum: 37f6661fe242264f3db6a805e22cefce0ecbc3c9c23db274733e275eb1e4663e337385ce9feac0e1a389fe32ceb844dd981d35f489158cce91d5e8cea3ca396b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Part of QAO-472

## Proposed Changes

* Update `@automattic/wpcom-block-editor` from `tinymce` 5.10.9 to 7.9.3.
* Refresh the root lockfile for that single dependency.

## Why are these changes being made?

* Clears the remaining TinyMCE Dependabot alerts while keeping this app surface separate from the broad grouped Dependabot PR.
* Uses TinyMCE 7 instead of combining this with the Electron, Electron Updater, and Playwright desktop updates from #111206.

## Testing Instructions

* `yarn install --immutable`
* `yarn dedupe --check`
* `yarn why tinymce`
* Confirmed `tinymce/tinymce`, `tinymce/icons/default`, and `tinymce/themes/silver` resolve from the installed package.
* `yarn workspace @automattic/wpcom-block-editor teamcity:build-app`
* `yarn typecheck-apps` was checked but currently fails in unrelated app/type declaration areas, so it is not used as a pass signal for this slice.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?