### PR TITLE
Dashboard: restore deleted-sites filter and empty state

### DIFF
--- a/client/dashboard/app/hooks/test/use-persistent-view.test.tsx
+++ b/client/dashboard/app/hooks/test/use-persistent-view.test.tsx
@@ -177,6 +177,31 @@ describe( 'usePersistentView', () => {
 				} );
 			} );
 		} );
+
+		it( 'should convert "true"/"false" query param values into a boolean `is` filter', async () => {
+			mockGetCalypsoPreferences( {} );
+
+			const { Wrapper } = createTestWrapper();
+
+			const queryParams = { is_deleted: 'true' };
+			const queryParamFilterFields = [ 'is_deleted' ];
+			const { result } = renderHook(
+				() =>
+					usePersistentView( {
+						slug,
+						defaultView,
+						queryParams,
+						queryParamFilterFields,
+					} ),
+				{ wrapper: Wrapper }
+			);
+
+			await waitFor( () => {
+				expect( result.current.view.filters ).toEqual( [
+					{ field: 'is_deleted', operator: 'is', value: true },
+				] );
+			} );
+		} );
 	} );
 
 	describe( 'updateView', () => {

--- a/client/dashboard/app/hooks/use-persistent-view.ts
+++ b/client/dashboard/app/hooks/use-persistent-view.ts
@@ -92,14 +92,17 @@ export function useBasePersistentView( {
 		( field ) => queryParams && queryParams[ field ] !== undefined
 	);
 
-	const [ transientFilters, setTransientFilters ] = useState< Filter[] >( [] );
+	const [ transientFilters, setTransientFilters ] = useState< Filter[] >( () =>
+		queryParamFilterFields
+			.filter( ( field ) => queryParams && queryParams[ field ] !== undefined )
+			.map( ( field ) => getTransientFilter( field, queryParams[ field ] ) )
+	);
 
 	useEffect( () => {
 		setTransientFilters(
 			transientFilterFields.map( ( field ) => getTransientFilter( field, queryParams[ field ] ) )
 		);
 
-		// Set transient filters once on initial page load.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ JSON.stringify( transientFilterFields ) ] );
 

--- a/client/dashboard/app/hooks/use-persistent-view.ts
+++ b/client/dashboard/app/hooks/use-persistent-view.ts
@@ -96,14 +96,7 @@ export function useBasePersistentView( {
 
 	useEffect( () => {
 		setTransientFilters(
-			transientFilterFields.map(
-				( field ) =>
-					( {
-						field,
-						operator: 'isAny',
-						value: [ queryParams[ field ].toString() ],
-					} ) as Filter
-			)
+			transientFilterFields.map( ( field ) => getTransientFilter( field, queryParams[ field ] ) )
 		);
 
 		// Set transient filters once on initial page load.
@@ -158,7 +151,7 @@ export function useBasePersistentView( {
 					newView.filters?.some(
 						( filter ) =>
 							filter.field === field &&
-							fastDeepEqual( filter.value, [ String( queryParams[ field ] ) ] )
+							fastDeepEqual( filter.value, getTransientFilter( field, queryParams[ field ] ).value )
 					)
 			);
 
@@ -218,6 +211,14 @@ export function useBasePersistentView( {
 	}, [ persistView, navigate, queryParams ] );
 
 	return { view, updateView, resetView: isViewModified ? resetView : undefined };
+}
+
+function getTransientFilter( field: string, rawValue: unknown ): Filter {
+	const stringValue = String( rawValue );
+	if ( stringValue === 'true' || stringValue === 'false' ) {
+		return { field, operator: 'is', value: stringValue === 'true' } as Filter;
+	}
+	return { field, operator: 'isAny', value: [ stringValue ] } as Filter;
 }
 
 function removeTransientPropertiesFromView( view: View ): View {

--- a/client/dashboard/sites/dataviews/actions.tsx
+++ b/client/dashboard/sites/dataviews/actions.tsx
@@ -111,7 +111,7 @@ export function useActions(): Action< Site >[] {
 			id: 'restore',
 			// Intentionally not `isPrimary`. For deleted sites, restore is the only
 			// eligible action, and the DataViews bug below hides primary actions behind
-			// hover with no kebab fallback, making restore unreachable.
+			// hover with no kebab fallback, making restore undiscoverable.
 			// https://github.com/WordPress/gutenberg/issues/78842
 			icon: backup,
 			label: __( 'Restore site' ),

--- a/client/dashboard/sites/dataviews/actions.tsx
+++ b/client/dashboard/sites/dataviews/actions.tsx
@@ -109,7 +109,6 @@ export function useActions(): Action< Site >[] {
 		},
 		{
 			id: 'restore',
-			isPrimary: true,
 			icon: backup,
 			label: __( 'Restore site' ),
 			isEligible: ( item: Site ) => canRestoreSite( item ),

--- a/client/dashboard/sites/dataviews/actions.tsx
+++ b/client/dashboard/sites/dataviews/actions.tsx
@@ -109,6 +109,10 @@ export function useActions(): Action< Site >[] {
 		},
 		{
 			id: 'restore',
+			// Intentionally not `isPrimary`. For deleted sites, restore is the only
+			// eligible action, and the DataViews bug below hides primary actions behind
+			// hover with no kebab fallback, making restore unreachable.
+			// https://github.com/WordPress/gutenberg/issues/78842
 			icon: backup,
 			label: __( 'Restore site' ),
 			isEligible: ( item: Site ) => canRestoreSite( item ),

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -1,4 +1,5 @@
 import { isAutomatticianQuery, siteBySlugQuery, siteByIdQuery } from '@automattic/api-queries';
+import { localizeUrl } from '@automattic/i18n-utils';
 import {
 	useQuery,
 	useQueryClient,
@@ -262,7 +263,14 @@ export default function Sites() {
 											'Sites that are deleted can be restored within the first 30 days of deletion. <learnLink>Learn how to restore a deleted site</learnLink>.'
 										),
 										{
-											learnLink: <InlineSupportLink supportContext="restore-site" />,
+											learnLink: (
+												<InlineSupportLink
+													supportLink={ localizeUrl(
+														'https://wordpress.com/support/delete-site/#restore-a-deleted-site'
+													) }
+													supportPostId={ 14411 }
+												/>
+											),
 										}
 									) }
 									isBorderless

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -268,10 +268,10 @@ export default function Sites() {
 									title={ __( 'You have no deleted sites' ) }
 									description={ createInterpolateElement(
 										__(
-											'Sites that are deleted can be restored within the first 30 days of deletion. <a>Learn how to restore a deleted site</a>.'
+											'Sites that are deleted can be restored within the first 30 days of deletion. <learnLink>Learn how to restore a deleted site</learnLink>.'
 										),
 										{
-											a: (
+											learnLink: (
 												<a
 													href={ localizeUrl(
 														'https://wordpress.com/support/delete-site/#restore-a-deleted-site'

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -268,7 +268,7 @@ export default function Sites() {
 									title={ __( 'You have no deleted sites' ) }
 									description={ createInterpolateElement(
 										__(
-											'Sites that are deleted can be restored within the first 30 days of deletion. Read more about restoring your site <a>here</a>.'
+											'Sites that are deleted can be restored within the first 30 days of deletion. <a>Learn how to restore a deleted site</a>.'
 										),
 										{
 											a: (

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -254,7 +254,7 @@ export default function Sites() {
 					</>
 				}
 			>
-				{ userHasSites ? (
+				{ userHasSites || isFilteringDeletedSites ? (
 					<SitesDataViews
 						view={ view }
 						sites={ filteredData }

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -51,13 +51,13 @@ type SiteListQueryOptions = {
 // (boolean `true` with the `is` operator) or from the URL (string `'true'` wrapped in
 // an array via `queryParamFilterFields`'s `isAny` operator). Treat all as active.
 function isDeletedFilterActive( filters: Filter[] ): boolean {
-	const isTruthy = ( v: unknown ) => v === true || v === 'true';
-	return filters.some(
-		( filter ) =>
-			filter.field === 'is_deleted' &&
-			( isTruthy( filter.value ) ||
-				( Array.isArray( filter.value ) && filter.value.some( isTruthy ) ) )
-	);
+	return filters.some( ( { field, value } ) => {
+		if ( field !== 'is_deleted' ) {
+			return false;
+		}
+		const values = Array.isArray( value ) ? value : [ value ];
+		return values.includes( true ) || values.includes( 'true' );
+	} );
 }
 
 const getFetchPaginatedSitesOptions = (

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -1,4 +1,5 @@
 import { isAutomatticianQuery, siteBySlugQuery, siteByIdQuery } from '@automattic/api-queries';
+import { localizeUrl } from '@automattic/i18n-utils';
 import {
 	useQuery,
 	useQueryClient,
@@ -6,6 +7,7 @@ import {
 	keepPreviousData,
 } from '@tanstack/react-query';
 import { Button, Modal } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { getISOWeek, getISOWeekYear } from 'date-fns';
 import deepmerge from 'deepmerge';
@@ -45,6 +47,19 @@ type SiteListQueryOptions = {
 	isAutomattician: boolean;
 };
 
+// A filter on `is_deleted=true` can arrive in multiple shapes: from the DataViews UI
+// (boolean `true` with the `is` operator) or from the URL (string `'true'` wrapped in
+// an array via `queryParamFilterFields`'s `isAny` operator). Treat all as active.
+function isDeletedFilterActive( filters: Filter[] ): boolean {
+	const isTruthy = ( v: unknown ) => v === true || v === 'true';
+	return filters.some(
+		( filter ) =>
+			filter.field === 'is_deleted' &&
+			( isTruthy( filter.value ) ||
+				( Array.isArray( filter.value ) && filter.value.some( isTruthy ) ) )
+	);
+}
+
 const getFetchPaginatedSitesOptions = (
 	view: View,
 	{ isDefaultView, isRestoringAccount, isAutomattician }: SiteListQueryOptions,
@@ -71,7 +86,7 @@ const getFetchPaginatedSitesOptions = (
 		per_page: view.perPage,
 	};
 
-	if ( filters.find( ( item: Filter ) => item.field === 'is_deleted' && item.value === true ) ) {
+	if ( isDeletedFilterActive( filters ) ) {
 		options.site_visibility = 'deleted';
 	}
 
@@ -164,6 +179,7 @@ export default function Sites() {
 		slug: 'sites',
 		defaultView,
 		queryParams: currentSearchParams,
+		queryParamFilterFields: [ 'is_deleted' ],
 		sanitizeFields,
 	} );
 
@@ -194,6 +210,8 @@ export default function Sites() {
 		view,
 		totalItems ?? 0
 	);
+
+	const isFilteringDeletedSites = isDeletedFilterActive( view.filters ?? [] );
 
 	return (
 		<>
@@ -245,13 +263,36 @@ export default function Sites() {
 						isLoading={ isLoadingSites || ( isPlaceholderData && hasNoData ) }
 						isPlaceholderData={ isPlaceholderData }
 						empty={
-							<DataViewsEmptyStateLayout
-								title={ __( 'No sites match your search' ) }
-								description={ __( 'Try again, or start a new site with the options below.' ) }
-								isBorderless
-							>
-								<EmptySitesSearchStateContent />
-							</DataViewsEmptyStateLayout>
+							isFilteringDeletedSites ? (
+								<DataViewsEmptyStateLayout
+									title={ __( 'You have no deleted sites' ) }
+									description={ createInterpolateElement(
+										__(
+											'Sites that are deleted can be restored within the first 30 days of deletion. Read more about restoring your site <a>here</a>.'
+										),
+										{
+											a: (
+												<a
+													href={ localizeUrl(
+														'https://wordpress.com/support/delete-site/#restore-a-deleted-site'
+													) }
+													target="_blank"
+													rel="noopener noreferrer"
+												/>
+											),
+										}
+									) }
+									isBorderless
+								/>
+							) : (
+								<DataViewsEmptyStateLayout
+									title={ __( 'No sites match your search' ) }
+									description={ __( 'Try again, or start a new site with the options below.' ) }
+									isBorderless
+								>
+									<EmptySitesSearchStateContent />
+								</DataViewsEmptyStateLayout>
+							)
 						}
 						paginationInfo={ paginationInfo }
 						onChangeView={ handleViewChange }

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -1,5 +1,4 @@
 import { isAutomatticianQuery, siteBySlugQuery, siteByIdQuery } from '@automattic/api-queries';
-import { localizeUrl } from '@automattic/i18n-utils';
 import {
 	useQuery,
 	useQueryClient,
@@ -20,6 +19,7 @@ import { usePersistentView } from '../app/hooks/use-persistent-view';
 import { sitesRoute } from '../app/router/sites';
 import { DarkModeAnnouncement } from '../components/dark-mode-announcement';
 import { DataViewsEmptyStateLayout } from '../components/dataviews';
+import InlineSupportLink from '../components/inline-support-link';
 import OptInSurvey, { useShouldShowOptInSurvey } from '../components/opt-in-survey';
 import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
@@ -271,15 +271,7 @@ export default function Sites() {
 											'Sites that are deleted can be restored within the first 30 days of deletion. <learnLink>Learn how to restore a deleted site</learnLink>.'
 										),
 										{
-											learnLink: (
-												<a
-													href={ localizeUrl(
-														'https://wordpress.com/support/delete-site/#restore-a-deleted-site'
-													) }
-													target="_blank"
-													rel="noopener noreferrer"
-												/>
-											),
+											learnLink: <InlineSupportLink supportContext="restore-site" />,
 										}
 									) }
 									isBorderless

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -47,17 +47,8 @@ type SiteListQueryOptions = {
 	isAutomattician: boolean;
 };
 
-// A filter on `is_deleted=true` can arrive in multiple shapes: from the DataViews UI
-// (boolean `true` with the `is` operator) or from the URL (string `'true'` wrapped in
-// an array via `queryParamFilterFields`'s `isAny` operator). Treat all as active.
 function isDeletedFilterActive( filters: Filter[] ): boolean {
-	return filters.some( ( { field, value } ) => {
-		if ( field !== 'is_deleted' ) {
-			return false;
-		}
-		const values = Array.isArray( value ) ? value : [ value ];
-		return values.includes( true ) || values.includes( 'true' );
-	} );
+	return filters.some( ( filter ) => filter.field === 'is_deleted' && filter.value === true );
 }
 
 const getFetchPaginatedSitesOptions = (

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -263,7 +263,7 @@ export default function Sites() {
 						isLoading={ isLoadingSites || ( isPlaceholderData && hasNoData ) }
 						isPlaceholderData={ isPlaceholderData }
 						empty={
-							isFilteringDeletedSites ? (
+							isFilteringDeletedSites && ! view.search ? (
 								<DataViewsEmptyStateLayout
 									title={ __( 'You have no deleted sites' ) }
 									description={ createInterpolateElement(

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -263,7 +263,7 @@ export default function Sites() {
 						isLoading={ isLoadingSites || ( isPlaceholderData && hasNoData ) }
 						isPlaceholderData={ isPlaceholderData }
 						empty={
-							isFilteringDeletedSites && ! view.search ? (
+							isFilteringDeletedSites ? (
 								<DataViewsEmptyStateLayout
 									title={ __( 'You have no deleted sites' ) }
 									description={ createInterpolateElement(


### PR DESCRIPTION
Part of DOTMSD-1213

## Proposed Changes

* Honor `?is_deleted=true` on `/sites` so the deletion-email restore link (once updated server-side) and direct URLs land on the deleted-sites view.
* Always render DataViews when the deleted filter is active, even if `user.site_count === 0` — fixes the central failing case where a user's only site is deleted.
* "Restore site" now appears in the always-visible row actions menu instead of being hover-only.
* Deleted-specific empty state with a link to the restore-deleted-site support doc. Falls back to the search-empty state when a search is also active.

## Testing Instructions

1. `yarn start-dashboard`.
2. Visit `/sites?is_deleted=true`.
   * Deleted sites listed; filter chip shows `Deleted: Yes`.
   * Each row's three-dot menu contains "Restore site".
   * If you have no deleted sites: "You have no deleted sites" + restore-docs link.
3. Without the URL flag, open Filters → Deleted → Yes. Same behavior.
4. Combine the deleted filter with a search that won't match anything: empty state should be "No sites match your search", not "You have no deleted sites".

## Follow-up

The site-deletion email still links to `/sites?status=deleted`. That template lives in wpcom (server-side) and needs to be updated to `/sites?is_deleted=true` to fully close the loop.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)