### PR TITLE
Akismet: default login to passwordless magic link

### DIFF
--- a/client/login/controller.jsx
+++ b/client/login/controller.jsx
@@ -1,7 +1,8 @@
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { getUrlParts } from '@automattic/calypso-url';
-import { isGravPoweredOAuth2Client } from 'calypso/lib/oauth2-clients';
+import { isAkismetOAuth2Client, isGravPoweredOAuth2Client } from 'calypso/lib/oauth2-clients';
+import { login as loginUrl } from 'calypso/lib/paths';
 import { DesktopLoginStart, DesktopLoginFinalize } from 'calypso/login/desktop-login';
 import { SOCIAL_HANDOFF_CONNECT_ACCOUNT } from 'calypso/state/action-types';
 import { isUserLoggedIn, getCurrentUserLocale } from 'calypso/state/current-user/selectors';
@@ -116,6 +117,27 @@ export async function login( context, next ) {
 				return next( error );
 			}
 		}
+	}
+
+	// Akismet logins default to the passwordless magic link flow, like Gravatar.
+	// Only redirect from the plain login view, leaving 2FA/lost-password/social
+	// sub-routes (which share this controller) untouched.
+	const oauth2Client = getOAuth2Client( context.store.getState(), Number( client_id ) );
+	const { flow, socialService, twoFactorAuthType, action } = context.params;
+	if (
+		config.isEnabled( 'login/magic-login' ) &&
+		! context.isServerSide &&
+		isAkismetOAuth2Client( oauth2Client ) &&
+		! ( twoFactorAuthType || action || flow || socialService )
+	) {
+		return page.redirect(
+			loginUrl( {
+				locale: context.params.lang,
+				twoFactorAuthType: 'link',
+				oauth2ClientId: client_id,
+				redirectTo: redirect_to,
+			} )
+		);
 	}
 
 	enhanceContextWithLogin( context );


### PR DESCRIPTION
## Proposed Changes

* When an Akismet user (OAuth2 client `973`) lands on the plain login view, redirect them to the passwordless magic link page (`/log-in/link`), mirroring the experience already used by Gravatar-powered clients.
* The redirect is scoped to the plain login view only — 2FA, lost-password, and social sub-routes (which share the same `login` controller) are left untouched, and the password form remains reachable from the magic login page.

## Why are these changes being made?

* Akismet currently lands on the password login form by default. Defaulting to the magic link flow gives Akismet the same low-friction, passwordless sign-in experience that Gravatar-powered clients already get.

## Testing Instructions

* With `login/magic-login` enabled, visit the Akismet login URL (`/log-in?client_id=973&redirect_to=...`) while logged out.
* Confirm you are redirected to the magic link page (`/log-in/link?client_id=973&redirect_to=...`).
* Confirm the password form is still reachable from the magic login page, and that 2FA (`/log-in/sms`, `/log-in/authenticator`, …), lost password (`/log-in/lostpassword`), and social callback routes are unaffected.
* Confirm non-Akismet clients and the standard WordPress.com login are unchanged.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)