### PR TITLE
Image Studio: scope Feature Clip sidebar panel to the post post type

### DIFF
--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
@@ -29,7 +29,7 @@ const mockCreateBlock = jest.fn( ( name: string, attributes: Record< string, unk
 	attributes,
 } ) );
 
-let mockPostType = 'post';
+let mockPostType: string | null = 'post';
 let mockMeta: Record< string, unknown > = {};
 let mockMedia: Record< string, unknown > | null = null;
 let mockHasResolvedMedia = true;
@@ -311,6 +311,19 @@ describe( 'feature-clip-sidebar-extension', () => {
 			mockPostType = 'jetpack_form';
 			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
 			render( <FeatureClipPanel /> );
+			expect( mockTrackPanelViewed ).not.toHaveBeenCalled();
+		} );
+
+		it( 'renders nothing while the post type is unknown (null) and does not fall back to post', () => {
+			// getCurrentPostType() returns null transiently before the post
+			// loads (and the editor store may be absent entirely). Treat that
+			// as unsupported — a 'post' fallback would flash the panel and fire
+			// a phantom impression until the real type resolves.
+			mockPostType = null;
+			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			const { container } = render( <FeatureClipPanel /> );
+			expect( container ).toBeEmptyDOMElement();
+			expect( mockFill ).not.toHaveBeenCalled();
 			expect( mockTrackPanelViewed ).not.toHaveBeenCalled();
 		} );
 

--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
@@ -2,6 +2,12 @@
  * @jest-environment jsdom
  */
 
+/* eslint-disable @typescript-eslint/no-require-imports --
+   Every test re-`require()`s the module after `jest.resetModules()` (see
+   `beforeEach`) so module-level state — the `pluginRegistered` idempotency
+   flag, and the React instance `mockUseEffect` binds to — is fresh per test.
+   Static `import` would defeat that isolation, so `require()` is intentional. */
+
 // eslint-disable-next-line import/order
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
@@ -23,6 +29,7 @@ const mockCreateBlock = jest.fn( ( name: string, attributes: Record< string, unk
 	attributes,
 } ) );
 
+let mockPostType = 'post';
 let mockMeta: Record< string, unknown > = {};
 let mockMedia: Record< string, unknown > | null = null;
 let mockHasResolvedMedia = true;
