### PR TITLE
Billing History: surface receipt type/amount/date inline at narrow widths

### DIFF
--- a/client/dashboard/me/billing-history/dataviews.tsx
+++ b/client/dashboard/me/billing-history/dataviews.tsx
@@ -363,40 +363,29 @@ function renderServiceNameDescription( receipt: Receipt ) {
 	);
 }
 
+function renderInlineHiddenField( key: string, label: string, value: string ) {
+	return (
+		<Text key={ key } isBlock variant="muted" size="12" className="billing-history-receipt-meta">
+			<span className="billing-history-receipt-meta-label">{ label }</span>
+			<span className="billing-history-receipt-meta-value">{ value }</span>
+		</Text>
+	);
+}
+
 function renderInlineHiddenFields( receipt: Receipt, visibleFields: string[] ) {
 	const lines: JSX.Element[] = [];
 
 	if ( ! visibleFields.includes( 'date' ) ) {
-		lines.push(
-			<Text key="date" isBlock variant="muted" size="12">
-				{ sprintf(
-					/* translators: %s is a formatted date, like May 21, 2026 */
-					__( 'Date: %s' ),
-					formatReceiptDate( receipt )
-				) }
-			</Text>
-		);
+		lines.push( renderInlineHiddenField( 'date', __( 'Date' ), formatReceiptDate( receipt ) ) );
 	}
 	if ( ! visibleFields.includes( 'type' ) ) {
 		lines.push(
-			<Text key="type" isBlock variant="muted" size="12">
-				{ sprintf(
-					/* translators: %s is a receipt type, like Refund or New purchase */
-					__( 'Type: %s' ),
-					getReceiptItemTypeForDisplay( receipt )
-				) }
-			</Text>
+			renderInlineHiddenField( 'type', __( 'Type' ), getReceiptItemTypeForDisplay( receipt ) )
 		);
 	}
 	if ( ! visibleFields.includes( 'amount' ) ) {
 		lines.push(
-			<Text key="amount" isBlock variant="muted" size="12">
-				{ sprintf(
-					/* translators: %s is a formatted price, like $96 */
-					__( 'Amount: %s' ),
-					formatReceiptAmount( receipt )
-				) }
-			</Text>
+			renderInlineHiddenField( 'amount', __( 'Amount' ), formatReceiptAmount( receipt ) )
 		);
 	}
 	return lines;

--- a/client/dashboard/me/billing-history/dataviews.tsx
+++ b/client/dashboard/me/billing-history/dataviews.tsx
@@ -121,15 +121,7 @@ export function getFields(
 				return getDateForFiltering( item );
 			},
 			render: ( { item }: { item: Receipt } ) => {
-				return (
-					<time>
-						{ new Date( item.date ).toLocaleDateString( undefined, {
-							year: 'numeric',
-							month: 'short',
-							day: 'numeric',
-						} ) }
-					</time>
-				);
+				return <time>{ formatReceiptDate( item ) }</time>;
 			},
 		},
 		{
@@ -304,6 +296,14 @@ function getDateForFiltering( receipt: Receipt ): string {
 	} );
 }
 
