### PR TITLE
Update desktop Electron runtime

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -39,7 +39,7 @@
 		"@electron/notarize": "^2.4.0",
 		"@playwright/browser-chromium": "1.57.0",
 		"copy-webpack-plugin": "^10.2.4",
-		"electron": "26.2.4",
+		"electron": "39.8.5",
 		"electron-builder": "24.13.3",
 		"electron-rebuild": "^2.3.5",
 		"jest": "^29.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9422,21 +9422,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^18.11.18":
-  version: 18.18.9
-  resolution: "@types/node@npm:18.18.9"
-  dependencies:
-    undici-types: "npm:~5.26.4"
-  checksum: 8d58fba5eede0df009412ee188bc96f4baf340f4fafbda1bc66fb680fa775aedc88f0cb154a2455966443d9538af402fff022fb0632bddb1bd0648e5a86e5db9
-  languageName: node
-  linkType: hard
-
 "@types/node@npm:^20.12.7":
   version: 20.12.7
   resolution: "@types/node@npm:20.12.7"
   dependencies:
     undici-types: "npm:~5.26.4"
   checksum: dce80d63a3b91892b321af823d624995c61e39c6a223cc0ac481a44d337640cc46931d33efb3beeed75f5c85c3bda1d97cef4c5cd4ec333caf5dee59cff6eca0
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^22.7.7":
+  version: 22.19.19
+  resolution: "@types/node@npm:22.19.19"
+  dependencies:
+    undici-types: "npm:~6.21.0"
+  checksum: 402e0f088c94cabda3cd721546bd8e4e75e098e0b342f6e03b90ca1e19c28986f9650112c64fcfd09fc8cebc0f8b20291a513153e90489331cf666e1e5503e16
   languageName: node
   linkType: hard
 
@@ -12571,7 +12571,7 @@ __metadata:
     archiver: "npm:^3.1.1"
     copy-webpack-plugin: "npm:^10.2.4"
     cross-env: "npm:^7.0.3"
-    electron: "npm:26.2.4"
+    electron: "npm:39.8.5"
     electron-builder: "npm:24.13.3"
     electron-fetch: "npm:^1.7.4"
     electron-rebuild: "npm:^2.3.5"
@@ -17099,16 +17099,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:26.2.4":
-  version: 26.2.4
-  resolution: "electron@npm:26.2.4"
+"electron@npm:39.8.5":
+  version: 39.8.5
+  resolution: "electron@npm:39.8.5"
   dependencies:
     "@electron/get": "npm:^2.0.0"
-    "@types/node": "npm:^18.11.18"
+    "@types/node": "npm:^22.7.7"
     extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: eaa861c890709453793c8893552ef91aaddfea716bde3d8b5d1d1064d553fe600f00297d45182c493a582cc76cfe98855ae3ececb865c5bcce3932f0c12beaf9
+  checksum: 21448e3d69a5e96912ce84533d39e7258be17879502cfed30bcdd6581b61516a1d1f3b492aad20344367967229bce27018625047f7ee6801257df93bf6b96d97
   languageName: node
   linkType: hard
 
@@ -32250,6 +32250,13 @@ __metadata:
   version: 5.26.5
   resolution: "undici-types@npm:5.26.5"
   checksum: bb673d7876c2d411b6eb6c560e0c571eef4a01c1c19925175d16e3a30c4c428181fb8d7ae802a261f283e4166a0ac435e2f505743aa9e45d893f9a3df017b501
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~6.21.0":
+  version: 6.21.0
+  resolution: "undici-types@npm:6.21.0"
+  checksum: c01ed51829b10aa72fc3ce64b747f8e74ae9b60eafa19a7b46ef624403508a54c526ffab06a14a26b3120d055e1104d7abe7c9017e83ced038ea5cf52f8d5e04
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Part of QAO-472

## Proposed Changes

* Update the desktop Electron runtime from `26.2.4` to `39.8.5`.
* Refresh the root Yarn lockfile for the Electron package and its Node type dependency.
* Leave `electron-builder`, `electron-updater`, `electron-rebuild`, and related desktop tooling unchanged from the previous cleanup slices.

## Why are these changes being made?

* The remaining High Dependabot alerts are all for the Electron runtime.
* This keeps the runtime migration isolated from the updater/builder and native-build cleanup work that already landed.
* After merge and alert scan refresh, this should clear the 8 remaining High alerts plus the Electron medium/low alert cluster.

## Testing Instructions

Validated locally:

* `git diff --check`
* `yarn install --immutable`
* `yarn dedupe --check`
* stale Electron 26 lockfile scan
* `yarn why electron`
* `yarn workspace WordPressDesktop exec electron --version`
* `NODE_OPTIONS=--max-old-space-size=8192 yarn workspace WordPressDesktop run build:config`
* `NODE_OPTIONS=--max-old-space-size=8192 yarn workspace WordPressDesktop run build:main`
* `NODE_OPTIONS=--max-old-space-size=8192 yarn workspace WordPressDesktop run build:app`
* `PYTHON="${PYTHON:-/Library/Developer/CommandLineTools/usr/bin/python3}" yarn workspace WordPressDesktop exec electron-rebuild --force --arch=arm64`
* `NODE_OPTIONS=--max-old-space-size=8192 yarn workspace WordPressDesktop run ci:build-mac`
* `yarn test-build-tools`
* `NODE_OPTIONS=--max-old-space-size=8192 yarn typecheck-client`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
