### PR TITLE
Notifications: close standalone app on outside click

### DIFF
--- a/apps/notifications/src/standalone-app/index.jsx
+++ b/apps/notifications/src/standalone-app/index.jsx
@@ -125,6 +125,27 @@ const NotesWrapper = ( { wpcom } ) => {
 		store.dispatch( { type: 'APP_REFRESH_NOTES', isVisible } );
 	}, [ isShowing, isVisible ] );
 
+	// The card sits inside a wider iframe, so the host can't detect clicks on
+	// the empty area around it. Dismiss from inside instead: close on any click
+	// outside the two panes. (Not gated on `isShowing` — when the panel is
+	// closed the host hides the iframe, so the backdrop receives no clicks.)
+	useEffect( () => {
+		const handleClickOutside = ( event ) => {
+			if ( event.button !== 0 ) {
+				return;
+			}
+			if ( event.target.closest( '.wpnc-app__list-pane, .wpnc-app__detail-pane' ) ) {
+				return;
+			}
+			// Stop the click from starting a text selection on the backdrop.
+			event.preventDefault();
+			store.dispatch( actions.ui.closePanel() );
+		};
+
+		document.addEventListener( 'mousedown', handleClickOutside );
+		return () => document.removeEventListener( 'mousedown', handleClickOutside );
+	}, [] );
+
 	useEffect( () => {
 		const handleMessages = ( { action, hidden, showing } ) => {
 			debug( 'message received', { action, hidden, showing } );

--- a/apps/notifications/src/standalone-app/style.scss
+++ b/apps/notifications/src/standalone-app/style.scss
@@ -28,16 +28,23 @@ body {
 .wpnc__main {
 	position: fixed;
 	inset: 0;
+
+	@include break-small {
+		inset: 8px;
+	}
 }
 
 .wpnc-app {
-	max-width: 448px;
 	margin-inline-start: auto;
 	box-sizing: border-box;
 	border: 1px solid #dcdcde;
 	border-radius: 4px;
 	box-shadow: 0 0 16px rgba(0, 0, 0, 0.12);
 	overflow: hidden;
+
+	@include break-small {
+		max-width: 448px;
+	}
 
 	@include break-large {
 		max-width: 896px;


### PR DESCRIPTION
Part of DOTMSD-1294

## Proposed Changes

* Dismiss the standalone Notifications app when clicking the empty area around the card. A `mousedown` listener in the standalone-app entry dispatches `closePanel()` whenever the click lands outside both panes (`.wpnc-app__list-pane` / `.wpnc-app__detail-pane`), and `preventDefault()`s so the click doesn't start a text selection on the backdrop.
* Move the gap around the card from the host's `<iframe>` padding into the iframe document. Mobile-first: below the small breakpoint the panel spans full width with no inset; from `break-small` up it floats as a card with an `8px` inset (`max-width: 448px`, and `896px` at `break-large`).

## Why are these changes being made?

* The standalone app renders inside a long-lived iframe. Clicks that land on padding applied to the `<iframe>` **element** (host side) never reach the iframe's document, and the host counts them as "inside" the iframe — so neither the iframe nor the host dismisses the panel, and the click instead starts a text selection on the backdrop.
* Handling the dismissal inside the iframe only works if the surrounding gap is part of the iframe's own document. Insetting `.wpnc__main` keeps that gap in this document, where the `mousedown` handler can see the click and close the panel.

> [!NOTE]
> This is the iframe half of the fix. For clicks on the surrounding area to reach this handler, the host (wp-admin masterbar) must stop padding the `<iframe>` element and size the iframe to cover the area that should be clickable. That change lives outside this repo.

## Testing Instructions

* Open the standalone Notifications app (`/notifications/app/`).
* From the small breakpoint up, click in the empty area around the card → the panel closes (host receives `togglePanel`), and no text selection starts.
* Clicking inside the list or an open note detail does **not** close it.
* Below the small breakpoint, the panel fills the full width with no surrounding gap.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)