### PR TITLE
Delayed Downgrades 1/4: scheduled downgrade data layer

### DIFF
--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -35,6 +35,10 @@ export function isRenewing( purchase: Purchase ): boolean {
 	return [ 'active', 'auto-renewing' ].includes( purchase.expiry_status );
 }
 
+export function hasScheduledDowngrade( purchase: Purchase ): boolean {
+	return !! purchase.scheduled_downgrade_product_id;
+}
+
 /**
  * Returns true if the purchase is in grace period with a failed or missing auto-renewal.
  */

--- a/client/lib/purchases/actions.js
+++ b/client/lib/purchases/actions.js
@@ -92,3 +92,20 @@ export function extendPurchaseWithFreeMonth( purchaseId ) {
 		apiNamespace: 'wpcom/v2',
 	} );
 }
+
+export async function scheduleDowngradeAsync( purchaseId, targetProductId ) {
+	const data = await wpcom.req.post( {
+		path: `/upgrades/${ purchaseId }/schedule-downgrade`,
+		apiVersion: '1.1',
+		body: { target_product_id: targetProductId },
+	} );
+	return { success: data.success, upgrade: data.upgrade };
+}
+
+export async function cancelScheduledDowngradeAsync( purchaseId ) {
+	const data = await wpcom.req.post( {
+		path: `/upgrades/${ purchaseId }/cancel-scheduled-downgrade`,
+		apiVersion: '1.1',
+	} );
+	return { success: data.success, upgrade: data.upgrade };
+}

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -800,6 +800,10 @@ export function isRenewing( purchase: Purchase ): boolean {
 	return [ 'active', 'autoRenewing' ].includes( purchase.expiryStatus );
 }
 
+export function hasScheduledDowngrade( purchase: Purchase ): boolean {
+	return !! purchase.scheduledDowngradeProductId;
+}
+
 /**
  * Returns true if the purchase is in grace period with a failed or missing auto-renewal.
  */

--- a/client/lib/purchases/test/index.js
+++ b/client/lib/purchases/test/index.js
@@ -11,6 +11,7 @@ import {
 	handleRenewNowClick,
 	handleRenewMultiplePurchasesClick,
 	shouldRenderMonthlyRenewalOption,
+	hasScheduledDowngrade,
 } from '../index';
 import data from './data';
 const {
@@ -419,6 +420,24 @@ describe( 'index', () => {
 					} )
 				).toBe( true );
 			} );
+		} );
+	} );
+
+	describe( '#hasScheduledDowngrade', () => {
+		test( 'returns true when scheduledDowngradeProductId is set', () => {
+			expect( hasScheduledDowngrade( { scheduledDowngradeProductId: 1003 } ) ).toBe( true );
+		} );
+
+		test( 'returns false when scheduledDowngradeProductId is null', () => {
+			expect( hasScheduledDowngrade( { scheduledDowngradeProductId: null } ) ).toBe( false );
+		} );
+
+		test( 'returns false when scheduledDowngradeProductId is 0', () => {
+			expect( hasScheduledDowngrade( { scheduledDowngradeProductId: 0 } ) ).toBe( false );
+		} );
+
+		test( 'returns false when scheduledDowngradeProductId is undefined', () => {
+			expect( hasScheduledDowngrade( {} ) ).toBe( false );
 		} );
 	} );
 } );

--- a/packages/api-core/src/upgrades/mutators.ts
+++ b/packages/api-core/src/upgrades/mutators.ts
@@ -105,3 +105,31 @@ export async function extendPurchaseWithFreeMonth(
 		apiNamespace: 'wpcom/v2',
 	} );
 }
+
+export async function scheduleDowngrade(
+	purchaseId: number,
+	targetProductId: number
+): Promise< { success: boolean; upgrade: Purchase } > {
+	const data = await wpcom.req.post( {
+		path: `/upgrades/${ purchaseId }/schedule-downgrade`,
+		apiVersion: '1.1',
+		body: { target_product_id: targetProductId },
+	} );
+	return {
+		success: data.success,
+		upgrade: normalizePurchase( data.upgrade ),
+	};
+}
+
+export async function cancelScheduledDowngrade(
+	purchaseId: number
+): Promise< { success: boolean; upgrade: Purchase } > {
+	const data = await wpcom.req.post( {
+		path: `/upgrades/${ purchaseId }/cancel-scheduled-downgrade`,
+		apiVersion: '1.1',
+	} );
+	return {
+		success: data.success,
+		upgrade: normalizePurchase( data.upgrade ),
+	};
+}

