### PR TITLE
Move constructor side effects to componentDidMount

### DIFF
--- a/client/blocks/get-apps/apps-badge.tsx
+++ b/client/blocks/get-apps/apps-badge.tsx
@@ -90,9 +90,16 @@ export class AppsBadge extends PureComponent< AppsBadgeProps, AppsBadgeState > {
 				? APP_STORE_BADGE_URLS[ props.storeName ].src.replace( '{localeSlug}', localeSlug )
 				: APP_STORE_BADGE_URLS[ props.storeName ].defaultSrc,
 		};
+	}
 
+	componentDidMount(): void {
+		const localeSlug = APP_STORE_BADGE_URLS[ this.props.storeName ].getLocaleSlug().toLowerCase();
+		const shouldLoadExternalImage = ! startsWith( localeSlug, 'en' );
+
+		// Kick off the external image load in the commit phase rather than the
+		// constructor, which React can run multiple times (or discard) before a
+		// mount commits under concurrent rendering.
 		if ( shouldLoadExternalImage ) {
-			this.image = null;
 			this.loadImage();
 		}
 	}

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -90,12 +90,6 @@ const INTERFACE_FIELDS = [
 ];
 
 class Account extends Component {
-	constructor( props ) {
-		super( props );
-
-		this.props.removeUnsavedUserSetting( 'user_login' );
-	}
-
 	state = {
 		redirect: false,
 		showConfirmUsernameForm: false,
@@ -114,6 +108,8 @@ class Account extends Component {
 	}
 
 	componentDidMount() {
+		this.props.removeUnsavedUserSetting( 'user_login' );
+
 		const params = new URLSearchParams( window.location.search );
 		if ( params.get( 'usernameChangeSuccess' ) === 'true' ) {
 			this.props.successNotice( this.props.translate( 'Username changed successfully!' ), {

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -63,7 +63,9 @@ class EditContactInfoFormCard extends Component {
 		};
 
 		this.contactFormFieldValues = this.getContactFormFieldValues();
+	}
 
+	componentDidMount() {
 		this.fetchWhois();
 	}
 


### PR DESCRIPTION
## Proposed Changes

Move render-phase side effects out of three React class component constructors and into `componentDidMount`:

- **`client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx`** — `this.fetchWhois()` (dispatches `requestWhois` + triggers a network fetch). `componentDidUpdate` already re-runs it on prop changes, so initial-fetch coverage is unchanged.
- **`client/blocks/get-apps/apps-badge.tsx`** — the external `loadImage()` network load. State initialization stays in the constructor (it's pure); `shouldLoadExternalImage` is recomputed in `componentDidMount`.
- **`client/me/account/main.jsx`** — the `removeUnsavedUserSetting( 'user_login' )` dispatch moved into the existing `componentDidMount`; the now-empty constructor is removed.

## Why are these changes being made?

A class component's `constructor` runs during the **render phase**, which React 18 concurrent rendering may execute multiple times — or discard entirely — before a mount commits (time-slicing interruptions, Suspense retries). Side effects placed there therefore fire on discarded render attempts, can run more than once per mount, and may emit "Cannot update a component while rendering" warnings.

This is the same class of bug as the notifications REST-client poll storm fixed in #111309 (constructor created the client and immediately started polling, flooding the endpoint under concurrent rendering). These three are lower blast-radius — each is a single, guarded, idempotent-ish action with no polling loop — but they share the root cause. `componentDidMount` runs exactly once per committed mount, which is the correct place for these effects.

Found via an audit of all React class component constructors in `client/`, `apps/`, and `packages/`. These were the only genuine offenders; SSR-guarded and pure-read cases (e.g. `document-head`, `app-banner`) were verified safe and left as-is.

## Testing Instructions

- `yarn typecheck-client` passes for the changed files (no new errors introduced; pre-existing Reader/Dashboard errors on trunk are unrelated).
- **Edit contact info:** open Domains → a domain → Contact information; confirm the form still loads the registrant's WHOIS data.
- **App badges:** on a page rendering the App Store / Google Play badges in a non-English locale, confirm the localized badge image still loads (and falls back on error).
- **Account settings:** load `/me/account`; confirm it behaves as before (no unsaved `user_login` lingering) and there are no React console warnings.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)