### PR TITLE
Fix experiment name: update mobile layout experiment to 202606

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-mobile-layout-experiment.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-mobile-layout-experiment.ts
@@ -5,7 +5,7 @@ import { useExperiment } from 'calypso/lib/explat';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
 
 // Register the variation names below in ExPlat alongside the experiment slug.
-const MOBILE_LAYOUT_EXPERIMENT_NAME = 'calypso_signup_onboarding_user_mobile_layout_202605';
+const MOBILE_LAYOUT_EXPERIMENT_NAME = 'calypso_signup_onboarding_user_mobile_layout_202606';
 
 type MobileLayoutExperimentVariant = 'control' | 'treatment_tos_bottom' | 'treatment_tos_top';
 


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of pbxNRc-64u-p2 and https://github.com/Automattic/wp-calypso/pull/110802

## Proposed Changes

* Updates the ExPlat experiment name from 202605 to 202606 to match the experiment in ExPlat.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The experiment name in the code (202605) doesn't exist in ExPlat, so the assignment API always returns null and users only ever see control. This aligns the code with the actual experiment (202606).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open an incognito window (mobile viewport)
* Go to https://wordpress.com/setup/onboarding/user?ref=logged-out-homepage-lp
* Use the ExPlat bookmarklets from the ExPlat experiment (`calypso_signup_onboarding_user_mobile_layout_202606`) to assign treatment
* Refresh

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

 - [x] Has the general commit checklist been followed?
 - [ ] Have you written new tests for your changes?
 - [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
 - [x] Have you checked for TypeScript, React or other console errors?