### PR TITLE
E2E: add publish 404 diagnostics

### DIFF
--- a/packages/calypso-e2e/src/element-helper.ts
+++ b/packages/calypso-e2e/src/element-helper.ts
@@ -1,4 +1,4 @@
-import { Locator, Page, Frame } from 'playwright';
+import { Locator, Page, Frame, Response } from 'playwright';
 import envVariables from './env-variables';
 
 const coreNavTabParent = 'div.components-tab-panel__tabs';
@@ -186,7 +186,8 @@ export async function clickNavTab(
  */
 export async function reloadAndRetry(
 	page: Page,
-	func: ( page: Page ) => Promise< void >
+	func: ( page: Page ) => Promise< void >,
+	options?: { onReload?: ( response: Response | null ) => Promise< void > | void }
 ): Promise< void > {
 	for ( let retries = 3; retries > 0; retries -= 1 ) {
 		try {
@@ -196,7 +197,8 @@ export async function reloadAndRetry(
 			if ( retries === 1 ) {
 				throw err;
 			} else {
-				await page.reload();
+				const response = await page.reload();
+				await options?.onReload?.( response );
 			}
 		}
 	}

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -1047,6 +1047,8 @@ export class EditorPage {
 		if ( ! publishedURL ) {
 			throw new Error( 'No published article URL found in response.' );
 		}
+		// `response` is the Promise.race winner — either the POST (Atomic) or the PUT (Simple).
+		// The `publishResponse.method` field in diagnostics will reflect whichever verb won.
 		const publishDiagnostics = getPublishDiagnostics( response, json, publishedURL );
 
 		if ( visit ) {
@@ -1160,6 +1162,10 @@ export class EditorPage {
 		} );
 		publicResponses.push( getResponseDiagnostic( response, 'published-url-goto' ) );
 
+		// `onReload` is called only when retrying (retries > 1). On the final attempt,
+		// `reloadAndRetry` re-throws without reloading, so the response for the last
+		// page load before the error is not captured — `publicResponses` reflects all
+		// attempts up to but not including the final failing check.
 		await reloadAndRetry( this.page, confirmPostShown, {
 			onReload: ( response ) => {
 				publicResponses.push( getResponseDiagnostic( response, 'published-url-reload' ) );

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -44,6 +44,164 @@ const selectors = {
 	welcomeTourCloseButton: 'button[aria-label="Close Tour"]',
 };
 
+type PublishResponseBody = {
+	ID?: number | string;
+	id?: number | string;
+	link?: string;
+	slug?: string;
+	status?: string;
+	type?: string;
+	body?: {
+		ID?: number | string;
+		id?: number | string;
+		link?: string;
+		slug?: string;
+		status?: string;
+		type?: string;
+	};
+};
+
+type ResponseDiagnostic = {
+	action: string;
+	method?: string;
+	status?: number;
+	url: string;
+	headers?: Record< string, string >;
+};
+
+type PublishDiagnostics = {
+	publishedURL: string;
+	publishResponse: ResponseDiagnostic;
+	postId?: number | string;
+	postSlug?: string;
+	postStatus?: string;
+	postType?: string;
+};
+
+const diagnosticHeaderNames = [ 'x-ac', 'x-nc', 'server-timing' ];
+
+/**
+ * Removes query strings and hashes before writing URLs to failure output.
+ */
+function sanitizeURLForDiagnostics( url: string ): string {
+	try {
+		const parsedURL = new URL( url );
+		return `${ parsedURL.origin }${ parsedURL.pathname }`;
+	} catch {
+		return url.replace( /[?#].*$/, '' );
+	}
+}
+
+/**
+ * Builds a small, safe response summary for publish/read-after-write failures.
+ */
+function getResponseDiagnostic( response: Response | null, action: string ): ResponseDiagnostic {
+	if ( ! response ) {
+		return {
+			action,
+			url: 'no response',
+		};
+	}
+
+	const headers = response.headers();
+	const diagnosticHeaders = Object.fromEntries(
+		diagnosticHeaderNames
+			.map( ( name ) => [ name, headers[ name ] ] as const )
+			.filter( ( entry ): entry is readonly [ string, string ] => Boolean( entry[ 1 ] ) )
+	);
+
+	const diagnostic: ResponseDiagnostic = {
+		action,
+		method: response.request().method(),
+		status: response.status(),
+		url: sanitizeURLForDiagnostics( response.url() ),
+	};
+
+	if ( Object.keys( diagnosticHeaders ).length > 0 ) {
+		diagnostic.headers = diagnosticHeaders;
+	}
+
+	return diagnostic;
+}
+
+/**
+ * Extracts the publish response fields needed to debug public 404s after publish.
+ */
+function getPublishDiagnostics(
+	response: Response,
+	body: PublishResponseBody,
+	publishedURL: string
+): PublishDiagnostics {
+	const publishedContent = body.body ?? body;
+
+	return {
+		publishedURL: sanitizeURLForDiagnostics( publishedURL ),
+		publishResponse: getResponseDiagnostic( response, 'publish' ),
+		postId: publishedContent.id ?? publishedContent.ID,
+		postSlug: publishedContent.slug,
+		postStatus: publishedContent.status,
+		postType: publishedContent.type,
+	};
+}
+
+/**
+ * Formats one response diagnostic for the thrown error message.
+ */
+function formatResponseDiagnostic( response: ResponseDiagnostic ): string {
+	const status = response.status ?? 'no status';
+	const method = response.method ?? 'unknown method';
+	const headers = response.headers ? ` headers=${ JSON.stringify( response.headers ) }` : '';
+
+	return `${ response.action }: ${ method } ${ status } ${ response.url }${ headers }`;
+}
+
+/**
+ * Formats post/page identifiers from the publish response.
+ */
+function formatPublishedContentDiagnostic( diagnostics?: PublishDiagnostics ): string {
+	if ( ! diagnostics ) {
+		return 'not captured';
+	}
+
+	const values = [
+		[ 'id', diagnostics.postId ],
+		[ 'type', diagnostics.postType ],
+		[ 'status', diagnostics.postStatus ],
+		[ 'slug', diagnostics.postSlug ],
+	]
+		.filter( ( [ , value ] ) => value !== undefined && value !== '' )
+		.map( ( [ key, value ] ) => `${ key }=${ value }` );
+
+	return values.length > 0 ? values.join( ' ' ) : 'no id/type/status/slug captured';
+}
+
+/**
+ * Builds the post-publish 404 error with enough context for log correlation.
+ */
+function getPublishedPost404Message( {
+	publishDiagnostics,
+	publicResponses,
+}: {
+	publishDiagnostics?: PublishDiagnostics;
+	publicResponses: ResponseDiagnostic[];
+} ): string {
+	return [
+		'Post not found - 404 error displayed',
+		`Published URL: ${ publishDiagnostics?.publishedURL ?? 'not captured' }`,
+		`Published content: ${ formatPublishedContentDiagnostic( publishDiagnostics ) }`,
+		`Publish response: ${
+			publishDiagnostics
+				? formatResponseDiagnostic( publishDiagnostics.publishResponse )
+				: 'not captured'
+		}`,
+		`Public responses: ${
+			publicResponses.length > 0
+				? publicResponses.map( formatResponseDiagnostic ).join( '; ' )
+				: 'not captured'
+		}`,
+	].join( '\n' );
+}
+
 /**
  * Represents an instance of the WPCOM's Gutenberg editor page.
  */
@@ -883,15 +1041,16 @@ export class EditorPage {
 			...actionsArray,
 		] );
 
-		const json = await response.json();
+		const json = ( await response.json() ) as PublishResponseBody;
 		// AT and Simple sites have slightly differing response from the API.
 		const publishedURL = json.link || json.body?.link;
 		if ( ! publishedURL ) {
 			throw new Error( 'No published article URL found in response.' );
 		}
+		const publishDiagnostics = getPublishDiagnostics( response, json, publishedURL );
 
 		if ( visit ) {
-			await this.visitPublishedPost( publishedURL, { timeout: timeout } );
+			await this.visitPublishedPost( publishedURL, { timeout: timeout, publishDiagnostics } );
 		}
 
 		return new URL( publishedURL );
@@ -977,8 +1136,13 @@ export class EditorPage {
 	 */
 	private async visitPublishedPost(
 		url: string,
-		{ timeout }: { timeout?: number } = {}
+		{
+			timeout,
+			publishDiagnostics,
+		}: { timeout?: number; publishDiagnostics?: PublishDiagnostics } = {}
 	): Promise< void > {
+		const publicResponses: ResponseDiagnostic[] = [];
+
 		// Some blocks, like "Click To Tweet" or "Logos" cause the post-publish
 		// panel to close immediately and leave the post in the unsaved state for
 		// some reason. Since the post state is unsaved, the warning dialog will be
@@ -990,9 +1154,17 @@ export class EditorPage {
 		// this listener can be removed.
 		this.allowLeavingWithoutSaving();
 
-		await this.page.goto( url, { waitUntil: 'domcontentloaded', timeout: timeout } );
+		const response = await this.page.goto( url, {
+			waitUntil: 'domcontentloaded',
+			timeout: timeout,
+		} );
+		publicResponses.push( getResponseDiagnostic( response, 'published-url-goto' ) );
 
-		await reloadAndRetry( this.page, confirmPostShown );
+		await reloadAndRetry( this.page, confirmPostShown, {
+			onReload: ( response ) => {
+				publicResponses.push( getResponseDiagnostic( response, 'published-url-reload' ) );
+			},
+		} );
 
 		/**
 		 * Closure to confirm that post is shown on screen as expected.
@@ -1013,7 +1185,12 @@ export class EditorPage {
 			const error404 = main.locator( 'div.error-404' );
 			if ( ( await error404.count() ) > 0 ) {
 				await page.waitForTimeout( 1000 ); // Give it a second before retrying.
-				throw new Error( 'Post not found - 404 error displayed' );
+				throw new Error(
+					getPublishedPost404Message( {
+						publishDiagnostics,
+						publicResponses,
+					} )
+				);
 			}
 		}
 	}


### PR DESCRIPTION
Part of TESTOPS-131

## Proposed Changes

* Add diagnostics to post-publish 404 failures in `EditorPage.publish()` / `visitPublishedPost()`.
* Include the sanitized published URL, publish response summary, post/page identifiers, public response status, and selected cache/routing headers.
* Preserve the existing publish flow and retry count.

## Why are these changes being made?

* Jetpack Simple Deployment saw public 404s after a successful publish response. The next failure needs enough context to correlate with publish, cache, and routing logs instead of only reporting the helper error.

## Testing Instructions

* `yarn eslint packages/calypso-e2e/src/element-helper.ts packages/calypso-e2e/src/lib/pages/editor-page.ts`
* `yarn workspace @automattic/calypso-e2e build`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
