### PR TITLE
Reader: show all organization sites in the sidebar

### DIFF
--- a/client/reader/AGENTS.md
+++ b/client/reader/AGENTS.md
@@ -36,6 +36,14 @@ The Reader is migrating from **Redux + data-layer** to **React Query** using the
 - **Legacy (Redux + data-layer)**: still present in most streams and core features.
 - **Current (React Query)**: used in newer features like `discover/`, `new-subscription/`, and subscription management. New features should use `@automattic/api-core` for API definitions and `@automattic/api-queries` for React Query hooks.
 
+**Always reach for the idiomatic React Query solution first.** Before hand-rolling effects, manual refetch chains, or imperative cache writes, check what TanStack Query already provides and prefer it:
+
+- Pagination → `useInfiniteQuery` with a correct `getNextPageParam`. Derive the stop condition from the API's real contract (page caps, server-side filtering, `total` counts), not from assumed page sizes. A bug where the org sidebar showed only the first page came from stopping pagination on a short page; see [`packages/api-queries/src/read-follows.ts`](../../packages/api-queries/src/read-follows.ts).
+- Refetch/sync → `staleTime`/`gcTime`, `invalidateQueries`, or `refetch` — not `useEffect` loops driving `fetchNextPage`.
+- Cross-feature refreshes → invalidate the canonical query key on the active `QueryClient` (see the mutation-factory rule below).
+- Loading/error/empty UI → the query's own `isPending`/`isError`/`data` state, not bespoke flags.
+- When unsure, consult the `tanstack-query-best-practices` skill and the official TanStack Query docs before introducing a custom workaround. Document any deliberate deviation from the idiomatic pattern with a comment explaining why.
+
 Site subscriptions are fully on React Query:
 
 - Endpoint contracts and adapters live in `packages/api-core/src/read-follows/`.

--- a/client/reader/AGENTS.md
+++ b/client/reader/AGENTS.md
@@ -42,7 +42,7 @@ The Reader is migrating from **Redux + data-layer** to **React Query** using the
 - Refetch/sync → `staleTime`/`gcTime`, `invalidateQueries`, or `refetch` — not `useEffect` loops driving `fetchNextPage`.
 - Cross-feature refreshes → invalidate the canonical query key on the active `QueryClient` (see the mutation-factory rule below).
 - Loading/error/empty UI → the query's own `isPending`/`isError`/`data` state, not bespoke flags.
-- When unsure, consult the `tanstack-query-best-practices` skill and the official TanStack Query docs before introducing a custom workaround. Document any deliberate deviation from the idiomatic pattern with a comment explaining why.
+- When unsure, consult the official TanStack Query docs before introducing a custom workaround. Document any deliberate deviation from the idiomatic pattern with a comment explaining why.
 
 Site subscriptions are fully on React Query:
 

--- a/client/reader/AGENTS.md
+++ b/client/reader/AGENTS.md
@@ -13,6 +13,13 @@ yarn test-client client/reader/<path>        # Run Reader tests
 yarn test-client:watch client/reader/<path>  # Run Reader tests in watch mode
 ```
 
+## Linear issues
+
+File Reader issues under the **Reader** Linear team (key `READ`, e.g. `READ-532`) — not the generic `LIN` team. When creating an issue with the Linear MCP tools, pass `team: "Reader"`.
+
+- The Reader team's issue identifiers use the `READ-` prefix. Reference them in PRs as `READ-123` (per the repo-wide rule to use Linear IDs, not full URLs), and link the work with `Closes READ-123` so the issue auto-closes on merge.
+- For a bug, set `labels: ["Bug"]` and an appropriate `priority` (1=Urgent … 4=Low).
+
 ## Architecture decisions
 
 ### Dark mode

--- a/packages/api-queries/src/__tests__/read-follows.test.tsx
+++ b/packages/api-queries/src/__tests__/read-follows.test.tsx
@@ -107,10 +107,12 @@ describe( 'siteSubscriptionsQuery', () => {
 		} );
 	} );
 
-	it( 'keeps paginating after a short page until an empty page is returned', async () => {
-		// The endpoint caps each page at 100 and filters deleted/spammy sites,
-		// so pages come back shorter than requested even when more remain. A
-		// short page must not be mistaken for the last page.
+	it( 'paginates by the server total, past short and empty pages, until all rows are covered', async () => {
+		// The server walks raw rows by offset and filters deleted/spammy sites
+		// *after* applying the page limit, so a page can be short or even empty
+		// while later offset windows still hold valid rows. With a reported total
+		// of 250 and a page size of 100, three pages cover every row — even
+		// though the middle page comes back empty.
 		const makeSubscription = ( id: number ) => ( {
 			ID: String( id ),
 			URL: `https://example-${ id }.com/feed/`,
