### PR TITLE
Domains: wire the "Get bundle" CTA to add bundle members to the cart

### DIFF
--- a/client/components/domains/wpcom-domain-search/test/use-wpcom-domain-search-props.ts
+++ b/client/components/domains/wpcom-domain-search/test/use-wpcom-domain-search-props.ts
@@ -322,6 +322,93 @@ describe( 'useWPCOMDomainSearchProps', () => {
 			] );
 		} );
 
+		it( 'does not render a bundle member as free even when it is the most expensive domain', () => {
+			mockUseShoppingCart.mockReturnValue(
+				buildShoppingCart( {
+					responseCart: {
+						products: [
+							buildProduct( {
+								uuid: 'bundle-net',
+								product_slug: 'dotnet_domain',
+								meta: 'my-bundle.net',
+								is_domain_registration: true,
+								item_original_cost_integer: 18_00,
+								item_original_subtotal_integer: 18_00,
+								item_subtotal_integer: 18_00,
+								extra: {
+									domain_bundle_group_id: 'v1.test.deadbeef',
+								},
+							} ),
+							buildProduct( {
+								uuid: 'standalone',
+								product_slug: 'dotcom_domain',
+								meta: 'my-standalone.com',
+								is_domain_registration: true,
+								item_original_cost_integer: 10_00,
+								item_original_subtotal_integer: 10_00,
+								item_subtotal_integer: 10_00,
+							} ),
+						],
+					},
+				} )
+			);
+
+			const { result } = renderHookWithProvider( () =>
+				useWPCOMDomainSearchProps( { ...defaultProps, isFirstDomainFreeForFirstYear: true } )
+			);
+
+			// The free promo skips the bundle member (the server excludes bundle
+			// domains from plan credit) and lands on the standalone domain.
+			expect( result.current.cart.items ).toEqual( [
+				expect.objectContaining( { uuid: 'bundle-net', salePrice: undefined, price: '$18' } ),
+				expect.objectContaining( { uuid: 'standalone', salePrice: '$0', price: '$10' } ),
+			] );
+		} );
+
+		it( 'does not render any domain as free when the cart holds only bundle members', () => {
+			mockUseShoppingCart.mockReturnValue(
+				buildShoppingCart( {
+					responseCart: {
+						products: [
+							buildProduct( {
+								uuid: 'bundle-com',
+								product_slug: 'dotcom_domain',
+								meta: 'my-bundle.com',
+								is_domain_registration: true,
+								item_original_cost_integer: 13_00,
+								item_original_subtotal_integer: 13_00,
+								item_subtotal_integer: 13_00,
+								extra: {
+									domain_bundle_group_id: 'v1.test.deadbeef',
+								},
+							} ),
+							buildProduct( {
+								uuid: 'bundle-net',
+								product_slug: 'dotnet_domain',
+								meta: 'my-bundle.net',
+								is_domain_registration: true,
+								item_original_cost_integer: 18_00,
+								item_original_subtotal_integer: 18_00,
+								item_subtotal_integer: 18_00,
+								extra: {
+									domain_bundle_group_id: 'v1.test.deadbeef',
+								},
+							} ),
+						],
+					},
+				} )
+			);
+
+			const { result } = renderHookWithProvider( () =>
+				useWPCOMDomainSearchProps( { ...defaultProps, isFirstDomainFreeForFirstYear: true } )
+			);
+
+			expect( result.current.cart.items ).toEqual( [
+				expect.objectContaining( { uuid: 'bundle-net', salePrice: undefined, price: '$18' } ),
+				expect.objectContaining( { uuid: 'bundle-com', salePrice: undefined, price: '$13' } ),
+			] );
+		} );
+
 		it( 'renders the first non-premium domain as free if config.priceRules.freeForFirstYear is true and there is a premium domain in the cart', () => {
 			mockUseShoppingCart.mockReturnValue(
 				buildShoppingCart( {

--- a/client/components/domains/wpcom-domain-search/test/use-wpcom-domain-search-props.ts
+++ b/client/components/domains/wpcom-domain-search/test/use-wpcom-domain-search-props.ts
@@ -829,6 +829,118 @@ describe( 'useWPCOMDomainSearchProps', () => {
 		expect( onContinue ).not.toHaveBeenCalled();
 	} );
 
+	describe( 'onAddBundle', () => {
+		const bundle = {
+			sld: 'example',
+			domains: [
+				{
+					domain: 'example.com',
+					cost: '$22.00',
+					raw_price: 22,
+					product_slug: 'domain_reg',
+					supports_privacy: true,
+				},
+				{
+					domain: 'example.net',
+					cost: '$18.00',
+					raw_price: 18,
+					product_slug: 'dotnet_domain',
+				},
+			],
+			bundle_price: 32,
+			original_price: 40,
+			discount_percent: 20,
+			category: 'business',
+			bundle_id: 'example_business',
+			bundle_group_id: 'server-issued-group-id',
+			catalogue_version: '3',
+		};
+
+		it( 'adds one product per bundle member, with the server-issued bundle extras, in a single cart call', async () => {
+			const replaceProductsInCart = jest.fn().mockResolvedValue( { products: [] } );
+
+			mockUseShoppingCart.mockReturnValue(
+				buildShoppingCart( {
+					responseCart: {
+						products: [
+							buildProduct( {
+								meta: 'my-existing-domain.com',
+								product_slug: 'domain',
+								is_domain_registration: true,
+							} ),
+						],
+					},
+					replaceProductsInCart,
+				} )
+			);
+
+			const { result } = renderHookWithProvider( () => useWPCOMDomainSearchProps( defaultProps ) );
+
+			await result.current.cart.onAddBundle?.( bundle );
+
+			expect( replaceProductsInCart ).toHaveBeenCalledTimes( 1 );
+			expect( replaceProductsInCart ).toHaveBeenCalledWith( [
+				{
+					product_slug: 'domain_reg',
+					meta: 'example.com',
+					extra: {
+						privacy_available: true,
+						privacy: true,
+						flow_name: 'flow-name',
+						domain_bundle_group_id: 'server-issued-group-id',
+						domain_bundle_role: 'primary',
+						expected_bundle_size: '2',
+					},
+				},
+				{
+					product_slug: 'dotnet_domain',
+					meta: 'example.net',
+					extra: {
+						flow_name: 'flow-name',
+						domain_bundle_group_id: 'server-issued-group-id',
+						domain_bundle_role: 'companion',
+						expected_bundle_size: '2',
+					},
+				},
+				expect.objectContaining( { meta: 'my-existing-domain.com', product_slug: 'domain' } ),
+			] );
+		} );
+
+		it( 'calls onContinue with the bundle items if flowAllowsMultipleDomainsInCart is false', async () => {
+			const bundleCartProducts = [
+				{
+					meta: 'example.com',
+					product_slug: 'domain_reg',
+					extra: { domain_bundle_group_id: 'server-issued-group-id' },
+				},
+				{
+					meta: 'example.net',
+					product_slug: 'dotnet_domain',
+					extra: { domain_bundle_group_id: 'server-issued-group-id' },
+				},
+			];
+			const replaceProductsInCart = jest.fn().mockResolvedValue( {
+				products: [ ...bundleCartProducts, { meta: 'unrelated.com', product_slug: 'domain' } ],
+			} );
+
+			mockUseShoppingCart.mockReturnValue( buildShoppingCart( { replaceProductsInCart } ) );
+
+			const onContinue = jest.fn();
+
+			const { result } = renderHookWithProvider( () =>
+				useWPCOMDomainSearchProps( {
+					...defaultProps,
+					flowAllowsMultipleDomainsInCart: false,
+					events: { ...defaultProps.events, onContinue },
+				} )
+			);
+
+			await result.current.cart.onAddBundle?.( bundle );
+
+			expect( onContinue ).toHaveBeenCalledWith( bundleCartProducts );
+		} );
+	} );
+
 	it( 'prepends products in the cart when adding a new domain', async () => {
 		const replaceProductsInCart = jest.fn();
 

--- a/client/components/domains/wpcom-domain-search/test/use-wpcom-domain-search-props.ts
+++ b/client/components/domains/wpcom-domain-search/test/use-wpcom-domain-search-props.ts
@@ -3,6 +3,11 @@
  */
 
 import {
+	DOMAIN_FOR_GRAVATAR_FLOW,
+	HUNDRED_YEAR_DOMAIN_FLOW,
+	HUNDRED_YEAR_PLAN_FLOW,
+} from '@automattic/onboarding';
+import {
 	getEmptyResponseCartProduct,
 	ResponseCart,
 	ResponseCartProduct,
@@ -21,6 +26,12 @@ jest.mock( '@automattic/shopping-cart', () => ( {
 	...jest.requireActual( '@automattic/shopping-cart' ),
 	useShoppingCart: jest.fn(),
 } ) );
+
+jest.mock( '@automattic/calypso-config', () => {
+	const config = () => 'development';
+	config.isEnabled = ( flag: string ) => flag === 'domain-bundling';
+	return config;
+} );
 
 jest.mock( '../analytics', () => ( {
 	...jest.requireActual( '../analytics' ),
@@ -857,7 +868,20 @@ describe( 'useWPCOMDomainSearchProps', () => {
 		};
 
 		it( 'adds one product per bundle member, with the server-issued bundle extras, in a single cart call', async () => {
-			const replaceProductsInCart = jest.fn().mockResolvedValue( { products: [] } );
+			const replaceProductsInCart = jest.fn().mockResolvedValue( {
+				products: [
+					{
+						meta: 'example.com',
+						product_slug: 'domain_reg',
+						extra: { domain_bundle_group_id: 'server-issued-group-id' },
+					},
+					{
+						meta: 'example.net',
+						product_slug: 'dotnet_domain',
+						extra: { domain_bundle_group_id: 'server-issued-group-id' },
+					},
+				],
+			} );
 
 			mockUseShoppingCart.mockReturnValue(
 				buildShoppingCart( {
@@ -874,7 +898,14 @@ describe( 'useWPCOMDomainSearchProps', () => {
 				} )
 			);
 
-			const { result } = renderHookWithProvider( () => useWPCOMDomainSearchProps( defaultProps ) );
+			const onContinue = jest.fn();
+
+			const { result } = renderHookWithProvider( () =>
+				useWPCOMDomainSearchProps( {
+					...defaultProps,
+					events: { ...defaultProps.events, onContinue },
+				} )
+			);
 
 			await result.current.cart.onAddBundle?.( bundle );
 
@@ -903,6 +934,61 @@ describe( 'useWPCOMDomainSearchProps', () => {
 					},
 				},
 				expect.objectContaining( { meta: 'my-existing-domain.com', product_slug: 'domain' } ),
+			] );
+
+			expect( onContinue ).not.toHaveBeenCalled();
+		} );
+
+		it( 'drops a standalone copy of a bundle member so the bundle-tagged product wins', async () => {
+			const replaceProductsInCart = jest.fn().mockResolvedValue( {
+				products: [
+					{
+						meta: 'example.com',
+						product_slug: 'domain_reg',
+						extra: { domain_bundle_group_id: 'server-issued-group-id' },
+					},
+					{
+						meta: 'example.net',
+						product_slug: 'dotnet_domain',
+						extra: { domain_bundle_group_id: 'server-issued-group-id' },
+					},
+				],
+			} );
+
+			mockUseShoppingCart.mockReturnValue(
+				buildShoppingCart( {
+					responseCart: {
+						products: [
+							// Already in the cart as a standalone registration; the
+							// backend dedupe keeps the last occurrence, so passing this
+							// through would strip the bundle extras from the member.
+							buildProduct( {
+								meta: 'example.com',
+								product_slug: 'domain_reg',
+								is_domain_registration: true,
+							} ),
+							buildProduct( {
+								meta: 'my-existing-domain.com',
+								product_slug: 'domain',
+								is_domain_registration: true,
+							} ),
+						],
+					},
+					replaceProductsInCart,
+				} )
+			);
+
+			const { result } = renderHookWithProvider( () => useWPCOMDomainSearchProps( defaultProps ) );
+
+			await result.current.cart.onAddBundle?.( bundle );
+
+			expect( replaceProductsInCart ).toHaveBeenCalledWith( [
+				expect.objectContaining( {
+					meta: 'example.com',
+					extra: expect.objectContaining( { domain_bundle_group_id: 'server-issued-group-id' } ),
+				} ),
+				expect.objectContaining( { meta: 'example.net' } ),
+				expect.objectContaining( { meta: 'my-existing-domain.com' } ),
 			] );
 		} );
 
@@ -939,6 +1025,56 @@ describe( 'useWPCOMDomainSearchProps', () => {
 
 			expect( onContinue ).toHaveBeenCalledWith( bundleCartProducts );
 		} );
+
+		it( 'throws and does not call onContinue when the synced cart comes back without the full bundle', async () => {
+			// The backend all-or-nothing invariant strips an incomplete bundle
+			// group from the cart silently, so the replace resolves without the
+			// bundle members rather than rejecting.
+			const replaceProductsInCart = jest.fn().mockResolvedValue( {
+				products: [ { meta: 'unrelated.com', product_slug: 'domain' } ],
+			} );
+
+			mockUseShoppingCart.mockReturnValue( buildShoppingCart( { replaceProductsInCart } ) );
+
+			const onContinue = jest.fn();
+
+			const { result } = renderHookWithProvider( () =>
+				useWPCOMDomainSearchProps( {
+					...defaultProps,
+					flowAllowsMultipleDomainsInCart: false,
+					events: { ...defaultProps.events, onContinue },
+				} )
+			);
+
+			await expect( result.current.cart.onAddBundle?.( bundle ) ).rejects.toThrow(
+				'The domain bundle could not be added to the cart.'
+			);
+
+			expect( onContinue ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'showBundleSuggestions', () => {
+		it( 'is enabled for a regular flow when the domain-bundling flag is on', () => {
+			mockUseShoppingCart.mockReturnValue( buildShoppingCart() );
+
+			const { result } = renderHookWithProvider( () => useWPCOMDomainSearchProps( defaultProps ) );
+
+			expect( result.current.config.showBundleSuggestions ).toBe( true );
+		} );
+
+		it.each( [ HUNDRED_YEAR_PLAN_FLOW, HUNDRED_YEAR_DOMAIN_FLOW, DOMAIN_FOR_GRAVATAR_FLOW ] )(
+			'is disabled for the %s flow',
+			( flowName ) => {
+				mockUseShoppingCart.mockReturnValue( buildShoppingCart() );
+
+				const { result } = renderHookWithProvider( () =>
+					useWPCOMDomainSearchProps( { ...defaultProps, flowName } )
+				);
+
+				expect( result.current.config.showBundleSuggestions ).toBe( false );
+			}
+		);
 	} );
 
 	it( 'prepends products in the cart when adding a new domain', async () => {

--- a/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-cart.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-cart.ts
@@ -143,6 +143,45 @@ export const useWPCOMDomainSearchCart = ( {
 
 				return cartItems;
 			},
+			onAddBundle: async ( bundle ) => {
+				// One product per bundle member, added in a single cart call so the
+				// add is all-or-nothing. The bundle metadata is server-issued and
+				// passed through verbatim — the backend cart validator verifies the
+				// group id and applies the discount; no price math happens here.
+				// Members arrive primary-first from the backend (the searched
+				// SLD+TLD anchors the bundle), so the first member is the primary.
+				const bundleProducts: MinimalRequestCartProduct[] = bundle.domains.map(
+					( member, index ) => ( {
+						product_slug: member.product_slug,
+						meta: member.domain,
+						extra: {
+							...( member.supports_privacy && {
+								privacy_available: member.supports_privacy,
+								privacy: member.supports_privacy,
+							} ),
+							...( flowName && { flow_name: flowName } ),
+							domain_bundle_group_id: bundle.bundle_group_id,
+							domain_bundle_role: index === 0 ? ( 'primary' as const ) : ( 'companion' as const ),
+							expected_bundle_size: String( bundle.domains.length ),
+						},
+					} )
+				);
+
+				const cartItems = await replaceProductsInCart( [
+					...bundleProducts,
+					...responseCart.products,
+				] );
+
+				if ( ! flowAllowsMultipleDomainsInCart ) {
+					return onContinue(
+						cartItems.products.filter(
+							( item ) => item.extra?.domain_bundle_group_id === bundle.bundle_group_id
+						)
+					);
+				}
+
+				return cartItems;
+			},
 			onRemoveItem: ( uuid ) => removeProductFromCart( uuid ),
 		};
 

--- a/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-cart.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-cart.ts
@@ -167,17 +167,37 @@ export const useWPCOMDomainSearchCart = ( {
 					} )
 				);
 
+				// A bundle member may already sit in the cart as a standalone
+				// product. The backend dedupes by product+meta keeping the last
+				// occurrence, which would strip the bundle extras from the member —
+				// so drop the standalone copy and let the bundle-tagged one win.
+				const isBundleMember = ( product: ResponseCartProduct ) =>
+					bundle.domains.some(
+						( member ) =>
+							member.product_slug === product.product_slug && member.domain === product.meta
+					);
+
 				const cartItems = await replaceProductsInCart( [
 					...bundleProducts,
-					...responseCart.products,
+					...responseCart.products.filter( ( product ) => ! isBundleMember( product ) ),
 				] );
 
+				// The backend enforces bundle integrity by silently stripping an
+				// incomplete group from the cart (e.g. a member became unavailable
+				// between suggestion and add) rather than returning a cart error, so
+				// the promise resolves even when the bundle didn't make it in. Turn
+				// that absence into an error so the mutation captures the failure
+				// instead of reporting success or continuing with a partial bundle.
+				const bundleItemsInCart = cartItems.products.filter(
+					( item ) => item.extra?.domain_bundle_group_id === bundle.bundle_group_id
+				);
+
+				if ( bundleItemsInCart.length < bundle.domains.length ) {
+					throw new Error( 'The domain bundle could not be added to the cart.' );
+				}
+
 				if ( ! flowAllowsMultipleDomainsInCart ) {
-					return onContinue(
-						cartItems.products.filter(
-							( item ) => item.extra?.domain_bundle_group_id === bundle.bundle_group_id
-						)
-					);
+					return onContinue( bundleItemsInCart );
 				}
 
 				return cartItems;

--- a/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-cart.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-cart.ts
@@ -89,8 +89,14 @@ export const useWPCOMDomainSearchCart = ( {
 			return b.item_subtotal_integer - a.item_subtotal_integer;
 		} );
 
+		// Bundle members never receive the free-domain promo: the server excludes
+		// them from plan free-domain credit (the bundle discount doesn't stack),
+		// so displaying one as free here would promise a price checkout won't honor.
 		const firstNonPremiumDomain = domainItems.find(
-			( item ) => ! isDomainMoveInternal( item ) && ! item.extra?.premium
+			( item ) =>
+				! isDomainMoveInternal( item ) &&
+				! item.extra?.premium &&
+				! item.extra?.domain_bundle_group_id
 		);
 		const freeDomainName = forceFirstNonPremiumDomainToBeFree
 			? firstNonPremiumDomain?.meta

--- a/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-props.ts
+++ b/client/components/domains/wpcom-domain-search/use-wpcom-domain-search-props.ts
@@ -1,5 +1,10 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { DomainSearch } from '@automattic/domain-search';
+import {
+	isDomainForGravatarFlow,
+	isHundredYearDomainFlow,
+	isHundredYearPlanFlow,
+} from '@automattic/onboarding';
 import { ResponseCartProduct } from '@automattic/shopping-cart';
 import { useMemo, type ComponentProps, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -74,15 +79,24 @@ export const useWPCOMDomainSearchProps = ( {
 	} );
 
 	const config = useMemo( () => {
+		// Bundles are fixed one-year registrations of multiple TLDs, so they
+		// don't fit flows that sell a single special-purpose registration —
+		// and those flows' beforeAddDomainToCart transforms (100-year term,
+		// Gravatar extras) are not applied to bundle members.
+		const flowSupportsBundles =
+			! isHundredYearPlanFlow( flowName ) &&
+			! isHundredYearDomainFlow( flowName ) &&
+			! isDomainForGravatarFlow( flowName );
+
 		return {
 			...externalConfig,
-			showBundleSuggestions: isEnabled( 'domain-bundling' ),
+			showBundleSuggestions: isEnabled( 'domain-bundling' ) && flowSupportsBundles,
 			priceRules: {
 				...externalConfig?.priceRules,
 				freeForFirstYear: isNextDomainFree,
 			},
 		};
-	}, [ externalConfig, isNextDomainFree ] );
+	}, [ externalConfig, isNextDomainFree, flowName ] );
 
 	const analyticsEvents = useWPCOMDomainSearchEvents( {
 		vendor: config.vendor,

--- a/packages/domain-search/src/components/bundle-card/index.tsx
+++ b/packages/domain-search/src/components/bundle-card/index.tsx
@@ -5,6 +5,7 @@ import {
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
+import { arrowRight } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { DomainSuggestionBadge } from '../../ui';
 import type { BundleSuggestion } from '@automattic/api-core';
@@ -89,9 +90,12 @@ export const BundleCard = ( {
 
 				{ isAddedToCart ? (
 					<Button
-						className="bundle-card__cta"
-						variant="primary"
+						className="bundle-card__cta bundle-card__cta--continue"
+						isPressed
+						aria-pressed="mixed"
 						__next40pxDefaultSize
+						icon={ arrowRight }
+						label={ __( 'Continue' ) }
 						onClick={ () => onContinue?.() }
 					>
 						{ __( 'Continue' ) }

--- a/packages/domain-search/src/components/bundle-card/index.tsx
+++ b/packages/domain-search/src/components/bundle-card/index.tsx
@@ -14,9 +14,16 @@ import './style.scss';
 interface BundleCardProps {
 	suggestion: BundleSuggestion | null;
 	onAddToCart?: ( bundle: BundleSuggestion ) => void;
+	isAddedToCart?: boolean;
+	onContinue?: () => void;
 }
 
-export const BundleCard = ( { suggestion, onAddToCart }: BundleCardProps ) => {
+export const BundleCard = ( {
+	suggestion,
+	onAddToCart,
+	isAddedToCart,
+	onContinue,
+}: BundleCardProps ) => {
 	const { __ } = useI18n();
 
 	if ( ! suggestion || suggestion.domains.length === 0 ) {
@@ -80,14 +87,25 @@ export const BundleCard = ( { suggestion, onAddToCart }: BundleCardProps ) => {
 					</Text>
 				) }
 
-				<Button
-					className="bundle-card__cta"
-					variant="primary"
-					__next40pxDefaultSize
-					onClick={ () => onAddToCart?.( suggestion ) }
-				>
-					{ __( 'Get bundle' ) }
-				</Button>
+				{ isAddedToCart ? (
+					<Button
+						className="bundle-card__cta"
+						variant="primary"
+						__next40pxDefaultSize
+						onClick={ () => onContinue?.() }
+					>
+						{ __( 'Continue' ) }
+					</Button>
+				) : (
+					<Button
+						className="bundle-card__cta"
+						variant="primary"
+						__next40pxDefaultSize
+						onClick={ () => onAddToCart?.( suggestion ) }
+					>
+						{ __( 'Get bundle' ) }
+					</Button>
+				) }
 			</VStack>
 		</div>
 	);

--- a/packages/domain-search/src/components/bundle-card/test/index.tsx
+++ b/packages/domain-search/src/components/bundle-card/test/index.tsx
@@ -124,6 +124,38 @@ describe( 'BundleCard', () => {
 		expect( onAddToCart ).toHaveBeenCalledWith( suggestion );
 	} );
 
+	it( 'renders a Continue CTA instead of Get bundle when the bundle is already in the cart', async () => {
+		const user = userEvent.setup();
+		const onContinue = jest.fn();
+		const onAddToCart = jest.fn();
+
+		render(
+			<BundleCard
+				suggestion={ buildSuggestion( twoDomains ) }
+				onAddToCart={ onAddToCart }
+				isAddedToCart
+				onContinue={ onContinue }
+			/>
+		);
+
+		expect( screen.queryByRole( 'button', { name: 'Get bundle' } ) ).not.toBeInTheDocument();
+
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
+
+		expect( onContinue ).toHaveBeenCalledTimes( 1 );
+		expect( onAddToCart ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not throw when Continue is clicked without an onContinue callback', async () => {
+		const user = userEvent.setup();
+
+		render( <BundleCard suggestion={ buildSuggestion( twoDomains ) } isAddedToCart /> );
+
+		await expect(
+			user.click( screen.getByRole( 'button', { name: 'Continue' } ) )
+		).resolves.not.toThrow();
+	} );
+
 	it( 'does not throw when the CTA is clicked without an onAddToCart callback', async () => {
 		const user = userEvent.setup();
 

--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -136,6 +136,10 @@ export const ResultsPage = () => {
 							events.onBundleAddToCart( bundle );
 							addBundleToCart( bundle );
 						} }
+						isAddedToCart={ bundleSuggestion.domains.every( ( { domain } ) =>
+							cart.hasItem( domain )
+						) }
+						onContinue={ events.onContinue }
 					/>
 				) }
 				{ isLoadingSuggestions ? (

--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -1,3 +1,4 @@
+import { useMutation } from '@tanstack/react-query';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { chevronDown, chevronUp, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
@@ -13,6 +14,7 @@ import { UnavailableSearchResult } from '../components/unavailable-search-result
 import { useRequestTracking } from '../hooks/use-request-tracking';
 import { useSuggestionsList } from '../hooks/use-suggestions-list';
 import { useDomainSearch } from './context';
+import type { BundleSuggestion } from '@automattic/api-core';
 
 const StickyCompactBanner = () => {
 	const { __ } = useI18n();
@@ -45,7 +47,19 @@ const StickyCompactBanner = () => {
 };
 
 export const ResultsPage = () => {
-	const { slots, config, events } = useDomainSearch();
+	const { slots, config, events, cart } = useDomainSearch();
+
+	// Accepting a bundle adds every member domain to the cart in one
+	// all-or-nothing operation. The cart mutation itself lives at the app layer
+	// (cart.onAddBundle); the mutation wrapper mirrors the single-domain
+	// add-to-cart path so failures are captured the same way.
+	const { mutate: addBundleToCart } = useMutation( {
+		mutationFn: async ( bundle: BundleSuggestion ) => {
+			await cart.onAddBundle?.( bundle );
+		},
+		networkMode: 'always',
+		retry: false,
+	} );
 
 	const {
 		isLoading: isLoadingSuggestions,
@@ -118,7 +132,10 @@ export const ResultsPage = () => {
 				{ ! isLoadingSuggestions && bundleSuggestion && (
 					<BundleCard
 						suggestion={ bundleSuggestion }
-						onAddToCart={ ( bundle ) => events.onBundleAddToCart( bundle ) }
+						onAddToCart={ ( bundle ) => {
+							events.onBundleAddToCart( bundle );
+							addBundleToCart( bundle );
+						} }
 					/>
 				) }
 				{ isLoadingSuggestions ? (

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -884,6 +884,49 @@ describe( 'ResultsPage', () => {
 		} );
 	} );
 
+	describe( 'bundle suggestion', () => {
+		it( 'calls cart.onAddBundle once with the bundle suggestion when "Get bundle" is clicked', async () => {
+			const user = userEvent.setup();
+			const onAddBundle = jest.fn().mockResolvedValue( undefined );
+
+			mockGetSuggestionsQuery( {
+				params: { query: 'test' },
+				suggestions: [ buildSuggestion( { domain_name: 'test.com' } ) ],
+			} );
+
+			render(
+				<TestDomainSearch
+					cart={ buildCart( { onAddBundle } ) }
+					config={ { showBundleSuggestions: true } }
+					query="test"
+				>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			await user.click( await screen.findByRole( 'button', { name: 'Get bundle' } ) );
+
+			await waitFor( () => {
+				expect( onAddBundle ).toHaveBeenCalledTimes( 1 );
+			} );
+
+			// The mock fetcher issues the bundle for the searched SLD; the whole
+			// suggestion (including the server-issued group id) is handed to the
+			// app layer untouched.
+			expect( onAddBundle ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					sld: 'test',
+					bundle_group_id: 'mock-test-group',
+					domains: expect.arrayContaining( [
+						expect.objectContaining( { domain: 'test.com' } ),
+						expect.objectContaining( { domain: 'test.net' } ),
+						expect.objectContaining( { domain: 'test.org' } ),
+					] ),
+				} )
+			);
+		} );
+	} );
+
 	describe( 'tracking', () => {
 		it( 'fires the onSuggestionsReceive event when the suggestions are received', async () => {
 			const onSuggestionsReceive = jest.fn();

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -931,6 +931,67 @@ describe( 'ResultsPage', () => {
 		} );
 	} );
 
+	describe( 'bundle continue state', () => {
+		it( 'shows Continue instead of Get bundle when every bundle member is in the cart', async () => {
+			const user = userEvent.setup();
+			const onContinue = jest.fn();
+
+			mockGetSuggestionsQuery( {
+				params: { query: 'bundle-added' },
+				suggestions: [ buildSuggestion( { domain_name: 'bundle-added.com' } ) ],
+			} );
+			mockGetBundleSuggestionQuery( {
+				params: { query: 'bundle-added' },
+				bundleSuggestion: buildBundleSuggestion( 'bundle-added' ),
+			} );
+
+			const { container } = render(
+				<TestDomainSearch
+					cart={ buildCart( { hasItem: ( domain ) => domain.startsWith( 'bundle-added.' ) } ) }
+					config={ { showBundleSuggestions: true } }
+					events={ { onContinue } }
+					query="bundle-added"
+				>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			await waitFor( () => {
+				expect( container.querySelector( '.bundle-card__cta' ) ).toBeInTheDocument();
+			} );
+			const bundleCta = container.querySelector( '.bundle-card__cta' ) as HTMLElement;
+
+			expect( bundleCta ).toHaveTextContent( 'Continue' );
+			expect( screen.queryByRole( 'button', { name: 'Get bundle' } ) ).not.toBeInTheDocument();
+
+			await user.click( bundleCta );
+			expect( onContinue ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'keeps Get bundle when only some members are in the cart', async () => {
+			mockGetSuggestionsQuery( {
+				params: { query: 'bundle-partial' },
+				suggestions: [ buildSuggestion( { domain_name: 'bundle-partial.com' } ) ],
+			} );
+			mockGetBundleSuggestionQuery( {
+				params: { query: 'bundle-partial' },
+				bundleSuggestion: buildBundleSuggestion( 'bundle-partial' ),
+			} );
+
+			render(
+				<TestDomainSearch
+					cart={ buildCart( { hasItem: ( domain ) => domain === 'bundle-partial.com' } ) }
+					config={ { showBundleSuggestions: true } }
+					query="bundle-partial"
+				>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			expect( await screen.findByRole( 'button', { name: 'Get bundle' } ) ).toBeInTheDocument();
+		} );
+	} );
+
 	describe( 'tracking', () => {
 		it( 'fires the onSuggestionsReceive event when the suggestions are received', async () => {
 			const onSuggestionsReceive = jest.fn();

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -893,6 +893,10 @@ describe( 'ResultsPage', () => {
 				params: { query: 'test' },
 				suggestions: [ buildSuggestion( { domain_name: 'test.com' } ) ],
 			} );
+			mockGetBundleSuggestionQuery( {
+				params: { query: 'test' },
+				bundleSuggestion: buildBundleSuggestion( 'test' ),
+			} );
 
 			render(
 				<TestDomainSearch

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -30,6 +30,12 @@ export interface DomainSearchCart {
 	items: SelectedDomain[];
 	total: string;
 	onAddItem: ( item: DomainSuggestion ) => Promise< unknown >;
+	/**
+	 * Add every member of a bundle suggestion to the cart in a single,
+	 * all-or-nothing operation. Implemented at the app layer; when absent the
+	 * bundle CTA is a no-op.
+	 */
+	onAddBundle?: ( bundle: BundleSuggestion ) => Promise< unknown >;
 	onRemoveItem: ( uuid: string ) => Promise< unknown >;
 	hasItem: ( domainName: string ) => boolean;
 }

--- a/packages/domain-search/src/test-helpers/factories/cart.ts
+++ b/packages/domain-search/src/test-helpers/factories/cart.ts
@@ -5,6 +5,7 @@ export const buildCart = ( overrides: Partial< DomainSearchCart > = {} ): Domain
 		items: [],
 		total: '$0',
 		onAddItem: jest.fn(),
+		onAddBundle: jest.fn(),
 		onRemoveItem: jest.fn(),
 		hasItem: jest.fn(),
 		...overrides,


### PR DESCRIPTION
Related to #DOMAINS-2190

## Proposed Changes

Wires the "Get bundle" CTA on the bundle suggestion card to actually add the bundle members to the cart. Previously the card rendered with no cart wiring, so the CTA was a no-op — nothing put a bundle in the cart, even though the backend contract (extras, server-side discount, all-or-nothing invariant) and the grouping UI were already in place.

<img width="2332" height="716" alt="CleanShot 2026-06-11 at 10 33 46@2x" src="https://github.com/user-attachments/assets/8eb0a02b-3b94-4c76-81f9-d21344d3730e" />


Follows the established portability pattern — the `domain-search` package never touches the shopping cart directly:

- `DomainSearchCart` gains an optional `onAddBundle( bundle )` callback (mirrors the existing `onAddItem` contract; optional so existing consumers are unaffected).
- `results.tsx` wires `BundleCard`'s `onAddToCart` to a `useMutation` wrapper around `cart.onAddBundle`, composed with the `calypso_domain_bundle_accepted` Tracks event from #111470.
- The app layer (`use-wpcom-domain-search-cart.ts`) implements it: one `MinimalRequestCartProduct` per member, added in a **single** `replaceProductsInCart` call (all-or-nothing matters — the backend enforces bundle integrity via expected size), mirroring the single-domain add path.

Plus the behaviors that fell out of building/manually testing the flow:

- **Silent-failure surfacing + dedupe**: `onAddBundle` throws when the synced cart comes back without the full bundle (the backend invariant strips incomplete groups silently), and a standalone copy of a member already in the cart is dropped so the bundle-tagged copy wins.
- **Flow gating**: bundle suggestions are hidden in the 100-year and Gravatar flows (fixed 1-year bundles don't fit those flows' cart transforms).
- **Free-domain promo exclusion**: the search cart panel no longer displays a bundle member as the "free" domain — the server excludes bundle domains from plan free-domain credit (DOMAINS-2169), so that $0 was a price checkout wouldn't honor.
- **Continue state**: once every member is in the cart, the card's CTA switches from "Get bundle" to the same dark arrow "Continue" treatment the single-domain suggestion CTAs use, wired to the same `onContinue` event.

Extras per member (server values passed through verbatim, no client price math):

| Field | Source |
|---|---|
| `domain_bundle_group_id` | `bundle.bundle_group_id`, verbatim |
| `domain_bundle_role` | `primary` for the first member (the wire contract: the backend emits members primary-first), `companion` otherwise |
| `expected_bundle_size` | member count |
| `privacy_available` / `privacy`, `flow_name` | same as the single-domain path |

`domain_bundle_discount_percent` is deliberately omitted — the backend recomputes it on every cart sync.

### Known display gaps (expected, not bugs in this PR)

- **The domain-search sidebar "Cart" panel does not group bundle members** — they render as individual rows. Grouping that panel is DOMAINS-2191, in progress as a stacked PR on this branch. The grouped surfaces today are the masterbar mini-cart popover and checkout order review.
- No group-level discount strikethrough on bundle rows yet — that's #111518 (DOMAINS-2174).
- A failed bundle add isn't rendered on the card yet — that's #111523 (DOMAINS-2192), stacked on this branch.

## Testing Instructions

```
yarn test-packages packages/domain-search
yarn test-client client/components/domains/wpcom-domain-search
```

### Manual (sandbox required)

The live fetcher only returns a bundle when the backend allows it, so you need: `WPCOM_DOMAIN_BUNDLE_DISCOUNTS_ENABLED` on your sandbox, `public-api.wordpress.com` sandboxed, and a logged-in session (bundles are logged-in-only — the group id HMAC binds the owner).

1. Open domain search with `?flags=domain-bundling` and search a clearly-unregistered domain **including a TLD from the stub catalogue** — `.com`, `.net`, `.org`, `.co`, `.blog`, `.me`, `.inc`, or `.llc` (e.g. `mydomaintest8231.com`). A bare term returns no bundle by design (nothing to anchor on).
2. The bundle card renders with real availability-checked members and server pricing.
3. Click **Get bundle** → all members land in the cart in one operation, with the server-side bundle discount applied to each member's price.
4. The card's CTA switches to **→ Continue** (same treatment as an added single-domain suggestion).
5. Masterbar cart popover: one grouped "Domain bundle" row. Checkout order review: same. (Sidebar panel: ungrouped, see known gaps.)
6. Dedupe: fresh search, add the `.com` member individually first, then Get bundle → one bundle-tagged copy in the cart, no duplicate.
7. The free-domain promo (if your flow has it) lands on a standalone domain, never a bundle member.
