### PR TITLE
Notifications day/time pickers - convert to/from UTC to show local time in UI

### DIFF
--- a/client/dashboard/me/notifications-emails/subscription-settings/form.tsx
+++ b/client/dashboard/me/notifications-emails/subscription-settings/form.tsx
@@ -52,14 +52,17 @@ const buildDeliveryHourElements = ( isUtcFallback: boolean ) =>
 		};
 	} );
 
-const buildDeliveryHourDescription = ( isUtcFallback: boolean, timezone?: string ) =>
-	isUtcFallback
-		? __( 'We couldn’t detect your time zone, so these times are shown in UTC.' )
-		: sprintf(
-				// translators: %(timezone)s is the timezone E.g. America/New_York
-				__( 'Times shown in your local time zone (%(timezone)s).' ),
-				{ timezone: timezone ?? '' }
-		  );
+const buildDeliveryHourDescription = ( isUtcFallback: boolean, timezone?: string ) => {
+	if ( isUtcFallback || ! timezone ) {
+		return __( 'We couldn’t detect your time zone, so these times are shown in UTC.' );
+	}
+
+	return sprintf(
+		// translators: %(timezone)s is the timezone E.g. America/New_York
+		__( 'Times shown in your local time zone (%(timezone)s).' ),
+		{ timezone }
+	);
+};
 
 export type SettingsData = Pick<
 	UserSettings,

--- a/client/dashboard/me/notifications-emails/subscription-settings/form.tsx
+++ b/client/dashboard/me/notifications-emails/subscription-settings/form.tsx
@@ -1,4 +1,9 @@
 import { UserSettings } from '@automattic/api-core';
+import {
+	fromUtcDeliveryWindow,
+	toUtcDeliveryWindow,
+	useDeliveryWindowTimezone,
+} from '@automattic/i18n-utils';
 import { CheckboxControl, SelectControl } from '@wordpress/components';
 import { DataForm, DataFormControlProps, Field, type Form } from '@wordpress/dataviews';
 import { __, sprintf } from '@wordpress/i18n';
@@ -20,6 +25,41 @@ const formatDateToLocalTime = ( date: Date ) => {
 		minute: '2-digit',
 	} ).format( date );
 };
+
+const padHour = ( hour: number ) => String( hour % 24 ).padStart( 2, '0' );
+
+// The delivery hour buckets are stored/sent as UTC. We display them in the
+// device's local time, falling back to clearly labeled UTC when the time zone
+// can't be detected.
+const buildDeliveryHourElements = ( isUtcFallback: boolean ) =>
+	Array.from( { length: 12 }, ( _, i ) => {
+		const startHour = i * 2;
+		const endHour = startHour + 2;
+
+		if ( isUtcFallback ) {
+			return {
+				label: `${ padHour( startHour ) }:00 - ${ padHour( endHour ) }:00 UTC`,
+				value: startHour,
+			};
+		}
+
+		return {
+			label: [
+				formatDateToLocalTime( new Date( 0, 0, 0, startHour, 0 ) ),
+				formatDateToLocalTime( new Date( 0, 0, 0, endHour, 0 ) ),
+			].join( ' - ' ),
+			value: startHour,
+		};
+	} );
+
+const buildDeliveryHourDescription = ( isUtcFallback: boolean, timezone?: string ) =>
+	isUtcFallback
+		? __( "We couldn't detect your time zone, so these times are shown in UTC." )
+		: sprintf(
+				// translators: %(timezone)s is the timezone E.g. America/New_York
+				__( 'Times shown in your local time zone (%(timezone)s).' ),
+				{ timezone: timezone ?? '' }
+		  );
 
 export type SettingsData = Pick<
 	UserSettings,
