### PR TITLE
Global Nav 2026: wire the A/B experiment into the logged-in layout

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -22,6 +22,7 @@ import { retrieveMobileRedirect } from 'calypso/jetpack-connect/persistence-util
 import { installKonamiListener } from 'calypso/layout/arcade-mode/detect';
 import EmptyMasterbar from 'calypso/layout/masterbar/empty';
 import MasterbarLoggedIn from 'calypso/layout/masterbar/logged-in';
+import { useNav2026Props } from 'calypso/layout/use-nav-2026-props';
 import { isInStepContainerV2FlowContext } from 'calypso/layout/utils';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { ClassicColorSchemeProvider, withColorScheme } from 'calypso/lib/color-scheme';
@@ -39,12 +40,7 @@ import UserVerificationChecker from 'calypso/lib/user/verification-checker';
 import PluginCompassAgentLoader from 'calypso/my-sites/plugins/plugin-compass-agent-loader';
 import { isFetchingAdminColor } from 'calypso/state/admin-color/selectors';
 import { loadTrackingTool } from 'calypso/state/analytics/actions';
-import {
-	getCurrentUser,
-	getCurrentUserDisplayName,
-	getCurrentUserEmail,
-	isUserLoggedIn,
-} from 'calypso/state/current-user/selectors';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors';
 import { getSidebarType, SidebarType } from 'calypso/state/global-sidebar/selectors';
 import { isUserNewerThan, WEEK_IN_MILLISECONDS } from 'calypso/state/guided-tours/contexts';
@@ -289,13 +285,7 @@ class Layout extends Component {
 					<UniversalNavbarHeader
 						isLoggedIn={ this.props.isLoggedIn }
 						sectionName={ this.props.sectionName }
-						{ ...( this.props.nav2026 && {
-							nav2026: true,
-							nav2026Variant: this.props.nav2026Variant,
-							userAvatar: this.props.userAvatar,
-							userName: this.props.userName,
-							userEmail: this.props.userEmail,
-						} ) }
+						{ ...this.props.nav2026Props }
 					/>
 				) }
 				<MasterbarComponent
@@ -478,6 +468,14 @@ class Layout extends Component {
 	}
 }
 
+// `Layout` is a class component, so the 2026 Global Nav hook lives in this
+// wrapper. The hook resolves the config-flag force-on and the ExPlat experiment
+// assignment into the props the universal header expects (or `{}` for the old nav).
+function LayoutWithNav2026Props( props ) {
+	const nav2026Props = useNav2026Props();
+	return <Layout { ...props } nav2026Props={ nav2026Props } />;
+}
+
 export default withCurrentRoute(
 	connect( ( state, { currentSection, currentRoute, currentQuery, secondary } ) => {
 		const dashboard = getDashboardFromHostname( window?.location?.hostname );
@@ -628,11 +626,6 @@ export default withCurrentRoute(
 			isNewUser: isUserNewerThan( WEEK_IN_MILLISECONDS )( state ),
 			isGravatarDomain,
 			hasUniversalHeader,
-			nav2026: config.isEnabled( 'nav-redesign/2026' ),
-			nav2026Variant: config.isEnabled( 'nav-redesign/2026-variant-2' ) ? 2 : 1,
-			userAvatar: getCurrentUser( state )?.avatar_URL,
-			userName: getCurrentUserDisplayName( state ),
-			userEmail: getCurrentUserEmail( state ),
 		};
-	} )( Layout )
+	} )( LayoutWithNav2026Props )
 );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -282,10 +282,9 @@ class Layout extends Component {
 		return (
 			<>
 				{ this.props.hasUniversalHeader && (
-					<UniversalNavbarHeader
+					<Nav2026UniversalHeader
 						isLoggedIn={ this.props.isLoggedIn }
 						sectionName={ this.props.sectionName }
-						{ ...this.props.nav2026Props }
 					/>
 				) }
 				<MasterbarComponent
@@ -468,10 +467,17 @@ class Layout extends Component {
 	}
 }
 
-// Hook wrapper — `Layout` is a class component.
-function LayoutWithNav2026Props( props ) {
+// Resolves the 2026 nav experiment only where the universal header renders,
+// so non-universal-header routes don't fetch an unused ExPlat assignment.
+function Nav2026UniversalHeader( { isLoggedIn, sectionName } ) {
 	const nav2026Props = useNav2026Props();
-	return <Layout { ...props } nav2026Props={ nav2026Props } />;
+	return (
+		<UniversalNavbarHeader
+			isLoggedIn={ isLoggedIn }
+			sectionName={ sectionName }
+			{ ...nav2026Props }
+		/>
+	);
 }
 
 export default withCurrentRoute(
@@ -625,5 +631,5 @@ export default withCurrentRoute(
 			isGravatarDomain,
 			hasUniversalHeader,
 		};
-	} )( LayoutWithNav2026Props )
+	} )( Layout )
 );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -468,9 +468,7 @@ class Layout extends Component {
 	}
 }
 
