### PR TITLE
Odyssey Stats: scope wp-admin section-title heading reset to period nav

### DIFF
--- a/apps/odyssey-stats/src/styles/wp-admin.scss
+++ b/apps/odyssey-stats/src/styles/wp-admin.scss
@@ -97,13 +97,15 @@
 		}
 	}
 
-	// Some `.stats-section-title` markup wraps a bare child `<h3>` (e.g.
-	// stats-date-label, stats-email-summary). wp-admin core (common.css) applies
-	// an unlayered `h2, h3 { font-size: 1.3em; margin: 1em 0; color: #1d2327 }`
-	// that wins over Calypso's `@layer reset`, inflating that inner heading and
-	// double-spacing it against its wrapper. Re-anchor it on the wrapper so the
-	// inner h3 follows the wrapper's (responsive) size/color and adds no margin.
-	& .stats-section-title h3 {
+	// The period-navigation heading (stats-date-label) wraps a bare child `<h3>`
+	// inside `.stats-section-title`. wp-admin core (common.css) applies an
+	// unlayered `h2, h3 { font-size: 1.3em; margin: 1em 0; color: #1d2327 }` that
+	// wins over Calypso's `@layer reset`, inflating that inner heading and
+	// double-spacing it against its wrapper. Scope the reset to the period nav so
+	// the inner h3 follows the wrapper's (responsive) size/color and adds no
+	// margin — without touching other `.stats-section-title` headings (e.g. the
+	// Emails summary, which lives under `.stats-summary-nav`, not the period nav).
+	& .stats-period-navigation .stats-section-title h3 {
 		font-size: inherit;
 		margin: 0;
 		color: inherit;


### PR DESCRIPTION
Part of STATS-260 — follow-up to #111390.

## Proposed Changes

* Narrow the wp-admin `.stats-section-title` inner-`<h3>` reset added in #111390 from `.stats-section-title h3` to `.stats-period-navigation .stats-section-title h3`.

## Why are these changes being made?

The reset in #111390 was too broad: `.stats-section-title h3` matched the bare inner `<h3>` in *every* "div-wraps-h3" usage, including the **Emails** summary heading (which lives under `.stats-summary-nav`, not the period nav), changing headings it shouldn't have. Only the traffic-page period heading (`stats-date-label`, rendered inside `StatsPeriodNavigation`) needs the reset — that's the one whose bare inner `<h3>` is inflated/double-margined by wp-admin core's unlayered `h2, h3` rule leaking past Calypso's `@layer reset`. Scoping to `.stats-period-navigation` targets only that case and leaves other section titles untouched.

The structural fix (a shared `StatsSectionTitle` component that removes the bare-inner-h3 markup, after which this whole workaround can go away) remains tracked in STATS-262.

## Testing Instructions

* In Odyssey Stats (wp-admin): open **Stats → Traffic** and confirm the period heading (e.g. "Stats for December 7") renders at the correct size/spacing on desktop and mobile.
* Open **Stats → Emails** and confirm the "Stats for Emails" heading is unchanged (no longer affected by the reset).

## Screenshots

<!-- Capture in Odyssey/wp-admin (a Jetpack/Atomic site). Before/After of the Traffic period heading + the Emails heading. -->

| Before | After |
|---|---|
| _todo_ | _todo_ |

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)