### PR TITLE
Move render-phase side effects into effects/commit phase

### DIFF
--- a/client/components/crm-downloads/crm-downloads.tsx
+++ b/client/components/crm-downloads/crm-downloads.tsx
@@ -1,7 +1,7 @@
 import { Card, Gridicon, Button } from '@automattic/components';
 import { ExternalLink } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import isJetpackCrmProduct from 'calypso/components/crm-downloads/is-jetpack-crm-product';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import useFetchJetpackCRMExtensionsQuery, {
@@ -60,7 +60,10 @@ export function CrmDownloadsContent( { licenseKey, isLoading }: CrmDownloadsProp
 		refetch: refetchExtensions,
 	} = useFetchJetpackCRMExtensionsQuery( isValidKey );
 
-	if ( isError ) {
+	useEffect( () => {
+		if ( ! isError ) {
+			return;
+		}
 		if ( error instanceof Error ) {
 			dispatch(
 				errorNotice(
@@ -78,7 +81,7 @@ export function CrmDownloadsContent( { licenseKey, isLoading }: CrmDownloadsProp
 				)
 			);
 		}
-	}
+	}, [ isError, error, dispatch, translate ] );
 
 	const handleExtensionDownload = useCallback(
 		async ( extensionSlug: string, extension: Extension ) => {

--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -282,8 +282,8 @@ const RecurringPaymentsPlanAddEditModal = ( {
 						translate( 'Added "%s" tier payment plan.', { args: editedProductName } )
 					)
 				);
-				recordTracksEvent( 'calypso_earn_page_payment_added', productDetails );
-				recordTracksEvent( 'calypso_earn_page_payment_added', annualProductDetails );
+				dispatch( recordTracksEvent( 'calypso_earn_page_payment_added', productDetails ) );
+				dispatch( recordTracksEvent( 'calypso_earn_page_payment_added', annualProductDetails ) );
 			} else {
 				dispatch(
 					requestAddProduct(
@@ -292,7 +292,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 						translate( 'Added "%s" payment plan.', { args: editedProductName } )
 					)
 				);
-				recordTracksEvent( 'calypso_earn_page_payment_added', productDetails );
+				dispatch( recordTracksEvent( 'calypso_earn_page_payment_added', productDetails ) );
 			}
 		} else if ( reason === 'submit' && product && product.ID ) {
 			productDetails.ID = product.ID;
@@ -332,7 +332,11 @@ const RecurringPaymentsPlanAddEditModal = ( {
 
 	// Record the "modal shown" event once on mount rather than on every render.
 	useEffect( () => {
-		recordTracksEvent( 'calypso_earn_page_payment_modal_show', { editing: product && product.ID } );
+		dispatch(
+			recordTracksEvent( 'calypso_earn_page_payment_modal_show', {
+				editing: product && product.ID,
+			} )
+		);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 

--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -330,7 +330,11 @@ const RecurringPaymentsPlanAddEditModal = ( {
 
 	const editing = product && product.ID;
 
-	recordTracksEvent( 'calypso_earn_page_payment_modal_show', { editing: editing } );
+	// Record the "modal shown" event once on mount rather than on every render.
+	useEffect( () => {
+		recordTracksEvent( 'calypso_earn_page_payment_modal_show', { editing: product && product.ID } );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
 
 	return (
 		<Dialog

--- a/client/my-sites/plans/current-plan/jetpack-product-install/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-product-install/index.tsx
@@ -80,10 +80,51 @@ export class JetpackProductInstall extends Component< Props, State > {
 	componentDidMount() {
 		this.requestInstallationStatus();
 		this.maybeStartInstall();
+		this.maybeReportInstallError();
 	}
 
 	componentDidUpdate() {
 		this.maybeStartInstall();
+		this.maybeReportInstallError();
+	}
+
+	/**
+	 * Report an installation error once, via analytics and logstash. Runs in the
+	 * commit phase (not render) so it fires only on committed updates rather than
+	 * on every — possibly discarded — render attempt under concurrent rendering.
+	 */
+	maybeReportInstallError(): void {
+		const hasErrorInstalling =
+			! this.shouldRefetchInstallationStatus() && this.installationHasRecoverableErrors();
+
+		if ( ! hasErrorInstalling || this.tracksEventSent ) {
+			return;
+		}
+
+		this.tracksEventSent = true;
+		const { status } = this.props;
+
+		this.props.recordTracksEvent( 'calypso_plans_autoconfig_error', {
+			checklist_name: 'jetpack',
+			error: 'installation_error',
+			location: 'JetpackChecklist',
+			status_akismet: status ? status.akismet_status : '(unknown)',
+			status_vaultpress: status ? status.vaultpress_status : '(unknown)',
+		} );
+
+		logToLogstash( {
+			feature: 'calypso_client',
+			message: 'Jetpack plugin installer error',
+			...( this.props.siteId && { site_id: this.props.siteId } ),
+			extra: {
+				pluginStatus: this.props.status,
+				knownPluginKeys: {
+					// Clean plugin keys for logging
+					akismet: !! this.state.pluginKeys?.akismet,
+					vaultpress: !! this.state.pluginKeys?.vaultpress,
+				},
+			},
+		} );
 	}
 
 	fetchPluginKeys = (): void => {
@@ -288,33 +329,6 @@ export class JetpackProductInstall extends Component< Props, State > {
 
 		const hasErrorInstalling =
 			! this.shouldRefetchInstallationStatus() && this.installationHasRecoverableErrors();
-
-		if ( hasErrorInstalling && ! this.tracksEventSent ) {
-			this.tracksEventSent = true;
-			const { status } = this.props;
-
-			this.props.recordTracksEvent( 'calypso_plans_autoconfig_error', {
-				checklist_name: 'jetpack',
-				error: 'installation_error',
-				location: 'JetpackChecklist',
-				status_akismet: status ? status.akismet_status : '(unknown)',
-				status_vaultpress: status ? status.vaultpress_status : '(unknown)',
-			} );
-
-			logToLogstash( {
-				feature: 'calypso_client',
-				message: 'Jetpack plugin installer error',
-				...( this.props.siteId && { site_id: this.props.siteId } ),
-				extra: {
-					pluginStatus: this.props.status,
-					knownPluginKeys: {
-						// Clean plugin keys for logging
-						akismet: !! this.state.pluginKeys?.akismet,
-						vaultpress: !! this.state.pluginKeys?.vaultpress,
-					},
-				},
-			} );
-		}
 
 		return (
 			<>

--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -198,9 +198,24 @@ export class Notifications extends Component {
 			);
 			this.postServiceWorkerMessage( { action: 'sendQueuedMessages' } );
 		}
+
+		this.maybeForceRefresh();
+	}
+
+	// Honor a requested force-refresh (e.g. dispatched from the desktop app) in
+	// the commit phase rather than during render, where it ran on every —
+	// possibly discarded — render attempt under concurrent rendering.
+	maybeForceRefresh() {
+		if ( this.props.forceRefresh ) {
+			debug( 'Refreshing notes panel...' );
+			refreshNotes();
+			this.props.didForceRefresh();
+		}
 	}
 
 	componentDidUpdate( prevProps ) {
+		this.maybeForceRefresh();
+
 		if ( prevProps.isShowing === this.props.isShowing ) {
 			return;
 		}
@@ -299,12 +314,6 @@ export class Notifications extends Component {
 	render() {
 		const localeSlug = this.props.currentLocaleSlug || config( 'i18n_default_locale_slug' );
 		const isDedicatedReaderPage = this.props.currentRoute?.startsWith( '/reader/notifications' );
-
-		if ( this.props.forceRefresh ) {
-			debug( 'Refreshing notes panel...' );
-			refreshNotes();
-			this.props.didForceRefresh();
-		}
 
 		return (
 			<>

--- a/client/performance-profiler/pages/dashboard/index.tsx
+++ b/client/performance-profiler/pages/dashboard/index.tsx
@@ -65,13 +65,15 @@ const PerformanceProfilerDashboard = ( props: PerformanceProfilerDashboardProps 
 
 	const siteUrl = new URL( url );
 
-	if ( isFetched && finalUrl ) {
-		performance.mark( 'test-started' );
-		recordTracksEvent( 'calypso_performance_profiler_test_started', {
-			url: finalUrl,
-			version: profilerVersion(),
-		} );
-	}
+	useEffect( () => {
+		if ( isFetched && finalUrl ) {
+			performance.mark( 'test-started' );
+			recordTracksEvent( 'calypso_performance_profiler_test_started', {
+				url: finalUrl,
+				version: profilerVersion(),
+			} );
+		}
+	}, [ isFetched, finalUrl ] );
 
 	// Append hash to the URL if it's not there to avoid losing it on page reload
 	useEffect( () => {


### PR DESCRIPTION
## Proposed Changes

Move render-phase side effects out of five components — into `useEffect` (function components) or the commit-phase lifecycle (class components):

- **`client/components/crm-downloads/crm-downloads.tsx`** — `if ( isError ) dispatch( errorNotice(...) )` ran in the component body → `useEffect` keyed on `[ isError, error ]`.
- **`client/my-sites/earn/components/add-edit-plan-modal/index.tsx`** — `recordTracksEvent( '…payment_modal_show' )` ran on every render → mount-only `useEffect`.
- **`client/performance-profiler/pages/dashboard/index.tsx`** — `performance.mark( 'test-started' )` + `recordTracksEvent( '…test_started' )` ran in the body → `useEffect` keyed on `[ isFetched, finalUrl ]`.
- **`client/my-sites/plans/current-plan/jetpack-product-install/index.tsx`** — in-`render()` error analytics + `logToLogstash` (and the `this.tracksEventSent` mutation) → a `maybeReportInstallError()` method called from `componentDidMount` / `componentDidUpdate`.
- **`client/notifications/index.jsx`** — the force-refresh handling (dispatched from the desktop app via `setForceRefresh`, see `client/lib/desktop-listeners/index.js`) ran in `render()` → a `maybeForceRefresh()` method called from `componentDidMount` / `componentDidUpdate`.

## Why are these changes being made?

A component's render phase — a function-component body, or a class `render()` method — can run multiple times, or be discarded entirely, before React 18 commits a mount/update under concurrent rendering. Side effects placed there fire on discarded render attempts and on every re-render, which over-counts analytics, repeats notices/logs, and can warn ("Cannot update a component while rendering"). This is the same class of bug as the notifications poll storm fixed in #111309 and the render-phase dispatches fixed in #110997 / #111000.

These were found by auditing class `render()` methods and function-component bodies for statement-position dispatch / navigation / analytics / notice calls (the function-component candidates were triaged per-file to exclude calls inside `useEffect`/`useCallback`/handlers/mutation callbacks). `useEffect` and commit-phase lifecycle methods run only on committed renders, which is the correct place for these effects. Behavior is preserved (including the desktop-only notifications force-refresh).

## Testing Instructions

- `yarn typecheck-client` and `yarn eslint` pass for the changed files (pre-existing unrelated Reader/Dashboard type errors on trunk are not affected).
- **CRM downloads:** load the Jetpack CRM downloads page with an invalid/erroring license key; confirm the error notice still appears (once), not repeatedly.
- **Earn → add/edit plan:** open the payment-plan modal; confirm it still opens and saves.
- **Performance profiler:** run a profiler report; confirm it loads and the `test_started` event still fires when results arrive.
- **Jetpack product install:** on a current-plan setup with a recoverable install error, confirm the error notice renders and the autoconfig-error event/log still fires once.
- **Notifications (desktop):** confirm a force-refresh (desktop app) still refreshes the notes panel.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Follow-up commit (`earn/add-edit-plan-modal`):** while moving the `payment_modal_show` tracks call into a `useEffect`, I noticed `recordTracksEvent` (the Redux action creator from `calypso/state/analytics/actions`) was being called **bare** at four sites in this file, so the returned action was never dispatched and the `payment_added` / `payment_modal_show` events never actually fired. Wrapped each in `dispatch(...)`. Note this one item is an intentional behavior change (the events now fire) — the rest of the PR is behavior-preserving.
