### PR TITLE
E2E: update Gutenberg navigator API check

### DIFF
--- a/test/e2e/specs/infrastructure/infrastructure__experimental-gutenberg.ts
+++ b/test/e2e/specs/infrastructure/infrastructure__experimental-gutenberg.ts
@@ -38,7 +38,7 @@ describe( DataHelper.createSuiteTitle( 'Gutenberg: Experimental Features' ), fun
 	it.each( [
 		[ 'blockEditor', '__unstableInserterMenuExtension', 'function' ],
 		[ 'date', '__experimentalGetSettings', 'function' ],
-		[ 'components', '__experimentalNavigationBackButton', 'object' ],
+		[ 'components', '__experimentalNavigatorBackButton', 'object' ],
 		[ 'editPost', '__experimentalMainDashboardButton', 'function' ],
 	] )(
 		'Experimental package %s and feature %s are available',


### PR DESCRIPTION
Part of TESTOPS-109

## Proposed Changes

* Update the Gutenberg experimental feature check from `__experimentalNavigationBackButton` to `__experimentalNavigatorBackButton`.

## Why are these changes being made?

* WPCom Tests Gutenberg runs repeatedly fail because the old `NavigationBackButton` experimental export is no longer present in the runtime.
* Calypso code currently depends on `__experimentalNavigatorBackButton`, and that export is already allowed in the unsafe WordPress API allowlist.
* This keeps the infrastructure check aligned with the experimental API Calypso actually uses.

## Testing Instructions

* Run `yarn eslint test/e2e/specs/infrastructure/infrastructure__experimental-gutenberg.ts`.
* Run `yarn prettier --check test/e2e/specs/infrastructure/infrastructure__experimental-gutenberg.ts`.
* Run `yarn workspace @automattic/calypso-e2e build`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?