### PR TITLE
Override pinned minimatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -347,6 +347,7 @@
 		"json-schema": "0.4.0",
 		"sha.js": "2.4.12",
 		"form-data": "^4.0.4",
+		"minimatch@npm:3.0.4": "3.1.5",
 		"@wordpress/a11y": "4.46.0",
 		"@wordpress/annotations": "3.46.0",
 		"@wordpress/api-fetch": "7.46.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -24887,21 +24887,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:2 || 3, minimatch@npm:^3.0.0, minimatch@npm:^3.0.3, minimatch@npm:^3.0.4, minimatch@npm:^3.0.5, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2, minimatch@npm:^3.1.5":
+"minimatch@npm:2 || 3, minimatch@npm:3.1.5, minimatch@npm:^3.0.0, minimatch@npm:^3.0.3, minimatch@npm:^3.0.4, minimatch@npm:^3.0.5, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2, minimatch@npm:^3.1.5":
   version: 3.1.5
   resolution: "minimatch@npm:3.1.5"
   dependencies:
     brace-expansion: "npm:^1.1.7"
   checksum: 2ecbdc0d33f07bddb0315a8b5afbcb761307a8778b48f0b312418ccbced99f104a2d17d8aca7573433c70e8ccd1c56823a441897a45e384ea76ef401a26ace70
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:3.0.4":
-  version: 3.0.4
-  resolution: "minimatch@npm:3.0.4"
-  dependencies:
-    brace-expansion: "npm:^1.1.7"
-  checksum: d0a2bcd93ebec08a9eef3ca83ba33c9fb6feb93932e0b4dc6aa46c5f37a9404bea7ad9ff7cafe23ce6634f1fe3b206f5315ecbb05812da6e692c21d8ecfd3dae
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Part of QAO-472

## Proposed Changes

* Add a targeted Yarn resolution for the exact `minimatch@3.0.4` descriptor.
* Resolve the old `dir-compare@2.4.0` path to `minimatch@3.1.5`, matching the existing patched 3.x line already used elsewhere in the repo.
* Remove the standalone vulnerable `minimatch@3.0.4` lockfile entry.

## Why are these changes being made?

* Dependabot still reports four alerts against `minimatch@3.0.4`. The remaining vulnerable path is an exact transitive pin under desktop builder tooling, so `yarn up -R minimatch` cannot move it.
* This keeps the parent tooling unchanged while applying a same-major patch override for the vulnerable implementation package.

## Testing Instructions

* `git diff --check`
* `yarn install --immutable`
* `yarn dedupe --check`
* `yarn why minimatch`
* Confirm no `minimatch@3.0.4` lockfile entry remains.
* `yarn node -e "const minimatch=require('minimatch'); const dirCompare=require('dir-compare'); console.log(minimatch('file.js','*.js')); console.log(typeof dirCompare.compareSync);"`
* `NODE_OPTIONS=--max-old-space-size=8192 yarn run build-desktop:app`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?