### PR TITLE
Keep sidebar image icons steady in customize mode

### DIFF
--- a/client/my-sites/sidebar/customize/customize-mode.scss
+++ b/client/my-sites/sidebar/customize/customize-mode.scss
@@ -15,6 +15,8 @@
 //   hover and selected paint suppressed (plugin v0.1.6, l.170-215, DES-605).
 // - Transitions are disabled on the customize overrides so there's no
 //   trailing blue "ease-out" when the cursor leaves a row.
+// - Image-backed plugin icons keep fixed opacity during customize mode
+//   (WordPress/wp-admin-sidebar#79).
 // - Drag-time hover suppression on every row (plugin v0.1.6, l.329-347).
 // - Solid drop-zone hints stay visible throughout customization
 //   (WordPress/wp-admin-sidebar#81).
@@ -108,6 +110,20 @@ body.is-admin-sidebar-customize-mode {
 		> .sidebar__menu.is-togglable > li > .sidebar__heading:focus .sidebar__menu-icon {
 			fill: var( --color-sidebar-text );
 			color: var( --color-sidebar-text );
+		}
+
+		// Image icons inherit Calypso's default `opacity: 0.6` idle state and
+		// `opacity: 1` hover/selected state. Customize rows are inert, so keep
+		// image-backed plugin icons at one brightness across the whole session.
+		> .sidebar__menu-link img.sidebar__menu-icon,
+		> .sidebar__menu-link:hover img.sidebar__menu-icon,
+		> .sidebar__menu-link:focus img.sidebar__menu-icon,
+		&.selected > .sidebar__menu-link img.sidebar__menu-icon,
+		&.selected > .sidebar__menu-link:hover img.sidebar__menu-icon,
+		> .sidebar__menu.is-togglable > li > .sidebar__heading img.sidebar__menu-icon,
+		> .sidebar__menu.is-togglable > li > .sidebar__heading:hover img.sidebar__menu-icon,
+		> .sidebar__menu.is-togglable > li > .sidebar__heading:focus img.sidebar__menu-icon {
+			opacity: 1;
 		}
 	}
 

--- a/client/my-sites/sidebar/customize/customize-mode.scss
+++ b/client/my-sites/sidebar/customize/customize-mode.scss
@@ -15,8 +15,8 @@
 //   hover and selected paint suppressed (plugin v0.1.6, l.170-215, DES-605).
 // - Transitions are disabled on the customize overrides so there's no
 //   trailing blue "ease-out" when the cursor leaves a row.
-// - Image-backed plugin icons keep fixed opacity during customize mode
-//   (WordPress/wp-admin-sidebar#79).
+// - Custom plugin icons stay on the sidebar foreground token during
+//   customize mode (WordPress/wp-admin-sidebar#79).
 // - Drag-time hover suppression on every row (plugin v0.1.6, l.329-347).
 // - Solid drop-zone hints stay visible throughout customization
 //   (WordPress/wp-admin-sidebar#81).
