### PR TITLE
Dashboard: move backup Learn more to page description, fix download doc

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -79,6 +79,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/settings/discussion-settings/',
 		post_id: 1504,
 	},
+	download_backup: {
+		link: 'https://wordpress.com/support/restore/download-backup/',
+		post_id: 411425,
+	},
 	domains: {
 		link: 'https://wordpress.com/support/domains/',
 		post_id: 1988,

--- a/client/dashboard/sites/backup-download/index.tsx
+++ b/client/dashboard/sites/backup-download/index.tsx
@@ -141,7 +141,20 @@ function SiteBackupDownload() {
 				<PageHeader
 					prefix={ <Breadcrumbs length={ 2 } /> }
 					title={ __( 'Download backup' ) }
-					description={ __( 'Download a backup of your site from a specific point in time.' ) }
+					description={ createInterpolateElement(
+						__( 'Download a backup of your site from a specific point in time. <LearnMore />' ),
+						{
+							LearnMore: isSelfHostedJetpackConnected( site ) ? (
+								<ExternalLink href={ localizeUrl( 'https://jetpack.com/support/backup/' ) }>
+									{ __( 'Learn more' ) }
+								</ExternalLink>
+							) : (
+								<InlineSupportLink supportContext="download_backup">
+									{ __( 'Learn more' ) }
+								</InlineSupportLink>
+							),
+						}
+					) }
 				/>
 			}
 		>
@@ -151,22 +164,10 @@ function SiteBackupDownload() {
 						<SectionHeader
 							title={ __( 'Download point' ) }
 							level={ 3 }
-							description={ createInterpolateElement(
-								/* translators: %(downloadPointDate)s: the date of the download point */
-								sprintf( __( '%(downloadPointDate)s. <LearnMore />' ), {
-									downloadPointDate,
-								} ),
-								{
-									LearnMore: isSelfHostedJetpackConnected( site ) ? (
-										<ExternalLink href={ localizeUrl( 'https://jetpack.com/support/backup/' ) }>
-											{ __( 'Learn more' ) }
-										</ExternalLink>
-									) : (
-										<InlineSupportLink supportContext="backups">
-											{ __( 'Learn more' ) }
-										</InlineSupportLink>
-									),
-								}
+							description={ sprintf(
+								/* translators: %(downloadPointDate)s is the date of the download point */
+								__( '%(downloadPointDate)s.' ),
+								{ downloadPointDate }
 							) }
 							decoration={ <Icon icon={ cloud } /> }
 						/>

--- a/client/dashboard/sites/backup-restore/index.tsx
+++ b/client/dashboard/sites/backup-restore/index.tsx
@@ -117,7 +117,24 @@ function SiteBackupRestore() {
 				<PageHeader
 					prefix={ <Breadcrumbs length={ 2 } /> }
 					title={ __( 'Site restore' ) }
-					description={ __( 'Restore your site to a previous point in time.' ) }
+					description={ createInterpolateElement(
+						__( 'Restore your site to a previous point in time. <LearnMore />' ),
+						{
+							LearnMore: isSelfHostedJetpackConnected( site ) ? (
+								<ExternalLink
+									href={ localizeUrl(
+										'https://jetpack.com/support/backup/restoring-with-jetpack-backup/'
+									) }
+								>
+									{ __( 'Learn more' ) }
+								</ExternalLink>
+							) : (
+								<InlineSupportLink supportContext="backups">
+									{ __( 'Learn more' ) }
+								</InlineSupportLink>
+							),
+						}
+					) }
 				/>
 			}
 		>
@@ -127,26 +144,10 @@ function SiteBackupRestore() {
 						<SectionHeader
 							title={ __( 'Restore point' ) }
 							level={ 3 }
-							description={ createInterpolateElement(
-								/* translators: %(restorePointDate)s: the date of the restore point */
-								sprintf( __( '%(restorePointDate)s. <LearnMore />' ), {
-									restorePointDate,
-								} ),
-								{
-									LearnMore: isSelfHostedJetpackConnected( site ) ? (
-										<ExternalLink
-											href={ localizeUrl(
-												'https://jetpack.com/support/backup/restoring-with-jetpack-backup/'
-											) }
-										>
-											{ __( 'Learn more' ) }
-										</ExternalLink>
-									) : (
-										<InlineSupportLink supportContext="backups">
-											{ __( 'Learn more' ) }
-										</InlineSupportLink>
-									),
-								}
+							description={ sprintf(
+								/* translators: %(restorePointDate)s is the date of the restore point */
+								__( '%(restorePointDate)s.' ),
+								{ restorePointDate }
 							) }
 							decoration={ <Icon icon={ cloud } /> }
 						/>


### PR DESCRIPTION
## Proposed Changes

* Move the "Learn more" link on the backup **restore** and **download** screens from the card into the page description to match MSD pattern.
* Point the download screen's support link at the "Download a backup of your site" doc instead of the restore doc.

## Why are these changes being made?

* Didn't follow established pattern.
* The download screen previously linked to a restore doc, which is the wrong topic.

## Screenshots

| Before | After |
|--------|--------|
| <img width="1044" height="945" alt="Screenshot 2026-06-10 at 2 06 43 PM" src="https://github.com/user-attachments/assets/d94b61f8-71b9-404c-943b-891312d2b4d4" /> | <img width="1042" height="949" alt="Screenshot 2026-06-10 at 2 06 05 PM" src="https://github.com/user-attachments/assets/dddcad69-9394-445a-ac7c-92ca7642e90c" />  |
| <img width="1046" height="944" alt="Screenshot 2026-06-10 at 2 06 33 PM" src="https://github.com/user-attachments/assets/8be46454-533d-43de-9be3-497e3f23a647" /> | <img width="1054" height="942" alt="Screenshot 2026-06-10 at 2 06 14 PM" src="https://github.com/user-attachments/assets/b932f8e7-cc28-43d6-9918-a1ef6b7d9062" /> | 
| <img width="710" height="560" alt="Screenshot 2026-06-10 at 2 26 24 PM" src="https://github.com/user-attachments/assets/d0dad985-5452-4123-b719-033ee54a1cc1" /> | <img width="705" height="565" alt="Screenshot 2026-06-10 at 2 26 53 PM" src="https://github.com/user-attachments/assets/64df78c7-e903-44e6-bd79-73a9e49bb0ed" /> |

## Testing Instructions

* Open a backup → **Restore**: "Learn more" shows in the page description and opens the restore doc.
* Open a backup → **Download**: "Learn more" shows in the page description and opens the download doc.
* On self-hosted Jetpack sites, links still go to the relevant jetpack.com pages.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?