### PR TITLE
A4A MSD: add route guards blocking cross-access between agency and client.

### DIFF
--- a/client/dashboard/agency-client/subscriptions/index.tsx
+++ b/client/dashboard/agency-client/subscriptions/index.tsx
@@ -1,3 +1,5 @@
+import { __ } from '@wordpress/i18n';
+import FlashMessage from '../../components/flash-message';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 
@@ -10,6 +12,12 @@ export default function AgencyClientSubscriptions() {
 					description="This is a sample subscriptions page."
 				/>
 			}
-		></PageLayout>
+		>
+			<FlashMessage
+				id="route-not-allowed"
+				type="error"
+				message={ __( 'You don’t have permission to view the requested page.' ) }
+			/>
+		</PageLayout>
 	);
 }

--- a/client/dashboard/agency/overview/index.tsx
+++ b/client/dashboard/agency/overview/index.tsx
@@ -1,10 +1,16 @@
+import { __ } from '@wordpress/i18n';
+import FlashMessage from '../../components/flash-message';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 
 export default function AgencyOverview() {
 	return (
-		<PageLayout
-			header={ <PageHeader description="This is a sample overview page." /> }
-		></PageLayout>
+		<PageLayout header={ <PageHeader description="This is a sample overview page." /> }>
+			<FlashMessage
+				id="route-not-allowed"
+				type="error"
+				message={ __( 'You don’t have permission to view the requested page.' ) }
+			/>
+		</PageLayout>
 	);
 }

--- a/client/dashboard/app/router/agency-client.tsx
+++ b/client/dashboard/app/router/agency-client.tsx
@@ -3,27 +3,23 @@ import { createRoute, createLazyRoute } from '@tanstack/react-router';
 import { redirectAsNotAllowed } from './redirect';
 import { rootRoute } from './root';
 
-/**
- * Block A4A agency users from client-only routes. `agencyQuery` is primed by the
- * root route's `beforeLoad`, so this resolves from cache.
- */
-async function requireClientUser( { cause }: { cause: string } ) {
-	// Preloads (hover/intent) shouldn't trigger redirects.
-	if ( cause === 'preload' ) {
-		return;
-	}
-
-	const agency = await queryClient.ensureQueryData( agencyQuery() );
-	if ( ! agency.isClientUser ) {
-		throw redirectAsNotAllowed( { to: '/overview' } );
-	}
-}
-
 // `/client` – parent route for agency-client surfaces
 const agencyClientParentRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: 'client',
-	beforeLoad: requireClientUser,
+	// Block A4A agency users from client-only routes. `agencyQuery` is primed by
+	// the root route's `beforeLoad`, so this resolves from cache.
+	beforeLoad: async ( { cause } ) => {
+		// Preloads (hover/intent) shouldn't trigger redirects.
+		if ( cause === 'preload' ) {
+			return;
+		}
+
+		const agency = await queryClient.ensureQueryData( agencyQuery() );
+		if ( ! agency.isClientUser ) {
+			throw redirectAsNotAllowed( { to: '/overview' } );
+		}
+	},
 } );
 
 // `/client/subscriptions` – agency client subscriptions overview

--- a/client/dashboard/app/router/agency-client.tsx
+++ b/client/dashboard/app/router/agency-client.tsx
@@ -1,10 +1,32 @@
+import { agencyQuery, queryClient } from '@automattic/api-queries';
 import { createRoute, createLazyRoute } from '@tanstack/react-router';
+import { redirectAsNotAllowed } from './redirect';
 import { rootRoute } from './root';
+
+/**
+ * Guard for client-only routes. A4A agency users have no access to client
+ * surfaces (subscriptions, etc.), so we bounce them to their agency area.
+ *
+ * Attach as a route's `beforeLoad`. The `agencyQuery` is already primed in the
+ * root route's `beforeLoad` for A4A, so this resolves from cache.
+ */
+async function requireClientUser( { cause }: { cause: string } ) {
+	// Hover/intent preloads shouldn't trigger redirects.
+	if ( cause === 'preload' ) {
+		return;
+	}
+
+	const agency = await queryClient.ensureQueryData( agencyQuery() );
+	if ( ! agency.isClientUser ) {
+		throw redirectAsNotAllowed( { to: '/overview' } );
+	}
+}
 
 // `/client` – parent route for agency-client surfaces
 const agencyClientParentRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: 'client',
+	beforeLoad: requireClientUser,
 } );
 
 // `/client/subscriptions` – agency client subscriptions overview

