### PR TITLE
Plans: Add self-serve downgrades for expired plans

### DIFF
--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -58,17 +58,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { DOMAIN_CANCEL, SUPPORT_ROOT } from '@automattic/urls';
 import { useQuery } from '@tanstack/react-query';
 import { hasTranslation } from '@wordpress/i18n';
-import {
-	check,
-	column,
-	download,
-	Icon,
-	payment,
-	reusableBlock,
-	tool,
-	trash,
-	upload,
-} from '@wordpress/icons';
+import { check, column, Icon, payment, reusableBlock, tool, trash, upload } from '@wordpress/icons';
 import clsx from 'clsx';
 import { localize, LocalizeProps, useTranslate } from 'i18n-calypso';
 import moment from 'moment';
@@ -133,7 +123,6 @@ import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features
 import {
 	getCancelPurchaseUrlFor,
 	getAddNewPaymentMethodUrlFor,
-	getDowngradeUrlFor,
 } from 'calypso/my-sites/purchases/paths';
 import { useSelector } from 'calypso/state';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
@@ -168,7 +157,7 @@ import { getCanonicalTheme } from 'calypso/state/themes/selectors';
 import { CalypsoDispatch, IAppState } from 'calypso/state/types';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { isRequestingWordAdsApprovalForSite } from 'calypso/state/wordads/approve/selectors';
-import { cancelPurchase, downgradePurchase, managePurchase, purchasesRoot } from '../paths';
+import { cancelPurchase, managePurchase, purchasesRoot } from '../paths';
 import PurchaseSiteHeader from '../purchases-site/header';
 import RemovePurchase from '../remove-purchase';
 import {
@@ -209,7 +198,6 @@ export interface ManagePurchaseProps {
 	cardTitle?: string;
 	getAddNewPaymentMethodUrlFor?: typeof getAddNewPaymentMethodUrlFor;
 	getCancelPurchaseUrlFor?: typeof getCancelPurchaseUrlFor;
-	getDowngradeUrlFor?: typeof getDowngradeUrlFor;
 	getChangePaymentMethodUrlFor?: GetChangePaymentMethodUrlFor;
 	getManagePurchaseUrlFor?: GetManagePurchaseUrlFor;
 	isSiteLevel?: boolean;
@@ -1115,30 +1103,6 @@ class ManagePurchase extends Component<
 		);
 	}
 
