### PR TITLE
Delayed Downgrades 2/4: wire front-end entry points for downgrade at renewal.

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -465,11 +465,11 @@ function isChangePlanEligible( purchase: Purchase, isMigrating: boolean ): boole
 		return /^(value_bundle|business-bundle|ecommerce-bundle)/.test( purchase.product_slug );
 	}
 
-	// Active plans: gated by the active-downgrade flags (instant arm only for now).
-	// Mirrors getActiveDowngradeVariant() === 'instant' from calypso/lib/purchases/active-downgrade-variant.
+	// Active plans: gated by either active-downgrade flag (instant or on-renewal).
+	// Mirrors getActiveDowngradeVariant() !== 'control' from calypso/lib/purchases/active-downgrade-variant.
 	if (
-		isEnabled( 'plans/scheduled-plan-downgrade' ) ||
-		! isEnabled( 'plans/active-plan-downgrade-instant' )
+		! isEnabled( 'plans/active-plan-downgrade-instant' ) &&
+		! isEnabled( 'plans/scheduled-plan-downgrade' )
 	) {
 		return false;
 	}
@@ -557,10 +557,19 @@ function ReSubscribeActionButton( { purchase }: { purchase: Purchase } ) {
 					purchaseId: String( purchase.ID ),
 			  } );
 
