### PR TITLE
Calypso products: keep plan term variants within the same group

### DIFF
--- a/packages/calypso-products/src/get-plan-term-variant.ts
+++ b/packages/calypso-products/src/get-plan-term-variant.ts
@@ -16,7 +16,7 @@ export function getPlanSlugForTermVariant(
 
 	if ( plan ) {
 		return Object.values( PLANS_LIST )
-			.filter( ( { type } ) => type === plan.type )
+			.filter( ( { group, type } ) => type === plan.type && group === plan.group )
 			.find( ( { term } ) => term === planTerm )
 			?.getStoreSlug();
 	}

--- a/packages/calypso-products/test/get-plan-term-variant.js
+++ b/packages/calypso-products/test/get-plan-term-variant.js
@@ -1,0 +1,33 @@
+import {
+	getPlanSlugForTermVariant,
+	PLAN_JETPACK_GROWTH_BI_YEARLY,
+	PLAN_JETPACK_GROWTH_MONTHLY,
+	PLAN_JETPACK_GROWTH_YEARLY,
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_PERSONAL_3_YEARS,
+	PLAN_PERSONAL_MONTHLY,
+	TERM_ANNUALLY,
+	TERM_BIENNIALLY,
+	TERM_TRIENNIALLY,
+} from '../src/index';
+
+describe( 'getPlanSlugForTermVariant', () => {
+	test( 'should return the matching plan variant for the requested term', () => {
+		expect( getPlanSlugForTermVariant( PLAN_JETPACK_GROWTH_MONTHLY, TERM_ANNUALLY ) ).toEqual(
+			PLAN_JETPACK_GROWTH_YEARLY
+		);
+		expect( getPlanSlugForTermVariant( PLAN_JETPACK_GROWTH_YEARLY, TERM_BIENNIALLY ) ).toEqual(
+			PLAN_JETPACK_GROWTH_BI_YEARLY
+		);
+		expect( getPlanSlugForTermVariant( PLAN_PERSONAL_MONTHLY, TERM_TRIENNIALLY ) ).toEqual(
+			PLAN_PERSONAL_3_YEARS
+		);
+	} );
+
+	test( 'should return undefined when no matching term variant exists', () => {
+		expect(
+			getPlanSlugForTermVariant( PLAN_JETPACK_PERSONAL_MONTHLY, TERM_BIENNIALLY )
+		).toBeUndefined();
+		expect( getPlanSlugForTermVariant( 'unknown_plan', TERM_ANNUALLY ) ).toBeUndefined();
+	} );
+} );


### PR DESCRIPTION
Part of #74640

## Proposed Changes

* add dedicated unit coverage for `getPlanSlugForTermVariant`
* verify the helper returns the expected variant across monthly, yearly, biennial, and triennial plan terms
* restrict term-variant lookups to plans in the same group so Jetpack plans do not resolve to WordPress.com plan variants with the same type

## Why are these changes being made?

* issue `#74640` called for follow-up tests around the `getPlanSlugForTermVariant` helper that was added for plan term switching
* while adding that coverage, the new test exposed that matching only on `type` can cross plan families and return a variant from a different product group
* filtering by both `group` and `type` keeps the helper aligned with the plan family the caller started from

## Testing Instructions

* run `yarn eslint packages/calypso-products/src/get-plan-term-variant.ts packages/calypso-products/test/get-plan-term-variant.js`
* run `yarn test-packages packages/calypso-products/test/get-plan-term-variant.js --runInBand`
* run `yarn workspace @automattic/calypso-products build`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?