### PR TITLE
Circle CI: Restore Windows and Linux desktop release builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -374,7 +374,9 @@ jobs:
           name: Install NVM
           # Pinned: the nvm.install 1.2.2.20251229 package hangs in silent mode
           # when Node.js is preinstalled on the image, timing out the job.
-          command: choco install -y nvm --version 1.1.12
+          # The pin must be on nvm.install — `nvm` is a meta-package whose
+          # dependency range still resolves to the latest nvm.install.
+          command: choco install -y nvm.install --version 1.1.12
       - run:
           name: Install Node environment
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,6 +263,223 @@ jobs:
       - run: *desktop-notify-github-success
       - run: *desktop-notify-github-failure
 
+  wp-desktop-linux:
+    docker:
+      - image: cimg/node:24.15.0-browsers
+    <<: *desktop_defaults
+    resource_class: medium+
+    shell: /bin/bash --login
+    environment:
+      NODE_OPTIONS: --max-old-space-size=5120
+      CONFIG_ENV: release
+      PLAYWRIGHT_SKIP_DOWNLOAD: 'true'
+      # If, for testing purposes, you want to generate all artifacts in the CI of a PR, uncomment the following line,
+      # and push a commit to your branch. Make sure to remove the commit before merging to trunk!
+      #PR_DEBUG_RELEASE: 'true'
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/wp-calypso
+      - run:
+          name: Set environment variables
+          command: |
+            if [[ "$PR_DEBUG_RELEASE" == "true" ]]; then
+              echo "export RELEASE_BUILD=true" >> "$BASH_ENV"
+              echo "export CSC_FOR_PULL_REQUEST=true" >> "$BASH_ENV"
+              source "$BASH_ENV"
+            fi
+
+            if [[ $CIRCLE_TAG == desktop-v* ]]; then
+              echo "export RELEASE_BUILD=true" >> "$BASH_ENV"
+              source "$BASH_ENV"
+            fi
+
+            # If this is not a release build, only build the executable required for end-to-end testing.
+            if [[ "$RELEASE_BUILD" != "true" ]]; then
+              echo "export ELECTRON_BUILDER_ARGS='-c.linux.target=dir'" >> "$BASH_ENV"
+              source "$BASH_ENV"
+            fi
+
+            echo RELEASE_BUILD=$RELEASE_BUILD
+            echo CSC_FOR_PULL_REQUEST=$CSC_FOR_PULL_REQUEST
+            echo ELECTRON_BUILDER_ARGS=$ELECTRON_BUILDER_ARGS
+      - run:
+          name: Install Linux deps
+          command: |
+            sudo apt update
+            sudo apt-get install -y libsecret-1-dev
+      - restore_cache: *restore-yarn-cache
+      # Since Node and Yarn are both bundled in the image, no need to add nvm and
+      # yarn ourselves. So we run the command directly here.
+      - run:
+          name: Yarn Install
+          command: yarn install --immutable --inline-builds
+      - save_cache: *save-yarn-cache
+      - run:
+          name: Build Desktop Linux
+          environment:
+            CSC_LINK: resource/certificates/win.p12
+            USE_HARD_LINKS: 'false'
+          command: |
+            set +e
+            cd desktop
+            ELECTRON_BUILDER_ARGS=$ELECTRON_BUILDER_ARGS yarn run build
+      - run:
+          name: e2e Tests
+          command: |
+            node --version
+            yarn --version
+            cd desktop && yarn run test:e2e
+      - run:
+          when: always
+          name: Persist Linux Executable
+          command: |
+            # If this isn't a full artifact build, ensure to persist the built application for inspection
+            test -f desktop/release/*.tar.gz || tar -zcf desktop/release/linux-unpacked.tar.gz desktop/release/linux-unpacked
+      - run:
+          when: always
+          name: Clean Up
+          command: |
+            set +e
+            rm -rf desktop/release/github
+            rm -rf desktop/release/linux-unpacked
+            rm -rf desktop/release/.icon-set
+            rm desktop/release/builder-debug.yml
+      - store_artifacts:
+          when: always
+          path: desktop/release
+      - store_artifacts:
+          when: always
+          path: desktop/test/e2e/results/
+      - persist_to_workspace:
+          root: ~/wp-calypso
+          paths:
+            - desktop/release
+
+  wp-desktop-windows:
+    executor:
+      name: win/default
+    working_directory: C:\Users\circleci\wp-calypso
+    environment:
+      CONFIG_ENV: release
+      PLAYWRIGHT_SKIP_DOWNLOAD: 'true'
+      # If, for testing purposes, you want to generate all artifacts in the CI of a PR, uncomment the following line,
+      # and push a commit to your branch. Make sure to remove the commit before merging to trunk!
+      #PR_DEBUG_RELEASE: 'true'
+    steps:
+      - checkout
+      - attach_workspace:
+          at: C:\Users\circleci\wp-calypso
+      - run:
+          name: Install NVM
+          command: choco install -y nvm
+      - run:
+          name: Install Node environment
+          command: |
+            $NODE_VERSION = Get-Content .nvmrc
+            nvm install $NODE_VERSION
+            nvm use $NODE_VERSION
+      - run:
+          name: Install Yarn
+          command: npm install -g yarn
+      - run:
+          name: Verify versions
+          shell: bash.exe
+          command: |
+            node --version
+            nvm --version
+            yarn --version
+      - run:
+          name: Install Make
+          command: choco install make
+      - run:
+          name: Install Desktop Dependencies
+          command: yarn
+      - when:
+          # Set the condition to true on both steps to force a full artifact build for Windows.
+          condition: << pipeline.git.tag >>
+          steps:
+            - run:
+                name: Build Appx
+                command: |
+                  # Use make (not yarn/npm directly) for bash-like environment variable substitution
+                  make -f desktop/Makefile build-main WINDOWS_STORE=1
+                  # Note: Windows Store build should be unsigned
+                  make -f desktop/Makefile package ELECTRON_BUILDER_ARGS='--config="electron-builder-appx.json"'
+            - run:
+                name: Clean Up Appx
+                command: |
+                  set +e
+                  rm -rf desktop/config
+                  rm desktop/release/*.yml
+                  rm -rf desktop/release/win-unpacked
+                  rm -rf desktop/release/win-ia32-unpacked
+                  rm desktop/release/builder-debug.yml || true
+                shell: bash.exe
+      - when:
+          condition: << pipeline.git.tag >>
+          steps:
+            - run:
+                name: Import Codesigning Certificate
+                command: |
+                  # Workaround for Sign Tool "private key filter" bug in Circle's Windows image.
+                  # Ref: https://travis-ci.community/t/codesigning-on-windows/
+                  #
+                  # Fix: Import .p12 into the local certificate store. Sign Tool will use
+                  # package.json's `certificateSubjectName` to find the imported cert.
+                  $env:CSC_LINK='C:\Users\circleci\wp-calypso\desktop\resource\certificates\win.p12'
+                  Import-PfxCertificate -FilePath $env:CSC_LINK -CertStoreLocation Cert:\LocalMachine\Root -Password (ConvertTo-SecureString -String $env:WIN_CSC_KEY_PASSWORD -AsPlainText -Force)
+      - run:
+          name: Build NSIS
+          command: |
+            If ( $env:CIRCLE_TAG -or $env:PR_DEBUG_RELEASE ) { $env:RELEASE_BUILD='true' }
+
+            # If this is not a release build, only build the executable required for end-to-end testing.
+            If ( -Not $env:RELEASE_BUILD ) {
+              $env:ARG2='-c.win.target=dir'
+            }
+
+            # Use make (not yarn/npm directly) for bash-like environment variable substitution
+            make -f desktop/Makefile build-main
+
+            # Codesign release (tagged) builds only
+            If ( $env:CIRCLE_TAG ) { $env:ARG1='-c.win.certificateSubjectName="Automattic"' }
+
+            echo "RELEASE_BUILD=$env:RELEASE_BUILD"
+            echo "ARG1=$env:ARG1"
+            echo "ARG2=$env:ARG2"
+
+            make -f desktop/Makefile package ELECTRON_BUILDER_ARGS=$($env:ARG1,$env:ARG2 -join " ")
+      - run:
+          name: Archive Unpacked Directories
+          command: |
+            tar -zcf desktop/release/win-unpacked-x64.tar.gz desktop/release/win-unpacked
+
+            # Check if win-ia32 build is present before archiving. If this is a full
+            # artifact build, the win-ia32-unpacked executable will be generated and we can archive it.
+            If ( $(Test-Path -Path desktop\release\win-ia32-unpacked) ) {
+              tar -zcf desktop/release/win-unpacked-ia32.tar.gz desktop/release/win-ia32-unpacked
+            } else {
+              echo "Skipping tar archive for 'desktop\release\win-ia32-unpacked' (not built)"
+            }
+      - run:
+          when: always
+          name: Clean Up NSIS
+          command: |
+            set +e
+            rm -rf desktop/release/github
+            rm -rf desktop/release/win-unpacked
+            rm -rf desktop/release/win-ia32-unpacked
+            rm desktop/release/builder-debug.yml || true
+          shell: bash.exe
+      - store_artifacts:
+          when: always
+          path: desktop\release
+      - persist_to_workspace:
+          root: C:\Users\circleci\wp-calypso
+          paths:
+            - desktop\release
+
   # Publish all the artifacts generated by the previous wp-desktop- jobs to a
   # GitHub release and generate the release notes using the Git commits history
   wp-desktop-publish:
@@ -324,10 +541,28 @@ workflows:
             branches:
               only:
                 - trunk
+                - /release\/.*/
+                - /desktop\/.*/
+      - wp-desktop-linux:
+          requires:
+            - wp-desktop-assets
+          filters:
+            branches:
+              only:
+                - trunk
                 - /circleci.*/
                 - /release\/.*/
                 - /desktop\/.*/
