### PR TITLE
A4A: Prevent assigning of the domain for the development site

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/use-license-actions.ts
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/use-license-actions.ts
@@ -61,7 +61,7 @@ export default function useLicenseActions(
 				href: `https://wordpress.com/domains/manage/${ siteSlug }`,
 				onClick: () => handleClickMenuItem( 'calypso_a4a_licenses_change_domain_click' ),
 				isExternalLink: true,
-				isEnabled: true,
+				isEnabled: ! isDevSite,
 			},
 			{
 				name: translate( 'Hosting configuration' ),

--- a/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
+++ b/client/a8c-for-agencies/sections/sites/site-actions/use-site-actions.ts
@@ -102,7 +102,7 @@ export default function useSiteActions( {
 				href: `https://wordpress.com/domains/manage/${ blog_id }`,
 				onClick: () => handleClickMenuItem( 'change_domain' ),
 				isExternalLink: true,
-				isEnabled: isWPCOMSite && ! isUrlOnly,
+				isEnabled: isWPCOMSite && ! isUrlOnly && ! isDevSite,
 			},
 			{
 				name: translate( 'Hosting configuration' ),
@@ -300,7 +300,12 @@ export function useSiteActionsDataViews( {
 				label: translate( 'Change domain' ),
 				icon: external,
 				isEligible( item: SiteData ) {
-					return canHaveActions( item ) && isAtomicSite( item ) && ! isUrlOnly( item );
+					return (
+						canHaveActions( item ) &&
+						isAtomicSite( item ) &&
+						! isUrlOnly( item ) &&
+						! isDevSite( item )
+					);
 				},
 				callback( items: SiteData[] ) {
 					window.open( `https://wordpress.com/domains/manage/${ getBlogId( items[ 0 ] ) }` );

--- a/client/my-sites/controller.jsx
+++ b/client/my-sites/controller.jsx
@@ -69,6 +69,7 @@ import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import isDIFMLiteInProgress from 'calypso/state/selectors/is-difm-lite-in-progress';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
+import isSiteA4ADevSite from 'calypso/state/selectors/is-site-a4a-dev-site';
 import isSiteMigrationInProgress from 'calypso/state/selectors/is-site-migration-in-progress';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
@@ -795,6 +796,25 @@ export function stagingSiteNotSupportedRedirect( context, next ) {
 	const selectedSite = getSelectedSite( store.getState() );
 
 	if ( selectedSite && isSiteWpcomStaging( store.getState(), selectedSite.ID ) ) {
+		const siteSlug = getSiteSlug( store.getState(), selectedSite.ID );
+
+		return page.redirect( `/home/${ siteSlug }` );
+	}
+
+	next();
+}
+
+/**
+ * Use this middleware to prevent navigation to pages which are not supported by
+ * Automattic for Agencies dev sites.
+ * @param {Object} context -- Middleware context
+ * @param {Function} next -- Call next middleware in chain
+ */
+export function a4aDevSiteNotSupportedRedirect( context, next ) {
+	const store = context.store;
+	const selectedSite = getSelectedSite( store.getState() );
+
+	if ( selectedSite && isSiteA4ADevSite( store.getState(), selectedSite.ID ) ) {
 		const siteSlug = getSiteSlug( store.getState(), selectedSite.ID );
 
 		return page.redirect( `/home/${ siteSlug }` );

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -12,6 +12,7 @@ import {
 	sites,
 	wpForTeamsGeneralNotSupportedRedirect,
 	stagingSiteNotSupportedRedirect,
+	a4aDevSiteNotSupportedRedirect,
 	noSite,
 } from 'calypso/my-sites/controller';
 import getSelectedSiteSlug from 'calypso/state/ui/selectors/get-selected-site-slug';
@@ -64,6 +65,7 @@ function getCommonHandlers( {
 		navigation,
 		wpForTeamsGeneralNotSupportedRedirect,
 		stagingSiteNotSupportedRedirect,
+		a4aDevSiteNotSupportedRedirect,
 	];
 
 	if ( noSitePath ) {
@@ -108,6 +110,7 @@ export default function () {
 		],
 		handlers: [
 			stagingSiteNotSupportedRedirect,
+			a4aDevSiteNotSupportedRedirect,
 			domainManagementController.domainManagementEmailRedirect,
 		],
 	} );
@@ -296,6 +299,7 @@ export default function () {
 		domainsController.redirectToUseYourDomainIfVipSite(),
 		domainsController.jetpackNoDomainsWarning,
 		stagingSiteNotSupportedRedirect,
+		a4aDevSiteNotSupportedRedirect,
 		sites,
 		makeLayout,
 		clientRender
@@ -307,6 +311,7 @@ export default function () {
 		domainsController.domainsAddHeader,
 		domainsController.jetpackNoDomainsWarning,
 		stagingSiteNotSupportedRedirect,
+		a4aDevSiteNotSupportedRedirect,
 		sites,
 		makeLayout,
 		clientRender
@@ -318,6 +323,7 @@ export default function () {
 		domainsController.domainsAddHeader,
 		domainsController.jetpackNoDomainsWarning,
 		stagingSiteNotSupportedRedirect,
+		a4aDevSiteNotSupportedRedirect,
 		sites,
 		makeLayout,
 		clientRender
@@ -329,6 +335,7 @@ export default function () {
 		domainsController.domainsAddRedirectHeader,
 		domainsController.jetpackNoDomainsWarning,
 		stagingSiteNotSupportedRedirect,
+		a4aDevSiteNotSupportedRedirect,
 		sites,
 		makeLayout,
 		clientRender
@@ -342,6 +349,7 @@ export default function () {
 		domainsController.redirectToUseYourDomainIfVipSite(),
 		domainsController.jetpackNoDomainsWarning,
 		stagingSiteNotSupportedRedirect,
+		a4aDevSiteNotSupportedRedirect,
 		domainsController.domainSearch,
 		makeLayout,
 		clientRender
@@ -354,6 +362,7 @@ export default function () {
 		domainsController.redirectIfNoSite( '/domains/add' ),
 		domainsController.jetpackNoDomainsWarning,
 		stagingSiteNotSupportedRedirect,
+		a4aDevSiteNotSupportedRedirect,
 		domainsController.emailUpsellForDomainRegistration,
 		makeLayout,
 		clientRender
@@ -367,6 +376,7 @@ export default function () {
 		domainsController.redirectToUseYourDomainIfVipSite(),
 		domainsController.jetpackNoDomainsWarning,
 		stagingSiteNotSupportedRedirect,
+		a4aDevSiteNotSupportedRedirect,
 		domainsController.redirectToDomainSearchSuggestion
 	);
 
@@ -377,6 +387,7 @@ export default function () {
 		domainsController.redirectIfNoSite( '/domains/add/mapping' ),
 		domainsController.jetpackNoDomainsWarning,
 		stagingSiteNotSupportedRedirect,
+		a4aDevSiteNotSupportedRedirect,
 		domainsController.mapDomain,
 		makeLayout,
 		clientRender
@@ -392,6 +403,7 @@ export default function () {
 		navigation,
 		domainsController.jetpackNoDomainsWarning,
 		stagingSiteNotSupportedRedirect,
+		a4aDevSiteNotSupportedRedirect,
 		domainsController.mapDomainSetup,
 		makeLayout,
 		clientRender
@@ -404,6 +416,7 @@ export default function () {
 		domainsController.redirectIfNoSite( '/domains/add/site-redirect' ),
 		domainsController.jetpackNoDomainsWarning,
 		stagingSiteNotSupportedRedirect,
+		a4aDevSiteNotSupportedRedirect,
 		domainsController.siteRedirect,
 		makeLayout,
 		clientRender
@@ -416,6 +429,7 @@ export default function () {
 		domainsController.redirectIfNoSite( '/domains/add/transfer' ),
 		domainsController.jetpackNoDomainsWarning,
 		stagingSiteNotSupportedRedirect,
+		a4aDevSiteNotSupportedRedirect,
 		domainsController.transferDomain,
 		makeLayout,
 		clientRender
@@ -432,6 +446,7 @@ export default function () {
 		domainsController.redirectIfNoSite( '/domains/add' ),
 		domainsController.jetpackNoDomainsWarning,
 		stagingSiteNotSupportedRedirect,
+		a4aDevSiteNotSupportedRedirect,
 		domainsController.useMyDomain,
 		makeLayout,
 		clientRender
@@ -444,6 +459,7 @@ export default function () {
 		domainsController.redirectIfNoSite( '/domains/manage' ),
 		domainsController.jetpackNoDomainsWarning,
 		stagingSiteNotSupportedRedirect,
+		a4aDevSiteNotSupportedRedirect,
 		domainsController.transferDomainPrecheck,
 		makeLayout,
 		clientRender
@@ -456,6 +472,7 @@ export default function () {
 			( params ) => `/domains/${ params.domain }?back_to=site-domains`
 		),
 		stagingSiteNotSupportedRedirect,
+		a4aDevSiteNotSupportedRedirect,
 		domainsController.redirectDomainToSite,
 		makeLayout,
 		clientRender
@@ -467,6 +484,7 @@ export default function () {
 		navigation,
 		domainsController.jetpackNoDomainsWarning,
 		stagingSiteNotSupportedRedirect,
+		a4aDevSiteNotSupportedRedirect,
 		domainManagementController.domainManagementIndex,
 		makeLayout,
 		clientRender

--- a/client/my-sites/test/a4a-dev-site-redirect.js
+++ b/client/my-sites/test/a4a-dev-site-redirect.js
@@ -1,0 +1,66 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import page from '@automattic/calypso-router';
+import isSiteA4ADevSite from 'calypso/state/selectors/is-site-a4a-dev-site';
+import getSiteSlug from 'calypso/state/sites/selectors/get-site-slug';
+import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
+import { a4aDevSiteNotSupportedRedirect } from '../controller';
+
+// Mock the leaf selector modules; the barrels that `controller` imports from
+// re-export these defaults, so the barrel imports resolve to these mocks too.
+jest.mock( 'calypso/state/selectors/is-site-a4a-dev-site' );
+jest.mock( 'calypso/state/ui/selectors/get-selected-site' );
+jest.mock( 'calypso/state/sites/selectors/get-site-slug' );
+
+describe( 'a4aDevSiteNotSupportedRedirect', () => {
+	const context = { store: { getState: () => ( {} ) } };
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'redirects A4A dev sites to the site home', () => {
+		const redirect = jest.spyOn( page, 'redirect' ).mockImplementation( () => {} );
+		const next = jest.fn();
+		getSelectedSite.mockReturnValue( { ID: 12345 } );
+		isSiteA4ADevSite.mockReturnValue( true );
+		getSiteSlug.mockReturnValue( 'example.com' );
+
+		a4aDevSiteNotSupportedRedirect( context, next );
+
+		expect( redirect ).toHaveBeenCalledWith( '/home/example.com' );
+		expect( next ).not.toHaveBeenCalled();
+
+		redirect.mockRestore();
+	} );
+
+	it( 'does not redirect when the selected site is not an A4A dev site', () => {
+		const redirect = jest.spyOn( page, 'redirect' ).mockImplementation( () => {} );
+		const next = jest.fn();
+		getSelectedSite.mockReturnValue( { ID: 12345 } );
+		isSiteA4ADevSite.mockReturnValue( false );
+
+		a4aDevSiteNotSupportedRedirect( context, next );
+
+		expect( redirect ).not.toHaveBeenCalled();
+		expect( next ).toHaveBeenCalledTimes( 1 );
+
+		redirect.mockRestore();
+	} );
+
+	it( 'does not redirect when there is no selected site', () => {
+		const redirect = jest.spyOn( page, 'redirect' ).mockImplementation( () => {} );
+		const next = jest.fn();
+		getSelectedSite.mockReturnValue( null );
+
+		a4aDevSiteNotSupportedRedirect( context, next );
+
+		expect( redirect ).not.toHaveBeenCalled();
+		expect( isSiteA4ADevSite ).not.toHaveBeenCalled();
+		expect( next ).toHaveBeenCalledTimes( 1 );
+
+		redirect.mockRestore();
+	} );
+} );

--- a/client/state/selectors/is-site-a4a-dev-site.ts
+++ b/client/state/selectors/is-site-a4a-dev-site.ts
@@ -1,0 +1,16 @@
+import { AppState } from 'calypso/types';
+import getRawSite from './get-raw-site';
+
+/**
+ * Returns true if site is an Automattic for Agencies dev site, false otherwise.
+ * @param  {Object}   state  Global state tree
+ * @param  {number | null}   siteId Site ID
+ * @returns {boolean}        Whether site is an A4A dev site or not
+ */
+export default function isSiteA4ADevSite( state: AppState, siteId: number | null ) {
+	if ( ! siteId ) {
+		return false;
+	}
+	const site = getRawSite( state, siteId );
+	return site?.is_a4a_dev_site ?? false;
+}


### PR DESCRIPTION
Context:  p1780472442504429-slack-C0707KYCAN9
## Proposed Changes

The current flow allows agencies to purchase a domain for a development site. This PR ensures that users cannot access the domain flow for development sites, similar to staging sites.

This pull request introduces a new middleware to prevent navigation to unsupported pages for Automattic for Agencies (A4A) dev sites and integrates it throughout the domains section of the My Sites area. It also adds a selector to determine whether a site is an A4A dev site and includes comprehensive tests for the new middleware.

**A4A Dev Site Navigation Restriction:**

- Added a new middleware function `a4aDevSiteNotSupportedRedirect` in `client/my-sites/controller.jsx` to redirect users away from pages not supported for A4A dev sites, sending them to the site home if necessary.
- Integrated the new middleware into all relevant route handlers in `client/my-sites/domains/index.js` to ensure consistent navigation restrictions for A4A dev sites throughout the domains management flow. [[1]](diffhunk://#diff-b02f02f6f361998214bb1331bfef8c26879cb02d0bdd864163e9f153bbc0140bR68) [[2]](diffhunk://#diff-b02f02f6f361998214bb1331bfef8c26879cb02d0bdd864163e9f153bbc0140bR113) [[3]](diffhunk://#diff-b02f02f6f361998214bb1331bfef8c26879cb02d0bdd864163e9f153bbc0140bR302) [[4]](diffhunk://#diff-b02f02f6f361998214bb1331bfef8c26879cb02d0bdd864163e9f153bbc0140bR314) [[5]](diffhunk://#diff-b02f02f6f361998214bb1331bfef8c26879cb02d0bdd864163e9f153bbc0140bR326) [[6]](diffhunk://#diff-b02f02f6f361998214bb1331bfef8c26879cb02d0bdd864163e9f153bbc0140bR338) [[7]](diffhunk://#diff-b02f02f6f361998214bb1331bfef8c26879cb02d0bdd864163e9f153bbc0140bR352) [[8]](diffhunk://#diff-b02f02f6f361998214bb1331bfef8c26879cb02d0bdd864163e9f153bbc0140bR365) [[9]](diffhunk://#diff-b02f02f6f361998214bb1331bfef8c26879cb02d0bdd864163e9f153bbc0140bR379) [[10]](diffhunk://#diff-b02f02f6f361998214bb1331bfef8c26879cb02d0bdd864163e9f153bbc0140bR390) [[11]](diffhunk://#diff-b02f02f6f361998214bb1331bfef8c26879cb02d0bdd864163e9f153bbc0140bR406) [[12]](diffhunk://#diff-b02f02f6f361998214bb1331bfef8c26879cb02d0bdd864163e9f153bbc0140bR419) [[13]](diffhunk://#diff-b02f02f6f361998214bb1331bfef8c26879cb02d0bdd864163e9f153bbc0140bR432) [[14]](diffhunk://#diff-b02f02f6f361998214bb1331bfef8c26879cb02d0bdd864163e9f153bbc0140bR449) [[15]](diffhunk://#diff-b02f02f6f361998214bb1331bfef8c26879cb02d0bdd864163e9f153bbc0140bR462) [[16]](diffhunk://#diff-b02f02f6f361998214bb1331bfef8c26879cb02d0bdd864163e9f153bbc0140bR475) [[17]](diffhunk://#diff-b02f02f6f361998214bb1331bfef8c26879cb02d0bdd864163e9f153bbc0140bR487) [[18]](diffhunk://#diff-b02f02f6f361998214bb1331bfef8c26879cb02d0bdd864163e9f153bbc0140bR15)

**Selector and Utility Improvements:**

- Introduced a new selector `isSiteA4ADevSite` in `client/state/selectors/is-site-a4a-dev-site.ts` to determine if a site is an A4A dev site based on the site’s properties.
- Updated imports in `client/my-sites/controller.jsx` to use the new selector.

**Testing:**

- Added a dedicated Jest test file `client/my-sites/test/a4a-dev-site-redirect.js` to verify the correct redirect behavior of the new middleware under different scenarios.

## Why are these changes being made?

* Development sites should not be able to assign a domain; otherwise, this creates a loophole that allows users to keep the license on the development site while making the site publicly available.

## Testing Instructions

* Prepare a development site and note the blog ID.
* Use the WPCOM live link to navigate to `/domains/manage/{BLOG_ID}`.
* Confirm that you are redirected to the site's home page instead of the manage domains page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?