### PR TITLE
Checkout: add post-checkout downgrade notice from purchase settings

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -294,18 +294,21 @@ export const purchaseSettingsRoute = createRoute( {
 		upgraded?: true;
 		cancelled?: true;
 		downgraded?: true;
+		plan_changed?: true;
 		intent?: 'auto-renew';
 	} => {
 		const isRefunded = search.refunded === true || search.refunded === 'true';
 		const isUpgraded = search.upgraded === true || search.upgraded === 'true';
 		const isCancelled = search.cancelled === true || search.cancelled === 'true';
 		const isDowngraded = search.downgraded === true || search.downgraded === 'true';
+		const isPlanChanged = search.plan_changed === true || search.plan_changed === 'true';
 		const intent = search.intent === 'auto-renew' ? ( 'auto-renew' as const ) : undefined;
 		return {
 			...( isRefunded ? { refunded: true } : {} ),
 			...( isUpgraded ? { upgraded: true } : {} ),
 			...( isCancelled ? { cancelled: true } : {} ),
 			...( isDowngraded ? { downgraded: true } : {} ),
+			...( isPlanChanged ? { plan_changed: true } : {} ),
 			...( intent ? { intent } : {} ),
 		};
 	},

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -100,7 +100,11 @@ import {
 	isCentennialPurchase,
 	hasAmountAvailableToRefund,
 } from '../../../utils/purchase';
-import { getSitePurchaseUpgradeUrl, getUpgradedPurchaseRedirectUrl } from '../../../utils/site-url';
+import {
+	getChangedPlanRedirectUrl,
+	getSitePurchaseUpgradeUrl,
+	getUpgradedPurchaseRedirectUrl,
+} from '../../../utils/site-url';
 import BillingFlexUsageCard from '../../billing-flex-usage';
 import { useIsSplitCancelRemoveEnabled } from '../cancel-purchase/use-is-split-cancel-remove-enabled';
 import { PurchasePaymentMethod } from '../purchase-payment-method';
@@ -145,7 +149,7 @@ function getWpcomPlanGridUrl( siteSlug: string | undefined ): string {
 		...( siteSlug && { siteSlug } ),
 		cancel_to: backUrl,
 		dashboard: getCurrentDashboard(),
-		redirect_to: getUpgradedPurchaseRedirectUrl(),
+		redirect_to: getChangedPlanRedirectUrl(),
 		allow_downgrade: 'true',
 	} );
 }

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -48,7 +48,8 @@ import type { Purchase } from '@automattic/api-core';
 export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 	const { user } = useAuth();
 	const isSplitCancelRemoveEnabled = useIsSplitCancelRemoveEnabled();
-	const { refunded, upgraded, cancelled, downgraded, intent } = purchaseSettingsRoute.useSearch();
+	const { refunded, upgraded, cancelled, downgraded, plan_changed, intent } =
+		purchaseSettingsRoute.useSearch();
 	const navigate = purchaseSettingsRoute.useNavigate();
 	// Show the transient cancelled success notice once after a cancel redirects
 	// here. The URL search param is cleared immediately so that a refresh / back
@@ -78,6 +79,21 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 			} );
 		}
 	}, [ downgraded, navigate ] );
