### PR TITLE
E2E: fix P2 default-block click race in IsolatedBlockEditorComponent

### DIFF
--- a/packages/calypso-e2e/src/lib/components/isolated-block-editor-component.ts
+++ b/packages/calypso-e2e/src/lib/components/isolated-block-editor-component.ts
@@ -48,11 +48,6 @@ export class IsolatedBlockEditorComponent {
 
 		await firstParagraph.or( defaultBlockButton ).first().waitFor( { state: 'visible' } );
 		if ( await defaultBlockButton.isVisible() ) {
-			// The placeholder can detach between the isVisible check above and the click
-			// if the editor re-renders (e.g. a webfont class change on <html> triggers a
-			// React repaint). Use a short timeout and noWaitAfter to fail fast without
-			// hanging on post-click navigation heuristics. The firstParagraph.waitFor
-			// below is the real assertion that the editor reached the correct state.
 			await defaultBlockButton.click( { timeout: 5000, noWaitAfter: true } ).catch( () => {} );
 			await firstParagraph.waitFor( { state: 'visible' } );
 		}

--- a/packages/calypso-e2e/src/lib/components/isolated-block-editor-component.ts
+++ b/packages/calypso-e2e/src/lib/components/isolated-block-editor-component.ts
@@ -49,11 +49,11 @@ export class IsolatedBlockEditorComponent {
 		await firstParagraph.or( defaultBlockButton ).first().waitFor( { state: 'visible' } );
 		if ( await defaultBlockButton.isVisible() ) {
 			// The placeholder can detach between the isVisible check above and the click
-			// below if the editor re-renders (e.g. a webfont class change on <html>
-			// triggers a React repaint). Swallow the error — if the placeholder was
-			// replaced during the click, firstParagraph.waitFor below confirms the
-			// editor reached the correct state.
-			await defaultBlockButton.click().catch( () => {} );
+			// if the editor re-renders (e.g. a webfont class change on <html> triggers a
+			// React repaint). Use a short timeout and noWaitAfter to fail fast without
+			// hanging on post-click navigation heuristics. The firstParagraph.waitFor
+			// below is the real assertion that the editor reached the correct state.
+			await defaultBlockButton.click( { timeout: 5000, noWaitAfter: true } ).catch( () => {} );
 			await firstParagraph.waitFor( { state: 'visible' } );
 		}
 

--- a/packages/calypso-e2e/src/lib/components/isolated-block-editor-component.ts
+++ b/packages/calypso-e2e/src/lib/components/isolated-block-editor-component.ts
@@ -48,7 +48,12 @@ export class IsolatedBlockEditorComponent {
 
 		await firstParagraph.or( defaultBlockButton ).first().waitFor( { state: 'visible' } );
 		if ( await defaultBlockButton.isVisible() ) {
-			await defaultBlockButton.click();
+			// The placeholder can detach between the isVisible check above and the click
+			// below if the editor re-renders (e.g. a webfont class change on <html>
+			// triggers a React repaint). Swallow the error — if the placeholder was
+			// replaced during the click, firstParagraph.waitFor below confirms the
+			// editor reached the correct state.
+			await defaultBlockButton.click().catch( () => {} );
 			await firstParagraph.waitFor( { state: 'visible' } );
 		}
 


### PR DESCRIPTION
Follow-up to #111155.

## Proposed changes

* Wrap `defaultBlockButton.click()` in `.catch( () => {} )` so a DOM-detach mid-click doesn't fail the test.

## Why

PR #111155 added the `defaultBlockButton` click path to handle the P2 editor's empty-state affordance. The fix works, but the `isVisible()` → `click()` sequence is two separate async round-trips. Between them, the editor can re-render — a webfont class change on `<html>` (Web Font Loader adds `wf-loading` while fonts fetch, then flips to `wf-active`) triggers a React repaint that detaches the placeholder before the click lands.

Observed failure on Mobile viewport (build 18050174):

```
TimeoutError: locator.click: Timeout 10000ms exceeded.
→ getByRole('button', { name: 'Add default block' })
→ element resolved, then detached from DOM during click
```

The `firstParagraph.waitFor( { state: 'visible' } )` immediately after the click is the real assertion that the editor reached the correct state. If the click error was swallowed but the editor didn't actually transition, that `waitFor` throws with a clear message. So catching the click error is safe.

## Testing instructions

* `ESLINT_USE_FLAT_CONFIG=false yarn eslint --ext .ts --cache packages/calypso-e2e/src/lib/components/isolated-block-editor-component.ts`
* `yarn workspace @automattic/calypso-e2e build`

## Pre-merge checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md).
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?