### PR TITLE
MSD: force opt-in toggle visibility via feature flag on stage

### DIFF
--- a/client/state/dashboard/selectors/is-dashboard-toggle-enabled.ts
+++ b/client/state/dashboard/selectors/is-dashboard-toggle-enabled.ts
@@ -9,6 +9,11 @@ const OLDEST_ELIGIBLE_USER: number = config( 'dashboard_opt_in_oldest_eligible_u
  * before 22 December 2025 can manually opt in or out.
  */
 export const isDashboardToggleEnabled = ( state: AppState ): boolean => {
+	// Useful for allowing internal testing for proxied a12s.
+	if ( config.isEnabled( 'dashboard/force-opt-in-visibility' ) ) {
+		return true;
+	}
+
 	const user = getCurrentUser( state ); // Ensure current user is loaded.
 	if ( ! user || user.ID > OLDEST_ELIGIBLE_USER ) {
 		return false;

--- a/config/development.json
+++ b/config/development.json
@@ -68,6 +68,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dark-mode": false,
+		"dashboard/force-opt-in-visibility": true,
 		"dashboard/omnibar": true,
 		"dashboard/omnibar-radical": false,
 		"dashboard/opt-in-banners": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -28,6 +28,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dark-mode": false,
+		"dashboard/force-opt-in-visibility": true,
 		"dashboard/omnibar": true,
 		"dashboard/opt-in-banners": false,
 		"dashboard/plans": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -38,6 +38,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dark-mode": false,
+		"dashboard/force-opt-in-visibility": true,
 		"dashboard/omnibar": true,
 		"dashboard/opt-in-banners": false,
 		"dashboard/wp-beta-program": true,

--- a/config/test.json
+++ b/config/test.json
@@ -34,6 +34,7 @@
 		"cookie-banner": false,
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
+		"dashboard/force-opt-in-visibility": true,
 		"dashboard/opt-in-banners": false,
 		"google-my-business": false,
 		"help": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -37,6 +37,7 @@
 		"current-site/domain-warning": false,
 		"current-site/notice": true,
 		"dark-mode": false,
+		"dashboard/force-opt-in-visibility": true,
 		"dashboard/omnibar": true,
 		"dashboard/opt-in-banners": false,
 		"dashboard/plans": true,


### PR DESCRIPTION
## Proposed Changes

This is useful for a CfT

* Add a `dashboard/force-opt-in-visibility` feature flag, enabled in `config/stage.json`.
* When the flag is enabled, the `/me/account` dashboard (MSD) opt-in toggle always appears, bypassing all eligibility checks (both `dashboard/v2` and the user-age cutoff).

## Why are these changes being made?

* The MSD opt-in toggle on `/me/account` is gated to users created before 22 December 2025, which makes it impossible for most proxied a12s to test the toggle on stage. This flag forces the toggle to appear so internal testing on stage works regardless of account age.

* Enabled in wpcalypso etc. too because that way it's testable in calypso.live

> **Note for reviewers:** the new check is placed *before* the `dashboard/v2` check intentionally, so the flag fully forces visibility. I'm also looking at just removing that whole `dashboard/v2` flag in #111426, which seems pretty much redundant now.

## Testing Instructions

* As a proxied user on stage, visit `/me/account` and confirm the dashboard beta opt-in toggle appears (even for accounts created after 22 Dec 2025).
* Without the flag (e.g. production), behaviour is unchanged.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
