### PR TITLE
Sites: refine deleted-sites empty state when other filters are active

### DIFF
--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -203,7 +203,13 @@ export default function Sites() {
 		totalItems ?? 0
 	);
 
-	const isFilteringDeletedSites = isDeletedFilterActive( view.filters ?? [] );
+	const filters = view.filters ?? [];
+	const hasActiveSearch = !! view.search;
+	const hasActiveQuery = hasActiveSearch || filters.length > 0;
+	const isFilteringOnlyDeletedSites =
+		isDeletedFilterActive( filters ) &&
+		! hasActiveSearch &&
+		filters.every( ( filter ) => filter.field === 'is_deleted' );
 
 	return (
 		<>
@@ -246,7 +252,7 @@ export default function Sites() {
 					</>
 				}
 			>
-				{ userHasSites || isFilteringDeletedSites ? (
+				{ userHasSites || hasActiveQuery ? (
 					<SitesDataViews
 						view={ view }
 						sites={ filteredData }
@@ -255,7 +261,7 @@ export default function Sites() {
 						isLoading={ isLoadingSites || ( isPlaceholderData && hasNoData ) }
 						isPlaceholderData={ isPlaceholderData }
 						empty={
-							isFilteringDeletedSites ? (
+							isFilteringOnlyDeletedSites ? (
 								<DataViewsEmptyStateLayout
 									title={ __( 'You have no deleted sites' ) }
 									description={ createInterpolateElement(


### PR DESCRIPTION
Part of DOTMSD-1213

Follow-up to #111233 to improve the messaging on the Sites list.

## Proposed Changes

* When the Sites list is filtered to deleted sites *and* another filter or search term is also applied, show the generic "no results" empty state instead of the "You have no deleted sites" copy.

## Why are these changes being made?

If the users has deletes site but have a second filtered applied. It shouldn't say "You have no deleted sites".

### What users will see

* **Only the deleted filter applied, no results** → "You have no deleted sites" (unchanged).
* **Deleted filter + another filter, no results** → generic "No sites match your search" view.
* **Deleted filter + a search term, no results** → generic "No sites match your search" view.
* **No filters/search and no sites at all** → "You don't have any sites yet" (unchanged).

## Testing Instructions

* Visit the Sites list with `?is_deleted=true` and confirm the "You have no deleted sites" copy still appears when no other filter or search is active.
* From that view, type into the search box (or apply another filter such as plan/visibility). Confirm the empty state switches to the generic "No sites match your search" view.
* Clear the search/filter and confirm the deleted-sites empty state returns.
* Visit the Sites list with no filters and confirm the standard list and the "you don't have any sites yet" welcome state are unaffected.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?