### PR TITLE
Dashboard: fix prettier/prettier eslint warnings

### DIFF
--- a/client/dashboard/docs/links.md
+++ b/client/dashboard/docs/links.md
@@ -1,7 +1,7 @@
 # Linking from and to the Dashboard
 
 - Every relative URL from the dashboard linking to the Classic WordPress.com/Calypso MUST use `wpcomLink()` function
-    - **Purpose**: Ensures proper environment configuration (dev vs production hostnames)
+  - **Purpose**: Ensures proper environment configuration (dev vs production hostnames)
 
 ```typescript
 // ✅ Correct - wrapped with wpcomLink()
@@ -15,8 +15,8 @@
 ```
 
 - Every relative URL from the Classic WordPress.com/Calypso to the dashboard MUST use `dashboardLink()` function
-    - **Purpose**: Ensures proper environment configuration (dev vs production hostnames)
+  - **Purpose**: Ensures proper environment configuration (dev vs production hostnames)
 - Every link to `/checkout` must have `redirect_to` and `cancel_to` query param
-    - **Purpose**: Ensures correct behaviour when exiting the checkout screen
+  - **Purpose**: Ensures correct behaviour when exiting the checkout screen
 - Every link to `/setup/plan-upgrade` must have a `cancel_to` query param
-    - **Purpose**: Ensures correct behaviour when exiting the upgrade screen
+  - **Purpose**: Ensures correct behaviour when exiting the upgrade screen


### PR DESCRIPTION
## Proposed Changes

* Run `eslint --fix` on `client/dashboard` to fix the 4 auto-fixable `prettier/prettier` warnings (all in `docs/links.md`).

## Why are these changes being made?

* A stricter shared ESLint config recently landed on trunk, leaving `client/dashboard/` with pre-existing lint failures. This is part of a series of PRs fixing them one rule class at a time. Each PR leaves every file it touches fully lint-clean, so the "Code style" CI check (which lints whole changed files) passes independently of the sibling PRs.

## Testing Instructions

* Run `yarn eslint client/dashboard` — no `prettier/prettier` failures remain.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
