### PR TITLE
fix(login): remove unused Jetpack Cloud class

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -12,7 +12,6 @@ import isAkismetRedirect from 'calypso/lib/akismet/is-akismet-redirect';
 import getGravatarOAuth2Flow from 'calypso/lib/get-gravatar-oauth2-flow';
 import { getSignupUrl, pathWithLeadingSlash } from 'calypso/lib/login';
 import {
-	isJetpackCloudOAuth2Client,
 	isA4AOAuth2Client,
 	isBlazeProOAuth2Client,
 	isGravatarFlowOAuth2Client,
@@ -574,8 +573,6 @@ class Login extends Component {
 					'is-akismet': isFromAkismet,
 					'is-jetpack': isJetpack,
 					'is-passport': isFromPassport,
-					// TODO: Confirm if `is-jetpack-cloud` is needed
-					'is-jetpack-cloud': isJetpackCloudOAuth2Client( oauth2Client ),
 					'is-automattic-for-agencies-flow': isFromAutomatticForAgenciesPlugin,
 					// TODO: Confirm if `is-a4a` is needed
 					'is-a4a': isA4AOAuth2Client( oauth2Client ),


### PR DESCRIPTION
Part of DOTCOM-13637

## Proposed Changes

* Remove the unused `is-jetpack-cloud` class from the login block wrapper.
* Remove the now-unused `isJetpackCloudOAuth2Client` import from the login block.

## Why are these changes being made?

The Jetpack Cloud-specific class on the inner login block appears to be unused. Jetpack Cloud styling still comes from the layout-level `jetpack-cloud` class, so this removes a stale class hook without changing the remaining Jetpack Cloud login layout behavior.

## Testing Instructions

* Run `ESLINT_USE_FLAT_CONFIG=false ./node_modules/.bin/eslint client/blocks/login/index.jsx`.
* Run `git diff --check`.
* Run `NODE_OPTIONS=--max-old-space-size=8192 ./node_modules/.bin/tsc --project client`.
* Confirm no `.login.is-jetpack-cloud` or `is-jetpack-cloud` login-block consumers remain in the focused login/signup/layout paths.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
