### PR TITLE
Account Recovery: add logged-out password-reset data layer

### DIFF
--- a/client/blocks/login/lost-password/test/use-account-recovery-reset.ts
+++ b/client/blocks/login/lost-password/test/use-account-recovery-reset.ts
@@ -1,0 +1,185 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import wp from 'calypso/lib/wp';
+import {
+	lookup,
+	requestReset,
+	validate,
+	reset,
+	useAccountRecoveryReset,
+} from '../use-account-recovery-reset';
+
+jest.mock( 'calypso/lib/wp', () => ( {
+	__esModule: true,
+	default: { req: { get: jest.fn(), post: jest.fn() } },
+} ) );
+
+const mockedGet = wp.req.get as jest.Mock;
+const mockedPost = wp.req.post as jest.Mock;
+
+const userData = { user: 'someone@example.com' };
+
+beforeEach( () => {
+	jest.clearAllMocks();
+} );
+
+describe( 'lookup', () => {
+	it( 'requests the lookup endpoint with the user data as the query', async () => {
+		mockedGet.mockResolvedValue( {} );
+
+		await lookup( userData );
+
+		expect( mockedGet ).toHaveBeenCalledWith(
+			{ path: '/account-recovery/lookup', apiNamespace: 'wpcom/v2' },
+			userData
+		);
+	} );
+
+	it( 'returns only configured methods, dropping empty/whitespace-only hints', async () => {
+		mockedGet.mockResolvedValue( {
+			primary_email: 'j****e@gmail.com',
+			secondary_email: '',
+			primary_sms: '   ',
+			secondary_sms: '+44*******21',
+		} );
+
+		await expect( lookup( userData ) ).resolves.toEqual( {
+			primary_email: 'j****e@gmail.com',
+			secondary_sms: '+44*******21',
+		} );
+	} );
+
+	it( 'returns an empty object when nothing is configured', async () => {
+		mockedGet.mockResolvedValue( {
+			primary_email: '',
+			secondary_email: '',
+			primary_sms: '',
+			secondary_sms: '',
+		} );
+
+		await expect( lookup( userData ) ).resolves.toEqual( {} );
+	} );
+
+	it( 'tolerates missing keys in the response', async () => {
+		mockedGet.mockResolvedValue( { primary_email: 'j****e@gmail.com' } );
+
+		await expect( lookup( userData ) ).resolves.toEqual( {
+			primary_email: 'j****e@gmail.com',
+		} );
+	} );
+
+	it( 'propagates API errors', async () => {
+		const error = new Error( 'lookup failed' );
+		mockedGet.mockRejectedValue( error );
+
+		await expect( lookup( userData ) ).rejects.toBe( error );
+	} );
+} );
+
+describe( 'requestReset', () => {
+	it( 'posts the method and user data', async () => {
+		mockedPost.mockResolvedValue( true );
+
+		await requestReset( { userData, method: 'secondary_sms' } );
+
+		expect( mockedPost ).toHaveBeenCalledWith(
+			{ path: '/account-recovery/request-reset', apiNamespace: 'wpcom/v2' },
+			{},
+			{ user: 'someone@example.com', method: 'secondary_sms' }
+		);
+	} );
+
+	it( 'includes the TOTP app-code for the authenticator method', async () => {
+		mockedPost.mockResolvedValue( true );
+
+		await requestReset( { userData, method: 'authenticator_app', appCode: '123456' } );
+
+		expect( mockedPost ).toHaveBeenCalledWith(
+			{ path: '/account-recovery/request-reset', apiNamespace: 'wpcom/v2' },
+			{},
+			{ user: 'someone@example.com', method: 'authenticator_app', 'app-code': '123456' }
+		);
+	} );
+
+	it( 'omits app-code for non-authenticator methods even if one is passed', async () => {
+		mockedPost.mockResolvedValue( true );
+
+		await requestReset( { userData, method: 'primary_email', appCode: '123456' } );
+
+		expect( mockedPost ).toHaveBeenCalledWith(
+			{ path: '/account-recovery/request-reset', apiNamespace: 'wpcom/v2' },
+			{},
+			{ user: 'someone@example.com', method: 'primary_email' }
+		);
+	} );
+
+	it( 'supports the firstname/lastname/url identity', async () => {
+		mockedPost.mockResolvedValue( true );
+		const altIdentity = { firstname: 'Jane', lastname: 'Doe', url: 'jane.example.com' };
+
+		await requestReset( { userData: altIdentity, method: 'secondary_email' } );
+
+		expect( mockedPost ).toHaveBeenCalledWith(
+			{ path: '/account-recovery/request-reset', apiNamespace: 'wpcom/v2' },
+			{},
+			{ ...altIdentity, method: 'secondary_email' }
+		);
+	} );
+} );
+
+describe( 'validate', () => {
+	it( 'posts the method and key', async () => {
+		mockedPost.mockResolvedValue( true );
+
+		await validate( { userData, method: 'secondary_sms', key: '12345678' } );
+
+		expect( mockedPost ).toHaveBeenCalledWith(
+			{ path: '/account-recovery/validate', apiNamespace: 'wpcom/v2' },
+			{},
+			{ user: 'someone@example.com', method: 'secondary_sms', key: '12345678' }
+		);
+	} );
+} );
+
+describe( 'reset', () => {
+	it( 'posts the method, key and new password', async () => {
+		mockedPost.mockResolvedValue( 12345 );
+
+		await reset( {
+			userData,
+			method: 'secondary_sms',
+			key: '12345678',
+			password: 'a-strong-password',
+		} );
+
+		expect( mockedPost ).toHaveBeenCalledWith(
+			{ path: '/account-recovery/reset', apiNamespace: 'wpcom/v2' },
+			{},
+			{
+				user: 'someone@example.com',
+				method: 'secondary_sms',
+				key: '12345678',
+				password: 'a-strong-password',
+			}
+		);
+	} );
+} );
+
+describe( 'useAccountRecoveryReset', () => {
+	it( 'returns stable references to the four calls', () => {
+		const { result, rerender } = renderHook( () => useAccountRecoveryReset() );
+		const first = result.current;
+
+		expect( Object.keys( first ).sort() ).toEqual( [
+			'lookup',
+			'requestReset',
+			'reset',
+			'validate',
+		] );
+
+		rerender();
+		expect( result.current ).toBe( first );
+	} );
+} );

