### PR TITLE
help-center: typed-`@wordpress/i18n` migration

### DIFF
--- a/packages/help-center/src/components/help-center-notice.tsx
+++ b/packages/help-center/src/components/help-center-notice.tsx
@@ -22,7 +22,7 @@ function getResponses( siteName?: string ) {
 						'%s is linked to another WordPress.com account. If you’re trying to access it, please follow our Account Recovery procedure.',
 						__i18n_text_domain__
 					),
-					siteName
+					siteName ?? ''
 				) }
 				&nbsp;{ ' ' }
 				<ExternalLink href={ localizeUrl( 'https://wordpress.com/wp-login.php?action=recovery' ) }>


### PR DESCRIPTION
Fixes DOTCOM-17302

Part of #105909

## Proposed Changes

* `getResponses` takes an optional `siteName` and passes it directly to a `%s` `sprintf` placeholder, which `@wordpress/i18n` 6.x types as `string` (TS2769 on `string | undefined`). Coerce with `?? ''` at the call site.

Forward-compatible: compiles against both `@wordpress/i18n` `^5.23.0` and `^6.x` (#105909). No runtime change.

## Why are these changes being made?

One of several small PRs decomposing the `@wordpress/i18n` 5.x → 6.x migration out of the renovate monorepo bump (#105909).

## Testing Instructions

### Calypso
1. Run `yarn start`.
2. Open the Help Center; the ownership notice still renders the site name correctly.

### Simple/Atomic/CIAB
1. Sandbox `widgets.wp.com`.
2. Run `cd apps/help-center && yarn dev --sync`.
3. Visit any Simple, Atomic, or CIAB site and open the Help Center; verify the ownership notice renders.

This is a type-only change (no behaviour difference); a `tsc --build` of `packages/help-center` passes against an `@wordpress/i18n@6.x` install.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
