### PR TITLE
Dashboard: Scale dotcom sidebar logo variant

### DIFF
--- a/client/dashboard/app-dotcom/logo.tsx
+++ b/client/dashboard/app-dotcom/logo.tsx
@@ -3,9 +3,8 @@ import { isEnabled } from '@automattic/calypso-config';
 function WordmarkLogo() {
 	return (
 		<svg
-			style={ { display: 'block' } }
-			width="132"
-			height="22"
+			style={ { display: 'block', translate: '0 2px' } }
+			width="170"
 			viewBox="0 0 132 22"
 			fill="none"
 			xmlns="http://www.w3.org/2000/svg"

--- a/client/dashboard/app/responsive-sidebar/sidebar.scss
+++ b/client/dashboard/app/responsive-sidebar/sidebar.scss
@@ -31,6 +31,6 @@
 }
 
 .dashboard-responsive-sidebar__logo {
-	padding: 14px $grid-unit-30 + 2px;
+	padding: $grid-unit-20 $grid-unit-30;
 	border-block-end: 1px solid var( --dashboard-header__border-color );
 }


### PR DESCRIPTION
## Proposed Changes

* Scale up the WordPress.com dotcom sidebar logo (`WordmarkLogo`): widen the SVG from `132` to `170` and nudge it down `2px` for vertical alignment.
* Restore the shared sidebar logo wrapper padding to grid-based values (`$grid-unit-20 $grid-unit-30`), removing the previous one-off pixel padding.

## Why are these changes being made?

Replaces #109950. That PR achieved logo alignment by tweaking the shared sidebar wrapper padding, which assumed the same adjustment would suit every dashboard variant. It doesn't — variants like CIAB use the same sidebar but a different logo. This scopes the sizing to the dotcom logo SVG itself and keeps the shared sidebar padding neutral, so other variants keep their default alignment.

## Testing Instructions

1. Navigate to `my.localhost:3000/sites` (or any Dashboard page) with the dotcom variant.
2. Verify the WordPress.com logo in the sidebar renders at the larger size and is vertically aligned.
3. Verify other dashboard variants (e.g. CIAB) are unaffected.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
