### PR TITLE
Jetpack AI Sidebar: cover Optimize Title page suggestions

### DIFF
--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -229,6 +229,16 @@ describe( 'getEmptyViewSuggestions', () => {
 		expect( labels ).not.toContain( 'AI Editorial Review' );
 	} );
 
+	it( 'shows Optimize Title on page editors when the preview feature enables it', () => {
+		installAiEditorialReviewData( { optimizeTitleSuggestion: true } );
+		installPostTypeMock( 'page' );
+
+		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
+
+		expect( labels ).toContain( 'Optimize Title' );
+		expect( labels ).not.toContain( 'AI Editorial Review' );
+	} );
+
 	it( 'hides AI Editorial Review until the post type is known', () => {
 		installAiEditorialReviewData();
 		installPostTypeMock();
@@ -358,6 +368,38 @@ describe( 'useSuggestions', () => {
 					surface: 'jetpack_ai_sidebar',
 				},
 			],
+		] );
+	} );
+
+	it( 'keeps Optimize Title out of selected-block suggestions', () => {
+		installAiEditorialReviewData( { optimizeTitleSuggestion: true } );
+		mockCurrentPostType = 'page';
+		mockSelectedBlock = { clientId: 'b-selected', name: 'core/paragraph' };
+		const onSuggestions = jest.fn();
+
+		render( React.createElement( SuggestionsProbe, { onSuggestions } ) );
+
+		const latestSuggestions =
+			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
+		expect( latestSuggestions.map( ( suggestion: any ) => suggestion.label ) ).toEqual( [
+			'Translate content',
+			'Change tone',
+			'Check grammar',
+			'Simplify text',
+		] );
+	} );
+
+	it( 'shows Optimize Title in Page Editor when no block is selected', () => {
+		installAiEditorialReviewData( { optimizeTitleSuggestion: true } );
+		mockCurrentPostType = 'page';
+		const onSuggestions = jest.fn();
+
+		render( React.createElement( SuggestionsProbe, { onSuggestions } ) );
+
+		const latestSuggestions =
+			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
+		expect( latestSuggestions.map( ( suggestion: any ) => suggestion.label ) ).toEqual( [
+			'Optimize Title',
 		] );
 	} );
 


### PR DESCRIPTION
Part of #111335

## Proposed Changes

* Add Jetpack AI Sidebar tests for showing Optimize Title in the Page/Site Editor when the preview feature enables it and no block is selected.
* Add coverage that selected-block suggestions stay block-specific, so Optimize Title does not appear while editing a selected paragraph block.

## Why are these changes being made?

* This is the Calypso test layer for enabling Jetpack-owned Optimize Title through the AM-composed Jetpack AI provider.
* The behavior matters for the Page/Site Editor path: Jetpack suggestions should be available when no block is selected, but block-level chips should not be polluted by post/page-level suggestions.

## Testing Instructions

* This PR is stacked on #111335.
* Pair with Automattic/jetpack#49420, which enables `jetpackAiSidebarPreview.features.optimizeTitleSuggestion`.
* Run `yarn workspace @automattic/jetpack-ai-sidebar test`.
* Manual: with Jetpack AI enabled in the Page/Site Editor and no selected block, open the sidebar and confirm Optimize Title is available.
* Manual: select a paragraph block and confirm the sidebar shows block-level suggestions like Translate content, Change tone, Check grammar, and Simplify text, without showing Optimize Title.
* Manual: confirm Post Editor behavior still shows Jetpack AI post-editor suggestions.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [x] Have you used memoizing on expensive computations? N/A, test-only change.
- [ ] Have we added the \"[Status] String Freeze\" label as soon as any new strings were ready for translation?
- [ ] For changes affecting Jetpack: Have we added the \"[Status] Needs Privacy Updates\" label if this pull request changes what data or activity we track or use?