### PR TITLE
Jetpack AI Sidebar: cover Optimize Title page suggestions

### DIFF
--- a/packages/jetpack-ai-sidebar/AGENTS.md
+++ b/packages/jetpack-ai-sidebar/AGENTS.md
@@ -36,10 +36,10 @@ All exports live in `src/index.ts`. This is intentionally a single-file provider
 
 ## Tools
 
-| Tool ID                      | Handler                     | UI Component           | Description                                              |
-| ---------------------------- | --------------------------- | ---------------------- | -------------------------------------------------------- |
-| `jetpack_ai__show_component` | `handleShowComponent`       | via `getChatComponent` | Renders Jetpack AI chat components                       |
-| `big_sky__show_component`    | `handleLegacyShowComponent` | Jetpack or Big Sky     | Temporary migration support; delegates non-Jetpack types |
+| Tool ID                           | Handler                     | UI Component           | Description                                              |
+| --------------------------------- | --------------------------- | ---------------------- | -------------------------------------------------------- |
+| `jetpack_ai__show_component`      | `handleShowComponent`       | via `getChatComponent` | Renders Jetpack AI chat components                       |
+| `big_sky__show_component`         | `handleLegacyShowComponent` | Jetpack or Big Sky     | Temporary migration support; delegates non-Jetpack types |
 | `jetpack-ai/update-block-content` | `handleUpdateBlockContent`  | _(chat text)_          | Updates block content with shimmer effect                |
 
 ### Show-component pattern

--- a/packages/jetpack-ai-sidebar/AGENTS.md
+++ b/packages/jetpack-ai-sidebar/AGENTS.md
@@ -29,7 +29,7 @@ All exports live in `src/index.ts`. This is intentionally a single-file provider
 
 - **Module-level state**: `addMessageFn`, `clearSuggestionsFn`, and `moduleCheckpointApi` are captured once via their respective hooks. These are module singletons — do NOT move them into React state or a store.
 - **`returnToAgent: false`**: The `handleUpdateBlockContent` and `handleShowComponent` handlers return `{ returnToAgent: false }`. This prevents the AM orchestrator from continuing automatically after the tool executes. Removing this breaks the UX flow.
-- **Tool ID normalization**: AM normalizes tool IDs (`wpcom/update-block-content` → `wpcom__update_block_content`). The `isUpdateBlockContentTool` / `isShowComponentTool` helpers handle both forms. Any new tool must follow this pattern.
+- **Tool ID normalization**: AM normalizes tool IDs (`jetpack-ai/update-block-content` → `jetpack_ai__update_block_content`). The `isUpdateBlockContentTool` / `isShowComponentTool` helpers handle both forms. Any new tool must follow this pattern.
 - **Show-component via `agentMessage` escape hatch**: `handleShowComponent` returns `{ agentMessage: JSON }` — it does NOT call `addMessageFn` directly. agenttic-client wraps the JSON in an `{ role: 'agent', parts: [text] }` message, AM's `convert-tool-messages-to-components` resolves the component via `getChatComponent`, and AgentChat's action bar (thumbs/Undo) attaches because the original message had a text content part. See "Show-component pattern" below.
 - **Role transformation**: AM's `useAbilitiesSetup` handler maps `role: 'assistant'` → `'agent'` and everything else → `'user'`. When injecting messages directly via `addMessageFn`, always use `'assistant'` — passing `'agent'` would make the message render as user content and get filtered out of the agent message list.
 - **Processing shimmer**: The block editing shimmer uses `Flow Block` font + CSS animations injected into the block's owning document (which may be an iframe). The `ensureProcessingStyles` function is idempotent — don't duplicate style injection.
@@ -40,7 +40,7 @@ All exports live in `src/index.ts`. This is intentionally a single-file provider
 | ---------------------------- | --------------------------- | ---------------------- | -------------------------------------------------------- |
 | `jetpack_ai__show_component` | `handleShowComponent`       | via `getChatComponent` | Renders Jetpack AI chat components                       |
 | `big_sky__show_component`    | `handleLegacyShowComponent` | Jetpack or Big Sky     | Temporary migration support; delegates non-Jetpack types |
-| `wpcom/update-block-content` | `handleUpdateBlockContent`  | _(chat text)_          | Updates block content with shimmer effect                |
+| `jetpack-ai/update-block-content` | `handleUpdateBlockContent`  | _(chat text)_          | Updates block content with shimmer effect                |
 
 ### Show-component pattern
 

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -229,6 +229,16 @@ describe( 'getEmptyViewSuggestions', () => {
 		expect( labels ).not.toContain( 'AI Editorial Review' );
 	} );
 
