### PR TITLE
Stats: fix navigation tab padding broken by admin-ui 2.x bump

### DIFF
--- a/client/my-sites/stats/components/stats-main/index.tsx
+++ b/client/my-sites/stats/components/stats-main/index.tsx
@@ -136,6 +136,9 @@ export default function StatsMain( {
 			{ ! isWPAdminAndNotSimpleSite && <QuerySiteFeatures siteIds={ [ siteId ] } /> }
 			<QuerySiteSettings siteId={ siteId } />
 			<Page
+				// Restore a stable styling hook lost when @wordpress/admin-ui 2.x moved Page
+				// internals to CSS Modules. Stats SCSS overrides target `.admin-ui-page`.
+				className="admin-ui-page"
 				showSidebarToggle={ false }
 				title={ <JetpackTitle title={ titleContent } /> }
 				subTitle={ breadcrumbs ? undefined : pageSubTitle }

--- a/client/my-sites/stats/stats-download-csv/style.scss
+++ b/client/my-sites/stats/stats-download-csv/style.scss
@@ -1,7 +1,9 @@
 @import "@wordpress/base-styles/breakpoints";
 
 .calypso-navigation-header,
-.admin-ui-page__header-actions {
+// admin-ui 2.x header has no stable class; the header is the first child of
+// the Page root (`.admin-ui-page`, restored via the Page `className` prop).
+.admin-ui-page > :first-child {
 	.stats-download-csv {
 		gap: 4px;
 

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -99,26 +99,26 @@ $font-sf-pro-display: "SF Pro Display", $sans;
 		padding: 0;
 	}
 
-	// Pull stats-navigation tabs into the Page header area visually.
-	.admin-ui-page__header {
-		border-bottom: none;
-
-		// Allow the title to truncate when breadcrumb text is long.
+	// admin-ui 2.x moved the Page internals to CSS Modules, so the old
+	// `.admin-ui-page*` class hooks were lost. `.admin-ui-page` is restored on
+	// the Page root via its `className` prop; everything else hangs off it.
+	.admin-ui-page {
+		// The header has no stable class in 2.x, so anchor structurally:
+		// StatsMain always passes a `title`, so the header is the first child.
 		> :first-child {
-			align-items: center;
-			height: $grid-unit-40;
+			// Merge the header into the navigation strip below it.
+			border-bottom: none;
 
-			> :first-child {
+			// Let the title group shrink so long breadcrumb text can truncate.
+			// admin-ui's title-group flex item has no stable class, so anchor on
+			// the element wrapping the title heading rather than its DOM position.
+			// Replace with a stable hook if @wordpress/admin-ui exposes one.
+			*:has(> h1) {
 				min-width: 0;
 			}
 		}
 
-		// Breadcrumb styling for detail pages.
-		.admin-ui-page__header-title {
-			display: flex;
-			align-items: center;
-		}
-
+		// Breadcrumb trail rendered inside the unified header on detail pages.
 		.stats-breadcrumbs {
 			display: inline-flex;
 			align-items: center;
@@ -144,11 +144,11 @@ $font-sf-pro-display: "SF Pro Display", $sans;
 			overflow: hidden;
 			text-overflow: ellipsis;
 		}
-	}
 
-	.admin-ui-page > .stats-navigation {
-		background: var(--wpds-color-bg-surface-neutral-strong);
-		padding-inline: var(--wpds-dimension-padding-2xl, 24px);
+		> .stats-navigation {
+			background: var(--wpds-color-bg-surface-neutral-strong);
+			padding-inline: var(--wpds-dimension-padding-2xl, 24px);
+		}
 	}
 
 	// TODO: Remove other independent segmented control styles by this mixin.

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -1,5 +1,6 @@
 @use "sass:math";
 @import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/breakpoints";
 @import "calypso/components/jetpack-page-layout/admin-ui-page";
 @import "calypso/my-sites/stats/modernized-tooltip-styles";
 @import "calypso/my-sites/stats/modernized-chart-tabs-styles";
@@ -146,8 +147,15 @@ $font-sf-pro-display: "SF Pro Display", $sans;
 		}
 
 		> .stats-navigation {
-			background: var(--wpds-color-bg-surface-neutral-strong);
-			padding-inline: var(--wpds-dimension-padding-2xl, 24px);
+			// The unified-header treatment (background strip + inset) only
+			// applies on wider screens. On small screens the nav block insets
+			// the tabs itself (16px on the --improved variant), so applying the
+			// inset here too would stack. Mirrors the block's
+			// `@media (max-width: $break-small)` rule.
+			@media (min-width: ($break-small + 1px)) {
+				background: var(--wpds-color-bg-surface-neutral-strong);
+				padding-inline: var(--wpds-dimension-padding-2xl, 24px);
+			}
 		}
 	}
 


### PR DESCRIPTION
Part of STATS-260

## Proposed Changes

* Pass `className="admin-ui-page"` to the `@wordpress/admin-ui` `<Page>` in `stats-main`, restoring the `.admin-ui-page` styling hook on the Page root.
* Re-anchor the Stats unified-header overrides in `style.scss` onto `.admin-ui-page` (header via `> :first-child`, breadcrumbs via the stable `.stats-breadcrumbs` classes), and drop the now-dead `.admin-ui-page__header*` selectors.
* Re-anchor the Download CSV header-actions styling in `stats-download-csv/style.scss` the same way.

## Why are these changes being made?

`@wordpress/admin-ui` was bumped `1.x → 2.1.0` in #111049, which moved the `Page`/`Header` internals to CSS Modules. The formerly-global classes (`admin-ui-page`, `admin-ui-page__header`, `admin-ui-page__header-title`, `admin-ui-page__header-actions`) are now hashed and no longer match, which **silently broke** the Stats unified-header and navigation overrides introduced in #109786 — most visibly the navigation tabs losing their padding/background (STATS-260).

The Page only forwards a `className` to its root, and exposes no stable hook for the header slot, so the header overrides are re-anchored on structural selectors as a stopgap. The upstream gap (admin-ui should expose a stable header `className`) is tracked in STATS-261.

## Testing Instructions

* Open **Stats → Traffic / Insights / Subscribers** and confirm the navigation tabs have horizontal padding and the full-width background strip (compare against the cramped, edge-to-edge state in STATS-260).
* Open a detail page with a breadcrumb (e.g. **Stats → a single post/email**) and confirm the breadcrumb header renders correctly and the header has no bottom border separating it from the tabs.
* Confirm the **Download CSV** button styling in the page header (e.g. Emails summary) is unchanged.
* Verify in both Calypso and Odyssey (wp-admin) Stats if possible.

## Screenshots

| Before | After |
|---|---|
|<img width="637" height="251" alt="截圖 2026-06-04 下午3 48 33" src="https://github.com/user-attachments/assets/c5328aa6-fb77-443c-a011-55e22941e6b4" />|<img width="619" height="243" alt="截圖 2026-06-04 下午3 48 15" src="https://github.com/user-attachments/assets/8b292d6a-df97-44aa-8f37-d6160f92d0f4" />|
|<img width="633" height="254" alt="截圖 2026-06-04 下午3 48 46" src="https://github.com/user-attachments/assets/c51f5f14-f5d1-4503-8dee-2a282d30b1c2" />|<img width="623" height="258" alt="截圖 2026-06-04 下午3 48 09" src="https://github.com/user-attachments/assets/f691cd95-13aa-4ff8-86d0-fcc31e36c2e6" />|
|<img width="624" height="217" alt="截圖 2026-06-04 下午3 48 57" src="https://github.com/user-attachments/assets/9efb7f6b-a0ec-4f0f-98a0-cdcf4656d130" />|<img width="621" height="208" alt="截圖 2026-06-04 下午3 47 55" src="https://github.com/user-attachments/assets/45cbc772-3a1d-4123-8093-49cb05adc7c8" />|

<!-- Drop in Before/After captures of Stats → Traffic showing the tab padding + full-width background. -->

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)