### PR TITLE
Delayed Downgrades 4/4: mirror on-renewal entry point and display state to Calypso

### DIFF
--- a/client/components/confirm-dialog/index.tsx
+++ b/client/components/confirm-dialog/index.tsx
@@ -25,6 +25,7 @@ interface ConfirmDialogProps {
 	onRequestClose: ComponentProps< typeof Modal >[ 'onRequestClose' ];
 	children: React.ReactNode;
 	title?: string;
+	size?: ComponentProps< typeof Modal >[ 'size' ];
 	style?: React.CSSProperties;
 	className?: string;
 }
@@ -33,6 +34,7 @@ export const ConfirmDialog = ( {
 	onRequestClose,
 	children,
 	title,
+	size,
 	style,
 	className,
 }: ConfirmDialogProps ) => {
@@ -41,6 +43,7 @@ export const ConfirmDialog = ( {
 			className={ clsx( 'confirm-dialog', className ) }
 			onRequestClose={ onRequestClose }
 			title={ title }
+			size={ size }
 			style={ style }
 		>
 			{ children }

--- a/client/me/purchases/manage-purchase/cancel-scheduled-downgrade-dialog.tsx
+++ b/client/me/purchases/manage-purchase/cancel-scheduled-downgrade-dialog.tsx
@@ -1,0 +1,84 @@
+import { getPlan } from '@automattic/calypso-products';
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import { ConfirmDialog, DialogContent, DialogFooter } from 'calypso/components/confirm-dialog';
+import { cancelScheduledDowngradeAsync } from 'calypso/lib/purchases/actions';
+import { useDispatch } from 'calypso/state';
+import { successNotice, errorNotice } from 'calypso/state/notices/actions';
+import { fetchUserPurchases, fetchSitePurchases } from 'calypso/state/purchases/actions';
+import type { Purchase } from 'calypso/lib/purchases/types';
+
+interface CancelScheduledDowngradeDialogProps {
+	isVisible: boolean;
+	purchase: Purchase;
+	onClose: () => void;
+	onCancelSuccess?: () => void;
+}
+
+export default function CancelScheduledDowngradeDialog( {
+	isVisible,
+	purchase,
+	onClose,
+	onCancelSuccess,
+}: CancelScheduledDowngradeDialogProps ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const [ isCanceling, setIsCanceling ] = useState( false );
+
+	if ( ! isVisible ) {
+		return null;
+	}
+
+	const currentPlanTitle = getPlan( purchase.productSlug )?.getTitle() ?? '';
+
+	const handleConfirm = async () => {
+		setIsCanceling( true );
+		try {
+			await cancelScheduledDowngradeAsync( purchase.id );
+			dispatch( fetchUserPurchases() );
+			dispatch( fetchSitePurchases( purchase.siteId ) );
+			dispatch(
+				successNotice( translate( 'Your scheduled downgrade was canceled.' ), {
+					duration: 5000,
+				} )
+			);
+			if ( onCancelSuccess ) {
+				onCancelSuccess();
+			} else {
+				onClose();
+			}
+		} catch ( error ) {
+			dispatch(
+				errorNotice(
+					translate( 'We were unable to cancel the scheduled downgrade. Please try again.' ),
+					{ duration: 5000 }
+				)
+			);
+		} finally {
+			setIsCanceling( false );
+		}
+	};
+
+	return (
+		<ConfirmDialog
+			onRequestClose={ onClose }
+			title={ String( translate( 'Keep your current plan?' ) ) }
+		>
+			<DialogContent>
+				{ translate(
+					'Your %(plan)s plan will stay active. You can schedule a downgrade again anytime.',
+					{ args: { plan: currentPlanTitle } }
+				) }
+			</DialogContent>
+			<DialogFooter>
+				<Button variant="tertiary" onClick={ onClose } disabled={ isCanceling }>
+					{ translate( 'Not now' ) }
+				</Button>
+				<Button variant="primary" onClick={ handleConfirm } isBusy={ isCanceling }>
+					{ translate( 'Keep my plan' ) }
+				</Button>
+			</DialogFooter>
+		</ConfirmDialog>
+	);
+}

--- a/client/me/purchases/manage-purchase/cancel-scheduled-downgrade-dialog.tsx
+++ b/client/me/purchases/manage-purchase/cancel-scheduled-downgrade-dialog.tsx
@@ -64,6 +64,7 @@ export default function CancelScheduledDowngradeDialog( {
 		<ConfirmDialog
 			onRequestClose={ onClose }
 			title={ String( translate( 'Keep your current plan?' ) ) }
+			size="small"
 		>
 			<DialogContent>
 				{ translate(

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -611,8 +611,9 @@ class ManagePurchase extends Component<
 				isPremium( purchase ) ||
 				isBusiness( purchase ) ||
 				isEcommerce( purchase ) );
+		const activeDowngradeVariant = getActiveDowngradeVariant();
 		const isActiveDowngradeEligible =
-			getActiveDowngradeVariant() === 'instant' &&
+			( activeDowngradeVariant === 'instant' || activeDowngradeVariant === 'on_renewal' ) &&
 			purchase &&
 			! isExpired( purchase ) &&
 			! isInExpirationGracePeriod( purchase ) &&
@@ -681,11 +682,12 @@ class ManagePurchase extends Component<
 				isBusiness( purchase ) ||
 				isEcommerce( purchase ) );
 
+		const activeDowngradeVariant = getActiveDowngradeVariant();
 		const isActiveDowngradeEligible =
 			! isExpired( purchase ) &&
 			! isInExpirationGracePeriod( purchase ) &&
 			isPlan( purchase ) &&
-			getActiveDowngradeVariant() === 'instant' &&
+			( activeDowngradeVariant === 'instant' || activeDowngradeVariant === 'on_renewal' ) &&
 			( isPremium( purchase ) || isBusiness( purchase ) || isEcommerce( purchase ) );
 
 		const isDowngradeEligible = isExpiredDowngradeEligible || isActiveDowngradeEligible;

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -52,12 +52,14 @@ import {
 	shouldAddPaymentSourceInsteadOfRenewingNow,
 	isMonthlyPurchase,
 	isInExpirationGracePeriod,
+	hasScheduledDowngrade,
 } from 'calypso/lib/purchases';
 import { getTrialCheckoutUrl } from 'calypso/lib/trials/get-trial-checkout-url';
 import { managePurchase } from 'calypso/me/purchases/paths';
 import UpcomingRenewalsDialog from 'calypso/me/purchases/upcoming-renewals/upcoming-renewals-dialog';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getAddNewPaymentMethodPath } from '../utils';
+import CancelScheduledDowngradeDialog from './cancel-scheduled-downgrade-dialog';
 import { classifyPurchaseForCopy } from './classify-purchase-for-copy';
 import type { SiteDetails } from '@automattic/data-stores';
 import type {
@@ -122,6 +124,11 @@ class PurchaseNotice extends Component<
 		showPlanChangedNotice:
 			typeof window !== 'undefined' &&
 			new URLSearchParams( window.location.search ).get( 'plan_changed' ) === 'true',
+		showDowngradeScheduledNotice:
+			typeof window !== 'undefined' &&
+			new URLSearchParams( window.location.search ).get( 'downgrade_scheduled' ) === 'true',
+		showCancelDowngradeDialog: false,
+		scheduledDowngradeCanceled: false,
 	};
 
 	componentDidMount() {
@@ -143,6 +150,10 @@ class PurchaseNotice extends Component<
 			params.delete( 'plan_changed' );
 			changed = true;
 		}
+		if ( params.get( 'downgrade_scheduled' ) === 'true' ) {
+			params.delete( 'downgrade_scheduled' );
+			changed = true;
+		}
 		if ( changed ) {
 			const newSearch = params.toString();
 			const newUrl =
@@ -161,6 +172,22 @@ class PurchaseNotice extends Component<
 
 	dismissPlanChangedNotice = () => {
 		this.setState( { showPlanChangedNotice: false } );
+	};
+
+	dismissDowngradeScheduledNotice = () => {
+		this.setState( { showDowngradeScheduledNotice: false } );
+	};
+
+	openCancelDowngradeDialog = () => {
+		this.setState( { showCancelDowngradeDialog: true } );
+	};
+
+	closeCancelDowngradeDialog = () => {
+		this.setState( { showCancelDowngradeDialog: false } );
+	};
+
+	handleCancelDowngradeSuccess = () => {
+		this.setState( { showCancelDowngradeDialog: false, scheduledDowngradeCanceled: true } );
 	};
 
 	/**
@@ -269,6 +296,100 @@ class PurchaseNotice extends Component<
 					args: { planName: getName( purchase ) },
 				} ) }
 			/>
+		);
+	}
+
+	renderDowngradeScheduledNotice() {
+		const { purchase, translate } = this.props;
+		if ( ! this.state.showDowngradeScheduledNotice || ! purchase ) {
+			return null;
+		}
+		return (
+			<Notice
+				className="manage-purchase__purchase-expiring-notice"
+				showDismiss
+				onDismissClick={ this.dismissDowngradeScheduledNotice }
+				status="is-success"
+				text={ translate( 'Your downgrade has been scheduled.' ) }
+			/>
+		);
+	}
+
+	renderScheduledDowngradeNotice() {
+		const { purchase, translate, moment } = this.props;
+		if (
+			! purchase ||
+			! config.isEnabled( 'plans/scheduled-plan-downgrade' ) ||
+			! hasScheduledDowngrade( purchase ) ||
+			this.state.scheduledDowngradeCanceled
+		) {
+			return null;
+		}
+
+		const targetPlanTitle =
+			getPlan( purchase.scheduledDowngradeProductSlug ?? '' )?.getTitle() ?? '';
+		const renewalDateFormatted = purchase.scheduledDowngradeRenewalDate
+			? moment( purchase.scheduledDowngradeRenewalDate ).format( 'LL' )
+			: '';
+
+		// Auto-renew ON: info notice with undo button.
+		if ( purchase.isAutoRenewEnabled ) {
+			return (
+				<>
+					<Notice
+						className="manage-purchase__purchase-expiring-notice"
+						showDismiss={ false }
+						status="is-info"
+						text={ translate(
+							'You\u2019ve scheduled a downgrade to %(plan)s. Your current plan stays active until %(date)s.',
+							{
+								args: {
+									plan: targetPlanTitle,
+									date: renewalDateFormatted,
+								},
+							}
+						) }
+					>
+						<NoticeAction onClick={ this.openCancelDowngradeDialog }>
+							{ translate( 'Undo downgrade' ) }
+						</NoticeAction>
+					</Notice>
+					<CancelScheduledDowngradeDialog
+						isVisible={ this.state.showCancelDowngradeDialog }
+						purchase={ purchase }
+						onClose={ this.closeCancelDowngradeDialog }
+						onCancelSuccess={ this.handleCancelDowngradeSuccess }
+					/>
+				</>
+			);
+		}
+
+		// Auto-renew OFF: warning notice with enable auto-renew and undo actions.
+		return (
+			<>
+				<Notice
+					className="manage-purchase__purchase-expiring-notice"
+					showDismiss={ false }
+					status="is-warning"
+					text={ translate(
+						'You\u2019ve scheduled a downgrade to %(plan)s, but your plan isn\u2019t set to renew. The downgrade won\u2019t happen unless you enable auto-renew.',
+						{
+							args: {
+								plan: targetPlanTitle,
+							},
+						}
+					) }
+				>
+					<NoticeAction onClick={ this.openCancelDowngradeDialog }>
+						{ translate( 'Undo downgrade' ) }
+					</NoticeAction>
+				</Notice>
+				<CancelScheduledDowngradeDialog
+					isVisible={ this.state.showCancelDowngradeDialog }
+					purchase={ purchase }
+					onClose={ this.closeCancelDowngradeDialog }
+				/>
+			</>
 		);
 	}
 
@@ -1489,6 +1610,11 @@ class PurchaseNotice extends Component<
 			return planChangedNotice;
 		}
 
+		const downgradeScheduledNotice = this.renderDowngradeScheduledNotice();
+		if ( downgradeScheduledNotice ) {
+			return downgradeScheduledNotice;
+		}
+
 		if ( purchase.asyncPendingPaymentBlockIsSet ) {
 			return this.renderAsyncPendingPaymentNotice();
 		}
@@ -1516,6 +1642,11 @@ class PurchaseNotice extends Component<
 
 		if ( this.shouldRenderConciergeConsumedNotice() ) {
 			return this.renderConciergeConsumedNotice();
+		}
+
+		const scheduledDowngradeNotice = this.renderScheduledDowngradeNotice();
+		if ( scheduledDowngradeNotice ) {
+			return scheduledDowngradeNotice;
 		}
 
 		const otherRenewablePurchasesNotice = this.renderOtherRenewablePurchasesNotice();

--- a/client/me/purchases/purchase-item/index.tsx
+++ b/client/me/purchases/purchase-item/index.tsx
@@ -1,4 +1,6 @@
+import config from '@automattic/calypso-config';
 import {
+	getPlan,
 	isDomainTransfer,
 	isDomainRegistration,
 	isConciergeSession,
@@ -49,6 +51,7 @@ import {
 	hasPaymentMethod,
 	isPaidWithCredits,
 	isInExpirationGracePeriod,
+	hasScheduledDowngrade,
 } from 'calypso/lib/purchases';
 import { getPurchaseListUrlFor } from 'calypso/my-sites/purchases/paths';
 import getSiteIconUrl from 'calypso/state/selectors/get-site-icon-url';
@@ -466,6 +469,11 @@ export function PurchaseItemStatus( {
 				<TrackImpression warning="purchase-expiring" />
 			</span>
 		);
+	}
+
+	if ( hasScheduledDowngrade( purchase ) && config.isEnabled( 'plans/scheduled-plan-downgrade' ) ) {
+		const targetTitle = getPlan( purchase.scheduledDowngradeProductSlug ?? '' )?.getTitle() ?? '';
+		return translate( 'Changing to %(plan)s at renewal', { args: { plan: targetTitle } } );
 	}
 
 	if ( isRenewing( purchase ) && purchase.renewDate ) {

--- a/client/my-sites/plans/current-plan/purchases-listing.jsx
+++ b/client/my-sites/plans/current-plan/purchases-listing.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import {
 	isFreeJetpackPlan,
 	isFreePlan,
@@ -30,6 +31,7 @@ import ProductExpiration from 'calypso/components/product-expiration';
 import {
 	isExpiring,
 	getDisplayName,
+	hasScheduledDowngrade,
 	isPartnerPurchase,
 	shouldAddPaymentSourceInsteadOfRenewingNow,
 } from 'calypso/lib/purchases';
@@ -38,6 +40,7 @@ import OwnerInfo from 'calypso/me/purchases/purchase-item/owner-info';
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
+import { hasLoadedSitePurchasesFromServer } from 'calypso/state/purchases/selectors/fetching';
 import isJetpackCloudEligible from 'calypso/state/selectors/is-jetpack-cloud-eligible';
 import {
 	getCurrentPlan,
@@ -71,9 +74,20 @@ class PurchasesListing extends Component {
 	};
 
 	isLoading() {
-		const { currentPlan, selectedSite, isRequestingPlans, isCloudEligible } = this.props;
+		const { currentPlan, selectedSite, isRequestingPlans, isCloudEligible, purchasesLoaded } =
+			this.props;
 
-		return ! currentPlan || ! selectedSite || isRequestingPlans || undefined === isCloudEligible;
+		if ( ! currentPlan || ! selectedSite || isRequestingPlans || undefined === isCloudEligible ) {
+			return true;
+		}
+
+		// Wait for purchases to load so the scheduled downgrade status doesn't flash
+		// "Renews on" before switching to "Changing to {plan} at renewal".
+		if ( config.isEnabled( 'plans/scheduled-plan-downgrade' ) && ! purchasesLoaded ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	isFreePlan( purchase ) {
@@ -143,6 +157,23 @@ class PurchasesListing extends Component {
 		// No expiration date for free plans.
 		if ( this.isFreePlan( plan ) ) {
 			return null;
+		}
+
+		const { purchases, translate } = this.props;
+		const planPurchase = purchases?.find(
+			( p ) => isPlan( p ) && p.productSlug === plan.productSlug
+		);
+
+		if (
+			planPurchase &&
+			hasScheduledDowngrade( planPurchase ) &&
+			config.isEnabled( 'plans/scheduled-plan-downgrade' )
+		) {
+			const targetTitle =
+				getPlan( planPurchase.scheduledDowngradeProductSlug ?? '' )?.getTitle() ?? '';
+			return translate( 'Changing to %(plan)s at renewal', {
+				args: { plan: targetTitle },
+			} );
 		}
 
 		const expiryMoment = plan.expiryDate ? this.props.moment( plan.expiryDate ) : null;
@@ -441,6 +472,7 @@ export default connect( ( state ) => {
 		isPlanExpiring: isCurrentPlanExpiring( state, selectedSiteId ),
 		isRequestingPlans: isRequestingSitePlans( state, selectedSiteId ),
 		purchases: getSitePurchases( state, selectedSiteId ),
+		purchasesLoaded: hasLoadedSitePurchasesFromServer( state ),
 		selectedSite: getSelectedSite( state ),
 		selectedSiteId,
 		selectedSiteSlug: getSelectedSiteSlug( state ),


### PR DESCRIPTION
Depends on: https://github.com/Automattic/wp-calypso/pull/111405

## Summary
This is PR 4/4 that adds a delayed downgrade capability to all active plans. This PR focuses on adding the entry points and notices to Calypso.

<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/f8d696f4-34a8-4ef7-a9b7-cbcfea661db9" />

<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/112f4f76-2ad1-4ae5-b110-a01beb4cd9f0" />

<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/6545acf6-fcfa-479b-a100-a75d597d5532" />

<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/8b95be08-7b36-4d7f-bbe0-f33b107163c4" />

<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/51de2a93-1666-4c5a-94e9-0b57b120c628" />



Technical details:
- **Entry point**: Widens the "Change plan" nav item gate to include the `on_renewal` experiment variant alongside `instant`, routing to the plan-upgrade stepper
- **Notices**: Transient success notice after scheduling (via `downgrade_scheduled` URL param) and persistent info/warning notice with "Undo downgrade" action that opens a confirmation dialog
- **Undo dialog**: `CancelScheduledDowngradeDialog` calls `cancelScheduledDowngradeAsync`, refetches purchases, and optimistically hides the notice
- **Purchase list status**: Shows "Changing to {plan} at renewal" in the purchases table
- **My Plans card**: Shows "Changing to {plan} at renewal" instead of "Renews on {date}", with skeleton loader gated on purchases loading to prevent flash

Gated behind `plans/scheduled-plan-downgrade` feature flag.

## Test plan

- [ ] Enable `plans/scheduled-plan-downgrade` flag
- [ ] Schedule a downgrade on an active plan via the plan-upgrade stepper
- [ ] Verify "Your downgrade has been scheduled" transient notice appears on redirect
- [ ] Verify persistent info notice with "Undo downgrade" action on manage-purchase page
- [ ] Click "Undo downgrade" → confirm in dialog → notice disappears immediately
- [ ] Verify "Changing to {plan} at renewal" in the purchases list
- [ ] Verify "Changing to {plan} at renewal" on the My Plans page (no "Renews on" flash)
- [ ] Turn off auto-renew → verify warning variant of the scheduled downgrade notice
- [ ] Verify no regressions on manage-purchase page without a scheduled downgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)