### PR TITLE
Backup: fix huge horizontal scroll on the in-progress view

### DIFF
--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -36,6 +36,14 @@ body.is-section-backup {
 	// flex column container would override `align-items: stretch` and shrink
 	// each card to its content width.
 	display: block;
+
+	// The page-layout content column is a flex column and this wrap is one of its
+	// items. The DotPager/Swipeable "tips" carousel sizes its slides from a
+	// ResizeObserver measurement of its own width with no upper bound, so an
+	// uncapped flex item lets that measurement feed back on itself and run the
+	// column out to the layout engine's 2^24px ceiling (huge horizontal scroll).
+	// Capping the item at its container width breaks the loop.
+	max-width: 100%;
 }
 
 .backup__search {


### PR DESCRIPTION
## Proposed Changes

* Cap `.backup__main-wrap` with `max-width: 100%` so the Backup **in‑progress** view can no longer be stretched to an enormous width by the tips carousel.

## Why are these changes being made?

The Backup in‑progress view renders the `DotPager` / `Swipeable` “Did you know” tips carousel. `Swipeable` sizes its slides from a `ResizeObserver` measurement of *its own* width, with no upper bound — fine as long as an ancestor caps that width.

#109899 (sticky Jetpack footer / fixed primary layout) migrated admin pages from a `height: 100%` block chain to a flex layout, which turned `.backup__main-wrap` into an **uncapped flex item of a flex column**. With no width ceiling, the carousel’s self‑measurement feeds back on itself and runs the column out to the layout engine’s 2^24px (~16.7M px) ceiling — producing a huge horizontal scrollbar across the whole page. It only manifests on the in‑progress view because that is the only Backup state that renders the carousel.

`max-width: 100%` restores the width ceiling the pre‑#109899 layout used to provide, breaking the feedback loop. It is a no‑op in normal layout and only engages to prevent the runaway.

The deeper root cause is in the shared `@automattic/components` `Swipeable` (it should cap its own self‑measured width). This PR contains the symptom at the call site; a follow‑up against that package would prevent the same class of bug in other flex contexts.

## Testing Instructions

1. On a site with Jetpack VaultPress Backup, open the Backup page in the **“Backup In Progress”** state (the view with the “Did you know” tips carousel and its pager dots).
2. On `trunk`: note the large horizontal scrollbar — the page scrolls ~16M px to the right.
3. On this branch: confirm there is no horizontal scrollbar and the page does not scroll horizontally.
4. Confirm the “Did you know” tips carousel still renders and flips between its two slides.

Optional console check (should print a sane width, not ~16777216):

```js
getComputedStyle( document.querySelector( '.swipeable__pages' ) ).width
```

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
