### PR TITLE
A4A Hosting: hide free domain benefit for BD monthly WPCOM plans

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/common/hosting-features.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/common/hosting-features.tsx
@@ -9,9 +9,15 @@ type Props = {
 	heading: string;
 	isPressable?: boolean;
 	areSignaturePlans?: boolean;
+	showFreeDomain?: boolean;
 };
 
-export default function HostingFeatures( { heading, isPressable, areSignaturePlans }: Props ) {
+export default function HostingFeatures( {
+	heading,
+	isPressable,
+	areSignaturePlans,
+	showFreeDomain = true,
+}: Props ) {
 	const translate = useTranslate();
 	const { __ } = useI18n();
 
@@ -79,7 +85,9 @@ export default function HostingFeatures( { heading, isPressable, areSignaturePla
 						translate( 'In-depth site analytics dashboard' ),
 						translate( 'Elastic-powered search' ),
 						translate( '4K, unbranded VideoPress player' ),
-						...( isPressable ? [] : [ translate( 'Free domain for one year' ) ] ),
+						...( ! isPressable && showFreeDomain
+							? [ translate( 'Free domain for one year' ) ]
+							: [] ),
 						translate( 'Smart redirects' ),
 					],
 				},

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/index.tsx
@@ -1,5 +1,8 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
+import { useContext } from 'react';
 import { BackgroundType10 } from 'calypso/a8c-for-agencies/components/page-section/backgrounds';
+import { TermPricingContext } from 'calypso/a8c-for-agencies/sections/marketplace/context';
 import ProfileAvatar1 from 'calypso/assets/images/a8c-for-agencies/hosting/standard-testimonial-1.webp';
 import ProfileAvatar2 from 'calypso/assets/images/a8c-for-agencies/hosting/standard-testimonial-2.webp';
 import HostingTestimonialsSection from '../../../common/hosting-testimonials-section';
@@ -15,11 +18,20 @@ type Props = {
 export default function StandardAgencyHosting( { onAddToCart }: Props ) {
 	const translate = useTranslate();
 
+	const { termPricing } = useContext( TermPricingContext );
+	const isTermPricingEnabled = isEnabled( 'a4a-bd-term-pricing' ) && isEnabled( 'a4a-bd-checkout' );
+
+	// Unlike the legacy system, BD monthly plans do not include a free domain, so hide that benefit.
+	const showFreeDomain = ! ( isTermPricingEnabled && termPricing === 'monthly' );
+
 	return (
 		<div className="standard-agency-hosting">
 			<WPCOMPlanSection onSelect={ onAddToCart } />
 
-			<HostingFeatures heading={ translate( 'Included with every WordPress.com site' ) } />
+			<HostingFeatures
+				heading={ translate( 'Included with every WordPress.com site' ) }
+				showFreeDomain={ showFreeDomain }
+			/>
 
 			<HostingTestimonialsSection
 				heading={ translate( 'Love for WordPress.com hosting' ) }


### PR DESCRIPTION
Part of A4A-2215
<!-- Link the related A4A Linear issue. -->

## Proposed Changes

<img width="538" height="585" alt="Screenshot 2026-06-02 at 12 07 46" src="https://github.com/user-attachments/assets/81bfea63-9167-4f43-a384-e631ed8d4ec6" />

* **`hosting-content/common/hosting-features.tsx`** — add an optional `showFreeDomain` prop (defaults to `true`). The "Free domain for one year" item now renders only when `! isPressable && showFreeDomain`, so existing callers are unaffected.
* **`hosting-content/standard-agency-hosting/index.tsx`** — read `termPricing` from `TermPricingContext` and the BD gate (`a4a-bd-term-pricing` + `a4a-bd-checkout`, matching the existing `isTermPricingEnabled` pattern used elsewhere in this section), then pass `showFreeDomain={ ! ( isTermPricingEnabled && termPricing === 'monthly' ) }`.

## Why are these changes being made?

The standard WordPress.com hosting "Included with every WordPress.com site" list always advertised a free domain, regardless of the monthly/yearly toggle. Under BD, monthly plans don't receive a free domain credit (the legacy system did), so listing it on monthly is misleading and confuses agencies. This hides the benefit only for the BD + monthly case; BD yearly and the legacy (non-BD) flow keep showing it as before. Pressable already excluded the free domain via `isPressable`, so only the standard WPCOM path needed the fix.

## Testing Instructions

1. Open the live link and go to **A4A → Marketplace → Hosting** with the BD term-pricing flags enabled (`a4a-bd-term-pricing` and `a4a-bd-checkout`).
2. Set the **Billed** toggle to **Monthly** and scroll to "Included with every WordPress.com site" → confirm "Free domain for one year" is no longer listed.
3. Switch the toggle to **Yearly** → confirm "Free domain for one year" reappears.
4. With the BD flags disabled (legacy flow), confirm the free domain still shows as before.
5. View the Pressable hosting tab and confirm its feature list is unchanged (no free domain, as before).
6. Verify there are no TypeScript / React console errors.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
