### PR TITLE
Drop redundant observe-typing hunk from the @wordpress/block-editor patch

### DIFF
--- a/.yarn/patches/@wordpress-block-editor-npm-15.20.0-2d52fc5cc4.patch
+++ b/.yarn/patches/@wordpress-block-editor-npm-15.20.0-2d52fc5cc4.patch
@@ -1,29 +1,3 @@
-diff --git a/build/components/observe-typing/index.cjs b/build/components/observe-typing/index.cjs
-index d0a91bd3f067026f713603c9b1bf6a375181b0b2..92210e9f91743d220a9aadee317db9ab05c382b4 100644
---- a/build/components/observe-typing/index.cjs
-+++ b/build/components/observe-typing/index.cjs
-@@ -116,7 +116,7 @@ function useTypingObserver() {
-           stopTypingOnSelectionUncollapse2
-         );
-         return () => {
--          node.ownerDocument.defaultView.clearTimeout(timerId);
-+          node.ownerDocument.defaultView?.clearTimeout(timerId);
-           node.removeEventListener(
-             "focus",
-             stopTypingOnNonTextField2
-diff --git a/build-module/components/observe-typing/index.mjs b/build-module/components/observe-typing/index.mjs
-index c2cb4a1d326cb0513cdd4e2d795c76d022622530..a13417f8a882d7908e42db755cbba47abf6c62a7 100644
---- a/build-module/components/observe-typing/index.mjs
-+++ b/build-module/components/observe-typing/index.mjs
-@@ -99,7 +99,7 @@ function useTypingObserver() {
-           stopTypingOnSelectionUncollapse2
-         );
-         return () => {
--          node.ownerDocument.defaultView.clearTimeout(timerId);
-+          node.ownerDocument.defaultView?.clearTimeout(timerId);
-           node.removeEventListener(
-             "focus",
-             stopTypingOnNonTextField2
 diff --git a/package.json b/package.json
 index a127d31c1fbdc56301fe78f2c0713f135afce2a1..d2121720e3a94873a104f79931c3ccb7dc47fd85 100644
 --- a/package.json

--- a/yarn.lock
+++ b/yarn.lock
@@ -10992,7 +10992,7 @@ __metadata:
 
 "@wordpress/block-editor@patch:@wordpress/block-editor@npm%3A15.20.0#~/.yarn/patches/@wordpress-block-editor-npm-15.20.0-2d52fc5cc4.patch":
   version: 15.20.0
-  resolution: "@wordpress/block-editor@patch:@wordpress/block-editor@npm%3A15.20.0#~/.yarn/patches/@wordpress-block-editor-npm-15.20.0-2d52fc5cc4.patch::version=15.20.0&hash=179576"
+  resolution: "@wordpress/block-editor@patch:@wordpress/block-editor@npm%3A15.20.0#~/.yarn/patches/@wordpress-block-editor-npm-15.20.0-2d52fc5cc4.patch::version=15.20.0&hash=ae8e93"
   dependencies:
     "@react-spring/web": "npm:^9.4.5"
     "@wordpress/a11y": "npm:^4.47.0"
@@ -11049,7 +11049,7 @@ __metadata:
   peerDependencies:
     react: ^19.2.4
     react-dom: ^19.2.4
-  checksum: 5cd0876dd2782fceda4a1f8cfd400a1bef5c638956f811c4577f3ce6de99adbe76a7c6702e13566d5a8e4588337a8926408c19f2505165458fb8931c38be9661
+  checksum: 79b40cba95cb4adb38fdb6ee64d33bba212db183950b0a2223df959ea613fc31e0e29f45bc4bf09e809654dfb99e581c2f4f32bfa3408cec269b664eb9df6a3e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Part of DOTCOM-17286

Follow-up to #111123, which introduced the `@wordpress/block-editor` yarn patch. The root-cause fix for the crash that patch guarded actually landed earlier, in #111100.

## Proposed Changes

* Remove the two `observe-typing` hunks from `.yarn/patches/@wordpress-block-editor-npm-15.20.0-…patch` (the `defaultView?.clearTimeout` optional-chaining in `useTypingObserver`).
* Keep the patch's `package.json` `exports` hunk, which surfaces `./build-module/components/iframe/get-compatibility-styles` — still deep-imported by `packages/verbum-block-editor`.
* `yarn.lock` updates to the new patch hash/checksum.

## Why are these changes being made?

The optional-chaining hunk guarded an iframe-unmount crash — `TypeError: Cannot read properties of null (reading 'clearTimeout')` thrown by `useTypingObserver`'s effect cleanup when the editor iframe is detached while typing.

That crash only occurs when the iframe's document is torn down out-of-band (its `defaultView` becomes `null`) while the React subtree inside it is still mounted. In the Reader quick-post editor the only trigger was the iframe **regenerating its blob `src`** mid-typing: `Iframe` derives `src` from a `WeakMap` keyed on `settings.__unstableResolvedAssets`, so a fresh `settings` object every render produced a new blob URL and forced the iframe to navigate.

That root cause is already fixed by the `useMemo` in `packages/verbum-block-editor/src/editor/index.tsx`, which freezes the `settings` identity (and therefore `__unstableResolvedAssets`). With a stable key the iframe never navigates while typing, `defaultView` never goes null, and the guarded line is never reached. The optional-chaining is therefore dead code for this consumer — and a per-bump maintenance cost (the patch must be re-verified on every `@wordpress/block-editor` upgrade).

**Trade-off / residual risk:** this removes a defense-in-depth guard. It would matter again only if (a) `settings` identity is allowed to churn mid-typing in the future (the memo's only dependency is `isRTL`), or (b) another consumer renders this iframe with an unstable settings object. The durable alternative is to upstream the optional-chaining to Gutenberg (it mirrors the existing `defaultView` guard on `bodyRef` in `iframe/index.js`) and drop it from here once a release ships; this PR opts to simply remove the now-redundant local patch.

## Testing Instructions

Verified three ways that dropping the hunk does not reintroduce the crash:

1. **Source** — the iframe blob-`src` is `WeakMap`-keyed on `settings.__unstableResolvedAssets`; the verbum `useMemo` freezes it.
2. **Isolated harness** — a minimal page driving the real `@wordpress/block-editor` `BlockCanvas`/`Iframe`/`useTypingObserver` in headless Chrome, with typing mode on. Matrix result: the `clearTimeout` `TypeError` fires **only** with the patch reverted **and** an unstable settings identity; with the patch reverted **and** memoized settings it is clean.
3. **Real app** — `yarn start`, open `http://calypso.localhost:3000/reader` logged in to an account with ≥1 site. In the quick-post editor (top of the Following feed) with the console open: type (no toolbar flicker), click **Post** / **Edit** (remounts via the `key` bump), and navigate away while mounted. No `Cannot read properties of null (reading 'clearTimeout')`.

To reproduce the crash this guard used to catch, temporarily make the verbum `settings` a fresh object per render (remove the `useMemo`) — the `TypeError` returns.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
