### PR TITLE
Checkout: update saved card submit label

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -355,7 +355,11 @@ function PortaledCheckoutFormSubmit( {
 		return null;
 	}
 	return createPortal(
-		<CheckoutFormSubmit validateForm={ validateForm } continueToNextIncompleteStep />,
+		<CheckoutFormSubmit
+			validateForm={ validateForm }
+			continueToNextIncompleteStep
+			changePaymentMethodStepId="payment-method-step"
+		/>,
 		slotEl
 	);
 }

--- a/client/my-sites/checkout/src/components/checkout-submit-button-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-submit-button-content.tsx
@@ -2,6 +2,7 @@ import { MaterialIcon } from '@automattic/components';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { styled } from '@automattic/wpcom-checkout';
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import useCartKey from '../../use-cart-key';
 
@@ -28,7 +29,7 @@ const StyledMaterialIcon = styled( MaterialIcon )`
  * There are also checkout-like forms (eg: "add credit card") which do not use
  * this because they want their submit button to render something different.
  */
-export function CheckoutSubmitButtonContent() {
+export function CheckoutSubmitButtonContent( { last4 }: { last4?: string } = {} ) {
 	const { __ } = useI18n();
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
@@ -50,7 +51,10 @@ export function CheckoutSubmitButtonContent() {
 	return (
 		<CreditCardPayButtonWrapper>
 			<StyledMaterialIcon icon="credit_card" />
-			{ __( 'Pay now' ) }
+			{ last4
+				? /* translators: %s is the last 4 digits of the saved card, e.g. "Pay with 3220" */
+				  sprintf( __( 'Pay with %s' ), last4 )
+				: __( 'Pay now' ) }
 		</CreditCardPayButtonWrapper>
 	);
 }

--- a/client/my-sites/checkout/src/components/checkout-submit-button-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-submit-button-content.tsx
@@ -30,7 +30,7 @@ const StyledMaterialIcon = styled( MaterialIcon )`
  * this because they want their submit button to render something different.
  */
 export function CheckoutSubmitButtonContent( { last4 }: { last4?: string } = {} ) {
-	const { __ } = useI18n();
+	const { __, _x } = useI18n();
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
 	const isPurchaseFree = responseCart.total_cost_integer === 0;
@@ -52,8 +52,12 @@ export function CheckoutSubmitButtonContent( { last4 }: { last4?: string } = {} 
 		<CreditCardPayButtonWrapper>
 			<StyledMaterialIcon icon="credit_card" />
 			{ last4
-				? /* translators: %s is the last 4 digits of the saved card, e.g. "Pay with 3220" */
-				  sprintf( __( 'Pay with %s' ), last4 )
+				? sprintf(
+						/* translators: %s is the masked saved card number, e.g. "**** 3220" */
+						__( 'Pay with %s' ),
+						/* translators: %s is the last 4 digits of the credit card number */
+						sprintf( _x( '**** %s', 'Masked credit card number' ), last4 )
+				  )
 				: __( 'Pay now' ) }
 		</CreditCardPayButtonWrapper>
 	);

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -710,13 +710,15 @@ const CheckoutSummaryPayButtonSlot = styled.div`
 	 * Each payment method provides its own button element, and a "Continue" button
 	 * renders here while steps are incomplete, so normalize every button in the slot
 	 * to a consistent full-width, 50px-tall look in the sidebar regardless of which
-	 * one is showing (Pay, Continue, PayPal, etc.).
+	 * one is showing (Pay, Continue, PayPal, etc.). The "Use a different payment
+	 * method" link is also a <button> but is a text link, so it is excluded from
+	 * the 50px submit-button sizing below.
 	 */
 	.checkout-submit-button {
 		width: 100%;
 	}
 
-	button {
+	button:not( .checkout-steps__change-payment-method-button ) {
 		width: 100%;
 		height: 50px;
 		box-sizing: border-box;

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -461,7 +461,7 @@ export default function useCreatePaymentMethods( {
 		isStripeLoading,
 		stripeLoadingError,
 		storedCards,
-		submitButtonContent: <CheckoutSubmitButtonContent />,
+		submitButtonContent: ( card ) => <CheckoutSubmitButtonContent last4={ card.card_last_4 } />,
 	} );
 
 	const existingPayPalPPCPMethods = useCreateExistingPayPalPPCP( {

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/use-create-existing-cards.ts
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/use-create-existing-cards.ts
@@ -18,7 +18,7 @@ export default function useCreateExistingCards( {
 	isStripeLoading: boolean;
 	stripeLoadingError: StripeLoadingError;
 	storedCards: StoredPaymentMethod[];
-	submitButtonContent: ReactNode;
+	submitButtonContent: ReactNode | ( ( card: StoredPaymentMethodCard ) => ReactNode );
 	allowEditingTaxInfo?: boolean;
 	isTaxInfoRequired?: boolean;
 } ): PaymentMethod[] {
@@ -53,7 +53,10 @@ export default function useCreateExistingCards( {
 					storedDetailsId: storedDetails.stored_details_id,
 					paymentMethodToken: storedDetails.mp_ref,
 					paymentPartnerProcessorId: storedDetails.payment_partner,
-					submitButtonContent,
+					submitButtonContent:
+						typeof submitButtonContent === 'function'
+							? submitButtonContent( storedDetails )
+							: submitButtonContent,
 					allowEditingTaxInfo,
 					isTaxInfoRequired,
 				} )

--- a/client/my-sites/checkout/src/test/existing-credit-card.tsx
+++ b/client/my-sites/checkout/src/test/existing-credit-card.tsx
@@ -219,7 +219,7 @@ describe( 'Existing credit card payment methods', () => {
 			></TestWrapper>
 		);
 		await waitFor( () => {
-			expect( screen.getByText( `Pay with ${ last4 }` ) ).toBeVisible();
+			expect( screen.getByText( `Pay with **** ${ last4 }` ) ).toBeVisible();
 		} );
 	} );
 } );

--- a/client/my-sites/checkout/src/test/existing-credit-card.tsx
+++ b/client/my-sites/checkout/src/test/existing-credit-card.tsx
@@ -9,14 +9,39 @@ import {
 	makeSuccessResponse,
 	CheckoutFormSubmit,
 } from '@automattic/composite-checkout';
+import { getEmptyResponseCart } from '@automattic/shopping-cart';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { useMemo } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
+import { CheckoutSubmitButtonContent } from 'calypso/my-sites/checkout/src/components/checkout-submit-button-content';
 import { createExistingCardMethod } from 'calypso/my-sites/checkout/src/payment-methods/existing-credit-card';
 import { createReduxStore } from 'calypso/state';
+
+const mockResponseCart = {
+	...getEmptyResponseCart(),
+	total_cost_integer: 15600,
+	sub_total_integer: 15600,
+	currency: 'USD',
+};
+
+jest.mock( 'calypso/my-sites/checkout/use-cart-key', () => ( {
+	__esModule: true,
+	default: () => 'no-site',
+} ) );
+
+jest.mock( '@automattic/shopping-cart', () => {
+	const actual = jest.requireActual( '@automattic/shopping-cart' );
+	return {
+		...actual,
+		useShoppingCart: () => ( {
+			...actual.emptyCart,
+			responseCart: mockResponseCart,
+		} ),
+	};
+} );
 
 function TestWrapper( { paymentMethods, paymentProcessors = undefined } ) {
 	const store = createReduxStore();
@@ -176,6 +201,25 @@ describe( 'Existing credit card payment methods', () => {
 		await userEvent.click( await screen.findByText( activePayButtonText ) );
 		await waitFor( () => {
 			expect( existingCardProcessor ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	it( 'renders "Pay with <last4>" on the submit button when CheckoutSubmitButtonContent is given a last4 prop', async () => {
+		mockTaxLocationEndpoint();
+		const last4 = '4242';
+		const existingCard = getExistingCardPaymentMethod( {
+			submitButtonContent: <CheckoutSubmitButtonContent last4={ last4 } />,
+		} );
+		render(
+			<TestWrapper
+				paymentMethods={ [ existingCard ] }
+				paymentProcessors={ {
+					[ existingCard.paymentProcessorId ]: () => makeSuccessResponse( 'ok' ),
+				} }
+			></TestWrapper>
+		);
+		await waitFor( () => {
+			expect( screen.getByText( `Pay with ${ last4 }` ) ).toBeVisible();
 		} );
 	} );
 } );

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -16,7 +16,7 @@ import {
 import { getDefaultPaymentMethodStep } from '../components/default-steps';
 import { useFormStatus } from '../lib/form-status';
 import joinClasses from '../lib/join-classes';
-import { usePaymentMethod } from '../lib/payment-methods';
+import { useAvailablePaymentMethodIds, usePaymentMethod } from '../lib/payment-methods';
 import { SubscriptionManager } from '../lib/subscription-manager';
 import { CheckoutStepGroupActions, FormStatus } from '../types';
 import Button from './button';
@@ -658,6 +658,23 @@ export const SubmitButtonWrapper = styled.div`
 	}
 `;
 
+const ChangePaymentMethodButton = styled.button`
+	display: block;
+	margin: 12px auto 0;
+	padding: 0;
+	border: none;
+	background: none;
+	color: ${ ( props ) => props.theme.colors.highlight };
+	font-size: 14px;
+	text-align: center;
+	text-decoration: underline;
+	cursor: pointer;
+
+	&:hover {
+		text-decoration: none;
+	}
+`;
+
 function CheckoutStepArea( {
 	children,
 	className,
@@ -685,6 +702,7 @@ export function CheckoutFormSubmit( {
 	submitButton,
 	onPageLoadError,
 	continueToNextIncompleteStep,
+	changePaymentMethodStepId,
 }: {
 	validateForm?: () => Promise< boolean >;
 	submitButtonHeader?: ReactNode;
@@ -693,6 +711,7 @@ export function CheckoutFormSubmit( {
 	submitButton?: ReactNode;
 	onPageLoadError?: CheckoutPageErrorCallback;
 	continueToNextIncompleteStep?: boolean;
+	changePaymentMethodStepId?: string;
 } ) {
 	const { __ } = useI18n();
 	const { state, actions } = useContext( CheckoutStepGroupContext );
@@ -806,6 +825,22 @@ export function CheckoutFormSubmit( {
 		isThereAnotherNumberedStep &&
 		!! nextIncompleteStepId;
 
+	const availablePaymentMethodIds = useAvailablePaymentMethodIds();
+	const showChangePaymentMethodLink =
+		!! changePaymentMethodStepId &&
+		! showContinueToNextIncompleteStep &&
+		availablePaymentMethodIds.length > 1;
+
+	const goToChangePaymentMethod = async () => {
+		if ( ! changePaymentMethodStepId ) {
+			return;
+		}
+		await makeStepActive( changePaymentMethodStepId );
+		document
+			.getElementById( changePaymentMethodStepId )
+			?.scrollIntoView?.( { behavior: 'smooth', block: 'start' } );
+	};
+
 	const goToNextIncompleteStep = async () => {
 		// Prefer the next incomplete step; otherwise just advance one step so the
 		// user always moves forward (covers the rare all-complete-but-not-last case).
@@ -852,6 +887,15 @@ export function CheckoutFormSubmit( {
 						onLoadError={ onSubmitButtonLoadError }
 					/>
 				)
+			) }
+			{ showChangePaymentMethodLink && (
+				<ChangePaymentMethodButton
+					type="button"
+					className="checkout-steps__change-payment-method-button"
+					onClick={ goToChangePaymentMethod }
+				>
+					{ __( 'Use a different payment method' ) }
+				</ChangePaymentMethodButton>
 			) }
 			<div className="checkout-steps__submit-footer-wrapper">{ submitButtonFooter || null }</div>
 		</SubmitButtonWrapper>

--- a/packages/composite-checkout/test/checkout.tsx
+++ b/packages/composite-checkout/test/checkout.tsx
@@ -991,6 +991,109 @@ describe( 'Checkout', () => {
 		} );
 	} );
 
+	describe( 'with changePaymentMethodStepId', function () {
+		const mockMethod = createMockMethod();
+		const mockMethod2 = createMockMethod( {
+			submitButton: <MockSubmitButton content="Pay Second Method" />,
+			activeContent: <div />,
+		} );
+		const steps = createMockStepObjects();
+
+		// steps[0] = 'custom-summary-step'   (no step number)
+		// steps[1] = 'custom-contact-step'   (numbered, isCompleteCallback () => true)
+		// steps[3] = 'custom-incomplete-step' (numbered, isCompleteCallback () => false)
+
+		function ChangePaymentCheckout( props ) {
+			const [ paymentData, setPaymentData ] = useState( {} );
+			const { stepObjectsWithStepNumber, stepObjectsWithoutStepNumber } =
+				createStepsFromStepObjects( props.steps || steps );
+			const createStepFromStepObject = createStepObjectConverter( paymentData );
+			return (
+				<myContext.Provider value={ [ paymentData, setPaymentData ] }>
+					<CheckoutProvider
+						paymentMethods={ props.paymentMethods || [ mockMethod, mockMethod2 ] }
+						paymentProcessors={ getMockPaymentProcessors() }
+						selectFirstAvailablePaymentMethod
+					>
+						<CheckoutStepGroup>
+							{ stepObjectsWithoutStepNumber.map( createStepFromStepObject ) }
+							{ stepObjectsWithStepNumber.map( createStepFromStepObject ) }
+							<CheckoutFormSubmit
+								continueToNextIncompleteStep
+								changePaymentMethodStepId={ props.changePaymentMethodStepId }
+							/>
+						</CheckoutStepGroup>
+					</CheckoutProvider>
+				</myContext.Provider>
+			);
+		}
+
+		const getSubmitArea = ( container ) =>
+			container.querySelector( '.checkout-steps__submit-button-wrapper' );
+
+		it( 'shows the "Use a different payment method" link when Pay button is shown and there is more than one payment method', () => {
+			const { container } = render(
+				<ChangePaymentCheckout
+					steps={ [ steps[ 0 ], steps[ 1 ] ] }
+					changePaymentMethodStepId="custom-contact-step"
+				/>
+			);
+			const submitArea = getSubmitArea( container );
+			expect(
+				queryByTextInNode( submitArea, 'Use a different payment method' )
+			).toBeInTheDocument();
+		} );
+
+		it( 'clicking the link scrolls to the target step', async () => {
+			const scrollIntoView = jest.fn();
+			window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+			const { container } = render(
+				<ChangePaymentCheckout
+					steps={ [ steps[ 0 ], steps[ 1 ] ] }
+					changePaymentMethodStepId="custom-contact-step"
+				/>
+			);
+			const submitArea = getSubmitArea( container );
+			const user = userEvent.setup();
+			await user.click( getByTextInNode( submitArea, 'Use a different payment method' ) );
+
+			await waitFor( () => {
+				expect( scrollIntoView ).toHaveBeenCalledWith( { behavior: 'smooth', block: 'start' } );
+			} );
+			expect( ( scrollIntoView.mock.instances[ 0 ] as HTMLElement ).id ).toBe(
+				'custom-contact-step'
+			);
+		} );
+
+		it( 'hides the link when there is only one available payment method', () => {
+			const { container } = render(
+				<ChangePaymentCheckout
+					steps={ [ steps[ 0 ], steps[ 1 ] ] }
+					changePaymentMethodStepId="custom-contact-step"
+					paymentMethods={ [ mockMethod ] }
+				/>
+			);
+			const submitArea = getSubmitArea( container );
+			expect(
+				queryByTextInNode( submitArea, 'Use a different payment method' )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'hides the link while a step is incomplete (Continue button is showing)', () => {
+			const { container } = render(
+				<ChangePaymentCheckout
+					steps={ [ steps[ 0 ], steps[ 1 ], steps[ 3 ] ] }
+					changePaymentMethodStepId="custom-contact-step"
+				/>
+			);
+			const submitArea = getSubmitArea( container );
+			expect( getByTextInNode( submitArea, 'Continue' ) ).toBeInTheDocument();
+			expect(
+				queryByTextInNode( submitArea, 'Use a different payment method' )
+			).not.toBeInTheDocument();
+		} );
+	} );
+
 	describe( 'submitting the form', function () {
 		let MyCheckout;
 		const submitButtonComponent = <MockSubmitButtonSimple />;


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/SHILL-2104/

## Proposed Changes

Checkout now has a persistent "Pay Now" submit button in the sidebar, which when active, represents the current selected payment method. When the button represents a stored card, this PR updates the label to say "Pay with **** 1234" to help clarify which payment method is being used. It also adds a link to "Use a different payment method" under the button that links to the payment method step.

<img width="3516" height="2356" alt="CleanShot 2026-06-04 at 15 29 07@2x" src="https://github.com/user-attachments/assets/a939e07e-25f7-457e-97da-ccdce667f783" />

**1. Saved-card pay button label**
* Add an optional `last4` prop to `CheckoutSubmitButtonContent`. In the ready-to-pay state, when a last 4 is provided the button reads **"Pay with **** 3220"** (masked, reusing the existing `_x( '**** %s', 'Masked credit card number' )` translation) with the card icon, instead of the generic "Pay now". Other states (Processing…, Please wait…, free → "Complete Checkout") are unchanged; omitting `last4` is byte-identical to today.
* Wire the **checkout** `useCreateExistingCards` to supply per-card content via a render-prop, so each saved card's button shows its own last 4.

**2. "Use a different payment method" link**
* Add an optional `changePaymentMethodStepId` prop to `CheckoutFormSubmit` (`@automattic/composite-checkout`). When set, it renders a centered "Use a different payment method" link below the submit button that expands and smooth-scrolls to the Payment Method step (reusing the existing `makeStepActive` + `scrollIntoView` pattern).
* The link shows only when (a) the real Pay button is shown (not the "Continue" state) and (b) there is more than one available payment method (`useAvailablePaymentMethodIds().length > 1`).

## Why are these changes being made?

When a shopper has saved cards, a generic "Pay now" doesn't say which card will be charged; "Pay with **** 3220" makes the active card explicit — especially with the pay button pinned in the sidebar and multiple cards on file. The "Use a different payment method" link gives a one-tap way to jump back to the Payment Method step to switch methods, without scrolling to find it.

## Testing Instructions

* `yarn test-client client/my-sites/checkout/src/test/existing-credit-card.tsx` — includes a test asserting the masked "Pay with **** <last 4>" label; existing tests confirm the static-content path is unchanged.
* `yarn test-packages packages/composite-checkout/test/checkout.tsx -t "changePaymentMethodStepId"` — 4 tests: link shows with the Pay button + >1 method; click scrolls to the target step; hidden with a single method; hidden while the Continue button shows.
* Manual (desktop): in checkout with a saved card selected and more than one payment method available, confirm the sidebar button reads "Pay with **** <last 4>" and a "Use a different payment method" link appears below it that scrolls to and expands the Payment Method step. Confirm the link is absent when only one method is available, and that a free cart still shows "Complete Checkout".

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)