### PR TITLE
Dashboard: remove icons from backup action buttons

### DIFF
--- a/client/dashboard/sites/backup-download/form.tsx
+++ b/client/dashboard/sites/backup-download/form.tsx
@@ -4,7 +4,6 @@ import { Button, __experimentalVStack as VStack } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { download } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { siteBackupDownloadRoute } from '../../app/router/sites';
@@ -120,7 +119,6 @@ function SiteBackupDownloadForm( {
 				<ButtonStack justify="flex-start">
 					<Button
 						variant="primary"
-						icon={ download }
 						type="submit"
 						isBusy={ isDownloadMutationPending }
 						disabled={ ! isFormValid || isDownloadMutationPending }

--- a/client/dashboard/sites/backup-download/success.tsx
+++ b/client/dashboard/sites/backup-download/success.tsx
@@ -1,6 +1,5 @@
 import { __experimentalVStack as VStack, Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { download } from '@wordpress/icons';
 import { useAnalytics } from '../../app/analytics';
 import { Notice } from '../../components/notice';
 import { Text } from '../../components/text';
@@ -28,7 +27,6 @@ function SiteBackupDownloadSuccess( {
 			actions={
 				<Button
 					variant="primary"
-					icon={ download }
 					text={ __( 'Download file' ) + ( fileSizeBytes ? ` (${ fileSizeBytes })` : '' ) }
 					onClick={ handleDownloadClick }
 				/>

--- a/client/dashboard/sites/backup-restore/form.tsx
+++ b/client/dashboard/sites/backup-restore/form.tsx
@@ -4,7 +4,6 @@ import { Button, __experimentalVStack as VStack } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { rotateLeft } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { siteBackupRestoreRoute } from '../../app/router/sites';
@@ -133,7 +132,6 @@ function SiteBackupRestoreForm( {
 				<ButtonStack justify="flex-start">
 					<Button
 						variant="primary"
-						icon={ rotateLeft }
 						type="submit"
 						isBusy={ isRestoreMutationPending }
 						disabled={ ! isFormValid || isRestoreMutationPending }

--- a/client/dashboard/sites/backup-restore/granular-form.tsx
+++ b/client/dashboard/sites/backup-restore/granular-form.tsx
@@ -3,7 +3,6 @@ import { useMutation } from '@tanstack/react-query';
 import { Button, __experimentalVStack as VStack, Panel } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { __, _n } from '@wordpress/i18n';
-import { rotateLeft } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useFileBrowserContext } from '../../../my-sites/backup/backup-contents-page/file-browser/file-browser-context';
 import { siteBackupRestoreRoute } from '../../app/router/sites';
@@ -99,7 +98,6 @@ function SiteBackupGranularRestoreForm( {
 				<ButtonStack justify="flex-start">
 					<Button
 						variant="primary"
-						icon={ rotateLeft }
 						type="submit"
 						isBusy={ isRestoreMutationPending }
 						disabled={ isRestoreMutationPending }

--- a/client/dashboard/sites/backups/backup-details.tsx
+++ b/client/dashboard/sites/backups/backup-details.tsx
@@ -50,7 +50,7 @@ export function BackupDetails( { backup, site, timezoneString, gmtOffset }: Back
 	);
 
 	// Granular backup download mutation
-	const granularDownloadRequest = useMutation(
+	const { mutate: granularDownloadMutate, isPending: isGranularDownloadPending } = useMutation(
 		siteGranularBackupDownloadInitiateMutation( site.ID )
 	);
 
@@ -78,7 +78,7 @@ export function BackupDetails( { backup, site, timezoneString, gmtOffset }: Back
 
 		recordTracksEvent( 'calypso_dashboard_backup_granular_download_request' );
 
-		granularDownloadRequest.mutate(
+		granularDownloadMutate(
 			{
 				rewindId: backup.rewind_id,
 				includePaths,
@@ -98,7 +98,7 @@ export function BackupDetails( { backup, site, timezoneString, gmtOffset }: Back
 	}, [
 		fileBrowserState,
 		recordTracksEvent,
-		granularDownloadRequest,
+		granularDownloadMutate,
 		backup.rewind_id,
 		router,
 		site.slug,
@@ -112,8 +112,8 @@ export function BackupDetails( { backup, site, timezoneString, gmtOffset }: Back
 				size={ isSmallViewport ? 'default' : 'compact' }
 				onClick={ hasSelectedFiles ? handleGranularDownloadClick : handleDownloadClick }
 				style={ { justifyContent: 'center' } }
-				disabled={ granularDownloadRequest.isPending }
-				isBusy={ granularDownloadRequest.isPending }
+				disabled={ isGranularDownloadPending }
+				isBusy={ isGranularDownloadPending }
 			>
 				{ hasSelectedFiles
 					? _n( 'Download selected file', 'Download selected files', selectedFilesCount )

--- a/client/dashboard/sites/backups/backup-details.tsx
+++ b/client/dashboard/sites/backups/backup-details.tsx
@@ -10,7 +10,6 @@ import {
 } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { rotateLeft, download } from '@wordpress/icons';
 import { useCallback } from 'react';
 import FileBrowser from '../../../my-sites/backup/backup-contents-page/file-browser';
 import { useFileBrowserContext } from '../../../my-sites/backup/backup-contents-page/file-browser/file-browser-context';
@@ -111,7 +110,6 @@ export function BackupDetails( { backup, site, timezoneString, gmtOffset }: Back
 			<Button
 				variant="tertiary"
 				size={ isSmallViewport ? 'default' : 'compact' }
-				icon={ download }
 				onClick={ hasSelectedFiles ? handleGranularDownloadClick : handleDownloadClick }
 				style={ { justifyContent: 'center' } }
 				disabled={ granularDownloadRequest.isPending }
@@ -124,7 +122,6 @@ export function BackupDetails( { backup, site, timezoneString, gmtOffset }: Back
 			<Button
 				variant="primary"
 				size={ isSmallViewport ? 'default' : 'compact' }
-				icon={ rotateLeft }
 				onClick={ handleRestoreClick }
 				style={ { justifyContent: 'center' } }
 			>


### PR DESCRIPTION
Related to DOTMSD-1263

## Proposed Changes

* Remove icons from the backup action buttons in the Dashboard:
  * **Download backup** / **Download selected file(s)** and **Restore to this point** / **Restore selected file(s)** (backup details)
  * **Generate download** (backup download form)
  * **Restore now** (backup restore form)
  * **Restore selected file(s)** (granular restore form)
  * **Download file** (backup download success notice)

## Why are these changes being made?

* We don't use icons in buttons in the Multi-site Dashboard.

## Screenshots

| Before | After |
|--------|--------|
| <img width="705" height="806" alt="Screenshot 2026-06-10 at 2 21 29 PM" src="https://github.com/user-attachments/assets/426509a9-ec33-48c8-901f-ddc008f82e10" /> | <img width="701" height="807" alt="Screenshot 2026-06-10 at 2 20 50 PM" src="https://github.com/user-attachments/assets/262d4248-f7e8-4b0c-9bbe-a5a9818265cc" /> |
| <img width="693" height="678" alt="Screenshot 2026-06-10 at 2 21 23 PM" src="https://github.com/user-attachments/assets/7eea7986-b8ce-4a05-adb5-79821ffa39e2" /> | <img width="697" height="690" alt="Screenshot 2026-06-10 at 2 20 42 PM" src="https://github.com/user-attachments/assets/2cf9ca5b-8645-49eb-a960-720fe94c0357" /> |
| <img width="805" height="403" alt="Screenshot 2026-06-10 at 2 21 14 PM" src="https://github.com/user-attachments/assets/ad60ba0f-0cf2-4633-9617-83b24689b42a" /> | <img width="864" height="421" alt="Screenshot 2026-06-10 at 2 20 36 PM" src="https://github.com/user-attachments/assets/44d84a3e-6028-49c1-9730-c41a84303490" /> |
| <img width="710" height="560" alt="Screenshot 2026-06-10 at 2 26 24 PM" src="https://github.com/user-attachments/assets/9cb9a166-0a5f-4c8b-82e1-9ee99f662457" /> | <img width="705" height="565" alt="Screenshot 2026-06-10 at 2 26 53 PM" src="https://github.com/user-attachments/assets/ef55579c-772f-4cc8-a0c9-ad7a0072c288" /> |

## Testing Instructions

* Go to a site's Backups in the Dashboard.
* Confirm the buttons above render without icons and still work as before.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)