### PR TITLE
Survicate: close survey on display when Help Center is open

### DIFF
--- a/packages/survicate/AGENTS.md
+++ b/packages/survicate/AGENTS.md
@@ -1,0 +1,108 @@
+# @automattic/survicate
+
+Thin integration layer around [Survicate](https://survicate.com/), the third-party
+survey SDK used to run in-product surveys on WordPress.com surfaces. This package
+loads the SDK, sets visitor traits, fires events, and — importantly — keeps surveys
+from interrupting users who are in the Help Center.
+
+## What this package does (and doesn't)
+
+- **Does**: decide whether to load Survicate, inject the SDK script, set visitor
+  traits, invoke named events, and suppress/close surveys when the Help Center is open.
+- **Doesn't**: define survey content, targeting, or campaign rules. Those live in the
+  Survicate dashboard (workspace `e4794374cce15378101b63de24117572`). We only control
+  the SDK lifecycle on our side.
+
+## The Survicate SDK (`window._sva`)
+
+Once the SDK script loads, it exposes a global `window._sva` object and dispatches a
+one-time `SurvicateReady` event on `window`. The global type is declared once in
+`visitor-traits.ts` (`declare global { interface Window { _sva?: {...} } }`) and is
+visible package-wide. The methods we use:
+
+- `invokeEvent(name)` — trigger an event-based survey.
+- `closeSurvey()` — dismiss any currently displayed survey.
+- `setVisitorTraits(traits)` — attach traits (email, account age) used for targeting.
+- `addEventListener(event, handler)` / `removeEventListener` — subscribe to SDK events
+  such as `survey_displayed`.
+- `destroyVisitor()` — reset the visitor.
+
+`_sva` is `undefined` until the script finishes loading, so **every access must be
+guarded** (`window._sva?.method`). Code may also run before `SurvicateReady` fires.
+
+## The two ways a survey can appear
+
+This is the key mental model. Surveys reach the screen through two independent paths,
+and each needs its own guard:
+
+1. **Explicit events** — our code calls `invokeSurvicateEvent('migrationCompleted')`
+   etc. from ~6 call sites (purchase cancel/refund flows, migration completion,
+   checkout thank-you). Guarded inside `invoke-event.ts`.
+2. **Auto-campaigns** — Survicate's own targeting fires a survey on its own (URL match,
+   "show after N seconds", etc.). This **never touches our code**, so an invoke-time
+   guard can't catch it. The only universal hook is the SDK's `survey_displayed` event.
+
+## Help Center coordination (defense-in-depth)
+
+Surveys must not cover the Help Center while a user is actively seeking support. Three
+complementary touch points enforce this — keep all three:
+
+1. **Open HC while a survey is showing** → `packages/data-stores/src/help-center/actions.ts`
+   (`setShowHelpCenter`) calls `window._sva?.closeSurvey?.()` on open. (Note: that file
+   intentionally inlines the call rather than importing this package — data-stores is a
+   lower-level shared package and must not depend on `@automattic/survicate`.)
+2. **Invoke an event while HC is open** → `invoke-event.ts` checks `isHelpCenterOpen()`
+   and skips the trigger (both immediately and deferred at `SurvicateReady` time).
+3. **Any survey displays while HC is open** → `load-script.ts` subscribes to
+   `survey_displayed` and closes it. This is the comprehensive net that also catches
+   auto-campaigns (path 2 above).
+
+`isHelpCenterOpen()` (exported from `invoke-event.ts`) reads the `automattic/help-center`
+`@wordpress/data` store by string and returns `false` if the store isn't registered, so
+it's safe to call even when the Help Center isn't loaded on the surface.
+
+**Known caveat — the display flash**: `survey_displayed` fires *after* the survey
+renders, so closing it produces a brief show-then-hide flicker for auto-campaigns. The
+SDK exposes no pre-display veto. If the flash ever becomes a real problem, the
+alternative is Survicate-side targeting (set a `help_center_open` visitor trait via
+`setSurvicateVisitorTraits` and exclude it in campaign config) — more reliable but
+requires dashboard coordination. Don't build that pre-emptively.
+
+## File map
+
+- `conditions.ts` — `shouldLoadSurvicate({ locale, isMobile })` (English, non-mobile
+  only) and `SURVICATE_WORKSPACE_ID`.
+- `load-script.ts` — `loadSurvicateScript()` injects the SDK and wires the
+  `survey_displayed` safety net; `isSurvicateScriptLoaded()`.
+- `invoke-event.ts` — `invokeSurvicateEvent()` and `isHelpCenterOpen()`.
+- `close-survey.ts` — `closeSurvicateSurvey()`: the single, guarded `_sva.closeSurvey()`
+  helper reused by the suppression call sites.
+- `visitor-traits.ts` — `setSurvicateVisitorTraits()`, `getAccountAgeInDays()`, and the
+  global `window._sva` type declaration.
+- `index.ts` — public exports.
+
+## Consumers
+
+The package's entry point is `client/dashboard/app/survicate/index.tsx` (`useSurvicate`
+hook), gated behind the `survicate_enabled` config flag. `invokeSurvicateEvent` is also
+called from classic Calypso purchase/cancel and checkout flows.
+
+## Conventions & gotchas
+
+- **Always guard `window._sva`** — it's `undefined` until the SDK loads.
+- **Use `closeSurvicateSurvey()`** rather than re-inlining `window._sva?.closeSurvey?.()`
+  inside this package.
+- **Listeners that wait for `SurvicateReady`** should use `{ once: true }`. Note the
+  event fires only once per page load — code that registers a `SurvicateReady` listener
+  *after* the SDK already loaded will never run, so register at load time.
+- Each `src/*.ts` file has a matching `src/test/*.test.ts`. Tests use
+  `@jest-environment jsdom`, mock `@wordpress/data`'s `select`, and stub `window._sva`.
+- Tab indentation, tabs for alignment (match existing files).
+
+## Commands
+
+```bash
+yarn test-packages packages/survicate          # run all package tests
+cd packages/survicate && npx tsc --build ./tsconfig.json   # typecheck
+yarn eslint packages/survicate/src/<file>       # lint
+```

