### PR TITLE
Calypso Cancellation Flow: show "Remove and refund" notice by default and make flow disable auto-renew

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/use-is-split-cancel-remove-enabled.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/use-is-split-cancel-remove-enabled.ts
@@ -1,12 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { useExperiment } from 'calypso/lib/explat';
-
-const EXPERIMENT_NAME = 'calypso_new_cancel_refund_flow_20260408';
 
 export function useIsSplitCancelRemoveEnabled(): boolean {
-	const [ isLoadingExperiment, experimentAssignment ] = useExperiment( EXPERIMENT_NAME );
-	return (
-		isEnabled( 'purchases/split-cancel-remove' ) ||
-		( ! isLoadingExperiment && experimentAssignment?.variationName === 'treatment' )
-	);
+	return isEnabled( 'purchases/split-cancel-remove' );
 }

--- a/client/me/purchases/cancel-purchase/index.tsx
+++ b/client/me/purchases/cancel-purchase/index.tsx
@@ -97,6 +97,7 @@ import CancelPurchaseFeatureList from './feature-list';
 import RefundEligibilityNotice from './refund-eligibility-notice';
 import TimeRemainingNotice from './time-remaining-notice';
 import { toPurchaseForCopy } from './to-purchase-for-copy';
+import { getCancellationTopNotice } from './which-top-notice';
 import type { UpgradesCancelFeaturesResponse } from '@automattic/api-core';
 import type { Purchases, SiteDetails } from '@automattic/data-stores';
 import type { GetManagePurchaseUrlFor } from 'calypso/lib/purchases/types';
@@ -1436,6 +1437,11 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 			includedDomainHasRadioButtons || this.state.cancelBundledDomain,
 			this.props.includedDomainPurchase
 		);