@@ -123,27 +125,29 @@ describe( 'siteSubscriptionsQuery', () => {
 			.query( { page: '1', number: '100', meta: '' } )
 			.reply( 200, {
 				subscriptions: [ makeSubscription( 1 ), makeSubscription( 2 ) ],
-				total_subscriptions: 150,
+				total_subscriptions: 250,
 				page: 1,
 				number: 2,
 			} );
+		// Middle page: every raw row in this window was filtered out, so it comes
+		// back empty — but there are still rows beyond it.
 		nock( BASE )
 			.get( '/rest/v1.2/read/following/mine' )
 			.query( { page: '2', number: '100', meta: '' } )
 			.reply( 200, {
-				subscriptions: [ makeSubscription( 3 ) ],
-				total_subscriptions: 150,
+				subscriptions: [],
+				total_subscriptions: 250,
 				page: 2,
-				number: 1,
+				number: 0,
 			} );
 		nock( BASE )
 			.get( '/rest/v1.2/read/following/mine' )
 			.query( { page: '3', number: '100', meta: '' } )
 			.reply( 200, {
-				subscriptions: [],
-				total_subscriptions: 150,
+				subscriptions: [ makeSubscription( 3 ) ],
+				total_subscriptions: 250,
 				page: 3,
-				number: 0,
+				number: 1,
 			} );
 
 		const client = newClient();
@@ -151,24 +155,24 @@ describe( 'siteSubscriptionsQuery', () => {
 			wrapper: makeWrapper( client ),
 		} );
 
-		// Page 1 is fetched automatically. There are more pages, so a short
-		// (non-empty) first page must not end pagination.
+		// Page 1 (auto-fetched) only covers 100 of 250 rows, so more remain.
 		await waitFor( () => expect( result.current.data?.pages ).toHaveLength( 1 ) );
 		expect( result.current.hasNextPage ).toBe( true );
 
-		// Fetch page 2 — still short, still not the last page.
+		// Page 2 comes back empty, but 200 < 250 rows covered — keep going.
 		await act( async () => {
 			await result.current.fetchNextPage();
 		} );
 		await waitFor( () => expect( result.current.data?.pages ).toHaveLength( 2 ) );
 		expect( result.current.hasNextPage ).toBe( true );
 
-		// Fetch page 3 — empty, so pagination stops here.
+		// Page 3 covers rows up to 300 >= 250, so pagination stops here.
 		await act( async () => {
 			await result.current.fetchNextPage();
 		} );
 		await waitFor( () => expect( result.current.hasNextPage ).toBe( false ) );
 
+		// The site beyond the empty middle page is still collected.
 		expect( getSiteSubscriptionsFromData( result.current.data ).map( ( sub ) => sub.ID ) ).toEqual(
 			[ 1, 2, 3 ]
 		);

--- a/packages/api-queries/src/__tests__/read-follows.test.tsx
+++ b/packages/api-queries/src/__tests__/read-follows.test.tsx
@@ -151,13 +151,23 @@ describe( 'siteSubscriptionsQuery', () => {
 			wrapper: makeWrapper( client ),
 		} );
 
-		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+		// Page 1 is fetched automatically. There are more pages, so a short
+		// (non-empty) first page must not end pagination.
+		await waitFor( () => expect( result.current.data?.pages ).toHaveLength( 1 ) );
+		expect( result.current.hasNextPage ).toBe( true );
 
+		// Fetch page 2 — still short, still not the last page.
 		await act( async () => {
-			while ( result.current.hasNextPage ) {
-				await result.current.fetchNextPage();
-			}
+			await result.current.fetchNextPage();
 		} );
+		await waitFor( () => expect( result.current.data?.pages ).toHaveLength( 2 ) );
+		expect( result.current.hasNextPage ).toBe( true );
+
+		// Fetch page 3 — empty, so pagination stops here.
+		await act( async () => {
+			await result.current.fetchNextPage();
+		} );
+		await waitFor( () => expect( result.current.hasNextPage ).toBe( false ) );
 
 		expect( getSiteSubscriptionsFromData( result.current.data ).map( ( sub ) => sub.ID ) ).toEqual(
 			[ 1, 2, 3 ]

--- a/packages/api-queries/src/__tests__/read-follows.test.tsx
+++ b/packages/api-queries/src/__tests__/read-follows.test.tsx
@@ -72,7 +72,7 @@ describe( 'siteSubscriptionsQuery', () => {
 	it( 'fetches follows with the canonical key and legacy paging args', async () => {
 		const scope = nock( BASE )
 			.get( '/rest/v1.2/read/following/mine' )
-			.query( { page: '1', number: '200', meta: '' } )
+			.query( { page: '1', number: '100', meta: '' } )
 			.reply( 200, {
 				subscriptions: [
 					{
@@ -84,7 +84,7 @@ describe( 'siteSubscriptionsQuery', () => {
 				],
 				total_subscriptions: 1,
 				page: 1,
-				number: 200,
+				number: 1,
 			} );
 
 		const client = newClient();
@@ -105,6 +105,63 @@ describe( 'siteSubscriptionsQuery', () => {
 			feed_ID: 789,
 			is_following: true,
 		} );
+	} );
+
+	it( 'keeps paginating after a short page until an empty page is returned', async () => {
+		// The endpoint caps each page at 100 and filters deleted/spammy sites,
+		// so pages come back shorter than requested even when more remain. A
+		// short page must not be mistaken for the last page.
+		const makeSubscription = ( id: number ) => ( {
+			ID: String( id ),
+			URL: `https://example-${ id }.com/feed/`,
+			blog_ID: String( id ),
+			feed_ID: String( id ),
+		} );
+
+		nock( BASE )
+			.get( '/rest/v1.2/read/following/mine' )
+			.query( { page: '1', number: '100', meta: '' } )
+			.reply( 200, {
+				subscriptions: [ makeSubscription( 1 ), makeSubscription( 2 ) ],
+				total_subscriptions: 150,
+				page: 1,
+				number: 2,
+			} );
+		nock( BASE )
+			.get( '/rest/v1.2/read/following/mine' )
+			.query( { page: '2', number: '100', meta: '' } )
+			.reply( 200, {
+				subscriptions: [ makeSubscription( 3 ) ],
+				total_subscriptions: 150,
+				page: 2,
+				number: 1,
+			} );
+		nock( BASE )
+			.get( '/rest/v1.2/read/following/mine' )
+			.query( { page: '3', number: '100', meta: '' } )
+			.reply( 200, {
+				subscriptions: [],
+				total_subscriptions: 150,
+				page: 3,
+				number: 0,
+			} );
+
+		const client = newClient();
+		const { result } = renderHook( () => useInfiniteQuery( siteSubscriptionsQuery() ), {
+			wrapper: makeWrapper( client ),
+		} );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		await act( async () => {
+			while ( result.current.hasNextPage ) {
+				await result.current.fetchNextPage();
+			}
+		} );
+
+		expect( getSiteSubscriptionsFromData( result.current.data ).map( ( sub ) => sub.ID ) ).toEqual(
+			[ 1, 2, 3 ]
+		);
 	} );
 } );
 

--- a/packages/api-queries/src/read-follows.ts
+++ b/packages/api-queries/src/read-follows.ts
@@ -22,9 +22,10 @@ import {
 	type QueryClient,
 } from '@tanstack/react-query';
 
-// The /read/following/mine endpoint caps the page size at 100 server-side
-// (PER_PAGE_MAX), so requesting more never returns more. Keep the request size
-// aligned with that cap so pagination advances one server page at a time.
+// The /read/following/mine endpoint paginates by walking raw subscription rows
+// with offset = (page - 1) * limit, and caps `limit` at 100 server-side
+// (PER_PAGE_MAX). Keep the request size aligned with that cap so each page maps
+// to exactly one server-side offset window.
 const ITEMS_PER_PAGE = 100;
 const MAX_ITEMS = 2000;
 const STALE_TIME = 60 * 60 * 1000;
@@ -47,27 +48,27 @@ export const siteSubscriptionsQuery = () =>
 			fetchReadFollows( { page: pageParam, number: ITEMS_PER_PAGE, meta: '' } ),
 		initialPageParam: 1,
 		getNextPageParam: ( lastPage, allPages ) => {
-			const fetchedItems = allPages.reduce(
-				( count, page ) => count + page.subscriptions.length,
-				0
-			);
-			const totalCount = allPages.find( ( page ) => typeof page.totalCount === 'number' )
-				?.totalCount;
-
 			if ( allPages.length >= MAX_PAGES_TO_FETCH ) {
 				return undefined;
 			}
-			// The server filters out deleted/spammy sites after applying the page
-			// limit, so a short (but non-empty) page does not mean we reached the
-			// end. Only an empty page signals there is nothing left to fetch.
-			if ( lastPage.subscriptions.length === 0 ) {
-				return undefined;
-			}
-			if ( typeof totalCount === 'number' && fetchedItems >= Math.min( totalCount, MAX_ITEMS ) ) {
-				return undefined;
+
+			// `total_subscriptions` is the server's raw row count (it does not
+			// discount deleted/spammy sites). The server filters those out *after*
+			// applying the page limit, so a page can come back short — or even
+			// empty — while later offset windows still hold valid rows. We must
+			// therefore decide whether another page exists from the offset we have
+			// covered, not from how many items the last page happened to return.
+			const totalCount = allPages.find( ( page ) => typeof page.totalCount === 'number' )
+				?.totalCount;
+
+			if ( typeof totalCount === 'number' ) {
+				const requestedRows = allPages.length * ITEMS_PER_PAGE;
+				return requestedRows >= Math.min( totalCount, MAX_ITEMS ) ? undefined : allPages.length + 1;
 			}
 
-			return allPages.length + 1;
+			// Without a total to compare against, fall back to stopping on an
+			// empty page.
+			return lastPage.subscriptions.length === 0 ? undefined : allPages.length + 1;
 		},
 		staleTime: STALE_TIME,
 		meta: { persist: true },

--- a/packages/api-queries/src/read-follows.ts
+++ b/packages/api-queries/src/read-follows.ts
@@ -22,7 +22,10 @@ import {
 	type QueryClient,
 } from '@tanstack/react-query';
 
-const ITEMS_PER_PAGE = 200;
+// The /read/following/mine endpoint caps the page size at 100 server-side
+// (PER_PAGE_MAX), so requesting more never returns more. Keep the request size
+// aligned with that cap so pagination advances one server page at a time.
+const ITEMS_PER_PAGE = 100;
 const MAX_ITEMS = 2000;
 const STALE_TIME = 60 * 60 * 1000;
 const MAX_PAGES_TO_FETCH = MAX_ITEMS / ITEMS_PER_PAGE;
@@ -54,7 +57,10 @@ export const siteSubscriptionsQuery = () =>
 			if ( allPages.length >= MAX_PAGES_TO_FETCH ) {
 				return undefined;
 			}
-			if ( lastPage.subscriptions.length < ITEMS_PER_PAGE ) {
+			// The server filters out deleted/spammy sites after applying the page
+			// limit, so a short (but non-empty) page does not mean we reached the
+			// end. Only an empty page signals there is nothing left to fetch.
+			if ( lastPage.subscriptions.length === 0 ) {
 				return undefined;
 			}
 			if ( typeof totalCount === 'number' && fetchedItems >= Math.min( totalCount, MAX_ITEMS ) ) {

--- a/packages/api-queries/src/read-follows.ts
+++ b/packages/api-queries/src/read-follows.ts
@@ -25,7 +25,10 @@ import {
 // The /read/following/mine endpoint paginates by walking raw subscription rows
 // with offset = (page - 1) * limit, and caps `limit` at 100 server-side
 // (PER_PAGE_MAX). Keep the request size aligned with that cap so each page maps
-// to exactly one server-side offset window.
+// to exactly one server-side offset window. Consumers that supply their own
+// queryFn (e.g. the data-stores subscription manager) must request this same
+// page size, or the next-page detection below (which reasons about covered
+// offset) will paginate incorrectly.
 const ITEMS_PER_PAGE = 100;
 const MAX_ITEMS = 2000;
 const STALE_TIME = 60 * 60 * 1000;

--- a/packages/data-stores/src/reader/queries/test/use-site-subscriptions-query.tsx
+++ b/packages/data-stores/src/reader/queries/test/use-site-subscriptions-query.tsx
@@ -113,10 +113,11 @@ describe( 'useSiteSubscriptionsQuery hook', () => {
 	} );
 
 	it( 'fetches additional pages through the subkey-aware API path', async () => {
-		const firstPage = Array.from( { length: 200 }, ( _value, index ) =>
+		// The server caps each page at 100 rows, so a full page is 100 items.
+		const firstPage = Array.from( { length: 100 }, ( _value, index ) =>
 			makeApiSubscription( index + 1 )
 		);
-		const secondPage = [ makeApiSubscription( 201 ) ];
+		const secondPage = [ makeApiSubscription( 101 ) ];
 
 		( callApi as jest.Mock ).mockImplementation( ( { path, isLoggedIn } ) => {
 			expect( isLoggedIn ).toBe( false );
@@ -124,18 +125,18 @@ describe( 'useSiteSubscriptionsQuery hook', () => {
 			if ( path.includes( 'page=1' ) ) {
 				return Promise.resolve( {
 					subscriptions: firstPage,
-					total_subscriptions: 201,
+					total_subscriptions: 101,
 					page: 1,
-					number: 200,
+					number: 100,
 				} );
 			}
 
 			if ( path.includes( 'page=2' ) ) {
 				return Promise.resolve( {
 					subscriptions: secondPage,
-					total_subscriptions: 201,
+					total_subscriptions: 101,
 					page: 2,
-					number: 200,
+					number: 1,
 				} );
 			}
 
@@ -147,7 +148,7 @@ describe( 'useSiteSubscriptionsQuery hook', () => {
 		} );
 
 		await waitFor( () => expect( callApi ).toHaveBeenCalledTimes( 2 ) );
-		await waitFor( () => expect( result.current.data.subscriptions ).toHaveLength( 201 ) );
+		await waitFor( () => expect( result.current.data.subscriptions ).toHaveLength( 101 ) );
 		expect( ( callApi as jest.Mock ).mock.calls[ 0 ][ 0 ] ).toMatchObject( {
 			apiVersion: '1.2',
 			isLoggedIn: false,

--- a/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
@@ -14,6 +14,13 @@ import type { SiteSubscriptionItem } from '../types';
 
 export const siteSubscriptionsQueryKeyPrefix = [ ...getSiteSubscriptionsQueryKey() ];
 
+// Must match the page size the shared `siteSubscriptionsQuery` (in
+// `@automattic/api-queries`) assumes for next-page detection. That query reasons
+// about how much offset it has covered, so requesting a different page size here
+// would make pagination stop early or over-fetch. The value mirrors the server
+// cap (`PER_PAGE_MAX = 100`) on `/read/following/mine`.
+const SITE_SUBSCRIPTIONS_PAGE_SIZE = 100;
+
 const sortByDateSubscribed = ( a: SiteSubscriptionItem, b: SiteSubscriptionItem ) =>
 	a.date_subscribed instanceof Date && b.date_subscribed instanceof Date
 		? b.date_subscribed.getTime() - a.date_subscribed.getTime()
@@ -51,7 +58,7 @@ const useSiteSubscriptionsQuery = () => {
 			const response = await callApi< SiteSubscriptionsApiResponse >( {
 				path: addQueryArgs( '/read/following/mine', {
 					page: pageParam,
-					number: 200,
+					number: SITE_SUBSCRIPTIONS_PAGE_SIZE,
 					meta: '',
 				} ),
 				apiVersion: '1.2',


### PR DESCRIPTION
Closes READ-532

| Before | After |
|--------|--------|
| <img width="524" height="400" alt="CleanShot 2026-06-05 at 11 10 48@2x" src="https://github.com/user-attachments/assets/392b4742-f78b-47e3-ad23-7f33ca63c7f1" /> | <img width="480" height="1560" alt="CleanShot 2026-06-05 at 11 11 15@2x" src="https://github.com/user-attachments/assets/8a3e44c4-31dd-41d0-8520-66c07be6699f" /> | 

## Proposed Changes

* `packages/api-queries/src/read-follows.ts`: fix how the site-subscriptions infinite query detects whether another page exists, and align the requested page size with the server cap (`ITEMS_PER_PAGE` 200 → 100).
* Add a regression test covering pagination continuing past short and empty pages until the server's reported total is covered.
* `client/reader/AGENTS.md`: document filing Reader issues under the `READ` Linear team and preferring idiomatic React Query solutions.

## Why are these changes being made?

The Reader sidebar organization sections (e.g. the Automattic org list) were showing fewer sites than they should — clicking "All" within an org revealed more sites than the sidebar listed.

The root cause was **how we detected whether another page existed**. After migrating the Reader follows layer to React Query, `getNextPageParam` decided there were no more pages by looking at the last page's contents:

```js
// stop paginating once a page is "not full"
if ( lastPage.subscriptions.length < ITEMS_PER_PAGE ) {
	return undefined;
}
```

That signal is wrong for `/read/following/mine`, because of how the endpoint paginates:

* It walks raw subscription rows by `offset = (page - 1) * limit` and caps `limit` at 100 (`PER_PAGE_MAX`), so requesting `number=200` never returns 200 items.
* It filters out deleted/spammy sites **after** applying the page limit, so a page can come back short — or even completely empty — while later offset windows still hold valid rows. The response `number` field is the post-filter count, not the page size.
* `total_subscriptions` is the server's raw row count and does **not** discount the filtered sites.

So "the page is shorter than requested → it must be the last page" fired on the very first page, and pagination stopped immediately. Only the first page of follows ever loaded, and any sidebar surface that filters the cached follows by `organization_id` only saw that subset. Org sites with older `date_subscribed` live deeper in the list and never loaded.

Note that simply stopping on an *empty* page would not be correct either: because filtering happens per offset window, an intermediate window can be entirely filtered (0 items) while later windows still have valid rows. The legacy Redux sync had exactly this blind spot — it paginated while `number > 0` (post-filter count), so a fully-filtered window would have stopped it too.

The fix decides "is there a next page?" from the offset we have covered versus the server's reported total, not from the last page's contents: keep paginating while `pagesFetched * pageSize < total_subscriptions`. The page size is lowered to 100 to match the server cap so each page maps to exactly one offset window. This is robust to short and empty intermediate pages alike.

```js
const totalCount = allPages.find( ( page ) => typeof page.totalCount === 'number' )?.totalCount;

if ( typeof totalCount === 'number' ) {
	const requestedRows = allPages.length * ITEMS_PER_PAGE;
	return requestedRows >= Math.min( totalCount, MAX_ITEMS ) ? undefined : allPages.length + 1;
}

// Fallback when the server gives no total: stop on an empty page.
return lastPage.subscriptions.length === 0 ? undefined : allPages.length + 1;
```

## Testing Instructions

### Scenario 1 - Organization sidebar lists every followed org site:
- Sign in with an account that follows more than ~100 sites, including several sites that belong to an organization (e.g. Automattic).
- Go to `/reader`.
- Expand the organization section in the sidebar.
- Check that it lists the same sites shown when clicking "All" within that organization — no sites are missing.

### Scenario 2 - Large follow lists fully populate:
- With the same account, go to `/reader/subscriptions`.
- Check that the full set of subscriptions loads (not just the first ~100), and that org sites with older subscription dates appear.

A regression test was added covering pagination continuing past short and empty pages until the server total is covered.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)