### PR TITLE
WIP- Reader onboarding - add email settings step

### DIFF
--- a/client/reader/onboarding-rsm/constants.tsx
+++ b/client/reader/onboarding-rsm/constants.tsx
@@ -1,5 +1,9 @@
 export const READER_ONBOARDING_PREFERENCE_KEY = 'has_completed_reader_onboarding';
 export const READER_ONBOARDING_SEEN_PREFERENCE_KEY = 'has_seen_reader_onboarding';
+// Saved when the user clicks Continue on the email-settings step; marks the
+// step's checklist task complete.
+export const READER_ONBOARDING_EMAIL_SETTINGS_PREFERENCE_KEY =
+	'has_completed_reader_onboarding_email_settings';
 export const READER_ONBOARDING_TRACKS_EVENT_PREFIX = 'calypso_reader_onboarding_';
 
 // Minimum followed counts that mark the interests/discover checklist tasks

--- a/client/reader/onboarding-rsm/email-settings-modal/index.tsx
+++ b/client/reader/onboarding-rsm/email-settings-modal/index.tsx
@@ -1,0 +1,329 @@
+import { updateUserSettings, type UserSettings } from '@automattic/api-core';
+import { userSettingsQuery } from '@automattic/api-queries';
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import {
+	applyDeliveryWindowEdit,
+	getDeliveryHourPickerHours,
+	getDisplayDeliveryWindow,
+	useDeliveryWindowTimezone,
+} from '@automattic/i18n-utils';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+	Button,
+	Notice,
+	SelectControl,
+	Spinner,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import React, { useEffect, useRef, useState } from 'react';
+import { READER_ONBOARDING_TRACKS_EVENT_PREFIX } from 'calypso/reader/onboarding-rsm/constants';
+import { StepIndicator } from 'calypso/reader/onboarding-rsm/step-indicator';
+
+import './style.scss';
+
+// Time the user has to keep changing settings before the accumulated edits
+// are auto-saved to /me/settings. Any pending edits are also flushed when
+// the user clicks Continue or leaves the step.
+const SAVE_DEBOUNCE_MS = 800;
+
+type EmailSettings = Pick<
+	UserSettings,
+	| 'subscription_delivery_email_default'
+	| 'subscription_delivery_mail_option'
+	| 'subscription_delivery_day'
+	| 'subscription_delivery_hour'
+>;
+
+/**
+ * Format the date to the user's local time, including or not the AM/PM
+ * suffix depending on the user's locale.
+ */
+const formatDateToLocalTime = ( date: Date ) => {
+	// undefined means it should use the user locale.
+	const userLocale = undefined;
+	return new Intl.DateTimeFormat( userLocale, {
+		hour: '2-digit',
+		minute: '2-digit',
+	} ).format( date );
+};
+
+const padHour = ( hour: number ) => String( hour % 24 ).padStart( 2, '0' );
+
+type SelectOption = { label: string; value: string };
+
+// Built at render time (not module scope) so the labels pick up the user's
+// locale. Explicitly typed so SelectControl treats values as plain strings
+// rather than inferring a literal union that the UserSettings types don't
+// satisfy.
+const getFrequencyOptions = (): SelectOption[] => [
+	{ label: __( 'Never send email' ), value: 'never' },
+	{ label: __( 'Send email instantly' ), value: 'instantly' },
+	{ label: __( 'Send email daily' ), value: 'daily' },
+	{ label: __( 'Send email every week' ), value: 'weekly' },
+];
+
+const getFormatOptions = (): SelectOption[] => [
+	{ label: __( 'HTML' ), value: 'html' },
+	{ label: __( 'Plain text' ), value: 'text' },
+];
+
+const getDayOptions = (): SelectOption[] => [
+	{ label: __( 'Sunday' ), value: '0' },
+	{ label: __( 'Monday' ), value: '1' },
+	{ label: __( 'Tuesday' ), value: '2' },
+	{ label: __( 'Wednesday' ), value: '3' },
+	{ label: __( 'Thursday' ), value: '4' },
+	{ label: __( 'Friday' ), value: '5' },
+	{ label: __( 'Saturday' ), value: '6' },
+];
+
+// The delivery hour buckets are stored/sent as UTC. We display them in the
+// device's local time, falling back to clearly labeled UTC when the time zone
+// can't be detected.
+const buildDeliveryHourOptions = ( isUtcFallback: boolean, displayHour: number ) =>
+	getDeliveryHourPickerHours( displayHour, isUtcFallback ).map( ( startHour ) => {
+		const endHour = startHour + 2;
+
+		if ( isUtcFallback ) {
+			return {
+				label: sprintf(
+					// translators: %(fromHour)s and %(toHour)s are hours on a 24-hour clock, e.g. 08 and 10. UTC is the time zone.
+					__( '%(fromHour)s:00 - %(toHour)s:00 UTC' ),
+					{
+						fromHour: padHour( startHour ),
+						toHour: padHour( endHour ),
+					}
+				),
+				value: String( startHour ),
+			};
+		}
+
+		return {
+			label: [
+				formatDateToLocalTime( new Date( 0, 0, 0, startHour, 0 ) ),
+				formatDateToLocalTime( new Date( 0, 0, 0, endHour, 0 ) ),
+			].join( ' - ' ),
+			value: String( startHour ),
+		};
+	} );
+
+interface EmailSettingsModalProps {
+	onContinue: () => void;
+}
+
+// Renders the body of the "email settings" step. The shared <Modal> wrapper
+// is provided by the parent (`ReaderOnboardingRsm`); this component is only
+// mounted while the step is active. X-out / escape are handled by the
+// wrapper's `onRequestClose`.
+export const EmailSettingsModal = ( { onContinue }: EmailSettingsModalProps ) => {
+	const queryClient = useQueryClient();
+	const { data: userSettings } = useQuery( userSettingsQuery() );
+	const { offsetHours, isUtcFallback, timezone } = useDeliveryWindowTimezone();
+
+	// Local working copy of the subscription settings. Seeded once from the
+	// settings query; window values (hour/day) are kept in UTC just like the
+	// backend stores them, and converted to local time for display only.
+	const [ settings, setSettings ] = useState< EmailSettings | null >( null );
+	const [ showSaveError, setShowSaveError ] = useState( false );
+	const pendingChangesRef = useRef< Partial< EmailSettings > >( {} );
+	const saveTimerRef = useRef< ReturnType< typeof setTimeout > | null >( null );
+
+	useEffect( () => {
+		if ( settings !== null || ! userSettings ) {
+			return;
+		}
+		setSettings( {
+			subscription_delivery_email_default: userSettings.subscription_delivery_email_default,
+			subscription_delivery_mail_option: userSettings.subscription_delivery_mail_option,
+			subscription_delivery_day: Number( userSettings.subscription_delivery_day ?? 0 ),
+			subscription_delivery_hour: Number( userSettings.subscription_delivery_hour ?? 0 ),
+		} );
+	}, [ settings, userSettings ] );
+
+	// `userSettingsMutation()` from api-queries writes to that package's
+	// singleton query client, which is not the client Calypso classic boots
+	// with — define the mutation locally against the contextual client so the
+	// cache the rest of the app reads actually gets the merged response.
+	const { mutate: saveSettings } = useMutation( {
+		mutationFn: updateUserSettings,
+		onSuccess: ( newData ) => {
+			queryClient.setQueryData(
+				userSettingsQuery().queryKey,
+				( oldData ) =>
+					oldData && {
+						...oldData,
+						...newData,
+					}
+			);
+		},
+		onError: () => setShowSaveError( true ),
+	} );
+
+	const flushPendingSave = () => {
+		if ( saveTimerRef.current !== null ) {
+			clearTimeout( saveTimerRef.current );
+			saveTimerRef.current = null;
+		}
+		const changes = pendingChangesRef.current;
+		if ( Object.keys( changes ).length === 0 ) {
+			return;
+		}
+		pendingChangesRef.current = {};
+		saveSettings( changes );
+		Object.entries( changes ).forEach( ( [ key, value ] ) => {
+			recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }email_settings_updated`, {
+				setting_name: key,
+				setting_value: String( value ),
+			} );
+		} );
+	};
+
+	// Keep a ref to the latest flush so the unmount cleanup (and the debounce
+	// timer) always run the current closure rather than a stale one.
+	const flushPendingSaveRef = useRef( flushPendingSave );
+	flushPendingSaveRef.current = flushPendingSave;
+
+	// Flush any pending (debounced) edits when the step unmounts — e.g. the
+	// user dismisses the modal or navigates Back before the debounce fires.
+	useEffect( () => () => flushPendingSaveRef.current(), [] );
+
+	const handleChange = ( edit: Partial< EmailSettings > ) => {
+		setShowSaveError( false );
+		setSettings( ( current ) => current && { ...current, ...edit } );
+		pendingChangesRef.current = { ...pendingChangesRef.current, ...edit };
+		if ( saveTimerRef.current !== null ) {
+			clearTimeout( saveTimerRef.current );
+		}
+		saveTimerRef.current = setTimeout( () => {
+			saveTimerRef.current = null;
+			flushPendingSaveRef.current();
+		}, SAVE_DEBOUNCE_MS );
+	};
+
+	const handleContinue = () => {
+		flushPendingSave();
+		onContinue();
+	};
+
+	const storedUtc = settings && {
+		hour: Number( settings.subscription_delivery_hour ),
+		day: Number( settings.subscription_delivery_day ),
+	};
+	const displayWindow = storedUtc && getDisplayDeliveryWindow( storedUtc, offsetHours );
+
+	const handleWindowChange = ( edit: Partial< { hour: number; day: number } > ) => {
+		if ( ! storedUtc ) {
+			return;
+		}
+		const utc = applyDeliveryWindowEdit( storedUtc, edit, offsetHours );
+		handleChange( {
+			subscription_delivery_hour: utc.hour,
+			subscription_delivery_day: utc.day,
+		} );
+	};
+
+	const deliveryFrequency = settings?.subscription_delivery_email_default;
+	const showFormat = !! deliveryFrequency && deliveryFrequency !== 'never';
+	const showHour = deliveryFrequency === 'daily' || deliveryFrequency === 'weekly';
+	const showDay = deliveryFrequency === 'weekly';
+
+	return (
+		<>
+			<VStack spacing={ 6 } className="email-settings-modal__content">
+				<VStack spacing={ 0 }>
+					<h2 className="email-settings-modal__title">{ __( 'Choose your delivery settings' ) }</h2>
+					<p className="email-settings-modal__subtitle">
+						{ __(
+							'Please choose the default email settings for new posts from sites you subscribe to. Default settings are applied when subscribing to a site. These preferences can also be adjusted on a per-site basis in the subscriptions management page.'
+						) }
+					</p>
+				</VStack>
+
+				{ showSaveError && (
+					<Notice
+						className="email-settings-modal__error-notice"
+						status="error"
+						isDismissible
+						onRemove={ () => setShowSaveError( false ) }
+					>
+						{ __( 'Failed to save your email settings. Please try again.' ) }
+					</Notice>
+				) }
+
+				{ ! settings && (
+					<HStack justify="center" className="email-settings-modal__loading">
+						<Spinner />
+					</HStack>
+				) }
+
+				{ settings && displayWindow && (
+					<VStack spacing={ 4 } className="email-settings-modal__form">
+						<SelectControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							label={ __( 'Default email delivery' ) }
+							value={ settings.subscription_delivery_email_default }
+							options={ getFrequencyOptions() }
+							onChange={ ( value ) =>
+								handleChange( { subscription_delivery_email_default: value } )
+							}
+						/>
+
+						{ showFormat && (
+							<SelectControl
+								__next40pxDefaultSize
+								__nextHasNoMarginBottom
+								label={ __( 'Email delivery format' ) }
+								value={ settings.subscription_delivery_mail_option }
+								options={ getFormatOptions() }
+								onChange={ ( value ) =>
+									handleChange( { subscription_delivery_mail_option: value } )
+								}
+							/>
+						) }
+
+						{ showHour && (
+							<SelectControl
+								__next40pxDefaultSize
+								__nextHasNoMarginBottom
+								label={ __( 'Email delivery time' ) }
+								value={ String( displayWindow.hour ) }
+								options={ buildDeliveryHourOptions( isUtcFallback, displayWindow.hour ) }
+								help={ sprintf(
+									// translators: %(timezone)s is the timezone E.g. America/New_York, or UTC when the device time zone is unknown.
+									__( 'Timezone: %(timezone)s' ),
+									{ timezone: isUtcFallback || ! timezone ? 'UTC' : timezone }
+								) }
+								onChange={ ( value ) => handleWindowChange( { hour: Number( value ) } ) }
+							/>
+						) }
+
+						{ showDay && (
+							<SelectControl
+								__next40pxDefaultSize
+								__nextHasNoMarginBottom
+								label={ __( 'Email delivery day' ) }
+								value={ String( displayWindow.day ) }
+								options={ getDayOptions() }
+								onChange={ ( value ) => handleWindowChange( { day: Number( value ) } ) }
+							/>
+						) }
+					</VStack>
+				) }
+			</VStack>
+
+			<div className="reader-onboarding-modal__footer">
+				<HStack justify="space-between" className="reader-onboarding-modal__footer-actions">
+					<StepIndicator totalSteps={ 4 } currentStep={ 2 } />
+					<HStack spacing={ 2 } justify="right" className="reader-onboarding-modal__footer-buttons">
+						<Button __next40pxDefaultSize variant="primary" onClick={ handleContinue }>
+							{ __( 'Continue' ) }
+						</Button>
+					</HStack>
+				</HStack>
+			</div>
+		</>
+	);
+};

--- a/client/reader/onboarding-rsm/email-settings-modal/style.scss
+++ b/client/reader/onboarding-rsm/email-settings-modal/style.scss
@@ -1,0 +1,38 @@
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
+
+// Frame sizing, the WP modal flex layout, the VStack scroll region, and the
+// footer of `.email-settings-modal` are shared with the other onboarding-rsm
+// modals; see `client/reader/onboarding-rsm/style.scss`.
+
+.email-settings-modal__content {
+	padding: 4px 32px 12px;
+}
+
+.email-settings-modal__title {
+	font-family: Recoleta, sans-serif;
+	font-size: 2.75rem;
+	font-weight: 400;
+	text-align: center;
+
+	@media ( max-width: $break-medium ) {
+		font-size: 1.5rem;
+	}
+}
+
+.email-settings-modal__subtitle {
+	text-align: center;
+	margin: 0 auto;
+	max-width: 640px;
+}
+
+.email-settings-modal__form,
+.email-settings-modal__error-notice {
+	width: 100%;
+	max-width: 420px;
+	margin-inline: auto;
+}
+
+.email-settings-modal__loading {
+	padding-block: 32px;
+}

--- a/client/reader/onboarding-rsm/email-settings-modal/test/index.test.tsx
+++ b/client/reader/onboarding-rsm/email-settings-modal/test/index.test.tsx
@@ -1,0 +1,236 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient } from '@tanstack/react-query';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import React from 'react';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { EmailSettingsModal } from '../index';
+
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	recordTracksEvent: jest.fn(),
+} ) );
+
+// Fix the device timezone so the local↔UTC delivery-window conversion is
+// deterministic in tests: UTC-4 (America/New_York during EDT).
+jest.mock( '@automattic/i18n-utils', () => {
+	const actual = jest.requireActual( '@automattic/i18n-utils' );
+	return {
+		...actual,
+		useDeliveryWindowTimezone: () => ( {
+			timezone: 'America/New_York',
+			offsetHours: -4,
+			isUtcFallback: false,
+		} ),
+	};
+} );
+
+const API_ROOT = 'https://public-api.wordpress.com';
+const SETTINGS_PATH = '/rest/v1.1/me/settings';
+
+const mockSettings = ( overrides: Record< string, unknown > = {} ) => ( {
+	subscription_delivery_email_default: 'never',
+	subscription_delivery_mail_option: 'html',
+	subscription_delivery_day: 0,
+	subscription_delivery_hour: 8,
+	...overrides,
+} );
+
+const nockGetSettings = ( overrides: Record< string, unknown > = {} ) =>
+	nock( API_ROOT ).get( SETTINGS_PATH ).reply( 200, mockSettings( overrides ) );
+
+// Captures every POST body so tests can assert what was saved and that
+// rapid edits coalesce into a single request.
+const nockPostSettings = ( { status = 200 }: { status?: number } = {} ) => {
+	const bodies: Record< string, unknown >[] = [];
+	nock( API_ROOT )
+		.post( SETTINGS_PATH, ( body ) => {
+			bodies.push( body as Record< string, unknown > );
+			return true;
+		} )
+		.reply( status, {} )
+		.persist();
+	return bodies;
+};
+
+const getQueryClient = () => {
+	const instance = new QueryClient();
+	instance.setDefaultOptions( {
+		queries: {
+			retry: false,
+		},
+	} );
+	return instance;
+};
+
+const renderModal = ( onContinue: () => void = jest.fn() ) =>
+	renderWithProvider( <EmailSettingsModal onContinue={ onContinue } />, {
+		queryClient: getQueryClient(),
+	} );
+
+const findFrequencySelect = () =>
+	screen.findByRole( 'combobox', { name: 'Default email delivery' } );
+
+describe( 'EmailSettingsModal', () => {
+	beforeAll( () => {
+		nock.disableNetConnect();
+	} );
+
+	beforeEach( () => {
+		nock.cleanAll();
+	} );
+
+	it( 'renders the title and description', async () => {
+		nockGetSettings();
+		renderModal();
+
+		expect(
+			screen.getByRole( 'heading', { name: 'Choose your delivery settings' } )
+		).toBeVisible();
+		expect(
+			screen.getByText( /Please choose the default email settings for new posts/ )
+		).toBeVisible();
+		expect( await findFrequencySelect() ).toBeVisible();
+	} );
+
+	it( 'shows only the delivery frequency select when delivery is set to never', async () => {
+		nockGetSettings();
+		renderModal();
+
+		expect( await findFrequencySelect() ).toHaveValue( 'never' );
+		expect(
+			screen.queryByRole( 'combobox', { name: 'Email delivery format' } )
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'combobox', { name: 'Email delivery time' } )
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'combobox', { name: 'Email delivery day' } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'reveals only the fields relevant to the selected frequency', async () => {
+		nockGetSettings();
+		nockPostSettings();
+		const user = userEvent.setup();
+		renderModal();
+
+		const frequency = await findFrequencySelect();
+
+		await user.selectOptions( frequency, 'instantly' );
+		expect( screen.getByRole( 'combobox', { name: 'Email delivery format' } ) ).toBeVisible();
+		expect(
+			screen.queryByRole( 'combobox', { name: 'Email delivery time' } )
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'combobox', { name: 'Email delivery day' } )
+		).not.toBeInTheDocument();
+
+		await user.selectOptions( frequency, 'daily' );
+		expect( screen.getByRole( 'combobox', { name: 'Email delivery format' } ) ).toBeVisible();
+		expect( screen.getByRole( 'combobox', { name: 'Email delivery time' } ) ).toBeVisible();
+		expect(
+			screen.queryByRole( 'combobox', { name: 'Email delivery day' } )
+		).not.toBeInTheDocument();
+
+		await user.selectOptions( frequency, 'weekly' );
+		expect( screen.getByRole( 'combobox', { name: 'Email delivery format' } ) ).toBeVisible();
+		expect( screen.getByRole( 'combobox', { name: 'Email delivery time' } ) ).toBeVisible();
+		expect( screen.getByRole( 'combobox', { name: 'Email delivery day' } ) ).toBeVisible();
+	} );
+
+	it( 'displays the stored UTC delivery window in local time', async () => {
+		// Stored UTC hour 8 with a -4 offset displays as the 04:00 local bucket.
+		nockGetSettings( { subscription_delivery_email_default: 'weekly' } );
+		renderModal();
+
+		expect( await screen.findByRole( 'combobox', { name: 'Email delivery time' } ) ).toHaveValue(
+			'4'
+		);
+		expect( screen.getByRole( 'combobox', { name: 'Email delivery day' } ) ).toHaveValue( '0' );
+		expect( screen.getByText( 'Timezone: America/New_York' ) ).toBeVisible();
+	} );
+
+	it( 'debounce-saves edits as a single request with the delivery window converted to UTC', async () => {
+		nockGetSettings( { subscription_delivery_email_default: 'daily' } );
+		const postBodies = nockPostSettings();
+		const user = userEvent.setup();
+		renderModal();
+
+		// Local 20:00 with a -4 offset is 00:00 UTC the next day, so the day
+		// wraps from Sunday (0) to Monday (1).
+		await user.selectOptions( await findFrequencySelect(), 'weekly' );
+		await user.selectOptions(
+			screen.getByRole( 'combobox', { name: 'Email delivery time' } ),
+			'20'
+		);
+
+		await waitFor(
+			() => {
+				expect( postBodies ).toHaveLength( 1 );
+			},
+			{ timeout: 3000 }
+		);
+
+		expect( postBodies[ 0 ] ).toMatchObject( {
+			subscription_delivery_email_default: 'weekly',
+			subscription_delivery_hour: 0,
+			subscription_delivery_day: 1,
+		} );
+	} );
+
+	it( 'flushes the pending save immediately and advances when Continue is clicked', async () => {
+		nockGetSettings( { subscription_delivery_email_default: 'instantly' } );
+		const postBodies = nockPostSettings();
+		const onContinue = jest.fn();
+		const user = userEvent.setup();
+		renderModal( onContinue );
+
+		await user.selectOptions(
+			await screen.findByRole( 'combobox', { name: 'Email delivery format' } ),
+			'text'
+		);
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
+
+		expect( onContinue ).toHaveBeenCalledTimes( 1 );
+		// The save fires synchronously on Continue, well before the debounce
+		// would have elapsed.
+		expect( postBodies ).toHaveLength( 1 );
+		expect( postBodies[ 0 ] ).toMatchObject( { subscription_delivery_mail_option: 'text' } );
+	} );
+
+	it( 'still advances on Continue when nothing was changed, without saving', async () => {
+		nockGetSettings();
+		const postBodies = nockPostSettings();
+		const onContinue = jest.fn();
+		const user = userEvent.setup();
+		renderModal( onContinue );
+
+		await findFrequencySelect();
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
+
+		expect( onContinue ).toHaveBeenCalledTimes( 1 );
+		expect( postBodies ).toHaveLength( 0 );
+	} );
+
+	it( 'shows an error notice when saving fails', async () => {
+		nockGetSettings();
+		nockPostSettings( { status: 500 } );
+		const user = userEvent.setup();
+		renderModal();
+
+		await user.selectOptions( await findFrequencySelect(), 'instantly' );
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
+
+		// The message also lands in the hidden a11y-speak live region, so scope
+		// the query to the visible notice content.
+		expect(
+			await screen.findByText( 'Failed to save your email settings. Please try again.', {
+				selector: '.components-notice__content',
+			} )
+		).toBeVisible();
+	} );
+} );

--- a/client/reader/onboarding-rsm/index.tsx
+++ b/client/reader/onboarding-rsm/index.tsx
@@ -15,12 +15,14 @@ import { useSiteSubscriptions as useCachedSiteSubscriptions } from 'calypso/read
 import { useFollowedTags } from 'calypso/reader/data/tags';
 import {
 	READER_ONBOARDING_ELIGIBLE_REGISTRATION_DATE,
+	READER_ONBOARDING_EMAIL_SETTINGS_PREFERENCE_KEY,
 	READER_ONBOARDING_MIN_FOLLOWED_SITES,
 	READER_ONBOARDING_MIN_FOLLOWED_TAGS,
 	READER_ONBOARDING_SEEN_PREFERENCE_KEY,
 	READER_ONBOARDING_PREFERENCE_KEY,
 	READER_ONBOARDING_TRACKS_EVENT_PREFIX,
 } from 'calypso/reader/onboarding-rsm/constants';
+import { EmailSettingsModal } from 'calypso/reader/onboarding-rsm/email-settings-modal';
 import InterestsModal from 'calypso/reader/onboarding-rsm/interests-modal';
 import { getPackBlogs } from 'calypso/reader/onboarding-rsm/interests-modal/get-pack-blogs';
 import { getTopicGroups } from 'calypso/reader/onboarding-rsm/interests-modal/topic-groups';
@@ -43,10 +45,11 @@ import './style.scss';
 // them feel seamless (no close/open animation between steps). The active
 // step's body is rendered as the only child of the shared modal; the
 // per-step CSS class on the modal frame keeps existing styles working.
-type Step = 'welcome' | 'interests' | 'discover';
+type Step = 'welcome' | 'email-settings' | 'interests' | 'discover';
 
 const STEP_FRAME_CLASS: Record< Step, string > = {
 	welcome: 'reader-welcome-modal',
+	'email-settings': 'email-settings-modal',
 	interests: 'interests-modal',
 	discover: 'subscribe-modal',
 };
@@ -106,6 +109,9 @@ const ReaderOnboardingRsm = ( {
 	);
 	const hasSeenOnboarding: boolean | null = useSelector( ( state ) =>
 		getPreference( state, READER_ONBOARDING_SEEN_PREFERENCE_KEY )
+	);
+	const hasCompletedEmailSettingsStep: boolean | null = useSelector( ( state ) =>
+		getPreference( state, READER_ONBOARDING_EMAIL_SETTINGS_PREFERENCE_KEY )
 	);
 
 	const hasFollowedTags = ( followedTags?.length ?? 0 ) >= READER_ONBOARDING_MIN_FOLLOWED_TAGS;
@@ -253,6 +259,8 @@ const ReaderOnboardingRsm = ( {
 	const recordStepClose = ( step: Step ) => {
 		if ( step === 'welcome' ) {
 			recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }welcome_modal_close` );
+		} else if ( step === 'email-settings' ) {
+			recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }email_settings_modal_close` );
 		} else if ( step === 'interests' ) {
 			recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }interests_modal_close` );
 		} else if ( step === 'discover' ) {
@@ -263,6 +271,8 @@ const ReaderOnboardingRsm = ( {
 	const recordStepOpen = ( step: Step ) => {
 		if ( step === 'welcome' ) {
 			recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }welcome_modal_open` );
+		} else if ( step === 'email-settings' ) {
+			recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }email_settings_modal_open` );
 		} else if ( step === 'interests' ) {
 			recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }interests_modal_open` );
 		} else if ( step === 'discover' ) {
@@ -286,8 +296,26 @@ const ReaderOnboardingRsm = ( {
 	const handleWelcomeContinue = () => {
 		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }welcome_modal_continue` );
 		runStepSideEffects( 'welcome' );
+		recordStepOpen( 'email-settings' );
+		setCurrentStep( 'email-settings' );
+	};
+
+	const handleEmailSettingsContinue = () => {
+		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }email_settings_modal_continue` );
+		runStepSideEffects( 'email-settings' );
+		// Continue marks the step's checklist task complete; the settings
+		// themselves are auto-saved by the step as they change.
+		if ( ! hasCompletedEmailSettingsStep ) {
+			dispatch( savePreference( READER_ONBOARDING_EMAIL_SETTINGS_PREFERENCE_KEY, true ) );
+		}
 		recordStepOpen( 'interests' );
 		setCurrentStep( 'interests' );
+	};
+
+	const handleEmailSettingsBack = () => {
+		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }email_settings_modal_back` );
+		runStepSideEffects( 'email-settings' );
+		openStep( 'welcome' );
 	};
 
 	const handleInterestsContinue = () => {
@@ -300,7 +328,7 @@ const ReaderOnboardingRsm = ( {
 	const handleInterestsBack = () => {
 		recordTracksEvent( `${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }interests_modal_back` );
 		runStepSideEffects( 'interests' );
-		openStep( 'welcome' );
+		openStep( 'email-settings' );
 	};
 
 	const handleDiscoverBack = () => {
@@ -381,6 +409,13 @@ const ReaderOnboardingRsm = ( {
 			disabled: false,
 		},
 		{
+			id: 'email-settings',
+			title: translate( 'Choose your delivery settings' ),
+			actionDispatch: () => openStep( 'email-settings' ),
+			completed: !! hasCompletedEmailSettingsStep,
+			disabled: false,
+		},
+		{
 			id: 'select-interests',
 			title: translate( 'Select some of your interests' ),
 			actionDispatch: () => openStep( 'interests' ),
@@ -400,7 +435,17 @@ const ReaderOnboardingRsm = ( {
 	];
 
 	let modalBackButton = null;
-	if ( currentStep === 'interests' ) {
+	if ( currentStep === 'email-settings' ) {
+		modalBackButton = (
+			<Button
+				size="compact"
+				className="reader-onboarding-modal__back-button"
+				onClick={ handleEmailSettingsBack }
+				icon={ chevronLeft }
+				label={ __( 'Back' ) }
+			/>
+		);
+	} else if ( currentStep === 'interests' ) {
 		modalBackButton = (
 			<Button
 				size="compact"
@@ -460,6 +505,9 @@ const ReaderOnboardingRsm = ( {
 				>
 					{ currentStep === 'welcome' && (
 						<WelcomeModal onClose={ handleStepClose } onContinue={ handleWelcomeContinue } />
+					) }
+					{ currentStep === 'email-settings' && (
+						<EmailSettingsModal onContinue={ handleEmailSettingsContinue } />
 					) }
 					{ currentStep === 'interests' && (
 						<InterestsModal

--- a/client/reader/onboarding-rsm/interests-modal/index.tsx
+++ b/client/reader/onboarding-rsm/interests-modal/index.tsx
@@ -376,7 +376,7 @@ const InterestsModal: React.FC< InterestsModalProps > = ( {
 
 			<div className="reader-onboarding-modal__footer">
 				<HStack justify="space-between" className="reader-onboarding-modal__footer-actions">
-					<StepIndicator totalSteps={ 3 } currentStep={ 2 } />
+					<StepIndicator totalSteps={ 4 } currentStep={ 3 } />
 					<HStack spacing={ 2 } justify="right" className="reader-onboarding-modal__footer-buttons">
 						<Button
 							__next40pxDefaultSize

--- a/client/reader/onboarding-rsm/style.scss
+++ b/client/reader/onboarding-rsm/style.scss
@@ -60,11 +60,13 @@ html:not( .accessible-focus ) .reader-onboarding-rsm-modal {
 	}
 }
 
-// Shared layout for all reader-onboarding-rsm modals (welcome, interests,
-// subscribe). All three share the same overall size, the same flex-column
-// scroll/footer architecture, and the same footer styling. Per-modal
-// stylesheets only handle modal-specific content, padding, and visuals.
+// Shared layout for all reader-onboarding-rsm modals (welcome, email
+// settings, interests, subscribe). They all share the same overall size, the
+// same flex-column scroll/footer architecture, and the same footer styling.
+// Per-modal stylesheets only handle modal-specific content, padding, and
+// visuals.
 .reader-welcome-modal,
+.email-settings-modal,
 .interests-modal,
 .subscribe-modal {
 	// Frame size: 980 × 740 max, clamped to the viewport in either axis when
@@ -122,9 +124,11 @@ html:not( .accessible-focus ) .reader-onboarding-rsm-modal {
 	}
 }
 
-// VStack-based modals (welcome, interests) make the inner content the scroll
-// region. Padding differs per-modal and stays in the per-modal stylesheets.
+// VStack-based modals (welcome, email settings, interests) make the inner
+// content the scroll region. Padding differs per-modal and stays in the
+// per-modal stylesheets.
 .reader-welcome-modal,
+.email-settings-modal,
 .interests-modal {
 	&__content {
 		flex: 1 1 auto;
@@ -146,6 +150,7 @@ html:not( .accessible-focus ) .reader-onboarding-rsm-modal {
 // content scrolls from the top. The doubled selector raises specificity
 // above WP's emotion-injected single-class rule.
 .reader-welcome-modal__content.reader-welcome-modal__content,
+.email-settings-modal__content.email-settings-modal__content,
 .interests-modal__content.interests-modal__content {
 	justify-content: flex-start;
 }

--- a/client/reader/onboarding-rsm/subscribe-modal/index.tsx
+++ b/client/reader/onboarding-rsm/subscribe-modal/index.tsx
@@ -298,7 +298,7 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { promptVerification, 
 			</div>
 			<div className="reader-onboarding-modal__footer">
 				<HStack justify="space-between" className="reader-onboarding-modal__footer-actions">
-					<StepIndicator totalSteps={ 3 } currentStep={ 3 } />
+					<StepIndicator totalSteps={ 4 } currentStep={ 4 } />
 					<HStack spacing={ 2 } justify="right" className="reader-onboarding-modal__footer-buttons">
 						<Button
 							__next40pxDefaultSize

--- a/client/reader/onboarding-rsm/test/index.test.tsx
+++ b/client/reader/onboarding-rsm/test/index.test.tsx
@@ -10,6 +10,7 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import {
 	READER_ONBOARDING_ELIGIBLE_REGISTRATION_DATE,
+	READER_ONBOARDING_EMAIL_SETTINGS_PREFERENCE_KEY,
 	READER_ONBOARDING_PREFERENCE_KEY,
 	READER_ONBOARDING_TRACKS_EVENT_PREFIX,
 } from 'calypso/reader/onboarding-rsm/constants';
@@ -101,6 +102,15 @@ jest.mock( 'calypso/reader/onboarding-rsm/welcome-modal', () => ( {
 	default: ( { onContinue }: { onContinue: () => void } ) => (
 		<div data-testid="welcome-modal-content">
 			<button onClick={ onContinue }>Pick your topics</button>
+		</div>
+	),
+} ) );
+
+jest.mock( 'calypso/reader/onboarding-rsm/email-settings-modal', () => ( {
+	__esModule: true,
+	EmailSettingsModal: ( { onContinue }: { onContinue: () => void } ) => (
+		<div data-testid="email-settings-modal-content">
+			<button onClick={ onContinue }>Continue</button>
 		</div>
 	),
 } ) );
@@ -226,14 +236,14 @@ describe( 'ReaderOnboardingRsm – back button navigation', () => {
 		expect( screen.queryByRole( 'button', { name: 'Back' } ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'shows a back button on the interests step that navigates back to the welcome step', async () => {
+	it( 'shows a back button on the email settings step that navigates back to the welcome step', async () => {
 		const user = userEvent.setup();
 		renderWithProvider( <ReaderOnboardingRsm /> );
 
 		await screen.findByTestId( 'welcome-modal-content' );
 		await user.click( screen.getByRole( 'button', { name: 'Pick your topics' } ) );
 
-		expect( await screen.findByTestId( 'interests-modal-content' ) ).toBeVisible();
+		expect( await screen.findByTestId( 'email-settings-modal-content' ) ).toBeVisible();
 		expect( screen.getByRole( 'button', { name: 'Back' } ) ).toBeVisible();
 
 		await user.click( screen.getByRole( 'button', { name: 'Back' } ) );
@@ -242,12 +252,31 @@ describe( 'ReaderOnboardingRsm – back button navigation', () => {
 		expect( screen.queryByRole( 'button', { name: 'Back' } ) ).not.toBeInTheDocument();
 	} );
 
+	it( 'shows a back button on the interests step that navigates back to the email settings step', async () => {
+		const user = userEvent.setup();
+		renderWithProvider( <ReaderOnboardingRsm /> );
+
+		await screen.findByTestId( 'welcome-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Pick your topics' } ) );
+		await screen.findByTestId( 'email-settings-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
+
+		expect( await screen.findByTestId( 'interests-modal-content' ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'Back' } ) ).toBeVisible();
+
+		await user.click( screen.getByRole( 'button', { name: 'Back' } ) );
+
+		expect( await screen.findByTestId( 'email-settings-modal-content' ) ).toBeVisible();
+	} );
+
 	it( 'shows a back button on the subscribe step that navigates back to the interests step', async () => {
 		const user = userEvent.setup();
 		renderWithProvider( <ReaderOnboardingRsm /> );
 
 		await screen.findByTestId( 'welcome-modal-content' );
 		await user.click( screen.getByRole( 'button', { name: 'Pick your topics' } ) );
+		await screen.findByTestId( 'email-settings-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
 		await screen.findByTestId( 'interests-modal-content' );
 		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
 
@@ -267,6 +296,8 @@ describe( 'ReaderOnboardingRsm – stream refresh on step close', () => {
 
 		await screen.findByTestId( 'welcome-modal-content' );
 		await user.click( screen.getByRole( 'button', { name: 'Pick your topics' } ) );
+		await screen.findByTestId( 'email-settings-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
 		await screen.findByTestId( 'interests-modal-content' );
 
 		expect( mockRefreshFollowingStreams ).not.toHaveBeenCalled();
@@ -282,6 +313,8 @@ describe( 'ReaderOnboardingRsm – stream refresh on step close', () => {
 
 		await screen.findByTestId( 'welcome-modal-content' );
 		await user.click( screen.getByRole( 'button', { name: 'Pick your topics' } ) );
+		await screen.findByTestId( 'email-settings-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
 		await screen.findByTestId( 'interests-modal-content' );
 		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
 		await screen.findByTestId( 'subscribe-modal-content' );
@@ -320,6 +353,8 @@ describe( 'ReaderOnboardingRsm – subscription query invalidation on step close
 
 		await screen.findByTestId( 'welcome-modal-content' );
 		await user.click( screen.getByRole( 'button', { name: 'Pick your topics' } ) );
+		await screen.findByTestId( 'email-settings-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
 		await screen.findByTestId( 'interests-modal-content' );
 		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
 		await screen.findByTestId( 'subscribe-modal-content' );
@@ -361,6 +396,8 @@ describe( 'ReaderOnboardingRsm – subscription query invalidation on step close
 
 		await screen.findByTestId( 'welcome-modal-content' );
 		await user.click( screen.getByRole( 'button', { name: 'Pick your topics' } ) );
+		await screen.findByTestId( 'email-settings-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
 		await screen.findByTestId( 'interests-modal-content' );
 
 		invalidateSpy.mockClear();
@@ -377,13 +414,15 @@ describe( 'ReaderOnboardingRsm – subscription query invalidation on step close
 	it( 'invalidates the subscription queries when Back is clicked on the interests step', async () => {
 		// Back from interests still leaves the step, so the same close
 		// side-effects (including invalidation) must run — otherwise a user
-		// could subscribe to a pack, go Back to welcome, and close from there
+		// could subscribe to a pack, go Back, and close from there
 		// without ever refreshing the cached subscription counts.
 		const user = userEvent.setup();
 		const { invalidateSpy } = renderWithInvalidateSpy( <ReaderOnboardingRsm /> );
 
 		await screen.findByTestId( 'welcome-modal-content' );
 		await user.click( screen.getByRole( 'button', { name: 'Pick your topics' } ) );
+		await screen.findByTestId( 'email-settings-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
 		await screen.findByTestId( 'interests-modal-content' );
 
 		invalidateSpy.mockClear();
@@ -405,6 +444,8 @@ describe( 'ReaderOnboardingRsm – subscription query invalidation on step close
 
 		await screen.findByTestId( 'welcome-modal-content' );
 		await user.click( screen.getByRole( 'button', { name: 'Pick your topics' } ) );
+		await screen.findByTestId( 'email-settings-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
 		await screen.findByTestId( 'interests-modal-content' );
 		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
 		await screen.findByTestId( 'subscribe-modal-content' );
@@ -450,6 +491,8 @@ describe( 'ReaderOnboardingRsm – step close vs navigation analytics', () => {
 
 		await screen.findByTestId( 'welcome-modal-content' );
 		await user.click( screen.getByRole( 'button', { name: 'Pick your topics' } ) );
+		await screen.findByTestId( 'email-settings-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
 		await screen.findByTestId( 'interests-modal-content' );
 
 		jest.mocked( recordTracksEvent ).mockClear();
@@ -467,6 +510,8 @@ describe( 'ReaderOnboardingRsm – step close vs navigation analytics', () => {
 
 		await screen.findByTestId( 'welcome-modal-content' );
 		await user.click( screen.getByRole( 'button', { name: 'Pick your topics' } ) );
+		await screen.findByTestId( 'email-settings-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
 		await screen.findByTestId( 'interests-modal-content' );
 
 		jest.mocked( recordTracksEvent ).mockClear();
@@ -484,6 +529,8 @@ describe( 'ReaderOnboardingRsm – step close vs navigation analytics', () => {
 
 		await screen.findByTestId( 'welcome-modal-content' );
 		await user.click( screen.getByRole( 'button', { name: 'Pick your topics' } ) );
+		await screen.findByTestId( 'email-settings-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
 		await screen.findByTestId( 'interests-modal-content' );
 		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
 		await screen.findByTestId( 'subscribe-modal-content' );
@@ -503,6 +550,8 @@ describe( 'ReaderOnboardingRsm – step close vs navigation analytics', () => {
 
 		await screen.findByTestId( 'welcome-modal-content' );
 		await user.click( screen.getByRole( 'button', { name: 'Pick your topics' } ) );
+		await screen.findByTestId( 'email-settings-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
 		await screen.findByTestId( 'interests-modal-content' );
 		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
 		await screen.findByTestId( 'subscribe-modal-content' );
@@ -535,6 +584,8 @@ describe( 'ReaderOnboardingRsm – step close vs navigation analytics', () => {
 
 		await screen.findByTestId( 'welcome-modal-content' );
 		await user.click( screen.getByRole( 'button', { name: 'Pick your topics' } ) );
+		await screen.findByTestId( 'email-settings-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
 		await screen.findByTestId( 'interests-modal-content' );
 
 		jest.mocked( recordTracksEvent ).mockClear();
@@ -549,6 +600,8 @@ describe( 'ReaderOnboardingRsm – step close vs navigation analytics', () => {
 
 		await screen.findByTestId( 'welcome-modal-content' );
 		await user.click( screen.getByRole( 'button', { name: 'Pick your topics' } ) );
+		await screen.findByTestId( 'email-settings-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
 		await screen.findByTestId( 'interests-modal-content' );
 		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
 		await screen.findByTestId( 'subscribe-modal-content' );
@@ -568,6 +621,8 @@ describe( 'ReaderOnboardingRsm – onboarding completion', () => {
 	const navigateToSubscribeStep = async ( user: ReturnType< typeof userEvent.setup > ) => {
 		await screen.findByTestId( 'welcome-modal-content' );
 		await user.click( screen.getByRole( 'button', { name: 'Pick your topics' } ) );
+		await screen.findByTestId( 'email-settings-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
 		await screen.findByTestId( 'interests-modal-content' );
 		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
 		await screen.findByTestId( 'subscribe-modal-content' );
@@ -731,6 +786,119 @@ describe( 'ReaderOnboardingRsm – onboarding completion', () => {
 			`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }completed`,
 			expect.anything()
 		);
+	} );
+} );
+
+describe( 'ReaderOnboardingRsm – email settings step', () => {
+	const navigateToEmailSettingsStep = async ( user: ReturnType< typeof userEvent.setup > ) => {
+		await screen.findByTestId( 'welcome-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Pick your topics' } ) );
+		await screen.findByTestId( 'email-settings-modal-content' );
+	};
+
+	it( 'shows the email settings step between welcome and interests', async () => {
+		const user = userEvent.setup();
+		renderWithProvider( <ReaderOnboardingRsm /> );
+
+		await navigateToEmailSettingsStep( user );
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
+
+		expect( await screen.findByTestId( 'interests-modal-content' ) ).toBeVisible();
+	} );
+
+	it( 'saves the email-settings completion preference when Continue is clicked', async () => {
+		const user = userEvent.setup();
+		renderWithProvider( <ReaderOnboardingRsm /> );
+
+		await navigateToEmailSettingsStep( user );
+
+		expect( savePreference ).not.toHaveBeenCalledWith(
+			READER_ONBOARDING_EMAIL_SETTINGS_PREFERENCE_KEY,
+			true
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
+
+		expect( savePreference ).toHaveBeenCalledWith(
+			READER_ONBOARDING_EMAIL_SETTINGS_PREFERENCE_KEY,
+			true
+		);
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }email_settings_modal_continue`
+		);
+	} );
+
+	it( 'does not save the completion preference when the step is dismissed without Continue', async () => {
+		const user = userEvent.setup();
+		renderWithProvider( <ReaderOnboardingRsm /> );
+
+		await navigateToEmailSettingsStep( user );
+
+		jest.mocked( recordTracksEvent ).mockClear();
+		await user.click( screen.getByRole( 'button', { name: 'Close modal' } ) );
+
+		expect( savePreference ).not.toHaveBeenCalledWith(
+			READER_ONBOARDING_EMAIL_SETTINGS_PREFERENCE_KEY,
+			true
+		);
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			`${ READER_ONBOARDING_TRACKS_EVENT_PREFIX }email_settings_modal_close`
+		);
+	} );
+
+	it( 'does not re-save the completion preference when the step was already completed', async () => {
+		const { getPreference } = jest.requireMock( 'calypso/state/preferences/selectors' ) as {
+			getPreference: jest.Mock;
+		};
+		getPreference.mockImplementation( ( _state: unknown, key: string ) =>
+			key === READER_ONBOARDING_EMAIL_SETTINGS_PREFERENCE_KEY ? true : null
+		);
+
+		const user = userEvent.setup();
+		renderWithProvider( <ReaderOnboardingRsm /> );
+
+		await navigateToEmailSettingsStep( user );
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
+
+		expect( savePreference ).not.toHaveBeenCalledWith(
+			READER_ONBOARDING_EMAIL_SETTINGS_PREFERENCE_KEY,
+			true
+		);
+
+		getPreference.mockReturnValue( null );
+	} );
+
+	it( 'renders an email-settings checklist task that completes via the saved preference', async () => {
+		renderWithProvider( <ReaderOnboardingRsm /> );
+
+		await screen.findByTestId( 'welcome-modal-content' );
+		expect( screen.getByTestId( 'checklist-item-email-settings' ) ).toHaveAttribute(
+			'data-completed',
+			'false'
+		);
+		expect( screen.getByTestId( 'checklist-item-email-settings' ) ).toHaveAttribute(
+			'data-disabled',
+			'false'
+		);
+	} );
+
+	it( 'marks the email-settings checklist task complete when the preference is set', async () => {
+		const { getPreference } = jest.requireMock( 'calypso/state/preferences/selectors' ) as {
+			getPreference: jest.Mock;
+		};
+		getPreference.mockImplementation( ( _state: unknown, key: string ) =>
+			key === READER_ONBOARDING_EMAIL_SETTINGS_PREFERENCE_KEY ? true : null
+		);
+
+		renderWithProvider( <ReaderOnboardingRsm /> );
+
+		await screen.findByTestId( 'welcome-modal-content' );
+		expect( screen.getByTestId( 'checklist-item-email-settings' ) ).toHaveAttribute(
+			'data-completed',
+			'true'
+		);
+
+		getPreference.mockReturnValue( null );
 	} );
 } );
 
@@ -991,6 +1159,8 @@ describe( 'ReaderOnboardingRsm – forceShow snapshot', () => {
 		await screen.findByTestId( 'welcome-modal-content' );
 		const user = userEvent.setup();
 		await user.click( screen.getByRole( 'button', { name: 'Pick your topics' } ) );
+		await screen.findByTestId( 'email-settings-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
 		await screen.findByTestId( 'interests-modal-content' );
 		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
 		await screen.findByTestId( 'subscribe-modal-content' );
@@ -1027,6 +1197,8 @@ describe( 'ReaderOnboardingRsm – interests-step "has followed" state lifted to
 		// Open interests; initial hasFollowed is false (no prior subscribe).
 		await screen.findByTestId( 'welcome-modal-content' );
 		await user.click( screen.getByRole( 'button', { name: 'Pick your topics' } ) );
+		await screen.findByTestId( 'email-settings-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
 		const interestsContent = await screen.findByTestId( 'interests-modal-content' );
 		expect( interestsContent ).toHaveAttribute( 'data-has-followed', 'false' );
 
@@ -1065,6 +1237,8 @@ describe( 'ReaderOnboardingRsm – interests-step "has followed" state lifted to
 
 		// Open interests, simulate any subscribe action, and close.
 		await user.click( screen.getByRole( 'button', { name: 'Pick your topics' } ) );
+		await screen.findByTestId( 'email-settings-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
 		await screen.findByTestId( 'interests-modal-content' );
 		await user.click( screen.getByRole( 'button', { name: 'Mark followed' } ) );
 		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
@@ -1088,6 +1262,8 @@ describe( 'ReaderOnboardingRsm – interests-step "has followed" state lifted to
 		);
 
 		await user.click( screen.getByRole( 'button', { name: 'Pick your topics' } ) );
+		await screen.findByTestId( 'email-settings-modal-content' );
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
 		await screen.findByTestId( 'interests-modal-content' );
 		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
 

--- a/client/reader/onboarding-rsm/welcome-modal/index.tsx
+++ b/client/reader/onboarding-rsm/welcome-modal/index.tsx
@@ -161,7 +161,7 @@ const WelcomeModal: React.FC< WelcomeModalProps > = ( { onClose, onContinue } ) 
 
 			<div className="reader-onboarding-modal__footer">
 				<HStack justify="space-between" className="reader-onboarding-modal__footer-actions">
-					<StepIndicator totalSteps={ 3 } currentStep={ 1 } />
+					<StepIndicator totalSteps={ 4 } currentStep={ 1 } />
 					<HStack
 						spacing={ 2 }
 						justify="right"


### PR DESCRIPTION
<!--
Link a related Github/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of # https://linear.app/a8c/issue/READ-534/onboarding-topic-bundles-silently-subscribe-users-by-email-to-20#comment-0912b803 

## Proposed Changes

Starts exploring the idea of adding email settings in reader onboarding (it feels very uninspiritng 😞 )


<img width="640" height="454" alt="settings-step-idea" src="https://github.com/user-attachments/assets/4ccd39c5-ac73-4422-b54a-d639c00506d8" />

*

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Let users choose if and how they want emails for site subscriptions before guiding them through subscribing to sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* view build on `*/reader?flags=reader/force-onboarding`
* verify there is a new step between welcome and interests
* verify changing the values results in settings being saved
* verify clicking "continue" from this step marks it complete and persists
* try with a fresh user account in the reader

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
