### PR TITLE
A4A: land Migrations on commissions page when commissions exist

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
@@ -44,7 +44,6 @@ import {
 	A4A_REFERRALS_DASHBOARD,
 	A4A_TEAM_LINK,
 	A4A_AGENCY_TIER_LINK,
-	A4A_MIGRATIONS_OVERVIEW_LINK,
 	A4A_WOOPAYMENTS_LINK,
 	A4A_LEARN_LINK,
 	A4A_RESOURCES_LINK,
@@ -81,7 +80,7 @@ const useMainMenuItems = ( path: string ) => {
 			? {
 					icon: moveTo,
 					path: A4A_MIGRATIONS_LINK,
-					link: A4A_MIGRATIONS_OVERVIEW_LINK,
+					link: A4A_MIGRATIONS_LINK,
 					title: translate( 'Migrations' ),
 					trackEventProps: {
 						menu_item: 'Automattic for Agencies / Migrations',

--- a/client/a8c-for-agencies/sections/migrations/controller.tsx
+++ b/client/a8c-for-agencies/sections/migrations/controller.tsx
@@ -1,10 +1,18 @@
 import { type Callback } from '@automattic/calypso-router';
 import PageViewTracker from 'calypso/a8c-for-agencies/components/a4a-page-view-tracker';
 import MigrationsSidebar from 'calypso/a8c-for-agencies/components/sidebar-menu/migrations';
+import SidebarPlaceholder from 'calypso/a8c-for-agencies/components/sidebar-placeholder';
 import ReferralsBankDetails from '../referrals/primary/bank-details';
 import MigrationsCommissions from './primary/migrations-commissions';
+import MigrationsLanding from './primary/migrations-landing';
 import MigrationsOverviewV2 from './primary/migrations-overview-v2';
 import SelfMigrationTool from './primary/self-migration-tool';
+
+export const migrationsLandingContext: Callback = ( context, next ) => {
+	context.primary = <MigrationsLanding />;
+	context.secondary = <SidebarPlaceholder />;
+	next();
+};
 
 export const migrationsOverviewContext: Callback = ( context, next ) => {
 	context.primary = (

--- a/client/a8c-for-agencies/sections/migrations/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/index.tsx
@@ -47,5 +47,11 @@ export default function () {
 		makeLayout,
 		clientRender
 	);
-	page( A4A_MIGRATIONS_LINK, () => page.redirect( A4A_MIGRATIONS_OVERVIEW_LINK ) );
+	page(
+		A4A_MIGRATIONS_LINK,
+		requireAccessContext,
+		controller.migrationsLandingContext,
+		makeLayout,
+		clientRender
+	);
 }

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-landing/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-landing/index.tsx
@@ -1,0 +1,31 @@
+import page from '@automattic/calypso-router';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import PagePlaceholder from 'calypso/a8c-for-agencies/components/page-placeholder';
+import {
+	A4A_MIGRATIONS_COMMISSIONS_LINK,
+	A4A_MIGRATIONS_OVERVIEW_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import useFetchTaggedSitesForMigration from '../../hooks/use-fetch-tagged-sites-for-migration';
+
+const MigrationsLanding = () => {
+	const translate = useTranslate();
+	const title = translate( 'Migrations' );
+
+	const { data: taggedSites, isFetched } = useFetchTaggedSitesForMigration();
+
+	useEffect( () => {
+		if ( ! isFetched ) {
+			return;
+		}
+		if ( taggedSites?.length ) {
+			page.redirect( A4A_MIGRATIONS_COMMISSIONS_LINK );
+			return;
+		}
+		page.redirect( A4A_MIGRATIONS_OVERVIEW_LINK );
+	}, [ taggedSites, isFetched ] );
+
+	return <PagePlaceholder title={ title } />;
+};
+
+export default MigrationsLanding;


### PR DESCRIPTION
Context: p1780314655167049/1779972621.452079-slack-C0A34L1Q7J9

## Proposed Changes

Standardize the Migrations section landing behavior with Reports and WooPayments: only default to the overview page when there are no commissions. Add a `MigrationsLanding` component that redirects to the commissions page when tagged sites exist, and point both the base route and the sidebar menu link at the landing route instead of overview.


## Why are these changes being made?

* Ensure we have consistent UI behavior in the A4A dashboard.

## Testing Instructions

Agency with Migrations
* Use the A4A live link and navigate to the `/overview` page.
* Confirm that clicking the Migrations menu in the sidebar redirects the user to the 'Commission' page.

Agency without Migrations

* Use the A4A live link and navigate to the `/overview` page.
* Confirm that clicking the Migrations menu in the sidebar redirects the user to the 'Overview' page.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?