### PR TITLE
Dashboard: fix all eslint issues in monetize-subscription and use-staging-site

### DIFF
--- a/client/dashboard/me/billing-monetize-subscriptions/monetize-subscription.tsx
+++ b/client/dashboard/me/billing-monetize-subscriptions/monetize-subscription.tsx
@@ -31,6 +31,11 @@ import OverviewCard from '../../components/overview-card';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { formatDate } from '../../utils/datetime';
+import type {
+	MonetizeSubscriptionAutoRenewResponse,
+	MonetizeSubscriptionStopResponse,
+} from '@automattic/api-core';
+import type { UseMutateFunction } from '@tanstack/react-query';
 
 import './style.scss';
 
@@ -42,8 +47,8 @@ function AutoRenewButton( {
 	isProduct,
 	subscription,
 }: {
-	disableAutoRenew: ( data: any, variables?: object ) => void;
-	enableAutoRenew: ( data: any, variables?: object ) => void;
+	disableAutoRenew: UseMutateFunction< MonetizeSubscriptionAutoRenewResponse, Error, void >;
+	enableAutoRenew: UseMutateFunction< MonetizeSubscriptionAutoRenewResponse, Error, void >;
 	isUpdating: boolean;
 	isAutoRenewing: boolean;
 	isProduct: boolean;
@@ -82,7 +87,7 @@ function AutoRenewButton( {
 				const locale = useLocale();
 				const helpText = ( () => {
 					if ( isAutoRenewing ) {
-						// translators: date is a formatted date string
+						// translators: %(date)s: a formatted date string
 						return sprintf( __( 'You will be billed on %(date)s' ), {
 							date: formatDate( new Date( Date.parse( data?.end_date ?? '' ) ), locale, {
 								dateStyle: 'long',
@@ -99,8 +104,8 @@ function AutoRenewButton( {
 						disabled={ isUpdating }
 						onChange={ () =>
 							isAutoRenewing
-								? disableAutoRenew( null, { onError: onError } )
-								: enableAutoRenew( null, { onError: onError } )
+								? disableAutoRenew( undefined, { onError: onError } )
+								: enableAutoRenew( undefined, { onError: onError } )
 						}
 						help={ helpText }
 					/>
@@ -129,9 +134,11 @@ function AutoRenewButton( {
 					data={ subscription }
 					form={ form }
 					onChange={ () => {
-						isAutoRenewing
-							? disableAutoRenew( null, { onError: onError } )
-							: enableAutoRenew( null, { onError: onError } );
+						if ( isAutoRenewing ) {
+							disableAutoRenew( undefined, { onError: onError } );
+						} else {
+							enableAutoRenew( undefined, { onError: onError } );
+						}
 					} }
 				/>
 			</CardBody>
@@ -144,7 +151,7 @@ function StopSubscriptionButton( {
 	isProduct,
 	subscription,
 }: {
-	stopSubscription: ( data: any, variables: object ) => void;
+	stopSubscription: UseMutateFunction< MonetizeSubscriptionStopResponse, Error, void >;
 	isProduct: boolean;
 	subscription: MonetizeSubscription;
 } ) {
@@ -165,7 +172,7 @@ function StopSubscriptionButton( {
 					isDestructive
 					size="compact"
 					onClick={ () => {
-						stopSubscription( null, {
+						stopSubscription( undefined, {
 							onSuccess: () => {
 								createSuccessNotice( __( 'This item has been removed.' ), { type: 'snackbar' } );
 								navigate( { to: monetizeSubscriptionsRoute.fullPath } );

--- a/client/dashboard/sites/site/use-staging-site.ts
+++ b/client/dashboard/sites/site/use-staging-site.ts
@@ -127,7 +127,9 @@ export default function useStagingSite( site: Site ) {
 				explicitDismiss: true,
 				id: 'staging-site-added',
 			} );
-			productionSite && queryClient.invalidateQueries( siteBySlugQuery( productionSite.slug ) );
+			if ( productionSite ) {
+				queryClient.invalidateQueries( siteBySlugQuery( productionSite.slug ) );
+			}
 			queryClient.setQueryData(
 				isCreatingStagingSiteQuery( productionSiteId ?? 0 ).queryKey,
 				false
@@ -226,7 +228,7 @@ export default function useStagingSite( site: Site ) {
 				recordTracksEvent( 'calypso_hosting_configuration_staging_site_add_failure' );
 				createErrorNotice(
 					sprintf(
-						// translators: "reason" is why adding the staging site failed.
+						// translators: %(reason)s: why adding the staging site failed.
 						__( 'Failed to create staging site: %(reason)s' ),
 						{ reason: error.message }
 					),


### PR DESCRIPTION
## Proposed Changes

* Fix all eslint failures in `me/billing-monetize-subscriptions/monetize-subscription.tsx` and `sites/site/use-staging-site.ts`: missing translator comments, `any` mutation prop types (now `UseMutateFunction<...>`), and unused expressions.
* These two files are split out from the sibling per-rule PRs because they contain errors from multiple rule classes; the "Code style" CI check lints whole changed files, so any PR touching them must fix everything at once to stay green.

## Why are these changes being made?

* A stricter shared ESLint config recently landed on trunk, leaving `client/dashboard/` with pre-existing lint failures. This is part of a series of PRs fixing them one rule class at a time. Each PR leaves every file it touches fully lint-clean, so the "Code style" CI check (which lints whole changed files) passes independently of the sibling PRs.

## Testing Instructions

* Run `yarn eslint` on the two files — zero failures. `yarn typecheck-client` passes. Smoke-test monetize subscription auto-renew toggle/stop and staging site creation notices.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
