### PR TITLE
Omnibar: Fix Help Center icon size

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -1213,17 +1213,18 @@ a.masterbar__quick-language-switcher {
 
 .masterbar__item-help {
 	@media only screen and (min-width: 782px) {
-		padding: 0 11px;
+		padding-left: 8px;
+		padding-right: 9px;
 	}
 
 	svg {
 		fill: var(--color-masterbar-icon);
-		width: 22px;
-		height: 22px;
+		width: 27px;
+		height: 27px;
 
 		@media only screen and (max-width: 781px) {
-			width: 30px;
-			height: 30px;
+			width: 37px;
+			height: 37px;
 		}
 	}
 }


### PR DESCRIPTION
Fixes p1780036567190559-slack-CRWCHQGUB

## Proposed Changes

Fix the help center icon size to match wp-admin's:

|Before|After|
|-|-|
|<img width="337" height="38" alt="image" src="https://github.com/user-attachments/assets/bdf0c262-528c-4c41-acec-ed1962082021" />|<img width="337" height="35" alt="image" src="https://github.com/user-attachments/assets/16d49bf1-4ee1-40af-8d46-2a0838a30c9b" />

|Before|After|
|-|-|
|<img width="198" height="49" alt="image" src="https://github.com/user-attachments/assets/c75b7746-5136-4321-bbc1-95560794e620" />|<img width="194" height="49" alt="image" src="https://github.com/user-attachments/assets/5eaccb29-b7ac-4600-ba10-fec6428de956" />


## Why are these changes being made?

Fixes a regression. I think this was introduced some time when we upgrade our dependencies, maybe `@wordpress/components`.

## Testing Instructions

Check the help center icon size on `/sites` on desktop and mobile resolutions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?