### PR TITLE
CSS: only declare the reset layer, let @wordpress/ui control its own layer order

### DIFF
--- a/client/assets/stylesheets/style.scss
+++ b/client/assets/stylesheets/style.scss
@@ -1,9 +1,10 @@
-// Layer order — weakest to strongest.
-// Unlayered styles (the bulk of Calypso) still beat both layers below.
-// Pinning `reset` before `wp-ui-components` lets `@wordpress/ui` defaults
-// override our reset (otherwise an unlayered reset would win over the
-// package's `@layer wp-ui-components` styles).
-@layer reset, wp-ui-components;
+// Declare the `reset` layer first so it sits at the bottom of the layer order.
+// Layers declared by styles that load later (e.g. `@wordpress/ui`) are appended
+// after it, so their defaults override our reset, while unlayered styles
+// (the bulk of Calypso) still beat all layered styles.
+// Note: do not pre-declare `@wordpress/ui` layer names here — that would
+// override the package's own intended internal layer ordering.
+@layer reset;
 
 // External Dependencies
 @import "vendor";


### PR DESCRIPTION
Part of #110579 — follow-up addressing [this review comment](https://github.com/Automattic/wp-calypso/pull/110579#discussion_r3306119318).

## Proposed Changes

* Change the layer declaration in `client/assets/stylesheets/style.scss` from `@layer reset, wp-ui-components;` to just `@layer reset;`, and update the explanatory comment.

## Why are these changes being made?

* #110579 pre-declared `wp-ui-components` in the layer order, but `@wordpress/ui` declares multiple layers internally, and `wp-ui-components` is only the second lowest among them. Since layer order is determined by the first declaration encountered, pre-declaring `wp-ui-components` pins it to the front, and the package's remaining layers get appended after it — scrambling the package's intended internal layer ordering.
* Declaring only `@layer reset;` is sufficient: layers declared by later-loaded styles append after it, so `@wordpress/ui` defaults still override our reset, and the package fully controls its own internal layer order.

## Testing Instructions

* Run Calypso locally (`yarn start`) and confirm global styles look unchanged (e.g. `/sites`, `/me`).
* In devtools, inspect a reset rule (e.g. on `body`) and confirm it is still inside `@layer reset`.
* Confirm no visual regressions on surfaces using `@wordpress/components`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