+function formatReceiptDate( receipt: Receipt ): string {
+	return new Date( receipt.date ).toLocaleDateString( undefined, {
+		year: 'numeric',
+		month: 'short',
+		day: 'numeric',
+	} );
+}
+
 function getServicesForFiltering( receipts: Receipt[] ): Array< { value: string; label: string } > {
 	return [ ...new Set( receipts.map( getServiceForFiltering ) ) ].sort().map( ( service ) => ( {
 		value: service,
@@ -372,11 +372,7 @@ function renderInlineHiddenFields( receipt: Receipt, visibleFields: string[] ) {
 				{ sprintf(
 					/* translators: %s is a formatted date, like May 21, 2026 */
 					__( 'Date: %s' ),
-					new Date( receipt.date ).toLocaleDateString( undefined, {
-						year: 'numeric',
-						month: 'short',
-						day: 'numeric',
-					} )
+					formatReceiptDate( receipt )
 				) }
 			</Text>
 		);

--- a/client/dashboard/me/billing-history/dataviews.tsx
+++ b/client/dashboard/me/billing-history/dataviews.tsx
@@ -54,7 +54,7 @@ export const DEFAULT_VIEW: View = {
 
 export function useActions() {
 	const navigate = useNavigate();
-	const sendEmailMutation = useMutation( {
+	const { mutate: sendEmail } = useMutation( {
 		...sendReceiptEmailMutation(),
 		meta: {
 			snackbar: {
@@ -87,17 +87,18 @@ export function useActions() {
 				isEligible: ( item: Receipt ) => Boolean( item.id ),
 				callback: ( items: Receipt[] ) => {
 					const item = items[ 0 ];
-					sendEmailMutation.mutate( String( item.id ) );
+					sendEmail( String( item.id ) );
 				},
 			},
 		],
-		[ navigate, sendEmailMutation ]
+		[ navigate, sendEmail ]
 	);
 }
 
 export function getFields(
 	receipts: Receipt[],
-	countryList: CountryListItem[] = []
+	countryList: CountryListItem[] = [],
+	visibleFields: string[] = WIDE_FIELDS
 ): Fields< Receipt > {
 	return [
 		{
@@ -154,14 +155,17 @@ export function getFields(
 			},
 			render: ( { item }: { item: Receipt } ) => {
 				return (
-					<Link
-						to={ receiptRoute.fullPath }
-						params={ { receiptId: item.id } }
-						title={ __( 'View receipt' ) }
-						className="receipts-link-to-receipt"
-					>
-						{ renderServiceNameDescription( item ) }
-					</Link>
+					<VStack spacing={ 1 }>
+						<Link
+							to={ receiptRoute.fullPath }
+							params={ { receiptId: item.id } }
+							title={ __( 'View receipt' ) }
+							className="receipts-link-to-receipt"
+						>
+							{ renderServiceNameDescription( item ) }
+						</Link>
+						{ renderInlineHiddenFields( item, visibleFields ) }
+					</VStack>
 				);
 			},
 		},
@@ -357,6 +361,49 @@ function renderServiceNameDescription( receipt: Receipt ) {
 			) }
 		</VStack>
 	);
+}
+
+function renderInlineHiddenFields( receipt: Receipt, visibleFields: string[] ) {
+	const lines: JSX.Element[] = [];
+
+	if ( ! visibleFields.includes( 'date' ) ) {
+		lines.push(
+			<Text key="date" isBlock variant="muted" size="12">
+				{ sprintf(
+					/* translators: %s is a formatted date, like May 21, 2026 */
+					__( 'Date: %s' ),
+					new Date( receipt.date ).toLocaleDateString( undefined, {
+						year: 'numeric',
+						month: 'short',
+						day: 'numeric',
+					} )
+				) }
+			</Text>
+		);
+	}
+	if ( ! visibleFields.includes( 'type' ) ) {
+		lines.push(
+			<Text key="type" isBlock variant="muted" size="12">
+				{ sprintf(
+					/* translators: %s is a receipt type, like Refund or New purchase */
+					__( 'Type: %s' ),
+					getReceiptItemTypeForDisplay( receipt )
+				) }
+			</Text>
+		);
+	}
+	if ( ! visibleFields.includes( 'amount' ) ) {
+		lines.push(
+			<Text key="amount" isBlock variant="muted" size="12">
+				{ sprintf(
+					/* translators: %s is a formatted price, like $96 */
+					__( 'Amount: %s' ),
+					formatReceiptAmount( receipt )
+				) }
+			</Text>
+		);
+	}
+	return lines;
 }
 
 function getReceiptItemTypesForFiltering(

--- a/client/dashboard/me/billing-history/index.tsx
+++ b/client/dashboard/me/billing-history/index.tsx
@@ -50,7 +50,7 @@ export default function BillingHistory() {
 	} );
 
 	const fields = useMemo(
-		() => getFields( receipts, countryList, ( view.fields as string[] ) ?? WIDE_FIELDS ),
+		() => getFields( receipts, countryList, view.fields ?? WIDE_FIELDS ),
 		[ receipts, countryList, view.fields ]
 	);
 

--- a/client/dashboard/me/billing-history/index.tsx
+++ b/client/dashboard/me/billing-history/index.tsx
@@ -49,7 +49,10 @@ export default function BillingHistory() {
 		}
 	} );
 
-	const fields = useMemo( () => getFields( receipts, countryList ), [ receipts, countryList ] );
+	const fields = useMemo(
+		() => getFields( receipts, countryList, ( view.fields as string[] ) ?? WIDE_FIELDS ),
+		[ receipts, countryList, view.fields ]
+	);
 
 	const { data: filteredReceipts, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( receipts, view, fields );

--- a/client/dashboard/me/billing-history/styles.scss
+++ b/client/dashboard/me/billing-history/styles.scss
@@ -20,10 +20,6 @@
 	}
 }
 
-.billing-history-receipt-meta-value {
-	font-size: 11px;
-}
-
 .receipt-icon {
 	width: 68px;
 	height: 68px;

--- a/client/dashboard/me/billing-history/styles.scss
+++ b/client/dashboard/me/billing-history/styles.scss
@@ -2,6 +2,28 @@
 	text-decoration: none;
 }
 
+.billing-history-receipt-meta {
+	display: flex;
+	align-items: baseline;
+	gap: 8px;
+}
+
+.billing-history-receipt-meta-label {
+	font-size: 11px;
+	font-weight: 500;
+	line-height: 20px;
+	text-transform: uppercase;
+	color: var( --wp-components-color-foreground );
+
+	&::after {
+		content: ":";
+	}
+}
+
+.billing-history-receipt-meta-value {
+	font-size: 11px;
+}
+
 .receipt-icon {
 	width: 68px;
 	height: 68px;

--- a/client/dashboard/me/billing-history/test/dataviews.test.tsx
+++ b/client/dashboard/me/billing-history/test/dataviews.test.tsx
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import { screen } from '@testing-library/react';
+import { type ComponentType } from 'react';
 import { render } from '../../../test-utils';
 import { getFields } from '../dataviews';
 import type { Receipt } from '@automattic/api-core';
@@ -62,7 +63,8 @@ const receipt = {
 function renderServiceCell( visibleFields: string[] ) {
 	const fields = getFields( [ receipt ], [], visibleFields );
 	const serviceField = fields.find( ( field ) => field.id === 'service' )!;
-	return render( <>{ serviceField.render!( { item: receipt, field: serviceField } as never ) }</> );
+	const ServiceCell = serviceField.render as ComponentType< { item: Receipt } >;
+	return render( <ServiceCell item={ receipt } /> );
 }
 
 describe( '<BillingHistory>', () => {

--- a/client/dashboard/me/billing-history/test/dataviews.test.tsx
+++ b/client/dashboard/me/billing-history/test/dataviews.test.tsx
@@ -70,24 +70,29 @@ function renderServiceCell( visibleFields: string[] ) {
 describe( '<BillingHistory>', () => {
 	test( 'shows Type and Amount inline when those columns are hidden', async () => {
 		renderServiceCell( [ 'date', 'service' ] );
-		expect( await screen.findByText( 'Type: Refund' ) ).toBeVisible();
-		expect( screen.getByText( 'Amount: $96' ) ).toBeVisible();
-		expect( screen.queryByText( /Date:/ ) ).not.toBeInTheDocument();
+		expect( await screen.findByText( 'Type' ) ).toBeVisible();
+		expect( screen.getByText( 'Refund' ) ).toBeVisible();
+		expect( screen.getByText( 'Amount' ) ).toBeVisible();
+		expect( screen.getByText( '$96' ) ).toBeVisible();
+		expect( screen.queryByText( 'Date' ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'shows Date inline when only the App column is visible', async () => {
 		renderServiceCell( [ 'service' ] );
-		expect( await screen.findByText( 'Date: May 21, 2026' ) ).toBeVisible();
-		expect( screen.getByText( 'Type: Refund' ) ).toBeVisible();
-		expect( screen.getByText( 'Amount: $96' ) ).toBeVisible();
+		expect( await screen.findByText( 'Date' ) ).toBeVisible();
+		expect( screen.getByText( 'May 21, 2026' ) ).toBeVisible();
+		expect( screen.getByText( 'Type' ) ).toBeVisible();
+		expect( screen.getByText( 'Refund' ) ).toBeVisible();
+		expect( screen.getByText( 'Amount' ) ).toBeVisible();
+		expect( screen.getByText( '$96' ) ).toBeVisible();
 	} );
 
 	test( 'shows no inline lines when all columns are visible', async () => {
 		renderServiceCell( [ 'date', 'service', 'type', 'amount' ] );
 		// Wait for the App cell's receipt link to render before asserting absence.
 		expect( await screen.findByRole( 'link' ) ).toBeVisible();
-		expect( screen.queryByText( /Type:/ ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( /Amount:/ ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( /Date:/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Type' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Amount' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Date' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/dashboard/me/billing-history/test/dataviews.test.tsx
+++ b/client/dashboard/me/billing-history/test/dataviews.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { getFields } from '../dataviews';
+import type { Receipt } from '@automattic/api-core';
+
+const receipt = {
+	id: 1,
+	service: 'WordPress.com',
+	service_slug: 'wpcom',
+	currency: 'USD',
+	subtotal_integer: 9600,
+	tax_integer: 0,
+	amount_integer: 9600,
+	tax_country_code: 'US',
+	date: '2026-05-21T00:00:00+00:00',
+	desc: '',
+	org: '',
+	address: null,
+	icon: '',
+	url: '',
+	support: '',
+	pay_ref: '',
+	pay_part: '',
+	cc_type: '',
+	cc_display_brand: '',
+	cc_num: '',
+	cc_name: '',
+	cc_email: '',
+	credit: '',
+	items: [
+		{
+			id: 1,
+			type: 'refund',
+			type_localized: 'Refund',
+			domain: null,
+			site_id: 1,
+			subtotal_integer: 9600,
+			tax_integer: 0,
+			amount_integer: 9600,
+			currency: 'USD',
+			licensed_quantity: 0,
+			new_quantity: 0,
+			product: 'WordPress.com Personal',
+			product_slug: 'personal-bundle',
+			variation: 'WordPress.com Personal',
+			variation_slug: '',
+			months_per_renewal_interval: 12,
+			wpcom_product_slug: 'personal-bundle',
+			cost_overrides: [],
+			volume: 0,
+			credits_used: null,
+			introductory_offer_terms: null,
+			price_tier_slug: '',
+			saas_redirect_url: '',
+		},
+	],
+} as unknown as Receipt;
+
+jest.mock( '@tanstack/react-router', () => ( {
+	Link: ( { children }: { children: React.ReactNode } ) => <span>{ children }</span>,
+	useNavigate: () => () => {},
+	createLink:
+		() =>
+		( { children }: { children: React.ReactNode } ) => <span>{ children }</span>,
+	createRoute: () => ( {
+		lazy: () => ( {} ),
+		fullPath: '/me/billing',
+	} ),
+	createLazyRoute: () => () => ( {} ),
+	createRootRoute: () => ( {} ),
+	createRouter: () => ( {} ),
+	RouterProvider: () => null,
+} ) );
+
+jest.mock( '../../../app/router/me', () => ( {
+	receiptRoute: {
+		fullPath: '/me/billing/receipts/$receiptId',
+	},
+} ) );
+
+function renderServiceCell( visibleFields: string[] ) {
+	const fields = getFields( [ receipt ], [], visibleFields );
+	const serviceField = fields.find( ( field ) => field.id === 'service' )!;
+	return render( <>{ serviceField.render!( { item: receipt, field: serviceField } as never ) }</> );
+}
+
+describe( 'dashboard billing history service cell inline fields', () => {
+	it( 'shows Type and Amount inline when those columns are hidden', () => {
+		renderServiceCell( [ 'date', 'service' ] );
+		expect( screen.getByText( /Type:/ ) ).toBeVisible();
+		expect( screen.getByText( /Amount:/ ) ).toBeVisible();
+		expect( screen.queryByText( /Date:/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows Date inline when only the App column is visible', () => {
+		renderServiceCell( [ 'service' ] );
+		expect( screen.getByText( /Date:/ ) ).toBeVisible();
+		expect( screen.getByText( /Type:/ ) ).toBeVisible();
+		expect( screen.getByText( /Amount:/ ) ).toBeVisible();
+	} );
+
+	it( 'shows no inline lines when all columns are visible', () => {
+		renderServiceCell( [ 'date', 'service', 'type', 'amount' ] );
+		expect( screen.queryByText( /Type:/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /Amount:/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /Date:/ ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/dashboard/me/billing-history/test/dataviews.test.tsx
+++ b/client/dashboard/me/billing-history/test/dataviews.test.tsx
@@ -1,7 +1,8 @@
 /**
  * @jest-environment jsdom
  */
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
+import { render } from '../../../test-utils';
 import { getFields } from '../dataviews';
 import type { Receipt } from '@automattic/api-core';
 
@@ -58,51 +59,31 @@ const receipt = {
 	],
 } as unknown as Receipt;
 
-jest.mock( '@tanstack/react-router', () => ( {
-	Link: ( { children }: { children: React.ReactNode } ) => <span>{ children }</span>,
-	useNavigate: () => () => {},
-	createLink:
-		() =>
-		( { children }: { children: React.ReactNode } ) => <span>{ children }</span>,
-	createRoute: () => ( {
-		lazy: () => ( {} ),
-		fullPath: '/me/billing',
-	} ),
-	createLazyRoute: () => () => ( {} ),
-	createRootRoute: () => ( {} ),
-	createRouter: () => ( {} ),
-	RouterProvider: () => null,
-} ) );
-
-jest.mock( '../../../app/router/me', () => ( {
-	receiptRoute: {
-		fullPath: '/me/billing/receipts/$receiptId',
-	},
-} ) );
-
 function renderServiceCell( visibleFields: string[] ) {
 	const fields = getFields( [ receipt ], [], visibleFields );
 	const serviceField = fields.find( ( field ) => field.id === 'service' )!;
 	return render( <>{ serviceField.render!( { item: receipt, field: serviceField } as never ) }</> );
 }
 
-describe( 'dashboard billing history service cell inline fields', () => {
-	it( 'shows Type and Amount inline when those columns are hidden', () => {
+describe( '<BillingHistory>', () => {
+	test( 'shows Type and Amount inline when those columns are hidden', async () => {
 		renderServiceCell( [ 'date', 'service' ] );
-		expect( screen.getByText( /Type:/ ) ).toBeVisible();
-		expect( screen.getByText( /Amount:/ ) ).toBeVisible();
+		expect( await screen.findByText( 'Type: Refund' ) ).toBeVisible();
+		expect( screen.getByText( 'Amount: $96' ) ).toBeVisible();
 		expect( screen.queryByText( /Date:/ ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'shows Date inline when only the App column is visible', () => {
+	test( 'shows Date inline when only the App column is visible', async () => {
 		renderServiceCell( [ 'service' ] );
-		expect( screen.getByText( /Date:/ ) ).toBeVisible();
-		expect( screen.getByText( /Type:/ ) ).toBeVisible();
-		expect( screen.getByText( /Amount:/ ) ).toBeVisible();
+		expect( await screen.findByText( 'Date: May 21, 2026' ) ).toBeVisible();
+		expect( screen.getByText( 'Type: Refund' ) ).toBeVisible();
+		expect( screen.getByText( 'Amount: $96' ) ).toBeVisible();
 	} );
 
-	it( 'shows no inline lines when all columns are visible', () => {
+	test( 'shows no inline lines when all columns are visible', async () => {
 		renderServiceCell( [ 'date', 'service', 'type', 'amount' ] );
+		// Wait for the App cell's receipt link to render before asserting absence.
+		expect( await screen.findByRole( 'link' ) ).toBeVisible();
 		expect( screen.queryByText( /Type:/ ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( /Amount:/ ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( /Date:/ ) ).not.toBeInTheDocument();

--- a/client/me/purchases/billing-history/billing-history-list-data-view.tsx
+++ b/client/me/purchases/billing-history/billing-history-list-data-view.tsx
@@ -35,6 +35,12 @@ export default function BillingHistoryListDataView( {
 	);
 	const fields = useFieldDefinitions( transactions, getReceiptUrlFor, visibleFields );
 	const viewState = useViewStateUpdate( fields );
+	// `visibleFields` cannot be derived directly from `viewState.view.fields`:
+	// `viewState` depends on `fields`, which depends on `visibleFields`, so reading
+	// the view here would be a declaration cycle. Instead we mirror the view's
+	// fields into state after each update. The field ids passed to
+	// `useViewStateUpdate` are stable regardless of visibility, so this does not
+	// loop.
 	useEffect( () => {
 		const nextFields = ( viewState.view.fields as string[] ) ?? [];
 		setVisibleFields( ( current ) =>

--- a/client/me/purchases/billing-history/billing-history-list-data-view.tsx
+++ b/client/me/purchases/billing-history/billing-history-list-data-view.tsx
@@ -1,11 +1,13 @@
 import { Gridicon } from '@automattic/components';
 import { DataViews } from '@wordpress/dataviews';
+import { isShallowEqualArrays } from '@wordpress/is-shallow-equal';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import getPastBillingTransactions from 'calypso/state/selectors/get-past-billing-transactions';
 import isRequestingBillingTransactions from 'calypso/state/selectors/is-requesting-billing-transactions';
 import { usePagination } from '../use-pagination';
+import { defaultDataViewsState } from './constants';
 import { useFieldDefinitions } from './hooks/use-field-definitions';
 import { useReceiptActions } from './hooks/use-receipt-actions';
 import { useTransactionsFiltering } from './hooks/use-transactions-filtering';
@@ -27,9 +29,18 @@ export default function BillingHistoryListDataView( {
 	siteId,
 }: BillingHistoryListProps ) {
 	const transactions = useSelector( getPastBillingTransactions );
-	const fields = useFieldDefinitions( transactions, getReceiptUrlFor );
 	const isLoading = useSelector( isRequestingBillingTransactions );
+	const [ visibleFields, setVisibleFields ] = useState< string[] >(
+		( defaultDataViewsState.fields as string[] ) ?? []
+	);
+	const fields = useFieldDefinitions( transactions, getReceiptUrlFor, visibleFields );
 	const viewState = useViewStateUpdate( fields );
+	useEffect( () => {
+		const nextFields = ( viewState.view.fields as string[] ) ?? [];
+		setVisibleFields( ( current ) =>
+			isShallowEqualArrays( current, nextFields ) ? current : nextFields
+		);
+	}, [ viewState.view.fields ] );
 	const receiptActions = useReceiptActions( getReceiptUrlFor );
 
 	const actions = receiptActions.map( ( action ) => ( {

--- a/client/me/purchases/billing-history/field-definitions.tsx
+++ b/client/me/purchases/billing-history/field-definitions.tsx
@@ -116,6 +116,15 @@ function getUniqueTransactionTypes(
 		} ) );
 }
 
+function renderInlineHiddenField( key: string, label: string, value: string ) {
+	return (
+		<span key={ key } className="billing-history__item-meta">
+			<span className="billing-history__item-meta-label">{ label }</span>
+			<span className="billing-history__item-meta-value">{ value }</span>
+		</span>
+	);
+}
+
 function renderInlineHiddenFields(
 	transaction: BillingTransaction,
 	translate: ReturnType< typeof useTranslate >,
@@ -126,37 +135,32 @@ function renderInlineHiddenFields(
 
 	if ( ! visibleFields.includes( 'date' ) ) {
 		lines.push(
-			<small key="date">
-				{ translate( 'Date: %s', {
-					args: [ formatDisplayDate( new Date( transaction.date ) ) ],
-					comment: '%s is a formatted date, like May 21, 2026',
-				} ) }
-			</small>
+			renderInlineHiddenField(
+				'date',
+				translate( 'Date' ),
+				formatDisplayDate( new Date( transaction.date ) )
+			)
 		);
 	}
 	if ( ! visibleFields.includes( 'type' ) ) {
 		lines.push(
-			<small key="type">
-				{ translate( 'Type: %s', {
-					args: [ transactionItem.type_localized || transactionItem.type ],
-					comment: '%s is a receipt type, like Refund or New purchase',
-				} ) }
-			</small>
+			renderInlineHiddenField(
+				'type',
+				translate( 'Type' ),
+				transactionItem.type_localized || transactionItem.type
+			)
 		);
 	}
 	if ( ! visibleFields.includes( 'amount' ) ) {
 		lines.push(
-			<small key="amount">
-				{ translate( 'Amount: %s', {
-					args: [
-						formatCurrency( transaction.amount_integer, transaction.currency, {
-							isSmallestUnit: true,
-							stripZeros: true,
-						} ),
-					],
-					comment: '%s is a formatted price, like $96',
-				} ) }
-			</small>
+			renderInlineHiddenField(
+				'amount',
+				translate( 'Amount' ),
+				formatCurrency( transaction.amount_integer, transaction.currency, {
+					isSmallestUnit: true,
+					stripZeros: true,
+				} )
+			)
 		);
 	}
 	return lines;

--- a/client/me/purchases/billing-history/field-definitions.tsx
+++ b/client/me/purchases/billing-history/field-definitions.tsx
@@ -1,4 +1,5 @@
 import { isAkismetPro500, getAkismetPro500ProductDisplayName } from '@automattic/calypso-products';
+import { formatCurrency } from '@automattic/number-formatters';
 import { type Fields, type Operator } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
 import { capitalPDangit } from 'calypso/lib/formatting';
@@ -114,10 +115,57 @@ function getUniqueTransactionTypes(
 		} ) );
 }
 
+function renderInlineHiddenFields(
+	transaction: BillingTransaction,
+	translate: ReturnType< typeof useTranslate >,
+	visibleFields: string[]
+) {
+	const [ transactionItem ] = groupDomainProducts( transaction.items, translate );
+	const lines: JSX.Element[] = [];
+
+	if ( ! visibleFields.includes( 'date' ) ) {
+		lines.push(
+			<small key="date">
+				{ translate( 'Date: %s', {
+					args: [ formatDisplayDate( new Date( transaction.date ) ) ],
+					comment: '%s is a formatted date, like May 21, 2026',
+				} ) }
+			</small>
+		);
+	}
+	if ( ! visibleFields.includes( 'type' ) ) {
+		lines.push(
+			<small key="type">
+				{ translate( 'Type: %s', {
+					args: [ transactionItem.type_localized || transactionItem.type ],
+					comment: '%s is a receipt type, like Refund or New purchase',
+				} ) }
+			</small>
+		);
+	}
+	if ( ! visibleFields.includes( 'amount' ) ) {
+		lines.push(
+			<small key="amount">
+				{ translate( 'Amount: %s', {
+					args: [
+						formatCurrency( transaction.amount_integer, transaction.currency, {
+							isSmallestUnit: true,
+							stripZeros: true,
+						} ),
+					],
+					comment: '%s is a formatted price, like $96',
+				} ) }
+			</small>
+		);
+	}
+	return lines;
+}
+
 export function getFieldDefinitions(
 	transactions: BillingTransaction[] | null,
 	translate: ReturnType< typeof useTranslate >,
-	getReceiptUrlFor: ( receiptId: string ) => string
+	getReceiptUrlFor: ( receiptId: string ) => string,
+	visibleFields: string[] = [ 'date', 'service', 'type', 'amount' ]
 ): Fields< BillingTransaction > {
 	return [
 		{
@@ -158,6 +206,7 @@ export function getFieldDefinitions(
 						>
 							{ renderServiceName( item, translate ) }
 						</a>
+						{ renderInlineHiddenFields( item, translate, visibleFields ) }
 					</div>
 				);
 			},

--- a/client/me/purchases/billing-history/field-definitions.tsx
+++ b/client/me/purchases/billing-history/field-definitions.tsx
@@ -3,6 +3,7 @@ import { formatCurrency } from '@automattic/number-formatters';
 import { type Fields, type Operator } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
 import { capitalPDangit } from 'calypso/lib/formatting';
+import { wideFields } from './constants';
 import {
 	getTransactionTermLabel,
 	groupDomainProducts,
@@ -165,7 +166,7 @@ export function getFieldDefinitions(
 	transactions: BillingTransaction[] | null,
 	translate: ReturnType< typeof useTranslate >,
 	getReceiptUrlFor: ( receiptId: string ) => string,
-	visibleFields: string[] = [ 'date', 'service', 'type', 'amount' ]
+	visibleFields: string[] = wideFields
 ): Fields< BillingTransaction > {
 	return [
 		{

--- a/client/me/purchases/billing-history/hooks/use-field-definitions.ts
+++ b/client/me/purchases/billing-history/hooks/use-field-definitions.ts
@@ -5,11 +5,12 @@ import type { BillingTransaction } from 'calypso/state/billing-transactions/type
 
 export function useFieldDefinitions(
 	transactions: BillingTransaction[] | null,
-	getReceiptUrlFor: ( receiptId: string ) => string
+	getReceiptUrlFor: ( receiptId: string ) => string,
+	visibleFields: string[]
 ) {
 	const translate = useTranslate();
 
 	return useMemo( () => {
-		return getFieldDefinitions( transactions, translate, getReceiptUrlFor );
-	}, [ transactions, translate, getReceiptUrlFor ] );
+		return getFieldDefinitions( transactions, translate, getReceiptUrlFor, visibleFields );
+	}, [ transactions, translate, getReceiptUrlFor, visibleFields ] );
 }

--- a/client/me/purchases/billing-history/style-data-view.scss
+++ b/client/me/purchases/billing-history/style-data-view.scss
@@ -264,3 +264,26 @@
 	 * hack it. */
 	color: #2f2f2f;
 }
+
+.billing-history__item-meta {
+	display: flex;
+	align-items: baseline;
+	gap: 0.5rem;
+	margin-top: 0.25rem;
+}
+
+.billing-history__item-meta-label {
+	font-size: 11px;
+	font-weight: 500;
+	line-height: 20px;
+	text-transform: uppercase;
+	color: var( --color-text );
+
+	&::after {
+		content: ":";
+	}
+}
+
+.billing-history__item-meta-value {
+	color: var( --color-text-subtle );
+}

--- a/client/me/purchases/billing-history/test/field-definitions.test.tsx
+++ b/client/me/purchases/billing-history/test/field-definitions.test.tsx
@@ -3,6 +3,7 @@
  */
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
+import { type ComponentType } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import { createTestReduxStore } from 'calypso/my-sites/checkout/src/test/util';
 import { getFieldDefinitions } from '../field-definitions';
@@ -73,12 +74,13 @@ function renderServiceCell( visibleFields: string[] ) {
 	const translate = ( ( text: string ) => text ) as never;
 	const fields = getFieldDefinitions( [ transaction ], translate, () => '/r/1', visibleFields );
 	const serviceField = fields.find( ( field ) => field.id === 'service' )!;
+	const ServiceCell = serviceField.render as ComponentType< { item: BillingTransaction } >;
 	const queryClient = new QueryClient();
 	const store = createTestReduxStore();
 	return render(
 		<ReduxProvider store={ store }>
 			<QueryClientProvider client={ queryClient }>
-				{ serviceField.render!( { item: transaction, field: serviceField } as never ) }
+				<ServiceCell item={ transaction } />
 			</QueryClientProvider>
 		</ReduxProvider>
 	);

--- a/client/me/purchases/billing-history/test/field-definitions.test.tsx
+++ b/client/me/purchases/billing-history/test/field-definitions.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { Provider as ReduxProvider } from 'react-redux';
+import { createTestReduxStore } from 'calypso/my-sites/checkout/src/test/util';
+import { getFieldDefinitions } from '../field-definitions';
+import type {
+	BillingTransaction,
+	BillingTransactionItem,
+} from 'calypso/state/billing-transactions/types';
+
+const item: BillingTransactionItem = {
+	id: '1',
+	type: 'refund',
+	type_localized: 'Refund',
+	domain: '',
+	site_id: '1',
+	subtotal: '',
+	raw_subtotal: 0,
+	subtotal_integer: 0,
+	tax: '',
+	raw_tax: 0,
+	tax_integer: 0,
+	amount: '',
+	raw_amount: 0,
+	amount_integer: 9600,
+	cost_overrides: [],
+	currency: 'USD',
+	licensed_quantity: 0,
+	new_quantity: 0,
+	product: 'WordPress.com Personal',
+	product_slug: 'personal-bundle',
+	variation: 'WordPress.com Personal',
+	variation_slug: '',
+	months_per_renewal_interval: 12,
+	wpcom_product_slug: 'personal-bundle',
+	volume: 0,
+} as unknown as BillingTransactionItem;
+
+const transaction: BillingTransaction = {
+	address: '',
+	amount: '',
+	amount_integer: 9600,
+	currency: 'USD',
+	tax_country_code: 'US',
+	cc_email: '',
+	cc_name: '',
+	cc_num: '',
+	cc_type: '',
+	cc_display_brand: null,
+	credit: '',
+	date: '2026-05-21T00:00:00+00:00',
+	desc: '',
+	icon: '',
+	id: '1',
+	items: [ item ],
+	org: '',
+	pay_part: '',
+	pay_ref: '',
+	service: 'WordPress.com',
+	service_slug: 'wpcom',
+	subtotal: '',
+	subtotal_integer: 9600,
+	support: '',
+	tax: '',
+	tax_integer: 0,
+	url: '',
+} as unknown as BillingTransaction;
+
+function renderServiceCell( visibleFields: string[] ) {
+	const translate = ( ( text: string ) => text ) as never;
+	const fields = getFieldDefinitions( [ transaction ], translate, () => '/r/1', visibleFields );
+	const serviceField = fields.find( ( field ) => field.id === 'service' )!;
+	const queryClient = new QueryClient();
+	const store = createTestReduxStore();
+	return render(
+		<ReduxProvider store={ store }>
+			<QueryClientProvider client={ queryClient }>
+				{ serviceField.render!( { item: transaction, field: serviceField } as never ) }
+			</QueryClientProvider>
+		</ReduxProvider>
+	);
+}
+
+describe( 'billing history service cell inline fields', () => {
+	it( 'shows Type and Amount inline when those columns are hidden', () => {
+		renderServiceCell( [ 'date', 'service' ] );
+		expect( screen.getByText( /Type:/ ) ).toBeVisible();
+		expect( screen.getByText( /Amount:/ ) ).toBeVisible();
+		expect( screen.queryByText( /Date:/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows Date inline when only the App column is visible', () => {
+		renderServiceCell( [ 'service' ] );
+		expect( screen.getByText( /Date:/ ) ).toBeVisible();
+		expect( screen.getByText( /Type:/ ) ).toBeVisible();
+		expect( screen.getByText( /Amount:/ ) ).toBeVisible();
+	} );
+
+	it( 'shows no inline lines when all columns are visible', () => {
+		renderServiceCell( [ 'date', 'service', 'type', 'amount' ] );
+		expect( screen.queryByText( /Type:/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /Amount:/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /Date:/ ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/me/purchases/billing-history/test/field-definitions.test.tsx
+++ b/client/me/purchases/billing-history/test/field-definitions.test.tsx
@@ -89,22 +89,27 @@ function renderServiceCell( visibleFields: string[] ) {
 describe( 'billing history service cell inline fields', () => {
 	it( 'shows Type and Amount inline when those columns are hidden', () => {
 		renderServiceCell( [ 'date', 'service' ] );
-		expect( screen.getByText( /Type:/ ) ).toBeVisible();
-		expect( screen.getByText( /Amount:/ ) ).toBeVisible();
-		expect( screen.queryByText( /Date:/ ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'Type' ) ).toBeVisible();
+		expect( screen.getByText( 'Refund' ) ).toBeVisible();
+		expect( screen.getByText( 'Amount' ) ).toBeVisible();
+		expect( screen.getByText( '$96' ) ).toBeVisible();
+		expect( screen.queryByText( 'Date' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'shows Date inline when only the App column is visible', () => {
 		renderServiceCell( [ 'service' ] );
-		expect( screen.getByText( /Date:/ ) ).toBeVisible();
-		expect( screen.getByText( /Type:/ ) ).toBeVisible();
-		expect( screen.getByText( /Amount:/ ) ).toBeVisible();
+		expect( screen.getByText( 'Date' ) ).toBeVisible();
+		expect( screen.getByText( 'May 21, 2026' ) ).toBeVisible();
+		expect( screen.getByText( 'Type' ) ).toBeVisible();
+		expect( screen.getByText( 'Refund' ) ).toBeVisible();
+		expect( screen.getByText( 'Amount' ) ).toBeVisible();
+		expect( screen.getByText( '$96' ) ).toBeVisible();
 	} );
 
 	it( 'shows no inline lines when all columns are visible', () => {
 		renderServiceCell( [ 'date', 'service', 'type', 'amount' ] );
-		expect( screen.queryByText( /Type:/ ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( /Amount:/ ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( /Date:/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Type' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Amount' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Date' ) ).not.toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
Fixes http://linear.app/a8c/issue/SHILL-2081

## Proposed Changes

In both the Calypso Billing History receipts list (`/me/purchases/billing`) and the Dashboard equivalent (`/me/billing/billing-history`), when the **Date**, **Type**, or **Amount** column is hidden at narrower widths (or via the column-options menu), its value now appears as a labeled line beneath the App name in the always-visible App column.

https://github.com/user-attachments/assets/724f7712-4ce2-4af7-b282-f55821e421f8

* Labels render as small uppercase "eyebrow" tags (`TYPE:`, `AMOUNT:`, `DATE:`) to visually separate them from their values.
* Mechanism: the currently-visible field IDs (`view.fields`) are threaded into each view's field-definition builder; the App column's renderer appends a line for whichever of date/type/amount is not currently a visible column. Keying off the visible fields (rather than the width tier) means manual column toggles are respected too.
* Drive-by cleanups in the Dashboard: fixed a pre-existing `@tanstack/query/no-unstable-deps` lint warning in `useActions` (destructured `mutate`) that blocked committing the touched file, and extracted a shared `formatReceiptDate` helper so the inline date matches the date column exactly.

## Why are these changes being made?

Receipts and refunds were indistinguishable in the list at common widths. The `Type` and `Amount` columns are only shown above 1280px, so below that — including the entire 960–1280px range — you couldn't tell whether a purchase had been refunded or whether a receipt was simply emailed. Surfacing the hidden fields inline keeps that information available without forcing the extra columns onto narrow layouts.

## Testing Instructions

1. Open `/me/purchases/billing` (Calypso) and the Dashboard `/me/billing/billing-history`.
2. Narrow the window below ~1280px → the `Type` and `Amount` columns collapse; confirm `TYPE: …` and `AMOUNT: …` now appear under the App name.
3. Narrow below ~960px → confirm `DATE: …` also appears.
4. Widen past 1280px → confirm the inline lines disappear (the columns take over again).
5. Open the column-options (gear) menu and toggle `Type` / `Amount` / `Date` off at a wide width → confirm the matching inline line appears.
6. Confirm a refunded purchase shows `TYPE: Refund` so it's distinguishable from a receipt.

Inline label/value colors use semantic tokens (`--color-text` / `--wp-components-color-foreground` / `--color-text-subtle`), so they adapt in dark mode by construction.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
