### PR TITLE
E2E: click selected page template option

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -237,14 +237,18 @@ export class EditorPage {
 	/**
 	 * Select a template from the grid of options.
 	 *
-	 * @param {string} label Label for the template (the string underneath the preview).
+	 * @param {string|Locator} template Template label or already-located template option.
 	 * @param param1 Keyed object parameter.
 	 * @param {number} param1.timeout Timeout to apply.
 	 */
 	async selectTemplate(
-		label: string,
+		template: string | Locator,
 		{ timeout = envVariables.TIMEOUT }: { timeout?: number } = {}
 	) {
+		if ( typeof template !== 'string' ) {
+			return await template.click( { timeout } );
+		}
+
 		const editor = await this.getEditorParent();
 		const inserterSelector = await editor.getByRole( 'listbox', { name: 'All' } );
 		const modalSelector = await editor.getByRole( 'listbox', {
@@ -252,7 +256,7 @@ export class EditorPage {
 		} );
 		return await inserterSelector
 			.or( modalSelector )
-			.getByRole( 'option', { name: label, exact: true } )
+			.getByRole( 'option', { name: template, exact: true } )
 			.first()
 			.click( { timeout: timeout } );
 	}

--- a/test/e2e/specs/editor-tracking/editor-tracking__block-inserted-event.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__block-inserted-event.ts
@@ -177,8 +177,7 @@ describe(
 						.getByRole( 'option' )
 						.first();
 
-					const pageTemplateToSelect = ( await firstPattern.getAttribute( 'aria-label' ) ) ?? '';
-					await editorPage.selectTemplate( pageTemplateToSelect, { timeout: 15 * 1000 } );
+					await editorPage.selectTemplate( firstPattern, { timeout: 15 * 1000 } );
 				} );
 
 				it( '"wpcom_block_inserted" event fires with "from_template_selector" set to true', async function () {

--- a/test/e2e/specs/editor/editor__page-basic-flow.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.ts
@@ -40,7 +40,6 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Page Flow' ), function () 
 	let editorPage: EditorPage;
 	let pagesPage: PagesPage;
 	let publishedUrl: URL;
-	let pageTemplateToSelect: string;
 	let pageTemplateFirstTextContent: string;
 
 	beforeAll( async () => {
@@ -90,8 +89,7 @@ describe( DataHelper.createSuiteTitle( 'Editor: Basic Page Flow' ), function () 
 				.textContent() ) || '';
 
 		pageTemplateFirstTextContent = pageTemplateFirstTextContent.trim();
-		pageTemplateToSelect = ( await selectedPatternLocator.getAttribute( 'aria-label' ) ) ?? '';
-		await editorPage.selectTemplate( pageTemplateToSelect, { timeout: 15 * 1000 } );
+		await editorPage.selectTemplate( selectedPatternLocator, { timeout: 15 * 1000 } );
 	} );
 
 	it( 'Template content loads into editor', async function () {


### PR DESCRIPTION
Part of TESTOPS-116

## Proposed Changes

* Allow `EditorPage.selectTemplate()` to click an already-located template option.
* Update page-template E2E callers to pass the pattern option they already found, instead of re-querying by exact accessible name.

## Why are these changes being made?

* Follow-up to #111270.
* Personal Gutenberg Atomic Nightly mobile verification no longer hit the old snackbar timeout, but still failed earlier while clicking the visible `About 12` pattern option.
* The test already had the target option locator. Reusing that locator avoids a second brittle exact-name lookup in the pattern picker.

## Testing Instructions

* Run `yarn eslint packages/calypso-e2e/src/lib/pages/editor-page.ts test/e2e/specs/editor/editor__page-basic-flow.ts test/e2e/specs/editor-tracking/editor-tracking__block-inserted-event.ts`.
* Run `yarn prettier --check packages/calypso-e2e/src/lib/pages/editor-page.ts test/e2e/specs/editor/editor__page-basic-flow.ts test/e2e/specs/editor-tracking/editor-tracking__block-inserted-event.ts`.
* Run `yarn workspace @automattic/calypso-e2e build`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?