+	it( 'shows Optimize Title on page editors when the preview feature enables it', () => {
+		installAiEditorialReviewData( { optimizeTitleSuggestion: true } );
+		installPostTypeMock( 'page' );
+
+		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
+
+		expect( labels ).toContain( 'Optimize Title' );
+		expect( labels ).not.toContain( 'AI Editorial Review' );
+	} );
+
 	it( 'hides AI Editorial Review until the post type is known', () => {
 		installAiEditorialReviewData();
 		installPostTypeMock();
@@ -358,6 +368,38 @@ describe( 'useSuggestions', () => {
 					surface: 'jetpack_ai_sidebar',
 				},
 			],
+		] );
+	} );
+
+	it( 'keeps Optimize Title out of selected-block suggestions', () => {
+		installAiEditorialReviewData( { optimizeTitleSuggestion: true } );
+		mockCurrentPostType = 'page';
+		mockSelectedBlock = { clientId: 'b-selected', name: 'core/paragraph' };
+		const onSuggestions = jest.fn();
+
+		render( React.createElement( SuggestionsProbe, { onSuggestions } ) );
+
+		const latestSuggestions =
+			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
+		expect( latestSuggestions.map( ( suggestion: any ) => suggestion.label ) ).toEqual( [
+			'Translate content',
+			'Change tone',
+			'Check grammar',
+			'Simplify text',
+		] );
+	} );
+
+	it( 'shows Optimize Title in Page Editor when no block is selected', () => {
+		installAiEditorialReviewData( { optimizeTitleSuggestion: true } );
+		mockCurrentPostType = 'page';
+		const onSuggestions = jest.fn();
+
+		render( React.createElement( SuggestionsProbe, { onSuggestions } ) );
+
+		const latestSuggestions =
+			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
+		expect( latestSuggestions.map( ( suggestion: any ) => suggestion.label ) ).toEqual( [
+			'Optimize Title',
 		] );
 	} );
 

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -39,6 +39,7 @@ let mockCurrentPostType: string | undefined = 'post';
 let mockBlocksByClientId: Record< string, any > = {};
 const SHOW_COMPONENT_TOOL_ID = 'jetpack_ai__show_component';
 const LEGACY_SHOW_COMPONENT_TOOL_ID = 'big_sky__show_component';
+const UPDATE_BLOCK_CONTENT_TOOL_ID = 'jetpack-ai/update-block-content';
 
 jest.mock( '@wordpress/components', () => {
 	const react = jest.requireActual< typeof import('react') >( 'react' );
@@ -147,6 +148,13 @@ function installAiEditorialReviewData( features: Record< string, boolean > = {} 
 			},
 		},
 	};
