### PR TITLE
E2E: register PostCheckoutSetupSitePage as a pw-base fixture

### DIFF
--- a/test/e2e/lib/pw-base.ts
+++ b/test/e2e/lib/pw-base.ts
@@ -21,6 +21,13 @@
  * @see https://playwright.dev/docs/test-fixtures
  */
 /* eslint-disable no-empty-pattern */
+/*
+ * Playwright fixtures pass values to the test via a `use( value )` callback.
+ * The `react-hooks/rules-of-hooks` rule misreads every `use(...)` call here as
+ * a React Hook invoked outside a component, so disable it for this file — there
+ * are no React hooks involved.
+ */
+/* eslint-disable react-hooks/rules-of-hooks */
 import {
 	AddPeoplePage,
 	AdvertisingPage,
@@ -61,6 +68,7 @@ import {
 	NewSiteResponse,
 	NoticeComponent,
 	PeoplePage,
+	PostCheckoutSetupSitePage,
 	PreviewComponent,
 	PurchasesPage,
 	RestAPIClient,
@@ -314,6 +322,10 @@ export const test = base.extend<
 		 * Page object representing the WordPress.com plans page.
 		 */
 		pagePlans: PlansPage;
+		/**
+		 * Page object representing the post-checkout "Set up your site" choice screen.
+		 */
+		pagePostCheckoutSetupSite: PostCheckoutSetupSitePage;
 		/**
 		 * Page object representing the WordPress.com purchases page.
 		 */
@@ -579,6 +591,10 @@ export const test = base.extend<
 	pagePlans: async ( { page }, use ) => {
 		const plansPage = new PlansPage( page );
 		await use( plansPage );
+	},
+	pagePostCheckoutSetupSite: async ( { page }, use ) => {
+		const postCheckoutSetupSitePage = new PostCheckoutSetupSitePage( page );
+		await use( postCheckoutSetupSitePage );
 	},
 	pagePurchases: async ( { page }, use ) => {
 		const purchasesPage = new PurchasesPage( page );

--- a/test/e2e/specs/flows/setup-domain__flows.spec.ts
+++ b/test/e2e/specs/flows/setup-domain__flows.spec.ts
@@ -4,7 +4,6 @@ import {
 	NewSiteResponse,
 	NewTestUserDetails,
 	NewUserResponse,
-	PostCheckoutSetupSitePage,
 	RestAPIClient,
 } from '@automattic/calypso-e2e';
 import { tags, test, expect } from '../../lib/pw-base';
@@ -270,6 +269,7 @@ test.describe(
 			componentNotice,
 			helperData,
 			pageCartCheckout,
+			pagePostCheckoutSetupSite,
 			pageSignupPickPlan,
 			pageUserSignUp,
 			pageMyProfile,
@@ -325,7 +325,7 @@ test.describe(
 				// Eligible paid plans now land on the post-checkout choice screen
 				// after checkout. This test re-enters the domain flow next, so just
 				// confirm checkout routed here rather than clicking through.
-				await new PostCheckoutSetupSitePage( page ).waitUntilLoaded();
+				await pagePostCheckoutSetupSite.waitUntilLoaded();
 			} );
 
 			await test.step( 'When I enter the domain flow', async function () {
@@ -514,6 +514,7 @@ test.describe(
 			componentNotice,
 			helperData,
 			pageCartCheckout,
+			pagePostCheckoutSetupSite,
 			pageSignupPickPlan,
 			pageUserSignUp,
 			pageMyProfile,
@@ -569,7 +570,7 @@ test.describe(
 				// Eligible paid plans now land on the post-checkout choice screen
 				// after checkout. This test re-enters the domain flow next, so just
 				// confirm checkout routed here rather than clicking through.
-				await new PostCheckoutSetupSitePage( page ).waitUntilLoaded();
+				await pagePostCheckoutSetupSite.waitUntilLoaded();
 			} );
 
 			await test.step( 'When I enter the domain flow with pre-selected site', async function () {

--- a/test/e2e/specs/plans/plans__signup-business.spec.ts
+++ b/test/e2e/specs/plans/plans__signup-business.spec.ts
@@ -1,4 +1,4 @@
-import { BrowserManager, PostCheckoutSetupSitePage, RestAPIClient } from '@automattic/calypso-e2e';
+import { BrowserManager, RestAPIClient } from '@automattic/calypso-e2e';
 import { expect, tags, test } from '../../lib/pw-base';
 import { apiDeleteSite } from '../shared';
 import type { NewSiteResponse, TestAccount } from '@automattic/calypso-e2e';
@@ -22,6 +22,7 @@ test.describe(
 			helperData,
 			page,
 			pageCartCheckout,
+			pagePostCheckoutSetupSite,
 			pageSignupPickPlan,
 		} ) => {
 			await test.step( `Given I am authenticated as '${ accountPreRelease.accountName }'`, async function () {
@@ -62,7 +63,7 @@ test.describe(
 			await test.step( 'Then I land on the post-checkout "Set up your site" screen', async function () {
 				// Eligible paid plans now land on the post-checkout choice screen
 				// after checkout, instead of going straight to Home.
-				await new PostCheckoutSetupSitePage( page ).waitUntilLoaded();
+				await pagePostCheckoutSetupSite.waitUntilLoaded();
 			} );
 
 			await test.step( `And the sidebar shows I am on the ${ planName } plan`, async function () {


### PR DESCRIPTION
Follow-up to #111225.

## Proposed Changes

* Register the `PostCheckoutSetupSitePage` page object (added in #111225) as a `pagePostCheckoutSetupSite` fixture in `test/e2e/lib/pw-base.ts`.
* Rewrite the new-framework specs that reached the post-checkout "Set up your site" screen to consume the fixture instead of instantiating the page object directly:
  * `specs/flows/setup-domain__flows.spec.ts` (both paid-site + cancel-plan tests)
  * `specs/plans/plans__signup-business.spec.ts`
* Disable `react-hooks/rules-of-hooks` file-wide in `pw-base.ts` (with an explanatory comment). The rule misreads every Playwright fixture's `use(...)` callback as a React Hook called outside a component — a false positive, since there are no React hooks in this file. This mirrors the file's existing file-wide `no-empty-pattern` disable for the analogous fixture idiom.

## Why are these changes being made?

#111225 added `PostCheckoutSetupSitePage` but used it as `new PostCheckoutSetupSitePage( page )` inside the `.spec.ts` files. The new Playwright Test framework's convention (see `test/e2e/AGENTS.md`) is to expose page objects as `page*` fixtures and inject them via the test's destructured parameters. This change aligns the new page object with that convention so future specs can use `pagePostCheckoutSetupSite` directly.

The legacy `specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts` (Jest runner, not a `.spec.ts`) is intentionally left instantiating the page object directly — legacy tests don't use pw-base fixtures.

## Testing Instructions

These specs require a running Calypso instance and make real purchases, so they run in CI (pre-release E2E) rather than locally. Local verification performed:

* `yarn eslint test/e2e/lib/pw-base.ts test/e2e/specs/flows/setup-domain__flows.spec.ts test/e2e/specs/plans/plans__signup-business.spec.ts` — passes, 0 errors.
* Type-check of the e2e `tsconfig.json` — passes, 0 errors.

No product/runtime behavior changes; this is test-infrastructure only.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
