### PR TITLE
Earn: fix navigation tab padding, mobile label, and dropdown styling

### DIFF
--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -109,15 +109,6 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 		return tabs;
 	};
 
-	const getEarnSelectedText = () => {
-		const selected = find( getEarnTabs(), { path: path } );
-		if ( selected ) {
-			return selected.title;
-		}
-
-		return '';
-	};
-
 	const getAdSelectedText = () => {
 		const selected = find( getAdTabs(), { path: path } );
 		if ( selected ) {
@@ -186,6 +177,14 @@ const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 		}
 
 		return tabItem.path === currentPath;
+	};
+
+	// Mirror the visible tab selection so the mobile dropdown header always
+	// reflects the active tab (including ads sub-sections, which map to the
+	// "Ads" tab, and paths carrying a query string).
+	const getEarnSelectedText = () => {
+		const selected = getEarnTabs().find( isEarnTabSelected );
+		return selected ? selected.title : '';
 	};
 
 	const getEarnSectionNav = () => {

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -17,10 +17,35 @@ body.is-section-jetpack-monetize {
 
 .earn-navigation {
 	.section-nav {
-		background: none;
 		box-shadow: none;
-		padding: 0 var(--wpds-dimension-padding-2xl, 24px);
 		border-bottom: var(--wpds-border-width-xs, 1px) solid var(--wpds-color-stroke-surface-neutral-weak, #e0e0e0);
+	}
+
+	// Keep the nav transparent on the earn page surface: the base bar, the
+	// minimal-variation mobile dropdown header, and the expanded mobile panel
+	// each paint their own background that we don't want here.
+	.section-nav,
+	.section-nav.minimal .section-nav__mobile-header,
+	.section-nav.is-open .section-nav__panel {
+		background: none;
+	}
+
+	// In the tabs view, keep the first tab's label flush with the page content
+	// instead of carrying the tab's own inline-start padding.
+	@include break-mobile {
+		.section-nav-tab:first-child .section-nav-tab__link {
+			padding-inline-start: 0;
+		}
+	}
+
+	// Drop the overflow fade mask — the tabs fit, and the left fade otherwise
+	// dims the flush-aligned first tab label.
+	.section-nav-tabs:not( .is-dropdown ) .section-nav-tabs__list {
+		&.is-overflowing-first,
+		&.is-overflowing-last,
+		&.is-overflowing-first.is-overflowing-last {
+			mask-image: none;
+		}
 	}
 }
 
@@ -159,23 +184,28 @@ body.is-section-jetpack-monetize {
 		background: none;
 	}
 
-	.section-nav-tab {
-		&:hover:not(.is-selected) {
-			border-bottom-color: transparent;
-		}
-		&.is-selected {
-			border-bottom: none;
-			.section-nav-tab__link {
-				color: var(--color-text);
+	// Desktop tab styling only. On mobile the nav collapses to a dropdown, so
+	// these link colors/padding would override the default dropdown styling and
+	// leave the selected item dark-on-blue.
+	@include breakpoint-deprecated( ">480px" ) {
+		.section-nav-tab {
+			&:hover:not(.is-selected) {
+				border-bottom-color: transparent;
+			}
+			&.is-selected {
+				border-bottom: none;
+				.section-nav-tab__link {
+					color: var(--color-text);
+				}
 			}
 		}
-	}
-	.section-nav-tab__link {
-		padding: 0 20px 10px 0;
-		color: var(--color-link);
-		&:hover {
-			background-color: transparent;
+		.section-nav-tab__link {
+			padding: 0 20px 10px 0;
 			color: var(--color-link);
+			&:hover {
+				background-color: transparent;
+				color: var(--color-link);
+			}
 		}
 	}
 }
@@ -212,35 +242,6 @@ See https://dequeuniversity.com/rules/axe/4.6/link-in-text-block?application=Axe
 h3.highlight-cards-heading,
 h3.ads__table-header-title {
 	font-size: 18px;
-}
-body:not(.theme-jetpack-cloud) {
-	.earn__ads-header {
-		margin: 20px 0;
-
-		h2.formatted-header__title {
-			margin: 0 0 12px;
-			font-size: $font-size-header-small;
-		}
-
-		.section-nav {
-			box-shadow: none;
-		}
-
-		.section-nav-tab {
-			&:hover:not(.is-selected) {
-				border-bottom-color: transparent;
-			}
-			&.is-selected {
-				border-bottom: none;
-			}
-			.section-nav-tab__link {
-				padding: 0 20px 10px 0;
-				&:hover {
-					background-color: transparent;
-				}
-			}
-		}
-	}
 }
 
 .earn__cancel-dialog {


### PR DESCRIPTION
## Proposed Changes

* Align the first Earn nav tab with the page content (remove the doubled inline padding) and drop the unneeded overflow fade mask and surface backgrounds so the bar sits cleanly on the page.
* Make the mobile dropdown header reflect the active tab for every section, including the ads sub-sections (which map to the "Ads" tab) and paths carrying a query string — previously it could render blank.
* Scope the Ads sub-nav's desktop tab styling to the tabs view so the mobile dropdown keeps the default section-nav styling (the desktop colors/padding were leaking into the dropdown and rendering the selected item dark-on-blue). Remove a redundant duplicate style block.

## Why are these changes being made?

* The Earn section navigation had a few visual rough edges: an over-indented first tab, an unnecessary edge fade, stray surface backgrounds, an empty mobile dropdown label on some routes, and a broken-looking Ads dropdown on mobile.

## Testing Instructions

* Visit `/earn/` and its sub-sections (Paid Subscribers, Payment Settings, Ads → Earnings/Payments/Settings).
* Desktop: confirm the first tab aligns with the page content, there's no edge fade on the tabs, and no stray backgrounds.
* Mobile (≤480px): open the nav dropdown and confirm the collapsed header shows the active tab's label on every section (including the ads sub-sections), and that the Ads dropdown items/selected item are styled normally (not dark-on-blue).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? (PCYsg-S3g-p2)
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)