### PR TITLE
My Sites: split simple React 19 type updates

### DIFF
--- a/client/my-sites/backup/backup-contents-page/file-browser/file-type-icon.tsx
+++ b/client/my-sites/backup/backup-contents-page/file-browser/file-type-icon.tsx
@@ -12,6 +12,7 @@ import {
 	wordpress,
 } from '@wordpress/icons';
 import { FileType } from './types';
+import type { JSX } from 'react';
 
 interface FileTypeIconProps {
 	type: FileType;

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-go-back-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-go-back-section.tsx
@@ -1,5 +1,6 @@
 import MasterbarStyled from '../redesign-v2/masterbar-styled';
 import { hasMultipleProductTypes } from './utils';
+import type { JSX } from 'react';
 
 export function MarketplaceGoBackSection( {
 	pluginSlugs,

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/index.tsx
@@ -4,6 +4,7 @@ import Item from 'calypso/layout/masterbar/item';
 import Masterbar from 'calypso/layout/masterbar/masterbar';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import { DefaultMasterbarContact } from './default-contact';
+import type { JSX } from 'react';
 import './style.scss';
 
 const MasterbarStyled = ( {

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -40,7 +40,14 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { pencil } from '@wordpress/icons';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useMemo, useState } from 'react';
+import {
+	useCallback,
+	useMemo,
+	useState,
+	type JSX,
+	type PropsWithChildren,
+	type ReactNode,
+} from 'react';
 import { createPortal } from 'react-dom';
 import Loading from 'calypso/components/loading';
 import { OnboardingProgress } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress';
@@ -125,7 +132,6 @@ import type {
 	ResponseCart,
 } from '@automattic/shopping-cart';
 import type { CountryListItem } from '@automattic/wpcom-checkout';
-import type { PropsWithChildren, ReactNode } from 'react';
 
 const debug = debugFactory( 'calypso:wp-checkout' );
 

--- a/client/my-sites/checkout/src/components/checkout-next-steps.tsx
+++ b/client/my-sites/checkout/src/components/checkout-next-steps.tsx
@@ -1,7 +1,7 @@
 import { Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo } from 'react';
+import { useMemo, type JSX } from 'react';
 import { hasDIFMProduct } from 'calypso/lib/cart-values/cart-items';
 import type { ResponseCart } from '@automattic/shopping-cart';
 import type { TranslateResult } from 'i18n-calypso';

--- a/client/my-sites/checkout/src/components/country-specific-payment-fields.tsx
+++ b/client/my-sites/checkout/src/components/country-specific-payment-fields.tsx
@@ -2,12 +2,11 @@ import { PAYMENT_PROCESSOR_COUNTRIES_FIELDS } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useState, type JSX, type PropsWithChildren, type ReactNode } from 'react';
 import FormPhoneMediaInput from 'calypso/components/forms/form-phone-media-input';
 import { StateSelect, Input, HiddenInput } from 'calypso/my-sites/domains/components/form';
 import type { CountryListItem } from '@automattic/wpcom-checkout';
 import type { PhoneInputValue } from 'calypso/components/phone-input';
-import type { PropsWithChildren, ReactNode } from 'react';
 
 export type CountrySpecificPaymentFieldsProps = {
 	className?: string;

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -379,7 +379,7 @@ function LineItemWrapper( {
 
 	useEffect( () => {
 		const handleClickOutside =
-			( ref: RefObject< HTMLDivElement >, toggle: ( key: string | null ) => void ) =>
+			( ref: RefObject< HTMLDivElement | null >, toggle: ( key: string | null ) => void ) =>
 			( event: MouseEvent ): void => {
 				if ( ref.current && ! ref.current.contains( event.target as Node ) ) {
 					toggle( null );

--- a/client/my-sites/checkout/src/payment-methods/wechat/index.tsx
+++ b/client/my-sites/checkout/src/payment-methods/wechat/index.tsx
@@ -6,7 +6,7 @@ import styled from '@emotion/styled';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
-import { useEffect, useState, Fragment } from 'react';
+import { useEffect, useState, Fragment, type JSX } from 'react';
 import { PaymentMethodLogos } from 'calypso/my-sites/checkout/src/components/payment-method-logos';
 import {
 	SummaryLine,

--- a/client/my-sites/customer-home/cards/features/site-preview/index.tsx
+++ b/client/my-sites/customer-home/cards/features/site-preview/index.tsx
@@ -3,7 +3,6 @@ import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
 import clsx from 'clsx';
-import { ReactNode } from 'react';
 import withIsFSEActive from 'calypso/data/themes/with-is-fse-active';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { Truncated } from 'calypso/sites-dashboard/components/sites-site-url';
@@ -13,6 +12,7 @@ import { createSiteDomainObject } from 'calypso/state/sites/domains/assembler';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { SitePreviewEllipsisMenu } from './site-preview-ellipsis-menu';
+import type { JSX, ReactNode } from 'react';
 import './style.scss';
 
 interface ThumbnailWrapperProps {

--- a/client/my-sites/customer-home/cards/launchpad/entrepreneur-site-setup.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/entrepreneur-site-setup.tsx
@@ -1,4 +1,5 @@
 import CustomerHomeLaunchpad from '.';
+import type { JSX } from 'react';
 
 const checklistSlug = 'entrepreneur-site-setup';
 

--- a/client/my-sites/customer-home/cards/launchpad/intent-build.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/intent-build.tsx
@@ -1,4 +1,5 @@
 import CustomerHomeLaunchpad from '.';
+import type { JSX } from 'react';
 
 const checklistSlug = 'intent-build';
 

--- a/client/my-sites/customer-home/cards/launchpad/intent-hosting.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/intent-hosting.tsx
@@ -1,4 +1,5 @@
 import CustomerHomeLaunchpad from '.';
+import type { JSX } from 'react';
 
 const checklistSlug = 'host-site';
 

--- a/client/my-sites/customer-home/cards/launchpad/intent-newsletter.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/intent-newsletter.tsx
@@ -4,6 +4,7 @@ import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CustomerHomeLaunchpad from '.';
 import type { AppState } from 'calypso/types';
+import type { JSX } from 'react';
 
 const LaunchpadIntentNewsletter = ( { checklistSlug }: { checklistSlug: string } ): JSX.Element => {
 	const siteId = useSelector( getSelectedSiteId ) || 0;

--- a/client/my-sites/customer-home/cards/launchpad/intent-write.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/intent-write.tsx
@@ -1,4 +1,5 @@
 import CustomerHomeLaunchpad from '.';
+import type { JSX } from 'react';
 
 const checklistSlug = 'intent-write';
 

--- a/client/my-sites/customer-home/cards/launchpad/post-migration.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/post-migration.tsx
@@ -1,4 +1,5 @@
 import LaunchpadPreLaunch from './pre-launch';
+import type { JSX } from 'react';
 
 export const LaunchpadPostMigration = (): JSX.Element => {
 	const checklistSlug = 'post-migration';

--- a/client/my-sites/customer-home/cards/launchpad/pre-launch.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/pre-launch.tsx
@@ -6,6 +6,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CustomerHomeLaunchpad from '.';
 import type { Task } from '@automattic/launchpad';
 import type { AppState } from 'calypso/types';
+import type { JSX } from 'react';
 
 type LaunchpadPreLaunchProps = {
 	checklistSlug?: string;

--- a/client/my-sites/customer-home/cards/launchpad/site-setup.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/site-setup.tsx
@@ -1,4 +1,5 @@
 import LaunchpadPreLaunch from './pre-launch';
+import type { JSX } from 'react';
 
 export const LaunchpadSiteSetup = (): JSX.Element => {
 	const checklistSlug = 'legacy-site-setup';

--- a/client/my-sites/domains/domain-management/settings/cards/contact-information/contacts-privacy-info.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/contact-information/contacts-privacy-info.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, type JSX } from 'react';
 import { connect } from 'react-redux';
 import { getSelectedDomain } from 'calypso/lib/domains';
 import InfoNotice from 'calypso/my-sites/domains/domain-management/components/domain/info-notice';

--- a/client/my-sites/domains/domain-management/settings/settings-header.tsx
+++ b/client/my-sites/domains/domain-management/settings/settings-header.tsx
@@ -4,7 +4,7 @@ import { home, Icon, info } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback } from 'react';
+import { useCallback, type JSX } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { useCurrentRoute } from 'calypso/components/route';
 import { resolveDomainStatus } from 'calypso/lib/domains';

--- a/client/my-sites/email/add-mailboxes/add-users-placeholder.tsx
+++ b/client/my-sites/email/add-mailboxes/add-users-placeholder.tsx
@@ -1,5 +1,6 @@
 import VerticalNav from 'calypso/components/vertical-nav';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
+import type { JSX } from 'react';
 
 const AddEmailAddressesCardPlaceholder = (): JSX.Element => {
 	return (

--- a/client/my-sites/email/add-mailboxes/email-provider-pricing-notice.tsx
+++ b/client/my-sites/email/add-mailboxes/email-provider-pricing-notice.tsx
@@ -15,6 +15,7 @@ import EmailPricingNotice from 'calypso/my-sites/email/email-pricing-notice';
 import { getEmailProductProperties } from 'calypso/my-sites/email/form/mailboxes/components/utilities/get-email-product-properties';
 import { EmailProvider } from 'calypso/my-sites/email/form/mailboxes/types';
 import { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
+import type { JSX } from 'react';
 
 interface EmailProviderPricingNoticeProps {
 	emailProduct: ProductListItem | null;

--- a/client/my-sites/email/add-mailboxes/index.tsx
+++ b/client/my-sites/email/add-mailboxes/index.tsx
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import { Card } from '@automattic/components';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
-import { MouseEvent, PropsWithChildren, useState } from 'react';
+import { useState, type JSX, type MouseEvent, type PropsWithChildren } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';

--- a/client/my-sites/email/form/mailboxes/components/mailbox-field/index.tsx
+++ b/client/my-sites/email/form/mailboxes/components/mailbox-field/index.tsx
@@ -1,6 +1,6 @@
 import { FormInputValidation, FormLabel } from '@automattic/components';
 import { TranslateResult } from 'i18n-calypso';
-import { InvalidEvent, useState } from 'react';
+import { useState, type ChangeEvent, type InvalidEvent, type JSX } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormPasswordInput from 'calypso/components/forms/form-password-input';
 import FormTextInput from 'calypso/components/forms/form-text-input';
@@ -10,7 +10,6 @@ import type {
 	MailboxFormFieldBase,
 	MutableFormFieldNames,
 } from 'calypso/my-sites/email/form/mailboxes/types';
-import type { ChangeEvent } from 'react';
 
 import './style.scss';
 

--- a/client/my-sites/email/form/mailboxes/components/mailbox-form-wrapper/index.tsx
+++ b/client/my-sites/email/form/mailboxes/components/mailbox-form-wrapper/index.tsx
@@ -1,5 +1,4 @@
 import { TranslateResult, useRtl } from 'i18n-calypso';
-import { PropsWithChildren } from 'react';
 import { MailboxForm } from 'calypso/my-sites/email/form/mailboxes';
 import { MailboxField } from 'calypso/my-sites/email/form/mailboxes/components/mailbox-field';
 import {
@@ -10,6 +9,7 @@ import {
 	MutableFormFieldNames,
 	TitanMailboxFormFields,
 } from 'calypso/my-sites/email/form/mailboxes/types';
+import type { JSX, PropsWithChildren } from 'react';
 
 interface MailboxFormWrapperProps {
 	fieldLabelTexts: Partial< Record< MutableFormFieldNames, TranslateResult > >;

--- a/client/my-sites/email/form/mailboxes/components/new-mailbox-list/index.tsx
+++ b/client/my-sites/email/form/mailboxes/components/new-mailbox-list/index.tsx
@@ -1,7 +1,7 @@
 import { Button, Gridicon } from '@automattic/components';
 import clsx from 'clsx';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
-import { FormEvent, useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, type FormEvent, type JSX, type ReactNode } from 'react';
 import CardHeading from 'calypso/components/card-heading';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { MailboxForm } from 'calypso/my-sites/email/form/mailboxes';
@@ -24,7 +24,6 @@ import {
 	MailboxFormFieldBase,
 	MutableFormFieldNames,
 } from 'calypso/my-sites/email/form/mailboxes/types';
-import type { ReactNode } from 'react';
 
 import './style.scss';
 

--- a/client/my-sites/importer/newsletter/components/summary-stat.tsx
+++ b/client/my-sites/importer/newsletter/components/summary-stat.tsx
@@ -1,5 +1,6 @@
 import { Icon } from '@wordpress/icons';
 import { clsx } from 'clsx';
+import type { JSX } from 'react';
 
 interface SummaryStatProps {
 	count?: number;

--- a/client/my-sites/importer/newsletter/content/conversion-summary.tsx
+++ b/client/my-sites/importer/newsletter/content/conversion-summary.tsx
@@ -9,6 +9,7 @@ import ImporterActionButtonContainer from 'calypso/my-sites/importer/importer-ac
 import { useDispatch } from 'calypso/state';
 import { startMappingAuthors, cancelImport } from 'calypso/state/imports/actions';
 import { SummaryStat } from '../components';
+import type { JSX } from 'react';
 
 interface UnsupportedFilesType {
 	[ key: string ]: number;
@@ -180,7 +181,7 @@ const PostErrorsMessage = ( { postErrors }: { postErrors: PostErrorsType } ) => 
 									<p>
 										{ createInterpolateElement(
 											sprintf(
-												/* translators: %s is the node name, %s is the block name */
+												/* translators: %(nodeName)s is the node name, %(blockName)s is the block name */
 												__(
 													'%(nodeName)s can be added using the <supportLink>%(blockName)s</supportLink>.'
 												),

--- a/client/my-sites/importer/newsletter/content/conversion-summary.tsx
+++ b/client/my-sites/importer/newsletter/content/conversion-summary.tsx
@@ -181,7 +181,7 @@ const PostErrorsMessage = ( { postErrors }: { postErrors: PostErrorsType } ) => 
 									<p>
 										{ createInterpolateElement(
 											sprintf(
-												/* translators: %s is the node name, %s is the block name */
+												/* translators: %(nodeName)s is the node name, %(blockName)s is the block name */
 												__(
 													'%(nodeName)s can be added using the <supportLink>%(blockName)s</supportLink>.'
 												),

--- a/client/my-sites/importer/newsletter/content/conversion-summary.tsx
+++ b/client/my-sites/importer/newsletter/content/conversion-summary.tsx
@@ -181,7 +181,7 @@ const PostErrorsMessage = ( { postErrors }: { postErrors: PostErrorsType } ) => 
 									<p>
 										{ createInterpolateElement(
 											sprintf(
-												/* translators: %(nodeName)s is the node name, %(blockName)s is the block name */
+												/* translators: %s is the node name, %s is the block name */
 												__(
 													'%(nodeName)s can be added using the <supportLink>%(blockName)s</supportLink>.'
 												),

--- a/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
@@ -23,6 +23,7 @@ import { useGetWebsiteContentQuery } from 'calypso/state/signup/steps/website-co
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 import type { AppState, SiteId, SiteSlug } from 'calypso/types';
+import type { JSX } from 'react';
 
 import './difm-lite-in-progress.scss';
 

--- a/client/my-sites/marketing/do-it-for-me/faq.tsx
+++ b/client/my-sites/marketing/do-it-for-me/faq.tsx
@@ -4,13 +4,13 @@ import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { formatNumber } from '@automattic/number-formatters';
 import styled from '@emotion/styled';
 import { Button } from '@wordpress/components';
-import { RefObject } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
-import { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
 import { CHARACTER_LIMIT } from 'calypso/signup/steps/website-content/section-types/constants';
 import FoldableFAQComponent from '../../../components/foldable-faq';
 import { useDIFMPlanInfo } from './use-difm-plan-info';
+import type { RefObject } from '@wordpress/element';
 
 const FAQHeader = styled.h1`
 	font-size: 2rem;
@@ -150,7 +150,7 @@ export const DIFMFAQ = ( {
 		siteId,
 	} );
 
-	const faqHeader = useRef( null );
+	const faqHeader = useRef< HTMLButtonElement >( null );
 	const [ isFAQSectionOpen, setIsFAQSectionOpen ] = useState( false );
 	const onFAQButtonClick = useCallback( () => {
 		setIsFAQSectionOpen( ( isFAQSectionOpen ) => ! isFAQSectionOpen );

--- a/client/my-sites/marketing/do-it-for-me/faq.tsx
+++ b/client/my-sites/marketing/do-it-for-me/faq.tsx
@@ -10,7 +10,7 @@ import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
 import { CHARACTER_LIMIT } from 'calypso/signup/steps/website-content/section-types/constants';
 import FoldableFAQComponent from '../../../components/foldable-faq';
 import { useDIFMPlanInfo } from './use-difm-plan-info';
-import type { RefObject } from '@wordpress/element';
+import type { Ref } from '@wordpress/element';
 
 const FAQHeader = styled.h1`
 	font-size: 2rem;
@@ -100,7 +100,7 @@ const CTASection = styled.div`
 `;
 
 interface FAQExpanderProps {
-	ref: RefObject< HTMLButtonElement >;
+	ref: Ref< HTMLButtonElement >;
 	onClick: () => void;
 	isFAQSectionOpen: boolean;
 	children: ReactNode;

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -156,7 +156,7 @@ const MarketplaceProductInstall = ( {
 	const hasAtomicFeature = useSelector( ( state ) =>
 		siteHasFeature( state, selectedSite?.ID ?? null, WPCOM_FEATURES_ATOMIC )
 	);
-	const supportsAtomicUpgrade = useRef< boolean >();
+	const supportsAtomicUpgrade = useRef< boolean >( undefined );
 	useEffect( () => {
 		supportsAtomicUpgrade.current = hasAtomicFeature;
 	}, [ hasAtomicFeature ] );
@@ -194,8 +194,9 @@ const MarketplaceProductInstall = ( {
 	useEffect( () => {
 		if ( shouldShowNoDirectAccessError ) {
 			waitFor( 2 ).then( () => {
-				// eslint-disable-next-line  @typescript-eslint/no-unused-expressions
-				shouldShowNoDirectAccessError && setNoDirectAccessError( true );
+				if ( shouldShowNoDirectAccessError ) {
+					setNoDirectAccessError( true );
+				}
 			} );
 		}
 	}, [ shouldShowNoDirectAccessError ] );

--- a/client/my-sites/patterns/components/localized-link.tsx
+++ b/client/my-sites/patterns/components/localized-link.tsx
@@ -1,5 +1,5 @@
 import { addLocaleToPathLocaleInFront, useLocale } from '@automattic/i18n-utils';
-import { forwardRef } from 'react';
+import { forwardRef, type JSX } from 'react';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 
@@ -19,3 +19,5 @@ export const LocalizedLink = forwardRef< HTMLAnchorElement, JSX.IntrinsicElement
 		);
 	}
 );
+
+LocalizedLink.displayName = 'LocalizedLink';

--- a/client/my-sites/patterns/components/localized-link.tsx
+++ b/client/my-sites/patterns/components/localized-link.tsx
@@ -19,5 +19,3 @@ export const LocalizedLink = forwardRef< HTMLAnchorElement, JSX.IntrinsicElement
 		);
 	}
 );
-
-LocalizedLink.displayName = 'LocalizedLink';

--- a/client/my-sites/patterns/components/localized-link.tsx
+++ b/client/my-sites/patterns/components/localized-link.tsx
@@ -19,3 +19,5 @@ export const LocalizedLink = forwardRef< HTMLAnchorElement, JSX.IntrinsicElement
 		);
 	}
 );
+
+LocalizedLink.displayName = 'LocalizedLink';

--- a/client/my-sites/patterns/components/readymade-templates/index.tsx
+++ b/client/my-sites/patterns/components/readymade-templates/index.tsx
@@ -1,13 +1,13 @@
 import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { RefObject, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type RefObject } from 'react';
 import { ReadymadeTemplatePreview } from 'calypso/my-sites/patterns/components/readymade-template-preview';
 import { PatternsSection } from 'calypso/my-sites/patterns/components/section';
 import { ReadymadeTemplatesProps } from 'calypso/my-sites/patterns/types';
 import './style.scss';
 
 type ReadymadeTemplatesSectionProps = ReadymadeTemplatesProps & {
-	forwardRef: RefObject< HTMLDivElement > | null;
+	forwardRef: RefObject< HTMLDivElement | null > | null;
 };
 
 export const ReadymadeTemplates = ( {

--- a/client/my-sites/patterns/components/readymade-templates/index.tsx
+++ b/client/my-sites/patterns/components/readymade-templates/index.tsx
@@ -1,13 +1,13 @@
 import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useRef, useState, type RefObject } from 'react';
+import { useEffect, useRef, useState, type Ref } from 'react';
 import { ReadymadeTemplatePreview } from 'calypso/my-sites/patterns/components/readymade-template-preview';
 import { PatternsSection } from 'calypso/my-sites/patterns/components/section';
 import { ReadymadeTemplatesProps } from 'calypso/my-sites/patterns/types';
 import './style.scss';
 
 type ReadymadeTemplatesSectionProps = ReadymadeTemplatesProps & {
-	forwardRef: RefObject< HTMLDivElement | null > | null;
+	forwardRef: Ref< HTMLDivElement > | null;
 };
 
 export const ReadymadeTemplates = ( {

--- a/client/my-sites/patterns/components/section/index.tsx
+++ b/client/my-sites/patterns/components/section/index.tsx
@@ -1,18 +1,18 @@
 import { PremiumBadge } from '@automattic/components';
 import clsx from 'clsx';
-import { RefObject } from 'react';
 import { preventWidows } from 'calypso/lib/formatting';
+import type { ReactNode, RefObject } from 'react';
 
 import './style.scss';
 
 type PatternsSectionProps = {
 	title: string;
 	id?: string;
-	forwardRef?: RefObject< HTMLDivElement >;
+	forwardRef?: RefObject< HTMLDivElement | null >;
 	description: string;
 	theme?: 'blue' | 'dark' | 'gray';
 	bodyFullWidth?: boolean;
-	children: React.ReactNode;
+	children: ReactNode;
 	isPremium?: boolean;
 };
 

--- a/client/my-sites/patterns/components/section/index.tsx
+++ b/client/my-sites/patterns/components/section/index.tsx
@@ -1,14 +1,14 @@
 import { PremiumBadge } from '@automattic/components';
 import clsx from 'clsx';
 import { preventWidows } from 'calypso/lib/formatting';
-import type { ReactNode, RefObject } from 'react';
+import type { ReactNode, Ref } from 'react';
 
 import './style.scss';
 
 type PatternsSectionProps = {
 	title: string;
 	id?: string;
-	forwardRef?: RefObject< HTMLDivElement | null >;
+	forwardRef?: Ref< HTMLDivElement >;
 	description: string;
 	theme?: 'blue' | 'dark' | 'gray';
 	bodyFullWidth?: boolean;

--- a/client/my-sites/patterns/components/toggle/index.tsx
+++ b/client/my-sites/patterns/components/toggle/index.tsx
@@ -8,6 +8,7 @@ import {
 	useEffect,
 	useLayoutEffect,
 	useRef,
+	type JSX,
 } from 'react';
 import { LocalizedLink } from 'calypso/my-sites/patterns/components/localized-link';
 
@@ -43,6 +44,8 @@ export const PatternLibraryToggleOption = forwardRef<
 		</Tooltip>
 	);
 } );
+
+PatternLibraryToggleOption.displayName = 'PatternLibraryToggleOption';
 
 type PatternLibraryToggleProps = {
 	className?: string;

--- a/client/my-sites/patterns/types.ts
+++ b/client/my-sites/patterns/types.ts
@@ -89,7 +89,7 @@ export type ReadymadeTemplateDetailsProps = {
 export type ReadymadeTemplateDetailsFC = React.FC< ReadymadeTemplateDetailsProps >;
 export type ReadymadeTemplatesProps = {
 	readymadeTemplates: ReadymadeTemplate[];
-	forwardRef: React.RefObject< HTMLDivElement > | null;
+	forwardRef: React.RefObject< HTMLDivElement | null > | null;
 };
 export type ReadymadeTemplatesFC = React.FC< ReadymadeTemplatesProps >;
 

--- a/client/my-sites/people/team-invite/invite-form.tsx
+++ b/client/my-sites/people/team-invite/invite-form.tsx
@@ -3,7 +3,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { Icon, check } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useState, ChangeEvent, useEffect, FormEvent, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback, type ChangeEvent, type FormEvent } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
@@ -99,7 +99,9 @@ function InviteForm( props: Props ) {
 	}
 
 	function tokenValidation( i: number, tokenValues: unknown[] ) {
-		tokenValues[ i ] && dispatch( validateTokens( siteId, tokenValues, role ) );
+		if ( tokenValues[ i ] ) {
+			dispatch( validateTokens( siteId, tokenValues, role ) );
+		}
 	}
 
 	/**
@@ -130,7 +132,9 @@ function InviteForm( props: Props ) {
 		const incrementControlNum =
 			valuesNum === tokenControlNum && TOKEN_CONTROL_MAX_NUM > tokenControlNum;
 
-		incrementControlNum && setTokenControlNum( tokenControlNum + 1 );
+		if ( incrementControlNum ) {
+			setTokenControlNum( tokenControlNum + 1 );
+		}
 	}
 
 	function toggleShowContractorCb() {

--- a/client/my-sites/people/team-invite/invite-link-form.tsx
+++ b/client/my-sites/people/team-invite/invite-link-form.tsx
@@ -27,7 +27,7 @@ export function InviteLinkForm( props: Props ) {
 		getInviteLinksForSite( state, siteId )
 	) as InviteLinks | null;
 
-	const copyConfirmTimeoutId = useRef< NodeJS.Timeout >();
+	const copyConfirmTimeoutId = useRef< NodeJS.Timeout >( undefined );
 
 	useEffect( resetActiveLinkValue, [ inviteLinks, role ] );
 	useEffect( toggleIsGeneratingInviteLinks, [ activeInviteLink ] );

--- a/client/my-sites/people/team-invite/invite-link-form.tsx
+++ b/client/my-sites/people/team-invite/invite-link-form.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useEffect, ChangeEvent, useRef } from 'react';
+import { useState, useEffect, useRef, type ChangeEvent } from 'react';
 import ClipboardButton from 'calypso/components/forms/clipboard-button';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import accept from 'calypso/lib/accept';

--- a/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/index.tsx
@@ -4,7 +4,7 @@ import page from '@automattic/calypso-router';
 import { Button, Gridicon } from '@automattic/components';
 import { Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState, type JSX } from 'react';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import Main from 'calypso/components/main';

--- a/client/my-sites/plans/trials/business-trial-expired/index.tsx
+++ b/client/my-sites/plans/trials/business-trial-expired/index.tsx
@@ -6,7 +6,7 @@ import {
 import page from '@automattic/calypso-router';
 import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, type JSX } from 'react';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import Main from 'calypso/components/main';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';

--- a/client/my-sites/plans/trials/trial-banner/index.tsx
+++ b/client/my-sites/plans/trials/trial-banner/index.tsx
@@ -12,6 +12,7 @@ import {
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import DoughnutChart from '../../doughnut-chart';
 import useBannerSubtitle from './use-banner-subtitle';
+import type { JSX } from 'react';
 import './style.scss';
 
 interface TrialBannerProps {

--- a/client/my-sites/plugins/marketplace-ai-experience/banner/index.tsx
+++ b/client/my-sites/plugins/marketplace-ai-experience/banner/index.tsx
@@ -17,6 +17,7 @@ import { useSelector } from 'react-redux';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { DESCRIBE_ROUTE_PREFIX } from '../constants';
 import { sparkleFilled } from '../sparkle-icon';
+import type { JSX } from 'react';
 
 import './style.scss';
 

--- a/client/my-sites/plugins/marketplace-ai-experience/hydrated-pick.tsx
+++ b/client/my-sites/plugins/marketplace-ai-experience/hydrated-pick.tsx
@@ -7,6 +7,7 @@
 import PluginsBrowserListElement from 'calypso/my-sites/plugins/plugins-browser-item';
 import { PluginsBrowserElementVariant } from 'calypso/my-sites/plugins/plugins-browser-item/types';
 import type { Pick } from './agent-provider';
+import type { JSX } from 'react';
 
 interface HydratedPickProps {
 	pick: Pick;

--- a/client/my-sites/plugins/marketplace-ai-experience/index.tsx
+++ b/client/my-sites/plugins/marketplace-ai-experience/index.tsx
@@ -17,6 +17,7 @@ import HydratedPick from './hydrated-pick';
 import { useIsLooking, usePicks } from './picks-store';
 import PromptForm from './prompt-form';
 import { sparkleFilled } from './sparkle-icon';
+import type { JSX } from 'react';
 
 import 'calypso/my-sites/plugins/plugins-browser-list/style.scss';
 import './style.scss';

--- a/client/my-sites/plugins/marketplace-ai-experience/prompt-form.tsx
+++ b/client/my-sites/plugins/marketplace-ai-experience/prompt-form.tsx
@@ -7,6 +7,7 @@ import '@automattic/agenttic-ui/index.css';
 import { AgentUIProvider, ChatInput, Suggestions, type Suggestion } from '@automattic/agenttic-ui';
 import { useMemo, useRef, useState } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
+import type { JSX } from 'react';
 
 import './prompt-form.scss';
 

--- a/client/my-sites/plugins/plugin-compass-agent-loader.tsx
+++ b/client/my-sites/plugins/plugin-compass-agent-loader.tsx
@@ -16,6 +16,7 @@ import { useStore } from 'calypso/state';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getSelectedSite, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import type { Suggestion } from '@automattic/agenttic-ui';
+import type { JSX } from 'react';
 
 const importAgentsManager = () =>
 	import(

--- a/client/my-sites/plugins/related-plugins/index.tsx
+++ b/client/my-sites/plugins/related-plugins/index.tsx
@@ -1,7 +1,7 @@
 import { Gridicon, Button, DotPager } from '@automattic/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo } from 'react';
+import { useMemo, type JSX } from 'react';
 import FullWidthSection from 'calypso/components/full-width-section';
 import { RelatedPlugin } from 'calypso/data/marketplace/types';
 import { useGetRelatedPlugins } from 'calypso/data/marketplace/use-get-related-plugins';

--- a/client/my-sites/plugins/search-categories/index.tsx
+++ b/client/my-sites/plugins/search-categories/index.tsx
@@ -4,7 +4,14 @@ import { isDesktop } from '@automattic/viewport';
 import { SearchControl } from '@wordpress/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { FC, useCallback, MutableRefObject, useRef, RefObject, useEffect } from 'react';
+import {
+	useCallback,
+	useRef,
+	useEffect,
+	type FC,
+	type MutableRefObject,
+	type RefObject,
+} from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import ScrollableHorizontalNavigation from 'calypso/components/scrollable-horizontal-navigation';
 import { setQueryArgs } from 'calypso/lib/query-args';
@@ -23,7 +30,7 @@ import { useTermsSuggestions } from '../use-terms-suggestions';
 import './style.scss';
 
 const SearchBox: FC< {
-	categoriesRef: RefObject< HTMLDivElement >;
+	categoriesRef: RefObject< HTMLDivElement | null >;
 	searchBoxRef: MutableRefObject< ImperativeHandle >;
 	searchTerm: string;
 	searchTerms: string[];
@@ -47,7 +54,7 @@ const SearchBox: FC< {
 			// Handle side effects when search is not empty
 			if ( search ) {
 				searchBoxRef.current?.blur();
-				categoriesRef.current &&
+				if ( categoriesRef.current ) {
 					scrollTo( {
 						x: 0,
 						y:
@@ -55,6 +62,7 @@ const SearchBox: FC< {
 							categoriesRef.current.getBoundingClientRect().height, // But don't show the categories
 						duration: 300,
 					} );
+				}
 			}
 
 			// Track search event

--- a/client/my-sites/sidebar/customize/index.tsx
+++ b/client/my-sites/sidebar/customize/index.tsx
@@ -148,7 +148,7 @@ export function useCustomizeContext(): CustomizeController | null {
  * inert/aria-hidden flips on the children container.
  */
 function useLiveRegion(): {
-	liveRef: React.RefObject< HTMLDivElement | null >;
+	liveRef: React.Ref< HTMLDivElement >;
 	announce: ( msg: string ) => void;
 } {
 	const liveRef = useRef< HTMLDivElement >( null );

--- a/client/my-sites/sidebar/customize/index.tsx
+++ b/client/my-sites/sidebar/customize/index.tsx
@@ -148,7 +148,7 @@ export function useCustomizeContext(): CustomizeController | null {
  * inert/aria-hidden flips on the children container.
  */
 function useLiveRegion(): {
-	liveRef: React.RefObject< HTMLDivElement >;
+	liveRef: React.RefObject< HTMLDivElement | null >;
 	announce: ( msg: string ) => void;
 } {
 	const liveRef = useRef< HTMLDivElement >( null );

--- a/client/my-sites/sidebar/customize/test/footer.tsx
+++ b/client/my-sites/sidebar/customize/test/footer.tsx
@@ -7,6 +7,7 @@ import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import { CustomizeFooter } from '../footer';
 import { CustomizeProvider, useCustomizeContext } from '../index';
+import type { JSX } from 'react';
 
 function renderInProvider( ui: JSX.Element, state: object = {} ) {
 	const store = configureStore()( {

--- a/client/my-sites/sidebar/customize/test/item-keyboard.tsx
+++ b/client/my-sites/sidebar/customize/test/item-keyboard.tsx
@@ -7,6 +7,7 @@ import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import MySitesSidebarUnifiedItem from '../../item';
 import { CustomizeProvider, useCustomizeContext } from '../index';
+import type { JSX } from 'react';
 
 function renderInProvider( ui: JSX.Element ) {
 	const store = configureStore()( {

--- a/client/my-sites/sidebar/customize/test/menu-keyboard.tsx
+++ b/client/my-sites/sidebar/customize/test/menu-keyboard.tsx
@@ -7,6 +7,7 @@ import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import MySitesSidebarUnifiedMenu from '../../menu';
 import { CustomizeProvider, useCustomizeContext } from '../index';
+import type { JSX } from 'react';
 
 function renderInProvider( ui: JSX.Element ) {
 	const store = configureStore()( {

--- a/client/my-sites/sidebar/customize/test/move-menu.tsx
+++ b/client/my-sites/sidebar/customize/test/move-menu.tsx
@@ -8,6 +8,7 @@ import configureStore from 'redux-mock-store';
 import { CustomizeProvider, useCustomizeContext } from '../index';
 import { MoveMenu } from '../move-menu';
 import type { LayoutDelta } from 'calypso/state/admin-sidebar/layout/types';
+import type { JSX } from 'react';
 
 function renderInProvider( ui: JSX.Element, state: object = {} ) {
 	const store = configureStore()( {

--- a/client/my-sites/sidebar/customize/test/provider.tsx
+++ b/client/my-sites/sidebar/customize/test/provider.tsx
@@ -7,6 +7,7 @@ import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import { BODY_CUSTOMIZE_CLASS, CustomizeProvider, useCustomizeContext } from '../index';
 import type { LayoutDelta } from 'calypso/state/admin-sidebar/layout/types';
+import type { JSX } from 'react';
 
 function renderInProvider( ui: JSX.Element ) {
 	const store = configureStore()( {

--- a/client/my-sites/stats/components/empty-state-action/empty-state-action.tsx
+++ b/client/my-sites/stats/components/empty-state-action/empty-state-action.tsx
@@ -1,6 +1,7 @@
 import { Card, CardBody, Icon } from '@wordpress/components';
 import { chevronRight } from '@wordpress/icons';
 import { trackStatsAnalyticsEvent } from 'calypso/my-sites/stats/utils';
+import type { JSX } from 'react';
 
 import './styles.scss';
 

--- a/client/my-sites/stats/components/highlight-cards/count-card.tsx
+++ b/client/my-sites/stats/components/highlight-cards/count-card.tsx
@@ -1,6 +1,6 @@
 import { Card, Popover } from '@automattic/components';
 import clsx from 'clsx';
-import { useRef, useState } from 'react';
+import { useRef, useState, type JSX } from 'react';
 import { formatNumber } from './lib/numbers';
 import TooltipContent from './tooltip-content';
 

--- a/client/my-sites/stats/components/line-chart/index.tsx
+++ b/client/my-sites/stats/components/line-chart/index.tsx
@@ -3,7 +3,7 @@ import '@automattic/charts/style.css';
 import { formatNumber } from '@automattic/number-formatters';
 import clsx from 'clsx';
 import { translate } from 'i18n-calypso';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, type JSX } from 'react';
 import ChartBarTooltip from 'calypso/components/chart/bar-tooltip';
 import { useMomentInSite } from '../../hooks/use-moment-site-zone';
 import StatsEmptyState from '../../stats-empty-state';
@@ -194,14 +194,13 @@ function StatsLineChart( {
 		( { datum }: EventHandlerParams< DataPointDate > ) => {
 			// datum.date is always in the timezone of the browser, we need to use literal date here.
 			if ( datum && datum.date ) {
-				onClick &&
-					onClick( {
-						data: {
-							period: `${ datum.date.getFullYear() }-${
-								datum.date.getMonth() + 1
-							}-${ datum.date.getDate() }`,
-						},
-					} );
+				onClick?.( {
+					data: {
+						period: `${ datum.date.getFullYear() }-${
+							datum.date.getMonth() + 1
+						}-${ datum.date.getDate() }`,
+					},
+				} );
 			}
 		},
 		[ onClick ]

--- a/client/my-sites/stats/feedback/use-on-screen.ts
+++ b/client/my-sites/stats/feedback/use-on-screen.ts
@@ -1,8 +1,8 @@
-import { useEffect, useMemo, useState, RefObject } from 'react';
+import { useEffect, useMemo, useState, type RefObject } from 'react';
 
 // Determines if an element is visible on screen or not.
 
-function useOnScreen( ref: RefObject< HTMLElement > ): boolean {
+function useOnScreen( ref: RefObject< HTMLElement | null > ): boolean {
 	const [ isIntersecting, setIntersecting ] = useState( false );
 
 	const observer = useMemo(

--- a/client/my-sites/stats/sections/all-time-highlights-section/index.tsx
+++ b/client/my-sites/stats/sections/all-time-highlights-section/index.tsx
@@ -4,7 +4,7 @@ import { formatNumber, formatNumberCompact } from '@automattic/number-formatters
 import { Icon, people, postContent, starEmpty, commentContent } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import React, { useMemo } from 'react';
+import React, { useMemo, type JSX } from 'react';
 import QueryPosts from 'calypso/components/data/query-posts';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
 import {

--- a/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder-form.tsx
+++ b/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder-form.tsx
@@ -16,7 +16,7 @@ type InputFieldProps = {
 	placeholder: string;
 	value: string;
 	onChange: ( e: React.ChangeEvent< HTMLInputElement > ) => void;
-	labelReference?: React.RefObject< HTMLLabelElement | null >;
+	labelReference?: React.Ref< HTMLLabelElement >;
 	ariaDescribedBy?: string;
 };
 
@@ -29,7 +29,7 @@ export type UtmBuilderProps = {
 	};
 };
 
-type UtmKeyType = 'url' | 'utm_source' | 'utm_medium' | 'utm_campaign' | 'utm_content' | 'utm_term';
+type UtmKeyType = string;
 
 type inputValuesType = Record< UtmKeyType, string >;
 type formLabelsType = Record<

--- a/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder-form.tsx
+++ b/client/my-sites/stats/stats-module-utm-builder/stats-module-utm-builder-form.tsx
@@ -16,7 +16,7 @@ type InputFieldProps = {
 	placeholder: string;
 	value: string;
 	onChange: ( e: React.ChangeEvent< HTMLInputElement > ) => void;
-	labelReference?: React.RefObject< HTMLLabelElement >;
+	labelReference?: React.RefObject< HTMLLabelElement | null >;
 	ariaDescribedBy?: string;
 };
 
@@ -29,9 +29,7 @@ export type UtmBuilderProps = {
 	};
 };
 
-const utmKeys = [ 'url', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term' ];
-
-type UtmKeyType = ( typeof utmKeys )[ number ];
+type UtmKeyType = 'url' | 'utm_source' | 'utm_medium' | 'utm_campaign' | 'utm_content' | 'utm_term';
 
 type inputValuesType = Record< UtmKeyType, string >;
 type formLabelsType = Record<

--- a/client/my-sites/stats/stats-purchase/tier-upgrade-slider/pricing-slider/types.ts
+++ b/client/my-sites/stats/stats-purchase/tier-upgrade-slider/pricing-slider/types.ts
@@ -1,4 +1,4 @@
-import type { HTMLProps, RefCallback } from 'react';
+import type { HTMLProps, RefCallback, JSX } from 'react';
 
 interface HTMLPropsWithRefCallback< T > extends HTMLProps< T > {
 	ref: RefCallback< T >;

--- a/client/my-sites/subscribers/components/empty-list-view/empty-list-view.tsx
+++ b/client/my-sites/subscribers/components/empty-list-view/empty-list-view.tsx
@@ -3,7 +3,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { Card, CardBody, Icon } from '@wordpress/components';
 import { chartBar, chevronRight, people, trendingUp } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
+import { useEffect, type JSX } from 'react';
 import { useSelector } from 'react-redux';
 import useSupportDocData from 'calypso/components/inline-support-link/use-support-doc-data';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';

--- a/client/my-sites/subscribers/components/jetpack-empty-list-view/jetpack-empty-list-view.tsx
+++ b/client/my-sites/subscribers/components/jetpack-empty-list-view/jetpack-empty-list-view.tsx
@@ -15,7 +15,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { Card, CardBody, Icon } from '@wordpress/components';
 import { copy, upload, reusableBlock, chevronRight } from '@wordpress/icons';
 import { useTranslate, default as i18n } from 'i18n-calypso';
-import { useEffect } from 'react';
+import { useEffect, type JSX } from 'react';
 import { useSelector } from 'react-redux';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { getSelectedSite } from 'calypso/state/ui/selectors';

--- a/client/my-sites/subscribers/components/migrate-subscribers-modal/migrate-subscribers-modal.tsx
+++ b/client/my-sites/subscribers/components/migrate-subscribers-modal/migrate-subscribers-modal.tsx
@@ -92,7 +92,7 @@ const MigrateSubscribersModal = ( {
 					isPlaceholder={ false }
 					selectedSiteId={ selectedSourceSiteId }
 					onSiteSelect={ setSourceSiteId }
-					filter={ ( siteId ) => {
+					filter={ ( siteId: number ) => {
 						return eligibleSiteIDs.includes( siteId );
 					} }
 				/>
@@ -163,9 +163,9 @@ const MigrateSubscribersModal = ( {
 								source_site_id: sourceSiteId,
 								target_site_id: targetSiteId,
 							} );
-							selectedSourceSiteId &&
-								targetSiteId &&
+							if ( selectedSourceSiteId && targetSiteId ) {
 								migrateSubscribersCallback( selectedSourceSiteId );
+							}
 						} }
 					>
 						{ translate( 'Confirm subscriber move' ) }


### PR DESCRIPTION
Part of #111325

Split from #111366

## Proposed Changes

React 18-safe type updates for the upcoming React 19 upgrade:

* Add explicit React `JSX` imports where return/prop types reference `JSX`.
* Convert React symbols only used as types to `type` imports.
* Type ref props as `Ref<T>` so they compile under both React 18 (`LegacyRef<T>`) and React 19 (stricter `RefObject<T>`).
* Small adjacent cleanups: `displayName` on touched `forwardRef` components, explicit control flow in place of short-circuit side effects, translator comment placeholder fixes enforced by linter.

## Why?

Keep low-risk type-shape work separate from runtime/test behavior changes in the stacked follow-up.

## Testing Instructions

* `yarn typecheck-client` clean for touched files under React 18 (current) and React 19 (verified locally with a temporary `@types/react@^19` bump).
* `yarn eslint` clean for touched files.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?