### PR TITLE
Notifications: Fix Notes Spam Requests

### DIFF
--- a/apps/notifications/src/panel/rest-client/wpcom.js
+++ b/apps/notifications/src/panel/rest-client/wpcom.js
@@ -76,5 +76,8 @@ export const sendLastSeenTime = ( time ) =>
 		{ time }
 	);
 
-export const subscribeToNoteStream = ( callback ) =>
-	wpcom().pinghub.connect( '/wpcom/me/newest-note-data', callback );
+export const subscribeToNoteStream = () => {
+	// TEMPORARY FIX. Disable Pinghub for now. It's failing and DDOSing the REST endpoint.
+	// return wpcom().pinghub.connect( '/wpcom/me/newest-note-data', callback );
+	return null;
+};


### PR DESCRIPTION
Disables WebSockets syncing which is throwing a 444 error and throwing the REST fallback into a loop (literally). 

### Testing

1. To see the bug, go to wp.com/home/SITE
2. Open DevTools > Network and filter by 'notifications'
3. Wait a few seconds and you'll see numerous requests in parallel.
4. To validate the fix, visit the live link this time.
5. You should see one request. And another after 30s.
