### PR TITLE
Dashboard domains: use Badge from @wordpress/ui

### DIFF
--- a/client/dashboard/domains/dataviews/field-ssl.tsx
+++ b/client/dashboard/domains/dataviews/field-ssl.tsx
@@ -22,8 +22,8 @@ export const DomainSslField = ( { domain }: { domain: DomainSummary } ) => {
 		domain.subtype.id === DomainSubtype.DEFAULT_ADDRESS ||
 		sslDetails?.certificate_provisioned
 	) {
-		return <Badge intent="success">{ __( 'SSL active' ) }</Badge>;
+		return <Badge intent="stable">{ __( 'SSL active' ) }</Badge>;
 	}
 
-	return <Badge intent="warning">{ __( 'SSL pending' ) }</Badge>;
+	return <Badge intent="low">{ __( 'SSL pending' ) }</Badge>;
 };

--- a/client/dashboard/domains/dataviews/field-ssl.tsx
+++ b/client/dashboard/domains/dataviews/field-ssl.tsx
@@ -1,6 +1,6 @@
 import { DomainSubtype, DomainSummary } from '@automattic/api-core';
 import { sslDetailsQuery } from '@automattic/api-queries';
-import { Badge } from '@automattic/ui';
+import { Badge } from '@wordpress/ui';
 import { useQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
 

--- a/client/dashboard/domains/dataviews/field-ssl.tsx
+++ b/client/dashboard/domains/dataviews/field-ssl.tsx
@@ -1,8 +1,8 @@
 import { DomainSubtype, DomainSummary } from '@automattic/api-core';
 import { sslDetailsQuery } from '@automattic/api-queries';
-import { Badge } from '@wordpress/ui';
 import { useQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
+import { Badge } from '@wordpress/ui';
 
 export const DomainSslField = ( { domain }: { domain: DomainSummary } ) => {
 	const { data: sslDetails } = useQuery( {

--- a/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
@@ -3,7 +3,7 @@ import {
 	DomainMappingSetupInfo,
 	DomainMappingStatus,
 } from '@automattic/api-core';
-import { Badge } from '@automattic/ui';
+import { Badge } from '@wordpress/ui';
 import { __experimentalText as Text } from '@wordpress/components';
 import { DataViews } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';

--- a/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
@@ -46,7 +46,7 @@ interface DnsRecordVerification {
 
 const VerificationBadge = ( { isVerified }: { isVerified: boolean } ) => {
 	return (
-		<Badge intent={ isVerified ? 'success' : 'warning' }>
+		<Badge intent={ isVerified ? 'stable' : 'low' }>
 			{ isVerified ? __( 'Verified' ) : __( 'Verifying' ) }
 		</Badge>
 	);

--- a/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
+++ b/client/dashboard/domains/domain-connection-setup/components/dns-records-table.tsx
@@ -3,10 +3,10 @@ import {
 	DomainMappingSetupInfo,
 	DomainMappingStatus,
 } from '@automattic/api-core';
-import { Badge } from '@wordpress/ui';
 import { __experimentalText as Text } from '@wordpress/components';
 import { DataViews } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
+import { Badge } from '@wordpress/ui';
 import { useMemo } from 'react';
 import { DataViewsCard } from '../../../components/dataviews';
 import { useDnsRecordNames } from '../hooks/use-dns-record-names';

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
@@ -1,5 +1,4 @@
 import { Domain, DomainConnectionSetupMode } from '@automattic/api-core';
-import { Badge } from '@wordpress/ui';
 import {
 	ExternalLink,
 	Icon,
@@ -11,6 +10,7 @@ import {
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { layout, swatch, atSymbol, published } from '@wordpress/icons';
+import { Badge } from '@wordpress/ui';
 import { useAppContext } from '../../app/context';
 import { siteDomainsRoute, siteOverviewRoute } from '../../app/router/sites';
 import { Card, CardBody } from '../../components/card';

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
@@ -72,7 +72,7 @@ export default function DomainConnectionVerification( {
 						<Text className="dashboard-domain-connection-verification__title" size={ 15 }>
 							{ domainName }
 						</Text>
-						<Badge intent={ status === 'connected' ? 'success' : 'warning' }>
+						<Badge intent={ status === 'connected' ? 'stable' : 'low' }>
 							{ status === 'connected' ? __( 'Active' ) : __( 'Verifying' ) }
 						</Badge>
 					</HStack>

--- a/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
+++ b/client/dashboard/domains/domain-connection-setup/domain-connection-verification.tsx
@@ -1,5 +1,5 @@
 import { Domain, DomainConnectionSetupMode } from '@automattic/api-core';
-import { Badge } from '@automattic/ui';
+import { Badge } from '@wordpress/ui';
 import {
 	ExternalLink,
 	Icon,

--- a/client/dashboard/domains/domain-overview/index.tsx
+++ b/client/dashboard/domains/domain-overview/index.tsx
@@ -7,7 +7,7 @@ import {
 	siteByIdQuery,
 } from '@automattic/api-queries';
 import { formatCurrency } from '@automattic/number-formatters';
-import { Badge } from '@automattic/ui';
+import { Badge } from '@wordpress/ui';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';

--- a/client/dashboard/domains/domain-overview/index.tsx
+++ b/client/dashboard/domains/domain-overview/index.tsx
@@ -7,10 +7,10 @@ import {
 	siteByIdQuery,
 } from '@automattic/api-queries';
 import { formatCurrency } from '@automattic/number-formatters';
-import { Badge } from '@wordpress/ui';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
+import { Badge } from '@wordpress/ui';
 import { useMemo } from 'react';
 import { useLocale } from '../../app/locale';
 import { PerformanceTrackerStop } from '../../app/performance-tracking';

--- a/client/dashboard/domains/domain-overview/index.tsx
+++ b/client/dashboard/domains/domain-overview/index.tsx
@@ -6,7 +6,7 @@ import {
 	domainMappingStatusQuery,
 } from '@automattic/api-queries';
 import { formatCurrency } from '@automattic/number-formatters';
-import { Badge } from '@automattic/ui';
+import { Badge } from '@wordpress/ui';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useSearch } from '@tanstack/react-router';
 import { Button, __experimentalHStack as HStack } from '@wordpress/components';

--- a/client/dashboard/domains/domain-security/ssl-certificate.tsx
+++ b/client/dashboard/domains/domain-security/ssl-certificate.tsx
@@ -191,12 +191,12 @@ export default function SslCertificate( { domainName, domain, sslDetails }: SslC
 
 	const renderBadge = () => {
 		if ( sslDetails.certificate_provisioned || domain.wpcom_domain ) {
-			return <Badge intent="success">{ __( 'SSL active' ) }</Badge>;
+			return <Badge intent="stable">{ __( 'SSL active' ) }</Badge>;
 		}
 		if ( domain.ssl_status === 'newly_registered' || domain.ssl_status === 'pending' ) {
-			return <Badge intent="warning">{ __( 'SSL Pending' ) }</Badge>;
+			return <Badge intent="low">{ __( 'SSL Pending' ) }</Badge>;
 		}
-		return <Badge intent="error">{ __( 'SSL Disabled' ) }</Badge>;
+		return <Badge intent="high">{ __( 'SSL Disabled' ) }</Badge>;
 	};
 
 	return (

--- a/client/dashboard/domains/domain-security/ssl-certificate.tsx
+++ b/client/dashboard/domains/domain-security/ssl-certificate.tsx
@@ -1,5 +1,5 @@
 import { provisionSslCertificateMutation } from '@automattic/api-queries';
-import { Badge } from '@automattic/ui';
+import { Badge } from '@wordpress/ui';
 import { CONTACT } from '@automattic/urls';
 import { useMutation } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';

--- a/client/dashboard/domains/domain-security/ssl-certificate.tsx
+++ b/client/dashboard/domains/domain-security/ssl-certificate.tsx
@@ -1,5 +1,4 @@
 import { provisionSslCertificateMutation } from '@automattic/api-queries';
-import { Badge } from '@wordpress/ui';
 import { CONTACT } from '@automattic/urls';
 import { useMutation } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
@@ -11,6 +10,7 @@ import {
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { Badge } from '@wordpress/ui';
 import { ReactElement } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { domainSecurityRoute } from '../../app/router/domains';

--- a/client/dashboard/domains/domain-transfer/inbound-transfer/in-progress.tsx
+++ b/client/dashboard/domains/domain-transfer/inbound-transfer/in-progress.tsx
@@ -21,7 +21,7 @@ export const InboundTransferInProgress = ( { domain }: { domain: Domain } ) => {
 		<InboundTransferStep
 			icon={ <Icon size={ 24 } icon={ drafts } /> }
 			title={ domainName }
-			badge={ <Badge intent="warning">{ __( 'In progress' ) }</Badge> }
+			badge={ <Badge intent="low">{ __( 'In progress' ) }</Badge> }
 			subtitle={ __( 'Estimated: 5–7 days' ) }
 			progress={ { currentStep: 2, color: 'var(--wp-admin-theme-color)' } }
 			domain={ domain }

--- a/client/dashboard/domains/domain-transfer/inbound-transfer/in-progress.tsx
+++ b/client/dashboard/domains/domain-transfer/inbound-transfer/in-progress.tsx
@@ -1,10 +1,10 @@
 import { Domain } from '@automattic/api-core';
 import { domainInboundTransferStatusQuery } from '@automattic/api-queries';
-import { Badge } from '@wordpress/ui';
 import { useQuery } from '@tanstack/react-query';
 import { Icon, __experimentalVStack as VStack } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { drafts, layout } from '@wordpress/icons';
+import { Badge } from '@wordpress/ui';
 import { siteOverviewRoute } from '../../../app/router/sites';
 import Notice from '../../../components/notice';
 import RouterLinkSummaryButton from '../../../components/router-link-summary-button';

--- a/client/dashboard/domains/domain-transfer/inbound-transfer/in-progress.tsx
+++ b/client/dashboard/domains/domain-transfer/inbound-transfer/in-progress.tsx
@@ -1,6 +1,6 @@
 import { Domain } from '@automattic/api-core';
 import { domainInboundTransferStatusQuery } from '@automattic/api-queries';
-import { Badge } from '@automattic/ui';
+import { Badge } from '@wordpress/ui';
 import { useQuery } from '@tanstack/react-query';
 import { Icon, __experimentalVStack as VStack } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';


### PR DESCRIPTION
Pre-requirement for removal of the Badge from `@automattic/ui` as we're now focusing on `@wordpress/ui` [Badge](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-badge-usage-guidelines--docs).

Part of https://github.com/Automattic/wp-calypso/issues/113835

## Proposed Changes

* Replace `@automattic/ui` `Badge` imports with `@wordpress/ui` in dashboard domains screens.

Some of the badges visible via "Summary button" component will be replaced separately with https://github.com/Automattic/wp-calypso/pull/111378:
<img width="690" height="305" alt="image" src="https://github.com/user-attachments/assets/0c665153-1f26-42df-8994-f99adc24c329" />


## Why are these changes being made?

* `Badge` is being removed from `@automattic/ui`, so dashboard domains need to consume `Badge` from `@wordpress/ui`.

## Testing Instructions

* Open dashboard domain pages that render badges and confirm they render correctly.

### Before
<img width="1168" height="200" alt="Screenshot 2026-08-25 at 16 46 47" src="https://github.com/user-attachments/assets/da71ec0a-e2a8-490d-9e1d-a0a4e587ccbf" />
<img width="704" height="438" alt="Screenshot 2026-08-25 at 16 47 41" src="https://github.com/user-attachments/assets/23cbc7dc-61a3-4723-b9ab-8fcfd3530265" />

### After
<img width="1396" height="192" alt="Screenshot 2026-08-25 at 15 57 42" src="https://github.com/user-attachments/assets/e54bf16a-b0cd-41c4-aeec-3594b03712de" />
<img width="739" height="586" alt="Screenshot 2026-08-25 at 15 57 53" src="https://github.com/user-attachments/assets/cde93173-c1f8-4176-962e-37e7d3708207" />
