### PR TITLE
Dark mode: migrate color-scheme engine to @wordpress/theme (WPDS) [exploration]

### DIFF
--- a/client/assets/stylesheets/shared/mixins/_dark-theme.scss
+++ b/client/assets/stylesheets/shared/mixins/_dark-theme.scss
@@ -1,15 +1,20 @@
-// Emits rules for the explicit dark theme and for the system theme when the OS
-// prefers dark. Intended to be nested inside a selector so `&` resolves to the
-// component or surface being themed.
+// ⚠️ DEPRECATED — transitional dark-only override hook.
+//
+// Theming now flows from the WPDS `ThemeProvider` (see
+// `client/lib/color-scheme/wpds-theme.tsx`), which sets `--wpds-*` token values
+// for the active mode. There is no longer a native "is dark" selector — dark is
+// just different token values. Components should consume `--wpds-*` tokens (or
+// `@wordpress/ui`) so they need NO dark-specific overrides at all.
+//
+// Until every consumer is migrated, this mixin keeps working by matching the
+// resolved `data-theme="dark"` bridge attribute set by the color-scheme provider.
+// The OS preference is now resolved in JS, so the legacy `data-theme="system"` +
+// `prefers-color-scheme` branch is no longer needed. Each migrated component
+// should drop its `when-dark-theme { … }` block; the final migration step removes
+// this mixin and the bridge attribute. See `client/lib/color-scheme/MIGRATION.md`.
 @mixin when-dark-theme {
 	@media screen {
 		:root[data-theme="dark"] & {
-			@content;
-		}
-	}
-
-	@media screen and (prefers-color-scheme: dark) {
-		:root[data-theme="system"] & {
 			@content;
 		}
 	}

--- a/client/lib/color-scheme/MIGRATION.md
+++ b/client/lib/color-scheme/MIGRATION.md
@@ -1,0 +1,219 @@
+# Dark mode → WordPress Design System (`@wordpress/theme`) migration
+
+> Status: **exploration / foundation landed.** This document is the step-by-step
+> plan for replacing Calypso's bespoke dark-mode engine with the official
+> WordPress Design System (WPDS), and it records what the accompanying draft PR
+> already changes versus what remains.
+
+## 1. Why
+
+The current dark mode is a **proprietary, hand-rolled system**:
+
+- A 800+ line SCSS palette engine (`client/lib/color-scheme/dark-theme.scss`)
+  generates color ramps with `color-mix()` and re-points Calypso's
+  `--dashboard-*`, `--color-*` and `--wp-components-*` variables at them.
+- Activation is a `data-theme="light|dark|system"` attribute written onto
+  `<html>`, with every surface duplicating `:root[data-theme="dark"]` +
+  `@media (prefers-color-scheme: dark)` selectors (the `when-dark-theme` mixin
+  and per-surface `*-dark-theme.scss` / `*-dark-mode.scss` override sheets).
+- Each `@wordpress/components` quirk is patched by a bespoke override mixin
+  (`-primary-button`, `-dataviews`, `-popover`, `-modal`, …).
+
+This is expensive to maintain, drifts from WordPress core, and has to be
+re-derived for every new component.
+
+**Target:** the official, themeable design system.
+
+- `@wordpress/theme` ships the **WPDS design tokens** (`--wpds-*` CSS custom
+  properties) and a `ThemeProvider` React component that **regenerates those
+  tokens for the active light/dark mode at runtime** from a background seed
+  color. No hand-rolled ramps, no `data-theme` selectors — dark is simply a
+  different set of token values within the provider's DOM subtree.
+- `@wordpress/ui` is the companion component library built **on the same WPDS
+  tokens out of the box**, so adopting it gives us themable components for free.
+- The `ThemeProvider` also remaps the legacy `--wp-components-color-*` and
+  `--wp-admin-theme-color` variables, so most existing `@wordpress/components`
+  follow the theme automatically with zero per-component overrides.
+
+## 2. Key architectural difference (read this first)
+
+The old system is **selector-driven**: "if `html[data-theme=dark]`, apply these
+overrides." WPDS is **token-value-driven**: the `ThemeProvider` sets different
+`--wpds-*` values; components that read those tokens just work. **There is no
+"is dark" selector in WPDS.**
+
+Consequence: the migration's real work is *moving components onto WPDS tokens /
+`@wordpress/ui`* so they stop needing dark-specific override blocks at all. Every
+`when-dark-theme { … }` block and every `*-dark-*.scss` mixin is a unit of debt
+to delete, not to port.
+
+## 3. The bridge strategy (how we migrate incrementally without a big-bang)
+
+Two transitional artifacts let surfaces migrate one at a time while everything
+keeps working:
+
+1. **`wpds-theme.tsx`** — unlocks the private `ThemeProvider` (sanctioned for
+   this migration), resolves `light | dark | system` to a concrete mode (tracking
+   the OS preference live), and mounts `<ThemeProvider isRoot color={{ bg }}>`.
+   This is now the **source of truth** for theming.
+2. **`_wpds-bridge.scss`** — the lean replacement for the palette engine. A single
+   `color-scheme-wpds-bridge` mixin maps Calypso's legacy `--dashboard-*` /
+   `--color-*` variables onto `--wpds-*` semantic tokens, mode-agnostically (the
+   token values already encode the mode). Surfaces include this once instead of
+   the 800-line engine, then peel lines off it as components adopt `--wpds-*`
+   directly.
+3. **`data-theme="light|dark"` bridge attribute** — still written by the provider,
+   but now only ever the *resolved* value. It exists solely so not-yet-migrated
+   SCSS (`when-dark-theme`, surface sheets) keeps matching. It is deleted in the
+   final phase.
+
+## 4. What the accompanying draft PR already changes
+
+- ➕ `wpds-theme.tsx`: private-API unlock + `WPDSThemeProvider` + `useResolvedColorScheme`.
+- ✏️ `shared.tsx`: wraps the app in `WPDSThemeProvider`; `data-theme` is now the
+  *resolved* light/dark bridge value (system resolved in JS, not in CSS).
+- ➕ `_wpds-bridge.scss`: the forward-looking variable bridge.
+- ⚠️ `dark-theme.scss` and the `when-dark-theme` mixin: marked **deprecated**; the
+  `when-dark-theme` system/`prefers-color-scheme` branch removed (resolution now
+  happens in JS).
+- ✏️ `index.tsx`: exports the new WPDS helpers.
+- ✏️ tests updated for the resolved-`data-theme` semantics.
+
+The legacy engine and per-surface sheets are intentionally **left in place** so
+the app still builds and current dark-mode surfaces keep rendering. They are
+removed surface-by-surface in the phases below. Doing all ~80 deeply-coupled
+files in one commit would be unreviewable and unbuildable — exactly what this
+exploration is meant to avoid.
+
+## 5. Step-by-step migration plan
+
+### Phase 0 — Build & tooling (prerequisite)
+
+1. Ensure `@wordpress/theme/design-tokens.css` is loaded **app-wide** (not just in
+   the dashboard `style.scss`). Add the import to the classic Calypso global
+   stylesheet entry so Reader/Themes also get base token values.
+2. Wire the WPDS token-fallback build plugins so `var(--wpds-*)` references get
+   fallbacks even before the stylesheet loads:
+   - PostCSS: `@wordpress/theme/postcss-plugins/postcss-ds-token-fallbacks`
+   - JS/TS (webpack/esbuild): `@wordpress/theme/esbuild-plugins/esbuild-ds-token-fallbacks`
+3. Add the WPDS Stylelint plugins (`no-unknown-ds-tokens`,
+   `no-setting-wpds-custom-properties`, `no-token-fallback-values`) to the
+   Stylelint config to enforce correct token usage going forward.
+4. Verify the private-API unlock resolves a **single** `@wordpress/private-apis`
+   instance in the webpack bundle (dedupe), otherwise `unlock()` cannot read the
+   lock. Add a dedupe/resolve alias if multiple copies appear.
+5. Confirm `@wordpress/style-runtime` (used by `ThemeProvider`) is bundled and
+   that the provider's injected `<style>` works in SSR/loading-screen contexts.
+
+### Phase 1 — Foundation (DONE in this PR)
+
+- Mount `WPDSThemeProvider`, resolve scheme in JS, ship the bridge mixin.
+
+### Phase 2 — Dashboard surface
+
+1. In `client/dashboard/app/style.scss`, replace the `:root[data-theme='dark']`
+   block (which `@include dashboard-dark-theme`) with an **unconditional**
+   `@include color-scheme-wpds-bridge` at `:root`.
+2. In `client/dashboard/app/_dark-theme.scss`, delete every mixin that only
+   re-derived tokens or patched `--wp-components-*` (`-tokens`,
+   `-calypso-properties`, `-palettes`, `-primary-button`, `-card`,
+   `-form-controls`, `-popover`, `-modal`, `-summary-button`, `-dataviews`,
+   `-site-icon`) — these are now handled by the provider + bridge. Keep only the
+   genuinely Calypso-markup-specific overrides until those components move to
+   `@wordpress/ui`.
+3. Convert dashboard charts (`chart-theme.ts`) to read WPDS tokens.
+4. Visual-regression the dashboard in light/dark/system; delete dead overrides.
+
+### Phase 3 — Reader surface
+
+1. `client/reader/color-scheme/dark-mode.scss`: replace
+   `color-scheme-dark-theme-calypso-overrides` with `color-scheme-wpds-bridge`.
+2. Migrate the ~25 Reader block/style sheets that use `when-dark-theme` (see file
+   list below) to consume `--wpds-*` tokens, deleting each `when-dark-theme`
+   block as it is converted.
+3. Replace remaining `--studio-*` / `--color-neutral-*` ramp-index references
+   (e.g. `--studio-blue-70`) with semantic WPDS tokens.
+
+### Phase 4 — Themes showcase surface
+
+1. `client/my-sites/themes/_dark-mode.scss`: same swap to the bridge.
+2. This sheet is the most ramp-coupled (`color-palette-alias`,
+   `--studio-blue-60/70/80`, `--color-accent-80`, `--color-neutral-50/70`).
+   Replace those with semantic tokens; where a numeric ramp is genuinely needed,
+   pull from the WPDS primitive tokens rather than the generated Calypso ramp.
+
+### Phase 5 — Adopt `@wordpress/ui`
+
+1. Introduce `@wordpress/ui` for new/rebuilt UI; load its isolation styles
+   (`.root { isolation: isolate; }`, `body { position: relative; }` per its
+   README) and call `useEnableWpCompatOverlaySlot()` once at the app root since we
+   bundle `@wordpress/components` alongside it.
+2. Replace bespoke components that exist only to be themed (badges, cards,
+   panels) with their `@wordpress/ui` equivalents, removing the matching dark
+   overrides.
+
+### Phase 6 — Eradication & cleanup
+
+1. Delete `client/lib/color-scheme/dark-theme.scss` (the engine) once no sheet
+   imports it.
+2. Delete the `when-dark-theme` mixin
+   (`client/assets/stylesheets/shared/mixins/_dark-theme.scss`) once no consumer
+   remains.
+3. Remove the `data-theme` bridge attribute write from `shared.tsx`; drop
+   `_wpds-bridge.scss` lines/the file as the last legacy variables disappear.
+4. Re-evaluate the `dark-mode` / `colorScheme` / `darkMode` feature flags in
+   `config/*.json` and `client/dashboard/app-*/index.tsx`: the WPDS path can be
+   on by default; keep a flag only if a staged rollout is desired.
+5. Update `client/dashboard/AGENTS.md` and `client/reader/AGENTS.md`, which
+   currently document the `when-dark-theme`/`dark-theme` conventions.
+
+## 6. File inventory (the eradication checklist)
+
+**Core library** — `client/lib/color-scheme/`: `dark-theme.scss` (delete),
+`shared.tsx` (drop bridge attr), `wpds-theme.tsx` (keep), `_wpds-bridge.scss`
+(shrink → delete), `query-provider.tsx` / `classic-provider.tsx` /
+`with-color-scheme.tsx` (unchanged API).
+
+**Shared mixin** — `client/assets/stylesheets/shared/mixins/_dark-theme.scss`
+(delete).
+
+**Surface sheets** — `client/dashboard/app/_dark-theme.scss`,
+`client/dashboard/app/style.scss`, `client/reader/color-scheme/dark-mode.scss`,
+`client/my-sites/themes/_dark-mode.scss`, `client/dashboard/app/chart-theme.ts`.
+
+**`when-dark-theme` consumers (~38)** — dashboard: `sites/add-new-site`,
+`me/billing-purchases` (+ `payment-methods/credit-card-fields`),
+`components/logs-activity/activity-event`, `components/offer-card`,
+`sites/site-launch-celebration-modal`, `sites/settings-ai-tools`,
+`sites/deployments-list/deployment-logs`, `app/snackbars`; reader/blocks:
+`blocks/reader-post-actions`, `blocks/reader-site-subscription`,
+`blocks/reader-post-card`, `blocks/comments/{form,post-comment}`,
+`blocks/reader-full-post` (+ `post-navigation`, `link-preview`),
+`blocks/reader-post-options-menu`, `reader/new-subscription/.../add-subscription-form`,
+`reader/stream`, `reader/site-subscriptions-manager`,
+`reader/list/.../list-header`, `reader/sites-list`,
+`reader/sidebar` (+ `reader-sidebar-tags/add-tags-form`, `reader-sidebar-recent`,
+`social`), `reader/user-profile/.../top-sites`, `components/notice`,
+`reader/components/{header,mobile-header,quick-post}`,
+`reader/social/{composer,composer-media}`, `reader/search-stream`.
+
+**Config / flags** — `config/dashboard-*.json`, `config/{development,production,
+stage,wpcalypso,horizon}.json`, `client/dashboard/app-dotcom/index.tsx`,
+`client/dashboard/app-ciab/index.tsx`, `client/dashboard/app/context.tsx`.
+
+**Docs** — `client/dashboard/AGENTS.md`, `client/reader/AGENTS.md`.
+
+## 7. Risks / open questions
+
+- **Visual parity.** WPDS-generated dark ramps won't be pixel-identical to the
+  hand-tuned values. Expect a design review per surface.
+- **`color-scheme: system`.** WPDS picks light/dark from the seed; we resolve
+  `system` in JS and re-seed. Confirm this is acceptable vs. a pure-CSS
+  `light-dark()` approach.
+- **Private API.** `ThemeProvider` is behind `privateApis`; the unlock is gated to
+  `wpds-theme.tsx`. Track the package for a public export and the consent-string
+  changes called out by `@wordpress/private-apis`.
+- **Provider wrapper element.** `ThemeProvider` renders a `display: contents` div;
+  verify no layout/`:root`-height assumptions break, especially under the Node
+  loading screen.
+- **Bundle dedupe.** A duplicated `@wordpress/private-apis` would break `unlock()`.

--- a/client/lib/color-scheme/MIGRATION.md
+++ b/client/lib/color-scheme/MIGRATION.md
@@ -181,7 +181,7 @@ exploration is meant to avoid.
 `client/dashboard/app/style.scss`, `client/reader/color-scheme/dark-mode.scss`,
 `client/my-sites/themes/_dark-mode.scss`, `client/dashboard/app/chart-theme.ts`.
 
-**`when-dark-theme` consumers (~38)** — dashboard: `sites/add-new-site`,
+**`when-dark-theme` consumers (~35)** — dashboard: `sites/add-new-site`,
 `me/billing-purchases` (+ `payment-methods/credit-card-fields`),
 `components/logs-activity/activity-event`, `components/offer-card`,
 `sites/site-launch-celebration-modal`, `sites/settings-ai-tools`,
@@ -217,3 +217,43 @@ stage,wpcalypso,horizon}.json`, `client/dashboard/app-dotcom/index.tsx`,
   verify no layout/`:root`-height assumptions break, especially under the Node
   loading screen.
 - **Bundle dedupe.** A duplicated `@wordpress/private-apis` would break `unlock()`.
+
+## 8. Estimated size & why this must be split
+
+A single PR doing the entire eradication would be large, and — more importantly —
+unreviewable and impossible to visually verify as one unit.
+
+Grounded in the current code:
+
+- **Deletions (mechanical):** the engine + surface sheets total **~1,900 lines** —
+  `dark-theme.scss` (875), dashboard `_dark-theme.scss` (468), Reader
+  `dark-mode.scss` (229), Themes `_dark-mode.scss` (258), the shared
+  `when-dark-theme` mixin (21), `chart-theme.ts` (26).
+- **Conversions (the hard part):** **~35 consumer stylesheets** each carry a
+  dark-only `when-dark-theme { … }` override that must be re-pointed to `--wpds-*`
+  tokens. Reader and Themes additionally consume *generated ramp indices*
+  (`--studio-blue-70`, `--color-accent-80`, `--color-neutral-50`, …) that have no
+  one-to-one semantic token and need design-led replacements.
+- **Plumbing:** ~8 config/flag files, 2 `AGENTS.md`, the unit tests, the app-wide
+  token-CSS import, and the PostCSS/Stylelint build wiring.
+
+All-in this is roughly **~55 files, on the order of +800 / −2,200 (~3,000 lines
+touched)**.
+
+But raw size understates the cost. This is fundamentally a **visual** migration:
+WPDS-generated dark ramps will not be pixel-identical to the hand-tuned values, so
+**every surface needs design QA in light, dark, and system modes.** That review
+burden — not the line count — is the reason `when-dark-theme` and the engine are
+removed *last*, only after each surface's components have been moved onto WPDS
+tokens and signed off.
+
+**Recommended split** (each PR ~10–20 files, independently shippable + QA-able):
+
+1. Foundation — *(this PR)*.
+2. Phase 0 tooling — token CSS app-wide + fallback/Stylelint plugins.
+3. Dashboard surface.
+4. Reader surface.
+5. Themes surface.
+6. `@wordpress/ui` adoption.
+7. Final eradication — delete the engine, the `when-dark-theme` mixin, the
+   `data-theme` bridge, and the bridge file; revisit the `dark-mode` flag.

--- a/client/lib/color-scheme/_wpds-bridge.scss
+++ b/client/lib/color-scheme/_wpds-bridge.scss
@@ -1,0 +1,77 @@
+/*
+ * WPDS bridge — the replacement for the bespoke dark-mode palette engine.
+ *
+ * The legacy `dark-theme.scss` hand-generated an entire color system with
+ * `color-mix()` ramps and then re-pointed Calypso's `--dashboard-*`, `--color-*`
+ * and `--wp-components-*` variables at those generated values, all gated behind
+ * `:root[data-theme="dark"]` and `prefers-color-scheme` media queries.
+ *
+ * In the WPDS model that work disappears. The `@wordpress/theme` `ThemeProvider`
+ * (mounted in `wpds-theme.tsx`) regenerates the `--wpds-*` semantic tokens for
+ * the active light/dark mode at runtime. This mixin simply maps Calypso's legacy
+ * variable contract onto those semantic tokens *once*, mode-agnostically — there
+ * are no `data-theme` selectors and no media queries here, because the token
+ * values already encode the mode.
+ *
+ * Emit it unconditionally at a themed root (e.g. `:root` or a surface wrapper).
+ * As each surface migrates its components to consume `--wpds-*`/`@wordpress/ui`
+ * directly, the corresponding lines below can be deleted; once a surface no
+ * longer reads any legacy variable, it drops this mixin entirely.
+ *
+ * NOTE: this file intentionally does NOT `@import` color-studio or define ramps.
+ * It is the lean, forward-looking counterpart to `dark-theme.scss`, which is now
+ * deprecated (see ./MIGRATION.md).
+ */
+
+@mixin color-scheme-wpds-bridge {
+	// Advertise both schemes to the browser so native UI (scrollbars, form
+	// controls, etc.) follows the WPDS-selected mode.
+	color-scheme: light dark;
+
+	// --- Page + surface backgrounds -------------------------------------
+	--dashboard__background-color: var( --wpds-color-bg-surface-neutral-weak );
+	--dashboard-surface__background-color: var( --wpds-color-bg-surface-neutral-strong );
+	--dashboard-inline-code__background-color: var( --wpds-color-bg-surface-neutral );
+	--dashboard-header__background-color: var( --wpds-color-bg-surface-neutral );
+	--color-surface: var( --wpds-color-bg-surface-neutral-strong );
+	--color-popover: var( --wpds-color-bg-surface-neutral-strong );
+	--color-popover-muted: var( --wpds-color-bg-surface-neutral );
+
+	// --- Foreground / text ----------------------------------------------
+	--dashboard__text-color: var( --wpds-color-fg-content-neutral );
+	--dashboard__text-muted-color: var( --wpds-color-fg-content-neutral-weak );
+	--dashboard-subtle__color: var( --wpds-color-fg-content-neutral-weak );
+	--dashboard-header__color: var( --wpds-color-fg-content-neutral );
+	--dashboard-menu-item__color: var( --wpds-color-fg-content-neutral-weak );
+	--dashboard-menu-item-active__color: var( --wpds-color-fg-content-neutral );
+	--dashboard-secondary-menu-item__color: var( --wpds-color-fg-content-neutral );
+	--color-text: var( --wpds-color-fg-content-neutral );
+	--color-text-subtle: var( --wpds-color-fg-content-neutral-weak );
+	--color-muted-foreground: var( --wpds-color-fg-content-neutral-weak );
+
+	// --- Strokes / borders ----------------------------------------------
+	--dashboard-surface__border-color: var( --wpds-color-stroke-surface-neutral );
+	--dashboard-field__border-color: var( --wpds-color-stroke-interactive-neutral );
+	--dashboard-header__border-color: var( --wpds-color-stroke-surface-neutral-weak );
+	--dashboard-header__divider-color: var( --wpds-color-stroke-surface-neutral-weak );
+	--dashboard-overview__divider-color: var( --wpds-color-stroke-surface-neutral-weak );
+	--color-border: var( --wpds-color-stroke-surface-neutral );
+	--color-border-subtle: var( --wpds-color-stroke-surface-neutral-weak );
+	--color-muted: var( --wpds-color-stroke-surface-neutral );
+
+	// --- Accent / brand --------------------------------------------------
+	// The ThemeProvider already remaps `--wp-admin-theme-color` and the
+	// `--wp-components-color-accent*` family from the brand seed, so consumers
+	// of those variables (most @wordpress/components) need nothing extra.
+	--color-primary: var( --wp-admin-theme-color );
+	--color-primary-foreground: var( --wpds-color-fg-interactive-brand-strong );
+	--color-accent: var( --wp-admin-theme-color );
+	--color-link: var( --wpds-color-fg-interactive-brand );
+	--color-ring: var( --wpds-color-stroke-focus-brand );
+
+	// --- Status / feedback ----------------------------------------------
+	--dashboard__foreground-color-success: var( --wpds-color-fg-content-success );
+	--dashboard__foreground-color-warning: var( --wpds-color-fg-content-warning );
+	--dashboard__foreground-color-error: var( --wpds-color-fg-content-error );
+	--dashboard-danger__color: var( --wpds-color-fg-content-error );
+}

--- a/client/lib/color-scheme/dark-theme.scss
+++ b/client/lib/color-scheme/dark-theme.scss
@@ -1,3 +1,16 @@
+/*
+ * ⚠️ DEPRECATED — bespoke dark-mode palette engine.
+ *
+ * This 800+ line library hand-rolls a dark color system and re-points Calypso's
+ * design variables at it. It is being replaced by the official WordPress Design
+ * System via `@wordpress/theme`'s `ThemeProvider` (see `./wpds-theme.tsx`) plus
+ * the lean variable bridge in `./_wpds-bridge.scss`.
+ *
+ * Do NOT add new mixins or token overrides here. New themed surfaces must consume
+ * `--wpds-*` tokens (or `@wordpress/ui` components) directly. This file is kept
+ * only so the not-yet-migrated surface override sheets keep compiling, and is
+ * deleted surface-by-surface in the phases described in `./MIGRATION.md`.
+ */
 @import '@automattic/color-studio/dist/color-variables';
 
 /*

--- a/client/lib/color-scheme/index.tsx
+++ b/client/lib/color-scheme/index.tsx
@@ -2,4 +2,5 @@ export { ClassicColorSchemeProvider } from './classic-provider';
 export { ColorSchemeProvider } from './query-provider';
 export { DEFAULT_SCHEME, PREFERENCE_KEY, isColorScheme, useColorScheme } from './shared';
 export { withColorScheme } from './with-color-scheme';
+export { SEED_BACKGROUND, WPDSThemeProvider, useResolvedColorScheme } from './wpds-theme';
 export type { ColorScheme, ColorSchemeContextType } from './shared';

--- a/client/lib/color-scheme/shared.tsx
+++ b/client/lib/color-scheme/shared.tsx
@@ -1,4 +1,5 @@
-import { createContext, useContext, useEffect, useRef } from 'react';
+import { useEffect, useRef, createContext, useContext } from 'react';
+import { WPDSThemeProvider, useResolvedColorScheme } from './wpds-theme';
 import type { ReactNode } from 'react';
 
 export type ColorScheme = 'light' | 'dark' | 'system';
@@ -17,8 +18,21 @@ export interface ColorSchemeContextType {
 
 const ColorSchemeContext = createContext< ColorSchemeContextType | undefined >( undefined );
 
-function useDocumentColorScheme(
-	colorScheme: ColorScheme,
+/**
+ * Transitional bridge: mirror the *resolved* light/dark mode onto the document
+ * root as `data-theme="light|dark"`.
+ *
+ * The WPDS `ThemeProvider` is the source of truth for theming now — it sets the
+ * actual `--wpds-*` token values. This attribute exists only so the SCSS that
+ * has not yet been migrated to WPDS tokens (the legacy `when-dark-theme` mixin
+ * and the per-surface `*-dark-theme`/`*-dark-mode` override sheets) keeps working
+ * during the migration. Unlike the old implementation it never writes the raw
+ * `system` value: the OS preference is resolved in JS, so downstream CSS only
+ * needs to match `dark`. Each surface that adopts WPDS tokens removes its
+ * dependency on this attribute, and the final migration step deletes it entirely.
+ */
+function useResolvedThemeAttribute(
+	resolvedScheme: 'light' | 'dark',
 	isReady: boolean,
 	restoreOnUnmount: boolean
 ) {
@@ -54,8 +68,8 @@ function useDocumentColorScheme(
 			hasAppliedTheme.current = true;
 		}
 
-		document.documentElement.dataset.theme = colorScheme;
-	}, [ colorScheme, isReady, restoreOnUnmount ] );
+		document.documentElement.dataset.theme = resolvedScheme;
+	}, [ resolvedScheme, isReady, restoreOnUnmount ] );
 }
 
 export function ColorSchemeContextProvider( {
@@ -73,7 +87,9 @@ export function ColorSchemeContextProvider( {
 	setColorScheme: ColorSchemeContextType[ 'setColorScheme' ];
 	waitForReady: boolean;
 } ) {
-	useDocumentColorScheme( colorScheme, isReady, restoreOnUnmount );
+	const resolvedScheme = useResolvedColorScheme( colorScheme );
+
+	useResolvedThemeAttribute( resolvedScheme, isReady, restoreOnUnmount );
 
 	if ( waitForReady && ! isReady ) {
 		return null;
@@ -81,7 +97,7 @@ export function ColorSchemeContextProvider( {
 
 	return (
 		<ColorSchemeContext.Provider value={ { colorScheme, setColorScheme } }>
-			{ children }
+			<WPDSThemeProvider resolvedScheme={ resolvedScheme }>{ children }</WPDSThemeProvider>
 		</ColorSchemeContext.Provider>
 	);
 }

--- a/client/lib/color-scheme/test/classic-provider.test.jsx
+++ b/client/lib/color-scheme/test/classic-provider.test.jsx
@@ -96,14 +96,17 @@ describe( 'ClassicColorSchemeProvider', () => {
 		expect( document.documentElement.dataset.theme ).toBe( 'dark' );
 	} );
 
-	test( 'applies saved system scheme', () => {
+	test( 'resolves the system scheme to a concrete light/dark data-theme', () => {
+		// The WPDS provider resolves `system` to the OS preference in JS, so the
+		// transitional `data-theme` bridge attribute only ever carries the
+		// resolved value. jsdom has no `matchMedia`, so this resolves to `light`.
 		renderWithStore(
 			buildState( { scheme: 'system' } ),
 			<ClassicColorSchemeProvider>
 				<span>child</span>
 			</ClassicColorSchemeProvider>
 		);
-		expect( document.documentElement.dataset.theme ).toBe( 'system' );
+		expect( document.documentElement.dataset.theme ).toBe( 'light' );
 	} );
 
 	test( 'removes data-theme when unmounted if there was no previous value', () => {

--- a/client/lib/color-scheme/wpds-theme.tsx
+++ b/client/lib/color-scheme/wpds-theme.tsx
@@ -1,0 +1,116 @@
+/**
+ * WordPress Design System (WPDS) theming bridge for Calypso.
+ *
+ * This module is the heart of the migration away from Calypso's bespoke
+ * dark-mode engine (the `color-scheme-dark-theme-*` SCSS mixin library and the
+ * `data-theme` attribute) toward the official `@wordpress/theme` package.
+ *
+ * `@wordpress/theme` does not expose its `ThemeProvider` publicly yet — it ships
+ * behind the package's `privateApis` lock. We deliberately opt in to the private
+ * API here. This is explicitly sanctioned for the migration: the WPDS team has
+ * confirmed the `ThemeProvider` shape is the intended public surface, and gating
+ * the unlock to this single module keeps the blast radius contained. If/when the
+ * provider graduates to a public export, this file becomes the only thing that
+ * needs to change.
+ */
+// eslint-disable-next-line no-restricted-imports
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+import { privateApis } from '@wordpress/theme';
+import { useEffect, useState } from 'react';
+import type { ColorScheme } from './shared';
+import type { ComponentType, ReactNode } from 'react';
+
+// `@wordpress/private-apis` only lets allow-listed core modules unlock private
+// exports. We borrow the `@wordpress/ui` slot (already on the allow-list and the
+// companion package we intend to consume) so Calypso can read the lock. The
+// consent string is fixed by `@wordpress/private-apis` and must match verbatim.
+const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+	'@wordpress/ui'
+);
+
+type ThemeProviderColor = { primary?: string; bg?: string };
+
+interface ThemeProviderProps {
+	children?: ReactNode;
+	color?: ThemeProviderColor;
+	cursor?: { control?: 'default' | 'pointer' };
+	density?: undefined | 'default' | 'compact' | 'comfortable';
+	isRoot?: boolean;
+}
+
+const { ThemeProvider } = unlock( privateApis ) as {
+	ThemeProvider: ComponentType< ThemeProviderProps >;
+};
+
+/**
+ * Background seed colors handed to the WPDS `ThemeProvider`.
+ *
+ * The provider derives the full token ramp — and crucially whether the theme is
+ * light or dark — from the background seed. These two values replace the entire
+ * hand-rolled `color-mix()` palette generator that used to live in
+ * `dark-theme.scss`.
+ *
+ * `LIGHT_BG` matches the WPDS default (`#f8f8f8`); `DARK_BG` matches the surface
+ * background the legacy dashboard dark theme used (`#1e1e1e`).
+ */
+export const SEED_BACKGROUND: Record< 'light' | 'dark', string > = {
+	light: '#f8f8f8',
+	dark: '#1e1e1e',
+};
+
+/**
+ * Resolves a stored `ColorScheme` ('light' | 'dark' | 'system') into a concrete
+ * 'light' | 'dark' value, tracking the OS preference live when set to 'system'.
+ */
+export function useResolvedColorScheme( colorScheme: ColorScheme ): 'light' | 'dark' {
+	const getSystemPrefersDark = () =>
+		typeof window !== 'undefined' &&
+		typeof window.matchMedia === 'function' &&
+		window.matchMedia( '(prefers-color-scheme: dark)' ).matches;
+
+	const [ systemPrefersDark, setSystemPrefersDark ] = useState( getSystemPrefersDark );
+
+	useEffect( () => {
+		if ( typeof window === 'undefined' || typeof window.matchMedia !== 'function' ) {
+			return;
+		}
+
+		const query = window.matchMedia( '(prefers-color-scheme: dark)' );
+		const handleChange = ( event: MediaQueryListEvent ) => setSystemPrefersDark( event.matches );
+
+		query.addEventListener( 'change', handleChange );
+		return () => query.removeEventListener( 'change', handleChange );
+	}, [] );
+
+	if ( colorScheme === 'system' ) {
+		return systemPrefersDark ? 'dark' : 'light';
+	}
+
+	return colorScheme === 'dark' ? 'dark' : 'light';
+}
+
+/**
+ * Wraps the app in the WPDS `ThemeProvider`, seeding it with the background
+ * color for the resolved scheme. The provider regenerates the `--wpds-*` design
+ * tokens (and the legacy `--wp-components-*`/`--wp-admin-theme-color` aliases)
+ * for the active mode, so every component that consumes WPDS tokens or
+ * `@wordpress/ui` follows the chosen color scheme automatically — no `data-theme`
+ * selectors and no bespoke palette mixins required.
+ *
+ * `isRoot` makes the provider also apply its tokens to the document root, so
+ * portaled overlays and the `html`/`body` background inherit the correct theme.
+ */
+export function WPDSThemeProvider( {
+	resolvedScheme,
+	children,
+}: {
+	resolvedScheme: 'light' | 'dark';
+	children: ReactNode;
+} ) {
+	return (
+		<ThemeProvider isRoot color={ { bg: SEED_BACKGROUND[ resolvedScheme ] } } density="compact">
+			{ children }
+		</ThemeProvider>
+	);
+}


