### PR TITLE
E2E: skip 100-year domain flow test pending DOMENG-694

### DIFF
--- a/test/e2e/specs/flows/setup-hundred-year-domain.spec.ts
+++ b/test/e2e/specs/flows/setup-hundred-year-domain.spec.ts
@@ -26,6 +26,11 @@ test.describe(
 			pageLogin,
 			pageUserSignUp,
 		} ) => {
+			test.skip(
+				true,
+				'Async domain registration omits is_hundred_year_domain from the transaction response, so the generic thank-you page renders instead of the 100-year one. See DOMENG-694.'
+			);
+
 			const testUser = helperData.getNewTestUser();
 			let newUserDetails: NewUserResponse;
 			let selectedDomain: string;


### PR DESCRIPTION
Part of DOMENG-694

## Proposed Changes

* Skip the `Setup Hundred Year Domain Flow` Playwright spec (`test/e2e/specs/flows/setup-hundred-year-domain.spec.ts`) with a reason pointing at DOMENG-694.

## Why are these changes being made?

* The test has been failing consistently in the Calypso E2E Pre-Release matrix since 2026-05-21, and reproduces locally 10/10 against staging.
* The root cause is server-side, not in Calypso or the test: with async domain registration enabled for all TLDs, the `hundred_year_domain` domain flag is only set after the registrar call completes, so the `POST /me/transactions` response carries `purchases[].is_hundred_year_domain: null`. Calypso maps that to `false` and renders the generic domain-only thank-you page instead of the 100-year one, failing the spec's assertion.
* Full root-cause analysis, traces, and TeamCity build history are in DOMENG-694. The skip keeps the Pre-Release matrix signal clean until the transaction response is fixed; the skip reason in the spec references the issue.

## Testing Instructions

* Run `yarn workspace wp-e2e-tests test:pw specs/flows/setup-hundred-year-domain.spec.ts --reporter=list` and verify the test is reported as skipped.