### PR TITLE
Global Nav 2026: add Tracks events, fix dropdown height morph + hover

### DIFF
--- a/client/layout/use-nav-2026-props.ts
+++ b/client/layout/use-nav-2026-props.ts
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { useExperiment } from 'calypso/lib/explat';
 import { useSelector } from 'calypso/state';
 import {
 	getCurrentUser,
@@ -16,25 +17,53 @@ type Nav2026Props =
 	  }
 	| Record< string, never >;
 
+// ExPlat experiment driving the 2026 Global Nav A/B test. It's a single
+// `wpcom`-platform experiment (also serving the LOHP + Landpack PHP surfaces);
+// the wpcom assignments controller allowlists it so the /assignments/calypso
+// endpoint returns it here too, giving every surface consistent bucketing.
+// Keep in sync with the PHP constant WPCOM_Global_Nav_Helpers::NAV_2026_EXPERIMENT.
+const NAV_2026_EXPERIMENT = 'calypso_lossless_revert';
+
+const VARIATION_TO_VARIANT: Record< string, 1 | 2 > = {
+	treatment_1: 1,
+	treatment_2: 2,
+};
+
 /**
  * Props to spread onto `UniversalNavbarHeader` to opt into the 2026 Global Nav.
- * Returns `{}` when the flag is off, so `{ ...useNav2026Props() }` is a no-op then.
+ * Returns `{}` when the nav stays on the old design, so `{ ...useNav2026Props() }`
+ * is a no-op then.
+ *
+ * Resolution order:
+ * 1. `nav-redesign/2026` config flag — manual force-on for staff/dev. Variant
+ *    follows the existing `nav-redesign/2026-variant-2` flag.
+ * 2. The NAV_2026_EXPERIMENT assignment — `treatment_1`/`treatment_2` map to
+ *    variants 1/2; everything else (control, null, still loading) → old nav.
  */
 export function useNav2026Props(): Nav2026Props {
-	const nav2026 = config.isEnabled( 'nav-redesign/2026' );
+	const forcedOn = config.isEnabled( 'nav-redesign/2026' );
 	const userAvatar = useSelector( ( state ) => getCurrentUser( state )?.avatar_URL );
 	const userName = useSelector( getCurrentUserDisplayName );
 	const userEmail = useSelector( getCurrentUserEmail );
 
-	if ( ! nav2026 ) {
+	// Hooks must run unconditionally; the assignment is ignored when forced on.
+	const [ isLoadingExperiment, experimentAssignment ] = useExperiment( NAV_2026_EXPERIMENT, {
+		isEligible: ! forcedOn,
+	} );
+
+	// Resolve the variant: the config flag forces it on for staff/dev, otherwise
+	// the experiment assignment decides. Anything else (control, null, loading,
+	// unknown variation) leaves it undefined → old nav.
+	let variant: 1 | 2 | undefined;
+	if ( forcedOn ) {
+		variant = config.isEnabled( 'nav-redesign/2026-variant-2' ) ? 2 : 1;
+	} else if ( ! isLoadingExperiment && experimentAssignment?.variationName ) {
+		variant = VARIATION_TO_VARIANT[ experimentAssignment.variationName ];
+	}
+
+	if ( ! variant ) {
 		return {};
 	}
 
-	return {
-		nav2026: true,
-		nav2026Variant: config.isEnabled( 'nav-redesign/2026-variant-2' ) ? 2 : 1,
-		userAvatar,
-		userName,
-		userEmail,
-	};
+	return { nav2026: true, nav2026Variant: variant, userAvatar, userName, userEmail };
 }

--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -39,15 +39,6 @@ const EVENT_NAME_EXCEPTIONS = [
 	'wpcom_support_free_migration_request_click',
 	// Help Center Menu Panel
 	'wpcom_help_center_icon_interaction',
-	// Global Nav 2026 — names shared with the landpack arm so both feed one dataset.
-	'wpcom_global_nav_item_hover',
-	'wpcom_global_nav_submenu_show',
-	'wpcom_global_nav_submenu_hide',
-	'wpcom_global_nav_mobile_menu_open',
-	'wpcom_global_nav_mobile_menu_close',
-	'wpcom_global_nav_mobile_category_select',
-	'wpcom_global_nav_mobile_back',
-	'wpcom_global_nav_link_click',
 ];
 
 let _superProps: any; // Added to all Tracks events.

--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -39,6 +39,15 @@ const EVENT_NAME_EXCEPTIONS = [
 	'wpcom_support_free_migration_request_click',
 	// Help Center Menu Panel
 	'wpcom_help_center_icon_interaction',
+	// Global Nav 2026 — names shared with the landpack arm so both feed one dataset.
+	'wpcom_global_nav_item_hover',
+	'wpcom_global_nav_submenu_show',
+	'wpcom_global_nav_submenu_hide',
+	'wpcom_global_nav_mobile_menu_open',
+	'wpcom_global_nav_mobile_menu_close',
+	'wpcom_global_nav_mobile_category_select',
+	'wpcom_global_nav_mobile_back',
+	'wpcom_global_nav_link_click',
 ];
 
 let _superProps: any; // Added to all Tracks events.

--- a/packages/wpcom-template-parts/jest.config.js
+++ b/packages/wpcom-template-parts/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	preset: '../../test/packages/jest-preset.js',
+};