@@ -24,6 +24,25 @@
 // @see WordPress/wp-admin-sidebar v0.1.6 src/customizer/customizer.css
 
 body.is-admin-sidebar-customize-mode {
+	// While customize mode is open, every row is visually inert except for
+	// the drag affordances. Pin all icon glyphs to the foreground token so
+	// Calypso's normal hover/selected icon colors cannot leak through.
+	.sidebar .sidebar__heading .sidebar__menu-icon,
+	.sidebar .sidebar__menu-link .sidebar__menu-icon {
+		fill: var( --color-sidebar-text ) !important;
+		color: var( --color-sidebar-text ) !important;
+	}
+
+	.sidebar .sidebar__heading .sidebar__menu-icon-img,
+	.sidebar .sidebar__menu-link .sidebar__menu-icon-img {
+		background-color: currentColor !important;
+	}
+
+	.sidebar .sidebar__heading img.sidebar__menu-icon,
+	.sidebar .sidebar__menu-link img.sidebar__menu-icon {
+		opacity: 1 !important;
+	}
+
 	// === REASSIGNABLE ROWS ===
 	// 1. Static `#2c3439` gray bg so they read as visually distinct.
 	// 2. `cursor: grab` across the whole row; `grabbing` while dragging.
@@ -99,22 +118,24 @@ body.is-admin-sidebar-customize-mode {
 			box-shadow: none;
 		}
 
-		// Icon color stays at idle across all interactive states (matches
-		// the public plugin's `color: inherit` rule for `.wp-menu-image`).
-		// Calypso's icon is `.sidebar__menu-icon`; keep its color tied to
-		// the LI text color so it doesn't paint blue on hover/selected.
+		// Icon color stays pinned to the sidebar foreground token across all
+		// interactive states. This keeps masked SVG custom icons on the same
+		// foreground as dashicons instead of assuming a fixed white value.
+		> .sidebar__menu-link .sidebar__menu-icon,
 		> .sidebar__menu-link:hover .sidebar__menu-icon,
 		> .sidebar__menu-link:focus .sidebar__menu-icon,
 		&.selected > .sidebar__menu-link .sidebar__menu-icon,
+		> .sidebar__menu.is-togglable > li > .sidebar__heading .sidebar__menu-icon,
 		> .sidebar__menu.is-togglable > li > .sidebar__heading:hover .sidebar__menu-icon,
 		> .sidebar__menu.is-togglable > li > .sidebar__heading:focus .sidebar__menu-icon {
 			fill: var( --color-sidebar-text );
 			color: var( --color-sidebar-text );
 		}
 
-		// Image icons inherit Calypso's default `opacity: 0.6` idle state and
-		// `opacity: 1` hover/selected state. Customize rows are inert, so keep
-		// image-backed plugin icons at one brightness across the whole session.
+		// Bitmap `<img>` icons inherit Calypso's default `opacity: 0.6` idle
+		// state and `opacity: 1` hover/selected state. Customize rows are
+		// inert, so keep bitmap icons at one brightness across the session.
+		// Masked SVG icons are handled by the foreground-token rule above.
 		> .sidebar__menu-link img.sidebar__menu-icon,
 		> .sidebar__menu-link:hover img.sidebar__menu-icon,
 		> .sidebar__menu-link:focus img.sidebar__menu-icon,
@@ -193,7 +214,7 @@ body.is-admin-sidebar-customize-mode {
 	// `<MySitesSidebarUnifiedMenu>` → `<ExpandableSidebarMenu>` renders a bare
 	// `<li>` wrapping `.sidebar__menu.is-togglable`, which the inert rule above
 	// doesn't catch. Same suppression treatment + kill the hover-intent flyout.
-	.sidebar > li:not( [data-wp-admin-sidebar-item-id] ) .sidebar__menu.is-togglable {
+	.sidebar > li:not( [data-wp-admin-sidebar-item-id] ) > .sidebar__menu.is-togglable {
 		.sidebar__menu-link,
 		.sidebar__heading {
 			pointer-events: none;
@@ -491,6 +512,30 @@ li.admin-sidebar-drop-indicator {
 
 	.sidebar__menu-item-parent:hover &,
 	.sidebar__menu-item-parent:focus-within &,
+	body.is-admin-sidebar-customize-mode
+		.sidebar
+		li[data-wp-admin-sidebar-item-id]:hover
+		> .sidebar__menu-link
+		&,
+	body.is-admin-sidebar-customize-mode
+		.sidebar
+		li[data-wp-admin-sidebar-item-id]:focus-within
+		> .sidebar__menu-link
+		&,
+	body.is-admin-sidebar-customize-mode
+		.sidebar
+		li[data-wp-admin-sidebar-item-id]:hover
+		> .sidebar__menu.is-togglable
+		> li
+		> .sidebar__heading
+		&,
+	body.is-admin-sidebar-customize-mode
+		.sidebar
+		li[data-wp-admin-sidebar-item-id]:focus-within
+		> .sidebar__menu.is-togglable
+		> li
+		> .sidebar__heading
+		&,
 	.sidebar__heading:hover &,
 	.sidebar__heading:focus-within &,
 	&[aria-expanded='true'] {

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -13,6 +13,10 @@ $brand-text: "SF Pro Text", $sans;
 
 // Override Global Vars
 .theme-default {
+	&.is-sidebar-overflow:has(.wp-admin-sidebar-group) {
+		--color-sidebar-gridicon-fill: var(--color-sidebar-text);
+	}
+
 	// client/assets/stylesheets/shared/_variables.scss
 	--sidebar-width-max: 272px;
 	--sidebar-width-min: 272px;


### PR DESCRIPTION
Part of WordPress/wp-admin-sidebar#79

## Proposed Changes

* Keep image-backed sidebar plugin icons at a fixed brightness while customize mode is active.
* Match the intended public plugin behavior for rows that use logo images instead of dashicons.

## Why are these changes being made?

Plugin rows should not flicker or change icon brightness while users move through the customizer. The rows are already treated as inert during customize mode, so the icon should stay visually steady.

## Testing Instructions

* Use a site with sidebar plugin rows that use image icons, for example Elementor, Jetpack, or UpdraftPlus.
* Open the Calypso sidebar customizer.
* Hover across reassignable plugin rows and confirm image icons do not brighten or flicker.
* Confirm dashicon rows still look unchanged.
* Confirm the normal sidebar outside customize mode keeps its existing hover and selected behavior.

### Automated checks run

* `./node_modules/.bin/stylelint client/my-sites/sidebar/customize/customize-mode.scss`
* `TZ=UTC ./node_modules/.bin/jest -c=test/client/jest.config.js client/my-sites/sidebar/customize/test --runInBand`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
