### PR TITLE
A4A: Allow Pressable add-on referrals for legacy billing

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hooks/test/use-pressable-addon-visibility.test.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/test/use-pressable-addon-visibility.test.ts
@@ -1,4 +1,7 @@
-import { getPressableAddonLicenseVisibility } from '../use-pressable-addon-visibility';
+import {
+	canShowPressableAddonsInMarketplace,
+	getPressableAddonLicenseVisibility,
+} from '../use-pressable-addon-visibility';
 import type { License } from 'calypso/state/partner-portal/types';
 
 const buildLicense = ( {
@@ -90,5 +93,34 @@ describe( 'getPressableAddonLicenseVisibility', () => {
 			hasActiveAgencyPressablePlanLicense: false,
 			hasActiveReferralPressablePlanLicense: false,
 		} );
+	} );
+} );
+
+describe( 'canShowPressableAddonsInMarketplace', () => {
+	it( 'shows add-ons in referral mode without an agency Pressable plan license', () => {
+		expect(
+			canShowPressableAddonsInMarketplace( {
+				isReferralMode: true,
+				hasActiveAgencyPressablePlanLicense: false,
+			} )
+		).toBe( true );
+	} );
+
+	it( 'shows add-ons in regular mode with an agency Pressable plan license', () => {
+		expect(
+			canShowPressableAddonsInMarketplace( {
+				isReferralMode: false,
+				hasActiveAgencyPressablePlanLicense: true,
+			} )
+		).toBe( true );
+	} );
+
+	it( 'hides add-ons in regular mode without an agency Pressable plan license', () => {
+		expect(
+			canShowPressableAddonsInMarketplace( {
+				isReferralMode: false,
+				hasActiveAgencyPressablePlanLicense: false,
+			} )
+		).toBe( false );
 	} );
 } );