@@ -93,7 +100,7 @@ jest.mock( '@wordpress/data', () => ( {
 	useSelect: ( selector: ( s: ( name: string ) => unknown ) => unknown ) => {
 		return selector( ( name: string ) => {
 			if ( name === 'core/editor' ) {
-				return { getCurrentPostType: () => 'post', getCurrentPostId: () => 7 };
+				return { getCurrentPostType: () => mockPostType, getCurrentPostId: () => 7 };
 			}
 			if ( name === 'core' ) {
 				return {
@@ -215,6 +222,7 @@ describe( 'feature-clip-sidebar-extension', () => {
 		mockDialogProps.mockClear();
 		mockInsertBlocks.mockClear();
 		mockCreateBlock.mockClear();
+		mockPostType = 'post';
 		mockMeta = {};
 		mockMedia = null;
 		mockHasResolvedMedia = true;
@@ -286,6 +294,38 @@ describe( 'feature-clip-sidebar-extension', () => {
 			// Both wrappers share one FeatureClipPanel mount, so the
 			// impression must not double-count.
 			expect( mockTrackPanelViewed ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
+	describe( 'post-type gating', () => {
+		it( 'renders nothing on an unsupported post type (jetpack_form)', () => {
+			mockPostType = 'jetpack_form';
+			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			const { container } = render( <FeatureClipPanel /> );
+			expect( container ).toBeEmptyDOMElement();
+			// Neither sidebar surface is wired up on an unsupported editor.
+			expect( mockFill ).not.toHaveBeenCalled();
+		} );
+
+		it( 'does not fire the panel-viewed impression on an unsupported post type', () => {
+			mockPostType = 'jetpack_form';
+			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			render( <FeatureClipPanel /> );
+			expect( mockTrackPanelViewed ).not.toHaveBeenCalled();
+		} );
+
+		it( 'renders nothing on a page (pages are unsupported for now)', () => {
+			mockPostType = 'page';
+			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			const { container } = render( <FeatureClipPanel /> );
+			expect( container ).toBeEmptyDOMElement();
+		} );
+
+		it( 'renders the panel on the post post type', () => {
+			mockPostType = 'post';
+			const { FeatureClipPanel } = require( './feature-clip-sidebar-extension' );
+			render( <FeatureClipPanel /> );
+			expect( screen.getByRole( 'button', { name: 'Generate clip' } ) ).toBeInTheDocument();
 		} );
 	} );
 

--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
@@ -196,7 +196,20 @@ function FeatureClipEmptyState(): JSX.Element {
 	);
 }
 
-function FeatureClipPanel(): JSX.Element {
+/**
+ * Post types the Feature Clip panel is offered on. Mirrors the backend, which
+ * registers the `_jetpack_feature_clip_id` meta for `post` only (see Jetpack's
+ * `register_feature_clip_post_meta` in image-studio.php — "pages can be added
+ * later"). The plugin is registered globally, so its render runs in EVERY
+ * block editor, including the standalone Jetpack Form editor
+ * (`post_type=jetpack_form`), where turning the post into a video makes no
+ * sense and the meta isn't even registered. The post-type gate lives in the
+ * panel render rather than at registration because registration happens once,
+ * up front, before the editor's current post type is known.
+ */
+const SUPPORTED_POST_TYPES = [ 'post' ];
+
+function FeatureClipPanel(): JSX.Element | null {
 	const { postType, postId } = useSelect( ( select ) => {
 		const editor = select( 'core/editor' ) as
 			| {
@@ -210,6 +223,22 @@ function FeatureClipPanel(): JSX.Element {
 		};
 	}, [] );
 
+	// Bail on unsupported post types before any of the body's hooks run, so the
+	// panel never mounts — and never fires a phantom panel-viewed impression —
+	// on editors like the Jetpack Form editor.
+	if ( ! SUPPORTED_POST_TYPES.includes( postType ) ) {
+		return null;
+	}
+
+	return <FeatureClipPanelBody postType={ postType } postId={ postId } />;
+}
+
+interface FeatureClipPanelBodyProps {
+	postType: string;
+	postId: number | null;
+}
+
+function FeatureClipPanelBody( { postType, postId }: FeatureClipPanelBodyProps ): JSX.Element {
 	// Pass the post ID explicitly. Without it `useEntityProp` falls back to
 	// EntityProvider context, which isn't set up for sidebar surfaces in every
 	// editor — meta would silently come back undefined and the panel would

--- a/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
+++ b/packages/image-studio/src/extensions/feature-clip-sidebar-extension.tsx
@@ -218,15 +218,20 @@ function FeatureClipPanel(): JSX.Element | null {
 			  }
 			| undefined;
 		return {
-			postType: editor?.getCurrentPostType?.() ?? 'post',
+			// Leave this null when the editor store is absent or the post type
+			// hasn't loaded yet — do NOT fall back to 'post'. A 'post' fallback
+			// would pass the gate below for an unknown type and flash the panel
+			// (plus fire a phantom impression) until the real type resolves.
+			postType: editor?.getCurrentPostType?.() ?? null,
 			postId: editor?.getCurrentPostId?.() ?? null,
 		};
 	}, [] );
 
-	// Bail on unsupported post types before any of the body's hooks run, so the
-	// panel never mounts — and never fires a phantom panel-viewed impression —
-	// on editors like the Jetpack Form editor.
-	if ( ! SUPPORTED_POST_TYPES.includes( postType ) ) {
+	// Bail until the post type is both known and supported, before any of the
+	// body's hooks run — so the panel never mounts (and never fires a phantom
+	// panel-viewed impression) on editors like the Jetpack Form editor, nor in
+	// the transient window before the current post type is available.
+	if ( ! postType || ! SUPPORTED_POST_TYPES.includes( postType ) ) {
 		return null;
 	}
 


### PR DESCRIPTION
Part of the Clips: AI Video Generation project (RSM). No dedicated issue — surfaced while triaging Feature Clip behavior on the standalone Jetpack Form editor.

## Proposed Changes

* Scope the "Feature Clip" post-editor sidebar panel to the `post` post type. Previously the panel rendered in **every** block editor, including the standalone Jetpack Form editor (`post_type=jetpack_form`).
* Add a `SUPPORTED_POST_TYPES` allow-list (currently `[ 'post' ]`) and bail (`return null`) from `FeatureClipPanel` before any body hooks run, so the panel never mounts — and never fires a phantom `panel-viewed` impression — on unsupported editors.
* Split the component into a thin `FeatureClipPanel` gate + `FeatureClipPanelBody` renderer so the heavier hooks (`useEntityProp`, `getMedia`, impression tracking) only run on supported post types.
* Add post-type gating tests.

## Why are these changes being made?

The Feature Clip panel is registered as a **global** Gutenberg plugin (`registerPlugin`), and its render emitted the document/Jetpack sidebar panels unconditionally. The only existing gate is `window.imageStudioData.canGenerateVideoClips`, which is a **site/plan** capability flag, not a post-type gate.

Meanwhile the backend registers the `_jetpack_feature_clip_id` post meta for `post` only (`register_feature_clip_post_meta` in Jetpack's `image-studio.php` — *"pages can be added later"*). So on `post_type=jetpack_form` the panel showed its "Turn this post into a short vertical video" CTA in an editor where the feature can't do anything and the meta isn't even registered. This change aligns the frontend's visible scope with the backend's supported scope.

## Testing Instructions

1. On a site where Feature Clip is enabled (`canGenerateVideoClips: true`), open the standard post editor (`post-new.php` / `post_type=post`) → the **Feature Clip** panel appears in the document sidebar (and Jetpack sidebar) as before.
2. Open the standalone Jetpack Form editor (`post-new.php?post_type=jetpack_form`) → the **Feature Clip** panel is **no longer present**.
3. Open a Page editor (`post_type=page`) → panel is **not** present (pages are unsupported for now; can be added later alongside the backend).
4. Confirm no `…feature_clip_panel_viewed` Tracks impression fires on the form/page editors.

Unit tests:
```
yarn test-packages packages/image-studio/src/extensions/feature-clip-sidebar-extension.test.tsx
```

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? (No new strings.)
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
