### PR TITLE
A4A Pressable: bring back promo banners for Q2 2026 migration offer

### DIFF
--- a/client/a8c-for-agencies/components/a4a-pressable-offer/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-pressable-offer/index.tsx
@@ -34,7 +34,7 @@ const PressableOffer = () => {
 	const onToggleView = useCallback( () => {
 		dispatch(
 			recordTracksEvent( 'calypso_a4a_pressable_promo_offer_q2_2026_toggle_view', {
-				event_type: ! isExpanded ? 'collapse' : 'expand',
+				event_type: isExpanded ? 'collapse' : 'expand',
 			} )
 		);
 		setIsExpanded( ( isExpanded ) => ! isExpanded );
@@ -71,7 +71,8 @@ const PressableOffer = () => {
 			role="button"
 			tabIndex={ 0 }
 			onKeyDown={ ( event ) => {
-				if ( event.key === 'Enter' ) {
+				if ( event.key === 'Enter' || event.key === ' ' ) {
+					event.preventDefault();
 					onToggleView();
 				}
 			} }

--- a/client/a8c-for-agencies/components/a4a-pressable-offer/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-pressable-offer/index.tsx
@@ -1,0 +1,165 @@
+import { Button } from '@wordpress/components';
+import { Icon, chevronDown } from '@wordpress/icons';
+import clsx from 'clsx';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useState } from 'react';
+import usePressableOwnershipType from 'calypso/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-pressable-ownership-type';
+import { useDispatch, useSelector } from 'calypso/state';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import SimpleList from '../simple-list';
+
+import './style.scss';
+
+const PRESSABLE_Q2_2026_DEADLINE = new Date( '2026-06-30T23:59:59.999Z' );
+const CONTACT_SALES_MAILTO = 'mailto:partnerships@automattic.com';
+const FULL_TERMS_URL =
+	'https://pressable.com/legal/summer-2026-migration-bonus-terms-and-conditions/';
+
+const PressableOffer = () => {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const [ isExpanded, setIsExpanded ] = useState( true );
+
+	const agency = useSelector( getActiveAgency );
+
+	const pressableOwnership = usePressableOwnershipType();
+
+	const shouldShowOffer =
+		agency?.billing_system === 'billingdragon' &&
+		pressableOwnership !== 'agency' &&
+		new Date() <= PRESSABLE_Q2_2026_DEADLINE;
+
+	const onToggleView = useCallback( () => {
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_pressable_promo_offer_q2_2026_toggle_view', {
+				event_type: ! isExpanded ? 'collapse' : 'expand',
+			} )
+		);
+		setIsExpanded( ( isExpanded ) => ! isExpanded );
+	}, [ dispatch, isExpanded ] );
+
+	const onContactSalesClick = useCallback(
+		( e: React.MouseEvent< HTMLAnchorElement | HTMLButtonElement > ) => {
+			e.stopPropagation();
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_pressable_promo_offer_q2_2026_contact_sales_click' )
+			);
+		},
+		[ dispatch ]
+	);
+
+	const onSeeFullTermsClick = useCallback(
+		( e: React.MouseEvent< HTMLAnchorElement | HTMLButtonElement > ) => {
+			e.stopPropagation();
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_pressable_promo_offer_q2_2026_see_full_terms_click' )
+			);
+		},
+		[ dispatch ]
+	);
+
+	if ( ! shouldShowOffer ) {
+		return null;
+	}
+
+	return (
+		<div
+			className={ clsx( 'a4a-pressable-offer', { 'is-expanded': isExpanded } ) }
+			onClick={ onToggleView }
+			role="button"
+			tabIndex={ 0 }
+			onKeyDown={ ( event ) => {
+				if ( event.key === 'Enter' ) {
+					onToggleView();
+				}
+			} }
+		>
+			<div className="a4a-pressable-offer__main">
+				<h3 className="a4a-pressable-offer__title">
+					<span>{ translate( 'Earn up to 35% cash back on Pressable. Offer ends June 30!' ) }</span>
+
+					<Button className="a4a-pressable-offer__view-toggle-mobile">
+						<Icon icon={ chevronDown } size={ 24 } />
+					</Button>
+				</h3>
+
+				{ isExpanded && (
+					<div className="a4a-pressable-offer__body">
+						<p className="a4a-pressable-offer__intro">
+							{ translate(
+								'Migrate your clients to Pressable and earn up to $50,000 back. Plans starting at 15% back for 12 months, up to 35% for 36 months. {{em}}All deals must be registered through the Automattic for Agencies team to qualify.{{/em}}',
+								{
+									components: {
+										em: <em />,
+									},
+								}
+							) }
+						</p>
+
+						<SimpleList
+							items={ [
+								translate(
+									'{{b}}Payout:{{/b}} 15% back (12-month plan), 25% back (24-month plan), 35% back (36-month plan)',
+									{
+										components: {
+											b: <b />,
+										},
+									}
+								),
+								translate( '{{b}}Max payout:{{/b}} $50,000 per agency', {
+									components: {
+										b: <b />,
+									},
+								} ),
+								translate( '{{b}}Payout date:{{/b}} July 15, 2027', {
+									components: {
+										b: <b />,
+									},
+								} ),
+								translate(
+									'{{b}}Not eligible:{{/b}} Migrations from WordPress VIP or WordPress.com to Pressable',
+									{
+										components: {
+											b: <b />,
+										},
+									}
+								),
+							] }
+						/>
+
+						<div className="a4a-pressable-offer__body-actions">
+							<Button
+								variant="primary"
+								href={ CONTACT_SALES_MAILTO }
+								onClick={ onContactSalesClick }
+							>
+								{ translate( 'Contact sales to claim this offer' ) }
+							</Button>
+
+							<Button
+								variant="secondary"
+								href={ FULL_TERMS_URL }
+								target="_blank"
+								rel="noopener noreferrer"
+								onClick={ onSeeFullTermsClick }
+							>
+								{ translate( 'See full terms ↗' ) }
+							</Button>
+
+							<span className="a4a-pressable-offer__body-actions-footnote">
+								{ translate( '*Offer valid May 21 – June 30, 2026' ) }
+							</span>
+						</div>
+					</div>
+				) }
+			</div>
+			<Button className="a4a-pressable-offer__view-toggle">
+				<Icon icon={ chevronDown } size={ 24 } />
+			</Button>
+		</div>
+	);
+};
+
+export default PressableOffer;

