### PR TITLE
Dashboard: Refine menu item prop types to compile under React 19 types

### DIFF
--- a/client/dashboard/components/menu/index.tsx
+++ b/client/dashboard/components/menu/index.tsx
@@ -1,7 +1,6 @@
 import { __experimentalHStack as HStack, MenuItem as WPMenuItem } from '@wordpress/components';
 import { ComponentProps, ComponentType } from 'react';
 import RouterLinkButton from '../router-link-button';
-import type { ActiveOptions } from '@tanstack/react-router';
 import './style.scss';
 
 interface MenuItemLinkProps
@@ -13,17 +12,12 @@ interface MenuItemLinkProps
 
 const MenuItemLink = WPMenuItem as ComponentType< MenuItemLinkProps >;
 
-function MenuItem( {
-	to,
-	children,
-	activeOptions,
-	onClick,
-}: {
-	to: string;
-	children: React.ReactNode;
-	activeOptions?: ActiveOptions;
-	onClick?: () => void;
-} ) {
+type MenuItemProps = Pick<
+	ComponentProps< typeof RouterLinkButton >,
+	'to' | 'activeOptions' | 'onClick'
+> & { children: React.ReactNode };
+
+function MenuItem( { to, children, activeOptions, onClick }: MenuItemProps ) {
 	return (
 		<RouterLinkButton
 			className="dashboard-menu__item"

--- a/client/dashboard/components/responsive-menu/index.tsx
+++ b/client/dashboard/components/responsive-menu/index.tsx
@@ -7,16 +7,37 @@ import {
 import { throttle, useViewportMatch } from '@wordpress/compose';
 import { __, isRTL } from '@wordpress/i18n';
 import { chevronLeft, chevronRight, menu } from '@wordpress/icons';
-import React, { useEffect, useRef, useState, ComponentProps, CSSProperties } from 'react';
+import React, { useEffect, useRef, useState, type ComponentProps, type CSSProperties } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import Menu from '../menu';
 import RouterLinkMenuItem from '../router-link-menu-item';
 
 import './style.scss';
 
+// <RouterLinkButton> uses `createLink` from TanStack, which widens `children`
+// to also accept a render-prop function and `onClick` to require an event
+// argument, and double-wraps `ref`. ResponsiveMenu only ever treats items as
+// plain menu items, we don't want to support the features provided by TanStack.
+// This type narrows those back to what we actually supports while keeping the
+// rest of the link typing (e.g. the `to` route validation).
+type ResponsiveMenuItemProps = Omit<
+	ComponentProps< typeof RouterLinkMenuItem >,
+	'children' | 'onClick' | 'ref'
+> & {
+	children: React.ReactNode;
+	onClick?: ( event?: React.MouseEvent< HTMLButtonElement > ) => void;
+};
+
+// The children of ResponsiveMenu can be any usual ReactNode, but if it _is_ an element
+// with props, then those props must be ResponsiveMenu.Item props.
+type ResponsiveMenuChildNode =
+	| Exclude< React.ReactNode, React.ReactElement | Iterable< React.ReactNode > >
+	| React.ReactElement< ResponsiveMenuItemProps >
+	| Iterable< ResponsiveMenuChildNode >;
+
 type ResponsiveMenuProps = {
 	prefix?: React.ReactNode;
-	children: React.ReactNode;
+	children: ResponsiveMenuChildNode;
 	icon?: React.ReactElement;
 	label?: string;
 	dropdownPlacement?: 'bottom-end' | 'bottom-start' | 'bottom';
@@ -144,7 +165,7 @@ function ResponsiveMenu( {
 	if ( isDesktop ) {
 		const inlineMenu = (
 			<Menu>
-				{ React.Children.map( children, ( child ) => {
+				{ React.Children.map( children, ( child ): React.ReactNode => {
 					if ( React.isValidElement( child ) && child.type === ResponsiveMenu.Item ) {
 						if ( child.props.target === '_blank' ) {
 							return (
@@ -152,8 +173,8 @@ function ResponsiveMenu( {
 									className="dashboard-menu__item"
 									variant="tertiary"
 									{ ...child.props }
-									onClick={ () => {
-										child.props.onClick?.();
+									onClick={ ( e: React.MouseEvent< HTMLButtonElement > ) => {
+										child.props.onClick?.( e );
 										recordTracksEvent( 'calypso_dashboard_menu_item_click', {
 											to: child.props.href ?? '',
 										} );
@@ -170,8 +191,8 @@ function ResponsiveMenu( {
 						return (
 							<Menu.Item
 								{ ...child.props }
-								onClick={ () => {
-									child.props.onClick?.();
+								onClick={ ( e: React.MouseEvent< HTMLButtonElement > ) => {
+									child.props.onClick?.( e );
 									recordTracksEvent( 'calypso_dashboard_menu_item_click', {
 										to: child.props.to ?? '',
 									} );
@@ -288,7 +309,7 @@ function ResponsiveMenu( {
 
 ResponsiveMenu.Item = function MenuItem(
 	// eslint-disable-next-line -- The props are not used because this is just a placeholder component.
-	props: ComponentProps< typeof RouterLinkMenuItem >
+	_props: ResponsiveMenuItemProps
 ) {
 	// This is going to be replaced with the right menu item depending on the screen size.
 	return null;


### PR DESCRIPTION
## Proposed Changes

Shared approach for an upcoming React 19 upgrade. Decouples the dashboard `Menu.Item` / `ResponsiveMenu.Item` prop types from the full TanStack `createLink` prop surface.

- `menu/index.tsx`: derive `MenuItemProps` from `ComponentProps< typeof RouterLinkButton >` (Pick `to | activeOptions | onClick`) instead of a hand-written shape.
- `responsive-menu/index.tsx`: add `ResponsiveMenuItemProps = Omit< ComponentProps< typeof RouterLinkMenuItem >, 'children' | 'onClick' | 'ref' > & { children; onClick? }`, used for both `ResponsiveMenuChildNode` and the `ResponsiveMenu.Item` placeholder.

Note: the temporary React 19 dependency bump used to surface these errors is **not** included — these are backward-compatible type refinements that compile against current deps.

## Why are these changes being made?

Under React 19's stricter type definitions, `ComponentProps< typeof RouterLinkMenuItem >` (where `RouterLinkMenuItem = createLink( ... )`) leaks TanStack Router's link typing into the menu placeholder components:

- `children` widens to `ReactNode | ((state: { isActive; isTransitioning }) => ReactNode)` (a render-prop function), which isn't a valid `ReactNode` for `Menu.Item`.
- `onClick` is typed to require an event argument, breaking `onClick?.()` calls.
- `createLink( forwardRef( ... ) )` double-wraps `ref` into `Ref< Ref< HTMLButtonElement > >`.

ResponsiveMenu only ever treats items as plain menu items, so the fix narrows these three props back to what the menus actually consume — while keeping the valuable part of the link typing (`to` route validation). This is the pattern I'd like us to standardize for the rest of the React 19 type fallout.

## Testing Instructions

- `yarn typecheck-client` passes for these files (verified locally against the React 19 type bump).
- Functional behavior is unchanged; no runtime changes. Smoke-test the dashboard top nav (desktop inline menu + mobile dropdown) renders and navigates.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?
