### PR TITLE
A4A Agent Studio: render deliverable thumbnails from HTML

### DIFF
--- a/client/a8c-for-agencies/sections/agent-studio/data/build-thumbnail-frames.ts
+++ b/client/a8c-for-agencies/sections/agent-studio/data/build-thumbnail-frames.ts
@@ -1,0 +1,99 @@
+/**
+ * Builds the single thumbnail frame an overview card renders, sized at its
+ * natural dimensions so the card can scale it down with CSS.
+ *
+ * - One-pager → the signed `/html` URL in `layout=filmstrip` mode (the wpcom
+ *   renderer lays the pages out in a horizontal row and self-fits each). The
+ *   frame is a cross-origin `src`, so it loads directly in an iframe — no
+ *   fetch, no client-side page splitting, no fit bootstrap.
+ * - Social → the client-composed tile wrapped as a same-origin `srcDoc`
+ *   (social has no server HTML).
+ */
+import type { AgentStudioSocialAsset } from '../types';
+
+export interface ThumbnailFrame {
+	width: number;
+	height: number;
+	/** Cross-origin signed URL loaded directly (one-pager filmstrip). */
+	src?: string;
+	/** Same-origin composed document (social tile). */
+	srcDoc?: string;
+}
+
+// The representative social tile for the card: the landscape "cover" size.
+const SOCIAL_PREVIEW_SIZE_KEY = 'cover';
+
+// US Letter at 96dpi — the renderer's native page canvas.
+const PAGE_NATURAL_WIDTH = 816;
+const PAGE_NATURAL_HEIGHT = 1056;
+
+// Must match the inter-page gap the wpcom filmstrip layout emits, so the
+// frame's declared width matches the document's actual row width.
+const FILMSTRIP_GAP = 16;
+
+/**
+ * One-pager → one frame whose `src` is the signed `/html` URL switched into
+ * filmstrip layout. The row is `pages` page-widths wide (plus gaps); the card
+ * scales it to the band height and clips. `null` until the URL is known.
+ */
+export function buildOnePagerFrame(
+	htmlUrl: string | undefined,
+	pages: number
+): ThumbnailFrame | null {
+	if ( ! htmlUrl ) {
+		return null;
+	}
+	const separator = htmlUrl.includes( '?' ) ? '&' : '?';
+	return {
+		src: `${ htmlUrl }${ separator }layout=filmstrip&pages=${ pages }`,
+		width: pages * PAGE_NATURAL_WIDTH + Math.max( 0, pages - 1 ) * FILMSTRIP_GAP,
+		height: PAGE_NATURAL_HEIGHT,
+	};
+}
+
+// Social tile markup is a body fragment (the detail view sets it via
+// `innerHTML`). Wrap it in a standalone document so it can be the iframe's
+// `srcDoc`, mirroring the capture path's shell: the brand pack's Inter family
+// plus a fixed-size, clipped body. No fit pipeline runs — the sandbox is
+// cross-origin, so a social tile renders unfitted and clips any overflow.
+const wrapSocialTile = ( innerHtml: string, width: number, height: number ): string =>
+	[
+		'<!doctype html>',
+		'<html lang="en">',
+		'<head>',
+		'<meta charset="utf-8">',
+		'<link rel="preconnect" href="https://fonts.googleapis.com">',
+		'<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>',
+		'<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap">',
+		'<style>',
+		'html,body{margin:0;padding:0;}',
+		`body{width:${ width }px;height:${ height }px;overflow:hidden;}`,
+		'</style>',
+		'</head>',
+		`<body>${ innerHtml }</body>`,
+		'</html>',
+	].join( '' );
+
+/**
+ * Social → a single representative tile frame (the landscape "cover" size,
+ * first direction). `null` when tiles haven't composed yet or carry no markup
+ * (the fallback/empty case), so the card keeps its placeholder.
+ */
+export function buildSocialFrame(
+	assets: AgentStudioSocialAsset[] | undefined
+): ThumbnailFrame | null {
+	if ( ! assets?.length ) {
+		return null;
+	}
+	const tile =
+		assets.find( ( asset ) => asset.sizeKey === SOCIAL_PREVIEW_SIZE_KEY && asset.html ) ??
+		assets.find( ( asset ) => asset.html );
+	if ( ! tile ) {
+		return null;
+	}
+	return {
+		srcDoc: wrapSocialTile( tile.html, tile.width, tile.height ),
+		width: tile.width,
+		height: tile.height,
+	};
+}

