### PR TITLE
Fix checkout summary amount wrapping on narrow viewports

### DIFF
--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -819,11 +819,15 @@ const CheckoutSummaryAmountWrapper = styled.div`
 
 const CheckoutSummaryLineItem = styled.div< { isDiscount?: boolean } >`
 	display: flex;
-	flex-wrap: wrap;
+	flex-wrap: nowrap;
 	font-size: 14px;
 	justify-content: space-between;
 	line-height: 20px;
 	margin-bottom: 4px;
+
+	& > *:last-child {
+		white-space: nowrap;
+	}
 
 	color: ${ ( props ) => ( props.isDiscount ? props.theme.colors.discount : 'inherit' ) };
 
@@ -853,6 +857,8 @@ const CheckoutSummarySubtotal = styled( CheckoutSummaryLineItem )< {
 		display: flex;
 		flex: 0 0 auto;
 		gap: 4px;
+		flex-wrap: wrap;
+		justify-content: flex-end;
 		margin-left: auto;
 
 		.rtl & {


### PR DESCRIPTION
Part of #

## Proposed Changes

* In `CheckoutSummaryLineItem`: change `flex-wrap: wrap` → `flex-wrap: nowrap` and add `white-space: nowrap` to the last child (the price/amount element) to keep currency symbol and numeric value on the same line.
* In `CheckoutSummarySubtotal`: add `flex-wrap: wrap` and `justify-content: flex-end` to the price wrapper so the subtotal amount can gracefully wrap within its own container when the viewport is very narrow, rather than overflowing.

## Why are these changes being made?

On narrow viewports (mobile widths, small sidebars) or when long currency
symbols are used (e.g. `US$`, `NZ$`), the checkout order summary line
items would break awkwardly — the currency symbol could wrap away from its
numeric value, or the label and price would jumble together. This fix
keeps each line item's label and price visually separated (via
`justify-content: space-between`) while ensuring the price itself never
breaks mid-number.

## Testing Instructions

1. Go to the checkout page with at least one item in the cart.
2. Open DevTools and set the viewport to a narrow width (≤ 360 px), or use a mobile device.
3. **Before fix**: Price amounts may wrap so the currency symbol (`US$`) appears on its own line separate from the numeric value, or the label and price overflow into each other.
4. **After fix**: Each line item keeps its label on the left and the price (currency symbol + number) together on the right without awkward breaking.
5. Test with a currency that has a multi-character prefix (e.g. switch locale to `en-US` which shows `US$`, or `en-NZ` for `NZ$`).
6. Verify layout in both LTR and RTL (e.g. Hebrew locale) — the `.rtl` rule block is preserved.
7. Check dark mode — no visual regressions.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages (ES, PT, FR, DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?