-	renderDowngradeNavItem() {
-		const { purchase, translate } = this.props;
-		if ( ! purchase ) {
-			return null;
-		}
-
-		if ( ! ( isBusiness( purchase ) || isPremium( purchase ) || isEcommerce( purchase ) ) ) {
-			return null;
-		}
-
-		const link = ( this.props.getDowngradeUrlFor ?? downgradePurchase )(
-			this.props.siteSlug,
-			purchase.id
-		);
-
-		return (
-			<CompactCard href={ link }>
-				<Icon icon={ download } className="card__icon" />
-				{ translate( 'Downgrade plan' ) }
-				{ this.renderActionDetails() }
-			</CompactCard>
-		);
-	}
-
 	renderPurchaseIcon() {
 		const { purchase, translate } = this.props;
 		if ( ! purchase ) {
@@ -1582,9 +1546,6 @@ class ManagePurchase extends Component<
 						{ config.isEnabled( 'jetpack/crm-downloads' ) && this.renderCrmDownloadsNavItem() }
 						{ this.renderReinstall() }
 						<div className="manage-purchase__downgrade-products">
-							{ config.isEnabled( 'plans/self-service-downgrade' ) && ! isPersonal( purchase )
-								? this.renderDowngradeNavItem()
-								: null }
 							{ this.renderCancelPurchaseNavItem() }
 							{ this.renderRemovePurchaseNavItem() }
 							{ this.renderCancelSurvey() }

--- a/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/index.tsx
+++ b/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/index.tsx
@@ -1,0 +1,135 @@
+import { purchaseCancelFeaturesQuery } from '@automattic/api-queries';
+import { Gridicon, Spinner } from '@automattic/components';
+import { useQuery } from '@tanstack/react-query';
+import { Button, Modal } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+
+import './style.scss';
+
+interface DowngradeConfirmationModalProps {
+	isOpen: boolean;
+	currentPlanName: string;
+	targetPlanName: string;
+	targetPlanSlug: string | null;
+	purchaseId: number | undefined;
+	onClose: () => void;
+	onConfirm: () => void;
+}
+
+function ModalBody( {
+	isLoading,
+	currentPlanName,
+	targetPlanName,
+	lostFeatures,
+}: {
+	isLoading: boolean;
+	currentPlanName: string;
+	targetPlanName: string;
+	lostFeatures: { feature_id: string; title: string }[];
+} ) {
+	const translate = useTranslate();
+
+	if ( isLoading ) {
+		return (
+			<div className="downgrade-confirmation-modal__loading">
+				<Spinner />
+			</div>
+		);
+	}
+
+	if ( lostFeatures.length === 0 ) {
+		return (
+			<p className="downgrade-confirmation-modal__description">
+				{ translate(
+					'When you change from %(currentPlan)s to %(targetPlan)s, your features will stay the same.',
+					{
+						args: { currentPlan: currentPlanName, targetPlan: targetPlanName },
+						comment: 'Message shown when downgrading an expired plan with no feature differences',
+					}
+				) }
+			</p>
+		);
+	}
+
+	return (
+		<>
+			<p className="downgrade-confirmation-modal__description">
+				{ translate(
+					"When you change from %(currentPlan)s to %(targetPlan)s, here's what you'll lose:",
+					{
+						args: { currentPlan: currentPlanName, targetPlan: targetPlanName },
+						comment:
+							'Message shown when downgrading an expired plan, listing features that will be lost',
+					}
+				) }
+			</p>
+			<ul className="downgrade-confirmation-modal__feature-list">
+				{ lostFeatures.map( ( feature ) => (
+					<li key={ feature.feature_id } className="downgrade-confirmation-modal__feature-item">
+						<Gridicon
+							icon="cross-small"
+							size={ 24 }
+							className="downgrade-confirmation-modal__feature-icon"
+						/>
+						<span className="downgrade-confirmation-modal__feature-text">{ feature.title }</span>
+					</li>
+				) ) }
+			</ul>
+		</>
+	);
+}
+
+const DowngradeConfirmationModal = ( {
+	isOpen,
+	currentPlanName,
+	targetPlanName,
+	targetPlanSlug,
+	purchaseId,
+	onClose,
+	onConfirm,
+}: DowngradeConfirmationModalProps ) => {
+	const translate = useTranslate();
+
+	const { data: cancelFeaturesData, isLoading } = useQuery( {
+		...purchaseCancelFeaturesQuery( purchaseId ?? 0, 'control', targetPlanSlug ?? undefined ),
+		enabled: !! purchaseId && !! targetPlanSlug && isOpen,
+	} );
+
+	if ( ! targetPlanSlug || ! isOpen ) {
+		return null;
+	}
+
+	const lostFeatures = cancelFeaturesData?.features ?? [];
+
+	return (
+		<Modal
+			title={ String( translate( 'Confirm downgrade' ) ) }
+			onRequestClose={ onClose }
+			className="downgrade-confirmation-modal"
+			size="medium"
+		>
+			<ModalBody
+				isLoading={ isLoading }
+				currentPlanName={ currentPlanName }
+				targetPlanName={ targetPlanName }
+				lostFeatures={ lostFeatures }
+			/>
+			<div className="downgrade-confirmation-modal__buttons">
+				<Button __next40pxDefaultSize variant="tertiary" onClick={ onClose }>
+					{ translate( 'Keep %(planName)s', {
+						args: { planName: currentPlanName },
+						comment: 'Button label to dismiss the downgrade modal and keep the current plan',
+					} ) }
+				</Button>
+				<Button __next40pxDefaultSize variant="primary" onClick={ onConfirm }>
+					{ translate( 'Downgrade to %(planName)s', {
+						args: { planName: targetPlanName },
+						comment: 'Button label to confirm downgrading to a lower-tier plan',
+					} ) }
+				</Button>
+			</div>
+		</Modal>
+	);
+};
+
+export default DowngradeConfirmationModal;

--- a/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/style.scss
+++ b/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/style.scss
@@ -1,0 +1,41 @@
+.downgrade-confirmation-modal__loading {
+	display: flex;
+	justify-content: center;
+	padding: 16px 0;
+}
+
+.downgrade-confirmation-modal__description {
+	font-size: $font-body-small;
+	margin-block-end: 8px;
+}
+
+.downgrade-confirmation-modal__feature-list {
+	list-style: none;
+	padding: 0;
+	margin: 0;
+}
+
+.downgrade-confirmation-modal__feature-item {
+	display: flex;
+	font-size: $font-body-small;
+}
+
+.downgrade-confirmation-modal__feature-text {
+	margin-block: auto;
+	flex: 1;
+	min-width: 0;
+}
+
+.downgrade-confirmation-modal__feature-icon {
+	color: var(--color-error-40);
+	flex-shrink: 0;
+	margin-inline-end: 8px;
+	margin-block-start: 2px;
+}
+
+.downgrade-confirmation-modal__buttons {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+	margin-block-start: 24px;
+}

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { isEnabled } from '@automattic/calypso-config';
 import {
 	applyTestFiltersToPlansList,
 	PRODUCT_1GB_SPACE,
@@ -155,7 +156,11 @@ function useDowngradeHandler( {
 			// If the server says the plan supports a self-service downgrade and the current
 			// plan is expired, send the user directly to checkout.
 			const targetPlan = sitePlansData?.find( ( p ) => p.productSlug === planSlug );
-			if ( targetPlan?.availableForDowngrade && currentPlanExpired ) {
+			if (
+				isEnabled( 'plans/expired-downgrade' ) &&
+				targetPlan?.availableForDowngrade &&
+				currentPlanExpired
+			) {
 				const planPath = getPlanPath( planSlug ) ?? '';
 				const checkoutUrl = `/checkout/${ siteSlug }/${ planPath }`;
 				window.location.href = addQueryArgs(

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
@@ -1,5 +1,4 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	applyTestFiltersToPlansList,
 	PRODUCT_1GB_SPACE,
@@ -21,14 +20,12 @@ import { cancelPurchase } from 'calypso/me/purchases/paths';
 import { useFreeTrialPlanSlugs } from 'calypso/my-sites/plans-features-main/hooks/use-free-trial-plan-slugs';
 import { useSelector } from 'calypso/state';
 import { isCurrentUserCurrentPlanOwner } from 'calypso/state/sites/plans/selectors';
-import { getPlansBySiteId } from 'calypso/state/sites/plans/selectors/get-plans-by-site';
 import { getSiteSlug, getSiteUrl, isCurrentPlanPaid } from 'calypso/state/sites/selectors';
 import { IAppState } from 'calypso/state/types';
 import useCurrentPlanManageHref from './use-current-plan-manage-href';
 import { useNonOwnerHandler } from './use-non-owner-handler';
 import type { PlansIntent, UseActionCallback } from '@automattic/plans-grid-next';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
-import type { SitePlanData } from 'calypso/my-sites/checkout/src/hooks/product-variants';
 
 function useUpgradeHandler( {
 	siteSlug,
@@ -126,47 +123,19 @@ function useDowngradeHandler( {
 	siteSlug,
 	siteUrl,
 	currentPlan,
-	currentPlanExpired,
-	sitePlansData,
-	coupon,
-	redirectTo,
 }: {
 	siteSlug?: string | null;
 	siteUrl?: string | null;
 	currentPlan: Plans.SitePlan | undefined;
-	currentPlanExpired: boolean;
-	sitePlansData: SitePlanData[] | null;
-	coupon?: string;
-	redirectTo?: string;
 } ) {
 	const { setNewMessagingChat, setNavigateToOdie } = useDispatch( HELP_CENTER_STORE );
 	const { data: canConnectToZendeskMessaging } = useCanConnectToZendeskMessaging();
 
 	return useCallback(
 		( planSlug: PlanSlug ) => {
-			// Use full navigations rather than `page()` below because this grid can be
-			// rendered inside the Stepper, where the `page` router is not initialized.
-
 			// A downgrade to the free plan is essentially cancelling the current plan.
 			if ( isFreePlan( planSlug ) ) {
-				window.location.href = cancelPurchase( siteSlug, currentPlan?.purchaseId );
-				return;
-			}
-
-			// If the server says the plan supports a self-service downgrade and the current
-			// plan is expired, send the user directly to checkout.
-			const targetPlan = sitePlansData?.find( ( p ) => p.productSlug === planSlug );
-			if (
-				isEnabled( 'plans/expired-downgrade' ) &&
-				targetPlan?.availableForDowngrade &&
-				currentPlanExpired
-			) {
-				const planPath = getPlanPath( planSlug ) ?? '';
-				const checkoutUrl = `/checkout/${ siteSlug }/${ planPath }`;
-				window.location.href = addQueryArgs(
-					{ ...( coupon && { coupon } ), ...( redirectTo && { redirect_to: redirectTo } ) },
-					checkoutUrl
-				);
+				page( cancelPurchase( siteSlug, currentPlan?.purchaseId ) );
 				return;
 			}
 
@@ -181,10 +150,6 @@ function useDowngradeHandler( {
 		},
 		[
 			currentPlan?.purchaseId,
-			currentPlanExpired,
-			sitePlansData,
-			coupon,
-			redirectTo,
 			setNewMessagingChat,
 			siteUrl,
 			siteSlug,
@@ -227,10 +192,6 @@ function useGenerateActionCallback( {
 } ): UseActionCallback {
 	const siteSlug = useSelector( ( state: IAppState ) => getSiteSlug( state, siteId ) );
 	const siteUrl = useSelector( ( state: IAppState ) => siteId && getSiteUrl( state, siteId ) );
-	const sitePlansData = useSelector( ( state: IAppState ) =>
-		siteId ? getPlansBySiteId( state, siteId )?.data : null
-	);
-	const currentPlanExpired = !! sitePlansData?.find( ( p ) => p.currentPlan )?.expired;
 	const freeTrialPlanSlugs = useFreeTrialPlanSlugs( {
 		intent: intent ?? 'default',
 		eligibleForFreeHostingTrial,
@@ -252,10 +213,6 @@ function useGenerateActionCallback( {
 		siteSlug,
 		siteUrl: siteUrl || '',
 		currentPlan,
-		currentPlanExpired,
-		sitePlansData: sitePlansData ?? null,
-		coupon,
-		redirectTo,
 	} );
 	const handleNonOwnerClick = useNonOwnerHandler( { siteId, currentPlan } );
 

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
@@ -20,12 +20,14 @@ import { cancelPurchase } from 'calypso/me/purchases/paths';
 import { useFreeTrialPlanSlugs } from 'calypso/my-sites/plans-features-main/hooks/use-free-trial-plan-slugs';
 import { useSelector } from 'calypso/state';
 import { isCurrentUserCurrentPlanOwner } from 'calypso/state/sites/plans/selectors';
+import { getPlansBySiteId } from 'calypso/state/sites/plans/selectors/get-plans-by-site';
 import { getSiteSlug, getSiteUrl, isCurrentPlanPaid } from 'calypso/state/sites/selectors';
 import { IAppState } from 'calypso/state/types';
 import useCurrentPlanManageHref from './use-current-plan-manage-href';
 import { useNonOwnerHandler } from './use-non-owner-handler';
 import type { PlansIntent, UseActionCallback } from '@automattic/plans-grid-next';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
+import type { SitePlanData } from 'calypso/my-sites/checkout/src/hooks/product-variants';
 
 function useUpgradeHandler( {
 	siteSlug,
@@ -123,10 +125,18 @@ function useDowngradeHandler( {
 	siteSlug,
 	siteUrl,
 	currentPlan,
+	currentPlanExpired,
+	sitePlansData,
+	coupon,
+	redirectTo,
 }: {
 	siteSlug?: string | null;
 	siteUrl?: string | null;
 	currentPlan: Plans.SitePlan | undefined;
+	currentPlanExpired: boolean;
+	sitePlansData: SitePlanData[] | null;
+	coupon?: string;
+	redirectTo?: string;
 } ) {
 	const { setNewMessagingChat, setNavigateToOdie } = useDispatch( HELP_CENTER_STORE );
 	const { data: canConnectToZendeskMessaging } = useCanConnectToZendeskMessaging();
@@ -136,6 +146,21 @@ function useDowngradeHandler( {
 			// A downgrade to the free plan is essentially cancelling the current plan.
 			if ( isFreePlan( planSlug ) ) {
 				page( cancelPurchase( siteSlug, currentPlan?.purchaseId ) );
+				return;
+			}
+
+			// If the server says the plan supports a self-service downgrade and the current
+			// plan is expired, send the user directly to checkout.
+			const targetPlan = sitePlansData?.find( ( p ) => p.productSlug === planSlug );
+			if ( targetPlan?.availableForDowngrade && currentPlanExpired ) {
+				const planPath = getPlanPath( planSlug ) ?? '';
+				const checkoutUrl = `/checkout/${ siteSlug }/${ planPath }`;
+				page(
+					addQueryArgs(
+						{ ...( coupon && { coupon } ), ...( redirectTo && { redirect_to: redirectTo } ) },
+						checkoutUrl
+					)
+				);
 				return;
 			}
 
@@ -150,6 +175,10 @@ function useDowngradeHandler( {
 		},
 		[
 			currentPlan?.purchaseId,
+			currentPlanExpired,
+			sitePlansData,
+			coupon,
+			redirectTo,
 			setNewMessagingChat,
 			siteUrl,
 			siteSlug,
@@ -192,6 +221,10 @@ function useGenerateActionCallback( {
 } ): UseActionCallback {
 	const siteSlug = useSelector( ( state: IAppState ) => getSiteSlug( state, siteId ) );
 	const siteUrl = useSelector( ( state: IAppState ) => siteId && getSiteUrl( state, siteId ) );
+	const sitePlansData = useSelector( ( state: IAppState ) =>
+		siteId ? getPlansBySiteId( state, siteId )?.data : null
+	);
+	const currentPlanExpired = !! sitePlansData?.find( ( p ) => p.currentPlan )?.expired;
 	const freeTrialPlanSlugs = useFreeTrialPlanSlugs( {
 		intent: intent ?? 'default',
 		eligibleForFreeHostingTrial,
@@ -213,6 +246,10 @@ function useGenerateActionCallback( {
 		siteSlug,
 		siteUrl: siteUrl || '',
 		currentPlan,
+		currentPlanExpired,
+		sitePlansData: sitePlansData ?? null,
+		coupon,
+		redirectTo,
 	} );
 	const handleNonOwnerClick = useNonOwnerHandler( { siteId, currentPlan } );
 

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
@@ -143,9 +143,12 @@ function useDowngradeHandler( {
 
 	return useCallback(
 		( planSlug: PlanSlug ) => {
+			// Use full navigations rather than `page()` below because this grid can be
+			// rendered inside the Stepper, where the `page` router is not initialized.
+
 			// A downgrade to the free plan is essentially cancelling the current plan.
 			if ( isFreePlan( planSlug ) ) {
-				page( cancelPurchase( siteSlug, currentPlan?.purchaseId ) );
+				window.location.href = cancelPurchase( siteSlug, currentPlan?.purchaseId );
 				return;
 			}
 
@@ -155,11 +158,9 @@ function useDowngradeHandler( {
 			if ( targetPlan?.availableForDowngrade && currentPlanExpired ) {
 				const planPath = getPlanPath( planSlug ) ?? '';
 				const checkoutUrl = `/checkout/${ siteSlug }/${ planPath }`;
-				page(
-					addQueryArgs(
-						{ ...( coupon && { coupon } ), ...( redirectTo && { redirect_to: redirectTo } ) },
-						checkoutUrl
-					)
+				window.location.href = addQueryArgs(
+					{ ...( coupon && { coupon } ), ...( redirectTo && { redirect_to: redirectTo } ) },
+					checkoutUrl
 				);
 				return;
 			}

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	type PlanSlug,
 	isFreePlan,
@@ -518,15 +517,6 @@ function getLoggedInPlansAction( {
 
 	// Downgrade action if the plan is not available for purchase
 	if ( ! availableForPurchase ) {
-		if ( isEnabled( 'plans/self-service-downgrade' ) ) {
-			return {
-				primary: {
-					callback: () => {},
-					text: translate( 'Requires downgrade' ),
-					status: 'disabled',
-				},
-			};
-		}
 		return createLoggedInPlansAction(
 			translate( 'Downgrade', { context: 'verb' } ),
 			'secondary',

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -937,14 +937,14 @@ const PlansFeaturesMain = ( {
 							return;
 						}
 						setPendingDowngradePlanSlug( null );
-						page(
-							addQueryArgs(
-								{
-									...( coupon && { coupon } ),
-									...( redirectTo && { redirect_to: redirectTo } ),
-								},
-								`/checkout/${ siteSlug }/${ planPath }`
-							)
+						// Use a full navigation rather than `page()` because this grid can be
+						// rendered inside the Stepper, where the `page` router is not initialized.
+						window.location.href = addQueryArgs(
+							{
+								...( coupon && { coupon } ),
+								...( redirectTo && { redirect_to: redirectTo } ),
+							},
+							`/checkout/${ siteSlug }/${ planPath }`
 						);
 					} }
 				/>

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -2,6 +2,7 @@ import config from '@automattic/calypso-config';
 import {
 	chooseDefaultCustomerType,
 	getPlan,
+	getPlanPath,
 	isFreePlan,
 	isPersonalPlan,
 	PLAN_PERSONAL,
@@ -59,6 +60,7 @@ import { retargetViewPlans } from 'calypso/lib/analytics/ad-tracking';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { planItem as getCartItemForPlan } from 'calypso/lib/cart-values/cart-items';
 import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
+import { addQueryArgs } from 'calypso/lib/url';
 import PlanNotice from 'calypso/my-sites/plans-features-main/components/plan-notice';
 import {
 	shouldForceDefaultPlansBasedOnIntent,
@@ -75,8 +77,10 @@ import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
 import isDomainOnlySiteSelector from 'calypso/state/selectors/is-domain-only-site';
 import isEligibleForWpComMonthlyPlan from 'calypso/state/selectors/is-eligible-for-wpcom-monthly-plan';
 import { isUserEligibleForFreeHostingTrial } from 'calypso/state/selectors/is-user-eligible-for-free-hosting-trial';
+import { getPlansBySiteId } from 'calypso/state/sites/plans/selectors/get-plans-by-site';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import ComparisonGridToggle from './components/comparison-grid-toggle';
+import DowngradeConfirmationModal from './components/downgrade-confirmation-modal';
 import PlanUpsellModal from './components/plan-upsell-modal';
 import { useModalResolutionCallback } from './components/plan-upsell-modal/hooks/use-modal-resolution-callback';
 import PlansPageSubheader from './components/plans-page-subheader';
@@ -245,6 +249,9 @@ const PlansFeaturesMain = ( {
 	onReady,
 }: PlansFeaturesMainProps ) => {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
+	const [ pendingDowngradePlanSlug, setPendingDowngradePlanSlug ] = useState< PlanSlug | null >(
+		null
+	);
 	// TODO: Remove temporary eslint disable
 	// eslint-disable-next-line
 	const [ lastClickedPlan, setLastClickedPlan ] = useState< string | null >( null );
@@ -263,6 +270,10 @@ const PlansFeaturesMain = ( {
 	);
 	const siteSlug = useSelector( ( state: IAppState ) => getSiteSlug( state, siteId ) );
 	const sitePlanSlug = currentPlan?.productSlug;
+	const sitePlansData = useSelector( ( state: IAppState ) =>
+		siteId ? getPlansBySiteId( state, siteId )?.data : null
+	);
+	const isPlanExpired = !! sitePlansData?.find( ( p ) => p.currentPlan )?.expired;
 	const userCanUpgradeToPersonalPlan = useSelector(
 		( state: IAppState ) => siteId && canUpgradeToPlan( state, siteId, PLAN_PERSONAL )
 	);
@@ -418,6 +429,15 @@ const PlansFeaturesMain = ( {
 			intentFromProps !== 'plans-p2'
 		) {
 			showDomainUpsellDialog();
+			return true;
+		}
+
+		// For expired plans, intercept downgrades to show a confirmation modal.
+		if (
+			isPlanExpired &&
+			sitePlansData?.find( ( p ) => p.productSlug === planSlug )?.availableForDowngrade
+		) {
+			setPendingDowngradePlanSlug( planSlug );
 			return true;
 		}
 
@@ -895,6 +915,35 @@ const PlansFeaturesMain = ( {
 						const cartItemForPlan = getCartItemForPlan( planSlug );
 						const cartItems = cartItemForPlan ? [ cartItemForPlan ] : null;
 						onUpgradeClick?.( cartItems );
+					} }
+				/>
+				<DowngradeConfirmationModal
+					isOpen={ !! pendingDowngradePlanSlug }
+					currentPlanName={ sitePlansData?.find( ( p ) => p.currentPlan )?.productName ?? '' }
+					targetPlanName={
+						sitePlansData?.find( ( p ) => p.productSlug === pendingDowngradePlanSlug )
+							?.productName ?? ''
+					}
+					targetPlanSlug={ pendingDowngradePlanSlug }
+					purchaseId={ currentPlan?.purchaseId }
+					onClose={ () => setPendingDowngradePlanSlug( null ) }
+					onConfirm={ () => {
+						const planPath = pendingDowngradePlanSlug
+							? getPlanPath( pendingDowngradePlanSlug )
+							: null;
+						if ( ! planPath || ! siteSlug ) {
+							return;
+						}
+						setPendingDowngradePlanSlug( null );
+						page(
+							addQueryArgs(
+								{
+									...( coupon && { coupon } ),
+									...( redirectTo && { redirect_to: redirectTo } ),
+								},
+								`/checkout/${ siteSlug }/${ planPath }`
+							)
+						);
 					} }
 				/>
 				{ siteId && gridPlansForFeaturesGrid && (

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -432,9 +432,11 @@ const PlansFeaturesMain = ( {
 			return true;
 		}
 
-		// For expired plans, intercept downgrades to show a confirmation modal.
+		// For expired plans, intercept paid-plan downgrades to show a confirmation modal.
+		// Free-plan downgrades are handled separately (they route to the cancel flow).
 		if (
 			isPlanExpired &&
+			! isFreePlan( planSlug ) &&
 			sitePlansData?.find( ( p ) => p.productSlug === planSlug )?.availableForDowngrade
 		) {
 			setPendingDowngradePlanSlug( planSlug );

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -938,6 +938,10 @@ const PlansFeaturesMain = ( {
 							return;
 						}
 						setPendingDowngradePlanSlug( null );
+						recordTracksEvent( 'calypso_plan_features_downgrade_click', {
+							current_plan: sitePlanSlug,
+							downgrading_to: pendingDowngradePlanSlug,
+						} );
 						// Use a full navigation rather than `page()` because this grid can be
 						// rendered inside the Stepper, where the `page` router is not initialized.
 						window.location.href = addQueryArgs(

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -435,6 +435,7 @@ const PlansFeaturesMain = ( {
 		// For expired plans, intercept paid-plan downgrades to show a confirmation modal.
 		// Free-plan downgrades are handled separately (they route to the cancel flow).
 		if (
+			config.isEnabled( 'plans/expired-downgrade' ) &&
 			isPlanExpired &&
 			! isFreePlan( planSlug ) &&
 			sitePlansData?.find( ( p ) => p.productSlug === planSlug )?.availableForDowngrade

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -26,7 +26,6 @@ import { logStashLoadErrorEvent } from '../checkout/src/lib/analytics';
 import {
 	getPurchaseListUrlFor,
 	getCancelPurchaseUrlFor,
-	getDowngradeUrlFor,
 	getConfirmCancelDomainUrlFor,
 	getManagePurchaseUrlFor,
 	getAddNewPaymentMethodUrlFor,
@@ -129,7 +128,6 @@ export function PurchaseDetails( {
 					purchaseListUrl={ getPurchaseListUrlFor( siteSlug ) }
 					redirectTo={ isJetpackCloud() ? `https://cloud.jetpack.com${ redirectTo }` : redirectTo }
 					getCancelPurchaseUrlFor={ getCancelPurchaseUrlFor }
-					getDowngradeUrlFor={ getDowngradeUrlFor }
 					getAddNewPaymentMethodUrlFor={ getAddNewPaymentMethodUrlFor }
 					getChangePaymentMethodUrlFor={ getChangeOrAddPaymentMethodUrlFor }
 					getManagePurchaseUrlFor={ getManagePurchaseUrlFor }

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -40,7 +40,6 @@
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,
-		"plans/self-service-downgrade": false,
 		"plans/updated-storage-labels": true,
 		"plans/upgradeable-storage": true,
 		"purchases/split-cancel-remove": true,

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -37,6 +37,7 @@
 		"mcp-settings": true,
 		"onboarding/interval-dropdown": true,
 		"performance/apm": true,
+		"plans/expired-downgrade": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -37,6 +37,7 @@
 		"mcp-settings": true,
 		"onboarding/interval-dropdown": true,
 		"performance/apm": false,
+		"plans/expired-downgrade": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -40,7 +40,6 @@
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,
-		"plans/self-service-downgrade": false,
 		"plans/updated-storage-labels": true,
 		"plans/upgradeable-storage": true,
 		"purchases/split-cancel-remove": false,

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -34,6 +34,7 @@
 		"mcp-settings": true,
 		"onboarding/interval-dropdown": true,
 		"performance/apm": false,
+		"plans/expired-downgrade": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -37,7 +37,6 @@
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,
-		"plans/self-service-downgrade": false,
 		"plans/updated-storage-labels": true,
 		"plans/upgradeable-storage": true,
 		"posthog-tracking": true,

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -34,6 +34,7 @@
 		"mcp-settings": true,
 		"onboarding/interval-dropdown": true,
 		"performance/apm": true,
+		"plans/expired-downgrade": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -37,7 +37,6 @@
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,
-		"plans/self-service-downgrade": false,
 		"plans/updated-storage-labels": true,
 		"plans/upgradeable-storage": true,
 		"posthog-tracking": true,

--- a/config/development.json
+++ b/config/development.json
@@ -166,6 +166,7 @@
 		"p2/p2-plus": true,
 		"page/export": true,
 		"performance/apm": true,
+		"plans/expired-downgrade": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/config/development.json
+++ b/config/development.json
@@ -169,7 +169,6 @@
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,
-		"plans/self-service-downgrade": false,
 		"plans/updated-storage-labels": true,
 		"plans/upgradeable-storage": true,
 		"plugins/plugin-compass": true,

--- a/config/production.json
+++ b/config/production.json
@@ -121,6 +121,7 @@
 		"onboarding/woo-hosting-post-purchase-setup-choice": true,
 		"p2/p2-plus": true,
 		"performance/apm": false,
+		"plans/expired-downgrade": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/config/production.json
+++ b/config/production.json
@@ -124,7 +124,6 @@
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,
-		"plans/self-service-downgrade": false,
 		"plans/updated-storage-labels": true,
 		"plans/upgradeable-storage": true,
 		"plugins/plugin-compass": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -118,6 +118,7 @@
 		"p2/p2-plus": true,
 		"page/export": true,
 		"performance/apm": true,
+		"plans/expired-downgrade": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -121,7 +121,6 @@
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,
-		"plans/self-service-downgrade": false,
 		"plans/updated-storage-labels": true,
 		"plans/upgradeable-storage": true,
 		"plugins/plugin-compass": true,

--- a/config/test.json
+++ b/config/test.json
@@ -81,6 +81,7 @@
 		"onboarding/import-from-wordpress": true,
 		"onboarding/post-checkout-ai-step": false,
 		"onboarding/woo-hosting-post-purchase-setup-choice": false,
+		"plans/expired-downgrade": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/config/test.json
+++ b/config/test.json
@@ -84,7 +84,6 @@
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,
-		"plans/self-service-downgrade": false,
 		"plugins/plugin-compass": true,
 		"post-list/qr-code-link": false,
 		"press-this": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -122,6 +122,7 @@
 		"onboarding/woo-hosting-post-purchase-setup-choice": true,
 		"p2/p2-plus": true,
 		"performance/apm": false,
+		"plans/expired-downgrade": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -125,7 +125,6 @@
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,
-		"plans/self-service-downgrade": false,
 		"plans/updated-storage-labels": true,
 		"plans/upgradeable-storage": true,
 		"plugins/plugin-compass": true,

--- a/packages/api-core/src/upgrades/fetchers.ts
+++ b/packages/api-core/src/upgrades/fetchers.ts
@@ -62,15 +62,32 @@ export async function hasExtendedPurchase( purchaseId: number ): Promise< boolea
 	} );
 }
 
+/**
+ * Fetches features that would be lost for a given purchase.
+ *
+ * GET /wpcom/v2/upgrades/{purchaseId}/cancel-features
+ *
+ * When `targetProductSlug` is provided, the response contains only the features
+ * that exist on the current plan but not on the target plan — i.e. the delta
+ * lost by downgrading. When omitted, all cancellation features for the current
+ * plan are returned.
+ *
+ * `variant` is an A/B experiment parameter; omit it (or pass `'control'`) in
+ * most contexts.
+ */
 export async function fetchCancellationFeatures(
 	purchaseId: number,
-	variant?: 'control' | 'treatment'
+	variant?: 'control' | 'treatment',
+	targetProductSlug?: string
 ): Promise< UpgradesCancelFeaturesResponse > {
 	return await wpcom.req.get(
 		{
 			path: `/upgrades/${ purchaseId }/cancel-features`,
 			apiNamespace: 'wpcom/v2',
 		},
-		variant ? { variant } : {}
+		{
+			...( variant && { variant } ),
+			...( targetProductSlug && { target_product_slug: targetProductSlug } ),
+		}
 	);
 }

--- a/packages/api-queries/src/upgrades.ts
+++ b/packages/api-queries/src/upgrades.ts
@@ -44,13 +44,26 @@ export const purchaseQuery = ( purchaseId: number ) =>
 		queryFn: () => fetchPurchase( purchaseId ),
 	} );
 
+/**
+ * TanStack Query options for fetching features lost when cancelling or
+ * downgrading a purchase.
+ *
+ * Pass `targetProductSlug` to scope the result to the feature delta between
+ * the current plan and a specific target plan (e.g. when showing a downgrade
+ * confirmation). Without it, all cancellation features for the current plan
+ * are returned.
+ *
+ * `variant` is an A/B experiment parameter; leave it as the default
+ * `'control'` unless you are explicitly running an experiment.
+ */
 export const purchaseCancelFeaturesQuery = (
 	purchaseId: number,
-	variant: 'control' | 'treatment' = 'control'
+	variant: 'control' | 'treatment' = 'control',
+	targetProductSlug?: string
 ) =>
 	queryOptions( {
-		queryKey: [ 'upgrades', purchaseId, 'cancel-features', variant ],
-		queryFn: () => fetchCancellationFeatures( purchaseId, variant ),
+		queryKey: [ 'upgrades', purchaseId, 'cancel-features', variant, targetProductSlug ],
+		queryFn: () => fetchCancellationFeatures( purchaseId, variant, targetProductSlug ),
 	} );
 
 export const hasPurchaseBeenExtendedQuery = ( purchaseId: number ) =>


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/SHILL-2090/implement-post-expiry-downgrade-flow

## Proposed Changes

When a user on an expired paid plan clicks "Downgrade" for a plan the server marks as `available_for_downgrade`, they now see a confirmation modal listing the features they'll lose before being sent to checkout. The feature list is fetched live from the `/wpcom/v2/upgrades/{id}/cancel-features` endpoint using a new `target_product_slug` parameter.

* Add `DowngradeConfirmationModal` component — shows lost features with "Keep plan" / "Downgrade to X" buttons; navigates to checkout on confirm
* Remove the never-active `plans/self-service-downgrade` feature flag (was `false` in all environments), its dead `renderDowngradeNavItem` method, and all associated imports from `manage-purchase`

> [!NOTE]
> This PR does not launch this feature to production. It's behind the `plans/expired-downgrade` feature flag which is enabled only in staging, wpcalypso, and development.

<img width="966" height="745" alt="Screenshot 2026-06-05 at 5 39 01 PM" src="https://github.com/user-attachments/assets/07d62807-a8bb-42d1-8ad6-a9c90c2b8a00" />


## Why are these changes being made?

Users with expired plans currently have no self-service path to downgrade — they're routed to support chat even when the server already knows a direct downgrade is valid (via `available_for_downgrade` on the `/sites/$site/plans` endpoint). This adds a confirmation step that makes the consequences of the downgrade clear before the user proceeds.

The feature list is fetched from the endpoint rather than computed client-side because `calypso-products` is deprecated — the server is the authoritative source for what a plan includes and what's lost in a given downgrade path.

## Testing Instructions

* Set up a site with a paid WordPress.com plan that's not the lowest tier (e.g. Premium or Business).
* Move that plan's expiration date into the past so that the plan is past its expiry date but still within its grace period (still an active plan).
* Navigate to /plans for that site (e.g. http://calypso.localhost:3000/plans/paytontest17197.wordpress.com).
* Click "Downgrade" on a lower-tier plan — the confirmation modal should open, showing features that would be lost.
* Confirm "Keep [plan]" closes the modal without navigating.
* Confirm "Downgrade to [plan]" navigates to /checkout with the target plan in the cart.
* Confirm that purchasing the new plan downgrades the user to that plan.
