### PR TITLE
Dashboard: prepare React 19-compatible types

### DIFF
--- a/client/dashboard/app/help-center/index.ts
+++ b/client/dashboard/app/help-center/index.ts
@@ -13,7 +13,7 @@ type HelpCenterDispatch = HelpCenterDispatchObject[ 'dispatch' ];
 const HELP_CENTER_STORE = 'automattic/help-center';
 
 export function useHelpCenter() {
-	const loadingPromiseRef = useRef< Promise< unknown > >();
+	const loadingPromiseRef = useRef< Promise< unknown > >( undefined );
 	const [ isLoading, setIsLoading ] = useState( false );
 	const isShown = useSelect(
 		( select ) => !! ( select( HELP_CENTER_STORE ) as HelpCenterSelect )?.isHelpCenterShown?.(),

--- a/client/dashboard/components/callout/types.ts
+++ b/client/dashboard/components/callout/types.ts
@@ -1,5 +1,5 @@
 import type { Icon } from '@wordpress/components';
-import type { ComponentProps, ReactNode } from 'react';
+import type { ComponentProps, ReactNode, JSX } from 'react';
 
 export interface CalloutProps {
 	/**

--- a/client/dashboard/components/confirm-modal/index.tsx
+++ b/client/dashboard/components/confirm-modal/index.tsx
@@ -30,8 +30,8 @@ export default function ConfirmModal( {
 	onCancel,
 	onConfirm,
 }: Props ) {
-	const cancelButtonRef = useRef();
-	const confirmButtonRef = useRef();
+	const cancelButtonRef = useRef( undefined );
+	const confirmButtonRef = useRef( undefined );
 
 	const handleOnConfirm = () => {
 		onConfirm?.();

--- a/client/dashboard/components/guided-tour/context.tsx
+++ b/client/dashboard/components/guided-tour/context.tsx
@@ -1,8 +1,16 @@
 import { userPreferenceQuery, userPreferenceMutation } from '@automattic/api-queries';
 import { useQuery, useMutation } from '@tanstack/react-query';
-import { createContext, useCallback, useMemo, useState, useEffect, useRef } from 'react';
+import {
+	createContext,
+	useCallback,
+	useMemo,
+	useState,
+	useEffect,
+	useRef,
+	type JSX,
+	type ReactNode,
+} from 'react';
 import { useAnalytics } from '../../app/analytics';
-import type { ReactNode } from 'react';
 
 export type TourStep = {
 	id: string;

--- a/client/dashboard/components/marked-lines/index.tsx
+++ b/client/dashboard/components/marked-lines/index.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import type { JSX } from 'react';
 import './style.scss';
 
 interface MarkedLinesProps {

--- a/client/dashboard/components/menu/index.tsx
+++ b/client/dashboard/components/menu/index.tsx
@@ -1,7 +1,6 @@
 import { __experimentalHStack as HStack, MenuItem as WPMenuItem } from '@wordpress/components';
 import { ComponentProps, ComponentType } from 'react';
 import RouterLinkButton from '../router-link-button';
-import type { ActiveOptions } from '@tanstack/react-router';
 import './style.scss';
 
 interface MenuItemLinkProps
@@ -13,17 +12,12 @@ interface MenuItemLinkProps
 
 const MenuItemLink = WPMenuItem as ComponentType< MenuItemLinkProps >;
 
-function MenuItem( {
-	to,
-	children,
-	activeOptions,
-	onClick,
-}: {
-	to: string;
-	children: React.ReactNode;
-	activeOptions?: ActiveOptions;
-	onClick?: () => void;
-} ) {
+type MenuItemProps = Pick<
+	ComponentProps< typeof RouterLinkButton >,
+	'to' | 'activeOptions' | 'onClick'
+> & { children: React.ReactNode };
+
+function MenuItem( { to, children, activeOptions, onClick }: MenuItemProps ) {
 	return (
 		<RouterLinkButton
 			className="dashboard-menu__item"

--- a/client/dashboard/components/responsive-menu/index.tsx
+++ b/client/dashboard/components/responsive-menu/index.tsx
@@ -7,41 +7,41 @@ import {
 import { throttle, useViewportMatch } from '@wordpress/compose';
 import { __, isRTL } from '@wordpress/i18n';
 import { chevronLeft, chevronRight, menu } from '@wordpress/icons';
-import React, { useEffect, useRef, useState, CSSProperties } from 'react';
+import React, { useEffect, useRef, useState, type ComponentProps, type CSSProperties } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import Menu from '../menu';
 import RouterLinkMenuItem from '../router-link-menu-item';
-import type { ActiveOptions } from '@tanstack/react-router';
 
 import './style.scss';
 
+// <RouterLinkButton> uses `createLink` from TanStack, which widens `children`
+// to also accept a render-prop function and `onClick` to require an event
+// argument, and double-wraps `ref`. ResponsiveMenu only ever treats items as
+// plain menu items, we don't want to support the features provided by TanStack.
+// This type narrows those back to what we actually supports while keeping the
+// rest of the link typing (e.g. the `to` route validation).
+type ResponsiveMenuItemProps = Omit<
+	ComponentProps< typeof RouterLinkMenuItem >,
+	'children' | 'onClick' | 'ref'
+> & {
+	children: React.ReactNode;
+	onClick?: ( event?: React.MouseEvent< HTMLButtonElement > ) => void;
+};
+
+// The children of ResponsiveMenu can be any usual ReactNode, but if it _is_ an element
+// with props, then those props must be ResponsiveMenu.Item props.
+type ResponsiveMenuChildNode =
+	| Exclude< React.ReactNode, React.ReactElement | Iterable< React.ReactNode > >
+	| React.ReactElement< ResponsiveMenuItemProps >
+	| Iterable< ResponsiveMenuChildNode >;
+
 type ResponsiveMenuProps = {
 	prefix?: React.ReactNode;
-	children: React.ReactNode;
+	children: ResponsiveMenuChildNode;
 	icon?: React.ReactElement;
 	label?: string;
 	dropdownPlacement?: 'bottom-end' | 'bottom-start' | 'bottom';
 };
-
-type ResponsiveMenuItemProps = {
-	onClick?: () => void;
-	children: React.ReactNode;
-} & (
-	| {
-			to: string;
-			activeOptions?: ActiveOptions;
-			href?: never;
-			target?: never;
-			rel?: never;
-	  }
-	| {
-			href: string;
-			target: '_blank';
-			rel?: string;
-			to?: never;
-			activeOptions?: never;
-	  }
-);
 
 function ScrollButton( {
 	icon,
@@ -165,24 +165,23 @@ function ResponsiveMenu( {
 	if ( isDesktop ) {
 		const inlineMenu = (
 			<Menu>
-				{ React.Children.map( children, ( child ) => {
+				{ React.Children.map( children, ( child ): React.ReactNode => {
 					if ( React.isValidElement( child ) && child.type === ResponsiveMenu.Item ) {
-						const item = child as React.ReactElement< ResponsiveMenuItemProps >;
-						if ( item.props.target === '_blank' ) {
+						if ( child.props.target === '_blank' ) {
 							return (
 								<Button
 									className="dashboard-menu__item"
 									variant="tertiary"
-									{ ...item.props }
-									onClick={ () => {
-										item.props.onClick?.();
+									{ ...child.props }
+									onClick={ ( e: React.MouseEvent< HTMLButtonElement > ) => {
+										child.props.onClick?.( e );
 										recordTracksEvent( 'calypso_dashboard_menu_item_click', {
-											to: item.props.href,
+											to: child.props.href ?? '',
 										} );
 									} }
 								>
 									<HStack justify="flex-start" spacing={ 1 }>
-										<span>{ item.props.children }</span>
+										<span>{ child.props.children }</span>
 										<span aria-label={ __( '(opens in a new tab)' ) }>&#8599;</span>
 									</HStack>
 								</Button>
@@ -191,11 +190,11 @@ function ResponsiveMenu( {
 
 						return (
 							<Menu.Item
-								{ ...item.props }
-								onClick={ () => {
-									item.props.onClick?.();
+								{ ...child.props }
+								onClick={ ( e: React.MouseEvent< HTMLButtonElement > ) => {
+									child.props.onClick?.( e );
 									recordTracksEvent( 'calypso_dashboard_menu_item_click', {
-										to: item.props.to,
+										to: child.props.to ?? '',
 									} );
 								} }
 							/>
@@ -267,20 +266,19 @@ function ResponsiveMenu( {
 				<>
 					{ React.Children.map( children, ( child ) => {
 						if ( React.isValidElement( child ) && child.type === ResponsiveMenu.Item ) {
-							const item = child as React.ReactElement< ResponsiveMenuItemProps >;
-							if ( item.props.target === '_blank' ) {
+							if ( child.props.target === '_blank' ) {
 								return (
 									<Menu.ItemLink
-										{ ...item.props }
+										{ ...child.props }
 										onClick={ () => {
-											item.props.onClick?.();
+											child.props.onClick?.();
 											recordTracksEvent( 'calypso_dashboard_menu_item_click', {
-												to: item.props.href,
+												to: child.props.href ?? '',
 											} );
 										} }
 									>
 										<HStack justify="flex-start" spacing={ 1 }>
-											<span>{ item.props.children }</span>
+											<span>{ child.props.children }</span>
 											<span aria-label={ __( '(opens in a new tab)' ) }>&#8599;</span>
 										</HStack>
 									</Menu.ItemLink>
@@ -289,12 +287,12 @@ function ResponsiveMenu( {
 
 							return (
 								<RouterLinkMenuItem
-									{ ...item.props }
+									{ ...child.props }
 									onClick={ () => {
 										onClose();
-										item.props.onClick?.();
+										child.props.onClick?.();
 										recordTracksEvent( 'calypso_dashboard_menu_item_click', {
-											to: item.props.to,
+											to: child.props.to ?? '',
 										} );
 									} }
 								/>
@@ -311,7 +309,7 @@ function ResponsiveMenu( {
 
 ResponsiveMenu.Item = function MenuItem(
 	// eslint-disable-next-line -- The props are not used because this is just a placeholder component.
-	props: ResponsiveMenuItemProps
+	_props: ResponsiveMenuItemProps
 ) {
 	// This is going to be replaced with the right menu item depending on the screen size.
 	return null;

--- a/client/dashboard/components/responsive-menu/index.tsx
+++ b/client/dashboard/components/responsive-menu/index.tsx
@@ -18,7 +18,7 @@ import './style.scss';
 // to also accept a render-prop function and `onClick` to require an event
 // argument, and double-wraps `ref`. ResponsiveMenu only ever treats items as
 // plain menu items, we don't want to support the features provided by TanStack.
-// This type narrows those back to what we actually supports while keeping the
+// This type narrows those back to what we actually support while keeping the
 // rest of the link typing (e.g. the `to` route validation).
 type ResponsiveMenuItemProps = Omit<
 	ComponentProps< typeof RouterLinkMenuItem >,

--- a/client/dashboard/components/responsive-menu/index.tsx
+++ b/client/dashboard/components/responsive-menu/index.tsx
@@ -7,10 +7,11 @@ import {
 import { throttle, useViewportMatch } from '@wordpress/compose';
 import { __, isRTL } from '@wordpress/i18n';
 import { chevronLeft, chevronRight, menu } from '@wordpress/icons';
-import React, { useEffect, useRef, useState, ComponentProps, CSSProperties } from 'react';
+import React, { useEffect, useRef, useState, CSSProperties } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import Menu from '../menu';
 import RouterLinkMenuItem from '../router-link-menu-item';
+import type { ActiveOptions } from '@tanstack/react-router';
 
 import './style.scss';
 
@@ -21,6 +22,26 @@ type ResponsiveMenuProps = {
 	label?: string;
 	dropdownPlacement?: 'bottom-end' | 'bottom-start' | 'bottom';
 };
+
+type ResponsiveMenuItemProps = {
+	onClick?: () => void;
+	children: React.ReactNode;
+} & (
+	| {
+			to: string;
+			activeOptions?: ActiveOptions;
+			href?: never;
+			target?: never;
+			rel?: never;
+	  }
+	| {
+			href: string;
+			target: '_blank';
+			rel?: string;
+			to?: never;
+			activeOptions?: never;
+	  }
+);
 
 function ScrollButton( {
 	icon,
@@ -146,21 +167,22 @@ function ResponsiveMenu( {
 			<Menu>
 				{ React.Children.map( children, ( child ) => {
 					if ( React.isValidElement( child ) && child.type === ResponsiveMenu.Item ) {
-						if ( child.props.target === '_blank' ) {
+						const item = child as React.ReactElement< ResponsiveMenuItemProps >;
+						if ( item.props.target === '_blank' ) {
 							return (
 								<Button
 									className="dashboard-menu__item"
 									variant="tertiary"
-									{ ...child.props }
+									{ ...item.props }
 									onClick={ () => {
-										child.props.onClick?.();
+										item.props.onClick?.();
 										recordTracksEvent( 'calypso_dashboard_menu_item_click', {
-											to: child.props.href ?? '',
+											to: item.props.href,
 										} );
 									} }
 								>
 									<HStack justify="flex-start" spacing={ 1 }>
-										<span>{ child.props.children }</span>
+										<span>{ item.props.children }</span>
 										<span aria-label={ __( '(opens in a new tab)' ) }>&#8599;</span>
 									</HStack>
 								</Button>
@@ -169,11 +191,11 @@ function ResponsiveMenu( {
 
 						return (
 							<Menu.Item
-								{ ...child.props }
+								{ ...item.props }
 								onClick={ () => {
-									child.props.onClick?.();
+									item.props.onClick?.();
 									recordTracksEvent( 'calypso_dashboard_menu_item_click', {
-										to: child.props.to ?? '',
+										to: item.props.to,
 									} );
 								} }
 							/>
@@ -245,19 +267,20 @@ function ResponsiveMenu( {
 				<>
 					{ React.Children.map( children, ( child ) => {
 						if ( React.isValidElement( child ) && child.type === ResponsiveMenu.Item ) {
-							if ( child.props.target === '_blank' ) {
+							const item = child as React.ReactElement< ResponsiveMenuItemProps >;
+							if ( item.props.target === '_blank' ) {
 								return (
 									<Menu.ItemLink
-										{ ...child.props }
+										{ ...item.props }
 										onClick={ () => {
-											child.props.onClick?.();
+											item.props.onClick?.();
 											recordTracksEvent( 'calypso_dashboard_menu_item_click', {
-												to: child.props.href ?? '',
+												to: item.props.href,
 											} );
 										} }
 									>
 										<HStack justify="flex-start" spacing={ 1 }>
-											<span>{ child.props.children }</span>
+											<span>{ item.props.children }</span>
 											<span aria-label={ __( '(opens in a new tab)' ) }>&#8599;</span>
 										</HStack>
 									</Menu.ItemLink>
@@ -266,12 +289,12 @@ function ResponsiveMenu( {
 
 							return (
 								<RouterLinkMenuItem
-									{ ...child.props }
+									{ ...item.props }
 									onClick={ () => {
 										onClose();
-										child.props.onClick?.();
+										item.props.onClick?.();
 										recordTracksEvent( 'calypso_dashboard_menu_item_click', {
-											to: child.props.to ?? '',
+											to: item.props.to,
 										} );
 									} }
 								/>
@@ -288,7 +311,7 @@ function ResponsiveMenu( {
 
 ResponsiveMenu.Item = function MenuItem(
 	// eslint-disable-next-line -- The props are not used because this is just a placeholder component.
-	props: ComponentProps< typeof RouterLinkMenuItem >
+	props: ResponsiveMenuItemProps
 ) {
 	// This is going to be replaced with the right menu item depending on the screen size.
 	return null;

--- a/client/dashboard/components/responsive-menu/index.tsx
+++ b/client/dashboard/components/responsive-menu/index.tsx
@@ -288,9 +288,9 @@ function ResponsiveMenu( {
 							return (
 								<RouterLinkMenuItem
 									{ ...child.props }
-									onClick={ () => {
+									onClick={ ( e ) => {
 										onClose();
-										child.props.onClick?.();
+										child.props.onClick?.( e );
 										recordTracksEvent( 'calypso_dashboard_menu_item_click', {
 											to: child.props.to ?? '',
 										} );

--- a/client/dashboard/components/section-header/index.tsx
+++ b/client/dashboard/components/section-header/index.tsx
@@ -6,6 +6,7 @@ import {
 import clsx from 'clsx';
 import { ButtonStack } from '../button-stack';
 import type { SectionHeaderProps } from './types';
+import type { JSX } from 'react';
 import './style.scss';
 
 /**

--- a/client/dashboard/components/switcher/switcher-content.tsx
+++ b/client/dashboard/components/switcher/switcher-content.tsx
@@ -6,11 +6,10 @@ import {
 } from '@wordpress/components';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { useMemo } from 'react';
+import { useMemo, type JSX, type PropsWithChildren } from 'react';
 import RouterLinkMenuItem from '../router-link-menu-item';
 import { RenderItem } from './types';
 import type { View, Field } from '@wordpress/dataviews';
-import type { PropsWithChildren } from 'react';
 
 export default function SwitcherContent< T >( {
 	itemClassName,

--- a/client/dashboard/me/billing-history/dataviews.tsx
+++ b/client/dashboard/me/billing-history/dataviews.tsx
@@ -3,7 +3,7 @@ import { useMutation } from '@tanstack/react-query';
 import { Link, useNavigate } from '@tanstack/react-router';
 import { __experimentalText as Text, __experimentalVStack as VStack } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { useMemo } from 'react';
+import { useMemo, type JSX } from 'react';
 import { receiptRoute } from '../../app/router/me';
 import { isAkismetPro500Plan } from '../../utils/akismet';
 import { getTaxName } from '../../utils/tax';

--- a/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/index.tsx
@@ -1462,7 +1462,7 @@ function CancelPurchaseInner() {
 		recordEvent( 'calypso_purchases_cancel_form_submit' );
 	};
 
-	const createdErrorNoticeForRedirect = useRef< boolean >();
+	const createdErrorNoticeForRedirect = useRef< boolean >( undefined );
 
 	const isDataLoading =
 		siteFeaturesQueryIsPending ||

--- a/client/dashboard/me/notifications-extras/extras-toggle-card/index.tsx
+++ b/client/dashboard/me/notifications-extras/extras-toggle-card/index.tsx
@@ -1,6 +1,6 @@
 import { __experimentalVStack as VStack, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useMemo, useCallback } from 'react';
+import { useMemo, useCallback, type JSX } from 'react';
 import { Card, CardBody } from '../../../components/card';
 import { SectionHeader } from '../../../components/section-header';
 import { Text } from '../../../components/text';

--- a/client/dashboard/sites/add-new-site/menu-item.tsx
+++ b/client/dashboard/sites/add-new-site/menu-item.tsx
@@ -5,7 +5,7 @@ import {
 	Button,
 } from '@wordpress/components';
 import { Icon } from '@wordpress/icons';
-import React from 'react';
+import type { ComponentProps, JSX } from 'react';
 
 type Props = {
 	children?: JSX.Element;
@@ -20,7 +20,7 @@ function MenuItem( {
 	title,
 	icon,
 	...buttonProps
-}: Props & React.ComponentProps< typeof Button > ) {
+}: Props & ComponentProps< typeof Button > ) {
 	return (
 		<Button
 			className="dashboard-add-new-site__menu-item"

--- a/client/dashboard/sites/deployments/deployments-callout.tsx
+++ b/client/dashboard/sites/deployments/deployments-callout.tsx
@@ -4,6 +4,7 @@ import UpsellCallout from '../hosting-feature-gated-with-callout/upsell';
 import illustrationUrl from './deployments-callout-illustration.svg';
 import GithubIcon from './icons/github';
 import type { Site } from '@automattic/api-core';
+import type { JSX } from 'react';
 
 export function getDeploymentsCalloutProps() {
 	return {

--- a/client/dashboard/sites/logs-activity/activity-logs-callout.tsx
+++ b/client/dashboard/sites/logs-activity/activity-logs-callout.tsx
@@ -5,6 +5,7 @@ import { chartBar } from '@wordpress/icons';
 import UpsellCallout from '../hosting-feature-gated-with-callout/upsell';
 import illustrationUrl from './activity-logs-callout-illustration.svg';
 import type { Site } from '@automattic/api-core';
+import type { JSX } from 'react';
 
 export function getActivityLogsCalloutProps() {
 	return {

--- a/client/dashboard/sites/logs/logs-callout.tsx
+++ b/client/dashboard/sites/logs/logs-callout.tsx
@@ -4,6 +4,7 @@ import { chartBar } from '@wordpress/icons';
 import UpsellCallout from '../hosting-feature-gated-with-callout/upsell';
 import illustrationUrl from './logs-callout-illustration.svg';
 import type { Site } from '@automattic/api-core';
+import type { JSX } from 'react';
 
 export function getLogsCalloutProps() {
 	return {

--- a/client/dashboard/sites/logs/test/downloader.test.tsx
+++ b/client/dashboard/sites/logs/test/downloader.test.tsx
@@ -8,6 +8,7 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from '../../../test-utils';
 import { LogsDownloader } from '../downloader';
+import type { JSX } from 'react';
 
 jest.mock( '@wordpress/i18n', () => ( {
 	__: ( s: string ) => s,

--- a/client/dashboard/sites/monitoring/monitoring-callout.tsx
+++ b/client/dashboard/sites/monitoring/monitoring-callout.tsx
@@ -4,6 +4,7 @@ import { chartBar } from '@wordpress/icons';
 import UpsellCallout from '../hosting-feature-gated-with-callout/upsell';
 import illustrationUrl from './monitoring-callout-illustration.svg';
 import type { Site } from '@automattic/api-core';
+import type { JSX } from 'react';
 
 export function getMonitoringCalloutProps() {
 	return {

--- a/client/dashboard/sites/performance/performance-callout.tsx
+++ b/client/dashboard/sites/performance/performance-callout.tsx
@@ -4,6 +4,7 @@ import { chartBar } from '@wordpress/icons';
 import UpsellCallout from '../hosting-feature-gated-with-callout/upsell';
 import illustrationUrl from './performance-callout-illustration.svg';
 import type { Site } from '@automattic/api-core';
+import type { JSX } from 'react';
 
 export function getPerformanceCalloutProps() {
 	return {

--- a/client/dashboard/sites/settings-caching/index.tsx
+++ b/client/dashboard/sites/settings-caching/index.tsx
@@ -19,7 +19,7 @@ import {
 import { DataForm } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type JSX } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { NavigationBlocker } from '../../app/navigation-blocker';
 import { ActionList } from '../../components/action-list';


### PR DESCRIPTION
Related to: #111325

## Proposed Changes

* Split the Dashboard-only React 19 forward-compatibility changes out of the larger validation branch.
* Add React-scoped `JSX` imports and explicit `useRef( undefined )` initializers in Dashboard files touched by the React 19 type codemod.
* Update `ResponsiveMenu` to type mapped children through an explicit local prop contract instead of relying on `ReactElement` props defaulting to `any`.
* Keep React, `@wordpress/*`, and lockfile versions unchanged in this PR.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* These changes are intended to land forward-compatible Dashboard work on trunk before the larger React 19 dependency migration.
* Keeping dependency versions unchanged lets this PR remain compatible with the current React 18-compatible package line while removing known React 19 type blockers.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Current React 18 dependency line:

* `yarn eslint --ext .ts,.tsx client/dashboard/app/help-center/index.ts client/dashboard/components/callout/types.ts client/dashboard/components/confirm-modal/index.tsx client/dashboard/components/guided-tour/context.tsx client/dashboard/components/marked-lines/index.tsx client/dashboard/components/responsive-menu/index.tsx client/dashboard/components/section-header/index.tsx client/dashboard/components/switcher/switcher-content.tsx client/dashboard/me/billing-history/dataviews.tsx client/dashboard/me/billing-purchases/cancel-purchase/index.tsx client/dashboard/me/notifications-extras/extras-toggle-card/index.tsx client/dashboard/sites/add-new-site/menu-item.tsx client/dashboard/sites/deployments/deployments-callout.tsx client/dashboard/sites/logs-activity/activity-logs-callout.tsx client/dashboard/sites/logs/logs-callout.tsx client/dashboard/sites/logs/test/downloader.test.tsx client/dashboard/sites/monitoring/monitoring-callout.tsx client/dashboard/sites/performance/performance-callout.tsx client/dashboard/sites/settings-caching/index.tsx`
* `yarn typecheck-client`
  * Currently fails on existing unresolved workspace package declarations for `@automattic/omnibar` and `@automattic/date-range-picker`.
  * The earlier `ResponsiveMenu` type errors introduced by the copied spike hunk were resolved before committing.

React 19 local validation, with dependency changes applied but not committed to this PR:

* `yarn install`
  * Installs React 19 packages, but postinstall fails on expected repo-wide React 19 type blockers outside this Dashboard slice.
* `yarn eslint --ext .ts,.tsx ...` against all touched Dashboard files passes.
* `yarn test-client client/dashboard/sites/logs/test/downloader.test.tsx` passes.
* `yarn test-client client/dashboard` passes: 117 suites, 937 tests.
* `yarn typecheck-client` still fails broadly under React 19. Filtering the output for `client/dashboard` only shows the existing unresolved workspace-package declarations for `@automattic/omnibar` and `@automattic/date-range-picker`, not errors in the files touched by this PR.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
