### PR TITLE
Domains: show Email Setup for connected domains on DNS page

### DIFF
--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -1,3 +1,4 @@
+import { DomainSubtype } from '@automattic/api-core';
 import {
 	domainQuery,
 	domainDnsMutation,
@@ -366,7 +367,8 @@ export default function DomainDns() {
 					</DataViews>
 				) }
 			</DataViewsCard>
-			{ domain.has_wpcom_nameservers && <EmailSetup /> }
+			{ ( domain.has_wpcom_nameservers ||
+				domain.subtype.id === DomainSubtype.DOMAIN_CONNECTION ) && <EmailSetup /> }
 			<RestoreDefaultARecords
 				onConfirm={ handleRestoreDefaultARecords }
 				onCancel={ () => setIsRestoreDefaultARecordsDialogOpen( false ) }

--- a/client/my-sites/domains/domain-management/dns/dns-records.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records.jsx
@@ -394,7 +394,7 @@ class DnsRecords extends Component {
 							selectedDomain={ selectedDomain }
 							selectedDomainName={ selectedDomainName }
 						/>
-						{ this.hasWpcomNameservers() && (
+						{ ( this.hasWpcomNameservers() || selectedDomain?.connectionMode ) && (
 							<EmailSetup selectedDomainName={ selectedDomainName } />
 						) }
 					</>


### PR DESCRIPTION
Part of DOTCOM-16138

## Proposed Changes

- Show the Email Setup section (Google Workspace, iCloud, Office 365, Zoho) on the DNS management page for connected domains (domain connections with external nameservers)
- Applies to both the classic Calypso DNS page (`client/my-sites/domains/domain-management/dns/dns-records.jsx`) and the new Dashboard DNS page (`client/dashboard/domains/domain-dns/index.tsx`)

## Why are these changes being made?

The Email Setup section was gated exclusively on `hasWpcomNameservers()` / `domain.has_wpcom_nameservers`. Connected domains use external nameservers, so this check returned false and the section was hidden — even though connected domains can fully manage DNS records through WordPress.com and need email provider setup options just as much as any other domain type.

The fix broadens the condition to also show Email Setup when the domain is a connection (`connectionMode` is set in the classic view; `subtype.id === DomainSubtype.DOMAIN_CONNECTION` in the Dashboard). Registered domains with nameservers pointed to an external host remain unaffected — the section stays hidden for those, since the DNS records managed here wouldn't be in effect.

## Testing Instructions

1. Add a Domain Connection to any site (external nameservers)
2. Navigate to **Upgrades → Domains → [domain] → DNS Records**
3. **Before:** the Email Setup section (Google Workspace, iCloud, Office 365, Zoho tabs) is absent
4. **After:** the Email Setup section appears below the DNS records list

Also verify that the section remains hidden for a registered domain whose nameservers are pointed to an external host.

### Before
<img width="1430" height="898" alt="before" src="https://github.com/user-attachments/assets/8b5830c5-0ccc-48cc-aac3-a5e8b24ff480" />

### After
<img width="1399" height="866" alt="after" src="https://github.com/user-attachments/assets/25c159d2-d80c-4044-98b9-35174d5f8401" />

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?