### PR TITLE
Bump @automattic/charts to 1.5.2 and enable zoom on backend perf chart

### DIFF
--- a/client/dashboard/sites/performance/backend/overview/chart-slot.tsx
+++ b/client/dashboard/sites/performance/backend/overview/chart-slot.tsx
@@ -92,6 +92,7 @@ export default function ChartSlot( {
 						data={ data }
 						stacked
 						curveType="monotone"
+						zoomable
 						showLegend
 						legend={ { interactive: true } }
 						withTooltips

--- a/client/package.json
+++ b/client/package.json
@@ -32,7 +32,7 @@
 		"@automattic/calypso-stripe": "workspace:^",
 		"@automattic/calypso-support-session": "workspace:^",
 		"@automattic/calypso-url": "workspace:^",
-		"@automattic/charts": "^1.4.3",
+		"@automattic/charts": "^1.5.2",
 		"@automattic/color-studio": "^4.1.0",
 		"@automattic/components": "workspace:^",
 		"@automattic/composite-checkout": "workspace:^",

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
 		"@automattic/calypso-doctor": "workspace:^",
 		"@automattic/calypso-products": "workspace:^",
 		"@automattic/calypso-router": "workspace:^",
-		"@automattic/charts": "^1.4.3",
+		"@automattic/charts": "^1.5.2",
 		"@automattic/color-studio": "^4.1.0",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -795,11 +795,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@automattic/charts@npm:^1.4.3":
-  version: 1.4.3
-  resolution: "@automattic/charts@npm:1.4.3"
+"@automattic/charts@npm:^1.5.2":
+  version: 1.5.2
+  resolution: "@automattic/charts@npm:1.5.2"
   dependencies:
-    "@automattic/number-formatters": "npm:^1.2.0"
+    "@automattic/number-formatters": "npm:^1.2.2"
     "@babel/runtime": "npm:7.29.2"
     "@react-spring/web": "npm:9.7.5"
     "@visx/annotation": "npm:^3.12.0"
@@ -819,9 +819,9 @@ __metadata:
     "@visx/vendor": "npm:^3.12.0"
     "@visx/xychart": "npm:^3.12.0"
     "@wordpress/i18n": "npm:^6.0.0"
-    "@wordpress/icons": "npm:^12.0.0"
+    "@wordpress/icons": "npm:^13.0.0"
     "@wordpress/theme": "npm:0.13.0"
-    "@wordpress/ui": "npm:0.11.0"
+    "@wordpress/ui": "npm:0.13.0"
     clsx: "npm:2.1.1"
     date-fns: "npm:^4.1.0"
     deepmerge: "npm:4.3.1"
@@ -832,7 +832,7 @@ __metadata:
   peerDependencies:
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
-  checksum: 3fcfcaaed2dd1f2472f6194a664ae5ebc65a798bf3b343be9348fd54632027c85119a27833b1461bba0461c32a5630cf042c1dec6edebfbee2db5b120a11dfae
+  checksum: 39f33e69292d4be85f940647b7d265668ae5241697948b3b5caaa54df281e2ba85983c3285c3fefe6ae13e8792812eb19ba24b22d1350aaa07da871517c95edc
   languageName: node
   linkType: hard
 
@@ -1816,6 +1816,17 @@ __metadata:
     debug: "npm:^4.4.0"
     tslib: "npm:^2.5.0"
   checksum: 30a10a7afcf4e01310fd405de9b0900c5f1eb55243e836b5ecb41b9eaf45121b6c9467ba21ab02c7386f687d7c9d526dc2c6ffb378392029dc22881a091bbb06
+  languageName: node
+  linkType: hard
+
+"@automattic/number-formatters@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "@automattic/number-formatters@npm:1.2.2"
+  dependencies:
+    "@wordpress/date": "npm:^5.19.0"
+    debug: "npm:^4.4.0"
+    tslib: "npm:^2.5.0"
+  checksum: 51b53f1a453626445151b3c21e60f4d4d059a0fa71949f5a3486d8ec196d3e5b7442a2c471d51f2d2a44c864bc694c164963170cccd8b10f4527aea6decd57c0
   languageName: node
   linkType: hard
 
@@ -13967,7 +13978,7 @@ __metadata:
     "@automattic/calypso-stripe": "workspace:^"
     "@automattic/calypso-support-session": "workspace:^"
     "@automattic/calypso-url": "workspace:^"
-    "@automattic/charts": "npm:^1.4.3"
+    "@automattic/charts": "npm:^1.5.2"
     "@automattic/color-studio": "npm:^4.1.0"
     "@automattic/components": "workspace:^"
     "@automattic/composite-checkout": "workspace:^"
@@ -33245,7 +33256,7 @@ __metadata:
     "@automattic/calypso-products": "workspace:^"
     "@automattic/calypso-router": "workspace:^"
     "@automattic/calypso-storybook": "workspace:^"
-    "@automattic/charts": "npm:^1.4.3"
+    "@automattic/charts": "npm:^1.5.2"
     "@automattic/color-studio": "npm:^4.1.0"
     "@automattic/components": "workspace:^"
     "@automattic/data-stores": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1808,18 +1808,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/number-formatters@npm:^1.1.2, @automattic/number-formatters@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "@automattic/number-formatters@npm:1.2.0"
-  dependencies:
-    "@wordpress/date": "npm:^5.19.0"
-    debug: "npm:^4.4.0"
-    tslib: "npm:^2.5.0"
-  checksum: 30a10a7afcf4e01310fd405de9b0900c5f1eb55243e836b5ecb41b9eaf45121b6c9467ba21ab02c7386f687d7c9d526dc2c6ffb378392029dc22881a091bbb06
-  languageName: node
-  linkType: hard
-
-"@automattic/number-formatters@npm:^1.2.2":
+"@automattic/number-formatters@npm:^1.1.2, @automattic/number-formatters@npm:^1.2.0, @automattic/number-formatters@npm:^1.2.2":
   version: 1.2.2
   resolution: "@automattic/number-formatters@npm:1.2.2"
   dependencies:


### PR DESCRIPTION
Part of #

## Proposed Changes

* Bump `@automattic/charts` from `^1.4.3` to `^1.5.2` (root and `client/` manifests + lockfile).
* Enable the new `zoomable` prop on the "Response time breakdown" `AreaChart` on the backend performance page, allowing drag-to-zoom on the X axis with a reset button while zoomed.

## Why are these changes being made?

* `@automattic/charts@1.5.2` introduces drag-to-zoom support on `AreaChart` via the `zoomable` prop. Bumping the package lets the backend performance breakdown chart take advantage of it so users can zoom into a time range of interest.

## Testing Instructions

* Visit a site's backend performance page (Settings -> Performance -> Backend) and open the "Response time breakdown" chart.
* Drag horizontally across the chart to select a range; the X axis should rescale to that range and a reset button should appear in the top-right.
* Click the reset button to return to the full range.
* Confirm tooltips and the interactive legend still work as before.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
