### PR TITLE
WIP/test: feat(plans): show student upgrade paths

### DIFF
--- a/client/dashboard/sites/site-plans/index.tsx
+++ b/client/dashboard/sites/site-plans/index.tsx
@@ -1,4 +1,9 @@
-import { SubscriptionBillPeriod } from '@automattic/api-core';
+import {
+	BusinessPlans,
+	DotcomPlans,
+	EcommercePlans,
+	SubscriptionBillPeriod,
+} from '@automattic/api-core';
 import { sitePlansQuery, siteBySlugQuery } from '@automattic/api-queries';
 import { formatCurrency, getCurrencyObject } from '@automattic/number-formatters';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
@@ -38,6 +43,12 @@ type UpgradeCreditsSource = 'plan' | 'domain' | 'other-upgrades' | 'domain-and-o
 
 type UpgradeCredit = { amount: number; currencyCode: string; source: UpgradeCreditsSource };
 
+const STUDENT_PLAN_UPGRADE_BILL_PERIODS: SubscriptionBillPeriodValue[] = [
+	SubscriptionBillPeriod.PLAN_ANNUAL_PERIOD,
+	SubscriptionBillPeriod.PLAN_BIENNIAL_PERIOD,
+	SubscriptionBillPeriod.PLAN_TRIENNIAL_PERIOD,
+];
+
 /**
  * Computes the upgrade credit to display in the notice banner, or null if none applies.
  *
@@ -47,7 +58,8 @@ type UpgradeCredit = { amount: number; currencyCode: string; source: UpgradeCred
  */
 function getUpgradeCredit(
 	activePlans: Array< { sitePlan: SiteContextualPlan; tierRank: number } >,
-	currentTierRank: number
+	currentTierRank: number,
+	hasHiddenCurrentPlan = false
 ): UpgradeCredit | null {
 	let amount = 0;
 	let currencyCode = '';
@@ -87,10 +99,22 @@ function getUpgradeCredit(
 	} else {
 		// No explicit override code: infer from whether the user has a shown plan.
 		// If they do (currentTierRank >= 0), this is likely a paid-plan upgrade credit.
-		source = currentTierRank >= 0 ? 'plan' : 'other-upgrades';
+		source = currentTierRank >= 0 || hasHiddenCurrentPlan ? 'plan' : 'other-upgrades';
 	}
 
 	return { amount, currencyCode, source };
+}
+
+function StudentPlanNotice() {
+	return (
+		<div className="site-plans__student-plan-notice">
+			<Notice variant="info" density="high">
+				{ __(
+					'This site is on the Student plan. Business and Commerce upgrade options are shown below.'
+				) }
+			</Notice>
+		</div>
+	);
 }
 
 function UpgradeCreditsNotice( {
@@ -723,11 +747,24 @@ export default function SitePlans() {
 	const plansByProductId = new Map< number, SiteContextualPlan >(
 		( sitePlans ?? [] ).map( ( p ) => [ p.product_id, p ] )
 	);
+	const currentPlanSlug =
+		sitePlans?.find( ( p ) => p.current_plan )?.product_slug ?? site.plan?.product_slug;
+	const isCurrentPlanStudent = currentPlanSlug === DotcomPlans.STUDENT;
+	const studentUpgradePlanSlugs = [ ...BusinessPlans, ...EcommercePlans ] as readonly string[];
 
 	// Plans to show, sorted by plan_card_order — one entry per plan family (deduplicated by
 	// product_tier_id in case multiple billing-period variants carry a plan_card_order).
 	const shownPlans = ( sitePlans ?? [] )
 		.filter( ( p ) => typeof p.plan_card_order === 'number' )
+		.filter( ( p ) => {
+			if ( ! isCurrentPlanStudent ) {
+				return true;
+			}
+			return ( p.product_tier_product_ids ?? [] ).some( ( id ) => {
+				const slug = plansByProductId.get( id )?.product_slug;
+				return !! slug && studentUpgradePlanSlugs.includes( slug );
+			} );
+		} )
 		.filter(
 			( p, index, arr ) =>
 				arr.findIndex( ( q ) => q.product_tier_id === p.product_tier_id ) === index
@@ -750,7 +787,12 @@ export default function SitePlans() {
 				} )
 			)
 		)
-	).sort( ( a, b ) => a - b ) as SubscriptionBillPeriodValue[];
+	)
+		.filter(
+			( billPeriod ) =>
+				! isCurrentPlanStudent || STUDENT_PLAN_UPGRADE_BILL_PERIODS.includes( billPeriod )
+		)
+		.sort( ( a, b ) => a - b ) as SubscriptionBillPeriodValue[];
 
 	const activePlans = shownPlans.map( ( canonicalPlan, tierRank ) => {
 		const siblings = ( canonicalPlan.product_tier_product_ids ?? [] )
@@ -768,8 +810,6 @@ export default function SitePlans() {
 	} );
 
 	// Tier rank of the current plan (by product_tier_id)
-	const currentPlanSlug =
-		sitePlans?.find( ( p ) => p.current_plan )?.product_slug ?? site.plan?.product_slug;
 	const currentTierRank = shownPlans.findIndex( ( p ) =>
 		( p.product_tier_product_ids ?? [] )
 			.map( ( id ) => plansByProductId.get( id )?.product_slug )
@@ -786,7 +826,7 @@ export default function SitePlans() {
 		planCardName: ap.sitePlan.plan_card_name ?? ap.sitePlan.product_name,
 	} ) );
 
