### PR TITLE
Legacy Contact: add /me/legacy-contact view behind feature flag

### DIFF
--- a/client/me/legacy-contact/controller.js
+++ b/client/me/legacy-contact/controller.js
@@ -1,0 +1,7 @@
+import { createElement } from 'react';
+import LegacyContactComponent from 'calypso/me/legacy-contact/main';
+
+export function legacyContact( context, next ) {
+	context.primary = createElement( LegacyContactComponent );
+	next();
+}

--- a/client/me/legacy-contact/index.js
+++ b/client/me/legacy-contact/index.js
@@ -1,0 +1,26 @@
+import config from '@automattic/calypso-config';
+import page from '@automattic/calypso-router';
+import {
+	makeLayout,
+	render as clientRender,
+	maybeRedirectToMultiSiteDashboard,
+} from 'calypso/controller';
+import { setupPreferences } from 'calypso/controller/preferences';
+import { sidebar } from 'calypso/me/controller';
+import { legacyContact } from './controller';
+
+export default function () {
+	if ( ! config.isEnabled( 'me/legacy-contact' ) ) {
+		return;
+	}
+
+	page(
+		'/me/legacy-contact',
+		setupPreferences,
+		maybeRedirectToMultiSiteDashboard( '/me/legacy-contact' ),
+		sidebar,
+		legacyContact,
+		makeLayout,
+		clientRender
+	);
+}

--- a/client/me/legacy-contact/index.js
+++ b/client/me/legacy-contact/index.js
@@ -1,10 +1,6 @@
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
-import {
-	makeLayout,
-	render as clientRender,
-	maybeRedirectToMultiSiteDashboard,
-} from 'calypso/controller';
+import { makeLayout, render as clientRender } from 'calypso/controller';
 import { setupPreferences } from 'calypso/controller/preferences';
 import { sidebar } from 'calypso/me/controller';
 import { legacyContact } from './controller';
@@ -14,13 +10,5 @@ export default function () {
 		return;
 	}
 
-	page(
-		'/me/legacy-contact',
-		setupPreferences,
-		maybeRedirectToMultiSiteDashboard( '/me/legacy-contact' ),
-		sidebar,
-		legacyContact,
-		makeLayout,
-		clientRender
-	);
+	page( '/me/legacy-contact', setupPreferences, sidebar, legacyContact, makeLayout, clientRender );
 }

--- a/client/me/legacy-contact/main.jsx
+++ b/client/me/legacy-contact/main.jsx
@@ -1,0 +1,33 @@
+import { Card } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import { Component } from 'react';
+import DocumentHead from 'calypso/components/data/document-head';
+import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+
+import './style.scss';
+
+class LegacyContact extends Component {
+	render() {
+		const { translate } = this.props;
+
+		return (
+			<Main wideLayout className="legacy-contact">
+				<PageViewTracker path="/me/legacy-contact" title="Me > Legacy Contact" />
+				<DocumentHead title={ translate( 'Legacy Contact' ) } />
+				<NavigationHeader navigationItems={ [] } title={ translate( 'Legacy Contact' ) } />
+
+				<Card className="legacy-contact__intro">
+					<p>
+						{ translate(
+							'A legacy contact is someone you choose to manage your account if you become unable to do so.'
+						) }
+					</p>
+				</Card>
+			</Main>
+		);
+	}
+}
+
+export default localize( LegacyContact );

