### PR TITLE
Subscribers: allow site picker page to scroll vertically

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-data-views/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-data-views/style.scss
@@ -6,13 +6,17 @@
 
 $padding-standard: 16px;
 
-body.is-section-subscribers,
+// Prevent layout shift when the DataViews actions dropdown opens.
+// Ariakit's modal dropdown sets overflow:hidden on the body to lock
+// scrolling, which hides the viewport scrollbar and jerks the content.
+// This page uses a fixed viewport height with internal scrolling,
+// so body-level scrolling is unnecessary.
+//
+// Scoped with :not( .is-global ) so the rule only applies to the
+// subscribers data-view page; the global site picker at /subscribers
+// keeps default body scrolling, since its list can exceed the viewport.
+body.is-section-subscribers:not( .is-global ),
 .theme-jetpack-cloud.is-group-jetpack-cloud.is-section-jetpack-subscribers {
-	// Prevent layout shift when the DataViews actions dropdown opens.
-	// Ariakit's modal dropdown sets overflow:hidden on the body to lock
-	// scrolling, which hides the viewport scrollbar and jerks the content.
-	// This page uses a fixed viewport height with internal scrolling,
-	// so body-level scrolling is unnecessary.
 	overflow: hidden;
 
 	.layout:not( .has-no-sidebar ),


### PR DESCRIPTION
Follow-up to #109749.

## Proposed Changes

* Narrow the `overflow: hidden` rule added in #109749 with `:not( .is-global )` so it only applies to the per-site Subscribers data-view page, not the global site-picker at `/subscribers`.

## Why are these changes being made?

* PR #109749 added `overflow: hidden` on `body.is-section-subscribers` to prevent the DataViews actions dropdown from causing a horizontal jerk when Ariakit's body-lock toggles the viewport scrollbar. That selector also matched the site-picker page at `/subscribers` (which shares the `is-section-subscribers` body class but has a tall, scrollable list of sites), making the picker un-scrollable on shorter viewports.
* The site-picker body carries an additional `is-global` class; the per-site data-view page does not. Excluding `is-global` keeps the original fix exactly as-is on `/subscribers/{slug}` and restores default body scrolling on the picker.

## Testing Instructions

* Go to `wordpress.com/subscribers` (the global site picker — no site selected).
  * Verify the page scrolls vertically when the site list exceeds the viewport.
* Go to `wordpress.com/subscribers/{your-site-slug}` (a site with at least one subscriber).
  * Click the three-dots actions button on any subscriber row.
  * Verify the page does **not** jerk/shift when the dropdown opens (the original fix in #109749 should still be intact).
  * Verify the DataViews table still scrolls internally and all rows are reachable.
* Same checks on the Jetpack Cloud variant under `theme-jetpack-cloud.is-group-jetpack-cloud.is-section-jetpack-subscribers` (selector left untouched).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)