### PR TITLE
Calypso Apps: externalize react/jsx-runtime to fix React 19

### DIFF
--- a/apps/blaze-dashboard/webpack.config.js
+++ b/apps/blaze-dashboard/webpack.config.js
@@ -149,6 +149,12 @@ module.exports = {
 						'lodash-es',
 						'react',
 						'react-dom',
+						// Externalize the JSX runtime alongside react/react-dom so it matches the
+						// React that WordPress provides. Bundling it (the default here, since it is
+						// absent from this allow list) ships an older React's runtime, whose elements
+						// React 19 rejects ("A React Element from an older version of React was rendered").
+						'react/jsx-runtime',
+						'react/jsx-dev-runtime',
 						'@wordpress/components',
 						'@wordpress/compose',
 						'@wordpress/i18n',

--- a/apps/odyssey-stats/webpack.config.js
+++ b/apps/odyssey-stats/webpack.config.js
@@ -143,6 +143,12 @@ module.exports = {
 						'lodash-es',
 						'react',
 						'react-dom',
+						// Externalize the JSX runtime alongside react/react-dom so it matches the
+						// React that WordPress provides. Bundling it (the default here, since it is
+						// absent from this allow list) ships an older React's runtime, whose elements
+						// React 19 rejects ("A React Element from an older version of React was rendered").
+						'react/jsx-runtime',
+						'react/jsx-dev-runtime',
 						'@wordpress/api-fetch',
 						'@wordpress/components',
 						'@wordpress/compose',

--- a/apps/wpcom-block-editor/webpack.config.js
+++ b/apps/wpcom-block-editor/webpack.config.js
@@ -71,12 +71,14 @@ function getWebpackConfig(
 					if ( request === 'tinymce/tinymce' ) {
 						return 'tinymce';
 					}
-					// Force bundling the React JSX runtime packages so that we don't have a missing `react-jsx-runtime`
-					// dependency on older WordPress versions that don't ship it yet.
+					// Externalize `react/jsx-runtime` (and its dev variant) to WordPress's `react-jsx-runtime`
+					// script handle so the runtime matches the React that WordPress provides. Bundling our own
+					// copy makes the editor create elements from an older React, which React 19 rejects
+					// ("A React Element from an older version of React was rendered"), throwing in every
+					// plugin's render during editor mount. WP ships `react-jsx-runtime` since 6.6.
 					if ( request === 'react/jsx-runtime' || request === 'react/jsx-dev-runtime' ) {
-						// returning null means don't externalize;
-						// returning undefined means call the default `requestToExternal`, which _would_ externalize `react-jsx-runtime`.
-						return null;
+						// returning undefined falls through to the default `requestToExternal`, which externalizes it.
+						return undefined;
 					}
 				},
 				requestToHandle( request ) {


### PR DESCRIPTION
Part of #

## Proposed Changes

Stop bundling `react/jsx-runtime` in three WordPress-embedded apps and externalize it to WordPress's `react-jsx-runtime` script handle, so the JSX runtime always matches the React that WordPress provides.

* **wpcom-block-editor** — was explicitly force-bundling it (`return null` → `return undefined`).
* **odyssey-stats** & **blaze-dashboard** — use `DependencyExtractionWebpackPlugin` with `useDefaults: false` + an allow list; they externalized `react`/`react-dom` but **omitted `react/jsx-runtime`**, so it was bundled by default. Added `react/jsx-runtime` and `react/jsx-dev-runtime` to both allow lists.

## Why are these changes being made?

These apps render into a host WordPress page that provides React. They were shipping their own copy of `react/jsx-runtime` (from React 18), which stamps JSX elements with an older React's internal element symbol. Under **React 19** the host rejects those elements:

> A React Element from an older version of React was rendered. This is not supported. … A library pre-bundled an old copy of "react" or "react/jsx-runtime".

In wpcom-block-editor this fired inside every plugin's `render()` during editor mount (caught by `PluginErrorBoundary`), surfacing in production as a cascade of minified **React error [#525](https://react.dev/errors/525)**. odyssey-stats and blaze-dashboard share the same structural mismatch and would hit the identical error as React 19 reaches their environments.

Externalizing makes the runtime match whatever React WordPress ships, so it works on **both React 18 and React 19**. WordPress has registered the `react-jsx-runtime` handle since 6.6 (and it's a transitive dependency already present on these screens), so the old "older WordPress versions don't ship it yet" rationale no longer applies.

## Testing Instructions

1. On a site running React 19 (set `define( 'SCRIPT_DEBUG', true )` to see the un-minified error), confirm the post editor currently logs *"A React Element from an older version of React was rendered"* / React [#525](https://react.dev/errors/525) on mount.
2. Build the affected app(s) and deploy the resulting `dist/` — including the regenerated `*.asset.php` manifests, which now list `react-jsx-runtime` as a dependency:
   * `yarn workspace @automattic/wpcom-block-editor build:wpcom-block-editor`
   * `yarn workspace @automattic/odyssey-stats dev`
   * `yarn workspace @automattic/blaze-dashboard dev`
3. Reload the editor (wpcom-block-editor) / the Stats screen (odyssey-stats) / the Advertising screen (blaze-dashboard) — the error is gone and the app renders normally.
4. Sanity-check a React 18 environment still works (the runtime simply matches whichever React WordPress ships).

Build-verified: after the change, all generated asset manifests list `react-jsx-runtime` and contain no bundled JSX runtime.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)