### PR TITLE
Sites plan: use Badge from @wordpress/ui

### DIFF
--- a/client/sites/plan/components/current-plan-panel/index.tsx
+++ b/client/sites/plan/components/current-plan-panel/index.tsx
@@ -1,7 +1,7 @@
 import { is100Year } from '@automattic/calypso-products';
 import { LoadingPlaceholder } from '@automattic/components';
-import { Badge } from '@automattic/ui';
 import { Button } from '@wordpress/components';
+import { Badge } from '@wordpress/ui';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { isPartnerPurchase, purchaseType } from 'calypso/lib/purchases';


### PR DESCRIPTION
Part of #

## Proposed Changes

* Replace   imports with  in sites plan screens.

## Why are these changes being made?

* Badge is being removed from , so this area now imports Badge from .

## Testing Instructions

* Verify sites plan screens still render badges correctly.