### PR TITLE
Domain bundles: add bundle_shown / accepted / removed Tracks events

### DIFF
--- a/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-events.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-events.ts
@@ -225,13 +225,13 @@ export const useWPCOMDomainSearchEvents = ( {
 				);
 			},
 			onBundleShown: ( bundle ) => {
-				recordTracksEvent( 'bundle_shown', {
+				recordTracksEvent( 'calypso_domain_bundle_shown', {
 					domain_bundle_group_id: bundle.bundle_group_id,
 					domain_count: bundle.domains.length,
 				} );
 			},
 			onBundleAddToCart: ( bundle ) => {
-				recordTracksEvent( 'bundle_accepted', {
+				recordTracksEvent( 'calypso_domain_bundle_accepted', {
 					domain_bundle_group_id: bundle.bundle_group_id,
 					domain_count: bundle.domains.length,
 				} );

--- a/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-events.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-events.ts
@@ -224,6 +224,18 @@ export const useWPCOMDomainSearchEvents = ( {
 					)
 				);
 			},
+			onBundleShown: ( bundle ) => {
+				recordTracksEvent( 'bundle_shown', {
+					domain_bundle_group_id: bundle.bundle_group_id,
+					domain_count: bundle.domains.length,
+				} );
+			},
+			onBundleAddToCart: ( bundle ) => {
+				recordTracksEvent( 'bundle_accepted', {
+					domain_bundle_group_id: bundle.bundle_group_id,
+					domain_count: bundle.domains.length,
+				} );
+			},
 		};
 	}, [ flowName, vendor, query, debouncedDomainSearchEvent, analyticsSection, dispatch ] );
 

--- a/client/layout/masterbar/masterbar-cart/masterbar-cart-button.tsx
+++ b/client/layout/masterbar/masterbar-cart/masterbar-cart-button.tsx
@@ -119,7 +119,7 @@ export function MasterbarCartButton( {
 						onRemoveProduct={ onRemoveProduct }
 						onRemoveBundle={ ( groupId, memberCount ) => {
 							reduxDispatch(
-								recordTracksEvent( 'bundle_removed_from_cart', {
+								recordTracksEvent( 'calypso_domain_bundle_removed_from_cart', {
 									domain_bundle_group_id: groupId,
 									domain_count: memberCount,
 								} )

--- a/client/layout/masterbar/masterbar-cart/masterbar-cart-button.tsx
+++ b/client/layout/masterbar/masterbar-cart/masterbar-cart-button.tsx
@@ -117,6 +117,14 @@ export function MasterbarCartButton( {
 						goToCheckout={ goToCheckout }
 						closeCart={ onClose }
 						onRemoveProduct={ onRemoveProduct }
+						onRemoveBundle={ ( groupId, memberCount ) => {
+							reduxDispatch(
+								recordTracksEvent( 'bundle_removed_from_cart', {
+									domain_bundle_group_id: groupId,
+									domain_count: memberCount,
+								} )
+							);
+						} }
 						onRemoveCoupon={ onRemoveCoupon }
 						checkoutLabel={ checkoutLabel }
 						emptyCart={ emptyCart }

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -232,7 +232,7 @@ export function WPOrderReviewLineItems( {
 								removeProductFromCart={ removeProductFromCart }
 								onRemoveBundle={ ( groupId, memberCount ) => {
 									reduxDispatch(
-										recordTracksEvent( 'bundle_removed_from_cart', {
+										recordTracksEvent( 'calypso_domain_bundle_removed_from_cart', {
 											domain_bundle_group_id: groupId,
 											domain_count: memberCount,
 										} )

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -230,6 +230,14 @@ export function WPOrderReviewLineItems( {
 									)
 								}
 								removeProductFromCart={ removeProductFromCart }
+								onRemoveBundle={ ( groupId, memberCount ) => {
+									reduxDispatch(
+										recordTracksEvent( 'bundle_removed_from_cart', {
+											domain_bundle_group_id: groupId,
+											domain_count: memberCount,
+										} )
+									);
+								} }
 							/>
 						</WPOrderReviewListItem>
 					);

--- a/packages/domain-search/src/page/context.ts
+++ b/packages/domain-search/src/page/context.ts
@@ -39,6 +39,8 @@ export const DEFAULT_CONTEXT_VALUE: DomainSearchContextType = {
 		onTrademarkClaimsNoticeAccepted: noop,
 		onTrademarkClaimsNoticeClosed: noop,
 		onPageView: noop,
+		onBundleShown: noop,
+		onBundleAddToCart: noop,
 	},
 	queries: {
 		availableTlds: ( search?: string, vendor?: string ) => availableTldsQuery( vendor, search ),

--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -1,7 +1,7 @@
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { chevronDown, chevronUp, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { BundleCard } from '../components/bundle-card';
 import { Cart } from '../components/cart';
 import { FeaturedSearchResults } from '../components/featured-search-results';
@@ -45,7 +45,7 @@ const StickyCompactBanner = () => {
 };
 
 export const ResultsPage = () => {
-	const { slots, config } = useDomainSearch();
+	const { slots, config, events } = useDomainSearch();
 
 	const {
 		isLoading: isLoadingSuggestions,
@@ -57,6 +57,23 @@ export const ResultsPage = () => {
 		config.numberOfDomainsResultsPerPage - featuredSuggestions.length;
 
 	useRequestTracking();
+
+	// Fire `bundle_shown` once per distinct bundle that actually renders. Keyed on
+	// the group id so a new bundle (different query/experiment arm) re-fires, but
+	// re-renders of the same bundle do not.
+	const shownBundleGroupId =
+		! isLoadingSuggestions && bundleSuggestion && bundleSuggestion.domains.length > 0
+			? bundleSuggestion.bundle_group_id
+			: undefined;
+
+	useEffect( () => {
+		if ( shownBundleGroupId && bundleSuggestion ) {
+			events.onBundleShown( bundleSuggestion );
+		}
+		// Intentionally keyed only on the group id: we want exactly one event per
+		// bundle that appears, not one per render or per `events`/object identity change.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ shownBundleGroupId ] );
 
 	const showCompactBanner = !! slots?.BeforeResults;
 
@@ -99,7 +116,10 @@ export const ResultsPage = () => {
 					<FeaturedSearchResults suggestions={ featuredSuggestions } />
 				) }
 				{ ! isLoadingSuggestions && bundleSuggestion && (
-					<BundleCard suggestion={ bundleSuggestion } />
+					<BundleCard
+						suggestion={ bundleSuggestion }
+						onAddToCart={ ( bundle ) => events.onBundleAddToCart( bundle ) }
+					/>
 				) }
 				{ isLoadingSuggestions ? (
 					<SearchResults.Placeholder />

--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -58,7 +58,7 @@ export const ResultsPage = () => {
 
 	useRequestTracking();
 
-	// Fire `bundle_shown` once per distinct bundle that actually renders. Keyed on
+	// Fire `onBundleShown` once per distinct bundle that actually renders. Keyed on
 	// the group id so a new bundle (different query/experiment arm) re-fires, but
 	// re-renders of the same bundle do not.
 	const shownBundleGroupId =

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -927,6 +927,83 @@ describe( 'ResultsPage', () => {
 			} );
 		} );
 
+		it( 'fires the onBundleShown event once when a bundle suggestion renders', async () => {
+			const onBundleShown = jest.fn();
+
+			mockGetSuggestionsQuery( {
+				params: { query: 'bundle-shown' },
+				suggestions: [ buildSuggestion( { domain_name: 'bundle-shown.com' } ) ],
+			} );
+
+			render(
+				<TestDomainSearch
+					events={ { onBundleShown } }
+					config={ { showBundleSuggestions: true } }
+					query="bundle-shown"
+				>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			await waitFor( () => {
+				expect( onBundleShown ).toHaveBeenCalledTimes( 1 );
+			} );
+
+			expect( onBundleShown ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					bundle_group_id: 'mock-bundle-shown-group',
+					domains: expect.arrayContaining( [
+						expect.objectContaining( { domain: 'bundle-shown.com' } ),
+					] ),
+				} )
+			);
+		} );
+
+		it( 'does not fire the onBundleShown event when bundles are disabled', async () => {
+			const onBundleShown = jest.fn();
+
+			mockGetSuggestionsQuery( {
+				params: { query: 'bundle-off' },
+				suggestions: [ buildSuggestion( { domain_name: 'bundle-off.com' } ) ],
+			} );
+
+			render(
+				<TestDomainSearch events={ { onBundleShown } } query="bundle-off">
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			expect( await screen.findByTitle( 'bundle-off.com' ) ).toBeInTheDocument();
+			expect( onBundleShown ).not.toHaveBeenCalled();
+		} );
+
+		it( 'fires the onBundleAddToCart event when the bundle CTA is clicked', async () => {
+			const user = userEvent.setup();
+			const onBundleAddToCart = jest.fn();
+
+			mockGetSuggestionsQuery( {
+				params: { query: 'bundle-accept' },
+				suggestions: [ buildSuggestion( { domain_name: 'bundle-accept.com' } ) ],
+			} );
+
+			render(
+				<TestDomainSearch
+					events={ { onBundleAddToCart } }
+					config={ { showBundleSuggestions: true } }
+					query="bundle-accept"
+				>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			await user.click( await screen.findByRole( 'button', { name: 'Get bundle' } ) );
+
+			expect( onBundleAddToCart ).toHaveBeenCalledTimes( 1 );
+			expect( onBundleAddToCart ).toHaveBeenCalledWith(
+				expect.objectContaining( { bundle_group_id: 'mock-bundle-accept-group' } )
+			);
+		} );
+
 		it( 'fires the onQueryAvailabilityCheck event when the availability is checked', async () => {
 			const onQueryAvailabilityCheck = jest.fn();
 

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -9,6 +9,7 @@ import { PriceRulesConfig, useSuggestion } from '../hooks/use-suggestion';
 import type { FilterState } from '../components/search-bar/types';
 import type { FeaturedSuggestionReason } from '../helpers/partition-suggestions';
 import type {
+	BundleSuggestion,
 	DomainAvailability,
 	DomainAvailabilityStatus,
 	DomainSuggestion,
@@ -75,6 +76,8 @@ export interface DomainSearchEvents {
 	onTrademarkClaimsNoticeAccepted: ( suggestion: ReturnType< typeof useSuggestion > ) => void;
 	onTrademarkClaimsNoticeClosed: ( suggestion: ReturnType< typeof useSuggestion > ) => void;
 	onPageView: () => void;
+	onBundleShown: ( bundle: BundleSuggestion ) => void;
+	onBundleAddToCart: ( bundle: BundleSuggestion ) => void;
 }
 
 export interface DomainSearchConfig {

--- a/packages/mini-cart/src/mini-cart-line-items.tsx
+++ b/packages/mini-cart/src/mini-cart-line-items.tsx
@@ -42,6 +42,7 @@ export function MiniCartLineItems( {
 	createUserAndSiteBeforeTransaction,
 	responseCart,
 	showBundleGrouping = false,
+	onRemoveBundle,
 }: {
 	removeProductFromCart: RemoveProductFromCart;
 	addProductsToCart: AddProductsToCart;
@@ -49,6 +50,7 @@ export function MiniCartLineItems( {
 	createUserAndSiteBeforeTransaction?: boolean;
 	responseCart: ResponseCart;
 	showBundleGrouping?: boolean;
+	onRemoveBundle?: ( groupId: string, memberCount: number ) => void;
 } ) {
 	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
 	const couponLineItem = getCouponLineItemFromCart( responseCart );
@@ -73,6 +75,7 @@ export function MiniCartLineItems( {
 									canItemBeRemovedFromCart( product, responseCart )
 								) }
 								removeProductFromCart={ removeProductFromCart }
+								onRemoveBundle={ onRemoveBundle }
 							/>
 						</MiniCartLineItemWrapper>
 					);

--- a/packages/mini-cart/src/mini-cart.tsx
+++ b/packages/mini-cart/src/mini-cart.tsx
@@ -132,6 +132,7 @@ export function MiniCart( {
 	goToCheckout,
 	closeCart,
 	onRemoveProduct,
+	onRemoveBundle,
 	onRemoveCoupon,
 	checkoutLabel,
 	emptyCart,
@@ -142,6 +143,7 @@ export function MiniCart( {
 	goToCheckout: ( siteSlug: string ) => void;
 	closeCart: () => void;
 	onRemoveProduct?: ( uuid: string ) => void;
+	onRemoveBundle?: ( groupId: string, memberCount: number ) => void;
 	onRemoveCoupon?: () => void;
 	checkoutLabel?: string;
 	emptyCart?: React.ReactNode;
@@ -201,6 +203,7 @@ export function MiniCart( {
 						addProductsToCart={ addProductsToCart }
 						responseCart={ responseCart }
 						showBundleGrouping={ showBundleGrouping }
+						onRemoveBundle={ onRemoveBundle }
 					/>
 					{ shouldRenderEmptyCart && emptyCart }
 					{ ! shouldRenderEmptyCart && <MiniCartTotal responseCart={ responseCart } /> }

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -424,12 +424,20 @@ export function BundleLineItem( {
 	isSummary,
 	hasDeleteButton,
 	removeProductFromCart,
+	onRemoveBundle,
 }: {
 	bundle: CartBundleLineItem;
 	className?: string | null;
 	isSummary?: boolean;
 	hasDeleteButton?: boolean;
 	removeProductFromCart?: RemoveProductFromCart;
+	/**
+	 * Fired once when a bundle group is removed from the cart (after the user
+	 * confirms the removal modal). Threaded from the app layer so this package
+	 * stays free of a direct analytics dependency. Receives the bundle's group id
+	 * and its member count.
+	 */
+	onRemoveBundle?: ( groupId: string, memberCount: number ) => void;
 } ) {
 	const translate = useTranslate();
 	const { formStatus } = useFormStatus();
@@ -454,6 +462,7 @@ export function BundleLineItem( {
 		products.forEach( ( product ) => {
 			removeProductFromCart?.( product.uuid );
 		} );
+		onRemoveBundle?.( bundle.groupId, products.length );
 	};
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */

--- a/packages/wpcom-checkout/test/bundle-line-item.tsx
+++ b/packages/wpcom-checkout/test/bundle-line-item.tsx
@@ -59,4 +59,37 @@ describe( 'BundleLineItem', () => {
 		expect( removeProductFromCart ).toHaveBeenCalledWith( 'primary' );
 		expect( removeProductFromCart ).toHaveBeenCalledWith( 'companion' );
 	} );
+
+	test( 'fires onRemoveBundle once with the group id and member count on confirmed removal', async () => {
+		const user = userEvent.setup();
+		const onRemoveBundle = jest.fn();
+
+		renderBundle( {
+			hasDeleteButton: true,
+			removeProductFromCart: jest.fn(),
+			onRemoveBundle,
+		} );
+
+		await user.click( screen.getByRole( 'button', { name: /Remove Domain bundle from cart/ } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
+
+		expect( onRemoveBundle ).toHaveBeenCalledTimes( 1 );
+		expect( onRemoveBundle ).toHaveBeenCalledWith( 'bundle-abc', 2 );
+	} );
+
+	test( 'does not fire onRemoveBundle when the removal is cancelled', async () => {
+		const user = userEvent.setup();
+		const onRemoveBundle = jest.fn();
+
+		renderBundle( {
+			hasDeleteButton: true,
+			removeProductFromCart: jest.fn(),
+			onRemoveBundle,
+		} );
+
+		await user.click( screen.getByRole( 'button', { name: /Remove Domain bundle from cart/ } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+
+		expect( onRemoveBundle ).not.toHaveBeenCalled();
+	} );
 } );


### PR DESCRIPTION
Related to #DOMAINS-2179

## Proposed Changes

Adds the bundle Tracks analytics events the ExPlat experiment will measure. **3 of the 4 events are wired here;** `bundle_declined` is deferred — see below.

Events follow the established portability pattern: the `domain-search` / `mini-cart` / `wpcom-checkout` packages emit **no** analytics directly (no `calypso-analytics`/`calypso-config` imports). They expose callback props that the app layer wires to `recordTracksEvent`.

| Event | Hook point | Properties |
|---|---|---|
| `calypso_domain_bundle_shown` | `useEffect` in `domain-search` results page, keyed on `bundle_group_id` (fires once per distinct bundle) | `domain_bundle_group_id`, `domain_count` |
| `calypso_domain_bundle_accepted` | the bundle card "Get bundle" CTA (was previously unwired) | `domain_bundle_group_id`, `domain_count` |
| `calypso_domain_bundle_removed_from_cart` | `BundleLineItem` remove-confirm flow, threaded `onRemoveBundle` through mini-cart + checkout consumers | `domain_bundle_group_id`, `domain_count` |

App-layer wiring lives in `use-wpcom-domain-search-events.ts`, `masterbar-cart-button.tsx`, and `wp-order-review-line-items.tsx` (all already dispatch `recordTracksEvent`).

### `bundle_declined` deferred

The bundle card has only an accept CTA — there's no dismiss affordance, so there's no clean decline signal to fire on. Adding one is a small UI change that ties into the design reconciliation. Tracked in DOMAINS-2187.

### Note

Member count uses the property key `domain_count`. If the experiment dashboards expect a different key, it's a one-line change in three call sites.

## Testing Instructions

```
yarn test-packages packages/wpcom-checkout/test/bundle-line-item.tsx
yarn test-packages packages/domain-search/src/page/test/results.tsx
```

`bundle-line-item` 5/5 (2 new), `results` 39/39 (3 new). Manual: with the flag on, verify `calypso_domain_bundle_shown` fires once when the card renders, `calypso_domain_bundle_accepted` on "Get bundle", and `calypso_domain_bundle_removed_from_cart` after confirming bundle removal — each with the group id + count.

