### PR TITLE
chore: prepare codebase for the TypeScript 6 upgrade

### DIFF
--- a/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
+++ b/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
@@ -173,7 +173,7 @@ export default function useSiteActions( {
 				href: `${ urlWithScheme }/wp-admin`,
 				onClick: () => handleClickMenuItem( 'visit_wp_admin' ),
 				isExternalLink: true,
-				isEnabled: true && ! isUrlOnly,
+				isEnabled: ! isUrlOnly,
 			},
 			{
 				name: translate( 'Remove site' ),
@@ -335,7 +335,7 @@ export function useSiteActionsDataViews( {
 			{
 				id: 'view_activity_not_wpcom',
 				label: translate( 'View activity' ),
-				isEligible( item: SiteData ) {
+				isEligible( item: SiteData ): boolean {
 					return canHaveActions( item ) && ! isAtomicSite( item ) && ! isUrlOnly( item );
 				},
 				callback( items: SiteData[] ) {
@@ -451,7 +451,7 @@ export function useSiteActionsDataViews( {
 			{
 				id: 'delete_site',
 				label: translate( 'Delete site' ),
-				isEligible( item: SiteData ) {
+				isEligible( item: SiteData ): boolean {
 					return canHaveActions( item ) && false; // Feature is always disabled, see canDelete above.
 				},
 				RenderModal: createDeleteSiteActionModal( {

--- a/client/declarations.d.ts
+++ b/client/declarations.d.ts
@@ -3,6 +3,8 @@ declare module '*.scss' {
 	export default content;
 }
 
+declare module '*.css';
+
 declare module 'browser-filesaver' {
 	export function saveAs( data: Blob, filename: string, disableAutoBOM?: boolean ): void;
 }

--- a/client/my-sites/domains/domain-management/domain-overview-pane/test/index.test.tsx
+++ b/client/my-sites/domains/domain-management/domain-overview-pane/test/index.test.tsx
@@ -31,7 +31,7 @@ window.IntersectionObserver = jest.fn( () => ( {
 	thresholds: [],
 	takeRecords: jest.fn(),
 	unobserve: jest.fn(),
-} ) );
+} ) ) as unknown as typeof IntersectionObserver;
 
 function createState( siteId = 1 ) {
 	return {

--- a/packages/agents-manager/src/style-imports.d.ts
+++ b/packages/agents-manager/src/style-imports.d.ts
@@ -1,0 +1,3 @@
+// Ambient declarations for side-effect style imports (TS6 requires these; see TS2882).
+declare module '*.scss';
+declare module '*.css';

--- a/packages/block-renderer/src/style-imports.d.ts
+++ b/packages/block-renderer/src/style-imports.d.ts
@@ -1,0 +1,3 @@
+// Ambient declarations for side-effect style imports (TS6 requires these; see TS2882).
+declare module '*.scss';
+declare module '*.css';

--- a/packages/components/src/style-imports.d.ts
+++ b/packages/components/src/style-imports.d.ts
@@ -1,0 +1,3 @@
+// Ambient declarations for side-effect style imports (TS6 requires these; see TS2882).
+declare module '*.scss';
+declare module '*.css';

--- a/packages/content-research/src/style-imports.d.ts
+++ b/packages/content-research/src/style-imports.d.ts
@@ -1,0 +1,3 @@
+// Ambient declarations for side-effect style imports (TS6 requires these; see TS2882).
+declare module '*.scss';
+declare module '*.css';

--- a/packages/design-picker/src/style-imports.d.ts
+++ b/packages/design-picker/src/style-imports.d.ts
@@ -1,0 +1,3 @@
+// Ambient declarations for side-effect style imports (TS6 requires these; see TS2882).
+declare module '*.scss';
+declare module '*.css';

--- a/packages/design-preview/src/style-imports.d.ts
+++ b/packages/design-preview/src/style-imports.d.ts
@@ -1,0 +1,3 @@
+// Ambient declarations for side-effect style imports (TS6 requires these; see TS2882).
+declare module '*.scss';
+declare module '*.css';

--- a/packages/domain-search/src/style-imports.d.ts
+++ b/packages/domain-search/src/style-imports.d.ts
@@ -1,0 +1,3 @@
+// Ambient declarations for side-effect style imports (TS6 requires these; see TS2882).
+declare module '*.scss';
+declare module '*.css';

--- a/packages/domains-table/src/style-imports.d.ts
+++ b/packages/domains-table/src/style-imports.d.ts
@@ -1,0 +1,3 @@
+// Ambient declarations for side-effect style imports (TS6 requires these; see TS2882).
+declare module '*.scss';
+declare module '*.css';

--- a/packages/global-styles/src/style-imports.d.ts
+++ b/packages/global-styles/src/style-imports.d.ts
@@ -1,0 +1,3 @@
+// Ambient declarations for side-effect style imports (TS6 requires these; see TS2882).
+declare module '*.scss';
+declare module '*.css';

--- a/packages/help-center/src/style-imports.d.ts
+++ b/packages/help-center/src/style-imports.d.ts
@@ -1,0 +1,3 @@
+// Ambient declarations for side-effect style imports (TS6 requires these; see TS2882).
+declare module '*.scss';
+declare module '*.css';

--- a/packages/image-studio/src/style-imports.d.ts
+++ b/packages/image-studio/src/style-imports.d.ts
@@ -1,0 +1,3 @@
+// Ambient declarations for side-effect style imports (TS6 requires these; see TS2882).
+declare module '*.scss';
+declare module '*.css';

--- a/packages/jest-circus-allure-reporter/.eslintrc.js
+++ b/packages/jest-circus-allure-reporter/.eslintrc.js
@@ -5,18 +5,6 @@ module.exports = {
 	rules: {
 		...nodeConfig.rules,
 
-		'require-jsdoc': [
-			'error',
-			{
-				require: {
-					FunctionDeclaration: true,
-					MethodDefinition: true,
-					ClassDeclaration: true,
-					ArrowFunctionExpression: false,
-					FunctionExpression: false,
-				},
-			},
-		],
 		'@typescript-eslint/no-unused-vars': [
 			'error',
 			{ argsIgnorePattern: '^_', ignoreRestSiblings: true },

--- a/packages/jetpack-ai-calypso/src/style-imports.d.ts
+++ b/packages/jetpack-ai-calypso/src/style-imports.d.ts
@@ -1,0 +1,3 @@
+// Ambient declarations for side-effect style imports (TS6 requires these; see TS2882).
+declare module '*.scss';
+declare module '*.css';

--- a/packages/jetpack-ai-sidebar/src/style-imports.d.ts
+++ b/packages/jetpack-ai-sidebar/src/style-imports.d.ts
@@ -1,0 +1,3 @@
+// Ambient declarations for side-effect style imports (TS6 requires these; see TS2882).
+declare module '*.scss';
+declare module '*.css';

--- a/packages/language-picker/src/style-imports.d.ts
+++ b/packages/language-picker/src/style-imports.d.ts
@@ -1,0 +1,3 @@
+// Ambient declarations for side-effect style imports (TS6 requires these; see TS2882).
+declare module '*.scss';
+declare module '*.css';

--- a/packages/launchpad/src/style-imports.d.ts
+++ b/packages/launchpad/src/style-imports.d.ts
@@ -1,0 +1,3 @@
+// Ambient declarations for side-effect style imports (TS6 requires these; see TS2882).
+declare module '*.scss';
+declare module '*.css';

--- a/packages/odie-client/src/style-imports.d.ts
+++ b/packages/odie-client/src/style-imports.d.ts
@@ -1,0 +1,3 @@
+// Ambient declarations for side-effect style imports (TS6 requires these; see TS2882).
+declare module '*.scss';
+declare module '*.css';

--- a/packages/omnibar/src/style-imports.d.ts
+++ b/packages/omnibar/src/style-imports.d.ts
@@ -1,0 +1,3 @@
+// Ambient declarations for side-effect style imports (TS6 requires these; see TS2882).
+declare module '*.scss';
+declare module '*.css';

--- a/packages/onboarding/src/style-imports.d.ts
+++ b/packages/onboarding/src/style-imports.d.ts
@@ -1,0 +1,3 @@
+// Ambient declarations for side-effect style imports (TS6 requires these; see TS2882).
+declare module '*.scss';
+declare module '*.css';

--- a/packages/plans-grid-next/src/style-imports.d.ts
+++ b/packages/plans-grid-next/src/style-imports.d.ts
@@ -1,0 +1,3 @@
+// Ambient declarations for side-effect style imports (TS6 requires these; see TS2882).
+declare module '*.scss';
+declare module '*.css';

--- a/packages/privacy-toolset/src/style-imports.d.ts
+++ b/packages/privacy-toolset/src/style-imports.d.ts
@@ -1,0 +1,3 @@
+// Ambient declarations for side-effect style imports (TS6 requires these; see TS2882).
+declare module '*.scss';
+declare module '*.css';

--- a/packages/search/src/style-imports.d.ts
+++ b/packages/search/src/style-imports.d.ts
@@ -1,0 +1,3 @@
+// Ambient declarations for side-effect style imports (TS6 requires these; see TS2882).
+declare module '*.scss';
+declare module '*.css';

--- a/packages/site-admin/src/style-imports.d.ts
+++ b/packages/site-admin/src/style-imports.d.ts
@@ -1,0 +1,3 @@
+// Ambient declarations for side-effect style imports (TS6 requires these; see TS2882).
+declare module '*.scss';
+declare module '*.css';

--- a/packages/subscriber/src/style-imports.d.ts
+++ b/packages/subscriber/src/style-imports.d.ts
@@ -1,0 +1,3 @@
+// Ambient declarations for side-effect style imports (TS6 requires these; see TS2882).
+declare module '*.scss';
+declare module '*.css';

--- a/packages/support-articles/src/style-imports.d.ts
+++ b/packages/support-articles/src/style-imports.d.ts
@@ -1,0 +1,3 @@
+// Ambient declarations for side-effect style imports (TS6 requires these; see TS2882).
+declare module '*.scss';
+declare module '*.css';

--- a/packages/verbum-block-editor/src/style-imports.d.ts
+++ b/packages/verbum-block-editor/src/style-imports.d.ts
@@ -1,0 +1,3 @@
+// Ambient declarations for side-effect style imports (TS6 requires these; see TS2882).
+declare module '*.scss';
+declare module '*.css';

--- a/packages/wpcom-template-parts/src/style-imports.d.ts
+++ b/packages/wpcom-template-parts/src/style-imports.d.ts
@@ -1,0 +1,3 @@
+// Ambient declarations for side-effect style imports (TS6 requires these; see TS2882).
+declare module '*.scss';
+declare module '*.css';

--- a/packages/zendesk-client/src/style-imports.d.ts
+++ b/packages/zendesk-client/src/style-imports.d.ts
@@ -1,0 +1,3 @@
+// Ambient declarations for side-effect style imports (TS6 requires these; see TS2882).
+declare module '*.scss';
+declare module '*.css';


### PR DESCRIPTION
Prep work for the TypeScript 6 upgrade (#111415), split out so that PR can shrink to essentially just the dependency bump.

## Proposed Changes

Forward-compatible groundwork. **Every change here is additive and harmless under the current TypeScript 5.9** — this PR makes no functional change, it just removes the friction TS6 would otherwise introduce:

- **Ambient `*.scss` / `*.css` module declarations** for side-effect style imports. TS5 allows these undeclared; TS6 errors (`TS2882`). Added a per-package `src/style-imports.d.ts` to every package that imports styles for side effects, plus `*.css` to `client/declarations.d.ts` (it already declared `*.scss`).
- **Two `isEligible` return-type annotations** in `use-site-actions.ts` so TS6's stricter inference doesn't fall into an implicit-any cycle (`TS7023`).
- **IntersectionObserver test-mock cast** to match the constructor type TS6 tightened (`TS2322`).
- **Dropped the `require-jsdoc` rule** from `jest-circus-allure-reporter/.eslintrc.js` — a core rule removed in ESLint 9 (already in use), which errors whenever that directory is linted.
- Removed a redundant `true &&` constant expression in `use-site-actions.ts` to keep the file lint-clean.

## Why are these changes being made?

So the Renovate `typescript@6` bump (#111415) can land as a near-trivial diff: just the version change plus an `ignoreDeprecations: "6.0"` flag in the two shared base tsconfigs. (That flag is the one change that can't live here — TS 5.9 rejects the value `error TS5103`, so it's coupled to the bump.)

The full set was validated end-to-end on top of the TS6 bump in a previous iteration of this branch — all CI checks passed there before this branch was rebased onto trunk to drop the bump.

## Testing Instructions

- `yarn typecheck-client`, `yarn typecheck-packages`, `yarn typecheck-apps` — all pass.
- Lint/format clean on all changed files.
- No runtime/behavioral change; no UI to test.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?

🤖 Generated with [Claude Code](https://claude.com/claude-code)