-	const upgradeCredit = getUpgradeCredit( activePlans, currentTierRank );
+	const upgradeCredit = getUpgradeCredit( activePlans, currentTierRank, isCurrentPlanStudent );
 
 	return (
 		<PageLayout
@@ -812,6 +852,7 @@ export default function SitePlans() {
 							source={ upgradeCredit.source }
 						/>
 					) }
+					{ isCurrentPlanStudent && <StudentPlanNotice /> }
 					<div className="site-plans__interval-selector-wrap">
 						<BillingIntervalSelector
 							billingInterval={ billingInterval }

--- a/client/dashboard/sites/site-plans/style.scss
+++ b/client/dashboard/sites/site-plans/style.scss
@@ -18,6 +18,10 @@
 	margin-block-start: 16px;
 }
 
+.site-plans__student-plan-notice {
+	margin-block-start: 16px;
+}
+
 .site-plans__grid {
 	margin-block-start: 16px;
 	display: grid;

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -5,6 +5,7 @@ import {
 	getPlan,
 	is100Year,
 	isFreePlanProduct,
+	isWpComStudentPlan,
 	PLAN_ECOMMERCE,
 	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 	PLAN_HOSTING_TRIAL_MONTHLY,
@@ -33,6 +34,7 @@ import QueryProducts from 'calypso/components/data/query-products-list';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import EmptyContent from 'calypso/components/empty-content';
 import Main from 'calypso/components/main';
+import Notice from 'calypso/components/notice';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
@@ -107,9 +109,13 @@ class PlansComponent extends Component {
 	}
 
 	isInvalidPlanInterval() {
-		const { isSiteEligibleForMonthlyPlan, intervalType, selectedSite } = this.props;
+		const { currentPlan, isSiteEligibleForMonthlyPlan, intervalType, selectedSite } = this.props;
 
 		if ( 'monthly' === intervalType && selectedSite ) {
+			if ( isWpComStudentPlan( currentPlan?.productSlug ) ) {
+				return true;
+			}
+
 			// This is the reason isInvalidPlanInterval even exists and the redirection isn't handled at controller level
 			return ! isSiteEligibleForMonthlyPlan;
 		}
@@ -184,6 +190,7 @@ class PlansComponent extends Component {
 		const hideEcommerce = deEmphasizedExperiment?.isVariantB && isFreePlan;
 
 		const isExperimentVariant = deEmphasizedExperiment && ! deEmphasizedExperiment.isControl;
+		const isStudentPlan = isWpComStudentPlan( currentPlan?.productSlug );
 		const highlightLabelOverrides =
 			isExperimentVariant && currentPlan?.productSlug
 				? { [ currentPlan.productSlug ]: this.props.translate( 'Current plan' ) }
@@ -191,37 +198,50 @@ class PlansComponent extends Component {
 
 		// Experiment: filter the visible plan tiers to those at or above the current plan.
 		const currentTier = getPlan( currentPlan?.productSlug )?.type;
-		const visiblePlanTiers =
-			isExperimentVariant && currentTier && PLAN_TIERS.includes( currentTier )
-				? PLAN_TIERS.slice( PLAN_TIERS.indexOf( currentTier ) )
-				: PLAN_TIERS;
+		let visiblePlanTiers = PLAN_TIERS;
+		if ( isStudentPlan ) {
+			visiblePlanTiers = [ TYPE_BUSINESS, TYPE_ECOMMERCE ];
+		} else if ( isExperimentVariant && currentTier && PLAN_TIERS.includes( currentTier ) ) {
+			visiblePlanTiers = PLAN_TIERS.slice( PLAN_TIERS.indexOf( currentTier ) );
+		}
 
 		return (
-			<PlansFeaturesMain
-				isInSiteDashboard={ isUntangled }
-				redirectToAddDomainFlow={ this.props.redirectToAddDomainFlow }
-				customerType={ this.props.customerType }
-				intervalType={ this.props.intervalType }
-				selectedFeature={ this.props.selectedFeature }
-				selectedPlan={ this.props.selectedPlan }
-				redirectTo={ this.props.redirectTo }
-				pluginSlug={ this.props.pluginSlug }
-				coupon={ this.props.coupon }
-				discountEndDate={ this.props.discountEndDate }
-				siteId={ selectedSite?.ID }
-				plansWithScroll={ false }
-				showLegacyStorageFeature={ this.props.siteHasLegacyStorage }
-				intent={ plansIntent }
-				isSpotlightOnCurrentPlan={ showSpotlight }
-				highlightLabelOverrides={ highlightLabelOverrides }
-				hideFreePlan={ ! visiblePlanTiers.includes( TYPE_FREE ) || undefined }
-				hidePersonalPlan={ ! visiblePlanTiers.includes( TYPE_PERSONAL ) || undefined }
-				hidePremiumPlan={ ! visiblePlanTiers.includes( TYPE_PREMIUM ) || undefined }
-				hideBusinessPlan={ ! visiblePlanTiers.includes( TYPE_BUSINESS ) || undefined }
-				hideEnterprisePlan={ hideEnterprise }
-				hideEcommercePlan={ hideEcommerce }
-				showPlanTypeSelectorDropdown={ isEnabled( 'onboarding/interval-dropdown' ) }
-			/>
+			<>
+				{ isStudentPlan && (
+					<Notice
+						status="is-info"
+						text={ this.props.translate(
+							'This site is on the Student plan. Business and Commerce upgrade options are shown below.'
+						) }
+						showDismiss={ false }
+					/>
+				) }
+				<PlansFeaturesMain
+					isInSiteDashboard={ isUntangled }
+					redirectToAddDomainFlow={ this.props.redirectToAddDomainFlow }
+					customerType={ this.props.customerType }
+					intervalType={ this.props.intervalType }
+					selectedFeature={ this.props.selectedFeature }
+					selectedPlan={ this.props.selectedPlan }
+					redirectTo={ this.props.redirectTo }
+					pluginSlug={ this.props.pluginSlug }
+					coupon={ this.props.coupon }
+					discountEndDate={ this.props.discountEndDate }
+					siteId={ selectedSite?.ID }
+					plansWithScroll={ false }
+					showLegacyStorageFeature={ this.props.siteHasLegacyStorage }
+					intent={ plansIntent }
+					isSpotlightOnCurrentPlan={ showSpotlight }
+					highlightLabelOverrides={ highlightLabelOverrides }
+					hideFreePlan={ ! visiblePlanTiers.includes( TYPE_FREE ) || undefined }
+					hidePersonalPlan={ ! visiblePlanTiers.includes( TYPE_PERSONAL ) || undefined }
+					hidePremiumPlan={ ! visiblePlanTiers.includes( TYPE_PREMIUM ) || undefined }
+					hideBusinessPlan={ ! visiblePlanTiers.includes( TYPE_BUSINESS ) || undefined }
+					hideEnterprisePlan={ isStudentPlan || hideEnterprise }
+					hideEcommercePlan={ hideEcommerce }
+					showPlanTypeSelectorDropdown={ isEnabled( 'onboarding/interval-dropdown' ) }
+				/>
+			</>
 		);
 	}
 

--- a/client/state/selectors/test/can-upgrade-to-plan.js
+++ b/client/state/selectors/test/can-upgrade-to-plan.js
@@ -22,6 +22,7 @@ import {
 	PLAN_PREMIUM,
 	PLAN_PREMIUM_2_YEARS,
 	PLAN_PREMIUM_3_YEARS,
+	PLAN_STUDENT,
 } from '@automattic/calypso-products';
 import canUpgradeToPlan from 'calypso/state/selectors/can-upgrade-to-plan';
 
@@ -109,6 +110,37 @@ describe( 'canUpgradeToPlan', () => {
 		].forEach( ( [ planOwned, planToPurchase ] ) =>
 			expect( canUpgradeToPlan( makeState( siteId, planOwned ), siteId, planToPurchase ) ).toBe(
 				true
+			)
+		);
+	} );
+
+	test( 'should return true from Student to Business and Commerce plans', () => {
+		[
+			PLAN_BUSINESS,
+			PLAN_BUSINESS_2_YEARS,
+			PLAN_BUSINESS_3_YEARS,
+			PLAN_ECOMMERCE,
+			PLAN_ECOMMERCE_2_YEARS,
+			PLAN_ECOMMERCE_3_YEARS,
+		].forEach( ( planToPurchase ) =>
+			expect( canUpgradeToPlan( makeState( siteId, PLAN_STUDENT ), siteId, planToPurchase ) ).toBe(
+				true
+			)
+		);
+	} );
+
+	test( 'should return false from Student to lower-tier and monthly plans', () => {
+		[ PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BUSINESS_MONTHLY ].forEach( ( planToPurchase ) =>
+			expect( canUpgradeToPlan( makeState( siteId, PLAN_STUDENT ), siteId, planToPurchase ) ).toBe(
+				false
+			)
+		);
+	} );
+
+	test( 'should return false when purchasing Student from other plans', () => {
+		[ PLAN_FREE, PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BUSINESS ].forEach( ( planOwned ) =>
+			expect( canUpgradeToPlan( makeState( siteId, planOwned ), siteId, PLAN_STUDENT ) ).toBe(
+				false
 			)
 		);
 	} );

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -6,6 +6,7 @@ import {
 	TYPE_FREE,
 	TYPE_PERSONAL,
 	TYPE_PREMIUM,
+	TYPE_STUDENT,
 	TYPE_WOOEXPRESS_MEDIUM,
 	TYPE_WOOEXPRESS_SMALL,
 	TYPE_WOO_HOSTED_BASIC,
@@ -189,12 +190,19 @@ export const usePlanTypesWithIntent = ( {
 			break;
 		case 'plans-plugins':
 			planTypes = [
-				...( currentSitePlanType ? [ currentSitePlanType ] : [] ),
+				...( currentSitePlanType && currentSitePlanType !== TYPE_STUDENT
+					? [ currentSitePlanType ]
+					: [] ),
 				TYPE_BUSINESS,
 				TYPE_ECOMMERCE,
 			];
 			break;
 		case 'plans-upgrade': {
+			if ( currentSitePlanType === TYPE_STUDENT ) {
+				planTypes = [ TYPE_BUSINESS, TYPE_ECOMMERCE ];
+				break;
+			}
+
 			// Show current plan plus all higher-tier plans (upgrade options only)
 			const upgradePlanTypes = [
 				TYPE_FREE,


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of #
Depends on: #111397 (#111349)

## Proposed Changes

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
