### PR TITLE
Live Preview: remove dead notice CSS

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.scss
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.scss
@@ -1,20 +1,3 @@
-.components-notice:has(.wpcom-live-preview-action) {
-	.components-notice__content {
-		display: flex;
-		align-items: center;
-		margin-right: 0;
-
-		.components-notice__actions {
-			margin-left: auto;
-
-			.components-notice__action {
-				margin-top: 0;
-				white-space: nowrap;
-			}
-		}
-	}
-}
-
 .wpcom-live-preview-sidebar-notice-container {
 	padding: 24px 24px 0;
 	border-top: 1px solid #2f2f2f;


### PR DESCRIPTION
## Proposed Changes

* Remove the orphaned `.components-notice:has(.wpcom-live-preview-action)` rules from the wpcom-block-editor Live Preview feature's `index.scss`.

## Why are these changes being made?

The `.wpcom-live-preview-action` class these rules target hasn't been rendered by any code since #102810 ("Remove Live Preview notices") deleted the notice that applied it. The selector matches no element today, so the styles are dead.

This surfaced while reviewing the `@wordpress/components` 33 → 35 bump (#111420): that major reworks the `Notice` internal DOM/class names, which *would* have affected this nested selector — except it's already dead. Removing it avoids confusion and keeps the bump clean.

## Testing Instructions

* No functional change — the removed selector matched nothing.
* `yarn lint:css` passes for the file.
* Optional sanity check: in the WordPress Site Editor on a WordPress.com site, start a theme Live Preview that requires an upgrade. The sidebar upgrade notice (styled by the remaining `.wpcom-live-preview-sidebar-notice` rules, untouched here) still renders correctly.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?

🤖 Generated with [Claude Code](https://claude.com/claude-code)