### PR TITLE
Update the checkout AGENTS doc to include detail about retiring payme…

### DIFF
--- a/client/my-sites/checkout/AGENTS.md
+++ b/client/my-sites/checkout/AGENTS.md
@@ -87,6 +87,32 @@ Seven touchpoints required (follow an existing implementation like PIX or BLIK):
 
 Steps 6-7 are the ones agents miss — without slug mapping the method never appears.
 
+### Retiring a Payment Method
+
+The inverse of the above — used when the backend retires a processor (or a single
+method on a still-active processor). Reference template: PR #110710 (SHILL-1968,
+Razorpay). The backend playbook is the wpcom retired-processors readme
+(`wp-content/lib/billingdaddy/src/retired-processors/readme.md`); this section covers
+only the Calypso checkout side.
+
+Two surfaces with opposite fates:
+
+**Remove — the checkout offering** (undo the seven touchpoints above):
+
+1. Payment method component (`src/payment-methods/{name}.tsx`) and its test.
+2. Processor function (`src/lib/{name}-processor.ts`) and its registration in `checkout-main.tsx`.
+3. Create hook (`use-create-{name}.ts`) and its registration(s) in `use-create-payment-methods/index.tsx`.
+4. **Both directions** of the class↔slug mapping in `packages/wpcom-checkout/src/translate-payment-method-names.ts` AND the dashboard copy at `client/dashboard/me/billing-purchases/payment-methods/translate-payment-method-names.ts`.
+5. Checkout-time UI: the `client/lib/checkout/validation.js` branch, `client/lib/cart-values` label, `payment-logo` name/style/svg, any `country-specific-payment-fields` reference.
+6. Feature flag in `config/*.json` and any dedicated client package (Razorpay had `@automattic/calypso-razorpay`; most methods have none).
+
+**Keep — historic display.** Saved and past payment methods must still render:
+
+- The `payment_type` union member in `packages/api-core/src/upgrades/types.ts` (e.g. `'netbanking'`, `'razorpay'`) — historic purchase rows still carry it.
+- For processors that stored partner-specific method meta (e.g. Razorpay's UPI: `razorpay_vpa`): the partner constant + identifier types in `api-core` and `packages/wpcom-checkout/src/stored-payment-method-util.tsx`, plus the stored-method logo. This is the JSON-contract surface documented in the backend readme. A processor that was never recurring and carried no partner-specific stored meta (e.g. dLocal/netbanking) has nothing here to keep beyond the `payment_type` union member.
+
+**Why removing the class↔slug mapping is safe.** `translateWpcomPaymentMethodToCheckoutPaymentMethod` `throw`s on an unknown class, but it only ever runs over the cart's `allowed_payment_methods` (`src/lib/translate-cart.ts`) — i.e. methods currently on offer. Once the backend drops the retired class from `allowed_payment_methods`, the `default: throw` is unreachable. Historic purchase display reads the `payment_type` string, never the class translator — which is why the union member above must stay.
+
 ## Common Pitfalls
 
 1. **Checkout links MUST include `redirect_to` and `cancel_to` params** — Missing

--- a/client/my-sites/checkout/AGENTS.md
+++ b/client/my-sites/checkout/AGENTS.md
@@ -91,8 +91,7 @@ Steps 6-7 are the ones agents miss — without slug mapping the method never app
 
 The inverse of the above — used when the backend retires a processor (or a single
 method on a still-active processor). Reference template: PR #110710 (SHILL-1968,
-Razorpay). The backend playbook is the wpcom retired-processors readme
-(`wp-content/lib/billingdaddy/src/retired-processors/readme.md`); this section covers
+Razorpay). The backend instructions are in the wpcom retired-processors readme; this section covers
 only the Calypso checkout side.
 
 Two surfaces with opposite fates:


### PR DESCRIPTION
…nt methods.

<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->
Part of SHILL-1970

## Proposed Changes

* Adds detail about the process for retiring payments processors to the checkout AGENTS.md file. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The main readme for the payment processor retirement work is in the backend code, but there are some specific things that the front end also needs to understand to correctly retire a payment processor. This seems like the best place to add that, and mirrors the section on adding a payment method quite nicely. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* I think visual inspection will be all that's needed. My biggest question is around referencing the backend and the issue in this. Happy to remove, not sure it adds all that much?

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