--- a/client/dashboard/app/router/agency-client.tsx
+++ b/client/dashboard/app/router/agency-client.tsx
@@ -4,14 +4,11 @@ import { redirectAsNotAllowed } from './redirect';
 import { rootRoute } from './root';
 
 /**
- * Guard for client-only routes. A4A agency users have no access to client
- * surfaces (subscriptions, etc.), so we bounce them to their agency area.
- *
- * Attach as a route's `beforeLoad`. The `agencyQuery` is already primed in the
- * root route's `beforeLoad` for A4A, so this resolves from cache.
+ * Block A4A agency users from client-only routes. `agencyQuery` is primed by the
+ * root route's `beforeLoad`, so this resolves from cache.
  */
 async function requireClientUser( { cause }: { cause: string } ) {
-	// Hover/intent preloads shouldn't trigger redirects.
+	// Preloads (hover/intent) shouldn't trigger redirects.
 	if ( cause === 'preload' ) {
 		return;
 	}

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -5,14 +5,11 @@ import { redirectAsNotAllowed } from './redirect';
 import { rootRoute } from './root';
 
 /**
- * Guard for agency-only routes. A4A client users have no access to agency
- * surfaces (overview, etc.), so we bounce them to their own client area.
- *
- * Attach as a route's `beforeLoad`. The `agencyQuery` is already primed in the
- * root route's `beforeLoad` for A4A, so this resolves from cache.
+ * Block A4A client users from agency-only routes. `agencyQuery` is primed by the
+ * root route's `beforeLoad`, so this resolves from cache.
  */
 async function requireAgencyUser( { cause }: { cause: string } ) {
-	// Hover/intent preloads shouldn't trigger redirects.
+	// Preloads (hover/intent) shouldn't trigger redirects.
 	if ( cause === 'preload' ) {
 		return;
 	}

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -1,6 +1,27 @@
+import { agencyQuery, queryClient } from '@automattic/api-queries';
 import { createRoute, createLazyRoute } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
+import { redirectAsNotAllowed } from './redirect';
 import { rootRoute } from './root';
+
+/**
+ * Guard for agency-only routes. A4A client users have no access to agency
+ * surfaces (overview, etc.), so we bounce them to their own client area.
+ *
+ * Attach as a route's `beforeLoad`. The `agencyQuery` is already primed in the
+ * root route's `beforeLoad` for A4A, so this resolves from cache.
+ */
+async function requireAgencyUser( { cause }: { cause: string } ) {
+	// Hover/intent preloads shouldn't trigger redirects.
+	if ( cause === 'preload' ) {
+		return;
+	}
+
+	const agency = await queryClient.ensureQueryData( agencyQuery() );
+	if ( agency.isClientUser ) {
+		throw redirectAsNotAllowed( { to: '/client/subscriptions' } );
+	}
+}
 
 // `/overview` – agency overview
 const agencyOverviewRoute = createRoute( {
@@ -13,6 +34,7 @@ const agencyOverviewRoute = createRoute( {
 	} ),
 	getParentRoute: () => rootRoute,
 	path: 'overview',
+	beforeLoad: requireAgencyUser,
 } ).lazy( () =>
 	import( '../../agency/overview' ).then( ( d ) =>
 		createLazyRoute( 'agency-overview' )( {

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -4,22 +4,6 @@ import { __ } from '@wordpress/i18n';
 import { redirectAsNotAllowed } from './redirect';
 import { rootRoute } from './root';
 
-/**
- * Block A4A client users from agency-only routes. `agencyQuery` is primed by the
- * root route's `beforeLoad`, so this resolves from cache.
- */
-async function requireAgencyUser( { cause }: { cause: string } ) {
-	// Preloads (hover/intent) shouldn't trigger redirects.
-	if ( cause === 'preload' ) {
-		return;
-	}
-
-	const agency = await queryClient.ensureQueryData( agencyQuery() );
-	if ( agency.isClientUser ) {
-		throw redirectAsNotAllowed( { to: '/client/subscriptions' } );
-	}
-}
-
 // `/overview` – agency overview
 const agencyOverviewRoute = createRoute( {
 	head: () => ( {
@@ -31,7 +15,19 @@ const agencyOverviewRoute = createRoute( {
 	} ),
 	getParentRoute: () => rootRoute,
 	path: 'overview',
-	beforeLoad: requireAgencyUser,
+	// Block A4A client users from agency-only routes. `agencyQuery` is primed by
+	// the root route's `beforeLoad`, so this resolves from cache.
+	beforeLoad: async ( { cause } ) => {
+		// Preloads (hover/intent) shouldn't trigger redirects.
+		if ( cause === 'preload' ) {
+			return;
+		}
+
+		const agency = await queryClient.ensureQueryData( agencyQuery() );
+		if ( agency.isClientUser ) {
+			throw redirectAsNotAllowed( { to: '/client/subscriptions' } );
+		}
+	},
 } ).lazy( () =>
 	import( '../../agency/overview' ).then( ( d ) =>
 		createLazyRoute( 'agency-overview' )( {

--- a/client/dashboard/app/router/redirect.ts
+++ b/client/dashboard/app/router/redirect.ts
@@ -13,10 +13,9 @@ export const dashboardRedirect: typeof redirect = ( options ) =>
 	redirect( { ...options, viewTransition: false } );
 
 /**
- * A `dashboardRedirect()` that also sets the `route-not-allowed` flash param,
- * so the destination can surface a "you don't have permission" snackbar (via a
- * `<FlashMessage id="route-not-allowed" />`). Use this whenever a `beforeLoad`
- * guard bounces a user away from a page they aren't allowed to access.
+ * A `dashboardRedirect()` that also sets the `route-not-allowed` flash param, so
+ * the destination can show a "you don't have permission" snackbar via a
+ * `<FlashMessage id="route-not-allowed" />`. Use it in `beforeLoad` guards.
  */
 export function redirectAsNotAllowed( options: {
 	to: string;

--- a/client/dashboard/app/router/redirect.ts
+++ b/client/dashboard/app/router/redirect.ts
@@ -12,11 +12,6 @@ import { redirect } from '@tanstack/react-router';
 export const dashboardRedirect: typeof redirect = ( options ) =>
 	redirect( { ...options, viewTransition: false } );
 
-/**
- * A `dashboardRedirect()` that also sets the `route-not-allowed` flash param, so
- * the destination can show a "you don't have permission" snackbar via a
- * `<FlashMessage id="route-not-allowed" />`. Use it in `beforeLoad` guards.
- */
 export function redirectAsNotAllowed( options: {
 	to: string;
 	params?: Record< string, string >;

--- a/client/dashboard/app/router/redirect.ts
+++ b/client/dashboard/app/router/redirect.ts
@@ -11,3 +11,23 @@ import { redirect } from '@tanstack/react-router';
  */
 export const dashboardRedirect: typeof redirect = ( options ) =>
 	redirect( { ...options, viewTransition: false } );
+
+/**
+ * A `dashboardRedirect()` that also sets the `route-not-allowed` flash param,
+ * so the destination can surface a "you don't have permission" snackbar (via a
+ * `<FlashMessage id="route-not-allowed" />`). Use this whenever a `beforeLoad`
+ * guard bounces a user away from a page they aren't allowed to access.
+ */
+export function redirectAsNotAllowed( options: {
+	to: string;
+	params?: Record< string, string >;
+	search?: Record< string, unknown >;
+} ) {
+	return dashboardRedirect( {
+		...options,
+		search: {
+			...options.search,
+			flash: 'route-not-allowed',
+		},
+	} );
+}

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -66,7 +66,7 @@ import { hasSiteTrialEnded } from '../../utils/site-trial';
 import { getSiteTypeFeatureSupports } from '../../utils/site-type-feature-support';
 import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import { AUTH_QUERY_KEY } from '../auth';
-import { dashboardRedirect } from './redirect';
+import { dashboardRedirect, redirectAsNotAllowed } from './redirect';
 import { rootRoute } from './root';
 import type { AppConfig } from '../context';
 import type { DifmWebsiteContentResponse, Site, User } from '@automattic/api-core';
@@ -1922,18 +1922,4 @@ async function loadSiteLogsRoute( { params: { siteSlug } }: { params: { siteSlug
 	if ( ! site.__inaccessible_jetpack_error ) {
 		await queryClient.prefetchQuery( siteSettingsQuery( site.ID ) );
 	}
-}
-
-function redirectAsNotAllowed( options: {
-	to: string;
-	params?: Record< string, string >;
-	search?: Record< string, unknown >;
-} ) {
-	return dashboardRedirect( {
-		...options,
-		search: {
-			...options.search,
-			flash: 'route-not-allowed',
-		},
-	} );
 }


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/A4A-2763/implement-route-guards-blocking-cross-access-between-agency-and-client

## Proposed Changes

### Why these guards are safe at the route level

  TanStack Router runs `beforeLoad` **root → leaf**, awaiting each one — route-level guards *stack* with ancestors', they
  don't override. So these run after the root guard:

  - `/overview` → root primes `agencyQuery`, then `requireAgencyUser` reads it
  - `/client/subscriptions` → root primes, then `requireClientUser` reads it

  Since the root already awaits `ensureQueryData( agencyQuery() )` (under `supports.agency`) before the child runs, the guards hit cache. They also call `ensureQueryData` themselves, so they're correct in isolation too. Both skip `cause
  === 'preload'`, matching the root.


## Why are these changes being made?

* Ensures user do not access protected resources that are not relevant to them.

## Testing Instructions
* Run yarn start-dashboard.
* Visit http://my.a4a.localhost:3000/

### As an Agency
* Visit http://my.a4a.localhost:3000/client/subscription
* Confirm you get redirected to the overview page with a flash message:
  <img width="473" height="108" alt="Screenshot 2026-06-11 at 8 34 25 PM" src="https://github.com/user-attachments/assets/1d0df3f9-9bd4-4a0f-a667-531079090673" />

### As an Agency Client
* Visit http://my.a4a.localhost:3000/overview
* Confirm you get redirected to the overview page with a flash message:
  <img width="473" height="108" alt="Screenshot 2026-06-11 at 8 34 25 PM" src="https://github.com/user-attachments/assets/1d0df3f9-9bd4-4a0f-a667-531079090673" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
