### PR TITLE
Reader: Hide own Recommended Blogs list from profile Lists tab

### DIFF
--- a/client/reader/user-profile/views/lists.tsx
+++ b/client/reader/user-profile/views/lists.tsx
@@ -18,6 +18,9 @@ export const UserLists = ( { user }: UserListsProps ): JSX.Element => {
 	const userLogin = user.user_login ?? '';
 	const { data, isLoading, isFetched } = useQuery( readUserListsQuery( userLogin ) );
 	const lists = data?.lists ?? [];
+	const visibleLists = lists.filter(
+		( list: List ) => ! ( list.slug === 'recommended-blogs' && list.is_owner )
+	);
 
 	if ( isLoading || ! isFetched ) {
 		return (
@@ -27,7 +30,7 @@ export const UserLists = ( { user }: UserListsProps ): JSX.Element => {
 		);
 	}
 
-	if ( lists.length === 0 ) {
+	if ( visibleLists.length === 0 ) {
 		return (
 			<div className="user-profile__lists">
 				<EmptyContent
@@ -42,7 +45,7 @@ export const UserLists = ( { user }: UserListsProps ): JSX.Element => {
 
 	return (
 		<div className="user-profile__lists">
-			{ lists.map( ( list: List ) => {
+			{ visibleLists.map( ( list: List ) => {
 				let description: React.ReactNode = list.description;
 				if ( list.slug === 'recommended-blogs' ) {
 					description = translate( 'A list of blogs recommended by %s.', {

--- a/client/reader/user-profile/views/test/lists.test.tsx
+++ b/client/reader/user-profile/views/test/lists.test.tsx
@@ -148,6 +148,29 @@ describe( 'UserLists', () => {
 		expect( link?.getAttribute( 'href' ) ).toBe( '/reader/list/anotheruser/recommended-blogs' );
 	} );
 
+	test( 'should hide own recommended-blogs list and show empty content when there are no other lists', () => {
+		const mockLists: List[] = [
+			{
+				ID: 1,
+				title: 'Recommended Blogs',
+				description: '',
+				slug: 'recommended-blogs',
+				owner: 'test_user',
+				is_public: true,
+				is_owner: true,
+			},
+		];
+
+		const queryClient = createQueryClient();
+		queryClient.setQueryData( readUserListsQuery( 'test_user' ).queryKey, { lists: mockLists } );
+
+		renderWithQueryClient( <UserLists user={ defaultUser } />, { queryClient } );
+
+		expect( screen.getByTestId( 'empty-content' ) ).toBeInTheDocument();
+		expect( screen.getByTestId( 'empty-content-line' ) ).toHaveTextContent( 'No lists yet.' );
+		expect( screen.queryByText( 'Recommended Blogs' ) ).not.toBeInTheDocument();
+	} );
+
 	test( 'should display fallback description when list has no description', () => {
 		const mockLists: List[] = [
 			{


### PR DESCRIPTION
## Proposed Changes

Fixes READ-144.

This updates the Reader profile Lists tab to hide only the profile owner's own `recommended-blogs` list. That special list already has a dedicated Recommended Blogs tab, so showing it in Lists can leave the Lists tab looking populated when it should show the empty state.

This intentionally keeps another user's `recommended-blogs` list visible, preserving the existing flow where someone can open and subscribe to another user's Recommended Blogs list. That is the narrower behavior suggested after the earlier closed PR.

## Testing Instructions

- Visit your own Reader profile Lists tab where `Recommended Blogs` is the only list.
- Confirm the Lists tab shows `No lists yet.` instead of the Recommended Blogs list item.
- Visit another user profile whose Lists tab includes `Recommended Blogs`.
- Confirm their Recommended Blogs list still appears.

## Test Results

```
yarn test-client client/reader/user-profile/views/test/lists.test.tsx --runInBand
PASS client/reader/user-profile/views/test/lists.test.tsx
Tests: 6 passed, 6 total
```