### PR TITLE
[DOTMSD-1265] Remove embedded empty-state border in dark mode

### DIFF
--- a/client/dashboard/app/_dark-theme.scss
+++ b/client/dashboard/app/_dark-theme.scss
@@ -233,7 +233,7 @@
 @mixin dashboard-dark-theme-dataviews {
 	@include color-scheme-dark-theme-dataviews;
 
-	.dataviews-no-results .components-surface.components-card.dashboard-empty-state__wrapper {
+	.dataviews-no-results .dashboard-empty-state__wrapper {
 		box-shadow: none;
 	}
 

--- a/client/dashboard/app/_dark-theme.scss
+++ b/client/dashboard/app/_dark-theme.scss
@@ -233,6 +233,10 @@
 @mixin dashboard-dark-theme-dataviews {
 	@include color-scheme-dark-theme-dataviews;
 
+	.dataviews-no-results .components-surface.components-card.dashboard-empty-state__wrapper {
+		box-shadow: none;
+	}
+
 	.dataviews-view-list__media-wrapper:has( .dashboard-backups__list-icon ) {
 		background-color: var( --wp-components-color-gray-200 );
 


### PR DESCRIPTION
Part of DOTMSD-1265

## Proposed Changes

* Remove the dark-mode card shadow from Dashboard empty-state cards only when they are embedded inside a DataViews no-results container.

## Why are these changes being made?

In dark mode, embedded DataViews empty states were showing a visible outline even though these empty states are rendered as borderless cards. The shared dark-mode card treatment reintroduces that outline through a card box shadow, which is useful for normal cards but wrong for the no-results empty state embedded inside a DataViews layout.

This keeps the shared dark card treatment intact for standalone cards, while clearing the shadow for the embedded no-results empty state so it matches the intended borderless light-mode presentation.

## Testing Instructions

* Visit `<site>/scan/active` and confirm the border is gone in dark mode.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
