### PR TITLE
Cancel flow: skip atomic-revert step under split flag

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -92,7 +92,13 @@ class CancelPurchaseForm extends Component {
 	};
 
 	getAllSurveySteps() {
-		const { purchase, skipRemovePlanSurvey, willAtomicSiteRevert, flowType } = this.props;
+		const {
+			purchase,
+			skipRemovePlanSurvey,
+			willAtomicSiteRevert,
+			flowType,
+			isSplitCancelRemoveEnabled,
+		} = this.props;
 		let steps = [ FEEDBACK_STEP ];
 
 		if (
@@ -108,7 +114,11 @@ class CancelPurchaseForm extends Component {
 			steps = [ FEEDBACK_STEP, NEXT_ADVENTURE_STEP ];
 		}
 
-		if ( willAtomicSiteRevert && flowType === CANCEL_FLOW_TYPE.REMOVE ) {
+		if (
+			willAtomicSiteRevert &&
+			flowType === CANCEL_FLOW_TYPE.REMOVE &&
+			! isSplitCancelRemoveEnabled
+		) {
 			steps.push( ATOMIC_REVERT_STEP );
 		}
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -354,6 +354,7 @@ function getAllSurveySteps( {
 	hasQuestionTwo,
 	plans,
 	userHasCompletedCancelSurveyForPurchase,
+	isSplitCancelRemoveEnabled,
 }: {
 	purchase: Purchase;
 	upsell: CancelPurchaseState[ 'upsell' ];
@@ -361,6 +362,7 @@ function getAllSurveySteps( {
 	hasQuestionTwo: boolean;
 	plans: PlanProduct[];
 	userHasCompletedCancelSurveyForPurchase: boolean;
+	isSplitCancelRemoveEnabled: boolean;
 } ): string[] {
 	let steps = getBasicSurveySteps( {
 		purchase,
@@ -371,7 +373,11 @@ function getAllSurveySteps( {
 	const skipRemovePlanSurvey = purchase.is_plan && userHasCompletedCancelSurveyForPurchase;
 	const flowType = getPurchaseCancellationFlowType( purchase );
 
-	if ( purchase.will_atomic_revert_after_removal && flowType === CANCEL_FLOW_TYPE.REMOVE ) {
+	if (
+		purchase.will_atomic_revert_after_removal &&
+		flowType === CANCEL_FLOW_TYPE.REMOVE &&
+		! isSplitCancelRemoveEnabled
+	) {
 		steps.push( ATOMIC_REVERT_STEP );
 	}
 
@@ -580,6 +586,7 @@ function CancelPurchaseInner() {
 		userHasCompletedCancelSurveyForPurchase: isSplitCancelRemoveEnabled
 			? false
 			: userHasCompletedCancelSurveyForPurchase,
+		isSplitCancelRemoveEnabled,
 	} );
 
 	const initSurveyState = () => {
@@ -895,9 +902,11 @@ function CancelPurchaseInner() {
 		const cancelActiveSubscriptions: Purchase[] = [];
 		const marketplaceSubscriptions = getActiveMarketplaceSubscriptions();
 		marketplaceSubscriptions.forEach( ( subscription ) => {
-			hasAmountAvailableToRefund( subscription )
-				? cancelAndRefundActiveSubscriptions.push( subscription )
-				: cancelActiveSubscriptions.push( subscription );
+			if ( hasAmountAvailableToRefund( subscription ) ) {
+				cancelAndRefundActiveSubscriptions.push( subscription );
+			} else {
+				cancelActiveSubscriptions.push( subscription );
+			}
 		} );
 		cancelAndRefundActiveSubscriptions.forEach( ( marketplaceSubscription ) => {
 			cancelAndRefundMutation.mutate(


### PR DESCRIPTION
## Proposed Changes
This PR removes a redundant confirmation screen that is already covered in the initial confirmation screen. The changes apply in Calypso and MSD.

| Remove | Covered by |
| -- | -- |
| <img width="1840" height="1162" alt="image" src="https://github.com/user-attachments/assets/54299109-697c-4a17-bce2-968d4d7cab63" /> | <img width="1840" height="1162" alt="image" src="https://github.com/user-attachments/assets/2f4e867a-0976-45a5-a030-d39897b8df5e" /> |
| | <img width="1840" height="1162" alt="image" src="https://github.com/user-attachments/assets/42245a54-29e5-4b05-88a5-9818156c4dbe" /> |

Technical details:
- Gate `ATOMIC_REVERT_STEP` behind `! isSplitCancelRemoveEnabled` in both dashboard (`cancel-purchase/index.tsx`) and legacy (`cancel-purchase-form/index.jsx`) survey step builders
- Thread `isSplitCancelRemoveEnabled` into the dashboard `getAllSurveySteps` parameter object
- Fix pre-existing `no-unused-expressions` lint error in `cancelAllMarketplaceSubscriptions` (ternary → if/else)

## Testing Instructions

1. Enable `purchases/split-cancel-remove` in `config/development.json`
2. On **both** `my.localhost:3000` (dashboard) and `calypso.localhost:3000` (legacy):
   - Navigate to an Atomic-transferred site's Purchase Settings
   - Click **Remove plan** → confirm checkbox screen
   - Verify the flow goes directly into the survey (feedback / next-adventure / removal) with **no** "Proceed with caution" intermediate step
   - Verify the backup download link still appears in the post-removal notice
3. Disable the flag and verify the "Proceed with caution" step still appears for Atomic sites

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)