### PR TITLE
Dashboard: Lighten sidebar back button via default Button size

### DIFF
--- a/client/dashboard/components/sidebar/sidebar-back-button.tsx
+++ b/client/dashboard/components/sidebar/sidebar-back-button.tsx
@@ -11,7 +11,6 @@ export function SidebarBackButton( { to, children }: { to: string; children: Rea
 				className="dashboard-sidebar__back-button"
 				icon={ arrowLeft }
 				iconSize={ 18 }
-				size="small"
 				to={ to }
 			>
 				{ children }


### PR DESCRIPTION
## Proposed Changes

**Before**

<img width="293" alt="CleanShot 2026-06-05 at 13 55 47@2x" src="https://github.com/user-attachments/assets/fb6b7e8f-9b0e-4b64-b948-07e371b328aa" />

**After**

<img width="291" alt="CleanShot 2026-06-05 at 13 57 47@2x" src="https://github.com/user-attachments/assets/51108b87-4f2f-4cd8-9148-8f45054b08d1" />

This replaces #109952.

## Why are these changes being made?

The goal is the same as #109952: make the back button ("Back to Sites", "Back to Domains") lighter and more consistent with the sidebar. But #109952 got there two ways a reviewer flagged as "hacking the official way of adding icons":

1. It replaced the `arrowLeft` SVG (on the `icon` prop) with a literal `←` text glyph in the button's children.
2. It hand-coded `font-size: 13px; line-height: 20px` in SCSS.

It turns out the hand-coded CSS was just reproducing the default `Button` size. `@wordpress/components` `Button` sizes are:

| `size` | height | font-size |
|---|---|---|
| `small` (old) | 24px | 11px |
| _(none)_ = default | 36px | **13px** |

So `size="small"` was the only thing forcing the font down to 11px; the PR's `font-size: 13px` was simply the default again. Dropping `size="small"` gives the intended 13px label for free — no SCSS, no text glyph, and the arrow stays on the official `icon` / `iconSize` API. The existing color override is unchanged.

## Testing Instructions

1. Navigate to a site overview page (`/sites/<siteSlug>`) — the "← Back to Sites" button shows the `arrowLeft` icon and a 13px label.
2. Navigate to a domain detail page (`/domains/<domainName>`) — same for "← Back to Domains".
3. Verify the arrow is still the SVG icon (not a text character) and the color remains the menu-item gray.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
