### PR TITLE
SummaryButton: use Badge from @wordpress/ui

### DIFF
--- a/client/components/option-content/index.tsx
+++ b/client/components/option-content/index.tsx
@@ -61,7 +61,7 @@ export function OptionContent( {
 				onClick={ onSelect }
 				href={ href }
 				disabled={ disabled || isPlaceholder || noAction }
-				badges={ recommended ? [ { text: __( 'Recommended' ), intent: 'success' } ] : undefined }
+				badges={ recommended ? [ { text: __( 'Recommended' ), intent: 'stable' } ] : undefined }
 			/>
 			{ benefits && (
 				<VStack

--- a/client/dashboard/agency/resources/mcp/overview-content.tsx
+++ b/client/dashboard/agency/resources/mcp/overview-content.tsx
@@ -16,7 +16,7 @@ const MCP_PROMPTS_PATH = '/resources/ai-mcp/prompts';
 
 function getToolsBadge( abilities: McpAvailableAbility[] ) {
 	if ( abilities.length === 0 ) {
-		return { text: __( 'No tools available' ) };
+		return { text: __( 'No tools available' ), intent: 'draft' as const };
 	}
 
 	const enabledCount = abilities.filter( ( ability ) => ability.enabled ).length;
@@ -26,7 +26,7 @@ function getToolsBadge( abilities: McpAvailableAbility[] ) {
 	}
 
 	if ( enabledCount === 0 ) {
-		return { text: __( 'None enabled' ) };
+		return { text: __( 'None enabled' ), intent: 'draft' as const };
 	}
 
 	return {

--- a/client/dashboard/agency/resources/mcp/overview-content.tsx
+++ b/client/dashboard/agency/resources/mcp/overview-content.tsx
@@ -22,7 +22,7 @@ function getToolsBadge( abilities: McpAvailableAbility[] ) {
 	const enabledCount = abilities.filter( ( ability ) => ability.enabled ).length;
 
 	if ( enabledCount === abilities.length ) {
-		return { text: __( 'All enabled' ), intent: 'success' as const };
+		return { text: __( 'All enabled' ), intent: 'stable' as const };
 	}
 
 	if ( enabledCount === 0 ) {
@@ -32,7 +32,7 @@ function getToolsBadge( abilities: McpAvailableAbility[] ) {
 	return {
 		/* translators: %1$d is the number of enabled tools, %2$d is the total number of tools */
 		text: sprintf( __( '%1$d of %2$d enabled' ), enabledCount, abilities.length ),
-		intent: 'info' as const,
+		intent: 'informational' as const,
 	};
 }
 

--- a/client/dashboard/components/summary-button-list/index.stories.tsx
+++ b/client/dashboard/components/summary-button-list/index.stories.tsx
@@ -37,13 +37,13 @@ export const Default: Story = {
 				key="theme"
 				title="Theme"
 				decoration={ <Icon icon={ brush } /> }
-				badges={ [ { text: 'Twenty Twenty-Four' } ] }
+				badges={ [ { text: 'Twenty Twenty-Four', intent: 'draft' } ] }
 			/>,
 			<SummaryButton
 				key="home"
 				title="Homepage settings"
 				decoration={ <Icon icon={ home } /> }
-				badges={ [ { text: 'Latest posts' } ] }
+				badges={ [ { text: 'Latest posts', intent: 'draft' } ] }
 			/>,
 		],
 	},
@@ -80,14 +80,14 @@ export const WithDescriptionsInButtons: Story = {
 				title="Theme"
 				description="Change the look and feel of your site"
 				decoration={ <Icon icon={ brush } /> }
-				badges={ [ { text: 'Twenty Twenty-Four' } ] }
+				badges={ [ { text: 'Twenty Twenty-Four', intent: 'draft' } ] }
 			/>,
 			<SummaryButton
 				key="home"
 				title="Homepage settings"
 				description="Choose what appears on your homepage"
 				decoration={ <Icon icon={ home } /> }
-				badges={ [ { text: 'Latest posts' } ] }
+				badges={ [ { text: 'Latest posts', intent: 'draft' } ] }
 			/>,
 		],
 	},

--- a/client/dashboard/components/summary-button-list/index.stories.tsx
+++ b/client/dashboard/components/summary-button-list/index.stories.tsx
@@ -31,7 +31,7 @@ export const Default: Story = {
 				key="visibility"
 				title="Site visibility"
 				decoration={ <Icon icon={ seen } /> }
-				badges={ [ { text: 'Public', intent: 'success' } ] }
+				badges={ [ { text: 'Public', intent: 'stable' } ] }
 			/>,
 			<SummaryButton
 				key="theme"
@@ -73,7 +73,7 @@ export const WithDescriptionsInButtons: Story = {
 				title="Site visibility"
 				description="Control who can see your site"
 				decoration={ <Icon icon={ seen } /> }
-				badges={ [ { text: 'Public', intent: 'success' } ] }
+				badges={ [ { text: 'Public', intent: 'stable' } ] }
 			/>,
 			<SummaryButton
 				key="theme"

--- a/client/dashboard/domains/domain-connection-setup/summary.tsx
+++ b/client/dashboard/domains/domain-connection-setup/summary.tsx
@@ -22,11 +22,11 @@ export default function DomainConnectionSetupSummary( {
 		isMappingVerificationSuccess( domainMappingStatus.mode ?? null, domainMappingStatus );
 
 	if ( isConnected ) {
-		badges.push( { text: __( 'Connected' ), intent: 'success' } );
+		badges.push( { text: __( 'Connected' ), intent: 'stable' } );
 	} else if ( domainMappingStatus?.mode === DomainConnectionSetupMode.ADVANCED ) {
-		badges.push( { text: __( 'Verifying DNS' ), intent: 'warning' } );
+		badges.push( { text: __( 'Verifying DNS' ), intent: 'low' } );
 	} else if ( domainMappingStatus?.mode === DomainConnectionSetupMode.SUGGESTED ) {
-		badges.push( { text: __( 'Verifying name servers' ), intent: 'warning' } );
+		badges.push( { text: __( 'Verifying name servers' ), intent: 'low' } );
 	}
 
 	return (

--- a/client/dashboard/domains/domain-contact-details/summary.tsx
+++ b/client/dashboard/domains/domain-contact-details/summary.tsx
@@ -13,7 +13,7 @@ export default function DomainContactDetailsSettingsSummary( {
 } ) {
 	const badges: SummaryButtonBadgeProps[] = [];
 	if ( domain.private_domain ) {
-		badges.push( { text: __( 'Privacy protection on' ), intent: 'success' as const } );
+		badges.push( { text: __( 'Privacy protection on' ), intent: 'stable' as const } );
 	} else {
 		badges.push( { text: __( 'Privacy protection off' ), intent: undefined } );
 	}

--- a/client/dashboard/domains/domain-contact-details/summary.tsx
+++ b/client/dashboard/domains/domain-contact-details/summary.tsx
@@ -15,7 +15,7 @@ export default function DomainContactDetailsSettingsSummary( {
 	if ( domain.private_domain ) {
 		badges.push( { text: __( 'Privacy protection on' ), intent: 'stable' as const } );
 	} else {
-		badges.push( { text: __( 'Privacy protection off' ), intent: undefined } );
+		badges.push( { text: __( 'Privacy protection off' ), intent: 'draft' as const } );
 	}
 
 	if ( domain.subtype.id === DomainSubtype.DOMAIN_CONNECTION ) {

--- a/client/dashboard/domains/domain-diagnostics/summary.tsx
+++ b/client/dashboard/domains/domain-diagnostics/summary.tsx
@@ -24,7 +24,7 @@ export default function DomainDiagnosticsSettingsSummary( {
 		{
 			text: __( 'Issues with DNS email records' ),
 			intent: domainDiagnostics.email_dns_records.dismissed_email_dns_issues_notice
-				? undefined
+				? ( 'draft' as const )
 				: ( 'high' as const ),
 		},
 	];

--- a/client/dashboard/domains/domain-diagnostics/summary.tsx
+++ b/client/dashboard/domains/domain-diagnostics/summary.tsx
@@ -25,7 +25,7 @@ export default function DomainDiagnosticsSettingsSummary( {
 			text: __( 'Issues with DNS email records' ),
 			intent: domainDiagnostics.email_dns_records.dismissed_email_dns_issues_notice
 				? undefined
-				: ( 'error' as const ),
+				: ( 'high' as const ),
 		},
 	];
 

--- a/client/dashboard/domains/domain-security/summary.tsx
+++ b/client/dashboard/domains/domain-security/summary.tsx
@@ -13,16 +13,16 @@ export default function NameServersSettingsSummary( {
 } ) {
 	const badges: SummaryButtonBadgeProps[] = [];
 	if ( domain.ssl_status === 'active' ) {
-		badges.push( { text: __( 'SSL active' ), intent: 'success' as const } );
+		badges.push( { text: __( 'SSL active' ), intent: 'stable' as const } );
 	} else if ( domain.ssl_status === 'newly_registered' || domain.ssl_status === 'pending' ) {
-		badges.push( { text: __( 'SSL Pending' ), intent: 'warning' as const } );
+		badges.push( { text: __( 'SSL Pending' ), intent: 'low' as const } );
 	} else {
-		badges.push( { text: __( 'SSL Disabled' ), intent: 'error' as const } );
+		badges.push( { text: __( 'SSL Disabled' ), intent: 'high' as const } );
 	}
 
 	if ( DomainSubtype.DOMAIN_REGISTRATION === domain.subtype.id ) {
 		if ( domain.is_dnssec_enabled ) {
-			badges.push( { text: __( 'DNSSEC enabled' ), intent: 'success' as const } );
+			badges.push( { text: __( 'DNSSEC enabled' ), intent: 'stable' as const } );
 		} else {
 			badges.push( { text: __( 'DNSSEC disabled' ), intent: undefined } );
 		}

--- a/client/dashboard/domains/domain-security/summary.tsx
+++ b/client/dashboard/domains/domain-security/summary.tsx
@@ -24,7 +24,7 @@ export default function NameServersSettingsSummary( {
 		if ( domain.is_dnssec_enabled ) {
 			badges.push( { text: __( 'DNSSEC enabled' ), intent: 'stable' as const } );
 		} else {
-			badges.push( { text: __( 'DNSSEC disabled' ), intent: undefined } );
+			badges.push( { text: __( 'DNSSEC disabled' ), intent: 'draft' as const } );
 		}
 	}
 

--- a/client/dashboard/domains/name-servers/summary.tsx
+++ b/client/dashboard/domains/name-servers/summary.tsx
@@ -11,7 +11,7 @@ export default function NameServersSettingsSummary( {
 } ) {
 	let badges = [];
 	if ( domain.has_wpcom_nameservers ) {
-		badges = [ { text: __( 'Using WordPress.com name servers' ), intent: 'success' as const } ];
+		badges = [ { text: __( 'Using WordPress.com name servers' ), intent: 'stable' as const } ];
 	} else {
 		badges = [ { text: __( 'Using custom name servers' ), intent: undefined } ];
 	}

--- a/client/dashboard/domains/name-servers/summary.tsx
+++ b/client/dashboard/domains/name-servers/summary.tsx
@@ -13,7 +13,7 @@ export default function NameServersSettingsSummary( {
 	if ( domain.has_wpcom_nameservers ) {
 		badges = [ { text: __( 'Using WordPress.com name servers' ), intent: 'stable' as const } ];
 	} else {
-		badges = [ { text: __( 'Using custom name servers' ), intent: undefined } ];
+		badges = [ { text: __( 'Using custom name servers' ), intent: 'draft' as const } ];
 	}
 
 	return (

--- a/client/dashboard/me/mcp/index.tsx
+++ b/client/dashboard/me/mcp/index.tsx
@@ -37,11 +37,11 @@ interface McpAbility {
 
 function getReadBadge( tools: Array< [ string, McpAbility ] > ) {
 	if ( tools.length === 0 ) {
-		return { text: __( 'All enabled' ), intent: 'success' as const };
+		return { text: __( 'All enabled' ), intent: 'stable' as const };
 	}
 	const enabledCount = tools.filter( ( [ , tool ] ) => tool.enabled ).length;
 	if ( enabledCount === tools.length ) {
-		return { text: __( 'All enabled' ), intent: 'success' as const };
+		return { text: __( 'All enabled' ), intent: 'stable' as const };
 	}
 	if ( enabledCount === 0 ) {
 		return { text: __( 'None enabled' ) };
@@ -49,17 +49,17 @@ function getReadBadge( tools: Array< [ string, McpAbility ] > ) {
 	return {
 		/* translators: %1$d is the number of enabled tools, %2$d is the total number of tools */
 		text: sprintf( __( '%1$d of %2$d enabled' ), enabledCount, tools.length ),
-		intent: 'info' as const,
+		intent: 'informational' as const,
 	};
 }
 
 function getWriteBadge( tools: Array< [ string, McpAbility ] > ) {
 	if ( tools.length === 0 ) {
-		return { text: __( 'All enabled' ), intent: 'success' as const };
+		return { text: __( 'All enabled' ), intent: 'stable' as const };
 	}
 	const enabledCount = tools.filter( ( [ , tool ] ) => tool.enabled ).length;
 	if ( enabledCount === tools.length ) {
-		return { text: __( 'All enabled' ), intent: 'success' as const };
+		return { text: __( 'All enabled' ), intent: 'stable' as const };
 	}
 	if ( enabledCount === 0 ) {
 		return { text: __( 'Disabled' ) };
@@ -67,7 +67,7 @@ function getWriteBadge( tools: Array< [ string, McpAbility ] > ) {
 	return {
 		/* translators: %1$d is the number of enabled tools, %2$d is the total number of tools */
 		text: sprintf( __( '%1$d of %2$d enabled' ), enabledCount, tools.length ),
-		intent: 'info' as const,
+		intent: 'informational' as const,
 	};
 }
 
@@ -91,12 +91,12 @@ function McpComponent() {
 	const exceptionCount = disabledSiteIds.length;
 	const exceptionBadge =
 		exceptionCount > 0
-			? { text: `${ exceptionCount } exceptions`, intent: 'warning' as const }
+			? { text: `${ exceptionCount } exceptions`, intent: 'low' as const }
 			: { text: __( 'No exceptions' ) };
 
 	const addSiteBadge =
 		enabledSiteIds.length > 0
-			? { text: `${ enabledSiteIds.length } sites`, intent: 'success' as const }
+			? { text: `${ enabledSiteIds.length } sites`, intent: 'stable' as const }
 			: { text: __( 'No sites added' ) };
 
 	const readBadge = getReadBadge( readTools );

--- a/client/dashboard/me/mcp/index.tsx
+++ b/client/dashboard/me/mcp/index.tsx
@@ -44,7 +44,7 @@ function getReadBadge( tools: Array< [ string, McpAbility ] > ) {
 		return { text: __( 'All enabled' ), intent: 'stable' as const };
 	}
 	if ( enabledCount === 0 ) {
-		return { text: __( 'None enabled' ) };
+		return { text: __( 'None enabled' ), intent: 'draft' as const };
 	}
 	return {
 		/* translators: %1$d is the number of enabled tools, %2$d is the total number of tools */
@@ -62,7 +62,7 @@ function getWriteBadge( tools: Array< [ string, McpAbility ] > ) {
 		return { text: __( 'All enabled' ), intent: 'stable' as const };
 	}
 	if ( enabledCount === 0 ) {
-		return { text: __( 'Disabled' ) };
+		return { text: __( 'Disabled' ), intent: 'draft' as const };
 	}
 	return {
 		/* translators: %1$d is the number of enabled tools, %2$d is the total number of tools */
@@ -92,12 +92,12 @@ function McpComponent() {
 	const exceptionBadge =
 		exceptionCount > 0
 			? { text: `${ exceptionCount } exceptions`, intent: 'low' as const }
-			: { text: __( 'No exceptions' ) };
+			: { text: __( 'No exceptions' ), intent: 'draft' as const };
 
 	const addSiteBadge =
 		enabledSiteIds.length > 0
 			? { text: `${ enabledSiteIds.length } sites`, intent: 'stable' as const }
-			: { text: __( 'No sites added' ) };
+			: { text: __( 'No sites added' ), intent: 'draft' as const };
 
 	const readBadge = getReadBadge( readTools );
 	const writeBadge = getWriteBadge( writeTools );

--- a/client/dashboard/me/notifications-emails/summary.tsx
+++ b/client/dashboard/me/notifications-emails/summary.tsx
@@ -14,9 +14,7 @@ export const NotificationsEmailsSummary = ( { density }: { density?: Density } )
 
 	const badges = useMemo(
 		() =>
-			isAllWpcomEmailsDisabled
-				? [ { text: __( 'All emails are paused' ), intent: 'warning' } ]
-				: [],
+			isAllWpcomEmailsDisabled ? [ { text: __( 'All emails are paused' ), intent: 'medium' } ] : [],
 		[ isAllWpcomEmailsDisabled ]
 	) as SummaryButtonBadgeProps[];
 

--- a/client/dashboard/me/preferences-ai-mcp/index.tsx
+++ b/client/dashboard/me/preferences-ai-mcp/index.tsx
@@ -13,7 +13,7 @@ export default function PreferencesAiMcp( { density }: { density?: Density } ) {
 	const badges = [
 		{
 			text: isEnabled ? __( 'Enabled' ) : __( 'Disabled' ),
-			intent: isEnabled ? ( 'stable' as const ) : undefined,
+			intent: isEnabled ? ( 'stable' as const ) : ( 'draft' as const ),
 		},
 	];
 

--- a/client/dashboard/me/preferences-ai-mcp/index.tsx
+++ b/client/dashboard/me/preferences-ai-mcp/index.tsx
@@ -13,7 +13,7 @@ export default function PreferencesAiMcp( { density }: { density?: Density } ) {
 	const badges = [
 		{
 			text: isEnabled ? __( 'Enabled' ) : __( 'Disabled' ),
-			intent: isEnabled ? ( 'success' as const ) : undefined,
+			intent: isEnabled ? ( 'stable' as const ) : undefined,
 		},
 	];
 

--- a/client/dashboard/me/preferences-blocked-sites/index.tsx
+++ b/client/dashboard/me/preferences-blocked-sites/index.tsx
@@ -21,7 +21,7 @@ export default function PreferencesBlockedSites( { density }: { density?: Densit
 							__( '%d blocked' ),
 							count
 						),
-						intent: 'info' as const,
+						intent: 'informational' as const,
 					},
 			  ];
 

--- a/client/dashboard/me/preferences-blocked-sites/index.tsx
+++ b/client/dashboard/me/preferences-blocked-sites/index.tsx
@@ -13,7 +13,7 @@ export default function PreferencesBlockedSites( { density }: { density?: Densit
 
 	const badges =
 		count === 0
-			? [ { text: __( 'None' ) } ]
+			? [ { text: __( 'None' ), intent: 'draft' as const } ]
 			: [
 					{
 						text: sprintf(

--- a/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
+++ b/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
@@ -20,7 +20,7 @@ export default function PreferencesNewHostingDashboard( { density }: { density?:
 	const badges = [
 		{
 			text: isOptedIn ? __( 'Enabled' ) : __( 'Disabled' ),
-			intent: isOptedIn ? ( 'stable' as const ) : undefined,
+			intent: isOptedIn ? ( 'stable' as const ) : ( 'draft' as const ),
 		},
 	];
 

--- a/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
+++ b/client/dashboard/me/preferences-new-hosting-dashboard/index.tsx
@@ -20,7 +20,7 @@ export default function PreferencesNewHostingDashboard( { density }: { density?:
 	const badges = [
 		{
 			text: isOptedIn ? __( 'Enabled' ) : __( 'Disabled' ),
-			intent: isOptedIn ? ( 'success' as const ) : undefined,
+			intent: isOptedIn ? ( 'stable' as const ) : undefined,
 		},
 	];
 

--- a/client/dashboard/me/preferences-privacy/index.tsx
+++ b/client/dashboard/me/preferences-privacy/index.tsx
@@ -17,7 +17,7 @@ export default function PreferencesPrivacy( { density }: { density?: Density } )
 						text: isSharingUsageInfo
 							? __( 'Sharing usage information' )
 							: __( 'Not sharing usage information' ),
-						intent: isSharingUsageInfo ? ( 'stable' as const ) : undefined,
+						intent: isSharingUsageInfo ? ( 'stable' as const ) : ( 'draft' as const ),
 					},
 			  ]
 			: undefined;

--- a/client/dashboard/me/preferences-privacy/index.tsx
+++ b/client/dashboard/me/preferences-privacy/index.tsx
@@ -17,7 +17,7 @@ export default function PreferencesPrivacy( { density }: { density?: Density } )
 						text: isSharingUsageInfo
 							? __( 'Sharing usage information' )
 							: __( 'Not sharing usage information' ),
-						intent: isSharingUsageInfo ? ( 'success' as const ) : undefined,
+						intent: isSharingUsageInfo ? ( 'stable' as const ) : undefined,
 					},
 			  ]
 			: undefined;

--- a/client/dashboard/me/preferences-wordpress-labs/index.tsx
+++ b/client/dashboard/me/preferences-wordpress-labs/index.tsx
@@ -13,7 +13,7 @@ export default function PreferencesWordPressLabs( { density }: { density?: Densi
 	const badges = [
 		{
 			text: isOptedIn ? __( 'Enabled' ) : __( 'Disabled' ),
-			intent: isOptedIn ? ( 'success' as const ) : undefined,
+			intent: isOptedIn ? ( 'stable' as const ) : ( 'draft' as const ),
 		},
 	];
 

--- a/client/dashboard/me/security-account-recovery/summary.tsx
+++ b/client/dashboard/me/security-account-recovery/summary.tsx
@@ -23,29 +23,29 @@ export default function SecurityAccountRecoverySummary( { density }: { density?:
 	if ( email && emailIsAccountEmail ) {
 		badges.push( {
 			text: __( 'Recovery email matches account email' ),
-			intent: 'warning',
+			intent: 'medium',
 		} );
 	} else if ( email ) {
 		badges.push( {
 			text: email_validated ? __( 'Email added' ) : __( 'Email not validated' ),
-			intent: email_validated ? 'success' : 'warning',
+			intent: email_validated ? 'stable' : 'low',
 		} );
 	} else {
 		badges.push( {
 			text: __( 'No recovery email' ),
-			intent: 'warning',
+			intent: 'medium',
 		} );
 	}
 
 	if ( phone ) {
 		badges.push( {
 			text: phone_validated ? __( 'SMS number added' ) : __( 'SMS number not validated' ),
-			intent: phone_validated ? 'success' : 'warning',
+			intent: phone_validated ? 'stable' : 'low',
 		} );
 	} else {
 		badges.push( {
 			text: __( 'No recovery SMS number' ),
-			intent: 'warning',
+			intent: 'medium',
 		} );
 	}
 

--- a/client/dashboard/me/security-connected-apps/summary.tsx
+++ b/client/dashboard/me/security-connected-apps/summary.tsx
@@ -27,7 +27,7 @@ export default function SecurityConnectedAppsSummary( { density }: { density?: D
 						connectedApplicationsCount
 				  )
 				: __( 'No connected applications' ),
-			intent: connectedApplicationsCount ? 'informational' : 'none',
+			intent: connectedApplicationsCount ? 'informational' : 'draft',
 		},
 	];
 

--- a/client/dashboard/me/security-connected-apps/summary.tsx
+++ b/client/dashboard/me/security-connected-apps/summary.tsx
@@ -27,7 +27,7 @@ export default function SecurityConnectedAppsSummary( { density }: { density?: D
 						connectedApplicationsCount
 				  )
 				: __( 'No connected applications' ),
-			intent: connectedApplicationsCount ? 'info' : 'default',
+			intent: connectedApplicationsCount ? 'informational' : 'none',
 		},
 	];
 

--- a/client/dashboard/me/security-legacy-contact/summary.tsx
+++ b/client/dashboard/me/security-legacy-contact/summary.tsx
@@ -15,7 +15,7 @@ export default function SecurityLegacyContactSummary( { density }: { density?: D
 	const badges: SummaryButtonBadgeProps[] = [
 		{
 			text: contact ? __( 'Legacy contact added' ) : __( 'No legacy contact added' ),
-			intent: contact ? 'stable' : 'none',
+			intent: contact ? 'stable' : 'draft',
 		},
 	];
 

--- a/client/dashboard/me/security-legacy-contact/summary.tsx
+++ b/client/dashboard/me/security-legacy-contact/summary.tsx
@@ -15,7 +15,7 @@ export default function SecurityLegacyContactSummary( { density }: { density?: D
 	const badges: SummaryButtonBadgeProps[] = [
 		{
 			text: contact ? __( 'Legacy contact added' ) : __( 'No legacy contact added' ),
-			intent: contact ? 'success' : 'default',
+			intent: contact ? 'stable' : 'none',
 		},
 	];
 

--- a/client/dashboard/me/security-password/summary.tsx
+++ b/client/dashboard/me/security-password/summary.tsx
@@ -19,7 +19,7 @@ export default function SecurityAccountRecoverySummary( { density }: { density?:
 	if ( is_passwordless_user ) {
 		badges.push( {
 			text: __( 'Password not set' ),
-			intent: 'warning',
+			intent: 'low',
 		} );
 	}
 

--- a/client/dashboard/me/security-social-logins/summary.tsx
+++ b/client/dashboard/me/security-social-logins/summary.tsx
@@ -22,7 +22,7 @@ export default function SecuritySocialLoginsSummary( { density }: { density?: De
 						socialLoginCount
 				  )
 				: __( 'No social logins added' ),
-			intent: socialLoginCount ? 'informational' : 'none',
+			intent: socialLoginCount ? 'informational' : 'draft',
 		},
 	];
 

--- a/client/dashboard/me/security-social-logins/summary.tsx
+++ b/client/dashboard/me/security-social-logins/summary.tsx
@@ -22,7 +22,7 @@ export default function SecuritySocialLoginsSummary( { density }: { density?: De
 						socialLoginCount
 				  )
 				: __( 'No social logins added' ),
-			intent: socialLoginCount ? 'info' : 'default',
+			intent: socialLoginCount ? 'informational' : 'none',
 		},
 	];
 

--- a/client/dashboard/me/security-ssh-key/summary.tsx
+++ b/client/dashboard/me/security-ssh-key/summary.tsx
@@ -15,7 +15,7 @@ export default function SecuritySshKeySummary( { density }: { density?: Density 
 	const badges: SummaryButtonBadgeProps[] = [
 		{
 			text: sshKeys.length ? __( 'SSH key added' ) : __( 'No SSH key added' ),
-			intent: sshKeys.length ? 'success' : 'default',
+			intent: sshKeys.length ? 'stable' : 'none',
 		},
 	];
 

--- a/client/dashboard/me/security-ssh-key/summary.tsx
+++ b/client/dashboard/me/security-ssh-key/summary.tsx
@@ -15,7 +15,7 @@ export default function SecuritySshKeySummary( { density }: { density?: Density 
 	const badges: SummaryButtonBadgeProps[] = [
 		{
 			text: sshKeys.length ? __( 'SSH key added' ) : __( 'No SSH key added' ),
-			intent: sshKeys.length ? 'stable' : 'none',
+			intent: sshKeys.length ? 'stable' : 'draft',
 		},
 	];
 

--- a/client/dashboard/me/security-two-step-auth/empty-state.tsx
+++ b/client/dashboard/me/security-two-step-auth/empty-state.tsx
@@ -23,7 +23,7 @@ export default function SecurityTwoStepAuthEmptyState( {
 				title={ getAppSetupTitle() }
 				description={ __( 'Use an app to generate two-step authentication codes.' ) }
 				decoration={ <Icon icon={ mobile } /> }
-				badges={ [ { text: __( 'Recommended' ), intent: 'success' } ] }
+				badges={ [ { text: __( 'Recommended' ), intent: 'stable' } ] }
 			/>
 			<RouterLinkSummaryButton
 				to="/me/security/two-step-auth/sms"

--- a/client/dashboard/me/security-two-step-auth/summary.tsx
+++ b/client/dashboard/me/security-two-step-auth/summary.tsx
@@ -21,14 +21,14 @@ export default function SecurityTwoStepAuthSummary( { density }: { density?: Den
 	const badges: SummaryButtonBadgeProps[] = [
 		{
 			text: two_step_enabled ? __( 'Enabled' ) : __( 'Not enabled' ),
-			intent: two_step_enabled ? 'success' : 'warning',
+			intent: two_step_enabled ? 'stable' : 'medium',
 		},
 	];
 
 	if ( two_step_enabled && ! two_step_backup_codes_printed ) {
 		badges.push( {
 			text: __( 'Backup codes not printed' ),
-			intent: 'warning',
+			intent: 'medium',
 		} );
 	}
 

--- a/client/dashboard/sites/settings-agency/summary.tsx
+++ b/client/dashboard/sites/settings-agency/summary.tsx
@@ -40,7 +40,7 @@ export default function AgencySettingsSummary( {
 					  }
 					: {
 							text: __( 'WordPress.com features enabled' ),
-							intent: 'info',
+							intent: 'informational',
 					  },
 			] }
 		/>

--- a/client/dashboard/sites/settings-ai-tools/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/index.tsx
@@ -81,11 +81,11 @@ interface McpAbility {
 
 function getReadBadge( tools: Array< [ string, McpAbility ] > ) {
 	if ( tools.length === 0 ) {
-		return { text: __( 'All enabled' ), intent: 'success' as const };
+		return { text: __( 'All enabled' ), intent: 'stable' as const };
 	}
 	const enabledCount = tools.filter( ( [ , tool ] ) => tool.enabled ).length;
 	if ( enabledCount === tools.length ) {
-		return { text: __( 'All enabled' ), intent: 'success' as const };
+		return { text: __( 'All enabled' ), intent: 'stable' as const };
 	}
 	if ( enabledCount === 0 ) {
 		return { text: __( 'Disabled' ) };
@@ -93,17 +93,17 @@ function getReadBadge( tools: Array< [ string, McpAbility ] > ) {
 	return {
 		/* translators: %1$d is the number of enabled tools, %2$d is the total number of tools */
 		text: sprintf( __( '%1$d of %2$d enabled' ), enabledCount, tools.length ),
-		intent: 'info' as const,
+		intent: 'informational' as const,
 	};
 }
 
 function getWriteBadge( tools: Array< [ string, McpAbility ] > ) {
 	if ( tools.length === 0 ) {
-		return { text: __( 'All enabled' ), intent: 'success' as const };
+		return { text: __( 'All enabled' ), intent: 'stable' as const };
 	}
 	const enabledCount = tools.filter( ( [ , tool ] ) => tool.enabled ).length;
 	if ( enabledCount === tools.length ) {
-		return { text: __( 'All enabled' ), intent: 'success' as const };
+		return { text: __( 'All enabled' ), intent: 'stable' as const };
 	}
 	if ( enabledCount === 0 ) {
 		return { text: __( 'Disabled' ) };
@@ -111,7 +111,7 @@ function getWriteBadge( tools: Array< [ string, McpAbility ] > ) {
 	return {
 		/* translators: %1$d is the number of enabled tools, %2$d is the total number of tools */
 		text: sprintf( __( '%1$d of %2$d enabled' ), enabledCount, tools.length ),
-		intent: 'info' as const,
+		intent: 'informational' as const,
 	};
 }
 
@@ -123,7 +123,7 @@ const features = [
 ];
 
 const upgradeRequiredText = __( 'Upgrade your plan to enable this setting.' );
-const upgradeRequiredBadge = { text: __( 'Upgrade required' ), intent: 'info' as const };
+const upgradeRequiredBadge = { text: __( 'Upgrade required' ), intent: 'informational' as const };
 
 function UpgradeRequiredBadge() {
 	return (
@@ -300,7 +300,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 	const hasSiteAbilityOverrides = Object.keys( siteAbilities ).length > 0;
 	const defaultToolEnabled = userSettings?.mcp_abilities?.site_level_enabled_default ?? false;
 	const defaultBadge = defaultToolEnabled
-		? { text: __( 'All enabled' ), intent: 'success' as const }
+		? { text: __( 'All enabled' ), intent: 'stable' as const }
 		: { text: __( 'Disabled' ) };
 	const readBadge = hasSiteAbilityOverrides ? getReadBadge( readTools ) : defaultBadge;
 	const writeBadge = hasSiteAbilityOverrides ? getWriteBadge( writeTools ) : defaultBadge;

--- a/client/dashboard/sites/settings-ai-tools/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/index.tsx
@@ -88,7 +88,7 @@ function getReadBadge( tools: Array< [ string, McpAbility ] > ) {
 		return { text: __( 'All enabled' ), intent: 'stable' as const };
 	}
 	if ( enabledCount === 0 ) {
-		return { text: __( 'Disabled' ) };
+		return { text: __( 'Disabled' ), intent: 'draft' as const };
 	}
 	return {
 		/* translators: %1$d is the number of enabled tools, %2$d is the total number of tools */
@@ -106,7 +106,7 @@ function getWriteBadge( tools: Array< [ string, McpAbility ] > ) {
 		return { text: __( 'All enabled' ), intent: 'stable' as const };
 	}
 	if ( enabledCount === 0 ) {
-		return { text: __( 'Disabled' ) };
+		return { text: __( 'Disabled' ), intent: 'draft' as const };
 	}
 	return {
 		/* translators: %1$d is the number of enabled tools, %2$d is the total number of tools */
@@ -301,7 +301,7 @@ export default function AIToolsSettings( { siteSlug }: { siteSlug: string } ) {
 	const defaultToolEnabled = userSettings?.mcp_abilities?.site_level_enabled_default ?? false;
 	const defaultBadge = defaultToolEnabled
 		? { text: __( 'All enabled' ), intent: 'stable' as const }
-		: { text: __( 'Disabled' ) };
+		: { text: __( 'Disabled' ), intent: 'draft' as const };
 	const readBadge = hasSiteAbilityOverrides ? getReadBadge( readTools ) : defaultBadge;
 	const writeBadge = hasSiteAbilityOverrides ? getWriteBadge( writeTools ) : defaultBadge;
 	const mcpMutation = useMutation(

--- a/client/dashboard/sites/settings-ai-tools/summary.tsx
+++ b/client/dashboard/sites/settings-ai-tools/summary.tsx
@@ -29,7 +29,7 @@ export default function AISiteToolsSettingsSummary( {
 			return [
 				{
 					text: __( 'Enabled' ),
-					intent: 'success' as const,
+					intent: 'stable' as const,
 				},
 			];
 		}

--- a/client/dashboard/sites/settings-apm/summary.tsx
+++ b/client/dashboard/sites/settings-apm/summary.tsx
@@ -18,7 +18,7 @@ export default function ApmSettingsSummary( { site, density }: { site: Site; den
 			return [
 				{
 					text: __( 'Enabled' ),
-					intent: 'success' as const,
+					intent: 'stable' as const,
 				},
 			];
 		}

--- a/client/dashboard/sites/settings-caching/summary.tsx
+++ b/client/dashboard/sites/settings-caching/summary.tsx
@@ -33,7 +33,7 @@ export default function CachingSettingsSummary( {
 			return [
 				{
 					text: __( 'Edge cache enabled' ),
-					intent: 'success' as const,
+					intent: 'stable' as const,
 				},
 			];
 		}

--- a/client/dashboard/sites/settings-crontab/summary.tsx
+++ b/client/dashboard/sites/settings-crontab/summary.tsx
@@ -42,7 +42,7 @@ export default function CrontabSettingsSummary( {
 							crontabCount
 					  )
 					: __( 'No scheduled jobs' ),
-			intent: crontabCount > 0 ? ( 'stable' as const ) : undefined,
+			intent: crontabCount > 0 ? ( 'stable' as const ) : ( 'draft' as const ),
 		},
 	].filter( ( badge ) => !! badge );
 

--- a/client/dashboard/sites/settings-crontab/summary.tsx
+++ b/client/dashboard/sites/settings-crontab/summary.tsx
@@ -42,7 +42,7 @@ export default function CrontabSettingsSummary( {
 							crontabCount
 					  )
 					: __( 'No scheduled jobs' ),
-			intent: crontabCount > 0 ? ( 'success' as const ) : undefined,
+			intent: crontabCount > 0 ? ( 'stable' as const ) : undefined,
 		},
 	].filter( ( badge ) => !! badge );
 

--- a/client/dashboard/sites/settings-defensive-mode/summary.tsx
+++ b/client/dashboard/sites/settings-defensive-mode/summary.tsx
@@ -32,7 +32,7 @@ export default function DefensiveModeSettingsSummary( {
 			return [
 				{
 					text: __( 'Enabled' ),
-					intent: 'info' as const,
+					intent: 'informational' as const,
 				},
 			];
 		}

--- a/client/dashboard/sites/settings-hundred-year-plan/summary.tsx
+++ b/client/dashboard/sites/settings-hundred-year-plan/summary.tsx
@@ -26,7 +26,9 @@ export default function HundredYearPlanSummary( {
 			density={ density }
 			decoration={ <Icon icon={ institution } /> }
 			badges={
-				settings.wpcom_locked_mode ? [ { text: __( 'Site locked' ), intent: 'info' as const } ] : []
+				settings.wpcom_locked_mode
+					? [ { text: __( 'Site locked' ), intent: 'informational' as const } ]
+					: []
 			}
 		/>
 	);

--- a/client/dashboard/sites/settings-php/summary.tsx
+++ b/client/dashboard/sites/settings-php/summary.tsx
@@ -27,8 +27,8 @@ export default function PHPSettingsSummary( { site, density }: { site: Site; den
 			{
 				text: version,
 				intent: versionCompare( version, recommendedValue, '>=' )
-					? ( 'success' as const )
-					: ( 'warning' as const ),
+					? ( 'stable' as const )
+					: ( 'low' as const ),
 			},
 		];
 	};

--- a/client/dashboard/sites/settings-redirect/summary.tsx
+++ b/client/dashboard/sites/settings-redirect/summary.tsx
@@ -18,7 +18,7 @@ export default function SiteRedirectSettingsSummary( {
 	}
 	let badges = [];
 	if ( site.options?.is_redirect ) {
-		badges = [ { text: __( 'Enabled' ), intent: 'success' as const } ];
+		badges = [ { text: __( 'Enabled' ), intent: 'stable' as const } ];
 	} else {
 		badges = [ { text: __( 'Disabled' ) } ];
 	}

--- a/client/dashboard/sites/settings-redirect/summary.tsx
+++ b/client/dashboard/sites/settings-redirect/summary.tsx
@@ -20,7 +20,7 @@ export default function SiteRedirectSettingsSummary( {
 	if ( site.options?.is_redirect ) {
 		badges = [ { text: __( 'Enabled' ), intent: 'stable' as const } ];
 	} else {
-		badges = [ { text: __( 'Disabled' ), intent: 'none' as const } ];
+		badges = [ { text: __( 'Disabled' ), intent: 'draft' as const } ];
 	}
 
 	return (

--- a/client/dashboard/sites/settings-redirect/summary.tsx
+++ b/client/dashboard/sites/settings-redirect/summary.tsx
@@ -20,7 +20,7 @@ export default function SiteRedirectSettingsSummary( {
 	if ( site.options?.is_redirect ) {
 		badges = [ { text: __( 'Enabled' ), intent: 'stable' as const } ];
 	} else {
-		badges = [ { text: __( 'Disabled' ) } ];
+		badges = [ { text: __( 'Disabled' ), intent: 'none' as const } ];
 	}
 
 	return (

--- a/client/dashboard/sites/settings-sftp-ssh/summary.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/summary.tsx
@@ -36,11 +36,11 @@ export default function SftpSshSettingsSummary( {
 	const badges = [
 		hasSftpFeature && {
 			text: sftpEnabled ? __( 'SFTP enabled' ) : __( 'SFTP disabled' ),
-			intent: sftpEnabled ? ( 'stable' as const ) : undefined,
+			intent: sftpEnabled ? ( 'stable' as const ) : ( 'draft' as const ),
 		},
 		hasSshFeature && {
 			text: sshEnabled ? __( 'SSH enabled' ) : __( 'SSH disabled' ),
-			intent: sshEnabled ? ( 'stable' as const ) : undefined,
+			intent: sshEnabled ? ( 'stable' as const ) : ( 'draft' as const ),
 		},
 	].filter( ( badge ) => !! badge );
 

--- a/client/dashboard/sites/settings-sftp-ssh/summary.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/summary.tsx
@@ -36,11 +36,11 @@ export default function SftpSshSettingsSummary( {
 	const badges = [
 		hasSftpFeature && {
 			text: sftpEnabled ? __( 'SFTP enabled' ) : __( 'SFTP disabled' ),
-			intent: sftpEnabled ? ( 'success' as const ) : undefined,
+			intent: sftpEnabled ? ( 'stable' as const ) : undefined,
 		},
 		hasSshFeature && {
 			text: sshEnabled ? __( 'SSH enabled' ) : __( 'SSH disabled' ),
-			intent: sshEnabled ? ( 'success' as const ) : undefined,
+			intent: sshEnabled ? ( 'stable' as const ) : undefined,
 		},
 	].filter( ( badge ) => !! badge );
 

--- a/client/dashboard/sites/settings-site-visibility/summary.tsx
+++ b/client/dashboard/sites/settings-site-visibility/summary.tsx
@@ -19,9 +19,9 @@ export default function SiteVisibilitySettingsSummary( {
 
 	let badges = [];
 	if ( site.launch_status === 'unlaunched' || site.is_coming_soon ) {
-		badges = [ { text: __( 'Coming soon' ), intent: 'informational' as const } ];
+		badges = [ { text: __( 'Coming soon' ), intent: 'low' as const } ];
 	} else if ( site.is_private ) {
-		badges = [ { text: __( 'Private' ) } ];
+		badges = [ { text: __( 'Private' ), intent: 'informational' as const } ];
 	} else {
 		badges = [ { text: __( 'Public' ), intent: 'stable' as const } ];
 	}

--- a/client/dashboard/sites/settings-site-visibility/summary.tsx
+++ b/client/dashboard/sites/settings-site-visibility/summary.tsx
@@ -19,11 +19,11 @@ export default function SiteVisibilitySettingsSummary( {
 
 	let badges = [];
 	if ( site.launch_status === 'unlaunched' || site.is_coming_soon ) {
-		badges = [ { text: __( 'Coming soon' ), intent: 'warning' as const } ];
+		badges = [ { text: __( 'Coming soon' ), intent: 'informational' as const } ];
 	} else if ( site.is_private ) {
 		badges = [ { text: __( 'Private' ) } ];
 	} else {
-		badges = [ { text: __( 'Public' ), intent: 'success' as const } ];
+		badges = [ { text: __( 'Public' ), intent: 'stable' as const } ];
 	}
 
 	return (

--- a/client/dashboard/sites/settings-subscription-gifting/summary.tsx
+++ b/client/dashboard/sites/settings-subscription-gifting/summary.tsx
@@ -22,7 +22,7 @@ export default function SubscriptionGiftingSettingsSummary( {
 
 	const badges = settings.wpcom_gifting_subscription
 		? [ { text: __( 'Enabled' ), intent: 'stable' as const } ]
-		: [ { text: __( 'Disabled' ) } ];
+		: [ { text: __( 'Disabled' ), intent: 'draft' as const } ];
 
 	return (
 		<RouterLinkSummaryButton

--- a/client/dashboard/sites/settings-subscription-gifting/summary.tsx
+++ b/client/dashboard/sites/settings-subscription-gifting/summary.tsx
@@ -21,7 +21,7 @@ export default function SubscriptionGiftingSettingsSummary( {
 	}
 
 	const badges = settings.wpcom_gifting_subscription
-		? [ { text: __( 'Enabled' ), intent: 'success' as const } ]
+		? [ { text: __( 'Enabled' ), intent: 'stable' as const } ]
 		: [ { text: __( 'Disabled' ) } ];
 
 	return (

--- a/client/dashboard/sites/settings-wordpress/summary.tsx
+++ b/client/dashboard/sites/settings-wordpress/summary.tsx
@@ -30,7 +30,7 @@ export default function WordPressSettingsSummary( {
 	const badges = [
 		{
 			text: wpVersion,
-			intent: versionTag === 'beta' ? ( 'warning' as const ) : ( 'success' as const ),
+			intent: versionTag === 'beta' ? ( 'informational' as const ) : ( 'stable' as const ),
 		},
 	];
 

--- a/client/dashboard/sites/settings-wpcom-login/summary.tsx
+++ b/client/dashboard/sites/settings-wpcom-login/summary.tsx
@@ -44,7 +44,7 @@ export default function WpcomLoginSettingsSummary( {
 		badges = [ { text: __( 'Unavailable' ) } ];
 	} else if ( ! isSimple( site ) && hasHostingFeature( site, HostingFeatures.SECURITY_SETTINGS ) ) {
 		badges = ssoEnabled
-			? [ { text: __( 'Enabled' ), intent: 'success' as const } ]
+			? [ { text: __( 'Enabled' ), intent: 'stable' as const } ]
 			: [ { text: __( 'Disabled' ) } ];
 	}
 

--- a/client/dashboard/sites/settings-wpcom-login/summary.tsx
+++ b/client/dashboard/sites/settings-wpcom-login/summary.tsx
@@ -41,11 +41,11 @@ export default function WpcomLoginSettingsSummary( {
 	let badges;
 	// Don't show any badge for Simple sites.
 	if ( ! isSimple( site ) && ! ssoAvailable ) {
-		badges = [ { text: __( 'Unavailable' ) } ];
+		badges = [ { text: __( 'Unavailable' ), intent: 'draft' as const } ];
 	} else if ( ! isSimple( site ) && hasHostingFeature( site, HostingFeatures.SECURITY_SETTINGS ) ) {
 		badges = ssoEnabled
 			? [ { text: __( 'Enabled' ), intent: 'stable' as const } ]
-			: [ { text: __( 'Disabled' ) } ];
+			: [ { text: __( 'Disabled' ), intent: 'draft' as const } ];
 	}
 
 	return (

--- a/client/me/mcp/hub-helpers.js
+++ b/client/me/mcp/hub-helpers.js
@@ -3,23 +3,23 @@
  * @param {number} enabledCount
  * @param {number} total
  * @param {(text: string, options?: { args?: Record<string, number> }) => string} translate
- * @returns {{ text: string, intent?: 'default' | 'success' | 'warning' }}
+ * @returns {{ text: string, intent?: 'none' | 'stable' | 'informational' }}
  */
 export function getAccessSummaryBadge( enabledCount, total, translate ) {
 	if ( total === 0 ) {
-		return { text: translate( 'None' ), intent: 'default' };
+		return { text: translate( 'None' ), intent: 'none' };
 	}
 	if ( enabledCount === 0 ) {
-		return { text: translate( 'None enabled' ), intent: 'default' };
+		return { text: translate( 'None enabled' ), intent: 'none' };
 	}
 	if ( enabledCount === total ) {
-		return { text: translate( 'All enabled' ), intent: 'success' };
+		return { text: translate( 'All enabled' ), intent: 'stable' };
 	}
 	return {
 		text: translate( '%(enabled)d of %(total)d enabled', {
 			args: { enabled: enabledCount, total },
 		} ),
-		intent: 'info',
+		intent: 'informational',
 	};
 }
 
@@ -28,22 +28,22 @@ export function getAccessSummaryBadge( enabledCount, total, translate ) {
  * @param {number} enabledCount
  * @param {number} total
  * @param {(text: string, options?: { args?: Record<string, number> }) => string} translate
- * @returns {{ text: string, intent?: 'default' | 'success' | 'warning' }}
+ * @returns {{ text: string, intent?: 'none' | 'stable' | 'informational' }}
  */
 export function getWriteAccessBadge( enabledCount, total, translate ) {
 	if ( total === 0 ) {
-		return { text: translate( 'None' ), intent: 'default' };
+		return { text: translate( 'None' ), intent: 'none' };
 	}
 	if ( enabledCount === 0 ) {
-		return { text: translate( 'Disabled' ), intent: 'default' };
+		return { text: translate( 'Disabled' ), intent: 'none' };
 	}
 	if ( enabledCount === total ) {
-		return { text: translate( 'All enabled' ), intent: 'success' };
+		return { text: translate( 'All enabled' ), intent: 'stable' };
 	}
 	return {
 		text: translate( '%(enabled)d of %(total)d enabled', {
 			args: { enabled: enabledCount, total },
 		} ),
-		intent: 'info',
+		intent: 'informational',
 	};
 }

--- a/client/me/mcp/hub-helpers.js
+++ b/client/me/mcp/hub-helpers.js
@@ -3,14 +3,14 @@
  * @param {number} enabledCount
  * @param {number} total
  * @param {(text: string, options?: { args?: Record<string, number> }) => string} translate
- * @returns {{ text: string, intent?: 'none' | 'stable' | 'informational' }}
+ * @returns {{ text: string, intent?: 'draft' | 'stable' | 'informational' }}
  */
 export function getAccessSummaryBadge( enabledCount, total, translate ) {
 	if ( total === 0 ) {
-		return { text: translate( 'None' ), intent: 'none' };
+		return { text: translate( 'None' ), intent: 'draft' };
 	}
 	if ( enabledCount === 0 ) {
-		return { text: translate( 'None enabled' ), intent: 'none' };
+		return { text: translate( 'None enabled' ), intent: 'draft' };
 	}
 	if ( enabledCount === total ) {
 		return { text: translate( 'All enabled' ), intent: 'stable' };
@@ -28,14 +28,14 @@ export function getAccessSummaryBadge( enabledCount, total, translate ) {
  * @param {number} enabledCount
  * @param {number} total
  * @param {(text: string, options?: { args?: Record<string, number> }) => string} translate
- * @returns {{ text: string, intent?: 'none' | 'stable' | 'informational' }}
+ * @returns {{ text: string, intent?: 'draft' | 'stable' | 'informational' }}
  */
 export function getWriteAccessBadge( enabledCount, total, translate ) {
 	if ( total === 0 ) {
-		return { text: translate( 'None' ), intent: 'none' };
+		return { text: translate( 'None' ), intent: 'draft' };
 	}
 	if ( enabledCount === 0 ) {
-		return { text: translate( 'Disabled' ), intent: 'none' };
+		return { text: translate( 'Disabled' ), intent: 'draft' };
 	}
 	if ( enabledCount === total ) {
 		return { text: translate( 'All enabled' ), intent: 'stable' };

--- a/client/me/mcp/main.jsx
+++ b/client/me/mcp/main.jsx
@@ -198,7 +198,7 @@ function McpComponent( { path } ) {
 									decoration={
 										<Icon className="mcp-hub__summary-icon" icon={ connection } size={ 24 } />
 									}
-									badges={ [ { text: mcpAddSiteBadgeText } ] }
+									badges={ [ { text: mcpAddSiteBadgeText, intent: 'draft' } ] }
 									density="medium"
 								/>
 							) }
@@ -231,7 +231,7 @@ function McpComponent( { path } ) {
 							badges={
 								disabledSiteCount > 0
 									? [ { text: mcpSiteExceptionsBadgeText, intent: 'low' } ]
-									: [ { text: translate( 'No exceptions' ) } ]
+									: [ { text: translate( 'No exceptions' ), intent: 'draft' } ]
 							}
 							density="medium"
 						/>

--- a/client/me/mcp/main.jsx
+++ b/client/me/mcp/main.jsx
@@ -230,7 +230,7 @@ function McpComponent( { path } ) {
 							}
 							badges={
 								disabledSiteCount > 0
-									? [ { text: mcpSiteExceptionsBadgeText, intent: 'warning' } ]
+									? [ { text: mcpSiteExceptionsBadgeText, intent: 'low' } ]
 									: [ { text: translate( 'No exceptions' ) } ]
 							}
 							density="medium"

--- a/packages/components/src/summary-button/index.stories.tsx
+++ b/packages/components/src/summary-button/index.stories.tsx
@@ -7,15 +7,15 @@ import SummaryButton from './index';
 // Define field options for the controls.
 const badgeOptions: Record< string, SummaryButtonBadgeProps[] > = {
 	'Three Badges': [
-		{ text: 'Active', intent: 'success' },
-		{ text: 'Auto-renew on', intent: 'info' },
-		{ text: 'Primary', intent: 'default' },
+		{ text: 'Active', intent: 'stable' },
+		{ text: 'Auto-renew on', intent: 'informational' },
+		{ text: 'Primary', intent: 'none' },
 	],
 	'Two Badges': [
-		{ text: 'Needs attention', intent: 'warning' },
-		{ text: 'Auto-renew off', intent: 'error' },
+		{ text: 'Needs attention', intent: 'medium' },
+		{ text: 'Auto-renew off', intent: 'high' },
 	],
-	'One Badge': [ { text: 'Coming soon', intent: 'info' } ],
+	'One Badge': [ { text: 'Coming soon', intent: 'informational' } ],
 	'No Badges': [],
 };
 

--- a/packages/components/src/summary-button/index.stories.tsx
+++ b/packages/components/src/summary-button/index.stories.tsx
@@ -9,7 +9,7 @@ const badgeOptions: Record< string, SummaryButtonBadgeProps[] > = {
 	'Three Badges': [
 		{ text: 'Active', intent: 'stable' },
 		{ text: 'Auto-renew on', intent: 'informational' },
-		{ text: 'Primary', intent: 'none' },
+		{ text: 'Primary', intent: 'draft' },
 	],
 	'Two Badges': [
 		{ text: 'Needs attention', intent: 'medium' },

--- a/packages/components/src/summary-button/index.tsx
+++ b/packages/components/src/summary-button/index.tsx
@@ -1,4 +1,3 @@
-import { Badge } from '@automattic/ui';
 import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
@@ -8,6 +7,7 @@ import {
 } from '@wordpress/components';
 import { isRTL } from '@wordpress/i18n';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
+import { Badge } from '@wordpress/ui';
 import clsx from 'clsx';
 import React, { forwardRef } from 'react';
 import { SummaryButtonProps } from './types';

--- a/packages/components/src/summary-button/index.tsx
+++ b/packages/components/src/summary-button/index.tsx
@@ -27,7 +27,7 @@ function BadgeList( { badges }: { badges: SummaryButtonProps[ 'badges' ] } ) {
 			className="summary-button-badge-list"
 		>
 			{ badges?.map( ( badge ) => (
-				<Badge key={ badge.text } intent={ badge.intent }>
+				<Badge key={ badge.text } intent={ badge.intent ?? 'draft' }>
 					{ badge.text }
 				</Badge>
 			) ) }

--- a/packages/components/src/summary-button/types.ts
+++ b/packages/components/src/summary-button/types.ts
@@ -14,7 +14,7 @@ export type SummaryButtonBadgeProps = {
 	text: string;
 	/**
 	 * Optional property to specify the intent of the badge.
-	 * @default 'default'
+	 * @default 'none'
 	 */
 	intent?: React.ComponentProps< typeof Badge >[ 'intent' ];
 };

--- a/packages/components/src/summary-button/types.ts
+++ b/packages/components/src/summary-button/types.ts
@@ -1,4 +1,4 @@
-import type { Badge } from '@automattic/ui';
+import type { Badge } from '@wordpress/ui';
 
 export type Density = 'low' | 'medium-low' | 'medium';
 

--- a/packages/components/src/summary-button/types.ts
+++ b/packages/components/src/summary-button/types.ts
@@ -14,7 +14,7 @@ export type SummaryButtonBadgeProps = {
 	text: string;
 	/**
 	 * Optional property to specify the intent of the badge.
-	 * @default 'none'
+	 * @default 'draft'
 	 */
 	intent?: React.ComponentProps< typeof Badge >[ 'intent' ];
 };


### PR DESCRIPTION
Pre-requirement for removal of the Badge from `@automattic/ui` as we're now focusing on `@wordpress/ui` [Badge](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-badge-usage-guidelines--docs).

Part of https://github.com/Automattic/wp-calypso/issues/113835

## Proposed Changes

* Replace `@automattic/ui` `Badge` imports with `@wordpress/ui` `Badge` `SummaryButton` component, which in turn is used around MSD.

## Why are these changes being made?

* `Badge` is being removed from `@automattic/ui`, so dashboard domains need to consume `Badge` from `@wordpress/ui`.

## Testing Instructions

* Verify SummaryButton badges still render correctly in used places.

### Before

#### Domain settings
<img width="702" height="290" alt="image" src="https://github.com/user-attachments/assets/c362c709-247f-4212-b001-1155ef0a6fc0" />
<img width="695" height="291" alt="image" src="https://github.com/user-attachments/assets/8b36d96e-5354-4b0e-83f9-042035185287" />
<img width="713" height="279" alt="image" src="https://github.com/user-attachments/assets/c281d0ad-8321-4913-b1aa-321c9418cce0" />

#### Settings
<img width="713" height="397" alt="image" src="https://github.com/user-attachments/assets/5849d4b0-2be4-41f1-b9ce-6aaf4b3944ad" />

#### Me → Security
<img width="729" height="531" alt="image" src="https://github.com/user-attachments/assets/a819e259-b0d3-416a-8ad0-311fee8cdee8" />


### After
#### Domain settings
<img width="688" height="277" alt="image" src="https://github.com/user-attachments/assets/cf75a125-1551-477f-9315-759436ddf176" />
<img width="708" height="307" alt="image" src="https://github.com/user-attachments/assets/55ade0b1-b80a-4be1-97fe-f48c7ff4fa11" />
<img width="734" height="317" alt="image" src="https://github.com/user-attachments/assets/e3b74df7-014a-46a7-ae17-32fefffc5a7c" />

#### Settings
<img width="707" height="589" alt="image" src="https://github.com/user-attachments/assets/ed4d06ab-299f-4ba6-8790-03ec01f8218f" />


#### Me → Security
<img width="690" height="533" alt="image" src="https://github.com/user-attachments/assets/428e17f7-3771-4c02-8838-493946550b67" />
