### PR TITLE
Add advanced CodeQL workflow

### DIFF
--- a/.github/codeql/actions.yml
+++ b/.github/codeql/actions.yml
@@ -1,0 +1,4 @@
+name: CodeQL Actions
+
+paths:
+  - .github/workflows

--- a/.github/codeql/js-apps-tools-tests.yml
+++ b/.github/codeql/js-apps-tools-tests.yml
@@ -1,0 +1,11 @@
+name: CodeQL JavaScript apps, tools, and tests
+
+paths:
+  - apps
+  - desktop
+  - bin
+  - build-tools
+  - test
+  - .storybook
+  - .eslintrc.js
+  - babel.config.js

--- a/.github/codeql/js-client-components-lib.yml
+++ b/.github/codeql/js-client-components-lib.yml
@@ -1,0 +1,7 @@
+name: CodeQL JavaScript client components and libraries
+
+paths:
+  - client/components
+  - client/data
+  - client/layout
+  - client/lib

--- a/.github/codeql/js-client-dashboard.yml
+++ b/.github/codeql/js-client-dashboard.yml
@@ -1,0 +1,4 @@
+name: CodeQL JavaScript client dashboard
+
+paths:
+  - client/dashboard

--- a/.github/codeql/js-client-my-sites.yml
+++ b/.github/codeql/js-client-my-sites.yml
@@ -1,0 +1,4 @@
+name: CodeQL JavaScript client my-sites
+
+paths:
+  - client/my-sites

--- a/.github/codeql/js-client-other.yml
+++ b/.github/codeql/js-client-other.yml
@@ -1,0 +1,18 @@
+name: CodeQL JavaScript remaining client code
+
+paths:
+  - client
+
+paths-ignore:
+  - client/a8c-for-agencies
+  - client/blocks
+  - client/components
+  - client/dashboard
+  - client/data
+  - client/jetpack-cloud
+  - client/landing
+  - client/layout
+  - client/lib
+  - client/my-sites
+  - client/reader
+  - client/state

--- a/.github/codeql/js-client-product-surfaces.yml
+++ b/.github/codeql/js-client-product-surfaces.yml
@@ -1,0 +1,8 @@
+name: CodeQL JavaScript client product surfaces
+
+paths:
+  - client/a8c-for-agencies
+  - client/blocks
+  - client/jetpack-cloud
+  - client/landing
+  - client/reader

--- a/.github/codeql/js-client-state.yml
+++ b/.github/codeql/js-client-state.yml
@@ -1,0 +1,4 @@
+name: CodeQL JavaScript client state
+
+paths:
+  - client/state

--- a/.github/codeql/js-packages.yml
+++ b/.github/codeql/js-packages.yml
@@ -1,0 +1,4 @@
+name: CodeQL JavaScript packages
+
+paths:
+  - packages

--- a/.github/codeql/ruby.yml
+++ b/.github/codeql/ruby.yml
@@ -1,0 +1,4 @@
+name: CodeQL Ruby
+
+paths:
+  - desktop

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,78 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ trunk ]
+  pull_request:
+    branches: [ trunk ]
+    paths:
+      - '.github/codeql/**'
+      - '.github/workflows/codeql-analysis.yml'
+  schedule:
+    - cron: '37 7 * * 1'
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: actions
+            language: actions
+            config-file: ./.github/codeql/actions.yml
+          - name: ruby
+            language: ruby
+            config-file: ./.github/codeql/ruby.yml
+          - name: js-client-state
+            language: javascript-typescript
+            config-file: ./.github/codeql/js-client-state.yml
+          - name: js-client-my-sites
+            language: javascript-typescript
+            config-file: ./.github/codeql/js-client-my-sites.yml
+          - name: js-client-dashboard
+            language: javascript-typescript
+            config-file: ./.github/codeql/js-client-dashboard.yml
+          - name: js-client-components-lib
+            language: javascript-typescript
+            config-file: ./.github/codeql/js-client-components-lib.yml
+          - name: js-client-product-surfaces
+            language: javascript-typescript
+            config-file: ./.github/codeql/js-client-product-surfaces.yml
+          - name: js-client-other
+            language: javascript-typescript
+            config-file: ./.github/codeql/js-client-other.yml
+          - name: js-packages
+            language: javascript-typescript
+            config-file: ./.github/codeql/js-packages.yml
+          - name: js-apps-tools-tests
+            language: javascript-typescript
+            config-file: ./.github/codeql/js-apps-tools-tests.yml
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@dc73d59c2d7bd4f8194098a91219eeee6d8a1719 # v4
+        with:
+          languages: ${{ matrix.language }}
+          config-file: ${{ matrix.config-file }}
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@dc73d59c2d7bd4f8194098a91219eeee6d8a1719 # v4
+        with:
+          category: /language:${{ matrix.language }}/component:${{ matrix.name }}


### PR DESCRIPTION
Part of CodeQL tool status cleanup

## Proposed Changes

* Add an advanced CodeQL workflow for Actions, Ruby, and JavaScript/TypeScript.
* Split JavaScript/TypeScript analysis by repo area so the large Calypso client scan does not run as one repo-wide CodeQL job.
* Pin CodeQL and checkout actions by SHA and define minimal workflow permissions.

## Why are these changes being made?

* GitHub default setup is currently not configured after repeated JavaScript/TypeScript dynamic CodeQL failures on May 19, 2025. The last failed analyses returned `unsuccessful execution, exit code: 0`, while Actions scans completed quickly.
* Advanced setup gives us explicit path scoping and schedule control for default-branch tool health.

## Testing Instructions

* Verified the workflow and CodeQL config files parse as YAML.
* Ran `actionlint` 1.7.12 against `.github/workflows/codeql-analysis.yml`.
* Ran `git diff --check`.
* Confirm this PR starts the CodeQL workflow. The `pull_request` trigger is limited to the workflow and CodeQL config files, so this PR should validate the new setup.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
