### PR TITLE
Fix chat inactivity time logic

### DIFF
--- a/packages/agents-manager/src/hooks/__tests__/use-persisted-history.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-persisted-history.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import { usePersistedHistory } from '../use-persisted-history';
+
+let mockSelectValues = {
+	persistedHistory: undefined as { entries: { pathname: string }[]; index: number } | undefined,
+	lastActive: undefined as number | undefined,
+};
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn( () => mockSelectValues ),
+	select: jest.fn( () => ( {
+		getAgentsManagerState: () => ( { routerHistory: {} } ),
+	} ) ),
+} ) );
+
+jest.mock( '../../stores', () => ( {
+	AGENTS_MANAGER_STORE: 'agents-manager-store',
+} ) );
+
+const HOUR_MS = 60 * 60 * 1000;
+
+function entry( pathname: string ) {
+	return { pathname, search: '', hash: '', key: pathname, state: null };
+}
+
+describe( 'usePersistedHistory — staleness gate', () => {
+	afterEach( () => {
+		jest.clearAllMocks();
+		mockSelectValues = { persistedHistory: undefined, lastActive: undefined };
+	} );
+
+	it( 'does not restore an expired active chat (stale + /chat)', () => {
+		const logSpy = jest.spyOn( console, 'log' ).mockImplementation( () => {} );
+		mockSelectValues = {
+			persistedHistory: { entries: [ entry( '/' ), entry( '/chat' ) ], index: 1 },
+			lastActive: Date.now() - ( HOUR_MS + 1000 ),
+		};
+
+		const { result } = renderHook( () => usePersistedHistory( 'site-1' ) );
+
+		// Falls back to the default root entry instead of the persisted /chat.
+		expect( result.current.history.length ).toBe( 1 );
+		expect( result.current.history.location.pathname ).toBe( '/' );
+		expect( logSpy ).toHaveBeenCalledWith(
+			'[AgentsManager] Active chat expired for site key "site-1"'
+		);
+		logSpy.mockRestore();
+	} );
+
+	it( 'restores a stale history when the last path is not /chat', () => {
+		mockSelectValues = {
+			persistedHistory: { entries: [ entry( '/' ), entry( '/history' ) ], index: 1 },
+			lastActive: Date.now() - ( HOUR_MS + 1000 ),
+		};
+
+		const { result } = renderHook( () => usePersistedHistory( 'site-1' ) );
+
+		expect( result.current.history.length ).toBe( 2 );
+		expect( result.current.history.location.pathname ).toBe( '/history' );
+	} );
+
+	it( 'restores an active chat when not stale', () => {
+		mockSelectValues = {
+			persistedHistory: { entries: [ entry( '/' ), entry( '/chat' ) ], index: 1 },
+			lastActive: Date.now(),
+		};
+
+		const { result } = renderHook( () => usePersistedHistory( 'site-1' ) );
+
+		expect( result.current.history.length ).toBe( 2 );
+		expect( result.current.history.location.pathname ).toBe( '/chat' );
+	} );
+
+	it( 'falls back to the default root entry when there is no persisted history', () => {
+		mockSelectValues = { persistedHistory: undefined, lastActive: Date.now() };
+
+		const { result } = renderHook( () => usePersistedHistory( 'site-1' ) );
+
+		expect( result.current.history.length ).toBe( 1 );
+		expect( result.current.history.location.pathname ).toBe( '/' );
+	} );
+} );

--- a/packages/agents-manager/src/hooks/use-persisted-history.ts
+++ b/packages/agents-manager/src/hooks/use-persisted-history.ts
@@ -172,9 +172,7 @@ export const usePersistedHistory = ( siteKey: string ) => {
 	const activeHistory = useMemo( () => {
 		// Staleness only blocks restoration of an old chat. Other routes
 		// (/history, /post, etc.) restore normally even when stale.
-		const entries = persistedHistory?.entries;
-		const lastPath =
-			entries && entries.length ? entries[ persistedHistory.index ]?.pathname : undefined;
+		const lastPath = persistedHistory?.entries?.[ persistedHistory.index ]?.pathname;
 		if ( isStale && lastPath === '/chat' ) {
 			// eslint-disable-next-line no-console
 			console.log( `[AgentsManager] Active chat expired for site key "${ siteKey }"` );

--- a/packages/agents-manager/src/hooks/use-persisted-history.ts
+++ b/packages/agents-manager/src/hooks/use-persisted-history.ts
@@ -170,7 +170,12 @@ export const usePersistedHistory = ( siteKey: string ) => {
 	// Skip restoring history if the site has been inactive beyond the timeout.
 	const isStale = lastActive ? Date.now() - lastActive > getInactivityTimeoutMs() : false;
 	const activeHistory = useMemo( () => {
-		if ( isStale ) {
+		// Staleness only blocks restoration of an old chat. Other routes
+		// (/history, /post, etc.) restore normally even when stale.
+		const entries = persistedHistory?.entries;
+		const lastPath =
+			entries && entries.length ? entries[ persistedHistory.index ]?.pathname : undefined;
+		if ( isStale && lastPath === '/chat' ) {
 			// eslint-disable-next-line no-console
 			console.log( `[AgentsManager] Active chat expired for site key "${ siteKey }"` );
 			return;


### PR DESCRIPTION
Part of AI-989

## Proposed Changes

Fix the inactivity time logic to only prevent the router history from being restored when the current route is `/chat`

## Testing Instructions

* Make sure the Unified AI Chat is enabled on https://wordpress.com/wp-admin/profile.php
* Run Calypso locally and open `https://wordpress.com/home/[YOUR_SITE]?inactivity_timeout=1`
  * The flag `?inactivity_timeout=1` will force the chat to always be stale 
* Wait for the AI Chat to appear and click the Chat History
* Reload the page
* The AI Chat should reload in the Chat History route
* Select a chat and reload the page
* Since we are forcing all chats to be stale, the AI Chat should appear with a new chat window
* Remove the `?inactivity_timeout=1`, select another chat, and reload the page
* The AI Chat should reload in the last selected chat

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
