### PR TITLE
A4A Plugin Management: standardize detail panel close to "X" icon

### DIFF
--- a/client/my-sites/plugins/plugins-dashboard/index.tsx
+++ b/client/my-sites/plugins/plugins-dashboard/index.tsx
@@ -1,6 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { hasMarketplaceProduct } from '@automattic/calypso-products';
-import { Button } from '@automattic/components';
+import { Button, Gridicon } from '@automattic/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import A4APluginsJetpackBanner from 'calypso/a8c-for-agencies/sections/plugins/plugins-jetpack-banner';
@@ -369,7 +369,9 @@ const PluginsDashboard = ( {
 								{ `${ selectedPlugin.name }` }
 							</Title>
 							<Actions>
-								<Button href="/plugins/manage/sites">{ translate( 'Close' ) }</Button>
+								<Button href="/plugins/manage/sites" borderless aria-label={ translate( 'Close' ) }>
+									<Gridicon icon="cross" size={ 24 } />
+								</Button>
 							</Actions>
 						</LayoutHeader>
 					</LayoutTop>


### PR DESCRIPTION
Part of A4A-2738

## Proposed Changes

* Replace the text **"Close"** button in the Plugin Management detail/manage side panel with a borderless `Gridicon` `cross` ("X") icon button. Close behavior is unchanged.

### What we're standardizing on

Other A4A detail panels already close with an "X" icon, rendered by the shared `ItemView` header:

* Shared close button (the "X"): [`client/layout/hosting-dashboard/item-view/item-view-header/index.tsx#L176-L183`](https://github.com/Automattic/wp-calypso/blob/c01d67ffec5/client/layout/hosting-dashboard/item-view/item-view-header/index.tsx#L176-L183)
* Sites panel uses it: [`client/a8c-for-agencies/sections/sites/features/a4a/overview-preview-pane.tsx#L246-L250`](https://github.com/Automattic/wp-calypso/blob/c01d67ffec5/client/a8c-for-agencies/sections/sites/features/a4a/overview-preview-pane.tsx#L246-L250)
* Referrals panel uses it: [`client/a8c-for-agencies/sections/referrals/referral-details/index.tsx#L132-L136`](https://github.com/Automattic/wp-calypso/blob/c01d67ffec5/client/a8c-for-agencies/sections/referrals/referral-details/index.tsx#L132-L136)

The plugins panel uses a different layout (`LayoutHeader`/`LayoutHeaderActions`), so this PR matches the "X" in place rather than refactoring the panel onto `ItemView`.

**BEFORE**
<img width="1782" height="598" alt="Screenshot 2026-06-04 at 1 11 21 PM" src="https://github.com/user-attachments/assets/96cb0b80-27d0-47cc-b3f8-207337cffdf9" />

**AFTER**
<img width="1780" height="595" alt="Screenshot 2026-06-04 at 1 11 38 PM" src="https://github.com/user-attachments/assets/9365e0ac-c851-47d3-8015-390525873688" />

## Why are these changes being made?

Found during an A4A support-rotation product walkthrough (pgjTho-28h-p2). Detail panels close inconsistently across the portal: Sites and Referrals use an "X" icon, but the plugins panel used a text "Close" button. Standardizing on the "X" makes closing a panel work the same way everywhere.

## Testing Instructions

* Go to Plugins → Manage plugins.
* Open a plugin's detail panel (click the plugin name, or the action menu → "Manage plugin").
* Confirm the panel header now shows an "X" icon in place of the "Close" text button, and clicking it closes the panel (returns to `/plugins/manage/sites`).
* Verify the icon is keyboard-focusable.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? (icon button carries an `aria-label` of "Close")
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?

🤖 Crafted by Travbot (Claude-powered)