--- a/packages/api-core/src/upgrades/test/mutators.test.ts
+++ b/packages/api-core/src/upgrades/test/mutators.test.ts
@@ -1,0 +1,77 @@
+import { scheduleDowngrade, cancelScheduledDowngrade } from '../mutators';
+
+const mockPost = jest.fn();
+jest.mock( '../../wpcom-fetcher', () => ( {
+	wpcom: {
+		req: {
+			post: ( ...args: unknown[] ) => mockPost( ...args ),
+		},
+	},
+} ) );
+
+function makeRawPurchase( overrides = {} ) {
+	return {
+		ID: '123',
+		attached_to_purchase_id: null,
+		ownership_id: '1',
+		product_id: '1009',
+		blog_id: '456',
+		user_id: '789',
+		is_domain: false,
+		is_domain_registration: false,
+		scheduled_downgrade_product_id: null,
+		scheduled_downgrade_product_slug: null,
+		scheduled_downgrade_renewal_date: null,
+		...overrides,
+	};
+}
+
+describe( 'scheduleDowngrade', () => {
+	beforeEach( () => {
+		mockPost.mockReset();
+	} );
+
+	test( 'POSTs to the correct path with target_product_id in the body', async () => {
+		const rawUpgrade = makeRawPurchase( {
+			scheduled_downgrade_product_id: 1003,
+			scheduled_downgrade_product_slug: 'personal-bundle',
+			scheduled_downgrade_renewal_date: '2026-07-01',
+		} );
+		mockPost.mockResolvedValue( { success: true, upgrade: rawUpgrade } );
+
+		const result = await scheduleDowngrade( 123, 1003 );
+
+		expect( mockPost ).toHaveBeenCalledWith( {
+			path: '/upgrades/123/schedule-downgrade',
+			apiVersion: '1.1',
+			body: { target_product_id: 1003 },
+		} );
+		expect( result.success ).toBe( true );
+		expect( result.upgrade.ID ).toBe( 123 );
+		expect( result.upgrade.scheduled_downgrade_product_id ).toBe( 1003 );
+	} );
+} );
+
+describe( 'cancelScheduledDowngrade', () => {
+	beforeEach( () => {
+		mockPost.mockReset();
+	} );
+
+	test( 'POSTs to the correct path with no body', async () => {
+		const rawUpgrade = makeRawPurchase( {
+			scheduled_downgrade_product_id: null,
+			scheduled_downgrade_product_slug: null,
+			scheduled_downgrade_renewal_date: null,
+		} );
+		mockPost.mockResolvedValue( { success: true, upgrade: rawUpgrade } );
+
+		const result = await cancelScheduledDowngrade( 123 );
+
+		expect( mockPost ).toHaveBeenCalledWith( {
+			path: '/upgrades/123/cancel-scheduled-downgrade',
+			apiVersion: '1.1',
+		} );
+		expect( result.success ).toBe( true );
+		expect( result.upgrade.scheduled_downgrade_product_id ).toBeNull();
+	} );
+} );

--- a/packages/api-core/src/upgrades/types.ts
+++ b/packages/api-core/src/upgrades/types.ts
@@ -351,6 +351,24 @@ export interface Purchase {
 	 */
 	is_auto_renew_enabled: boolean;
 
+	/**
+	 * The product ID the subscription will downgrade to at its next renewal,
+	 * or null if no downgrade is scheduled.
+	 */
+	scheduled_downgrade_product_id: number | null;
+
+	/**
+	 * The product slug the subscription will downgrade to at its next renewal,
+	 * or null if no downgrade is scheduled.
+	 */
+	scheduled_downgrade_product_slug: string | null;
+
+	/**
+	 * The date when the scheduled downgrade will take effect (the next renewal
+	 * date), or null if no downgrade is scheduled.
+	 */
+	scheduled_downgrade_renewal_date: string | null;
+
 	payment_card_id: number | string | undefined;
 	payment_card_type: string | undefined;
 	payment_card_processor: string | undefined;

--- a/packages/api-core/tsconfig.json
+++ b/packages/api-core/tsconfig.json
@@ -6,5 +6,5 @@
 		"rootDir": "src"
 	},
 	"include": [ "src", "src/*.json" ],
-	"exclude": [ "**/__tests__/*", "**/__mocks__/*" ]
+	"exclude": [ "**/__tests__/*", "**/__mocks__/*", "**/test/*" ]
 }

--- a/packages/api-queries/src/upgrades.ts
+++ b/packages/api-queries/src/upgrades.ts
@@ -10,6 +10,8 @@ import {
 	fetchUserTransferredPurchases,
 	fetchSitePurchases,
 	fetchCancellationFeatures,
+	scheduleDowngrade,
+	cancelScheduledDowngrade,
 } from '@automattic/api-core';
 import { queryOptions, mutationOptions } from '@tanstack/react-query';
 import { queryClient } from './query-client';