--- a/client/a8c-for-agencies/sections/agent-studio/data/use-deliverable-thumbnail.ts
+++ b/client/a8c-for-agencies/sections/agent-studio/data/use-deliverable-thumbnail.ts
@@ -1,0 +1,113 @@
+/**
+ * Resolves the thumbnail frame for an overview deliverable card. Reuses the
+ * detail page's data hooks and composer (no new endpoint surface):
+ *
+ * - One-pager → the linked collateral's first variant `html_url`, switched
+ *   into `layout=filmstrip` and loaded directly as a cross-origin `<iframe
+ *   src>` (the wpcom renderer lays the pages out and self-fits them).
+ * - Social → the run's brief composed client-side into tiles, of which the
+ *   representative landscape tile is shown.
+ *
+ * `useAgentStudioRun` is already fetched by `useDeliverableTitle` for the same
+ * output, so React Query dedupes it. The one-pager path adds only the
+ * collateral request (the HTML itself is loaded by the iframe, not fetched
+ * here); social composes client-side. Both only once the deliverable is
+ * `ready`. The social composition shares its query key with the detail view,
+ * so opening a deliverable reuses the warmed cache.
+ */
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import {
+	composeSocialAssetsFromBrief,
+	type ServerSocialBrief,
+} from '../social-design/create-social-assets';
+import {
+	buildOnePagerFrame,
+	buildSocialFrame,
+	type ThumbnailFrame,
+} from './build-thumbnail-frames';
+import useAgentStudioCollateral from './use-agent-studio-collateral';
+import useAgentStudioRun, { type AgentStudioRunPayload } from './use-agent-studio-run';
+import type { AgentStudioOutput } from '../types';
+
+const SOCIAL_DELIVERABLE_TYPE = 'social-assets';
+
+// Cover plus following pages, laid out as a filmstrip by the renderer; the row
+// clips so a longer document shows a partial trailing page.
+const FILMSTRIP_PAGES = 4;
+
+const extractPostId = ( payload: unknown ): number | undefined => {
+	if ( ! payload || typeof payload !== 'object' ) {
+		return undefined;
+	}
+	const candidate = ( payload as AgentStudioRunPayload ).post_id;
+	return typeof candidate === 'number' && candidate > 0 ? candidate : undefined;
+};
+
+interface SocialRunPayload extends AgentStudioRunPayload {
+	brief?: ServerSocialBrief;
+}
+
+const extractSocialBrief = ( payload: unknown ): ServerSocialBrief | undefined => {
+	if ( ! payload || typeof payload !== 'object' ) {
+		return undefined;
+	}
+	const brief = ( payload as SocialRunPayload ).brief;
+	if ( ! brief || typeof brief !== 'object' || typeof brief.headline !== 'string' ) {
+		return undefined;
+	}
+	return brief;
+};
+
+export interface DeliverableThumbnail {
+	frames: ThumbnailFrame[];
+	/** One-pager (horizontal page row) vs social (single centered tile). */
+	isFilmstrip: boolean;
+	isLoading: boolean;
+	isError: boolean;
+}
+
+export default function useDeliverableThumbnail( output: AgentStudioOutput ): DeliverableThumbnail {
+	const isOnePager = output.deliverableType !== SOCIAL_DELIVERABLE_TYPE;
+	const isReady = output.status === 'ready';
+	const wantsOnePager = isOnePager && isReady;
+	const wantsSocial = ! isOnePager && isReady;
+
+	const run = useAgentStudioRun( output.id );
+	const postId = extractPostId( run.data?.payload );
+	const brief = extractSocialBrief( run.data?.payload );
+
+	const collateral = useAgentStudioCollateral( wantsOnePager ? postId : undefined );
+	const htmlUrl = collateral.data?.variants?.[ 0 ]?.html_url;
+
+	const social = useQuery( {
+		queryKey: [ 'a4a-agent-studio-social-tiles', output.id, brief ],
+		queryFn: () => composeSocialAssetsFromBrief( { brief: brief as ServerSocialBrief } ),
+		enabled: wantsSocial && !! brief,
+		staleTime: Infinity,
+		refetchOnWindowFocus: false,
+	} );
+
+	const frame = useMemo( () => {
+		if ( wantsOnePager ) {
+			return buildOnePagerFrame( htmlUrl, FILMSTRIP_PAGES );
+		}
+		if ( wantsSocial ) {
+			return buildSocialFrame( social.data?.assets );
+		}
+		return null;
+	}, [ wantsOnePager, wantsSocial, htmlUrl, social.data ] );
+
+	const frames = frame ? [ frame ] : [];
+	const isError = collateral.isError || social.isError;
+	// Only show the loading state while the chain can still produce a frame.
+	// A ready run that never yields a `post_id` / brief settles to the
+	// placeholder rather than spinning forever.
+	const isResolving =
+		run.isLoading ||
+		( wantsOnePager && !! postId && collateral.isLoading ) ||
+		( wantsSocial && !! brief && social.isLoading );
+	const isLoading = frames.length === 0 && ! isError && isResolving;
+
+	return { frames, isFilmstrip: wantsOnePager, isLoading, isError };
+}

