### PR TITLE
Dashboard: track sites list search and per-site quick actions

### DIFF
--- a/client/dashboard/sites/dataviews/actions.tsx
+++ b/client/dashboard/sites/dataviews/actions.tsx
@@ -5,6 +5,7 @@ import { backup, wordpress } from '@wordpress/icons';
 import { lazy, Suspense } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { siteDomainsRoute } from '../../app/router/sites';
+import ComponentViewTracker from '../../components/component-view-tracker';
 import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { getSiteBlockingStatus } from '../../utils/site-status';
 import { siteTypeSupportsFeature } from '../../utils/site-type-feature-support';
@@ -34,6 +35,7 @@ export function useActions(): Action< Site >[] {
 			label: __( 'WP Admin ↗' ),
 			callback: ( sites: Site[] ) => {
 				const site = sites[ 0 ];
+				recordTracksEvent( 'calypso_dashboard_sites_action_click', { action: 'admin' } );
 				if ( site.options?.admin_url ) {
 					window.open( site.options.admin_url, '_blank' );
 				}
@@ -45,6 +47,7 @@ export function useActions(): Action< Site >[] {
 			label: __( 'Visit site ↗' ),
 			callback: ( sites: Site[] ) => {
 				const site = sites[ 0 ];
+				recordTracksEvent( 'calypso_dashboard_sites_action_click', { action: 'site' } );
 				if ( site.URL ) {
 					window.open( site.URL, '_blank' );
 				}
@@ -56,6 +59,7 @@ export function useActions(): Action< Site >[] {
 			label: isDashboardBackport() ? __( 'Domains ↗' ) : __( 'Domains' ),
 			callback: ( sites: Site[] ) => {
 				const site = sites[ 0 ];
+				recordTracksEvent( 'calypso_dashboard_sites_action_click', { action: 'domains' } );
 				if ( isDashboardBackport() ) {
 					window.open( `/domains/manage/${ site.slug }`, '_blank' );
 					return;
@@ -73,6 +77,7 @@ export function useActions(): Action< Site >[] {
 			label: __( 'Jetpack Cloud ↗' ),
 			callback: ( sites: Site[] ) => {
 				const site = sites[ 0 ];
+				recordTracksEvent( 'calypso_dashboard_sites_action_click', { action: 'jetpack-cloud' } );
 				window.open( `https://cloud.jetpack.com/landing/${ site.slug }` );
 			},
 			isEligible: ( item: Site ) => isSelfHostedJetpackConnected( item ),
@@ -87,6 +92,12 @@ export function useActions(): Action< Site >[] {
 					params: { siteSlug: site.slug },
 				} );
 
+				recordTracksEvent( 'calypso_dashboard_sites_action_click', {
+					action: 'prepare-for-launch',
+				} );
+				// Legacy event, kept for continuity with existing dashboards/queries. Now
+				// redundant with the unified action_click event above; remove once teams
+				// relying on it have migrated. See PR discussion.
 				recordTracksEvent( 'calypso_sites_dashboard_site_action_prepare_for_launch_click' );
 			},
 			isEligible: ( item: Site ) =>
@@ -100,6 +111,7 @@ export function useActions(): Action< Site >[] {
 			label: __( 'Settings' ),
 			callback: ( sites: Site[] ) => {
 				const site = sites[ 0 ];
+				recordTracksEvent( 'calypso_dashboard_sites_action_click', { action: 'settings' } );
 				router.navigate( { to: '/sites/$siteSlug/settings', params: { siteSlug: site.slug } } );
 			},
 			isEligible: ( item: Site ) =>
@@ -118,6 +130,10 @@ export function useActions(): Action< Site >[] {
 			isEligible: ( item: Site ) => canRestoreSite( item ),
 			RenderModal: ( { items, closeModal } ) => (
 				<Suspense fallback={ null }>
+					<ComponentViewTracker
+						eventName="calypso_dashboard_sites_action_click"
+						properties={ { action: 'restore' } }
+					/>
 					<SiteRestoreContentInfo site={ items[ 0 ] } onClose={ closeModal ?? noop } />
 				</Suspense>
 			),
@@ -128,6 +144,10 @@ export function useActions(): Action< Site >[] {
 			isEligible: ( item: Site ) => canDisconnectSite( item ),
 			RenderModal: ( { items, closeModal } ) => (
 				<Suspense fallback={ null }>
+					<ComponentViewTracker
+						eventName="calypso_dashboard_sites_action_click"
+						properties={ { action: 'disconnect' } }
+					/>
 					<JetpackSiteDisconnect site={ items[ 0 ] } onClose={ closeModal ?? noop } />
 				</Suspense>
 			),
@@ -138,6 +158,10 @@ export function useActions(): Action< Site >[] {
 			isEligible: ( item: Site ) => canLeaveSite( item ),
 			RenderModal: ( { items, closeModal } ) => (
 				<Suspense fallback={ null }>
+					<ComponentViewTracker
+						eventName="calypso_dashboard_sites_action_click"
+						properties={ { action: 'leave' } }
+					/>
 					<SiteLeaveContentInfo site={ items[ 0 ] } onClose={ closeModal ?? noop } />
 				</Suspense>
 			),

--- a/client/dashboard/sites/dataviews/views.ts
+++ b/client/dashboard/sites/dataviews/views.ts
@@ -79,6 +79,12 @@ export function recordViewChanges(
 	newView: View,
 	recordTracksEvent: AnalyticsClient[ 'recordTracksEvent' ]
 ) {
+	// Fire once when the user starts searching (empty -> non-empty), rather than
+	// on every keystroke, and without logging the term itself.
+	if ( ! oldView.search && newView.search ) {
+		recordTracksEvent( 'calypso_dashboard_sites_search' );
+	}
+
 	if ( oldView.type !== newView.type ) {
 		recordTracksEvent( 'calypso_dashboard_sites_view_type_changed', { type: newView.type } );
 

--- a/client/dashboard/sites/test/views.ts
+++ b/client/dashboard/sites/test/views.ts
@@ -22,6 +22,27 @@ describe( 'recordViewChanges', () => {
 		expect( tracks ).not.toHaveBeenCalled();
 	} );
 
+	test( 'records search started when search goes from empty to non-empty', () => {
+		const tracks = jest.fn();
+		const oldView: View = { type: 'grid' };
+		const newView: View = { type: 'grid', search: 'hello' };
+
+		recordViewChanges( oldView, newView, tracks );
+
+		expect( tracks ).toHaveBeenCalledTimes( 1 );
+		expect( tracks ).toHaveBeenCalledWith( 'calypso_dashboard_sites_search' );
+	} );
+
+	test( 'does not record search when search term changes between non-empty values', () => {
+		const tracks = jest.fn();
+		const oldView: View = { type: 'grid', search: 'hel' };
+		const newView: View = { type: 'grid', search: 'hello' };
+
+		recordViewChanges( oldView, newView, tracks );
+
+		expect( tracks ).not.toHaveBeenCalled();
+	} );
+
 	test( 'add new field', () => {
 		const tracks = jest.fn();
 		const oldView: View = { type: 'grid' };


### PR DESCRIPTION
## Proposed Changes

Adds Tracks events for two sites list flows we can't currently measure:

- `calypso_dashboard_sites_search`
  - fired once when search goes empty → non-empty. Not per keystroke; term not logged (site names are sensitive).
- `calypso_dashboard_sites_action_click`

## Why

The sites list is the dashboard's front door, but we're blind to two things:

- Search reliance
  - heavy use, especially on large accounts, signals the list/filtering needs work.
- Which row actions get used

## Reviewer note

`prepare-for-launch` also still fires the legacy `calypso_sites_dashboard_site_action_prepare_for_launch_click` (old reversed prefix) to no break existing tracking.

## Testing Instructions

1. Open the sites list with Tracks debugging on.
2. Type in search → one `calypso_dashboard_sites_search` (no term, not per keystroke).
3. Trigger each row action → `calypso_dashboard_sites_action_click` with matching `action`.
4. `yarn test-client client/dashboard/sites/test/views.ts`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)