### PR TITLE
Domain bundles: test multi-bundle carts in groupBundleLineItems

### DIFF
--- a/packages/wpcom-checkout/test/fixtures/bundle-cart.ts
+++ b/packages/wpcom-checkout/test/fixtures/bundle-cart.ts
@@ -98,10 +98,8 @@ export function buildMultiBundleResponseCart(): ResponseCart {
 				meta: 'standalone.blog',
 				item_subtotal_integer: 3000,
 			} ),
-			buildDomainProduct(
-				{ uuid: 'brimnir-info', meta: 'brimnir.info', item_subtotal_integer: 1500 },
-				{ groupId: 'bundle-brimnir', role: 'primary', expectedBundleSize: 3 }
-			),
+			// The brimnir primary is deliberately listed last so ordering tests
+			// exercise the primary-first reordering rather than the input order.
 			buildDomainProduct(
 				{ uuid: 'brimnir-co', meta: 'brimnir.co', item_subtotal_integer: 2500 },
 				{ groupId: 'bundle-brimnir', role: 'companion', expectedBundleSize: 3 }
@@ -109,6 +107,10 @@ export function buildMultiBundleResponseCart(): ResponseCart {
 			buildDomainProduct(
 				{ uuid: 'brimnir-vip', meta: 'brimnir.vip', item_subtotal_integer: 4200 },
 				{ groupId: 'bundle-brimnir', role: 'companion', expectedBundleSize: 3 }
+			),
+			buildDomainProduct(
+				{ uuid: 'brimnir-info', meta: 'brimnir.info', item_subtotal_integer: 1500 },
+				{ groupId: 'bundle-brimnir', role: 'primary', expectedBundleSize: 3 }
 			),
 		],
 	};

--- a/packages/wpcom-checkout/test/fixtures/bundle-cart.ts
+++ b/packages/wpcom-checkout/test/fixtures/bundle-cart.ts
@@ -69,3 +69,47 @@ export function buildBundleResponseCart(): ResponseCart {
 		],
 	};
 }
+
+/**
+ * Build a mock responseCart containing two distinct domain bundles interleaved
+ * with a standalone domain registration, mirroring a multi-bundle cart from the
+ * design mockups. The "thalasso" bundle holds .com/.org/.net and the "brimnir"
+ * bundle holds .info/.co/.vip, with a standalone domain sitting between them.
+ * @returns A ResponseCart with two bundle groups plus an ungrouped product.
+ */
+export function buildMultiBundleResponseCart(): ResponseCart {
+	return {
+		...getEmptyResponseCart(),
+		products: [
+			buildDomainProduct(
+				{ uuid: 'thalasso-com', meta: 'thalasso.com', item_subtotal_integer: 2200 },
+				{ groupId: 'bundle-thalasso', role: 'primary', expectedBundleSize: 3 }
+			),
+			buildDomainProduct(
+				{ uuid: 'thalasso-org', meta: 'thalasso.org', item_subtotal_integer: 2000 },
+				{ groupId: 'bundle-thalasso', role: 'companion', expectedBundleSize: 3 }
+			),
+			buildDomainProduct(
+				{ uuid: 'thalasso-net', meta: 'thalasso.net', item_subtotal_integer: 1800 },
+				{ groupId: 'bundle-thalasso', role: 'companion', expectedBundleSize: 3 }
+			),
+			buildDomainProduct( {
+				uuid: 'standalone',
+				meta: 'standalone.blog',
+				item_subtotal_integer: 3000,
+			} ),
+			buildDomainProduct(
+				{ uuid: 'brimnir-info', meta: 'brimnir.info', item_subtotal_integer: 1500 },
+				{ groupId: 'bundle-brimnir', role: 'primary', expectedBundleSize: 3 }
+			),
+			buildDomainProduct(
+				{ uuid: 'brimnir-co', meta: 'brimnir.co', item_subtotal_integer: 2500 },
+				{ groupId: 'bundle-brimnir', role: 'companion', expectedBundleSize: 3 }
+			),
+			buildDomainProduct(
+				{ uuid: 'brimnir-vip', meta: 'brimnir.vip', item_subtotal_integer: 4200 },
+				{ groupId: 'bundle-brimnir', role: 'companion', expectedBundleSize: 3 }
+			),
+		],
+	};
+}

--- a/packages/wpcom-checkout/test/group-bundle-line-items.ts
+++ b/packages/wpcom-checkout/test/group-bundle-line-items.ts
@@ -1,5 +1,9 @@
 import { groupBundleLineItems } from '../src/group-bundle-line-items';
