### PR TITLE
Domain bundles: wire bundle suggestion to live with_bundles=1 API

### DIFF
--- a/packages/api-core/src/domain-suggestions/__tests__/fetchers.test.ts
+++ b/packages/api-core/src/domain-suggestions/__tests__/fetchers.test.ts
@@ -1,38 +1,74 @@
+import nock from 'nock';
 import { fetchBundleSuggestion } from '..';
+import type { BundleSuggestion } from '../types';
+
+const BASE = 'https://public-api.wordpress.com';
+
+const bundleSuggestion: BundleSuggestion = {
+	sld: 'example',
+	domains: [
+		{
+			domain: 'example.com',
+			cost: '$22.00',
+			raw_price: 22,
+			product_slug: 'domain_reg',
+			supports_privacy: true,
+		},
+		{
+			domain: 'example.net',
+			cost: '$18.00',
+			raw_price: 18,
+			product_slug: 'domain_reg',
+			supports_privacy: true,
+		},
+	],
+	bundle_price: 40,
+	original_price: 50,
+	discount_percent: 20,
+	category: 'business',
+	bundle_id: 'example_business',
+	bundle_group_id: 'signed-group-id',
+	catalogue_version: '1',
+};
 
 describe( 'fetchBundleSuggestion', () => {
-	it( 'returns a bundle suggestion shaped like the with_bundles payload', async () => {
+	afterEach( () => nock.cleanAll() );
+
+	it( 'requests /domains/suggestions with with_bundles=1 and returns the bundle portion', async () => {
+		const scope = nock( BASE )
+			.get( '/rest/v1.1/domains/suggestions' )
+			.query( ( query ) => query.with_bundles === '1' && query.query === 'example' )
+			.reply( 200, {
+				domain_suggestions: [],
+				bundle_suggestion: bundleSuggestion,
+			} );
+
 		const bundle = await fetchBundleSuggestion( 'example' );
 
-		expect( bundle ).not.toBeNull();
-		expect( bundle?.sld ).toBe( 'example' );
-		expect( bundle?.domains.length ).toBeGreaterThanOrEqual( 2 );
+		expect( scope.isDone() ).toBe( true );
+		expect( bundle ).toEqual( bundleSuggestion );
+	} );
 
-		bundle?.domains.forEach( ( domain ) => {
-			expect( domain.domain.startsWith( 'example.' ) ).toBe( true );
-			expect( typeof domain.cost ).toBe( 'string' );
-			expect( typeof domain.raw_price ).toBe( 'number' );
-			expect( typeof domain.product_slug ).toBe( 'string' );
+	it( 'lowercases the query before sending it', async () => {
+		const scope = nock( BASE )
+			.get( '/rest/v1.1/domains/suggestions' )
+			.query( ( query ) => query.query === 'mybrand.com' )
+			.reply( 200, {
+				domain_suggestions: [],
+				bundle_suggestion: bundleSuggestion,
+			} );
+
+		await fetchBundleSuggestion( 'MyBrand.com' );
+
+		expect( scope.isDone() ).toBe( true );
+	} );
+
+	it( 'returns null when the response carries no bundle suggestion', async () => {
+		nock( BASE ).get( '/rest/v1.1/domains/suggestions' ).query( true ).reply( 200, {
+			domain_suggestions: [],
+			bundle_suggestion: null,
 		} );
 
-		expect( typeof bundle?.bundle_price ).toBe( 'number' );
-		expect( typeof bundle?.original_price ).toBe( 'number' );
-		expect( typeof bundle?.discount_percent ).toBe( 'number' );
-		expect( typeof bundle?.category ).toBe( 'string' );
-		expect( typeof bundle?.bundle_id ).toBe( 'string' );
-		expect( typeof bundle?.bundle_group_id ).toBe( 'string' );
-		expect( typeof bundle?.catalogue_version ).toBe( 'string' );
-	} );
-
-	it( 'derives the sld from a full-domain query', async () => {
-		const bundle = await fetchBundleSuggestion( 'MyBrand.com' );
-
-		expect( bundle?.sld ).toBe( 'mybrand' );
-		expect( bundle?.domains[ 0 ].domain ).toBe( 'mybrand.com' );
-	} );
-
-	it( 'returns null for an empty query', async () => {
-		expect( await fetchBundleSuggestion( '' ) ).toBeNull();
-		expect( await fetchBundleSuggestion( '   ' ) ).toBeNull();
+		expect( await fetchBundleSuggestion( 'example' ) ).toBeNull();
 	} );
 } );

--- a/packages/api-core/src/domain-suggestions/fetchers.ts
+++ b/packages/api-core/src/domain-suggestions/fetchers.ts
@@ -1,7 +1,6 @@
 import { wpcom } from '../wpcom-fetcher';
 import type {
 	BundleSuggestion,
-	BundleSuggestionDomain,
 	DomainSuggestion,
 	DomainSuggestionQuery,
 	FreeDomainSuggestion,
@@ -79,53 +78,27 @@ export async function fetchAvailableTlds( search?: string, vendor?: string ): Pr
 /**
  * Fetch a bundle suggestion for a search query.
  *
- * M1a placeholder: returns hardcoded fixture data shaped like the
- * `with_bundles=1` payload (DOMAINS-2166) so the search flow can render the
- * bundle card end-to-end before the backend is wired up. M1b replaces the body
- * with a real network call without changing this signature.
+ * Calls the `with_bundles=1` opt-in on `/domains/suggestions` (DOMAINS-2166),
+ * which wraps the response as `{ domain_suggestions, bundle_suggestion }`. We
+ * only need the `bundle_suggestion` portion here. The backend gates the bundle
+ * on its own feature flag and returns `null` when no bundle applies; the
+ * frontend `domain-bundling` flag additionally gates whether this fetcher runs
+ * at all (see the `bundleSuggestionQuery` consumer).
  * @param search The domain search query (an SLD or FQDN).
  * @returns A bundle suggestion, or null when no bundle applies.
  */
 export async function fetchBundleSuggestion( search: string ): Promise< BundleSuggestion | null > {
-	const sld = search.trim().toLowerCase().split( '.' )[ 0 ];
-
-	if ( ! sld ) {
-		return null;
-	}
-
-	const domains: BundleSuggestionDomain[] = [
+	const response: { bundle_suggestion?: BundleSuggestion | null } = await wpcom.req.get(
 		{
-			domain: `${ sld }.com`,
-			cost: '$22.00',
-			raw_price: 22,
-			product_slug: 'domain_reg',
-			supports_privacy: true,
+			apiVersion: '1.1',
+			path: '/domains/suggestions',
 		},
 		{
-			domain: `${ sld }.net`,
-			cost: '$18.00',
-			raw_price: 18,
-			product_slug: 'domain_reg',
-			supports_privacy: true,
-		},
-		{
-			domain: `${ sld }.org`,
-			cost: '$20.00',
-			raw_price: 20,
-			product_slug: 'domain_reg',
-			supports_privacy: true,
-		},
-	];
+			query: search.trim().toLocaleLowerCase(),
+			vendor: 'variation2_front',
+			with_bundles: 1,
+		}
+	);
 
-	return {
-		sld,
-		domains,
-		bundle_price: 48,
-		original_price: 60,
-		discount_percent: 20,
-		category: 'business',
-		bundle_id: `${ sld }_business`,
-		bundle_group_id: `mock-${ sld }-group`,
-		catalogue_version: '1',
-	};
+	return response.bundle_suggestion ?? null;
 }

--- a/packages/domain-search/src/hooks/test/use-suggestions-list.tsx
+++ b/packages/domain-search/src/hooks/test/use-suggestions-list.tsx
@@ -3,10 +3,29 @@
  */
 import { renderHook, waitFor } from '@testing-library/react';
 import nock from 'nock';
-import { mockGetSuggestionsQuery } from '../../test-helpers/queries/suggestions';
+import {
+	mockGetBundleSuggestionQuery,
+	mockGetSuggestionsQuery,
+} from '../../test-helpers/queries/suggestions';
 import { queryClient, TestDomainSearch } from '../../test-helpers/renderer';
 import { useSuggestionsList } from '../use-suggestions-list';
 import type { DomainSearchConfig } from '../../page/types';
+import type { BundleSuggestion } from '@automattic/api-core';
+
+const TEST_BUNDLE_SUGGESTION: BundleSuggestion = {
+	sld: 'test',
+	domains: [
+		{ domain: 'test.com', cost: '$22.00', raw_price: 22, product_slug: 'domain_reg' },
+		{ domain: 'test.org', cost: '$22.00', raw_price: 22, product_slug: 'domain_reg' },
+	],
+	bundle_price: 36,
+	original_price: 44,
+	discount_percent: 18,
+	category: 'business',
+	bundle_id: 'test-bundle',
+	bundle_group_id: 'v1.test.deadbeef',
+	catalogue_version: '1',
+};
 
 const renderUseSuggestionsList = ( config?: Partial< DomainSearchConfig > ) =>
 	renderHook( () => useSuggestionsList(), {
@@ -25,6 +44,10 @@ describe( 'useSuggestionsList — bundle suggestions', () => {
 
 	it( 'surfaces a bundle suggestion when showBundleSuggestions is on', async () => {
 		mockGetSuggestionsQuery( { params: { query: 'test' }, suggestions: [] } );
+		mockGetBundleSuggestionQuery( {
+			params: { query: 'test' },
+			bundleSuggestion: TEST_BUNDLE_SUGGESTION,
+		} );
 
 		const { result } = renderUseSuggestionsList( { showBundleSuggestions: true } );
 

--- a/packages/domain-search/src/test-helpers/queries/suggestions.ts
+++ b/packages/domain-search/src/test-helpers/queries/suggestions.ts
@@ -1,6 +1,7 @@
 import nock from 'nock';
 import qs from 'qs';
 import type {
+	BundleSuggestion,
 	DomainSuggestion,
 	DomainSuggestionQuery,
 	FreeDomainSuggestion,
@@ -33,6 +34,23 @@ export const mockGetSuggestionsQuery = ( {
 	}
 
 	return request.reply( 200, suggestions );
+};
+
+export const mockGetBundleSuggestionQuery = ( {
+	params,
+	bundleSuggestion,
+}: {
+	params: Partial< DomainSuggestionQuery >;
+	bundleSuggestion: BundleSuggestion | null;
+} ) => {
+	return nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1.1/domains/suggestions' )
+		.query( {
+			vendor: 'variation2_front',
+			with_bundles: 1,
+			...params,
+		} )
+		.reply( 200, { bundle_suggestion: bundleSuggestion } );
 };
 
 export const mockGetFreeSuggestionQuery = ( {


### PR DESCRIPTION
Related to DOMAINS-2177

## Proposed Changes

Replaces the M1a hardcoded mock body of `fetchBundleSuggestion` with a real authenticated wpcom REST call to the `with_bundles=1` opt-in on `/domains/suggestions` (backend shipped in DOMAINS-2166, deployed). The TypeScript contract was designed in M1a to match the live payload, so the public signature is unchanged — this is a fetcher-body swap, no consumer changes.

- `packages/api-core/src/domain-suggestions/fetchers.ts` — `fetchBundleSuggestion` now issues `wpcom.req.get` to `/domains/suggestions` with `with_bundles=1`, mirroring `fetchDomainSuggestions`' request mechanism, and returns `response.bundle_suggestion ?? null`. Signature stays `Promise<BundleSuggestion | null>`.
- `packages/api-core/src/domain-suggestions/__tests__/fetchers.test.ts` — tests rewritten to mock the HTTP layer with `nock` (matching the existing `read-follows` fetcher-test pattern) instead of asserting static fixture output.

The `domain-bundling` feature-flag gate is untouched — it lives at the consumer layer (`use-wpcom-domain-search-props.ts` → `showBundleSuggestions`), not in the fetcher. The backend independently gates the bundle and returns `null` when its flag is off.

## Testing Instructions

Unit:

```
yarn test-packages packages/api-core/src/domain-suggestions/__tests__/fetchers.test.ts
yarn tsc --noEmit -p packages/api-core/tsconfig.json
```

3/3 pass, clean typecheck.

Manual (sandbox API routing + `WPCOM_DOMAIN_BUNDLE_DISCOUNTS_ENABLED` on):

1. Run Calypso against a sandbox with the backend flag enabled.
2. Domain search (onboarding or `/domains/add`) for a term in a catalogue bundle category.
3. Confirm the `/domains/suggestions` request carries `with_bundles=1` and the response has a non-null `bundle_suggestion`, and the bundle card renders.
4. Negative path: flag off / non-bundle term → `bundle_suggestion: null` → no card.
