### PR TITLE
Checkout: stack available wallet buttons (Apple Pay, Google Pay) in the sidebar

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import {
 	isYearly,
 	isJetpackPurchasableItem,
@@ -341,6 +342,12 @@ function CheckoutSidebarNudge( {
 	);
 }
 
+// Wallet payment methods promoted to stacked one-tap buttons in the summary
+// sidebar, above the main Pay/Continue button. Checkout only renders the ones
+// that are actually available (created and not filtered out). Order here is the
+// stacking order. paypal-js (PPCP) is intentionally excluded — it is legacy.
+const SIDEBAR_EXPRESS_PAYMENT_METHOD_IDS = [ 'apple-pay', 'google-pay', 'paypal-express' ];
+
 // Renders CheckoutFormSubmit inside CheckoutStepGroup (so it keeps full step-state
 // awareness) while portaling its output into the sidebar slot registered via
 // SubmitButtonSlotContext. The sidebar button IS the active payment-method submit
@@ -354,8 +361,15 @@ function PortaledCheckoutFormSubmit( {
 	if ( ! slotEl ) {
 		return null;
 	}
+	const expressPaymentMethodIds = isEnabled( 'checkout/sidebar-express-payment-buttons' )
+		? SIDEBAR_EXPRESS_PAYMENT_METHOD_IDS
+		: [];
 	return createPortal(
-		<CheckoutFormSubmit validateForm={ validateForm } continueToNextIncompleteStep />,
+		<CheckoutFormSubmit
+			validateForm={ validateForm }
+			continueToNextIncompleteStep
+			expressPaymentMethodIds={ expressPaymentMethodIds }
+		/>,
 		slotEl
 	);
 }

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -345,8 +345,13 @@ function CheckoutSidebarNudge( {
 // Wallet payment methods promoted to stacked one-tap buttons in the summary
 // sidebar, above the main Pay/Continue button. Checkout only renders the ones
 // that are actually available (created and not filtered out). Order here is the
-// stacking order. paypal-js (PPCP) is intentionally excluded — it is legacy.
-const SIDEBAR_EXPRESS_PAYMENT_METHOD_IDS = [ 'apple-pay', 'google-pay', 'paypal-express' ];
+// stacking order.
+//
+// PayPal is intentionally omitted: the current PayPal method (paypal-js) only
+// renders its button when it is the actively-selected method — it caches the
+// PayPal Buttons click handler, so it cannot be shown as an always-visible
+// express button without reworking that component. Tracked as a follow-up.
+const SIDEBAR_EXPRESS_PAYMENT_METHOD_IDS = [ 'apple-pay', 'google-pay' ];
 
 // Renders CheckoutFormSubmit inside CheckoutStepGroup (so it keeps full step-state
 // awareness) while portaling its output into the sidebar slot registered via

--- a/client/my-sites/checkout/src/components/checkout-submit-button-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-submit-button-content.tsx
@@ -2,6 +2,7 @@ import { MaterialIcon } from '@automattic/components';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { styled } from '@automattic/wpcom-checkout';
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import useCartKey from '../../use-cart-key';
 
@@ -28,7 +29,7 @@ const StyledMaterialIcon = styled( MaterialIcon )`
  * There are also checkout-like forms (eg: "add credit card") which do not use
  * this because they want their submit button to render something different.
  */
-export function CheckoutSubmitButtonContent() {
+export function CheckoutSubmitButtonContent( { last4 }: { last4?: string } = {} ) {
 	const { __ } = useI18n();
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
@@ -50,7 +51,10 @@ export function CheckoutSubmitButtonContent() {
 	return (
 		<CreditCardPayButtonWrapper>
 			<StyledMaterialIcon icon="credit_card" />
-			{ __( 'Pay now' ) }
+			{ last4
+				? /* translators: %s is the last 4 digits of the saved card, e.g. "Pay with 3220" */
+				  sprintf( __( 'Pay with %s' ), last4 )
+				: __( 'Pay now' ) }
 		</CreditCardPayButtonWrapper>
 	);
 }

--- a/client/my-sites/checkout/src/components/checkout-submit-button-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-submit-button-content.tsx
@@ -30,7 +30,7 @@ const StyledMaterialIcon = styled( MaterialIcon )`
  * this because they want their submit button to render something different.
  */
 export function CheckoutSubmitButtonContent( { last4 }: { last4?: string } = {} ) {
-	const { __ } = useI18n();
+	const { __, _x } = useI18n();
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
 	const isPurchaseFree = responseCart.total_cost_integer === 0;
@@ -52,8 +52,12 @@ export function CheckoutSubmitButtonContent( { last4 }: { last4?: string } = {} 
 		<CreditCardPayButtonWrapper>
 			<StyledMaterialIcon icon="credit_card" />
 			{ last4
-				? /* translators: %s is the last 4 digits of the saved card, e.g. "Pay with 3220" */
-				  sprintf( __( 'Pay with %s' ), last4 )
+				? sprintf(
+						/* translators: %s is the masked saved card number, e.g. "**** 3220" */
+						__( 'Pay with %s' ),
+						/* translators: %s is the last 4 digits of the credit card number */
+						sprintf( _x( '**** %s', 'Masked credit card number' ), last4 )
+				  )
 				: __( 'Pay now' ) }
 		</CreditCardPayButtonWrapper>
 	);

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -720,6 +720,7 @@ const CheckoutSummaryPayButtonSlot = styled.div`
 		width: 100%;
 		height: 50px;
 		box-sizing: border-box;
+		margin-block-end: 6px;
 	}
 `;
 const CheckoutSummaryFeatures = styled.div`

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -461,7 +461,7 @@ export default function useCreatePaymentMethods( {
 		isStripeLoading,
 		stripeLoadingError,
 		storedCards,
-		submitButtonContent: <CheckoutSubmitButtonContent />,
+		submitButtonContent: ( card ) => <CheckoutSubmitButtonContent last4={ card.card_last_4 } />,
 	} );
 
 	const existingPayPalPPCPMethods = useCreateExistingPayPalPPCP( {

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/use-create-existing-cards.ts
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/use-create-existing-cards.ts
@@ -18,7 +18,7 @@ export default function useCreateExistingCards( {
 	isStripeLoading: boolean;
 	stripeLoadingError: StripeLoadingError;
 	storedCards: StoredPaymentMethod[];
-	submitButtonContent: ReactNode;
+	submitButtonContent: ReactNode | ( ( card: StoredPaymentMethodCard ) => ReactNode );
 	allowEditingTaxInfo?: boolean;
 	isTaxInfoRequired?: boolean;
 } ): PaymentMethod[] {
@@ -53,7 +53,10 @@ export default function useCreateExistingCards( {
 					storedDetailsId: storedDetails.stored_details_id,
 					paymentMethodToken: storedDetails.mp_ref,
 					paymentPartnerProcessorId: storedDetails.payment_partner,
-					submitButtonContent,
+					submitButtonContent:
+						typeof submitButtonContent === 'function'
+							? submitButtonContent( storedDetails )
+							: submitButtonContent,
 					allowEditingTaxInfo,
 					isTaxInfoRequired,
 				} )

--- a/client/my-sites/checkout/src/test/existing-credit-card.tsx
+++ b/client/my-sites/checkout/src/test/existing-credit-card.tsx
@@ -219,7 +219,7 @@ describe( 'Existing credit card payment methods', () => {
 			></TestWrapper>
 		);
 		await waitFor( () => {
-			expect( screen.getByText( `Pay with ${ last4 }` ) ).toBeVisible();
+			expect( screen.getByText( `Pay with **** ${ last4 }` ) ).toBeVisible();
 		} );
 	} );
 } );

--- a/client/my-sites/checkout/src/test/existing-credit-card.tsx
+++ b/client/my-sites/checkout/src/test/existing-credit-card.tsx
@@ -9,14 +9,39 @@ import {
 	makeSuccessResponse,
 	CheckoutFormSubmit,
 } from '@automattic/composite-checkout';
+import { getEmptyResponseCart } from '@automattic/shopping-cart';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { useMemo } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
+import { CheckoutSubmitButtonContent } from 'calypso/my-sites/checkout/src/components/checkout-submit-button-content';
 import { createExistingCardMethod } from 'calypso/my-sites/checkout/src/payment-methods/existing-credit-card';
 import { createReduxStore } from 'calypso/state';
+
+const mockResponseCart = {
+	...getEmptyResponseCart(),
+	total_cost_integer: 15600,
+	sub_total_integer: 15600,
+	currency: 'USD',
+};
+
+jest.mock( 'calypso/my-sites/checkout/use-cart-key', () => ( {
+	__esModule: true,
+	default: () => 'no-site',
+} ) );
+
+jest.mock( '@automattic/shopping-cart', () => {
+	const actual = jest.requireActual( '@automattic/shopping-cart' );
+	return {
+		...actual,
+		useShoppingCart: () => ( {
+			...actual.emptyCart,
+			responseCart: mockResponseCart,
+		} ),
+	};
+} );
 
 function TestWrapper( { paymentMethods, paymentProcessors = undefined } ) {
 	const store = createReduxStore();
@@ -176,6 +201,25 @@ describe( 'Existing credit card payment methods', () => {
 		await userEvent.click( await screen.findByText( activePayButtonText ) );
 		await waitFor( () => {
 			expect( existingCardProcessor ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	it( 'renders "Pay with <last4>" on the submit button when CheckoutSubmitButtonContent is given a last4 prop', async () => {
+		mockTaxLocationEndpoint();
+		const last4 = '4242';
+		const existingCard = getExistingCardPaymentMethod( {
+			submitButtonContent: <CheckoutSubmitButtonContent last4={ last4 } />,
+		} );
+		render(
+			<TestWrapper
+				paymentMethods={ [ existingCard ] }
+				paymentProcessors={ {
+					[ existingCard.paymentProcessorId ]: () => makeSuccessResponse( 'ok' ),
+				} }
+			></TestWrapper>
+		);
+		await waitFor( () => {
+			expect( screen.getByText( `Pay with ${ last4 }` ) ).toBeVisible();
 		} );
 	} );
 } );

--- a/config/development.json
+++ b/config/development.json
@@ -60,6 +60,7 @@
 		"calypso/refund-eligibility-notice": false,
 		"checkout/checkout-version": true,
 		"checkout/google-pay": true,
+		"checkout/sidebar-express-payment-buttons": true,
 		"checkout/stripe-upi": true,
 		"ciab/allow-domain-features": true,
 		"ciab/custom-branding": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -21,6 +21,7 @@
 		"catch-js-errors": true,
 		"checkout/checkout-version": false,
 		"checkout/google-pay": true,
+		"checkout/sidebar-express-payment-buttons": false,
 		"checkout/stripe-upi": true,
 		"ciab/allow-domain-features": true,
 		"ciab/custom-branding": true,

--- a/config/production.json
+++ b/config/production.json
@@ -34,6 +34,7 @@
 		"catch-js-errors": true,
 		"checkout/checkout-version": false,
 		"checkout/google-pay": true,
+		"checkout/sidebar-express-payment-buttons": false,
 		"checkout/stripe-upi": true,
 		"ciab/allow-domain-features": true,
 		"ciab/custom-branding": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -31,6 +31,7 @@
 		"catch-js-errors": true,
 		"checkout/checkout-version": true,
 		"checkout/google-pay": true,
+		"checkout/sidebar-express-payment-buttons": false,
 		"checkout/stripe-upi": true,
 		"ciab/allow-domain-features": true,
 		"ciab/custom-branding": true,

--- a/config/test.json
+++ b/config/test.json
@@ -30,6 +30,7 @@
 		"catch-js-errors": false,
 		"checkout/checkout-version": false,
 		"checkout/google-pay": true,
+		"checkout/sidebar-express-payment-buttons": false,
 		"checkout/stripe-upi": true,
 		"cookie-banner": false,
 		"current-site/domain-warning": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -30,6 +30,7 @@
 		"catch-js-errors": false,
 		"checkout/checkout-version": true,
 		"checkout/google-pay": true,
+		"checkout/sidebar-express-payment-buttons": false,
 		"checkout/stripe-upi": true,
 		"ciab/allow-domain-features": true,
 		"ciab/custom-branding": true,

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -685,6 +685,7 @@ export function CheckoutFormSubmit( {
 	submitButton,
 	onPageLoadError,
 	continueToNextIncompleteStep,
+	expressPaymentMethodIds,
 }: {
 	validateForm?: () => Promise< boolean >;
 	submitButtonHeader?: ReactNode;
@@ -693,6 +694,7 @@ export function CheckoutFormSubmit( {
 	submitButton?: ReactNode;
 	onPageLoadError?: CheckoutPageErrorCallback;
 	continueToNextIncompleteStep?: boolean;
+	expressPaymentMethodIds?: string[];
 } ) {
 	const { __ } = useI18n();
 	const { state, actions } = useContext( CheckoutStepGroupContext );
@@ -850,6 +852,7 @@ export function CheckoutFormSubmit( {
 						validateForm={ wrappedValidateForm }
 						disabled={ isDisabled }
 						onLoadError={ onSubmitButtonLoadError }
+						expressPaymentMethodIds={ expressPaymentMethodIds }
 					/>
 				)
 			) }

--- a/packages/composite-checkout/src/components/checkout-submit-button.tsx
+++ b/packages/composite-checkout/src/components/checkout-submit-button.tsx
@@ -24,21 +24,35 @@ export default function CheckoutSubmitButton( {
 	className,
 	disabled,
 	onLoadError,
+	expressPaymentMethodIds = [],
 }: {
 	validateForm?: () => Promise< boolean >;
 	className?: string;
 	disabled?: boolean;
 	onLoadError?: ( error: Error ) => void;
+	expressPaymentMethodIds?: string[];
 } ) {
 	const paymentMethods = useAllPaymentMethods();
 
+	const isExpress = ( paymentMethod: PaymentMethod ) =>
+		expressPaymentMethodIds.includes( paymentMethod.id );
+
+	// Render express-eligible methods first so they stack above the active
+	// method's button in the sidebar. Relative order within each group is
+	// preserved. When expressPaymentMethodIds is empty this is a no-op.
+	const orderedPaymentMethods = [
+		...paymentMethods.filter( isExpress ),
+		...paymentMethods.filter( ( paymentMethod ) => ! isExpress( paymentMethod ) ),
+	];
+
 	return (
 		<>
-			{ paymentMethods.map( ( paymentMethod ) => {
+			{ orderedPaymentMethods.map( ( paymentMethod ) => {
 				return (
 					<CheckoutSubmitButtonForPaymentMethod
 						key={ paymentMethod.id }
 						paymentMethod={ paymentMethod }
+						isExpress={ isExpress( paymentMethod ) }
 						validateForm={ validateForm }
 						className={ className }
 						disabled={ disabled }
@@ -52,12 +66,14 @@ export default function CheckoutSubmitButton( {
 
 function CheckoutSubmitButtonForPaymentMethod( {
 	paymentMethod,
+	isExpress,
 	validateForm,
 	className,
 	disabled,
 	onLoadError,
 }: {
 	paymentMethod: PaymentMethod;
+	isExpress: boolean;
 	validateForm?: () => Promise< boolean >;
 	className?: string;
 	disabled?: boolean;
@@ -66,14 +82,19 @@ function CheckoutSubmitButtonForPaymentMethod( {
 	const handlePaymentProcessorPromise = useHandlePaymentProcessorResponse();
 	const [ activePaymentMethodId ] = usePaymentMethodId();
 	const isActive = paymentMethod.id === activePaymentMethodId;
+	// Express methods are shown and clickable even when they are not the
+	// actively-selected method, so the sidebar can offer them as one-tap
+	// alternatives. Non-express methods only show when active (the others stay
+	// hidden via the --inactive class).
+	const isShown = isActive || isExpress;
 	const { formStatus } = useFormStatus();
 	const { __ } = useI18n();
-	const isDisabled = disabled || formStatus !== FormStatus.READY || ! isActive;
+	const isDisabled = disabled || formStatus !== FormStatus.READY || ! isShown;
 	const onClick = useProcessPayment( paymentMethod?.paymentProcessorId ?? '' );
 	const onClickWithValidation: ProcessPayment = async (
 		processorData: PaymentProcessorSubmitData
 	) => {
-		if ( ! isActive ) {
+		if ( ! isShown ) {
 			const rejection = Promise.resolve(
 				makeErrorResponse( __( 'This payment method is not currently available.' ) )
 			);
@@ -133,7 +154,7 @@ function CheckoutSubmitButtonForPaymentMethod( {
 				className={ joinClasses( [
 					className,
 					'checkout-submit-button',
-					isActive ? 'checkout-submit-button--active' : 'checkout-submit-button--inactive',
+					isShown ? 'checkout-submit-button--active' : 'checkout-submit-button--inactive',
 				] ) }
 			>
 				{ clonedSubmitButton }

--- a/packages/composite-checkout/test/checkout.tsx
+++ b/packages/composite-checkout/test/checkout.tsx
@@ -991,6 +991,116 @@ describe( 'Checkout', () => {
 		} );
 	} );
 
+	describe( 'with expressPaymentMethodIds', function () {
+		const steps = createMockStepObjects();
+		// steps[0] = summary (no step number)
+		// steps[1] = numbered, complete (isCompleteCallback () => true)
+		// steps[3] = numbered, incomplete (isCompleteCallback () => false)
+
+		const cardMethod = {
+			...createMockMethod( { submitButton: <MockSubmitButton content="Pay with Card" /> } ),
+			id: 'card',
+		};
+		const applePayMethod = {
+			...createMockMethod( { submitButton: <MockSubmitButton content="Apple Pay" /> } ),
+			id: 'apple-pay',
+		};
+
+		function ExpressCheckout( {
+			expressIds,
+			checkoutSteps,
+		}: {
+			expressIds: string[];
+			checkoutSteps: ReturnType< typeof createMockStepObjects >;
+		} ) {
+			const [ paymentData, setPaymentData ] = useState( {} );
+			const { stepObjectsWithStepNumber, stepObjectsWithoutStepNumber } =
+				createStepsFromStepObjects( checkoutSteps );
+			const createStepFromStepObject = createStepObjectConverter( paymentData );
+			return (
+				<myContext.Provider value={ [ paymentData, setPaymentData ] }>
+					<CheckoutProvider
+						paymentMethods={ [ cardMethod, applePayMethod ] }
+						paymentProcessors={ getMockPaymentProcessors() }
+						selectFirstAvailablePaymentMethod
+					>
+						<CheckoutStepGroup>
+							{ stepObjectsWithoutStepNumber.map( createStepFromStepObject ) }
+							{ stepObjectsWithStepNumber.map( createStepFromStepObject ) }
+							<CheckoutFormSubmit
+								continueToNextIncompleteStep
+								expressPaymentMethodIds={ expressIds }
+							/>
+						</CheckoutStepGroup>
+					</CheckoutProvider>
+				</myContext.Provider>
+			);
+		}
+
+		const getSubmitArea = ( container: HTMLElement ) =>
+			container.querySelector( '.checkout-steps__submit-button-wrapper' ) as HTMLElement;
+
+		it( 'shows an express method submit button even when it is not the active method', () => {
+			const { container } = render(
+				<ExpressCheckout
+					expressIds={ [ 'apple-pay' ] }
+					checkoutSteps={ [ steps[ 0 ], steps[ 1 ] ] }
+				/>
+			);
+			const submitArea = getSubmitArea( container );
+			// card is active (first available); apple-pay is express but not active.
+			const applePayButton = getByTextInNode( submitArea, 'Apple Pay' );
+			expect( applePayButton ).toBeInTheDocument();
+			expect( applePayButton ).not.toBeDisabled();
+			expect( applePayButton.closest( '.checkout-submit-button' ) ).toHaveClass(
+				'checkout-submit-button--active'
+			);
+		} );
+
+		it( 'renders express buttons before the active non-express button', () => {
+			const { container } = render(
+				<ExpressCheckout
+					expressIds={ [ 'apple-pay' ] }
+					checkoutSteps={ [ steps[ 0 ], steps[ 1 ] ] }
+				/>
+			);
+			const submitArea = getSubmitArea( container );
+			const wrappers = Array.from(
+				submitArea.querySelectorAll( '.checkout-submit-button' )
+			) as HTMLElement[];
+			const applePayIndex = wrappers.findIndex( ( w ) => w.textContent?.includes( 'Apple Pay' ) );
+			const cardIndex = wrappers.findIndex( ( w ) => w.textContent?.includes( 'Pay with Card' ) );
+			expect( applePayIndex ).toBeGreaterThanOrEqual( 0 );
+			expect( cardIndex ).toBeGreaterThanOrEqual( 0 );
+			expect( applePayIndex ).toBeLessThan( cardIndex );
+		} );
+
+		it( 'does not show express buttons while a step is incomplete (Continue shows instead)', () => {
+			const { container } = render(
+				<ExpressCheckout
+					expressIds={ [ 'apple-pay' ] }
+					checkoutSteps={ [ steps[ 0 ], steps[ 1 ], steps[ 3 ] ] }
+				/>
+			);
+			const submitArea = getSubmitArea( container );
+			expect( getByTextInNode( submitArea, 'Continue' ) ).toBeInTheDocument();
+			expect( queryByTextInNode( submitArea, 'Apple Pay' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'keeps a non-express inactive method hidden', () => {
+			const { container } = render(
+				<ExpressCheckout expressIds={ [] } checkoutSteps={ [ steps[ 0 ], steps[ 1 ] ] } />
+			);
+			const submitArea = getSubmitArea( container );
+			// card is active → shown; apple-pay is neither express nor active → hidden.
+			expect( getByTextInNode( submitArea, 'Pay with Card' ) ).toBeInTheDocument();
+			const applePayButton = queryByTextInNode( submitArea, 'Apple Pay' );
+			expect( applePayButton?.closest( '.checkout-submit-button' ) ).toHaveClass(
+				'checkout-submit-button--inactive'
+			);
+		} );
+	} );
+
 	describe( 'submitting the form', function () {
 		let MyCheckout;
 		const submitButtonComponent = <MockSubmitButtonSimple />;

--- a/packages/composite-checkout/test/checkout.tsx
+++ b/packages/composite-checkout/test/checkout.tsx
@@ -993,9 +993,9 @@ describe( 'Checkout', () => {
 
 	describe( 'with expressPaymentMethodIds', function () {
 		const steps = createMockStepObjects();
-		// steps[0] = summary (no step number)
-		// steps[1] = numbered, complete (isCompleteCallback () => true)
-		// steps[3] = numbered, incomplete (isCompleteCallback () => false)
+		// steps[0] = custom-summary-step    (no step number)
+		// steps[1] = custom-contact-step    (numbered, isCompleteCallback () => true)
+		// steps[3] = custom-incomplete-step (numbered, isCompleteCallback () => false)
 
 		const cardMethod = {
 			...createMockMethod( { submitButton: <MockSubmitButton content="Pay with Card" /> } ),
@@ -1050,7 +1050,7 @@ describe( 'Checkout', () => {
 			const submitArea = getSubmitArea( container );
 			// card is active (first available); apple-pay is express but not active.
 			const applePayButton = getByTextInNode( submitArea, 'Apple Pay' );
-			expect( applePayButton ).toBeInTheDocument();
+			expect( applePayButton ).toBeVisible();
 			expect( applePayButton ).not.toBeDisabled();
 			expect( applePayButton.closest( '.checkout-submit-button' ) ).toHaveClass(
 				'checkout-submit-button--active'
@@ -1098,6 +1098,118 @@ describe( 'Checkout', () => {
 			expect( applePayButton?.closest( '.checkout-submit-button' ) ).toHaveClass(
 				'checkout-submit-button--inactive'
 			);
+		} );
+
+		it( 'renders the active method exactly once when it is also in expressPaymentMethodIds', () => {
+			// card is the active (first) method AND in expressIds — it must not be
+			// duplicated; the wrapper should appear exactly once.
+			const { container } = render(
+				<ExpressCheckout expressIds={ [ 'card' ] } checkoutSteps={ [ steps[ 0 ], steps[ 1 ] ] } />
+			);
+			const submitArea = getSubmitArea( container );
+			const wrappers = Array.from(
+				submitArea.querySelectorAll( '.checkout-submit-button' )
+			) as HTMLElement[];
+			const cardWrapperCount = wrappers.filter(
+				( w ) => w.textContent?.includes( 'Pay with Card' )
+			).length;
+			expect( cardWrapperCount ).toBe( 1 );
+		} );
+
+		it( 'clicking an express button invokes its own processor, not the active method processor', async () => {
+			// Build methods with DISTINCT processor ids so we can assert which one fires.
+			const cardProcessor = jest
+				.fn()
+				.mockResolvedValue( { type: PaymentProcessorResponseType.SUCCESS, payload: true } );
+			const applePayProcessor = jest
+				.fn()
+				.mockResolvedValue( { type: PaymentProcessorResponseType.SUCCESS, payload: true } );
+
+			// Submit button components that call usePaymentProcessor with their own
+			// processor id (not the shared 'mock' key used by MockSubmitButton).
+			function CardSubmitButton( { disabled }: { disabled?: boolean } ) {
+				const { setTransactionComplete, setTransactionPending } = useTransactionStatus();
+				const process = usePaymentProcessor( 'card-processor' );
+				const onClick = () => {
+					setTransactionPending();
+					process( true ).then( ( result ) => setTransactionComplete( result ) );
+				};
+				return (
+					<button disabled={ disabled } onClick={ onClick }>
+						Pay with Card
+					</button>
+				);
+			}
+
+			function ApplePaySubmitButton( { disabled }: { disabled?: boolean } ) {
+				const { setTransactionComplete, setTransactionPending } = useTransactionStatus();
+				const process = usePaymentProcessor( 'apple-pay-processor' );
+				const onClick = () => {
+					setTransactionPending();
+					process( true ).then( ( result ) => setTransactionComplete( result ) );
+				};
+				return (
+					<button disabled={ disabled } onClick={ onClick }>
+						Apple Pay
+					</button>
+				);
+			}
+
+			const cardMethodDistinct = {
+				...createMockMethod( { submitButton: <CardSubmitButton /> } ),
+				id: 'card',
+				paymentProcessorId: 'card-processor',
+			};
+			const applePayMethodDistinct = {
+				...createMockMethod( { submitButton: <ApplePaySubmitButton /> } ),
+				id: 'apple-pay',
+				paymentProcessorId: 'apple-pay-processor',
+			};
+
+			function ExpressCheckoutWithDistinctProcessors() {
+				const [ paymentData, setPaymentData ] = useState( {} );
+				// Use only steps[0] + steps[1] so all steps are complete and Pay buttons show.
+				const { stepObjectsWithStepNumber, stepObjectsWithoutStepNumber } =
+					createStepsFromStepObjects( [ steps[ 0 ], steps[ 1 ] ] );
+				const createStepFromStepObject = createStepObjectConverter( paymentData );
+				return (
+					<myContext.Provider value={ [ paymentData, setPaymentData ] }>
+						<CheckoutProvider
+							paymentMethods={ [ cardMethodDistinct, applePayMethodDistinct ] }
+							paymentProcessors={ {
+								'card-processor': cardProcessor,
+								'apple-pay-processor': applePayProcessor,
+							} }
+							selectFirstAvailablePaymentMethod
+						>
+							<CheckoutStepGroup>
+								{ stepObjectsWithoutStepNumber.map( createStepFromStepObject ) }
+								{ stepObjectsWithStepNumber.map( createStepFromStepObject ) }
+								<CheckoutFormSubmit
+									continueToNextIncompleteStep
+									expressPaymentMethodIds={ [ 'apple-pay' ] }
+								/>
+							</CheckoutStepGroup>
+						</CheckoutProvider>
+					</myContext.Provider>
+				);
+			}
+
+			const { container } = render( <ExpressCheckoutWithDistinctProcessors /> );
+			const submitArea = getSubmitArea( container );
+
+			// card is the active method; apple-pay is express but NOT active.
+			// Clicking the Apple Pay button should invoke applePayProcessor only.
+			const applePayButton = getByTextInNode( submitArea, 'Apple Pay' );
+			expect( applePayButton ).toBeVisible();
+
+			const user = userEvent.setup();
+			await user.click( applePayButton );
+
+			await waitFor( () => {
+				expect( applePayProcessor ).toHaveBeenCalledTimes( 1 );
+			} );
+			expect( cardProcessor ).not.toHaveBeenCalled();
 		} );
 	} );
 

--- a/packages/composite-checkout/test/checkout.tsx
+++ b/packages/composite-checkout/test/checkout.tsx
@@ -23,7 +23,11 @@ import {
 	makeErrorResponse,
 	useMakeStepActive,
 } from '../src/public-api';
-import { PaymentProcessorFunction, PaymentProcessorResponseType } from '../src/types';
+import {
+	PaymentProcessorFunction,
+	PaymentProcessorResponseType,
+	ProcessPayment,
+} from '../src/types';
 import { DefaultCheckoutSteps } from './utils/default-checkout-steps';
 
 const myContext = createContext( undefined );
@@ -1125,31 +1129,33 @@ describe( 'Checkout', () => {
 				.fn()
 				.mockResolvedValue( { type: PaymentProcessorResponseType.SUCCESS, payload: true } );
 
-			// Submit button components that call usePaymentProcessor with their own
-			// processor id (not the shared 'mock' key used by MockSubmitButton).
-			function CardSubmitButton( { disabled }: { disabled?: boolean } ) {
-				const { setTransactionComplete, setTransactionPending } = useTransactionStatus();
-				const process = usePaymentProcessor( 'card-processor' );
-				const onClick = () => {
-					setTransactionPending();
-					process( true ).then( ( result ) => setTransactionComplete( result ) );
-				};
+			// Submit buttons that use the INJECTED onClick prop (the cloned
+			// onClickWithValidation from CheckoutSubmitButton), exactly like
+			// MockSubmitButtonSimple. This exercises the real isShown guard in
+			// production code instead of bypassing it.
+			function CardSubmitButton( {
+				disabled,
+				onClick,
+			}: {
+				disabled?: boolean;
+				onClick?: ProcessPayment;
+			} ) {
 				return (
-					<button disabled={ disabled } onClick={ onClick }>
+					<button disabled={ disabled } onClick={ () => onClick?.( {} ) }>
 						Pay with Card
 					</button>
 				);
 			}
 
-			function ApplePaySubmitButton( { disabled }: { disabled?: boolean } ) {
-				const { setTransactionComplete, setTransactionPending } = useTransactionStatus();
-				const process = usePaymentProcessor( 'apple-pay-processor' );
-				const onClick = () => {
-					setTransactionPending();
-					process( true ).then( ( result ) => setTransactionComplete( result ) );
-				};
+			function ApplePaySubmitButton( {
+				disabled,
+				onClick,
+			}: {
+				disabled?: boolean;
+				onClick?: ProcessPayment;
+			} ) {
 				return (
-					<button disabled={ disabled } onClick={ onClick }>
+					<button disabled={ disabled } onClick={ () => onClick?.( {} ) }>
 						Apple Pay
 					</button>
 				);


### PR DESCRIPTION
## Proposed Changes

This surfaces Apple Pay and Google Pay submit buttons in the sidebar when available and after the billing information step is complete. It also updates the "Pay now" button for saved cards to read "Pay with **** 1234".

<img width="3220" height="2344" alt="CleanShot 2026-06-03 at 22 28 29@2x" src="https://github.com/user-attachments/assets/56e2427f-79d4-44b9-99f6-de9ea911e2bc" />

* Uses a new feature flag `checkout/sidebar-express-payment-buttons` (enabled in development, off everywhere else).
* Add an opt-in `expressPaymentMethodIds: string[]` prop to `@automattic/composite-checkout`, threaded `CheckoutFormSubmit` → `CheckoutSubmitButton`. For a payment method whose `id` is in that set, its submit button renders **visibly** (not hidden via `checkout-submit-button--inactive`), is ordered **before** the other buttons, and is **clickable even when it is not the actively-selected method** (the `isActive` restriction becomes `isShown = isActive || isExpress` for the disable check, the click guard, and the wrapper class). When the prop is empty/omitted, behavior is identical to today — Jetpack Cloud, A8C for Agencies, and the mobile inline submit are unaffected.
* Curated list ships **Apple Pay and Google Pay** only. PayPal is intentionally omitted for now.
* **This does not include PayPal**: the current PayPal method (`paypal-js`) only renders its button when it is the actively-selected method — it returns a `Loading` placeholder otherwise — because the `@paypal/react-paypal-js` `PayPalButtons` component caches its `onClick` closure. It therefore can't be shown as an always-visible express button without reworking that component. (`paypal-express` is the legacy method.) Adding PayPal to the sidebar will be handled in a follow-up.

## Why are these changes being made?

After the desktop checkout redesign pinned the summary sidebar and added a persistent Pay CTA, the sidebar is a natural home for one-tap wallet buttons. Surfacing Apple Pay / Google Pay above the main Pay button gives shoppers a faster path to purchase when their device supports a wallet, without changing the main payment-method list (the methods still appear there too). The capability is generic (an ID list) in `composite-checkout`; WordPress.com owns which methods are promoted and the rollout flag.

## Testing Instructions

* `yarn test-packages packages/composite-checkout/test/checkout.tsx -t "expressPaymentMethodIds"` — 6 tests covering: an express method's button is visible + enabled when not the active method; express buttons are ordered before the active non-express button; clicking an express button invokes its own payment processor (not the active method's); a method that is both active and express renders exactly once; express buttons are hidden while a step is incomplete (Continue shows instead); a non-express inactive method stays hidden.
* Manual (desktop width, dev has the flag on): with a cart that offers a wallet, complete all steps and confirm Apple Pay / Google Pay appear stacked above the Pay button, full-width and 50px tall, only when the wallet is actually available on the device. Confirm clicking a wallet button starts that method's flow even when a card is selected in the list below. Set the flag to `false` in `config/development.json` and confirm the sidebar shows only the single Pay/Continue button.
* Note: Apple Pay / Google Pay are difficult to exercise on a local dev host due to wallet domain verification; the package unit tests cover the rendering/dispatch/ordering/gating logic the wallet buttons rely on.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)