### PR DESCRIPTION
## Summary

**This is an exploration draft PR** to determine how to migrate Calypso's
dark mode off its bespoke, proprietary engine and onto the official WordPress
Design System (WPDS) via [`@wordpress/theme`](https://www.npmjs.com/package/@wordpress/theme),
using the WPDS CSS tokens (`--wpds-*`) and the `ThemeProvider` React component
(consumed via its private API), plus a path to [`@wordpress/ui`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-ui/)
componentry which uses WPDS tokens out of the box.

It lands the **foundation + a detailed phased plan**, not the full mechanical
eradication (which spans ~80 deeply-coupled files and would be unreviewable in a
single commit). The full plan lives in
[`client/lib/color-scheme/MIGRATION.md`](../blob/cursor/dark-mode-wpds-theme-migration/client/lib/color-scheme/MIGRATION.md).

### The problem with the current dark mode

- An 800+ line SCSS palette engine (`client/lib/color-scheme/dark-theme.scss`)
  hand-generates color ramps with `color-mix()` and re-points Calypso's
  `--dashboard-*` / `--color-*` / `--wp-components-*` variables at them.
- Activation is a `data-theme="light|dark|system"` attribute on `<html>`, with
  every surface duplicating `:root[data-theme="dark"]` + `prefers-color-scheme`
  selectors (the `when-dark-theme` mixin and per-surface override sheets).
- Each `@wordpress/components` quirk is patched by a bespoke override mixin.

### The target

- `@wordpress/theme`'s `ThemeProvider` **regenerates the `--wpds-*` design tokens
  for the active light/dark mode at runtime** from a background seed color — no
  hand-rolled ramps, no `data-theme` selectors. Dark is just different token
  values inside the provider's subtree.
- The provider also remaps the legacy `--wp-components-*` / `--wp-admin-theme-color`
  variables, so most `@wordpress/components` follow the theme with zero overrides.
- `@wordpress/ui` is built on the same tokens, giving themable components for free.

## What this PR changes

- ➕ `client/lib/color-scheme/wpds-theme.tsx` — unlocks the private `ThemeProvider`
  (gated to this one module), resolves `light|dark|system` to a concrete mode
  (tracking the OS preference live), and mounts `<ThemeProvider isRoot color={{ bg }}>`.
- ✏️ `client/lib/color-scheme/shared.tsx` — wraps the app in the WPDS provider;
  `data-theme` now carries only the *resolved* light/dark value as a transitional
  bridge (system is resolved in JS, not CSS). Public API (`useColorScheme`,
  `ColorSchemeProvider`, `ClassicColorSchemeProvider`, `withColorScheme`) is
  unchanged, so all call sites keep working.
- ➕ `client/lib/color-scheme/_wpds-bridge.scss` — the lean replacement for the
  palette engine: one `color-scheme-wpds-bridge` mixin maps Calypso's legacy
  variables onto `--wpds-*` semantic tokens, mode-agnostically.
- ⚠️ `dark-theme.scss` and the `when-dark-theme` mixin — marked **deprecated**;
  the `when-dark-theme` `prefers-color-scheme`/`system` branch removed (resolution
  now happens in JS). Left in place so the app still builds and current dark-mode
  surfaces keep rendering; deleted surface-by-surface per the plan.
- ➕ `client/lib/color-scheme/MIGRATION.md` — the full phased eradication plan +
  file inventory + risks.

## Migration plan (see MIGRATION.md for detail)

0. **Tooling** — load `@wordpress/theme/design-tokens.css` app-wide, wire the WPDS
   token-fallback build plugins + Stylelint rules, verify a single
   `@wordpress/private-apis` instance in the bundle.
1. **Foundation** — *(this PR)* mount `WPDSThemeProvider`, resolve scheme in JS, ship the bridge.
2. **Dashboard** — swap `dashboard-dark-theme` for the unconditional bridge; delete token/`--wp-components-*` override mixins.
3. **Reader** — convert the ~25 `when-dark-theme` block sheets to `--wpds-*`.
4. **Themes** — convert the ramp-index-coupled showcase sheet to semantic tokens.
5. **Adopt `@wordpress/ui`** — rebuild themable components on WPDS components.
6. **Eradicate** — delete `dark-theme.scss`, the `when-dark-theme` mixin, the
   `data-theme` bridge, and the bridge file; revisit the `dark-mode` flag.

## Test plan

- [x] `client/lib/color-scheme` unit tests pass (29/29) — confirms the private-API
      `ThemeProvider` unlock loads and renders.
- [x] ESLint + Stylelint pass on changed files.
- [ ] Phase 0 build wiring (token CSS app-wide + fallback plugins) before any surface flips.
- [ ] Visual review of dashboard/Reader/Themes in light/dark/system as each phase lands.
- [ ] Confirm no `@wordpress/private-apis` duplication in the production bundle.