### PR TITLE
Add reset all action to admin sidebar customizer

### DIFF
--- a/client/my-sites/sidebar/customize/customize-mode.scss
+++ b/client/my-sites/sidebar/customize/customize-mode.scss
@@ -341,7 +341,9 @@ body.is-admin-sidebar-customize-mode {
 		pointer-events: none;
 		transform: scaleX( 1 );
 		transform-origin: center;
-		transition: opacity 160ms ease, transform 160ms ease;
+		transition:
+			opacity 160ms ease,
+			transform 160ms ease;
 	}
 
 	.sidebar > li:not( .admin-sidebar-drop-indicator )::before,
@@ -355,7 +357,6 @@ body.is-admin-sidebar-customize-mode {
 		> li:not( .admin-sidebar-drop-indicator ):last-child::after {
 		bottom: 0;
 	}
-
 }
 
 // Source row fades while the ghost follows the cursor (Phase 2 row 17 visual).
@@ -409,7 +410,7 @@ li.admin-sidebar-drop-indicator {
 }
 
 // Customize-mode footer. Docked at the bottom of the sidebar surface with
-// auto-save status plus compact controls.
+// Reset all plus compact Undo / Retry / Done controls.
 .admin-sidebar-customize-footer {
 	display: flex;
 	flex-direction: column;
@@ -420,10 +421,35 @@ li.admin-sidebar-drop-indicator {
 	box-shadow: 0 -8px 12px -8px rgba( 0, 0, 0, 0.5 );
 	margin-top: auto;
 
-	&__status {
+	&__reset-all {
+		flex: 0 0 auto;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		gap: 6px;
+		padding: 6px 12px;
+		border: 0;
+		border-radius: 3px;
+		background: transparent;
 		color: rgba( 240, 240, 241, 0.75 );
-		font-size: 12px;
-		line-height: 1.4;
+		font-size: 13px;
+		cursor: pointer;
+	}
+
+	&__reset-all:hover:not( [disabled] ),
+	&__reset-all:focus-visible:not( [disabled] ) {
+		color: #fff;
+		background: rgba( 240, 240, 241, 0.08 );
+	}
+
+	&__reset-all[disabled] {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+
+	&__reset-all-icon {
+		flex: 0 0 auto;
+		display: block;
 	}
 
 	&__undo,
@@ -455,6 +481,13 @@ li.admin-sidebar-drop-indicator {
 		opacity: 0.55;
 		cursor: not-allowed;
 	}
+}
+
+.admin-sidebar-reset-all-modal__actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 16px;
+	margin-top: 24px;
 }
 
 // Drag handle (grip). Rendered inside reassignable items during customize

--- a/client/my-sites/sidebar/customize/draft-state.ts
+++ b/client/my-sites/sidebar/customize/draft-state.ts
@@ -172,6 +172,16 @@ export function resetItem( state: CustomizerDraftState, itemId: string ): Custom
 }
 
 /**
+ * Drop every override and revert the full sidebar to the default layout.
+ */
+export function resetAll( state: CustomizerDraftState ): CustomizerDraftState {
+	return recomputeDirty( {
+		...state,
+		workingDelta: { ...state.workingDelta, overrides: [] },
+	} );
+}
+
+/**
  * Replace the saved delta and reset working to match. Called after a
  * successful POST so subsequent edits compute isDirty against the new server
  * truth.

--- a/client/my-sites/sidebar/customize/footer.tsx
+++ b/client/my-sites/sidebar/customize/footer.tsx
@@ -1,29 +1,55 @@
 /**
- * Customize-mode footer with auto-save status, Undo, Retry, and Done.
+ * Customize-mode footer with Reset all, Undo, Retry, and Done.
  *
  * Mirrors `renderFooter` + `updateFooter` in the public plugin's
- * `customizer/customizer.js` v0.1.10.
+ * `customizer/customizer.js`.
  */
 
+import { Button, Modal } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
+import { useState } from 'react';
 import { useCustomizeContext } from './index';
-import type { CustomizerDraftState } from './draft-state';
 
 const FOOTER_CLASS = 'admin-sidebar-customize-footer';
 
 export function CustomizeFooter() {
 	const ctx = useCustomizeContext();
+	const [ isResetModalOpen, setResetModalOpen ] = useState( false );
 	if ( ! ctx || ! ctx.isCustomizing ) {
 		return null;
 	}
-	const { draft, exit, undo, retry, canUndo, hasPendingSave, lastSavedAt } = ctx;
-	const status = getStatusText( draft, hasPendingSave, lastSavedAt );
+	const { draft, exit, undo, retry, canUndo, canResetAll, hasPendingSave, resetAll } = ctx;
+	const isSaving = draft.isSaving || hasPendingSave;
+	const closeResetModal = () => setResetModalOpen( false );
+	const confirmResetAll = () => {
+		resetAll();
+		closeResetModal();
+	};
 
 	return (
 		<div className={ FOOTER_CLASS }>
-			<div className={ `${ FOOTER_CLASS }__status` } role="status" aria-live="polite">
-				{ status }
-			</div>
+			<button
+				type="button"
+				className={ `${ FOOTER_CLASS }__reset-all` }
+				disabled={ ! canResetAll }
+				onClick={ () => setResetModalOpen( true ) }
+			>
+				<svg
+					className={ `${ FOOTER_CLASS }__reset-all-icon` }
+					width="15"
+					height="15"
+					viewBox="0 0 24 24"
+					aria-hidden="true"
+					focusable="false"
+					xmlns="http://www.w3.org/2000/svg"
+				>
+					<path
+						fill="currentColor"
+						d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4z"
+					/>
+				</svg>
+				<span className={ `${ FOOTER_CLASS }__reset-all-label` }>{ translate( 'Reset all' ) }</span>
+			</button>
 			<button
 				type="button"
 				className={ `${ FOOTER_CLASS }__undo` }
@@ -44,33 +70,35 @@ export function CustomizeFooter() {
 			<button
 				type="button"
 				className={ `${ FOOTER_CLASS }__done` }
-				disabled={ draft.isSaving || hasPendingSave }
+				disabled={ isSaving }
 				onClick={ () => exit( { confirmIfDirty: true } ) }
 			>
-				{ translate( 'Done' ) }
+				{ isSaving ? translate( 'Saving…' ) : translate( 'Done' ) }
 			</button>
+			{ isResetModalOpen && (
+				<Modal
+					title={ translate( 'Reset all to default?' ) as string }
+					className="admin-sidebar-reset-all-modal"
+					size="small"
+					onRequestClose={ closeResetModal }
+				>
+					<p className="admin-sidebar-reset-all-modal__body">
+						{ translate(
+							'This restores the default order and grouping for every item in the sidebar. Your current customizations will be removed.'
+						) }
+					</p>
+					<div className="admin-sidebar-reset-all-modal__actions">
+						<Button variant="tertiary" onClick={ closeResetModal }>
+							{ translate( 'Cancel' ) }
+						</Button>
+						<Button variant="primary" onClick={ confirmResetAll }>
+							{ translate( 'Reset all' ) }
+						</Button>
+					</div>
+				</Modal>
+			) }
 		</div>
 	);
 }
 
 export default CustomizeFooter;
-
-function getStatusText(
-	draft: CustomizerDraftState,
-	hasPendingSave: boolean,
-	lastSavedAt: number
-) {
-	if ( draft.saveError ) {
-		return draft.saveError.message;
-	}
-	if ( draft.isSaving || hasPendingSave ) {
-		return translate( 'Saving…' );
-	}
-	if ( draft.isDirty ) {
-		return translate( 'Unsaved changes.' );
-	}
-	if ( lastSavedAt ) {
-		return translate( 'Saved.' );
-	}
-	return translate( 'Changes save automatically.' );
-}

--- a/client/my-sites/sidebar/customize/index.tsx
+++ b/client/my-sites/sidebar/customize/index.tsx
@@ -51,6 +51,7 @@ import {
 	deltasEqual,
 	endDrag as endDragState,
 	moveItem,
+	resetAll,
 	resetItem,
 	restoreWorking,
 	type CustomizerDraftState,
@@ -77,16 +78,16 @@ export interface CommitMoveDetails {
 }
 
 interface UndoFrame {
-	itemId: string;
-	previousPosition: LayoutPosition;
 	previousDelta: LayoutDelta;
 	label: string;
+	isResetAll?: boolean;
 }
 
 type Action =
 	| { type: 'set'; state: CustomizerDraftState }
 	| { type: 'move'; itemId: string; position: LayoutPosition }
 	| { type: 'reset_item'; itemId: string }
+	| { type: 'reset_all' }
 	| { type: 'cancel' }
 	| { type: 'apply_saved'; saved: LayoutDelta }
 	| { type: 'begin_drag'; itemId: string; sourcePosition: LayoutPosition }
@@ -102,6 +103,8 @@ function reducer( state: CustomizerDraftState, action: Action ): CustomizerDraft
 			return moveItem( state, action.itemId, action.position );
 		case 'reset_item':
 			return resetItem( state, action.itemId );
+		case 'reset_all':
+			return resetAll( state );
 		case 'cancel':
 			return cancel( state );
 		case 'apply_saved':
@@ -126,11 +129,13 @@ export interface CustomizeController {
 	exit: ( options?: { confirmIfDirty?: boolean } ) => void;
 	commitMove: ( itemId: string, position: LayoutPosition, details?: CommitMoveDetails ) => boolean;
 	resetItem: ( itemId: string, details?: CommitMoveDetails ) => boolean;
+	resetAll: () => boolean;
 	beginDrag: ( itemId: string, sourcePosition: LayoutPosition ) => void;
 	endDrag: () => void;
 	undo: () => void;
 	retry: () => void;
 	canUndo: boolean;
+	canResetAll: boolean;
 	hasPendingSave: boolean;
 	lastSavedAt: number;
 	announce: ( msg: string ) => void;
@@ -180,10 +185,6 @@ function positionsEqual( a?: LayoutPosition, b?: LayoutPosition ): boolean {
 		return b.kind === 'in_group' && a.group_id === b.group_id;
 	}
 	return true;
-}
-
-function clonePosition( position: LayoutPosition ): LayoutPosition {
-	return { ...position };
 }
 
 function errorMessage( err: unknown ): string {
@@ -397,8 +398,6 @@ export function CustomizeProvider( {
 				const nextStack = [
 					...undoStackRef.current,
 					{
-						itemId,
-						previousPosition: clonePosition( details.previousPosition ),
 						previousDelta,
 						label: details.label || itemId,
 					},
@@ -425,6 +424,32 @@ export function CustomizeProvider( {
 		[ commitWorkingChange ]
 	);
 
+	const resetAllHandler = useCallback( () => {
+		if ( draftRef.current.activeDrag || draftRef.current.workingDelta.overrides.length === 0 ) {
+			return false;
+		}
+		const previousDelta = cloneDelta( draftRef.current.workingDelta );
+		const nextState = resetAll( draftRef.current );
+		if ( deltasEqual( previousDelta, nextState.workingDelta ) ) {
+			setDraftState( nextState );
+			return false;
+		}
+
+		setDraftState( nextState );
+		const nextStack = [
+			...undoStackRef.current,
+			{
+				previousDelta,
+				label: translate( 'all items' ) as string,
+				isResetAll: true,
+			},
+		].slice( -MAX_UNDO_STACK );
+		setUndoFrames( nextStack );
+		scheduleAutosave( nextState.workingDelta );
+		announce( translate( 'Reset all items to their default positions.' ) as string );
+		return true;
+	}, [ announce, scheduleAutosave, setDraftState, setUndoFrames ] );
+
 	const beginDrag = useCallback(
 		( itemId: string, sourcePosition: LayoutPosition ) => {
 			setDraftState( beginDragState( draftRef.current, itemId, sourcePosition ) );
@@ -445,11 +470,15 @@ export function CustomizeProvider( {
 		const nextState = restoreWorking( draftRef.current, frame.previousDelta );
 		setDraftState( nextState );
 		scheduleAutosave( nextState.workingDelta );
-		announce(
-			translate( 'Undid last change for %(label)s.', {
-				args: { label: frame.label },
-			} ) as string
-		);
+		if ( frame.isResetAll ) {
+			announce( translate( 'Undid reset of all items.' ) as string );
+		} else {
+			announce(
+				translate( 'Undid last change for %(label)s.', {
+					args: { label: frame.label },
+				} ) as string
+			);
+		}
 	}, [ announce, scheduleAutosave, setDraftState, setUndoFrames ] );
 
 	const retry = useCallback( () => {
@@ -525,6 +554,9 @@ export function CustomizeProvider( {
 			if ( document.querySelector( '.admin-sidebar-move-menu' ) ) {
 				return;
 			}
+			if ( document.querySelector( '.admin-sidebar-reset-all-modal' ) ) {
+				return;
+			}
 			if (
 				draftRef.current.activeDrag ||
 				draftRef.current.isSaving ||
@@ -547,11 +579,17 @@ export function CustomizeProvider( {
 			exit,
 			commitMove,
 			resetItem: resetItemHandler,
+			resetAll: resetAllHandler,
 			beginDrag,
 			endDrag,
 			undo,
 			retry,
 			canUndo: undoStack.length > 0 && ! draft.activeDrag,
+			canResetAll:
+				draft.workingDelta.overrides.length > 0 &&
+				! draft.activeDrag &&
+				! draft.isSaving &&
+				! hasPendingSave,
 			hasPendingSave,
 			lastSavedAt,
 			announce,
@@ -563,6 +601,7 @@ export function CustomizeProvider( {
 			exit,
 			commitMove,
 			resetItemHandler,
+			resetAllHandler,
 			beginDrag,
 			endDrag,
 			undo,

--- a/client/my-sites/sidebar/customize/test/draft-state.ts
+++ b/client/my-sites/sidebar/customize/test/draft-state.ts
@@ -8,6 +8,7 @@ import {
 	emptyDelta,
 	endDrag,
 	moveItem,
+	resetAll,
 	recomputeDirty,
 	resetItem,
 	restoreWorking,
@@ -132,6 +133,24 @@ describe( 'customize draft-state', () => {
 			expect( a.isDirty ).toBe( true );
 			const b = resetItem( a, 'x' );
 			expect( b.isDirty ).toBe( false );
+		} );
+	} );
+
+	describe( 'resetAll', () => {
+		it( 'drops every override and marks dirty against a customized saved delta', () => {
+			const saved: LayoutDelta = {
+				version: 1,
+				updated_at: 100,
+				overrides: [
+					{ itemId: 'a', position: { ...samplePosition } },
+					{ itemId: 'b', position: { kind: 'top_level', index: 2 } },
+				],
+			};
+			const state = createDraftState( saved );
+			const next = resetAll( state );
+			expect( next.workingDelta.overrides ).toEqual( [] );
+			expect( next.savedDelta.overrides ).toEqual( saved.overrides );
+			expect( next.isDirty ).toBe( true );
 		} );
 	} );
 

--- a/client/my-sites/sidebar/customize/test/footer.tsx
+++ b/client/my-sites/sidebar/customize/test/footer.tsx
@@ -2,11 +2,12 @@
  * @jest-environment jsdom
  */
 
-import { act, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import { CustomizeFooter } from '../footer';
 import { CustomizeProvider, useCustomizeContext } from '../index';
+import type { LayoutDelta } from 'calypso/state/admin-sidebar/layout/types';
 
 function renderInProvider( ui: JSX.Element, state: object = {} ) {
 	const store = configureStore()( {
@@ -26,6 +27,17 @@ function EnterButton() {
 		</button>
 	);
 }
+
+const savedDelta: LayoutDelta = {
+	version: 1,
+	updated_at: 100,
+	overrides: [
+		{
+			itemId: 'plugin:stats:-:stats.php',
+			position: { kind: 'top_level', index: 2 },
+		},
+	],
+};
 
 describe( '<CustomizeFooter>', () => {
 	it( 'renders nothing when customize mode is off', () => {
@@ -49,7 +61,8 @@ describe( '<CustomizeFooter>', () => {
 		act( () => {
 			( container.querySelector( 'button' ) as HTMLButtonElement ).click();
 		} );
-		expect( screen.getByText( 'Changes save automatically.' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Changes save automatically.' ) ).not.toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: /Reset all/i } ) ).toBeDisabled();
 		expect( screen.getByRole( 'button', { name: /Undo/i } ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'button', { name: /Done/i } ) ).toBeInTheDocument();
 	} );
@@ -66,5 +79,51 @@ describe( '<CustomizeFooter>', () => {
 		} );
 		const undo = screen.getByRole( 'button', { name: /Undo/i } );
 		expect( undo ).toBeDisabled();
+	} );
+
+	it( 'confirms reset all and folds saving state into Done', async () => {
+		const saveLayoutImpl = jest.fn( () => new Promise< LayoutDelta >( () => {} ) );
+		const { container } = renderInProvider(
+			<CustomizeProvider saveLayoutImpl={ saveLayoutImpl }>
+				<EnterButton />
+				<CustomizeFooter />
+			</CustomizeProvider>,
+			{
+				adminSidebarLayout: { bySite: { 12345: savedDelta } },
+			}
+		);
+		act( () => {
+			( container.querySelector( 'button' ) as HTMLButtonElement ).click();
+		} );
+
+		const resetButton = screen.getByRole( 'button', { name: /Reset all/i } );
+		expect( resetButton ).toBeEnabled();
+
+		fireEvent.click( resetButton );
+		const dialog = screen.getByRole( 'dialog', { name: 'Reset all to default?' } );
+		expect(
+			within( dialog ).getByText(
+				'This restores the default order and grouping for every item in the sidebar. Your current customizations will be removed.'
+			)
+		).toBeInTheDocument();
+
+		fireEvent.click( within( dialog ).getByRole( 'button', { name: 'Cancel' } ) );
+		expect(
+			screen.queryByRole( 'dialog', { name: 'Reset all to default?' } )
+		).not.toBeInTheDocument();
+
+		fireEvent.click( resetButton );
+		const confirmDialog = screen.getByRole( 'dialog', { name: 'Reset all to default?' } );
+		fireEvent.click( within( confirmDialog ).getByRole( 'button', { name: 'Reset all' } ) );
+
+		await waitFor( () => expect( saveLayoutImpl ).toHaveBeenCalledTimes( 1 ) );
+		const savedDeltaArg = (
+			saveLayoutImpl.mock.calls[ 0 ] as unknown as [ unknown, { delta: LayoutDelta } ]
+		 )[ 1 ].delta;
+		expect( savedDeltaArg.overrides ).toEqual( [] );
+		expect( screen.getByRole( 'button', { name: 'Saving…' } ) ).toBeDisabled();
+		expect( screen.queryByText( 'Saving…' ) ).not.toHaveClass(
+			'admin-sidebar-customize-footer__status'
+		);
 	} );
 } );

--- a/client/my-sites/sidebar/customize/test/provider.tsx
+++ b/client/my-sites/sidebar/customize/test/provider.tsx
@@ -8,11 +8,12 @@ import configureStore from 'redux-mock-store';
 import { BODY_CUSTOMIZE_CLASS, CustomizeProvider, useCustomizeContext } from '../index';
 import type { LayoutDelta } from 'calypso/state/admin-sidebar/layout/types';
 
-function renderInProvider( ui: JSX.Element ) {
+function renderInProvider( ui: JSX.Element, state: object = {} ) {
 	const store = configureStore()( {
 		ui: { selectedSiteId: 12345 },
 		adminSidebarLayout: { bySite: {} },
 		adminSidebarExpandState: { bySite: {} },
+		...state,
 	} );
 	return render( <Provider store={ store }>{ ui }</Provider> );
 }
@@ -84,5 +85,52 @@ describe( '<CustomizeProvider>', () => {
 		expect( exposedCtx?.draft.isSaving ).toBe( true );
 		expect( exposedCtx?.canUndo ).toBe( true );
 		expect( saveLayoutImpl ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'resetAll drops every override and Undo restores the previous delta', () => {
+		const savedDelta: LayoutDelta = {
+			version: 1,
+			updated_at: 100,
+			overrides: [
+				{
+					itemId: 'plugin:stats:-:stats.php',
+					position: { kind: 'top_level', index: 2 },
+				},
+				{
+					itemId: 'plugin:forms:-:forms.php',
+					position: { kind: 'in_group', group_id: 'plugins', index: 1 },
+				},
+			],
+		};
+		const saveLayoutImpl = jest.fn( () => new Promise< LayoutDelta >( () => {} ) );
+		renderInProvider(
+			<CustomizeProvider saveLayoutImpl={ saveLayoutImpl }>
+				<ExposeContext />
+			</CustomizeProvider>,
+			{
+				adminSidebarLayout: { bySite: { 12345: savedDelta } },
+			}
+		);
+		act( () => {
+			exposedCtx?.enter();
+		} );
+		expect( exposedCtx?.canResetAll ).toBe( true );
+
+		act( () => {
+			expect( exposedCtx?.resetAll() ).toBe( true );
+		} );
+		expect( exposedCtx?.draft.workingDelta.overrides ).toEqual( [] );
+		expect( exposedCtx?.canUndo ).toBe( true );
+		expect( saveLayoutImpl ).toHaveBeenCalledTimes( 1 );
+		const savedDeltaArg = (
+			saveLayoutImpl.mock.calls[ 0 ] as unknown as [ unknown, { delta: LayoutDelta } ]
+		 )[ 1 ].delta;
+		expect( savedDeltaArg.overrides ).toEqual( [] );
+
+		act( () => {
+			exposedCtx?.undo();
+		} );
+		expect( exposedCtx?.draft.workingDelta.overrides ).toEqual( savedDelta.overrides );
+		expect( exposedCtx?.canUndo ).toBe( false );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of WordPress/wp-admin-sidebar#61
Part of WordPress/wp-admin-sidebar#84

## Proposed Changes

* Adds the new Reset all action to the Calypso admin sidebar customizer.
* Shows a confirmation dialog before clearing the current sidebar customizations.
* Keeps reset undoable as a single change, so Undo restores the previous arrangement.
* Moves the saving state into the Done button to match the updated footer behavior.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* This keeps the Calypso customizer in parity with the upstream reset-all work in WordPress/wp-admin-sidebar.

## Media


https://github.com/user-attachments/assets/d578dcfd-db8c-4f6a-a71d-44e1aefd9fc3



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start Calypso locally and open a site with the admin sidebar mock enabled:
  * `http://calypso.localhost:3000/home/[stickered site]?adminSidebarMock=1`
* Enter the sidebar customizer from the My Plugins header.
* Confirm Reset all opens the confirmation dialog.
* Confirm Cancel closes the dialog without changing the layout.
* Confirm Reset all restores the default sidebar arrangement, disables Reset all, and enables Undo.
* Confirm Undo restores the previous arrangement as one step.
* Confirm Done exits customizer mode.

Validated with:

* `git diff --check`
* `node .yarn/releases/yarn-4.0.2.cjs prettier --check client/my-sites/sidebar/customize/footer.tsx`
* `node .yarn/releases/yarn-4.0.2.cjs eslint client/my-sites/sidebar/customize/draft-state.ts client/my-sites/sidebar/customize/footer.tsx client/my-sites/sidebar/customize/index.tsx client/my-sites/sidebar/customize/test/draft-state.ts client/my-sites/sidebar/customize/test/footer.tsx client/my-sites/sidebar/customize/test/provider.tsx`
* `node .yarn/releases/yarn-4.0.2.cjs stylelint client/my-sites/sidebar/customize/customize-mode.scss`
* `node .yarn/releases/yarn-4.0.2.cjs test-client client/my-sites/sidebar/customize/test --runInBand`
* Browser tested locally against the mocked Calypso sidebar route above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
