### PR TITLE
Reader: Fix bug where editor is stealing focus after coming back from full post

### DIFF
--- a/client/reader/components/quick-post/lazy.tsx
+++ b/client/reader/components/quick-post/lazy.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+import { useInView } from 'react-intersection-observer';
+import AsyncLoad from 'calypso/components/async-load';
+import { QuickPostSkeleton } from './skeleton';
+
+const loadQuickPost = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-reader-components-quick-post" */ 'calypso/reader/components/quick-post'
+	);
+
+// The composer renders a Gutenberg block editor inside an `editor-canvas`
+// iframe, which scrolls itself into view as it initializes — and because the
+// composer sits at the very top of the stream, that scrolls the whole page to
+// the top. When the stream remounts after a full post is closed, that scroll
+// races the stream's scroll restoration and occasionally wins, dumping the
+// reader back at the top of the feed (READ-133).
+//
+// Gate the iframe on visibility: it only mounts once its slot is on screen, so
+// when the user has scrolled past it — the exact situation the bug happens in —
+// the editor never mounts and never scrolls. We can't just read the scroll
+// position at mount: the stream restores scroll on a deferred timeout (see
+// `client/reader/stream/index.jsx`), so the page momentarily sits at the top
+// before jumping to the saved position. Skipping the observer until that
+// initial layout has settled keeps us from mounting the editor during that
+// transient top position.
+const SETTLE_DELAY_MS = 300;
+
+export function LazyQuickPost(): JSX.Element {
+	const [ hasSettled, setHasSettled ] = useState( false );
+	const { ref, inView } = useInView( {
+		triggerOnce: true,
+		skip: ! hasSettled,
+		rootMargin: '200px 0px',
+	} );
+
+	useEffect( () => {
+		const timer = setTimeout( () => setHasSettled( true ), SETTLE_DELAY_MS );
+		return () => clearTimeout( timer );
+	}, [] );
+
+	return (
+		<div ref={ ref } className="quick-post-lazy">
+			{ inView ? (
+				<AsyncLoad require={ loadQuickPost } placeholder={ <QuickPostSkeleton /> } />
+			) : (
+				<QuickPostSkeleton />
+			) }
+		</div>
+	);
+}

