### PR TITLE
Domain bundles: group bundle-tagged line items in mini-cart and checkout

### DIFF
--- a/client/layout/masterbar/masterbar-cart/masterbar-cart-button.tsx
+++ b/client/layout/masterbar/masterbar-cart/masterbar-cart-button.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Popover } from '@automattic/components';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
 import { MiniCart } from '@automattic/mini-cart';
@@ -119,6 +120,7 @@ export function MasterbarCartButton( {
 						onRemoveCoupon={ onRemoveCoupon }
 						checkoutLabel={ checkoutLabel }
 						emptyCart={ emptyCart }
+						showBundleGrouping={ config.isEnabled( 'domain-bundling' ) }
 					/>
 				</CheckoutErrorBoundary>
 			</Popover>

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -6,8 +6,10 @@ import {
 	canItemBeRemovedFromCart,
 	getCouponLineItemFromCart,
 	getCreditsLineItemFromCart,
+	groupBundleLineItems,
 	isWpComProductRenewal,
 	joinClasses,
+	BundleLineItem,
 	CouponLineItem,
 	NonProductLineItem,
 	LineItem,
@@ -45,6 +47,7 @@ import type {
 	RemoveCouponFromCart,
 	AddProductsToCart,
 } from '@automattic/shopping-cart';
+import type { GroupedCartLineItem } from '@automattic/wpcom-checkout';
 import type { PropsWithChildren, RefObject } from 'react';
 
 const WPOrderReviewList = styled.ul`
@@ -122,6 +125,16 @@ export function WPOrderReviewLineItems( {
 	} );
 	const [ initialProducts ] = useState( () => responseCart.products );
 	const [ forceShowAkQuantityDropdown, setForceShowAkQuantityDropdown ] = useState( false );
+
+	// Bundle grouping is gated behind the `domain-bundling` feature flag. When off,
+	// every product renders on its own line exactly as before.
+	const groupedLineItems: GroupedCartLineItem[] = config.isEnabled( 'domain-bundling' )
+		? groupBundleLineItems( responseCart.products )
+		: responseCart.products.map( ( product ) => ( { type: 'product' as const, product } ) );
+
+	// Match the single-item path: the WooCommerce mobile app webview hides the
+	// remove action, so a bundle must not surface one either.
+	const isWooMobile = isWcMobileApp();
 
 	const isAkismetProMultipleLicensesCart = useMemo( () => {
 		if ( ! config.isEnabled( 'akismet/checkout-quantity-dropdown' ) ) {
@@ -203,38 +216,59 @@ export function WPOrderReviewLineItems( {
 
 	return (
 		<WPOrderReviewList className={ joinClasses( [ className, 'order-review-line-items' ] ) }>
-			{ responseCart.products.map( ( product ) => (
-				<LineItemWrapper
-					key={ product.uuid }
-					product={ product }
-					isSummary={ isSummary }
-					removeProductFromCart={ removeProductFromCart }
-					onChangeSelection={ onChangeSelection }
-					createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
-					responseCart={ responseCart }
-					isPwpoUser={ isPwpoUser }
-					onRemoveProduct={ onRemoveProduct }
-					onRemoveProductClick={ onRemoveProductClick }
-					onRemoveProductCancel={ onRemoveProductCancel }
-					hasPartnerCoupon={ hasPartnerCoupon }
-					isDisabled={ isDisabled }
-					initialVariantTerm={
-						initialProducts.find( ( initialProduct ) => {
-							return initialProduct.product_variants.find(
-								( variant ) => variant.product_id === product.product_id
-							);
-						} )?.months_per_bill_period
-					}
-					toggleVariantSelector={ handleVariantToggle }
-					variantOpenId={ variantOpenId }
-					isAkPro500Cart={ isAkismetProMultipleLicensesCart || forceShowAkQuantityDropdown }
-					setForceShowAkQuantityDropdown={ setForceShowAkQuantityDropdown }
-					onChangeAkProQuantity={ changeAkismetPro500CartQuantity }
-					toggleAkQuantityDropdown={ handleAkQuantityToggle }
-					akQuantityOpenId={ akQuantityOpenId }
-					isRenewalPricingExperiment={ isRenewalPricingTreatment( renewalPricingVariation ) }
-				/>
-			) ) }
+			{ groupedLineItems.map( ( entry ) => {
+				if ( entry.type === 'bundle' ) {
+					return (
+						<WPOrderReviewListItem key={ `bundle-${ entry.groupId }` }>
+							<BundleLineItem
+								bundle={ entry }
+								isSummary={ isSummary }
+								hasDeleteButton={
+									! isWooMobile &&
+									entry.products.every( ( product ) =>
+										canItemBeRemovedFromCart( product, responseCart )
+									)
+								}
+								removeProductFromCart={ removeProductFromCart }
+							/>
+						</WPOrderReviewListItem>
+					);
+				}
+
+				const { product } = entry;
+				return (
+					<LineItemWrapper
+						key={ product.uuid }
+						product={ product }
+						isSummary={ isSummary }
+						removeProductFromCart={ removeProductFromCart }
+						onChangeSelection={ onChangeSelection }
+						createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
+						responseCart={ responseCart }
+						isPwpoUser={ isPwpoUser }
+						onRemoveProduct={ onRemoveProduct }
+						onRemoveProductClick={ onRemoveProductClick }
+						onRemoveProductCancel={ onRemoveProductCancel }
+						hasPartnerCoupon={ hasPartnerCoupon }
+						isDisabled={ isDisabled }
+						initialVariantTerm={
+							initialProducts.find( ( initialProduct ) => {
+								return initialProduct.product_variants.find(
+									( variant ) => variant.product_id === product.product_id
+								);
+							} )?.months_per_bill_period
+						}
+						toggleVariantSelector={ handleVariantToggle }
+						variantOpenId={ variantOpenId }
+						isAkPro500Cart={ isAkismetProMultipleLicensesCart || forceShowAkQuantityDropdown }
+						setForceShowAkQuantityDropdown={ setForceShowAkQuantityDropdown }
+						onChangeAkProQuantity={ changeAkismetPro500CartQuantity }
+						toggleAkQuantityDropdown={ handleAkQuantityToggle }
+						akQuantityOpenId={ akQuantityOpenId }
+						isRenewalPricingExperiment={ isRenewalPricingTreatment( renewalPricingVariation ) }
+					/>
+				);
+			} ) }
 			{ restorableProducts.map( ( product ) => (
 				<RemovedFromCartItem
 					key={ product.uuid }

--- a/packages/mini-cart/jest.config.js
+++ b/packages/mini-cart/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+	preset: '../../test/packages/jest-preset.js',
+	testEnvironment: 'jsdom',
+	globals: {
+		configData: {},
+	},
+};

--- a/packages/mini-cart/src/mini-cart-line-items.tsx
+++ b/packages/mini-cart/src/mini-cart-line-items.tsx
@@ -1,6 +1,8 @@
 import {
 	getCouponLineItemFromCart,
 	getCreditsLineItemFromCart,
+	groupBundleLineItems,
+	BundleLineItem,
 	NonProductLineItem,
 	LineItem,
 	canItemBeRemovedFromCart,
@@ -39,20 +41,44 @@ export function MiniCartLineItems( {
 	removeCoupon,
 	createUserAndSiteBeforeTransaction,
 	responseCart,
+	showBundleGrouping = false,
 }: {
 	removeProductFromCart: RemoveProductFromCart;
 	addProductsToCart: AddProductsToCart;
 	removeCoupon: RemoveCouponFromCart;
 	createUserAndSiteBeforeTransaction?: boolean;
 	responseCart: ResponseCart;
+	showBundleGrouping?: boolean;
 } ) {
 	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
 	const couponLineItem = getCouponLineItemFromCart( responseCart );
 	const [ restorableProducts, setRestorableProducts ] = useRestorableProducts();
 
+	// Bundle grouping is gated behind the `domain-bundling` feature flag, surfaced
+	// here as the `showBundleGrouping` prop (this package stays free of a
+	// calypso-config dependency). When off, every product renders on its own line.
+	const groupedLineItems = showBundleGrouping
+		? groupBundleLineItems( responseCart.products )
+		: responseCart.products.map( ( product ) => ( { type: 'product' as const, product } ) );
+
 	return (
 		<MiniCartLineItemsWrapper className="mini-cart-line-items">
-			{ responseCart.products.map( ( product ) => {
+			{ groupedLineItems.map( ( entry ) => {
+				if ( entry.type === 'bundle' ) {
+					return (
+						<MiniCartLineItemWrapper key={ `bundle-${ entry.groupId }` }>
+							<BundleLineItem
+								bundle={ entry }
+								hasDeleteButton={ entry.products.every( ( product ) =>
+									canItemBeRemovedFromCart( product, responseCart )
+								) }
+								removeProductFromCart={ removeProductFromCart }
+							/>
+						</MiniCartLineItemWrapper>
+					);
+				}
+
+				const { product } = entry;
 				return (
 					<MiniCartLineItemWrapper key={ product.uuid }>
 						<LineItem

--- a/packages/mini-cart/src/mini-cart.tsx
+++ b/packages/mini-cart/src/mini-cart.tsx
@@ -135,6 +135,7 @@ export function MiniCart( {
 	onRemoveCoupon,
 	checkoutLabel,
 	emptyCart,
+	showBundleGrouping = false,
 }: {
 	selectedSiteSlug: string;
 	cartKey: number | undefined;
@@ -144,6 +145,7 @@ export function MiniCart( {
 	onRemoveCoupon?: () => void;
 	checkoutLabel?: string;
 	emptyCart?: React.ReactNode;
+	showBundleGrouping?: boolean;
 } ) {
 	const {
 		responseCart,
@@ -198,6 +200,7 @@ export function MiniCart( {
 						removeProductFromCart={ handleRemoveProduct }
 						addProductsToCart={ addProductsToCart }
 						responseCart={ responseCart }
+						showBundleGrouping={ showBundleGrouping }
 					/>
 					{ shouldRenderEmptyCart && emptyCart }
 					{ ! shouldRenderEmptyCart && <MiniCartTotal responseCart={ responseCart } /> }

--- a/packages/mini-cart/test/mini-cart-line-items.tsx
+++ b/packages/mini-cart/test/mini-cart-line-items.tsx
@@ -1,0 +1,74 @@
+import { CheckoutProvider } from '@automattic/composite-checkout';
+import { getEmptyResponseCart, getEmptyResponseCartProduct } from '@automattic/shopping-cart';
+import { RestorableProductsProvider } from '@automattic/wpcom-checkout';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MiniCartLineItems } from '../src/mini-cart-line-items';
+import type { ResponseCart, ResponseCartProduct } from '@automattic/shopping-cart';
+
+function domainProduct(
+	uuid: string,
+	meta: string,
+	groupId?: string,
+	role?: 'primary' | 'companion'
+): ResponseCartProduct {
+	return {
+		...getEmptyResponseCartProduct(),
+		uuid,
+		meta,
+		product_slug: 'domain_reg',
+		is_domain_registration: true,
+		item_subtotal_integer: 2000,
+		extra: groupId
+			? { domain_bundle_group_id: groupId, domain_bundle_role: role, expected_bundle_size: '2' }
+			: {},
+	};
+}
+
+function bundleCart(): ResponseCart {
+	return {
+		...getEmptyResponseCart(),
+		products: [
+			domainProduct( 'primary', 'example.com', 'bundle-abc', 'primary' ),
+			domainProduct( 'companion', 'example.net', 'bundle-abc', 'companion' ),
+			domainProduct( 'standalone', 'standalone.com' ),
+		],
+	};
+}
+
+function renderLineItems( showBundleGrouping: boolean ) {
+	return render(
+		<CheckoutProvider paymentMethods={ [] } paymentProcessors={ {} }>
+			<RestorableProductsProvider>
+				<MiniCartLineItems
+					responseCart={ bundleCart() }
+					removeProductFromCart={ jest.fn() }
+					addProductsToCart={ jest.fn() }
+					removeCoupon={ jest.fn() }
+					showBundleGrouping={ showBundleGrouping }
+				/>
+			</RestorableProductsProvider>
+		</CheckoutProvider>
+	);
+}
+
+describe( 'MiniCartLineItems bundle grouping', () => {
+	test( 'folds bundle members into one grouped line item when grouping is enabled', () => {
+		renderLineItems( true );
+
+		expect( screen.getByText( 'Domain bundle' ) ).toBeVisible();
+		// Both members show inside the group; the standalone domain stays on its own line.
+		expect( screen.getByText( 'example.com' ) ).toBeVisible();
+		expect( screen.getByText( 'example.net' ) ).toBeVisible();
+		expect( screen.getByText( 'standalone.com' ) ).toBeVisible();
+	} );
+
+	test( 'renders every product on its own line when grouping is disabled', () => {
+		renderLineItems( false );
+
+		expect( screen.queryByText( 'Domain bundle' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'example.com' ) ).toBeVisible();
+		expect( screen.getByText( 'example.net' ) ).toBeVisible();
+		expect( screen.getByText( 'standalone.com' ) ).toBeVisible();
+	} );
+} );

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -32,6 +32,7 @@ import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useState, PropsWithChildren, useRef, Dispatch, SetStateAction } from 'react';
 import { getLabel, DefaultLineItemSublabel } from './checkout-labels';
+import { type CartBundleLineItem } from './group-bundle-line-items';
 import {
 	getIntroductoryOfferIntervalDisplay,
 	getItemIntroductoryOfferDisplay,
@@ -410,6 +411,123 @@ function EmailMeta( { product, isRenewal }: { product: ResponseCartProduct; isRe
 			} ) }
 		</>
 	);
+}
+
+/**
+ * Render a domain bundle as a single grouped line item: one title and total, the
+ * member domains listed beneath, and a single remove action that clears every
+ * member from the cart at once (matching the backend's all-or-nothing rule).
+ */
+export function BundleLineItem( {
+	bundle,
+	className = null,
+	isSummary,
+	hasDeleteButton,
+	removeProductFromCart,
+}: {
+	bundle: CartBundleLineItem;
+	className?: string | null;
+	isSummary?: boolean;
+	hasDeleteButton?: boolean;
+	removeProductFromCart?: RemoveProductFromCart;
+} ) {
+	const translate = useTranslate();
+	const { formStatus } = useFormStatus();
+	const isDisabled = formStatus !== FormStatus.READY;
+	const [ isModalVisible, setIsModalVisible ] = useState( false );
+
+	const { products } = bundle;
+	// All members of a bundle are guaranteed to share a currency, so the total can
+	// safely be summed in the smallest unit and rendered under the first member's currency.
+	const currency = products[ 0 ]?.currency ?? 'USD';
+	const bundleTotalInteger = products.reduce(
+		( total, product ) => total + product.item_subtotal_integer,
+		0
+	);
+	const bundleTotalDisplay = formatCurrency( bundleTotalInteger, currency, {
+		isSmallestUnit: true,
+		stripZeros: true,
+	} );
+	const bundleLabel = String( translate( 'Domain bundle' ) );
+
+	const removeBundleFromCart = () => {
+		products.forEach( ( product ) => {
+			removeProductFromCart?.( product.uuid );
+		} );
+	};
+
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
+	return (
+		<div
+			className={ joinClasses( [ className, 'checkout-line-item' ] ) }
+			data-e2e-product-slug="domain-bundle"
+			data-product-type="domain-bundle"
+		>
+			<LineItemTitle isSummary={ isSummary }>{ bundleLabel }</LineItemTitle>
+
+			<span className="checkout-line-item__price">
+				<LineItemPrice actualAmount={ bundleTotalDisplay } />
+			</span>
+
+			{ products.map( ( product ) => (
+				<LineItemMeta key={ product.uuid }>
+					<span>{ product.meta }</span>
+					<span>
+						{ formatCurrency( product.item_subtotal_integer, product.currency, {
+							isSmallestUnit: true,
+							stripZeros: true,
+						} ) }
+					</span>
+				</LineItemMeta>
+			) ) }
+
+			{ hasDeleteButton && removeProductFromCart && (
+				<>
+					<DeleteButtonWrapper>
+						<DeleteButton
+							className="checkout-line-item__remove-product"
+							buttonType="text-button"
+							aria-label={ String(
+								translate( 'Remove %s from cart', {
+									args: bundleLabel,
+								} )
+							) }
+							disabled={ isDisabled }
+							onClick={ () => {
+								setIsModalVisible( true );
+							} }
+						>
+							{ translate( 'Remove from cart' ) }
+						</DeleteButton>
+					</DeleteButtonWrapper>
+
+					<CheckoutModal
+						isVisible={ isModalVisible }
+						closeModal={ () => {
+							setIsModalVisible( false );
+						} }
+						secondaryAction={ () => {
+							setIsModalVisible( false );
+						} }
+						primaryAction={ removeBundleFromCart }
+						secondaryButtonCTA={ String( translate( 'Cancel' ) ) }
+						title={ String( translate( 'Remove domain bundle' ) ) }
+						copy={ String(
+							translate(
+								'Removing this domain bundle will remove its %(domainCount)d domain from your cart.',
+								'Removing this domain bundle will remove all %(domainCount)d domains from your cart.',
+								{
+									count: products.length,
+									args: { domainCount: products.length },
+								}
+							)
+						) }
+					/>
+				</>
+			) }
+		</div>
+	);
+	/* eslint-enable wpcalypso/jsx-classname-namespace */
 }
 
 interface ModalCopy {

--- a/packages/wpcom-checkout/src/group-bundle-line-items.ts
+++ b/packages/wpcom-checkout/src/group-bundle-line-items.ts
@@ -1,0 +1,102 @@
+import type { ResponseCartProduct } from '@automattic/shopping-cart';
+
+/**
+ * A single, ungrouped cart product rendered on its own line.
+ */
+export interface CartSingleLineItem {
+	type: 'product';
+	product: ResponseCartProduct;
+}
+
+/**
+ * A set of cart products that belong to the same domain bundle, rendered as one
+ * grouped line item. `products` is ordered primary-first, then companions in
+ * their original cart order.
+ */
+export interface CartBundleLineItem {
+	type: 'bundle';
+	groupId: string;
+	products: ResponseCartProduct[];
+}
+
+export type GroupedCartLineItem = CartSingleLineItem | CartBundleLineItem;
+
+/**
+ * Fold cart products that share a `domain_bundle_group_id` into a single grouped
+ * line item, leaving every other product untouched.
+ *
+ * The result preserves cart order: a bundle group appears at the position of its
+ * first member, and ungrouped products stay exactly where they were. Within a
+ * group, the `primary` member is listed first, then companions in cart order.
+ *
+ * A "group" of fewer than two surviving members is degenerate (the backend
+ * enforces all-or-nothing membership, so it shouldn't happen) and is rendered as
+ * a plain product rather than as a one-item bundle.
+ * @param products The cart's products, in cart order.
+ * @returns Render entries in cart order: plain products and bundle groups.
+ */
+export function groupBundleLineItems( products: ResponseCartProduct[] ): GroupedCartLineItem[] {
+	const groupOrder: string[] = [];
+	const membersByGroup = new Map< string, ResponseCartProduct[] >();
+
+	for ( const product of products ) {
+		const groupId = product.extra?.domain_bundle_group_id;
+
+		if ( ! groupId ) {
+			continue;
+		}
+
+		if ( ! membersByGroup.has( groupId ) ) {
+			membersByGroup.set( groupId, [] );
+			groupOrder.push( groupId );
+		}
+
+		membersByGroup.get( groupId )?.push( product );
+	}
+
+	// Group ids that ended up with a single member fall back to plain products.
+	const realBundleGroups = new Set(
+		groupOrder.filter( ( groupId ) => ( membersByGroup.get( groupId )?.length ?? 0 ) >= 2 )
+	);
+
+	const entries: GroupedCartLineItem[] = [];
+	const emittedGroups = new Set< string >();
+
+	for ( const product of products ) {
+		const groupId = product.extra?.domain_bundle_group_id;
+
+		if ( ! groupId || ! realBundleGroups.has( groupId ) ) {
+			entries.push( { type: 'product', product } );
+			continue;
+		}
+
+		// Emit the whole bundle once, at the position of its first member.
+		if ( emittedGroups.has( groupId ) ) {
+			continue;
+		}
+
+		emittedGroups.add( groupId );
+		entries.push( {
+			type: 'bundle',
+			groupId,
+			products: orderBundleMembers( membersByGroup.get( groupId ) ?? [] ),
+		} );
+	}
+
+	return entries;
+}
+
+/**
+ * Order a bundle's members primary-first, preserving the original cart order for
+ * everything else (companions and any untagged members).
+ * @param members The bundle's members, in cart order.
+ * @returns The members with the `primary` role moved to the front.
+ */
+function orderBundleMembers( members: ResponseCartProduct[] ): ResponseCartProduct[] {
+	const primaries = members.filter(
+		( product ) => product.extra?.domain_bundle_role === 'primary'
+	);
+	const rest = members.filter( ( product ) => product.extra?.domain_bundle_role !== 'primary' );
+
+	return [ ...primaries, ...rest ];
+}

--- a/packages/wpcom-checkout/src/index.ts
+++ b/packages/wpcom-checkout/src/index.ts
@@ -26,6 +26,7 @@ export * from './checkout-labels';
 export * from './introductory-offer';
 export * from './join-classes';
 export * from './checkout-line-items';
+export * from './group-bundle-line-items';
 export * from './get-country-postal-code-support';
 export * from './get-country-tax-requirements';
 export * from './can-item-be-removed-from-cart';

--- a/packages/wpcom-checkout/test/bundle-line-item.tsx
+++ b/packages/wpcom-checkout/test/bundle-line-item.tsx
@@ -1,0 +1,62 @@
+import { CheckoutProvider } from '@automattic/composite-checkout';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { BundleLineItem } from '../src/checkout-line-items';
+import { buildDomainProduct } from './fixtures/bundle-cart';
+import type { CartBundleLineItem } from '../src/group-bundle-line-items';
+
+const bundle: CartBundleLineItem = {
+	type: 'bundle',
+	groupId: 'bundle-abc',
+	products: [
+		buildDomainProduct(
+			{ uuid: 'primary', meta: 'example.com', item_subtotal_integer: 2200 },
+			{ groupId: 'bundle-abc', role: 'primary' }
+		),
+		buildDomainProduct(
+			{ uuid: 'companion', meta: 'example.net', item_subtotal_integer: 1800 },
+			{ groupId: 'bundle-abc', role: 'companion' }
+		),
+	],
+};
+
+function renderBundle( props: Partial< React.ComponentProps< typeof BundleLineItem > > = {} ) {
+	return render(
+		<CheckoutProvider paymentMethods={ [] } paymentProcessors={ {} }>
+			<BundleLineItem bundle={ bundle } { ...props } />
+		</CheckoutProvider>
+	);
+}
+
+describe( 'BundleLineItem', () => {
+	test( 'renders the bundle label, member domains, and the summed total', () => {
+		renderBundle();
+
+		expect( screen.getByText( 'Domain bundle' ) ).toBeVisible();
+		expect( screen.getByText( 'example.com' ) ).toBeVisible();
+		expect( screen.getByText( 'example.net' ) ).toBeVisible();
+		// 2200 + 1800 = 4000 smallest-unit => $40.
+		expect( screen.getByText( /\$40\b/ ) ).toBeVisible();
+	} );
+
+	test( 'shows no remove button without hasDeleteButton', () => {
+		renderBundle( { removeProductFromCart: jest.fn() } );
+
+		expect( screen.queryByRole( 'button', { name: /Remove/ } ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'removes every bundle member when the removal is confirmed', async () => {
+		const user = userEvent.setup();
+		const removeProductFromCart = jest.fn();
+
+		renderBundle( { hasDeleteButton: true, removeProductFromCart } );
+
+		await user.click( screen.getByRole( 'button', { name: /Remove Domain bundle from cart/ } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
+
+		expect( removeProductFromCart ).toHaveBeenCalledTimes( 2 );
+		expect( removeProductFromCart ).toHaveBeenCalledWith( 'primary' );
+		expect( removeProductFromCart ).toHaveBeenCalledWith( 'companion' );
+	} );
+} );

--- a/packages/wpcom-checkout/test/fixtures/bundle-cart.ts
+++ b/packages/wpcom-checkout/test/fixtures/bundle-cart.ts
@@ -1,0 +1,71 @@
+import { getEmptyResponseCart, getEmptyResponseCartProduct } from '@automattic/shopping-cart';
+import type {
+	DomainBundleRole,
+	ResponseCart,
+	ResponseCartProduct,
+} from '@automattic/shopping-cart';
+
+/**
+ * Build a single domain cart product for bundle-grouping fixtures.
+ * @param overrides Fields to override on the empty product (uuid, meta, etc.).
+ * @param bundle Optional bundle metadata written into `extra`.
+ * @param bundle.groupId The shared bundle group id.
+ * @param bundle.role This product's role within the bundle.
+ * @param bundle.expectedBundleSize Expected member count (defaults to 2).
+ * @returns A ResponseCartProduct shaped like a domain registration line item.
+ */
+export function buildDomainProduct(
+	overrides: Partial< ResponseCartProduct > = {},
+	bundle?: {
+		groupId: string;
+		role: DomainBundleRole;
+		expectedBundleSize?: number;
+	}
+): ResponseCartProduct {
+	return {
+		...getEmptyResponseCartProduct(),
+		product_slug: 'domain_reg',
+		is_domain_registration: true,
+		...overrides,
+		extra: {
+			...overrides.extra,
+			...( bundle && {
+				domain_bundle_group_id: bundle.groupId,
+				domain_bundle_role: bundle.role,
+				expected_bundle_size: String( bundle.expectedBundleSize ?? 2 ),
+			} ),
+		},
+	};
+}
+
+/**
+ * Build a mock responseCart containing a three-domain bundle plus an unrelated,
+ * ungrouped product. Used by the grouping helper and line-item render tests.
+ * @returns A ResponseCart with bundle-tagged and untagged products.
+ */
+export function buildBundleResponseCart(): ResponseCart {
+	return {
+		...getEmptyResponseCart(),
+		products: [
+			buildDomainProduct(
+				{ uuid: 'primary', meta: 'example.com', item_subtotal_integer: 2200 },
+				{ groupId: 'bundle-abc', role: 'primary', expectedBundleSize: 3 }
+			),
+			buildDomainProduct(
+				{ uuid: 'companion-net', meta: 'example.net', item_subtotal_integer: 1800 },
+				{ groupId: 'bundle-abc', role: 'companion', expectedBundleSize: 3 }
+			),
+			buildDomainProduct(
+				{ uuid: 'companion-org', meta: 'example.org', item_subtotal_integer: 2000 },
+				{ groupId: 'bundle-abc', role: 'companion', expectedBundleSize: 3 }
+			),
+			{
+				...getEmptyResponseCartProduct(),
+				uuid: 'plan',
+				product_slug: 'value_bundle',
+				product_name: 'WordPress.com Explorer',
+				item_subtotal_integer: 9600,
+			},
+		],
+	};
+}

--- a/packages/wpcom-checkout/test/group-bundle-line-items.ts
+++ b/packages/wpcom-checkout/test/group-bundle-line-items.ts
@@ -1,0 +1,116 @@
+import { groupBundleLineItems } from '../src/group-bundle-line-items';
+import { buildBundleResponseCart, buildDomainProduct } from './fixtures/bundle-cart';
+
+describe( 'groupBundleLineItems', () => {
+	test( 'returns ungrouped products as plain product entries in order', () => {
+		const a = buildDomainProduct( { uuid: 'a', meta: 'a.com' } );
+		const b = buildDomainProduct( { uuid: 'b', meta: 'b.com' } );
+
+		expect( groupBundleLineItems( [ a, b ] ) ).toEqual( [
+			{ type: 'product', product: a },
+			{ type: 'product', product: b },
+		] );
+	} );
+
+	test( 'folds products sharing a group id into a single bundle entry', () => {
+		const primary = buildDomainProduct(
+			{ uuid: 'p', meta: 'example.com' },
+			{ groupId: 'g1', role: 'primary' }
+		);
+		const companion = buildDomainProduct(
+			{ uuid: 'c', meta: 'example.net' },
+			{ groupId: 'g1', role: 'companion' }
+		);
+
+		const result = groupBundleLineItems( [ primary, companion ] );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ] ).toEqual( {
+			type: 'bundle',
+			groupId: 'g1',
+			products: [ primary, companion ],
+		} );
+	} );
+
+	test( 'positions the bundle where its first member appears and keeps other products in place', () => {
+		const lead = buildDomainProduct( { uuid: 'lead', meta: 'lead.com' } );
+		const primary = buildDomainProduct(
+			{ uuid: 'p', meta: 'example.com' },
+			{ groupId: 'g1', role: 'primary' }
+		);
+		const trailing = buildDomainProduct( { uuid: 'trail', meta: 'trail.com' } );
+		const companion = buildDomainProduct(
+			{ uuid: 'c', meta: 'example.net' },
+			{ groupId: 'g1', role: 'companion' }
+		);
+
+		const result = groupBundleLineItems( [ lead, primary, trailing, companion ] );
+
+		expect(
+			result.map( ( entry ) => ( entry.type === 'bundle' ? entry.groupId : entry.product.uuid ) )
+		).toEqual( [ 'lead', 'g1', 'trail' ] );
+	} );
+
+	test( 'orders bundle members primary-first then companions in cart order', () => {
+		const companionFirst = buildDomainProduct(
+			{ uuid: 'c1', meta: 'a.net' },
+			{ groupId: 'g1', role: 'companion' }
+		);
+		const primary = buildDomainProduct(
+			{ uuid: 'p', meta: 'a.com' },
+			{ groupId: 'g1', role: 'primary' }
+		);
+		const companionSecond = buildDomainProduct(
+			{ uuid: 'c2', meta: 'a.org' },
+			{ groupId: 'g1', role: 'companion' }
+		);
+
+		const [ entry ] = groupBundleLineItems( [ companionFirst, primary, companionSecond ] );
+
+		const memberUuids = entry.type === 'bundle' ? entry.products.map( ( p ) => p.uuid ) : [];
+
+		expect( entry.type ).toBe( 'bundle' );
+		expect( memberUuids ).toEqual( [ 'p', 'c1', 'c2' ] );
+	} );
+
+	test( 'keeps distinct group ids as separate bundles', () => {
+		const g1a = buildDomainProduct( { uuid: 'g1a' }, { groupId: 'g1', role: 'primary' } );
+		const g1b = buildDomainProduct( { uuid: 'g1b' }, { groupId: 'g1', role: 'companion' } );
+		const g2a = buildDomainProduct( { uuid: 'g2a' }, { groupId: 'g2', role: 'primary' } );
+		const g2b = buildDomainProduct( { uuid: 'g2b' }, { groupId: 'g2', role: 'companion' } );
+
+		const result = groupBundleLineItems( [ g1a, g1b, g2a, g2b ] );
+
+		expect( result ).toHaveLength( 2 );
+		expect( result.every( ( entry ) => entry.type === 'bundle' ) ).toBe( true );
+	} );
+
+	test( 'falls back to a plain product when a group has only one surviving member', () => {
+		const lonely = buildDomainProduct(
+			{ uuid: 'lonely', meta: 'lonely.com' },
+			{ groupId: 'g1', role: 'primary' }
+		);
+
+		expect( groupBundleLineItems( [ lonely ] ) ).toEqual( [
+			{ type: 'product', product: lonely },
+		] );
+	} );
+
+	test( 'returns an empty list for an empty cart', () => {
+		expect( groupBundleLineItems( [] ) ).toEqual( [] );
+	} );
+
+	test( 'splits a realistic cart into one bundle group and the standalone plan', () => {
+		const result = groupBundleLineItems( buildBundleResponseCart().products );
+
+		expect(
+			result.map( ( entry ) => ( entry.type === 'bundle' ? entry.groupId : entry.product.uuid ) )
+		).toEqual( [ 'bundle-abc', 'plan' ] );
+
+		const [ bundleEntry ] = result;
+		const memberUuids =
+			bundleEntry.type === 'bundle' ? bundleEntry.products.map( ( p ) => p.uuid ) : [];
+
+		expect( memberUuids ).toEqual( [ 'primary', 'companion-net', 'companion-org' ] );
+	} );
+} );


### PR DESCRIPTION
Related to #DOMAINS-2171

## Proposed Changes

Fold cart products that share a server-issued `domain_bundle_group_id` into a single grouped line item in the **mini-cart** and the **checkout order review**, behind the `domain-bundling` feature flag.

- **`groupBundleLineItems`** (`packages/wpcom-checkout/src/group-bundle-line-items.ts`) — pure helper that collapses products sharing a group id into one bundle entry (members ordered primary-first, group positioned at its first member in cart order) and leaves every other product untouched. A group with fewer than 2 surviving members falls back to a plain product.
- **`BundleLineItem`** (added to `packages/wpcom-checkout/src/checkout-line-items.tsx`) — renders the grouped row: bundle label, summed total, member-domain rows, and a single confirm-to-remove-all action.
- **Checkout** (`wp-order-review-line-items.tsx`) gates grouping inline on `config.isEnabled( 'domain-bundling' )`.
- **Mini-cart** gates via a `showBundleGrouping` prop threaded from the masterbar cart button through `MiniCart` → `MiniCartLineItems`, keeping `@automattic/mini-cart` free of a `calypso-config` dependency.

## Why are these changes being made?

Part of the Domain Bundling & Upsell Phase 1 (M1a) frontend work. The backend issues a `domain_bundle_group_id` shared by every domain in a bundle; the cart needs to render those members as one grouped item (member list, bundle total, single remove) rather than as separate lines. This is built against the `domain_bundle_*` cart-extra fields landed in DOMAINS-2164.

The feature is **dark unless the `domain-bundling` flag is enabled** — the same flag that gates the search-side bundle suggestion (DOMAINS-2172). With the flag off, the grouping helper is bypassed entirely and every product renders on its own line exactly as before.

## Testing Instructions

Feature-flag status:

```
yarn run feature-search domain-bundling
```

Automated:

```
yarn test-packages packages/wpcom-checkout/test/group-bundle-line-items.ts packages/wpcom-checkout/test/bundle-line-item.tsx packages/mini-cart/test/mini-cart-line-items.tsx
```

13 tests covering the grouping helper (ordering, positioning, fallback, realistic-cart split), the `BundleLineItem` render + remove-all-members flow, and the mini-cart surface with the flag on (grouped) vs off (flat).

### Previewing the grouped UI manually

There is **no live add-to-cart path that tags products with `domain_bundle_group_id` yet** (that's a later ticket), so a normal cart won't contain bundle members and nothing groups. To eyeball the grouped row, temporarily tag the cart's domains client-side.

1. In `client/my-sites/checkout/src/components/wp-order-review-line-items.tsx`, just **before** the `groupedLineItems` computation, tag every domain into one bundle:

   ```ts
   // TEMP — preview only, revert before merge.
   const previewProducts = responseCart.products.map( ( product ) =>
       product.is_domain_registration
           ? {
                 ...product,
                 extra: {
                     ...product.extra,
                     domain_bundle_group_id: 'dev-preview',
                     domain_bundle_role: 'companion' as const,
                 },
             }
           : product
   );
   ```

   …then feed `previewProducts` to `groupBundleLineItems( … )` instead of `responseCart.products`. (The mini-cart surface, `packages/mini-cart/src/mini-cart-line-items.tsx`, takes the same edit.)

2. Add 2+ domains to a cart, then go to `/checkout/<site>?flags=domain-bundling`.
3. The **order review** (left panel) shows a single "Domain bundle" row — all domains listed, summed total, one Remove. Drop the flag (`?flags=-domain-bundling`) and refresh → they split back into individual lines.
4. **Revert the temporary edit.**

Notes:
- Use `/checkout`, not the signup domain step — that step renders the `@automattic/domain-search` package's own cart, which is out of scope here.
- The checkout **Summary** sidebar (`wp-checkout-order-summary.tsx`) is a separate component and intentionally does **not** group — tracked in DOMAINS-2175.

## Notes / scope

- **Storybook** entries were deferred: the `wpcom-checkout`/`mini-cart` packages are not wired into any Storybook config (unlike `domain-search`), so adding one would mean introducing those packages to the root Storybook glob. Out of scope here.
- **Per-member discount/renewal disclosure** inside the grouped row (crossed-out original price, intro-offer callout, renewal term) is intentionally not surfaced in M1a — it's a design/product decision against mock data. Tracked in DOMAINS-2174.
- A `WPOrderReviewLineItems` full integration render was scoped out: it requires a redux store harness, and the checkout branch is structurally identical to the mini-cart branch (same helper, same `BundleLineItem`), which are both covered.
