### PR TITLE
MSD: Remove staging sites from sites list

### DIFF
--- a/client/dashboard/app-ciab/index.tsx
+++ b/client/dashboard/app-ciab/index.tsx
@@ -57,9 +57,9 @@ boot( {
 		siteSwitcher: () => import( '../sites-ciab/site-switcher' ),
 	},
 	queries: {
-		sitesQuery: ( fetchSitesOptions?: FetchSitesOptions ) =>
+		sitesQuery: ( fetchSitesOptions?: Partial< FetchSitesOptions > ) =>
 			sitesQuery( [ 'commerce-garden' ], fetchSitesOptions ),
-		paginatedSitesQuery: ( fetchSitesOptions?: FetchPaginatedSitesOptions ) =>
+		paginatedSitesQuery: ( fetchSitesOptions?: Partial< FetchPaginatedSitesOptions > ) =>
 			paginatedSitesQuery( [ 'commerce-garden' ], fetchSitesOptions ),
 		dashboardSiteFiltersQuery: ( fields: FetchDashboardSiteFiltersParams[ 'fields' ] ) =>
 			dashboardSiteFiltersQuery( [ 'commerce-garden' ], fields ),

--- a/client/dashboard/app-dotcom/index.tsx
+++ b/client/dashboard/app-dotcom/index.tsx
@@ -53,8 +53,9 @@ boot( {
 		siteSwitcher: () => import( '../sites/site-switcher' ),
 	},
 	queries: {
-		sitesQuery: ( fetchSiteOptions?: FetchSitesOptions ) => sitesQuery( 'all', fetchSiteOptions ),
-		paginatedSitesQuery: ( fetchSiteOptions?: FetchPaginatedSitesOptions ) =>
+		sitesQuery: ( fetchSiteOptions?: Partial< FetchSitesOptions > ) =>
+			sitesQuery( 'all', fetchSiteOptions ),
+		paginatedSitesQuery: ( fetchSiteOptions?: Partial< FetchPaginatedSitesOptions > ) =>
 			paginatedSitesQuery( 'all', fetchSiteOptions ),
 		dashboardSiteFiltersQuery: ( fields: FetchDashboardSiteFiltersParams[ 'fields' ] ) =>
 			dashboardSiteFiltersQuery( 'all', fields ),

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -66,9 +66,11 @@ export type AppConfig = {
 		siteSwitcher: () => Promise< { default: React.FC< any > } >;
 	};
 	queries: {
-		sitesQuery: ( fetchSiteOptions?: FetchSitesOptions ) => ReturnType< typeof sitesQuery >;
+		sitesQuery: (
+			fetchSiteOptions?: Partial< FetchSitesOptions >
+		) => ReturnType< typeof sitesQuery >;
 		paginatedSitesQuery: (
-			fetchSiteOptions?: FetchPaginatedSitesOptions
+			fetchSiteOptions?: Partial< FetchPaginatedSitesOptions >
 		) => ReturnType< typeof paginatedSitesQuery >;
 		dashboardSiteFiltersQuery: (
 			field: FetchDashboardSiteFiltersParams[ 'fields' ]
@@ -108,8 +110,9 @@ export const APP_CONTEXT_DEFAULT_CONFIG: AppConfig = {
 		siteSwitcher: () => Promise.resolve( { default: () => null } ),
 	},
 	queries: {
-		sitesQuery: ( fetchSiteOptions?: FetchSitesOptions ) => sitesQuery( 'all', fetchSiteOptions ),
-		paginatedSitesQuery: ( fetchSiteOptions?: FetchPaginatedSitesOptions ) =>
+		sitesQuery: ( fetchSiteOptions?: Partial< FetchSitesOptions > ) =>
+			sitesQuery( 'all', fetchSiteOptions ),
+		paginatedSitesQuery: ( fetchSiteOptions?: Partial< FetchPaginatedSitesOptions > ) =>
 			paginatedSitesQuery( 'all', fetchSiteOptions ),
 		dashboardSiteFiltersQuery: ( fields: FetchDashboardSiteFiltersParams[ 'fields' ] ) =>
 			dashboardSiteFiltersQuery( 'all', fields ),

--- a/client/dashboard/plugins/manage/hooks/use-sites-by-id.ts
+++ b/client/dashboard/plugins/manage/hooks/use-sites-by-id.ts
@@ -4,7 +4,9 @@ import { useAppContext } from '../../../app/context';
 
 export const useSitesById = () => {
 	const { queries } = useAppContext();
-	const { data: sites, isLoading: isLoadingSites } = useQuery( queries.sitesQuery() );
+	const { data: sites, isLoading: isLoadingSites } = useQuery(
+		queries.sitesQuery( { include_staging: true } )
+	);
 
 	const map = new Map< number, Site >();
 

--- a/client/dashboard/plugins/plugin/use-plugin.ts
+++ b/client/dashboard/plugins/plugin/use-plugin.ts
@@ -45,11 +45,7 @@ export const usePlugin = ( pluginSlug: string, { enabled = true }: { enabled?: b
 		isFetching: isFetchingSitePlugins,
 	} = useQuery( { ...pluginsQuery(), enabled } );
 	const { data: sites, isLoading: isLoadingSites } = useQuery(
-		queries.sitesQuery( {
-			include_staging: true,
-			include_a8c_owned: false,
-			site_visibility: 'visible',
-		} )
+		queries.sitesQuery( { include_staging: true } )
 	);
 	const { data: marketplacePlugins, isLoading: isLoadingMarketplacePlugins } = useQuery(
 		marketplacePluginsQuery()

--- a/client/dashboard/plugins/plugin/use-plugin.ts
+++ b/client/dashboard/plugins/plugin/use-plugin.ts
@@ -44,7 +44,13 @@ export const usePlugin = ( pluginSlug: string, { enabled = true }: { enabled?: b
 		isLoading: isLoadingSitesPlugins,
 		isFetching: isFetchingSitePlugins,
 	} = useQuery( { ...pluginsQuery(), enabled } );
-	const { data: sites, isLoading: isLoadingSites } = useQuery( queries.sitesQuery() );
+	const { data: sites, isLoading: isLoadingSites } = useQuery(
+		queries.sitesQuery( {
+			include_staging: true,
+			include_a8c_owned: false,
+			site_visibility: 'visible',
+		} )
+	);
 	const { data: marketplacePlugins, isLoading: isLoadingMarketplacePlugins } = useQuery(
 		marketplacePluginsQuery()
 	);

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -69,7 +69,9 @@ const getFetchPaginatedSitesOptions = (
 		// See: https://github.com/Automattic/wp-calypso/pull/104220.
 		site_visibility: view.search || shouldIncludeA8COwned || isRestoringAccount ? 'all' : 'visible',
 		include_a8c_owned: shouldIncludeA8COwned,
-		include_staging: false,
+		// Keep showing staging sites in the dashboard backport (classic Calypso),
+		// but exclude them from the standalone dashboard site list.
+		include_staging: isDashboardBackport(),
 		search: view.search,
 		sort_field: view.sort?.field,
 		sort_direction: view.sort?.direction,

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -69,6 +69,7 @@ const getFetchPaginatedSitesOptions = (
 		// See: https://github.com/Automattic/wp-calypso/pull/104220.
 		site_visibility: view.search || shouldIncludeA8COwned || isRestoringAccount ? 'all' : 'visible',
 		include_a8c_owned: shouldIncludeA8COwned,
+		include_staging: false,
 		search: view.search,
 		sort_field: view.sort?.field,
 		sort_direction: view.sort?.direction,

--- a/packages/api-core/src/me-sites/fetchers.ts
+++ b/packages/api-core/src/me-sites/fetchers.ts
@@ -14,6 +14,7 @@ export interface FetchSitesOptions {
 	source?: string;
 	site_visibility: 'all' | 'visible' | 'hidden' | 'deleted';
 	include_a8c_owned: boolean;
+	include_staging?: boolean;
 }
 
 export interface FetchPaginatedSitesOptions extends FetchSitesOptions {
@@ -33,7 +34,7 @@ export interface FetchPaginatedSitesResponse {
 
 export async function fetchSites(
 	site_types: FetchSiteTypes,
-	{ source, site_visibility, include_a8c_owned }: FetchSitesOptions
+	{ source, site_visibility, include_a8c_owned, include_staging = false }: FetchSitesOptions
 ): Promise< Site[] > {
 	const { sites } = await wpcom.req.get(
 		{
@@ -47,6 +48,7 @@ export async function fetchSites(
 			site_activity: 'active',
 			site_visibility,
 			include_a8c_owned,
+			include_staging,
 			include_domain_only: false,
 			filters: site_types !== 'all' ? site_types.join( ',' ) : undefined,
 		}
@@ -60,6 +62,7 @@ export async function fetchPaginatedSites(
 		source,
 		site_visibility,
 		include_a8c_owned,
+		include_staging = false,
 		search,
 		plan,
 		visibility,
@@ -81,6 +84,7 @@ export async function fetchPaginatedSites(
 			site_activity: 'active',
 			site_visibility,
 			include_a8c_owned,
+			include_staging,
 			include_domain_only: false,
 			filters: site_types !== 'all' ? site_types.join( ',' ) : undefined,
 			search,

--- a/packages/api-queries/src/sites.ts
+++ b/packages/api-queries/src/sites.ts
@@ -10,7 +10,11 @@ export const sitesQueryKey = [ 'sites', SITE_FIELDS, SITE_OPTIONS ];
 
 export const sitesQuery = (
 	siteFilters: FetchSiteTypes,
-	fetchSitesOptions: FetchSitesOptions = { site_visibility: 'visible', include_a8c_owned: false }
+	fetchSitesOptions: FetchSitesOptions = {
+		site_visibility: 'visible',
+		include_a8c_owned: false,
+		include_staging: false,
+	}
 ) => {
 	const { source, ...fetchSitesOptionsKey } = fetchSitesOptions;
 	return queryOptions( {

--- a/packages/api-queries/src/sites.ts
+++ b/packages/api-queries/src/sites.ts
@@ -10,16 +10,13 @@ export const sitesQueryKey = [ 'sites', SITE_FIELDS, SITE_OPTIONS ];
 
 export const sitesQuery = (
 	siteFilters: FetchSiteTypes,
-	fetchSitesOptions: FetchSitesOptions = {
-		site_visibility: 'visible',
-		include_a8c_owned: false,
-		include_staging: false,
-	}
+	fetchSitesOptions: FetchSitesOptions = { site_visibility: 'visible', include_a8c_owned: false }
 ) => {
-	const { source, ...fetchSitesOptionsKey } = fetchSitesOptions;
+	const withDefaults = { include_staging: false, ...fetchSitesOptions };
+	const { source, ...fetchSitesOptionsKey } = withDefaults;
 	return queryOptions( {
 		queryKey: [ ...sitesQueryKey, siteFilters, fetchSitesOptionsKey ],
-		queryFn: () => fetchSites( siteFilters, fetchSitesOptions ),
+		queryFn: () => fetchSites( siteFilters, withDefaults ),
 	} );
 };
 
@@ -30,10 +27,11 @@ export const paginatedSitesQuery = (
 		include_a8c_owned: false,
 	}
 ) => {
-	const { source, ...fetchSitesOptionsKey } = fetchSitesOptions;
+	const withDefaults = { include_staging: false, ...fetchSitesOptions };
+	const { source, ...fetchSitesOptionsKey } = withDefaults;
 	return queryOptions( {
 		queryKey: [ ...sitesQueryKey, 'paginated', siteFilters, fetchSitesOptionsKey ],
-		queryFn: () => fetchPaginatedSites( siteFilters, fetchSitesOptions ),
+		queryFn: () => fetchPaginatedSites( siteFilters, withDefaults ),
 	} );
 };
 

--- a/packages/api-queries/src/sites.ts
+++ b/packages/api-queries/src/sites.ts
@@ -10,9 +10,14 @@ export const sitesQueryKey = [ 'sites', SITE_FIELDS, SITE_OPTIONS ];
 
 export const sitesQuery = (
 	siteFilters: FetchSiteTypes,
-	fetchSitesOptions: FetchSitesOptions = { site_visibility: 'visible', include_a8c_owned: false }
+	fetchSitesOptions: Partial< FetchSitesOptions > = {}
 ) => {
-	const withDefaults = { include_staging: false, ...fetchSitesOptions };
+	const withDefaults: FetchSitesOptions = {
+		site_visibility: 'visible',
+		include_a8c_owned: false,
+		include_staging: false,
+		...fetchSitesOptions,
+	};
 	const { source, ...fetchSitesOptionsKey } = withDefaults;
 	return queryOptions( {
 		queryKey: [ ...sitesQueryKey, siteFilters, fetchSitesOptionsKey ],
@@ -22,12 +27,14 @@ export const sitesQuery = (
 
 export const paginatedSitesQuery = (
 	siteFilters: FetchSiteTypes,
-	fetchSitesOptions: FetchPaginatedSitesOptions = {
+	fetchSitesOptions: Partial< FetchPaginatedSitesOptions > = {}
+) => {
+	const withDefaults: FetchPaginatedSitesOptions = {
 		site_visibility: 'visible',
 		include_a8c_owned: false,
-	}
-) => {
-	const withDefaults = { include_staging: false, ...fetchSitesOptions };
+		include_staging: false,
+		...fetchSitesOptions,
+	};
 	const { source, ...fetchSitesOptionsKey } = withDefaults;
 	return queryOptions( {
 		queryKey: [ ...sitesQueryKey, 'paginated', siteFilters, fetchSitesOptionsKey ],


### PR DESCRIPTION
Part of DOTMSD-220

Reopens #108019 (closed as stale). 

## Proposed Changes

Excludes staging sites from the follow locations:
- The main site list
- The site switcher
- The primary-site dropdown in the submenu
- Sites notifications (`notifications/sites`)
- The domain transfer site selector

The plugins page will still display staging sites so plugins can be managed.

## Backport behavior

The dashboard site list is also rendered inside classic Calypso via the backport, which runs the same dashboard code. Staging sites are intentionally **kept** there so we don't introduce unnecessary changes in short succession.

## Testing Instructions

With the backend support in place:

**Standalone dashboard** — confirm staging sites do **not** appear in:
- The main site list
- The site switcher
- The primary-site dropdown in the submenu
- Sites notifications (`notifications/sites`)
- The domain transfer site selector

Confirm staging sites **still** appear on:
- `plugins/manage/gutenberg`
- The site list in the classic Calypso backport (`/sites`)

Test the Calypso V1. Expect to see staging sites in the sites list.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? (PCYsg-S3g-p2)
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)