### PR TITLE
A4A + Jetpack Cloud: React 19 forward-compatible types

### DIFF
--- a/client/a8c-for-agencies/components/a4a-popover/menu-item.tsx
+++ b/client/a8c-for-agencies/components/a4a-popover/menu-item.tsx
@@ -2,6 +2,7 @@ import { Button } from '@wordpress/components';
 import { Icon } from '@wordpress/icons';
 import clsx from 'clsx';
 import { TranslateResult } from 'i18n-calypso';
+import type { JSX } from 'react';
 
 import './style.scss';
 

--- a/client/a8c-for-agencies/components/a4a-select-site/site-table.tsx
+++ b/client/a8c-for-agencies/components/a4a-select-site/site-table.tsx
@@ -37,7 +37,7 @@ const A4ASelectSiteTable = ( {
 		[ dispatch, setSelectedSite ]
 	);
 
-	const prevSelectedSiteId = useRef< number | undefined >();
+	const prevSelectedSiteId = useRef< number | undefined >( undefined );
 
 	// Only update when selectedSiteId actually changes, not when items array is recreated
 	useEffect( () => {

--- a/client/a8c-for-agencies/components/add-new-site-button/index.tsx
+++ b/client/a8c-for-agencies/components/add-new-site-button/index.tsx
@@ -4,7 +4,7 @@ import { Button as WPButton } from '@wordpress/components';
 import { Icon } from '@wordpress/icons';
 import clsx from 'clsx';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
-import { useRef, useState } from 'react';
+import { useRef, useState, type JSX } from 'react';
 import useFetchDevLicenses from 'calypso/a8c-for-agencies/data/purchases/use-fetch-dev-licenses';
 import useFetchPendingSites from 'calypso/a8c-for-agencies/data/sites/use-fetch-pending-sites';
 import usePressableOwnershipType from 'calypso/a8c-for-agencies/sections/marketplace/hosting-overview/hooks/use-pressable-ownership-type';

--- a/client/a8c-for-agencies/components/consolidated-stats-card/index.tsx
+++ b/client/a8c-for-agencies/components/consolidated-stats-card/index.tsx
@@ -14,7 +14,7 @@ import './style.scss';
 interface CardInfoProps {
 	title?: string;
 	children?: React.ReactNode;
-	wrapperRef: React.RefObject< HTMLElement >;
+	wrapperRef: React.RefObject< HTMLElement | null >;
 	footerText: string;
 	footerAction?: React.ReactNode;
 }

--- a/client/a8c-for-agencies/components/foldable-nav/types.ts
+++ b/client/a8c-for-agencies/components/foldable-nav/types.ts
@@ -1,4 +1,5 @@
 import { TranslateResult } from 'i18n-calypso';
+import type { JSX } from 'react';
 
 export interface Props {
 	header: string;

--- a/client/a8c-for-agencies/components/items-dashboard/items-dataviews/index.tsx
+++ b/client/a8c-for-agencies/components/items-dashboard/items-dataviews/index.tsx
@@ -32,7 +32,7 @@ const ItemsDataViews = ( {
 	children,
 }: ItemsDataViewsProps ) => {
 	const translate = useTranslate();
-	const scrollContainerRef = useRef< HTMLElement >();
+	const scrollContainerRef = useRef< HTMLElement >( undefined );
 	const previousDataViewsState = usePrevious( data.dataViewsState );
 
 	useLayoutEffect( () => {

--- a/client/a8c-for-agencies/components/offering/types.ts
+++ b/client/a8c-for-agencies/components/offering/types.ts
@@ -1,3 +1,4 @@
+import type { JSX } from 'react';
 export type OfferingCardProps = {
 	title: string;
 	description: string;

--- a/client/a8c-for-agencies/components/sidebar-menu/lib/utils.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/utils.ts
@@ -1,5 +1,6 @@
 import { itemLinkMatches } from 'calypso/my-sites/sidebar/utils';
 import { A4A_SITES_LINK } from './constants';
+import type { JSX } from 'react';
 
 type MenuItemProps = {
 	id?: string;

--- a/client/a8c-for-agencies/components/sidebar/index.tsx
+++ b/client/a8c-for-agencies/components/sidebar/index.tsx
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import { useBreakpoint } from '@automattic/viewport-react';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
+import { useEffect, type JSX } from 'react';
 import JetpackIcons from 'calypso/components/jetpack/jetpack-icons';
 import Sidebar, {
 	SidebarV2Main as SidebarMain,

--- a/client/a8c-for-agencies/components/step-section-item/index.tsx
+++ b/client/a8c-for-agencies/components/step-section-item/index.tsx
@@ -1,7 +1,7 @@
 import { Button, Badge } from '@automattic/components';
 import { Icon } from '@wordpress/icons';
 import clsx from 'clsx';
-import React from 'react';
+import React, { type JSX } from 'react';
 import { preventWidows } from 'calypso/lib/formatting';
 import StatusBadge from './status-badge';
 import type { TranslateResult } from 'i18n-calypso';

--- a/client/a8c-for-agencies/components/step-section-item/status-badge.tsx
+++ b/client/a8c-for-agencies/components/step-section-item/status-badge.tsx
@@ -1,6 +1,6 @@
 import { Badge, Tooltip } from '@automattic/components';
 import clsx from 'clsx';
-import { useRef, useState, ComponentProps } from 'react';
+import { useRef, useState, ComponentProps, type JSX } from 'react';
 
 import './style.scss';
 

--- a/client/a8c-for-agencies/components/task-steps/index.tsx
+++ b/client/a8c-for-agencies/components/task-steps/index.tsx
@@ -2,7 +2,7 @@ import { FoldableCard } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { Icon, check } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useState, type JSX } from 'react';
 import { preventWidows } from 'calypso/lib/formatting';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';

--- a/client/a8c-for-agencies/components/upcoming-event/index.tsx
+++ b/client/a8c-for-agencies/components/upcoming-event/index.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@wordpress/components';
 import clsx from 'clsx';
-import { useMemo } from 'react';
+import { useMemo, type JSX } from 'react';
 import { useDispatch } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { UpcomingEventProps } from './types';

--- a/client/a8c-for-agencies/lib/translation.ts
+++ b/client/a8c-for-agencies/lib/translation.ts
@@ -1,28 +1,26 @@
-type Item =
-	| string
-	| number
-	| {
-			props?: {
-				children?: Item | Item[];
-				href?: string;
-			};
-	  };
+import type { ReactNode } from 'react';
+
+type ItemProps = {
+	children?: ReactNode;
+	href?: string;
+};
 
 // Extract nested strings from a translated string
-export function extractStrings( item: Item, result: string = '' ): string {
+export function extractStrings( item: ReactNode, result: string = '' ): string {
 	if ( typeof item === 'string' || typeof item === 'number' ) {
 		result += item;
-	} else if ( item?.props ) {
-		if ( Array.isArray( item.props.children ) ) {
-			for ( const child of item.props.children ) {
+	} else if ( item && typeof item === 'object' && 'props' in item && item.props ) {
+		const props = item.props as ItemProps;
+		if ( Array.isArray( props.children ) ) {
+			for ( const child of props.children ) {
 				result = extractStrings( child, result );
 			}
-		} else if ( item.props.children ) {
-			result = extractStrings( item.props.children, result );
+		} else if ( props.children ) {
+			result = extractStrings( props.children, result );
 		}
 
-		if ( item.props.href ) {
-			result += `: ${ item.props.href }`;
+		if ( props.href ) {
+			result += `: ${ props.href }`;
 		}
 	}
 	return result;

--- a/client/a8c-for-agencies/sections/agency-tier/download-badges/download-link.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/download-badges/download-link.tsx
@@ -8,6 +8,7 @@ import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import type { DirectoryApplicationType } from '../../partner-directory/types';
 import type { AgencyTier } from '../types';
+import type { JSX } from 'react';
 
 function DownloadLink( {
 	product,

--- a/client/a8c-for-agencies/sections/exclusive-offers/overview-content/types.ts
+++ b/client/a8c-for-agencies/sections/exclusive-offers/overview-content/types.ts
@@ -1,3 +1,4 @@
+import type { JSX } from 'react';
 export type PartnerOffer = {
 	id: string;
 	type?: string;

--- a/client/a8c-for-agencies/sections/learn/format-agency-resources.tsx
+++ b/client/a8c-for-agencies/sections/learn/format-agency-resources.tsx
@@ -5,6 +5,7 @@ import WooLogo from 'calypso/a8c-for-agencies/sections/exclusive-offers/overview
 import WordPressDotComLogo from 'calypso/a8c-for-agencies/sections/exclusive-offers/overview-content/images/wordpressdotcom.svg';
 import type { APIAgencyResource } from 'calypso/a8c-for-agencies/data/learn/types';
 import type { ResourceItem } from 'calypso/a8c-for-agencies/sections/learn/resource-center/overview-content/types';
+import type { JSX } from 'react';
 
 /**
  * Get logo JSX element based on related product

--- a/client/a8c-for-agencies/sections/learn/resource-center/overview-content/types.ts
+++ b/client/a8c-for-agencies/sections/learn/resource-center/overview-content/types.ts
@@ -1,3 +1,4 @@
+import type { JSX } from 'react';
 export type ResourceItem = {
 	id: number;
 	name: string;

--- a/client/a8c-for-agencies/sections/marketplace/checkout/pending-payment-popover.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/pending-payment-popover.tsx
@@ -4,7 +4,7 @@ import A4APopover from 'calypso/a8c-for-agencies/components/a4a-popover';
 import { A4A_INVOICES_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 
 type Props = {
-	wrapperRef: React.RefObject< HTMLButtonElement >;
+	wrapperRef: React.RefObject< HTMLButtonElement | null >;
 	hidePopover: () => void;
 };
 

--- a/client/a8c-for-agencies/sections/marketplace/common/hosting-features-section-v2/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/common/hosting-features-section-v2/index.tsx
@@ -3,6 +3,7 @@ import { Icon } from '@wordpress/icons';
 import A4ACarousel from 'calypso/a8c-for-agencies/components/a4a-carousel';
 import PageSection, { PageSectionProps } from 'calypso/a8c-for-agencies/components/page-section';
 import SimpleList from 'calypso/a8c-for-agencies/components/simple-list';
+import type { JSX } from 'react';
 
 import './style.scss';
 

--- a/client/a8c-for-agencies/sections/marketplace/common/hosting-features-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/common/hosting-features-section/index.tsx
@@ -1,5 +1,6 @@
 import PageSection, { PageSectionProps } from 'calypso/a8c-for-agencies/components/page-section';
 import HostingOverviewFeatures from '../hosting-overview-features';
+import type { JSX } from 'react';
 
 type Props = Omit< PageSectionProps, 'children' > & {
 	items: {

--- a/client/a8c-for-agencies/sections/marketplace/common/hosting-overview-features/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/common/hosting-overview-features/index.tsx
@@ -1,4 +1,5 @@
 import { Icon } from '@wordpress/icons';
+import type { JSX } from 'react';
 
 import './style.scss';
 

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/common/hosting-plan-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/common/hosting-plan-section/index.tsx
@@ -1,7 +1,7 @@
 import { Button, Tooltip } from '@wordpress/components';
 import clsx from 'clsx';
 import { TranslateResult } from 'i18n-calypso';
-import { Children } from 'react';
+import { Children, type JSX } from 'react';
 import PageSection from 'calypso/a8c-for-agencies/components/page-section';
 
 import './style.scss';

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/index.tsx
@@ -117,7 +117,6 @@ function HostingOverview( { section }: SectionProps ) {
 			wide
 		>
 			<GuidedTour defaultTourId="marketplaceWalkthrough" />
-
 			<LayoutTop>
 				<PressableUsageLimitNotice />
 				<A4AAgencyApprovalNotice />
@@ -142,7 +141,11 @@ function HostingOverview( { section }: SectionProps ) {
 						) }
 						<div className="a4a-marketplace__header-actions">
 							<MobileSidebarNavigation />
-							<div ref={ ( ref ) => setReferralToggleRef( ref as HTMLElement | null ) }>
+							<div
+								ref={ ( ref ) => {
+									setReferralToggleRef( ref as HTMLElement | null );
+								} }
+							>
 								<ReferralToggle />
 							</div>
 							<ShoppingCart
@@ -179,7 +182,6 @@ function HostingOverview( { section }: SectionProps ) {
 					ref={ heroSectionRef }
 				/>
 			</LayoutTop>
-
 			<LayoutBody className="hosting-overview__body">
 				<QueryProductsList currency="USD" />
 

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/index.tsx
@@ -140,7 +140,6 @@ export function ProductsOverview( { siteId, suggestedProduct, productBrand, sear
 			wide
 		>
 			<GuidedTour defaultTourId="marketplaceWalkthrough" />
-
 			<div className="products-overview__top" ref={ topRef }>
 				<LayoutTop>
 					<A4AAgencyApprovalNotice />
@@ -166,7 +165,11 @@ export function ProductsOverview( { siteId, suggestedProduct, productBrand, sear
 							) }
 							<div className="a4a-marketplace__header-actions">
 								<MobileSidebarNavigation />
-								<div ref={ ( ref ) => setReferralToggleRef( ref as HTMLElement | null ) }>
+								<div
+									ref={ ( ref ) => {
+										setReferralToggleRef( ref as HTMLElement | null );
+									} }
+								>
 									<ReferralToggle />
 								</div>
 								<ShoppingCart
@@ -200,7 +203,6 @@ export function ProductsOverview( { siteId, suggestedProduct, productBrand, sear
 					<ProductCategoryMenu onSelect={ onCategorySelected } />
 				</LayoutTop>
 			</div>
-
 			<div
 				className="products-overview__action-panel-wrapper"
 				ref={ actionPanelRef }
@@ -218,7 +220,6 @@ export function ProductsOverview( { siteId, suggestedProduct, productBrand, sear
 					setSelectedBundleSize={ setSelectedBundleSize }
 				/>
 			</div>
-
 			<ShoppingCartContext.Provider value={ { setSelectedCartItems, selectedCartItems } }>
 				{
 					// we will remove this once we have the new product listing component

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/hooks/use-on-screen.ts
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-filter/hooks/use-on-screen.ts
@@ -1,6 +1,6 @@
 import { RefObject, useEffect, useMemo, useState } from 'react';
 
-export default function useOnScreen( ref: RefObject< HTMLElement > ) {
+export default function useOnScreen( ref: RefObject< HTMLElement | null > ) {
 	const [ isIntersecting, setIntersecting ] = useState( false );
 
 	const observer = useMemo(

--- a/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-hosting-features/index.tsx
+++ b/client/a8c-for-agencies/sections/migrations/primary/migrations-overview-v2/sections/migrations-hosting-features/index.tsx
@@ -5,6 +5,7 @@ import A4ACarousel from 'calypso/a8c-for-agencies/components/a4a-carousel';
 import PageSection from 'calypso/a8c-for-agencies/components/page-section';
 import SimpleList from 'calypso/a8c-for-agencies/components/simple-list';
 import { preventWidows } from 'calypso/lib/formatting';
+import type { JSX } from 'react';
 
 import './style.scss';
 

--- a/client/a8c-for-agencies/sections/partner-directory/lib/get-brand-meta.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/lib/get-brand-meta.tsx
@@ -2,6 +2,7 @@ import { WordPressLogo, JetpackLogo } from '@automattic/components';
 import WooLogoColor from 'calypso/assets/images/icons/Woo_logo_color.svg';
 import pressableIcon from 'calypso/assets/images/pressable/pressable-icon.svg';
 import { Agency } from 'calypso/state/a8c-for-agencies/types';
+import type { JSX } from 'react';
 
 export type BrandMeta = {
 	brand: string;

--- a/client/a8c-for-agencies/sections/referrals/referrals-list/subscription-status.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referrals-list/subscription-status.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { ReactNode } from 'react';
+import { ReactNode, type JSX } from 'react';
 import StatusBadge from 'calypso/a8c-for-agencies/components/step-section-item/status-badge';
 import { getReferralStatus } from '../lib/get-referral-status';
 import type { Referral } from '../types';

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-sites-dataviews.tsx
@@ -152,7 +152,9 @@ export const JetpackSitesDataViews = ( {
 					<>
 						<span
 							className="sites-dataview__site-header sites-dataview__site-header--sort"
-							ref={ ( ref ) => setIntroRef( ref as HTMLElement | null ) }
+							ref={ ( ref ) => {
+								setIntroRef( ref as HTMLElement | null );
+							} }
 						>
 							{ translate( 'Site' ).toUpperCase() }
 						</span>
@@ -196,7 +198,9 @@ export const JetpackSitesDataViews = ( {
 					<div>
 						<span
 							className="sites-dataview__stats-header"
-							ref={ ( ref ) => setStatsRef( ref as HTMLElement | null ) }
+							ref={ ( ref ) => {
+								setStatsRef( ref as HTMLElement | null );
+							} }
 						>
 							STATS
 						</span>
@@ -219,7 +223,9 @@ export const JetpackSitesDataViews = ( {
 					<>
 						<span
 							className="sites-dataview__boost-header"
-							ref={ ( ref ) => setBoostRef( ref as HTMLElement | null ) }
+							ref={ ( ref ) => {
+								setBoostRef( ref as HTMLElement | null );
+							} }
 						>
 							BOOST
 						</span>
@@ -242,7 +248,9 @@ export const JetpackSitesDataViews = ( {
 					<>
 						<span
 							className="sites-dataview__backup-header"
-							ref={ ( ref ) => setBackupRef( ref as HTMLElement | null ) }
+							ref={ ( ref ) => {
+								setBackupRef( ref as HTMLElement | null );
+							} }
 						>
 							BACKUP
 						</span>
@@ -265,7 +273,9 @@ export const JetpackSitesDataViews = ( {
 					<>
 						<span
 							className="sites-dataview__monitor-header"
-							ref={ ( ref ) => setMonitorRef( ref as HTMLElement | null ) }
+							ref={ ( ref ) => {
+								setMonitorRef( ref as HTMLElement | null );
+							} }
 						>
 							MONITOR
 						</span>
@@ -288,7 +298,9 @@ export const JetpackSitesDataViews = ( {
 					<>
 						<span
 							className="sites-dataview__scan-header"
-							ref={ ( ref ) => setScanRef( ref as HTMLElement | null ) }
+							ref={ ( ref ) => {
+								setScanRef( ref as HTMLElement | null );
+							} }
 						>
 							SCAN
 						</span>
@@ -311,7 +323,9 @@ export const JetpackSitesDataViews = ( {
 					<>
 						<span
 							className="sites-dataview__plugins-header"
-							ref={ ( ref ) => setPluginsRef( ref as HTMLElement | null ) }
+							ref={ ( ref ) => {
+								setPluginsRef( ref as HTMLElement | null );
+							} }
 						>
 							PLUGINS
 						</span>

--- a/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-header-actions/index.tsx
@@ -50,7 +50,11 @@ export default function SitesHeaderActions( { onWPCOMImport }: Props ) {
 					onCreateSiteSuccess={ onCreateSiteSuccess }
 				/>
 			) }
-			<div ref={ ( ref ) => setTourStepRef( ref ) }>
+			<div
+				ref={ ( ref ) => {
+					setTourStepRef( ref );
+				} }
+			>
 				{ isEnabled( 'a4a-updated-add-new-site' ) ? (
 					<AddNewSite />
 				) : (

--- a/client/jetpack-cloud/components/guided-tour/index.tsx
+++ b/client/jetpack-cloud/components/guided-tour/index.tsx
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import { Popover, Button } from '@automattic/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, type JSX } from 'react';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getJetpackDashboardPreference as getPreference } from 'calypso/state/jetpack-agency-dashboard/selectors';

--- a/client/jetpack-cloud/components/layout/header.tsx
+++ b/client/jetpack-cloud/components/layout/header.tsx
@@ -51,7 +51,7 @@ export default function LayoutHeader( { showStickyContent, children }: Props ) {
 
 	const [ divRef, hasCrossed ] = useDetectWindowBoundary();
 
-	const outerDivProps = divRef ? { ref: divRef as React.RefObject< HTMLDivElement | null > } : {};
+	const outerDivProps = divRef ? { ref: divRef as React.RefObject< HTMLDivElement > } : {};
 
 	const [ minHeaderHeight, setMinHeaderHeight ] = useState( 0 );
 

--- a/client/jetpack-cloud/components/layout/header.tsx
+++ b/client/jetpack-cloud/components/layout/header.tsx
@@ -51,7 +51,7 @@ export default function LayoutHeader( { showStickyContent, children }: Props ) {
 
 	const [ divRef, hasCrossed ] = useDetectWindowBoundary();
 
-	const outerDivProps = divRef ? { ref: divRef as React.RefObject< HTMLDivElement > } : {};
+	const outerDivProps = divRef ? { ref: divRef as React.RefObject< HTMLDivElement | null > } : {};
 
 	const [ minHeaderHeight, setMinHeaderHeight ] = useState( 0 );
 

--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -1,7 +1,7 @@
 import { Icon, starEmpty } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, type JSX } from 'react';
 import JetpackIcons from 'calypso/components/jetpack/jetpack-icons';
 import Sidebar, {
 	SidebarV2Main as SidebarMain,

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/hooks.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/hooks.tsx
@@ -131,7 +131,7 @@ export function useHandleResetNotification(
 const MAX_ACTIONBAR_HEIGHT = 30;
 const MIN_ACTIONBAR_WIDTH = 400;
 
-export function useHandleShowHideActionBar( node: RefObject< HTMLDivElement > ) {
+export function useHandleShowHideActionBar( node: RefObject< HTMLDivElement | null > ) {
 	const [ actionBarVisible, setActionBarVisible ] = useState( true );
 	const { isBulkManagementActive } = useContext( SitesOverviewContext );
 

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/use-show-verified-badge.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/notification-settings/use-show-verified-badge.ts
@@ -5,7 +5,7 @@ const TIMEOUT_DURATION = 10000;
 const useShowVerifiedBadge = () => {
 	const [ verifiedItem, setVerifiedItem ] = useState< { [ key: string ]: string } | undefined >();
 
-	const timeoutIdRef = useRef< ReturnType< typeof setTimeout > | undefined >();
+	const timeoutIdRef = useRef< ReturnType< typeof setTimeout > | undefined >( undefined );
 
 	const handleSetVerifiedItem = useCallback(
 		( type: string, item: string ) => {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/license-info-modal/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/license-info-modal/index.tsx
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
-import { useContext, useMemo } from 'react';
+import { useContext, useMemo, type JSX } from 'react';
 import { A4A_MARKETPLACE_CHECKOUT_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useProductsQuery from 'calypso/a8c-for-agencies/data/marketplace/use-products-query';
 import LicenseLightbox from 'calypso/jetpack-cloud/sections/partner-portal/license-lightbox';

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content-header.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content-header.tsx
@@ -18,7 +18,7 @@ interface Props {
 export default function SiteContentHeader( { content, pageTitle, showStickyContent }: Props ) {
 	const [ divRef, hasCrossed ] = useDetectWindowBoundary();
 
-	const outerDivProps = divRef ? { ref: divRef as React.RefObject< HTMLDivElement | null > } : {};
+	const outerDivProps = divRef ? { ref: divRef as React.RefObject< HTMLDivElement > } : {};
 
 	const translate = useTranslate();
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content-header.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content-header.tsx
@@ -18,7 +18,7 @@ interface Props {
 export default function SiteContentHeader( { content, pageTitle, showStickyContent }: Props ) {
 	const [ divRef, hasCrossed ] = useDetectWindowBoundary();
 
-	const outerDivProps = divRef ? { ref: divRef as React.RefObject< HTMLDivElement > } : {};
+	const outerDivProps = divRef ? { ref: divRef as React.RefObject< HTMLDivElement | null > } : {};
 
 	const translate = useTranslate();
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-dashboard-show-large-screen.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-dashboard-show-large-screen.ts
@@ -4,7 +4,7 @@ import { useCallback, useState, useEffect, RefObject } from 'react';
 const DESKTOP_BREAKPOINT = '>1280px';
 
 const useDashboardShowLargeScreen = (
-	siteTableRef: RefObject< HTMLTableElement >,
+	siteTableRef: RefObject< HTMLTableElement | null >,
 	containerRef: { current: { clientWidth: number } }
 ) => {
 	const isDesktop = useBreakpoint( DESKTOP_BREAKPOINT );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/site-php-version.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/site-php-version.tsx
@@ -1,4 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
+import type { JSX } from 'react';
 
 export default function SitePhpVersion( {
 	phpVersion,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/sites-overview.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/sites-overview.tsx
@@ -6,7 +6,7 @@
 import { isWithinBreakpoint } from '@automattic/viewport';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, act } from '@testing-library/react';
-import React from 'react';
+import React, { type JSX } from 'react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import { thunk } from 'redux-thunk';

--- a/client/jetpack-cloud/sections/overview/foldable-nav/types.ts
+++ b/client/jetpack-cloud/sections/overview/foldable-nav/types.ts
@@ -1,4 +1,5 @@
 import { TranslateResult } from 'i18n-calypso';
+import type { JSX } from 'react';
 
 export interface Props {
 	header: string;

--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox/index.tsx
@@ -1,7 +1,7 @@
 import { Button, Gridicon } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
 import clsx from 'clsx';
-import { FunctionComponent, ReactNode, useCallback } from 'react';
+import { FunctionComponent, ReactNode, useCallback, type JSX } from 'react';
 import useMinimizeHelpCenterOnMount from 'calypso/a8c-for-agencies/hooks/use-minimize-help-center-on-mount';
 import JetpackLightbox, {
 	JetpackLightboxAside,

--- a/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/card-content.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/card-content.tsx
@@ -9,7 +9,7 @@ import page from '@automattic/calypso-router';
 import { Button, JetpackLogo, WooLogo, CloudLogo, Tooltip } from '@automattic/components';
 import { formatCurrency } from '@automattic/number-formatters';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useRef, useState, type JSX } from 'react';
 import useIssueLicenses from 'calypso/jetpack-cloud/sections/partner-portal/hooks/use-issue-licenses';
 import { partnerPortalBasePath } from 'calypso/lib/jetpack/paths';
 import { addQueryArgs } from 'calypso/lib/url';

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/mobile-menu-button.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/mobile-menu-button.tsx
@@ -6,7 +6,7 @@ import type { MouseEvent, FC, SetStateAction, Dispatch, RefObject } from 'react'
 interface MobileMenuButtonProps {
 	isOpen: boolean;
 	setIsOpen: Dispatch< SetStateAction< boolean > >;
-	mobileMenu: RefObject< HTMLDivElement >;
+	mobileMenu: RefObject< HTMLDivElement | null >;
 }
 
 const MobileMenuButton: FC< MobileMenuButtonProps > = ( { isOpen, setIsOpen, mobileMenu } ) => {

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -54,7 +54,7 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 
 	const [ barRef, hasCrossed ] = useDetectWindowBoundary( windowBoundaryOffset );
 
-	const outerDivProps = barRef ? { ref: barRef as React.RefObject< HTMLDivElement > } : {};
+	const outerDivProps = barRef ? { ref: barRef as React.RefObject< HTMLDivElement | null > } : {};
 
 	const classes = clsx( 'header__content-background-wrapper', {
 		'header__content-background-wrapper--sticky': shouldShowCart && hasCrossed,

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/index.tsx
@@ -54,7 +54,7 @@ const JetpackComMasterbar: React.FC< Props > = ( { pathname } ) => {
 
 	const [ barRef, hasCrossed ] = useDetectWindowBoundary( windowBoundaryOffset );
 
-	const outerDivProps = barRef ? { ref: barRef as React.RefObject< HTMLDivElement | null > } : {};
+	const outerDivProps = barRef ? { ref: barRef as React.RefObject< HTMLDivElement > } : {};
 
 	const classes = clsx( 'header__content-background-wrapper', {
 		'header__content-background-wrapper--sticky': shouldShowCart && hasCrossed,

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/utils.ts
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/utils.ts
@@ -26,7 +26,7 @@ export const isValidLink = ( url: string ) => {
 };
 
 export const closeOnFocusOut = (
-	ref: RefObject< HTMLDivElement >,
+	ref: RefObject< HTMLDivElement | null >,
 	isOpen: boolean,
 	toggle: () => void
 ) => {

--- a/client/jetpack-cloud/sections/sidebar-navigation/types.ts
+++ b/client/jetpack-cloud/sections/sidebar-navigation/types.ts
@@ -1,3 +1,4 @@
+import type { JSX } from 'react';
 export type MenuItemProps = {
 	id?: string;
 	icon: JSX.Element;

--- a/client/jetpack-cloud/sections/utils/show-banner.ts
+++ b/client/jetpack-cloud/sections/utils/show-banner.ts
@@ -1,4 +1,5 @@
 import type { Preference } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+import type { JSX } from 'react';
 
 const ONE_DAY_IN_MILLISECONDS = 1000 * 60 * 60 * 24;
 


### PR DESCRIPTION
Part of #111325 (Migrate Calypso to React 19, DOTCOM-17400)

Resolves DOTCOM-17549

## Proposed Changes

Forward-compatible React 19 type changes for `client/a8c-for-agencies` and `client/jetpack-cloud`. No dependency or lockfile changes — these stay green on the current React 18 line while being ready for the eventual React 19 bump (which lands as the final PR in #111325). Split into three commits:

* **Simple type updates** (34 files) — mechanical output of `types-react-codemod` (`scoped-jsx` + `useRef-required-initial`):
  * add explicit `import type { JSX } from 'react'` where `JSX` is referenced;
  * `useRef< T >()` → `useRef< T >( undefined )` (required-initial-arg rule; `useRef()` already initializes `current` to `undefined`, so this is a no-op at runtime).
* **Forward-compat manual fixes** (8 files) — changes the codemods can't produce, mirroring the validation spike:
  * widen `RefObject< T >` → `RefObject< T | null >` where the ref can be null;
  * `a8c-for-agencies/lib/translation.ts`: type `extractStrings` against `ReactNode` and narrow element `props` access instead of relying on a bespoke `Item` type.
* **Fixes beyond the spike** (7 files) — found by dry-running the full `types-react-codemod` React 19 transform set (the spike only ran two transforms) plus a grep for runtime breakers:
  * `refobject-defaults` (3): widen `as React.RefObject< T >` casts;
  * `no-implicit-ref-callback-return` (4): give ref callbacks a block body so they don't implicitly return a value (React 19 treats a returned value as a cleanup function). The wrapped setters are `useState` setters returning `undefined`, and React 18 ignores ref-callback return values — so no behavior change.

There is **no functional/behavior change** in this PR — it is purely a type-level forward-compat migration.

## Why are these changes being made?

To land forward-compatible source changes on trunk ahead of the React 19 dependency bump, keeping each area's diff small and reviewable. Keeping React, `@wordpress/*`, and the lockfile unchanged means these changes remain compatible with the current React 18 line while removing known React 19 type blockers.

## Testing Instructions

These changes are type-level only and compile on the current React 18 line.

* Focused ESLint on the changed files (expect 0 errors):

```bash
git diff trunk... --name-only -- client/a8c-for-agencies client/jetpack-cloud | rg '\.(js|jsx|ts|tsx)$' | xargs yarn eslint --ext .js,.jsx,.ts,.tsx
```

* `yarn typecheck-client` — 0 errors in `client/a8c-for-agencies` and `client/jetpack-cloud`.
* Jetpack Cloud sites-overview suite still passes: `yarn test-client client/jetpack-cloud/sections/agency-dashboard/sites-overview/test/sites-overview.tsx`.

Forward-compat validation (React 19 installed locally, not committed): with `react`/`react-dom` `19.2.7`, `@types/react` `19.2.16`, `@types/react-dom` `19.2.3`, and `@wordpress/element` `7.0.0` pinned, `tsc --project client` shows that none of the remaining React 19 errors in these two directories originate from the files changed here — they all cascade from shared components (e.g. `Tooltip`, shared text/heading primitives, `connect()` HOCs) that are migrated separately.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