+		const topNotice = getCancellationTopNotice( {
+			showDomainOptionsStep: this.state.showDomainOptionsStep,
+			hasRefund: Boolean( refundAmountString ),
+			displayVariant,
+		} );
 		return (
 			<>
 				{ ! isJetpack && ! isAkismet && ! isDomainRegistrationPurchase && (
@@ -1483,30 +1489,24 @@ class CancelPurchase extends Component< CancelPurchaseAllProps, CancelPurchaseSt
 						align="left"
 					/>
 
-					{ ! this.state.showDomainOptionsStep &&
-						( ! refundAmountString ||
-							intent === 'auto-renew' ||
-							( intent === 'cancel' && ! this.props.isSplitCancelRemoveEnabled ) ) && (
-							<TimeRemainingNotice
-								purchase={ purchase }
-								displayVariant={ displayVariant }
-								intent={ intent ?? null }
-							/>
-						) }
+					{ topNotice === 'time-remaining' && (
+						<TimeRemainingNotice
+							purchase={ purchase }
+							displayVariant={ displayVariant }
+							intent={ intent ?? null }
+						/>
+					) }
 
 					<div className="cancel-purchase__inner-wrapper">
 						<div className="cancel-purchase__left">
-							{ ! this.state.showDomainOptionsStep &&
-								this.props.isSplitCancelRemoveEnabled &&
-								refundAmountString &&
-								intent === 'cancel' && (
-									<RefundEligibilityNotice
-										mode="refund-eligibility"
-										refundAmount={ refundAmountString }
-										purchase={ purchase }
-									/>
-								) }
-							{ ! this.state.showDomainOptionsStep && refundAmountString && intent === 'remove' && (
+							{ topNotice === 'refund-eligibility' && refundAmountString && (
+								<RefundEligibilityNotice
+									mode="refund-eligibility"
+									refundAmount={ refundAmountString }
+									purchase={ purchase }
+								/>
+							) }
+							{ topNotice === 'confirmed' && refundAmountString && (
 								<RefundEligibilityNotice
 									refundAmount={ refundAmountString }
 									mode="confirmed"

--- a/client/me/purchases/cancel-purchase/test/which-top-notice.test.ts
+++ b/client/me/purchases/cancel-purchase/test/which-top-notice.test.ts
@@ -1,0 +1,55 @@
+import { getCancellationTopNotice } from '../which-top-notice';
+
+describe( 'getCancellationTopNotice', () => {
+	test( 'returns null while the domain-options step is showing', () => {
+		expect(
+			getCancellationTopNotice( {
+				showDomainOptionsStep: true,
+				hasRefund: true,
+				displayVariant: 'cancel',
+			} )
+		).toBeNull();
+	} );
+
+	test( 'returns time-remaining when there is no refund, for every variant', () => {
+		for ( const displayVariant of [ 'cancel', 'remove', 'auto-renew' ] as const ) {
+			expect(
+				getCancellationTopNotice( {
+					showDomainOptionsStep: false,
+					hasRefund: false,
+					displayVariant,
+				} )
+			).toBe( 'time-remaining' );
+		}
+	} );
+
+	test( 'returns refund-eligibility for a refundable cancel (the default param-less path)', () => {
+		expect(
+			getCancellationTopNotice( {
+				showDomainOptionsStep: false,
+				hasRefund: true,
+				displayVariant: 'cancel',
+			} )
+		).toBe( 'refund-eligibility' );
+	} );
+
+	test( 'returns confirmed for a refundable remove', () => {
+		expect(
+			getCancellationTopNotice( {
+				showDomainOptionsStep: false,
+				hasRefund: true,
+				displayVariant: 'remove',
+			} )
+		).toBe( 'confirmed' );
+	} );
+
+	test( 'returns time-remaining for a refundable auto-renew variant', () => {
+		expect(
+			getCancellationTopNotice( {
+				showDomainOptionsStep: false,
+				hasRefund: true,
+				displayVariant: 'auto-renew',
+			} )
+		).toBe( 'time-remaining' );
+	} );
+} );

--- a/client/me/purchases/cancel-purchase/which-top-notice.ts
+++ b/client/me/purchases/cancel-purchase/which-top-notice.ts
@@ -1,0 +1,37 @@
+import type { DisplayVariant } from 'calypso/lib/purchases/utils';
+
+export type CancellationTopNotice = 'refund-eligibility' | 'confirmed' | 'time-remaining' | null;
+
+/**
+ * Decides which notice renders at the top of the cancellation flow. The outcomes are mutually
+ * exclusive: for a single `displayVariant` and a boolean `hasRefund`, at most one notice shows.
+ *
+ * - refund available + cancel variant → 'refund-eligibility' (the "Remove and refund" CTA)
+ * - refund available + remove variant → 'confirmed'
+ * - no refund, or the auto-renew variant → 'time-remaining'
+ * - while the domain-options step is showing → null (no top notice)
+ */
+export function getCancellationTopNotice( {
+	showDomainOptionsStep,
+	hasRefund,
+	displayVariant,
+}: {
+	showDomainOptionsStep: boolean;
+	hasRefund: boolean;
+	displayVariant: DisplayVariant;
+} ): CancellationTopNotice {
+	if ( showDomainOptionsStep ) {
+		return null;
+	}
+	if ( ! hasRefund ) {
+		return 'time-remaining';
+	}
+	switch ( displayVariant ) {
+		case 'cancel':
+			return 'refund-eligibility';
+		case 'remove':
+			return 'confirmed';
+		case 'auto-renew':
+			return 'time-remaining';
+	}
+}

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -1050,9 +1050,11 @@ class ManagePurchase extends Component<
 			this.props.siteSlug,
 			id
 		);
-		// Under flag, carry the user's intent through to the confirmation screen so
-		// it renders the matching variant (Cancel copy + disable-auto-renew mutation).
-		const link = isSplitEnabled ? `${ baseLink }?intent=cancel` : baseLink;
+		// Carry the user's intent through to the confirmation screen so it renders
+		// the matching variant: the "Cancel" CTA always means cancel (disable
+		// auto-renew, keep features until expiry), distinct from the "Remove and
+		// refund" action offered by the refund-eligibility notice (intent=remove).
+		const link = `${ baseLink }?intent=cancel`;
 		const canRefund = hasAmountAvailableToRefund( purchase );
 
 		if ( ! canRefund && isDomainTransfer( purchase ) ) {

--- a/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
+++ b/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
@@ -12,8 +12,16 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import nock from 'nock';
 import { Provider as ReduxProvider } from 'react-redux';
+import { useIsSplitCancelRemoveEnabled } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/use-is-split-cancel-remove-enabled';
 import { createReduxStore } from 'calypso/state';
 import ManagePurchase from '../index';
+
+jest.mock(
+	'calypso/dashboard/me/billing-purchases/cancel-purchase/use-is-split-cancel-remove-enabled',
+	() => ( {
+		useIsSplitCancelRemoveEnabled: jest.fn( () => true ),
+	} )
+);
 
 const purchase = {
 	ID: '19823155',
@@ -124,6 +132,36 @@ function createMockReduxStoreForPurchase( purchaseForRedux, domains_items = {} )
 
 describe( 'Purchase Management Buttons', () => {
 	const queryClient = new QueryClient();
+
+	beforeEach( () => {
+		// Default to the split-cancel-remove flow being enabled (matches config/test.json);
+		// individual tests opt out to exercise the flag-off path.
+		useIsSplitCancelRemoveEnabled.mockReturnValue( true );
+	} );
+
+	it( 'cancel button links to the cancel flow with intent=cancel even when the split flag is off', async () => {
+		useIsSplitCancelRemoveEnabled.mockReturnValue( false );
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.2/me/payment-methods?expired=include' )
+			.reply( 200 );
+
+		const store = createMockReduxStoreForPurchase( { ...purchase, is_auto_renew_enabled: true } );
+
+		render(
+			<QueryClientProvider client={ queryClient }>
+				<ReduxProvider store={ store }>
+					<ManagePurchase
+						purchaseId={ Number( purchase.ID ) }
+						isSiteLevel
+						siteSlug="onecooltestsite.com"
+					/>
+				</ReduxProvider>
+			</QueryClientProvider>
+		);
+
+		const cancelLink = await screen.findByRole( 'link', { name: /Cancel plan/i } );
+		expect( cancelLink ).toHaveAttribute( 'href', expect.stringContaining( 'intent=cancel' ) );
+	} );
 
 	it( 'renders a cancel button when auto-renew is ON', async () => {
 		nock( 'https://public-api.wordpress.com' )

--- a/packages/calypso-e2e/src/lib/flows/cancel-purchase-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/cancel-purchase-flow.ts
@@ -76,8 +76,11 @@ export async function cancelAtomicPurchaseFlow(
 		customReasonText: string;
 	}
 ) {
+	// The feedback question is worded by intent: "Why would you like to cancel?"
+	// on the cancel path and "Why would you like to remove?" on the refund-and-
+	// remove (`intent=remove`) path this flow now drives. Match either.
 	await page
-		.getByRole( 'combobox', { name: 'Why would you like to cancel?' } )
+		.getByRole( 'combobox', { name: /Why would you like to (cancel|remove)\?/ } )
 		.selectOption( feedback.reason );
 
 	await page

--- a/packages/calypso-e2e/src/lib/flows/cancel-purchase-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/cancel-purchase-flow.ts
@@ -52,18 +52,24 @@ export async function cancelSubscriptionFlow( page: Page ) {
  *
  * Matching all of these keeps the flow robust regardless of which variant is
  * served. `exact: true` ensures "Continue" does not also resolve "Continue
- * removal" (and vice versa), so the locator never matches two buttons at once.
+ * removal" (and vice versa).
+ *
+ * The locator is scoped to the survey's `.cancel-purchase-form` container. The
+ * survey renders as an overlay on top of the cancellation confirmation screen,
+ * whose own primary button can share a label (e.g. "Continue removal"); scoping
+ * avoids matching that underlying button and tripping strict-mode violations.
  *
  * @param {Page} page Page object the survey is rendered on.
  * @returns {Locator} Locator matching the survey's primary step button.
  */
 function surveyStepButton( page: Page ): Locator {
-	return page
+	const surveyForm = page.locator( '.cancel-purchase-form' );
+	return surveyForm
 		.getByRole( 'button', { name: 'Submit', exact: true } )
-		.or( page.getByRole( 'button', { name: 'Continue', exact: true } ) )
-		.or( page.getByRole( 'button', { name: 'Complete', exact: true } ) )
-		.or( page.getByRole( 'button', { name: 'Continue removal', exact: true } ) )
-		.or( page.getByRole( 'button', { name: 'Complete removal', exact: true } ) );
+		.or( surveyForm.getByRole( 'button', { name: 'Continue', exact: true } ) )
+		.or( surveyForm.getByRole( 'button', { name: 'Complete', exact: true } ) )
+		.or( surveyForm.getByRole( 'button', { name: 'Continue removal', exact: true } ) )
+		.or( surveyForm.getByRole( 'button', { name: 'Complete removal', exact: true } ) );
 }
 
 /**

--- a/packages/calypso-e2e/src/lib/flows/cancel-purchase-flow.ts
+++ b/packages/calypso-e2e/src/lib/flows/cancel-purchase-flow.ts
@@ -44,22 +44,26 @@ export async function cancelSubscriptionFlow( page: Page ) {
 /**
  * Returns a locator that matches the cancellation survey's primary step button.
  *
- * The button's label depends on the survey step and the active experiment
- * variant: a non-final step renders "Continue", while the final step renders
- * "Submit" (legacy variant) or "Complete" (the split cancel/remove experiment
- * with an `intent=cancel` deep link). Matching all three keeps the flow robust
- * regardless of which variant is served.
+ * The button's label depends on the survey step and the active intent/variant:
+ * - Legacy / `intent=cancel`: non-final step renders "Continue", final step
+ *   renders "Submit" (legacy) or "Complete" (split cancel/remove).
+ * - `intent=remove` (the refund-and-remove path this flow now drives): non-final
+ *   step renders "Continue removal", final step renders "Complete removal".
+ *
+ * Matching all of these keeps the flow robust regardless of which variant is
+ * served. `exact: true` ensures "Continue" does not also resolve "Continue
+ * removal" (and vice versa), so the locator never matches two buttons at once.
  *
  * @param {Page} page Page object the survey is rendered on.
  * @returns {Locator} Locator matching the survey's primary step button.
  */
 function surveyStepButton( page: Page ): Locator {
-	// Exact matching avoids accidentally resolving to longer labels used by
-	// other survey variants (e.g. "Continue removal", "Complete removal").
 	return page
 		.getByRole( 'button', { name: 'Submit', exact: true } )
 		.or( page.getByRole( 'button', { name: 'Continue', exact: true } ) )
-		.or( page.getByRole( 'button', { name: 'Complete', exact: true } ) );
+		.or( page.getByRole( 'button', { name: 'Complete', exact: true } ) )
+		.or( page.getByRole( 'button', { name: 'Continue removal', exact: true } ) )
+		.or( page.getByRole( 'button', { name: 'Complete removal', exact: true } ) );
 }
 
 /**
@@ -80,9 +84,10 @@ export async function cancelAtomicPurchaseFlow(
 		.getByRole( 'textbox', { name: 'Can you please specify?' } )
 		.fill( feedback.customReasonText );
 
-	// Submit the feedback step. This is not the final step, so the button is
-	// labelled "Continue", but match the other labels too to ride out variant
-	// differences.
+	// Submit the feedback step. This is not the final step, so under the
+	// refund-and-remove (`intent=remove`) path the button is labelled "Continue
+	// removal"; other variants label it "Continue". `surveyStepButton` matches
+	// whichever renders.
 	await clickWhenEnabled( surveyStepButton( page ) );
 
 	// The next (and final) step asks where the user is headed next. Selecting an

--- a/packages/calypso-e2e/src/lib/pages/me/purchases-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/me/purchases-page.ts
@@ -45,14 +45,57 @@ export class PurchasesPage {
 	/* Purchase detail view */
 
 	/**
-	 * Clicks a cancellation action for the purchase.
+	 * Clicks a cancellation action for the purchase and advances to its
+	 * cancellation survey.
 	 *
-	 * @param {PurchaseActions} action Action to click.
+	 * The "Cancel plan" entry now lands on a cancellation confirmation screen
+	 * (`intent=cancel`) whose primary "Cancel subscription" action only disables
+	 * auto-renew — it no longer issues a refund. To drive the immediate
+	 * refund-and-remove path (the one the plan-cancellation specs assert), the
+	 * flow instead follows the "Remove plan and claim refund." notice link on that
+	 * screen. The link navigates to the same route with `intent=remove`, where the
+	 * primary confirm button reads "Continue removal". Confirming there begins the
+	 * cancellation survey, which fires the refund on completion.
+	 *
+	 * "Cancel subscription" preserves the legacy single-confirm behavior for the
+	 * callers that still rely on it.
+	 *
+	 * @param {PurchaseActions} action Action link to click on the purchase detail view.
 	 */
 	async cancelPurchase( action: PurchaseActions ) {
 		await this.page.getByRole( 'link', { name: action } ).click();
 
-		if ( action === 'Cancel plan' || action === 'Cancel subscription' ) {
+		if ( action === 'Cancel plan' ) {
+			// Follow the refund-eligibility notice link to switch from the
+			// auto-renew-only `intent=cancel` screen to the refund-and-remove
+			// `intent=remove` screen.
+			await this.page
+				.getByRole( 'button', { name: 'Remove plan and claim refund.', exact: true } )
+				.click();
+
+			// The screen remounts under `intent=remove`. Wait for its primary
+			// "Continue removal" button before interacting.
+			const continueRemovalButton = this.page.getByRole( 'button', {
+				name: 'Continue removal',
+				exact: true,
+			} );
+			await continueRemovalButton.waitFor( { state: 'visible' } );
+
+			// Under the split-cancel-remove flag the confirm button is gated behind
+			// an "I've reviewed what I'll lose…" checkbox; without the flag there is
+			// no checkbox and the button is enabled immediately. Tick it only when
+			// present so the flow works regardless of the served variant.
+			const confirmCheckbox = this.page.locator( 'label.cancel-purchase__confirm-checkbox input' );
+			if ( ( await confirmCheckbox.count() ) > 0 ) {
+				await confirmCheckbox.check();
+			}
+
+			// Confirm. Clicking "Continue removal" begins the cancellation survey.
+			await continueRemovalButton.click();
+			return;
+		}
+
+		if ( action === 'Cancel subscription' ) {
 			await this.page.getByRole( 'button', { name: 'Cancel subscription' } ).click();
 		}
 	}


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/SHILL-2107/

## Proposed Changes

This effectively reverts the cancellation flow to the treatment variant of the `calypso_split_cancel_refund_20260316` flow introduced in #108541.

It makes the "Remove and refund" notice part of the default cancellation flow and switches the flow without clicking the notice cancel rather than issue an immediate refund. The rest of the flag's UI stays gated.

Request: p1778255013281959-slack-C097SQTJV9S

* Add a small pure helper `getCancellationTopNotice` that picks the top-of-flow notice (`refund-eligibility` / `confirmed` / `time-remaining`) from `displayVariant` + refund availability, with unit tests — so the decision is testable without rendering the large connected cancel component.
* Render the refund-eligibility ("Remove and refund") notice by default when a refund is available on a cancel, instead of only under the flag.
* Make the "Cancel plan" CTA always carry `?intent=cancel`, so the main Cancel action disables auto-renew; immediate remove-and-refund stays reachable only via the notice's "Remove plan and claim refund." link (`?intent=remove`).
* Retire the `calypso_new_cancel_refund_flow` experiment from `useIsSplitCancelRemoveEnabled` — the hook now keys solely off the config flag.

## Why are these changes being made?

The `purchases/split-cancel-remove` work separated two distinct actions for a refundable plan: *cancel* (stop auto-renew, keep features until the term ends) and *remove + refund* (immediate removal with money back). We want the refund notice and that separation in the default flow, while keeping the rest of the flag's UI (new CTA copy, survey changes, warnings, etc.) gated.

Root cause of the wrong-survey bug: the default "Cancel plan" CTA only appended `?intent=cancel` under the flag. With the flag off, the cancel page received no intent, so a refundable plan fell back to `getPurchaseCancellationFlowType` → `CANCEL_WITH_REFUND`, which showed the "Cancel plan and refund" survey and fired the refund mutation. That both duplicated and contradicted the new notice. Carrying `intent=cancel` resolves the main Cancel to `CANCEL_AUTORENEW` (disable auto-renew), leaving the refund reachable only through the notice.

## Testing Instructions

TC:
```
yarn test-client client/me/purchases/cancel-purchase/ client/me/purchases/manage-purchase/test/purchase-management-buttons.js
```

Manual testing (with `purchases/split-cancel-remove` OFF — the production default):

* On a site with a **refundable** plan, open Me → Purchases → the plan.
* The CTA reads **"Cancel plan"** with a **"Refund available"** subtitle.
* Click **Cancel plan** → the cancellation flow shows a **"Remove and refund"** notice at the top ("You're eligible for a … refund if you remove your plan now").
* Click the main confirm button → the survey title reads **"Cancel plan"** (not "Cancel plan and refund"); completing it **disables auto-renew** and keeps the plan until expiry (no refund).
* Click the notice's **"Remove plan and claim refund."** link → confirmation screen for remove + refund; completing it removes the plan and issues the refund.
* On a **non-refundable** plan: no refund notice; time-remaining behavior unchanged.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?