### PR TITLE
A4A Agent Studio: clean up deliverable cards (titles, clickable, placeholder)

### DIFF
--- a/client/a8c-for-agencies/sections/agent-studio/data/use-deliverable-title.ts
+++ b/client/a8c-for-agencies/sections/agent-studio/data/use-deliverable-title.ts
@@ -1,0 +1,30 @@
+/**
+ * Resolves the human title for a deliverable card.
+ *
+ * The outputs endpoint returns a machine-generated run title
+ * (`Recipe run — <recipe>`). The heading the user actually typed in the
+ * brief lives in the run's `input_snapshot` (`title` for one-pagers,
+ * `headline` for social) and is present even while the run is still
+ * generating, so we fetch the run and prefer it.
+ */
+import useAgentStudioRun, { type AgentStudioRunResponse } from './use-agent-studio-run';
+import type { AgentStudioOutput } from '../types';
+
+const SOCIAL_DELIVERABLE_TYPE = 'social-assets';
+
+const readString = ( value: unknown ): string | undefined =>
+	typeof value === 'string' && value.trim() ? value.trim() : undefined;
+
+export function resolveDeliverableTitle(
+	output: AgentStudioOutput,
+	run?: AgentStudioRunResponse
+): string {
+	const snapshot = run?.input_snapshot;
+	const snapshotKey = output.deliverableType === SOCIAL_DELIVERABLE_TYPE ? 'headline' : 'title';
+	return readString( snapshot?.[ snapshotKey ] ) ?? output.title;
+}
+
+export default function useDeliverableTitle( output: AgentStudioOutput ): string {
+	const run = useAgentStudioRun( output.id );
+	return resolveDeliverableTitle( output, run.data );
+}