--- a/client/a8c-for-agencies/sections/agent-studio/primary/overview/deliverable-card.tsx
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/overview/deliverable-card.tsx
@@ -13,9 +13,11 @@ import { __ } from '@wordpress/i18n';
 import { Icon, moreVertical, page, trash, cautionFilled as warning } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useState } from 'react';
+import useDeliverableThumbnail from '../../data/use-deliverable-thumbnail';
 import useDeliverableTitle from '../../data/use-deliverable-title';
 import { getAgentStudioOutputPath } from '../../lib/paths';
 import DeleteDeliverableDialog from './delete-deliverable-dialog';
+import DeliverableThumbnailFrame from './deliverable-thumbnail-frame';
 import type { AgentStudioOutput } from '../../types';
 
 import './style.scss';
@@ -35,7 +37,7 @@ export default function DeliverableCard( { output }: Props ) {
 			className={ clsx( 'a4a-agent-studio-deliverable-card', { 'is-clickable': isReady } ) }
 		>
 			<CardMedia className="a4a-agent-studio-deliverable-card__media">
-				<DeliverablePreview output={ output } />
+				<DeliverablePreview output={ output } title={ title } />
 			</CardMedia>
 			<CardBody className="a4a-agent-studio-deliverable-card__body">
 				<HStack justify="space-between" alignment="flex-start" spacing={ 2 }>
@@ -81,7 +83,9 @@ export default function DeliverableCard( { output }: Props ) {
 	);
 }
 
