### PR TITLE
Fix: show 404 for unrecognized Reader paths instead of hanging (READ-130)

### DIFF
--- a/client/reader/index.ts
+++ b/client/reader/index.ts
@@ -5,6 +5,7 @@ import { getAnyLanguageRouteParam, getLanguageRouteParam } from '@automattic/i18
 import { addMiddleware } from 'redux-dynamic-middlewares';
 import {
 	makeLayout,
+	notFound,
 	redirectLoggedOut,
 	redirectLoggedOutToSignup,
 	render as clientRender,
@@ -276,6 +277,9 @@ export default async function (): Promise< void > {
 	);
 
 	setupReaderRedirects();
+
+	// Catch-all: show 404 for any unrecognized /reader/* path instead of hanging.
+	page( '/reader/*', notFound, makeLayout, clientRender );
 }
 
 /**


### PR DESCRIPTION
Fixes READ-130

## Proposed Changes

* Add a catch-all `/reader/*` route at the end of the Reader route setup that renders a standard "Page not found" view

## Why are these changes being made?

Visiting an unrecognized Reader URL (e.g. `wordpress.com/reader/asdfaljkaw34lkjbas`) caused the page to hang indefinitely with a console warning instead of showing a 404. The root cause: `sections-middleware` matched `/reader/*` paths and loaded the Reader JS chunk, but no registered `page()` route handled the unrecognized path, so no handler fired and nothing rendered.

The fix adds a catch-all route using the existing `notFound` controller middleware, placed after all specific Reader routes so valid paths are unaffected.

## Testing Instructions

1. Visit `https://wordpress.com/reader/asdfaljkaw34lkjbas` (or any invalid Reader path)
2. **Before:** page hangs, console shows a warning, nothing renders
3. **After:** standard "Page not found" page renders

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?

Note: Verified via code review and git history; not tested on a live site. Reviewer input on live-site behavior requested.

Note: The Linear issue was auto-marked "In Progress" when this PR opened. This is a Bug Blitz contribution pending review, not actively worked by an engineer.