### PR TITLE
A4A Licenses: revoke WordPress.com plans in-app instead of redirecting to wordpress.com

### DIFF
--- a/client/a8c-for-agencies/components/a4a-feedback/churn-mechanism/cancel-license-feedback-modal.tsx
+++ b/client/a8c-for-agencies/components/a4a-feedback/churn-mechanism/cancel-license-feedback-modal.tsx
@@ -142,13 +142,9 @@ const CancelLicenseFeedbackModal = ( {
 				cta: 'cancel',
 			} )
 		);
-		if ( isAtomicSite ) {
-			window.open( `https://wordpress.com/purchases/subscriptions/${ siteSlug }`, '_blank' );
-		} else {
-			revokeLicense( {
-				licenseKey,
-			} );
-		}
+		revokeLicense( {
+			licenseKey,
+		} );
 		handleSubmitFeedback();
 	};
 
@@ -175,16 +171,12 @@ const CancelLicenseFeedbackModal = ( {
 		if ( revokeLicenseStatus === 'success' ) {
 			handleLicenseRevocationSuccess();
 		}
-		if (
-			( revokeLicenseStatus === 'success' || isAtomicSite ) &&
-			saveFeedbackStatus === 'success'
-		) {
+		if ( revokeLicenseStatus === 'success' && saveFeedbackStatus === 'success' ) {
 			handleCloseAndRefreshLicences();
 		}
 	}, [
 		handleCloseAndRefreshLicences,
 		handleLicenseRevocationSuccess,
-		isAtomicSite,
 		revokeLicenseStatus,
 		saveFeedbackStatus,
 	] );
@@ -212,6 +204,17 @@ const CancelLicenseFeedbackModal = ( {
 				<>
 					{ translate(
 						'A revoked license cannot be reused, and the associated site will no longer have access to the provisioned product. You will stop being billed for this license immediately.'
+					) }
+					{ isAtomicSite && (
+						<>
+							<br />
+							<br />
+							<strong>
+								{ translate(
+									'This will cancel the WordPress.com hosting plan for this site. The site will lose its plan features and hosting access.'
+								) }
+							</strong>
+						</>
 					) }
 					{ isChildLicense && (
 						<>
@@ -243,7 +246,7 @@ const CancelLicenseFeedbackModal = ( {
 						disabled={ isLoading || ( suggestion && ! suggestions.length ) }
 						isBusy={ isLoading }
 					>
-						{ isAtomicSite ? translate( 'Cancel license ↗' ) : translate( 'Cancel license' ) }
+						{ translate( 'Cancel license' ) }
 					</Button>
 				</>
 			}


### PR DESCRIPTION
Part of A4A-2344
<!-- Link the related A4A Linear issue. -->

## Proposed Changes

* **`components/a4a-feedback/churn-mechanism/cancel-license-feedback-modal.tsx`** — for atomic WordPress.com licenses, `handleOnCancel` now calls the existing `revokeLicense({ licenseKey })` mutation instead of opening `wordpress.com/purchases/subscriptions/{site}` in a new tab. This unifies the atomic path with the non-atomic one, which already revoked in-app. The success `useEffect` and button label are simplified accordingly (the `↗` external-link affordance is gone), and a site-loss warning is shown for atomic sites so the agency knows the live site loses its plan and hosting.

## Why are these changes being made?

Revoking a WordPress.com hosting license through A4A only short-circuited for non-atomic licenses. For atomic (live) sites the revoke action dropped the agency into wordpress.com's full consumer cancellation flow — six confirmation clicks and two rounds of feedback — which is confusing and redundant when they already confirmed the revoke in A4A. The A4A revoke endpoint (`DELETE /wpcom/v2/agency/license`) already cancels the underlying subscription and revokes the license regardless of atomic status — the same path the non-atomic revoke already uses — so the redirect was unnecessary friction. Agencies can now cancel entirely within A4A, with a clear warning about what happens to the site.

## Testing Instructions

1. Open the live link and go to **A4A → Purchases → Licenses**.
2. For an **atomic** WordPress.com license, open the `⋯` menu → **Revoke**. Confirm the modal shows the warning that the site will lose its plan and hosting, and that the primary button reads **Cancel license** (no `↗`).
3. Click **Cancel license** → confirm the license is revoked in place (success notice "License revoked successfully", the list refreshes, the badge becomes "Revoked"), and that **no** wordpress.com tab opens.
4. For a **non-atomic** WPCOM license (expand the row → **Revoke**), confirm the in-app revoke still works as before.
5. Confirm the `calypso_a4a_churn_feedback_cta_click` and `calypso_a4a_churn_feedback_submit` Tracks events still fire.
6. Verify there are no TypeScript / React console errors.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
