### PR TITLE
Logged-out Help Center FAB: remove from account-creation and login routes

### DIFF
--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -26,7 +26,6 @@ import { setupLocale } from 'calypso/boot/locale';
 import AsyncLoad from 'calypso/components/async-load';
 import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
 import { AsyncHelpCenterApp } from 'calypso/components/help-center';
-import AsyncHelpCenterFab from 'calypso/components/help-center-fab/async';
 import getSuperProps from 'calypso/lib/analytics/super-props';
 import { setupErrorLogger } from 'calypso/lib/error-logger/setup-error-logger';
 import loadDevHelpers from 'calypso/lib/load-dev-helpers';
@@ -34,13 +33,12 @@ import { addQueryArgs } from 'calypso/lib/url';
 import { initializeCurrentUser } from 'calypso/lib/user/shared-utils';
 import { onDisablePersistence } from 'calypso/lib/user/store';
 import wpcom from 'calypso/lib/wp';
-import { createReduxStore, useSelector } from 'calypso/state';
+import { createReduxStore } from 'calypso/state';
 import { setCurrentUser } from 'calypso/state/current-user/actions';
 import { getInitialState, getStateFromCache, persistOnChange } from 'calypso/state/initial-state';
 import { createQueryClient } from 'calypso/state/query-client';
 import initialReducer from 'calypso/state/reducer';
 import { setStore } from 'calypso/state/redux-store';
-import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { setCurrentFlowName } from 'calypso/state/signup/flow/actions';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { FlowRenderer } from './declarative-flow/internals';
@@ -125,21 +123,6 @@ function LazyHelpCenter( { currentUser }: { currentUser: UserStore.CurrentUser }
 	return <AsyncHelpCenterApp currentUser={ currentUser } sectionName="stepper" />;
 }
 
