### PR TITLE
A4A Signup: prefill agency country from phone country code

### DIFF
--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
@@ -5,7 +5,7 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import Form from 'calypso/a8c-for-agencies/components/form';
 import FormField from 'calypso/a8c-for-agencies/components/form/field';
 import FormFooter from 'calypso/a8c-for-agencies/components/form/footer';
@@ -62,12 +62,26 @@ const SignupContactForm = ( { onContinue, initialFormData, withEmail = false }: 
 		agencyUrl: false,
 	} );
 
-	const handlePhoneInputChange = ( data: { phoneNumberFull: string } ) => {
+	// Track the phone input's country code so step 2 can auto-populate the
+	// agency location when the user supplies a phone number.
+	const [ phoneCountryCode, setPhoneCountryCode ] = useState( '' );
+
+	const handlePhoneInputChange = ( data: {
+		phoneNumber: string;
+		phoneNumberFull: string;
+		countryData?: { code: string };
+	} ) => {
 		setFormData( ( prev ) => ( {
 			...prev,
 			phoneNumber: data.phoneNumberFull,
 		} ) );
+		setPhoneCountryCode( data.phoneNumber && data.countryData?.code ? data.countryData.code : '' );
 	};
+
+	const dataToContinue: Partial< AgencyDetailsSignupPayload > = useMemo(
+		() => ( phoneCountryCode ? { ...formData, country: phoneCountryCode } : formData ),
+		[ formData, phoneCountryCode ]
+	);
 
 	const handleInputChange =
 		( field: keyof AgencyDetailsSignupPayload ) =>
@@ -101,7 +115,7 @@ const SignupContactForm = ( { onContinue, initialFormData, withEmail = false }: 
 				} );
 
 				if ( ! duplicateAgencyName && ! duplicateURL ) {
-					onContinue( formData );
+					onContinue( dataToContinue );
 				} else {
 					// Fire track event to track the view of the duplicate agency warning dialog
 					dispatch(
@@ -116,12 +130,12 @@ const SignupContactForm = ( { onContinue, initialFormData, withEmail = false }: 
 				}
 			} catch ( error ) {
 				// In case the verification fails, we just let the user continue with the form submission.
-				onContinue( formData );
+				onContinue( dataToContinue );
 			} finally {
 				setIsProceeding( false );
 			}
 		},
-		[ validate, formData, onContinue, dispatch ]
+		[ validate, formData, dataToContinue, onContinue, dispatch ]
 	);
 
 	const closeDuplicateAgencyWarning = () => {
@@ -323,7 +337,7 @@ const SignupContactForm = ( { onContinue, initialFormData, withEmail = false }: 
 							<Button
 								variant="primary"
 								onClick={ () => {
-									onContinue( formData );
+									onContinue( dataToContinue );
 									closeDuplicateAgencyWarning();
 								} }
 							>


### PR DESCRIPTION
Part of A4A-1966
<!-- Link the related A4A Linear issue. -->

## Proposed Changes

The agency signup form has two steps. Step 1 asks for an optional phone number (with a country-code dropdown). Step 2 asks _"Where is your agency located?"_. When an agency supplies a phone number on step 1, we now carry the phone input's selected country code into step 2 so the location dropdown lands prefilled. If no phone digits are entered, step 2 stays untouched and the dropdown defaults to empty as before.

* **`signup-v2/components/multi-step-form/contact-form/index.tsx`** — track a new `phoneCountryCode` state alongside `formData`. `handlePhoneInputChange` widens its parameter type to read `data.phoneNumber` (cleaned digits) and `data.countryData?.code` (ISO-2 country code) off `FormPhoneInput`'s `onChange` payload, and stores the code only while the user has actually typed phone digits — so the dropdown's `initialCountryCode="US"` default doesn't leak through when the field is empty. A memoized `dataToContinue` augments the outgoing payload with `country: phoneCountryCode` whenever it's set, and replaces the three `onContinue( formData )` call sites: the happy path in `handleSubmit`, the duplicate-detection `catch` fallback, and the duplicate-agency modal's _Continue creating new agency account_ button.

Step 2's `PersonalizationForm` already reads `country` from `initialFormData` and seeds the `SearchableDropdown` with it, so no changes are needed there — the parent `MultiStepForm` merges step 1's payload into the shared form state via `updateDataAndContinue`, and step 2 picks the prefilled country up on mount.

The country codes from `FormPhoneInput.getValue().countryData.code` are ISO-2 (`US`, `DE`, `FR`, …), which is the same key shape `useCountriesAndStates()` uses for `countryOptions[].value`, so the prefilled value matches a real dropdown option without any translation.

## Why are these changes being made?

The two fields ask for related information, and the country code is already in front of the agency when they fill in step 1 — making them re-pick it on step 2 is extra work for no gain. Prefilling shortens the flow and removes a small but real source of mismatches between the phone country and the agency location.

## Testing Instructions

1. Open the live link and go to the A4A signup flow (`/signup`).
2. On step 1, fill in name / agency / URL, change the **Country code** dropdown to a non-default country (e.g. Germany / `+49`) and type a phone number. Click **Continue for free**.
3. On step 2 (**Personalize your experience**), confirm the **Where is your agency located?** dropdown is prefilled with the same country you picked on step 1 (e.g. Germany).
4. Confirm you can still change the country from the dropdown on step 2.
5. Restart the flow. On step 1, leave the phone number empty (the country-code dropdown will still default to **US**), and click **Continue for free**. Confirm the country dropdown on step 2 stays empty (placeholder **Select country**).
6. Restart the flow. On step 1, type phone digits, then delete them again before submitting. Confirm step 2's country dropdown is empty.
7. Trigger the duplicate-agency modal (reuse an existing agency name or URL) with a phone number filled in, then click **Continue creating new agency account** — confirm step 2's country is still prefilled.
8. Verify there are no TypeScript / React console errors.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?