### PR TITLE
Domain bundles: typed mock fetcher + bundle card in search flow (domain-bundling flag)

### DIFF
--- a/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-props.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-props.ts
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { DomainSearch } from '@automattic/domain-search';
 import { ResponseCartProduct } from '@automattic/shopping-cart';
 import { useMemo, type ComponentProps, useCallback } from 'react';
@@ -75,6 +76,7 @@ export const useWPCOMDomainSearchProps = ( {
 	const config = useMemo( () => {
 		return {
 			...externalConfig,
+			showBundleSuggestions: isEnabled( 'domain-bundling' ),
 			priceRules: {
 				...externalConfig?.priceRules,
 				freeForFirstYear: isNextDomainFree,

--- a/config/development.json
+++ b/config/development.json
@@ -83,6 +83,7 @@
 		"dev/react-query-devtools": true,
 		"dev/store-sandbox-helper": true,
 		"dolly/telegram": true,
+		"domain-bundling": true,
 		"domain-transfer-redesign": true,
 		"email-accounts/enabled": true,
 		"entrepreneur/skip-trial-for-migration": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -35,6 +35,7 @@
 		"dashboard/v2/backport/site-overview": true,
 		"dashboard/wp-beta-program": true,
 		"design-picker/use-assembler-styles": true,
+		"domain-bundling": true,
 		"domain-transfer-redesign": true,
 		"google-my-business": false,
 		"help": true,

--- a/config/production.json
+++ b/config/production.json
@@ -47,6 +47,7 @@
 		"dashboard/v2/backport/site-overview": true,
 		"dashboard/wp-beta-program": true,
 		"dolly/telegram": true,
+		"domain-bundling": false,
 		"domain-transfer-redesign": true,
 		"google-my-business": true,
 		"help": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -49,6 +49,7 @@
 		"dev/preferences-helper": true,
 		"dev/store-sandbox-helper": true,
 		"dolly/telegram": true,
+		"domain-bundling": true,
 		"domain-transfer-redesign": true,
 		"email-accounts/enabled": true,
 		"google-my-business": true,

--- a/packages/api-core/src/domain-suggestions/__tests__/fetchers.test.ts
+++ b/packages/api-core/src/domain-suggestions/__tests__/fetchers.test.ts
@@ -1,0 +1,38 @@
+import { fetchBundleSuggestion } from '..';
+
+describe( 'fetchBundleSuggestion', () => {
+	it( 'returns a bundle suggestion shaped like the with_bundles payload', async () => {
+		const bundle = await fetchBundleSuggestion( 'example' );
+
+		expect( bundle ).not.toBeNull();
+		expect( bundle?.sld ).toBe( 'example' );
+		expect( bundle?.domains.length ).toBeGreaterThanOrEqual( 2 );
+
+		bundle?.domains.forEach( ( domain ) => {
+			expect( domain.domain.startsWith( 'example.' ) ).toBe( true );
+			expect( typeof domain.cost ).toBe( 'string' );
+			expect( typeof domain.raw_price ).toBe( 'number' );
+			expect( typeof domain.product_slug ).toBe( 'string' );
+		} );
+
+		expect( typeof bundle?.bundle_price ).toBe( 'number' );
+		expect( typeof bundle?.original_price ).toBe( 'number' );
+		expect( typeof bundle?.discount_percent ).toBe( 'number' );
+		expect( typeof bundle?.category ).toBe( 'string' );
+		expect( typeof bundle?.bundle_id ).toBe( 'string' );
+		expect( typeof bundle?.bundle_group_id ).toBe( 'string' );
+		expect( typeof bundle?.catalogue_version ).toBe( 'string' );
+	} );
+
+	it( 'derives the sld from a full-domain query', async () => {
+		const bundle = await fetchBundleSuggestion( 'MyBrand.com' );
+
+		expect( bundle?.sld ).toBe( 'mybrand' );
+		expect( bundle?.domains[ 0 ].domain ).toBe( 'mybrand.com' );
+	} );
+
+	it( 'returns null for an empty query', async () => {
+		expect( await fetchBundleSuggestion( '' ) ).toBeNull();
+		expect( await fetchBundleSuggestion( '   ' ) ).toBeNull();
+	} );
+} );

--- a/packages/api-core/src/domain-suggestions/fetchers.ts
+++ b/packages/api-core/src/domain-suggestions/fetchers.ts
@@ -83,7 +83,6 @@ export async function fetchAvailableTlds( search?: string, vendor?: string ): Pr
  * `with_bundles=1` payload (DOMAINS-2166) so the search flow can render the
  * bundle card end-to-end before the backend is wired up. M1b replaces the body
  * with a real network call without changing this signature.
- *
  * @param search The domain search query (an SLD or FQDN).
  * @returns A bundle suggestion, or null when no bundle applies.
  */

--- a/packages/api-core/src/domain-suggestions/fetchers.ts
+++ b/packages/api-core/src/domain-suggestions/fetchers.ts
@@ -1,5 +1,11 @@
 import { wpcom } from '../wpcom-fetcher';
-import type { DomainSuggestion, DomainSuggestionQuery, FreeDomainSuggestion } from './types';
+import type {
+	BundleSuggestion,
+	BundleSuggestionDomain,
+	DomainSuggestion,
+	DomainSuggestionQuery,
+	FreeDomainSuggestion,
+} from './types';
 
 export async function fetchDomainSuggestions(
 	search: string,
@@ -68,4 +74,59 @@ export async function fetchAvailableTlds( search?: string, vendor?: string ): Pr
 	);
 
 	return tlds;
+}
+
+/**
+ * Fetch a bundle suggestion for a search query.
+ *
+ * M1a placeholder: returns hardcoded fixture data shaped like the
+ * `with_bundles=1` payload (DOMAINS-2166) so the search flow can render the
+ * bundle card end-to-end before the backend is wired up. M1b replaces the body
+ * with a real network call without changing this signature.
+ *
+ * @param search The domain search query (an SLD or FQDN).
+ * @returns A bundle suggestion, or null when no bundle applies.
+ */
+export async function fetchBundleSuggestion( search: string ): Promise< BundleSuggestion | null > {
+	const sld = search.trim().toLowerCase().split( '.' )[ 0 ];
+
+	if ( ! sld ) {
+		return null;
+	}
+
+	const domains: BundleSuggestionDomain[] = [
+		{
+			domain: `${ sld }.com`,
+			cost: '$22.00',
+			raw_price: 22,
+			product_slug: 'domain_reg',
+			supports_privacy: true,
+		},
+		{
+			domain: `${ sld }.net`,
+			cost: '$18.00',
+			raw_price: 18,
+			product_slug: 'domain_reg',
+			supports_privacy: true,
+		},
+		{
+			domain: `${ sld }.org`,
+			cost: '$20.00',
+			raw_price: 20,
+			product_slug: 'domain_reg',
+			supports_privacy: true,
+		},
+	];
+
+	return {
+		sld,
+		domains,
+		bundle_price: 48,
+		original_price: 60,
+		discount_percent: 20,
+		category: 'business',
+		bundle_id: `${ sld }_business`,
+		bundle_group_id: `mock-${ sld }-group`,
+		catalogue_version: '1',
+	};
 }

--- a/packages/api-queries/src/domains.ts
+++ b/packages/api-queries/src/domains.ts
@@ -6,6 +6,7 @@ import {
 	DomainUpdateStatus,
 	fetchAvailableTlds,
 	fetchBulkDomainUpdateStatus,
+	fetchBundleSuggestion,
 	fetchDomains,
 	fetchDomainSuggestions,
 	fetchFreeDomainSuggestion,
@@ -39,6 +40,13 @@ export const freeSuggestionQuery = (
 	queryOptions( {
 		queryKey: [ 'free-suggestion', query, params ],
 		queryFn: () => fetchFreeDomainSuggestion( query, params ),
+		meta: { persist: false },
+	} );
+
+export const bundleSuggestionQuery = ( query: string ) =>
+	queryOptions( {
+		queryKey: [ 'bundle-suggestion', query ],
+		queryFn: () => fetchBundleSuggestion( query ),
 		meta: { persist: false },
 	} );
 

--- a/packages/domain-search/src/hooks/test/use-suggestions-list.tsx
+++ b/packages/domain-search/src/hooks/test/use-suggestions-list.tsx
@@ -1,0 +1,44 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import { mockGetSuggestionsQuery } from '../../test-helpers/queries/suggestions';
+import { queryClient, TestDomainSearch } from '../../test-helpers/renderer';
+import { useSuggestionsList } from '../use-suggestions-list';
+import type { DomainSearchConfig } from '../../page/types';
+
+const renderUseSuggestionsList = ( config?: Partial< DomainSearchConfig > ) =>
+	renderHook( () => useSuggestionsList(), {
+		wrapper: ( { children } ) => (
+			<TestDomainSearch query="test" config={ config }>
+				{ children }
+			</TestDomainSearch>
+		),
+	} );
+
+describe( 'useSuggestionsList — bundle suggestions', () => {
+	afterEach( () => {
+		nock.cleanAll();
+		queryClient.clear();
+	} );
+
+	it( 'surfaces a bundle suggestion when showBundleSuggestions is on', async () => {
+		mockGetSuggestionsQuery( { params: { query: 'test' }, suggestions: [] } );
+
+		const { result } = renderUseSuggestionsList( { showBundleSuggestions: true } );
+
+		await waitFor( () => expect( result.current.bundleSuggestion ).toBeTruthy() );
+		expect( result.current.bundleSuggestion?.sld ).toBe( 'test' );
+		expect( result.current.bundleSuggestion?.domains.length ).toBeGreaterThan( 0 );
+	} );
+
+	it( 'does not surface a bundle suggestion when the flag is off', async () => {
+		mockGetSuggestionsQuery( { params: { query: 'test' }, suggestions: [] } );
+
+		const { result } = renderUseSuggestionsList( { showBundleSuggestions: false } );
+
+		await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+		expect( result.current.bundleSuggestion ).toBeUndefined();
+	} );
+} );

--- a/packages/domain-search/src/hooks/use-suggestions-list.ts
+++ b/packages/domain-search/src/hooks/use-suggestions-list.ts
@@ -77,10 +77,12 @@ export const useSuggestionsList = () => {
 		} ) ),
 	} );
 
-	const { isLoadingAvailablePremiumDomains, availablePremiumDomains } = useMemo(
-		() => availablePremiumDomainsCombinator( availabilityResults ),
-		[ availabilityResults ]
-	);
+	// Derived inline (not memoized): availabilityResults is a fresh array each
+	// render, so memoizing on it gains nothing and trips @tanstack/query's
+	// no-unstable-deps rule. Recomputing every render matches the previous
+	// behaviour exactly.
+	const { isLoadingAvailablePremiumDomains, availablePremiumDomains } =
+		availablePremiumDomainsCombinator( availabilityResults );
 
 	const isLoading =
 		isLoadingSuggestions ||

--- a/packages/domain-search/src/hooks/use-suggestions-list.ts
+++ b/packages/domain-search/src/hooks/use-suggestions-list.ts
@@ -49,6 +49,14 @@ export const useSuggestionsList = () => {
 		enabled: config.skippable && ! isFqdnQuery,
 	} );
 
+	// Bundle suggestions are gated behind the frontend `domain-bundling` flag
+	// (surfaced as config.showBundleSuggestions). When off, the query never runs
+	// and bundleSuggestion stays undefined, leaving the rest of the flow unchanged.
+	const { data: bundleSuggestion } = useQuery( {
+		...queries.bundleSuggestion( query ),
+		enabled: config.showBundleSuggestions,
+	} );
+
 	const { isLoading: isLoadingQueryAvailability, data: fqdnAvailability } = useQuery( {
 		...queries.domainAvailability( query ),
 		enabled: isFqdnQuery,
@@ -123,5 +131,6 @@ export const useSuggestionsList = () => {
 		isLoading,
 		featuredSuggestions,
 		regularSuggestions,
+		bundleSuggestion,
 	};
 };

--- a/packages/domain-search/src/page/context.ts
+++ b/packages/domain-search/src/page/context.ts
@@ -1,5 +1,6 @@
 import {
 	availableTldsQuery,
+	bundleSuggestionQuery,
 	domainAvailabilityQuery,
 	domainSuggestionsQuery,
 	freeSuggestionQuery,
@@ -45,6 +46,7 @@ export const DEFAULT_CONTEXT_VALUE: DomainSearchContextType = {
 			domainSuggestionsQuery( query, params ),
 		domainAvailability: ( domainName: string ) => domainAvailabilityQuery( domainName ),
 		freeSuggestion: ( query: string ) => freeSuggestionQuery( query ),
+		bundleSuggestion: ( query: string ) => bundleSuggestionQuery( query ),
 	},
 	cart: {
 		items: [],
@@ -67,6 +69,7 @@ export const DEFAULT_CONTEXT_VALUE: DomainSearchContextType = {
 		includeOwnedDomainInSuggestions: false,
 		allowedTlds: [],
 		numberOfDomainsResultsPerPage: 10,
+		showBundleSuggestions: false,
 		priceRules: {
 			hidePrice: false,
 			oneTimePrice: false,
@@ -159,6 +162,13 @@ export const useDomainSearchContextValue = ( {
 						include_dotblogsubdomain:
 							normalizedConfig.includeDotBlogSubdomain && isBlogSubdomainQuery( query ),
 					} ),
+					enabled: false,
+					staleTime: Infinity,
+					refetchOnMount: false,
+					refetchOnWindowFocus: false,
+				} ),
+				bundleSuggestion: ( query ) => ( {
+					...bundleSuggestionQuery( query ),
 					enabled: false,
 					staleTime: Infinity,
 					refetchOnMount: false,

--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -2,6 +2,7 @@ import { __experimentalVStack as VStack } from '@wordpress/components';
 import { chevronDown, chevronUp, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useState } from 'react';
+import { BundleCard } from '../components/bundle-card';
 import { Cart } from '../components/cart';
 import { FeaturedSearchResults } from '../components/featured-search-results';
 import { SearchBar } from '../components/search-bar';
@@ -50,6 +51,7 @@ export const ResultsPage = () => {
 		isLoading: isLoadingSuggestions,
 		featuredSuggestions,
 		regularSuggestions,
+		bundleSuggestion,
 	} = useSuggestionsList();
 	const numberOfInitialVisibleSuggestions =
 		config.numberOfDomainsResultsPerPage - featuredSuggestions.length;
@@ -95,6 +97,9 @@ export const ResultsPage = () => {
 					<FeaturedSearchResults.Placeholder />
 				) : (
 					<FeaturedSearchResults suggestions={ featuredSuggestions } />
+				) }
+				{ ! isLoadingSuggestions && bundleSuggestion && (
+					<BundleCard suggestion={ bundleSuggestion } />
 				) }
 				{ isLoadingSuggestions ? (
 					<SearchResults.Placeholder />

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -1,5 +1,6 @@
 import {
 	availableTldsQuery,
+	bundleSuggestionQuery,
 	domainSuggestionsQuery,
 	freeSuggestionQuery,
 	domainAvailabilityQuery,
@@ -86,6 +87,12 @@ export interface DomainSearchConfig {
 	allowedTlds: string[];
 	includeOwnedDomainInSuggestions: boolean;
 	numberOfDomainsResultsPerPage: number;
+	/**
+	 * Show domain bundle suggestions in the search flow. Frontend dev/Storybook
+	 * gate, set from the `domain-bundling` feature flag at the app layer. Default
+	 * false, so bundles stay hidden unless a consumer opts in.
+	 */
+	showBundleSuggestions: boolean;
 }
 
 export interface DomainSearchProps {
@@ -124,6 +131,7 @@ export interface DomainSearchContextType
 		) => ReturnType< typeof domainSuggestionsQuery >;
 		domainAvailability: ( domainName: string ) => ReturnType< typeof domainAvailabilityQuery >;
 		freeSuggestion: ( query: string ) => ReturnType< typeof freeSuggestionQuery >;
+		bundleSuggestion: ( query: string ) => ReturnType< typeof bundleSuggestionQuery >;
 	};
 	config: DomainSearchConfig;
 }


### PR DESCRIPTION
## What & why

Related to DOMAINS-2172

Adds a typed mock fetcher for bundle suggestions so the search flow can render the bundle card (from the previous issue) end-to-end against fixtures, before the backend is ready. M1b swaps the fixture for a real `with_bundles=1` call without changing the type signature.

## Changes

- **`api-core`** — `fetchBundleSuggestion( search )` returns hardcoded fixture data shaped like the DOMAINS-2166 payload (variable-length `domains[]`, prices, discount, category, ids, faked `bundle_group_id`, catalogue version). No network call.
- **`api-queries`** — `bundleSuggestionQuery` wrapping the fetcher.
- **`domain-search`** — new `showBundleSuggestions` config field (default `false`); a `bundleSuggestion` query in the context; `useSuggestionsList` runs it only when the flag is on and surfaces it; `results.tsx` renders `<BundleCard>` when present.
- **App layer** — `use-wpcom-domain-search-props` sets `showBundleSuggestions` from the new `domain-bundling` Calypso feature flag. One place, covers every search surface that mounts through `WPCOMDomainSearch` (signup, stepper, my-sites).

<img width="1227" height="1025" alt="CleanShot 2026-06-04 at 11 24 50" src="https://github.com/user-attachments/assets/35f50dcd-af75-4cce-8c36-6f666eb00f1a" />


## Feature flag

`domain-bundling`: `true` in `development`/`wpcalypso`/`horizon` (dev + Storybook visibility), `false` in `production`, default-off everywhere else. The `@automattic/domain-search` package never imports `calypso-config` — it gates on the `showBundleSuggestions` config field, which the app layer feeds from the flag, keeping the package portable.

Check the flag's status across environments with:

```
yarn run feature-search domain-bundling
```

## Testing

- `api-core`: `fetchBundleSuggestion` returns the right shape / derives the sld / returns null for empty.
- `domain-search`: `useSuggestionsList` surfaces the bundle when the flag is on and leaves it `undefined` when off.
- Confirm the flag is enabled where you expect: `yarn run feature-search domain-bundling`.

> [!WARNING]
> **Local jest/tsc/eslint were not run** — this was built in a fresh git worktree without `node_modules`, and a full `yarn install` wasn't feasible in-session. Relying on CI for typecheck/lint/test. Please confirm CI is green before review.

To see it locally: `domain-bundling` is on in `development`, so the bundle card renders in the search flow (and in the BundleCard Storybook).

Related to #DOMAINS-2172