-// `Layout` is a class component, so the 2026 Global Nav hook lives in this
-// wrapper. The hook resolves the config-flag force-on and the ExPlat experiment
-// assignment into the props the universal header expects (or `{}` for the old nav).
+// Hook wrapper — `Layout` is a class component.
 function LayoutWithNav2026Props( props ) {
 	const nav2026Props = useNav2026Props();
 	return <Layout { ...props } nav2026Props={ nav2026Props } />;

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -583,8 +583,9 @@ body.is-mobile-app-view {
 	--nav-2026-admin-offset: var( --masterbar-height );
 }
 
-// Patterns and modern themes opt out — their hero slides under the nav, so don't reserve space.
+// Patterns, modern themes, and logged-out plugins opt out — their hero slides under the nav, so don't reserve space.
 .layout.is-section-patterns:has( .x-nav--2026-redesign ) .layout__header-section,
-.layout.is-theme-showcase-modern:has( .x-nav--2026-redesign ) .layout__header-section {
+.layout.is-theme-showcase-modern:has( .x-nav--2026-redesign ) .layout__header-section,
+.layout.is-section-plugins:not( .is-logged-in ):has( .x-nav--2026-redesign ) .layout__header-section {
 	min-height: 0;
 }

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -583,7 +583,7 @@ body.is-mobile-app-view {
 	--nav-2026-admin-offset: var( --masterbar-height );
 }
 
-// Patterns, modern themes, and logged-out plugins opt out — their hero slides under the nav, so don't reserve space.
+// These surfaces float the nav over their hero, so don't reserve its space.
 .layout.is-section-patterns:has( .x-nav--2026-redesign ) .layout__header-section,
 .layout.is-theme-showcase-modern:has( .x-nav--2026-redesign ) .layout__header-section,
 .layout.is-section-plugins:not( .is-logged-in ):has( .x-nav--2026-redesign ) .layout__header-section {

--- a/client/layout/use-nav-2026-props.ts
+++ b/client/layout/use-nav-2026-props.ts
@@ -47,8 +47,11 @@ export function useNav2026Props(): Nav2026Props {
 	const userEmail = useSelector( getCurrentUserEmail );
 
 	// Hooks must run unconditionally; the assignment is ignored when forced on.
+	// SSR is ineligible: the server-side ExPlat dummy client logs an error on
+	// every render-time read and can never produce an assignment anyway. The
+	// browser refetches on hydration, where eligibility flips true.
 	const [ isLoadingExperiment, experimentAssignment ] = useExperiment( NAV_2026_EXPERIMENT, {
-		isEligible: ! forcedOn,
+		isEligible: ! forcedOn && typeof window !== 'undefined',
 	} );
 
 	// Resolve the variant: the config flag forces it on for staff/dev, otherwise

--- a/client/layout/use-nav-2026-props.ts
+++ b/client/layout/use-nav-2026-props.ts
@@ -46,10 +46,7 @@ export function useNav2026Props(): Nav2026Props {
 	const userName = useSelector( getCurrentUserDisplayName );
 	const userEmail = useSelector( getCurrentUserEmail );
 
-	// Hooks must run unconditionally; the assignment is ignored when forced on.
-	// SSR is ineligible: the server-side ExPlat dummy client logs an error on
-	// every render-time read and can never produce an assignment anyway. The
-	// browser refetches on hydration, where eligibility flips true.
+	// SSR is ineligible (no assignment server-side); the browser refetches on hydration.
 	const [ isLoadingExperiment, experimentAssignment ] = useExperiment( NAV_2026_EXPERIMENT, {
 		isEligible: ! forcedOn && typeof window !== 'undefined',
 	} );

--- a/client/my-sites/patterns/style.scss
+++ b/client/my-sites/patterns/style.scss
@@ -73,12 +73,17 @@
 		}
 	}
 
-	// Closed state: transparent nav over the dark hero, so text/logo/chevron go white.
+	// Closed state: transparent nav over the dark hero, so text/logo/chevron go
+	// white — and the Get started hover swap inverts with the ink (white fill,
+	// dark label), via the hooks the shared nav stylesheet exposes.
 	.lpc-header-nav-container:not(
 			:has( .x-dropdown--2026.x-dropdown-content[aria-hidden='false'] )
 		):not( .is-scrolled )
 		.x-nav--2026-redesign
 		.x-nav-item {
+		--x-nav-2026-cta-hover-fill: var( --studio-white );
+		--x-nav-2026-cta-hover-ink: var( --studio-gray-100 );
+
 		color: var( --studio-white ) !important;
 
 		.x-nav-link-chevron::before {

--- a/client/my-sites/patterns/style.scss
+++ b/client/my-sites/patterns/style.scss
@@ -73,9 +73,7 @@
 		}
 	}
 
-	// Closed state: transparent nav over the dark hero, so text/logo/chevron go
-	// white — and the Get started hover swap inverts with the ink (white fill,
-	// dark label), via the hooks the shared nav stylesheet exposes.
+	// Closed over the dark hero: white nav ink, inverted CTA hover swap.
 	.lpc-header-nav-container:not(
 			:has( .x-dropdown--2026.x-dropdown-content[aria-hidden='false'] )
 		):not( .is-scrolled )

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -174,6 +174,14 @@ body.is-section-plugins #primary .main.is-logged-out {
 		}
 	}
 
+	// 2026 nav floats over this hero; extend the gray up behind it and pad content
+	// down by the nav height so it clears the transparent bar.
+	.layout.is-section-plugins:not( .is-logged-in ):has( .x-nav--2026-redesign ) & {
+		margin-top: calc( -1 * var( --nav-2026-sticky-offset ) );
+		padding-top: calc( 157px + var( --nav-2026-sticky-offset ) );
+		background-color: var( --studio-gray-0 );
+	}
+
 	&::before {
 		content: "";
 		position: absolute;

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -174,8 +174,7 @@ body.is-section-plugins #primary .main.is-logged-out {
 		}
 	}
 
