### PR TITLE
Dashboard: remove explicit any types

### DIFF
--- a/client/dashboard/app/hooks/test/use-persistent-view.test.tsx
+++ b/client/dashboard/app/hooks/test/use-persistent-view.test.tsx
@@ -43,19 +43,20 @@ function createTestWrapper() {
 	return { Wrapper, getRouter: () => router };
 }
 
-function mockGetCalypsoPreferences( preferences: any ) {
+function mockGetCalypsoPreferences( preferences: Record< string, unknown > ) {
 	return nock( 'https://public-api.wordpress.com' )
 		.get( '/rest/v1.1/me/preferences' )
 		.reply( 200, { calypso_preferences: preferences } );
 }
 
-function mockUpdateCalypsoPreferences( preferences?: any ) {
+function mockUpdateCalypsoPreferences( preferences?: Record< string, unknown > ) {
 	return nock( 'https://public-api.wordpress.com' )
 		.post(
 			'/rest/v1.1/me/preferences',
-			preferences && {
-				calypso_preferences: preferences,
-			}
+			preferences &&
+				( {
+					calypso_preferences: preferences,
+				} as nock.DataMatcherMap )
 		)
 		.reply( 200 );
 }

--- a/client/dashboard/app/hooks/use-persistent-view.ts
+++ b/client/dashboard/app/hooks/use-persistent-view.ts
@@ -7,6 +7,14 @@ import { setTransientQueryParamsAtPathname } from '../transient-query-params';
 import type { AnyRouteMatch } from '@tanstack/react-router';
 import type { Filter, View } from '@wordpress/dataviews';
 
+type QueryParams = Record< string, unknown >;
+
+type UseViewNavigate = ( options: {
+	search: QueryParams;
+	replace?: boolean;
+	resetScroll?: boolean;
+} ) => void;
+
 export interface UseViewOptions {
 	/**
 	 * Unique slug to identify the view.
@@ -23,7 +31,7 @@ export interface UseViewOptions {
 	 * The URL query params in the current page.
 	 * If passed, transient properties (`page` and `search`) are synced to the URL query params.
 	 */
-	queryParams?: any;
+	queryParams?: QueryParams;
 
 	/**
 	 * Fields that should become transient filters when present in the URL query params.
@@ -48,7 +56,9 @@ export function usePersistentView( options: UseViewOptions ) {
 
 	return useBasePersistentView( {
 		...options,
-		navigate,
+		// The TanStack navigate function is wider than UseViewNavigate, but its
+		// loosely-typed `search` option rejects plain query param objects.
+		navigate: navigate as unknown as UseViewNavigate,
 		matches,
 	} );
 }
@@ -63,14 +73,7 @@ export function useBasePersistentView( {
 	navigate,
 }: UseViewOptions & {
 	matches?: AnyRouteMatch[];
-	navigate: ( {
-		search,
-		replace,
-	}: {
-		search: any;
-		replace?: boolean;
-		resetScroll?: boolean;
-	} ) => void;
+	navigate: UseViewNavigate;
 } ): {
 	view: View;
 	updateView: ( newView: View ) => void;
@@ -83,8 +86,8 @@ export function useBasePersistentView( {
 
 	const baseView = persistedView ?? defaultView;
 
-	const page = parseInt( queryParams?.page ) || baseView.page || 1;
-	const search = queryParams?.search || baseView.search || '';
+	const page = parseInt( queryParams?.page as string ) || baseView.page || 1;
+	const search = ( queryParams?.search as string ) || baseView.search || '';
 
 	const transientProperties = useMemo( () => ( { page, search } ), [ page, search ] );
 
@@ -95,12 +98,12 @@ export function useBasePersistentView( {
 	const [ transientFilters, setTransientFilters ] = useState< Filter[] >( () =>
 		queryParamFilterFields
 			.filter( ( field ) => queryParams && queryParams[ field ] !== undefined )
-			.map( ( field ) => getTransientFilter( field, queryParams[ field ] ) )
+			.map( ( field ) => getTransientFilter( field, queryParams?.[ field ] ) )
 	);
 
 	useEffect( () => {
 		setTransientFilters(
-			transientFilterFields.map( ( field ) => getTransientFilter( field, queryParams[ field ] ) )
+			transientFilterFields.map( ( field ) => getTransientFilter( field, queryParams?.[ field ] ) )
 		);
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -113,7 +116,7 @@ export function useBasePersistentView( {
 
 		let transientQueryParams: Record< string, unknown > = {};
 		transientFilters.forEach( ( { field } ) => {
-			transientQueryParams[ field ] = queryParams[ field ];
+			transientQueryParams[ field ] = queryParams?.[ field ];
 		} );
 		transientQueryParams = mergeQueryParamsWithTransientProperties(
 			transientQueryParams,
@@ -154,7 +157,10 @@ export function useBasePersistentView( {
 					newView.filters?.some(
 						( filter ) =>
 							filter.field === field &&
-							fastDeepEqual( filter.value, getTransientFilter( field, queryParams[ field ] ).value )
+							fastDeepEqual(
+								filter.value,
+								getTransientFilter( field, queryParams?.[ field ] ).value
+							)
 					)
 			);
 
@@ -247,7 +253,10 @@ function removeEmptyFiltersFromView( view: View ): View {
 	return view;
 }
 
-function clearQueryParamsFromTransientFilters( queryParams: any, transientFilterFields: string[] ) {
+function clearQueryParamsFromTransientFilters(
+	queryParams: QueryParams,
+	transientFilterFields: string[]
+) {
 	const newQueryParams = { ...queryParams };
 
 	transientFilterFields.forEach( ( field ) => {
@@ -258,9 +267,9 @@ function clearQueryParamsFromTransientFilters( queryParams: any, transientFilter
 }
 
 function mergeQueryParamsWithTransientProperties(
-	queryParams: any,
+	queryParams: QueryParams | undefined,
 	{ page, search }: { page?: number; search?: string }
-): any {
+): QueryParams {
 	const newQueryParams = { ...queryParams };
 
 	if ( page === 1 ) {

--- a/client/dashboard/components/dataviews/dataviews.tsx
+++ b/client/dashboard/components/dataviews/dataviews.tsx
@@ -2,9 +2,13 @@ import { DataViews as WPDataViews } from '@wordpress/dataviews';
 import { useEffect, useLayoutEffect, useRef } from 'react';
 import { isDashboardBackport } from '../../utils/is-dashboard-backport';
 import { sanitizeView } from './sanitize-view';
-import type { ComponentProps } from 'react';
+import type { ComponentProps, ComponentType } from 'react';
 
 type WPDataViewsProps< Item > = ComponentProps< typeof WPDataViews< Item > >;
+
+// `WPDataViews` declares `getItemId` via a conditional type on `Item`, which TS
+// cannot verify when spreading generic props, so spread through a loose alias.
+const LooseWPDataViews = WPDataViews as unknown as ComponentType< Record< string, unknown > >;
 
 export type DataViewsProps< Item > = WPDataViewsProps< Item > & {
 	isPlaceholderData?: boolean;
@@ -39,7 +43,8 @@ export function DataViews< Item >( { view, isPlaceholderData, ...props }: DataVi
 
 	const sanitizedView = sanitizeView( view, props.fields );
 
-	return <WPDataViews< Item > view={ sanitizedView } { ...( props as any ) } />;
+	const dataViewsProps = { ...props, view: sanitizedView };
+	return <LooseWPDataViews { ...dataViewsProps } />;
 }
 
 DataViews.Layout = WPDataViews.Layout;

--- a/client/dashboard/components/dataviews/sanitize-view.ts
+++ b/client/dashboard/components/dataviews/sanitize-view.ts
@@ -3,7 +3,7 @@ import type { Field, View } from '@wordpress/dataviews';
 /**
  * Sanitize view by removing any invalid or malformed entries.
  */
-export function sanitizeView( view: View, fields: Field< any >[] ) {
+export function sanitizeView< Item >( view: View, fields: Field< Item >[] ) {
 	// If no sanitization is needed then a reference to the same object should be returned.
 	const sanitized = view;
 	const fieldsSet = new Set( fields.map( ( field ) => field.id ) );

--- a/client/dashboard/components/dataviews/test/sanitize-view.test.ts
+++ b/client/dashboard/components/dataviews/test/sanitize-view.test.ts
@@ -6,7 +6,7 @@ import { sanitizeView } from '../sanitize-view';
 import type { Field, View } from '@wordpress/dataviews';
 
 describe( 'sanitizeView', () => {
-	const fields: Field< any >[] = [
+	const fields: Field< Record< string, unknown > >[] = [
 		{ id: 'name', enableSorting: true },
 		{ id: 'is_deleted', enableSorting: false },
 		{ id: 'visibility', enableSorting: true },

--- a/client/dashboard/domains/dataviews/sort-nullable-strings.ts
+++ b/client/dashboard/domains/dataviews/sort-nullable-strings.ts
@@ -4,7 +4,7 @@ import type { SortDirection } from '@wordpress/dataviews';
  * Sort comparator for nullable string field values. Null/undefined values sort
  * to the end regardless of direction.
  */
-export function sortNullableStrings( a: any, b: any, direction: SortDirection ) {
+export function sortNullableStrings( a: unknown, b: unknown, direction: SortDirection ) {
 	if ( a == null && b == null ) {
 		return 0;
 	}

--- a/client/dashboard/domains/domain-forwarding/test/add.test.tsx
+++ b/client/dashboard/domains/domain-forwarding/test/add.test.tsx
@@ -6,24 +6,26 @@ import userEvent from '@testing-library/user-event';
 import { render } from '../../../test-utils';
 import DomainForwardingForm from '../form';
 import type { FormData } from '../form';
+import type { DomainForwarding } from '@automattic/api-core';
 
 const domainName = 'example.com';
 
 interface TestFormProps {
 	forceSubdomain?: boolean;
-	initialData?: any;
+	initialData?: Partial< DomainForwarding > | null;
 	onSubmit?: ( data: FormData ) => void;
 	isSubmitting?: boolean;
 	submitButtonText?: string;
 }
 
-function renderForm( props: TestFormProps = {} ) {
+function renderForm( { initialData, ...props }: TestFormProps = {} ) {
 	const defaultProps = {
 		domainName,
 		onSubmit: jest.fn(),
 		isSubmitting: false,
 		submitButtonText: 'Add',
 		forceSubdomain: false,
+		initialData: initialData as DomainForwarding | null | undefined,
 		...props,
 	};
 

--- a/client/dashboard/domains/domain-forwarding/test/edit.test.tsx
+++ b/client/dashboard/domains/domain-forwarding/test/edit.test.tsx
@@ -6,23 +6,25 @@ import userEvent from '@testing-library/user-event';
 import { render } from '../../../test-utils';
 import DomainForwardingForm from '../form';
 import type { FormData } from '../form';
+import type { DomainForwarding } from '@automattic/api-core';
 
 const domainName = 'example.com';
 
 interface TestFormProps {
 	forceSubdomain?: boolean;
-	initialData?: any;
+	initialData?: Partial< DomainForwarding > | null;
 	onSubmit?: ( data: FormData ) => void;
 	isSubmitting?: boolean;
 }
 
-function renderEditForm( props: TestFormProps = {} ) {
+function renderEditForm( { initialData, ...props }: TestFormProps = {} ) {
 	const defaultProps = {
 		domainName,
 		onSubmit: jest.fn(),
 		isSubmitting: false,
 		submitButtonText: 'Update',
 		forceSubdomain: false,
+		initialData: initialData as DomainForwarding | null | undefined,
 		...props,
 	};
 

--- a/client/dashboard/me/mcp/index.tsx
+++ b/client/dashboard/me/mcp/index.tsx
@@ -132,7 +132,7 @@ function McpComponent() {
 					account: accountAbilities,
 					...( sitesToReset.length > 0 && { sites: sitesToReset } ),
 				},
-			} as any,
+			},
 			{
 				onSuccess: () => {
 					recordTracksEvent( 'calypso_dashboard_mcp_account_toggled', { enabled } );

--- a/client/dashboard/me/mcp/mcp-sites/index.tsx
+++ b/client/dashboard/me/mcp/mcp-sites/index.tsx
@@ -23,7 +23,7 @@ import SiteIcon from '../../../components/site-icon';
 import { getSiteDisplayName } from '../../../utils/site-name';
 import { getSiteDisplayUrl } from '../../../utils/site-url';
 import PreferencesLoginSiteDropdown from '../../preferences-primary-site/site-dropdown';
-import type { Site } from '@automattic/api-core';
+import type { McpAbility, Site } from '@automattic/api-core';
 
 export default function McpMcpSites() {
 	const { recordTracksEvent } = useAnalytics();
@@ -38,7 +38,7 @@ export default function McpMcpSites() {
 	const [ selectedSiteId, setSelectedSiteId ] = useState< string | null >( null );
 
 	const mcpAbilities = getAccountMcpAbilities( userSettings || {} );
-	const mcpEnabled = Object.values( mcpAbilities ).some( ( tool: any ) => tool.enabled );
+	const mcpEnabled = Object.values( mcpAbilities ).some( ( tool: McpAbility ) => tool.enabled );
 
 	const disabledSiteIds = getDisabledSiteIds( userSettings || {} );
 	const enabledSiteIds = getEnabledSiteIds( userSettings || {} );
@@ -86,7 +86,7 @@ export default function McpMcpSites() {
 						},
 					],
 				},
-			} as any,
+			},
 			{
 				onSuccess: () => {
 					recordTracksEvent( eventName, { site_id: siteId } );
@@ -101,7 +101,7 @@ export default function McpMcpSites() {
 				mcp_abilities: {
 					sites: [ { blog_id: siteId, site_level_enabled: null } ],
 				},
-			} as any,
+			},
 			{
 				onSuccess: () => {
 					recordTracksEvent( 'calypso_dashboard_mcp_site_removed', { site_id: siteId } );

--- a/client/dashboard/me/mcp/read/index.tsx
+++ b/client/dashboard/me/mcp/read/index.tsx
@@ -66,7 +66,7 @@ export default function McpRead() {
 						[ toolId ]: enabled,
 					},
 				},
-			} as any,
+			},
 			{
 				onSuccess: () => {
 					recordTracksEvent( 'calypso_dashboard_mcp_read_tool_toggled', {
@@ -92,7 +92,7 @@ export default function McpRead() {
 				mcp_abilities: {
 					account: accountAbilities,
 				},
-			} as any,
+			},
 			{
 				onSuccess: () => {
 					recordTracksEvent( 'calypso_dashboard_mcp_read_enable_all_toggled', {

--- a/client/dashboard/me/mcp/write/index.tsx
+++ b/client/dashboard/me/mcp/write/index.tsx
@@ -64,7 +64,7 @@ export default function McpWrite() {
 						[ toolId ]: enabled,
 					},
 				},
-			} as any,
+			},
 			{
 				onSuccess: () => {
 					recordTracksEvent( 'calypso_dashboard_mcp_write_tool_toggled', {
@@ -90,7 +90,7 @@ export default function McpWrite() {
 				mcp_abilities: {
 					account: accountAbilities,
 				},
-			} as any,
+			},
 			{
 				onSuccess: () => {
 					recordTracksEvent( 'calypso_dashboard_mcp_write_enable_all_toggled', {

--- a/client/dashboard/me/security-social-logins/google-login.tsx
+++ b/client/dashboard/me/security-social-logins/google-login.tsx
@@ -12,6 +12,17 @@ import { useAnalytics } from '../../app/analytics';
 import { wpcomLink } from '../../utils/link';
 import type { SocialLoginButtonProps } from './types';
 
+interface GoogleOAuth2 {
+	initCodeClient: ( config: {
+		client_id: string;
+		scope: string;
+		ux_mode: string;
+		redirect_uri: string;
+		state: string;
+		callback: ( response: { error: string; code: string; state: string } ) => void;
+	} ) => { requestCode: () => void };
+}
+
 // This component supports only Social Login from Google.
 // It is used only in the Security page for now to connect and disconnect Google accounts.
 // We can extend other flows in the future.
@@ -30,7 +41,9 @@ export default function GoogleLogin( {
 	const [ showLoading, setShowLoading ] = useState( false );
 
 	const loadGoogleIdentityServicesAPI = async () => {
-		const windowObj = window as unknown as Window & { google: { accounts: { oauth2: any } } };
+		const windowObj = window as unknown as Window & {
+			google?: { accounts?: { oauth2?: GoogleOAuth2 } };
+		};
 
 		if ( ! windowObj?.google?.accounts?.oauth2 ) {
 			try {

--- a/client/dashboard/plugins/plugin/sites-without-this-plugin.tsx
+++ b/client/dashboard/plugins/plugin/sites-without-this-plugin.tsx
@@ -38,12 +38,23 @@ type SitesWithoutThisPluginProps = {
 	sitesWithoutThisPlugin: Site[];
 };
 
-const getPluginInstallErrorCode = ( source: any ): string | undefined =>
-	source?.code ||
-	source?.data?.code ||
-	source?.error ||
-	source?.body?.error ||
-	source?.body?.data?.code;
+type PluginInstallErrorSource = {
+	code?: string;
+	error?: string;
+	data?: { code?: string };
+	body?: { error?: string; data?: { code?: string } };
+};
+
+const getPluginInstallErrorCode = ( source: unknown ): string | undefined => {
+	const errorSource = source as PluginInstallErrorSource | null | undefined;
+	return (
+		errorSource?.code ||
+		errorSource?.data?.code ||
+		errorSource?.error ||
+		errorSource?.body?.error ||
+		errorSource?.body?.data?.code
+	);
+};
 
 const handlePluginAlreadyInstalled = ( {
 	displayPluginName,
@@ -145,7 +156,7 @@ export const SitesWithoutThisPlugin = ( {
 						}
 
 						installPluginMutate( { siteId: site.ID, slug: pluginSlug } )
-							.then( ( response: any ) => {
+							.then( ( response ) => {
 								// In some cases the API can return HTTP 200 with an error code
 								// in the response body (e.g., plugin_already_installed). Detect
 								// that case here and treat it like the error path below.
@@ -175,7 +186,7 @@ export const SitesWithoutThisPlugin = ( {
 								// Invalidate the cache once more to trigger a delayed check to avoid inconsistent states.
 								setTimeout( () => invalidatePlugins(), 2000 );
 							} )
-							.catch( ( error: any ) => {
+							.catch( ( error ) => {
 								const errorCode = getPluginInstallErrorCode( error );
 
 								if ( errorCode === 'plugin_already_installed' ) {

--- a/client/dashboard/sites/performance/performance-insight-table.tsx
+++ b/client/dashboard/sites/performance/performance-insight-table.tsx
@@ -7,10 +7,11 @@ import type {
 	SitePerformanceReport,
 	PerformanceMetricAuditDetails,
 	PerformanceMetricAuditDetailsItem,
+	PerformanceMetricAuditDetailsItemObject,
 } from '@automattic/api-core';
 
 const renderNode = (
-	data: { [ key: string ]: any },
+	data: PerformanceMetricAuditDetailsItemObject,
 	fullPageScreenshot: SitePerformanceReport[ 'fullPageScreenshot' ]
 ) => {
 	const rect = data.boundingRect;
@@ -19,7 +20,7 @@ const renderNode = (
 		const maxThumbnailSize = { width: 147, height: 100 };
 		return (
 			<InsightScreenshotWithOverlay
-				nodeId={ data.lhId }
+				nodeId={ data.lhId ?? '' }
 				screenshot={ fullPageScreenshot.screenshot }
 				elementRectSC={ rect }
 				maxRenderSizeDC={ maxThumbnailSize }

--- a/client/dashboard/sites/settings-ai-tools/read/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/read/index.tsx
@@ -61,8 +61,7 @@ export default function SiteAIToolsRead() {
 	// When there are no site-specific overrides, use site_level_enabled_default as the effective
 	// enabled state for every tool. True when account MCP is on, false when it's disabled for sites.
 	const hasSiteAbilityOverrides = Object.keys( siteAbilities ).length > 0;
-	const defaultToolEnabled =
-		( userSettings as any )?.mcp_abilities?.site_level_enabled_default ?? false;
+	const defaultToolEnabled = userSettings?.mcp_abilities?.site_level_enabled_default ?? false;
 	const mcpAbilities = hasSiteAbilityOverrides
 		? mergedAbilities
 		: Object.fromEntries(

--- a/client/dashboard/sites/settings-ai-tools/write/index.tsx
+++ b/client/dashboard/sites/settings-ai-tools/write/index.tsx
@@ -61,8 +61,7 @@ export default function SiteAIToolsWrite() {
 	// When there are no site-specific overrides, use site_level_enabled_default as the effective
 	// enabled state for every tool. True when account MCP is on, false when it's disabled for sites.
 	const hasSiteAbilityOverrides = Object.keys( siteAbilities ).length > 0;
-	const defaultToolEnabled =
-		( userSettings as any )?.mcp_abilities?.site_level_enabled_default ?? false;
+	const defaultToolEnabled = userSettings?.mcp_abilities?.site_level_enabled_default ?? false;
 	const mcpAbilities = hasSiteAbilityOverrides
 		? mergedAbilities
 		: Object.fromEntries(

--- a/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/ssh-card.tsx
@@ -273,7 +273,7 @@ export default function SshCard( {
 						help={ field.description }
 						options={ field.elements }
 						disabled={ ! hasUserSshKeys }
-						onChange={ ( newValue: any ) =>
+						onChange={ ( newValue: string ) =>
 							onChange( {
 								[ field.id ]: newValue,
 							} )

--- a/packages/api-core/src/me-settings/mutators.ts
+++ b/packages/api-core/src/me-settings/mutators.ts
@@ -1,8 +1,8 @@
 import { wpcom } from '../wpcom-fetcher';
-import type { PasswordValidationResponse, UserSettings } from './types';
+import type { PasswordValidationResponse, UserSettings, UserSettingsUpdate } from './types';
 
 export async function updateUserSettings(
-	data: Partial< UserSettings >
+	data: UserSettingsUpdate
 ): Promise< Partial< UserSettings > > {
 	const saveableKeys: ( keyof UserSettings )[] = [
 		'first_name',

--- a/packages/api-core/src/me-settings/types.ts
+++ b/packages/api-core/src/me-settings/types.ts
@@ -39,6 +39,24 @@ export type McpAbilities = {
 	site_level_enabled_default?: boolean;
 };
 
+export type McpSiteOverrideUpdate = {
+	blog_id: number;
+	account_tools_enabled?: boolean | null;
+	site_level_enabled?: boolean | null;
+	abilities?: Record< string, unknown >;
+};
+
+/**
+ * Update payload for MCP abilities. Unlike the read shape, ability toggles are
+ * sent as booleans keyed by tool ID.
+ */
+export type McpAbilitiesUpdate = {
+	account?: Record< string, boolean >;
+	site?: Record< string, boolean >;
+	sites?: McpSiteOverrideUpdate[];
+	site_level_enabled_default?: boolean;
+};
+
 export interface UserSettings {
 	advertising_targeting_opt_out: boolean;
 	avatar_URL: string;
@@ -90,6 +108,14 @@ export interface UserSettings {
 	user_email_change_pending?: boolean;
 	new_user_email?: string;
 }
+
+/**
+ * Payload accepted by updateUserSettings. Same as UserSettings except
+ * mcp_abilities also accepts the boolean-toggle update shape.
+ */
+export type UserSettingsUpdate = Omit< Partial< UserSettings >, 'mcp_abilities' > & {
+	mcp_abilities?: McpAbilities | McpAbilitiesUpdate;
+};
 
 export interface PasswordValidationResponse {
 	passed: boolean;

--- a/packages/api-core/src/site-performance/types.ts
+++ b/packages/api-core/src/site-performance/types.ts
@@ -16,12 +16,23 @@ type PerformanceMetricAuditDetailsHeading = {
 	subItemsHeading?: { key: string; valueType?: string };
 };
 
-type PerformanceMetricAuditDetailsItemObject = {
+export type PerformanceMetricAuditDetailsItemObject = {
 	location?: {
 		url: string;
 		line: number;
 		column: number;
 	};
+	boundingRect?: {
+		width: number;
+		height: number;
+		top: number;
+		left: number;
+		right?: number;
+		bottom?: number;
+	};
+	lhId?: string;
+	nodeLabel?: string;
+	snippet?: string;
 } & Record< string, string | number >;
 
 type PerformanceMetricAuditDetailsSubItemObject = {


### PR DESCRIPTION
## Proposed Changes

* Fix all `@typescript-eslint/no-explicit-any` warnings in `client/dashboard` by replacing `any` with real types.
* Add `McpAbilitiesUpdate`/`UserSettingsUpdate` types to `@automattic/api-core` so MCP settings mutations no longer need `as any` (the update payload sends boolean toggles, unlike the read shape).
* Add `boundingRect`/`lhId`/`nodeLabel`/`snippet` to the performance audit item type to match the actual Lighthouse payload.
* One contained cast remains in `components/dataviews/dataviews.tsx`: TS can’t validate generic spreads against WPDataViews’ conditional `getItemId` prop, so the previous `as any` becomes a documented module-level alias cast.

## Why are these changes being made?

* A stricter shared ESLint config recently landed on trunk, leaving `client/dashboard/` with pre-existing lint failures. This is part of a series of PRs fixing them one rule class at a time. Each PR leaves every file it touches fully lint-clean, so the "Code style" CI check (which lints whole changed files) passes independently of the sibling PRs.

## Testing Instructions

* Run `yarn eslint client/dashboard` — no `no-explicit-any` warnings remain. `yarn typecheck-client` passes. `yarn test-client client/dashboard` passes.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
