### PR TITLE
subscriber: typed-`@wordpress/i18n` migration

### DIFF
--- a/packages/subscriber/src/components/add-form/index.tsx
+++ b/packages/subscriber/src/components/add-form/index.tsx
@@ -108,7 +108,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 	 * ↓ Fields
 	 */
 	const emailControlMaxNum = 6;
-	const emailControlPlaceholder = [
+	const emailControlPlaceholder: string[] = [
 		__( 'bestie@email.com' ),
 		__( 'chrisfromwork@email.com' ),
 		__( 'family@email.com' ),
@@ -172,9 +172,9 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 
 	useEffect( () => {
 		if ( !! getValidEmails().length || ( isSelectedFileValid && selectedFile ) ) {
-			onChangeIsImportValid && onChangeIsImportValid( true );
+			onChangeIsImportValid?.( true );
 		} else {
-			onChangeIsImportValid && onChangeIsImportValid( false );
+			onChangeIsImportValid?.( false );
 		}
 	}, [ getValidEmails, isSelectedFileValid, selectedFile, onChangeIsImportValid ] );
 
@@ -192,16 +192,21 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 
 		if ( manualListEmailInviting ) {
 			// add subscribers with invite email
-			validEmails.length && addSubscribers( siteId, validEmails );
+			if ( validEmails.length ) {
+				addSubscribers( siteId, validEmails );
+			}
 			// import subscribers providing only CSV list of emails
-			selectedFile && importCsvSubscribers( siteId, selectedFile );
-		} else {
+			if ( selectedFile ) {
+				importCsvSubscribers( siteId, selectedFile );
+			}
+		} else if ( selectedFile || validEmails.length ) {
 			// import subscribers proving CSV and manual list of emails
-			( selectedFile || validEmails.length ) &&
-				importCsvSubscribers( siteId, selectedFile, validEmails, selectedCategories );
+			importCsvSubscribers( siteId, selectedFile, validEmails, selectedCategories );
 		}
 
-		! validEmails.length && ! selectedFile && allowEmptyFormSubmit && onImportFinished?.();
+		if ( ! validEmails.length && ! selectedFile && allowEmptyFormSubmit ) {
+			onImportFinished?.();
+		}
 	}
 
 	function onEmailChange( value: string, index: number ) {
@@ -246,7 +251,9 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 		const isValid = isValidExtension( file.name );
 
 		setIsSelectedFileValid( isValid );
-		isValid && setSelectedFile( file );
+		if ( isValid ) {
+			setSelectedFile( file );
+		}
 		importCsvSubscribersUpdate( undefined );
 	}
 
@@ -428,7 +435,7 @@ export const AddSubscriberForm: FunctionComponent< Props > = ( props ) => {
 				<label className="add-subscriber__form-label-links">
 					{ createInterpolateElement(
 						sprintf(
-							/* translators: the first string variable shows a selected file name, Replace and Remove are links */
+							/* translators: %s is the selected file name, Replace and Remove are links */
 							__(
 								'<strong>%s</strong> <uploadBtn>Replace</uploadBtn> | <removeBtn>Remove</removeBtn>'
 							),


### PR DESCRIPTION
Fixes DOTCOM-17304

Part of #105909

## Proposed Changes

* `emailControlPlaceholder` is inferred from `__()` calls as a union of `TransformedText` string literals, so pushing a different translated literal later fails (TS2345). Annotate it `: string[]` to widen the element type.

Forward-compatible: compiles against both `@wordpress/i18n` `^5.23.0` and `^6.x` (#105909). No runtime change.

### Drive-by lint cleanup

Touching this file makes the branch Code Style check re-lint it in full, which surfaced pre-existing eslint errors that had to be cleared to land this PR:

* Replaced `cond && fn()` short-circuit statements with `?.()` calls / `if` blocks (`@typescript-eslint/no-unused-expressions`).
* Named `%s` in the selected-file notice's translator comment (`@wordpress/i18n-translator-comments`).

These are behaviour-preserving.

## Why are these changes being made?

One of several small PRs decomposing the `@wordpress/i18n` 5.x → 6.x migration out of the renovate monorepo bump (#105909).

## Testing Instructions

* `tsc --build` of `packages/subscriber` passes against an `@wordpress/i18n@6.x` install.
* The add-subscribers form still appends an extra email placeholder row as rows are filled in, imports/invites still trigger correctly, and the selected-file "Replace | Remove" notice still renders. No behaviour change.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
