### PR TITLE
Edit plan modal - add spacing in advanced options

### DIFF
--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -1,6 +1,6 @@
 import { Dialog, FormInputValidation, FormLabel, FoldableCard } from '@automattic/components';
 import { formatCurrency } from '@automattic/number-formatters';
-import { ToggleControl } from '@wordpress/components';
+import { __experimentalVStack as VStack, ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { ChangeEvent, useState, useEffect, useMemo } from 'react';
 import CountedTextArea from 'calypso/components/forms/counted-textarea';
@@ -198,7 +198,11 @@ const RecurringPaymentsPlanAddEditModal = ( {
 			// Set the current price if the value is a valid number or an empty string.
 			if ( '' === event.currentTarget.value || ! isNaN( value ) ) {
 				const newPrice = Number( event.currentTarget.value );
-				isAnnualProduct ? setCurrentAnnualPrice( newPrice ) : setCurrentPrice( newPrice );
+				if ( isAnnualProduct ) {
+					setCurrentAnnualPrice( newPrice );
+				} else {
+					setCurrentPrice( newPrice );
+				}
 			}
 			setEditedPrice( true );
 		};
@@ -515,31 +519,34 @@ const RecurringPaymentsPlanAddEditModal = ( {
 						hideSummary
 						className="memberships__dialog-advanced-options"
 					>
-						{ ! editedPostIsTier && (
-							<FormFieldset className="memberships__dialog-sections-type">
-								<ToggleControl
-									onChange={ ( newValue ) => {
-										setEditedPostPaidNewsletter( newValue );
-									} }
-									checked={ editedPostPaidNewsletter }
-									disabled={ !! product.ID || editedPostIsTier }
-									label={ translate( 'Add customers to newsletter mailing list' ) }
-								/>
-							</FormFieldset>
-						) }
 						<FormFieldset>
-							<ToggleControl
-								onChange={ handlePayWhatYouWant }
-								checked={ editedPayWhatYouWant }
-								label={ translate(
-									'Enable customers to pick their own amount (“Pay what you want”)'
+							<VStack>
+								{ ! editedPostIsTier && (
+									<ToggleControl
+										__nextHasNoMarginBottom
+										onChange={ ( newValue ) => {
+											setEditedPostPaidNewsletter( newValue );
+										} }
+										checked={ editedPostPaidNewsletter }
+										disabled={ !! product.ID || editedPostIsTier }
+										label={ translate( 'Add customers to newsletter mailing list' ) }
+									/>
 								) }
-							/>
-							<ToggleControl
-								onChange={ handleMultiplePerUser }
-								checked={ editedMultiplePerUser }
-								label={ translate( 'Enable customers to make the same purchase multiple times' ) }
-							/>
+								<ToggleControl
+									__nextHasNoMarginBottom
+									onChange={ handlePayWhatYouWant }
+									checked={ editedPayWhatYouWant }
+									label={ translate(
+										'Enable customers to pick their own amount (“Pay what you want”)'
+									) }
+								/>
+								<ToggleControl
+									__nextHasNoMarginBottom
+									onChange={ handleMultiplePerUser }
+									checked={ editedMultiplePerUser }
+									label={ translate( 'Enable customers to make the same purchase multiple times' ) }
+								/>
+							</VStack>
 						</FormFieldset>
 					</FoldableCard>
 				) }


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # https://linear.app/a8c/issue/NL-22/newsletter-tier-form-improve-spacing-on-advanced-options#comment-c2b310e8

## Proposed Changes

Adds a VStack to the advanced options list to apply some basic spacing.

BEFORE
<img width="516" height="115" alt="Screenshot 2026-05-29 at 10 46 12 AM" src="https://github.com/user-attachments/assets/d33f9113-28e1-4f39-960c-c27b59fa8c7d" />


AFTER
<img width="546" height="136" alt="Screenshot 2026-05-29 at 10 46 03 AM" src="https://github.com/user-attachments/assets/232fb1dd-1b9f-4c3a-8ddf-de2b22ee233e" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Consistent design spacing across app.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `*/earn/payments/{siteURL}` for one of your sites
* Click the "Add a new payment plan" button.
* At the bottom of the modal, click "Advanced options"
* verify there is now some vertical space between them, smoke test that they still work as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