--- a/client/a8c-for-agencies/sections/marketplace/hooks/test/use-pressable-addon-visibility.test.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/test/use-pressable-addon-visibility.test.ts
@@ -35,11 +35,10 @@ describe( 'getPressableAddonLicenseVisibility', () => {
 	it( 'returns no visibility for empty input', () => {
 		expect( getPressableAddonLicenseVisibility( [] ) ).toEqual( {
 			hasActiveAgencyPressablePlanLicense: false,
-			hasActiveReferralPressablePlanLicense: false,
 		} );
 	} );
 
-	it( 'OFF mode case: only referral pressable plan license does not grant agency visibility', () => {
+	it( 'does not grant agency visibility for a referral Pressable plan license', () => {
 		const visibility = getPressableAddonLicenseVisibility( [
 			buildLicense( {
 				licenseKey: 'pressable-premium',
@@ -49,22 +48,20 @@ describe( 'getPressableAddonLicenseVisibility', () => {
 
 		expect( visibility ).toEqual( {
 			hasActiveAgencyPressablePlanLicense: false,
-			hasActiveReferralPressablePlanLicense: true,
 		} );
 	} );
 
-	it( 'ON mode case: only non-referral pressable plan license does not grant referral visibility', () => {
+	it( 'grants agency visibility for a non-referral Pressable plan license', () => {
 		const visibility = getPressableAddonLicenseVisibility( [
 			buildLicense( { licenseKey: 'pressable-premium' } ),
 		] );
 
 		expect( visibility ).toEqual( {
 			hasActiveAgencyPressablePlanLicense: true,
-			hasActiveReferralPressablePlanLicense: false,
 		} );
 	} );
 
-	it( 'marks both visibilities when both license types exist', () => {
+	it( 'grants agency visibility when both license types exist', () => {
 		const visibility = getPressableAddonLicenseVisibility( [
 			buildLicense( { licenseKey: 'pressable-premium' } ),
 			buildLicense( {
@@ -75,7 +72,6 @@ describe( 'getPressableAddonLicenseVisibility', () => {
 
 		expect( visibility ).toEqual( {
 			hasActiveAgencyPressablePlanLicense: true,
-			hasActiveReferralPressablePlanLicense: true,
 		} );
 	} );
 
@@ -91,7 +87,6 @@ describe( 'getPressableAddonLicenseVisibility', () => {
 
 		expect( visibility ).toEqual( {
 			hasActiveAgencyPressablePlanLicense: false,
-			hasActiveReferralPressablePlanLicense: false,
 		} );
 	} );
 } );

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-pressable-addon-visibility.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-pressable-addon-visibility.ts
@@ -13,6 +13,13 @@ type PressableAddonLicenseVisibility = {
 	hasActiveReferralPressablePlanLicense: boolean;
 };
 
+type PressableAddonMarketplaceVisibility = Pick<
+	PressableAddonLicenseVisibility,
+	'hasActiveAgencyPressablePlanLicense'
+> & {
+	isReferralMode: boolean;
+};
+
 export const DEFAULT_PRESSABLE_ADDON_VISIBILITY: PressableAddonLicenseVisibility = {
 	hasActiveAgencyPressablePlanLicense: false,
 	hasActiveReferralPressablePlanLicense: false,
@@ -45,6 +52,17 @@ export function getPressableAddonLicenseVisibility(
 		},
 		{ ...DEFAULT_PRESSABLE_ADDON_VISIBILITY }
 	);
+}
+
+export function canShowPressableAddonsInMarketplace( {
+	isReferralMode,
+	hasActiveAgencyPressablePlanLicense,
+}: PressableAddonMarketplaceVisibility ) {
+	if ( isReferralMode ) {
+		return true;
+	}
+
+	return hasActiveAgencyPressablePlanLicense;
 }
 
 export default function usePressableAddonVisibility() {

--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-pressable-addon-visibility.ts
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-pressable-addon-visibility.ts
@@ -10,7 +10,6 @@ import type { License } from 'calypso/state/partner-portal/types';
 
 type PressableAddonLicenseVisibility = {
 	hasActiveAgencyPressablePlanLicense: boolean;
-	hasActiveReferralPressablePlanLicense: boolean;
 };
 
 type PressableAddonMarketplaceVisibility = Pick<
@@ -22,7 +21,6 @@ type PressableAddonMarketplaceVisibility = Pick<
 
 export const DEFAULT_PRESSABLE_ADDON_VISIBILITY: PressableAddonLicenseVisibility = {
 	hasActiveAgencyPressablePlanLicense: false,
-	hasActiveReferralPressablePlanLicense: false,
 };
 
 export function getPressableAddonLicenseVisibility(
@@ -42,9 +40,7 @@ export function getPressableAddonLicenseVisibility(
 				return visibility;
 			}
 
-			if ( license.referral ) {
-				visibility.hasActiveReferralPressablePlanLicense = true;
-			} else {
+			if ( ! license.referral ) {
 				visibility.hasActiveAgencyPressablePlanLicense = true;
 			}
 

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/hooks/use-product-filter-options.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/hooks/use-product-filter-options.tsx
@@ -45,22 +45,23 @@ import {
 	PRODUCT_VENDOR_WOOCOMMERCE,
 } from '../../../constants';
 import { MarketplaceTypeContext } from '../../../context';
-import usePressableAddonVisibility from '../../../hooks/use-pressable-addon-visibility';
+import usePressableAddonVisibility, {
+	canShowPressableAddonsInMarketplace,
+} from '../../../hooks/use-pressable-addon-visibility';
 import { isPressableAddonProduct } from '../../../lib/hosting';
 
 export default function useProductFilterOptions() {
 	const translate = useTranslate();
 	const { marketplaceType } = useContext( MarketplaceTypeContext );
 	const { data: productsAndPlans = [] } = useProductsQuery();
-	const { hasActiveAgencyPressablePlanLicense, hasActiveReferralPressablePlanLicense } =
-		usePressableAddonVisibility();
+	const { hasActiveAgencyPressablePlanLicense } = usePressableAddonVisibility();
 	const hasPressableAddonsAvailable = productsAndPlans.some( ( { family_slug } ) =>
 		isPressableAddonProduct( family_slug )
 	);
-	const canShowPressableAddonsByMode =
-		marketplaceType === 'referral'
-			? hasActiveReferralPressablePlanLicense
-			: hasActiveAgencyPressablePlanLicense;
+	const canShowPressableAddonsByMode = canShowPressableAddonsInMarketplace( {
+		isReferralMode: marketplaceType === 'referral',
+		hasActiveAgencyPressablePlanLicense,
+	} );
 
 	return {
 		[ PRODUCT_FILTER_KEY_CATEGORIES ]: [

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-listing/index.tsx
@@ -14,7 +14,9 @@ import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { MarketplaceTypeContext, ShoppingCartContext } from '../../context';
 import { useProductTermAvailabilityTooltip } from '../../hooks/use-marketplace';
-import usePressableAddonVisibility from '../../hooks/use-pressable-addon-visibility';
+import usePressableAddonVisibility, {
+	canShowPressableAddonsInMarketplace,
+} from '../../hooks/use-pressable-addon-visibility';
 import { SelectedFilters } from '../../lib/product-filter';
 import useProductAndPlansWithPressableVisibility from '../hooks/use-product-and-plans-with-pressable-visibility';
 import { getSupportedBundleSizes } from '../hooks/use-product-bundle-size';
@@ -62,11 +64,11 @@ export default function ProductListing( {
 		() => ( isReferralMode ? 1 : selectedBundleSize ),
 		[ isReferralMode, selectedBundleSize ]
 	);
-	const { hasActiveAgencyPressablePlanLicense, hasActiveReferralPressablePlanLicense } =
-		usePressableAddonVisibility();
-	const canShowPressableAddonsByMode = isReferralMode
-		? hasActiveReferralPressablePlanLicense
-		: hasActiveAgencyPressablePlanLicense;
+	const { hasActiveAgencyPressablePlanLicense } = usePressableAddonVisibility();
+	const canShowPressableAddonsByMode = canShowPressableAddonsInMarketplace( {
+		isReferralMode,
+		hasActiveAgencyPressablePlanLicense,
+	} );
 
 	const {
 		filteredProductsAndBundles,


### PR DESCRIPTION
Part of A4A Pressable add-ons project

## Proposed Changes

* Allow legacy billing agencies to see Pressable add-ons in Marketplace referral mode.
* Keep Pressable add-on listing and category/filter visibility aligned.
* Preserve regular mode behavior for agency-owned Pressable plans.

## Why are these changes being made?

* Agencies using legacy billing should be able to send Pressable add-ons as client referrals.
* Referral mode should expose Pressable add-ons under the same conditions as Billing Dragon.

## Testing Instructions

* Open the A4A Marketplace Products page.
* Turn on referral mode.
* Verify the Pressable add-ons section appears for a legacy billing agency.
* Verify the Pressable category/filter option appears in the same state.
* Repeat the referral-mode check for a Billing Dragon agency.
* Turn off referral mode.
* Verify regular mode behavior is unchanged.

_— ClemenAgent (Powered by Codex)_

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
