### PR TITLE
domain-search: typed-`@wordpress/i18n` migration

### DIFF
--- a/packages/domain-search/src/helpers/get-availability-notice.tsx
+++ b/packages/domain-search/src/helpers/get-availability-notice.tsx
@@ -205,9 +205,7 @@ export const getAvailabilityNotice = (
 					sprintf(
 						/* translators: %(domain)s is the domain name */
 						__(
-							'<strong>%(domain)s</strong> is already connected to this site, but registered somewhere else. Do you want to move ' +
-								'it from your current domain provider to WordPress.com so you can manage the domain and the site ' +
-								'together? <button>Yes, transfer it to WordPress.com.</button>'
+							'<strong>%(domain)s</strong> is already connected to this site, but registered somewhere else. Do you want to move it from your current domain provider to WordPress.com so you can manage the domain and the site together? <button>Yes, transfer it to WordPress.com.</button>'
 						),
 						{
 							domain,
@@ -277,8 +275,7 @@ export const getAvailabilityNotice = (
 				sprintf(
 					/* translators: %(domain)s is the domain name, %(site)s is the other site domain */
 					__(
-						'<strong>%(domain)s</strong> is already connected to your site %(site)s. If you want to connect it to this site ' +
-							'instead, we will be happy to help you do that. <a>Contact us</a>.'
+						'<strong>%(domain)s</strong> is already connected to your site %(site)s. If you want to connect it to this site instead, we will be happy to help you do that. <a>Contact us</a>.'
 					),
 					{
 						domain,
@@ -297,8 +294,7 @@ export const getAvailabilityNotice = (
 				sprintf(
 					/* translators: %(domain)s is the domain name, %(site)s is the other site domain */
 					__(
-						'<strong>%(domain)s</strong> is already connected to your site %(site)s.' +
-							' <button>Register it to the connected site</button>.'
+						'<strong>%(domain)s</strong> is already connected to your site %(site)s. <button>Register it to the connected site</button>.'
 					),
 					{
 						domain,
@@ -380,7 +376,7 @@ export const getAvailabilityNotice = (
 			break;
 		case DomainAvailabilityStatus.MAINTENANCE:
 			if ( availabilityData.tld ) {
-				let maintenanceEnd = __( 'shortly' );
+				let maintenanceEnd: string = __( 'shortly' );
 				if ( availabilityData.maintenance_end_time ) {
 					maintenanceEnd = moment
 						.unix( parseInt( availabilityData.maintenance_end_time, 10 ) )
@@ -389,10 +385,9 @@ export const getAvailabilityNotice = (
 
 				message = createInterpolateElement(
 					sprintf(
-						/* translators: %(tld)s is the TLD */
+						/* translators: %(tld)s is the TLD, %(maintenanceEnd)s is the maintenance end time */
 						__(
-							'Domains ending with <strong>.%(tld)s</strong> are undergoing maintenance. Please ' +
-								'try a different extension or check back %(maintenanceEnd)s.'
+							'Domains ending with <strong>.%(tld)s</strong> are undergoing maintenance. Please try a different extension or check back %(maintenanceEnd)s.'
 						),
 						{
 							tld: availabilityData.tld,
@@ -407,7 +402,7 @@ export const getAvailabilityNotice = (
 			}
 			break;
 		case DomainAvailabilityStatus.PURCHASES_DISABLED: {
-			let maintenanceEnd = __( 'shortly' );
+			let maintenanceEnd: string = __( 'shortly' );
 			if ( availabilityData.maintenance_end_time ) {
 				maintenanceEnd = moment
 					.unix( parseInt( availabilityData.maintenance_end_time, 10 ) )
@@ -417,8 +412,7 @@ export const getAvailabilityNotice = (
 			message = sprintf(
 				/* translators: %(maintenanceEnd)s is the maintenance end time */
 				__(
-					'Domain registration is unavailable at this time. Please select a free subdomain ' +
-						'or check back %(maintenanceEnd)s.'
+					'Domain registration is unavailable at this time. Please select a free subdomain or check back %(maintenanceEnd)s.'
 				),
 				{
 					maintenanceEnd,

--- a/packages/domain-search/src/helpers/parse-match-reasons.ts
+++ b/packages/domain-search/src/helpers/parse-match-reasons.ts
@@ -23,7 +23,7 @@ function sortMatchReasons( matchReasons: string[] ) {
 }
 
 function getMatchReasonPhrasesMap( tld: string ) {
-	return new Map( [
+	return new Map< string, string >( [
 		[
 			TLD_EXACT_MATCH,
 			/* translators: %(tld)s is the TLD */

--- a/packages/domain-search/src/ui/domain-search-controls/filter-button.tsx
+++ b/packages/domain-search/src/ui/domain-search-controls/filter-button.tsx
@@ -25,7 +25,7 @@ export const DomainSearchControlsFilterButton = forwardRef(
 					'Filter, %(filterCount)s filters applied',
 					count
 				),
-				{ filterCount: count }
+				{ filterCount: String( count ) }
 			);
 		} else {
 			ariaLabel = __( 'Filter, no filters applied' );

--- a/packages/domain-search/src/ui/domain-search-skip-suggestion/index.tsx
+++ b/packages/domain-search/src/ui/domain-search-skip-suggestion/index.tsx
@@ -36,7 +36,7 @@ const DomainSearchSkipSuggestion = ( {
 
 	let title;
 	let subtitle;
-	let buttonText = __( 'Skip purchase' );
+	let buttonText: string = __( 'Skip purchase' );
 	let showButton = true;
 	let chevronOnMobile = false;
 
@@ -95,7 +95,7 @@ const DomainSearchSkipSuggestion = ( {
 	const skipLabel = sprintf(
 		// translators: %(domain)s is the domain name
 		__( 'Skip purchase and continue with %(domain)s' ),
-		{ domain }
+		{ domain: domain ?? '' }
 	);
 
 	const renderRight = () => {

--- a/packages/domain-search/src/ui/domains-full-cart-summary/index.tsx
+++ b/packages/domain-search/src/ui/domains-full-cart-summary/index.tsx
@@ -15,7 +15,7 @@ export const DomainsFullCartSummary = ( {
 		// translators: %(domains)s is the number of domains selected.
 		_n( '%(domains)s domain', '%(domains)s domains', totalItems ),
 		{
-			domains: totalItems,
+			domains: String( totalItems ),
 		}
 	);
 

--- a/packages/domain-search/src/ui/domains-mini-cart/summary.tsx
+++ b/packages/domain-search/src/ui/domains-mini-cart/summary.tsx
@@ -21,7 +21,7 @@ export const DomainsMiniCartSummary = ( {
 		// translators: %(domains)s is the number of domains selected.
 		_n( '%(domains)s domain', '%(domains)s domains', totalItems ),
 		{
-			domains: totalItems,
+			domains: String( totalItems ),
 		}
 	);
 
@@ -33,7 +33,7 @@ export const DomainsMiniCartSummary = ( {
 			totalItems
 		),
 		{
-			domains: totalItems,
+			domains: String( totalItems ),
 			total: totalPrice,
 		}
 	);


### PR DESCRIPTION
Fixes DOTCOM-17300

Part of #105909

## Proposed Changes

Forward-compatible TypeScript fixes so `packages/domain-search` compiles against both `@wordpress/i18n` `^5.23.0` (trunk's current pin) and `^6.x` (the bump in #105909). Because `TransformedText<T> extends string`, every change is a no-op at runtime and type-checks under both versions.

* Join `+`-concatenated `sprintf` format strings into single string literals so 6.x's typed-format parser recognises the `%(…)s` placeholders (TS2353). The string passed to `__()` is byte-for-byte identical, so no translation keys change.
* Coerce numeric `sprintf` args with `String( … )` and widen an optional arg with `?? ''` (TS2769).
* Widen `let` bindings initialised from `__()` to `: string` where they are later reassigned a plain `string` (TS2322).
* Annotate the match-reason map as `Map< string, string >` so its differing `TransformedText` literal values unify to `string` (TS2769).

No real i18n bugs surfaced — all placeholders already matched their arg keys; these are purely type-level fixes.

## Why are these changes being made?

One of several small PRs decomposing the `@wordpress/i18n` 5.x → 6.x migration out of the renovate monorepo bump (#105909). `@wordpress/i18n@6` brands `__()`'s return as `TransformedText<T>` and type-checks `sprintf()` format strings against their args, surfacing these errors in `domain-search`.

## Testing Instructions

* `yarn typecheck-client` (and a direct `tsc --build` of `packages/domain-search`) passes against an `@wordpress/i18n@6.x` install — 18 type errors → 0.
* No runtime/behaviour change: rendered strings, placeholders, and translation keys are unchanged.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
