### PR TITLE
A4A: Wire A4A payment notice API

### DIFF
--- a/client/a8c-for-agencies/components/payment-risk-notice-banner/constants.ts
+++ b/client/a8c-for-agencies/components/payment-risk-notice-banner/constants.ts
@@ -1,9 +1,8 @@
 import { isEnabled } from '@automattic/calypso-config';
+import type { PaymentNoticeSeverity } from 'calypso/state/a8c-for-agencies/types';
 
 export const PAYMENT_RISK_NOTICE_BANNER_FLAG = 'a4a-payment-risk-notice-banner';
 
-export type PaymentRiskNoticeSeverity = 'warning' | 'error';
-
-export const PAYMENT_RISK_NOTICE_SEVERITY: PaymentRiskNoticeSeverity = 'error';
+export type PaymentRiskNoticeSeverity = PaymentNoticeSeverity;
 
 export const isPaymentRiskNoticeBannerEnabled = () => isEnabled( PAYMENT_RISK_NOTICE_BANNER_FLAG );

--- a/client/a8c-for-agencies/components/payment-risk-notice-banner/index.tsx
+++ b/client/a8c-for-agencies/components/payment-risk-notice-banner/index.tsx
@@ -12,7 +12,7 @@ import {
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { isPaymentRiskNoticeBannerEnabled } from './constants';
+import usePaymentRiskNotice from './use-payment-risk-notice';
 
 import './style.scss';
 
@@ -30,44 +30,59 @@ export default function PaymentRiskNoticeBanner( {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const { setShowHelpCenter, setNavigateToRoute } = useDataStoreDispatch( HELP_CENTER_STORE );
-	const isPaymentRiskNoticeEnabled = isPaymentRiskNoticeBannerEnabled();
+	const paymentNotice = usePaymentRiskNotice();
 	const ctaUrl = isEnabled( 'a4a-bd-checkout' )
 		? EXTERNAL_WPCOM_PAYMENT_METHODS_URL
 		: A4A_PAYMENT_METHODS_LINK;
 
 	useEffect( () => {
-		if ( isPaymentRiskNoticeEnabled ) {
+		if ( paymentNotice ) {
 			dispatch(
 				recordTracksEvent( 'calypso_a4a_payment_risk_notice_banner_view', {
 					source,
+					state: paymentNotice.state,
+					severity: paymentNotice.severity,
 				} )
 			);
 		}
-	}, [ dispatch, isPaymentRiskNoticeEnabled, source ] );
+	}, [ dispatch, paymentNotice, source ] );
 
 	const onCtaClick = useCallback( () => {
+		if ( ! paymentNotice ) {
+			return;
+		}
+
 		dispatch(
 			recordTracksEvent( 'calypso_a4a_payment_risk_notice_banner_cta_click', {
 				source,
+				state: paymentNotice.state,
+				severity: paymentNotice.severity,
 			} )
 		);
-	}, [ dispatch, source ] );
+	}, [ dispatch, paymentNotice, source ] );
 
 	const onContactUsClick = useCallback(
 		( event: MouseEvent< HTMLAnchorElement > ) => {
 			event.preventDefault();
+
+			if ( ! paymentNotice ) {
+				return;
+			}
+
 			setShowHelpCenter( true );
 			setNavigateToRoute( '/contact-form' );
 			dispatch(
 				recordTracksEvent( 'calypso_a4a_payment_risk_notice_banner_contact_us_click', {
 					source,
+					state: paymentNotice.state,
+					severity: paymentNotice.severity,
 				} )
 			);
 		},
-		[ dispatch, setNavigateToRoute, setShowHelpCenter, source ]
+		[ dispatch, paymentNotice, setNavigateToRoute, setShowHelpCenter, source ]
 	);
 
