### PR TITLE
Notifications: create the REST client in componentDidMount, not the constructor

### DIFF
--- a/apps/notifications/src/panel/Notifications.jsx
+++ b/apps/notifications/src/panel/Notifications.jsx
@@ -76,9 +76,18 @@ export class Notifications extends PureComponent {
 		],
 	};
 
-	constructor( props ) {
-		super( props );
+	state = {
+		// Set up the client in componentDidMount (the commit phase), not the
+		// constructor. React can run the constructor/render phase many times
+		// before it commits a mount (concurrent rendering, Suspense retries),
+		// and `new RestClient()` immediately starts polling the notifications
+		// REST API. Creating the client in the constructor therefore fired a
+		// request on every discarded render attempt and flooded the endpoint.
+		// componentDidMount runs exactly once per mount.
+		isReady: false,
+	};
 
+	componentDidMount() {
 		const { customEnhancer, actionHandlers, isShowing, isVisible, receiveMessage, wpcom } =
 			this.props;
 
@@ -105,10 +114,13 @@ export class Notifications extends PureComponent {
 		store.dispatch( { type: SET_IS_SHOWING, isShowing } );
 
 		client.setVisibility( { isShowing, isVisible } );
-	}
 
-	componentDidMount() {
 		store.dispatch( { type: 'APP_IS_READY' } );
+
+		// The client is intentionally created here, in the commit phase; render
+		// one more time now that it exists so the panel can mount with it.
+		// eslint-disable-next-line react/no-did-mount-set-state
+		this.setState( { isReady: true } );
 	}
 
 	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
@@ -136,7 +148,7 @@ export class Notifications extends PureComponent {
 		}
 
 		if ( isShowing !== this.props.isShowing || isVisible !== this.props.isVisible ) {
-			client.setVisibility( { isShowing, isVisible } );
+			client?.setVisibility( { isShowing, isVisible } );
 		}
 	}
 
@@ -147,6 +159,13 @@ export class Notifications extends PureComponent {
 	}
 
 	render() {
+		// Nothing to render until componentDidMount has created the client and
+		// initialized the store. This also keeps the constructor/render phase
+		// free of the side effects that previously ran on every render attempt.
+		if ( ! this.state.isReady ) {
+			return null;
+		}
+
 		return (
 			<Provider store={ store }>
 				<RestClientContext.Provider value={ client }>


### PR DESCRIPTION
Part of DOTCOM-17385

## Proposed Changes

* Create the notifications REST client and initialize its store in `componentDidMount` instead of the constructor, and render nothing until it is ready.

## Why are these changes being made?

* The panel created its REST client in the constructor, and the client starts polling/calls the notifications REST API as soon as it is constructed. React runs the constructor/render phase many times before it commits a mount (concurrent rendering, Suspense retries), so a brand-new client and a fresh request fired on every discarded render attempt — flooding the notifications endpoint (the OK-response stat climbed from ~220k to ~6M per 20 minutes on /home and /plans). `componentDidMount` runs exactly once per committed mount, so the client and its requests are created a single time.

## Testing Instructions

* In DevTools run `localStorage.setItem( 'debug', 'notifications:rest-client' )` and reload `/home` or `/plans`.
* Confirm the REST client initializes once and polls on its normal interval — one `getNotes`, then quiet — instead of a continuous burst.
* Open the notifications panel and confirm it still loads notes.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
