### PR TITLE
Delayed Downgrades 3/4: scheduled downgrade display state + undo

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -290,6 +290,7 @@ export const purchaseSettingsRoute = createRoute( {
 		cancelled?: true;
 		downgraded?: true;
 		plan_changed?: true;
+		downgrade_scheduled?: true;
 		intent?: 'auto-renew';
 	} => {
 		const isRefunded = search.refunded === true || search.refunded === 'true';
@@ -297,6 +298,8 @@ export const purchaseSettingsRoute = createRoute( {
 		const isCancelled = search.cancelled === true || search.cancelled === 'true';
 		const isDowngraded = search.downgraded === true || search.downgraded === 'true';
 		const isPlanChanged = search.plan_changed === true || search.plan_changed === 'true';
+		const isDowngradeScheduled =
+			search.downgrade_scheduled === true || search.downgrade_scheduled === 'true';
 		const intent = search.intent === 'auto-renew' ? ( 'auto-renew' as const ) : undefined;
 		return {
 			...( isRefunded ? { refunded: true } : {} ),
@@ -304,6 +307,7 @@ export const purchaseSettingsRoute = createRoute( {
 			...( isCancelled ? { cancelled: true } : {} ),
 			...( isDowngraded ? { downgraded: true } : {} ),
 			...( isPlanChanged ? { plan_changed: true } : {} ),
+			...( isDowngradeScheduled ? { downgrade_scheduled: true } : {} ),
 			...( intent ? { intent } : {} ),
 		};
 	},

--- a/client/dashboard/me/billing-purchases/dataviews.tsx
+++ b/client/dashboard/me/billing-purchases/dataviews.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { JETPACK_CONTACT_SUPPORT } from '@automattic/urls';
 import { Link, useNavigate } from '@tanstack/react-router';
 import { __experimentalHStack as HStack, Icon, Popover, Button } from '@wordpress/components';
@@ -14,6 +15,8 @@ import { PurchaseExpiryStatus } from '../../components/purchase-expiry-status';
 import SiteIcon from '../../components/site-icon';
 import {
 	isRenewing,
+	hasScheduledDowngrade,
+	getTargetPlanTitle,
 	isTransferredOwnership,
 	isAkismetHoldingSitePurchase,
 	isMarketplaceHoldingSitePurchase,
@@ -432,6 +435,23 @@ export function getFields( {
 			},
 			render: ( { item }: { item: Purchase } ) => {
 				const site = sites.find( ( site ) => site.ID === item.blog_id );
+				if (
+					hasScheduledDowngrade( item ) &&
+					item.is_auto_renew_enabled &&
+					isEnabled( 'plans/scheduled-plan-downgrade' )
+				) {
+					return (
+						<div>
+							{ sprintf(
+								/* translators: %(plan)s is the target plan name */
+								__( 'Changing to %(plan)s at renewal' ),
+								{
+									plan: getTargetPlanTitle( item.scheduled_downgrade_product_slug ?? '' ),
+								}
+							) }
+						</div>
+					);
+				}
 				return (
 					<div>
 						<PurchaseExpiryStatus purchase={ item } isSiteMissing={ ! site } />

--- a/client/dashboard/me/billing-purchases/purchase-settings/cancel-scheduled-downgrade-dialog.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/cancel-scheduled-downgrade-dialog.tsx
@@ -1,14 +1,11 @@
 import { userCancelScheduledDowngradeQuery } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
 import {
-	Modal,
-	Button,
-	__experimentalVStack as VStack,
+	__experimentalConfirmDialog as ConfirmDialog,
 	__experimentalText as Text,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState } from 'react';
-import { ButtonStack } from '../../../components/button-stack';
 import type { Purchase } from '@automattic/api-core';
 
 interface CancelScheduledDowngradeDialogProps {
@@ -16,6 +13,7 @@ interface CancelScheduledDowngradeDialogProps {
 	currentPlanTitle: string;
 	isOpen: boolean;
 	onClose: () => void;
+	onCancelSuccess?: () => void;
 }
 
 export function CancelScheduledDowngradeDialog( {
@@ -23,9 +21,10 @@ export function CancelScheduledDowngradeDialog( {
 	currentPlanTitle,
 	isOpen,
 	onClose,
+	onCancelSuccess,
 }: CancelScheduledDowngradeDialogProps ) {
 	const [ error, setError ] = useState< string | null >( null );
-	const { mutate: cancelScheduledDowngrade, isPending } = useMutation( {
+	const { mutate: cancelScheduledDowngrade } = useMutation( {
 		...userCancelScheduledDowngradeQuery(),
 		meta: {
 			snackbar: {
@@ -35,6 +34,7 @@ export function CancelScheduledDowngradeDialog( {
 		onSuccess: () => {
 			setError( null );
 			onClose();
+			onCancelSuccess?.();
 		},
 		onError: ( err: Error ) => {
 			setError( err.message );
@@ -46,43 +46,24 @@ export function CancelScheduledDowngradeDialog( {
 	}
 
 	return (
-		<Modal
-			title={ String( __( 'Cancel scheduled downgrade?' ) ) }
-			onRequestClose={ onClose }
+		<ConfirmDialog
+			__experimentalHideHeader={ false }
+			title={ String( __( 'Keep your current plan?' ) ) }
 			size="small"
+			confirmButtonText={ String( __( 'Keep my plan' ) ) }
+			cancelButtonText={ String( __( 'Not now' ) ) }
+			isOpen={ isOpen }
+			onConfirm={ () => cancelScheduledDowngrade( { purchaseId: purchase.ID } ) }
+			onCancel={ onClose }
 		>
-			<VStack spacing={ 4 }>
-				<Text>
-					{ sprintf(
-						/* translators: %(plan)s is the name of the current plan */
-						__(
-							'Your plan will keep renewing as %(plan)s. You can schedule a downgrade again anytime.'
-						),
-						{ plan: currentPlanTitle }
-					) }
-				</Text>
-				{ error && <Text className="cancel-scheduled-downgrade-dialog__error">{ error }</Text> }
-				<ButtonStack justify="flex-start">
-					<Button
-						__next40pxDefaultSize
-						variant="primary"
-						isDestructive
-						isBusy={ isPending }
-						disabled={ isPending }
-						onClick={ () => cancelScheduledDowngrade( { purchaseId: purchase.ID } ) }
-					>
-						{ __( 'Cancel downgrade' ) }
-					</Button>
-					<Button
-						__next40pxDefaultSize
-						variant="tertiary"
-						onClick={ onClose }
-						disabled={ isPending }
-					>
-						{ __( 'Keep schedule' ) }
-					</Button>
-				</ButtonStack>
-			</VStack>
-		</Modal>
+			<Text>
+				{ sprintf(
+					/* translators: %(plan)s is the current plan name (e.g. "WordPress.com Business") */
+					__( 'Your %(plan)s plan will stay active. You can schedule a downgrade again anytime.' ),
+					{ plan: currentPlanTitle }
+				) }
+			</Text>
+			{ error && <Text>{ error }</Text> }
+		</ConfirmDialog>
 	);
 }

--- a/client/dashboard/me/billing-purchases/purchase-settings/cancel-scheduled-downgrade-dialog.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/cancel-scheduled-downgrade-dialog.tsx
@@ -50,6 +50,7 @@ export function CancelScheduledDowngradeDialog( {
 			__experimentalHideHeader={ false }
 			title={ String( __( 'Keep your current plan?' ) ) }
 			size="small"
+			closeButtonLabel={ String( __( 'Close' ) ) }
 			confirmButtonText={ String( __( 'Keep my plan' ) ) }
 			cancelButtonText={ String( __( 'Not now' ) ) }
 			isOpen={ isOpen }

--- a/client/dashboard/me/billing-purchases/purchase-settings/cancel-scheduled-downgrade-dialog.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/cancel-scheduled-downgrade-dialog.tsx
@@ -1,0 +1,88 @@
+import { userCancelScheduledDowngradeQuery } from '@automattic/api-queries';
+import { useMutation } from '@tanstack/react-query';
+import {
+	Modal,
+	Button,
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { useState } from 'react';
+import { ButtonStack } from '../../../components/button-stack';
+import type { Purchase } from '@automattic/api-core';
+
+interface CancelScheduledDowngradeDialogProps {
+	purchase: Purchase;
+	currentPlanTitle: string;
+	isOpen: boolean;
+	onClose: () => void;
+}
+
+export function CancelScheduledDowngradeDialog( {
+	purchase,
+	currentPlanTitle,
+	isOpen,
+	onClose,
+}: CancelScheduledDowngradeDialogProps ) {
+	const [ error, setError ] = useState< string | null >( null );
+	const { mutate: cancelScheduledDowngrade, isPending } = useMutation( {
+		...userCancelScheduledDowngradeQuery(),
+		meta: {
+			snackbar: {
+				success: __( 'Your scheduled downgrade was canceled.' ),
+			},
+		},
+		onSuccess: () => {
+			setError( null );
+			onClose();
+		},
+		onError: ( err: Error ) => {
+			setError( err.message );
+		},
+	} );
+
+	if ( ! isOpen ) {
+		return null;
+	}
+
+	return (
+		<Modal
+			title={ String( __( 'Cancel scheduled downgrade?' ) ) }
+			onRequestClose={ onClose }
+			size="small"
+		>
+			<VStack spacing={ 4 }>
+				<Text>
+					{ sprintf(
+						/* translators: %(plan)s is the name of the current plan */
+						__(
+							'Your plan will keep renewing as %(plan)s. You can schedule a downgrade again anytime.'
+						),
+						{ plan: currentPlanTitle }
+					) }
+				</Text>
+				{ error && <Text className="cancel-scheduled-downgrade-dialog__error">{ error }</Text> }
+				<ButtonStack justify="flex-start">
+					<Button
+						__next40pxDefaultSize
+						variant="primary"
+						isDestructive
+						isBusy={ isPending }
+						disabled={ isPending }
+						onClick={ () => cancelScheduledDowngrade( { purchaseId: purchase.ID } ) }
+					>
+						{ __( 'Cancel downgrade' ) }
+					</Button>
+					<Button
+						__next40pxDefaultSize
+						variant="tertiary"
+						onClick={ onClose }
+						disabled={ isPending }
+					>
+						{ __( 'Keep schedule' ) }
+					</Button>
+				</ButtonStack>
+			</VStack>
+		</Modal>
+	);
+}

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -102,6 +102,7 @@ import {
 	isCentennialPurchase,
 	hasAmountAvailableToRefund,
 	hasScheduledDowngrade,
+	getTargetPlanTitle,
 } from '../../../utils/purchase';
 import { getSitePurchaseUpgradeUrl, getUpgradedPurchaseRedirectUrl } from '../../../utils/site-url';
 import BillingFlexUsageCard from '../../billing-flex-usage';
@@ -122,26 +123,6 @@ const SPACING = {
 	DEFAULT: 6,
 	SMALL: 4,
 };
-
-/**
- * Resolves a product slug (e.g. "value_bundle_monthly") to its display name.
- * Used for the scheduled downgrade target plan title.
- */
-function getTargetPlanTitle( slug: string ): string {
-	if ( slug.startsWith( 'personal-bundle' ) ) {
-		return __( 'Personal' );
-	}
-	if ( slug.startsWith( 'value_bundle' ) ) {
-		return __( 'Premium' );
-	}
-	if ( slug.startsWith( 'business-bundle' ) ) {
-		return __( 'Business' );
-	}
-	if ( slug.startsWith( 'ecommerce-bundle' ) ) {
-		return __( 'Commerce' );
-	}
-	return slug;
-}
 
 function renewPurchase( purchase: Purchase ): void {
 	window.location.href = getRenewalUrlFromPurchase( purchase );

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -49,6 +49,7 @@ import {
 	check,
 } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
+import { useState } from 'react';
 import { useAnalytics } from '../../../app/analytics';
 import { useAuth } from '../../../app/auth';
 import Breadcrumbs from '../../../app/breadcrumbs';
@@ -99,12 +100,14 @@ import {
 	isA4ABillingDragonPurchase,
 	isCentennialPurchase,
 	hasAmountAvailableToRefund,
+	hasScheduledDowngrade,
 } from '../../../utils/purchase';
 import { getSitePurchaseUpgradeUrl, getUpgradedPurchaseRedirectUrl } from '../../../utils/site-url';
 import BillingFlexUsageCard from '../../billing-flex-usage';
 import { useIsSplitCancelRemoveEnabled } from '../cancel-purchase/use-is-split-cancel-remove-enabled';
 import { PurchasePaymentMethod } from '../purchase-payment-method';
 import AkismetApiKeyCard from './akismet-api-key-card';
+import { CancelScheduledDowngradeDialog } from './cancel-scheduled-downgrade-dialog';
 import { classifyPurchaseForCopy } from './classify-purchase-for-copy';
 import { getCancelButtonCopy, getRemoveButtonCopy } from './get-cancel-remove-copy';
 import JetpackLicenseKeyCard from './jetpack-license-key-card';
@@ -118,6 +121,26 @@ const SPACING = {
 	DEFAULT: 6,
 	SMALL: 4,
 };
+
+/**
+ * Resolves a product slug (e.g. "value_bundle_monthly") to its display name.
+ * Used for the scheduled downgrade target plan title.
+ */
+function getTargetPlanTitle( slug: string ): string {
+	if ( slug.startsWith( 'personal-bundle' ) ) {
+		return __( 'Personal' );
+	}
+	if ( slug.startsWith( 'value_bundle' ) ) {
+		return __( 'Premium' );
+	}
+	if ( slug.startsWith( 'business-bundle' ) ) {
+		return __( 'Business' );
+	}
+	if ( slug.startsWith( 'ecommerce-bundle' ) ) {
+		return __( 'Commerce' );
+	}
+	return slug;
+}
 
 function renewPurchase( purchase: Purchase ): void {
 	window.location.href = getRenewalUrlFromPurchase( purchase );
@@ -814,6 +837,26 @@ function getFields( {
 				const isSplitCancelRemoveEnabled = useIsSplitCancelRemoveEnabled();
 				const { getValue } = field;
 				const helpText = ( () => {
+					// Scheduled downgrade: show target plan + renewal date instead of generic billing copy.
+					if (
+						hasScheduledDowngrade( purchase ) &&
+						purchase.is_auto_renew_enabled &&
+						isEnabled( 'plans/scheduled-plan-downgrade' )
+					) {
+						const targetTitle = getTargetPlanTitle(
+							purchase.scheduled_downgrade_product_slug ?? ''
+						);
+						const renewalDate = formatDate(
+							new Date( purchase.scheduled_downgrade_renewal_date ?? purchase.renew_date ),
+							locale,
+							{ dateStyle: 'long' }
+						);
+						return sprintf(
+							/* translators: %(plan)s is the target plan name, %(date)s is the renewal date */
+							__( 'Renews as the %(plan)s plan on %(date)s.' ),
+							{ plan: targetTitle, date: renewalDate }
+						);
+					}
 					if (
 						purchase.is_auto_renew_enabled &&
 						Boolean( purchase.renew_date ) &&
@@ -924,6 +967,13 @@ function ManageSubscriptionCard( { purchase }: { purchase: Purchase } ) {
 	const { user } = useAuth();
 	const navigate = useNavigate();
 	const isSplitCancelRemoveEnabled = useIsSplitCancelRemoveEnabled();
+	const [ isCancelDialogOpen, setIsCancelDialogOpen ] = useState( false );
+
+	const isScheduledDowngrade =
+		hasScheduledDowngrade( purchase ) && isEnabled( 'plans/scheduled-plan-downgrade' );
+	const targetPlanTitle = isScheduledDowngrade
+		? getTargetPlanTitle( purchase.scheduled_downgrade_product_slug ?? '' )
+		: '';
 
 	if ( isIncludedWithPlan( purchase ) ) {
 		return null;
@@ -932,31 +982,76 @@ function ManageSubscriptionCard( { purchase }: { purchase: Purchase } ) {
 	return (
 		<Card>
 			<CardBody>
-				<DataForm< Purchase >
-					data={ purchase }
-					fields={ getFields( { isMutationPending, user } ) }
-					form={ form }
-					onChange={ ( newData ) => {
-						if ( newData.is_auto_renew_enabled !== purchase.is_auto_renew_enabled ) {
-							if ( ! newData.is_auto_renew_enabled && isSplitCancelRemoveEnabled ) {
-								navigate( {
-									to: cancelPurchaseRoute.fullPath,
-									params: { purchaseId: purchase.ID },
-									search: { intent: 'auto-renew' as const },
+				<VStack spacing={ 4 }>
+					<DataForm< Purchase >
+						data={ purchase }
+						fields={ getFields( { isMutationPending, user } ) }
+						form={ form }
+						onChange={ ( newData ) => {
+							if ( newData.is_auto_renew_enabled !== purchase.is_auto_renew_enabled ) {
+								if ( ! newData.is_auto_renew_enabled && isSplitCancelRemoveEnabled ) {
+									navigate( {
+										to: cancelPurchaseRoute.fullPath,
+										params: { purchaseId: purchase.ID },
+										search: { intent: 'auto-renew' as const },
+									} );
+									return;
+								}
+								setAutoRenew( {
+									purchaseId: purchase.ID,
+									autoRenew: newData.is_auto_renew_enabled,
 								} );
-								return;
 							}
-							setAutoRenew( { purchaseId: purchase.ID, autoRenew: newData.is_auto_renew_enabled } );
-						}
-					} }
-				/>
+						} }
+					/>
 
-				{ error && (
-					<Notice status="error" isDismissible={ false }>
-						{ error.message }
-					</Notice>
-				) }
+					{ isScheduledDowngrade && purchase.is_auto_renew_enabled && (
+						<Button variant="link" isDestructive onClick={ () => setIsCancelDialogOpen( true ) }>
+							{ __( 'Cancel scheduled downgrade' ) }
+						</Button>
+					) }
+
+					{ isScheduledDowngrade && ! purchase.is_auto_renew_enabled && (
+						<Notice
+							status="warning"
+							isDismissible={ false }
+							actions={ [
+								{
+									label: __( 'Turn on auto-renew' ),
+									onClick: () =>
+										setAutoRenew( {
+											purchaseId: purchase.ID,
+											autoRenew: true,
+										} ),
+								},
+							] }
+						>
+							{ sprintf(
+								/* translators: %(plan)s is the target plan name */
+								__(
+									'You scheduled a downgrade to the %(plan)s plan, but it won\u2019t take effect while auto-renew is off. Turn on auto-renew to keep the scheduled change.'
+								),
+								{ plan: targetPlanTitle }
+							) }
+						</Notice>
+					) }
+
+					{ error && (
+						<Notice status="error" isDismissible={ false }>
+							{ error.message }
+						</Notice>
+					) }
+				</VStack>
 			</CardBody>
+
+			{ isScheduledDowngrade && (
+				<CancelScheduledDowngradeDialog
+					purchase={ purchase }
+					currentPlanTitle={ purchase.product_name }
+					isOpen={ isCancelDialogOpen }
+					onClose={ () => setIsCancelDialogOpen( false ) }
+				/>
+			) }
 		</Card>
 	);
 }
@@ -1614,6 +1709,19 @@ export default function PurchaseSettings() {
 										return __( 'Pending renewal' );
 									}
 									if ( purchase.is_auto_renew_enabled && isRenewing( purchase ) ) {
+										if (
+											hasScheduledDowngrade( purchase ) &&
+											isEnabled( 'plans/scheduled-plan-downgrade' )
+										) {
+											const targetTitle = getTargetPlanTitle(
+												purchase.scheduled_downgrade_product_slug ?? ''
+											);
+											return sprintf(
+												/* translators: %(plan)s is the target plan name */
+												__( 'Downgrade to %(plan)s scheduled' ),
+												{ plan: targetTitle }
+											);
+										}
 										return __( 'Auto-renew is enabled' );
 									}
 									if ( isIncluded && purchase.attached_to_purchase_id ) {

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -49,7 +49,7 @@ import {
 	check,
 } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useAnalytics } from '../../../app/analytics';
 import { useAuth } from '../../../app/auth';
 import Breadcrumbs from '../../../app/breadcrumbs';
@@ -67,6 +67,7 @@ import { Card, CardBody } from '../../../components/card';
 import ClipboardInputControl from '../../../components/clipboard-input-control';
 import { useFormattedTime } from '../../../components/formatted-time';
 import { MetadataList, MetadataItem } from '../../../components/metadata-list';
+import { Notice as DashboardNotice } from '../../../components/notice';
 import OverviewCard from '../../../components/overview-card';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
@@ -958,6 +959,115 @@ const form = {
 	],
 };
 
+function ScheduledDowngradeNotice( { purchase }: { purchase: Purchase } ) {
+	const locale = useLocale();
+	const { mutate: setAutoRenew } = useMutation( userPurchaseSetAutoRenewQuery() );
+	const [ isCancelDialogOpen, setIsCancelDialogOpen ] = useState( false );
+	const [ isDismissed, setIsDismissed ] = useState( false );
+
+	// When redirected from the confirmation modal after scheduling a downgrade,
+	// downgrade_scheduled=true is in the URL. The API cache may still show stale
+	// data (no scheduled_downgrade fields, auto-renew off). Capture the flag on
+	// mount so we can render the auto-renew-ON info variant optimistically, then
+	// clear the param from the URL (same pattern as cancelled/plan_changed).
+	const { downgrade_scheduled: justScheduled } = purchaseSettingsRoute.useSearch();
+	const [ isOptimistic ] = useState( () => Boolean( justScheduled ) );
+	const navigate = purchaseSettingsRoute.useNavigate();
+	useEffect( () => {
+		if ( justScheduled ) {
+			navigate( {
+				search: ( prev: Record< string, unknown > ) => {
+					const { downgrade_scheduled: _ds, ...rest } = prev;
+					return rest;
+				},
+				replace: true,
+			} );
+		}
+	}, [ justScheduled, navigate ] );
+
+	const isScheduledDowngrade =
+		( hasScheduledDowngrade( purchase ) || isOptimistic ) &&
+		isEnabled( 'plans/scheduled-plan-downgrade' );
+
+	if ( ! isScheduledDowngrade || isDismissed ) {
+		return null;
+	}
+
+	const targetPlanTitle = getTargetPlanTitle( purchase.scheduled_downgrade_product_slug ?? '' );
+
+	// When arriving via redirect (isOptimistic), auto-renew was just enabled by
+	// the confirmation modal — show the info variant even if the cached purchase
+	// object still says auto-renew is off.
+	const showAutoRenewOnVariant = purchase.is_auto_renew_enabled || isOptimistic;
+
+	return (
+		<>
+			{ showAutoRenewOnVariant ? (
+				<DashboardNotice
+					actions={
+						<Button variant="secondary" onClick={ () => setIsCancelDialogOpen( true ) }>
+							{ __( 'Undo downgrade' ) }
+						</Button>
+					}
+				>
+					{ sprintf(
+						/* translators: %(plan)s is the target plan name, %(date)s is the renewal date */
+						__(
+							'You\u2019ve scheduled a downgrade to %(plan)s. Your current plan stays active until %(date)s.'
+						),
+						{
+							plan: targetPlanTitle,
+							date: formatDate(
+								new Date( purchase.scheduled_downgrade_renewal_date ?? purchase.renew_date ),
+								locale,
+								{ dateStyle: 'long' }
+							),
+						}
+					) }
+				</DashboardNotice>
+			) : (
+				<DashboardNotice
+					variant="warning"
+					actions={
+						<HStack spacing={ 2 } justify="flex-start">
+							<Button
+								variant="secondary"
+								onClick={ () =>
+									setAutoRenew( {
+										purchaseId: purchase.ID,
+										autoRenew: true,
+									} )
+								}
+							>
+								{ __( 'Enable auto-renew' ) }
+							</Button>
+							<Button variant="tertiary" onClick={ () => setIsCancelDialogOpen( true ) }>
+								{ __( 'Undo downgrade' ) }
+							</Button>
+						</HStack>
+					}
+				>
+					{ sprintf(
+						/* translators: %(plan)s is the target plan name */
+						__(
+							'You\u2019ve scheduled a downgrade to %(plan)s, but your plan isn\u2019t set to renew. The downgrade won\u2019t happen unless you enable auto-renew.'
+						),
+						{ plan: targetPlanTitle }
+					) }
+				</DashboardNotice>
+			) }
+
+			<CancelScheduledDowngradeDialog
+				purchase={ purchase }
+				currentPlanTitle={ purchase.product_name }
+				isOpen={ isCancelDialogOpen }
+				onClose={ () => setIsCancelDialogOpen( false ) }
+				onCancelSuccess={ () => setIsDismissed( true ) }
+			/>
+		</>
+	);
+}
+
 function ManageSubscriptionCard( { purchase }: { purchase: Purchase } ) {
 	const {
 		mutate: setAutoRenew,
@@ -967,13 +1077,6 @@ function ManageSubscriptionCard( { purchase }: { purchase: Purchase } ) {
 	const { user } = useAuth();
 	const navigate = useNavigate();
 	const isSplitCancelRemoveEnabled = useIsSplitCancelRemoveEnabled();
-	const [ isCancelDialogOpen, setIsCancelDialogOpen ] = useState( false );
-
-	const isScheduledDowngrade =
-		hasScheduledDowngrade( purchase ) && isEnabled( 'plans/scheduled-plan-downgrade' );
-	const targetPlanTitle = isScheduledDowngrade
-		? getTargetPlanTitle( purchase.scheduled_downgrade_product_slug ?? '' )
-		: '';
 
 	if ( isIncludedWithPlan( purchase ) ) {
 		return null;
@@ -1005,37 +1108,6 @@ function ManageSubscriptionCard( { purchase }: { purchase: Purchase } ) {
 						} }
 					/>
 
-					{ isScheduledDowngrade && purchase.is_auto_renew_enabled && (
-						<Button variant="link" isDestructive onClick={ () => setIsCancelDialogOpen( true ) }>
-							{ __( 'Cancel scheduled downgrade' ) }
-						</Button>
-					) }
-
-					{ isScheduledDowngrade && ! purchase.is_auto_renew_enabled && (
-						<Notice
-							status="warning"
-							isDismissible={ false }
-							actions={ [
-								{
-									label: __( 'Turn on auto-renew' ),
-									onClick: () =>
-										setAutoRenew( {
-											purchaseId: purchase.ID,
-											autoRenew: true,
-										} ),
-								},
-							] }
-						>
-							{ sprintf(
-								/* translators: %(plan)s is the target plan name */
-								__(
-									'You scheduled a downgrade to the %(plan)s plan, but it won\u2019t take effect while auto-renew is off. Turn on auto-renew to keep the scheduled change.'
-								),
-								{ plan: targetPlanTitle }
-							) }
-						</Notice>
-					) }
-
 					{ error && (
 						<Notice status="error" isDismissible={ false }>
 							{ error.message }
@@ -1043,15 +1115,6 @@ function ManageSubscriptionCard( { purchase }: { purchase: Purchase } ) {
 					) }
 				</VStack>
 			</CardBody>
-
-			{ isScheduledDowngrade && (
-				<CancelScheduledDowngradeDialog
-					purchase={ purchase }
-					currentPlanTitle={ purchase.product_name }
-					isOpen={ isCancelDialogOpen }
-					onClose={ () => setIsCancelDialogOpen( false ) }
-				/>
-			) }
 		</Card>
 	);
 }
@@ -1597,6 +1660,7 @@ export default function PurchaseSettings() {
 	return (
 		<PageLayout
 			size="small"
+			notices={ <ScheduledDowngradeNotice purchase={ purchase } /> }
 			header={
 				<VStack>
 					<PageHeader

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -6,6 +6,7 @@ import {
 	userPreferenceMutation,
 	userPreferenceQuery,
 } from '@automattic/api-queries';
+import { isEnabled } from '@automattic/calypso-config';
 import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { Button } from '@wordpress/components';
@@ -32,6 +33,7 @@ import {
 	getRenewalUrlFromPurchase,
 	isInExpirationGracePeriod,
 	isAkismetFreeProduct,
+	hasScheduledDowngrade,
 } from '../../../utils/purchase';
 import { getSitePurchaseUpgradeUrl, getUpgradedPurchaseRedirectUrl } from '../../../utils/site-url';
 import { useIsSplitCancelRemoveEnabled } from '../cancel-purchase/use-is-split-cancel-remove-enabled';
@@ -162,6 +164,12 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 				) }
 			</Notice>
 		);
+	}
+
+	// Suppress all other notices when a scheduled downgrade is active — the
+	// page-level ScheduledDowngradeNotice already communicates plan status.
+	if ( hasScheduledDowngrade( purchase ) && isEnabled( 'plans/scheduled-plan-downgrade' ) ) {
+		return null;
 	}
 
 	if ( purchase.async_pending_payment_block_is_set ) {

--- a/client/dashboard/me/billing-purchases/purchase-settings/test/cancel-scheduled-downgrade-dialog.test.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/test/cancel-scheduled-downgrade-dialog.test.tsx
@@ -2,6 +2,11 @@
  * @jest-environment jsdom
  */
 
+// Prevent the import chain from pulling in server-side wpcom/superagent.
+jest.mock( 'calypso/lib/wp', () => ( {
+	req: { get: jest.fn(), post: jest.fn() },
+} ) );
+
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';

--- a/client/dashboard/me/billing-purchases/purchase-settings/test/cancel-scheduled-downgrade-dialog.test.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/test/cancel-scheduled-downgrade-dialog.test.tsx
@@ -38,11 +38,11 @@ describe( '<CancelScheduledDowngradeDialog />', () => {
 		);
 
 		expect(
-			await screen.findByRole( 'dialog', { name: /cancel scheduled downgrade/i } )
+			await screen.findByRole( 'dialog', { name: /keep your current plan/i } )
 		).toBeVisible();
-		expect( screen.getByText( /Your plan will keep renewing as Business/i ) ).toBeVisible();
-		expect( screen.getByRole( 'button', { name: /cancel downgrade/i } ) ).toBeVisible();
-		expect( screen.getByRole( 'button', { name: /keep schedule/i } ) ).toBeVisible();
+		expect( screen.getByText( /Your Business plan will stay active/i ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: /keep my plan/i } ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: /not now/i } ) ).toBeVisible();
 	} );
 
 	test( 'calls cancel mutation on confirm and closes on success', async () => {
@@ -62,7 +62,7 @@ describe( '<CancelScheduledDowngradeDialog />', () => {
 			/>
 		);
 
-		const confirmButton = await screen.findByRole( 'button', { name: /cancel downgrade/i } );
+		const confirmButton = await screen.findByRole( 'button', { name: /keep my plan/i } );
 		await user.click( confirmButton );
 
 		await waitFor( () => {
@@ -83,7 +83,7 @@ describe( '<CancelScheduledDowngradeDialog />', () => {
 			/>
 		);
 
-		const keepButton = await screen.findByRole( 'button', { name: /keep schedule/i } );
+		const keepButton = await screen.findByRole( 'button', { name: /not now/i } );
 		await user.click( keepButton );
 
 		expect( onClose ).toHaveBeenCalled();

--- a/client/dashboard/me/billing-purchases/purchase-settings/test/cancel-scheduled-downgrade-dialog.test.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/test/cancel-scheduled-downgrade-dialog.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import { render } from '../../../../test-utils';
+import { CancelScheduledDowngradeDialog } from '../cancel-scheduled-downgrade-dialog';
+import type { Purchase } from '@automattic/api-core';
+
+function makePurchase( overrides: Partial< Purchase > = {} ): Purchase {
+	return {
+		ID: 123,
+		product_name: 'WordPress.com Business',
+		product_slug: 'business-bundle',
+		is_plan: true,
+		scheduled_downgrade_product_id: 1009,
+		scheduled_downgrade_product_slug: 'value_bundle',
+		scheduled_downgrade_renewal_date: '2026-07-15T00:00:00+00:00',
+		...overrides,
+	} as Purchase;
+}
+
+describe( '<CancelScheduledDowngradeDialog />', () => {
+	afterEach( () => {
+		nock.cleanAll();
+	} );
+
+	test( 'renders title, body copy, and both buttons', async () => {
+		render(
+			<CancelScheduledDowngradeDialog
+				purchase={ makePurchase() }
+				currentPlanTitle="Business"
+				isOpen
+				onClose={ jest.fn() }
+			/>
+		);
+
+		expect(
+			await screen.findByRole( 'dialog', { name: /cancel scheduled downgrade/i } )
+		).toBeVisible();
+		expect( screen.getByText( /Your plan will keep renewing as Business/i ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: /cancel downgrade/i } ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: /keep schedule/i } ) ).toBeVisible();
+	} );
+
+	test( 'calls cancel mutation on confirm and closes on success', async () => {
+		const user = userEvent.setup();
+		const onClose = jest.fn();
+
+		nock( 'https://public-api.wordpress.com' )
+			.post( '/rest/v1.1/upgrades/123/cancel-scheduled-downgrade' )
+			.reply( 200, { success: true } );
+
+		render(
+			<CancelScheduledDowngradeDialog
+				purchase={ makePurchase() }
+				currentPlanTitle="Business"
+				isOpen
+				onClose={ onClose }
+			/>
+		);
+
+		const confirmButton = await screen.findByRole( 'button', { name: /cancel downgrade/i } );
+		await user.click( confirmButton );
+
+		await waitFor( () => {
+			expect( onClose ).toHaveBeenCalled();
+		} );
+	} );
+
+	test( 'Keep schedule button calls onClose', async () => {
+		const user = userEvent.setup();
+		const onClose = jest.fn();
+
+		render(
+			<CancelScheduledDowngradeDialog
+				purchase={ makePurchase() }
+				currentPlanTitle="Business"
+				isOpen
+				onClose={ onClose }
+			/>
+		);
+
+		const keepButton = await screen.findByRole( 'button', { name: /keep schedule/i } );
+		await user.click( keepButton );
+
+		expect( onClose ).toHaveBeenCalled();
+	} );
+
+	test( 'returns null when not open', () => {
+		const { container } = render(
+			<CancelScheduledDowngradeDialog
+				purchase={ makePurchase() }
+				currentPlanTitle="Business"
+				isOpen={ false }
+				onClose={ jest.fn() }
+			/>
+		);
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+} );

--- a/client/dashboard/sites/overview-plan-card/index.tsx
+++ b/client/dashboard/sites/overview-plan-card/index.tsx
@@ -1,5 +1,6 @@
 import { DotcomPlans, JetpackPlans, WooHostedPlans } from '@automattic/api-core';
 import { siteCurrentPlanQuery, siteByIdQuery, purchaseQuery } from '@automattic/api-queries';
+import { isEnabled } from '@automattic/calypso-config';
 import { JetpackLogo } from '@automattic/components/src/logos/jetpack-logo';
 import { useQuery } from '@tanstack/react-query';
 import {
@@ -14,6 +15,7 @@ import { wordpress } from '@wordpress/icons';
 import { commerceGardenPlan } from '../../components/icons';
 import OverviewCard from '../../components/overview-card';
 import { PurchaseExpiryStatus } from '../../components/purchase-expiry-status';
+import { hasScheduledDowngrade, getTargetPlanTitle } from '../../utils/purchase';
 import {
 	getJetpackProductsForSite,
 	getSitePlanDisplayName,
@@ -219,6 +221,20 @@ function getCardDescription( site: Site, purchase?: Purchase ) {
 				: __( 'Upgrade to access more Jetpack tools.' );
 		case WooHostedPlans.WOO_HOSTED_FREE_PLAN:
 			return __( 'Upgrade to keep your online store.' );
+	}
+
+	if (
+		purchase &&
+		hasScheduledDowngrade( purchase ) &&
+		purchase.is_auto_renew_enabled &&
+		isEnabled( 'plans/scheduled-plan-downgrade' )
+	) {
+		const targetTitle = getTargetPlanTitle( purchase.scheduled_downgrade_product_slug ?? '' );
+		return sprintf(
+			/* translators: %(plan)s is the target plan name */
+			__( 'Changing to %(plan)s at renewal.' ),
+			{ plan: targetTitle }
+		);
 	}
 
 	if ( purchase ) {

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -40,6 +40,26 @@ export function hasScheduledDowngrade( purchase: Purchase ): boolean {
 }
 
 /**
+ * Resolves a product slug (e.g. "value_bundle_monthly") to its display name.
+ * Used for the scheduled downgrade target plan title.
+ */
+export function getTargetPlanTitle( slug: string ): string {
+	if ( slug.startsWith( 'personal-bundle' ) || slug.startsWith( 'starter-plan' ) ) {
+		return __( 'Personal' );
+	}
+	if ( slug.startsWith( 'value_bundle' ) ) {
+		return __( 'Premium' );
+	}
+	if ( slug.startsWith( 'business-bundle' ) ) {
+		return __( 'Business' );
+	}
+	if ( slug.startsWith( 'ecommerce-bundle' ) ) {
+		return __( 'Commerce' );
+	}
+	return slug;
+}
+
+/**
  * Returns true if the purchase is in grace period with a failed or missing auto-renewal.
  */
 export function isFailedAutoRenewal( purchase: Purchase ): boolean {

--- a/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/index.tsx
+++ b/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/index.tsx
@@ -19,7 +19,7 @@ import {
 } from 'calypso/lib/purchases/actions';
 import { addQueryArgs } from 'calypso/lib/url';
 import { useDispatch, useSelector } from 'calypso/state';
-import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { errorNotice } from 'calypso/state/notices/actions';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import type { Purchase } from 'calypso/lib/purchases/types';
 
@@ -138,18 +138,18 @@ const DowngradeConfirmationModal = ( {
 					} );
 				}
 
-				dispatch(
-					successNotice(
-						translate( 'Your plan will downgrade to %(targetPlan)s on %(date)s.', {
-							args: {
-								targetPlan: targetPlanTitle,
-								date: renewalDateFormatted,
-							},
-						} ),
-						{ duration: 5000 }
-					)
-				);
-				onClose();
+				// Redirect to purchase settings — the page-level notice communicates the schedule.
+				// Append downgrade_scheduled=true so purchase settings can render optimistically
+				// before the API cache refreshes (same pattern as plan_changed=true).
+				const cancelTo = new URLSearchParams( window.location.search ).get( 'cancel_to' );
+				if ( cancelTo ) {
+					const separator = cancelTo.includes( '?' ) ? '&' : '?';
+					window.location.href = cancelTo + separator + 'downgrade_scheduled=true';
+				} else {
+					window.location.href = `/purchases/subscriptions/${ siteSlug ?? '' }/${
+						purchase.id
+					}?downgrade_scheduled=true`;
+				}
 			} catch ( error ) {
 				dispatch(
 					errorNotice(

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -83,6 +83,7 @@ export default function useGenerateActionHook( {
 	isPlanExpired: isPlanExpiredProp,
 	redirectTo,
 	pluginSlug,
+	scheduledDowngradeTargetSlug,
 }: {
 	siteId?: number | null;
 	cartHandler?: ( cartItems?: MinimalRequestCartProduct[] | null ) => void;
@@ -104,6 +105,7 @@ export default function useGenerateActionHook( {
 	isPlanExpired?: boolean;
 	redirectTo?: string;
 	pluginSlug?: string;
+	scheduledDowngradeTargetSlug?: string | null;
 } ): UseAction {
 	const translate = useTranslate();
 	const currentPlan = Plans.useCurrentPlan( { siteId } );
@@ -244,6 +246,7 @@ export default function useGenerateActionHook( {
 			setIsLoading,
 			isLoading,
 			plansIntent,
+			scheduledDowngradeTargetSlug,
 		} );
 		return {
 			...action,
@@ -444,6 +447,7 @@ function getLoggedInPlansAction( {
 	isLoading,
 	setIsLoading,
 	plansIntent,
+	scheduledDowngradeTargetSlug,
 }: {
 	getActionCallback: UseActionCallback;
 	planSlug: PlanSlug;
@@ -455,6 +459,7 @@ function getLoggedInPlansAction( {
 	isLoading: boolean;
 	setIsLoading: ( value: boolean ) => void;
 	plansIntent?: PlansIntent | null;
+	scheduledDowngradeTargetSlug?: string | null;
 } & UseActionHookProps ): GridAction {
 	// Use plan type matching instead of exact slug matching for the 'plans-upgrade' intent.
 	// This allows monthly/yearly versions of the same plan to be considered "current"
@@ -602,11 +607,19 @@ function getLoggedInPlansAction( {
 		const targetTier = PLAN_TIER_ORDER[ getPlanClass( planSlug ) ] ?? 0;
 
 		if ( targetTier < currentTier ) {
+			const isAlreadyScheduled =
+				scheduledDowngradeTargetSlug &&
+				getPlanClass( planSlug ) === getPlanClass( scheduledDowngradeTargetSlug );
 			const downgradeLabel =
 				getActiveDowngradeVariant() === 'on_renewal'
 					? translate( 'Downgrade at renewal' )
 					: translate( 'Downgrade', { context: 'verb' } );
-			return createLoggedInPlansAction( downgradeLabel, 'secondary' );
+			return createLoggedInPlansAction(
+				downgradeLabel,
+				'secondary',
+				undefined,
+				isAlreadyScheduled ? 'disabled' : undefined
+			);
 		}
 		if ( ! isStuck ) {
 			return createLoggedInPlansAction( translate( 'Upgrade', { context: 'verb' } ) );

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -63,6 +63,7 @@ import QuerySites from 'calypso/components/data/query-sites';
 import { retargetViewPlans } from 'calypso/lib/analytics/ad-tracking';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { planItem as getCartItemForPlan } from 'calypso/lib/cart-values/cart-items';
+import { hasScheduledDowngrade } from 'calypso/lib/purchases';
 import { getActiveDowngradeVariant } from 'calypso/lib/purchases/active-downgrade-variant';
 import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
 import PlanNotice from 'calypso/my-sites/plans-features-main/components/plan-notice';
@@ -541,16 +542,45 @@ const PlansFeaturesMain = ( {
 		);
 	}, [ isPlanExpired, sitePlanSlug ] );
 
-	// Merge prop-provided overrides with expired-plan overrides. Expired overrides take precedence.
+	// When a scheduled downgrade exists, mark the target plan with a badge.
+	const scheduledDowngradeHighlightOverrides = useMemo( () => {
+		if (
+			isPlanExpired ||
+			getActiveDowngradeVariant() !== 'on_renewal' ||
+			! currentPlanPurchase ||
+			! hasScheduledDowngrade( currentPlanPurchase )
+		) {
+			return undefined;
+		}
+		const targetSlug = currentPlanPurchase.scheduledDowngradeProductSlug;
+		if ( ! targetSlug ) {
+			return undefined;
+		}
+		return { [ targetSlug ]: translate( 'Downgrade scheduled' ) } as {
+			[ K in PlanSlug ]?: TranslateResult;
+		};
+	}, [ isPlanExpired, currentPlanPurchase, translate ] );
+
+	// Merge prop-provided overrides with expired-plan and scheduled-downgrade overrides.
+	// Expired overrides take precedence over scheduled (the two don't coexist, but be safe).
 	const effectiveHighlightOverrides = useMemo( () => {
-		if ( ! expiredPlanHighlightOverrides && ! highlightLabelOverrides ) {
+		if (
+			! expiredPlanHighlightOverrides &&
+			! highlightLabelOverrides &&
+			! scheduledDowngradeHighlightOverrides
+		) {
 			return undefined;
 		}
 		return {
 			...highlightLabelOverrides,
+			...scheduledDowngradeHighlightOverrides,
 			...expiredPlanHighlightOverrides,
 		};
-	}, [ highlightLabelOverrides, expiredPlanHighlightOverrides ] );
+	}, [
+		highlightLabelOverrides,
+		expiredPlanHighlightOverrides,
+		scheduledDowngradeHighlightOverrides,
+	] );
 
 	// we need all the plans that are available to pick for comparison grid (these should extend into plans-ui data store selectors)
 	const gridPlansForComparisonGrid = useGridPlansForComparisonGrid( {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -486,6 +486,15 @@ const PlansFeaturesMain = ( {
 		return false;
 	};
 
+	// When a scheduled downgrade exists, pass the target slug to disable its button.
+	const scheduledDowngradeTargetSlug =
+		! isPlanExpired &&
+		getActiveDowngradeVariant() === 'on_renewal' &&
+		currentPlanPurchase &&
+		hasScheduledDowngrade( currentPlanPurchase )
+			? currentPlanPurchase.scheduledDowngradeProductSlug
+			: null;
+
 	const useAction = useGenerateActionHook( {
 		siteId,
 		cartHandler: onUpgradeClick,
@@ -503,6 +512,7 @@ const PlansFeaturesMain = ( {
 		isPlanExpired,
 		redirectTo,
 		pluginSlug,
+		scheduledDowngradeTargetSlug,
 	} );
 
 	const isDomainOnlySite = useSelector( ( state: IAppState ) =>

--- a/client/state/purchases/actions.js
+++ b/client/state/purchases/actions.js
@@ -107,7 +107,7 @@ export const fetchSitePurchases = ( siteId ) => ( dispatch ) => {
 
 	return wpcom.req
 		.get( {
-			path: `/sites/${ siteId }/purchases`,
+			path: `/upgrades?site=${ siteId }`,
 			apiVersion: '1.2',
 		} )
 		.then( ( data ) => {

--- a/client/state/purchases/test/actions.js
+++ b/client/state/purchases/test/actions.js
@@ -47,7 +47,7 @@ describe( 'actions', () => {
 	describe( '#fetchSitePurchases', () => {
 		useNock( ( nock ) => {
 			nock( 'https://public-api.wordpress.com:443' )
-				.get( `/rest/v1.2/sites/${ siteId }/purchases` )
+				.get( `/rest/v1.2/upgrades?site=${ siteId }` )
 				.reply( 200, purchases );
 		} );
 
@@ -289,7 +289,7 @@ describe( 'actions', () => {
 			// unfiltered.
 			const apiResponse = [ { ID: 1 }, { ID: 2 } ];
 			nockInstance( 'https://public-api.wordpress.com:443' )
-				.get( `/rest/v1.2/sites/${ siteId }/purchases` )
+				.get( `/rest/v1.2/upgrades?site=${ siteId }` )
 				.reply( 200, apiResponse );
 
 			return fetchSitePurchases( siteId )( dispatch ).then( () => {

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -42,7 +42,7 @@
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,
-		"plans/scheduled-plan-downgrade": false,
+		"plans/scheduled-plan-downgrade": true,
 		"plans/self-service-downgrade": false,
 		"plans/updated-storage-labels": true,
 		"plans/upgradeable-storage": true,

--- a/config/development.json
+++ b/config/development.json
@@ -171,7 +171,7 @@
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,
-		"plans/scheduled-plan-downgrade": false,
+		"plans/scheduled-plan-downgrade": true,
 		"plans/self-service-downgrade": false,
 		"plans/updated-storage-labels": true,
 		"plans/upgradeable-storage": true,


### PR DESCRIPTION
Depends on https://github.com/Automattic/wp-calypso/pull/111392

## Summary
This is PR 3/4 that adds a delayed downgrade capability to all active plans. This PR focuses on showing the scheduled downgrade on various touch points.

<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/cbdac901-610c-46c9-9fd4-1234c89b7181" />

<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/482a4dac-881d-4bb7-9f58-163b1dacc8f0" />

<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/e9aac67f-3c87-4193-9cc9-98ab4a7cf7a0" />

<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/b2ecfbde-cd81-4576-ac68-76d4406a5fd9" />

<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/91574e7b-c7a0-4764-b3ea-3cc032e7d522" />


Technical details:

- Add scheduled downgrade display state across dashboard and classic surfaces:
  - Page-level notice with undo dialog on purchase settings
  - "Downgrade scheduled" badge on target plan in the plans grid
  - Disabled "Downgrade at renewal" button for the already-scheduled plan
  - Auto-renew help text showing target plan and renewal date
  - Purchase status badge in the purchase settings header
- Switch classic Redux `fetchSitePurchases` from `/sites/{siteId}/purchases` to `/upgrades?site={siteId}` so the classic plans page receives `scheduled_downgrade_*` fields
- Fix cancel-scheduled-downgrade dialog test assertions to match polished copy

**Feature flags**: `plans/scheduled-plan-downgrade` (off in production)

## Test plan

- [ ] Schedule a downgrade on a Premium/Business plan via the dashboard confirmation modal
- [ ] Verify purchase settings shows the page-level notice with "Undo downgrade" button
- [ ] Verify auto-renew help text shows target plan name and renewal date
- [ ] Navigate to classic plans page (`/plans/{site}`) — verify "Downgrade scheduled" badge appears on target plan and its button is disabled
- [ ] Navigate to WP Admin plans page — verify same badge and disabled button
- [ ] Click "Undo downgrade" — verify dialog copy matches ("Keep your current plan?", "Keep my plan", "Not now")
- [ ] Confirm undo — verify notice disappears and badge/disabled state are removed from plans grid
- [ ] Verify no regressions on plans page without a scheduled downgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)