### PR TITLE
Dashboard: fix hook dependency arrays

### DIFF
--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -137,7 +137,7 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 		const path = config( 'wpcom_login_url' ) || '/log-in';
 		const loginUrl = `${ path }?redirect_to=${ encodeURIComponent( currentPath ) }`;
 		window.location.href = loginUrl;
-	}, [] );
+	}, [ supports.startStoreRoute ] );
 
 	// Subscribe to network errors and when errors occur due to being logged
 	// out, redirect the user to the log in screen.

--- a/client/dashboard/app/responsive-sidebar/use-sidebar-scroll-sync.ts
+++ b/client/dashboard/app/responsive-sidebar/use-sidebar-scroll-sync.ts
@@ -22,7 +22,7 @@ export function useSidebarScrollSync( { enabled, sidebarRef, navigatorRef }: Opt
 		if ( ! enabled ) {
 			return;
 		}
-		const sidebarElement = sidebarRef.current;
+		const originalSidebarElement = sidebarRef.current;
 		let cachedSidebarHeight = 0;
 		let cachedOmnibarHeight = 0;
 		let scheduled = false;
@@ -117,7 +117,9 @@ export function useSidebarScrollSync( { enabled, sidebarRef, navigatorRef }: Opt
 			window.cancelAnimationFrame( initId );
 			window.removeEventListener( 'scroll', schedule );
 			resizeObserver.disconnect();
-			sidebarElement?.removeAttribute( 'style' );
+			// sidebarRef may have changed by the time we're cleaning up, so make sure
+			// we clean up the original element from the start of this effect.
+			originalSidebarElement?.removeAttribute( 'style' );
 			document.body.style.minHeight = '';
 		};
 	}, [ enabled, sidebarRef, navigatorRef ] );

--- a/client/dashboard/app/responsive-sidebar/use-sidebar-scroll-sync.ts
+++ b/client/dashboard/app/responsive-sidebar/use-sidebar-scroll-sync.ts
@@ -22,6 +22,7 @@ export function useSidebarScrollSync( { enabled, sidebarRef, navigatorRef }: Opt
 		if ( ! enabled ) {
 			return;
 		}
+		const sidebarElement = sidebarRef.current;
 		let cachedSidebarHeight = 0;
 		let cachedOmnibarHeight = 0;
 		let scheduled = false;
@@ -116,7 +117,7 @@ export function useSidebarScrollSync( { enabled, sidebarRef, navigatorRef }: Opt
 			window.cancelAnimationFrame( initId );
 			window.removeEventListener( 'scroll', schedule );
 			resizeObserver.disconnect();
-			sidebarRef.current?.removeAttribute( 'style' );
+			sidebarElement?.removeAttribute( 'style' );
 			document.body.style.minHeight = '';
 		};
 	}, [ enabled, sidebarRef, navigatorRef ] );


### PR DESCRIPTION
## Proposed Changes

* Fix the 2 `react-hooks/exhaustive-deps` warnings in `client/dashboard`:
  * `app/auth/index.tsx`: add the missing `supports.startStoreRoute` dependency to `handleAuthError`.
  * `app/responsive-sidebar/use-sidebar-scroll-sync.ts`: capture `sidebarRef.current` at effect start and use the captured node in the cleanup.

## Why are these changes being made?

* A stricter shared ESLint config recently landed on trunk, leaving `client/dashboard/` with pre-existing lint failures. This is part of a series of PRs fixing them one rule class at a time. Each PR leaves every file it touches fully lint-clean, so the "Code style" CI check (which lints whole changed files) passes independently of the sibling PRs.

## Testing Instructions

* Run `yarn eslint client/dashboard` — no `react-hooks/exhaustive-deps` warnings remain. Auth redirect and responsive sidebar scroll behave as before.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