@@ -98,6 +100,29 @@ export const cancelAndRefundPurchaseMutation = () =>
 export const extendPurchaseWithFreeMonthMutation = () =>
 	mutationOptions( {
 		mutationFn: ( purchaseId: number ) => extendPurchaseWithFreeMonth( purchaseId ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( userPurchasesQuery() );
+		},
+	} );
+
+export const userScheduleDowngradeQuery = () =>
+	mutationOptions( {
+		mutationFn: ( {
+			purchaseId,
+			targetProductId,
+		}: {
+			purchaseId: number;
+			targetProductId: number;
+		} ) => scheduleDowngrade( purchaseId, targetProductId ),
+		onSuccess: () => {
+			queryClient.invalidateQueries( userPurchasesQuery() );
+		},
+	} );
+
+export const userCancelScheduledDowngradeQuery = () =>
+	mutationOptions( {
+		mutationFn: ( { purchaseId }: { purchaseId: number } ) =>
+			cancelScheduledDowngrade( purchaseId ),
 		onSuccess: () => {
 			queryClient.invalidateQueries( userPurchasesQuery() );
 		},

--- a/packages/data-stores/src/purchases/lib/assembler.ts
+++ b/packages/data-stores/src/purchases/lib/assembler.ts
@@ -118,6 +118,9 @@ export function createPurchaseObject( purchase: RawPurchase ): Purchase {
 		isAutoRenewEnabled: purchase.is_auto_renew_enabled,
 		isJetpackPlanOrProduct: purchase.is_jetpack_plan_or_product,
 		isAttachedToHoldingSite: Boolean( purchase.is_attached_to_holding_site ),
+		scheduledDowngradeProductId: purchase.scheduled_downgrade_product_id ?? null,
+		scheduledDowngradeProductSlug: purchase.scheduled_downgrade_product_slug ?? null,
+		scheduledDowngradeRenewalDate: purchase.scheduled_downgrade_renewal_date ?? null,
 	};
 
 	if ( isCreditCardPurchase( purchase ) ) {

--- a/packages/data-stores/src/purchases/types.ts
+++ b/packages/data-stores/src/purchases/types.ts
@@ -195,6 +195,24 @@ export interface Purchase {
 
 	isJetpackPlanOrProduct: boolean;
 	isAttachedToHoldingSite: boolean;
+
+	/**
+	 * The product ID the subscription will downgrade to at its next renewal,
+	 * or null if no downgrade is scheduled.
+	 */
+	scheduledDowngradeProductId: number | null;
+
+	/**
+	 * The product slug the subscription will downgrade to at its next renewal,
+	 * or null if no downgrade is scheduled.
+	 */
+	scheduledDowngradeProductSlug: string | null;
+
+	/**
+	 * The date when the scheduled downgrade will take effect (the next renewal
+	 * date), or null if no downgrade is scheduled.
+	 */
+	scheduledDowngradeRenewalDate: string | null;
 }
 
 export interface PurchasePriceTier {


### PR DESCRIPTION
Depends on: https://github.com/Automattic/wp-calypso/pull/111320
Depends on: 221529-ghe-Automattic/wpcom

## Summary

This is PR 1/4 that adds a delayed downgrade capability to all active plans. There are no front-end changes here.

Technical details:
- **Purchase types**: `scheduled_downgrade_product_id`, `scheduled_downgrade_product_slug`, `scheduled_downgrade_renewal_date` in both `api-core` (snake_case, dashboard) and `data-stores` (camelCase, legacy) + assembler mapping
- **Mutators**: `scheduleDowngrade()` and `cancelScheduledDowngrade()` in `api-core`, following the `setPurchaseAutoRenew` pattern
- **Query hooks**: `userScheduleDowngradeQuery` and `userCancelScheduledDowngradeQuery` in `api-queries`
- **Legacy helpers**: `scheduleDowngradeAsync()` and `cancelScheduledDowngradeAsync()` in `client/lib/purchases/actions.js`
- **Readers**: `hasScheduledDowngrade()` in both dashboard and legacy utils
- **Tests**: 6 new tests (2 mutator POST path assertions, 4 reader boolean assertions)

### Backend contract

Endpoints from `try/downgrades-on-renewal` sandbox branch:
- `POST /upgrades/{id}/schedule-downgrade` — body `{ target_product_id }` → `{ success, upgrade }`
- `POST /upgrades/{id}/cancel-scheduled-downgrade` → `{ success, upgrade }`

## Test plan

- [ ] \`yarn jest packages/api-core/src/upgrades/test/mutators.test.ts\` — 2 tests pass
- [ ] \`yarn test-client client/lib/purchases/test/index.js\` — 48 tests pass (4 new)
- [ ] \`npx tsc --project packages/api-core/tsconfig.json --noEmit\` — clean
- [ ] \`npx tsc --project packages/data-stores/tsconfig.json --noEmit\` — clean
- [ ] \`npx tsc --project packages/api-queries/tsconfig.json --noEmit\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)