### PR TITLE
Agents Manager: show recommended guides in Support Guides

### DIFF
--- a/packages/agents-manager/src/components/__tests__/chat-header.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/chat-header.test.tsx
@@ -73,10 +73,10 @@ function installAdminBarTrigger() {
 	document.body.appendChild( el );
 }
 
-function renderChatHeader() {
+function renderChatHeader( title?: string ) {
 	return render(
 		<MemoryRouter>
-			<ChatHeader onClose={ jest.fn() } options={ [] } />
+			<ChatHeader onClose={ jest.fn() } options={ [] } title={ title } />
 		</MemoryRouter>
 	);
 }
@@ -87,6 +87,19 @@ describe( 'ChatHeader', () => {
 		mockIsDocked = false;
 		mockSetIsMinimized.mockClear();
 		document.getElementById( 'wp-admin-bar-agents-manager' )?.remove();
+	} );
+
+	it( 'renders the title with a matching title attribute so the full text shows on hover when truncated', () => {
+		const title = 'A very long support guides title';
+		renderChatHeader( title );
+
+		expect( screen.getByText( title ) ).toHaveAttribute( 'title', title );
+	} );
+
+	it( 'does not render the title element when no title is provided', () => {
+		const { container } = renderChatHeader();
+
+		expect( container.querySelector( '.agents-manager-chat-header__title' ) ).toBeNull();
 	} );
 
 	it( 'shows the history button by default', () => {

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -106,6 +106,7 @@ export default function AgentDock( {
 
 	// `agentConfig` is guaranteed non-null here because AgentSetup guards rendering
 	const agentId = agentConfig!.agentId;
+
 	// Reader-chat runs on public blog frontends where there's no wp-admin
 	// sidebar to dock into. Detect that context so we can hide options that
 	// don't apply and avoid persisting open/close state through the logged-in
@@ -115,10 +116,12 @@ export default function AgentDock( {
 		! isReaderChat && isJetpackAiSidebarPreviewFeatureEnabled( 'chatHistory' );
 	const showSupportGuides =
 		! isReaderChat && isJetpackAiSidebarPreviewFeatureEnabled( 'supportGuides' );
+
 	// Woo AI sites (sectionName 'wooai-admin') don't have HVM tagging yet,
 	// so Zendesk escalation is disabled until routing is in place.
 	const isWooAiAdmin = sectionName === 'wooai-admin';
 	const shouldShowUnifiedSupport = shouldUseUnifiedAgent && ! isReaderChat && ! isWooAiAdmin;
+
 	const setOpenState = useCallback(
 		( isOpen: boolean ) => setIsOpen( isOpen, ! isReaderChat ),
 		[ isReaderChat, setIsOpen ]
@@ -166,7 +169,8 @@ export default function AgentDock( {
 		setDesktopMediaQuery,
 	} );
 
-	useReaderChatPersistence( agentId );
+	// Persist the reader-chat open state across page loads (no-op for other agents).
+	useReaderChatPersistence();
 
 	const handleAbort = useCallback( () => {
 		const agentManager = getAgentManager();

--- a/packages/agents-manager/src/components/chat-header/index.tsx
+++ b/packages/agents-manager/src/components/chat-header/index.tsx
@@ -49,7 +49,12 @@ export default function ChatHeader( { onClose, options, title, onBack }: Props )
 					<Icon icon={ chevronLeft } />
 				</Button>
 			) }
-			{ title && <div className="agents-manager-chat-header__title">{ title }</div> }
+			{ title && (
+				// Show the full title on hover when it's truncated.
+				<div className="agents-manager-chat-header__title" title={ title }>
+					{ title }
+				</div>
+			) }
 			<div className="agents-manager-chat-header__actions">
 				<DropdownMenu
 					className="agents-manager-chat-header__more-options"

--- a/packages/agents-manager/src/components/chat-header/style.scss
+++ b/packages/agents-manager/src/components/chat-header/style.scss
@@ -27,6 +27,12 @@
 		font-weight: 600;
 		color: var( --color-foreground );
 		flex-grow: 1;
+		// Truncate long titles with an ellipsis.
+		// `min-width: 0` lets the flex item shrink so the ellipsis can show.
+		min-width: 0;
+		overflow: hidden;
+		white-space: nowrap;
+		text-overflow: ellipsis;
 	}
 
 	&__actions {

--- a/packages/agents-manager/src/components/support-guides/index.tsx
+++ b/packages/agents-manager/src/components/support-guides/index.tsx
@@ -24,15 +24,9 @@ interface SearchResultsProps {
 
 function SearchResults( { searchInput }: SearchResultsProps ) {
 	const trimmedInput = searchInput.trim();
+	// An empty input returns recommended guides from the API.
+	const isRecommended = ! trimmedInput;
 	const { data, isFetching, isError, refetch } = useHelpSearchQuery( trimmedInput );
-
-	if ( ! trimmedInput ) {
-		return (
-			<div className="agent-manager-support-guides__status">
-				{ __( 'Search guides to find answers to your questions.', '__i18n_text_domain__' ) }
-			</div>
-		);
-	}
 
 	if ( isFetching ) {
 		return (
@@ -43,6 +37,15 @@ function SearchResults( { searchInput }: SearchResultsProps ) {
 	}
 
 	if ( isError ) {
+		// If recommended guides fail to load, show the search prompt instead of an error.
+		if ( isRecommended ) {
+			return (
+				<div className="agent-manager-support-guides__status">
+					{ __( 'Search guides to find answers to your questions.', '__i18n_text_domain__' ) }
+				</div>
+			);
+		}
+
 		return (
 			<div className="agent-manager-support-guides__status">
 				{ __( 'Something went wrong.', '__i18n_text_domain__' ) }{ ' ' }
@@ -66,18 +69,25 @@ function SearchResults( { searchInput }: SearchResultsProps ) {
 	}
 
 	return (
-		<ItemGroup isSeparated isBordered isRounded>
-			{ data?.map( ( item ) => (
-				<Item key={ item.post_id }>
-					<Link
-						to={ `/post?link=${ encodeURIComponent( item.link ) }` }
-						state={ { searchQuery: trimmedInput } }
-					>
-						{ item.title }
-					</Link>
-				</Item>
-			) ) }
-		</ItemGroup>
+		<>
+			<h3 className="agent-manager-support-guides__title">
+				{ isRecommended
+					? __( 'Recommended Guides', '__i18n_text_domain__' )
+					: __( 'Search Results', '__i18n_text_domain__' ) }
+			</h3>
+			<ItemGroup isSeparated isBordered isRounded>
+				{ data?.map( ( item ) => (
+					<Item key={ item.post_id }>
+						<Link
+							to={ `/post?link=${ encodeURIComponent( item.link ) }` }
+							state={ { searchQuery: trimmedInput } }
+						>
+							{ item.title }
+						</Link>
+					</Item>
+				) ) }
+			</ItemGroup>
+		</>
 	);
 }
 
@@ -142,6 +152,7 @@ export default function SupportGuides( {
 					justify="stretch"
 				>
 					<SearchControl
+						placeholder={ __( 'Search guides…', '__i18n_text_domain__' ) }
 						onChange={ setSearchInput }
 						// The click event is highjacked by the drag-handlers of the floating chat container.
 						onClick={ ( e ) => e.currentTarget.focus() }

--- a/packages/agents-manager/src/components/support-guides/index.tsx
+++ b/packages/agents-manager/src/components/support-guides/index.tsx
@@ -77,7 +77,8 @@ function SearchResults( { searchInput }: SearchResultsProps ) {
 			</h3>
 			<ItemGroup isSeparated isBordered isRounded>
 				{ data?.map( ( item ) => (
-					<Item key={ item.post_id }>
+					// `post_id` is optional, so fall back to keep keys unique and defined.
+					<Item key={ item.post_id ?? item.link ?? item.title }>
 						<Link
 							to={ `/post?link=${ encodeURIComponent( item.link ) }` }
 							state={ { searchQuery: trimmedInput } }

--- a/packages/agents-manager/src/components/support-guides/style.scss
+++ b/packages/agents-manager/src/components/support-guides/style.scss
@@ -5,6 +5,13 @@
 	height: calc( 100% - 32px );
 	padding: 16px;
 
+	.agent-manager-support-guides__title {
+		margin: 0;
+		font-size: $font-size-small;
+		font-weight: 600;
+		color: var( --color-foreground );
+	}
+
 	.agent-manager-support-guides__status {
 		text-align: center;
 		font-size: $font-size-small;
@@ -17,6 +24,9 @@
 	}
 
 	.components-search-control {
+		// Add space below the search bar, on top of the `VStack` gap.
+		margin-bottom: 8px;
+
 		.components-input-control__container {
 			background-color: var( --color-muted );
 
@@ -53,7 +63,8 @@
 	.components-item-group {
 		border-radius: 16px;
 		border-color: var( --color-muted );
-		max-height: 85%;
+		// Cap the list height so long lists scroll instead of growing the panel.
+		max-height: 80%;
 		overflow-y: auto;
 
 		div[role='listitem'] {

--- a/packages/agents-manager/src/hooks/use-help-search-query.ts
+++ b/packages/agents-manager/src/hooks/use-help-search-query.ts
@@ -75,7 +75,9 @@ export default function useHelpSearchQuery(
 		queryKey: [ 'agents-manager-help-search', search, locale, sectionName ],
 		queryFn: () => fetchArticlesAPI( search, locale, sectionName ),
 		refetchOnWindowFocus: false,
-		enabled: !! search,
+		// Help content changes rarely, so cache results for 5 minutes
+		// instead of refetching on remount.
+		staleTime: 5 * 60 * 1000,
 		...queryOptions,
 	} );
 }

--- a/packages/agents-manager/src/hooks/use-reader-chat-persistence.ts
+++ b/packages/agents-manager/src/hooks/use-reader-chat-persistence.ts
@@ -1,5 +1,6 @@
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
+import { useAgentsManagerContext } from '../contexts';
 import { AGENTS_MANAGER_STORE } from '../stores';
 import { isReaderChatAgent } from '../utils/is-reader-chat-agent';
 import type { AgentsManagerSelect } from '@automattic/data-stores';
@@ -12,9 +13,13 @@ import type { AgentsManagerSelect } from '@automattic/data-stores';
  * flag in `localStorage`: restore it on first mount and write it on every
  * toggle. No-op for other agents, whose state is server-backed.
  */
-export default function useReaderChatPersistence( agentId: string ): void {
+export default function useReaderChatPersistence(): void {
+	const { agentConfig } = useAgentsManagerContext();
+	const { agentId } = agentConfig!;
+
 	const isReaderChat = isReaderChatAgent( agentId );
 	const storageKey = `jetpack-reader-chat-open-${ agentId }`;
+
 	const { setIsOpen } = useDispatch( AGENTS_MANAGER_STORE );
 	const isOpen = useSelect(
 		( select ) => ( select( AGENTS_MANAGER_STORE ) as AgentsManagerSelect ).getIsOpen(),
@@ -26,6 +31,7 @@ export default function useReaderChatPersistence( agentId: string ): void {
 		if ( ! isReaderChat ) {
 			return;
 		}
+
 		try {
 			if ( localStorage.getItem( storageKey ) === '1' && ! isOpen ) {
 				setIsOpen( true, false );
@@ -41,6 +47,7 @@ export default function useReaderChatPersistence( agentId: string ): void {
 		if ( ! isReaderChat ) {
 			return;
 		}
+
 		try {
 			if ( isOpen ) {
 				localStorage.setItem( storageKey, '1' );

--- a/packages/agents-manager/src/hooks/use-reader-chat-persistence.ts
+++ b/packages/agents-manager/src/hooks/use-reader-chat-persistence.ts
@@ -15,7 +15,8 @@ import type { AgentsManagerSelect } from '@automattic/data-stores';
  */
 export default function useReaderChatPersistence(): void {
 	const { agentConfig } = useAgentsManagerContext();
-	const { agentId } = agentConfig!;
+	// No-op until the agent config is ready; `isReaderChatAgent( '' )` is false.
+	const agentId = agentConfig?.agentId ?? '';
 
 	const isReaderChat = isReaderChatAgent( agentId );
 	const storageKey = `jetpack-reader-chat-open-${ agentId }`;


### PR DESCRIPTION
Part of AI-991

## Proposed Changes

**Main change — Recommended guides (AI-991):**
- The Support Guides panel now shows **recommended guides** when the search input is empty, replacing the previous static prompt ("Search guides to find answers to your questions."). An empty query is sent to the help search API, which returns recommended articles.
- Added a section title: **"Recommended Guides"** for the empty/recommended case and **"Search Results"** for an actual search. The title is shown only when there are results (hidden for loading, empty, and error states).
- The old prompt text now appears only as a fallback when the recommended fetch fails.

**Extra improvements (bundled):**
- Added a placeholder to the search bar ("Search guides…").
- Cache help search results for 5 minutes (`staleTime`) so repeat searches and the recommended set aren't refetched on every remount.
- Truncate long chat header titles with an ellipsis, and expose the full title on hover via the `title` attribute.
- Refactored `useReaderChatPersistence` to read `agentId` from context instead of a prop, matching the convention used by the other context-aware hooks in the package.
- Minor Support Guides spacing/layout tweaks (title style, search-bar gap, list `max-height`).

## Why are these changes being made?

The empty state of Support Guides was a dead-end static message. Surfacing recommended guides gives users immediately useful content before they type anything, consistent with how the Help Center presents recommended guides.

## Testing Instructions

- Sandbox this PR
- Enable the unified AI experience
- Go to: `https://<YOUR_SITE>/wp-admin`
- Open the "Support guides" view from the WP admin bar > dropdown menu
- You will see the recommended guides:
  - The same search results will be cached for 5 minutes now 

<img width="373" height="522" alt="截圖 2026-06-03 下午6 12 56" src="https://github.com/user-attachments/assets/fb1d282f-6df5-4f14-a88c-df870e6ec820" />

> Note: The view is disabled by a Jetpack flag; you can remove the flag to test it.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
