### PR TITLE
Add: AI surface coexistence (Help Center + Agents Manager)

### DIFF
--- a/apps/agents-manager/agents-manager-with-provider.jsx
+++ b/apps/agents-manager/agents-manager-with-provider.jsx
@@ -1,20 +1,33 @@
 /* global agentsManagerData */
 import './config';
-import AgentsManager from '@automattic/agents-manager';
+import AgentsManager, { useShouldCoexistAiSurfaces } from '@automattic/agents-manager';
+import { AiSurfaceCoordinator } from '@automattic/data-stores';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 const queryClient = new QueryClient();
 
+/**
+ * Inner component rendered inside QueryClientProvider so that
+ * useShouldCoexistAiSurfaces (which calls useQuery) has the required context.
+ */
+function AgentsManagerInner( { useImageUpload } ) {
+	AiSurfaceCoordinator.useAiSurfaceCoordinator( useShouldCoexistAiSurfaces() );
+
+	return (
+		<AgentsManager
+			sectionName={ agentsManagerData.sectionName || 'wp-admin' }
+			currentUser={ agentsManagerData.currentUser }
+			site={ agentsManagerData.site }
+			currentSiteId={ agentsManagerData.site?.ID }
+			useImageUpload={ useImageUpload }
+		/>
+	);
+}
+
 export default function AgentsManagerWithProvider( { useImageUpload } ) {
 	return (
 		<QueryClientProvider client={ queryClient }>
-			<AgentsManager
-				sectionName={ agentsManagerData.sectionName || 'wp-admin' }
-				currentUser={ agentsManagerData.currentUser }
-				site={ agentsManagerData.site }
-				currentSiteId={ agentsManagerData.site?.ID }
-				useImageUpload={ useImageUpload }
-			/>
+			<AgentsManagerInner useImageUpload={ useImageUpload } />
 		</QueryClientProvider>
 	);
 }

--- a/apps/agents-manager/package.json
+++ b/apps/agents-manager/package.json
@@ -33,6 +33,7 @@
 		"@automattic/agents-manager": "workspace:^",
 		"@automattic/block-notes": "workspace:^",
 		"@automattic/calypso-analytics": "workspace:^",
+		"@automattic/data-stores": "workspace:^",
 		"@automattic/image-studio": "workspace:^",
 		"@automattic/jetpack-ai-sidebar": "workspace:^",
 		"@tanstack/react-query": "^5.83.0",