--- a/client/me/legacy-contact/main.jsx
+++ b/client/me/legacy-contact/main.jsx
@@ -21,7 +21,7 @@ class LegacyContact extends Component {
 				<Card className="legacy-contact__intro">
 					<p>
 						{ translate(
-							'A legacy contact is someone you choose to manage your account if you become unable to do so.'
+							'A legacy contact is someone you trust to have access to your account after your death.'
 						) }
 					</p>
 				</Card>

--- a/client/me/legacy-contact/main.jsx
+++ b/client/me/legacy-contact/main.jsx
@@ -1,6 +1,5 @@
 import { Card } from '@automattic/components';
-import { localize } from 'i18n-calypso';
-import { Component } from 'react';
+import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
@@ -8,26 +7,22 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 
 import './style.scss';
 
-class LegacyContact extends Component {
-	render() {
-		const { translate } = this.props;
+export default function LegacyContact() {
+	const translate = useTranslate();
 
-		return (
-			<Main wideLayout className="legacy-contact">
-				<PageViewTracker path="/me/legacy-contact" title="Me > Legacy Contact" />
-				<DocumentHead title={ translate( 'Legacy Contact' ) } />
-				<NavigationHeader navigationItems={ [] } title={ translate( 'Legacy Contact' ) } />
+	return (
+		<Main wideLayout className="legacy-contact">
+			<PageViewTracker path="/me/legacy-contact" title="Me > Legacy Contact" />
+			<DocumentHead title={ translate( 'Legacy Contact' ) } />
+			<NavigationHeader navigationItems={ [] } title={ translate( 'Legacy Contact' ) } />
 
-				<Card className="legacy-contact__intro">
-					<p>
-						{ translate(
-							'A legacy contact is someone you trust to have access to your account after your death.'
-						) }
-					</p>
-				</Card>
-			</Main>
-		);
-	}
+			<Card className="legacy-contact__intro">
+				<p>
+					{ translate(
+						'A legacy contact is someone you trust to have access to your account after your death.'
+					) }
+				</p>
+			</Card>
+		</Main>
+	);
 }
-
-export default localize( LegacyContact );

--- a/client/me/legacy-contact/style.scss
+++ b/client/me/legacy-contact/style.scss
@@ -1,0 +1,7 @@
+.legacy-contact__intro {
+	max-width: 480px;
+
+	p {
+		margin-bottom: 0;
+	}
+}

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -11,6 +11,7 @@ import {
 	lockOutline,
 	notAllowed,
 	payment,
+	people,
 	seen,
 } from '@wordpress/icons';
 import { localize } from 'i18n-calypso';
@@ -226,6 +227,17 @@ class MeSidebar extends Component {
 						onNavigate={ this.onNavigate }
 						preloadSectionName="site-blocks"
 					/>
+
+					{ config.isEnabled( 'me/legacy-contact' ) && (
+						<SidebarItem
+							selected={ itemLinkMatches( '/legacy-contact', path ) }
+							link="/me/legacy-contact"
+							label={ translate( 'Legacy Contact' ) }
+							icon={ people }
+							onNavigate={ this.onNavigate }
+							preloadSectionName="legacy-contact"
+						/>
+					) }
 
 					<SidebarItem
 						selected={ itemLinkMatches( '/get-apps', path ) }

--- a/client/sections.js
+++ b/client/sections.js
@@ -110,6 +110,12 @@ const sections = [
 		module: 'calypso/me/site-blocks',
 		group: 'me',
 	},
+	{
+		name: 'legacy-contact',
+		paths: [ '/me/legacy-contact' ],
+		module: 'calypso/me/legacy-contact',
+		group: 'me',
+	},
 	// This should be the last section for `/me` paths as it would otherwise have precedence over
 	// the other sub `/me/*` sections when resolving the requested path
 	{

--- a/client/sections.js
+++ b/client/sections.js
@@ -115,6 +115,10 @@ const sections = [
 		paths: [ '/me/legacy-contact' ],
 		module: 'calypso/me/legacy-contact',
 		group: 'me',
+		// Dev-only surface (mirrors the `me/legacy-contact` feature flag). Restricting the
+		// envId keeps the route from being registered — and its chunk from being lazy-loaded —
+		// in non-development environments.
+		envId: [ 'development' ],
 	},
 	// This should be the last section for `/me` paths as it would otherwise have precedence over
 	// the other sub `/me/*` sections when resolving the requested path

--- a/client/sections.js
+++ b/client/sections.js
@@ -115,10 +115,6 @@ const sections = [
 		paths: [ '/me/legacy-contact' ],
 		module: 'calypso/me/legacy-contact',
 		group: 'me',
-		// Dev-only surface (mirrors the `me/legacy-contact` feature flag). Restricting the
-		// envId keeps the route from being registered — and its chunk from being lazy-loaded —
-		// in non-development environments.
-		envId: [ 'development' ],
 	},
 	// This should be the last section for `/me` paths as it would otherwise have precedence over
 	// the other sub `/me/*` sections when resolving the requested path

--- a/config/development.json
+++ b/config/development.json
@@ -146,6 +146,7 @@
 		"mcp-settings": true,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
+		"me/legacy-contact": true,
 		"migration-flow/introductory-offer": true,
 		"migration/ssh-migration": false,
 		"nav-redesign/2026": false,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -83,6 +83,7 @@
 		"marketplace-reviews-notification": false,
 		"marketplace-test": false,
 		"me/account/color-scheme-picker": true,
+		"me/legacy-contact": false,
 		"migration-flow/introductory-offer": true,
 		"migration/ssh-migration": false,
 		"nav-redesign/2026": false,

--- a/config/production.json
+++ b/config/production.json
@@ -102,6 +102,7 @@
 		"mcp-settings": true,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
+		"me/legacy-contact": false,
 		"migration-flow/introductory-offer": true,
 		"migration/ssh-migration": false,
 		"oauth/unified-experience": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -100,6 +100,7 @@
 		"mcp-settings": true,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
+		"me/legacy-contact": false,
 		"migration-flow/introductory-offer": true,
 		"migration/ssh-migration": false,
 		"oauth/unified-experience": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -104,6 +104,7 @@
 		"mcp-settings": true,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
+		"me/legacy-contact": false,
 		"migration-flow/introductory-offer": true,
 		"migration/ssh-migration": false,
 		"nav-redesign/2026": false,


### PR DESCRIPTION
## Proposed Changes

* Add a new `/me/legacy-contact` section (route, controller, view, styles) with a "Legacy Contact" sidebar item.
* Gate it behind a new `me/legacy-contact` feature flag — on in `development`, off everywhere else.

Part of RSM-4290.

<img width="269" height="101" alt="Screenshot 2026-06-10 at 15 46 01" src="https://github.com/user-attachments/assets/18bfef37-fd8f-4dca-b1b6-b0eb7506c93b" />



## Why are these changes being made?

* Scaffolds the Legacy Contact account-management view behind a development-only flag so it can be built out incrementally without exposing an unfinished surface in production. The view currently renders placeholder copy.

## Testing Instructions

* With the flag enabled (default in `development`), run Calypso and open `/me`.
* Confirm a "Legacy Contact" item appears in the sidebar (people icon) and navigates to `/me/legacy-contact`, rendering the page with its heading and intro card.
* Confirm that in environments where `me/legacy-contact` is `false`, the sidebar item is hidden and `/me/legacy-contact` does not resolve to this view.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?