### PR TITLE
Agents Manager: add persisted minimized state for the floating chat

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,7 @@
 	"dependencies": {
 		"@automattic/accessible-focus": "workspace:^",
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-ui": "^0.1.58",
+		"@automattic/agenttic-ui": "^0.1.65",
 		"@automattic/api-core": "workspace:^",
 		"@automattic/api-queries": "workspace:^",
 		"@automattic/block-renderer": "workspace:^",

--- a/packages/agents-manager/README.md
+++ b/packages/agents-manager/README.md
@@ -20,7 +20,14 @@ import AgentsManager from '@automattic/agents-manager';
 function MyApp() {
 	const site = { ID: 456, URL: 'https://example.com' };
 
-	return <AgentsManager currentRoute="/dashboard" sectionName="dashboard" site={ site } currentSiteId={ site.ID } />;
+	return (
+		<AgentsManager
+			sectionName="dashboard"
+			site={ site }
+			currentSiteId={ site.ID }
+			currentRoute="/dashboard"
+		/>
+	);
 }
 ```
 
@@ -32,6 +39,8 @@ Use `HeadlessAgentInitializer` when you need to create the agent without renderi
 import { HeadlessAgentInitializer } from '@automattic/agents-manager';
 
 function MyApp() {
+	const site = { ID: 456, URL: 'https://example.com' };
+
 	return <HeadlessAgentInitializer site={ site } currentRoute="/media" />;
 }
 ```
@@ -76,13 +85,13 @@ See `src/hooks/use-setup-custom-actions/README.md` for details.
 ### AgentsManager Props
 
 | Prop            | Type                           | Description                                                                                                              |
-|-----------------|--------------------------------|--------------------------------------------------------------------------------------------------------------------------|
+| --------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
 | `sectionName`   | `string`                       | The name of the current section (e.g., 'wp-admin', 'gutenberg').                                                         |
 | `currentUser`   | `CurrentUser` (optional)       | Current user (from `@automattic/data-stores`). Sets `isLoggedIn`.                                                        |
 | `site`          | `AgentsManagerSite` (optional) | The selected site object (from `@automattic/data-stores`).                                                               |
 | `currentRoute`  | `string` (optional)            | The current route path.                                                                                                  |
 | `currentSiteId` | `number` (optional)            | The ID of the selected site. When set, chat state is scoped to this site. When omitted, uses a shared "no-site" context. |
-| `handleClose`   | `() => void` (optional)        | Called when the agent is closed.                                                                                         |
+| `agentId`       | `string` (optional)            | Explicit agent ID for hosts that must not fall back to Unified Chat.                                                     |
 
 ### Exported Hooks and Utilities
 

--- a/packages/agents-manager/package.json
+++ b/packages/agents-manager/package.json
@@ -41,8 +41,8 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-client": "^0.1.58",
-		"@automattic/agenttic-ui": "^0.1.58",
+		"@automattic/agenttic-client": "^0.1.65",
+		"@automattic/agenttic-ui": "^0.1.65",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",

--- a/packages/agents-manager/src/components/__tests__/agent-dock.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-dock.test.tsx
@@ -256,16 +256,16 @@ describe( 'AgentDock', () => {
 		expect( location.dataset.sessionId ).toBe( 'session-123' );
 	} );
 
-	it( 'resumes the active session when opening the docked sidebar', () => {
+	it( 'keeps the current route when opening the docked sidebar', () => {
 		useWpAdminAgent();
 
 		renderAgentDock( '/history' );
 		const { onOpenSidebar } = mockUseAgentLayoutManager.mock.calls.at( -1 )[ 0 ];
 		act( () => onOpenSidebar() );
 
-		const location = screen.getByTestId( 'location' );
-		expect( location.textContent ).toBe( '/chat' );
-		expect( location.dataset.sessionId ).toBe( 'session-123' );
+		// Opening the docked sidebar must not override a route chosen from the
+		// WP admin bar (e.g. Chat history / Support guides).
+		expect( screen.getByTestId( 'location' ).textContent ).toBe( '/history' );
 	} );
 
 	it( 'resumes the active session when expanding from the support guides view', () => {

--- a/packages/agents-manager/src/components/__tests__/agent-dock.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-dock.test.tsx
@@ -2,16 +2,22 @@
  * @jest-environment jsdom
  */
 /* eslint-disable import/order -- jest.mock calls must precede imports */
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router-dom';
 import type { AgentsManagerContextType } from '../../contexts';
 
 const mockAbortCurrentRequest = jest.fn();
 const mockSetIsOpen = jest.fn();
 const mockSetIsDocked = jest.fn();
 const mockUseAgentLayoutManager = jest.fn();
-let mockShouldUseUnifiedAgent = false;
 let mockContext: Partial< AgentsManagerContextType > = {};
+let mockAgentsManagerState: {
+	isOpen?: boolean;
+	isDocked?: boolean;
+	isMinimized?: boolean;
+} = { isOpen: true, isDocked: false };
+let mockHasAdminBar = false;
+let mockShouldUseUnifiedAgent = false;
 
 type AgentsManagerTestGlobal = typeof globalThis & {
 	agentsManagerData?: {
@@ -36,24 +42,25 @@ jest.mock( '@wordpress/data', () => ( {
 	useDispatch: () => ( {
 		setIsOpen: mockSetIsOpen,
 		setIsDocked: mockSetIsDocked,
+		setIsMinimized: jest.fn(),
 	} ),
-	useSelect: () => ( {
-		isOpen: true,
-		isDocked: false,
-	} ),
+	useSelect: () => mockAgentsManagerState,
 } ) );
 jest.mock( '@wordpress/i18n', () => ( { __: ( text: string ) => text } ) );
 jest.mock( '@wordpress/icons', () => ( {
+	columns: 'columns',
 	comment: 'comment',
 	drawerRight: 'drawerRight',
-	help: 'help',
+	lineSolid: 'lineSolid',
 	login: 'login',
-	lifesaver: 'lifesaver',
 } ) );
 jest.mock( '../../contexts', () => ( {
 	useAgentsManagerContext: () => mockContext,
 } ) );
-jest.mock( '../../hooks/use-admin-bar-integration', () => () => {} );
+jest.mock( '../../hooks/use-admin-bar-integration', () => ( {
+	__esModule: true,
+	default: () => mockHasAdminBar,
+} ) );
 jest.mock( '../../hooks/use-agent-layout-manager', () => ( options: unknown ) => {
 	mockUseAgentLayoutManager( options );
 	return {
@@ -81,12 +88,14 @@ jest.mock( '../orchestrator-chat', () => ( {
 	__esModule: true,
 	default: ( {
 		chatHeaderOptions,
+		isOpen,
 		onExpand,
 	}: {
 		chatHeaderOptions: { title: string }[];
+		isOpen: boolean;
 		onExpand: () => void;
 	} ) => (
-		<div data-testid="orchestrator-chat">
+		<div data-testid="orchestrator-chat" data-chat-open={ String( isOpen ) }>
 			{ chatHeaderOptions.map( ( option ) => option.title ).join( '|' ) }
 			<button onClick={ onExpand }>Expand chat</button>
 		</div>
@@ -94,11 +103,21 @@ jest.mock( '../orchestrator-chat', () => ( {
 } ) );
 jest.mock( '../zendesk-chat', () => ( {
 	__esModule: true,
-	default: () => <div data-testid="zendesk-chat">Zendesk chat</div>,
+	default: ( { onExpand }: { onExpand: () => void } ) => (
+		<div data-testid="zendesk-chat">
+			Zendesk chat
+			<button onClick={ onExpand }>Expand Zendesk</button>
+		</div>
+	),
 } ) );
 jest.mock( '../agent-history', () => ( {
 	__esModule: true,
-	default: () => <div data-testid="agent-history">History</div>,
+	default: ( { onExpand }: { onExpand: () => void } ) => (
+		<div data-testid="agent-history">
+			History
+			<button onClick={ onExpand }>Expand history</button>
+		</div>
+	),
 } ) );
 jest.mock( '../support-guide', () => ( {
 	__esModule: true,
@@ -111,10 +130,21 @@ jest.mock( '../support-guides', () => ( {
 
 import AgentDock from '../agent-dock';
 
+function LocationProbe() {
+	const { pathname, state } = useLocation();
+	const sessionId = ( state as { sessionId?: string } | null )?.sessionId ?? '';
+	return (
+		<div data-testid="location" data-session-id={ sessionId }>
+			{ pathname }
+		</div>
+	);
+}
+
 function renderAgentDock( initialEntry = '/chat' ) {
 	return render(
 		<MemoryRouter initialEntries={ [ initialEntry ] }>
 			<AgentDock />
+			<LocationProbe />
 		</MemoryRouter>
 	);
 }
@@ -128,16 +158,31 @@ function installJetpackAiSidebarPreviewData( features: Record< string, boolean >
 	};
 }
 
+// A regular (non-reader) agent running in wp-admin.
+function useWpAdminAgent() {
+	mockContext = {
+		siteKey: 'site-1',
+		sectionName: 'wp-admin',
+		agentConfig: {
+			agentId: 'wp-orchestrator',
+		},
+		getActiveSessionId: () => 'session-123',
+	} as Partial< AgentsManagerContextType >;
+}
+
 describe( 'AgentDock', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
+		mockHasAdminBar = false;
 		mockShouldUseUnifiedAgent = false;
+		mockAgentsManagerState = { isOpen: true, isDocked: false };
 		mockContext = {
 			siteKey: 'site-1',
 			sectionName: 'reader-chat',
 			agentConfig: {
 				agentId: 'reader-chat',
 			},
+			getActiveSessionId: () => 'session-123',
 		} as Partial< AgentsManagerContextType >;
 	} );
 
@@ -145,66 +190,94 @@ describe( 'AgentDock', () => {
 		delete ( globalThis as AgentsManagerTestGlobal ).agentsManagerData;
 	} );
 
-	it( 'does not expose Zendesk chat for Reader Chat when Unified Chat is enabled', async () => {
-		mockShouldUseUnifiedAgent = true;
+	it( 'hides the chat when closed if the WP admin bar trigger is present', () => {
+		useWpAdminAgent();
+		mockHasAdminBar = true;
+		mockAgentsManagerState = { isOpen: false, isDocked: false };
 
 		renderAgentDock();
 
-		expect( screen.getByTestId( 'orchestrator-chat' ).textContent ).toContain( 'New chat' );
-		expect( screen.getByTestId( 'orchestrator-chat' ).textContent ).not.toContain(
-			'New Zendesk chat'
-		);
+		expect( screen.queryByTestId( 'orchestrator-chat' ) ).toBeNull();
+	} );
+
+	it( 'shows the chat when open with the WP admin bar trigger present', () => {
+		// `beforeEach` already sets the open state.
+		useWpAdminAgent();
+		mockHasAdminBar = true;
+
+		renderAgentDock();
+
+		expect( screen.getByTestId( 'orchestrator-chat' ) ).toBeTruthy();
+	} );
+
+	it( 'keeps the chat mounted when closed without the WP admin bar trigger', () => {
+		useWpAdminAgent();
+		mockAgentsManagerState = { isOpen: false, isDocked: false };
+
+		renderAgentDock();
+
+		expect( screen.getByTestId( 'orchestrator-chat' ) ).toBeTruthy();
+	} );
+
+	it( 'shows the minimized bar (chat not expanded) when minimized with the WP admin bar trigger', () => {
+		useWpAdminAgent();
+		mockHasAdminBar = true;
+		mockAgentsManagerState = { isOpen: true, isDocked: false, isMinimized: true };
+
+		renderAgentDock();
+
+		expect( screen.getByTestId( 'orchestrator-chat' ).dataset.chatOpen ).toBe( 'false' );
+	} );
+
+	it( 'ignores the minimized state without the WP admin bar trigger', () => {
+		useWpAdminAgent();
+		mockAgentsManagerState = { isOpen: true, isDocked: false, isMinimized: true };
+
+		renderAgentDock();
+
+		expect( screen.getByTestId( 'orchestrator-chat' ).dataset.chatOpen ).toBe( 'true' );
+	} );
+
+	it( 'resumes the active session when expanding from the minimized state', () => {
+		useWpAdminAgent();
+		mockHasAdminBar = true;
+		mockAgentsManagerState = { isOpen: true, isDocked: false, isMinimized: true };
+
+		renderAgentDock( '/history' );
+		fireEvent.click( screen.getByText( 'Expand history' ) );
+
+		const location = screen.getByTestId( 'location' );
+		expect( location.textContent ).toBe( '/chat' );
+		expect( location.dataset.sessionId ).toBe( 'session-123' );
+	} );
+
+	it( 'resumes the active session when opening the docked sidebar', () => {
+		useWpAdminAgent();
+
+		renderAgentDock( '/history' );
+		const { onOpenSidebar } = mockUseAgentLayoutManager.mock.calls.at( -1 )[ 0 ];
+		act( () => onOpenSidebar() );
+
+		const location = screen.getByTestId( 'location' );
+		expect( location.textContent ).toBe( '/chat' );
+		expect( location.dataset.sessionId ).toBe( 'session-123' );
+	} );
+
+	it( 'keeps the Zendesk conversation when expanding from the minimized state', () => {
+		useWpAdminAgent();
+		mockShouldUseUnifiedAgent = true;
+		mockHasAdminBar = true;
+		mockAgentsManagerState = { isOpen: true, isDocked: false, isMinimized: true };
 
 		renderAgentDock( '/zendesk' );
+		fireEvent.click( screen.getByText( 'Expand Zendesk' ) );
 
-		await waitFor( () => expect( screen.queryByTestId( 'zendesk-chat' ) ).toBeNull() );
-	} );
-
-	it( 'keeps Zendesk chat available for regular agents when Unified Chat is enabled', () => {
-		mockShouldUseUnifiedAgent = true;
-		mockContext = {
-			siteKey: 'site-1',
-			sectionName: 'wp-admin',
-			agentConfig: {
-				agentId: 'wp-orchestrator',
-			},
-		} as Partial< AgentsManagerContextType >;
-
-		renderAgentDock();
-
-		expect( screen.getByTestId( 'orchestrator-chat' ).textContent ).toContain( 'New Zendesk chat' );
-	} );
-
-	it( 'hides support guides when Jetpack AI Sidebar Preview disables them', async () => {
-		installJetpackAiSidebarPreviewData( { supportGuides: false } );
-		mockContext = {
-			siteKey: 'site-1',
-			sectionName: 'wp-admin',
-			agentConfig: {
-				agentId: 'wp-orchestrator',
-			},
-		} as Partial< AgentsManagerContextType >;
-
-		renderAgentDock();
-
-		expect( screen.getByTestId( 'orchestrator-chat' ).textContent ).not.toContain(
-			'Support guides'
-		);
-
-		renderAgentDock( '/support-guides' );
-
-		await waitFor( () => expect( screen.queryByTestId( 'support-guides' ) ).toBeNull() );
+		expect( screen.getByTestId( 'location' ).textContent ).toBe( '/zendesk' );
 	} );
 
 	it( 'hides history route when Jetpack AI Sidebar Preview disables chat history', async () => {
 		installJetpackAiSidebarPreviewData( { chatHistory: false } );
-		mockContext = {
-			siteKey: 'site-1',
-			sectionName: 'wp-admin',
-			agentConfig: {
-				agentId: 'wp-orchestrator',
-			},
-		} as Partial< AgentsManagerContextType >;
+		useWpAdminAgent();
 
 		renderAgentDock( '/history' );
 
@@ -213,19 +286,7 @@ describe( 'AgentDock', () => {
 
 	it( 'treats missing Jetpack AI Sidebar Preview features as disabled', async () => {
 		installJetpackAiSidebarPreviewData( {} );
-		mockContext = {
-			siteKey: 'site-1',
-			sectionName: 'wp-admin',
-			agentConfig: {
-				agentId: 'wp-orchestrator',
-			},
-		} as Partial< AgentsManagerContextType >;
-
-		renderAgentDock();
-
-		expect( screen.getByTestId( 'orchestrator-chat' ).textContent ).not.toContain(
-			'Support guides'
-		);
+		useWpAdminAgent();
 
 		renderAgentDock( '/history' );
 
@@ -249,13 +310,7 @@ describe( 'AgentDock', () => {
 	} );
 
 	it( 'opens regular agents and saves shared Agents Manager state', () => {
-		mockContext = {
-			siteKey: 'site-1',
-			sectionName: 'wp-admin',
-			agentConfig: {
-				agentId: 'wp-orchestrator',
-			},
-		} as Partial< AgentsManagerContextType >;
+		useWpAdminAgent();
 
 		renderAgentDock();
 

--- a/packages/agents-manager/src/components/__tests__/agent-dock.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-dock.test.tsx
@@ -125,7 +125,12 @@ jest.mock( '../support-guide', () => ( {
 } ) );
 jest.mock( '../support-guides', () => ( {
 	__esModule: true,
-	default: () => <div data-testid="support-guides">Support guides</div>,
+	default: ( { onExpand }: { onExpand: () => void } ) => (
+		<div data-testid="support-guides">
+			Support guides
+			<button onClick={ onExpand }>Expand guides</button>
+		</div>
+	),
 } ) );
 
 import AgentDock from '../agent-dock';
@@ -257,6 +262,20 @@ describe( 'AgentDock', () => {
 		renderAgentDock( '/history' );
 		const { onOpenSidebar } = mockUseAgentLayoutManager.mock.calls.at( -1 )[ 0 ];
 		act( () => onOpenSidebar() );
+
+		const location = screen.getByTestId( 'location' );
+		expect( location.textContent ).toBe( '/chat' );
+		expect( location.dataset.sessionId ).toBe( 'session-123' );
+	} );
+
+	it( 'resumes the active session when expanding from the support guides view', () => {
+		installJetpackAiSidebarPreviewData( { supportGuides: true } );
+		useWpAdminAgent();
+		mockHasAdminBar = true;
+		mockAgentsManagerState = { isOpen: true, isDocked: false, isMinimized: true };
+
+		renderAgentDock( '/support-guides' );
+		fireEvent.click( screen.getByText( 'Expand guides' ) );
 
 		const location = screen.getByTestId( 'location' );
 		expect( location.textContent ).toBe( '/chat' );

--- a/packages/agents-manager/src/components/__tests__/chat-header.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/chat-header.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 /* eslint-disable import/order -- jest.mock calls must precede imports */
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
 type AgentsManagerTestGlobal = typeof globalThis & {
@@ -13,6 +13,9 @@ type AgentsManagerTestGlobal = typeof globalThis & {
 		};
 	};
 };
+
+let mockIsDocked = false;
+const mockSetIsMinimized = jest.fn();
 
 jest.mock( '@wordpress/components', () => ( {
 	Button: ( {
@@ -39,7 +42,17 @@ jest.mock( '@wordpress/icons', () => ( {
 	chevronLeft: 'chevronLeft',
 	close: 'close',
 	Icon: () => null,
+	lineSolid: 'lineSolid',
 	moreVertical: 'moreVertical',
+} ) );
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: () => ( { setIsMinimized: mockSetIsMinimized } ),
+	useSelect: ( mapSelect: ( select: () => unknown ) => unknown ) =>
+		mapSelect( () => ( { getIsDocked: () => mockIsDocked } ) ),
+} ) );
+jest.mock( '../../stores', () => ( { AGENTS_MANAGER_STORE: 'agents-manager' } ) );
+jest.mock( '../../hooks/use-admin-bar-integration', () => ( {
+	ADMIN_BAR_BUTTON_ID: 'wp-admin-bar-agents-manager',
 } ) );
 jest.mock( '../chat-header/style.scss', () => ( {} ) );
 
@@ -54,6 +67,12 @@ function installJetpackAiSidebarPreviewData( features: Record< string, boolean >
 	};
 }
 
+function installAdminBarTrigger() {
+	const el = document.createElement( 'div' );
+	el.id = 'wp-admin-bar-agents-manager';
+	document.body.appendChild( el );
+}
+
 function renderChatHeader() {
 	return render(
 		<MemoryRouter>
@@ -65,6 +84,9 @@ function renderChatHeader() {
 describe( 'ChatHeader', () => {
 	afterEach( () => {
 		delete ( globalThis as AgentsManagerTestGlobal ).agentsManagerData;
+		mockIsDocked = false;
+		mockSetIsMinimized.mockClear();
+		document.getElementById( 'wp-admin-bar-agents-manager' )?.remove();
 	} );
 
 	it( 'shows the history button by default', () => {
@@ -87,5 +109,29 @@ describe( 'ChatHeader', () => {
 		renderChatHeader();
 
 		expect( screen.queryByText( 'View history' ) ).toBeNull();
+	} );
+
+	it( 'minimizes the chat when the Minimize button is clicked', () => {
+		installAdminBarTrigger();
+
+		renderChatHeader();
+		fireEvent.click( screen.getByText( 'Minimize' ) );
+
+		expect( mockSetIsMinimized ).toHaveBeenCalledWith( true );
+	} );
+
+	it( 'hides the Minimize button without the WP admin bar trigger', () => {
+		renderChatHeader();
+
+		expect( screen.queryByText( 'Minimize' ) ).toBeNull();
+	} );
+
+	it( 'hides the Minimize button when docked', () => {
+		installAdminBarTrigger();
+		mockIsDocked = true;
+
+		renderChatHeader();
+
+		expect( screen.queryByText( 'Minimize' ) ).toBeNull();
 	} );
 } );

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -213,7 +213,7 @@ export default function AgentChat( {
 		[ mergedComponents, markdownExtensions ]
 	);
 
-	let floatingChatState: ChatState = 'collapsed';
+	let floatingChatState: ChatState = 'minimized';
 	if ( isOpen ) {
 		floatingChatState = 'expanded';
 	} else if ( isCompactMode ) {

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -350,6 +350,7 @@ export default function AgentDock( {
 		<SupportGuide
 			onAbort={ handleAbort }
 			onClose={ handleClose }
+			onExpand={ handleExpand }
 			isDocked={ isDocked }
 			isOpen={ chatIsOpen }
 			chatHeaderOptions={ chatHeaderOptions }
@@ -360,6 +361,7 @@ export default function AgentDock( {
 		<SupportGuides
 			onAbort={ handleAbort }
 			onClose={ handleClose }
+			onExpand={ handleExpand }
 			isDocked={ isDocked }
 			isOpen={ chatIsOpen }
 			chatHeaderOptions={ chatHeaderOptions }

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -5,7 +5,7 @@ import {
 	type Suggestion,
 } from '@automattic/agenttic-ui';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useCallback, useEffect, useState } from '@wordpress/element';
+import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { columns, comment, drawerRight, login } from '@wordpress/icons';
 import { Routes, Route, Navigate, useLocation, useNavigate } from 'react-router-dom';
@@ -13,6 +13,7 @@ import { useAgentsManagerContext } from '../../contexts';
 import { useSetupCustomActions } from '../../hooks/custom-actions';
 import useAdminBarIntegration from '../../hooks/use-admin-bar-integration';
 import useAgentLayoutManager from '../../hooks/use-agent-layout-manager';
+import useReaderChatPersistence from '../../hooks/use-reader-chat-persistence';
 import { useShouldUseUnifiedAgent } from '../../hooks/use-should-use-unified-agent';
 import { AGENTS_MANAGER_STORE } from '../../stores';
 import { LocalConversationListItem } from '../../types';
@@ -114,29 +115,23 @@ export default function AgentDock( {
 		! isReaderChat && isJetpackAiSidebarPreviewFeatureEnabled( 'chatHistory' );
 	const showSupportGuides =
 		! isReaderChat && isJetpackAiSidebarPreviewFeatureEnabled( 'supportGuides' );
+	// Woo AI sites (sectionName 'wooai-admin') don't have HVM tagging yet,
+	// so Zendesk escalation is disabled until routing is in place.
+	const isWooAiAdmin = sectionName === 'wooai-admin';
+	const shouldShowUnifiedSupport = shouldUseUnifiedAgent && ! isReaderChat && ! isWooAiAdmin;
 	const setOpenState = useCallback(
 		( isOpen: boolean ) => setIsOpen( isOpen, ! isReaderChat ),
 		[ isReaderChat, setIsOpen ]
 	);
-
-	const goToActiveChat = () => {
-		// Keep a live conversation (orchestrator or Zendesk) as-is.
-		if ( pathname === '/chat' || pathname === '/zendesk' ) {
-			return;
-		}
-		// Resume the active session — `/chat` alone would start a new chat.
-		navigate( '/chat', { state: { sessionId: getActiveSessionId() } } );
-	};
 
 	const { isDocked, canDock, dock, undock, openSidebar, closeSidebar, createAgentPortal } =
 		useAgentLayoutManager( {
 			defaultDocked: isReaderChat ? false : isPersistedDocked,
 			defaultOpen: isPersistedOpen,
 			desktopMediaQuery,
-			onOpenSidebar: () => {
-				setOpenState( true );
-				goToActiveChat();
-			},
+			// Only open the sidebar; keep the current route. Admin-bar items
+			// set their own route (e.g. history) before opening it.
+			onOpenSidebar: () => setOpenState( true ),
 			onCloseSidebar: () => setOpenState( false ),
 			isSplitScreen,
 		} );
@@ -171,6 +166,8 @@ export default function AgentDock( {
 		setDesktopMediaQuery,
 	} );
 
+	useReaderChatPersistence( agentId );
+
 	const handleAbort = useCallback( () => {
 		const agentManager = getAgentManager();
 
@@ -178,11 +175,6 @@ export default function AgentDock( {
 			agentManager.abortCurrentRequest( agentId );
 		}
 	}, [ agentId ] );
-
-	// Woo AI sites (sectionName 'wooai-admin') don't have HVM tagging yet,
-	// so Zendesk escalation is disabled until routing is in place.
-	const isWooAiAdmin = sectionName === 'wooai-admin';
-	const shouldShowUnifiedSupport = shouldUseUnifiedAgent && ! isReaderChat && ! isWooAiAdmin;
 
 	const handleChatHasMessagesChange = useCallback(
 		( hasMessages: boolean ) => setIsOrchestratorChatEmpty( ! hasMessages ),
@@ -196,7 +188,12 @@ export default function AgentDock( {
 			setIsMinimized( false );
 		}
 		setOpenState( true );
-		goToActiveChat();
+
+		// Return to the active chat, resuming its session — unless already
+		// on a live chat/Zendesk view.
+		if ( pathname !== '/chat' && pathname !== '/zendesk' ) {
+			navigate( '/chat', { state: { sessionId: getActiveSessionId() } } );
+		}
 	};
 
 	const handleSelectConversation = ( conversation: LocalConversationListItem ) => {
@@ -213,40 +210,6 @@ export default function AgentDock( {
 			navigate( '/chat', { state: { sessionId } } );
 		}
 	};
-
-	// Persist reader-chat open/closed state across page navigations via
-	// localStorage — the AGENTS_MANAGER_STORE is in-memory only, so a fresh
-	// page load resets isOpen to false by default. Read the stored flag on
-	// mount and restore; write it on every toggle.
-	const OPEN_STORAGE_KEY = `jetpack-reader-chat-open-${ agentId }`;
-	useEffect( () => {
-		if ( ! isReaderChat ) {
-			return;
-		}
-		try {
-			if ( localStorage.getItem( OPEN_STORAGE_KEY ) === '1' && ! isPersistedOpen ) {
-				setOpenState( true );
-			}
-		} catch {
-			// ignore
-		}
-		// Only restore on first mount.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [] );
-	useEffect( () => {
-		if ( ! isReaderChat ) {
-			return;
-		}
-		try {
-			if ( isPersistedOpen ) {
-				localStorage.setItem( OPEN_STORAGE_KEY, '1' );
-			} else {
-				localStorage.removeItem( OPEN_STORAGE_KEY );
-			}
-		} catch {
-			// ignore
-		}
-	}, [ isPersistedOpen, isReaderChat, OPEN_STORAGE_KEY ] );
 
 	const getChatHeaderOptions = (): ChatHeaderOptions => {
 		return [

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -7,7 +7,7 @@ import {
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { columns, comment, drawerRight, help, login, lifesaver } from '@wordpress/icons';
+import { columns, comment, drawerRight, login } from '@wordpress/icons';
 import { Routes, Route, Navigate, useLocation, useNavigate } from 'react-router-dom';
 import { useAgentsManagerContext } from '../../contexts';
 import { useSetupCustomActions } from '../../hooks/custom-actions';
@@ -76,7 +76,7 @@ export default function AgentDock( {
 	useCheckpoint,
 	capabilities,
 }: Props ) {
-	const { siteKey, sectionName, agentConfig } = useAgentsManagerContext();
+	const { siteKey, sectionName, agentConfig, getActiveSessionId } = useAgentsManagerContext();
 
 	const [ isCompactMode, setIsCompactMode ] = useState(
 		window.__agentsManagerActions?.isCompactMode ?? false
@@ -88,11 +88,12 @@ export default function AgentDock( {
 		window.__agentsManagerActions?.desktopMediaQuery
 	);
 	const [ isOrchestratorChatEmpty, setIsOrchestratorChatEmpty ] = useState( true );
-	const [ isZendeskChatEmpty, setIsZendeskChatEmpty ] = useState( true );
-	const { setIsOpen, setIsDocked, setIsSplitScreen } = useDispatch( AGENTS_MANAGER_STORE );
+	const { setIsOpen, setIsDocked, setIsMinimized, setIsSplitScreen } =
+		useDispatch( AGENTS_MANAGER_STORE );
 	const {
 		isOpen: isPersistedOpen = false,
 		isDocked: isPersistedDocked = false,
+		isMinimized = false,
 		isSplitScreen = false,
 	} = useSelect( ( select ) => {
 		const store: AgentsManagerSelect = select( AGENTS_MANAGER_STORE );
@@ -118,21 +119,36 @@ export default function AgentDock( {
 		[ isReaderChat, setIsOpen ]
 	);
 
+	const goToActiveChat = () => {
+		// Keep a live conversation (orchestrator or Zendesk) as-is.
+		if ( pathname === '/chat' || pathname === '/zendesk' ) {
+			return;
+		}
+		// Resume the active session — `/chat` alone would start a new chat.
+		navigate( '/chat', { state: { sessionId: getActiveSessionId() } } );
+	};
+
 	const { isDocked, canDock, dock, undock, openSidebar, closeSidebar, createAgentPortal } =
 		useAgentLayoutManager( {
 			defaultDocked: isReaderChat ? false : isPersistedDocked,
 			defaultOpen: isPersistedOpen,
 			desktopMediaQuery,
-			onOpenSidebar: () => setOpenState( true ),
+			onOpenSidebar: () => {
+				setOpenState( true );
+				goToActiveChat();
+			},
 			onCloseSidebar: () => setOpenState( false ),
 			isSplitScreen,
 		} );
 
-	// Handle WordPress admin bar integration
-	useAdminBarIntegration( {
+	// WP admin bar integration. Returns whether a trigger button can reopen the chat.
+	const hasAdminBarTrigger = useAdminBarIntegration( {
 		isOpen: isPersistedOpen,
 		sectionName,
 		maybeOpenChat: () => {
+			if ( isMinimized ) {
+				setIsMinimized( false );
+			}
 			if ( ! isPersistedOpen ) {
 				if ( isDocked ) {
 					openSidebar();
@@ -172,18 +188,15 @@ export default function AgentDock( {
 		( hasMessages: boolean ) => setIsOrchestratorChatEmpty( ! hasMessages ),
 		[]
 	);
-	const handleZendeskHasMessagesChange = useCallback(
-		( hasMessages: boolean ) => setIsZendeskChatEmpty( ! hasMessages ),
-		[]
-	);
 
 	const handleClose = isDocked ? closeSidebar : () => setOpenState( false );
 
 	const handleExpand = () => {
-		setOpenState( true );
-		if ( pathname === '/history' ) {
-			navigate( '/' );
+		if ( isMinimized ) {
+			setIsMinimized( false );
 		}
+		setOpenState( true );
+		goToActiveChat();
 	};
 
 	const handleSelectConversation = ( conversation: LocalConversationListItem ) => {
@@ -243,21 +256,6 @@ export default function AgentDock( {
 				isDisabled: pathname === '/chat' && isOrchestratorChatEmpty,
 				onClick: () => navigate( '/' ),
 			},
-			shouldShowUnifiedSupport && {
-				icon: lifesaver,
-				title: __( 'New Zendesk chat', '__i18n_text_domain__' ),
-				isDisabled: pathname === '/zendesk' && isZendeskChatEmpty,
-				onClick: () => {
-					handleAbort();
-					navigate( '/zendesk' );
-				},
-			},
-			showSupportGuides && {
-				icon: help,
-				title: __( 'Support guides', '__i18n_text_domain__' ),
-				isDisabled: pathname === '/support-guides',
-				onClick: () => navigate( '/support-guides' ),
-			},
 			// Sidebar docking only makes sense in wp-admin where a block-editor
 			// sidebar slot exists. On public reader-chat frontends there's no
 			// sidebar to dock into — the click does nothing, so hide the option.
@@ -296,11 +294,17 @@ export default function AgentDock( {
 
 	const chatHeaderOptions = getChatHeaderOptions();
 
+	// The WP admin bar trigger can reopen the chat, so it gates two behaviors:
+	// hide it on close, and minimize it to the bar.
+	const isChatVisible = isPersistedOpen || ! hasAdminBarTrigger;
+	const isMinimizedActive = hasAdminBarTrigger && isMinimized;
+	const chatIsOpen = isPersistedOpen && ! isMinimizedActive;
+
 	const OrchestratorChatRoute = (
 		<OrchestratorChat
 			emptyViewSuggestions={ emptyViewSuggestions }
 			isDocked={ isDocked }
-			isOpen={ isPersistedOpen }
+			isOpen={ chatIsOpen }
 			onClose={ handleClose }
 			onExpand={ handleExpand }
 			chatHeaderOptions={ chatHeaderOptions }
@@ -321,13 +325,12 @@ export default function AgentDock( {
 	const ZendeskChatRoute = (
 		<ZendeskChat
 			isDocked={ isDocked }
-			isOpen={ isPersistedOpen }
+			isOpen={ chatIsOpen }
 			onClose={ handleClose }
 			onExpand={ handleExpand }
 			chatHeaderOptions={ chatHeaderOptions }
 			markdownComponents={ markdownComponents }
 			markdownExtensions={ markdownExtensions }
-			onHasMessagesChange={ handleZendeskHasMessagesChange }
 		/>
 	);
 
@@ -335,7 +338,7 @@ export default function AgentDock( {
 		<AgentHistory
 			chatHeaderOptions={ chatHeaderOptions }
 			isDocked={ isDocked }
-			isOpen={ isPersistedOpen }
+			isOpen={ chatIsOpen }
 			onAbort={ handleAbort }
 			onClose={ handleClose }
 			onExpand={ handleExpand }
@@ -346,9 +349,9 @@ export default function AgentDock( {
 	const SupportGuideRoute = (
 		<SupportGuide
 			onAbort={ handleAbort }
-			onClose={ closeSidebar }
+			onClose={ handleClose }
 			isDocked={ isDocked }
-			isOpen={ isPersistedOpen }
+			isOpen={ chatIsOpen }
 			chatHeaderOptions={ chatHeaderOptions }
 		/>
 	);
@@ -356,15 +359,16 @@ export default function AgentDock( {
 	const SupportGuidesRoute = (
 		<SupportGuides
 			onAbort={ handleAbort }
-			onClose={ closeSidebar }
+			onClose={ handleClose }
 			isDocked={ isDocked }
-			isOpen={ isPersistedOpen }
+			isOpen={ chatIsOpen }
 			chatHeaderOptions={ chatHeaderOptions }
 		/>
 	);
 
 	return (
 		shouldRenderChat &&
+		isChatVisible &&
 		createAgentPortal(
 			// NOTE: Use route state to pass data that needs to be accessed throughout the app.
 			<Routes>

--- a/packages/agents-manager/src/components/agent-history/index.tsx
+++ b/packages/agents-manager/src/components/agent-history/index.tsx
@@ -59,7 +59,7 @@ export default function AgentHistory( {
 			error={ null }
 			onSubmit={ () => {} }
 			variant={ isDocked ? 'embedded' : 'floating' }
-			floatingChatState={ isOpen ? 'expanded' : 'collapsed' }
+			floatingChatState={ isOpen ? 'expanded' : 'minimized' }
 			onClose={ onClose }
 			onExpand={ onExpand }
 			onStop={ onAbort }

--- a/packages/agents-manager/src/components/chat-header/index.tsx
+++ b/packages/agents-manager/src/components/chat-header/index.tsx
@@ -1,9 +1,14 @@
 import { Button, DropdownMenu } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { close, moreVertical, backup, chevronLeft, Icon } from '@wordpress/icons';
+import { close, lineSolid, moreVertical, backup, chevronLeft, Icon } from '@wordpress/icons';
 import { useNavigate } from 'react-router-dom';
+import { ADMIN_BAR_BUTTON_ID } from '../../hooks/use-admin-bar-integration';
+import { AGENTS_MANAGER_STORE } from '../../stores';
 import { isReaderChatHost } from '../../utils/is-reader-chat-agent';
 import { isJetpackAiSidebarPreviewFeatureEnabled } from '../../utils/jetpack-ai-sidebar-preview';
+import type { AgentsManagerSelect } from '@automattic/data-stores';
 import type { ComponentProps } from 'react';
 import './style.scss';
 
@@ -18,8 +23,19 @@ interface Props {
 
 export default function ChatHeader( { onClose, options, title, onBack }: Props ) {
 	const navigate = useNavigate();
+	const { setIsMinimized } = useDispatch( AGENTS_MANAGER_STORE );
+	const isDocked = useSelect(
+		( select ) => ( select( AGENTS_MANAGER_STORE ) as AgentsManagerSelect ).getIsDocked(),
+		[]
+	);
+	const [ hasAdminBarTrigger ] = useState(
+		() => !! document.getElementById( ADMIN_BAR_BUTTON_ID )
+	);
+
 	const showChatHistory =
 		! isReaderChatHost() && isJetpackAiSidebarPreviewFeatureEnabled( 'chatHistory' );
+	// Minimize only applies to the floating chat reachable from the WP admin bar.
+	const showMinimize = hasAdminBarTrigger && ! isDocked;
 
 	return (
 		<div className="agents-manager-chat-header">
@@ -58,6 +74,15 @@ export default function ChatHeader( { onClose, options, title, onBack }: Props )
 						icon={ backup }
 						onClick={ () => navigate( '/history' ) }
 						label={ __( 'View history', '__i18n_text_domain__' ) }
+						size="small"
+					/>
+				) }
+				{ showMinimize && (
+					<Button
+						className="agents-manager-chat-header__minimize-btn"
+						icon={ lineSolid }
+						onClick={ () => setIsMinimized( true ) }
+						label={ __( 'Minimize', '__i18n_text_domain__' ) }
 						size="small"
 					/>
 				) }

--- a/packages/agents-manager/src/components/support-guide/index.tsx
+++ b/packages/agents-manager/src/components/support-guide/index.tsx
@@ -63,7 +63,7 @@ export default function SupportGuide( {
 			error={ null }
 			onSubmit={ () => {} }
 			variant={ isDocked ? 'embedded' : 'floating' }
-			floatingChatState={ isOpen ? 'expanded' : 'collapsed' }
+			floatingChatState={ isOpen ? 'expanded' : 'minimized' }
 			onClose={ onClose }
 			onStop={ onAbort }
 			expandOnHover={ false }

--- a/packages/agents-manager/src/components/support-guide/index.tsx
+++ b/packages/agents-manager/src/components/support-guide/index.tsx
@@ -22,6 +22,8 @@ interface SupportGuideProps {
 	onAbort: () => void;
 	/** Called when the chat is closed. */
 	onClose: () => void;
+	/** Called when the chat is expanded (floating mode). */
+	onExpand: () => void;
 }
 
 export default function SupportGuide( {
@@ -30,6 +32,7 @@ export default function SupportGuide( {
 	isDocked,
 	onAbort,
 	onClose,
+	onExpand,
 }: SupportGuideProps ) {
 	const { site, sectionName, isEligibleForChat } = useAgentsManagerContext();
 	const navigate = useNavigate();
@@ -65,6 +68,7 @@ export default function SupportGuide( {
 			variant={ isDocked ? 'embedded' : 'floating' }
 			floatingChatState={ isOpen ? 'expanded' : 'minimized' }
 			onClose={ onClose }
+			onExpand={ onExpand }
 			onStop={ onAbort }
 			expandOnHover={ false }
 		>

--- a/packages/agents-manager/src/components/support-guides/index.tsx
+++ b/packages/agents-manager/src/components/support-guides/index.tsx
@@ -92,6 +92,8 @@ interface SupportGuidesProps {
 	onAbort: () => void;
 	/** Called when the chat is closed. */
 	onClose: () => void;
+	/** Called when the chat is expanded (floating mode). */
+	onExpand: () => void;
 }
 
 export default function SupportGuides( {
@@ -100,6 +102,7 @@ export default function SupportGuides( {
 	isDocked,
 	onAbort,
 	onClose,
+	onExpand,
 }: SupportGuidesProps ) {
 	const { state } = useLocation();
 	const [ searchInput, setSearchInput, debouncedSearchInput ] = useDebouncedInput(
@@ -123,6 +126,7 @@ export default function SupportGuides( {
 			variant={ isDocked ? 'embedded' : 'floating' }
 			floatingChatState={ isOpen ? 'expanded' : 'minimized' }
 			onClose={ onClose }
+			onExpand={ onExpand }
 			onStop={ onAbort }
 			expandOnHover={ false }
 		>

--- a/packages/agents-manager/src/components/support-guides/index.tsx
+++ b/packages/agents-manager/src/components/support-guides/index.tsx
@@ -121,7 +121,7 @@ export default function SupportGuides( {
 			error={ null }
 			onSubmit={ () => {} }
 			variant={ isDocked ? 'embedded' : 'floating' }
-			floatingChatState={ isOpen ? 'expanded' : 'collapsed' }
+			floatingChatState={ isOpen ? 'expanded' : 'minimized' }
 			onClose={ onClose }
 			onStop={ onAbort }
 			expandOnHover={ false }

--- a/packages/agents-manager/src/components/zendesk-chat/index.tsx
+++ b/packages/agents-manager/src/components/zendesk-chat/index.tsx
@@ -1,6 +1,5 @@
 import { type MarkdownComponents, type MarkdownExtensions } from '@automattic/agenttic-ui';
 import { useManagedZendeskChat } from '@automattic/zendesk-client';
-import { useEffect } from '@wordpress/element';
 import AgentChat from '../agent-chat';
 import { type Options as ChatHeaderOptions } from '../chat-header';
 import ConcludedConversationFooter from '../concluded-conversation-footer';
@@ -22,8 +21,6 @@ interface Props {
 	markdownComponents?: MarkdownComponents;
 	/** Custom markdown extensions. */
 	markdownExtensions?: MarkdownExtensions;
-	/** Called when the has-messages state changes. */
-	onHasMessagesChange: ( hasMessages: boolean ) => void;
 }
 
 export default function ZendeskChat( {
@@ -34,7 +31,6 @@ export default function ZendeskChat( {
 	onExpand,
 	markdownComponents = {},
 	markdownExtensions = {},
-	onHasMessagesChange,
 }: Props ) {
 	const {
 		agentticMessages,
@@ -47,12 +43,6 @@ export default function ZendeskChat( {
 		notice,
 		hasInteractionEnded,
 	} = useManagedZendeskChat();
-
-	// Notify parent when has-messages state changes
-	const hasMessages = agentticMessages.length > 0;
-	useEffect( () => {
-		onHasMessagesChange( hasMessages );
-	}, [ hasMessages, onHasMessagesChange ] );
 
 	return (
 		<AgentChat

--- a/packages/agents-manager/src/hooks/use-admin-bar-integration/index.tsx
+++ b/packages/agents-manager/src/hooks/use-admin-bar-integration/index.tsx
@@ -1,9 +1,9 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { useEffect, useRef } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import './style.scss';
 
 // Admin bar element selectors
-const ADMIN_BAR_BUTTON_ID = 'wp-admin-bar-agents-manager';
+export const ADMIN_BAR_BUTTON_ID = 'wp-admin-bar-agents-manager';
 const ADMIN_BAR_CHAT_ITEM_ID = 'wp-admin-bar-agents-manager-chat-support';
 const ADMIN_BAR_HISTORY_ITEM_ID = 'wp-admin-bar-agents-manager-chat-history';
 const ADMIN_BAR_GUIDES_ITEM_ID = 'wp-admin-bar-agents-manager-support-guides';
@@ -32,16 +32,21 @@ interface UseAdminBarIntegrationOptions {
  * - Menu panel toggle visibility
  * - Click outside to close menu
  * - Menu item click handlers with tracking
+ *
+ * Returns whether the WP admin bar trigger button is present on the page.
  */
 export default function useAdminBarIntegration( {
 	isOpen,
 	sectionName,
 	maybeOpenChat,
 	navigate,
-}: UseAdminBarIntegrationOptions ) {
+}: UseAdminBarIntegrationOptions ): boolean {
 	// Ref to avoid re-attaching DOM event listeners when the caller passes a new `maybeOpenChat` reference.
 	const maybeOpenChatRef = useRef( maybeOpenChat );
 	maybeOpenChatRef.current = maybeOpenChat;
+
+	// Whether the WP admin bar trigger button is on the page.
+	const [ hasButton ] = useState( () => !! document.getElementById( ADMIN_BAR_BUTTON_ID ) );
 
 	// Update admin bar button active state based on isOpen
 	useEffect( () => {
@@ -135,4 +140,6 @@ export default function useAdminBarIntegration( {
 			guidesItem?.removeEventListener( 'click', handleGuidesClick );
 		};
 	}, [ navigate, sectionName ] );
+
+	return hasButton;
 }

--- a/packages/agents-manager/src/hooks/use-reader-chat-persistence.ts
+++ b/packages/agents-manager/src/hooks/use-reader-chat-persistence.ts
@@ -1,0 +1,54 @@
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { AGENTS_MANAGER_STORE } from '../stores';
+import { isReaderChatAgent } from '../utils/is-reader-chat-agent';
+import type { AgentsManagerSelect } from '@automattic/data-stores';
+
+/**
+ * Persists the reader-chat open state across page navigations.
+ *
+ * Reader-chat runs on public blog frontends where `AGENTS_MANAGER_STORE` is
+ * in-memory only, so a fresh page load resets `isOpen` to false. Mirror the
+ * flag in `localStorage`: restore it on first mount and write it on every
+ * toggle. No-op for other agents, whose state is server-backed.
+ */
+export default function useReaderChatPersistence( agentId: string ): void {
+	const isReaderChat = isReaderChatAgent( agentId );
+	const storageKey = `jetpack-reader-chat-open-${ agentId }`;
+	const { setIsOpen } = useDispatch( AGENTS_MANAGER_STORE );
+	const isOpen = useSelect(
+		( select ) => ( select( AGENTS_MANAGER_STORE ) as AgentsManagerSelect ).getIsOpen(),
+		[]
+	);
+
+	// Restore on first mount.
+	useEffect( () => {
+		if ( ! isReaderChat ) {
+			return;
+		}
+		try {
+			if ( localStorage.getItem( storageKey ) === '1' && ! isOpen ) {
+				setIsOpen( true, false );
+			}
+		} catch {
+			// ignore
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+
+	// Write on every toggle.
+	useEffect( () => {
+		if ( ! isReaderChat ) {
+			return;
+		}
+		try {
+			if ( isOpen ) {
+				localStorage.setItem( storageKey, '1' );
+			} else {
+				localStorage.removeItem( storageKey );
+			}
+		} catch {
+			// ignore
+		}
+	}, [ isOpen, isReaderChat, storageKey ] );
+}

--- a/packages/block-notes/package.json
+++ b/packages/block-notes/package.json
@@ -41,7 +41,7 @@
 	},
 	"dependencies": {
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-client": "^0.1.58",
+		"@automattic/agenttic-client": "^0.1.65",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@wordpress/abilities": "^0.12.0",
 		"@wordpress/api-fetch": "^7.46.0",

--- a/packages/data-stores/src/agents-manager/actions.ts
+++ b/packages/data-stores/src/agents-manager/actions.ts
@@ -10,6 +10,7 @@ import type { APIFetchOptions } from '../shared-types';
 type AgentsManagerState = {
 	isOpen?: boolean;
 	isDocked?: boolean;
+	isMinimized?: boolean;
 	floatingPosition?: 'left' | 'right';
 	routerHistory?: null; // Only used to clear history
 };
@@ -35,6 +36,10 @@ export function* saveAgentsManagerState( state: AgentsManagerState ) {
 
 	if ( typeof state.isDocked === 'boolean' ) {
 		saveState.agents_manager_docked = state.isDocked;
+	}
+
+	if ( typeof state.isMinimized === 'boolean' ) {
+		saveState.agents_manager_minimized = state.isMinimized;
 	}
 
 	if ( state.floatingPosition === 'left' || state.floatingPosition === 'right' ) {
@@ -94,6 +99,17 @@ export function* setIsDocked( isDocked: boolean, shouldSave: boolean = true ) {
 	} as const;
 }
 
+export function* setIsMinimized( isMinimized: boolean, shouldSave: boolean = true ) {
+	if ( shouldSave ) {
+		yield saveAgentsManagerState( { isMinimized } );
+	}
+
+	return {
+		type: 'AGENTS_MANAGER_SET_MINIMIZED',
+		isMinimized,
+	} as const;
+}
+
 export function* setFloatingPosition(
 	floatingPosition: 'left' | 'right',
 	shouldSave: boolean = true
@@ -149,4 +165,5 @@ export type AgentsManagerAction =
 	| ReturnType< typeof setIsSplitScreen >
 	| GeneratorReturnType< typeof setIsOpen >
 	| GeneratorReturnType< typeof setIsDocked >
+	| GeneratorReturnType< typeof setIsMinimized >
 	| GeneratorReturnType< typeof setFloatingPosition >;

--- a/packages/data-stores/src/agents-manager/reducer.ts
+++ b/packages/data-stores/src/agents-manager/reducer.ts
@@ -19,6 +19,17 @@ const isDocked: Reducer< boolean | undefined, AgentsManagerAction > = ( state, a
 	return state;
 };
 
+export const isMinimized: Reducer< boolean | undefined, AgentsManagerAction > = (
+	state,
+	action
+) => {
+	switch ( action.type ) {
+		case 'AGENTS_MANAGER_SET_MINIMIZED':
+			return action.isMinimized;
+	}
+	return state;
+};
+
 const routerHistory: Reducer< PerSiteRouterHistory | undefined, AgentsManagerAction > = (
 	state,
 	action
@@ -84,6 +95,7 @@ export const isSplitScreen: Reducer< boolean, AgentsManagerAction > = ( state = 
 const reducer = combineReducers( {
 	isOpen,
 	isDocked,
+	isMinimized,
 	routerHistory,
 	lastActivity,
 	isLoading,

--- a/packages/data-stores/src/agents-manager/resolvers.ts
+++ b/packages/data-stores/src/agents-manager/resolvers.ts
@@ -5,6 +5,7 @@ import {
 	setRouterHistory,
 	setLastActivity,
 	setIsDocked,
+	setIsMinimized,
 	setIsOpen,
 	setIsLoading,
 	setHasLoaded,
@@ -30,6 +31,7 @@ function isValidRouterHistory( value: unknown ): value is PerSiteRouterHistory {
 type AgentsManagerStateResponse = {
 	agents_manager_open?: boolean;
 	agents_manager_docked?: boolean;
+	agents_manager_minimized?: boolean;
 	agents_manager_floating_position?: 'left' | 'right';
 	agents_manager_router_history?: PerSiteRouterHistory;
 	agents_manager_last_activity?: PerSiteLastActivity;
@@ -59,6 +61,10 @@ export function* getAgentsManagerState() {
 
 		if ( typeof state.agents_manager_docked === 'boolean' ) {
 			yield setIsDocked( state.agents_manager_docked, false );
+		}
+
+		if ( typeof state.agents_manager_minimized === 'boolean' ) {
+			yield setIsMinimized( state.agents_manager_minimized, false );
 		}
 
 		if (

--- a/packages/data-stores/src/agents-manager/selectors.ts
+++ b/packages/data-stores/src/agents-manager/selectors.ts
@@ -3,6 +3,7 @@ import type { State } from './reducer';
 export const getAgentsManagerState = ( state: State ) => ( {
 	isOpen: state.isOpen,
 	isDocked: state.isDocked,
+	isMinimized: state.isMinimized,
 	routerHistory: state.routerHistory,
 	lastActivity: state.lastActivity,
 	isLoading: state.isLoading,
@@ -12,6 +13,7 @@ export const getAgentsManagerState = ( state: State ) => ( {
 } );
 export const getIsOpen = ( state: State ) => state.isOpen;
 export const getIsDocked = ( state: State ) => state.isDocked;
+export const getIsMinimized = ( state: State ) => state.isMinimized;
 export const getIsSplitScreen = ( state: State ) => state.isSplitScreen;
 export const getRouterHistory = ( state: State, siteKey: string ) => {
 	if ( ! state.routerHistory ) {

--- a/packages/data-stores/src/agents-manager/test/reducer.test.ts
+++ b/packages/data-stores/src/agents-manager/test/reducer.test.ts
@@ -1,16 +1,19 @@
-import { isSplitScreen } from '../reducer';
-import { getIsSplitScreen } from '../selectors';
+import { isMinimized, isSplitScreen } from '../reducer';
+import { getIsMinimized, getIsSplitScreen } from '../selectors';
 import type { State } from '../reducer';
 
 const setSplit = ( isSplit: boolean ) =>
 	( { type: 'AGENTS_MANAGER_SET_SPLIT_SCREEN', isSplitScreen: isSplit } ) as const;
+
+const setMinimized = ( minimized: boolean ) =>
+	( { type: 'AGENTS_MANAGER_SET_MINIMIZED', isMinimized: minimized } ) as const;
 
 describe( 'isSplitScreen reducer slice', () => {
 	it( 'defaults to false', () => {
 		expect( isSplitScreen( undefined, { type: '@@INIT' } as never ) ).toBe( false );
 	} );
 
-	it( 'returns the action value on AGENTS_MANAGER_SET_SPLIT_SCREEN', () => {
+	it( 'returns the action value on `AGENTS_MANAGER_SET_SPLIT_SCREEN`', () => {
 		expect( isSplitScreen( false, setSplit( true ) ) ).toBe( true );
 		expect( isSplitScreen( true, setSplit( false ) ) ).toBe( false );
 	} );
@@ -38,5 +41,29 @@ describe( 'getIsSplitScreen selector', () => {
 		const state = { isSplitScreen: true } as State;
 		expect( getIsSplitScreen( state ) ).toBe( true );
 		expect( getIsSplitScreen( { isSplitScreen: false } as State ) ).toBe( false );
+	} );
+} );
+
+describe( 'isMinimized reducer slice', () => {
+	it( 'defaults to undefined', () => {
+		expect( isMinimized( undefined, { type: '@@INIT' } as never ) ).toBeUndefined();
+	} );
+
+	it( 'returns the action value on `AGENTS_MANAGER_SET_MINIMIZED`', () => {
+		expect( isMinimized( undefined, setMinimized( true ) ) ).toBe( true );
+		expect( isMinimized( true, setMinimized( false ) ) ).toBe( false );
+	} );
+
+	it( 'leaves state untouched on unrelated actions', () => {
+		expect( isMinimized( true, { type: 'AGENTS_MANAGER_SET_OPEN', isOpen: false } as never ) ).toBe(
+			true
+		);
+	} );
+} );
+
+describe( 'getIsMinimized selector', () => {
+	it( 'returns the slice value', () => {
+		expect( getIsMinimized( { isMinimized: true } as State ) ).toBe( true );
+		expect( getIsMinimized( { isMinimized: false } as State ) ).toBe( false );
 	} );
 } );

--- a/packages/image-studio/package.json
+++ b/packages/image-studio/package.json
@@ -51,8 +51,8 @@
 	},
 	"dependencies": {
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-client": "^0.1.58",
-		"@automattic/agenttic-ui": "^0.1.58",
+		"@automattic/agenttic-client": "^0.1.65",
+		"@automattic/agenttic-ui": "^0.1.65",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/oauth-token": "workspace:^",
 		"@wordpress/abilities": "^0.12.0",

--- a/packages/jetpack-ai-sidebar/package.json
+++ b/packages/jetpack-ai-sidebar/package.json
@@ -44,7 +44,7 @@
 		"typecheck": "tsc --build --dry"
 	},
 	"dependencies": {
-		"@automattic/agenttic-client": "^0.1.58",
+		"@automattic/agenttic-client": "^0.1.65",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/calypso-url": "workspace:^",
 		"@wordpress/abilities": "^0.12.0",

--- a/packages/odie-client/package.json
+++ b/packages/odie-client/package.json
@@ -41,7 +41,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-ui": "^0.1.58",
+		"@automattic/agenttic-ui": "^0.1.65",
 		"@automattic/components": "workspace:^",
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/zendesk-client": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -143,8 +143,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/agents-manager@workspace:packages/agents-manager"
   dependencies:
-    "@automattic/agenttic-client": "npm:^0.1.58"
-    "@automattic/agenttic-ui": "npm:^0.1.58"
+    "@automattic/agenttic-client": "npm:^0.1.65"
+    "@automattic/agenttic-ui": "npm:^0.1.65"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
@@ -190,9 +190,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/agenttic-client@npm:^0.1.58":
-  version: 0.1.58
-  resolution: "@automattic/agenttic-client@npm:0.1.58"
+"@automattic/agenttic-client@npm:^0.1.65":
+  version: 0.1.65
+  resolution: "@automattic/agenttic-client@npm:0.1.65"
   dependencies:
     "@types/react": "npm:^18.0.0"
     marked: "npm:^16.2.1"
@@ -206,13 +206,13 @@ __metadata:
   peerDependenciesMeta:
     "@wordpress/api-fetch":
       optional: true
-  checksum: 56f7c576329369a8c3e827112ea2f930b333c0e1eae4c4f80b2d3064a93ea9671317b5a90c2d91dfa2eb2bcb93bff8e6ffc24c72b7de5ed031d3f68346586e90
+  checksum: 0ae1174b03c24cee7333d44970bc708f7f979a9376e50d94b9782fdb0db4977a08fefd319a40c7af88f1a0dedd010f974b43d25dfa7591c7b8acb95b7205b7d8
   languageName: node
   linkType: hard
 
-"@automattic/agenttic-ui@npm:^0.1.58":
-  version: 0.1.58
-  resolution: "@automattic/agenttic-ui@npm:0.1.58"
+"@automattic/agenttic-ui@npm:^0.1.65":
+  version: 0.1.65
+  resolution: "@automattic/agenttic-ui@npm:0.1.65"
   dependencies:
     "@automattic/charts": "npm:>=0.58.0 <1.0.0"
     "@floating-ui/react-dom": "npm:^2.1.6"
@@ -238,7 +238,7 @@ __metadata:
   dependenciesMeta:
     marked:
       optional: true
-  checksum: 0488aace57988ef5cd260dad10edce3f1404f11d66acd0136fac8008065fc7c2654c685ade6733fc202cc36e705215502ca04cc4808814682a69e9a104624877
+  checksum: bbe517f06f87a838c6da18fa25eb32fdab5abb88d2e291900ed3387212ac225d2525ed2ea01026bb9ef3956a7280f2a60a7bc71994bea7bb111008b457652b19
   languageName: node
   linkType: hard
 
@@ -352,7 +352,7 @@ __metadata:
   resolution: "@automattic/block-notes@workspace:packages/block-notes"
   dependencies:
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-client": "npm:^0.1.58"
+    "@automattic/agenttic-client": "npm:^0.1.65"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@testing-library/react": "npm:^15.0.0"
@@ -1507,8 +1507,8 @@ __metadata:
   resolution: "@automattic/image-studio@workspace:packages/image-studio"
   dependencies:
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-client": "npm:^0.1.58"
-    "@automattic/agenttic-ui": "npm:^0.1.58"
+    "@automattic/agenttic-client": "npm:^0.1.65"
+    "@automattic/agenttic-ui": "npm:^0.1.65"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/oauth-token": "workspace:^"
@@ -1603,7 +1603,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/jetpack-ai-sidebar@workspace:packages/jetpack-ai-sidebar"
   dependencies:
-    "@automattic/agenttic-client": "npm:^0.1.58"
+    "@automattic/agenttic-client": "npm:^0.1.65"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/calypso-url": "workspace:^"
@@ -1866,7 +1866,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/odie-client@workspace:packages/odie-client"
   dependencies:
-    "@automattic/agenttic-ui": "npm:^0.1.58"
+    "@automattic/agenttic-ui": "npm:^0.1.65"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/i18n-utils": "workspace:^"
@@ -13948,7 +13948,7 @@ __metadata:
   dependencies:
     "@automattic/accessible-focus": "workspace:^"
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-ui": "npm:^0.1.58"
+    "@automattic/agenttic-ui": "npm:^0.1.65"
     "@automattic/api-core": "workspace:^"
     "@automattic/api-queries": "workspace:^"
     "@automattic/block-renderer": "workspace:^"


### PR DESCRIPTION
Linear: `AI-986`, `AI-985`

## Proposed Changes

Adds a persisted **minimized** state to the Agents Manager floating chat.

- Undocked floating chat uses the agenttic `minimized` bar as its closed state (was the collapsed FAB).
- Minimized state is **persisted** via the store (server-backed `agents_manager_minimized`) and respected only when the WP admin bar trigger is present.
- Adds a header **Minimize** button (shown when the admin bar trigger is present and undocked).
- **Hide-on-close:** closing unmounts the chat when the admin bar can reopen it; otherwise the minimized bar remains.
- **Expanding** the minimized bar returns to the active conversation, resuming its session — a live chat or Zendesk view is kept as-is.
- Docked (sidebar) chat is unchanged — keeps its original FAB.
- Removed the **New Zendesk chat** and **Support guides** menu options — they were for development testing only.
- Reader-chat open-state persistence moved into a `useReaderChatPersistence` hook (no behavior change).

**Depends on:** agenttic-ui `minimized` ChatState (`AI-985`, released) and the backend `agents_manager_minimized` allowed key.

## Testing Instructions

- Sandbox this PR
- Go to `https://<YOUR_SITE_URL>/wp-admin/`, and the docked and undocked chat should work as follows:
  - Click the "X" to hide the chat
  - Click the WP admin-bar > dropdown menu items will open (or expand) the corresponding view
  - The undocked chat has a new "Minimized" option in the top bar section
  - Expand the undocked chat, which will show the active chat
  - The chat states will be persisted: `minimzed`, `hidden`, `expanded`
  
https://github.com/user-attachments/assets/47c4f758-dc5b-4db7-94d2-0c0cf126bf51

- Go to: `https://<YOUR_SITE_URL>/wp-admin/site-editor.php?p=%2F&canvas=edit`, and the docked and undocked chat should work as follows:
  - The undocked chat doesn't have the "Minimized" option
  - Close the undocked chat, now use the minimized state instead
  - Chat state should be persisted the same as before

https://github.com/user-attachments/assets/509adb48-6565-46da-9340-7514aee7cf12