--- a/client/blocks/login/lost-password/use-account-recovery-reset.ts
+++ b/client/blocks/login/lost-password/use-account-recovery-reset.ts
@@ -1,0 +1,147 @@
+/**
+ * Data layer for the logged-out account-recovery password reset flow.
+ *
+ * Wraps the public `wpcom/v2/account-recovery/*` REST endpoints
+ * (`lookup` → `request-reset` → `validate` → `reset`) as plain
+ * promise-returning functions. By design this uses direct `wp.req` calls with
+ * no Redux: the flow is logged-out and ephemeral, so the calling components own
+ * their loading/error/step state. See `plan-phase2.md` §3 (decided 2026-06-09).
+ */
+
+import { useMemo } from 'react';
+import wp from 'calypso/lib/wp';
+
+const API_NAMESPACE = 'wpcom/v2';
+
+/**
+ * Identifies the locked-out user. Provide EITHER `user` (login or email) OR the
+ * firstname/lastname/url triple — never both, or the API responds with a 400.
+ */
+export type AccountRecoveryUserData =
+	| { user: string }
+	| { firstname: string; lastname: string; url: string };
+
+/** Verification methods accepted by `request-reset` / `validate` / `reset`. */
+export type AccountRecoveryMethod =
+	| 'primary_email'
+	| 'secondary_email'
+	| 'primary_sms'
+	| 'secondary_sms'
+	| 'authenticator_app'
+	| 'transactionid'
+	| 'activation_key';
+
+/** The subset of methods `lookup` can report an obscured hint for. */
+export type AccountRecoveryLookupMethod =
+	| 'primary_email'
+	| 'secondary_email'
+	| 'primary_sms'
+	| 'secondary_sms';
+
+/**
+ * Configured methods for the resolved user, keyed by method and valued by the
+ * backend's obscured hint (e.g. `j****e@gmail.com`). Only methods that are
+ * actually configured are present; unconfigured ones are omitted.
+ */
+export type AccountRecoveryAvailableMethods = Partial<
+	Record< AccountRecoveryLookupMethod, string >
+>;
+
+interface RequestResetArgs {
+	userData: AccountRecoveryUserData;
+	method: AccountRecoveryMethod;
+	/** The current TOTP code; required (and verified inline) for `authenticator_app`. */
+	appCode?: string;
+}
+
+interface ValidateArgs {
+	userData: AccountRecoveryUserData;
+	method: AccountRecoveryMethod;
+	/** The code received via SMS/email. */
+	key: string;
+}
+
+interface ResetArgs extends ValidateArgs {
+	password: string;
+}
+
+const LOOKUP_METHODS: AccountRecoveryLookupMethod[] = [
+	'primary_email',
+	'secondary_email',
+	'primary_sms',
+	'secondary_sms',
+];
+
+/** The endpoint returns obscured hints; treat empty/whitespace-only as "not configured". */
+function hasHint( value: unknown ): value is string {
+	return typeof value === 'string' && value.trim().length > 0;
+}
+
+/**
+ * GET the methods available to the resolved user, filtered to those actually
+ * configured. The endpoint currently returns keys even for unset methods
+ * (an obscured empty string) and does not yet filter to validated methods —
+ * both are being tightened backend-side, so we drop empty hints here too.
+ */
+export async function lookup(
+	userData: AccountRecoveryUserData
+): Promise< AccountRecoveryAvailableMethods > {
+	const response = ( await wp.req.get(
+		{ path: '/account-recovery/lookup', apiNamespace: API_NAMESPACE },
+		userData
+	) ) as Partial< Record< AccountRecoveryLookupMethod, string > >;
+
+	return LOOKUP_METHODS.reduce< AccountRecoveryAvailableMethods >( ( available, method ) => {
+		const hint = response?.[ method ];
+		if ( hasHint( hint ) ) {
+			available[ method ] = hint;
+		}
+		return available;
+	}, {} );
+}
+
+/**
+ * POST to send a reset code/link via the chosen method. For `authenticator_app`
+ * the TOTP `appCode` is verified inline, so this call IS the verification step.
+ */
+export async function requestReset( {
+	userData,
+	method,
+	appCode,
+}: RequestResetArgs ): Promise< void > {
+	const body: Record< string, unknown > = { ...userData, method };
+	if ( method === 'authenticator_app' && appCode !== undefined ) {
+		body[ 'app-code' ] = appCode;
+	}
+	await wp.req.post(
+		{ path: '/account-recovery/request-reset', apiNamespace: API_NAMESPACE },
+		{},
+		body
+	);
+}
+
+/** POST to check a code before showing the set-new-password screen. */
+export async function validate( { userData, method, key }: ValidateArgs ): Promise< void > {
+	await wp.req.post(
+		{ path: '/account-recovery/validate', apiNamespace: API_NAMESPACE },
+		{},
+		{ ...userData, method, key }
+	);
+}
+
+/** POST to set the new password (the backend re-validates the key). */
+export async function reset( { userData, method, key, password }: ResetArgs ): Promise< void > {
+	await wp.req.post(
+		{ path: '/account-recovery/reset', apiNamespace: API_NAMESPACE },
+		{},
+		{ ...userData, method, key, password }
+	);
+}
+
+/**
+ * Exposes the four account-recovery reset calls as a stable object. Stateless
+ * by design (no Redux); callers manage their own loading/error/step state.
+ */
+export function useAccountRecoveryReset() {
+	return useMemo( () => ( { lookup, requestReset, validate, reset } ), [] );
+}