-
+      - wp-desktop-windows:
+          requires:
+            - wp-desktop-assets
+          filters:
+            branches:
+              only:
+                - trunk
+                - /circleci.*/
+                - /release\/.*/
+                - /desktop\/.*/
   wp-desktop-release:
     when: << pipeline.git.tag >>
     jobs:
@@ -341,10 +576,23 @@ workflows:
           filters:
             tags:
               only: /desktop-v.*/
-
+      - wp-desktop-linux:
+          requires:
+            - wp-desktop-assets
+          filters:
+            tags:
+              only: /desktop-v.*/
+      - wp-desktop-windows:
+          requires:
+            - wp-desktop-assets
+          filters:
+            tags:
+              only: /desktop-v.*/
       - wp-desktop-publish:
           requires:
             - wp-desktop-mac
+            - wp-desktop-linux
+            - wp-desktop-windows
           filters:
             tags:
               only: /desktop-v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -547,13 +547,16 @@ workflows:
                 - trunk
                 - /release\/.*/
                 - /desktop\/.*/
+      # Unlike wp-desktop-mac, the linux and windows jobs are excluded from
+      # trunk on purpose: building them on every trunk commit is what #103588
+      # set out to stop. They still run on desktop/release/circleci branches
+      # and on desktop-v* tags (see the wp-desktop-release workflow below).
       - wp-desktop-linux:
           requires:
             - wp-desktop-assets
           filters:
             branches:
               only:
