### PR TITLE
Dashboard: remove decorative icons from backup detail and download/restore headers

### DIFF
--- a/client/dashboard/sites/backup-download/form.tsx
+++ b/client/dashboard/sites/backup-download/form.tsx
@@ -4,7 +4,7 @@ import { Button, __experimentalVStack as VStack } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { siteBackupDownloadRoute } from '../../app/router/sites';
@@ -113,14 +113,8 @@ function SiteBackupDownloadForm( {
 			<VStack spacing={ 4 }>
 				<p>
 					{ createInterpolateElement(
-						sprintf(
-							/* translators: %(downloadPointDate)s is the date and time of the backup */
-							__(
-								'Choose what to download from your <strong>%(downloadPointDate)s</strong> backup:'
-							),
-							{ downloadPointDate }
-						),
-						{ strong: <strong /> }
+						__( 'Choose what to download from your <downloadPointDate /> backup:' ),
+						{ downloadPointDate: <strong>{ downloadPointDate }</strong> }
 					) }
 				</p>
 				<DataForm< DownloadConfig >

--- a/client/dashboard/sites/backup-download/form.tsx
+++ b/client/dashboard/sites/backup-download/form.tsx
@@ -116,7 +116,7 @@ function SiteBackupDownloadForm( {
 						sprintf(
 							/* translators: %(downloadPointDate)s is the date and time of the backup */
 							__(
-								'Choose the items you wish to include in the download from your <strong>%(downloadPointDate)s</strong> backup:'
+								'Choose what to download from your <strong>%(downloadPointDate)s</strong> backup:'
 							),
 							{ downloadPointDate }
 						),

--- a/client/dashboard/sites/backup-download/form.tsx
+++ b/client/dashboard/sites/backup-download/form.tsx
@@ -3,7 +3,8 @@ import { useMutation } from '@tanstack/react-query';
 import { Button, __experimentalVStack as VStack } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
-import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { siteBackupDownloadRoute } from '../../app/router/sites';
@@ -50,9 +51,11 @@ const fields: Field< DownloadConfig >[] = [
 
 function SiteBackupDownloadForm( {
 	siteId,
+	downloadPointDate,
 	onDownloadInitiate,
 }: {
 	siteId: number;
+	downloadPointDate: string;
 	onDownloadInitiate: ( downloadId: number ) => void;
 } ) {
 	const { rewindId } = siteBackupDownloadRoute.useParams();
@@ -108,7 +111,18 @@ function SiteBackupDownloadForm( {
 	return (
 		<form onSubmit={ handleSubmit }>
 			<VStack spacing={ 4 }>
-				<p>{ __( 'Choose the items you wish to include in the download:' ) }</p>
+				<p>
+					{ createInterpolateElement(
+						sprintf(
+							/* translators: %(downloadPointDate)s is the date and time of the backup */
+							__(
+								'Choose the items you wish to include in the download from your <strong>%(downloadPointDate)s</strong> backup:'
+							),
+							{ downloadPointDate }
+						),
+						{ strong: <strong /> }
+					) }
+				</p>
 				<DataForm< DownloadConfig >
 					data={ formData }
 					fields={ fields }

--- a/client/dashboard/sites/backup-download/index.tsx
+++ b/client/dashboard/sites/backup-download/index.tsx
@@ -6,7 +6,6 @@ import { ExternalLink, __experimentalVStack as VStack } from '@wordpress/compone
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { Icon, cloud } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState, useEffect } from 'react';
 import { useAnalytics } from '../../app/analytics';
@@ -168,7 +167,6 @@ function SiteBackupDownload() {
 									),
 								}
 							) }
-							decoration={ <Icon icon={ cloud } /> }
 						/>
 					</CardHeader>
 					<CardBody>

--- a/client/dashboard/sites/backup-download/index.tsx
+++ b/client/dashboard/sites/backup-download/index.tsx
@@ -134,11 +134,7 @@ function SiteBackupDownload() {
 		<PageLayout
 			size="small"
 			header={
-				<PageHeader
-					prefix={ <Breadcrumbs length={ 2 } /> }
-					title={ __( 'Download backup' ) }
-					description={ __( 'Download a backup of your site from a specific point in time.' ) }
-				/>
+				<PageHeader prefix={ <Breadcrumbs length={ 2 } /> } title={ __( 'Download backup' ) } />
 			}
 		>
 			{ currentStep !== 'success' ? (

--- a/client/dashboard/sites/backup-download/index.tsx
+++ b/client/dashboard/sites/backup-download/index.tsx
@@ -1,23 +1,18 @@
 import { siteBySlugQuery, siteSettingsQuery } from '@automattic/api-queries';
-import { localizeUrl } from '@automattic/i18n-utils';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useRouter } from '@tanstack/react-router';
-import { ExternalLink, __experimentalVStack as VStack } from '@wordpress/components';
+import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { createInterpolateElement } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState, useEffect } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { siteBackupDownloadRoute } from '../../app/router/sites';
-import { Card, CardBody, CardHeader } from '../../components/card';
+import { Card, CardBody } from '../../components/card';
 import { useFormattedTime } from '../../components/formatted-time';
-import InlineSupportLink from '../../components/inline-support-link';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import { SectionHeader } from '../../components/section-header';
-import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import SiteBackupDownloadError from './error';
 import SiteBackupDownloadForm from './form';
 import SiteBackupDownloadProgress from './progress';
@@ -96,6 +91,7 @@ function SiteBackupDownload() {
 	const downloadPointDate = useFormattedTime(
 		new Date( parseFloat( rewindId ) * 1000 ).toISOString(),
 		{
+			dateStyle: 'medium',
 			timeStyle: 'short',
 		},
 		timezoneString,
@@ -108,6 +104,7 @@ function SiteBackupDownload() {
 				return (
 					<SiteBackupDownloadForm
 						siteId={ site.ID }
+						downloadPointDate={ downloadPointDate }
 						onDownloadInitiate={ handleDownloadInitiate }
 					/>
 				);
@@ -146,29 +143,6 @@ function SiteBackupDownload() {
 		>
 			{ currentStep !== 'success' ? (
 				<Card>
-					<CardHeader>
-						<SectionHeader
-							title={ __( 'Download point' ) }
-							level={ 3 }
-							description={ createInterpolateElement(
-								/* translators: %(downloadPointDate)s: the date of the download point */
-								sprintf( __( '%(downloadPointDate)s. <LearnMore />' ), {
-									downloadPointDate,
-								} ),
-								{
-									LearnMore: isSelfHostedJetpackConnected( site ) ? (
-										<ExternalLink href={ localizeUrl( 'https://jetpack.com/support/backup/' ) }>
-											{ __( 'Learn more' ) }
-										</ExternalLink>
-									) : (
-										<InlineSupportLink supportContext="backups">
-											{ __( 'Learn more' ) }
-										</InlineSupportLink>
-									),
-								}
-							) }
-						/>
-					</CardHeader>
 					<CardBody>
 						<VStack spacing={ 4 }>{ renderStep() }</VStack>
 					</CardBody>

--- a/client/dashboard/sites/backup-restore/form.tsx
+++ b/client/dashboard/sites/backup-restore/form.tsx
@@ -4,7 +4,7 @@ import { Button, __experimentalVStack as VStack } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { siteBackupRestoreRoute } from '../../app/router/sites';
@@ -122,14 +122,8 @@ function SiteBackupRestoreForm( {
 			<VStack spacing={ 4 }>
 				<p>
 					{ createInterpolateElement(
-						sprintf(
-							/* translators: %(restorePointDate)s is the date and time of the backup */
-							__(
-								'Choose what to restore from your <strong>%(restorePointDate)s</strong> backup:'
-							),
-							{ restorePointDate }
-						),
-						{ strong: <strong /> }
+						__( 'Choose what to restore from your <restorePointDate /> backup:' ),
+						{ restorePointDate: <strong>{ restorePointDate }</strong> }
 					) }
 				</p>
 				<DataForm< RestoreConfig >

--- a/client/dashboard/sites/backup-restore/form.tsx
+++ b/client/dashboard/sites/backup-restore/form.tsx
@@ -3,7 +3,8 @@ import { useMutation } from '@tanstack/react-query';
 import { Button, __experimentalVStack as VStack } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
-import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { siteBackupRestoreRoute } from '../../app/router/sites';
@@ -51,9 +52,11 @@ const fields: Field< RestoreConfig >[] = [
 
 function SiteBackupRestoreForm( {
 	siteId,
+	restorePointDate,
 	onRestoreInitiate,
 }: {
 	siteId: number;
+	restorePointDate: string;
 	onRestoreInitiate: ( restoreId: number ) => void;
 } ) {
 	const { rewindId } = siteBackupRestoreRoute.useParams();
@@ -117,7 +120,18 @@ function SiteBackupRestoreForm( {
 	return (
 		<form onSubmit={ handleSubmit }>
 			<VStack spacing={ 4 }>
-				<p>{ __( 'Choose the items you wish to restore:' ) }</p>
+				<p>
+					{ createInterpolateElement(
+						sprintf(
+							/* translators: %(restorePointDate)s is the date and time of the backup */
+							__(
+								'Choose the items you wish to restore from your <strong>%(restorePointDate)s</strong> backup:'
+							),
+							{ restorePointDate }
+						),
+						{ strong: <strong /> }
+					) }
+				</p>
 				<DataForm< RestoreConfig >
 					data={ formData }
 					fields={ fields }

--- a/client/dashboard/sites/backup-restore/form.tsx
+++ b/client/dashboard/sites/backup-restore/form.tsx
@@ -125,7 +125,7 @@ function SiteBackupRestoreForm( {
 						sprintf(
 							/* translators: %(restorePointDate)s is the date and time of the backup */
 							__(
-								'Choose the items you wish to restore from your <strong>%(restorePointDate)s</strong> backup:'
+								'Choose what to restore from your <strong>%(restorePointDate)s</strong> backup:'
 							),
 							{ restorePointDate }
 						),

--- a/client/dashboard/sites/backup-restore/granular-form.tsx
+++ b/client/dashboard/sites/backup-restore/granular-form.tsx
@@ -2,7 +2,8 @@ import { siteBackupGranularRestoreMutation } from '@automattic/api-queries';
 import { useMutation } from '@tanstack/react-query';
 import { Button, __experimentalVStack as VStack, Panel } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { __, _n } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useFileBrowserContext } from '../../../my-sites/backup/backup-contents-page/file-browser/file-browser-context';
 import { siteBackupRestoreRoute } from '../../app/router/sites';
@@ -13,9 +14,11 @@ import FileSectionPanelBody from './file-section-panel-body';
 
 function SiteBackupGranularRestoreForm( {
 	siteId,
+	restorePointDate,
 	onRestoreInitiate,
 }: {
 	siteId: number;
+	restorePointDate: string;
 	onRestoreInitiate: ( restoreId: number ) => void;
 } ) {
 	const { rewindId } = siteBackupRestoreRoute.useParams();
@@ -78,10 +81,17 @@ function SiteBackupGranularRestoreForm( {
 		<form onSubmit={ handleSubmit }>
 			<VStack spacing={ 4 }>
 				<Text>
-					{ _n(
-						'The following item will be restored:',
-						'All the following selected items will be restored:',
-						browserCheckList.totalItems
+					{ createInterpolateElement(
+						sprintf(
+							/* translators: %(restorePointDate)s is the date and time of the backup */
+							_n(
+								'The following item will be restored from your <strong>%(restorePointDate)s</strong> backup:',
+								'All the following selected items will be restored from your <strong>%(restorePointDate)s</strong> backup:',
+								browserCheckList.totalItems
+							),
+							{ restorePointDate }
+						),
+						{ strong: <strong /> }
 					) }
 				</Text>
 				<Panel>

--- a/client/dashboard/sites/backup-restore/granular-form.tsx
+++ b/client/dashboard/sites/backup-restore/granular-form.tsx
@@ -85,8 +85,8 @@ function SiteBackupGranularRestoreForm( {
 						sprintf(
 							/* translators: %(restorePointDate)s is the date and time of the backup */
 							_n(
-								'The following item will be restored from your <strong>%(restorePointDate)s</strong> backup:',
-								'All the following selected items will be restored from your <strong>%(restorePointDate)s</strong> backup:',
+								'Restoring the following item from your <strong>%(restorePointDate)s</strong> backup:',
+								'Restoring the following items from your <strong>%(restorePointDate)s</strong> backup:',
 								browserCheckList.totalItems
 							),
 							{ restorePointDate }

--- a/client/dashboard/sites/backup-restore/granular-form.tsx
+++ b/client/dashboard/sites/backup-restore/granular-form.tsx
@@ -3,7 +3,7 @@ import { useMutation } from '@tanstack/react-query';
 import { Button, __experimentalVStack as VStack, Panel } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
-import { __, _n, sprintf } from '@wordpress/i18n';
+import { __, _n } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useFileBrowserContext } from '../../../my-sites/backup/backup-contents-page/file-browser/file-browser-context';
 import { siteBackupRestoreRoute } from '../../app/router/sites';
@@ -82,16 +82,12 @@ function SiteBackupGranularRestoreForm( {
 			<VStack spacing={ 4 }>
 				<Text>
 					{ createInterpolateElement(
-						sprintf(
-							/* translators: %(restorePointDate)s is the date and time of the backup */
-							_n(
-								'Restoring the following item from your <strong>%(restorePointDate)s</strong> backup:',
-								'Restoring the following items from your <strong>%(restorePointDate)s</strong> backup:',
-								browserCheckList.totalItems
-							),
-							{ restorePointDate }
+						_n(
+							'Restoring the following item from your <restorePointDate /> backup:',
+							'Restoring the following items from your <restorePointDate /> backup:',
+							browserCheckList.totalItems
 						),
-						{ strong: <strong /> }
+						{ restorePointDate: <strong>{ restorePointDate }</strong> }
 					) }
 				</Text>
 				<Panel>

--- a/client/dashboard/sites/backup-restore/index.tsx
+++ b/client/dashboard/sites/backup-restore/index.tsx
@@ -5,7 +5,6 @@ import { ExternalLink, __experimentalVStack as VStack } from '@wordpress/compone
 import { useDispatch } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { Icon, cloud } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { useFileBrowserContext } from '../../../my-sites/backup/backup-contents-page/file-browser/file-browser-context';
@@ -148,7 +147,6 @@ function SiteBackupRestore() {
 									),
 								}
 							) }
-							decoration={ <Icon icon={ cloud } /> }
 						/>
 					</CardHeader>
 					<CardBody>

--- a/client/dashboard/sites/backup-restore/index.tsx
+++ b/client/dashboard/sites/backup-restore/index.tsx
@@ -114,11 +114,7 @@ function SiteBackupRestore() {
 		<PageLayout
 			size="small"
 			header={
-				<PageHeader
-					prefix={ <Breadcrumbs length={ 2 } /> }
-					title={ __( 'Site restore' ) }
-					description={ __( 'Restore your site to a previous point in time.' ) }
-				/>
+				<PageHeader prefix={ <Breadcrumbs length={ 2 } /> } title={ __( 'Site restore' ) } />
 			}
 		>
 			{ currentStep !== 'success' ? (

--- a/client/dashboard/sites/backup-restore/index.tsx
+++ b/client/dashboard/sites/backup-restore/index.tsx
@@ -1,23 +1,18 @@
 import { siteBySlugQuery, siteSettingsQuery } from '@automattic/api-queries';
-import { localizeUrl } from '@automattic/i18n-utils';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { ExternalLink, __experimentalVStack as VStack } from '@wordpress/components';
+import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { createInterpolateElement } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { useFileBrowserContext } from '../../../my-sites/backup/backup-contents-page/file-browser/file-browser-context';
 import { useAnalytics } from '../../app/analytics';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { siteBackupRestoreRoute } from '../../app/router/sites';
-import { Card, CardBody, CardHeader } from '../../components/card';
+import { Card, CardBody } from '../../components/card';
 import { useFormattedTime } from '../../components/formatted-time';
-import InlineSupportLink from '../../components/inline-support-link';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import { SectionHeader } from '../../components/section-header';
-import { isSelfHostedJetpackConnected } from '../../utils/site-types';
 import SiteBackupRestoreError from './error';
 import SiteBackupRestoreForm from './form';
 import SiteBackupGranularRestoreForm from './granular-form';
@@ -76,6 +71,7 @@ function SiteBackupRestore() {
 	const restorePointDate = useFormattedTime(
 		new Date( parseFloat( rewindId ) * 1000 ).toISOString(),
 		{
+			dateStyle: 'medium',
 			timeStyle: 'short',
 		},
 		timezoneString,
@@ -88,10 +84,15 @@ function SiteBackupRestore() {
 				return hasSelectedFiles && ! hasSelectedAllFiles ? (
 					<SiteBackupGranularRestoreForm
 						siteId={ site.ID }
+						restorePointDate={ restorePointDate }
 						onRestoreInitiate={ handleRestoreInitiate }
 					/>
 				) : (
-					<SiteBackupRestoreForm siteId={ site.ID } onRestoreInitiate={ handleRestoreInitiate } />
+					<SiteBackupRestoreForm
+						siteId={ site.ID }
+						restorePointDate={ restorePointDate }
+						onRestoreInitiate={ handleRestoreInitiate }
+					/>
 				);
 			case 'progress':
 				return restoreId ? (
@@ -122,33 +123,6 @@ function SiteBackupRestore() {
 		>
 			{ currentStep !== 'success' ? (
 				<Card>
-					<CardHeader>
-						<SectionHeader
-							title={ __( 'Restore point' ) }
-							level={ 3 }
-							description={ createInterpolateElement(
-								/* translators: %(restorePointDate)s: the date of the restore point */
-								sprintf( __( '%(restorePointDate)s. <LearnMore />' ), {
-									restorePointDate,
-								} ),
-								{
-									LearnMore: isSelfHostedJetpackConnected( site ) ? (
-										<ExternalLink
-											href={ localizeUrl(
-												'https://jetpack.com/support/backup/restoring-with-jetpack-backup/'
-											) }
-										>
-											{ __( 'Learn more' ) }
-										</ExternalLink>
-									) : (
-										<InlineSupportLink supportContext="backups">
-											{ __( 'Learn more' ) }
-										</InlineSupportLink>
-									),
-								}
-							) }
-						/>
-					</CardHeader>
 					<CardBody>
 						<VStack spacing={ 4 }>{ renderStep() }</VStack>
 					</CardBody>

--- a/client/dashboard/sites/backups/backup-details.tsx
+++ b/client/dashboard/sites/backups/backup-details.tsx
@@ -6,7 +6,6 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	Button,
-	Icon,
 } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { __, _n, sprintf } from '@wordpress/i18n';
@@ -20,7 +19,6 @@ import { Card, CardBody, CardHeader } from '../../components/card';
 import { useFormattedTime } from '../../components/formatted-time';
 import { SectionHeader } from '../../components/section-header';
 import { Text } from '../../components/text';
-import { gridiconToWordPressIcon } from '../../utils/gridicons';
 import { ImagePreview } from './image-preview';
 import type { ActivityLogEntry, Site } from '@automattic/api-core';
 
@@ -135,11 +133,7 @@ export function BackupDetails( { backup, site, timezoneString, gmtOffset }: Back
 	return (
 		<Card>
 			<CardHeader style={ { flexDirection: 'column', alignItems: 'stretch' } }>
-				<SectionHeader
-					title={ backup.summary }
-					decoration={ <Icon icon={ gridiconToWordPressIcon( backup.gridicon ) } /> }
-					actions={ ! isSmallViewport ? actions : null }
-				/>
+				<SectionHeader title={ backup.summary } actions={ ! isSmallViewport ? actions : null } />
 				{ isSmallViewport ? actions : null }
 			</CardHeader>
 			<CardBody style={ { minHeight: '300px' } }>


### PR DESCRIPTION
Related to DOTMSD-1263

## Proposed Changes

- Remove the icon shown next to the backup summary title in the backup details panel.
- On the **Download backup** and **Site restore** inner pages, remove the "Download point" / "Restore point" card header entirely. 
  - The Dashboard doesn't use cut off headers like this. 
- Move backup's date and time into the test.


## Why are these changes being made?

We don't show icons next to section/title headers, or use card headers, anywhere else in the Dashboard. The surrounding context already makes these clear, and the timestamp reads more naturally inline with the prompt.

## Screenshots

| Before | After |
|--------|--------|
| <img width="737" height="808" alt="Screenshot 2026-06-10 at 2 56 39 PM" src="https://github.com/user-attachments/assets/964d264f-7588-47b3-9b1c-3688a75cbcee" /> | <img width="697" height="692" alt="Screenshot 2026-06-10 at 2 56 11 PM" src="https://github.com/user-attachments/assets/31b6eb05-6a0f-4277-98a8-08945b5ddd63" /> |
| <img width="706" height="681" alt="Screenshot 2026-06-10 at 2 56 33 PM" src="https://github.com/user-attachments/assets/8d394240-b9cc-4eb3-bdd5-f300345739ba" /> | <img width="719" height="600" alt="Screenshot 2026-06-10 at 2 56 18 PM" src="https://github.com/user-attachments/assets/881ccf83-9db0-494a-a1cd-0c802ddeccef" />  | 


## Testing Instructions

* In the Dashboard, open a site's Backups and select a backup to view its details in the right panel — confirm the title no longer has an icon.
* Click through to **Download backup** and **Site restore** — confirm there's no card header or page-header description, and that the form prompt names the backup's date and time in bold.
* On the restore page, select individual files and confirm the granular restore prompt also names the date and time.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)