### PR TITLE
Fix marketplace plugins pagination in logged out view

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -135,6 +135,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search } ) => {
 					siteSlug={ siteSlug }
 					siteId={ siteId }
 					sites={ sites }
+					isLoggedOut={ ! shouldUseLoggedInView }
 				/>
 			);
 		}
@@ -148,7 +149,12 @@ const PluginsBrowser = ( { trackPageViews = true, category, search } ) => {
 
 		if ( category ) {
 			return (
-				<PluginsCategoryResultsPage category={ category } sites={ sites } siteSlug={ siteSlug } />
+				<PluginsCategoryResultsPage
+					category={ category }
+					sites={ sites }
+					siteSlug={ siteSlug }
+					isLoggedOut={ ! shouldUseLoggedInView }
+				/>
 			);
 		}
 

--- a/client/my-sites/plugins/plugins-category-results-page/index.jsx
+++ b/client/my-sites/plugins/plugins-category-results-page/index.jsx
@@ -10,7 +10,7 @@ import { WPBEGINNER_PLUGINS } from '../constants';
 import { useIsMarketplaceRedesignEnabled } from '../hooks/use-is-marketplace-redesign-enabled';
 import usePlugins from '../use-plugins';
 
-const PluginsCategoryResultsPage = ( { category, siteSlug, sites } ) => {
+const PluginsCategoryResultsPage = ( { category, siteSlug, sites, isLoggedOut } ) => {
 	const { plugins, isFetching, fetchNextPage, pagination } = usePlugins( {
 		category,
 		infinite: true,
@@ -51,12 +51,16 @@ const PluginsCategoryResultsPage = ( { category, siteSlug, sites } ) => {
 				site={ siteSlug }
 				showPlaceholders={ isFetching }
 				currentSites={ sites }
-				variant={ PluginsBrowserListVariant.InfiniteScroll }
+				variant={
+					isLoggedOut
+						? PluginsBrowserListVariant.Paginated
+						: PluginsBrowserListVariant.InfiniteScroll
+				}
 				extended
 				injectAfterIndex={ isMarketplaceRedesign ? 12 : undefined }
 				injectElement={ isMarketplaceRedesign ? <BusinessPlanBanner /> : undefined }
 			/>
-			<InfiniteScroll nextPageMethod={ fetchNextPage } />
+			{ ! isLoggedOut && <InfiniteScroll nextPageMethod={ fetchNextPage } /> }
 		</FullWidthSection>
 	);
 };

--- a/client/my-sites/plugins/plugins-search-results-page/index.jsx
+++ b/client/my-sites/plugins/plugins-search-results-page/index.jsx
@@ -26,6 +26,7 @@ const PluginsSearchResultPage = ( {
 	sites,
 	categoryName,
 	setIsFetchingPluginsBySearchTerm,
+	isLoggedOut,
 } ) => {
 	const {
 		plugins: pluginsBySearchTerm = [],
@@ -132,13 +133,17 @@ const PluginsSearchResultPage = ( {
 					site={ siteSlug }
 					showPlaceholders={ isFetchingPluginsBySearchTerm }
 					currentSites={ sites }
-					variant={ PluginsBrowserListVariant.Paginated }
+					variant={
+						isLoggedOut
+							? PluginsBrowserListVariant.Paginated
+							: PluginsBrowserListVariant.InfiniteScroll
+					}
 					extended
 					search={ searchTerm }
 					injectAfterIndex={ isMarketplaceRedesign ? 12 : undefined }
 					injectElement={ isMarketplaceRedesign ? <BusinessPlanBanner /> : undefined }
 				/>
-				<InfiniteScroll nextPageMethod={ fetchNextPage } />
+				{ ! isLoggedOut && <InfiniteScroll nextPageMethod={ fetchNextPage } /> }
 			</FullWidthSection>
 		);
 	}


### PR DESCRIPTION
Part of #67075

## Proposed Changes

* Pass `isLoggedOut` prop from `PluginsBrowser` down to `PluginsCategoryResultsPage` and `PluginsSearchResultPage`
* Switch both components to render `PluginsBrowserListVariant.Paginated` (instead of `InfiniteScroll`) when the user is logged out
* Suppress the `<InfiniteScroll>` component when the user is logged out

## Why are these changes being made?

Logged-out users visiting the Marketplace plugins pages were seeing an
infinite-scroll layout that relies on authenticated API calls. Since
logged-out users can't authenticate, this caused silent failures and a
broken UX — no additional results would load when scrolling. Paginated
navigation is the correct experience for unauthenticated visitors and
matches the intended behaviour described in #67075.

## Testing Instructions

1. Open the WordPress.com Marketplace in an incognito/private window (logged out).
2. Navigate to a plugin category page (e.g. `/plugins/browse/featured`).
3. **Before fix**: The page renders with an `InfiniteScroll` list — scrolling to the bottom triggers no new results.
4. **After fix**: The page renders with a paginated list — page navigation controls appear at the bottom and clicking them loads the next set of plugins correctly.
5. Repeat for the search results page: search for a plugin term while logged out and verify pagination controls appear.
6. Log in and confirm infinite scroll still works as expected for authenticated users.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?
