### PR TITLE
E2E: Use Blackbox test key in auth tests

### DIFF
--- a/test/e2e/lib/blackbox-test-key.ts
+++ b/test/e2e/lib/blackbox-test-key.ts
@@ -1,0 +1,30 @@
+import type { Page } from '@playwright/test';
+
+// Intentionally public Blackbox test key. It mirrors Turnstile-style test keys and
+// always allows `/v1/collect`, so auth E2E tests do not depend on live challenges.
+const BLACKBOX_ALWAYS_ALLOW_PUBLIC_TEST_KEY = '1xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+
+export async function useBlackboxTestKeyForCollect( page: Page ): Promise< void > {
+	await page.route( 'https://blackbox-api.wp.com/v1/collect**', async ( route ) => {
+		const request = route.request();
+
+		if ( request.method() === 'GET' ) {
+			const url = new URL( request.url() );
+			url.searchParams.set( 'apikey', BLACKBOX_ALWAYS_ALLOW_PUBLIC_TEST_KEY );
+			await route.continue( { url: url.toString() } );
+			return;
+		}
+
+		if ( request.method() !== 'POST' ) {
+			await route.continue();
+			return;
+		}
+
+		await route.continue( {
+			headers: {
+				...request.headers(),
+				'x-blackbox-api-key': BLACKBOX_ALWAYS_ALLOW_PUBLIC_TEST_KEY,
+			},
+		} );
+	} );
+}

--- a/test/e2e/lib/pw-base.ts
+++ b/test/e2e/lib/pw-base.ts
@@ -90,6 +90,7 @@ import {
 } from '@automattic/calypso-e2e';
 import { test as base, expect } from '@playwright/test';
 import { apiCloseAccount } from '../specs/shared';
+import { useBlackboxTestKeyForCollect } from './blackbox-test-key';
 import { getAccount } from './get-account';
 
 export type CustomOptions = {
@@ -357,7 +358,7 @@ export const test = base.extend<
 	}
 >( {
 	viewportName: [ 'desktop', { option: true } ],
-	page: async ( { page, viewportName }, use ) => {
+	page: async ( { page, viewportName }, use, testInfo ) => {
 		// Set process.env.VIEWPORT_NAME so page objects/components can access it via envVariables.
 		process.env.VIEWPORT_NAME = viewportName;
 		await page.context().addCookies( [
@@ -368,6 +369,10 @@ export const test = base.extend<
 				path: '/',
 			},
 		] );
+
+		if ( testInfo.project.name === 'authentication' ) {
+			await useBlackboxTestKeyForCollect( page );
+		}
 
 		await use( page );
 	},


### PR DESCRIPTION
Part of TESTOPS-120

## Proposed Changes

* Add an Authentication-project Playwright fixture that routes Blackbox `/v1/collect` requests through the public always-allow test key.
* Leave the login page and Calypso config untouched; only Blackbox collect calls in Authentication tests are affected.

## Why are these changes being made?

* Blackbox challenges can block Authentication E2E before the test reaches its login assertions.
* These tests validate WordPress.com auth flows, not Blackbox challenge scoring. Using Blackbox's public test key keeps the auth flow deterministic while still loading the real login UI and SDK.

## Testing Instructions

* `yarn eslint --ext .ts --cache test/e2e/lib/pw-base.ts test/e2e/lib/blackbox-test-key.ts`
* `yarn workspace @automattic/calypso-e2e build`
* `CALYPSO_BASE_URL=<production Calypso base URL> yarn playwright test specs/authentication/authentication__login-localized-hydration.spec.ts --project=authentication --reporter=list --no-deps`
  * Result: 2 passed.
* Full Authentication run: `CALYPSO_BASE_URL=<production Calypso base URL> yarn playwright test --project=authentication --grep @authentication --reporter=list --no-deps`
  * Result: 7 passed, 1 skipped, 1 failed in SMS with a local account password rejection before the SMS code step. That failure did not hit the Blackbox route.
* One-off browser probe confirmed the login page loaded normally and one Blackbox collect response returned `mode: "test"`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
