### PR TITLE
Add sidebar move menu affordance parity

### DIFF
--- a/client/my-sites/sidebar/customize/customize-mode.scss
+++ b/client/my-sites/sidebar/customize/customize-mode.scss
@@ -457,7 +457,7 @@ li.admin-sidebar-drop-indicator {
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
-	width: 22px;
+	width: 0;
 	height: 28px;
 	margin-left: 8px;
 	color: inherit;
@@ -466,6 +466,22 @@ li.admin-sidebar-drop-indicator {
 	line-height: 1;
 	background: transparent;
 	border: 0;
+	opacity: 0;
+	overflow: hidden;
+	pointer-events: none;
+	position: relative;
+	transition: opacity 120ms ease;
+	z-index: 2;
+
+	.sidebar__menu-item-parent:hover &,
+	.sidebar__menu-item-parent:focus-within &,
+	.sidebar__heading:hover &,
+	.sidebar__heading:focus-within &,
+	&[aria-expanded='true'] {
+		width: 22px;
+		opacity: 1;
+		pointer-events: auto;
+	}
 
 	&:focus-visible {
 		outline: 2px solid var( --wp-admin-sidebar-customizer-theme, #2271b1 );

--- a/client/my-sites/sidebar/customize/move-menu.tsx
+++ b/client/my-sites/sidebar/customize/move-menu.tsx
@@ -29,7 +29,7 @@ interface MoveMenuProps {
 	itemId: string;
 	itemLabel: string;
 	triggerEl: HTMLElement | null;
-	onClose: () => void;
+	onClose: ( options?: { blurTrigger?: boolean } ) => void;
 }
 
 interface MenuChoice {
@@ -182,7 +182,7 @@ export const MoveMenu = ( { itemId, itemLabel, triggerEl, onClose }: MoveMenuPro
 			if ( triggerEl?.contains( target ) ) {
 				return;
 			}
-			onClose();
+			onClose( { blurTrigger: true } );
 		};
 		const handleClickAway = ( ev: MouseEvent ) => {
 			const target = ev.target instanceof Element ? ev.target : null;
@@ -195,7 +195,7 @@ export const MoveMenu = ( { itemId, itemLabel, triggerEl, onClose }: MoveMenuPro
 			if ( triggerEl?.contains( target ) ) {
 				return;
 			}
-			onClose();
+			onClose( { blurTrigger: true } );
 		};
 		const handleKey = ( ev: KeyboardEvent ) => {
 			if ( ev.key === 'Escape' ) {

--- a/client/my-sites/sidebar/customize/test/item-keyboard.tsx
+++ b/client/my-sites/sidebar/customize/test/item-keyboard.tsx
@@ -57,11 +57,43 @@ describe( '<MySitesSidebarUnifiedItem> customize keyboard behaviour', () => {
 		const link = container.querySelector( 'a.sidebar__menu-link' ) as HTMLAnchorElement;
 		expect( link ).toHaveAttribute( 'tabindex', '-1' );
 		expect( screen.getByRole( 'button', { name: 'Reorder Stats' } ) ).toBeInTheDocument();
-		expect( screen.getByRole( 'button', { name: 'More options' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'More options' } ) ).toHaveTextContent( '⋮' );
 
 		fireEvent.click( link );
 
 		expect( trackClickEvent ).not.toHaveBeenCalled();
 		expect( window.scrollTo ).not.toHaveBeenCalled();
+	} );
+
+	it( 'hides the more-options trigger from focus after click-close', () => {
+		const { container } = renderInProvider(
+			<CustomizeProvider>
+				<EnterButton />
+				<MySitesSidebarUnifiedItem
+					title="Stats"
+					slug="stats"
+					url="https://example.com/stats"
+					icon="stats"
+					inlineIcon={ null }
+					itemId="stats"
+					reassignable
+					shouldOpenExternalLinksInCurrentTab
+				/>
+			</CustomizeProvider>
+		);
+
+		act( () => {
+			screen.getByRole( 'button', { name: 'Enter' } ).click();
+		} );
+
+		const trigger = screen.getByRole( 'button', { name: 'More options' } );
+		trigger.focus();
+		fireEvent.click( trigger );
+		expect( trigger ).toHaveAttribute( 'aria-expanded', 'true' );
+
+		fireEvent.click( trigger );
+
+		expect( trigger ).toHaveAttribute( 'aria-expanded', 'false' );
+		expect( container.ownerDocument.activeElement ).not.toBe( trigger );
 	} );
 } );

--- a/client/my-sites/sidebar/customize/test/menu-keyboard.tsx
+++ b/client/my-sites/sidebar/customize/test/menu-keyboard.tsx
@@ -82,7 +82,7 @@ describe( '<MySitesSidebarUnifiedMenu> customize keyboard behaviour', () => {
 		expect( row ).toBeInTheDocument();
 		expect( heading ).toHaveAttribute( 'tabindex', '-1' );
 		expect( screen.getByRole( 'button', { name: 'Reorder Upgrades' } ) ).toBeInTheDocument();
-		expect( screen.getByRole( 'button', { name: 'More options' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'More options' } ) ).toHaveTextContent( '⋮' );
 		expect( screen.queryByRole( 'button', { name: 'Reorder Plans' } ) ).not.toBeInTheDocument();
 	} );
 

--- a/client/my-sites/sidebar/item.jsx
+++ b/client/my-sites/sidebar/item.jsx
@@ -78,9 +78,19 @@ export const MySitesSidebarUnifiedItem = ( {
 	const handleMoreClick = useCallback( ( ev ) => {
 		ev.preventDefault();
 		ev.stopPropagation();
-		setMoveMenuOpen( ( open ) => ! open );
+		setMoveMenuOpen( ( open ) => {
+			if ( open && typeof moreRef.current?.blur === 'function' ) {
+				moreRef.current.blur();
+			}
+			return ! open;
+		} );
 	}, [] );
-	const handleMoveMenuClose = useCallback( () => setMoveMenuOpen( false ), [] );
+	const handleMoveMenuClose = useCallback( ( options = {} ) => {
+		setMoveMenuOpen( false );
+		if ( options.blurTrigger && typeof moreRef.current?.blur === 'function' ) {
+			moreRef.current.blur();
+		}
+	}, [] );
 
 	const onNavigate = () => {
 		if ( typeof trackClickEvent === 'function' ) {
@@ -157,7 +167,7 @@ export const MySitesSidebarUnifiedItem = ( {
 						}
 					} }
 				>
-					⋯
+					⋮
 				</span>
 			) }
 			{ showCustomizeDecorations && moveMenuOpen && (

--- a/client/my-sites/sidebar/menu.jsx
+++ b/client/my-sites/sidebar/menu.jsx
@@ -65,9 +65,19 @@ export const MySitesSidebarUnifiedMenu = ( menuProps ) => {
 	const handleMoreClick = useCallback( ( ev ) => {
 		ev.preventDefault();
 		ev.stopPropagation();
-		setMoveMenuOpen( ( open ) => ! open );
+		setMoveMenuOpen( ( open ) => {
+			if ( open && typeof moreRef.current?.blur === 'function' ) {
+				moreRef.current.blur();
+			}
+			return ! open;
+		} );
 	}, [] );
-	const handleMoveMenuClose = useCallback( () => setMoveMenuOpen( false ), [] );
+	const handleMoveMenuClose = useCallback( ( options = {} ) => {
+		setMoveMenuOpen( false );
+		if ( options.blurTrigger && typeof moreRef.current?.blur === 'function' ) {
+			moreRef.current.blur();
+		}
+	}, [] );
 	const showAsExpanded =
 		( isMobile && ( childIsSelected || isExpanded ) ) || // For mobile breakpoints, we dont' care about the sidebar collapsed status.
 		( isDesktop && childIsSelected && ! sidebarCollapsed ); // For desktop breakpoints, a child should be selected and the sidebar being expanded.
@@ -171,7 +181,7 @@ export const MySitesSidebarUnifiedMenu = ( menuProps ) => {
 									}
 								} }
 							>
-								⋯
+								⋮
 							</span>
 							{ moveMenuOpen && (
 								<MoveMenu


### PR DESCRIPTION
Part of https://github.com/WordPress/wp-admin-sidebar/pull/83

## Proposed Changes

* Match the quieter move-menu affordance from the upstream sidebar PR.
* Show the more-options control only when a sidebar row is hovered, focused, or has an open menu.
* Use the vertical ellipsis affordance for the move menu trigger.

## Why are these changes being made?

The sidebar customizer has a non-drag path for moving items, but showing that control on every row makes the sidebar feel crowded. This keeps the control available on hover and keyboard focus while making the default state quieter.

## Testing Instructions

* Start Calypso and open a site with the wp-admin sidebar redesign enabled.
* Enter sidebar customize mode.
* Confirm the move-menu trigger is hidden by default.
* Hover or keyboard-focus a reassignable row and confirm the trigger appears as a vertical ellipsis.
* Open the trigger, close it by clicking it again, and confirm it disappears when focus leaves the row.
* Open the trigger again and confirm the move menu actions still work.

Manual verification:

* Studio `paysite` wp-admin customizer passed.
* Local Calypso on `chriskmnds.wordpress.com` passed.

Automated checks run:

* `node node_modules/jest/bin/jest.js -c=test/client/jest.config.js --runTestsByPath client/my-sites/sidebar/customize/test/item-keyboard.tsx client/my-sites/sidebar/customize/test/menu-keyboard.tsx client/my-sites/sidebar/customize/test/move-menu.tsx --runInBand`
* `git diff --check`

Note: the local pre-commit hook could not run because Volta reports that Yarn is unavailable in this shell. The targeted tests above were run directly through the repo checkout.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

