### PR TITLE
[DOTMSD-1254] Fix dark mode contrast across Reader and Dashboard

### DIFF
--- a/client/dashboard/app/_dark-theme.scss
+++ b/client/dashboard/app/_dark-theme.scss
@@ -1,5 +1,12 @@
 @import 'calypso/lib/color-scheme/dark-theme';
 
+/* Links */
+@mixin dashboard-dark-theme-links {
+	@at-root :where( & ) a {
+		color: var( --wp-admin-theme-color-darker-20 );
+	}
+}
+
 /* Callout */
 @mixin dashboard-dark-theme-callout {
 	.dashboard-callout__content > :first-child {
@@ -441,6 +448,7 @@
 	@include dashboard-dark-theme-emails;
 	@include dashboard-dark-theme-form-controls;
 	@include dashboard-dark-theme-item-group;
+	@include dashboard-dark-theme-links;
 	@include color-scheme-dark-theme-modal;
 	@include dashboard-dark-theme-modal;
 	@include color-scheme-dark-theme-palettes;

--- a/client/dashboard/app/style.scss
+++ b/client/dashboard/app/style.scss
@@ -39,18 +39,6 @@ a {
 	color: var( --wp-admin-theme-color );
 }
 
-@media screen {
-	:where( :root[data-theme='dark'] ) a {
-		color: var( --wp-admin-theme-color-darker-20 );
-	}
-}
-
-@media screen and ( prefers-color-scheme: dark ) {
-	:where( :root[data-theme='system'] ) a {
-		color: var( --wp-admin-theme-color-darker-20 );
-	}
-}
-
 // This is a temporary fix to ensure the tooltip has dashboard colors and a box-shadow.
 // Currently, there is an issue with @automattic/charts where svgLabelSmall.fill is defined with var().
 // This causes the visx tooltip to render a malformed box-shadow value, given that it interpolates the color. e.g: `${theme?.color}55`.

--- a/client/dashboard/app/style.scss
+++ b/client/dashboard/app/style.scss
@@ -39,6 +39,18 @@ a {
 	color: var( --wp-admin-theme-color );
 }
 
+@media screen {
+	:where( :root[data-theme='dark'] ) a {
+		color: var( --wp-admin-theme-color-darker-20 );
+	}
+}
+
+@media screen and ( prefers-color-scheme: dark ) {
+	:where( :root[data-theme='system'] ) a {
+		color: var( --wp-admin-theme-color-darker-20 );
+	}
+}
+
 // This is a temporary fix to ensure the tooltip has dashboard colors and a box-shadow.
 // Currently, there is an issue with @automattic/charts where svgLabelSmall.fill is defined with var().
 // This causes the visx tooltip to render a malformed box-shadow value, given that it interpolates the color. e.g: `${theme?.color}55`.

--- a/client/lib/color-scheme/dark-theme.scss
+++ b/client/lib/color-scheme/dark-theme.scss
@@ -641,6 +641,36 @@ This mixin generates alias variables for a color palette. For example, the
 			background: var( --wp-components-color-gray-300 );
 			color: var( --wp-components-color-gray-800 );
 		}
+
+		&.has-values {
+			background: color-mix(
+				in srgb,
+				var( --dashboard-surface__background-color ) 85%,
+				var( --wp-components-color-accent-darker-20 )
+			);
+			color: var( --wp-components-color-accent-darker-20 );
+
+			&:hover,
+			&:focus-visible,
+			&[aria-expanded='true'] {
+				background: color-mix(
+					in srgb,
+					var( --dashboard-surface__background-color ) 75%,
+					var( --wp-components-color-accent-darker-20 )
+				);
+				color: var( --wp-components-color-accent-darker-20 );
+			}
+		}
+	}
+
+	.dataviews-filters__container-visibility-toggle .dataviews-filters-toggle__count {
+		background: color-mix(
+			in srgb,
+			var( --dashboard-surface__background-color ) 70%,
+			var( --wp-components-color-accent-darker-20 )
+		);
+		color: var( --dashboard__text-color );
+		outline-color: var( --dashboard-surface__background-color );
 	}
 
 	.dataviews-footer {

--- a/client/lib/color-scheme/dark-theme.scss
+++ b/client/lib/color-scheme/dark-theme.scss
@@ -195,6 +195,46 @@ This mixin generates alias variables for a color palette. For example, the
 	}
 }
 