--- a/client/a8c-for-agencies/sections/agent-studio/primary/overview/deliverable-card.tsx
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/overview/deliverable-card.tsx
@@ -1,5 +1,4 @@
 import {
-	Button,
 	Card,
 	CardBody,
 	CardMedia,
@@ -12,7 +11,9 @@ import {
 import { dateI18n } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
 import { Icon, moreVertical, page, trash, cautionFilled as warning } from '@wordpress/icons';
+import clsx from 'clsx';
 import { useState } from 'react';
+import useDeliverableTitle from '../../data/use-deliverable-title';
 import { getAgentStudioOutputPath } from '../../lib/paths';
 import DeleteDeliverableDialog from './delete-deliverable-dialog';
 import type { AgentStudioOutput } from '../../types';
@@ -25,39 +26,50 @@ interface Props {
 
 export default function DeliverableCard( { output }: Props ) {
 	const [ isDeleteDialogOpen, setIsDeleteDialogOpen ] = useState( false );
+	const title = useDeliverableTitle( output );
+	const isReady = output.status === 'ready';
 
 	return (
-		<Card size="small" className="a4a-agent-studio-deliverable-card">
+		<Card
+			size="small"
+			className={ clsx( 'a4a-agent-studio-deliverable-card', { 'is-clickable': isReady } ) }
+		>
 			<CardMedia className="a4a-agent-studio-deliverable-card__media">
 				<DeliverablePreview output={ output } />
 			</CardMedia>
 			<CardBody className="a4a-agent-studio-deliverable-card__body">
-				<VStack spacing={ 1 } className="a4a-agent-studio-deliverable-card__info">
-					<Text size={ 15 } weight={ 600 } className="a4a-agent-studio-deliverable-card__title">
-						{ output.title }
-					</Text>
-					<Text variant="muted">{ dateI18n( 'F j, Y', output.createdAt ) }</Text>
-					<Text variant="muted">{ getMetaLabel( output ) }</Text>
-				</VStack>
-				<HStack justify="space-between" alignment="center">
-					{ output.status === 'ready' && (
-						<Button variant="secondary" href={ getAgentStudioOutputPath( output.id ) }>
-							{ __( 'View' ) }
-						</Button>
-					) }
-					<DropdownMenu
-						icon={ moreVertical }
-						label={ __( 'Deliverable actions' ) }
-						controls={ [
-							{
-								title: __( 'Delete' ),
-								icon: trash,
-								onClick: () => setIsDeleteDialogOpen( true ),
-							},
-						] }
-					/>
+				<HStack justify="space-between" alignment="flex-start" spacing={ 2 }>
+					<VStack spacing={ 1 } className="a4a-agent-studio-deliverable-card__info">
+						<Text size={ 15 } weight={ 600 } className="a4a-agent-studio-deliverable-card__title">
+							{ title }
+						</Text>
+						<Text variant="muted">{ dateI18n( 'F j, Y', output.createdAt ) }</Text>
+					</VStack>
+					{ /* Sits above the card-wide link overlay so its clicks aren't swallowed. */ }
+					<div className="a4a-agent-studio-deliverable-card__menu">
+						<DropdownMenu
+							icon={ moreVertical }
+							label={ __( 'Deliverable actions' ) }
+							controls={ [
+								{
+									title: __( 'Delete' ),
+									icon: trash,
+									onClick: () => setIsDeleteDialogOpen( true ),
+								},
+							] }
+						/>
+					</div>
 				</HStack>
 			</CardBody>
+			{ /* Stretched link makes the whole card open the deliverable without
+			     nesting interactive elements inside one another. */ }
+			{ isReady && (
+				<a
+					className="a4a-agent-studio-deliverable-card__link"
+					href={ getAgentStudioOutputPath( output.id ) }
+					aria-label={ title }
+				/>
+			) }
 			{ isDeleteDialogOpen && (
 				<DeleteDeliverableDialog
 					output={ output }
@@ -88,45 +100,9 @@ function DeliverablePreview( { output }: Props ) {
 		);
 	}
 
-	// Server-rendered preview URLs land directly on the output once the
-	// wpcom side pre-renders thumbnails. Until then social-campaign
-	// outputs show the placeholder icon — the deliverable detail page
-	// still composes the tiles live from the brief.
-	if ( output.previewUrls?.length ) {
-		return <PreviewUrlCollage urls={ output.previewUrls } />;
-	}
-
 	return (
 		<div className="a4a-agent-studio-deliverable-card__placeholder">
 			<Icon icon={ page } size={ 32 } />
 		</div>
 	);
-}
-
-function PreviewUrlCollage( { urls }: { urls: string[] } ) {
-	return (
-		<div className="a4a-agent-studio-deliverable-card__collage">
-			{ urls.slice( 0, 4 ).map( ( url ) => (
-				<div
-					key={ url }
-					className="a4a-agent-studio-deliverable-card__collage-tile"
-					style={ { aspectRatio: '1 / 1' } }
-				>
-					<img src={ url } alt="" />
-				</div>
-			) ) }
-		</div>
-	);
-}
-
-function getMetaLabel( output: AgentStudioOutput ) {
-	if ( output.status === 'generating' ) {
-		return __( 'Generating…' );
-	}
-
-	if ( output.status === 'failed' ) {
-		return __( 'Generation failed' );
-	}
-
-	return output.deliverableType;
 }

--- a/client/a8c-for-agencies/sections/agent-studio/primary/overview/style.scss
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/overview/style.scss
@@ -17,29 +17,57 @@
 }
 
 .a4a-agent-studio-deliverable-card.components-card {
+	position: relative;
 	display: flex;
 	flex-direction: column;
 	height: 100%;
+	min-width: 0;
+	overflow: hidden;
+}
+
+.a4a-agent-studio-deliverable-card.is-clickable {
+	cursor: pointer;
+	transition: box-shadow 120ms ease;
+}
+
+.a4a-agent-studio-deliverable-card.is-clickable:hover,
+.a4a-agent-studio-deliverable-card.is-clickable:focus-within {
+	box-shadow: 0 4px 16px rgba( 0, 0, 0, 0.12 );
+}
+
+// Card-wide link overlay — covers the card so a click anywhere opens the
+// deliverable.
+.a4a-agent-studio-deliverable-card__link {
+	position: absolute;
+	inset: 0;
+	z-index: 1;
+}
+
+// Lift the actions menu above the link overlay so its button stays clickable.
+.a4a-agent-studio-deliverable-card__menu {
+	position: relative;
+	z-index: 2;
 }
 
 .a4a-agent-studio-deliverable-card__media.components-card__media {
 	display: flex;
 	align-items: center;
+	min-width: 0;
 	min-height: 160px;
+	overflow: hidden;
 	background: var( --color-neutral-80 );
 }
 
-// Stretch the body to fill the (equal-height) card and keep the delete
-// action pinned to the bottom, so the buttons line up across the row.
 .a4a-agent-studio-deliverable-card__body.components-card__body {
 	display: flex;
-	flex: 1;
 	flex-direction: column;
-	gap: 16px;
 }
 
+// Let the title block take the row's width so the actions menu sits flush
+// against the card's trailing edge.
 .a4a-agent-studio-deliverable-card__info {
 	flex: 1;
+	min-width: 0;
 }
 
 // Clamp long titles to two lines so cards in a row stay the same height.
@@ -49,20 +77,6 @@
 	-webkit-box-orient: vertical;
 	-webkit-line-clamp: 2;
 	line-clamp: 2;
-}
-
-.a4a-agent-studio-deliverable-card__strip {
-	display: flex;
-	gap: 8px;
-	padding: 16px;
-	overflow: hidden;
-}
-
-.a4a-agent-studio-deliverable-card__strip img {
-	flex-shrink: 0;
-	height: 128px;
-	width: auto;
-	border-radius: 4px;
 }
 
 .a4a-agent-studio-deliverable-card__state {
@@ -88,40 +102,4 @@
 .a4a-agent-studio-deliverable-card__placeholder svg,
 .a4a-agent-studio-deliverable-card__placeholder svg path {
 	fill: currentColor;
-}
-
-.a4a-agent-studio-deliverable-card__collage {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	gap: 3%;
-	box-sizing: border-box;
-	width: 100%;
-	min-height: 160px;
-	padding: 6%;
-	background: var( --color-neutral-90 );
-	aspect-ratio: 1200 / 630;
-	overflow: hidden;
-}
-
-.a4a-agent-studio-deliverable-card__collage-tile {
-	display: block;
-	flex-shrink: 0;
-	height: 100%;
-	overflow: hidden;
-	border-radius: 2px;
-	background: var( --color-surface );
-	box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.25 ), 0 10px 24px -8px rgba( 0, 0, 0, 0.45 );
-}
-
-.a4a-agent-studio-deliverable-card__collage-tile img {
-	display: block;
-	width: 100%;
-	height: 100%;
-	object-fit: cover;
-}
-
-.a4a-agent-studio-deliverable-card__collage-tile > div {
-	width: 100%;
-	height: 100%;
 }


### PR DESCRIPTION
Part of #

## Proposed Changes

The Agent Studio deliverables overview (`/resources-and-tools/agent-studio`) lists each generated deliverable as a card. Each card showed a generic page icon as its preview, the title `Recipe run — compose-one-pager-ela-v2` (the server-side run title), a `one-pager` / `social-assets` meta label, and a separate **View** button.

This PR cleans up the card:

* **Real titles.** The title now comes from the heading the user typed in the brief (`run.input_snapshot.title` for one-pagers, `.headline` for social), falling back to the run title. This replaces the `Recipe run — <recipe>` string. A small `useDeliverableTitle` hook fetches the run and resolves it.
* **Dropped the run-type label** (`one-pager` / `social-assets`), which added no value.
* **Whole card is clickable.** A stretched-link overlay opens the deliverable from anywhere on the card; the **View** button is removed and the three-dots actions menu (Delete) moves up next to the title, layered above the overlay so its clicks aren't swallowed.
* **Preview stays a generic placeholder** for now. A richer per-deliverable thumbnail is deferred to a follow-up.

## Why are these changes being made?

The cards gave little useful information: the machine-generated `Recipe run — compose-one-pager-ela-v2` title carried no meaning to the user, and the run type plus the standalone View button added clutter. Showing the user's own heading makes the grid scannable, and making the whole card clickable is the expected interaction for a gallery of items.

An earlier iteration of this PR rendered real previews from each deliverable's HTML; that turned out more complex than warranted for this pass, so the preview is left as a placeholder and a better thumbnail will be explored separately.

## Testing Instructions

Prerequisites: a local A4A dev instance running (`yarn start-a8c-for-agencies`), signed into an agency that has generated some Agent Studio deliverables.

1. Go to `/resources-and-tools/agent-studio`.
2. Confirm each card shows its title as the heading entered in the brief, not `Recipe run — …`, with no `one-pager` / `social-assets` label — only the title and date.
3. Confirm the preview area shows a generic placeholder (no per-deliverable rendering).
4. Click anywhere on a ready card (not the menu) and confirm it opens that deliverable's detail page.
5. Click the three-dots menu and confirm it opens (with Delete) without navigating.
6. Confirm generating / failed deliverables still show their respective states in the preview area.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)? <!-- A4A-only surface; verified in the A4A dev environment. -->
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2). <!-- Card link uses a real anchor with an aria-label; the actions menu remains a separate, focusable control. -->
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?