### PR TITLE
Checkout: replace disabled Pay button with a Continue CTA that scrolls to the next incomplete step

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -354,7 +354,10 @@ function PortaledCheckoutFormSubmit( {
 	if ( ! slotEl ) {
 		return null;
 	}
-	return createPortal( <CheckoutFormSubmit validateForm={ validateForm } />, slotEl );
+	return createPortal(
+		<CheckoutFormSubmit validateForm={ validateForm } continueToNextIncompleteStep />,
+		slotEl
+	);
 }
 
 export default function CheckoutMainContent( {

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -688,16 +688,20 @@ const CheckoutSummaryPayButtonSlot = styled.div`
 	margin-top: 16px;
 
 	/*
-	 * The real submit button renders here via a React portal (see submit-button-slot.ts).
-	 * Each payment method provides its own button element, so we style the slot to give
-	 * them a consistent full-width look in the sidebar.
+	 * The submit button renders here via a React portal (see submit-button-slot.ts).
+	 * Each payment method provides its own button element, and a "Continue" button
+	 * renders here while steps are incomplete, so normalize every button in the slot
+	 * to a consistent full-width, 50px-tall look in the sidebar regardless of which
+	 * one is showing (Pay, Continue, PayPal, etc.).
 	 */
 	.checkout-submit-button {
 		width: 100%;
 	}
 
-	.checkout-submit-button button {
+	button {
 		width: 100%;
+		height: 50px;
+		box-sizing: border-box;
 	}
 `;
 const CheckoutSummaryFeatures = styled.div`

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -794,9 +794,15 @@ export function CheckoutFormSubmit( {
 	} )();
 
 	// Show "Continue" only when the submit button would otherwise be disabled
-	// because there is another numbered step after the active one.
+	// because there is another numbered step after the active one AND there is
+	// actually an incomplete step to go to. The latter guard matters for returning
+	// purchasers whose steps are all auto-completed while the active step is still
+	// an earlier step: there is nothing to continue to, so show the Pay button.
 	const showContinueToNextIncompleteStep =
-		!! continueToNextIncompleteStep && ! disableSubmitButton && isThereAnotherNumberedStep;
+		!! continueToNextIncompleteStep &&
+		! disableSubmitButton &&
+		isThereAnotherNumberedStep &&
+		!! nextIncompleteStepId;
 
 	const goToNextIncompleteStep = async () => {
 		// Prefer the next incomplete step; otherwise just advance one step so the

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -806,9 +806,17 @@ export function CheckoutFormSubmit( {
 		if ( ! targetStepId ) {
 			return;
 		}
-		await makeStepActive( targetStepId );
+		const didActivateTarget = await makeStepActive( targetStepId );
+		// If activation failed, makeStepActive stopped on an intervening step that
+		// did not validate and left it active. Scroll to whichever step actually
+		// ended up active (read from the live store) so the user lands on the step
+		// that needs attention rather than a step that stayed collapsed. Desktop
+		// does not auto-scroll on step changes, so we always scroll explicitly.
+		const stepIdToScrollTo = didActivateTarget
+			? targetStepId
+			: getStepIdFromNumber( state.activeStepNumber ) ?? targetStepId;
 		document
-			.getElementById( targetStepId )
+			.getElementById( stepIdToScrollTo )
 			?.scrollIntoView?.( { behavior: 'smooth', block: 'start' } );
 	};
 

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -821,6 +821,9 @@ export function CheckoutFormSubmit( {
 					buttonType="primary"
 					fullWidth
 					className="checkout-steps__continue-button"
+					// Distinguish this from the per-step inline "Continue" buttons for
+					// assistive technology, which would otherwise announce "Continue" twice.
+					aria-label={ __( 'Continue to the next step' ) }
 					onClick={ goToNextIncompleteStep }
 				>
 					{ __( 'Continue' ) }

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -682,6 +682,7 @@ export function CheckoutFormSubmit( {
 	disableSubmitButton,
 	submitButton,
 	onPageLoadError,
+	continueToNextIncompleteStep,
 }: {
 	validateForm?: () => Promise< boolean >;
 	submitButtonHeader?: ReactNode;
@@ -689,10 +690,18 @@ export function CheckoutFormSubmit( {
 	disableSubmitButton?: boolean;
 	submitButton?: ReactNode;
 	onPageLoadError?: CheckoutPageErrorCallback;
+	continueToNextIncompleteStep?: boolean;
 } ) {
+	const { __ } = useI18n();
 	const { state, actions } = useContext( CheckoutStepGroupContext );
-	const { activeStepNumber, totalSteps, stepCompleteStatus, stepSkipValidationOnSubmitMap } = state;
-	const { getStepCompleteCallback, setStepCompleteStatus } = actions;
+	const {
+		activeStepNumber,
+		totalSteps,
+		stepCompleteStatus,
+		stepIdMap,
+		stepSkipValidationOnSubmitMap,
+	} = state;
+	const { getStepCompleteCallback, setStepCompleteStatus, makeStepActive } = actions;
 	const isThereAnotherNumberedStep = activeStepNumber < totalSteps;
 	const areAllStepsComplete = Object.values( stepCompleteStatus ).every(
 		( isComplete ) => isComplete === true
@@ -764,15 +773,66 @@ export function CheckoutFormSubmit( {
 		}
 		return false;
 	} )();
+
+	const getStepIdFromNumber = ( stepNumber: number ): string | undefined =>
+		Object.entries( stepIdMap ).find( ( [ , num ] ) => num === stepNumber )?.[ 0 ];
+
+	// The next step the user needs to address: the first incomplete step at or
+	// after the active step, falling back to the lowest incomplete step overall.
+	const nextIncompleteStepId = ( () => {
+		for ( let step = Math.max( activeStepNumber, 1 ); step <= totalSteps; step++ ) {
+			if ( ! stepCompleteStatus[ step ] ) {
+				return getStepIdFromNumber( step );
+			}
+		}
+		for ( let step = 1; step <= totalSteps; step++ ) {
+			if ( ! stepCompleteStatus[ step ] ) {
+				return getStepIdFromNumber( step );
+			}
+		}
+		return undefined;
+	} )();
+
+	// Show "Continue" only when the submit button would otherwise be disabled
+	// because there is another numbered step after the active one.
+	const showContinueToNextIncompleteStep =
+		!! continueToNextIncompleteStep && ! disableSubmitButton && isThereAnotherNumberedStep;
+
+	const goToNextIncompleteStep = async () => {
+		// Prefer the next incomplete step; otherwise just advance one step so the
+		// user always moves forward (covers the rare all-complete-but-not-last case).
+		const targetStepId =
+			nextIncompleteStepId ?? getStepIdFromNumber( Math.min( activeStepNumber + 1, totalSteps ) );
+		if ( ! targetStepId ) {
+			return;
+		}
+		await makeStepActive( targetStepId );
+		document
+			.getElementById( targetStepId )
+			?.scrollIntoView?.( { behavior: 'smooth', block: 'start' } );
+	};
+
 	return (
 		<SubmitButtonWrapper className="checkout-steps__submit-button-wrapper" ref={ submitWrapperRef }>
 			{ submitButtonHeader || null }
-			{ submitButton || (
-				<CheckoutSubmitButton
-					validateForm={ wrappedValidateForm }
-					disabled={ isDisabled }
-					onLoadError={ onSubmitButtonLoadError }
-				/>
+			{ showContinueToNextIncompleteStep ? (
+				<Button
+					type="button"
+					buttonType="primary"
+					fullWidth
+					className="checkout-steps__continue-button"
+					onClick={ goToNextIncompleteStep }
+				>
+					{ __( 'Continue' ) }
+				</Button>
+			) : (
+				submitButton || (
+					<CheckoutSubmitButton
+						validateForm={ wrappedValidateForm }
+						disabled={ isDisabled }
+						onLoadError={ onSubmitButtonLoadError }
+					/>
+				)
 			) }
 			<div className="checkout-steps__submit-footer-wrapper">{ submitButtonFooter || null }</div>
 		</SubmitButtonWrapper>

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -427,7 +427,9 @@ function CheckoutStepGroupWrapper( {
 			// context consumers get the modified store because its identity has
 			// changed.
 			setTimeout( () => {
-				isMounted.current && setContextValue( { ...store } );
+				if ( isMounted.current ) {
+					setContextValue( { ...store } );
+				}
 			}, 0 );
 		} );
 	}, [ store ] );

--- a/packages/composite-checkout/test/checkout.tsx
+++ b/packages/composite-checkout/test/checkout.tsx
@@ -934,6 +934,61 @@ describe( 'Checkout', () => {
 			expect( getByTextInNode( submitArea, 'Pay Please' ) ).toBeDisabled();
 			expect( queryByTextInNode( submitArea, 'Continue' ) ).not.toBeInTheDocument();
 		} );
+
+		it( 'renders the submit button (not Continue) when all steps are complete even if the active step is not the last', async () => {
+			// Mirrors a returning purchaser: all steps get auto-completed (via
+			// completeAllSteps), but the active step can remain an earlier step. The
+			// summary CTA should be the real Pay button, not Continue.
+			function CompleteAllStepsButton() {
+				const completeAllSteps = useCompleteAllSteps();
+				return <button onClick={ () => completeAllSteps() }>Complete all steps</button>;
+			}
+			function GoBackToFirstStepButton( { stepId } ) {
+				const makeStepActive = useMakeStepActive();
+				return <button onClick={ () => makeStepActive( stepId ) }>Go back to first step</button>;
+			}
+			const completableSteps = [
+				steps[ 0 ],
+				{ ...steps[ 1 ], id: 'returning-step-a', className: 'returning-step-a' },
+				{ ...steps[ 1 ], id: 'returning-step-b', className: 'returning-step-b' },
+				{ ...steps[ 1 ], id: 'returning-step-c', className: 'returning-step-c' },
+			];
+			function ReturningPurchaserCheckout() {
+				const [ paymentData, setPaymentData ] = useState( {} );
+				const { stepObjectsWithStepNumber, stepObjectsWithoutStepNumber } =
+					createStepsFromStepObjects( completableSteps );
+				const createStepFromStepObject = createStepObjectConverter( paymentData );
+				return (
+					<myContext.Provider value={ [ paymentData, setPaymentData ] }>
+						<CheckoutProvider
+							paymentMethods={ [ mockMethod ] }
+							paymentProcessors={ getMockPaymentProcessors() }
+							selectFirstAvailablePaymentMethod
+						>
+							<CheckoutStepGroup>
+								{ stepObjectsWithoutStepNumber.map( createStepFromStepObject ) }
+								{ stepObjectsWithStepNumber.map( createStepFromStepObject ) }
+								<CompleteAllStepsButton />
+								<GoBackToFirstStepButton stepId="returning-step-a" />
+								<CheckoutFormSubmit continueToNextIncompleteStep />
+							</CheckoutStepGroup>
+						</CheckoutProvider>
+					</myContext.Provider>
+				);
+			}
+			const { container, getByText } = render( <ReturningPurchaserCheckout /> );
+			const user = userEvent.setup();
+			// Complete every step (advances the active step to the last one), then go
+			// back to the first step so all steps are complete but the active step is
+			// not the last — the state a returning purchaser lands in.
+			await user.click( getByText( 'Complete all steps' ) );
+			await user.click( getByText( 'Go back to first step' ) );
+			const submitArea = getSubmitArea( container );
+			await waitFor( () => {
+				expect( getByTextInNode( submitArea, 'Pay Please' ) ).toBeInTheDocument();
+			} );
+			expect( queryByTextInNode( submitArea, 'Continue' ) ).not.toBeInTheDocument();
+		} );
 	} );
 
 	describe( 'submitting the form', function () {

--- a/packages/composite-checkout/test/checkout.tsx
+++ b/packages/composite-checkout/test/checkout.tsx
@@ -888,6 +888,12 @@ describe( 'Checkout', () => {
 			const submitArea = getSubmitArea( container );
 			expect( getByTextInNode( submitArea, 'Continue' ) ).toBeInTheDocument();
 			expect( getByTextInNode( submitArea, 'Continue' ) ).not.toBeDisabled();
+			// Has a distinct accessible name so screen readers don't announce a bare
+			// "Continue" twice (the active step renders its own inline Continue button).
+			expect( getByTextInNode( submitArea, 'Continue' ) ).toHaveAttribute(
+				'aria-label',
+				'Continue to the next step'
+			);
 			expect( queryByTextInNode( submitArea, 'Pay Please' ) ).not.toBeInTheDocument();
 		} );
 

--- a/packages/composite-checkout/test/checkout.tsx
+++ b/packages/composite-checkout/test/checkout.tsx
@@ -844,6 +844,92 @@ describe( 'Checkout', () => {
 		} );
 	} );
 
+	describe( 'with continueToNextIncompleteStep', function () {
+		const mockMethod = createMockMethod();
+		const steps = createMockStepObjects();
+
+		// steps[0] = summary (no step number)
+		// steps[1] = 'custom-contact-step'    (numbered, isCompleteCallback () => true)
+		// steps[3] = 'custom-incomplete-step' (numbered, isCompleteCallback () => false)
+
+		function ContinueCheckout( props ) {
+			const [ paymentData, setPaymentData ] = useState( {} );
+			const { stepObjectsWithStepNumber, stepObjectsWithoutStepNumber } =
+				createStepsFromStepObjects( props.steps || steps );
+			const createStepFromStepObject = createStepObjectConverter( paymentData );
+			return (
+				<myContext.Provider value={ [ paymentData, setPaymentData ] }>
+					<CheckoutProvider
+						paymentMethods={ [ mockMethod ] }
+						paymentProcessors={ getMockPaymentProcessors() }
+						selectFirstAvailablePaymentMethod
+					>
+						<CheckoutStepGroup>
+							{ stepObjectsWithoutStepNumber.map( createStepFromStepObject ) }
+							{ stepObjectsWithStepNumber.map( createStepFromStepObject ) }
+							{ props.withProp ? (
+								<CheckoutFormSubmit continueToNextIncompleteStep />
+							) : (
+								<CheckoutFormSubmit />
+							) }
+						</CheckoutStepGroup>
+					</CheckoutProvider>
+				</myContext.Provider>
+			);
+		}
+
+		const getSubmitArea = ( container ) =>
+			container.querySelector( '.checkout-steps__submit-button-wrapper' );
+
+		it( 'renders an enabled Continue button instead of a disabled submit button when a later step exists', () => {
+			const { container } = render(
+				<ContinueCheckout withProp steps={ [ steps[ 0 ], steps[ 1 ], steps[ 3 ] ] } />
+			);
+			const submitArea = getSubmitArea( container );
+			expect( getByTextInNode( submitArea, 'Continue' ) ).toBeInTheDocument();
+			expect( getByTextInNode( submitArea, 'Continue' ) ).not.toBeDisabled();
+			expect( queryByTextInNode( submitArea, 'Pay Please' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'smooth-scrolls to the next incomplete step when Continue is clicked', async () => {
+			const scrollIntoView = jest.fn();
+			window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+			const { container } = render(
+				<ContinueCheckout withProp steps={ [ steps[ 0 ], steps[ 1 ], steps[ 3 ] ] } />
+			);
+			const submitArea = getSubmitArea( container );
+			const user = userEvent.setup();
+			await user.click( getByTextInNode( submitArea, 'Continue' ) );
+
+			await waitFor( () => {
+				expect( scrollIntoView ).toHaveBeenCalledWith( { behavior: 'smooth', block: 'start' } );
+			} );
+			// The active step (step 1) is the first incomplete step, so it is the scroll target.
+			expect( ( scrollIntoView.mock.instances[ 0 ] as HTMLElement ).id ).toBe(
+				'custom-contact-step'
+			);
+		} );
+
+		it( 'renders the payment method submit button when the last step is active', () => {
+			const { container } = render(
+				<ContinueCheckout withProp steps={ [ steps[ 0 ], steps[ 1 ] ] } />
+			);
+			const submitArea = getSubmitArea( container );
+			expect( getByTextInNode( submitArea, 'Pay Please' ) ).toBeInTheDocument();
+			expect( getByTextInNode( submitArea, 'Pay Please' ) ).not.toBeDisabled();
+			expect( queryByTextInNode( submitArea, 'Continue' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'leaves the disabled submit button unchanged when the prop is not set', () => {
+			const { container } = render(
+				<ContinueCheckout steps={ [ steps[ 0 ], steps[ 1 ], steps[ 3 ] ] } />
+			);
+			const submitArea = getSubmitArea( container );
+			expect( getByTextInNode( submitArea, 'Pay Please' ) ).toBeDisabled();
+			expect( queryByTextInNode( submitArea, 'Continue' ) ).not.toBeInTheDocument();
+		} );
+	} );
+
 	describe( 'submitting the form', function () {
 		let MyCheckout;
 		const submitButtonComponent = <MockSubmitButtonSimple />;

--- a/packages/composite-checkout/test/checkout.tsx
+++ b/packages/composite-checkout/test/checkout.tsx
@@ -317,17 +317,17 @@ describe( 'Checkout', () => {
 			expect( content ).toHaveStyle( 'display: block' );
 			step = container.querySelector( '.' + steps[ 2 ].className );
 			content = step.querySelector( '.checkout-steps__step-complete-content' );
-			expect( content ).toBeNull;
+			expect( content ).toBeNull();
 			step = container.querySelector( '.' + steps[ 3 ].className );
 			content = step.querySelector( '.checkout-steps__step-complete-content' );
-			expect( content ).toBeNull;
+			expect( content ).toBeNull();
 		} );
 
 		it( 'does not render the completeStepContent when active', () => {
 			const { container } = render( <MyCheckout /> );
 			const step = container.querySelector( '.' + steps[ 1 ].className );
 			const content = step.querySelector( '.checkout-steps__step-complete-content' );
-			expect( content ).toBeNull;
+			expect( content ).toBeNull();
 		} );
 
 		it( 'renders the continue button for the active step', () => {


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/SHILL-2091/

## Proposed Changes

This replaces the persistent sidebar "Pay Now" button with a "Continue" button when there are incomplete steps. The button scrolls to the next incomplete step on click. When all steps are complete (on load or otherwise), the button is a "Pay Now" submit button.

https://github.com/user-attachments/assets/fa7fb69e-e177-45a4-ac05-f4d795c8e52e

* Add an opt-in `continueToNextIncompleteStep` prop to `CheckoutFormSubmit` (`@automattic/composite-checkout`). When set and the submit button would be disabled because a later numbered step is incomplete, it renders an enabled primary "Continue" button instead.
* Clicking "Continue" activates the next incomplete step (as if pressing its Edit button) and smooth-scrolls it into view. Desktop does not auto-scroll on step changes, so the scroll is explicit.
* Wire WordPress.com checkout to pass the prop via `PortaledCheckoutFormSubmit`. Jetpack Cloud, A8C for Agencies, and other consumers omit the prop and keep the current disabled-button behavior.
* Give the Continue CTA a distinct accessible name (`aria-label="Continue to the next step"`) so screen readers don't announce a bare "Continue" twice (the active step renders its own inline Continue button).
* If activation fails because an intervening step doesn't validate, scroll to the step that actually became active rather than one that stayed collapsed.
* Show the Pay button (not Continue) when every step is already complete even if the active step is not the last — the state a returning purchaser lands in after `completeAllSteps()`.
* Normalize every button in the summary pay-button slot (Pay, Continue, PayPal) to a consistent full-width, 50px-tall (`border-box`) look.

## Why are these changes being made?

After the desktop checkout redesign pinned the summary sidebar and added a persistent Pay CTA, the button stays visible but is disabled until all steps are complete. Since incomplete steps are often below the fold, a greyed-out "Pay now" reads as "stuck" rather than "there's more to do below," so users can miss subsequent steps unless they happen to scroll.

An enabled "Continue" button is more discoverable and is genuinely actionable. It also avoids a technical pitfall: a `disabled` button doesn't fire click events, so intercepting a click on a disabled button would require faking the disabled state. Swapping in a real, enabled button sidesteps that entirely and is better for accessibility.

The behavior lives in `CheckoutFormSubmit` because that component already owns the disabled-when-incomplete decision and has the step-group context it needs (active step, completion status, the `makeStepActive` action). Keeping it there and gating it behind an opt-in prop means no behavior change for non-Calypso consumers.

## Testing Instructions

TC:
```
yarn test-packages packages/composite-checkout/test/checkout.tsx -t "continueToNextIncompleteStep"
```

Manual testing:
* Open a desktop-width checkout with multiple steps (e.g. a plan + a domain so Billing and Payment steps appear) as a new user.
* Confirm the summary CTA reads "Continue" while a step is incomplete, and that clicking it scrolls to and expands the next incomplete step (Billing / Payment).
* Complete all steps and confirm the CTA becomes "Pay now" and submits normally.
* As a returning purchaser (saved contact details + saved payment method), confirm the CTA is "Pay now" immediately, not "Continue".
* Confirm the Pay / Continue / PayPal buttons are all the same 50px height in the sidebar.