-                - trunk
                 - /circleci.*/
                 - /release\/.*/
                 - /desktop\/.*/
@@ -563,7 +566,6 @@ workflows:
           filters:
             branches:
               only:
-                - trunk
                 - /circleci.*/
                 - /release\/.*/
                 - /desktop\/.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -372,7 +372,9 @@ jobs:
           at: C:\Users\circleci\wp-calypso
       - run:
           name: Install NVM
-          command: choco install -y nvm
+          # Pinned: the nvm.install 1.2.2.20251229 package hangs in silent mode
+          # when Node.js is preinstalled on the image, timing out the job.
+          command: choco install -y nvm --version 1.1.12
       - run:
           name: Install Node environment
           command: |


### PR DESCRIPTION
Restores the Linux and Windows desktop release builds removed in #103588, without reinstating their cost on every trunk commit.

## Proposed Changes

* Restore the `wp-desktop-linux` and `wp-desktop-windows` CircleCI jobs removed in #103588, including their entries in the `wp-desktop` and `wp-desktop-release` workflows.
* Unlike a plain revert, keep `trunk` **out** of the linux/windows branch filters: #103588's motivation was the cost of building Linux and Windows on every trunk merge (~40 a day, each Windows build taking ~40 minutes on the expensive Windows executor). This PR preserves that saving — the two jobs only run on `desktop/*`, `release/*`, `circleci*` branches and on `desktop-v*` release tags, where they are actually needed.
* Restore `wp-desktop-publish` requiring all three platform builds (mac, linux, windows) before publishing a release.
* Bump the restored `wp-desktop-linux` Docker image from `cimg/node:22.9.0-browsers` to `cimg/node:24.15.0-browsers` to match the repo-wide Node.js upgrade (#110139) that landed after the removal.
* Pin the Windows job's nvm install to `nvm.install` 1.1.12. Chocolatey now resolves `nvm` to `nvm.install` 1.2.2.20251229, whose `nvm-setup.exe` hangs in silent mode when Node.js is preinstalled on the image (as it is on CircleCI's Windows executor), timing out the job after 10 minutes of no output. The pin must target `nvm.install` directly — `nvm` is a meta-package whose dependency range still resolves to the latest `nvm.install` even when the meta-package version is pinned.

## Why are these changes being made?

* #103588 (part of DOTCOM-10593) was described as removing unused desktop *tests*, but the `wp-desktop-linux` and `wp-desktop-windows` jobs also produced the Linux and Windows release binaries. Since their removal, tagged `desktop-v*` releases only build and publish macOS artifacts.
* Restoring these jobs makes it possible to ship the WordPress Desktop App for Linux and Windows again (the recent `desktop-v8.2.0-beta1` tag produced only macOS artifacts).
* CircleCI build history confirms the original cost concern: every trunk merge still runs `wp-desktop-assets` + `wp-desktop-mac` (~40/day). This PR deliberately does not add linux/windows back to that path.
* The PR branch intentionally uses the `desktop/` prefix so the desktop CircleCI workflow triggers here — the desktop jobs only run on `trunk`, `release/*`, `desktop/*` (and `circleci*` for linux/windows) branches.

## Testing Instructions

* Check that Circle CI triggers all four desktop jobs on this PR’s branch pipeline:
  - `wp-desktop-assets` ✅
  - `wp-desktop-mac` ✅
  - `wp-desktop-linux` ✅
  - `wp-desktop-windows` ✅
* Verify the `wp-desktop-linux` and `wp-desktop-windows` jobs build successfully on Node 24 (the Linux job previously pinned an older Node image). ✅ All four jobs pass on this branch.
* On the next `desktop-v*` tag, verify `wp-desktop-publish` waits for all three platform builds and the draft release contains Linux and Windows artifacts.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

