### PR TITLE
A4A: show user and agency name in the profile dropdown

### DIFF
--- a/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
+++ b/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
@@ -1,10 +1,12 @@
 import { Button, Gravatar } from '@automattic/components';
+import { __experimentalText as Text } from '@wordpress/components';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useRef, useState } from 'react';
 import { isClientView } from 'calypso/a8c-for-agencies/sections/purchases/payment-methods/lib/is-client-view';
 import useOutsideClickCallback from 'calypso/lib/use-outside-click-callback';
 import { useDispatch, useSelector } from 'calypso/state';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import { redirectToLogout } from 'calypso/state/current-user/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
@@ -26,6 +28,8 @@ type DropdownMenuProps = {
 const DropdownMenu = ( { isExpanded, setMenuExpanded }: DropdownMenuProps ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
+	const user = useSelector( getCurrentUser );
+	const agency = useSelector( getActiveAgency );
 
 	const onGetHelp = useCallback( () => {
 		setMenuExpanded( false );
@@ -51,6 +55,24 @@ const DropdownMenu = ( { isExpanded, setMenuExpanded }: DropdownMenuProps ) => {
 
 	return (
 		<ul className="a4a-sidebar__profile-dropdown-menu" hidden={ ! isExpanded }>
+			{ user?.display_name && (
+				<li className="a4a-sidebar__profile-dropdown-greeting">
+					<Text className="a4a-sidebar__profile-dropdown-greeting-welcome" weight={ 600 }>
+						{ translate( 'Welcome, %(name)s!', {
+							args: { name: user.display_name },
+							comment: '%(name)s is the name of the logged-in user',
+						} ) }
+					</Text>
+					{ agency?.name && (
+						<Text
+							className="a4a-sidebar__profile-dropdown-greeting-agency"
+							color="var(--color-text-subtle)"
+						>
+							{ agency.name }
+						</Text>
+					) }
+				</li>
+			) }
 			{
 				// Show the "Contact support" button if the user is not a client
 				! isClient && (

--- a/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
+++ b/client/a8c-for-agencies/components/sidebar/header/profile-dropdown.tsx
@@ -57,11 +57,8 @@ const DropdownMenu = ( { isExpanded, setMenuExpanded }: DropdownMenuProps ) => {
 		<ul className="a4a-sidebar__profile-dropdown-menu" hidden={ ! isExpanded }>
 			{ user?.display_name && (
 				<li className="a4a-sidebar__profile-dropdown-greeting">
-					<Text className="a4a-sidebar__profile-dropdown-greeting-welcome" weight={ 600 }>
-						{ translate( 'Welcome, %(name)s!', {
-							args: { name: user.display_name },
-							comment: '%(name)s is the name of the logged-in user',
-						} ) }
+					<Text className="a4a-sidebar__profile-dropdown-greeting-name" weight={ 600 }>
+						{ user.display_name }
 					</Text>
 					{ agency?.name && (
 						<Text

--- a/client/a8c-for-agencies/components/sidebar/header/style.scss
+++ b/client/a8c-for-agencies/components/sidebar/header/style.scss
@@ -99,7 +99,7 @@ html.accessible-focus .a4a-sidebar__profile-dropdown-button:focus {
 // Qualified with the parent class so these rules out-specify the Text
 // component's own (emotion) styles; otherwise white-space: nowrap loses the
 // cascade and the lines wrap. display: block lets text-overflow engage.
-.a4a-sidebar__profile-dropdown-greeting .a4a-sidebar__profile-dropdown-greeting-welcome,
+.a4a-sidebar__profile-dropdown-greeting .a4a-sidebar__profile-dropdown-greeting-name,
 .a4a-sidebar__profile-dropdown-greeting .a4a-sidebar__profile-dropdown-greeting-agency {
 	display: block;
 	max-width: 100%;
@@ -108,7 +108,7 @@ html.accessible-focus .a4a-sidebar__profile-dropdown-button:focus {
 	text-overflow: ellipsis;
 }
 
-.a4a-sidebar__profile-dropdown-greeting .a4a-sidebar__profile-dropdown-greeting-welcome {
+.a4a-sidebar__profile-dropdown-greeting .a4a-sidebar__profile-dropdown-greeting-name {
 	color: var(--color-text);
 }
 

--- a/client/a8c-for-agencies/components/sidebar/header/style.scss
+++ b/client/a8c-for-agencies/components/sidebar/header/style.scss
@@ -4,8 +4,6 @@
 // Rules in this file inspired by:
 // client/components/jetpack/profile-dropdown/style.scss
 
-$profile-dropdown-menu-height: 250px;
-
 .a4a-sidebar__header {
 	display: flex;
 	justify-content: space-between;
@@ -83,7 +81,35 @@ html.accessible-focus .a4a-sidebar__profile-dropdown-button:focus {
 }
 
 .a4a-sidebar__profile-dropdown.is-align-menu-up .a4a-sidebar__profile-dropdown-menu {
-	inset-block-start: -$profile-dropdown-menu-height;
+	// Anchor the upward menu by its bottom edge so it always sits above the
+	// button regardless of its height (the menu grows with the greeting).
+	inset-block-start: auto;
+	inset-block-end: calc(100% + 4px);
+}
+
+.a4a-sidebar__profile-dropdown-greeting {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	padding: 4px 8px 12px;
+	margin-block-end: 8px;
+	border-block-end: 1px solid var(--color-border-subtle);
+}
+
+// Qualified with the parent class so these rules out-specify the Text
+// component's own (emotion) styles; otherwise white-space: nowrap loses the
+// cascade and the lines wrap. display: block lets text-overflow engage.
+.a4a-sidebar__profile-dropdown-greeting .a4a-sidebar__profile-dropdown-greeting-welcome,
+.a4a-sidebar__profile-dropdown-greeting .a4a-sidebar__profile-dropdown-greeting-agency {
+	display: block;
+	max-width: 100%;
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+}
+
+.a4a-sidebar__profile-dropdown-greeting .a4a-sidebar__profile-dropdown-greeting-welcome {
+	color: var(--color-text);
 }
 
 .a4a-sidebar__profile-dropdown-menu-item {


### PR DESCRIPTION

Closes https://linear.app/a8c/issue/A4A-1996/add-display-of-agency-name-to-portal#agent-session-afa68835

<img width="256" height="336" alt="Screenshot 2026-06-10 at 6 38 43 PM" src="https://github.com/user-attachments/assets/190245ad-0fe8-46d9-bb58-b996362fdc50" />


## Proposed Changes
Add a display at the top of the sidebar profile dropdown that displays the user's name and the active agency name beneath it, so agencies can confirm which account they are managing. Both lines truncate to a single line with an ellipsis.

## Why are these changes being made?
Provides an indicator for the agency for which they are logged in.

## Testing Instructions

* Use the A4A live link and navigate to `/overview` page.
* Click the User profile menu in the sidebar.
* Confirm you see a greeting message with the agency name as subtext.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
