### PR TITLE
My Sites: split remaining React 19 updates

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -43,6 +43,7 @@ import { useTranslate } from 'i18n-calypso';
 import {
 	useCallback,
 	useMemo,
+	useRef,
 	useState,
 	type JSX,
 	type PropsWithChildren,
@@ -500,8 +501,24 @@ export default function CheckoutMainContent( {
 
 	const checkoutActions = useDispatch( CHECKOUT_STORE );
 
-	const [ shouldShowContactDetailsValidationErrors, setShouldShowContactDetailsValidationErrors ] =
-		useState( true );
+	const [
+		shouldShowContactDetailsValidationErrors,
+		setShouldShowContactDetailsValidationErrorsState,
+	] = useState( true );
+	// Mirror the flag in a ref so the step-completion validation — which runs
+	// synchronously right after the contact-form autocomplete sets this to
+	// `false` — reads the current value instead of a stale render closure. Under
+	// React 19's update timing the state setter hasn't propagated to the
+	// `isCompleteCallback` closure yet, which would otherwise surface validation
+	// errors for cached details the user never entered.
+	// See `use-prefill-checkout-contact-form`.
+	const shouldShowContactDetailsValidationErrorsRef = useRef(
+		shouldShowContactDetailsValidationErrors
+	);
+	const setShouldShowContactDetailsValidationErrors = useCallback( ( value: boolean ) => {
+		shouldShowContactDetailsValidationErrorsRef.current = value;
+		setShouldShowContactDetailsValidationErrorsState( value );
+	}, [] );
 
 	// The "Summary" view is displayed in the sidebar at desktop (wide) widths
 	// and before the first step at mobile (smaller) widths. At smaller widths it
@@ -816,8 +833,13 @@ export default function CheckoutMainContent( {
 							stepId="contact-form"
 							onPageLoadError={ onPageLoadError }
 							isCompleteCallback={ async () => {
+								// Read from the ref: autocomplete suppresses errors by setting the
+								// flag to `false` immediately before invoking this callback, and the
+								// state update would not yet be visible in this closure.
+								const shouldDisplayValidationErrors =
+									shouldShowContactDetailsValidationErrorsRef.current;
 								// Touch the fields so they display validation errors
-								if ( shouldShowContactDetailsValidationErrors ) {
+								if ( shouldDisplayValidationErrors ) {
 									touchContactFields();
 								}
 								const validationResponse = await validateContactDetails(
@@ -829,7 +851,7 @@ export default function CheckoutMainContent( {
 									clearDomainContactErrorMessages,
 									reduxDispatch,
 									translate,
-									shouldShowContactDetailsValidationErrors
+									shouldDisplayValidationErrors
 								);
 								if ( validationResponse ) {
 									// When the contact details change, update the VAT details on the server.
@@ -843,7 +865,7 @@ export default function CheckoutMainContent( {
 										}
 									} catch ( error ) {
 										reduxDispatch( removeNotice( 'vat_info_notice' ) );
-										if ( shouldShowContactDetailsValidationErrors ) {
+										if ( shouldDisplayValidationErrors ) {
 											reduxDispatch(
 												errorNotice( ( error as Error ).message, { id: 'vat_info_notice' } )
 											);

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -813,9 +813,6 @@ const CheckoutSummaryFeaturesListItem = styled( 'li' )< { isSupported?: boolean 
 		padding-left: 0;
 	}
 `;
-CheckoutSummaryFeaturesListItem.defaultProps = {
-	isSupported: true,
-};
 
 const CheckoutSummaryTitle = styled.div`
 	margin-bottom: 16px;

--- a/client/my-sites/checkout/src/test/checkout-contact-autocomplete.tsx
+++ b/client/my-sites/checkout/src/test/checkout-contact-autocomplete.tsx
@@ -78,9 +78,7 @@ describe( 'Checkout contact step', () => {
 	it( 'does not complete the contact step when the contact step button has not been clicked and there are no cached details', async () => {
 		mockCachedContactDetailsEndpoint( {} );
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } />, {
-			legacyRoot: true,
-		} );
+		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		// Wait for the cart to load
 		await screen.findByText( 'Country' );
 		expect( screen.queryByTestId( 'payment-method-step--visible' ) ).not.toBeInTheDocument();
@@ -93,9 +91,7 @@ describe( 'Checkout contact step', () => {
 		} );
 		mockContactDetailsValidationEndpoint( 'tax', { success: true } );
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } />, {
-			legacyRoot: true,
-		} );
+		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		// Wait for the cart to load
 		await screen.findByLabelText( 'Continue with the entered contact details' );
 		const countryField = await screen.findByLabelText( 'Country' );
@@ -116,9 +112,7 @@ describe( 'Checkout contact step', () => {
 		} );
 		mockContactDetailsValidationEndpoint( 'tax', { success: false, messages: [ 'Invalid' ] } );
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } />, {
-			legacyRoot: true,
-		} );
+		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		// Wait for the cart to load
 		await screen.findByText( 'Country' );
 		await expect( screen.findByTestId( 'payment-method-step--visible' ) ).toNeverAppear();
@@ -134,9 +128,7 @@ describe( 'Checkout contact step', () => {
 			messages: { postal_code: [ 'Postal code error message' ] },
 		} );
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } />, {
-			legacyRoot: true,
-		} );
+		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		// Wait for the cart to load
 		await screen.findByText( 'Country' );
 		await expect( screen.findByText( 'Postal code error message' ) ).toNeverAppear();
@@ -260,8 +252,7 @@ describe( 'Checkout contact step', () => {
 					{ ...defaultPropsForMockCheckout }
 					cartChanges={ { products: [ product ] } }
 					additionalProps={ { isLoggedOutCart: logged === 'out' } }
-				/>,
-				{ legacyRoot: true }
+				/>
 			);
 
 			// Wait for the cart to load

--- a/client/my-sites/checkout/src/test/checkout-vat-form.tsx
+++ b/client/my-sites/checkout/src/test/checkout-vat-form.tsx
@@ -94,9 +94,7 @@ describe( 'Checkout contact step VAT form', () => {
 	it( 'does not render the VAT field checkbox if the selected country does not support VAT', async () => {
 		const user = userEvent.setup();
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } />, {
-			legacyRoot: true,
-		} );
+		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		await screen.findByLabelText( 'Continue with the entered contact details' );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'US' );
 		expect( screen.queryByLabelText( 'Add VAT details' ) ).not.toBeInTheDocument();
@@ -105,9 +103,7 @@ describe( 'Checkout contact step VAT form', () => {
 	it( 'renders the VAT field checkbox if the selected country does support VAT', async () => {
 		const user = userEvent.setup();
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } />, {
-			legacyRoot: true,
-		} );
+		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		await screen.findByLabelText( 'Continue with the entered contact details' );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'GB' );
 		expect( await screen.findByLabelText( 'Add VAT details' ) ).toBeInTheDocument();
@@ -116,9 +112,7 @@ describe( 'Checkout contact step VAT form', () => {
 	it( 'does not render the VAT fields if the checkbox is not checked', async () => {
 		const user = userEvent.setup();
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } />, {
-			legacyRoot: true,
-		} );
+		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		await screen.findByLabelText( 'Continue with the entered contact details' );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'GB' );
 		expect( await screen.findByLabelText( 'Add VAT details' ) ).not.toBeChecked();
@@ -128,9 +122,7 @@ describe( 'Checkout contact step VAT form', () => {
 	it( 'renders the VAT fields if the checkbox is checked', async () => {
 		const user = userEvent.setup();
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } />, {
-			legacyRoot: true,
-		} );
+		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		await screen.findByLabelText( 'Continue with the entered contact details' );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'GB' );
 		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
@@ -141,9 +133,7 @@ describe( 'Checkout contact step VAT form', () => {
 	it( 'does not render the Northern Ireland checkbox is if the VAT checkbox is checked and the country is EU', async () => {
 		const user = userEvent.setup();
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } />, {
-			legacyRoot: true,
-		} );
+		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		await screen.findByLabelText( 'Continue with the entered contact details' );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'ES' );
 		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
@@ -153,9 +143,7 @@ describe( 'Checkout contact step VAT form', () => {
 	it( 'renders the Northern Ireland checkbox is if the VAT checkbox is checked and the country is GB', async () => {
 		const user = userEvent.setup();
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } />, {
-			legacyRoot: true,
-		} );
+		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		await screen.findByLabelText( 'Continue with the entered contact details' );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'GB' );
 		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
@@ -165,9 +153,7 @@ describe( 'Checkout contact step VAT form', () => {
 	it( 'hides the Northern Ireland checkbox is if the VAT checkbox is checked and the country is changed from GB to ES', async () => {
 		const user = userEvent.setup();
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } />, {
-			legacyRoot: true,
-		} );
+		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		await screen.findByLabelText( 'Continue with the entered contact details' );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'GB' );
 		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
@@ -193,9 +179,7 @@ describe( 'Checkout contact step VAT form', () => {
 			country: 'GB',
 		} );
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } />, {
-			legacyRoot: true,
-		} );
+		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 
 		// Wait for checkout to load.
 		await screen.findByLabelText( 'Continue with the entered contact details' );
@@ -225,9 +209,7 @@ describe( 'Checkout contact step VAT form', () => {
 			country: 'GB',
 		} );
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } />, {
-			legacyRoot: true,
-		} );
+		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 
 		// Wait for checkout to load.
 		await screen.findByLabelText( 'Continue with the entered contact details' );
@@ -258,9 +240,7 @@ describe( 'Checkout contact step VAT form', () => {
 			country: 'XI',
 		} );
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } />, {
-			legacyRoot: true,
-		} );
+		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 
 		// Wait for checkout to load.
 		await screen.findByLabelText( 'Continue with the entered contact details' );
@@ -290,9 +270,7 @@ describe( 'Checkout contact step VAT form', () => {
 		} );
 		const cartChanges = { products: [ planWithoutDomain ] };
 		const user = userEvent.setup();
-		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } />, {
-			legacyRoot: true,
-		} );
+		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 
 		// Wait for checkout to load.
 		await screen.findByLabelText( 'Continue with the entered contact details' );
@@ -319,9 +297,7 @@ describe( 'Checkout contact step VAT form', () => {
 		mockContactDetailsValidationEndpoint( 'tax', { success: true } );
 		const user = userEvent.setup();
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } />, {
-			legacyRoot: true,
-		} );
+		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 
 		// Wait for the cart to load
 		await screen.findByLabelText( 'Continue with the entered contact details' );
@@ -350,9 +326,7 @@ describe( 'Checkout contact step VAT form', () => {
 		mockSetVatInfoEndpoint();
 		const user = userEvent.setup();
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } />, {
-			legacyRoot: true,
-		} );
+		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 
 		// Wait for the cart to load
 		await screen.findByLabelText( 'Continue with the entered contact details' );
@@ -388,10 +362,7 @@ describe( 'Checkout contact step VAT form', () => {
 				{ ...defaultPropsForMockCheckout }
 				cartChanges={ cartChanges }
 				additionalProps={ { isLoggedOutCart: true } }
-			/>,
-			{
-				legacyRoot: true,
-			}
+			/>
 		);
 
 		// Wait for the cart to load
@@ -415,9 +386,7 @@ describe( 'Checkout contact step VAT form', () => {
 		mockContactDetailsValidationEndpoint( 'tax', { success: true } );
 		const user = userEvent.setup();
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } />, {
-			legacyRoot: true,
-		} );
+		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 
 		// Wait for the cart to load
 		await screen.findByLabelText( 'Continue with the entered contact details' );
@@ -446,9 +415,7 @@ describe( 'Checkout contact step VAT form', () => {
 		mockContactDetailsValidationEndpoint( 'tax', { success: true } );
 		const user = userEvent.setup();
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } />, {
-			legacyRoot: true,
-		} );
+		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 
 		// Wait for the cart to load
 		await screen.findByLabelText( 'Continue with the entered contact details' );
@@ -477,9 +444,7 @@ describe( 'Checkout contact step VAT form', () => {
 		mockContactDetailsValidationEndpoint( 'tax', { success: true } );
 		const user = userEvent.setup();
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } />, {
-			legacyRoot: true,
-		} );
+		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 
 		// Wait for the cart to load
 		await screen.findByLabelText( 'Continue with the entered contact details' );
@@ -508,9 +473,7 @@ describe( 'Checkout contact step VAT form', () => {
 		mockContactDetailsValidationEndpoint( 'tax', { success: true } );
 		const user = userEvent.setup();
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } />, {
-			legacyRoot: true,
-		} );
+		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 
 		// Wait for the cart to load
 		await screen.findByLabelText( 'Continue with the entered contact details' );
@@ -553,9 +516,7 @@ describe( 'Checkout contact step VAT form', () => {
 		} );
 		const user = userEvent.setup();
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } />, {
-			legacyRoot: true,
-		} );
+		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 
 		// Wait for the cart to load
 		await screen.findByLabelText( 'Continue with the entered contact details' );
@@ -595,9 +556,7 @@ describe( 'Checkout contact step VAT form', () => {
 		mockContactDetailsValidationEndpoint( 'tax', { success: true } );
 		const user = userEvent.setup();
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } />, {
-			legacyRoot: true,
-		} );
+		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		await screen.findByLabelText( 'Continue with the entered contact details' );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
 		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
@@ -624,9 +583,7 @@ describe( 'Checkout contact step VAT form', () => {
 		mockContactDetailsValidationEndpoint( 'tax', { success: true } );
 		const user = userEvent.setup();
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } />, {
-			legacyRoot: true,
-		} );
+		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		await screen.findByLabelText( 'Continue with the entered contact details' );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
 		// Check the box
@@ -764,10 +721,7 @@ describe( 'Checkout contact step VAT form', () => {
 				{ ...defaultPropsForMockCheckout }
 				cartChanges={ cartChanges }
 				setCart={ setCart }
-			/>,
-			{
-				legacyRoot: true,
-			}
+			/>
 		);
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
 		await user.type( await screen.findByLabelText( 'Postal code' ), postalCode );
@@ -806,9 +760,7 @@ describe( 'Checkout contact step VAT form', () => {
 		mockContactDetailsValidationEndpoint( 'tax', { success: true } );
 		const user = userEvent.setup();
 		const cartChanges = { products: [ planWithoutDomain ] };
-		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } />, {
-			legacyRoot: true,
-		} );
+		render( <MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } /> );
 		await user.selectOptions( await screen.findByLabelText( 'Country' ), countryCode );
 		await user.click( await screen.findByLabelText( 'Add VAT details' ) );
 		await user.type( await screen.findByLabelText( 'VAT ID' ), vatId );

--- a/client/my-sites/customer-home/celebrate-site-launch-modal/use-redux-site-with-query-client-launch-status-sync.ts
+++ b/client/my-sites/customer-home/celebrate-site-launch-modal/use-redux-site-with-query-client-launch-status-sync.ts
@@ -18,7 +18,7 @@ export function useReduxSiteWithQueryClientLaunchStatusSync( siteId: number ) {
 
 	const { data: site } = useQuery( siteByIdQuery( siteId ) );
 
-	const cachedReduxSiteLaunchStatus = useRef< undefined | string >();
+	const cachedReduxSiteLaunchStatus = useRef< undefined | string >( undefined );
 	cachedReduxSiteLaunchStatus.current = reduxSite?.launch_status;
 
 	useEffect( () => {

--- a/client/my-sites/domains/components/domain-warnings/test/index.js
+++ b/client/my-sites/domains/components/domain-warnings/test/index.js
@@ -8,9 +8,9 @@ import {
 	MAP_SUBDOMAIN,
 } from '@automattic/urls';
 import moment from 'moment';
-import ReactDom from 'react-dom';
-import TestUtils from 'react-dom/test-utils';
+import { createRef } from 'react';
 import { type as domainTypes } from 'calypso/lib/domains/constants';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { DomainWarnings } from '../';
 
 jest.mock( 'calypso/lib/analytics/tracks', () => ( {} ) );
@@ -29,9 +29,9 @@ describe( 'index', () => {
 				moment,
 			};
 
-			const component = TestUtils.renderIntoDocument( <DomainWarnings { ...props } /> );
+			const { container } = renderWithProvider( <DomainWarnings { ...props } /> );
 
-			expect( ReactDom.findDOMNode( component ) ).toBeNull();
+			expect( container ).toBeEmptyDOMElement();
 		} );
 
 		test( 'should render the highest priority notice when there are others', () => {
@@ -47,9 +47,9 @@ describe( 'index', () => {
 				moment,
 			};
 
-			const component = TestUtils.renderIntoDocument( <DomainWarnings { ...props } /> );
+			const { container } = renderWithProvider( <DomainWarnings { ...props } /> );
 
-			expect( ReactDom.findDOMNode( component ) ).toHaveTextContent(
+			expect( container ).toHaveTextContent(
 				/If you are unable to access your site at \{\{strong\}\}%\(domainName\)s\{\{\/strong\}\}/
 			);
 		} );
@@ -69,9 +69,9 @@ describe( 'index', () => {
 				moment,
 			};
 
-			const component = TestUtils.renderIntoDocument( <DomainWarnings { ...props } /> );
+			const { container } = renderWithProvider( <DomainWarnings { ...props } /> );
 
-			expect( ReactDom.findDOMNode( component ) ).toHaveTextContent(
+			expect( container ).toHaveTextContent(
 				/We are setting up \{\{strong\}\}%\(domainName\)s\{\{\/strong\}\} for you/
 			);
 		} );
@@ -97,11 +97,9 @@ describe( 'index', () => {
 				moment,
 			};
 
-			const component = TestUtils.renderIntoDocument( <DomainWarnings { ...props } /> );
+			const { container } = renderWithProvider( <DomainWarnings { ...props } /> );
 
-			expect( ReactDom.findDOMNode( component ) ).toHaveTextContent(
-				/We are setting up your new domains for you/
-			);
+			expect( container ).toHaveTextContent( /We are setting up your new domains for you/ );
 		} );
 	} );
 
@@ -121,13 +119,11 @@ describe( 'index', () => {
 				moment,
 			};
 
-			const component = TestUtils.renderIntoDocument( <DomainWarnings { ...props } /> );
+			const { container } = renderWithProvider( <DomainWarnings { ...props } /> );
 
-			const domNode = ReactDom.findDOMNode( component );
-			const textContent = domNode.textContent;
-			const links = [].slice.call( domNode.querySelectorAll( 'a' ) );
+			const links = [].slice.call( container.querySelectorAll( 'a' ) );
 
-			expect( textContent ).toContain( 'contact your domain registrar' );
+			expect( container ).toHaveTextContent( 'contact your domain registrar' );
 			expect( links.some( ( link ) => link.href === MAP_DOMAIN_CHANGE_NAME_SERVERS ) ).toBeTruthy();
 		} );
 
@@ -152,10 +148,9 @@ describe( 'index', () => {
 				moment,
 			};
 
-			const component = TestUtils.renderIntoDocument( <DomainWarnings { ...props } /> );
+			const { container } = renderWithProvider( <DomainWarnings { ...props } /> );
 
-			const domNode = ReactDom.findDOMNode( component );
-			const links = [].slice.call( domNode.querySelectorAll( 'a' ) );
+			const links = [].slice.call( container.querySelectorAll( 'a' ) );
 
 			expect( links.some( ( link ) => link.href === MAP_EXISTING_DOMAIN_UPDATE_DNS ) ).toBeTruthy();
 		} );
@@ -174,13 +169,11 @@ describe( 'index', () => {
 				selectedSite: { domain: 'blog.example.com' },
 				moment,
 			};
-			const component = TestUtils.renderIntoDocument( <DomainWarnings { ...props } /> );
+			const { container } = renderWithProvider( <DomainWarnings { ...props } /> );
 
-			const domNode = ReactDom.findDOMNode( component );
-			const textContent = domNode.textContent;
-			const links = [].slice.call( domNode.querySelectorAll( 'a' ) );
+			const links = [].slice.call( container.querySelectorAll( 'a' ) );
 
-			expect( textContent ).toContain( 'DNS records need to be configured' );
+			expect( container ).toHaveTextContent( 'DNS records need to be configured' );
 			expect( links.some( ( link ) => link.href === MAP_SUBDOMAIN ) ).toBeTruthy();
 		} );
 
@@ -204,13 +197,13 @@ describe( 'index', () => {
 				selectedSite: { domain: 'blog.example.com' },
 				moment,
 			};
-			const component = TestUtils.renderIntoDocument( <DomainWarnings { ...props } /> );
+			const { container } = renderWithProvider( <DomainWarnings { ...props } /> );
 
-			const domNode = ReactDom.findDOMNode( component );
-			const textContent = domNode.textContent;
-			const links = [].slice.call( domNode.querySelectorAll( 'a' ) );
+			const links = [].slice.call( container.querySelectorAll( 'a' ) );
 
-			expect( textContent ).toContain( "Some of your domains' DNS records need to be configured" );
+			expect( container ).toHaveTextContent(
+				"Some of your domains' DNS records need to be configured"
+			);
 			expect( links.some( ( link ) => link.href === MAP_SUBDOMAIN ) ).toBeTruthy();
 		} );
 
@@ -234,13 +227,11 @@ describe( 'index', () => {
 				selectedSite: { domain: 'blog.example.com' },
 				moment,
 			};
-			const component = TestUtils.renderIntoDocument( <DomainWarnings { ...props } /> );
+			const { container } = renderWithProvider( <DomainWarnings { ...props } /> );
 
-			const domNode = ReactDom.findDOMNode( component );
-			const textContent = domNode.textContent;
-			const links = [].slice.call( domNode.querySelectorAll( 'a' ) );
+			const links = [].slice.call( container.querySelectorAll( 'a' ) );
 
-			expect( textContent ).toContain(
+			expect( container ).toHaveTextContent(
 				"Some of your domains' name server records need to be configured"
 			);
 			expect( links.some( ( link ) => link.href === MAP_EXISTING_DOMAIN_UPDATE_DNS ) ).toBeTruthy();
@@ -270,13 +261,11 @@ describe( 'index', () => {
 				selectedSite: { domain: 'blog.example.com', slug: 'blog.example.com' },
 				moment,
 			};
-			const component = TestUtils.renderIntoDocument( <DomainWarnings { ...props } /> );
+			const { container } = renderWithProvider( <DomainWarnings { ...props } /> );
 
-			const domNode = ReactDom.findDOMNode( component );
-			const textContent = domNode.textContent;
-			const links = [].slice.call( domNode.querySelectorAll( 'a' ) );
+			const links = [].slice.call( container.querySelectorAll( 'a' ) );
 
-			expect( textContent ).toContain( 'Please verify ownership of domains' );
+			expect( container ).toHaveTextContent( 'Please verify ownership of domains' );
 			expect(
 				links.some( ( link ) =>
 					link.href.endsWith( '/domains/manage/blog.example.com/edit/blog.example.com' )
@@ -311,13 +300,11 @@ describe( 'index', () => {
 				selectedSite: { domain: 'blog.example.com', slug: 'blog.example.com' },
 				moment,
 			};
-			const component = TestUtils.renderIntoDocument( <DomainWarnings { ...props } /> );
+			const { container } = renderWithProvider( <DomainWarnings { ...props } /> );
 
-			const domNode = ReactDom.findDOMNode( component );
-			const textContent = domNode.textContent;
-			const links = [].slice.call( domNode.querySelectorAll( 'a' ) );
+			const links = [].slice.call( container.querySelectorAll( 'a' ) );
 
-			expect( textContent ).toContain(
+			expect( container ).toHaveTextContent(
 				'Your domains may be suspended because your email address is not verified.'
 			);
 			expect(
@@ -354,12 +341,9 @@ describe( 'index', () => {
 				selectedSite: { domain: 'blog.example.com', slug: 'blog.example.com' },
 				moment,
 			};
-			const component = TestUtils.renderIntoDocument( <DomainWarnings { ...props } /> );
+			const { container } = renderWithProvider( <DomainWarnings { ...props } /> );
 
-			const domNode = ReactDom.findDOMNode( component );
-			const textContent = domNode.textContent;
-
-			expect( textContent ).toContain(
+			expect( container ).toHaveTextContent(
 				'Some domains on this site are about to be suspended because their owner has not'
 			);
 		} );
@@ -367,31 +351,35 @@ describe( 'index', () => {
 
 	describe( 'Ruleset filtering', () => {
 		test( 'should only process allowed renderers', () => {
+			const ref = createRef();
 			const props = {
 				translate,
 				domain: { name: 'example.com' },
 				allowedRules: [],
 				selectedSite: {},
 				moment,
+				ref,
 			};
 
-			const component = TestUtils.renderIntoDocument( <DomainWarnings { ...props } /> );
+			renderWithProvider( <DomainWarnings { ...props } /> );
 
-			expect( component.getPipe().length ).toBe( 0 );
+			expect( ref.current.getPipe().length ).toBe( 0 );
 		} );
 
 		test( 'should not allow running extra functions other than defined in getPipe()', () => {
+			const ref = createRef();
 			const props = {
 				translate,
 				domain: { name: 'example.com' },
 				allowedRules: [ 'getDomains' ],
 				selectedSite: {},
 				moment,
+				ref,
 			};
 
-			const component = TestUtils.renderIntoDocument( <DomainWarnings { ...props } /> );
+			renderWithProvider( <DomainWarnings { ...props } /> );
 
-			expect( component.getPipe().length ).toBe( 0 );
+			expect( ref.current.getPipe().length ).toBe( 0 );
 		} );
 	} );
 } );

--- a/client/my-sites/earn/components/add-edit-coupon-modal/test/index.tsx
+++ b/client/my-sites/earn/components/add-edit-coupon-modal/test/index.tsx
@@ -13,7 +13,6 @@ jest.mock( 'calypso/state/ui/selectors' );
 
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { unmountComponentAtNode } from 'react-dom';
 import Modal from 'react-modal';
 import {
 	getconnectedAccountDefaultCurrencyForSiteId,
@@ -70,7 +69,6 @@ describe( 'RecurringPaymentsCouponAddEditModal', () => {
 	} );
 
 	afterEach( () => {
-		unmountComponentAtNode( modalRoot );
 		document.body.removeChild( modalRoot );
 		[ ...document.getElementsByClassName( 'ReactModalPortal' ) ].map( ( el ) => {
 			document.body.removeChild( el );

--- a/client/my-sites/earn/memberships/test/coupons-list.tsx
+++ b/client/my-sites/earn/memberships/test/coupons-list.tsx
@@ -5,7 +5,6 @@
 
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { unmountComponentAtNode } from 'react-dom';
 import Modal from 'react-modal';
 import membershipsReducer from 'calypso/state/memberships/reducer';
 import siteSettingsReducer from 'calypso/state/site-settings/reducer';
@@ -136,7 +135,6 @@ describe( 'CouponsList', () => {
 	} );
 
 	afterEach( () => {
-		unmountComponentAtNode( modalRoot );
 		document.body.removeChild( modalRoot );
 		modalRoot = null;
 	} );

--- a/client/my-sites/importer/newsletter/content/conversion-summary.tsx
+++ b/client/my-sites/importer/newsletter/content/conversion-summary.tsx
@@ -181,7 +181,7 @@ const PostErrorsMessage = ( { postErrors }: { postErrors: PostErrorsType } ) => 
 									<p>
 										{ createInterpolateElement(
 											sprintf(
-												/* translators: %s is the node name, %s is the block name */
+												/* translators: %(nodeName)s is the node name, %(blockName)s is the block name */
 												__(
 													'%(nodeName)s can be added using the <supportLink>%(blockName)s</supportLink>.'
 												),

--- a/client/my-sites/importer/newsletter/content/conversion-summary.tsx
+++ b/client/my-sites/importer/newsletter/content/conversion-summary.tsx
@@ -181,7 +181,7 @@ const PostErrorsMessage = ( { postErrors }: { postErrors: PostErrorsType } ) => 
 									<p>
 										{ createInterpolateElement(
 											sprintf(
-												/* translators: %(nodeName)s is the node name, %(blockName)s is the block name */
+												/* translators: %s is the node name, %s is the block name */
 												__(
 													'%(nodeName)s can be added using the <supportLink>%(blockName)s</supportLink>.'
 												),

--- a/client/my-sites/media-library/list.jsx
+++ b/client/my-sites/media-library/list.jsx
@@ -146,16 +146,15 @@ export class MediaLibraryList extends Component {
 		return this.props.moment( minDate ).format( 'YYYY-MM-DD' );
 	};
 
-	renderItem = ( item, listIndex, itemRef ) => {
+	renderItem = ( item ) => {
 		const index = findIndex( this.props.media, { ID: item.ID } );
 		const selectedItems = this.props.selectedItems;
 		const selectedIndex = findIndex( selectedItems, { ID: item.ID } );
-		const ref = this.getItemRef( item );
+		const itemKey = this.getItemRef( item );
 
 		return (
 			<ListItem
-				forwardedRef={ itemRef }
-				key={ ref }
+				key={ itemKey }
 				style={ this.getMediaItemStyle( index ) }
 				media={ item }
 				scale={ this.props.mediaScale }

--- a/client/my-sites/patterns/components/localized-link.tsx
+++ b/client/my-sites/patterns/components/localized-link.tsx
@@ -19,5 +19,3 @@ export const LocalizedLink = forwardRef< HTMLAnchorElement, JSX.IntrinsicElement
 		);
 	}
 );
-
-LocalizedLink.displayName = 'LocalizedLink';

--- a/client/my-sites/patterns/components/localized-link.tsx
+++ b/client/my-sites/patterns/components/localized-link.tsx
@@ -19,3 +19,5 @@ export const LocalizedLink = forwardRef< HTMLAnchorElement, JSX.IntrinsicElement
 		);
 	}
 );
+
+LocalizedLink.displayName = 'LocalizedLink';

--- a/client/my-sites/people/team-invite/invite-form.tsx
+++ b/client/my-sites/people/team-invite/invite-form.tsx
@@ -46,7 +46,7 @@ function InviteForm( props: Props ) {
 	const defaultUserRole = useInitialRole( siteId );
 	const isAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
 	const isSiteForTeams = useSelector( ( state ) => isSiteWPForTeams( state, siteId ) );
-	const prevInvitingProgress = useRef();
+	const prevInvitingProgress = useRef( undefined );
 	const { errors: tokenErrors, progress: validationProgress } = useSelector( getTokenValidation );
 	const { progress: invitingProgress, success: invitingSuccess } =
 		useSelector( getSendInviteState );

--- a/client/my-sites/plugins/plugin-management-v2/test/remove-plugin.test.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/test/remove-plugin.test.tsx
@@ -6,7 +6,6 @@ import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import React from 'react';
-import { unmountComponentAtNode } from 'react-dom';
 import Modal from 'react-modal';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
@@ -81,7 +80,6 @@ describe( '<RemovePlugin>', () => {
 	} );
 
 	afterEach( () => {
-		unmountComponentAtNode( modalRoot );
 		document.body.removeChild( modalRoot );
 		modalRoot = null;
 	} );

--- a/client/my-sites/promote-post-i2/components/campaigns-filter/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaigns-filter/index.tsx
@@ -36,7 +36,13 @@ export default function CampaignsFilter( props: Props ) {
 					selected={ campaignsFilter === option.value }
 					onClick={ () => handleChange( option.value as CampaignsFilterType ) }
 				>
-					<span ref={ ( el ) => ( tabsRef.current[ option.value ] = el ) }>{ option.label }</span>
+					<span
+						ref={ ( el ) => {
+							tabsRef.current[ option.value ] = el;
+						} }
+					>
+						{ option.label }
+					</span>
 				</SegmentedControl.Item>
 			) ) }
 		</SegmentedControl>

--- a/client/my-sites/promote-post-i2/components/payments-filter/index.tsx
+++ b/client/my-sites/promote-post-i2/components/payments-filter/index.tsx
@@ -56,7 +56,11 @@ export default function PaymentsFilter( props: Props ) {
 							selected={ paymentsFilter === option.value }
 							onClick={ () => handleChange( option.value as PaymentsFilterType ) }
 						>
-							<span ref={ ( el ) => ( tabsRef.current[ option.value ] = el ) }>
+							<span
+								ref={ ( el ) => {
+									tabsRef.current[ option.value ] = el;
+								} }
+							>
 								{ option.label }
 							</span>
 						</SegmentedControl.Item>

--- a/client/my-sites/promote-post-i2/components/promoted-post-filter/index.tsx
+++ b/client/my-sites/promote-post-i2/components/promoted-post-filter/index.tsx
@@ -2,7 +2,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { formatCurrency, formatNumber } from '@automattic/number-formatters';
 import { Popover } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { ReactNode, useMemo, useRef, useState } from 'react';
+import { useMemo, useRef, useState, type ReactNode } from 'react';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
@@ -113,7 +113,13 @@ export default function PromotePostTabBar( { tabs, selectedTab }: Props ) {
 								className={ className }
 								onClick={ () => onTabClick( id ) }
 							>
-								<span ref={ ( el ) => ( tabsRef.current[ id ] = el ) }>{ name }</span>
+								<span
+									ref={ ( el ) => {
+										tabsRef.current[ id ] = el;
+									} }
+								>
+									{ name }
+								</span>
 								{ itemCount && itemCount !== 0 ? (
 									<span className="a8c-count">
 										{ isCountAmount ? '$' : null }

--- a/client/my-sites/promote-post-i2/components/search-bar/index.tsx
+++ b/client/my-sites/promote-post-i2/components/search-bar/index.tsx
@@ -353,7 +353,11 @@ export default function SearchBar( props: Props ) {
 										selected={ postType === option.value }
 										onClick={ () => onChangePostTypeFilter( option.value ) }
 									>
-										<span ref={ ( el ) => ( tabsRef.current[ option.value ] = el ) }>
+										<span
+											ref={ ( el ) => {
+												tabsRef.current[ option.value ] = el;
+											} }
+										>
 											{ ' ' }
 											{ option.label }{ ' ' }
 										</span>

--- a/client/my-sites/site-settings/seo-settings/test/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/test/form.jsx
@@ -75,7 +75,7 @@ describe( 'SeoForm basic tests', () => {
 		expect( screen.queryByTestId( 'UpsellNudge' ) ).toBeVisible();
 		expect( UpsellNudge ).toHaveBeenCalledWith(
 			expect.objectContaining( { event: 'calypso_seo_settings_upgrade_nudge' } ),
-			expect.anything()
+			undefined
 		);
 	} );
 
@@ -157,7 +157,7 @@ describe( 'UpsellNudge should get appropriate plan constant', () => {
 			expect( nudge ).toBeVisible();
 			expect( UpsellNudge ).toHaveBeenCalledWith(
 				expect.objectContaining( { plan: PLAN_BUSINESS } ),
-				expect.anything()
+				undefined
 			);
 		}
 	);
@@ -171,7 +171,7 @@ describe( 'UpsellNudge should get appropriate plan constant', () => {
 			expect( screen.getByTestId( 'UpsellNudge' ) ).toBeVisible();
 			expect( UpsellNudge ).toHaveBeenCalledWith(
 				expect.objectContaining( { plan: PLAN_BUSINESS_2_YEARS } ),
-				expect.anything()
+				undefined
 			);
 		}
 	);
@@ -183,7 +183,7 @@ describe( 'UpsellNudge should get appropriate plan constant', () => {
 			expect( screen.getByTestId( 'UpsellNudge' ) ).toBeVisible();
 			expect( UpsellNudge ).toHaveBeenCalledWith(
 				expect.objectContaining( { href: expect.stringContaining( PLAN_JETPACK_SECURITY_DAILY ) } ),
-				expect.anything()
+				undefined
 			);
 		}
 	);

--- a/client/my-sites/site-settings/seo-settings/test/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/test/form.jsx
@@ -73,9 +73,9 @@ describe( 'SeoForm basic tests', () => {
 			/>
 		);
 		expect( screen.queryByTestId( 'UpsellNudge' ) ).toBeVisible();
-		expect( UpsellNudge ).toHaveBeenCalledWith(
-			expect.objectContaining( { event: 'calypso_seo_settings_upgrade_nudge' } ),
-			undefined
+		expect( UpsellNudge ).toHaveBeenCalled();
+		expect( UpsellNudge.mock.lastCall[ 0 ] ).toEqual(
+			expect.objectContaining( { event: 'calypso_seo_settings_upgrade_nudge' } )
 		);
 	} );
 
@@ -155,9 +155,9 @@ describe( 'UpsellNudge should get appropriate plan constant', () => {
 			);
 			const nudge = screen.getByTestId( 'UpsellNudge' );
 			expect( nudge ).toBeVisible();
-			expect( UpsellNudge ).toHaveBeenCalledWith(
-				expect.objectContaining( { plan: PLAN_BUSINESS } ),
-				undefined
+			expect( UpsellNudge ).toHaveBeenCalled();
+			expect( UpsellNudge.mock.lastCall[ 0 ] ).toEqual(
+				expect.objectContaining( { plan: PLAN_BUSINESS } )
 			);
 		}
 	);
@@ -169,9 +169,9 @@ describe( 'UpsellNudge should get appropriate plan constant', () => {
 				<SeoForm { ...props } siteIsJetpack={ false } selectedSite={ { plan: { product_slug } } } />
 			);
 			expect( screen.getByTestId( 'UpsellNudge' ) ).toBeVisible();
-			expect( UpsellNudge ).toHaveBeenCalledWith(
-				expect.objectContaining( { plan: PLAN_BUSINESS_2_YEARS } ),
-				undefined
+			expect( UpsellNudge ).toHaveBeenCalled();
+			expect( UpsellNudge.mock.lastCall[ 0 ] ).toEqual(
+				expect.objectContaining( { plan: PLAN_BUSINESS_2_YEARS } )
 			);
 		}
 	);
@@ -181,9 +181,11 @@ describe( 'UpsellNudge should get appropriate plan constant', () => {
 		( product_slug ) => {
 			render( <SeoForm { ...props } siteIsJetpack selectedSite={ { plan: { product_slug } } } /> );
 			expect( screen.getByTestId( 'UpsellNudge' ) ).toBeVisible();
-			expect( UpsellNudge ).toHaveBeenCalledWith(
-				expect.objectContaining( { href: expect.stringContaining( PLAN_JETPACK_SECURITY_DAILY ) } ),
-				undefined
+			expect( UpsellNudge ).toHaveBeenCalled();
+			expect( UpsellNudge.mock.lastCall[ 0 ] ).toEqual(
+				expect.objectContaining( {
+					href: expect.stringContaining( PLAN_JETPACK_SECURITY_DAILY ),
+				} )
 			);
 		}
 	);

--- a/client/my-sites/site-settings/test/form-google-analytics.jsx
+++ b/client/my-sites/site-settings/test/form-google-analytics.jsx
@@ -125,9 +125,9 @@ describe( 'UpsellNudge should get appropriate plan constant for both forms', () 
 			);
 			const nudge = screen.queryByTestId( 'UpsellNudge' );
 			expect( nudge ).toBeVisible();
-			expect( UpsellNudge ).toHaveBeenCalledWith(
-				expect.objectContaining( { plan: PLAN_PREMIUM } ),
-				undefined
+			expect( UpsellNudge ).toHaveBeenCalled();
+			expect( UpsellNudge.mock.lastCall[ 0 ] ).toEqual(
+				expect.objectContaining( { plan: PLAN_PREMIUM } )
 			);
 		}
 	);
@@ -139,9 +139,9 @@ describe( 'UpsellNudge should get appropriate plan constant for both forms', () 
 				<GoogleAnalyticsSimpleForm { ...myProps } site={ { plan: { product_slug } } } />
 			);
 			expect( screen.queryByTestId( 'UpsellNudge' ) ).toBeVisible();
-			expect( UpsellNudge ).toHaveBeenCalledWith(
-				expect.objectContaining( { plan: PLAN_PREMIUM_2_YEARS } ),
-				undefined
+			expect( UpsellNudge ).toHaveBeenCalled();
+			expect( UpsellNudge.mock.lastCall[ 0 ] ).toEqual(
+				expect.objectContaining( { plan: PLAN_PREMIUM_2_YEARS } )
 			);
 		}
 	);
@@ -155,9 +155,9 @@ describe( 'UpsellNudge should get appropriate plan constant for both forms', () 
 				</Provider>
 			);
 			expect( screen.queryByTestId( 'UpsellNudge' ) ).toBeVisible();
-			expect( UpsellNudge ).toHaveBeenCalledWith(
-				expect.objectContaining( { plan: PLAN_JETPACK_SECURITY_DAILY } ),
-				undefined
+			expect( UpsellNudge ).toHaveBeenCalled();
+			expect( UpsellNudge.mock.lastCall[ 0 ] ).toEqual(
+				expect.objectContaining( { plan: PLAN_JETPACK_SECURITY_DAILY } )
 			);
 		}
 	);

--- a/client/my-sites/site-settings/test/form-google-analytics.jsx
+++ b/client/my-sites/site-settings/test/form-google-analytics.jsx
@@ -127,7 +127,7 @@ describe( 'UpsellNudge should get appropriate plan constant for both forms', () 
 			expect( nudge ).toBeVisible();
 			expect( UpsellNudge ).toHaveBeenCalledWith(
 				expect.objectContaining( { plan: PLAN_PREMIUM } ),
-				expect.anything()
+				undefined
 			);
 		}
 	);
@@ -141,7 +141,7 @@ describe( 'UpsellNudge should get appropriate plan constant for both forms', () 
 			expect( screen.queryByTestId( 'UpsellNudge' ) ).toBeVisible();
 			expect( UpsellNudge ).toHaveBeenCalledWith(
 				expect.objectContaining( { plan: PLAN_PREMIUM_2_YEARS } ),
-				expect.anything()
+				undefined
 			);
 		}
 	);
@@ -157,7 +157,7 @@ describe( 'UpsellNudge should get appropriate plan constant for both forms', () 
 			expect( screen.queryByTestId( 'UpsellNudge' ) ).toBeVisible();
 			expect( UpsellNudge ).toHaveBeenCalledWith(
 				expect.objectContaining( { plan: PLAN_JETPACK_SECURITY_DAILY } ),
-				expect.anything()
+				undefined
 			);
 		}
 	);

--- a/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder-form.tsx
+++ b/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder-form.tsx
@@ -29,7 +29,9 @@ export type UtmBuilderProps = {
 	};
 };
 
-type UtmKeyType = string;
+const utmKeys = [ 'url', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term' ];
+
+type UtmKeyType = ( typeof utmKeys )[ number ];
 
 type inputValuesType = Record< UtmKeyType, string >;
 type formLabelsType = Record<

--- a/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder-form.tsx
+++ b/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder-form.tsx
@@ -29,13 +29,14 @@ export type UtmBuilderProps = {
 	};
 };
 
-const utmKeys = [ 'url', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term' ];
+type UtmKeyType = 'url' | 'utm_source' | 'utm_medium' | 'utm_campaign' | 'utm_content' | 'utm_term';
 
-type UtmKeyType = ( typeof utmKeys )[ number ];
+type InputValueKey = Extract< UtmKeyType, 'utm_campaign' | 'utm_source' | 'utm_medium' >;
+type FormLabelKey = Extract< UtmKeyType, 'url' | InputValueKey >;
 
-type inputValuesType = Record< UtmKeyType, string >;
+type inputValuesType = Record< InputValueKey, string >;
 type formLabelsType = Record<
-	UtmKeyType,
+	FormLabelKey,
 	{ label: string; placeholder: string; describedBy?: string }
 >;
 
@@ -205,7 +206,7 @@ const UtmBuilder: React.FC< UtmBuilderProps > = ( { initialData } ) => {
 						ariaDescribedBy={ fromLabels.url.describedBy }
 						labelReference={ initialFieldReference }
 					/>
-					{ Object.keys( inputValues ).map( ( key ) => (
+					{ ( Object.keys( inputValues ) as InputValueKey[] ).map( ( key ) => (
 						<InputField
 							key={ key }
 							id={ key }

--- a/client/my-sites/store/components/d3/sparkline/index.jsx
+++ b/client/my-sites/store/components/d3/sparkline/index.jsx
@@ -6,12 +6,12 @@ import PropTypes from 'prop-types';
 import D3Base from '../base';
 
 const Sparkline = ( {
-	aspectRatio,
+	aspectRatio = 4.5,
 	className,
 	data,
 	highlightIndex,
-	highlightRadius,
-	margin,
+	highlightRadius = 3.5,
+	margin = { top: 4, right: 4, bottom: 4, left: 4 },
 	maxHeight,
 } ) => {
 	function drawSparkline( svg, params ) {
@@ -71,17 +71,6 @@ Sparkline.propTypes = {
 	highlightRadius: PropTypes.number,
 	margin: PropTypes.object,
 	maxHeight: PropTypes.number,
-};
-
-Sparkline.defaultProps = {
-	aspectRatio: 4.5,
-	highlightRadius: 3.5,
-	margin: {
-		top: 4,
-		right: 4,
-		bottom: 4,
-		left: 4,
-	},
 };
 
 export default Sparkline;

--- a/client/my-sites/store/components/d3/sparkline/test/index.jsx
+++ b/client/my-sites/store/components/d3/sparkline/test/index.jsx
@@ -24,29 +24,18 @@ describe( 'Sparkline', () => {
 		expect( container ).toMatchSnapshot();
 	} );
 
-	test( 'should have a default aspectRatio of 4.5', () => {
-		const sparkline = <Sparkline data={ [ 1, 2, 3, 4, 5 ] } />;
-		expect( sparkline.props.aspectRatio ).toEqual( 4.5 );
-	} );
+	// React 19 no longer merges a function component's `defaultProps` onto the
+	// element, so the default values (now default parameters) can't be read off
+	// `element.props`. The defaults are exercised by the rendering tests above.
 
 	test( 'should have a defined aspectRatio if set', () => {
 		const sparkline = <Sparkline data={ [ 1, 2, 3, 4, 5 ] } aspectRatio={ 10 } />;
 		expect( sparkline.props.aspectRatio ).toEqual( 10 );
 	} );
 
-	test( 'should have a default highlightRadius of 3.5', () => {
-		const sparkline = <Sparkline data={ [ 1, 2, 3, 4, 5 ] } />;
-		expect( sparkline.props.highlightRadius ).toEqual( 3.5 );
-	} );
-
 	test( 'should have a defined highlightRadius if set', () => {
 		const sparkline = <Sparkline data={ [ 1, 2, 3, 4, 5 ] } highlightRadius={ 10 } />;
 		expect( sparkline.props.highlightRadius ).toEqual( 10 );
-	} );
-
-	test( 'should have a default margin', () => {
-		const sparkline = <Sparkline data={ [ 1, 2, 3, 4, 5 ] } />;
-		expect( sparkline.props.margin ).toEqual( { top: 4, right: 4, bottom: 4, left: 4 } );
 	} );
 
 	test( 'should have a defined margin if set', () => {

--- a/packages/domain-search/src/components/unavailable-search-result/test/index.tsx
+++ b/packages/domain-search/src/components/unavailable-search-result/test/index.tsx
@@ -279,12 +279,7 @@ describe( 'UnavailableSearchResult', () => {
 
 				await waitFor( () => expect( availabilityQuery.isDone() ).toBe( true ) );
 
-				const loadingElement = screen.queryByText( 'LOADING_TEST_CONTENT' );
-				if ( loadingElement ) {
-					await waitForElementToBeRemoved( loadingElement );
-				}
-
-				expect( container ).toBeEmptyDOMElement();
+				await waitFor( () => expect( container ).toBeEmptyDOMElement() );
 			}
 		);
 	} );


### PR DESCRIPTION
Part of #111325

Related to #111368

## Proposed Changes

* Split the remaining `client/my-sites` React 19 compatibility updates into a follow-up PR stacked on the simple type PR.
* Keep the more behavior-sensitive changes separate from the simple type/nullability updates:
  * checkout contact validation ref mirror;
  * removal of `legacyRoot` test rendering;
  * function-component `defaultProps` replacement;
  * `findDOMNode` / legacy React DOM test API replacements;
  * callback-ref return-shape fixes;
  * React 19 mock/component-call assertion updates.

## Why are these changes being made?

* Keep review focused: #111368 carries the straightforward type-shape work, while this PR carries the changes that deserve more attention.
* Make it easier to land the React 18-safe type work first and review runtime/test behavior changes separately.
* Preserve the original My Sites split from #111366 as a smaller stacked pair.

## Testing Instructions

This PR is stacked on #111368. Review this PR using the diff against `codex/my-sites-react-19-simple-types`.

* `git diff --cached --check -- client/my-sites`
* Focused ESLint on changed `client/my-sites` JS/TS files:

```bash
git diff --cached --name-only -- client/my-sites | rg '\.(js|jsx|ts|tsx)$' | xargs yarn eslint --ext .js,.jsx,.ts,.tsx
```

* Result: 0 errors, 1 existing `react-hooks/exhaustive-deps` warning:
  * `client/my-sites/promote-post-i2/components/search-bar/index.tsx`

React 19 smoke context from the original split work:

* The combined My Sites content was smoke-tested locally with targeted `client/my-sites` suites under the local React 19 dependency install.
* 6 suites passed and 3 suites exposed follow-up blockers:
  * `client/my-sites/checkout/src/test/checkout-contact-autocomplete.tsx`: one autocomplete test still shows a postal code error for invalid cached details under React 19.
  * `client/my-sites/earn/components/add-edit-coupon-modal/test/index.tsx`: selector mock setup is not a Jest mock in that run.
  * `client/my-sites/plugins/plugin-management-v2/test/remove-plugin.test.tsx`: shared `client/lib/accept` still calls removed `ReactDom.render`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