--- a/client/reader/components/quick-post/test/lazy.test.tsx
+++ b/client/reader/components/quick-post/test/lazy.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, act } from '@testing-library/react';
+import { LazyQuickPost } from '../lazy';
+
+let mockInView = false;
+const mockRef = jest.fn();
+const useInViewCalls: Array< { skip?: boolean } > = [];
+
+jest.mock( 'react-intersection-observer', () => ( {
+	useInView: ( opts: { skip?: boolean } ) => {
+		useInViewCalls.push( opts );
+		return { ref: mockRef, inView: mockInView };
+	},
+} ) );
+
+// AsyncLoad lazily imports the heavy editor chunk; stand in for the resolved
+// editor so we can assert when (and only when) it gets mounted.
+jest.mock( 'calypso/components/async-load', () => ( {
+	__esModule: true,
+	default: () => <div data-testid="quick-post-editor" />,
+} ) );
+
+jest.mock( '../skeleton', () => ( {
+	QuickPostSkeleton: () => <div data-testid="quick-post-skeleton" />,
+} ) );
+
+describe( 'LazyQuickPost', () => {
+	beforeEach( () => {
+		jest.useFakeTimers();
+		mockInView = false;
+		useInViewCalls.length = 0;
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	it( 'shows the skeleton and keeps the observer skipped until the initial layout settles', () => {
+		render( <LazyQuickPost /> );
+
+		expect( screen.getByTestId( 'quick-post-skeleton' ) ).toBeVisible();
+		expect( screen.queryByTestId( 'quick-post-editor' ) ).not.toBeInTheDocument();
+		expect( useInViewCalls[ useInViewCalls.length - 1 ].skip ).toBe( true );
+	} );
+
+	it( 'starts observing once the initial layout has settled', () => {
+		render( <LazyQuickPost /> );
+
+		act( () => {
+			jest.advanceTimersByTime( 300 );
+		} );
+
+		expect( useInViewCalls[ useInViewCalls.length - 1 ].skip ).toBe( false );
+	} );
+
+	it( 'mounts the editor only once the settled slot is in view', () => {
+		render( <LazyQuickPost /> );
+
+		// Slot is on screen, but the editor should wait for the layout to settle.
+		mockInView = true;
+		act( () => {
+			jest.advanceTimersByTime( 300 );
+		} );
+
+		expect( screen.getByTestId( 'quick-post-editor' ) ).toBeVisible();
+		expect( screen.queryByTestId( 'quick-post-skeleton' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/reader/following/main.tsx
+++ b/client/reader/following/main.tsx
@@ -6,7 +6,7 @@ import AsyncLoad from 'calypso/components/async-load';
 import BloganuaryHeader from 'calypso/components/bloganuary-header';
 import NavigationHeader from 'calypso/components/navigation-header';
 import ResurrectedWelcomeModalGate from 'calypso/components/resurrected-welcome-modal';
-import { QuickPostSkeleton } from 'calypso/reader/components/quick-post/skeleton';
+import { LazyQuickPost } from 'calypso/reader/components/quick-post/lazy';
 import ReaderOnboardingGate from 'calypso/reader/onboarding/gate';
 import SuggestionProvider from 'calypso/reader/search-stream/suggestion-provider';
 import ReaderStream from 'calypso/reader/stream';
@@ -18,10 +18,6 @@ import { useFollowingView } from './view-preference';
 import ViewToggle from './view-toggle';
 import './style.scss';
 
-const loadQuickPost = () =>
-	import(
-		/* webpackChunkName: "async-load-calypso-reader-components-quick-post" */ 'calypso/reader/components/quick-post'
-	);
 const loadTrackResurrections = () =>
 	import(
 		/* webpackChunkName: "async-load-calypso-lib-analytics-track-resurrections" */ 'calypso/lib/analytics/track-resurrections'
@@ -85,7 +81,7 @@ function FollowingStream( { ...props } ) {
 					{ hasSites && (
 						<Card className="following-stream__quick-post-card">
 							<CardBody>
-								<AsyncLoad require={ loadQuickPost } placeholder={ <QuickPostSkeleton /> } />
+								<LazyQuickPost />
 							</CardBody>
 						</Card>
 					) }

--- a/client/reader/on-this-day/main.tsx
+++ b/client/reader/on-this-day/main.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
 import NavigationHeader from 'calypso/components/navigation-header';
 import ResurrectedWelcomeModalGate from 'calypso/components/resurrected-welcome-modal';
-import { QuickPostSkeleton } from 'calypso/reader/components/quick-post/skeleton';
+import { LazyQuickPost } from 'calypso/reader/components/quick-post/lazy';
 import ReaderOnboardingGate from 'calypso/reader/onboarding/gate';
 import SuggestionProvider from 'calypso/reader/search-stream/suggestion-provider';
 import ReaderStream from 'calypso/reader/stream';
@@ -18,10 +18,6 @@ import { getOnThisDayStreamKey } from './get-stream-key';
 import { OnThisDay } from './index';
 import '../following/style.scss';
 
-const loadQuickPost = () =>
-	import(
-		/* webpackChunkName: "async-load-calypso-reader-components-quick-post" */ 'calypso/reader/components/quick-post'
-	);
 const loadTrackResurrections = () =>
 	import(
 		/* webpackChunkName: "async-load-calypso-lib-analytics-track-resurrections" */ 'calypso/lib/analytics/track-resurrections'
@@ -80,7 +76,7 @@ function OnThisDayStream() {
 					{ hasSites && (
 						<Card className="following-stream__quick-post-card">
 							<CardBody>
-								<AsyncLoad require={ loadQuickPost } placeholder={ <QuickPostSkeleton /> } />
+								<LazyQuickPost />
 							</CardBody>
 						</Card>
 					) }


### PR DESCRIPTION
Fixes READ-133
Fixes READ-295

## Proposed Changes

* Add a visibility-gated loader (`LazyQuickPost`) for the Reader stream's QuickPost composer: the Gutenberg `editor-canvas` iframe is now only mounted once its slot is actually on screen.
* Wire it into both stream entry points that render the composer (`following/main.tsx` and `on-this-day/main.tsx`), deduping the previously copy-pasted async loader.
* Add unit tests for the new component.

## Why are these changes being made?

The QuickPost composer sits at the very top of the Recents/Following stream and mounts a full block editor inside an `editor-canvas` iframe. As that iframe initializes it scrolls itself into view, which scrolls the whole page to the top.

When you open a post and click back, the stream remounts and restores your scroll position on a deferred timeout. The composer iframe re-initializes around the same time, and the two scrolls race — when the iframe wins, you get yanked back to the top of the feed instead of your previous position. It's intermittent (~1 in 5) because it's purely timing-dependent, and it affects regular posts too, not just recommended ones.

The composer lives at the top of the stream, so it is always offscreen exactly when this bug fires. Gating the iframe on visibility means it never mounts (and never scrolls) while the user has scrolled past it. When the composer *is* on screen (user at the top), a scroll-to-top is a harmless no-op. This also sidesteps the issue regardless of whether the disruption comes from `scrollIntoView` or a focus grab — there's simply no iframe present to do either.

The observer is skipped for a short settle window after mount so it isn't fooled by the transient `scrollY === 0` that exists before the stream's deferred scroll restoration runs.

## Testing Instructions

* Open the Reader and switch to the Recent list view (the one showing the QuickPost composer at the top).
* Scroll down until the recommended-posts section (or any post well down the feed) is visible.
* Open a post, then click the back button. Repeat ~10 times.
* **Expected:** you return to your previous scroll position.
* Separately, confirm the composer still loads and works normally when you're at the top of the feed (write a post, publish, open the full editor).