### PR TITLE
Suppress stale Big Sky sidebar in Jetpack AI post editor

### DIFF
--- a/packages/agents-manager/src/components/agents-manager.tsx
+++ b/packages/agents-manager/src/components/agents-manager.tsx
@@ -20,6 +20,7 @@ import {
 	type ImageUploadHook,
 	type LoadedProviders,
 } from '../utils/load-external-providers';
+import { startSuppressingStaleBigSkySidebar } from '../utils/suppress-stale-big-sky-sidebar';
 import AgentDock from './agent-dock';
 import { PersistentRouter } from './persistent-router';
 
@@ -98,6 +99,8 @@ function AgentSetup( {
 	// Read agent/version overrides from browser URL (?agent=, ?version=).
 	// PersistentRouter (memory router) does not track window.location.search.
 	const { agentId, version, isLoading: isAgentConfigLoading } = useAgentConfig( hostAgentId );
+
+	useEffect( () => startSuppressingStaleBigSkySidebar(), [] );
 
 	// Restore the session ID. Priority:
 	//   1. Router state (calypso navigation carries sessionId on resume).

--- a/packages/agents-manager/src/global.d.ts
+++ b/packages/agents-manager/src/global.d.ts
@@ -14,6 +14,9 @@ declare const agentsManagerData:
 			agentProviders?: ( string | import('./utils/load-external-providers').LoadedProviders )[];
 			useUnifiedExperience?: boolean;
 			agentId?: string;
+			sectionName?: string;
+			aiEditorialReviewEnabled?: boolean;
+			reviewMediatorEnabled?: boolean;
 			helpCenterUrl?: string;
 			jetpackAiSidebarPreview?: {
 				enabled: boolean;

--- a/packages/agents-manager/src/utils/__tests__/suppress-stale-big-sky-sidebar.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/suppress-stale-big-sky-sidebar.test.ts
@@ -144,6 +144,13 @@ describe( 'suppressStaleBigSkySidebar', () => {
 		expect( shouldSuppressStaleBigSkySidebar() ).toBe( true );
 	} );
 
+	it( 'falls back to post editor body classes when the editor store returns null', () => {
+		mockSelect.mockReturnValue( { getCurrentPostType: () => null } );
+		document.body.className = 'post-type-post post-php block-editor-page';
+
+		expect( shouldSuppressStaleBigSkySidebar() ).toBe( true );
+	} );
+
 	it( 'does not suppress when Jetpack AI Sidebar preview is disabled', () => {
 		installAgentsManagerData( {
 			sectionName: 'gutenberg',

--- a/packages/agents-manager/src/utils/__tests__/suppress-stale-big-sky-sidebar.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/suppress-stale-big-sky-sidebar.test.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import {
+	clearStaleBigSkySidebarSuppression,
 	shouldSuppressStaleBigSkySidebar,
 	suppressStaleBigSkySidebar,
 } from '../suppress-stale-big-sky-sidebar';
@@ -18,6 +19,7 @@ function installAgentsManagerData( data: unknown ) {
 
 describe( 'suppressStaleBigSkySidebar', () => {
 	beforeEach( () => {
+		jest.useRealTimers();
 		document.documentElement.className = '';
 		document.body.className = '';
 		document.head.innerHTML = '';
@@ -34,6 +36,7 @@ describe( 'suppressStaleBigSkySidebar', () => {
 	} );
 
 	afterEach( () => {
+		clearStaleBigSkySidebarSuppression();
 		delete ( globalThis as typeof globalThis & { agentsManagerData?: unknown } ).agentsManagerData;
 	} );
 
@@ -65,6 +68,41 @@ describe( 'suppressStaleBigSkySidebar', () => {
 		);
 	} );
 
+	it( 'restores suppressed Big Sky chrome and layout classes on cleanup', () => {
+		document.body.innerHTML = `
+			<div class="block-editor__container big-sky-sidebar-container big-sky-sidebar-container--sidebar-open">
+				<div class="big-sky-sidebar" aria-hidden="false"></div>
+				<button class="big-sky-sidebar__fab"></button>
+			</div>
+		`;
+
+		expect( suppressStaleBigSkySidebar() ).toBe( true );
+
+		clearStaleBigSkySidebarSuppression();
+
+		expect( document.documentElement.classList ).not.toContain(
+			'agents-manager-suppress-stale-big-sky-sidebar'
+		);
+		expect(
+			document.getElementById( 'agents-manager-suppress-stale-big-sky-sidebar-style' )
+		).toBeNull();
+		expect( document.querySelector( '.big-sky-sidebar' ) ).not.toHaveAttribute( 'hidden' );
+		expect( document.querySelector( '.big-sky-sidebar' ) ).toHaveAttribute(
+			'aria-hidden',
+			'false'
+		);
+		expect( document.querySelector( '.big-sky-sidebar__fab' ) ).not.toHaveAttribute( 'hidden' );
+		expect( document.querySelector( '.big-sky-sidebar__fab' ) ).not.toHaveAttribute(
+			'aria-hidden'
+		);
+		expect( document.querySelector( '.block-editor__container' ) ).toHaveClass(
+			'big-sky-sidebar-container'
+		);
+		expect( document.querySelector( '.block-editor__container' ) ).toHaveClass(
+			'big-sky-sidebar-container--sidebar-open'
+		);
+	} );
+
 	it( 'does not suppress outside the post editor', () => {
 		mockSelect.mockReturnValue( { getCurrentPostType: () => 'page' } );
 		document.body.className = 'post-type-page';
@@ -74,6 +112,36 @@ describe( 'suppressStaleBigSkySidebar', () => {
 		expect( document.documentElement.classList ).not.toContain(
 			'agents-manager-suppress-stale-big-sky-sidebar'
 		);
+	} );
+
+	it( 'does not suppress when the Agents Manager section is missing', () => {
+		installAgentsManagerData( {
+			aiEditorialReviewEnabled: true,
+			jetpackAiSidebarPreview: {
+				enabled: true,
+				features: { aiEditorialReview: true },
+			},
+		} );
+
+		expect( shouldSuppressStaleBigSkySidebar() ).toBe( false );
+	} );
+
+	it( 'does not suppress on non-editor post screens when the editor store is unavailable', () => {
+		mockSelect.mockImplementation( () => {
+			throw new Error( 'store unavailable' );
+		} );
+		document.body.className = 'post-type-post edit-php';
+
+		expect( shouldSuppressStaleBigSkySidebar() ).toBe( false );
+	} );
+
+	it( 'suppresses on post editor body classes when the editor store is unavailable', () => {
+		mockSelect.mockImplementation( () => {
+			throw new Error( 'store unavailable' );
+		} );
+		document.body.className = 'post-type-post post-php block-editor-page';
+
+		expect( shouldSuppressStaleBigSkySidebar() ).toBe( true );
 	} );
 
 	it( 'does not suppress when Jetpack AI Sidebar preview is disabled', () => {

--- a/packages/agents-manager/src/utils/__tests__/suppress-stale-big-sky-sidebar.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/suppress-stale-big-sky-sidebar.test.ts
@@ -1,0 +1,88 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+	shouldSuppressStaleBigSkySidebar,
+	suppressStaleBigSkySidebar,
+} from '../suppress-stale-big-sky-sidebar';
+
+const mockSelect = jest.fn();
+
+jest.mock( '@wordpress/data', () => ( {
+	select: ( ...args: unknown[] ) => mockSelect( ...args ),
+} ) );
+
+function installAgentsManagerData( data: unknown ) {
+	( globalThis as typeof globalThis & { agentsManagerData?: unknown } ).agentsManagerData = data;
+}
+
+describe( 'suppressStaleBigSkySidebar', () => {
+	beforeEach( () => {
+		document.documentElement.className = '';
+		document.body.className = '';
+		document.head.innerHTML = '';
+		document.body.innerHTML = '';
+		mockSelect.mockReturnValue( { getCurrentPostType: () => 'post' } );
+		installAgentsManagerData( {
+			sectionName: 'gutenberg',
+			aiEditorialReviewEnabled: true,
+			jetpackAiSidebarPreview: {
+				enabled: true,
+				features: { aiEditorialReview: true },
+			},
+		} );
+	} );
+
+	afterEach( () => {
+		delete ( globalThis as typeof globalThis & { agentsManagerData?: unknown } ).agentsManagerData;
+	} );
+
+	it( 'suppresses Big Sky chrome in the AER post editor', () => {
+		document.body.innerHTML = `
+			<div class="block-editor__container big-sky-sidebar-container big-sky-sidebar-container--sidebar-open">
+				<div class="big-sky-sidebar"></div>
+				<button class="big-sky-sidebar__fab"></button>
+			</div>
+			<div id="big-sky-wp-admin-agent-root"></div>
+		`;
+
+		expect( suppressStaleBigSkySidebar() ).toBe( true );
+
+		expect( document.documentElement.classList ).toContain(
+			'agents-manager-suppress-stale-big-sky-sidebar'
+		);
+		expect(
+			document.getElementById( 'agents-manager-suppress-stale-big-sky-sidebar-style' )
+		).toBeTruthy();
+		expect( document.querySelector( '.big-sky-sidebar' ) ).toHaveAttribute( 'hidden' );
+		expect( document.querySelector( '.big-sky-sidebar__fab' ) ).toHaveAttribute( 'hidden' );
+		expect( document.getElementById( 'big-sky-wp-admin-agent-root' ) ).toHaveAttribute( 'hidden' );
+		expect( document.querySelector( '.block-editor__container' ) ).not.toHaveClass(
+			'big-sky-sidebar-container'
+		);
+		expect( document.querySelector( '.block-editor__container' ) ).not.toHaveClass(
+			'big-sky-sidebar-container--sidebar-open'
+		);
+	} );
+
+	it( 'does not suppress outside the post editor', () => {
+		mockSelect.mockReturnValue( { getCurrentPostType: () => 'page' } );
+		document.body.className = 'post-type-page';
+
+		expect( shouldSuppressStaleBigSkySidebar() ).toBe( false );
+		expect( suppressStaleBigSkySidebar() ).toBe( false );
+		expect( document.documentElement.classList ).not.toContain(
+			'agents-manager-suppress-stale-big-sky-sidebar'
+		);
+	} );
+
+	it( 'does not suppress when Jetpack AI Sidebar preview is disabled', () => {
+		installAgentsManagerData( {
+			sectionName: 'gutenberg',
+			aiEditorialReviewEnabled: true,
+			jetpackAiSidebarPreview: { enabled: false },
+		} );
+
+		expect( shouldSuppressStaleBigSkySidebar() ).toBe( false );
+	} );
+} );

--- a/packages/agents-manager/src/utils/suppress-stale-big-sky-sidebar.ts
+++ b/packages/agents-manager/src/utils/suppress-stale-big-sky-sidebar.ts
@@ -19,6 +19,16 @@ const BIG_SKY_LAYOUT_CLASSES = [
 	'big-sky-sidebar-container--sidebar-open',
 ];
 
+const RETRY_DELAYS_MS = [ 100, 500, 1500 ];
+
+type SuppressedSurfaceState = {
+	hidden: boolean;
+	ariaHidden: string | null;
+};
+
+const suppressedSurfaces = new Map< HTMLElement, SuppressedSurfaceState >();
+const strippedLayoutClasses = new Map< HTMLElement, Set< string > >();
+
 function getAgentsManagerData() {
 	return typeof agentsManagerData !== 'undefined' ? agentsManagerData : undefined;
 }
@@ -31,13 +41,27 @@ function getCurrentPostType(): string | undefined {
 	}
 }
 
+function isPostEditorScreen(): boolean {
+	const currentPostType = getCurrentPostType();
+	if ( currentPostType !== undefined ) {
+		return currentPostType === 'post';
+	}
+
+	return (
+		document.body.classList.contains( 'post-type-post' ) &&
+		document.body.classList.contains( 'block-editor-page' ) &&
+		( document.body.classList.contains( 'post-php' ) ||
+			document.body.classList.contains( 'post-new-php' ) )
+	);
+}
+
 export function shouldSuppressStaleBigSkySidebar(): boolean {
 	if ( typeof document === 'undefined' ) {
 		return false;
 	}
 
 	const data = getAgentsManagerData();
-	if ( data?.sectionName && data.sectionName !== 'gutenberg' ) {
+	if ( data?.sectionName !== 'gutenberg' ) {
 		return false;
 	}
 
@@ -55,7 +79,7 @@ export function shouldSuppressStaleBigSkySidebar(): boolean {
 		return false;
 	}
 
-	return getCurrentPostType() === 'post' || document.body.classList.contains( 'post-type-post' );
+	return isPostEditorScreen();
 }
 
 function ensureSuppressionStyle(): void {
@@ -71,13 +95,78 @@ function ensureSuppressionStyle(): void {
 			visibility: hidden !important;
 			pointer-events: none !important;
 		}
+
+		.${ SUPPRESSION_CLASS } .block-editor .big-sky-sidebar-container.big-sky-sidebar-container--sidebar-open .edit-post-layout {
+			border-radius: 0 !important;
+			margin: 0 !important;
+			overflow: visible !important;
+			width: 100% !important;
+		}
+
+		.${ SUPPRESSION_CLASS } .block-editor .big-sky-sidebar-container.big-sky-sidebar-container--sidebar-open .admin-ui-navigable-region.interface-interface-skeleton__actions,
+		.${ SUPPRESSION_CLASS } .block-editor .big-sky-sidebar-container.big-sky-sidebar-container--sidebar-open .editor-post-publish-panel,
+		.${ SUPPRESSION_CLASS } .block-editor .big-sky-sidebar-container.big-sky-sidebar-container--sidebar-open .interface-navigable-region.interface-interface-skeleton__actions {
+			border-radius: 0 !important;
+			left: auto !important;
+			margin: 0 !important;
+			overflow: visible !important;
+			right: 0 !important;
+		}
 	`;
 
 	document.head.appendChild( style );
 }
 
+function suppressSurface( el: HTMLElement ): void {
+	if ( ! suppressedSurfaces.has( el ) ) {
+		suppressedSurfaces.set( el, {
+			hidden: el.hidden,
+			ariaHidden: el.getAttribute( 'aria-hidden' ),
+		} );
+	}
+
+	el.hidden = true;
+	el.setAttribute( 'aria-hidden', 'true' );
+}
+
+function stripBigSkyLayoutClasses(): void {
+	for ( const className of BIG_SKY_LAYOUT_CLASSES ) {
+		document.querySelectorAll< HTMLElement >( `.${ className }` ).forEach( ( el ) => {
+			const strippedClasses = strippedLayoutClasses.get( el ) ?? new Set< string >();
+
+			strippedClasses.add( className );
+			strippedLayoutClasses.set( el, strippedClasses );
+			el.classList.remove( className );
+		} );
+	}
+}
+
+export function clearStaleBigSkySidebarSuppression(): void {
+	document.documentElement.classList.remove( SUPPRESSION_CLASS );
+	document.getElementById( SUPPRESSION_STYLE_ID )?.remove();
+
+	for ( const [ el, state ] of suppressedSurfaces ) {
+		el.hidden = state.hidden;
+
+		if ( state.ariaHidden === null ) {
+			el.removeAttribute( 'aria-hidden' );
+		} else {
+			el.setAttribute( 'aria-hidden', state.ariaHidden );
+		}
+	}
+
+	suppressedSurfaces.clear();
+
+	for ( const [ el, classNames ] of strippedLayoutClasses ) {
+		el.classList.add( ...classNames );
+	}
+
+	strippedLayoutClasses.clear();
+}
+
 export function suppressStaleBigSkySidebar(): boolean {
 	if ( ! shouldSuppressStaleBigSkySidebar() ) {
+		clearStaleBigSkySidebarSuppression();
 		return false;
 	}
 
@@ -87,16 +176,8 @@ export function suppressStaleBigSkySidebar(): boolean {
 
 	document
 		.querySelectorAll< HTMLElement >( BIG_SKY_SURFACE_SELECTORS.join( ',' ) )
-		.forEach( ( el ) => {
-			el.hidden = true;
-			el.setAttribute( 'aria-hidden', 'true' );
-		} );
-
-	for ( const className of BIG_SKY_LAYOUT_CLASSES ) {
-		document.querySelectorAll< HTMLElement >( `.${ className }` ).forEach( ( el ) => {
-			el.classList.remove( className );
-		} );
-	}
+		.forEach( suppressSurface );
+	stripBigSkyLayoutClasses();
 
 	return true;
 }
@@ -104,10 +185,11 @@ export function suppressStaleBigSkySidebar(): boolean {
 export function startSuppressingStaleBigSkySidebar(): () => void {
 	if ( typeof window === 'undefined' || typeof MutationObserver === 'undefined' ) {
 		suppressStaleBigSkySidebar();
-		return () => {};
+		return clearStaleBigSkySidebarSuppression;
 	}
 
 	if ( ! shouldSuppressStaleBigSkySidebar() ) {
+		clearStaleBigSkySidebarSuppression();
 		return () => {};
 	}
 
@@ -116,13 +198,18 @@ export function startSuppressingStaleBigSkySidebar(): () => void {
 	const observer = new MutationObserver( () => {
 		suppressStaleBigSkySidebar();
 	} );
+	const retryTimers = RETRY_DELAYS_MS.map( ( delay ) =>
+		window.setTimeout( suppressStaleBigSkySidebar, delay )
+	);
 
 	observer.observe( document.body, {
 		attributes: true,
 		attributeFilter: [ 'class' ],
-		childList: true,
-		subtree: true,
 	} );
 
-	return () => observer.disconnect();
+	return () => {
+		observer.disconnect();
+		retryTimers.forEach( window.clearTimeout );
+		clearStaleBigSkySidebarSuppression();
+	};
 }

--- a/packages/agents-manager/src/utils/suppress-stale-big-sky-sidebar.ts
+++ b/packages/agents-manager/src/utils/suppress-stale-big-sky-sidebar.ts
@@ -1,0 +1,128 @@
+// global.d.ts declares ambient globals (e.g. agentsManagerData) that are injected server-side.
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference path="../global.d.ts" />
+
+import { select } from '@wordpress/data';
+import { isJetpackAiSidebarPreviewFeatureEnabled } from './jetpack-ai-sidebar-preview';
+
+const SUPPRESSION_CLASS = 'agents-manager-suppress-stale-big-sky-sidebar';
+const SUPPRESSION_STYLE_ID = 'agents-manager-suppress-stale-big-sky-sidebar-style';
+
+const BIG_SKY_SURFACE_SELECTORS = [
+	'.big-sky-sidebar',
+	'.big-sky-sidebar__fab',
+	'#big-sky-wp-admin-agent-root',
+];
+
+const BIG_SKY_LAYOUT_CLASSES = [
+	'big-sky-sidebar-container',
+	'big-sky-sidebar-container--sidebar-open',
+];
+
+function getAgentsManagerData() {
+	return typeof agentsManagerData !== 'undefined' ? agentsManagerData : undefined;
+}
+
+function getCurrentPostType(): string | undefined {
+	try {
+		return select( 'core/editor' )?.getCurrentPostType?.();
+	} catch {
+		return undefined;
+	}
+}
+
+export function shouldSuppressStaleBigSkySidebar(): boolean {
+	if ( typeof document === 'undefined' ) {
+		return false;
+	}
+
+	const data = getAgentsManagerData();
+	if ( data?.sectionName && data.sectionName !== 'gutenberg' ) {
+		return false;
+	}
+
+	const previewEnabled = data?.jetpackAiSidebarPreview?.enabled === true;
+	const hasPreviewFeature = Object.values( data?.jetpackAiSidebarPreview?.features ?? {} ).some(
+		Boolean
+	);
+	const jetpackAiSidebarActive =
+		hasPreviewFeature ||
+		!! data?.aiEditorialReviewEnabled ||
+		!! data?.reviewMediatorEnabled ||
+		isJetpackAiSidebarPreviewFeatureEnabled( 'aiEditorialReview', false );
+
+	if ( ! previewEnabled || ! jetpackAiSidebarActive ) {
+		return false;
+	}
+
+	return getCurrentPostType() === 'post' || document.body.classList.contains( 'post-type-post' );
+}
+
+function ensureSuppressionStyle(): void {
+	if ( document.getElementById( SUPPRESSION_STYLE_ID ) ) {
+		return;
+	}
+
+	const style = document.createElement( 'style' );
+	style.id = SUPPRESSION_STYLE_ID;
+	style.textContent = `
+		.${ SUPPRESSION_CLASS } ${ BIG_SKY_SURFACE_SELECTORS.join( `,\n\t\t.${ SUPPRESSION_CLASS } ` ) } {
+			display: none !important;
+			visibility: hidden !important;
+			pointer-events: none !important;
+		}
+	`;
+
+	document.head.appendChild( style );
+}
+
+export function suppressStaleBigSkySidebar(): boolean {
+	if ( ! shouldSuppressStaleBigSkySidebar() ) {
+		return false;
+	}
+
+	// Temporary AM guard while Big Sky updates its Agents Manager class detection.
+	ensureSuppressionStyle();
+	document.documentElement.classList.add( SUPPRESSION_CLASS );
+
+	document
+		.querySelectorAll< HTMLElement >( BIG_SKY_SURFACE_SELECTORS.join( ',' ) )
+		.forEach( ( el ) => {
+			el.hidden = true;
+			el.setAttribute( 'aria-hidden', 'true' );
+		} );
+
+	for ( const className of BIG_SKY_LAYOUT_CLASSES ) {
+		document.querySelectorAll< HTMLElement >( `.${ className }` ).forEach( ( el ) => {
+			el.classList.remove( className );
+		} );
+	}
+
+	return true;
+}
+
+export function startSuppressingStaleBigSkySidebar(): () => void {
+	if ( typeof window === 'undefined' || typeof MutationObserver === 'undefined' ) {
+		suppressStaleBigSkySidebar();
+		return () => {};
+	}
+
+	if ( ! shouldSuppressStaleBigSkySidebar() ) {
+		return () => {};
+	}
+
+	suppressStaleBigSkySidebar();
+
+	const observer = new MutationObserver( () => {
+		suppressStaleBigSkySidebar();
+	} );
+
+	observer.observe( document.body, {
+		attributes: true,
+		attributeFilter: [ 'class' ],
+		childList: true,
+		subtree: true,
+	} );
+
+	return () => observer.disconnect();
+}

--- a/packages/agents-manager/src/utils/suppress-stale-big-sky-sidebar.ts
+++ b/packages/agents-manager/src/utils/suppress-stale-big-sky-sidebar.ts
@@ -35,7 +35,8 @@ function getAgentsManagerData() {
 
 function getCurrentPostType(): string | undefined {
 	try {
-		return select( 'core/editor' )?.getCurrentPostType?.();
+		const postType = select( 'core/editor' )?.getCurrentPostType?.();
+		return typeof postType === 'string' ? postType : undefined;
 	} catch {
 		return undefined;
 	}
@@ -142,6 +143,10 @@ function stripBigSkyLayoutClasses(): void {
 }
 
 export function clearStaleBigSkySidebarSuppression(): void {
+	if ( typeof document === 'undefined' ) {
+		return;
+	}
+
 	document.documentElement.classList.remove( SUPPRESSION_CLASS );
 	document.getElementById( SUPPRESSION_STYLE_ID )?.remove();
 


### PR DESCRIPTION
## Proposed changes

- Add a temporary Agents Manager guard that hides stale Big Sky sidebar chrome when the Jetpack AI Sidebar preview is active in the post editor.
- Keep the guard narrow to the Gutenberg post editor and active Jetpack AI Sidebar preview payload.
- Remove stale Big Sky layout classes so the editor layout returns to the Agents Manager surface.

## Testing

- yarn jest -c packages/agents-manager/jest.config.js packages/agents-manager/src/utils/__tests__/suppress-stale-big-sky-sidebar.test.ts --runInBand
- yarn eslint --ext .ts,.tsx packages/agents-manager/src/utils/suppress-stale-big-sky-sidebar.ts packages/agents-manager/src/utils/__tests__/suppress-stale-big-sky-sidebar.test.ts packages/agents-manager/src/components/agents-manager.tsx