### PR TITLE
Desktop: remove redundant accelerators from Edit menu to fix Ctrl+A on Windows

### DIFF
--- a/desktop/app/lib/menu/edit-menu.js
+++ b/desktop/app/lib/menu/edit-menu.js
@@ -1,12 +1,10 @@
 module.exports = [
 	{
 		label: 'Undo',
-		accelerator: 'CmdOrCtrl+Z',
 		role: 'undo',
 	},
 	{
 		label: 'Redo',
-		accelerator: 'Shift+CmdOrCtrl+Z',
 		role: 'redo',
 	},
 	{
@@ -14,22 +12,18 @@ module.exports = [
 	},
 	{
 		label: 'Cut',
-		accelerator: 'CmdOrCtrl+X',
 		role: 'cut',
 	},
 	{
 		label: 'Copy',
-		accelerator: 'CmdOrCtrl+C',
 		role: 'copy',
 	},
 	{
 		label: 'Paste',
-		accelerator: 'CmdOrCtrl+V',
 		role: 'paste',
 	},
 	{
 		label: 'Select All',
-		accelerator: 'CmdOrCtrl+A',
 		role: 'selectall',
 	},
 ];


### PR DESCRIPTION
## Proposed Changes

* Fixes DOTAPP-4

## Why are these changes being made?

On Windows, Electron's menu accelerators intercept keyboard events before they reach the web content. This caused `Ctrl+A` to open/highlight the Edit menu popup instead of selecting all text in the editor (e.g. Gutenberg). The same issue affects Cut, Copy, Paste, Undo, and Redo in theory, though `Ctrl+A` is the most disruptive since it's commonly used inside the editor.

On macOS, the menu bar is system-level and separate from the window, so `Cmd+A` reaches the focused web view first — this is why the bug only manifests on Windows.

All six affected menu items already have a `role` property (`undo`, `redo`, `cut`, `copy`, `paste`, `selectall`). When a role is set, Electron's built-in role handling already wires up the correct keyboard shortcuts for each platform natively in the web content. The explicit `accelerator` entries are therefore redundant everywhere and actively harmful on Windows/Linux.

## Testing Instructions

* Build and run the desktop app on Windows
* Open the block editor (Gutenberg) and type some text
* Press `Ctrl+A` — it should select all text instead of opening a menu popup
* Verify Cut (`Ctrl+X`), Copy (`Ctrl+C`), Paste (`Ctrl+V`), Undo (`Ctrl+Z`), Redo (`Ctrl+Shift+Z`) still work as expected
* On macOS, verify the same shortcuts continue to work normally

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?