### PR TITLE
Add OpenAI advertising base tracking pixel

### DIFF
--- a/client/lib/analytics/ad-tracking/constants.js
+++ b/client/lib/analytics/ad-tracking/constants.js
@@ -40,6 +40,7 @@ export const PINTEREST_SCRIPT_URL = 'https://s.pinimg.com/ct/core.js';
 export const PARSLEY_SCRIPT_URL = 'https://cdn.parsely.com/keys/wordpress.com/p.js?ver=3.3.2';
 // We're storing the pixel ID separately to reuse it, but it needs to be passed in the URL.
 export const TIKTOK_SCRIPT_URL = 'https://analytics.tiktok.com/i18n/pixel/events.js?sdkid=';
+export const OPENAI_SCRIPT_URL = 'https://bzrcdn.openai.com/sdk/oaiq.min.js';
 export const TRACKING_IDS = {
 	bingInit: '4074038',
 	criteo: '31321',
@@ -78,6 +79,7 @@ export const TRACKING_IDS = {
 	parselyTracker: 'wordpress.com',
 	wpcomLinkedinId: '7224796',
 	tiktokPixelId: 'D5JLDS3C77UAODHQ56P0',
+	openAIPixelId: 'P5UDeK78Yenagza4gXqkds',
 };
 // This name is something we created to store a session id for DCM Floodlight session tracking
 export const DCM_FLOODLIGHT_SESSION_COOKIE_NAME = 'dcmsid';

--- a/client/lib/analytics/ad-tracking/load-tracking-scripts.js
+++ b/client/lib/analytics/ad-tracking/load-tracking-scripts.js
@@ -22,6 +22,7 @@ import {
 	REDDIT_TRACKING_SCRIPT_URL,
 	TIKTOK_SCRIPT_URL,
 	WPCOM_REDDIT_PIXEL_ID,
+	OPENAI_SCRIPT_URL,
 } from './constants';
 import { circularReferenceSafeJSONStringify } from './debug';
 import { setup } from './setup';
@@ -127,6 +128,10 @@ function getTrackingScriptsToLoad() {
 	// The pixel must be loaded with the ID in the URL.
 	if ( mayWeTrackByTracker( 'tiktok' ) ) {
 		scripts.push( TIKTOK_SCRIPT_URL + TRACKING_IDS.tiktokPixelId );
+	}
+
+	if ( mayWeTrackByTracker( 'openai' ) ) {
+		scripts.push( OPENAI_SCRIPT_URL );
 	}
 
 	return scripts;

--- a/client/lib/analytics/ad-tracking/setup.js
+++ b/client/lib/analytics/ad-tracking/setup.js
@@ -112,6 +112,9 @@ export function setup() {
 		if ( mayWeInitTracker( 'tiktok' ) ) {
 			setupTikTokGlobal();
 		}
+		if ( mayWeInitTracker( 'openai' ) ) {
+			setupOpenAIGlobal();
+		}
 	}
 }
 
@@ -300,6 +303,19 @@ function setupTikTokGlobal() {
 	} );
 }
 
+/**
+ * Sets up the OpenAI advertising pixel based on the obfuscated code provided by OpenAI.
+ */
+function setupOpenAIGlobal() {
+	if ( window.oaiq ) {
+		return;
+	}
+	const q = function () {
+		q.q.push( arguments );
+	};
+	q.q = [];
+	window.oaiq = q;
+}
 function setupGtag() {
 	if ( window.dataLayer && window.gtag ) {
 		return;

--- a/client/lib/analytics/tracker-buckets.ts
+++ b/client/lib/analytics/tracker-buckets.ts
@@ -9,6 +9,7 @@ import {
 } from 'calypso/lib/analytics/utils';
 import { isE2ETest } from 'calypso/lib/e2e';
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const allAdTrackers = [
 	'bing',
 	'floodlight',
@@ -35,6 +36,7 @@ const allAdTrackers = [
 	'clarity',
 	'reddit',
 	'tiktok',
+	'openai',
 ] as const;
 
 const sessionAdTrackers = [ 'hotjar', 'logrocket' ];
@@ -65,6 +67,7 @@ export const AdTrackersBuckets: { [ key in AdTracker ]: Bucket | null } = {
 	reddit: Bucket.ADVERTISING,
 	linkedin: Bucket.ADVERTISING,
 	tiktok: Bucket.ADVERTISING,
+	openai: Bucket.ADVERTISING,
 	quora: Bucket.ADVERTISING,
 
 	// Disabled trackers:
@@ -104,6 +107,7 @@ export const AdTrackersInitGuards: Partial< { [ key in AdTracker ]: () => boolea
 	clarity: () => 'clarity' in window,
 	reddit: () => 'rdt' in window,
 	tiktok: () => 'ttq' in window,
+	openai: () => 'oaiq' in window,
 };
 
 const isTrackerIntialized = ( tracker: AdTracker ): boolean => {

--- a/client/lib/analytics/utils/get-exceptions.ts
+++ b/client/lib/analytics/utils/get-exceptions.ts
@@ -14,6 +14,7 @@ const getExceptions = (): Partial< Record< AdTracker, boolean > > => {
 		facebook: region === 'california' && countryCode === 'us',
 		tiktok: region === 'california' && countryCode === 'us',
 		quora: region === 'california' && countryCode === 'us',
+		openai: region === 'california' && countryCode === 'us',
 	};
 };
 

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -651,6 +651,7 @@ function setUpCSP( req, res, next ) {
 			'www.redditstatic.com', // Reddit tracking pixel
 			'https://analytics.tiktok.com', // TikTok tracking pixel
 			'https://bzrcdn.openai.com/', // OpenAI tracking pixel
+			'https://bzr.openai.com/', // OpenAI tracking pixel
 			'https://a.quora.com', // Quora tracking pixel.
 			'www.googletagmanager.com',
 			'https://accounts.google.com',

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -650,6 +650,7 @@ function setUpCSP( req, res, next ) {
 			'https://snap.licdn.com', // LinkedIn analytics
 			'www.redditstatic.com', // Reddit tracking pixel
 			'https://analytics.tiktok.com', // TikTok tracking pixel
+			'https://bzrcdn.openai.com/', // OpenAI tracking pixel
 			'https://a.quora.com', // Quora tracking pixel.
 			'www.googletagmanager.com',
 			'https://accounts.google.com',


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of M4R73CH-1898

## Proposed Changes

* Add the base OpenAI advertising pixel.
* Rewrite the provided obfuscated pixel so we can load it using the privacy toolkit.
* Respect the California exception, similar to what we're doing for Meta.
* Update CSP to be able to load content from https://bzrcdn.openai.com.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- To support upcoming OpenAI Ads campaigns.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `setup/onboarding/domains` and make sure you clear the sensitive_pixel_options cookie if set.
* Visit `setup/onboarding/domains?flags=ad-tracking,cookie-banner` , confirm there are no console errors and no script containing openai is loaded.
* Click on Customize, accept Analytics but not Advertising and click Accept selection. Confirm there are no console errors and no script containing openai is loaded.
* Clear the sensitive_pixel_options cookie and refresh the page.
* Accept Advertising and confirm there are no console errors and the pixel: https://bzrcdn.openai.com/sdk/oaiq.min.js was loaded successfully.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