-	// 2026 nav floats over this hero; extend the gray up behind it and pad content
-	// down by the nav height so it clears the transparent bar.
+	// 2026 nav floats over this hero; gray bleeds up behind it, content clears it.
 	.layout.is-section-plugins:not( .is-logged-in ):has( .x-nav--2026-redesign ) & {
 		margin-top: calc( -1 * var( --nav-2026-sticky-offset ) );
 		padding-top: calc( 157px + var( --nav-2026-sticky-offset ) );

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -122,6 +122,12 @@
 		margin-bottom: 0;
 	}
 }
+
+// Logged-in /themes has no hero; tint the fixed-nav band to the header backdrop.
+.layout.is-logged-in.is-section-themes:has( .x-nav--2026-redesign ) .layout__header-section {
+	background-color: var( --color-primary-5 );
+}
+
 .is-logged-out {
 	--color-surface-backdrop: var( --color-primary-5 );
 

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/app-banner.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/app-banner.tsx
@@ -37,6 +37,7 @@ export function Nav2026AppBanner( {
 			) }
 			href={ localizeUrl( '//apps.wordpress.com/get/?campaign=wpcom-log-out-home-global-nav' ) }
 			tabIndex={ isHidden ? -1 : tabIndex }
+			aria-hidden={ isHidden || undefined }
 		>
 			<span className="x-menu-mobile-app-banner-icons" aria-hidden="true">
 				<svg

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/app-banner.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/app-banner.tsx
@@ -11,6 +11,7 @@ type Translate = ( text: string, domain?: string ) => string;
 
 interface Nav2026AppBannerProps {
 	mobilePlatform: 'ios' | 'android' | null;
+	isHidden?: boolean;
 	tabIndex: number | undefined;
 	localizeUrl: LocalizeUrl;
 	__: Translate;
@@ -19,6 +20,7 @@ interface Nav2026AppBannerProps {
 // "Get Jetpack app" mobile banner (whole banner is the link). `null` off iOS / Android.
 export function Nav2026AppBanner( {
 	mobilePlatform,
+	isHidden,
 	tabIndex,
 	localizeUrl,
 	__,
@@ -30,10 +32,11 @@ export function Nav2026AppBanner( {
 		<a
 			className={ clsx(
 				'x-menu-mobile-app-banner',
-				`x-menu-mobile-app-banner--${ mobilePlatform }`
+				`x-menu-mobile-app-banner--${ mobilePlatform }`,
+				{ 'is-hidden': isHidden }
 			) }
 			href={ localizeUrl( '//apps.wordpress.com/get/?campaign=wpcom-log-out-home-global-nav' ) }
-			tabIndex={ tabIndex }
+			tabIndex={ isHidden ? -1 : tabIndex }
 		>
 			<span className="x-menu-mobile-app-banner-icons" aria-hidden="true">
 				<svg

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/mobile-menu.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/mobile-menu.tsx
@@ -213,12 +213,15 @@ export function Nav2026MobileMenu( {
 					) }
 				</div>
 				<div className="x-menu-mobile-footer" ref={ mobileFooterRef }>
-					<Nav2026AppBanner
-						mobilePlatform={ mobilePlatform }
-						tabIndex={ mobileMenuTabIndex }
-						localizeUrl={ localizeUrl }
-						__={ __ }
-					/>
+					{ /* The app banner belongs to the menu's top-level screen only. */ }
+					{ ! activeCategory && (
+						<Nav2026AppBanner
+							mobilePlatform={ mobilePlatform }
+							tabIndex={ mobileMenuTabIndex }
+							localizeUrl={ localizeUrl }
+							__={ __ }
+						/>
+					) }
 					{ isLoggedIn ? (
 						<a
 							className="x-menu-mobile-user x-link"

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/mobile-menu.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/mobile-menu.tsx
@@ -213,7 +213,7 @@ export function Nav2026MobileMenu( {
 					) }
 				</div>
 				<div className="x-menu-mobile-footer" ref={ mobileFooterRef }>
-					{ /* Top-level screen only; hidden (faded) while a category is drilled into. */ }
+					{ /* Top-level screen only; hidden while a category is drilled into. */ }
 					<Nav2026AppBanner
 						mobilePlatform={ mobilePlatform }
 						isHidden={ !! activeCategory }

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/mobile-menu.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/mobile-menu.tsx
@@ -213,15 +213,14 @@ export function Nav2026MobileMenu( {
 					) }
 				</div>
 				<div className="x-menu-mobile-footer" ref={ mobileFooterRef }>
-					{ /* The app banner belongs to the menu's top-level screen only. */ }
-					{ ! activeCategory && (
-						<Nav2026AppBanner
-							mobilePlatform={ mobilePlatform }
-							tabIndex={ mobileMenuTabIndex }
-							localizeUrl={ localizeUrl }
-							__={ __ }
-						/>
-					) }
+					{ /* Top-level screen only; hidden (faded) while a category is drilled into. */ }
+					<Nav2026AppBanner
+						mobilePlatform={ mobilePlatform }
+						isHidden={ !! activeCategory }
+						tabIndex={ mobileMenuTabIndex }
+						localizeUrl={ localizeUrl }
+						__={ __ }
+					/>
 					{ isLoggedIn ? (
 						<a
 							className="x-menu-mobile-user x-link"

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -1093,7 +1093,19 @@ $x-menu-2026-admin-bar-mobile: 46px;
 		padding-inline-end: 18px;
 	}
 
-	// "Get started" CTA — outlined pill (no fill).
+	// Hamburger: centre the trigger in the 64px bar (the legacy block layout
+	// positioned it for the taller old bar). The icon keeps its legacy 10px
+	// inner offset — that leaves the bars 1px above true centre, close enough.
+	.x-nav-link__menu {
+		display: flex;
+		align-items: center;
+		height: $x-nav-2026-height;
+		padding-block: 0;
+	}
+
+	// "Get started" CTA — outlined pill (no fill). Hover flips it to a filled
+	// pill: ink fill, inverted label. Sections that recolour the nav ink over
+	// dark heroes can override the flip pair via the two custom properties.
 	.x-nav-link__primary.cta-btn-nav {
 		display: flex;
 		align-items: center;
@@ -1106,7 +1118,9 @@ $x-menu-2026-admin-bar-mobile: 46px;
 		color: inherit !important;
 		border: 1px solid currentcolor;
 		border-radius: 3px;
-		transition: opacity $x-nav-2026-transition;
+		transition:
+			background-color $x-nav-2026-transition,
+			color $x-nav-2026-transition;
 
 		&::before {
 			display: none;
@@ -1114,7 +1128,9 @@ $x-menu-2026-admin-bar-mobile: 46px;
 
 		&:hover,
 		&:focus {
-			opacity: 0.8;
+			background: var( --x-nav-2026-cta-hover-fill, #{$studio-gray-100} ) !important;
+			color: var( --x-nav-2026-cta-hover-ink, #{$studio-white} ) !important;
+			border-color: var( --x-nav-2026-cta-hover-fill, #{$studio-gray-100} );
 		}
 	}
 
@@ -1159,8 +1175,9 @@ $x-menu-2026-admin-bar-mobile: 46px;
 		transform: scaleY( -1 ) rotate( 45deg );
 	}
 
-	// Non-dropdown items (no chevron) dim to 0.8 on hover instead of changing colour.
-	.x-nav-item:hover .x-nav-link:not( :has( .x-nav-link-chevron ) ) {
+	// Non-dropdown items (no chevron) dim to 0.8 on hover instead of changing
+	// colour. The "Get started" CTA is excluded: it flips to a filled pill above.
+	.x-nav-item:hover .x-nav-link:not( :has( .x-nav-link-chevron ) ):not( .x-nav-link__primary ) {
 		opacity: 0.8;
 	}
 }

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -1832,6 +1832,25 @@ $x-menu-2026-admin-bar-mobile: 46px;
 		}
 	}
 
+	// Top-level screen only. Fades + collapses on drill; browsers without
+	// allow-discrete snap instead.
+	.x-menu-mobile-footer > .x-menu-mobile-app-banner {
+		transition:
+			opacity var( --x-menu-2026-header-fade-duration, 0.3s ) var( --x-menu-2026-easing ),
+			visibility var( --x-menu-2026-header-fade-duration, 0.3s ) var( --x-menu-2026-easing ),
+			display var( --x-menu-2026-header-fade-duration, 0.3s ) allow-discrete;
+
+		@starting-style {
+			opacity: 0;
+		}
+	}
+
+	.x-menu-mobile-footer > .x-menu-mobile-app-banner.is-hidden {
+		display: none;
+		opacity: 0;
+		visibility: hidden;
+	}
+
 	// Overlapping WordPress + Jetpack badge icons.
 	.x-menu-mobile-app-banner-icons {
 		display: flex;

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -1832,8 +1832,7 @@ $x-menu-2026-admin-bar-mobile: 46px;
 		}
 	}
 
-	// Top-level screen only. Fades + collapses on drill; browsers without
-	// allow-discrete snap instead.
+	// Top-level screen only; fades + collapses on drill (is-hidden).
 	.x-menu-mobile-footer > .x-menu-mobile-app-banner {
 		transition:
 			opacity var( --x-menu-2026-header-fade-duration, 0.3s ) var( --x-menu-2026-easing ),

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -1835,6 +1835,11 @@ $x-menu-2026-admin-bar-mobile: 46px;
 
 	// Top-level screen only; fades + collapses on drill (is-hidden).
 	.x-menu-mobile-footer > .x-menu-mobile-app-banner {
+		// Fade declared on its own first so the opacity/visibility transition
+		// survives in browsers that drop the `display … allow-discrete` item.
+		transition:
+			opacity var( --x-menu-2026-header-fade-duration, 0.3s ) var( --x-menu-2026-easing ),
+			visibility var( --x-menu-2026-header-fade-duration, 0.3s ) var( --x-menu-2026-easing );
 		transition:
 			opacity var( --x-menu-2026-header-fade-duration, 0.3s ) var( --x-menu-2026-easing ),
 			visibility var( --x-menu-2026-header-fade-duration, 0.3s ) var( --x-menu-2026-easing ),

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -1019,7 +1019,7 @@ $x-menu-2026-admin-bar-mobile: 46px;
 .lpc-header-nav-wrapper
 	.lpc-header-nav-container
 	.masterbar-menu
-	.masterbar:has( .x-nav--2026-redesign ):has( .x-nav-item__wide:hover )::before {
+	.masterbar:has( .x-nav--2026-redesign ):has( .x-nav-item__wide:hover .x-nav-link-chevron )::before {
 	background-color: $studio-white;
 	opacity: 1;
 	transition: opacity 0.12s ease-out 0s;
@@ -1036,7 +1036,7 @@ $x-menu-2026-admin-bar-mobile: 46px;
 .lpc-header-nav-wrapper
 	.lpc-header-nav-container
 	.masterbar-menu
-	.masterbar:has( .x-nav--2026-redesign ):has( .x-nav-item__wide:hover ) {
+	.masterbar:has( .x-nav--2026-redesign ):has( .x-nav-item__wide:hover .x-nav-link-chevron ) {
 	backdrop-filter: blur( var( --x-nav-2026-scrolled-blur ) );
 }
 

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -1114,12 +1114,13 @@ $x-menu-2026-admin-bar-mobile: 46px;
 		margin-inline-start: 12px;
 		margin-inline-end: 15px;
 		padding: 0 20px !important;
-		background: transparent !important;
+		background-color: transparent !important;
 		color: inherit !important;
 		border: 1px solid currentcolor;
 		border-radius: 3px;
 		transition:
 			background-color $x-nav-2026-transition,
+			border-color $x-nav-2026-transition,
 			color $x-nav-2026-transition;
 
 		&::before {
@@ -1128,7 +1129,7 @@ $x-menu-2026-admin-bar-mobile: 46px;
 
 		&:hover,
 		&:focus {
-			background: var( --x-nav-2026-cta-hover-fill, #{$studio-gray-100} ) !important;
+			background-color: var( --x-nav-2026-cta-hover-fill, #{$studio-gray-100} ) !important;
 			color: var( --x-nav-2026-cta-hover-ink, #{$studio-white} ) !important;
 			border-color: var( --x-nav-2026-cta-hover-fill, #{$studio-gray-100} );
 		}
@@ -1848,6 +1849,8 @@ $x-menu-2026-admin-bar-mobile: 46px;
 		display: none;
 		opacity: 0;
 		visibility: hidden;
+		// allow-discrete defers display:none, so block clicks during fade-out.
+		pointer-events: none;
 	}
 
 	// Overlapping WordPress + Jetpack badge icons.

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -1833,7 +1833,8 @@ $x-menu-2026-admin-bar-mobile: 46px;
 		}
 	}
 
-	// Top-level screen only; fades + collapses on drill (is-hidden).
+	// Top-level screen only; collapses on drill (is-hidden). Fades where
+	// `allow-discrete` is supported, otherwise snaps shut.
 	.x-menu-mobile-footer > .x-menu-mobile-app-banner {
 		// Fade declared on its own first so the opacity/visibility transition
 		// survives in browsers that drop the `display … allow-discrete` item.


### PR DESCRIPTION
Part of WPBRAND-402

## Proposed Changes

* **A/B testing**: logged-in pages that use the universal header (Themes, Plugins, …) resolve the 2026 nav from the ExPlat experiment assignment, the same way the logged-out surfaces do.
* **A/B testing**: server-side rendering no longer reads the experiment; the client applies the variant after hydration.
* **Design polish**: the Get started button flips colors on hover — the outlined pill fills with the nav ink and the label inverts. The mobile menu icon is vertically centered in the new 64px nav bar (legacy nav untouched).
* **Design polish**: the mobile menu’s “Get Jetpack app” banner shows only on the menu’s top-level screen, not inside a drilled-in category.

## Why are these changes being made?

* Part of the Global Nav 2026 A/B testing infrastructure (WPBRAND-402): every surface should resolve the nav variant through the same order — staff override flag first, then the experiment assignment.
* The hover, alignment, and banner changes address design feedback on the new nav.

## Testing Instructions

* `yarn start`, log in, and open `calypso.localhost:3000/themes?flags=nav-redesign/2026` — the new nav shows on the logged-in page (flag-forced path).
* Without the flag, the experiment path needs an assignment: a8c-only for now — sandbox the API, allowlist the experiment for the `calypso` platform (companion wpcom change), and set a manual variation in ExPlat. Then plain `/themes` while logged in shows the assigned variant.
* Hover the “Get started” button in the new nav: it fills with the ink color and the label inverts. The other links keep their existing hover behavior.
* Narrow the viewport until the hamburger shows: the icon is vertically centered in the bar. Open the menu on a phone-sized viewport (iOS/Android UA): the app banner shows at the top level and hides when you enter a category.
* Check the dev server logs while loading a logged-out page (e.g. `/themes`): no “Attempting to dangerously get ExperimentAssignment in SSR context” errors.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
