### PR TITLE
Override serialize-javascript

### DIFF
--- a/package.json
+++ b/package.json
@@ -352,6 +352,8 @@
 		"flatted@npm:^2.0.0": "3.4.2",
 		"immutable@npm:~3.7.4": "3.8.3",
 		"minimatch@npm:3.0.4": "3.1.5",
+		"serialize-javascript@npm:^6.0.0": "7.0.5",
+		"serialize-javascript@npm:^6.0.2": "7.0.5",
 		"tmp@npm:^0.0.33": "0.2.7",
 		"uuid@npm:^8.3.0": "11.1.1",
 		"uuid@npm:^8.3.2": "11.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -27584,15 +27584,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"randombytes@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "randombytes@npm:2.1.0"
-  dependencies:
-    safe-buffer: "npm:^5.1.0"
-  checksum: 50395efda7a8c94f5dffab564f9ff89736064d32addf0cc7e8bf5e4166f09f8ded7a0849ca6c2d2a59478f7d90f78f20d8048bca3cdf8be09d8e8a10790388f3
-  languageName: node
-  linkType: hard
-
 "range-parser@npm:^1.2.1, range-parser@npm:~1.2.1":
   version: 1.2.1
   resolution: "range-parser@npm:1.2.1"
@@ -29809,7 +29800,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:5.2.1, safe-buffer@npm:^5.0.1, safe-buffer@npm:^5.1.0, safe-buffer@npm:^5.1.1, safe-buffer@npm:^5.1.2, safe-buffer@npm:^5.2.0, safe-buffer@npm:^5.2.1, safe-buffer@npm:~5.2.0":
+"safe-buffer@npm:5.2.1, safe-buffer@npm:^5.0.1, safe-buffer@npm:^5.1.1, safe-buffer@npm:^5.1.2, safe-buffer@npm:^5.2.0, safe-buffer@npm:^5.2.1, safe-buffer@npm:~5.2.0":
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
   checksum: 6501914237c0a86e9675d4e51d89ca3c21ffd6a31642efeba25ad65720bce6921c9e7e974e5be91a786b25aa058b5303285d3c15dbabf983a919f5f630d349f3
@@ -30333,12 +30324,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serialize-javascript@npm:^6.0.0, serialize-javascript@npm:^6.0.2":
-  version: 6.0.2
-  resolution: "serialize-javascript@npm:6.0.2"
-  dependencies:
-    randombytes: "npm:^2.1.0"
-  checksum: 2dd09ef4b65a1289ba24a788b1423a035581bef60817bea1f01eda8e3bda623f86357665fe7ac1b50f6d4f583f97db9615b3f07b2a2e8cbcb75033965f771dd2
+"serialize-javascript@npm:7.0.5":
+  version: 7.0.5
+  resolution: "serialize-javascript@npm:7.0.5"
+  checksum: 7b7818e5267f6d474ec7a56d36ba69dd712726a13eab37706ec94615fb7ca8945471f2b7fb0dc9dbe8c79c1930c1079d97f66f91315c8c8c2ca6c38898cec96f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Part of QAO-472

## Proposed Changes

* Add targeted Yarn resolutions for `serialize-javascript@^6.0.0` and `serialize-javascript@^6.0.2`, resolving both to `7.0.5`.
* Remove the vulnerable `serialize-javascript@6.0.2` lockfile entry and its now-unused `randombytes` transitive.

## Why are these changes being made?

* `serialize-javascript@6.0.2` has one High and one Moderate Dependabot alert.
* The vulnerable package is pulled through `copy-webpack-plugin`, `css-minimizer-webpack-plugin`, and `terser-webpack-plugin`.
* A targeted override keeps the current webpack plugin versions stable, including the SWC-sensitive `terser-webpack-plugin@5.3.16` line.

## Testing Instructions

* `git diff --check`
* `yarn install --immutable`
* `yarn dedupe --check`
* `yarn why serialize-javascript`
* Confirmed no `serialize-javascript@6.0.2` or `randombytes@2.1.0` lockfile entries remain.
* Ran direct `serialize-javascript@7.0.5` API smoke checks for HTML escaping, functions, regexps, dates, maps, and sets.
* Ran parent-resolution smoke checks for `copy-webpack-plugin@10.2.4`, `css-minimizer-webpack-plugin@3.4.1`, and `terser-webpack-plugin@5.3.16`.
* `yarn test-build-tools`
* `yarn test-packages packages/webpack-inline-constant-exports-plugin/test/index.js packages/webpack-config-flag-plugin/test/index.js packages/webpack-rtl-plugin/test/index.js --runInBand`
* `NODE_OPTIONS=--max-old-space-size=8192 yarn typecheck-client`
* `NODE_OPTIONS=--max-old-space-size=8192 yarn run build-client`
* `NODE_OPTIONS=--max-old-space-size=8192 yarn run build-desktop:app`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
