### PR TITLE
Revert AI builder entry points from Vega flow

### DIFF
--- a/client/components/sites-add-new-site/index.tsx
+++ b/client/components/sites-add-new-site/index.tsx
@@ -1,7 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Dropdown } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { AI_SITE_BUILDER_SPEC_FLOW } from 'calypso/lib/site-spec';
 import { AuthProvider } from '../../dashboard/app/auth';
 import { AsyncContent } from './async';
 import AddNewSiteButton from './button';
@@ -33,10 +32,7 @@ export const SitesAddNewSitePopover = ( { showCompact, context }: Props ) => {
 				) }
 				renderContent={ () => (
 					<div className="sites-add-new-site__popover-content">
-						<AsyncContent
-							context={ context }
-							aiSiteBuilderPath={ `/setup/${ AI_SITE_BUILDER_SPEC_FLOW }` }
-						/>
+						<AsyncContent context={ context } aiSiteBuilderPath="/setup/ai-site-builder" />
 					</div>
 				) }
 				onToggle={ ( isOpen ) => {

--- a/client/dashboard/sites/add-new-site/index.tsx
+++ b/client/dashboard/sites/add-new-site/index.tsx
@@ -16,7 +16,6 @@ import { useHelpCenter } from '../../app/help-center';
 import OfferCard from '../../components/offer-card';
 import { wpcomLink } from '../../utils/link';
 import { userHasFlag } from '../../utils/user';
-import { AI_SITE_BUILDER_SPEC_FLOW } from '../ai-site-builder-spec-flow';
 import Column from './column';
 import MenuItem from './menu-item';
 import type { AddNewSiteProps } from './types';
@@ -24,7 +23,7 @@ import './style.scss';
 
 function AddNewSite( {
 	context = 'unknown',
-	aiSiteBuilderPath = `/setup/${ AI_SITE_BUILDER_SPEC_FLOW }`,
+	aiSiteBuilderPath = '/setup/ai-site-builder',
 }: AddNewSiteProps ) {
 	const { recordTracksEvent } = useAnalytics();
 	const auth = useContext( AuthContext );

--- a/client/dashboard/sites/ai-site-builder-spec-flow.ts
+++ b/client/dashboard/sites/ai-site-builder-spec-flow.ts
@@ -1,5 +1,0 @@
-/**
- * Keep in sync with `AI_SITE_BUILDER_SPEC_FLOW` in `@automattic/onboarding`.
- * The dashboard tree cannot import from `@automattic/*` packages.
- */
-export const AI_SITE_BUILDER_SPEC_FLOW = 'ai-site-builder-spec';

--- a/client/dashboard/sites/empty-sites-state/index.tsx
+++ b/client/dashboard/sites/empty-sites-state/index.tsx
@@ -8,7 +8,6 @@ import { useAnalytics } from '../../app/analytics';
 import EmptyState from '../../components/empty-state';
 import OfferCard from '../../components/offer-card';
 import { wpcomLink } from '../../utils/link';
-import { AI_SITE_BUILDER_SPEC_FLOW } from '../ai-site-builder-spec-flow';
 
 const CONTEXT = 'dashboard-sites';
 const EMPTY_STATE_REF = 'dashboard-sites-empty-state';
@@ -57,7 +56,7 @@ function CreateAndBuildActions() {
 				actions={
 					<Button
 						variant="secondary"
-						href={ addQueryArgs( wpcomLink( `/setup/${ AI_SITE_BUILDER_SPEC_FLOW }` ), {
+						href={ addQueryArgs( wpcomLink( '/setup/ai-site-builder' ), {
 							source: CONTEXT,
 							ref: EMPTY_STATE_REF,
 						} ) }

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -26,7 +26,6 @@ import { PageHeader } from '../components/page-header';
 import PageLayout from '../components/page-layout';
 import { isDashboardBackport } from '../utils/is-dashboard-backport';
 import AddNewSite from './add-new-site';
-import { AI_SITE_BUILDER_SPEC_FLOW } from './ai-site-builder-spec-flow';
 import {
 	SitesDataViews,
 	useActions,
@@ -217,10 +216,7 @@ export default function Sites() {
 			<InviteAcceptedFlashMessage />
 			{ isModalOpen && (
 				<Modal title={ __( 'Add new site' ) } onRequestClose={ () => setIsModalOpen( false ) }>
-					<AddNewSite
-						context="sites-dashboard"
-						aiSiteBuilderPath={ `/setup/${ AI_SITE_BUILDER_SPEC_FLOW }` }
-					/>
+					<AddNewSite context="sites-dashboard" aiSiteBuilderPath="/setup/ai-site-builder" />
 				</Modal>
 			) }
 			<PageLayout

--- a/client/dashboard/sites/site-switcher/index.tsx
+++ b/client/dashboard/sites/site-switcher/index.tsx
@@ -10,7 +10,6 @@ import { plus } from '@wordpress/icons';
 import { useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import AddNewSite from '../add-new-site';
-import { AI_SITE_BUILDER_SPEC_FLOW } from '../ai-site-builder-spec-flow';
 import { SiteSwitcherBase } from './base';
 import type { SiteSwitcherProps } from './types';
 
@@ -42,10 +41,7 @@ const SiteSwitcher = ( props: SiteSwitcherProps ) => {
 					title={ __( 'Add new site' ) }
 					onRequestClose={ () => setIsAddSiteModalOpen( false ) }
 				>
-					<AddNewSite
-						context="sites-dashboard"
-						aiSiteBuilderPath={ `/setup/${ AI_SITE_BUILDER_SPEC_FLOW }` }
-					/>
+					<AddNewSite context="sites-dashboard" aiSiteBuilderPath="/setup/ai-site-builder" />
 				</Modal>
 			) }
 		</>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
@@ -1,12 +1,11 @@
 import config from '@automattic/calypso-config';
 import { getSessionId as getPostHogSessionId } from '@automattic/posthog';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useRef } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSpec } from 'calypso/lib/site-spec';
 import { getCiabSiteSpecConfig, type SiteSpecConfig } from 'calypso/lib/site-spec/utils';
-import { getVegaSiteSpecConfig } from 'calypso/lib/site-spec/vega';
 import wpcom from 'calypso/lib/wp';
 import type { Step as StepType } from '../../types';
 
@@ -98,8 +97,6 @@ const SiteSpec: StepType = function SiteSpec() {
 		window.location.href = url;
 	}, [] );
 
-	const vegaConfig = useMemo( () => getVegaSiteSpecConfig(), [] );
-
 	return (
 		<>
 			<DocumentHead title={ translate( 'Build Your Site with AI' ) } />
@@ -110,7 +107,7 @@ const SiteSpec: StepType = function SiteSpec() {
 					onSpecConfirm={ handleCiabSpecConfirm }
 				/>
 			) : (
-				<SiteSpecContainer siteSpecConfig={ vegaConfig } />
+				<SiteSpecContainer />
 			) }
 		</>
 	);

--- a/client/lib/site-spec/index.ts
+++ b/client/lib/site-spec/index.ts
@@ -1,3 +1,2 @@
-export const AI_SITE_BUILDER_SPEC_FLOW = 'ai-site-builder-spec';
 export { useSiteSpec } from './use-site-spec';
 export { VEGA_AGENT_ID, getVegaSiteSpecConfig } from './vega';


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #

## Proposed Changes

* Point the general add-site AI entry points back to `/setup/ai-site-builder`.
* Stop passing the Vega SiteSpec config for the non-CIAB SiteSpec step so it falls back to the default SiteSpec config.
* Remove the now-unused Dashboard `ai-site-builder-spec` helper and SiteSpec lib re-export.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The general AI site builder entry points should return to the non-Vega flow. CIAB/store-specific paths remain on the SiteSpec flow because they use the Woo/CIAB setup.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm with search that general add-site Dashboard paths no longer reference `AI_SITE_BUILDER_SPEC_FLOW` or `/setup/ai-site-builder-spec`.
* Confirmed with search that active Stepper/Dashboard/add-site code no longer references `getVegaSiteSpecConfig`, `VEGA_AGENT_ID`, or `vega-site-spec`.
* Test that a non-a11n, non-proxied user can add new sites via Big Sky without having to select a domain

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