--- a/packages/survicate/src/close-survey.ts
+++ b/packages/survicate/src/close-survey.ts
@@ -1,0 +1,14 @@
+import debug from './debug';
+
+/**
+ * Closes any currently displayed Survicate survey.
+ *
+ * Safe to call in any context: it is a no-op when the Survicate SDK has not
+ * loaded (`window._sva` is undefined) or when running outside the browser.
+ */
+export function closeSurvicateSurvey(): void {
+	if ( typeof window !== 'undefined' && window._sva?.closeSurvey ) {
+		debug( 'Closing Survicate survey' );
+		window._sva.closeSurvey();
+	}
+}

--- a/packages/survicate/src/index.ts
+++ b/packages/survicate/src/index.ts
@@ -1,4 +1,5 @@
 export { shouldLoadSurvicate, SURVICATE_WORKSPACE_ID } from './conditions';
+export { closeSurvicateSurvey } from './close-survey';
 export { isSurvicateScriptLoaded, loadSurvicateScript } from './load-script';
 export { invokeSurvicateEvent } from './invoke-event';
 export { getAccountAgeInDays, setSurvicateVisitorTraits } from './visitor-traits';

--- a/packages/survicate/src/invoke-event.ts
+++ b/packages/survicate/src/invoke-event.ts
@@ -8,7 +8,7 @@ const HELP_CENTER_STORE = 'automattic/help-center';
  * `@wordpress/data` store. Returns `false` if the store is not registered
  * (e.g. in contexts where the Help Center is not loaded).
  */
