### PR TITLE
A4A: surface error when logo image cannot be decoded

### DIFF
--- a/client/a8c-for-agencies/components/logo-file-upload/index.tsx
+++ b/client/a8c-for-agencies/components/logo-file-upload/index.tsx
@@ -38,7 +38,9 @@ export interface LogoFileUploadProps {
 function LogoFileUpload( { displayUrl, onFileSelect }: LogoFileUploadProps ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-	const [ error, setError ] = useState< LogoFileValidationError | 'dimensions' | null >( null );
+	const [ error, setError ] = useState< LogoFileValidationError | 'dimensions' | 'decode' | null >(
+		null
+	);
 	const maxLogoSizeMb = Math.floor( A4A_LOGO_MAX_FILE_SIZE_BYTES / ( 1024 * 1024 ) );
 
 	const handleFileSelect = useCallback(
@@ -58,10 +60,16 @@ function LogoFileUpload( { displayUrl, onFileSelect }: LogoFileUploadProps ) {
 				return;
 			}
 
-			const isValidDimensions = await validateLogoDimensions( file, {
-				requiredWidth: A4A_LOGO_REQUIRED_WIDTH,
-				requiredHeight: A4A_LOGO_REQUIRED_HEIGHT,
-			} );
+			let isValidDimensions = false;
+			try {
+				isValidDimensions = await validateLogoDimensions( file, {
+					requiredWidth: A4A_LOGO_REQUIRED_WIDTH,
+					requiredHeight: A4A_LOGO_REQUIRED_HEIGHT,
+				} );
+			} catch {
+				setError( 'decode' );
+				return;
+			}
 
 			if ( ! isValidDimensions ) {
 				setError( 'dimensions' );
@@ -93,6 +101,10 @@ function LogoFileUpload( { displayUrl, onFileSelect }: LogoFileUploadProps ) {
 				height: A4A_LOGO_REQUIRED_HEIGHT,
 			},
 		} );
+	}
+
+	if ( error === 'decode' ) {
+		errorMessage = translate( 'The image could not be read. Please use a valid JPG or PNG.' );
 	}
 
 	const uploadHelpText = translate(

--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/logo-picker.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/logo-picker.tsx
@@ -20,10 +20,16 @@ const LogoPicker = ( { logo, onPick }: Props ) => {
 	const onImagePick = async ( file: File ) => {
 		setError( null );
 
-		const isValidDimensions = await validateLogoDimensions( file, {
-			requiredWidth: A4A_LOGO_REQUIRED_WIDTH,
-			requiredHeight: A4A_LOGO_REQUIRED_HEIGHT,
-		} );
+		let isValidDimensions = false;
+		try {
+			isValidDimensions = await validateLogoDimensions( file, {
+				requiredWidth: A4A_LOGO_REQUIRED_WIDTH,
+				requiredHeight: A4A_LOGO_REQUIRED_HEIGHT,
+			} );
+		} catch {
+			setError( translate( 'The image could not be read. Please use a valid JPG or PNG.' ) );
+			return;
+		}
 
 		if ( ! isValidDimensions ) {
 			setError( translate( 'Company logo must have 800px width and 320px height.' ) );


### PR DESCRIPTION
Part of A4A-2285
<!-- Link the related A4A Linear issue. -->

## Proposed Changes

<img width="463" height="107" alt="Screenshot 2026-06-05 at 11 29 02" src="https://github.com/user-attachments/assets/8e532ccd-86ad-4a0a-9b10-75bf26c5efd7" />

* **`client/a8c-for-agencies/components/logo-file-upload/index.tsx`** — `handleFileSelect` now wraps `validateLogoDimensions` in a `try/catch`. A decode failure sets a new `'decode'` error state that renders “The image could not be read. Please use a valid JPG or PNG.” instead of bubbling up as an unhandled rejection.
* **`client/a8c-for-agencies/sections/partner-directory/agency-details/logo-picker.tsx`** — same treatment: the `validateLogoDimensions` call is wrapped in `try/catch` and surfaces the same friendly message via the existing `error` state.

## Why are these changes being made?

`validateLogoDimensions` rejects when an image fails to decode (the underlying `Image.onerror` path). Both callers awaited it without a `try/catch`, so a corrupt or malformed PNG/JPEG that still passed the MIME and size checks produced an unhandled promise rejection inside the async change handler. The result was a console runtime error and a logo picker stuck with no validation message — the user had no idea why nothing happened. Catching the rejection at the call site and showing a clear error makes the failure recoverable and consistent with the existing format/size/dimensions errors.

## Testing Instructions

1. Open the live link and go to **A4A → Partner directory → Agency details** (logo picker) or the referral checkout logo upload.
2. Prepare a file that passes the MIME/size checks but cannot be decoded — e.g. rename a text file to `logo.png`, or truncate a valid PNG so its bytes are corrupt.
3. Select it as the logo. Confirm the UI shows “The image could not be read. Please use a valid JPG or PNG.” and that there is **no** unhandled promise rejection in the console.
4. Confirm a valid 800×320 logo still uploads, and that an off-dimension or wrong-format/oversized file still shows its respective error.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