+@mixin color-scheme-dark-theme-secondary-tertiary-and-link-buttons {
+	// Calypso's default WP button overrides set action tokens on the button
+	// itself, so root-level dark theme tokens do not reach these variants.
+	.components-button:is( .is-secondary, .is-tertiary, .is-link ):not(
+			:disabled,
+			[aria-disabled='true'],
+			.is-destructive,
+			.is-pressed,
+			[aria-pressed='true']
+		) {
+		--wp-components-color-accent: var( --color-link );
+		--wp-components-color-accent-darker-10: var( --color-link-dark );
+		--wp-components-color-accent-darker-20: var( --color-link );
+
+		color: var( --wp-components-color-accent );
+
+		&:hover,
+		&:active {
+			color: var( --wp-components-color-accent-darker-20 );
+		}
+	}
+
+	.components-button.is-secondary:not(
+			:disabled,
+			[aria-disabled='true'],
+			.is-destructive,
+			.is-pressed,
+			[aria-pressed='true']
+		):not( :focus ) {
+		border-color: var( --wp-components-color-accent );
+		box-shadow: inset 0 0 0 1px var( --wp-components-color-accent ), 0 0 0 currentColor;
+
+		&:hover {
+			border-color: var( --wp-components-color-accent-darker-20 );
+			box-shadow: inset 0 0 0 1px var( --wp-components-color-accent-darker-20 ),
+				0 0 0 currentColor;
+		}
+	}
+}
+
 @mixin color-scheme-dark-theme-calypso-tokens {
 	@include color-scheme-dark-theme-tokens;
 	@include color-scheme-dark-theme-palettes;
@@ -777,6 +817,7 @@ This mixin generates alias variables for a color palette. For example, the
 	@include color-scheme-dark-theme-modal;
 	@include color-scheme-dark-theme-site-icon;
 	@include color-scheme-dark-theme-primary-button;
+	@include color-scheme-dark-theme-secondary-tertiary-and-link-buttons;
 	@include color-scheme-dark-theme-agenttic;
 }
 

--- a/client/reader/color-scheme/dark-mode.scss
+++ b/client/reader/color-scheme/dark-mode.scss
@@ -70,6 +70,32 @@
 		}
 	}
 
