### PR TITLE
Domains: surface add-to-cart failures on the bundle suggestion card

### DIFF
--- a/packages/domain-search/src/components/bundle-card/bundle-card.stories.tsx
+++ b/packages/domain-search/src/components/bundle-card/bundle-card.stories.tsx
@@ -140,6 +140,19 @@ export const WithPremiumDomain = () => (
 	</StoryWrapper>
 );
 
+export const WithError = () => (
+	<StoryWrapper>
+		<BundleCard
+			suggestion={ buildSuggestion( [
+				buildDomain( { domain: 'example.com', cost: '$22.00' } ),
+				buildDomain( { domain: 'example.net', cost: '$18.00' } ),
+			] ) }
+			onAddToCart={ () => {} }
+			errorMessage="Sorry, we can't determine the availability of the domain you're trying to register. Please try again in a few minutes."
+		/>
+	</StoryWrapper>
+);
+
 export const Empty = () => (
 	<StoryWrapper>
 		<BundleCard suggestion={ null } />

--- a/packages/domain-search/src/components/bundle-card/index.tsx
+++ b/packages/domain-search/src/components/bundle-card/index.tsx
@@ -1,5 +1,6 @@
 import {
 	Button,
+	Notice,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
@@ -17,6 +18,7 @@ interface BundleCardProps {
 	onAddToCart?: ( bundle: BundleSuggestion ) => void;
 	isAddedToCart?: boolean;
 	onContinue?: () => void;
+	errorMessage?: string;
 }
 
 export const BundleCard = ( {
@@ -24,6 +26,7 @@ export const BundleCard = ( {
 	onAddToCart,
 	isAddedToCart,
 	onContinue,
+	errorMessage,
 }: BundleCardProps ) => {
 	const { __ } = useI18n();
 
@@ -86,6 +89,12 @@ export const BundleCard = ( {
 							'Premium domains are subject to different pricing and may not be eligible for promotions.'
 						) }
 					</Text>
+				) }
+
+				{ errorMessage && (
+					<Notice className="bundle-card__error" status="error" isDismissible={ false }>
+						{ errorMessage }
+					</Notice>
 				) }
 
 				{ isAddedToCart ? (

--- a/packages/domain-search/src/components/bundle-card/index.tsx
+++ b/packages/domain-search/src/components/bundle-card/index.tsx
@@ -1,6 +1,5 @@
 import {
 	Button,
-	Notice,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
@@ -8,7 +7,7 @@ import {
 import { sprintf } from '@wordpress/i18n';
 import { arrowRight } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { DomainSuggestionBadge } from '../../ui';
+import { DomainSearchNotice, DomainSuggestionBadge } from '../../ui';
 import type { BundleSuggestion } from '@automattic/api-core';
 
 import './style.scss';
@@ -18,6 +17,8 @@ interface BundleCardProps {
 	onAddToCart?: ( bundle: BundleSuggestion ) => void;
 	isAddedToCart?: boolean;
 	onContinue?: () => void;
+	isBusy?: boolean;
+	disabled?: boolean;
 	errorMessage?: string;
 }
 
@@ -26,6 +27,8 @@ export const BundleCard = ( {
 	onAddToCart,
 	isAddedToCart,
 	onContinue,
+	isBusy,
+	disabled,
 	errorMessage,
 }: BundleCardProps ) => {
 	const { __ } = useI18n();
@@ -91,11 +94,7 @@ export const BundleCard = ( {
 					</Text>
 				) }
 
-				{ errorMessage && (
-					<Notice className="bundle-card__error" status="error" isDismissible={ false }>
-						{ errorMessage }
-					</Notice>
-				) }
+				{ errorMessage && <DomainSearchNotice status="error">{ errorMessage }</DomainSearchNotice> }
 
 				{ isAddedToCart ? (
 					<Button
@@ -105,6 +104,7 @@ export const BundleCard = ( {
 						__next40pxDefaultSize
 						icon={ arrowRight }
 						label={ __( 'Continue' ) }
+						disabled={ disabled }
 						onClick={ () => onContinue?.() }
 					>
 						{ __( 'Continue' ) }
@@ -114,6 +114,8 @@ export const BundleCard = ( {
 						className="bundle-card__cta"
 						variant="primary"
 						__next40pxDefaultSize
+						isBusy={ isBusy }
+						disabled={ disabled }
 						onClick={ () => onAddToCart?.( suggestion ) }
 					>
 						{ __( 'Get bundle' ) }

--- a/packages/domain-search/src/components/bundle-card/test/index.tsx
+++ b/packages/domain-search/src/components/bundle-card/test/index.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { render, screen } from '@testing-library/react';
+import { getByText, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { BundleCard } from '..';
 import type { BundleSuggestion, BundleSuggestionDomain } from '@automattic/api-core';
@@ -164,6 +164,27 @@ describe( 'BundleCard', () => {
 		await expect(
 			user.click( screen.getByRole( 'button', { name: 'Get bundle' } ) )
 		).resolves.not.toThrow();
+	} );
+
+	it( 'renders the error message when errorMessage is provided', () => {
+		// Scoped to the render container because the Notice also announces the
+		// message through the a11y-speak live region appended to document.body.
+		const { container } = render(
+			<BundleCard
+				suggestion={ buildSuggestion( twoDomains ) }
+				errorMessage="Something went wrong."
+			/>
+		);
+
+		expect( getByText( container, 'Something went wrong.' ) ).toBeInTheDocument();
+		// The CTA stays available so the user can retry.
+		expect( screen.getByRole( 'button', { name: 'Get bundle' } ) ).toBeEnabled();
+	} );
+
+	it( 'does not render an error notice when errorMessage is not provided', () => {
+		const { container } = render( <BundleCard suggestion={ buildSuggestion( twoDomains ) } /> );
+
+		expect( container.querySelector( '.bundle-card__error' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders a placeholder with no CTA or domain rows for a null suggestion', () => {

--- a/packages/domain-search/src/components/bundle-card/test/index.tsx
+++ b/packages/domain-search/src/components/bundle-card/test/index.tsx
@@ -184,7 +184,13 @@ describe( 'BundleCard', () => {
 	it( 'does not render an error notice when errorMessage is not provided', () => {
 		const { container } = render( <BundleCard suggestion={ buildSuggestion( twoDomains ) } /> );
 
-		expect( container.querySelector( '.bundle-card__error' ) ).not.toBeInTheDocument();
+		expect( container.querySelector( '.domain-search-notice' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'marks the CTA busy and disabled while an add-to-cart is in flight', () => {
+		render( <BundleCard suggestion={ buildSuggestion( twoDomains ) } isBusy disabled /> );
+
+		expect( screen.getByRole( 'button', { name: 'Get bundle' } ) ).toBeDisabled();
 	} );
 
 	it( 'renders a placeholder with no CTA or domain rows for a null suggestion', () => {

--- a/packages/domain-search/src/hooks/use-is-current-mutation.ts
+++ b/packages/domain-search/src/hooks/use-is-current-mutation.ts
@@ -1,11 +1,24 @@
 import { useQueryClient } from '@tanstack/react-query';
-import { useId } from 'react';
+import { useCallback, useId, useSyncExternalStore } from 'react';
 
 export const useIsCurrentMutation = () => {
 	const queryClient = useQueryClient();
 	const mutationId = useId();
+	const mutationCache = queryClient.getMutationCache();
 
-	const lastMutationId = queryClient.getMutationCache().findAll().at( -1 )?.meta?.mutationId;
+	// Subscribe to the cache so a mutation fired by another component
+	// re-renders this one — otherwise a superseded error surface lingers
+	// until something else happens to re-render it.
+	const subscribe = useCallback(
+		( onStoreChange: () => void ) => mutationCache.subscribe( onStoreChange ),
+		[ mutationCache ]
+	);
+
+	const lastMutationId = useSyncExternalStore(
+		subscribe,
+		() => mutationCache.findAll().at( -1 )?.meta?.mutationId,
+		() => undefined
+	);
 
 	return {
 		mutationId,

--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -11,6 +11,7 @@ import { SearchNotice } from '../components/search-notice';
 import { SearchResults } from '../components/search-results';
 import { SkipSuggestion } from '../components/skip-suggestion';
 import { UnavailableSearchResult } from '../components/unavailable-search-result';
+import { useIsCurrentMutation } from '../hooks/use-is-current-mutation';
 import { useRequestTracking } from '../hooks/use-request-tracking';
 import { useSuggestionsList } from '../hooks/use-suggestions-list';
 import { useDomainSearch } from './context';
@@ -47,19 +48,34 @@ const StickyCompactBanner = () => {
 };
 
 export const ResultsPage = () => {
+	const { __ } = useI18n();
 	const { slots, config, events, cart } = useDomainSearch();
+
+	const { mutationId, isCurrentMutation } = useIsCurrentMutation();
 
 	// Accepting a bundle adds every member domain to the cart in one
 	// all-or-nothing operation. The cart mutation itself lives at the app layer
 	// (cart.onAddBundle); the mutation wrapper mirrors the single-domain
 	// add-to-cart path so failures are captured the same way.
-	const { mutate: addBundleToCart } = useMutation( {
+	const { mutate: addBundleToCart, error: addBundleError } = useMutation( {
+		meta: {
+			mutationId,
+		},
 		mutationFn: async ( bundle: BundleSuggestion ) => {
 			await cart.onAddBundle?.( bundle );
 		},
 		networkMode: 'always',
 		retry: false,
 	} );
+
+	// The cart rejects with the server's first cart message (a CartActionError),
+	// which is already user-facing copy. Fall back when it's missing. Clicking
+	// "Get bundle" again re-fires the mutation, which clears the error state.
+	const bundleErrorMessage =
+		isCurrentMutation && addBundleError
+			? addBundleError.message ||
+			  __( 'Sorry, we couldn’t add the bundle to your cart. Please try again.' )
+			: undefined;
 
 	const {
 		isLoading: isLoadingSuggestions,
@@ -140,6 +156,7 @@ export const ResultsPage = () => {
 							cart.hasItem( domain )
 						) }
 						onContinue={ events.onContinue }
+						errorMessage={ bundleErrorMessage }
 					/>
 				) }
 				{ isLoadingSuggestions ? (

--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -1,4 +1,4 @@
-import { useMutation } from '@tanstack/react-query';
+import { useIsMutating, useMutation } from '@tanstack/react-query';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { chevronDown, chevronUp, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
@@ -49,7 +49,7 @@ const StickyCompactBanner = () => {
 
 export const ResultsPage = () => {
 	const { __ } = useI18n();
-	const { slots, config, events, cart } = useDomainSearch();
+	const { slots, config, events, cart, query } = useDomainSearch();
 
 	const { mutationId, isCurrentMutation } = useIsCurrentMutation();
 
@@ -57,7 +57,12 @@ export const ResultsPage = () => {
 	// all-or-nothing operation. The cart mutation itself lives at the app layer
 	// (cart.onAddBundle); the mutation wrapper mirrors the single-domain
 	// add-to-cart path so failures are captured the same way.
-	const { mutate: addBundleToCart, error: addBundleError } = useMutation( {
+	const {
+		mutate: addBundleToCart,
+		error: addBundleError,
+		isPending: isAddingBundle,
+		reset: resetAddBundle,
+	} = useMutation( {
 		meta: {
 			mutationId,
 		},
@@ -67,6 +72,14 @@ export const ResultsPage = () => {
 		networkMode: 'always',
 		retry: false,
 	} );
+
+	const isMutating = !! useIsMutating();
+
+	// A failed add shouldn't follow the user to a different search: a new
+	// query produces a new bundle suggestion, so drop the stale error.
+	useEffect( () => {
+		resetAddBundle();
+	}, [ query, resetAddBundle ] );
 
 	// The cart rejects with the server's first cart message (a CartActionError),
 	// which is already user-facing copy. Fall back when it's missing. Clicking
@@ -156,6 +169,8 @@ export const ResultsPage = () => {
 							cart.hasItem( domain )
 						) }
 						onContinue={ events.onContinue }
+						isBusy={ isAddingBundle }
+						disabled={ isMutating }
 						errorMessage={ bundleErrorMessage }
 					/>
 				) }

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -1,5 +1,5 @@
 import { DomainAvailabilityStatus, type BundleSuggestion } from '@automattic/api-core';
-import { render, screen, waitFor } from '@testing-library/react';
+import { getByText, queryByText, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { buildAvailability } from '../../test-helpers/factories/availability';
 import { buildCart, buildCartItem } from '../../test-helpers/factories/cart';
@@ -928,6 +928,113 @@ describe( 'ResultsPage', () => {
 					] ),
 				} )
 			);
+		} );
+
+		it( 'shows the server error message on the bundle card when adding the bundle fails', async () => {
+			const user = userEvent.setup();
+			const onAddBundle = jest
+				.fn()
+				.mockRejectedValue(
+					new Error(
+						'We can’t determine the availability of the domain you’re trying to register.'
+					)
+				);
+
+			mockGetSuggestionsQuery( {
+				params: { query: 'test-bundle-error' },
+				suggestions: [ buildSuggestion( { domain_name: 'test-bundle-error.com' } ) ],
+			} );
+
+			// Scoped to the render container because the error Notice also announces
+			// the message through the a11y-speak live region on document.body.
+			const { container } = render(
+				<TestDomainSearch
+					cart={ buildCart( { onAddBundle } ) }
+					config={ { showBundleSuggestions: true } }
+					query="test-bundle-error"
+				>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			await user.click( await screen.findByRole( 'button', { name: 'Get bundle' } ) );
+
+			await waitFor( () => {
+				expect(
+					getByText(
+						container,
+						'We can’t determine the availability of the domain you’re trying to register.'
+					)
+				).toBeInTheDocument();
+			} );
+		} );
+
+		it( 'shows a generic error message when the rejection has no usable message', async () => {
+			const user = userEvent.setup();
+			const onAddBundle = jest.fn().mockRejectedValue( new Error( '' ) );
+
+			mockGetSuggestionsQuery( {
+				params: { query: 'test-bundle-fallback' },
+				suggestions: [ buildSuggestion( { domain_name: 'test-bundle-fallback.com' } ) ],
+			} );
+
+			const { container } = render(
+				<TestDomainSearch
+					cart={ buildCart( { onAddBundle } ) }
+					config={ { showBundleSuggestions: true } }
+					query="test-bundle-fallback"
+				>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			await user.click( await screen.findByRole( 'button', { name: 'Get bundle' } ) );
+
+			await waitFor( () => {
+				expect(
+					getByText(
+						container,
+						'Sorry, we couldn’t add the bundle to your cart. Please try again.'
+					)
+				).toBeInTheDocument();
+			} );
+		} );
+
+		it( 'clears the error when retrying succeeds', async () => {
+			const user = userEvent.setup();
+			const onAddBundle = jest
+				.fn()
+				.mockRejectedValueOnce( new Error( 'Transient bundle error' ) )
+				.mockResolvedValueOnce( undefined );
+
+			mockGetSuggestionsQuery( {
+				params: { query: 'test-bundle-retry' },
+				suggestions: [ buildSuggestion( { domain_name: 'test-bundle-retry.com' } ) ],
+			} );
+
+			const { container } = render(
+				<TestDomainSearch
+					cart={ buildCart( { onAddBundle } ) }
+					config={ { showBundleSuggestions: true } }
+					query="test-bundle-retry"
+				>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			await user.click( await screen.findByRole( 'button', { name: 'Get bundle' } ) );
+
+			await waitFor( () => {
+				expect( getByText( container, 'Transient bundle error' ) ).toBeInTheDocument();
+			} );
+
+			await user.click( screen.getByRole( 'button', { name: 'Get bundle' } ) );
+
+			await waitFor( () => {
+				expect( queryByText( container, 'Transient bundle error' ) ).not.toBeInTheDocument();
+			} );
+
+			expect( onAddBundle ).toHaveBeenCalledTimes( 2 );
 		} );
 	} );
 

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -1036,6 +1036,136 @@ describe( 'ResultsPage', () => {
 
 			expect( onAddBundle ).toHaveBeenCalledTimes( 2 );
 		} );
+
+		it( 'clears the error when the search query changes', async () => {
+			const user = userEvent.setup();
+			const onAddBundle = jest.fn().mockRejectedValue( new Error( 'Stale bundle error' ) );
+			const cart = buildCart( { onAddBundle } );
+
+			mockGetSuggestionsQuery( {
+				params: { query: 'test-bundle-stale' },
+				suggestions: [ buildSuggestion( { domain_name: 'test-bundle-stale.com' } ) ],
+			} );
+			mockGetSuggestionsQuery( {
+				params: { query: 'test-bundle-fresh' },
+				suggestions: [ buildSuggestion( { domain_name: 'test-bundle-fresh.com' } ) ],
+			} );
+
+			const { container, rerender } = render(
+				<TestDomainSearch
+					cart={ cart }
+					config={ { showBundleSuggestions: true } }
+					query="test-bundle-stale"
+				>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			await user.click( await screen.findByRole( 'button', { name: 'Get bundle' } ) );
+
+			await waitFor( () => {
+				expect( getByText( container, 'Stale bundle error' ) ).toBeInTheDocument();
+			} );
+
+			// A new search renders a new bundle suggestion; the old failure
+			// shouldn't be pinned to it.
+			rerender(
+				<TestDomainSearch
+					cart={ cart }
+					config={ { showBundleSuggestions: true } }
+					query="test-bundle-fresh"
+				>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			await waitFor( () => {
+				expect( queryByText( container, 'Stale bundle error' ) ).not.toBeInTheDocument();
+			} );
+
+			expect( await screen.findByRole( 'button', { name: 'Get bundle' } ) ).toBeEnabled();
+		} );
+
+		it( 'disables the CTA while the bundle add is pending', async () => {
+			const user = userEvent.setup();
+			let resolveAdd = () => {};
+			const onAddBundle = jest.fn().mockImplementation(
+				() =>
+					new Promise< void >( ( resolve ) => {
+						resolveAdd = resolve;
+					} )
+			);
+
+			mockGetSuggestionsQuery( {
+				params: { query: 'test-bundle-pending' },
+				suggestions: [ buildSuggestion( { domain_name: 'test-bundle-pending.com' } ) ],
+			} );
+
+			render(
+				<TestDomainSearch
+					cart={ buildCart( { onAddBundle } ) }
+					config={ { showBundleSuggestions: true } }
+					query="test-bundle-pending"
+				>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			await user.click( await screen.findByRole( 'button', { name: 'Get bundle' } ) );
+
+			await waitFor( () => {
+				expect( screen.getByRole( 'button', { name: 'Get bundle' } ) ).toBeDisabled();
+			} );
+
+			resolveAdd();
+
+			await waitFor( () => {
+				expect( screen.getByRole( 'button', { name: 'Get bundle' } ) ).toBeEnabled();
+			} );
+
+			expect( onAddBundle ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'yields the bundle error when another add-to-cart mutation starts', async () => {
+			const user = userEvent.setup();
+			const onAddBundle = jest.fn().mockRejectedValue( new Error( 'Bundle add failed' ) );
+
+			mockGetSuggestionsQuery( {
+				params: { query: 'test-bundle-supersede' },
+				suggestions: [ buildSuggestion( { domain_name: 'test-bundle-supersede.com' } ) ],
+			} );
+			mockGetAvailabilityQuery( {
+				params: { domainName: 'test-bundle-supersede.com' },
+				availability: buildAvailability( {
+					domain_name: 'test-bundle-supersede.com',
+					status: DomainAvailabilityStatus.AVAILABLE,
+				} ),
+			} );
+
+			const { container } = render(
+				<TestDomainSearch
+					cart={ buildCart( { onAddBundle } ) }
+					config={ { showBundleSuggestions: true } }
+					query="test-bundle-supersede"
+				>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			await user.click( await screen.findByRole( 'button', { name: 'Get bundle' } ) );
+
+			await waitFor( () => {
+				expect( getByText( container, 'Bundle add failed' ) ).toBeInTheDocument();
+			} );
+
+			// The most recent mutation owns the error surface: starting a
+			// single-domain add supersedes the bundle failure.
+			await user.click( screen.getByRole( 'button', { name: 'Add to cart' } ) );
+
+			await waitFor( () => {
+				expect( queryByText( container, 'Bundle add failed' ) ).not.toBeInTheDocument();
+			} );
+		} );
 	} );
 
 	describe( 'bundle continue state', () => {

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -944,6 +944,10 @@ describe( 'ResultsPage', () => {
 				params: { query: 'test-bundle-error' },
 				suggestions: [ buildSuggestion( { domain_name: 'test-bundle-error.com' } ) ],
 			} );
+			mockGetBundleSuggestionQuery( {
+				params: { query: 'test-bundle-error' },
+				bundleSuggestion: buildBundleSuggestion( 'test-bundle-error' ),
+			} );
 
 			// Scoped to the render container because the error Notice also announces
 			// the message through the a11y-speak live region on document.body.
@@ -976,6 +980,10 @@ describe( 'ResultsPage', () => {
 			mockGetSuggestionsQuery( {
 				params: { query: 'test-bundle-fallback' },
 				suggestions: [ buildSuggestion( { domain_name: 'test-bundle-fallback.com' } ) ],
+			} );
+			mockGetBundleSuggestionQuery( {
+				params: { query: 'test-bundle-fallback' },
+				bundleSuggestion: buildBundleSuggestion( 'test-bundle-fallback' ),
 			} );
 
 			const { container } = render(
@@ -1010,6 +1018,10 @@ describe( 'ResultsPage', () => {
 			mockGetSuggestionsQuery( {
 				params: { query: 'test-bundle-retry' },
 				suggestions: [ buildSuggestion( { domain_name: 'test-bundle-retry.com' } ) ],
+			} );
+			mockGetBundleSuggestionQuery( {
+				params: { query: 'test-bundle-retry' },
+				bundleSuggestion: buildBundleSuggestion( 'test-bundle-retry' ),
 			} );
 
 			const { container } = render(
@@ -1046,9 +1058,17 @@ describe( 'ResultsPage', () => {
 				params: { query: 'test-bundle-stale' },
 				suggestions: [ buildSuggestion( { domain_name: 'test-bundle-stale.com' } ) ],
 			} );
+			mockGetBundleSuggestionQuery( {
+				params: { query: 'test-bundle-stale' },
+				bundleSuggestion: buildBundleSuggestion( 'test-bundle-stale' ),
+			} );
 			mockGetSuggestionsQuery( {
 				params: { query: 'test-bundle-fresh' },
 				suggestions: [ buildSuggestion( { domain_name: 'test-bundle-fresh.com' } ) ],
+			} );
+			mockGetBundleSuggestionQuery( {
+				params: { query: 'test-bundle-fresh' },
+				bundleSuggestion: buildBundleSuggestion( 'test-bundle-fresh' ),
 			} );
 
 			const { container, rerender } = render(
@@ -1100,6 +1120,10 @@ describe( 'ResultsPage', () => {
 				params: { query: 'test-bundle-pending' },
 				suggestions: [ buildSuggestion( { domain_name: 'test-bundle-pending.com' } ) ],
 			} );
+			mockGetBundleSuggestionQuery( {
+				params: { query: 'test-bundle-pending' },
+				bundleSuggestion: buildBundleSuggestion( 'test-bundle-pending' ),
+			} );
 
 			render(
 				<TestDomainSearch
@@ -1133,6 +1157,10 @@ describe( 'ResultsPage', () => {
 			mockGetSuggestionsQuery( {
 				params: { query: 'test-bundle-supersede' },
 				suggestions: [ buildSuggestion( { domain_name: 'test-bundle-supersede.com' } ) ],
+			} );
+			mockGetBundleSuggestionQuery( {
+				params: { query: 'test-bundle-supersede' },
+				bundleSuggestion: buildBundleSuggestion( 'test-bundle-supersede' ),
 			} );
 			mockGetAvailabilityQuery( {
 				params: { domainName: 'test-bundle-supersede.com' },


### PR DESCRIPTION
Related to #DOMAINS-2192

**Stacked on #111519 (DOMAINS-2190)** — review only the top two commits; the base commit is the CTA→cart wiring under review there.

## Proposed Changes

When the "Get bundle" add-to-cart fails, the user currently gets no feedback — the react-query mutation captures the rejection but `BundleCard` has no error slot. Found during manual testing: the cart validator rejected one member with a transient availability error, the response carried the message, and the UI showed nothing.

<img width="2304" height="832" alt="CleanShot 2026-06-11 at 11 21 02@2x" src="https://github.com/user-attachments/assets/f2b0621a-81bd-41b8-b50d-fde60fe9f3c8" />


This renders the failure inline on the card:

- `results.tsx` captures the bundle mutation's error (scoped with the same `meta.mutationId` pattern the sibling CTAs use) and passes an `errorMessage` to `BundleCard`.
- `BundleCard` gains an optional `errorMessage` prop and renders a non-dismissible error notice immediately above the CTA, using the package's `DomainSearchNotice` primitive. (`DomainSuggestionErrorCTA` wasn't reusable here: it requires the `DomainSuggestionsList` container context, which the bundle card isn't inside.)
- The message prefers the server's cart error (`CartActionError.message` from `replaceProductsInCart` is already user-facing copy), with a translated fallback: "Sorry, we couldn't add the bundle to your cart. Please try again."
- Retry is the CTA itself — clicking again re-fires the mutation, which resets the error state and clears the notice. Transient errors recover on retry, and the server remains the source of correctness (no client-side availability pre-check, per the issue). Clearing/refreshing the suggestion on *permanent* failures is deferred to DOMAINS-2193 — distinguishing permanent from transient needs more than `CartActionError`'s message-only payload (decision recorded on the Linear issue).
- New `WithError` Storybook variant in the BundleCard stories for design review.

The second commit addresses review findings:

- The bundle mutation resets when the search query changes, so a stale failure can't render on a new, unrelated bundle suggestion.
- The CTA mirrors the sibling single-domain CTA's pending treatment: `isBusy` while the bundle add is in flight, `disabled` while any cart mutation is running — no more overlapping `onAddBundle` calls from button-mashing.
- `useIsCurrentMutation` now subscribes to the mutation cache (`useSyncExternalStore`), so an error surface superseded by another component's mutation clears immediately instead of waiting for an incidental re-render. This also benefits the existing consumers (`suggestion-cta`, `full-cart`).

Zero changes outside `packages/domain-search`; no `calypso-config`/`calypso-analytics` imports (portability invariant).

## Testing Instructions

```
yarn test-packages packages/domain-search
```

30 suites / 340 tests pass (15 new): error renders with the server message, fallback on empty message, error clears on successful retry, error clears on a new search, error yields to a newer mutation, CTA disabled while the add is pending, no notice without an error.

Storybook: `WithError` variant under Components/BundleCard.

### Manual

Prerequisites: sandbox with `WPCOM_DOMAIN_BUNDLE_DISCOUNTS_ENABLED` on, `public-api.wordpress.com` sandboxed, logged in, `?flags=domain-bundling`.

1. Search an unregistered domain with a bundle-eligible TLD (.com/.net/.org/.co/.blog/.me/.inc/.llc) so the card renders. Use a fresh SLD — if the bundle is already in your cart the CTA shows Continue instead.
2. In devtools → Network, toggle **Offline** (do NOT use "Block request URL" — blocking leaves the wpcom proxy-iframe request permanently pending, so the promise never rejects and the CTA spins forever; that hang affects every cart op in Calypso and is a devtools artifact, not this PR).
3. Click **Get bundle** → red notice above the CTA ("Sorry, we couldn't add the bundle to your cart…"). CTA stays enabled.
4. Go back online, click again → notice clears, members land in the cart, CTA flips to Continue.
5. Busy state: throttle to Slow 3G — while the add is pending the CTA is busy/disabled.

Storybook visual: `yarn workspace @automattic/domain-search storybook:start` → Components/BundleCard → WithError.

