### PR TITLE
E2E: handle social sharing confirmation while publishing

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-publish-panel-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-publish-panel-component.ts
@@ -99,7 +99,65 @@ export class EditorPublishPanelComponent {
 			return;
 		}
 
+		await this.continuePastSocialSharingConfirmation();
+
 		await publishButtonLocator.click();
+	}
+
+	/**
+	 * Continues past Jetpack Social's pre-publish confirmation when it appears.
+	 */
+	private async continuePastSocialSharingConfirmation(): Promise< void > {
+		const editorParent = await this.editor.parent();
+		const socialSharingDialog = editorParent.getByRole( 'dialog' ).filter( {
+			has: this.page.getByRole( 'heading', {
+				name: 'Confirm social sharing',
+				exact: true,
+			} ),
+		} );
+		const continueButton = socialSharingDialog.getByRole( 'button', {
+			name: 'Continue',
+			exact: true,
+		} );
+
+		try {
+			await continueButton.waitFor( { state: 'visible', timeout: 2000 } );
+		} catch ( error ) {
+			if ( ! this.isTimeoutError( error ) ) {
+				throw error;
+			}
+
+			if ( await socialSharingDialog.isVisible().catch( () => false ) ) {
+				throw new Error(
+					'Jetpack Social sharing confirmation appeared, but its Continue button was not visible.',
+					{ cause: error }
+				);
+			}
+
+			return;
+		}
+
+		await continueButton.click();
+
+		try {
+			await socialSharingDialog.waitFor( { state: 'hidden', timeout: 5000 } );
+		} catch ( error ) {
+			throw new Error( 'Jetpack Social sharing confirmation did not close after Continue.', {
+				cause: error,
+			} );
+		}
+	}
+
+	/**
+	 * Checks whether an error came from a Playwright timeout.
+	 *
+	 * @param {unknown} error The error to inspect.
+	 * @returns {boolean} True when the error is a Playwright timeout.
+	 */
+	private isTimeoutError( error: unknown ): boolean {
+		const message = error instanceof Error ? error.message : String( error );
+
+		return /Timeout \d+ms exceeded/.test( message );
 	}
 
 	/* Post-publish state */


### PR DESCRIPTION
Part of TESTOPS-104

## Proposed Changes

* Dismiss Jetpack Social's "Confirm social sharing" dialog when it appears during the shared editor publish helper.
* Wait for the dialog to close before clicking the publish-panel button.

## Why are these changes being made?

* Gutenberg Simple production runs repeatedly fail the same Story and CoBlocks publish tests because a connected social account opens the Social confirmation dialog.
* The helper waits for the post publish response, but that response never happens while the dialog blocks the final publish-panel click.
* First failed scheduled pair found in TeamCity: desktop #2288 and mobile #2160. Latest repeat checked: desktop #2304 and mobile #2176.

## Testing Instructions

* Reviewed first-failure TeamCity artifacts; the screenshot shows the "Confirm social sharing" dialog blocking publish.
* Ran local Playwright runtime probes for the no-dialog, missing-Continue, and Continue-closes paths.
* Ran `yarn workspace @automattic/calypso-e2e build`.
* Ran `git diff --check`.
* Commit hook ran Prettier and lint successfully.
* PR CI passed, including direct desktop/mobile E2E, Playwright matrix, Dashboard E2E, unit tests, code style, Docker image, Buildkite install, and translate.
* Personal Gutenberg Simple production TeamCity verification passed: desktop #2305 and mobile #2177.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?