### PR TITLE
Global Nav 2026: slide the desktop dropdown open and closed

### DIFF
--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/hooks.ts
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/hooks.ts
@@ -184,9 +184,22 @@ export function useDropdownFlip( {
 		// Snap any in-flight morph back to `auto` before we measure, so reads are clean.
 		releaseRef.current?.();
 
-		// Closed → open: let CSS grow the panel; flag the unroll so items wait for it.
+		// Closed → open: unroll the white surface from the nav edge, and flag the open so items wait for it.
 		if ( prev === null && next !== null ) {
 			el.classList.add( 'is-dropdown-first-open' );
+			// Drive the `::after` scaleY here (not pure CSS): the panel is `visibility: hidden` at
+			// rest, so the open commit has no rendered `scaleY(0)` frame to ease from. Pin 0 with no
+			// transition, force a reflow, then ease to 1 — the same trick the height morph uses below.
+			if ( ! window.matchMedia( '( prefers-reduced-motion: reduce )' ).matches ) {
+				el.style.setProperty( '--x-dropdown-2026-unroll-duration', '0s' );
+				el.style.setProperty( '--x-dropdown-2026-unroll', '0' );
+				void el.offsetHeight;
+				el.style.setProperty(
+					'--x-dropdown-2026-unroll-duration',
+					'var( --x-dropdown-2026-panel-duration )'
+				);
+				el.style.setProperty( '--x-dropdown-2026-unroll', '1' );
+			}
 			const timer = setTimeout(
 				() => el.classList.remove( 'is-dropdown-first-open' ),
 				morphMs() + 50
@@ -196,12 +209,28 @@ export function useDropdownFlip( {
 			return () => clearTimeout( timer );
 		}
 
-		// Open → closed: nothing to morph. Don't re-measure here — the panel content
-		// is already `aria-hidden` / out of flow, so `el.offsetHeight` reads 0; the
-		// cached resting height (stored on open / switch) is the one to keep.
+		// Open → closed: hold the panel at its resting height while the content + surface fade
+		// out, then snap it shut — otherwise React drops the block out of flow on the same frame
+		// and the panel collapses while the content is still fading, reading as a slide-up. The
+		// cached height is the resting value (React already zeroed `el.offsetHeight`).
 		if ( prev !== null && next === null ) {
 			el.classList.remove( 'is-dropdown-first-open' );
-			return;
+			const node = el;
+			const held = heightByNameRef.current[ prev ];
+			if ( ! held ) {
+				return;
+			}
+			node.style.overflow = 'hidden';
+			node.style.height = `${ held }px`;
+			const release = () => {
+				node.style.height = '';
+				node.style.overflow = '';
+			};
+			const timer = setTimeout( release, morphMs() + 50 );
+			return () => {
+				clearTimeout( timer );
+				release();
+			};
 		}
 
 		// Open → open: FLIP the wrapper height between the two menus.

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/hooks.ts
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/hooks.ts
@@ -175,10 +175,17 @@ export function useDropdownFlip( {
 		}
 
 		// Read the CSS var, not `transitionDuration` — that's a comma list (visibility, height)
-		// and `parseFloat` would grab visibility, not the height value we want.
+		// and `parseFloat` would grab visibility, not the height value we want. The var is
+		// host-tunable, so honour both `s` and `ms` units rather than assuming seconds.
 		const morphMs = () => {
-			const raw = getComputedStyle( el ).getPropertyValue( '--x-dropdown-2026-panel-duration' );
-			return parseFloat( raw ) * 1000 || 280;
+			const raw = getComputedStyle( el )
+				.getPropertyValue( '--x-dropdown-2026-panel-duration' )
+				.trim();
+			const value = parseFloat( raw );
+			if ( ! value ) {
+				return 280;
+			}
+			return /ms$/.test( raw ) ? value : value * 1000;
 		};
 
 		// Snap any in-flight morph back to `auto` before we measure, so reads are clean.
@@ -216,7 +223,7 @@ export function useDropdownFlip( {
 			el.classList.remove( 'is-dropdown-first-open' );
 			const node = el;
 			const held = heightByNameRef.current[ prev ];
-			if ( ! held ) {
+			if ( held === undefined ) {
 				return;
 			}
 			node.style.overflow = 'hidden';

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/hooks.ts
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/hooks.ts
@@ -190,16 +190,15 @@ export function useDropdownFlip( {
 			// Drive the `::after` scaleY here (not pure CSS): the panel is `visibility: hidden` at
 			// rest, so the open commit has no rendered `scaleY(0)` frame to ease from. Pin 0 with no
 			// transition, force a reflow, then ease to 1 — the same trick the height morph uses below.
-			if ( ! window.matchMedia( '( prefers-reduced-motion: reduce )' ).matches ) {
-				el.style.setProperty( '--x-dropdown-2026-unroll-duration', '0s' );
-				el.style.setProperty( '--x-dropdown-2026-unroll', '0' );
-				void el.offsetHeight;
-				el.style.setProperty(
-					'--x-dropdown-2026-unroll-duration',
-					'var( --x-dropdown-2026-panel-duration )'
-				);
-				el.style.setProperty( '--x-dropdown-2026-unroll', '1' );
-			}
+			// Reduced motion is handled in CSS (the `::after` transform is reset there), so no guard here.
+			el.style.setProperty( '--x-dropdown-2026-unroll-duration', '0s' );
+			el.style.setProperty( '--x-dropdown-2026-unroll', '0' );
+			void el.offsetHeight;
+			el.style.setProperty(
+				'--x-dropdown-2026-unroll-duration',
+				'var( --x-dropdown-2026-panel-duration )'
+			);
+			el.style.setProperty( '--x-dropdown-2026-unroll', '1' );
 			const timer = setTimeout(
 				() => el.classList.remove( 'is-dropdown-first-open' ),
 				morphMs() + 50

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -1263,17 +1263,37 @@ $x-menu-2026-admin-bar-mobile: 46px;
 	width: auto;
 	height: auto; // at rest; the JS FLIP pins an explicit px height during a switch
 	z-index: $x-nav-2026-dropdown-z-index;
-	background: $studio-white;
+	// The white surface lives on `::after` so it can unroll on open without scaling the content; the panel itself is transparent.
+	background: transparent;
 	opacity: 1;
 	visibility: hidden;
 	pointer-events: none;
 	transition: visibility $x-nav-2026-transition;
+
+	// White surface that unrolls (scaleY) from the nav edge on first open, mirroring the reference's `.x-nav-dropdown-wrapper--2026::after`. `--x-dropdown-2026-unroll` is driven from `useDropdownFlip` so the open commit has a rendered `scaleY(0)` frame to ease from (a CSS-only version can't, since the panel is `visibility: hidden` at rest).
+	&::after {
+		content: '';
+		position: absolute;
+		inset-inline: 0;
+		inset-block: 0;
+		background-color: $studio-white;
+		z-index: -1;
+		pointer-events: none;
+		transform: scaleY( var( --x-dropdown-2026-unroll, 1 ) );
+		transform-origin: top;
+	}
 
 	// Height morph is desktop-only (below 1025 the wide items are hidden, no dropdown).
 	@media ( min-width: 1025px ) {
 		transition:
 			visibility $x-nav-2026-transition,
 			height var( --x-dropdown-2026-panel-duration ) var( --x-dropdown-2026-easing );
+
+		// JS sets the unroll duration only for the first-open ease; switches keep the surface up (no reroll).
+		&::after {
+			transition: transform var( --x-dropdown-2026-unroll-duration, 0s )
+				var( --x-dropdown-2026-easing );
+		}
 	}
 }
 
@@ -1294,6 +1314,8 @@ $x-menu-2026-admin-bar-mobile: 46px;
 	padding-inline-start: 24px;
 	border-radius: 0;
 	box-shadow: none;
+	// The panel's `::after` owns the white surface (so it can unroll on open); drop the legacy content background that would otherwise paint over it.
+	background: transparent;
 	transform: none;
 	opacity: 0;
 	visibility: hidden;
@@ -2028,6 +2050,11 @@ $x-menu-2026-admin-bar-mobile: 46px;
 
 	.x-dropdown--2026.x-dropdown-content .x-dropdown-subcategory-title,
 	.x-dropdown--2026.x-dropdown-content .x-dropdown-link.x-dropdown-link {
+		transform: none !important;
+	}
+
+	// No unroll: the white surface is simply present when open, gone when not.
+	.x-dropdown.x-dropdown--2026::after {
 		transform: none !important;
 	}
 }


### PR DESCRIPTION
Follow-up to #111439.

## Proposed Changes

* Animate the desktop Global Nav 2026 dropdown so it slides open and closes smoothly, matching the shipped Landpack reference.
* On open, the dropdown's white surface unrolls down from the nav bar instead of popping into place.
* On close, the panel stays put while its contents fade out, then closes — it no longer collapses upward while the menu is still visible.

## Why are these changes being made?

* The previous port reused the reference's height-morph for switching between menus but never carried over the open/close slide, so opening and closing the desktop dropdown felt abrupt compared to the reference. This brings the motion in line.

## Testing Instructions

* Run Calypso locally and open `/patterns?flags=nav-redesign/2026` (logged in), at a desktop width (≥ 1025px).
* Hover a nav item with a dropdown (e.g. Resources): the panel should slide/unroll down from the bar.
* Move between two dropdowns: the panel height should ease between them without re-sliding.
* Move the cursor off the nav: the contents fade out and the panel closes cleanly, without collapsing upward while still visible.
* Confirm the mobile menu (narrow widths) and the legacy nav (no flag) are unchanged.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
