### PR TITLE
MSD: Exclude staging sites from the dashboard site list (minimal)

### DIFF
--- a/client/dashboard/app-ciab/index.tsx
+++ b/client/dashboard/app-ciab/index.tsx
@@ -7,6 +7,7 @@ import {
 } from '@automattic/api-queries';
 /* eslint-enable no-restricted-imports */
 import boot from '../app/boot';
+import { withDashboardSiteDefaults } from '../app/site-query-defaults';
 import { getPostHogConfig } from './posthog';
 import CiabDashboardStepperLogo from './stepper-logo';
 import './translations';
@@ -58,9 +59,9 @@ boot( {
 	},
 	queries: {
 		sitesQuery: ( fetchSitesOptions?: FetchSitesOptions ) =>
-			sitesQuery( [ 'commerce-garden' ], fetchSitesOptions ),
+			sitesQuery( [ 'commerce-garden' ], withDashboardSiteDefaults( fetchSitesOptions ) ),
 		paginatedSitesQuery: ( fetchSitesOptions?: FetchPaginatedSitesOptions ) =>
-			paginatedSitesQuery( [ 'commerce-garden' ], fetchSitesOptions ),
+			paginatedSitesQuery( [ 'commerce-garden' ], withDashboardSiteDefaults( fetchSitesOptions ) ),
 		dashboardSiteFiltersQuery: ( fields: FetchDashboardSiteFiltersParams[ 'fields' ] ) =>
 			dashboardSiteFiltersQuery( [ 'commerce-garden' ], fields ),
 		domainsQuery: () => domainsQuery( { garden: 'commerce' } ),

--- a/client/dashboard/app-dotcom/index.tsx
+++ b/client/dashboard/app-dotcom/index.tsx
@@ -8,6 +8,7 @@ import {
 /* eslint-enable no-restricted-imports */
 import { isEnabled } from '@automattic/calypso-config';
 import boot from '../app/boot';
+import { withDashboardSiteDefaults } from '../app/site-query-defaults';
 import Logo from './logo';
 import type {
 	FetchSitesOptions,
@@ -53,9 +54,10 @@ boot( {
 		siteSwitcher: () => import( '../sites/site-switcher' ),
 	},
 	queries: {
-		sitesQuery: ( fetchSiteOptions?: FetchSitesOptions ) => sitesQuery( 'all', fetchSiteOptions ),
+		sitesQuery: ( fetchSiteOptions?: FetchSitesOptions ) =>
+			sitesQuery( 'all', withDashboardSiteDefaults( fetchSiteOptions ) ),
 		paginatedSitesQuery: ( fetchSiteOptions?: FetchPaginatedSitesOptions ) =>
-			paginatedSitesQuery( 'all', fetchSiteOptions ),
+			paginatedSitesQuery( 'all', withDashboardSiteDefaults( fetchSiteOptions ) ),
 		dashboardSiteFiltersQuery: ( fields: FetchDashboardSiteFiltersParams[ 'fields' ] ) =>
 			dashboardSiteFiltersQuery( 'all', fields ),
 		domainsQuery: () => domainsQuery(),

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -7,6 +7,7 @@ import {
 } from '@automattic/api-queries';
 /* eslint-enable no-restricted-imports */
 import { createContext, useContext } from 'react';
+import { withDashboardSiteDefaults } from './site-query-defaults';
 import type {
 	FetchSitesOptions,
 	FetchPaginatedSitesOptions,
@@ -108,9 +109,10 @@ export const APP_CONTEXT_DEFAULT_CONFIG: AppConfig = {
 		siteSwitcher: () => Promise.resolve( { default: () => null } ),
 	},
 	queries: {
-		sitesQuery: ( fetchSiteOptions?: FetchSitesOptions ) => sitesQuery( 'all', fetchSiteOptions ),
+		sitesQuery: ( fetchSiteOptions?: FetchSitesOptions ) =>
+			sitesQuery( 'all', withDashboardSiteDefaults( fetchSiteOptions ) ),
 		paginatedSitesQuery: ( fetchSiteOptions?: FetchPaginatedSitesOptions ) =>
-			paginatedSitesQuery( 'all', fetchSiteOptions ),
+			paginatedSitesQuery( 'all', withDashboardSiteDefaults( fetchSiteOptions ) ),
 		dashboardSiteFiltersQuery: ( fields: FetchDashboardSiteFiltersParams[ 'fields' ] ) =>
 			dashboardSiteFiltersQuery( 'all', fields ),
 		domainsQuery: () => domainsQuery(),

--- a/client/dashboard/app/site-query-defaults.ts
+++ b/client/dashboard/app/site-query-defaults.ts
@@ -1,16 +1,22 @@
-import type { FetchPaginatedSitesOptions } from '@automattic/api-core';
+import type { FetchSitesOptions } from '@automattic/api-core';
 
 /**
  * Apply the dashboard's default site-query options. Staging sites are excluded
  * by default ( `include_staging: false` ); callers opt back in by passing
  * `include_staging: true`. Kept dashboard-local so that other
  * `@automattic/api-queries` consumers ( e.g. Reader, me/mcp ) are unaffected.
+ *
+ * Generic over the caller's options so the paginated and non-paginated queries
+ * each keep their own option shape.
  */
-export const withDashboardSiteDefaults = (
-	options?: Partial< FetchPaginatedSitesOptions >
-): FetchPaginatedSitesOptions => ( {
-	site_visibility: 'visible',
-	include_a8c_owned: false,
-	include_staging: false,
-	...options,
-} );
+export const withDashboardSiteDefaults = < T extends Partial< FetchSitesOptions > >(
+	options?: T
+): T & FetchSitesOptions =>
+	// Cast: the spread is the defaults merged with `options`, i.e. `T & FetchSitesOptions`,
+	// but TS can't infer that a spread covers the generic `T`.
+	( {
+		site_visibility: 'visible',
+		include_a8c_owned: false,
+		include_staging: false,
+		...options,
+	} ) as T & FetchSitesOptions;

--- a/client/dashboard/app/site-query-defaults.ts
+++ b/client/dashboard/app/site-query-defaults.ts
@@ -1,0 +1,16 @@
+import type { FetchPaginatedSitesOptions } from '@automattic/api-core';
+
+/**
+ * Apply the dashboard's default site-query options. Staging sites are excluded
+ * by default ( `include_staging: false` ); callers opt back in by passing
+ * `include_staging: true`. Kept dashboard-local so that other
+ * `@automattic/api-queries` consumers ( e.g. Reader, me/mcp ) are unaffected.
+ */
+export const withDashboardSiteDefaults = (
+	options?: Partial< FetchPaginatedSitesOptions >
+): FetchPaginatedSitesOptions => ( {
+	site_visibility: 'visible',
+	include_a8c_owned: false,
+	include_staging: false,
+	...options,
+} );

--- a/client/dashboard/plugins/hooks/use-plugin-sites.ts
+++ b/client/dashboard/plugins/hooks/use-plugin-sites.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
+import { useAppContext } from '../../app/context';
+
+/**
+ * Sites for the plugin-management surfaces. Unlike the rest of the dashboard,
+ * these intentionally include staging sites so plugins can be managed on them.
+ */
+export const usePluginSites = () => {
+	const { queries } = useAppContext();
+	return useQuery(
+		queries.sitesQuery( {
+			site_visibility: 'visible',
+			include_a8c_owned: false,
+			include_staging: true,
+		} )
+	);
+};

--- a/client/dashboard/plugins/manage/hooks/use-sites-by-id.ts
+++ b/client/dashboard/plugins/manage/hooks/use-sites-by-id.ts
@@ -1,16 +1,8 @@
 import { Site } from '@automattic/api-core';
-import { useQuery } from '@tanstack/react-query';
-import { useAppContext } from '../../../app/context';
+import { usePluginSites } from '../../hooks/use-plugin-sites';
 
 export const useSitesById = () => {
-	const { queries } = useAppContext();
-	const { data: sites, isLoading: isLoadingSites } = useQuery(
-		queries.sitesQuery( {
-			site_visibility: 'visible',
-			include_a8c_owned: false,
-			include_staging: true,
-		} )
-	);
+	const { data: sites, isLoading: isLoadingSites } = usePluginSites();
 
 	const map = new Map< number, Site >();
 

--- a/client/dashboard/plugins/manage/hooks/use-sites-by-id.ts
+++ b/client/dashboard/plugins/manage/hooks/use-sites-by-id.ts
@@ -4,7 +4,13 @@ import { useAppContext } from '../../../app/context';
 
 export const useSitesById = () => {
 	const { queries } = useAppContext();
-	const { data: sites, isLoading: isLoadingSites } = useQuery( queries.sitesQuery() );
+	const { data: sites, isLoading: isLoadingSites } = useQuery(
+		queries.sitesQuery( {
+			site_visibility: 'visible',
+			include_a8c_owned: false,
+			include_staging: true,
+		} )
+	);
 
 	const map = new Map< number, Site >();
 

--- a/client/dashboard/plugins/plugin/use-plugin.ts
+++ b/client/dashboard/plugins/plugin/use-plugin.ts
@@ -7,8 +7,8 @@ import {
 } from '@automattic/api-queries';
 import { useQuery, useQueries, useQueryClient } from '@tanstack/react-query';
 import { useMemo } from 'react';
-import { useAppContext } from '../../app/context';
 import { useLocale } from '../../app/locale';
+import { usePluginSites } from '../hooks/use-plugin-sites';
 
 export interface SiteWithPluginData extends Site {
 	actionLinks?: SitePlugin[ 'action_links' ];
@@ -37,20 +37,13 @@ const useMarketplaceSearchIcon = ( pluginSlug: string ) => {
 export const usePlugin = ( pluginSlug: string, { enabled = true }: { enabled?: boolean } = {} ) => {
 	const queryClient = useQueryClient();
 	const availableIcon = useMarketplaceSearchIcon( pluginSlug );
-	const { queries } = useAppContext();
 	const locale = useLocale();
 	const {
 		data: sitesPlugins,
 		isLoading: isLoadingSitesPlugins,
 		isFetching: isFetchingSitePlugins,
 	} = useQuery( { ...pluginsQuery(), enabled } );
-	const { data: sites, isLoading: isLoadingSites } = useQuery(
-		queries.sitesQuery( {
-			site_visibility: 'visible',
-			include_a8c_owned: false,
-			include_staging: true,
-		} )
-	);
+	const { data: sites, isLoading: isLoadingSites } = usePluginSites();
 	const { data: marketplacePlugins, isLoading: isLoadingMarketplacePlugins } = useQuery(
 		marketplacePluginsQuery()
 	);

--- a/client/dashboard/plugins/plugin/use-plugin.ts
+++ b/client/dashboard/plugins/plugin/use-plugin.ts
@@ -44,7 +44,13 @@ export const usePlugin = ( pluginSlug: string, { enabled = true }: { enabled?: b
 		isLoading: isLoadingSitesPlugins,
 		isFetching: isFetchingSitePlugins,
 	} = useQuery( { ...pluginsQuery(), enabled } );
-	const { data: sites, isLoading: isLoadingSites } = useQuery( queries.sitesQuery() );
+	const { data: sites, isLoading: isLoadingSites } = useQuery(
+		queries.sitesQuery( {
+			site_visibility: 'visible',
+			include_a8c_owned: false,
+			include_staging: true,
+		} )
+	);
 	const { data: marketplacePlugins, isLoading: isLoadingMarketplacePlugins } = useQuery(
 		marketplacePluginsQuery()
 	);

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -69,6 +69,9 @@ const getFetchPaginatedSitesOptions = (
 		// See: https://github.com/Automattic/wp-calypso/pull/104220.
 		site_visibility: view.search || shouldIncludeA8COwned || isRestoringAccount ? 'all' : 'visible',
 		include_a8c_owned: shouldIncludeA8COwned,
+		// Keep staging sites in the classic Calypso backport; the standalone
+		// dashboard omits the param and relies on the backend default to exclude.
+		...( isDashboardBackport() && { include_staging: true } ),
 		search: view.search,
 		sort_field: view.sort?.field,
 		sort_direction: view.sort?.direction,

--- a/packages/api-core/src/me-sites/fetchers.ts
+++ b/packages/api-core/src/me-sites/fetchers.ts
@@ -14,6 +14,7 @@ export interface FetchSitesOptions {
 	source?: string;
 	site_visibility: 'all' | 'visible' | 'hidden' | 'deleted';
 	include_a8c_owned: boolean;
+	include_staging?: boolean;
 }
 
 export interface FetchPaginatedSitesOptions extends FetchSitesOptions {
@@ -33,7 +34,7 @@ export interface FetchPaginatedSitesResponse {
 
 export async function fetchSites(
 	site_types: FetchSiteTypes,
-	{ source, site_visibility, include_a8c_owned }: FetchSitesOptions
+	{ source, site_visibility, include_a8c_owned, include_staging }: FetchSitesOptions
 ): Promise< Site[] > {
 	const { sites } = await wpcom.req.get(
 		{
@@ -47,6 +48,7 @@ export async function fetchSites(
 			site_activity: 'active',
 			site_visibility,
 			include_a8c_owned,
+			include_staging,
 			include_domain_only: false,
 			filters: site_types !== 'all' ? site_types.join( ',' ) : undefined,
 		}
@@ -60,6 +62,7 @@ export async function fetchPaginatedSites(
 		source,
 		site_visibility,
 		include_a8c_owned,
+		include_staging,
 		search,
 		plan,
 		visibility,
@@ -81,6 +84,7 @@ export async function fetchPaginatedSites(
 			site_activity: 'active',
 			site_visibility,
 			include_a8c_owned,
+			include_staging,
 			include_domain_only: false,
 			filters: site_types !== 'all' ? site_types.join( ',' ) : undefined,
 			search,


### PR DESCRIPTION
Part of DOTMSD-220

Alternative to #111428 with a smaller shared-package footprint. Where #111428 changes the shared `sitesQuery`/`paginatedSitesQuery` defaults (affecting Reader social and `me/mcp`), this version keeps the shared query untouched and confines the staging policy to the dashboard.

## Approach

- `@automattic/api-core`: add an optional `include_staging?: boolean` to `FetchSitesOptions` and forward it on both `/me/sites` fetchers (1.2 + 1.3) **only when provided** (same handling as `source`). Behavior-neutral for callers that don't pass it.
- `@automattic/api-queries`: **unchanged.** No new default, no query-key change — Reader social (`sitesQuery('all')`) and the `me/mcp` screens are unaffected.
- Dashboard: the context query wrappers default `include_staging: false` via `withDashboardSiteDefaults`, so every dashboard surface excludes staging. Plugin surfaces and the classic Calypso backport opt back in with `include_staging: true`.

The backend only excludes staging when `include_staging: false` is sent explicitly (an absent param includes them), so the default is applied in the dashboard wrappers rather than relying on backend behavior.

## Where staging is excluded (`include_staging: false`, via the wrapper default)

- Main site list, site switcher, primary-site dropdown, `notifications/sites`, domain-transfer selector.

## Where staging is kept (`include_staging: true`)

- Single-plugin page and plugins management list + bulk-action modal (shared `usePluginSites` hook).
- The classic Calypso backport site list (`isDashboardBackport()`).

## Why dashboard-scoped

`withDashboardSiteDefaults` lives in the dashboard and is applied only by the dashboard's context query wrappers. Reader social and `me/mcp` import the shared `sitesQuery` directly, so their behavior and query keys are unchanged.

## Trade-off vs #111428

Same correctness (explicit `include_staging: false`), but the default is confined to the dashboard wrappers instead of the shared query layer — so other `@automattic/api-queries` consumers are not affected, and the cache-key normalization that #111428 required is unnecessary.

## Testing Instructions

With the backend support in place:

- Standalone dashboard — staging sites do **not** appear in: main site list, site switcher, primary-site dropdown, `notifications/sites`, domain-transfer selector.
- Staging sites **still** appear on: `plugins/manage/gutenberg` and the classic Calypso backport `/sites` list.

DevTools console check (v1.3 endpoint):

```js
const count = (v) =>
  wp.req.get('/me/sites', { apiVersion: '1.3', include_staging: v, site_visibility: 'all', per_page: 100, fields: 'ID,is_wpcom_staging_site' })
    .then(r => ({ total: r.sites.length, staging: r.sites.filter(s => s.is_wpcom_staging_site).length }));
Promise.all([count(false), count(true)]).then(([off, on]) => console.table({ false: off, true: on }));
```

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you tested accessibility for your changes? (PCYsg-S3g-p2)
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)