### PR TITLE
Dashboard me: use Badge from @wordpress/ui

### DIFF
--- a/client/dashboard/me/security-connected-apps/application-details-modal.tsx
+++ b/client/dashboard/me/security-connected-apps/application-details-modal.tsx
@@ -1,4 +1,3 @@
-import { Badge } from '@automattic/ui';
 import {
 	Modal,
 	ExternalLink,
@@ -7,6 +6,7 @@ import {
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { Badge } from '@wordpress/ui';
 import { useLocale } from '../../app/locale';
 import type { ConnectedApplication } from '@automattic/api-core';
 

--- a/client/dashboard/me/security-connected-apps/application-details-modal.tsx
+++ b/client/dashboard/me/security-connected-apps/application-details-modal.tsx
@@ -89,7 +89,7 @@ export default function ApplicationDetailsModal( { application, onClose }: Props
 						value={
 							<VStack spacing={ 2 }>
 								<Badge
-									intent="default"
+									intent="draft"
 									style={ {
 										maxWidth: 'fit-content',
 									} }

--- a/client/dashboard/me/security-ssh-key/ssh-key.tsx
+++ b/client/dashboard/me/security-ssh-key/ssh-key.tsx
@@ -1,5 +1,4 @@
 import { deleteSshKeyMutation } from '@automattic/api-queries';
-import { Badge } from '@automattic/ui';
 import { useMutation } from '@tanstack/react-query';
 import {
 	Button,
@@ -10,6 +9,7 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { pencil as edit, trash } from '@wordpress/icons';
+import { Badge } from '@wordpress/ui';
 import { useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { useLocale } from '../../app/locale';

--- a/client/dashboard/me/security-ssh-key/ssh-key.tsx
+++ b/client/dashboard/me/security-ssh-key/ssh-key.tsx
@@ -66,7 +66,7 @@ export default function SshKey( {
 							<Text variant="muted" lineHeight="20px" size="13px">
 								{ sshKey.sha256 }
 							</Text>
-							<Badge intent="info">
+							<Badge intent="informational">
 								{ sprintf(
 									/* translators: %s is when the SSH key was attached. */
 									__( 'Attached on %s' ),


### PR DESCRIPTION
Pre-requirement for removal of the Badge from `@automattic/ui` as we're now focusing on `@wordpress/ui` [Badge](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-badge-usage-guidelines--docs).

Part of https://github.com/Automattic/wp-calypso/issues/113835

## Proposed Changes

* Replace `@automattic/ui` `Badge` imports with `@wordpress/ui` in dashboard me screens.

## Why are these changes being made?

* Badge is being removed from `@automattic/ui` as a way to consolidate into one design system badge instead. 
* 
## Testing Instructions

* Verify dashboard me security screens still render badges correctly and colors make sense:
   * Me → Security → Connected apps → three dots → details (http://my.localhost:3000/me/security/connected-apps)
   * Me → Security → SSH Key (http://my.localhost:3000/me/security/ssh-key)

### Before
<img width="915" height="581" alt="Screenshot 2026-08-27 at 14 02 40" src="https://github.com/user-attachments/assets/21c4dcda-c8d4-441f-9161-5e96fe70c04c" />
<img width="730" height="290" alt="Screenshot 2026-08-27 at 14 01 59" src="https://github.com/user-attachments/assets/0037ad5c-9be3-4a10-b5cb-25a88e541ac0" />

### After
<img width="899" height="580" alt="Screenshot 2026-08-27 at 14 04 27" src="https://github.com/user-attachments/assets/91e56234-000c-491b-9bba-92d8eb337717" />
<img width="748" height="299" alt="Screenshot 2026-08-27 at 13 59 35" src="https://github.com/user-attachments/assets/3ea00689-82f1-413f-bc09-ba73349f116b" />

### Not included

Note that these badges are handled in a separate component PR at https://github.com/Automattic/wp-calypso/pull/111378:

<img width="729" height="531" alt="image" src="https://github.com/user-attachments/assets/a819e259-b0d3-416a-8ad0-311fee8cdee8" />

