### PR TITLE
feat(plans): honor student entitlements

### DIFF
--- a/client/dashboard/sites/performance/backend-access.ts
+++ b/client/dashboard/sites/performance/backend-access.ts
@@ -1,4 +1,4 @@
-import { BusinessPlans, EcommercePlans } from '@automattic/api-core';
+import { BusinessPlans, EcommercePlans, StudentPlans } from '@automattic/api-core';
 
 export function hasBackendAccess( productSlug: string | undefined ) {
 	if ( ! productSlug ) {
@@ -6,6 +6,7 @@ export function hasBackendAccess( productSlug: string | undefined ) {
 	}
 	return (
 		( BusinessPlans as readonly string[] ).includes( productSlug ) ||
-		( EcommercePlans as readonly string[] ).includes( productSlug )
+		( EcommercePlans as readonly string[] ).includes( productSlug ) ||
+		( StudentPlans as readonly string[] ).includes( productSlug )
 	);
 }

--- a/client/dashboard/sites/performance/test/backend-access.test.ts
+++ b/client/dashboard/sites/performance/test/backend-access.test.ts
@@ -1,0 +1,13 @@
+import { DotcomPlans } from '@automattic/api-core';
+import { hasBackendAccess } from '../backend-access';
+
+describe( 'hasBackendAccess', () => {
+	test( 'allows Student plans', () => {
+		expect( hasBackendAccess( DotcomPlans.STUDENT ) ).toBe( true );
+	} );
+
+	test( 'does not allow lower-tier plans', () => {
+		expect( hasBackendAccess( DotcomPlans.PREMIUM ) ).toBe( false );
+		expect( hasBackendAccess( undefined ) ).toBe( false );
+	} );
+} );

--- a/client/dashboard/sites/plans.ts
+++ b/client/dashboard/sites/plans.ts
@@ -34,6 +34,7 @@ export const isSitePlanBigSkyTrial = ( site: Site ) => {
 		DotcomPlans.BUSINESS_MONTHLY,
 		DotcomPlans.BUSINESS_2_YEARS,
 		DotcomPlans.BUSINESS_3_YEARS,
+		DotcomPlans.STUDENT,
 		DotcomPlans.PREMIUM,
 		DotcomPlans.PREMIUM_MONTHLY,
 		DotcomPlans.PREMIUM_2_YEARS,

--- a/client/dashboard/sites/test/plans.test.ts
+++ b/client/dashboard/sites/test/plans.test.ts
@@ -1,0 +1,24 @@
+import { DotcomPlans } from '@automattic/api-core';
+import { isSitePlanBigSkyTrial, isSitePlanPaid } from '../plans';
+import type { Site } from '@automattic/api-core';
+
+const makeSite = ( productSlug: string ): Site =>
+	( {
+		launch_status: 'unlaunched',
+		options: {
+			site_creation_flow: 'ai-site-builder',
+		},
+		plan: {
+			product_slug: productSlug,
+		},
+	} ) as Site;
+
+describe( 'site plan helpers', () => {
+	test( 'does not treat Student as a Big Sky trial plan', () => {
+		expect( isSitePlanBigSkyTrial( makeSite( DotcomPlans.STUDENT ) ) ).toBe( false );
+	} );
+
+	test( 'treats Student as a paid plan', () => {
+		expect( isSitePlanPaid( makeSite( DotcomPlans.STUDENT ) ) ).toBe( true );
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
@@ -1,12 +1,6 @@
 import { siteBySlugQuery } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
-import {
-	FEATURE_BIG_SKY,
-	isBusiness,
-	isEcommerce,
-	isPersonal,
-	isPremium,
-} from '@automattic/calypso-products';
+import { FEATURE_BIG_SKY, isEcommerce } from '@automattic/calypso-products';
 import { SiteIntent } from '@automattic/data-stores/src/onboard';
 import { Step } from '@automattic/onboarding';
 import { useQuery } from '@tanstack/react-query';
@@ -64,7 +58,6 @@ const PostCheckoutOnboarding: StepType< {
 	const showBigSkyChoice =
 		isEnabled( 'onboarding/post-checkout-ai-step' ) &&
 		!! site?.plan &&
-		( isPersonal( site.plan ) || isPremium( site.plan ) || isBusiness( site.plan ) ) &&
 		site.plan.features?.active?.includes( FEATURE_BIG_SKY );
 
 	const intent = useSelect(

--- a/client/landing/stepper/hooks/use-is-site-big-sky-eligible.ts
+++ b/client/landing/stepper/hooks/use-is-site-big-sky-eligible.ts
@@ -39,11 +39,12 @@ export function useIsBigSkyEligible( flowName?: string ) {
 	);
 
 	const isEligibleGoals = isGoalsBigSkyEligible( goals );
+	const siteHasBigSkyFeature = site?.plan?.features?.active?.includes( FEATURE_BIG_SKY ) ?? false;
 	const isEligiblePlan =
 		isPersonalPlan( product_slug ) ||
 		isPremiumPlan( product_slug ) ||
-		isBusinessPlan( product_slug );
-	const siteHasBigSkyFeature = site?.plan?.features?.active?.includes( FEATURE_BIG_SKY ) ?? false;
+		isBusinessPlan( product_slug ) ||
+		siteHasBigSkyFeature;
 
 	if ( flowName === AI_SITE_BUILDER_FLOW ) {
 		return { isEligible: true };

--- a/client/landing/stepper/hooks/use-site-preview-share-code.ts
+++ b/client/landing/stepper/hooks/use-site-preview-share-code.ts
@@ -1,4 +1,8 @@
-import { isWpComBusinessPlan, isWpComEcommercePlan } from '@automattic/calypso-products';
+import {
+	isWpComBusinessPlan,
+	isWpComEcommercePlan,
+	isWpComStudentPlan,
+} from '@automattic/calypso-products';
 import { useEffect } from 'react';
 import { useCreateSitePreviewLink } from 'calypso/components/site-preview-links/use-create-site-preview-link';
 import { useSitePreviewLinks } from 'calypso/components/site-preview-links/use-site-preview-links';
@@ -13,9 +17,14 @@ export function useSitePreviewShareCode() {
 	const isEcommercePlan = site?.plan?.product_slug
 		? isWpComEcommercePlan( site?.plan?.product_slug )
 		: false;
+	const isStudentPlan = site?.plan?.product_slug
+		? isWpComStudentPlan( site?.plan?.product_slug )
+		: false;
 
 	const usePreviewSiteLinksQueryEnabled =
-		site?.is_coming_soon && ( isBusinessPlan || isEcommercePlan ) && site?.is_wpcom_atomic;
+		site?.is_coming_soon &&
+		( isBusinessPlan || isEcommercePlan || isStudentPlan ) &&
+		site?.is_wpcom_atomic;
 
 	// Retrieves site preview share code if it exists
 	const { data: previewLinks, isInitialLoading: isPreviewLinksLoading } = useSitePreviewLinks( {
@@ -28,15 +37,14 @@ export function useSitePreviewShareCode() {
 		siteId: Number( site?.ID ),
 	} );
 
-	// Generate preview link for site on business or ecommerce plan
-	// Preview links are only available on these two plans
+	// Generate preview link for eligible Atomic sites.
 	useEffect( () => {
 		if ( previewLinks && Array.isArray( previewLinks ) && previewLinks.length === 0 ) {
-			if ( isBusinessPlan || isEcommercePlan ) {
+			if ( isBusinessPlan || isEcommercePlan || isStudentPlan ) {
 				createLink();
 			}
 		}
-	}, [ previewLinks, createLink, isBusinessPlan, isEcommercePlan ] );
+	}, [ previewLinks, createLink, isBusinessPlan, isEcommercePlan, isStudentPlan ] );
 
 	const shareCode = previewLinks?.[ 0 ]?.code;
 

--- a/client/my-sites/marketing/do-it-for-me/use-difm-plan-info.ts
+++ b/client/my-sites/marketing/do-it-for-me/use-difm-plan-info.ts
@@ -8,6 +8,7 @@ import {
 	isBusiness,
 	isEcommerce,
 	isPro,
+	isStudentPlan,
 	getFeatureByKey,
 } from '@automattic/calypso-products';
 import { formatCurrency } from '@automattic/number-formatters';
@@ -23,8 +24,8 @@ import { getSitePlan } from 'calypso/state/sites/selectors';
 const hasHigherPlan = ( currentPlan: string, plan: typeof PLAN_PREMIUM | typeof PLAN_BUSINESS ) => {
 	const planMatchers =
 		plan === PLAN_PREMIUM
-			? [ isPremium, isBusiness, isEcommerce, isPro ]
-			: [ isBusiness, isEcommerce, isPro ];
+			? [ isPremium, isBusiness, isEcommerce, isPro, isStudentPlan ]
+			: [ isBusiness, isEcommerce, isPro, isStudentPlan ];
 
 	return planMatchers.some( ( planMatcher ) =>
 		planMatcher( {

--- a/client/my-sites/podcast/components/welcome.tsx
+++ b/client/my-sites/podcast/components/welcome.tsx
@@ -3,6 +3,7 @@ import {
 	isEcommercePlan,
 	isPersonalPlan,
 	isPremiumPlan,
+	isStudentPlan,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { PlanPrice } from '@automattic/components';
@@ -21,8 +22,9 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getSitePlanSlug from 'calypso/state/sites/selectors/get-site-plan-slug';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
-type PlanSlug = 'personal' | 'premium' | 'business';
-type PlanTier = 'free' | PlanSlug;
+type PurchasablePlanSlug = 'personal' | 'premium' | 'business';
+type DisplayPlanSlug = PurchasablePlanSlug | 'student';
+type PlanTier = 'free' | DisplayPlanSlug;
 type Translate = ReturnType< typeof useTranslate >;
 
 const getPlanTier = ( planSlug: string | null ): PlanTier => {
@@ -31,6 +33,9 @@ const getPlanTier = ( planSlug: string | null ): PlanTier => {
 	}
 	if ( isBusinessPlan( planSlug ) || isEcommercePlan( planSlug ) ) {
 		return 'business';
+	}
+	if ( isStudentPlan( planSlug ) ) {
+		return 'student';
 	}
 	if ( isPremiumPlan( planSlug ) ) {
 		return 'premium';
@@ -42,10 +47,10 @@ const getPlanTier = ( planSlug: string | null ): PlanTier => {
 };
 
 interface PlanDef {
-	slug: PlanSlug;
+	slug: DisplayPlanSlug;
 	name: string;
 	blurb: string;
-	price: number;
+	price?: number;
 	features: string[];
 }
 
@@ -91,6 +96,17 @@ function getPlanCards( tier: PlanTier, translate: Translate ): PlanCard[] {
 			translate( 'SFTP, WP-CLI, and GitHub Deployments' ) as string,
 		],
 	};
+	const student: PlanDef = {
+		slug: 'student',
+		name: translate( 'Student' ) as string,
+		blurb: translate( 'Podcasting is included in your Student plan.' ) as string,
+		features: [
+			translate( 'Audio upload to WordPress.com' ) as string,
+			translate( 'Podcast dashboard' ) as string,
+			translate( 'Native podcast stats' ) as string,
+			translate( 'Episode block' ) as string,
+		],
+	};
 
 	switch ( tier ) {
 		case 'free':
@@ -110,7 +126,13 @@ function getPlanCards( tier: PlanTier, translate: Translate ): PlanCard[] {
 			];
 		case 'business':
 			return [ { plan: business, label: 'your-plan' } ];
+		case 'student':
+			return [ { plan: student, label: 'your-plan' } ];
 	}
+}
+
+function isPurchasablePlanSlug( planSlug: DisplayPlanSlug ): planSlug is PurchasablePlanSlug {
+	return planSlug === 'personal' || planSlug === 'premium' || planSlug === 'business';
 }
 
 const getBenefits = (
@@ -198,7 +220,7 @@ function Welcome() {
 
 	// Redirect through Calypso checkout, then back to /settings/podcast so the user can
 	// click Enable on their now-eligible plan.
-	const goToCheckout = ( targetPlan: PlanSlug ) => {
+	const goToCheckout = ( targetPlan: PurchasablePlanSlug ) => {
 		dispatch(
 			recordTracksEvent( 'calypso_podcast_upgrade_clicked', {
 				plan_slug: targetPlan,
@@ -301,11 +323,21 @@ function Welcome() {
 											</Text>
 											<Text variant="muted">{ plan.blurb }</Text>
 										</VStack>
-										<PlanPrice rawPrice={ plan.price } currencyCode="USD" displayPerMonthNotation />
+										{ typeof plan.price === 'number' && (
+											<PlanPrice
+												rawPrice={ plan.price }
+												currencyCode="USD"
+												displayPerMonthNotation
+											/>
+										) }
 										<Button
 											className="podcast__plan-cta"
 											variant={ isRecommended || isYourPlan ? 'primary' : 'secondary' }
-											onClick={ () => ( isYourPlan ? goToSettings() : goToCheckout( plan.slug ) ) }
+											onClick={ () =>
+												isYourPlan || ! isPurchasablePlanSlug( plan.slug )
+													? goToSettings()
+													: goToCheckout( plan.slug )
+											}
 										>
 											{ isYourPlan
 												? translate( 'Enable podcasting' )

--- a/client/my-sites/site-settings/fediverse-settings/WpcomFediverseSettingsSection.jsx
+++ b/client/my-sites/site-settings/fediverse-settings/WpcomFediverseSettingsSection.jsx
@@ -1,4 +1,10 @@
-import { getPlan, isFreePlanProduct, PLAN_BUSINESS } from '@automattic/calypso-products';
+import {
+	getPlan,
+	isFreePlanProduct,
+	isWpComBusinessPlan,
+	isWpComStudentPlan,
+	PLAN_BUSINESS,
+} from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
@@ -97,7 +103,8 @@ const BusinessPlanUpsellCard = ( { siteId } ) => {
 	const sitePlanSlug = useSelector( ( state ) => getSitePlanSlug( state, siteId ) ?? '' );
 	// If the user is already on Atomic, we'll be in `JetpackFediverseSettingsSection` instead.
 	// But they could have purchased the upgrade and not have transferred yet.
-	const isBusinessPlan = sitePlanSlug === PLAN_BUSINESS;
+	const canInstallActivityPubPlugin =
+		isWpComBusinessPlan( sitePlanSlug ) || isWpComStudentPlan( sitePlanSlug );
 	const domain = useSelector( ( state ) => getSiteDomain( state, siteId ) );
 	const linkUrl = `/plans/select/business/${ domain }`;
 	const translate = useTranslate();
@@ -107,7 +114,7 @@ const BusinessPlanUpsellCard = ( { siteId } ) => {
 		recordTracksEvent( 'calypso_activitypub_business_plan_upsell_click', { route: currentRoute } );
 	};
 	const planName = getPlan( PLAN_BUSINESS )?.getTitle() ?? '';
-	if ( isBusinessPlan ) {
+	if ( canInstallActivityPubPlugin ) {
 		// show a card that links to the plugin page to install the ActivityPub plugin
 		return (
 			<div>

--- a/client/sites-dashboard/components/with-atomic-transfer.tsx
+++ b/client/sites-dashboard/components/with-atomic-transfer.tsx
@@ -1,4 +1,4 @@
-import { isBusinessPlan, isEcommercePlan } from '@automattic/calypso-products';
+import { planHasFeature, WPCOM_FEATURES_ATOMIC } from '@automattic/calypso-products';
 import { useCheckSiteTransferStatus } from '../hooks/use-check-site-transfer-status';
 import type { SiteExcerptData } from '@automattic/sites';
 
@@ -19,9 +19,9 @@ const MaybePollAtomicTransfer = ( { site, children }: WithAtomicTransferProps ) 
 		return children( { wasTransferring: false } );
 	}
 
-	const isBusinessOrEcommerceSite = isBusinessPlan( sitePlan ) || isEcommercePlan( sitePlan );
+	const hasAtomicFeature = planHasFeature( sitePlan, WPCOM_FEATURES_ATOMIC );
 
-	if ( ! isBusinessOrEcommerceSite ) {
+	if ( ! hasAtomicFeature ) {
 		return children( { wasTransferring: false } );
 	}
 

--- a/client/state/sites/plans/selectors/is-site-big-sky-trial.ts
+++ b/client/state/sites/plans/selectors/is-site-big-sky-trial.ts
@@ -11,6 +11,7 @@ import {
 	PLAN_PREMIUM_MONTHLY,
 	PLAN_PREMIUM_2_YEARS,
 	PLAN_PREMIUM_3_YEARS,
+	PLAN_STUDENT,
 	PLAN_ECOMMERCE_MONTHLY,
 	PLAN_ECOMMERCE_2_YEARS,
 	PLAN_ECOMMERCE_3_YEARS,
@@ -51,6 +52,7 @@ export default function isSiteBigSkyTrial( state: AppState, siteId: number ) {
 		PLAN_PREMIUM_MONTHLY,
 		PLAN_PREMIUM_2_YEARS,
 		PLAN_PREMIUM_3_YEARS,
+		PLAN_STUDENT,
 	];
 
 	const productSlug = currentPlan?.productSlug || site?.plan?.product_slug;


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #
Depends on #111397 (#111349)
## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
