### PR TITLE
Dashboard: enable interim omnibar in all environments

### DIFF
--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -23,6 +23,9 @@ import WooCommerceLogo from 'calypso/components/woocommerce-logo';
 import { InterimOmnibar } from 'calypso/dashboard/app/interim-omnibar/interim-omnibar';
 import { InitialOmnibar } from 'calypso/dashboard/app/omnibar/omnibar';
 import { getDashboardStepperLogo } from 'calypso/dashboard/app/stepper-logo';
+import { CIAB_DASHBOARD_SECTION_DEFINITION } from 'calypso/dashboard/app-ciab/section';
+import { DOTCOM_DASHBOARD_SECTION_DEFINITION } from 'calypso/dashboard/app-dotcom/section';
+import isDashboardEnv from 'calypso/dashboard/utils/is-dashboard-env';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { isGravPoweredOAuth2Client, isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { jsonStringifyForHtml } from 'calypso/server/sanitize';
@@ -105,6 +108,11 @@ class Document extends Component {
 
 		const isRTL = isLocaleRtl( lang );
 
+		const isDashboardOmnibarPage =
+			( isDashboardEnv() || env === 'development' ) &&
+			( sectionName === DOTCOM_DASHBOARD_SECTION_DEFINITION.name ||
+				sectionName === CIAB_DASHBOARD_SECTION_DEFINITION.name );
+
 		let headTitle = head.title;
 		let headFaviconUrl;
 		let isWCCOM = false;
@@ -164,12 +172,12 @@ class Document extends Component {
 					} ) }
 				>
 					{ /* eslint-disable wpcalypso/jsx-classname-namespace, react/no-danger */ }
-					{ dashboard && config.isEnabled( 'dashboard/omnibar-radical' ) && (
+					{ isDashboardOmnibarPage && config.isEnabled( 'dashboard/omnibar-radical' ) && (
 						<div id="wpcom-omnibar">
 							<InitialOmnibar user={ user } />
 						</div>
 					) }
-					{ dashboard &&
+					{ isDashboardOmnibarPage &&
 						config.isEnabled( 'dashboard/omnibar' ) &&
 						! config.isEnabled( 'dashboard/omnibar-radical' ) && (
 							<div id="wpcom-omnibar">

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -26,7 +26,7 @@
 		"ciab/custom-branding": true,
 		"cookie-banner": true,
 		"dark-mode": true,
-		"dashboard/omnibar": false,
+		"dashboard/omnibar": true,
 		"dashboard/v2": false,
 		"dashboard/wp-beta-program": true,
 		"domain-transfer-redesign": true,

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -25,7 +25,7 @@
 		"ciab/custom-branding": true,
 		"cookie-banner": false,
 		"dark-mode": true,
-		"dashboard/omnibar": false,
+		"dashboard/omnibar": true,
 		"dashboard/v2": false,
 		"dashboard/wp-beta-program": true,
 		"dev/store-sandbox-helper": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -28,7 +28,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dark-mode": false,
-		"dashboard/omnibar": false,
+		"dashboard/omnibar": true,
 		"dashboard/opt-in-banners": false,
 		"dashboard/plans": true,
 		"dashboard/v2": true,

--- a/config/production.json
+++ b/config/production.json
@@ -41,7 +41,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dark-mode": false,
-		"dashboard/omnibar": false,
+		"dashboard/omnibar": true,
 		"dashboard/opt-in-banners": false,
 		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -38,7 +38,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dark-mode": false,
-		"dashboard/omnibar": false,
+		"dashboard/omnibar": true,
 		"dashboard/opt-in-banners": false,
 		"dashboard/v2": true,
 		"dashboard/v2/backport/site-overview": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -37,7 +37,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dark-mode": false,
-		"dashboard/omnibar": false,
+		"dashboard/omnibar": true,
 		"dashboard/opt-in-banners": false,
 		"dashboard/plans": true,
 		"dashboard/v2": true,


### PR DESCRIPTION
## Proposed Changes

* Enable the `dashboard/omnibar` feature flag (interim omnibar) in all remaining environments: production, dashboard-production, stage, dashboard-stage, horizon, and wpcalypso.

It was already enabled in development/dashboard-development/dashboard-horizon. `dashboard/omnibar-radical` is untouched.

## Why are these changes being made?

* The interim omnibar has been validated in dev environments and is ready to ship everywhere. We are still working on the launch button (#111034) but it's not really a blocker to enabling the interim omnibar.

## Testing Instructions

* Load the Dashboard in each environment and confirm the interim omnibar renders in the `#wpcom-omnibar` slot.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
