### PR TITLE
domains-table: typed-`@wordpress/i18n` migration

### DIFF
--- a/packages/domains-table/src/utils/get-domain-type-text.tsx
+++ b/packages/domains-table/src/utils/get-domain-type-text.tsx
@@ -9,7 +9,7 @@ type PartialDomainInfo = Pick<
 
 export function getDomainTypeText(
 	domain: PartialDomainInfo,
-	__: typeof __type = ( text: string ) => text,
+	__: typeof __type = ( ( text: string ) => text ) as typeof __type,
 	context = domainInfoContext.DOMAIN_ITEM
 ) {
 	const underMaintenance = domain?.tldMaintenanceEndTime && domain?.tldMaintenanceEndTime > 0;


### PR DESCRIPTION
Fixes DOTCOM-17301

Part of #105909

## Proposed Changes

* `getDomainTypeText` accepts an injectable `__` typed `typeof __`. Under `@wordpress/i18n` 6.x that type is generic (`<Text>( text: Text ) => TransformedText<Text>`), so the plain identity default `( text ) => text` no longer satisfies it (TS2322). Cast the default to `typeof __` so the fallback keeps its identity behaviour.

Forward-compatible: compiles against both `@wordpress/i18n` `^5.23.0` (trunk's pin) and `^6.x` (#105909). No runtime change.

## Why are these changes being made?

One of several small PRs decomposing the `@wordpress/i18n` 5.x → 6.x migration out of the renovate monorepo bump (#105909).

## Testing Instructions

* `yarn typecheck-client` / a `tsc --build` of `packages/domains-table` passes against an `@wordpress/i18n@6.x` install. No behaviour change.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