+		// On-renewal variant: different entry-point copy for active plans.
+		const isOnRenewal = isActiveChangePlanEligible && isEnabled( 'plans/scheduled-plan-downgrade' );
+
 		return (
 			<ActionList.ActionItem
-				title={ __( 'Change plan' ) }
-				description={ __( 'Upgrade or downgrade to a plan that works for you.' ) }
+				title={ isOnRenewal ? __( 'Downgrade on renewal' ) : __( 'Change plan' ) }
+				description={
+					isOnRenewal
+						? __(
+								'Switch to a lower-tier plan starting at your next renewal. Keep your current features until then.'
+						  )
+						: __( 'Upgrade or downgrade to a plan that works for you.' )
+				}
 				actions={
 					<Button
 						variant="secondary"

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -557,19 +557,10 @@ function ReSubscribeActionButton( { purchase }: { purchase: Purchase } ) {
 					purchaseId: String( purchase.ID ),
 			  } );
 
-		// On-renewal variant: different entry-point copy for active plans.
-		const isOnRenewal = isActiveChangePlanEligible && isEnabled( 'plans/scheduled-plan-downgrade' );
-
 		return (
 			<ActionList.ActionItem
-				title={ isOnRenewal ? __( 'Downgrade on renewal' ) : __( 'Change plan' ) }
-				description={
-					isOnRenewal
-						? __(
-								'Switch to a lower-tier plan starting at your next renewal. Keep your current features until then.'
-						  )
-						: __( 'Upgrade or downgrade to a plan that works for you.' )
-				}
+				title={ __( 'Change plan' ) }
+				description={ __( 'Upgrade or downgrade to a plan that works for you.' ) }
 				actions={
 					<Button
 						variant="secondary"

--- a/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
+++ b/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
@@ -16,6 +16,7 @@ import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { SITE_STORE } from 'calypso/landing/stepper/stores';
 import { getCurrentQueryParams } from 'calypso/landing/stepper/utils/get-current-query-params';
 import { stepsWithRequiredLogin } from 'calypso/landing/stepper/utils/steps-with-required-login';
+import { getActiveDowngradeVariant } from 'calypso/lib/purchases/active-downgrade-variant';
 import { isExternal } from 'calypso/lib/url';
 
 const BASE_STEPS = [ STEPS.UNIFIED_PLANS ];
@@ -127,7 +128,9 @@ const planUpgradeFlow: FlowV2< typeof initialize > = {
 					// site object is null for Atomic *.wpcomstaging.com slugs, so feed the
 					// purchase's blog_id through.
 					siteId: changePlanPurchaseQuery.data?.blog_id,
-					isRefundable: changePlanPurchaseQuery.data?.is_refundable ?? false,
+					isRefundable:
+						getActiveDowngradeVariant() !== 'on_renewal' &&
+						( changePlanPurchaseQuery.data?.is_refundable ?? false ),
 				} ),
 				...( isChangePlan &&
 					currentIntervalType && {

--- a/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/index.tsx
+++ b/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/index.tsx
@@ -9,12 +9,17 @@ import { Gridicon } from '@automattic/components';
 import { formatCurrency } from '@automattic/number-formatters';
 import { Button, Modal, __experimentalHStack as HStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import moment from 'moment';
 import { useMemo, useState } from 'react';
 import { isRefundable } from 'calypso/lib/purchases';
-import { cancelAndRefundPurchaseAsync } from 'calypso/lib/purchases/actions';
+import {
+	cancelAndRefundPurchaseAsync,
+	enableAutoRenew,
+	scheduleDowngradeAsync,
+} from 'calypso/lib/purchases/actions';
 import { addQueryArgs } from 'calypso/lib/url';
 import { useDispatch, useSelector } from 'calypso/state';
-import { errorNotice } from 'calypso/state/notices/actions';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import type { Purchase } from 'calypso/lib/purchases/types';
 
@@ -29,6 +34,9 @@ interface DowngradeConfirmationModalProps {
 	onClose: () => void;
 	purchase: Purchase | null;
 	isPlanExpired: boolean;
+	mode?: 'immediate' | 'on_renewal';
+	currentRenewalPriceText?: string;
+	targetRenewalPriceText?: string;
 }
 
 const DowngradeConfirmationModal = ( {
@@ -40,6 +48,9 @@ const DowngradeConfirmationModal = ( {
 	onClose,
 	purchase,
 	isPlanExpired,
+	mode = 'immediate',
+	currentRenewalPriceText,
+	targetRenewalPriceText,
 }: DowngradeConfirmationModalProps ) => {
 	const translate = useTranslate();
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
@@ -79,6 +90,12 @@ const DowngradeConfirmationModal = ( {
 	const currentPlanTitle = getPlan( currentPlanSlug )?.getTitle() ?? '';
 	const targetPlanTitle = getPlan( targetPlanSlug )?.getTitle() ?? '';
 
+	// When auto-renew is on, expiryDate is the next renewal date.
+	// Use non-breaking spaces so the date never wraps mid-line.
+	const renewalDateFormatted = purchase?.expiryDate
+		? moment( purchase.expiryDate ).format( 'LL' ).replace( / /g, '\u00A0' )
+		: '';
+
 	const handleConfirm = async () => {
 		if ( isPlanExpired ) {
 			// Expired plan: route to checkout
@@ -100,7 +117,52 @@ const DowngradeConfirmationModal = ( {
 			return;
 		}
 
-		// Active plan: use cancel API
+		if ( mode === 'on_renewal' ) {
+			// On-renewal: schedule the downgrade for the next renewal date.
+			if ( ! purchase || isDowngrading ) {
+				return;
+			}
+			const targetProductId = getPlan( targetPlanSlug )?.getProductId();
+			if ( ! targetProductId ) {
+				return;
+			}
+
+			setIsDowngrading( true );
+			try {
+				await scheduleDowngradeAsync( purchase.id, targetProductId );
+
+				// Ensure auto-renew is on so the scheduled downgrade triggers at renewal.
+				if ( ! purchase.isAutoRenewEnabled ) {
+					await new Promise< void >( ( resolve ) => {
+						enableAutoRenew( purchase.id, () => resolve() );
+					} );
+				}
+
+				dispatch(
+					successNotice(
+						translate( 'Your plan will downgrade to %(targetPlan)s on %(date)s.', {
+							args: {
+								targetPlan: targetPlanTitle,
+								date: renewalDateFormatted,
+							},
+						} ),
+						{ duration: 5000 }
+					)
+				);
+				onClose();
+			} catch ( error ) {
+				dispatch(
+					errorNotice(
+						error instanceof Error ? error.message : translate( 'An unknown error occurred' ),
+						{ duration: 5000 }
+					)
+				);
+				setIsDowngrading( false );
+			}
+			return;
+		}
+
+		// Active plan (immediate): use cancel API
 		if ( ! purchase || isDowngrading ) {
 			return;
 		}
@@ -164,6 +226,31 @@ const DowngradeConfirmationModal = ( {
 	};
 
 	const renderDescription = () => {
+		if ( mode === 'on_renewal' ) {
+			return (
+				<>
+					<p className="downgrade-confirmation-modal__description">
+						{ translate(
+							'Your plan will change from %(currentPlan)s to %(targetPlan)s on %(date)s. You’ll keep your current features until then.',
+							{
+								args: {
+									currentPlan: currentPlanTitle,
+									targetPlan: targetPlanTitle,
+									date: renewalDateFormatted,
+								},
+								comment: 'Message shown when scheduling a plan downgrade for the next renewal date',
+							}
+						) }
+					</p>
+					{ lostFeatures.length > 0 && (
+						<p className="downgrade-confirmation-modal__description">
+							{ translate( 'Your site will lose access to these features:' ) }
+						</p>
+					) }
+				</>
+			);
+		}
+
 		if ( isPlanExpired ) {
 			// Expired plan: show "what you'll lose" copy
 			if ( lostFeatures.length > 0 ) {
@@ -252,9 +339,14 @@ const DowngradeConfirmationModal = ( {
 		);
 	};
 
+	const modalTitle =
+		mode === 'on_renewal'
+			? String( translate( 'Downgrade on renewal' ) )
+			: String( translate( 'Confirm downgrade' ) );
+
 	return (
 		<Modal
-			title={ String( translate( 'Confirm downgrade' ) ) }
+			title={ modalTitle }
 			onRequestClose={ onClose }
 			className="downgrade-confirmation-modal"
 			size="medium"
@@ -276,12 +368,25 @@ const DowngradeConfirmationModal = ( {
 					) ) }
 				</ul>
 			) }
+			{ mode === 'on_renewal' && currentRenewalPriceText && targetRenewalPriceText && (
+				<p className="downgrade-confirmation-modal__description downgrade-confirmation-modal__price-change">
+					{ translate( 'Your renewal price will change from %(currentPrice)s to %(targetPrice)s.', {
+						args: {
+							currentPrice: currentRenewalPriceText,
+							targetPrice: targetRenewalPriceText,
+						},
+						comment: 'Price comparison shown when scheduling a plan downgrade for renewal',
+					} ) }
+				</p>
+			) }
 			<HStack spacing={ 3 } justify="flex-end" className="downgrade-confirmation-modal__buttons">
 				<Button __next40pxDefaultSize variant="tertiary" onClick={ onClose }>
-					{ translate( 'Keep %(planName)s', {
-						args: { planName: currentPlanTitle },
-						comment: 'Button label to dismiss the downgrade modal and keep the current plan',
-					} ) }
+					{ mode === 'on_renewal'
+						? translate( 'Keep my plan' )
+						: translate( 'Keep %(planName)s', {
+								args: { planName: currentPlanTitle },
+								comment: 'Button label to dismiss the downgrade modal and keep the current plan',
+						  } ) }
 				</Button>
 				<Button
 					__next40pxDefaultSize
@@ -290,10 +395,12 @@ const DowngradeConfirmationModal = ( {
 					isBusy={ isDowngrading }
 					disabled={ isDowngrading }
 				>
-					{ translate( 'Downgrade to %(planName)s', {
-						args: { planName: targetPlanTitle },
-						comment: 'Button label to confirm downgrading to a lower-tier plan',
-					} ) }
+					{ mode === 'on_renewal'
+						? translate( 'Downgrade on renewal' )
+						: translate( 'Downgrade to %(planName)s', {
+								args: { planName: targetPlanTitle },
+								comment: 'Button label to confirm downgrading to a lower-tier plan',
+						  } ) }
 				</Button>
 			</HStack>
 		</Modal>

--- a/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/index.tsx
+++ b/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/index.tsx
@@ -231,14 +231,17 @@ const DowngradeConfirmationModal = ( {
 				<>
 					<p className="downgrade-confirmation-modal__description">
 						{ translate(
-							'Your plan will change from %(currentPlan)s to %(targetPlan)s on %(date)s. You’ll keep your current features until then.',
+							'On %(date)s, your plan will switch from %(currentPlan)s to %(targetPlan)s. The renewal price will change from %(currentPrice)s to %(targetPrice)s.',
 							{
 								args: {
+									date: renewalDateFormatted,
 									currentPlan: currentPlanTitle,
 									targetPlan: targetPlanTitle,
-									date: renewalDateFormatted,
+									currentPrice: currentRenewalPriceText ?? '',
+									targetPrice: targetRenewalPriceText ?? '',
 								},
-								comment: 'Message shown when scheduling a plan downgrade for the next renewal date',
+								comment:
+									'Message shown when scheduling a plan downgrade for the next renewal date, including price change',
 							}
 						) }
 					</p>
@@ -341,7 +344,7 @@ const DowngradeConfirmationModal = ( {
 
 	const modalTitle =
 		mode === 'on_renewal'
-			? String( translate( 'Downgrade on renewal' ) )
+			? String( translate( 'Downgrade at renewal' ) )
 			: String( translate( 'Confirm downgrade' ) );
 
 	return (
@@ -368,17 +371,6 @@ const DowngradeConfirmationModal = ( {
 					) ) }
 				</ul>
 			) }
-			{ mode === 'on_renewal' && currentRenewalPriceText && targetRenewalPriceText && (
-				<p className="downgrade-confirmation-modal__description downgrade-confirmation-modal__price-change">
-					{ translate( 'Your renewal price will change from %(currentPrice)s to %(targetPrice)s.', {
-						args: {
-							currentPrice: currentRenewalPriceText,
-							targetPrice: targetRenewalPriceText,
-						},
-						comment: 'Price comparison shown when scheduling a plan downgrade for renewal',
-					} ) }
-				</p>
-			) }
 			<HStack spacing={ 3 } justify="flex-end" className="downgrade-confirmation-modal__buttons">
 				<Button __next40pxDefaultSize variant="tertiary" onClick={ onClose }>
 					{ mode === 'on_renewal'
@@ -396,7 +388,7 @@ const DowngradeConfirmationModal = ( {
 					disabled={ isDowngrading }
 				>
 					{ mode === 'on_renewal'
-						? translate( 'Downgrade on renewal' )
+						? translate( 'Downgrade at renewal' )
 						: translate( 'Downgrade to %(planName)s', {
 								args: { planName: targetPlanTitle },
 								comment: 'Button label to confirm downgrading to a lower-tier plan',

--- a/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/index.tsx
+++ b/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/index.tsx
@@ -260,7 +260,7 @@ const DowngradeConfirmationModal = ( {
 				return (
 					<p className="downgrade-confirmation-modal__description">
 						{ translate(
-							"When you change from %(currentPlan)s to %(targetPlan)s, here's what you'll lose:",
+							'When you change from %(currentPlan)s to %(targetPlan)s, here’s what you’ll lose:',
 							{
 								args: {
 									currentPlan: currentPlanTitle,
@@ -294,7 +294,7 @@ const DowngradeConfirmationModal = ( {
 			return (
 				<p className="downgrade-confirmation-modal__description">
 					{ translate(
-						"When you downgrade from %(currentPlan)s to %(targetPlan)s, you'll receive a refund of %(amount)s to your original payment method.",
+						'When you downgrade from %(currentPlan)s to %(targetPlan)s, you’ll receive a refund of %(amount)s to your original payment method.',
 						{
 							args: {
 								currentPlan: currentPlanTitle,

--- a/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/style.scss
+++ b/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/style.scss
@@ -27,6 +27,10 @@
 	margin-block-start: 2px;
 }
 
+.downgrade-confirmation-modal__price-change {
+	margin-block-start: 16px;
+}
+
 .downgrade-confirmation-modal__buttons {
 	margin-block-start: 24px;
 }

--- a/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/style.scss
+++ b/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/style.scss
@@ -27,10 +27,6 @@
 	margin-block-start: 2px;
 }
 
-.downgrade-confirmation-modal__price-change {
-	margin-block-start: 16px;
-}
-
 .downgrade-confirmation-modal__buttons {
 	margin-block-start: 24px;
 }

--- a/client/my-sites/plans-features-main/hooks/test/use-generate-action-hook.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-generate-action-hook.ts
@@ -23,6 +23,9 @@ jest.mock( 'i18n-calypso', () => ( {
 } ) );
 jest.mock( '@wordpress/data' );
 jest.mock( '../use-generate-action-callback', () => () => jest.fn() );
+jest.mock( 'calypso/lib/purchases/active-downgrade-variant', () => ( {
+	getActiveDowngradeVariant: jest.fn( () => 'control' ),
+} ) );
 
 import {
 	PLAN_BUSINESS,

--- a/client/my-sites/plans-features-main/hooks/test/use-generate-action-hook.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-generate-action-hook.ts
@@ -41,6 +41,7 @@ import {
 import { Plans } from '@automattic/data-stores';
 import { renderHook } from '@testing-library/react';
 import { useSelector } from 'react-redux';
+import { getActiveDowngradeVariant } from 'calypso/lib/purchases/active-downgrade-variant';
 import useGenerateActionHook from '../use-generate-action-hook';
 
 describe( 'useGenerateActionHook', () => {
@@ -114,6 +115,7 @@ describe( 'useGenerateActionHook', () => {
 
 		( Plans.useCurrentPlan as jest.Mock ).mockImplementation( () => null );
 		( Plans.usePricingMetaForGridPlans as jest.Mock ).mockImplementation( () => ( {} ) );
+		( getActiveDowngradeVariant as jest.Mock ).mockReturnValue( 'control' );
 	} );
 
 	it( 'should handle enterprise plans', () => {

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -551,7 +551,8 @@ function getLoggedInPlansAction( {
 
 	// Downgrade action if the plan is not available for purchase.
 	// Skip this when the plan is expired — let it fall through to the "Get {plan}" block.
-	if ( ! availableForPurchase && ! isPlanExpired ) {
+	// Also skip when active downgrades are enabled — fall through to the downgrade label block.
+	if ( ! availableForPurchase && ! isPlanExpired && getActiveDowngradeVariant() === 'control' ) {
 		if ( isEnabled( 'plans/self-service-downgrade' ) ) {
 			return {
 				primary: {
@@ -590,10 +591,9 @@ function getLoggedInPlansAction( {
 	}
 
 	// Show "Downgrade" (secondary) for lower-tier, "Upgrade" (primary) for higher-tier.
-	// Only in change-plan flow (active downgrades) or expired plans — not normal upgrades,
-	// which fall through to the sticky-price block below.
+	// Applies to expired plans, change-plan flow, or when active downgrade flags are on.
 	if (
-		( isPlanExpired || isChangePlanFlow ) &&
+		( isPlanExpired || isChangePlanFlow || getActiveDowngradeVariant() !== 'control' ) &&
 		sitePlanSlug &&
 		getPlanClass( planSlug ) !== getPlanClass( sitePlanSlug )
 	) {
@@ -603,7 +603,7 @@ function getLoggedInPlansAction( {
 		if ( targetTier < currentTier ) {
 			const downgradeLabel =
 				getActiveDowngradeVariant() === 'on_renewal'
-					? translate( 'Downgrade on renewal' )
+					? translate( 'Downgrade at renewal' )
 					: translate( 'Downgrade', { context: 'verb' } );
 			return createLoggedInPlansAction( downgradeLabel, 'secondary' );
 		}

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -23,6 +23,7 @@ import {
 import { AddOns, PlanPricing, Plans } from '@automattic/data-stores';
 import { useState } from '@wordpress/element';
 import { type LocalizeProps, type TranslateResult, useTranslate } from 'i18n-calypso';
+import { getActiveDowngradeVariant } from 'calypso/lib/purchases/active-downgrade-variant';
 import { useSelector } from 'calypso/state';
 import getDomainFromHomeUpsellInQuery from 'calypso/state/selectors/get-domain-from-home-upsell-in-query';
 import {
@@ -600,10 +601,11 @@ function getLoggedInPlansAction( {
 		const targetTier = PLAN_TIER_ORDER[ getPlanClass( planSlug ) ] ?? 0;
 
 		if ( targetTier < currentTier ) {
-			return createLoggedInPlansAction(
-				translate( 'Downgrade', { context: 'verb' } ),
-				'secondary'
-			);
+			const downgradeLabel =
+				getActiveDowngradeVariant() === 'on_renewal'
+					? translate( 'Downgrade on renewal' )
+					: translate( 'Downgrade', { context: 'verb' } );
+			return createLoggedInPlansAction( downgradeLabel, 'secondary' );
 		}
 		return createLoggedInPlansAction( translate( 'Upgrade', { context: 'verb' } ) );
 	}

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -592,6 +592,7 @@ function getLoggedInPlansAction( {
 
 	// Show "Downgrade" (secondary) for lower-tier, "Upgrade" (primary) for higher-tier.
 	// Applies to expired plans, change-plan flow, or when active downgrade flags are on.
+	// When `isStuck` and the target is an upgrade, fall through to the sticky-price block below.
 	if (
 		( isPlanExpired || isChangePlanFlow || getActiveDowngradeVariant() !== 'control' ) &&
 		sitePlanSlug &&
@@ -607,7 +608,9 @@ function getLoggedInPlansAction( {
 					: translate( 'Downgrade', { context: 'verb' } );
 			return createLoggedInPlansAction( downgradeLabel, 'secondary' );
 		}
-		return createLoggedInPlansAction( translate( 'Upgrade', { context: 'verb' } ) );
+		if ( ! isStuck ) {
+			return createLoggedInPlansAction( translate( 'Upgrade', { context: 'verb' } ) );
+		}
 	}
 
 	/**

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -28,6 +28,7 @@ import {
 import page from '@automattic/calypso-router';
 import { Button, Spinner } from '@automattic/components';
 import { WpcomPlansUI, AddOns, Plans } from '@automattic/data-stores';
+import { formatCurrency } from '@automattic/number-formatters';
 import { isAnyHostingFlow } from '@automattic/onboarding';
 import {
 	FeaturesGrid,
@@ -451,7 +452,7 @@ const PlansFeaturesMain = ( {
 		// Downgrade confirmation (expired plans → checkout, active plans → cancel API)
 		const isDowngradeGateOpen = isPlanExpired
 			? config.isEnabled( 'plans/expired-plan-downgrade' )
-			: getActiveDowngradeVariant() === 'instant';
+			: getActiveDowngradeVariant() !== 'control';
 		if (
 			isDowngradeGateOpen &&
 			sitePlanSlug &&
@@ -996,6 +997,30 @@ const PlansFeaturesMain = ( {
 					onClose={ () => setPendingDowngradePlanSlug( null ) }
 					purchase={ currentPlanPurchase }
 					isPlanExpired={ isPlanExpired }
+					mode={
+						getActiveDowngradeVariant() === 'on_renewal' && ! isPlanExpired
+							? 'on_renewal'
+							: 'immediate'
+					}
+					currentRenewalPriceText={
+						currentPlanPurchase
+							? formatCurrency( currentPlanPurchase.amount, currentPlanPurchase.currencyCode )
+							: ''
+					}
+					targetRenewalPriceText={ ( () => {
+						if ( ! pendingDowngradePlanSlug || ! gridPlansForFeaturesGrid ) {
+							return '';
+						}
+						const targetGridPlan = gridPlansForFeaturesGrid.find(
+							( gp ) => gp.planSlug === pendingDowngradePlanSlug
+						);
+						const price = targetGridPlan?.pricing.originalPrice.full;
+						const currency = targetGridPlan?.pricing.currencyCode;
+						if ( price == null || ! currency ) {
+							return '';
+						}
+						return formatCurrency( price, currency );
+					} )() }
 				/>
 				{ siteId && gridPlansForFeaturesGrid && (
 					<PlanNotice

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -1019,7 +1019,7 @@ const PlansFeaturesMain = ( {
 						if ( price == null || ! currency ) {
 							return '';
 						}
-						return formatCurrency( price, currency );
+						return formatCurrency( price, currency, { isSmallestUnit: true } );
 					} )() }
 				/>
 				{ siteId && gridPlansForFeaturesGrid && (

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -240,7 +240,14 @@ class PlansComponent extends Component {
 				intent={ plansIntent }
 				isSpotlightOnCurrentPlan={ showSpotlight && ! isPlanExpired }
 				highlightLabelOverrides={ highlightLabelOverrides }
-				hideFreePlan={ isPlanExpired || ! visiblePlanTiers.includes( TYPE_FREE ) || undefined }
+				hideFreePlan={
+					isPlanExpired ||
+					( ! isFreePlan &&
+						( isEnabled( 'plans/active-plan-downgrade-instant' ) ||
+							isEnabled( 'plans/scheduled-plan-downgrade' ) ) ) ||
+					! visiblePlanTiers.includes( TYPE_FREE ) ||
+					undefined
+				}
 				hidePersonalPlan={ ! visiblePlanTiers.includes( TYPE_PERSONAL ) || undefined }
 				hidePremiumPlan={ ! visiblePlanTiers.includes( TYPE_PREMIUM ) || undefined }
 				hideBusinessPlan={ ! visiblePlanTiers.includes( TYPE_BUSINESS ) || undefined }


### PR DESCRIPTION
Depends on: https://github.com/Automattic/wp-calypso/pull/111323

## Proposed Changes

This is PR 2/4 that adds a delayed downgrade capability to all active plans. This PR focuses on wiring the foundational pieces implemented in part one to the front-end of MSD. Calypso will be handled separately.

<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/33c64e0f-5d2e-4a28-b86a-41a2e9dc0858" />
<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/9ebdffbf-6019-40da-920b-d43c1c18f934" />
<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/f46d51e7-47c8-40be-9b23-f75595608f86" />
<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/eddadf62-db0e-4462-b1f5-a24e36e093ff" />
<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/bbc582a6-af1a-4cd2-9f14-630e36d85589" />


Technical details:
- Wire the on-renewal downgrade schedule flow for the dashboard:
  - **Purchase Settings entry point**: "Change plan" action (shared copy for both instant and on-renewal arms)
  - **Plans grid**: "Downgrade at renewal" button label for lower-tier plans when `plans/scheduled-plan-downgrade` flag is on
  - **Confirmation modal**: on_renewal mode with date, price change, feature loss list, and schedule mutation via `scheduleDowngradeAsync`
  - **Plan-upgrade stepper**: suppress refund subtitle for on-renewal variant
- Polish copy: "on renewal" → "at renewal" throughout, merge date + price into single paragraph
- Fix `formatCurrency` to pass `isSmallestUnit` for renewal price display
- Hide Free plan in legacy grid when active downgrade flags are enabled
- Broaden downgrade label/action conditions to include flagged active downgrades (not only change-plan flow)

## Why are these changes being made?

This is the on-renewal scheduling arm of the self-serve plan downgrade feature. Instead of an immediate cancel-and-refund, users with active plans can schedule a downgrade that takes effect at their next renewal date. They keep current features until then.

Stacks on `add/downgrade-renewal-foundation` (types, mutators, query hooks) and depends on the `try/downgrades-on-renewal` sandbox backend for the `/upgrades/{id}/schedule-downgrade` endpoint.

## Testing Instructions

1. Enable `plans/expired-plan-downgrade`, `plans/active-plan-downgrade-instant`, and `plans/scheduled-plan-downgrade` flags in development config
2. Navigate to Purchase Settings for an active Business or Premium plan
3. Click "Change plan" → "See plans"
4. Lower-tier plans should show "Downgrade at renewal" buttons
5. Click one → confirmation modal should show renewal date, price change, feature losses
6. Confirm → schedule mutation fires (requires sandbox backend)

**Note**: Backend endpoint at `POST /upgrades/{id}/schedule-downgrade` lives on the `try/downgrades-on-renewal` sandbox branch. Without it, the confirm action will 500.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?

🤖 Generated with [Claude Code](https://claude.com/claude-code)