### PR TITLE
Override old flatted pin

### DIFF
--- a/package.json
+++ b/package.json
@@ -347,6 +347,7 @@
 		"json-schema": "0.4.0",
 		"sha.js": "2.4.12",
 		"form-data": "^4.0.4",
+		"flatted@npm:^2.0.0": "3.4.2",
 		"immutable@npm:~3.7.4": "3.8.3",
 		"minimatch@npm:3.0.4": "3.1.5",
 		"tmp@npm:^0.0.33": "0.2.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19143,14 +19143,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flatted@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "flatted@npm:2.0.1"
-  checksum: f4176c0344820f7b049994e8980c5daecf54ca0e1aaf36ba030761939de28e1548364acf4452e297dd751789cfed9cdc59da327844202d3fce8b06c1ea332b93
-  languageName: node
-  linkType: hard
-
-"flatted@npm:^3.1.0, flatted@npm:^3.2.9, flatted@npm:^3.3.3":
+"flatted@npm:3.4.2, flatted@npm:^3.1.0, flatted@npm:^3.2.9, flatted@npm:^3.3.3":
   version: 3.4.2
   resolution: "flatted@npm:3.4.2"
   checksum: a65b67aae7172d6cdf63691be7de6c5cd5adbdfdfe2e9da1a09b617c9512ed794037741ee53d93114276bff3f93cd3b0d97d54f9b316e1e4885dde6e9ffdf7ed


### PR DESCRIPTION
Part of QAO-472

## Proposed Changes

* Add a targeted Yarn resolution for `flatted@^2.0.0` to resolve to `3.4.2`.
* Regenerate the lockfile so the vulnerable `flatted@2.0.1` package entry is removed.

## Why are these changes being made?

* This removes the Dependabot alert for `flatted` through `markdown-eslint-parser -> eslint@6 -> file-entry-cache@5 -> flat-cache@2`.
* `eslint-plugin-md` and `markdown-eslint-parser` have no newer published version, so this keeps the parent graph stable while using the patched `flatted@3.4.2` version already used elsewhere in the repo.

## Testing Instructions

* `git diff --check`
* `yarn install --immutable`
* `yarn dedupe --check`
* `yarn why flatted`
* Direct smoke for `file-entry-cache@5` through `flat-cache@2`, including circular serialization and cache write/read.
* Markdown ESLint stdin smoke through `eslint-plugin-md` and `markdown-eslint-parser`.
* `NODE_OPTIONS=--max-old-space-size=8192 yarn typecheck-client`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?