### PR TITLE
A4A: Switch agency image uploads to the dedicated /media endpoint

### DIFF
--- a/client/a8c-for-agencies/sections/agent-studio/data/use-upload-agent-media.ts
+++ b/client/a8c-for-agencies/sections/agent-studio/data/use-upload-agent-media.ts
@@ -1,8 +1,8 @@
 /**
- * Multipart upload to `POST /agency/<id>/profile/logo` with
- * `purpose=agent_media`. The `purpose` param switches the server to a
- * UUID filename and the richer payload below; without it the server
- * returns the Partner Directory logo shape (`{ logo_url }`).
+ * Multipart upload to `POST /agency/<id>/media` with
+ * `asset_type=agent_media`. The `asset_type` param switches the server to a
+ * UUID filename; `partner_directory_logo` instead yields a predictable,
+ * overwriting name. Both return the normalized payload below.
  * Backend rules: jpeg/png only, 10 MB max, field name `media`.
  */
 import { useMutation, type UseMutationOptions } from '@tanstack/react-query';
@@ -11,6 +11,7 @@ import { useSelector } from 'calypso/state';
 import { getActiveAgencyId } from 'calypso/state/a8c-for-agencies/agency/selectors';
 
 export interface UploadAgentMediaResponse {
+	asset_type: string;
 	attachment_id: number;
 	url: string;
 	mime: string;
@@ -26,10 +27,10 @@ export const uploadAgentMedia = (
 		wpcom.req.post(
 			{
 				apiNamespace: 'wpcom/v2',
-				path: `/agency/${ agencyId }/profile/logo`,
+				path: `/agency/${ agencyId }/media`,
 				formData: [
 					[ 'media', file ],
-					[ 'purpose', 'agent_media' ],
+					[ 'asset_type', 'agent_media' ],
 				],
 			},
 			( error: Error | null, response: UploadAgentMediaResponse ) => {

--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -174,11 +174,11 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 					setIsUploadingLogo( true );
 					try {
 						const result = await uploadLogo( agencyId, referralLogo.file );
-						if ( result?.logo_url ) {
-							logoUrl = result.logo_url;
+						if ( result?.url ) {
+							logoUrl = result.url;
 							setLastUploadedFile( {
 								...fileSignature,
-								logoUrl: result.logo_url,
+								logoUrl: result.url,
 							} );
 						}
 					} catch ( error ) {

--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/hooks/use-submit-form.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/hooks/use-submit-form.ts
@@ -45,7 +45,7 @@ export default function useSubmitForm( { formData, onSubmitSuccess, onSubmitErro
 
 			const file = await getImageFile( agencyId ?? 0, formData.logoUrl );
 			const upload = await uploadLogo( agencyId, file );
-			newLogo = upload?.logo_url;
+			newLogo = upload?.url;
 
 			setIsUploadingImage( false );
 		}

--- a/client/a8c-for-agencies/sections/partner-directory/agency-details/hooks/use-upload-logo.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/agency-details/hooks/use-upload-logo.ts
@@ -1,16 +1,28 @@
 import wpcom from 'calypso/lib/wp';
 
-export const useUploadLogo = () => async ( agencyId: number | undefined, file: File ) => {
-	if ( agencyId === undefined ) {
-		return;
-	}
+interface UploadLogoResponse {
+	asset_type: string;
+	attachment_id: number;
+	url: string;
+	mime: string;
+	width: number;
+	height: number;
+}
 
-	const formData = new FormData();
-	formData.append( 'media', file );
+export const useUploadLogo =
+	() =>
+	async ( agencyId: number | undefined, file: File ): Promise< UploadLogoResponse | undefined > => {
+		if ( agencyId === undefined ) {
+			return;
+		}
 
-	return await wpcom.req.post( {
-		apiNamespace: 'wpcom/v2',
-		path: '/agency/' + agencyId + '/profile/logo',
-		body: formData,
-	} );
-};
+		const formData = new FormData();
+		formData.append( 'media', file );
+		formData.append( 'asset_type', 'partner_directory_logo' );
+
+		return await wpcom.req.post( {
+			apiNamespace: 'wpcom/v2',
+			path: '/agency/' + agencyId + '/media',
+			body: formData,
+		} );
+	};


### PR DESCRIPTION
Part of 221246-ghe-Automattic/wpcom

## Proposed Changes

Both A4A image upload flows — the Partner Directory profile logo and the Agent Studio one-pager/social brief media — upload through a single WP.com route: `POST /wpcom/v2/agency/<id>/profile/logo`. That route lives in the Partner-Directory-specific profile controller, and a `purpose` param overloads its behavior:

- `purpose=logo` → predictable, overwriting filename; returns `{ logo_url }`.
- `purpose=agent_media` → UUID filename; returns `{ attachment_id, url, mime, width, height }`.

WP.com PR [^1] adds a dedicated `POST /wpcom/v2/agency/<id>/media` endpoint in its own controller. An `asset_type` enum (`partner_directory_logo | agent_media`) selects the filename strategy, and the endpoint returns one normalized payload `{ asset_type, attachment_id, url, mime, width, height }` for both types. `partner_directory_logo` keeps the predictable `logo-image-<id>.<ext>` filename, so the Partner Directory logo URL stays stable across re-uploads exactly as before.

This change repoints the Calypso callers at the new endpoint:

- **Partner Directory** (`use-upload-logo.ts`): path → `/agency/<id>/media`, sends `asset_type=partner_directory_logo`. The response field changes from `logo_url` to `url`, so the two consumers (`use-submit-form.ts` and the marketplace checkout `request-client-payment.tsx`) read `url` instead.
- **Agent Studio** (`use-upload-agent-media.ts`): path → `/agency/<id>/media`, `purpose=agent_media` → `asset_type=agent_media`. Response shape is unchanged apart from an added `asset_type` field.

## Why are these changes being made?

The route is named `/profile/logo`, but half its traffic is generic agent-brief media that has nothing to do with a profile logo. The overload existed only because adding a new public-api write route requires a systems whitelisting request, so the route was reused rather than given a proper home. The new endpoint gives agency media a properly named, self-contained home.

Image-only (JPEG/PNG), ≤10MB, and authenticated-request constraints are identical to the old route — no new file types or auth behavior.

## Testing Instructions

Prerequisites: a sandbox with the WP.com patch [^1] applied, an A4A agency you can edit (`a4a_edit_agency` capability), and a small JPEG and PNG. The `/media` route is not whitelisted on production yet, so this must be tested against a sandbox.

**Partner Directory logo**
1. Go to Partner Directory → agency details.
2. Upload a new logo image and save the form.
3. Confirm the upload succeeds and the saved logo renders.
4. In the network tab, confirm the request hits `POST /wpcom/v2/agency/<id>/media` with `asset_type=partner_directory_logo`, and that the stored URL basename is `logo-image-<id>.<ext>`.

**Marketplace checkout referral logo**
5. Start a “request client payment” referral flow and upload a referral logo.
6. Confirm the logo uploads, the preview renders, and re-using the same file does not re-upload (it reuses the cached URL).

**Agent Studio media**
7. In Agent Studio, upload a hero/content image or logo for a one-pager or social brief.
8. Confirm the upload succeeds, the image renders, and the request hits `POST /wpcom/v2/agency/<id>/media` with `asset_type=agent_media` and a `a4a-<hex>.<ext>` filename.

**Validation (both flows)**
9. Upload a non-image (e.g. a `.txt`) → upload is rejected.
10. Upload a >10MB image → upload is rejected.

[^1]: Automattic/wpcom#221246

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)