-import { buildBundleResponseCart, buildDomainProduct } from './fixtures/bundle-cart';
+import {
+	buildBundleResponseCart,
+	buildDomainProduct,
+	buildMultiBundleResponseCart,
+} from './fixtures/bundle-cart';
 
 describe( 'groupBundleLineItems', () => {
 	test( 'returns ungrouped products as plain product entries in order', () => {
@@ -112,5 +116,92 @@ describe( 'groupBundleLineItems', () => {
 			bundleEntry.type === 'bundle' ? bundleEntry.products.map( ( p ) => p.uuid ) : [];
 
 		expect( memberUuids ).toEqual( [ 'primary', 'companion-net', 'companion-org' ] );
+	} );
+
+	describe( 'multi-bundle carts', () => {
+		test( 'folds each distinct group into its own bundle entry around the standalone product', () => {
+			const result = groupBundleLineItems( buildMultiBundleResponseCart().products );
+
+			expect(
+				result.map( ( entry ) => ( entry.type === 'bundle' ? entry.groupId : entry.product.uuid ) )
+			).toEqual( [ 'bundle-thalasso', 'standalone', 'bundle-brimnir' ] );
+		} );
+
+		test( 'positions each bundle at its first member and keeps the standalone product in place', () => {
+			const result = groupBundleLineItems( buildMultiBundleResponseCart().products );
+
+			// The standalone domain sits at index 3 in the source cart, after the
+			// three thalasso members; once those fold into one entry it lands at
+			// index 1, between the two grouped bundles.
+			expect( result ).toHaveLength( 3 );
+			expect( result[ 0 ] ).toMatchObject( { type: 'bundle', groupId: 'bundle-thalasso' } );
+			expect( result[ 1 ] ).toMatchObject( {
+				type: 'product',
+				product: { uuid: 'standalone' },
+			} );
+			expect( result[ 2 ] ).toMatchObject( { type: 'bundle', groupId: 'bundle-brimnir' } );
+		} );
+
+		test( 'orders members primary-first within each group independently', () => {
+			const result = groupBundleLineItems( buildMultiBundleResponseCart().products );
+
+			const membersByGroup = Object.fromEntries(
+				result
+					.filter( ( entry ) => entry.type === 'bundle' )
+					.map( ( entry ) => [ entry.groupId, entry.products.map( ( product ) => product.uuid ) ] )
+			);
+
+			expect( membersByGroup[ 'bundle-thalasso' ] ).toEqual( [
+				'thalasso-com',
+				'thalasso-org',
+				'thalasso-net',
+			] );
+			expect( membersByGroup[ 'bundle-brimnir' ] ).toEqual( [
+				'brimnir-info',
+				'brimnir-co',
+				'brimnir-vip',
+			] );
+		} );
+
+		test( "each group's total sums only its own members, with no cross-contamination", () => {
+			const result = groupBundleLineItems( buildMultiBundleResponseCart().products );
+
+			const totalByGroup = Object.fromEntries(
+				result
+					.filter( ( entry ) => entry.type === 'bundle' )
+					.map( ( entry ) => [
+						entry.groupId,
+						entry.products.reduce( ( sum, product ) => sum + product.item_subtotal_integer, 0 ),
+					] )
+			);
+
+			// thalasso: 2200 + 2000 + 1800
+			expect( totalByGroup[ 'bundle-thalasso' ] ).toBe( 6000 );
+			// brimnir: 1500 + 2500 + 4200
+			expect( totalByGroup[ 'bundle-brimnir' ] ).toBe( 8200 );
+		} );
+
+		test( 'leaves the standalone product untouched', () => {
+			const sourceProducts = buildMultiBundleResponseCart().products;
+			const standalone = sourceProducts.find( ( product ) => product.uuid === 'standalone' );
+
+			const result = groupBundleLineItems( sourceProducts );
+			const standaloneEntry = result.find(
+				( entry ) => entry.type === 'product' && entry.product.uuid === 'standalone'
+			);
+
+			expect( standaloneEntry ).toEqual( { type: 'product', product: standalone } );
+		} );
+
+		test( 'produces unique, stable group ids usable as render keys', () => {
+			const result = groupBundleLineItems( buildMultiBundleResponseCart().products );
+
+			const keys = result
+				.filter( ( entry ) => entry.type === 'bundle' )
+				.map( ( entry ) => `bundle-${ entry.groupId }` );
+
+			expect( keys ).toEqual( [ 'bundle-bundle-thalasso', 'bundle-bundle-brimnir' ] );
+			expect( new Set( keys ).size ).toBe( keys.length );
+		} );
 	} );
 } );


### PR DESCRIPTION
Related to DOMAINS-2180

## Proposed Changes

Adds multi-bundle cart test coverage for the `groupBundleLineItems` helper (shipped in DOMAINS-2171). The existing tests only exercised a single bundle group plus standalone products; real carts can contain two or more distinct bundles. **Test-only — no change to helper behavior.** The helper already handles multi-bundle input correctly; no bug was found.

- `packages/wpcom-checkout/test/fixtures/bundle-cart.ts` — adds `buildMultiBundleResponseCart()`: a 7-product cart with two distinct bundle groups (`bundle-thalasso`, `bundle-brimnir`) and a standalone domain interleaved between them. Reuses the existing `buildDomainProduct` helper and matches the style of `buildBundleResponseCart`.
- `packages/wpcom-checkout/test/group-bundle-line-items.ts` — new `multi-bundle carts` describe block (6 cases): each group folds independently, each appears at the position of its first member, primary-first ordering holds within each group, each group's total sums only its own members (no cross-contamination), the standalone is left untouched, and group ids yield unique stable `bundle-${groupId}` render keys.

## Testing Instructions

```
yarn test-packages packages/wpcom-checkout/test/group-bundle-line-items.ts
```

14 pass (6 new). To confirm the new cases genuinely guard the behavior, temporarily make the helper fold all bundles under one group id and re-run — the multi-bundle cases should fail. Revert after.
