### PR TITLE
Dashboard: replace require() with ES imports

### DIFF
--- a/client/dashboard/AGENTS.md
+++ b/client/dashboard/AGENTS.md
@@ -15,6 +15,10 @@ This is the new hosting dashboard for WordPress.com.
   2. If the behavior genuinely differs per dashboard variant, add a property to `AppConfig` that each variant provides, and branch on that property instead of the name.
   3. Before doing either, ask: if this UX is better for one variant, wouldn't it be better for all users? Prefer a single code path when possible.
 
+### Testing
+
+- Read [docs/testing.md](./docs/testing.md) before writing or modifying tests.
+
 ### Dark mode
 
 - Shared dark-mode tokens and component-wide overrides for components used across multiple Calypso surfaces live in `client/lib/color-scheme/dark-theme.scss`. Add dashboard-only exceptions to `client/dashboard/app/_dark-theme.scss` using the existing `dashboard-dark-theme-*` mixins (or add a new one and `@include` it from `dashboard-dark-theme`) instead of writing ad-hoc `:root[data-theme='dark']` blocks elsewhere.

--- a/client/dashboard/docs/testing.md
+++ b/client/dashboard/docs/testing.md
@@ -139,6 +139,8 @@ test( 'saves preferences', () => {
 // ✅ Good: top-level import + cast
 import { userPreferencesMutation } from '@automattic/api-queries';
 
+jest.mock( '@automattic/api-queries' );
+
 test( 'saves preferences', () => {
 	( userPreferencesMutation as jest.Mock ).mockReturnValue( /* … */ );
 } );

--- a/client/dashboard/docs/testing.md
+++ b/client/dashboard/docs/testing.md
@@ -129,10 +129,13 @@ Do not use inline `require()` to load a mocked module "after" `jest.mock()` is s
 ```tsx
 // ❌ Bad: lazy require to "get the mock"
 test( 'saves preferences', () => {
+	// eslint-disable-next-line @typescript-eslint/no-require-imports
 	const { userPreferencesMutation } = require( '@automattic/api-queries' );
 	userPreferencesMutation.mockReturnValue( /* … */ );
 } );
+```
 
+```tsx
 // ✅ Good: top-level import + cast
 import { userPreferencesMutation } from '@automattic/api-queries';
 

--- a/client/dashboard/docs/testing.md
+++ b/client/dashboard/docs/testing.md
@@ -44,20 +44,20 @@ Note: `nock.cleanAll()` is already called globally after each test, so you don't
 
 ```tsx
 nock( 'https://public-api.wordpress.com' )
-  .get( `/wpcom/v2/sites/${ siteId }/hosting/error-logs` )
-  .query( true ) // match any query string
-  .reply( 200, { data: { logs: [], total_results: 0, scroll_id: null } } );
+	.get( `/wpcom/v2/sites/${ siteId }/hosting/error-logs` )
+	.query( true ) // match any query string
+	.reply( 200, { data: { logs: [], total_results: 0, scroll_id: null } } );
 ```
 
 **Intercepting a mutation (POST):**
 
 ```tsx
 const scope = nock( 'https://public-api.wordpress.com' )
-  .post( '/rest/v1.1/me/preferences', ( body ) => {
-    // optionally inspect the request body
-    return true;
-  } )
-  .reply( 200, { calypso_preferences: {} } );
+	.post( '/rest/v1.1/me/preferences', ( body ) => {
+		// optionally inspect the request body
+		return true;
+	} )
+	.reply( 200, { calypso_preferences: {} } );
 
 // …trigger the mutation…
 
@@ -70,8 +70,8 @@ DELETE, so use `.delete()` not `.post()`:
 
 ```tsx
 nock( 'https://public-api.wordpress.com' )
-  .delete( `/wpcom/v2/sites/${ productionSiteId }/staging-site/${ stagingSiteId }` )
-  .reply( 200, {} );
+	.delete( `/wpcom/v2/sites/${ productionSiteId }/staging-site/${ stagingSiteId }` )
+	.reply( 200, {} );
 ```
 
 **Tips:**
@@ -87,22 +87,22 @@ Assert the request body inside nock's body callback using Jest matchers, then us
 
 ```tsx
 const scope = nock( 'https://public-api.wordpress.com' )
-  .post( '/rest/v1.1/me/preferences', ( body ) => {
-    expect( body ).toEqual(
-      expect.objectContaining( {
-        my_key: 'strict string check',
-        some_string: expect.any( String ),
-        pi: expect.closeTo( 3.14 ),
-      } )
-    );
-    return true;
-  } )
-  .reply( 200, { calypso_preferences: {} } );
+	.post( '/rest/v1.1/me/preferences', ( body ) => {
+		expect( body ).toEqual(
+			expect.objectContaining( {
+				my_key: 'strict string check',
+				some_string: expect.any( String ),
+				pi: expect.closeTo( 3.14 ),
+			} )
+		);
+		return true;
+	} )
+	.reply( 200, { calypso_preferences: {} } );
 
 // …trigger the mutation…
 
 await waitFor( () => {
-  expect( scope.isDone() ).toBe( true );
+	expect( scope.isDone() ).toBe( true );
 } );
 ```
 
@@ -120,6 +120,36 @@ const queryClient = new QueryClient();
 queryClient.setQueryData( [ 'staging-site', 1, 'is-deleting' ], true );
 
 render( <MyComponent />, { queryClient } );
+```
+
+### Mocking Modules: use ES imports, not `require()`
+
+Do not use inline `require()` to load a mocked module "after" `jest.mock()` is set up. Jest hoists `jest.mock()` calls above all imports, so a top-level ES import already receives the mocked version. Inline `require()` is also an ESLint error (`@typescript-eslint/no-require-imports`).
+
+```tsx
+// ❌ Bad: lazy require to "get the mock"
+test( 'saves preferences', () => {
+	const { userPreferencesMutation } = require( '@automattic/api-queries' );
+	userPreferencesMutation.mockReturnValue( /* … */ );
+} );
+
+// ✅ Good: top-level import + cast
+import { userPreferencesMutation } from '@automattic/api-queries';
+
+test( 'saves preferences', () => {
+	( userPreferencesMutation as jest.Mock ).mockReturnValue( /* … */ );
+} );
+```
+
+Deferred loading is only genuinely needed with `jest.resetModules()`, `jest.isolateModules()`, or `jest.doMock()` — and even then prefer `await import()` over `require()`.
+
+One exception: a `jest.mock()` factory runs before imports are initialized, so it cannot reference top-level imports. Inside a factory, use `jest.requireActual()`:
+
+```tsx
+jest.mock( 'some-module', () => {
+	const { createElement } = jest.requireActual( 'react' );
+	// …
+} );
 ```
 
 ### Utility Function Tests

--- a/client/dashboard/domains/domain-forwarding/test/notice.test.tsx
+++ b/client/dashboard/domains/domain-forwarding/test/notice.test.tsx
@@ -4,10 +4,11 @@
 import { Domain, DomainSubtype } from '@automattic/api-core';
 import { screen } from '@testing-library/react';
 import { render } from '../../../test-utils';
+import { DomainForwardingNotice } from '../notice';
 
 const domainName = 'example.com';
 
-const getMockedDomainData = ( customProps: Partial< Domain > = {} ) => {
+const getMockedDomainData = ( customProps: Partial< Domain > = {} ): Domain => {
 	return {
 		domain: domainName,
 		aftermarket_auction: false,
@@ -47,7 +48,7 @@ const getMockedDomainData = ( customProps: Partial< Domain > = {} ) => {
 		type: 'wpcom',
 		wpcom_domain: true,
 		...customProps,
-	};
+	} as Domain;
 };
 
 test( 'shows warning notice when domain registration uses external name servers', () => {
@@ -59,7 +60,6 @@ test( 'shows warning notice when domain registration uses external name servers'
 	} );
 
 	const TestWrapper = () => {
-		const { DomainForwardingNotice } = require( '../notice' );
 		return <DomainForwardingNotice domainName={ domainName } domainData={ domainData } />;
 	};
 
@@ -85,7 +85,6 @@ test( 'shows warning notice when domain connection uses external name servers', 
 	} );
 
 	const TestWrapper = () => {
-		const { DomainForwardingNotice } = require( '../notice' );
 		return <DomainForwardingNotice domainName={ domainName } domainData={ domainData } />;
 	};
 
@@ -109,7 +108,6 @@ test( 'shows info notice when domain is primary domain on non-domain-only site',
 	} );
 
 	const TestWrapper = () => {
-		const { DomainForwardingNotice } = require( '../notice' );
 		return <DomainForwardingNotice domainName={ domainName } domainData={ domainData } />;
 	};
 
@@ -133,7 +131,6 @@ test( 'shows no notice when domain uses WordPress.com nameservers and is not pri
 	} );
 
 	const TestWrapper = () => {
-		const { DomainForwardingNotice } = require( '../notice' );
 		return <DomainForwardingNotice domainName={ domainName } domainData={ domainData } />;
 	};
 

--- a/client/dashboard/me/preferences-default-landing/test/index.test.tsx
+++ b/client/dashboard/me/preferences-default-landing/test/index.test.tsx
@@ -3,6 +3,7 @@
  */
 
 import '@testing-library/jest-dom';
+import { rawUserPreferencesQuery, userPreferencesMutation } from '@automattic/api-queries';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useDispatch } from '@wordpress/data';
@@ -41,11 +42,9 @@ jest.mock(
 );
 
 function renderPreferencesDefaultLanding() {
-	const { rawUserPreferencesQuery } = require( '@automattic/api-queries' );
-
 	// Mock rawUserPreferencesQuery to return the API response
 	// This is required because the component uses useSuspenseQuery which needs data immediately
-	rawUserPreferencesQuery.mockReturnValue( {
+	( rawUserPreferencesQuery as jest.Mock ).mockReturnValue( {
 		queryKey: [ 'me', 'preferences' ],
 		queryFn: () =>
 			Promise.resolve( {
@@ -64,8 +63,7 @@ function renderPreferencesDefaultLanding() {
 }
 
 afterEach( () => {
-	const { rawUserPreferencesQuery } = require( '@automattic/api-queries' );
-	rawUserPreferencesQuery.mockClear();
+	( rawUserPreferencesQuery as jest.Mock ).mockClear();
 } );
 
 test( 'save button is disabled when form is not dirty', async () => {
@@ -112,8 +110,7 @@ test( 'saves preferences successfully', async () => {
 	} );
 
 	// Override the mock to make mutationFn return a resolved promise
-	const { userPreferencesMutation } = require( '@automattic/api-queries' );
-	userPreferencesMutation.mockReturnValue( {
+	( userPreferencesMutation as jest.Mock ).mockReturnValue( {
 		mutationFn: jest.fn( () =>
 			Promise.resolve( {
 				'sites-landing-page': {
@@ -162,8 +159,7 @@ test( 'handles save error gracefully', async () => {
 
 	// Override the mock to make mutationFn return a rejected promise
 	// This simulates an API error
-	const { userPreferencesMutation } = require( '@automattic/api-queries' );
-	userPreferencesMutation.mockReturnValue( {
+	( userPreferencesMutation as jest.Mock ).mockReturnValue( {
 		mutationFn: jest.fn( () => Promise.reject( new Error( 'Server error' ) ) ),
 	} );
 
@@ -206,8 +202,7 @@ test( 'disables save button while saving', async () => {
 
 	// Override the mock to make mutationFn return a delayed promise
 	// This simulates an async operation that takes time, making isPending true
-	const { userPreferencesMutation } = require( '@automattic/api-queries' );
-	userPreferencesMutation.mockReturnValue( {
+	( userPreferencesMutation as jest.Mock ).mockReturnValue( {
 		mutationFn: jest.fn( () => {
 			return new Promise( ( resolve ) => {
 				setTimeout( () => {

--- a/client/dashboard/me/preferences-primary-site/test/index.test.tsx
+++ b/client/dashboard/me/preferences-primary-site/test/index.test.tsx
@@ -3,6 +3,7 @@
  */
 
 import '@testing-library/jest-dom';
+import { userSettingsQuery } from '@automattic/api-queries';
 import { screen, waitFor } from '@testing-library/react';
 import { render } from '../../../test-utils';
 import PreferencesPrimarySite from '../index';
@@ -74,10 +75,8 @@ const mockSites: DeepPartial< Site >[] = [
 ];
 
 function renderPreferencesPrimarySite() {
-	const { userSettingsQuery } = require( '@automattic/api-queries' );
-
 	// Mock userSettingsQuery to return the API response
-	userSettingsQuery.mockReturnValue( {
+	( userSettingsQuery as jest.Mock ).mockReturnValue( {
 		queryKey: [ 'me', 'settings' ],
 		queryFn: () =>
 			Promise.resolve( {
@@ -108,9 +107,7 @@ test( 'save button is disabled when form is not dirty', async () => {
 } );
 
 test( 'hides primary site selector when user has no sites', async () => {
-	const { userSettingsQuery } = require( '@automattic/api-queries' );
-
-	userSettingsQuery.mockReturnValue( {
+	( userSettingsQuery as jest.Mock ).mockReturnValue( {
 		queryKey: [ 'me', 'settings' ],
 		queryFn: () =>
 			Promise.resolve( {

--- a/client/dashboard/sites/staging-site-sync-modal/test/index.test.tsx
+++ b/client/dashboard/sites/staging-site-sync-modal/test/index.test.tsx
@@ -5,6 +5,7 @@
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
+import useRewindableActivityLogQuery from '../../../../data/activity-log/use-rewindable-activity-log-query';
 import { render } from '../../../test-utils';
 import StagingSiteSyncModal from '../index';
 import type { Site } from '@automattic/api-core';
@@ -33,7 +34,7 @@ jest.mock( '../../../components/inline-support-link', () => {
 jest.mock(
 	'../../../../my-sites/backup/backup-contents-page/file-browser/file-browser-context',
 	() => {
-		const { createContext, useContext, createElement, useState } = require( 'react' );
+		const { createContext, useContext, createElement, useState } = jest.requireActual( 'react' );
 
 		const FileBrowserContext = createContext( null );
 
@@ -283,8 +284,10 @@ describe( 'Form Submission', () => {
 	} );
 
 	test( 'submit button is enabled when domain confirmation matches', async () => {
-		const useRewindableActivityLogQuery = require( '../../../../data/activity-log/use-rewindable-activity-log-query' );
-		useRewindableActivityLogQuery.mockReturnValue( { data: undefined, isLoading: false } );
+		( useRewindableActivityLogQuery as jest.Mock ).mockReturnValue( {
+			data: undefined,
+			isLoading: false,
+		} );
 
 		mockSite( createMockSite() );
 		mockSite( createMockStagingSite() );
@@ -322,8 +325,10 @@ describe( 'Form Submission', () => {
 	} );
 
 	test( 'submits with expected options on push to production', async () => {
-		const useRewindableActivityLogQuery = require( '../../../../data/activity-log/use-rewindable-activity-log-query' );
-		useRewindableActivityLogQuery.mockReturnValue( { data: undefined, isLoading: false } );
+		( useRewindableActivityLogQuery as jest.Mock ).mockReturnValue( {
+			data: undefined,
+			isLoading: false,
+		} );
 		const prod = createMockSite( { slug: 'test-site' } );
 		const stag = createMockStagingSite();
 


### PR DESCRIPTION
## Proposed Changes

* Fix all `@typescript-eslint/no-require-imports` errors in `client/dashboard` (all in test files): replace inline `require()` of mocked modules with top-level imports plus `as jest.Mock` casts, and `require( 'react' )` inside a `jest.mock` factory with `jest.requireActual`.
* Document the pattern in `client/dashboard/docs/testing.md` (jest hoists `jest.mock()`, so top-level imports already receive the mock) and point agents at the doc from `client/dashboard/AGENTS.md`, so the lazy-`require()` pattern doesn’t get reintroduced.

## Why are these changes being made?

* A stricter shared ESLint config recently landed on trunk, leaving `client/dashboard/` with pre-existing lint failures. This is part of a series of PRs fixing them one rule class at a time. Each PR leaves every file it touches fully lint-clean, so the "Code style" CI check (which lints whole changed files) passes independently of the sibling PRs.

## Testing Instructions

* Run `yarn eslint client/dashboard` — no `no-require-imports` failures remain. `yarn test-client client/dashboard` passes (the modified test suites all pass).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

