### PR TITLE
Plans: allow instant downgrade within refund period

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -441,9 +441,29 @@ function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase } ) {
 	return null;
 }
 
+/**
+ * Whether the "Change plan" action should be offered for this purchase: either
+ * the plan is past expiry (downgrade-to-checkout) or still within its refund
+ * window (instant downgrade). Gated by the `plans/expired-downgrade` flag.
+ */
+function shouldShowChangePlan( purchase: Purchase ): boolean {
+	if ( ! config.isEnabled( 'plans/expired-downgrade' ) ) {
+		return false;
+	}
+	return (
+		( purchase.is_past_expiry_date && purchase.is_plan ) ||
+		isWithinRefundWindowDowngradeEligible( purchase )
+	);
+}
+
 function UpgradeActionButton( { purchase }: { purchase: Purchase } ) {
 	const { recordTracksEvent } = useAnalytics();
 	if ( ! purchase.is_upgradable ) {
+		return null;
+	}
+	// When "Change plan" is offered (downgrade-eligible), it supersedes the
+	// upgrade action — matching the classic purchases page.
+	if ( shouldShowChangePlan( purchase ) ) {
 		return null;
 	}
 	const upgradeUrl = getSitePurchaseUpgradeUrl( purchase, getUpgradedPurchaseRedirectUrl() );
@@ -608,16 +628,11 @@ function ReinstallButton( { purchase }: { purchase: Purchase } ) {
 function ChangePlanActionItem( { purchase }: { purchase: Purchase } ) {
 	const { recordTracksEvent } = useAnalytics();
 
-	if ( ! config.isEnabled( 'plans/expired-downgrade' ) ) {
+	if ( ! shouldShowChangePlan( purchase ) ) {
 		return null;
 	}
 
 	const isPastExpiryDowngrade = purchase.is_past_expiry_date && purchase.is_plan;
-	const isRefundWindowDowngrade = isWithinRefundWindowDowngradeEligible( purchase );
-
-	if ( ! isPastExpiryDowngrade && ! isRefundWindowDowngrade ) {
-		return null;
-	}
 
 	return (
 		<ActionList.ActionItem

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -96,6 +96,7 @@ import {
 	isWpcomFlexSubscription,
 	isAkismetFreeProduct,
 	isInExpirationGracePeriod,
+	isWithinRefundWindowDowngradeEligible,
 	isA4ABillingDragonPurchase,
 	isCentennialPurchase,
 	hasAmountAvailableToRefund,
@@ -611,7 +612,10 @@ function ChangePlanActionItem( { purchase }: { purchase: Purchase } ) {
 		return null;
 	}
 
-	if ( ! purchase.is_past_expiry_date || ! purchase.is_plan ) {
+	const isPastExpiryDowngrade = purchase.is_past_expiry_date && purchase.is_plan;
+	const isRefundWindowDowngrade = isWithinRefundWindowDowngradeEligible( purchase );
+
+	if ( ! isPastExpiryDowngrade && ! isRefundWindowDowngrade ) {
 		return null;
 	}
 
@@ -626,6 +630,7 @@ function ChangePlanActionItem( { purchase }: { purchase: Purchase } ) {
 					onClick={ () => {
 						recordTracksEvent( 'calypso_purchases_change_plan_click', {
 							product_slug: purchase.product_slug,
+							mode: isPastExpiryDowngrade ? 'expired' : 'refund-window',
 						} );
 						window.location.href = getExpiredNewPlanUrl( purchase );
 					} }

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -714,6 +714,27 @@ export function hasAmountAvailableToRefund( purchase: Purchase ) {
 }
 
 /**
+ * Returns true if the plan is eligible for an instant, self-serve downgrade: the
+ * plan is still within its initial refund window (not a renewal) and has neither
+ * expired nor entered its post-expiry grace period.
+ *
+ * Note: this intentionally does NOT require a refundable amount. Instant
+ * downgrades are also offered for plans that were paid with credits or are
+ * otherwise free, where no money would be refunded.
+ *
+ * This is distinct from {@link isInExpirationGracePeriod}, which gates the
+ * downgrade-to-checkout flow for plans whose expiry date has already passed.
+ */
+export function isWithinRefundWindowDowngradeEligible( purchase: Purchase ): boolean {
+	return (
+		purchase.is_plan &&
+		purchase.is_within_initial_refund_window &&
+		! isExpired( purchase ) &&
+		! isInExpirationGracePeriod( purchase )
+	);
+}
+
+/**
  * Returns the purchase cancellation flow.
  */
 export function getPurchaseCancellationFlowType( purchase: Purchase ): CancelFlowType {

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -765,6 +765,28 @@ export function hasAmountAvailableToRefund( purchase: Purchase ): boolean {
 }
 
 /**
+ * Returns true if the plan is eligible for an instant, self-serve downgrade: the
+ * plan is still within its initial refund window (not a renewal) and has neither
+ * expired nor entered its post-expiry grace period.
+ *
+ * Note: this intentionally does NOT require a refundable amount. Instant
+ * downgrades are also offered for plans that were paid with credits or are
+ * otherwise free, where no money would be refunded.
+ *
+ * The caller is responsible for confirming the purchase is a plan (see `isPlan`
+ * from `@automattic/calypso-products`). This is distinct from
+ * `isInExpirationGracePeriod`, which gates the downgrade-to-checkout flow for
+ * plans whose expiry date has already passed.
+ */
+export function isWithinRefundWindowDowngradeEligible( purchase: Purchase ): boolean {
+	return (
+		purchase.isWithinInitialRefundWindow &&
+		! isExpired( purchase ) &&
+		! isInExpirationGracePeriod( purchase )
+	);
+}
+
+/**
  * Checks whether the specified purchase can be removed from a user account.
  * @param {Object} purchase - the purchase with which we are concerned
  * @returns {boolean} true if the purchase can be removed, false otherwise

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -100,6 +100,7 @@ import {
 	canAutoRenewBeTurnedOff,
 	isExpired,
 	isInExpirationGracePeriod,
+	isWithinRefundWindowDowngradeEligible,
 	isOneTimePurchase,
 	isPartnerPurchase,
 	isRenewable,
@@ -597,7 +598,10 @@ class ManagePurchase extends Component<
 		if ( ! purchase || ! isPlan( purchase ) ) {
 			return false;
 		}
-		if ( ! isInExpirationGracePeriod( purchase ) ) {
+		if (
+			! isInExpirationGracePeriod( purchase ) &&
+			! isWithinRefundWindowDowngradeEligible( purchase )
+		) {
 			return false;
 		}
 		return true;

--- a/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/index.tsx
+++ b/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/index.tsx
@@ -12,6 +12,16 @@ interface DowngradeConfirmationModalProps {
 	targetPlanName: string;
 	targetPlanSlug: string | null;
 	purchaseId: number | undefined;
+	/**
+	 * When true, the downgrade is performed instantly (paid out of the refund)
+	 * rather than routed to checkout. The refund amount is displayed and the
+	 * confirm button reflects the refund.
+	 */
+	isInstantDowngrade?: boolean;
+	/** Pre-formatted, localized refund amount (e.g. "$48.00"). */
+	refundText?: string;
+	/** When true, the confirm action is in flight; disable buttons and show a spinner. */
+	isConfirming?: boolean;
 	onClose: () => void;
 	onConfirm: () => void;
 }
@@ -21,11 +31,15 @@ function ModalBody( {
 	currentPlanName,
 	targetPlanName,
 	lostFeatures,
+	isInstantDowngrade,
+	refundText,
 }: {
 	isLoading: boolean;
 	currentPlanName: string;
 	targetPlanName: string;
 	lostFeatures: { feature_id: string; title: string }[];
+	isInstantDowngrade?: boolean;
+	refundText?: string;
 } ) {
 	const translate = useTranslate();
 
@@ -37,17 +51,29 @@ function ModalBody( {
 		);
 	}
 
+	const refundLine = isInstantDowngrade && refundText && (
+		<p className="downgrade-confirmation-modal__refund">
+			{ translate( 'You will be refunded %(refundText)s.', {
+				args: { refundText },
+				comment: 'Message shown when downgrading a plan that is within its refund window',
+			} ) }
+		</p>
+	);
+
 	if ( lostFeatures.length === 0 ) {
 		return (
-			<p className="downgrade-confirmation-modal__description">
-				{ translate(
-					'When you change from %(currentPlan)s to %(targetPlan)s, your features will stay the same.',
-					{
-						args: { currentPlan: currentPlanName, targetPlan: targetPlanName },
-						comment: 'Message shown when downgrading an expired plan with no feature differences',
-					}
-				) }
-			</p>
+			<>
+				<p className="downgrade-confirmation-modal__description">
+					{ translate(
+						'When you change from %(currentPlan)s to %(targetPlan)s, your features will stay the same.',
+						{
+							args: { currentPlan: currentPlanName, targetPlan: targetPlanName },
+							comment: 'Message shown when downgrading an expired plan with no feature differences',
+						}
+					) }
+				</p>
+				{ refundLine }
+			</>
 		);
 	}
 
@@ -75,6 +101,7 @@ function ModalBody( {
 					</li>
 				) ) }
 			</ul>
+			{ refundLine }
 		</>
 	);
 }
@@ -85,6 +112,9 @@ const DowngradeConfirmationModal = ( {
 	targetPlanName,
 	targetPlanSlug,
 	purchaseId,
+	isInstantDowngrade,
+	refundText,
+	isConfirming,
 	onClose,
 	onConfirm,
 }: DowngradeConfirmationModalProps ) => {
@@ -113,19 +143,38 @@ const DowngradeConfirmationModal = ( {
 				currentPlanName={ currentPlanName }
 				targetPlanName={ targetPlanName }
 				lostFeatures={ lostFeatures }
+				isInstantDowngrade={ isInstantDowngrade }
+				refundText={ refundText }
 			/>
 			<div className="downgrade-confirmation-modal__buttons">
-				<Button __next40pxDefaultSize variant="tertiary" onClick={ onClose }>
+				<Button
+					__next40pxDefaultSize
+					variant="tertiary"
+					onClick={ onClose }
+					disabled={ isConfirming }
+				>
 					{ translate( 'Keep %(planName)s', {
 						args: { planName: currentPlanName },
 						comment: 'Button label to dismiss the downgrade modal and keep the current plan',
 					} ) }
 				</Button>
-				<Button __next40pxDefaultSize variant="primary" onClick={ onConfirm }>
-					{ translate( 'Downgrade to %(planName)s', {
-						args: { planName: targetPlanName },
-						comment: 'Button label to confirm downgrading to a lower-tier plan',
-					} ) }
+				<Button
+					__next40pxDefaultSize
+					variant="primary"
+					onClick={ onConfirm }
+					isBusy={ isConfirming }
+					disabled={ isConfirming }
+				>
+					{ isInstantDowngrade && refundText
+						? translate( 'Downgrade and refund %(refundText)s', {
+								args: { refundText },
+								comment:
+									'Button label to confirm an instant downgrade that issues a refund of the given amount',
+						  } )
+						: translate( 'Downgrade to %(planName)s', {
+								args: { planName: targetPlanName },
+								comment: 'Button label to confirm downgrading to a lower-tier plan',
+						  } ) }
 				</Button>
 			</div>
 		</Modal>

--- a/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/style.scss
+++ b/client/my-sites/plans-features-main/components/downgrade-confirmation-modal/style.scss
@@ -33,6 +33,13 @@
 	margin-block-start: 2px;
 }
 
+.downgrade-confirmation-modal__refund {
+	font-size: $font-body-small;
+	font-weight: 600;
+	margin-block-start: 16px;
+	margin-block-end: 0;
+}
+
 .downgrade-confirmation-modal__buttons {
 	display: flex;
 	justify-content: flex-end;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -291,6 +291,11 @@ const PlansFeaturesMain = ( {
 	const reduxDispatch = useReduxDispatch();
 	const queryClient = useQueryClient();
 	const cancelAndRefundMutation = useMutation( cancelAndRefundPurchaseMutation() );
+	// Stays true from the moment the instant downgrade is confirmed until the page
+	// navigates away, so the dialog can keep showing a loader across the mutation
+	// AND the subsequent purchases refetch (the mutation's own isPending clears
+	// before that refetch completes). Only reset on error.
+	const [ isDowngrading, setIsDowngrading ] = useState( false );
 	const currentPlanPurchaseId = currentPlan?.purchaseId;
 	const { data: currentPurchase } = useQuery( {
 		...purchaseQuery( currentPlanPurchaseId ?? 0 ),
@@ -318,7 +323,14 @@ const PlansFeaturesMain = ( {
 			? formatCurrency( downgradeRefundAmount, currentPurchase.currency_code )
 			: undefined;
 
-	const closeDowngradeModal = () => setPendingDowngradePlanSlug( null );
+	// Ignore dismiss requests (X/Escape/overlay) while an instant downgrade is in
+	// flight so the loader stays visible until the redirect.
+	const closeDowngradeModal = () => {
+		if ( isDowngrading ) {
+			return;
+		}
+		setPendingDowngradePlanSlug( null );
+	};
 
 	// Refund-window mode: perform the downgrade instantly via the cancel endpoint.
 	const confirmInstantDowngrade = () => {
@@ -333,6 +345,8 @@ const PlansFeaturesMain = ( {
 		} );
 		recordTracksEvent( 'calypso_purchases_downgrade_form_submit' );
 		const blogId = currentPurchase?.blog_id;
+		// Keep the dialog open with its loader until the redirect; only reset on error.
+		setIsDowngrading( true );
 		cancelAndRefundMutation.mutate(
 			{
 				purchaseId: currentPlanPurchaseId,
@@ -340,16 +354,21 @@ const PlansFeaturesMain = ( {
 			},
 			{
 				onSuccess: async () => {
-					closeDowngradeModal();
 					// Refetch purchases so we can resolve the newly-provisioned purchase,
 					// needed both to substitute the `:purchaseId` placeholder below and to
-					// deep-link to its settings page in the fallback.
-					const freshPurchases = await queryClient.fetchQuery( userPurchasesQuery() );
-					const newPurchase = freshPurchases?.find(
-						( p ) =>
-							String( p.product_id ) === String( toProductId ) &&
-							String( p.blog_id ) === String( blogId )
-					);
+					// deep-link to its settings page in the fallback. The dialog stays open
+					// (showing its loader) throughout; the redirect below unmounts it.
+					let newPurchase;
+					try {
+						const freshPurchases = await queryClient.fetchQuery( userPurchasesQuery() );
+						newPurchase = freshPurchases?.find(
+							( p ) =>
+								String( p.product_id ) === String( toProductId ) &&
+								String( p.blog_id ) === String( blogId )
+						);
+					} catch {
+						// Ignore — fall through and navigate without the new purchase id.
+					}
 
 					// Honor the `redirect_to` the entry point provided so the user returns
 					// to where they came from (e.g. the Dashboard purchase settings) with a
@@ -376,6 +395,7 @@ const PlansFeaturesMain = ( {
 							: `/plans/${ siteSlug }?downgraded=true`;
 				},
 				onError: ( error: Error ) => {
+					setIsDowngrading( false );
 					reduxDispatch( errorNotice( error.message ) );
 				},
 			}
@@ -1078,7 +1098,7 @@ const PlansFeaturesMain = ( {
 					purchaseId={ currentPlan?.purchaseId }
 					isInstantDowngrade={ downgradeMode === 'instant' }
 					refundText={ downgradeRefundText }
-					isConfirming={ cancelAndRefundMutation.isPending }
+					isConfirming={ cancelAndRefundMutation.isPending || isDowngrading }
 					onClose={ closeDowngradeModal }
 					onConfirm={ confirmDowngrade }
 				/>

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -54,7 +54,7 @@ import {
 	useRef,
 	useState,
 } from '@wordpress/element';
-import { hasQueryArg } from '@wordpress/url';
+import { getQueryArg, hasQueryArg } from '@wordpress/url';
 import clsx from 'clsx';
 import { localize, useTranslate, type TranslateResult } from 'i18n-calypso';
 import { ReactNode } from 'react';
@@ -341,23 +341,38 @@ const PlansFeaturesMain = ( {
 			{
 				onSuccess: async () => {
 					closeDowngradeModal();
-					// Honor an explicit redirect target (e.g. from the dashboard / classic
-					// purchase pages) if one was provided.
-					if ( redirectTo ) {
-						window.location.href = redirectTo;
-						return;
-					}
-					// Otherwise refetch purchases and land on the newly-downgraded plan's
-					// settings page, falling back to the plans page.
+					// Refetch purchases so we can resolve the newly-provisioned purchase,
+					// needed both to substitute the `:purchaseId` placeholder below and to
+					// deep-link to its settings page in the fallback.
 					const freshPurchases = await queryClient.fetchQuery( userPurchasesQuery() );
 					const newPurchase = freshPurchases?.find(
 						( p ) =>
 							String( p.product_id ) === String( toProductId ) &&
 							String( p.blog_id ) === String( blogId )
 					);
+
+					// Honor the `redirect_to` the entry point provided so the user returns
+					// to where they came from (e.g. the Dashboard purchase settings) with a
+					// success notice. When this grid renders inside the Stepper the value is
+					// only on the URL, not the `redirectTo` prop, so check both. The target
+					// carries a `:purchaseId` placeholder (as checkout's pending page does),
+					// which we substitute with the newly-provisioned purchase.
+					const redirectTarget = redirectTo ?? getQueryArg( window.location.href, 'redirect_to' );
+					if (
+						typeof redirectTarget === 'string' &&
+						( newPurchase || ! redirectTarget.includes( ':purchaseId' ) )
+					) {
+						window.location.href = newPurchase
+							? redirectTarget.replaceAll( ':purchaseId', String( newPurchase.ID ) )
+							: redirectTarget;
+						return;
+					}
+
+					// Fallback: deep-link to the new plan's settings page (or the plans
+					// page) with a notice.
 					window.location.href =
 						newPurchase && siteSlug
-							? managePurchase( siteSlug, newPurchase.ID )
+							? `${ managePurchase( siteSlug, newPurchase.ID ) }?downgraded=true`
 							: `/plans/${ siteSlug }?downgraded=true`;
 				},
 				onError: ( error: Error ) => {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -1,3 +1,8 @@
+import {
+	cancelAndRefundPurchaseMutation,
+	purchaseQuery,
+	userPurchasesQuery,
+} from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
 import {
 	chooseDefaultCustomerType,
@@ -26,6 +31,7 @@ import {
 import page from '@automattic/calypso-router';
 import { Button, Spinner } from '@automattic/components';
 import { WpcomPlansUI, AddOns, Plans } from '@automattic/data-stores';
+import { formatCurrency } from '@automattic/number-formatters';
 import { isAnyHostingFlow } from '@automattic/onboarding';
 import {
 	FeaturesGrid,
@@ -38,6 +44,7 @@ import {
 } from '@automattic/plans-grid-next';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import styled from '@emotion/styled';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useDispatch } from '@wordpress/data';
 import {
 	useCallback,
@@ -51,7 +58,7 @@ import { hasQueryArg } from '@wordpress/url';
 import clsx from 'clsx';
 import { localize, useTranslate, type TranslateResult } from 'i18n-calypso';
 import { ReactNode } from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch as useReduxDispatch } from 'react-redux';
 import QueryActivePromotions from 'calypso/components/data/query-active-promotions';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
@@ -61,6 +68,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { planItem as getCartItemForPlan } from 'calypso/lib/cart-values/cart-items';
 import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
 import { addQueryArgs } from 'calypso/lib/url';
+import { managePurchase } from 'calypso/me/purchases/paths';
 import PlanNotice from 'calypso/my-sites/plans-features-main/components/plan-notice';
 import {
 	shouldForceDefaultPlansBasedOnIntent,
@@ -71,6 +79,7 @@ import { useFreeTrialPlanSlugs } from 'calypso/my-sites/plans-features-main/hook
 import usePlanDifferentiatorsExperiment from 'calypso/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment';
 import usePlanTypeDestinationCallback from 'calypso/my-sites/plans-features-main/hooks/use-plan-type-destination-callback';
 import { getCurrentUserName } from 'calypso/state/current-user/selectors';
+import { errorNotice } from 'calypso/state/notices/actions';
 import canUpgradeToPlan from 'calypso/state/selectors/can-upgrade-to-plan';
 import getDomainFromHomeUpsellInQuery from 'calypso/state/selectors/get-domain-from-home-upsell-in-query';
 import getPreviousRoute from 'calypso/state/selectors/get-previous-route';
@@ -274,6 +283,116 @@ const PlansFeaturesMain = ( {
 		siteId ? getPlansBySiteId( state, siteId )?.data : null
 	);
 	const isPlanExpired = !! sitePlansData?.find( ( p ) => p.currentPlan )?.expired;
+
+	// Refund-window instant downgrade: when the current plan is still within its
+	// initial refund window, a downgrade is performed instantly via the cancel
+	// endpoint instead of routing the user to checkout. This applies regardless of
+	// whether any money would be refunded (e.g. plans paid with credits or free).
+	const reduxDispatch = useReduxDispatch();
+	const queryClient = useQueryClient();
+	const cancelAndRefundMutation = useMutation( cancelAndRefundPurchaseMutation() );
+	const currentPlanPurchaseId = currentPlan?.purchaseId;
+	const { data: currentPurchase } = useQuery( {
+		...purchaseQuery( currentPlanPurchaseId ?? 0 ),
+		enabled: !! currentPlanPurchaseId,
+	} );
+	const isWithinRefundWindow =
+		config.isEnabled( 'plans/expired-downgrade' ) &&
+		!! currentPurchase &&
+		currentPurchase.is_within_initial_refund_window &&
+		! currentPurchase.is_past_expiry_date;
+	const downgradeMode: 'instant' | 'checkout' = isWithinRefundWindow ? 'instant' : 'checkout';
+
+	// The product the user is downgrading to, and the refund specific to that
+	// downgrade target. `refund_options` carries the per-target refund amount,
+	// which differs from the purchase's full `refund_amount`.
+	const downgradeTargetProductId = pendingDowngradePlanSlug
+		? getPlan( pendingDowngradePlanSlug )?.getProductId()
+		: undefined;
+	const downgradeRefundAmount =
+		currentPurchase?.refund_options?.find(
+			( option ) => option.to_product_id === downgradeTargetProductId
+		)?.refund_amount ?? 0;
+	const downgradeRefundText =
+		currentPurchase && downgradeRefundAmount > 0
+			? formatCurrency( downgradeRefundAmount, currentPurchase.currency_code )
+			: undefined;
+
+	const closeDowngradeModal = () => setPendingDowngradePlanSlug( null );
+
+	// Refund-window mode: perform the downgrade instantly via the cancel endpoint.
+	const confirmInstantDowngrade = () => {
+		const toProductId = downgradeTargetProductId;
+		if ( ! currentPlanPurchaseId || ! toProductId ) {
+			return;
+		}
+		recordTracksEvent( 'calypso_plan_features_downgrade_click', {
+			current_plan: sitePlanSlug,
+			downgrading_to: pendingDowngradePlanSlug,
+			mode: 'instant',
+		} );
+		recordTracksEvent( 'calypso_purchases_downgrade_form_submit' );
+		const blogId = currentPurchase?.blog_id;
+		cancelAndRefundMutation.mutate(
+			{
+				purchaseId: currentPlanPurchaseId,
+				options: { type: 'downgrade', to_product_id: toProductId },
+			},
+			{
+				onSuccess: async () => {
+					closeDowngradeModal();
+					// Honor an explicit redirect target (e.g. from the dashboard / classic
+					// purchase pages) if one was provided.
+					if ( redirectTo ) {
+						window.location.href = redirectTo;
+						return;
+					}
+					// Otherwise refetch purchases and land on the newly-downgraded plan's
+					// settings page, falling back to the plans page.
+					const freshPurchases = await queryClient.fetchQuery( userPurchasesQuery() );
+					const newPurchase = freshPurchases?.find(
+						( p ) =>
+							String( p.product_id ) === String( toProductId ) &&
+							String( p.blog_id ) === String( blogId )
+					);
+					window.location.href =
+						newPurchase && siteSlug
+							? managePurchase( siteSlug, newPurchase.ID )
+							: `/plans/${ siteSlug }?downgraded=true`;
+				},
+				onError: ( error: Error ) => {
+					reduxDispatch( errorNotice( error.message ) );
+				},
+			}
+		);
+	};
+
+	// Checkout mode: route the user to checkout to purchase the downgrade.
+	const confirmCheckoutDowngrade = () => {
+		const planPath = pendingDowngradePlanSlug ? getPlanPath( pendingDowngradePlanSlug ) : null;
+		if ( ! planPath || ! siteSlug ) {
+			return;
+		}
+		closeDowngradeModal();
+		recordTracksEvent( 'calypso_plan_features_downgrade_click', {
+			current_plan: sitePlanSlug,
+			downgrading_to: pendingDowngradePlanSlug,
+			mode: 'checkout',
+		} );
+		// Use a full navigation rather than `page()` because this grid can be rendered
+		// inside the Stepper, where the `page` router is not initialized.
+		window.location.href = addQueryArgs(
+			{
+				...( coupon && { coupon } ),
+				...( redirectTo && { redirect_to: redirectTo } ),
+			},
+			`/checkout/${ siteSlug }/${ planPath }`
+		);
+	};
+
+	const confirmDowngrade = () =>
+		downgradeMode === 'instant' ? confirmInstantDowngrade() : confirmCheckoutDowngrade();
+
 	const userCanUpgradeToPersonalPlan = useSelector(
 		( state: IAppState ) => siteId && canUpgradeToPlan( state, siteId, PLAN_PERSONAL )
 	);
@@ -438,6 +557,18 @@ const PlansFeaturesMain = ( {
 		if (
 			config.isEnabled( 'plans/expired-downgrade' ) &&
 			isPlanExpired &&
+			! isFreePlan( planSlug ) &&
+			sitePlansData?.find( ( p ) => p.productSlug === planSlug )?.availableForDowngrade
+		) {
+			setPendingDowngradePlanSlug( planSlug );
+			return true;
+		}
+
+		// For plans still within their refund window, intercept paid-plan downgrades
+		// to show a confirmation modal that performs the downgrade instantly (paid out
+		// of the refund) instead of routing to checkout.
+		if (
+			isWithinRefundWindow &&
 			! isFreePlan( planSlug ) &&
 			sitePlansData?.find( ( p ) => p.productSlug === planSlug )?.availableForDowngrade
 		) {
@@ -930,29 +1061,11 @@ const PlansFeaturesMain = ( {
 					}
 					targetPlanSlug={ pendingDowngradePlanSlug }
 					purchaseId={ currentPlan?.purchaseId }
-					onClose={ () => setPendingDowngradePlanSlug( null ) }
-					onConfirm={ () => {
-						const planPath = pendingDowngradePlanSlug
-							? getPlanPath( pendingDowngradePlanSlug )
-							: null;
-						if ( ! planPath || ! siteSlug ) {
-							return;
-						}
-						setPendingDowngradePlanSlug( null );
-						recordTracksEvent( 'calypso_plan_features_downgrade_click', {
-							current_plan: sitePlanSlug,
-							downgrading_to: pendingDowngradePlanSlug,
-						} );
-						// Use a full navigation rather than `page()` because this grid can be
-						// rendered inside the Stepper, where the `page` router is not initialized.
-						window.location.href = addQueryArgs(
-							{
-								...( coupon && { coupon } ),
-								...( redirectTo && { redirect_to: redirectTo } ),
-							},
-							`/checkout/${ siteSlug }/${ planPath }`
-						);
-					} }
+					isInstantDowngrade={ downgradeMode === 'instant' }
+					refundText={ downgradeRefundText }
+					isConfirming={ cancelAndRefundMutation.isPending }
+					onClose={ closeDowngradeModal }
+					onConfirm={ confirmDowngrade }
 				/>
 				{ siteId && gridPlansForFeaturesGrid && (
 					<PlanNotice

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -414,15 +414,25 @@ const PlansFeaturesMain = ( {
 			downgrading_to: pendingDowngradePlanSlug,
 			mode: 'checkout',
 		} );
+		// Every /checkout link must carry redirect_to and cancel_to (per the links
+		// guidelines) so exiting checkout behaves correctly. When this grid renders
+		// inside the Stepper these arrive on the URL rather than as props, so read
+		// both the prop and the current URL.
+		const redirectTarget = redirectTo ?? getQueryArg( window.location.href, 'redirect_to' );
+		const cancelTarget = getQueryArg( window.location.href, 'cancel_to' );
+		const checkoutQuery: Record< string, string > = {};
+		if ( coupon ) {
+			checkoutQuery.coupon = coupon;
+		}
+		if ( typeof redirectTarget === 'string' ) {
+			checkoutQuery.redirect_to = redirectTarget;
+		}
+		if ( typeof cancelTarget === 'string' ) {
+			checkoutQuery.cancel_to = cancelTarget;
+		}
 		// Use a full navigation rather than `page()` because this grid can be rendered
 		// inside the Stepper, where the `page` router is not initialized.
-		window.location.href = addQueryArgs(
-			{
-				...( coupon && { coupon } ),
-				...( redirectTo && { redirect_to: redirectTo } ),
-			},
-			`/checkout/${ siteSlug }/${ planPath }`
-		);
+		window.location.href = addQueryArgs( checkoutQuery, `/checkout/${ siteSlug }/${ planPath }` );
 	};
 
 	const confirmDowngrade = () =>


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2109/

## Proposed changes

This adds a second self-serve downgrade path: when a plan is still within its initial refund window, the existing "Change plan"/"Downgrade" entry points are shown, the downgrade dialog displays the downgrade-specific refund amount, and confirming performs the downgrade instantly via the cancel endpoint's `type: 'downgrade'` / `to_product_id` feature — no checkout round-trip. It is gated by the same `plans/expired-downgrade` config flag as the existing past-expiry downgrade flow, and the two are mutually exclusive by purchase state.

> [!NOTE]
> This PR will not enable this feature in production; it's currently behind the same feature flag as the post-expiry downgrade (see https://github.com/Automattic/wp-calypso/pull/111408) and is therefore active in staging, development, and wpcalypso. We may ultimately want to launch them separately but for now this is convenient.

Dashboard             |  Calypso
:-------------------------:|:-------------------------:
<img width="1253" height="936" alt="Screenshot 2026-06-08 at 6 19 30 PM" src="https://github.com/user-attachments/assets/faefadaf-663e-4ccb-868c-de258a089752" /> | <img width="1274" height="758" alt="Screenshot 2026-06-08 at 6 18 33 PM" src="https://github.com/user-attachments/assets/cd1ea913-3348-4a22-afbd-df2bc7bf291f" />
<img width="702" height="529" alt="Screenshot 2026-06-09 at 3 54 37 PM" src="https://github.com/user-attachments/assets/cc1bbab3-3099-4537-80a5-8898d6827fe1" /> | <img width="1101" height="650" alt="Screenshot 2026-06-09 at 4 04 55 PM" src="https://github.com/user-attachments/assets/34a3f672-7e07-4c37-8982-abad243e63e7" />

## Why are these changes being made?

Previously, self-serve downgrades only existed for plans past their expiry date (grace period; see https://linear.app/a8c/issue/SHILL-2090/implement-post-expiry-downgrade-flow), and those routed the user to checkout to purchase the lower-tier plan. Users who are still within their refund window have no reason to pay again — the cheaper plan can be provisioned immediately and the difference refunded — so sending them through checkout is both unnecessary friction and confusing.

This flow reuses the cancel endpoint's existing `to_product_id` downgrade capability (already used by the cancellation flow) to perform the change instantly. The full purchase `refund_amount` is the wrong number to display here because it reflects cancelling the plan outright; the per-target `refund_options` entry carries the correct amount for a downgrade to a specific product. The eligibility check deliberately omits any "amount > 0" requirement so that plans bought with credits or otherwise free still get the instant path (they simply won't show a refund line). Reusing the existing `plans/expired-downgrade` flag keeps the two downgrade types rolling out and rolling back together, and because one path requires the expiry date to have passed and the other requires it not to have, they can never both apply to the same purchase.

## Testing instructions

* Enable the `plans/expired-downgrade` flag (already on in development configs).
* Use a site whose current paid plan is **within its initial refund window** (recently purchased, not a renewal).
* Dashboard → purchase settings: confirm a "Change plan" action appears → click it → in the plan grid pick a lower-tier plan → confirm the dialog shows the downgrade-specific refund amount and the lost-features list → click "Downgrade and refund …" → confirm the downgrade happens instantly (no checkout) and you land on the new plan's settings page.
* Repeat from Classic `/me/purchases/...` ("Change plan" nav item → `/plans/{site}`) and the Stepper plans page (`/setup/plan-upgrade?allow_downgrade=true`).
* Credit/free plan within the window: confirm the instant downgrade is still offered, with no refund line and a plain "Downgrade to …" button.
* Regression: a plan **past its expiry date** (grace period) still routes to checkout, with no refund line and no instant mutation.
* A plan that is neither within the refund window nor past expiry shows no "Change plan" entry point.

