### PR TITLE
Agents Manager: drop Jetpack AI Sidebar provider from AM merge

### DIFF
--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -192,6 +192,9 @@ export function mergeUseSuggestionsHooks(
 	};
 }
 
+/** Provider module path for the Jetpack AI Sidebar; filtered out as a kill switch. */
+const JETPACK_AI_SIDEBAR_PROVIDER_PATH = 'jetpack-ai-sidebar.provider.mjs';
+
 /**
  * Load external agent providers from agentsManagerData.agentProviders.
  *
@@ -206,8 +209,15 @@ export function mergeUseSuggestionsHooks(
  * @returns Promise resolving to merged providers or empty object if none found.
  */
 export async function loadExternalProviders(): Promise< LoadedProviders > {
-	const agentProviders =
-		typeof agentsManagerData !== 'undefined' ? agentsManagerData?.agentProviders || [] : [];
+	// Kill switch: drop the Jetpack AI Sidebar provider on all site types so its
+	// sidebar surface never loads. Other providers (Block Notes, Big Sky, …) are
+	// unaffected.
+	const agentProviders = (
+		typeof agentsManagerData !== 'undefined' ? agentsManagerData?.agentProviders || [] : []
+	).filter(
+		( provider ) =>
+			typeof provider !== 'string' || ! provider.includes( JETPACK_AI_SIDEBAR_PROVIDER_PATH )
+	);
 
 	// Only the public reader-chat entry registers the follow-up chip globals
 	// (`window.__jetpackReaderFollowupChips` / `reader-chat-followups-updated`).


### PR DESCRIPTION
## Proposed Changes

* Filter `jetpack-ai-sidebar.provider.mjs` out of `agentsManagerData.agentProviders` before Agents Manager dynamically imports external providers.
* Leave all other provider entries untouched, so unrelated providers can still be merged by Agents Manager.
* Keep the change scoped to the Agents Manager provider merge. This does not change Jetpack/PHP enqueue behavior for `jetpack-ai-sidebar.min.js` or Image Studio.

## Why are these changes being made?

This adds a small Calypso-side stopgap for the Jetpack AI Sidebar provider while the broader rollout path is reassessed. The provider is what contributes Jetpack AI Sidebar-specific tools, context, suggestions, components, and capabilities to Agents Manager. Dropping that provider avoids merging those contributions without changing the server-side script enqueue path or other editor AI surfaces.

## Testing Instructions

1. Load the post editor on a site where Jetpack AI Sidebar Preview would normally be enabled.
2. Open the browser Network tab and confirm `jetpack-ai-sidebar.provider.mjs` is not requested by Agents Manager.
3. Confirm it is still acceptable if `jetpack-ai-sidebar.min.js` appears in Network; this PR gates the provider import, not Jetpack's PHP-enqueued IIFE bundle.
4. Confirm unrelated editor AI surfaces still work where enabled, especially Image Studio's `/image` -> `Generate Image` button.
5. If another provider is present in `agentsManagerData.agentProviders`, confirm that provider still loads.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
