### PR TITLE
Remove experimental label from appearance/dark mode settings

### DIFF
--- a/client/dashboard/me/appearance/index.tsx
+++ b/client/dashboard/me/appearance/index.tsx
@@ -1,4 +1,3 @@
-import { Badge } from '@automattic/ui';
 import {
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
@@ -43,7 +42,6 @@ export default function Appearance() {
 					prefix={ <Breadcrumbs length={ 2 } /> }
 					title={ __( 'Appearance' ) }
 					description={ __( 'Customize the appearance.' ) }
-					actions={ <Badge>{ __( 'Experimental' ) }</Badge> }
 				/>
 			}
 		>
@@ -54,7 +52,7 @@ export default function Appearance() {
 							level={ 3 }
 							title={ __( 'Color scheme' ) }
 							description={ __(
-								'Set the dashboard appearance to light, dark, or your system setting. This setting will also apply to other supported surface areas. This is experimental, if you like it or find issues we’d love to hear your feedback on it.'
+								'Set the dashboard appearance to light, dark, or your system setting. This setting will also apply to other supported surface areas.'
 							) }
 						/>
 						<ToggleGroupControl

--- a/client/dashboard/me/preferences-appearance/index.tsx
+++ b/client/dashboard/me/preferences-appearance/index.tsx
@@ -25,7 +25,7 @@ function PreferencesAppearanceSummary( { density }: { density?: Density } ) {
 		<RouterLinkSummaryButton
 			density={ density }
 			to="/me/preferences/appearance"
-			title={ __( 'Appearance (Experimental)' ) }
+			title={ __( 'Appearance' ) }
 			description={ __( 'Choose how the dashboard looks.' ) }
 			decoration={ <Icon icon={ styles } size={ 24 } /> }
 			badges={ [ { text: getColorSchemeLabel( colorScheme ) } ] }

--- a/client/dashboard/me/preferences-appearance/test/index.test.tsx
+++ b/client/dashboard/me/preferences-appearance/test/index.test.tsx
@@ -60,9 +60,10 @@ afterEach( () => {
 test( 'renders when dark mode is supported regardless of opt-in preference', async () => {
 	renderPreferencesAppearance();
 
-	expect(
-		await screen.findByRole( 'link', { name: /Appearance \(Experimental\)/i } )
-	).toHaveAttribute( 'href', '/me/preferences/appearance' );
+	expect( await screen.findByRole( 'link', { name: /Appearance/i } ) ).toHaveAttribute(
+		'href',
+		'/me/preferences/appearance'
+	);
 	expect( screen.getByText( 'Dark' ) ).toBeVisible();
 } );
 
@@ -72,9 +73,7 @@ test( 'does not render in the Dashboard backport', async () => {
 	renderPreferencesAppearance();
 
 	await waitFor( () => {
-		expect(
-			screen.queryByRole( 'link', { name: /Appearance \(Experimental\)/i } )
-		).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'link', { name: /Appearance/i } ) ).not.toBeInTheDocument();
 	} );
 } );
 
@@ -88,9 +87,7 @@ test( 'does not render when dark mode is not supported', async () => {
 	} );
 
 	await waitFor( () => {
-		expect(
-			screen.queryByRole( 'link', { name: /Appearance \(Experimental\)/i } )
-		).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'link', { name: /Appearance/i } ) ).not.toBeInTheDocument();
 	} );
 } );
 
@@ -105,8 +102,6 @@ test( 'does not render when color scheme is not supported', async () => {
 	} );
 
 	await waitFor( () => {
-		expect(
-			screen.queryByRole( 'link', { name: /Appearance \(Experimental\)/i } )
-		).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'link', { name: /Appearance/i } ) ).not.toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
The dark mode feature in MSD was shipped with an "Experimental" label during the initial CfT. Andrea and Francesco confirmed there are no known bugs or regressions, and usage metrics look good, so the label can be removed.

Changes:

Removed "(Experimental)" from the Appearance nav link title
Removed the "Experimental" badge from the Appearance page header
Removed the "this is experimental" sentence from the description
Updated 4 test assertions accordingly

Context: https://a8c.slack.com/archives/C08JZTRS6NA/p1780464046829199