### PR TITLE
APM: make Response time breakdown chart zoomable

### DIFF
--- a/.yarn/patches/@automattic-charts-npm-1.5.0-228f6cf856.patch
+++ b/.yarn/patches/@automattic-charts-npm-1.5.0-228f6cf856.patch
@@ -1,0 +1,128 @@
+diff --git a/dist/index.cjs b/dist/index.cjs
+index b5ebdf1ba32203b929872b33d49c2a154303f854..877568c221607b50477a811a59725ff17cb07465 100644
+--- a/dist/index.cjs
++++ b/dist/index.cjs
+@@ -4707,6 +4707,16 @@ var AreaChartInternal = /* @__PURE__ */ _react.forwardRef.call(void 0, ({
+         contentHeight
+       }) => {
+         const chartHeight = contentHeight > 0 ? contentHeight : height;
++        const __zoomClipMargin = { ...defaultMargin, ...margin };
++        const __zoomClipLeft = __zoomClipMargin.left ?? 0;
++        const __zoomClipTop = __zoomClipMargin.top ?? 0;
++        const __zoomClipRight = __zoomClipMargin.right ?? 0;
++        const __zoomClipBottom = __zoomClipMargin.bottom ?? 0;
++        const __zoomClipWidth = Math.max(0, (width ?? 0) - __zoomClipLeft - __zoomClipRight);
++        const __zoomClipHeight = Math.max(0, chartHeight - __zoomClipTop - __zoomClipBottom);
++        const __zoomClipId = `area-zoom-clip-${String(chartId).replace(/[^a-zA-Z0-9_-]/g, "-")}`;
++        const __zoomClipActive = zoomable && Boolean(zoom.domain) && Number.isFinite(width) && __zoomClipWidth > 0 && __zoomClipHeight > 0;
++        const __zoomClipPath = __zoomClipActive ? `url(#${__zoomClipId})` : void 0;
+         return /* @__PURE__ */ _jsxruntime.jsx.call(void 0, "div", {
+           role: "grid",
+           "aria-label": _i18n.__.call(void 0, "Area chart", "jetpack-charts"),
+@@ -4736,7 +4746,17 @@ var AreaChartInternal = /* @__PURE__ */ _react.forwardRef.call(void 0, ({
+               onPointerMove: zoom.handlers.onPointerMove,
+               onPointerOut,
+               pointerEventsDataKey: "nearest",
+-              children: [gridVisibility !== "none" && /* @__PURE__ */ _jsxruntime.jsx.call(void 0, _xychart.Grid, {
++              children: [__zoomClipActive && /* @__PURE__ */ _jsxruntime.jsx.call(void 0, "defs", {
++                children: /* @__PURE__ */ _jsxruntime.jsx.call(void 0, "clipPath", {
++                  id: __zoomClipId,
++                  children: /* @__PURE__ */ _jsxruntime.jsx.call(void 0, "rect", {
++                    x: __zoomClipLeft,
++                    y: __zoomClipTop,
++                    width: __zoomClipWidth,
++                    height: __zoomClipHeight
++                  })
++                })
++              }), gridVisibility !== "none" && /* @__PURE__ */ _jsxruntime.jsx.call(void 0, _xychart.Grid, {
+                 columns: false,
+                 numTicks: 4
+               }), chartOptions.axis.x.display && /* @__PURE__ */ _jsxruntime.jsx.call(void 0, _xychart.Axis, {
+@@ -4749,12 +4769,18 @@ var AreaChartInternal = /* @__PURE__ */ _react.forwardRef.call(void 0, ({
+                 width,
+                 height: chartHeight,
+                 children: _i18n.__.call(void 0, "All series are hidden. Click legend items to show data.", "jetpack-charts")
+-              }) : null, !allSeriesHidden && stacked && /* @__PURE__ */ _jsxruntime.jsx.call(void 0, _xychart.AnimatedAreaStack, {
+-                curve,
+-                offset: stackOffset,
+-                renderLine: resolvedWithStroke,
++              }) : null, !allSeriesHidden && stacked && /* @__PURE__ */ _jsxruntime.jsx.call(void 0, "g", {
++                clipPath: __zoomClipPath,
++                children: /* @__PURE__ */ _jsxruntime.jsx.call(void 0, _xychart.AnimatedAreaStack, {
++                  curve,
++                  offset: stackOffset,
++                  renderLine: resolvedWithStroke,
++                  children: seriesWithVisibility.map(renderSeries)
++                })
++              }), !allSeriesHidden && !stacked && /* @__PURE__ */ _jsxruntime.jsx.call(void 0, "g", {
++                clipPath: __zoomClipPath,
+                 children: seriesWithVisibility.map(renderSeries)
+-              }), !allSeriesHidden && !stacked && seriesWithVisibility.map(renderSeries), withTooltips && /* @__PURE__ */ _jsxruntime.jsxs.call(void 0, _jsxruntime.Fragment, {
++              }), withTooltips && /* @__PURE__ */ _jsxruntime.jsxs.call(void 0, _jsxruntime.Fragment, {
+                 children: [/* @__PURE__ */ _jsxruntime.jsx.call(void 0, AccessibleTooltip, {
+                   detectBounds: true,
+                   snapTooltipToDatumX: true,
+diff --git a/dist/index.js b/dist/index.js
+index fecc6b073e8470deaeae828f36646562cfe604de..4cd33085c8ea625ebafbfe68d4eeae8d151d460c 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -4707,6 +4707,16 @@ var AreaChartInternal = /* @__PURE__ */ forwardRef5(({
+         contentHeight
+       }) => {
+         const chartHeight = contentHeight > 0 ? contentHeight : height;
++        const __zoomClipMargin = { ...defaultMargin, ...margin };
++        const __zoomClipLeft = __zoomClipMargin.left ?? 0;
++        const __zoomClipTop = __zoomClipMargin.top ?? 0;
++        const __zoomClipRight = __zoomClipMargin.right ?? 0;
++        const __zoomClipBottom = __zoomClipMargin.bottom ?? 0;
++        const __zoomClipWidth = Math.max(0, (width ?? 0) - __zoomClipLeft - __zoomClipRight);
++        const __zoomClipHeight = Math.max(0, chartHeight - __zoomClipTop - __zoomClipBottom);
++        const __zoomClipId = `area-zoom-clip-${String(chartId).replace(/[^a-zA-Z0-9_-]/g, "-")}`;
++        const __zoomClipActive = zoomable && Boolean(zoom.domain) && Number.isFinite(width) && __zoomClipWidth > 0 && __zoomClipHeight > 0;
++        const __zoomClipPath = __zoomClipActive ? `url(#${__zoomClipId})` : void 0;
+         return /* @__PURE__ */ _jsx18("div", {
+           role: "grid",
+           "aria-label": __5("Area chart", "jetpack-charts"),
+@@ -4736,7 +4746,17 @@ var AreaChartInternal = /* @__PURE__ */ forwardRef5(({
+               onPointerMove: zoom.handlers.onPointerMove,
+               onPointerOut,
+               pointerEventsDataKey: "nearest",
+-              children: [gridVisibility !== "none" && /* @__PURE__ */ _jsx18(Grid2, {
++              children: [__zoomClipActive && /* @__PURE__ */ _jsx18("defs", {
++                children: /* @__PURE__ */ _jsx18("clipPath", {
++                  id: __zoomClipId,
++                  children: /* @__PURE__ */ _jsx18("rect", {
++                    x: __zoomClipLeft,
++                    y: __zoomClipTop,
++                    width: __zoomClipWidth,
++                    height: __zoomClipHeight
++                  })
++                })
++              }), gridVisibility !== "none" && /* @__PURE__ */ _jsx18(Grid2, {
+                 columns: false,
+                 numTicks: 4
+               }), chartOptions.axis.x.display && /* @__PURE__ */ _jsx18(Axis2, {
+@@ -4749,12 +4769,18 @@ var AreaChartInternal = /* @__PURE__ */ forwardRef5(({
+                 width,
+                 height: chartHeight,
+                 children: __5("All series are hidden. Click legend items to show data.", "jetpack-charts")
+-              }) : null, !allSeriesHidden && stacked && /* @__PURE__ */ _jsx18(AnimatedAreaStack, {
+-                curve,
+-                offset: stackOffset,
+-                renderLine: resolvedWithStroke,
++              }) : null, !allSeriesHidden && stacked && /* @__PURE__ */ _jsx18("g", {
++                clipPath: __zoomClipPath,
++                children: /* @__PURE__ */ _jsx18(AnimatedAreaStack, {
++                  curve,
++                  offset: stackOffset,
++                  renderLine: resolvedWithStroke,
++                  children: seriesWithVisibility.map(renderSeries)
++                })
++              }), !allSeriesHidden && !stacked && /* @__PURE__ */ _jsx18("g", {
++                clipPath: __zoomClipPath,
+                 children: seriesWithVisibility.map(renderSeries)
+-              }), !allSeriesHidden && !stacked && seriesWithVisibility.map(renderSeries), withTooltips && /* @__PURE__ */ _jsxs8(_Fragment4, {
++              }), withTooltips && /* @__PURE__ */ _jsxs8(_Fragment4, {
+                 children: [/* @__PURE__ */ _jsx18(AccessibleTooltip, {
+                   detectBounds: true,
+                   snapTooltipToDatumX: true,

--- a/client/dashboard/sites/performance/backend/overview/chart-slot.tsx
+++ b/client/dashboard/sites/performance/backend/overview/chart-slot.tsx
@@ -91,6 +91,7 @@ export default function ChartSlot( {
 						height={ 320 }
 						data={ data }
 						stacked
+						zoomable
 						curveType="monotone"
 						showLegend
 						legend={ { interactive: true } }

--- a/client/package.json
+++ b/client/package.json
@@ -32,7 +32,7 @@
 		"@automattic/calypso-stripe": "workspace:^",
 		"@automattic/calypso-support-session": "workspace:^",
 		"@automattic/calypso-url": "workspace:^",
-		"@automattic/charts": "^1.4.3",
+		"@automattic/charts": "patch:@automattic/charts@npm%3A1.5.0#~/.yarn/patches/@automattic-charts-npm-1.5.0-228f6cf856.patch",
 		"@automattic/color-studio": "^4.1.0",
 		"@automattic/components": "workspace:^",
 		"@automattic/composite-checkout": "workspace:^",

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
 		"@automattic/calypso-doctor": "workspace:^",
 		"@automattic/calypso-products": "workspace:^",
 		"@automattic/calypso-router": "workspace:^",
-		"@automattic/charts": "^1.4.3",
+		"@automattic/charts": "patch:@automattic/charts@npm%3A1.5.0#~/.yarn/patches/@automattic-charts-npm-1.5.0-228f6cf856.patch",
 		"@automattic/color-studio": "^4.1.0",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -755,6 +755,47 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@automattic/charts@npm:1.5.0":
+  version: 1.5.0
+  resolution: "@automattic/charts@npm:1.5.0"
+  dependencies:
+    "@automattic/number-formatters": "npm:^1.2.0"
+    "@babel/runtime": "npm:7.29.2"
+    "@react-spring/web": "npm:9.7.5"
+    "@visx/annotation": "npm:^3.12.0"
+    "@visx/axis": "npm:^3.12.0"
+    "@visx/curve": "npm:^3.12.0"
+    "@visx/event": "npm:^3.12.0"
+    "@visx/gradient": "npm:^3.12.0"
+    "@visx/grid": "npm:^3.12.0"
+    "@visx/group": "npm:^3.12.0"
+    "@visx/legend": "npm:^3.12.0"
+    "@visx/pattern": "npm:^3.12.0"
+    "@visx/responsive": "npm:^3.12.0"
+    "@visx/scale": "npm:^3.12.0"
+    "@visx/shape": "npm:^3.12.0"
+    "@visx/text": "npm:^3.12.0"
+    "@visx/tooltip": "npm:^3.12.0"
+    "@visx/vendor": "npm:^3.12.0"
+    "@visx/xychart": "npm:^3.12.0"
+    "@wordpress/i18n": "npm:^6.0.0"
+    "@wordpress/icons": "npm:^13.0.0"
+    "@wordpress/theme": "npm:0.13.0"
+    "@wordpress/ui": "npm:0.13.0"
+    clsx: "npm:2.1.1"
+    date-fns: "npm:^4.1.0"
+    deepmerge: "npm:4.3.1"
+    dompurify: "npm:^3.3.3"
+    fast-deep-equal: "npm:3.1.3"
+    react-google-charts: "npm:^5.2.1"
+    tslib: "npm:2.8.1"
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+  checksum: 6d9c1df1717fb4bdeec4a4f7c5c5ff6054679ea3fefbbbcfe9da1b7ee7fd59b723a5c092f3507049d7978bcff1d14f4e873e151c5712c045bffd3e5ddc6d6ec8
+  languageName: node
+  linkType: hard
+
 "@automattic/charts@npm:>=0.58.0 <1.0.0":
   version: 0.58.0
   resolution: "@automattic/charts@npm:0.58.0"
@@ -795,9 +836,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@automattic/charts@npm:^1.4.3":
-  version: 1.4.3
-  resolution: "@automattic/charts@npm:1.4.3"
+"@automattic/charts@patch:@automattic/charts@npm%3A1.5.0#~/.yarn/patches/@automattic-charts-npm-1.5.0-228f6cf856.patch":
+  version: 1.5.0
+  resolution: "@automattic/charts@patch:@automattic/charts@npm%3A1.5.0#~/.yarn/patches/@automattic-charts-npm-1.5.0-228f6cf856.patch::version=1.5.0&hash=dd4773"
   dependencies:
     "@automattic/number-formatters": "npm:^1.2.0"
     "@babel/runtime": "npm:7.29.2"
@@ -819,9 +860,9 @@ __metadata:
     "@visx/vendor": "npm:^3.12.0"
     "@visx/xychart": "npm:^3.12.0"
     "@wordpress/i18n": "npm:^6.0.0"
-    "@wordpress/icons": "npm:^12.0.0"
+    "@wordpress/icons": "npm:^13.0.0"
     "@wordpress/theme": "npm:0.13.0"
-    "@wordpress/ui": "npm:0.11.0"
+    "@wordpress/ui": "npm:0.13.0"
     clsx: "npm:2.1.1"
     date-fns: "npm:^4.1.0"
     deepmerge: "npm:4.3.1"
@@ -832,7 +873,7 @@ __metadata:
   peerDependencies:
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
-  checksum: 3fcfcaaed2dd1f2472f6194a664ae5ebc65a798bf3b343be9348fd54632027c85119a27833b1461bba0461c32a5630cf042c1dec6edebfbee2db5b120a11dfae
+  checksum: 91960bb64f6db4e19af96ea926ec386062df7594433744ca0283dde5fe487b2afc40e090e1d64e9a1f0334794728cc351c079244eaf0d2c5d3e62df4024f6277
   languageName: node
   linkType: hard
 
@@ -13967,7 +14008,7 @@ __metadata:
     "@automattic/calypso-stripe": "workspace:^"
     "@automattic/calypso-support-session": "workspace:^"
     "@automattic/calypso-url": "workspace:^"
-    "@automattic/charts": "npm:^1.4.3"
+    "@automattic/charts": "patch:@automattic/charts@npm%3A1.5.0#~/.yarn/patches/@automattic-charts-npm-1.5.0-228f6cf856.patch"
     "@automattic/color-studio": "npm:^4.1.0"
     "@automattic/components": "workspace:^"
     "@automattic/composite-checkout": "workspace:^"
@@ -33217,7 +33258,7 @@ __metadata:
     "@automattic/calypso-products": "workspace:^"
     "@automattic/calypso-router": "workspace:^"
     "@automattic/calypso-storybook": "workspace:^"
-    "@automattic/charts": "npm:^1.4.3"
+    "@automattic/charts": "patch:@automattic/charts@npm%3A1.5.0#~/.yarn/patches/@automattic-charts-npm-1.5.0-228f6cf856.patch"
     "@automattic/color-studio": "npm:^4.1.0"
     "@automattic/components": "workspace:^"
     "@automattic/data-stores": "workspace:^"


### PR DESCRIPTION
Part of #

## Proposed Changes

* Bump `@automattic/charts` from `^1.4.3` to `1.5.0`, which introduces an opt-in `zoomable` X-axis (drag to select a time range, with a reset button).
* Enable `zoomable` on the **Response time breakdown** area chart in the backend APM overview (`client/dashboard/sites/performance/backend/overview/chart-slot.tsx`).
* Add a Yarn patch to `@automattic/charts@1.5.0` that clips the `AreaChart` series to the inner plot rect while zoomed. The shipped zoom feature restricts the x-domain but renders the area paths through every data point without a `clipPath` (the chart SVG is `overflow: visible`), so a zoomed view spills the stacked areas outside the plot and over the axis labels. The patch wraps the series in a group clipped to the plot box (`margin.left/top` .. `innerWidth/innerHeight`), active only while zoomed.

## Why are these changes being made?

The backend APM Response time breakdown chart spans a long time window, so being able to drag-zoom into a sub-range makes it much easier to inspect spikes. The library's zoom feature is the right primitive, but it renders area series unclipped, so without the patch the zoomed areas render outside the plot. The patch contains them to the gridline box. The clip only engages while zoomed, so unzoomed rendering is unchanged.

The underlying clip issue affects the library's `LineChart` and `AreaChart` zoom for any consumer; an upstream fix is being pursued so this patch can be dropped later.

## Testing Instructions

* `yarn start-dashboard`, then open a site's **Performance > Backend** tab (`/sites/<site>/performance/backend`).
* Drag horizontally across the **Response time breakdown** chart to zoom into a range.
* Confirm the stacked areas stay within the gridlines (no spill over the y-axis labels or outside the card) and that the zoom-out button restores the full range.
* Confirm the unzoomed chart, tooltips, and interactive legend behave as before.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
