### PR TITLE
Odyssey Stats: fix wp-admin heading rendering (sticky header + section-title leak)

### DIFF
--- a/apps/odyssey-stats/src/styles/wp-admin.scss
+++ b/apps/odyssey-stats/src/styles/wp-admin.scss
@@ -78,7 +78,12 @@
 	}
 	// Disable sticky header — in wp-admin the admin-ui-page forms its own
 	// scroll container, causing the header to stick and overlap content.
-	& .admin-ui-page__header {
+	// admin-ui 2.x moved the Page internals to CSS Modules, so the old
+	// `.admin-ui-page__header` hook is gone. `.admin-ui-page` is restored on the
+	// Page root via its `className` prop; the header has no stable class, so
+	// anchor structurally (StatsMain always passes a `title`, so it's the first
+	// child). Replace with a stable hook if @wordpress/admin-ui exposes one.
+	& .admin-ui-page > :first-child {
 		position: static;
 	}
 
@@ -90,6 +95,18 @@
 		@media (max-width: 600px) {
 			padding-left: 0;
 		}
+	}
+
+	// Some `.stats-section-title` markup wraps a bare child `<h3>` (e.g.
+	// stats-date-label, stats-email-summary). wp-admin core (common.css) applies
+	// an unlayered `h2, h3 { font-size: 1.3em; margin: 1em 0; color: #1d2327 }`
+	// that wins over Calypso's `@layer reset`, inflating that inner heading and
+	// double-spacing it against its wrapper. Re-anchor it on the wrapper so the
+	// inner h3 follows the wrapper's (responsive) size/color and adds no margin.
+	& .stats-section-title h3 {
+		font-size: inherit;
+		margin: 0;
+		color: inherit;
 	}
 
 	// Offset margin of menu items set in Calypso.


### PR DESCRIPTION
Part of STATS-260

This PR groups two **independent** heading-rendering fixes in `apps/odyssey-stats/src/styles/wp-admin.scss` (same file, same area). Only the first is caused by admin-ui; the second is a long-latent wp-admin/`@layer` leak.

## Proposed Changes

* **Sticky header (admin-ui 2.x — STATS-260):** re-anchor the override from the dead `.admin-ui-page__header` class onto the structural selector `.admin-ui-page > :first-child`, matching the Calypso-side fix.
* **Section-title leak (not admin-ui — STATS-262 line):** neutralize wp-admin core's global `h2, h3` rule where it leaks into bare `.stats-section-title` inner headings (`font-size`/`margin`/`color` → `inherit`/`0`/`inherit`), so the inner `<h3>` follows its wrapper's responsive size/color instead of being inflated.

## Why are these changes being made?

**Sticky header** — The `@wordpress/admin-ui` `1.x → 2.1.0` bump moved the `Page`/`Header` internals to CSS Modules, hashing the formerly-global `.admin-ui-page__header` class, so Odyssey's sticky-header override silently stopped matching. This is the Odyssey-side counterpart of the Calypso fix in #111340 (also part of STATS-260). `.admin-ui-page` is restored on the Page root via its `className` prop (already done in the shared `stats-main`), so the header is re-anchored structurally as a stopgap, since no stable header class exists yet (upstream ask tracked in STATS-261).

**Section-title leak** — This one is **unrelated to admin-ui**. Some `.stats-section-title` markup wraps a *bare* `<h3>` in a `<div>` (e.g. `stats-date-label`, `stats-email-summary`). That inner `<h3>` relies on inheriting size/color from its wrapper, but wp-admin core (`common.css`) applies an unlayered `h2, h3 { font-size: 1.3em; margin: 1em 0; color: #1d2327 }` that wins over Calypso's `@layer reset` (layered styles always lose to unlayered), inflating the heading and double-spacing it — this would happen regardless of the admin-ui version. The structural root cause (inconsistent `.stats-section-title` DOM shape) and the proper fix (extract a shared `StatsSectionTitle` component) are tracked in STATS-262; this PR is the targeted wp-admin stopgap, and the workaround is flagged for removal once STATS-262 lands.

## Testing Instructions

* In Odyssey Stats (wp-admin): open **Stats → Traffic / Insights** and scroll — confirm the page header no longer sticks/overlaps content on scroll.
* Confirm the main period heading (e.g. "Stats for December 7") and the **Emails** summary heading render at the correct size/spacing (not oversized, no doubled top/bottom margin), matching WordPress.com.
* Verify on both desktop and mobile widths.

## Screenshots

<!-- Capture in Odyssey/wp-admin (a Jetpack/Atomic site). Drop in Before/After of (1) the page header on scroll and (2) the period / Emails heading size + margin. -->

| Before | After |
|---|---|
| _todo_ | _todo_ |

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)