### PR TITLE
Agents Manager: compose peer AI providers

### DIFF
--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -6,6 +6,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import type { Suggestion } from '@automattic/agenttic-ui';
 
 const mockUseAgentChat = jest.fn();
+let mockSelectedBlock: unknown;
 
 jest.mock(
 	'@automattic/agenttic-client',
@@ -18,11 +19,18 @@ jest.mock(
 	{ virtual: true }
 );
 jest.mock( '@wordpress/data', () => ( {
-	useSelect: ( mapSelect: ( select: () => unknown ) => unknown ) =>
-		mapSelect( () => ( {
-			getCurrentPostId: () => undefined,
-			getCurrentPostType: () => undefined,
-		} ) ),
+	useSelect: ( mapSelect: ( select: ( storeName?: string ) => unknown ) => unknown ) =>
+		mapSelect( ( storeName?: string ) => {
+			if ( storeName === 'core/block-editor' ) {
+				return {
+					getSelectedBlock: () => mockSelectedBlock,
+				};
+			}
+			return {
+				getCurrentPostId: () => undefined,
+				getCurrentPostType: () => undefined,
+			};
+		} ),
 } ) );
 jest.mock( '@wordpress/element', () => jest.requireActual( 'react' ) );
 jest.mock( '@wordpress/i18n', () => ( { __: ( text: string ) => text } ) );
@@ -110,6 +118,7 @@ import OrchestratorChat from '../orchestrator-chat';
 
 describe( 'OrchestratorChat', () => {
 	beforeEach( () => {
+		mockSelectedBlock = undefined;
 		mockUseAgentChat.mockReturnValue( {
 			addMessage: jest.fn(),
 			messages: [],
@@ -369,5 +378,123 @@ describe( 'OrchestratorChat', () => {
 			optimizeTitleSuggestion,
 			bigSkySuggestion,
 		] );
+	} );
+
+	it( 'does not append empty-view suggestions when a block is selected', () => {
+		const textBlockSuggestion = {
+			id: 'translate',
+			label: 'Translate content',
+			prompt: 'Translate this to:',
+		};
+		const bigSkySuggestion = {
+			id: 'customize-colors',
+			label: 'Change colors',
+			prompt: 'Show me color palettes for my site',
+		};
+		const registerSuggestions = jest.fn();
+		const useSuggestions = jest.fn( () => ( { suggestions: [ textBlockSuggestion ] } ) );
+		mockSelectedBlock = { clientId: 'block-1', name: 'core/paragraph' };
+
+		mockUseAgentChat.mockReturnValue( {
+			addMessage: jest.fn(),
+			messages: [],
+			suggestions: [],
+			isProcessing: false,
+			error: null,
+			loadMessages: jest.fn(),
+			onSubmit: jest.fn(),
+			abortCurrentRequest: jest.fn(),
+			clearSuggestions: jest.fn(),
+			registerSuggestions,
+			registerMessageActions: jest.fn(),
+			progressMessage: null,
+		} );
+
+		render(
+			<OrchestratorChat
+				emptyViewSuggestions={ [ bigSkySuggestion ] }
+				isDocked
+				isOpen
+				onClose={ jest.fn() }
+				onExpand={ jest.fn() }
+				chatHeaderOptions={ [] }
+				markdownComponents={ {} }
+				markdownExtensions={ {} }
+				isCompactMode={ false }
+				useSuggestions={ useSuggestions }
+				onHasMessagesChange={ jest.fn() }
+			/>
+		);
+
+		expect( screen.getByTestId( 'empty-view-suggestions' ).textContent ).toContain(
+			'Translate content'
+		);
+		expect( screen.getByTestId( 'empty-view-suggestions' ).textContent ).not.toContain(
+			'Change colors'
+		);
+		expect( registerSuggestions ).toHaveBeenCalledWith( [ textBlockSuggestion ] );
+	} );
+
+	it( 'ignores stale Agenttic suggestions when selected-block provider suggestions are available', () => {
+		const textBlockSuggestion = {
+			id: 'translate',
+			label: 'Translate content',
+			prompt: 'Translate this to:',
+		};
+		const staleImageSuggestion = {
+			id: 'generate-image',
+			label: 'Generate image',
+			prompt: 'Generate an image of:',
+		};
+		const globalSuggestion = {
+			id: 'customize-colors',
+			label: 'Change colors',
+			prompt: 'Show me color palettes for my site',
+		};
+		const registerSuggestions = jest.fn();
+		const useSuggestions = jest.fn( () => ( { suggestions: [ textBlockSuggestion ] } ) );
+		mockSelectedBlock = { clientId: 'block-1', name: 'core/paragraph' };
+
+		mockUseAgentChat.mockReturnValue( {
+			addMessage: jest.fn(),
+			messages: [],
+			suggestions: [ staleImageSuggestion ],
+			isProcessing: false,
+			error: null,
+			loadMessages: jest.fn(),
+			onSubmit: jest.fn(),
+			abortCurrentRequest: jest.fn(),
+			clearSuggestions: jest.fn(),
+			registerSuggestions,
+			registerMessageActions: jest.fn(),
+			progressMessage: null,
+		} );
+
+		render(
+			<OrchestratorChat
+				emptyViewSuggestions={ [ globalSuggestion ] }
+				isDocked
+				isOpen
+				onClose={ jest.fn() }
+				onExpand={ jest.fn() }
+				chatHeaderOptions={ [] }
+				markdownComponents={ {} }
+				markdownExtensions={ {} }
+				isCompactMode={ false }
+				useSuggestions={ useSuggestions }
+				onHasMessagesChange={ jest.fn() }
+			/>
+		);
+
+		expect( screen.getByTestId( 'empty-view-suggestions' ).textContent ).toContain(
+			'Translate content'
+		);
+		expect( screen.getByTestId( 'empty-view-suggestions' ).textContent ).not.toContain(
+			'Generate image'
+		);
+		expect( screen.getByTestId( 'empty-view-suggestions' ).textContent ).not.toContain(
+			'Change colors'
+		);
+		expect( registerSuggestions ).toHaveBeenCalledWith( [ textBlockSuggestion ] );
 	} );
 } );

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -18,7 +18,11 @@ jest.mock(
 	{ virtual: true }
 );
 jest.mock( '@wordpress/data', () => ( {
-	useSelect: () => undefined,
+	useSelect: ( mapSelect: ( select: () => unknown ) => unknown ) =>
+		mapSelect( () => ( {
+			getCurrentPostId: () => undefined,
+			getCurrentPostType: () => undefined,
+		} ) ),
 } ) );
 jest.mock( '@wordpress/element', () => jest.requireActual( 'react' ) );
 jest.mock( '@wordpress/i18n', () => ( { __: ( text: string ) => text } ) );
@@ -66,10 +70,24 @@ jest.mock( '../agent-chat', () => ( {
 	__esModule: true,
 	default: ( {
 		onSuggestionClick,
+		suggestions,
+		emptyViewSuggestions,
 	}: {
 		onSuggestionClick: ( suggestion: Suggestion | string ) => void;
+		suggestions: Suggestion[];
+		emptyViewSuggestions: Suggestion[];
 	} ) => (
 		<>
+			<div data-testid="input-suggestions">
+				{ suggestions.map( ( suggestion ) => (
+					<span key={ suggestion.id }>{ suggestion.label }</span>
+				) ) }
+			</div>
+			<div data-testid="empty-view-suggestions">
+				{ emptyViewSuggestions.map( ( suggestion ) => (
+					<span key={ suggestion.id }>{ suggestion.label }</span>
+				) ) }
+			</div>
 			<button
 				onClick={ () =>
 					onSuggestionClick( {
@@ -208,5 +226,148 @@ describe( 'OrchestratorChat', () => {
 		);
 
 		expect( useSuggestions ).toHaveBeenCalledWith( undefined, { suggestionsVisible: true } );
+	} );
+
+	it( 'treats docked chat as visible even when the floating open state is false', () => {
+		const dynamicSuggestion = {
+			id: 'optimize-title',
+			label: 'Optimize Title',
+			prompt: 'Optimize the title of this post',
+		};
+		const useSuggestions = jest.fn( ( _maxSuggestions, options ) => ( {
+			suggestions: options?.suggestionsVisible ? [ dynamicSuggestion ] : [],
+		} ) );
+
+		render(
+			<OrchestratorChat
+				emptyViewSuggestions={ [] }
+				isDocked
+				isOpen={ false }
+				onClose={ jest.fn() }
+				onExpand={ jest.fn() }
+				chatHeaderOptions={ [] }
+				markdownComponents={ {} }
+				markdownExtensions={ {} }
+				isCompactMode={ false }
+				useSuggestions={ useSuggestions }
+				onHasMessagesChange={ jest.fn() }
+			/>
+		);
+
+		expect( useSuggestions ).toHaveBeenCalledWith( undefined, { suggestionsVisible: true } );
+		expect( screen.getByTestId( 'empty-view-suggestions' ).textContent ).toContain(
+			'Optimize Title'
+		);
+	} );
+
+	it( 'passes live external provider suggestions when Agenttic suggestions are empty', () => {
+		const dynamicSuggestion = {
+			id: 'change-colors',
+			label: 'Change colors',
+			prompt: 'Show me color palettes for my site',
+		};
+		const useSuggestions = jest.fn( () => ( { suggestions: [ dynamicSuggestion ] } ) );
+
+		mockUseAgentChat.mockReturnValue( {
+			addMessage: jest.fn(),
+			messages: [
+				{
+					id: 'tool-result',
+					role: 'agent',
+					content: [ { type: 'text', text: 'Here are some options.' } ],
+				},
+			],
+			suggestions: [],
+			isProcessing: false,
+			error: null,
+			loadMessages: jest.fn(),
+			onSubmit: jest.fn(),
+			abortCurrentRequest: jest.fn(),
+			clearSuggestions: jest.fn(),
+			registerSuggestions: jest.fn(),
+			registerMessageActions: jest.fn(),
+			progressMessage: null,
+		} );
+
+		render(
+			<OrchestratorChat
+				emptyViewSuggestions={ [] }
+				isDocked
+				isOpen
+				onClose={ jest.fn() }
+				onExpand={ jest.fn() }
+				chatHeaderOptions={ [] }
+				markdownComponents={ {} }
+				markdownExtensions={ {} }
+				isCompactMode={ false }
+				useSuggestions={ useSuggestions }
+				onHasMessagesChange={ jest.fn() }
+			/>
+		);
+
+		expect( screen.getByTestId( 'input-suggestions' ).textContent ).toContain( 'Change colors' );
+	} );
+
+	it( 'composes dynamic and empty-view provider suggestions while the chat is empty', () => {
+		const optimizeTitleSuggestion = {
+			id: 'optimize-title',
+			label: 'Optimize Title',
+			prompt: 'Optimize the title of this post',
+		};
+		const bigSkySuggestion = {
+			id: 'customize-colors',
+			label: 'Change colors',
+			prompt: 'Show me color palettes for my site',
+		};
+		const registerSuggestions = jest.fn();
+		const useSuggestions = jest.fn( () => ( { suggestions: [ optimizeTitleSuggestion ] } ) );
+
+		mockUseAgentChat.mockReturnValue( {
+			addMessage: jest.fn(),
+			messages: [],
+			suggestions: [],
+			isProcessing: false,
+			error: null,
+			loadMessages: jest.fn(),
+			onSubmit: jest.fn(),
+			abortCurrentRequest: jest.fn(),
+			clearSuggestions: jest.fn(),
+			registerSuggestions,
+			registerMessageActions: jest.fn(),
+			progressMessage: null,
+		} );
+
+		render(
+			<OrchestratorChat
+				emptyViewSuggestions={ [ bigSkySuggestion ] }
+				isDocked
+				isOpen
+				onClose={ jest.fn() }
+				onExpand={ jest.fn() }
+				chatHeaderOptions={ [] }
+				markdownComponents={ {} }
+				markdownExtensions={ {} }
+				isCompactMode={ false }
+				useSuggestions={ useSuggestions }
+				onHasMessagesChange={ jest.fn() }
+			/>
+		);
+
+		expect( screen.getByTestId( 'input-suggestions' ).textContent ).not.toContain(
+			'Optimize Title'
+		);
+		expect( screen.getByTestId( 'input-suggestions' ).textContent ).not.toContain(
+			'Change colors'
+		);
+		expect( screen.getByTestId( 'empty-view-suggestions' ).textContent ).toContain(
+			'Optimize Title'
+		);
+		expect( screen.getByTestId( 'empty-view-suggestions' ).textContent ).toContain(
+			'Change colors'
+		);
+		expect( registerSuggestions ).toHaveBeenCalledWith( [
+			optimizeTitleSuggestion,
+			bigSkySuggestion,
+		] );
 	} );
 } );

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -30,21 +30,22 @@ import {
 	type ExternalContextCardAction,
 } from '../../utils/external-context';
 import { isReaderChatAgent } from '../../utils/is-reader-chat-agent';
+import {
+	type NavigationContinuationHook,
+	type AbilitiesSetupHook,
+	type GetChatComponent,
+	type UseSuggestionsHook,
+	type SiteBuildUtils,
+	type ImageUploadHook,
+	type UseCheckpointHook,
+} from '../../utils/load-external-providers';
 import { getOrchestratorErrorMessage } from '../../utils/orchestrator-error-message';
 import { persistLastActivity } from '../../utils/persist-last-activity';
 import { getReaderChatErrorMessage } from '../../utils/reader-chat-error-message';
+import { isSiteEditorContext } from '../../utils/site-editor-context';
 import AgentChat from '../agent-chat';
 import { type Options as ChatHeaderOptions } from '../chat-header';
 import type { BigSkyMessage } from '../../types';
-import type {
-	NavigationContinuationHook,
-	AbilitiesSetupHook,
-	GetChatComponent,
-	UseSuggestionsHook,
-	SiteBuildUtils,
-	ImageUploadHook,
-	UseCheckpointHook,
-} from '../../utils/load-external-providers';
 
 interface Props {
 	/** Suggestions displayed when the chat is empty. */
@@ -83,6 +84,23 @@ interface Props {
 	onHasMessagesChange: ( hasMessages: boolean ) => void;
 }
 
+function mergeSuggestionsById( ...suggestionLists: Suggestion[][] ): Suggestion[] {
+	const merged: Suggestion[] = [];
+	const seenIds = new Set< string >();
+
+	for ( const suggestionList of suggestionLists ) {
+		for ( const suggestion of suggestionList ) {
+			if ( seenIds.has( suggestion.id ) ) {
+				continue;
+			}
+			seenIds.add( suggestion.id );
+			merged.push( suggestion );
+		}
+	}
+
+	return merged;
+}
+
 export default function OrchestratorChat( {
 	emptyViewSuggestions,
 	isDocked,
@@ -102,7 +120,8 @@ export default function OrchestratorChat( {
 	useCheckpoint,
 	onHasMessagesChange,
 }: Props ) {
-	const { agentConfig, getActiveSessionId, siteKey } = useAgentsManagerContext();
+	const { agentConfig, getActiveSessionId, siteKey, sectionName, currentRoute } =
+		useAgentsManagerContext();
 
 	const navigate = useNavigate();
 	const [ inputValue, setInputValue ] = useState( '' );
@@ -111,9 +130,22 @@ export default function OrchestratorChat( {
 	const [ isBuildingSite, setIsBuildingSite ] = useState( false );
 	const [ deletedMessageIds, setDeletedMessageIds ] = useState< Set< string > >( new Set() );
 	const [ hasUserSentMessage, setHasUserSentMessage ] = useState( false );
-	const currentPostId = useSelect( ( select ) => {
-		return ( select( 'core/editor' ) as { getCurrentPostId?: () => number } )?.getCurrentPostId?.();
+	const { currentPostId, isEditorContext } = useSelect( ( select ) => {
+		const editorStore = select( 'core/editor' ) as {
+			getCurrentPostId?: () => number;
+			getCurrentPostType?: () => string | undefined;
+		};
+		const postId = editorStore?.getCurrentPostId?.();
+		const postType = editorStore?.getCurrentPostType?.();
+		const editorPostTypes = [ 'post', 'page', 'wp_template', 'wp_template_part' ];
+
+		return {
+			currentPostId: postId,
+			isEditorContext: postId != null || ( !! postType && editorPostTypes.includes( postType ) ),
+		};
 	}, [] );
+	const shouldRenderEditorComponents =
+		isEditorContext || isSiteEditorContext( sectionName, currentRoute );
 
 	const {
 		addMessage,
@@ -162,25 +194,9 @@ export default function OrchestratorChat( {
 	// Use dynamic suggestions from the external provider (e.g., Big Sky block-based suggestions)
 	const maxDynamicSuggestions = isDocked ? undefined : 3;
 	const dynamicSuggestions = useSuggestions?.( maxDynamicSuggestions, {
-		suggestionsVisible: isOpen || isCompactMode,
+		suggestionsVisible: isDocked || isOpen || isCompactMode,
 	} );
 	const dynamicSuggestionsList = dynamicSuggestions?.suggestions ?? [];
-	const dynamicSuggestionsKey = JSON.stringify(
-		dynamicSuggestionsList.map( ( s ) => [ s.id, s.label, s.prompt ] )
-	);
-
-	// Register dynamic suggestions whenever they change
-	useEffect( () => {
-		if ( dynamicSuggestionsList.length > 0 ) {
-			registerSuggestions?.( dynamicSuggestionsList );
-		} else {
-			// Clear suggestions when there are none
-			clearSuggestions?.();
-		}
-		// Track suggestion content, not array identity. Some merged providers
-		// return a fresh empty array on each render.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ dynamicSuggestionsKey, registerSuggestions, clearSuggestions ] );
 
 	// Persist the chat route so the conversation can be resumed later.
 	useSaveNewChatRoute( hasUserSentMessage );
@@ -432,6 +448,7 @@ export default function OrchestratorChat( {
 			messages: currentMessages,
 			getChatComponent,
 			currentPostId,
+			isEditorContext: shouldRenderEditorComponents,
 			onSubmit: onSubmitWithImages,
 		} );
 
@@ -443,6 +460,7 @@ export default function OrchestratorChat( {
 		isBuildingSite,
 		messages,
 		onSubmitWithImages,
+		shouldRenderEditorComponents,
 		siteBuildUtils,
 		thinkingMessage,
 	] );
@@ -460,20 +478,34 @@ export default function OrchestratorChat( {
 	const showProcessingIndicator =
 		( isProcessing || ( isThinking && ! isBuildingSite ) ) && ! shouldSuppressTransientThinking;
 
-	// Determine which suggestions to show following Big Sky's logic:
-	// - When there are dynamic suggestions (from block selection, etc.), show those
-	// - Otherwise, show empty view suggestions only when there are no messages AND no input text
-	let displayedEmptyViewSuggestions: Suggestion[] = [];
-	if ( suggestions.length > 0 ) {
-		displayedEmptyViewSuggestions = suggestions;
-	} else if ( displayedMessages.length === 0 && inputValue.length === 0 ) {
-		displayedEmptyViewSuggestions = emptyViewSuggestions;
-	}
+	const shouldShowEmptySuggestions = displayedMessages.length === 0 && inputValue.length === 0;
+	const registeredSuggestions = shouldShowEmptySuggestions
+		? mergeSuggestionsById( dynamicSuggestionsList, suggestions, emptyViewSuggestions )
+		: mergeSuggestionsById( dynamicSuggestionsList, suggestions );
+	const activeSuggestions = shouldShowEmptySuggestions ? [] : registeredSuggestions;
+	const activeSuggestionsKey = JSON.stringify(
+		registeredSuggestions.map( ( s ) => [ s.id, s.label, s.prompt ] )
+	);
+
+	// Register the same suggestions Agenttic receives as props so string-based
+	// suggestion callbacks and provider-composed chips stay in sync.
+	useEffect( () => {
+		if ( registeredSuggestions.length > 0 ) {
+			registerSuggestions?.( registeredSuggestions );
+		} else {
+			clearSuggestions?.();
+		}
+		// Track suggestion content, not array identity. Some merged providers
+		// return a fresh empty array on each render.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ activeSuggestionsKey, registerSuggestions, clearSuggestions ] );
+
+	const displayedEmptyViewSuggestions = shouldShowEmptySuggestions ? registeredSuggestions : [];
 
 	return (
 		<AgentChat
 			messages={ displayedMessages }
-			suggestions={ suggestions }
+			suggestions={ activeSuggestions }
 			emptyViewSuggestions={ displayedEmptyViewSuggestions }
 			isProcessing={ showProcessingIndicator }
 			thinkingMessage={ progressMessage }

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -197,6 +197,16 @@ export default function OrchestratorChat( {
 		suggestionsVisible: isDocked || isOpen || isCompactMode,
 	} );
 	const dynamicSuggestionsList = dynamicSuggestions?.suggestions ?? [];
+	const hasSelectedBlock = useSelect( ( select ) => {
+		try {
+			const blockEditorStore = select( 'core/block-editor' ) as {
+				getSelectedBlock?: () => unknown;
+			};
+			return !! blockEditorStore?.getSelectedBlock?.();
+		} catch {
+			return false;
+		}
+	}, [] );
 
 	// Persist the chat route so the conversation can be resumed later.
 	useSaveNewChatRoute( hasUserSentMessage );
@@ -479,9 +489,15 @@ export default function OrchestratorChat( {
 		( isProcessing || ( isThinking && ! isBuildingSite ) ) && ! shouldSuppressTransientThinking;
 
 	const shouldShowEmptySuggestions = displayedMessages.length === 0 && inputValue.length === 0;
+	const agentticSuggestions =
+		hasSelectedBlock && dynamicSuggestionsList.length > 0 ? [] : suggestions;
 	const registeredSuggestions = shouldShowEmptySuggestions
-		? mergeSuggestionsById( dynamicSuggestionsList, suggestions, emptyViewSuggestions )
-		: mergeSuggestionsById( dynamicSuggestionsList, suggestions );
+		? mergeSuggestionsById(
+				dynamicSuggestionsList,
+				agentticSuggestions,
+				hasSelectedBlock ? [] : emptyViewSuggestions
+		  )
+		: mergeSuggestionsById( dynamicSuggestionsList, agentticSuggestions );
 	const activeSuggestions = shouldShowEmptySuggestions ? [] : registeredSuggestions;
 	const activeSuggestionsKey = JSON.stringify(
 		registeredSuggestions.map( ( s ) => [ s.id, s.label, s.prompt ] )

--- a/packages/agents-manager/src/hooks/__tests__/use-empty-view-suggestions.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-empty-view-suggestions.test.ts
@@ -45,11 +45,21 @@ const siteEditorSuggestion = {
 	prompt: 'Show me color palettes for my site that are:',
 };
 
-function mockCoreStoreReady( isReady: boolean ) {
+function mockCoreStoreReady( isReady: boolean, postType?: string ) {
 	mockUseSelect.mockImplementation( ( mapSelect ) =>
-		mapSelect( () => ( {
-			getCurrentTheme: () => ( isReady ? { stylesheet: 'pub/theme' } : null ),
-		} ) )
+		mapSelect( ( storeName: string ) => {
+			if ( storeName === 'core' ) {
+				return {
+					getCurrentTheme: () => ( isReady ? { stylesheet: 'pub/theme' } : null ),
+				};
+			}
+			if ( storeName === 'core/editor' ) {
+				return {
+					getCurrentPostType: () => postType,
+				};
+			}
+			return {};
+		} )
 	);
 }
 
@@ -135,6 +145,7 @@ describe( 'useEmptyViewSuggestions', () => {
 	} );
 
 	it( 'filters site-editor-only provider suggestions in the post editor even if section is misreported', async () => {
+		mockCoreStoreReady( true, 'post' );
 		mockContext = {
 			sectionName: 'site-editor',
 			currentRoute: '/wp-admin/post.php?post=1&action=edit',
@@ -147,10 +158,41 @@ describe( 'useEmptyViewSuggestions', () => {
 		await waitFor( () => expect( result.current ).toEqual( [] ) );
 	} );
 
+	it( 'keeps site-editor provider suggestions in the page editor', async () => {
+		mockCoreStoreReady( true, 'page' );
+		mockContext = {
+			sectionName: 'gutenberg',
+			currentRoute: '/wp-admin/post.php?post=1&action=edit',
+		};
+		const getEmptyViewSuggestions = jest.fn( () => [ siteEditorSuggestion, bigSkySuggestion ] );
+		const loadedProviders = { getEmptyViewSuggestions } as unknown as LoadedProviders;
+
+		const { result } = renderHook( () => useEmptyViewSuggestions( { loadedProviders } ) );
+
+		await waitFor( () =>
+			expect( result.current ).toEqual( [ siteEditorSuggestion, bigSkySuggestion ] )
+		);
+	} );
+
 	it( 'keeps site-editor-only provider suggestions in Site Editor', async () => {
 		mockContext = {
 			sectionName: 'site-editor',
 			currentRoute: undefined,
+		};
+		const getEmptyViewSuggestions = jest.fn( () => [ siteEditorSuggestion, bigSkySuggestion ] );
+		const loadedProviders = { getEmptyViewSuggestions } as unknown as LoadedProviders;
+
+		const { result } = renderHook( () => useEmptyViewSuggestions( { loadedProviders } ) );
+
+		await waitFor( () =>
+			expect( result.current ).toEqual( [ siteEditorSuggestion, bigSkySuggestion ] )
+		);
+	} );
+
+	it( 'keeps site-editor-only provider suggestions when Site Editor is reported as Gutenberg', async () => {
+		mockContext = {
+			sectionName: 'gutenberg',
+			currentRoute: '/wp-admin/site-editor.php?canvas=edit',
 		};
 		const getEmptyViewSuggestions = jest.fn( () => [ siteEditorSuggestion, bigSkySuggestion ] );
 		const loadedProviders = { getEmptyViewSuggestions } as unknown as LoadedProviders;

--- a/packages/agents-manager/src/hooks/__tests__/use-empty-view-suggestions.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-empty-view-suggestions.test.ts
@@ -83,6 +83,8 @@ describe( 'useEmptyViewSuggestions', () => {
 
 	afterEach( () => {
 		delete ( window as unknown as { agentsManagerData?: unknown } ).agentsManagerData;
+		delete ( window as unknown as { bigSkyInitialState?: unknown } ).bigSkyInitialState;
+		document.body.classList.remove( 'post-type-page' );
 		window.history.pushState( {}, '', '/' );
 	} );
 
@@ -164,6 +166,29 @@ describe( 'useEmptyViewSuggestions', () => {
 			sectionName: 'gutenberg',
 			currentRoute: '/wp-admin/post.php?post=1&action=edit',
 		};
+		const getEmptyViewSuggestions = jest.fn( () => [ siteEditorSuggestion, bigSkySuggestion ] );
+		const loadedProviders = { getEmptyViewSuggestions } as unknown as LoadedProviders;
+
+		const { result } = renderHook( () => useEmptyViewSuggestions( { loadedProviders } ) );
+
+		await waitFor( () =>
+			expect( result.current ).toEqual( [ siteEditorSuggestion, bigSkySuggestion ] )
+		);
+	} );
+
+	it( 'keeps site-editor provider suggestions in the page editor from Big Sky runtime screen data', async () => {
+		mockCoreStoreReady( true, undefined );
+		mockContext = {
+			sectionName: 'gutenberg',
+			currentRoute: '/wp-admin/post.php?post=1&action=edit',
+		};
+		( window as unknown as { bigSkyInitialState?: Record< string, unknown > } ).bigSkyInitialState =
+			{
+				currentScreen: {
+					screen: 'post',
+					postType: 'page',
+				},
+			};
 		const getEmptyViewSuggestions = jest.fn( () => [ siteEditorSuggestion, bigSkySuggestion ] );
 		const loadedProviders = { getEmptyViewSuggestions } as unknown as LoadedProviders;
 

--- a/packages/agents-manager/src/hooks/__tests__/use-zoom-action.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-zoom-action.test.ts
@@ -11,7 +11,11 @@ jest.mock( '../../utils/is-editor-page' );
 
 type MessageActionsRegistration = Parameters< UseAgentChatReturn[ 'registerMessageActions' ] >[ 0 ];
 
-function createToolMessage( type: string, data: Record< string, unknown > = {} ): UIMessage {
+function createToolMessage(
+	type: string,
+	data: Record< string, unknown > = {},
+	toolId = 'big_sky__show_component'
+): UIMessage {
 	return {
 		id: 'message-1',
 		role: 'agent',
@@ -19,7 +23,7 @@ function createToolMessage( type: string, data: Record< string, unknown > = {} )
 			{
 				type: 'text',
 				text: JSON.stringify( {
-					tool_id: 'big_sky__show_component',
+					tool_id: toolId,
 					data: {
 						type,
 						...data,
@@ -45,7 +49,12 @@ describe( 'useZoomAction', () => {
 		( isEditorPage as jest.Mock ).mockReturnValue( true );
 	} );
 
-	it( 'registers zoom action for show-component messages', () => {
+	it.each( [
+		'big-sky/show-component',
+		'big-sky-show-component',
+		'big_sky__show_component',
+		'jetpack_ai__show_component',
+	] )( 'registers zoom action for %s messages', ( toolId ) => {
 		let registration: MessageActionsRegistration | undefined;
 		const registerMessageActions = jest.fn( ( nextRegistration ) => {
 			registration = nextRegistration;
@@ -53,7 +62,9 @@ describe( 'useZoomAction', () => {
 
 		renderHook( () => useZoomAction( registerMessageActions ) );
 
-		expect( getActions( registration, createToolMessage( 'pattern-picker' ) ) ).toHaveLength( 1 );
+		expect(
+			getActions( registration, createToolMessage( 'pattern-picker', {}, toolId ) )
+		).toHaveLength( 1 );
 	} );
 
 	it.each( [ 'color-picker', 'font-picker' ] )(

--- a/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
+++ b/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
@@ -97,7 +97,20 @@ function getWindowPathname(): string {
 	return typeof window !== 'undefined' ? window.location.pathname : '';
 }
 
+function isSiteEditorRoute( currentRoute?: string ): boolean {
+	const pathname = getWindowPathname();
+	return (
+		!! currentRoute?.includes( 'site-editor.php' ) ||
+		pathname.includes( 'site-editor.php' ) ||
+		( typeof document !== 'undefined' && document.body?.classList.contains( 'site-editor-php' ) )
+	);
+}
+
 function isPostEditorSurface( sectionName: string, currentRoute?: string ): boolean {
+	if ( isSiteEditorRoute( currentRoute ) ) {
+		return false;
+	}
+
 	const pathname = getWindowPathname();
 	return (
 		sectionName === 'gutenberg' ||
@@ -113,11 +126,11 @@ function isSiteEditorSurface( sectionName: string, currentRoute?: string ): bool
 		return false;
 	}
 
-	return (
-		sectionName === 'site-editor' ||
-		!! currentRoute?.includes( 'site-editor.php' ) ||
-		getWindowPathname().includes( 'site-editor.php' )
-	);
+	return sectionName === 'site-editor' || isSiteEditorRoute( currentRoute );
+}
+
+function isPageEditorSurface( currentPostType?: string, currentRoute?: string ): boolean {
+	return currentPostType === 'page' || !! currentRoute?.includes( 'post_type=page' );
 }
 
 function filterEmptyViewSuggestions(
@@ -137,7 +150,6 @@ export function useEmptyViewSuggestions( {
 }: UseEmptyViewSuggestionsOptions ): Suggestion[] | null {
 	const isReaderChat = isReaderChatHost();
 	const { sectionName, currentRoute } = useAgentsManagerContext();
-	const shouldShowSiteEditorSuggestions = isSiteEditorSurface( sectionName, currentRoute );
 
 	// Default suggestions - used when Big Sky doesn't provide custom ones
 	const defaultSuggestions = useMemo(
@@ -165,24 +177,34 @@ export function useEmptyViewSuggestions( {
 
 	// Wait for WordPress core store to be ready (specifically theme data)
 	// This is needed because Big Sky's getEmptyViewSuggestions filters by theme
-	const isCoreStoreReady = useSelect(
+	const editorState = useSelect(
 		( select ) => {
 			if ( ! hasBigSkySuggestions ) {
-				return true; // No need to wait if not using Big Sky suggestions
+				return { isCoreStoreReady: true, currentPostType: undefined }; // No need to wait if not using Big Sky suggestions
 			}
 			try {
 				const coreStore = select( 'core' ) as {
 					getCurrentTheme?: () => unknown;
 				};
+				const editorStore = select( 'core/editor' ) as {
+					getCurrentPostType?: () => string | undefined;
+				};
 				// Check if getCurrentTheme returns a value (meaning store is ready)
 				const theme = coreStore?.getCurrentTheme?.();
-				return !! theme;
+				return {
+					isCoreStoreReady: !! theme,
+					currentPostType: editorStore?.getCurrentPostType?.(),
+				};
 			} catch {
-				return false;
+				return { isCoreStoreReady: false, currentPostType: undefined };
 			}
 		},
 		[ hasBigSkySuggestions ]
 	);
+	const isCoreStoreReady = editorState.isCoreStoreReady;
+	const shouldShowSiteEditorSuggestions =
+		isSiteEditorSurface( sectionName, currentRoute ) ||
+		isPageEditorSurface( editorState.currentPostType, currentRoute );
 
 	// Compute empty view suggestions once when store is ready
 	const [ emptyViewSuggestions, setEmptyViewSuggestions ] = useState< Suggestion[] | null >( null );

--- a/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
+++ b/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
@@ -129,8 +129,29 @@ function isSiteEditorSurface( sectionName: string, currentRoute?: string ): bool
 	return sectionName === 'site-editor' || isSiteEditorRoute( currentRoute );
 }
 
+function getRuntimeCurrentPostType(): string | undefined {
+	if ( typeof window === 'undefined' ) {
+		return undefined;
+	}
+
+	const runtime = window as unknown as {
+		agentsManagerData?: { currentScreen?: { postType?: unknown } };
+		bigSkyInitialState?: { currentScreen?: { postType?: unknown } };
+	};
+	const postType =
+		runtime.agentsManagerData?.currentScreen?.postType ??
+		runtime.bigSkyInitialState?.currentScreen?.postType;
+
+	return typeof postType === 'string' ? postType : undefined;
+}
+
 function isPageEditorSurface( currentPostType?: string, currentRoute?: string ): boolean {
-	return currentPostType === 'page' || !! currentRoute?.includes( 'post_type=page' );
+	return (
+		currentPostType === 'page' ||
+		getRuntimeCurrentPostType() === 'page' ||
+		!! currentRoute?.includes( 'post_type=page' ) ||
+		( typeof document !== 'undefined' && document.body?.classList.contains( 'post-type-page' ) )
+	);
 }
 
 function filterEmptyViewSuggestions(

--- a/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
@@ -4,6 +4,8 @@ import UnavailableToolMessage from '../../components/unavailable-tool-message';
 import convertToolMessagesToComponents from '../convert-tool-messages-to-components';
 import { isEditorPage } from '../is-editor-page';
 import {
+	BIG_SKY_SHOW_COMPONENT_ABILITY,
+	BIG_SKY_SHOW_COMPONENT_AGENTTIC_TOOL_ID,
 	BIG_SKY_SHOW_COMPONENT_TOOL_ID,
 	JETPACK_AI_SHOW_COMPONENT_TOOL_ID,
 } from '../show-component-tools';
@@ -23,6 +25,8 @@ const MockComponent = jest.fn();
 const mockOnSubmit = jest.fn();
 const SHOW_COMPONENT_TOOL_ID = JETPACK_AI_SHOW_COMPONENT_TOOL_ID;
 const LEGACY_SHOW_COMPONENT_TOOL_ID = BIG_SKY_SHOW_COMPONENT_TOOL_ID;
+const RAW_BIG_SKY_SHOW_COMPONENT_TOOL_ID = BIG_SKY_SHOW_COMPONENT_ABILITY;
+const AGENTTIC_BIG_SKY_SHOW_COMPONENT_TOOL_ID = BIG_SKY_SHOW_COMPONENT_AGENTTIC_TOOL_ID;
 
 const convertWithDefaults = (
 	options: Omit< Parameters< typeof convertToolMessagesToComponents >[ 0 ], 'onSubmit' >
@@ -101,6 +105,9 @@ describe( 'convertToolMessagesToComponents', () => {
 				contentType: 'my-component',
 			},
 		} );
+		expect( getChatComponent ).toHaveBeenCalledWith( 'my-component', {
+			toolId: SHOW_COMPONENT_TOOL_ID,
+		} );
 	} );
 
 	it( 'renders legacy Big Sky show-component messages during migration', () => {
@@ -121,6 +128,336 @@ describe( 'convertToolMessagesToComponents', () => {
 			type: 'component',
 			component: MockComponent,
 			componentProps: { name: 'test', contentType: 'my-component' },
+		} );
+		expect( getChatComponent ).toHaveBeenCalledWith( 'my-component', {
+			toolId: LEGACY_SHOW_COMPONENT_TOOL_ID,
+		} );
+	} );
+
+	it( 'renders a Big Sky picker from a streamed tool call when Agenttic omits agentMessage', () => {
+		const toolCall = createMessage( {
+			id: 'tool-call-1',
+			content: [
+				{
+					type: 'data',
+					data: {
+						toolCallId: 'toolu_1',
+						toolId: LEGACY_SHOW_COMPONENT_TOOL_ID,
+						arguments: {
+							type: 'font-picker',
+							props: { fontPairings: [ { heading: 'Inter', body: 'Lora' } ] },
+							summary: 'Here are some fonts.',
+							followUpTasks: false,
+						},
+					},
+				},
+			],
+		} );
+		const emptyToolResult = createMessage( {
+			id: 'tool-result-1',
+			content: [
+				{
+					type: 'data',
+					data: {
+						toolCallId: 'toolu_1',
+						result: undefined,
+					},
+				},
+			],
+		} );
+		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
+
+		const result = convertWithDefaults( {
+			messages: [ toolCall, emptyToolResult ],
+			getChatComponent,
+		} );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].id ).toBe( 'tool-result-1' );
+		expect( result[ 0 ].content[ 0 ] ).toMatchObject( {
+			type: 'text',
+			text: 'Here are some fonts.',
+		} );
+		expect( result[ 0 ].content[ 1 ] ).toMatchObject( {
+			type: 'component',
+			component: MockComponent,
+			componentProps: {
+				fontPairings: [ { heading: 'Inter', body: 'Lora' } ],
+				summary: 'Here are some fonts.',
+				contentType: 'font-picker',
+			},
+		} );
+		expect( result[ 0 ] ).toMatchObject( { disabled: false } );
+		expect( getChatComponent ).toHaveBeenCalledWith( 'font-picker', {
+			toolId: LEGACY_SHOW_COMPONENT_TOOL_ID,
+		} );
+	} );
+
+	it( 'renders raw Big Sky show-component tool calls emitted by WordPress abilities', () => {
+		const toolCall = createMessage( {
+			id: 'tool-call-1',
+			content: [
+				{
+					type: 'data',
+					data: {
+						toolCallId: 'toolu_1',
+						toolId: RAW_BIG_SKY_SHOW_COMPONENT_TOOL_ID,
+						arguments: {
+							type: 'color-picker',
+							props: { palettes: [ { name: 'Ocean' } ] },
+							summary: 'Here are some colors.',
+							followUpTasks: false,
+						},
+					},
+				},
+			],
+		} );
+		const emptyToolResult = createMessage( {
+			id: 'tool-result-1',
+			content: [
+				{
+					type: 'data',
+					data: {
+						toolCallId: 'toolu_1',
+						result: undefined,
+					},
+				},
+			],
+		} );
+		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
+
+		const result = convertWithDefaults( {
+			messages: [ toolCall, emptyToolResult ],
+			getChatComponent,
+		} );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].id ).toBe( 'tool-result-1' );
+		expect( result[ 0 ].content[ 0 ] ).toMatchObject( {
+			type: 'text',
+			text: 'Here are some colors.',
+		} );
+		expect( result[ 0 ].content[ 1 ] ).toMatchObject( {
+			type: 'component',
+			component: MockComponent,
+			componentProps: {
+				palettes: [ { name: 'Ocean' } ],
+				summary: 'Here are some colors.',
+				contentType: 'color-picker',
+			},
+		} );
+		expect( result[ 0 ] ).toMatchObject( { disabled: false } );
+		expect( getChatComponent ).toHaveBeenCalledWith( 'color-picker', {
+			toolId: RAW_BIG_SKY_SHOW_COMPONENT_TOOL_ID,
+		} );
+	} );
+
+	it( 'renders hyphenated Big Sky show-component tool calls emitted by Agenttic', () => {
+		const toolCall = createMessage( {
+			id: 'tool-call-1',
+			content: [
+				{
+					type: 'data',
+					data: {
+						toolCallId: 'toolu_1',
+						toolId: AGENTTIC_BIG_SKY_SHOW_COMPONENT_TOOL_ID,
+						arguments: {
+							type: 'color-picker',
+							props: { palettes: [ { name: 'Sunset' } ] },
+							summary: 'Here are some colors.',
+							followUpTasks: false,
+						},
+					},
+				},
+			],
+		} );
+		const emptyToolResult = createMessage( {
+			id: 'tool-result-1',
+			content: [
+				{
+					type: 'data',
+					data: {
+						toolCallId: 'toolu_1',
+						result: undefined,
+					},
+				},
+			],
+		} );
+		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
+
+		const result = convertWithDefaults( {
+			messages: [ toolCall, emptyToolResult ],
+			getChatComponent,
+		} );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].id ).toBe( 'tool-result-1' );
+		expect( result[ 0 ].content[ 1 ] ).toMatchObject( {
+			type: 'component',
+			component: MockComponent,
+			componentProps: {
+				palettes: [ { name: 'Sunset' } ],
+				summary: 'Here are some colors.',
+				contentType: 'color-picker',
+			},
+		} );
+		expect( getChatComponent ).toHaveBeenCalledWith( 'color-picker', {
+			toolId: AGENTTIC_BIG_SKY_SHOW_COMPONENT_TOOL_ID,
+		} );
+	} );
+
+	it( 'renders an orphaned show-component tool call emitted by an input-required result', () => {
+		const toolCall = createMessage( {
+			id: 'tool-call-1',
+			content: [
+				{
+					type: 'data',
+					data: {
+						toolCallId: 'toolu_1',
+						toolId: SHOW_COMPONENT_TOOL_ID,
+						arguments: {
+							type: 'title-picker',
+							props: {
+								titles: [ { title: 'Better WordPress Blogging Tips', explanation: 'Clear.' } ],
+							},
+							isCurrent: true,
+							hideZoomAction: true,
+						},
+					},
+				},
+			],
+		} );
+		const assistantText = createMessage( {
+			id: 'agent-text-1',
+			content: [ { type: 'text', text: 'I suggested a few optimized titles.' } ],
+		} );
+		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
+
+		const result = convertWithDefaults( {
+			messages: [ toolCall, assistantText ],
+			getChatComponent,
+		} );
+
+		expect( result ).toHaveLength( 2 );
+		expect( result[ 0 ].id ).toBe( 'tool-call-1' );
+		expect( result[ 0 ].content[ 0 ] ).toMatchObject( {
+			type: 'component',
+			component: MockComponent,
+			componentProps: {
+				titles: [ { title: 'Better WordPress Blogging Tips', explanation: 'Clear.' } ],
+				contentType: 'title-picker',
+			},
+		} );
+		expect( result[ 0 ] ).toMatchObject( { disabled: false } );
+		expect( result[ 1 ] ).toBe( assistantText );
+		expect( getChatComponent ).toHaveBeenCalledWith( 'title-picker', {
+			toolId: SHOW_COMPONENT_TOOL_ID,
+		} );
+	} );
+
+	it( 'dedupes provider agentMessage UI when the matching tool result renders the same component', () => {
+		const toolCall = createMessage( {
+			id: 'tool-call-1',
+			content: [
+				{
+					type: 'data',
+					data: {
+						toolCallId: 'toolu_1',
+						toolId: SHOW_COMPONENT_TOOL_ID,
+						arguments: {
+							type: 'title-picker',
+							props: {
+								titles: [ { title: 'Better WordPress Blogging Tips', explanation: 'Clear.' } ],
+							},
+							isCurrent: true,
+							hideZoomAction: true,
+						},
+					},
+				},
+			],
+		} );
+		const providerAgentMessage = createToolMessage(
+			SHOW_COMPONENT_TOOL_ID,
+			{
+				type: 'title-picker',
+				props: {
+					titles: [ { title: 'Better WordPress Blogging Tips', explanation: 'Clear.' } ],
+				},
+				isCurrent: true,
+				hideZoomAction: true,
+				calypsoCheckpointId: 'toolu_1',
+			},
+			{ id: 'provider-agent-message-1' }
+		);
+		const toolResult = createMessage( {
+			id: 'tool-result-1',
+			content: [
+				{
+					type: 'data',
+					data: {
+						toolCallId: 'toolu_1',
+						result: 'Component displayed successfully',
+					},
+				},
+			],
+		} );
+		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
+
+		const result = convertWithDefaults( {
+			messages: [ toolCall, providerAgentMessage, toolResult ],
+			getChatComponent,
+		} );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].id ).toBe( 'tool-result-1' );
+		expect( result[ 0 ].content[ 0 ] ).toMatchObject( {
+			type: 'component',
+			component: MockComponent,
+			componentProps: {
+				titles: [ { title: 'Better WordPress Blogging Tips', explanation: 'Clear.' } ],
+				contentType: 'title-picker',
+			},
+		} );
+		expect( result[ 0 ] ).toMatchObject( { disabled: false } );
+	} );
+
+	it( 'dedupes matching live and persisted show-component agent messages', () => {
+		const liveMessage = createToolMessage(
+			LEGACY_SHOW_COMPONENT_TOOL_ID,
+			{
+				type: 'color-picker',
+				props: { palettes: [ { name: 'Rose' } ] },
+				isCurrent: true,
+				calypsoCheckpointId: 'toolu_1',
+			},
+			{ id: 'live-message-1' }
+		);
+		const persistedMessage = createToolMessage(
+			LEGACY_SHOW_COMPONENT_TOOL_ID,
+			{
+				type: 'color-picker',
+				props: { palettes: [ { name: 'Rose' } ] },
+				isCurrent: true,
+				calypsoCheckpointId: 'toolu_1',
+			},
+			{ id: 'persisted-message-1' }
+		);
+		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
+
+		const result = convertWithDefaults( {
+			messages: [ liveMessage, persistedMessage ],
+			getChatComponent,
+		} );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].id ).toBe( 'persisted-message-1' );
+		expect( result[ 0 ].content[ 0 ] ).toMatchObject( {
+			type: 'component',
+			component: MockComponent,
+			componentProps: {
+				palettes: [ { name: 'Rose' } ],
+				contentType: 'color-picker',
+			},
 		} );
 	} );
 
@@ -178,6 +515,29 @@ describe( 'convertToolMessagesToComponents', () => {
 			type: 'component',
 			component: UnavailableToolMessage,
 			componentProps: { type: 'picker' },
+		} );
+	} );
+
+	it( 'renders tool messages when editor context is active outside wp-admin URLs', () => {
+		( isEditorPage as jest.Mock ).mockReturnValue( false );
+		const message = createToolMessage( LEGACY_SHOW_COMPONENT_TOOL_ID, {
+			type: 'my-component',
+			props: { name: 'test' },
+			isCurrent: true,
+		} );
+		const getChatComponent = jest.fn().mockReturnValue( MockComponent );
+
+		const result = convertWithDefaults( {
+			messages: [ message ],
+			getChatComponent,
+			isEditorContext: true,
+		} );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].content[ 0 ] ).toMatchObject( {
+			type: 'component',
+			component: MockComponent,
+			componentProps: { name: 'test', contentType: 'my-component' },
 		} );
 	} );
 

--- a/packages/agents-manager/src/utils/__tests__/create-agent-config.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/create-agent-config.test.ts
@@ -17,6 +17,9 @@ import { createCalypsoAuthProvider } from '../../auth/calypso-auth-provider';
 
 const mockCanConnectToZendesk = canConnectToZendesk as jest.Mock;
 const mockCreateCalypsoAuthProvider = createCalypsoAuthProvider as jest.Mock;
+type ToolProviderOption = NonNullable<
+	Parameters< typeof createAgentConfig >[ 0 ][ 'toolProvider' ]
+>;
 
 function setAgentsManagerData( data: Record< string, unknown > ) {
 	( window as unknown as { agentsManagerData?: Record< string, unknown > } ).agentsManagerData =
@@ -192,5 +195,93 @@ describe( 'createAgentConfig', () => {
 				},
 			} )
 		);
+	} );
+
+	it( 'returns empty abilities when the final tool provider returns an invalid payload', async () => {
+		const warnSpy = jest.spyOn( console, 'warn' ).mockImplementation();
+		const config = await createAgentConfig( {
+			sessionId: 'session-1',
+			toolProvider: {
+				getAbilities: jest.fn().mockResolvedValue( undefined ),
+				executeAbility: jest.fn(),
+			} as unknown as ToolProviderOption,
+		} );
+
+		expect( config.toolProvider?.getAbilities ).toEqual( expect.any( Function ) );
+		await expect( config.toolProvider!.getAbilities!() ).resolves.toEqual( [] );
+		expect( warnSpy ).toHaveBeenCalledWith(
+			'[AgentsManager] Tool provider returned invalid abilities; expected array.'
+		);
+
+		warnSpy.mockRestore();
+	} );
+
+	it( 'filters malformed abilities and removes null annotation values', async () => {
+		const config = await createAgentConfig( {
+			sessionId: 'session-1',
+			toolProvider: {
+				getAbilities: jest.fn().mockResolvedValue( [
+					{
+						name: 'valid/tool',
+						meta: {
+							annotations: {
+								readonly: null,
+								destructive: true,
+							},
+						},
+					},
+					{ label: 'Missing name' },
+				] ),
+				executeAbility: jest.fn(),
+			} as unknown as ToolProviderOption,
+		} );
+
+		expect( config.toolProvider?.getAbilities ).toEqual( expect.any( Function ) );
+		await expect( config.toolProvider!.getAbilities!() ).resolves.toEqual( [
+			{
+				name: 'valid/tool',
+				meta: {
+					annotations: {
+						destructive: true,
+					},
+				},
+			},
+		] );
+	} );
+
+	it( 'preserves ability callbacks while normalizing metadata', async () => {
+		const callback = jest.fn();
+		const ability = {
+			name: 'jetpack_ai__show_component',
+			meta: {
+				annotations: {
+					readonly: null,
+					destructive: false,
+				},
+			},
+		};
+		Object.defineProperty( ability, 'callback', {
+			value: callback,
+			enumerable: false,
+		} );
+		const config = await createAgentConfig( {
+			sessionId: 'session-1',
+			toolProvider: {
+				getAbilities: jest.fn().mockResolvedValue( [ ability ] ),
+				executeAbility: jest.fn(),
+			} as unknown as ToolProviderOption,
+		} );
+
+		await expect( config.toolProvider!.getAbilities!() ).resolves.toEqual( [
+			{
+				name: 'jetpack_ai__show_component',
+				meta: {
+					annotations: {
+						destructive: false,
+					},
+				},
+				callback,
+			},
+		] );
 	} );
 } );

--- a/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
@@ -471,6 +471,51 @@ describe( 'loadExternalProviders', () => {
 		warnSpy.mockRestore();
 	} );
 
+	it( 'keeps last successful provider abilities when execution-time refresh fails', async () => {
+		const warnSpy = jest.spyOn( console, 'warn' ).mockImplementation();
+		let shouldFailRefresh = false;
+		const executeAbility = jest.fn().mockResolvedValue( { result: { provider: 'jetpack' } } );
+		const provider = {
+			toolProvider: {
+				getAbilities: jest.fn( async () => {
+					if ( shouldFailRefresh ) {
+						throw new Error( 'transient provider failure' );
+					}
+					return [ { name: 'jetpack-ai/show-component' } ];
+				} ),
+				executeAbility,
+			},
+		};
+		const agentsManagerData = {
+			agentId: 'wp-orchestrator',
+			agentProviders: [ provider ],
+		};
+		( globalThis as typeof globalThis & { agentsManagerData?: unknown } ).agentsManagerData =
+			agentsManagerData;
+
+		const providers = await loadExternalProviders();
+
+		expect( await providers.toolProvider?.getAbilities() ).toEqual( [
+			{ name: 'jetpack-ai/show-component' },
+		] );
+
+		shouldFailRefresh = true;
+
+		await providers.toolProvider?.executeAbility( 'jetpack_ai__show_component', {
+			type: 'title-picker',
+		} );
+
+		expect( executeAbility ).toHaveBeenCalledWith( 'jetpack-ai/show-component', {
+			type: 'title-picker',
+		} );
+		expect( warnSpy ).toHaveBeenCalledWith(
+			'[AgentsManager] Failed to load abilities from provider:',
+			expect.any( Error )
+		);
+
+		warnSpy.mockRestore();
+	} );
+
 	it( 'adds callbacks for a single provider so UI agent messages are promoted', async () => {
 		const bigSkyResult = {
 			result: { success: true, message: 'Pick a palette.' },

--- a/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
@@ -4,6 +4,7 @@
 import {
 	loadExternalProviders,
 	mergeCapabilitiesInto,
+	mergeContextProviders,
 	mergeUseSuggestionsHooks,
 } from '../load-external-providers';
 import type { ProviderCapabilities, UseSuggestionsHook } from '../load-external-providers';
@@ -65,6 +66,108 @@ describe( 'mergeCapabilitiesInto', () => {
 		const merged: ProviderCapabilities = {};
 		mergeCapabilitiesInto( merged, lazyCapabilities );
 		expect( merged.supportsSplitScreen ).toBe( true );
+	} );
+} );
+
+describe( 'mergeContextProviders', () => {
+	it( 'preserves earlier provider editor context while filling missing fields from later providers', () => {
+		const provider = mergeContextProviders( [
+			{
+				getClientContext: () => ( {
+					url: 'https://example.com/wp-admin/post.php?post=1&action=edit',
+					pathname: '/wp-admin/post.php',
+					search: '?post=1&action=edit',
+					environment: 'wp-admin',
+					currentScreen: {
+						url: 'https://example.com/wp-admin/post.php?post=1&action=edit',
+					},
+					currentPageContent: [ { id: 'big-sky-block' } ],
+					selectedBlockClientId: 'short-selected-id',
+					contextEntries: [
+						{
+							id: 'big-sky-page-context',
+							type: 'big-sky-page-context',
+						},
+					],
+				} ),
+			},
+			{
+				getClientContext: () => ( {
+					url: 'https://example.com/wp-admin/post.php?post=1&action=edit',
+					pathname: '/wp-admin/post.php',
+					search: '?post=1&action=edit',
+					environment: 'gutenberg',
+					titleSuggestionCount: 3,
+					currentScreen: {
+						postType: 'page',
+					},
+					currentPageContent: [ { id: 'jetpack-block' } ],
+					selectedBlockClientId: 'short-selected-id',
+					contextEntries: [
+						{
+							id: 'selected-block-content',
+							type: 'selected-block-content',
+							data: { content: 'Selected text' },
+						},
+					],
+				} ),
+			},
+		] );
+
+		expect( provider?.getClientContext() ).toEqual(
+			expect.objectContaining( {
+				environment: 'wp-admin',
+				titleSuggestionCount: 3,
+				currentScreen: {
+					url: 'https://example.com/wp-admin/post.php?post=1&action=edit',
+					postType: 'page',
+				},
+				currentPageContent: [ { id: 'big-sky-block' } ],
+				selectedBlockClientId: 'short-selected-id',
+				contextEntries: [
+					{
+						id: 'big-sky-page-context',
+						type: 'big-sky-page-context',
+					},
+					{
+						id: 'selected-block-content',
+						type: 'selected-block-content',
+						data: { content: 'Selected text' },
+					},
+				],
+			} )
+		);
+	} );
+
+	it( 'keeps earlier provider selected block id when later selected-block context is present', () => {
+		const provider = mergeContextProviders( [
+			{
+				getClientContext: () => ( {
+					environment: 'wp-admin',
+					selectedBlockClientId: 'short-selected-id',
+				} ),
+			},
+			{
+				getClientContext: () => ( {
+					environment: 'gutenberg',
+					selectedBlockClientId: 'raw-selected-id',
+					contextEntries: [
+						{
+							id: 'selected-block-content',
+							type: 'selected-block-content',
+							data: { content: 'Selected text' },
+						},
+					],
+				} ),
+			},
+		] );
+
+		expect( provider?.getClientContext() ).toEqual(
+			expect.objectContaining( {
+				environment: 'wp-admin',
+				selectedBlockClientId: 'short-selected-id',
+			} )
+		);
 	} );
 } );
 
@@ -526,6 +629,64 @@ describe( 'loadExternalProviders', () => {
 			providers.getChatComponent?.( 'title-picker', { toolId: 'big_sky__show_component' } )
 		).toBe( BigSkyTitlePicker );
 		expect( providers.getChatComponent?.( 'title-picker' ) ).toBe( BigSkyTitlePicker );
+	} );
+
+	it( 'composes Big Sky and Jetpack context providers without replacing Big Sky editor context', async () => {
+		const bigSkyProvider = {
+			contextProvider: {
+				getClientContext: () => ( {
+					url: 'https://example.com/wp-admin/post.php?post=1&action=edit',
+					pathname: '/wp-admin/post.php',
+					search: '?post=1&action=edit',
+					environment: 'wp-admin',
+					currentPageContent: [ { id: 'big-sky-block' } ],
+					selectedBlockClientId: 'short-selected-id',
+				} ),
+			},
+		};
+		const jetpackProvider = {
+			contextProvider: {
+				getClientContext: () => ( {
+					url: 'https://example.com/wp-admin/post.php?post=1&action=edit',
+					pathname: '/wp-admin/post.php',
+					search: '?post=1&action=edit',
+					environment: 'gutenberg',
+					titleSuggestionCount: 3,
+					selectedBlockClientId: 'raw-selected-id',
+					contextEntries: [
+						{
+							id: 'selected-block-content',
+							type: 'selected-block-content',
+							data: { content: 'Selected text' },
+						},
+					],
+				} ),
+			},
+		};
+		const agentsManagerData = {
+			agentId: 'wp-orchestrator',
+			agentProviders: [ bigSkyProvider, jetpackProvider ],
+		};
+		( globalThis as typeof globalThis & { agentsManagerData?: unknown } ).agentsManagerData =
+			agentsManagerData;
+
+		const providers = await loadExternalProviders();
+
+		expect( providers.contextProvider?.getClientContext() ).toEqual(
+			expect.objectContaining( {
+				environment: 'wp-admin',
+				titleSuggestionCount: 3,
+				currentPageContent: [ { id: 'big-sky-block' } ],
+				selectedBlockClientId: 'short-selected-id',
+				contextEntries: [
+					{
+						id: 'selected-block-content',
+						type: 'selected-block-content',
+						data: { content: 'Selected text' },
+					},
+				],
+			} )
+		);
 	} );
 
 	it( 'falls through to Jetpack for legacy show-component messages with Jetpack-only component types', async () => {

--- a/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
@@ -144,12 +144,18 @@ describe( 'mergeContextProviders', () => {
 			{
 				getClientContext: () => ( {
 					environment: 'wp-admin',
+					url: 'https://example.com/wp-admin/post.php?post=1&action=edit',
+					pathname: '/wp-admin/post.php',
+					search: '?post=1&action=edit',
 					selectedBlockClientId: 'short-selected-id',
 				} ),
 			},
 			{
 				getClientContext: () => ( {
 					environment: 'gutenberg',
+					url: 'https://example.com/wp-admin/post.php?post=1&action=edit',
+					pathname: '/wp-admin/post.php',
+					search: '?post=1&action=edit',
 					selectedBlockClientId: 'raw-selected-id',
 					contextEntries: [
 						{

--- a/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
@@ -90,6 +90,566 @@ describe( 'loadExternalProviders', () => {
 		expect( providers.contextProvider ).toBeUndefined();
 		expect( providers.useSuggestions ).toEqual( expect.any( Function ) );
 	} );
+
+	it( 'does not freeze provider abilities before hook-dependent abilities register', async () => {
+		let showComponentRegistered = false;
+		const executeAbility = jest.fn().mockResolvedValue( { result: { provider: 'big-sky' } } );
+		const provider = {
+			toolProvider: {
+				getAbilities: jest.fn( async () =>
+					showComponentRegistered ? [ { name: 'big-sky/show-component' } ] : []
+				),
+				executeAbility,
+			},
+		};
+		const agentsManagerData = {
+			agentId: 'wp-orchestrator',
+			agentProviders: [ provider ],
+		};
+		( globalThis as typeof globalThis & { agentsManagerData?: unknown } ).agentsManagerData =
+			agentsManagerData;
+
+		const providers = await loadExternalProviders();
+
+		expect( provider.toolProvider.getAbilities ).not.toHaveBeenCalled();
+		expect( await providers.toolProvider?.getAbilities() ).toEqual( [] );
+
+		showComponentRegistered = true;
+
+		expect( await providers.toolProvider?.getAbilities() ).toEqual( [
+			{ name: 'big-sky/show-component' },
+		] );
+
+		await providers.toolProvider?.executeAbility( 'big_sky__show_component', {
+			type: 'color-picker',
+		} );
+
+		expect( executeAbility ).toHaveBeenCalledWith( 'big-sky/show-component', {
+			type: 'color-picker',
+		} );
+	} );
+
+	it( 'composes tool providers in registration order with first-provider-wins duplicates', async () => {
+		const firstExecuteAbility = jest.fn().mockResolvedValue( { result: { provider: 'first' } } );
+		const secondExecuteAbility = jest.fn().mockResolvedValue( { result: { provider: 'second' } } );
+		const firstProvider = {
+			toolProvider: {
+				getAbilities: jest.fn().mockResolvedValue( [
+					{ name: 'wpcom/update-block-content', label: 'First shared' },
+					{ name: 'first-only', label: 'First only' },
+				] ),
+				executeAbility: firstExecuteAbility,
+			},
+		};
+		const secondProvider = {
+			toolProvider: {
+				getAbilities: jest.fn().mockResolvedValue( [
+					{ name: 'wpcom/update-block-content', label: 'Second shared' },
+					{ name: 'second-only', label: 'Second only' },
+				] ),
+				executeAbility: secondExecuteAbility,
+			},
+		};
+		const agentsManagerData = {
+			agentId: 'wp-orchestrator',
+			agentProviders: [ firstProvider, secondProvider ],
+		};
+		( globalThis as typeof globalThis & { agentsManagerData?: unknown } ).agentsManagerData =
+			agentsManagerData;
+
+		const providers = await loadExternalProviders();
+		const abilities = await providers.toolProvider?.getAbilities();
+
+		expect( abilities ).toEqual( [
+			{ name: 'wpcom/update-block-content', label: 'First shared' },
+			{ name: 'first-only', label: 'First only' },
+			{ name: 'second-only', label: 'Second only' },
+		] );
+
+		await providers.toolProvider?.executeAbility( 'wpcom__update_block_content', {} );
+		await providers.toolProvider?.executeAbility( 'second-only', {} );
+
+		expect( firstExecuteAbility ).toHaveBeenCalledWith( 'wpcom/update-block-content', {} );
+		expect( secondExecuteAbility ).toHaveBeenCalledWith( 'second-only', {} );
+	} );
+
+	it( 'keeps the first provider for equivalent raw and normalized non-show-component ability names', async () => {
+		const firstExecuteAbility = jest.fn().mockResolvedValue( { result: { provider: 'first' } } );
+		const secondExecuteAbility = jest.fn().mockResolvedValue( { result: { provider: 'second' } } );
+		const firstProvider = {
+			toolProvider: {
+				getAbilities: jest.fn().mockResolvedValue( [ { name: 'wpcom__update_block_content' } ] ),
+				executeAbility: firstExecuteAbility,
+			},
+		};
+		const secondProvider = {
+			toolProvider: {
+				getAbilities: jest.fn().mockResolvedValue( [ { name: 'wpcom/update-block-content' } ] ),
+				executeAbility: secondExecuteAbility,
+			},
+		};
+		const agentsManagerData = {
+			agentId: 'wp-orchestrator',
+			agentProviders: [ firstProvider, secondProvider ],
+		};
+		( globalThis as typeof globalThis & { agentsManagerData?: unknown } ).agentsManagerData =
+			agentsManagerData;
+
+		const providers = await loadExternalProviders();
+
+		expect( await providers.toolProvider?.getAbilities() ).toEqual( [
+			{ name: 'wpcom__update_block_content' },
+		] );
+
+		await providers.toolProvider?.executeAbility( 'wpcom/update-block-content', {} );
+
+		expect( firstExecuteAbility ).toHaveBeenCalledWith( 'wpcom__update_block_content', {} );
+		expect( secondExecuteAbility ).not.toHaveBeenCalled();
+	} );
+
+	it( 'keeps Big Sky ownership for show-component even when Jetpack legacy alias loads first', async () => {
+		const bigSkyResult = {
+			result: { provider: 'big-sky' },
+			returnToAgent: true,
+			agentMessage: JSON.stringify( {
+				tool_id: 'big_sky__show_component',
+				data: { type: 'color-picker' },
+			} ),
+		};
+		const bigSkyExecuteAbility = jest.fn().mockResolvedValue( bigSkyResult );
+		const jetpackExecuteAbility = jest
+			.fn()
+			.mockResolvedValue( { result: { provider: 'jetpack' } } );
+		const BigSkyColorPicker = () => null;
+		const JetpackTitlePicker = () => null;
+		const jetpackProvider = {
+			toolProvider: {
+				getAbilities: jest
+					.fn()
+					.mockResolvedValue( [
+						{ name: 'jetpack_ai__show_component' },
+						{ name: 'big_sky__show_component' },
+					] ),
+				executeAbility: jetpackExecuteAbility,
+			},
+			getChatComponent: jest.fn( ( type: string ) =>
+				type === 'title-picker' ? JetpackTitlePicker : null
+			),
+		};
+		const bigSkyProvider = {
+			toolProvider: {
+				getAbilities: jest.fn().mockResolvedValue( [ { name: 'big-sky/show-component' } ] ),
+				executeAbility: bigSkyExecuteAbility,
+			},
+			getChatComponent: jest.fn( ( type: string ) =>
+				type === 'color-picker' ? BigSkyColorPicker : null
+			),
+		};
+		const agentsManagerData = {
+			agentId: 'wp-orchestrator',
+			agentProviders: [ jetpackProvider, bigSkyProvider ],
+		};
+		( globalThis as typeof globalThis & { agentsManagerData?: unknown } ).agentsManagerData =
+			agentsManagerData;
+
+		const providers = await loadExternalProviders();
+
+		const abilities = await providers.toolProvider?.getAbilities();
+		expect( abilities ).toEqual( [
+			{ name: 'jetpack_ai__show_component' },
+			{ name: 'big-sky/show-component' },
+		] );
+		const bigSkyShowComponentAbility = abilities?.find(
+			( ability ) => ability.name === 'big-sky/show-component'
+		);
+
+		expect( bigSkyShowComponentAbility?.callback ).toEqual( expect.any( Function ) );
+		await expect(
+			bigSkyShowComponentAbility?.callback?.( { type: 'color-picker' } )
+		).resolves.toBe( bigSkyResult );
+
+		await providers.toolProvider?.executeAbility( 'big_sky__show_component', {
+			type: 'color-picker',
+		} );
+		await providers.toolProvider?.executeAbility( 'big-sky-show-component', {
+			type: 'font-picker',
+		} );
+
+		expect( bigSkyExecuteAbility ).toHaveBeenCalledWith( 'big-sky/show-component', {
+			type: 'color-picker',
+		} );
+		expect( bigSkyExecuteAbility ).toHaveBeenCalledWith( 'big-sky/show-component', {
+			type: 'font-picker',
+		} );
+		expect( jetpackExecuteAbility ).not.toHaveBeenCalledWith(
+			'big_sky__show_component',
+			expect.anything()
+		);
+		expect(
+			providers.getChatComponent?.( 'color-picker', { toolId: 'big_sky__show_component' } )
+		).toBe( BigSkyColorPicker );
+		expect(
+			providers.getChatComponent?.( 'color-picker', { toolId: 'big-sky-show-component' } )
+		).toBe( BigSkyColorPicker );
+		expect(
+			providers.getChatComponent?.( 'title-picker', { toolId: 'jetpack_ai__show_component' } )
+		).toBe( JetpackTitlePicker );
+	} );
+
+	it( 'continues loading later providers when one provider import fails', async () => {
+		const warnSpy = jest.spyOn( console, 'warn' ).mockImplementation();
+		const provider = {
+			toolProvider: {
+				getAbilities: jest.fn().mockResolvedValue( [ { name: 'second-only' } ] ),
+				executeAbility: jest.fn(),
+			},
+		};
+		const agentsManagerData = {
+			agentId: 'wp-orchestrator',
+			agentProviders: [ 'https://example.invalid/missing-provider.mjs', provider ],
+		};
+		( globalThis as typeof globalThis & { agentsManagerData?: unknown } ).agentsManagerData =
+			agentsManagerData;
+
+		const providers = await loadExternalProviders();
+
+		expect( await providers.toolProvider?.getAbilities() ).toEqual( [ { name: 'second-only' } ] );
+		expect( warnSpy ).toHaveBeenCalledWith(
+			expect.stringContaining( 'Failed to load provider' ),
+			expect.anything()
+		);
+
+		warnSpy.mockRestore();
+	} );
+
+	it( 'continues composing later providers when one provider returns invalid abilities', async () => {
+		const warnSpy = jest.spyOn( console, 'warn' ).mockImplementation();
+		const badProvider = {
+			toolProvider: {
+				getAbilities: jest.fn().mockResolvedValue( undefined ),
+				executeAbility: jest.fn(),
+			},
+		};
+		const goodProvider = {
+			toolProvider: {
+				getAbilities: jest
+					.fn()
+					.mockResolvedValue( [ { name: 'good-provider/tool' }, { label: 'Missing name' } ] ),
+				executeAbility: jest.fn().mockResolvedValue( { result: { provider: 'good' } } ),
+			},
+		};
+		const agentsManagerData = {
+			agentId: 'wp-orchestrator',
+			agentProviders: [ badProvider, goodProvider ],
+		};
+		( globalThis as typeof globalThis & { agentsManagerData?: unknown } ).agentsManagerData =
+			agentsManagerData;
+
+		const providers = await loadExternalProviders();
+
+		expect( await providers.toolProvider?.getAbilities() ).toEqual( [
+			{ name: 'good-provider/tool' },
+		] );
+		await providers.toolProvider?.executeAbility( 'good_provider__tool', {} );
+		expect( goodProvider.toolProvider.executeAbility ).toHaveBeenCalledWith(
+			'good-provider/tool',
+			{}
+		);
+		expect( warnSpy ).toHaveBeenCalledWith(
+			'[AgentsManager] Provider returned invalid abilities; expected array.'
+		);
+
+		warnSpy.mockRestore();
+	} );
+
+	it( 'adds callbacks for a single provider so UI agent messages are promoted', async () => {
+		const bigSkyResult = {
+			result: { success: true, message: 'Pick a palette.' },
+			returnToAgent: true,
+			agentMessage: JSON.stringify( {
+				tool_id: 'big_sky__show_component',
+				data: { type: 'color-picker' },
+			} ),
+		};
+		const bigSkyExecuteAbility = jest.fn().mockResolvedValue( bigSkyResult );
+		const BigSkyColorPicker = () => null;
+		const bigSkyProvider = {
+			toolProvider: {
+				getAbilities: jest.fn().mockResolvedValue( [ { name: 'big-sky/show-component' } ] ),
+				executeAbility: bigSkyExecuteAbility,
+			},
+			getChatComponent: jest.fn( ( type: string ) =>
+				type === 'color-picker' ? BigSkyColorPicker : null
+			),
+		};
+		const agentsManagerData = {
+			agentId: 'dolly',
+			agentProviders: [ bigSkyProvider ],
+		};
+		( globalThis as typeof globalThis & { agentsManagerData?: unknown } ).agentsManagerData =
+			agentsManagerData;
+
+		const providers = await loadExternalProviders();
+		const abilities = await providers.toolProvider?.getAbilities();
+		const showComponentAbility = abilities?.find(
+			( ability ) => ability.name === 'big-sky/show-component'
+		);
+
+		expect( abilities ).toEqual( [ { name: 'big-sky/show-component' } ] );
+		expect( showComponentAbility?.callback ).toEqual( expect.any( Function ) );
+		await expect( showComponentAbility?.callback?.( { type: 'color-picker' } ) ).resolves.toBe(
+			bigSkyResult
+		);
+		expect( bigSkyExecuteAbility ).toHaveBeenCalledWith( 'big-sky/show-component', {
+			type: 'color-picker',
+		} );
+		expect(
+			providers.getChatComponent?.( 'color-picker', { toolId: 'big_sky__show_component' } )
+		).toBe( BigSkyColorPicker );
+	} );
+
+	it( 'loads Jetpack AI by itself when no host provider is present', async () => {
+		const JetpackTitlePicker = () => null;
+		const jetpackToolProvider = {
+			getAbilities: jest.fn().mockResolvedValue( [ { name: 'jetpack_ai__show_component' } ] ),
+			executeAbility: jest.fn().mockResolvedValue( { result: { provider: 'jetpack' } } ),
+		};
+		const jetpackProvider = {
+			toolProvider: jetpackToolProvider,
+			getChatComponent: jest.fn( ( type: string ) =>
+				type === 'title-picker' ? JetpackTitlePicker : null
+			),
+		};
+		const agentsManagerData = {
+			agentId: 'wp-orchestrator',
+			agentProviders: [ jetpackProvider ],
+		};
+		( globalThis as typeof globalThis & { agentsManagerData?: unknown } ).agentsManagerData =
+			agentsManagerData;
+
+		const providers = await loadExternalProviders();
+		const abilities = await providers.toolProvider?.getAbilities();
+
+		expect( abilities ).toEqual( [ { name: 'jetpack_ai__show_component' } ] );
+		expect( abilities?.[ 0 ]?.callback ).toEqual( expect.any( Function ) );
+		await providers.toolProvider?.executeAbility( 'jetpack_ai__show_component', {} );
+		expect( jetpackToolProvider.executeAbility ).toHaveBeenCalledWith(
+			'jetpack_ai__show_component',
+			{}
+		);
+		expect(
+			providers.getChatComponent?.( 'title-picker', { toolId: 'jetpack_ai__show_component' } )
+		).toBe( JetpackTitlePicker );
+	} );
+
+	it( 'promotes nested provider agent messages returned by executeAbility', async () => {
+		const agentMessage = JSON.stringify( {
+			tool_id: 'jetpack_ai__show_component',
+			data: { type: 'title-picker' },
+		} );
+		const jetpackExecuteAbility = jest.fn().mockResolvedValue( {
+			result: {
+				result: 'Component displayed successfully',
+				returnToAgent: false,
+				agentMessage,
+			},
+			returnToAgent: false,
+		} );
+		const jetpackProvider = {
+			toolProvider: {
+				getAbilities: jest.fn().mockResolvedValue( [ { name: 'jetpack_ai__show_component' } ] ),
+				executeAbility: jetpackExecuteAbility,
+			},
+		};
+		const agentsManagerData = {
+			agentId: 'wp-orchestrator',
+			agentProviders: [ jetpackProvider ],
+		};
+		( globalThis as typeof globalThis & { agentsManagerData?: unknown } ).agentsManagerData =
+			agentsManagerData;
+
+		const providers = await loadExternalProviders();
+		const abilities = await providers.toolProvider?.getAbilities();
+		const showComponentAbility = abilities?.find(
+			( ability ) => ability.name === 'jetpack_ai__show_component'
+		);
+
+		await expect(
+			showComponentAbility?.callback?.( {
+				type: 'title-picker',
+			} )
+		).resolves.toEqual(
+			expect.objectContaining( {
+				agentMessage,
+			} )
+		);
+		expect( jetpackExecuteAbility ).toHaveBeenCalledWith( 'jetpack_ai__show_component', {
+			type: 'title-picker',
+		} );
+	} );
+
+	it( 'composes Big Sky and Jetpack while routing source-owned components first', async () => {
+		const BigSkyTitlePicker = () => null;
+		const JetpackTitlePicker = () => null;
+		const bigSkyProvider = {
+			toolProvider: {
+				getAbilities: jest.fn().mockResolvedValue( [ { name: 'big-sky/show-component' } ] ),
+				executeAbility: jest.fn(),
+			},
+			getChatComponent: jest.fn( ( type: string ) =>
+				type === 'title-picker' ? BigSkyTitlePicker : null
+			),
+		};
+		const jetpackProvider = {
+			toolProvider: {
+				getAbilities: jest.fn().mockResolvedValue( [ { name: 'jetpack_ai__show_component' } ] ),
+				executeAbility: jest.fn(),
+			},
+			getChatComponent: jest.fn( ( type: string ) =>
+				type === 'title-picker' ? JetpackTitlePicker : null
+			),
+		};
+		const agentsManagerData = {
+			agentId: 'wp-orchestrator',
+			agentProviders: [ bigSkyProvider, jetpackProvider ],
+		};
+		( globalThis as typeof globalThis & { agentsManagerData?: unknown } ).agentsManagerData =
+			agentsManagerData;
+
+		const providers = await loadExternalProviders();
+		await providers.toolProvider?.getAbilities();
+
+		expect(
+			providers.getChatComponent?.( 'title-picker', { toolId: 'jetpack_ai__show_component' } )
+		).toBe( JetpackTitlePicker );
+		expect(
+			providers.getChatComponent?.( 'title-picker', { toolId: 'big_sky__show_component' } )
+		).toBe( BigSkyTitlePicker );
+		expect( providers.getChatComponent?.( 'title-picker' ) ).toBe( BigSkyTitlePicker );
+	} );
+
+	it( 'falls through to Jetpack for legacy show-component messages with Jetpack-only component types', async () => {
+		const BigSkyFontPicker = () => null;
+		const JetpackTitlePicker = () => null;
+		const bigSkyProvider = {
+			toolProvider: {
+				getAbilities: jest.fn().mockResolvedValue( [ { name: 'big-sky/show-component' } ] ),
+				executeAbility: jest.fn(),
+			},
+			getChatComponent: jest.fn( ( type: string ) =>
+				type === 'font-picker' ? BigSkyFontPicker : null
+			),
+		};
+		const jetpackProvider = {
+			toolProvider: {
+				getAbilities: jest.fn().mockResolvedValue( [ { name: 'jetpack_ai__show_component' } ] ),
+				executeAbility: jest.fn(),
+			},
+			getChatComponent: jest.fn( ( type: string ) =>
+				type === 'title-picker' ? JetpackTitlePicker : null
+			),
+		};
+		const agentsManagerData = {
+			agentId: 'wp-orchestrator',
+			agentProviders: [ bigSkyProvider, jetpackProvider ],
+		};
+		( globalThis as typeof globalThis & { agentsManagerData?: unknown } ).agentsManagerData =
+			agentsManagerData;
+
+		const providers = await loadExternalProviders();
+
+		expect(
+			providers.getChatComponent?.( 'title-picker', { toolId: 'big_sky__show_component' } )
+		).toBe( JetpackTitlePicker );
+		expect(
+			providers.getChatComponent?.( 'font-picker', { toolId: 'big_sky__show_component' } )
+		).toBe( BigSkyFontPicker );
+	} );
+
+	it( 'uses the owning tool provider when a component-only provider is registered first', async () => {
+		const HostTitlePicker = () => null;
+		const JetpackTitlePicker = () => null;
+		const hostProvider = {
+			getChatComponent: jest.fn( ( type: string ) =>
+				type === 'title-picker' ? HostTitlePicker : null
+			),
+		};
+		const jetpackToolProvider = {
+			getAbilities: jest.fn().mockResolvedValue( [ { name: 'jetpack_ai__show_component' } ] ),
+			executeAbility: jest.fn(),
+		};
+		const jetpackProvider = {
+			toolProvider: jetpackToolProvider,
+			getChatComponent: jest.fn( ( type: string ) =>
+				type === 'title-picker' ? JetpackTitlePicker : null
+			),
+		};
+		const agentsManagerData = {
+			agentId: 'wp-orchestrator',
+			agentProviders: [ hostProvider, jetpackProvider ],
+		};
+		( globalThis as typeof globalThis & { agentsManagerData?: unknown } ).agentsManagerData =
+			agentsManagerData;
+
+		const providers = await loadExternalProviders();
+		await providers.toolProvider?.getAbilities();
+
+		expect(
+			providers.getChatComponent?.( 'title-picker', { toolId: 'jetpack_ai__show_component' } )
+		).toBe( JetpackTitlePicker );
+		expect( providers.getChatComponent?.( 'title-picker' ) ).toBe( HostTitlePicker );
+	} );
+
+	it( 'composes a third provider under Unified Chat without changing Big Sky or Jetpack ownership', async () => {
+		const bigSkyExecuteAbility = jest.fn().mockResolvedValue( { result: { provider: 'big-sky' } } );
+		const jetpackExecuteAbility = jest
+			.fn()
+			.mockResolvedValue( { result: { provider: 'jetpack' } } );
+		const unifiedChatExecuteAbility = jest
+			.fn()
+			.mockResolvedValue( { result: { provider: 'unified-chat' } } );
+		const bigSkyProvider = {
+			toolProvider: {
+				getAbilities: jest.fn().mockResolvedValue( [ { name: 'big-sky/show-component' } ] ),
+				executeAbility: bigSkyExecuteAbility,
+			},
+		};
+		const jetpackProvider = {
+			toolProvider: {
+				getAbilities: jest.fn().mockResolvedValue( [ { name: 'jetpack_ai__show_component' } ] ),
+				executeAbility: jetpackExecuteAbility,
+			},
+		};
+		const unifiedChatProvider = {
+			toolProvider: {
+				getAbilities: jest.fn().mockResolvedValue( [ { name: 'unified-chat/search' } ] ),
+				executeAbility: unifiedChatExecuteAbility,
+			},
+		};
+		const agentsManagerData = {
+			agentId: 'wpcom-workflow-unified_chat',
+			agentProviders: [ bigSkyProvider, jetpackProvider, unifiedChatProvider ],
+		};
+		( globalThis as typeof globalThis & { agentsManagerData?: unknown } ).agentsManagerData =
+			agentsManagerData;
+		( window as typeof window & { agentsManagerData?: unknown } ).agentsManagerData =
+			agentsManagerData;
+
+		const providers = await loadExternalProviders();
+
+		expect( await providers.toolProvider?.getAbilities() ).toEqual( [
+			{ name: 'big-sky/show-component' },
+			{ name: 'jetpack_ai__show_component' },
+			{ name: 'unified-chat/search' },
+		] );
+
+		await providers.toolProvider?.executeAbility( 'jetpack_ai__show_component', {} );
+		await providers.toolProvider?.executeAbility( 'unified_chat__search', {} );
+
+		expect( jetpackExecuteAbility ).toHaveBeenCalledWith( 'jetpack_ai__show_component', {} );
+		expect( unifiedChatExecuteAbility ).toHaveBeenCalledWith( 'unified-chat/search', {} );
+		expect( bigSkyExecuteAbility ).not.toHaveBeenCalled();
+	} );
 } );
 
 describe( 'mergeUseSuggestionsHooks', () => {

--- a/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
+++ b/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
@@ -7,6 +7,12 @@ import { getDisplayMessageFromToolData, isDisplayableToolMessageTool } from './t
 import type { GetChatComponent } from './load-external-providers';
 import type { UIMessage, UseAgentChatReturn } from '@automattic/agenttic-client';
 
+type ShowComponentToolCall = {
+	toolCallId: string;
+	toolId: string;
+	data: Record< string, unknown >;
+};
+
 export type AgentsManagerUIMessage = UIMessage & {
 	disabled?: boolean;
 	/** Suppress Agenttic's transient thinking indicator while this message is the latest one. */
@@ -17,7 +23,167 @@ interface Options {
 	messages: UIMessage[];
 	getChatComponent?: GetChatComponent;
 	currentPostId?: number;
+	isEditorContext?: boolean;
 	onSubmit: UseAgentChatReturn[ 'onSubmit' ];
+}
+
+function getShowComponentToolCall( message: UIMessage ): ShowComponentToolCall | undefined {
+	const toolCall = message.content?.find(
+		( content ) =>
+			content.type === 'data' &&
+			content.data &&
+			typeof content.data.toolCallId === 'string' &&
+			typeof content.data.toolId === 'string' &&
+			isShowComponentTool( content.data.toolId ) &&
+			typeof content.data.arguments === 'object' &&
+			content.data.arguments !== null
+	);
+
+	if ( ! toolCall?.data ) {
+		return undefined;
+	}
+
+	return {
+		toolCallId: toolCall.data.toolCallId as string,
+		toolId: toolCall.data.toolId as string,
+		data: toolCall.data.arguments as Record< string, unknown >,
+	};
+}
+
+function getToolResultCallId( message: UIMessage ): string | undefined {
+	const toolResult = message.content?.find(
+		( content ) =>
+			content.type === 'data' &&
+			content.data &&
+			typeof content.data.toolCallId === 'string' &&
+			'result' in content.data
+	);
+
+	return toolResult?.data?.toolCallId as string | undefined;
+}
+
+function findPreviousShowComponentToolCall(
+	messages: UIMessage[],
+	currentIndex: number,
+	toolCallId: string
+): ShowComponentToolCall | undefined {
+	for ( let i = currentIndex - 1; i >= 0; i-- ) {
+		const toolCall = getShowComponentToolCall( messages[ i ] );
+		if ( toolCall?.toolCallId === toolCallId ) {
+			return toolCall;
+		}
+	}
+
+	return undefined;
+}
+
+function hasLaterToolResult(
+	messages: UIMessage[],
+	currentIndex: number,
+	toolCallId: string
+): boolean {
+	for ( let i = currentIndex + 1; i < messages.length; i++ ) {
+		if ( getToolResultCallId( messages[ i ] ) === toolCallId ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+function hasLaterShowComponentMessage( messages: UIMessage[], currentIndex: number ): boolean {
+	for ( let i = currentIndex + 1; i < messages.length; i++ ) {
+		const firstContentText = messages[ i ].content?.[ 0 ]?.text;
+		if ( ! firstContentText ) {
+			continue;
+		}
+
+		try {
+			const textData = JSON.parse( firstContentText );
+			if ( isShowComponentTool( textData.tool_id ) ) {
+				return true;
+			}
+		} catch ( _error ) {
+			// Ignore non-JSON text messages.
+		}
+	}
+
+	return false;
+}
+
+function getShowComponentCheckpoint( data: Record< string, unknown > ): string | undefined {
+	return typeof data.calypsoCheckpointId === 'string' ? data.calypsoCheckpointId : undefined;
+}
+
+function hasLaterMatchingShowComponentMessage(
+	messages: UIMessage[],
+	currentIndex: number,
+	toolId: string,
+	data: Record< string, unknown >
+): boolean {
+	const checkpointId = getShowComponentCheckpoint( data );
+	if ( ! checkpointId ) {
+		return false;
+	}
+
+	for ( let i = currentIndex + 1; i < messages.length; i++ ) {
+		const firstContentText = messages[ i ].content?.[ 0 ]?.text;
+		if ( ! firstContentText ) {
+			continue;
+		}
+
+		try {
+			const textData = JSON.parse( firstContentText );
+			if (
+				textData.tool_id === toolId &&
+				typeof textData.data === 'object' &&
+				textData.data !== null &&
+				getShowComponentCheckpoint( textData.data as Record< string, unknown > ) === checkpointId
+			) {
+				return true;
+			}
+		} catch ( _error ) {
+			// Ignore non-JSON text messages.
+		}
+	}
+
+	return false;
+}
+
+function hasLaterMatchingShowComponentToolResult(
+	messages: UIMessage[],
+	currentIndex: number,
+	toolId: string,
+	data: Record< string, unknown >
+): boolean {
+	const contentType = typeof data.type === 'string' ? data.type : undefined;
+	const checkpointId = getShowComponentCheckpoint( data );
+
+	for ( let i = currentIndex + 1; i < messages.length; i++ ) {
+		const toolResultCallId = getToolResultCallId( messages[ i ] );
+		if ( ! toolResultCallId ) {
+			continue;
+		}
+
+		if ( checkpointId && toolResultCallId === checkpointId ) {
+			return true;
+		}
+
+		const previousToolCall = findPreviousShowComponentToolCall( messages, i, toolResultCallId );
+		if ( ! previousToolCall || previousToolCall.toolId !== toolId ) {
+			continue;
+		}
+
+		if ( checkpointId && previousToolCall.toolCallId === checkpointId ) {
+			return true;
+		}
+
+		if ( ! checkpointId && contentType && previousToolCall.data.type === contentType ) {
+			return true;
+		}
+	}
+
+	return false;
 }
 
 /**
@@ -27,13 +193,151 @@ export default function convertToolMessagesToComponents( {
 	messages,
 	getChatComponent,
 	currentPostId,
+	isEditorContext = false,
 	onSubmit,
 }: Options ): AgentsManagerUIMessage[] {
+	const renderShowComponentMessage = (
+		message: UIMessage,
+		index: number,
+		array: UIMessage[],
+		toolId: string,
+		data: Record< string, unknown >,
+		forceCurrent = false
+	): AgentsManagerUIMessage[] => {
+		// If not on an editor page, show an unavailable tool message instead of the component
+		if ( ! isEditorPage() && ! isEditorContext ) {
+			return [
+				{
+					...message,
+					content: [
+						{
+							type: 'component' as const,
+							component: UnavailableToolMessage as React.ComponentType,
+							componentProps: { type: 'picker' },
+						},
+					],
+				},
+			];
+		}
+
+		const { type: contentType, props = {}, followUpTasks, isCurrent, postId, summary } = data;
+		if ( typeof contentType !== 'string' ) {
+			return [];
+		}
+
+		const Component = getChatComponent?.( contentType, { toolId } );
+
+		// No matching component found for this content type — drop the message to avoid showing raw JSON.
+		if ( ! Component ) {
+			return [];
+		}
+
+		const componentProps = typeof props === 'object' && props !== null ? props : {};
+		const summaryText = typeof summary === 'string' && summary.trim() ? summary.trim() : undefined;
+
+		// Whether this is the last show-component message in the array.
+		const isLastMessage = forceCurrent || index === array.length - 1;
+
+		// In the site editor, React-Query caching keeps past conversations alive when the
+		// user navigates to a different page. Compare the picker's `postId` with the
+		// current editor page to disable pickers that no longer belong to this page.
+		const isPageChanged =
+			typeof postId === 'number' && !! currentPostId && postId !== currentPostId;
+		const isMessageCurrent = typeof isCurrent === 'boolean' ? isCurrent : forceCurrent;
+		const isStale = ! isLastMessage || ! isMessageCurrent || isPageChanged;
+
+		const componentMessage: AgentsManagerUIMessage = {
+			...message,
+			content: [
+				...( summaryText
+					? [
+							{
+								type: 'text' as const,
+								text: summaryText,
+							},
+					  ]
+					: [] ),
+				{
+					type: 'component' as const,
+					component: Component,
+					componentProps: {
+						...componentProps,
+						...( summaryText && { summary: summaryText } ),
+						contentType,
+					},
+				},
+			],
+			disabled: isStale,
+			suppressThinking: true,
+		};
+
+		// Only show `next-step-button` when the component is active and has follow-up tasks.
+		if ( isStale || ! followUpTasks ) {
+			return [ componentMessage ];
+		}
+
+		// Omit `actions` so the parent message's actions don't leak into the next-step message.
+		const { actions, content, ...baseMessage } = message;
+
+		return [
+			componentMessage,
+			{
+				...baseMessage,
+				id: `${ message.id }-next-step`,
+				content: [
+					{
+						type: 'component' as const,
+						component: NextStepButton as React.ComponentType,
+						componentProps: { onMoveToNextStep: onSubmit },
+					},
+				],
+			},
+		];
+	};
+
 	return messages.flatMap( ( message, index, array ) => {
 		const firstContentText = message.content?.[ 0 ]?.text;
 
 		// @ts-expect-error -- `assistant` comes from Big Sky messages
 		if ( ( message.role !== 'agent' && message.role !== 'assistant' ) || ! firstContentText ) {
+			const toolCall = getShowComponentToolCall( message );
+			if ( toolCall ) {
+				if (
+					hasLaterToolResult( array, index, toolCall.toolCallId ) ||
+					hasLaterShowComponentMessage( array, index )
+				) {
+					return [];
+				}
+
+				return renderShowComponentMessage(
+					message,
+					index,
+					array,
+					toolCall.toolId,
+					toolCall.data,
+					true
+				);
+			}
+
+			const toolResultCallId = getToolResultCallId( message );
+			if ( toolResultCallId && ! hasLaterShowComponentMessage( array, index ) ) {
+				const previousToolCall = findPreviousShowComponentToolCall(
+					array,
+					index,
+					toolResultCallId
+				);
+				if ( previousToolCall ) {
+					return renderShowComponentMessage(
+						message,
+						index,
+						array,
+						previousToolCall.toolId,
+						previousToolCall.data,
+						true
+					);
+				}
+			}
+
 			return [ message ];
 		}
 
@@ -68,90 +372,34 @@ export default function convertToolMessagesToComponents( {
 
 		// Handle `show-component` tool message
 		if ( isShowComponentTool( textData.tool_id ) ) {
-			// If not on an editor page, show an unavailable tool message instead of the component
-			if ( ! isEditorPage() ) {
-				return [
-					{
-						...message,
-						content: [
-							{
-								type: 'component' as const,
-								component: UnavailableToolMessage as React.ComponentType,
-								componentProps: { type: 'picker' },
-							},
-						],
-					},
-				];
-			}
-
-			const toolData = textData.data ?? {};
-			const { type: contentType, props, followUpTasks, isCurrent, postId, summary } = toolData;
-			const Component = getChatComponent?.( contentType );
-
-			// No matching component found for this content type — drop the message to avoid showing raw JSON.
-			if ( ! Component ) {
+			if ( typeof textData.data !== 'object' || textData.data === null ) {
 				return [];
 			}
 
-			const summaryText =
-				typeof summary === 'string' && summary.trim() ? summary.trim() : undefined;
-
-			// Whether this is the last message in the array.
-			const isLastMessage = index === array.length - 1;
-
-			// In the site editor, React-Query caching keeps past conversations alive when the
-			// user navigates to a different page. Compare the picker's `postId` with the
-			// current editor page to disable pickers that no longer belong to this page.
-			const isPageChanged = !! postId && !! currentPostId && postId !== currentPostId;
-			const isStale = ! isLastMessage || ! isCurrent || isPageChanged;
-
-			const componentMessage: AgentsManagerUIMessage = {
-				...message,
-				content: [
-					...( summaryText
-						? [
-								{
-									type: 'text' as const,
-									text: summaryText,
-								},
-						  ]
-						: [] ),
-					{
-						type: 'component' as const,
-						component: Component,
-						componentProps: {
-							...props,
-							...( summaryText && { summary: summaryText } ),
-							contentType,
-						},
-					},
-				],
-				disabled: isStale,
-				suppressThinking: true,
-			};
-
-			// Only show `next-step-button` when the component is active and has follow-up tasks.
-			if ( isStale || ! followUpTasks ) {
-				return [ componentMessage ];
+			if (
+				hasLaterMatchingShowComponentToolResult(
+					array,
+					index,
+					textData.tool_id,
+					textData.data as Record< string, unknown >
+				) ||
+				hasLaterMatchingShowComponentMessage(
+					array,
+					index,
+					textData.tool_id,
+					textData.data as Record< string, unknown >
+				)
+			) {
+				return [];
 			}
 
-			// Omit `actions` so the parent message's actions don't leak into the next-step message.
-			const { actions, content, ...baseMessage } = message;
-
-			return [
-				componentMessage,
-				{
-					...baseMessage,
-					id: `${ message.id }-next-step`,
-					content: [
-						{
-							type: 'component' as const,
-							component: NextStepButton as React.ComponentType,
-							componentProps: { onMoveToNextStep: onSubmit },
-						},
-					],
-				},
-			];
+			return renderShowComponentMessage(
+				message,
+				index,
+				array,
+				textData.tool_id,
+				textData.data as Record< string, unknown >
+			);
 		}
 
 		// Handle agent-facing Big Sky tool result summaries.

--- a/packages/agents-manager/src/utils/create-agent-config.ts
+++ b/packages/agents-manager/src/utils/create-agent-config.ts
@@ -73,19 +73,35 @@ function wrapToolProvider( toolProvider: ToolProvider ): UseAgentChatConfig[ 'to
 		...toolProvider,
 		getAbilities: async (): Promise< AgenticAbility[] > => {
 			const abilities = await toolProvider.getAbilities();
-			return abilities.map( ( ability ) => ( {
-				...ability,
-				meta: ability.meta?.annotations
-					? {
-							...ability.meta,
-							annotations: Object.fromEntries(
-								Object.entries( ability.meta.annotations ).filter(
-									( [ , value ] ) => value !== null
-								)
-							),
-					  }
-					: ability.meta,
-			} ) ) as AgenticAbility[];
+			if ( ! Array.isArray( abilities ) ) {
+				// eslint-disable-next-line no-console
+				console.warn( '[AgentsManager] Tool provider returned invalid abilities; expected array.' );
+				return [];
+			}
+
+			return abilities
+				.filter( ( ability ) => ability && typeof ability.name === 'string' )
+				.map( ( ability ) => {
+					const normalizedAbility = {
+						...ability,
+						meta: ability.meta?.annotations
+							? {
+									...ability.meta,
+									annotations: Object.fromEntries(
+										Object.entries( ability.meta.annotations ).filter(
+											( [ , value ] ) => value !== null
+										)
+									),
+							  }
+							: ability.meta,
+					} as AgenticAbility;
+
+					if ( typeof ability.callback === 'function' ) {
+						normalizedAbility.callback = ability.callback;
+					}
+
+					return normalizedAbility;
+				} );
 		},
 	};
 }

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -176,6 +176,7 @@ type AbilityProviderEntry = {
 	provider: ToolProvider;
 	abilityName: string;
 };
+type ProviderAbilities = Awaited< ReturnType< ToolProvider[ 'getAbilities' ] > >;
 
 type ProviderClientContext = ReturnType< ContextProvider[ 'getClientContext' ] >;
 
@@ -405,6 +406,7 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 	// OR-merged across all providers.
 	const mergedCapabilities: ProviderCapabilities = {};
 	const abilityProviderMap = new Map< string, AbilityProviderEntry >();
+	const lastGoodProviderAbilities = new Map< ToolProvider, ProviderAbilities >();
 
 	// Collect exports that need to be merged across all providers.
 	const allToolProviders: ToolProvider[] = [];
@@ -497,8 +499,6 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 	// order they were registered; earlier providers win on ability-name
 	// collisions.
 	const refreshProviderAbilities = async () => {
-		abilityProviderMap.clear();
-
 		const allAbilityResults = await Promise.all(
 			allToolProviders.map( async ( tp ) => {
 				try {
@@ -506,16 +506,18 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 					if ( ! Array.isArray( abilities ) ) {
 						// eslint-disable-next-line no-console
 						console.warn( '[AgentsManager] Provider returned invalid abilities; expected array.' );
-						return [];
+						return lastGoodProviderAbilities.get( tp ) ?? [];
 					}
+					lastGoodProviderAbilities.set( tp, abilities );
 					return abilities;
 				} catch ( error ) {
 					// eslint-disable-next-line no-console
 					console.warn( '[AgentsManager] Failed to load abilities from provider:', error );
-					return [];
+					return lastGoodProviderAbilities.get( tp ) ?? [];
 				}
 			} )
 		);
+		const nextAbilityProviderMap = new Map< string, AbilityProviderEntry >();
 		const seenAbilities = new Map< string, unknown >();
 		// Normalize ability names: AM converts `/` → `__` and `-` → `_`
 		// when routing tool calls. Index both raw and normalized forms
@@ -534,21 +536,21 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 						abilityName: ability.name,
 					};
 					const abilityWithCallback = addProviderCallbackToAbility( ability, entry );
-					abilityProviderMap.set( ability.name, entry );
-					abilityProviderMap.set( BIG_SKY_SHOW_COMPONENT_AGENTTIC_TOOL_ID, entry );
-					abilityProviderMap.set( BIG_SKY_SHOW_COMPONENT_TOOL_ID, entry );
+					nextAbilityProviderMap.set( ability.name, entry );
+					nextAbilityProviderMap.set( BIG_SKY_SHOW_COMPONENT_AGENTTIC_TOOL_ID, entry );
+					nextAbilityProviderMap.set( BIG_SKY_SHOW_COMPONENT_TOOL_ID, entry );
 					seenAbilities.set( BIG_SKY_SHOW_COMPONENT_TOOL_ID, abilityWithCallback );
 					continue;
 				}
 
 				const existingEntry =
-					abilityProviderMap.get( ability.name ) ?? abilityProviderMap.get( normalized );
+					nextAbilityProviderMap.get( ability.name ) ?? nextAbilityProviderMap.get( normalized );
 				if ( existingEntry ) {
-					if ( ! abilityProviderMap.has( ability.name ) ) {
-						abilityProviderMap.set( ability.name, existingEntry );
+					if ( ! nextAbilityProviderMap.has( ability.name ) ) {
+						nextAbilityProviderMap.set( ability.name, existingEntry );
 					}
-					if ( ! abilityProviderMap.has( normalized ) ) {
-						abilityProviderMap.set( normalized, existingEntry );
+					if ( ! nextAbilityProviderMap.has( normalized ) ) {
+						nextAbilityProviderMap.set( normalized, existingEntry );
 					}
 					continue;
 				}
@@ -557,10 +559,15 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 					provider: allToolProviders[ i ],
 					abilityName: ability.name,
 				};
-				abilityProviderMap.set( ability.name, entry );
-				abilityProviderMap.set( normalized, entry );
+				nextAbilityProviderMap.set( ability.name, entry );
+				nextAbilityProviderMap.set( normalized, entry );
 				seenAbilities.set( normalized, addProviderCallbackToAbility( ability, entry ) );
 			}
+		}
+
+		abilityProviderMap.clear();
+		for ( const [ key, entry ] of nextAbilityProviderMap ) {
+			abilityProviderMap.set( key, entry );
 		}
 
 		return [ ...seenAbilities.values() ] as Awaited< ReturnType< ToolProvider[ 'getAbilities' ] > >;

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -97,9 +97,16 @@ type ChatComponentType =
 /**
  * Get a chat component by type for rendering in agent messages.
  * @param type - The type of chat component to get
+ * @param context - Optional source tool metadata for source-aware component lookup
  * @returns The React component for the specified type, or `null` if unknown
  */
-export type GetChatComponent = ( type: ChatComponentType ) => React.ComponentType< unknown > | null;
+export type GetChatComponentContext = {
+	toolId?: string;
+};
+export type GetChatComponent = (
+	type: ChatComponentType | string,
+	context?: GetChatComponentContext
+) => React.ComponentType< unknown > | null;
 
 /**
  * Checkpoint return type - for saving and restoring editor state so that AI actions can be undone.
@@ -163,6 +170,72 @@ export interface LoadedProviders {
 	useImageUpload?: ImageUploadHook;
 	useCheckpoint?: UseCheckpointHook;
 	capabilities?: ProviderCapabilities;
+}
+
+type AbilityProviderEntry = {
+	provider: ToolProvider;
+	abilityName: string;
+};
+
+const BIG_SKY_SHOW_COMPONENT_ABILITY = 'big-sky/show-component';
+const BIG_SKY_SHOW_COMPONENT_AGENTTIC_TOOL_ID = 'big-sky-show-component';
+const BIG_SKY_SHOW_COMPONENT_TOOL_ID = 'big_sky__show_component';
+
+function getProviderAgentMessage( result: unknown ): string | undefined {
+	if ( ! result || typeof result !== 'object' ) {
+		return undefined;
+	}
+
+	const agentMessage = ( result as { agentMessage?: unknown } ).agentMessage;
+	if ( typeof agentMessage === 'string' && agentMessage.trim() ) {
+		return agentMessage;
+	}
+
+	const nestedResult = ( result as { result?: unknown } ).result;
+	if ( ! nestedResult || typeof nestedResult !== 'object' ) {
+		return undefined;
+	}
+
+	const nestedAgentMessage = ( nestedResult as { agentMessage?: unknown } ).agentMessage;
+	return typeof nestedAgentMessage === 'string' && nestedAgentMessage.trim()
+		? nestedAgentMessage
+		: undefined;
+}
+
+function normalizeProviderResult( result: unknown ): unknown {
+	const message = getProviderAgentMessage( result );
+	if ( ! message || ! result || typeof result !== 'object' ) {
+		return result;
+	}
+
+	if ( ( result as { agentMessage?: unknown } ).agentMessage === message ) {
+		return result;
+	}
+
+	return {
+		...( result as Record< string, unknown > ),
+		agentMessage: message,
+	};
+}
+
+function addProviderCallbackToAbility( ability: unknown, entry: AbilityProviderEntry ): unknown {
+	if ( ! ability || typeof ability !== 'object' ) {
+		return ability;
+	}
+
+	const abilityWithCallback = { ...( ability as Record< string, unknown > ) };
+	const existingCallback =
+		typeof abilityWithCallback.callback === 'function' ? abilityWithCallback.callback : undefined;
+	Object.defineProperty( abilityWithCallback, 'callback', {
+		value: async ( args: unknown ) => {
+			const result = existingCallback
+				? await existingCallback( args )
+				: await entry.provider.executeAbility( entry.abilityName, args );
+			return normalizeProviderResult( result );
+		},
+		enumerable: false,
+	} );
+	return abilityWithCallback;
 }
 
 export function mergeUseSuggestionsHooks(
@@ -243,10 +316,14 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 	let mergedUseCheckpoint: UseCheckpointHook | undefined;
 	// OR-merged across all providers.
 	const mergedCapabilities: ProviderCapabilities = {};
+	const abilityProviderMap = new Map< string, AbilityProviderEntry >();
 
 	// Collect exports that need to be merged across all providers.
 	const allToolProviders: ToolProvider[] = [];
-	const allGetChatComponents: GetChatComponent[] = [];
+	const allGetChatComponents: Array< {
+		getChatComponent: GetChatComponent;
+		toolProvider?: ToolProvider;
+	} > = [];
 	const allAbilitiesSetups: AbilitiesSetupHook[] = [];
 	const allUseSuggestions: UseSuggestionsHook[] = [];
 	const allGetEmptyViewSuggestions: ( () => Suggestion[] )[] = [];
@@ -284,7 +361,10 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 			allToolProviders.push( module.toolProvider );
 		}
 		if ( module.getChatComponent ) {
-			allGetChatComponents.push( module.getChatComponent );
+			allGetChatComponents.push( {
+				getChatComponent: module.getChatComponent,
+				toolProvider: module.toolProvider,
+			} );
 		}
 		if ( module.useAbilitiesSetup ) {
 			allAbilitiesSetups.push( module.useAbilitiesSetup );
@@ -327,16 +407,19 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 	// getChatComponent, useSuggestions, etc). Providers are processed in the
 	// order they were registered; earlier providers win on ability-name
 	// collisions.
-	if ( allToolProviders.length === 1 ) {
-		mergedToolProvider = allToolProviders[ 0 ];
-	} else if ( allToolProviders.length > 1 ) {
-		// Fetch all abilities once and build a name→provider map so that
-		// executeAbility can look up the owning provider in O(1) instead of
-		// re-querying getAbilities() on every call.
+	const refreshProviderAbilities = async () => {
+		abilityProviderMap.clear();
+
 		const allAbilityResults = await Promise.all(
 			allToolProviders.map( async ( tp ) => {
 				try {
-					return await tp.getAbilities();
+					const abilities = await tp.getAbilities();
+					if ( ! Array.isArray( abilities ) ) {
+						// eslint-disable-next-line no-console
+						console.warn( '[AgentsManager] Provider returned invalid abilities; expected array.' );
+						return [];
+					}
+					return abilities;
 				} catch ( error ) {
 					// eslint-disable-next-line no-console
 					console.warn( '[AgentsManager] Failed to load abilities from provider:', error );
@@ -344,7 +427,6 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 				}
 			} )
 		);
-		const abilityProviderMap = new Map< string, ToolProvider >();
 		const seenAbilities = new Map< string, unknown >();
 		// Normalize ability names: AM converts `/` → `__` and `-` → `_`
 		// when routing tool calls. Index both raw and normalized forms
@@ -352,29 +434,59 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 		const normalize = ( name: string ) => name.replace( /\//g, '__' ).replace( /-/g, '_' );
 		for ( let i = 0; i < allToolProviders.length; i++ ) {
 			for ( const ability of allAbilityResults[ i ] ) {
-				if ( ! abilityProviderMap.has( ability.name ) ) {
-					abilityProviderMap.set( ability.name, allToolProviders[ i ] );
-					const normalized = normalize( ability.name );
-					if ( normalized !== ability.name ) {
-						abilityProviderMap.set( normalized, allToolProviders[ i ] );
-					}
-					seenAbilities.set( ability.name, ability );
+				if ( ! ability || typeof ability.name !== 'string' ) {
+					continue;
 				}
+
+				const normalized = normalize( ability.name );
+				if ( ability.name === BIG_SKY_SHOW_COMPONENT_ABILITY ) {
+					const entry = {
+						provider: allToolProviders[ i ],
+						abilityName: ability.name,
+					};
+					const abilityWithCallback = addProviderCallbackToAbility( ability, entry );
+					abilityProviderMap.set( ability.name, entry );
+					abilityProviderMap.set( BIG_SKY_SHOW_COMPONENT_AGENTTIC_TOOL_ID, entry );
+					abilityProviderMap.set( BIG_SKY_SHOW_COMPONENT_TOOL_ID, entry );
+					seenAbilities.set( BIG_SKY_SHOW_COMPONENT_TOOL_ID, abilityWithCallback );
+					continue;
+				}
+
+				const existingEntry =
+					abilityProviderMap.get( ability.name ) ?? abilityProviderMap.get( normalized );
+				if ( existingEntry ) {
+					if ( ! abilityProviderMap.has( ability.name ) ) {
+						abilityProviderMap.set( ability.name, existingEntry );
+					}
+					if ( ! abilityProviderMap.has( normalized ) ) {
+						abilityProviderMap.set( normalized, existingEntry );
+					}
+					continue;
+				}
+
+				const entry = {
+					provider: allToolProviders[ i ],
+					abilityName: ability.name,
+				};
+				abilityProviderMap.set( ability.name, entry );
+				abilityProviderMap.set( normalized, entry );
+				seenAbilities.set( normalized, addProviderCallbackToAbility( ability, entry ) );
 			}
 		}
-		const cachedAbilities = [ ...seenAbilities.values() ] as Awaited<
-			ReturnType< ToolProvider[ 'getAbilities' ] >
-		>;
 
+		return [ ...seenAbilities.values() ] as Awaited< ReturnType< ToolProvider[ 'getAbilities' ] > >;
+	};
+
+	if ( allToolProviders.length > 0 ) {
 		mergedToolProvider = {
-			getAbilities: async () => cachedAbilities,
+			getAbilities: refreshProviderAbilities,
 			executeAbility: async ( name: string, args: unknown ) => {
-				// Use the pre-built map — avoids re-querying getAbilities() on
-				// every call and surfaces real errors from the owning provider
-				// instead of silently swallowing them.
-				const provider = abilityProviderMap.get( name );
-				if ( provider ) {
-					return provider.executeAbility( name, args );
+				// Rebuild at execution time because some provider abilities are
+				// registered by setup hooks after the provider module is imported.
+				await refreshProviderAbilities();
+				const entry = abilityProviderMap.get( name );
+				if ( entry ) {
+					return entry.provider.executeAbility( entry.abilityName, args );
 				}
 				throw new Error( `No provider handled ability: ${ name }` );
 			},
@@ -383,11 +495,29 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 
 	// Merge getChatComponent: try each provider, return first non-null.
 	if ( allGetChatComponents.length === 1 ) {
-		mergedGetChatComponent = allGetChatComponents[ 0 ];
+		mergedGetChatComponent = allGetChatComponents[ 0 ].getChatComponent;
 	} else if ( allGetChatComponents.length > 1 ) {
-		mergedGetChatComponent = ( ( type: string ) => {
-			for ( const fn of allGetChatComponents ) {
-				const result = fn( type as ChatComponentType );
+		mergedGetChatComponent = ( ( type: string, context?: GetChatComponentContext ) => {
+			const sourceProvider =
+				typeof context?.toolId === 'string'
+					? abilityProviderMap.get( context.toolId )?.provider
+					: undefined;
+			const sourceComponentResolver = sourceProvider
+				? allGetChatComponents.find( ( entry ) => entry.toolProvider === sourceProvider )
+				: undefined;
+
+			if ( sourceComponentResolver ) {
+				const result = sourceComponentResolver.getChatComponent( type, context );
+				if ( result ) {
+					return result;
+				}
+			}
+
+			for ( const entry of allGetChatComponents ) {
+				if ( entry === sourceComponentResolver ) {
+					continue;
+				}
+				const result = entry.getChatComponent( type, context );
 				if ( result ) {
 					return result;
 				}

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -177,9 +177,98 @@ type AbilityProviderEntry = {
 	abilityName: string;
 };
 
+type ProviderClientContext = ReturnType< ContextProvider[ 'getClientContext' ] >;
+
 const BIG_SKY_SHOW_COMPONENT_ABILITY = 'big-sky/show-component';
 const BIG_SKY_SHOW_COMPONENT_AGENTTIC_TOOL_ID = 'big-sky-show-component';
 const BIG_SKY_SHOW_COMPONENT_TOOL_ID = 'big_sky__show_component';
+
+function mergeContextEntries(
+	firstEntries?: ProviderClientContext[ 'contextEntries' ],
+	secondEntries?: ProviderClientContext[ 'contextEntries' ]
+): ProviderClientContext[ 'contextEntries' ] | undefined {
+	const entries = [ ...( firstEntries || [] ), ...( secondEntries || [] ) ];
+	if ( entries.length === 0 ) {
+		return undefined;
+	}
+
+	const merged = [];
+	const seenIds = new Set< string >();
+	for ( const entry of entries ) {
+		if ( entry?.id && seenIds.has( entry.id ) ) {
+			continue;
+		}
+		if ( entry?.id ) {
+			seenIds.add( entry.id );
+		}
+		merged.push( entry );
+	}
+	return merged;
+}
+
+function isEmptyContextValue( value: unknown ): boolean {
+	return value === undefined || value === null || value === '';
+}
+
+function isPlainRecord( value: unknown ): value is Record< string, unknown > {
+	return !! value && typeof value === 'object' && ! Array.isArray( value );
+}
+
+function mergeClientContexts(
+	firstContext: ProviderClientContext,
+	secondContext: ProviderClientContext
+): ProviderClientContext {
+	const merged = { ...firstContext };
+
+	for ( const [ key, value ] of Object.entries( secondContext ) ) {
+		if ( key === 'contextEntries' ) {
+			continue;
+		}
+
+		const existing = merged[ key ];
+		if (
+			[ 'constructorArguments', 'currentScreen', 'siteEditorActions' ].includes( key ) &&
+			isPlainRecord( existing ) &&
+			isPlainRecord( value )
+		) {
+			merged[ key ] = { ...value, ...existing };
+			continue;
+		}
+
+		if ( isEmptyContextValue( existing ) && ! isEmptyContextValue( value ) ) {
+			merged[ key ] = value;
+		}
+	}
+
+	const contextEntries = mergeContextEntries(
+		firstContext.contextEntries,
+		secondContext.contextEntries
+	);
+	if ( contextEntries ) {
+		merged.contextEntries = contextEntries;
+	}
+
+	return merged;
+}
+
+export function mergeContextProviders(
+	contextProviders: ContextProvider[]
+): ContextProvider | undefined {
+	if ( contextProviders.length === 0 ) {
+		return undefined;
+	}
+
+	if ( contextProviders.length === 1 ) {
+		return contextProviders[ 0 ];
+	}
+
+	return {
+		getClientContext: () =>
+			contextProviders
+				.map( ( contextProvider ) => contextProvider.getClientContext() )
+				.reduce( mergeClientContexts ),
+	};
+}
 
 function getProviderAgentMessage( result: unknown ): string | undefined {
 	if ( ! result || typeof result !== 'object' ) {
@@ -304,7 +393,6 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 	}
 
 	let mergedToolProvider: ToolProvider | undefined;
-	let mergedContextProvider: ContextProvider | undefined;
 	let mergedGetEmptyViewSuggestions: ( () => Suggestion[] ) | undefined;
 	let mergedMarkdownComponents: MarkdownComponents | undefined;
 	let mergedMarkdownExtensions: MarkdownExtensions | undefined;
@@ -320,6 +408,7 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 
 	// Collect exports that need to be merged across all providers.
 	const allToolProviders: ToolProvider[] = [];
+	const allContextProviders: ContextProvider[] = [];
 	const allGetChatComponents: Array< {
 		getChatComponent: GetChatComponent;
 		toolProvider?: ToolProvider;
@@ -360,6 +449,9 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 		if ( module.toolProvider ) {
 			allToolProviders.push( module.toolProvider );
 		}
+		if ( module.contextProvider ) {
+			allContextProviders.push( module.contextProvider );
+		}
 		if ( module.getChatComponent ) {
 			allGetChatComponents.push( {
 				getChatComponent: module.getChatComponent,
@@ -377,9 +469,6 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 		}
 
 		// First-write-wins for singleton exports.
-		if ( module.contextProvider && ! mergedContextProvider ) {
-			mergedContextProvider = module.contextProvider;
-		}
 		if ( module.markdownComponents && ! mergedMarkdownComponents ) {
 			mergedMarkdownComponents = module.markdownComponents;
 		}
@@ -492,6 +581,8 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 			},
 		};
 	}
+
+	const mergedContextProvider = mergeContextProviders( allContextProviders );
 
 	// Merge getChatComponent: try each provider, return first non-null.
 	if ( allGetChatComponents.length === 1 ) {

--- a/packages/agents-manager/src/utils/show-component-tools.ts
+++ b/packages/agents-manager/src/utils/show-component-tools.ts
@@ -1,7 +1,11 @@
+export const BIG_SKY_SHOW_COMPONENT_ABILITY = 'big-sky/show-component';
+export const BIG_SKY_SHOW_COMPONENT_AGENTTIC_TOOL_ID = 'big-sky-show-component';
 export const BIG_SKY_SHOW_COMPONENT_TOOL_ID = 'big_sky__show_component';
 export const JETPACK_AI_SHOW_COMPONENT_TOOL_ID = 'jetpack_ai__show_component';
 
 const SHOW_COMPONENT_TOOL_IDS = [
+	BIG_SKY_SHOW_COMPONENT_ABILITY,
+	BIG_SKY_SHOW_COMPONENT_AGENTTIC_TOOL_ID,
 	BIG_SKY_SHOW_COMPONENT_TOOL_ID,
 	JETPACK_AI_SHOW_COMPONENT_TOOL_ID,
 ];

--- a/packages/jetpack-ai-sidebar/AGENTS.md
+++ b/packages/jetpack-ai-sidebar/AGENTS.md
@@ -29,18 +29,18 @@ All exports live in `src/index.ts`. This is intentionally a single-file provider
 
 - **Module-level state**: `addMessageFn`, `clearSuggestionsFn`, and `moduleCheckpointApi` are captured once via their respective hooks. These are module singletons — do NOT move them into React state or a store.
 - **`returnToAgent: false`**: The `handleUpdateBlockContent` and `handleShowComponent` handlers return `{ returnToAgent: false }`. This prevents the AM orchestrator from continuing automatically after the tool executes. Removing this breaks the UX flow.
-- **Tool ID normalization**: AM normalizes tool IDs (`wpcom/update-block-content` → `wpcom__update_block_content`). The `isUpdateBlockContentTool` / `isShowComponentTool` helpers handle both forms. Any new tool must follow this pattern.
+- **Tool ID normalization**: AM normalizes tool IDs (`jetpack-ai/update-block-content` → `jetpack_ai__update_block_content`). The `isUpdateBlockContentTool` / `isShowComponentTool` helpers handle both forms. Any new tool must follow this pattern.
 - **Show-component via `agentMessage` escape hatch**: `handleShowComponent` returns `{ agentMessage: JSON }` — it does NOT call `addMessageFn` directly. agenttic-client wraps the JSON in an `{ role: 'agent', parts: [text] }` message, AM's `convert-tool-messages-to-components` resolves the component via `getChatComponent`, and AgentChat's action bar (thumbs/Undo) attaches because the original message had a text content part. See "Show-component pattern" below.
 - **Role transformation**: AM's `useAbilitiesSetup` handler maps `role: 'assistant'` → `'agent'` and everything else → `'user'`. When injecting messages directly via `addMessageFn`, always use `'assistant'` — passing `'agent'` would make the message render as user content and get filtered out of the agent message list.
 - **Processing shimmer**: The block editing shimmer uses `Flow Block` font + CSS animations injected into the block's owning document (which may be an iframe). The `ensureProcessingStyles` function is idempotent — don't duplicate style injection.
 
 ## Tools
 
-| Tool ID                      | Handler                     | UI Component           | Description                                              |
-| ---------------------------- | --------------------------- | ---------------------- | -------------------------------------------------------- |
-| `jetpack_ai__show_component` | `handleShowComponent`       | via `getChatComponent` | Renders Jetpack AI chat components                       |
-| `big_sky__show_component`    | `handleLegacyShowComponent` | Jetpack or Big Sky     | Temporary migration support; delegates non-Jetpack types |
-| `wpcom/update-block-content` | `handleUpdateBlockContent`  | _(chat text)_          | Updates block content with shimmer effect                |
+| Tool ID                           | Handler                     | UI Component           | Description                                              |
+| --------------------------------- | --------------------------- | ---------------------- | -------------------------------------------------------- |
+| `jetpack_ai__show_component`      | `handleShowComponent`       | via `getChatComponent` | Renders Jetpack AI chat components                       |
+| `big_sky__show_component`         | `handleLegacyShowComponent` | Jetpack or Big Sky     | Temporary migration support; delegates non-Jetpack types |
+| `jetpack-ai/update-block-content` | `handleUpdateBlockContent`  | _(chat text)_          | Updates block content with shimmer effect                |
 
 ### Show-component pattern
 

--- a/packages/jetpack-ai-sidebar/src/global.d.ts
+++ b/packages/jetpack-ai-sidebar/src/global.d.ts
@@ -6,7 +6,7 @@ declare const agentsManagerData:
 			aiEditorialReviewEnabled?: boolean;
 			reviewMediatorEnabled?: boolean;
 			jetpackAiSidebarPreview?: {
-				enabled: boolean;
+				enabled?: boolean;
 				features?: {
 					aiEditorialReview?: boolean;
 					blockTransformations?: boolean;

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -38,7 +38,6 @@ let mockSelectedBlock: any = null;
 let mockCurrentPostType: string | undefined = 'post';
 let mockBlocksByClientId: Record< string, any > = {};
 const SHOW_COMPONENT_TOOL_ID = 'jetpack_ai__show_component';
-const LEGACY_SHOW_COMPONENT_TOOL_ID = 'big_sky__show_component';
 const UPDATE_BLOCK_CONTENT_TOOL_ID = 'jetpack-ai/update-block-content';
 
 jest.mock( '@wordpress/components', () => {
@@ -839,7 +838,6 @@ describe( 'toolProvider', () => {
 
 			expect( names ).toContain( UPDATE_BLOCK_CONTENT_TOOL_ID );
 			expect( names ).toContain( SHOW_COMPONENT_TOOL_ID );
-			expect( names ).toContain( LEGACY_SHOW_COMPONENT_TOOL_ID );
 		} );
 
 		it( 'keeps update-block-content available on Big Sky Page Editor surfaces', async () => {
@@ -867,13 +865,9 @@ describe( 'toolProvider', () => {
 		it( 'wires a callback on each provided ability', async () => {
 			const abilities = await toolProvider.getAbilities();
 			const showComponent = abilities.find( ( a: any ) => a.name === SHOW_COMPONENT_TOOL_ID );
-			const legacyShowComponent = abilities.find(
-				( a: any ) => a.name === LEGACY_SHOW_COMPONENT_TOOL_ID
-			);
 			const updateBlock = abilities.find( ( a: any ) => a.name === UPDATE_BLOCK_CONTENT_TOOL_ID );
 
 			expect( typeof showComponent?.callback ).toBe( 'function' );
-			expect( typeof legacyShowComponent?.callback ).toBe( 'function' );
 			expect( typeof updateBlock?.callback ).toBe( 'function' );
 		} );
 
@@ -902,58 +896,6 @@ describe( 'toolProvider', () => {
 			expect( names ).toContain( 'big-sky/show-component' );
 			expect( names ).toContain( 'big-sky/change-colors' );
 			expect( names ).toContain( SHOW_COMPONENT_TOOL_ID );
-			expect( names ).not.toContain( LEGACY_SHOW_COMPONENT_TOOL_ID );
-		} );
-
-		it( 'delegates non-Jetpack legacy show-component callbacks to Big Sky', async () => {
-			const args = {
-				type: 'color-picker',
-				props: { colors: [] },
-			};
-			const executeAbility = jest.fn().mockResolvedValue( {
-				result: 'Big Sky component displayed successfully',
-				returnToAgent: false,
-			} );
-			( window as any ).wp.abilities = {
-				getAbilities: jest.fn().mockResolvedValue( [] ),
-				executeAbility,
-			};
-
-			const abilities = await toolProvider.getAbilities();
-			const legacyShowComponent = abilities.find(
-				( a: any ) => a.name === LEGACY_SHOW_COMPONENT_TOOL_ID
-			);
-			const result = await legacyShowComponent.callback( args );
-
-			expect( executeAbility ).toHaveBeenCalledWith( 'big-sky/show-component', args );
-			expect( result ).toEqual( {
-				result: 'Big Sky component displayed successfully',
-				returnToAgent: false,
-			} );
-		} );
-
-		it.each( [
-			[ 'empty', '' ],
-			[ 'whitespace-only', '   ' ],
-		] )( 'does not delegate %s legacy show-component callbacks', async ( _label, type ) => {
-			const executeAbility = jest.fn();
-			( window as any ).wp.abilities = {
-				getAbilities: jest.fn().mockResolvedValue( [] ),
-				executeAbility,
-			};
-
-			const abilities = await toolProvider.getAbilities();
-			const legacyShowComponent = abilities.find(
-				( a: any ) => a.name === LEGACY_SHOW_COMPONENT_TOOL_ID
-			);
-			const result = await legacyShowComponent.callback( {
-				type,
-				props: {},
-			} );
-
-			expect( executeAbility ).not.toHaveBeenCalled();
-			expect( result ).toMatchObject( { success: false } );
-			expect( result.error ).toMatch( /missing type/ );
 		} );
 
 		it( 'omits update-block-content when block transformations are disabled', async () => {
@@ -964,7 +906,6 @@ describe( 'toolProvider', () => {
 
 			expect( names ).not.toContain( UPDATE_BLOCK_CONTENT_TOOL_ID );
 			expect( names ).toContain( SHOW_COMPONENT_TOOL_ID );
-			expect( names ).toContain( LEGACY_SHOW_COMPONENT_TOOL_ID );
 		} );
 	} );
 
@@ -1015,60 +956,6 @@ describe( 'toolProvider', () => {
 			expect( parsed.data.calypsoCheckpointId ).toBe( 'call_test_123' );
 			expect( parsed.data.isCurrent ).toBe( true );
 			expect( parsed.data.hideZoomAction ).toBe( true );
-		} );
-
-		it( 'accepts the legacy Big Sky show-component tool during migration', async () => {
-			const { result } = ( await toolProvider.executeAbility( LEGACY_SHOW_COMPONENT_TOOL_ID, {
-				type: 'review-mediation',
-				props: {
-					summary: 'Summary.',
-					conflicts: [],
-					implications: [],
-					suggested_edits: [],
-					guideline_violations: [],
-				},
-			} ) ) as any;
-
-			const parsed = JSON.parse( result.agentMessage );
-			expect( parsed.tool_id ).toBe( SHOW_COMPONENT_TOOL_ID );
-			expect( parsed.data.type ).toBe( 'review-mediation' );
-		} );
-
-		it( 'delegates non-Jetpack legacy show-component calls to Big Sky', async () => {
-			const args = {
-				type: 'color-picker',
-				props: { colors: [] },
-			};
-			const executeAbility = jest.fn().mockResolvedValue( {
-				result: 'Big Sky component displayed successfully',
-				returnToAgent: false,
-			} );
-			( window as any ).wp.abilities = { executeAbility };
-
-			const result = await toolProvider.executeAbility( LEGACY_SHOW_COMPONENT_TOOL_ID, args );
-
-			expect( executeAbility ).toHaveBeenCalledWith( 'big-sky/show-component', args );
-			expect( result ).toEqual( {
-				result: 'Big Sky component displayed successfully',
-				returnToAgent: false,
-			} );
-		} );
-
-		it.each( [
-			[ 'empty', '' ],
-			[ 'whitespace-only', '   ' ],
-		] )( 'does not delegate %s legacy show-component calls to Big Sky', async ( _label, type ) => {
-			const executeAbility = jest.fn();
-			( window as any ).wp.abilities = { executeAbility };
-
-			const { result } = await toolProvider.executeAbility( LEGACY_SHOW_COMPONENT_TOOL_ID, {
-				type,
-				props: {},
-			} );
-
-			expect( executeAbility ).not.toHaveBeenCalled();
-			expect( result ).toMatchObject( { success: false } );
-			expect( result.error ).toMatch( /missing type/ );
 		} );
 
 		it( 'does not attach a title checkpoint to review-mediation components', async () => {

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -773,6 +773,23 @@ describe( 'toolProvider', () => {
 			expect( typeof updateBlock?.callback ).toBe( 'function' );
 		} );
 
+		it( 'preserves Big Sky abilities exposed through wp.abilities', async () => {
+			( window as any ).wp.abilities = {
+				getAbilities: jest.fn().mockResolvedValue( [
+					{ name: 'big-sky/show-component', label: 'Big Sky show component' },
+					{ name: 'big-sky/change-colors', label: 'Change colors' },
+				] ),
+			};
+
+			const abilities = await toolProvider.getAbilities();
+			const names = abilities.map( ( a: any ) => a.name );
+
+			expect( names ).toContain( 'big-sky/show-component' );
+			expect( names ).toContain( 'big-sky/change-colors' );
+			expect( names ).toContain( SHOW_COMPONENT_TOOL_ID );
+			expect( names ).not.toContain( LEGACY_SHOW_COMPONENT_TOOL_ID );
+		} );
+
 		it( 'delegates non-Jetpack legacy show-component callbacks to Big Sky', async () => {
 			const args = {
 				type: 'color-picker',

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -39,6 +39,7 @@ let mockCurrentPostType: string | undefined = 'post';
 let mockBlocksByClientId: Record< string, any > = {};
 const SHOW_COMPONENT_TOOL_ID = 'jetpack_ai__show_component';
 const LEGACY_SHOW_COMPONENT_TOOL_ID = 'big_sky__show_component';
+const UPDATE_BLOCK_CONTENT_TOOL_ID = 'jetpack-ai/update-block-content';
 
 jest.mock( '@wordpress/components', () => {
 	const react = jest.requireActual< typeof import('react') >( 'react' );
@@ -149,6 +150,13 @@ function installAiEditorialReviewData( features: Record< string, boolean > = {} 
 	};
 }
 
+function installBigSkyProviderData( features: Record< string, boolean > = {} ) {
+	installAiEditorialReviewData( features );
+	( globalThis as any ).agentsManagerData.agentProviders = [
+		'https://widgets.wp.com/agents-manager/big-sky.provider.mjs',
+	];
+}
+
 function SuggestionsProbe( {
 	onSuggestions,
 	maxSuggestions,
@@ -226,6 +234,16 @@ describe( 'getEmptyViewSuggestions', () => {
 		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
 
 		expect( labels ).not.toContain( 'Optimize Title' );
+		expect( labels ).not.toContain( 'AI Editorial Review' );
+	} );
+
+	it( 'shows Optimize Title on page editors when the preview feature enables it', () => {
+		installAiEditorialReviewData( { optimizeTitleSuggestion: true } );
+		installPostTypeMock( 'page' );
+
+		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
+
+		expect( labels ).toContain( 'Optimize Title' );
 		expect( labels ).not.toContain( 'AI Editorial Review' );
 	} );
 
@@ -358,6 +376,70 @@ describe( 'useSuggestions', () => {
 					surface: 'jetpack_ai_sidebar',
 				},
 			],
+		] );
+	} );
+
+	it( 'keeps Optimize Title out of selected-block suggestions', () => {
+		installAiEditorialReviewData( { optimizeTitleSuggestion: true } );
+		mockCurrentPostType = 'page';
+		mockSelectedBlock = { clientId: 'b-selected', name: 'core/paragraph' };
+		const onSuggestions = jest.fn();
+
+		render( React.createElement( SuggestionsProbe, { onSuggestions } ) );
+
+		const latestSuggestions =
+			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
+		expect( latestSuggestions.map( ( suggestion: any ) => suggestion.label ) ).toEqual( [
+			'Translate content',
+			'Change tone',
+			'Check grammar',
+			'Simplify text',
+		] );
+	} );
+
+	it( 'omits Jetpack selected-block text suggestions on Big Sky Page Editor surfaces', () => {
+		installBigSkyProviderData( { optimizeTitleSuggestion: true } );
+		mockCurrentPostType = 'page';
+		mockSelectedBlock = { clientId: 'b-selected', name: 'core/paragraph' };
+		const onSuggestions = jest.fn();
+
+		render( React.createElement( SuggestionsProbe, { onSuggestions } ) );
+
+		const latestSuggestions =
+			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
+		expect( latestSuggestions.map( ( suggestion: any ) => suggestion.label ) ).toEqual( [] );
+		expect( getTracksCalls( 'jetpack_ai_block_transformation_suggestion_rendered' ) ).toEqual( [] );
+	} );
+
+	it( 'keeps Jetpack selected-block text suggestions on Jetpack-only Page Editor surfaces', () => {
+		installAiEditorialReviewData( { optimizeTitleSuggestion: true } );
+		mockCurrentPostType = 'page';
+		mockSelectedBlock = { clientId: 'b-selected', name: 'core/paragraph' };
+		const onSuggestions = jest.fn();
+
+		render( React.createElement( SuggestionsProbe, { onSuggestions } ) );
+
+		const latestSuggestions =
+			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
+		expect( latestSuggestions.map( ( suggestion: any ) => suggestion.label ) ).toEqual( [
+			'Translate content',
+			'Change tone',
+			'Check grammar',
+			'Simplify text',
+		] );
+	} );
+
+	it( 'shows Optimize Title in Page Editor when no block is selected', () => {
+		installAiEditorialReviewData( { optimizeTitleSuggestion: true } );
+		mockCurrentPostType = 'page';
+		const onSuggestions = jest.fn();
+
+		render( React.createElement( SuggestionsProbe, { onSuggestions } ) );
+
+		const latestSuggestions =
+			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
+		expect( latestSuggestions.map( ( suggestion: any ) => suggestion.label ) ).toEqual( [
+			'Optimize Title',
 		] );
 	} );
 
@@ -755,9 +837,31 @@ describe( 'toolProvider', () => {
 			const abilities = await toolProvider.getAbilities();
 			const names = abilities.map( ( a: any ) => a.name );
 
-			expect( names ).toContain( 'wpcom/update-block-content' );
+			expect( names ).toContain( UPDATE_BLOCK_CONTENT_TOOL_ID );
 			expect( names ).toContain( SHOW_COMPONENT_TOOL_ID );
 			expect( names ).toContain( LEGACY_SHOW_COMPONENT_TOOL_ID );
+		} );
+
+		it( 'keeps update-block-content available on Big Sky Page Editor surfaces', async () => {
+			installBigSkyProviderData();
+			installPostTypeMock( 'page' );
+
+			const abilities = await toolProvider.getAbilities();
+			const names = abilities.map( ( a: any ) => a.name );
+
+			expect( names ).toContain( UPDATE_BLOCK_CONTENT_TOOL_ID );
+			expect( names ).toContain( SHOW_COMPONENT_TOOL_ID );
+		} );
+
+		it( 'keeps update-block-content on Jetpack-only Page Editor surfaces', async () => {
+			installAiEditorialReviewData();
+			installPostTypeMock( 'page' );
+
+			const abilities = await toolProvider.getAbilities();
+			const names = abilities.map( ( a: any ) => a.name );
+
+			expect( names ).toContain( UPDATE_BLOCK_CONTENT_TOOL_ID );
+			expect( names ).toContain( SHOW_COMPONENT_TOOL_ID );
 		} );
 
 		it( 'wires a callback on each provided ability', async () => {
@@ -766,11 +870,22 @@ describe( 'toolProvider', () => {
 			const legacyShowComponent = abilities.find(
 				( a: any ) => a.name === LEGACY_SHOW_COMPONENT_TOOL_ID
 			);
-			const updateBlock = abilities.find( ( a: any ) => a.name === 'wpcom/update-block-content' );
+			const updateBlock = abilities.find( ( a: any ) => a.name === UPDATE_BLOCK_CONTENT_TOOL_ID );
 
 			expect( typeof showComponent?.callback ).toBe( 'function' );
 			expect( typeof legacyShowComponent?.callback ).toBe( 'function' );
 			expect( typeof updateBlock?.callback ).toBe( 'function' );
+		} );
+
+		it( 'includes routing instructions on update-block-content', async () => {
+			const abilities = await toolProvider.getAbilities();
+			const updateBlock = abilities.find( ( a: any ) => a.name === UPDATE_BLOCK_CONTENT_TOOL_ID );
+
+			expect( updateBlock?.meta?.instructions ).toContain(
+				'Jetpack AI Sidebar selected text-block'
+			);
+			expect( updateBlock?.meta?.instructions ).toContain( 'jetpack_ai__update_block_content' );
+			expect( updateBlock?.meta?.instructions ).toContain( 'wpcom__rewrite_content' );
 		} );
 
 		it( 'preserves Big Sky abilities exposed through wp.abilities', async () => {
@@ -847,7 +962,7 @@ describe( 'toolProvider', () => {
 			const abilities = await toolProvider.getAbilities();
 			const names = abilities.map( ( a: any ) => a.name );
 
-			expect( names ).not.toContain( 'wpcom/update-block-content' );
+			expect( names ).not.toContain( UPDATE_BLOCK_CONTENT_TOOL_ID );
 			expect( names ).toContain( SHOW_COMPONENT_TOOL_ID );
 			expect( names ).toContain( LEGACY_SHOW_COMPONENT_TOOL_ID );
 		} );
@@ -1077,11 +1192,13 @@ function installWpDataMockWithBlockEditor(
 			name: 'core/paragraph',
 			attributes: { content: 'original block content' },
 		},
-	}
+	},
+	selectedClientId?: string
 ) {
 	const editorState: { title: string } = { title: 'original' };
 	const blockUpdates: Array< { clientId: string; attrs: Record< string, unknown > } > = [];
 	const selectedClientIds: string[] = [];
+	let selectedBlockClientId = selectedClientId;
 	( window as any ).wp = {
 		data: {
 			select: ( store: string ) => {
@@ -1095,6 +1212,10 @@ function installWpDataMockWithBlockEditor(
 					return {
 						getBlock: ( clientId: string ) =>
 							blocks[ clientId ] ? { clientId, ...blocks[ clientId ] } : null,
+						getSelectedBlock: () =>
+							selectedBlockClientId && blocks[ selectedBlockClientId ]
+								? { clientId: selectedBlockClientId, ...blocks[ selectedBlockClientId ] }
+								: null,
 						getBlocks: () =>
 							Object.entries( blocks ).map( ( [ clientId, block ] ) => ( {
 								clientId,
@@ -1126,6 +1247,7 @@ function installWpDataMockWithBlockEditor(
 							}
 						},
 						selectBlock: ( clientId: string ) => {
+							selectedBlockClientId = clientId;
 							selectedClientIds.push( clientId );
 						},
 					};
@@ -1373,6 +1495,42 @@ describe( 'applyReviewEdit', () => {
 				attrs: { content: 'Hello world, this is my first post.' },
 			},
 		] );
+		warn.mockRestore();
+	} );
+
+	it( 'falls back to the selected block when the clientId is compressed', async () => {
+		const { blockUpdates } = installWpDataMockWithBlockEditor(
+			{
+				'live-client-id': {
+					name: 'core/paragraph',
+					attributes: { content: 'hello world' },
+				},
+			},
+			'live-client-id'
+		);
+		useAbilitiesSetup( { addMessage: () => undefined, clearSuggestions: () => undefined } as any );
+		const warn = jest.spyOn( console, 'warn' ).mockImplementation( () => undefined );
+
+		const promise = applyReviewEdit( 'short-id', 'hola mundo' );
+		jest.advanceTimersByTime( 1000 );
+		const result = await promise;
+
+		expect( result ).toMatchObject( {
+			success: true,
+			clientId: 'live-client-id',
+			contentBefore: 'hello world',
+			contentAfter: 'hola mundo',
+		} );
+		expect( blockUpdates ).toEqual( [
+			{
+				clientId: 'live-client-id',
+				attrs: { content: 'hola mundo' },
+			},
+		] );
+		expect( warn ).toHaveBeenCalledWith(
+			'[ReviewMediation] stale clientId matched selected block',
+			expect.any( Object )
+		);
 		warn.mockRestore();
 	} );
 

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -272,9 +272,6 @@ function applySuggestionLimit< T extends { id: string } >(
 // ---------- Show-component ability ----------
 
 const SHOW_COMPONENT_TOOL_ID = 'jetpack_ai__show_component';
-const LEGACY_SHOW_COMPONENT_TOOL_ID = 'big_sky__show_component';
-const BIG_SKY_SHOW_COMPONENT_ABILITY = 'big-sky/show-component';
-const SHOW_COMPONENT_TOOL_IDS = [ SHOW_COMPONENT_TOOL_ID, LEGACY_SHOW_COMPONENT_TOOL_ID ];
 
 /**
  * Client-side ability definition for `jetpack_ai__show_component`.
@@ -299,23 +296,8 @@ const SHOW_COMPONENT_ABILITY: any = {
 	},
 };
 
-const LEGACY_SHOW_COMPONENT_ABILITY: any = {
-	...SHOW_COMPONENT_ABILITY,
-	id: LEGACY_SHOW_COMPONENT_TOOL_ID,
-	name: LEGACY_SHOW_COMPONENT_TOOL_ID,
-};
-
 function hasShowComponentType( type: unknown ): type is string {
 	return typeof type === 'string' && type.trim() !== '';
-}
-
-function isJetpackShowComponentType( type: unknown ): boolean {
-	return hasShowComponentType( type ) && !! getChatComponent( type );
-}
-
-function shouldDelegateLegacyShowComponent( input: any ): boolean {
-	const type = input?.type;
-	return hasShowComponentType( type ) && ! isJetpackShowComponentType( type );
 }
 
 /**
@@ -381,17 +363,6 @@ function handleShowComponent( input: any ): any {
 		returnToAgent: false,
 		agentMessage,
 	};
-}
-
-async function handleLegacyShowComponent( input: any ): Promise< any > {
-	if ( shouldDelegateLegacyShowComponent( input ) ) {
-		const executeAbility = getAbilitiesExecuteAbility();
-		if ( executeAbility ) {
-			return executeAbility( 'big-sky/show-component', input );
-		}
-	}
-
-	return handleShowComponent( input );
 }
 
 /**
@@ -467,20 +438,8 @@ function filterAbility( abilities: any[], toolId: string ): any[] {
 	);
 }
 
-function hasLegacyShowComponentAbility( abilities: any[] ): boolean {
-	const legacyNormalized = normalizeAbilityName( LEGACY_SHOW_COMPONENT_TOOL_ID );
-	return abilities.some( ( ability: any ) => {
-		const name = ability?.name;
-		return (
-			typeof name === 'string' &&
-			( name === BIG_SKY_SHOW_COMPONENT_ABILITY ||
-				normalizeAbilityName( name ) === legacyNormalized )
-		);
-	} );
-}
-
 function isShowComponentTool( toolId: string ): boolean {
-	return SHOW_COMPONENT_TOOL_IDS.includes( toolId );
+	return toolId === SHOW_COMPONENT_TOOL_ID;
 }
 
 export const toolProvider = {
@@ -506,7 +465,6 @@ export const toolProvider = {
 			}
 		}
 
-		const externalLegacyShowComponentAvailable = hasLegacyShowComponentAbility( abilities );
 		abilities = filterAbility( abilities, UPDATE_BLOCK_CONTENT_TOOL_ID );
 		abilities = filterAbility( abilities, LEGACY_UPDATE_BLOCK_CONTENT_TOOL_ID );
 		abilities = filterAbility( abilities, SHOW_COMPONENT_TOOL_ID );
@@ -523,14 +481,6 @@ export const toolProvider = {
 				...SHOW_COMPONENT_ABILITY,
 				callback: handleShowComponent,
 			},
-			...( externalLegacyShowComponentAvailable
-				? []
-				: [
-						{
-							...LEGACY_SHOW_COMPONENT_ABILITY,
-							callback: handleLegacyShowComponent,
-						},
-				  ] ),
 		];
 		abilities.unshift( ...jetpackAbilities );
 		return abilities;
@@ -546,13 +496,6 @@ export const toolProvider = {
 		if ( isUpdateBlockContentTool( name ) ) {
 			const result = await handleUpdateBlockContent( args );
 			return { result, returnToAgent: false };
-		}
-
-		if ( name === LEGACY_SHOW_COMPONENT_TOOL_ID && shouldDelegateLegacyShowComponent( args ) ) {
-			const executeAbility = getAbilitiesExecuteAbility();
-			if ( executeAbility ) {
-				return executeAbility( 'big-sky/show-component', args );
-			}
 		}
 
 		if ( isShowComponentTool( name ) ) {

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -119,7 +119,7 @@ function isJetpackAiSidebarPreviewFeatureEnabled(
 	if ( ! preview ) {
 		return defaultValue;
 	}
-	if ( ! preview.enabled ) {
+	if ( preview.enabled === false ) {
 		return false;
 	}
 	return preview.features?.[ feature ] === true;
@@ -228,6 +228,7 @@ function applySuggestionLimit< T extends { id: string } >(
 
 const SHOW_COMPONENT_TOOL_ID = 'jetpack_ai__show_component';
 const LEGACY_SHOW_COMPONENT_TOOL_ID = 'big_sky__show_component';
+const BIG_SKY_SHOW_COMPONENT_ABILITY = 'big-sky/show-component';
 const SHOW_COMPONENT_TOOL_IDS = [ SHOW_COMPONENT_TOOL_ID, LEGACY_SHOW_COMPONENT_TOOL_ID ];
 
 /**
@@ -421,6 +422,18 @@ function filterAbility( abilities: any[], toolId: string ): any[] {
 	);
 }
 
+function hasLegacyShowComponentAbility( abilities: any[] ): boolean {
+	const legacyNormalized = normalizeAbilityName( LEGACY_SHOW_COMPONENT_TOOL_ID );
+	return abilities.some( ( ability: any ) => {
+		const name = ability?.name;
+		return (
+			typeof name === 'string' &&
+			( name === BIG_SKY_SHOW_COMPONENT_ABILITY ||
+				normalizeAbilityName( name ) === legacyNormalized )
+		);
+	} );
+}
+
 function isShowComponentTool( toolId: string ): boolean {
 	return SHOW_COMPONENT_TOOL_IDS.includes( toolId );
 }
@@ -448,10 +461,9 @@ export const toolProvider = {
 			}
 		}
 
+		const externalLegacyShowComponentAvailable = hasLegacyShowComponentAbility( abilities );
 		abilities = filterAbility( abilities, UPDATE_BLOCK_CONTENT_TOOL_ID );
-		for ( const toolId of SHOW_COMPONENT_TOOL_IDS ) {
-			abilities = filterAbility( abilities, toolId );
-		}
+		abilities = filterAbility( abilities, SHOW_COMPONENT_TOOL_ID );
 		const jetpackAbilities = [
 			...( isBlockTransformationsEnabled()
 				? [
@@ -465,10 +477,14 @@ export const toolProvider = {
 				...SHOW_COMPONENT_ABILITY,
 				callback: handleShowComponent,
 			},
-			{
-				...LEGACY_SHOW_COMPONENT_ABILITY,
-				callback: handleLegacyShowComponent,
-			},
+			...( externalLegacyShowComponentAvailable
+				? []
+				: [
+						{
+							...LEGACY_SHOW_COMPONENT_ABILITY,
+							callback: handleLegacyShowComponent,
+						},
+				  ] ),
 		];
 		abilities.unshift( ...jetpackAbilities );
 		return abilities;

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -39,6 +39,7 @@ import {
 } from './utils/block-actions';
 import {
 	UPDATE_BLOCK_CONTENT_TOOL_ID,
+	LEGACY_UPDATE_BLOCK_CONTENT_TOOL_ID,
 	UPDATE_BLOCK_CONTENT_ABILITY,
 	isUpdateBlockContentTool,
 } from './utils/tool-provider';
@@ -145,6 +146,50 @@ function isOptimizeTitleSuggestionEnabled(): boolean {
 
 function isBlockTransformationsEnabled(): boolean {
 	return isJetpackAiSidebarPreviewFeatureEnabled( 'blockTransformations', true );
+}
+
+function providerEntryLooksLikeDesignProvider( providerEntry: unknown ): boolean {
+	const providerSource =
+		typeof providerEntry === 'string'
+			? providerEntry
+			: [
+					( providerEntry as any )?.id,
+					( providerEntry as any )?.name,
+					( providerEntry as any )?.url,
+					( providerEntry as any )?.src,
+			  ]
+					.filter( ( value ) => typeof value === 'string' )
+					.join( ' ' );
+
+	return /big[-_]?sky|dolly/i.test( providerSource );
+}
+
+function hasDesignProviderActive(): boolean {
+	const data = getAgentsManagerData() as any;
+	const providers = Array.isArray( data?.agentProviders ) ? data.agentProviders : [];
+
+	return (
+		providers.some( providerEntryLooksLikeDesignProvider ) ||
+		typeof ( window as any ).bigSkyInitialState !== 'undefined' ||
+		!! data?.bigSkyVersion ||
+		!! data?.siteMetadata?.big_sky_version
+	);
+}
+
+function isDesignEditorSurface(
+	currentPostType: string | undefined = getCurrentEditorPostType()
+): boolean {
+	const pathname = window.location.pathname;
+
+	return currentPostType === 'page' || pathname.includes( 'site-editor.php' );
+}
+
+function shouldProvideBlockTransformations( currentPostType?: string ): boolean {
+	if ( ! isBlockTransformationsEnabled() ) {
+		return false;
+	}
+
+	return ! ( isDesignEditorSurface( currentPostType ) && hasDesignProviderActive() );
 }
 
 function getCurrentEditorPostType(): string | undefined {
@@ -402,8 +447,8 @@ export function useAbilitiesSetup( actions: {
 
 /**
  * Normalize an ability name to the format used by agenttic-client for matching.
- * @param {string} name - Ability name (e.g., 'wpcom/update-block-content').
- * @returns {string} Normalized name (e.g., 'wpcom__update_block_content').
+ * @param {string} name - Ability name (e.g., 'jetpack-ai/update-block-content').
+ * @returns {string} Normalized name (e.g., 'jetpack_ai__update_block_content').
  */
 function normalizeAbilityName( name: string ): string {
 	return name.replace( /\//g, '__' ).replace( /-/g, '_' );
@@ -440,7 +485,7 @@ function isShowComponentTool( toolId: string ): boolean {
 
 export const toolProvider = {
 	/**
-	 * Client-side abilities this provider handles: `wpcom/update-block-content`
+	 * Client-side abilities this provider handles: `jetpack-ai/update-block-content`
 	 * (block edits + summary) and Jetpack show-component tools (interactive
 	 * pickers, registered here so self-hosted Jetpack sees the tool_id).
 	 * @returns {Promise<any[]>} Array of ability descriptors.
@@ -463,6 +508,7 @@ export const toolProvider = {
 
 		const externalLegacyShowComponentAvailable = hasLegacyShowComponentAbility( abilities );
 		abilities = filterAbility( abilities, UPDATE_BLOCK_CONTENT_TOOL_ID );
+		abilities = filterAbility( abilities, LEGACY_UPDATE_BLOCK_CONTENT_TOOL_ID );
 		abilities = filterAbility( abilities, SHOW_COMPONENT_TOOL_ID );
 		const jetpackAbilities = [
 			...( isBlockTransformationsEnabled()
@@ -794,7 +840,7 @@ function trackRenderedBlockTransformationSuggestions(
 }
 
 function trackBlockTransformationSuggestionClickForValue( value: string ): void {
-	if ( ! isBlockTransformationsEnabled() ) {
+	if ( ! shouldProvideBlockTransformations() ) {
 		return;
 	}
 
@@ -923,7 +969,7 @@ export function useSuggestions(
 
 	const selectedBlock = editorContext.selectedBlock;
 	const aiEditorialReviewSuggestions = getAiEditorialReviewSuggestions( editorContext.postType );
-	const blockTransformationsEnabled = isBlockTransformationsEnabled();
+	const blockTransformationsEnabled = shouldProvideBlockTransformations( editorContext.postType );
 	const applicable = useMemo(
 		() =>
 			selectedBlock && blockTransformationsEnabled

--- a/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
@@ -354,6 +354,31 @@ function findBlockSnapshotByCurrentText( currentText: string ): {
 	return {};
 }
 
+function getSelectedOrRememberedBlockSnapshot(
+	currentText?: string
+): { clientId: string; name: string; content: string } | null {
+	const block = getSelectedOrRememberedBlock();
+	if ( ! block?.clientId ) {
+		return null;
+	}
+
+	const snapshot = {
+		clientId: block.clientId,
+		name: block.name,
+		content: getEditableBlockContent( block ),
+	};
+
+	if ( ! isSupportedEditBlockType( snapshot.name ) ) {
+		return null;
+	}
+
+	if ( currentText && ! snapshot.content.includes( currentText ) ) {
+		return null;
+	}
+
+	return snapshot;
+}
+
 /**
  * Handle the update-block-content tool call: apply text changes to a block.
  * @param {any} input - Tool input with clientId, content, optional summary / currentText,
@@ -405,6 +430,21 @@ export function handleUpdateBlockContent( input: any ): any {
 				snapshot = fallback.snapshot;
 				// eslint-disable-next-line no-console
 				console.warn( '[ReviewMediation] stale clientId matched by currentText', {
+					clientId,
+					targetClientId,
+				} );
+			}
+		}
+
+		if ( ! snapshot ) {
+			const selectedSnapshot = getSelectedOrRememberedBlockSnapshot(
+				hasCurrentText ? currentText : undefined
+			);
+			if ( selectedSnapshot ) {
+				targetClientId = selectedSnapshot.clientId;
+				snapshot = selectedSnapshot;
+				// eslint-disable-next-line no-console
+				console.warn( '[ReviewMediation] stale clientId matched selected block', {
 					clientId,
 					targetClientId,
 				} );

--- a/packages/jetpack-ai-sidebar/src/utils/tool-provider.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/tool-provider.ts
@@ -11,7 +11,8 @@
 
 import type { Tool } from '@automattic/agenttic-client';
 
-export const UPDATE_BLOCK_CONTENT_TOOL_ID = 'wpcom/update-block-content';
+export const UPDATE_BLOCK_CONTENT_TOOL_ID = 'jetpack-ai/update-block-content';
+export const LEGACY_UPDATE_BLOCK_CONTENT_TOOL_ID = 'wpcom/update-block-content';
 
 export const UPDATE_BLOCK_CONTENT_ABILITY: Tool = {
 	id: UPDATE_BLOCK_CONTENT_TOOL_ID,
@@ -19,6 +20,10 @@ export const UPDATE_BLOCK_CONTENT_ABILITY: Tool = {
 	...( { label: 'Update block content', category: 'jetpack-ai' } as any ), // eslint-disable-line @typescript-eslint/no-explicit-any
 	description:
 		'Update the text content of a specific block in the editor. Use this after translating, changing tone, checking grammar, or any other text transformation. The block will be updated directly in the editor.',
+	meta: {
+		instructions:
+			'Call jetpack_ai__update_block_content for Jetpack AI Sidebar selected text-block transformations, including translation, tone changes, grammar/spelling fixes, simplification, and similar rewrites. Use selected_block_client_id as clientId. When selected block content is available, include the exact original attributes.content string as currentText. Do not use wpcom__rewrite_content, wpcom__block_editing, or big_sky__set_processing_state for these Jetpack AI Sidebar selected-block transformations.',
+	},
 	input_schema: {
 		type: 'object',
 		properties: {
@@ -45,5 +50,10 @@ export const UPDATE_BLOCK_CONTENT_ABILITY: Tool = {
 };
 
 export function isUpdateBlockContentTool( toolId: string ): boolean {
-	return toolId === UPDATE_BLOCK_CONTENT_TOOL_ID || toolId === 'wpcom__update_block_content';
+	return [
+		UPDATE_BLOCK_CONTENT_TOOL_ID,
+		'jetpack_ai__update_block_content',
+		LEGACY_UPDATE_BLOCK_CONTENT_TOOL_ID,
+		'wpcom__update_block_content',
+	].includes( toolId );
 }


### PR DESCRIPTION
Base [PR](https://github.com/Automattic/wp-calypso/pull/111260) is porting of Dolly site editor context to AM

## Proposed Changes

* Load every provider from `agentsManagerData.agentProviders`, collect each provider's `toolProvider`, and expose one merged AM `toolProvider` to Agenttic.
* Merge abilities by provider registration order:
    * `getAbilities()` asks each provider for its current abilities at runtime, so hook-registered abilities can still appear after provider setup.
    * Ability names are indexed in both raw and normalized forms, for example `wpcom/update-block-content` and `wpcom__update_block_content` route to the same owning provider.
    * Unique abilities from later providers are added to the merged list.
    * Exact duplicate or equivalent normalized abilities use first-provider-wins, so the earlier registered provider keeps ownership.
    * `executeAbility()` refreshes the map and delegates the tool call back to the provider that supplied the winning ability.
* Keep interactive components source-aware by passing the tool id into `getChatComponent`. AM first asks the provider that owns the tool call for the matching component, then falls back to the other providers if needed. This lets Big Sky/Dolly pickers and Jetpack AI Sidebar components coexist in the same chat.
* Continue composing non-ability provider exports generically: chat components, empty-view suggestions, dynamic suggestions, capabilities, setup hooks, and checkpoint hooks.
* Add Optimize Title as a Jetpack-owned ability in the composed provider flow. In Page/Site Editor, Big Sky/Dolly keeps ownership of design tools and picker UI, while Jetpack owns the Optimize Title suggestion and title-picker component path.

Simple Post Editor (BigSky + JP AI) using Change Font, Optimize Title, Translate
<img width="1518" height="949" alt="Screenshot 2026-06-05 at 17 38 52" src="https://github.com/user-attachments/assets/69ddc098-ac67-4ec5-b931-64e8b9e3844e" />

Simple Page Editor (BigSky + JP AI) using AI Editorial Review, Optimize Title, Translate and move block
<img width="1519" height="1421" alt="Screenshot 2026-06-05 at 17 36 53" src="https://github.com/user-attachments/assets/4d00a3f1-d008-4c6f-bc2a-1855b80755bf" />

JN Page Editor (JP AI only) with Optimize Title 
<img width="1523" height="1464" alt="Screenshot 2026-06-05 at 17 41 25" src="https://github.com/user-attachments/assets/0f084db5-cc03-4e74-a4e2-4a0c01206352" />

## Why are these changes being made?

* This lets Dolly/Big Sky, Jetpack AI, and future providers compose through AM as peers.
* It keeps provider ownership clear: the host/design provider owns its design tools, and Jetpack AI owns its sidebar tools.

## Testing Instructions
* Checkout WPCOM PR 221819.
* Install this Calypso PR and Jetpack PR Automattic/jetpack#49387.

```
bin/jetpack-downloader test jetpack forno-326/merge-bigsky-jetpack-in-am
install-plugin.sh am forno-326/merge-bigsky-jetpack-in-am
```

### Page/Site Editor
1. Change font. Confirm the picker renders.
2. Optimize Title. Confirm the picker renders.
3. Select text, then run Translate to. Confirm the text is translated.
4. Select text, then run Move this to top of the page. Confirm the text moves.

### Post Editor
1. Run AI Editorial Review. Confirm the review UI renders.
2. Run Optimize Title. Confirm the picker renders.
3. Select text, then run Translate to. Confirm the text is translated.
4. Select text, then run Move this to top of the page. Confirm the text moves.

### Suggestions UI
Test this in both Page/Site Editor and Post Editor.

1. On load, confirm only Change font/color and Optimize Title suggestions show. Text, image, and column prompts should not show.
2. Select text. Confirm only text suggestions show. Site editor and image prompts should not show.
3. Select an image. Confirm only image suggestions show.

* Make sure easy-site-editor still works: <site_url>/wp-admin/admin.php?page=easy-site-editor

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?




