### PR TITLE
Purchases: Add types for expiry and downgrade

### DIFF
--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -81,12 +81,15 @@ export function isExpired( purchase: Purchase ) {
  *
  * This is the "active but already past expiry" case that {@link isExpired} does
  * NOT cover: such purchases report an `expiry_status` of 'expiring' (or
- * 'manual-renew'), not 'expired'. It is `is_past_expiry_date` being true while
- * the subscription is still active — excluding bundle-`included` purchases
- * (whose lifecycle is governed by their parent) and Akismet free products.
+ * 'manual-renew'), not 'expired'. Equivalent to `is_past_expiry_date` being
+ * true while {@link isExpired} is false (excluding Akismet free products).
  */
 export function isInExpirationGracePeriod( purchase: Purchase ): boolean {
-	if ( ! purchase.is_past_expiry_date ) {
+	if ( ! purchase.expiry_date ) {
+		return false;
+	}
+
+	if ( new Date( purchase.expiry_date ) >= new Date() ) {
 		return false;
 	}
 	if ( isExpired( purchase ) ) {

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -45,20 +45,48 @@ export function isFailedAutoRenewal( purchase: Purchase ): boolean {
 	);
 }
 
+/**
+ * Returns true if the purchase is still active but headed toward lapsing: it
+ * either requires a manual renewal or is expiring soon without auto-renew.
+ *
+ * Note this also covers purchases that are active but already PAST their expiry
+ * date (in the grace period), because the backend reports those as 'expiring'
+ * rather than 'expired'. It does NOT cover already-lapsed purchases — see
+ * {@link isExpired}. To test specifically for past-expiry, use the
+ * `is_past_expiry_date` flag on the purchase.
+ */
 export function isExpiring( purchase: Purchase ) {
 	return [ 'manual-renew', 'expiring' ].includes( purchase.expiry_status );
 }
 
+/**
+ * Returns true only if the underlying subscription is no longer active (the
+ * backend `expiry_status` is 'expired').
+ *
+ * Important: this is NOT the same as the purchase being past its expiry date. A
+ * subscription that is still active but past its expiry date (i.e. in its grace
+ * period) reports as 'expiring', not 'expired', so this returns false for it —
+ * see {@link isExpiring} and {@link isInExpirationGracePeriod}. To test whether
+ * the expiry date itself has passed (regardless of active/lapsed state), use the
+ * `is_past_expiry_date` flag on the purchase.
+ */
 export function isExpired( purchase: Purchase ) {
 	return 'expired' === purchase.expiry_status;
 }
 
+/**
+ * Returns true if the purchase is past its expiry date but the subscription is
+ * still active — the post-expiry grace period during which it can still be
+ * renewed before fully lapsing.
+ *
+ * This is the "active but already past expiry" case that {@link isExpired} does
+ * NOT cover: such purchases report an `expiry_status` of 'expiring' (or
+ * 'manual-renew'), not 'expired'. It is `is_past_expiry_date` being true while
+ * the subscription is still active — excluding bundle-`included` purchases
+ * (whose lifecycle is governed by their parent) and Akismet free products.
+ */
 export function isInExpirationGracePeriod( purchase: Purchase ): boolean {
-	if ( ! purchase.expiry_date ) {
-		return false;
-	}
-
-	if ( new Date( purchase.expiry_date ) >= new Date() ) {
+	if ( ! purchase.is_past_expiry_date ) {
 		return false;
 	}
 	if ( isExpired( purchase ) ) {

--- a/packages/api-core/src/upgrades/types.ts
+++ b/packages/api-core/src/upgrades/types.ts
@@ -181,7 +181,8 @@ export interface Purchase {
 	 * surfaces here as 'expiring' (because past-expiry trivially satisfies
 	 * "expiring soon" and a lapsed purchase is not auto-renewing). However,
 	 * 'expiring' also covers subscriptions that are merely approaching expiry
-	 * and have NOT passed it yet.
+	 * and have NOT passed it yet. To distinguish "active but already past
+	 * expiry" precisely, use `is_past_expiry_date`.
 	 */
 	expiry_status:
 		| 'expiring'
@@ -191,6 +192,19 @@ export interface Purchase {
 		| 'manual-renew'
 		| 'expired'
 		| 'one-time-purchase';
+
+	/**
+	 * True if the subscription's expiry date has already passed, whether it is
+	 * still active (i.e. in its post-expiry grace period) or has since become
+	 * inactive ('expired'). This is a more precise signal than
+	 * `expiry_status === 'expiring'`, which also covers subscriptions that are
+	 * merely approaching expiry but have not passed it.
+	 *
+	 * Always false for purchases with no expiry time (one-time purchases and
+	 * perpetual purchases).
+	 */
+	is_past_expiry_date: boolean;
+
 	iap_purchase_management_link: string | null;
 
 	/**

--- a/packages/api-core/src/upgrades/types.ts
+++ b/packages/api-core/src/upgrades/types.ts
@@ -437,6 +437,26 @@ export interface Purchase {
 	is_upgradable: boolean;
 
 	/**
+	 * True if this subscription's plan can be downgraded to a different, lower
+	 * plan type (eg: Business to Personal).
+	 *
+	 * Only ever true for plans. Like `is_upgradable`, this is false for A4A
+	 * plans, bundle-`included` subscriptions, and (for Jetpack plans) holding
+	 * sites. Unlike `is_upgradable`, an active subscription that is merely past
+	 * its expiry date (grace period) is still considered downgradable; only
+	 * inactive ('expired') subscriptions are excluded.
+	 */
+	is_plan_type_downgradable: boolean;
+
+	/**
+	 * True if this subscription's plan can be downgraded to a shorter billing
+	 * term of the same plan (eg: annual to monthly).
+	 *
+	 * Gated by the same eligibility rules as `is_plan_type_downgradable`.
+	 */
+	is_plan_term_downgradable: boolean;
+
+	/**
 	 * True if deactivating this subscription will cause the site to be reverted
 	 * from an Atomic site to a Simple site. This is only true if the site is
 	 * currently on the Atomic architecture and removing this subscription would

--- a/packages/api-core/src/upgrades/types.ts
+++ b/packages/api-core/src/upgrades/types.ts
@@ -141,6 +141,48 @@ export interface Purchase {
 	domain_registration_agreement_url: string | undefined;
 	blog_created_date: string;
 	expiry_date: string;
+
+	/**
+	 * A coarse, display-oriented summary of where this purchase is in its
+	 * lifecycle. Derived on the backend from
+	 * `Store_Subscription::get_expiry_status()`, which combines the subscription
+	 * status, the expiry date, whether it expires "soon", and whether it is
+	 * configured to auto-renew. One of:
+	 *
+	 * - 'active': Active, has a future expiry date, and set to auto-renew, but
+	 *   renewal is not imminent (more than ~3 months away; ~10 days for monthly
+	 *   plans). Renews automatically on the renewal date. No action needed.
+	 *
+	 * - 'auto-renewing': Same as 'active' but renewal IS imminent (within the
+	 *   "expiring soon" window). Will auto-renew on the renewal date.
+	 *
+	 * - 'manual-renew': Active, has a future expiry date, but NOT set to
+	 *   auto-renew and not yet expiring soon. The user must renew manually
+	 *   before the expiry date or it will lapse.
+	 *
+	 * - 'expiring': Active, expiring soon (or already PAST its expiry date, see
+	 *   below), and NOT going to auto-renew. This is the "needs attention"
+	 *   state: the purchase is still active but will lapse unless renewed.
+	 *
+	 * - 'expired': The underlying subscription is no longer active
+	 *   (`subscription_status !== 'active'`). Note this is NOT the same as being
+	 *   past the expiry date — see below.
+	 *
+	 * - 'included': This purchase is part of a bundle (e.g. a domain bundled
+	 *   with a plan) and its lifecycle is governed by the parent subscription.
+	 *   This overrides any of the above.
+	 *
+	 * - 'one-time-purchase': The purchase has no expiry time at all (a perpetual
+	 *   purchase or a one-time product). Never renews and never lapses.
+	 *
+	 * Determining an active subscription that is PAST its expiry date (grace
+	 * period): this status alone is NOT sufficient, and it is NOT 'expired'.
+	 * A subscription that is still `active` but whose expiry date has passed
+	 * surfaces here as 'expiring' (because past-expiry trivially satisfies
+	 * "expiring soon" and a lapsed purchase is not auto-renewing). However,
+	 * 'expiring' also covers subscriptions that are merely approaching expiry
+	 * and have NOT passed it yet.
+	 */
 	expiry_status:
 		| 'expiring'
 		| 'included'


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/SHILL-2090/

## Proposed changes

Documents the `expiry_status` field on the `Purchase` type and adds the new `is_past_expiry_date`, `is_plan_type_downgradable`, and `is_plan_term_downgradable` fields, mirroring the backend definitions in `Billing_Upgrade`. These support the post-expiry downgrade flow by giving the client precise, well-documented signals for a purchase's lifecycle state and downgrade eligibility.

Depends on 221783-ghe-Automattic/wpcom

## Why are these changes being made?

The post-expiry downgrade flow (SHILL-2090) needs to determine, on the client, whether a purchase is past its expiry date and whether it is eligible to be downgraded. The existing `expiry_status` field is coarse and display-oriented — notably, an active subscription in its post-expiry grace period reports as `expiring`, not `expired`, which is easy to misuse. Rather than reconstruct that logic client-side, the backend already exposes precise booleans (`is_past_expiry_date`, `is_plan_type_downgradable`, `is_plan_term_downgradable`); this change brings the `Purchase` TypeScript type in sync with those fields and documents the subtle lifecycle semantics so consumers don't have to reverse-engineer them from the PHP source.

## Testing instructions

* No runtime behavior changes — this is a type/docs-only change.