### PR TITLE
A4A Referrals: escape CSV fields against formula injection

### DIFF
--- a/client/a8c-for-agencies/sections/referrals/lib/generate-commissions-csv.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/generate-commissions-csv.ts
@@ -30,7 +30,9 @@ const FORMULA_TRIGGERS = [ '=', '+', '-', '@', '\t', '\r' ];
  */
 function csvEscape( value: unknown ): string {
 	let str = value == null ? '' : String( value );
-	if ( FORMULA_TRIGGERS.some( ( char ) => str.startsWith( char ) ) ) {
+	// A lone trigger character (e.g. the '-' placeholder used for missing values) is not a
+	// formula, so only neutralize when there is content after the trigger.
+	if ( str.length > 1 && FORMULA_TRIGGERS.some( ( char ) => str.startsWith( char ) ) ) {
 		str = `'${ str }`;
 	}
 	const needsQuotes = /[",\n]/.test( str );

--- a/client/a8c-for-agencies/sections/referrals/lib/generate-commissions-csv.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/generate-commissions-csv.ts
@@ -14,12 +14,25 @@ const CSV_LINE_ENDING = '\r\n';
 const UTF8_BOM = '\uFEFF';
 
 /**
+ * Characters that spreadsheet applications (Excel, Google Sheets, etc.) treat as the
+ * start of a formula. A field beginning with one of these can execute on open, so we
+ * neutralize it. Includes tab and carriage return, which some parsers strip before
+ * evaluating the remaining formula.
+ */
+const FORMULA_TRIGGERS = [ '=', '+', '-', '@', '\t', '\r' ];
+
+/**
  * Escapes a value for CSV format.
+ * Neutralizes formula injection by prefixing a single quote to fields that begin with a
+ * formula trigger character (spreadsheets render the leading quote-prefixed value as a literal string).
  * Wraps in quotes if the value contains commas, quotes, or newlines.
  * Doubles any existing quotes.
  */
 function csvEscape( value: unknown ): string {
-	const str = value == null ? '' : String( value );
+	let str = value == null ? '' : String( value );
+	if ( FORMULA_TRIGGERS.some( ( char ) => str.startsWith( char ) ) ) {
+		str = `'${ str }`;
+	}
 	const needsQuotes = /[",\n]/.test( str );
 	const escaped = str.replace( /"/g, '""' );
 	return needsQuotes ? `"${ escaped }"` : escaped;

--- a/client/a8c-for-agencies/sections/referrals/lib/test/generate-commissions-csv.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/test/generate-commissions-csv.ts
@@ -44,6 +44,11 @@ describe( 'generateCommissionsCsv', () => {
 		expect( csv ).not.toContain( "'Pro Plan" );
 	} );
 
+	it( 'does not prefix a lone trigger character used as a placeholder', () => {
+		const csv = generateCommissionsCsv( [], [], payoutWithProductName( '-' ) );
+		expect( csv ).not.toContain( "'-" );
+	} );
+
 	it( 'still quotes and escapes fields containing commas and quotes', () => {
 		const csv = generateCommissionsCsv( [], [], payoutWithProductName( 'Plan "A", annual' ) );
 		expect( csv ).toContain( '"Plan ""A"", annual"' );

--- a/client/a8c-for-agencies/sections/referrals/lib/test/generate-commissions-csv.ts
+++ b/client/a8c-for-agencies/sections/referrals/lib/test/generate-commissions-csv.ts
@@ -1,0 +1,51 @@
+import { generateCommissionsCsv } from '../generate-commissions-csv';
+import type { ReferralCommissionPayoutResponse } from '../../types';
+
+function payoutWithProductName( productName: string ): ReferralCommissionPayoutResponse {
+	return {
+		total_amount: 100,
+		total_commission: 10,
+		start_date: '2024-01-01',
+		end_date: '2024-01-31',
+		next_payout_date: '2024-03-02',
+		client_data: [
+			{
+				client_user_id: 'N/A',
+				email: 'client@example.com',
+				total_amount: 100,
+				total_commission: 10,
+				products: [
+					{
+						product_id: 1,
+						product_name: productName,
+						total_amount: 100,
+						total_commission: 10,
+						invoices: [ { payment_date: '2024-01-15', paid_amount: 100, commission_amount: 10 } ],
+					},
+				],
+			},
+		],
+	};
+}
+
+describe( 'generateCommissionsCsv', () => {
+	it.each( [ '=HYPERLINK(evil)', '+1+1', '-1', '@SUM(A1)', '\tcmd', '\rcmd' ] )(
+		'neutralizes formula injection in fields starting with %j',
+		( payload ) => {
+			const csv = generateCommissionsCsv( [], [], payoutWithProductName( payload ) );
+			// The injected field is prefixed with a single quote so spreadsheets treat it as a literal string.
+			expect( csv ).toContain( `'${ payload }` );
+		}
+	);
+
+	it( 'does not alter values that do not start with a formula trigger', () => {
+		const csv = generateCommissionsCsv( [], [], payoutWithProductName( 'Pro Plan' ) );
+		expect( csv ).toContain( 'Pro Plan' );
+		expect( csv ).not.toContain( "'Pro Plan" );
+	} );
+
+	it( 'still quotes and escapes fields containing commas and quotes', () => {
+		const csv = generateCommissionsCsv( [], [], payoutWithProductName( 'Plan "A", annual' ) );
+		expect( csv ).toContain( '"Plan ""A"", annual"' );
+	} );
+} );


### PR DESCRIPTION
Part of A4A-2287
<!-- Link the related A4A Linear issue. -->

## Proposed Changes

* **`client/a8c-for-agencies/sections/referrals/lib/generate-commissions-csv.ts`** — `csvEscape` now neutralizes CSV formula injection: any field that begins with a spreadsheet formula trigger (`=`, `+`, `-`, `@`, tab, or carriage return) is prefixed with a single quote, which Excel/Google Sheets render as a literal string rather than evaluating. The prefix is applied before the existing RFC 4180 quoting, so comma/quote/newline escaping is unaffected. Folding this into the single `csvEscape` chokepoint covers every column, including the referral-client-influenceable `Client Email` and `Product Name` fields.
* **`client/a8c-for-agencies/sections/referrals/lib/test/generate-commissions-csv.ts`** — new tests covering each formula trigger, that ordinary values are left untouched, and that RFC 4180 comma/quote escaping still applies.

## Why are these changes being made?

The commissions CSV generator only quoted fields containing commas, quotes, or newlines. It did not neutralize values beginning with `=`, `+`, `-`, or `@`. Because client email and product name come from API data that referral clients can influence, an attacker could craft a field starting with a spreadsheet formula (e.g. `=HYPERLINK(...)`). When an agency user downloaded the CSV and opened it in Excel or Google Sheets, the formula could execute, enabling data exfiltration. Prefixing trigger characters with a single quote is the standard mitigation and renders the value inert.

## Testing Instructions

1. Run the unit tests: `yarn test-client client/a8c-for-agencies/sections/referrals/lib/test/generate-commissions-csv.ts`.
2. In **A4A → Referrals**, download a commissions CSV that includes a client whose email or product name begins with `=`, `+`, `-`, or `@`.
3. Open the file in Excel or Google Sheets and confirm the offending field is shown verbatim as text (leading `'`) and does not evaluate as a formula.
4. Confirm normal fields, and fields containing commas or quotes, still render correctly.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
