### PR TITLE
Domain bundles: group bundle line items in the checkout order summary

### DIFF
--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import {
 	isBiennially,
 	isDIFMProduct,
@@ -19,6 +20,7 @@ import {
 	doesIntroductoryOfferHavePriceIncrease,
 	filterCostOverridesForLineItem,
 	getLabel,
+	groupBundleLineItems,
 	isOverrideCodeIntroductoryOffer,
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
@@ -36,7 +38,10 @@ import useCartKey from '../../use-cart-key';
 import { getAffiliateCouponLabel } from '../../utils';
 import { CheckIcon } from './check-icon';
 import type { Theme } from '@automattic/composite-checkout';
-import type { LineItemCostOverrideForDisplay } from '@automattic/wpcom-checkout';
+import type {
+	CartBundleLineItem,
+	LineItemCostOverrideForDisplay,
+} from '@automattic/wpcom-checkout';
 
 const PALETTE = colorStudio.colors;
 const COLOR_GRAY_40 = PALETTE[ 'Gray 40' ];
@@ -600,16 +605,93 @@ export function CouponCostOverride( {
 	);
 }
 
+const BundleMemberList = styled.div`
+	display: flex;
+	flex-direction: column;
+	font-size: 12px;
+	font-weight: 400;
+	gap: 2px;
+
+	& .cost-overrides-list-bundle-member {
+		display: flex;
+		justify-content: space-between;
+		gap: 0 16px;
+	}
+`;
+
+/**
+ * Render a domain bundle as a single compact row in the order summary, mirroring
+ * the order-review surface's `BundleLineItem`: a "Domain bundle" title with the
+ * summed bundle total, and each member domain listed beneath with its own price.
+ * The presentation matches the summary's other product rows (green check icon,
+ * label-and-price header) rather than reusing the heavier review component.
+ */
+export function BundleProductAndCostOverridesList( { bundle }: { bundle: CartBundleLineItem } ) {
+	const translate = useTranslate();
+	const { products } = bundle;
+	// All members of a bundle share a currency, so the total can safely be summed
+	// in the smallest unit and rendered under the first member's currency.
+	const currency = products[ 0 ]?.currency ?? 'USD';
+	const bundleTotalInteger = products.reduce(
+		( total, product ) => total + product.item_subtotal_integer,
+		0
+	);
+	const bundleTotalDisplay = formatCurrency( bundleTotalInteger, currency, {
+		isSmallestUnit: true,
+		stripZeros: true,
+	} );
+
+	return (
+		<SimplifiedSingleProductAndCostOverridesListWrapper className="cost-overrides-list-product-wrapper">
+			<WPCheckoutCheckIcon />
+			<ProductTitleAreaForCostOverridesList>
+				<span className="cost-overrides-list-product__title">{ translate( 'Domain bundle' ) }</span>
+				<SimplifiedLineItemPrice actualAmount={ bundleTotalDisplay } />
+			</ProductTitleAreaForCostOverridesList>
+			<BundleMemberList>
+				{ products.map( ( product ) => (
+					<div className="cost-overrides-list-bundle-member" key={ product.uuid }>
+						<span>{ product.meta }</span>
+						<span>
+							{ formatCurrency( product.item_subtotal_integer, product.currency, {
+								isSmallestUnit: true,
+								stripZeros: true,
+							} ) }
+						</span>
+					</div>
+				) ) }
+			</BundleMemberList>
+		</SimplifiedSingleProductAndCostOverridesListWrapper>
+	);
+}
+
 export function ProductsAndCostOverridesList( { responseCart }: { responseCart: ResponseCart } ) {
+	// Bundle grouping is gated behind the `domain-bundling` feature flag. When off,
+	// every product renders on its own line exactly as before.
+	const groupedLineItems = config.isEnabled( 'domain-bundling' )
+		? groupBundleLineItems( responseCart.products )
+		: responseCart.products.map( ( product ) => ( { type: 'product' as const, product } ) );
+
 	return (
 		<ProductsAndCostOverridesListWrapper className="wp-checkout-order-summary__products-list">
-			{ responseCart.products.map( ( product ) => (
-				<SingleProductAndCostOverridesList
-					product={ product }
-					responseCart={ responseCart }
-					key={ product.uuid }
-				/>
-			) ) }
+			{ groupedLineItems.map( ( entry ) => {
+				if ( entry.type === 'bundle' ) {
+					return (
+						<BundleProductAndCostOverridesList
+							bundle={ entry }
+							key={ `bundle-${ entry.groupId }` }
+						/>
+					);
+				}
+
+				return (
+					<SingleProductAndCostOverridesList
+						product={ entry.product }
+						responseCart={ responseCart }
+						key={ entry.product.uuid }
+					/>
+				);
+			} ) }
 			<CouponCostOverride responseCart={ responseCart } />
 		</ProductsAndCostOverridesListWrapper>
 	);

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -632,8 +632,13 @@ export function BundleProductAndCostOverridesList( { bundle }: { bundle: CartBun
 	// All members of a bundle share a currency, so the total can safely be summed
 	// in the smallest unit and rendered under the first member's currency.
 	const currency = products[ 0 ]?.currency ?? 'USD';
+	// Strip per-member coupon discounts before summing. The order summary shows
+	// coupon savings on a dedicated CouponCostOverride line, so the per-line prices
+	// here must reflect the pre-coupon subtotal or the discount is counted twice
+	// (this mirrors how getLineItemPriceDisplay renders single products on this
+	// surface).
 	const bundleTotalInteger = products.reduce(
-		( total, product ) => total + product.item_subtotal_integer,
+		( total, product ) => total + getItemSubtotalExcludingCoupon( product ),
 		0
 	);
 	const bundleTotalDisplay = formatCurrency( bundleTotalInteger, currency, {
@@ -653,7 +658,7 @@ export function BundleProductAndCostOverridesList( { bundle }: { bundle: CartBun
 					<div className="cost-overrides-list-bundle-member" key={ product.uuid }>
 						<span>{ product.meta }</span>
 						<span>
-							{ formatCurrency( product.item_subtotal_integer, product.currency, {
+							{ formatCurrency( getItemSubtotalExcludingCoupon( product ), product.currency, {
 								isSmallestUnit: true,
 								stripZeros: true,
 							} ) }

--- a/client/my-sites/checkout/src/components/test/cost-overrides-list.test.tsx
+++ b/client/my-sites/checkout/src/components/test/cost-overrides-list.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { checkoutTheme } from '@automattic/composite-checkout';
+import { getEmptyResponseCartProduct } from '@automattic/shopping-cart';
+import { ThemeProvider } from '@emotion/react';
+import { render, screen } from '@testing-library/react';
+import { BundleProductAndCostOverridesList } from '../cost-overrides-list';
+import type { CartBundleLineItem } from '@automattic/wpcom-checkout';
+
+function buildDomainProduct( overrides: { uuid: string; meta: string; subtotal: number } ) {
+	return {
+		...getEmptyResponseCartProduct(),
+		product_slug: 'domain_reg',
+		is_domain_registration: true,
+		uuid: overrides.uuid,
+		meta: overrides.meta,
+		item_subtotal_integer: overrides.subtotal,
+	};
+}
+
+const bundle: CartBundleLineItem = {
+	type: 'bundle',
+	groupId: 'bundle-abc',
+	products: [
+		buildDomainProduct( { uuid: 'primary', meta: 'example.com', subtotal: 2200 } ),
+		buildDomainProduct( { uuid: 'companion', meta: 'example.net', subtotal: 1800 } ),
+	],
+};
+
+function renderBundleRow() {
+	return render(
+		<ThemeProvider theme={ checkoutTheme }>
+			<BundleProductAndCostOverridesList bundle={ bundle } />
+		</ThemeProvider>
+	);
+}
+
+describe( 'BundleProductAndCostOverridesList', () => {
+	it( 'renders the bundle label, each member domain, and the summed total', () => {
+		renderBundleRow();
+
+		expect( screen.getByText( 'Domain bundle' ) ).toBeVisible();
+		expect( screen.getByText( 'example.com' ) ).toBeVisible();
+		expect( screen.getByText( 'example.net' ) ).toBeVisible();
+		// 2200 + 1800 = 4000 smallest-unit => $40.
+		expect( screen.getByText( /\$40\b/ ) ).toBeVisible();
+	} );
+} );

--- a/client/my-sites/checkout/src/components/test/cost-overrides-list.test.tsx
+++ b/client/my-sites/checkout/src/components/test/cost-overrides-list.test.tsx
@@ -2,14 +2,51 @@
  * @jest-environment jsdom
  */
 
+import config from '@automattic/calypso-config';
 import { checkoutTheme } from '@automattic/composite-checkout';
-import { getEmptyResponseCartProduct } from '@automattic/shopping-cart';
+import {
+	createShoppingCartManagerClient,
+	getEmptyResponseCart,
+	getEmptyResponseCartProduct,
+	ShoppingCartProvider,
+} from '@automattic/shopping-cart';
 import { ThemeProvider } from '@emotion/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
-import { BundleProductAndCostOverridesList } from '../cost-overrides-list';
+import { useState } from 'react';
+import { Provider as ReduxProvider } from 'react-redux';
+import { createStore, applyMiddleware } from 'redux';
+import { thunk } from 'redux-thunk';
+import {
+	mockGetCartEndpointWith,
+	mockSetCartEndpointWith,
+} from 'calypso/my-sites/checkout/src/test/util';
+import {
+	BundleProductAndCostOverridesList,
+	ProductsAndCostOverridesList,
+} from '../cost-overrides-list';
+import { storeData } from './lib/fixtures';
+import type {
+	ResponseCart,
+	ResponseCartCostOverride,
+	ResponseCartProduct,
+} from '@automattic/shopping-cart';
 import type { CartBundleLineItem } from '@automattic/wpcom-checkout';
 
-function buildDomainProduct( overrides: { uuid: string; meta: string; subtotal: number } ) {
+const mockConfig = config as unknown as { isEnabled: jest.Mock };
+jest.mock( '@automattic/calypso-config', () => {
+	const mock = () => '';
+	mock.isEnabled = jest.fn();
+	return mock;
+} );
+
+function buildDomainProduct( overrides: {
+	uuid: string;
+	meta: string;
+	subtotal: number;
+	costOverrides?: ResponseCartCostOverride[];
+	extra?: ResponseCartProduct[ 'extra' ];
+} ) {
 	return {
 		...getEmptyResponseCartProduct(),
 		product_slug: 'domain_reg',
@@ -17,6 +54,20 @@ function buildDomainProduct( overrides: { uuid: string; meta: string; subtotal: 
 		uuid: overrides.uuid,
 		meta: overrides.meta,
 		item_subtotal_integer: overrides.subtotal,
+		cost_overrides: overrides.costOverrides ?? [],
+		extra: overrides.extra ?? {},
+	};
+}
+
+function buildCouponOverride( oldSubtotal: number, newSubtotal: number ): ResponseCartCostOverride {
+	return {
+		human_readable_reason: 'Coupon',
+		override_code: 'coupon-discount',
+		old_subtotal_integer: oldSubtotal,
+		new_subtotal_integer: newSubtotal,
+		does_override_original_cost: false,
+		percentage: 0,
+		first_unit_only: false,
 	};
 }
 
@@ -29,10 +80,10 @@ const bundle: CartBundleLineItem = {
 	],
 };
 
-function renderBundleRow() {
+function renderBundleRow( bundleToRender: CartBundleLineItem = bundle ) {
 	return render(
 		<ThemeProvider theme={ checkoutTheme }>
-			<BundleProductAndCostOverridesList bundle={ bundle } />
+			<BundleProductAndCostOverridesList bundle={ bundleToRender } />
 		</ThemeProvider>
 	);
 }
@@ -46,5 +97,114 @@ describe( 'BundleProductAndCostOverridesList', () => {
 		expect( screen.getByText( 'example.net' ) ).toBeVisible();
 		// 2200 + 1800 = 4000 smallest-unit => $40.
 		expect( screen.getByText( /\$40\b/ ) ).toBeVisible();
+	} );
+
+	it( 'shows pre-coupon prices so the dedicated coupon line is not double-counted', () => {
+		// The companion carries a $2 coupon discount: its item_subtotal_integer is
+		// already reduced to 1800, but the order summary renders coupon savings on a
+		// separate line, so the bundle must display the pre-coupon 2000.
+		renderBundleRow( {
+			type: 'bundle',
+			groupId: 'bundle-coupon',
+			products: [
+				buildDomainProduct( { uuid: 'primary', meta: 'example.com', subtotal: 2200 } ),
+				buildDomainProduct( {
+					uuid: 'companion',
+					meta: 'example.net',
+					subtotal: 1800,
+					costOverrides: [ buildCouponOverride( 2000, 1800 ) ],
+				} ),
+			],
+		} );
+
+		// Companion shows the pre-coupon $20, not the $18 post-coupon subtotal.
+		expect( screen.getByText( /\$20\b/ ) ).toBeVisible();
+		expect( screen.queryByText( /\$18\b/ ) ).not.toBeInTheDocument();
+		// 2200 + 2000 = 4200 smallest-unit => $42.
+		expect( screen.getByText( /\$42\b/ ) ).toBeVisible();
+	} );
+} );
+
+function buildCartWithBundle(): ResponseCart {
+	return {
+		...getEmptyResponseCart(),
+		products: [
+			buildDomainProduct( {
+				uuid: 'primary',
+				meta: 'example.com',
+				subtotal: 2200,
+				extra: { domain_bundle_group_id: 'group-1', domain_bundle_role: 'primary' },
+			} ),
+			buildDomainProduct( {
+				uuid: 'companion',
+				meta: 'example.net',
+				subtotal: 1800,
+				extra: { domain_bundle_group_id: 'group-1', domain_bundle_role: 'companion' },
+			} ),
+		],
+	};
+}
+
+function TestWrapper( {
+	children,
+	initialCart,
+}: {
+	children: React.ReactNode;
+	initialCart: ResponseCart;
+} ) {
+	const [ reduxStore ] = useState( () => applyMiddleware( thunk )( createStore )( storeData ) );
+	const [ queryClient ] = useState( () => new QueryClient() );
+	const mockSetCartEndpoint = mockSetCartEndpointWith( {
+		currency: initialCart.currency,
+		locale: initialCart.locale,
+	} );
+	const managerClient = createShoppingCartManagerClient( {
+		getCart: mockGetCartEndpointWith( initialCart ),
+		setCart: mockSetCartEndpoint,
+	} );
+	return (
+		<ReduxProvider store={ reduxStore }>
+			<QueryClientProvider client={ queryClient }>
+				<ShoppingCartProvider managerClient={ managerClient }>
+					<ThemeProvider theme={ checkoutTheme }>{ children }</ThemeProvider>
+				</ShoppingCartProvider>
+			</QueryClientProvider>
+		</ReduxProvider>
+	);
+}
+
+describe( 'ProductsAndCostOverridesList', () => {
+	afterEach( () => {
+		mockConfig.isEnabled.mockRestore();
+	} );
+
+	it( 'groups bundle-tagged products into a single bundle row when the flag is on', () => {
+		mockConfig.isEnabled.mockImplementation( ( flag ) => flag === 'domain-bundling' );
+		const responseCart = buildCartWithBundle();
+
+		render(
+			<TestWrapper initialCart={ responseCart }>
+				<ProductsAndCostOverridesList responseCart={ responseCart } />
+			</TestWrapper>
+		);
+
+		expect( screen.getByText( 'Domain bundle' ) ).toBeVisible();
+		expect( screen.getByText( 'example.com' ) ).toBeVisible();
+		expect( screen.getByText( 'example.net' ) ).toBeVisible();
+	} );
+
+	it( 'renders each product on its own line when the flag is off', () => {
+		mockConfig.isEnabled.mockImplementation( () => false );
+		const responseCart = buildCartWithBundle();
+
+		render(
+			<TestWrapper initialCart={ responseCart }>
+				<ProductsAndCostOverridesList responseCart={ responseCart } />
+			</TestWrapper>
+		);
+
+		expect( screen.queryByText( 'Domain bundle' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'example.com' ) ).toBeVisible();
+		expect( screen.getByText( 'example.net' ) ).toBeVisible();
 	} );
 } );

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -440,6 +440,11 @@ export function BundleLineItem( {
 	// All members of a bundle are guaranteed to share a currency, so the total can
 	// safely be summed in the smallest unit and rendered under the first member's currency.
 	const currency = products[ 0 ]?.currency ?? 'USD';
+	// Raw subtotals (coupon included) are correct on this surface: the order review
+	// shows post-coupon prices on every line item. The order summary's bundle row
+	// (BundleProductAndCostOverridesList in cost-overrides-list.tsx) intentionally
+	// differs — it excludes coupon discounts because that surface lists coupon
+	// savings on a dedicated line. Don't "harmonize" the two.
 	const bundleTotalInteger = products.reduce(
 		( total, product ) => total + product.item_subtotal_integer,
 		0


### PR DESCRIPTION
Related to #DOMAINS-2175

## Proposed Changes

**Before:**
<img width="1205" height="1235" alt="CleanShot 2026-06-11 at 12 03 20" src="https://github.com/user-attachments/assets/ca514125-7c01-4921-9439-c4623747c77b" />

**After:**
(note that this doesn't represent the final design polish, just the basic functionality)
<img width="1247" height="890" alt="CleanShot 2026-06-11 at 12 13 10" src="https://github.com/user-attachments/assets/401407a5-d83f-49f4-8290-453150b62395" />



Groups bundle-tagged line items into a single row in the checkout **order summary** panel. DOMAINS-2171 grouped bundles in the order *review* and the mini-cart but not the summary panel; this closes that gap so the grouping is consistent across every checkout surface.

The summary panel renders its product rows via `ProductsAndCostOverridesList` in `client/my-sites/checkout/src/components/cost-overrides-list.tsx` (not `wp-checkout-order-summary.tsx` directly), so the change lives there:

- `cost-overrides-list.tsx` — applies `groupBundleLineItems` to `responseCart.products` and renders a new compact `BundleProductAndCostOverridesList` row (green check, "Domain bundle" label, summed total, member domains listed beneath with prices). Product entries continue through the unchanged `SingleProductAndCostOverridesList`.
- `test/cost-overrides-list.test.tsx` — new test asserting the bundle row renders the label, both member domains, and the summed total.

A compact row was built rather than reusing the order-review `BundleLineItem` (which carries remove buttons + confirmation modal that don't fit the summary panel's visual language). DOMAINS-2175 scopes the collapsed row's look as a decision to make with design — this layout still needs design review before the flag ships.

**Fixed term:** the bundle registers at one year only — no term selector on the row (each domain renews individually at full price; see DOMAINS-2173). DOMAINS-2181 (group term selector) was cancelled.

## Flag gating

Inline `config.isEnabled( 'domain-bundling' )`, identical to `wp-order-review-line-items.tsx`. Flag off → byte-for-byte the previous behavior.

## Testing Instructions

```
yarn test-client client/my-sites/checkout/src/components/test/cost-overrides-list.test.tsx
```

### Manual testing — no sandbox needed

There's no merged UI path that puts a bundle in the cart yet (DOMAINS-2190 is in review), so use the throwaway branch **`domains-2175-manual-test`** — this PR plus the pre-rebase DOMAINS-2190 commits (CTA→cart wiring), both still on the mock bundle fetcher, so the whole flow works against production:

1. `git checkout domains-2175-manual-test && yarn && yarn start`
2. Open domain search with `?flags=domain-bundling` and search a clearly unregistered SLD (e.g. `qwlekjh38skj`) — the mock fetcher fabricates `.com`/`.net`/`.org` members without checking availability, and production *does* validate availability at add time, so a taken domain gets silently dropped from the cart.
3. Click **Get bundle** on the bundle card — all three members land in the cart with `domain_bundle_group_id` extras.
4. Go to checkout: the right-hand "Your order" summary shows a single "Domain bundle" row with the member domains listed beneath and the summed total.
5. Flag off → unchanged summary, members render as individual rows.

Expected non-issues while testing on this branch:
- **No discount/strikethrough** — the server flag is off in production and the mock group id can't pass HMAC verification, so members show full price. This PR is grouping only; pricing display is DOMAINS-2174.
- **The domain-search sidebar cart panel shows members ungrouped** — known gap, DOMAINS-2191, not part of this PR.

Real-data alternative: a sandbox with `WPCOM_DOMAIN_BUNDLE_DISCOUNTS_ENABLED` on and Calypso's API routed to it, on a branch rebased onto trunk (live fetcher) with the rebased DOMAINS-2190 branch merged in — full end-to-end including the server discount.