+	.reader-onboarding {
+		.checklist-item__task-content.components-button:hover:not( [disabled] ),
+		.checklist-item__task-content.components-button:focus:not( [disabled] ) {
+			color: var( --color-link );
+			fill: var( --color-link );
+		}
+
+		.checklist-item__task.completed.enabled > button:hover,
+		.checklist-item__task.completed.enabled > button:focus,
+		.checklist-item__task.pending > button:hover,
+		.checklist-item__task.pending > button:focus,
+		.checklist-item__task.completed.enabled > a:hover,
+		.checklist-item__task.completed.enabled > a:focus,
+		.checklist-item__task.pending > a:hover,
+		.checklist-item__task.pending > a:focus {
+			.checklist-item__text {
+				color: var( --color-link );
+			}
+
+			.checklist-item__chevron,
+			.checklist-item__checkmark {
+				fill: var( --color-link );
+			}
+		}
+	}
+
 	.popover.is-top .popover__arrow::before,
 	.popover.is-top-left .popover__arrow::before,
 	.popover.is-top-right .popover__arrow::before {
@@ -159,8 +185,18 @@
 	}
 
 	.subscribe-modal__site-list-column .reader-subscription-list-item.is-selected {
-		background-color: color-mix( in srgb, var( --color-primary-0 ) 45%, var( --color-surface ) );
-		border-color: var( --color-primary );
+		background-color: color-mix(
+			in srgb,
+			var( --wp-admin-theme-color ) 12%,
+			var( --color-surface )
+		);
+		border-color: color-mix( in srgb, var( --wp-admin-theme-color ) 60%, var( --color-surface ) );
+
+		&::after {
+			background-color: inherit;
+			border-top-color: inherit;
+			border-right-color: inherit;
+		}
 	}
 
 	.subscribe-modal__preview-placeholder {

--- a/client/reader/color-scheme/dark-mode.scss
+++ b/client/reader/color-scheme/dark-mode.scss
@@ -58,6 +58,16 @@
 
 	.reader-onboarding-modal__footer {
 		border-top-color: var( --color-border-subtle );
+
+		.components-button.is-tertiary:not( :disabled, [aria-disabled='true'] ) {
+			color: var( --color-text-subtle );
+
+			&:hover,
+			&:focus,
+			&:active {
+				color: var( --color-text );
+			}
+		}
 	}
 
 	.popover.is-top .popover__arrow::before,

--- a/packages/help-center/src/components/help-center-support-chat-message.scss
+++ b/packages/help-center/src/components/help-center-support-chat-message.scss
@@ -7,6 +7,18 @@
 	align-items: center;
 	gap: 4px;
 
+	@media screen {
+		:root[data-theme='dark'] & {
+			color: var( --dashboard__text-muted-color, var( --studio-gray-50, #646970 ) );
+		}
+	}
+
+	@media screen and ( prefers-color-scheme: dark ) {
+		:root[data-theme='system'] & {
+			color: var( --dashboard__text-muted-color, var( --studio-gray-50, #646970 ) );
+		}
+	}
+
 	.help-center-support-chat__conversation-information-name {
 		text-overflow: ellipsis;
 		overflow: hidden;

--- a/packages/help-center/src/components/help-center-support-chat-message.scss
+++ b/packages/help-center/src/components/help-center-support-chat-message.scss
@@ -1,7 +1,7 @@
 @import 'variables';
 
 .help-center-support-chat__conversation-sub-information {
-	color: var( --studio-gray-50, #646970 );
+	color: var( --studio-gray-50 );
 	display: flex;
 	font-size: $font-body-extra-small;
 	align-items: center;
@@ -9,13 +9,13 @@
 
 	@media screen {
 		:root[data-theme='dark'] & {
-			color: var( --dashboard__text-muted-color, var( --studio-gray-50, #646970 ) );
+			color: var( --dashboard__text-muted-color, var( --studio-gray-50 ) );
 		}
 	}
 
 	@media screen and ( prefers-color-scheme: dark ) {
 		:root[data-theme='system'] & {
-			color: var( --dashboard__text-muted-color, var( --studio-gray-50, #646970 ) );
+			color: var( --dashboard__text-muted-color, var( --studio-gray-50 ) );
 		}
 	}
 

--- a/packages/odie-client/src/components/message/style.scss
+++ b/packages/odie-client/src/components/message/style.scss
@@ -453,7 +453,7 @@ $feedback-button-size: 28px;
 $custom-border-corner-size: 16px;
 
 .odie-gradient-to-white {
-	background: linear-gradient( 180deg, rgba( 255, 255, 255, 0 ) 0%, #fff 50% );
+	background: linear-gradient( 180deg, rgba( 255, 255, 255, 0 ) 0%, var( --color-surface, #fff ) 50% );
 	display: flex;
 	align-items: center;
 	gap: 8px;


### PR DESCRIPTION
Part of DOTMSD-1254 and DOTMSD-1252

## Proposed Changes

| | |
|---|---|
| <img width="2912" height="2514" alt="CleanShot 2026-05-29 at 15 13 22@2x" src="https://github.com/user-attachments/assets/35e6e58c-a1d1-4187-881b-d65fab2e08b8" /> | <img width="1774" height="1626" alt="CleanShot 2026-05-29 at 15 49 43@2x" src="https://github.com/user-attachments/assets/bde68492-580a-4845-ad70-6169a9176781" /> |

| | | |
|---|---|---|
| <img width="2022" height="1512" alt="CleanShot 2026-05-29 at 18 10 06@2x" src="https://github.com/user-attachments/assets/88103dd6-698b-415b-8580-205e2961a783" /> | <img width="2004" height="1522" alt="CleanShot 2026-05-29 at 18 10 14@2x" src="https://github.com/user-attachments/assets/de3b6db2-e9dd-4f85-a917-4b57d1e83bb8" /> | <img width="2032" height="1504" alt="CleanShot 2026-05-29 at 18 21 31@2x" src="https://github.com/user-attachments/assets/25e3ce87-94a6-46b5-a8bc-9901ce227985" /> |

* Improve dark-mode contrast for Reader onboarding checklist links, footer actions, "See more topics", "Continue", and "Finish" controls.
* Normalize secondary, tertiary, and link-style WordPress component buttons in dark mode through the shared dark-theme button token override.
* Tune the selected Reader Discover site card treatment so the selected fill, border, and arrow pointer stay visible without overpowering the dark surface.
* Lift Dashboard dark-mode plain links through the Dashboard dark-theme mixin system instead of an ad-hoc root override.
* Calm DataViews dark-mode filter count badges and active filter chips so small count text and active filter labels remain readable without the saturated blue fill feeling as heavy.
* Lift Help Center recent-conversation metadata in Dashboard dark mode to the Dashboard muted text token.
* Use the current dark surface token for the Odie message gradient so Help Center hover/scroll overlays do not flash white in dark mode.
* Use existing dark-mode tokens only; no new dependencies, strings, APIs, or component contracts.

## Why are these changes being made?

The original Reader onboarding secondary actions were too muted in dark mode. A broader audit from DOTMSD-1252 also found the same contrast pattern around Dashboard links, DataViews filter badges, Help Center secondary metadata, and Help Center/Odie overlays.

This keeps the changes scoped to token-level dark-mode styling: Reader onboarding actions use existing Reader link tokens, shared WordPress component buttons inherit the same dark-mode action token behavior, Dashboard links live in the Dashboard dark-theme mixin system, DataViews filter affordances use quieter dark-mode chip treatments, Help Center metadata uses Dashboard muted text where available, and Odie gradients use the active surface token.

## Testing Instructions

* Localhost paths for manual dark-mode validation:
    * `http://my.localhost:3000/domains` — inspect the Domains DataViews filter count badge, open the filter panel to inspect the active filter chip, and check domain setup links plus secondary metadata for contrast.
    * `http://my.localhost:3000/sites` — inspect Sites list secondary metadata, then open the Help Center/Support Assistant and confirm message hover/scroll overlays do not flash white in dark mode.
    * `http://calypso.localhost:3000/reader?flags=reader%2Fonboarding-rsm%2Creader%2Fforce-onboarding&codexTopics=1780070507751` — validate Reader onboarding step 1 checklist link hover/focus contrast.
    * `http://calypso.localhost:3000/reader?flags=reader%2Fonboarding-rsm%2Creader%2Fforce-onboarding&codexTopics=1780070507751` — validate Reader onboarding step 2 topic cards, "Subscribe" buttons, "See more topics", and "Continue".
    * `http://calypso.localhost:3000/reader?flags=reader%2Fonboarding-rsm%2Creader%2Fforce-onboarding&codexTopics=1780070507751` — validate Reader onboarding step 3 selected site card fill, subdued border, matching arrow pointer, and "Finish".
* If the Reader onboarding has already been completed locally, use the same Reader URL with a fresh `codexTopics` value.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
