### PR TITLE
api-core: Add missing types for SiteContextualPlan

### DIFF
--- a/packages/api-core/src/site-plans/types.ts
+++ b/packages/api-core/src/site-plans/types.ts
@@ -105,12 +105,12 @@ export interface SiteContextualPlan {
 	introductory_offer_raw_price_integer?: number;
 	introductory_offer_interval_unit?: string;
 	introductory_offer_interval_count?: number;
-	introductory_offer_end_date?: string | null; // Only when is_current_plan && has subscription
+	introductory_offer_end_date?: string | null; // Only when current_plan && has subscription
 
-	// Current plan fields (conditional - when is_current_plan is true)
+	// This means that the plan is active but it could be past its expiry date.
 	current_plan?: boolean;
 
-	// Subscription fields (conditional - when is_current_plan && !is_free)
+	// Subscription fields (conditional - when current_plan && !is_free)
 	user_is_owner?: boolean | null;
 	id?: number | null;
 	has_domain_credit?: boolean | null;
@@ -123,8 +123,30 @@ export interface SiteContextualPlan {
 	partner_name?: string;
 	user_facing_expiry?: string | null; // Deprecated, same as expiry
 
-	// Trial availability (conditional - when !is_current_plan && !is_free)
+	// Trial availability (conditional - when !current_plan && !is_free)
 	can_start_trial?: boolean;
+
+	/**
+	 * Whether the site's current plan can be upgraded to this plan. Computed by
+	 * the server from the same upgrade-path authority the shopping cart uses.
+	 * Present on non-current plans.
+	 */
+	available_for_upgrade?: boolean;
+
+	/**
+	 * Whether the site's current plan can be downgraded to this plan. Computed by
+	 * the server from the same plan-path authority the shopping cart uses.
+	 * Present on non-current plans.
+	 */
+	available_for_downgrade?: boolean;
+
+	/**
+	 * Whether this plan has passed its expiry date. If this is set on the
+	 * current plan, that means that the plan is still active but is now within
+	 * its grace period. Once the grace period ends, the plan will no longer be
+	 * returned with current_plan: true.
+	 */
+	is_expired?: boolean;
 
 	/**
 	 * Display order for plan cards on the comparison page. Lower values appear first.


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/SHILL-2106/

## Proposed changes

Adds TypeScript definitions for three `SiteContextualPlan` properties returned by the `/sites/%s/plans` endpoint that were never reflected in `@automattic/api-core`. The fields were added to the endpoint response in #111404 but the type was left out of sync.

* Add `available_for_upgrade?: boolean` — whether the site's current plan can be upgraded to this plan.
* Add `available_for_downgrade?: boolean` — whether the site's current plan can be downgraded to this plan.
* Add `is_expired?: boolean` — whether the plan has passed its expiry date (when set on the current plan, it's still active but within its grace period).
* Clarify a few adjacent comments to use the actual `current_plan` field name instead of the nonexistent `is_current_plan`.

## Why are these changes being made?

#111404 began relying on the server's `available_for_upgrade` flag (plus the companion `available_for_downgrade` and `is_expired` fields) from the `/sites/%s/plans` endpoint, and consumes them via the camelCase `SitePlanData` shape in Calypso. However, the canonical endpoint type in `@automattic/api-core` (`SiteContextualPlan`) was never updated to include them, so any consumer reading the raw endpoint response through the typed client wouldn't see these fields and would have no type safety around them.

Adding them to `SiteContextualPlan` keeps the shared type definition aligned with what the endpoint actually returns, so downstream consumers (api-queries and beyond) get accurate types without resorting to casts. All three are optional, matching their conditional presence in the response (the availability flags appear on non-current plans).

## Testing instructions
* This is a types-only change with no runtime behavior; confirm the package type-checks cleanly and that the three new fields appear on `SiteContextualPlan` with IntelliSense.

