### PR TITLE
Site purchases: bump useSitePurchases to API v1.2

### DIFF
--- a/packages/data-stores/src/purchases/queries/use-site-purchases.ts
+++ b/packages/data-stores/src/purchases/queries/use-site-purchases.ts
@@ -21,7 +21,7 @@ export function getUseSitePurchasesOptions(
 		queryFn: async (): Promise< PurchasesIndex > => {
 			const purchases: RawPurchase[] = await wpcomRequest( {
 				path: `/sites/${ encodeURIComponent( siteId as string ) }/purchases`,
-				apiVersion: '1.1',
+				apiVersion: '1.2',
 			} );
 
 			return Object.fromEntries(


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/SHILL-1200/replace-get-user-purchasesget-site-purchases

## Proposed Changes

* Bump the `useSitePurchases` data-stores query (`getUseSitePurchasesOptions`) from API version `1.1` to `1.2` for the `/sites/<id>/purchases` endpoint.

## Why are these changes being made?

* The `1.1` version of the site purchases endpoint uses an old mechanism to encode purchases which is expensive and complex. It is being retired and we need to stop using it.
* This was the last caller in Calypso still hitting the `/sites/<id>/purchases` endpoint on a pre-1.2 API version. The Redux `fetchSitePurchases` thunk already calls the same endpoint at `1.2`, so this aligns the two callers.
* The response shape is unchanged between the two: both decode into the shared `RawPurchase` type (re-exported from `@automattic/api-core`) and pass through `createPurchaseObject`, so no consumer changes are required.

## Testing Instructions

* Load a flow that reads site purchases through data-stores (e.g. the plans page / storage add-on purchase status) and confirm purchases still resolve correctly.
* Verify the network request to `/sites/<id>/purchases` is made with `apiVersion: 1.2` and returns the expected purchase data.
