### PR TITLE
Agent Studio: Load Inter as a webfont so PNG stat numbers don't clip

### DIFF
--- a/client/a8c-for-agencies/sections/agent-studio/social-design/brandPacks/default-pack.ts
+++ b/client/a8c-for-agencies/sections/agent-studio/social-design/brandPacks/default-pack.ts
@@ -1,8 +1,10 @@
 import type { BrandPack } from './types';
 
-const SYSTEM_STACK =
-	"Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif";
-
+// Inter is loaded as a real webfont (not a system stack) so the browser
+// fits the tile against the exact same face Browserless rasterises the
+// PNG with — see `googleFonts.ts`. A system stack resolved to whatever
+// the OS had (San Francisco on macOS, a generic on the Linux renderer),
+// and the per-environment glyph-width gap clipped baked-size stat numbers.
 const A4A_BLUE = '#3858E9';
 
 export const DEFAULT_SOCIAL_BRAND_PACK: BrandPack = {
@@ -30,7 +32,7 @@ export const DEFAULT_SOCIAL_BRAND_PACK: BrandPack = {
 		{
 			role: 'h1',
 			family: 'Inter',
-			systemFamily: SYSTEM_STACK,
+			googleFamily: 'Inter',
 			weight: 600,
 			case: 'as-typed',
 			tracking: '-0.025em',
@@ -38,7 +40,7 @@ export const DEFAULT_SOCIAL_BRAND_PACK: BrandPack = {
 		{
 			role: 'h2',
 			family: 'Inter',
-			systemFamily: SYSTEM_STACK,
+			googleFamily: 'Inter',
 			weight: 600,
 			case: 'as-typed',
 			tracking: '-0.02em',
@@ -46,7 +48,7 @@ export const DEFAULT_SOCIAL_BRAND_PACK: BrandPack = {
 		{
 			role: 'h3',
 			family: 'Inter',
-			systemFamily: SYSTEM_STACK,
+			googleFamily: 'Inter',
 			weight: 600,
 			case: 'as-typed',
 			tracking: '-0.01em',
@@ -54,7 +56,7 @@ export const DEFAULT_SOCIAL_BRAND_PACK: BrandPack = {
 		{
 			role: 'eyebrow',
 			family: 'Inter',
-			systemFamily: SYSTEM_STACK,
+			googleFamily: 'Inter',
 			weight: 600,
 			case: 'uppercase',
 			tracking: '0.08em',
@@ -62,7 +64,7 @@ export const DEFAULT_SOCIAL_BRAND_PACK: BrandPack = {
 		{
 			role: 'body',
 			family: 'Inter',
-			systemFamily: SYSTEM_STACK,
+			googleFamily: 'Inter',
 			weight: 400,
 			case: 'as-typed',
 			tracking: '0',

--- a/client/a8c-for-agencies/sections/agent-studio/social-design/services/googleFonts.ts
+++ b/client/a8c-for-agencies/sections/agent-studio/social-design/services/googleFonts.ts
@@ -9,7 +9,10 @@ export type GoogleFont = {
 };
 
 export const GOOGLE_FONTS: GoogleFont[] = [
-	{ family: 'Inter', category: 'sans', weights: [ 400, 700, 900 ] },
+	// Weights span what the Bea renderer asks for (body 400, headline/stat
+	// 600) plus the 500/700/900 the capture stylesheet requests, so the
+	// browser fit and the Browserless render resolve identical faces.
+	{ family: 'Inter', category: 'sans', weights: [ 400, 500, 600, 700, 900 ] },
 	{ family: 'Space Grotesk', category: 'sans', weights: [ 400, 500, 700 ] },
 	{ family: 'Manrope', category: 'sans', weights: [ 400, 700, 800 ] },
 	{ family: 'Archivo Black', category: 'display', weights: [ 400 ] },
@@ -75,8 +78,14 @@ async function primeCanvasFont( family: string ) {
 	try {
 		await Promise.all( [
 			document.fonts.load( `400 24px "${ family }"` ),
+			document.fonts.load( `500 24px "${ family }"` ),
+			document.fonts.load( `600 24px "${ family }"` ),
 			document.fonts.load( `700 24px "${ family }"` ),
 			document.fonts.load( `400 60px "${ family }"` ),
+			// The stat-hero fitter measures at the headline weight (600) via
+			// canvas measureText; without priming that weight the canvas falls
+			// back to a generic face and the measured width is wrong.
+			document.fonts.load( `600 84px "${ family }"` ),
 			document.fonts.load( `700 84px "${ family }"` ),
 			document.fonts.load( `400 108px "${ family }"` ),
 			document.fonts.load( `700 120px "${ family }"` ),


### PR DESCRIPTION
## Summary

Social tiles are fit in the browser: `prepareBeaRenderElement` measures each headline and stat-hero number against the loaded font and bakes the resulting pixel `font-size` into the markup. That post-fit HTML is then captured and handed to Browserless (via the wpcom `social/.../png` endpoint) to rasterise the downloadable PNG.

The default brand pack declared its fonts with a `systemFamily` stack (`Inter, -apple-system, …`) and never loaded Inter as a webfont. So the browser fit measured whatever the OS substituted for that stack — San Francisco on macOS — while Browserless, which loads Inter from the stylesheet the capture injects, painted the baked size in Inter. Inter's glyphs are wider, so a stat number sized to fit San Francisco overflowed and clipped at the right edge in the downloaded PNG, even though the on-screen preview looked correct.

This converges the two environments on the same face:

- `default-pack.ts`: every role now uses `googleFamily: 'Inter'` instead of the `systemFamily` stack, so the client loads and fits against the same Inter face Browserless renders.
- `googleFonts.ts`: Inter's curated weight set widens from `400/700/900` to `400/500/600/700/900`, matching what the Bea renderer uses (body 400, headline/stat 600) and the capture stylesheet requests, so the fit and the render resolve identical faces.
- `googleFonts.ts`: `primeCanvasFont` now also primes weight 600 — the weight the stat-hero fitter measures with via `canvas.measureText` — so it no longer falls back to a generic face and mis-measures.

No wpcom/server change is needed; the capture already injects the Inter stylesheet Browserless uses.

## Testing Instructions

Prerequisites: a8c-for-agencies running locally, signed in as an agency user, with an agent studio social campaign that produces a stat-hero tile (a large number like `94%`).

1. Open the social campaign output and view a stat-hero variant in the preview. Confirm the big number renders fully inside the tile.
2. Download that tile's PNG.
3. Open the downloaded PNG and confirm the number is fully visible — not clipped at the right edge — and matches the on-screen preview.
4. Repeat for the `story` (1080x1920) and `square` (1080x1080) sizes.
5. Regression check: download a non-stat tile (headline-only) and confirm the headline still fits and renders in Inter.