### PR TITLE
client/blocks: React 19 forward-compatible (behavior-preserving)

### DIFF
--- a/client/blocks/app-banner/index.jsx
+++ b/client/blocks/app-banner/index.jsx
@@ -6,7 +6,6 @@ import { localize, withRtl } from 'i18n-calypso';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
-import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import AnimatedIcon from 'calypso/components/animated-icon';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
@@ -98,7 +97,7 @@ export class AppBanner extends Component {
 			return;
 		}
 		if ( appBanner ) {
-			this.appBannerNode = ReactDom.findDOMNode( appBanner );
+			this.appBannerNode = appBanner;
 			this.appBannerNode.addEventListener( 'mousedown', this.stopBubblingEvents, false );
 			this.appBannerNode.addEventListener( 'touchstart', this.stopBubblingEvents, false );
 			document.body.classList.add( 'app-banner-is-visible' );

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -139,7 +139,19 @@ class PostCommentList extends Component {
 		if ( prevState !== this.state && prevProps === this.props ) {
 			return;
 		}
-		this.initialFetches();
+		// Only re-run the initial fetches when one of their inputs actually
+		// changes. Running on every update can loop: `initialFetches` calls
+		// `setState`, which (under React 19's stricter update accounting) can
+		// re-enter `componentDidUpdate` and trigger another fetch, exceeding the
+		// maximum update depth.
+		if (
+			prevProps.isInitialCommentLoading !== this.props.isInitialCommentLoading ||
+			prevProps.startingCommentId !== this.props.startingCommentId ||
+			prevProps.initialComment !== this.props.initialComment ||
+			prevProps.commentsTree !== this.props.commentsTree
+		) {
+			this.initialFetches();
+		}
 		if (
 			prevProps.siteId !== this.props.siteId ||
 			prevProps.postId !== this.props.postId ||

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -139,10 +139,8 @@ class PostCommentList extends Component {
 		if ( prevState !== this.state && prevProps === this.props ) {
 			return;
 		}
-		// Only re-run the initial fetches when one of their inputs actually
-		// changes. Running on every update can loop: `initialFetches` calls
-		// `setState`, which (under React 19's stricter update accounting) can
-		// re-enter `componentDidUpdate` and trigger another fetch, exceeding the
+		// Only re-run initialFetches when one of its inputs changes; running it on
+		// every update can re-enter componentDidUpdate via setState and exceed the
 		// maximum update depth.
 		if (
 			prevProps.isInitialCommentLoading !== this.props.isInitialCommentLoading ||

--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -139,17 +139,7 @@ class PostCommentList extends Component {
 		if ( prevState !== this.state && prevProps === this.props ) {
 			return;
 		}
-		// Only re-run initialFetches when one of its inputs changes; running it on
-		// every update can re-enter componentDidUpdate via setState and exceed the
-		// maximum update depth.
-		if (
-			prevProps.isInitialCommentLoading !== this.props.isInitialCommentLoading ||
-			prevProps.startingCommentId !== this.props.startingCommentId ||
-			prevProps.initialComment !== this.props.initialComment ||
-			prevProps.commentsTree !== this.props.commentsTree
-		) {
-			this.initialFetches();
-		}
+		this.initialFetches();
 		if (
 			prevProps.siteId !== this.props.siteId ||
 			prevProps.postId !== this.props.postId ||

--- a/client/blocks/comments/post-trackback.tsx
+++ b/client/blocks/comments/post-trackback.tsx
@@ -1,6 +1,7 @@
 import { Gridicon, TimeSince } from '@automattic/components';
 import { get } from 'lodash';
 import { getUserProfileUrl } from 'calypso/reader/user-profile/user-profile.utils';
+import type { JSX } from 'react';
 
 import './post-comment.scss'; // yes, this is intentional. they share styles.
 

--- a/client/blocks/dismissible-card/index.jsx
+++ b/client/blocks/dismissible-card/index.jsx
@@ -9,6 +9,9 @@ import { isCardDismissed } from './selectors';
 
 import './style.scss';
 
+/**
+ * @param {{ className?: string; highlight?: 'error' | 'info' | 'success' | 'warning'; temporary?: boolean; onClick?: ( event: import('react').MouseEvent ) => void; preferenceName: string; href?: string; children?: import('react').ReactNode; }} props
+ */
 function DismissibleCard( {
 	className,
 	highlight,

--- a/client/blocks/follow-button/index.tsx
+++ b/client/blocks/follow-button/index.tsx
@@ -12,6 +12,7 @@ import { errorNotice } from 'calypso/state/notices/actions';
 import { registerLastActionRequiresLogin } from 'calypso/state/reader-ui/actions';
 import { useResendEmailVerification } from '../../landing/stepper/hooks/use-resend-email-verification';
 import FollowButton from './button';
+import type { JSX } from 'react';
 
 interface FollowButtonContainerProps {
 	siteUrl: string;

--- a/client/blocks/import/capture/capture-input.tsx
+++ b/client/blocks/import/capture/capture-input.tsx
@@ -46,7 +46,7 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 	const [ isValid, setIsValid ] = useState( false );
 	const [ submitted, setSubmitted ] = useState( false );
 	const [ validationMessage, setValidationMessage ] = useState( '' );
-	const lastInvalidValue = useRef< string | undefined >();
+	const lastInvalidValue = useRef< string | undefined >( undefined );
 	const showValidationMsg = hasError || ( submitted && ! isValid );
 	const { search } = useLocation();
 
@@ -56,7 +56,13 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 		const urlValue = new URLSearchParams( search ).get( 'from' ) || '';
 		if ( skipInitialChecking ) {
 			setUrlValue( urlValue );
-			validateUrl( urlValue );
+			// Avoid surfacing a "missing address" validation message for an empty
+			// initial value (e.g. when this input remounts after a failed scan).
+			// The empty-string message would otherwise override the generic error
+			// message shown when `hasError` is set by the parent.
+			if ( urlValue ) {
+				validateUrl( urlValue );
+			}
 			return;
 		}
 
@@ -88,7 +94,9 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 
 	function onFormSubmit( e: FormEvent< HTMLFormElement > ) {
 		e.preventDefault();
-		isValid && onInputEnter( urlValue );
+		if ( isValid ) {
+			onInputEnter( urlValue );
+		}
 		setSubmitted( true );
 
 		if ( ! isValid && urlValue?.length > 4 && urlValue !== lastInvalidValue.current ) {

--- a/client/blocks/import/capture/capture-input.tsx
+++ b/client/blocks/import/capture/capture-input.tsx
@@ -56,13 +56,7 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 		const urlValue = new URLSearchParams( search ).get( 'from' ) || '';
 		if ( skipInitialChecking ) {
 			setUrlValue( urlValue );
-			// Avoid surfacing a "missing address" validation message for an empty
-			// initial value (e.g. when this input remounts after a failed scan).
-			// The empty-string message would otherwise override the generic error
-			// message shown when `hasError` is set by the parent.
-			if ( urlValue ) {
-				validateUrl( urlValue );
-			}
+			validateUrl( urlValue );
 			return;
 		}
 

--- a/client/blocks/importer/wordpress/upgrade-plan/types.ts
+++ b/client/blocks/importer/wordpress/upgrade-plan/types.ts
@@ -1,6 +1,6 @@
 import type { PlanSlug } from '@automattic/calypso-products';
 import type { PricingMetaForGridPlan, SiteDetails } from '@automattic/data-stores';
-import type { ReactNode } from 'react';
+import type { ReactNode, JSX } from 'react';
 
 export type HostingDetailsItem = {
 	title: string;

--- a/client/blocks/inline-help/inline-help-search-card.tsx
+++ b/client/blocks/inline-help/inline-help-search-card.tsx
@@ -31,7 +31,7 @@ const InlineHelpSearchCard = ( {
 	sectionName,
 	useSearchControl,
 }: Props ) => {
-	const cardRef = useRef< { searchInput: HTMLInputElement } >();
+	const cardRef = useRef< { searchInput: HTMLInputElement } >( undefined );
 	const translate = useTranslate();
 
 	// Focus in the input element.

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -12,7 +12,6 @@ import { localize } from 'i18n-calypso';
 import { capitalize, defer, includes, get, debounce } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
-import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
 import { FormDivider } from 'calypso/blocks/authentication';
 import JetpackConnectSiteOnly from 'calypso/blocks/jetpack-connect-site-only';
@@ -339,7 +338,7 @@ export class LoginForm extends Component {
 			// Google Chrome on iOS will autofill without sending events, leading the user
 			// to see a filled box but getting an error. We fetch the value directly from
 			// the DOM as a workaround.
-			const usernameOrEmail = ReactDom.findDOMNode( this.usernameOrEmail ).value;
+			const usernameOrEmail = this.usernameOrEmail.value;
 
 			this.props.getAuthAccountType( usernameOrEmail );
 
@@ -794,7 +793,7 @@ export class LoginForm extends Component {
 						onChange={ this.onChangeUsernameOrEmailField }
 						id="usernameOrEmail"
 						name="usernameOrEmail"
-						ref={ this.saveUsernameOrEmailRef }
+						inputRef={ this.saveUsernameOrEmailRef }
 						value={ this.state.usernameOrEmail }
 						disabled={ isEmailOrUsernameInputDisabled }
 						hasCoreStyles

--- a/client/blocks/login/stories/shared.tsx
+++ b/client/blocks/login/stories/shared.tsx
@@ -1,5 +1,6 @@
 import LoginSubmitButton from '../login-submit-button';
-import type { StoryFn, StoryObj } from '@storybook/react';
+import type { StoryObj } from '@storybook/react';
+import type { ComponentType } from 'react';
 import './style.scss';
 
 export const submitButtonArgs = {
@@ -9,7 +10,7 @@ export const submitButtonArgs = {
 	buttonText: 'Continue',
 };
 
-export const LoginFormWrapper = ( Story: StoryFn ) => (
+export const LoginFormWrapper = ( Story: ComponentType ) => (
 	<div className="login" style={ { maxWidth: '360px', padding: '30px' } }>
 		<div className="login__form">
 			<Story />
@@ -17,49 +18,49 @@ export const LoginFormWrapper = ( Story: StoryFn ) => (
 	</div>
 );
 
-export const LoginFormAction = ( Story: StoryFn ) => (
+export const LoginFormAction = ( Story: ComponentType ) => (
 	<div className="login__form-action">
 		<Story />
 	</div>
 );
 
-export const A4AWrapper = ( Story: StoryFn ) => (
+export const A4AWrapper = ( Story: ComponentType ) => (
 	<div className="a8c-for-agencies">
 		<Story />
 	</div>
 );
 
-export const AkismetWrapper = ( Story: StoryFn ) => (
+export const AkismetWrapper = ( Story: ComponentType ) => (
 	<div className="is-akismet">
 		<Story />
 	</div>
 );
 
-export const BlazeWrapper = ( Story: StoryFn ) => (
+export const BlazeWrapper = ( Story: ComponentType ) => (
 	<div className="blaze-pro">
 		<Story />
 	</div>
 );
 
-export const CrowdsignalWrapper = ( Story: StoryFn ) => (
+export const CrowdsignalWrapper = ( Story: ComponentType ) => (
 	<div className="crowdsignal">
 		<Story />
 	</div>
 );
 
-export const WooWrapper = ( Story: StoryFn ) => (
+export const WooWrapper = ( Story: ComponentType ) => (
 	<div className="woo is-woo-passwordless is-woo-com-oauth">
 		<Story />
 	</div>
 );
 
-export const JetpackCloudWrapper = ( Story: StoryFn ) => (
+export const JetpackCloudWrapper = ( Story: ComponentType ) => (
 	<div className="jetpack-cloud">
 		<Story />
 	</div>
 );
 
-export const JetpackLoginWrapper = ( Story: StoryFn ) => (
+export const JetpackLoginWrapper = ( Story: ComponentType ) => (
 	<div className="layout is-jetpack-login">
 		<div className="login is-jetpack" style={ { maxWidth: '360px', padding: '30px' } }>
 			<div className="login__form">
@@ -69,7 +70,7 @@ export const JetpackLoginWrapper = ( Story: StoryFn ) => (
 	</div>
 );
 
-export const GravatarWrapper = ( Story: StoryFn ) => (
+export const GravatarWrapper = ( Story: ComponentType ) => (
 	<div className="layout is-section-login is-grav-powered-client">
 		<div className="login" style={ { maxWidth: '360px' } }>
 			<Story />
@@ -77,7 +78,7 @@ export const GravatarWrapper = ( Story: StoryFn ) => (
 	</div>
 );
 
-export const WPJobManagerWrapper = ( Story: StoryFn ) => (
+export const WPJobManagerWrapper = ( Story: ComponentType ) => (
 	<div className="layout is-section-login is-grav-powered-client is-wp-job-manager">
 		<div className="login" style={ { maxWidth: '360px' } }>
 			<Story />

--- a/client/blocks/plugin-scheduled-updates-common/error-utils.tsx
+++ b/client/blocks/plugin-scheduled-updates-common/error-utils.tsx
@@ -1,6 +1,7 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
 import type { APIError } from '@automattic/data-stores';
+import type { JSX } from 'react';
 
 export const handleErrorMessage = ( error: APIError ): string => {
 	switch ( error.status ) {

--- a/client/blocks/reader-author-link/docs/example.tsx
+++ b/client/blocks/reader-author-link/docs/example.tsx
@@ -1,5 +1,6 @@
 import { Card } from '@automattic/components';
 import ReaderAuthorLink, { ReaderLinkAuthor } from 'calypso/blocks/reader-author-link';
+import type { JSX } from 'react';
 
 export default function ReaderAuthorLinkExample(): JSX.Element {
 	const author: ReaderLinkAuthor = {

--- a/client/blocks/reader-featured-video/index.jsx
+++ b/client/blocks/reader-featured-video/index.jsx
@@ -43,8 +43,7 @@ class ReaderFeaturedVideo extends Component {
 		className: '',
 	};
 
-	// The component's root element is the parent of the embed node. This was
-	// previously obtained via `findDOMNode( this )`, which React 19 removed.
+	// Root element is the embed node's parent.
 	getRootNode = () => this.videoEmbedRef?.parentNode ?? null;
 
 	setVideoSizingStrategy = ( videoEmbed ) => {

--- a/client/blocks/reader-featured-video/index.jsx
+++ b/client/blocks/reader-featured-video/index.jsx
@@ -7,7 +7,6 @@ import { localize } from 'i18n-calypso';
 import { throttle } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
-import ReactDom from 'react-dom';
 import playIconImage from 'calypso/assets/images/reader/play-icon.webp';
 import readerPocketCastImage from 'calypso/assets/images/reader/reader-pocket-cast.svg';
 import ReaderFeaturedImage from 'calypso/blocks/reader-featured-image';
@@ -44,10 +43,14 @@ class ReaderFeaturedVideo extends Component {
 		className: '',
 	};
 
+	// The component's root element is the parent of the embed node. This was
+	// previously obtained via `findDOMNode( this )`, which React 19 removed.
+	getRootNode = () => this.videoEmbedRef?.parentNode ?? null;
+
 	setVideoSizingStrategy = ( videoEmbed ) => {
 		let sizingFunction = defaultSizingFunction;
 		if ( videoEmbed ) {
-			const maxWidth = ReactDom.findDOMNode( this ).parentNode.offsetWidth;
+			const maxWidth = this.getRootNode()?.parentNode?.offsetWidth;
 			const embedSize = EmbedHelper.getEmbedSizingFunction( videoEmbed );
 
 			sizingFunction = ( available = maxWidth ) => embedSize( available );
@@ -57,8 +60,8 @@ class ReaderFeaturedVideo extends Component {
 
 	updateVideoSize = () => {
 		if ( this.videoEmbedRef ) {
-			const iframe = ReactDom.findDOMNode( this.videoEmbedRef ).querySelector( 'iframe' );
-			const availableWidth = ReactDom.findDOMNode( this ).parentNode.offsetWidth;
+			const iframe = this.videoEmbedRef.querySelector( 'iframe' );
+			const availableWidth = this.getRootNode()?.parentNode?.offsetWidth;
 			const style = {
 				...this.getEmbedSize( availableWidth ),
 				borderRadius: '6px',

--- a/client/blocks/reader-feed-header/badge.tsx
+++ b/client/blocks/reader-feed-header/badge.tsx
@@ -1,5 +1,6 @@
 import { Site } from '@automattic/api-core';
 import { Gridicon } from '@automattic/components';
+import type { JSX } from 'react';
 
 interface ReaderFeedHeaderSiteBadgeProps {
 	site?: Site;

--- a/client/blocks/reader-feed-header/follow.tsx
+++ b/client/blocks/reader-feed-header/follow.tsx
@@ -1,7 +1,7 @@
 import { Gridicon } from '@automattic/components';
 import { filterURLForDisplay } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useState, type JSX } from 'react';
 import { shallowEqual } from 'react-redux';
 import SiteNotificationSettings from 'calypso/blocks/reader-site-notification-settings';
 import ReaderSuggestedFollowsDialog from 'calypso/blocks/reader-suggested-follows/dialog';

--- a/client/blocks/reader-feed-item/index.tsx
+++ b/client/blocks/reader-feed-item/index.tsx
@@ -11,7 +11,7 @@ import {
 import { rss } from '@wordpress/icons';
 import { filterURLForDisplay } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type JSX } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { SiteIcon } from 'calypso/blocks/site-icon';
 import {

--- a/client/blocks/reader-full-post/content-processor.tsx
+++ b/client/blocks/reader-full-post/content-processor.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { type JSX } from 'react';
 import LinkPreview from './link-preview';
 
 interface ContentProcessorProps {

--- a/client/blocks/reader-full-post/link-preview.tsx
+++ b/client/blocks/reader-full-post/link-preview.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { Card, Spinner } from '@automattic/components';
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, type JSX } from 'react';
 import { getRelativeTimeString } from 'calypso/dashboard/utils/datetime';
 import wpcom from 'calypso/lib/wp';
 import './link-preview.scss';

--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -20,6 +20,9 @@ import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
 import { ReaderFreshlyPressedButton } from '../reader-freshly-pressed-button';
 import './style.scss';
 
+/**
+ * @param {{ post: Object; site?: Object; onCommentClick?: Function; iconSize?: number; className?: string; fullPost?: boolean; commentsApiDisabled?: boolean; }} props
+ */
 const ReaderPostActions = ( {
 	post,
 	site,

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -62,8 +62,7 @@ class ReaderPostCard extends Component {
 
 	cardRef = createRef();
 
-	// Merge the internal card ref with an optional `itemRef` from InfiniteList so the
-	// parent list can measure this item's DOM node without `findDOMNode`.
+	// Forward the node to an optional itemRef from InfiniteList so the list can measure it.
 	setCardRef = ( node ) => {
 		this.cardRef.current = node;
 		const { itemRef } = this.props;

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -4,8 +4,7 @@ import clsx from 'clsx';
 import closest from 'component-closest';
 import { flowRight as compose, truncate } from 'lodash';
 import PropTypes from 'prop-types';
-import { Component } from 'react';
-import ReactDom from 'react-dom';
+import { createRef, Component } from 'react';
 import { connect } from 'react-redux';
 import ReaderPostActions from 'calypso/blocks/reader-post-actions';
 import CompactPostCard from 'calypso/blocks/reader-post-card/compact';
@@ -61,6 +60,20 @@ class ReaderPostCard extends Component {
 		showBylineSecondarySiteLink: true,
 	};
 
+	cardRef = createRef();
+
+	// Merge the internal card ref with an optional `itemRef` from InfiniteList so the
+	// parent list can measure this item's DOM node without `findDOMNode`.
+	setCardRef = ( node ) => {
+		this.cardRef.current = node;
+		const { itemRef } = this.props;
+		if ( typeof itemRef === 'function' ) {
+			itemRef( node );
+		} else if ( itemRef ) {
+			itemRef.current = node;
+		}
+	};
+
 	state = {
 		isSuggestedFollowsModalOpen: false,
 	};
@@ -78,7 +91,7 @@ class ReaderPostCard extends Component {
 	};
 
 	handleCardClick = ( event ) => {
-		const rootNode = ReactDom.findDOMNode( this );
+		const rootNode = this.cardRef.current;
 		const selection = window.getSelection && window.getSelection();
 
 		// if the click has modifier or was not primary, ignore it
@@ -277,7 +290,7 @@ class ReaderPostCard extends Component {
 
 		const onClick = ! isPostPhoto ? this.handleCardClick : noop;
 		return (
-			<Card className={ classes } onClick={ onClick } tagName="article">
+			<Card ref={ this.setCardRef } className={ classes } onClick={ onClick } tagName="article">
 				{ ! compact && postByline }
 				{ readerPostCard }
 				{ this.props.children }

--- a/client/blocks/reader-subscription-list-item/placeholder.tsx
+++ b/client/blocks/reader-subscription-list-item/placeholder.tsx
@@ -1,4 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
+import type { JSX } from 'react';
 
 const ReaderSubscriptionListItemPlaceholder = (): JSX.Element => {
 	const translate = useTranslate();

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -17,6 +17,7 @@ import getIsWoo from 'calypso/state/selectors/get-is-woo';
 import PasswordlessSignupForm from './passwordless';
 import SocialSignupForm from './social';
 import type { SignupAllowedService } from 'calypso/components/social-buttons/utils';
+import type { JSX } from 'react';
 import './style.scss';
 
 interface QueryArgs {

--- a/client/blocks/signup-form/stories/shared.tsx
+++ b/client/blocks/signup-form/stories/shared.tsx
@@ -1,5 +1,6 @@
 import SignupSubmitButton from '../signup-submit-button';
-import type { StoryFn, StoryObj } from '@storybook/react';
+import type { StoryObj } from '@storybook/react';
+import type { ComponentType } from 'react';
 import './style.scss';
 
 export const submitButtonArgs = {
@@ -8,7 +9,7 @@ export const submitButtonArgs = {
 	children: 'Continue',
 };
 
-export const SignupFormWrapper = ( Story: StoryFn ) => (
+export const SignupFormWrapper = ( Story: ComponentType ) => (
 	<div className="signup-form" style={ { maxWidth: '360px', padding: '30px' } }>
 		<div className="card logged-out-form__footer">
 			<Story />
@@ -16,37 +17,37 @@ export const SignupFormWrapper = ( Story: StoryFn ) => (
 	</div>
 );
 
-export const A4AWrapper = ( Story: StoryFn ) => (
+export const A4AWrapper = ( Story: ComponentType ) => (
 	<div className="a8c-for-agencies">
 		<Story />
 	</div>
 );
 
-export const AkismetWrapper = ( Story: StoryFn ) => (
+export const AkismetWrapper = ( Story: ComponentType ) => (
 	<div className="is-akismet">
 		<Story />
 	</div>
 );
 
-export const BlazeWrapper = ( Story: StoryFn ) => (
+export const BlazeWrapper = ( Story: ComponentType ) => (
 	<div className="blaze-pro">
 		<Story />
 	</div>
 );
 
-export const CrowdsignalWrapper = ( Story: StoryFn ) => (
+export const CrowdsignalWrapper = ( Story: ComponentType ) => (
 	<div className="crowdsignal">
 		<Story />
 	</div>
 );
 
-export const WooWrapper = ( Story: StoryFn ) => (
+export const WooWrapper = ( Story: ComponentType ) => (
 	<div className="woo is-woo-passwordless is-woo-com-oauth">
 		<Story />
 	</div>
 );
 
-export const JetpackWrapper = ( Story: StoryFn ) => (
+export const JetpackWrapper = ( Story: ComponentType ) => (
 	<div className="jetpack-cloud">
 		<Story />
 	</div>

--- a/client/blocks/site-icon/index.tsx
+++ b/client/blocks/site-icon/index.tsx
@@ -12,6 +12,7 @@ import getSiteIconId from 'calypso/state/selectors/get-site-icon-id';
 import getSiteIconUrl from 'calypso/state/selectors/get-site-icon-url';
 import isTransientMedia from 'calypso/state/selectors/is-transient-media';
 import { getSite } from 'calypso/state/sites/selectors';
+import type { JSX } from 'react';
 
 export type Site = {
 	ID?: number;

--- a/client/blocks/stats-navigation/constants.ts
+++ b/client/blocks/stats-navigation/constants.ts
@@ -1,5 +1,6 @@
 import { commentAuthorAvatar, search, video } from '@wordpress/icons';
 import { translate } from 'i18n-calypso';
+import type { JSX } from 'react';
 
 /**
  * Intervals

--- a/client/blocks/stats-sparkline/index.jsx
+++ b/client/blocks/stats-sparkline/index.jsx
@@ -125,6 +125,9 @@ const getStatsInsightsHourlyViews = createSelector(
 	( state, siteId ) => getSiteStatsNormalizedData( state, siteId, 'statsInsights' )
 );
 
+/**
+ * @param {{ className?: string; showLoader?: boolean; siteId?: number; }} props
+ */
 const StatsSparkline = ( { className, showLoader = false, siteId } ) => {
 	const hourlyViews = useSelector( ( state ) => getStatsInsightsHourlyViews( state, siteId ) );
 	return (

--- a/client/blocks/time-mismatch-warning/test/__snapshots__/index.jsx.snap
+++ b/client/blocks/time-mismatch-warning/test/__snapshots__/index.jsx.snap
@@ -53,26 +53,3 @@ exports[`TimeMismatchWarning to render if GMT offsets do not match 1`] = `
   </div>
 </div>
 `;
-
-exports[`TimeMismatchWarning to render the passed site settings URL 1`] = `
-[MockFunction] {
-  "calls": Array [
-    Array [
-      "This page reflects the time zone set on your site. It looks like that does not match your current time zone. {{SiteSettings}}You can update your site time zone here{{/SiteSettings}}.",
-      Object {
-        "components": Object {
-          "SiteSettings": <a
-            href="https://example.com"
-          />,
-        },
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "type": "return",
-      "value": "This page reflects the time zone set on your site. It looks like that does not match your current time zone. {{SiteSettings}}You can update your site time zone here{{/SiteSettings}}.",
-    },
-  ],
-}
-`;

--- a/client/blocks/time-mismatch-warning/test/index.jsx
+++ b/client/blocks/time-mismatch-warning/test/index.jsx
@@ -68,9 +68,6 @@ describe( 'TimeMismatchWarning', () => {
 		getSiteGmtOffset.mockReturnValueOnce( 10 );
 		useTranslate.mockImplementationOnce( () => translate );
 		render( <TimeMismatchWarning siteId={ 1 } settingsUrl="https://example.com" /> );
-		// Assert on the interpolation component rather than snapshotting the mock:
-		// React 19 elements carry non-deterministic debug/owner data that breaks
-		// snapshot serialization.
 		const [ , options ] = translate.mock.calls[ 0 ];
 		expect( options.components.SiteSettings.props.href ).toBe( 'https://example.com' );
 	} );

--- a/client/blocks/time-mismatch-warning/test/index.jsx
+++ b/client/blocks/time-mismatch-warning/test/index.jsx
@@ -68,7 +68,11 @@ describe( 'TimeMismatchWarning', () => {
 		getSiteGmtOffset.mockReturnValueOnce( 10 );
 		useTranslate.mockImplementationOnce( () => translate );
 		render( <TimeMismatchWarning siteId={ 1 } settingsUrl="https://example.com" /> );
-		expect( translate ).toMatchSnapshot();
+		// Assert on the interpolation component rather than snapshotting the mock:
+		// React 19 elements carry non-deterministic debug/owner data that breaks
+		// snapshot serialization.
+		const [ , options ] = translate.mock.calls[ 0 ];
+		expect( options.components.SiteSettings.props.href ).toBe( 'https://example.com' );
 	} );
 
 	test( 'to render the status if set', () => {

--- a/client/blocks/user-avatar/docs/example.tsx
+++ b/client/blocks/user-avatar/docs/example.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps } from 'react';
+import { ComponentProps, type JSX } from 'react';
 import UserAvatar from 'calypso/blocks/user-avatar';
 
 const UserAvatarExample = (): JSX.Element => {

--- a/client/blocks/user-avatar/user-hovercard/index.tsx
+++ b/client/blocks/user-avatar/user-hovercard/index.tsx
@@ -5,7 +5,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Spinner } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
+import { useEffect, type JSX } from 'react';
 import UserAvatarDefaultIcon from 'calypso/reader/components/icons/user-avatar-default-icon';
 import { UserAvatarInfo } from '..';
 import PrimaryBlogCard from './primary-blog-card';

--- a/client/blocks/user-avatar/user-hovercard/primary-blog-card/index.tsx
+++ b/client/blocks/user-avatar/user-hovercard/primary-blog-card/index.tsx
@@ -8,6 +8,7 @@ import ReaderFollowButton from 'calypso/reader/follow-button';
 import { getStreamUrl } from 'calypso/reader/route';
 import { useDispatch } from 'calypso/state';
 import { successNotice } from 'calypso/state/notices/actions';
+import type { JSX } from 'react';
 
 interface PrimaryBlogCardProps {
 	user: UserResponse;

--- a/client/blocks/user-avatar/user-hovercard/recommended-blogs/index.tsx
+++ b/client/blocks/user-avatar/user-hovercard/recommended-blogs/index.tsx
@@ -2,7 +2,7 @@ import './styles.scss';
 import { Spinner } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { shuffle } from 'lodash';
-import { useMemo } from 'react';
+import { useMemo, type JSX } from 'react';
 import { useFeedRecommendationsQuery } from 'calypso/data/reader/use-feed-recommendations-query';
 import { ReaderSitesList } from 'calypso/reader/sites-list';
 

--- a/client/blocks/user-avatar/user-hovercard/user-hovercard-header/index.tsx
+++ b/client/blocks/user-avatar/user-hovercard/user-hovercard-header/index.tsx
@@ -4,6 +4,7 @@ import AutoDirection from 'calypso/components/auto-direction';
 import PreloadedImage from 'calypso/components/preloaded-image';
 import UserAvatarDefaultIcon from 'calypso/reader/components/icons/user-avatar-default-icon';
 import { getProcessedGravatarUrl } from '../../utils';
+import type { JSX } from 'react';
 
 interface UserHovercardHeaderProps {
 	user: UserResponse;


### PR DESCRIPTION
Part of the [Calypso → React 19 migration](https://linear.app/a8c/project/migrate-calypso-to-react-19-ed8301da230e/overview). Covers the `client/blocks` area of the area-split plan, derived from the spike #111325.

## Proposed Changes

Make `client/blocks` source forward-compatible with React 19. Every change compiles cleanly on the current React 18 and is behavior-preserving:

* Import the `JSX` namespace explicitly wherever `JSX.Element` is referenced — React 19 no longer exposes `JSX` as a global.
* Pass an explicit initial value to `useRef` (a required argument in React 19's types).
* Replace removed `ReactDom.findDOMNode` calls with refs in self-contained components (app-banner, login-form via `FormTextInput`'s `inputRef`, reader-featured-video, reader-post-card).
* Type Storybook decorators as `ComponentType` instead of the removed `StoryFn` argument shape.
* Rework one test assertion (time-mismatch-warning) to avoid snapshotting a React element, whose internal fields are non-deterministic under React 19.

## Why are these changes being made?

Gutenberg and the `@wordpress/*` packages Calypso depends on are moving to React 19. Landing the forward-compatible source changes per area now lets the final `package.json` React 19 bump happen as a single low-risk PR once every area is ready.

## Scope notes

Kept deliberately limited to mechanical, behavior-preserving changes. Excluded from this PR:

* **author-selector** — its `findDOMNode` removal depends on an `InfiniteList` (`client/components`) change that hasn't landed; left on `findDOMNode` for now to avoid a React 18 regression.
* **React-19-only test assertions** (call signatures with an `undefined` second arg) — they fail under React 18.
* **PostCommentList `componentDidUpdate` fetch guard** — an intentional runtime change to prevent a React 19 max-update-depth loop; kept separate from this mechanical sweep so it can get focused review and a deep-link test.

## Testing Instructions

* `yarn typecheck-client` — passes (no new errors in `client/blocks`).
* `yarn test-client client/blocks` — all suites pass.
* Reader post cards verified in-browser: plain card-body click navigates to the post; modifier-click and inline-comment clicks are correctly ignored; no `findDOMNode` warning originates from `client/blocks` (the remaining one is from the not-yet-migrated `InfiniteList`).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
