### PR TITLE
Stepper: Re-launch account-step round 2 experiment (202606_v2)

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/index.tsx
@@ -60,7 +60,7 @@ const UserStepComponent: StepType = function UserStep( {
 	const { topBarLogo, partnerConfig, signupTosElement } = usePartnerBranding();
 
 	// Woo-referrer users keep the permanent email-first + slider treatment from PR #110118.
-	// Everyone else is bucketed by calypso_account_step_improvement_202605_v2 (round 2):
+	// Everyone else is bucketed by calypso_account_step_improvement_202606_v2 (round 2):
 	//   - control                            -> default single-column signup
 	//   - treatment_email_slider_webp        -> open email + slider, email on top
 	//   - treatment_email_bottom_slider_webp -> open email + slider, email below social

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-account-creation-experiment.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-account-creation-experiment.ts
@@ -36,7 +36,7 @@ function useAccountCreationExperiment( {
 	// Excluded from the experiment:
 	//   - Woo-referrer users (permanent treatment from PR #110118 — preserve their UX).
 	//   - Sub-960 px viewports — mobile-web signup is owned by a separate team.
-	const [ isLoading, assignment ] = useExperiment( 'calypso_account_step_improvement_202605_v2', {
+	const [ isLoading, assignment ] = useExperiment( 'calypso_account_step_improvement_202606_v2', {
 		isEligible: isOnboardingFlow( flow ) && ! isWooReferrer && isLargeViewport,
 	} );
 


### PR DESCRIPTION
## What
Bumps the account-step improvement (round 2) experiment slug from `calypso_account_step_improvement_202605_v2` → `calypso_account_step_improvement_202606_v2` in the assignment hook (and its comment).

Follow-up to #110757.

## Why
The `…202605_v2` entry was set to User Type *"newly signed up users (logged in)"*. Assignment on `/setup/onboarding/user` happens **before** login, when visitors are anonymous, so almost no one matched the audience (~5 participants). The experiment was re-created with User Type *"all users (new + existing + anonymous)"*. ExPlat can't change audience on a launched experiment, so it's a fresh entry with a new slug — and the code constant must match it exactly or every user falls back to control.

## How to test
On desktop (≥960 px) `/setup/onboarding/user`, force-assign each variant via the experiment's bookmarklets:
- `control` → single-column signup
- `treatment_email_slider_webp` → open email + slider, email on top
- `treatment_email_bottom_slider_webp` → open email + slider, email below social

Sub-960 px viewports and `ref=woo-hosting-solutions-flow` are excluded (unchanged).