### PR TITLE
Domains: show group-level discount strikethrough on bundle line items

### DIFF
--- a/packages/mini-cart/test/mini-cart-line-items.tsx
+++ b/packages/mini-cart/test/mini-cart-line-items.tsx
@@ -10,15 +10,18 @@ function domainProduct(
 	uuid: string,
 	meta: string,
 	groupId?: string,
-	role?: 'primary' | 'companion'
+	role?: 'primary' | 'companion',
+	prices: { subtotal?: number; original?: number } = {}
 ): ResponseCartProduct {
+	const subtotal = prices.subtotal ?? 2000;
 	return {
 		...getEmptyResponseCartProduct(),
 		uuid,
 		meta,
 		product_slug: 'domain_reg',
 		is_domain_registration: true,
-		item_subtotal_integer: 2000,
+		item_subtotal_integer: subtotal,
+		item_original_subtotal_integer: prices.original ?? subtotal,
 		extra: groupId
 			? { domain_bundle_group_id: groupId, domain_bundle_role: role, expected_bundle_size: '2' }
 			: {},
@@ -36,12 +39,12 @@ function bundleCart(): ResponseCart {
 	};
 }
 
-function renderLineItems( showBundleGrouping: boolean ) {
+function renderLineItems( showBundleGrouping: boolean, responseCart: ResponseCart = bundleCart() ) {
 	return render(
 		<CheckoutProvider paymentMethods={ [] } paymentProcessors={ {} }>
 			<RestorableProductsProvider>
 				<MiniCartLineItems
-					responseCart={ bundleCart() }
+					responseCart={ responseCart }
 					removeProductFromCart={ jest.fn() }
 					addProductsToCart={ jest.fn() }
 					removeCoupon={ jest.fn() }
@@ -70,5 +73,36 @@ describe( 'MiniCartLineItems bundle grouping', () => {
 		expect( screen.getByText( 'example.com' ) ).toBeVisible();
 		expect( screen.getByText( 'example.net' ) ).toBeVisible();
 		expect( screen.getByText( 'standalone.com' ) ).toBeVisible();
+	} );
+
+	test( 'crosses out only the discounted bundle in a multi-bundle cart', () => {
+		const cart: ResponseCart = {
+			...getEmptyResponseCart(),
+			products: [
+				// Discounted bundle: original 6500 + 6400 = 12900 ($129), discounted 2200 + 700 = 2900 ($29).
+				domainProduct( 'a-primary', 'first.com', 'bundle-a', 'primary', {
+					subtotal: 2200,
+					original: 6500,
+				} ),
+				domainProduct( 'a-companion', 'first.net', 'bundle-a', 'companion', {
+					subtotal: 700,
+					original: 6400,
+				} ),
+				// Undiscounted bundle: 2000 + 2000 = 4000 ($40), no crossed-out price.
+				domainProduct( 'b-primary', 'second.com', 'bundle-b', 'primary' ),
+				domainProduct( 'b-companion', 'second.net', 'bundle-b', 'companion' ),
+			],
+		};
+
+		const { container } = renderLineItems( true, cart );
+
+		const crossedOut = screen.getByText( /\$129\b/ );
+		expect( crossedOut ).toBeVisible();
+		expect( crossedOut.tagName ).toBe( 'S' );
+		expect( screen.getByText( /\$29\b/ ) ).toBeVisible();
+		expect( screen.getByText( /\$40\b/ ) ).toBeVisible();
+
+		// Only the discounted bundle shows a strikethrough.
+		expect( container.querySelectorAll( 's' ) ).toHaveLength( 1 );
 	} );
 } );

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -492,6 +492,12 @@ export function BundleLineItem( {
 				/>
 			</span>
 
+			{ isBundleDiscounted && (
+				<LineItemMeta>
+					<DiscountCallout>{ translate( 'Discount for first year' ) }</DiscountCallout>
+				</LineItemMeta>
+			) }
+
 			{ products.map( ( product ) => (
 				<LineItemMeta key={ product.uuid }>
 					<span>{ product.meta }</span>

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -456,6 +456,17 @@ export function BundleLineItem( {
 		isSmallestUnit: true,
 		stripZeros: true,
 	} );
+	// The backend applies the bundle discount as a cost override on each member, so
+	// the pre-discount group price is the sum of the members' original subtotals.
+	const bundleOriginalInteger = products.reduce(
+		( total, product ) => total + product.item_original_subtotal_integer,
+		0
+	);
+	const bundleOriginalDisplay = formatCurrency( bundleOriginalInteger, currency, {
+		isSmallestUnit: true,
+		stripZeros: true,
+	} );
+	const isBundleDiscounted = bundleTotalInteger < bundleOriginalInteger;
 	const bundleLabel = String( translate( 'Domain bundle' ) );
 
 	const removeBundleFromCart = () => {
@@ -475,7 +486,10 @@ export function BundleLineItem( {
 			<LineItemTitle isSummary={ isSummary }>{ bundleLabel }</LineItemTitle>
 
 			<span className="checkout-line-item__price">
-				<LineItemPrice actualAmount={ bundleTotalDisplay } />
+				<LineItemPrice
+					actualAmount={ bundleTotalDisplay }
+					crossedOutAmount={ isBundleDiscounted ? bundleOriginalDisplay : undefined }
+				/>
 			</span>
 
 			{ products.map( ( product ) => (

--- a/packages/wpcom-checkout/test/bundle-line-item.tsx
+++ b/packages/wpcom-checkout/test/bundle-line-item.tsx
@@ -78,10 +78,11 @@ describe( 'BundleLineItem', () => {
 		expect( screen.getByText( /\$40\b/ ) ).toBeVisible();
 	} );
 
-	test( 'shows no crossed-out price when the bundle is not discounted', () => {
+	test( 'shows no crossed-out price or discount callout when the bundle is not discounted', () => {
 		const { container } = renderBundle();
 
 		expect( container.querySelector( 's' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Discount for first year' ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'shows the summed original price crossed out when the bundle is discounted', () => {
@@ -93,6 +94,7 @@ describe( 'BundleLineItem', () => {
 		const crossedOut = screen.getByText( /\$129\b/ );
 		expect( crossedOut ).toBeVisible();
 		expect( crossedOut.tagName ).toBe( 'S' );
+		expect( screen.getByText( 'Discount for first year' ) ).toBeVisible();
 	} );
 
 	test( 'shows no remove button without hasDeleteButton', () => {

--- a/packages/wpcom-checkout/test/bundle-line-item.tsx
+++ b/packages/wpcom-checkout/test/bundle-line-item.tsx
@@ -11,12 +11,50 @@ const bundle: CartBundleLineItem = {
 	groupId: 'bundle-abc',
 	products: [
 		buildDomainProduct(
-			{ uuid: 'primary', meta: 'example.com', item_subtotal_integer: 2200 },
+			{
+				uuid: 'primary',
+				meta: 'example.com',
+				item_subtotal_integer: 2200,
+				item_original_subtotal_integer: 2200,
+			},
 			{ groupId: 'bundle-abc', role: 'primary' }
 		),
 		buildDomainProduct(
-			{ uuid: 'companion', meta: 'example.net', item_subtotal_integer: 1800 },
+			{
+				uuid: 'companion',
+				meta: 'example.net',
+				item_subtotal_integer: 1800,
+				item_original_subtotal_integer: 1800,
+			},
 			{ groupId: 'bundle-abc', role: 'companion' }
+		),
+	],
+};
+
+// A bundle whose members carry a server-side discount: the discounted price lives
+// in item_subtotal_integer while item_original_subtotal_integer keeps the
+// pre-discount price.
+const discountedBundle: CartBundleLineItem = {
+	type: 'bundle',
+	groupId: 'bundle-discounted',
+	products: [
+		buildDomainProduct(
+			{
+				uuid: 'primary',
+				meta: 'example.com',
+				item_subtotal_integer: 2200,
+				item_original_subtotal_integer: 6500,
+			},
+			{ groupId: 'bundle-discounted', role: 'primary' }
+		),
+		buildDomainProduct(
+			{
+				uuid: 'companion',
+				meta: 'example.net',
+				item_subtotal_integer: 700,
+				item_original_subtotal_integer: 6400,
+			},
+			{ groupId: 'bundle-discounted', role: 'companion' }
 		),
 	],
 };
@@ -38,6 +76,23 @@ describe( 'BundleLineItem', () => {
 		expect( screen.getByText( 'example.net' ) ).toBeVisible();
 		// 2200 + 1800 = 4000 smallest-unit => $40.
 		expect( screen.getByText( /\$40\b/ ) ).toBeVisible();
+	} );
+
+	test( 'shows no crossed-out price when the bundle is not discounted', () => {
+		const { container } = renderBundle();
+
+		expect( container.querySelector( 's' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'shows the summed original price crossed out when the bundle is discounted', () => {
+		renderBundle( { bundle: discountedBundle } );
+
+		// 2200 + 700 = 2900 smallest-unit => $29.
+		expect( screen.getByText( /\$29\b/ ) ).toBeVisible();
+		// 6500 + 6400 = 12900 smallest-unit => $129, struck through.
+		const crossedOut = screen.getByText( /\$129\b/ );
+		expect( crossedOut ).toBeVisible();
+		expect( crossedOut.tagName ).toBe( 'S' );
 	} );
 
 	test( 'shows no remove button without hasDeleteButton', () => {

--- a/packages/wpcom-checkout/test/fixtures/bundle-cart.ts
+++ b/packages/wpcom-checkout/test/fixtures/bundle-cart.ts
@@ -48,15 +48,30 @@ export function buildBundleResponseCart(): ResponseCart {
 		...getEmptyResponseCart(),
 		products: [
 			buildDomainProduct(
-				{ uuid: 'primary', meta: 'example.com', item_subtotal_integer: 2200 },
+				{
+					uuid: 'primary',
+					meta: 'example.com',
+					item_subtotal_integer: 2200,
+					item_original_subtotal_integer: 2200,
+				},
 				{ groupId: 'bundle-abc', role: 'primary', expectedBundleSize: 3 }
 			),
 			buildDomainProduct(
-				{ uuid: 'companion-net', meta: 'example.net', item_subtotal_integer: 1800 },
+				{
+					uuid: 'companion-net',
+					meta: 'example.net',
+					item_subtotal_integer: 1800,
+					item_original_subtotal_integer: 1800,
+				},
 				{ groupId: 'bundle-abc', role: 'companion', expectedBundleSize: 3 }
 			),
 			buildDomainProduct(
-				{ uuid: 'companion-org', meta: 'example.org', item_subtotal_integer: 2000 },
+				{
+					uuid: 'companion-org',
+					meta: 'example.org',
+					item_subtotal_integer: 2000,
+					item_original_subtotal_integer: 2000,
+				},
 				{ groupId: 'bundle-abc', role: 'companion', expectedBundleSize: 3 }
 			),
 			{


### PR DESCRIPTION
Related to #DOMAINS-2174

## Proposed Changes

Adds the group-level discount strikethrough from the design mockups (e.g. ~~$129~~ $29) to the grouped bundle line item, along with the "Discount for first year" callout label.

Both surfaces that render bundles on trunk — the masterbar mini-cart and the checkout order review — share the same `BundleLineItem` component (`packages/wpcom-checkout/src/checkout-line-items.tsx`), so a single component change covers both:

- `BundleLineItem` sums each member's `item_original_subtotal_integer` and passes it as `crossedOutAmount` to the existing `LineItemPrice` component when the discounted total is lower. This is the same field comparison and rendering pattern (`<s>` markup) the non-bundle `CheckoutLineItem` already uses for coupon/intro-offer discounts.
- When the bundle is discounted, the row also renders the existing `DiscountCallout` with the "Discount for first year" label, matching how standalone domain rows disclose the discount. (Accurate for bundles since they're fixed 1-year registrations.)
- No client-side price math from `domain_bundle_discount_percent` — that field is display metadata; the comparison uses the server-computed subtotal integers, so the strikethrough only renders when the backend cost override actually lowered the price.
- Test fixtures (`packages/wpcom-checkout/test/fixtures/bundle-cart.ts`) now populate `item_original_subtotal_integer`, matching how the backend always sends both fields.

<img width="2528" height="1748" alt="CleanShot 2026-06-11 at 10 57 18@2x" src="https://github.com/user-attachments/assets/9d0a6883-08ae-4ecd-b3c7-88296da22e04" />


Notes:

- The checkout **order summary** panel surface from #111469 (DOMAINS-2175) is intentionally untouched — it gets this treatment in a follow-up once that PR merges.
- The callout renders as the sole child of the `LineItemMeta` row, so it sits left-aligned under the title (standalone rows right-align it next to a sublabel). Flagging for a visual check against the mock.
- Bundles are fixed 1-year registrations — no term/variant UI here (locked decision; see DOMAINS-2181, cancelled).
- No `calypso-config`/`calypso-analytics` imports added to the portable packages.

## Testing Instructions

```
yarn test-packages packages/wpcom-checkout packages/mini-cart
```

9 suites / 59 tests pass, including new cases: strikethrough renders with the correct summed original price, the "Discount for first year" callout shows only on discounted bundles, no strikethrough when undiscounted, and a multi-bundle cart where only the discounted bundle shows the treatment.

### Manual

Prerequisites: `WPCOM_DOMAIN_BUNDLE_DISCOUNTS_ENABLED` on your sandbox, `public-api.wordpress.com` sandboxed, logged-in session, and `?flags=domain-bundling` on every page load. The strikethrough only renders when the server actually discounts (`item_original_subtotal_integer > item_subtotal_integer`), which requires a real server-issued bundle.

1. **Seed the cart** — this branch has no UI path that adds a bundle (that's #111519): run the #111519 branch, search a clearly-unregistered domain with a catalogue TLD (e.g. `mytestdomain123.com` — eligible TLDs: .com/.net/.org/.co/.blog/.me/.inc/.llc), click "Get bundle". The cart is server-side, so it follows your user.
2. Switch to this branch's build (same browser/user — the bundle stays in the cart).
3. **Checkout order review** (left column): the grouped "Domain bundle" row shows the crossed-out original sum next to the discounted sum (e.g. ~~$39~~ $28.10) with the green "Discount for first year" callout, members listed beneath.
4. **Masterbar cart popover** (on pages that have the masterbar): same treatment on the grouped row.
5. Negative check: flip the sandbox flag off and reload checkout — the next cart sync drops the discount and the row renders the plain total, no strikethrough/callout.

Expected on this branch (not bugs): the right-hand order **summary** panel lists members individually (#111469's surface), and the domain-search sidebar cart panel is ungrouped (DOMAINS-2191).

