### PR TITLE
Dashboard: fix unstable useQueries deps in deployments list

### DIFF
--- a/client/dashboard/sites/deployments-list/index.tsx
+++ b/client/dashboard/sites/deployments-list/index.tsx
@@ -48,8 +48,11 @@ function DeploymentsList() {
 		codeDeploymentsQuery( site.ID )
 	);
 
-	// Fetch all deployment runs in parallel
-	const deploymentRunsQueries = useQueries( {
+	// Fetch all deployment runs in parallel, then transform the data to include
+	// deployment info and mark active deployments. The transformation lives in
+	// `combine` (rather than a separate useMemo over the queries result) so the
+	// output stays referentially stable across renders.
+	const { deploymentRuns, isLoadingRuns } = useQueries( {
 		queries: deployments.map( ( deployment: CodeDeploymentData ) => ( {
 			...codeDeploymentRunsQuery( site.ID, deployment.id ),
 			refetchInterval: 5000,
@@ -57,38 +60,38 @@ function DeploymentsList() {
 				persist: false,
 			},
 		} ) ),
+		combine: ( results ) => {
+			const allRuns: DeploymentRunWithDeploymentInfo[] = [];
+
+			results.forEach( ( query, index ) => {
+				const deployment = deployments[ index ];
+				if ( query.data && deployment ) {
+					const runsWithInfo = query.data.map( ( run: DeploymentRun ) => {
+						const isActiveDeployment =
+							deployment.current_deployment_run?.id === run.id ||
+							( ! deployment.current_deployment_run &&
+								deployment.current_deployed_run?.id === run.id );
+
+						return {
+							...run,
+							repository_name: deployment.repository_name,
+							branch_name: deployment.branch_name,
+							is_automated: deployment.is_automated,
+							is_active_deployment: isActiveDeployment,
+						};
+					} );
+					allRuns.push( ...runsWithInfo );
+				}
+			} );
+
+			return {
+				deploymentRuns: allRuns,
+				isLoadingRuns: results.some( ( query ) => query.isLoading ),
+			};
+		},
 	} );
 
-	// Transform the data to include deployment info and mark active deployments
-	const deploymentRuns: DeploymentRunWithDeploymentInfo[] = useMemo( () => {
-		const allRuns: DeploymentRunWithDeploymentInfo[] = [];
-
-		deploymentRunsQueries.forEach( ( query, index ) => {
-			const deployment = deployments[ index ];
-			if ( query.data && deployment ) {
-				const runsWithInfo = query.data.map( ( run: DeploymentRun ) => {
-					const isActiveDeployment =
-						deployment.current_deployment_run?.id === run.id ||
-						( ! deployment.current_deployment_run &&
-							deployment.current_deployed_run?.id === run.id );
-
-					return {
-						...run,
-						repository_name: deployment.repository_name,
-						branch_name: deployment.branch_name,
-						is_automated: deployment.is_automated,
-						is_active_deployment: isActiveDeployment,
-					};
-				} );
-				allRuns.push( ...runsWithInfo );
-			}
-		} );
-
-		return allRuns;
-	}, [ deployments, deploymentRunsQueries ] );
-
-	const isLoading =
-		isLoadingDeployments || deploymentRunsQueries.some( ( query ) => query.isLoading );
+	const isLoading = isLoadingDeployments || isLoadingRuns;
 
 	const repositoryOptions = useMemo( () => {
 		return Array.from( new Set( deploymentRuns.map( ( item ) => item.repository_name ) ) )

--- a/client/dashboard/sites/deployments-list/index.tsx
+++ b/client/dashboard/sites/deployments-list/index.tsx
@@ -3,13 +3,19 @@ import {
 	codeDeploymentsQuery,
 	codeDeploymentRunsQuery,
 } from '@automattic/api-queries';
-import { useSuspenseQuery, useQuery, useQueries, useQueryClient } from '@tanstack/react-query';
+import {
+	useSuspenseQuery,
+	useQuery,
+	useQueries,
+	useQueryClient,
+	type UseQueryResult,
+} from '@tanstack/react-query';
 import { Button, Modal } from '@wordpress/components';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon, seen } from '@wordpress/icons';
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import { usePersistentView } from '../../app/hooks/use-persistent-view';
 import { PerformanceTrackerStop } from '../../app/performance-tracking';
 import {
@@ -48,17 +54,8 @@ function DeploymentsList() {
 		codeDeploymentsQuery( site.ID )
 	);
 
-	// Fetch all deployment runs in parallel and then transform the data to include
-	// deployment info and mark active deployments.
-	const { deploymentRuns, isLoadingRuns } = useQueries( {
-		queries: deployments.map( ( deployment: CodeDeploymentData ) => ( {
-			...codeDeploymentRunsQuery( site.ID, deployment.id ),
-			refetchInterval: 5000,
-			meta: {
-				persist: false,
-			},
-		} ) ),
-		combine: ( results ) => {
+	const combineDeploymentRuns = useCallback(
+		( results: UseQueryResult< DeploymentRun[] >[] ) => {
 			const allRuns: DeploymentRunWithDeploymentInfo[] = [];
 
 			results.forEach( ( query, index ) => {
@@ -87,6 +84,19 @@ function DeploymentsList() {
 				isLoadingRuns: results.some( ( query ) => query.isLoading ),
 			};
 		},
+		[ deployments ]
+	);
+
+	// Fetch all deployment runs in parallel and transform via the memoized combiner.
+	const { deploymentRuns, isLoadingRuns } = useQueries( {
+		queries: deployments.map( ( deployment: CodeDeploymentData ) => ( {
+			...codeDeploymentRunsQuery( site.ID, deployment.id ),
+			refetchInterval: 5000,
+			meta: {
+				persist: false,
+			},
+		} ) ),
+		combine: combineDeploymentRuns,
 	} );
 
 	const isLoading = isLoadingDeployments || isLoadingRuns;

--- a/client/dashboard/sites/deployments-list/index.tsx
+++ b/client/dashboard/sites/deployments-list/index.tsx
@@ -48,10 +48,8 @@ function DeploymentsList() {
 		codeDeploymentsQuery( site.ID )
 	);
 
-	// Fetch all deployment runs in parallel, then transform the data to include
-	// deployment info and mark active deployments. The transformation lives in
-	// `combine` (rather than a separate useMemo over the queries result) so the
-	// output stays referentially stable across renders.
+	// Fetch all deployment runs in parallel and then transform the data to include
+	// deployment info and mark active deployments.
 	const { deploymentRuns, isLoadingRuns } = useQueries( {
 		queries: deployments.map( ( deployment: CodeDeploymentData ) => ( {
 			...codeDeploymentRunsQuery( site.ID, deployment.id ),


### PR DESCRIPTION
## Proposed Changes

* Move the deployment-runs transformation in `deployments-list` out of a `useMemo` (which depended on the non-referentially-stable `useQueries` result) and into the `combine` option of `useQueries`.
* Return `isLoadingRuns` from `combine`, replacing the `.some()` loading check over the raw queries array.

## Why are these changes being made?

Main reason, it produced an eslint error. Eslint is what pointed out to me that the `useQueries` results aren't referentially stable.

TanStack Query memoizes `combine`'s output, so the transformed `deploymentRuns` is now referentially stable — clearing the lint error and keeping the downstream `repositoryOptions`/`userNameOptions` memos stable too.

## Testing Instructions

* Run `yarn eslint client/dashboard/sites/deployments-list/index.tsx` — no errors.
* Open the site Deployments list with one or more connected repositories; verify runs render, active deployments are marked, repository/author filters populate, and loading state behaves as before.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [x] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
