### PR TITLE
Dashboard: add missing translator comments

### DIFF
--- a/client/dashboard/app/header/index.tsx
+++ b/client/dashboard/app/header/index.tsx
@@ -19,7 +19,7 @@ function Header() {
 			{ Logo && (
 				<div style={ { display: 'flex', alignItems: 'center' } }>
 					<RouterLinkButton
-						/* translators: Screen reader text for link to root of the hosting dashboard. "name" is the product of whose hosting dashboard this is: e.g. WordPress.com */
+						/* translators: Screen reader text for link to root of the hosting dashboard. %(name)s: the product whose hosting dashboard this is, e.g. WordPress.com */
 						aria-label={ sprintf( __( '%(name)s home' ), { name } ) }
 						icon={ <Logo /> }
 						to="/"

--- a/client/dashboard/components/domain-contact-details-form/contact-form.tsx
+++ b/client/dashboard/components/domain-contact-details-form/contact-form.tsx
@@ -141,7 +141,7 @@ export default function ContactForm( {
 					<Text as="p">
 						{ createInterpolateElement(
 							sprintf(
-								/* translators: %1$s: ICANN acronym */
+								/* translators: %s: ICANN acronym */
 								__(
 									'<external>%s</external> requires accurate contact information for registrants. This information will be validated after purchase. Failure to validate your contact information will result in domain suspension.'
 								),

--- a/client/dashboard/components/formatted-time/index.ts
+++ b/client/dashboard/components/formatted-time/index.ts
@@ -41,10 +41,10 @@ export function useFormattedTime(
 		if ( isToday ) {
 			if ( formatOptions?.timeStyle ) {
 				if ( lowercaseCalendarLabel ) {
-					// translators: time today
+					// translators: %s: the time of day, e.g. 3:00 pm
 					return sprintf( __( 'today at %s' ), formatted );
 				}
-				// translators: time today
+				// translators: %s: the time of day, e.g. 3:00 pm
 				return sprintf( __( 'Today at %s' ), formatted );
 			}
 			return lowercaseCalendarLabel ? __( 'today' ) : __( 'Today' );

--- a/client/dashboard/components/formatted-time/index.ts
+++ b/client/dashboard/components/formatted-time/index.ts
@@ -41,10 +41,10 @@ export function useFormattedTime(
 		if ( isToday ) {
 			if ( formatOptions?.timeStyle ) {
 				if ( lowercaseCalendarLabel ) {
-					// translators: %s: the time of day, e.g. 3:00 pm
+					// translators: %s: the time of day, e.g. 3:00 pm, or 15:00
 					return sprintf( __( 'today at %s' ), formatted );
 				}
-				// translators: %s: the time of day, e.g. 3:00 pm
+				// translators: %s: the time of day, e.g. 3:00 pm, or 15:00
 				return sprintf( __( 'Today at %s' ), formatted );
 			}
 			return lowercaseCalendarLabel ? __( 'today' ) : __( 'Today' );

--- a/client/dashboard/components/purchase-expiry-status/index.tsx
+++ b/client/dashboard/components/purchase-expiry-status/index.tsx
@@ -162,7 +162,7 @@ export function PurchaseExpiryStatus( {
 	) {
 		return createInterpolateElement(
 			sprintf(
-				// translators: date is a formatted date, amount is a currency amount, and excludeTaxStringAbbreviation is something like "excludes VAT"
+				// translators: %(date)s: a formatted date, %(amount)s: a currency amount, excludeTaxStringAbbreviation: something like "excludes VAT"
 				__(
 					'Free trial ends on %(date)s, renews automatically at %(amount)s <excludeTaxStringAbbreviation />'
 				),
@@ -190,7 +190,7 @@ export function PurchaseExpiryStatus( {
 		return (
 			<span>
 				{
-					// translators: date is a formatted date
+					// translators: %(date)s: a formatted date
 					sprintf( __( 'Free trial ends on %(date)s' ), {
 						date: formatDate( new Date( purchase.expiry_date ), locale, { dateStyle: 'long' } ),
 					} )
@@ -208,7 +208,7 @@ export function PurchaseExpiryStatus( {
 		return (
 			<span>
 				{ sprintf(
-					// translators: date is a formatted date
+					// translators: %(date)s: a formatted date
 					__( 'Credit card expires before your next renewal on %(date)s' ),
 					{
 						date: formatDate( new Date( purchase.renew_date ), locale, { dateStyle: 'long' } ),
@@ -256,7 +256,7 @@ export function PurchaseExpiryStatus( {
 			case SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD:
 				return createInterpolateElement(
 					sprintf(
-						// translators: date is a formatted date, amount is a currency amount, and excludeTaxStringAbbreviation is something like "excludes VAT"
+						// translators: %(date)s: a formatted date, %(amount)s: a currency amount, excludeTaxStringAbbreviation: something like "excludes VAT"
 						__( 'Renews monthly at %(amount)s <excludeTaxStringAbbreviation /> on %(date)s' ),
 						translateArgs
 					),
@@ -265,7 +265,7 @@ export function PurchaseExpiryStatus( {
 			case SubscriptionBillPeriod.PLAN_ANNUAL_PERIOD:
 				return createInterpolateElement(
 					sprintf(
-						// translators: date is a formatted date, amount is a currency amount, and excludeTaxStringAbbreviation is something like "excludes VAT"
+						// translators: %(date)s: a formatted date, %(amount)s: a currency amount, excludeTaxStringAbbreviation: something like "excludes VAT"
 						__( 'Renews yearly at %(amount)s <excludeTaxStringAbbreviation /> on %(date)s' ),
 						translateArgs
 					),
@@ -274,7 +274,7 @@ export function PurchaseExpiryStatus( {
 			case SubscriptionBillPeriod.PLAN_BIENNIAL_PERIOD:
 				return createInterpolateElement(
 					sprintf(
-						// translators: date is a formatted date, amount is a currency amount, and excludeTaxStringAbbreviation is something like "excludes VAT"
+						// translators: %(date)s: a formatted date, %(amount)s: a currency amount, excludeTaxStringAbbreviation: something like "excludes VAT"
 						__(
 							'Renews every two years at %(amount)s <excludeTaxStringAbbreviation /> on %(date)s'
 						),
@@ -285,7 +285,7 @@ export function PurchaseExpiryStatus( {
 			case SubscriptionBillPeriod.PLAN_TRIENNIAL_PERIOD:
 				return createInterpolateElement(
 					sprintf(
-						// translators: date is a formatted date, amount is a currency amount, and excludeTaxStringAbbreviation is something like "excludes VAT"
+						// translators: %(date)s: a formatted date, %(amount)s: a currency amount, excludeTaxStringAbbreviation: something like "excludes VAT"
 						__(
 							'Renews every three years at %(amount)s <excludeTaxStringAbbreviation /> on %(date)s'
 						),
@@ -296,7 +296,7 @@ export function PurchaseExpiryStatus( {
 			default:
 				return createInterpolateElement(
 					sprintf(
-						// translators: date is a formatted date, amount is a currency amount, and excludeTaxStringAbbreviation is something like "excludes VAT"
+						// translators: %(date)s: a formatted date, %(amount)s: a currency amount, excludeTaxStringAbbreviation: something like "excludes VAT"
 						__( 'Renews at %(amount)s <excludeTaxStringAbbreviation /> on %(date)s' ),
 						translateArgs
 					),

--- a/client/dashboard/components/site-preview-link/index.tsx
+++ b/client/dashboard/components/site-preview-link/index.tsx
@@ -24,7 +24,7 @@ function getExpiryStringLessThanOneDay( expiryDate: Date, now: Date ) {
 
 	if ( expiryInSeconds < ONE_MINUTE_IN_SECONDS ) {
 		return sprintf(
-			// translators: %(seconds) is the number of seconds until the link expires.
+			// translators: %(seconds)d: the number of seconds until the link expires.
 			_n( 'Expires in %(seconds)d second', 'Expires in %(seconds)d seconds', expiryInSeconds ),
 			{ seconds: expiryInSeconds }
 		);
@@ -50,7 +50,7 @@ function getExpiryStringLessThanOneDay( expiryDate: Date, now: Date ) {
 
 	const days = Math.round( expiryInSeconds / ONE_DAY_IN_SECONDS );
 	return sprintf(
-		// translators: %(days) is the number of days until the link expires.
+		// translators: %(days)d: the number of days until the link expires.
 		_n( 'Expires in %(days)d day', 'Expires in %(days)d days', days ),
 		{ days }
 	);
@@ -83,7 +83,7 @@ const LinkExpiryCopy = ( { expiresAt }: LinkExpiryCopyProps ) => {
 	return (
 		<>
 			{ sprintf(
-				// translators: %(days) is the number of days until the link expires. We know it is at least 1 day.
+				// translators: %(days)d: the number of days until the link expires. We know it is at least 1 day.
 				_n( 'Expires in %(days)d day', 'Expires in %(days)d days', days ),
 				{ days }
 			) }

--- a/client/dashboard/components/time-since/index.tsx
+++ b/client/dashboard/components/time-since/index.tsx
@@ -32,7 +32,7 @@ function useRelativeTime( date: Date, locale: string, formatOptions?: Intl.DateT
 		// Minutes ago (less than 60 minutes)
 		if ( minutesAgo < 60 ) {
 			return sprintf(
-				/* translators: %s is the number of minutes. Example for a resulting string: 2m ago */
+				/* translators: %(minutes)d: the number of minutes. Example for a resulting string: 2m ago */
 				__( '%(minutes)dm ago' ),
 				{
 					minutes: minutesAgo,
@@ -43,7 +43,7 @@ function useRelativeTime( date: Date, locale: string, formatOptions?: Intl.DateT
 		// Hours ago (less than 24 hours)
 		if ( hoursAgo < 24 ) {
 			return sprintf(
-				/* translators: %s is the number of hours. Example for a resulting string: 5h ago */
+				/* translators: %(hours)d: the number of hours. Example for a resulting string: 5h ago */
 				__( '%(hours)dh ago' ),
 				{
 					hours: hoursAgo,
@@ -54,7 +54,7 @@ function useRelativeTime( date: Date, locale: string, formatOptions?: Intl.DateT
 		// Days ago (less than 7 days)
 		if ( daysAgo < 7 ) {
 			return sprintf(
-				/* translators: %s is the number of days. Example for a resulting string: 4d ago */
+				/* translators: %(days)d: the number of days. Example for a resulting string: 4d ago */
 				__( '%(days)dd ago' ),
 				{
 					days: daysAgo,

--- a/client/dashboard/domains/dataviews/auto-renew-modal.tsx
+++ b/client/dashboard/domains/dataviews/auto-renew-modal.tsx
@@ -43,7 +43,7 @@ export const AutoRenewModal = ( { items, onSuccess }: AutoRenewModalProps ) => {
 		);
 	};
 
-	/* translators: domainCount will be the number of domains to update */
+	/* translators: %(domainCount)d: the number of domains to update */
 	const helperText = sprintf( __( 'Managing auto-renewal settings for %(domainCount)d domains:' ), {
 		domainCount: items.length,
 	} );

--- a/client/dashboard/domains/domain-diagnostics/index.tsx
+++ b/client/dashboard/domains/domain-diagnostics/index.tsx
@@ -60,7 +60,7 @@ export default function DomainDiagnostics() {
 			message = record.error_message;
 		} else if ( record.status === 'incorrect' ) {
 			message = sprintf(
-				/* translators: dnsRecordType is a DNS record type, e.g. SPF, DKIM or DMARC */
+				/* translators: %(dnsRecordType)s: a DNS record type, e.g. SPF, DKIM or DMARC */
 				__( 'Your %(dnsRecordType)s record is incorrect. The correct record should be:' ),
 				{
 					dnsRecordType: uppercaseRecord,
@@ -68,7 +68,7 @@ export default function DomainDiagnostics() {
 			);
 		} else if ( record.status === 'not_found' ) {
 			message = sprintf(
-				/* translators: dnsRecordType is a DNS record type, e.g. SPF, DKIM or DMARC */
+				/* translators: %(dnsRecordType)s: a DNS record type, e.g. SPF, DKIM or DMARC */
 				__( 'There is no %(dnsRecordType)s record. The correct record should be:' ),
 				{
 					dnsRecordType: uppercaseRecord,

--- a/client/dashboard/domains/domain-overview/index.tsx
+++ b/client/dashboard/domains/domain-overview/index.tsx
@@ -84,12 +84,12 @@ export default function DomainOverview() {
 									{ ( () => {
 										switch ( domain.subtype.id ) {
 											case DomainSubtype.DOMAIN_CONNECTION:
-												// translators: date is the date the domain was connected.
+												// translators: %(date)s: the date the domain was connected.
 												return sprintf( __( 'Connected on %(date)s' ), {
 													date: formattedRegistrationDate,
 												} );
 											case DomainSubtype.DOMAIN_REGISTRATION:
-												// translators: date is the date the domain was registered.
+												// translators: %(date)s: the date the domain was registered.
 												return sprintf( __( 'Registered on %(date)s' ), {
 													date: formattedRegistrationDate,
 												} );

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-any-user.tsx
@@ -147,7 +147,7 @@ export default function TransferDomainToAnyUser() {
 					{ hasEmailWithUs && (
 						<Text as="p">
 							{ sprintf(
-								/* Translators: %s: domainName is the domain name */
+								/* translators: %(domainName)s: the domain name */
 								__(
 									'The email subscription for %(domainName)s will be transferred along with the domain.'
 								),

--- a/client/dashboard/domains/domains-contact-details/index.tsx
+++ b/client/dashboard/domains/domains-contact-details/index.tsx
@@ -145,7 +145,7 @@ export default function DomainsContactInfo() {
 	};
 
 	const editingMessage =
-		/* translators: %(domainCount) is the number of domains */
+		/* translators: %(domainCount)d: the number of domains */
 		_n(
 			'Editing contact details for %(domainCount)d domain:',
 			'Editing contact details for %(domainCount)d domains:',

--- a/client/dashboard/me/billing-payment-methods/index.tsx
+++ b/client/dashboard/me/billing-payment-methods/index.tsx
@@ -427,7 +427,7 @@ function PaymentMethodExpiry( { paymentMethod }: { paymentMethod: StoredPaymentM
 			<VStack>
 				<Text>
 					{ sprintf(
-						// translators: date is a formatted credit card expiration date, eg: 10/25
+						// translators: %(date)s: a formatted credit card expiration date, eg: 10/25
 						__( 'Expires %(date)s' ),
 						{
 							// The use of `MM/YY` should not be localized as it is an ISO standard across credit card forms: https://en.wikipedia.org/wiki/ISO/IEC_7813

--- a/client/dashboard/me/billing-payment-methods/payment-method-delete-dialog.tsx
+++ b/client/dashboard/me/billing-payment-methods/payment-method-delete-dialog.tsx
@@ -89,7 +89,7 @@ export const PaymentMethodDeleteDialog = ( {
 										{ isInExpirationGracePeriod( purchase )
 											? __( 'Pending renewal' )
 											: sprintf(
-													// translators: date is a formatted renewal date
+													// translators: %(date)s: a formatted renewal date
 													__( 'Renews on %(date)s' ),
 													{
 														date: formatDate( new Date( purchase.renew_date ), locale, {

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/jetpack-cancellation-offer-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/jetpack-cancellation-offer-step.tsx
@@ -51,13 +51,13 @@ const JetpackCancellationOfferStep: FC< Props > = ( props ) => {
 		switch ( purchase.bill_period_days ) {
 			case SubscriptionBillPeriod.PLAN_BIENNIAL_PERIOD:
 				offerHeadline = sprintf(
-					/* Translators: %(discount)d%% is a discount percentage like 15% or 20% */
+					/* translators: %(discount)d: a discount percentage like 15 or 20, %(name)s: the product name, %(periods)d: the number of renewal periods */
 					__( 'Get %(discount)d%% off %(name)s for your next %(periods)d two-year renewals' ),
 					headlineOptions.args
 				);
 				renewalCopy = createInterpolateElement(
 					sprintf(
-						/* Translators: %(renewalPrice)d%% is this price charged when the subscription renews */
+						/* translators: %(renewalPrice)s: the discounted renewal price, %(fullPrice)s: the regular renewal price, %(periods)d: the number of renewal periods */
 						__(
 							'Your subscription renews every two years. It will renew at <strong>%(renewalPrice)s / two years</strong> for the next %(periods)d two-year renewals. It will then renew at <strong>%(fullPrice)s / two years</strong> each following two-year renewal.'
 						),
@@ -67,13 +67,13 @@ const JetpackCancellationOfferStep: FC< Props > = ( props ) => {
 				);
 				if ( 1 === periods ) {
 					offerHeadline = sprintf(
-						/* Translators: %(discount)d%% is a discount percentage like 15% or 20% */
+						/* translators: %(discount)d: a discount percentage like 15 or 20, %(name)s: the product name, %(periods)d: the number of renewal periods */
 						__( 'Get %(discount)d%% off %(name)s for your next two-year renewal' ),
 						headlineOptions.args
 					);
 					renewalCopy = createInterpolateElement(
 						sprintf(
-							/* Translators: %(renewalPrice)d%% is this price charged when the subscription renews */
+							/* translators: %(renewalPrice)s: the discounted renewal price, %(fullPrice)s: the regular renewal price, %(periods)d: the number of renewal periods */
 							__(
 								'Your subscription renews every two years. It will renew at <strong>%(renewalPrice)s / two years</strong> for the next two years. It will then renew at <strong>%(fullPrice)s/ two years</strong> each following two-year renewal.'
 							),
@@ -85,13 +85,13 @@ const JetpackCancellationOfferStep: FC< Props > = ( props ) => {
 				break;
 			case SubscriptionBillPeriod.PLAN_ANNUAL_PERIOD:
 				offerHeadline = sprintf(
-					/* Translators: %(discount)d%% is a discount percentage like 15% or 20% */
+					/* translators: %(discount)d: a discount percentage like 15 or 20, %(name)s: the product name, %(periods)d: the number of renewal periods */
 					__( 'Get %(discount)d%% off %(name)s for the next %(periods)d years' ),
 					headlineOptions.args
 				);
 				renewalCopy = createInterpolateElement(
 					sprintf(
-						/* Translators: %(renewalPrice)d%% is this price charged when the subscription renews */
+						/* translators: %(renewalPrice)s: the discounted renewal price, %(fullPrice)s: the regular renewal price, %(periods)d: the number of renewal periods */
 						__(
 							'Your annual subscription will renew at <strong>%(renewalPrice)s/year</strong> for the next %(periods)d years. It will then renew at <strong>%(fullPrice)s/year</strong> each following year.'
 						),
@@ -101,13 +101,13 @@ const JetpackCancellationOfferStep: FC< Props > = ( props ) => {
 				);
 				if ( 1 === periods ) {
 					offerHeadline = sprintf(
-						/* Translators: %(discount)d%% is a discount percentage like 15% or 20% */
+						/* translators: %(discount)d: a discount percentage like 15 or 20, %(name)s: the product name, %(periods)d: the number of renewal periods */
 						__( 'Get %(discount)d%% off %(name)s for the next year' ),
 						headlineOptions.args
 					);
 					renewalCopy = createInterpolateElement(
 						sprintf(
-							/* Translators: %(renewalPrice)d%% is this price charged when the subscription renews */
+							/* translators: %(renewalPrice)s: the discounted renewal price, %(fullPrice)s: the regular renewal price, %(periods)d: the number of renewal periods */
 							__(
 								'Your annual subscription will renew at <strong>%(renewalPrice)s/year</strong> for the next year. It will then renew at <strong>%(fullPrice)s/year</strong> each following year.'
 							),
@@ -119,13 +119,13 @@ const JetpackCancellationOfferStep: FC< Props > = ( props ) => {
 				break;
 			case SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD:
 				offerHeadline = sprintf(
-					/* Translators: %(discount)d%% is a discount percentage like 15% or 20% */
+					/* translators: %(discount)d: a discount percentage like 15 or 20, %(name)s: the product name, %(periods)d: the number of renewal periods */
 					__( 'Get %(discount)d%% off %(name)s for the next %(periods)d months' ),
 					headlineOptions.args
 				);
 				renewalCopy = createInterpolateElement(
 					sprintf(
-						/* Translators: %(renewalPrice)d%% is this price charged when the subscription renews */
+						/* translators: %(renewalPrice)s: the discounted renewal price, %(fullPrice)s: the regular renewal price, %(periods)d: the number of renewal periods */
 						__(
 							'Your monthly subscription will renew at <strong>%(renewalPrice)s/month</strong> for the next %(periods)d months. It will then renew at <strong>%(fullPrice)s/month</strong> each following month.'
 						),
@@ -135,13 +135,13 @@ const JetpackCancellationOfferStep: FC< Props > = ( props ) => {
 				);
 				if ( 1 === periods ) {
 					offerHeadline = sprintf(
-						/* Translators: %(discount)d%% is a discount percentage like 15% or 20% */
+						/* translators: %(discount)d: a discount percentage like 15 or 20, %(name)s: the product name, %(periods)d: the number of renewal periods */
 						__( 'Get %(discount)d%% off %(name)s for the next month' ),
 						headlineOptions.args
 					);
 					renewalCopy = createInterpolateElement(
 						sprintf(
-							/* Translators: %(renewalPrice)d%% is this price charged when the subscription renews */
+							/* translators: %(renewalPrice)s: the discounted renewal price, %(fullPrice)s: the regular renewal price, %(periods)d: the number of renewal periods */
 							__(
 								'Your monthly subscription will renew at <strong>%(renewalPrice)s/month</strong> for the next month. It will then renew at <strong>%(fullPrice)s/month</strong> each following month.'
 							),

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/jetpack-cancellation-offer-step.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancel-purchase-form/step-components/jetpack-cancellation-offer-step.tsx
@@ -67,13 +67,13 @@ const JetpackCancellationOfferStep: FC< Props > = ( props ) => {
 				);
 				if ( 1 === periods ) {
 					offerHeadline = sprintf(
-						/* translators: %(discount)d: a discount percentage like 15 or 20, %(name)s: the product name, %(periods)d: the number of renewal periods */
+						/* translators: %(discount)d: a discount percentage like 15 or 20, %(name)s: the product name */
 						__( 'Get %(discount)d%% off %(name)s for your next two-year renewal' ),
 						headlineOptions.args
 					);
 					renewalCopy = createInterpolateElement(
 						sprintf(
-							/* translators: %(renewalPrice)s: the discounted renewal price, %(fullPrice)s: the regular renewal price, %(periods)d: the number of renewal periods */
+							/* translators: %(renewalPrice)s: the discounted renewal price, %(fullPrice)s: the regular renewal price */
 							__(
 								'Your subscription renews every two years. It will renew at <strong>%(renewalPrice)s / two years</strong> for the next two years. It will then renew at <strong>%(fullPrice)s/ two years</strong> each following two-year renewal.'
 							),
@@ -101,13 +101,13 @@ const JetpackCancellationOfferStep: FC< Props > = ( props ) => {
 				);
 				if ( 1 === periods ) {
 					offerHeadline = sprintf(
-						/* translators: %(discount)d: a discount percentage like 15 or 20, %(name)s: the product name, %(periods)d: the number of renewal periods */
+						/* translators: %(discount)d: a discount percentage like 15 or 20, %(name)s: the product name */
 						__( 'Get %(discount)d%% off %(name)s for the next year' ),
 						headlineOptions.args
 					);
 					renewalCopy = createInterpolateElement(
 						sprintf(
-							/* translators: %(renewalPrice)s: the discounted renewal price, %(fullPrice)s: the regular renewal price, %(periods)d: the number of renewal periods */
+							/* translators: %(renewalPrice)s: the discounted renewal price, %(fullPrice)s: the regular renewal price */
 							__(
 								'Your annual subscription will renew at <strong>%(renewalPrice)s/year</strong> for the next year. It will then renew at <strong>%(fullPrice)s/year</strong> each following year.'
 							),
@@ -135,13 +135,13 @@ const JetpackCancellationOfferStep: FC< Props > = ( props ) => {
 				);
 				if ( 1 === periods ) {
 					offerHeadline = sprintf(
-						/* translators: %(discount)d: a discount percentage like 15 or 20, %(name)s: the product name, %(periods)d: the number of renewal periods */
+						/* translators: %(discount)d: a discount percentage like 15 or 20, %(name)s: the product name */
 						__( 'Get %(discount)d%% off %(name)s for the next month' ),
 						headlineOptions.args
 					);
 					renewalCopy = createInterpolateElement(
 						sprintf(
-							/* translators: %(renewalPrice)s: the discounted renewal price, %(fullPrice)s: the regular renewal price, %(periods)d: the number of renewal periods */
+							/* translators: %(renewalPrice)s: the discounted renewal price, %(fullPrice)s: the regular renewal price */
 							__(
 								'Your monthly subscription will renew at <strong>%(renewalPrice)s/month</strong> for the next month. It will then renew at <strong>%(fullPrice)s/month</strong> each following month.'
 							),

--- a/client/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy.ts
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/get-confirmation-copy.ts
@@ -141,14 +141,14 @@ export function formatTimeRemaining( expiryDate: string | Date, from: Date = new
 	}
 	if ( parts.length === 2 ) {
 		return sprintf(
-			/* translators: joins two duration parts, e.g. "1 month and 11 days" */
+			/* translators: %1$s and %2$s are duration parts, e.g. "1 month and 11 days" */
 			__( '%1$s and %2$s' ),
 			parts[ 0 ],
 			parts[ 1 ]
 		);
 	}
 	return sprintf(
-		/* translators: joins three duration parts, e.g. "2 years, 3 months, and 14 days" */
+		/* translators: %1$s, %2$s and %3$s are duration parts, e.g. "2 years, 3 months, and 14 days" */
 		__( '%1$s, %2$s, and %3$s' ),
 		parts[ 0 ],
 		parts[ 1 ],

--- a/client/dashboard/me/billing-purchases/purchase-product.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-product.tsx
@@ -18,14 +18,14 @@ export function PurchaseProduct( { purchase, site }: { purchase: Purchase; site?
 			const linkTitle =
 				site.name === site.slug
 					? __( 'View site' )
-					: // translators: the siteName is the name of the site
+					: // translators: %(siteName)s: the name of the site
 					  sprintf( __( 'View %(siteName)s' ), { siteName: site.name } );
 			const linkText = site.name === site.slug ? __( 'View site' ) : site.slug;
 			return (
 				<div>
 					{ createInterpolateElement(
 						sprintf(
-							// translators: The string contains the product name, the name of the site, and the URL for the site e.g. Premium plan for Block Store (blockstore.com)
+							// translators: %(purchaseType)s: the product name. The string also contains the name of the site and the URL for the site e.g. Premium plan for Block Store (blockstore.com)
 							__( '%(purchaseType)s for <siteName /> (<siteDomain />)' ),
 							{
 								purchaseType: productType,
@@ -38,7 +38,7 @@ export function PurchaseProduct( { purchase, site }: { purchase: Purchase; site?
 									to={ purchasesRoute.fullPath }
 									search={ { site: site.ID } }
 									title={
-										// translators: the siteName is the name of the site
+										// translators: %(siteName)s: the name of the site
 										sprintf( __( 'View active upgrades for %(siteName)s' ), {
 											siteName: site.name,
 										} )
@@ -62,7 +62,7 @@ export function PurchaseProduct( { purchase, site }: { purchase: Purchase; site?
 			return (
 				<div>
 					{ createInterpolateElement(
-						// translators: The string contains the product name, the URL of the site, and a link to visit the site (e.g. "Premium plan for blockstore.com (view site)")
+						// translators: %(purchaseType)s: the product name. The string also contains the URL of the site and a link to visit the site (e.g. "Premium plan for blockstore.com (view site)")
 						sprintf( __( '%(purchaseType)s for <siteDomain /> (<viewSite />)' ), {
 							purchaseType: productType,
 						} ),
@@ -73,7 +73,7 @@ export function PurchaseProduct( { purchase, site }: { purchase: Purchase; site?
 									to={ purchasesRoute.fullPath }
 									search={ { site: site.ID } }
 									title={
-										// translators: the siteDomain is the domain of the site
+										// translators: %(siteDomain)s: the domain of the site
 										sprintf( __( 'View active upgrades for %(siteDomain)s' ), {
 											siteDomain: site.slug,
 										} )
@@ -101,7 +101,7 @@ export function PurchaseProduct( { purchase, site }: { purchase: Purchase; site?
 			const linkTitle =
 				site.name === site.slug
 					? __( 'View site' )
-					: // translators: the siteName is the name of the site
+					: // translators: %(siteName)s: the name of the site
 					  sprintf( __( 'View %(siteName)s' ), { siteName: site.name } );
 			const linkText = site.name === site.slug ? __( 'View site' ) : site.slug;
 			return (
@@ -116,7 +116,7 @@ export function PurchaseProduct( { purchase, site }: { purchase: Purchase; site?
 									to={ purchasesRoute.fullPath }
 									search={ { site: site.ID } }
 									title={
-										// translators: the siteName is the name of the site
+										// translators: %(siteName)s: the name of the site
 										sprintf( __( 'View active upgrades for %(siteName)s' ), {
 											siteName: site.name,
 										} )
@@ -142,7 +142,7 @@ export function PurchaseProduct( { purchase, site }: { purchase: Purchase; site?
 			<div>
 				{ createInterpolateElement(
 					sprintf(
-						// translators: The string contains the product name, the URL of the site, and a link to view the site (e.g. "Premium plan for blockstore.com (view site)")
+						// translators: %(purchaseType)s: the product name, %(site)s: the site domain, followed by a link to view the site (e.g. "Premium plan for blockstore.com (view site)")
 						__( '%(purchaseType)s for %(site)s (<viewSite />)' ),
 						{
 							purchaseType: productType,

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-expiring-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-expiring-notice.tsx
@@ -163,7 +163,7 @@ function ExpiringText( {
 
 		if ( purchase.is_attached_to_holding_site ) {
 			return sprintf(
-				// translators: purchaseName is the name of the plan and daysToExpiry is a number of days
+				// translators: %(purchaseName)s: the name of the plan, %(daysToExpiry)d: a number of days
 				__( '%(purchaseName)s will expire and be removed in %(daysToExpiry)d days.' ),
 				{
 					purchaseName,
@@ -173,11 +173,11 @@ function ExpiringText( {
 		}
 
 		const message = isDomainWithoutSite
-			? // translators: purchaseName is the name of the domain and daysToExpiry is a number of days
+			? // translators: %(purchaseName)s: the name of the domain, %(daysToExpiry)d: a number of days
 			  __(
 					'%(purchaseName)s will expire and be removed from your account in %(daysToExpiry)d days.'
 			  )
-			: // translators: purchaseName is the name of the plan and daysToExpiry is a number of days
+			: // translators: %(purchaseName)s: the name of the plan, %(daysToExpiry)d: a number of days
 			  __(
 					'%(purchaseName)s will expire and be removed from your site in %(daysToExpiry)d days.'
 			  );

--- a/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
@@ -130,7 +130,7 @@ export function UpcomingRenewalsDialog( {
 					<Heading>{ __( 'Upcoming renewals' ) }</Heading>
 					<Text variant="muted" className="upcoming-renewals-dialog__site-label">
 						{
-							// translators: siteName is the URL of the site
+							// translators: %(siteName)s: the URL of the site
 							sprintf( __( 'Site: %(siteName)s' ), { siteName: siteDomain } )
 						}
 					</Text>

--- a/client/dashboard/me/billing-tax-details/user-tax-form.tsx
+++ b/client/dashboard/me/billing-tax-details/user-tax-form.tsx
@@ -89,7 +89,7 @@ function VatIdControl( { data, field, onChange }: UserTaxFormControlProps ) {
 		! canUserEdit &&
 		createInterpolateElement(
 			sprintf(
-				/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
+				/* translators: %(taxName)s: the name of taxes in the country (eg: "VAT" or "GST"). */
 				__(
 					'To change your %(taxName)s ID, <contactSupportLink>please contact support</contactSupportLink>.'
 				),

--- a/client/dashboard/me/profile-gravatar/index.tsx
+++ b/client/dashboard/me/profile-gravatar/index.tsx
@@ -148,7 +148,7 @@ export default function GravatarProfileSection() {
 							title={ __( 'Public Gravatar profile' ) }
 							description={ createInterpolateElement(
 								sprintf(
-									/* translators: %1$s: User email */
+									/* translators: %s: User email */
 									__(
 										'Your WordPress profile is linked to Gravatar, making your Gravatar public by default. It might appear on other sites using Gravatar when logged in with <strong>%s</strong>. Manage your Gravatar settings on your <external>Gravatar profile</external>'
 									),

--- a/client/dashboard/plugins/manage/components/action-render-modal.tsx
+++ b/client/dashboard/plugins/manage/components/action-render-modal.tsx
@@ -365,7 +365,7 @@ export default function ActionRenderModal( {
 				const prefix = buildSuccessPrefix( actionId, items );
 				createSuccessNotice(
 					sprintf(
-						// translators: %d is the number of sites.
+						// translators: %1$s: the action performed, %2$d: the number of sites.
 						_n( '%1$s on %2$d site', '%1$s on %2$d sites', successCount, 'next-admin' ),
 						prefix,
 						successCount
@@ -379,7 +379,7 @@ export default function ActionRenderModal( {
 				const errorPrefix = buildErrorPrefix( actionId, items );
 				createErrorNotice(
 					sprintf(
-						// translators: %d is the number of sites.
+						// translators: %1$s: the action performed, %2$d: the number of sites.
 						_n( '%1$s on %2$d site', '%1$s on %2$d sites', errorCount, 'next-admin' ),
 						errorPrefix,
 						errorCount

--- a/client/dashboard/plugins/plugin/index.tsx
+++ b/client/dashboard/plugins/plugin/index.tsx
@@ -70,7 +70,7 @@ export function PluginTabs( {
 					<SectionHeader
 						level={ 3 }
 						title={ sprintf(
-							// translators: %(count) is the number of sites the plugin is installed on.
+							// translators: %(count)d: the number of sites the plugin is installed on.
 							_n(
 								'Installed on %(count)d site',
 								'Installed on %(count)d sites',

--- a/client/dashboard/plugins/scheduled-updates/helpers.ts
+++ b/client/dashboard/plugins/scheduled-updates/helpers.ts
@@ -206,30 +206,30 @@ export function prepareScheduleName( locale: string, schedule: ScheduledUpdateRo
 	const dayNumber = new Date( schedule.nextUpdate * 1000 ).getDay();
 
 	if ( schedule.schedule === 'daily' ) {
-		/* translators: Daily at 10 am. */
+		/* translators: %s: a time of day, e.g. 10 am. */
 		return sprintf( __( 'Daily at %s' ), time );
 	} else if ( schedule.schedule === 'weekly' ) {
 		switch ( dayNumber ) {
 			case 0:
-				/* translators: Sundays at 10 am. */
+				/* translators: %s: a time of day, e.g. 10 am. */
 				return sprintf( __( 'Sundays at %s' ), time );
 			case 1:
-				/* translators: Mondays at 10 am. */
+				/* translators: %s: a time of day, e.g. 10 am. */
 				return sprintf( __( 'Mondays at %s' ), time );
 			case 2:
-				/* translators: Tuesdays at 10 am. */
+				/* translators: %s: a time of day, e.g. 10 am. */
 				return sprintf( __( 'Tuesdays at %s' ), time );
 			case 3:
-				/* translators: Wednesdays at 10 am. */
+				/* translators: %s: a time of day, e.g. 10 am. */
 				return sprintf( __( 'Wednesdays at %s' ), time );
 			case 4:
-				/* translators: Thursdays at 10 am. */
+				/* translators: %s: a time of day, e.g. 10 am. */
 				return sprintf( __( 'Thursdays at %s' ), time );
 			case 5:
-				/* translators: Fridays at 10 am. */
+				/* translators: %s: a time of day, e.g. 10 am. */
 				return sprintf( __( 'Fridays at %s' ), time );
 			case 6:
-				/* translators: Saturdays at 10 am. */
+				/* translators: %s: a time of day, e.g. 10 am. */
 				return sprintf( __( 'Saturdays at %s' ), time );
 		}
 	}

--- a/client/dashboard/sites/backup-download/index.tsx
+++ b/client/dashboard/sites/backup-download/index.tsx
@@ -152,7 +152,7 @@ function SiteBackupDownload() {
 							title={ __( 'Download point' ) }
 							level={ 3 }
 							description={ createInterpolateElement(
-								/* translators: %s is the date of the download point */
+								/* translators: %(downloadPointDate)s: the date of the download point */
 								sprintf( __( '%(downloadPointDate)s. <LearnMore />' ), {
 									downloadPointDate,
 								} ),

--- a/client/dashboard/sites/backup-restore/index.tsx
+++ b/client/dashboard/sites/backup-restore/index.tsx
@@ -128,7 +128,7 @@ function SiteBackupRestore() {
 							title={ __( 'Restore point' ) }
 							level={ 3 }
 							description={ createInterpolateElement(
-								/* translators: %s is the date of the restore point */
+								/* translators: %(restorePointDate)s: the date of the restore point */
 								sprintf( __( '%(restorePointDate)s. <LearnMore />' ), {
 									restorePointDate,
 								} ),

--- a/client/dashboard/sites/overview-performance-card/index.tsx
+++ b/client/dashboard/sites/overview-performance-card/index.tsx
@@ -61,7 +61,7 @@ function PerformanceCardContentWithFinishedTests( {
 	} else {
 		const recommendationCount = Object.keys( report.audits ).length;
 		description = sprintf(
-			// translators: %d is the number of performance recommendations available.
+			// translators: %d: the number of performance recommendations available.
 			_n( '%d recommendation available.', '%d recommendations available.', recommendationCount ),
 			recommendationCount
 		);

--- a/client/dashboard/sites/overview/storage-warning-banner.tsx
+++ b/client/dashboard/sites/overview/storage-warning-banner.tsx
@@ -67,7 +67,7 @@ export function StorageWarningBanner( { site }: { site: Site } ) {
 				}
 			>
 				{ sprintf(
-					// translators: "used" and "available" amounts data including a unit, e.g. "2.03 MB" or "1.5 GB".
+					// translators: %(used)s: amount of storage used, %(available)s: the storage limit, each including a unit, e.g. "2.03 MB" or "1.5 GB".
 					__(
 						'%(used)s of your %(available)s storage limit has been used. Upgrade to continue storing media, plugins, themes, and backups.'
 					),

--- a/client/dashboard/sites/scan/index.tsx
+++ b/client/dashboard/sites/scan/index.tsx
@@ -138,7 +138,7 @@ function SiteScan( { scanTab }: { scanTab: 'active' | 'history' } ) {
 										} }
 									>
 										{ sprintf(
-											/* translators: %d: number of threats */
+											/* translators: %(threatsCount)d: number of threats */
 											_n(
 												'Auto-fix %(threatsCount)d threat',
 												'Auto-fix %(threatsCount)d threats',

--- a/client/dashboard/utils/domain-permissions.ts
+++ b/client/dashboard/utils/domain-permissions.ts
@@ -81,7 +81,7 @@ const DOMAIN_PERMISSION_CHECKS = {
 			check: checkCurrentUserIsOwner,
 			getErrorMessage: ( domain: Domain ) =>
 				sprintf(
-					/* translators: domain is the domain name, owner is the owner of the domain */
+					/* translators: %(domain)s: the domain name, %(owner)s: the owner of the domain */
 					__( '%(domain)s transfers can be managed only by the user %(owner)s.' ),
 					{ domain: domain.domain, owner: domain.owner }
 				),
@@ -99,7 +99,7 @@ const DOMAIN_PERMISSION_CHECKS = {
 			check: checkCurrentUserIsOwner,
 			getErrorMessage: ( domain: Domain ) =>
 				sprintf(
-					/* translators: domain is the domain name, owner is the owner of the domain */
+					/* translators: %(domain)s: the domain name, %(owner)s: the owner of the domain */
 					__( '%(domain)s can be transferred only by the user {{strong}}%(owner)s{{/strong}}.' ),
 					{ domain: domain.domain, owner: domain.owner }
 				),
@@ -108,7 +108,7 @@ const DOMAIN_PERMISSION_CHECKS = {
 			check: checkNotRedeemable,
 			getErrorMessage: ( domain: Domain ) =>
 				sprintf(
-					/* translators: domain is the domain name */
+					/* translators: %(domain)s: the domain name */
 					__( '%(domain)s is in redemption so it is not possible to transfer it.' ),
 					{ domain: domain.domain }
 				),
@@ -117,7 +117,7 @@ const DOMAIN_PERMISSION_CHECKS = {
 			check: checkNotHundredYearDomain,
 			getErrorMessage: ( domain: Domain ) =>
 				sprintf(
-					/* translators: domain is the domain name */
+					/* translators: %(domain)s: the domain name */
 					__( '%(domain)s is a 100-year domain and cannot be transferred.' ),
 					{ domain: domain.domain }
 				),
@@ -130,7 +130,7 @@ const DOMAIN_PERMISSION_CHECKS = {
 			check: checkNotAftermarketAuction,
 			getErrorMessage: ( domain: Domain ) =>
 				sprintf(
-					/* translators: domain is the domain name */
+					/* translators: %(domain)s: the domain name */
 					__(
 						'%(domain)s expired over 30 days ago and has been offered for sale at auction. Currently it is not possible to renew it.'
 					),
@@ -182,7 +182,7 @@ const DOMAIN_PERMISSION_CHECKS = {
 			check: checkCurrentUserIsOwner,
 			getErrorMessage: ( domain: Domain ) =>
 				sprintf(
-					/* translators: domain is the domain name, owner is the owner of the domain */
+					/* translators: %(domain)s: the domain name, %(owner)s: the owner of the domain */
 					__( '%(domain)s contact info can be managed only by the user %(owner)s.' ),
 					{ domain: domain.domain, owner: domain.owner }
 				),
@@ -207,7 +207,7 @@ const DOMAIN_PERMISSION_CHECKS = {
 			check: checkCurrentUserIsOwner,
 			getErrorMessage: ( domain: Domain ) =>
 				sprintf(
-					/* translators: domain is the domain name, owner is the owner of the domain */
+					/* translators: %(domain)s: the domain name, %(owner)s: the owner of the domain */
 					__( '%(domain)s contact verification can be managed only by the user %(owner)s.' ),
 					{ domain: domain.domain, owner: domain.owner }
 				),


### PR DESCRIPTION
## Proposed Changes

* Fix all `@wordpress/i18n-translator-comments` errors in `client/dashboard` (comment-only changes, no string or logic changes).
* The rule tokenizes comment words, and words starting with `s`/`d`/`f` (e.g. "date", "seconds") are consumed as printf format specifiers, so prose like “date is a formatted date” never satisfies it. Comments are rewritten to the canonical `%(placeholder)s: description` form.

## Why are these changes being made?

* A stricter shared ESLint config recently landed on trunk, leaving `client/dashboard/` with pre-existing lint failures. This is part of a series of PRs fixing them one rule class at a time. Each PR leaves every file it touches fully lint-clean, so the "Code style" CI check (which lints whole changed files) passes independently of the sibling PRs.

## Testing Instructions

* Run `yarn eslint client/dashboard` — no `@wordpress/i18n-translator-comments` failures remain. Comment-only change; no runtime behavior change.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
