### PR TITLE
Gate Jetpack AI Sidebar to simple sites

### DIFF
--- a/packages/agents-manager/src/components/__tests__/agents-manager.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agents-manager.test.tsx
@@ -49,6 +49,13 @@ jest.mock( '../persistent-router', () => ( { PersistentRouter: () => null } ) );
 import AgentsManager from '../agents-manager';
 
 describe( 'AgentsManager', () => {
+	afterEach( () => {
+		capturedProps = null;
+		delete ( globalThis as typeof globalThis & { agentsManagerData?: unknown } ).agentsManagerData;
+		delete ( globalThis as typeof globalThis & { _currentSiteType?: unknown } )._currentSiteType;
+		delete ( window as typeof window & { _currentSiteType?: unknown } )._currentSiteType;
+	} );
+
 	it( 'forwards props to the context provider', () => {
 		const mockUser = {
 			ID: 789,
@@ -75,6 +82,51 @@ describe( 'AgentsManager', () => {
 				currentUser: mockUser,
 				site: mockSite,
 				currentRoute: '/sites/fulltest.com',
+				siteKey: '999',
+			} )
+		);
+	} );
+
+	it( 'does not render the post-editor Jetpack AI Sidebar-only surface', () => {
+		( globalThis as typeof globalThis & { _currentSiteType?: unknown } )._currentSiteType =
+			'atomic';
+		( globalThis as typeof globalThis & { agentsManagerData?: unknown } ).agentsManagerData = {
+			sectionName: 'gutenberg',
+			agentProviders: [ 'https://widgets.wp.com/agents-manager/jetpack-ai-sidebar.provider.mjs' ],
+			jetpackAiSidebarPreview: { enabled: true },
+		};
+
+		render(
+			<AgentsManager
+				sectionName="gutenberg"
+				site={ { ID: 999, domain: 'non-simple.example.com' } }
+				currentSiteId={ 999 }
+			/>
+		);
+
+		expect( capturedProps ).toBeNull();
+	} );
+
+	it( 'renders other post-editor providers when Jetpack AI Sidebar is gated', () => {
+		const mockSite = { ID: 999, domain: 'non-simple.example.com' };
+
+		( globalThis as typeof globalThis & { _currentSiteType?: unknown } )._currentSiteType =
+			'atomic';
+		( globalThis as typeof globalThis & { agentsManagerData?: unknown } ).agentsManagerData = {
+			sectionName: 'gutenberg',
+			agentProviders: [
+				'https://example.com/wp-content/plugins/big-sky/build/calypso-agent-provider/index.js',
+				'https://widgets.wp.com/agents-manager/jetpack-ai-sidebar.provider.mjs',
+			],
+			jetpackAiSidebarPreview: { enabled: true },
+		};
+
+		render( <AgentsManager sectionName="gutenberg" site={ mockSite } currentSiteId={ 999 } /> );
+
+		expect( capturedProps ).toEqual(
+			expect.objectContaining( {
+				sectionName: 'gutenberg',
+				site: mockSite,
 				siteKey: '999',
 			} )
 		);

--- a/packages/agents-manager/src/components/agents-manager.tsx
+++ b/packages/agents-manager/src/components/agents-manager.tsx
@@ -14,6 +14,7 @@ import { useEmptyViewSuggestions } from '../hooks/use-empty-view-suggestions';
 import { AGENTS_MANAGER_STORE } from '../stores';
 import { clearSessionId, getOrCreateSessionId } from '../utils/agent-session';
 import { createAgentConfig } from '../utils/create-agent-config';
+import { shouldSuppressAgentsManagerWhenJetpackAiSidebarGated } from '../utils/gate-jetpack-ai-sidebar-to-simple-sites';
 import { isReaderChatAgent } from '../utils/is-reader-chat-agent';
 import {
 	loadExternalProviders,
@@ -61,6 +62,10 @@ export default function AgentsManager( {
 	}, [] );
 
 	if ( ! isStoreReady ) {
+		return null;
+	}
+
+	if ( shouldSuppressAgentsManagerWhenJetpackAiSidebarGated() ) {
 		return null;
 	}
 

--- a/packages/agents-manager/src/utils/__tests__/gate-jetpack-ai-sidebar-to-simple-sites.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/gate-jetpack-ai-sidebar-to-simple-sites.test.ts
@@ -1,0 +1,110 @@
+import {
+	getAgentProvidersWithJetpackAiSidebarGated,
+	shouldSuppressAgentsManagerWhenJetpackAiSidebarGated,
+} from '../gate-jetpack-ai-sidebar-to-simple-sites';
+
+const JETPACK_PROVIDER = 'https://widgets.wp.com/agents-manager/jetpack-ai-sidebar.provider.mjs';
+const BIG_SKY_PROVIDER =
+	'https://example.com/wp-content/plugins/big-sky/build/calypso-agent-provider/index.js';
+
+const setAgentsManagerData = ( data: unknown ) => {
+	( globalThis as typeof globalThis & { agentsManagerData?: unknown } ).agentsManagerData = data;
+};
+
+const setJetpackScriptData = ( data: unknown ) => {
+	( globalThis as typeof globalThis & { JetpackScriptData?: unknown } ).JetpackScriptData = data;
+};
+
+const setCurrentSiteType = ( siteType: unknown ) => {
+	( globalThis as typeof globalThis & { _currentSiteType?: unknown } )._currentSiteType = siteType;
+};
+
+describe( 'Jetpack AI Sidebar Simple-site gate', () => {
+	afterEach( () => {
+		delete ( globalThis as typeof globalThis & { agentsManagerData?: unknown } ).agentsManagerData;
+		delete ( globalThis as typeof globalThis & { JetpackScriptData?: unknown } ).JetpackScriptData;
+		delete ( globalThis as typeof globalThis & { _currentSiteType?: unknown } )._currentSiteType;
+	} );
+
+	it( 'keeps the Jetpack AI Sidebar provider on WordPress.com Simple sites from editor site type', () => {
+		setCurrentSiteType( 'simple' );
+		setAgentsManagerData( {
+			sectionName: 'gutenberg',
+			agentProviders: [ JETPACK_PROVIDER ],
+			jetpackAiSidebarPreview: { enabled: true },
+		} );
+
+		expect( getAgentProvidersWithJetpackAiSidebarGated() ).toEqual( [ JETPACK_PROVIDER ] );
+		expect( shouldSuppressAgentsManagerWhenJetpackAiSidebarGated() ).toBe( false );
+	} );
+
+	it( 'keeps the Jetpack AI Sidebar provider on WordPress.com Simple sites from Jetpack script data', () => {
+		setJetpackScriptData( { site: { host: 'wpcom' } } );
+		setAgentsManagerData( {
+			sectionName: 'gutenberg',
+			agentProviders: [ JETPACK_PROVIDER ],
+			jetpackAiSidebarPreview: { enabled: true },
+		} );
+
+		expect( getAgentProvidersWithJetpackAiSidebarGated() ).toEqual( [ JETPACK_PROVIDER ] );
+		expect( shouldSuppressAgentsManagerWhenJetpackAiSidebarGated() ).toBe( false );
+	} );
+
+	it( 'removes only the Jetpack AI Sidebar provider on WordPress.com Atomic sites', () => {
+		setCurrentSiteType( 'atomic' );
+		setAgentsManagerData( {
+			sectionName: 'gutenberg',
+			agentProviders: [ BIG_SKY_PROVIDER, JETPACK_PROVIDER ],
+			jetpackAiSidebarPreview: { enabled: true },
+		} );
+
+		expect( getAgentProvidersWithJetpackAiSidebarGated() ).toEqual( [ BIG_SKY_PROVIDER ] );
+		expect( shouldSuppressAgentsManagerWhenJetpackAiSidebarGated() ).toBe( false );
+	} );
+
+	it( 'removes the Jetpack AI Sidebar provider on self-hosted Jetpack sites', () => {
+		setJetpackScriptData( { site: { host: 'unknown' } } );
+		setAgentsManagerData( {
+			sectionName: 'gutenberg',
+			agentProviders: [ JETPACK_PROVIDER ],
+			jetpackAiSidebarPreview: { enabled: true },
+		} );
+
+		expect( getAgentProvidersWithJetpackAiSidebarGated() ).toEqual( [] );
+		expect( shouldSuppressAgentsManagerWhenJetpackAiSidebarGated() ).toBe( true );
+	} );
+
+	it( 'suppresses Agents Manager when Jetpack AI Sidebar is the only non-Simple post-editor provider', () => {
+		setCurrentSiteType( 'atomic' );
+		setAgentsManagerData( {
+			sectionName: 'gutenberg',
+			agentProviders: [ JETPACK_PROVIDER ],
+			jetpackAiSidebarPreview: { enabled: true },
+		} );
+
+		expect( shouldSuppressAgentsManagerWhenJetpackAiSidebarGated() ).toBe( true );
+	} );
+
+	it( 'does not remove the Jetpack AI Sidebar provider outside the post editor', () => {
+		setCurrentSiteType( 'atomic' );
+		setAgentsManagerData( {
+			sectionName: 'wp-admin',
+			agentProviders: [ JETPACK_PROVIDER ],
+			jetpackAiSidebarPreview: { enabled: true },
+		} );
+
+		expect( getAgentProvidersWithJetpackAiSidebarGated() ).toEqual( [ JETPACK_PROVIDER ] );
+		expect( shouldSuppressAgentsManagerWhenJetpackAiSidebarGated() ).toBe( false );
+	} );
+
+	it( 'does not suppress unrelated post-editor providers', () => {
+		setCurrentSiteType( 'atomic' );
+		setAgentsManagerData( {
+			sectionName: 'gutenberg',
+			agentProviders: [ BIG_SKY_PROVIDER ],
+		} );
+
+		expect( getAgentProvidersWithJetpackAiSidebarGated() ).toEqual( [ BIG_SKY_PROVIDER ] );
+		expect( shouldSuppressAgentsManagerWhenJetpackAiSidebarGated() ).toBe( false );
+	} );
+} );

--- a/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
@@ -72,6 +72,8 @@ describe( 'loadExternalProviders', () => {
 	afterEach( () => {
 		delete ( globalThis as typeof globalThis & { agentsManagerData?: unknown } ).agentsManagerData;
 		delete ( window as typeof window & { agentsManagerData?: unknown } ).agentsManagerData;
+		delete ( globalThis as typeof globalThis & { _currentSiteType?: unknown } )._currentSiteType;
+		delete ( window as typeof window & { _currentSiteType?: unknown } )._currentSiteType;
 	} );
 
 	it( 'does not merge external editor providers into Reader Chat', async () => {
@@ -89,6 +91,49 @@ describe( 'loadExternalProviders', () => {
 		expect( providers.toolProvider ).toBeUndefined();
 		expect( providers.contextProvider ).toBeUndefined();
 		expect( providers.useSuggestions ).toEqual( expect.any( Function ) );
+	} );
+
+	it( 'filters the Jetpack AI Sidebar provider from post-editor providers', async () => {
+		( globalThis as typeof globalThis & { _currentSiteType?: unknown } )._currentSiteType =
+			'atomic';
+		const toolProvider = {
+			getAbilities: jest.fn( async () => [] ),
+			executeAbility: jest.fn(),
+		};
+
+		const agentsManagerData = {
+			sectionName: 'gutenberg',
+			agentProviders: [
+				{ toolProvider },
+				'https://widgets.wp.com/agents-manager/jetpack-ai-sidebar.provider.mjs',
+			],
+			jetpackAiSidebarPreview: { enabled: true },
+		};
+		( globalThis as typeof globalThis & { agentsManagerData?: unknown } ).agentsManagerData =
+			agentsManagerData;
+		( window as typeof window & { agentsManagerData?: unknown } ).agentsManagerData =
+			agentsManagerData;
+
+		const providers = await loadExternalProviders();
+
+		expect( providers.toolProvider ).toBe( toolProvider );
+		expect( toolProvider.getAbilities ).not.toHaveBeenCalled();
+	} );
+
+	it( 'returns no providers when the post-editor surface only has Jetpack AI Sidebar', async () => {
+		( globalThis as typeof globalThis & { _currentSiteType?: unknown } )._currentSiteType =
+			'atomic';
+		const agentsManagerData = {
+			sectionName: 'gutenberg',
+			agentProviders: [ 'https://widgets.wp.com/agents-manager/jetpack-ai-sidebar.provider.mjs' ],
+			jetpackAiSidebarPreview: { enabled: true },
+		};
+		( globalThis as typeof globalThis & { agentsManagerData?: unknown } ).agentsManagerData =
+			agentsManagerData;
+		( window as typeof window & { agentsManagerData?: unknown } ).agentsManagerData =
+			agentsManagerData;
+
+		await expect( loadExternalProviders() ).resolves.toEqual( {} );
 	} );
 } );
 

--- a/packages/agents-manager/src/utils/gate-jetpack-ai-sidebar-to-simple-sites.ts
+++ b/packages/agents-manager/src/utils/gate-jetpack-ai-sidebar-to-simple-sites.ts
@@ -1,0 +1,87 @@
+// global.d.ts declares ambient globals (e.g. agentsManagerData) that are injected server-side.
+// Ambient declaration files cannot be `import`ed; a triple-slash reference is required to ensure
+// the global is visible when TypeScript resolves this file via the import graph rather than the
+// tsconfig include list (e.g. during sandbox / CI builds).
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference path="../global.d.ts" />
+
+const JETPACK_AI_SIDEBAR_PROVIDER_PATH = 'jetpack-ai-sidebar.provider.mjs';
+const POST_EDITOR_SECTION_NAME = 'gutenberg';
+
+export type AgentProviderEntry = string | object;
+
+type AgentsManagerInlineData = {
+	agentProviders?: AgentProviderEntry[];
+	jetpackAiSidebarPreview?: unknown;
+	sectionName?: unknown;
+};
+
+type JetpackScriptData = {
+	site?: {
+		host?: unknown;
+	};
+};
+
+function getAgentsManagerInlineData(): AgentsManagerInlineData | undefined {
+	return typeof agentsManagerData !== 'undefined'
+		? ( agentsManagerData as unknown as AgentsManagerInlineData )
+		: undefined;
+}
+
+function getInlineAgentProviders( data?: AgentsManagerInlineData ): AgentProviderEntry[] {
+	return Array.isArray( data?.agentProviders ) ? data.agentProviders : [];
+}
+
+function getEditorSiteTypeSimpleStatus(): boolean | undefined {
+	const siteType = ( globalThis as unknown as { _currentSiteType?: unknown } )._currentSiteType;
+	return typeof siteType === 'string' ? siteType === 'simple' : undefined;
+}
+
+function getJetpackScriptDataSimpleStatus(): boolean | undefined {
+	const host = ( globalThis as unknown as { JetpackScriptData?: JetpackScriptData } )
+		.JetpackScriptData?.site?.host;
+	return typeof host === 'string' ? host === 'wpcom' : undefined;
+}
+
+function isWpcomSimpleSite(): boolean {
+	return getEditorSiteTypeSimpleStatus() ?? getJetpackScriptDataSimpleStatus() ?? false;
+}
+
+export function isJetpackAiSidebarProvider( provider: unknown ): boolean {
+	return typeof provider === 'string' && provider.includes( JETPACK_AI_SIDEBAR_PROVIDER_PATH );
+}
+
+function shouldDisableJetpackAiSidebarForCurrentSite( data?: AgentsManagerInlineData ): boolean {
+	if ( data?.sectionName !== POST_EDITOR_SECTION_NAME ) {
+		return false;
+	}
+
+	if ( isWpcomSimpleSite() ) {
+		return false;
+	}
+
+	return (
+		data.jetpackAiSidebarPreview !== undefined ||
+		getInlineAgentProviders( data ).some( isJetpackAiSidebarProvider )
+	);
+}
+
+export function getAgentProvidersWithJetpackAiSidebarGated(): AgentProviderEntry[] {
+	const data = getAgentsManagerInlineData();
+	const providers = getInlineAgentProviders( data );
+
+	if ( ! shouldDisableJetpackAiSidebarForCurrentSite( data ) ) {
+		return providers;
+	}
+
+	return providers.filter( ( provider ) => ! isJetpackAiSidebarProvider( provider ) );
+}
+
+export function shouldSuppressAgentsManagerWhenJetpackAiSidebarGated(): boolean {
+	const data = getAgentsManagerInlineData();
+
+	return (
+		shouldDisableJetpackAiSidebarForCurrentSite( data ) &&
+		getAgentProvidersWithJetpackAiSidebarGated().length === 0
+	);
+}

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -12,6 +12,7 @@
  */
 
 import { getAgentManager, UIMessage } from '@automattic/agenttic-client';
+import { getAgentProvidersWithJetpackAiSidebarGated } from './gate-jetpack-ai-sidebar-to-simple-sites';
 import { isReaderChatAgent } from './is-reader-chat-agent';
 import { useReaderFollowupSuggestions } from './reader-followup-hook';
 import type { ImageUploadHook } from '../hooks/use-image-upload';
@@ -206,8 +207,7 @@ export function mergeUseSuggestionsHooks(
  * @returns Promise resolving to merged providers or empty object if none found.
  */
 export async function loadExternalProviders(): Promise< LoadedProviders > {
-	const agentProviders =
-		typeof agentsManagerData !== 'undefined' ? agentsManagerData?.agentProviders || [] : [];
+	const agentProviders = getAgentProvidersWithJetpackAiSidebarGated();
 
 	// Only the public reader-chat entry registers the follow-up chip globals
 	// (`window.__jetpackReaderFollowupChips` / `reader-chat-followups-updated`).


### PR DESCRIPTION
## Proposed Changes

* Gate the Jetpack AI Sidebar provider to WordPress.com Simple sites in the post editor.
* Filter only `jetpack-ai-sidebar.provider.mjs` from Agents Manager providers on non-Simple sites.
* Keep Agents Manager mounted when another provider remains, so unrelated providers are not hidden.
* Suppress Agents Manager only when Jetpack AI Sidebar was the only post-editor provider.
* Add focused coverage for Simple, Atomic, self-hosted, and mixed-provider cases.

## Why are these changes being made?

Jetpack AI Sidebar should not be exposed through the post-editor Agents Manager surface on Atomic or self-hosted sites while the experience is being constrained to Simple sites.

Atomic sites may also register other Agents Manager providers. Filtering only the Jetpack AI Sidebar provider avoids hiding unrelated providers while still preventing the Jetpack AI Sidebar surface from loading on non-Simple sites.

## Testing Instructions

Automated checks:

* `yarn jest -c test/packages/jest.config.js --runTestsByPath packages/agents-manager/src/components/__tests__/agents-manager.test.tsx packages/agents-manager/src/utils/__tests__/gate-jetpack-ai-sidebar-to-simple-sites.test.ts packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts`
* `yarn eslint packages/agents-manager/src/components/agents-manager.tsx packages/agents-manager/src/components/__tests__/agents-manager.test.tsx packages/agents-manager/src/utils/load-external-providers.ts packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts packages/agents-manager/src/utils/gate-jetpack-ai-sidebar-to-simple-sites.ts packages/agents-manager/src/utils/__tests__/gate-jetpack-ai-sidebar-to-simple-sites.test.ts`
* `yarn tsc -p packages/agents-manager/tsconfig.json --noEmit`

Manual checks:

* On a WordPress.com Simple site, open the post editor and confirm the Jetpack AI Sidebar provider remains available.
* On an Atomic site, open the post editor and confirm `jetpack-ai-sidebar.provider.mjs` is filtered from the Agents Manager providers.
* On an Atomic site with another Agents Manager provider registered, confirm that provider remains available after the Jetpack AI Sidebar provider is filtered.
* On a self-hosted Jetpack site, open the post editor and confirm the Jetpack AI Sidebar provider is not loaded.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [x] Have you used memoizing on expensive computations? Not applicable; this adds only simple inline-data checks.
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?
