### PR TITLE
Override draft-js immutable

### DIFF
--- a/package.json
+++ b/package.json
@@ -347,6 +347,7 @@
 		"json-schema": "0.4.0",
 		"sha.js": "2.4.12",
 		"form-data": "^4.0.4",
+		"immutable@npm:~3.7.4": "3.8.3",
 		"minimatch@npm:3.0.4": "3.1.5",
 		"@wordpress/a11y": "4.46.0",
 		"@wordpress/annotations": "3.46.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20864,6 +20864,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"immutable@npm:3.8.3":
+  version: 3.8.3
+  resolution: "immutable@npm:3.8.3"
+  checksum: bafa7b8371b7622bc3d128cd9e6bba3a654b968f09a237929629f43ac26f7e974a5879cd38baad0c26f6f0628753968611bf832add7bf0c44d647bf4306a2988
+  languageName: node
+  linkType: hard
+
 "immutable@npm:^4.0.0":
   version: 4.3.8
   resolution: "immutable@npm:4.3.8"
@@ -20875,13 +20882,6 @@ __metadata:
   version: 5.1.5
   resolution: "immutable@npm:5.1.5"
   checksum: 8017ece1578e3c5939ba3305176aee059def1b8a90c7fa2a347ef583ebbd38cbe77ce1bbd786a5fab57e2da00bbcb0493b92e4332cdc4e1fe5cfb09a4688df31
-  languageName: node
-  linkType: hard
-
-"immutable@npm:~3.7.4":
-  version: 3.7.6
-  resolution: "immutable@npm:3.7.6"
-  checksum: efe2bbb2620aa897afbb79545b9eda4dd3dc072e05ae7004895a7efb43187e4265612a88f8723f391eb1c87c46c52fd11e2d1968e42404450c63e49558d7ca4e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Part of QAO-472

## Proposed Changes

* Add a targeted Yarn resolution for the `immutable@~3.7.4` descriptor used by `draft-js`.
* Resolve the `draft-js@0.11.7` path to `immutable@3.8.3`, the patched version for the remaining `immutable` alert.
* Remove the vulnerable `immutable@3.7.6` lockfile entry.

## Why are these changes being made?

* Dependabot reports `immutable@3.7.6` under `draft-js`. `draft-js@0.11.7` is still the current stable line and pins `immutable` to `~3.7.4`, so a parent upgrade does not move this path.
* This keeps `draft-js` unchanged while applying the patched same-major `immutable` 3.x release.

## Testing Instructions

* `git diff --check`
* `yarn install --immutable`
* `yarn dedupe --check`
* `yarn why immutable`
* Confirm no `immutable@3.7.6` lockfile entry remains.
* `yarn node -e "const {EditorState, ContentState, convertToRaw, convertFromRaw}=require('draft-js'); const content=ContentState.createFromText('hello'); const raw=convertToRaw(content); const restored=convertFromRaw(raw); const state=EditorState.createWithContent(restored); console.log(raw.blocks[0].text); console.log(state.getCurrentContent().getPlainText());"`
* `NODE_OPTIONS=--max-old-space-size=8192 yarn typecheck-client`
* `NODE_OPTIONS=--max-old-space-size=8192 yarn run build-client`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?