-function isHelpCenterOpen(): boolean {
+export function isHelpCenterOpen(): boolean {
 	try {
 		const store = select( HELP_CENTER_STORE ) as { isHelpCenterShown?: () => boolean } | undefined;
 		return !! store?.isHelpCenterShown?.();

--- a/packages/survicate/src/invoke-event.ts
+++ b/packages/survicate/src/invoke-event.ts
@@ -1,4 +1,5 @@
 import { select } from '@wordpress/data';
+import { closeSurvicateSurvey } from './close-survey';
 import debug from './debug';
 
 const HELP_CENTER_STORE = 'automattic/help-center';
@@ -29,9 +30,7 @@ export function isHelpCenterOpen(): boolean {
 export function invokeSurvicateEvent( eventName: string ): () => void {
 	if ( isHelpCenterOpen() ) {
 		debug( 'Survicate event "%s" suppressed (Help Center is open)', eventName );
-		if ( typeof window._sva !== 'undefined' && window._sva.closeSurvey ) {
-			window._sva.closeSurvey();
-		}
+		closeSurvicateSurvey();
 		return () => {};
 	}
 

--- a/packages/survicate/src/load-script.ts
+++ b/packages/survicate/src/load-script.ts
@@ -1,5 +1,6 @@
 import { loadScript } from '@automattic/load-script';
 import debug from './debug';
+import { isHelpCenterOpen } from './invoke-event';
 
 /**
  * Checks whether the Survicate script is already loaded on the page.
@@ -14,6 +15,24 @@ export function isSurvicateScriptLoaded(): boolean {
  */
 export function loadSurvicateScript( workspaceId: string ): Promise< void > {
 	debug( 'Loading Survicate script for workspace %s', workspaceId );
+
+	window.addEventListener(
+		'SurvicateReady',
+		function () {
+			window._sva?.addEventListener?.( 'survey_displayed', () => {
+				debug( 'Survicate survey displayed' );
+
+				if ( isHelpCenterOpen() ) {
+					debug( 'Survicate event suppressed (Help Center is open)' );
+					if ( typeof window._sva !== 'undefined' && window._sva.closeSurvey ) {
+						window._sva.closeSurvey();
+					}
+				}
+			} );
+		},
+		{ once: true }
+	);
+
 	return loadScript(
 		`https://survey.survicate.com/workspaces/${ workspaceId }/web_surveys.js`
 	).then( () => {

--- a/packages/survicate/src/load-script.ts
+++ b/packages/survicate/src/load-script.ts
@@ -1,4 +1,5 @@
 import { loadScript } from '@automattic/load-script';
+import { closeSurvicateSurvey } from './close-survey';
 import debug from './debug';
 import { isHelpCenterOpen } from './invoke-event';
 
@@ -23,10 +24,8 @@ export function loadSurvicateScript( workspaceId: string ): Promise< void > {
 				debug( 'Survicate survey displayed' );
 
 				if ( isHelpCenterOpen() ) {
-					debug( 'Survicate event suppressed (Help Center is open)' );
-					if ( typeof window._sva !== 'undefined' && window._sva.closeSurvey ) {
-						window._sva.closeSurvey();
-					}
+					debug( 'Survicate survey suppressed (Help Center is open)' );
+					closeSurvicateSurvey();
 				}
 			} );
 		},

--- a/packages/survicate/src/test/close-survey.test.ts
+++ b/packages/survicate/src/test/close-survey.test.ts
@@ -1,0 +1,32 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { closeSurvicateSurvey } from '../close-survey';
+
+describe( 'closeSurvicateSurvey', () => {
+	afterEach( () => {
+		window._sva = undefined;
+	} );
+
+	test( 'should call closeSurvey when the SDK is loaded', () => {
+		const closeSurvey = jest.fn();
+		window._sva = { closeSurvey };
+
+		closeSurvicateSurvey();
+
+		expect( closeSurvey ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'should be a no-op when the SDK is not loaded', () => {
+		window._sva = undefined;
+
+		expect( () => closeSurvicateSurvey() ).not.toThrow();
+	} );
+
+	test( 'should be a no-op when closeSurvey is unavailable', () => {
+		window._sva = {};
+
+		expect( () => closeSurvicateSurvey() ).not.toThrow();
+	} );
+} );

--- a/packages/survicate/src/test/load-script.test.ts
+++ b/packages/survicate/src/test/load-script.test.ts
@@ -1,11 +1,36 @@
+/**
+ * @jest-environment jsdom
+ */
+
 jest.mock( '@automattic/load-script', () => ( {
 	loadScript: jest.fn( () => Promise.resolve() ),
 } ) );
 
+jest.mock( '@wordpress/data', () => ( {
+	select: jest.fn(),
+} ) );
+
 import { loadScript } from '@automattic/load-script';
+import { select } from '@wordpress/data';
 import { loadSurvicateScript } from '../load-script';
 
+const mockSelect = select as jest.Mock;
+
+function setHelpCenterOpen( open: boolean ) {
+	mockSelect.mockReturnValue( { isHelpCenterShown: () => open } );
+}
+
 describe( 'loadSurvicateScript', () => {
+	beforeEach( () => {
+		window._sva = undefined;
+		setHelpCenterOpen( false );
+	} );
+
+	afterEach( () => {
+		window._sva = undefined;
+		mockSelect.mockReset();
+	} );
+
 	test( 'should call loadScript with the correct Survicate URL', async () => {
 		await loadSurvicateScript( 'test-workspace-id' );
 
@@ -18,5 +43,40 @@ describe( 'loadSurvicateScript', () => {
 		( loadScript as jest.Mock ).mockRejectedValueOnce( new Error( 'load failed' ) );
 
 		await expect( loadSurvicateScript( 'test-id' ) ).rejects.toThrow( 'load failed' );
+	} );
+
+	test( 'should close the survey when it is displayed while the Help Center is open', () => {
+		const closeSurvey = jest.fn();
+		const addEventListener = jest.fn();
+		window._sva = { closeSurvey, addEventListener };
+
+		loadSurvicateScript( 'test-workspace-id' );
+
+		// Survicate signals readiness, which registers the survey_displayed listener.
+		window.dispatchEvent( new Event( 'SurvicateReady' ) );
+		expect( addEventListener ).toHaveBeenCalledWith( 'survey_displayed', expect.any( Function ) );
+
+		// Simulate a survey being displayed while the Help Center is open.
+		setHelpCenterOpen( true );
+		const onSurveyDisplayed = addEventListener.mock.calls[ 0 ][ 1 ];
+		onSurveyDisplayed();
+
+		expect( closeSurvey ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'should not close the survey when the Help Center is closed', () => {
+		const closeSurvey = jest.fn();
+		const addEventListener = jest.fn();
+		window._sva = { closeSurvey, addEventListener };
+
+		loadSurvicateScript( 'test-workspace-id' );
+
+		window.dispatchEvent( new Event( 'SurvicateReady' ) );
+
+		setHelpCenterOpen( false );
+		const onSurveyDisplayed = addEventListener.mock.calls[ 0 ][ 1 ];
+		onSurveyDisplayed();
+
+		expect( closeSurvey ).not.toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
Related to this Slack thread: p1780402466012289-slack-C029GN3KD

## Proposed Changes

* Export `isHelpCenterOpen()` from `invoke-event.ts` so it can be reused.
* In `loadSurvicateScript()`, attach a one-time `SurvicateReady` listener that subscribes to the `survey_displayed` event. When a survey is displayed while the Help Center is open, the survey is immediately closed via `window._sva.closeSurvey()`.

## Why are these changes being made?

* Survicate surveys can pop up over the Help Center, interrupting users who are actively seeking support. The previous suppression logic prevented invoking events while the Help Center was open, but surveys could still surface from other triggers. This adds a defensive check at display time to close any survey that appears while the Help Center is open.

## Testing Instructions

* Open the Help Center.
* Trigger a Survicate survey while the Help Center is open.
* Confirm the survey does not remain visible (it is closed on display).
* Close the Help Center and confirm surveys display normally.
* Check the console (with Survicate debug enabled) for the `Survicate event suppressed (Help Center is open)` log.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)