+}
+
+function installBigSkyProviderData( features: Record< string, boolean > = {} ) {
+	installAiEditorialReviewData( features );
+	( globalThis as any ).agentsManagerData.agentProviders = [
+		'https://widgets.wp.com/agents-manager/big-sky.provider.mjs',
+	];
 }
 
 function SuggestionsProbe( {
@@ -372,6 +380,38 @@ describe( 'useSuggestions', () => {
 	} );
 
 	it( 'keeps Optimize Title out of selected-block suggestions', () => {
+		installAiEditorialReviewData( { optimizeTitleSuggestion: true } );
+		mockCurrentPostType = 'page';
+		mockSelectedBlock = { clientId: 'b-selected', name: 'core/paragraph' };
+		const onSuggestions = jest.fn();
+
+		render( React.createElement( SuggestionsProbe, { onSuggestions } ) );
+
+		const latestSuggestions =
+			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
+		expect( latestSuggestions.map( ( suggestion: any ) => suggestion.label ) ).toEqual( [
+			'Translate content',
+			'Change tone',
+			'Check grammar',
+			'Simplify text',
+		] );
+	} );
+
+	it( 'omits Jetpack selected-block text suggestions on Big Sky Page Editor surfaces', () => {
+		installBigSkyProviderData( { optimizeTitleSuggestion: true } );
+		mockCurrentPostType = 'page';
+		mockSelectedBlock = { clientId: 'b-selected', name: 'core/paragraph' };
+		const onSuggestions = jest.fn();
+
+		render( React.createElement( SuggestionsProbe, { onSuggestions } ) );
+
+		const latestSuggestions =
+			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
+		expect( latestSuggestions.map( ( suggestion: any ) => suggestion.label ) ).toEqual( [] );
+		expect( getTracksCalls( 'jetpack_ai_block_transformation_suggestion_rendered' ) ).toEqual( [] );
+	} );
+
+	it( 'keeps Jetpack selected-block text suggestions on Jetpack-only Page Editor surfaces', () => {
 		installAiEditorialReviewData( { optimizeTitleSuggestion: true } );
 		mockCurrentPostType = 'page';
 		mockSelectedBlock = { clientId: 'b-selected', name: 'core/paragraph' };
@@ -797,9 +837,31 @@ describe( 'toolProvider', () => {
 			const abilities = await toolProvider.getAbilities();
 			const names = abilities.map( ( a: any ) => a.name );
 
-			expect( names ).toContain( 'wpcom/update-block-content' );
+			expect( names ).toContain( UPDATE_BLOCK_CONTENT_TOOL_ID );
 			expect( names ).toContain( SHOW_COMPONENT_TOOL_ID );
 			expect( names ).toContain( LEGACY_SHOW_COMPONENT_TOOL_ID );
+		} );
+
+		it( 'keeps update-block-content available on Big Sky Page Editor surfaces', async () => {
+			installBigSkyProviderData();
+			installPostTypeMock( 'page' );
+
+			const abilities = await toolProvider.getAbilities();
+			const names = abilities.map( ( a: any ) => a.name );
+
+			expect( names ).toContain( UPDATE_BLOCK_CONTENT_TOOL_ID );
+			expect( names ).toContain( SHOW_COMPONENT_TOOL_ID );
+		} );
+
+		it( 'keeps update-block-content on Jetpack-only Page Editor surfaces', async () => {
+			installAiEditorialReviewData();
+			installPostTypeMock( 'page' );
+
+			const abilities = await toolProvider.getAbilities();
+			const names = abilities.map( ( a: any ) => a.name );
+
+			expect( names ).toContain( UPDATE_BLOCK_CONTENT_TOOL_ID );
+			expect( names ).toContain( SHOW_COMPONENT_TOOL_ID );
 		} );
 
 		it( 'wires a callback on each provided ability', async () => {
@@ -808,11 +870,22 @@ describe( 'toolProvider', () => {
 			const legacyShowComponent = abilities.find(
 				( a: any ) => a.name === LEGACY_SHOW_COMPONENT_TOOL_ID
 			);
-			const updateBlock = abilities.find( ( a: any ) => a.name === 'wpcom/update-block-content' );
+			const updateBlock = abilities.find( ( a: any ) => a.name === UPDATE_BLOCK_CONTENT_TOOL_ID );
 
 			expect( typeof showComponent?.callback ).toBe( 'function' );
 			expect( typeof legacyShowComponent?.callback ).toBe( 'function' );
 			expect( typeof updateBlock?.callback ).toBe( 'function' );
+		} );
+
+		it( 'includes routing instructions on update-block-content', async () => {
+			const abilities = await toolProvider.getAbilities();
+			const updateBlock = abilities.find( ( a: any ) => a.name === UPDATE_BLOCK_CONTENT_TOOL_ID );
+
+			expect( updateBlock?.meta?.instructions ).toContain(
+				'Jetpack AI Sidebar selected text-block'
+			);
+			expect( updateBlock?.meta?.instructions ).toContain( 'jetpack_ai__update_block_content' );
+			expect( updateBlock?.meta?.instructions ).toContain( 'wpcom__rewrite_content' );
 		} );
 
 		it( 'preserves Big Sky abilities exposed through wp.abilities', async () => {
@@ -889,7 +962,7 @@ describe( 'toolProvider', () => {
 			const abilities = await toolProvider.getAbilities();
 			const names = abilities.map( ( a: any ) => a.name );
 
-			expect( names ).not.toContain( 'wpcom/update-block-content' );
+			expect( names ).not.toContain( UPDATE_BLOCK_CONTENT_TOOL_ID );
 			expect( names ).toContain( SHOW_COMPONENT_TOOL_ID );
 			expect( names ).toContain( LEGACY_SHOW_COMPONENT_TOOL_ID );
 		} );
@@ -1119,11 +1192,13 @@ function installWpDataMockWithBlockEditor(
 			name: 'core/paragraph',
 			attributes: { content: 'original block content' },
 		},
-	}
+	},
+	selectedClientId?: string
 ) {
 	const editorState: { title: string } = { title: 'original' };
 	const blockUpdates: Array< { clientId: string; attrs: Record< string, unknown > } > = [];
 	const selectedClientIds: string[] = [];
+	let selectedBlockClientId = selectedClientId;
 	( window as any ).wp = {
 		data: {
 			select: ( store: string ) => {
@@ -1137,6 +1212,10 @@ function installWpDataMockWithBlockEditor(
 					return {
 						getBlock: ( clientId: string ) =>
 							blocks[ clientId ] ? { clientId, ...blocks[ clientId ] } : null,
+						getSelectedBlock: () =>
+							selectedBlockClientId && blocks[ selectedBlockClientId ]
+								? { clientId: selectedBlockClientId, ...blocks[ selectedBlockClientId ] }
+								: null,
 						getBlocks: () =>
 							Object.entries( blocks ).map( ( [ clientId, block ] ) => ( {
 								clientId,
@@ -1168,6 +1247,7 @@ function installWpDataMockWithBlockEditor(
 							}
 						},
 						selectBlock: ( clientId: string ) => {
+							selectedBlockClientId = clientId;
 							selectedClientIds.push( clientId );
 						},
 					};
@@ -1415,6 +1495,42 @@ describe( 'applyReviewEdit', () => {
 				attrs: { content: 'Hello world, this is my first post.' },
 			},
 		] );
+		warn.mockRestore();
+	} );
+
+	it( 'falls back to the selected block when the clientId is compressed', async () => {
+		const { blockUpdates } = installWpDataMockWithBlockEditor(
+			{
+				'live-client-id': {
+					name: 'core/paragraph',
+					attributes: { content: 'hello world' },
+				},
+			},
+			'live-client-id'
+		);
+		useAbilitiesSetup( { addMessage: () => undefined, clearSuggestions: () => undefined } as any );
+		const warn = jest.spyOn( console, 'warn' ).mockImplementation( () => undefined );
+
+		const promise = applyReviewEdit( 'short-id', 'hola mundo' );
+		jest.advanceTimersByTime( 1000 );
+		const result = await promise;
+
+		expect( result ).toMatchObject( {
+			success: true,
+			clientId: 'live-client-id',
+			contentBefore: 'hello world',
+			contentAfter: 'hola mundo',
+		} );
+		expect( blockUpdates ).toEqual( [
+			{
+				clientId: 'live-client-id',
+				attrs: { content: 'hola mundo' },
+			},
+		] );
+		expect( warn ).toHaveBeenCalledWith(
+			'[ReviewMediation] stale clientId matched selected block',
+			expect.any( Object )
+		);
 		warn.mockRestore();
 	} );
 

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -39,6 +39,7 @@ import {
 } from './utils/block-actions';
 import {
 	UPDATE_BLOCK_CONTENT_TOOL_ID,
+	LEGACY_UPDATE_BLOCK_CONTENT_TOOL_ID,
 	UPDATE_BLOCK_CONTENT_ABILITY,
 	isUpdateBlockContentTool,
 } from './utils/tool-provider';
@@ -145,6 +146,50 @@ function isOptimizeTitleSuggestionEnabled(): boolean {
 
 function isBlockTransformationsEnabled(): boolean {
 	return isJetpackAiSidebarPreviewFeatureEnabled( 'blockTransformations', true );
+}
+
+function providerEntryLooksLikeDesignProvider( providerEntry: unknown ): boolean {
+	const providerSource =
+		typeof providerEntry === 'string'
+			? providerEntry
+			: [
+					( providerEntry as any )?.id,
+					( providerEntry as any )?.name,
+					( providerEntry as any )?.url,
+					( providerEntry as any )?.src,
+			  ]
+					.filter( ( value ) => typeof value === 'string' )
+					.join( ' ' );
+
+	return /big[-_]?sky|dolly/i.test( providerSource );
+}
+
+function hasDesignProviderActive(): boolean {
+	const data = getAgentsManagerData() as any;
+	const providers = Array.isArray( data?.agentProviders ) ? data.agentProviders : [];
+
+	return (
+		providers.some( providerEntryLooksLikeDesignProvider ) ||
+		typeof ( window as any ).bigSkyInitialState !== 'undefined' ||
+		!! data?.bigSkyVersion ||
+		!! data?.siteMetadata?.big_sky_version
+	);
+}
+
+function isDesignEditorSurface(
+	currentPostType: string | undefined = getCurrentEditorPostType()
+): boolean {
+	const pathname = window.location.pathname;
+
+	return currentPostType === 'page' || pathname.includes( 'site-editor.php' );
+}
+
+function shouldProvideBlockTransformations( currentPostType?: string ): boolean {
+	if ( ! isBlockTransformationsEnabled() ) {
+		return false;
+	}
+
+	return ! ( isDesignEditorSurface( currentPostType ) && hasDesignProviderActive() );
 }
 
 function getCurrentEditorPostType(): string | undefined {
@@ -402,8 +447,8 @@ export function useAbilitiesSetup( actions: {
 
 /**
  * Normalize an ability name to the format used by agenttic-client for matching.
- * @param {string} name - Ability name (e.g., 'wpcom/update-block-content').
- * @returns {string} Normalized name (e.g., 'wpcom__update_block_content').
+ * @param {string} name - Ability name (e.g., 'jetpack-ai/update-block-content').
+ * @returns {string} Normalized name (e.g., 'jetpack_ai__update_block_content').
  */
 function normalizeAbilityName( name: string ): string {
 	return name.replace( /\//g, '__' ).replace( /-/g, '_' );
@@ -440,7 +485,7 @@ function isShowComponentTool( toolId: string ): boolean {
 
 export const toolProvider = {
 	/**
-	 * Client-side abilities this provider handles: `wpcom/update-block-content`
+	 * Client-side abilities this provider handles: `jetpack-ai/update-block-content`
 	 * (block edits + summary) and Jetpack show-component tools (interactive
 	 * pickers, registered here so self-hosted Jetpack sees the tool_id).
 	 * @returns {Promise<any[]>} Array of ability descriptors.
@@ -463,6 +508,7 @@ export const toolProvider = {
 
 		const externalLegacyShowComponentAvailable = hasLegacyShowComponentAbility( abilities );
 		abilities = filterAbility( abilities, UPDATE_BLOCK_CONTENT_TOOL_ID );
+		abilities = filterAbility( abilities, LEGACY_UPDATE_BLOCK_CONTENT_TOOL_ID );
 		abilities = filterAbility( abilities, SHOW_COMPONENT_TOOL_ID );
 		const jetpackAbilities = [
 			...( isBlockTransformationsEnabled()
@@ -794,7 +840,7 @@ function trackRenderedBlockTransformationSuggestions(
 }
 
 function trackBlockTransformationSuggestionClickForValue( value: string ): void {
-	if ( ! isBlockTransformationsEnabled() ) {
+	if ( ! shouldProvideBlockTransformations() ) {
 		return;
 	}
 
@@ -923,7 +969,7 @@ export function useSuggestions(
 
 	const selectedBlock = editorContext.selectedBlock;
 	const aiEditorialReviewSuggestions = getAiEditorialReviewSuggestions( editorContext.postType );
-	const blockTransformationsEnabled = isBlockTransformationsEnabled();
+	const blockTransformationsEnabled = shouldProvideBlockTransformations( editorContext.postType );
 	const applicable = useMemo(
 		() =>
 			selectedBlock && blockTransformationsEnabled

--- a/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
@@ -354,6 +354,31 @@ function findBlockSnapshotByCurrentText( currentText: string ): {
 	return {};
 }
 
+function getSelectedOrRememberedBlockSnapshot(
+	currentText?: string
+): { clientId: string; name: string; content: string } | null {
+	const block = getSelectedOrRememberedBlock();
+	if ( ! block?.clientId ) {
+		return null;
+	}
+
+	const snapshot = {
+		clientId: block.clientId,
+		name: block.name,
+		content: getEditableBlockContent( block ),
+	};
+
+	if ( ! isSupportedEditBlockType( snapshot.name ) ) {
+		return null;
+	}
+
+	if ( currentText && ! snapshot.content.includes( currentText ) ) {
+		return null;
+	}
+
+	return snapshot;
+}
+
 /**
  * Handle the update-block-content tool call: apply text changes to a block.
  * @param {any} input - Tool input with clientId, content, optional summary / currentText,
@@ -405,6 +430,21 @@ export function handleUpdateBlockContent( input: any ): any {
 				snapshot = fallback.snapshot;
 				// eslint-disable-next-line no-console
 				console.warn( '[ReviewMediation] stale clientId matched by currentText', {
+					clientId,
+					targetClientId,
+				} );
+			}
+		}
+
+		if ( ! snapshot ) {
+			const selectedSnapshot = getSelectedOrRememberedBlockSnapshot(
+				hasCurrentText ? currentText : undefined
+			);
+			if ( selectedSnapshot ) {
+				targetClientId = selectedSnapshot.clientId;
+				snapshot = selectedSnapshot;
+				// eslint-disable-next-line no-console
+				console.warn( '[ReviewMediation] stale clientId matched selected block', {
 					clientId,
 					targetClientId,
 				} );

--- a/packages/jetpack-ai-sidebar/src/utils/tool-provider.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/tool-provider.ts
@@ -11,7 +11,8 @@
 
 import type { Tool } from '@automattic/agenttic-client';
 
-export const UPDATE_BLOCK_CONTENT_TOOL_ID = 'wpcom/update-block-content';
+export const UPDATE_BLOCK_CONTENT_TOOL_ID = 'jetpack-ai/update-block-content';
+export const LEGACY_UPDATE_BLOCK_CONTENT_TOOL_ID = 'wpcom/update-block-content';
 
 export const UPDATE_BLOCK_CONTENT_ABILITY: Tool = {
 	id: UPDATE_BLOCK_CONTENT_TOOL_ID,
@@ -19,6 +20,10 @@ export const UPDATE_BLOCK_CONTENT_ABILITY: Tool = {
 	...( { label: 'Update block content', category: 'jetpack-ai' } as any ), // eslint-disable-line @typescript-eslint/no-explicit-any
 	description:
 		'Update the text content of a specific block in the editor. Use this after translating, changing tone, checking grammar, or any other text transformation. The block will be updated directly in the editor.',
+	meta: {
+		instructions:
+			'Call jetpack_ai__update_block_content for Jetpack AI Sidebar selected text-block transformations, including translation, tone changes, grammar/spelling fixes, simplification, and similar rewrites. Use selected_block_client_id as clientId. When selected block content is available, include the exact original attributes.content string as currentText. Do not use wpcom__rewrite_content, wpcom__block_editing, or big_sky__set_processing_state for these Jetpack AI Sidebar selected-block transformations.',
+	},
 	input_schema: {
 		type: 'object',
 		properties: {
@@ -45,5 +50,10 @@ export const UPDATE_BLOCK_CONTENT_ABILITY: Tool = {
 };
 
 export function isUpdateBlockContentTool( toolId: string ): boolean {
-	return toolId === UPDATE_BLOCK_CONTENT_TOOL_ID || toolId === 'wpcom__update_block_content';
+	return [
+		UPDATE_BLOCK_CONTENT_TOOL_ID,
+		'jetpack_ai__update_block_content',
+		LEGACY_UPDATE_BLOCK_CONTENT_TOOL_ID,
+		'wpcom__update_block_content',
+	].includes( toolId );
 }


### PR DESCRIPTION
Part of #111335

## Proposed Changes

* Add Jetpack AI Sidebar tests for showing Optimize Title in the Page/Site Editor when the preview feature enables it and no block is selected.
* Add coverage that selected-block suggestions stay block-specific, so Optimize Title does not appear while editing a selected paragraph block.

## Why are these changes being made?

* This is the Calypso test layer for enabling Jetpack-owned Optimize Title through the AM-composed Jetpack AI provider.
* The behavior matters for the Page/Site Editor path: Jetpack suggestions should be available when no block is selected, but block-level chips should not be polluted by post/page-level suggestions.

## Testing Instructions

* This PR is stacked on #111335.
* Pair with Automattic/jetpack#49421, which enables `jetpackAiSidebarPreview.features.optimizeTitleSuggestion`.
* Run `yarn workspace @automattic/jetpack-ai-sidebar test`.
* Manual: with Jetpack AI enabled in the Page/Site Editor and no selected block, open the sidebar and confirm Optimize Title is available.
* Manual: select a paragraph block and confirm the sidebar shows block-level suggestions like Translate content, Change tone, Check grammar, and Simplify text, without showing Optimize Title.
* Manual: confirm Post Editor behavior still shows Jetpack AI post-editor suggestions.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [x] Have you used memoizing on expensive computations? N/A, test-only change.
- [ ] Have we added the \"[Status] String Freeze\" label as soon as any new strings were ready for translation?
- [ ] For changes affecting Jetpack: Have we added the \"[Status] Needs Privacy Updates\" label if this pull request changes what data or activity we track or use?

