### PR TITLE
Global Nav 2026: baton-pass the subnav over the fixed nav

### DIFF
--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -66,6 +66,13 @@ body.is-focus-sites {
 		// against the viewport. Global `overflow: hidden` above breaks sticky.
 		overflow: visible;
 	}
+
+	// `overflow: hidden` above breaks the subnav baton-pass sticky; let it pin.
+	.is-section-themes:has( .x-nav--2026-redesign ) &,
+	.is-section-patterns:has( .x-nav--2026-redesign ) &,
+	.is-section-plugins:has( .x-nav--2026-redesign ) & {
+		overflow: visible;
+	}
 	// Note that we have to use a 0,0,3,1 specificity selector to override the
 	// one in `client/my-sites/sidebar/style.scss` which has 0,0,3,0 in case it
 	// loads second, which happens if checkout is not the first page of calypso
@@ -589,3 +596,4 @@ body.is-mobile-app-view {
 .layout.is-section-plugins:not( .is-logged-in ):has( .x-nav--2026-redesign ) .layout__header-section {
 	min-height: 0;
 }
+

--- a/client/my-sites/patterns/components/pattern-library/style.scss
+++ b/client/my-sites/patterns/components/pattern-library/style.scss
@@ -55,13 +55,11 @@
 	}
 }
 