--- a/client/a8c-for-agencies/components/a4a-pressable-offer/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-pressable-offer/index.tsx
@@ -12,7 +12,8 @@ import SimpleList from '../simple-list';
 import './style.scss';
 
 const PRESSABLE_Q2_2026_DEADLINE = new Date( '2026-06-30T23:59:59.999Z' );
-const CONTACT_SALES_MAILTO = 'mailto:partnerships@automattic.com';
+const CONTACT_SALES_MAILTO =
+	'mailto:partnerships@automattic.com?subject=Pressable%20Summer%202026%20Promo';
 const FULL_TERMS_URL =
 	'https://pressable.com/legal/summer-2026-migration-bonus-terms-and-conditions/';
 

--- a/client/a8c-for-agencies/components/a4a-pressable-offer/style.scss
+++ b/client/a8c-for-agencies/components/a4a-pressable-offer/style.scss
@@ -1,0 +1,126 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/variables";
+
+.a4a-pressable-offer {
+	display: flex;
+	flex-direction: row;
+	gap: 16px;
+
+	border-radius: 4px;
+	background-color: var(--color-surface);
+	transition: padding 0.15s linear;
+	padding: 8px 16px;
+	cursor: pointer;
+
+	@include break-medium {
+		padding: 20px 32px;
+		&.is-expanded {
+			padding: 20px 32px 24px;
+		}
+	}
+}
+
+.theme-a8c-for-agencies .components-button.a4a-pressable-offer__view-toggle {
+	display: none;
+
+	@include break-medium {
+		display: block;
+	}
+}
+
+.a4a-pressable-offer__main {
+	flex-direction: column;
+	gap: 8px;
+	flex-grow: 1;
+}
+
+.a4a-pressable-offer__title {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+
+	@include heading-large;
+
+	@include break-medium {
+		@include heading-x-large;
+		margin-block-start: 10px;
+		margin-block-end: 8px;
+	}
+}
+
+.a4a-pressable-offer__body {
+	display: flex;
+	gap: 24px;
+	align-content: center;
+	flex-direction: column;
+
+	.simple-list {
+		max-width: 850px;
+		margin-inline-start: 16px;
+
+		li {
+			@include body-medium;
+		}
+	}
+}
+
+.a4a-pressable-offer__intro {
+	@include body-medium;
+	max-width: 850px;
+	margin-block-start: 24px;
+	margin-block-end: 0;
+
+	em {
+		font-style: italic;
+	}
+}
+
+.a4a-pressable-offer__body-actions {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+
+	@include break-xlarge {
+		flex-direction: row;
+		align-items: center;
+	}
+}
+
+.a4a-pressable-offer__body-actions-footnote {
+	@include body-small;
+}
+
+.theme-a8c-for-agencies .components-button.a4a-pressable-offer__view-toggle-mobile {
+	display: block;
+
+	@include break-medium {
+		display: none;
+	}
+}
+
+.theme-a8c-for-agencies .components-button.a4a-pressable-offer__view-toggle,
+.theme-a8c-for-agencies .components-button.a4a-pressable-offer__view-toggle-mobile {
+	&,
+	&:hover,
+	&:focus,
+	&:focus-visible {
+		background-color: transparent;
+
+		&:not(:focus-visible) {
+			border: none;
+			box-shadow: none;
+		}
+	}
+
+	svg {
+		transition: transform 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275), color 0.2s ease-in;
+	}
+}
+
+.a4a-pressable-offer.is-expanded {
+	.components-button.a4a-pressable-offer__view-toggle svg,
+	.components-button.a4a-pressable-offer__view-toggle-mobile svg {
+		transform: rotate(180deg);
+	}
+}

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hero-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hero-section/index.tsx
@@ -2,6 +2,7 @@ import { useBreakpoint } from '@automattic/viewport-react';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { forwardRef, useMemo } from 'react';
+import PressableOffer from 'calypso/a8c-for-agencies/components/a4a-pressable-offer';
 import NavItem from 'calypso/components/section-nav/item';
 import { preventWidows } from 'calypso/lib/formatting';
 import { SectionProps } from '..';