--- a/packages/wpcom-template-parts/src/types.ts
+++ b/packages/wpcom-template-parts/src/types.ts
@@ -53,6 +53,8 @@ export interface ClickableItemProps extends MenuItemProps {
 	tabIndex?: number;
 	/** Reading-order position, published as `--stagger-index` for the dropdown slide-in. */
 	index?: number;
+	/** Fires when the pointer enters the item's `<li>` (2026 nav hover tracking). */
+	onItemMouseEnter?: () => void;
 }
 
 export type LanguageOptions = Record< string, string >;

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -614,7 +614,11 @@ const UniversalNavbarHeader = ( {
 										<ClickableItem
 											className="x-nav-item x-nav-item__wide"
 											titleValue=""
-											content={ __( 'Log In', __i18n_text_domain__ ) }
+											content={
+												nav2026
+													? __( 'Log in', __i18n_text_domain__ )
+													: __( 'Log In', __i18n_text_domain__ )
+											}
 											urlValue={
 												loginUrl ||
 												localizeUrl( '//wordpress.com/log-in', locale, isLoggedIn, true )
@@ -626,7 +630,11 @@ const UniversalNavbarHeader = ( {
 										<ClickableItem
 											className="x-nav-item x-nav-item__wide"
 											titleValue=""
-											content={ __( 'Get started', __i18n_text_domain__ ) }
+											content={
+												nav2026
+													? __( 'Get started', __i18n_text_domain__ )
+													: __( 'Get Started', __i18n_text_domain__ )
+											}
 											urlValue={ startUrl }
 											type="nav"
 											typeClassName="x-nav-link x-nav-link__primary x-link cta-btn-nav"

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -208,6 +208,8 @@ const UniversalNavbarHeader = ( {
 					if ( open ) {
 						if ( nav2026 ) {
 							recordMobileMenuClose( isScrolledRef.current, 'escape' );
+						} else {
+							recordLegacyMobileMenuClose( 'escape' );
 						}
 						setCurrentDropdown( null );
 						menuTriggerRef.current?.focus();

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -139,7 +139,7 @@ const UniversalNavbarHeader = ( {
 		setMobileMenuOpen( true );
 	}, [ nav2026 ] );
 
-	// Legacy hamburger open/close, recording for the A/B control arm.
+	// Old-nav hamburger open/close, recording the usage events.
 	const openLegacyMobileMenu = useCallback( () => {
 		recordLegacyMobileMenuOpen();
 		setMobileMenuOpen( true );
@@ -177,10 +177,8 @@ const UniversalNavbarHeader = ( {
 		return () => clearTimeout( timer );
 	}, [ nav2026, isMobileMenuOpen ] );
 
-	// Legacy (control) arm: the 2026 hover/submenu events fire from React state,
-	// but the flag-off nav opens dropdowns via CSS `:hover`, so bind DOM listeners
-	// (like the landpack reference) to emit the same events with `is_2026: false`.
-	// Without this the A/B test's control arm has no engagement telemetry.
+	// The old nav fires its hover/submenu usage events via DOM listeners (it has no
+	// React state to hook); the new nav fires them from its handlers below.
 	useEffect( () => {
 		if ( nav2026 || ! legacyNavRef.current ) {
 			return;

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -626,7 +626,7 @@ const UniversalNavbarHeader = ( {
 										<ClickableItem
 											className="x-nav-item x-nav-item__wide"
 											titleValue=""
-											content={ __( 'Get Started', __i18n_text_domain__ ) }
+											content={ __( 'Get started', __i18n_text_domain__ ) }
 											urlValue={ startUrl }
 											type="nav"
 											typeClassName="x-nav-link x-nav-link__primary x-link cta-btn-nav"

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -67,12 +67,10 @@ const UniversalNavbarHeader = ( {
 
 	const mobilePlatform = useMobilePlatform( nav2026 );
 	const isScrolled = useScrollState( nav2026 );
-	// Mirror `isScrolled` into a ref so event callbacks (mobile open/close/category/
-	// back) can read the current value for the `is_floating` Tracks prop without
-	// re-subscribing on every scroll.
+	// Mirror `isScrolled` into a ref so event callbacks can read it for the
+	// `is_floating` Tracks prop without re-subscribing on every scroll.
 	const isScrolledRef = useRef( isScrolled );
 	isScrolledRef.current = isScrolled;
-	// Previous category, so a Back tracks event can report which one it left.
 	const prevDropdownRef = useRef< string | null >( null );
 	// The <nav> element, so the legacy arm can bind DOM-listener telemetry.
 	const legacyNavRef = useRef< HTMLElement >( null );
@@ -134,7 +132,6 @@ const UniversalNavbarHeader = ( {
 		}
 	}, [ nav2026, activeDropdown ] );
 
-	// Open the mobile menu (hamburger), recording it.
 	const openMobileMenu = useCallback( () => {
 		if ( nav2026 ) {
 			recordMobileMenuOpen( isScrolledRef.current );
@@ -142,7 +139,12 @@ const UniversalNavbarHeader = ( {
 		setMobileMenuOpen( true );
 	}, [ nav2026 ] );
 
-	// Legacy hamburger menu close, recording the reason for the A/B control arm.
+	// Legacy hamburger open/close, recording for the A/B control arm.
+	const openLegacyMobileMenu = useCallback( () => {
+		recordLegacyMobileMenuOpen();
+		setMobileMenuOpen( true );
+	}, [] );
+
 	const closeLegacyMobileMenu = useCallback( ( reason: string ) => {
 		recordLegacyMobileMenuClose( reason );
 		setMobileMenuOpen( false );
@@ -673,14 +675,7 @@ const UniversalNavbarHeader = ( {
 											aria-haspopup={ nav2026 ? 'dialog' : undefined }
 											aria-controls={ nav2026 ? 'x-mobile-menu-2026' : undefined }
 											aria-expanded={ isMobileMenuOpen }
-											onClick={
-												nav2026
-													? openMobileMenu
-													: () => {
-															recordLegacyMobileMenuOpen();
-															setMobileMenuOpen( true );
-													  }
-											}
+											onClick={ nav2026 ? openMobileMenu : openLegacyMobileMenu }
 										>
 											<span className="x-hidden">{ __( 'Menu', __i18n_text_domain__ ) }</span>
 											<span className="x-icon x-icon__menu">

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -28,6 +28,8 @@ import {
 	recordNavLinkClick,
 	resetNavHoverDedupe,
 	bindLegacyNavTracks,
+	recordLegacyMobileMenuOpen,
+	recordLegacyMobileMenuClose,
 } from './nav-2026/tracks';
 import './style.scss';
 
@@ -139,6 +141,12 @@ const UniversalNavbarHeader = ( {
 		}
 		setMobileMenuOpen( true );
 	}, [ nav2026 ] );
+
+	// Legacy hamburger menu close, recording the reason for the A/B control arm.
+	const closeLegacyMobileMenu = useCallback( ( reason: string ) => {
+		recordLegacyMobileMenuClose( reason );
+		setMobileMenuOpen( false );
+	}, [] );
 
 	// Mobile drill-down: select a category or go Back, recording either.
 	const selectMobileCategory = useCallback(
@@ -665,7 +673,14 @@ const UniversalNavbarHeader = ( {
 											aria-haspopup={ nav2026 ? 'dialog' : undefined }
 											aria-controls={ nav2026 ? 'x-mobile-menu-2026' : undefined }
 											aria-expanded={ isMobileMenuOpen }
-											onClick={ nav2026 ? openMobileMenu : () => setMobileMenuOpen( true ) }
+											onClick={
+												nav2026
+													? openMobileMenu
+													: () => {
+															recordLegacyMobileMenuOpen();
+															setMobileMenuOpen( true );
+													  }
+											}
 										>
 											<span className="x-hidden">{ __( 'Menu', __i18n_text_domain__ ) }</span>
 											<span className="x-icon x-icon__menu">
@@ -724,13 +739,13 @@ const UniversalNavbarHeader = ( {
 							{ /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */ }
 							<div
 								className="x-menu-overlay"
-								onKeyDown={ () => setMobileMenuOpen( false ) }
-								onClick={ () => setMobileMenuOpen( false ) }
+								onKeyDown={ () => closeLegacyMobileMenu( 'escape' ) }
+								onClick={ () => closeLegacyMobileMenu( 'overlay' ) }
 							/>
 							<div className="x-menu-content">
 								<button
 									className="x-menu-button x-link"
-									onClick={ () => setMobileMenuOpen( false ) }
+									onClick={ () => closeLegacyMobileMenu( 'close_button' ) }
 								>
 									<span className="x-hidden">
 										{ __( 'Close the navigation menu', __i18n_text_domain__ ) }

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -731,10 +731,10 @@ const UniversalNavbarHeader = ( {
 							aria-label={ __( 'WordPress.com Navigation Menu', __i18n_text_domain__ ) }
 							aria-hidden={ ! isMobileMenuOpen }
 						>
-							{ /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */ }
+							{ /* Click-outside scrim; Escape is handled by the document keydown listener above. */ }
+							{ /* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */ }
 							<div
 								className="x-menu-overlay"
-								onKeyDown={ () => closeLegacyMobileMenu( 'escape' ) }
 								onClick={ () => closeLegacyMobileMenu( 'overlay' ) }
 							/>
 							<div className="x-menu-content">

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -27,6 +27,7 @@ import {
 	recordMobileBack,
 	recordNavLinkClick,
 	resetNavHoverDedupe,
+	bindLegacyNavTracks,
 } from './nav-2026/tracks';
 import './style.scss';
 
@@ -71,6 +72,8 @@ const UniversalNavbarHeader = ( {
 	isScrolledRef.current = isScrolled;
 	// Previous category, so a Back tracks event can report which one it left.
 	const prevDropdownRef = useRef< string | null >( null );
+	// The <nav> element, so the legacy arm can bind DOM-listener telemetry.
+	const legacyNavRef = useRef< HTMLElement >( null );
 	useDropdownOffset( nav2026, nav2026Variant );
 	useFooterHeight( {
 		nav2026,
@@ -163,6 +166,17 @@ const UniversalNavbarHeader = ( {
 		const timer = setTimeout( () => setIsMenuOpening( false ), 1100 );
 		return () => clearTimeout( timer );
 	}, [ nav2026, isMobileMenuOpen ] );
+
+	// Legacy (control) arm: the 2026 hover/submenu events fire from React state,
+	// but the flag-off nav opens dropdowns via CSS `:hover`, so bind DOM listeners
+	// (like the landpack reference) to emit the same events with `is_2026: false`.
+	// Without this the A/B test's control arm has no engagement telemetry.
+	useEffect( () => {
+		if ( nav2026 || ! legacyNavRef.current ) {
+			return;
+		}
+		return bindLegacyNavTracks( legacyNavRef.current );
+	}, [ nav2026 ] );
 
 	// Escape closes whichever is open (desktop dropdown or mobile menu); hover/focus keeps one open.
 	useEffect( () => {
@@ -276,6 +290,7 @@ const UniversalNavbarHeader = ( {
 					<div className="masterbar-menu">
 						<div className="masterbar">
 							<nav
+								ref={ legacyNavRef }
 								className={ clsx( 'x-nav', { 'x-nav--2026-redesign': nav2026 } ) }
 								aria-label="WordPress.com"
 							>

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -4,7 +4,7 @@ import { useLocalizeUrl, useIsEnglishLocale, useLocale } from '@automattic/i18n-
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
 import clsx from 'clsx';
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { HeaderProps } from '../types';
 import { NonClickableItem, ClickableItem } from './menu-items';
 import { Nav2026DesktopDropdown } from './nav-2026/desktop-dropdown';
@@ -17,6 +17,17 @@ import {
 } from './nav-2026/hooks';
 import { Nav2026MobileMenu } from './nav-2026/mobile-menu';
 import { getNav2026Menus } from './nav-2026/taxonomy';
+import {
+	recordNavItemHover,
+	recordSubmenuShow,
+	recordSubmenuHide,
+	recordMobileMenuOpen,
+	recordMobileMenuClose,
+	recordMobileCategorySelect,
+	recordMobileBack,
+	recordNavLinkClick,
+	resetNavHoverDedupe,
+} from './nav-2026/tracks';
 import './style.scss';
 
 const UniversalNavbarHeader = ( {
@@ -53,6 +64,13 @@ const UniversalNavbarHeader = ( {
 
 	const mobilePlatform = useMobilePlatform( nav2026 );
 	const isScrolled = useScrollState( nav2026 );
+	// Mirror `isScrolled` into a ref so event callbacks (mobile open/close/category/
+	// back) can read the current value for the `is_floating` Tracks prop without
+	// re-subscribing on every scroll.
+	const isScrolledRef = useRef( isScrolled );
+	isScrolledRef.current = isScrolled;
+	// Previous category, so a Back tracks event can report which one it left.
+	const prevDropdownRef = useRef< string | null >( null );
 	useDropdownOffset( nav2026, nav2026Variant );
 	useFooterHeight( {
 		nav2026,
@@ -63,11 +81,77 @@ const UniversalNavbarHeader = ( {
 	} );
 	const dropdownRef = useDropdownFlip( { nav2026, activeDropdown } );
 
-	const closeMobileMenu = useCallback( () => {
-		setMobileMenuOpen( false );
-		setCurrentDropdown( null );
-		menuTriggerRef.current?.focus();
-	}, [] );
+	const nav2026Menus = useMemo(
+		() =>
+			nav2026
+				? getNav2026Menus( { __, localizeUrl, locale, isLoggedIn, variant: nav2026Variant } )
+				: [],
+		[ nav2026, __, localizeUrl, locale, isLoggedIn, nav2026Variant ]
+	);
+	const activeCategory = nav2026Menus.find( ( menu ) => menu.name === currentDropdown );
+
+	const closeMobileMenu = useCallback(
+		( reason = 'close_button' ) => {
+			setMobileMenuOpen( ( open ) => {
+				if ( open && nav2026 ) {
+					recordMobileMenuClose( isScrolledRef.current, reason );
+				}
+				return false;
+			} );
+			setCurrentDropdown( null );
+			menuTriggerRef.current?.focus();
+			// eslint-disable-next-line react-hooks/exhaustive-deps
+		},
+		[ nav2026 ]
+	);
+
+	// Desktop dropdown open/switch/close: emit submenu show for the newly-open
+	// menu and hide for the one it replaced. Driven by `activeDropdown` so it
+	// covers hover, focus, and keyboard dismiss uniformly.
+	useEffect( () => {
+		if ( ! nav2026 ) {
+			return;
+		}
+		const prev = prevDropdownRef.current;
+		const next = activeDropdown;
+		prevDropdownRef.current = next;
+		if ( prev === next ) {
+			return;
+		}
+		if ( prev ) {
+			recordSubmenuHide( isScrolledRef.current, prev );
+		}
+		if ( next ) {
+			recordSubmenuShow( isScrolledRef.current, next );
+		} else {
+			// Fully closed — let the next open of the same item re-emit a hover.
+			resetNavHoverDedupe();
+		}
+	}, [ nav2026, activeDropdown ] );
+
+	// Open the mobile menu (hamburger), recording it.
+	const openMobileMenu = useCallback( () => {
+		if ( nav2026 ) {
+			recordMobileMenuOpen( isScrolledRef.current );
+		}
+		setMobileMenuOpen( true );
+	}, [ nav2026 ] );
+
+	// Mobile drill-down: select a category or go Back, recording either.
+	const selectMobileCategory = useCallback(
+		( name: string | null ) => {
+			if ( nav2026 ) {
+				if ( name ) {
+					const title = nav2026Menus.find( ( menu ) => menu.name === name )?.title ?? '';
+					recordMobileCategorySelect( isScrolledRef.current, name, title );
+				} else {
+					recordMobileBack( isScrolledRef.current, currentDropdown );
+				}
+			}
+			setCurrentDropdown( name );
+		},
+		[ nav2026, currentDropdown, nav2026Menus ]
+	);
 
 	// `is-opening` while the panel slides in. 1100ms ≈ slide 340 + reveal 430 + fade 300.
 	useEffect( () => {
@@ -98,6 +182,9 @@ const UniversalNavbarHeader = ( {
 				// Mobile menu — return focus to the hamburger.
 				setMobileMenuOpen( ( open ) => {
 					if ( open ) {
+						if ( nav2026 ) {
+							recordMobileMenuClose( isScrolledRef.current, 'escape' );
+						}
 						setCurrentDropdown( null );
 						menuTriggerRef.current?.focus();
 					}
@@ -145,7 +232,7 @@ const UniversalNavbarHeader = ( {
 			document.removeEventListener( 'mouseenter', handleInteraction, true );
 			document.removeEventListener( 'keydown', handleKeyDown );
 		};
-	}, [] );
+	}, [ nav2026 ] );
 
 	if ( ! startUrl ) {
 		const startPaths: Record< string, string > = {
@@ -159,11 +246,6 @@ const UniversalNavbarHeader = ( {
 			sectionName ? { ref: sectionName + '-lp' } : {}
 		);
 	}
-
-	const nav2026Menus = nav2026
-		? getNav2026Menus( { __, localizeUrl, locale, isLoggedIn, variant: nav2026Variant } )
-		: [];
-	const activeCategory = nav2026Menus.find( ( menu ) => menu.name === currentDropdown );
 
 	return (
 		<div
@@ -198,12 +280,19 @@ const UniversalNavbarHeader = ( {
 								aria-label="WordPress.com"
 							>
 								<ul className="x-nav-list x-nav-list__left" role="menu">
-									<li className="x-nav-item" role="none">
+									<li
+										className="x-nav-item"
+										role="none"
+										onMouseEnter={
+											nav2026 ? () => recordNavItemHover( isScrolled, 'logo', false ) : undefined
+										}
+									>
 										<a
 											role="menuitem"
 											className="x-nav-link x-nav-link__logo x-link"
 											href={ localizeUrl( '//wordpress.com' ) }
 											target="_self"
+											onClick={ ( event ) => recordNavLinkClick( event.currentTarget ) }
 										>
 											<WordPressWordmark
 												className="x-icon x-icon__logo"
@@ -224,8 +313,14 @@ const UniversalNavbarHeader = ( {
 														className="x-nav-item x-nav-item__wide"
 														role="none"
 														key={ menu.name }
-														onMouseEnter={ () => setActiveDropdown( menu.name ) }
-														onFocus={ () => setActiveDropdown( menu.name ) }
+														onMouseEnter={ () => {
+															recordNavItemHover( isScrolled, menu.name, true );
+															setActiveDropdown( menu.name );
+														} }
+														onFocus={ () => {
+															recordNavItemHover( isScrolled, menu.name, true );
+															setActiveDropdown( menu.name );
+														} }
 													>
 														<NonClickableItem
 															className="x-nav-link x-link"
@@ -243,6 +338,9 @@ const UniversalNavbarHeader = ( {
 														urlValue={ menu.href }
 														type="nav"
 														target="_self"
+														onItemMouseEnter={ () =>
+															recordNavItemHover( isScrolled, menu.name, false )
+														}
 													/>
 												)
 											) }
@@ -544,7 +642,7 @@ const UniversalNavbarHeader = ( {
 											aria-haspopup={ nav2026 ? 'dialog' : undefined }
 											aria-controls={ nav2026 ? 'x-mobile-menu-2026' : undefined }
 											aria-expanded={ isMobileMenuOpen }
-											onClick={ () => setMobileMenuOpen( true ) }
+											onClick={ nav2026 ? openMobileMenu : () => setMobileMenuOpen( true ) }
 										>
 											<span className="x-hidden">{ __( 'Menu', __i18n_text_domain__ ) }</span>
 											<span className="x-icon x-icon__menu">
@@ -591,7 +689,7 @@ const UniversalNavbarHeader = ( {
 							mobilePlatform={ mobilePlatform }
 							mobileFooterRef={ mobileFooterRef }
 							closeMobileMenu={ closeMobileMenu }
-							setCurrentDropdown={ setCurrentDropdown }
+							setCurrentDropdown={ selectMobileCategory }
 						/>
 					) : (
 						<div

--- a/packages/wpcom-template-parts/src/universal-header-navigation/menu-items.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/menu-items.tsx
@@ -88,9 +88,8 @@ export const ClickableItem = ( {
 	const onClick = ( event: React.MouseEvent< HTMLAnchorElement > ) => {
 		const target = event.currentTarget;
 		clickNavLinkEvent( target );
-		// Also emit the shared `wpcom_global_nav_link_click` (the landpack arm
-		// fires the same event). It resolves `is_2026`/source from the DOM, so it
-		// reports correctly on both the legacy and 2026 navs.
+		// Also emit the global-nav usage event; it resolves its props from the DOM
+		// so it reports correctly on either nav.
 		recordNavLinkClick( target );
 	};
 	return (

--- a/packages/wpcom-template-parts/src/universal-header-navigation/menu-items.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/menu-items.tsx
@@ -1,5 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { ClickableItemProps, MenuItemProps } from '../types';
+import { recordNavLinkClick } from './nav-2026/tracks';
 
 export const NonClickableItem = ( {
 	content,
@@ -74,6 +75,7 @@ export const ClickableItem = ( {
 	target,
 	tabIndex,
 	index,
+	onItemMouseEnter,
 }: ClickableItemProps ) => {
 	let liClassName = '';
 	if ( type === 'menu' ) {
@@ -83,14 +85,19 @@ export const ClickableItem = ( {
 		liClassName = liClassName + ' ' + className;
 	}
 
-	const onClick = ( event: React.MouseEvent< HTMLElement > ) => {
+	const onClick = ( event: React.MouseEvent< HTMLAnchorElement > ) => {
 		const target = event.currentTarget;
 		clickNavLinkEvent( target );
+		// Also emit the shared `wpcom_global_nav_link_click` (the landpack arm
+		// fires the same event). It resolves `is_2026`/source from the DOM, so it
+		// reports correctly on both the legacy and 2026 navs.
+		recordNavLinkClick( target );
 	};
 	return (
 		<li
 			className={ liClassName }
 			role="none"
+			onMouseEnter={ onItemMouseEnter }
 			style={
 				index !== undefined ? ( { '--stagger-index': index } as React.CSSProperties ) : undefined
 			}

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/hooks.ts
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/hooks.ts
@@ -199,12 +199,11 @@ export function useDropdownFlip( {
 			return () => clearTimeout( timer );
 		}
 
-		// Open → closed: nothing to morph (but keep the last height for re-open).
+		// Open → closed: nothing to morph. Don't re-measure here — the panel content
+		// is already `aria-hidden` / out of flow, so `el.offsetHeight` reads 0; the
+		// cached resting height (stored on open / switch) is the one to keep.
 		if ( prev !== null && next === null ) {
 			el.classList.remove( 'is-dropdown-first-open' );
-			if ( prev ) {
-				heightByNameRef.current[ prev ] = el.offsetHeight;
-			}
 			return;
 		}
 

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/hooks.ts
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/hooks.ts
@@ -149,9 +149,17 @@ export function useDropdownFlip( {
 	activeDropdown,
 }: UseDropdownFlipArgs ): React.RefObject< HTMLDivElement > {
 	const dropdownRef = useRef< HTMLDivElement >( null );
-	// `prevDropdown` tells first-open from switch; `prevHeight` is the FLIP `from`.
+	// Tells first-open from switch.
 	const prevDropdownRef = useRef< string | null >( null );
-	const prevHeightRef = useRef< number >( 0 );
+	// Resting height of each panel, captured while it was the active block. The
+	// FLIP `from` must be the OUTGOING panel's height, but by the time this
+	// layout effect runs React has already swapped `aria-hidden`, so the wrapper
+	// already measures the INCOMING panel — reading the DOM for `from` always
+	// yields `to` (and the morph self-cancels as `from === to`). Keying the
+	// height by name and reading the previous name's stored value sidesteps that.
+	const heightByNameRef = useRef< Record< string, number > >( {} );
+	// Release callback for an in-flight morph, so a rapid re-switch can snap back first.
+	const releaseRef = useRef< ( () => void ) | null >( null );
 
 	useIsomorphicLayoutEffect( () => {
 		if ( ! nav2026 || typeof window === 'undefined' ) {
@@ -176,6 +184,9 @@ export function useDropdownFlip( {
 			return parseFloat( raw ) * 1000 || 280;
 		};
 
+		// Snap any in-flight morph back to `auto` before we measure, so reads are clean.
+		releaseRef.current?.();
+
 		// Closed → open: let CSS grow the panel; flag the unroll so items wait for it.
 		if ( prev === null && next !== null ) {
 			el.classList.add( 'is-dropdown-first-open' );
@@ -183,34 +194,39 @@ export function useDropdownFlip( {
 				() => el.classList.remove( 'is-dropdown-first-open' ),
 				morphMs() + 50
 			);
-			return () => {
-				clearTimeout( timer );
-				prevHeightRef.current = el.offsetHeight;
-			};
+			// Record the opened panel's resting height for a future switch's `from`.
+			heightByNameRef.current[ next ] = el.offsetHeight;
+			return () => clearTimeout( timer );
 		}
 
-		// Open → closed: nothing to morph.
+		// Open → closed: nothing to morph (but keep the last height for re-open).
 		if ( prev !== null && next === null ) {
 			el.classList.remove( 'is-dropdown-first-open' );
+			if ( prev ) {
+				heightByNameRef.current[ prev ] = el.offsetHeight;
+			}
 			return;
 		}
 
 		// Open → open: FLIP the wrapper height between the two menus.
 		if ( prev !== null && next !== null && prev !== next ) {
 			el.classList.remove( 'is-dropdown-first-open' );
-			// Reduced motion: snap instead of animate.
-			if ( window.matchMedia( '( prefers-reduced-motion: reduce )' ).matches ) {
-				return () => {
-					prevHeightRef.current = el.offsetHeight;
-				};
-			}
-			const from = prevHeightRef.current;
+			// `to` is live (DOM already shows `next`); `from` is the outgoing panel's
+			// stored height, falling back to a live read only if we never saw it.
 			const to = el.offsetHeight;
-			if ( ! from || from === to ) {
-				return () => {
-					prevHeightRef.current = el.offsetHeight;
-				};
+			const from = heightByNameRef.current[ prev ] ?? to;
+			// Keep the incoming panel's height fresh for the next switch.
+			heightByNameRef.current[ next ] = to;
+
+			// Reduced motion, equal heights, or no usable `from`: snap, don't animate.
+			if (
+				! from ||
+				from === to ||
+				window.matchMedia( '( prefers-reduced-motion: reduce )' ).matches
+			) {
+				return;
 			}
+
 			// Alias keeps `el`'s non-null narrowing inside the closures.
 			const node = el;
 			node.style.overflow = 'hidden';
@@ -230,7 +246,9 @@ export function useDropdownFlip( {
 				listenerAbort.abort();
 				node.style.height = '';
 				node.style.overflow = '';
+				releaseRef.current = null;
 			};
+			releaseRef.current = release;
 			node.addEventListener(
 				'transitionend',
 				( e: TransitionEvent ) => {
@@ -242,16 +260,10 @@ export function useDropdownFlip( {
 			);
 			const fallback = window.setTimeout( release, morphMs() + 50 );
 			return () => {
-				// `to` is the settled height — the next switch's `from`, no re-measure.
 				clearTimeout( fallback );
 				release();
-				prevHeightRef.current = to;
 			};
 		}
-
-		return () => {
-			prevHeightRef.current = el.offsetHeight;
-		};
 	}, [ nav2026, activeDropdown ] );
 
 	return dropdownRef;

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/hooks.ts
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/hooks.ts
@@ -151,12 +151,9 @@ export function useDropdownFlip( {
 	const dropdownRef = useRef< HTMLDivElement >( null );
 	// Tells first-open from switch.
 	const prevDropdownRef = useRef< string | null >( null );
-	// Resting height of each panel, captured while it was the active block. The
-	// FLIP `from` must be the OUTGOING panel's height, but by the time this
-	// layout effect runs React has already swapped `aria-hidden`, so the wrapper
-	// already measures the INCOMING panel — reading the DOM for `from` always
-	// yields `to` (and the morph self-cancels as `from === to`). Keying the
-	// height by name and reading the previous name's stored value sidesteps that.
+	// Each panel's resting height, keyed by name. By the time this effect runs the
+	// DOM already shows the incoming panel, so the outgoing height (the FLIP `from`)
+	// has to come from here, not a live measurement.
 	const heightByNameRef = useRef< Record< string, number > >( {} );
 	// Release callback for an in-flight morph, so a rapid re-switch can snap back first.
 	const releaseRef = useRef< ( () => void ) | null >( null );

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/mobile-menu.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/mobile-menu.tsx
@@ -36,7 +36,7 @@ interface Nav2026MobileMenuProps {
 	variant: 'default' | 'minimal';
 	mobilePlatform: 'ios' | 'android' | null;
 	mobileFooterRef: React.RefObject< HTMLDivElement >;
-	closeMobileMenu: () => void;
+	closeMobileMenu: ( reason?: string ) => void;
 	setCurrentDropdown: ( name: string | null ) => void;
 }
 
@@ -75,7 +75,11 @@ export function Nav2026MobileMenu( {
 			aria-hidden={ ! isMobileMenuOpen }
 		>
 			{ /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */ }
-			<div className="x-menu-overlay" onKeyDown={ closeMobileMenu } onClick={ closeMobileMenu } />
+			<div
+				className="x-menu-overlay"
+				onKeyDown={ () => closeMobileMenu( 'overlay' ) }
+				onClick={ () => closeMobileMenu( 'overlay' ) }
+			/>
 			<div className="x-menu-content">
 				<div className="x-menu-mobile-main">
 					{ /* Sticky header; inside the scroller so it stickies as the list scrolls. */ }
@@ -110,7 +114,7 @@ export function Nav2026MobileMenu( {
 							<button
 								type="button"
 								className="x-menu-button x-menu-mobile-close x-link"
-								onClick={ closeMobileMenu }
+								onClick={ () => closeMobileMenu( 'close_button' ) }
 								tabIndex={ mobileMenuTabIndex }
 							>
 								<span className="x-hidden">{ __( 'Close menu', __i18n_text_domain__ ) }</span>

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/test/tracks.ts
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/test/tracks.ts
@@ -1,0 +1,203 @@
+/**
+ * @jest-environment jsdom
+ */
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import {
+	recordNavItemHover,
+	recordSubmenuShow,
+	recordSubmenuHide,
+	recordMobileMenuOpen,
+	recordMobileMenuClose,
+	recordMobileCategorySelect,
+	recordMobileBack,
+	recordNavLinkClick,
+	resetNavHoverDedupe,
+} from '../tracks';
+
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	recordTracksEvent: jest.fn(),
+} ) );
+
+const mockRecord = recordTracksEvent as jest.MockedFunction< typeof recordTracksEvent >;
+
+describe( 'nav-2026 tracks', () => {
+	beforeEach( () => {
+		mockRecord.mockClear();
+		resetNavHoverDedupe();
+		document.body.innerHTML = '';
+	} );
+
+	describe( 'recordNavItemHover', () => {
+		it( 'fires item_hover with is_2026, is_floating, name, is_dropdown', () => {
+			recordNavItemHover( true, 'websites', true );
+			expect( mockRecord ).toHaveBeenCalledWith( 'wpcom_global_nav_item_hover', {
+				is_2026: true,
+				is_floating: true,
+				name: 'websites',
+				is_dropdown: true,
+			} );
+		} );
+
+		it( 'dedupes consecutive hovers of the same item', () => {
+			recordNavItemHover( false, 'hosting', true );
+			recordNavItemHover( false, 'hosting', true );
+			expect( mockRecord ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 're-fires after a different item, and after a dedupe reset', () => {
+			recordNavItemHover( false, 'hosting', true );
+			recordNavItemHover( false, 'domains', true );
+			expect( mockRecord ).toHaveBeenCalledTimes( 2 );
+
+			resetNavHoverDedupe();
+			recordNavItemHover( false, 'domains', true );
+			expect( mockRecord ).toHaveBeenCalledTimes( 3 );
+		} );
+	} );
+
+	describe( 'submenu show/hide', () => {
+		it( 'fires submenu_show with the name', () => {
+			recordSubmenuShow( false, 'resources' );
+			expect( mockRecord ).toHaveBeenCalledWith( 'wpcom_global_nav_submenu_show', {
+				is_2026: true,
+				is_floating: false,
+				name: 'resources',
+			} );
+		} );
+
+		it( 'fires submenu_hide with the name', () => {
+			recordSubmenuHide( true, 'resources' );
+			expect( mockRecord ).toHaveBeenCalledWith( 'wpcom_global_nav_submenu_hide', {
+				is_2026: true,
+				is_floating: true,
+				name: 'resources',
+			} );
+		} );
+	} );
+
+	describe( 'mobile menu open/close', () => {
+		it( 'fires mobile_menu_open with burger_menu start type + viewport width', () => {
+			recordMobileMenuOpen( false );
+			expect( mockRecord ).toHaveBeenCalledWith( 'wpcom_global_nav_mobile_menu_open', {
+				is_2026: true,
+				is_floating: false,
+				start_type: 'burger_menu',
+				viewport_width: window.innerWidth,
+			} );
+		} );
+
+		it( 'fires mobile_menu_close with the reason', () => {
+			recordMobileMenuClose( false, 'overlay' );
+			expect( mockRecord ).toHaveBeenCalledWith( 'wpcom_global_nav_mobile_menu_close', {
+				is_2026: true,
+				is_floating: false,
+				reason: 'overlay',
+				viewport_width: window.innerWidth,
+			} );
+		} );
+	} );
+
+	describe( 'mobile category/back', () => {
+		it( 'fires category_select with name + title', () => {
+			recordMobileCategorySelect( false, 'hosting', 'Hosting' );
+			expect( mockRecord ).toHaveBeenCalledWith( 'wpcom_global_nav_mobile_category_select', {
+				is_2026: true,
+				is_floating: false,
+				name: 'hosting',
+				title: 'Hosting',
+			} );
+		} );
+
+		it( 'fires back with from_name (nullable)', () => {
+			recordMobileBack( false, 'hosting' );
+			expect( mockRecord ).toHaveBeenCalledWith( 'wpcom_global_nav_mobile_back', {
+				is_2026: true,
+				is_floating: false,
+				from_name: 'hosting',
+			} );
+
+			mockRecord.mockClear();
+			recordMobileBack( false, null );
+			expect( mockRecord ).toHaveBeenCalledWith( 'wpcom_global_nav_mobile_back', {
+				is_2026: true,
+				is_floating: false,
+				from_name: null,
+			} );
+		} );
+	} );
+
+	describe( 'recordNavLinkClick', () => {
+		// Builds a detached DOM tree and returns the inner <a> so closest() works.
+		function linkIn( html: string ): HTMLAnchorElement {
+			const host = document.createElement( 'div' );
+			host.innerHTML = html;
+			document.body.appendChild( host );
+			return host.querySelector( 'a' ) as HTMLAnchorElement;
+		}
+
+		it( 'resolves a desktop-dropdown link to its category via data-dropdown-name', () => {
+			const link = linkIn(
+				`<div class="lpc-header-nav-container is-scrolled">
+					<div class="x-dropdown x-dropdown--2026">
+						<div class="x-dropdown-content" data-dropdown-name="hosting">
+							<a href="https://wordpress.com/hosting/">Managed hosting</a>
+						</div>
+					</div>
+				</div>`
+			);
+			recordNavLinkClick( link );
+			expect( mockRecord ).toHaveBeenCalledWith(
+				'wpcom_global_nav_link_click',
+				expect.objectContaining( {
+					is_2026: true,
+					is_floating: true,
+					source: 'desktop_dropdown',
+					category: 'hosting',
+					text: 'Managed hosting',
+				} )
+			);
+		} );
+
+		it( 'resolves a mobile-dropdown link to its category', () => {
+			const link = linkIn(
+				`<div class="x-menu x-menu--2026">
+					<ul class="x-menu-mobile-dropdown-list" data-dropdown-name="domains">
+						<li><a href="https://wordpress.com/domains/">Find a domain</a></li>
+					</ul>
+				</div>`
+			);
+			recordNavLinkClick( link );
+			expect( mockRecord ).toHaveBeenCalledWith(
+				'wpcom_global_nav_link_click',
+				expect.objectContaining( {
+					is_2026: true,
+					source: 'mobile_dropdown',
+					category: 'domains',
+				} )
+			);
+		} );
+
+		it( 'resolves the logo and a top-level link, and reports is_2026 false outside the 2026 nav', () => {
+			const logo = linkIn(
+				`<nav class="x-nav x-nav--2026-redesign">
+					<a class="x-nav-link x-nav-link__logo" href="https://wordpress.com">logo</a>
+				</nav>`
+			);
+			recordNavLinkClick( logo );
+			expect( mockRecord ).toHaveBeenCalledWith(
+				'wpcom_global_nav_link_click',
+				expect.objectContaining( { is_2026: true, source: 'logo', is_floating: false } )
+			);
+
+			mockRecord.mockClear();
+			const legacy = linkIn(
+				'<nav class="x-nav"><a href="https://wordpress.com/pricing/">Pricing</a></nav>'
+			);
+			recordNavLinkClick( legacy );
+			expect( mockRecord ).toHaveBeenCalledWith(
+				'wpcom_global_nav_link_click',
+				expect.objectContaining( { is_2026: false, source: 'top_level', category: null } )
+			);
+		} );
+	} );
+} );

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/test/tracks.ts
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/test/tracks.ts
@@ -30,7 +30,7 @@ describe( 'nav-2026 tracks', () => {
 	describe( 'recordNavItemHover', () => {
 		it( 'fires item_hover with is_2026, is_floating, name, is_dropdown', () => {
 			recordNavItemHover( true, 'websites', true );
-			expect( mockRecord ).toHaveBeenCalledWith( 'wpcom_global_nav_item_hover', {
+			expect( mockRecord ).toHaveBeenCalledWith( 'calypso_global_nav_item_hover', {
 				is_2026: true,
 				is_floating: true,
 				name: 'websites',
@@ -58,7 +58,7 @@ describe( 'nav-2026 tracks', () => {
 	describe( 'submenu show/hide', () => {
 		it( 'fires submenu_show with the name', () => {
 			recordSubmenuShow( false, 'resources' );
-			expect( mockRecord ).toHaveBeenCalledWith( 'wpcom_global_nav_submenu_show', {
+			expect( mockRecord ).toHaveBeenCalledWith( 'calypso_global_nav_submenu_show', {
 				is_2026: true,
 				is_floating: false,
 				name: 'resources',
@@ -67,7 +67,7 @@ describe( 'nav-2026 tracks', () => {
 
 		it( 'fires submenu_hide with the name', () => {
 			recordSubmenuHide( true, 'resources' );
-			expect( mockRecord ).toHaveBeenCalledWith( 'wpcom_global_nav_submenu_hide', {
+			expect( mockRecord ).toHaveBeenCalledWith( 'calypso_global_nav_submenu_hide', {
 				is_2026: true,
 				is_floating: true,
 				name: 'resources',
@@ -78,7 +78,7 @@ describe( 'nav-2026 tracks', () => {
 	describe( 'mobile menu open/close', () => {
 		it( 'fires mobile_menu_open with burger_menu start type + viewport width', () => {
 			recordMobileMenuOpen( false );
-			expect( mockRecord ).toHaveBeenCalledWith( 'wpcom_global_nav_mobile_menu_open', {
+			expect( mockRecord ).toHaveBeenCalledWith( 'calypso_global_nav_mobile_menu_open', {
 				is_2026: true,
 				is_floating: false,
 				start_type: 'burger_menu',
@@ -88,7 +88,7 @@ describe( 'nav-2026 tracks', () => {
 
 		it( 'fires mobile_menu_close with the reason', () => {
 			recordMobileMenuClose( false, 'overlay' );
-			expect( mockRecord ).toHaveBeenCalledWith( 'wpcom_global_nav_mobile_menu_close', {
+			expect( mockRecord ).toHaveBeenCalledWith( 'calypso_global_nav_mobile_menu_close', {
 				is_2026: true,
 				is_floating: false,
 				reason: 'overlay',
@@ -100,7 +100,7 @@ describe( 'nav-2026 tracks', () => {
 	describe( 'mobile category/back', () => {
 		it( 'fires category_select with name + title', () => {
 			recordMobileCategorySelect( false, 'hosting', 'Hosting' );
-			expect( mockRecord ).toHaveBeenCalledWith( 'wpcom_global_nav_mobile_category_select', {
+			expect( mockRecord ).toHaveBeenCalledWith( 'calypso_global_nav_mobile_category_select', {
 				is_2026: true,
 				is_floating: false,
 				name: 'hosting',
@@ -110,7 +110,7 @@ describe( 'nav-2026 tracks', () => {
 
 		it( 'fires back with from_name (nullable)', () => {
 			recordMobileBack( false, 'hosting' );
-			expect( mockRecord ).toHaveBeenCalledWith( 'wpcom_global_nav_mobile_back', {
+			expect( mockRecord ).toHaveBeenCalledWith( 'calypso_global_nav_mobile_back', {
 				is_2026: true,
 				is_floating: false,
 				from_name: 'hosting',
@@ -118,7 +118,7 @@ describe( 'nav-2026 tracks', () => {
 
 			mockRecord.mockClear();
 			recordMobileBack( false, null );
-			expect( mockRecord ).toHaveBeenCalledWith( 'wpcom_global_nav_mobile_back', {
+			expect( mockRecord ).toHaveBeenCalledWith( 'calypso_global_nav_mobile_back', {
 				is_2026: true,
 				is_floating: false,
 				from_name: null,
@@ -147,7 +147,7 @@ describe( 'nav-2026 tracks', () => {
 			);
 			recordNavLinkClick( link );
 			expect( mockRecord ).toHaveBeenCalledWith(
-				'wpcom_global_nav_link_click',
+				'calypso_global_nav_link_click',
 				expect.objectContaining( {
 					is_2026: true,
 					is_floating: true,
@@ -168,7 +168,7 @@ describe( 'nav-2026 tracks', () => {
 			);
 			recordNavLinkClick( link );
 			expect( mockRecord ).toHaveBeenCalledWith(
-				'wpcom_global_nav_link_click',
+				'calypso_global_nav_link_click',
 				expect.objectContaining( {
 					is_2026: true,
 					source: 'mobile_dropdown',
@@ -185,7 +185,7 @@ describe( 'nav-2026 tracks', () => {
 			);
 			recordNavLinkClick( logo );
 			expect( mockRecord ).toHaveBeenCalledWith(
-				'wpcom_global_nav_link_click',
+				'calypso_global_nav_link_click',
 				expect.objectContaining( { is_2026: true, source: 'logo', is_floating: false } )
 			);
 
@@ -195,7 +195,7 @@ describe( 'nav-2026 tracks', () => {
 			);
 			recordNavLinkClick( legacy );
 			expect( mockRecord ).toHaveBeenCalledWith(
-				'wpcom_global_nav_link_click',
+				'calypso_global_nav_link_click',
 				expect.objectContaining( { is_2026: false, source: 'top_level', category: null } )
 			);
 		} );

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/tracks.ts
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/tracks.ts
@@ -1,15 +1,8 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 
 /*
- * `wpcom_global_nav_*` Tracks events for the 2026 Global Nav. These match the
- * landpack reference (`wp-content/plugins/landpack/src/client/nav/tracks.js`)
- * name-for-name and prop-for-prop, so the React (Calypso) and PHP (landpack)
- * arms of the redesign A/B test feed one unified Tracks dataset. The reference
- * is DOM-event driven; here we fire straight from the React handlers/state.
- *
- * `recordTracksEvent` only emits names prefixed with a known source unless
- * they're listed in `EVENT_NAME_EXCEPTIONS` (packages/calypso-analytics);
- * each `wpcom_global_nav_*` name below is registered there.
+ * `calypso_global_nav_*` Tracks events that measure how people use the global
+ * nav. `is_2026` tags which nav design fired the event so the two can be compared.
  */
 
 type TracksProps = Record< string, string | number | boolean | null | undefined >;
@@ -30,26 +23,26 @@ export function recordNavItemHover( isFloating: boolean, name: string, isDropdow
 		return;
 	}
 	lastHoverName = name;
-	record( 'wpcom_global_nav_item_hover', isFloating, { name, is_dropdown: isDropdown } );
+	record( 'calypso_global_nav_item_hover', isFloating, { name, is_dropdown: isDropdown } );
 }
 
 export function recordSubmenuShow( isFloating: boolean, name: string ): void {
-	record( 'wpcom_global_nav_submenu_show', isFloating, { name } );
+	record( 'calypso_global_nav_submenu_show', isFloating, { name } );
 }
 
 export function recordSubmenuHide( isFloating: boolean, name: string ): void {
-	record( 'wpcom_global_nav_submenu_hide', isFloating, { name } );
+	record( 'calypso_global_nav_submenu_hide', isFloating, { name } );
 }
 
 export function recordMobileMenuOpen( isFloating: boolean ): void {
-	record( 'wpcom_global_nav_mobile_menu_open', isFloating, {
+	record( 'calypso_global_nav_mobile_menu_open', isFloating, {
 		start_type: 'burger_menu',
 		viewport_width: typeof window !== 'undefined' ? window.innerWidth : 0,
 	} );
 }
 
 export function recordMobileMenuClose( isFloating: boolean, reason: string ): void {
-	record( 'wpcom_global_nav_mobile_menu_close', isFloating, {
+	record( 'calypso_global_nav_mobile_menu_close', isFloating, {
 		reason,
 		viewport_width: typeof window !== 'undefined' ? window.innerWidth : 0,
 	} );
@@ -60,11 +53,11 @@ export function recordMobileCategorySelect(
 	name: string,
 	title: string
 ): void {
-	record( 'wpcom_global_nav_mobile_category_select', isFloating, { name, title } );
+	record( 'calypso_global_nav_mobile_category_select', isFloating, { name, title } );
 }
 
 export function recordMobileBack( isFloating: boolean, fromName: string | null ): void {
-	record( 'wpcom_global_nav_mobile_back', isFloating, { from_name: fromName } );
+	record( 'calypso_global_nav_mobile_back', isFloating, { from_name: fromName } );
 }
 
 interface ResolvedLink {
@@ -73,7 +66,6 @@ interface ResolvedLink {
 }
 
 // Resolve which part of the nav a clicked link came from, for the click event.
-// Mirrors `resolveLink()` in the landpack reference.
 function resolveLink( link: HTMLElement ): ResolvedLink {
 	const mobileList = link.closest< HTMLElement >( '.x-menu-mobile-dropdown-list' );
 	if ( mobileList ) {
@@ -97,14 +89,12 @@ function resolveLink( link: HTMLElement ): ResolvedLink {
 }
 
 export function recordNavLinkClick( link: HTMLAnchorElement ): void {
-	// Resolve `is_2026`/`is_floating` from the DOM (not React state) so this works
-	// from a plain click handler and matches the landpack reference, which fires
-	// for both the legacy and 2026 navs with `is_2026` telling them apart.
+	// Resolve from the DOM so this works from a plain click handler on either nav.
 	const is2026 = !! link.closest( '.x-nav--2026-redesign, .x-dropdown--2026, .x-menu--2026' );
 	const isFloating = !! link.closest( '.lpc-header-nav-container.is-scrolled' );
 	const { source, category } = resolveLink( link );
 
-	recordTracksEvent( 'wpcom_global_nav_link_click', {
+	recordTracksEvent( 'calypso_global_nav_link_click', {
 		is_2026: is2026,
 		is_floating: isFloating,
 		href: link.href,
@@ -115,34 +105,29 @@ export function recordNavLinkClick( link: HTMLAnchorElement ): void {
 	} );
 }
 
-/*
- * Legacy (flag-off) nav telemetry for the A/B control arm — the same events with
- * `is_2026: false`. `is_floating` falls back to `scrollY` (the legacy nav has no
- * `is-scrolled` class), matching the reference's `isFloating()`.
- */
+// The same events for the old nav (`is_2026: false`), so both designs are
+// measured. `is_floating` comes from `scrollY` since the old nav has no scrolled class.
 function recordLegacy( name: string, props: TracksProps = {} ): void {
 	const isFloating = typeof window !== 'undefined' && window.scrollY > 0;
 	recordTracksEvent( name, { is_2026: false, is_floating: isFloating, ...props } );
 }
 
 export function recordLegacyMobileMenuOpen(): void {
-	recordLegacy( 'wpcom_global_nav_mobile_menu_open', {
+	recordLegacy( 'calypso_global_nav_mobile_menu_open', {
 		start_type: 'burger_menu',
 		viewport_width: typeof window !== 'undefined' ? window.innerWidth : 0,
 	} );
 }
 
 export function recordLegacyMobileMenuClose( reason: string ): void {
-	recordLegacy( 'wpcom_global_nav_mobile_menu_close', {
+	recordLegacy( 'calypso_global_nav_mobile_menu_close', {
 		reason,
 		viewport_width: typeof window !== 'undefined' ? window.innerWidth : 0,
 	} );
 }
 
-// The legacy nav opens dropdowns via CSS `:hover` (no React state to tap), so —
-// like the reference's `tracks.js` — bind DOM listeners for the hover/submenu
-// events. Returns a cleanup. (The legacy mobile menu IS React-state driven, so
-// its open/close fire from the handlers above, not here.)
+// The old nav opens dropdowns via CSS `:hover` with no React state to tap, so
+// bind DOM listeners to capture its hover/submenu events. Returns a cleanup.
 export function bindLegacyNavTracks( nav: HTMLElement ): () => void {
 	const cleanups: Array< () => void > = [];
 	let legacyLastHover: string | null = null;
@@ -162,7 +147,7 @@ export function bindLegacyNavTracks( nav: HTMLElement ): () => void {
 					return;
 				}
 				legacyLastHover = name;
-				recordLegacy( 'wpcom_global_nav_item_hover', { name, is_dropdown: false } );
+				recordLegacy( 'calypso_global_nav_item_hover', { name, is_dropdown: false } );
 			};
 			item.addEventListener( 'mouseenter', onEnter );
 			cleanups.push( () => item.removeEventListener( 'mouseenter', onEnter ) );
@@ -173,13 +158,13 @@ export function bindLegacyNavTracks( nav: HTMLElement ): () => void {
 		const onEnter = () => {
 			if ( name && name !== legacyLastHover ) {
 				legacyLastHover = name;
-				recordLegacy( 'wpcom_global_nav_item_hover', { name, is_dropdown: true } );
+				recordLegacy( 'calypso_global_nav_item_hover', { name, is_dropdown: true } );
 			}
 			openSubmenu = name;
-			recordLegacy( 'wpcom_global_nav_submenu_show', { name } );
+			recordLegacy( 'calypso_global_nav_submenu_show', { name } );
 		};
 		const onLeave = () => {
-			recordLegacy( 'wpcom_global_nav_submenu_hide', { name: openSubmenu } );
+			recordLegacy( 'calypso_global_nav_submenu_hide', { name: openSubmenu } );
 			openSubmenu = null;
 			legacyLastHover = null;
 		};
@@ -197,7 +182,7 @@ export function bindLegacyNavTracks( nav: HTMLElement ): () => void {
 		const onLogo = () => {
 			if ( legacyLastHover !== 'logo' ) {
 				legacyLastHover = 'logo';
-				recordLegacy( 'wpcom_global_nav_item_hover', { name: 'logo', is_dropdown: false } );
+				recordLegacy( 'calypso_global_nav_item_hover', { name: 'logo', is_dropdown: false } );
 			}
 		};
 		logo.addEventListener( 'mouseenter', onLogo );

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/tracks.ts
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/tracks.ts
@@ -17,7 +17,6 @@ type TracksProps = Record< string, string | number | boolean | null | undefined 
 // Dedupe so re-entering the same item doesn't emit duplicate hovers.
 let lastHoverName: string | null = null;
 
-// Reset between submenu opens so re-opening the same item hovers again.
 export function resetNavHoverDedupe(): void {
 	lastHoverName = null;
 }
@@ -40,103 +39,6 @@ export function recordSubmenuShow( isFloating: boolean, name: string ): void {
 
 export function recordSubmenuHide( isFloating: boolean, name: string ): void {
 	record( 'wpcom_global_nav_submenu_hide', isFloating, { name } );
-}
-
-/*
- * Legacy (flag-off) nav telemetry. The 2026 events above fire from the React
- * handlers and hardcode `is_2026: true`. The control arm of the A/B test needs
- * the SAME engagement events with `is_2026: false`, but the legacy nav opens its
- * dropdowns via CSS `:hover` (no React state to tap), so — like the landpack
- * reference's `tracks.js` — we bind DOM listeners. `bindLegacyNavTracks` attaches
- * them and returns a cleanup. `is_floating` falls back to `scrollY` (the legacy
- * nav has no `is-scrolled` class), matching the reference's `isFloating()`.
- */
-function recordLegacy( name: string, props: TracksProps = {} ): void {
-	const isFloating = typeof window !== 'undefined' && window.scrollY > 0;
-	recordTracksEvent( name, { is_2026: false, is_floating: isFloating, ...props } );
-}
-
-// Legacy mobile (hamburger) menu open/close. The legacy menu is React-state
-// driven (`setMobileMenuOpen`), so unlike the desktop hover events these fire
-// straight from the handlers rather than via DOM listeners. The reference's
-// legacy menu has no drill-down, so only open/close (no category/back).
-export function recordLegacyMobileMenuOpen(): void {
-	recordLegacy( 'wpcom_global_nav_mobile_menu_open', {
-		start_type: 'burger_menu',
-		viewport_width: typeof window !== 'undefined' ? window.innerWidth : 0,
-	} );
-}
-
-export function recordLegacyMobileMenuClose( reason: string ): void {
-	recordLegacy( 'wpcom_global_nav_mobile_menu_close', {
-		reason,
-		viewport_width: typeof window !== 'undefined' ? window.innerWidth : 0,
-	} );
-}
-
-export function bindLegacyNavTracks( nav: HTMLElement ): () => void {
-	const cleanups: Array< () => void > = [];
-	let legacyLastHover: string | null = null;
-	let openSubmenu: string | null = null;
-
-	// Dropdown items: `<li.x-nav-item__wide>` holding a `.x-dropdown-content[data-dropdown-name]`.
-	nav.querySelectorAll< HTMLElement >( '.x-nav-item__wide' ).forEach( ( item ) => {
-		const content = item.querySelector< HTMLElement >( '.x-dropdown-content[data-dropdown-name]' );
-		if ( ! content ) {
-			// Non-dropdown wide item (Support, Pricing, Log In, Get Started): hover only.
-			const link = item.querySelector< HTMLElement >( '.x-nav-link' );
-			if ( ! link ) {
-				return;
-			}
-			const name = ( link.textContent || '' ).trim();
-			const onEnter = () => {
-				if ( ! name || name === legacyLastHover ) {
-					return;
-				}
-				legacyLastHover = name;
-				recordLegacy( 'wpcom_global_nav_item_hover', { name, is_dropdown: false } );
-			};
-			item.addEventListener( 'mouseenter', onEnter );
-			cleanups.push( () => item.removeEventListener( 'mouseenter', onEnter ) );
-			return;
-		}
-
-		const name = content.dataset.dropdownName || '';
-		const onEnter = () => {
-			if ( name && name !== legacyLastHover ) {
-				legacyLastHover = name;
-				recordLegacy( 'wpcom_global_nav_item_hover', { name, is_dropdown: true } );
-			}
-			openSubmenu = name;
-			recordLegacy( 'wpcom_global_nav_submenu_show', { name } );
-		};
-		const onLeave = () => {
-			recordLegacy( 'wpcom_global_nav_submenu_hide', { name: openSubmenu } );
-			openSubmenu = null;
-			legacyLastHover = null;
-		};
-		item.addEventListener( 'mouseenter', onEnter );
-		item.addEventListener( 'mouseleave', onLeave );
-		cleanups.push( () => {
-			item.removeEventListener( 'mouseenter', onEnter );
-			item.removeEventListener( 'mouseleave', onLeave );
-		} );
-	} );
-
-	// Logo hover (no text → name it explicitly).
-	const logo = nav.querySelector< HTMLElement >( '.x-nav-link__logo' );
-	if ( logo ) {
-		const onLogo = () => {
-			if ( legacyLastHover !== 'logo' ) {
-				legacyLastHover = 'logo';
-				recordLegacy( 'wpcom_global_nav_item_hover', { name: 'logo', is_dropdown: false } );
-			}
-		};
-		logo.addEventListener( 'mouseenter', onLogo );
-		cleanups.push( () => logo.removeEventListener( 'mouseenter', onLogo ) );
-	}
-
-	return () => cleanups.forEach( ( fn ) => fn() );
 }
 
 export function recordMobileMenuOpen( isFloating: boolean ): void {
@@ -211,4 +113,96 @@ export function recordNavLinkClick( link: HTMLAnchorElement ): void {
 		source,
 		category,
 	} );
+}
+
+/*
+ * Legacy (flag-off) nav telemetry for the A/B control arm — the same events with
+ * `is_2026: false`. `is_floating` falls back to `scrollY` (the legacy nav has no
+ * `is-scrolled` class), matching the reference's `isFloating()`.
+ */
+function recordLegacy( name: string, props: TracksProps = {} ): void {
+	const isFloating = typeof window !== 'undefined' && window.scrollY > 0;
+	recordTracksEvent( name, { is_2026: false, is_floating: isFloating, ...props } );
+}
+
+export function recordLegacyMobileMenuOpen(): void {
+	recordLegacy( 'wpcom_global_nav_mobile_menu_open', {
+		start_type: 'burger_menu',
+		viewport_width: typeof window !== 'undefined' ? window.innerWidth : 0,
+	} );
+}
+
+export function recordLegacyMobileMenuClose( reason: string ): void {
+	recordLegacy( 'wpcom_global_nav_mobile_menu_close', {
+		reason,
+		viewport_width: typeof window !== 'undefined' ? window.innerWidth : 0,
+	} );
+}
+
+// The legacy nav opens dropdowns via CSS `:hover` (no React state to tap), so —
+// like the reference's `tracks.js` — bind DOM listeners for the hover/submenu
+// events. Returns a cleanup. (The legacy mobile menu IS React-state driven, so
+// its open/close fire from the handlers above, not here.)
+export function bindLegacyNavTracks( nav: HTMLElement ): () => void {
+	const cleanups: Array< () => void > = [];
+	let legacyLastHover: string | null = null;
+	let openSubmenu: string | null = null;
+
+	nav.querySelectorAll< HTMLElement >( '.x-nav-item__wide' ).forEach( ( item ) => {
+		const content = item.querySelector< HTMLElement >( '.x-dropdown-content[data-dropdown-name]' );
+		if ( ! content ) {
+			// Non-dropdown wide item (Support, Pricing, Log In, Get Started): hover only.
+			const link = item.querySelector< HTMLElement >( '.x-nav-link' );
+			if ( ! link ) {
+				return;
+			}
+			const name = ( link.textContent || '' ).trim();
+			const onEnter = () => {
+				if ( ! name || name === legacyLastHover ) {
+					return;
+				}
+				legacyLastHover = name;
+				recordLegacy( 'wpcom_global_nav_item_hover', { name, is_dropdown: false } );
+			};
+			item.addEventListener( 'mouseenter', onEnter );
+			cleanups.push( () => item.removeEventListener( 'mouseenter', onEnter ) );
+			return;
+		}
+
+		const name = content.dataset.dropdownName || '';
+		const onEnter = () => {
+			if ( name && name !== legacyLastHover ) {
+				legacyLastHover = name;
+				recordLegacy( 'wpcom_global_nav_item_hover', { name, is_dropdown: true } );
+			}
+			openSubmenu = name;
+			recordLegacy( 'wpcom_global_nav_submenu_show', { name } );
+		};
+		const onLeave = () => {
+			recordLegacy( 'wpcom_global_nav_submenu_hide', { name: openSubmenu } );
+			openSubmenu = null;
+			legacyLastHover = null;
+		};
+		item.addEventListener( 'mouseenter', onEnter );
+		item.addEventListener( 'mouseleave', onLeave );
+		cleanups.push( () => {
+			item.removeEventListener( 'mouseenter', onEnter );
+			item.removeEventListener( 'mouseleave', onLeave );
+		} );
+	} );
+
+	// Logo has no text, so name it explicitly.
+	const logo = nav.querySelector< HTMLElement >( '.x-nav-link__logo' );
+	if ( logo ) {
+		const onLogo = () => {
+			if ( legacyLastHover !== 'logo' ) {
+				legacyLastHover = 'logo';
+				recordLegacy( 'wpcom_global_nav_item_hover', { name: 'logo', is_dropdown: false } );
+			}
+		};
+		logo.addEventListener( 'mouseenter', onLogo );
+		cleanups.push( () => logo.removeEventListener( 'mouseenter', onLogo ) );
+	}
+
+	return () => cleanups.forEach( ( fn ) => fn() );
 }

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/tracks.ts
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/tracks.ts
@@ -91,6 +91,8 @@ function resolveLink( link: HTMLElement ): ResolvedLink {
 export function recordNavLinkClick( link: HTMLAnchorElement ): void {
 	// Resolve from the DOM so this works from a plain click handler on either nav.
 	const is2026 = !! link.closest( '.x-nav--2026-redesign, .x-dropdown--2026, .x-menu--2026' );
+	// Only the new nav floats (sticky-on-scroll); the old nav never does, so the
+	// scrolled class is the right signal — absent on the old nav means not floating.
 	const isFloating = !! link.closest( '.lpc-header-nav-container.is-scrolled' );
 	const { source, category } = resolveLink( link );
 

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/tracks.ts
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/tracks.ts
@@ -42,6 +42,85 @@ export function recordSubmenuHide( isFloating: boolean, name: string ): void {
 	record( 'wpcom_global_nav_submenu_hide', isFloating, { name } );
 }
 
+/*
+ * Legacy (flag-off) nav telemetry. The 2026 events above fire from the React
+ * handlers and hardcode `is_2026: true`. The control arm of the A/B test needs
+ * the SAME engagement events with `is_2026: false`, but the legacy nav opens its
+ * dropdowns via CSS `:hover` (no React state to tap), so — like the landpack
+ * reference's `tracks.js` — we bind DOM listeners. `bindLegacyNavTracks` attaches
+ * them and returns a cleanup. `is_floating` falls back to `scrollY` (the legacy
+ * nav has no `is-scrolled` class), matching the reference's `isFloating()`.
+ */
+function recordLegacy( name: string, props: TracksProps = {} ): void {
+	const isFloating = typeof window !== 'undefined' && window.scrollY > 0;
+	recordTracksEvent( name, { is_2026: false, is_floating: isFloating, ...props } );
+}
+
+export function bindLegacyNavTracks( nav: HTMLElement ): () => void {
+	const cleanups: Array< () => void > = [];
+	let legacyLastHover: string | null = null;
+	let openSubmenu: string | null = null;
+
+	// Dropdown items: `<li.x-nav-item__wide>` holding a `.x-dropdown-content[data-dropdown-name]`.
+	nav.querySelectorAll< HTMLElement >( '.x-nav-item__wide' ).forEach( ( item ) => {
+		const content = item.querySelector< HTMLElement >( '.x-dropdown-content[data-dropdown-name]' );
+		if ( ! content ) {
+			// Non-dropdown wide item (Support, Pricing, Log In, Get Started): hover only.
+			const link = item.querySelector< HTMLElement >( '.x-nav-link' );
+			if ( ! link ) {
+				return;
+			}
+			const name = ( link.textContent || '' ).trim();
+			const onEnter = () => {
+				if ( ! name || name === legacyLastHover ) {
+					return;
+				}
+				legacyLastHover = name;
+				recordLegacy( 'wpcom_global_nav_item_hover', { name, is_dropdown: false } );
+			};
+			item.addEventListener( 'mouseenter', onEnter );
+			cleanups.push( () => item.removeEventListener( 'mouseenter', onEnter ) );
+			return;
+		}
+
+		const name = content.dataset.dropdownName || '';
+		const onEnter = () => {
+			if ( name && name !== legacyLastHover ) {
+				legacyLastHover = name;
+				recordLegacy( 'wpcom_global_nav_item_hover', { name, is_dropdown: true } );
+			}
+			openSubmenu = name;
+			recordLegacy( 'wpcom_global_nav_submenu_show', { name } );
+		};
+		const onLeave = () => {
+			recordLegacy( 'wpcom_global_nav_submenu_hide', { name: openSubmenu } );
+			openSubmenu = null;
+			legacyLastHover = null;
+		};
+		item.addEventListener( 'mouseenter', onEnter );
+		item.addEventListener( 'mouseleave', onLeave );
+		cleanups.push( () => {
+			item.removeEventListener( 'mouseenter', onEnter );
+			item.removeEventListener( 'mouseleave', onLeave );
+		} );
+	} );
+
+	// Logo hover (no text → name it explicitly).
+	const logo = nav.querySelector< HTMLElement >( '.x-nav-link__logo' );
+	if ( logo ) {
+		const onLogo = () => {
+			if ( legacyLastHover !== 'logo' ) {
+				legacyLastHover = 'logo';
+				recordLegacy( 'wpcom_global_nav_item_hover', { name: 'logo', is_dropdown: false } );
+			}
+		};
+		logo.addEventListener( 'mouseenter', onLogo );
+		cleanups.push( () => logo.removeEventListener( 'mouseenter', onLogo ) );
+	}
+
+	return () => cleanups.forEach( ( fn ) => fn() );
+}
+
 export function recordMobileMenuOpen( isFloating: boolean ): void {
 	record( 'wpcom_global_nav_mobile_menu_open', isFloating, {
 		start_type: 'burger_menu',

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/tracks.ts
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/tracks.ts
@@ -56,6 +56,24 @@ function recordLegacy( name: string, props: TracksProps = {} ): void {
 	recordTracksEvent( name, { is_2026: false, is_floating: isFloating, ...props } );
 }
 
+// Legacy mobile (hamburger) menu open/close. The legacy menu is React-state
+// driven (`setMobileMenuOpen`), so unlike the desktop hover events these fire
+// straight from the handlers rather than via DOM listeners. The reference's
+// legacy menu has no drill-down, so only open/close (no category/back).
+export function recordLegacyMobileMenuOpen(): void {
+	recordLegacy( 'wpcom_global_nav_mobile_menu_open', {
+		start_type: 'burger_menu',
+		viewport_width: typeof window !== 'undefined' ? window.innerWidth : 0,
+	} );
+}
+
+export function recordLegacyMobileMenuClose( reason: string ): void {
+	recordLegacy( 'wpcom_global_nav_mobile_menu_close', {
+		reason,
+		viewport_width: typeof window !== 'undefined' ? window.innerWidth : 0,
+	} );
+}
+
 export function bindLegacyNavTracks( nav: HTMLElement ): () => void {
 	const cleanups: Array< () => void > = [];
 	let legacyLastHover: string | null = null;

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/tracks.ts
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/tracks.ts
@@ -1,0 +1,117 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+
+/*
+ * `wpcom_global_nav_*` Tracks events for the 2026 Global Nav. These match the
+ * landpack reference (`wp-content/plugins/landpack/src/client/nav/tracks.js`)
+ * name-for-name and prop-for-prop, so the React (Calypso) and PHP (landpack)
+ * arms of the redesign A/B test feed one unified Tracks dataset. The reference
+ * is DOM-event driven; here we fire straight from the React handlers/state.
+ *
+ * `recordTracksEvent` only emits names prefixed with a known source unless
+ * they're listed in `EVENT_NAME_EXCEPTIONS` (packages/calypso-analytics);
+ * each `wpcom_global_nav_*` name below is registered there.
+ */
+
+type TracksProps = Record< string, string | number | boolean | null | undefined >;
+
+// Dedupe so re-entering the same item doesn't emit duplicate hovers.
+let lastHoverName: string | null = null;
+
+// Reset between submenu opens so re-opening the same item hovers again.
+export function resetNavHoverDedupe(): void {
+	lastHoverName = null;
+}
+
+function record( name: string, isFloating: boolean, props: TracksProps = {} ): void {
+	recordTracksEvent( name, { is_2026: true, is_floating: isFloating, ...props } );
+}
+
+export function recordNavItemHover( isFloating: boolean, name: string, isDropdown: boolean ): void {
+	if ( ! name || name === lastHoverName ) {
+		return;
+	}
+	lastHoverName = name;
+	record( 'wpcom_global_nav_item_hover', isFloating, { name, is_dropdown: isDropdown } );
+}
+
+export function recordSubmenuShow( isFloating: boolean, name: string ): void {
+	record( 'wpcom_global_nav_submenu_show', isFloating, { name } );
+}
+
+export function recordSubmenuHide( isFloating: boolean, name: string ): void {
+	record( 'wpcom_global_nav_submenu_hide', isFloating, { name } );
+}
+
+export function recordMobileMenuOpen( isFloating: boolean ): void {
+	record( 'wpcom_global_nav_mobile_menu_open', isFloating, {
+		start_type: 'burger_menu',
+		viewport_width: typeof window !== 'undefined' ? window.innerWidth : 0,
+	} );
+}
+
+export function recordMobileMenuClose( isFloating: boolean, reason: string ): void {
+	record( 'wpcom_global_nav_mobile_menu_close', isFloating, {
+		reason,
+		viewport_width: typeof window !== 'undefined' ? window.innerWidth : 0,
+	} );
+}
+
+export function recordMobileCategorySelect(
+	isFloating: boolean,
+	name: string,
+	title: string
+): void {
+	record( 'wpcom_global_nav_mobile_category_select', isFloating, { name, title } );
+}
+
+export function recordMobileBack( isFloating: boolean, fromName: string | null ): void {
+	record( 'wpcom_global_nav_mobile_back', isFloating, { from_name: fromName } );
+}
+
+interface ResolvedLink {
+	source: 'mobile_dropdown' | 'desktop_dropdown' | 'logo' | 'top_level';
+	category: string | null;
+}
+
+// Resolve which part of the nav a clicked link came from, for the click event.
+// Mirrors `resolveLink()` in the landpack reference.
+function resolveLink( link: HTMLElement ): ResolvedLink {
+	const mobileList = link.closest< HTMLElement >( '.x-menu-mobile-dropdown-list' );
+	if ( mobileList ) {
+		return { source: 'mobile_dropdown', category: mobileList.dataset.dropdownName || null };
+	}
+
+	if ( link.closest( '.x-menu' ) ) {
+		return { source: 'mobile_dropdown', category: null };
+	}
+
+	if ( link.closest( '.x-dropdown' ) ) {
+		const content = link.closest< HTMLElement >( '.x-dropdown-content' );
+		return { source: 'desktop_dropdown', category: content?.dataset.dropdownName || null };
+	}
+
+	if ( link.closest( '.x-nav-link__logo' ) ) {
+		return { source: 'logo', category: null };
+	}
+
+	return { source: 'top_level', category: null };
+}
+
+export function recordNavLinkClick( link: HTMLAnchorElement ): void {
+	// Resolve `is_2026`/`is_floating` from the DOM (not React state) so this works
+	// from a plain click handler and matches the landpack reference, which fires
+	// for both the legacy and 2026 navs with `is_2026` telling them apart.
+	const is2026 = !! link.closest( '.x-nav--2026-redesign, .x-dropdown--2026, .x-menu--2026' );
+	const isFloating = !! link.closest( '.lpc-header-nav-container.is-scrolled' );
+	const { source, category } = resolveLink( link );
+
+	recordTracksEvent( 'wpcom_global_nav_link_click', {
+		is_2026: is2026,
+		is_floating: isFloating,
+		href: link.href,
+		text: ( link.textContent || '' ).trim(),
+		name: link.dataset.dropdownTrigger || null,
+		source,
+		category,
+	} );
+}

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -968,6 +968,7 @@ $x-menu-2026-admin-bar-mobile: 46px;
 	.lpc-header-nav-container
 	.masterbar-menu
 	.masterbar:has( .x-nav--2026-redesign ) {
+	--x-nav-2026-scrolled-blur: #{$x-nav-2026-scrolled-blur};
 	position: fixed;
 	// Below the admin bar when one exists; falls back for non-Calypso consumers.
 	top: var( --nav-2026-admin-offset, var( --masterbar-height, 0 ) );
@@ -976,35 +977,66 @@ $x-menu-2026-admin-bar-mobile: 46px;
 	height: $x-nav-2026-height;
 	background: transparent;
 	border-bottom-color: transparent;
-	// Exit (white → transparent) eases out after a short delay so the surface lingers.
-	transition:
-		background-color $x-nav-2026-transition 0.12s,
-		box-shadow $x-nav-2026-transition 0.12s,
-		backdrop-filter $x-nav-2026-transition 0.12s;
+	// The white surface is a ::before opacity layer (matches the reference's
+	// `.x-nav-dropdown-wrapper--2026::before`): opacity reveals it 0 → 0.97
+	// scrolled → 1 dropdown-open/hover, so the nav strip fades as one layer
+	// rather than animating `background-color`. The blur stays on the masterbar
+	// itself — `backdrop-filter` on a `z-index:-1` layer can't sample the page.
+	&::before {
+		content: '';
+		position: absolute;
+		inset-block-start: 0;
+		inset-inline: 0;
+		height: $x-nav-2026-height;
+		background-color: rgba( $studio-white, 0.97 );
+		opacity: 0;
+		pointer-events: none;
+		z-index: -1;
+		// Resting state = the fade-OUT (scrolling back to top): hold the white for
+		// 0.22s before it fades so the surface doesn't vanish in the same frame the
+		// page content slides back under the bar.
+		transition: opacity $x-nav-2026-transition 0.22s;
+	}
+	// Exit (blur → none) eases out after a short delay so the surface lingers.
+	transition: backdrop-filter $x-nav-2026-transition 0.12s;
 }
 
-// Dropdown-open or scrolled: nav bar turns white (continuous with the panel below, legible over scrolled content).
+// Scrolled (no dropdown): frosted tint + hairline shadow on the ::before.
+.lpc-header-nav-wrapper
+	.lpc-header-nav-container.is-scrolled
+	.masterbar-menu
+	.masterbar:has( .x-nav--2026-redesign )::before {
+	opacity: 0.97;
+	box-shadow: 0 1px 1px rgba( $studio-black, 0.02 );
+	// Fade-IN keeps delay 0 so entering the float state stays instant.
+	transition: opacity $x-nav-2026-transition 0s;
+}
+
+// Dropdown-open or trigger-hovered: surface goes fully solid white (the frost
+// tint would let the dropdown panel show through), opacity 1, snapped in quickly.
+.lpc-header-nav-container:has( .x-dropdown--2026.x-dropdown-content[aria-hidden='false'] )
+	.masterbar:has( .x-nav--2026-redesign )::before,
+.lpc-header-nav-wrapper
+	.lpc-header-nav-container
+	.masterbar-menu
+	.masterbar:has( .x-nav--2026-redesign ):has( .x-nav-item__wide:hover )::before {
+	background-color: $studio-white;
+	opacity: 1;
+	transition: opacity 0.12s ease-out 0s;
+}
+
+// Blur the page behind the bar — on the masterbar (above the page), since
+// ::before (z-index:-1) can't sample it. Scrolled, dropdown-open, or hovered.
+.lpc-header-nav-wrapper
+	.lpc-header-nav-container.is-scrolled
+	.masterbar-menu
+	.masterbar:has( .x-nav--2026-redesign ),
 .lpc-header-nav-container:has( .x-dropdown--2026.x-dropdown-content[aria-hidden='false'] )
 	.masterbar:has( .x-nav--2026-redesign ),
 .lpc-header-nav-wrapper
-	.lpc-header-nav-container.is-scrolled
+	.lpc-header-nav-container
 	.masterbar-menu
-	.masterbar:has( .x-nav--2026-redesign ) {
-	background: $studio-white;
-	// Snap the white surface in quickly when it appears (0.12s, no delay).
-	transition:
-		background-color 0.12s ease-out,
-		box-shadow 0.12s ease-out;
-}
-
-// Scrolled-only (NOT dropdown-open): near-opaque white + backdrop blur + hairline shadow (dropdown-open stays fully solid, above).
-.lpc-header-nav-wrapper
-	.lpc-header-nav-container.is-scrolled
-	.masterbar-menu
-	.masterbar:has( .x-nav--2026-redesign ) {
-	--x-nav-2026-scrolled-blur: #{$x-nav-2026-scrolled-blur};
-	background: rgba( $studio-white, 0.97 );
-	box-shadow: 0 1px 1px rgba( $studio-black, 0.02 );
+	.masterbar:has( .x-nav--2026-redesign ):has( .x-nav-item__wide:hover ) {
 	backdrop-filter: blur( var( --x-nav-2026-scrolled-blur ) );
 }
 

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -1336,6 +1336,9 @@ $x-menu-2026-admin-bar-mobile: 46px;
 		font-weight: 400;
 		line-height: $x-dropdown-2026-link-line-height;
 		color: $studio-gray-100;
+		// The wrapper's white surface owns the background; the legacy
+		// `.x-dropdown-link` base paints a hover background that must not leak here.
+		background: transparent;
 		// Never underline, even in sections (e.g. themes) that underline links by default.
 		text-decoration: none;
 		transition:
@@ -1346,7 +1349,10 @@ $x-menu-2026-admin-bar-mobile: 46px;
 		&:hover,
 		&:focus,
 		&:active {
-			color: $studio-wordpress-blue-50;
+			// Studio blue (not WordPress blue) + no background, matching the reference.
+			color: $studio-blue-50;
+			background: transparent;
+			opacity: 1;
 		}
 	}
 


### PR DESCRIPTION
Part of WPBRAND-413 and WPBRAND-402

## Proposed Changes

This brings the Calypso version of the 2026 Global Nav in line with the reference implementation, and wires up the A/B test that decides which nav a visitor sees:

* **A/B switch.** The new nav now turns on via the redesign experiment, so visitors are split between the new and current nav. A flag still force-enables it for staff/dev.
* **Analytics.** Adds the `calypso_global_nav_*` Tracks events (hover, open/close a menu, mobile menu use, link clicks) so we can measure how people use the nav. They fire on both the new nav and the current one, so the A/B test can compare them.
* **Polish.** Fixes a few things that didn't match the reference: the dropdown now animates its height when switching menus, the link hover color is corrected, and the bar gets the right frosted/blurred background when scrolled.
* **Copy.** The new nav uses "Log in" / "Get started"; the current nav keeps its existing labels.

Also adds unit tests for the new analytics code.

## Why are these changes being made?

The 2026 nav was first ported to Calypso in #111319, but the analytics events and a few visual details were added to the reference afterwards and never made it across. This catches Calypso up so both versions behave the same and feed the same data, and connects it to the experiment so the redesign can be tested against the current nav.

## Testing Instructions

* Add `?flags=nav-redesign/2026` to a logged-out page that shows the nav (e.g. the themes page) to see the new design.
* Open the browser console, interact with the nav (hover items, open dropdowns, open the mobile menu, click links), and confirm `calypso_global_nav_*` events fire on both the new and current nav.
* Switch between two dropdowns and confirm the panel height animates smoothly.
* Scroll down and confirm the bar gets a frosted, slightly transparent background.
* `yarn jest -c packages/wpcom-template-parts/jest.config.js` passes.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
