### PR TITLE
Purchase Settings: Add downgrade links

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -614,7 +614,7 @@ function ChangePlanActionItem( { purchase }: { purchase: Purchase } ) {
 	return (
 		<ActionList.ActionItem
 			title={ __( 'Change plan' ) }
-			description={ __( 'Switch to a different plan for this site.' ) }
+			description={ __( 'Upgrade or downgrade to a plan that works for you.' ) }
 			actions={
 				<Button
 					variant="secondary"

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -626,7 +626,7 @@ function ChangePlanActionItem( { purchase }: { purchase: Purchase } ) {
 						window.location.href = getExpiredNewPlanUrl( purchase );
 					} }
 				>
-					{ __( 'See plans' ) }
+					{ __( 'View plans' ) }
 				</Button>
 			}
 		/>

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -145,6 +145,7 @@ function getWpcomPlanGridUrl( siteSlug: string | undefined ): string {
 		cancel_to: backUrl,
 		dashboard: getCurrentDashboard(),
 		redirect_to: getUpgradedPurchaseRedirectUrl(),
+		allow_downgrade: 'true',
 	} );
 }
 

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -15,6 +15,7 @@ import {
 	reinstallMarketplacePluginsQuery,
 	siteBySlugQuery,
 } from '@automattic/api-queries';
+import config from '@automattic/calypso-config';
 import { domainManagementEdit, domainUseMyDomain } from '@automattic/domains-table/src/utils/paths';
 import { formatCurrency } from '@automattic/number-formatters';
 import { INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS } from '@automattic/urls';
