### PR TITLE
Dashboard: hide domain upsell card for A4A dev-license sites

### DIFF
--- a/client/dashboard/sites/overview-domains-card/index.tsx
+++ b/client/dashboard/sites/overview-domains-card/index.tsx
@@ -90,7 +90,7 @@ export default function DomainsCard( { site }: { site: Site } ) {
 		select: ( data ) => data.filter( ( domain ) => domain.blog_id === site.ID ),
 	} );
 
-	if ( site.is_wpcom_staging_site ) {
+	if ( site.is_wpcom_staging_site || site.is_a4a_dev_site ) {
 		return null;
 	}
 

--- a/client/dashboard/sites/overview/test/index.test.tsx
+++ b/client/dashboard/sites/overview/test/index.test.tsx
@@ -280,7 +280,11 @@ describe( '<SiteOverview>', () => {
 		expect( await getCard( 'Last scan' ) ).toBeVisible();
 		expect( await getCard( 'Development license' ) ).toBeVisible();
 		expect( await getCard( 'Latest activity' ) ).toBeVisible();
-		expect( await getCard( 'The perfect domain awaits' ) ).toBeVisible();
+
+		// Dev-license sites don't render the domains card or its upsell.
+		await waitFor( () =>
+			expect( screen.queryByText( 'The perfect domain awaits' ) ).not.toBeInTheDocument()
+		);
 	} );
 
 	test( 'renders the overview of a site with Flex plan', async () => {


### PR DESCRIPTION
Part of A4A-2316
<!-- Link the related A4A dev-sites Linear issue. -->

## Proposed Changes

| Before | After |
|--------|--------|
| <img width="1266" height="793" alt="Screenshot 2026-06-02 at 10 28 26" src="https://github.com/user-attachments/assets/6848dc06-091e-4443-a378-0db8447c2b66" /> | <img width="1284" height="786" alt="Screenshot 2026-06-02 at 10 27 56" src="https://github.com/user-attachments/assets/a7d5a37b-3751-47d6-bbe7-09a4e66a2ae4" /> | 
* **`client/dashboard/sites/overview-domains-card/index.tsx`** — extend the early return that already hides the domains card for `is_wpcom_staging_site` to also cover `is_a4a_dev_site`, so dev-license sites render no domains card at all.

## Why are these changes being made?

Sites on a development license still showed the **"Claim your free domain"** banner in the site dashboard. The card short-circuited only for staging sites, so dev sites fell through to `DomainUpsellCard`, which renders that banner whenever the site reports `has_domain_credit`. A dev-license site can't act on that offer, so the nudge is misleading. Gating it on `is_a4a_dev_site` mirrors how staging sites — the other non-production, agency-managed case — are already handled, and matches the existing `is_a4a_dev_site` special-casing in the overview plan card.

## Testing Instructions

1. Open the live link and view a site that is on a **development license** (`is_a4a_dev_site`).
2. On the site overview, confirm the domains card — including the "Claim your free domain" banner — no longer renders.
3. View a regular (non-dev, non-staging) site and confirm its domains card and any domain upsell still render as before.
4. View a staging site and confirm it still renders no domains card (unchanged).
5. Verify there are no TypeScript / React console errors.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