-	if ( ! isPaymentRiskNoticeEnabled ) {
+	if ( ! paymentNotice ) {
 		return null;
 	}
 
@@ -101,17 +116,21 @@ export default function PaymentRiskNoticeBanner( {
 		<LayoutBanner
 			isFullWidth={ isFullWidth }
 			className="a4a-payment-risk-notice-banner"
-			level="error"
-			title={ translate( 'Action required: We’re unable to renew your subscription(s)' ) }
+			level={ paymentNotice.severity }
+			title={
+				paymentNotice.title ??
+				translate( 'Action required: We’re unable to renew your subscription(s)' )
+			}
 			actions={ [ fixPaymentMethodCta, contactUsCta ] }
 			hideCloseButton
 			allowTemporaryDismissal
 			preferenceName="a4a-payment-risk-notice-banner-temporary-dismissed"
 		>
 			<div>
-				{ translate(
-					'We couldn’t process payment for one or more of your subscriptions with the payment method we have on file. If this isn’t resolved, your subscriptions will be cancelled and your sites may go offline. Please update your payment method to stay covered.'
-				) }
+				{ paymentNotice.content ??
+					translate(
+						'We couldn’t process payment for one or more of your subscriptions with the payment method we have on file. If this isn’t resolved, your subscriptions will be cancelled and your sites may go offline. Please update your payment method to stay covered.'
+					) }
 			</div>
 		</LayoutBanner>
 	);

--- a/client/a8c-for-agencies/components/payment-risk-notice-banner/index.tsx
+++ b/client/a8c-for-agencies/components/payment-risk-notice-banner/index.tsx
@@ -31,41 +31,43 @@ export default function PaymentRiskNoticeBanner( {
 	const dispatch = useDispatch();
 	const { setShowHelpCenter, setNavigateToRoute } = useDataStoreDispatch( HELP_CENTER_STORE );
 	const paymentNotice = usePaymentRiskNotice();
+	const noticeState = paymentNotice?.state;
+	const noticeSeverity = paymentNotice?.severity;
 	const ctaUrl = isEnabled( 'a4a-bd-checkout' )
 		? EXTERNAL_WPCOM_PAYMENT_METHODS_URL
 		: A4A_PAYMENT_METHODS_LINK;
 
 	useEffect( () => {
-		if ( paymentNotice ) {
+		if ( noticeState && noticeSeverity ) {
 			dispatch(
 				recordTracksEvent( 'calypso_a4a_payment_risk_notice_banner_view', {
 					source,
-					state: paymentNotice.state,
-					severity: paymentNotice.severity,
+					state: noticeState,
+					severity: noticeSeverity,
 				} )
 			);
 		}
-	}, [ dispatch, paymentNotice, source ] );
+	}, [ dispatch, noticeState, noticeSeverity, source ] );
 
 	const onCtaClick = useCallback( () => {
-		if ( ! paymentNotice ) {
+		if ( ! noticeState || ! noticeSeverity ) {
 			return;
 		}
 
 		dispatch(
 			recordTracksEvent( 'calypso_a4a_payment_risk_notice_banner_cta_click', {
 				source,
-				state: paymentNotice.state,
-				severity: paymentNotice.severity,
+				state: noticeState,
+				severity: noticeSeverity,
 			} )
 		);
-	}, [ dispatch, paymentNotice, source ] );
+	}, [ dispatch, noticeState, noticeSeverity, source ] );
 
 	const onContactUsClick = useCallback(
 		( event: MouseEvent< HTMLAnchorElement > ) => {
 			event.preventDefault();
 
-			if ( ! paymentNotice ) {
+			if ( ! noticeState || ! noticeSeverity ) {
 				return;
 			}
 
@@ -74,15 +76,15 @@ export default function PaymentRiskNoticeBanner( {
 			dispatch(
 				recordTracksEvent( 'calypso_a4a_payment_risk_notice_banner_contact_us_click', {
 					source,
-					state: paymentNotice.state,
-					severity: paymentNotice.severity,
+					state: noticeState,
+					severity: noticeSeverity,
 				} )
 			);
 		},
-		[ dispatch, paymentNotice, setNavigateToRoute, setShowHelpCenter, source ]
+		[ dispatch, noticeState, noticeSeverity, setNavigateToRoute, setShowHelpCenter, source ]
 	);
 
-	if ( ! paymentNotice ) {
+	if ( ! paymentNotice || ! noticeState || ! noticeSeverity ) {
 		return null;
 	}
 
@@ -116,7 +118,7 @@ export default function PaymentRiskNoticeBanner( {
 		<LayoutBanner
 			isFullWidth={ isFullWidth }
 			className="a4a-payment-risk-notice-banner"
-			level={ paymentNotice.severity }
+			level={ noticeSeverity }
 			title={
 				paymentNotice.title ??
 				translate( 'Action required: We’re unable to renew your subscription(s)' )

--- a/client/a8c-for-agencies/components/payment-risk-notice-banner/test/index.test.tsx
+++ b/client/a8c-for-agencies/components/payment-risk-notice-banner/test/index.test.tsx
@@ -7,11 +7,13 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import PaymentRiskNoticeBanner from '..';
+import type { PaymentNotice } from 'calypso/state/a8c-for-agencies/types';
 import type { ReactNode } from 'react';
 
 const mockSetShowHelpCenter = jest.fn();
 const mockSetNavigateToRoute = jest.fn();
 const mockDispatch = jest.fn();
+let mockPaymentNotice: PaymentNotice | null = null;
 
 jest.mock( '@automattic/calypso-config', () => ( {
 	isEnabled: jest.fn(),
@@ -68,13 +70,15 @@ jest.mock( 'calypso/a8c-for-agencies/components/layout/banner', () => ( {
 	default: ( {
 		actions,
 		children,
+		level,
 		title,
 	}: {
 		actions?: ReactNode[];
 		children: ReactNode;
+		level: string;
 		title?: string;
 	} ) => (
-		<section>
+		<section data-level={ level } data-testid="layout-banner">
 			{ title && <h2>{ title }</h2> }
 			{ children }
 			{ actions }
@@ -84,6 +88,16 @@ jest.mock( 'calypso/a8c-for-agencies/components/layout/banner', () => ( {
 
 jest.mock( 'calypso/state', () => ( {
 	useDispatch: () => mockDispatch,
+	useSelector: ( selector: ( state: unknown ) => unknown ) =>
+		selector( {
+			a8cForAgencies: {
+				agencies: {
+					activeAgency: {
+						payment_notice: mockPaymentNotice,
+					},
+				},
+			},
+		} ),
 } ) );
 
 jest.mock( 'calypso/state/analytics/actions', () => ( {
@@ -102,6 +116,13 @@ const mockedRecordTracksEvent = recordTracksEvent as jest.MockedFunction<
 describe( 'PaymentRiskNoticeBanner', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
+		mockPaymentNotice = {
+			state: 'renewal_failure',
+			severity: 'error',
+			title: 'Action required: We are unable to renew your subscription(s)',
+			content:
+				'We could not process payment for one or more of your subscriptions with the payment method we have on file.',
+		};
 		mockedIsEnabled.mockImplementation( ( flag ) => flag === 'a4a-payment-risk-notice-banner' );
 	} );
 
@@ -114,25 +135,42 @@ describe( 'PaymentRiskNoticeBanner', () => {
 		expect( mockDispatch ).not.toHaveBeenCalled();
 	} );
 
-	it( 'renders the notice and records view and CTA click events', async () => {
+	it( 'does not render when the payment notice is missing', () => {
+		mockPaymentNotice = null;
+
+		const { container } = render( <PaymentRiskNoticeBanner source="overview" /> );
+
+		expect( container ).toBeEmptyDOMElement();
+		expect( mockDispatch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'renders the API notice and records view and CTA click events', async () => {
 		const user = userEvent.setup();
+		mockPaymentNotice = {
+			state: 'card_expiry',
+			severity: 'warning',
+			title: 'Action required: Update your payment method',
+			content:
+				'The payment method we have on file is expiring soon. Please update it to avoid interruption to your subscriptions and sites.',
+		};
 
 		render( <PaymentRiskNoticeBanner source="overview" /> );
 
 		expect(
 			screen.getByRole( 'heading', {
-				name: 'Action required: We’re unable to renew your subscription(s)',
+				name: 'Action required: Update your payment method',
 			} )
 		).toBeVisible();
 		expect(
 			screen.getByText(
-				'We couldn’t process payment for one or more of your subscriptions with the payment method we have on file. If this isn’t resolved, your subscriptions will be cancelled and your sites may go offline. Please update your payment method to stay covered.'
+				'The payment method we have on file is expiring soon. Please update it to avoid interruption to your subscriptions and sites.'
 			)
 		).toBeVisible();
+		expect( screen.getByTestId( 'layout-banner' ) ).toHaveAttribute( 'data-level', 'warning' );
 
 		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
 			'calypso_a4a_payment_risk_notice_banner_view',
-			{ source: 'overview' }
+			{ source: 'overview', state: 'card_expiry', severity: 'warning' }
 		);
 
 		const fixPaymentMethodButton = screen.getByRole( 'button', { name: 'Fix payment method' } );
@@ -144,14 +182,14 @@ describe( 'PaymentRiskNoticeBanner', () => {
 
 		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
 			'calypso_a4a_payment_risk_notice_banner_cta_click',
-			{ source: 'overview' }
+			{ source: 'overview', state: 'card_expiry', severity: 'warning' }
 		);
 
 		await user.click( screen.getByRole( 'button', { name: 'Contact us' } ) );
 
 		expect( mockedRecordTracksEvent ).toHaveBeenCalledWith(
 			'calypso_a4a_payment_risk_notice_banner_contact_us_click',
-			{ source: 'overview' }
+			{ source: 'overview', state: 'card_expiry', severity: 'warning' }
 		);
 		expect( mockSetShowHelpCenter ).toHaveBeenCalledWith( true );
 		expect( mockSetNavigateToRoute ).toHaveBeenCalledWith( '/contact-form' );

--- a/client/a8c-for-agencies/components/payment-risk-notice-banner/test/index.test.tsx
+++ b/client/a8c-for-agencies/components/payment-risk-notice-banner/test/index.test.tsx
@@ -144,6 +144,22 @@ describe( 'PaymentRiskNoticeBanner', () => {
 		expect( mockDispatch ).not.toHaveBeenCalled();
 	} );
 
+	it( 'does not record another view event when the same notice is refetched', () => {
+		const getViewEventCalls = () =>
+			mockedRecordTracksEvent.mock.calls.filter(
+				( [ eventName ] ) => eventName === 'calypso_a4a_payment_risk_notice_banner_view'
+			);
+
+		const { rerender } = render( <PaymentRiskNoticeBanner source="overview" /> );
+
+		expect( getViewEventCalls() ).toHaveLength( 1 );
+
+		mockPaymentNotice = { ...mockPaymentNotice! };
+		rerender( <PaymentRiskNoticeBanner source="overview" /> );
+
+		expect( getViewEventCalls() ).toHaveLength( 1 );
+	} );
+
 	it( 'renders the API notice and records view and CTA click events', async () => {
 		const user = userEvent.setup();
 		mockPaymentNotice = {

--- a/client/a8c-for-agencies/components/payment-risk-notice-banner/use-payment-risk-notice.ts
+++ b/client/a8c-for-agencies/components/payment-risk-notice-banner/use-payment-risk-notice.ts
@@ -1,0 +1,14 @@
+import { useSelector } from 'calypso/state';
+import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
+import { isPaymentRiskNoticeBannerEnabled } from './constants';
+import type { PaymentNotice } from 'calypso/state/a8c-for-agencies/types';
+
+export default function usePaymentRiskNotice(): PaymentNotice | null {
+	const agency = useSelector( getActiveAgency );
+
+	if ( ! isPaymentRiskNoticeBannerEnabled() ) {
+		return null;
+	}
+
+	return agency?.payment_notice ?? null;
+}

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
@@ -18,11 +18,8 @@ import {
 } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
-import {
-	isPaymentRiskNoticeBannerEnabled,
-	PAYMENT_RISK_NOTICE_SEVERITY,
-} from 'calypso/a8c-for-agencies/components/payment-risk-notice-banner/constants';
 import PaymentRiskNoticeMenuIndicator from 'calypso/a8c-for-agencies/components/payment-risk-notice-banner/menu-indicator';
+import usePaymentRiskNotice from 'calypso/a8c-for-agencies/components/payment-risk-notice-banner/use-payment-risk-notice';
 import { isPathAllowed } from 'calypso/a8c-for-agencies/lib/permission';
 import { A4A_REPORTS_LINK } from 'calypso/a8c-for-agencies/sections/reports/constants';
 import wooPaymentsIcon from 'calypso/assets/images/a8c-for-agencies/woopayments/woo-sidebar-icon.svg';
@@ -56,7 +53,7 @@ const useMainMenuItems = ( path: string ) => {
 	const translate = useTranslate();
 
 	const agency = useSelector( getActiveAgency );
-	const showPaymentRiskIndicator = isPaymentRiskNoticeBannerEnabled();
+	const paymentNotice = usePaymentRiskNotice();
 
 	const menuItems = useMemo( () => {
 		let referralItems = [] as any[];
@@ -183,10 +180,10 @@ const useMainMenuItems = ( path: string ) => {
 				icon: currencyDollar,
 				path: A4A_PURCHASES_LINK,
 				link: A4A_LICENSES_LINK,
-				title: showPaymentRiskIndicator ? (
+				title: paymentNotice ? (
 					<span className="a4a-payment-risk-notice-menu-title">
 						<span>{ translate( 'Purchases' ) }</span>
-						<PaymentRiskNoticeMenuIndicator severity={ PAYMENT_RISK_NOTICE_SEVERITY } />
+						<PaymentRiskNoticeMenuIndicator severity={ paymentNotice.severity } />
 					</span>
 				) : (
 					translate( 'Purchases' )
@@ -247,7 +244,7 @@ const useMainMenuItems = ( path: string ) => {
 		]
 			.map( ( item ) => createItem( item, path ) )
 			.filter( ( item ) => isPathAllowed( item.link, agency ) );
-	}, [ agency, path, showPaymentRiskIndicator, translate ] );
+	}, [ agency, path, paymentNotice, translate ] );
 	return menuItems;
 };
 

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-main-menu-items.tsx
@@ -54,6 +54,7 @@ const useMainMenuItems = ( path: string ) => {
 
 	const agency = useSelector( getActiveAgency );
 	const paymentNotice = usePaymentRiskNotice();
+	const paymentNoticeSeverity = paymentNotice?.severity;
 
 	const menuItems = useMemo( () => {
 		let referralItems = [] as any[];
@@ -180,10 +181,10 @@ const useMainMenuItems = ( path: string ) => {
 				icon: currencyDollar,
 				path: A4A_PURCHASES_LINK,
 				link: A4A_LICENSES_LINK,
-				title: paymentNotice ? (
+				title: paymentNoticeSeverity ? (
 					<span className="a4a-payment-risk-notice-menu-title">
 						<span>{ translate( 'Purchases' ) }</span>
-						<PaymentRiskNoticeMenuIndicator severity={ paymentNotice.severity } />
+						<PaymentRiskNoticeMenuIndicator severity={ paymentNoticeSeverity } />
 					</span>
 				) : (
 					translate( 'Purchases' )
@@ -244,7 +245,7 @@ const useMainMenuItems = ( path: string ) => {
 		]
 			.map( ( item ) => createItem( item, path ) )
 			.filter( ( item ) => isPathAllowed( item.link, agency ) );
-	}, [ agency, path, paymentNotice, translate ] );
+	}, [ agency, path, paymentNoticeSeverity, translate ] );
 	return menuItems;
 };
 

--- a/client/state/a8c-for-agencies/types.ts
+++ b/client/state/a8c-for-agencies/types.ts
@@ -29,6 +29,25 @@ export interface TitanUsage {
 }
 
 export type AgencyTierStatus = 'early_access' | 'tier_protected';
+
+export type PaymentNoticeState = 'card_expiry' | 'renewal_failure';
+
+export type PaymentNoticeSeverity = 'warning' | 'error';
+
+export interface PaymentNotice {
+	state: PaymentNoticeState;
+	severity: PaymentNoticeSeverity;
+	source?: string;
+	title?: string;
+	content?: string;
+	action_label?: string;
+	action_url?: string;
+	failed_at?: string;
+	grace_period_ends_at?: string;
+	affected_subscription_ids?: number[];
+	can_current_user_manage_payment_method?: boolean;
+}
+
 export interface Agency {
 	id: number;
 	name: string;
@@ -129,6 +148,7 @@ export interface Agency {
 	approval_status: ApprovalStatus | '';
 	created_at: string;
 	billing_system?: 'billingdragon' | 'legacy';
+	payment_notice?: PaymentNotice | null;
 }
 
 export type UserBillingType = 'legacy' | 'billingdragon';


### PR DESCRIPTION
Part of A4A-2583

## Proposed Changes

* Wire the A4A agency `payment_notice` API response into the existing payment-risk banner.
* Keep `a4a-payment-risk-notice-banner` as a kill switch while testing.
* Use the same flag + `payment_notice` gate for the Purchases sidebar indicator.
* Use API `title`, `content`, and `severity` for the banner when present.
* Include notice `state` and `severity` in payment-risk banner Tracks events.

<img width="1477" height="505" alt="image" src="https://github.com/user-attachments/assets/5b32e2f1-caa5-4633-8fbb-41674c7bd288" />


## Why are these changes being made?

The backend now derives live payment notices and exposes them on the A4A agency response. The existing banner was only feature-flag driven for visual testing, so it needs to use the API response before we can safely test and roll out real notices.

## Testing Instructions

* Enable the `a4a-payment-risk-notice-banner` feature flag.
* Use an agency whose API response includes `payment_notice`.
* Open A4A Overview.
* Verify the payment-risk banner is visible and uses the API notice copy/severity.
* Open a Purchases page.
* Verify the Purchases sidebar item shows the notice indicator using the API severity.
* Disable the feature flag.
* Verify the banner and sidebar indicator are hidden.
* Use an agency whose API response has `payment_notice: null`.
* Verify the banner and sidebar indicator are hidden, even when the flag is enabled.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

_— ClemenAgent (Powered by Codex)_
