### PR TITLE
Override http-proxy-agent once

### DIFF
--- a/package.json
+++ b/package.json
@@ -341,6 +341,7 @@
 		"@types/react-dom": "^18.3.7",
 		"@types/wordpress__block-editor": "npm:noop-package@1.0.0",
 		"@types/wordpress__editor": "npm:noop-package@1.0.0",
+		"@tootallnate/once@npm:1": "2.0.1",
 		"keytar@npm:7.7.0/node-addon-api": "3.1.0",
 		"lzma-native": "^8.0.6",
 		"node-abi": "3.35.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8692,14 +8692,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tootallnate/once@npm:1":
-  version: 1.1.2
-  resolution: "@tootallnate/once@npm:1.1.2"
-  checksum: 8fe4d006e90422883a4fa9339dd05a83ff626806262e1710cee5758d493e8cbddf2db81c0e4690636dc840b02c9fda62877866ea774ebd07c1777ed5fafbdec6
-  languageName: node
-  linkType: hard
-
-"@tootallnate/once@npm:2":
+"@tootallnate/once@npm:2, @tootallnate/once@npm:2.0.1":
   version: 2.0.1
   resolution: "@tootallnate/once@npm:2.0.1"
   checksum: 23b01a341485be711c602077936d70f8e695405bb88ab4433dc6d1e6cb4556401518789574d399eded790b70b27738136c9a8f02df7ae4219f4ba28bb22d586b


### PR DESCRIPTION
Part of QAO-472

## Proposed Changes

* Add a targeted Yarn resolution for the `@tootallnate/once@npm:1` descriptor.
* Resolve `http-proxy-agent@4.0.1` to `@tootallnate/once@2.0.1`, matching the existing patched line already used by `http-proxy-agent@5.0.0`.
* Remove the vulnerable `@tootallnate/once@1.1.2` lockfile entry.

## Why are these changes being made?

* Dependabot reports the remaining `@tootallnate/once` alert against `1.1.2`. The vulnerable path is `node-gyp -> make-fetch-happen -> http-proxy-agent@4 -> @tootallnate/once@1`.
* `http-proxy-agent@4` imports the default function and does not use the removed v1 `spread` helper. The smoke checks below cover that runtime path.

## Testing Instructions

* `git diff --check`
* `yarn install --immutable`
* `yarn dedupe --check`
* `yarn why @tootallnate/once`
* Confirm no `@tootallnate/once@1.1.2` lockfile entry remains.
* Node smoke check for `@tootallnate/once@2.0.1` default export resolution.
* Local HTTP proxy smoke through `make-fetch-happen -> http-proxy-agent@4`, confirming a proxied request succeeds with the override.
* Direct local HTTP proxy smoke through `make-fetch-happen/node_modules/http-proxy-agent`.
* `yarn test-build-tools`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?