@@ -85,6 +86,7 @@ export function HeroSection(
 						)
 					) }
 				</div>
+				<PressableOffer />
 			</div>
 
 			<ul className="hosting-hero-section__tabs">{ navItems }</ul>

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hero-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hero-section/style.scss
@@ -23,6 +23,14 @@ $tab-background-selected: var(--color-surface);
 		}
 	}
 
+	.a4a-pressable-offer {
+		display: none;
+
+		@include break-large {
+			display: inherit;
+		}
+	}
+
 	.hosting-hero-section__content {
 		height: auto;
 	}

--- a/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
@@ -2,7 +2,6 @@ import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
 import { useMemo } from 'react';
-import { A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { UpcomingEventProps } from 'calypso/a8c-for-agencies/components/upcoming-event/types';
 import usePressableOwnershipType from 'calypso/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-pressable-ownership-type';
 import PressableLogo from 'calypso/assets/images/a8c-for-agencies/events/pressable-logo.svg';
@@ -73,36 +72,38 @@ export const useUpcomingEvents = () => {
 			...( shouldShowPressablePromoOffer
 				? [
 						{
-							id: 'a4a-pressable-promo-offer-2026-01-29',
+							id: 'a4a-pressable-promo-offer-2026-q2',
 							date: {
-								from: moment( '2026-01-27' ),
-								to: moment( '2026-04-30' ),
+								from: moment( '2026-05-21' ),
+								to: moment( '2026-06-30' ),
 							},
-							displayDate: translate( 'Jan 27—April 30, 2026' ),
-							title: translate(
-								'Limited time offer: Get up to 6 months of free Pressable hosting on new plans!'
-							),
+							title: translate( 'Earn up to 35% cash back on Pressable. Offer ends June 30!' ),
 							subtitle: translate( 'Automattic for Agencies & Pressable' ),
 							descriptions: [
 								translate(
-									'Enjoy up to 6 months free on Pressable Signature and Premium plans with Automattic for Agencies. Choose annual billing for 6 months free or monthly billing for 3 months free, while still earning revenue share and reseller incentives.'
+									'Migrate your clients to Pressable and earn up to $50,000 back. Plans starting at 15% back for 12 months, up to 35% for 36 months. {{em}}All deals must be registered through the Automattic for Agencies team to qualify.{{/em}}',
+									{
+										components: {
+											em: <em />,
+										},
+									}
 								),
 							],
 							ctas: [
 								{
 									variant: 'primary',
-									label: translate( 'View promo details' ),
-									url: A4A_MARKETPLACE_HOSTING_PRESSABLE_LINK,
+									label: translate( 'Contact sales to claim this offer' ),
+									url: 'mailto:partnerships@automattic.com',
 									trackEventName:
-										'calypso_a4a_overview_events_a4a_pressable_promo_offer_2026_01_29_view_click',
+										'calypso_a4a_overview_events_a4a_pressable_promo_offer_q2_2026_contact_sales_click',
 								},
 								{
 									variant: 'secondary',
 									label: translate( 'See full terms' ),
-									url: 'https://pressable.com/legal/hosting-promotion-terms',
+									url: 'https://pressable.com/legal/summer-2026-migration-bonus-terms-and-conditions/',
 									isExternal: true,
 									trackEventName:
-										'calypso_a4a_overview_events_a4a_pressable_promo_offer_2026_01_29_view_terms_click',
+										'calypso_a4a_overview_events_a4a_pressable_promo_offer_q2_2026_see_full_terms_click',
 								},
 							],
 							logoUrl: PressableLogo,

--- a/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/events/hooks/use-upcoming-events.tsx
@@ -93,7 +93,7 @@ export const useUpcomingEvents = () => {
 								{
 									variant: 'primary',
 									label: translate( 'Contact sales to claim this offer' ),
-									url: 'mailto:partnerships@automattic.com',
+									url: 'mailto:partnerships@automattic.com?subject=Pressable%20Summer%202026%20Promo',
 									trackEventName:
 										'calypso_a4a_overview_events_a4a_pressable_promo_offer_q2_2026_contact_sales_click',
 								},
@@ -107,7 +107,7 @@ export const useUpcomingEvents = () => {
 								},
 							],
 							logoUrl: PressableLogo,
-							dateClassName: 'a4a-event__date--pressable',
+							dateClassName: 'a4a-event__date--a4a',
 						},
 				  ]
 				: [] ),

--- a/client/a8c-for-agencies/sections/overview/body/events/styles.scss
+++ b/client/a8c-for-agencies/sections/overview/body/events/styles.scss
@@ -37,6 +37,10 @@
 	color: var(--color-scary-50);
 }
 
+.a4a-event__date--pressable {
+	color: var(--color-primary);
+}
+
 .a4a-event__image--a4a,
 .a4a-event__image--klaviyo {
 	background-size: 90%;

--- a/client/a8c-for-agencies/sections/overview/body/events/styles.scss
+++ b/client/a8c-for-agencies/sections/overview/body/events/styles.scss
@@ -37,10 +37,6 @@
 	color: var(--color-scary-50);
 }
 
-.a4a-event__date--pressable {
-	color: var(--color-primary);
-}
-
 .a4a-event__image--a4a,
 .a4a-event__image--klaviyo {
 	background-size: 90%;


### PR DESCRIPTION
Part of A4A-2708
<!-- Link the related A4A Linear issue. -->

## Proposed Changes

Bring back the two A4A in-product Pressable promo banners with copy for the **Q2 2026 cash-back migration offer** (May 21 – June 30, 2026). Both banners show only for BillingDragon agencies that have never owned a Pressable plan, and auto-hide after `2026-06-30T23:59:59.999Z`.

<img width="764" height="298" alt="Screenshot 2026-06-01 at 17 46 29" src="https://github.com/user-attachments/assets/9bccd45d-c877-486f-838d-00df13790035" />

<img width="1147" height="339" alt="Screenshot 2026-06-01 at 17 47 04" src="https://github.com/user-attachments/assets/d9338483-a18f-41ef-8017-1f774a86e35d" />

* **`components/a4a-pressable-offer/index.tsx`** + **`.../style.scss`** — restore the `PressableOffer` hero banner that was removed in #110357 after the Q1 promo expired. Updated for Q2:
  * Title: "Earn up to 35% cash back on Pressable. Offer ends June 30!"
  * Intro paragraph above the `SimpleList`, with the disclaimer italicized via an `{{em}}…{{/em}}` placeholder so the translation stays as a single string.
  * `SimpleList` bullets: payout tiers (15/25/35%), $50,000 cap, July 15, 2027 payout date, ineligibility note for VIP / WordPress.com origins.
  * Primary CTA → `mailto:partnerships@automattic.com`; secondary CTA → `https://pressable.com/legal/summer-2026-migration-bonus-terms-and-conditions/` (new tab).
  * Visibility gate simplified: drop the `isReferMode` bypass; gate is now `billing_system === 'billingdragon' && pressableOwnership !== 'agency' && now <= 2026-06-30T23:59:59Z`.
  * Tracks events namespaced as `calypso_a4a_pressable_promo_offer_q2_2026_{toggle_view,contact_sales_click,see_full_terms_click}` so analytics don't mix with the Q1 promo.
* **`sections/marketplace/hosting-overview/hero-section/index.tsx`** + **`.../style.scss`** — re-mount `<PressableOffer />` as the last child of `.hosting-hero-section__content`, and re-add the `.a4a-pressable-offer { display: none; @include break-large { display: inherit; } }` rule that hides the banner below large viewports.
* **`sections/overview/body/events/hooks/use-upcoming-events.tsx`** — replace the expired Jan 27 – Apr 30 Pressable event with a new Q2 entry (`id: 'a4a-pressable-promo-offer-2026-q2'`, dates 2026-05-21 / 2026-06-30, matching title + CTAs + tracks names). The existing `event.date.to >= today` filter will auto-hide it on July 1.
* **`sections/overview/body/events/styles.scss`** — add the missing `.a4a-event__date--pressable { color: var(--color-primary); }` rule (the classname was already referenced by the entry).

## Why are these changes being made?

Marketing is launching the Pressable Q2 2026 migration cash-back promo (up to 35% back, capped at $50,000 per agency). The in-product banners are the headline distribution channel and need to ship before the offer window opens.

## Testing Instructions

1. Open the live link as a BillingDragon agency that has never owned a Pressable plan.
2. Go to **A4A → Overview** and confirm the "Earn up to 35% cash back on Pressable…" event appears in **News and updates**, with displayDate "May 21 – June 30, 2026", the disclaimer italicized, and both CTAs wired (mailto + new-tab terms URL).
3. Go to **A4A → Marketplace → Hosting → Pressable** at ≥1280px and confirm the hero banner renders, expands/collapses on click, and both CTAs work. Below 1280px the banner is hidden (kept behaviour from the prior implementation).
4. Switch the active agency to one that owns Pressable through A4A (`pressableOwnership === 'agency'`) — both banners should disappear.
5. Set the system clock past `2026-06-30T23:59:59Z` (or mock `Date`) — both banners should disappear: the hero via its date guard, the Overview entry via the existing `date.to >= today` filter.
6. With the Tracks debugger open, confirm `calypso_a4a_pressable_promo_offer_q2_2026_toggle_view`, `…_contact_sales_click`, and `…_see_full_terms_click` fire on the hero, and the matching `calypso_a4a_overview_events_a4a_pressable_promo_offer_q2_2026_*` events fire from the Overview entry.
7. Verify there are no TypeScript / React console errors.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?