### PR TITLE
Notifications v2: source detail header from note.header

### DIFF
--- a/apps/notifications/src/app/note-icon/style.scss
+++ b/apps/notifications/src/app/note-icon/style.scss
@@ -1,9 +1,18 @@
 @import '@wordpress/base-styles/colors';
 
+// Nudge the icon down so it visually aligns with the cap-height of adjacent
+// text. Scoped to `.wpnc__user` (compound class selector, specificity 0,2,0)
+// so it outranks the body-content reset's `.wpnc__body-content div` rule
+// (0,1,1), which otherwise zeroes margins on all descendant divs.
+.wpnc__user .wpnc__note-icon {
+	margin-block: 4px;
+}
+
 .wpnc__note-icon {
 	position: relative;
 	height: 100%;
 	display: inline-flex;
+	margin-block: 4px;
 
 	img {
 		border-radius: 50%;

--- a/apps/notifications/src/app/note-list/dataviews-overrides.scss
+++ b/apps/notifications/src/app/note-list/dataviews-overrides.scss
@@ -25,6 +25,26 @@
 	}
 }
 
+// Dark-theme selected note: a restrained tint plus accent bar, with toned-down
+// dividers so the row doesn't read as a saturated boxed-in block.
+@mixin dark-selected-note-list-item {
+	div[role="article"].is-selected,
+	div[role="article"].is-selected:focus-within,
+	div[role="article"].is-selected:has(.is-unread),
+	div[role="article"].is-selected:has(.is-unread):focus-within {
+		border-top-color: color-mix(in srgb, var(--wp-admin-theme-color) 28%, var(--color-surface));
+
+		& + div[role="article"] {
+			border-top-color: color-mix(in srgb, var(--wp-admin-theme-color) 28%, var(--color-surface));
+		}
+
+		.dataviews-view-list__item-wrapper {
+			background-color: color-mix(in srgb, var(--wp-admin-theme-color) 20%, var(--color-surface));
+			box-shadow: inset 3px 0 0 var(--wp-admin-theme-color);
+		}
+	}
+}
+
 .wpnc__note-list .dataviews-view-list {
 	// When displaying fields in the DataViews, using the --wp-admin-theme-color color on hover is overwhelming.
 	// We override the hover color with the text color.
@@ -58,8 +78,22 @@
 		}
 	}
 
+	// Selected note: accent bar + stronger tint. The unread pairing keeps it
+	// winning over the `:has(.is-unread)` rules above, which would otherwise
+	// mask DataViews' faint built-in selection.
+	div[role="article"].is-selected,
+	div[role="article"].is-selected:focus-within,
+	div[role="article"].is-selected:has(.is-unread),
+	div[role="article"].is-selected:has(.is-unread):focus-within {
+		.dataviews-view-list__item-wrapper {
+			background-color: rgba(var(--wp-admin-theme-color--rgb), 0.12);
+			box-shadow: inset 3px 0 0 var(--wp-admin-theme-color);
+		}
+	}
+
 	@include ui-mixins.when-dark-theme {
 		@include dark-unread-note-list-item;
+		@include dark-selected-note-list-item;
 	}
 
 	// We override the media field

--- a/apps/notifications/src/app/note-list/style.scss
+++ b/apps/notifications/src/app/note-list/style.scss
@@ -35,6 +35,11 @@
 				color: var(--dashboard__text-muted-color, var(--color-text-subtle));
 			}
 		}