@@ -601,6 +602,10 @@ function ReinstallButton( { purchase }: { purchase: Purchase } ) {
 
 function ChangePlanActionItem( { purchase }: { purchase: Purchase } ) {
 	const { recordTracksEvent } = useAnalytics();
+
+	if ( ! config.isEnabled( 'plans/expired-downgrade' ) ) {
+		return null;
+	}
 
 	if ( ! purchase.is_past_expiry_date || ! purchase.is_plan ) {
 		return null;

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -598,6 +598,35 @@ function ReinstallButton( { purchase }: { purchase: Purchase } ) {
 	);
 }
 
+function ChangePlanActionItem( { purchase }: { purchase: Purchase } ) {
+	const { recordTracksEvent } = useAnalytics();
+
+	if ( ! purchase.is_past_expiry_date || ! purchase.is_plan ) {
+		return null;
+	}
+
+	return (
+		<ActionList.ActionItem
+			title={ __( 'Change plan' ) }
+			description={ __( 'Switch to a different plan for this site.' ) }
+			actions={
+				<Button
+					variant="secondary"
+					size="compact"
+					onClick={ () => {
+						recordTracksEvent( 'calypso_purchases_change_plan_click', {
+							product_slug: purchase.product_slug,
+						} );
+						window.location.href = getExpiredNewPlanUrl( purchase );
+					} }
+				>
+					{ __( 'See plans' ) }
+				</Button>
+			}
+		/>
+	);
+}
+
 function PurchaseSettingsActions( { purchase }: { purchase: Purchase } ) {
 	// 100-year plans and domains have no self-serve actions (no upgrade, no
 	// renew, no cancel/remove). Skip the card entirely so we don't render an
@@ -613,6 +642,7 @@ function PurchaseSettingsActions( { purchase }: { purchase: Purchase } ) {
 		return (
 			<VStack spacing={ 4 }>
 				<ActionList>
+					<ChangePlanActionItem purchase={ purchase } />
 					<ReSubscribeActionButton purchase={ purchase } />
 				</ActionList>
 			</VStack>
@@ -626,6 +656,7 @@ function PurchaseSettingsActions( { purchase }: { purchase: Purchase } ) {
 				<JetpackCRMDownloadsButton purchase={ purchase } />
 				<UpgradeActionButton purchase={ purchase } />
 				<ReSubscribeActionButton purchase={ purchase } />
+				<ChangePlanActionItem purchase={ purchase } />
 				<RenewActionButton purchase={ purchase } />
 				<CancelOrRemoveActionButton purchase={ purchase } />
 			</ActionList>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/index.tsx
@@ -77,7 +77,9 @@ function getPlansIntent( flowName: string | null ): PlansIntent | null {
 		case ONBOARDING_UNIFIED_FLOW:
 			return 'plans-affiliate';
 		case PLAN_UPGRADE_FLOW:
-			return 'plans-upgrade';
+			return search.get( 'allow_downgrade' ) === 'true'
+				? 'plans-upgrade-or-downgrade'
+				: 'plans-upgrade';
 		case WOO_HOSTED_PLANS_FLOW:
 			return 'plans-woo-hosted';
 		default:

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -447,6 +447,10 @@ function UnifiedPlansStep( {
 			return translate( 'Pick a plan for your store' );
 		}
 
+		if ( intent === 'plans-upgrade-or-downgrade' ) {
+			return translate( 'Find your best fit' );
+		}
+
 		return translate( 'There’s a plan for you' );
 	};
 
@@ -566,11 +570,13 @@ function UnifiedPlansStep( {
 			return null;
 		}
 
-		if (
-			isOnboardingFlow( flowName ) ||
-			intent === 'plans-upgrade' ||
-			intent === 'plans-upgrade-or-downgrade'
-		) {
+		if ( intent === 'plans-upgrade-or-downgrade' ) {
+			return translate(
+				'Compare plans and pick the one that works for where your site is headed.'
+			);
+		}
+
+		if ( isOnboardingFlow( flowName ) || intent === 'plans-upgrade' ) {
 			return translate( 'Whatever site you’re building, there’s a plan to make it happen sooner.' );
 		}
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -566,7 +566,11 @@ function UnifiedPlansStep( {
 			return null;
 		}
 
-		if ( isOnboardingFlow( flowName ) || intent === 'plans-upgrade' ) {
+		if (
+			isOnboardingFlow( flowName ) ||
+			intent === 'plans-upgrade' ||
+			intent === 'plans-upgrade-or-downgrade'
+		) {
 			return translate( 'Whatever site you’re building, there’s a plan to make it happen sooner.' );
 		}
 	};

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -520,14 +520,46 @@ export function canAutoRenewBeTurnedOff( purchase: Purchase ) {
 	return purchase.isAutoRenewEnabled;
 }
 
+/**
+ * Whether the purchase has already passed its expiry date and is no longer
+ * active. This reflects the backend's `expiry_status` field being `expired`,
+ * meaning the subscription has lapsed (auto-renew did not occur or was off) and
+ * the associated product/features are no longer provided.
+ *
+ * This is distinct from `isExpiring`, which indicates a still-active purchase
+ * that is scheduled to expire in the future (e.g. auto-renew is off), and from
+ * `isInExpirationGracePeriod`, which covers the window just after the expiry
+ * date during which the purchase can still be renewed.
+ */
 export function isExpired( purchase: Purchase ) {
 	return 'expired' === purchase.expiryStatus;
 }
 
+/**
+ * Whether the purchase is still active but scheduled to expire because it will
+ * not auto-renew. This reflects the backend's `expiry_status` field being
+ * either `expiring` (auto-renew is off, so it will lapse on its expiry date) or
+ * `manualRenew` (a purchase that has no auto-renew and must be renewed by hand).
+ *
+ * Note this describes a purchase that has not yet expired — once the expiry date
+ * passes without renewal the status becomes `expired` (see `isExpired`).
+ */
 export function isExpiring( purchase: Purchase ) {
 	return [ 'manualRenew', 'expiring' ].includes( purchase.expiryStatus );
 }
 
+/**
+ * Whether the purchase is within the grace period: the window just after its
+ * expiry date has passed but during which it can still be renewed to restore
+ * service without interruption.
+ *
+ * This returns `true` only when all of the following hold:
+ * - the purchase has an expiry date that is in the past;
+ * - it is not already fully `expired` (see `isExpired`);
+ * - it is either renewing or expiring (i.e. it is a renewable subscription
+ *   rather than, say, a one-time purchase);
+ * - it is not an Akismet free product (which has no meaningful grace period).
+ */
 export function isInExpirationGracePeriod( purchase: Purchase ): boolean {
 	if ( ! purchase.expiryDate ) {
 		return false;

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -99,6 +99,7 @@ import {
 	isPaidWithCredits,
 	canAutoRenewBeTurnedOff,
 	isExpired,
+	isInExpirationGracePeriod,
 	isOneTimePurchase,
 	isPartnerPurchase,
 	isRenewable,
@@ -586,6 +587,24 @@ class ManagePurchase extends Component<
 		}
 
 		return `/plans/${ siteSlug }`;
+	}
+
+	renderChangePlanNavItem() {
+		const { purchase, siteSlug, translate } = this.props;
+		if ( ! purchase || ! isPlan( purchase ) ) {
+			return null;
+		}
+
+		if ( ! isExpired( purchase ) && ! isInExpirationGracePeriod( purchase ) ) {
+			return null;
+		}
+
+		return (
+			<CompactCard tagName="a" displayAsLink href={ `/plans/${ siteSlug }` }>
+				<Icon icon={ column } className="card__icon" />
+				{ translate( 'Change plan' ) }
+			</CompactCard>
+		);
 	}
 
 	renderUpgradeNavItem() {
@@ -1531,6 +1550,7 @@ class ManagePurchase extends Component<
 				) }
 				{ isProductOwner && ! purchase.isLocked && (
 					<>
+						{ this.renderChangePlanNavItem() }
 						{ ! preventRenewal &&
 							! renderMonthlyRenewalOption &&
 							! isActive100YearPurchase &&

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -589,19 +589,25 @@ class ManagePurchase extends Component<
 		return `/plans/${ siteSlug }`;
 	}
 
-	renderChangePlanNavItem() {
-		const { purchase, siteSlug, translate } = this.props;
+	shouldRenderDowngradeOption(): boolean {
+		const { purchase } = this.props;
 		if ( ! config.isEnabled( 'plans/expired-downgrade' ) ) {
-			return null;
+			return false;
 		}
 		if ( ! purchase || ! isPlan( purchase ) ) {
+			return false;
+		}
+		if ( ! isInExpirationGracePeriod( purchase ) ) {
+			return false;
+		}
+		return true;
+	}
+
+	renderChangePlanNavItem() {
+		const { siteSlug, translate } = this.props;
+		if ( ! this.shouldRenderDowngradeOption() ) {
 			return null;
 		}
-
-		if ( ! isExpired( purchase ) && ! isInExpirationGracePeriod( purchase ) ) {
-			return null;
-		}
-
 		return (
 			<CompactCard tagName="a" displayAsLink href={ `/plans/${ siteSlug }` }>
 				<Icon icon={ column } className="card__icon" />
@@ -612,11 +618,17 @@ class ManagePurchase extends Component<
 
 	renderUpgradeNavItem() {
 		const { purchase, translate } = this.props;
+		if ( this.shouldRenderDowngradeOption() ) {
+			return null;
+		}
 		if ( ! purchase ) {
 			return null;
 		}
-
-		if ( isPartnerPurchase( purchase ) || isA4ABillingDragonPurchase( purchase ) ) {
+		if (
+			isJetpackHoldingSitePurchase( purchase ) ||
+			isPartnerPurchase( purchase ) ||
+			isA4ABillingDragonPurchase( purchase )
+		) {
 			return null;
 		}
 
@@ -1561,10 +1573,8 @@ class ManagePurchase extends Component<
 							this.renderRenewNowNavItem() }
 						{ ! preventRenewal && renderMonthlyRenewalOption && this.renderRenewAnnuallyNavItem() }
 						{ ! preventRenewal && renderMonthlyRenewalOption && this.renderRenewMonthlyNavItem() }
-						{ /* We don't want to show the Renew/Upgrade nav item for "Jetpack" temporary sites, but we DO
-						show it for "Akismet" temporary sites. (And all other types of purchases) */ }
 						{ /* TODO: Add ability to Renew Akismet subscription */ }
-						{ ! isJetpackHoldingSitePurchase( purchase ) && this.renderUpgradeNavItem() }
+						{ this.renderUpgradeNavItem() }
 						{ this.renderEditPaymentMethodNavItem() }
 						{ config.isEnabled( 'jetpack/crm-downloads' ) && this.renderCrmDownloadsNavItem() }
 						{ this.renderReinstall() }

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -591,6 +591,9 @@ class ManagePurchase extends Component<
 
 	renderChangePlanNavItem() {
 		const { purchase, siteSlug, translate } = this.props;
+		if ( ! config.isEnabled( 'plans/expired-downgrade' ) ) {
+			return null;
+		}
 		if ( ! purchase || ! isPlan( purchase ) ) {
 			return null;
 		}

--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -366,10 +366,17 @@ const PlansPageSubheader = ( {
 			return <PlanBenefitHeader />;
 		}
 
-		if (
-			! isUsingStepContainerV2 &&
-			( isOnboarding || intent === 'plans-upgrade' || intent === 'plans-upgrade-or-downgrade' )
-		) {
+		if ( ! isUsingStepContainerV2 && intent === 'plans-upgrade-or-downgrade' ) {
+			return (
+				<Subheader { ...subheaderCommonProps }>
+					{ translate(
+						'Compare plans and pick the one that works for where your site is headed.'
+					) }
+				</Subheader>
+			);
+		}
+
+		if ( ! isUsingStepContainerV2 && ( isOnboarding || intent === 'plans-upgrade' ) ) {
 			return (
 				<Subheader { ...subheaderCommonProps }>
 					{ translate( 'Whatever site you’re building, there’s a plan to make it happen sooner.' ) }

--- a/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
+++ b/client/my-sites/plans-features-main/components/plans-page-subheader.tsx
@@ -366,7 +366,10 @@ const PlansPageSubheader = ( {
 			return <PlanBenefitHeader />;
 		}
 
-		if ( ! isUsingStepContainerV2 && ( isOnboarding || intent === 'plans-upgrade' ) ) {
+		if (
+			! isUsingStepContainerV2 &&
+			( isOnboarding || intent === 'plans-upgrade' || intent === 'plans-upgrade-or-downgrade' )
+		) {
 			return (
 				<Subheader { ...subheaderCommonProps }>
 					{ translate( 'Whatever site you’re building, there’s a plan to make it happen sooner.' ) }
@@ -380,9 +383,11 @@ const PlansPageSubheader = ( {
 	return (
 		<>
 			{ renderSubheader() }
-			{ isDisplayingPlansNeededForFeature && intent !== 'plans-upgrade' && (
-				<SecondaryFormattedHeader siteSlug={ siteSlug } selectedFeature={ selectedFeature } />
-			) }
+			{ isDisplayingPlansNeededForFeature &&
+				intent !== 'plans-upgrade' &&
+				intent !== 'plans-upgrade-or-downgrade' && (
+					<SecondaryFormattedHeader siteSlug={ siteSlug } selectedFeature={ selectedFeature } />
+				) }
 		</>
 	);
 };

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-callback.ts
@@ -266,7 +266,9 @@ function useGenerateActionCallback( {
 			/* 3. In the logged-in plans dashboard, handle plan downgrades and plan downgrade tracks events */
 			if (
 				sitePlanSlug &&
-				( ! flowName || flowName === WOO_HOSTED_PLANS_FLOW ) &&
+				( ! flowName ||
+					flowName === WOO_HOSTED_PLANS_FLOW ||
+					intent === 'plans-upgrade-or-downgrade' ) &&
 				intent !== 'plans-p2' &&
 				intent !== 'plans-blog-onboarding' &&
 				! availableForPurchase

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -443,7 +443,8 @@ function getLoggedInPlansAction( {
 	// Use plan type matching instead of exact slug matching for the 'plans-upgrade' intent.
 	// This allows monthly/yearly versions of the same plan to be considered "current"
 	const isUpgradeFlow =
-		plansIntent && [ 'plans-upgrade', 'plans-woo-hosted' ].includes( plansIntent );
+		plansIntent &&
+		[ 'plans-upgrade', 'plans-upgrade-or-downgrade', 'plans-woo-hosted' ].includes( plansIntent );
 	const current =
 		isUpgradeFlow && sitePlanSlug
 			? getPlanClass( sitePlanSlug ) === getPlanClass( planSlug )

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -390,6 +390,7 @@ const PlansFeaturesMain = ( {
 		// For plans-upgrade intent, skip isValidFeatureKey check since we want to check against "included" features
 		// that may not be in the feature key list (e.g. because they're grouped into a broader feature).
 		( intent === 'plans-upgrade' ||
+			intent === 'plans-upgrade-or-downgrade' ||
 			( isValidFeatureKey( selectedFeature ) &&
 				!! selectedPlan &&
 				!! getPlan( selectedPlan ) &&

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -221,6 +221,15 @@ export const usePlanTypesWithIntent = ( {
 			}
 			break;
 		}
+		case 'plans-upgrade-or-downgrade': {
+			// Show all plans — used when the current plan is expired and the user
+			// may want to downgrade as well as upgrade.
+			planTypes = [ TYPE_FREE, TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS, TYPE_ECOMMERCE ];
+			if ( isEnterpriseAvailable ) {
+				planTypes.push( TYPE_ENTERPRISE_GRID_WPCOM );
+			}
+			break;
+		}
 		case 'plans-jetpack-app':
 			planTypes = [ TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS, TYPE_ECOMMERCE ];
 			break;

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -87,6 +87,7 @@ export type PlansIntent =
 	| 'plans-playground'
 	| 'plans-playground-premium' // This plan intent is currently not utilized but will be soon
 	| 'plans-upgrade'
+	| 'plans-upgrade-or-downgrade'
 	| 'plans-wordpress-hosting'
 	| 'plans-website-builder'
 	| 'plans-woo-hosted'


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/SHILL-2090/implement-post-expiry-downgrade-flow

## Proposed Changes

Adds a "Change plan" action button to both purchase settings pages (Dashboard and classic Calypso) when a plan is past its expiry date but still active (within its grace period), giving the user a direct route to the plans page to pick a downgrade (or upgrade).

Depends on https://github.com/Automattic/wp-calypso/pull/111408 which adds the downgrade path to the plans page.

Based on the original concept in https://github.com/Automattic/wp-calypso/pull/111070

> [!NOTE]
> This PR does not launch this feature to production. It's behind the `plans/expired-downgrade` feature flag which is enabled only in staging, wpcalypso, and development.

Dashboard             |  Calypso
:-------------------------:|:-------------------------:
<img width="679" height="850" alt="Screenshot 2026-06-08 at 1 25 52 PM" src="https://github.com/user-attachments/assets/30f3d1d8-6c32-4b41-b87d-397a2a5af26c" /> | <img width="964" height="839" alt="Screenshot 2026-06-08 at 1 13 32 PM" src="https://github.com/user-attachments/assets/748a3567-ec83-4389-8277-678832f597af" />
<img width="1240" height="1105" alt="Screenshot 2026-06-08 at 1 16 21 PM" src="https://github.com/user-attachments/assets/51333e8d-6073-4701-ab5e-17d634a39b60" /> | <img width="1269" height="1301" alt="Screenshot 2026-06-08 at 1 18 43 PM" src="https://github.com/user-attachments/assets/604dca66-e551-4ac6-8c44-6e355e7df024" />

<img width="1208" height="794" alt="Screenshot 2026-06-05 at 6 24 12 PM" src="https://github.com/user-attachments/assets/844db86c-80e6-4038-a353-c9caccef16f8" />


## Why are these changes being made?

When a paid plan lapses, the purchase settings page offers renew / re-subscribe actions but no clear way to switch to a *different* plan — including a lower tier. This adds a dedicated "Change plan" affordance so users whose plan is past expiry can get to the plans page and choose another plan.

The two surfaces use the appropriate expiry check for their data model: the Dashboard's `Purchase` exposes `is_past_expiry_date` (which covers both the grace period and fully-lapsed states), while classic Calypso has no single equivalent, so it combines `isExpired` (fully lapsed) with `isInExpirationGracePeriod` (past the expiry date but still within grace) to match the same window.

## Testing Instructions

* Use a site with a paid plan that is past its expiry date but still active.
* Dashboard: visit `/me/billing/purchases/{purchaseId}` and confirm a "Change plan" card appears in the actions group at the bottom of the page, above "Renew now". Click "See plans" and confirm it opens the plans page for that site.
* Classic: visit `/purchases/subscriptions/{siteSlug}/{purchaseId}` and confirm a "Change plan" nav item appears above "Renew now". Click it and confirm it navigates to `/plans/{siteSlug}`.
* Confirm the "Change plan" entry point does NOT appear for an active (not past-expiry) plan, for domains, or for non-plan products.
