### PR TITLE
Plugins: noindex uncurated /plugins/browse/<term> pages

### DIFF
--- a/client/my-sites/plugins/controller-logged-out.js
+++ b/client/my-sites/plugins/controller-logged-out.js
@@ -7,11 +7,14 @@ import {
 } from 'calypso/data/marketplace/use-wpcom-plugins-query';
 import { getSiteFragment } from 'calypso/lib/route';
 import wpcom from 'calypso/lib/wp';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { setDocumentHeadMeta } from 'calypso/state/document-head/actions';
+import { getDocumentHeadMeta } from 'calypso/state/document-head/selectors';
 import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
 import { getPlugin as getWporgPluginSelector } from 'calypso/state/plugins/wporg/selectors';
 import { receiveProductsList } from 'calypso/state/products-list/actions';
 import { isMarketplaceProduct as isMarketplaceProductSelector } from 'calypso/state/products-list/selectors';
-import { getCategories } from './categories/use-categories';
+import { ALLOWED_CATEGORIES, getCategories } from './categories/use-categories';
 import { UNLISTED_PLUGINS } from './constants';
 import { getCategoryForPluginsBrowser } from './controller';
 
@@ -173,6 +176,40 @@ export async function fetchCategoryPlugins( context, next ) {
 		],
 		context
 	);
+
+	next();
+}
+
+/**
+ * Mark uncurated `/plugins/browse/<term>` pages as `noindex`.
+ *
+ * Only the curated `ALLOWED_CATEGORIES` are intentional landing pages meant to be
+ * indexed. Every other term is a tag fallthrough: each plugin links all of its
+ * WordPress.org tags as `/plugins/browse/<tag>` (see plugin-details-header), which
+ * generates a long tail of ~49k thin tag pages. Google crawls these and declines to
+ * index them, so they pile up in Search Console's "Crawled - currently not indexed"
+ * bucket. Emitting `noindex` reclassifies them into the intentional "Excluded by
+ * 'noindex' tag" bucket. We deliberately keep them crawlable (no robots.txt block)
+ * so Googlebot can recrawl and observe the directive.
+ */
+export function setBrowsePluginsNoindex( context, next ) {
+	if ( ! context.isServerSide || isUserLoggedIn( context.store.getState() ) ) {
+		return next();
+	}
+
+	const category = getCategoryForPluginsBrowser( context );
+	const isCurated =
+		!! category &&
+		ALLOWED_CATEGORIES.some( ( allowed ) => allowed.toLowerCase() === category.toLowerCase() );
+
+	if ( ! isCurated ) {
+		const meta = getDocumentHeadMeta( context.store.getState() )
+			// Drop any existing robots meta to avoid duplicate tags.
+			.filter( ( { name } ) => name !== 'robots' )
+			.concat( { name: 'robots', content: 'noindex' } );
+
+		context.store.dispatch( setDocumentHeadMeta( meta ) );
+	}
 
 	next();
 }

