### PR TITLE
Dashboard: fix unused expressions

### DIFF
--- a/client/dashboard/domains/domain-connection-setup/legacy-transfer-setup.tsx
+++ b/client/dashboard/domains/domain-connection-setup/legacy-transfer-setup.tsx
@@ -47,7 +47,9 @@ export default function DomainTransferSetup() {
 
 	const setNextStepName = () => {
 		const next = stepsDefinition[ currentStepName as StepNameValue ]?.next;
-		next && setCurrentStepName( next );
+		if ( next ) {
+			setCurrentStepName( next );
+		}
 	};
 
 	const goBack = () => {

--- a/client/dashboard/domains/domain-transfer/select-site.tsx
+++ b/client/dashboard/domains/domain-transfer/select-site.tsx
@@ -53,7 +53,9 @@ export function SelectSite( { attachedSiteId, onSiteSelect }: Props ) {
 				newSelection.includes( site.ID?.toString() ?? '' )
 			);
 
-			selectedSite && onSiteSelect( selectedSite );
+			if ( selectedSite ) {
+				onSiteSelect( selectedSite );
+			}
 		},
 		[ sites, onSiteSelect ]
 	);

--- a/client/dashboard/domains/domain-transfer/transfer-domain-to-other-site.tsx
+++ b/client/dashboard/domains/domain-transfer/transfer-domain-to-other-site.tsx
@@ -34,22 +34,21 @@ export default function DomainTransferToOtherSite() {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
 	const onConfirmTransfer = () => {
-		!! selectedSite &&
-			transferDomainToSite( selectedSite.ID, {
-				onSuccess: () => {
-					createSuccessNotice( __( 'Domain transferred successfully.' ), { type: 'snackbar' } );
-					setIsConfirmDialogOpen( false );
-					navigate( { to: domainRoute.fullPath, params: { domainName } } );
-				},
-				onError: ( e ) => {
-					createErrorNotice(
-						e.message || __( 'An error occurred while transferring the domain.' ),
-						{
-							type: 'snackbar',
-						}
-					);
-				},
-			} );
+		if ( ! selectedSite ) {
+			return;
+		}
+		transferDomainToSite( selectedSite.ID, {
+			onSuccess: () => {
+				createSuccessNotice( __( 'Domain transferred successfully.' ), { type: 'snackbar' } );
+				setIsConfirmDialogOpen( false );
+				navigate( { to: domainRoute.fullPath, params: { domainName } } );
+			},
+			onError: ( e ) => {
+				createErrorNotice( e.message || __( 'An error occurred while transferring the domain.' ), {
+					type: 'snackbar',
+				} );
+			},
+		} );
 	};
 
 	return (

--- a/client/dashboard/emails/add-mailbox/index.tsx
+++ b/client/dashboard/emails/add-mailbox/index.tsx
@@ -112,12 +112,14 @@ const AddProfessionalEmail = () => {
 			return;
 		}
 
-		isAddMailboxRoute
-			? addToCart( { mailboxOperations, onFinally: () => setIsSubmitting( false ) } )
-			: setUpMailbox( {
-					mailboxOperations,
-					onFinally: () => setIsSubmitting( false ),
-			  } );
+		if ( isAddMailboxRoute ) {
+			addToCart( { mailboxOperations, onFinally: () => setIsSubmitting( false ) } );
+		} else {
+			setUpMailbox( {
+				mailboxOperations,
+				onFinally: () => setIsSubmitting( false ),
+			} );
+		}
 	};
 
 	const removeForm = ( index: number ) => {

--- a/client/dashboard/me/billing-history/utils.tsx
+++ b/client/dashboard/me/billing-history/utils.tsx
@@ -392,9 +392,9 @@ export function doesIntroductoryOfferHaveDifferentTermLengthThanProduct(
 	monthsPerBillPeriodForProduct: number | undefined | null
 ): boolean {
 	if (
-		costOverrides?.some( ( costOverride ) => {
-			! isOverrideCodeIntroductoryOffer( costOverride.override_code );
-		} )
+		costOverrides?.some(
+			( costOverride ) => ! isOverrideCodeIntroductoryOffer( costOverride.override_code )
+		)
 	) {
 		return false;
 	}

--- a/client/dashboard/sites/monitoring-http-responses-card/index.tsx
+++ b/client/dashboard/sites/monitoring-http-responses-card/index.tsx
@@ -81,11 +81,12 @@ function useSiteMetricsData(
 							values[ statusCode ] = [];
 						}
 
-						values.hasOwnProperty( statusCode ) &&
+						if ( values.hasOwnProperty( statusCode ) ) {
 							values[ statusCode ].push( {
 								date,
 								value: count > 0 ? Math.round( count * 60 * 100 ) / 100 : 0, // Convert to requests per minute and round to 2 decimals.
 							} );
+						}
 					} );
 				}
 			}


### PR DESCRIPTION
## Proposed Changes

* Fix `@typescript-eslint/no-unused-expressions` errors in `client/dashboard`: convert `cond && fn()` / ternary statements to `if` statements.
* Behavior fix in `me/billing-history/utils.tsx`: the `costOverrides?.some()` callback never returned a value, so the non-introductory-offer guard in `doesIntroductoryOfferHaveDifferentTermLengthThanProduct()` was dead code. The callback now returns the comparison, matching the canonical implementation in `packages/wpcom-checkout/src/transformations.ts`.

## Why are these changes being made?

* A stricter shared ESLint config recently landed on trunk, leaving `client/dashboard/` with pre-existing lint failures. This is part of a series of PRs fixing them one rule class at a time. Each PR leaves every file it touches fully lint-clean, so the "Code style" CI check (which lints whole changed files) passes independently of the sibling PRs.

## Testing Instructions

* Lint/typecheck: `yarn eslint client/dashboard` shows no remaining `no-unused-expressions` failures, and `yarn typecheck-client` passes.
* Manual check of the behavior fix (billing history receipts):
  * Context: `doesIntroductoryOfferHaveDifferentTermLengthThanProduct()` controls two things on a receipt line item — whether the price is rendered struck-through, and whether discount rows show “Amount paid in transaction: …” instead of a discount amount. That treatment should only apply when the item’s *only* cost overrides are introductory offers and the offer term differs from the product’s billing period. Before this fix the guard never fired, so items with additional non-intro discounts got the treatment too.
  * Start the Dashboard (`yarn start-dashboard`), go to **Me → Billing → Billing history** (`/me/billing/history`) and open receipts.
  * Receipt item with an intro offer on a different term than the product (e.g. 3-month intro price on an annual plan) and **no other discounts**: unchanged — struck-through price, discount row reads “Amount paid in transaction: …”.
  * Receipt item with such an intro offer **plus** another non-intro discount (e.g. a coupon): previously got the struck-through price and “Amount paid in transaction” text; now shows the plain price and regular discount amounts.
  * Cross-check: the receipt should now match the same receipt in classic Calypso Billing History (**Me → Purchases → Billing history**, `/me/purchases/billing/:receiptId`), which already uses the correct logic from `packages/wpcom-checkout`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
