### PR TITLE
A4A Migrations: handle new 'ineligible' commission status

### DIFF
--- a/client/a8c-for-agencies/sections/migrations/commissions-list/commission-columns.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/commission-columns.tsx
@@ -21,11 +21,9 @@ export const MigratedOnColumn = ( { migratedOn }: { migratedOn: number } ) => {
 export const ReviewStatusColumn = ( {
 	reviewStatus,
 	rejectionReason,
-	canTagSitesForCommission,
 }: {
 	reviewStatus: string;
 	rejectionReason?: string;
-	canTagSitesForCommission: boolean;
 } ) => {
 	const translate = useTranslate();
 	const buttonRef = useRef< HTMLButtonElement | null >( null );
@@ -53,24 +51,21 @@ export const ReviewStatusColumn = ( {
 					statusText: translate( 'Ineligible' ),
 					statusType: 'info',
 				};
+			case 'ineligible':
+				return {
+					statusText: translate( 'Ineligible' ),
+					statusType: 'info',
+				};
 			case 'reverification':
 				return {
 					statusText: translate( 'Pending re-verification' ),
 					statusType: 'info',
 				};
 			case 'pending':
-				// Agencies still eligible for the Pressable migration incentive see a real
-				// "Pending" review state; for everyone else the incentive has ended, so a
-				// pending migration is effectively ineligible.
-				return canTagSitesForCommission
-					? {
-							statusText: translate( 'Pending' ),
-							statusType: 'warning',
-					  }
-					: {
-							statusText: translate( 'Ineligible' ),
-							statusType: 'info',
-					  };
+				return {
+					statusText: translate( 'Pending' ),
+					statusType: 'warning',
+				};
 			default:
 				// Unknown status - don't show a badge
 				return null;
@@ -92,7 +87,7 @@ export const ReviewStatusColumn = ( {
 		/>
 	);
 
-	if ( reviewStatus === 'rejected' && rejectionReason ) {
+	if ( ( reviewStatus === 'rejected' || reviewStatus === 'ineligible' ) && rejectionReason ) {
 		return (
 			<span className="commission-columns__rejected-status">
 				{ badge }

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/index.tsx
@@ -23,12 +23,10 @@ export default function MigrationsCommissionsList( {
 	items,
 	fetchMigratedSites,
 	migrationTags,
-	canTagSitesForCommission,
 }: {
 	items: TaggedSite[];
 	fetchMigratedSites: () => void;
 	migrationTags: string[];
-	canTagSitesForCommission: boolean;
 } ) {
 	const translate = useTranslate();
 
@@ -96,7 +94,6 @@ export default function MigrationsCommissionsList( {
 						<ReviewStatusColumn
 							reviewStatus={ item.incentive_status }
 							rejectionReason={ item.incentive_rejection_reason }
-							canTagSitesForCommission={ canTagSitesForCommission }
 						/>
 					);
 				},
@@ -104,7 +101,7 @@ export default function MigrationsCommissionsList( {
 				enableSorting: false,
 			},
 		],
-		[ translate, canTagSitesForCommission ]
+		[ translate ]
 	);
 
 	return (
@@ -136,11 +133,7 @@ export default function MigrationsCommissionsList( {
 					</ItemsDataViews>
 				</div>
 			) : (
-				<MigrationsCommissionsListMobileView
-					commissions={ items }
-					actions={ actions }
-					canTagSitesForCommission={ canTagSitesForCommission }
-				/>
+				<MigrationsCommissionsListMobileView commissions={ items } actions={ actions } />
 			) }
 
 			{ activeModal?.kind === 'untag' && (

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/mobile-view.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/mobile-view.tsx
@@ -13,11 +13,9 @@ import './style.scss';
 
 export default function MigrationsCommissionsListMobileView( {
 	commissions,
-	canTagSitesForCommission,
 	actions,
 }: {
 	commissions: TaggedSite[];
-	canTagSitesForCommission: boolean;
 	actions: Action[];
 } ) {
 	const translate = useTranslate();
@@ -44,10 +42,7 @@ export default function MigrationsCommissionsListMobileView( {
 								</ListItemCardContent>
 							}
 							<ListItemCardContent title={ translate( 'Review status' ) }>
-								<ReviewStatusColumn
-									reviewStatus={ commission.incentive_status }
-									canTagSitesForCommission={ canTagSitesForCommission }
-								/>
+								<ReviewStatusColumn reviewStatus={ commission.incentive_status } />
 							</ListItemCardContent>
 						</ListItemCard>
 					);

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/test/commission-columns.test.tsx
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/test/commission-columns.test.tsx
@@ -9,22 +9,22 @@ import { ReviewStatusColumn } from '../commission-columns';
 
 describe( 'ReviewStatusColumn', () => {
 	it( 'renders nothing when the review status is empty', () => {
-		const { container } = render( <ReviewStatusColumn reviewStatus="" canTagSitesForCommission /> );
+		const { container } = render( <ReviewStatusColumn reviewStatus="" /> );
 		expect( container ).toBeEmptyDOMElement();
 	} );
 
-	it( 'shows a "Pending" badge for pending migrations while the agency is still eligible for the incentive', () => {
-		render( <ReviewStatusColumn reviewStatus="pending" canTagSitesForCommission /> );
+	it( 'shows a "Pending" badge for pending migrations', () => {
+		render( <ReviewStatusColumn reviewStatus="pending" /> );
 		expect( screen.getByText( 'Pending' ) ).toBeVisible();
 	} );
 
-	it( 'shows an "Ineligible" badge for pending migrations once the agency is no longer eligible for the incentive', () => {
-		render( <ReviewStatusColumn reviewStatus="pending" canTagSitesForCommission={ false } /> );
+	it( 'shows an "Ineligible" badge for rejected migrations', () => {
+		render( <ReviewStatusColumn reviewStatus="rejected" /> );
 		expect( screen.getByText( 'Ineligible' ) ).toBeVisible();
 	} );
 
-	it( 'shows an "Ineligible" badge for rejected migrations regardless of incentive eligibility', () => {
-		render( <ReviewStatusColumn reviewStatus="rejected" canTagSitesForCommission /> );
+	it( 'shows an "Ineligible" badge for ineligible migrations', () => {
+		render( <ReviewStatusColumn reviewStatus="ineligible" /> );
 		expect( screen.getByText( 'Ineligible' ) ).toBeVisible();
 	} );
 } );

--- a/client/a8c-for-agencies/sections/migrations/commissions-list/use-commission-list-actions.ts
+++ b/client/a8c-for-agencies/sections/migrations/commissions-list/use-commission-list-actions.ts
@@ -30,7 +30,10 @@ export default function useCommissionListActions( {
 				id: 'request-another-verification',
 				label: translate( 'Request another verification' ),
 				isEligible( item: TaggedSite ) {
-					return isRequestVerificationEnabled && item.incentive_status === 'rejected';
+					return (
+						isRequestVerificationEnabled &&
+						( item.incentive_status === 'rejected' || item.incentive_status === 'ineligible' )
+					);
 				},
 				callback( items: TaggedSite[] ) {
 					onRequestReview( items[ 0 ] );

--- a/client/a8c-for-agencies/sections/migrations/hooks/use-fetch-tagged-sites-for-migration.ts
+++ b/client/a8c-for-agencies/sections/migrations/hooks/use-fetch-tagged-sites-for-migration.ts
@@ -18,7 +18,8 @@ export default function useFetchTaggedSitesForMigration() {
 		refetchOnWindowFocus: false,
 	} );
 
-	// Filter sites to only include those with pending, verified, or paid incentive_status
+	// Filter sites to only include those with a known incentive_status:
+	// pending, verified, paid, rejected, reverification, or ineligible.
 	const filteredData = useMemo( () => {
 		if ( ! query.data ) {
 			return query.data;
@@ -32,7 +33,8 @@ export default function useFetchTaggedSitesForMigration() {
 				status === 'verified' ||
 				status === 'paid' ||
 				status === 'rejected' ||
-				status === 'reverification'
+				status === 'reverification' ||
+				status === 'ineligible'
 			);
 		} );
 	}, [ query.data ] );

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-commissions/index.tsx
@@ -69,7 +69,6 @@ export default function MigrationsCommissions() {
 					items={ taggedSites }
 					fetchMigratedSites={ fetchMigratedSites }
 					migrationTags={ migrationTags }
-					canTagSitesForCommission={ canTagSitesForCommission }
 				/>
 			</div>
 		);


### PR DESCRIPTION
Part of #
<!-- Link the related A4A Linear issue. -->

## Proposed Changes

The A4A migrations commissions API now returns `'ineligible'` as a real `incentive_status` value for sites that don't qualify for the incentive. This PR teaches the commissions list to render those rows, reusing the affordances already used for `'rejected'` (badge, reason popover, "Request another verification" action), and drops the per-row conditional that relabeled `'pending'` rows as "Ineligible" when the agency was outside the Pressable 2026 promo window — that case is now expressed directly by the backend status.

* **`hooks/use-fetch-tagged-sites-for-migration.ts`** — accept `'ineligible'` in the status whitelist so the rows reach the table; refresh the stale comment that listed the accepted statuses.
* **`commissions-list/commission-columns.tsx`** — add a `case 'ineligible'` to `getStatusProps()` (Ineligible badge, info style) and widen the rejection-reason popover from `=== 'rejected'` to `'rejected' || 'ineligible'`. Simplify the `case 'pending'` branch (no more `canTagSitesForCommission` ternary) and drop the now-unused `canTagSitesForCommission` prop on `ReviewStatusColumn`.
* **`commissions-list/use-commission-list-actions.ts`** — "Request another verification" eligibility now matches `'rejected' || 'ineligible'`, so agencies can resubmit ineligible sites.
* **`commissions-list/index.tsx`** + **`commissions-list/mobile-view.tsx`** + **`primary/migrations-commissions/index.tsx`** — drop the now-unused `canTagSitesForCommission` pass-through to the list and mobile-view components. The hook call and the other usages stay (incentive-ended banner, consolidated section, header CTAs, empty-state CTA).
* **`commissions-list/test/commission-columns.test.tsx`** — add a test for the `'ineligible'` badge; drop the obsolete "pending + not eligible → Ineligible" test and simplify the remaining names.

## Why are these changes being made?

Without this change, rows with `incentive_status: 'ineligible'` are filtered out at the data layer and never reach the table. The cleanup that follows just removes a per-row branch that the new backend signal makes redundant — `canTagSitesForCommission` still drives the agency-level page chrome, but no longer the per-row badge.

## Testing Instructions

1. Open the live link and go to **A4A → Migrations → Commissions**.
2. Confirm rows with the existing statuses still render correctly:
   * `'pending'` → "Pending" warning badge.
   * `'verified'` → "Confirmed" success badge.
   * `'paid'` → "Paid" success badge.
   * `'rejected'` (with `incentive_rejection_reason`) → "Ineligible" info badge plus a reason-icon button that opens a popover with the rejection reason.
   * `'reverification'` → "Pending re-verification" info badge.
3. With a fixture (or DevTools network override) that returns `incentive_status: 'ineligible'` plus an `incentive_rejection_reason`:
   * The row appears in the table.
   * The badge reads "Ineligible".
   * The reason-icon button opens the same popover used for `'rejected'`.
   * The row's action menu offers "Request another verification" (and not "Request verification" / "Untag site").
4. Confirm the agency-level page chrome still flips correctly: the **Incentive ended** banner, the consolidated quarter-summary section, the header **Tag sites for commission** button, and the empty-state CTA only render when the agency is inside the Pressable 2026 promo window.
5. Verify there are no TypeScript / React console errors.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?