-// Matches the stepper user (account-creation) step, including the optional
-// locale segment from FlowRenderer's route (e.g. `/setup/onboarding/user/es`).
-// useSyncRoute keeps the Redux `currentRoute` in sync with react-router
-// navigation, so the FAB can live outside <BrowserRouter> (mounting it inside
-// would nest the Help Center panel's own <Router> and crash).
-const USER_STEP_PATH = /^\/setup\/[^/]+\/user(?:\/[^/]+)?\/?$/;
-
-function StepperUserStepFab() {
-	const currentRoute = useSelector( getCurrentRoute );
-	if ( ! USER_STEP_PATH.test( currentRoute ) ) {
-		return null;
-	}
-	return <AsyncHelpCenterFab sectionName="stepper" />;
-}
-
 async function main() {
 	const { pathname, search } = window.location;
 
@@ -164,7 +147,11 @@ async function main() {
 
 			return new Promise< T >( ( resolve, reject ) => {
 				const cb = ( error: Error, response: T ) => {
-					error ? reject( error ) : resolve( response );
+					if ( error ) {
+						reject( error );
+					} else {
+						resolve( response );
+					}
 				};
 				if ( method && ( method as string ).toUpperCase() !== 'GET' ) {
 					wpcom.req.post( { ...rest, method }, queryObj, body, cb );
@@ -308,14 +295,6 @@ async function main() {
 									sectionName={ flowName }
 									loadAgentsManager
 								/>
-								{ /* The stepper has no masterbar or help button, so logged-out visitors
-								   on the account-creation step need this FAB to summon the Help Center.
-								   It reads its route gate from Redux (kept in sync by useSyncRoute) so
-								   it can live outside <BrowserRouter> — mounting it inside would nest
-								   the Help Center panel's own <Router> and crash. */ }
-								{ ! user && config.isEnabled( 'help-center/logged-out-fab' ) && (
-									<StepperUserStepFab />
-								) }
 							</>
 						) ) }
 					{ 'development' === process.env.NODE_ENV && (

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -1,6 +1,5 @@
 import config, { isEnabled } from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
-import { getLanguageSlugs } from '@automattic/i18n-utils';
 import { Step } from '@automattic/onboarding';
 import { UniversalNavbarHeader, UniversalNavbarFooter } from '@automattic/wpcom-template-parts';
 import clsx from 'clsx';
@@ -36,7 +35,6 @@ import {
 import { usePartnerBranding } from 'calypso/lib/partner-branding';
 import { createAccountUrl } from 'calypso/lib/paths';
 import isReaderTagEmbedPage from 'calypso/lib/reader/is-reader-tag-embed-page';
-import untrailingslashit from 'calypso/lib/route/untrailingslashit';
 import { getOnboardingUrl as getPatternLibraryOnboardingUrl } from 'calypso/my-sites/patterns/paths';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getRedirectToOriginal, isTwoFactorEnabled } from 'calypso/state/login/selectors';
@@ -85,7 +83,6 @@ const loadSupportArticleDialog = () =>
 const HELP_CENTER_FAB_SECTIONS = [
 	'accept-invite',
 	'checkout',
-	'login',
 	'mailing-lists',
 	'patterns',
 	'performance-profiler',
@@ -98,35 +95,6 @@ const HELP_CENTER_FAB_SECTIONS = [
 
 // Fallback when section name is unreliable — e.g. /me/account/closed activates as 'me'.
 const HELP_CENTER_FAB_ROUTES = [ '/me/account/closed' ];
-
-// /log-in briefly carries social-handoff tokens before the login controller strips
-// them (?access_token / ?id_token in query, #id_token / #client_id in hash).
-// Suppress the FAB during that window so window.location.href doesn't reach Zendesk.
-const WPCOM_LOGIN_FAB_PATHNAMES = new Set( [
-	'/log-in',
-	'/log-in/lostpassword',
-	...getLanguageSlugs().flatMap( ( slug ) => [
-		`/log-in/${ slug }`,
-		`/log-in/lostpassword/${ slug }`,
-	] ),
-] );
-
-const TOKEN_BEARING_LOGIN_QUERY_KEYS = [ 'access_token', 'id_token' ];
-
-const isFabSafeLoginUrl = () => {
-	if ( typeof window === 'undefined' ) {
-		return false;
-	}
-	const { pathname, search, hash } = window.location;
-	if ( ! WPCOM_LOGIN_FAB_PATHNAMES.has( untrailingslashit( pathname ) ) || hash ) {
-		return false;
-	}
-	if ( ! search ) {
-		return true;
-	}
-	const params = new URLSearchParams( search );
-	return ! TOKEN_BEARING_LOGIN_QUERY_KEYS.some( ( key ) => params.has( key ) );
-};
 
 const LayoutLoggedOut = ( {
 	isAkismet,
@@ -203,13 +171,7 @@ const LayoutLoggedOut = ( {
 		! isJetpackCloud &&
 		! isWooOAuth2Client( oauth2Client );
 
-	// OAuth client logins (Gravatar, WPJobManager, Woo, etc.) and /log-in/jetpack
-	// have their own branding and support paths.
-	const isWpcomLogin =
-		sectionName === 'login' && ! useOAuth2Layout && ! isJetpackLogin && isFabSafeLoginUrl();
-
-	const isEligibleSection =
-		HELP_CENTER_FAB_SECTIONS.includes( sectionName ) && ( sectionName !== 'login' || isWpcomLogin );
+	const isEligibleSection = HELP_CENTER_FAB_SECTIONS.includes( sectionName );
 
 	// Logged-in users use the masterbar control instead.
 	// Reader tag embeds are widgets meant to be iframed by third parties — no FAB.

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -91,7 +91,6 @@ const HELP_CENTER_FAB_SECTIONS = [
 	'performance-profiler',
 	'plugins',
 	'reader',
-	'signup',
 	'site-profiler',
 	'theme',
 	'themes',
@@ -99,14 +98,6 @@ const HELP_CENTER_FAB_SECTIONS = [
 
 // Fallback when section name is unreliable — e.g. /me/account/closed activates as 'me'.
 const HELP_CENTER_FAB_ROUTES = [ '/me/account/closed' ];
-
-// Within the `signup` section the FAB is scoped to the account-creation step
-// (`user-social` or `user`) so it appears on `/start/account/user-social` but
-// not on flow-specific steps like `/start/domain/domain-only`. The `<flow>`
-// segment is optional because the default signup flow omits it, producing
-// URLs like `/start/user` and `/start/user/<stepSection>/<lang>`. Matches up
-// to two trailing segments (`:stepSectionName` and/or `:lang`).
-const SIGNUP_ACCOUNT_STEP_PATH = /^\/start\/(?:[^/]+\/)?(?:user|user-social)(?:\/[^/]+){0,2}\/?$/;
 
 // /log-in briefly carries social-handoff tokens before the login controller strips
 // them (?access_token / ?id_token in query, #id_token / #client_id in hash).
@@ -217,16 +208,8 @@ const LayoutLoggedOut = ( {
 	const isWpcomLogin =
 		sectionName === 'login' && ! useOAuth2Layout && ! isJetpackLogin && isFabSafeLoginUrl();
 
-	// OAuth client signups (Woo, BlazePro, Gravatar, WPJobManager, etc.) run under
-	// their own brand. For plain WPCOM signup we only show the FAB on the
-	// account-creation step, not on flow-specific steps like `domain-only`.
-	const isWpcomSignup =
-		sectionName === 'signup' && ! useOAuth2Layout && SIGNUP_ACCOUNT_STEP_PATH.test( currentRoute );
-
 	const isEligibleSection =
-		HELP_CENTER_FAB_SECTIONS.includes( sectionName ) &&
-		( sectionName !== 'login' || isWpcomLogin ) &&
-		( sectionName !== 'signup' || isWpcomSignup );
+		HELP_CENTER_FAB_SECTIONS.includes( sectionName ) && ( sectionName !== 'login' || isWpcomLogin );
 
 	// Logged-in users use the masterbar control instead.
 	// Reader tag embeds are widgets meant to be iframed by third parties — no FAB.


### PR DESCRIPTION
Part of HAP-2869

## Proposed Changes

Remove the logged-out Help Center FAB from authentication / account-entry surfaces:

* **Account-creation step:**
  * Signup: `/start/user` and `/start/user-social` (drops `signup` from `HELP_CENTER_FAB_SECTIONS` and removes the `SIGNUP_ACCOUNT_STEP_PATH` / `isWpcomSignup` gating in `client/layout/logged-out.jsx`).
  * Stepper: `/setup/<flow>/user` (removes `StepperUserStepFab` and its mount in `client/landing/stepper/index.tsx`).
* **Login:** the entire `login` section — `/log-in`, `/log-in/lostpassword`, and locale variants. Drops `login` from `HELP_CENTER_FAB_SECTIONS` and removes the now-unused `isWpcomLogin` gating, the `isFabSafeLoginUrl` helper and its supporting constants, and the now-unused `getLanguageSlugs` / `untrailingslashit` imports.
* Drive-by: convert a pre-existing ternary-as-statement in the stepper Promise callback to `if/else` so the touched file passes `lint-staged`.

Other logged-out surfaces (checkout, themes, plugins, patterns, reader, site-profiler, etc.) are unaffected and keep the FAB.

## Testing Instructions

* With the `help-center/logged-out-fab` feature enabled, while logged out:
  * Visit `/start/user`, `/start/user-social`, a stepper flow's `/setup/<flow>/user` step, `/log-in`, and `/log-in/lostpassword` -> the Help Center FAB should **no longer appear**.
  * Visit a still-covered surface (e.g. `/checkout`, `/themes`, `/plugins`, Reader) -> the FAB should **still appear** as before.
* Confirm no console/TypeScript errors.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors? <!-- yarn typecheck-client passes; no runtime/console check performed yet -->
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? (PCYsg-S3g-p2)
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
