### PR TITLE
Fix: show direct forum/support search on mobile nav (DOTCOM-17217)

### DIFF
--- a/apps/happy-blocks/block-library/search-card/index.php
+++ b/apps/happy-blocks/block-library/search-card/index.php
@@ -97,7 +97,7 @@ $website                 = isset( $args['website'] ) ? $args['website'] : '';
 			</div>
 
 			<!-- Search button -->
-			<?php if ( ! $should_show_search_navigation ) : ?>
+			<?php if ( $should_show_search_navigation ) : ?>
 			<div class="happy-blocks_navigation_search">
 				<a class="jetpack-search-filter__link" href="#">
 					<svg xmlns="http://www.w3.org/2000/svg" class="search-icon" width="24" height="24" viewBox="0 0 24 24" fill="#1E1E1E">


### PR DESCRIPTION
Part of DOTCOM-17217

## Proposed Changes

* In `apps/happy-blocks/block-library/search-card/index.php`, fix the **mobile** navigation search button condition. It used an inverted check (`! $should_show_search_navigation`), while the desktop copy used the correct non-inverted check. One-line change: the mobile button now uses the same condition as desktop.

## Why are these changes being made?

On the WordPress.com Forums and Support pages, the direct-search entry point (the "Search" link that opens the Jetpack Instant Search overlay) is rendered as two separate copies — one inside `.desktop-nav-container` and one inside `.mobile-nav-container`, with CSS swapping which container is visible at the 782px breakpoint.

Both copies originally shared the same condition (`! $is_front_page`). In #107527 the shared flag `$should_show_search_navigation` was introduced; the desktop copy was converted correctly, but the mobile copy was negated (`! $should_show_search_navigation`). As a result the mobile search button only rendered on 404 pages and was hidden everywhere else — including Forums and Support — so mobile/tablet users had no way to reach direct search and were pushed into the AI-assisted flow instead. Desktop was unaffected.

This change restores the desktop/mobile parity that existed before #107527.

## Testing Instructions

* The flag is computed server-side and does not vary by viewport; desktop and mobile are independent `<div>`s in separate containers, so this only affects the button inside `.mobile-nav-container` (visible only at ≤782px). Desktop rendering is unchanged.
* On a viewport ≤782px, open WordPress.com Forums / Support. **Before:** no search option in the nav (even in the hamburger area). **After:** the search icon appears in the mobile nav and opens the direct search overlay, matching desktop.
* Verified via code review and git history; not yet tested on a live support site. Reviewer input on live-site behavior welcome.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

---

Note: The linked Linear issue (DOTCOM-17217) was auto-marked "In Progress" when this PR opened. This is a Dotcom Bug Blitz contribution that is review-ready, not actively being worked by the owning engineering team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)