+	// Transient success notice shown after a change-plan checkout (upgrade or
+	// downgrade) redirects back here with `?plan_changed=true`. The param is
+	// stripped immediately so it doesn't survive a refresh or back navigation.
+	const [ showPlanChangedNotice, setShowPlanChangedNotice ] = useState( Boolean( plan_changed ) );
+	useEffect( () => {
+		if ( plan_changed ) {
+			navigate( {
+				search: ( prev: Record< string, unknown > ) => {
+					const { plan_changed: _plan_changed, ...rest } = prev;
+					return rest;
+				},
+				replace: true,
+			} );
+		}
+	}, [ plan_changed, navigate ] );
 	const { data: purchaseAttachedTo } = useQuery( {
 		...purchaseQuery( purchase.attached_to_purchase_id ?? 0 ),
 		enabled: Boolean( purchase.attached_to_purchase_id ),
@@ -138,6 +154,18 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 		return (
 			<Notice variant="success" onClose={ () => setShowDowngradedNotice( false ) }>
 				{ __( 'You\u2019ve switched to monthly billing.' ) }
+			</Notice>
+		);
+	}
+
+	if ( showPlanChangedNotice ) {
+		return (
+			<Notice variant="success" onClose={ () => setShowPlanChangedNotice( false ) }>
+				{ sprintf(
+					// translators: %s is the name of the plan, e.g. "WordPress.com Personal"
+					__( 'Your plan has been updated to %s.' ),
+					purchase.product_name
+				) }
 			</Notice>
 		);
 	}

--- a/client/dashboard/utils/site-url.ts
+++ b/client/dashboard/utils/site-url.ts
@@ -101,6 +101,17 @@ export function getUpgradedPurchaseRedirectUrl(): string {
 	return dashboardLink( '/me/billing/purchases/:purchaseId?upgraded=true' );
 }
 
+/**
+ * `redirect_to` URL for the change-plan flow, which can result in either an
+ * upgrade or a downgrade. Unlike `getUpgradedPurchaseRedirectUrl`, it lands on
+ * the purchase-settings page with a neutral "plan changed" notice rather than
+ * an upgrade-specific one. The `:purchaseId` placeholder resolves to the newly
+ * provisioned plan's purchase (see `getUpgradedPurchaseRedirectUrl`).
+ */
+export function getChangedPlanRedirectUrl(): string {
+	return dashboardLink( '/me/billing/purchases/:purchaseId?plan_changed=true' );
+}
+
 export function getSitePurchaseUpgradeUrl( purchase: Purchase, redirectTo?: string ) {
 	if ( isAkismetProduct( purchase ) ) {
 		// For the first Iteration of Calypso Akismet checkout we are only suggesting

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -604,12 +604,18 @@ class ManagePurchase extends Component<
 	}
 
 	renderChangePlanNavItem() {
-		const { siteSlug, translate } = this.props;
+		const { siteSlug, getManagePurchaseUrlFor = managePurchase, translate } = this.props;
 		if ( ! this.shouldRenderDowngradeOption() ) {
 			return null;
 		}
+		// Land back on the newly-provisioned plan's manage-purchase page after
+		// checkout with a success notice. The `:purchaseId` placeholder is
+		// substituted by the checkout pending page once the new subscription
+		// appears (analogous to `:receiptId`).
+		const redirectTo = getManagePurchaseUrlFor( siteSlug, ':purchaseId' ) + '?plan_changed=true';
+		const href = addQueryArgs( { redirect_to: redirectTo }, `/plans/${ siteSlug }` );
 		return (
-			<CompactCard tagName="a" displayAsLink href={ `/plans/${ siteSlug }` }>
+			<CompactCard tagName="a" displayAsLink href={ href }>
 				<Icon icon={ column } className="card__icon" />
 				{ translate( 'Change plan' ) }
 			</CompactCard>

--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -116,6 +116,9 @@ class PurchaseNotice extends Component<
 		showDowngradedRedirectNotice:
 			typeof window !== 'undefined' &&
 			new URLSearchParams( window.location.search ).get( 'downgraded' ) === 'true',
+		showPlanChangedRedirectNotice:
+			typeof window !== 'undefined' &&
+			new URLSearchParams( window.location.search ).get( 'plan_changed' ) === 'true',
 	};
 
 	componentDidMount() {
@@ -133,6 +136,10 @@ class PurchaseNotice extends Component<
 			params.delete( 'downgraded' );
 			changed = true;
 		}
+		if ( params.get( 'plan_changed' ) === 'true' ) {
+			params.delete( 'plan_changed' );
+			changed = true;
+		}
 		if ( changed ) {
 			const newSearch = params.toString();
 			const newUrl =
@@ -147,6 +154,10 @@ class PurchaseNotice extends Component<
 
 	dismissDowngradedRedirectNotice = () => {
 		this.setState( { showDowngradedRedirectNotice: false } );
+	};
+
+	dismissPlanChangedRedirectNotice = () => {
+		this.setState( { showPlanChangedRedirectNotice: false } );
 	};
 
 	/**
@@ -236,6 +247,30 @@ class PurchaseNotice extends Component<
 				onDismissClick={ this.dismissDowngradedRedirectNotice }
 				status="is-success"
 				text={ this.props.translate( 'You\u2019ve switched to monthly billing.' ) }
+			/>
+		);
+	}
+
+	/**
+	 * Transient success notice shown after a change-plan checkout (upgrade or
+	 * downgrade) redirects back here with `?plan_changed=true`. The URL param is
+	 * cleared on mount so refresh / back-navigation falls through to the regular
+	 * notices.
+	 */
+	renderPlanChangedRedirectNotice() {
+		const { purchase, translate } = this.props;
+		if ( ! this.state.showPlanChangedRedirectNotice || ! purchase ) {
+			return null;
+		}
+		return (
+			<Notice
+				className="manage-purchase__purchase-expiring-notice"
+				showDismiss
+				onDismissClick={ this.dismissPlanChangedRedirectNotice }
+				status="is-success"
+				text={ translate( 'Your plan has been updated to %(planName)s.', {
+					args: { planName: getName( purchase ) },
+				} ) }
 			/>
 		);
 	}
@@ -1419,6 +1454,11 @@ class PurchaseNotice extends Component<
 		const downgradedRedirectNotice = this.renderDowngradedRedirectNotice();
 		if ( downgradedRedirectNotice ) {
 			return downgradedRedirectNotice;
+		}
+
+		const planChangedRedirectNotice = this.renderPlanChangedRedirectNotice();
+		if ( planChangedRedirectNotice ) {
+			return planChangedRedirectNotice;
 		}
 
 		if ( purchase.asyncPendingPaymentBlockIsSet ) {


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/SHILL-2090/

## Proposed changes

Adds a post-checkout success notice that appears after a plan is changed via the expired/grace-period "Change plan" flow, on both the Dashboard and Classic purchase-management surfaces (seehttps://github.com/Automattic/wp-calypso/pull/111409). It reuses the existing URL-param-driven notice pattern (`upgraded`/`downgraded`/`cancelled`) and the shared checkout `:purchaseId` redirect substitution, so no new component props or flags are threaded through.

<img width="1131" height="380" alt="Screenshot 2026-06-08 at 4 07 27 PM" src="https://github.com/user-attachments/assets/d4715e6a-b825-4598-8e3c-a0873402cee7" />

> [!NOTE]
> If you start the downgrade process from the plans page directly rather than the purchase settings page, this notice will not be shown.

## Why are these changes being made?

The expired-plan "Change plan" flow lets a user upgrade or downgrade, but its post-checkout redirect previously landed on the purchase-settings page with `?upgraded=true`, which shows "Your site has been upgraded." — incorrect after a downgrade. After completing a plan change, the user got either a misleading message (Dashboard) or no confirmation at all (Classic).

This adds a neutral, accurate confirmation that covers both upgrade and downgrade outcomes through the single change-plan flow. Rather than detecting up-vs-down at checkout time, it uses one "plan has been updated" message keyed off a `plan_changed` URL param. That param-driven approach matches how the codebase already handles `upgraded`/`downgraded`/`cancelled`/`refunded` notices, and the `:purchaseId` placeholder (resolved by the shared checkout pending page) ensures the notice lands on the newly-provisioned plan and shows its name — so the change stays declarative with no extra props or flags.

## Testing instructions

* Use a site with an expired or grace-period paid plan (Personal/Premium/Business/Commerce). Feature flag `plans/expired-downgrade` must be enabled so you must test in development, wpcalypso, or staging.
* Dashboard: go to the purchase settings page for the expired plan → click "Change plan" → pick a plan → complete checkout. Confirm you land back on the purchase settings page with a green "Your plan has been updated to {new plan name}." notice, and that the `plan_changed` param is stripped from the URL after it appears (refresh should not re-show it).
* Classic: open the manage-purchase page (`/me/purchases/:site/:id`) for the expired plan → click "Change plan" → pick a plan → complete checkout. Confirm the same "Your plan has been updated to {new plan name}." success notice appears and the URL param clears.