-// 2026 nav is `position: fixed`, so the sticky filter must stick below it (admin-bar
-// offset + 64px nav) instead of at `top: 0` / the masterbar height, where it would hide
-// behind the nav. Scoped to the 2026 path; wins over the base + logged-in rules above
-// via the `:has()` ancestor. Kept sticky on mobile too (the base rule drops to
-// `position: static` < $break-mobile), so the pills track below the nav at every width.
+// Baton-pass: filter sticks at the fixed nav's top and rides above it (z-index
+// beats the nav's 801), covering it as it pins.
 .is-section-patterns:has(.x-nav--2026-redesign) .pattern-library__filters {
-	top: var(--nav-2026-sticky-offset);
+	top: var(--nav-2026-admin-offset);
+	z-index: 1000;
 
 	@media (max-width: $break-mobile) {
 		position: sticky;

--- a/client/my-sites/plugins/search-box-header/style.scss
+++ b/client/my-sites/plugins/search-box-header/style.scss
@@ -168,14 +168,12 @@
 			border-bottom: 1px solid var(--studio-gray-5);
 			background-color: var(--studio-white);
 
-			// 2026 nav is `position: fixed`; pin this fixed search bar below it (admin-bar
-			// offset + 64px nav) instead of at the masterbar height, where it would sit
-			// behind the nav. Scoped to the 2026 path via the layout-root `:has()`. The
-			// `margin-top: 0` cancels the legacy `-32px` pull-up (it offset the bar against
-			// the old masterbar) so the bar lands exactly at the nav's bottom edge.
+			// Baton-pass: anchor at the fixed nav's top and ride above it, covering
+			// it as it pins. `margin-top: 0` cancels the legacy masterbar pull-up.
 			.is-section-plugins:has(.x-nav--2026-redesign) & {
-				top: var(--nav-2026-sticky-offset);
+				top: var(--nav-2026-admin-offset);
 				margin-top: 0;
+				z-index: 1000;
 			}
 
 			.layout__secondary ~ .layout__primary & {

--- a/client/my-sites/plugins/search-categories/style.scss
+++ b/client/my-sites/plugins/search-categories/style.scss
@@ -103,12 +103,12 @@ $search-categories-height: 40px;
 		top: 0;
 		z-index: 20;
 
-		// 2026 nav is `position: fixed`; stick the category filter below it (admin-bar
-		// offset + 64px nav) instead of at `top: 0`, where it would hide behind the nav.
-		// The `.plugins-browser--site-view` fixed-top fallback below is logged-in
-		// site-view only (no 2026 nav, which requires no selected site), so it's untouched.
+		// Baton-pass: filter sticks at the fixed nav's top and rides above it,
+		// covering it as it pins (opaque bg via the parent's white background).
 		.is-section-plugins:has(.x-nav--2026-redesign) & {
-			top: var(--nav-2026-sticky-offset);
+			top: var(--nav-2026-admin-offset);
+			z-index: 1000;
+			background-color: var(--studio-white);
 		}
 
 		&.fixed-top {

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -831,7 +831,9 @@ body.is-section-plugins:has(.is-full-width-layout) {
 			height: 0;
 		}
 
-		.x-nav-item, .x-dropdown-link, .x-menu-link {
+		.x-nav-item,
+		.x-dropdown-link,
+		.x-menu-link:not(.cta-btn-nav) {
 			color: var(--studio-gray-100);
 		}
 		.x-dropdown-link {

--- a/client/my-sites/themes/filter-bar-modern/style.scss
+++ b/client/my-sites/themes/filter-bar-modern/style.scss
@@ -31,11 +31,11 @@
 	}
 }
 
-// 2026 nav is `position: fixed`, so the sticky filter bar must stick below it
-// (admin-bar offset + 64px nav) instead of at `top: 0`, where it would hide behind the
-// nav. Scoped to the 2026 path via the `:has()` ancestor on the layout root.
+// Baton-pass: filter sticks at the fixed nav's top and rides above it, covering
+// it as it pins.
 .is-section-themes:has(.x-nav--2026-redesign) .filter-bar-modern {
-	top: var(--nav-2026-sticky-offset);
+	top: var(--nav-2026-admin-offset);
+	z-index: 1000;
 }
 
 .filter-bar-modern__content {

--- a/client/my-sites/themes/hero-modern/style.scss
+++ b/client/my-sites/themes/hero-modern/style.scss
@@ -20,6 +20,16 @@ $hero-modern-navbar-height: 57px; // UniversalHeaderNavigation
 		padding-top: var(--nav-2026-sticky-offset);
 	}
 
+	.layout:has(.x-nav--2026-redesign) main.is-logged-out & {
+		.full-width-section__content {
+			padding-top: 96px;
+
+			@media (min-width: $break-small) {
+				padding-top: 108px;
+			}
+		}
+	}
+
 	.full-width-section__content {
 		max-width: 1220px;
 		padding: 48px 0;

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -135,6 +135,7 @@ const UniversalNavbarHeader = ( {
 	const openMobileMenu = useCallback( () => {
 		if ( nav2026 ) {
 			recordMobileMenuOpen( isScrolledRef.current );
+			setIsMenuOpening( true );
 		}
 		setMobileMenuOpen( true );
 	}, [ nav2026 ] );

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -1101,6 +1101,10 @@ $x-menu-2026-admin-bar-mobile: 46px;
 		align-items: center;
 		height: $x-nav-2026-height;
 		padding-block: 0;
+
+		&::before {
+			bottom: 8px;
+		}
 	}
 
 	// "Get started" CTA — outlined pill (no fill). Hover flips it to a filled
@@ -1432,11 +1436,10 @@ $x-menu-2026-admin-bar-mobile: 46px;
 
 /* Mobile menu — full-screen white panel: header (logo ⇄ back + close), drill-down category list, footer (logged-out CTAs vs logged-in user). */
 .x-menu--2026 {
-	/* Drill / reveal timing tokens (from the Landpack reference). drill-fade drives the logo⇄back and nav-list⇄dropdown crossfades; reveal-delay gates the first-open header/footer reveal. */
+	/* Drill / reveal timing tokens (from the Landpack reference). drill-fade drives the logo⇄back and nav-list⇄dropdown crossfades; reveal-delay gates the first-open content reveal. */
 	--x-menu-2026-easing: cubic-bezier( 0.45, 0.85, 0.9, 1 );
 	--x-menu-2026-panel-duration: 0.34s; // panel slide in/out
-	--x-menu-2026-reveal-delay: 0.43s; // gap before header/footer/items fade in on open
-	--x-menu-2026-header-fade-duration: 0.3s; // logo / close / footer reveal duration
+	--x-menu-2026-reveal-delay: 0.43s; // lead-in before content appears after the panel slide
 	--x-menu-2026-stagger-offset: 32px; // nav items' left slide-in distance
 	--x-menu-2026-stagger-duration: 0.3s; // each nav item's slide-in duration
 	--x-menu-2026-stagger-step: 0.018s; // per-item delay step (× --stagger-index)
@@ -1808,7 +1811,7 @@ $x-menu-2026-admin-bar-mobile: 46px;
 		}
 
 		// Only the footer's CONTENTS fade in on open; the blurred bar stays put so nav items slide behind it. Base snaps out with the panel (0s / panel-delay).
-		> * {
+		> *:not( .x-menu-mobile-app-banner ) {
 			opacity: 0;
 			transition: opacity 0s var( --x-menu-2026-easing ) var( --x-menu-2026-panel-duration );
 		}
@@ -1833,30 +1836,17 @@ $x-menu-2026-admin-bar-mobile: 46px;
 		}
 	}
 
-	// Top-level screen only; collapses on drill (is-hidden). Fades where
-	// `allow-discrete` is supported, otherwise snaps shut.
+	// Top-level screen only; fades in, snaps out on drill (is-hidden).
 	.x-menu-mobile-footer > .x-menu-mobile-app-banner {
-		// Fade declared on its own first so the opacity/visibility transition
-		// survives in browsers that drop the `display … allow-discrete` item.
-		transition:
-			opacity var( --x-menu-2026-header-fade-duration, 0.3s ) var( --x-menu-2026-easing ),
-			visibility var( --x-menu-2026-header-fade-duration, 0.3s ) var( --x-menu-2026-easing );
-		transition:
-			opacity var( --x-menu-2026-header-fade-duration, 0.3s ) var( --x-menu-2026-easing ),
-			visibility var( --x-menu-2026-header-fade-duration, 0.3s ) var( --x-menu-2026-easing ),
-			display var( --x-menu-2026-header-fade-duration, 0.3s ) allow-discrete;
-
-		@starting-style {
-			opacity: 0;
-		}
+		opacity: 0;
+		pointer-events: none;
+		transition: opacity 0.27s var( --x-menu-2026-easing );
 	}
 
 	.x-menu-mobile-footer > .x-menu-mobile-app-banner.is-hidden {
-		display: none;
 		opacity: 0;
-		visibility: hidden;
-		// allow-discrete defers display:none, so block clicks during fade-out.
 		pointer-events: none;
+		transition: none;
 	}
 
 	// Overlapping WordPress + Jetpack badge icons.
@@ -2037,26 +2027,32 @@ $x-menu-2026-admin-bar-mobile: 46px;
 		font-size: $x-menu-item-font-size-narrow;
 	}
 
-	/* Open: logo / close / footer-contents visible via the quick drill-fade by default (so BACK re-shows the logo promptly); the slow panel-synced reveal below applies ONLY during initial open (`.is-opening`). */
+	/* Open: logo / close / footer-contents reveal immediately except during initial open, where they wait for the panel slide. */
 	&.x-menu__open {
 		.x-menu-mobile-logo:not( .is-hidden ),
 		.x-menu-button.x-menu-mobile-close,
-		.x-menu-mobile-footer > * {
+		.x-menu-mobile-footer > *:not( .x-menu-mobile-app-banner ) {
 			opacity: 1;
 			visibility: visible;
 			transition: var( --x-menu-2026-drill-fade );
 		}
 
+		.x-menu-mobile-footer > .x-menu-mobile-app-banner:not( .is-hidden ) {
+			opacity: 1;
+			pointer-events: auto;
+		}
+
 		&.is-opening {
 			.x-menu-mobile-logo:not( .is-hidden ),
 			.x-menu-button.x-menu-mobile-close,
-			.x-menu-mobile-footer > * {
-				// Delayed past the slide so they stay unpainted until the gap, then fade in.
+			.x-menu-mobile-footer > *:not( .x-menu-mobile-app-banner ) {
 				transition:
-					opacity var( --x-menu-2026-header-fade-duration ) var( --x-menu-2026-easing )
-						var( --x-menu-2026-reveal-delay ),
-					visibility var( --x-menu-2026-header-fade-duration ) var( --x-menu-2026-easing )
-						var( --x-menu-2026-reveal-delay );
+					opacity 0.27s var( --x-menu-2026-easing ) var( --x-menu-2026-reveal-delay ),
+					visibility 0.27s var( --x-menu-2026-easing ) var( --x-menu-2026-reveal-delay );
+			}
+
+			.x-menu-mobile-footer > .x-menu-mobile-app-banner:not( .is-hidden ) {
+				transition: opacity 0.27s var( --x-menu-2026-easing ) var( --x-menu-2026-reveal-delay );
 			}
 		}
 	}


### PR DESCRIPTION
Part of WPBRAND-403

## Proposed Changes

* Add the 2026 nav baton-pass behavior for Themes, Patterns, and Plugins, so the page subnav takes over the top navigation position while scrolling.
* Adjust the logged-out Themes hero top spacing when the 2026 nav is enabled so the hero content clears the redesigned mobile nav.
* Fix the Plugins mobile “Get started” CTA color when the 2026 nav is enabled.
* Update the 2026 mobile menu opening sequence so the panel slides in empty first, then menu items, the Jetpack app banner, and footer CTAs fade in after the panel settles.
* Simplify the Jetpack app banner transitions in Calypso: remove the delayed fade-out behavior on drill-in, use opacity-only fade-in, and disable pointer events while hidden.

## Why are these changes being made?

* Design review flagged the Themes, Patterns, and Plugins filter navigation stacking beneath the global nav instead of taking over the top navigation position.
* The logged-out mobile pages needed spacing and CTA polish for the 2026 nav.
* The mobile menu should feel like one staged interaction: the panel enters first, then the menu content appears after it settles.
* The Jetpack app banner needed simpler, more reliable show/hide behavior on mobile browsers.

## Testing Instructions

* Visit `/themes`, `/patterns`, and `/plugins` with the 2026 nav enabled by appending `?flags=nav-redesign/2026`.
* Scroll each page down and back up. Confirm the page subnav takes over the top navigation position without stacking below the global nav.
* On logged-out mobile `/themes`, confirm the hero content has enough top spacing below the redesigned nav.
* On mobile `/plugins`, confirm the “Get started” CTA keeps the correct color.
* Open the mobile menu. Confirm the panel slides in empty first, then the menu items, Jetpack app banner, and footer CTAs appear after the panel settles.
* Drill into a mobile menu category. Confirm the Jetpack app banner hides immediately. Tap Back and confirm it fades back in with the top-level menu.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
