### PR TITLE
E2E: stabilize pattern insertion wait

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -35,6 +35,7 @@ const selectors = {
 
 	// Within the editor body.
 	blockWarning: '.block-editor-warning',
+	editorBlock: '.block-editor-block-list__block',
 
 	// Toast
 	toastViewPostLink: '.components-snackbar__content a:text-matches("View (Post|Page)", "i")',
@@ -284,7 +285,7 @@ export class EditorPage {
 		const enteredText = await this.editorGutenbergComponent.getText();
 
 		if ( text !== enteredText ) {
-			`Failed to verify entered text: got ${ enteredText }, expected ${ text }`;
+			throw new Error( `Failed to verify entered text: got ${ enteredText }, expected ${ text }` );
 		}
 	}
 
@@ -431,7 +432,7 @@ export class EditorPage {
 			// If it is not present, exit early.
 			try {
 				await blockInsertedPopupConfirmButtonLocator.waitFor( { timeout: 100 } );
-			} catch ( e ) {
+			} catch {
 				// Probably doesn't exist. That's ok.
 			}
 
@@ -510,6 +511,8 @@ export class EditorPage {
 		exactMatch = true
 	): Promise< Locator > {
 		const editorParent = await this.editor.parent();
+		const editorCanvas = await this.editor.canvas();
+		const editorBlockCountBefore = await editorCanvas.locator( selectors.editorBlock ).count();
 
 		await inserter.searchBlockInserter( patternName );
 		const locator = await inserter.selectBlockInserterResult( patternName, {
@@ -526,7 +529,21 @@ export class EditorPage {
 		const insertConfirmationToastLocator = editorParent.locator(
 			`.components-snackbar__content:text('Block pattern "${ actualPatternName }" inserted.')`
 		);
-		await insertConfirmationToastLocator.waitFor();
+		const insertedBlockLocator = editorCanvas
+			.locator( selectors.editorBlock )
+			.nth( editorBlockCountBefore );
+
+		try {
+			await Promise.any( [
+				insertConfirmationToastLocator.waitFor( { timeout: 15 * 1000 } ),
+				insertedBlockLocator.waitFor( { timeout: 15 * 1000 } ),
+			] );
+		} catch ( error ) {
+			throw new Error(
+				`Timed out waiting for pattern "${ actualPatternName }" to finish inserting.`,
+				{ cause: error }
+			);
+		}
 		return locator;
 	}
 


### PR DESCRIPTION
Part of TESTOPS-116

## Proposed Changes

* Update `EditorPage.addPatternFromInserter()` so pattern insertion waits for either the old confirmation snackbar or editor block-count growth after selecting a pattern.
* Fix two existing lint issues in the same helper file so targeted validation passes.

## Why are these changes being made?

* WPCom Tests Gutenberg Atomic Nightly repeatedly failed after inserting the About pattern because the helper waited only for the confirmation snackbar.
* Artifacts show the pattern was inserted and selected, but the snackbar did not appear.
* This keeps the old snackbar contract while accepting a direct editor insertion signal.

## Testing Instructions

* Review the changed helper and confirm it still waits after selecting a pattern.
* Run `yarn eslint packages/calypso-e2e/src/lib/pages/editor-page.ts`.
* Run `yarn prettier --check packages/calypso-e2e/src/lib/pages/editor-page.ts`.
* Run `yarn workspace @automattic/calypso-e2e build`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?