### PR TITLE
Mark packages/calypso-products as deprecated/avoid for AI agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@
 - **Help Center** (`packages/help-center`) — shared component library for WordPress.com support. Also deployed via `apps/help-center/` to `widgets.wp.com`.
 - **Image Studio** (`packages/image-studio`) — AI-powered image editing and generation
 - **Block Notes** (`packages/block-notes`) — AI-powered block commenting system for WordPress
+- **Calypso Products** (`packages/calypso-products`) — ⚠️ **Avoid.** Deprecated/frozen: a bloated client-side duplicate of product data the backend already owns. Don't add to it; prefer backend-driven data (e.g. `@automattic/api-queries`). See `packages/calypso-products/AGENTS.md`.
 
 ## Apps
 

--- a/packages/calypso-products/AGENTS.md
+++ b/packages/calypso-products/AGENTS.md
@@ -1,0 +1,22 @@
+# @automattic/calypso-products
+
+This module contains hardcoded information about the various products sold within Calypso — product slugs, plan intervals, feature lists, and a large collection of `is-*` predicate helpers.
+
+## ⚠️ AVOID adding to or depending on this package
+
+**For AI agents and contributors: treat this package as deprecated/frozen. Do not reach for it by default, and do not grow it.**
+
+This package is very large and bloated. It acts as a **second, client-side source of truth** for product data that the backend already knows in most cases. Hardcoding product knowledge here means it drifts from the backend, must be manually maintained for every new product or plan, and ships unnecessary bytes to every client that imports it.
+
+### What this means in practice
+
+- **Do not add new files or helpers here** (e.g. another `is-some-new-product.ts`, slug constant, or feature-list entry). New product logic belongs on the backend.
+- **Prefer fetching product/plan/feature data from the backend** over deriving it client-side. Use the relevant API queries (e.g. `@automattic/api-queries`) so the server stays the source of truth.
+- **When touching code that imports from `@automattic/calypso-products`**, treat it as an opportunity to migrate the logic to the backend or to a backend-driven query, rather than extending the client-side duplication.
+- **Only use existing exports when there is genuinely no backend-driven alternative** and the data is static/build-time constant. If you must, reuse what already exists rather than adding more.
+
+### Why it's hard to remove
+
+Much of Calypso still imports from here, so the package can't simply be deleted. The goal is to **stop the bleeding**: don't add to it, and chip away at existing usages by moving the logic server-side whenever you're already in the area.
+
+If you believe a genuinely new client-side product helper is unavoidable, surface that explicitly and explain why the backend can't own it — don't add it silently.

--- a/packages/calypso-products/CLAUDE.md
+++ b/packages/calypso-products/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
Fixes [SHILL-2093](https://linear.app/a8c/issue/SHILL-2093/mark-automatticcalypso-products-as-deprecatedavoid-for-ai-agents-and)

## Proposed Changes

* Add `packages/calypso-products/AGENTS.md` marking the package as deprecated/frozen, telling agents and contributors not to add to it and to prefer backend-driven product data (e.g. `@automattic/api-queries`).
* Add `packages/calypso-products/CLAUDE.md` (`@AGENTS.md`) so Claude Code auto-loads the guidance, matching the convention used by other packages.
* Add a short pointer in the root `AGENTS.md` Packages section so the steer is visible to agents that never open the package directory.

## Why are these changes being made?

`@automattic/calypso-products` is very large and bloated. It acts as a second, client-side source of truth for product data the backend already knows in most cases — drifting from the backend, requiring manual maintenance for every new product/plan, and shipping unnecessary bytes. These markers stop the bleeding: discourage adding to the package and nudge new/changed logic toward the backend.

## Testing Instructions

* Docs-only change. Confirm the files render correctly and the root `AGENTS.md` pointer links to `packages/calypso-products/AGENTS.md`.


