### PR TITLE
i18n-utils: typed-`@wordpress/i18n` migration

### DIFF
--- a/packages/i18n-utils/src/locale-context.tsx
+++ b/packages/i18n-utils/src/locale-context.tsx
@@ -40,7 +40,11 @@ function mapWpI18nLangToLocaleSlug( locale: Locale = '' ): Locale {
  */
 function getWpI18nLocaleLang(): string | undefined {
 	const localeData = i18n.getLocaleData() || {};
-	return localeData[ '' ]?.lang || localeData[ '' ]?.language || '';
+	const defaultData = localeData[ '' ];
+	if ( ! defaultData || Array.isArray( defaultData ) ) {
+		return '';
+	}
+	return ( defaultData.lang as string ) || ( defaultData.language as string ) || '';
 }
 
 /**


### PR DESCRIPTION
Fixes DOTCOM-17306

Part of #105909

## Proposed Changes

* `getLocaleData()` is typed in `@wordpress/i18n` 6.x as `Record< string, I18nDomainMetadata | string[] >`. `getWpI18nLocaleLang()` reads `.lang`/`.language` off the `''` entry, which fails because `string[]` has no such properties (TS2339). Guard against the `string[]` case before reading the metadata.

Forward-compatible: compiles against both `@wordpress/i18n` `^5.23.0` (trunk's pin) and `^6.x` (#105909). No runtime change — the `''` entry holds locale metadata, never a translations array.

## Why are these changes being made?

One of several small PRs decomposing the `@wordpress/i18n` 5.x → 6.x migration out of the renovate monorepo bump (#105909). This one surfaced only after the other package migrations landed and trunk was merged into the renovate branch, unblocking the workspace build far enough to type-check `i18n-utils`.

## Testing Instructions

* `tsc --build packages/tsconfig.json` passes against an `@wordpress/i18n@6.x` install (0 errors); `yarn install --immutable` completes cleanly.
* Locale detection (`getWpI18nLocaleSlug` / `getWpI18nLocaleLang`) still returns the active language. No behaviour change.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
