### PR TITLE
A4A: Redesign agency tier cards as horizontal scroll row

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,7 @@ output/
 **/.claude/settings.local.json
 .claude/test-pr/
 .claude/worktrees/
+client/a8c-for-agencies/.claude/
 
 # husky's auto-generated init directory (not the committed pre-commit/pre-push scripts)
 .husky/_

--- a/.gitignore
+++ b/.gitignore
@@ -138,7 +138,6 @@ output/
 **/.claude/settings.local.json
 .claude/test-pr/
 .claude/worktrees/
-client/a8c-for-agencies/.claude/
 
 # husky's auto-generated init directory (not the committed pre-commit/pre-push scripts)
 .husky/_

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/constants.ts
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/constants.ts
@@ -28,7 +28,11 @@ export const ALL_TIERS: TierItem[] = [
 		level: 0,
 		id: 'emerging-partner',
 		name: __( 'Account activated' ),
-		description: __( 'Joining the program' ),
+		description: sprintf(
+			/* translators: %s is the influenced revenue */
+			__( 'Under %s influenced revenue' ),
+			formatCurrency( TARGET_INFLUENCED_REVENUE[ 'agency-partner' ], 'USD', { stripZeros: true } )
+		),
 		heading: __( 'Essential benefits' ),
 		subheading: __( 'Tools, earning opportunities, support & training and more' ),
 		influencedRevenue: TARGET_INFLUENCED_REVENUE[ 'agency-partner' ],
@@ -118,10 +122,10 @@ export const ALL_TIERS: TierItem[] = [
 		description: sprintf(
 			/* translators: %s is the influenced revenue */
 			__( '%s+ influenced revenue' ),
-			formatCurrency( TARGET_INFLUENCED_REVENUE[ 'agency-partner' ], 'USD' )
+			formatCurrency( TARGET_INFLUENCED_REVENUE[ 'agency-partner' ], 'USD', { stripZeros: true } )
 		),
 		heading: __( '2 additional benefits unlocked' ),
-		subheading: __( 'Directory visibility, early access' ),
+		subheading: __( 'Directory inclusion, early access to product & feature improvements' ),
 		progressCardDescription: __(
 			"You're making great progress! Keep growing your influenced revenue to unlock Pro Partner benefits."
 		),
@@ -161,7 +165,9 @@ export const ALL_TIERS: TierItem[] = [
 		description: sprintf(
 			/* translators: %s is the influenced revenue */
 			__( '%s+ influenced revenue' ),
-			formatCurrency( TARGET_INFLUENCED_REVENUE[ 'pro-agency-partner' ], 'USD' )
+			formatCurrency( TARGET_INFLUENCED_REVENUE[ 'pro-agency-partner' ], 'USD', {
+				stripZeros: true,
+			} )
 		),
 		heading: __( '3 additional benefits unlocked' ),
 		subheading: __( 'Co-Marketing, qualified leads, partner manager & more' ),
@@ -206,7 +212,9 @@ export const ALL_TIERS: TierItem[] = [
 		description: sprintf(
 			/* translators: %s is the influenced revenue */
 			__( '%s+ influenced revenue and invitation to the tier.' ),
-			formatCurrency( TARGET_INFLUENCED_REVENUE[ 'vip-pro-agency-partner' ], 'USD' )
+			formatCurrency( TARGET_INFLUENCED_REVENUE[ 'vip-pro-agency-partner' ], 'USD', {
+				stripZeros: true,
+			} )
 		),
 		heading: __( '2 additional benefits unlocked' ),
 		subheading: __( 'Higher VIP referral commissions, annual credits' ),
@@ -238,7 +246,7 @@ export const ALL_TIERS: TierItem[] = [
 		description: sprintf(
 			/* translators: %s is the influenced revenue */
 			__( '%s+ influenced revenue and invitation to the tier.' ),
-			formatCurrency( TARGET_INFLUENCED_REVENUE[ 'premier-partner' ], 'USD' )
+			formatCurrency( TARGET_INFLUENCED_REVENUE[ 'premier-partner' ], 'USD', { stripZeros: true } )
 		),
 		heading: __( '2 premium benefits' ),
 		subheading: __( 'Parse.ly trial, marketing funds' ),

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/index.tsx
@@ -32,7 +32,7 @@ export default function AgencyTierOverviewContent( {
 				</CardBody>
 			</Card>
 			<TierCards currentAgencyTierId={ currentAgencyTierId } tierStatus={ tierStatus } />
-			<Divider orientation="horizontal" margin={ 4 } style={ { color: '#F0F0F0' } } />
+			<Divider orientation="horizontal" style={ { color: '#F0F0F0' } } />
 			<TierBenefits currentAgencyTierId={ currentAgencyTierId } />
 		</VStack>
 	);

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/style.scss
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/style.scss
@@ -16,13 +16,17 @@
 	&::after {
 		content: '';
 		position: absolute;
-		top: 0;
-		right: 0;
+		inset-block-start: 0;
+		inset-inline-end: 0;
 		width: 80px;
 		height: 100%;
-		background: linear-gradient( to right, transparent, #fff );
+		background: linear-gradient( to right, transparent, var(--color-surface) );
 		pointer-events: none;
 		z-index: 1;
+	}
+
+	html[dir="rtl"] &::after {
+		background: linear-gradient( to left, transparent, var(--color-surface) ) #{"/*rtl:ignore*/"};
 	}
 }
 
@@ -35,7 +39,8 @@
 	scroll-behavior: smooth;
 	// 4px block padding so box-shadows/borders aren't clipped top/bottom.
 	// 24px inline-start for left breathing room.
-	padding: 4px 0 4px 4px;
+	padding-block: 4px;
+	padding-inline: 4px 0;
 	// Hide scrollbar visually but keep functionality
 	scrollbar-width: none;
 	-ms-overflow-style: none;
@@ -103,4 +108,3 @@
 		color: var(--color-primary-60);
 	}
 }
-

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/style.scss
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/style.scss
@@ -70,16 +70,21 @@
 
 	// Lower (already-passed) tiers are muted
 	&.is-lower-tier {
-		filter: grayscale( 0.35 );
-		transition: filter 0.2s ease;
+		opacity: 0.55;
+		filter: grayscale( 0.65 );
+		transition:
+			opacity 0.2s ease,
+			filter 0.2s ease;
 
 		&:focus-within {
+			opacity: 1;
 			filter: none;
 		}
 
 		// On pointer devices (desktop), reveal on hover
 		@media ( hover: hover ) and ( pointer: fine ) {
 			&:hover {
+				opacity: 1;
 				filter: none;
 			}
 		}

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/style.scss
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/style.scss
@@ -1,8 +1,81 @@
+@import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/colors";
 
 :root {
 	--color-gray-100: #{$gray-100};
 	--color-gray-700: #{$gray-700};
+}
+
+// Wrapper provides the gradient fade — must sit outside the scroll container
+// because overflow clips pseudo-elements.
+.tier-cards-scroll-wrapper {
+	position: relative;
+	margin-inline-start: -4px;
+
+	// Gradient fade hinting there's more content to scroll
+	&::after {
+		content: '';
+		position: absolute;
+		top: 0;
+		right: 0;
+		width: 80px;
+		height: 100%;
+		background: linear-gradient( to right, transparent, #fff );
+		pointer-events: none;
+		z-index: 1;
+	}
+}
+
+// Tier cards horizontal scroll container
+.tier-cards-container {
+	display: flex;
+	flex-direction: row;
+	gap: 24px;
+	overflow-x: auto;
+	scroll-behavior: smooth;
+	// 4px block padding so box-shadows/borders aren't clipped top/bottom.
+	// 24px inline-start for left breathing room.
+	padding: 4px 0 4px 4px;
+	// Hide scrollbar visually but keep functionality
+	scrollbar-width: none;
+	-ms-overflow-style: none;
+	&::-webkit-scrollbar {
+		display: none;
+	}
+}
+
+// Individual card wrappers — fixed width so cards never stack.
+// On small screens: 85vw shows the current card fully with the next peeking in.
+// On larger screens: dynamic ~30% width shows ~3 cards with a peek.
+.tier-card-wrapper {
+	width: 72vw;
+	min-width: 260px;
+	min-height: 250px;
+	flex-shrink: 0;
+
+	@media ( min-width: #{ $break-small } ) {
+		width: clamp( 260px, calc( 30% - 12px ), 340px );
+	}
+
+	// Right-edge breathing room for the last card's border/shadow
+	&:last-child {
+		margin-inline-end: 80px; // wider than gradient so border clears the fade
+	}
+
+	// Lower (already-passed) tiers are muted
+	&.is-lower-tier {
+		opacity: 0.45;
+		filter: grayscale( 0.25 );
+		transition: opacity 0.2s ease, filter 0.2s ease;
+
+		// On pointer devices (desktop), reveal on hover
+		@media ( hover: hover ) and ( pointer: fine ) {
+			&:hover {
+				opacity: 1;
+				filter: none;
+			}
+		}
+	}
 }
 
 .agency-tier-overview-revamped {

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/style.scss
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/style.scss
@@ -32,13 +32,15 @@
 
 // Tier cards horizontal scroll container
 .tier-cards-container {
+	--tier-card-width: max( 260px, 72vw );
+
 	display: flex;
 	flex-direction: row;
 	gap: 24px;
 	overflow-x: auto;
 	scroll-behavior: smooth;
 	// 4px block padding so box-shadows/borders aren't clipped top/bottom.
-	// 24px inline-start for left breathing room.
+	// 4px inline-start padding so box-shadows/borders aren't clipped.
 	padding-block: 4px;
 	padding-inline: 4px 0;
 	// Hide scrollbar visually but keep functionality
@@ -47,36 +49,37 @@
 	&::-webkit-scrollbar {
 		display: none;
 	}
+
+	&::after {
+		content: '';
+		flex: 0 0 max( 80px, calc( 100% - var(--tier-card-width) ) );
+	}
+
+	@media ( min-width: #{ $break-small } ) {
+		--tier-card-width: clamp( 260px, calc( 30% - 12px ), 340px );
+	}
 }
 
 // Individual card wrappers — fixed width so cards never stack.
-// On small screens: 85vw shows the current card fully with the next peeking in.
+// On small screens: 72vw shows the current card fully with the next peeking in.
 // On larger screens: dynamic ~30% width shows ~3 cards with a peek.
 .tier-card-wrapper {
-	width: 72vw;
-	min-width: 260px;
+	width: var(--tier-card-width);
 	min-height: 250px;
 	flex-shrink: 0;
 
-	@media ( min-width: #{ $break-small } ) {
-		width: clamp( 260px, calc( 30% - 12px ), 340px );
-	}
-
-	// Right-edge breathing room for the last card's border/shadow
-	&:last-child {
-		margin-inline-end: 80px; // wider than gradient so border clears the fade
-	}
-
 	// Lower (already-passed) tiers are muted
 	&.is-lower-tier {
-		opacity: 0.45;
-		filter: grayscale( 0.25 );
-		transition: opacity 0.2s ease, filter 0.2s ease;
+		filter: grayscale( 0.35 );
+		transition: filter 0.2s ease;
+
+		&:focus-within {
+			filter: none;
+		}
 
 		// On pointer devices (desktop), reveal on hover
 		@media ( hover: hover ) and ( pointer: fine ) {
 			&:hover {
-				opacity: 1;
 				filter: none;
 			}
 		}

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-cards.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-cards.tsx
@@ -77,14 +77,20 @@ export default function TierCards( {
 	// Scroll so the current tier card is the first visible card on mount.
 	// Level 0 is already at the natural scroll start — only scroll for higher tiers.
 	useEffect( () => {
-		if ( ! containerRef.current || ! currentTier || currentTier.level === 0 ) {
+		const container = containerRef.current;
+		if ( ! container || ! currentTier || currentTier.level === 0 ) {
 			return;
 		}
-		const currentCard = containerRef.current.querySelector< HTMLElement >(
-			'[data-is-current-tier="true"]'
-		);
+		const currentCard = container.querySelector< HTMLElement >( '[data-is-current-tier="true"]' );
 		if ( currentCard ) {
-			currentCard.scrollIntoView( { block: 'nearest', inline: 'start' } );
+			const isRTL = getComputedStyle( container ).direction === 'rtl';
+			const containerRect = container.getBoundingClientRect();
+			const cardRect = currentCard.getBoundingClientRect();
+			const scrollOffset = isRTL
+				? cardRect.right - containerRect.right
+				: cardRect.left - containerRect.left;
+
+			container.scrollLeft += scrollOffset;
 		}
 	}, [ currentTier ] );
 
@@ -135,7 +141,7 @@ export default function TierCards( {
 							<Text color={ TEXT_COLOR }>{ tier.description }</Text>
 							{ isCurrentTier && isEarlyAccess && (
 								<Text color={ TEXT_COLOR } style={ { fontStyle: 'italic' } } weight={ 700 }>
-									{ createInterpolateElement( __( "You're in early. <a>Learn more</a>" ), {
+									{ createInterpolateElement( __( 'You’re in early. <a>Learn more</a>' ), {
 										a: (
 											<Button onClick={ handleViewEarlyAccessInfo } variant="link">
 												{ __( 'Learn more.' ) }
@@ -173,7 +179,7 @@ export default function TierCards( {
 							variant={ isSecondary ? 'secondary' : 'primary' }
 							style={ { marginBlockStart: '24px', alignSelf: 'flex-start' } }
 						>
-							{ hasHigherTier ? __( "See what you'll unlock" ) : __( 'View your benefits' ) }
+							{ hasHigherTier ? __( 'See what you’ll unlock' ) : __( 'View your benefits' ) }
 						</Button>
 					</CardBody>
 				</Card>
@@ -193,14 +199,14 @@ export default function TierCards( {
 					isDismissible
 					size="medium"
 					onRequestClose={ () => setShowEarlyAccessModal( false ) }
-					title={ __( "You've been granted early access" ) }
+					title={ __( 'You’ve been granted early access' ) }
 				>
 					<VStack spacing={ 8 }>
 						<Text>
 							{ sprintf(
 								/* translators: %s is the tier name */
 								__(
-									"You've been given early access to the %s tier in recognition of your partnership with Automattic. This is your head start to unlock powerful benefits, tools, and resources."
+									'You’ve been given early access to the %s tier in recognition of your partnership with Automattic. This is your head start to unlock powerful benefits, tools, and resources.'
 								),
 								currentTier.name
 							) }
@@ -246,7 +252,7 @@ export default function TierCards( {
 						</Text>
 						<Text>
 							{ __(
-								"You can still move up to a higher tier if your influenced revenue qualifies. However, if you do not meet the minimum requirements for this tier, any downgrade will only occur when the next year's cycle begins in January. This protection ensures you can continue to enjoy your current tier benefits throughout the year."
+								'You can still move up to a higher tier if your influenced revenue qualifies. However, if you do not meet the minimum requirements for this tier, any downgrade will only occur when the next year’s cycle begins in January. This protection ensures you can continue to enjoy your current tier benefits throughout the year.'
 							) }
 						</Text>
 						<ButtonStack justify="flex-end">

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-cards.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-cards.tsx
@@ -10,10 +10,9 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalHeading as Heading,
 } from '@wordpress/components';
-import { useViewportMatch } from '@wordpress/compose';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { ButtonStack } from 'calypso/dashboard/components/button-stack';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -35,7 +34,7 @@ export default function TierCards( {
 
 	const currentTier = getCurrentAgencyTier( currentAgencyTierId );
 
-	const isSmallViewport = useViewportMatch( 'wide', '<' );
+	const containerRef = useRef< HTMLDivElement >( null );
 
 	const [ showEarlyAccessModal, setShowEarlyAccessModal ] = useState( false );
 	const [ showTierProtectedModal, setShowTierProtectedModal ] = useState( false );
@@ -57,6 +56,7 @@ export default function TierCards( {
 		);
 		setShowTierProtectedModal( true );
 	};
+
 	const handleViewBenefits = ( tierId: string ) => {
 		dispatch(
 			recordTracksEvent( 'calypso_a4a_agency_tier_view_benefits_click', {
@@ -73,108 +73,137 @@ export default function TierCards( {
 	const isEarlyAccess = tierStatus === 'early_access';
 	const isTierProtected = tierStatus === 'tier_protected';
 
-	const content = (
-		<>
-			{ ALL_TIERS.map( ( tier ) => {
-				const hasLowerTier = currentTier && currentTier.level > tier.level;
-				const hasHigherTier = currentTier && currentTier.level < tier.level;
-				const isCurrentTier = currentTier === tier;
-				const isSecondary = hasLowerTier || hasHigherTier;
+	// Scroll so the current tier card is the first visible card on mount.
+	// Level 0 is already at the natural scroll start — only scroll for higher tiers.
+	useEffect( () => {
+		if ( ! containerRef.current || ! currentTier || currentTier.level === 0 ) {
+			return;
+		}
+		const currentCard = containerRef.current.querySelector< HTMLElement >(
+			'[data-is-current-tier="true"]'
+		);
+		if ( currentCard ) {
+			const containerRect = containerRef.current.getBoundingClientRect();
+			const cardRect = currentCard.getBoundingClientRect();
+			containerRef.current.scrollLeft += cardRect.left - containerRect.left;
+		}
+	}, [ currentTier ] );
 
-				return (
-					<Card
-						key={ tier.id }
-						style={ {
-							width: '100%',
-							height: '100%',
-							display: 'flex',
-							flexDirection: 'column',
-							...( isCurrentTier && {
-								boxShadow: '0 0 0 1px var(--color-primary-50)',
-							} ),
-						} }
-					>
-						<CardBody style={ { display: 'flex', flexDirection: 'column', height: '100%' } }>
-							<VStack spacing={ 1 } style={ { flex: 1, justifyContent: 'flex-start' } }>
-								<HStack style={ { marginBlockEnd: '4px' } }>
-									<Heading level={ 3 } weight={ 500 }>
-										{ tier.name }
-									</Heading>
-									{ isCurrentTier && ! isEarlyAccess && (
-										<Badge
-											style={ { minWidth: 'fit-content' } }
-											intent="default"
-											children={ __( 'Your tier' ) }
-										/>
-									) }
-								</HStack>
-								{ isCurrentTier && isEarlyAccess && (
+	const cards = ALL_TIERS.map( ( tier ) => {
+		const hasLowerTier = currentTier && currentTier.level > tier.level;
+		const hasHigherTier = currentTier && currentTier.level < tier.level;
+		const isCurrentTier = currentTier === tier;
+		const isSecondary = hasLowerTier || hasHigherTier;
+
+		return (
+			<div
+				key={ tier.id }
+				className={ [ 'tier-card-wrapper', hasLowerTier ? 'is-lower-tier' : '' ]
+					.filter( Boolean )
+					.join( ' ' ) }
+				data-is-current-tier={ isCurrentTier ? 'true' : undefined }
+			>
+				<Card
+					style={ {
+						width: '100%',
+						height: '100%',
+						display: 'flex',
+						flexDirection: 'column',
+						...( isCurrentTier && {
+							boxShadow: 'inset 0 0 0 1px var(--color-primary-50)',
+						} ),
+					} }
+				>
+					<CardBody style={ { display: 'flex', flexDirection: 'column', height: '100%' } }>
+						<VStack spacing={ 1 } style={ { flex: 1, justifyContent: 'flex-start' } }>
+							<HStack style={ { marginBlockEnd: '4px' } }>
+								<Heading level={ 3 } weight={ 500 }>
+									{ tier.name }
+								</Heading>
+								{ isCurrentTier && ! isEarlyAccess && (
 									<Badge
-										style={ { width: 'fit-content' } }
+										style={ { minWidth: 'fit-content' } }
 										intent="default"
-										children={ __( 'Your tier — Early access' ) }
+										children={ __( 'Your tier' ) }
 									/>
 								) }
-								<Text color={ TEXT_COLOR }>{ tier.description }</Text>
-								{ isCurrentTier && isEarlyAccess && (
-									<Text color={ TEXT_COLOR } style={ { fontStyle: 'italic' } } weight={ 700 }>
-										{ createInterpolateElement( __( 'You’re in early. <a>Learn more</a>' ), {
+							</HStack>
+							{ isCurrentTier && isEarlyAccess && (
+								<Badge
+									style={ { width: 'fit-content' } }
+									intent="default"
+									children={ __( 'Your tier — Early access' ) }
+								/>
+							) }
+							<Text color={ TEXT_COLOR }>{ tier.description }</Text>
+							{ isCurrentTier && isEarlyAccess && (
+								<Text color={ TEXT_COLOR } style={ { fontStyle: 'italic' } } weight={ 700 }>
+									{ createInterpolateElement( __( "You're in early. <a>Learn more</a>" ), {
+										a: (
+											<Button onClick={ handleViewEarlyAccessInfo } variant="link">
+												{ __( 'Learn more.' ) }
+											</Button>
+										),
+									} ) }
+								</Text>
+							) }
+							{ isCurrentTier && isTierProtected && (
+								<Text color={ TEXT_COLOR } style={ { fontStyle: 'italic' } } weight={ 700 }>
+									{ createInterpolateElement(
+										__( 'Your tier level is protected. <a>Learn more</a>' ),
+										{
 											a: (
-												<Button onClick={ handleViewEarlyAccessInfo } variant="link">
+												<Button onClick={ handleViewTierProtectedInfo } variant="link">
 													{ __( 'Learn more.' ) }
 												</Button>
 											),
-										} ) }
-									</Text>
-								) }
-								{ isCurrentTier && isTierProtected && (
-									<Text color={ TEXT_COLOR } style={ { fontStyle: 'italic' } } weight={ 700 }>
-										{ createInterpolateElement(
-											__( 'Your tier level is protected. <a>Learn more</a>' ),
-											{
-												a: (
-													<Button onClick={ handleViewTierProtectedInfo } variant="link">
-														{ __( 'Learn more.' ) }
-													</Button>
-												),
-											}
-										) }
-									</Text>
-								) }
-							</VStack>
-							<VStack
-								spacing={ 1 }
-								style={ { flex: 1, justifyContent: 'flex-start', marginBlockStart: '8px' } }
-							>
-								<Text color={ TEXT_COLOR } weight={ 700 }>
-									{ tier.heading }
+										}
+									) }
 								</Text>
-								<Text color={ TEXT_COLOR }>{ tier.subheading }</Text>
-							</VStack>
-							<Button
-								onClick={ () => handleViewBenefits( tier.id as string ) }
-								variant={ isSecondary ? 'secondary' : 'primary' }
-								style={ { marginBlockStart: '24px', alignSelf: 'flex-start' } }
-							>
-								{ hasHigherTier ? __( 'See what you’ll unlock' ) : __( 'View your benefits' ) }
-							</Button>
-						</CardBody>
-					</Card>
-				);
-			} ) }
+							) }
+						</VStack>
+						<VStack
+							spacing={ 1 }
+							style={ { flex: 1, justifyContent: 'flex-start', marginBlockStart: '8px' } }
+						>
+							<Text color={ TEXT_COLOR } weight={ 700 }>
+								{ tier.heading }
+							</Text>
+							<Text color={ TEXT_COLOR }>{ tier.subheading }</Text>
+						</VStack>
+						<Button
+							onClick={ () => handleViewBenefits( tier.id as string ) }
+							variant={ isSecondary ? 'secondary' : 'primary' }
+							style={ { marginBlockStart: '24px', alignSelf: 'flex-start' } }
+						>
+							{ hasHigherTier ? __( "See what you'll unlock" ) : __( 'View your benefits' ) }
+						</Button>
+					</CardBody>
+				</Card>
+			</div>
+		);
+	} );
+
+	return (
+		<>
+			<div className="tier-cards-scroll-wrapper">
+				<div ref={ containerRef } className="tier-cards-container">
+					{ cards }
+				</div>
+			</div>
 			{ showEarlyAccessModal && currentTier && (
 				<Modal
 					isDismissible
 					size="medium"
 					onRequestClose={ () => setShowEarlyAccessModal( false ) }
-					title={ __( 'You’ve been granted early access' ) }
+					title={ __( "You've been granted early access" ) }
 				>
 					<VStack spacing={ 8 }>
 						<Text>
 							{ sprintf(
 								/* translators: %s is the tier name */
 								__(
-									'You’ve been given early access to the %s tier in recognition of your partnership with Automattic. This is your head start to unlock powerful benefits, tools, and resources.'
+									"You've been given early access to the %s tier in recognition of your partnership with Automattic. This is your head start to unlock powerful benefits, tools, and resources."
 								),
 								currentTier.name
 							) }
@@ -220,7 +249,7 @@ export default function TierCards( {
 						</Text>
 						<Text>
 							{ __(
-								'You can still move up to a higher tier if your influenced revenue qualifies. However, if you do not meet the minimum requirements for this tier, any downgrade will only occur when the next year’s cycle begins in January. This protection ensures you can continue to enjoy your current tier benefits throughout the year.'
+								"You can still move up to a higher tier if your influenced revenue qualifies. However, if you do not meet the minimum requirements for this tier, any downgrade will only occur when the next year's cycle begins in January. This protection ensures you can continue to enjoy your current tier benefits throughout the year."
 							) }
 						</Text>
 						<ButtonStack justify="flex-end">
@@ -232,27 +261,5 @@ export default function TierCards( {
 				</Modal>
 			) }
 		</>
-	);
-
-	if ( isSmallViewport ) {
-		return (
-			<VStack spacing={ 6 } style={ { alignItems: 'center' } }>
-				{ content }
-			</VStack>
-		);
-	}
-
-	return (
-		<div
-			style={ {
-				display: 'grid',
-				gridTemplateColumns: 'repeat(3, 1fr)',
-				gridAutoRows: '1fr',
-				gap: '24px',
-				alignItems: 'stretch',
-			} }
-		>
-			{ content }
-		</div>
 	);
 }

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-cards.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-cards.tsx
@@ -74,7 +74,7 @@ export default function TierCards( {
 	const isEarlyAccess = tierStatus === 'early_access';
 	const isTierProtected = tierStatus === 'tier_protected';
 
-	// Scroll so the current tier card is the first visible card on mount.
+	// Scroll so the current tier stays selected while previous tiers remain visible.
 	// Level 0 is already at the natural scroll start — only scroll for higher tiers.
 	useEffect( () => {
 		const container = containerRef.current;
@@ -83,12 +83,21 @@ export default function TierCards( {
 		}
 		const currentCard = container.querySelector< HTMLElement >( '[data-is-current-tier="true"]' );
 		if ( currentCard ) {
-			const isRTL = getComputedStyle( container ).direction === 'rtl';
+			const containerStyles = getComputedStyle( container );
+			const isRTL = containerStyles.direction === 'rtl';
 			const containerRect = container.getBoundingClientRect();
 			const cardRect = currentCard.getBoundingClientRect();
+			const previousCard = currentCard.previousElementSibling;
+			const cardGap = Number.parseFloat( containerStyles.columnGap ) || 0;
+			const previousTierOffset =
+				previousCard instanceof HTMLElement
+					? previousCard.getBoundingClientRect().width + cardGap
+					: 0;
+			const availableInlineSpace = Math.max( containerRect.width - cardRect.width, 0 );
+			const visiblePreviousTierOffset = Math.min( previousTierOffset, availableInlineSpace / 2 );
 			const scrollOffset = isRTL
-				? cardRect.right - containerRect.right
-				: cardRect.left - containerRect.left;
+				? cardRect.right - containerRect.right + visiblePreviousTierOffset
+				: cardRect.left - containerRect.left - visiblePreviousTierOffset;
 
 			container.scrollLeft += scrollOffset;
 		}

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-cards.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-cards.tsx
@@ -12,6 +12,7 @@ import {
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import clsx from 'clsx';
 import { useState, useEffect, useRef } from 'react';
 import { ButtonStack } from 'calypso/dashboard/components/button-stack';
 import { useDispatch } from 'calypso/state';
@@ -98,9 +99,7 @@ export default function TierCards( {
 		return (
 			<div
 				key={ tier.id }
-				className={ [ 'tier-card-wrapper', hasLowerTier ? 'is-lower-tier' : '' ]
-					.filter( Boolean )
-					.join( ' ' ) }
+				className={ clsx( 'tier-card-wrapper', hasLowerTier && 'is-lower-tier' ) }
 				data-is-current-tier={ isCurrentTier ? 'true' : undefined }
 			>
 				<Card

--- a/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-cards.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/overview-content/tier-cards.tsx
@@ -84,9 +84,7 @@ export default function TierCards( {
 			'[data-is-current-tier="true"]'
 		);
 		if ( currentCard ) {
-			const containerRect = containerRef.current.getBoundingClientRect();
-			const cardRect = currentCard.getBoundingClientRect();
-			containerRef.current.scrollLeft += cardRect.left - containerRect.left;
+			currentCard.scrollIntoView( { block: 'nearest', inline: 'start' } );
 		}
 	}, [ currentTier ] );
 


### PR DESCRIPTION
Replaces the responsive grid/stacked layout with a single horizontal scroll container. Current tier is always the first visible card; lower (already-achieved) tiers scroll off to the left and are visually muted. A gradient fade on the right hints at more cards to scroll.

[Linear issue](https://linear.app/a8c/issue/A4A-2736/tiers-remove-stacking-of-tier-cards-clean-up-verbiage)

### Old:
<img width="2984" height="2132" alt="CleanShot 2026-06-04 at 13 07 51@2x" src="https://github.com/user-attachments/assets/f6c33dcc-3b13-49b0-9a21-b8e47f5ce217" />
<img width="854" height="1848" alt="CleanShot 2026-06-04 at 13 08 26@2x" src="https://github.com/user-attachments/assets/cd01f37e-eceb-4a70-b847-ceb81de3ee06" />


### New



<img width="762" height="1554" alt="CleanShot 2026-06-04 at 13 06 08@2x" src="https://github.com/user-attachments/assets/3740b4e4-9cc9-41e0-a1f1-7f5f80349a79" />
<img width="764" height="1548" alt="CleanShot 2026-06-04 at 13 05 33@2x" src="https://github.com/user-attachments/assets/7922e166-4535-4e5c-ad6d-5eed0fab8322" />
<img width="3438" height="1816" alt="CleanShot 2026-06-04 at 13 05 05@2x" src="https://github.com/user-attachments/assets/22d5003b-77e4-4a8c-b7bd-33977846905c" />
<img width="3432" height="1974" alt="CleanShot 2026-06-04 at 13 04 47@2x" src="https://github.com/user-attachments/assets/3fcbb4b7-579e-4721-8c07-c02185f8f79e" />


## Proposed Changes

* Adds side scrolling behavior for all devices. Reduces vertical real-estate.
* Modifies some verbiage to reduce visual load. 

Details:
- Horizontal scroll with hidden scrollbar; mobile cards are 72vw, desktop uses clamp-based width (~3 visible + peek)
- Scroll-to-current-tier on mount via getBoundingClientRect
- Lower tiers muted (opacity + grayscale); hover reveals on pointer devices
- Gradient fade overlay on right edge via wrapper pseudo-element
- Tier 0 description changed to "Under $1,200 influenced revenue"
- All formatCurrency calls use stripZeros to remove trailing .00
- Agency Partner subheading updated to reflect clearer benefit copy
- Removed Divider margin={4} to equalise spacing above/below card row

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

The previous layout stacked tier cards into a grid that consumed significant vertical real estate, particularly on mobile. Agencies couldn't see all their tier options at a glance, and there was no clear visual hierarchy between the current tier and future tiers. The horizontal scroll pattern keeps the current tier front and center while visually deprioritizing already-achieved tiers, shifting the focus forward rather than backward. The gradient fade and card peeking create a natural scroll affordance without requiring additional UI chrome.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Navigate to /agency-tier on a desktop viewport
- Cards should scroll horizontally in a single row — none should stack
- The current tier card should be the first visible card on load
- A gradient fade should be visible on the right edge hinting at more cards
- Resize to mobile (<600px) or use DevTools mobile emulation
- The current tier card should occupy ~72vw with the next card peeking in on the right
- If testing with an account on a tier above level 0 (e.g. Agency Partner or higher):
- Lower/already-achieved tier cards to the left should appear muted (reduced opacity)
- On desktop, hovering a muted card should restore it to full opacity
- Scroll fully right — the last card's border should not be clipped
- Scroll fully left — the first card's border should not be clipped
- Confirm "Account activated" shows "Under $1,200 influenced revenue" with no .00 decimals on any tier card

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