+
+		&:hover .wpnc__excerpt,
+		&:focus-within .wpnc__excerpt {
+			color: inherit;
+		}
 	}
 
 	.wpnc__note-icon .wpnc__gridicon {

--- a/apps/notifications/src/app/templates/note-summary.tsx
+++ b/apps/notifications/src/app/templates/note-summary.tsx
@@ -44,11 +44,13 @@ const NoteSummaryIcon = ( { iconUrl, link }: { iconUrl?: string; link?: string }
 // whole title links to the first range's target.
 const NoteSummaryTitle = ( { block, link }: { block: Subject; link?: string } ) => {
 	if ( ( block.ranges?.length ?? 0 ) > 1 ) {
+		// Drop `media` so `html()` doesn't render the avatar inline at full size
+		// (it's already shown by `NoteSummaryIcon`).
 		return (
 			<Text className="wpnc__user-title" weight={ 500 }>
 				<span
 					// eslint-disable-next-line react/no-danger
-					dangerouslySetInnerHTML={ { __html: html( block ) } }
+					dangerouslySetInnerHTML={ { __html: html( { text: block.text, ranges: block.ranges } ) } }
 				/>
 			</Text>
 		);
@@ -78,7 +80,7 @@ const NoteSummary = ( { note }: { note: Note } ) => {
 
 	if ( ! header || header.length === 0 ) {
 		return (
-			<HStack justify="flex-start" spacing={ 4 } alignment="top">
+			<HStack justify="flex-start" spacing={ 4 } alignment="center">
 				<NoteSummaryIcon iconUrl={ note.icon } />
 				<VStack className="wpnc__text-summary" spacing={ 0 }>
 					<ExternalLink href={ note.url }>{ note.subject[ 0 ].text }</ExternalLink>
@@ -91,13 +93,21 @@ const NoteSummary = ( { note }: { note: Note } ) => {
 	const snippet = header[ 1 ];
 	const subjectLink = getHeaderLink( subject );
 	const avatarUrl = subject.media?.[ 0 ]?.url;
+	// Skip an empty `header[1]`, which would render a label-less link (just its
+	// trailing icon) and top-align the icon against a single-line header.
+	const hasSnippet = !! snippet?.text?.trim();
 
 	return (
-		<HStack className="wpnc__user" justify="flex-start" spacing={ 4 } alignment="top">
+		<HStack
+			className="wpnc__user"
+			justify="flex-start"
+			spacing={ 4 }
+			alignment={ hasSnippet ? 'top' : 'center' }
+		>
 			<NoteSummaryIcon iconUrl={ avatarUrl } link={ subjectLink } />
 			<VStack className="wpnc__text-summary" spacing={ 0 }>
 				<NoteSummaryTitle block={ subject } link={ subjectLink } />
-				{ snippet && <ExternalLink href={ note.url }>{ snippet.text }</ExternalLink> }
+				{ hasSnippet && <ExternalLink href={ note.url }>{ snippet.text }</ExternalLink> }
 			</VStack>
 		</HStack>
 	);

--- a/apps/notifications/src/app/templates/note-summary.tsx
+++ b/apps/notifications/src/app/templates/note-summary.tsx
@@ -4,24 +4,21 @@ import {
 	__experimentalVStack as VStack,
 	ExternalLink,
 } from '@wordpress/components';
+import { html } from '../../panel/indices-to-html';
 import NoteIcon from '../note-icon';
-import type { Note } from '../types';
+import type { Note, Subject } from '../types';
 import type { CSSProperties } from 'react';
 
-type HeaderBlock = NonNullable< Note[ 'header' ] >[ number ];
-
-// Resolve the link used to wrap the header avatar / subject text. When the
-// first range is a user whose id differs from the site id, prefer the Reader
-// profile URL; otherwise fall back to the range's url. Mirrors the legacy
-// `SummaryInSingle` behaviour.
-const getHeaderLink = ( block: HeaderBlock ): string | undefined => {
-	const range = block.ranges?.[ 0 ] as
-		| { id?: number | string; site_id?: number; url?: string }
-		| undefined;
+// Resolve the link used to wrap the header avatar / subject text. A user range
+// whose id differs from the site id links to the Reader profile (some site
+// notifications populate id with the siteId); anything else falls back to the
+// range's own url. Mirrors the legacy `SummaryInSingle` behaviour.
+const getHeaderLink = ( block: Subject ): string | undefined => {
+	const range = block.ranges?.[ 0 ];
 	if ( ! range ) {
 		return undefined;
 	}
-	if ( range.id && range.id !== range.site_id ) {
+	if ( range.type === 'user' && range.id && range.id !== range.site_id ) {
 		return `https://wordpress.com/reader/users/id/${ range.id }`;
 	}
 	return range.url;
@@ -38,6 +35,37 @@ const NoteSummaryIcon = ( { iconUrl, link }: { iconUrl?: string; link?: string }
 		<a href={ link } style={ iconWrapStyle } target="_blank" rel="noopener noreferrer">
 			{ content }
 		</a>
+	);
+};
+
+// Title row of the detail header. When the header block references multiple
+// entities (e.g. "You on Post Title"), render it through `html()` so each
+// range keeps its own link, matching the legacy `UserHeader`; otherwise the
+// whole title links to the first range's target.
+const NoteSummaryTitle = ( { block, link }: { block: Subject; link?: string } ) => {
+	if ( ( block.ranges?.length ?? 0 ) > 1 ) {
+		return (
+			<Text className="wpnc__user-title" weight={ 500 }>
+				<span
+					// eslint-disable-next-line react/no-danger
+					dangerouslySetInnerHTML={ { __html: html( block ) } }
+				/>
+			</Text>
+		);
+	}
+
+	if ( link ) {
+		return (
+			<a className="wpnc__user-title" href={ link } target="_blank" rel="noreferrer">
+				<Text weight={ 500 }>{ block.text }</Text>
+			</a>
+		);
+	}
+
+	return (
+		<Text className="wpnc__user-title" weight={ 500 }>
+			{ block.text }
+		</Text>
 	);
 };
 
@@ -68,15 +96,7 @@ const NoteSummary = ( { note }: { note: Note } ) => {
 		<HStack className="wpnc__user" justify="flex-start" spacing={ 4 } alignment="top">
 			<NoteSummaryIcon iconUrl={ avatarUrl } link={ subjectLink } />
 			<VStack className="wpnc__text-summary" spacing={ 0 }>
-				{ subjectLink ? (
-					<a className="wpnc__user-title" href={ subjectLink } target="_blank" rel="noreferrer">
-						<Text weight={ 500 }>{ subject.text }</Text>
-					</a>
-				) : (
-					<Text className="wpnc__user-title" weight={ 500 }>
-						{ subject.text }
-					</Text>
-				) }
+				<NoteSummaryTitle block={ subject } link={ subjectLink } />
 				{ snippet && <ExternalLink href={ note.url }>{ snippet.text }</ExternalLink> }
 			</VStack>
 		</HStack>

--- a/apps/notifications/src/app/templates/note-summary.tsx
+++ b/apps/notifications/src/app/templates/note-summary.tsx
@@ -1,57 +1,83 @@
 import {
 	__experimentalHStack as HStack,
+	__experimentalText as Text,
 	__experimentalVStack as VStack,
 	ExternalLink,
 } from '@wordpress/components';
-import { html } from '../../panel/indices-to-html';
 import NoteIcon from '../note-icon';
 import type { Note } from '../types';
 import type { CSSProperties } from 'react';
 
-const getNoteIconLink = ( note: Note ) => {
-	const user = ( note.subject?.[ 0 ].ranges || [] ).find( ( { type } ) => type === 'user' );
-	if ( user ) {
-		const { id: userId, site_id: siteId, url } = user;
-		// Some site notifications populate id with the siteId, so consider the userId falsy in this
-		// case.
-		return userId && userId !== siteId ? `https://wordpress.com/reader/users/id/${ userId }` : url;
-	}
+type HeaderBlock = NonNullable< Note[ 'header' ] >[ number ];
 
-	return '';
+// Resolve the link used to wrap the header avatar / subject text. When the
+// first range is a user whose id differs from the site id, prefer the Reader
+// profile URL; otherwise fall back to the range's url. Mirrors the legacy
+// `SummaryInSingle` behaviour.
+const getHeaderLink = ( block: HeaderBlock ): string | undefined => {
+	const range = block.ranges?.[ 0 ] as
+		| { id?: number | string; site_id?: number; url?: string }
+		| undefined;
+	if ( ! range ) {
+		return undefined;
+	}
+	if ( range.id && range.id !== range.site_id ) {
+		return `https://wordpress.com/reader/users/id/${ range.id }`;
+	}
+	return range.url;
 };
 
-const NoteSummaryIcon = ( { note }: { note: Note } ) => {
-	const link = getNoteIconLink( note );
-	const style: CSSProperties = { display: 'flex', flexShrink: 0 };
-	const content = <NoteIcon icon={ note.icon } size={ 32 } />;
+const iconWrapStyle: CSSProperties = { display: 'flex', flexShrink: 0 };
 
+const NoteSummaryIcon = ( { iconUrl, link }: { iconUrl?: string; link?: string } ) => {
+	const content = <NoteIcon icon={ iconUrl } size={ 32 } />;
 	if ( ! link ) {
-		return <div style={ style }> { content }</div>;
+		return <div style={ iconWrapStyle }>{ content }</div>;
 	}
-
 	return (
-		<a href={ link } style={ style } target="_blank" rel="noopener noreferrer">
+		<a href={ link } style={ iconWrapStyle } target="_blank" rel="noopener noreferrer">
 			{ content }
 		</a>
 	);
 };
 
+// Detail-view header: built from `note.header` so the first row anchors the
+// panel with the post owner / author + post title (matching the legacy
+// `SummaryInSingle`). Falls back to rendering `note.subject` when a note has
+// no `header` block (some system notes).
 const NoteSummary = ( { note }: { note: Note } ) => {
+	const header = note.header;
+
+	if ( ! header || header.length === 0 ) {
+		return (
+			<HStack justify="flex-start" spacing={ 4 } alignment="top">
+				<NoteSummaryIcon iconUrl={ note.icon } />
+				<VStack className="wpnc__text-summary" spacing={ 0 }>
+					<ExternalLink href={ note.url }>{ note.subject[ 0 ].text }</ExternalLink>
+				</VStack>
+			</HStack>
+		);
+	}
+
+	const subject = header[ 0 ];
+	const snippet = header[ 1 ];
+	const subjectLink = getHeaderLink( subject );
+	const avatarUrl = subject.media?.[ 0 ]?.url;
+
 	return (
-		<HStack justify="flex-start" spacing={ 4 }>
-			<NoteSummaryIcon note={ note } />
-			<VStack className="wpnc__text-summary">
-				<ExternalLink href={ note.url }>
-					<span
-						className="wpnc__subject"
-						/* eslint-disable-next-line react/no-danger */
-						dangerouslySetInnerHTML={ {
-							__html: html( note.subject[ 0 ], {
-								links: false,
-							} ),
-						} }
-					/>
-				</ExternalLink>
+		<HStack className="wpnc__user" justify="flex-start" spacing={ 4 } alignment="top">
+			<NoteSummaryIcon iconUrl={ avatarUrl } link={ subjectLink } />
+			<VStack className="wpnc__text-summary" spacing={ 0 }>
+				{ subjectLink ? (
+					<a className="wpnc__user-title" href={ subjectLink } target="_blank" rel="noreferrer">
+						<Text weight={ 500 }>{ subject.text }</Text>
+					</a>
+				) : (
+					<Text className="wpnc__user-title" weight={ 500 }>
+						{ subject.text }
+					</Text>
+				) }
+				{ snippet && <ExternalLink href={ note.url }>{ snippet.text }</ExternalLink> }
 			</VStack>
 		</HStack>
 	);

--- a/apps/notifications/src/app/types.ts
+++ b/apps/notifications/src/app/types.ts
@@ -25,7 +25,7 @@ type Media = {
 	width?: string | number;
 };
 
-type Subject = {
+export type Subject = {
 	text: string;
 	ranges?: Range[];
 	media?: Media[];


### PR DESCRIPTION
Follow-up to #111077 addressing the review on #110995 — https://github.com/Automattic/wp-calypso/pull/110995#pullrequestreview-4374494679 — about the detail-panel context header regressing in the side-by-side rewrite.

## The regression

The v1 detail panel anchored itself with a row built from `note.header`: `header[0]` was the post owner / author + their avatar, and `header[1]` was the post-title snippet. The v2 rewrite swapped that for a `NoteSummary` built from `note.subject` + `note.icon`, which broke two surfaces:

- **Likes detail** — the header avatar came from `note.icon`, which is the first liker's avatar. So that person appeared twice — once in the summary row, then again as the first item in the liker list.
- **Mentions detail** — without a header block at all, the panel jumped straight into the comment body, losing the "who wrote the post you were mentioned in" context.

Same root cause: the context anchor row keyed off `note.header` was dropped.

## What this PR does

- Rewrite `NoteSummary` to consume `note.header`: avatar from `header[0].media[0]`, subject text from `header[0].text`, post-title snippet from `header[1].text`.
- Follow the v2 `block-user.tsx` pattern for the subject — `<a className="wpnc__user-title"><Text weight={ 500 }>...</Text></a>` — so the chrome matches the rest of the side-by-side panel. Bold via Text's `weight` prop (the `.wpnc__user .wpnc__user-title { font-weight: 500 }` rule loses to Text's internal styles).
- Snippet wrapped in `ExternalLink` so it carries the external-arrow affordance to the post.
- Fall back to the prior `note.subject` rendering when a note has no `header` block (some system notes), so we don't regress those.
- Nudge `.wpnc__note-icon` down by `margin-block: 4px` so the avatar aligns with the cap-height of adjacent text. Added a scoped `.wpnc__user .wpnc__note-icon` rule with the same value so the offset survives the `.wpnc__body-content div { margin: 0 }` reset when the icon is rendered inside the body (e.g. inside `block-user`).
- In the note-list, make the excerpt inherit the row's color on hover / focus so it stops looking detached from the row's interactive state.

## Follow-up fixes (from self-review + testing)

- **Single-row header centering** — center the icon against the subject when there's no second row (empty header, or a header with no snippet text) instead of top-aligning it.
- **No oversized header avatar** — `html()`'s `convert()` folds `block.media` into the ranges, so passing the whole subject block drew the gravatar inline at native server size, next to and duplicating the `NoteSummaryIcon`. Pass only `text` + `ranges`, mirroring the legacy `UserHeader`'s media-less copy.
- **No stray snippet arrow** — skip the snippet `ExternalLink` when `header[1]` has no text; an empty snippet otherwise rendered a label-less link showing only its trailing icon on its own line.
- **Clearer list selection** — DataViews' built-in `.is-selected` tint is a faint 8% and the unread `:has(.is-unread)` rules out-specified and masked it. Add an explicit selected-row style (solid accent bar + stronger tint) that wins on both read and unread rows. Tuned separately for dark mode — a restrained tint with toned-down dividers rather than a saturated boxed-in block — and scoped to `.wpnc__note-list` so it never leaks to other DataViews instances.

## Test plan

- [ ] Open a Likes notification at xlarge — the detail header shows the post owner's avatar + their name (bold, linked to Reader profile), with the post title beneath linked to the post. The first liker no longer appears twice.
- [ ] Open a Mentions notification — the detail header now shows the post author + post title; the comment body sits below it instead of starting flush at the top.
- [ ] Open a Comment / Follow notification — header still renders sensibly (post owner avatar + name + post title), with no oversized gravatar in the header.
- [ ] Open a system note without a `header` block (e.g. a daily prompt or a billing notification) — falls back to rendering `note.subject` (no crash, no broken header).
- [ ] Single-row header (no snippet text) — the icon is vertically centered against the title, and there is no stray external-link arrow on its own line.
- [ ] Avatar visually centers on the first line of the subject text (4px offset working).
- [ ] Select a note in the list — the active row is clearly highlighted (accent bar + tint), including for unread rows.
- [ ] In the note-list, hover / focus a row — the excerpt color tracks the row's interactive color.
- [ ] No TypeScript / React console errors.
- [ ] Tested in dark mode — list selection reads clearly without looking weird.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
