### PR TITLE
ADS-1029 Sync Blaze campaign creation strings

### DIFF
--- a/client/lib/promote-post/string.ts
+++ b/client/lib/promote-post/string.ts
@@ -222,11 +222,13 @@ const BlazePressStrings = () => {
 	);
 	translate( 'Blaze campaigns are billed in USD.' );
 	translate(
-		'I agree to recurring weekly charges of up to %(maxBudgetFormatted)s per week starting %(formattedDate)s'
+		'I agree to recurring weekly charges of up to %(maxBudgetFormatted)s per week starting %(formattedDate)s.'
 	);
 	translate(
-		'I agree to be charged up to %(maxBudgetFormatted)s starting %(formattedDate)s. Charges may be made in one or more payments, and the campaign'
+		'I agree to be charged up to %(maxBudgetFormatted)s starting %(formattedDate)s. Charges may be made in one or more payments.'
 	);
+	translate( 'Charges continue until I cancel' );
+	translate( 'The campaign can be canceled at any time' );
 	translate( 'Creating campaign' );
 	translate( 'Submit campaign' );
 	translate( 'Content suggested with the help of AI.' );

--- a/client/lib/promote-post/string.ts
+++ b/client/lib/promote-post/string.ts
@@ -135,6 +135,9 @@ const BlazePressStrings = () => {
 	translate( 'Duration (days)' );
 	translate( 'Weekly Total' );
 	translate( 'Daily budget' );
+	translate( '%(amount)s/day' );
+	translate( '%(amount)s weekly total' );
+	translate( '%(amount)s per day' );
 	translate( 'Total spend for the campaign duration' );
 	translate( 'Weekly click estimate' );
 	translate( 'Estimated clicks for the campaign duration' );
@@ -155,6 +158,7 @@ const BlazePressStrings = () => {
 	translate( 'day' );
 	translate( 'Weekly' );
 	translate( 'Total' );
+	translate( '%(amount)s total' );
 	translate( 'Est. weekly clicks' );
 	translate( 'Estimated clicks' );
 	translate( 'Tumblr Post views weekly' );
@@ -215,6 +219,13 @@ const BlazePressStrings = () => {
 	translate( 'Promote' );
 	translate(
 		'By clicking "Submit campaign" you agree to our {{linkTos}}Terms of Service{{/linkTos}} and {{linkAdvertisingPolicy}}Advertising Policy{{/linkAdvertisingPolicy}}, and authorize charges to your payment method at regular intervals for the specified budget and duration, until cancellation. {{linkMoreAboutAds}}Learn more{{/linkMoreAboutAds}}.'
+	);
+	translate( 'Blaze campaigns are billed in USD.' );
+	translate(
+		'I agree to recurring weekly charges of up to %(maxBudgetFormatted)s per week starting %(formattedDate)s'
+	);
+	translate(
+		'I agree to be charged up to %(maxBudgetFormatted)s starting %(formattedDate)s. Charges may be made in one or more payments, and the campaign'
 	);
 	translate( 'Creating campaign' );
 	translate( 'Submit campaign' );


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of https://linear.app/a8c/issue/ADS-1029/blaze-campaign-creation-should-explicitly-display-usd-currency-code

## Proposed Changes

* Sync ADS-1029-related Blaze widget strings generated from the `a8c-dsp` companion branch.
* Keep this PR scoped to `client/lib/promote-post/string.ts`.
* Leave Blaze dashboard setup pricing unchanged so `formatCurrency( 5, 'USD' )` continues to handle localization and geolocation.

Companion `a8c-dsp` PR: https://github.tumblr.net/Tumblr/a8c-dsp/pull/3884

## Why are these changes being made?

The DSP widget adds and updates campaign creation strings for clearer USD billing and formatter-controlled USD display. Calypso imports `client/lib/promote-post/string.ts` so those widget strings are available in the WordPress.com wrapper.

This is the Calypso translation-string mirror for ADS-1029. The currency formatting behavior is implemented and tested in the companion `a8c-dsp` PR. This PR does not change the Calypso setup page or pricing formatting behavior.

## Testing Instructions

Automated checks:

```bash
node .yarn/releases/yarn-4.0.2.cjs eslint client/lib/promote-post/string.ts
node .yarn/releases/yarn-4.0.2.cjs workspace @automattic/blaze-dashboard build
```

Expected result:

* eslint passes with only existing deprecation warnings
* Blaze dashboard build completes, with existing asset-size warnings only

Manual check:

1. Review `client/lib/promote-post/string.ts`.
2. Confirm the added entries are ADS-1029 Blaze widget strings only.
3. Do not expect a Calypso setup-page visual change from this PR. `disconnected-site.jsx` is intentionally unchanged and continues to use `formatCurrency( 5, 'USD' )`.
4. Use the companion `a8c-dsp` PR for the end-to-end sandbox smoke test. When both branches are loaded there, confirm the branch-loaded campaign creation flow shows formatter-controlled USD output, for example `US$5` and `US$35` for non-US geo.

Additional note:

`typecheck-client` was also run during implementation and failed in unrelated existing areas. No errors referenced the touched file.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
