### PR TITLE
Dashboard: fix unstable TanStack Query deps

### DIFF
--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -41,7 +41,7 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const { data: purchases } = useQuery( userPurchasesQuery() );
 
-	const setPrimaryDomainMutation = useMutation( {
+	const { mutate: setPrimaryDomain, isPending: isSettingPrimaryDomain } = useMutation( {
 		...siteSetPrimaryDomainMutation(),
 		meta: {
 			snackbar: {
@@ -169,7 +169,7 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 						origin: 'dataviews_actions',
 					} );
 
-					setPrimaryDomainMutation.mutate(
+					setPrimaryDomain(
 						{ siteId: site.ID, domain: domain.domain },
 						{
 							onSuccess: () => {
@@ -206,7 +206,7 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 					const hasRedirect = site?.options?.is_redirect ?? false;
 					return !! site && canSetAsPrimary( { domain: item, site, user } ) && ! hasRedirect;
 				},
-				disabled: setPrimaryDomainMutation.isPending,
+				disabled: isSettingPrimaryDomain,
 			},
 			{
 				id: 'transfer-domain',
@@ -331,7 +331,8 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 			user,
 			router,
 			purchases,
-			setPrimaryDomainMutation,
+			setPrimaryDomain,
+			isSettingPrimaryDomain,
 			createSuccessNotice,
 			sitesByBlogId,
 			recordTracksEvent,

--- a/client/dashboard/domains/domain-dns/actions.tsx
+++ b/client/dashboard/domains/domain-dns/actions.tsx
@@ -11,7 +11,7 @@ import type { Action } from '@wordpress/dataviews';
 
 export function useDnsActions(): Action< DnsRecord >[] {
 	const { domainName } = domainRoute.useParams();
-	const deleteMutation = useMutation( {
+	const { mutate: deleteDnsRecord, isPending: isDeletingDnsRecord } = useMutation( {
 		...domainDnsMutation( domainName ),
 		meta: {
 			snackbar: {
@@ -29,7 +29,7 @@ export function useDnsActions(): Action< DnsRecord >[] {
 				return;
 			}
 
-			deleteMutation.mutate( {
+			deleteDnsRecord( {
 				recordsToAdd: [],
 				recordsToRemove: [ itemToDelete ],
 				restoreDefaultARecords: false,
@@ -59,11 +59,11 @@ export function useDnsActions(): Action< DnsRecord >[] {
 					return ! ( item.protected_field && 'MX' !== item.type ) || item.type === 'A';
 				},
 				id: 'delete',
-				isBusy: deleteMutation.isPending,
+				isBusy: isDeletingDnsRecord,
 				label: __( 'Delete' ),
 				icon: <Icon icon={ trash } />,
 				callback: handleDelete,
 			},
 		];
-	}, [ deleteMutation, router, domainName ] );
+	}, [ deleteDnsRecord, isDeletingDnsRecord, router, domainName ] );
 }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-flow.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-flow.tsx
@@ -66,8 +66,6 @@ export default function DomainRemovalFlow( { purchase, onCancel }: DomainRemoval
 		} );
 	}, [ purchase, removePurchase, createSuccessNotice, createErrorNotice, navigate ] );
 
-	const isLoading = isRemovingPurchase;
-
 	return (
 		<div>
 			{ currentStep === 'warning' && (
@@ -75,7 +73,7 @@ export default function DomainRemovalFlow( { purchase, onCancel }: DomainRemoval
 					purchase={ purchase }
 					onContinue={ handleContinue }
 					onCancel={ onCancel }
-					isLoading={ isLoading }
+					isLoading={ isRemovingPurchase }
 				/>
 			) }
 			{ currentStep === 'confirmation' && (
@@ -83,7 +81,7 @@ export default function DomainRemovalFlow( { purchase, onCancel }: DomainRemoval
 					purchase={ purchase }
 					onConfirm={ handleConfirm }
 					onCancel={ onCancel }
-					isLoading={ isLoading }
+					isLoading={ isRemovingPurchase }
 				/>
 			) }
 		</div>

--- a/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-flow.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/domain-removal-flow.tsx
@@ -23,14 +23,16 @@ export default function DomainRemovalFlow( { purchase, onCancel }: DomainRemoval
 	const [ currentStep, setCurrentStep ] = useState< RemovalStep >( 'warning' );
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const navigate = useNavigate();
-	const removePurchaseMutator = useMutation( removePurchaseMutation() );
+	const { mutate: removePurchase, isPending: isRemovingPurchase } = useMutation(
+		removePurchaseMutation()
+	);
 
 	const handleContinue = useCallback( () => {
 		setCurrentStep( 'confirmation' );
 	}, [] );
 
 	const handleConfirm = useCallback( () => {
-		removePurchaseMutator.mutate( purchase.ID, {
+		removePurchase( purchase.ID, {
 			onSuccess: () => {
 				const domainName = purchase.meta || purchase.product_name;
 				createSuccessNotice(
@@ -62,9 +64,9 @@ export default function DomainRemovalFlow( { purchase, onCancel }: DomainRemoval
 				);
 			},
 		} );
-	}, [ purchase, removePurchaseMutator, createSuccessNotice, createErrorNotice, navigate ] );
+	}, [ purchase, removePurchase, createSuccessNotice, createErrorNotice, navigate ] );
 
-	const isLoading = removePurchaseMutator.isPending;
+	const isLoading = isRemovingPurchase;
 
 	return (
 		<div>

--- a/client/dashboard/plugins/manage/index.tsx
+++ b/client/dashboard/plugins/manage/index.tsx
@@ -78,7 +78,7 @@ export default function PluginsList() {
 		return batches;
 	}, [ plugins ] );
 
-	const marketplaceSearchResults = useQueries( {
+	const { marketplaceSearchData, allSearchQueriesLoaded } = useQueries( {
 		queries:
 			slugBatches.length > 0
 				? slugBatches.map( ( slugs ) =>
@@ -89,23 +89,24 @@ export default function PluginsList() {
 						} )
 				  )
 				: [],
+		combine: ( results ) => ( {
+			marketplaceSearchData: results.flatMap( ( result ) => result.data?.data.results || [] ),
+			allSearchQueriesLoaded: results.every( ( result ) => result.isSuccess ),
+		} ),
 	} );
 
 	const iconBySlug = useMemo( () => {
 		// Only recalculate once all queries have data
-		const allQueriesLoaded = marketplaceSearchResults.every( ( result ) => result.isSuccess );
-		if ( ! allQueriesLoaded ) {
+		if ( ! allSearchQueriesLoaded ) {
 			return new Map< string, PluginListRow[ 'icon' ] >();
 		}
 
 		const marketplacePluginsBySlug = new Map( Object.entries( marketplacePlugins?.results || {} ) );
 
-		const marketplaceSearchBySlug = marketplaceSearchResults
-			.flatMap( ( result ) => result.data?.data.results || [] )
-			.reduce( ( acc, { fields } ) => {
-				acc.set( fields.slug, fields );
-				return acc;
-			}, new Map< string, MarketplaceSearchResult[ 'fields' ] >() );
+		const marketplaceSearchBySlug = marketplaceSearchData.reduce( ( acc, { fields } ) => {
+			acc.set( fields.slug, fields );
+			return acc;
+		}, new Map< string, MarketplaceSearchResult[ 'fields' ] >() );
 
 		return plugins.reduce( ( acc, { slug } ) => {
 			let icon;
@@ -119,7 +120,7 @@ export default function PluginsList() {
 
 			return acc;
 		}, new Map< string, PluginListRow[ 'icon' ] >() );
-	}, [ plugins, marketplacePlugins, marketplaceSearchResults ] );
+	}, [ plugins, marketplacePlugins, marketplaceSearchData, allSearchQueriesLoaded ] );
 
 	const pluginsWithIcon = useMemo( () => {
 		return plugins.map( ( plugin ) => {

--- a/client/dashboard/plugins/scheduled-updates/hooks/use-create-schedules.ts
+++ b/client/dashboard/plugins/scheduled-updates/hooks/use-create-schedules.ts
@@ -52,7 +52,7 @@ function createMonitorUrls( siteUrl: string ): JetpackMonitorSettings[ 'urls' ] 
 export function useCreateSchedules( siteIds: number[] ) {
 	const { recordTracksEvent } = useAnalytics();
 	const { data: eligibleSites = [] } = useEligibleSites();
-	const createBatch = useMutation( updateSchedulesBatchCreateMutation( siteIds ) );
+	const { mutate: createBatch } = useMutation( updateSchedulesBatchCreateMutation( siteIds ) );
 	const { mutateAsync: createMonitorForSite } = useMutation(
 		siteJetpackMonitorSettingsCreateMutation()
 	);
@@ -72,7 +72,7 @@ export function useCreateSchedules( siteIds: number[] ) {
 			};
 
 			return await new Promise< void >( ( resolve, reject ) => {
-				createBatch.mutate( body, {
+				createBatch( body, {
 					onSuccess: async ( results ) => {
 						const successfulSiteIds = ( results || [] )
 							.filter( ( result ) => ! result.error )

--- a/client/dashboard/plugins/scheduled-updates/hooks/use-scheduled-updates.ts
+++ b/client/dashboard/plugins/scheduled-updates/hooks/use-scheduled-updates.ts
@@ -11,11 +11,13 @@ export function useScheduledUpdates() {
 	);
 	const { data: sites, isLoading: isLoadingSites } = useQuery( queries.sitesQuery() );
 	const siteIds = Object.keys( scheduledUpdates?.sites ?? [] );
-	const pluginQueries = useQueries( {
+	const { pluginsData, isLoadingPlugins } = useQueries( {
 		queries: siteIds.map( ( id ) => siteCorePluginsQuery( Number( id ) ) ),
+		combine: ( results ) => ( {
+			pluginsData: results.map( ( result ) => result.data ),
+			isLoadingPlugins: results.some( ( result ) => result.isLoading ),
+		} ),
 	} );
-
-	const isLoadingPlugins = pluginQueries.some( ( query ) => query.isLoading );
 
 	return useMemo( () => {
 		if ( ! scheduledUpdates || ! sites ) {
@@ -33,14 +35,12 @@ export function useScheduledUpdates() {
 
 		// Build plugin slug to name map
 		const pluginMap = new Map< string, string >();
-		pluginQueries.forEach( ( query ) => {
-			if ( query.data ) {
-				query.data.forEach( ( plugin ) => {
-					if ( plugin.plugin && plugin.name ) {
-						pluginMap.set( plugin.plugin, plugin.name );
-					}
-				} );
-			}
+		pluginsData.forEach( ( plugins ) => {
+			plugins?.forEach( ( plugin ) => {
+				if ( plugin.plugin && plugin.name ) {
+					pluginMap.set( plugin.plugin, plugin.name );
+				}
+			} );
 		} );
 
 		const updates = scheduledUpdates.sites;
@@ -88,7 +88,7 @@ export function useScheduledUpdates() {
 		sites,
 		isLoadingSchedules,
 		isLoadingSites,
-		pluginQueries,
+		pluginsData,
 		isLoadingPlugins,
 	] );
 }

--- a/client/dashboard/sites/scan/hooks/use-fix-threats.ts
+++ b/client/dashboard/sites/scan/hooks/use-fix-threats.ts
@@ -13,7 +13,7 @@ export function useFixThreats( siteId: number, threatIds: number[] ) {
 	const queryClient = useQueryClient();
 	const [ fixState, setFixState ] = useState< FixState >( 'idle' );
 
-	const fixMutation = useMutation( {
+	const { mutate: fixThreats, error: fixError } = useMutation( {
 		...fixThreatsMutation( siteId ),
 		onError: () => setFixState( 'idle' ),
 	} );
@@ -58,8 +58,8 @@ export function useFixThreats( siteId: number, threatIds: number[] ) {
 
 	const startFix = useCallback( () => {
 		setFixState( 'fixing' );
-		return fixMutation.mutate( threatIds );
-	}, [ threatIds, fixMutation ] );
+		return fixThreats( threatIds );
+	}, [ threatIds, fixThreats ] );
 
 	useEffect( () => {
 		if ( status.isComplete && fixState === 'fixing' ) {
@@ -73,6 +73,6 @@ export function useFixThreats( siteId: number, threatIds: number[] ) {
 		startFix,
 		isFixing: fixState === 'fixing',
 		status,
-		error: fixMutation.error,
+		error: fixError,
 	};
 }


### PR DESCRIPTION
## Proposed Changes

* Fix all `@tanstack/query/no-unstable-deps` errors in `client/dashboard`:
  * Destructure `mutate`/`isPending`/`error` from `useMutation` instead of passing the whole (referentially unstable) result into hook dependency arrays.
  * Use the `combine` option on `useQueries` to derive stable data/loading values instead of depending on the raw results array.

## Why are these changes being made?

* A stricter shared ESLint config recently landed on trunk, leaving `client/dashboard/` with pre-existing lint failures. This is part of a series of PRs fixing them one rule class at a time. Each PR leaves every file it touches fully lint-clean, so the "Code style" CI check (which lints whole changed files) passes independently of the sibling PRs.

## Testing Instructions

* Run `yarn eslint client/dashboard` — no `@tanstack/query/no-unstable-deps` failures remain. `yarn typecheck-client` and `yarn test-client client/dashboard` pass. Smoke-test the touched screens: domain list set-primary action, DNS record delete, plugin list icons, scheduled updates, backups granular download, deployments list, scan auto-fix, purchase domain removal.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
