### PR TITLE
Reader: guard PostCommentList initial fetches against an update-depth loop

### DIFF
--- a/client/blocks/comments/post-comment-list.jsx
+++ b/client/blocks/comments/post-comment-list.jsx
@@ -139,7 +139,17 @@ class PostCommentList extends Component {
 		if ( prevState !== this.state && prevProps === this.props ) {
 			return;
 		}
-		this.initialFetches();
+		// Only re-run initialFetches when one of its inputs changes; running it on
+		// every update can re-enter componentDidUpdate via setState and exceed the
+		// maximum update depth.
+		if (
+			prevProps.isInitialCommentLoading !== this.props.isInitialCommentLoading ||
+			prevProps.startingCommentId !== this.props.startingCommentId ||
+			prevProps.initialComment !== this.props.initialComment ||
+			prevProps.commentsTree !== this.props.commentsTree
+		) {
+			this.initialFetches();
+		}
 		if (
 			prevProps.siteId !== this.props.siteId ||
 			prevProps.postId !== this.props.postId ||


### PR DESCRIPTION
Part of the [Calypso → React 19 migration](https://linear.app/a8c/project/migrate-calypso-to-react-19-ed8301da230e/overview). Split out from the `client/blocks` forward-compat PR (#111506) because, unlike that PR's mechanical edits, this is an intentional runtime behavior change.

## Proposed Changes

Gate `PostCommentList.componentDidUpdate`'s call to `initialFetches()` on the props that method actually depends on, instead of calling it on every prop-driven update.

## Why are these changes being made?

`initialFetches()` dispatches comment-fetch actions, which update props and re-enter `componentDidUpdate`. Calling it unconditionally on every update let unrelated prop churn keep re-triggering that cycle. React 18 tolerated it; React 19's stricter update accounting surfaces it as "maximum update depth exceeded". Gating the call to `initialFetches`'s real inputs (`isInitialCommentLoading`, `startingCommentId`, `initialComment`, `commentsTree`) — the class-component equivalent of a `useEffect` dependency array — breaks the cycle while still re-running whenever any input that affects the fetch decision changes.

## Testing Instructions

* `yarn test-client client/blocks/comments` passes.
* Deep-link into a post's comments (a comment permalink / notification link with a `startingCommentId`) and confirm the initial comments still load and the view scrolls to the target comment.
* Open a post with many comments, expand/collapse, and confirm "Show more comments" paging still works.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
