### PR TITLE
A4A Agency Tier: translate the emerging-partner tier description

### DIFF
--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/constants.ts
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/constants.ts
@@ -28,7 +28,7 @@ export const ALL_TIERS: TierItem[] = [
 		level: 0,
 		id: 'emerging-partner',
 		name: __( 'Account activated' ),
-		description: 'Joining the program',
+		description: __( 'Joining the program' ),
 		heading: __( 'Essential benefits' ),
 		subheading: __( 'Tools, earning opportunities, support & training and more' ),
 		influencedRevenue: TARGET_INFLUENCED_REVENUE[ 'agency-partner' ],


### PR DESCRIPTION
Part of A4A-2718

## Proposed Changes

* Wrap the emerging-partner tier `description` ("Joining the program") in `__()` in `client/a8c-for-agencies/sections/agency-tier/overview-content/constants.ts`. It was the only field in that file not going through the translation wrapper.

## Why are these changes being made?

* The string showed in English on non-English locales. I caught it in a Spanish pass of the A4A portal. Every sibling field already uses `__()`, so this was a one-field miss. This adds a new translatable string, so it likely needs the "[Status] String Freeze" label.

## Testing Instructions

* Set your account interface language to Spanish (or any non-English locale).
* Open the Agency Tier page.
* The `Account activated` card should show the string `Joining the program`. For now it'll continue displaying in English until the translations come back.

<img width="525" height="245" alt="Screenshot 2026-06-04 at 11 25 48 AM" src="https://github.com/user-attachments/assets/9e6af386-74e7-4e62-9439-ebd448d31d3a" />


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Crafted by Travbot (Claude Code)
