### PR TITLE
Override external-editor tmp

### DIFF
--- a/package.json
+++ b/package.json
@@ -348,6 +348,7 @@
 		"sha.js": "2.4.12",
 		"form-data": "^4.0.4",
 		"minimatch@npm:3.0.4": "3.1.5",
+		"tmp@npm:^0.0.33": "0.2.7",
 		"@wordpress/a11y": "4.46.0",
 		"@wordpress/annotations": "3.46.0",
 		"@wordpress/api-fetch": "7.46.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -25929,13 +25929,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"os-tmpdir@npm:~1.0.2":
-  version: 1.0.2
-  resolution: "os-tmpdir@npm:1.0.2"
-  checksum: f438450224f8e2687605a8dd318f0db694b6293c5d835ae509a69e97c8de38b6994645337e5577f5001115470414638978cc49da1cdcc25106dad8738dc69990
-  languageName: node
-  linkType: hard
-
 "outvariant@npm:^1.2.1, outvariant@npm:^1.4.0, outvariant@npm:^1.4.2, outvariant@npm:^1.4.3":
   version: 1.4.3
   resolution: "outvariant@npm:1.4.3"
@@ -32014,16 +32007,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tmp@npm:^0.0.33":
-  version: 0.0.33
-  resolution: "tmp@npm:0.0.33"
-  dependencies:
-    os-tmpdir: "npm:~1.0.2"
-  checksum: 69863947b8c29cabad43fe0ce65cec5bb4b481d15d4b4b21e036b060b3edbf3bc7a5541de1bacb437bb3f7c4538f669752627fdf9b4aaf034cebd172ba373408
-  languageName: node
-  linkType: hard
-
-"tmp@npm:^0.2.0":
+"tmp@npm:0.2.7, tmp@npm:^0.2.0":
   version: 0.2.7
   resolution: "tmp@npm:0.2.7"
   checksum: 59eb55584f2f07210d3231b6a1f6b5c2b9794d8a7b509c8ee867ed2acad6d2245ee2448b7937b676ffbff3155a70077edde8a69f9d7cf0f90c86a62e8910c357


### PR DESCRIPTION
Part of QAO-472

## Proposed Changes

* Add a targeted Yarn resolution for the `tmp@^0.0.33` descriptor used by `external-editor`.
* Resolve `external-editor@3.1.0` to `tmp@0.2.7`, matching the existing patched `tmp` line already used by `tmp-promise`.
* Remove the vulnerable `tmp@0.0.33` and now-unused `os-tmpdir` lockfile entries.

## Why are these changes being made?

* Dependabot reports the remaining `tmp` alerts against `tmp@0.0.33`. The only vulnerable path is `external-editor -> tmp@^0.0.33`; the other `tmp` path is already on `0.2.7`.
* `external-editor@3.1.0` is still the current line and uses `tmp.tmpNameSync()`, which is present in `tmp@0.2.7`.

## Testing Instructions

* `git diff --check`
* `yarn install --immutable`
* `yarn dedupe --check`
* `yarn why tmp`
* Confirm no `tmp@0.0.33` or `os-tmpdir` lockfile entry remains.
* Node smoke check for `tmp`, `external-editor`, `inquirer`, `node-plop`, and `eslint` imports.
* `ExternalEditor` constructor/cleanup smoke check using a temporary text file.
* `yarn test-build-tools`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?