### PR TITLE
Notifications: build app-based standalone entry alongside the panel

### DIFF
--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -33,6 +33,7 @@
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/webpack-extensive-lodash-replacement-plugin": "workspace:^",
 		"@wordpress/components": "^35.0.0",
+		"@wordpress/compose": "^8.1.0",
 		"@wordpress/data": "^10.48.0",
 		"@wordpress/dataviews": "^16.0.0",
 		"@wordpress/element": "^8.0.0",

--- a/apps/notifications/postcss.config.js
+++ b/apps/notifications/postcss.config.js
@@ -1,7 +1,25 @@
 module.exports = () => ( {
 	plugins: {
 		'postcss-custom-properties': {
-			importFrom: [ require.resolve( '@automattic/calypso-color-schemes/js' ) ],
+			importFrom: [
+				require.resolve( '@automattic/calypso-color-schemes/js' ),
+				// The WordPress.com admin theme color. The src/app note-list
+				// hover/unread styles read these (e.g.
+				// `rgba(var(--wp-admin-theme-color--rgb), …)`); calypso hosts
+				// (e.g. client/dashboard/app-dotcom) define them in :root, but
+				// the standalone iframe has no such host, so resolve them here.
+				{
+					customProperties: {
+						'--wp-admin-theme-color': '#3858e9',
+						'--wp-admin-theme-color--rgb': '56, 88, 233',
+						'--wp-admin-theme-color-darker-10': '#2145e6',
+						'--wp-admin-theme-color-darker-10--rgb': '33, 69, 230',
+						'--wp-admin-theme-color-darker-20': '#183ad6',
+						'--wp-admin-theme-color-darker-20--rgb': '24, 58, 214',
+						'--wp-admin-border-width-focus': '2px',
+					},
+				},
+			],
 			// @TODO: Drop `preserve: false` workaround if possible
 			// See https://github.com/Automattic/jetpack/pull/13854#issuecomment-550898168
 			preserve: false,

--- a/apps/notifications/postcss.config.js
+++ b/apps/notifications/postcss.config.js
@@ -1,25 +1,7 @@
 module.exports = () => ( {
 	plugins: {
 		'postcss-custom-properties': {
-			importFrom: [
-				require.resolve( '@automattic/calypso-color-schemes/js' ),
-				// The WordPress.com admin theme color. The src/app note-list
-				// hover/unread styles read these (e.g.
-				// `rgba(var(--wp-admin-theme-color--rgb), …)`); calypso hosts
-				// (e.g. client/dashboard/app-dotcom) define them in :root, but
-				// the standalone iframe has no such host, so resolve them here.
-				{
-					customProperties: {
-						'--wp-admin-theme-color': '#3858e9',
-						'--wp-admin-theme-color--rgb': '56, 88, 233',
-						'--wp-admin-theme-color-darker-10': '#2145e6',
-						'--wp-admin-theme-color-darker-10--rgb': '33, 69, 230',
-						'--wp-admin-theme-color-darker-20': '#183ad6',
-						'--wp-admin-theme-color-darker-20--rgb': '24, 58, 214',
-						'--wp-admin-border-width-focus': '2px',
-					},
-				},
-			],
+			importFrom: [ require.resolve( '@automattic/calypso-color-schemes/js' ) ],
 			// @TODO: Drop `preserve: false` workaround if possible
 			// See https://github.com/Automattic/jetpack/pull/13854#issuecomment-550898168
 			preserve: false,

--- a/apps/notifications/src/app/note/index.tsx
+++ b/apps/notifications/src/app/note/index.tsx
@@ -77,7 +77,7 @@ type NoteProps = {
 
 const Note = ( { isDismissible, noteId, setSelectedNoteId }: NoteProps ) => {
 	const dispatch = useDispatch();
-	const isLargeScreen = useViewportMatch( 'xlarge' );
+	const isLargeScreen = useViewportMatch( 'large' );
 	const goBack = () => setSelectedNoteId( undefined );
 
 	const notes = useSelector( ( state ) => ( getAllNotes( state ) || [] ) as NoteObject[] );

--- a/apps/notifications/src/app/note/style.scss
+++ b/apps/notifications/src/app/note/style.scss
@@ -288,7 +288,8 @@
 	}
 }
 
-.wpnc__action-link.has-icon.has-text {
+// Outweigh WP Button's `.components-button.has-icon.has-text` rule.
+.wpnc__action-link.components-button.has-icon.has-text {
 	// Start each button at its natural (content) width and share the remaining
 	// space from there. This keeps labels centered regardless of which one is
 	// longest, so it stays correct across languages.

--- a/apps/notifications/src/app/style.scss
+++ b/apps/notifications/src/app/style.scss
@@ -26,7 +26,7 @@ $wpnc-slide-easing: cubic-bezier(0.33, 0, 0, 1);
 	}
 }
 
-@include break-xlarge {
+@include break-large {
 	// At xlarge each pane carries its own chrome, so the popover goes
 	// transparent and lets the combined card show through. The popover
 	// is sized for both panes (896px) at all times; without this the
@@ -123,7 +123,7 @@ $wpnc-slide-easing: cubic-bezier(0.33, 0, 0, 1);
 
 // Below xlarge: single column. List slides toward the inline-start edge
 // (left in LTR, right in RTL) while the detail slides in from inline-end.
-@media (max-width: #{$break-xlarge - 1px}) {
+@media (max-width: #{$break-large - 1px}) {
 	.wpnc-app__detail-pane.is-open ~ .wpnc-app__list-pane {
 		transform: translateX(-100%);
 
@@ -135,7 +135,7 @@ $wpnc-slide-easing: cubic-bezier(0.33, 0, 0, 1);
 
 // At xlarge: side-by-side. List pinned right, detail pinned left, sharing the
 // list's left border as the divider (so detail has no right border).
-@include break-xlarge {
+@include break-large {
 	.wpnc-app__list-pane {
 		inset-inline-start: auto;
 		width: $wpnc-pane-width;
@@ -161,16 +161,9 @@ $wpnc-slide-easing: cubic-bezier(0.33, 0, 0, 1);
 		}
 	}
 
-	// When open, the wrapper carries the shared shadow so both panes look like
-	// a single card.
-	.wpnc-app:has(.wpnc-app__detail-pane.is-open) {
-		border-radius: $wpnc-pane-radius;
-		box-shadow: $wpnc-pane-shadow;
-
-		.wpnc-app__list-pane {
-			border-start-start-radius: 0;
-			border-end-start-radius: 0;
-			box-shadow: none;
-		}
+	.wpnc-app:has(.wpnc-app__detail-pane.is-open) .wpnc-app__list-pane {
+		border-start-start-radius: 0;
+		border-end-start-radius: 0;
+		box-shadow: none;
 	}
 }

--- a/apps/notifications/src/app/style.scss
+++ b/apps/notifications/src/app/style.scss
@@ -124,6 +124,13 @@ $wpnc-slide-easing: cubic-bezier(0.33, 0, 0, 1);
 // Below xlarge: single column. List slides toward the inline-start edge
 // (left in LTR, right in RTL) while the detail slides in from inline-end.
 @media (max-width: #{$break-large - 1px}) {
+	// Clip the panes that slide off-screen (the closed detail sits at
+	// translateX(100%), past the inline-end edge) so they don't cause horizontal
+	// overflow. The panes carry no shadow at this breakpoint, so nothing is cut.
+	.wpnc-app {
+		overflow: hidden;
+	}
+
 	.wpnc-app__detail-pane.is-open ~ .wpnc-app__list-pane {
 		transform: translateX(-100%);
 

--- a/apps/notifications/src/standalone-app/index.jsx
+++ b/apps/notifications/src/standalone-app/index.jsx
@@ -77,13 +77,12 @@ const ACTION_HANDLERS = {
 			window.open( href, '_blank' );
 		},
 	],
-	SET_LAYOUT: [
-		( st, { layout } ) =>
-			sendMessage( {
-				action: 'widescreen',
-				widescreen: layout === 'widescreen',
-			} ),
-	],
+	// Note: the host widescreen resize is driven from the detail pane's
+	// `.is-open` class via a MutationObserver in NotesWrapper, not from the
+	// panel's SELECT_NOTE → SET_LAYOUT chain. The app dispatches SELECT_NOTE on
+	// open but never on close (it closes via React state), so SET_LAYOUT only
+	// ever fires 'widescreen' and never 'narrow' — observing the class lets us
+	// resize the iframe both ways and stays in sync with the side-by-side CSS.
 	VIEW_SETTINGS: [ () => window.open( 'https://wordpress.com/me/notifications' ) ],
 	CLOSE_SHORTCUTS_POPOVER: [ () => sendMessage( { action: 'closeShortcutsPopover' } ) ],
 	TOGGLE_SHORTCUTS_POPOVER: [ () => sendMessage( { action: 'toggleShortcutsPopover' } ) ],
@@ -154,10 +153,60 @@ const NotesWrapper = ( { wpcom } ) => {
 		document.addEventListener( 'visibilitychange', handleVisibilityChange );
 		window.addEventListener( 'message', receiveMessage( handleMessages ) );
 
+		// The app toggles `.wpnc-app__detail-pane.is-open` when a note detail
+		// opens or closes, but it doesn't ask the host to resize the iframe (it
+		// tracks the open note in React state, not redux, so the panel's
+		// SELECT_NOTE → setLayout chain never fires on close). Mirror that class
+		// into the host's widescreen resize so the frame widens for the
+		// side-by-side layout on open and narrows again on close — keyed on the
+		// same signal the CSS uses.
+		//
+		// Widen immediately on open, but defer narrowing on close until the
+		// detail has finished sliding back behind the list. Narrowing right away
+		// drops the frame below the side-by-side breakpoint mid-animation, which
+		// hands the close transition to the single-column rule (detail on top)
+		// and makes it slide out over the list instead of behind it.
+		const SLIDE_MS = 300;
+		let lastWidescreen = null;
+		let narrowTimer = 0;
+		const syncWidescreen = () => {
+			const isOpen = !! document.querySelector( '.wpnc-app__detail-pane.is-open' );
+			if ( isOpen === lastWidescreen ) {
+				return;
+			}
+			lastWidescreen = isOpen;
+
+			clearTimeout( narrowTimer );
+			narrowTimer = 0;
+
+			if ( isOpen ) {
+				sendMessage( { action: 'widescreen', widescreen: true } );
+			} else {
+				narrowTimer = setTimeout( () => {
+					narrowTimer = 0;
+					sendMessage( { action: 'widescreen', widescreen: false } );
+				}, SLIDE_MS + 50 );
+			}
+		};
+		const layoutObserver = new MutationObserver( syncWidescreen );
+		const mountNode = document.getElementsByClassName( 'wpnc__main' )[ 0 ];
+		if ( mountNode ) {
+			layoutObserver.observe( mountNode, {
+				subtree: true,
+				attributes: true,
+				attributeFilter: [ 'class' ],
+			} );
+		}
+
 		// Let the host know the iframe has booted and is ready to be toggled.
 		// The app dispatches APP_IS_READY into a transient store created before
 		// our custom enhancer takes over, so we signal readiness directly here.
 		sendMessage( { action: 'iFrameReady' } );
+
+		return () => {
+			clearTimeout( narrowTimer );
+			layoutObserver.disconnect();
+		};
 
 		// Listeners only need to be attached once on mount.
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/notifications/src/standalone-app/index.jsx
+++ b/apps/notifications/src/standalone-app/index.jsx
@@ -1,0 +1,198 @@
+import '@automattic/calypso-polyfills';
+import { setLocaleData } from '@wordpress/i18n';
+import debugFactory from 'debug';
+import { setLocale } from 'i18n-calypso';
+import { useEffect, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import NotificationApp, { refreshNotes } from '../app';
+import { SET_IS_SHOWING } from '../panel/state/action-types';
+import actions from '../panel/state/actions';
+import { createClient } from '../standalone/client';
+import { receiveMessage, sendMessage } from '../standalone/messaging';
+
+import './style.scss';
+
+const debug = debugFactory( 'notifications:standalone-app' );
+
+const localePattern = /[&?]locale=([\w_-]+)/;
+const match = localePattern.exec( document.location.search );
+const locale = match ? match[ 1 ] : 'en';
+
+const fetchLocale = async ( localeSlug ) => {
+	try {
+		const response = await fetch(
+			`https://widgets.wp.com/notifications/languages/${ localeSlug }-v1.1.json`
+		);
+
+		// Fall back to English if the locale is not available
+		if ( ! response.ok ) {
+			return;
+		}
+
+		const localeData = await response.json();
+		// Sync @wordpress/i18n first — setLocale triggers re-renders that call __()
+		setLocaleData( localeData );
+		setLocale( localeData );
+	} catch {}
+};
+
+// The notifications app (src/app) owns its Redux store internally and exposes
+// no isShowing/isVisible props (it is built for popover hosts where mount means
+// "open"). The standalone widget instead lives in a long-lived iframe whose
+// host toggles it open/closed via postMessage, so we keep a reference to that
+// store through a custom enhancer and drive the open/visibility state into it
+// directly — the same effect the old panel component performed via props.
+let store = { dispatch: () => {}, getState: () => {} };
+const customEnhancer = ( next ) => ( reducer, initialState ) =>
+	( store = next( reducer, initialState ) );
+
+const ACTION_HANDLERS = {
+	APP_RENDER_NOTES: [
+		( st, { latestType, newNoteCount } ) =>
+			newNoteCount > 0
+				? sendMessage( {
+						action: 'render',
+						num_new: newNoteCount,
+						latest_type: latestType,
+				  } )
+				: sendMessage( { action: 'renderAllSeen' } ),
+	],
+	CLOSE_PANEL: [ () => sendMessage( { action: 'togglePanel' } ) ],
+	OPEN_LINK: [ ( st, { href } ) => window.open( href, '_blank' ) ],
+	OPEN_SITE: [
+		( st, { siteId, href } ) => {
+			sendMessage( { action: 'openSite', siteId } );
+			window.open( href, '_blank' );
+		},
+	],
+	OPEN_POST: [
+		( st, { siteId, postId, href } ) => {
+			sendMessage( { action: 'openPost', siteId, postId } );
+			window.open( href, '_blank' );
+		},
+	],
+	OPEN_COMMENT: [
+		( st, { siteId, postId, commentId, href } ) => {
+			sendMessage( { action: 'openComment', siteId, postId, commentId } );
+			window.open( href, '_blank' );
+		},
+	],
+	SET_LAYOUT: [
+		( st, { layout } ) =>
+			sendMessage( {
+				action: 'widescreen',
+				widescreen: layout === 'widescreen',
+			} ),
+	],
+	VIEW_SETTINGS: [ () => window.open( 'https://wordpress.com/me/notifications' ) ],
+	CLOSE_SHORTCUTS_POPOVER: [ () => sendMessage( { action: 'closeShortcutsPopover' } ) ],
+	TOGGLE_SHORTCUTS_POPOVER: [ () => sendMessage( { action: 'toggleShortcutsPopover' } ) ],
+	EDIT_COMMENT: [
+		( st, { siteId, postId, commentId, href } ) => {
+			sendMessage( { action: 'editComment', siteId, postId, commentId } );
+			window.open( href, '_blank' );
+		},
+	],
+	ANSWER_PROMPT: [
+		( st, { siteId, href } ) => {
+			sendMessage( { action: 'answerPrompt', siteId, href } );
+			window.open( href, '_blank' );
+		},
+	],
+};
+
+const NotesWrapper = ( { wpcom } ) => {
+	const [ isShowing, setIsShowing ] = useState( false );
+	const [ isVisible, setIsVisible ] = useState( document.visibilityState === 'visible' );
+
+	if ( locale && 'en' !== locale ) {
+		fetchLocale( locale );
+	}
+
+	debug( 'wrapper state update', { isShowing, isVisible } );
+
+	// Mirror the host-driven open/visibility state into the app's store. The
+	// APP_REFRESH_NOTES handler (registered by the app) reads the panel-open
+	// flag back out of the store and forwards both values to the REST client,
+	// so SET_IS_SHOWING must be dispatched first.
+	useEffect( () => {
+		store.dispatch( { type: SET_IS_SHOWING, isShowing } );
+		if ( ! isShowing ) {
+			// Unselect the note so key handlers don't steal keystrokes while hidden.
+			store.dispatch( actions.ui.unselectNote() );
+		}
+		store.dispatch( { type: 'APP_REFRESH_NOTES', isVisible } );
+	}, [ isShowing, isVisible ] );
+
+	useEffect( () => {
+		const handleMessages = ( { action, hidden, showing } ) => {
+			debug( 'message received', { action, hidden, showing } );
+
+			if ( 'togglePanel' === action ) {
+				setIsShowing( !! showing );
+			}
+
+			if ( 'toggleVisibility' === action ) {
+				setIsVisible( ! hidden );
+			}
+
+			if ( 'refreshNotes' === action ) {
+				refreshNotes();
+			}
+
+			if ( 'closeShortcutsPopover' === action ) {
+				store.dispatch( actions.ui.closeShortcutsPopover() );
+			}
+
+			if ( 'toggleShortcutsPopover' === action ) {
+				store.dispatch( actions.ui.toggleShortcutsPopover() );
+			}
+		};
+
+		const handleVisibilityChange = () => setIsVisible( document.visibilityState === 'visible' );
+
+		document.addEventListener( 'visibilitychange', handleVisibilityChange );
+		window.addEventListener( 'message', receiveMessage( handleMessages ) );
+
+		// Let the host know the iframe has booted and is ready to be toggled.
+		// The app dispatches APP_IS_READY into a transient store created before
+		// our custom enhancer takes over, so we signal readiness directly here.
+		sendMessage( { action: 'iFrameReady' } );
+
+		// Listeners only need to be attached once on mount.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+
+	return (
+		<NotificationApp
+			customEnhancer={ customEnhancer }
+			actionHandlers={ ACTION_HANDLERS }
+			locale={ locale }
+			wpcom={ wpcom }
+		/>
+	);
+};
+
+const render = ( wpcom ) => {
+	document.body.classList.add( 'font-smoothing-antialiased' );
+
+	const root = createRoot( document.getElementsByClassName( 'wpnc__main' )[ 0 ] );
+	root.render( <NotesWrapper wpcom={ wpcom } /> );
+};
+
+const setTracksUser = ( wpcom ) => {
+	wpcom.req
+		.get( '/me', { fields: 'ID,username' } )
+		.then( ( { ID, username } ) => {
+			window._tkq = window._tkq || [];
+			window._tkq.push( [ 'identifyUser', ID, username ] );
+		} )
+		.catch( () => {} );
+};
+
+const init = ( wpcom ) => {
+	setTracksUser( wpcom );
+	render( wpcom );
+};
+
+createClient().then( init );

--- a/apps/notifications/src/standalone-app/index.jsx
+++ b/apps/notifications/src/standalone-app/index.jsx
@@ -153,63 +153,12 @@ const NotesWrapper = ( { wpcom } ) => {
 		document.addEventListener( 'visibilitychange', handleVisibilityChange );
 		window.addEventListener( 'message', receiveMessage( handleMessages ) );
 
-		// The app toggles `.wpnc-app__detail-pane.is-open` when a note detail
-		// opens or closes, but it doesn't ask the host to resize the iframe (it
-		// tracks the open note in React state, not redux, so the panel's
-		// SELECT_NOTE → setLayout chain never fires on close). Mirror that class
-		// into the host's widescreen resize so the frame widens for the
-		// side-by-side layout on open and narrows again on close — keyed on the
-		// same signal the CSS uses.
-		//
-		// Widen immediately on open, but defer narrowing on close until the
-		// detail has finished sliding back behind the list. Narrowing right away
-		// drops the frame below the side-by-side breakpoint mid-animation, which
-		// hands the close transition to the single-column rule (detail on top)
-		// and makes it slide out over the list instead of behind it.
-		const SLIDE_MS = 300;
-		let lastWidescreen = null;
-		let narrowTimer = 0;
-		const syncWidescreen = () => {
-			const isOpen = !! document.querySelector( '.wpnc-app__detail-pane.is-open' );
-			if ( isOpen === lastWidescreen ) {
-				return;
-			}
-			lastWidescreen = isOpen;
-
-			clearTimeout( narrowTimer );
-			narrowTimer = 0;
-
-			if ( isOpen ) {
-				sendMessage( { action: 'widescreen', widescreen: true } );
-			} else {
-				narrowTimer = setTimeout( () => {
-					narrowTimer = 0;
-					sendMessage( { action: 'widescreen', widescreen: false } );
-				}, SLIDE_MS + 50 );
-			}
-		};
-		const layoutObserver = new MutationObserver( syncWidescreen );
-		const mountNode = document.getElementsByClassName( 'wpnc__main' )[ 0 ];
-		if ( mountNode ) {
-			layoutObserver.observe( mountNode, {
-				subtree: true,
-				attributes: true,
-				attributeFilter: [ 'class' ],
-			} );
-		}
-
 		// Let the host know the iframe has booted and is ready to be toggled.
 		// The app dispatches APP_IS_READY into a transient store created before
 		// our custom enhancer takes over, so we signal readiness directly here.
 		sendMessage( { action: 'iFrameReady' } );
 
-		return () => {
-			clearTimeout( narrowTimer );
-			layoutObserver.disconnect();
-		};
-
-		// Listeners only need to be attached once on mount.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
+		sendMessage( { action: 'widescreen', widescreen: true } );
 	}, [] );
 
 	return (

--- a/apps/notifications/src/standalone-app/index.jsx
+++ b/apps/notifications/src/standalone-app/index.jsx
@@ -1,4 +1,5 @@
 import '@automattic/calypso-polyfills';
+import { useViewportMatch } from '@wordpress/compose';
 import { setLocaleData } from '@wordpress/i18n';
 import debugFactory from 'debug';
 import { setLocale } from 'i18n-calypso';
@@ -103,6 +104,7 @@ const ACTION_HANDLERS = {
 const NotesWrapper = ( { wpcom } ) => {
 	const [ isShowing, setIsShowing ] = useState( false );
 	const [ isVisible, setIsVisible ] = useState( document.visibilityState === 'visible' );
+	const isMobileViewport = useViewportMatch( 'small', '<' );
 
 	if ( locale && 'en' !== locale ) {
 		fetchLocale( locale );
@@ -167,12 +169,39 @@ const NotesWrapper = ( { wpcom } ) => {
 			actionHandlers={ ACTION_HANDLERS }
 			locale={ locale }
 			wpcom={ wpcom }
+			isDismissible={ isMobileViewport }
 		/>
+	);
+};
+
+// The src/app components consume the wp-admin theme variables (directly and via
+// DataViews). WP-admin provides them globally, but this standalone iframe is the
+// host, so we must supply them — matching client/dashboard/app-dotcom (default
+// blue admin color). They're set on the document root via JS rather than in CSS
+// because this app's postcss runs `postcss-custom-properties` with
+// `preserve: false`, which strips `:root` custom-property declarations from the
+// built stylesheet. Setting them on `documentElement` keeps them on `:root`, so
+// they also cascade to popovers/dropdowns that portal to the iframe body.
+const WP_ADMIN_THEME_VARS = {
+	'--wp-admin-theme-color': '#3858e9',
+	'--wp-admin-theme-color--rgb': '56, 88, 233',
+	'--wp-admin-theme-color-darker-10': '#2145e6',
+	'--wp-admin-theme-color-darker-10--rgb': '33, 69, 230',
+	'--wp-admin-theme-color-darker-20': '#183ad6',
+	'--wp-admin-theme-color-darker-20--rgb': '24, 58, 214',
+	'--wp-admin-border-width-focus': '2px',
+};
+
+const applyAdminThemeVars = () => {
+	const { style } = document.documentElement;
+	Object.entries( WP_ADMIN_THEME_VARS ).forEach( ( [ name, value ] ) =>
+		style.setProperty( name, value )
 	);
 };
 
 const render = ( wpcom ) => {
 	document.body.classList.add( 'font-smoothing-antialiased' );
+	applyAdminThemeVars();
 
 	const root = createRoot( document.getElementsByClassName( 'wpnc__main' )[ 0 ] );
 	root.render( <NotesWrapper wpcom={ wpcom } /> );

--- a/apps/notifications/src/standalone-app/style.scss
+++ b/apps/notifications/src/standalone-app/style.scss
@@ -2,24 +2,27 @@
 // app expects its host to provide (e.g. client/dashboard/app/style.scss). The
 // standalone iframe is that host, so load them here.
 @import '@wordpress/dataviews/build-style/style.css';
+@import "@wordpress/base-styles/variables";
+@import "@wordpress/base-styles/colors";
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 
-// The src/app UI is built to be sized by a host popover (it targets
-// `.components-popover` in its own stylesheet). In the standalone iframe there
-// is no popover, so size the mount container to fill the frame and let
-// `.wpnc-app` (width/height: 100%) stretch to fit.
 html,
 body {
 	height: 100%;
 	margin: 0;
-	// The closed detail pane is parked off the inline-end edge; keep it clipped.
 	overflow: hidden;
 }
 
-// The app's components carry their own font, but the iframe body has none, so
-// any inherited text (e.g. DataViews content) falls back to the browser default
-// (serif). Set the WordPress system font stack like the other app hosts do.
+// The app's components carry their own typography, but text that inherits from
+// `body` (the note detail body, list content) otherwise falls back to the
+// browser defaults (serif, 16px). Match the body typography the other app hosts
+// set (e.g. client/dashboard/app + app-dotcom) so the detail renders the same.
 body {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: $font-size-medium;
+	line-height: $font-line-height-small;
+	color: $gray-900;
 }
 
 .wpnc__main {
@@ -27,37 +30,18 @@ body {
 	inset: 0;
 }
 
-// Side-by-side list + detail.
-//
-// `src/app` only lays the two panes out side by side at `@include break-xlarge`
-// (min-width: 1080px), where a host popover sizes it. The standalone iframe is
-// full-bleed and usually narrower than that even when it fills the browser, so
-// the app falls back to the single-column overlay. Re-apply the app's own
-// side-by-side layout at the width where both columns fit: the main list panel
-// is pinned to the inline-end side and sits on top, and the detail sits behind
-// it on the inline-start side. The app's base `translateX(100%)` ↔
-// `translateX(0)` then slides the detail out leftward from behind the list on
-// open and back rightward behind it on close.
-@media ( min-width: 768px ) {
-	// Main list panel: fills the inline-end side, on top.
-	.wpnc-app__list-pane {
-		inset-inline-start: 448px;
-		inset-inline-end: 0;
-		width: auto;
-		z-index: 2;
-		border-inline-start: 1px solid var(--color-border-subtle, #c3c4c7);
-	}
+.wpnc-app {
+	max-width: 448px;
+	margin-inline-start: auto;
+	box-sizing: border-box;
+	border: 1px solid #dcdcde;
+	border-radius: 4px;
+	box-shadow: 0 0 16px rgba(0, 0, 0, 0.12);
+	overflow: hidden;
 
-	// Detail: inline-start 448px, behind the list.
-	.wpnc-app__detail-pane {
-		inset-inline-end: auto;
-		width: 448px;
-		z-index: 1;
-	}
-
-	// Keep the list put in side-by-side (cancel the single-column slide-out the
-	// app applies below its own 1080px breakpoint).
-	.wpnc-app__detail-pane.is-open ~ .wpnc-app__list-pane {
-		transform: none;
+	@include break-large {
+		max-width: 896px;
+		border: 0;
+		box-shadow: none;
 	}
 }

--- a/apps/notifications/src/standalone-app/style.scss
+++ b/apps/notifications/src/standalone-app/style.scss
@@ -1,0 +1,14 @@
+// The src/app UI is built to be sized by a host popover (it targets
+// `.components-popover` in its own stylesheet). In the standalone iframe there
+// is no popover, so size the mount container to fill the frame and let
+// `.wpnc-app` (width/height: 100%) stretch to fit.
+html,
+body {
+	height: 100%;
+	margin: 0;
+}
+
+.wpnc__main {
+	position: fixed;
+	inset: 0;
+}

--- a/apps/notifications/src/standalone-app/style.scss
+++ b/apps/notifications/src/standalone-app/style.scss
@@ -1,3 +1,8 @@
+// The src/app note list renders with @wordpress/dataviews, whose styles the
+// app expects its host to provide (e.g. client/dashboard/app/style.scss). The
+// standalone iframe is that host, so load them here.
+@import '@wordpress/dataviews/build-style/style.css';
+
 // The src/app UI is built to be sized by a host popover (it targets
 // `.components-popover` in its own stylesheet). In the standalone iframe there
 // is no popover, so size the mount container to fill the frame and let
@@ -6,9 +11,53 @@ html,
 body {
 	height: 100%;
 	margin: 0;
+	// The closed detail pane is parked off the inline-end edge; keep it clipped.
+	overflow: hidden;
+}
+
+// The app's components carry their own font, but the iframe body has none, so
+// any inherited text (e.g. DataViews content) falls back to the browser default
+// (serif). Set the WordPress system font stack like the other app hosts do.
+body {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 }
 
 .wpnc__main {
 	position: fixed;
 	inset: 0;
+}
+
+// Side-by-side list + detail.
+//
+// `src/app` only lays the two panes out side by side at `@include break-xlarge`
+// (min-width: 1080px), where a host popover sizes it. The standalone iframe is
+// full-bleed and usually narrower than that even when it fills the browser, so
+// the app falls back to the single-column overlay. Re-apply the app's own
+// side-by-side layout at the width where both columns fit: the main list panel
+// is pinned to the inline-end side and sits on top, and the detail sits behind
+// it on the inline-start side. The app's base `translateX(100%)` ↔
+// `translateX(0)` then slides the detail out leftward from behind the list on
+// open and back rightward behind it on close.
+@media ( min-width: 768px ) {
+	// Main list panel: fills the inline-end side, on top.
+	.wpnc-app__list-pane {
+		inset-inline-start: 448px;
+		inset-inline-end: 0;
+		width: auto;
+		z-index: 2;
+		border-inline-start: 1px solid var(--color-border-subtle, #c3c4c7);
+	}
+
+	// Detail: inline-start 448px, behind the list.
+	.wpnc-app__detail-pane {
+		inset-inline-end: auto;
+		width: 448px;
+		z-index: 1;
+	}
+
+	// Keep the list put in side-by-side (cancel the single-column slide-out the
+	// app applies below its own 1080px breakpoint).
+	.wpnc-app__detail-pane.is-open ~ .wpnc-app__list-pane {
+		transform: none;
+	}
 }

--- a/apps/notifications/webpack.config.js
+++ b/apps/notifications/webpack.config.js
@@ -13,49 +13,37 @@ const GenerateChunksMapPlugin = require( '../../build-tools/webpack/generate-chu
 const shouldEmitStats = process.env.EMIT_STATS && process.env.EMIT_STATS !== 'false';
 const isDevelopment = process.env.NODE_ENV !== 'production';
 
+// While this used to be the output of "git describe", we don't really use
+// tags enough to justify it. Now, the short sha will be good enough. The commit
+// sha from process.env is set by TeamCity, and tracks GitHub. (rev-parse often
+// does not.)
+const gitDescribe = (
+	process.env.commit_sha ??
+	spawnSync( 'git', [ 'rev-parse', 'HEAD' ], {
+		encoding: 'utf8',
+	} ).stdout.replace( '\n', '' )
+).slice( 0, 11 );
+
+const pageMeta = {
+	'git-describe': gitDescribe,
+};
+
 /**
- * Return a webpack config object
- *
- * Arguments to this function replicate webpack's so this config can be used on the command line,
- * with individual options overridden by command line args. Note that webpack-cli seems to convert
- * kebab-case (like `--ouput-path`) to camelCase (`outputPath`)
- * @see {@link https://webpack.js.org/configuration/configuration-types/#exporting-a-function}
- * @see {@link https://webpack.js.org/api/cli/}
- * @param  {Object}  env                           environment options
- * @param  {Object}  argv                          options map
- * @param  {Object}  argv.entry                    Entry point(s)
- * @param  {string}  argv.outputPath                Output path
- * @param  {string}  argv.outputFilename            Output filename pattern
- * @returns {Object}                                webpack config
+ * Build a webpack config object for a single standalone entry.
+ * @param  {Object}  env                  environment options
+ * @param  {Object}  options              entry options
+ * @param  {string}  options.entry        entry point
+ * @param  {string}  options.outputPath   output path
+ * @param  {string}  options.publicPath   public path used in the generated HTML
+ * @param  {boolean} options.withStats    whether to emit bundle stats for this entry
+ * @returns {Object}                      webpack config
  */
-function getWebpackConfig(
-	env = {},
-	{
-		entry = path.join( __dirname, 'src', 'standalone' ),
-		outputPath = path.join( __dirname, 'dist' ),
-		outputFilename = 'build.min.js',
-	}
-) {
+function buildConfig( env, { entry, outputPath, publicPath, withStats } ) {
 	const webpackConfig = getBaseWebpackConfig( env, {
 		entry,
-		'output-filename': outputFilename,
+		'output-filename': 'build.min.js',
 		'output-path': outputPath,
 	} );
-
-	// While this used to be the output of "git describe", we don't really use
-	// tags enough to justify it. Now, the short sha will be good enough. The commit
-	// sha from process.env is set by TeamCity, and tracks GitHub. (rev-parse often
-	// does not.)
-	const gitDescribe = (
-		process.env.commit_sha ??
-		spawnSync( 'git', [ 'rev-parse', 'HEAD' ], {
-			encoding: 'utf8',
-		} ).stdout.replace( '\n', '' )
-	).slice( 0, 11 );
-
-	const pageMeta = {
-		'git-describe': gitDescribe,
-	};
 
 	return {
 		...webpackConfig,
@@ -67,7 +55,7 @@ function getWebpackConfig(
 			new HtmlWebpackPlugin( {
 				filename: path.join( outputPath, 'index.html' ),
 				template: path.join( __dirname, 'src', 'index.ejs' ),
-				publicPath: 'https://widgets.wp.com/notifications/',
+				publicPath,
 				hash: true,
 				inject: false,
 				scriptLoading: 'blocking',
@@ -77,7 +65,7 @@ function getWebpackConfig(
 			new HtmlWebpackPlugin( {
 				filename: path.join( outputPath, 'rtl.html' ),
 				template: path.join( __dirname, 'src', 'index.ejs' ),
-				publicPath: 'https://widgets.wp.com/notifications/',
+				publicPath,
 				hash: true,
 				inject: false,
 				scriptLoading: 'blocking',
@@ -85,9 +73,9 @@ function getWebpackConfig(
 				includeStyle: ( href ) => href.includes( '.rtl.css' ),
 			} ),
 			new GenerateChunksMapPlugin( {
-				output: path.resolve( __dirname, 'dist/chunks-map.json' ),
+				output: path.resolve( outputPath, 'chunks-map.json' ),
 			} ),
-			shouldEmitStats &&
+			withStats &&
 				new BundleAnalyzerPlugin( {
 					analyzerMode: 'disabled', // just write the stats.json file
 					generateStatsFile: true,
@@ -104,6 +92,37 @@ function getWebpackConfig(
 		].filter( Boolean ),
 		devtool: isDevelopment ? 'inline-cheap-source-map' : 'source-map',
 	};
+}
+
+/**
+ * Return the webpack config(s).
+ *
+ * Two standalone entries are built side by side while we migrate the widget
+ * from the legacy `src/panel` UI to the new `src/app` UI:
+ *   - `src/standalone`     → dist/      (panel, served from /notifications/)
+ *   - `src/standalone-app` → dist/app/  (app,   served from /notifications/app/)
+ *
+ * Arguments to this function replicate webpack's so this config can be used on the command line.
+ * @see {@link https://webpack.js.org/configuration/configuration-types/#exporting-a-function}
+ * @see {@link https://webpack.js.org/api/cli/}
+ * @param  {Object} env environment options
+ * @returns {Array}     webpack configs
+ */
+function getWebpackConfig( env = {} ) {
+	return [
+		buildConfig( env, {
+			entry: path.join( __dirname, 'src', 'standalone' ),
+			outputPath: path.join( __dirname, 'dist' ),
+			publicPath: 'https://widgets.wp.com/notifications/',
+			withStats: shouldEmitStats,
+		} ),
+		buildConfig( env, {
+			entry: path.join( __dirname, 'src', 'standalone-app' ),
+			outputPath: path.join( __dirname, 'dist', 'app' ),
+			publicPath: 'https://widgets.wp.com/notifications/app/',
+			withStats: false,
+		} ),
+	];
 }
 
 module.exports = getWebpackConfig;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1782,6 +1782,7 @@ __metadata:
     "@automattic/webpack-extensive-lodash-replacement-plugin": "workspace:^"
     "@automattic/wp-babel-makepot": "workspace:^"
     "@wordpress/components": "npm:^35.0.0"
+    "@wordpress/compose": "npm:^8.1.0"
     "@wordpress/data": "npm:^10.48.0"
     "@wordpress/dataviews": "npm:^16.0.0"
     "@wordpress/element": "npm:^8.0.0"


### PR DESCRIPTION
DOTMSD-1294

## Proposed Changes

- Add a new `apps/notifications/src/standalone-app` entry that renders the new `src/app` notifications UI in the standalone iframe widget, alongside the existing panel-based `src/standalone` entry (left untouched).
- The webpack config now exports **both** entries as a multi-compiler array, built in a single run:
  - `src/standalone` → `dist/` — panel, served from `/notifications/` (unchanged)
  - `src/standalone-app` → `dist/app/` — app, served from `/notifications/app/`
- Reuse the existing `src/standalone/client` and `src/standalone/messaging` modules from the new entry.
- Add `src/standalone-app/style.scss` to size the `.wpnc__main` mount node to fill the iframe (the app's own stylesheet only sizes a host `.components-popover`, which doesn't exist in the standalone frame).

## Why are these changes being made?

The standalone notifications widget (deployed to `widgets.wp.com/notifications`) still renders the legacy `src/panel` UI, while the new `src/app` UI is already used by the Reader and Multi-site Dashboard. Building both entries side by side keeps the current panel build byte-for-byte in place while making the new app build available at `/notifications/app/`, so the widget can be migrated to the new UI gradually (point the host iframe at the app URL when ready).

The new app's `NotificationApp` is built for popover hosts (mount = open) and intentionally exposes no `isShowing`/`isVisible` props. The standalone iframe instead has a long-lived mount whose host toggles open/closed via `postMessage`, so the new entry replicates what the old panel component did internally — it captures the app's Redux store via `customEnhancer` and drives `SET_IS_SHOWING` / `APP_REFRESH_NOTES` (and `unselectNote` when hidden) into it on host messages, preserving the polling pause/resume behavior. It also signals `iFrameReady` to the host directly on mount, because the app dispatches its `APP_IS_READY` into a transient pre-enhancer store that the host action handlers never see.

## Testing Instructions

- `yarn workspace @automattic/notifications build:notifications` now produces both builds: the panel at `dist/` (`build.min.js`, `index.html`, `rtl.html`, …) and the app at `dist/app/` (same filenames, public path `/notifications/app/`).
- Verified the generated HTML references the correct public paths (`/notifications/build.min.js` vs `/notifications/app/build.min.js`).
- `yarn eslint` / `yarn stylelint` on the new files and `yarn typecheck-apps` pass.
- Visual QA still needed: load the app build (`/notifications/app/`) inside the masterbar iframe and confirm open/close, tab-visibility polling, keyboard shortcuts, and panel sizing behave like the panel build.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)