### PR TITLE
OpenAI pixel: Add page view event tracking

### DIFF
--- a/client/lib/analytics/ad-tracking/load-tracking-scripts.js
+++ b/client/lib/analytics/ad-tracking/load-tracking-scripts.js
@@ -188,10 +188,6 @@ function initLoadedTrackingScripts() {
 			pixelId: TRACKING_IDS.openAIPixelId,
 			debug: true,
 		} );
-		// see https://developers.openai.com/ads/measurement-pixel
-		window.oaiq( 'measure', 'page_viewed', {
-			type: 'contents',
-		} );
 	}
 	if ( mayWeTrackByTracker( 'quora' ) ) {
 		// We've initialized the pixel in setupQuoraGlobal, it's safe to track the page view now.

--- a/client/lib/analytics/ad-tracking/load-tracking-scripts.js
+++ b/client/lib/analytics/ad-tracking/load-tracking-scripts.js
@@ -183,6 +183,12 @@ function initLoadedTrackingScripts() {
 	if ( mayWeTrackByTracker( 'tiktok' ) ) {
 		initTikTok();
 	}
+	if ( mayWeTrackByTracker( 'openai' ) ) {
+		window.oaiq( 'init', {
+			pixelId: TRACKING_IDS.openAIPixelId,
+			debug: true,
+		} );
+	}
 	if ( mayWeTrackByTracker( 'quora' ) ) {
 		// We've initialized the pixel in setupQuoraGlobal, it's safe to track the page view now.
 		window.qp( 'track', 'ViewContent' );

--- a/client/lib/analytics/ad-tracking/load-tracking-scripts.js
+++ b/client/lib/analytics/ad-tracking/load-tracking-scripts.js
@@ -187,10 +187,6 @@ function initLoadedTrackingScripts() {
 		window.oaiq( 'init', {
 			pixelId: TRACKING_IDS.openAIPixelId,
 		} );
-		// Track the first page view after accepting the cookie banner.
-		window.oaiq( 'measure', 'page_viewed', {
-			type: 'contents',
-		} );
 	}
 	if ( mayWeTrackByTracker( 'quora' ) ) {
 		// We've initialized the pixel in setupQuoraGlobal, it's safe to track the page view now.

--- a/client/lib/analytics/ad-tracking/load-tracking-scripts.js
+++ b/client/lib/analytics/ad-tracking/load-tracking-scripts.js
@@ -188,6 +188,10 @@ function initLoadedTrackingScripts() {
 			pixelId: TRACKING_IDS.openAIPixelId,
 			debug: true,
 		} );
+		// see https://developers.openai.com/ads/measurement-pixel
+		window.oaiq( 'measure', 'page_viewed', {
+			type: 'contents',
+		} );
 	}
 	if ( mayWeTrackByTracker( 'quora' ) ) {
 		// We've initialized the pixel in setupQuoraGlobal, it's safe to track the page view now.

--- a/client/lib/analytics/ad-tracking/load-tracking-scripts.js
+++ b/client/lib/analytics/ad-tracking/load-tracking-scripts.js
@@ -186,7 +186,10 @@ function initLoadedTrackingScripts() {
 	if ( mayWeTrackByTracker( 'openai' ) ) {
 		window.oaiq( 'init', {
 			pixelId: TRACKING_IDS.openAIPixelId,
-			debug: true,
+		} );
+		// Track the first page view after accepting the cookie banner.
+		window.oaiq( 'measure', 'page_viewed', {
+			type: 'contents',
 		} );
 	}
 	if ( mayWeTrackByTracker( 'quora' ) ) {

--- a/client/lib/analytics/ad-tracking/retarget.js
+++ b/client/lib/analytics/ad-tracking/retarget.js
@@ -89,12 +89,14 @@ export async function retarget( urlPath ) {
 		debug( 'retarget: [TikTok]' );
 		window.ttq.page();
 	}
+
+	// OpenAI
 	if ( mayWeTrackByTracker( 'openai' ) ) {
-		debug( 'retarget: [OpenAI]' );
-		window.oaiq( 'init', {
-			pixelId: TRACKING_IDS.openAIPixelId,
-			debug: true,
+		// see https://developers.openai.com/ads/measurement-pixel
+		window.oaiq( 'measure', 'page_viewed', {
+			type: 'contents',
 		} );
+		debug( 'retarget: [OpenAI]' );
 	}
 	// Rate limited retargeting (secondary trackers)
 

--- a/client/lib/analytics/ad-tracking/retarget.js
+++ b/client/lib/analytics/ad-tracking/retarget.js
@@ -93,15 +93,18 @@ export async function retarget( urlPath ) {
 	// OpenAI
 	if ( mayWeTrackByTracker( 'openai' ) ) {
 		// see https://developers.openai.com/ads/measurement-pixel
-		window.oaiq( 'measure', 'page_viewed', {
+		const eventProps = {
 			type: 'contents',
 			contents: [
 				{
 					id: urlPath,
+					name: document.title,
+					content_type: 'page',
 				},
 			],
-		} );
-		debug( 'retarget: [OpenAI]' );
+		};
+		window.oaiq( 'measure', 'page_viewed', eventProps );
+		debug( 'retarget: [OpenAI]', eventProps );
 	}
 	// Rate limited retargeting (secondary trackers)
 

--- a/client/lib/analytics/ad-tracking/retarget.js
+++ b/client/lib/analytics/ad-tracking/retarget.js
@@ -89,7 +89,13 @@ export async function retarget( urlPath ) {
 		debug( 'retarget: [TikTok]' );
 		window.ttq.page();
 	}
-
+	if ( mayWeTrackByTracker( 'openai' ) ) {
+		debug( 'retarget: [OpenAI]' );
+		window.oaiq( 'init', {
+			pixelId: TRACKING_IDS.openAIPixelId,
+			debug: true,
+		} );
+	}
 	// Rate limited retargeting (secondary trackers)
 
 	const nowTimestamp = Date.now() / 1000;

--- a/client/lib/analytics/ad-tracking/retarget.js
+++ b/client/lib/analytics/ad-tracking/retarget.js
@@ -95,6 +95,11 @@ export async function retarget( urlPath ) {
 		// see https://developers.openai.com/ads/measurement-pixel
 		window.oaiq( 'measure', 'page_viewed', {
 			type: 'contents',
+			contents: [
+				{
+					id: urlPath,
+				},
+			],
 		} );
 		debug( 'retarget: [OpenAI]' );
 	}

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -798,6 +798,7 @@ function setUpCSP( req, res, next ) {
 			'wss://*.zendesk.com', // Zendesk WebSocket connections
 			'https://ekr.zdassets.com', // Zendesk composer
 			'https://*.config.smooch.io', // Smooch/Sunshine Conversations config
+			'https://bzr.openai.com', // OpenAI Ads tracking pixel
 		],
 		'report-uri': [ '/cspreport' ],
 	};


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of M4R73CH-1898

## Proposed Changes

Track the `page view` event, similar to what we're doing for other trackers. The event is only triggered on `retarget`, I decided against also triggering it on init as the SDK would end up sending 2 separate events. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To support upcoming OpenAI Ads campaigns.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit https://container-reverent-knuth.calypso.live/setup/onboarding/domains?flags=ad-tracking,cookie-banner and clear the `sensitive_pixel_options` cookie.
* Reload the page, confirm the cookie banner is displayed and no OpenAI script is loaded/no errors are shown in console.
* Accept all cookies, refresh the page and confirm you see an `openai` events call that sends the current page path.

<img width="613" height="208" alt="image" src="https://github.com/user-attachments/assets/c12be52f-e1e7-47e7-867a-93d62d3d7d12" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