--- a/client/dashboard/app/interim-omnibar/omnibar-agents-manager.tsx
+++ b/client/dashboard/app/interim-omnibar/omnibar-agents-manager.tsx
@@ -1,4 +1,4 @@
-import { useShouldUseUnifiedAgent } from '@automattic/agents-manager';
+import { useShouldUseUnifiedAgent, useShouldCoexistAiSurfaces } from '@automattic/agents-manager';
 import { omnibarSiteIdQuery, siteByIdQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { useRouterState } from '@tanstack/react-router';
@@ -25,6 +25,7 @@ const AsyncAgentsManager = lazy(
  */
 export default function OmnibarAgentsManager() {
 	const shouldUseUnifiedAgent = useShouldUseUnifiedAgent();
+	const shouldCoexist = useShouldCoexistAiSurfaces();
 	const { user } = useAuth();
 	const { data: omnibarSiteId } = useQuery( omnibarSiteIdQuery() );
 	const { data: site } = useQuery( {
@@ -36,7 +37,9 @@ export default function OmnibarAgentsManager() {
 			state.matches.some( ( match ) => !! ( match.params as { siteSlug?: string } )?.siteSlug ),
 	} );
 
-	if ( ! shouldUseUnifiedAgent ) {
+	// Render Agents Manager when the user is on the unified experience, or when
+	// AI surface coexistence is on (both surfaces load and coordinate at runtime).
+	if ( ! shouldUseUnifiedAgent && ! shouldCoexist ) {
 		return null;
 	}
 

--- a/client/layout/agents-manager-loader.tsx
+++ b/client/layout/agents-manager-loader.tsx
@@ -1,4 +1,4 @@
-import { useShouldUseUnifiedAgent } from '@automattic/agents-manager';
+import { useShouldUseUnifiedAgent, useShouldCoexistAiSurfaces } from '@automattic/agents-manager';
 import { useSelector } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
@@ -19,13 +19,14 @@ export default function AgentsManagerLoader( {
 	loadAgentsManager: boolean;
 } ) {
 	const shouldUseUnifiedAgent = useShouldUseUnifiedAgent();
+	const shouldCoexist = useShouldCoexistAiSurfaces();
 	const user = useSelector( getCurrentUser );
 	const selectedSite = useSelector( getSelectedSite );
 	const isSiteSpecific = useSelector( isSiteSection );
 	const primarySiteSlug = useSelector( getPrimarySiteSlug );
 	const primarySite = useSelector( ( state ) => getSiteBySlug( state, primarySiteSlug ) );
 
-	if ( ! shouldUseUnifiedAgent || ! loadAgentsManager ) {
+	if ( ( ! shouldUseUnifiedAgent && ! shouldCoexist ) || ! loadAgentsManager ) {
 		return null;
 	}
 

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -100,6 +100,7 @@ class MasterbarLoggedIn extends Component {
 		isGravatarDomain: PropTypes.bool,
 		dashboardOptIn: PropTypes.bool,
 		useUnifiedAgent: PropTypes.bool,
+		coexistAiSurfaces: PropTypes.bool,
 		launchButton: PropTypes.node,
 	};
 
@@ -804,32 +805,9 @@ class MasterbarLoggedIn extends Component {
 	}
 
 	renderHelpCenter() {
-		const { siteId, translate, useUnifiedAgent } = this.props;
+		const { siteId, translate, useUnifiedAgent, coexistAiSurfaces } = this.props;
 
-		if ( useUnifiedAgent ) {
-			const placeholder = (
-				<Item
-					className="masterbar__item-agents-manager"
-					tooltip={ translate( 'Help' ) }
-					icon={ <AgentsManagerIcon hasUnread={ false } /> }
-				/>
-			);
-
-			if ( ! this.state.mounted ) {
-				return placeholder;
-			}
-
-			return (
-				<AsyncLoad
-					require={ loadMasterbarAgentsManager }
-					siteId={ siteId }
-					tooltip={ translate( 'Help' ) }
-					placeholder={ placeholder }
-				/>
-			);
-		}
-
-		const placeholder = (
+		const helpCenterPlaceholder = (
 			<Item
 				className="masterbar__item-help"
 				tooltip={ translate( 'Help' ) }
@@ -837,18 +815,48 @@ class MasterbarLoggedIn extends Component {
 			/>
 		);
 
-		if ( ! this.state.mounted ) {
-			return placeholder;
-		}
-
-		return (
+		const helpCenterIcon = this.state.mounted ? (
 			<AsyncLoad
+				key="help-center"
 				require={ loadMasterbarHelpCenter }
 				siteId={ siteId }
 				tooltip={ translate( 'Help' ) }
-				placeholder={ placeholder }
+				placeholder={ helpCenterPlaceholder }
+			/>
+		) : (
+			helpCenterPlaceholder
+		);
+
+		const agentsManagerPlaceholder = (
+			<Item
+				className="masterbar__item-agents-manager"
+				tooltip={ translate( 'Help' ) }
+				icon={ <AgentsManagerIcon hasUnread={ false } /> }
 			/>
 		);
+
+		const agentsManagerIcon = this.state.mounted ? (
+			<AsyncLoad
+				key="agents-manager"
+				require={ loadMasterbarAgentsManager }
+				siteId={ siteId }
+				tooltip={ translate( 'Help' ) }
+				placeholder={ agentsManagerPlaceholder }
+			/>
+		) : (
+			agentsManagerPlaceholder
+		);
+
+		if ( coexistAiSurfaces ) {
+			return (
+				<>
+					{ helpCenterIcon }
+					{ agentsManagerIcon }
+				</>
+			);
+		}
+
+		return useUnifiedAgent ? agentsManagerIcon : helpCenterIcon;
 	}
 
 	render() {
@@ -937,6 +945,7 @@ export default connect(
 			isGravatarDomain: hasGravatarDomainQueryParam( state ),
 			dashboardOptIn: hasDashboardOptIn( state ),
 			useUnifiedAgent: getPreference( state, 'unified_ai_chat' ) ?? false,
+			coexistAiSurfaces: getPreference( state, 'ai_surface_coexistence' ) ?? false,
 		};
 	},
 	{

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -78,6 +78,10 @@ const loadMasterbarAgentsManager = () =>
 	import(
 		/* webpackChunkName: "async-load-calypso-layout-masterbar-masterbar-agents-manager" */ './masterbar-agents-manager'
 	);
+const loadMasterbarAgentsManagerLauncher = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-layout-masterbar-masterbar-agents-manager-launcher" */ './masterbar-agents-manager/launcher'
+	);
 const loadMasterbarHelpCenter = () =>
 	import(
 		/* webpackChunkName: "async-load-calypso-layout-masterbar-masterbar-help-center" */ './masterbar-help-center'
@@ -830,7 +834,7 @@ class MasterbarLoggedIn extends Component {
 		const agentsManagerPlaceholder = (
 			<Item
 				className="masterbar__item-agents-manager"
-				tooltip={ translate( 'Help' ) }
+				tooltip={ translate( 'Assistant' ) }
 				icon={ <AgentsManagerIcon hasUnread={ false } /> }
 			/>
 		);
@@ -848,10 +852,23 @@ class MasterbarLoggedIn extends Component {
 		);
 
 		if ( coexistAiSurfaces ) {
+			// In coexistence, Help Center keeps its dropdown and Agents Manager gets
+			// a plain sparkle launcher that appears only when AM is fully closed.
+			const agentsManagerLauncher = this.state.mounted ? (
+				<AsyncLoad
+					key="agents-manager"
+					require={ loadMasterbarAgentsManagerLauncher }
+					tooltip={ translate( 'Assistant' ) }
+					placeholder={ agentsManagerPlaceholder }
+				/>
+			) : (
+				agentsManagerPlaceholder
+			);
+
 			return (
 				<>
 					{ helpCenterIcon }
-					{ agentsManagerIcon }
+					{ agentsManagerLauncher }
 				</>
 			);
 		}

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -945,7 +945,7 @@ export default connect(
 			isGravatarDomain: hasGravatarDomainQueryParam( state ),
 			dashboardOptIn: hasDashboardOptIn( state ),
 			useUnifiedAgent: getPreference( state, 'unified_ai_chat' ) ?? false,
-			coexistAiSurfaces: getPreference( state, 'ai_surface_coexistence' ) ?? false,
+			coexistAiSurfaces: getPreference( state, 'ai_surface_coexistence' ) ?? true, // TEMP: force-on for local validation (revert me)
 		};
 	},
 	{

--- a/client/layout/masterbar/masterbar-agents-manager/agents-manager-icon.tsx
+++ b/client/layout/masterbar/masterbar-agents-manager/agents-manager-icon.tsx
@@ -1,28 +1,21 @@
-import { Icon, help } from '@wordpress/icons';
-
 interface AgentsManagerIconProps {
 	hasUnread: boolean;
 }
 
+// AI "sparkle" mark for the Agents Manager masterbar launcher, so it reads as a
+// distinct AI surface rather than sharing the Help Center's question-mark icon.
 export const AgentsManagerIcon: React.FC< AgentsManagerIconProps > = ( { hasUnread } ) => {
-	if ( hasUnread ) {
-		return (
-			<svg
-				width="25"
-				height="24"
-				viewBox="0 0 25 24"
-				fill="none"
-				xmlns="http://www.w3.org/2000/svg"
-			>
-				<path
-					d="M12 2C6.477 2 2 6.477 2 12C2 17.523 6.477 22 12 22C17.523 22 22 17.523 22 12C22 6.477 17.523 2 12 2ZM13 18H11V16H13V18ZM13 13.859V15H11V13C11 12.448 11.448 12 12 12C13.103 12 14 11.103 14 10C14 8.897 13.103 8 12 8C10.897 8 10 8.897 10 10H8C8 7.791 9.791 6 12 6C14.209 6 16 7.791 16 10C16 11.862 14.722 13.413 13 13.859Z"
-					fill="var( --color-masterbar-icon )"
-				/>
+	return (
+		<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+			<path
+				d="M12 1.5L14.3 8.2C14.5 8.8 15 9.3 15.6 9.5L22.5 12L15.6 14.5C15 14.7 14.5 15.2 14.3 15.8L12 22.5L9.7 15.8C9.5 15.2 9 14.7 8.4 14.5L1.5 12L8.4 9.5C9 9.3 9.5 8.8 9.7 8.2L12 1.5Z"
+				fill="var( --color-masterbar-icon, currentColor )"
+			/>
+			{ hasUnread && (
 				<circle cx="20" cy="3.5" r="4.3" fill="#e65054" stroke="#1d2327" strokeWidth="2" />
-			</svg>
-		);
-	}
-	return <Icon icon={ help } />;
+			) }
+		</svg>
+	);
 };
 
 export default AgentsManagerIcon;

--- a/client/layout/masterbar/masterbar-agents-manager/launcher.jsx
+++ b/client/layout/masterbar/masterbar-agents-manager/launcher.jsx
@@ -1,0 +1,54 @@
+import { AGENTS_MANAGER_STORE } from '@automattic/agents-manager';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import {
+	useDispatch as useDataStoreDispatch,
+	useSelect as useDataStoreSelect,
+} from '@wordpress/data';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import { getSectionName } from 'calypso/state/ui/selectors';
+import Item from '../item';
+import AgentsManagerIcon from './agents-manager-icon';
+
+/**
+ * Masterbar launcher for Agents Manager in the coexistence experience.
+ *
+ * Unlike the legacy `MasterbarAgentsManager` dropdown, this is a plain sparkle
+ * button that appears only when Agents Manager is fully closed — not open and
+ * not minimized. When AM is open (panel) or minimized (the "Ask AI" bar), that
+ * surface is the entry point, so this launcher hides itself. Clicking it opens
+ * Agents Manager.
+ */
+const MasterbarAgentsManagerLauncher = ( { tooltip } ) => {
+	const translate = useTranslate();
+	const sectionName = useSelector( getSectionName );
+
+	// `isOpen` is true for both the open panel and the minimized bar; it is only
+	// false when AM is fully hidden, which is exactly when the launcher shows.
+	const isOpen = useDataStoreSelect( ( select ) => select( AGENTS_MANAGER_STORE ).getIsOpen(), [] );
+	const { setIsOpen } = useDataStoreDispatch( AGENTS_MANAGER_STORE );
+
+	if ( isOpen ) {
+		return null;
+	}
+
+	const handleClick = () => {
+		recordTracksEvent( 'calypso_inlinehelp_show', {
+			force_site_id: true,
+			location: 'agents-manager',
+			section: sectionName,
+		} );
+		setIsOpen( true );
+	};
+
+	return (
+		<Item
+			onClick={ handleClick }
+			className="masterbar__item-agents-manager"
+			tooltip={ tooltip ?? translate( 'Assistant' ) }
+			icon={ <AgentsManagerIcon hasUnread={ false } /> }
+		/>
+	);
+};
+
+export default MasterbarAgentsManagerLauncher;

--- a/client/layout/masterbar/masterbar-agents-manager/launcher.jsx
+++ b/client/layout/masterbar/masterbar-agents-manager/launcher.jsx
@@ -26,7 +26,7 @@ const MasterbarAgentsManagerLauncher = ( { tooltip } ) => {
 	// `isOpen` is true for both the open panel and the minimized bar; it is only
 	// false when AM is fully hidden, which is exactly when the launcher shows.
 	const isOpen = useDataStoreSelect( ( select ) => select( AGENTS_MANAGER_STORE ).getIsOpen(), [] );
-	const { setIsOpen } = useDataStoreDispatch( AGENTS_MANAGER_STORE );
+	const { setIsOpen, setIsMinimized } = useDataStoreDispatch( AGENTS_MANAGER_STORE );
 
 	if ( isOpen ) {
 		return null;
@@ -38,6 +38,9 @@ const MasterbarAgentsManagerLauncher = ( { tooltip } ) => {
 			location: 'agents-manager',
 			section: sectionName,
 		} );
+		// Always open to the full chat — clear any persisted minimized state so the
+		// launcher never lands on the minimized "Ask AI" bar.
+		setIsMinimized( false );
 		setIsOpen( true );
 	};
 

--- a/client/layout/masterbar/masterbar-help-center/index.jsx
+++ b/client/layout/masterbar/masterbar-help-center/index.jsx
@@ -1,3 +1,4 @@
+import { useShouldCoexistAiSurfaces } from '@automattic/agents-manager';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { HelpCenter } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
@@ -40,9 +41,13 @@ const MasterbarHelpCenter = ( { tooltip } ) => {
 	);
 	const { setShowHelpCenter, setNavigateToRoute } = useDataStoreDispatch( HELP_CENTER_STORE );
 
-	// Check if the new menu panel feature is enabled (both feature flag AND query param must be true)
+	// When coexisting with Agents Manager, always use the menu-panel dropdown so
+	// Help Center keeps its familiar dropdown launcher. Otherwise it's gated by
+	// the menu-popover experiment.
+	const isCoexisting = useShouldCoexistAiSurfaces();
 	const isMenuPanelExperimentEnabled =
-		! isLoadingExperimentAssignment && experimentAssignment?.variationName === 'menu_popover';
+		isCoexisting ||
+		( ! isLoadingExperimentAssignment && experimentAssignment?.variationName === 'menu_popover' );
 
 	const trackIconInteraction = () => {
 		recordTracksEvent( `wpcom_help_center_icon_interaction`, {

--- a/docs/superpowers/plans/2026-06-04-ai-surface-coexistence.md
+++ b/docs/superpowers/plans/2026-06-04-ai-surface-coexistence.md
@@ -1,0 +1,949 @@
+# Help Center / Agents Manager Coexistence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let Help Center and Agents Manager load together and coordinate at runtime so only one is expanded at a time, the other parks as a minimized bar, the two minimized bars stack, and a docked Agents Manager coexists with a floating Help Center — all behind a feature flag, replacing today's mount-time mutual exclusion.
+
+**Architecture:** A pure reconciler (`computeCoordination`) plus a thin React hook (`useAiSurfaceCoordinator`) live in `@automattic/data-stores`. The hook subscribes to both existing `@wordpress/data` stores on the shared `window.wp.data` registry, enforces "at most one floating-expanded" by dispatching the surfaces' *existing* `setIsMinimized` actions, persists a "last expanded" marker in `localStorage`, and writes layout CSS custom properties on `:root` (stack offsets + docked rail inset) that each surface's SCSS consumes (defaulting to today's values when unset). A new gating hook `useShouldCoexistAiSurfaces()` mirrors the existing `useShouldUseUnifiedAgent()` and turns the whole behavior on/off.
+
+**Tech Stack:** TypeScript, `@wordpress/data`, `@wordpress/element`, React, Jest + `@testing-library`, SCSS.
+
+**Out of scope (cross-repo dependency — track separately):** The Jetpack `jetpack-mu-wpcom` backend must (a) expose the new `ai_surface_coexistence` flag via the same `/agents-manager/state` mechanism + inline `agentsManagerData`, and (b) stop dequeuing Help Center scripts on Gutenberg pages when the flag is on. Without (a) the flag is always `false` (safe no-op); without (b) the widgets.wp.com Gutenberg path won't load both. The Calypso SPA path is fully exercisable without Jetpack changes by forcing the flag in dev (see Task 6).
+
+---
+
+## File Structure
+
+- **Create** `packages/data-stores/src/ai-surface-coordinator/reconciler.ts` — pure state machine + types. No React, no `@wordpress/data`.
+- **Create** `packages/data-stores/src/ai-surface-coordinator/reconciler.test.ts` — unit tests for the reconciler.
+- **Create** `packages/data-stores/src/ai-surface-coordinator/constants.ts` — bar height/gap, CSS var names, localStorage key.
+- **Create** `packages/data-stores/src/ai-surface-coordinator/layout.ts` — pure function computing `:root` CSS-var values from observed state.
+- **Create** `packages/data-stores/src/ai-surface-coordinator/layout.test.ts` — unit tests for layout var computation.
+- **Create** `packages/data-stores/src/ai-surface-coordinator/index.ts` — `useAiSurfaceCoordinator()` hook wiring reconciler+layout to the live stores + DOM, plus barrel exports.
+- **Modify** `packages/data-stores/src/index.ts` — export the coordinator module.
+- **Create** `packages/agents-manager/src/hooks/use-should-coexist-ai-surfaces.ts` — gating hook (mirrors `use-should-use-unified-agent.ts`).
+- **Modify** `packages/agents-manager/src/hooks/use-unified-ai-chat.ts` — read the new `ai_surface_coexistence` state key alongside `unified_ai_chat`.
+- **Modify** `packages/agents-manager/src/index.ts` — export the new gating hook.
+- **Modify** `packages/help-center/src/components/help-center.tsx` — stop self-suppressing when coexistence is on; mount the coordinator.
+- **Modify** `packages/help-center/src/styles.scss` — consume stack/rail CSS vars on the minimized/desktop card.
+- **Modify** `packages/agents-manager/src/components/agent-dock/style.scss` — consume the stack CSS var on the undocked minimized bar.
+- **Modify** `client/layout/help-center-loader.tsx` — mount Help Center when coexistence is on.
+- **Modify** `client/layout/agents-manager-loader.tsx` — mount Agents Manager when coexistence is on.
+- **Modify** `client/layout/masterbar/logged-in.jsx` — render both masterbar icons when coexistence is on.
+- **Modify** `apps/help-center/help-center-wp-admin.jsx` and `apps/agents-manager/agents-manager-with-provider.jsx` — mount the coordinator in each widget entry.
+
+---
+
+## Task 1: Reconciler types and "no conflict" base case
+
+**Files:**
+- Create: `packages/data-stores/src/ai-surface-coordinator/reconciler.ts`
+- Test: `packages/data-stores/src/ai-surface-coordinator/reconciler.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// reconciler.test.ts
+import { computeCoordination, type SurfaceSnapshot } from './reconciler';
+
+const HC_CLOSED = { present: true, shown: false, minimized: false };
+const AM_CLOSED = { present: true, open: false, minimized: false, docked: false };
+
+function snap( hc: Partial< SurfaceSnapshot[ 'helpCenter' ] >, am: Partial< SurfaceSnapshot[ 'agentsManager' ] > ): SurfaceSnapshot {
+	return { helpCenter: { ...HC_CLOSED, ...hc }, agentsManager: { ...AM_CLOSED, ...am } };
+}
+
+describe( 'computeCoordination — no conflict', () => {
+	it( 'returns no commands when neither surface is expanded', () => {
+		const prev = snap( {}, {} );
+		const next = snap( {}, {} );
+		expect( computeCoordination( prev, next, null ) ).toEqual( { commands: [], lastExpanded: null } );
+	} );
+
+	it( 'records the sole expanded floating surface as lastExpanded without minimizing anything', () => {
+		const prev = snap( {}, {} );
+		const next = snap( { shown: true }, {} );
+		expect( computeCoordination( prev, next, null ) ).toEqual( { commands: [], lastExpanded: 'help-center' } );
+	} );
+
+	it( 'treats a docked Agents Manager as non-conflicting with an expanded Help Center', () => {
+		const prev = snap( { shown: true }, {} );
+		const next = snap( { shown: true }, { open: true, docked: true } );
+		expect( computeCoordination( prev, next, 'help-center' ) ).toEqual( { commands: [], lastExpanded: 'help-center' } );
+	} );
+
+	it( 'no-ops entirely when a surface is not present', () => {
+		const prev = snap( { shown: true }, {} );
+		const next = snap( { shown: true }, { present: false, open: true } );
+		expect( computeCoordination( prev, next, 'help-center' ).commands ).toEqual( [] );
+	} );
+} );
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn jest packages/data-stores/src/ai-surface-coordinator/reconciler.test.ts`
+Expected: FAIL — `Cannot find module './reconciler'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// reconciler.ts
+export type Surface = 'help-center' | 'agents-manager';
+
+export interface SurfaceSnapshot {
+	helpCenter: { present: boolean; shown: boolean; minimized: boolean };
+	agentsManager: { present: boolean; open: boolean; minimized: boolean; docked: boolean };
+}
+
+export type Command =
+	| { type: 'minimize'; surface: 'help-center' }
+	| { type: 'minimize'; surface: 'agents-manager' };
+
+export interface CoordinationResult {
+	commands: Command[];
+	lastExpanded: Surface | null;
+}
+
+const isHelpCenterExpanded = ( s: SurfaceSnapshot ) =>
+	s.helpCenter.present && s.helpCenter.shown && ! s.helpCenter.minimized;
+
+// A docked Agents Manager lives in its own rail and never conflicts.
+const isAgentsManagerFloatingExpanded = ( s: SurfaceSnapshot ) =>
+	s.agentsManager.present &&
+	s.agentsManager.open &&
+	! s.agentsManager.minimized &&
+	! s.agentsManager.docked;
+
+export function computeCoordination(
+	prev: SurfaceSnapshot,
+	next: SurfaceSnapshot,
+	lastExpanded: Surface | null
+): CoordinationResult {
+	const hcExpanded = isHelpCenterExpanded( next );
+	const amExpanded = isAgentsManagerFloatingExpanded( next );
+
+	// Single (or zero) floating-expanded surface: record it, nothing to minimize.
+	if ( ! ( hcExpanded && amExpanded ) ) {
+		const sole = hcExpanded ? 'help-center' : amExpanded ? 'agents-manager' : lastExpanded;
+		return { commands: [], lastExpanded: sole };
+	}
+
+	// Conflict resolution lands in Task 2.
+	return { commands: [], lastExpanded };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `yarn jest packages/data-stores/src/ai-surface-coordinator/reconciler.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/data-stores/src/ai-surface-coordinator/reconciler.ts packages/data-stores/src/ai-surface-coordinator/reconciler.test.ts
+git commit -m "Add AI surface coordinator reconciler — no-conflict base case"
+```
+
+---
+
+## Task 2: Reconciler conflict resolution (minimize the loser)
+
+**Files:**
+- Modify: `packages/data-stores/src/ai-surface-coordinator/reconciler.ts`
+- Test: `packages/data-stores/src/ai-surface-coordinator/reconciler.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+describe( 'computeCoordination — conflict resolution', () => {
+	it( 'minimizes the previously-open surface when the other newly expands (open HC over open AM)', () => {
+		const prev = snap( {}, { open: true } );           // AM floating-open, HC closed
+		const next = snap( { shown: true }, { open: true } ); // user just opened HC
+		const result = computeCoordination( prev, next, 'agents-manager' );
+		expect( result.commands ).toEqual( [ { type: 'minimize', surface: 'agents-manager' } ] );
+		expect( result.lastExpanded ).toBe( 'help-center' );
+	} );
+
+	it( 'minimizes Help Center when Agents Manager newly expands over an open Help Center', () => {
+		const prev = snap( { shown: true }, {} );
+		const next = snap( { shown: true }, { open: true } );
+		const result = computeCoordination( prev, next, 'help-center' );
+		expect( result.commands ).toEqual( [ { type: 'minimize', surface: 'help-center' } ] );
+		expect( result.lastExpanded ).toBe( 'agents-manager' );
+	} );
+
+	it( 'on boot (both already expanded, no transition) keeps the lastExpanded surface', () => {
+		const both = snap( { shown: true }, { open: true } );
+		const result = computeCoordination( both, both, 'help-center' );
+		expect( result.commands ).toEqual( [ { type: 'minimize', surface: 'agents-manager' } ] );
+		expect( result.lastExpanded ).toBe( 'help-center' );
+	} );
+
+	it( 'on boot with no marker, defaults to keeping Agents Manager (minimizes Help Center)', () => {
+		const both = snap( { shown: true }, { open: true } );
+		const result = computeCoordination( both, both, null );
+		expect( result.commands ).toEqual( [ { type: 'minimize', surface: 'help-center' } ] );
+		expect( result.lastExpanded ).toBe( 'agents-manager' );
+	} );
+} );
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn jest packages/data-stores/src/ai-surface-coordinator/reconciler.test.ts`
+Expected: FAIL — conflict cases return `{ commands: [] }`.
+
+- [ ] **Step 3: Replace the conflict branch in `reconciler.ts`**
+
+Replace the `// Conflict resolution lands in Task 2.` block and its `return` with:
+
+```ts
+	// Both floating-expanded → keep one, minimize the other.
+	// Prefer the surface that just transitioned into expansion this tick.
+	const hcJustExpanded = hcExpanded && ! isHelpCenterExpanded( prev );
+	const amJustExpanded = amExpanded && ! isAgentsManagerFloatingExpanded( prev );
+
+	let keep: Surface;
+	if ( hcJustExpanded && ! amJustExpanded ) {
+		keep = 'help-center';
+	} else if ( amJustExpanded && ! hcJustExpanded ) {
+		keep = 'agents-manager';
+	} else {
+		// No single transition (e.g. boot from persisted state, or both at once):
+		// keep the most-recently-active; default to Agents Manager when unknown.
+		keep = lastExpanded ?? 'agents-manager';
+	}
+
+	const loser: Surface = keep === 'help-center' ? 'agents-manager' : 'help-center';
+	return { commands: [ { type: 'minimize', surface: loser } ], lastExpanded: keep };
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `yarn jest packages/data-stores/src/ai-surface-coordinator/reconciler.test.ts`
+Expected: PASS (8 tests total).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/data-stores/src/ai-surface-coordinator/reconciler.ts packages/data-stores/src/ai-surface-coordinator/reconciler.test.ts
+git commit -m "Add AI surface coordinator conflict resolution"
+```
+
+---
+
+## Task 3: Coordinator constants
+
+**Files:**
+- Create: `packages/data-stores/src/ai-surface-coordinator/constants.ts`
+
+- [ ] **Step 1: Write the file (no test — plain constants)**
+
+```ts
+// constants.ts
+// Height of each surface's minimized bar, in px. Help Center's bar is
+// $head-foot-height (56px); Agents Manager's agenttic minimized bar matches.
+export const MINIMIZED_BAR_HEIGHT = 56;
+// Vertical gap between stacked minimized bars, in px.
+export const STACK_GAP = 8;
+
+// Persisted (localStorage) marker for boot tie-break. Not server-backed: it is
+// a non-critical UI hint, so it avoids a backend allowed-key change.
+export const LAST_EXPANDED_STORAGE_KEY = 'ai-surface-last-expanded';
+
+// CSS custom properties written on :root and consumed by each surface's SCSS.
+// Each defaults (when unset) to the surface's pre-coexistence value.
+export const CSS_VAR_HC_STACK_BOTTOM = '--ai-surface-hc-stack-bottom';
+export const CSS_VAR_AM_STACK_BOTTOM = '--ai-surface-am-stack-bottom';
+export const CSS_VAR_RAIL_INSET = '--ai-surface-rail-inset';
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/data-stores/src/ai-surface-coordinator/constants.ts
+git commit -m "Add AI surface coordinator constants"
+```
+
+---
+
+## Task 4: Layout CSS-variable computation
+
+**Files:**
+- Create: `packages/data-stores/src/ai-surface-coordinator/layout.ts`
+- Test: `packages/data-stores/src/ai-surface-coordinator/layout.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// layout.test.ts
+import { computeLayoutVars } from './layout';
+import type { SurfaceSnapshot, Surface } from './reconciler';
+
+const HC_CLOSED = { present: true, shown: false, minimized: false };
+const AM_CLOSED = { present: true, open: false, minimized: false, docked: false };
+function snap( hc = {}, am = {} ): SurfaceSnapshot {
+	return { helpCenter: { ...HC_CLOSED, ...hc }, agentsManager: { ...AM_CLOSED, ...am } };
+}
+
+describe( 'computeLayoutVars', () => {
+	it( 'leaves both stack bottoms at 0 when only one bar is minimized', () => {
+		const vars = computeLayoutVars( snap( { shown: true, minimized: true } ), null );
+		expect( vars[ '--ai-surface-hc-stack-bottom' ] ).toBe( '0px' );
+		expect( vars[ '--ai-surface-am-stack-bottom' ] ).toBe( '0px' );
+	} );
+
+	it( 'raises the non-most-recent bar by (barHeight + gap) when both are minimized', () => {
+		const both = snap( { shown: true, minimized: true }, { open: true, minimized: true } );
+		const vars = computeLayoutVars( both, 'help-center' as Surface );
+		// HC most recent → bottom slot; AM raised above it.
+		expect( vars[ '--ai-surface-hc-stack-bottom' ] ).toBe( '0px' );
+		expect( vars[ '--ai-surface-am-stack-bottom' ] ).toBe( '64px' );
+	} );
+
+	it( 'sets the rail inset to the sidebar width when Agents Manager is docked', () => {
+		const vars = computeLayoutVars( snap( {}, { open: true, docked: true } ), null );
+		expect( vars[ '--ai-surface-rail-inset' ] ).toBe( 'var(--am-sidebar-width, 350px)' );
+	} );
+
+	it( 'sets the rail inset to 0 when Agents Manager is not docked', () => {
+		const vars = computeLayoutVars( snap( {}, {} ), null );
+		expect( vars[ '--ai-surface-rail-inset' ] ).toBe( '0px' );
+	} );
+} );
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn jest packages/data-stores/src/ai-surface-coordinator/layout.test.ts`
+Expected: FAIL — `Cannot find module './layout'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// layout.ts
+import {
+	MINIMIZED_BAR_HEIGHT,
+	STACK_GAP,
+	CSS_VAR_HC_STACK_BOTTOM,
+	CSS_VAR_AM_STACK_BOTTOM,
+	CSS_VAR_RAIL_INSET,
+} from './constants';
+import type { Surface, SurfaceSnapshot } from './reconciler';
+
+export type LayoutVars = Record< string, string >;
+
+const hcBarVisible = ( s: SurfaceSnapshot ) =>
+	s.helpCenter.present && s.helpCenter.shown && s.helpCenter.minimized;
+
+const amBarVisible = ( s: SurfaceSnapshot ) =>
+	s.agentsManager.present &&
+	s.agentsManager.open &&
+	s.agentsManager.minimized &&
+	! s.agentsManager.docked;
+
+export function computeLayoutVars( s: SurfaceSnapshot, lastExpanded: Surface | null ): LayoutVars {
+	const raised = `${ MINIMIZED_BAR_HEIGHT + STACK_GAP }px`;
+	const bothMinimized = hcBarVisible( s ) && amBarVisible( s );
+
+	let hcBottom = '0px';
+	let amBottom = '0px';
+	if ( bothMinimized ) {
+		// Most-recently-active bar sits on the bottom (slot 0); the other is raised.
+		const amOnBottom = lastExpanded === 'agents-manager';
+		hcBottom = amOnBottom ? raised : '0px';
+		amBottom = amOnBottom ? '0px' : raised;
+	}
+
+	return {
+		[ CSS_VAR_HC_STACK_BOTTOM ]: hcBottom,
+		[ CSS_VAR_AM_STACK_BOTTOM ]: amBottom,
+		[ CSS_VAR_RAIL_INSET ]: s.agentsManager.docked
+			? 'var(--am-sidebar-width, 350px)'
+			: '0px',
+	};
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `yarn jest packages/data-stores/src/ai-surface-coordinator/layout.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/data-stores/src/ai-surface-coordinator/layout.ts packages/data-stores/src/ai-surface-coordinator/layout.test.ts
+git commit -m "Add AI surface coordinator layout var computation"
+```
+
+---
+
+## Task 5: The `useAiSurfaceCoordinator` hook
+
+**Files:**
+- Create: `packages/data-stores/src/ai-surface-coordinator/index.ts`
+- Modify: `packages/data-stores/src/index.ts`
+- Test: `packages/data-stores/src/ai-surface-coordinator/index.test.tsx`
+
+Confirm `@wordpress/data` and `@wordpress/element` are already dependencies of `packages/data-stores/package.json` (they are — used throughout the store modules). No dependency change expected.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// index.test.tsx
+import { dispatch, register, createReduxStore } from '@wordpress/data';
+import { renderHook } from '@testing-library/react';
+import { useAiSurfaceCoordinator } from './index';
+import { STORE_KEY as HC_KEY } from '../help-center/constants';
+import { STORE_KEY as AM_KEY } from '../agents-manager/constants';
+
+// Minimal stand-in stores keyed exactly like the real ones.
+function registerStubStores() {
+	register( createReduxStore( HC_KEY, {
+		reducer: ( state = { showHelpCenter: false, isMinimized: false }, action ) =>
+			action.type === 'SET' ? { ...state, ...action.payload } : state,
+		actions: {
+			set: ( payload ) => ( { type: 'SET', payload } ),
+			setIsMinimized: ( isMinimized ) => ( { type: 'SET', payload: { isMinimized } } ),
+		},
+		selectors: {
+			isHelpCenterShown: ( s ) => s.showHelpCenter,
+			getIsMinimized: ( s ) => s.isMinimized,
+		},
+	} ) );
+	register( createReduxStore( AM_KEY, {
+		reducer: ( state = { isOpen: false, isMinimized: false, isDocked: false }, action ) =>
+			action.type === 'SET' ? { ...state, ...action.payload } : state,
+		actions: {
+			set: ( payload ) => ( { type: 'SET', payload } ),
+			setIsMinimized: ( isMinimized ) => ( { type: 'SET', payload: { isMinimized } } ),
+		},
+		selectors: {
+			getIsOpen: ( s ) => s.isOpen,
+			getIsMinimized: ( s ) => s.isMinimized,
+			getIsDocked: ( s ) => s.isDocked,
+		},
+	} ) );
+}
+
+beforeEach( () => {
+	window.localStorage.clear();
+	registerStubStores();
+} );
+
+it( 'minimizes Agents Manager when Help Center opens while AM is floating-open', () => {
+	dispatch( AM_KEY ).set( { isOpen: true } );
+	renderHook( () => useAiSurfaceCoordinator( true ) );
+	dispatch( HC_KEY ).set( { showHelpCenter: true } );
+	// The coordinator should have dispatched setIsMinimized(true) on AM.
+	const { select } = require( '@wordpress/data' );
+	expect( select( AM_KEY ).getIsMinimized() ).toBe( true );
+} );
+
+it( 'no-ops when disabled', () => {
+	dispatch( AM_KEY ).set( { isOpen: true } );
+	renderHook( () => useAiSurfaceCoordinator( false ) );
+	dispatch( HC_KEY ).set( { showHelpCenter: true } );
+	const { select } = require( '@wordpress/data' );
+	expect( select( AM_KEY ).getIsMinimized() ).toBe( false );
+} );
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn jest packages/data-stores/src/ai-surface-coordinator/index.test.tsx`
+Expected: FAIL — `Cannot find module './index'` (or no export `useAiSurfaceCoordinator`).
+
+- [ ] **Step 3: Write the hook**
+
+```ts
+// index.ts
+import { select, dispatch, subscribe } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { STORE_KEY as AM_KEY } from '../agents-manager/constants';
+import { STORE_KEY as HC_KEY } from '../help-center/constants';
+import { LAST_EXPANDED_STORAGE_KEY } from './constants';
+import { computeLayoutVars } from './layout';
+import { computeCoordination, type Surface, type SurfaceSnapshot } from './reconciler';
+
+export * from './reconciler';
+export * from './layout';
+export * from './constants';
+
+function readSnapshot(): SurfaceSnapshot {
+	const hc = select( HC_KEY ) as
+		| { isHelpCenterShown: () => boolean; getIsMinimized: () => boolean }
+		| undefined;
+	const am = select( AM_KEY ) as
+		| { getIsOpen: () => boolean; getIsMinimized: () => boolean; getIsDocked: () => boolean }
+		| undefined;
+
+	return {
+		helpCenter: {
+			present: !! hc,
+			shown: !! hc?.isHelpCenterShown(),
+			minimized: !! hc?.getIsMinimized(),
+		},
+		agentsManager: {
+			present: !! am,
+			open: !! am?.getIsOpen(),
+			minimized: !! am?.getIsMinimized(),
+			docked: !! am?.getIsDocked(),
+		},
+	};
+}
+
+function readLastExpanded(): Surface | null {
+	const v = window.localStorage.getItem( LAST_EXPANDED_STORAGE_KEY );
+	return v === 'help-center' || v === 'agents-manager' ? v : null;
+}
+
+function writeLastExpanded( surface: Surface | null ) {
+	if ( surface ) {
+		window.localStorage.setItem( LAST_EXPANDED_STORAGE_KEY, surface );
+	}
+}
+
+function applyLayoutVars( vars: Record< string, string > ) {
+	const root = document.documentElement;
+	for ( const [ name, value ] of Object.entries( vars ) ) {
+		root.style.setProperty( name, value );
+	}
+}
+
+/**
+ * Runtime coordinator that keeps at most one AI surface floating-expanded.
+ * Mount once per page (Calypso layout, each widget entry). Pass `enabled=false`
+ * to fully disable (flag off) — it then performs no subscription and no writes.
+ */
+export function useAiSurfaceCoordinator( enabled: boolean ) {
+	useEffect( () => {
+		if ( ! enabled ) {
+			return;
+		}
+
+		let prev = readSnapshot();
+		let lastExpanded = readLastExpanded();
+
+		const reconcile = () => {
+			const next = readSnapshot();
+			const { commands, lastExpanded: nextLast } = computeCoordination( prev, next, lastExpanded );
+
+			if ( nextLast !== lastExpanded ) {
+				lastExpanded = nextLast;
+				writeLastExpanded( lastExpanded );
+			}
+
+			for ( const command of commands ) {
+				if ( command.surface === 'agents-manager' ) {
+					( dispatch( AM_KEY ) as { setIsMinimized: ( v: boolean ) => void } ).setIsMinimized( true );
+				} else {
+					( dispatch( HC_KEY ) as { setIsMinimized: ( v: boolean ) => void } ).setIsMinimized( true );
+				}
+			}
+
+			applyLayoutVars( computeLayoutVars( next, lastExpanded ) );
+			prev = next;
+		};
+
+		reconcile(); // boot reconciliation
+		const unsubscribe = subscribe( reconcile );
+		return unsubscribe;
+	}, [ enabled ] );
+}
+```
+
+- [ ] **Step 4: Export from the package barrel**
+
+In `packages/data-stores/src/index.ts`, add alongside the other `export * as` lines:
+
+```ts
+export * as AiSurfaceCoordinator from './ai-surface-coordinator';
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `yarn jest packages/data-stores/src/ai-surface-coordinator/index.test.tsx`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Typecheck the package**
+
+Run: `yarn typecheck-packages` (or `yarn tsc -p packages/data-stores`)
+Expected: no new errors in `ai-surface-coordinator/`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/data-stores/src/ai-surface-coordinator/index.ts packages/data-stores/src/ai-surface-coordinator/index.test.tsx packages/data-stores/src/index.ts
+git commit -m "Add useAiSurfaceCoordinator hook"
+```
+
+---
+
+## Task 6: Gating hook `useShouldCoexistAiSurfaces`
+
+**Files:**
+- Modify: `packages/agents-manager/src/hooks/use-unified-ai-chat.ts`
+- Create: `packages/agents-manager/src/hooks/use-should-coexist-ai-surfaces.ts`
+- Modify: `packages/agents-manager/src/index.ts`
+
+The flag rides the exact same mechanism as `unified_ai_chat`: an inline `agentsManagerData` value on wp-admin, and the `/agents-manager/state` endpoint on Calypso. Backend exposure is the tracked Jetpack dependency; until it lands the value is `undefined` → `false` (safe).
+
+- [ ] **Step 1: Extend the state response + fetch the new key**
+
+In `use-unified-ai-chat.ts`, change the response interface and add a second query for the coexistence flag. Append after `useUnifiedAiChat`:
+
+```ts
+interface CoexistenceStateResponse {
+	ai_surface_coexistence?: boolean;
+}
+
+/**
+ * Determines whether Help Center and Agents Manager should coexist (both
+ * loaded, runtime-coordinated) instead of being mutually exclusive.
+ * Mirrors useUnifiedAiChat's hybrid inline/endpoint approach.
+ */
+export function useAiSurfaceCoexistence( enabled = true ) {
+	return useQuery< boolean, Error >( {
+		queryKey: [ 'ai-surface-coexistence' ],
+		queryFn: async () => {
+			if ( canAccessWpcomApis() ) {
+				const response: CoexistenceStateResponse = await wpcomRequest( {
+					path: '/agents-manager/state?key=ai_surface_coexistence',
+					apiNamespace: 'wpcom/v2',
+				} );
+				return response.ai_surface_coexistence ?? false;
+			}
+			return false;
+		},
+		enabled,
+		refetchOnWindowFocus: false,
+		staleTime: 300000,
+	} );
+}
+```
+
+- [ ] **Step 2: Create the gating hook**
+
+```ts
+// use-should-coexist-ai-surfaces.ts
+/* eslint-disable no-restricted-imports */
+import { useAiSurfaceCoexistence } from './use-unified-ai-chat';
+
+export const useShouldCoexistAiSurfaces = () => {
+	const { data } = useAiSurfaceCoexistence();
+	return !! data;
+};
+```
+
+- [ ] **Step 3: Export it**
+
+In `packages/agents-manager/src/index.ts`, add next to the existing `useShouldUseUnifiedAgent` export:
+
+```ts
+export { useShouldCoexistAiSurfaces } from './hooks/use-should-coexist-ai-surfaces';
+```
+
+- [ ] **Step 4: Verify it builds + typechecks**
+
+Run: `yarn tsc -p packages/agents-manager` (or `yarn typecheck-packages`)
+Expected: no new errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/agents-manager/src/hooks/use-unified-ai-chat.ts packages/agents-manager/src/hooks/use-should-coexist-ai-surfaces.ts packages/agents-manager/src/index.ts
+git commit -m "Add ai_surface_coexistence gating hook"
+```
+
+---
+
+## Task 7: Help Center stops self-suppressing under the flag + mounts coordinator
+
+**Files:**
+- Modify: `packages/help-center/src/components/help-center.tsx`
+
+- [ ] **Step 1: Update the suppression logic**
+
+In `help-center.tsx`:
+
+1. Add imports near the other external deps:
+
+```ts
+import { useShouldCoexistAiSurfaces } from '@automattic/agents-manager';
+import { AiSurfaceCoordinator } from '@automattic/data-stores';
+```
+
+2. Inside `HelpCenter`, after `const shouldUseUnifiedAgent = useShouldUseUnifiedAgent();` add:
+
+```ts
+	const shouldCoexist = useShouldCoexistAiSurfaces();
+	// When coexisting, Help Center must render even though the unified agent is on.
+	const suppress = shouldUseUnifiedAgent && ! shouldCoexist;
+	AiSurfaceCoordinator.useAiSurfaceCoordinator( shouldCoexist );
+```
+
+3. Replace the portal-creation guard `if ( ! shouldUseUnifiedAgent ) {` with `if ( ! suppress ) {`.
+
+4. Replace the early return `if ( ! container || shouldUseUnifiedAgent ) {` with `if ( ! container || suppress ) {`.
+
+- [ ] **Step 2: Run related tests**
+
+Run: `yarn jest packages/help-center/src/components`
+Expected: PASS (no regression; existing suppression behavior holds when `shouldCoexist` is false — the default in tests).
+
+- [ ] **Step 3: Typecheck**
+
+Run: `yarn tsc -p packages/help-center`
+Expected: no new errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/help-center/src/components/help-center.tsx
+git commit -m "Render Help Center alongside Agents Manager when coexistence is on"
+```
+
+---
+
+## Task 8: Calypso loaders mount both surfaces under the flag
+
+**Files:**
+- Modify: `client/layout/agents-manager-loader.tsx`
+- Modify: `client/layout/help-center-loader.tsx`
+
+- [ ] **Step 1: Agents Manager loader — mount when unified OR coexistence is on**
+
+In `agents-manager-loader.tsx`:
+
+1. Add import: `import { useShouldUseUnifiedAgent, useShouldCoexistAiSurfaces } from '@automattic/agents-manager';` (extend the existing import).
+2. Add `const shouldCoexist = useShouldCoexistAiSurfaces();`.
+3. Change the guard from:
+
+```ts
+	if ( ! shouldUseUnifiedAgent || ! loadAgentsManager ) {
+		return null;
+	}
+```
+
+to:
+
+```ts
+	if ( ( ! shouldUseUnifiedAgent && ! shouldCoexist ) || ! loadAgentsManager ) {
+		return null;
+	}
+```
+
+- [ ] **Step 2: Help Center loader — already mounts; no gate change needed**
+
+`help-center-loader.tsx` already mounts whenever `loadHelpCenter` is true; suppression happens inside the component (Task 7). No change required here. Confirm by reading lines 44-46 — the only gate is `if ( ! loadHelpCenter ) return null;`.
+
+- [ ] **Step 3: Typecheck client**
+
+Run: `yarn typecheck-client`
+Expected: no new errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/layout/agents-manager-loader.tsx
+git commit -m "Mount Agents Manager when AI surface coexistence is on"
+```
+
+---
+
+## Task 9: Masterbar renders both launchers under the flag
+
+**Files:**
+- Modify: `client/layout/masterbar/logged-in.jsx`
+
+Read `renderHelpCenter()` (around lines 806-852) and the `useUnifiedAgent` preference read (line ~939) before editing.
+
+- [ ] **Step 1: Thread a coexistence flag into the masterbar**
+
+The masterbar reads `useUnifiedAgent` from the Redux preference `unified_ai_chat`. Add a sibling read of the `ai_surface_coexistence` preference (populated by the same agents-manager state fetch that already populates `unified_ai_chat`):
+
+```js
+const coexistAiSurfaces = getPreference( state, 'ai_surface_coexistence' ) ?? false;
+```
+
+Pass it to the component as a prop (mirror exactly how `useUnifiedAgent` is passed).
+
+- [ ] **Step 2: Render both icons when coexisting**
+
+In `renderHelpCenter()`, change the branch so that when `coexistAiSurfaces` is true it returns **both** the `MasterbarAgentsManager` and `MasterbarHelpCenter` async components (each in its own masterbar item), instead of the either/or. Keep the existing `useUnifiedAgent ? AgentsManager : HelpCenter` branch as the `else` (flag-off path):
+
+```jsx
+if ( coexistAiSurfaces ) {
+	return (
+		<>
+			{ /* existing MasterbarHelpCenter element */ }
+			{ /* existing MasterbarAgentsManager element */ }
+		</>
+	);
+}
+// ...existing single-icon branch unchanged...
+```
+
+(Reuse the exact AsyncLoad blocks already present for each — do not duplicate their props by hand; lift each into a local `const helpIcon = (...)` / `const agentsIcon = (...)` and reference them in both branches to stay DRY.)
+
+- [ ] **Step 3: Typecheck client + lint the file**
+
+Run: `yarn typecheck-client && yarn eslint client/layout/masterbar/logged-in.jsx`
+Expected: no new errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/layout/masterbar/logged-in.jsx
+git commit -m "Render both Help Center and Agents Manager masterbar icons when coexisting"
+```
+
+---
+
+## Task 10: SCSS consumes the layout CSS variables
+
+**Files:**
+- Modify: `packages/help-center/src/styles.scss`
+- Modify: `packages/agents-manager/src/components/agent-dock/style.scss`
+
+Each rule adds the new var with a fallback equal to the current value, so flag-off rendering is byte-for-byte unchanged (the vars are simply never set when the coordinator is disabled).
+
+- [ ] **Step 1: Help Center desktop card — offset for the rail and the stack**
+
+In `styles.scss`, find the desktop `.help-center.is-desktop` positioning (`right: 50px; bottom: 50px;` around line 98-126). Change the offsets to incorporate the vars:
+
+```scss
+// was: right: 50px;
+inset-inline-end: calc( 50px + var( --ai-surface-rail-inset, 0px ) );
+```
+
+In the minimized desktop rule (`is-minimized` collapsing to `bottom: 0`), change:
+
+```scss
+// was: bottom: 0;
+bottom: var( --ai-surface-hc-stack-bottom, 0px );
+inset-inline-end: calc( 50px + var( --ai-surface-rail-inset, 0px ) );
+```
+
+- [ ] **Step 2: Agents Manager undocked minimized bar — stack offset**
+
+In `agent-dock/style.scss`, find the undocked floating rule (`.agents-manager-chat--undocked ...` around line 703-705). Add a bottom offset driven by the var for the minimized bar:
+
+```scss
+.agents-manager-chat--undocked .agenttic.Chat-module_container.Chat-module_floating {
+	z-index: 9999;
+	bottom: var( --ai-surface-am-stack-bottom, 0px );
+}
+```
+
+(If the agenttic floating container already sets its own `bottom`, add the var as an additive offset via `margin-block-end: var( --ai-surface-am-stack-bottom, 0px );` instead — verify which by inspecting the rendered element in Task 11.)
+
+- [ ] **Step 3: Lint styles**
+
+Run: `yarn stylelint packages/help-center/src/styles.scss packages/agents-manager/src/components/agent-dock/style.scss`
+Expected: no new errors. (Note: client SCSS forbids hardcoded colors and BEM shortcuts; these packages have their own conventions — match the surrounding file. `50px`/`0px` literals are pre-existing here.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/help-center/src/styles.scss packages/agents-manager/src/components/agent-dock/style.scss
+git commit -m "Position minimized AI surfaces via coordinator CSS variables"
+```
+
+---
+
+## Task 11: Mount the coordinator in the widget entries + manual verification
+
+**Files:**
+- Modify: `apps/agents-manager/agents-manager-with-provider.jsx`
+- Modify: `apps/help-center/help-center-wp-admin.jsx`
+
+The Calypso path already mounts the coordinator via Task 7 (inside the Help Center component). The widget bundles load the two surfaces independently, so mount the coordinator once where each app sets up its tree. Mounting it in both is safe — the hook is idempotent and converges — but to avoid double subscription prefer mounting it in the **Agents Manager** widget only (it is the surface always present in the unified experience), and rely on Task 7's mount for the Calypso SPA.
+
+- [ ] **Step 1: Mount in the Agents Manager widget provider**
+
+Read `apps/agents-manager/agents-manager-with-provider.jsx`. At the top of its root component, add:
+
+```jsx
+import { useShouldCoexistAiSurfaces } from '@automattic/agents-manager';
+import { AiSurfaceCoordinator } from '@automattic/data-stores';
+// ...inside the component body:
+AiSurfaceCoordinator.useAiSurfaceCoordinator( useShouldCoexistAiSurfaces() );
+```
+
+- [ ] **Step 2: Build the widget bundles**
+
+Run: `cd apps/agents-manager && yarn build` (or `yarn dev --sync` when sandboxing `widgets.wp.com`).
+Expected: build succeeds; no type errors.
+
+- [ ] **Step 3: Manual verification — Calypso (flag forced on)**
+
+Until the Jetpack backend exposes the flag, force it in dev by stubbing the query. Run `yarn start`, then in the browser console set the React Query cache or temporarily hard-code `useAiSurfaceCoexistence`'s `queryFn` to return `true`. Verify the behavior matrix from the spec:
+- Open Help Center, click the Agents icon → AM expands, HC drops to a stacked bar.
+- Re-open HC from its bar → HC expands, AM drops to a stacked bar.
+- Minimize both → two bars stacked bottom-right, most-recently-active on the bottom.
+- Dock AM, then open HC → both visible, HC card offset left of the rail.
+- Reload with both having been expanded → most-recently-active wins.
+
+Expected: matches the matrix. Capture before/after screenshots.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/agents-manager/agents-manager-with-provider.jsx
+git commit -m "Mount AI surface coordinator in the Agents Manager widget"
+```
+
+---
+
+## Task 12: Full type-check + test sweep before PR
+
+- [ ] **Step 1: Run the checks CI will run**
+
+```bash
+yarn typecheck-client
+yarn typecheck-packages
+yarn jest packages/data-stores/src/ai-surface-coordinator
+yarn jest packages/help-center
+yarn jest -c test/packages/jest.config.js --testPathPattern=agents-manager
+```
+
+Expected: all green. Fix any failures at the source (no `as any` / `@ts-ignore`).
+
+- [ ] **Step 2: Commit any fixes, then open a draft PR**
+
+Follow `.github/PULL_REQUEST_TEMPLATE.md`. Include testing instructions for **both** Calypso (`yarn start`) and Simple/Atomic/CIAB (sandbox `widgets.wp.com`, `cd apps/agents-manager && yarn dev --sync`). Reference Linear IDs, not URLs. Note the Jetpack backend dependency (flag exposure + Gutenberg dequeue removal) as a blocker for the widget Gutenberg path.
+
+---
+
+## Cross-repo dependency (tracked separately, not in this plan)
+
+In `jetpack-mu-wpcom/src/features/agents-manager/` (Jetpack monorepo):
+1. Expose `ai_surface_coexistence` through the same path that serves `unified_ai_chat`: the `/agents-manager/state` endpoint and the inline `agentsManagerData`. Gate it behind whatever rollout filter mirrors `agents_manager_use_unified_experience`.
+2. Stop dequeuing Help Center scripts on Gutenberg pages when `ai_surface_coexistence` is on (see the "Help Center dequeue" pitfall in `packages/agents-manager/AGENTS.md`).
+
+Until (1) ships, the flag resolves to `false` everywhere and behavior is exactly as today.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Coordinator (Approach A), shared registry → Tasks 1-5 (reconciler/layout/hook).
+- "At most one floating-expanded; opening one minimizes the other" → Tasks 1-2, verified Task 11.
+- Graceful no-op when one surface absent → Task 1 (present flag) + Task 5 (`!! select(KEY)`).
+- Boot reconciliation, most-recently-active wins → Task 2 + Task 5 (localStorage marker).
+- Docked AM coexists; HC offsets left of rail → reconciler `docked` exclusion (Task 1), `--ai-surface-rail-inset` (Tasks 4, 10).
+- Vertical stack, most-recent on bottom → Task 4 + Task 10.
+- Two masterbar launchers → Task 9.
+- Flag gating / rollout (flag on = coexist, off = today) → Task 6 (hook), Tasks 7-9 (gated mounts/branches).
+- Reader-chat / single-surface unaffected → no-op behavior (Tasks 1, 5).
+- Testing (coordinator state machine, stack slots, manual matrix) → Tasks 1-5 unit tests, Task 11 manual.
+
+**Placeholder scan:** Tasks 9 and 10 reference "the existing MasterbarHelpCenter element" and "if the agenttic container sets its own bottom" — these are deliberate reads-of-existing-code with a concrete decision attached (lift into a const; switch to `margin-block-end`), not TBDs, because the exact surrounding JSX/CSS must be read in-place. All new modules (Tasks 1-6) contain complete code.
+
+**Type consistency:** `SurfaceSnapshot`, `Surface`, `Command`, `CoordinationResult` are defined in Task 1 and used unchanged in Tasks 2, 4, 5. `computeCoordination`/`computeLayoutVars`/`useAiSurfaceCoordinator` names are stable across tasks. CSS var names come from the single `constants.ts` (Task 3) and are reused in Tasks 4, 5, 10. Store keys are imported from each store's existing `constants.ts`.

--- a/docs/superpowers/specs/2026-06-04-ai-surface-coexistence-design.md
+++ b/docs/superpowers/specs/2026-06-04-ai-surface-coexistence-design.md
@@ -2,7 +2,57 @@
 
 **Date:** 2026-06-04
 **Branch:** `add/ai-surface-coexistence`
-**Status:** Approved design — ready for implementation planning
+**Status:** Implemented and validated live on the Dashboard. This section
+records the design as built — see **"Revisions from live validation"** below for
+where the implementation diverged from the original design after testing in a
+running Calypso instance.
+
+## Revisions from live validation (2026-06-04)
+
+Live testing in a running Calypso dev instance surfaced three things the
+original design (written from code reading) got wrong or missed. The
+implementation reflects these corrections:
+
+1. **A third surface: the Dashboard interim omnibar.** The original design
+   covered the classic Calypso masterbar and the widgets path. But the new
+   Multi-site Dashboard (`/sites`, `client/dashboard/app/interim-omnibar/`)
+   renders Agents Manager via `omnibar-agents-manager.tsx`, gated on
+   `useShouldUseUnifiedAgent()` only. That gate now also honors the coexistence
+   flag. The shared Help Center component (and thus the coordinator) already
+   mounts here.
+
+2. **Agents Manager parks via `setIsOpen(false)`, not `isMinimized`.** In
+   Calypso/Dashboard, Agents Manager's closed state is the agenttic **"Ask AI"
+   compact bar** — a *persistent bottom-right launcher* shown whenever AM is not
+   open (`isOpen === false`). `isMinimized` is a wp-admin-only concept. So the
+   coordinator parks AM by dispatching `setIsOpen(false)` (collapsing to the Ask
+   AI bar), and treats AM as "expanded" when `isOpen && !docked`.
+
+3. **Asymmetric layout, not symmetric stacking.** Because the Ask AI bar is a
+   permanent fixture (not a transient pill), the design is no longer "two equal
+   pills stack." Instead **Help Center yields to the persistent Ask AI bar**:
+   whenever the bar is present, Help Center (its open card *and* its minimized
+   bar) shifts up by the bar height + gap (single `--ai-surface-hc-bottom-offset`
+   var). When both are minimized this still produces the desired vertical stack
+   (HC bar above the Ask AI bar). Agents Manager always owns the bottom-right
+   corner.
+
+   A competing `!important` fixed-position declaration on the draggable Help
+   Center card defeated the offset, so the coordinator's offset rule also uses
+   `!important` to match its priority.
+
+**Live-validated:** both surfaces load together; open-one-parks-the-other (both
+directions); HC sits cleanly above the Ask AI bar; both-minimized bars stack with
+an 8px gap and zero overlap; docked AM + open HC coexist with HC offset left of
+the rail; reload boot-reconciliation restores a clean state. **Not validated
+live:** the classic Calypso masterbar (routes redirect to Dashboard/wp-admin
+locally) and the widgets/wp-admin path (both are code-complete + unit-tested);
+the boot tie-break for "both persisted-expanded" (unit-tested only — the
+coordinator never lets both persist as expanded in-session).
+
+---
+
+**Original design status:** Approved design — ready for implementation planning
 
 ## Background
 

--- a/docs/superpowers/specs/2026-06-04-ai-surface-coexistence-design.md
+++ b/docs/superpowers/specs/2026-06-04-ai-surface-coexistence-design.md
@@ -237,3 +237,62 @@ planning time (new flag layered on top vs. repurposing the existing one).
   persistence backend).
 - Slot/offset hand-off mechanism across the two portals (CSS custom property vs. state).
 - New flag vs. repurposing `unified_ai_chat`.
+
+## Phase 2: launcher & layout refinements (live-driven)
+
+A second round of live feedback reshaped the launchers, the Agents Manager state
+model, and the minimized-bar layout. Implemented unless noted.
+
+**Launchers (Dashboard masterbar / omnibar)**
+- **Help Center keeps its dropdown.** `MasterbarHelpCenter` forces its
+  menu-panel dropdown on when coexisting (otherwise it is gated behind the
+  `calypso_help_center_menu_popover_increase_exposure` ExPlat experiment, so it
+  only appeared for users in that variation).
+- **Agents Manager gets a sparkle launcher, not a dropdown.** New
+  `MasterbarAgentsManagerLauncher` — a plain sparkle button that renders **only
+  when AM is fully hidden** (`isOpen === false`) and opens AM on click. When AM
+  is open or minimized, its panel / bar is the entry point so the launcher hides.
+- The AM masterbar icon is now an **AI sparkle** (was the WordPress `help`
+  question-mark, which made it indistinguishable from Help Center).
+
+**Agents Manager 3-state model (when coexisting)**
+- States: **open** (`isOpen && !minimized`) / **minimized** — the "Ask AI" bar
+  (`isOpen && minimized`) / **fully hidden** (`!isOpen`, nothing on screen).
+- Realized by treating AM as having a reopen trigger when coexisting:
+  `hasAdminBarTrigger ||= isCoexisting` in `agent-dock`, which makes the floating
+  chat hide on close (instead of leaving the persistent Ask AI bar) and allows
+  minimizing. The masterbar sparkle is the external reopen trigger.
+- The chat header shows the **Minimize** control when coexisting + undocked
+  (`chat-header` previously detected only the wp-admin DOM trigger).
+- The coordinator parks AM by **minimizing** it to the bar (`setIsMinimized`),
+  not fully hiding it.
+
+**Layout / alignment**
+- Help Center is matched to Agents Manager's **372px width** and a **shared
+  right edge** (`right: 16px`) when coexisting, gated by the
+  `is-ai-surface-coexisting` class the coordinator sets on `<html>`. The open
+  panel sits above the other surface's minimized bar via
+  `--ai-surface-hc-bottom-offset`.
+- **DECISION (not yet implemented): when BOTH are minimized, render the two bars
+  in a single shared container.** This is the brainstorm's "shared tray"
+  (option C), chosen over independent CSS-offset bars because two independently
+  positioned, different-width bars do not align cleanly. This supersedes the
+  both-minimized case of the CSS-offset approach and is the main remaining
+  implementation item. It requires a coordinator-owned container that both
+  surfaces portal their minimized bar into.
+
+**Cross-repo dependency (not changeable in Calypso)**
+- Renaming the Agents Manager minimized bar label from **"Ask AI" to "WordPress
+  Assistant"** requires a change in the external **`@automattic/agenttic-ui`**
+  package: the label is the hardcoded default `title` of agenttic-ui's internal
+  `MinimizedView`, and `AgentUI.Container` does not expose a `title` prop. Either
+  expose the prop in agenttic-ui (then pass it from `agent-chat`) or override the
+  `"Ask AI"` string in the `a8c-agenttic` text domain.
+
+**Validated live (Dashboard, clean load):** AM fully hidden by default with the
+sparkle + Help dropdown both shown; sparkle opens AM and hides itself; Help
+dropdown renders its menu panel; AM minimize control present when undocked. **Not
+yet done:** the shared-tray both-minimized container; the "WordPress Assistant"
+label (agenttic-ui); final visual alignment tuning of the open-above-minimized
+column (needs a clean browser — heavy live testing left persisted docked/open
+state that muddies local verification).

--- a/docs/superpowers/specs/2026-06-04-ai-surface-coexistence-design.md
+++ b/docs/superpowers/specs/2026-06-04-ai-surface-coexistence-design.md
@@ -1,0 +1,189 @@
+# Coexisting Help Center & Agents Manager — Design
+
+**Date:** 2026-06-04
+**Branch:** `add/ai-surface-coexistence`
+**Status:** Approved design — ready for implementation planning
+
+## Background
+
+Today the Help Center and Agents Manager are **mutually exclusive at mount time**. A
+single server flag (`unified_ai_chat`, surfaced via `useShouldUseUnifiedAgent()`) decides
+which one renders:
+
+- When the flag is **off**, Help Center mounts and the Agents Manager loader returns `null`.
+- When the flag is **on**, Agents Manager mounts and Help Center *suppresses its own portal
+  entirely* — `packages/help-center/src/components/help-center.tsx` returns `null` and never
+  creates its DOM container.
+- The masterbar (`client/layout/masterbar/logged-in.jsx`, `renderHelpCenter()`) shows exactly
+  **one** icon, branched on the flag.
+
+Because only one surface ever exists on the page, there is no runtime coordination.
+
+Key facts established during exploration:
+
+- Both surfaces already own a `@wordpress/data` store in `@automattic/data-stores`:
+  - `automattic/help-center` — `show`, `isMinimized` (both persisted).
+  - `automattic/agents-manager` — `isOpen`, `isMinimized`, `isDocked`, `floatingPosition`
+    (persisted) and `isSplitScreen` (session-only). Minimized state was recently added in
+    PR #111297; the undocked minimized state is the agenttic `minimized` bar.
+- **Both widget bundles externalize `@wordpress/data` to the global `window.wp.data`
+  registry** (`apps/help-center/webpack.config.js`, `apps/agents-manager/webpack.config.js`
+  via `DependencyExtractionWebpackPlugin`; `wp-data` appears in each `*.asset.json`), and both
+  register their stores by string key on that one singleton. So a coordinator can
+  `select()`/`dispatch()` across both stores in **both** Calypso and widgets.wp.com — no
+  cross-bundle messaging is required. The help-center wp-admin entry already checks for both
+  `#wp-admin-bar-agents-manager` and `#wp-admin-bar-help-center`, confirming they coexist.
+- Both undocked surfaces anchor to the **bottom-right** corner (Help Center: draggable card at
+  `right:50px; bottom:50px`, minimized bar docks to `bottom:0`; Agents Manager: FAB + floating
+  chat). Only Agents Manager has a **docked/sidebar** mode (fixed right rail, pushes page
+  content left, `z-index: 999999`).
+
+## Goal
+
+Load **both** surfaces on the same page and make them aware of each other so that:
+
+1. At most **one** surface is *expanded* at a time when both are floating.
+2. Opening one **auto-minimizes** the other (it is never fully dismissed by the act of opening
+   the other).
+3. Both can sit **minimized together**, their bars **stacked vertically** in the bottom-right.
+4. **Agents Manager docked** coexists peacefully with a floating Help Center (no mutual
+   exclusion in that case).
+
+This replaces the flag-driven, mount-time mutual exclusion with runtime coordination.
+
+## Non-goals
+
+- No new docking/sidebar capability for Help Center — only Agents Manager docks.
+- No merging of the two surfaces into one component or one store (that is Approach C, rejected
+  below).
+- No change to reader-chat or any other single-surface context's behavior.
+- No horizontal or "shared tray" arrangement of minimized bars (Approach B/C in stacking,
+  rejected).
+
+## Approaches considered
+
+**Coordination mechanism**
+
+- **A — Subscription coordinator (chosen).** A thin shared hook/module subscribes to both
+  stores and enforces the invariant by dispatching the surfaces' *existing* actions. Smallest
+  change, reuses existing state, surfaces stay ignorant of each other, trivially flag-gated,
+  works identically in Calypso and each widget bundle via the shared registry.
+- **B — Cross-store awareness inside each store's actions.** Teach each store's open action to
+  minimize the other. No new module, but the invariant is split across two files, each store
+  hard-depends on the other's key, and dispatch loops/ordering become a risk. Rejected.
+- **C — New shared coordinator store** owning `activeSurface` + stack order, with both surfaces
+  deriving visibility from it. Cleanest long-term shape, but a real refactor only justified if
+  more AI surfaces are coming. Rejected for now (revisit if a third surface appears).
+
+**Minimized-bar arrangement:** vertical stack (chosen) over horizontal row or shared-tray
+container.
+
+**Launchers:** two separate masterbar icons (chosen) over a single icon with in-surface switch
+or a chooser menu.
+
+## Design
+
+### 1. The coordinator
+
+A new `useAiSurfaceCoordinator()` hook (a small shared module; lives alongside the stores in
+`@automattic/data-stores` or a dedicated small package, decided at planning time), mounted
+**once per environment**: in the Calypso layout, and in each widget app entry that can host both
+surfaces. It:
+
+- Subscribes to `automattic/help-center` (`show`, `isMinimized`) and
+  `automattic/agents-manager` (`isOpen`, `isMinimized`, `isDocked`) on the shared
+  `window.wp.data` registry.
+- Enforces the invariant by dispatching the **existing** actions only —
+  `setShowHelpCenter`/`showHelpCenter`/`setIsMinimized` (help-center) and
+  `setIsOpen`/`setIsMinimized` (agents-manager). No new visibility logic is added inside the
+  surface components.
+- **No-ops gracefully when only one surface is present.** If the other store is not registered
+  (e.g. reader-chat public frontends, or a page that enqueues only one widget), the coordinator
+  does nothing, leaving single-surface behavior exactly as today.
+- Owns a small **persisted "last expanded surface"** marker used for boot reconciliation.
+- Guards against dispatch loops: a transition only fires when it actually changes state, and the
+  coordinator must not react to a minimize it just caused.
+
+### 2. Behavior rules
+
+- **Floating + floating:** when one surface becomes expanded (via its masterbar icon, or by
+  un-minimizing its bar), the coordinator sets the other to `isMinimized: true`.
+- **Docked AM + Help Center:** coexist. No mutual exclusion. Any floating Help Center element —
+  open card *or* minimized bar — offsets left by the sidebar width so it never overlaps the
+  rail. There is **no** "minimize-on-dock" action: to dock, Agents Manager must be open, which
+  (by the floating rule) means Help Center is already minimized or closed at that moment.
+- **Boot reconciliation:** if persisted state has *both* surfaces expanded, the coordinator
+  expands the **most-recently-active** surface (from the persisted marker) and minimizes the
+  other.
+
+#### Behavior matrix
+
+| Situation | Result |
+|---|---|
+| HC open, click Agents icon | AM expands; HC → minimized bar (stacked) |
+| AM open (floating), click Help icon | HC expands; AM → minimized bar (stacked) |
+| Both minimized | Two bars, vertical stack, bottom-right |
+| AM docked + open HC | Coexist — HC floats, offset left of the rail |
+| Dock AM | HC already minimized/closed (AM was open) → no action |
+| Reload, both were expanded | Most-recently-active expands; other minimizes |
+
+### 3. Stacking
+
+- Vertical stack in the bottom-right; the **most-recently-active** bar sits on the **bottom**
+  (nearest the corner), the other above it.
+- The coordinator assigns each *visible minimized* bar a slot index. Each bar computes its
+  bottom offset from the heights of the bars below it (Help Center's bar is ~56px;
+  Agents Manager uses the agenttic `minimized` bar). The mechanism for handing the slot/offset
+  to each bar (a shared CSS custom property vs. a prop/state read) is decided at planning time;
+  the constraint is that it must work across the two separate portals the bars render into.
+- When Agents Manager is docked, the same stack applies but shifted left of the rail.
+- **Mobile:** still at most one expanded (full-width bottom sheet); minimized bars use the same
+  vertical stack at the bottom edge.
+
+### 4. Launchers
+
+Two masterbar / admin-bar icons — a Help (`?`) icon and an Agents/AI (`✨`) icon — each toggling
+its own surface. This replaces the single-icon, flag-branched `renderHelpCenter()` in
+`client/layout/masterbar/logged-in.jsx`. Clicking one while the other is expanded triggers the
+auto-minimize rule via the coordinator.
+
+### 5. Gating and rollout
+
+The coexistence behavior is gated behind a feature flag so it can ship dark and ramp:
+
+- **Flag on:** both loaders (`client/layout/help-center-loader.tsx`,
+  `client/layout/agents-manager-loader.tsx`) mount; `help-center.tsx` stops self-suppressing;
+  the masterbar renders both icons; the coordinator runs.
+- **Flag off:** today's exact behavior is preserved (mount-time mutual exclusion, single icon).
+
+The relationship between the new flag and the existing `unified_ai_chat` flag is resolved at
+planning time (new flag layered on top vs. repurposing the existing one).
+
+### 6. Components touched (indicative)
+
+- New: `useAiSurfaceCoordinator()` + its persisted "last expanded surface" marker.
+- `packages/help-center/src/components/help-center.tsx` — stop self-suppressing under the flag.
+- `packages/help-center` container/scss — offset-left positioning when AM is docked; stack slot.
+- `packages/agents-manager` — expose/consume stack slot for its minimized bar; offset-left math
+  is moot for the docked rail but relevant to its minimized bar's position.
+- `client/layout/help-center-loader.tsx`, `client/layout/agents-manager-loader.tsx` — both mount
+  under the flag.
+- `client/layout/masterbar/logged-in.jsx` — render both icons under the flag.
+- Widget entries in `apps/help-center` and `apps/agents-manager` — mount the coordinator.
+
+## Testing
+
+- **Coordinator unit tests:** every transition in the behavior matrix; no dispatch loops;
+  single-surface no-op; boot reconciliation (both-expanded → most-recently-active wins);
+  docked-AM coexistence (opening HC does not minimize a docked AM).
+- **Component tests:** the two minimized bars receive correct stack slot / offset; Help Center
+  offsets left when AM is docked.
+- **Manual matrix:** run the full behavior matrix in both Calypso and a wp-admin page that
+  enqueues both widgets, desktop and mobile.
+
+## Open items for planning
+
+- Exact home of the coordinator module and the "last expanded surface" marker (which store /
+  persistence backend).
+- Slot/offset hand-off mechanism across the two portals (CSS custom property vs. state).
+- New flag vs. repurposing `unified_ai_chat`.

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -14,6 +14,7 @@ import { useSetupCustomActions } from '../../hooks/custom-actions';
 import useAdminBarIntegration from '../../hooks/use-admin-bar-integration';
 import useAgentLayoutManager from '../../hooks/use-agent-layout-manager';
 import useReaderChatPersistence from '../../hooks/use-reader-chat-persistence';
+import { useShouldCoexistAiSurfaces } from '../../hooks/use-should-coexist-ai-surfaces';
 import { useShouldUseUnifiedAgent } from '../../hooks/use-should-use-unified-agent';
 import { AGENTS_MANAGER_STORE } from '../../stores';
 import { LocalConversationListItem } from '../../types';
@@ -136,8 +137,13 @@ export default function AgentDock( {
 			isSplitScreen,
 		} );
 
+	// When coexisting with Help Center, an external masterbar sparkle reopens the
+	// chat, so AM behaves as if it has a trigger: it fully hides on close (rather
+	// than leaving the persistent "Ask AI" bar) and can minimize to a bar.
+	const isCoexisting = useShouldCoexistAiSurfaces();
+
 	// WP admin bar integration. Returns whether a trigger button can reopen the chat.
-	const hasAdminBarTrigger = useAdminBarIntegration( {
+	const hasAdminBarButton = useAdminBarIntegration( {
 		isOpen: isPersistedOpen,
 		sectionName,
 		maybeOpenChat: () => {
@@ -154,6 +160,7 @@ export default function AgentDock( {
 		},
 		navigate,
 	} );
+	const hasAdminBarTrigger = hasAdminBarButton || isCoexisting;
 
 	useSetupCustomActions( {
 		canDock,

--- a/packages/agents-manager/src/components/agent-dock/style.scss
+++ b/packages/agents-manager/src/components/agent-dock/style.scss
@@ -703,7 +703,6 @@ body.post-new-php.agents-manager-sidebar-container {
 .agents-manager-chat--undocked .agenttic.Chat-module_container.Chat-module_floating {
 	// Fix the undocked chat overlapping with the nav menu
 	z-index: 9999;
-	margin-block-end: var( --ai-surface-am-stack-bottom, 0 );
 
 	.big-sky__dock__menu__variation-picker .edit-site-global-styles-variations_item {
 		&:not( .is-active ):hover {

--- a/packages/agents-manager/src/components/agent-dock/style.scss
+++ b/packages/agents-manager/src/components/agent-dock/style.scss
@@ -699,10 +699,21 @@ body.post-new-php.agents-manager-sidebar-container {
 	}
 }
 
+// Coexistence: widen the floating chat to the shared 410px column width so it
+// matches Help Center (the wider option), in both open and minimized states.
+.is-ai-surface-coexisting
+	.agents-manager-chat--undocked
+	.agenttic.Chat-module_container.Chat-module_floating {
+	width: 410px;
+}
+
 /* Agenttic UI: Styles for the undocked chat */
 .agents-manager-chat--undocked .agenttic.Chat-module_container.Chat-module_floating {
 	// Fix the undocked chat overlapping with the nav menu
 	z-index: 9999;
+	// Lift the open panel above Help Center's minimized bar when coexisting
+	// (0 unless the coordinator sets it).
+	margin-block-end: var( --ai-surface-am-bottom-offset, 0 );
 
 	.big-sky__dock__menu__variation-picker .edit-site-global-styles-variations_item {
 		&:not( .is-active ):hover {

--- a/packages/agents-manager/src/components/agent-dock/style.scss
+++ b/packages/agents-manager/src/components/agent-dock/style.scss
@@ -714,6 +714,34 @@ body.post-new-php.agents-manager-sidebar-container {
 	right: 16px !important;
 	bottom: 16px !important;
 	transform: none !important;
+
+	// Agenttic caps the inner content/pill narrower than the container; let them
+	// fill the shared 410px width so the minimized bar lines up with Help Center.
+	.Chat-module_content {
+		width: 100% !important;
+	}
+
+	// On the minimized bar specifically, drop agenttic's 8px content padding so
+	// the pill fills the full 410px width (right edge at 16px like Help Center)
+	// and sits flush against Help Center's bar above it. Scoped via :has so the
+	// open panel keeps its inset.
+	.Chat-module_content:has( .MinimizedView-module_button ) {
+		padding: 0 !important;
+	}
+
+	.MinimizedView-module_button {
+		width: 100% !important;
+	}
+}
+
+// When both surfaces are minimized, square the Agents Manager bar's top corners
+// so it sits flush under Help Center's bar (which already squares its bottom),
+// reading as one stacked container rounded only on the outer edges.
+.is-ai-surfaces-both-minimized
+	.agents-manager-chat--undocked
+	.MinimizedView-module_button {
+	border-start-start-radius: 0 !important;
+	border-start-end-radius: 0 !important;
 }
 
 /* Agenttic UI: Styles for the undocked chat */

--- a/packages/agents-manager/src/components/agent-dock/style.scss
+++ b/packages/agents-manager/src/components/agent-dock/style.scss
@@ -714,6 +714,10 @@ body.post-new-php.agents-manager-sidebar-container {
 	right: 16px !important;
 	bottom: 16px !important;
 	transform: none !important;
+	// The chat is a fixed column here, so disable agenttic's `transition: all`
+	// which otherwise animates the recomputed position — a weird slide-in from
+	// the left when opening or expanding from the minimized bar.
+	transition: none !important;
 
 	// Agenttic caps the inner content/pill narrower than the container; let them
 	// fill the shared 410px width so the minimized bar lines up with Help Center.

--- a/packages/agents-manager/src/components/agent-dock/style.scss
+++ b/packages/agents-manager/src/components/agent-dock/style.scss
@@ -699,42 +699,23 @@ body.post-new-php.agents-manager-sidebar-container {
 	}
 }
 
-// Coexistence: pin the floating chat into a fixed bottom-right column aligned
-// with Help Center — shared 410px width and 16px right/bottom insets, in both
-// open and minimized states. Agenttic positions the chat with a width-derived
-// `translateX`, which a CSS width change alone would leave stale (pushing it
-// off-screen); right-anchoring and clearing the transform keeps it aligned.
-// (This fixes the chat in place, so it is no longer drag-repositionable while
-// coexisting — intended for the aligned-column layout.)
+// Coexistence: keep agenttic's native width and positioning for the floating
+// chat (overriding them disrupts its JS-driven entry/state animation, causing a
+// slide-in from the left). Only let the inner content/pill fill the bar's width
+// so the minimized bar lines up with Help Center, which is matched to the same
+// native width.
 .is-ai-surface-coexisting
 	.agents-manager-chat--undocked
 	.agenttic.Chat-module_container.Chat-module_floating {
-	width: 410px;
-	left: auto !important;
-	right: 16px !important;
-	bottom: 16px !important;
-	transform: none !important;
-	// The chat is a fixed column here, so disable agenttic's `transition: all`
-	// which otherwise animates the recomputed position — a weird slide-in from
-	// the left when opening or expanding from the minimized bar.
-	transition: none !important;
-
-	// Agenttic caps the inner content/pill narrower than the container; let them
-	// fill the shared 410px width so the minimized bar lines up with Help Center.
-	.Chat-module_content {
-		width: 100% !important;
-	}
-
-	// On the minimized bar specifically, drop agenttic's 8px content padding so
-	// the pill fills the full 410px width (right edge at 16px like Help Center)
-	// and sits flush against Help Center's bar above it. Scoped via :has so the
-	// open panel keeps its inset.
+	// On the minimized bar only, drop agenttic's 8px content padding and let the
+	// pill fill the bar so it lines up with Help Center's bar above it. Scoped
+	// via :has so the open panel keeps agenttic's native sizing untouched.
 	.Chat-module_content:has( .MinimizedView-module_button ) {
 		padding: 0 !important;
-	}
 
-	.MinimizedView-module_button {
-		width: 100% !important;
+		.MinimizedView-module_button {
+			width: 100% !important;
+		}
 	}
 }
 

--- a/packages/agents-manager/src/components/agent-dock/style.scss
+++ b/packages/agents-manager/src/components/agent-dock/style.scss
@@ -699,12 +699,21 @@ body.post-new-php.agents-manager-sidebar-container {
 	}
 }
 
-// Coexistence: widen the floating chat to the shared 410px column width so it
-// matches Help Center (the wider option), in both open and minimized states.
+// Coexistence: pin the floating chat into a fixed bottom-right column aligned
+// with Help Center — shared 410px width and 16px right/bottom insets, in both
+// open and minimized states. Agenttic positions the chat with a width-derived
+// `translateX`, which a CSS width change alone would leave stale (pushing it
+// off-screen); right-anchoring and clearing the transform keeps it aligned.
+// (This fixes the chat in place, so it is no longer drag-repositionable while
+// coexisting — intended for the aligned-column layout.)
 .is-ai-surface-coexisting
 	.agents-manager-chat--undocked
 	.agenttic.Chat-module_container.Chat-module_floating {
 	width: 410px;
+	left: auto !important;
+	right: 16px !important;
+	bottom: 16px !important;
+	transform: none !important;
 }
 
 /* Agenttic UI: Styles for the undocked chat */

--- a/packages/agents-manager/src/components/agent-dock/style.scss
+++ b/packages/agents-manager/src/components/agent-dock/style.scss
@@ -703,6 +703,7 @@ body.post-new-php.agents-manager-sidebar-container {
 .agents-manager-chat--undocked .agenttic.Chat-module_container.Chat-module_floating {
 	// Fix the undocked chat overlapping with the nav menu
 	z-index: 9999;
+	margin-block-end: var( --ai-surface-am-stack-bottom, 0 );
 
 	.big-sky__dock__menu__variation-picker .edit-site-global-styles-variations_item {
 		&:not( .is-active ):hover {

--- a/packages/agents-manager/src/components/chat-header/index.tsx
+++ b/packages/agents-manager/src/components/chat-header/index.tsx
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { close, lineSolid, moreVertical, backup, chevronLeft, Icon } from '@wordpress/icons';
 import { useNavigate } from 'react-router-dom';
 import { ADMIN_BAR_BUTTON_ID } from '../../hooks/use-admin-bar-integration';
+import { useShouldCoexistAiSurfaces } from '../../hooks/use-should-coexist-ai-surfaces';
 import { AGENTS_MANAGER_STORE } from '../../stores';
 import { isReaderChatHost } from '../../utils/is-reader-chat-agent';
 import { isJetpackAiSidebarPreviewFeatureEnabled } from '../../utils/jetpack-ai-sidebar-preview';
@@ -31,11 +32,15 @@ export default function ChatHeader( { onClose, options, title, onBack }: Props )
 	const [ hasAdminBarTrigger ] = useState(
 		() => !! document.getElementById( ADMIN_BAR_BUTTON_ID )
 	);
+	// When coexisting with Help Center, the masterbar sparkle reopens the chat,
+	// so the floating chat can be minimized to its bar just like in wp-admin.
+	const isCoexisting = useShouldCoexistAiSurfaces();
 
 	const showChatHistory =
 		! isReaderChatHost() && isJetpackAiSidebarPreviewFeatureEnabled( 'chatHistory' );
-	// Minimize only applies to the floating chat reachable from the WP admin bar.
-	const showMinimize = hasAdminBarTrigger && ! isDocked;
+	// Minimize only applies to the floating chat reachable from a reopen trigger
+	// (the WP admin bar, or the masterbar sparkle when coexisting).
+	const showMinimize = ( hasAdminBarTrigger || isCoexisting ) && ! isDocked;
 
 	return (
 		<div className="agents-manager-chat-header">

--- a/packages/agents-manager/src/hooks/use-should-coexist-ai-surfaces.ts
+++ b/packages/agents-manager/src/hooks/use-should-coexist-ai-surfaces.ts
@@ -3,5 +3,5 @@ import { useAiSurfaceCoexistence } from './use-unified-ai-chat';
 
 export const useShouldCoexistAiSurfaces = () => {
 	const { data } = useAiSurfaceCoexistence();
-	return !! data;
+	return !! data || true; // TEMP: force-on for local validation (revert me)
 };

--- a/packages/agents-manager/src/hooks/use-should-coexist-ai-surfaces.ts
+++ b/packages/agents-manager/src/hooks/use-should-coexist-ai-surfaces.ts
@@ -1,0 +1,7 @@
+/* eslint-disable no-restricted-imports */
+import { useAiSurfaceCoexistence } from './use-unified-ai-chat';
+
+export const useShouldCoexistAiSurfaces = () => {
+	const { data } = useAiSurfaceCoexistence();
+	return !! data;
+};

--- a/packages/agents-manager/src/hooks/use-unified-ai-chat.ts
+++ b/packages/agents-manager/src/hooks/use-unified-ai-chat.ts
@@ -49,3 +49,31 @@ export function useUnifiedAiChat( enabled = true ) {
 		staleTime: 300000, // 5 minutes
 	} );
 }
+
+interface CoexistenceStateResponse {
+	ai_surface_coexistence?: boolean;
+}
+
+/**
+ * Determines whether Help Center and Agents Manager should coexist (both
+ * loaded, runtime-coordinated) instead of being mutually exclusive.
+ * Mirrors useUnifiedAiChat's hybrid inline/endpoint approach.
+ */
+export function useAiSurfaceCoexistence( enabled = true ) {
+	return useQuery< boolean, Error >( {
+		queryKey: [ 'ai-surface-coexistence' ],
+		queryFn: async () => {
+			if ( canAccessWpcomApis() ) {
+				const response: CoexistenceStateResponse = await wpcomRequest( {
+					path: '/agents-manager/state?key=ai_surface_coexistence',
+					apiNamespace: 'wpcom/v2',
+				} );
+				return response.ai_surface_coexistence ?? false;
+			}
+			return false;
+		},
+		enabled,
+		refetchOnWindowFocus: false,
+		staleTime: 300000,
+	} );
+}

--- a/packages/agents-manager/src/index.ts
+++ b/packages/agents-manager/src/index.ts
@@ -21,6 +21,7 @@ export type {
 } from './types';
 
 export { useShouldUseUnifiedAgent } from './hooks/use-should-use-unified-agent';
+export { useShouldCoexistAiSurfaces } from './hooks/use-should-coexist-ai-surfaces';
 export { useImageUpload } from './hooks/use-image-upload';
 
 // Feedback exports

--- a/packages/data-stores/src/ai-surface-coordinator/constants.ts
+++ b/packages/data-stores/src/ai-surface-coordinator/constants.ts
@@ -1,8 +1,8 @@
 // Height of the Agents Manager "Ask AI" compact bar, in px. Matches Help
 // Center's own minimized bar height ($head-foot-height, 56px).
 export const MINIMIZED_BAR_HEIGHT = 56;
-// Vertical gap left between Help Center and the Ask AI bar when stacked.
-export const STACK_GAP = 8;
+// Vertical gap left between an open panel and the other surface's minimized bar.
+export const STACK_GAP = 16;
 
 // Persisted (localStorage) marker for boot tie-break. Not server-backed: it is
 // a non-critical UI hint, so it avoids a backend allowed-key change.
@@ -15,5 +15,8 @@ export const LAST_EXPANDED_STORAGE_KEY = 'ai-surface-last-expanded';
 // when that bar occupies the bottom-right corner, Help Center (its open card
 // and its minimized bar) shifts up by this offset to sit above it.
 export const CSS_VAR_HC_BOTTOM_OFFSET = '--ai-surface-hc-bottom-offset';
+// Bottom offset lifting the Agents Manager open panel above Help Center's
+// minimized bar (the symmetric counterpart of the HC offset).
+export const CSS_VAR_AM_BOTTOM_OFFSET = '--ai-surface-am-bottom-offset';
 // Extra inline-end inset for Help Center to clear a docked Agents Manager rail.
 export const CSS_VAR_RAIL_INSET = '--ai-surface-rail-inset';

--- a/packages/data-stores/src/ai-surface-coordinator/constants.ts
+++ b/packages/data-stores/src/ai-surface-coordinator/constants.ts
@@ -1,6 +1,9 @@
-// Height of the Agents Manager "Ask AI" compact bar, in px. Matches Help
-// Center's own minimized bar height ($head-foot-height, 56px).
+// Visible height of Help Center's minimized bar, in px ($head-foot-height).
 export const MINIMIZED_BAR_HEIGHT = 56;
+// Visible height of Agents Manager's minimized "Ask AI" bar, in px. It is
+// shorter than Help Center's bar (agenttic's MinimizedView), so offsets that
+// stack against it use this value rather than MINIMIZED_BAR_HEIGHT.
+export const AM_MINIMIZED_BAR_HEIGHT = 40;
 // Vertical gap left between an open panel and the other surface's minimized bar.
 export const STACK_GAP = 16;
 

--- a/packages/data-stores/src/ai-surface-coordinator/constants.ts
+++ b/packages/data-stores/src/ai-surface-coordinator/constants.ts
@@ -1,0 +1,15 @@
+// Height of each surface's minimized bar, in px. Help Center's bar is
+// $head-foot-height (56px); Agents Manager's agenttic minimized bar matches.
+export const MINIMIZED_BAR_HEIGHT = 56;
+// Vertical gap between stacked minimized bars, in px.
+export const STACK_GAP = 8;
+
+// Persisted (localStorage) marker for boot tie-break. Not server-backed: it is
+// a non-critical UI hint, so it avoids a backend allowed-key change.
+export const LAST_EXPANDED_STORAGE_KEY = 'ai-surface-last-expanded';
+
+// CSS custom properties written on :root and consumed by each surface's SCSS.
+// Each defaults (when unset) to the surface's pre-coexistence value.
+export const CSS_VAR_HC_STACK_BOTTOM = '--ai-surface-hc-stack-bottom';
+export const CSS_VAR_AM_STACK_BOTTOM = '--ai-surface-am-stack-bottom';
+export const CSS_VAR_RAIL_INSET = '--ai-surface-rail-inset';

--- a/packages/data-stores/src/ai-surface-coordinator/constants.ts
+++ b/packages/data-stores/src/ai-surface-coordinator/constants.ts
@@ -1,7 +1,7 @@
-// Height of each surface's minimized bar, in px. Help Center's bar is
-// $head-foot-height (56px); Agents Manager's agenttic minimized bar matches.
+// Height of the Agents Manager "Ask AI" compact bar, in px. Matches Help
+// Center's own minimized bar height ($head-foot-height, 56px).
 export const MINIMIZED_BAR_HEIGHT = 56;
-// Vertical gap between stacked minimized bars, in px.
+// Vertical gap left between Help Center and the Ask AI bar when stacked.
 export const STACK_GAP = 8;
 
 // Persisted (localStorage) marker for boot tie-break. Not server-backed: it is
@@ -10,6 +10,10 @@ export const LAST_EXPANDED_STORAGE_KEY = 'ai-surface-last-expanded';
 
 // CSS custom properties written on :root and consumed by each surface's SCSS.
 // Each defaults (when unset) to the surface's pre-coexistence value.
-export const CSS_VAR_HC_STACK_BOTTOM = '--ai-surface-hc-stack-bottom';
-export const CSS_VAR_AM_STACK_BOTTOM = '--ai-surface-am-stack-bottom';
+//
+// Help Center yields to Agents Manager's persistent "Ask AI" launcher bar:
+// when that bar occupies the bottom-right corner, Help Center (its open card
+// and its minimized bar) shifts up by this offset to sit above it.
+export const CSS_VAR_HC_BOTTOM_OFFSET = '--ai-surface-hc-bottom-offset';
+// Extra inline-end inset for Help Center to clear a docked Agents Manager rail.
 export const CSS_VAR_RAIL_INSET = '--ai-surface-rail-inset';

--- a/packages/data-stores/src/ai-surface-coordinator/index.ts
+++ b/packages/data-stores/src/ai-surface-coordinator/index.ts
@@ -118,13 +118,28 @@ export function useAiSurfaceCoordinator( enabled: boolean ) {
 			}
 
 			applyLayoutVars( computeLayoutVars( next ) );
+
+			// Mark when both surfaces are minimized so their bars can be styled as
+			// one stacked container (flush, rounded only on the outer edges).
+			const bothMinimized =
+				next.helpCenter.present &&
+				next.helpCenter.shown &&
+				next.helpCenter.minimized &&
+				next.agentsManager.present &&
+				next.agentsManager.open &&
+				next.agentsManager.minimized &&
+				! next.agentsManager.docked;
+			document.documentElement.classList.toggle( 'is-ai-surfaces-both-minimized', bothMinimized );
 		};
 
 		reconcile(); // boot reconciliation
 		const unsubscribe = subscribe( reconcile );
 		return () => {
 			unsubscribe();
-			document.documentElement.classList.remove( 'is-ai-surface-coexisting' );
+			document.documentElement.classList.remove(
+				'is-ai-surface-coexisting',
+				'is-ai-surfaces-both-minimized'
+			);
 		};
 	}, [ enabled ] );
 }

--- a/packages/data-stores/src/ai-surface-coordinator/index.ts
+++ b/packages/data-stores/src/ai-surface-coordinator/index.ts
@@ -94,7 +94,10 @@ export function useAiSurfaceCoordinator( enabled: boolean ) {
 			try {
 				for ( const command of commands ) {
 					if ( command.surface === 'agents-manager' ) {
-						( dispatch( AM_KEY ) as AgentsManagerDispatch ).setIsMinimized( true );
+						// Agents Manager "parks" by closing its panel back to the
+						// persistent "Ask AI" bar — not via isMinimized (which is a
+						// wp-admin-only concept). setIsOpen( false ) is its real close.
+						( dispatch( AM_KEY ) as AgentsManagerDispatch ).setIsOpen( false );
 					} else {
 						( dispatch( HC_KEY ) as HelpCenterDispatch[ 'dispatch' ] ).setIsMinimized( true );
 					}
@@ -110,7 +113,7 @@ export function useAiSurfaceCoordinator( enabled: boolean ) {
 				prev = readSnapshot();
 			}
 
-			applyLayoutVars( computeLayoutVars( next, lastExpanded ) );
+			applyLayoutVars( computeLayoutVars( next ) );
 		};
 
 		reconcile(); // boot reconciliation

--- a/packages/data-stores/src/ai-surface-coordinator/index.ts
+++ b/packages/data-stores/src/ai-surface-coordinator/index.ts
@@ -5,18 +5,19 @@ import { STORE_KEY as HC_KEY } from '../help-center/constants';
 import { LAST_EXPANDED_STORAGE_KEY } from './constants';
 import { computeLayoutVars } from './layout';
 import { computeCoordination, type Surface, type SurfaceSnapshot } from './reconciler';
+import type {
+	AgentsManagerSelect,
+	Dispatch as AgentsManagerDispatch,
+} from '../agents-manager/types';
+import type { HelpCenterSelect, Dispatch as HelpCenterDispatch } from '../help-center/types';
 
 export * from './reconciler';
 export * from './layout';
 export * from './constants';
 
 function readSnapshot(): SurfaceSnapshot {
-	const hc = select( HC_KEY ) as
-		| { isHelpCenterShown: () => boolean; getIsMinimized: () => boolean }
-		| undefined;
-	const am = select( AM_KEY ) as
-		| { getIsOpen: () => boolean; getIsMinimized: () => boolean; getIsDocked: () => boolean }
-		| undefined;
+	const hc = select( HC_KEY ) as unknown as HelpCenterSelect | undefined;
+	const am = select( AM_KEY ) as unknown as AgentsManagerSelect | undefined;
 
 	return {
 		helpCenter: {
@@ -34,13 +35,21 @@ function readSnapshot(): SurfaceSnapshot {
 }
 
 function readLastExpanded(): Surface | null {
-	const v = window.localStorage.getItem( LAST_EXPANDED_STORAGE_KEY );
-	return v === 'help-center' || v === 'agents-manager' ? v : null;
+	try {
+		const v = window.localStorage.getItem( LAST_EXPANDED_STORAGE_KEY );
+		return v === 'help-center' || v === 'agents-manager' ? v : null;
+	} catch {
+		return null;
+	}
 }
 
 function writeLastExpanded( surface: Surface | null ) {
 	if ( surface ) {
-		window.localStorage.setItem( LAST_EXPANDED_STORAGE_KEY, surface );
+		try {
+			window.localStorage.setItem( LAST_EXPANDED_STORAGE_KEY, surface );
+		} catch {
+			// Non-critical UI hint; ignore storage failures (e.g. Safari private mode).
+		}
 	}
 }
 
@@ -64,8 +73,12 @@ export function useAiSurfaceCoordinator( enabled: boolean ) {
 
 		let prev = readSnapshot();
 		let lastExpanded = readLastExpanded();
+		let reconciling = false;
 
 		const reconcile = () => {
+			if ( reconciling ) {
+				return;
+			}
 			const next = readSnapshot();
 			const { commands, lastExpanded: nextLast } = computeCoordination( prev, next, lastExpanded );
 
@@ -74,20 +87,30 @@ export function useAiSurfaceCoordinator( enabled: boolean ) {
 				writeLastExpanded( lastExpanded );
 			}
 
-			for ( const command of commands ) {
-				if ( command.surface === 'agents-manager' ) {
-					( dispatch( AM_KEY ) as { setIsMinimized: ( v: boolean ) => void } ).setIsMinimized(
-						true
-					);
-				} else {
-					( dispatch( HC_KEY ) as { setIsMinimized: ( v: boolean ) => void } ).setIsMinimized(
-						true
-					);
+			// Snapshot prev BEFORE dispatching so re-entrant calls see a consistent baseline.
+			prev = next;
+
+			reconciling = true;
+			try {
+				for ( const command of commands ) {
+					if ( command.surface === 'agents-manager' ) {
+						( dispatch( AM_KEY ) as AgentsManagerDispatch ).setIsMinimized( true );
+					} else {
+						( dispatch( HC_KEY ) as HelpCenterDispatch[ 'dispatch' ] ).setIsMinimized( true );
+					}
 				}
+			} finally {
+				reconciling = false;
+			}
+
+			// After commands ran, bring prev in sync with the actual store state so
+			// subsequent ticks correctly detect new transitions (e.g. a surface
+			// re-expanding after having been minimized by a command above).
+			if ( commands.length > 0 ) {
+				prev = readSnapshot();
 			}
 
 			applyLayoutVars( computeLayoutVars( next, lastExpanded ) );
-			prev = next;
 		};
 
 		reconcile(); // boot reconciliation

--- a/packages/data-stores/src/ai-surface-coordinator/index.ts
+++ b/packages/data-stores/src/ai-surface-coordinator/index.ts
@@ -94,10 +94,10 @@ export function useAiSurfaceCoordinator( enabled: boolean ) {
 			try {
 				for ( const command of commands ) {
 					if ( command.surface === 'agents-manager' ) {
-						// Agents Manager "parks" by closing its panel back to the
-						// persistent "Ask AI" bar — not via isMinimized (which is a
-						// wp-admin-only concept). setIsOpen( false ) is its real close.
-						( dispatch( AM_KEY ) as AgentsManagerDispatch ).setIsOpen( false );
+						// Park Agents Manager by minimizing it to its "Ask AI" bar
+						// (stays open, just collapsed) rather than fully hiding it, so
+						// the user keeps a visible, one-click way back to it.
+						( dispatch( AM_KEY ) as AgentsManagerDispatch ).setIsMinimized( true );
 					} else {
 						( dispatch( HC_KEY ) as HelpCenterDispatch[ 'dispatch' ] ).setIsMinimized( true );
 					}

--- a/packages/data-stores/src/ai-surface-coordinator/index.ts
+++ b/packages/data-stores/src/ai-surface-coordinator/index.ts
@@ -1,0 +1,97 @@
+import { select, dispatch, subscribe } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { STORE_KEY as AM_KEY } from '../agents-manager/constants';
+import { STORE_KEY as HC_KEY } from '../help-center/constants';
+import { LAST_EXPANDED_STORAGE_KEY } from './constants';
+import { computeLayoutVars } from './layout';
+import { computeCoordination, type Surface, type SurfaceSnapshot } from './reconciler';
+
+export * from './reconciler';
+export * from './layout';
+export * from './constants';
+
+function readSnapshot(): SurfaceSnapshot {
+	const hc = select( HC_KEY ) as
+		| { isHelpCenterShown: () => boolean; getIsMinimized: () => boolean }
+		| undefined;
+	const am = select( AM_KEY ) as
+		| { getIsOpen: () => boolean; getIsMinimized: () => boolean; getIsDocked: () => boolean }
+		| undefined;
+
+	return {
+		helpCenter: {
+			present: !! hc,
+			shown: !! hc?.isHelpCenterShown(),
+			minimized: !! hc?.getIsMinimized(),
+		},
+		agentsManager: {
+			present: !! am,
+			open: !! am?.getIsOpen(),
+			minimized: !! am?.getIsMinimized(),
+			docked: !! am?.getIsDocked(),
+		},
+	};
+}
+
+function readLastExpanded(): Surface | null {
+	const v = window.localStorage.getItem( LAST_EXPANDED_STORAGE_KEY );
+	return v === 'help-center' || v === 'agents-manager' ? v : null;
+}
+
+function writeLastExpanded( surface: Surface | null ) {
+	if ( surface ) {
+		window.localStorage.setItem( LAST_EXPANDED_STORAGE_KEY, surface );
+	}
+}
+
+function applyLayoutVars( vars: Record< string, string > ) {
+	const root = document.documentElement;
+	for ( const [ name, value ] of Object.entries( vars ) ) {
+		root.style.setProperty( name, value );
+	}
+}
+
+/**
+ * Runtime coordinator that keeps at most one AI surface floating-expanded.
+ * Mount once per page (Calypso layout, each widget entry). Pass `enabled=false`
+ * to fully disable (flag off) — it then performs no subscription and no writes.
+ */
+export function useAiSurfaceCoordinator( enabled: boolean ) {
+	useEffect( () => {
+		if ( ! enabled ) {
+			return;
+		}
+
+		let prev = readSnapshot();
+		let lastExpanded = readLastExpanded();
+
+		const reconcile = () => {
+			const next = readSnapshot();
+			const { commands, lastExpanded: nextLast } = computeCoordination( prev, next, lastExpanded );
+
+			if ( nextLast !== lastExpanded ) {
+				lastExpanded = nextLast;
+				writeLastExpanded( lastExpanded );
+			}
+
+			for ( const command of commands ) {
+				if ( command.surface === 'agents-manager' ) {
+					( dispatch( AM_KEY ) as { setIsMinimized: ( v: boolean ) => void } ).setIsMinimized(
+						true
+					);
+				} else {
+					( dispatch( HC_KEY ) as { setIsMinimized: ( v: boolean ) => void } ).setIsMinimized(
+						true
+					);
+				}
+			}
+
+			applyLayoutVars( computeLayoutVars( next, lastExpanded ) );
+			prev = next;
+		};
+
+		reconcile(); // boot reconciliation
+		const unsubscribe = subscribe( reconcile );
+		return unsubscribe;
+	}, [ enabled ] );
+}

--- a/packages/data-stores/src/ai-surface-coordinator/index.ts
+++ b/packages/data-stores/src/ai-surface-coordinator/index.ts
@@ -71,6 +71,10 @@ export function useAiSurfaceCoordinator( enabled: boolean ) {
 			return;
 		}
 
+		// Mark the document so each surface's SCSS can apply coexistence-only
+		// layout (shared width + right edge) without affecting standalone mode.
+		document.documentElement.classList.add( 'is-ai-surface-coexisting' );
+
 		let prev = readSnapshot();
 		let lastExpanded = readLastExpanded();
 		let reconciling = false;
@@ -118,6 +122,9 @@ export function useAiSurfaceCoordinator( enabled: boolean ) {
 
 		reconcile(); // boot reconciliation
 		const unsubscribe = subscribe( reconcile );
-		return unsubscribe;
+		return () => {
+			unsubscribe();
+			document.documentElement.classList.remove( 'is-ai-surface-coexisting' );
+		};
 	}, [ enabled ] );
 }

--- a/packages/data-stores/src/ai-surface-coordinator/layout.ts
+++ b/packages/data-stores/src/ai-surface-coordinator/layout.ts
@@ -30,11 +30,14 @@ const amOpenPanel = ( s: SurfaceSnapshot ) =>
 export function computeLayoutVars( s: SurfaceSnapshot ): LayoutVars {
 	const raised = `${ MINIMIZED_BAR_HEIGHT + STACK_GAP }px`;
 
-	// Help Center always sits above Agents Manager's bar when that bar is present
-	// — whether Help Center is the open card (single-open case) or its own
-	// minimized bar (both-minimized case, which forms a single aligned column
-	// since both share the same width and right edge).
-	const hcBottomOffset = amBarPresent( s ) ? raised : '0px';
+	// Help Center always sits above Agents Manager's bar when that bar is present.
+	// When BOTH are minimized they form a single stacked container, so the bars
+	// sit flush (no gutter); when Help Center is the open card it keeps the
+	// gutter above the bar.
+	let hcBottomOffset = '0px';
+	if ( amBarPresent( s ) ) {
+		hcBottomOffset = hcBarPresent( s ) ? `${ MINIMIZED_BAR_HEIGHT }px` : raised;
+	}
 	// Agents Manager's open panel lifts above Help Center's minimized bar. (When
 	// AM is itself minimized, it stays at the bottom and Help Center lifts above
 	// it via the offset above — so they never both lift.)

--- a/packages/data-stores/src/ai-surface-coordinator/layout.ts
+++ b/packages/data-stores/src/ai-surface-coordinator/layout.ts
@@ -9,12 +9,16 @@ import type { SurfaceSnapshot } from './reconciler';
 export type LayoutVars = Record< string, string >;
 
 /**
- * Agents Manager's "Ask AI" compact bar is a persistent bottom-right launcher:
- * it is shown whenever Agents Manager is loaded but neither expanded nor docked.
+ * Agents Manager's "Ask AI" minimized bar sits in the bottom-right corner only
+ * while AM is open *and* minimized (not docked). When fully hidden (not open)
+ * nothing is shown there, and when expanded the panel — not a bar — is shown.
  * While that bar owns the corner, Help Center must sit above it.
  */
 const amBarPresent = ( s: SurfaceSnapshot ) =>
-	s.agentsManager.present && ! s.agentsManager.open && ! s.agentsManager.docked;
+	s.agentsManager.present &&
+	s.agentsManager.open &&
+	s.agentsManager.minimized &&
+	! s.agentsManager.docked;
 
 export function computeLayoutVars( s: SurfaceSnapshot ): LayoutVars {
 	return {

--- a/packages/data-stores/src/ai-surface-coordinator/layout.ts
+++ b/packages/data-stores/src/ai-surface-coordinator/layout.ts
@@ -1,39 +1,26 @@
 import {
 	MINIMIZED_BAR_HEIGHT,
 	STACK_GAP,
-	CSS_VAR_HC_STACK_BOTTOM,
-	CSS_VAR_AM_STACK_BOTTOM,
+	CSS_VAR_HC_BOTTOM_OFFSET,
 	CSS_VAR_RAIL_INSET,
 } from './constants';
-import type { Surface, SurfaceSnapshot } from './reconciler';
+import type { SurfaceSnapshot } from './reconciler';
 
 export type LayoutVars = Record< string, string >;
 
-const hcBarVisible = ( s: SurfaceSnapshot ) =>
-	s.helpCenter.present && s.helpCenter.shown && s.helpCenter.minimized;
+/**
+ * Agents Manager's "Ask AI" compact bar is a persistent bottom-right launcher:
+ * it is shown whenever Agents Manager is loaded but neither expanded nor docked.
+ * While that bar owns the corner, Help Center must sit above it.
+ */
+const amBarPresent = ( s: SurfaceSnapshot ) =>
+	s.agentsManager.present && ! s.agentsManager.open && ! s.agentsManager.docked;
 
-const amBarVisible = ( s: SurfaceSnapshot ) =>
-	s.agentsManager.present &&
-	s.agentsManager.open &&
-	s.agentsManager.minimized &&
-	! s.agentsManager.docked;
-
-export function computeLayoutVars( s: SurfaceSnapshot, lastExpanded: Surface | null ): LayoutVars {
-	const raised = `${ MINIMIZED_BAR_HEIGHT + STACK_GAP }px`;
-	const bothMinimized = hcBarVisible( s ) && amBarVisible( s );
-
-	let hcBottom = '0px';
-	let amBottom = '0px';
-	if ( bothMinimized ) {
-		// Most-recently-active bar sits on the bottom (slot 0); the other is raised.
-		const amOnBottom = lastExpanded === 'agents-manager';
-		hcBottom = amOnBottom ? raised : '0px';
-		amBottom = amOnBottom ? '0px' : raised;
-	}
-
+export function computeLayoutVars( s: SurfaceSnapshot ): LayoutVars {
 	return {
-		[ CSS_VAR_HC_STACK_BOTTOM ]: hcBottom,
-		[ CSS_VAR_AM_STACK_BOTTOM ]: amBottom,
+		[ CSS_VAR_HC_BOTTOM_OFFSET ]: amBarPresent( s )
+			? `${ MINIMIZED_BAR_HEIGHT + STACK_GAP }px`
+			: '0px',
 		[ CSS_VAR_RAIL_INSET ]: s.agentsManager.docked ? 'var(--am-sidebar-width, 350px)' : '0px',
 	};
 }

--- a/packages/data-stores/src/ai-surface-coordinator/layout.ts
+++ b/packages/data-stores/src/ai-surface-coordinator/layout.ts
@@ -2,29 +2,47 @@ import {
 	MINIMIZED_BAR_HEIGHT,
 	STACK_GAP,
 	CSS_VAR_HC_BOTTOM_OFFSET,
+	CSS_VAR_AM_BOTTOM_OFFSET,
 	CSS_VAR_RAIL_INSET,
 } from './constants';
 import type { SurfaceSnapshot } from './reconciler';
 
 export type LayoutVars = Record< string, string >;
 
-/**
- * Agents Manager's "Ask AI" minimized bar sits in the bottom-right corner only
- * while AM is open *and* minimized (not docked). When fully hidden (not open)
- * nothing is shown there, and when expanded the panel — not a bar — is shown.
- * While that bar owns the corner, Help Center must sit above it.
- */
+// Help Center's minimized bar sits in the bottom-right corner when shown + minimized.
+const hcBarPresent = ( s: SurfaceSnapshot ) =>
+	s.helpCenter.present && s.helpCenter.shown && s.helpCenter.minimized;
+
+// Help Center's open card is shown when it's shown and not minimized.
+const hcOpenCard = ( s: SurfaceSnapshot ) =>
+	s.helpCenter.present && s.helpCenter.shown && ! s.helpCenter.minimized;
+
+// Agents Manager's "Ask AI" minimized bar (open + minimized, undocked).
 const amBarPresent = ( s: SurfaceSnapshot ) =>
 	s.agentsManager.present &&
 	s.agentsManager.open &&
 	s.agentsManager.minimized &&
 	! s.agentsManager.docked;
 
+// Agents Manager's open floating panel (open, not minimized, undocked).
+const amOpenPanel = ( s: SurfaceSnapshot ) =>
+	s.agentsManager.present &&
+	s.agentsManager.open &&
+	! s.agentsManager.minimized &&
+	! s.agentsManager.docked;
+
 export function computeLayoutVars( s: SurfaceSnapshot ): LayoutVars {
+	const raised = `${ MINIMIZED_BAR_HEIGHT + STACK_GAP }px`;
+
+	// Whichever surface is OPEN lifts above the OTHER surface's minimized bar so
+	// the open panel sits cleanly above it. (Both-minimized is handled by a
+	// shared container, not these offsets.)
+	const hcBottomOffset = amBarPresent( s ) && hcOpenCard( s ) ? raised : '0px';
+	const amBottomOffset = hcBarPresent( s ) && amOpenPanel( s ) ? raised : '0px';
+
 	return {
-		[ CSS_VAR_HC_BOTTOM_OFFSET ]: amBarPresent( s )
-			? `${ MINIMIZED_BAR_HEIGHT + STACK_GAP }px`
-			: '0px',
+		[ CSS_VAR_HC_BOTTOM_OFFSET ]: hcBottomOffset,
+		[ CSS_VAR_AM_BOTTOM_OFFSET ]: amBottomOffset,
 		[ CSS_VAR_RAIL_INSET ]: s.agentsManager.docked ? 'var(--am-sidebar-width, 350px)' : '0px',
 	};
 }

--- a/packages/data-stores/src/ai-surface-coordinator/layout.ts
+++ b/packages/data-stores/src/ai-surface-coordinator/layout.ts
@@ -1,0 +1,39 @@
+import {
+	MINIMIZED_BAR_HEIGHT,
+	STACK_GAP,
+	CSS_VAR_HC_STACK_BOTTOM,
+	CSS_VAR_AM_STACK_BOTTOM,
+	CSS_VAR_RAIL_INSET,
+} from './constants';
+import type { Surface, SurfaceSnapshot } from './reconciler';
+
+export type LayoutVars = Record< string, string >;
+
+const hcBarVisible = ( s: SurfaceSnapshot ) =>
+	s.helpCenter.present && s.helpCenter.shown && s.helpCenter.minimized;
+
+const amBarVisible = ( s: SurfaceSnapshot ) =>
+	s.agentsManager.present &&
+	s.agentsManager.open &&
+	s.agentsManager.minimized &&
+	! s.agentsManager.docked;
+
+export function computeLayoutVars( s: SurfaceSnapshot, lastExpanded: Surface | null ): LayoutVars {
+	const raised = `${ MINIMIZED_BAR_HEIGHT + STACK_GAP }px`;
+	const bothMinimized = hcBarVisible( s ) && amBarVisible( s );
+
+	let hcBottom = '0px';
+	let amBottom = '0px';
+	if ( bothMinimized ) {
+		// Most-recently-active bar sits on the bottom (slot 0); the other is raised.
+		const amOnBottom = lastExpanded === 'agents-manager';
+		hcBottom = amOnBottom ? raised : '0px';
+		amBottom = amOnBottom ? '0px' : raised;
+	}
+
+	return {
+		[ CSS_VAR_HC_STACK_BOTTOM ]: hcBottom,
+		[ CSS_VAR_AM_STACK_BOTTOM ]: amBottom,
+		[ CSS_VAR_RAIL_INSET ]: s.agentsManager.docked ? 'var(--am-sidebar-width, 350px)' : '0px',
+	};
+}

--- a/packages/data-stores/src/ai-surface-coordinator/layout.ts
+++ b/packages/data-stores/src/ai-surface-coordinator/layout.ts
@@ -13,10 +13,6 @@ export type LayoutVars = Record< string, string >;
 const hcBarPresent = ( s: SurfaceSnapshot ) =>
 	s.helpCenter.present && s.helpCenter.shown && s.helpCenter.minimized;
 
-// Help Center's open card is shown when it's shown and not minimized.
-const hcOpenCard = ( s: SurfaceSnapshot ) =>
-	s.helpCenter.present && s.helpCenter.shown && ! s.helpCenter.minimized;
-
 // Agents Manager's "Ask AI" minimized bar (open + minimized, undocked).
 const amBarPresent = ( s: SurfaceSnapshot ) =>
 	s.agentsManager.present &&
@@ -34,10 +30,14 @@ const amOpenPanel = ( s: SurfaceSnapshot ) =>
 export function computeLayoutVars( s: SurfaceSnapshot ): LayoutVars {
 	const raised = `${ MINIMIZED_BAR_HEIGHT + STACK_GAP }px`;
 
-	// Whichever surface is OPEN lifts above the OTHER surface's minimized bar so
-	// the open panel sits cleanly above it. (Both-minimized is handled by a
-	// shared container, not these offsets.)
-	const hcBottomOffset = amBarPresent( s ) && hcOpenCard( s ) ? raised : '0px';
+	// Help Center always sits above Agents Manager's bar when that bar is present
+	// — whether Help Center is the open card (single-open case) or its own
+	// minimized bar (both-minimized case, which forms a single aligned column
+	// since both share the same width and right edge).
+	const hcBottomOffset = amBarPresent( s ) ? raised : '0px';
+	// Agents Manager's open panel lifts above Help Center's minimized bar. (When
+	// AM is itself minimized, it stays at the bottom and Help Center lifts above
+	// it via the offset above — so they never both lift.)
 	const amBottomOffset = hcBarPresent( s ) && amOpenPanel( s ) ? raised : '0px';
 
 	return {

--- a/packages/data-stores/src/ai-surface-coordinator/layout.ts
+++ b/packages/data-stores/src/ai-surface-coordinator/layout.ts
@@ -1,5 +1,6 @@
 import {
 	MINIMIZED_BAR_HEIGHT,
+	AM_MINIMIZED_BAR_HEIGHT,
 	STACK_GAP,
 	CSS_VAR_HC_BOTTOM_OFFSET,
 	CSS_VAR_AM_BOTTOM_OFFSET,
@@ -28,20 +29,21 @@ const amOpenPanel = ( s: SurfaceSnapshot ) =>
 	! s.agentsManager.docked;
 
 export function computeLayoutVars( s: SurfaceSnapshot ): LayoutVars {
-	const raised = `${ MINIMIZED_BAR_HEIGHT + STACK_GAP }px`;
-
 	// Help Center always sits above Agents Manager's bar when that bar is present.
-	// When BOTH are minimized they form a single stacked container, so the bars
-	// sit flush (no gutter); when Help Center is the open card it keeps the
-	// gutter above the bar.
+	// Offsets are measured against the AM bar's own (shorter) height: flush when
+	// both are minimized (one stacked container), or with a STACK_GAP gutter when
+	// Help Center is the open card above the bar.
 	let hcBottomOffset = '0px';
 	if ( amBarPresent( s ) ) {
-		hcBottomOffset = hcBarPresent( s ) ? `${ MINIMIZED_BAR_HEIGHT }px` : raised;
+		hcBottomOffset = hcBarPresent( s )
+			? `${ AM_MINIMIZED_BAR_HEIGHT }px`
+			: `${ AM_MINIMIZED_BAR_HEIGHT + STACK_GAP }px`;
 	}
-	// Agents Manager's open panel lifts above Help Center's minimized bar. (When
-	// AM is itself minimized, it stays at the bottom and Help Center lifts above
-	// it via the offset above — so they never both lift.)
-	const amBottomOffset = hcBarPresent( s ) && amOpenPanel( s ) ? raised : '0px';
+	// Agents Manager's open panel lifts above Help Center's (taller) minimized bar
+	// with a gutter. (When AM is itself minimized it stays at the bottom and Help
+	// Center lifts above it via the offset above — so they never both lift.)
+	const amBottomOffset =
+		hcBarPresent( s ) && amOpenPanel( s ) ? `${ MINIMIZED_BAR_HEIGHT + STACK_GAP }px` : '0px';
 
 	return {
 		[ CSS_VAR_HC_BOTTOM_OFFSET ]: hcBottomOffset,

--- a/packages/data-stores/src/ai-surface-coordinator/reconciler.ts
+++ b/packages/data-stores/src/ai-surface-coordinator/reconciler.ts
@@ -1,0 +1,66 @@
+export type Surface = 'help-center' | 'agents-manager';
+
+export interface SurfaceSnapshot {
+	helpCenter: { present: boolean; shown: boolean; minimized: boolean };
+	agentsManager: { present: boolean; open: boolean; minimized: boolean; docked: boolean };
+}
+
+export type Command =
+	| { type: 'minimize'; surface: 'help-center' }
+	| { type: 'minimize'; surface: 'agents-manager' };
+
+export interface CoordinationResult {
+	commands: Command[];
+	lastExpanded: Surface | null;
+}
+
+const isHelpCenterExpanded = ( s: SurfaceSnapshot ) =>
+	s.helpCenter.present && s.helpCenter.shown && ! s.helpCenter.minimized;
+
+// A docked Agents Manager lives in its own rail and never conflicts.
+const isAgentsManagerFloatingExpanded = ( s: SurfaceSnapshot ) =>
+	s.agentsManager.present &&
+	s.agentsManager.open &&
+	! s.agentsManager.minimized &&
+	! s.agentsManager.docked;
+
+export function computeCoordination(
+	prev: SurfaceSnapshot,
+	next: SurfaceSnapshot,
+	lastExpanded: Surface | null
+): CoordinationResult {
+	const hcExpanded = isHelpCenterExpanded( next );
+	const amExpanded = isAgentsManagerFloatingExpanded( next );
+
+	// Single (or zero) floating-expanded surface: record it, nothing to minimize.
+	if ( ! ( hcExpanded && amExpanded ) ) {
+		let sole: Surface | null;
+		if ( hcExpanded ) {
+			sole = 'help-center';
+		} else if ( amExpanded ) {
+			sole = 'agents-manager';
+		} else {
+			sole = lastExpanded;
+		}
+		return { commands: [], lastExpanded: sole };
+	}
+
+	// Both floating-expanded → keep one, minimize the other.
+	// Prefer the surface that just transitioned into expansion this tick.
+	const hcJustExpanded = hcExpanded && ! isHelpCenterExpanded( prev );
+	const amJustExpanded = amExpanded && ! isAgentsManagerFloatingExpanded( prev );
+
+	let keep: Surface;
+	if ( hcJustExpanded && ! amJustExpanded ) {
+		keep = 'help-center';
+	} else if ( amJustExpanded && ! hcJustExpanded ) {
+		keep = 'agents-manager';
+	} else {
+		// No single transition (e.g. boot from persisted state, or both at once):
+		// keep the most-recently-active; default to Agents Manager when unknown.
+		keep = lastExpanded ?? 'agents-manager';
+	}
+
+	const loser: Surface = keep === 'help-center' ? 'agents-manager' : 'help-center';
+	return { commands: [ { type: 'minimize', surface: loser } ], lastExpanded: keep };
+}

--- a/packages/data-stores/src/ai-surface-coordinator/test/index.test.tsx
+++ b/packages/data-stores/src/ai-surface-coordinator/test/index.test.tsx
@@ -36,7 +36,6 @@ function registerStubStores() {
 			) => ( action.type === 'SET' ? { ...state, ...action.payload } : state ),
 			actions: {
 				set: ( payload: Record< string, unknown > ) => ( { type: 'SET', payload } ),
-				// Mirrors the real store: closing the panel is setIsOpen( false ).
 				setIsOpen: ( isOpen: boolean ) => ( { type: 'SET', payload: { isOpen } } ),
 				setIsMinimized: ( isMinimized: boolean ) => ( {
 					type: 'SET',
@@ -71,7 +70,7 @@ beforeEach( () => {
 	} );
 } );
 
-it( 'closes Agents Manager when Help Center opens while AM is expanded', () => {
+it( 'minimizes Agents Manager to its bar when Help Center opens while AM is expanded', () => {
 	act( () => {
 		( dispatch( AM_KEY ) as AMDispatch ).set( { isOpen: true } );
 	} );
@@ -79,7 +78,8 @@ it( 'closes Agents Manager when Help Center opens while AM is expanded', () => {
 	act( () => {
 		( dispatch( HC_KEY ) as HCDispatch ).set( { showHelpCenter: true } );
 	} );
-	expect( select( AM_KEY ).getIsOpen() ).toBe( false );
+	expect( select( AM_KEY ).getIsMinimized() ).toBe( true );
+	expect( select( AM_KEY ).getIsOpen() ).toBe( true ); // still open, just minimized to the bar
 	unmount();
 } );
 
@@ -103,13 +103,14 @@ it( 'no-ops when disabled', () => {
 	act( () => {
 		( dispatch( HC_KEY ) as HCDispatch ).set( { showHelpCenter: true } );
 	} );
-	expect( select( AM_KEY ).getIsOpen() ).toBe( true );
+	expect( select( AM_KEY ).getIsMinimized() ).toBe( false );
 	unmount();
 } );
 
 it( "offsets Help Center above Agents Manager's Ask AI bar via a CSS custom property", () => {
-	// AM loaded but closed → its persistent Ask AI bar is present, HC shown.
+	// AM open + minimized → its Ask AI bar is shown, HC open above it.
 	act( () => {
+		( dispatch( AM_KEY ) as AMDispatch ).set( { isOpen: true, isMinimized: true } );
 		( dispatch( HC_KEY ) as HCDispatch ).set( { showHelpCenter: true } );
 	} );
 	const { unmount } = renderHook( () => useAiSurfaceCoordinator( true ) );
@@ -127,15 +128,15 @@ it( 'does NOT coordinate after unmount', () => {
 	const { unmount } = renderHook( () => useAiSurfaceCoordinator( true ) );
 	unmount();
 
-	// After unmount, opening HC must NOT close AM.
+	// After unmount, opening HC must NOT minimize AM.
 	act( () => {
 		( dispatch( HC_KEY ) as HCDispatch ).set( { showHelpCenter: true } );
 	} );
-	expect( select( AM_KEY ).getIsOpen() ).toBe( true );
+	expect( select( AM_KEY ).getIsMinimized() ).toBe( false );
 } );
 
 it( 'handles a second conflict correctly after a first (re-entrancy / stale prev)', () => {
-	// Round 1: AM open, HC opens → AM is closed.
+	// Round 1: AM open, HC opens → AM minimized to its bar.
 	act( () => {
 		( dispatch( AM_KEY ) as AMDispatch ).set( { isOpen: true } );
 	} );
@@ -143,12 +144,12 @@ it( 'handles a second conflict correctly after a first (re-entrancy / stale prev
 	act( () => {
 		( dispatch( HC_KEY ) as HCDispatch ).set( { showHelpCenter: true } );
 	} );
-	expect( select( AM_KEY ).getIsOpen() ).toBe( false );
+	expect( select( AM_KEY ).getIsMinimized() ).toBe( true );
 
-	// Round 2: AM re-expands while HC is still shown → AM just-expanded wins,
-	// so Help Center is minimized.
+	// Round 2: AM un-minimizes (re-expands) while HC is still shown → AM just
+	// became expanded, so Help Center is minimized.
 	act( () => {
-		( dispatch( AM_KEY ) as AMDispatch ).set( { isOpen: true } );
+		( dispatch( AM_KEY ) as AMDispatch ).set( { isMinimized: false } );
 	} );
 	expect( select( HC_KEY ).getIsMinimized() ).toBe( true );
 

--- a/packages/data-stores/src/ai-surface-coordinator/test/index.test.tsx
+++ b/packages/data-stores/src/ai-surface-coordinator/test/index.test.tsx
@@ -116,7 +116,7 @@ it( "offsets Help Center above Agents Manager's Ask AI bar via a CSS custom prop
 	const { unmount } = renderHook( () => useAiSurfaceCoordinator( true ) );
 
 	const root = document.documentElement;
-	expect( root.style.getPropertyValue( CSS_VAR_HC_BOTTOM_OFFSET ) ).toBe( '72px' ); // 56 + 16
+	expect( root.style.getPropertyValue( CSS_VAR_HC_BOTTOM_OFFSET ) ).toBe( '56px' ); // AM bar 40 + gap 16
 	expect( root.style.getPropertyValue( CSS_VAR_RAIL_INSET ) ).toBe( '0px' );
 	unmount();
 } );

--- a/packages/data-stores/src/ai-surface-coordinator/test/index.test.tsx
+++ b/packages/data-stores/src/ai-surface-coordinator/test/index.test.tsx
@@ -5,7 +5,7 @@ import { renderHook, act } from '@testing-library/react';
 import { dispatch, register, createReduxStore, select } from '@wordpress/data';
 import { STORE_KEY as AM_KEY } from '../../agents-manager/constants';
 import { STORE_KEY as HC_KEY } from '../../help-center/constants';
-import { CSS_VAR_AM_STACK_BOTTOM, CSS_VAR_HC_STACK_BOTTOM, CSS_VAR_RAIL_INSET } from '../constants';
+import { CSS_VAR_HC_BOTTOM_OFFSET, CSS_VAR_RAIL_INSET } from '../constants';
 import { useAiSurfaceCoordinator } from '../index';
 
 function registerStubStores() {
@@ -36,6 +36,8 @@ function registerStubStores() {
 			) => ( action.type === 'SET' ? { ...state, ...action.payload } : state ),
 			actions: {
 				set: ( payload: Record< string, unknown > ) => ( { type: 'SET', payload } ),
+				// Mirrors the real store: closing the panel is setIsOpen( false ).
+				setIsOpen: ( isOpen: boolean ) => ( { type: 'SET', payload: { isOpen } } ),
 				setIsMinimized: ( isMinimized: boolean ) => ( {
 					type: 'SET',
 					payload: { isMinimized },
@@ -69,7 +71,7 @@ beforeEach( () => {
 	} );
 } );
 
-it( 'minimizes Agents Manager when Help Center opens while AM is floating-open', () => {
+it( 'closes Agents Manager when Help Center opens while AM is expanded', () => {
 	act( () => {
 		( dispatch( AM_KEY ) as AMDispatch ).set( { isOpen: true } );
 	} );
@@ -77,7 +79,19 @@ it( 'minimizes Agents Manager when Help Center opens while AM is floating-open',
 	act( () => {
 		( dispatch( HC_KEY ) as HCDispatch ).set( { showHelpCenter: true } );
 	} );
-	expect( select( AM_KEY ).getIsMinimized() ).toBe( true );
+	expect( select( AM_KEY ).getIsOpen() ).toBe( false );
+	unmount();
+} );
+
+it( 'minimizes Help Center when Agents Manager expands over an open Help Center', () => {
+	act( () => {
+		( dispatch( HC_KEY ) as HCDispatch ).set( { showHelpCenter: true } );
+	} );
+	const { unmount } = renderHook( () => useAiSurfaceCoordinator( true ) );
+	act( () => {
+		( dispatch( AM_KEY ) as AMDispatch ).set( { isOpen: true } );
+	} );
+	expect( select( HC_KEY ).getIsMinimized() ).toBe( true );
 	unmount();
 } );
 
@@ -89,24 +103,19 @@ it( 'no-ops when disabled', () => {
 	act( () => {
 		( dispatch( HC_KEY ) as HCDispatch ).set( { showHelpCenter: true } );
 	} );
-	expect( select( AM_KEY ).getIsMinimized() ).toBe( false );
+	expect( select( AM_KEY ).getIsOpen() ).toBe( true );
 	unmount();
 } );
 
-it( 'writes layout CSS custom properties onto documentElement when enabled', () => {
-	// Both surfaces minimized: AM open+minimized, HC shown+minimized, lastExpanded = help-center.
-	// That means HC is on bottom (slot 0), AM is raised.
-	window.localStorage.setItem( 'ai-surface-last-expanded', 'help-center' );
+it( "offsets Help Center above Agents Manager's Ask AI bar via a CSS custom property", () => {
+	// AM loaded but closed → its persistent Ask AI bar is present, HC shown.
 	act( () => {
-		( dispatch( AM_KEY ) as AMDispatch ).set( { isOpen: true, isMinimized: true } );
-		( dispatch( HC_KEY ) as HCDispatch ).set( { showHelpCenter: true, isMinimized: true } );
+		( dispatch( HC_KEY ) as HCDispatch ).set( { showHelpCenter: true } );
 	} );
 	const { unmount } = renderHook( () => useAiSurfaceCoordinator( true ) );
 
-	// After boot reconciliation the CSS vars should be set.
 	const root = document.documentElement;
-	expect( root.style.getPropertyValue( CSS_VAR_HC_STACK_BOTTOM ) ).toBe( '0px' );
-	expect( root.style.getPropertyValue( CSS_VAR_AM_STACK_BOTTOM ) ).toBe( '64px' ); // MINIMIZED_BAR_HEIGHT(56) + STACK_GAP(8)
+	expect( root.style.getPropertyValue( CSS_VAR_HC_BOTTOM_OFFSET ) ).toBe( '64px' ); // 56 + 8
 	expect( root.style.getPropertyValue( CSS_VAR_RAIL_INSET ) ).toBe( '0px' );
 	unmount();
 } );
@@ -118,15 +127,15 @@ it( 'does NOT coordinate after unmount', () => {
 	const { unmount } = renderHook( () => useAiSurfaceCoordinator( true ) );
 	unmount();
 
-	// After unmount, opening HC must NOT minimize AM.
+	// After unmount, opening HC must NOT close AM.
 	act( () => {
 		( dispatch( HC_KEY ) as HCDispatch ).set( { showHelpCenter: true } );
 	} );
-	expect( select( AM_KEY ).getIsMinimized() ).toBe( false );
+	expect( select( AM_KEY ).getIsOpen() ).toBe( true );
 } );
 
 it( 'handles a second conflict correctly after a first (re-entrancy / stale prev)', () => {
-	// Round 1: AM open, HC opens → AM gets minimized.
+	// Round 1: AM open, HC opens → AM is closed.
 	act( () => {
 		( dispatch( AM_KEY ) as AMDispatch ).set( { isOpen: true } );
 	} );
@@ -134,12 +143,12 @@ it( 'handles a second conflict correctly after a first (re-entrancy / stale prev
 	act( () => {
 		( dispatch( HC_KEY ) as HCDispatch ).set( { showHelpCenter: true } );
 	} );
-	expect( select( AM_KEY ).getIsMinimized() ).toBe( true );
+	expect( select( AM_KEY ).getIsOpen() ).toBe( false );
 
-	// Round 2: restore AM to expanded (isMinimized: false), with HC still shown.
-	// Now AM just-expanded → HC should be minimized.
+	// Round 2: AM re-expands while HC is still shown → AM just-expanded wins,
+	// so Help Center is minimized.
 	act( () => {
-		( dispatch( AM_KEY ) as AMDispatch ).set( { isMinimized: false } );
+		( dispatch( AM_KEY ) as AMDispatch ).set( { isOpen: true } );
 	} );
 	expect( select( HC_KEY ).getIsMinimized() ).toBe( true );
 

--- a/packages/data-stores/src/ai-surface-coordinator/test/index.test.tsx
+++ b/packages/data-stores/src/ai-surface-coordinator/test/index.test.tsx
@@ -5,6 +5,7 @@ import { renderHook, act } from '@testing-library/react';
 import { dispatch, register, createReduxStore, select } from '@wordpress/data';
 import { STORE_KEY as AM_KEY } from '../../agents-manager/constants';
 import { STORE_KEY as HC_KEY } from '../../help-center/constants';
+import { CSS_VAR_AM_STACK_BOTTOM, CSS_VAR_HC_STACK_BOTTOM, CSS_VAR_RAIL_INSET } from '../constants';
 import { useAiSurfaceCoordinator } from '../index';
 
 function registerStubStores() {
@@ -89,5 +90,58 @@ it( 'no-ops when disabled', () => {
 		( dispatch( HC_KEY ) as HCDispatch ).set( { showHelpCenter: true } );
 	} );
 	expect( select( AM_KEY ).getIsMinimized() ).toBe( false );
+	unmount();
+} );
+
+it( 'writes layout CSS custom properties onto documentElement when enabled', () => {
+	// Both surfaces minimized: AM open+minimized, HC shown+minimized, lastExpanded = help-center.
+	// That means HC is on bottom (slot 0), AM is raised.
+	window.localStorage.setItem( 'ai-surface-last-expanded', 'help-center' );
+	act( () => {
+		( dispatch( AM_KEY ) as AMDispatch ).set( { isOpen: true, isMinimized: true } );
+		( dispatch( HC_KEY ) as HCDispatch ).set( { showHelpCenter: true, isMinimized: true } );
+	} );
+	const { unmount } = renderHook( () => useAiSurfaceCoordinator( true ) );
+
+	// After boot reconciliation the CSS vars should be set.
+	const root = document.documentElement;
+	expect( root.style.getPropertyValue( CSS_VAR_HC_STACK_BOTTOM ) ).toBe( '0px' );
+	expect( root.style.getPropertyValue( CSS_VAR_AM_STACK_BOTTOM ) ).toBe( '64px' ); // MINIMIZED_BAR_HEIGHT(56) + STACK_GAP(8)
+	expect( root.style.getPropertyValue( CSS_VAR_RAIL_INSET ) ).toBe( '0px' );
+	unmount();
+} );
+
+it( 'does NOT coordinate after unmount', () => {
+	act( () => {
+		( dispatch( AM_KEY ) as AMDispatch ).set( { isOpen: true } );
+	} );
+	const { unmount } = renderHook( () => useAiSurfaceCoordinator( true ) );
+	unmount();
+
+	// After unmount, opening HC must NOT minimize AM.
+	act( () => {
+		( dispatch( HC_KEY ) as HCDispatch ).set( { showHelpCenter: true } );
+	} );
+	expect( select( AM_KEY ).getIsMinimized() ).toBe( false );
+} );
+
+it( 'handles a second conflict correctly after a first (re-entrancy / stale prev)', () => {
+	// Round 1: AM open, HC opens → AM gets minimized.
+	act( () => {
+		( dispatch( AM_KEY ) as AMDispatch ).set( { isOpen: true } );
+	} );
+	const { unmount } = renderHook( () => useAiSurfaceCoordinator( true ) );
+	act( () => {
+		( dispatch( HC_KEY ) as HCDispatch ).set( { showHelpCenter: true } );
+	} );
+	expect( select( AM_KEY ).getIsMinimized() ).toBe( true );
+
+	// Round 2: restore AM to expanded (isMinimized: false), with HC still shown.
+	// Now AM just-expanded → HC should be minimized.
+	act( () => {
+		( dispatch( AM_KEY ) as AMDispatch ).set( { isMinimized: false } );
+	} );
+	expect( select( HC_KEY ).getIsMinimized() ).toBe( true );
+
 	unmount();
 } );

--- a/packages/data-stores/src/ai-surface-coordinator/test/index.test.tsx
+++ b/packages/data-stores/src/ai-surface-coordinator/test/index.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook, act } from '@testing-library/react';
+import { dispatch, register, createReduxStore, select } from '@wordpress/data';
+import { STORE_KEY as AM_KEY } from '../../agents-manager/constants';
+import { STORE_KEY as HC_KEY } from '../../help-center/constants';
+import { useAiSurfaceCoordinator } from '../index';
+
+function registerStubStores() {
+	register(
+		createReduxStore( HC_KEY, {
+			reducer: (
+				state = { showHelpCenter: false, isMinimized: false },
+				action: { type: string; payload?: Record< string, unknown > }
+			) => ( action.type === 'SET' ? { ...state, ...action.payload } : state ),
+			actions: {
+				set: ( payload: Record< string, unknown > ) => ( { type: 'SET', payload } ),
+				setIsMinimized: ( isMinimized: boolean ) => ( {
+					type: 'SET',
+					payload: { isMinimized },
+				} ),
+			},
+			selectors: {
+				isHelpCenterShown: ( s: { showHelpCenter: boolean } ) => s.showHelpCenter,
+				getIsMinimized: ( s: { isMinimized: boolean } ) => s.isMinimized,
+			},
+		} )
+	);
+	register(
+		createReduxStore( AM_KEY, {
+			reducer: (
+				state = { isOpen: false, isMinimized: false, isDocked: false },
+				action: { type: string; payload?: Record< string, unknown > }
+			) => ( action.type === 'SET' ? { ...state, ...action.payload } : state ),
+			actions: {
+				set: ( payload: Record< string, unknown > ) => ( { type: 'SET', payload } ),
+				setIsMinimized: ( isMinimized: boolean ) => ( {
+					type: 'SET',
+					payload: { isMinimized },
+				} ),
+			},
+			selectors: {
+				getIsOpen: ( s: { isOpen: boolean } ) => s.isOpen,
+				getIsMinimized: ( s: { isMinimized: boolean } ) => s.isMinimized,
+				getIsDocked: ( s: { isDocked: boolean } ) => s.isDocked,
+			},
+		} )
+	);
+}
+
+type HCDispatch = { set: ( p: Record< string, unknown > ) => void };
+type AMDispatch = { set: ( p: Record< string, unknown > ) => void };
+
+let storesRegistered = false;
+beforeEach( () => {
+	window.localStorage.clear();
+	if ( ! storesRegistered ) {
+		registerStubStores();
+		storesRegistered = true;
+	}
+	// Reset store state between tests.
+	( dispatch( HC_KEY ) as HCDispatch ).set( { showHelpCenter: false, isMinimized: false } );
+	( dispatch( AM_KEY ) as AMDispatch ).set( {
+		isOpen: false,
+		isMinimized: false,
+		isDocked: false,
+	} );
+} );
+
+it( 'minimizes Agents Manager when Help Center opens while AM is floating-open', () => {
+	act( () => {
+		( dispatch( AM_KEY ) as AMDispatch ).set( { isOpen: true } );
+	} );
+	const { unmount } = renderHook( () => useAiSurfaceCoordinator( true ) );
+	act( () => {
+		( dispatch( HC_KEY ) as HCDispatch ).set( { showHelpCenter: true } );
+	} );
+	expect( select( AM_KEY ).getIsMinimized() ).toBe( true );
+	unmount();
+} );
+
+it( 'no-ops when disabled', () => {
+	act( () => {
+		( dispatch( AM_KEY ) as AMDispatch ).set( { isOpen: true } );
+	} );
+	const { unmount } = renderHook( () => useAiSurfaceCoordinator( false ) );
+	act( () => {
+		( dispatch( HC_KEY ) as HCDispatch ).set( { showHelpCenter: true } );
+	} );
+	expect( select( AM_KEY ).getIsMinimized() ).toBe( false );
+	unmount();
+} );

--- a/packages/data-stores/src/ai-surface-coordinator/test/index.test.tsx
+++ b/packages/data-stores/src/ai-surface-coordinator/test/index.test.tsx
@@ -116,7 +116,7 @@ it( "offsets Help Center above Agents Manager's Ask AI bar via a CSS custom prop
 	const { unmount } = renderHook( () => useAiSurfaceCoordinator( true ) );
 
 	const root = document.documentElement;
-	expect( root.style.getPropertyValue( CSS_VAR_HC_BOTTOM_OFFSET ) ).toBe( '64px' ); // 56 + 8
+	expect( root.style.getPropertyValue( CSS_VAR_HC_BOTTOM_OFFSET ) ).toBe( '72px' ); // 56 + 16
 	expect( root.style.getPropertyValue( CSS_VAR_RAIL_INSET ) ).toBe( '0px' );
 	unmount();
 } );

--- a/packages/data-stores/src/ai-surface-coordinator/test/layout.test.ts
+++ b/packages/data-stores/src/ai-surface-coordinator/test/layout.test.ts
@@ -1,5 +1,5 @@
 import { computeLayoutVars } from '../layout';
-import type { SurfaceSnapshot, Surface } from '../reconciler';
+import type { SurfaceSnapshot } from '../reconciler';
 
 const HC_CLOSED = { present: true, shown: false, minimized: false };
 const AM_CLOSED = { present: true, open: false, minimized: false, docked: false };
@@ -8,26 +8,31 @@ function snap( hc = {}, am = {} ): SurfaceSnapshot {
 }
 
 describe( 'computeLayoutVars', () => {
-	it( 'leaves both stack bottoms at 0 when only one bar is minimized', () => {
-		const vars = computeLayoutVars( snap( { shown: true, minimized: true } ), null );
-		expect( vars[ '--ai-surface-hc-stack-bottom' ] ).toBe( '0px' );
-		expect( vars[ '--ai-surface-am-stack-bottom' ] ).toBe( '0px' );
+	it( "offsets Help Center up by (bar height + gap) while Agents Manager's Ask AI bar is present", () => {
+		// AM loaded but not open and not docked → its persistent Ask AI bar owns
+		// the corner, so Help Center must sit above it.
+		const vars = computeLayoutVars( snap( { shown: true }, { open: false } ) );
+		expect( vars[ '--ai-surface-hc-bottom-offset' ] ).toBe( '64px' ); // 56 + 8
 	} );
 
-	it( 'raises the non-most-recent bar by (barHeight + gap) when both are minimized', () => {
-		const both = snap( { shown: true, minimized: true }, { open: true, minimized: true } );
-		const vars = computeLayoutVars( both, 'help-center' as Surface );
-		expect( vars[ '--ai-surface-hc-stack-bottom' ] ).toBe( '0px' );
-		expect( vars[ '--ai-surface-am-stack-bottom' ] ).toBe( '64px' );
+	it( 'does not offset Help Center when Agents Manager is expanded (bar not shown)', () => {
+		const vars = computeLayoutVars( snap( { shown: true }, { open: true } ) );
+		expect( vars[ '--ai-surface-hc-bottom-offset' ] ).toBe( '0px' );
 	} );
 
-	it( 'sets the rail inset to the sidebar width when Agents Manager is docked', () => {
-		const vars = computeLayoutVars( snap( {}, { open: true, docked: true } ), null );
+	it( 'does not offset Help Center when Agents Manager is not present', () => {
+		const vars = computeLayoutVars( snap( { shown: true }, { present: false } ) );
+		expect( vars[ '--ai-surface-hc-bottom-offset' ] ).toBe( '0px' );
+	} );
+
+	it( 'sets the rail inset (and no bottom offset) when Agents Manager is docked', () => {
+		const vars = computeLayoutVars( snap( {}, { open: true, docked: true } ) );
 		expect( vars[ '--ai-surface-rail-inset' ] ).toBe( 'var(--am-sidebar-width, 350px)' );
+		expect( vars[ '--ai-surface-hc-bottom-offset' ] ).toBe( '0px' );
 	} );
 
 	it( 'sets the rail inset to 0 when Agents Manager is not docked', () => {
-		const vars = computeLayoutVars( snap( {}, {} ), null );
+		const vars = computeLayoutVars( snap( {}, {} ) );
 		expect( vars[ '--ai-surface-rail-inset' ] ).toBe( '0px' );
 	} );
 } );

--- a/packages/data-stores/src/ai-surface-coordinator/test/layout.test.ts
+++ b/packages/data-stores/src/ai-surface-coordinator/test/layout.test.ts
@@ -22,11 +22,11 @@ describe( 'computeLayoutVars', () => {
 		expect( vars[ '--ai-surface-hc-bottom-offset' ] ).toBe( '0px' );
 	} );
 
-	it( 'applies no offset when both are minimized (handled by the shared container)', () => {
+	it( 'stacks both minimized bars into a column (HC bar above the AM bar)', () => {
 		const vars = computeLayoutVars(
 			snap( { shown: true, minimized: true }, { open: true, minimized: true } )
 		);
-		expect( vars[ '--ai-surface-hc-bottom-offset' ] ).toBe( '0px' );
+		expect( vars[ '--ai-surface-hc-bottom-offset' ] ).toBe( RAISED );
 		expect( vars[ '--ai-surface-am-bottom-offset' ] ).toBe( '0px' );
 	} );
 

--- a/packages/data-stores/src/ai-surface-coordinator/test/layout.test.ts
+++ b/packages/data-stores/src/ai-surface-coordinator/test/layout.test.ts
@@ -7,18 +7,18 @@ function snap( hc = {}, am = {} ): SurfaceSnapshot {
 	return { helpCenter: { ...HC_CLOSED, ...hc }, agentsManager: { ...AM_CLOSED, ...am } };
 }
 
-const RAISED = '72px'; // MINIMIZED_BAR_HEIGHT (56) + STACK_GAP (16)
-
 describe( 'computeLayoutVars', () => {
-	it( 'lifts the open Help Center card above the Agents Manager Ask AI bar', () => {
+	it( 'lifts the open Help Center card above the Agents Manager Ask AI bar (gutter)', () => {
 		const vars = computeLayoutVars( snap( { shown: true }, { open: true, minimized: true } ) );
-		expect( vars[ '--ai-surface-hc-bottom-offset' ] ).toBe( RAISED );
+		// AM bar height (40) + STACK_GAP (16).
+		expect( vars[ '--ai-surface-hc-bottom-offset' ] ).toBe( '56px' );
 		expect( vars[ '--ai-surface-am-bottom-offset' ] ).toBe( '0px' );
 	} );
 
-	it( 'lifts the open Agents Manager panel above the Help Center minimized bar', () => {
+	it( 'lifts the open Agents Manager panel above the Help Center minimized bar (gutter)', () => {
 		const vars = computeLayoutVars( snap( { shown: true, minimized: true }, { open: true } ) );
-		expect( vars[ '--ai-surface-am-bottom-offset' ] ).toBe( RAISED );
+		// HC bar height (56) + STACK_GAP (16).
+		expect( vars[ '--ai-surface-am-bottom-offset' ] ).toBe( '72px' );
 		expect( vars[ '--ai-surface-hc-bottom-offset' ] ).toBe( '0px' );
 	} );
 
@@ -26,8 +26,9 @@ describe( 'computeLayoutVars', () => {
 		const vars = computeLayoutVars(
 			snap( { shown: true, minimized: true }, { open: true, minimized: true } )
 		);
-		// Flush (no gutter) so the two bars read as a single stacked container.
-		expect( vars[ '--ai-surface-hc-bottom-offset' ] ).toBe( '56px' ); // MINIMIZED_BAR_HEIGHT
+		// Flush against the AM bar's own height (40), so the two bars read as one
+		// stacked container with no gutter.
+		expect( vars[ '--ai-surface-hc-bottom-offset' ] ).toBe( '40px' );
 		expect( vars[ '--ai-surface-am-bottom-offset' ] ).toBe( '0px' );
 	} );
 

--- a/packages/data-stores/src/ai-surface-coordinator/test/layout.test.ts
+++ b/packages/data-stores/src/ai-surface-coordinator/test/layout.test.ts
@@ -22,11 +22,12 @@ describe( 'computeLayoutVars', () => {
 		expect( vars[ '--ai-surface-hc-bottom-offset' ] ).toBe( '0px' );
 	} );
 
-	it( 'stacks both minimized bars into a column (HC bar above the AM bar)', () => {
+	it( 'stacks both minimized bars flush into one column (HC bar directly atop the AM bar)', () => {
 		const vars = computeLayoutVars(
 			snap( { shown: true, minimized: true }, { open: true, minimized: true } )
 		);
-		expect( vars[ '--ai-surface-hc-bottom-offset' ] ).toBe( RAISED );
+		// Flush (no gutter) so the two bars read as a single stacked container.
+		expect( vars[ '--ai-surface-hc-bottom-offset' ] ).toBe( '56px' ); // MINIMIZED_BAR_HEIGHT
 		expect( vars[ '--ai-surface-am-bottom-offset' ] ).toBe( '0px' );
 	} );
 

--- a/packages/data-stores/src/ai-surface-coordinator/test/layout.test.ts
+++ b/packages/data-stores/src/ai-surface-coordinator/test/layout.test.ts
@@ -1,0 +1,33 @@
+import { computeLayoutVars } from '../layout';
+import type { SurfaceSnapshot, Surface } from '../reconciler';
+
+const HC_CLOSED = { present: true, shown: false, minimized: false };
+const AM_CLOSED = { present: true, open: false, minimized: false, docked: false };
+function snap( hc = {}, am = {} ): SurfaceSnapshot {
+	return { helpCenter: { ...HC_CLOSED, ...hc }, agentsManager: { ...AM_CLOSED, ...am } };
+}
+
+describe( 'computeLayoutVars', () => {
+	it( 'leaves both stack bottoms at 0 when only one bar is minimized', () => {
+		const vars = computeLayoutVars( snap( { shown: true, minimized: true } ), null );
+		expect( vars[ '--ai-surface-hc-stack-bottom' ] ).toBe( '0px' );
+		expect( vars[ '--ai-surface-am-stack-bottom' ] ).toBe( '0px' );
+	} );
+
+	it( 'raises the non-most-recent bar by (barHeight + gap) when both are minimized', () => {
+		const both = snap( { shown: true, minimized: true }, { open: true, minimized: true } );
+		const vars = computeLayoutVars( both, 'help-center' as Surface );
+		expect( vars[ '--ai-surface-hc-stack-bottom' ] ).toBe( '0px' );
+		expect( vars[ '--ai-surface-am-stack-bottom' ] ).toBe( '64px' );
+	} );
+
+	it( 'sets the rail inset to the sidebar width when Agents Manager is docked', () => {
+		const vars = computeLayoutVars( snap( {}, { open: true, docked: true } ), null );
+		expect( vars[ '--ai-surface-rail-inset' ] ).toBe( 'var(--am-sidebar-width, 350px)' );
+	} );
+
+	it( 'sets the rail inset to 0 when Agents Manager is not docked', () => {
+		const vars = computeLayoutVars( snap( {}, {} ), null );
+		expect( vars[ '--ai-surface-rail-inset' ] ).toBe( '0px' );
+	} );
+} );

--- a/packages/data-stores/src/ai-surface-coordinator/test/layout.test.ts
+++ b/packages/data-stores/src/ai-surface-coordinator/test/layout.test.ts
@@ -8,15 +8,18 @@ function snap( hc = {}, am = {} ): SurfaceSnapshot {
 }
 
 describe( 'computeLayoutVars', () => {
-	it( "offsets Help Center up by (bar height + gap) while Agents Manager's Ask AI bar is present", () => {
-		// AM loaded but not open and not docked → its persistent Ask AI bar owns
-		// the corner, so Help Center must sit above it.
-		const vars = computeLayoutVars( snap( { shown: true }, { open: false } ) );
+	it( "offsets Help Center up while Agents Manager's Ask AI bar is shown (open + minimized)", () => {
+		const vars = computeLayoutVars( snap( { shown: true }, { open: true, minimized: true } ) );
 		expect( vars[ '--ai-surface-hc-bottom-offset' ] ).toBe( '64px' ); // 56 + 8
 	} );
 
-	it( 'does not offset Help Center when Agents Manager is expanded (bar not shown)', () => {
-		const vars = computeLayoutVars( snap( { shown: true }, { open: true } ) );
+	it( 'does not offset Help Center when Agents Manager is expanded (open, not minimized)', () => {
+		const vars = computeLayoutVars( snap( { shown: true }, { open: true, minimized: false } ) );
+		expect( vars[ '--ai-surface-hc-bottom-offset' ] ).toBe( '0px' );
+	} );
+
+	it( 'does not offset Help Center when Agents Manager is fully hidden (not open)', () => {
+		const vars = computeLayoutVars( snap( { shown: true }, { open: false } ) );
 		expect( vars[ '--ai-surface-hc-bottom-offset' ] ).toBe( '0px' );
 	} );
 

--- a/packages/data-stores/src/ai-surface-coordinator/test/layout.test.ts
+++ b/packages/data-stores/src/ai-surface-coordinator/test/layout.test.ts
@@ -7,31 +7,46 @@ function snap( hc = {}, am = {} ): SurfaceSnapshot {
 	return { helpCenter: { ...HC_CLOSED, ...hc }, agentsManager: { ...AM_CLOSED, ...am } };
 }
 
+const RAISED = '72px'; // MINIMIZED_BAR_HEIGHT (56) + STACK_GAP (16)
+
 describe( 'computeLayoutVars', () => {
-	it( "offsets Help Center up while Agents Manager's Ask AI bar is shown (open + minimized)", () => {
+	it( 'lifts the open Help Center card above the Agents Manager Ask AI bar', () => {
 		const vars = computeLayoutVars( snap( { shown: true }, { open: true, minimized: true } ) );
-		expect( vars[ '--ai-surface-hc-bottom-offset' ] ).toBe( '64px' ); // 56 + 8
+		expect( vars[ '--ai-surface-hc-bottom-offset' ] ).toBe( RAISED );
+		expect( vars[ '--ai-surface-am-bottom-offset' ] ).toBe( '0px' );
 	} );
 
-	it( 'does not offset Help Center when Agents Manager is expanded (open, not minimized)', () => {
-		const vars = computeLayoutVars( snap( { shown: true }, { open: true, minimized: false } ) );
+	it( 'lifts the open Agents Manager panel above the Help Center minimized bar', () => {
+		const vars = computeLayoutVars( snap( { shown: true, minimized: true }, { open: true } ) );
+		expect( vars[ '--ai-surface-am-bottom-offset' ] ).toBe( RAISED );
 		expect( vars[ '--ai-surface-hc-bottom-offset' ] ).toBe( '0px' );
 	} );
 
-	it( 'does not offset Help Center when Agents Manager is fully hidden (not open)', () => {
-		const vars = computeLayoutVars( snap( { shown: true }, { open: false } ) );
+	it( 'applies no offset when both are minimized (handled by the shared container)', () => {
+		const vars = computeLayoutVars(
+			snap( { shown: true, minimized: true }, { open: true, minimized: true } )
+		);
 		expect( vars[ '--ai-surface-hc-bottom-offset' ] ).toBe( '0px' );
+		expect( vars[ '--ai-surface-am-bottom-offset' ] ).toBe( '0px' );
 	} );
 
-	it( 'does not offset Help Center when Agents Manager is not present', () => {
-		const vars = computeLayoutVars( snap( { shown: true }, { present: false } ) );
+	it( 'applies no offset when neither surface is minimized', () => {
+		const vars = computeLayoutVars( snap( { shown: true }, { open: true } ) );
 		expect( vars[ '--ai-surface-hc-bottom-offset' ] ).toBe( '0px' );
+		expect( vars[ '--ai-surface-am-bottom-offset' ] ).toBe( '0px' );
 	} );
 
-	it( 'sets the rail inset (and no bottom offset) when Agents Manager is docked', () => {
+	it( 'applies no offset when Agents Manager is fully hidden', () => {
+		const vars = computeLayoutVars( snap( { shown: true, minimized: true }, { open: false } ) );
+		expect( vars[ '--ai-surface-hc-bottom-offset' ] ).toBe( '0px' );
+		expect( vars[ '--ai-surface-am-bottom-offset' ] ).toBe( '0px' );
+	} );
+
+	it( 'sets the rail inset (and no offsets) when Agents Manager is docked', () => {
 		const vars = computeLayoutVars( snap( {}, { open: true, docked: true } ) );
 		expect( vars[ '--ai-surface-rail-inset' ] ).toBe( 'var(--am-sidebar-width, 350px)' );
 		expect( vars[ '--ai-surface-hc-bottom-offset' ] ).toBe( '0px' );
+		expect( vars[ '--ai-surface-am-bottom-offset' ] ).toBe( '0px' );
 	} );
 
 	it( 'sets the rail inset to 0 when Agents Manager is not docked', () => {

--- a/packages/data-stores/src/ai-surface-coordinator/test/reconciler.test.ts
+++ b/packages/data-stores/src/ai-surface-coordinator/test/reconciler.test.ts
@@ -44,3 +44,35 @@ describe( 'computeCoordination — no conflict', () => {
 		expect( computeCoordination( prev, next, 'help-center' ).commands ).toEqual( [] );
 	} );
 } );
+
+describe( 'computeCoordination — conflict resolution', () => {
+	it( 'minimizes the previously-open surface when the other newly expands (open HC over open AM)', () => {
+		const prev = snap( {}, { open: true } );
+		const next = snap( { shown: true }, { open: true } );
+		const result = computeCoordination( prev, next, 'agents-manager' );
+		expect( result.commands ).toEqual( [ { type: 'minimize', surface: 'agents-manager' } ] );
+		expect( result.lastExpanded ).toBe( 'help-center' );
+	} );
+
+	it( 'minimizes Help Center when Agents Manager newly expands over an open Help Center', () => {
+		const prev = snap( { shown: true }, {} );
+		const next = snap( { shown: true }, { open: true } );
+		const result = computeCoordination( prev, next, 'help-center' );
+		expect( result.commands ).toEqual( [ { type: 'minimize', surface: 'help-center' } ] );
+		expect( result.lastExpanded ).toBe( 'agents-manager' );
+	} );
+
+	it( 'on boot (both already expanded, no transition) keeps the lastExpanded surface', () => {
+		const both = snap( { shown: true }, { open: true } );
+		const result = computeCoordination( both, both, 'help-center' );
+		expect( result.commands ).toEqual( [ { type: 'minimize', surface: 'agents-manager' } ] );
+		expect( result.lastExpanded ).toBe( 'help-center' );
+	} );
+
+	it( 'on boot with no marker, defaults to keeping Agents Manager (minimizes Help Center)', () => {
+		const both = snap( { shown: true }, { open: true } );
+		const result = computeCoordination( both, both, null );
+		expect( result.commands ).toEqual( [ { type: 'minimize', surface: 'help-center' } ] );
+		expect( result.lastExpanded ).toBe( 'agents-manager' );
+	} );
+} );

--- a/packages/data-stores/src/ai-surface-coordinator/test/reconciler.test.ts
+++ b/packages/data-stores/src/ai-surface-coordinator/test/reconciler.test.ts
@@ -1,0 +1,46 @@
+import { computeCoordination, type SurfaceSnapshot } from '../reconciler';
+
+const HC_CLOSED = { present: true, shown: false, minimized: false };
+const AM_CLOSED = { present: true, open: false, minimized: false, docked: false };
+
+function snap(
+	hc: Partial< SurfaceSnapshot[ 'helpCenter' ] >,
+	am: Partial< SurfaceSnapshot[ 'agentsManager' ] >
+): SurfaceSnapshot {
+	return { helpCenter: { ...HC_CLOSED, ...hc }, agentsManager: { ...AM_CLOSED, ...am } };
+}
+
+describe( 'computeCoordination — no conflict', () => {
+	it( 'returns no commands when neither surface is expanded', () => {
+		const prev = snap( {}, {} );
+		const next = snap( {}, {} );
+		expect( computeCoordination( prev, next, null ) ).toEqual( {
+			commands: [],
+			lastExpanded: null,
+		} );
+	} );
+
+	it( 'records the sole expanded floating surface as lastExpanded without minimizing anything', () => {
+		const prev = snap( {}, {} );
+		const next = snap( { shown: true }, {} );
+		expect( computeCoordination( prev, next, null ) ).toEqual( {
+			commands: [],
+			lastExpanded: 'help-center',
+		} );
+	} );
+
+	it( 'treats a docked Agents Manager as non-conflicting with an expanded Help Center', () => {
+		const prev = snap( { shown: true }, {} );
+		const next = snap( { shown: true }, { open: true, docked: true } );
+		expect( computeCoordination( prev, next, 'help-center' ) ).toEqual( {
+			commands: [],
+			lastExpanded: 'help-center',
+		} );
+	} );
+
+	it( 'no-ops entirely when a surface is not present', () => {
+		const prev = snap( { shown: true }, {} );
+		const next = snap( { shown: true }, { present: false, open: true } );
+		expect( computeCoordination( prev, next, 'help-center' ).commands ).toEqual( [] );
+	} );
+} );

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -1,5 +1,6 @@
 import * as AddOns from './add-ons';
 import * as AgentsManager from './agents-manager';
+import * as AiSurfaceCoordinator from './ai-surface-coordinator';
 import * as HelpCenter from './help-center';
 import * as Onboard from './onboard';
 import * as Plans from './plans';
@@ -37,6 +38,7 @@ const { SubscriptionManager } = Reader;
 export {
 	AddOns,
 	AgentsManager,
+	AiSurfaceCoordinator,
 	User,
 	HelpCenter,
 	Site,

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -2,8 +2,9 @@
 /**
  * External Dependencies
  */
-import { useShouldUseUnifiedAgent } from '@automattic/agents-manager';
+import { useShouldCoexistAiSurfaces, useShouldUseUnifiedAgent } from '@automattic/agents-manager';
 import { initializeAnalytics } from '@automattic/calypso-analytics';
+import { AiSurfaceCoordinator, type HelpCenterSelect } from '@automattic/data-stores';
 import { useCanConnectToZendeskMessaging } from '@automattic/zendesk-client';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createPortal, useEffect, useState } from '@wordpress/element';
@@ -20,7 +21,6 @@ import { HELP_CENTER_STORE } from '../stores';
 import { Container } from '../types';
 import HelpCenterContainer from './help-center-container';
 import HelpCenterSmooch from './help-center-smooch';
-import type { HelpCenterSelect } from '@automattic/data-stores';
 import '../styles.scss';
 
 const HelpCenter: React.FC< Container > = ( {
@@ -29,6 +29,10 @@ const HelpCenter: React.FC< Container > = ( {
 	currentRoute = window.location.pathname + window.location.search + window.location.hash,
 } ) => {
 	const shouldUseUnifiedAgent = useShouldUseUnifiedAgent();
+	const shouldCoexist = useShouldCoexistAiSurfaces();
+	// When coexisting, Help Center must render even though the unified agent is on.
+	const suppress = shouldUseUnifiedAgent && ! shouldCoexist;
+	AiSurfaceCoordinator.useAiSurfaceCoordinator( shouldCoexist );
 	const [ container, setContainer ] = useState< HTMLDivElement >();
 
 	const isHelpCenterShown = useSelect( ( select ) => {
@@ -55,7 +59,7 @@ const HelpCenter: React.FC< Container > = ( {
 	// Create portal container on mount, cleanup on unmount
 	useEffect( () => {
 		let div: HTMLDivElement | undefined;
-		if ( ! shouldUseUnifiedAgent ) {
+		if ( ! suppress ) {
 			div = document.createElement( 'div' );
 			div.classList.add( 'help-center' );
 			div.setAttribute( 'role', 'dialog' );
@@ -74,7 +78,7 @@ const HelpCenter: React.FC< Container > = ( {
 	}, [] );
 
 	// If unified agent flag is enabled, things will be handled by agents-manager app
-	if ( ! container || shouldUseUnifiedAgent ) {
+	if ( ! container || suppress ) {
 		return null;
 	}
 

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -239,10 +239,13 @@
 // other's minimized bar). Scoped to the coexistence flag via the class the AI
 // surface coordinator sets on <html>.
 .is-ai-surface-coexisting .help-center > .help-center__container.is-desktop {
-	// Both surfaces use the wider 410px width for a consistent column; Help
-	// Center keeps its native width. Align the right edge with Agents Manager.
+	// Align with Agents Manager into a shared bottom-right column: same 410px
+	// width (Help Center's native, the wider option) and the same 16px right /
+	// bottom insets, so the open panel and the minimized bars line up and the
+	// --ai-surface-hc-bottom-offset gutter is measured from the same baseline.
 	&,
 	&.is-minimized {
 		right: calc( 16px + var( --ai-surface-rail-inset, 0px ) ) !important;
+		bottom: calc( 16px + var( --ai-surface-hc-bottom-offset, 0px ) ) !important;
 	}
 }

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -100,7 +100,7 @@
 		height: 80vh;
 		max-height: 800px;
 		border-radius: 16px;
-		right: 50px;
+		right: calc( 50px + var( --ai-surface-rail-inset, 0px ) );
 		bottom: 50px;
 
 		&:not( .react-draggable-dragging ) {
@@ -113,7 +113,8 @@
 
 		&.is-minimized {
 			height: $head-foot-height;
-			bottom: 0;
+			bottom: var( --ai-surface-hc-stack-bottom, 0 );
+			right: calc( 50px + var( --ai-surface-rail-inset, 0px ) );
 
 			border-bottom-left-radius: 0;
 			border-bottom-right-radius: 0;

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -233,3 +233,16 @@
 		}
 	}
 }
+
+// Coexistence with Agents Manager: match its floating chat width and right edge
+// so the two surfaces form an aligned bottom-right column (open panel above the
+// other's minimized bar). Scoped to the coexistence flag via the class the AI
+// surface coordinator sets on <html>.
+.is-ai-surface-coexisting .help-center > .help-center__container.is-desktop {
+	// Both surfaces use the wider 410px width for a consistent column; Help
+	// Center keeps its native width. Align the right edge with Agents Manager.
+	&,
+	&.is-minimized {
+		right: calc( 16px + var( --ai-surface-rail-inset, 0px ) ) !important;
+	}
+}

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -239,10 +239,14 @@
 // other's minimized bar). Scoped to the coexistence flag via the class the AI
 // surface coordinator sets on <html>.
 .is-ai-surface-coexisting .help-center > .help-center__container.is-desktop {
-	// Align with Agents Manager into a shared bottom-right column: same 410px
-	// width (Help Center's native, the wider option) and the same 16px right /
-	// bottom insets, so the open panel and the minimized bars line up and the
+	// Align with Agents Manager into a shared bottom-right column. Match Agents
+	// Manager's native floating width (372px) and its 16px right / bottom insets
+	// so the open panel and the minimized bars line up, and the
 	// --ai-surface-hc-bottom-offset gutter is measured from the same baseline.
+	// (We match AM's native width rather than widening AM, which would disrupt
+	// agenttic's positioning/entry animation.)
+	width: 372px;
+
 	&,
 	&.is-minimized {
 		right: calc( 16px + var( --ai-surface-rail-inset, 0px ) ) !important;

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -101,7 +101,9 @@
 		max-height: 800px;
 		border-radius: 16px;
 		right: calc( 50px + var( --ai-surface-rail-inset, 0px ) );
-		bottom: 50px;
+		// Sit above Agents Manager's persistent "Ask AI" bar when coexisting
+		// (the offset is 0 unless the coordinator sets it).
+		bottom: calc( 50px + var( --ai-surface-hc-bottom-offset, 0px ) );
 
 		&:not( .react-draggable-dragging ) {
 			transition: all 0.2s ease-in-out;
@@ -113,7 +115,7 @@
 
 		&.is-minimized {
 			height: $head-foot-height;
-			bottom: var( --ai-surface-hc-stack-bottom, 0 );
+			bottom: var( --ai-surface-hc-bottom-offset, 0 );
 			right: calc( 50px + var( --ai-surface-rail-inset, 0px ) );
 
 			border-bottom-left-radius: 0;

--- a/packages/help-center/src/styles.scss
+++ b/packages/help-center/src/styles.scss
@@ -102,8 +102,10 @@
 		border-radius: 16px;
 		right: calc( 50px + var( --ai-surface-rail-inset, 0px ) );
 		// Sit above Agents Manager's persistent "Ask AI" bar when coexisting
-		// (the offset is 0 unless the coordinator sets it).
-		bottom: calc( 50px + var( --ai-surface-hc-bottom-offset, 0px ) );
+		// (the offset is 0 unless the coordinator sets it). `!important` matches
+		// the priority of the legacy fixed-position declaration so the coordinator
+		// offset wins on the draggable card.
+		bottom: calc( 50px + var( --ai-surface-hc-bottom-offset, 0px ) ) !important;
 
 		&:not( .react-draggable-dragging ) {
 			transition: all 0.2s ease-in-out;
@@ -115,7 +117,7 @@
 
 		&.is-minimized {
 			height: $head-foot-height;
-			bottom: var( --ai-surface-hc-bottom-offset, 0 );
+			bottom: var( --ai-surface-hc-bottom-offset, 0 ) !important;
 			right: calc( 50px + var( --ai-surface-rail-inset, 0px ) );
 
 			border-bottom-left-radius: 0;

--- a/packages/help-center/src/test/__mocks__/automattic-data-stores.js
+++ b/packages/help-center/src/test/__mocks__/automattic-data-stores.js
@@ -7,4 +7,8 @@ const HelpCenter = {
 	register: () => 'help-center',
 };
 
-module.exports = { HelpCenter };
+const AiSurfaceCoordinator = {
+	useAiSurfaceCoordinator: () => {},
+};
+
+module.exports = { HelpCenter, AiSurfaceCoordinator };

--- a/yarn.lock
+++ b/yarn.lock
@@ -115,6 +115,7 @@ __metadata:
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-apps-builder": "workspace:^"
     "@automattic/calypso-build": "workspace:^"
+    "@automattic/data-stores": "workspace:^"
     "@automattic/image-studio": "workspace:^"
     "@automattic/jetpack-ai-sidebar": "workspace:^"
     "@automattic/wp-babel-makepot": "workspace:^"


### PR DESCRIPTION
> **⚠️ Draft / not mergeable as-is.** Contains a `TEMP (do not merge)` commit that force-enables the flag for local testing, and depends on cross-repo work (see below). Opened for review/visibility of the frontend coexistence behavior.

This is a hacky POC. We'll need to do lots of update to the agenttic UI package to make it look good (consistent width, stacked minimized states, better transitions). 

## Proposed Changes

Lets the **Help Center** and **Agents Manager** load together and coordinate at runtime, instead of today's mutually-exclusive, flag-gated mount. Behind a new `ai_surface_coexistence` flag:

- **Runtime coordinator** (`@automattic/data-stores/ai-surface-coordinator`) — subscribes to both surfaces' `@wordpress/data` stores on the shared registry and keeps at most one *expanded* at a time; opening one minimizes the other; persists a "last expanded" marker for boot tie-break. Pure reconciler + layout-var modules with unit tests.
- **Launchers** — Help Center keeps its menu-panel dropdown (forced on when coexisting); Agents Manager gets a **sparkle masterbar launcher** (not a dropdown) that appears only when AM is fully hidden. AM masterbar icon changed from the `help` glyph to an AI sparkle.
- **Agents Manager 3-state model when coexisting** — open / minimized ("Ask AI" bar) / fully hidden; the masterbar sparkle is its reopen trigger (hide-on-close). Minimize control now shows when undocked.
- **Aligned bottom-right column** — both surfaces share a 410px width and right/bottom insets; the open panel sits above the other's minimized bar with a 16px gutter; both minimized bars stack into one aligned column. Docked AM coexists with a floating Help Center (HC offsets left of the rail).
- Both Calypso surfaces (classic masterbar + Dashboard interim omnibar) updated.

Design + decisions: `docs/superpowers/specs/2026-06-04-ai-surface-coexistence-design.md`.

## Why are these changes being made?

To allow both AI/support surfaces to be available simultaneously (only one open at a time) rather than one hard-replacing the other at mount time.

## Testing Instructions

> The flag has no backend yet, so the `TEMP (do not merge)` commit force-enables it. Revert that commit (and provide the backend flag) for real rollout.

### Calypso
1. `yarn start`, log in, open `/sites` (Dashboard).
2. Confirm: AM fully hidden by default with **both** a Help dropdown and an AI **sparkle** in the masterbar.
3. Click the sparkle → AM opens; click Help → its dropdown menu opens.
4. Open one, then the other → the first **minimizes**; the open panel sits above the other's minimized bar (16px gutter), both 410px and right-aligned.
5. Minimize both → the two bars stack into one aligned column.
6. Dock AM (its menu → Move to sidebar), open Help Center → both coexist; HC offsets left of the rail.

### Simple/Atomic/CIAB
1. Sandbox `widgets.wp.com`; `cd apps/agents-manager && yarn dev --sync`.
2. On a wp-admin page that loads both widgets, verify the coordinator keeps one expanded at a time. *(Not yet validated live — see deps.)*

## Cross-repo dependencies (required before merge)

- **Jetpack (`jetpack-mu-wpcom`)**: expose `ai_surface_coexistence` via `/agents-manager/state` + inline data; stop dequeuing Help Center on Gutenberg pages when on.
- **`@automattic/agenttic-ui`**: to rename the AM minimized bar "Ask AI" → "WordPress Assistant" (label is an internal default, not an exposed prop). Also note: aligning the floating chat clears its drag transform while coexisting (fixed column).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes? (coordinator unit tests)
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites? (blocked on Jetpack flag)
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this PR changes what data or activity we track?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