### PR DESCRIPTION
Part of DOTOBRD-377

## Proposed Changes

* Add `useAccountRecoveryReset` (`client/blocks/login/lost-password/use-account-recovery-reset.ts`) — a small, Redux-free data layer wrapping the public `wpcom/v2/account-recovery/*` REST endpoints for the redesigned logged-out Lost Password flow: `lookup → request-reset → validate → reset`.
* `lookup` filters out unconfigured methods (the endpoint currently returns obscured empty strings for unset methods), returning only methods with a real hint.
* `request-reset` includes the TOTP `app-code` for the `authenticator_app` method (verified inline by the backend).
* Typed user-identity union (`{ user }` _xor_ `{ firstname, lastname, url }`) and method enum.
* Unit tests covering endpoint shapes, hint filtering, app-code in/exclusion, the alternate identity, error propagation, and hook stability.

This is the first PR of Account Recovery Phase 2 and is **inert** — nothing imports it yet, so it is safe to land ahead of the UI work.

## Why are these changes being made?

Users can save a recovery email and phone, but the logged-out "Lost your password?" flow ignores them — and ~60% of reset failures are users locked out of their original email. Phase 2 lets a locked-out user verify identity with a method they already configured (recovery email, recovery phone, or 2FA code). This PR lands the data layer; the redesigned method-picker UI and the emailed-reset-link landing route follow in separate PRs.

## Testing Instructions

* `yarn test-client client/blocks/login/lost-password/test/use-account-recovery-reset.ts` — 12 tests should pass.
* Not wired to any UI yet, so there is nothing to exercise in the browser.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
