### PR TITLE
Override old uuid range

### DIFF
--- a/package.json
+++ b/package.json
@@ -350,6 +350,8 @@
 		"immutable@npm:~3.7.4": "3.8.3",
 		"minimatch@npm:3.0.4": "3.1.5",
 		"tmp@npm:^0.0.33": "0.2.7",
+		"uuid@npm:^8.3.0": "11.1.1",
+		"uuid@npm:^8.3.2": "11.1.1",
 		"@wordpress/a11y": "4.46.0",
 		"@wordpress/annotations": "3.46.0",
 		"@wordpress/api-fetch": "7.46.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -33380,6 +33380,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uuid@npm:11.1.1":
+  version: 11.1.1
+  resolution: "uuid@npm:11.1.1"
+  bin:
+    uuid: dist/esm/bin/uuid
+  checksum: 9e3af58eba872ece5a5e76f4773a94fc78a0ef2c2444c38dbe6b42f41dadf76c01850fd783604f27986f6195e6286aef064d45987d401b2a33127b98ddf7c0c5
+  languageName: node
+  linkType: hard
+
 "uuid@npm:^14.0.0":
   version: 14.0.0
   resolution: "uuid@npm:14.0.0"
@@ -33395,15 +33404,6 @@ __metadata:
   bin:
     uuid: ./bin/uuid
   checksum: 1c13950df865c4f506ebfe0a24023571fa80edf2e62364297a537c80af09c618299797bbf2dbac6b1f8ae5ad182ba474b89db61e0e85839683991f7e08795347
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^8.3.0, uuid@npm:^8.3.2":
-  version: 8.3.2
-  resolution: "uuid@npm:8.3.2"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: bcbb807a917d374a49f475fae2e87fdca7da5e5530820ef53f65ba1d12131bd81a92ecf259cc7ce317cbe0f289e7d79fdfebcef9bfa3087c8c8a2fa304c9be54
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Part of QAO-472

## Proposed Changes

* Add targeted Yarn resolutions for `uuid@^8.3.0` and `uuid@^8.3.2` to resolve to `11.1.1`.
* Regenerate the lockfile so the vulnerable `uuid@8.3.2` package entry is removed.

## Why are these changes being made?

* This removes the Dependabot alert for `uuid@8.3.2`.
* The affected parents are `@vgs/collect-js` and `allure-js-commons`; both use the `v4()` export, which is still available in `uuid@11.1.1` for CommonJS and ESM consumers.

## Testing Instructions

* `git diff --check`
* `yarn install --immutable`
* `yarn dedupe --check`
* `yarn why uuid`
* CommonJS and ESM import smokes for `uuid@11.1.1` through `@vgs/collect-js` and `allure-js-commons`.
* Runtime Allure smoke creating group and test UUIDs.
* `yarn workspace @automattic/jest-circus-allure-reporter build`
* `yarn test-client client/my-sites/checkout/src/test/vgs-credit-card-fields.test.tsx --runInBand`
* `NODE_OPTIONS=--max-old-space-size=8192 yarn typecheck-client`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?