-function DeliverablePreview( { output }: Props ) {
+function DeliverablePreview( { output, title }: Props & { title: string } ) {
+	const { frames, isFilmstrip, isLoading } = useDeliverableThumbnail( output );
+
 	if ( output.status === 'generating' ) {
 		return (
 			<div className="a4a-agent-studio-deliverable-card__state">
@@ -96,6 +100,28 @@ function DeliverablePreview( { output }: Props ) {
 			<div className="a4a-agent-studio-deliverable-card__state">
 				<Icon icon={ warning } size={ 24 } />
 				<Text>{ __( 'Generation failed' ) }</Text>
+			</div>
+		);
+	}
+
+	if ( frames.length > 0 ) {
+		return (
+			<div
+				className={ clsx( 'a4a-agent-studio-deliverable-card__frames', {
+					'is-filmstrip': isFilmstrip,
+				} ) }
+			>
+				{ frames.map( ( frame, index ) => (
+					<DeliverableThumbnailFrame key={ index } frame={ frame } title={ title } />
+				) ) }
+			</div>
+		);
+	}
+
+	if ( isLoading ) {
+		return (
+			<div className="a4a-agent-studio-deliverable-card__state">
+				<Spinner />
 			</div>
 		);
 	}

--- a/client/a8c-for-agencies/sections/agent-studio/primary/overview/deliverable-thumbnail-frame.tsx
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/overview/deliverable-thumbnail-frame.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useRef, useState } from 'react';
+import type { ThumbnailFrame } from '../../data/build-thumbnail-frames';
+
+interface Props {
+	frame: ThumbnailFrame;
+	title: string;
+}
+
+/**
+ * Renders one thumbnail frame in a sandboxed iframe scaled to its container.
+ *
+ * A frame is either a cross-origin `src` (the one-pager's signed filmstrip
+ * URL) or a same-origin `srcDoc` (the client-composed social tile). Either way
+ * `sandbox="allow-scripts"` WITHOUT `allow-same-origin` runs the document's
+ * scripts (the page's `fit.js`) in an opaque origin, so they can't reach the
+ * parent window or the session token. The iframe is laid out at its natural
+ * canvas size and shrunk with a CSS transform; the container clips the overflow.
+ */
+export default function DeliverableThumbnailFrame( { frame, title }: Props ) {
+	const wrapRef = useRef< HTMLDivElement >( null );
+	const [ scale, setScale ] = useState( 0 );
+
+	useEffect( () => {
+		const wrap = wrapRef.current;
+		if ( ! wrap ) {
+			return;
+		}
+		// Scale to the band height so each page shows in full; its natural
+		// width then determines how many fit before the row clips.
+		const update = () => {
+			const height = wrap.clientHeight;
+			if ( height > 0 ) {
+				setScale( height / frame.height );
+			}
+		};
+		update();
+		const observer = new ResizeObserver( update );
+		observer.observe( wrap );
+		return () => observer.disconnect();
+	}, [ frame.height ] );
+
+	return (
+		<div
+			ref={ wrapRef }
+			className="a4a-agent-studio-deliverable-card__frame"
+			role="img"
+			aria-label={ title }
+			style={ { aspectRatio: `${ frame.width } / ${ frame.height }` } }
+		>
+			<iframe
+				title={ title }
+				src={ frame.src }
+				srcDoc={ frame.srcDoc }
+				sandbox="allow-scripts"
+				scrolling="no"
+				tabIndex={ -1 }
+				style={ {
+					width: frame.width,
+					height: frame.height,
+					border: 0,
+					transform: `scale(${ scale })`,
+					transformOrigin: 'top left',
+				} }
+			/>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/agent-studio/primary/overview/style.scss
+++ b/client/a8c-for-agencies/sections/agent-studio/primary/overview/style.scss
@@ -53,9 +53,11 @@
 	display: flex;
 	align-items: center;
 	min-width: 0;
-	min-height: 160px;
+	min-height: 210px;
 	overflow: hidden;
-	background: var( --color-neutral-80 );
+	// No background of its own: the placeholder, state, and social band each
+	// paint their own, and a one-pager's pages sit on the card surface. A dark
+	// media background here would show through at the rounded top corners.
 }
 
 .a4a-agent-studio-deliverable-card__body.components-card__body {
@@ -85,7 +87,9 @@
 	gap: 8px;
 	align-items: center;
 	justify-content: center;
+	width: 100%;
 	min-height: 160px;
+	background: var( --color-neutral-80 );
 	color: var( --color-text-inverted );
 }
 
@@ -102,4 +106,65 @@
 .a4a-agent-studio-deliverable-card__placeholder svg,
 .a4a-agent-studio-deliverable-card__placeholder svg path {
 	fill: currentColor;
+}
+
+// Thumbnail area: each page is scaled to the band height (shown in full) and
+// packed left-to-right at its natural width. A single tile (social) stays
+// centered on a dark band; a multi-page one-pager (`is-filmstrip`) pulls the
+// cover half off the leading edge so ~4 pages span the area and the trailing
+// page is half-visible too. The one-pager has no background of its own — the
+// pages sit on the card surface, so the rounded card corners stay clean.
+.a4a-agent-studio-deliverable-card__frames {
+	box-sizing: border-box;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 6px;
+	width: 100%;
+	height: 210px;
+	overflow: hidden;
+}
+
+.a4a-agent-studio-deliverable-card__frames.is-filmstrip {
+	justify-content: flex-start;
+}
+
+.a4a-agent-studio-deliverable-card__frames.is-filmstrip
+	.a4a-agent-studio-deliverable-card__frame:first-child {
+	// Half of a page's scaled width (a 210px-tall page is ~162px wide), so the
+	// cover bleeds halfway off the leading edge.
+	margin-inline-start: -81px;
+}
+
+// A single social tile reads as a contained card floating on a dark band:
+// give it breathing room on all sides. The band's top corners are rounded to
+// the card's radius so it's clipped on its own clean curve (no dark fringe).
+.a4a-agent-studio-deliverable-card__frames:not( .is-filmstrip ) {
+	padding: 24px;
+	// Round the band's top corners (>= the card's radius) so its dark
+	// backdrop is clipped on a clean curve rather than leaving a fringe.
+	border-start-start-radius: 8px;
+	border-start-end-radius: 8px;
+	background: var( --color-neutral-100 );
+}
+
+.a4a-agent-studio-deliverable-card__frames:not( .is-filmstrip )
+	.a4a-agent-studio-deliverable-card__frame {
+	border-radius: 4px;
+}
+
+.a4a-agent-studio-deliverable-card__frame {
+	position: relative;
+	flex: 0 0 auto;
+	height: 100%;
+	overflow: hidden;
+}
+
+.a4a-agent-studio-deliverable-card__frame iframe {
+	position: absolute;
+	inset-block-start: 0;
+	inset-inline-start: 0;
+	// Opt out of the global `iframe { max-width: 100% }` reset so the page
+	// keeps its natural canvas width and the transform can scale it to fit.
+	max-width: none;
 }


### PR DESCRIPTION
Renders real previews on the Agent Studio overview cards.

**Depends on wpcom Automattic/wpcom#221717** (`&layout=filmstrip` on the `/html` route). The one-pager preview loads that endpoint directly, so this can't merge until #221717 deploys. To test the two together, apply both patches to a sandbox and point your dev Calypso at it.

## Proposed Changes

* Replace the generic placeholder icon on the overview cards with a real preview of each deliverable, rendered in an iframe scaled to the card.
* **One-pager**: load the deliverable's signed `/html` URL in `layout=filmstrip` mode as a single cross-origin `<iframe src>`. The wpcom renderer lays the pages out in a horizontal row and self-fits each; the card scales it to a dark band, peeks the cover off the leading edge, and clips the trailing page.
* **Social**: a single representative landscape tile, composed client-side from the run's brief (social has no server HTML), wrapped as a `srcDoc` and shown as a contained, rounded card.
* The iframe uses `sandbox="allow-scripts"` without `allow-same-origin`; the one-pager URL is also cross-origin, so the deliverable's scripts run isolated from the parent window and the session token.

## Why are these changes being made?

The overview grid shows every deliverable with the same placeholder page icon, so an agency can't tell one deliverable from another without opening each. #111317 deliberately deferred a real thumbnail; this is that follow-up.

An earlier iteration of this PR rendered the thumbnail by fetching the composed HTML, splitting it into per-page documents client-side, re-wrapping each in its own iframe, and injecting a script to re-run the fitter. That worked but was a lot of brittle client code. Since the `/html` URL is signed (so a cross-origin `<iframe src>` can load it directly) and the page's `fit.js` self-runs on load, moving the page-row layout into the renderer (wpcom#221717) lets the one-pager card collapse to a single `<iframe src>` with a CSS scale — no fetch, no `splitIntoPages`/`wrapAsDocument`, no fit bootstrap, no per-page iframes.

## Testing Instructions

Prerequisites: a sandbox with **both** this branch and wpcom#221717 applied, your dev A4A (`yarn start-a8c-for-agencies`) pointed at it, signed in, `a4a-agent-studio` enabled, and an agency with both one-pager and social deliverables in a `ready` state (plus ideally one generating and one failed).

1. Open `/resources-and-tools/agent-studio`.
2. Confirm each ready **one-pager** card shows a horizontal filmstrip of real pages on a dark band — cover half-visible on the leading edge, a couple of full pages, trailing page clipped — with fitted (non-overflowing) text.
3. Confirm each ready **social** card shows a single landscape tile as a centered, rounded card with padding.
4. Confirm **generating** cards show the spinner, **failed** cards the warning, and a ready card whose preview is still resolving shows a brief spinner.
5. Confirm the whole card is still clickable (opens the deliverable) and the three-dot actions menu (Delete) still works over the preview.
6. Inspect a one-pager preview iframe: its `src` should be the signed `/html` URL with `&layout=filmstrip&pages=4`, and there should be no console errors.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
