### PR TITLE
Add scroll debug to the Reader POC virtualized flow

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -89,6 +89,7 @@ export class FullPostView extends Component {
 		currentPath: PropTypes.string,
 		isAutomattician: PropTypes.bool,
 		commentsApiDisabled: PropTypes.bool,
+		disableScrollManagement: PropTypes.bool,
 	};
 
 	hasScrolledToCommentAnchor = false;
@@ -118,11 +119,13 @@ export class FullPostView extends Component {
 		this.maybeDisableAppBanner();
 		this.mountedPath = this.props.currentPath;
 
-		this.checkForCommentAnchor();
+		if ( ! this.props.disableScrollManagement ) {
+			this.checkForCommentAnchor();
 
-		// If we have a comment anchor, scroll to comments
-		if ( this.hasCommentAnchor && ! this.hasScrolledToCommentAnchor ) {
-			this.scrollToComments();
+			// If we have a comment anchor, scroll to comments
+			if ( this.hasCommentAnchor && ! this.hasScrolledToCommentAnchor ) {
+				this.scrollToComments();
+			}
 		}
 
 		// Adds WPiFrameResize listener for setting the corect height in embedded iFrames.
@@ -135,13 +138,15 @@ export class FullPostView extends Component {
 
 		document.addEventListener( 'visibilitychange', this.handleVisibilityChange );
 
-		const scrollableContainer = this.findScrollableContainer();
-		if ( scrollableContainer ) {
-			this.scrollableContainer = scrollableContainer;
-			if ( scrollableContainer !== window ) {
-				this.scrollTracker.setContainer( scrollableContainer );
+		if ( ! this.props.disableScrollManagement ) {
+			const scrollableContainer = this.findScrollableContainer();
+			if ( scrollableContainer ) {
+				this.scrollableContainer = scrollableContainer;
+				if ( scrollableContainer !== window ) {
+					this.scrollTracker.setContainer( scrollableContainer );
+				}
+				this.resetScroll();
 			}
-			this.resetScroll();
 		}
 	}
 
@@ -163,8 +168,10 @@ export class FullPostView extends Component {
 				this.trackScrollDepth( prevProps.post );
 				this.trackExitBeforeCompletion( prevProps.post );
 				this.setReadingStartTime();
-				this.resetScroll();
-				this.focusPostTitle();
+				if ( ! this.props.disableScrollManagement ) {
+					this.resetScroll();
+					this.focusPostTitle();
+				}
 			}
 		}
 
@@ -172,11 +179,13 @@ export class FullPostView extends Component {
 			this.hasScrolledToCommentAnchor = false;
 		}
 
-		this.checkForCommentAnchor();
+		if ( ! this.props.disableScrollManagement ) {
+			this.checkForCommentAnchor();
 
-		// If we have a comment anchor, scroll to comments
-		if ( this.hasCommentAnchor && ! this.hasScrolledToCommentAnchor ) {
-			this.scrollToComments();
+			// If we have a comment anchor, scroll to comments
+			if ( this.hasCommentAnchor && ! this.hasScrolledToCommentAnchor ) {
+				this.scrollToComments();
+			}
 		}
 
 		// Check if we just finished loading the post and enable the app banner when there's no error
@@ -319,6 +328,10 @@ export class FullPostView extends Component {
 	};
 
 	resetScroll = () => {
+		if ( this.props.disableScrollManagement ) {
+			return;
+		}
+
 		this.clearResetScrollTimeout();
 		this.resetScrollTimeout = setTimeout( () => {
 			if ( ! this.scrollableContainer ) {
@@ -508,6 +521,10 @@ export class FullPostView extends Component {
 
 	// Scroll to the top of the comments section.
 	scrollToComments = ( { focusTextArea = false } = {} ) => {
+		if ( this.props.disableScrollManagement ) {
+			return;
+		}
+
 		if ( ! this.props.post || this.props.post._state || this._scrolling ) {
 			return;
 		}

--- a/client/reader/index.ts
+++ b/client/reader/index.ts
@@ -40,6 +40,7 @@ import {
 	listListing,
 } from './list/controller';
 import { onThisDay } from './on-this-day/controller';
+import { read295PocList, read295PocPost } from './read-295-poc/controller';
 import { redirectMeToCurrentUser, userProfile } from './user-profile/controller';
 
 function forceTeamA8C( context: Context, next: () => void ): void {
@@ -62,6 +63,26 @@ export async function lazyLoadDependencies(): Promise< void > {
 export default async function (): Promise< void > {
 	await lazyLoadDependencies();
 	setupReadRoutes();
+
+	page(
+		'/reader/read-295-poc',
+		redirectLoggedOutToSignup,
+		sidebar,
+		setBeforePrimary,
+		read295PocList,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/reader/read-295-poc/posts/:sourceType/:sourceId/:post',
+		redirectLoggedOutToSignup,
+		sidebar,
+		setBeforePrimary,
+		read295PocPost,
+		makeLayout,
+		clientRender
+	);
 
 	page(
 		[ '/reader', '/reader/recent/:feed_id' ],

--- a/client/reader/read-295-poc/controller.jsx
+++ b/client/reader/read-295-poc/controller.jsx
@@ -1,0 +1,17 @@
+import Read295Poc from './';
+
+export function read295PocList( context, next ) {
+	context.primary = <Read295Poc />;
+	next();
+}
+
+export function read295PocPost( context, next ) {
+	context.primary = (
+		<Read295Poc
+			sourceType={ context.params.sourceType }
+			sourceId={ context.params.sourceId }
+			postId={ context.params.post }
+		/>
+	);
+	next();
+}

--- a/client/reader/read-295-poc/index.jsx
+++ b/client/reader/read-295-poc/index.jsx
@@ -1,9 +1,19 @@
 import page from '@automattic/calypso-router';
 import { useEffect, useRef } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
+import withDimensions from 'calypso/lib/with-dimensions';
+import ReaderInfiniteStream from 'calypso/reader/components/reader-infinite-stream';
 import ReaderMain from 'calypso/reader/components/reader-main';
 import { isPaddingStreamItem, useInfiniteStream } from 'calypso/reader/data/stream';
 import PostLifecycle from 'calypso/reader/stream/post-lifecycle';
+import PostPlaceholder from 'calypso/reader/stream/post-placeholder';
+import 'calypso/reader/stream/style.scss';
+import {
+	installRead295ScrollDebug,
+	logRead295ScrollDebug,
+	observeRead295ScrollDebugElement,
+	startRead295ScrollDebugTimeline,
+} from './scroll-debug';
 import './style.scss';
 
 const POC_STREAM_KEY = 'following';
@@ -57,21 +67,40 @@ function getPostPath( postKey ) {
 	return null;
 }
 
-function Read295PocListItem( { item, index } ) {
+function Read295PocListItem( { index, item, onShouldMeasure } ) {
+	const rowRef = useRef( null );
 	const postKey = getPostKeyFromStreamItem( item );
 	const path = getPostPath( postKey );
 	const handleClick = () => {
 		if ( path ) {
+			logRead295ScrollDebug( 'card navigate', { index, path, postKey } );
+			startRead295ScrollDebugTimeline( 'card navigate' );
 			page( path );
 		}
 	};
 
+	useEffect( () => {
+		const row = rowRef.current;
+		if ( ! row || ! onShouldMeasure || ! window.ResizeObserver ) {
+			return;
+		}
+
+		const observer = new window.ResizeObserver( () => onShouldMeasure() );
+		observer.observe( row );
+
+		return () => observer.disconnect();
+	}, [ onShouldMeasure ] );
+
 	if ( ! postKey ) {
-		return null;
+		return (
+			<div className="read-295-poc__item" ref={ rowRef }>
+				<PostPlaceholder />
+			</div>
+		);
 	}
 
 	return (
-		<div className="read-295-poc__item" id={ `read-295-poc-post-${ index + 1 }` }>
+		<div className="read-295-poc__item" id={ `read-295-poc-post-${ index + 1 }` } ref={ rowRef }>
 			<PostLifecycle
 				blockedSites={ [] }
 				compact={ false }
@@ -90,61 +119,99 @@ function Read295PocListItem( { item, index } ) {
 	);
 }
 
-function AutoFetchNextPage( { fetchNextPage, hasNextPage, isFetchingNextPage } ) {
-	const sentinelRef = useRef( null );
-
-	useEffect( () => {
-		const sentinel = sentinelRef.current;
-		if ( ! sentinel || ! hasNextPage || isFetchingNextPage ) {
-			return;
-		}
-
-		const observer = new IntersectionObserver(
-			( entries ) => {
-				if ( entries.some( ( entry ) => entry.isIntersecting ) ) {
-					fetchNextPage();
-				}
-			},
-			{ rootMargin: '800px 0px' }
-		);
-
-		observer.observe( sentinel );
-
-		return () => observer.disconnect();
-	}, [ fetchNextPage, hasNextPage, isFetchingNextPage ] );
-
-	if ( ! hasNextPage ) {
-		return null;
-	}
-
-	return (
-		<div className="read-295-poc__load-more" ref={ sentinelRef }>
-			{ isFetchingNextPage ? 'Carregando mais posts...' : ' ' }
-		</div>
+function read295PocRowRenderer( { items, measuredRowRenderer, rowRendererProps } ) {
+	return measuredRowRenderer(
+		Read295PocListItem,
+		{
+			index: rowRendererProps.index,
+			item: items[ rowRendererProps.index ],
+		},
+		rowRendererProps
 	);
 }
 
-function Read295PocList() {
-	const stream = useInfiniteStream( { streamKey: POC_STREAM_KEY } );
-	const items = stream.items.filter( ( item ) => ! isPaddingStreamItem( item ) );
+function Read295PocVirtualizedList( { fetchNextPage, hasNextPage, items, width } ) {
+	useEffect( () => {
+		logRead295ScrollDebug( 'virtualized list update', {
+			itemsLength: items.length,
+			width,
+		} );
+		startRead295ScrollDebugTimeline( 'virtualized list update' );
+	}, [ items.length, width ] );
 
 	return (
-		<ReaderMain className="read-295-poc read-295-poc--list">
+		<ReaderInfiniteStream
+			fetchNextPage={ fetchNextPage }
+			hasNextPage={ hasNextPage }
+			items={ items }
+			minHeight={ 220 }
+			rowRenderer={ read295PocRowRenderer }
+			width={ width }
+		/>
+	);
+}
+
+const Read295PocVirtualizedListWithDimensions = withDimensions( Read295PocVirtualizedList );
+
+function Read295PocList() {
+	const listRef = useRef( null );
+	const stream = useInfiniteStream( { streamKey: POC_STREAM_KEY } );
+	const items = stream.items.filter( ( item ) => ! isPaddingStreamItem( item ) );
+	const fetchNextPage = () => {
+		if ( stream.hasNextPage && ! stream.isFetchingNextPage ) {
+			stream.fetchNextPage();
+		}
+	};
+	const hasNextPage = () => stream.hasNextPage;
+
+	useEffect( () => {
+		installRead295ScrollDebug();
+		logRead295ScrollDebug( 'list mounted', {
+			itemsLength: items.length,
+			hasNextPage: stream.hasNextPage,
+			isFetchingNextPage: stream.isFetchingNextPage,
+		} );
+		startRead295ScrollDebugTimeline( 'list mounted' );
+
+		const stopObserving = observeRead295ScrollDebugElement( 'read-295-poc list', listRef.current );
+
+		return () => {
+			logRead295ScrollDebug( 'list unmounted', {
+				itemsLength: items.length,
+			} );
+			stopObserving?.();
+		};
+		// Keep this mount/unmount logger scoped to the component lifecycle.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+
+	useEffect( () => {
+		logRead295ScrollDebug( 'list data update', {
+			itemsLength: items.length,
+			rawItemsLength: stream.items.length,
+			hasNextPage: stream.hasNextPage,
+			isFetchingNextPage: stream.isFetchingNextPage,
+		} );
+		startRead295ScrollDebugTimeline( 'list data update' );
+	}, [ items.length, stream.hasNextPage, stream.isFetchingNextPage, stream.items.length ] );
+
+	return (
+		<ReaderMain className="read-295-poc read-295-poc--list following">
 			{ stream.error && (
 				<div className="read-295-poc__notice">Erro ao carregar o feed nesta POC.</div>
 			) }
 
-			<div className="read-295-poc__list">
-				{ items.map( ( item, index ) => (
-					<Read295PocListItem item={ item } index={ index } key={ `${ item.postId }-${ index }` } />
-				) ) }
+			<div className="stream__container">
+				<div className="reader__content">
+					<div className="read-295-poc__list stream__list" ref={ listRef }>
+						<Read295PocVirtualizedListWithDimensions
+							fetchNextPage={ fetchNextPage }
+							hasNextPage={ hasNextPage }
+							items={ items }
+						/>
+					</div>
+				</div>
 			</div>
-
-			<AutoFetchNextPage
-				fetchNextPage={ stream.fetchNextPage }
-				hasNextPage={ stream.hasNextPage }
-				isFetchingNextPage={ stream.isFetchingNextPage }
-			/>
 		</ReaderMain>
 	);
 }

--- a/client/reader/read-295-poc/index.jsx
+++ b/client/reader/read-295-poc/index.jsx
@@ -1,0 +1,169 @@
+import page from '@automattic/calypso-router';
+import { useEffect, useRef } from 'react';
+import AsyncLoad from 'calypso/components/async-load';
+import ReaderMain from 'calypso/reader/components/reader-main';
+import { isPaddingStreamItem, useInfiniteStream } from 'calypso/reader/data/stream';
+import PostLifecycle from 'calypso/reader/stream/post-lifecycle';
+import './style.scss';
+
+const POC_STREAM_KEY = 'following';
+
+const loadReaderFullPost = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-blocks-reader-full-post" */ 'calypso/blocks/reader-full-post'
+	);
+
+function valueToNumber( value ) {
+	if ( value === undefined || value === null || value === '' ) {
+		return null;
+	}
+
+	const number = Number( value );
+	return Number.isFinite( number ) ? number : null;
+}
+
+function getPostKeyFromStreamItem( item ) {
+	if ( ! item || isPaddingStreamItem( item ) ) {
+		return null;
+	}
+
+	const postId = valueToNumber( item.postId );
+	if ( ! postId ) {
+		return null;
+	}
+
+	const blogId = valueToNumber( item.blogId );
+	if ( blogId ) {
+		return { blogId, postId };
+	}
+
+	const feedId = valueToNumber( item.feedId );
+	if ( feedId ) {
+		return { feedId, postId };
+	}
+
+	return null;
+}
+
+function getPostPath( postKey ) {
+	if ( postKey?.blogId ) {
+		return `/reader/blogs/${ postKey.blogId }/posts/${ postKey.postId }`;
+	}
+
+	if ( postKey?.feedId ) {
+		return `/reader/feeds/${ postKey.feedId }/posts/${ postKey.postId }`;
+	}
+
+	return null;
+}
+
+function Read295PocListItem( { item, index } ) {
+	const postKey = getPostKeyFromStreamItem( item );
+	const path = getPostPath( postKey );
+	const handleClick = () => {
+		if ( path ) {
+			page( path );
+		}
+	};
+
+	if ( ! postKey ) {
+		return null;
+	}
+
+	return (
+		<div className="read-295-poc__item" id={ `read-295-poc-post-${ index + 1 }` }>
+			<PostLifecycle
+				blockedSites={ [] }
+				compact={ false }
+				fixedHeaderHeight={ 0 }
+				handleClick={ handleClick }
+				index={ index }
+				isDiscoverStream={ false }
+				isSelected={ false }
+				postKey={ postKey }
+				showBylineSecondarySiteLink={ false }
+				showFollowButton={ false }
+				showSiteName
+				streamKey={ POC_STREAM_KEY }
+			/>
+		</div>
+	);
+}
+
+function AutoFetchNextPage( { fetchNextPage, hasNextPage, isFetchingNextPage } ) {
+	const sentinelRef = useRef( null );
+
+	useEffect( () => {
+		const sentinel = sentinelRef.current;
+		if ( ! sentinel || ! hasNextPage || isFetchingNextPage ) {
+			return;
+		}
+
+		const observer = new IntersectionObserver(
+			( entries ) => {
+				if ( entries.some( ( entry ) => entry.isIntersecting ) ) {
+					fetchNextPage();
+				}
+			},
+			{ rootMargin: '800px 0px' }
+		);
+
+		observer.observe( sentinel );
+
+		return () => observer.disconnect();
+	}, [ fetchNextPage, hasNextPage, isFetchingNextPage ] );
+
+	if ( ! hasNextPage ) {
+		return null;
+	}
+
+	return (
+		<div className="read-295-poc__load-more" ref={ sentinelRef }>
+			{ isFetchingNextPage ? 'Carregando mais posts...' : ' ' }
+		</div>
+	);
+}
+
+function Read295PocList() {
+	const stream = useInfiniteStream( { streamKey: POC_STREAM_KEY } );
+	const items = stream.items.filter( ( item ) => ! isPaddingStreamItem( item ) );
+
+	return (
+		<ReaderMain className="read-295-poc read-295-poc--list">
+			{ stream.error && (
+				<div className="read-295-poc__notice">Erro ao carregar o feed nesta POC.</div>
+			) }
+
+			<div className="read-295-poc__list">
+				{ items.map( ( item, index ) => (
+					<Read295PocListItem item={ item } index={ index } key={ `${ item.postId }-${ index }` } />
+				) ) }
+			</div>
+
+			<AutoFetchNextPage
+				fetchNextPage={ stream.fetchNextPage }
+				hasNextPage={ stream.hasNextPage }
+				isFetchingNextPage={ stream.isFetchingNextPage }
+			/>
+		</ReaderMain>
+	);
+}
+
+function Read295PocPost( { sourceType, sourceId, postId } ) {
+	const postProps =
+		sourceType === 'blog' ? { blogId: sourceId, postId } : { feedId: sourceId, postId };
+
+	return (
+		<div className="read-295-poc read-295-poc--full-post">
+			<AsyncLoad disableScrollManagement require={ loadReaderFullPost } { ...postProps } />
+		</div>
+	);
+}
+
+export default function Read295Poc( { sourceType, sourceId, postId } ) {
+	if ( postId ) {
+		return <Read295PocPost postId={ postId } sourceId={ sourceId } sourceType={ sourceType } />;
+	}
+
+	return <Read295PocList />;
+}

--- a/client/reader/read-295-poc/scroll-debug.js
+++ b/client/reader/read-295-poc/scroll-debug.js
@@ -1,0 +1,222 @@
+/* eslint-disable no-console */
+
+const DEBUG_KEY = '__read295ScrollDebug';
+const LOG_PREFIX = '[READ-295][scroll]';
+const TIMELINE_DURATION_MS = 7000;
+
+function getDocumentHeight() {
+	const scrollingElement = document.scrollingElement || document.documentElement;
+	return scrollingElement?.scrollHeight ?? 0;
+}
+
+function getScrollSnapshot() {
+	const scrollingElement = document.scrollingElement || document.documentElement;
+
+	return {
+		timestamp: Math.round( performance.now() ),
+		path: window.location.pathname,
+		hash: window.location.hash,
+		scrollY: Math.round( window.scrollY ),
+		pageYOffset: Math.round( window.pageYOffset ),
+		documentScrollTop: Math.round( scrollingElement?.scrollTop ?? 0 ),
+		documentHeight: Math.round( getDocumentHeight() ),
+		viewportHeight: Math.round( window.innerHeight ),
+	};
+}
+
+function getElementSnapshot( element ) {
+	if ( ! element ) {
+		return null;
+	}
+
+	const rect = element.getBoundingClientRect?.();
+	return {
+		tagName: element.tagName,
+		className: element.className,
+		id: element.id,
+		scrollTop: Math.round( element.scrollTop ?? 0 ),
+		scrollHeight: Math.round( element.scrollHeight ?? 0 ),
+		clientHeight: Math.round( element.clientHeight ?? 0 ),
+		rectTop: rect ? Math.round( rect.top ) : undefined,
+		rectHeight: rect ? Math.round( rect.height ) : undefined,
+	};
+}
+
+function getStack() {
+	return new Error().stack?.split( '\n' ).slice( 2, 9 ).join( '\n' );
+}
+
+function log( label, data = {} ) {
+	console.log( LOG_PREFIX, label, {
+		...getScrollSnapshot(),
+		...data,
+	} );
+}
+
+function startTimeline( reason ) {
+	const debugState = window[ DEBUG_KEY ];
+	if ( ! debugState ) {
+		return;
+	}
+
+	if ( debugState.timelineFrame ) {
+		cancelAnimationFrame( debugState.timelineFrame );
+	}
+
+	const startedAt = performance.now();
+	let previous = getScrollSnapshot();
+	log( 'timeline start', { reason } );
+
+	const tick = () => {
+		const next = getScrollSnapshot();
+		const scrollChanged = Math.abs( next.scrollY - previous.scrollY ) > 1;
+		const heightChanged = Math.abs( next.documentHeight - previous.documentHeight ) > 1;
+
+		if ( scrollChanged || heightChanged ) {
+			log( 'timeline change', {
+				reason,
+				previous,
+				next,
+				scrollChanged,
+				heightChanged,
+			} );
+			previous = next;
+		}
+
+		if ( performance.now() - startedAt < TIMELINE_DURATION_MS ) {
+			debugState.timelineFrame = requestAnimationFrame( tick );
+			return;
+		}
+
+		debugState.timelineFrame = null;
+		log( 'timeline end', { reason } );
+	};
+
+	debugState.timelineFrame = requestAnimationFrame( tick );
+}
+
+function patchWindowScrollTo( debugState ) {
+	window.scrollTo = function read295WindowScrollTo( ...args ) {
+		log( 'window.scrollTo', {
+			args,
+			stack: getStack(),
+		} );
+		startTimeline( 'window.scrollTo' );
+		return debugState.originalWindowScrollTo.apply( this, args );
+	};
+}
+
+function patchElementScrollTo( debugState ) {
+	if ( ! debugState.originalElementScrollTo ) {
+		return;
+	}
+
+	window.Element.prototype.scrollTo = function read295ElementScrollTo( ...args ) {
+		log( 'element.scrollTo', {
+			args,
+			element: getElementSnapshot( this ),
+			stack: getStack(),
+		} );
+		startTimeline( 'element.scrollTo' );
+		return debugState.originalElementScrollTo.apply( this, args );
+	};
+}
+
+export function installRead295ScrollDebug() {
+	if ( typeof window === 'undefined' || window[ DEBUG_KEY ]?.installed ) {
+		return;
+	}
+
+	const debugState = {
+		installed: true,
+		originalWindowScrollTo: window.scrollTo,
+		originalElementScrollTo: window.Element?.prototype?.scrollTo,
+		timelineFrame: null,
+		scrollFrame: null,
+	};
+
+	window[ DEBUG_KEY ] = debugState;
+	patchWindowScrollTo( debugState );
+	patchElementScrollTo( debugState );
+
+	const onScroll = () => {
+		if ( debugState.scrollFrame ) {
+			return;
+		}
+
+		debugState.scrollFrame = requestAnimationFrame( () => {
+			debugState.scrollFrame = null;
+			log( 'window scroll event' );
+		} );
+	};
+
+	const onPopState = () => {
+		log( 'popstate' );
+		startTimeline( 'popstate' );
+	};
+
+	const onPageShow = ( event ) => {
+		log( 'pageshow', { persisted: event.persisted } );
+		startTimeline( 'pageshow' );
+	};
+
+	const onClick = ( event ) => {
+		const target = event.target?.closest?.( 'a, button, .reader__card' );
+		if ( ! target ) {
+			return;
+		}
+
+		log( 'click', {
+			element: getElementSnapshot( target ),
+			href: target.href,
+		} );
+		startTimeline( 'click' );
+	};
+
+	window.addEventListener( 'scroll', onScroll, { passive: true } );
+	window.addEventListener( 'popstate', onPopState );
+	window.addEventListener( 'pageshow', onPageShow );
+	document.addEventListener( 'click', onClick, true );
+
+	log( 'debug installed' );
+	startTimeline( 'debug installed' );
+}
+
+export function logRead295ScrollDebug( label, data = {} ) {
+	if ( typeof window === 'undefined' ) {
+		return;
+	}
+
+	log( label, data );
+}
+
+export function startRead295ScrollDebugTimeline( reason ) {
+	if ( typeof window === 'undefined' ) {
+		return;
+	}
+
+	startTimeline( reason );
+}
+
+export function observeRead295ScrollDebugElement( label, element ) {
+	if ( typeof window === 'undefined' || ! element || ! window.ResizeObserver ) {
+		return;
+	}
+
+	let previous = getElementSnapshot( element );
+	log( 'element observe start', { label, element: previous } );
+
+	const observer = new window.ResizeObserver( () => {
+		const next = getElementSnapshot( element );
+		log( 'element resize', {
+			label,
+			previous,
+			next,
+		} );
+		previous = next;
+		startTimeline( `${ label } resize` );
+	} );
+
+	observer.observe( element );
+	return () => observer.disconnect();
+}

--- a/client/reader/read-295-poc/style.scss
+++ b/client/reader/read-295-poc/style.scss
@@ -1,0 +1,86 @@
+body.is-section-reader.is-global:has( .read-295-poc ) {
+	overflow-y: auto;
+}
+
+body.is-section-reader
+	div.layout.is-global-sidebar-visible
+	.layout__primary
+	> div:has( .read-295-poc ) {
+	height: auto;
+	overflow: visible;
+}
+
+body.is-section-reader
+	div.layout.is-global-sidebar-visible
+	.layout__primary
+	> div:has( .read-295-poc )
+	> div {
+	height: auto;
+	overflow: visible;
+}
+
+.read-295-poc {
+	box-sizing: border-box;
+	margin: 0 auto;
+	max-width: 760px;
+	padding: 32px 24px 80px;
+
+	* {
+		box-sizing: border-box;
+	}
+}
+
+.read-295-poc__post {
+	background: var( --color-surface );
+	border: 1px solid var( --color-border-subtle );
+	border-radius: 4px;
+	box-shadow: 0 1px 2px color-mix( in srgb, var( --color-neutral-100 ) 8%, transparent );
+	min-height: 120vh;
+	padding: 24px;
+
+	button {
+		margin-bottom: 24px;
+	}
+}
+
+.read-295-poc h1,
+.read-295-poc h2,
+.read-295-poc p {
+	margin-top: 0;
+}
+
+.read-295-poc__list {
+	display: grid;
+	gap: 18px;
+}
+
+.read-295-poc__item {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	justify-content: space-between;
+}
+
+.read-295-poc__post a,
+.read-295-poc__post button {
+	align-self: flex-start;
+	background: var( --color-primary );
+	border: 0;
+	border-radius: 4px;
+	color: var( --color-text-inverted );
+	cursor: pointer;
+	display: inline-flex;
+	font-size: 0.875rem;
+	font-weight: 500;
+	line-height: 1;
+	padding: 10px 14px;
+	text-decoration: none;
+}
+
+.read-295-poc__load-more {
+	color: var( --color-text-subtle );
+	font-size: 0.875rem;
+	margin-top: 24px;
+	min-height: 32px;
+	text-align: center;
+}

--- a/client/reader/read-295-poc/style.scss
+++ b/client/reader/read-295-poc/style.scss
@@ -22,7 +22,7 @@ body.is-section-reader
 .read-295-poc {
 	box-sizing: border-box;
 	margin: 0 auto;
-	max-width: 760px;
+	max-width: 720px;
 	padding: 32px 24px 80px;
 
 	* {
@@ -50,8 +50,9 @@ body.is-section-reader
 }
 
 .read-295-poc__list {
-	display: grid;
-	gap: 18px;
+	margin: 0 auto;
+	max-width: 672px;
+	width: 100%;
 }
 
 .read-295-poc__item {
@@ -59,6 +60,11 @@ body.is-section-reader
 	flex-direction: column;
 	gap: 8px;
 	justify-content: space-between;
+}
+
+.read-295-poc .reader-infinite-stream__row-wrapper {
+	border-bottom: 0;
+	padding-bottom: 18px;
 }
 
 .read-295-poc__post a,
@@ -75,12 +81,4 @@ body.is-section-reader
 	line-height: 1;
 	padding: 10px 14px;
 	text-decoration: none;
-}
-
-.read-295-poc__load-more {
-	color: var( --color-text-subtle );
-	font-size: 0.875rem;
-	margin-top: 24px;
-	min-height: 32px;
-	text-align: center;
 }

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -4,23 +4,17 @@ import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { times } from 'lodash';
 import PropTypes from 'prop-types';
-import { createRef, Component, Fragment } from 'react';
+import { Component, Fragment } from 'react';
 import * as React from 'react';
-import ReactDom from 'react-dom';
 import { connect, useDispatch } from 'react-redux';
 import AppPromo from 'calypso/blocks/app-promo';
-import { usePostLikes } from 'calypso/components/data/post-likes';
 import InfiniteList from 'calypso/components/infinite-list';
 import ListEnd from 'calypso/components/list-end';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
-import scrollTo from 'calypso/lib/scroll-to';
 import withDimensions from 'calypso/lib/with-dimensions';
-import { isEditorIframeFocused } from 'calypso/reader/components/quick-post/utils';
 import ReaderMain from 'calypso/reader/components/reader-main';
-import { useCachedPost } from 'calypso/reader/data/post/cache';
-import { withPostLikeActions } from 'calypso/reader/data/post/likes';
 import { useSiteSubscriptions } from 'calypso/reader/data/site-subscriptions';
 import {
 	analyticsForStream,
@@ -29,13 +23,11 @@ import {
 	PER_FETCH,
 	useInfiniteStream,
 } from 'calypso/reader/data/stream';
-import { isLikeable } from 'calypso/reader/post/capabilities';
-import { keysAreEqual, keyToString } from 'calypso/reader/post-key';
+import { keyToString } from 'calypso/reader/post-key';
 import { MAX_POSTS_FOR_LOGGED_OUT_USERS } from 'calypso/reader/reader.const';
 import ReaderStreamLoginPrompt from 'calypso/reader/stream/login-prompt';
 import UpdateNotice from 'calypso/reader/update-notice';
 import { showSelectedPost, getStreamType } from 'calypso/reader/utils';
-import XPostHelper from 'calypso/reader/xpost-helper';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getBlockedSites } from 'calypso/state/reader/site-blocks/selectors';
 import { viewStream } from 'calypso/state/reader-ui/actions';
@@ -43,7 +35,6 @@ import { resetCardExpansions } from 'calypso/state/reader-ui/card-expansions/act
 import { getSelectedRecentFeedId } from 'calypso/state/reader-ui/sidebar/selectors';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
-import isNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
 import { ReaderPerformanceTrackerStop } from '../reader-performance-tracker';
 import { CustomerCouncilBanner } from './customer-council-banner';
 import EmptyContent from './empty';
@@ -51,7 +42,6 @@ import { StreamError } from './error';
 import PostLifecycle from './post-lifecycle';
 import PostPlaceholder from './post-placeholder';
 import { useStreamPendingPosts } from './use-stream-pending-posts';
-import { useStreamPostKeySelection } from './use-stream-post-key-selection';
 import {
 	getDistanceBetweenPrompts,
 	getDistanceBetweenRecs,
@@ -64,7 +54,6 @@ export const WIDE_DISPLAY_CUTOFF = 950 + 64 * 2 + 8 * 2;
 const GUESSED_POST_HEIGHT = 600;
 const noop = () => {};
 const pagesByKey = new Map();
-const inputTags = [ 'INPUT', 'SELECT', 'TEXTAREA' ];
 
 const useStreamRenderAnalytics = ( pages, streamKey ) => {
 	const dispatch = useDispatch();
@@ -109,7 +98,6 @@ class ReaderStream extends Component {
 		onUpdatesShown: PropTypes.func,
 		placeholderFactory: PropTypes.func,
 		recsStreamKey: PropTypes.string,
-		restoreScroll: PropTypes.bool,
 		hideDefaultEmptyContentIfMissing: PropTypes.bool,
 		showFollowButton: PropTypes.bool,
 		showFollowInHeader: PropTypes.bool,
@@ -129,7 +117,6 @@ class ReaderStream extends Component {
 		fetchNextPage: PropTypes.func,
 		pendingCount: PropTypes.number,
 		consumePending: PropTypes.func,
-		isRefetching: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -139,7 +126,6 @@ class ReaderStream extends Component {
 		isDiscoverStream: false,
 		isMain: true,
 		onUpdatesShown: noop,
-		restoreScroll: true,
 		showFollowButton: true,
 		showFollowInHeader: false,
 		suppressSiteNameLink: false,
@@ -155,19 +141,6 @@ class ReaderStream extends Component {
 
 	isMounted = false;
 
-	/**
-	 * A mutation observer to watch whether the target exists
-	 */
-	observer = null;
-
-	// We can use to keep track of whether we need to scroll to the selected post in the update
-	// cycle.
-	wasSelectedByOpeningPost = false;
-
-	listRef = createRef();
-	overlayRef = createRef();
-	mountTimeout = null;
-
 	handlePostsSelected = () => {
 		this.setState( { selectedTab: 'posts' } );
 	};
@@ -175,324 +148,23 @@ class ReaderStream extends Component {
 		this.setState( { selectedTab: 'sites' } );
 	};
 
-	componentDidUpdate( { selectedPostKey, streamKey, selectedFeedId } ) {
-		// Fetch new page if selected feed or stream is changed.
-		if ( selectedFeedId !== this.props.selectedFeedId ) {
-			// `useInfiniteStream` is keyed by `feedId`, so the cache rotates
-			// automatically — no manual purge needed. Selection lives under the
-			// new `streamKey`'s entry, which starts empty.
-			this.scrollFeedListToTop();
-		} else if ( streamKey !== this.props.streamKey ) {
+	componentDidUpdate( { streamKey } ) {
+		if ( streamKey !== this.props.streamKey ) {
 			this.props.resetCardExpansions();
 			this.props.viewStream( streamKey, window.location.pathname );
 		}
-
-		if ( ! keysAreEqual( selectedPostKey, this.props.selectedPostKey ) ) {
-			// Don't scroll to the post if it was clicked for selection. This causes the scroll to
-			// propagate into the full post screen the first time you click select an item in the
-			// reader, meaning the full post screen opens halfway scrolled down the post.
-			if ( ! this.wasSelectedByOpeningPost ) {
-				this.scrollToSelectedPost( true );
-			}
-			this.wasSelectedByOpeningPost = false;
-			this.focusSelectedPost( this.props.selectedPostKey );
-		}
 	}
+
 	tryAgain = () => {
 		this.props.refetch();
 	};
-
-	focusSelectedPost = ( selectedPostKey ) => {
-		const postRefKey = this.getPostRef( selectedPostKey );
-		const ref = this.listRef.current && this.listRef.current.refs[ postRefKey ];
-		const node = ReactDom.findDOMNode( ref );
-
-		if ( node ) {
-			// Skip anchors inside .user-avatar to avoid triggering hovercard.
-			const firstLink = node.querySelector( 'a:not(.user-avatar a)' );
-
-			if ( firstLink ) {
-				firstLink.focus();
-			}
-		}
-	};
-
-	_popstate = () => {
-		if (
-			this.props.selectedPostKey &&
-			window.history.scrollRestoration !== 'manual' &&
-			this.props.restoreScroll
-		) {
-			this.scrollToSelectedPost( false );
-		}
-	};
-
-	scrollToSelectedPost( animate ) {
-		// Don't scroll when the selection is the very first item in the list:
-		// the page is (or should be) already at the top, and pushing it past
-		// the fixed header just to "show" item 0 looks like a glitch — the
-		// user wasn't navigating away from item 0 in the first place.
-		if ( this.props.selectedPostIndex === 0 ) {
-			return;
-		}
-		const scrollContainer = this.state.listContext || window;
-		const containerOffset = scrollContainer.getBoundingClientRect?.().top || 0;
-		const headerOffset = -1 * this.props.fixedHeaderHeight || 0; // a fixed position header means we can't just scroll the element into view.
-		const totalOffset = headerOffset - containerOffset - 20; // 20px of constant offset to ensure the post isnt cramped against the top container or header border.
-		const selectedNode = ReactDom.findDOMNode( this ).querySelector( '.card.is-selected' );
-		if ( selectedNode ) {
-			selectedNode.focus();
-			const scrollContainerPosition = scrollContainer.scrollTop;
-			const boundingClientRect = selectedNode.getBoundingClientRect();
-			const scrollY = parseInt(
-				scrollContainerPosition + boundingClientRect.top + totalOffset,
-				10
-			);
-			if ( animate ) {
-				scrollTo( {
-					x: 0,
-					y: scrollY,
-					duration: 200,
-					container: scrollContainer,
-				} );
-			} else {
-				scrollContainer.scrollTo( 0, scrollY );
-			}
-		}
-	}
 
 	componentDidMount() {
 		const { streamKey } = this.props;
 		this.props.resetCardExpansions();
 		this.props.viewStream( streamKey, window.location.pathname );
 		this.isMounted = true;
-
-		window.addEventListener( 'popstate', this._popstate );
-		if ( 'scrollRestoration' in window.history ) {
-			window.history.scrollRestoration = 'manual';
-		}
-
-		if ( this.props.selectedPostKey ) {
-			// Show an overlay while we are handling initial scroll and focus to prevent flashing
-			// content.
-			if ( this.overlayRef.current ) {
-				this.overlayRef.current.classList.add( 'stream__init-overlay-enabled' );
-			}
-			this.mountTimeout = setTimeout( () => {
-				if ( this.props.restoreScroll ) {
-					this.scrollToSelectedPost( false );
-					this.focusSelectedPost( this.props.selectedPostKey );
-				}
-				if ( this.overlayRef.current ) {
-					this.overlayRef.current.classList.remove( 'stream__init-overlay-enabled' );
-				}
-			}, 100 );
-		}
-
-		document.addEventListener( 'keydown', this.handleKeydown, true );
-
-		/**
-		 * Observe the class list of the body element because the scroll container depends on it.
-		 */
-		this.observer = new window.MutationObserver( () => {
-			if ( ! this.listRef.current ) {
-				return;
-			}
-
-			const scrollContainer = this.getScrollContainer(
-				ReactDom.findDOMNode( this.listRef.current )
-			);
-			if ( scrollContainer !== this.state.listContext ) {
-				this.setState( {
-					listContext: scrollContainer,
-				} );
-			}
-		} );
-		this.observer.observe( document.body, { attributeFilter: [ 'class' ] } );
 	}
-
-	componentWillUnmount() {
-		window.removeEventListener( 'popstate', this._popstate );
-		if ( 'scrollRestoration' in window.history ) {
-			window.history.scrollRestoration = 'auto';
-		}
-
-		document.removeEventListener( 'keydown', this.handleKeydown, true );
-
-		if ( this.observer ) {
-			this.observer.disconnect();
-		}
-
-		if ( this.mountTimeout ) {
-			clearTimeout( this.mountTimeout );
-		}
-	}
-
-	handleKeydown = ( event ) => {
-		if ( this.props.notificationsOpen ) {
-			return;
-		}
-
-		const tagName = ( event.target || event.srcElement ).tagName;
-		if (
-			inputTags.includes( tagName ) ||
-			event.target.isContentEditable ||
-			isEditorIframeFocused() // Disable keyboard shortcuts when quick post editor is focused.
-		) {
-			return;
-		}
-
-		if ( event?.metaKey || event?.ctrlKey ) {
-			// avoid conflicting with the command palette shortcut cmd+k
-			return;
-		}
-
-		switch ( event.key ) {
-			// Move selection down.
-			case 'ArrowRight':
-			case 'j': {
-				return this.selectNextItem();
-			}
-
-			// Move selection up.
-			case 'ArrowLeft':
-			case 'k': {
-				return this.selectPrevItem();
-			}
-
-			// Open selection.
-			case 'Enter': {
-				return this.handleOpenSelection();
-			}
-
-			// Open selection in a new tab.
-			case 'v': {
-				return this.handleOpenSelectionNewTab();
-			}
-
-			// Like selection.
-			case 'l': {
-				return this.toggleLikeOnSelectedPost();
-			}
-		}
-	};
-
-	handleOpenSelectionNewTab = () => {
-		const { selectedPostKey } = this.props;
-		if ( selectedPostKey ) {
-			window.open( selectedPostKey.url, '_blank', 'noreferrer,noopener' );
-		}
-	};
-
-	handleOpenSelection = () => {
-		this.props.showSelectedPost( {
-			store: this.props.streamKey,
-			postKey: this.props.selectedPostKey,
-		} );
-	};
-
-	toggleLikeOnSelectedPost = () => {
-		const { selectedPost } = this.props;
-
-		// only toggle a like on a x-post if we have the appropriate metadata,
-		// and original post is full screen
-		const xPostMetadata = XPostHelper.getXPostMetadata( selectedPost );
-		if ( xPostMetadata?.postURL ) {
-			return;
-		}
-
-		if ( isLikeable( selectedPost ) ) {
-			this.toggleLikeAction();
-		}
-	};
-
-	toggleLikeAction() {
-		const { isLikePending, isUnlikePending, likedPost, selectedPost } = this.props;
-		if ( likedPost === null ) {
-			// unknown... ignore for now
-			return;
-		}
-
-		if ( isLikePending || isUnlikePending ) {
-			return;
-		}
-
-		const toggler = likedPost ? this.props.unlikePost : this.props.likePost;
-		toggler( selectedPost.site_ID, selectedPost.ID, { source: 'reader' } );
-	}
-
-	getVisibleItemIndexes() {
-		return (
-			this.listRef.current &&
-			this.listRef.current.getVisibleItemIndexes( { offsetTop: this.props.fixedHeaderHeight || 0 } )
-		);
-	}
-
-	selectNextItem = () => {
-		// note that we grab the items directly from the stream because we don't want the transformed
-		// one with combined cards
-		const { items } = this.props;
-
-		// This should already be false but this is a safety.
-		this.wasSelectedByOpeningPost = false;
-
-		// If the currently selected item is too far away in scroll position to be rendered by the
-		// infinite list, lets fall back to the magic selection functionality noted below.
-		const selectedItem = this.state.listContext?.querySelector( '.card.is-selected' );
-		// do we have a selected item? if so, just move to the next one
-		if ( this.props.selectedPostKey && selectedItem ) {
-			this.props.selectNextPost();
-			return;
-		}
-
-		const visibleIndexes = this.getVisibleItemIndexes();
-
-		// This is slightly magical...
-		// When a user tries to select the "next" item, we really want to select
-		// the next item if and only if the currently selected item is at the top of the
-		// screen. If the currently selected item is off screen, we'd rather select the item
-		// at the top of the screen, rather than the strictly "next" item. This is so a user can
-		// pick an item with the keyboard shortcuts, then scroll down a bit, then hit `next` again
-		// and have it pick the item at the top of the screen, rather than the item we scrolled past
-		if ( visibleIndexes && visibleIndexes.length > 0 ) {
-			// default to the first item in the visible list. this item is likely off screen when the user
-			// is scrolled down the page
-			let index = visibleIndexes[ 0 ].index;
-
-			// walk down the list of "visible" items, looking for the first item whose top extent is on screen
-			for ( let i = 0; i < visibleIndexes.length; i++ ) {
-				const visibleIndex = visibleIndexes[ i ];
-				// skip items whose top are off screen or are recommendation blocks
-				if ( visibleIndex.bounds.top > 0 && ! items[ visibleIndex.index ].isRecommendationBlock ) {
-					index = visibleIndex.index;
-					break;
-				}
-			}
-
-			const candidate = items[ index ];
-			if ( keysAreEqual( candidate, this.props.selectedPostKey ) ) {
-				this.props.selectNextPost();
-			} else {
-				this.props.selectPostKey( candidate );
-			}
-		}
-	};
-
-	selectPrevItem = () => {
-		// note that we grab the items directly from the stream because we don't want the transformed
-		// one with combined cards
-		const { selectedPostKey, items } = this.props;
-
-		// This should already be false but this is a safety.
-		this.wasSelectedByOpeningPost = false;
-
-		// unlike selectNextItem, we don't want any magic here. Just move back an item if the user
-		// currently has a selected item. Otherwise do nothing.
-		// We avoid the magic here because we expect users to enter the flow using next, not previous.
-		if ( selectedPostKey ) {
-			this.props.selectPreviousPost( items );
-		}
-	};
 
 	getPageHandle = ( pageHandle, startDate ) => {
 		if ( pageHandle ) {
@@ -526,15 +198,6 @@ class ReaderStream extends Component {
 	showUpdates = () => {
 		this.props.onUpdatesShown();
 		this.props.consumePending();
-		this.scrollFeedListToTop();
-	};
-
-	scrollFeedListToTop = () => {
-		if ( ! this.listRef.current ) {
-			return;
-		}
-
-		this.listRef.current.scrollToTop();
 	};
 
 	renderLoadingPlaceholders = () => {
@@ -587,20 +250,10 @@ class ReaderStream extends Component {
 	};
 
 	renderPost = ( postKey, index ) => {
-		const { selectedPostKey, streamKey, primarySiteId } = this.props;
-		const isSelected = !! ( selectedPostKey && keysAreEqual( selectedPostKey, postKey ) );
+		const { streamKey, primarySiteId } = this.props;
 
 		const itemKey = this.getPostRef( postKey );
 		const showPost = ( args ) => {
-			// Ensure the post selected becomes the selected item. It may already be the selected
-			// item through shortkeys, or not if using a mouse clicking flow. Setting the selected
-			// item this way adds consistency to scroll position when coming back from the full post
-			// view, as well as avoids conflict between our systems for preserving scroll position
-			// and scrolling to selected posts when users use a mix of shortkeys and mouse clicks.
-			if ( ! isSelected ) {
-				this.props.selectPostKey( postKey );
-				this.wasSelectedByOpeningPost = true;
-			}
 			this.props.showSelectedPost( {
 				...args,
 				postKey: postKey,
@@ -613,14 +266,13 @@ class ReaderStream extends Component {
 				{ this.renderAppPromo( index ) }
 				<PostLifecycle
 					ref={ itemKey /* The ref is stored into `InfiniteList`'s `this.ref` map */ }
-					isSelected={ isSelected }
+					isSelected={ false }
 					handleClick={ showPost }
 					postKey={ postKey }
 					suppressSiteNameLink={ this.props.suppressSiteNameLink }
 					showFollowInHeader={ this.props.showFollowInHeader }
 					isDiscoverStream={ this.props.isDiscoverStream }
 					showSiteName={ this.props.showSiteNameOnCards }
-					selectedPostKey={ undefined }
 					followSource={ this.props.followSource }
 					blockedSites={ this.props.blockedSites }
 					streamKey={ streamKey }
@@ -637,36 +289,8 @@ class ReaderStream extends Component {
 		);
 	};
 
-	setListContext = ( component ) => {
-		if ( ! component ) {
-			return;
-		}
-
-		this.listRef.current = component;
-		this.setState( {
-			listContext: this.getScrollContainer( ReactDom.findDOMNode( component ) ),
-		} );
-	};
-
-	getScrollContainer = ( node ) => {
-		// Leave it to the default scroll container if we cannot find it or its the root element.
-		if ( ! node || node.ownerDocument === node.parentNode ) {
-			return false;
-		}
-
-		// Return when overflow is defined to either auto or scroll.
-		const { overflowY } = getComputedStyle( node );
-		if ( /(auto|scroll)/.test( overflowY ) ) {
-			return node;
-		}
-
-		// Continue traversing.
-		return this.getScrollContainer( node.parentNode );
-	};
-
 	render() {
-		const { translate, forcePlaceholders, lastPage, streamHeader, streamKey, selectedPostKey } =
-			this.props;
+		const { translate, forcePlaceholders, lastPage, streamHeader, streamKey } = this.props;
 		const wideDisplay = this.props.width > WIDE_DISPLAY_CUTOFF;
 		const isReaderCouncilStream = false; // Disabling banner. Original condition: ( this.props.isDiscoverStream || this.props.streamKey === 'following' );
 		let { items, isRequesting } = this.props;
@@ -685,7 +309,11 @@ class ReaderStream extends Component {
 
 		// TODO: `following` probably shouldn't be added as a class to every stream, but style selectors need
 		// to be updated before we can remove it.
-		let baseClassnames = clsx( 'following', this.props.className );
+		let baseClassnames = clsx(
+			'following',
+			'reader-stream__browser-scroll-poc',
+			this.props.className
+		);
 		const SidebarContent =
 			typeof this.props.streamSidebar === 'function'
 				? this.props.streamSidebar( wideDisplay )
@@ -717,7 +345,6 @@ class ReaderStream extends Component {
 				<>
 					<InfiniteList
 						key={ this.props.streamKey }
-						ref={ this.setListContext }
 						items={ items }
 						lastPage={ lastPage }
 						fetchingNextPage={ isRequesting }
@@ -727,9 +354,7 @@ class ReaderStream extends Component {
 						renderItem={ this.renderPost }
 						renderLoadingPlaceholders={ this.renderLoadingPlaceholders }
 						className="stream__list"
-						context={ this.state.listContext }
-						selectedItem={ selectedPostKey }
-						restoreScroll={ this.props.restoreScroll }
+						restoreScroll={ false }
 					/>
 				</>
 			);
@@ -813,7 +438,6 @@ class ReaderStream extends Component {
 
 		return (
 			<TopLevel className={ baseClassnames } wideLayout={ this.props.wideLayout }>
-				<div ref={ this.overlayRef } className="stream__init-overlay" />
 				<UpdateNotice count={ this.props.pendingCount } onClick={ this.showUpdates } />
 				{ this.props.children }
 				{ showingStream && items.length ? this.props.intro?.() : null }
@@ -918,32 +542,6 @@ const withStreamPosts = ( WrappedComponent ) =>
 			resetPending();
 		}, [ refetch, resetPending ] );
 
-		// Selection lives in the React Query cache (not Redux). The hook is
-		// keyed by `[streamKey, localeSlug]`, so switching streams (including
-		// `following:feed-X` ↔ `following:feed-Y`) naturally yields a fresh
-		// `selectedPostKey`.
-		const {
-			selectedPostKey,
-			selectedPostIndex,
-			selectPostKey,
-			selectNextPost,
-			selectPreviousPost,
-		} = useStreamPostKeySelection( {
-			streamKey: props.streamKey,
-			localeSlug: props.localeSlug,
-			feedId: props.selectedFeedId,
-			startDate: props.startDate,
-			items: streamPostsQuery.items,
-		} );
-
-		// `<Stream>` reads the selected post body for keyboard actions from the
-		// canonical Reader post cache, then uses the post likes query as the
-		// source of truth for the current liked state.
-		const canonicalSelectedPost = useCachedPost( selectedPostKey );
-		const selectedPost = canonicalSelectedPost;
-		const { postLikes } = usePostLikes( selectedPost?.site_ID, selectedPost?.ID );
-		const likedPost = selectedPost ? postLikes?.iLike ?? Boolean( selectedPost.i_like ) : null;
-
 		return (
 			<WrappedComponent
 				{ ...props }
@@ -960,13 +558,6 @@ const withStreamPosts = ( WrappedComponent ) =>
 				fetchNextPage={ streamPostsQuery.fetchNextPage }
 				pendingCount={ pendingCount }
 				consumePending={ consumePending }
-				selectedPostKey={ selectedPostKey }
-				selectedPostIndex={ selectedPostIndex }
-				selectPostKey={ selectPostKey }
-				selectNextPost={ selectNextPost }
-				selectPreviousPost={ selectPreviousPost }
-				selectedPost={ selectedPost }
-				likedPost={ likedPost }
 			/>
 		);
 	};
@@ -983,7 +574,6 @@ export default connect(
 
 		return {
 			blockedSites: getBlockedSites( state ),
-			notificationsOpen: isNotificationsOpen( state ),
 			streamKey,
 			selectedFeedId: getSelectedRecentFeedId( state ),
 			primarySiteId: getPrimarySiteId( state ),
@@ -996,4 +586,4 @@ export default connect(
 		showSelectedPost,
 		viewStream,
 	}
-)( localize( withDimensions( withStreamPosts( withPostLikeActions( ReaderStream ) ) ) ) );
+)( localize( withDimensions( withStreamPosts( ReaderStream ) ) ) );

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -4,6 +4,20 @@
 @import '@wordpress/base-styles/breakpoints';
 @import 'calypso/assets/stylesheets/shared/mixins/long-content-fade';
 
+body.is-section-reader.is-global:has( .reader-stream__browser-scroll-poc ) {
+	overflow-y: auto;
+}
+
+body.is-section-reader div.layout.is-global-sidebar-visible .layout__primary > div:has( .reader-stream__browser-scroll-poc ) {
+	height: auto;
+	overflow: visible;
+}
+
+body.is-section-reader div.layout.is-global-sidebar-visible .layout__primary > div:has( .reader-stream__browser-scroll-poc ) > div {
+	height: auto;
+	overflow: visible;
+}
+
 .following {
 
 	@include breakpoint-deprecated( '<660px' ) {


### PR DESCRIPTION
## Summary
- Reintroduce the READ-295 POC as a virtualized Reader list backed by `ReaderInfiniteStream`
- Restore the Reader card/detail flow while keeping scroll management disabled on the POC full-post route
- Add temporary scroll instrumentation to trace navigation, resize, and browser scroll restoration during back navigation

## Testing
- UI tested locally in the browser on the READ-295 POC route
- Lint and formatting checks passed
- `git diff --check` passed