### PR TITLE
Agents Manager: gate the Jetpack AI Sidebar preview on non-Simple sites

### DIFF
--- a/apps/agents-manager/__tests__/agents-manager-gutenberg.test.js
+++ b/apps/agents-manager/__tests__/agents-manager-gutenberg.test.js
@@ -1,0 +1,65 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Tests the gutenberg entry's registerPlugin wiring: the Jetpack AI Sidebar
+ * preview gate decides whether the Agents Manager mounts. The entry has
+ * side-effecting imports (config, the full AM bundle), so those are mocked
+ * and only the registered render function is exercised.
+ */
+
+jest.mock( '../config', () => ( {} ), { virtual: true } );
+jest.mock( '../agents-manager-with-provider', () => ( {
+	__esModule: true,
+	default: function AgentsManagerWithProvider() {
+		return null;
+	},
+} ) );
+
+const mockRegisterPlugin = jest.fn();
+jest.mock( '@wordpress/plugins', () => ( { registerPlugin: mockRegisterPlugin } ) );
+
+const JETPACK_PROVIDER = 'https://widgets.wp.com/agents-manager/jetpack-ai-sidebar.provider.mjs';
+
+describe( 'agents-manager-gutenberg entry', () => {
+	let render;
+
+	beforeAll( () => {
+		require( '../agents-manager-gutenberg' );
+		render = mockRegisterPlugin.mock.calls[ 0 ]?.[ 1 ]?.render;
+	} );
+
+	afterEach( () => {
+		delete globalThis.agentsManagerData;
+		delete window._currentSiteType;
+	} );
+
+	it( 'registers the jetpack-agents-manager plugin with a render function', () => {
+		expect( mockRegisterPlugin ).toHaveBeenCalledWith(
+			'jetpack-agents-manager',
+			expect.objectContaining( { render: expect.any( Function ) } )
+		);
+	} );
+
+	it( 'renders nothing when the preview gate suppresses the mount', () => {
+		globalThis.agentsManagerData = {
+			sectionName: 'gutenberg',
+			agentProviders: [ JETPACK_PROVIDER ],
+			jetpackAiSidebarPreview: { enabled: true },
+		};
+
+		expect( render() ).toBeNull();
+	} );
+
+	it( 'renders the Agents Manager when the gate allows the mount', () => {
+		window._currentSiteType = 'simple';
+		globalThis.agentsManagerData = {
+			sectionName: 'gutenberg',
+			agentProviders: [ JETPACK_PROVIDER ],
+			jetpackAiSidebarPreview: { enabled: true },
+		};
+
+		const result = render();
+		expect( result ).not.toBeNull();
+		expect( result.type.name ).toBe( 'AgentsManagerWithProvider' );
+	} );
+} );

