### PR TITLE
Help Center: scope persisted open-state per app to stop app leaking into other apps.

### DIFF
--- a/client/a8c-for-agencies/index.tsx
+++ b/client/a8c-for-agencies/index.tsx
@@ -1,6 +1,12 @@
 import page from '@automattic/calypso-router';
+import { HelpCenter } from '@automattic/data-stores';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { redirectToLandingContext } from './controller';
+
+// Namespace the persisted Help Center open-state to A4A so that opening the
+// Help Center here doesn't leak into (or get overridden by) the shared
+// WPCOM/Jetpack user preferences. Must run before any Help Center store read.
+HelpCenter.setHelpCenterAppId( 'a4a' );
 
 export default function () {
 	page( '/', redirectToLandingContext, makeLayout, clientRender );

--- a/client/a8c-for-agencies/index.tsx
+++ b/client/a8c-for-agencies/index.tsx
@@ -3,9 +3,7 @@ import { HelpCenter } from '@automattic/data-stores';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { redirectToLandingContext } from './controller';
 
-// Namespace the persisted Help Center open-state to A4A so that opening the
-// Help Center here doesn't leak into (or get overridden by) the shared
-// WPCOM/Jetpack user preferences. Must run before any Help Center store read.
+// Must run before any Help Center store read.
 HelpCenter.setHelpCenterAppId( 'a4a' );
 
 export default function () {

--- a/client/a8c-for-agencies/index.tsx
+++ b/client/a8c-for-agencies/index.tsx
@@ -1,10 +1,6 @@
 import page from '@automattic/calypso-router';
-import { HelpCenter } from '@automattic/data-stores';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { redirectToLandingContext } from './controller';
-
-// Must run before any Help Center store read.
-HelpCenter.setHelpCenterAppId( 'a4a' );
 
 export default function () {
 	page( '/', redirectToLandingContext, makeLayout, clientRender );

--- a/packages/data-stores/src/help-center/index.ts
+++ b/packages/data-stores/src/help-center/index.ts
@@ -39,4 +39,5 @@ export function register(): typeof STORE_KEY {
 	return STORE_KEY;
 }
 
+export { setHelpCenterAppId } from './utils';
 export type { HelpCenterSite } from './types';

--- a/packages/data-stores/src/help-center/test/utils.ts
+++ b/packages/data-stores/src/help-center/test/utils.ts
@@ -1,0 +1,99 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { PREFERENCES_KEY } from '../constants';
+
+jest.mock( '@wordpress/data', () => ( {
+	select: jest.fn(),
+} ) );
+
+jest.mock( '../../wpcom-request', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+	canAccessWpcomApis: jest.fn(),
+} ) );
+
+describe( 'help-center utils — localStorage persistence (logged out)', () => {
+	let utils: typeof import('../utils');
+
+	beforeEach( async () => {
+		jest.resetModules();
+		window.localStorage.clear();
+		utils = await import( '../utils' );
+	} );
+
+	it( 'persists and reads under the unscoped key when no appId is set', () => {
+		utils.persistValueSafely( 'help_center_open', true );
+
+		expect( window.localStorage.getItem( PREFERENCES_KEY + 'help_center_open' ) ).toBe( 'true' );
+		expect( utils.retrieveValueSafely( 'help_center_open' ) ).toBe( true );
+	} );
+
+	it( 'persists under the app-scoped key when an appId is set', () => {
+		utils.setHelpCenterAppId( 'a4a' );
+		utils.persistValueSafely( 'help_center_open', true );
+
+		expect( window.localStorage.getItem( PREFERENCES_KEY + 'help_center_open_a4a' ) ).toBe(
+			'true'
+		);
+		// The shared, unscoped field is left untouched.
+		expect( window.localStorage.getItem( PREFERENCES_KEY + 'help_center_open' ) ).toBeNull();
+	} );
+
+	it( 'falls back to the shared (unscoped) value when the scoped one is absent', () => {
+		// Value written by another, unscoped context.
+		window.localStorage.setItem( PREFERENCES_KEY + 'help_center_open', 'true' );
+		utils.setHelpCenterAppId( 'a4a' );
+
+		expect( utils.retrieveValueSafely( 'help_center_open' ) ).toBe( true );
+	} );
+
+	it( 'prefers the scoped value over the shared one once it exists', () => {
+		window.localStorage.setItem( PREFERENCES_KEY + 'help_center_open', 'false' );
+		window.localStorage.setItem( PREFERENCES_KEY + 'help_center_open_a4a', 'true' );
+		utils.setHelpCenterAppId( 'a4a' );
+
+		expect( utils.retrieveValueSafely( 'help_center_open' ) ).toBe( true );
+	} );
+} );
+
+describe( 'getPersistedPreference — server preferences (logged in)', () => {
+	async function setup(
+		preferences: Record< string, unknown >
+	): Promise< typeof import('../utils') > {
+		jest.resetModules();
+
+		const { select } = await import( '@wordpress/data' );
+		( select as jest.Mock ).mockReturnValue( { getIsLoggedIn: () => true } );
+
+		const wpcomRequest = await import( '../../wpcom-request' );
+		( wpcomRequest.canAccessWpcomApis as jest.Mock ).mockReturnValue( true );
+		( wpcomRequest.default as jest.Mock ).mockResolvedValue( {
+			calypso_preferences: preferences,
+		} );
+
+		return import( '../utils' );
+	}
+
+	it( 'returns the scoped value when present', async () => {
+		const utils = await setup( { help_center_open: false, help_center_open_a4a: true } );
+		utils.setHelpCenterAppId( 'a4a' );
+
+		await expect( utils.getPersistedPreference( 'help_center_open' ) ).resolves.toBe( true );
+	} );
+
+	it( 'falls back to the unscoped value when the scoped one is absent', async () => {
+		const utils = await setup( { help_center_open: true } );
+		utils.setHelpCenterAppId( 'a4a' );
+
+		await expect( utils.getPersistedPreference( 'help_center_open' ) ).resolves.toBe( true );
+	} );
+
+	it( 'reads the unscoped value when no appId is set', async () => {
+		const utils = await setup( { help_center_open: true, help_center_open_a4a: false } );
+		utils.setHelpCenterAppId( undefined );
+
+		await expect( utils.getPersistedPreference( 'help_center_open' ) ).resolves.toBe( true );
+	} );
+} );

--- a/packages/data-stores/src/help-center/utils.ts
+++ b/packages/data-stores/src/help-center/utils.ts
@@ -12,10 +12,6 @@ const memoryStore: Preferences[ 'calypso_preferences' ] = {
 	help_center_router_history: null,
 };
 
-/**
- * Identifies the app/product the Help Center is running inside (e.g. 'a4a').
- *
- */
 let helpCenterAppId: string | undefined;
 
 export function setHelpCenterAppId( appId: string | undefined ): void {

--- a/packages/data-stores/src/help-center/utils.ts
+++ b/packages/data-stores/src/help-center/utils.ts
@@ -22,8 +22,22 @@ export function setHelpCenterAppId( appId: string | undefined ): void {
 	helpCenterAppId = appId;
 }
 
-function scopedKey< T extends keyof Preferences[ 'calypso_preferences' ] >( key: T ): T {
-	return ( helpCenterAppId ? `${ key }_${ helpCenterAppId }` : key ) as T;
+function scopedKey( key: string ): string {
+	return helpCenterAppId ? `${ key }_${ helpCenterAppId }` : key;
+}
+
+/**
+ * Reads the app-scoped preference, falling back to the shared (unscoped) one.
+ */
+function readScoped< T extends keyof Preferences[ 'calypso_preferences' ] >(
+	preferences: Preferences[ 'calypso_preferences' ],
+	key: T
+): Preferences[ 'calypso_preferences' ][ T ] | undefined {
+	// The scoped key is dynamic, so the cast is confined here to keep callers typed.
+	const scoped = (
+		preferences as unknown as Record< string, Preferences[ 'calypso_preferences' ][ T ] >
+	 )[ scopedKey( key ) ];
+	return scoped ?? preferences[ key ];
 }
 
 export function deleteValuesSafely(): void {
@@ -54,7 +68,7 @@ export function retrieveValueSafely< T extends keyof Preferences[ 'calypso_prefe
 ): Preferences[ 'calypso_preferences' ][ T ] | undefined {
 	try {
 		// Prefer this app's scoped value, falling back to the shared (unscoped)
-		// one when it hasn't stored its own yet. Mapped onto the original key.
+		// one when it hasn't stored its own yet.
 		const value =
 			window.localStorage.getItem( PREFERENCES_KEY + scopedKey( key ) ) ??
 			window.localStorage.getItem( PREFERENCES_KEY + key );
@@ -95,8 +109,7 @@ export async function getPersistedPreference<
 
 	if ( isLoggedIn ) {
 		const preferences = await getCalypsoPreferences();
-		const scopedValue = preferences[ scopedKey( key ) ];
-		return scopedValue ?? preferences[ key ];
+		return readScoped( preferences, key );
 	}
 
 	return retrieveValueSafely( key );

--- a/packages/data-stores/src/help-center/utils.ts
+++ b/packages/data-stores/src/help-center/utils.ts
@@ -12,11 +12,25 @@ const memoryStore: Preferences[ 'calypso_preferences' ] = {
 	help_center_router_history: null,
 };
 
+/**
+ * Identifies the app/product the Help Center is running inside (e.g. 'a4a').
+ *
+ */
+let helpCenterAppId: string | undefined;
+
+export function setHelpCenterAppId( appId: string | undefined ): void {
+	helpCenterAppId = appId;
+}
+
+function scopedKey< T extends keyof Preferences[ 'calypso_preferences' ] >( key: T ): T {
+	return ( helpCenterAppId ? `${ key }_${ helpCenterAppId }` : key ) as T;
+}
+
 export function deleteValuesSafely(): void {
 	try {
-		window.localStorage.removeItem( PREFERENCES_KEY + 'help_center_open' );
-		window.localStorage.removeItem( PREFERENCES_KEY + 'help_center_minimized' );
-		window.localStorage.removeItem( PREFERENCES_KEY + 'help_center_router_history' );
+		window.localStorage.removeItem( PREFERENCES_KEY + scopedKey( 'help_center_open' ) );
+		window.localStorage.removeItem( PREFERENCES_KEY + scopedKey( 'help_center_minimized' ) );
+		window.localStorage.removeItem( PREFERENCES_KEY + scopedKey( 'help_center_router_history' ) );
 	} catch ( error ) {
 		memoryStore.help_center_open = undefined;
 		memoryStore.help_center_minimized = false;
@@ -29,7 +43,7 @@ export function persistValueSafely< T extends keyof Preferences[ 'calypso_prefer
 	value: Preferences[ 'calypso_preferences' ][ T ]
 ): void {
 	try {
-		window.localStorage.setItem( PREFERENCES_KEY + key, JSON.stringify( value ) );
+		window.localStorage.setItem( PREFERENCES_KEY + scopedKey( key ), JSON.stringify( value ) );
 	} catch ( error ) {
 		memoryStore[ key ] = value;
 	}
@@ -39,7 +53,11 @@ export function retrieveValueSafely< T extends keyof Preferences[ 'calypso_prefe
 	key: T
 ): Preferences[ 'calypso_preferences' ][ T ] | undefined {
 	try {
-		const value = window.localStorage.getItem( PREFERENCES_KEY + key );
+		// Prefer this app's scoped value, falling back to the shared (unscoped)
+		// one when it hasn't stored its own yet. Mapped onto the original key.
+		const value =
+			window.localStorage.getItem( PREFERENCES_KEY + scopedKey( key ) ) ??
+			window.localStorage.getItem( PREFERENCES_KEY + key );
 		return value ? JSON.parse( value ) : undefined;
 	} catch ( error ) {
 		return memoryStore[ key ];
@@ -77,7 +95,8 @@ export async function getPersistedPreference<
 
 	if ( isLoggedIn ) {
 		const preferences = await getCalypsoPreferences();
-		return preferences[ key ];
+		const scopedValue = preferences[ scopedKey( key ) ];
+		return scopedValue ?? preferences[ key ];
 	}
 
 	return retrieveValueSafely( key );
@@ -96,7 +115,7 @@ export function persistPreference< T extends keyof Preferences[ 'calypso_prefere
 		return;
 	}
 
-	const newPreferences = { [ preference ]: value };
+	const newPreferences = { [ scopedKey( preference ) ]: value };
 
 	const isLoggedIn = ( select( STORE_KEY ) as unknown as HelpCenterSelect ).getIsLoggedIn();
 

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -4,6 +4,7 @@
  */
 import { useShouldUseUnifiedAgent } from '@automattic/agents-manager';
 import { initializeAnalytics } from '@automattic/calypso-analytics';
+import { HelpCenter as HelpCenterStore } from '@automattic/data-stores';
 import { useCanConnectToZendeskMessaging } from '@automattic/zendesk-client';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createPortal, useEffect, useState } from '@wordpress/element';
@@ -102,6 +103,10 @@ export default function ContextualizedHelpCenter( {
 }: Container &
 	Partial< HelpCenterRequiredInformation > &
 	Pick< HelpCenterRequiredInformation, 'currentUser' | 'sectionName' > ) {
+	HelpCenterStore.setHelpCenterAppId(
+		props.product && props.product !== 'wpcom' ? props.product : undefined
+	);
+
 	return (
 		<HelpCenterRequiredContextProvider value={ props }>
 			<HelpCenter hidden={ hidden } currentRoute={ currentRoute } handleClose={ handleClose } />


### PR DESCRIPTION

Closes https://linear.app/a8c/issue/A4A-2717/a4a-support-modal-appears-in-network-admin

## Proposed Changes
  The Help Center open-state is persisted to the shared per-user `calypso_preferences` blob (and localStorage when logged out), so opening it in A4A flipped the same `help_center_open` field that WPCOM and Jetpack Manage read on boot —  making it appear there too.

  The data store now supports an optional app id: when set, the open-state is read/written under app-namespaced keys (`help_center_open_a4a`, etc.), falling back to the unscoped field until the app stores its own. The Help Center panel sets this itself from the `product` it's already configured with (in `ContextualizedHelpCenter`, mounted on every  route), so no app opts in at boot — `a4a` scopes its keys, while WPCOM/Jetpack stay unscoped and unchanged.


## Why are these changes being made?

So Help Center state isn't shared across apps.

## Testing Instructions


  * On the A4A live link, navigate to a non-root page (e.g. `/sites`) and open the Help Center via the sidebar.
  * Open some articles, then go to WordPress.com (e.g. https://wordpress.com/sites/<SITES>) and refresh.
  * Confirm the Help Center doesn't open there.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
