### PR TITLE
jetpack-ai-calypso: typed-`@wordpress/i18n` migration

### DIFF
--- a/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.tsx
@@ -211,7 +211,9 @@ export const Prompt: React.FC< { initialPrompt?: string } > = ( { initialPrompt 
 							{ sprintf(
 								// translators: %u is the number of requests
 								__( '%u requests remaining.', 'jetpack' ),
-								requestsRemaining
+								// `%u` renders fine at runtime (tannin) but the typed-sprintf parser
+								// only knows %s/%d/%f, so it types this arg as `never`. Cast past it.
+								requestsRemaining as unknown as never
 							) }
 						</div>
 						{ hasNextTier && (


### PR DESCRIPTION
Fixes DOTCOM-17303

Part of #105909

## Proposed Changes

* The "requests remaining" string uses the `%u` specifier. `%u` renders correctly at runtime (the tannin `sprintf` accepts it), but `@wordpress/i18n` 6.x's typed-`sprintf` parser only recognises `%s`/`%d`/`%f`, so it types the numeric argument as `never` (TS2769/TS2345). Keep `%u` and cast the argument past the unrepresentable `never` slot.

No runtime change and no translatable-string change (the `%u requests remaining.` msgid is preserved). Forward-compatible: compiles against both `@wordpress/i18n` `^5.23.0` and `^6.x` (#105909).

## Why are these changes being made?

One of several small PRs decomposing the `@wordpress/i18n` 5.x → 6.x migration out of the renovate monorepo bump (#105909).

## Testing Instructions

* `tsc --build` of `packages/jetpack-ai-calypso` passes against an `@wordpress/i18n@6.x` install.
* In the Jetpack AI logo generator, the requests-remaining footer still shows the correct count.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