--- a/apps/agents-manager/__tests__/agents-manager-gutenberg.test.js
+++ b/apps/agents-manager/__tests__/agents-manager-gutenberg.test.js
@@ -20,12 +20,22 @@ jest.mock( '@wordpress/plugins', () => ( { registerPlugin: mockRegisterPlugin } 
 
 const JETPACK_PROVIDER = 'https://widgets.wp.com/agents-manager/jetpack-ai-sidebar.provider.mjs';
 
-describe( 'agents-manager-gutenberg entry', () => {
+const loadRender = () => {
 	let render;
 
-	beforeAll( () => {
+	jest.isolateModules( () => {
 		require( '../agents-manager-gutenberg' );
-		render = mockRegisterPlugin.mock.calls[ 0 ]?.[ 1 ]?.render;
+		render = mockRegisterPlugin.mock.calls.at( -1 )?.[ 1 ]?.render;
+	} );
+
+	return render;
+};
+
+describe( 'agents-manager-gutenberg entry', () => {
+	beforeEach( () => {
+		mockRegisterPlugin.mockClear();
+		delete globalThis.agentsManagerData;
+		delete window._currentSiteType;
 	} );
 
 	afterEach( () => {
@@ -34,6 +44,8 @@ describe( 'agents-manager-gutenberg entry', () => {
 	} );
 
 	it( 'registers the jetpack-agents-manager plugin with a render function', () => {
+		loadRender();
+
 		expect( mockRegisterPlugin ).toHaveBeenCalledWith(
 			'jetpack-agents-manager',
 			expect.objectContaining( { render: expect.any( Function ) } )
@@ -47,6 +59,9 @@ describe( 'agents-manager-gutenberg entry', () => {
 			jetpackAiSidebarPreview: { enabled: true },
 		};
 
+		const render = loadRender();
+
+		expect( globalThis.agentsManagerData.agentProviders ).toEqual( [] );
 		expect( render() ).toBeNull();
 	} );
 
@@ -58,6 +73,9 @@ describe( 'agents-manager-gutenberg entry', () => {
 			jetpackAiSidebarPreview: { enabled: true },
 		};
 
+		const render = loadRender();
+
+		expect( globalThis.agentsManagerData.agentProviders ).toEqual( [ JETPACK_PROVIDER ] );
 		const result = render();
 		expect( result ).not.toBeNull();
 		expect( result.type.name ).toBe( 'AgentsManagerWithProvider' );

--- a/apps/agents-manager/__tests__/jetpack-ai-sidebar-preview-gate.test.js
+++ b/apps/agents-manager/__tests__/jetpack-ai-sidebar-preview-gate.test.js
@@ -1,0 +1,107 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { shouldSuppressJetpackAiSidebarPreview } from '../jetpack-ai-sidebar-preview-gate';
+
+const JETPACK_PROVIDER = 'https://widgets.wp.com/agents-manager/jetpack-ai-sidebar.provider.mjs';
+const BIG_SKY_PROVIDER =
+	'https://example.com/wp-content/plugins/big-sky/build/calypso-agent-provider/index.js';
+const BLOCK_NOTES_PROVIDER = 'block-notes/headless-agent-provider';
+
+const setAgentsManagerData = ( data ) => {
+	globalThis.agentsManagerData = data;
+};
+
+describe( 'shouldSuppressJetpackAiSidebarPreview', () => {
+	afterEach( () => {
+		delete globalThis.agentsManagerData;
+		delete window._currentSiteType;
+	} );
+
+	it( 'does not suppress when agentsManagerData is undefined', () => {
+		expect( shouldSuppressJetpackAiSidebarPreview() ).toBe( false );
+	} );
+
+	it( 'does not suppress or filter when the preview data is absent', () => {
+		setAgentsManagerData( {
+			sectionName: 'gutenberg',
+			agentProviders: [ BLOCK_NOTES_PROVIDER ],
+		} );
+
+		expect( shouldSuppressJetpackAiSidebarPreview() ).toBe( false );
+		expect( globalThis.agentsManagerData.agentProviders ).toEqual( [ BLOCK_NOTES_PROVIDER ] );
+	} );
+
+	it( 'does not suppress or filter on Simple sites', () => {
+		window._currentSiteType = 'simple';
+		setAgentsManagerData( {
+			sectionName: 'gutenberg',
+			agentProviders: [ JETPACK_PROVIDER ],
+			jetpackAiSidebarPreview: { enabled: true },
+		} );
+
+		expect( shouldSuppressJetpackAiSidebarPreview() ).toBe( false );
+		expect( globalThis.agentsManagerData.agentProviders ).toEqual( [ JETPACK_PROVIDER ] );
+	} );
+
+	it( 'suppresses on self-hosted sites where the preview registered the only provider', () => {
+		setAgentsManagerData( {
+			sectionName: 'gutenberg',
+			agentProviders: [ JETPACK_PROVIDER ],
+			jetpackAiSidebarPreview: { enabled: true },
+		} );
+
+		expect( shouldSuppressJetpackAiSidebarPreview() ).toBe( true );
+		expect( globalThis.agentsManagerData.agentProviders ).toEqual( [] );
+	} );
+
+	it( 'suppresses on Atomic sites when no providers remain', () => {
+		window._currentSiteType = 'atomic';
+		setAgentsManagerData( {
+			sectionName: 'gutenberg',
+			agentProviders: [],
+			jetpackAiSidebarPreview: { enabled: true },
+		} );
+
+		expect( shouldSuppressJetpackAiSidebarPreview() ).toBe( true );
+	} );
+
+	it( 'filters only the Jetpack AI Sidebar provider when others remain', () => {
+		window._currentSiteType = 'atomic';
+		const objectProvider = { toolProvider: {} };
+		setAgentsManagerData( {
+			sectionName: 'gutenberg',
+			agentProviders: [ objectProvider, BIG_SKY_PROVIDER, JETPACK_PROVIDER ],
+			jetpackAiSidebarPreview: { enabled: true },
+		} );
+
+		expect( shouldSuppressJetpackAiSidebarPreview() ).toBe( false );
+		expect( globalThis.agentsManagerData.agentProviders ).toEqual( [
+			objectProvider,
+			BIG_SKY_PROVIDER,
+		] );
+	} );
+
+	it( 'stays suppressed when called again after filtering', () => {
+		setAgentsManagerData( {
+			sectionName: 'gutenberg',
+			agentProviders: [ JETPACK_PROVIDER ],
+			jetpackAiSidebarPreview: { enabled: true },
+		} );
+
+		expect( shouldSuppressJetpackAiSidebarPreview() ).toBe( true );
+		expect( shouldSuppressJetpackAiSidebarPreview() ).toBe( true );
+	} );
+
+	it( 'tolerates a malformed agentProviders value', () => {
+		setAgentsManagerData( {
+			sectionName: 'gutenberg',
+			agentProviders: 'not-an-array',
+			jetpackAiSidebarPreview: { enabled: true },
+		} );
+
+		expect( shouldSuppressJetpackAiSidebarPreview() ).toBe( true );
+		expect( globalThis.agentsManagerData.agentProviders ).toEqual( [] );
+	} );
+} );

--- a/apps/agents-manager/agents-manager-gutenberg.jsx
+++ b/apps/agents-manager/agents-manager-gutenberg.jsx
@@ -1,7 +1,8 @@
 import './config';
 import { registerPlugin } from '@wordpress/plugins';
 import AgentsManagerWithProvider from './agents-manager-with-provider';
+import { shouldSuppressJetpackAiSidebarPreview } from './jetpack-ai-sidebar-preview-gate';
 
 registerPlugin( 'jetpack-agents-manager', {
-	render: () => <AgentsManagerWithProvider />,
+	render: () => ( shouldSuppressJetpackAiSidebarPreview() ? null : <AgentsManagerWithProvider /> ),
 } );

--- a/apps/agents-manager/agents-manager-gutenberg.jsx
+++ b/apps/agents-manager/agents-manager-gutenberg.jsx
@@ -3,6 +3,8 @@ import { registerPlugin } from '@wordpress/plugins';
 import AgentsManagerWithProvider from './agents-manager-with-provider';
 import { shouldSuppressJetpackAiSidebarPreview } from './jetpack-ai-sidebar-preview-gate';
 
+const shouldSuppressAgentsManager = shouldSuppressJetpackAiSidebarPreview();
+
 registerPlugin( 'jetpack-agents-manager', {
-	render: () => ( shouldSuppressJetpackAiSidebarPreview() ? null : <AgentsManagerWithProvider /> ),
+	render: () => ( shouldSuppressAgentsManager ? null : <AgentsManagerWithProvider /> ),
 } );

--- a/apps/agents-manager/jetpack-ai-sidebar-preview-gate.js
+++ b/apps/agents-manager/jetpack-ai-sidebar-preview-gate.js
@@ -1,21 +1,16 @@
 /* global agentsManagerData */
 
 /**
- * Stopgap kill switch for the Jetpack AI Sidebar preview.
+ * Temporary kill switch for the Jetpack AI Sidebar preview.
  *
- * Jetpack 15.9 enables the AI Sidebar preview by default in the post editor
- * with no kill switch on Atomic and self-hosted sites (AI-993): the "Ask AI"
- * dock renders even when the site's AI Assistant setting is off. The PHP fix
- * (Automattic/jetpack#49489) needs a plugin release, while this bundle ships
- * straight from widgets.wp.com — so the gate lives here, in the one entry
- * point Jetpack 15.9 mounts in the post editor.
+ * Jetpack can mount this post-editor surface on Atomic/self-hosted sites
+ * before the server-side AI Assistant setting gate is available everywhere.
+ * This widgets.wp.com entrypoint ships faster, so it filters the preview
+ * provider client-side.
  *
- * Simple sites are gated server-side by wpcom (D222450) and pass through
- * untouched: gutenberg-wpcom sets `window._currentSiteType = 'simple'` on
- * every Simple-site editor.
+ * Simple sites keep using wpcom's server-side gate and pass through untouched.
  *
- * Remove once Jetpack releases honoring the AI Assistant setting have
- * rolled out to most sites.
+ * Remove once released Jetpack versions honor the AI Assistant setting.
  */
 
 const JETPACK_AI_SIDEBAR_PROVIDER_FILE = 'jetpack-ai-sidebar.provider.mjs';

--- a/apps/agents-manager/jetpack-ai-sidebar-preview-gate.js
+++ b/apps/agents-manager/jetpack-ai-sidebar-preview-gate.js
@@ -1,0 +1,54 @@
+/* global agentsManagerData */
+
+/**
+ * Stopgap kill switch for the Jetpack AI Sidebar preview.
+ *
+ * Jetpack 15.9 enables the AI Sidebar preview by default in the post editor
+ * with no kill switch on Atomic and self-hosted sites (AI-993): the "Ask AI"
+ * dock renders even when the site's AI Assistant setting is off. The PHP fix
+ * (Automattic/jetpack#49489) needs a plugin release, while this bundle ships
+ * straight from widgets.wp.com — so the gate lives here, in the one entry
+ * point Jetpack 15.9 mounts in the post editor.
+ *
+ * Simple sites are gated server-side by wpcom (D222450) and pass through
+ * untouched: gutenberg-wpcom sets `window._currentSiteType = 'simple'` on
+ * every Simple-site editor.
+ *
+ * Remove once Jetpack releases honoring the AI Assistant setting have
+ * rolled out to most sites.
+ */
+
+const JETPACK_AI_SIDEBAR_PROVIDER_FILE = 'jetpack-ai-sidebar.provider.mjs';
+
+/**
+ * Gate the Jetpack AI Sidebar preview on non-Simple sites.
+ *
+ * Removes the Jetpack AI Sidebar provider from
+ * `agentsManagerData.agentProviders`, which Agents Manager's
+ * `loadExternalProviders()` reads later.
+ * @returns {boolean} True when Agents Manager should not mount at all —
+ *                    the preview was the only reason it was loaded.
+ */
+export function shouldSuppressJetpackAiSidebarPreview() {
+	const data = typeof agentsManagerData !== 'undefined' ? agentsManagerData : undefined;
+
+	// Not a preview-driven mount (e.g. Block Notes without the preview).
+	if ( ! data?.jetpackAiSidebarPreview ) {
+		return false;
+	}
+
+	// wpcom owns the Simple-site gating server-side.
+	if ( window._currentSiteType === 'simple' ) {
+		return false;
+	}
+
+	const providers = Array.isArray( data.agentProviders ) ? data.agentProviders : [];
+	const remaining = providers.filter(
+		( provider ) =>
+			! ( typeof provider === 'string' && provider.includes( JETPACK_AI_SIDEBAR_PROVIDER_FILE ) )
+	);
+	data.agentProviders = remaining;
+
+	// Mount only when another provider (Block Notes, Big Sky, …) still needs AM.
+	return remaining.length === 0;
+}


### PR DESCRIPTION
Part of AI-993 (Bug: "Ask AI" floating bar persists in wp-admin editor after AI settings disabled)

## Proposed Changes

* Add a stopgap kill switch for the Jetpack AI Sidebar preview in the `agents-manager-gutenberg` entry point — the one bundle Jetpack 15.9's CDN loader mounts in the post editor from `widgets.wp.com`.
* When `agentsManagerData.jetpackAiSidebarPreview` is present and the site is not a WordPress.com Simple site (`window._currentSiteType !== 'simple'`), filter `jetpack-ai-sidebar.provider.mjs` out of `agentsManagerData.agentProviders`.
* Skip mounting Agents Manager entirely (no "Ask AI" dock/FAB) when the preview was the only registered provider. Mounts with other providers (Block Notes, Big Sky) keep working with just the Jetpack provider removed.
* No changes to `packages/agents-manager` or any other shared code — Calypso, Help Center, Image Studio, Block Notes, CIAB, Woo AI, wp-admin headless, and Reader Chat bundles are untouched.

## Why are these changes being made?

Jetpack 15.9 enables the AI Editorial Review sidebar preview by default in the post editor, and the released PHP has no working kill switch on Atomic and self-hosted sites: the "Ask AI" dock renders even when the site-level AI Assistant setting is off (LIN-AI-993, escalation reports). Simple sites are already gated server-side.

The proper fix (Automattic/jetpack#49489) requires a Jetpack plugin release. This bundle, however, is served from `widgets.wp.com` and can be redeployed immediately — so the gate lives in the entry point that only ships there, keying off the two signals the released Jetpack 15.9 PHP already provides:

* `jetpackAiSidebarPreview` in the inline `agentsManagerData` marks every preview-driven mount (set directly by the CDN loader, via the data filter, and via the Atomic inline patch).
* `window._currentSiteType` is set to `simple` on every Simple-site editor, where the server-side gate already owns the decision — those mounts pass through untouched.

Once Jetpack releases that honor the AI Assistant setting have rolled out, this gate can be removed.

## Testing Instructions

Automated:

* `yarn jest -c apps/agents-manager/jest.config.js`

Sandbox (sandbox `widgets.wp.com`, then `cd apps/agents-manager && yarn dev --sync`):

* On a self-hosted Jetpack 15.9 site (e.g. Jurassic Ninja), open the post editor and confirm the "Ask AI" dock/FAB and Jetpack AI Sidebar no longer appear.
* On a self-hosted site with Block Notes enabled, confirm Agents Manager still mounts for Block Notes and only the Jetpack AI Sidebar provider is dropped.
* On an Atomic site, open the post editor and confirm the preview-driven Agents Manager surface no longer appears.
* On a WordPress.com Simple site, confirm the Jetpack AI Sidebar / AI Editorial Review still works exactly as before (gate is a no-op when `_currentSiteType === 'simple'`).
* Confirm Image Studio (Media Library and post editor) and Reader Chat are unaffected.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
