### PR TITLE
Agents Manager: collapse chat to a FAB on pages without the admin bar trigger

### DIFF
--- a/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
@@ -6,9 +6,11 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { Suggestion } from '@automattic/agenttic-ui';
-import type { ReactNode, Ref } from 'react';
+import type { ComponentProps, ReactNode, Ref } from 'react';
 
 const mockSetFloatingPosition = jest.fn();
+const mockContainerProps = jest.fn();
+const mockHasAdminBarTrigger = jest.fn();
 
 jest.mock(
 	'@automattic/agenttic-ui',
@@ -18,10 +20,13 @@ jest.mock(
 		function MockContainer( {
 			children,
 			emptyView,
+			floatingChatState,
 		}: {
 			children: ReactNode;
 			emptyView: ReactNode;
+			floatingChatState?: string;
 		} ) {
+			mockContainerProps( { floatingChatState } );
 			return (
 				<div>
 					{ emptyView }
@@ -129,10 +134,43 @@ jest.mock( '../../utils/is-plugin-compass-agent', () => ( {
 jest.mock( '../../utils/is-reader-chat-agent', () => ( {
 	isReaderChatHost: () => false,
 } ) );
+jest.mock( '../../hooks/use-admin-bar-integration', () => ( {
+	hasAdminBarTrigger: () => mockHasAdminBarTrigger(),
+} ) );
 
 import AgentChat from '../agent-chat';
 
+function renderAgentChat( props: Partial< ComponentProps< typeof AgentChat > > = {} ) {
+	return render(
+		<AgentChat
+			messages={ [] }
+			suggestions={ [] }
+			emptyViewSuggestions={ [] }
+			error={ null }
+			chatHeaderOptions={ [] }
+			isProcessing={ false }
+			isLoadingConversation={ false }
+			isDocked={ false }
+			isOpen={ false }
+			onSubmit={ jest.fn() }
+			onAbort={ jest.fn() }
+			onClose={ jest.fn() }
+			onExpand={ jest.fn() }
+			onSuggestionClick={ jest.fn() }
+			{ ...props }
+		/>
+	);
+}
+
 describe( 'AgentChat', () => {
+	beforeEach( () => {
+		mockHasAdminBarTrigger.mockReturnValue( false );
+	} );
+
+	afterEach( () => {
+		mockContainerProps.mockClear();
+	} );
+
 	it( 'forwards empty view suggestion clicks to the shared suggestion handler', async () => {
 		const user = userEvent.setup();
 		const suggestion = {
@@ -142,27 +180,24 @@ describe( 'AgentChat', () => {
 		};
 		const onSuggestionClick = jest.fn();
 
-		render(
-			<AgentChat
-				messages={ [] }
-				suggestions={ [] }
-				emptyViewSuggestions={ [ suggestion ] }
-				error={ null }
-				chatHeaderOptions={ [] }
-				isProcessing={ false }
-				isLoadingConversation={ false }
-				isDocked={ false }
-				isOpen
-				onSubmit={ jest.fn() }
-				onAbort={ jest.fn() }
-				onClose={ jest.fn() }
-				onExpand={ jest.fn() }
-				onSuggestionClick={ onSuggestionClick }
-			/>
-		);
+		renderAgentChat( { isOpen: true, emptyViewSuggestions: [ suggestion ], onSuggestionClick } );
 
 		await user.click( screen.getByRole( 'button', { name: 'Check grammar' } ) );
 
 		expect( onSuggestionClick ).toHaveBeenCalledWith( suggestion, [ suggestion ] );
+	} );
+
+	it( 'collapses to a button when closed without the WP admin bar trigger', () => {
+		renderAgentChat( { isOpen: false } );
+
+		expect( mockContainerProps ).toHaveBeenLastCalledWith( { floatingChatState: 'collapsed' } );
+	} );
+
+	it( 'minimizes to the bar when closed with the WP admin bar trigger present', () => {
+		mockHasAdminBarTrigger.mockReturnValue( true );
+
+		renderAgentChat( { isOpen: false } );
+
+		expect( mockContainerProps ).toHaveBeenLastCalledWith( { floatingChatState: 'minimized' } );
 	} );
 } );

--- a/packages/agents-manager/src/components/__tests__/chat-header.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/chat-header.test.tsx
@@ -7,6 +7,7 @@ import { MemoryRouter } from 'react-router-dom';
 
 let mockIsDocked = false;
 const mockSetIsMinimized = jest.fn();
+const mockHasAdminBarTrigger = jest.fn();
 
 jest.mock( '@wordpress/components', () => ( {
 	Button: ( {
@@ -43,17 +44,11 @@ jest.mock( '@wordpress/data', () => ( {
 } ) );
 jest.mock( '../../stores', () => ( { AGENTS_MANAGER_STORE: 'agents-manager' } ) );
 jest.mock( '../../hooks/use-admin-bar-integration', () => ( {
-	ADMIN_BAR_BUTTON_ID: 'wp-admin-bar-agents-manager',
+	hasAdminBarTrigger: () => mockHasAdminBarTrigger(),
 } ) );
 jest.mock( '../chat-header/style.scss', () => ( {} ) );
 
 import ChatHeader from '../chat-header';
-
-function installAdminBarTrigger() {
-	const el = document.createElement( 'div' );
-	el.id = 'wp-admin-bar-agents-manager';
-	document.body.appendChild( el );
-}
 
 // `isReaderChatHost()` reads the agent ID from this global.
 function installReaderChatHost() {
@@ -71,10 +66,13 @@ function renderChatHeader( title?: string ) {
 }
 
 describe( 'ChatHeader', () => {
+	beforeEach( () => {
+		mockHasAdminBarTrigger.mockReturnValue( false );
+	} );
+
 	afterEach( () => {
 		mockIsDocked = false;
 		mockSetIsMinimized.mockClear();
-		document.getElementById( 'wp-admin-bar-agents-manager' )?.remove();
 		delete ( globalThis as { agentsManagerData?: unknown } ).agentsManagerData;
 	} );
 
@@ -106,7 +104,7 @@ describe( 'ChatHeader', () => {
 	} );
 
 	it( 'minimizes the chat when the Minimize button is clicked', () => {
-		installAdminBarTrigger();
+		mockHasAdminBarTrigger.mockReturnValue( true );
 
 		renderChatHeader();
 		fireEvent.click( screen.getByText( 'Minimize' ) );
@@ -121,7 +119,7 @@ describe( 'ChatHeader', () => {
 	} );
 
 	it( 'hides the Minimize button when docked', () => {
-		installAdminBarTrigger();
+		mockHasAdminBarTrigger.mockReturnValue( true );
 		mockIsDocked = true;
 
 		renderChatHeader();

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -14,6 +14,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useMemo, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
+import { hasAdminBarTrigger } from '../../hooks/use-admin-bar-integration';
 import { AGENTS_MANAGER_STORE } from '../../stores';
 import { isPluginCompassHost } from '../../utils/is-plugin-compass-agent';
 import { isReaderChatHost } from '../../utils/is-reader-chat-agent';
@@ -213,7 +214,8 @@ export default function AgentChat( {
 		[ mergedComponents, markdownExtensions ]
 	);
 
-	let floatingChatState: ChatState = 'minimized';
+	// Without an admin bar trigger, use `collapsed` (a FAB) instead of `minimized`.
+	let floatingChatState: ChatState = hasAdminBarTrigger() ? 'minimized' : 'collapsed';
 	if ( isOpen ) {
 		floatingChatState = 'expanded';
 	} else if ( isCompactMode ) {

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -265,8 +265,8 @@ export default function AgentDock( {
 
 	const chatHeaderOptions = getChatHeaderOptions();
 
-	// The WP admin bar trigger can reopen the chat, so it gates two behaviors:
-	// hide it on close, and minimize it to the bar.
+	// With an admin bar trigger, the chat hides on close and can minimize to the
+	// bar. Without one, it stays mounted and collapses to a button instead.
 	const isChatVisible = isPersistedOpen || ! hasAdminBarTrigger;
 	const isMinimizedActive = hasAdminBarTrigger && isMinimized;
 	const chatIsOpen = isPersistedOpen && ! isMinimizedActive;

--- a/packages/agents-manager/src/components/agent-history/index.tsx
+++ b/packages/agents-manager/src/components/agent-history/index.tsx
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useNavigate } from 'react-router-dom';
 import { useAgentsManagerContext } from '../../contexts';
+import { hasAdminBarTrigger } from '../../hooks/use-admin-bar-integration';
 import { AGENTS_MANAGER_STORE } from '../../stores';
 import { LocalConversationListItem } from '../../types';
 import ChatHeader, { type Options as ChatHeaderOptions } from '../chat-header';
@@ -45,6 +46,9 @@ export default function AgentHistory( {
 	}, [] );
 	const navigate = useNavigate();
 
+	// Without an admin bar trigger, use `collapsed` (a FAB) instead of `minimized`.
+	const closedChatState = hasAdminBarTrigger() ? 'minimized' : 'collapsed';
+
 	const handleBack = () => {
 		navigate( '/chat', { state: { sessionId: getActiveSessionId() } } );
 	};
@@ -59,7 +63,7 @@ export default function AgentHistory( {
 			error={ null }
 			onSubmit={ () => {} }
 			variant={ isDocked ? 'embedded' : 'floating' }
-			floatingChatState={ isOpen ? 'expanded' : 'minimized' }
+			floatingChatState={ isOpen ? 'expanded' : closedChatState }
 			onClose={ onClose }
 			onExpand={ onExpand }
 			onStop={ onAbort }

--- a/packages/agents-manager/src/components/chat-header/index.tsx
+++ b/packages/agents-manager/src/components/chat-header/index.tsx
@@ -1,10 +1,9 @@
 import { Button, DropdownMenu } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { close, lineSolid, moreVertical, backup, chevronLeft, Icon } from '@wordpress/icons';
 import { useNavigate } from 'react-router-dom';
-import { ADMIN_BAR_BUTTON_ID } from '../../hooks/use-admin-bar-integration';
+import { hasAdminBarTrigger } from '../../hooks/use-admin-bar-integration';
 import { AGENTS_MANAGER_STORE } from '../../stores';
 import { isReaderChatHost } from '../../utils/is-reader-chat-agent';
 import type { AgentsManagerSelect } from '@automattic/data-stores';
@@ -27,12 +26,8 @@ export default function ChatHeader( { onClose, options, title, onBack }: Props )
 		( select ) => ( select( AGENTS_MANAGER_STORE ) as AgentsManagerSelect ).getIsDocked(),
 		[]
 	);
-	const [ hasAdminBarTrigger ] = useState(
-		() => !! document.getElementById( ADMIN_BAR_BUTTON_ID )
-	);
-
 	// Minimize only applies to the floating chat reachable from the WP admin bar.
-	const showMinimize = hasAdminBarTrigger && ! isDocked;
+	const showMinimize = hasAdminBarTrigger() && ! isDocked;
 
 	return (
 		<div className="agents-manager-chat-header">

--- a/packages/agents-manager/src/components/support-guide/index.tsx
+++ b/packages/agents-manager/src/components/support-guide/index.tsx
@@ -7,6 +7,7 @@ import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAgentsManagerContext } from '../../contexts';
+import { hasAdminBarTrigger } from '../../hooks/use-admin-bar-integration';
 import { AGENTS_MANAGER_STORE } from '../../stores';
 import ChatHeader, { type Options as ChatHeaderOptions } from '../chat-header';
 import './style.scss';
@@ -43,6 +44,8 @@ export default function SupportGuide( {
 		return store.getAgentsManagerState();
 	}, [] );
 
+	// Without an admin bar trigger, use `collapsed` (a FAB) instead of `minimized`.
+	const closedChatState = hasAdminBarTrigger() ? 'minimized' : 'collapsed';
 	const isFromChat = !! ( state?.sessionId || state?.conversationId );
 
 	// Navigate back to the source route, preserving relevant state.
@@ -66,7 +69,7 @@ export default function SupportGuide( {
 			error={ null }
 			onSubmit={ () => {} }
 			variant={ isDocked ? 'embedded' : 'floating' }
-			floatingChatState={ isOpen ? 'expanded' : 'minimized' }
+			floatingChatState={ isOpen ? 'expanded' : closedChatState }
 			onClose={ onClose }
 			onExpand={ onExpand }
 			onStop={ onAbort }

--- a/packages/agents-manager/src/components/support-guides/index.tsx
+++ b/packages/agents-manager/src/components/support-guides/index.tsx
@@ -13,6 +13,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { Link, useLocation } from 'react-router-dom';
+import { hasAdminBarTrigger } from '../../hooks/use-admin-bar-integration';
 import useHelpSearchQuery from '../../hooks/use-help-search-query';
 import { AGENTS_MANAGER_STORE } from '../../stores';
 import ChatHeader, { type Options as ChatHeaderOptions } from '../chat-header';
@@ -125,6 +126,9 @@ export default function SupportGuides( {
 		return store.getAgentsManagerState();
 	}, [] );
 
+	// Without an admin bar trigger, use `collapsed` (a FAB) instead of `minimized`.
+	const closedChatState = hasAdminBarTrigger() ? 'minimized' : 'collapsed';
+
 	return (
 		<AgentUI.Container
 			initialChatPosition={ floatingPosition }
@@ -135,7 +139,7 @@ export default function SupportGuides( {
 			error={ null }
 			onSubmit={ () => {} }
 			variant={ isDocked ? 'embedded' : 'floating' }
-			floatingChatState={ isOpen ? 'expanded' : 'minimized' }
+			floatingChatState={ isOpen ? 'expanded' : closedChatState }
 			onClose={ onClose }
 			onExpand={ onExpand }
 			onStop={ onAbort }

--- a/packages/agents-manager/src/hooks/use-admin-bar-integration/index.tsx
+++ b/packages/agents-manager/src/hooks/use-admin-bar-integration/index.tsx
@@ -1,9 +1,9 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { useEffect, useRef, useState } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 import './style.scss';
 
 // Admin bar element selectors
-export const ADMIN_BAR_BUTTON_ID = 'wp-admin-bar-agents-manager';
+const ADMIN_BAR_BUTTON_ID = 'wp-admin-bar-agents-manager';
 const ADMIN_BAR_CHAT_ITEM_ID = 'wp-admin-bar-agents-manager-chat-support';
 const ADMIN_BAR_HISTORY_ITEM_ID = 'wp-admin-bar-agents-manager-chat-history';
 const ADMIN_BAR_GUIDES_ITEM_ID = 'wp-admin-bar-agents-manager-support-guides';
@@ -22,6 +22,13 @@ interface UseAdminBarIntegrationOptions {
 	sectionName: string;
 	maybeOpenChat: () => void;
 	navigate: ( route: string, options?: { state?: object } ) => void;
+}
+
+/**
+ * Whether the WP admin bar trigger button is on the page.
+ */
+export function hasAdminBarTrigger(): boolean {
+	return !! document.getElementById( ADMIN_BAR_BUTTON_ID );
 }
 
 /**
@@ -46,7 +53,7 @@ export default function useAdminBarIntegration( {
 	maybeOpenChatRef.current = maybeOpenChat;
 
 	// Whether the WP admin bar trigger button is on the page.
-	const [ hasButton ] = useState( () => !! document.getElementById( ADMIN_BAR_BUTTON_ID ) );
+	const hasButton = hasAdminBarTrigger();
 
 	// Update admin bar button active state based on isOpen
 	useEffect( () => {


### PR DESCRIPTION
Part of AI-1001

## Proposed Changes

* On pages **without** the WP admin bar trigger, the chat now collapses to a floating action button (the `collapsed` chat state) instead of minimizing to a bar (`minimized`). This applies across all routes (chat, Zendesk, history, support guide, and support guides).
* Added a small, pure `hasAdminBarTrigger()` predicate in `use-admin-bar-integration`; each route picks `collapsed` vs `minimized` for the closed `floatingChatState` based on it. Pages **with** the admin bar trigger are unchanged (still `minimized`).
* `chat-header` and the admin bar hook now share the `hasAdminBarTrigger()` predicate.
* Added unit coverage for the new behavior and refactored the affected tests to control the trigger via a Jest mock.

## Why are these changes being made?

<!-- -->
On pages without the WP admin bar trigger there is no button to reopen the chat once it is closed, so minimizing it to a bar leaves no clear way back. Collapsing to a floating action button provides a persistent, obvious re-entry point in those contexts, while admin-bar pages keep their existing minimize-to-bar behavior.

## Testing Instructions

* Sandbox this PR, and go to `https://<YOUR_SITE>/wp-admin/site-editor.php?p=%2F&canvas=edit`
* Now the closing state of the undocked chat will be the FAB:

https://github.com/user-attachments/assets/1fd5a995-cd66-42db-93c3-36c54f88b542

* Go to `https://<YOUR_SITE>/wp-admin/`, and the minimized state still work the same

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