@@ -96,26 +136,8 @@ const baseFields: Field< SettingsData >[] = [
 		id: 'subscription_delivery_hour',
 		label: __( 'Hour' ),
 		type: 'integer' as const,
-		description: sprintf(
-			// translators: %(timezone)s is the timezone E.g. America/New_York
-			__( 'Timezone: %(timezone)s' ),
-			{
-				timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-			}
-		),
-		elements: [
-			...Array.from( { length: 12 }, ( _, i ) => {
-				const startHour = i * 2;
-				const endHour = startHour + 2;
-				return {
-					label: [
-						formatDateToLocalTime( new Date( 0, 0, 0, startHour, 0 ) ),
-						formatDateToLocalTime( new Date( 0, 0, 0, endHour, 0 ) ),
-					].join( ' - ' ),
-					value: startHour,
-				};
-			} ),
-		],
+		description: buildDeliveryHourDescription( false ),
+		elements: buildDeliveryHourElements( false ),
 		Edit: CustomSelectControl,
 	},
 	{
@@ -167,12 +189,36 @@ const baseFields: Field< SettingsData >[] = [
 
 const automatticianFields = [ 'p2_disable_autofollow_on_comment' ];
 
-export const getFields = ( includeAutomatticianFields: boolean ): Field< SettingsData >[] => {
+interface DeliveryWindowDisplay {
+	isUtcFallback: boolean;
+	timezone?: string;
+}
+
+export const getFields = (
+	includeAutomatticianFields: boolean,
+	deliveryWindow?: DeliveryWindowDisplay
+): Field< SettingsData >[] => {
+	const fields = deliveryWindow
+		? baseFields.map( ( field ) => {
+				if ( field.id !== 'subscription_delivery_hour' ) {
+					return field;
+				}
+				return {
+					...field,
+					description: buildDeliveryHourDescription(
+						deliveryWindow.isUtcFallback,
+						deliveryWindow.timezone
+					),
+					elements: buildDeliveryHourElements( deliveryWindow.isUtcFallback ),
+				};
+		  } )
+		: baseFields;
+
 	if ( includeAutomatticianFields ) {
-		return baseFields;
+		return fields;
 	}
 
-	return baseFields.filter( ( field ) => {
+	return fields.filter( ( field ) => {
 		return ! automatticianFields.includes( field.id );
 	} );
 };
@@ -204,14 +250,58 @@ interface FormProps {
 }
 
 export const SubscriptionSettingsForm = ( { data, isAutomattician, onChange }: FormProps ) => {
+	const { offsetHours, isUtcFallback, timezone } = useDeliveryWindowTimezone();
+
+	// The backend stores/sends the delivery window as UTC. Present it to the
+	// DataForm in local time, and convert edits back to UTC before bubbling up.
+	const localData = useMemo( () => {
+		const local = fromUtcDeliveryWindow(
+			{
+				hour: Number( data.subscription_delivery_hour ?? 0 ),
+				day: Number( data.subscription_delivery_day ?? 0 ),
+			},
+			offsetHours ?? 0
+		);
+		return {
+			...data,
+			subscription_delivery_hour: local.hour,
+			subscription_delivery_day: local.day,
+		};
+	}, [ data, offsetHours ] );
+
 	const handleChange = useCallback(
 		( edit: Partial< SettingsData > ) => {
-			onChange( Object.assign( {}, data, edit ) as SettingsData );
+			const touchesWindow =
+				'subscription_delivery_hour' in edit || 'subscription_delivery_day' in edit;
+
+			if ( ! touchesWindow ) {
+				onChange( Object.assign( {}, data, edit ) as SettingsData );
+				return;
+			}
+
+			// Changing either field can wrap the day boundary once converted back
+			// to UTC, so recompute the whole window from the local values.
+			const utc = toUtcDeliveryWindow(
+				{
+					hour: Number( edit.subscription_delivery_hour ?? localData.subscription_delivery_hour ),
+					day: Number( edit.subscription_delivery_day ?? localData.subscription_delivery_day ),
+				},
+				offsetHours ?? 0
+			);
+			onChange(
+				Object.assign( {}, data, edit, {
+					subscription_delivery_hour: utc.hour,
+					subscription_delivery_day: utc.day,
+				} ) as SettingsData
+			);
 		},
-		[ onChange, data ]
+		[ onChange, data, localData, offsetHours ]
 	);
 
-	const fields = useMemo( () => getFields( isAutomattician ), [ isAutomattician ] );
+	const fields = useMemo(
+		() => getFields( isAutomattician, { isUtcFallback, timezone } ),
+		[ isAutomattician, isUtcFallback, timezone ]
+	);
 	const form: Form = {
 		layout: { type: 'regular' as const },
 		fields: [
@@ -235,7 +325,7 @@ export const SubscriptionSettingsForm = ( { data, isAutomattician, onChange }: F
 		<DataForm< SettingsData >
 			fields={ fields }
 			form={ form }
-			data={ data }
+			data={ localData }
 			onChange={ handleChange }
 		/>
 	);

--- a/client/dashboard/me/notifications-emails/subscription-settings/form.tsx
+++ b/client/dashboard/me/notifications-emails/subscription-settings/form.tsx
@@ -40,7 +40,14 @@ const buildDeliveryHourElements = ( isUtcFallback: boolean ) =>
 
 		if ( isUtcFallback ) {
 			return {
-				label: `${ padHour( startHour ) }:00 - ${ padHour( endHour ) }:00 UTC`,
+				label: sprintf(
+					// translators: %(fromHour)s and %(toHour)s are hours on a 24-hour clock, e.g. 08 and 10. UTC is the time zone.
+					__( '%(fromHour)s:00 - %(toHour)s:00 UTC' ),
+					{
+						fromHour: padHour( startHour ),
+						toHour: padHour( endHour ),
+					}
+				),
 				value: startHour,
 			};
 		}

--- a/client/dashboard/me/notifications-emails/subscription-settings/form.tsx
+++ b/client/dashboard/me/notifications-emails/subscription-settings/form.tsx
@@ -55,14 +55,12 @@ const buildDeliveryHourElements = ( isUtcFallback: boolean ) =>
 	} );
 
 const buildDeliveryHourDescription = ( isUtcFallback: boolean, timezone?: string ) => {
-	if ( isUtcFallback || ! timezone ) {
-		return __( "We couldn't detect your time zone, so these times are shown in UTC." );
-	}
-
 	return sprintf(
-		// translators: %(timezone)s is the timezone E.g. America/New_York
-		__( 'Times are shown in your local time zone (%(timezone)s).' ),
-		{ timezone }
+		// translators: %(timezone)s is the timezone E.g. America/New_York, or UTC when the device time zone is unknown.
+		__( 'Timezone: %(timezone)s' ),
+		{
+			timezone: isUtcFallback || ! timezone ? 'UTC' : timezone,
+		}
 	);
 };
 

--- a/client/dashboard/me/notifications-emails/subscription-settings/form.tsx
+++ b/client/dashboard/me/notifications-emails/subscription-settings/form.tsx
@@ -1,7 +1,9 @@
 import { UserSettings } from '@automattic/api-core';
 import {
 	applyDeliveryWindowEdit,
+	getDeliveryWindowOffsetHours,
 	getDisplayDeliveryWindow,
+	guessTimezone,
 	useDeliveryWindowTimezone,
 } from '@automattic/i18n-utils';
 import { CheckboxControl, SelectControl } from '@wordpress/components';
@@ -54,15 +56,42 @@ const buildDeliveryHourElements = ( isUtcFallback: boolean ) =>
 
 const buildDeliveryHourDescription = ( isUtcFallback: boolean, timezone?: string ) => {
 	if ( isUtcFallback || ! timezone ) {
-		return __( 'We couldn’t detect your time zone, so these times are shown in UTC.' );
+		return __( "We couldn't detect your time zone, so these times are shown in UTC." );
 	}
 
 	return sprintf(
 		// translators: %(timezone)s is the timezone E.g. America/New_York
-		__( 'Times shown in your local time zone (%(timezone)s).' ),
+		__( 'Times are shown in your local time zone (%(timezone)s).' ),
 		{ timezone }
 	);
 };
+
+function getDeliveryWindowDisplayDefaults(): DeliveryWindowDisplay {
+	const timezone = guessTimezone();
+	const offsetHours = getDeliveryWindowOffsetHours( timezone );
+
+	return {
+		timezone,
+		isUtcFallback: offsetHours === null,
+	};
+}
+
+function applyDeliveryWindowToHourField(
+	fields: Field< SettingsData >[],
+	delivery: DeliveryWindowDisplay
+): Field< SettingsData >[] {
+	return fields.map( ( field ) => {
+		if ( field.id !== 'subscription_delivery_hour' ) {
+			return field;
+		}
+
+		return {
+			...field,
+			description: buildDeliveryHourDescription( delivery.isUtcFallback, delivery.timezone ),
+			elements: buildDeliveryHourElements( delivery.isUtcFallback ),
+		};
+	} );
+}
 
 export type SettingsData = Pick<
 	UserSettings,
@@ -97,7 +126,7 @@ const CustomSelectControl = ( { field, data, onChange }: DataFormControlProps< S
 	);
 };
 
-const baseFields: Field< SettingsData >[] = [
+const baseFieldsWithoutDeliveryWindow: Field< SettingsData >[] = [
 	{
 		id: 'subscription_delivery_email_default',
 		label: __( 'Default email delivery' ),
@@ -139,8 +168,6 @@ const baseFields: Field< SettingsData >[] = [
 		id: 'subscription_delivery_hour',
 		label: __( 'Hour' ),
 		type: 'integer' as const,
-		description: buildDeliveryHourDescription( false ),
-		elements: buildDeliveryHourElements( false ),
 		Edit: CustomSelectControl,
 	},
 	{
@@ -190,9 +217,14 @@ const baseFields: Field< SettingsData >[] = [
 	},
 ];
 
+const baseFields = applyDeliveryWindowToHourField(
+	baseFieldsWithoutDeliveryWindow,
+	getDeliveryWindowDisplayDefaults()
+);
+
 const automatticianFields = [ 'p2_disable_autofollow_on_comment' ];
 
-interface DeliveryWindowDisplay {
+export interface DeliveryWindowDisplay {
 	isUtcFallback: boolean;
 	timezone?: string;
 }
@@ -201,21 +233,8 @@ export const getFields = (
 	includeAutomatticianFields: boolean,
 	deliveryWindow?: DeliveryWindowDisplay
 ): Field< SettingsData >[] => {
-	const fields = deliveryWindow
-		? baseFields.map( ( field ) => {
-				if ( field.id !== 'subscription_delivery_hour' ) {
-					return field;
-				}
-				return {
-					...field,
-					description: buildDeliveryHourDescription(
-						deliveryWindow.isUtcFallback,
-						deliveryWindow.timezone
-					),
-					elements: buildDeliveryHourElements( deliveryWindow.isUtcFallback ),
-				};
-		  } )
-		: baseFields;
+	const delivery = deliveryWindow ?? getDeliveryWindowDisplayDefaults();
+	const fields = applyDeliveryWindowToHourField( baseFields, delivery );
 
 	if ( includeAutomatticianFields ) {
 		return fields;

--- a/client/dashboard/me/notifications-emails/subscription-settings/form.tsx
+++ b/client/dashboard/me/notifications-emails/subscription-settings/form.tsx
@@ -1,7 +1,7 @@
 import { UserSettings } from '@automattic/api-core';
 import {
-	fromUtcDeliveryWindow,
-	toUtcDeliveryWindow,
+	applyDeliveryWindowEdit,
+	getDisplayDeliveryWindow,
 	useDeliveryWindowTimezone,
 } from '@automattic/i18n-utils';
 import { CheckboxControl, SelectControl } from '@wordpress/components';
@@ -257,20 +257,22 @@ export const SubscriptionSettingsForm = ( { data, isAutomattician, onChange }: F
 
 	// The backend stores/sends the delivery window as UTC. Present it to the
 	// DataForm in local time, and convert edits back to UTC before bubbling up.
+	const storedUtc = useMemo(
+		() => ( {
+			hour: Number( data.subscription_delivery_hour ?? 0 ),
+			day: Number( data.subscription_delivery_day ?? 0 ),
+		} ),
+		[ data.subscription_delivery_hour, data.subscription_delivery_day ]
+	);
+
 	const localData = useMemo( () => {
-		const local = fromUtcDeliveryWindow(
-			{
-				hour: Number( data.subscription_delivery_hour ?? 0 ),
-				day: Number( data.subscription_delivery_day ?? 0 ),
-			},
-			offsetHours ?? 0
-		);
+		const display = getDisplayDeliveryWindow( storedUtc, offsetHours );
 		return {
 			...data,
-			subscription_delivery_hour: local.hour,
-			subscription_delivery_day: local.day,
+			subscription_delivery_hour: display.hour,
+			subscription_delivery_day: display.day,
 		};
-	}, [ data, offsetHours ] );
+	}, [ data, offsetHours, storedUtc ] );
 
 	const handleChange = useCallback(
 		( edit: Partial< SettingsData > ) => {
@@ -282,15 +284,14 @@ export const SubscriptionSettingsForm = ( { data, isAutomattician, onChange }: F
 				return;
 			}
 
-			// Changing either field can wrap the day boundary once converted back
-			// to UTC, so recompute the whole window from the local values.
-			const utc = toUtcDeliveryWindow(
-				{
-					hour: Number( edit.subscription_delivery_hour ?? localData.subscription_delivery_hour ),
-					day: Number( edit.subscription_delivery_day ?? localData.subscription_delivery_day ),
-				},
-				offsetHours ?? 0
-			);
+			const windowEdit: Partial< { hour: number; day: number } > = {};
+			if ( 'subscription_delivery_hour' in edit ) {
+				windowEdit.hour = Number( edit.subscription_delivery_hour );
+			}
+			if ( 'subscription_delivery_day' in edit ) {
+				windowEdit.day = Number( edit.subscription_delivery_day );
+			}
+			const utc = applyDeliveryWindowEdit( storedUtc, windowEdit, offsetHours );
 			onChange(
 				Object.assign( {}, data, edit, {
 					subscription_delivery_hour: utc.hour,
@@ -298,7 +299,7 @@ export const SubscriptionSettingsForm = ( { data, isAutomattician, onChange }: F
 				} ) as SettingsData
 			);
 		},
-		[ onChange, data, localData, offsetHours ]
+		[ onChange, data, storedUtc, offsetHours ]
 	);
 
 	const fields = useMemo(

--- a/client/dashboard/me/notifications-emails/subscription-settings/form.tsx
+++ b/client/dashboard/me/notifications-emails/subscription-settings/form.tsx
@@ -2,9 +2,7 @@ import { UserSettings } from '@automattic/api-core';
 import {
 	applyDeliveryWindowEdit,
 	getDeliveryHourPickerHours,
-	getDeliveryWindowOffsetHours,
 	getDisplayDeliveryWindow,
-	guessTimezone,
 	useDeliveryWindowTimezone,
 } from '@automattic/i18n-utils';
 import { CheckboxControl, SelectControl } from '@wordpress/components';
@@ -71,16 +69,6 @@ const buildDeliveryHourDescription = ( isUtcFallback: boolean, timezone?: string
 	);
 };
 
-function getDeliveryWindowDisplayDefaults(): DeliveryWindowDisplay {
-	const timezone = guessTimezone();
-	const offsetHours = getDeliveryWindowOffsetHours( timezone );
-
-	return {
-		timezone,
-		isUtcFallback: offsetHours === null,
-	};
-}
-
 function applyDeliveryWindowToHourField(
 	fields: Field< SettingsData >[],
 	delivery: DeliveryWindowDisplay,
@@ -132,7 +120,7 @@ const CustomSelectControl = ( { field, data, onChange }: DataFormControlProps< S
 	);
 };
 
-const baseFieldsWithoutDeliveryWindow: Field< SettingsData >[] = [
+const baseFields: Field< SettingsData >[] = [
 	{
 		id: 'subscription_delivery_email_default',
 		label: __( 'Default email delivery' ),
@@ -223,12 +211,6 @@ const baseFieldsWithoutDeliveryWindow: Field< SettingsData >[] = [
 	},
 ];
 
-const baseFields = applyDeliveryWindowToHourField(
-	baseFieldsWithoutDeliveryWindow,
-	getDeliveryWindowDisplayDefaults(),
-	0
-);
-
 const automatticianFields = [ 'p2_disable_autofollow_on_comment' ];
 
 export interface DeliveryWindowDisplay {
@@ -238,11 +220,10 @@ export interface DeliveryWindowDisplay {
 
 export const getFields = (
 	includeAutomatticianFields: boolean,
-	deliveryWindow?: DeliveryWindowDisplay,
-	displayHour = 0
+	deliveryWindow: DeliveryWindowDisplay,
+	displayHour: number
 ): Field< SettingsData >[] => {
-	const delivery = deliveryWindow ?? getDeliveryWindowDisplayDefaults();
-	const fields = applyDeliveryWindowToHourField( baseFields, delivery, displayHour );
+	const fields = applyDeliveryWindowToHourField( baseFields, deliveryWindow, displayHour );
 
 	if ( includeAutomatticianFields ) {
 		return fields;

--- a/client/dashboard/me/notifications-emails/subscription-settings/form.tsx
+++ b/client/dashboard/me/notifications-emails/subscription-settings/form.tsx
@@ -1,6 +1,7 @@
 import { UserSettings } from '@automattic/api-core';
 import {
 	applyDeliveryWindowEdit,
+	getDeliveryHourPickerHours,
 	getDeliveryWindowOffsetHours,
 	getDisplayDeliveryWindow,
 	guessTimezone,
@@ -33,9 +34,8 @@ const padHour = ( hour: number ) => String( hour % 24 ).padStart( 2, '0' );
 // The delivery hour buckets are stored/sent as UTC. We display them in the
 // device's local time, falling back to clearly labeled UTC when the time zone
 // can't be detected.
-const buildDeliveryHourElements = ( isUtcFallback: boolean ) =>
-	Array.from( { length: 12 }, ( _, i ) => {
-		const startHour = i * 2;
+const buildDeliveryHourElements = ( isUtcFallback: boolean, displayHour: number ) =>
+	getDeliveryHourPickerHours( displayHour, isUtcFallback ).map( ( startHour ) => {
 		const endHour = startHour + 2;
 
 		if ( isUtcFallback ) {
@@ -83,7 +83,8 @@ function getDeliveryWindowDisplayDefaults(): DeliveryWindowDisplay {
 
 function applyDeliveryWindowToHourField(
 	fields: Field< SettingsData >[],
-	delivery: DeliveryWindowDisplay
+	delivery: DeliveryWindowDisplay,
+	displayHour: number
 ): Field< SettingsData >[] {
 	return fields.map( ( field ) => {
 		if ( field.id !== 'subscription_delivery_hour' ) {
@@ -93,7 +94,7 @@ function applyDeliveryWindowToHourField(
 		return {
 			...field,
 			description: buildDeliveryHourDescription( delivery.isUtcFallback, delivery.timezone ),
-			elements: buildDeliveryHourElements( delivery.isUtcFallback ),
+			elements: buildDeliveryHourElements( delivery.isUtcFallback, displayHour ),
 		};
 	} );
 }
@@ -224,7 +225,8 @@ const baseFieldsWithoutDeliveryWindow: Field< SettingsData >[] = [
 
 const baseFields = applyDeliveryWindowToHourField(
 	baseFieldsWithoutDeliveryWindow,
-	getDeliveryWindowDisplayDefaults()
+	getDeliveryWindowDisplayDefaults(),
+	0
 );
 
 const automatticianFields = [ 'p2_disable_autofollow_on_comment' ];
@@ -236,10 +238,11 @@ export interface DeliveryWindowDisplay {
 
 export const getFields = (
 	includeAutomatticianFields: boolean,
-	deliveryWindow?: DeliveryWindowDisplay
+	deliveryWindow?: DeliveryWindowDisplay,
+	displayHour = 0
 ): Field< SettingsData >[] => {
 	const delivery = deliveryWindow ?? getDeliveryWindowDisplayDefaults();
-	const fields = applyDeliveryWindowToHourField( baseFields, delivery );
+	const fields = applyDeliveryWindowToHourField( baseFields, delivery, displayHour );
 
 	if ( includeAutomatticianFields ) {
 		return fields;
@@ -327,8 +330,13 @@ export const SubscriptionSettingsForm = ( { data, isAutomattician, onChange }: F
 	);
 
 	const fields = useMemo(
-		() => getFields( isAutomattician, { isUtcFallback, timezone } ),
-		[ isAutomattician, isUtcFallback, timezone ]
+		() =>
+			getFields(
+				isAutomattician,
+				{ isUtcFallback, timezone },
+				Number( localData.subscription_delivery_hour ?? 0 )
+			),
+		[ isAutomattician, isUtcFallback, timezone, localData.subscription_delivery_hour ]
 	);
 	const form: Form = {
 		layout: { type: 'regular' as const },

--- a/client/dashboard/me/notifications-emails/subscription-settings/form.tsx
+++ b/client/dashboard/me/notifications-emails/subscription-settings/form.tsx
@@ -54,7 +54,7 @@ const buildDeliveryHourElements = ( isUtcFallback: boolean ) =>
 
 const buildDeliveryHourDescription = ( isUtcFallback: boolean, timezone?: string ) =>
 	isUtcFallback
-		? __( "We couldn't detect your time zone, so these times are shown in UTC." )
+		? __( 'We couldn’t detect your time zone, so these times are shown in UTC.' )
 		: sprintf(
 				// translators: %(timezone)s is the timezone E.g. America/New_York
 				__( 'Times shown in your local time zone (%(timezone)s).' ),

--- a/client/dashboard/me/notifications-emails/subscription-settings/test/index.test.tsx
+++ b/client/dashboard/me/notifications-emails/subscription-settings/test/index.test.tsx
@@ -292,7 +292,7 @@ describe( 'SubscriptionSettings', () => {
 		// With no time zone, values are shown unchanged (raw UTC).
 		expect( await hourSelect() ).toHaveValue( '8' );
 		// The UTC fallback copy and labels should be present.
-		expect( await screen.findByText( /shown in UTC/i ) ).toBeInTheDocument();
+		expect( await screen.findByText( /shown in UTC/i ) ).toBeVisible();
 		expect( screen.getByRole( 'option', { name: '08:00 - 10:00 UTC' } ) ).toBeInTheDocument();
 	} );
 } );

--- a/client/dashboard/me/notifications-emails/subscription-settings/test/index.test.tsx
+++ b/client/dashboard/me/notifications-emails/subscription-settings/test/index.test.tsx
@@ -291,8 +291,8 @@ describe( 'SubscriptionSettings', () => {
 
 		// With no time zone, values are shown unchanged (raw UTC).
 		expect( await hourSelect() ).toHaveValue( '8' );
-		// The UTC fallback copy and labels should be present.
-		expect( await screen.findByText( /shown in UTC/i ) ).toBeVisible();
+		// The UTC fallback description and option labels should be present.
+		expect( await screen.findByText( /Timezone:\s*UTC/i ) ).toBeVisible();
 		expect( screen.getByRole( 'option', { name: '08:00 - 10:00 UTC' } ) ).toBeInTheDocument();
 	} );
 

--- a/client/dashboard/me/notifications-emails/subscription-settings/test/index.test.tsx
+++ b/client/dashboard/me/notifications-emails/subscription-settings/test/index.test.tsx
@@ -295,4 +295,43 @@ describe( 'SubscriptionSettings', () => {
 		expect( await screen.findByText( /shown in UTC/i ) ).toBeVisible();
 		expect( screen.getByRole( 'option', { name: '08:00 - 10:00 UTC' } ) ).toBeInTheDocument();
 	} );
+
+	it( 'preserves an odd stored UTC hour when only the day changes in UTC fallback mode', async () => {
+		( useDeliveryWindowTimezone as jest.Mock ).mockReturnValue( {
+			timezone: undefined,
+			offsetHours: null,
+			isUtcFallback: true,
+		} );
+
+		mockGetIsAutomatticianApi( false );
+		mockGetSettingsApi( {
+			...defaultUserSettings,
+			subscription_delivery_day: 1,
+			subscription_delivery_hour: 5,
+		} );
+
+		nock( 'https://public-api.wordpress.com:443' )
+			.post(
+				'/rest/v1.1/me/settings',
+				( body ) =>
+					Number( body.subscription_delivery_hour ) === 5 &&
+					Number( body.subscription_delivery_day ) === 2
+			)
+			.reply( 200, {} );
+
+		render( <SubscriptionSettings />, { wrapper: Wrapper() } );
+
+		// The hour dropdown only lists even buckets; an odd stored UTC hour (5) may
+		// not match an <option>, but changing only the day must not alter it on save.
+		expect( await daySelect() ).toHaveValue( '1' );
+
+		await userEvent.selectOptions( await daySelect(), '2' );
+		await userEvent.click( await saveButton() );
+
+		await waitFor( () => {
+			const snackbar = notificationSnackBar();
+			expect( snackbar ).toBeVisible();
+			expect( snackbar ).toHaveTextContent( 'Subscription settings saved.' );
+		} );
+	} );
 } );

--- a/client/dashboard/me/notifications-emails/subscription-settings/test/index.test.tsx
+++ b/client/dashboard/me/notifications-emails/subscription-settings/test/index.test.tsx
@@ -2,6 +2,12 @@
  * @jest-environment jsdom
  */
 import { UserSettings } from '@automattic/api-core';
+import {
+	fromUtcDeliveryWindow,
+	getDeliveryWindowOffsetHours,
+	toUtcDeliveryWindow,
+	useDeliveryWindowTimezone,
+} from '@automattic/i18n-utils';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -18,6 +24,14 @@ jest.mock(
 );
 
 jest.mock( '@tanstack/react-router' );
+
+// Mock only the timezone hook so we can drive the UTC↔local delivery-window
+// conversion deterministically, without depending on the machine's real time
+// zone. The conversion helpers themselves stay real.
+jest.mock( '@automattic/i18n-utils', () => ( {
+	...jest.requireActual( '@automattic/i18n-utils' ),
+	useDeliveryWindowTimezone: jest.fn(),
+} ) );
 
 const mockGetIsAutomatticianApi = ( isAutomttician: boolean ) => {
 	return nock( 'https://public-api.wordpress.com:443' )
@@ -99,6 +113,12 @@ describe( 'SubscriptionSettings', () => {
 	beforeEach( () => {
 		//Snackbar requires window.scrollTo to be defined
 		window.scrollTo = jest.fn();
+		// Default to UTC so the existing tests keep their identity behavior.
+		( useDeliveryWindowTimezone as jest.Mock ).mockReturnValue( {
+			timezone: 'UTC',
+			offsetHours: 0,
+			isUtcFallback: false,
+		} );
 	} );
 
 	it( "doesn't render the automatticians only checkbox", async () => {
@@ -201,5 +221,78 @@ describe( 'SubscriptionSettings', () => {
 			expect( snackbar ).toBeVisible();
 			expect( snackbar ).toHaveTextContent( 'Subscription settings saved.' );
 		} );
+	} );
+
+	it( 'displays the stored UTC window in local time and saves edits back as UTC', async () => {
+		// Evaluate the offset the same way the hook would, so the test stays
+		// correct across daylight-saving transitions.
+		const offsetHours = getDeliveryWindowOffsetHours( 'America/Los_Angeles' ) ?? 0;
+		( useDeliveryWindowTimezone as jest.Mock ).mockReturnValue( {
+			timezone: 'America/Los_Angeles',
+			offsetHours,
+			isUtcFallback: false,
+		} );
+		const expectedLocal = fromUtcDeliveryWindow( { hour: 0, day: 1 }, offsetHours );
+
+		mockGetIsAutomatticianApi( false );
+		mockGetSettingsApi( {
+			...defaultUserSettings,
+			subscription_delivery_day: 1,
+			subscription_delivery_hour: 0,
+		} );
+
+		render( <SubscriptionSettings />, { wrapper: Wrapper() } );
+
+		// UTC Monday 00:00 should show as the previous-day local bucket in PT.
+		expect( await daySelect() ).toHaveValue( String( expectedLocal.day ) );
+		expect( await hourSelect() ).toHaveValue( String( expectedLocal.hour ) );
+
+		// Pick a different local bucket and verify it round-trips back to UTC.
+		const newLocalHour = expectedLocal.hour === 0 ? 2 : 0;
+		const expectedUtc = toUtcDeliveryWindow(
+			{ hour: newLocalHour, day: expectedLocal.day },
+			offsetHours
+		);
+
+		nock( 'https://public-api.wordpress.com:443' )
+			.post(
+				'/rest/v1.1/me/settings',
+				( body ) =>
+					Number( body.subscription_delivery_hour ) === expectedUtc.hour &&
+					Number( body.subscription_delivery_day ) === expectedUtc.day
+			)
+			.reply( 200, {} );
+
+		await userEvent.selectOptions( await hourSelect(), String( newLocalHour ) );
+		await userEvent.click( await saveButton() );
+
+		await waitFor( () => {
+			const snackbar = notificationSnackBar();
+			expect( snackbar ).toBeVisible();
+			expect( snackbar ).toHaveTextContent( 'Subscription settings saved.' );
+		} );
+	} );
+
+	it( 'falls back to clearly labeled UTC when the time zone is unknown', async () => {
+		( useDeliveryWindowTimezone as jest.Mock ).mockReturnValue( {
+			timezone: undefined,
+			offsetHours: null,
+			isUtcFallback: true,
+		} );
+
+		mockGetIsAutomatticianApi( false );
+		mockGetSettingsApi( {
+			...defaultUserSettings,
+			subscription_delivery_day: 1,
+			subscription_delivery_hour: 8,
+		} );
+
+		render( <SubscriptionSettings />, { wrapper: Wrapper() } );
+
+		// With no time zone, values are shown unchanged (raw UTC).
+		expect( await hourSelect() ).toHaveValue( '8' );
+		// The UTC fallback copy and labels should be present.
+		expect( await screen.findByText( /shown in UTC/i ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'option', { name: '08:00 - 10:00 UTC' } ) ).toBeInTheDocument();
 	} );
 } );

--- a/client/dashboard/me/notifications-emails/subscription-settings/test/index.test.tsx
+++ b/client/dashboard/me/notifications-emails/subscription-settings/test/index.test.tsx
@@ -321,8 +321,9 @@ describe( 'SubscriptionSettings', () => {
 
 		render( <SubscriptionSettings />, { wrapper: Wrapper() } );
 
-		// The hour dropdown only lists even buckets; an odd stored UTC hour (5) may
-		// not match an <option>, but changing only the day must not alter it on save.
+		expect( await hourSelect() ).toHaveValue( '5' );
+		expect( screen.getByRole( 'option', { name: '05:00 - 07:00 UTC' } ) ).toBeInTheDocument();
+
 		expect( await daySelect() ).toHaveValue( '1' );
 
 		await userEvent.selectOptions( await daySelect(), '2' );

--- a/client/landing/subscriptions/components/fields/delivery-window-input/delivery-window-input.tsx
+++ b/client/landing/subscriptions/components/fields/delivery-window-input/delivery-window-input.tsx
@@ -1,8 +1,13 @@
 /* eslint-disable no-restricted-imports */
 import { FormLabel } from '@automattic/components';
 import { Reader } from '@automattic/data-stores';
+import {
+	fromUtcDeliveryWindow,
+	toUtcDeliveryWindow,
+	useDeliveryWindowTimezone,
+} from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
-import { FormEventHandler, useCallback } from 'react';
+import { FormEvent, FormEventHandler, useCallback } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSelect from 'calypso/components/forms/form-select';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
@@ -15,6 +20,8 @@ type DeliveryWindowInputProps = {
 	onHourChange: FormEventHandler< HTMLSelectElement >;
 };
 
+const padHour = ( hour: number ) => String( hour % 24 ).padStart( 2, '0' );
+
 const DeliveryWindowInput = ( {
 	dayValue,
 	hourValue,
@@ -23,10 +30,26 @@ const DeliveryWindowInput = ( {
 }: DeliveryWindowInputProps ) => {
 	const translate = useTranslate();
 	const moment = useLocalizedMoment();
+	const { offsetHours, isUtcFallback, timezone } = useDeliveryWindowTimezone();
+
+	// The stored day/hour are UTC. Show them in the device's local time, and
+	// convert edits back to UTC for the caller. Fall back to raw UTC values
+	// (clearly labeled) when the time zone can't be detected.
+	const localWindow = fromUtcDeliveryWindow( { hour: hourValue, day: dayValue }, offsetHours ?? 0 );
 
 	const getLabel = useCallback(
-		( hour: number ) =>
-			translate( '%(fromHour)s - %(toHour)s', {
+		( hour: number ) => {
+			if ( isUtcFallback ) {
+				return translate( '%(fromHour)s:00 - %(toHour)s:00 UTC', {
+					context: 'Hour range (in UTC) between which subscriptions are delivered',
+					args: {
+						fromHour: padHour( hour ),
+						toHour: padHour( hour + 2 ),
+					},
+				} );
+			}
+
+			return translate( '%(fromHour)s - %(toHour)s', {
 				context: 'Hour range between which subscriptions are delivered',
 				args: {
 					fromHour: moment().hour( hour ).minute( 0 ).format( 'LT' ),
@@ -35,8 +58,9 @@ const DeliveryWindowInput = ( {
 						.minute( 0 )
 						.format( 'LT' ),
 				},
-			} ),
-		[ moment, translate ]
+			} );
+		},
+		[ isUtcFallback, moment, translate ]
 	);
 
 	const orderedWeekDays = moment.weekdays( true );
@@ -46,20 +70,52 @@ const DeliveryWindowInput = ( {
 		[ moment ]
 	);
 
+	// Emit a synthetic change to the caller's single-field handlers. Both the
+	// day and hour are emitted together because converting a local edit back to
+	// UTC can wrap the day across midnight.
+	const emitUtcWindow = useCallback(
+		( localHour: number, localDay: number ) => {
+			const utc = toUtcDeliveryWindow( { hour: localHour, day: localDay }, offsetHours ?? 0 );
+			const syntheticEvent = ( value: number ) =>
+				( {
+					currentTarget: { value: String( value ) },
+				} ) as unknown as FormEvent< HTMLSelectElement >;
+			onHourChange( syntheticEvent( utc.hour ) );
+			onDayChange( syntheticEvent( utc.day ) );
+		},
+		[ offsetHours, onDayChange, onHourChange ]
+	);
+
+	const handleDayChange: FormEventHandler< HTMLSelectElement > = ( evt ) => {
+		emitUtcWindow( localWindow.hour, parseInt( evt.currentTarget.value, 10 ) || 0 );
+	};
+
+	const handleHourChange: FormEventHandler< HTMLSelectElement > = ( evt ) => {
+		emitUtcWindow( parseInt( evt.currentTarget.value, 10 ) || 0, localWindow.day );
+	};
+
 	return (
 		<FormFieldset className="delivery-window-input">
 			<FormLabel htmlFor="delivery_window_day">
 				{ translate( 'Daily/weekly delivery window' ) }
 			</FormLabel>
 			<div className="select-row">
-				<FormSelect name="delivery_window_day" onChange={ onDayChange } value={ dayValue }>
+				<FormSelect
+					name="delivery_window_day"
+					onChange={ handleDayChange }
+					value={ localWindow.day }
+				>
 					{ orderedWeekDays.map( ( weekDay: string ) => (
 						<option key={ weekDay } value={ getDayValue( weekDay ) }>
 							{ weekDay }
 						</option>
 					) ) }
 				</FormSelect>
-				<FormSelect name="delivery_window_hour" onChange={ onHourChange } value={ hourValue }>
+				<FormSelect
+					name="delivery_window_hour"
+					onChange={ handleHourChange }
+					value={ localWindow.hour }
+				>
 					{ [ 0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22 ].map( ( hour ) => (
 						<option key={ hour } value={ hour }>
 							{ getLabel( hour ) }
@@ -72,7 +128,12 @@ const DeliveryWindowInput = ( {
 				<span className="tip-text">
 					{ translate(
 						'Your emails will be sent out at this day and time once you choose a daily or weekly delivery'
-					) }
+					) }{ ' ' }
+					{ isUtcFallback
+						? translate( "We couldn't detect your time zone, so these times are shown in UTC." )
+						: translate( 'Times are shown in your local time zone (%(timezone)s).', {
+								args: { timezone: timezone ?? '' },
+						  } ) }
 				</span>
 			</div>
 		</FormFieldset>

--- a/client/landing/subscriptions/components/fields/delivery-window-input/delivery-window-input.tsx
+++ b/client/landing/subscriptions/components/fields/delivery-window-input/delivery-window-input.tsx
@@ -3,6 +3,7 @@ import { FormLabel } from '@automattic/components';
 import { Reader } from '@automattic/data-stores';
 import {
 	applyDeliveryWindowEdit,
+	getDeliveryHourPickerHours,
 	getDisplayDeliveryWindow,
 	useDeliveryWindowTimezone,
 } from '@automattic/i18n-utils';
@@ -128,7 +129,7 @@ const DeliveryWindowInput = ( {
 					onChange={ handleHourChange }
 					value={ displayWindow.hour }
 				>
-					{ [ 0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22 ].map( ( hour ) => (
+					{ getDeliveryHourPickerHours( displayWindow.hour, isUtcFallback ).map( ( hour ) => (
 						<option key={ hour } value={ hour }>
 							{ getLabel( hour ) }
 						</option>

--- a/client/landing/subscriptions/components/fields/delivery-window-input/delivery-window-input.tsx
+++ b/client/landing/subscriptions/components/fields/delivery-window-input/delivery-window-input.tsx
@@ -129,10 +129,10 @@ const DeliveryWindowInput = ( {
 					{ translate(
 						'Your emails will be sent out at this day and time once you choose a daily or weekly delivery'
 					) }{ ' ' }
-					{ isUtcFallback
+					{ isUtcFallback || ! timezone
 						? translate( "We couldn't detect your time zone, so these times are shown in UTC." )
 						: translate( 'Times are shown in your local time zone (%(timezone)s).', {
-								args: { timezone: timezone ?? '' },
+								args: { timezone },
 						  } ) }
 				</span>
 			</div>

--- a/client/landing/subscriptions/components/fields/delivery-window-input/delivery-window-input.tsx
+++ b/client/landing/subscriptions/components/fields/delivery-window-input/delivery-window-input.tsx
@@ -2,8 +2,8 @@
 import { FormLabel } from '@automattic/components';
 import { Reader } from '@automattic/data-stores';
 import {
-	fromUtcDeliveryWindow,
-	toUtcDeliveryWindow,
+	applyDeliveryWindowEdit,
+	getDisplayDeliveryWindow,
 	useDeliveryWindowTimezone,
 } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
@@ -35,7 +35,8 @@ const DeliveryWindowInput = ( {
 	// The stored day/hour are UTC. Show them in the device's local time, and
 	// convert edits back to UTC for the caller. Fall back to raw UTC values
 	// (clearly labeled) when the time zone can't be detected.
-	const localWindow = fromUtcDeliveryWindow( { hour: hourValue, day: dayValue }, offsetHours ?? 0 );
+	const storedUtc = { hour: hourValue, day: dayValue };
+	const displayWindow = getDisplayDeliveryWindow( storedUtc, offsetHours );
 
 	const getLabel = useCallback(
 		( hour: number ) => {
@@ -74,8 +75,7 @@ const DeliveryWindowInput = ( {
 	// day and hour are emitted together because converting a local edit back to
 	// UTC can wrap the day across midnight.
 	const emitUtcWindow = useCallback(
-		( localHour: number, localDay: number ) => {
-			const utc = toUtcDeliveryWindow( { hour: localHour, day: localDay }, offsetHours ?? 0 );
+		( utc: { hour: number; day: number } ) => {
 			const syntheticEvent = ( value: number ) =>
 				( {
 					currentTarget: { value: String( value ) },
@@ -83,15 +83,27 @@ const DeliveryWindowInput = ( {
 			onHourChange( syntheticEvent( utc.hour ) );
 			onDayChange( syntheticEvent( utc.day ) );
 		},
-		[ offsetHours, onDayChange, onHourChange ]
+		[ onDayChange, onHourChange ]
 	);
 
 	const handleDayChange: FormEventHandler< HTMLSelectElement > = ( evt ) => {
-		emitUtcWindow( localWindow.hour, parseInt( evt.currentTarget.value, 10 ) || 0 );
+		emitUtcWindow(
+			applyDeliveryWindowEdit(
+				storedUtc,
+				{ day: parseInt( evt.currentTarget.value, 10 ) || 0 },
+				offsetHours
+			)
+		);
 	};
 
 	const handleHourChange: FormEventHandler< HTMLSelectElement > = ( evt ) => {
-		emitUtcWindow( parseInt( evt.currentTarget.value, 10 ) || 0, localWindow.day );
+		emitUtcWindow(
+			applyDeliveryWindowEdit(
+				storedUtc,
+				{ hour: parseInt( evt.currentTarget.value, 10 ) || 0 },
+				offsetHours
+			)
+		);
 	};
 
 	return (
@@ -103,7 +115,7 @@ const DeliveryWindowInput = ( {
 				<FormSelect
 					name="delivery_window_day"
 					onChange={ handleDayChange }
-					value={ localWindow.day }
+					value={ displayWindow.day }
 				>
 					{ orderedWeekDays.map( ( weekDay: string ) => (
 						<option key={ weekDay } value={ getDayValue( weekDay ) }>
@@ -114,7 +126,7 @@ const DeliveryWindowInput = ( {
 				<FormSelect
 					name="delivery_window_hour"
 					onChange={ handleHourChange }
-					value={ localWindow.hour }
+					value={ displayWindow.hour }
 				>
 					{ [ 0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22 ].map( ( hour ) => (
 						<option key={ hour } value={ hour }>

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -209,6 +209,7 @@ class NotificationSubscriptions extends Component {
 	render() {
 		const { teams } = this.props;
 		const isAutomattician = isAutomatticTeamMember( teams );
+		const displayWindow = this.getDisplayDeliveryWindow();
 
 		return (
 			<Main wideLayout className="reader-subscriptions__notifications-settings">
@@ -301,7 +302,7 @@ class NotificationSubscriptions extends Component {
 								name="subscription_delivery_day"
 								onChange={ this.handleDeliveryWindowChange( 'day' ) }
 								onFocus={ this.handleFocusEvent( 'Email delivery window day' ) }
-								value={ String( this.getDisplayDeliveryWindow().day ) }
+								value={ String( displayWindow.day ) }
 							>
 								{ this.renderLocalizedWeekdayOptions() }
 							</FormSelect>
@@ -312,10 +313,10 @@ class NotificationSubscriptions extends Component {
 								name="subscription_delivery_hour"
 								onChange={ this.handleDeliveryWindowChange( 'hour' ) }
 								onFocus={ this.handleFocusEvent( 'Email Delivery Window Time' ) }
-								value={ String( this.getDisplayDeliveryWindow().hour ) }
+								value={ String( displayWindow.hour ) }
 							>
 								{ getDeliveryHourPickerHours(
-									this.getDisplayDeliveryWindow().hour,
+									displayWindow.hour,
 									this.props.deliveryWindowIsUtcFallback
 								).map( ( hour ) => (
 									<option key={ hour } value={ hour }>

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -331,7 +331,7 @@ class NotificationSubscriptions extends Component {
 								{ this.props.translate(
 									'When choosing daily or weekly email delivery, which time of day would you prefer?'
 								) }{ ' ' }
-								{ this.props.deliveryWindowIsUtcFallback
+								{ this.props.deliveryWindowIsUtcFallback || ! this.props.deliveryWindowTimezone
 									? this.props.translate(
 											"We couldn't detect your time zone, so these times are shown in UTC."
 									  )

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -438,11 +438,11 @@ const NotificationSubscriptionsWithHooks = ( props ) => {
 	const { offsetHours, isUtcFallback, timezone } = useDeliveryWindowTimezone();
 	return (
 		<NotificationSubscriptions
+			{ ...props }
 			hasSubscriptions={ hasNonSelfSubscriptions }
 			deliveryWindowOffsetHours={ offsetHours }
 			deliveryWindowIsUtcFallback={ isUtcFallback }
 			deliveryWindowTimezone={ timezone }
-			{ ...props }
 		/>
 	);
 };

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -1,5 +1,11 @@
 import { Card, FormLabel } from '@automattic/components';
-import { getNumericFirstDayOfWeek, withLocale } from '@automattic/i18n-utils';
+import {
+	fromUtcDeliveryWindow,
+	getNumericFirstDayOfWeek,
+	toUtcDeliveryWindow,
+	useDeliveryWindowTimezone,
+	withLocale,
+} from '@automattic/i18n-utils';
 import {
 	Button,
 	CheckboxControl,
@@ -111,6 +117,17 @@ class NotificationSubscriptions extends Component {
 	};
 
 	getDeliveryHourLabel( hour ) {
+		if ( this.props.deliveryWindowIsUtcFallback ) {
+			const pad = ( value ) => String( value % 24 ).padStart( 2, '0' );
+			return this.props.translate( '%(fromHour)s:00 - %(toHour)s:00 UTC', {
+				context: 'Hour range (in UTC) between which subscriptions are delivered',
+				args: {
+					fromHour: pad( hour ),
+					toHour: pad( hour + 2 ),
+				},
+			} );
+		}
+
 		return this.props.translate( '%(fromHour)s - %(toHour)s', {
 			context: 'Hour range between which subscriptions are delivered',
 			args: {
@@ -123,6 +140,39 @@ class NotificationSubscriptions extends Component {
 			},
 		} );
 	}
+
+	// The backend stores delivery hour/day as UTC. Convert to the device's local
+	// time for display, and back to UTC on save, so the picker matches what the
+	// user expects. Falls back to raw UTC when the time zone is unknown.
+	getStoredUtcDeliveryWindow() {
+		return {
+			hour: parseInt( this.props.getSetting( 'subscription_delivery_hour' ), 10 ) || 0,
+			day: parseInt( this.props.getSetting( 'subscription_delivery_day' ), 10 ) || 0,
+		};
+	}
+
+	getLocalDeliveryWindow() {
+		return fromUtcDeliveryWindow(
+			this.getStoredUtcDeliveryWindow(),
+			this.props.deliveryWindowOffsetHours ?? 0
+		);
+	}
+
+	// Changing either the hour or the day can wrap the day boundary once
+	// converted back to UTC, so we recompute and persist both settings together.
+	handleDeliveryWindowChange = ( field ) => ( event ) => {
+		const newLocalWindow = {
+			...this.getLocalDeliveryWindow(),
+			[ field ]: parseInt( event.currentTarget.value, 10 ) || 0,
+		};
+		const utc = toUtcDeliveryWindow( newLocalWindow, this.props.deliveryWindowOffsetHours ?? 0 );
+		this.props.updateSetting( {
+			currentTarget: { name: 'subscription_delivery_day', value: String( utc.day ) },
+		} );
+		this.props.updateSetting( {
+			currentTarget: { name: 'subscription_delivery_hour', value: String( utc.hour ) },
+		} );
+	};
 
 	renderLocalizedWeekdayOptions() {
 		const { translate, locale } = this.props;
@@ -248,9 +298,9 @@ class NotificationSubscriptions extends Component {
 								className="reader-subscriptions__delivery-window"
 								id="subscription_delivery_day"
 								name="subscription_delivery_day"
-								onChange={ this.props.updateSetting }
+								onChange={ this.handleDeliveryWindowChange( 'day' ) }
 								onFocus={ this.handleFocusEvent( 'Email delivery window day' ) }
-								value={ this.props.getSetting( 'subscription_delivery_day' ) }
+								value={ String( this.getLocalDeliveryWindow().day ) }
 							>
 								{ this.renderLocalizedWeekdayOptions() }
 							</FormSelect>
@@ -259,9 +309,9 @@ class NotificationSubscriptions extends Component {
 								disabled={ this.props.getDisabledState() }
 								id="subscription_delivery_hour"
 								name="subscription_delivery_hour"
-								onChange={ this.props.updateSetting }
+								onChange={ this.handleDeliveryWindowChange( 'hour' ) }
 								onFocus={ this.handleFocusEvent( 'Email Delivery Window Time' ) }
-								value={ this.props.getSetting( 'subscription_delivery_hour' ) }
+								value={ String( this.getLocalDeliveryWindow().hour ) }
 							>
 								<option value="0">{ this.getDeliveryHourLabel( 0 ) }</option>
 								<option value="2">{ this.getDeliveryHourLabel( 2 ) }</option>
@@ -280,7 +330,17 @@ class NotificationSubscriptions extends Component {
 							<FormSettingExplanation>
 								{ this.props.translate(
 									'When choosing daily or weekly email delivery, which time of day would you prefer?'
-								) }
+								) }{ ' ' }
+								{ this.props.deliveryWindowIsUtcFallback
+									? this.props.translate(
+											"We couldn't detect your time zone, so these times are shown in UTC."
+									  )
+									: this.props.translate(
+											'Times are shown in your local time zone (%(timezone)s).',
+											{
+												args: { timezone: this.props.deliveryWindowTimezone },
+											}
+									  ) }
 							</FormSettingExplanation>
 						</FormFieldset>
 
@@ -375,7 +435,16 @@ const mapDispatchToProps = {
 
 const NotificationSubscriptionsWithHooks = ( props ) => {
 	const { hasNonSelfSubscriptions } = useSiteSubscriptions();
-	return <NotificationSubscriptions hasSubscriptions={ hasNonSelfSubscriptions } { ...props } />;
+	const { offsetHours, isUtcFallback, timezone } = useDeliveryWindowTimezone();
+	return (
+		<NotificationSubscriptions
+			hasSubscriptions={ hasNonSelfSubscriptions }
+			deliveryWindowOffsetHours={ offsetHours }
+			deliveryWindowIsUtcFallback={ isUtcFallback }
+			deliveryWindowTimezone={ timezone }
+			{ ...props }
+		/>
+	);
 };
 
 export default compose(

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -1,6 +1,7 @@
 import { Card, FormLabel } from '@automattic/components';
 import {
 	applyDeliveryWindowEdit,
+	getDeliveryHourPickerHours,
 	getDisplayDeliveryWindow,
 	getNumericFirstDayOfWeek,
 	useDeliveryWindowTimezone,
@@ -313,18 +314,14 @@ class NotificationSubscriptions extends Component {
 								onFocus={ this.handleFocusEvent( 'Email Delivery Window Time' ) }
 								value={ String( this.getDisplayDeliveryWindow().hour ) }
 							>
-								<option value="0">{ this.getDeliveryHourLabel( 0 ) }</option>
-								<option value="2">{ this.getDeliveryHourLabel( 2 ) }</option>
-								<option value="4">{ this.getDeliveryHourLabel( 4 ) }</option>
-								<option value="6">{ this.getDeliveryHourLabel( 6 ) }</option>
-								<option value="8">{ this.getDeliveryHourLabel( 8 ) }</option>
-								<option value="10">{ this.getDeliveryHourLabel( 10 ) }</option>
-								<option value="12">{ this.getDeliveryHourLabel( 12 ) }</option>
-								<option value="14">{ this.getDeliveryHourLabel( 14 ) }</option>
-								<option value="16">{ this.getDeliveryHourLabel( 16 ) }</option>
-								<option value="18">{ this.getDeliveryHourLabel( 18 ) }</option>
-								<option value="20">{ this.getDeliveryHourLabel( 20 ) }</option>
-								<option value="22">{ this.getDeliveryHourLabel( 22 ) }</option>
+								{ getDeliveryHourPickerHours(
+									this.getDisplayDeliveryWindow().hour,
+									this.props.deliveryWindowIsUtcFallback
+								).map( ( hour ) => (
+									<option key={ hour } value={ hour }>
+										{ this.getDeliveryHourLabel( hour ) }
+									</option>
+								) ) }
 							</FormSelect>
 
 							<FormSettingExplanation>

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -1,8 +1,8 @@
 import { Card, FormLabel } from '@automattic/components';
 import {
-	fromUtcDeliveryWindow,
+	applyDeliveryWindowEdit,
+	getDisplayDeliveryWindow,
 	getNumericFirstDayOfWeek,
-	toUtcDeliveryWindow,
 	useDeliveryWindowTimezone,
 	withLocale,
 } from '@automattic/i18n-utils';
@@ -151,21 +151,21 @@ class NotificationSubscriptions extends Component {
 		};
 	}
 
-	getLocalDeliveryWindow() {
-		return fromUtcDeliveryWindow(
+	getDisplayDeliveryWindow() {
+		return getDisplayDeliveryWindow(
 			this.getStoredUtcDeliveryWindow(),
-			this.props.deliveryWindowOffsetHours ?? 0
+			this.props.deliveryWindowOffsetHours
 		);
 	}
 
 	// Changing either the hour or the day can wrap the day boundary once
 	// converted back to UTC, so we recompute and persist both settings together.
 	handleDeliveryWindowChange = ( field ) => ( event ) => {
-		const newLocalWindow = {
-			...this.getLocalDeliveryWindow(),
-			[ field ]: parseInt( event.currentTarget.value, 10 ) || 0,
-		};
-		const utc = toUtcDeliveryWindow( newLocalWindow, this.props.deliveryWindowOffsetHours ?? 0 );
+		const utc = applyDeliveryWindowEdit(
+			this.getStoredUtcDeliveryWindow(),
+			{ [ field ]: parseInt( event.currentTarget.value, 10 ) || 0 },
+			this.props.deliveryWindowOffsetHours
+		);
 		this.props.updateSetting( {
 			currentTarget: { name: 'subscription_delivery_day', value: String( utc.day ) },
 		} );
@@ -300,7 +300,7 @@ class NotificationSubscriptions extends Component {
 								name="subscription_delivery_day"
 								onChange={ this.handleDeliveryWindowChange( 'day' ) }
 								onFocus={ this.handleFocusEvent( 'Email delivery window day' ) }
-								value={ String( this.getLocalDeliveryWindow().day ) }
+								value={ String( this.getDisplayDeliveryWindow().day ) }
 							>
 								{ this.renderLocalizedWeekdayOptions() }
 							</FormSelect>
@@ -311,7 +311,7 @@ class NotificationSubscriptions extends Component {
 								name="subscription_delivery_hour"
 								onChange={ this.handleDeliveryWindowChange( 'hour' ) }
 								onFocus={ this.handleFocusEvent( 'Email Delivery Window Time' ) }
-								value={ String( this.getLocalDeliveryWindow().hour ) }
+								value={ String( this.getDisplayDeliveryWindow().hour ) }
 							>
 								<option value="0">{ this.getDeliveryHourLabel( 0 ) }</option>
 								<option value="2">{ this.getDeliveryHourLabel( 2 ) }</option>

--- a/packages/i18n-utils/src/delivery-window/conversion.ts
+++ b/packages/i18n-utils/src/delivery-window/conversion.ts
@@ -1,0 +1,138 @@
+export type DeliveryWindow = {
+	/**
+	 * Hour of day, 0-23. The picker exposes only even 2-hour buckets
+	 * (0, 2, … 22) in local time, but the stored UTC value may be any whole
+	 * hour once a non-even offset is applied.
+	 */
+	hour: number;
+	/** Day of week, 0 (Sunday) - 6 (Saturday). */
+	day: number;
+};
+
+const DAYS_IN_WEEK = 7;
+const HOURS_IN_DAY = 24;
+
+function normalizeDay( day: number ): number {
+	return ( ( day % DAYS_IN_WEEK ) + DAYS_IN_WEEK ) % DAYS_IN_WEEK;
+}
+
+/**
+ * Snap an hour (0-23) down to the nearest even-numbered delivery-window bucket
+ * (0, 2, … 22). The picker only exposes 2-hour buckets, so a stored value that
+ * doesn't line up (e.g. legacy data stored as an even UTC hour, viewed with an
+ * odd offset) is snapped so the dropdown always has a valid selected option.
+ */
+function snapToHourBucket( hour: number ): number {
+	return hour - ( hour % 2 );
+}
+
+/**
+ * Shift a delivery window by a whole number of hours, wrapping the day when the
+ * hour crosses midnight in either direction.
+ */
+function shiftWindow( window: DeliveryWindow, deltaHours: number ): DeliveryWindow {
+	const rawHour = window.hour + deltaHours;
+	const dayShift = Math.floor( rawHour / HOURS_IN_DAY );
+	const hour = ( ( rawHour % HOURS_IN_DAY ) + HOURS_IN_DAY ) % HOURS_IN_DAY;
+
+	return {
+		hour,
+		day: normalizeDay( window.day + dayShift ),
+	};
+}
+
+/**
+ * Compute the device's timezone offset, in whole hours, relative to UTC for a
+ * given IANA timezone. A positive value means the local time is ahead of UTC
+ * (e.g. `Asia/Tokyo` → +9); a negative value means behind (e.g.
+ * `America/New_York` → -4 during EDT).
+ *
+ * Timezones with sub-hour offsets (e.g. `Asia/Kolkata` at +5:30) are rounded
+ * to the nearest whole hour, since the delivery-window picker only supports
+ * whole hours. This means the cron may fire up to ~30 minutes away from the
+ * displayed bucket for those users, which is acceptable for this coarse
+ * 2-hour-window UI.
+ * @param timezone An IANA timezone string, e.g. `America/New_York`. When
+ *   undefined (device timezone could not be detected), returns `null` so
+ *   callers can fall back to displaying raw UTC values.
+ * @param reference The instant at which to evaluate the offset. Defaults to
+ *   now, so daylight-saving transitions are respected.
+ * @returns The whole-hour offset from UTC, or `null` when no timezone is given
+ *   or the timezone is invalid.
+ */
+export function getDeliveryWindowOffsetHours(
+	timezone: string | undefined,
+	reference: Date = new Date()
+): number | null {
+	if ( ! timezone ) {
+		return null;
+	}
+
+	try {
+		const formatter = new Intl.DateTimeFormat( 'en-US', {
+			timeZone: timezone,
+			year: 'numeric',
+			month: 'numeric',
+			day: 'numeric',
+			hour: 'numeric',
+			minute: 'numeric',
+			second: 'numeric',
+			hourCycle: 'h23',
+		} );
+
+		const parts = formatter
+			.formatToParts( reference )
+			.reduce< Record< string, number > >( ( acc, part ) => {
+				if ( part.type !== 'literal' ) {
+					acc[ part.type ] = Number( part.value );
+				}
+				return acc;
+			}, {} );
+
+		const asUtc = Date.UTC(
+			parts.year,
+			parts.month - 1,
+			parts.day,
+			parts.hour,
+			parts.minute,
+			parts.second
+		);
+
+		// Round to whole minutes first: `asUtc` is truncated to second precision
+		// while `reference` carries milliseconds, and that sub-second gap can
+		// otherwise tip a true :30 offset (e.g. Asia/Kolkata) to the wrong side.
+		const offsetMinutes = Math.round( ( asUtc - reference.getTime() ) / 60000 );
+		const offsetHours = Math.round( offsetMinutes / 60 );
+		// Normalize -0 to 0.
+		return offsetHours === 0 ? 0 : offsetHours;
+	} catch ( e ) {
+		return null;
+	}
+}
+
+/**
+ * Convert a stored UTC delivery window to the equivalent local-time window for
+ * display. The hour is snapped to the nearest even bucket so the picker always
+ * has a valid selected option, and the day wraps when crossing midnight.
+ * @param utc The window as stored on the backend (interpreted as UTC).
+ * @param offsetHours The local offset from UTC in whole hours.
+ */
+export function fromUtcDeliveryWindow( utc: DeliveryWindow, offsetHours: number ): DeliveryWindow {
+	const shifted = shiftWindow( utc, offsetHours );
+	return {
+		hour: snapToHourBucket( shifted.hour ),
+		day: shifted.day,
+	};
+}
+
+/**
+ * Convert a local-time delivery window (as picked in the UI, always an even
+ * bucket) back to the UTC window to persist on the backend. The result is exact
+ * (not snapped) so the delivery time stays accurate even for odd offsets; the
+ * stored UTC hour may therefore be odd.
+ * @param local The window as displayed/picked in local time.
+ * @param offsetHours The local offset from UTC in whole hours.
+ */
+export function toUtcDeliveryWindow( local: DeliveryWindow, offsetHours: number ): DeliveryWindow {
+	return shiftWindow( local, -offsetHours );
+}

--- a/packages/i18n-utils/src/delivery-window/conversion.ts
+++ b/packages/i18n-utils/src/delivery-window/conversion.ts
@@ -133,8 +133,8 @@ export function getDeliveryWindowOffsetHours(
 
 /**
  * Convert a stored UTC delivery window to the equivalent local-time window for
- * display. The hour is snapped to the nearest even bucket so the picker always
- * has a valid selected option, and the day wraps when crossing midnight.
+ * display. The hour is snapped down to the nearest lower even bucket so the picker
+ * always has a valid selected option, and the day wraps when crossing midnight.
  * @param utc The window as stored on the backend (interpreted as UTC).
  * @param offsetHours The local offset from UTC in whole hours.
  */

--- a/packages/i18n-utils/src/delivery-window/conversion.ts
+++ b/packages/i18n-utils/src/delivery-window/conversion.ts
@@ -27,10 +27,6 @@ function snapToHourBucket( hour: number ): number {
 }
 
 /**
- * Shift a delivery window by a whole number of hours, wrapping the day when the
- * hour crosses midnight in either direction.
- */
-/**
  * Round a minute offset to the nearest whole hour, rounding half-hour ties
  * away from zero so negative zones like UTC-3:30 (America/St_Johns) become -4,
  * not -3.
@@ -43,6 +39,10 @@ function roundMinutesToWholeHours( offsetMinutes: number ): number {
 	return sign * Math.round( Math.abs( offsetMinutes ) / 60 );
 }
 
+/**
+ * Shift a delivery window by a whole number of hours, wrapping the day when the
+ * hour crosses midnight in either direction.
+ */
 function shiftWindow( window: DeliveryWindow, deltaHours: number ): DeliveryWindow {
 	const rawHour = window.hour + deltaHours;
 	const dayShift = Math.floor( rawHour / HOURS_IN_DAY );
@@ -146,4 +146,43 @@ export function fromUtcDeliveryWindow( utc: DeliveryWindow, offsetHours: number 
  */
 export function toUtcDeliveryWindow( local: DeliveryWindow, offsetHours: number ): DeliveryWindow {
 	return shiftWindow( local, -offsetHours );
+}
+
+/**
+ * Convert a stored UTC window for display in the picker. When the device
+ * timezone is unknown (`offsetHours === null`), returns the raw stored values
+ * without snapping so day-only edits do not change an untouched hour.
+ */
+export function getDisplayDeliveryWindow(
+	utc: DeliveryWindow,
+	offsetHours: number | null
+): DeliveryWindow {
+	if ( offsetHours === null ) {
+		return { hour: utc.hour, day: utc.day };
+	}
+	return fromUtcDeliveryWindow( utc, offsetHours );
+}
+
+/**
+ * Apply a partial edit from the picker and return the UTC window to persist.
+ * In UTC-fallback mode, only fields present in `edit` are updated; the rest
+ * are taken unchanged from `storedUtc`.
+ */
+export function applyDeliveryWindowEdit(
+	storedUtc: DeliveryWindow,
+	edit: Partial< DeliveryWindow >,
+	offsetHours: number | null
+): DeliveryWindow {
+	if ( offsetHours === null ) {
+		return {
+			hour: edit.hour ?? storedUtc.hour,
+			day: edit.day ?? storedUtc.day,
+		};
+	}
+	const display = getDisplayDeliveryWindow( storedUtc, offsetHours );
+	const local = {
+		hour: edit.hour ?? display.hour,
+		day: edit.day ?? display.day,
+	};
+	return toUtcDeliveryWindow( local, offsetHours );
 }

--- a/packages/i18n-utils/src/delivery-window/conversion.ts
+++ b/packages/i18n-utils/src/delivery-window/conversion.ts
@@ -12,6 +12,16 @@ export type DeliveryWindow = {
 const DAYS_IN_WEEK = 7;
 const HOURS_IN_DAY = 24;
 
+/** Even-hour buckets (0, 2, … 22) shown in the delivery-window picker in local-time mode. */
+export const STANDARD_DELIVERY_HOUR_BUCKETS = Array.from(
+	{ length: HOURS_IN_DAY / 2 },
+	( _, index ) => index * 2
+);
+
+function normalizeDeliveryHour( hour: number ): number {
+	return ( ( hour % HOURS_IN_DAY ) + HOURS_IN_DAY ) % HOURS_IN_DAY;
+}
+
 function normalizeDay( day: number ): number {
 	return ( ( day % DAYS_IN_WEEK ) + DAYS_IN_WEEK ) % DAYS_IN_WEEK;
 }
@@ -185,4 +195,27 @@ export function applyDeliveryWindowEdit(
 		day: edit.day ?? display.day,
 	};
 	return toUtcDeliveryWindow( local, offsetHours );
+}
+
+/**
+ * Hour values to render in the delivery-window `<select>`, so the control can
+ * always represent the current setting.
+ *
+ * - **UTC fallback** (`utcFallback: true`): every whole hour 0–23, since the UI
+ *   shows the raw stored UTC hour (which may be odd after prior saves).
+ * - **Local-time mode**: the standard even 2-hour buckets, plus the current
+ *   `displayHour` when it is not already listed (defensive; normally snapped to even).
+ */
+export function getDeliveryHourPickerHours( displayHour: number, utcFallback: boolean ): number[] {
+	const normalizedDisplayHour = normalizeDeliveryHour( displayHour );
+
+	if ( utcFallback ) {
+		return Array.from( { length: HOURS_IN_DAY }, ( _, hour ) => hour );
+	}
+
+	if ( STANDARD_DELIVERY_HOUR_BUCKETS.includes( normalizedDisplayHour ) ) {
+		return STANDARD_DELIVERY_HOUR_BUCKETS;
+	}
+
+	return [ ...STANDARD_DELIVERY_HOUR_BUCKETS, normalizedDisplayHour ].sort( ( a, b ) => a - b );
 }

--- a/packages/i18n-utils/src/delivery-window/conversion.ts
+++ b/packages/i18n-utils/src/delivery-window/conversion.ts
@@ -30,6 +30,19 @@ function snapToHourBucket( hour: number ): number {
  * Shift a delivery window by a whole number of hours, wrapping the day when the
  * hour crosses midnight in either direction.
  */
+/**
+ * Round a minute offset to the nearest whole hour, rounding half-hour ties
+ * away from zero so negative zones like UTC-3:30 (America/St_Johns) become -4,
+ * not -3.
+ */
+function roundMinutesToWholeHours( offsetMinutes: number ): number {
+	if ( offsetMinutes === 0 ) {
+		return 0;
+	}
+	const sign = Math.sign( offsetMinutes );
+	return sign * Math.round( Math.abs( offsetMinutes ) / 60 );
+}
+
 function shiftWindow( window: DeliveryWindow, deltaHours: number ): DeliveryWindow {
 	const rawHour = window.hour + deltaHours;
 	const dayShift = Math.floor( rawHour / HOURS_IN_DAY );
@@ -102,9 +115,7 @@ export function getDeliveryWindowOffsetHours(
 		// while `reference` carries milliseconds, and that sub-second gap can
 		// otherwise tip a true :30 offset (e.g. Asia/Kolkata) to the wrong side.
 		const offsetMinutes = Math.round( ( asUtc - reference.getTime() ) / 60000 );
-		const offsetHours = Math.round( offsetMinutes / 60 );
-		// Normalize -0 to 0.
-		return offsetHours === 0 ? 0 : offsetHours;
+		return roundMinutesToWholeHours( offsetMinutes );
 	} catch ( e ) {
 		return null;
 	}

--- a/packages/i18n-utils/src/delivery-window/index.ts
+++ b/packages/i18n-utils/src/delivery-window/index.ts
@@ -2,6 +2,8 @@ export {
 	getDeliveryWindowOffsetHours,
 	fromUtcDeliveryWindow,
 	toUtcDeliveryWindow,
+	getDisplayDeliveryWindow,
+	applyDeliveryWindowEdit,
 } from './conversion';
 export type { DeliveryWindow } from './conversion';
 export { default as useDeliveryWindowTimezone } from './use-delivery-window-timezone';

--- a/packages/i18n-utils/src/delivery-window/index.ts
+++ b/packages/i18n-utils/src/delivery-window/index.ts
@@ -1,0 +1,8 @@
+export {
+	getDeliveryWindowOffsetHours,
+	fromUtcDeliveryWindow,
+	toUtcDeliveryWindow,
+} from './conversion';
+export type { DeliveryWindow } from './conversion';
+export { default as useDeliveryWindowTimezone } from './use-delivery-window-timezone';
+export type { DeliveryWindowTimezone } from './use-delivery-window-timezone';

--- a/packages/i18n-utils/src/delivery-window/index.ts
+++ b/packages/i18n-utils/src/delivery-window/index.ts
@@ -4,6 +4,8 @@ export {
 	toUtcDeliveryWindow,
 	getDisplayDeliveryWindow,
 	applyDeliveryWindowEdit,
+	getDeliveryHourPickerHours,
+	STANDARD_DELIVERY_HOUR_BUCKETS,
 } from './conversion';
 export type { DeliveryWindow } from './conversion';
 export { default as useDeliveryWindowTimezone } from './use-delivery-window-timezone';

--- a/packages/i18n-utils/src/delivery-window/test/conversion.test.ts
+++ b/packages/i18n-utils/src/delivery-window/test/conversion.test.ts
@@ -44,6 +44,17 @@ describe( 'delivery-window conversion', () => {
 			// Asia/Kathmandu is +5:45 → rounds to +6.
 			expect( getDeliveryWindowOffsetHours( 'Asia/Kathmandu' ) ).toBe( 6 );
 		} );
+
+		it( 'rounds negative sub-hour offsets away from zero', () => {
+			// America/St_Johns is UTC-3:30 in winter → nearest whole hour is -4.
+			expect(
+				getDeliveryWindowOffsetHours( 'America/St_Johns', new Date( '2026-01-15T12:00:00Z' ) )
+			).toBe( -4 );
+			// Newfoundland Daylight Time is UTC-2:30 in summer → nearest is -3.
+			expect(
+				getDeliveryWindowOffsetHours( 'America/St_Johns', new Date( '2026-07-15T12:00:00Z' ) )
+			).toBe( -3 );
+		} );
 	} );
 
 	describe( 'fromUtcDeliveryWindow', () => {

--- a/packages/i18n-utils/src/delivery-window/test/conversion.test.ts
+++ b/packages/i18n-utils/src/delivery-window/test/conversion.test.ts
@@ -1,0 +1,120 @@
+import {
+	fromUtcDeliveryWindow,
+	getDeliveryWindowOffsetHours,
+	toUtcDeliveryWindow,
+	type DeliveryWindow,
+} from '../conversion';
+
+describe( 'delivery-window conversion', () => {
+	describe( 'getDeliveryWindowOffsetHours', () => {
+		it( 'returns null when no timezone is provided', () => {
+			expect( getDeliveryWindowOffsetHours( undefined ) ).toBeNull();
+		} );
+
+		it( 'returns null for an invalid timezone', () => {
+			expect( getDeliveryWindowOffsetHours( 'Not/AZone' ) ).toBeNull();
+		} );
+
+		it( 'returns 0 for UTC', () => {
+			expect( getDeliveryWindowOffsetHours( 'UTC' ) ).toBe( 0 );
+		} );
+
+		it( 'returns a positive offset for a timezone ahead of UTC', () => {
+			// Asia/Tokyo has no DST and is always +9.
+			expect( getDeliveryWindowOffsetHours( 'Asia/Tokyo' ) ).toBe( 9 );
+		} );
+
+		it( 'returns a negative offset for a timezone behind UTC', () => {
+			// America/New_York is -5 (EST) or -4 (EDT) depending on the date.
+			const winter = getDeliveryWindowOffsetHours(
+				'America/New_York',
+				new Date( '2026-01-15T12:00:00Z' )
+			);
+			const summer = getDeliveryWindowOffsetHours(
+				'America/New_York',
+				new Date( '2026-07-15T12:00:00Z' )
+			);
+			expect( winter ).toBe( -5 );
+			expect( summer ).toBe( -4 );
+		} );
+
+		it( 'rounds sub-hour offsets to the nearest whole hour', () => {
+			// Asia/Kolkata is +5:30 → rounds to +6 (nearest).
+			expect( getDeliveryWindowOffsetHours( 'Asia/Kolkata' ) ).toBe( 6 );
+			// Asia/Kathmandu is +5:45 → rounds to +6.
+			expect( getDeliveryWindowOffsetHours( 'Asia/Kathmandu' ) ).toBe( 6 );
+		} );
+	} );
+
+	describe( 'fromUtcDeliveryWindow', () => {
+		it( 'is identity when the offset is 0', () => {
+			const utc: DeliveryWindow = { hour: 8, day: 3 };
+			expect( fromUtcDeliveryWindow( utc, 0 ) ).toEqual( utc );
+		} );
+
+		it( 'shifts the hour by the offset without crossing midnight', () => {
+			expect( fromUtcDeliveryWindow( { hour: 12, day: 2 }, -4 ) ).toEqual( {
+				hour: 8,
+				day: 2,
+			} );
+		} );
+
+		it( 'wraps the day forward when the local hour rolls past midnight', () => {
+			// UTC Saturday 22:00 + 4 → Sunday 02:00.
+			expect( fromUtcDeliveryWindow( { hour: 22, day: 6 }, 4 ) ).toEqual( {
+				hour: 2,
+				day: 0,
+			} );
+		} );
+
+		it( 'wraps the day backward when the local hour rolls before midnight', () => {
+			// UTC Sunday 02:00 - 4 → Saturday 22:00.
+			expect( fromUtcDeliveryWindow( { hour: 2, day: 0 }, -4 ) ).toEqual( {
+				hour: 22,
+				day: 6,
+			} );
+		} );
+
+		it( 'snaps to the nearest lower even-hour bucket', () => {
+			// UTC 8:00 + 5 (odd offset, e.g. rounded IST) → 13:00, snapped to 12.
+			expect( fromUtcDeliveryWindow( { hour: 8, day: 1 }, 5 ).hour ).toBe( 12 );
+		} );
+	} );
+
+	describe( 'toUtcDeliveryWindow', () => {
+		it( 'is exact (not snapped) so odd offsets keep accurate delivery times', () => {
+			// Local Sunday 00:00 in an odd offset (-5) → UTC Sunday 05:00 (odd).
+			expect( toUtcDeliveryWindow( { hour: 0, day: 0 }, -5 ) ).toEqual( {
+				hour: 5,
+				day: 0,
+			} );
+		} );
+
+		it( 'wraps the day backward across midnight', () => {
+			// Local Sunday 00:00 with a +5 offset → UTC Saturday 19:00.
+			expect( toUtcDeliveryWindow( { hour: 0, day: 0 }, 5 ) ).toEqual( {
+				hour: 19,
+				day: 6,
+			} );
+		} );
+
+		it( 'round-trips the real picker flow local → UTC → local for every bucket', () => {
+			// The picker only ever emits even local hours; converting to UTC and
+			// back must return the exact same local bucket for any whole offset.
+			const offsets = [ -12, -8, -5, -4, -1, 0, 3, 5, 9, 12 ];
+			const localHours = [ 0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22 ];
+			const days = [ 0, 1, 2, 3, 4, 5, 6 ];
+
+			for ( const offset of offsets ) {
+				for ( const hour of localHours ) {
+					for ( const day of days ) {
+						const local: DeliveryWindow = { hour, day };
+						const utc = toUtcDeliveryWindow( local, offset );
+						const roundTripped = fromUtcDeliveryWindow( utc, offset );
+						expect( roundTripped ).toEqual( local );
+					}
+				}
+			}
+		} );
+	} );
+} );

--- a/packages/i18n-utils/src/delivery-window/test/conversion.test.ts
+++ b/packages/i18n-utils/src/delivery-window/test/conversion.test.ts
@@ -1,8 +1,10 @@
 import {
 	applyDeliveryWindowEdit,
 	fromUtcDeliveryWindow,
+	getDeliveryHourPickerHours,
 	getDeliveryWindowOffsetHours,
 	getDisplayDeliveryWindow,
+	STANDARD_DELIVERY_HOUR_BUCKETS,
 	toUtcDeliveryWindow,
 	type DeliveryWindow,
 } from '../conversion';
@@ -146,6 +148,29 @@ describe( 'delivery-window conversion', () => {
 				hour: 5,
 				day: 2,
 			} );
+		} );
+	} );
+
+	describe( 'getDeliveryHourPickerHours', () => {
+		it( 'returns every whole hour in UTC-fallback mode', () => {
+			expect( getDeliveryHourPickerHours( 5, true ) ).toEqual(
+				Array.from( { length: 24 }, ( _, hour ) => hour )
+			);
+		} );
+
+		it( 'returns standard even buckets when the display hour is already a bucket', () => {
+			expect( getDeliveryHourPickerHours( 8, false ) ).toEqual( STANDARD_DELIVERY_HOUR_BUCKETS );
+		} );
+
+		it( 'includes a non-bucket display hour in local-time mode', () => {
+			expect( getDeliveryHourPickerHours( 5, false ) ).toEqual( [
+				0, 2, 4, 5, 6, 8, 10, 12, 14, 16, 18, 20, 22,
+			] );
+		} );
+
+		it( 'normalizes display hours before matching options', () => {
+			expect( getDeliveryHourPickerHours( 26, false ) ).toEqual( STANDARD_DELIVERY_HOUR_BUCKETS );
+			expect( getDeliveryHourPickerHours( 25, true ) ).toContain( 1 );
 		} );
 	} );
 } );

--- a/packages/i18n-utils/src/delivery-window/test/conversion.test.ts
+++ b/packages/i18n-utils/src/delivery-window/test/conversion.test.ts
@@ -1,6 +1,8 @@
 import {
+	applyDeliveryWindowEdit,
 	fromUtcDeliveryWindow,
 	getDeliveryWindowOffsetHours,
+	getDisplayDeliveryWindow,
 	toUtcDeliveryWindow,
 	type DeliveryWindow,
 } from '../conversion';
@@ -126,6 +128,24 @@ describe( 'delivery-window conversion', () => {
 					}
 				}
 			}
+		} );
+	} );
+
+	describe( 'getDisplayDeliveryWindow', () => {
+		it( 'returns raw UTC values without snapping when offset is unknown', () => {
+			expect( getDisplayDeliveryWindow( { hour: 5, day: 1 }, null ) ).toEqual( {
+				hour: 5,
+				day: 1,
+			} );
+		} );
+	} );
+
+	describe( 'applyDeliveryWindowEdit', () => {
+		it( 'preserves an odd stored UTC hour when only the day changes in fallback mode', () => {
+			expect( applyDeliveryWindowEdit( { hour: 5, day: 1 }, { day: 2 }, null ) ).toEqual( {
+				hour: 5,
+				day: 2,
+			} );
 		} );
 	} );
 } );

--- a/packages/i18n-utils/src/delivery-window/use-delivery-window-timezone.ts
+++ b/packages/i18n-utils/src/delivery-window/use-delivery-window-timezone.ts
@@ -1,0 +1,32 @@
+import { useMemo } from 'react';
+import guessTimezone from '../guess-timezone';
+import { getDeliveryWindowOffsetHours } from './conversion';
+
+export type DeliveryWindowTimezone = {
+	/** The detected IANA timezone, or undefined when it could not be detected. */
+	timezone: string | undefined;
+	/** Whole-hour offset from UTC, or null when the timezone is unknown. */
+	offsetHours: number | null;
+	/** True when we could not detect a timezone and should display raw UTC. */
+	isUtcFallback: boolean;
+};
+
+/**
+ * Detect the device timezone (via `guessTimezone`) and derive the whole-hour
+ * offset used to convert delivery windows between UTC and local time.
+ *
+ * When the timezone cannot be detected, `isUtcFallback` is true and callers
+ * should display the raw UTC values with a clear "UTC" label.
+ */
+export default function useDeliveryWindowTimezone(): DeliveryWindowTimezone {
+	return useMemo( () => {
+		const timezone = guessTimezone();
+		const offsetHours = getDeliveryWindowOffsetHours( timezone );
+
+		return {
+			timezone,
+			offsetHours,
+			isUtcFallback: offsetHours === null,
+		};
+	}, [] );
+}

--- a/packages/i18n-utils/src/index.ts
+++ b/packages/i18n-utils/src/index.ts
@@ -19,6 +19,8 @@ export {
 	toUtcDeliveryWindow,
 	getDisplayDeliveryWindow,
 	applyDeliveryWindowEdit,
+	getDeliveryHourPickerHours,
+	STANDARD_DELIVERY_HOUR_BUCKETS,
 	useDeliveryWindowTimezone,
 } from './delivery-window';
 export type { DeliveryWindow, DeliveryWindowTimezone } from './delivery-window';

--- a/packages/i18n-utils/src/index.ts
+++ b/packages/i18n-utils/src/index.ts
@@ -17,6 +17,8 @@ export {
 	getDeliveryWindowOffsetHours,
 	fromUtcDeliveryWindow,
 	toUtcDeliveryWindow,
+	getDisplayDeliveryWindow,
+	applyDeliveryWindowEdit,
 	useDeliveryWindowTimezone,
 } from './delivery-window';
 export type { DeliveryWindow, DeliveryWindowTimezone } from './delivery-window';

--- a/packages/i18n-utils/src/index.ts
+++ b/packages/i18n-utils/src/index.ts
@@ -13,5 +13,12 @@ export {
 } from './locale-context';
 export * from './locales';
 export { default as guessTimezone } from './guess-timezone';
+export {
+	getDeliveryWindowOffsetHours,
+	fromUtcDeliveryWindow,
+	toUtcDeliveryWindow,
+	useDeliveryWindowTimezone,
+} from './delivery-window';
+export type { DeliveryWindow, DeliveryWindowTimezone } from './delivery-window';
 export * from './utils';
 export * from './date-utils';


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # https://linear.app/a8c/issue/NL-641/daily-digest-delivery-time-reader-settings-stores-local-hour-as-if-it

## Proposed Changes

Show notification day/time delivery setting in local time in the UI (convert to/from utc/device-timezone) so users can see and set this setting based on their local time.

The API stores delivery day/hour as UTC, but the UI treated picker values as local time without conversion—so users often set the wrong send window.

This PR adds shared UTC↔local helpers in @automattic/i18n-utils and uses them on all three surfaces: /me/notifications/subscriptions, dashboard email notification settings, and subscription portal settings. Edits are converted back to UTC on save; if the device timezone is unknown, the UI shows raw UTC with clear labeling.

Some before/afters for each screen this influences

BEFORE (me settings)
<img width="1099" height="914" alt="Screenshot 2026-05-29 at 2 54 07 PM" src="https://github.com/user-attachments/assets/ce69b932-b967-4528-9be9-c36d1dc33707" />

AFTER (me settings) - hours/day shown in local time instead, description mentions timezone
<img width="1188" height="914" alt="Screenshot 2026-05-29 at 2 53 15 PM" src="https://github.com/user-attachments/assets/d11d61b5-e5d6-472a-9da5-f8847e281083" />

BEFORE (v2 dashboard) - (note the timezone is a lie, those are the saved UTC values)
<img width="744" height="850" alt="Screenshot 2026-05-29 at 3 05 28 PM" src="https://github.com/user-attachments/assets/a80268f6-bfff-4d45-9cd9-a966cc8000c4" />

AFTER (v2 dashboard) - hours/day shown in local time instead, description same as before but will show "UTC" when local timezone is not detected and we fallback to UTC
<img width="739" height="806" alt="Screenshot 2026-05-29 at 2 52 53 PM" src="https://github.com/user-attachments/assets/b553a7a0-74c3-4ff0-929a-5aafcf3ca034" />

BEFORE (subscriber only portal)
<img width="856" height="636" alt="Screenshot 2026-05-29 at 2 47 06 PM" src="https://github.com/user-attachments/assets/8ef5e8be-d880-4253-ad19-3e4cacc6795a" />

AFTER (subscriber only portal) - hours/day shown in local time instead, description mentions timezone
<img width="1126" height="647" alt="Screenshot 2026-05-29 at 2 47 18 PM" src="https://github.com/user-attachments/assets/f1b06616-1e25-4201-9bc9-f86f25d15487" />


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The backend stores the values as UTC which is expected. The front-end forms just surface times that get saved as they are (as UTC on the backend), but do not note the times as UTC to the user so the user expectation is that they are setting the values based on their local timezones.  This change will allow the UI to show and set the value with respect to the devices local time, while still receiving and sending the UTC version to the backend.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Note - there is currently another issue you may find when trying to set a value that would map to 11pm UTC from me settings or v2 dashboard, as that endpoint currently limits at hour 22. The email-settings endpoint for the portal and cron systems already accept and use 23 completely fine, I hope to fix this issue in 220899-ghe-Automattic/wpcom


* Run this calypso branch.
* First, at any of the interfaces, you should notice the time shown as your current setting is different than on production. This is because previously production was actually showing the UTC value, so you should expect it to change now that it is showing the local value. e.g. My delivery window said 2-4pm, now says 10am-12pm - this is because UTC is 4 hours ahead of my local time. Confirm your settings now show local device time, and the timezone should be explained in the description.
* Go to `calypso.localhost:3000/me/notifications/subscriptions`
    * Open dev tools to the network tab and pre-search `/me/settings`, you can delete existing data.
    * Change the input to another value, save.
    * Inspect the new entries payload and response. Verify the hour and day integer values are in UTC. (in my case if i save hour 6am, the hour value should be 10 here in the request/response since utc is 4 hours ahead of me)
    * Set the value to something that would be another day of the week in UTC. e.g. If I set the day/time to "Tuesday" and "10pm", that is actually Wednesday and 2am utc - so the request/response should show day `3` (Wednesday, 1 starts on monday) and hour `2` (4 hours ahead of my time).
*  Go to the v2 dashboard version, on local build this is at `my.localhost:3000/me/notifications/emails`
    * Repeat the same tests as you did on the other page.
*  Go to the portal version for a subscriber without a wpcom account.
    * On a test blog, add a subscriber that doesn't correspond to a wpcom account (i used myNormalEmail+subscribertest@gmail.com)
    * Publish a post
    * Log into that email and find the copy addressed to that +subscribertest account
    * at the bottom of the email, right click "unsubscribe" and copy the URL from the link.
    * in an incognito tab, paste the link
    * this should load into the portal where you can access `wordpress.com/subscriptions/settings` (it will open to a site specific, can click "back" and goto "settings")
    * you will want to instead load `calypso.localhost:3000/subscriptions/settings`
    * you will need to open the application tab -> cookies -> calypso.localhost, and create a `subkey` cookie identical to the wordpress.com one, but for the calypso.localhost domain.
    * reload calypso localhost window
    * now you can do the same tests you did for the me/settings page and v2 dashboard pages, except this time filter the request for `/read/email-settings` (instead of the previous `/me/settings`)
    * verify the days/times sent out are in the UTC values.
* Re-test by changing your device timezone by 1 hour to verify things work well here, since these now fall off-center to the 2 hour brackets you just set.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?