--- a/client/my-sites/plugins/index.node.js
+++ b/client/my-sites/plugins/index.node.js
@@ -11,6 +11,7 @@ import {
 	fetchPlugin,
 	validatePlugin,
 	skipIfLoggedIn,
+	setBrowsePluginsNoindex,
 } from './controller-logged-out';
 
 export default function ( router ) {
@@ -36,6 +37,7 @@ export default function ( router ) {
 		setupPreferences,
 		fetchCategoryPlugins,
 		setEnglishCanonicalUrl,
+		setBrowsePluginsNoindex,
 		browsePlugins,
 		makeLayout
 	);

--- a/client/my-sites/plugins/test/controller-logged-out.js
+++ b/client/my-sites/plugins/test/controller-logged-out.js
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment jsdom
+ */
+import { setBrowsePluginsNoindex } from '../controller-logged-out';
+
+function makeContext( category, { isServerSide = true, loggedIn = false, meta = [] } = {} ) {
+	const dispatched = [];
+	return {
+		isServerSide,
+		params: { category },
+		store: {
+			getState: () => ( {
+				// isUserLoggedIn() reads currentUser?.id !== null, so an explicit
+				// null id is required to represent a logged-out request.
+				currentUser: { id: loggedIn ? 123 : null },
+				documentHead: { meta },
+			} ),
+			dispatch: ( action ) => dispatched.push( action ),
+		},
+		dispatched,
+	};
+}
+
+const robotsMeta = ( context ) =>
+	context.dispatched
+		.flatMap( ( action ) => action.meta || [] )
+		.filter( ( { name } ) => name === 'robots' );
+
+describe( 'setBrowsePluginsNoindex', () => {
+	test( 'adds noindex robots meta for an uncurated tag fallthrough term', () => {
+		const next = jest.fn();
+		const context = makeContext( 'email-money-transfer' );
+
+		setBrowsePluginsNoindex( context, next );
+
+		expect( robotsMeta( context ) ).toEqual( [ { name: 'robots', content: 'noindex' } ] );
+		expect( next ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'does NOT add noindex for a curated ALLOWED_CATEGORIES term', () => {
+		const next = jest.fn();
+		const context = makeContext( 'seo' );
+
+		setBrowsePluginsNoindex( context, next );
+
+		expect( context.dispatched ).toHaveLength( 0 );
+		expect( next ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'matches curated categories case-insensitively (e.g. jobBoards via jobboards)', () => {
+		const upper = makeContext( 'SEO' );
+		setBrowsePluginsNoindex( upper, jest.fn() );
+		expect( upper.dispatched ).toHaveLength( 0 );
+
+		// `jobBoards` is camelCase in the allowlist but lowercased in URLs.
+		const camel = makeContext( 'jobboards' );
+		setBrowsePluginsNoindex( camel, jest.fn() );
+		expect( camel.dispatched ).toHaveLength( 0 );
+	} );
+
+	test( 'does nothing on client-side (non-SSR) requests', () => {
+		const next = jest.fn();
+		const context = makeContext( 'email-money-transfer', { isServerSide: false } );
+
+		setBrowsePluginsNoindex( context, next );
+
+		expect( context.dispatched ).toHaveLength( 0 );
+		expect( next ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'does nothing for logged-in users', () => {
+		const next = jest.fn();
+		const context = makeContext( 'email-money-transfer', { loggedIn: true } );
+
+		setBrowsePluginsNoindex( context, next );
+
+		expect( context.dispatched ).toHaveLength( 0 );
+		expect( next ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'preserves existing non-robots meta and replaces any prior robots meta', () => {
+		const next = jest.fn();
+		const context = makeContext( 'email-money-transfer', {
+			meta: [
+				{ name: 'description', content: 'Plugins' },
+				{ name: 'robots', content: 'index' },
+			],
+		} );
+
+		setBrowsePluginsNoindex( context, next );
+
+		const { meta } = context.dispatched[ 0 ];
+		expect( meta ).toContainEqual( { name: 'description', content: 'Plugins' } );
+		expect( meta.filter( ( { name } ) => name === 'robots' ) ).toEqual( [
+			{ name: 'robots', content: 'noindex' },
+		] );
+	} );
+} );


### PR DESCRIPTION
<!-- No linked issue. -->

## Proposed Changes

* Add a `setBrowsePluginsNoindex` SSR middleware on the `/plugins/browse/:category` route that emits `<meta name="robots" content="noindex">` whenever the term is **not** one of the curated `ALLOWED_CATEGORIES`.
* Curated category pages (matched case-insensitively, so the camelCased `jobBoards` still matches a `jobboards` URL) are untouched and remain indexable.
* The pages stay HTTP 200 and crawlable — no `robots.txt` block — so Googlebot can recrawl and observe the directive.

## Why are these changes being made?

The `/plugins/browse/:category` route only curates ~64 categories, but it renders a page for *any* term: every plugin links all of its WordPress.org tags as `/plugins/browse/<tag>` (see `plugin-details-header`), and unknown terms fall through to an Elasticsearch tag query. Enumerating the WordPress.org plugin directory (~60.5k plugins) yields **~49k distinct tags**, i.e. ~49k thin, near-duplicate tag pages in the canonical (English) form alone, and far more once locale variants are counted.

Google crawls this long tail and declines to index it, so these pages accumulate in Search Console's **"Crawled – currently not indexed"** bucket. That bucket has grown large enough relative to our indexable pages that we believe it is contributing a sitewide quality signal.

`noindex` is the only directive that deterministically moves these pages into the intentional **"Excluded by 'noindex' tag"** bucket — a `canonical` is only a hint and is unreliable for arbitrary thin tags. Keeping the pages crawlable is intentional: a `robots.txt` block would prevent Googlebot from ever seeing the `noindex`.

This is orthogonal to the localized-canonical work from #110657: that addressed duplicate *localized* variants; this addresses the uncurated *tag* long tail.

## Testing Instructions

* `yarn test-client client/my-sites/plugins/test/controller-logged-out.js` — 6 cases covering curated vs. uncurated terms, case-insensitivity, SSR-only, logged-out-only, and meta de-duplication.
* Manually: as a logged-out user, view source of an uncurated browse page (e.g. `/plugins/browse/email-money-transfer`) and confirm `<meta name="robots" content="noindex">` is present; confirm a curated page (e.g. `/plugins/browse/seo`) has no such tag.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?

🤖 Generated with [Claude Code](https://claude.com/claude-code)