### PR TITLE
Akismet: update Pro and Business limit copy

### DIFF
--- a/client/dashboard/me/billing-history/dataviews.tsx
+++ b/client/dashboard/me/billing-history/dataviews.tsx
@@ -5,7 +5,7 @@ import { __experimentalText as Text, __experimentalVStack as VStack } from '@wor
 import { __, sprintf } from '@wordpress/i18n';
 import { useMemo } from 'react';
 import { receiptRoute } from '../../app/router/me';
-import { getAkismetProductDisplayName } from '../../utils/akismet';
+import { getAkismetProductDisplayName, isAkismetProOrBusinessPlan } from '../../utils/akismet';
 import { getTaxName } from '../../utils/tax';
 import {
 	formatReceiptAmount,
@@ -324,11 +324,13 @@ function renderServiceNameDescription( receipt: Receipt ) {
 
 	const receiptItem = receiptItems[ 0 ];
 	const termLabel = getTransactionTermLabel( receiptItem );
-	const displayLabel = getAkismetProductDisplayName(
-		label,
-		receiptItem.wpcom_product_slug,
-		receiptItem.licensed_quantity ?? 0
-	);
+	const displayLabel = isAkismetProOrBusinessPlan( receiptItem.wpcom_product_slug )
+		? getAkismetProductDisplayName(
+				label,
+				receiptItem.wpcom_product_slug,
+				receiptItem.licensed_quantity ?? 0
+		  )
+		: label;
 
 	return (
 		<VStack spacing={ 1 }>

--- a/client/dashboard/me/billing-history/dataviews.tsx
+++ b/client/dashboard/me/billing-history/dataviews.tsx
@@ -5,7 +5,7 @@ import { __experimentalText as Text, __experimentalVStack as VStack } from '@wor
 import { __, sprintf } from '@wordpress/i18n';
 import { useMemo } from 'react';
 import { receiptRoute } from '../../app/router/me';
-import { isAkismetPro500Plan } from '../../utils/akismet';
+import { getAkismetProductDisplayName } from '../../utils/akismet';
 import { getTaxName } from '../../utils/tax';
 import {
 	formatReceiptAmount,
@@ -324,16 +324,11 @@ function renderServiceNameDescription( receipt: Receipt ) {
 
 	const receiptItem = receiptItems[ 0 ];
 	const termLabel = getTransactionTermLabel( receiptItem );
-	const isAkismet =
-		receiptItem.licensed_quantity && isAkismetPro500Plan( receiptItem.wpcom_product_slug );
-	const displayLabel = isAkismet
-		? sprintf(
-				/* translators: 1: product name like "Akismet Pro", 2: number of requests per month */
-				__( '%1$s (%2$d requests/month)' ),
-				label.replace( /\s*\(.*$/, '' ).trim(),
-				500 * parseInt( String( receiptItem.licensed_quantity ) )
-		  )
-		: label;
+	const displayLabel = getAkismetProductDisplayName(
+		label,
+		receiptItem.wpcom_product_slug,
+		receiptItem.licensed_quantity ?? 0
+	);
 
 	return (
 		<VStack spacing={ 1 }>

--- a/client/dashboard/me/billing-history/receipt.tsx
+++ b/client/dashboard/me/billing-history/receipt.tsx
@@ -25,7 +25,7 @@ import { receiptRoute, taxDetailsRoute } from '../../app/router/me';
 import { Card, CardBody } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import { getAkismetProductDisplayName } from '../../utils/akismet';
+import { getAkismetProductDisplayName, isAkismetProOrBusinessPlan } from '../../utils/akismet';
 import { getTaxName } from '../../utils/tax';
 import {
 	formatReceiptAmount,
@@ -367,11 +367,13 @@ function ReceiptLineItems( { receipt }: { receipt: Receipt } ) {
 
 function ReceiptLineItem( { item, receipt }: { item: ReceiptItem; receipt: Receipt } ) {
 	const termLabel = getTransactionTermLabel( item );
-	const variationDisplay = getAkismetProductDisplayName(
-		item.variation,
-		item.wpcom_product_slug,
-		item.licensed_quantity ?? 0
-	);
+	const variationDisplay = isAkismetProOrBusinessPlan( item.wpcom_product_slug )
+		? getAkismetProductDisplayName(
+				item.variation,
+				item.wpcom_product_slug,
+				item.licensed_quantity ?? 0
+		  )
+		: item.variation;
 	const shouldShowDiscount = areReceiptItemDiscountsAccurate( receipt.date );
 	const subtotalInteger = shouldShowDiscount
 		? getReceiptItemOriginalCost( item )

--- a/client/dashboard/me/billing-history/receipt.tsx
+++ b/client/dashboard/me/billing-history/receipt.tsx
@@ -25,7 +25,7 @@ import { receiptRoute, taxDetailsRoute } from '../../app/router/me';
 import { Card, CardBody } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import { isAkismetPro500Plan } from '../../utils/akismet';
+import { getAkismetProductDisplayName } from '../../utils/akismet';
 import { getTaxName } from '../../utils/tax';
 import {
 	formatReceiptAmount,
@@ -367,15 +367,11 @@ function ReceiptLineItems( { receipt }: { receipt: Receipt } ) {
 
 function ReceiptLineItem( { item, receipt }: { item: ReceiptItem; receipt: Receipt } ) {
 	const termLabel = getTransactionTermLabel( item );
-	const isAkismet = item.licensed_quantity && isAkismetPro500Plan( item.wpcom_product_slug );
-	const variationDisplay = isAkismet
-		? sprintf(
-				/* translators: 1: product name like "Akismet Pro", 2: number of requests per month */
-				__( '%1$s (%2$d requests/month)' ),
-				item.variation.replace( /\s*\(.*$/, '' ).trim(),
-				500 * parseInt( String( item.licensed_quantity ) )
-		  )
-		: item.variation;
+	const variationDisplay = getAkismetProductDisplayName(
+		item.variation,
+		item.wpcom_product_slug,
+		item.licensed_quantity ?? 0
+	);
 	const shouldShowDiscount = areReceiptItemDiscountsAccurate( receipt.date );
 	const subtotalInteger = shouldShowDiscount
 		? getReceiptItemOriginalCost( item )

--- a/client/dashboard/me/billing-history/utils.tsx
+++ b/client/dashboard/me/billing-history/utils.tsx
@@ -190,10 +190,10 @@ function renderSpaceAddOnquantitySummary( licensedQuantity: number, isRenewal: b
 function renderAkismetTransactionQuantitySummary( licensedQuantity: number, isRenewal: boolean ) {
 	if ( isRenewal ) {
 		return sprintf(
-			/* translators: %d: number of 500 API call licenses */
+			/* translators: %d: number of 8K API call licenses */
 			_n(
-				'Renewal for %d 500 API call license',
-				'Renewal for %d 500 API call licenses',
+				'Renewal for %d 8K API call license',
+				'Renewal for %d 8K API call licenses',
 				licensedQuantity
 			),
 			licensedQuantity
@@ -201,10 +201,10 @@ function renderAkismetTransactionQuantitySummary( licensedQuantity: number, isRe
 	}
 
 	return sprintf(
-		/* translators: %d: number of 500 API call licenses */
+		/* translators: %d: number of 8K API call licenses */
 		_n(
-			'Purchase of %d 500 API call license',
-			'Purchase of %d 500 API call licenses',
+			'Purchase of %d 8K API call license',
+			'Purchase of %d 8K API call licenses',
 			licensedQuantity
 		),
 		licensedQuantity

--- a/client/dashboard/utils/akismet.ts
+++ b/client/dashboard/utils/akismet.ts
@@ -14,3 +14,18 @@ export function isAkismetPro500Plan( productSlug: string ): boolean {
 		] as readonly string[]
 	 ).includes( productSlug );
 }
+
+/**
+ * Determines whether the specified product slug is for an Akismet Business 5k plan.
+ * @param {string} productSlug - slug of the product
+ * @returns {boolean} true if the slug refers to any Akismet Business 5k plan, false otherwise
+ */
+export function isAkismetBusiness5kPlan( productSlug: string ): boolean {
+	return (
+		[
+			AkismetPlans.PRODUCT_AKISMET_BUSINESS_5K_MONTHLY,
+			AkismetPlans.PRODUCT_AKISMET_BUSINESS_5K_YEARLY,
+			AkismetPlans.PRODUCT_AKISMET_BUSINESS_5K_BI_YEARLY,
+		] as readonly string[]
+	 ).includes( productSlug );
+}

--- a/client/dashboard/utils/akismet.ts
+++ b/client/dashboard/utils/akismet.ts
@@ -38,9 +38,21 @@ export function isAkismetBusiness5kPlan( productSlug: string ): boolean {
 }
 
 /**
+ * Determines whether the specified product slug is for an Akismet plan that has a
+ * synthesized display name (Akismet Pro 500 or Business 5k).
+ * @param {string} productSlug - slug of the product
+ * @returns {boolean} true if the slug refers to such a plan, false otherwise
+ */
+export function isAkismetProOrBusinessPlan( productSlug: string ): boolean {
+	return isAkismetPro500Plan( productSlug ) || isAkismetBusiness5kPlan( productSlug );
+}
+
+/**
  * Returns the display name for an Akismet Pro or Business product, appending the
  * current monthly request allotment (e.g. "Akismet Pro (8K requests/month)").
- * For any other product, the given product name is returned unchanged.
+ *
+ * Assumes the product is an Akismet Pro 500 or Business 5k plan; guard calls with
+ * {@link isAkismetProOrBusinessPlan}.
  * @param {string} productName - the product name to format
  * @param {string} productSlug - slug of the product
  * @param {number} quantity - the licensed/renewal quantity (Pro scales with this)
@@ -53,7 +65,12 @@ export function getAkismetProductDisplayName(
 ): string {
 	const baseName = productName.replace( /\s*\(.*$/, '' ).trim();
 
-	if ( isAkismetPro500Plan( productSlug ) && quantity >= 1 ) {
+	if ( isAkismetPro500Plan( productSlug ) ) {
+		// The Pro allotment scales with quantity; a quantity below 1 has no
+		// meaningful allotment, so fall back to the bare product name.
+		if ( quantity < 1 ) {
+			return baseName;
+		}
 		const requestsInThousands = ( AKISMET_PRO_REQUESTS_PER_QUANTITY * quantity ) / 1000;
 		/* translators: %(productName)s is the product name (e.g. "Akismet Pro"); %(requestsK)d is the monthly request count in thousands, rendered as "NK" (e.g. "8K"). */
 		return sprintf( __( '%(productName)s (%(requestsK)dK requests/month)' ), {
@@ -62,14 +79,11 @@ export function getAkismetProductDisplayName(
 		} );
 	}
 
-	if ( isAkismetBusiness5kPlan( productSlug ) ) {
-		const requestsInThousands = AKISMET_BUSINESS_REQUESTS_PER_MONTH / 1000;
-		/* translators: %(productName)s is the product name (e.g. "Akismet Business"); %(requestsK)d is the monthly request count in thousands, rendered as "NK" (e.g. "80K"). */
-		return sprintf( __( '%(productName)s (%(requestsK)dK requests/month)' ), {
-			productName: baseName,
-			requestsK: requestsInThousands,
-		} );
-	}
-
-	return productName;
+	// Akismet Business 5k — a flat monthly allotment.
+	const requestsInThousands = AKISMET_BUSINESS_REQUESTS_PER_MONTH / 1000;
+	/* translators: %(productName)s is the product name (e.g. "Akismet Business"); %(requestsK)d is the monthly request count in thousands, rendered as "NK" (e.g. "80K"). */
+	return sprintf( __( '%(productName)s (%(requestsK)dK requests/month)' ), {
+		productName: baseName,
+		requestsK: requestsInThousands,
+	} );
 }

--- a/client/dashboard/utils/akismet.ts
+++ b/client/dashboard/utils/akismet.ts
@@ -64,24 +64,20 @@ export function getAkismetProductDisplayName(
 	quantity: number
 ): string {
 	const baseName = productName.replace( /\s*\(.*$/, '' ).trim();
+	const isPro = isAkismetPro500Plan( productSlug );
 
-	if ( isAkismetPro500Plan( productSlug ) ) {
-		// The Pro allotment scales with quantity; a quantity below 1 has no
-		// meaningful allotment, so fall back to the bare product name.
-		if ( quantity < 1 ) {
-			return baseName;
-		}
-		const requestsInThousands = ( AKISMET_PRO_REQUESTS_PER_QUANTITY * quantity ) / 1000;
-		/* translators: %(productName)s is the product name (e.g. "Akismet Pro"); %(requestsK)d is the monthly request count in thousands, rendered as "NK" (e.g. "8K"). */
-		return sprintf( __( '%(productName)s (%(requestsK)dK requests/month)' ), {
-			productName: baseName,
-			requestsK: requestsInThousands,
-		} );
+	// The Pro allotment scales with quantity; a quantity below 1 has no
+	// meaningful allotment, so fall back to the bare product name. Business is a
+	// flat monthly allotment that ignores quantity.
+	if ( isPro && quantity < 1 ) {
+		return baseName;
 	}
 
-	// Akismet Business 5k — a flat monthly allotment.
-	const requestsInThousands = AKISMET_BUSINESS_REQUESTS_PER_MONTH / 1000;
-	/* translators: %(productName)s is the product name (e.g. "Akismet Business"); %(requestsK)d is the monthly request count in thousands, rendered as "NK" (e.g. "80K"). */
+	const requestsInThousands = isPro
+		? ( AKISMET_PRO_REQUESTS_PER_QUANTITY * quantity ) / 1000
+		: AKISMET_BUSINESS_REQUESTS_PER_MONTH / 1000;
+
+	/* translators: %(productName)s is the product name (e.g. "Akismet Pro"); %(requestsK)d is the monthly request count in thousands, rendered as "NK" (e.g. "8K"). */
 	return sprintf( __( '%(productName)s (%(requestsK)dK requests/month)' ), {
 		productName: baseName,
 		requestsK: requestsInThousands,

--- a/client/dashboard/utils/akismet.ts
+++ b/client/dashboard/utils/akismet.ts
@@ -1,4 +1,11 @@
 import { AkismetPlans } from '@automattic/api-core';
+import { __, sprintf } from '@wordpress/i18n';
+
+// "Pro 500" / "Business 5k" are legacy names retained for backend product-slug
+// stability (ak_pro5h_*, ak_bus5k_*). The current allotments are 8000
+// requests/month per Pro quantity and 80000 requests/month for Business.
+const AKISMET_PRO_REQUESTS_PER_QUANTITY = 8000;
+const AKISMET_BUSINESS_REQUESTS_PER_MONTH = 80000;
 
 /**
  * Determines whether the specified product slug is for an Akismet Pro 500 plan.
@@ -28,4 +35,41 @@ export function isAkismetBusiness5kPlan( productSlug: string ): boolean {
 			AkismetPlans.PRODUCT_AKISMET_BUSINESS_5K_BI_YEARLY,
 		] as readonly string[]
 	 ).includes( productSlug );
+}
+
+/**
+ * Returns the display name for an Akismet Pro or Business product, appending the
+ * current monthly request allotment (e.g. "Akismet Pro (8K requests/month)").
+ * For any other product, the given product name is returned unchanged.
+ * @param {string} productName - the product name to format
+ * @param {string} productSlug - slug of the product
+ * @param {number} quantity - the licensed/renewal quantity (Pro scales with this)
+ * @returns {string} the formatted display name
+ */
+export function getAkismetProductDisplayName(
+	productName: string,
+	productSlug: string,
+	quantity: number
+): string {
+	const baseName = productName.replace( /\s*\(.*$/, '' ).trim();
+
+	if ( isAkismetPro500Plan( productSlug ) && quantity >= 1 ) {
+		const requestsInThousands = ( AKISMET_PRO_REQUESTS_PER_QUANTITY * quantity ) / 1000;
+		/* translators: %(productName)s is the product name (e.g. "Akismet Pro"); %(requestsK)d is the monthly request count in thousands, rendered as "NK" (e.g. "8K"). */
+		return sprintf( __( '%(productName)s (%(requestsK)dK requests/month)' ), {
+			productName: baseName,
+			requestsK: requestsInThousands,
+		} );
+	}
+
+	if ( isAkismetBusiness5kPlan( productSlug ) ) {
+		const requestsInThousands = AKISMET_BUSINESS_REQUESTS_PER_MONTH / 1000;
+		/* translators: %(productName)s is the product name (e.g. "Akismet Business"); %(requestsK)d is the monthly request count in thousands, rendered as "NK" (e.g. "80K"). */
+		return sprintf( __( '%(productName)s (%(requestsK)dK requests/month)' ), {
+			productName: baseName,
+			requestsK: requestsInThousands,
+		} );
+	}
+
+	return productName;
 }

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -14,7 +14,7 @@ import { formatNumber } from '@automattic/number-formatters';
 import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { isAfter, parseISO, startOfDay } from 'date-fns';
-import { isAkismetPro500Plan } from './akismet';
+import { isAkismetBusiness5kPlan, isAkismetPro500Plan } from './akismet';
 import { isWithinLast, isWithinNext, getDateFromCreditCardExpiry } from './datetime';
 import { isGSuiteProductSlug } from './gsuite';
 import { redirectToDashboardLink, wpcomLink } from './link';
@@ -325,6 +325,18 @@ export function getTitleForDisplay( purchase: Purchase ): string {
 		const requestsInThousands =
 			( AKISMET_PRO_REQUESTS_PER_QUANTITY * purchase.renewal_price_tier_usage_quantity ) / 1000;
 		/* translators: %(productName)s is the product name (e.g. "Akismet Pro"); %(requestsK)d is the monthly request count in thousands, rendered as "NK" (e.g. "8K"). */
+		return sprintf( __( '%(productName)s (%(requestsK)dK requests/month)' ), {
+			productName: purchase.product_name.replace( /\s*\(.*$/, '' ).trim(),
+			requestsK: requestsInThousands,
+		} );
+	}
+
+	if ( isAkismetBusiness5kPlan( purchase.product_slug ) ) {
+		// "Business 5k" is legacy naming retained for backend product-slug stability
+		// (ak_bus5k_*). The allotment is now 80000 requests/month.
+		const AKISMET_BUSINESS_REQUESTS_PER_MONTH = 80000;
+		const requestsInThousands = AKISMET_BUSINESS_REQUESTS_PER_MONTH / 1000;
+		/* translators: %(productName)s is the product name (e.g. "Akismet Business"); %(requestsK)d is the monthly request count in thousands, rendered as "NK" (e.g. "80K"). */
 		return sprintf( __( '%(productName)s (%(requestsK)dK requests/month)' ), {
 			productName: purchase.product_name.replace( /\s*\(.*$/, '' ).trim(),
 			requestsK: requestsInThousands,

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -317,7 +317,7 @@ export function getTitleForDisplay( purchase: Purchase ): string {
 	if (
 		isAkismetPro500Plan( purchase.product_slug ) &&
 		purchase.renewal_price_tier_usage_quantity &&
-		purchase.renewal_price_tier_usage_quantity >= 1
+		purchase.renewal_price_tier_usage_quantity > 1
 	) {
 		// "Pro 500" is legacy naming retained for backend product-slug stability
 		// (ak_pro5h_*). The per-quantity allotment is now 8000 requests/month.

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -317,7 +317,7 @@ export function getTitleForDisplay( purchase: Purchase ): string {
 	if (
 		isAkismetPro500Plan( purchase.product_slug ) &&
 		purchase.renewal_price_tier_usage_quantity &&
-		purchase.renewal_price_tier_usage_quantity > 1
+		purchase.renewal_price_tier_usage_quantity >= 1
 	) {
 		// "Pro 500" is legacy naming retained for backend product-slug stability
 		// (ak_pro5h_*). The per-quantity allotment is now 8000 requests/month.

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -322,12 +322,12 @@ export function getTitleForDisplay( purchase: Purchase ): string {
 		// "Pro 500" is legacy naming retained for backend product-slug stability
 		// (ak_pro5h_*). The per-quantity allotment is now 8000 requests/month.
 		const AKISMET_PRO_REQUESTS_PER_QUANTITY = 8000;
-		const requestsInK =
+		const requestsInThousands =
 			( AKISMET_PRO_REQUESTS_PER_QUANTITY * purchase.renewal_price_tier_usage_quantity ) / 1000;
 		/* translators: %(productName)s is the product name (e.g. "Akismet Pro"); %(requestsK)d is the monthly request count in thousands, rendered as "NK" (e.g. "8K"). */
 		return sprintf( __( '%(productName)s (%(requestsK)dK requests/month)' ), {
 			productName: purchase.product_name.replace( /\s*\(.*$/, '' ).trim(),
-			requestsK: requestsInK,
+			requestsK: requestsInThousands,
 		} );
 	}
 

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -317,12 +317,17 @@ export function getTitleForDisplay( purchase: Purchase ): string {
 	if (
 		isAkismetPro500Plan( purchase.product_slug ) &&
 		purchase.renewal_price_tier_usage_quantity &&
-		purchase.renewal_price_tier_usage_quantity > 1
+		purchase.renewal_price_tier_usage_quantity >= 1
 	) {
-		/* translators: %(productName)s is the product name "Akismet Pro", %(requests)d is a number of requests/month */
-		return sprintf( __( '%(productName)s (%(requests)d requests/month)' ), {
+		// "Pro 500" is legacy naming retained for backend product-slug stability
+		// (ak_pro5h_*). The per-quantity allotment is now 8000 requests/month.
+		const AKISMET_PRO_REQUESTS_PER_QUANTITY = 8000;
+		const requestsInK =
+			( AKISMET_PRO_REQUESTS_PER_QUANTITY * purchase.renewal_price_tier_usage_quantity ) / 1000;
+		/* translators: %(productName)s is the product name (e.g. "Akismet Pro"); %(requestsK)d is the monthly request count in thousands, rendered as "NK" (e.g. "8K"). */
+		return sprintf( __( '%(productName)s (%(requestsK)dK requests/month)' ), {
 			productName: purchase.product_name.replace( /\s*\(.*$/, '' ).trim(),
-			requests: 500 * purchase.renewal_price_tier_usage_quantity,
+			requestsK: requestsInK,
 		} );
 	}
 

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -14,7 +14,7 @@ import { formatNumber } from '@automattic/number-formatters';
 import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { isAfter, parseISO, startOfDay } from 'date-fns';
-import { isAkismetBusiness5kPlan, isAkismetPro500Plan } from './akismet';
+import { getAkismetProductDisplayName } from './akismet';
 import { isWithinLast, isWithinNext, getDateFromCreditCardExpiry } from './datetime';
 import { isGSuiteProductSlug } from './gsuite';
 import { redirectToDashboardLink, wpcomLink } from './link';
@@ -314,36 +314,11 @@ export function getTitleForDisplay( purchase: Purchase ): string {
 		return purchase.meta;
 	}
 
-	if (
-		isAkismetPro500Plan( purchase.product_slug ) &&
-		purchase.renewal_price_tier_usage_quantity &&
-		purchase.renewal_price_tier_usage_quantity >= 1
-	) {
-		// "Pro 500" is legacy naming retained for backend product-slug stability
-		// (ak_pro5h_*). The per-quantity allotment is now 8000 requests/month.
-		const AKISMET_PRO_REQUESTS_PER_QUANTITY = 8000;
-		const requestsInThousands =
-			( AKISMET_PRO_REQUESTS_PER_QUANTITY * purchase.renewal_price_tier_usage_quantity ) / 1000;
-		/* translators: %(productName)s is the product name (e.g. "Akismet Pro"); %(requestsK)d is the monthly request count in thousands, rendered as "NK" (e.g. "8K"). */
-		return sprintf( __( '%(productName)s (%(requestsK)dK requests/month)' ), {
-			productName: purchase.product_name.replace( /\s*\(.*$/, '' ).trim(),
-			requestsK: requestsInThousands,
-		} );
-	}
-
-	if ( isAkismetBusiness5kPlan( purchase.product_slug ) ) {
-		// "Business 5k" is legacy naming retained for backend product-slug stability
-		// (ak_bus5k_*). The allotment is now 80000 requests/month.
-		const AKISMET_BUSINESS_REQUESTS_PER_MONTH = 80000;
-		const requestsInThousands = AKISMET_BUSINESS_REQUESTS_PER_MONTH / 1000;
-		/* translators: %(productName)s is the product name (e.g. "Akismet Business"); %(requestsK)d is the monthly request count in thousands, rendered as "NK" (e.g. "80K"). */
-		return sprintf( __( '%(productName)s (%(requestsK)dK requests/month)' ), {
-			productName: purchase.product_name.replace( /\s*\(.*$/, '' ).trim(),
-			requestsK: requestsInThousands,
-		} );
-	}
-
-	return purchase.product_name;
+	return getAkismetProductDisplayName(
+		purchase.product_name,
+		purchase.product_slug,
+		purchase.renewal_price_tier_usage_quantity ?? 0
+	);
 }
 
 export function getTitleForListDisplay( purchase: Purchase ): string {

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -14,7 +14,7 @@ import { formatNumber } from '@automattic/number-formatters';
 import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { isAfter, parseISO, startOfDay } from 'date-fns';
-import { getAkismetProductDisplayName } from './akismet';
+import { getAkismetProductDisplayName, isAkismetProOrBusinessPlan } from './akismet';
 import { isWithinLast, isWithinNext, getDateFromCreditCardExpiry } from './datetime';
 import { isGSuiteProductSlug } from './gsuite';
 import { redirectToDashboardLink, wpcomLink } from './link';
@@ -314,11 +314,15 @@ export function getTitleForDisplay( purchase: Purchase ): string {
 		return purchase.meta;
 	}
 
-	return getAkismetProductDisplayName(
-		purchase.product_name,
-		purchase.product_slug,
-		purchase.renewal_price_tier_usage_quantity ?? 0
-	);
+	if ( isAkismetProOrBusinessPlan( purchase.product_slug ) ) {
+		return getAkismetProductDisplayName(
+			purchase.product_name,
+			purchase.product_slug,
+			purchase.renewal_price_tier_usage_quantity ?? 0
+		);
+	}
+
+	return purchase.product_name;
 }
 
 export function getTitleForListDisplay( purchase: Purchase ): string {

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -27,6 +27,8 @@ import {
 	isJetpackStatsPaidProductSlug,
 	isAkismetPro500,
 	getAkismetPro500ProductDisplayName,
+	isAkismetBusiness5k,
+	getAkismetBusiness5kProductDisplayName,
 	isAkismetFreeProduct,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
@@ -310,6 +312,10 @@ export function getDisplayName( purchase: Purchase ): TranslateResult {
 
 	if ( isAkismetPro500( purchase ) ) {
 		return getAkismetPro500ProductDisplayName( productName, purchaseRenewalQuantity );
+	}
+
+	if ( isAkismetBusiness5k( purchase ) ) {
+		return getAkismetBusiness5kProductDisplayName( productName );
 	}
 
 	return getName( purchase );

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -26,9 +26,8 @@ import {
 	isJetpackAISlug,
 	isJetpackStatsPaidProductSlug,
 	isAkismetPro500,
-	getAkismetPro500ProductDisplayName,
 	isAkismetBusiness5k,
-	getAkismetBusiness5kProductDisplayName,
+	getAkismetProductDisplayName,
 	isAkismetFreeProduct,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
@@ -310,12 +309,8 @@ export function getDisplayName( purchase: Purchase ): TranslateResult {
 		return getStorageAddOnDisplayName( productName, purchaseRenewalQuantity );
 	}
 
-	if ( isAkismetPro500( purchase ) ) {
-		return getAkismetPro500ProductDisplayName( productName, purchaseRenewalQuantity );
-	}
-
-	if ( isAkismetBusiness5k( purchase ) ) {
-		return getAkismetBusiness5kProductDisplayName( productName );
+	if ( isAkismetPro500( purchase ) || isAkismetBusiness5k( purchase ) ) {
+		return getAkismetProductDisplayName( purchase, productName, purchaseRenewalQuantity );
 	}
 
 	return getName( purchase );

--- a/client/me/purchases/billing-history/field-definitions.tsx
+++ b/client/me/purchases/billing-history/field-definitions.tsx
@@ -1,4 +1,9 @@
-import { isAkismetPro500, getAkismetPro500ProductDisplayName } from '@automattic/calypso-products';
+import {
+	isAkismetPro500,
+	getAkismetPro500ProductDisplayName,
+	isAkismetBusiness5k,
+	getAkismetBusiness5kProductDisplayName,
+} from '@automattic/calypso-products';
 import { type Fields, type Operator } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
 import { capitalPDangit } from 'calypso/lib/formatting';
@@ -20,13 +25,18 @@ function renderServiceNameDescription(
 	transaction: BillingTransactionItem,
 	translate: ReturnType< typeof useTranslate >
 ) {
-	const isAkismet = isAkismetPro500( { product_slug: transaction.wpcom_product_slug } );
-	const planName = isAkismet
-		? String(
+	const getPlanName = () => {
+		if ( isAkismetPro500( { product_slug: transaction.wpcom_product_slug } ) ) {
+			return String(
 				getAkismetPro500ProductDisplayName( transaction.variation, transaction.licensed_quantity )
-		  )
-		: transaction.variation;
-	const plan = capitalPDangit( planName );
+			);
+		}
+		if ( isAkismetBusiness5k( { product_slug: transaction.wpcom_product_slug } ) ) {
+			return String( getAkismetBusiness5kProductDisplayName( transaction.variation ) );
+		}
+		return transaction.variation;
+	};
+	const plan = capitalPDangit( getPlanName() );
 	const termLabel = getTransactionTermLabel( transaction, translate );
 
 	return (
@@ -166,16 +176,21 @@ export function getFieldDefinitions(
 				if ( transactionItem.product === transactionItem.variation ) {
 					return String( transactionItem.product );
 				}
-				const isAkismet = isAkismetPro500( { product_slug: transactionItem.wpcom_product_slug } );
-				const name = isAkismet
-					? String(
+				const getName = () => {
+					if ( isAkismetPro500( { product_slug: transactionItem.wpcom_product_slug } ) ) {
+						return String(
 							getAkismetPro500ProductDisplayName(
 								transactionItem.variation,
 								transactionItem.licensed_quantity
 							)
-					  )
-					: transactionItem.variation;
-				return capitalPDangit( name );
+						);
+					}
+					if ( isAkismetBusiness5k( { product_slug: transactionItem.wpcom_product_slug } ) ) {
+						return String( getAkismetBusiness5kProductDisplayName( transactionItem.variation ) );
+					}
+					return transactionItem.variation;
+				};
+				return capitalPDangit( getName() );
 			},
 		},
 		{

--- a/client/me/purchases/billing-history/field-definitions.tsx
+++ b/client/me/purchases/billing-history/field-definitions.tsx
@@ -1,9 +1,4 @@
-import {
-	isAkismetPro500,
-	getAkismetPro500ProductDisplayName,
-	isAkismetBusiness5k,
-	getAkismetBusiness5kProductDisplayName,
-} from '@automattic/calypso-products';
+import { getAkismetProductDisplayName } from '@automattic/calypso-products';
 import { type Fields, type Operator } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
 import { capitalPDangit } from 'calypso/lib/formatting';
@@ -25,18 +20,13 @@ function renderServiceNameDescription(
 	transaction: BillingTransactionItem,
 	translate: ReturnType< typeof useTranslate >
 ) {
-	const getPlanName = () => {
-		if ( isAkismetPro500( { product_slug: transaction.wpcom_product_slug } ) ) {
-			return String(
-				getAkismetPro500ProductDisplayName( transaction.variation, transaction.licensed_quantity )
-			);
-		}
-		if ( isAkismetBusiness5k( { product_slug: transaction.wpcom_product_slug } ) ) {
-			return String( getAkismetBusiness5kProductDisplayName( transaction.variation ) );
-		}
-		return transaction.variation;
-	};
-	const plan = capitalPDangit( getPlanName() );
+	const plan = capitalPDangit(
+		getAkismetProductDisplayName(
+			{ product_slug: transaction.wpcom_product_slug },
+			transaction.variation,
+			transaction.licensed_quantity
+		)
+	);
 	const termLabel = getTransactionTermLabel( transaction, translate );
 
 	return (
@@ -176,21 +166,12 @@ export function getFieldDefinitions(
 				if ( transactionItem.product === transactionItem.variation ) {
 					return String( transactionItem.product );
 				}
-				const getName = () => {
-					if ( isAkismetPro500( { product_slug: transactionItem.wpcom_product_slug } ) ) {
-						return String(
-							getAkismetPro500ProductDisplayName(
-								transactionItem.variation,
-								transactionItem.licensed_quantity
-							)
-						);
-					}
-					if ( isAkismetBusiness5k( { product_slug: transactionItem.wpcom_product_slug } ) ) {
-						return String( getAkismetBusiness5kProductDisplayName( transactionItem.variation ) );
-					}
-					return transactionItem.variation;
-				};
-				return capitalPDangit( getName() );
+				const name = getAkismetProductDisplayName(
+					{ product_slug: transactionItem.wpcom_product_slug },
+					transactionItem.variation,
+					transactionItem.licensed_quantity
+				);
+				return capitalPDangit( name );
 			},
 		},
 		{

--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -1,9 +1,4 @@
-import {
-	isAkismetPro500,
-	getAkismetPro500ProductDisplayName,
-	isAkismetBusiness5k,
-	getAkismetBusiness5kProductDisplayName,
-} from '@automattic/calypso-products';
+import { getAkismetProductDisplayName } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, Card, FormLabel } from '@automattic/components';
 import { formatCurrency } from '@automattic/number-formatters';
@@ -585,15 +580,11 @@ function ReceiptLineItem( {
 			<tr>
 				<td className="billing-history__receipt-item-name">
 					<span>
-						{ ( () => {
-							if ( isAkismetPro500( { product_slug: item.wpcom_product_slug } ) ) {
-								return getAkismetPro500ProductDisplayName( item.variation, item.licensed_quantity );
-							}
-							if ( isAkismetBusiness5k( { product_slug: item.wpcom_product_slug } ) ) {
-								return getAkismetBusiness5kProductDisplayName( item.variation );
-							}
-							return item.variation;
-						} )() }
+						{ getAkismetProductDisplayName(
+							{ product_slug: item.wpcom_product_slug },
+							item.variation,
+							item.licensed_quantity
+						) }
 					</span>
 					<small>({ item.type_localized })</small>
 					{ termLabel && <em>{ termLabel }</em> }

--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -1,4 +1,9 @@
-import { isAkismetPro500, getAkismetPro500ProductDisplayName } from '@automattic/calypso-products';
+import {
+	isAkismetPro500,
+	getAkismetPro500ProductDisplayName,
+	isAkismetBusiness5k,
+	getAkismetBusiness5kProductDisplayName,
+} from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, Card, FormLabel } from '@automattic/components';
 import { formatCurrency } from '@automattic/number-formatters';
@@ -580,9 +585,15 @@ function ReceiptLineItem( {
 			<tr>
 				<td className="billing-history__receipt-item-name">
 					<span>
-						{ isAkismetPro500( { product_slug: item.wpcom_product_slug } )
-							? getAkismetPro500ProductDisplayName( item.variation, item.licensed_quantity )
-							: item.variation }
+						{ ( () => {
+							if ( isAkismetPro500( { product_slug: item.wpcom_product_slug } ) ) {
+								return getAkismetPro500ProductDisplayName( item.variation, item.licensed_quantity );
+							}
+							if ( isAkismetBusiness5k( { product_slug: item.wpcom_product_slug } ) ) {
+								return getAkismetBusiness5kProductDisplayName( item.variation );
+							}
+							return item.variation;
+						} )() }
 					</span>
 					<small>({ item.type_localized })</small>
 					{ termLabel && <em>{ termLabel }</em> }

--- a/client/me/purchases/billing-history/utils.tsx
+++ b/client/me/purchases/billing-history/utils.tsx
@@ -320,8 +320,8 @@ function renderAkismetTransactionQuantitySummary(
 ) {
 	if ( isRenewal ) {
 		return translate(
-			'Renewal for %(quantity)d 500 API call license',
-			'Renewal for %(quantity)d 500 API call licenses',
+			'Renewal for %(quantity)d 8K API call license',
+			'Renewal for %(quantity)d 8K API call licenses',
 			{
 				args: { quantity: licensed_quantity },
 				count: licensed_quantity,
@@ -330,8 +330,8 @@ function renderAkismetTransactionQuantitySummary(
 	}
 
 	return translate(
-		'Purchase of %(quantity)d 500 API call license',
-		'Purchase of %(quantity)d 500 API call licenses',
+		'Purchase of %(quantity)d 8K API call license',
+		'Purchase of %(quantity)d 8K API call licenses',
 		{
 			args: { quantity: licensed_quantity },
 			count: licensed_quantity,

--- a/client/my-sites/checkout/src/components/akismet-pro-quantity-dropdown/index.tsx
+++ b/client/my-sites/checkout/src/components/akismet-pro-quantity-dropdown/index.tsx
@@ -146,11 +146,11 @@ export const AkismetProQuantityDropDown: FunctionComponent< AkismetProQuantityDr
 	const translate = useTranslate();
 	const { dropdownOptions, AkBusinessDropdownPosition } = useMemo( () => {
 		const dropdownOptions = [
-			preventWidows( translate( '500 spam calls/mo, up to 1 site' ) ),
-			preventWidows( translate( '1000 spam calls/mo, up to 2 sites' ) ),
-			preventWidows( translate( '1500 spam calls/mo, up to 3 sites' ) ),
-			preventWidows( translate( '2000 spam calls/mo, up to 4 sites' ) ),
-			preventWidows( translate( '5000 spam calls/mo, unlimited sites (Akismet Business)' ) ),
+			preventWidows( translate( '8K spam calls/mo, up to 1 site' ) ),
+			preventWidows( translate( '16K spam calls/mo, up to 2 sites' ) ),
+			preventWidows( translate( '24K spam calls/mo, up to 3 sites' ) ),
+			preventWidows( translate( '32K spam calls/mo, up to 4 sites' ) ),
+			preventWidows( translate( '80K spam calls/mo, unlimited sites (Akismet Business)' ) ),
 		];
 		const AkBusinessDropdownPosition = dropdownOptions.length;
 		return {

--- a/client/my-sites/checkout/src/lib/get-akismet-product-features.ts
+++ b/client/my-sites/checkout/src/lib/get-akismet-product-features.ts
@@ -62,7 +62,8 @@ function getFeatureStrings(
 		case 'pro_40k':
 			return [ ...baseFeatures, translate( '40K API calls per month' ), ...baseProFeatures ];
 		case 'business':
-			return [ ...baseFeatures, translate( '80K API calls per month' ), ...baseEnterpriseFeatures ];
+			// Legacy Akismet Business SKU (ak_ent_*_1); existing customers retain the 60K allotment.
+			return [ ...baseFeatures, translate( '60K API calls per month' ), ...baseEnterpriseFeatures ];
 		case 'business_5k':
 			// 'business_5k' is legacy naming; the Akismet Business allotment is now 80K.
 			return [ ...baseFeatures, translate( '80K API calls per month' ), ...baseEnterpriseFeatures ];

--- a/client/my-sites/checkout/src/lib/get-akismet-product-features.ts
+++ b/client/my-sites/checkout/src/lib/get-akismet-product-features.ts
@@ -51,7 +51,8 @@ function getFeatureStrings(
 		case 'personal':
 			return [ ...baseFeatures ];
 		case 'pro_5h':
-			return [ ...baseFeatures, translate( '500 API calls per month' ), ...baseProFeatures ];
+			// 'pro_5h' is legacy naming; the Akismet Pro base allotment is now 8K.
+			return [ ...baseFeatures, translate( '8K API calls per month' ), ...baseProFeatures ];
 		case 'pro_10k':
 			return [ ...baseFeatures, translate( '10K API calls per month' ), ...baseProFeatures ];
 		case 'pro_20k':
@@ -61,9 +62,10 @@ function getFeatureStrings(
 		case 'pro_40k':
 			return [ ...baseFeatures, translate( '40K API calls per month' ), ...baseProFeatures ];
 		case 'business':
-			return [ ...baseFeatures, translate( '60K API calls per month' ), ...baseEnterpriseFeatures ];
+			return [ ...baseFeatures, translate( '80K API calls per month' ), ...baseEnterpriseFeatures ];
 		case 'business_5k':
-			return [ ...baseFeatures, translate( '5K API calls per month' ), ...baseEnterpriseFeatures ];
+			// 'business_5k' is legacy naming; the Akismet Business allotment is now 80K.
+			return [ ...baseFeatures, translate( '80K API calls per month' ), ...baseEnterpriseFeatures ];
 		case 'enterprise_15k':
 			return [ ...baseFeatures, translate( '15K API calls per month' ), ...baseEnterpriseFeatures ];
 		case 'enterprise_25k':

--- a/packages/calypso-products/src/constants/akismet.ts
+++ b/packages/calypso-products/src/constants/akismet.ts
@@ -22,6 +22,10 @@ export const PRODUCT_AKISMET_ENTERPRISE_2M_YEARLY = 'ak_ep2m_yearly_1';
 export const PRODUCT_AKISMET_ENTERPRISE_2M_MONTHLY = 'ak_ep2m_monthly_1';
 export const PRODUCT_AKISMET_ENTERPRISE_GT2M_YEARLY = 'ak_epgt2m_yearly_1';
 export const PRODUCT_AKISMET_ENTERPRISE_GT2M_MONTHLY = 'ak_epgt2m_monthly_1';
+// The "500" / "5K" / "5h" segments in the following slug names are legacy
+// naming retained for backend product-slug stability. They no longer reflect
+// the current API limits (Akismet Pro is now 8K calls/mo per quantity, and
+// Akismet Business is 80K calls/mo).
 export const PRODUCT_AKISMET_PRO_500_MONTHLY = 'ak_pro5h_monthly';
 export const PRODUCT_AKISMET_PRO_500_YEARLY = 'ak_pro5h_yearly';
 export const PRODUCT_AKISMET_PRO_500_BI_YEARLY = 'ak_pro5h_bi_yearly';

--- a/packages/calypso-products/src/format-akismet-display-name.ts
+++ b/packages/calypso-products/src/format-akismet-display-name.ts
@@ -1,0 +1,24 @@
+import { translate } from 'i18n-calypso';
+
+/**
+ * Formats an Akismet product display name with its current monthly request
+ * allotment, e.g. "Akismet Pro (8K requests/month)". Any stale parenthetical
+ * suffix already present in the product name is stripped before the current
+ * allotment is appended.
+ * @param {string} productName - the product name (may carry a stale parenthetical)
+ * @param {number} requestsInThousands - the monthly request allotment, in thousands
+ * @returns {string} the formatted display name
+ */
+export function formatAkismetDisplayName(
+	productName: string,
+	requestsInThousands: number
+): string {
+	/* translators: %(productName)s is the product name (e.g. "Akismet Pro"); %(requestsK)d is the monthly request count in thousands, rendered as "NK" (e.g. "8K"). */
+	return translate( '%(productName)s (%(requestsK)dK requests/month)', {
+		args: {
+			productName: productName.replace( /\s*\(.*$/, '' ).trim(),
+			requestsK: requestsInThousands,
+		},
+		textOnly: true,
+	} );
+}

--- a/packages/calypso-products/src/get-akismet-business-5k-product-display-name.ts
+++ b/packages/calypso-products/src/get-akismet-business-5k-product-display-name.ts
@@ -1,4 +1,4 @@
-import { translate } from 'i18n-calypso';
+import { formatAkismetDisplayName } from './format-akismet-display-name';
 
 // The "5k" in this filename / function name is legacy naming retained for
 // backend product-slug stability (ak_bus5k_*). The actual allotment is now
@@ -6,14 +6,5 @@ import { translate } from 'i18n-calypso';
 const AKISMET_BUSINESS_REQUESTS_PER_MONTH = 80000;
 
 export function getAkismetBusiness5kProductDisplayName( productName: string ) {
-	const requestsInThousands = AKISMET_BUSINESS_REQUESTS_PER_MONTH / 1000;
-
-	/* translators: %(productName)s is the product name (e.g. "Akismet Business"); %(requestsK)d is the monthly request count in thousands, rendered as "NK" (e.g. "80K"). */
-	return translate( '%(productName)s (%(requestsK)dK requests/month)', {
-		args: {
-			productName: productName.replace( /\s*\(.*$/, '' ).trim(),
-			requestsK: requestsInThousands,
-		},
-		textOnly: true,
-	} );
+	return formatAkismetDisplayName( productName, AKISMET_BUSINESS_REQUESTS_PER_MONTH / 1000 );
 }

--- a/packages/calypso-products/src/get-akismet-business-5k-product-display-name.ts
+++ b/packages/calypso-products/src/get-akismet-business-5k-product-display-name.ts
@@ -1,0 +1,19 @@
+import { translate } from 'i18n-calypso';
+
+// The "5k" in this filename / function name is legacy naming retained for
+// backend product-slug stability (ak_bus5k_*). The actual allotment is now
+// 80000 requests/month, not 5K.
+const AKISMET_BUSINESS_REQUESTS_PER_MONTH = 80000;
+
+export function getAkismetBusiness5kProductDisplayName( productName: string ) {
+	const requestsInThousands = AKISMET_BUSINESS_REQUESTS_PER_MONTH / 1000;
+
+	/* translators: %(productName)s is the product name (e.g. "Akismet Business"); %(requestsK)d is the monthly request count in thousands, rendered as "NK" (e.g. "80K"). */
+	return translate( '%(productName)s (%(requestsK)dK requests/month)', {
+		args: {
+			productName: productName.replace( /\s*\(.*$/, '' ).trim(),
+			requestsK: requestsInThousands,
+		},
+		textOnly: true,
+	} );
+}

--- a/packages/calypso-products/src/get-akismet-pro-500-product-display-name.ts
+++ b/packages/calypso-products/src/get-akismet-pro-500-product-display-name.ts
@@ -6,7 +6,7 @@ import { translate } from 'i18n-calypso';
 const AKISMET_PRO_REQUESTS_PER_QUANTITY = 8000;
 
 export function getAkismetPro500ProductDisplayName( productName: string, quantity: number | null ) {
-	if ( ! quantity || quantity < 1 ) {
+	if ( ! quantity || quantity <= 1 ) {
 		return productName;
 	}
 

--- a/packages/calypso-products/src/get-akismet-pro-500-product-display-name.ts
+++ b/packages/calypso-products/src/get-akismet-pro-500-product-display-name.ts
@@ -1,4 +1,4 @@
-import { translate } from 'i18n-calypso';
+import { formatAkismetDisplayName } from './format-akismet-display-name';
 
 // The "500" in this filename / function name is legacy naming retained for
 // backend product-slug stability (ak_pro5h_*). The actual per-quantity allotment
@@ -10,14 +10,8 @@ export function getAkismetPro500ProductDisplayName( productName: string, quantit
 		return productName;
 	}
 
-	const requestsInThousands = ( AKISMET_PRO_REQUESTS_PER_QUANTITY * quantity ) / 1000;
-
-	/* translators: %(productName)s is the product name (e.g. "Akismet Pro"); %(requestsK)d is the monthly request count in thousands, rendered as "NK" (e.g. "8K"). */
-	return translate( '%(productName)s (%(requestsK)dK requests/month)', {
-		args: {
-			productName: productName.replace( /\s*\(.*$/, '' ).trim(),
-			requestsK: requestsInThousands,
-		},
-		textOnly: true,
-	} );
+	return formatAkismetDisplayName(
+		productName,
+		( AKISMET_PRO_REQUESTS_PER_QUANTITY * quantity ) / 1000
+	);
 }

--- a/packages/calypso-products/src/get-akismet-pro-500-product-display-name.ts
+++ b/packages/calypso-products/src/get-akismet-pro-500-product-display-name.ts
@@ -1,16 +1,23 @@
 import { translate } from 'i18n-calypso';
 
+// The "500" in this filename / function name is legacy naming retained for
+// backend product-slug stability (ak_pro5h_*). The actual per-quantity allotment
+// is now 8000 requests/month, not 500.
+export const AKISMET_PRO_REQUESTS_PER_QUANTITY = 8000;
+
 export function getAkismetPro500ProductDisplayName( productName: string, quantity: number | null ) {
-	if ( quantity && quantity > 1 ) {
-		/* translators: %s is the product name "Akismet Pro", %d is a number of requests/month */
-		return translate( '%(productName)s (%(requests)d requests/month)', {
-			args: {
-				productName: productName.replace( /\s*\(.*$/, '' ).trim(),
-				requests: 500 * quantity,
-			},
-			textOnly: true,
-		} );
+	if ( ! quantity || quantity < 1 ) {
+		return productName;
 	}
 
-	return productName;
+	const requestsInK = ( AKISMET_PRO_REQUESTS_PER_QUANTITY * quantity ) / 1000;
+
+	/* translators: %(productName)s is the product name (e.g. "Akismet Pro"); %(requestsK)d is the monthly request count in thousands, rendered as "NK" (e.g. "8K"). */
+	return translate( '%(productName)s (%(requestsK)dK requests/month)', {
+		args: {
+			productName: productName.replace( /\s*\(.*$/, '' ).trim(),
+			requestsK: requestsInK,
+		},
+		textOnly: true,
+	} );
 }

--- a/packages/calypso-products/src/get-akismet-pro-500-product-display-name.ts
+++ b/packages/calypso-products/src/get-akismet-pro-500-product-display-name.ts
@@ -6,7 +6,7 @@ import { translate } from 'i18n-calypso';
 const AKISMET_PRO_REQUESTS_PER_QUANTITY = 8000;
 
 export function getAkismetPro500ProductDisplayName( productName: string, quantity: number | null ) {
-	if ( ! quantity || quantity <= 1 ) {
+	if ( ! quantity || quantity < 1 ) {
 		return productName;
 	}
 

--- a/packages/calypso-products/src/get-akismet-pro-500-product-display-name.ts
+++ b/packages/calypso-products/src/get-akismet-pro-500-product-display-name.ts
@@ -10,13 +10,13 @@ export function getAkismetPro500ProductDisplayName( productName: string, quantit
 		return productName;
 	}
 
-	const requestsInK = ( AKISMET_PRO_REQUESTS_PER_QUANTITY * quantity ) / 1000;
+	const requestsInThousands = ( AKISMET_PRO_REQUESTS_PER_QUANTITY * quantity ) / 1000;
 
 	/* translators: %(productName)s is the product name (e.g. "Akismet Pro"); %(requestsK)d is the monthly request count in thousands, rendered as "NK" (e.g. "8K"). */
 	return translate( '%(productName)s (%(requestsK)dK requests/month)', {
 		args: {
 			productName: productName.replace( /\s*\(.*$/, '' ).trim(),
-			requestsK: requestsInK,
+			requestsK: requestsInThousands,
 		},
 		textOnly: true,
 	} );

--- a/packages/calypso-products/src/get-akismet-pro-500-product-display-name.ts
+++ b/packages/calypso-products/src/get-akismet-pro-500-product-display-name.ts
@@ -3,7 +3,7 @@ import { translate } from 'i18n-calypso';
 // The "500" in this filename / function name is legacy naming retained for
 // backend product-slug stability (ak_pro5h_*). The actual per-quantity allotment
 // is now 8000 requests/month, not 500.
-export const AKISMET_PRO_REQUESTS_PER_QUANTITY = 8000;
+const AKISMET_PRO_REQUESTS_PER_QUANTITY = 8000;
 
 export function getAkismetPro500ProductDisplayName( productName: string, quantity: number | null ) {
 	if ( ! quantity || quantity < 1 ) {

--- a/packages/calypso-products/src/get-akismet-product-display-name.ts
+++ b/packages/calypso-products/src/get-akismet-product-display-name.ts
@@ -1,0 +1,26 @@
+import { getAkismetBusiness5kProductDisplayName } from './get-akismet-business-5k-product-display-name';
+import { getAkismetPro500ProductDisplayName } from './get-akismet-pro-500-product-display-name';
+import { isAkismetBusiness5k } from './is-akismet-business-5k';
+import { isAkismetPro500 } from './is-akismet-pro-500';
+import type { WithSnakeCaseSlug, WithCamelCaseSlug } from './types';
+
+/**
+ * Returns the display name for an Akismet Pro or Business product, appending the
+ * current monthly request allotment (e.g. "Akismet Pro (8K requests/month)").
+ * For any other product, the given product name is returned unchanged.
+ */
+export function getAkismetProductDisplayName(
+	product: WithCamelCaseSlug | WithSnakeCaseSlug,
+	productName: string,
+	quantity: number | null
+): string {
+	if ( isAkismetPro500( product ) ) {
+		return getAkismetPro500ProductDisplayName( productName, quantity );
+	}
+
+	if ( isAkismetBusiness5k( product ) ) {
+		return getAkismetBusiness5kProductDisplayName( productName );
+	}
+
+	return productName;
+}

--- a/packages/calypso-products/src/index.ts
+++ b/packages/calypso-products/src/index.ts
@@ -11,3 +11,4 @@ export * from './is-tiered-volume-space-addon';
 export * from './is-multi-year-domain-product';
 export * from './get-storage-addon-display-name';
 export * from './get-akismet-pro-500-product-display-name';
+export * from './get-akismet-business-5k-product-display-name';

--- a/packages/calypso-products/src/index.ts
+++ b/packages/calypso-products/src/index.ts
@@ -12,3 +12,4 @@ export * from './is-multi-year-domain-product';
 export * from './get-storage-addon-display-name';
 export * from './get-akismet-pro-500-product-display-name';
 export * from './get-akismet-business-5k-product-display-name';
+export * from './get-akismet-product-display-name';

--- a/packages/wpcom-checkout/src/checkout-labels.ts
+++ b/packages/wpcom-checkout/src/checkout-labels.ts
@@ -17,8 +17,7 @@ import {
 	isJetpackStatsPaidTieredProductSlug,
 	isAkismetPro500,
 	isAkismetBusiness5k,
-	getAkismetPro500ProductDisplayName,
-	getAkismetBusiness5kProductDisplayName,
+	getAkismetProductDisplayName,
 } from '@automattic/calypso-products';
 import { formatNumber } from '@automattic/number-formatters';
 import { translate } from 'i18n-calypso';
@@ -124,12 +123,8 @@ export function getLabel( product: ResponseCartProduct ): string {
 		} );
 	}
 
-	if ( isAkismetPro500( product ) ) {
-		return getAkismetPro500ProductDisplayName( product.product_name, quantity );
-	}
-
-	if ( isAkismetBusiness5k( product ) ) {
-		return getAkismetBusiness5kProductDisplayName( product.product_name );
+	if ( isAkismetPro500( product ) || isAkismetBusiness5k( product ) ) {
+		return getAkismetProductDisplayName( product, product.product_name, quantity );
 	}
 
 	return product.product_name || '';

--- a/packages/wpcom-checkout/src/checkout-labels.ts
+++ b/packages/wpcom-checkout/src/checkout-labels.ts
@@ -16,7 +16,9 @@ import {
 	isJetpackAISlug,
 	isJetpackStatsPaidTieredProductSlug,
 	isAkismetPro500,
+	isAkismetBusiness5k,
 	getAkismetPro500ProductDisplayName,
+	getAkismetBusiness5kProductDisplayName,
 } from '@automattic/calypso-products';
 import { formatNumber } from '@automattic/number-formatters';
 import { translate } from 'i18n-calypso';
@@ -124,6 +126,10 @@ export function getLabel( product: ResponseCartProduct ): string {
 
 	if ( isAkismetPro500( product ) ) {
 		return getAkismetPro500ProductDisplayName( product.product_name, quantity );
+	}
+
+	if ( isAkismetBusiness5k( product ) ) {
+		return getAkismetBusiness5kProductDisplayName( product.product_name );
 	}
 
 	return product.product_name || '';


### PR DESCRIPTION
## Proposed Changes

* Pro tier dropdown: `500`/`1000`/`1500`/`2000` → `8K`/`16K`/`24K`/`32K` spam calls/mo.
* Business dropdown: `5000` → `80K` spam calls/mo.
* Pro and Business display names: replace the product name (including previous spam calls/mo) with the new limits. Applies to every paid Pro quantity (q=1 included) and to all Business 5K variants.
* Business checkout features: `5K` → `80K`. Legacy 60K Business SKU (`ak_ent_*_1`) left unchanged.
* Slugs (`ak_pro5h_*`, `ak_bus5k_*`) unchanged — legacy-naming comments added.

Mirrors the matching akismet.com PR.

## Testing

* `/checkout/akismet/ak_pro5h_yearly` — dropdown reads `8K`/`16K`/`24K`/`32K`/`80K`; each option submits `ak_pro5h_yearly:-q-N`.
* Cart line for Pro: `q=1` → `Akismet Pro (8K requests/month)` (was `(500 requests/month)`); `q=2/3/4` → `16K`/`24K`/`32K`.
* `/checkout/akismet/ak_bus5k_yearly` — cart line reads `Akismet Business (80K requests/month)` (was `(5K requests/month)`); features list reads `80K API calls per month`.
* Dashboard purchases page (`/me/purchases`) — Pro and Business subs show the new `(NK requests/month)` suffix.

<img width="678" height="710" alt="Screenshot 2026-05-29 at 16 34 24" src="https://github.com/user-attachments/assets/b5e385df-58dd-4e0d-b84e-d4f42e1b96c5" />
<img width="688" height="436" alt="Screenshot 2026-05-29 at 16 37 37" src="https://github.com/user-attachments/assets/4ff47ede-c308-4775-bd14-16a5ff3df9dc" />

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?